### PR TITLE
Hoist duplicate malloc wrappers from localeModels to ChapelLocale.

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -3,6 +3,8 @@
 pragma "no use ChapelStandard"
 module ChapelLocale {
 
+  use LocaleModel;
+
   //
   // An abstract class. Specifies the required locale interface.
   // Each locale implementation must inherit from this class.
@@ -317,7 +319,7 @@ module ChapelLocale {
   const dummyLocale = new locale();
 
   extern proc chpl_task_getRequestedSubloc(): chpl_sublocID_t;
-  extern var chpl_nodeID: int(32);
+
   // Return the locale ID of the current locale
   inline proc here_id {
     return chpl_buildLocaleID(chpl_nodeID,chpl_task_getRequestedSubloc());
@@ -335,6 +337,46 @@ module ChapelLocale {
       // For code prior to rootLocale initialization
       return dummyLocale;
   }
+
+  //////////////////////////////////////////
+  //
+  // support for memory management
+  //
+
+  // The allocator pragma is used by scalar replacement.
+  pragma "allocator"
+  pragma "no sync demotion"
+  pragma "locale model alloc"
+  proc chpl_here_alloc(size:int, md:int(16)) {
+    pragma "insert line file info"
+      extern proc chpl_mem_alloc(size:int, md:int(16)) : opaque;
+    return chpl_mem_alloc(size, md + chpl_memhook_md_num());
+  }
+
+  pragma "allocator"
+  pragma "no sync demotion"
+  proc chpl_here_calloc(size:int, number:int, md:int(16)) {
+    pragma "insert line file info"
+      extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : opaque;
+    return chpl_mem_calloc(number, size, md + chpl_memhook_md_num());
+  }
+
+  pragma "allocator"
+  pragma "no sync demotion"
+  proc chpl_here_realloc(ptr:opaque, size:int, md:int(16)) {
+    pragma "insert line file info"
+      extern proc chpl_mem_realloc(ptr:opaque, size:int, md:int(16)) : opaque;
+    return chpl_mem_realloc(ptr, size, md + chpl_memhook_md_num());
+  }
+
+  pragma "no sync demotion"
+  pragma "locale model free"
+  proc chpl_here_free(ptr:opaque) {
+    pragma "insert line file info"
+      extern proc chpl_mem_free(ptr:opaque): void;
+    chpl_mem_free(ptr);
+  }
+
 
   pragma "insert line file info"
   extern proc chpl_memhook_malloc_pre(number:int, size:int, md:int(16)): void;

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -244,46 +244,6 @@ module LocaleModel {
 
   //////////////////////////////////////////
   //
-  // support for memory management
-  //
-
-  // The allocator pragma is used by scalar replacement.
-  pragma "allocator"
-  pragma "no sync demotion"
-  pragma "locale model alloc"
-  proc chpl_here_alloc(size:int, md:int(16)) {
-    pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:int, md:int(16)) : opaque;
-    return chpl_mem_alloc(size, md + chpl_memhook_md_num());
-  }
-
-  pragma "allocator"
-  pragma "no sync demotion"
-  proc chpl_here_calloc(size:int, number:int, md:int(16)) {
-    pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : opaque;
-    return chpl_mem_calloc(number, size, md + chpl_memhook_md_num());
-  }
-
-  pragma "allocator"
-  pragma "no sync demotion"
-  proc chpl_here_realloc(ptr:opaque, size:int, md:int(16)) {
-    pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:opaque, size:int, md:int(16)) : opaque;
-    return chpl_mem_realloc(ptr, size, md + chpl_memhook_md_num());
-  }
-
-  pragma "no sync demotion"
-  pragma "locale model free"
-  proc chpl_here_free(ptr:opaque) {
-    pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:opaque): void;
-    chpl_mem_free(ptr);
-  }
-
-
-  //////////////////////////////////////////
-  //
   // support for "on" statements
   //
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -316,46 +316,6 @@ module LocaleModel {
 
   //////////////////////////////////////////
   //
-  // support for memory management
-  //
-
-  // The allocator pragma is used by scalar replacement.
-  pragma "allocator"
-  pragma "no sync demotion"
-  pragma "locale model alloc"
-  proc chpl_here_alloc(size:int, md:int(16)) {
-    pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:int, md:int(16)) : opaque;
-    return chpl_mem_alloc(size, md + chpl_memhook_md_num());
-  }
-
-  pragma "allocator"
-  pragma "no sync demotion"
-  proc chpl_here_calloc(size:int, number:int, md:int(16)) {
-    pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : opaque;
-    return chpl_mem_calloc(number, size, md + chpl_memhook_md_num());
-  }
-
-  pragma "allocator"
-  pragma "no sync demotion"
-  proc chpl_here_realloc(ptr:opaque, size:int, md:int(16)) {
-    pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:opaque, size:int, md:int(16)) : opaque;
-    return chpl_mem_realloc(ptr, size, md + chpl_memhook_md_num());
-  }
-
-  pragma "no sync demotion"
-  pragma "locale model free"
-  proc chpl_here_free(ptr:opaque) {
-    pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:opaque): void;
-    chpl_mem_free(ptr);
-  }
-
-
-  //////////////////////////////////////////
-  //
   // support for "on" statements
   //
 


### PR DESCRIPTION
I noticed that chpl_here_alloc() and kin are identical in the two localeModels, and can be hoisted into ChapelLocale.  I noticed because my work on calling user default constructors exposes a circular dependency in the modules, wherein the size of a chpl_nodeID (defined in the localeModel) must be known in order to allocate a wide pointer, but ChapelLocale is a dependency of LocaleModel and was getting resolved first.  This left chpl_nodeID unresolved in the place where it is first  used.

I solved this by creating an explicit dependency of ChapelLocale on the locale model -- by adding a use statement at the beginning of ChapelLocale.  I also removed the redundant definition for chpl_nodeID there, since the locale model may have a different idea on the subject.

I consolidated the redundant copies of chpl_here_alloc() and kin by hoisting them from the localeModel files to ChapelLocale.chpl.  This may not be strictly necessary, but it is a nice factoring.

I checked to ensure that the "locale model alloc" pragma is not affected by this move.  The effect of that pragma is to prevent the widening of the interface to that particular function.  I also checked to ensure that the "locale model free" pragma was not affected.  It is used for some consistency checks and an optimization that removes setting the CID in the calling context.  It appears that a change in these effects would be unlikely merely due to moving the marked functions between modules.

[tested on domains distributions multilocale parallel (std-flat)]
