### PR TITLE
Update .bad file

### DIFF
--- a/test/users/ferguson/local-return.bad
+++ b/test/users/ferguson/local-return.bad
@@ -1,3 +1,2 @@
 local-return.chpl:1: In function 'go':
-local-return.chpl:1: warning: control reaches end of function that returns a value
-10
+local-return.chpl:1: error: control reaches end of function that returns a value


### PR DESCRIPTION
It now reflects that we generate an error instead of a warning when we trigger "control flow reached end of function that returns a value".
