### PR TITLE
Fix io/lydia/mkdir/makeWithMode.chpl on mac.

### DIFF
--- a/test/io/lydia/mkdir/makeWithMode.prediff
+++ b/test/io/lydia/mkdir/makeWithMode.prediff
@@ -1,3 +1,7 @@
-#!/bin/bash
-permissionsInOctal=`printf "0%d" $(stat -c %a useAMode)`
-printf "%o\n" $(($permissionsInOctal & 0777)) > $2
+#!/usr/bin/env python
+
+import os, sys
+
+s = os.stat('useAMode')
+with open(sys.argv[2], 'w') as fp:
+    fp.write("%o\n" % (s.st_mode & 0777))


### PR DESCRIPTION
stat call in the bash script was not supported on mac. Instead of figuring out
how to support multiple versions of stat, convert script to python and use its
os.stat function.
