### PR TITLE
Update test scripts since qthreads became the default

### DIFF
--- a/util/cron/common-fifo.bash
+++ b/util/cron/common-fifo.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#
+# Configure environment for fifo testing. This should be sourced by other
+# scripts that wish to make use of the variables set here.
+
+export CHPL_TASKS=fifo

--- a/util/cron/machine.chap11
+++ b/util/cron/machine.chap11
@@ -3,18 +3,7 @@
 CWD=$(cd $(dirname $0) ; pwd)
 
 source $CWD/common.bash
+source $CWD/common-fifo.bash
 
-# qthreads + flat + none
-$CWD/nightly.qthreads -full
-
-# TODO: Uncomment the below and remove the above once qthreads is the
-#       default. Also be sure to split the below into two separate scripts and
-#       create separate jenkins jobs for them. (thomasvandoren, 2014-07-01)
-
-# # fifo + flat + none + full suite
-# $CWD/nightly.fifo -full
-
-# source $CWD/common-gasnet.bash
-
-# # fifo + flat + gasnet + examples
-# $CWD/nightly.fifo -examples
+# fifo + flat + none
+$CWD/nightly.fifo -full

--- a/util/cron/machine.chap13
+++ b/util/cron/machine.chap13
@@ -3,13 +3,8 @@
 CWD=$(cd $(dirname $0) ; pwd)
 
 source $CWD/common.bash
+source $CWD/common-fifo.bash
+source $CWD/common-gasnet.bash
 
-# This should be common-gasnet.bash, but since it also sources
-# common.bash, we copy it here
-export CHPL_COMM=gasnet
-export GASNET_SPAWNFN=L
-export GASNET_ROUTE_OUTPUT=0
-export CHPL_GASNET_CFG_OPTIONS=--disable-ibv
-
-# qthreads + flat + gasnet + multilocale suite
-$CWD/nightly.qthreads -full
+# fifo + flat + gasnet
+$CWD/nightly.fifo -full

--- a/util/cron/nightly.valgrind
+++ b/util/cron/nightly.valgrind
@@ -7,6 +7,20 @@ source $CWD/common.bash
 export CHPL_RT_NUM_THREADS_PER_LOCALE=100
 log_info "Testing valgrind."
 
+# qthreads doesn't have the appropriate suppressions for valgrind testing yet
+source $CWD/common-fifo.bash
+
+# once qthreads+valgrind works, we need to enable oversubscription since we use
+# paratest. --enabled-valgrind builds qthreads with valgrind macros to help
+# with debugging
+tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
+if [ "${tasks}" == "qthreads" ] ; then
+    export QT_AFFINITY=no
+    export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
+    export CHPL_QTHREAD_MORE_CFG_OPTIONS=--enable-valgrind
+fi
+
+
 $CWD/nightly -cron -valgrind -no-futures \
     -suppress Suppressions/valgrind.suppress \
     -parnodefile $CWD/../../test/Nodes/CHAP07


### PR DESCRIPTION
Previously we explicitly tested qthreads in a couple of configurations. Since
qthreads is the default we now want to switch those machines to test fifo.

Also valgrind will use fifo for the time being (and maybe permanently.) We
don't have valgrind suppressions for qthreads.
