### PR TITLE
Add rename and remove to the C reserved symbol names list

### DIFF
--- a/compiler/passes/reservedSymbolNames
+++ b/compiler/passes/reservedSymbolNames
@@ -58,6 +58,8 @@
   open
   pow
   printf
+  remove
+  rename
   scanf
   sync
   quad

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -833,7 +833,7 @@ proc openmem(style:iostyle = defaultIOStyle()):file {
    error: a syserr used to indicate if an error occurred during renaming.
    oldname: current name of the file
    newname: name which should refer to the file in the future.*/
-proc renameFile(out error: syserr, oldname, newname: string) {
+proc rename(out error: syserr, oldname, newname: string) {
   error = qio_file_rename(oldname.c_str(), newname.c_str());
 }
 
@@ -841,9 +841,9 @@ proc renameFile(out error: syserr, oldname, newname: string) {
    if one occurred.  The file is not opened during this operation.
    oldname: current name of the file
    newname: name which should refer to the file in the future.*/
-proc renameFile(oldname, newname: string) {
+proc rename(oldname, newname: string) {
   var err:syserr = ENOERR;
-  renameFile(err, oldname, newname);
+  rename(err, oldname, newname);
   if err then ioerror(err, "in rename", oldname);
 }
 
@@ -851,16 +851,16 @@ proc renameFile(oldname, newname: string) {
    if one occurred via an out parameter.
    err: a syserr used to indicate if an error occurred during removal
    name: the name of the file/directory to remove */
-proc removeFile(out err: syserr, name: string) {
+proc remove(out err: syserr, name: string) {
   err = qio_file_remove(name.c_str());
 }
 
 /* Removes the file or directory specified by name, generating an error
    if one occurred.
    name: the name of the file/directory to remove */
-proc removeFile(name: string) {
+proc remove(name: string) {
   var err:syserr = ENOERR;
-  removeFile(err, name);
+  remove(err, name);
   if err then ioerror(err, "in remove", name);
 }
 

--- a/test/io/lydia/remove/nonempty_dir.chpl
+++ b/test/io/lydia/remove/nonempty_dir.chpl
@@ -1,3 +1,3 @@
 // This test tries to remove a directory that still has contents
 var dirname = "nonempty";
-removeFile(dirname);
+remove(dirname);

--- a/test/io/lydia/remove/nonexistent_file.chpl
+++ b/test/io/lydia/remove/nonexistent_file.chpl
@@ -1,3 +1,3 @@
 // This test tries to remove a file that did not exist
 var filename = "nonexistent_file.txt";
-removeFile(filename);
+remove(filename);

--- a/test/io/lydia/remove/remove_dir.chpl
+++ b/test/io/lydia/remove/remove_dir.chpl
@@ -1,3 +1,3 @@
 // This test removes a directory.
 var dirname = "remove_directory";
-removeFile(dirname);
+remove(dirname);

--- a/test/io/lydia/remove/remove_file.chpl
+++ b/test/io/lydia/remove/remove_file.chpl
@@ -1,3 +1,3 @@
 // This test removes a file.
 var filename = "remove_file.txt";
-removeFile(filename);
+remove(filename);

--- a/test/io/lydia/rename/no_such_file.chpl
+++ b/test/io/lydia/rename/no_such_file.chpl
@@ -2,4 +2,4 @@
 // because no_such_fileOld.txt does not exist.
 var oldname = "no_such_fileOld.txt";
 var newname = "no_such_fileNew.txt";
-renameFile(oldname, newname);
+rename(oldname, newname);

--- a/test/io/lydia/rename/rename_file.chpl
+++ b/test/io/lydia/rename/rename_file.chpl
@@ -1,4 +1,4 @@
 // Moves the file rename_fileOld.txt to rename_fileNew.txt.
 var oldname = "rename_fileOld.txt";
 var newname = "rename_fileNew.txt";
-renameFile(oldname, newname);
+rename(oldname, newname);


### PR DESCRIPTION
This allows the new file methods to be named rename and remove instead of
renameFile and removeFile.  Adjusted the test files accordingly.
