### PR TITLE
Make qthreads our default tasking layer

### DIFF
--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_locale_model
+import chpl_arch, chpl_platform
 from utils import memoize
 
 @memoize
 def get():
     tasks_val = os.environ.get('CHPL_TASKS')
     if not tasks_val:
-        locale_model_val = chpl_locale_model.get()
-        if locale_model_val == 'numa':
-            tasks_val = 'qthreads'
-        else:
+        arch_val = chpl_arch.get('target', get_lcd=True)
+        platform_val = chpl_platform.get()
+        if arch_val == 'knc' or platform_val == 'cygwin':
             tasks_val = 'fifo'
+        else:
+            tasks_val = 'qthreads'
     return tasks_val
 
 

--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -9,3 +9,11 @@ export CHPL_COMM=gasnet
 export GASNET_SPAWNFN=L
 export GASNET_ROUTE_OUTPUT=0
 export CHPL_GASNET_CFG_OPTIONS=--disable-ibv
+
+tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
+if [ "${tasks}" == "qthreads" ] ; then
+    # Set these to use oversubscription to help with timeouts
+    export QT_AFFINITY=no
+    export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
+fi
+

--- a/util/cron/test-perf-chap03-qthreads.bash
+++ b/util/cron/test-perf-chap03-qthreads.bash
@@ -5,5 +5,5 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-perf.bash
 source $CWD/common-qthreads.bash
-export CHPL_QTHREAD_NO_GUARD_PAGES=yes
+export CHPL_MEM=tcmalloc
 $CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -numtrials 5 -startdate 08/21/07

--- a/util/cron/test-perf-chap04-qthreads.bash
+++ b/util/cron/test-perf-chap04-qthreads.bash
@@ -5,7 +5,7 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-perf.bash
 source $CWD/common-qthreads.bash
-export CHPL_QTHREAD_NO_GUARD_PAGES=yes
+export CHPL_MEM=tcmalloc
 # releasePerformance still generates results based on the fifo timings. It's
 # run here again, otherwise syncing the qthreads results blows away the
 # directory with the releaseOverRelease graphs in


### PR DESCRIPTION
I believe we have all the correctness and performance regressions out of the
way and we are ready to switch to using qthreads as the default tasking layer.

This makes that change for all cases except arch == knc or platform == cygwin

This does NOT update our testing scripts. For tonight we will have multiple
machines testing the same configurations. This switch is to see if there are
any surprises or if anything with qthreads blows up. If it does it's likely
we'll just back it out.

If everything goes well, I'll update the testing scripts tomorrow. As a
temporary measure to make sure gasnet testing goes well, this just copies
setting oversubscription and turning off affinity in gasnet common.

Lastly this turns the previous scripts that were testing qthreads performance
alongside fifo to now test qthreads+tcmalloc. Eventually they should be testing
fifo, but we want to get some performance numbers for tcmalloc.
