### PR TITLE
Suppress notifications from modern mac testing.

### DIFF
--- a/util/cron/test-mac-default-full.bash
+++ b/util/cron/test-mac-default-full.bash
@@ -5,4 +5,9 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 
+# Do not send modern mac test results to regressions list until
+# nondeterministic compiler errors are fixed.
+# (thomasvandoren, 2014-09-08)
+export CHPL_NIGHTLY_CRON_RECIPIENT="chapel-test-results-all@lists.sourceforge.net"
+
 $CWD/nightly -cron

--- a/util/cron/test-mac-gasnet-examples.bash
+++ b/util/cron/test-mac-gasnet-examples.bash
@@ -5,4 +5,8 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
 
+# Do not send modern mac test results to regressions list until
+# nondeterministic compiler errors are fixed.
+# (thomasvandoren, 2014-09-08)
+export CHPL_NIGHTLY_CRON_RECIPIENT="chapel-test-results-all@lists.sourceforge.net"
 $CWD/nightly -cron -examples


### PR DESCRIPTION
This will avoid lots of notifications to regressions list. This should be
reverted once the nondeterministic failures are fixed.
