### PR TITLE
FATAL error generated from compiler for type int.

### DIFF
--- a/test/types/scalar/tmacd/fatal.chpl
+++ b/test/types/scalar/tmacd/fatal.chpl
@@ -1,0 +1,5 @@
+var sum1 = 0.0;
+var sum : int = 0;
+
+sum1 = 4.0;
+sum = (int)(sum1);

--- a/test/types/scalar/tmacd/fatal.future
+++ b/test/types/scalar/tmacd/fatal.future
@@ -1,0 +1,1 @@
+bug: (int)(real_variable) causes a fatal error rather than a compiler error.

--- a/test/types/scalar/tmacd/fatal.good
+++ b/test/types/scalar/tmacd/fatal.good
@@ -1,0 +1,2 @@
+chpl fatal.chpl
+internal error: FUN5596 chpl Version 1.9.0.620405d


### PR DESCRIPTION
Compiler generates a FATAL for the following program

var sum1 = 0.0;
var sum : int = 0;

sum1 = 4.0;
sum = (int)(sum1);

internal error: FUN5894 chpl Version X.XX.X

Compiler treat (int) as a constructor call for int taking
a real argument.  This should generate an error message.
