### PR TITLE
Remove .future on passing future test

### DIFF
--- a/test/users/ferguson/tuple-by-ref-to-copy.future
+++ b/test/users/ferguson/tuple-by-ref-to-copy.future
@@ -1,8 +1,0 @@
-bug: Problem with ref varargs
-
-I'm getting
-
-error: assertion error [expr.cpp:3004]
-
-and preliminary analysis indicates that we're trying to assign to
-the literal 0 in code generation.


### PR DESCRIPTION
This future was solved by my _defaultOf language feature, I believe due to the change in the scopeResolve pass which caused ref variable fields to no longer be default initialized, since the field will be assigned to at a later point.
