### PR TITLE
Skip parallel/cobegin/test_big_recursive_cobegin on cygwin.

### DIFF
--- a/test/TRIAGE
+++ b/test/TRIAGE
@@ -261,6 +261,7 @@ windows land (which could take days if nobody notices). Added a skipif so the
 test will not run on cygwin until the issue can be investigated further.
 
 [Error: Timed out executing program parallel/taskPar/sungeun/private] (8/19/14)
+[Error: Timed out executing program parallel/cobegin/deitz/test_big_recursive_cobegin] (9/2/14)
 
 
 

--- a/test/parallel/cobegin/deitz/test_big_recursive_cobegin.skipif
+++ b/test/parallel/cobegin/deitz/test_big_recursive_cobegin.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM == cygwin


### PR DESCRIPTION
It has been timing out on cygwin testing, but timedexec is not able to kill it.

Similar behavior to test skipped in #175.
