### PR TITLE
Make external decls of tasking layer functions match their defs.

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -370,21 +370,21 @@ module ChapelLocale {
 
   proc locale.totalThreads() {
     var totalThreads: int;
-    extern proc chpl_task_getNumThreads() : int;
+    extern proc chpl_task_getNumThreads() : uint(32);
     on this do totalThreads = chpl_task_getNumThreads();
     return totalThreads;
   }
   
   proc locale.idleThreads() {
     var idleThreads: int;
-    extern proc chpl_task_getNumIdleThreads() : int;
+    extern proc chpl_task_getNumIdleThreads() : uint(32);
     on this do idleThreads = chpl_task_getNumIdleThreads();
     return idleThreads;
   }
   
   proc locale.queuedTasks() {
     var queuedTasks: int;
-    extern proc chpl_task_getNumQueuedTasks() : int;
+    extern proc chpl_task_getNumQueuedTasks() : uint(32);
     on this do queuedTasks = chpl_task_getNumQueuedTasks();
     return queuedTasks;
   }
@@ -395,7 +395,7 @@ module ChapelLocale {
   
   proc locale.blockedTasks() {
     var blockedTasks: int;
-    extern proc chpl_task_getNumBlockedTasks() : int;
+    extern proc chpl_task_getNumBlockedTasks() : int(32);
     on this do blockedTasks = chpl_task_getNumBlockedTasks();
     return blockedTasks;
   }


### PR DESCRIPTION
The ChapelLocale module's external declarations of 4 functions in the
tasking layer interface didn't match the definitions of those same
functions.  Fix the decls.
