### PR TITLE
Functionality from #128 no longer results in an out-of-bounds error here

### DIFF
--- a/test/domains/dinan/assoc_array_access_oob.good
+++ b/test/domains/dinan/assoc_array_access_oob.good
@@ -1,1 +1,2 @@
-assoc_array_access_oob.chpl:4: error: halt reached - array index out of bounds: 5
+indices is: {5}
+elems is: 1.0


### PR DESCRIPTION
With merge  #128, this test correctly no longer produces an error.
