### PR TITLE
Updating the line numbers for test_var_iterator5_error.good again

### DIFF
--- a/test/functions/deitz/iterators/test_var_iterator5_error.good
+++ b/test/functions/deitz/iterators/test_var_iterator5_error.good
@@ -1,3 +1,3 @@
 test_var_iterator5_error.chpl:8: error: illegal lvalue in assignment
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2459: In function '=':
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2461: error: illegal lvalue in assignment
+$CHPL_HOME/modules/internal/ChapelArray.chpl:2476: In function '=':
+$CHPL_HOME/modules/internal/ChapelArray.chpl:2478: error: illegal lvalue in assignment


### PR DESCRIPTION
They changed again yesterday after my commit to fix it with the "providing isXxx functions" commit
