### PR TITLE
Attempt to fix the recent "continually re-make version.cpp" issue

### DIFF
--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -5,8 +5,8 @@
 #define MINOR_VERSION "9"
 #define UPDATE_VERSION "0"
 
-static const char* BUILD_VERSION =
+static const char* BUILD_VERSION = "
 #include "BUILD_VERSION"
-;
+";
 
 #endif

--- a/util/devel/updateBuildVersion
+++ b/util/devel/updateBuildVersion
@@ -39,6 +39,6 @@ if ($build_version eq $last_build_version ||
 } else {
 #    print "Updating build version ($build_version != $last_build_version)\n";
     open BUILD_VERSION, ">$build_version_file" or die "can't open $build_version_file for writing $!";
-    print BUILD_VERSION "\"$build_version\"\n";
+    print BUILD_VERSION "$build_version\n";
     close BUILD_VERSION;
 }


### PR DESCRIPTION
This commit attempts to fix the recent problem that Sung has been
complaining about in which version.cpp is continually re-built.
Though I have not seen it on my desktop, I am seeing it on my
personal Mac which permitted me to debug it.  I'm wondering if
there could be a sensitivity to Perl version number at play here?

From what I could tell, the BUILD_VERSION file has been storing the
git SHA value as a string literal with quotes (e.g., "abcdef" would
appear in the file.  This was compared against a string without qutoes
(e.g., abcdef) and returned false, so it would create a new
BUILD_VERSION file.

The approach I took here was to move the quotes out of the
BUILD_VERSION file and place them into the version_num.h file.  It
surprised me a little that this worked because I thought C didn't
generally like multi-line string literals, yet it does, at least on my
Mac's version of gcc.  It would be good to do some more testing on
newer gcc's before merging back to master.
