### PR TITLE
Updating HDFS to use CHPL_AUXIO_INCLUDE and CHPL_AUXIO_LIBS

### DIFF
--- a/doc/release/technotes/README.hdfs
+++ b/doc/release/technotes/README.hdfs
@@ -14,14 +14,16 @@ The HDFS functionality in Chapel is dependent upon both Hadoop and
 Java being installed.  Your HADOOP_INSTALL, JAVA_INSTALL and CLASSPATH
 environment variables must be set as described below in 'Setting up
 Hadoop.' Without this it will not compile with HDFS even if the flags
-are set.
+are set. As well, the HDFS functionality is also dependent upon the
+CHPL_AUXIO_INCLUDE and CHPL_AUXIO_LIBS being set properly. For more 
+information on how to set these properly, see README.auxIO.
 
 
 Enabling HDFS Support
 ---------------------
 
 Once you have ensured that Hadoop and Java are installed and have the
-three variables above, defined, set the environment variable
+five variables above, defined, set the environment variable
 CHPL_AUX_FILESYS to 'hdfs' to enable HDFS support:
 
   export CHPL_AUX_FILESYS=hdfs
@@ -193,6 +195,13 @@ Here is a sample .bashrc for using Hadoop within Chapel:
 export HADOOP_INSTALL=<Place where you have Hadoop installed>
 export HADOOP_HOME=$HADOOP_INSTALL
 export HADOOP_VERSION=<Your Hadoop version number>
+#
+# Note that these might contain more paths than these if you have more
+# than one IO system enabled. These are all that you will need in order
+# to use HDFS (only)
+#
+export CHPL_AUXIO_INCLUDE="-I$JAVA_INSTALL/include -I$JAVA_INSTALL/include/linux  -I$HADOOP_INSTALL/src/c++/libhdfs"
+export CHPL_AUXIO_LIBS="-L$JAVA_INSTALL/jre/lib/amd64/server -L$HADOOP_INSTALL/c++/Linux-amd64-64/lib"
 
 #
 # So we can run things such as start-all.sh etc. from anywhere and

--- a/runtime/make/Makefile.runtime.include
+++ b/runtime/make/Makefile.runtime.include
@@ -26,6 +26,19 @@ ifeq ($(OPTIMIZE),1)
 RUNTIME_DEFS += -DCHPL_OPTIMIZE
 endif
 
+# For HDFS support (and backwards compatibility)
+ifneq (,$(findstring hdfs,$(CHPL_MAKE_AUXFS)))
+	CHPL_AUXIO_INCLUDE ?= \
+		-I$(JAVA_INSTALL)/include \
+		-I$(JAVA_INSTALL)/include/linux \
+		-I$(HADOOP_INSTALL)/src/c++/libhdfs \
+
+	CHPL_AUXIO_LIBS ?= \
+		-L$(JAVA_INSTALL)/jre/lib/amd64/server \
+		-L$(HADOOP_INSTALL)/c++/Linux-amd64-64/lib 
+endif 
+
+
 # Some tasking layers put something in RUNTIME_INCLS first.
 RUNTIME_INCLS += \
         -I. \

--- a/runtime/src/qio/auxFilesys/hdfs/Makefile.share
+++ b/runtime/src/qio/auxFilesys/hdfs/Makefile.share
@@ -9,11 +9,13 @@ SRCS = $(SVN_SRCS)
 
 AUXFS_HDFS_OBJS = $(addprefix $(AUXFS_HDFS_OBJDIR)/,$(addsuffix .o,$(basename qio_plugin_hdfs.cc)))\
 
-ifneq (,$(findstring clang,$(CHPL_MAKE_TARGET_COMPILER)))
-  RUNTIME_INCLS+= -Qunused-arguments
-endif
+RUNTIME_INCLS += \
+	$(CHPL_AUXIO_INCLUDE) \
+	$(CHPL_AUXIO_LIBS) 
 
-RUNTIME_INCLS+= $(CHPL_AUXIO_INCLUDE) $(CHPL_AUXIO_LIBS)
+ifneq (,$(findstring clang,$(CHPL_MAKE_TARGET_COMPILER)))
+	RUNTIME_INCLS += -Qunused-arguments
+endif
 
 $(RUNTIME_OBJ_DIR)/qio_plugin_hdfs.o: $(AUXFS_SRCS) \
                                          $(RUNTIME_OBJ_DIR_STAMP)


### PR DESCRIPTION
Changing HDFS to use CHPL_AUXIO_INCLUDE and CHPL_AUXIO_LIBS for library and include paths. Updating README.hdfs to reflect this as well.

[Note: This was previously reviewed by kyleb - see #135]
