### PR TITLE
Feature request for a readUntil function

### DIFF
--- a/test/io/bharshbarg/readUntil.chpl
+++ b/test/io/bharshbarg/readUntil.chpl
@@ -1,0 +1,14 @@
+config const delim = "!";
+assert(delim.length == 1);
+config const lineLen = 100;
+
+var f = openmem();
+var w = f.writer();
+
+for i in 1..lineLen-1 do w.write((i%9) + 1);
+
+w.write(delim);
+
+var r = f.reader();
+var data : string;
+r.readUntil(data, ascii(delim));

--- a/test/io/bharshbarg/readUntil.future
+++ b/test/io/bharshbarg/readUntil.future
@@ -1,0 +1,24 @@
+feature request: Make readline a wrapper around a new 'readUntil' function which would take a ascii character to stop reading at.
+
+IO's readline code could be easily adapted into a new 'readUntil' function
+that would take a uint(8) argument representing the ascii character to
+stop reading at. 'readline' could then become a simple wrapper around
+'readUntil', passing 0x0A as an argument.
+
+A couple of questions to consider:
+
+- is 'readUntil' a good name?
+- Do we want to accept a string argument to be used with the 'ascii'
+function? This is probably a general question in chapel about how we want
+users to deal with single characters.
+
+Ex: readUntil(dataStr, 0x3E);    vs    readUntil(dataStr, ">");
+
+It also occurs to me that a new user might try something like this:
+
+readUntil(dataStr, "foo");
+
+Expecting to get everything up until "foo", which is something I think may
+be more appropriate for regex. Unfortunately, I'm not sure how to do this
+with re2, as it doesn't support lookaheads. We could always assert that
+the string must be of length 1.


### PR DESCRIPTION
IO's readline code could be easily adapted into a new 'readUntil' function that would take a uint(8) argument representing the ascii character to stop reading at. 'readline' could then become a simple wrapper around  'readUntil', passing 0x0A or "\n" as an argument. While no one may have asked for it yet, I can see it being a valuable feature in the future.
