### PR TITLE
Qthreads setenv

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -338,12 +338,12 @@ static void *initializer(void *junk)
 // values, or if we were prevented from setting values because they existed
 // (and override was 0.)
 static void chpl_qt_setenv(char* var, char* val, int32_t override) {
-    int32_t buffSize = 100;
-    char    qt_env[buffSize];
-    char    qthread_env[buffSize];
-    char    *qt_val;
-    char    *qthread_val;
-    int32_t eitherSet = false;
+    int32_t   buffSize = 100;
+    char      qt_env[buffSize];
+    char      qthread_env[buffSize];
+    char      *qt_val;
+    char      *qthread_val;
+    chpl_bool eitherSet = false;
 
     strncpy(qt_env, "QT_", buffSize);
     strncat(qt_env, var, buffSize);


### PR DESCRIPTION
Add a helper function to set a qthreads env var

This is meant to mirror setenv functionality, but qthreads has two environment
variables for every setting: a QT_ and a QTHREAD_ version. We often forget to
think about both so this wraps the overriding logic. In verbose mode it prints
out if we overrode values, or if we were prevented from setting values because
they existed (and override was 0.)

Note that unlike setenv it is a void function and doesn't check if the value
to set contains an "=" or if the value is NULL, however I can update it if that
seems useful. We previously just ignored any errors anyways and since this is
internal use only, it seems fine.

This also puts a note at STACK_SIZE so we don't forget that we want to update
it's behavior.

I have some upcoming changes that will change qthread env vars and this is
something I always forget about when setting a qthread env var and I think it
makes setting a qthread env var cleaner, even though the function is kind of
large for what it does.
