### PR TITLE
Allow the mppdepth setting to be omitted in launchcmd script.

### DIFF
--- a/util/test/launchcmd-for-aprun-launcher
+++ b/util/test/launchcmd-for-aprun-launcher
@@ -539,6 +539,12 @@ class PbsProJob(AbstractPbsJob):
 
     hostlist_resource = 'mppnodes'
     num_nodes_resource = 'mppwidth'
+
+    # If CHPL_PBSPRO_NO_MPPDEPTH is set in the environment, set class attribute
+    # to None. Otherwise, default to mppdepth.
+    #
+    # This allows callers to optionally disable this particular setting, which
+    # can conflict with the hostlist/mppnodes setting.
     num_cpus_resource = 'mppdepth' if 'CHPL_PBSPRO_NO_MPPDEPTH' not in os.environ else None
 
     @property


### PR DESCRIPTION
When `CHPL_PBSPRO_NO_MPPDEPTH` is set in the environment, the mppdepth argument
will be omitted when calling qsub.
