### PR TITLE
Regex: Cache string size to improve performance for large strings in matches iterator

### DIFF
--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -422,7 +422,7 @@ record regexp {
     } else {
       pos = 0;
       endpos = text.size;
-      textSize = text.size;
+      textSize = endpos;
     }
     var nfound = 0; 
     var cur = pos;


### PR DESCRIPTION
In the regex-dna shootout, we need to count the number of matches in a very large string. With the current state of strings, calling text.size invokes strlen. Calling strlen on this very large string every time we look for a match is very slow. By caching the string's length, the performance of this iterator improves immensely.
