### PR TITLE
TRIAGE update

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -21,12 +21,6 @@ general regressions (seem to happen in most configurations)
 (Reviewed for accuracy 07/15/14)
 ===========================================================
 
-regexp_test.cc:9:21: fatal error: re2/re2.h: No such file or directory
-----------------------------------------------------------------------
-[Error compiling C Regexp tests]
-Started 7/26/14.
-Greg's https://github.com/chapel-lang/chapel/pull/74 should fix this.
-
 
 ==============================================
 linux64 regressions (in addition to the above)

--- a/test/TRIAGE
+++ b/test/TRIAGE
@@ -45,9 +45,14 @@ It is being escalated to github support.
 Intermittent: got a lot of these early in the week of 7/20, fewer on 7/25,
               but then more again on 7/26, only a few on 7/27, etc.
 
+CCE errors building runtime with 8.4 (The identifier "__func__" is undefined.)
+---------------------------------------------------------------------
+Bug http://bugzilla.us.cray.com/show_bug.cgi?id=815301
+
 *** Caught a fatal signal: SIGSEGV(11) on node 3/4: gasnet.qthreads.numa
 ------------------------------------------------------------------------
 [Error matching program output for distributions/diten/oneOrMoreLocales/testCyclicDist]
+[Error matching program output for release/examples/programs/quicksort]
 
 gasnet.qthreads.numa is getting a timeout mail per night, approximately
 -----------------------------------------------------------------------


### PR DESCRIPTION
Fixed C Regexp tests
release/examples/programs/quicksort seg faulted once for qthreads.gasnet.numa
CCE runtime build error, should be fixed in latest CCE
