### PR TITLE
Ensure catfiles (compiler output, etc) is added to final output when using slurm prediff.

### DIFF
--- a/util/test/prediff-for-slurm-launcher
+++ b/util/test/prediff-for-slurm-launcher
@@ -67,6 +67,13 @@ if ($batch) {
     open MODFILE, ">$modfile" or die "could not open the modified test output file $modfile: $!";
     open BATCHOUTFILE, $batchOutfile or die "could not open the test output file $batchOutfile: $!";
 
+    # Copy any preexisting contents (catfiles, compiler output, etc) of
+    # OUTFILE to MODFILE.
+    while (<OUTFILE>) {
+	my $line = $_;
+	print MODFILE $line;
+    }
+
     # copy the output to the modified file for each line that doesn't start with
     # slurm unless the job failed then print the slurm errors 
     while (<BATCHOUTFILE>) {


### PR DESCRIPTION
This fixes an error where the output file generated by the compiler was not included in the final output,
and resulted in mysterious failures. I think the bigger issue is that catfiles are evaluated before the
system prediff. I am not yet sure if there is a reason for that, but this change is useful regardless.
