### PR TITLE
Lower the problem size for test_many_domain and test_many_array

### DIFF
--- a/test/distributions/robust/arithmetic/stress/test_many_array.chpl
+++ b/test/distributions/robust/arithmetic/stress/test_many_array.chpl
@@ -1,6 +1,6 @@
 use driver;
 
-config const n: int = 2000;
+config const n: int = 500;
 
 for i in 1..n do
   foo(i);

--- a/test/distributions/robust/arithmetic/stress/test_many_domains.chpl
+++ b/test/distributions/robust/arithmetic/stress/test_many_domains.chpl
@@ -1,6 +1,6 @@
 use driver;
 
-config const n: int = 10000;
+config const n: int = 500;
 
 for i in 1..n do
   foo(i);


### PR DESCRIPTION
Since switching to qthreads these tests take a lot longer to execute and
test_many_domain times out pretty often. test_many_domain has also been timing
out for numa+gasnet for months

This doesn't reflect a real problem with qthreads, so much as it does a
"problem" with the testing framework. Even with qthreads configured with
oversubscription and affinity off there is still interference from multiple
qthreads instances running on the same machine.

I tested these two programs out on an xc and on a cluster, and the qthreads
version was a few seconds quicker so I'm pretty confident in my claim that it's
just how we test gasnet+qthreads that's responsible for the slow down and not
some performance mystery that needs to be explored.

These new sizes lower the execution time to ~30 seconds.
