### PR TITLE
Fixing hdfs function stub file so Cray C++ compiler no longer generates warnings

### DIFF
--- a/runtime/src/qio/auxFilesys/hdfs/qio_plugin_hdfs_stubs.cc
+++ b/runtime/src/qio/auxFilesys/hdfs/qio_plugin_hdfs_stubs.cc
@@ -22,50 +22,49 @@
 #include "qio_plugin_hdfs.h"
 #include "qbuffer.h"
 #include "error.h"
-#undef exit
 
-#define HDFS_ERROR { \
+#define HDFS_ERROR(ret) { \
   chpl_internal_error("No HDFS Support");\
-  exit(EXIT_FAILURE);\
+  ret;\
 }
 
 
-qioerr hdfs_readv(void* file, const struct iovec *vector, int count, ssize_t* num_read_out, void* fs) HDFS_ERROR
+qioerr hdfs_readv(void* file, const struct iovec *vector, int count, ssize_t* num_read_out, void* fs) HDFS_ERROR(return 0)
 
-qioerr hdfs_pwritev(void* fd, const struct iovec* iov, int iovcnt, off_t see_to_offset, ssize_t* num_read_out, void* fs) HDFS_ERROR
+qioerr hdfs_pwritev(void* fd, const struct iovec* iov, int iovcnt, off_t see_to_offset, ssize_t* num_read_out, void* fs) HDFS_ERROR(return 0)
 
-qioerr hdfs_writev(void* fl, const struct iovec* iov, int iovcnt, ssize_t* num_written_out, void* fs) HDFS_ERROR
+qioerr hdfs_writev(void* fl, const struct iovec* iov, int iovcnt, ssize_t* num_written_out, void* fs) HDFS_ERROR(return 0)
 
-qioerr hdfs_preadv(void* file, const struct iovec *vector, int count, off_t offset, ssize_t* num_read_out, void* fs) HDFS_ERROR
-
-// This doesn't need to become an fptr since we call this from chapel
-qioerr hdfs_connect(void** fs_out, const char* pathname, int port) HDFS_ERROR
+qioerr hdfs_preadv(void* file, const struct iovec *vector, int count, off_t offset, ssize_t* num_read_out, void* fs) HDFS_ERROR(return 0)
 
 // This doesn't need to become an fptr since we call this from chapel
-qioerr hdfs_disconnect(void* fs) HDFS_ERROR
+qioerr hdfs_connect(void** fs_out, const char* pathname, int port) HDFS_ERROR(return 0)
 
-qioerr hdfs_open(void** file, const char* path, int* flags, mode_t mode, qio_hint_t iohints, void* fs) HDFS_ERROR
+// This doesn't need to become an fptr since we call this from chapel
+qioerr hdfs_disconnect(void* fs) HDFS_ERROR(return 0)
 
-qioerr hdfs_close(void* fl, void* fs) HDFS_ERROR
+qioerr hdfs_open(void** file, const char* path, int* flags, mode_t mode, qio_hint_t iohints, void* fs) HDFS_ERROR(return 0)
 
-qioerr hdfs_seek(void* fl, off_t offset, int whence, off_t* offset_out, void* fs) HDFS_ERROR
+qioerr hdfs_close(void* fl, void* fs) HDFS_ERROR(return 0)
 
-qioerr hdfs_fsync(void* fl, void* fs) HDFS_ERROR
+qioerr hdfs_seek(void* fl, off_t offset, int whence, off_t* offset_out, void* fs) HDFS_ERROR(return 0)
 
-qioerr hdfs_getcwd(void* file, const char** path_out, void* fs) HDFS_ERROR
+qioerr hdfs_fsync(void* fl, void* fs) HDFS_ERROR(return 0)
 
-qioerr hdfs_getpath(void* file, const char** string_out, void* fs) HDFS_ERROR
+qioerr hdfs_getcwd(void* file, const char** path_out, void* fs) HDFS_ERROR(return 0)
+
+qioerr hdfs_getpath(void* file, const char** string_out, void* fs) HDFS_ERROR(return 0)
 
 // ----- multilocale ------
-void hdfs_create_locale_mapping(char ***char_arr, int num, const char *loc_name) HDFS_ERROR
+void hdfs_create_locale_mapping(char ***char_arr, int num, const char *loc_name) HDFS_ERROR(return)
 
-char** hdfs_alloc_array(int num_locales) HDFS_ERROR
+char** hdfs_alloc_array(int num_locales) HDFS_ERROR(return NULL)
 
-qioerr hdfs_get_owners_for_bytes(qio_file_t* file, hdfs_block_byte_map_t** locs, int* out_num_blocks, char** locale_array, int num_locales, off_t start_byte, off_t len) HDFS_ERROR
+qioerr hdfs_get_owners_for_bytes(qio_file_t* file, hdfs_block_byte_map_t** locs, int* out_num_blocks, char** locale_array, int num_locales, off_t start_byte, off_t len) HDFS_ERROR(return 0)
 
-qioerr hdfs_get_owners(qio_file_t* file, hdfs_block_byte_map_t** loc, int* out_num_blocks, char** arr, int n) HDFS_ERROR
+qioerr hdfs_get_owners(qio_file_t* file, hdfs_block_byte_map_t** loc, int* out_num_blocks, char** arr, int n) HDFS_ERROR(return 0)
 
-hdfs_block_byte_map_t hdfs_index_array(hdfs_block_byte_map_t* locs, int index) HDFS_ERROR
+hdfs_block_byte_map_t hdfs_index_array(hdfs_block_byte_map_t* locs, int index) HDFS_ERROR(return locs[0])
 
 qio_file_functions_t hdfs_function_struct = {
     &hdfs_writev,


### PR DESCRIPTION
The Cray C++ compiler was not recognizing the `exit` at the end of the the `HDFS_ERROR` and was generating warning at compile time. This commit fixes these problems by adding a return statement of the proper type at the end of `HDFS_ERROR` macro.

This has been tested on: gcc [4.7.2, 4.3.4], pgi, cray, and intel compilers.

@Kyle-B said he would review
