### PR TITLE
Fix build errors with CHPL_DEVELOPER set.

### DIFF
--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -27,8 +27,8 @@
 #define WRAP_TO_STR(x) TO_STR(x)
 #define TO_STR(x) #x
 
+extern char** environ;
 static void add_env_options(int* argc, char** argv[]) {
-  extern char** environ;
   int envc;
   int new_argc;
   char** new_argv;
@@ -59,7 +59,7 @@ static void add_env_options(int* argc, char** argv[]) {
   // Add a -E option for each environment variable.
   //
   for (i = 0; i < envc; i++) {
-    new_argv[*argc + 2 * i + 0] = "-E";
+    new_argv[*argc + 2 * i + 0] = (char*) "-E";
     new_argv[*argc + 2 * i + 1] = environ[i];
   }
 


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/194 causes build errors when
CHPL_DEVELOPER is set.  Fix those:
- Move the extern declaration for environ to the file scope.  It's still
  duplicates the one in <unistd.h> in certain environments, but gcc
  doesn't gripe if the duplicate isn't in a nested scope.
- Cast the assignment of "-E" to (char_) at line 62; by default a string
  constant has type (const char_), but the left side in this case isn't
  const.
