### PR TITLE
Fannkuch cleanup to improve style and use atomics

### DIFF
--- a/test/studies/shootout/fannkuch-redux/bharshbarg/fannkuch-redux-iter.chpl
+++ b/test/studies/shootout/fannkuch-redux/bharshbarg/fannkuch-redux-iter.chpl
@@ -1,4 +1,4 @@
-/* The ComputeI Language Benchmarks Game
+/* The Computer Language Benchmarks Game
  * http://benchmarksgame.alioth.debian.org/
  *
  * contributed by Ben Harshbarger
@@ -28,9 +28,7 @@ proc main() {
 
   const work = 0 .. (Fact[n] - chunksz) by chunksz;
 
-  forall idx in dynamic(work, 1) {
-    fannkuch(idx, idx+chunksz);
-  }
+  forall idx in dynamic(work, 1) do fannkuch(idx, idx+chunksz);
   
   writeln(checks.read(), "\nPfannkuchen(", n, ") = ", flips.read());
 }


### PR DESCRIPTION
Most of these changes were initiated based off of an offline review. While there are many small style changes, the biggest change is using atomics in favor of reducing arrays. 

The total checksum can be added to easily enough. To keep track of the maximum number of flips, we use 'compareExchange' to make sure we don't overwrite any changes made by another task.

@Kyle-B or @lydia-duncan might want to review this.
