### PR TITLE
See the performance impact of not using hwloc

### DIFF
--- a/util/cron/test-perf-chap03-qthreads.bash
+++ b/util/cron/test-perf-chap03-qthreads.bash
@@ -5,5 +5,5 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-perf.bash
 source $CWD/common-qthreads.bash
-export CHPL_MEM=tcmalloc
+export CHPL_HWLOC=none
 $CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -numtrials 5 -startdate 08/21/07

--- a/util/cron/test-perf-chap04-qthreads.bash
+++ b/util/cron/test-perf-chap04-qthreads.bash
@@ -5,7 +5,7 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-perf.bash
 source $CWD/common-qthreads.bash
-export CHPL_MEM=tcmalloc
+export CHPL_HWLOC=none
 # releasePerformance still generates results based on the fifo timings. It's
 # run here again, otherwise syncing the qthreads results blows away the
 # directory with the releaseOverRelease graphs in


### PR DESCRIPTION
[This is in my playground scripts, not the real perf testing]

I'm curious. If there's no performance benefit to using hwloc, it seems like
it'd be nice to turn it off by default since it increases startup times, and it
would remove a 3rd party dependency for our defaults.
