### PR TITLE
Fix a bad argument to printf().

### DIFF
--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -237,7 +237,8 @@ void printHelpTable(void) {
       for (p = flagList[i].description;
            (pNext = strchr(p, '\n')) != NULL;
            p = pNext + 1) {
-        fprintf(stdout, "%.*s\n%*s", pNext - p, p, longestFlag + 6, "");
+        fprintf(stdout, "%.*s\n%*s", (int) (pNext - p), p,
+                longestFlag + 6, "");
       }
       fprintf(stdout, "%s\n", p);
     }


### PR DESCRIPTION
The ".*" max-length specifier for a printf field expects the
corresponding argument to be an int.  I was passing a size_t instead,
because it was the difference of two pointers.  Fix that.
