### PR TITLE
Allow the lcd architecture to be found for chapel modules

### DIFF
--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -302,7 +302,7 @@ def get(location, map_to_compiler=False, get_lcd=False):
     if get_lcd:
         stderr.write("Warning: Getting the lowest common denominator "
                      "architecture is only supported for the Chapel module on "
-                     "cray systems.\n")
+                     "Cray platforms.\n")
 
     # Only try to do any auto-detection or verification when:
     # comm == none  -- The inverse means that we are probably cross-compiling.

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -45,8 +45,8 @@ def print_mode(mode='list'):
         print_var('CHPL_TARGET_PLATFORM', target_platform, mode)
         print_var('CHPL_TARGET_COMPILER', target_compiler, mode)
 
-    get_module_lcd = chpl_home == chpl_module_home and chpl_home != '' and  \
-                     (mode == 'runtime' or mode == 'make')
+    get_module_lcd = ( (chpl_home == chpl_module_home) and (chpl_home != '') and
+                     (mode == 'runtime' or mode == 'make') )
     if m != 'compiler' and m != 'launcher':
         target_arch = chpl_arch.get('target', mode == 'make', get_module_lcd)
         print_var('CHPL_TARGET_ARCH', target_arch, mode, 'arch')


### PR DESCRIPTION
[content reviewed by @gbtitus, python style by @Kyle-B]

We add the architecture to the gen directory so that we can differentiate
between knc and non-knc builds. However, we build the module with the lowest
common denominator processor module loaded so that users can build with any
compatible processor module loaded and we don't have to build a binary for each
one. For instance, we build with sandybridge, but a user can have either
sandybridge or ivybridge loaded and the binaries will be compatible. However,
we would have sandybridge in the gen directory for the module, and the current
scripts would try to look for a gen directory with ivybridge in it. This adds a
routine in chpl_arch to get the lowest common denominator for the modules, and
gets it for the runtime in printchplenv iff a cray module is loaded, and it's
home location is the same as chapel home.

The reason for that is because a developer might have a module loaded, but also
have a working chapel repo that is their chapel home. Just because the module
is loaded, doesn't mean you need to get the lcd. You only want the lcd iff the
module is loaded, and the module binary is the one actually being used.
