### PR TITLE
Reducing number of tasks to avoid timeouts in parSafeMember test

### DIFF
--- a/test/domains/sungeun/assoc/parSafeMember.chpl
+++ b/test/domains/sungeun/assoc/parSafeMember.chpl
@@ -1,5 +1,5 @@
 config const iters = 800;
-config const n = 100;
+config const n = 50;
 
 var D: domain(real);
 


### PR DESCRIPTION
This test was probably creating more tasks than it needed to, and was timing out quite frequently. Reducing the number of tasks to 50 should bring the running time down well below our timeout threshold. This change was suggested by @sungeunchoi.
