### PR TITLE
Make the memoize decorator pass through kwargs

### DIFF
--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -4,7 +4,9 @@ from distutils.spawn import find_executable
 def memoize(func):
     cache = func.cache = {}
 
-    def memoize_wrapper(*args):
+    def memoize_wrapper(*args, **kwargs):
+        if kwargs:
+            return func(*args, **kwargs)
         if args not in cache:
             cache[args] = func(*args)
         return cache[args]


### PR DESCRIPTION
The old memoize didn't handle key word arguments at all, this version
will call the function correctly, without any caching happening. If it
proves to be necessary in the future, it shouldn't be too hard to add the
caching in for the kwargs form as well.
