### PR TITLE
Add DIRNAME.skipif for some test dirs with custom 'sub_test'.

### DIFF
--- a/test/compflags/ferguson.skipif
+++ b/test/compflags/ferguson.skipif
@@ -1,0 +1,7 @@
+# It suffices to test this directory only for one configuration -
+# so skip if it is not the standard configuration.
+CHPL_COMM != none
+COMPOPTS <= --baseline
+COMPOPTS <= --no-local
+CHPL_TEST_PERF == on
+CHPL_TEST_VGRND_EXE == on

--- a/test/functions/ferguson.skipif
+++ b/test/functions/ferguson.skipif
@@ -1,0 +1,7 @@
+# It suffices to test this directory only for one configuration -
+# so skip if it is not the standard configuration.
+CHPL_COMM != none
+COMPOPTS <= --baseline
+COMPOPTS <= --no-local
+CHPL_TEST_PERF == on
+CHPL_TEST_VGRND_EXE == on

--- a/test/io/ferguson/ctests.skipif
+++ b/test/io/ferguson/ctests.skipif
@@ -1,0 +1,7 @@
+# It suffices to test this directory only for one configuration -
+# so skip if it is not the standard configuration.
+CHPL_COMM != none
+COMPOPTS <= --baseline
+COMPOPTS <= --no-local
+CHPL_TEST_PERF == on
+CHPL_TEST_VGRND_EXE == on

--- a/test/io/ferguson/utf8cols.skipif
+++ b/test/io/ferguson/utf8cols.skipif
@@ -1,0 +1,7 @@
+# It suffices to test this directory only for one configuration -
+# so skip if it is not the standard configuration.
+CHPL_COMM != none
+COMPOPTS <= --baseline
+COMPOPTS <= --no-local
+CHPL_TEST_PERF == on
+CHPL_TEST_VGRND_EXE == on

--- a/test/regexp/ferguson/ctests.skipif
+++ b/test/regexp/ferguson/ctests.skipif
@@ -1,0 +1,7 @@
+# It suffices to test this directory only for one configuration -
+# so skip if it is not the standard configuration.
+CHPL_COMM != none
+COMPOPTS <= --baseline
+COMPOPTS <= --no-local
+CHPL_TEST_PERF == on
+CHPL_TEST_VGRND_EXE == on

--- a/test/users/ferguson/bswap.skipif
+++ b/test/users/ferguson/bswap.skipif
@@ -1,0 +1,7 @@
+# It suffices to test this directory only for one configuration -
+# so skip if it is not the standard configuration.
+CHPL_COMM != none
+COMPOPTS <= --baseline
+COMPOPTS <= --no-local
+CHPL_TEST_PERF == on
+CHPL_TEST_VGRND_EXE == on

--- a/test/users/ferguson/sys/getenv.skipif
+++ b/test/users/ferguson/sys/getenv.skipif
@@ -1,0 +1,7 @@
+# It suffices to test this directory only for one configuration -
+# so skip if it is not the standard configuration.
+CHPL_COMM != none
+COMPOPTS <= --baseline
+COMPOPTS <= --no-local
+CHPL_TEST_PERF == on
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Added DIRNAME.skipif for some test dirs with custom 'sub_test'.

The following directories:

  test/compflags/ferguson
  test/users/ferguson/bswap
  test/users/ferguson/sys/getenv
  test/regexp/ferguson/ctests
  test/io/ferguson/utf8cols
  test/io/ferguson/ctests
  test/functions/ferguson

(a) use custom 'sub_test', and
(b) need testing only under one configuration.

Since these 'sub_test' do not perform skipif checks, they were getting
tested under all configurations every night, which is excessive and
on occasion has created noise in our nightly emails.

So I am adding DIRNAME.skipif so for each DIRNAME in the above,
aiming at having those dirs be tested for the standard configuration only.
If there are other configurations that should be ruled out,
these skipifs should be extended.

As of this commit, the seven .skipif files are identical.
