### PR TITLE
Use output file specified by user instead of appending %j.out.

### DIFF
--- a/doc/release/README.launcher
+++ b/doc/release/README.launcher
@@ -154,8 +154,7 @@ Settings:
   running it interactively as usual. In this mode, the output will be
   written by default to a file called <executableName>.<jobID>.out. The
   environment variable CHPL_LAUNCHER_SLURM_OUTPUT_FILENAME can be used
-  to specify a different base filename than the executable's name, and
-  the jobID and '.out' will be appended to it.
+  to specify a different filename for the output.
 
 
 --------------------

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -185,7 +185,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     if (getenv("CHPL_LAUNCHER_USE_SBATCH") != NULL) {
 //    fprintf(slurmFile, "#SBATCH -joe\n");  
     if (outputfn!=NULL) 
-      fprintf(slurmFile, "#SBATCH -o %s.%%j.out\n", outputfn);
+      fprintf(slurmFile, "#SBATCH -o %s\n", outputfn);
     else
       fprintf(slurmFile, "#SBATCH -o %s.%%j.out\n", argv[0]);
 //    fprintf(slurmFile, "cd $SBATCH_O_WORKDIR\n");

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -209,10 +209,10 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       fprintf(slurmFile, "#SBATCH --account=%s\n", account);
     }
  
-    // set the output name to either the user specified.<jobID>.out 
+    // set the output name to either the user specified
     // or to the binaryName.<jobID>.out if none specified
     if (outputfn!=NULL) {
-      fprintf(slurmFile, "#SBATCH --output=%s.%%j.out\n", outputfn);
+      fprintf(slurmFile, "#SBATCH --output=%s\n", outputfn);
     }
     else {
       fprintf(slurmFile, "#SBATCH --output=%s.%%j.out\n", argv[0]);


### PR DESCRIPTION
Update slurm-srun and slurm-gasnetrun_ibv launchers to treat
CHPL_LAUNCHER_SLURM_OUTPUT_FILENAME env var as full file path. They both use
the value directly as the --output argument when calling sbatch.

Previously, these launchers would append "%j.out" to the user specified value
and use that for --output argument. This is unnecessary (and slightly
restrictive) because the user can specify a value with escaped characters, like
%j, that slurm will populate with the appropriate values.

Confirmed with @ronawho that this is an ok change.
