### PR TITLE
Remove ability to turn off qthreads work stealing (for good this time)

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -41,7 +41,6 @@
 #include "qt_syncvar.h" // for blockreporting
 #include "qt_hash.h" /* for qt_key_t */
 #include "qt_atomics.h"      /* for SPINLOCK_BODY() */
-#include "qt_threadqueues.h" // for qthread_steal_disable
 #include "qt_envariables.h"
 #include "qt_debug.h"
 
@@ -320,7 +319,6 @@ void chpl_task_init(void)
     size_t    callStackSize;
     pthread_t initer;
     char      newenv_stack[100] = { 0 };
-    char *noWorkSteal;
 
 
     // Set up available hardware parallelism.
@@ -419,12 +417,6 @@ void chpl_task_init(void)
         if (signal(SIGINT, SIGINT_handler) == SIG_ERR) {
             perror("Could not register SIGINT handler");
         }
-    }
-
-    // Turn off work stealing if it was configured to be off
-    noWorkSteal = getenv("CHPL_QTHREAD_NO_WORK_STEALING");
-    if (noWorkSteal != NULL && strncmp(noWorkSteal, "yes", 3) == 0) {
-      qthread_steal_disable();
     }
 }
 


### PR DESCRIPTION
The ability to turn off work stealing has been added and removed twice now.
Both times to try out the performance of the sherwood scheduler with work
stealing off. The first time it was turned off unconditionally and the second
only if an env var was set.

We are going to use the nemesis scheduler by default and only use sherwood for
numa now. I'm removing this not because we're using nemesis by default as it
might have been useful for numa but because it doesn't do what we expect it to.
It seems sherwood is highly intertwined with work stealing. I believe that when
you create tasks it places them all on a local shepherd and relies on work
stealing to distribute work (where as nemesis or something deals out work to
shepherds in a round robin fashion.) So turning off work stealing the way we
were didn't have the desired behavior.
