### PR TITLE
Try out the sherwood scheduler again for qthreads with condwait-queue

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -41,6 +41,7 @@
 #include "qt_syncvar.h" // for blockreporting
 #include "qt_hash.h" /* for qt_key_t */
 #include "qt_atomics.h"      /* for SPINLOCK_BODY() */
+#include "qt_threadqueues.h" // for qthread_steal_disable
 #include "qt_envariables.h"
 #include "qt_debug.h"
 
@@ -320,6 +321,8 @@ void chpl_task_init(void)
     size_t    callStackSize;
     pthread_t initer;
     char      newenv_stack[100] = { 0 };
+    char *noWorkSteal;
+
 
     // Set up available hardware parallelism.
 
@@ -435,6 +438,12 @@ void chpl_task_init(void)
         if (signal(SIGINT, SIGINT_handler) == SIG_ERR) {
             perror("Could not register SIGINT handler");
         }
+    }
+
+    // Turn off work stealing if it was configured to be off
+    noWorkSteal = getenv("CHPL_QTHREAD_NO_WORK_STEALING");
+    if (noWorkSteal != NULL && strncmp(noWorkSteal, "yes", 3) == 0) {
+      qthread_steal_disable();
     }
 }
 

--- a/util/cron/test-perf-chap03-qthreads.bash
+++ b/util/cron/test-perf-chap03-qthreads.bash
@@ -6,8 +6,9 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-perf.bash
 source $CWD/common-qthreads.bash
 export CHPL_QTHREAD_NO_GUARD_PAGES=yes
-export CHPL_QTHREAD_SCHEDULER=nemesis
+export CHPL_QTHREAD_NO_WORK_STEALING=yes
 export CHPL_QTHREAD_MORE_CFG_OPTIONS=--enable-condwait-queue
-export QTHREAD_NUM_SHEPHERDS=2
-export QTHREAD_NUM_WORKERS_PER_SHEPHERD=1
+#export CHPL_QTHREAD_SCHEDULER=nemesis
+#export QTHREAD_NUM_SHEPHERDS=2
+#export QTHREAD_NUM_WORKERS_PER_SHEPHERD=1
 $CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -numtrials 5 -startdate 08/21/07

--- a/util/cron/test-perf-chap04-qthreads.bash
+++ b/util/cron/test-perf-chap04-qthreads.bash
@@ -6,10 +6,11 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-perf.bash
 source $CWD/common-qthreads.bash
 export CHPL_QTHREAD_NO_GUARD_PAGES=yes
-export CHPL_QTHREAD_SCHEDULER=nemesis
+export CHPL_QTHREAD_NO_WORK_STEALING=yes
 export CHPL_QTHREAD_MORE_CFG_OPTIONS=--enable-condwait-queue
-export QTHREAD_NUM_SHEPHERDS=8
-export QTHREAD_NUM_WORKERS_PER_SHEPHERD=1
+#export CHPL_QTHREAD_SCHEDULER=nemesis
+#export QTHREAD_NUM_SHEPHERDS=8
+#export QTHREAD_NUM_WORKERS_PER_SHEPHERD=1
 # releasePerformance still generates results based on the fifo timings. It's
 # run here again, otherwise syncing the qthreads results blows away the
 # directory with the releaseOverRelease graphs in


### PR DESCRIPTION
I want to see what the performance for the sherwood scheduler is like again now
that we have condwait-queue enabled. It would be great if we could use the
sherwood scheduler instead of the nemesis. I don't think that's going to be the
case and I'm pretty sure there's more overhead to using the sherwood scheduler
over nemesis, but I want to confirm this with some testing tonight.

Like before this disables work stealing since that had a negative performance
impact on a lot of tests, but this makes disabling work stealing dependent on
an environment variable instead of forcing it like I did last time.
