### PR TITLE
Update prediff-for-aprun-with-moab to filter more generally.

### DIFF
--- a/util/test/prediff-for-aprun-with-moab
+++ b/util/test/prediff-for-aprun-with-moab
@@ -4,6 +4,6 @@
 
 if [ "${1}" != "mandelbrot" ] ; then
     outfile=$2
-    cat $outfile | grep -v '/opt/cray/ccm/default/etc/cray-ccm-epilogue: line 95: echo: write error: Broken pipe' > $outfile.tmp
+    cat $outfile | grep -v -E '.*/cray-ccm-epilogue: line .*: echo: write error: Broken pipe' > $outfile.tmp
     mv $outfile.tmp $outfile
 fi


### PR DESCRIPTION
Removes absolute filepath and line number from grep filter. This came about when we moved testing from one system to another.
