### PR TITLE
Add volatile to *(int *)(0) = 0; in qthreads source

### DIFF
--- a/third-party/qthread/qthread-1.10/include/qthread/qthread.h
+++ b/third-party/qthread/qthread-1.10/include/qthread/qthread.h
@@ -1550,7 +1550,7 @@ static QINLINE void *qthread_cas_ptr_(void **addr,
 #  error The size of void* either could not be determined, or is very unusual.
     /* This should never happen, so deliberately cause a seg fault for
      * corefile analysis */
-    *(int *)(0) = 0;
+    *(volatile int *)(0) = 0;
     return NULL;                       /* compiler check */
 # endif  // if (SIZEOF_VOIDP == 4)
 } /*}}}*/

--- a/third-party/qthread/qthread-1.10/include/qthread/qthread.hpp
+++ b/third-party/qthread/qthread-1.10/include/qthread/qthread.hpp
@@ -236,7 +236,7 @@ inline T qthread_incr(T       *operand,
             return qthread_incr64((uint64_t *)operand, incr);
 
         default:
-            *(int *)(0) = 0;
+            *(volatile int *)(0) = 0;
     }
     return T(0);                       // never hit - keep compiler happy
 }


### PR DESCRIPTION
"*(int *)(0) = 0;" is used in sections that should never be executed and if
somehow you did get there this causes a deliberate segfault so you can get a
good core dump. Clang complains if this are non-volatile, which breaks the
build if CHPL_DEVELOPER (warnings => errors) is set.
