### PR TITLE
Another slightly strange enum cast future.

### DIFF
--- a/test/types/enum/sungeun/cast_enum_weird_4.bad
+++ b/test/types/enum/sungeun/cast_enum_weird_4.bad
@@ -1,0 +1,2 @@
+$CHPL_HOME/modules/internal/String.chpl:148: error: unable to resolve return type of function '_cast'
+$CHPL_HOME/modules/internal/String.chpl:148: error: called recursively at this point

--- a/test/types/enum/sungeun/cast_enum_weird_4.chpl
+++ b/test/types/enum/sungeun/cast_enum_weird_4.chpl
@@ -1,0 +1,25 @@
+proc f(type t) {
+  proc f0() {
+    {
+      enum E { zero=-1, one=-2, two=-4, three=-8 };
+      const s: t = "three";
+      const x = s:E;
+      writeln(s);
+    }
+  }
+  f0();
+
+  proc f1() {
+    enum E { zero=-1, one=-2, two=-4, three=-8 };
+    {
+      const x = E.three;
+      const s = x:t;
+      writeln(s);
+    }
+  }
+  f1();
+}
+
+f(string);
+
+

--- a/test/types/enum/sungeun/cast_enum_weird_4.future
+++ b/test/types/enum/sungeun/cast_enum_weird_4.future
@@ -1,0 +1,2 @@
+bug: Unable to resolve return type for cast between enum and string if enum declared in function and string passed in as type parameter
+

--- a/test/types/enum/sungeun/cast_enum_weird_4.good
+++ b/test/types/enum/sungeun/cast_enum_weird_4.good
@@ -1,0 +1,2 @@
+three
+three


### PR DESCRIPTION
If the enum declaration is moved to the global scope or if the string type is used directly
(vs. as a type parameter), things work fine.
