### PR TITLE
Add a .skipif for new future that PGI doesn't handle cleanly

### DIFF
--- a/test/types/complex/diten/complexCastToString.skipif
+++ b/test/types/complex/diten/complexCastToString.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER <= pgi


### PR DESCRIPTION
The PGI compiler doesn't like -0.0i and turns it into positive 0.0i.  Skip
this test if CHPL_TARGET_COMPILER contains pgi.
