### PR TITLE
Fix updateBuildVersion bug so we don't always rebuild version.cpp

### DIFF
--- a/util/devel/updateBuildVersion
+++ b/util/devel/updateBuildVersion
@@ -16,7 +16,7 @@ if ($build_version_file eq "") {
 }
 
 if (-r "$build_version_file") {
-    $last_build_version = `cat $build_version_file`;
+    $last_build_version = `sed -e 's/"//g' $build_version_file`; # remove quotes
     chomp($last_build_version);
 } else {
     $last_build_version = "!!!";


### PR DESCRIPTION
The updateBuildVersion script had a bug that caused it to always think there
was a new version. It was testing ("versionNum" eq versionNum), including
quotes as characters for one of the strings, so they are always different.
This just removes the quotes.
