### PR TITLE
Change line numbers for test_var_iterator5_error

### DIFF
--- a/test/functions/deitz/iterators/test_var_iterator5_error.good
+++ b/test/functions/deitz/iterators/test_var_iterator5_error.good
@@ -1,3 +1,3 @@
 test_var_iterator5_error.chpl:8: error: illegal lvalue in assignment
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2238: In function '=':
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2240: error: illegal lvalue in assignment
+$CHPL_HOME/modules/internal/ChapelArray.chpl:2459: In function '=':
+$CHPL_HOME/modules/internal/ChapelArray.chpl:2461: error: illegal lvalue in assignment


### PR DESCRIPTION
This test expects a compiler failure, but it has the explicit line numbers in
the .good file. The line numbers changed with the addition of arrays as vectors work
