### PR TITLE
Fixing channel.readstring

### DIFF
--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -1600,9 +1600,6 @@ unlock:
   return err;
 }
 
-// Returns the length of a file that backs a channel
-qioerr qio_channel_get_channel_size(qio_channel_t* chan, int64_t* len_out);
-
 #ifdef __cplusplus
 } // end extern "C"
 #endif

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1358,14 +1358,6 @@ qioerr qio_file_length(qio_file_t* f, int64_t *len_out)
   return err;
 }
 
-// get the size of this channel
-qioerr qio_channel_get_channel_size(qio_channel_t* chan, int64_t* len_out) 
-{ 
-  *len_out = chan->end_pos - chan->start_pos;
-  return 0;
-}
-
-
 /* CHANNELS ----------------------------- */
 static
 qioerr _qio_channel_init(qio_channel_t* ch, qio_chtype_t type)


### PR DESCRIPTION
The previous version of this function was very inefficient, since it would allocate the size of the file, even though we might have a reader on only a very small portion of the file. This pull request fixes this problem by instead giving back the total size of the given channel.
