### PR TITLE
Avoid C/C++ ELF section disagreement for chpl_qthread_done_initializing.

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -106,6 +106,10 @@ static void profile_print(void)
 # define PROFILE_INCR(counter,count)
 #endif /* CHAPEL_PROFILE */
 
+#ifndef QTHREAD_MULTINODE
+volatile int chpl_qthread_done_initializing;
+#endif
+
 // aka chpl_task_list_p
 struct chpl_task_list {
     chpl_fn_p        fun;

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
@@ -260,6 +260,10 @@ void threadlayer_exit(void);
 
 
 #ifndef QTHREAD_MULTINODE
+extern
+#ifdef __cplusplus
+"C"
+#endif
 volatile int chpl_qthread_done_initializing;
 #endif
 


### PR DESCRIPTION
As it stood, the definition of chpl_qthread_done_initializing in the .h
file here resulted in that symbol being assigned to the uninitialized
.bss ELF section when the .h file was compiled by g++ (for example, for
runtime/src/qio/auxFilesys/hdfs/qio_plugin_hdfs_stubs.cc), and to the
"common" meta-section when it was compiled by gcc.  The .bss section
entry for this symbol in the resulting qio_plugin_hdfs.o then caused
that file to get linked into user programs, which resulted in a gripe
when the gcc-driven linker couldn't find __gxx_personality_v0, a symbol
which is defined in libstdc++, which isn't searched during gcc-driven
linking.

Fix this by defining this symbol as extern (extern "C" for C++) in the
.h file, and move the actual definition into the .c file.
