### PR TITLE
Replace spinwait in syncvar unlock with qthread_yield

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -157,7 +157,7 @@ void chpl_sync_lock(chpl_sync_aux_t *s)
     PROFILE_INCR(profile_sync_lock, 1);
 
     l = qthread_incr(&s->lockers_in, 1);
-    while (l != s->lockers_out) SPINLOCK_BODY();
+    while (l != s->lockers_out) qthread_yield();
 }
 
 void chpl_sync_unlock(chpl_sync_aux_t *s)


### PR DESCRIPTION
[idea ok'd / from @gbtitus] 

Testing out the performance implications of this. This makes sense
because if a qthread is just spinning while waiting on a sync var, we really
want them to yield, and let somebody else do some work.

I believe if we used real qthread sync vars we wouldn't need to do this, but
the yield in the unlock would still be needed.

It might also make sense to only do this every x iterations of the loop, but
that means adding a counter to that, which might not be worth it. We'll see
