### PR TITLE
Try touch -A iff touch -d failed in hwloc makefile

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -54,8 +54,8 @@ hwloc-config: FORCE
 # newer than $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag prevents make from
 # trying to do that step.
 #
-	touch -m -r $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -d '+1 sec' \
-	      $(HWLOC_SUBDIR)/README
+	touch -m -r  $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -d '+1 sec' $(HWLOC_SUBDIR)/README 2>/dev/null || \
+		touch -m -r $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -A '01' $(HWLOC_SUBDIR)/README
 #
 # Then configure
 #


### PR DESCRIPTION
touch -d is only available for gnu touch (and recent versions of bsd touch) but
darwin has an ancient version of bsd touch on it so we revert to trying -A if
-d wasn't valid.
