### PR TITLE
Fix stdin execopts to look for first instance of '<'

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1343,10 +1343,11 @@ for testname in testsrc:
                 args += lastexecopts
             # sys.stdout.write("args=%s\n"%(args))
 
-            if len(args) >= 2 and args[-2] == '<':
-              execOptRedirect = args[-1]
-              args.pop(-2)
-              args.pop(-1)
+            if len(args) >= 2 and '<' in args:
+              redirIdx = args.index('<')
+              execOptRedirect = args[redirIdx + 1]
+              args.pop(redirIdx+1)
+              args.pop(redirIdx)
               if redirectin == None or redirectin == "/dev/null":
                 if os.access(execOptRedirect, os.R_OK):
                   redirectin = execOptRedirect


### PR DESCRIPTION
Some of our automated tests add arguments after those in execopts, and we were only looking at the last two arguments. This fix will look for the first instance of '<', instead of looking at the second-to-last argument.
