### PR TITLE
Temporarily set CHPL_RT_CALL_STACK_SIZE=2M for linux32 builds

### DIFF
--- a/util/cron/test-linux32-default-examples.bash
+++ b/util/cron/test-linux32-default-examples.bash
@@ -4,4 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
+# put in for qthreads testing, because for 32 bit default 8M * 128
+# preallocated causes segfaults
+export CHPL_RT_CALL_STACK_SIZE=2M
 $CWD/nightly -cron -examples

--- a/util/cron/test-linux32-gasnet-examples.bash
+++ b/util/cron/test-linux32-gasnet-examples.bash
@@ -4,4 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
+# put in for qthreads testing, because for 32 bit default 8M * 128
+# preallocated causes segfaults
+export CHPL_RT_CALL_STACK_SIZE=2M
 $CWD/nightly -cron -examples


### PR DESCRIPTION
Qthreads preallocates stacks for 128 threads up front and our large stack size
of 8M means we have over 1GB allocated right away which causes segfaults for
linux32. This is meant as a temporary measure so that we can get some testing
in for qthreads still.
