### PR TITLE
Minor wording improvements to the contributor agreements' README

### DIFF
--- a/doc/developer/contributorAgreements/README
+++ b/doc/developer/contributorAgreements/README
@@ -2,8 +2,12 @@
 Chapel Contributor Agreements
 =============================
 
-This directory contains contributor agreements that are a precondition for
-obtaining write access to the Chapel repository.  There are two versions:
+This directory contains Chapel's Apache-2.0-based contributor license
+agreements (CLAs) which serve as a precondition for committing code to
+the Chapel repository.  There are two versions:
 
-chapel-ccla.pdf : For corporate contributors
-chapel-icla.pdf : For individual contributors
+* chapel-ccla.pdf : For corporations (or other organizations) in which
+                    one person is responsible for granting the rights
+                    for other contributors
+
+* chapel-icla.pdf : For individual contributors


### PR DESCRIPTION
Clarified that the CLAs are Apache-based
Clarified that the "corporate" form applies to other organizations as well
Clarified that signing these doesn't give write permissions so much as commit
permissions.
