### PR TITLE
Make chpl_arch return 'none' for versions of gcc < 4.3

### DIFF
--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -115,9 +115,7 @@ class argument_map(object):
                 return cls.gcc47.get(arch, '')
             if version >= 4.3:
                 return cls.gcc43.get(arch, '')
-            else:
-                stderr.write('Warning: Argument map not found for GCC version: "{0}"\n'.format(version))
-                return ''
+            return 'none'
         elif compiler == 'intel':
             return cls.intel.get(arch, '')
         elif compiler == 'clang':


### PR DESCRIPTION
Old versions of GCC would get a few warnings when chpl_arch was run. After this commit versions of GCC before 4.3 will use 'none' for CHPL_TARGET_ARCH.
