### PR TITLE
Lower number of unlocks before doing a qthread yield

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -169,7 +169,7 @@ void chpl_sync_unlock(chpl_sync_aux_t *s)
     // TODO see if this is a good number after some performance results get in
     //
     // Give other tasks that are waiting on a sync variable a chance to run.
-    // Currently this is every 4096 unlocks. [x % 2n == x & (2n - 1)] This
+    // Currently this is every 1024 unlocks. [x % 2n == x & (2n - 1)] This
     // number was chosen with a little trial and error.
     //
     // qthread_yield is used over chpl_task_yield. chpl_task_yield just adds
@@ -177,7 +177,7 @@ void chpl_sync_unlock(chpl_sync_aux_t *s)
     // shepherds we are either setting up or tearing down in which case the
     // pthread unlock will guarantee progress. When qthread_yield() is called
     // from a non-qthread it's just a no-op.
-    if ((qthread_incr(&s->lockers_out, 1) & 0xFFF) == 0xFFF) {
+    if ((qthread_incr(&s->lockers_out, 1) & 0x3FF) == 0x3FF) {
         qthread_yield();
     }
 }


### PR DESCRIPTION
I had previously increased the number because I thought it was the source of a
performance regression. However, it turned out to be a different commit around
the same time. The previous number left some timeouts for tests that were
previously deadlocking. This lowers the number of unlocks to 1024 from 4096,
but not back down to the original low of 256 because there were some slight
performance regressions from that.

Note that this is still not necessarily the "final" number and that a
qthread_yield will still be added to the spinlock loop in the sync var lock but
I want to get performance results with this value first.
