### PR TITLE
Ensure that 'castCall' is not "may be used uninitialized" in wrappers.cp...

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -539,8 +539,10 @@ static void addArgCoercion(FnSymbol* fn, CallExpr* call, ArgSymbol* formal,
     else if (ats->hasFlag(FLAG_SINGLE))
       castCall = new CallExpr("readFF", gMethodToken, prevActual);
 
-    else
+    else {
       INT_ASSERT(false);    // Unhandled case.
+      castCall = NULL;      // make gcc happy
+    }
 
   } else if (ats->hasFlag(FLAG_REF)) {
     //


### PR DESCRIPTION
I did not reproduce the original error, so not sure this is a fix. From visual observation, it should be.

The original error occurred according to this job:

Hostname: chap12
Revision: https://github.com/chapel-lang/chapel/commit/4d052f3 [github.com]
Logfile:  /tmp/day5-Fri-linux64.gnu.none.qthreads.flat-fst.log.18419
Started:  Fri Aug 29 02:08:28 2014
Ended:    Fri Aug 29 02:09:47 2014
        http://chapel-ci.us.cray.com/job/correctness-chap12/77/
