### PR TITLE
Pragma never noinit

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -121,7 +121,7 @@ symbolFlag( FLAG_MODULE_INIT , npr, "module init" , "a module init function" )
 // This flag marks the result of an autoCopy as necessary.
 // Necessary autoCopies are not removed by the removeUnnecessaryAutoCopyCalls optimization.
 symbolFlag( FLAG_NECESSARY_AUTO_COPY, npr, "necessary auto copy", "a variable containing a necessary autoCopy" )
-symbolFlag( FLAG_NEVER_NOINIT, ypr, "never noinit", "this type must be initialized" )
+symbolFlag( FLAG_IGNORE_NOINIT, ypr, "ignore noinit", "this type must be initialized" )
 symbolFlag( FLAG_NON_BLOCKING , npr, "non blocking" , "with FLAG_ON/FLAG_ON_BLOCK, non-blocking on functions" )
 symbolFlag( FLAG_NO_AUTO_DESTROY , ypr, "no auto destroy" , ncm )
 symbolFlag( FLAG_NO_CODEGEN , ypr, "no codegen" , "do not generate e.g. C code defining this symbol" )

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4450,7 +4450,7 @@ preFold(Expr* expr) {
         USR_FATAL(call, "invalid type specification");
       Type* type = call->get(1)->getValType();
       if (isAggregateType(type)) {
-        if (type->symbol->hasFlag(FLAG_NEVER_NOINIT)) {
+        if (type->symbol->hasFlag(FLAG_IGNORE_NOINIT)) {
           // These types deal with their uninitialized fields differently than
           // normal records/classes.  They may require special case
           // implementations, but were capable of being isolated from the new

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -257,7 +257,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomicflag {
     var _v:atomic_flag = create_atomic_flag();
     inline proc ~atomicflag() {
@@ -330,7 +330,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit" 
+  pragma "ignore noinit" 
   record atomic_uint8 {
     var _v:atomic_uint_least8_t = create_atomic_uint_least8();
     inline proc ~atomic_uint8() {
@@ -431,7 +431,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomic_uint16 {
     var _v:atomic_uint_least16_t = create_atomic_uint_least16();
     inline proc ~atomic_uint16() {
@@ -532,7 +532,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomic_uint32 {
     var _v:atomic_uint_least32_t = create_atomic_uint_least32();
     inline proc ~atomic_uint32() {
@@ -633,7 +633,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomic_uint64 {
     var _v:atomic_uint_least64_t = create_atomic_uint_least64();
     inline proc ~atomic_uint64() {
@@ -734,7 +734,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomic_int8 {
     var _v:atomic_int_least8_t = create_atomic_int_least8();
     inline proc ~atomic_int8() {
@@ -835,7 +835,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomic_int16 {
     var _v:atomic_int_least16_t = create_atomic_int_least16();
     inline proc ~atomic_int16() {
@@ -936,7 +936,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomic_int32 {
     var _v:atomic_int_least32_t = create_atomic_int_least32();
     inline proc ~atomic_int32() {
@@ -1037,7 +1037,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomic_int64 {
     var _v:atomic_int_least64_t = create_atomic_int_least64();
     inline proc ~atomic_int64() {
@@ -1139,7 +1139,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomic_real64 {
     var _v:atomic__real64 = create_atomic__real64();
     inline proc ~atomic_real64() {
@@ -1217,7 +1217,7 @@ module Atomics {
   }
 
   pragma "atomic type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record atomic_real32 {
     var _v:atomic__real32 = create_atomic__real32();
     inline proc ~atomic_real32() {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -541,7 +541,7 @@ module ChapelArray {
   // Distribution wrapper record
   //
   pragma "distribution"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record _distribution {
     var _value;
     var _valueType;
@@ -643,7 +643,7 @@ module ChapelArray {
   //
   pragma "domain"
   pragma "has runtime type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record _domain {
     var _value;     // stores domain class, may be privatized
     var _valueType; // stores type of privatized domains
@@ -1207,7 +1207,7 @@ module ChapelArray {
   //
   pragma "array"
   pragma "has runtime type"
-  pragma "never noinit"
+  pragma "ignore noinit"
   record _array {
     var _value;     // stores array class, may be privatized
     var _valueType; // stores type of privatized arrays

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -14,7 +14,7 @@ module ChapelSyncvar {
   pragma "sync"
     pragma "no object" // Optimize out the object base pointer.
     pragma "no default functions"
-    pragma "never noinit"
+    pragma "ignore noinit"
     class _syncvar {
       type base_type;
       var  value: base_type;       // actual data - may need to be declared specially on some targets!
@@ -155,7 +155,7 @@ module ChapelSyncvar {
     pragma "single"
     pragma "no object" // Optimize out the object base pointer.
     pragma "no default functions"
-    pragma "never noinit"
+    pragma "ignore noinit"
     class _singlevar {
       type base_type;
       var  value: base_type;     // actual data - may need to be declared specially on some targets!


### PR DESCRIPTION
In function resolution we warned users about using noinit with certain types because it did not work at the moment.  This was done by checking that the type in question was one of the known failure types.  However, if a developer were to create a type they did not think should work with noinit, they would have to alter the compiler to recognize and warn about this case.  The impact was partially theoretical in Chapel as it stands today - a user on their own could just remember not to use noinit with the type, and if code containing that type was submitted back, perhaps a comment would be needed so that anyone hoping to use that type would not make that mistake.

However, it is hoped that we can move to a world where return temps are not default initialized unless necessary, since these variables will be assigned to before they are returned.  In this case, types that may not otherwise have seen noinit would have it applied to them when a variable of that type was returned.  In such cases, it would be essential for the developer to inform the compiler that this type must never use noinit, so that noinit was not inserted for the return temp of that type.  Thus, the solution at the moment is to create a pragma "do not init", which would allow a user or developer to specify this case without needed to alter the compiler.
