### PR TITLE
Add futures for calling writef with const/var string as first arg.

### DIFF
--- a/test/io/thomasvandoren/WritefWithConstPattern.bad
+++ b/test/io/thomasvandoren/WritefWithConstPattern.bad
@@ -1,0 +1,11 @@
+WritefWithConstPattern.chpl:7: error: unresolved call 'writef(string, "something clever")'
+$CHPL_HOME/modules/standard/IO.chpl:2808: note: candidates are: channel.writef(fmt: string, args ...?k, out error: syserr)
+$CHPL_HOME/modules/standard/IO.chpl:2812: note:                 channel.writef(fmt: c_string, args ...?k, out error: syserr)
+$CHPL_HOME/modules/standard/IO.chpl:2966: note:                 channel.writef(fmt: string, out error: syserr)
+$CHPL_HOME/modules/standard/IO.chpl:2970: note:                 channel.writef(fmt: c_string, out error: syserr)
+$CHPL_HOME/modules/standard/IO.chpl:3303: note:                 channel.writef(fmt: string, args ...?k)
+$CHPL_HOME/modules/standard/IO.chpl:3307: note:                 channel.writef(fmt: c_string, args ...?k)
+$CHPL_HOME/modules/standard/IO.chpl:3317: note:                 channel.writef(fmt: string)
+$CHPL_HOME/modules/standard/IO.chpl:3321: note:                 channel.writef(fmt: c_string)
+$CHPL_HOME/modules/standard/IO.chpl:3363: note:                 writef(fmt: c_string, args ...?k)
+$CHPL_HOME/modules/standard/IO.chpl:3366: note:                 writef(fmt: c_string)

--- a/test/io/thomasvandoren/WritefWithConstPattern.chpl
+++ b/test/io/thomasvandoren/WritefWithConstPattern.chpl
@@ -1,0 +1,7 @@
+/*
+ * Note that by manually putting the string literal where the variable is, this
+ * is "fixed".
+ */
+
+const outPattern = "%s\n";
+writef(outPattern, "something clever");

--- a/test/io/thomasvandoren/WritefWithConstPattern.future
+++ b/test/io/thomasvandoren/WritefWithConstPattern.future
@@ -1,0 +1,16 @@
+bug: writef fails to resolve when first argument is const string instead of string literal
+
+This example highlights the issue:
+
+const outPattern = "%s\n";
+writef(outPattern, "something clever");
+
+The compiler is unable to resolve writef. The canditate includes these options,
+which are fairly close to 'writef(string, "something clever")':
+
+channel.writef(fmt: string, args ...?k)
+channel.writef(fmt: c_string, args ...?k)
+writef(fmt: c_string, args ...?k)
+
+However, it is notable that writef(fmt: string, args ...?k) is missing from the
+candidate list.

--- a/test/io/thomasvandoren/WritefWithConstPattern.good
+++ b/test/io/thomasvandoren/WritefWithConstPattern.good
@@ -1,0 +1,1 @@
+something clever

--- a/test/io/thomasvandoren/WritefWithVarPattern.bad
+++ b/test/io/thomasvandoren/WritefWithVarPattern.bad
@@ -1,0 +1,11 @@
+WritefWithVarPattern.chpl:7: error: unresolved call 'writef(string, "i can haz format?")'
+$CHPL_HOME/modules/standard/IO.chpl:2808: note: candidates are: channel.writef(fmt: string, args ...?k, out error: syserr)
+$CHPL_HOME/modules/standard/IO.chpl:2812: note:                 channel.writef(fmt: c_string, args ...?k, out error: syserr)
+$CHPL_HOME/modules/standard/IO.chpl:2966: note:                 channel.writef(fmt: string, out error: syserr)
+$CHPL_HOME/modules/standard/IO.chpl:2970: note:                 channel.writef(fmt: c_string, out error: syserr)
+$CHPL_HOME/modules/standard/IO.chpl:3303: note:                 channel.writef(fmt: string, args ...?k)
+$CHPL_HOME/modules/standard/IO.chpl:3307: note:                 channel.writef(fmt: c_string, args ...?k)
+$CHPL_HOME/modules/standard/IO.chpl:3317: note:                 channel.writef(fmt: string)
+$CHPL_HOME/modules/standard/IO.chpl:3321: note:                 channel.writef(fmt: c_string)
+$CHPL_HOME/modules/standard/IO.chpl:3363: note:                 writef(fmt: c_string, args ...?k)
+$CHPL_HOME/modules/standard/IO.chpl:3366: note:                 writef(fmt: c_string)

--- a/test/io/thomasvandoren/WritefWithVarPattern.chpl
+++ b/test/io/thomasvandoren/WritefWithVarPattern.chpl
@@ -1,0 +1,7 @@
+/*
+ * Note that by manually putting the string literal where the variable is, this
+ * is "fixed".
+ */
+
+var outPattern = "%s\n";
+writef(outPattern, "i can haz format?");

--- a/test/io/thomasvandoren/WritefWithVarPattern.future
+++ b/test/io/thomasvandoren/WritefWithVarPattern.future
@@ -1,0 +1,16 @@
+bug: writef fails to resolve when first argument is var string instead of string literal
+
+This example highlights the issue:
+
+var outPattern = "%s\n";
+writef(outPattern, "i can haz format?");
+
+The compiler is unable to resolve writef. The canditate includes these options,
+which are fairly close to 'writef(string, "i can haz format?")':
+
+channel.writef(fmt: string, args ...?k)
+channel.writef(fmt: c_string, args ...?k)
+writef(fmt: c_string, args ...?k)
+
+However, it is notable that writef(fmt: string, args ...?k) is missing from the
+candidate list.

--- a/test/io/thomasvandoren/WritefWithVarPattern.good
+++ b/test/io/thomasvandoren/WritefWithVarPattern.good
@@ -1,0 +1,1 @@
+i can haz format?


### PR DESCRIPTION
The compiler fails to resolve these calls. I noticed this when I was putting together `/test/trivial/thomasvandoren/GitIntro.chpl` in commit 817119d.
