### PR TITLE
No longer peg call stack size for linux32 box

### DIFF
--- a/util/cron/test-linux32-default-examples.bash
+++ b/util/cron/test-linux32-default-examples.bash
@@ -4,7 +4,5 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
-# put in for qthreads testing, because for 32 bit default 8M * 128
-# preallocated causes segfaults
-export CHPL_RT_CALL_STACK_SIZE=2M
+
 $CWD/nightly -cron -examples

--- a/util/cron/test-linux32-gasnet-examples.bash
+++ b/util/cron/test-linux32-gasnet-examples.bash
@@ -4,7 +4,5 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
-# put in for qthreads testing, because for 32 bit default 8M * 128
-# preallocated causes segfaults
-export CHPL_RT_CALL_STACK_SIZE=2M
+
 $CWD/nightly -cron -examples


### PR DESCRIPTION
The issue with qthreads has been fixed with
cee911bf5a2efdeb6ed9753d984a07b0b6d0b78c
