### PR TITLE
Fix launchcmd script to work with PBSPro 

### DIFF
--- a/util/test/launchcmd-for-aprun-launcher
+++ b/util/test/launchcmd-for-aprun-launcher
@@ -54,7 +54,7 @@ class AbstractPbsJob(object):
     """Abstract job runner implementation."""
 
     # NOTE: These class attributes are intentionally left commented. They will
-    #       cause AttributeError if they is accessed from this class. They
+    #       cause AttributeError if they are accessed from this class. They
     #       *should only* be accessed from a sub class.
     #hostlist_resource = None
     #num_nodes_resource = None


### PR DESCRIPTION
For qsub, PBSPro requires that you reserve the number of nodes, as well as the
number of cpus per node. This adds that logic to the launchcmd script for
PBSPro (it's not needed for MOAB/TORQUE.)

This behavior matches what we do in our pbs-aprun launcher, and the method for
determining the number of cores to reserve is based off of the code in the
launcher as well.
