### PR TITLE
Instead of using Chapel's writeln() to print the value returned by

### DIFF
--- a/test/execflags/gbt/getenv.chpl
+++ b/test/execflags/gbt/getenv.chpl
@@ -1,2 +1,3 @@
 extern proc getenv(const name: c_string): c_string;
-for loc in Locales do on loc do writeln(getenv('GETENV_ENV_VAR'));
+extern proc printf(const fmt: c_string, const arg1: c_string);
+for loc in Locales do on loc do printf('%s\n', getenv('GETENV_ENV_VAR'));


### PR DESCRIPTION
getenv(), call C's printf() directly.  Chapel writeln() doesn't work for
printing c_string arguments on non-0 locales, because writeln() executes
on locale 0 and the pointer for a string on some other locale isn't
meaningful on locale 0 (and we don't deep-copy the string).
