### PR TITLE
If bundled gmp is built, even on a cray, default to CHPL_GMP=gmp.

### DIFF
--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -12,17 +12,18 @@ def get():
         target_compiler = chpl_compiler.get('target')
         target_arch = chpl_arch.get('target', get_lcd=True)
 
-        if target_platform.startswith('cray-x'):
+        # Detect if gmp has been built for this configuration.
+        chpl_home = utils.get_chpl_home()
+        gmp_target_dir = '{0}-{1}-{2}'.format(target_platform, target_compiler, target_arch)
+        gmp_subdir = os.path.join(chpl_home, 'third-party', 'gmp',
+                                  'install', gmp_target_dir)
+
+        if os.path.exists(os.path.join(gmp_subdir, 'include', 'gmp.h')):
+            gmp_val = 'gmp'
+        elif target_platform.startswith('cray-x'):
             gmp_val = 'system'
         else:
-            chpl_home = utils.get_chpl_home()
-            gmp_target_dir = '{0}-{1}-{2}'.format(target_platform, target_compiler, target_arch)
-            gmp_subdir = os.path.join(chpl_home, 'third-party', 'gmp',
-                                      'install', gmp_target_dir)
-            if os.path.exists(os.path.join(gmp_subdir, 'include', 'gmp.h')):
-                gmp_val = 'gmp'
-            else:
-                gmp_val = 'none'
+            gmp_val = 'none'
     return gmp_val
 
 


### PR DESCRIPTION
Motivated by knc, but will be useful when/if bundled gmp is built for
cray-x*. For knc, bundled gmp is the only supported option (aside from
CHPL_GMP=none).
