### PR TITLE
Use fifo instead of Qthreads when testing on mac os version < 10.

### DIFF
--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -38,9 +38,11 @@ $CHPL_HOME/util/test/checkCopyrights.bash
 source $CHPL_HOME/util/cron/common.bash
 
 # Special case for older mac we use for testing. Warnings from arch.py and as
-# need to be filtered.
+# need to be filtered. Qthreads is not supported for mac os version < 10, so
+# use fifo instead.
 if [ "$(uname -s)" = "Darwin" -a "$(uname -r)" = "9.8.0" ] ; then
     export CHPL_START_TEST_ARGS="--syspreexec ${CHPL_HOME}/util/test/preexec-for-old-macs"
+    export CHPL_TASKS=fifo
 fi
 
 # Compile chapel and make sure the hello world examples run.

--- a/util/cron/machine.macchapel-mac
+++ b/util/cron/machine.macchapel-mac
@@ -4,6 +4,10 @@ CWD=$(cd $(dirname $0) ; pwd)
 
 source $CWD/common.bash
 
+# macchapel-mac has os version 9.8, which is not supported for Qthreads. Use
+# fifo instead.
+export CHPL_TASKS=fifo
+
 log_info "Starting nightly."
 export CHPL_START_TEST_ARGS="-syspreexec $CWD/../test/preexec-for-old-macs"
 $CWD/nightly -cron -examples


### PR DESCRIPTION
Qthreads does not support mac os versions less than 10, so this updates smoke
and correctness tests to use fifo on the old mac used for chapel testing.
