### PR TITLE
Make scenario-3-assoc-... reseliant to line number changes

### DIFF
--- a/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.bad
+++ b/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.bad
@@ -1,5 +1,5 @@
-scenario-3-assoc-dom-of-record-with-const-fld.chpl:3: error: cannot assign to a record of the type Node using the default assignment operator because it has 'const' field(s)
-scenario-3-assoc-dom-of-record-with-const-fld.chpl:17: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
-scenario-3-assoc-dom-of-record-with-const-fld.chpl:18: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
-$CHPL_HOME/modules/internal/ChapelArray.chpl:241: In function 'chpl__buildAssociativeArrayExpr':
-$CHPL_HOME/modules/internal/ChapelArray.chpl:270: error: cannot assign to a record of the type Coeff using the default assignment operator because it has 'const' field(s)
+scenario-3-assoc-dom-of-record-with-const-fld.chpl: error: cannot assign to a record of the type Node using the default assignment operator because it has 'const' field(s)
+scenario-3-assoc-dom-of-record-with-const-fld.chpl: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+scenario-3-assoc-dom-of-record-with-const-fld.chpl: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+$CHPL_HOME/modules/internal/ChapelArray.chpl: In function 'chpl__buildAssociativeArrayExpr':
+$CHPL_HOME/modules/internal/ChapelArray.chpl: error: cannot assign to a record of the type Coeff using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.good
+++ b/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.good
@@ -1,5 +1,5 @@
-scenario-3-assoc-dom-of-record-with-const-fld.chpl:17: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
-scenario-3-assoc-dom-of-record-with-const-fld.chpl:18: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+scenario-3-assoc-dom-of-record-with-const-fld.chpl: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+scenario-3-assoc-dom-of-record-with-const-fld.chpl: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 {(lvl = 1)}
 {(lvl = 1000)}
 {(lvl = 1000)}

--- a/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.prediff
+++ b/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.prediff
@@ -1,0 +1,3 @@
+#!/bin/sh
+cut -d ':' -f 1,3- $2 > $2.prediff.tmp
+mv $2.prediff.tmp $2


### PR DESCRIPTION
This future was failing to match agasint the bad file since the line
number inside of ChapelArray had changed. This commit adds a prediff to
cut the line number out of the warnings.
