### PR TITLE
Removing unnecessary var descriptor

### DIFF
--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
@@ -1,6 +1,6 @@
 extern proc memcpy(a:[], b, len);
 
-proc string.toBytes() var {
+proc string.toBytes() {
    var b : [1..this.length] uint(8);
    memcpy(b, this, this.length);
    return b;


### PR DESCRIPTION
This function returns an array, which is already returned by reference.
