### PR TITLE
Add missing generated variables to runtime/include/chplcgfns.h

### DIFF
--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -440,6 +440,8 @@ static void codegen_aggregate_def(AggregateType* ct) {
 // Only put C data objects into this file, not Chapel ones, as it may
 // also be #include'd into a launcher, and those are C/C++ code.
 //
+// New generated variables should be added to runtime/include/chplcgfns.h
+//
 static const char* sCfgFname = "chpl_compilation_config";
 
 static void codegen_header_compilation_config() {

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -15,16 +15,35 @@
 
 /* This header file is for routines that are in the generated code */
 
-/* defined in chpl__header.h: */
-
+/* defined in chpl_compilation_config.c: */
 extern const char* chpl_compileCommand;
 extern const char* chpl_compileVersion;
+extern const char* CHPL_HOME;
 extern const char* CHPL_HOST_PLATFORM;
-extern const char* CHPL_TARGET_PLATFORM;
 extern const char* CHPL_HOST_COMPILER;
+extern const char* CHPL_TARGET_PLATFORM;
 extern const char* CHPL_TARGET_COMPILER;
-extern const char* CHPL_THREADS;
+extern const char* CHPL_TARGET_ARCH;
+extern const char* CHPL_LOCALE_MODEL;
 extern const char* CHPL_COMM;
+extern const char* CHPL_COMM_SUBSTRATE;
+extern const char* CHPL_GASNET_SEGMENT;
+extern const char* CHPL_TASKS;
+extern const char* CHPL_THREADS;
+extern const char* CHPL_LAUNCHER;
+extern const char* CHPL_TIMERS;
+extern const char* CHPL_MEM;
+extern const char* CHPL_MAKE;
+extern const char* CHPL_ATOMICS;
+extern const char* CHPL_NETWORK_ATOMICS;
+extern const char* CHPL_GMP;
+extern const char* CHPL_HWLOC;
+extern const char* CHPL_REGEXP;
+extern const char* CHPL_WIDE_POINTERS;
+extern const char* CHPL_LLVM;
+extern const char* CHPL_AUX_FILESYS;
+extern const int CHPL_STACK_CHECKS;
+extern const int CHPL_CACHE_REMOTE;
 
 /* defined in main.c */
 extern char* chpl_executionCommand;


### PR DESCRIPTION
runtime/include/chplcgfns.h is home to extern variables and function
declarations that are defined in the generated code. It hasn't been updated in
a while so I added all of the current ones and added a note in codegen that new
values should be placed in this file.

I ran into this when I wanted to check CHPL_STACK_CHECKS. I didn't originally
realize this file existed and while adding CHPL_STACK_CHECKS I figured I'd
update all of them.
