### PR TITLE
Ask devs to email chapel_admin with clas and commit access requests.

### DIFF
--- a/doc/developer/bestPractices/ContributorInfo.txt
+++ b/doc/developer/bestPractices/ContributorInfo.txt
@@ -25,7 +25,7 @@ similar, though the specific people involved are likely to change and grow).
 
 * If you will need commit/push access to the main repository,
   `chapel-lang/chapel`_, send a request including your github username to
-  chapel_admin@cray.com.
+  chapel_admin _at_ cray.com.
 
 .. note::
 
@@ -45,8 +45,8 @@ similar, though the specific people involved are likely to change and grow).
   packages must be approved by Cray leadership before being committed.
 
 * Sign a Chapel contributor's agreement, located at the URL below, and send it
-  to your contact at Cray (ask for one at the chapel_admin@cray.com list if you
-  don't).
+  to your contact at Cray (ask for one at the chapel_admin _at_ cray.com list
+  if you don't).
 
   https://github.com/chapel-lang/chapel/tree/master/doc/developer/contributorAgreements/
 


### PR DESCRIPTION
Instead of mailing chapel-developers@, we are now asking people to send admin
requests (i.e. GitHub team access, CLAs) to chapel_admin@cray.com.
