### PR TITLE
Build fewer LLVM components to speed compile

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -47,7 +47,7 @@ NPROCS := $(shell python -c 'import multiprocessing ; print multiprocessing.cpu_
 $(LLVM_FILE):
 	if [ ! -d llvm ]; then ./unpack-llvm.sh; fi
 	mkdir -p $(LLVM_BUILD_DIR)
-	cd $(LLVM_BUILD_DIR) && $(LLVM_SRC_DIR)/configure CC='$(CC)' CXX='$(CXX)' --prefix=$(LLVM_INSTALL_DIR) --enable-optimized $(CHPL_LLVM_DEBUG)
+	cd $(LLVM_BUILD_DIR) && $(LLVM_SRC_DIR)/configure CC='$(CC)' CXX='$(CXX)' --prefix=$(LLVM_INSTALL_DIR) --enable-optimized --disable-clang-arcmt --disable-clang-static-analyzer --disable-clang-rewriter --disable-docs --enable-targets=host,x86,x86_64 $(CHPL_LLVM_DEBUG)
 	cd $(LLVM_BUILD_DIR) && $(MAKE) -j$(NPROCS)
 	cd $(LLVM_BUILD_DIR) && $(MAKE) install
 	cd $(LLVM_BUILD_DIR) && cd test && make lit.site.cfg


### PR DESCRIPTION
This patch significantly reduces the build
size and the build time. It omits some LLVM
and Clang components we don't use and only
builds host and x86 and x86-64 backends.

Used to take 23 minutes, now takes 18 minutes
to CHPL_LLVM=llvm time make on my machine. In
addition, llvm/build is now 8G (was 12G)
and llvm/install is now 4.6G (was 5.8G).
