### PR TITLE
Sets

### DIFF
--- a/test/associative/bharshbarg/arrays/arraySetOps.chpl
+++ b/test/associative/bharshbarg/arrays/arraySetOps.chpl
@@ -23,10 +23,16 @@ for i in 1..n {
 
 // a and b are disjoint, so r == a
 var r = a - b;
-assert(r.domain == a.domain);
+for i in r.domain {
+  assert(ad.member(i));
+  assert(r[i] == a[i]);
+}
 
 var s = a ^ b;
-assert(s.domain == q.domain);
+for i in s.domain {
+  assert(q.domain.member(i));
+  assert(s[i] == q[i]);
+}
 
 // all indices should be less than n/2
 var t = a & c;


### PR DESCRIPTION
This fix should stop this test from failing in a nondeterministic way.

For associative domains, the order in which indices are yielded is nondeterministic. Below, even though the domains for the arrays have the same indices, the indices may have been added in a different order because of the internal forall used by the set operation. Because of this, the order in which the indices are yielded may not be the same. The promoted "==" would invoke the parallel iterators of the arrays, and an assertion fails when checking for domain mismatch.
