### PR TITLE
Updating fasta-based PREEXECs to use sub_test's compiler

### DIFF
--- a/test/studies/shootout/k-nucleotide/bharshbarg/PREEXEC
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/PREEXEC
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Note: This is not safe for parallel testing
 
 # Only run this script when doing a perf run
@@ -10,7 +12,8 @@ if [ -n "$CHPL_TEST_PERF" ]; then
   fi
 
   if [ ! -f $CHPL_HOME/test/tmp/fasta.big ]; then
-    chpl $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+    # '$3' is the compiler given to us by sub_test
+    $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
     
     # needed by k-nucleotide and reverse-complement
     ./tmpFasta --n=25000000 > $CHPL_HOME/test/tmp/fasta.big

--- a/test/studies/shootout/regex-dna/bharshbarg/PREEXEC
+++ b/test/studies/shootout/regex-dna/bharshbarg/PREEXEC
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Note: This is not safe for parallel testing
 
 # Only run this script when doing a perf run
@@ -10,7 +12,8 @@ if [ -n "$CHPL_TEST_PERF" ]; then
   fi
 
   if [ ! -f $CHPL_HOME/test/tmp/fasta.big ]; then
-    chpl $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+    # '$3' is the compiler given to us by sub_test
+    $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
     
     # needed by k-nucleotide and reverse-complement
     ./tmpFasta --n=25000000 > $CHPL_HOME/test/tmp/fasta.big

--- a/test/studies/shootout/reverse-complement/bharshbarg/PREEXEC
+++ b/test/studies/shootout/reverse-complement/bharshbarg/PREEXEC
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Note: This is not safe for parallel testing
 
 # Only run this script when doing a perf run
@@ -10,7 +12,8 @@ if [ -n "$CHPL_TEST_PERF" ]; then
   fi
 
   if [ ! -f $CHPL_HOME/test/tmp/fasta.big ]; then
-    chpl $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+    # '$3' is the compiler given to us by sub_test
+    $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
     
     # needed by k-nucleotide and reverse-complement
     ./tmpFasta --n=25000000 > $CHPL_HOME/test/tmp/fasta.big


### PR DESCRIPTION
Currently this script relies on an environment in which we can simply call 'chpl' to compile. This doesn't work with some nightly testing, and it's better to use the compiler argument given to us by sub_test anyways.

"set -e" is added so we get an actually error code when something goes wrong.
