### PR TITLE
runtime/qio: use getcwd instead of getwd

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -283,7 +283,7 @@ extern proc qio_file_get_style(f:qio_file_ptr_t, ref style:iostyle);
 extern proc qio_file_length(f:qio_file_ptr_t, ref len:int(64)):syserr;
 
 extern proc qio_chdir(name: c_string):syserr;
-extern proc qio_cwd(ref working_dir:c_string);
+extern proc qio_cwd(ref working_dir:c_string):syserr;
 extern proc qio_file_rename(oldname: c_string, newname: c_string):syserr;
 extern proc qio_file_remove(name: c_string):syserr;
 
@@ -619,12 +619,23 @@ proc chdir(name: string) {
   if err then ioerror(err, "in chdir", name);
 }
 
-/* Returns the current working directory. */
-proc cwd(): string {
+/* Returns the current working directory.
+   err: a syserr used to indicate if an error occurred
+*/
+proc cwd(out err: syserr): string {
   var tmp:c_string, ret:string;
-  qio_cwd(tmp);
+  err = qio_cwd(tmp);
+  if err then return "";
   ret = toString(tmp);
   chpl_free_c_string(tmp);
+  return ret;
+}
+
+/* Returns the current working directory. Generates an error if one occurred. */
+proc cwd(): string {
+  var err: syserr = ENOERR;
+  var ret = cwd(err);
+  if err then ioerror(err, "in cwd");
   return ret;
 }
 

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -574,7 +574,7 @@ qioerr qio_file_sync(qio_file_t* f);
 
 qioerr qio_chdir(const char* name);
 
-void qio_cwd(const char** working_dir);
+qioerr qio_cwd(const char** working_dir);
 
 // Renames the file from oldname to newname, returning a qioerr if one
 // occured.

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1065,10 +1065,17 @@ qioerr qio_chdir(const char* name) {
   return err;
 }
 
-void qio_cwd(const char** working_dir) {
-  char* pathbuf = (char *)qio_malloc(MAXPATHLEN*sizeof(char));
-  getwd(pathbuf);
-  *working_dir = pathbuf;
+qioerr qio_cwd(const char** working_dir) {
+  qioerr err = 0;
+  size_t bufsize = MAXPATHLEN*sizeof(char);
+  char* bufptr;
+  char* pathbuf = (char *)qio_malloc(bufsize);
+  bufptr = getcwd(pathbuf, bufsize);
+  if (bufptr == NULL)
+    err = qio_mkerror_errno();
+  else
+    *working_dir = pathbuf;
+  return err;
 }
 
 /* Renames the file from oldname to newname, returning a qioerr if one


### PR DESCRIPTION
getwd is deprecated in favor of getcwd.

Related to #325.
