### PR TITLE
Fix hwloc build for pgcc

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -16,7 +16,11 @@ HWLOC_DIR = $(HWLOC_ABS_DIR)
 CHPL_HWLOC_CFG_OPTIONS += --enable-static --disable-shared --disable-libxml2 --disable-pci
 
 ifneq ($(CHPL_MAKE_PLATFORM), darwin)
+ifeq ($(CHPL_MAKE_TARGET_COMPILER), pgi)
+  CHPL_HWLOC_CFG_OPTIONS += LDFLAGS=-Bstatic
+else
   CHPL_HWLOC_CFG_OPTIONS += LDFLAGS=-static
+endif
 endif
 
 CHPL_HWLOC_CFG_OPTIONS += $(CHPL_HWLOC_MORE_CFG_OPTIONS)


### PR DESCRIPTION
pgcc does not support the -static flag. They have their own version, -Bstatic.
This isn't a problem for PrgEnv-pgi since the PrgEnv wrapper translates -static
to the appropriate command.

See 2f9e3f73cf0afebd2b20870586569fc71c76d02e for more info. Note that we didn't
used to just test pgcc without the wrappers but I believe we do now to try to
test for users who just use the pgi compiler not on a cray.
