### PR TITLE
Move stack declarations for aprun argument list to global scope.

### DIFF
--- a/runtime/src/launch/aprun/aprun-utils.c
+++ b/runtime/src/launch/aprun/aprun-utils.c
@@ -189,10 +189,10 @@ int getCPUsPerCU() {
 // This function allocates and returns a NULL terminated argument list
 // with the aprun command to be run
 //
-char _nbuf[16];
-char _dbuf[16];
-char _Nbuf[16];
-char _jbuf[16];
+static char _nbuf[16];
+static char _dbuf[16];
+static char _Nbuf[16];
+static char _jbuf[16];
 extern const char *CHPL_TARGET_ARCH; // supplied by the generated code
 char** chpl_create_aprun_cmd(int argc, char* argv[],
                              int32_t numLocales, const char* _ccArg) {

--- a/runtime/src/launch/pbs-aprun/aprun-utils.c
+++ b/runtime/src/launch/pbs-aprun/aprun-utils.c
@@ -189,10 +189,10 @@ int getCPUsPerCU() {
 // This function allocates and returns a NULL terminated argument list
 // with the aprun command to be run
 //
-char _nbuf[16];
-char _dbuf[16];
-char _Nbuf[16];
-char _jbuf[16];
+static char _nbuf[16];
+static char _dbuf[16];
+static char _Nbuf[16];
+static char _jbuf[16];
 extern const char *CHPL_TARGET_ARCH; // supplied by the generated code
 char** chpl_create_aprun_cmd(int argc, char* argv[],
                              int32_t numLocales, const char* _ccArg) {


### PR DESCRIPTION
These declarations were previously at the global scope, but I had
moved them on to the stack in my previous commit (r23802 in the SVN
world) because my original design was to copy them before returning.
I decided to keep the design that was originally there before my
commit, but forgot to move the local declarations back to the global
scope.

This worked in local testing likely because I did not build optimized.
