### PR TITLE
Split the test classes/bradc/arrayInClass/genericArrayInClass-otharrs in...

### DIFF
--- a/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.bad
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.bad
@@ -1,0 +1,76 @@
+In file included from /tmp/chpl-hilde-2684.deleteme/_main.c:18:
+/tmp/chpl-hilde-2684.deleteme/DefaultRectangular.c: In function 'dsiReallocate13':
+/tmp/chpl-hilde-2684.deleteme/DefaultRectangular.c:11966: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultRectangular.c:11971: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultRectangular.c:11984: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultRectangular.c:11989: error: used struct type value where scalar is required
+In file included from /tmp/chpl-hilde-2684.deleteme/_main.c:20:
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c: In function 'coforall_fn11':
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c:9016: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c:9021: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c:9034: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c:9039: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c: In function 'coforall_fn21':
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c:14973: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c:14978: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c:14991: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/ChapelArray.c:14996: error: used struct type value where scalar is required
+In file included from /tmp/chpl-hilde-2684.deleteme/_main.c:24:
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c: In function '_backupArray8':
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:40545: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:40550: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:40563: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:40568: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:40998: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:41003: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:41016: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:41021: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c: In function '_backupArray9':
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:42050: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:42055: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:42068: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:42073: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:42503: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:42508: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:42521: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:42526: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c: In function '_backupArray10':
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:43555: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:43560: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:43573: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:43578: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:44008: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:44013: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:44026: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:44031: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c: In function '_preserveArrayElement8':
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61175: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61180: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61193: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61198: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c: In function '_preserveArrayElement9':
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61384: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61389: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61402: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61407: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c: In function '_preserveArrayElement10':
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61593: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61598: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61611: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultAssociative.c:61616: error: used struct type value where scalar is required
+In file included from /tmp/chpl-hilde-2684.deleteme/_main.c:25:
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c: In function 'sparseShiftArray3':
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:3946: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:3951: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:3964: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:3969: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:4144: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:4149: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:4162: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:4167: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:4250: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:4255: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:4268: error: used struct type value where scalar is required
+/tmp/chpl-hilde-2684.deleteme/DefaultSparse.c:4273: error: used struct type value where scalar is required
+gmake: *** [/tmp/chpl-hilde-2684.deleteme/genericArrayInClass-otharrs-inline-iterators.tmp] Error 1
+error: compiling generated source

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.chpl
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.chpl
@@ -1,0 +1,223 @@
+// declare class types
+
+class ArithC {
+  type t;
+
+  var x: [1..3] t;
+}
+
+class AssocC {
+  type t;
+
+  var assocDom: domain(string);
+  var x: [assocDom] t;
+}
+
+class OpaqueC {
+  type t;
+
+  var opaqueDom: domain(opaque);
+  var x: [opaqueDom] t;
+}
+
+class SparseC {
+  type t;
+  
+  var sparseDom: sparse subdomain({1..3});
+  var x: [sparseDom] t;
+}
+
+enum probClass {S, W, A, B, C};
+
+class EnumC {
+  type t;
+  
+  var enumDom: domain(probClass);
+  var x: [enumDom] t;
+}
+
+// generic print routine
+
+proc foo(C) {
+  writeln("C.x.domain is: ", C.x.domain);
+  writeln("x is: ", C.x);
+  writeln();
+}
+
+{
+  // declare associative class instances
+
+  var assocDom: domain(string);
+  type assocArr = [assocDom] real;
+
+  var myArithC = new ArithC(assocArr);
+  var myAssocC = new AssocC(assocArr);
+  var myOpaqueC = new OpaqueC(assocArr);
+  var mySparseC = new SparseC(assocArr);
+  var myEnumC = new EnumC(assocArr);
+
+  assocDom += "two";
+
+  // initialize class instances
+
+  [i in myArithC.x.domain] [j in assocDom] myArithC.x(i)(j) = i + 2/10.0;
+  
+  myAssocC.assocDom += "two";
+  [j in assocDom] myAssocC.x("two")(j) = 2 + 2/10.0;
+
+  const newInd = myOpaqueC.opaqueDom.create();
+  [j in assocDom] myOpaqueC.x(newInd)(j) = 2 + 2/10.0;
+
+  mySparseC.sparseDom += 2;
+  [j in assocDom] mySparseC.x(2)(j) = 2 + 2/10.0;
+
+  [i in myEnumC.x.domain] [j in assocDom] myEnumC.x(i)(j) = i:int + 2:real/10.0;
+
+  // check class instances
+
+  foo(myArithC);
+  foo(myAssocC);
+  foo(myOpaqueC);
+  foo(mySparseC);
+  foo(myEnumC);
+
+  delete myArithC;
+  delete myAssocC;
+  delete myOpaqueC;
+  delete mySparseC;
+  delete myEnumC;
+}
+
+
+{
+  // declare associative class instances
+
+  var opaqueDom: domain(opaque);
+  type opaqueArr = [opaqueDom] real;
+
+  var myArithC = new ArithC(opaqueArr);
+  var myAssocC = new AssocC(opaqueArr);
+  var myOpaqueC = new OpaqueC(opaqueArr);
+  var mySparseC = new SparseC(opaqueArr);
+  var myEnumC = new EnumC(opaqueArr);
+
+  opaqueDom.create();
+
+  // initialize class instances
+
+  [i in myArithC.x.domain] [j in opaqueDom] myArithC.x(i)(j) = i + 2/10.0;
+  
+  myAssocC.assocDom += "two";
+  [j in opaqueDom] myAssocC.x("two")(j) = 2 + 2/10.0;
+  
+  const newInd = myOpaqueC.opaqueDom.create();
+  [j in opaqueDom] myOpaqueC.x(newInd)(j) = 2 + 2/10.0;
+  
+  mySparseC.sparseDom += 2;
+  [j in opaqueDom] mySparseC.x(2)(j) = 2 + 2/10.0;
+  
+  [i in myEnumC.x.domain] [j in opaqueDom] myEnumC.x(i)(j) = i:int + 2:real/10.0;
+  
+  // check class instances
+  
+  foo(myArithC);
+  foo(myAssocC);
+  foo(myOpaqueC);
+  foo(mySparseC);
+  foo(myEnumC);
+
+  delete myArithC;
+  delete myAssocC;
+  delete myOpaqueC;
+  delete mySparseC;
+  delete myEnumC;
+}
+
+
+{
+  // declare associative class instances
+
+  var sparseDom: sparse subdomain({1..3});
+  type sparseArr = [sparseDom] real;
+
+  var myArithC = new ArithC(sparseArr);
+  var myAssocC = new AssocC(sparseArr);
+  var myOpaqueC = new OpaqueC(sparseArr);
+  var mySparseC = new SparseC(sparseArr);
+  var myEnumC = new EnumC(sparseArr);
+
+  sparseDom += 2;
+
+  // initialize class instances
+
+  [i in myArithC.x.domain] [j in sparseDom] myArithC.x(i)(j) = i + j/10.0;
+  
+  myAssocC.assocDom += "two";
+  [j in sparseDom] myAssocC.x("two")(j) = 2 + j/10.0;
+  
+  const newInd = myOpaqueC.opaqueDom.create();
+  [j in sparseDom] myOpaqueC.x(newInd)(j) = 2 + j/10.0;
+  
+  mySparseC.sparseDom += 2;
+  [j in sparseDom] mySparseC.x(2)(j) = 2 + j/10.0;
+  
+  [i in myEnumC.x.domain] [j in sparseDom] myEnumC.x(i)(j) = i:int + j:real/10.0;
+  
+  // check class instances
+  
+  foo(myArithC);
+  foo(myAssocC);
+  foo(myOpaqueC);
+  foo(mySparseC);
+  foo(myEnumC);
+
+  delete myArithC;
+  delete myAssocC;
+  delete myOpaqueC;
+  delete mySparseC;
+  delete myEnumC;
+}
+
+
+
+{
+  // declare associative class instances
+
+  var enumDom: domain(probClass);
+  type enumArr = [enumDom] real;
+
+  var myArithC = new ArithC(enumArr);
+  var myAssocC = new AssocC(enumArr);
+  var myOpaqueC = new OpaqueC(enumArr);
+  var mySparseC = new SparseC(enumArr);
+  var myEnumC = new EnumC(enumArr);
+
+  // initialize class instances
+
+  [i in myArithC.x.domain] [j in enumDom] myArithC.x(i)(j) = i + j:real/10.0;
+  
+  myAssocC.assocDom += "two";
+  [j in enumDom] myAssocC.x("two")(j) = 2 + j:real/10.0;
+  
+  const newInd = myOpaqueC.opaqueDom.create();
+  [j in enumDom] myOpaqueC.x(newInd)(j) = 2 + j:real/10.0;
+  
+  mySparseC.sparseDom += 2;
+  [j in enumDom] mySparseC.x(2)(j) = 2 + j:real/10.0;
+  
+  [i in myEnumC.x.domain] [j in enumDom] myEnumC.x(i)(j) = i:int + j:real/10.0;
+  
+  // check class instances
+  
+  foo(myArithC);
+  foo(myAssocC);
+  foo(myOpaqueC);
+  foo(mySparseC);
+  foo(myEnumC);
+
+  delete myArithC;
+  delete myAssocC;
+  delete myOpaqueC;
+  delete mySparseC;
+  delete myEnumC;
+}

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.future
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.future
@@ -1,0 +1,48 @@
+bug: Zippered iterator inlining may cause segfaults.
+
+The auto-generated _getIterator function copies fields from the iterator record
+and sets the initial value of the "more" field.  But it does not set an initial
+value for the "value" field, expecting this to be set by the first call to
+zip1().  This works fine if the type of the "value" field is a fundamental type
+(such as int(64)), because even an uninitialized instance is still value.
+
+However, for types requiring initialization (for example, a record containing a
+class field) the fact the "value" is uninitialized can lead to problems.  In
+this particular case, the test for whether there are more values to be yielded
+depends upon the yielded value itself.*  When an attempt is made to evaluate a
+field in that value, a segmentation fault results.
+
+valgrind can be used to pinpoint the error.  For example, I see:
+
+==4201== Conditional jump or move depends on uninitialised value(s)
+==4201==    at 0x5256B4: zip13 (DefaultOpaque.c:1015)
+==4201== 
+
+Note that a segfault will not necessarily occur, since an uninitialized value
+may still look like a value pointer within a valid segment.  I also noted that
+when CHPL_LOCALE_MODEL=numa, due to recent changes in LICM, the problem with
+zippered iterator inlining is uncovered by the C compiler, which make it
+slightly easier to debug.  Sample error messages look like:
+
+  In file included from obj/_main.c:25:
+  obj/DefaultSparse.c: In function ‘sparseShiftArray3’:
+  obj/DefaultSparse.c:3976: error: used struct type value where scalar is required
+  obj/DefaultSparse.c:3981: error: used struct type value where scalar is required
+  obj/DefaultSparse.c:3994: error: used struct type value where scalar is required
+  etc.
+
+This problem is isolated to zippered iterator inlining.  With iterator inlining
+turned off, the test runs as expected.  (See the companion test
+genericArrayInClass-otharrs)
+
+The solution probably involves rewriting how zippered iterator inlining is
+implemented.  Any explicit initialization code probably needs to be broken off
+and placed in a loop initialization clause.  In addition, if the yielded value
+is not explicitly initialized, it probably needs to be initialized through a
+call to the default constructor for its type.  The latter approach was not
+attempted, because iterator inlining takes place after resolution, but the
+insertion of default constructor calls needs to take place in or before
+resolution.  Workarounds are possible (for example, storing a map of default
+constructors for later use), but a better approach probably involves converting
+zippered iteration to its inlined form prior to resolution.
+

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.good
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.good
@@ -1,0 +1,60 @@
+C.x.domain is: {1..3}
+x is: 1.2 2.2 3.2
+
+C.x.domain is: {two}
+x is: 2.2
+
+C.x.domain is: {{}}
+x is: 2.2
+
+C.x.domain is: {2}
+x is: 2.2
+
+C.x.domain is: {S, W, A, B, C}
+x is: 1.2 2.2 3.2 4.2 5.2
+
+C.x.domain is: {1..3}
+x is: 1.2 2.2 3.2
+
+C.x.domain is: {two}
+x is: 2.2
+
+C.x.domain is: {{}}
+x is: 2.2
+
+C.x.domain is: {2}
+x is: 2.2
+
+C.x.domain is: {S, W, A, B, C}
+x is: 1.2 2.2 3.2 4.2 5.2
+
+C.x.domain is: {1..3}
+x is: 1.2 2.2 3.2
+
+C.x.domain is: {two}
+x is: 2.2
+
+C.x.domain is: {{}}
+x is: 2.2
+
+C.x.domain is: {2}
+x is: 2.2
+
+C.x.domain is: {S, W, A, B, C}
+x is: 1.2 2.2 3.2 4.2 5.2
+
+C.x.domain is: {1..3}
+x is: 1.1 1.2 1.3 1.4 1.5 2.1 2.2 2.3 2.4 2.5 3.1 3.2 3.3 3.4 3.5
+
+C.x.domain is: {two}
+x is: 2.1 2.2 2.3 2.4 2.5
+
+C.x.domain is: {{}}
+x is: 2.1 2.2 2.3 2.4 2.5
+
+C.x.domain is: {2}
+x is: 2.1 2.2 2.3 2.4 2.5
+
+C.x.domain is: {S, W, A, B, C}
+x is: 1.1 1.2 1.3 1.4 1.5 2.1 2.2 2.3 2.4 2.5 3.1 3.2 3.3 3.4 3.5 4.1 4.2 4.3 4.4 4.5 5.1 5.2 5.3 5.4 5.5
+

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.skipif
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.skipif
@@ -1,0 +1,1 @@
+CHPL_LOCALE_MODEL!=numa

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs.compopts
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs.compopts
@@ -1,0 +1,1 @@
+--no-inline-iterators


### PR DESCRIPTION
...to a test and a future.

The test shows the ability to create and iterate over arrays-of-arrays that are stored in
classes (which is a valuable test by itself).

The future is due to a bug in zippered iterator inlining, which makes the test fail unless
inlining is turned off.

So, iterator inlining is turned off in the .compopts file associated with the main test.
Details of the bug are provided in the .bad and .future files in the added future test.
