### PR TITLE
Lower stack size for test/stress/deitz/test_10k_coforall.chpl

### DIFF
--- a/test/stress/deitz/test_10k_coforall.execenv
+++ b/test/stress/deitz/test_10k_coforall.execenv
@@ -1,5 +1,5 @@
 CHPL_RT_NUM_THREADS_PER_LOCALE=255
-
+CHPL_RT_CALL_STACK_SIZE=256K
 #
 # We turn off guard pages for this test as it creates many little tasks
 #


### PR DESCRIPTION
This test has the potential to create a lot tasks that exist simultaneously. On
some of our tests boxes with limited ram, we run out of memory. Qthreads places
no limit on the number of qthreads and thus stacks that can exist at once. For
tests like this I've been trying to limit the "max" memory usage to under 4GB.
4GB seems like a large enough value for correctness tests, and it is low enough
that our 32 bit machines shouldn't have trouble.
