### PR TITLE
Revert "Change qthreads topology/affinity setup to work with nemesis"

### DIFF
--- a/third-party/qthread/qthread-1.10/src/affinity/common.c
+++ b/third-party/qthread/qthread-1.10/src/affinity/common.c
@@ -48,15 +48,7 @@ void INTERNAL qt_topology_init(qthread_shepherd_id_t * nshepherds,
     qt_affinity_init(&num_sheps, &num_wps, &num_workers);
 
     /* Adjust logical topology */
-    if (THREADQUEUE_POLICY_TRUE == qt_threadqueue_policy(SINGLE_WORKER)) { 
-        if (num_workers != 0) {
-            num_sheps = num_workers;
-        } else {
-            num_workers = num_sheps * num_wps;
-            num_sheps = num_workers;
-        }
-        num_wps = 1;
-    } else if (num_workers != 0) {
+    if (num_workers != 0) {
         if ((num_workers < num_sheps) || (num_workers == 1)) {
             num_wps = 1;
             num_sheps      = num_workers;


### PR DESCRIPTION
This reverts commit 27d267d7e6167b11a11a66a5d07a9335f841a2e8.

This commit was intended to fix the number of shepherds and workers per
shepherd that qthreads used for single threaded schedulers like nemesis.
While it corrected the number, it did it after the affinity layer was setup
which meant that we had threads being poorly pinned to cores.

Now the chpl_task_init (or an expert user) is responsible for setting the right
number of shepherds and workers per shepherd before qthreads init, so we no
longer need this.
