### PR TITLE
Test --dataParIgnoreRunningTasks=true in my playground

### DIFF
--- a/util/cron/test-perf-chap03-qthreads.bash
+++ b/util/cron/test-perf-chap03-qthreads.bash
@@ -4,5 +4,4 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-perf.bash
 source $CWD/common-qthreads.bash
-export CHPL_HWLOC=none
-$CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -numtrials 5 -startdate 08/21/07
+$CWD/nightly -cron -execopts --dataParIgnoreRunningTasks=true -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -numtrials 5 -startdate 08/21/07

--- a/util/cron/test-perf-chap04-qthreads.bash
+++ b/util/cron/test-perf-chap04-qthreads.bash
@@ -4,8 +4,7 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-perf.bash
 source $CWD/common-qthreads.bash
-export CHPL_HWLOC=none
 # releasePerformance still generates results based on the fifo timings. It's
 # run here again, otherwise syncing the qthreads results blows away the
 # directory with the releaseOverRelease graphs in
-$CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -releasePerformance -numtrials 5 -startdate 07/28/12
+$CWD/nightly -cron -execopts --dataParIgnoreRunningTasks=true -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -releasePerformance -numtrials 5 -startdate 07/28/12


### PR DESCRIPTION
I've been curious if qthreads handles nested parallelism better, and am even
more curious with some of the results greg was seeing where we have better
performance for some tests when dataParTasksPerLocale > numCores

This will probably be my last experiment before retiring these scripts
