### PR TITLE
Fix problems in our file timestamp adjustments.

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -43,18 +43,18 @@ hwloc-config: FORCE
 # ahead in version numbers as that which was used when packaging the
 # Qthreads release
 #
-	cd $(HWLOC_SUBDIR) && find . -name "*.m4" | xargs touch configure.ac
-	sleep 2
+	cd $(HWLOC_SUBDIR) && touch -c configure.ac
+	cd $(HWLOC_SUBDIR) && find . -name "*.m4" | xargs touch 
+	cd $(HWLOC_SUBDIR) && touch -c aclocal.m4
 	cd $(HWLOC_SUBDIR) && touch configure
-	sleep 2
 	cd $(HWLOC_SUBDIR) && find . -name "*.in" | xargs touch
 #
 # For reasons not yet understood, our use of a separate build dir breaks
 # the doxygen doc rebuild step.  Ensuring that $(HWLOC_SUBDIR)/README is
-# at least as new as $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag prevents
-# make from trying to do that step.
+# newer than $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag prevents make from
+# trying to do that step.
 #
-	touch -m -r $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag \
+	touch -m -r $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -d '+1 sec' \
 	      $(HWLOC_SUBDIR)/README
 #
 # Then configure


### PR DESCRIPTION
We were still seeing problems with attempts to rebuild things, due to
losing the file timestamp information when we put the untarred sources
into the repository and get them back out.  This change seems (cross
fingers) to solve those problems.

While here, I removed the sleep commands, because I don't think they're
actually needed.
