### PR TITLE
Update test/users/bugzilla/bug794131/

### DIFF
--- a/test/users/bugzilla/bug794131/bug794131.h
+++ b/test/users/bugzilla/bug794131/bug794131.h
@@ -3,7 +3,7 @@
 //typedef void* data_set;
 
 typedef struct __data_set {
-
+  int x;
 } _data_set, *data_set;
 
 int64_t read_stuff(data_set location, void* things, uint64_t start, uint64_t size, uint64_t count);


### PR DESCRIPTION
This test failed because the type data_set was really an empty struct. I looked at the test and the type in question was not actually important to its functionality, so the test has now been simplified and the type removed.
