### PR TITLE
Updating README and testReleaseHelp to include 'rehash' for csh users

### DIFF
--- a/README
+++ b/README
@@ -54,8 +54,12 @@ capabilities in the interest of a simple and clean build.
 
         make
 
+4) csh/tcsh users only: Update your shell's path cache using:
 
-4) To ensure you have installed Chapel properly, you can optionally
+        rehash
+
+
+5) To ensure you have installed Chapel properly, you can optionally
    run an automatic sanity check using few example programs:
 
         gmake check
@@ -65,25 +69,25 @@ capabilities in the interest of a simple and clean build.
         make check
 
 
-5) Compile an example program using:
+6) Compile an example program using:
 
         chpl -o hello examples/hello.chpl
 
 
-6) Execute the resulting executable:
+7) Execute the resulting executable:
 
         ./hello
 
 
-7) Experiment with Chapel in Quick Start mode to your heart's content.
+8) Experiment with Chapel in Quick Start mode to your heart's content.
 
    Once you are comfortable with Chapel and interested in using a
-   full-featured version:
+   full-featured version in the preferred configuration:
 
    a) Open up a new shell to avoid inheriting the previous environment
       settings.
 
-   b) Repeat steps 1-6 above -- except in Step 2, use util/setchplenv.*
+   b) Repeat steps 1-7 above, but in Step 2, use util/setchplenv.*
       instead of util/quickstart/setchplenv.*
 
    This will set up your environment to use Chapel in the preferred
@@ -93,7 +97,7 @@ capabilities in the interest of a simple and clean build.
    at chapel_info@cray.com.
 
 
-8) If you plan to do performance studies of Chapel programs, be sure
+9) If you plan to do performance studies of Chapel programs, be sure
    to (a) use the full-featured version and (b) read the PERFORMANCE
    file in this directory to avoid common pitfalls.
 

--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -31,6 +31,12 @@ if ($tmpstatus != 0) then
     echo "ERROR: make failed"
     exit($tmpstatus)
 endif
+rehash   # required for csh only; if we convert this to bash, drop this
+set tmpstatus = $status
+if ($tmpstatus != 0) then
+    echo "ERROR: make failed"
+    exit($tmpstatus)
+endif
 $mymake check
 set tmpstatus = $status
 if ($tmpstatus != 0) then


### PR DESCRIPTION
Sadly, csh users who set their environment first and build second (as
we now require in the quickstart world) need to do a rehash in order
to update their path to see 'chpl'.  Added a step for them in the README
and updated the testReleaseHelp script to do the same thing.
