### PR TITLE
Add .gitignore files for many files generated during testing

### DIFF
--- a/test/chpldoc/.gitignore
+++ b/test/chpldoc/.gitignore
@@ -1,0 +1,2 @@
+docs
+*.good

--- a/test/studies/amr/advection/amr/.gitignore
+++ b/test/studies/amr/advection/amr/.gitignore
@@ -1,0 +1,3 @@
+_output
+*.tmp
+*.tmp.save

--- a/test/studies/amr/advection/grid/.gitignore
+++ b/test/studies/amr/advection/grid/.gitignore
@@ -1,0 +1,3 @@
+_output
+*.tmp
+*.tmp.save

--- a/test/studies/amr/advection/level/.gitignore
+++ b/test/studies/amr/advection/level/.gitignore
@@ -1,0 +1,3 @@
+_output
+*.tmp
+*.tmp.save

--- a/test/studies/amr/diffusion/grid/.gitignore
+++ b/test/studies/amr/diffusion/grid/.gitignore
@@ -1,0 +1,3 @@
+_output
+*.tmp
+*.tmp.save

--- a/test/studies/amr/diffusion/level/.gitignore
+++ b/test/studies/amr/diffusion/level/.gitignore
@@ -1,0 +1,3 @@
+_output
+*.tmp
+*.tmp.save


### PR DESCRIPTION
These .gitignore files correspond to svn:ignore properties from the Subversion
repository. There are still a few generated files left to clean up or ignore,
but this takes care of most of them.
