### PR TITLE
See what the implications are for turning off qthreads affinity

### DIFF
--- a/util/cron/test-perf-chap04-qthreads.bash
+++ b/util/cron/test-perf-chap04-qthreads.bash
@@ -7,6 +7,7 @@ source $CWD/common-perf.bash
 source $CWD/common-qthreads.bash
 export CHPL_QTHREAD_NO_GUARD_PAGES=yes
 export CHPL_QTHREAD_SCHEDULER=nemesis
+export QTHREAD_AFFINITY=no
 export QTHREAD_NUM_SHEPHERDS=8
 export QTHREAD_NUM_WORKERS_PER_SHEPHERD=1
 # releasePerformance still generates results based on the fifo timings. It's


### PR DESCRIPTION
[more qthreads testing stuff, discussed with sung]

There are some for-loop and while-loop tests that are worse on chap04 (multi
socket) but not on chap03 (single socket.) The current guess is that because
qthreads pins shepherds to cores, if a core switches to another pthread, the
shepherd (and it's workers) can't make progress, meaning that qthreads could
perform worse in single threaded cases. If shepherds are not pinned to
cores, that should mean that if the OS swaps the shepherds thread, that
shepherd should be able to move to a different core and continue making
progress but on a different core.

However, in cases where qthreads is using all systems resources, it seems
likely that we would want affinity (shepherds pinned to cores) but we're not
really sure of the implications yet, hence trying this.

Also it's possible that since we switched to using the nemesis scheduler, we
want affinity off for that, and only leave it on for configurations not using
nemesis (numa, using sherwood.)
