### PR TITLE
Sort file systems in CHPL_AUX_FILESYS variable

### DIFF
--- a/util/printchplenv
+++ b/util/printchplenv
@@ -112,7 +112,9 @@ def print_mode(mode='list'):
 
     aux_filesys = chpl_aux_filesys.get()
     if mode == 'make' or mode == 'runtime':
-        aux_filesys = aux_filesys.replace(' ', '_')
+        tmp = aux_filesys.split(' ')
+        tmp.sort()
+        aux_filesys = "_".join(tmp)
     print_var('CHPL_AUX_FILESYS', aux_filesys, mode, 'fs', ('runtime',))
 
     # NOT using `m` here, 'simple' does not need these values


### PR DESCRIPTION
We currently use `printchplenv --make` to determine the path for the gen directory. Since we were not sorting the names in the environment variable for `CHPL_AUX_FILESYS` we wound up viewing `CHPL_AUX_FILESYS="hdfs curl"` as different from `CHPL_AUX_FILESYS="curl hdfs"`. 

This fixes this problem by first sorting the string before adding the underscores for the path.
