### PR TITLE
Only update BUILD_VERSION when revision changes.

### DIFF
--- a/util/devel/updateBuildVersion
+++ b/util/devel/updateBuildVersion
@@ -28,7 +28,7 @@ if (defined $ENV{'CHPL_HOME'} &&
     $git_rev = `cd $ENV{'CHPL_HOME'} && git rev-parse --short HEAD`;
     chomp($git_rev);
 
-    $build_version = "$git_rev";
+    $build_version = "\"$git_rev\"";
 } else {
     $build_version = "-999";
 }
@@ -39,6 +39,6 @@ if ($build_version eq $last_build_version ||
 } else {
 #    print "Updating build version ($build_version != $last_build_version)\n";
     open BUILD_VERSION, ">$build_version_file" or die "can't open $build_version_file for writing $!";
-    print BUILD_VERSION "\"$build_version\"\n";
+    print BUILD_VERSION "$build_version\n";
     close BUILD_VERSION;
 }


### PR DESCRIPTION
This was broken in 2b5040c because the BUILD_VERSION included a quoted version of the string and we compared that to an unquoted version in `updateBuildVersion`. This caused version.cpp to rebuild all the time, which is less than ideal.

This fixes #125.
