### PR TITLE
Change naming of local subdomain query functions

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -791,10 +791,6 @@ proc BlockCyclicArr.dsiSlice(d: BlockCyclicDom) {
 proc BlockCyclicArr.dsiReindex(dom) {
   compilerError("reindexing not yet implemented for Block-Cyclic");
 }
-    
-proc BlockCyclicArr.dsiTargetLocDom() {
-  return dom.dist.targetLocDom;
-}
 
 proc BlockCyclicArr.dsiTargetLocales() {
   return dom.dist.targetLocales;

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1382,10 +1382,6 @@ proc BlockArr.doiBulkTransfer(B) {
   }
   if debugBlockDistBulkTransfer then writeln("Comms:",getCommDiagnostics());
 }
-    
-proc BlockArr.dsiTargetLocDom() {
-  return dom.dist.targetLocDom;
-}
 
 proc BlockArr.dsiTargetLocales() {
   return dom.dist.targetLocales;

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -1153,10 +1153,6 @@ proc CyclicArr.doiBulkTransferFromDR(Barg)
       }
     }
 }
-    
-proc CyclicArr.dsiTargetLocDom() {
-  return dom.dist.targetLocDom;
-}
 
 proc CyclicArr.dsiTargetLocales() {
   return dom.dist.targetLocales;

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -652,10 +652,6 @@ proc ReplicatedArr.dsiRankChange(sliceDef: ReplicatedDom,
 
   return result;
 }
-    
-proc ReplicatedArr.dsiTargetLocDom() {
-  return dom.dist.targetLocales.domain;
-}
 
 proc ReplicatedArr.dsiTargetLocales() {
   return dom.dist.targetLocales;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1515,11 +1515,6 @@ module ChapelArray {
   
     proc displayRepresentation() { _value.dsiDisplayRepresentation(); }
 
-    // the locale grid domain
-    proc targetLocDom() {
-      return _value.dsiTargetLocDom();
-    }
-
     // the locale grid
     proc targetLocales() {
       return _value.dsiTargetLocales();

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -587,10 +587,6 @@ module DefaultAssociative {
       data(newslot) = tmpTable[oldslot];
     }
 
-    proc dsiTargetLocDom() {
-      compilerError("targetLocDom is unsupported by associative domains");
-    }
-
     proc dsiTargetLocales() {
       compilerError("targetLocales is unsupported by associative domains");
     }

--- a/modules/internal/DefaultOpaque.chpl
+++ b/modules/internal/DefaultOpaque.chpl
@@ -115,10 +115,6 @@ module DefaultOpaque {
   
     proc dsiAccess(ind : idxType) ref : eltType
       return anarray.dsiAccess(ind);
-    
-    proc dsiTargetLocDom() {
-      compilerError("targetLocDom is unsupported by opaque domains");
-    }
 
     proc dsiTargetLocales() {
       compilerError("targetLocales is unsupported by opaque domains");

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -876,10 +876,6 @@ module DefaultRectangular {
         if dom.dsiNumIndices > 0 then rad.shiftedData = shiftedData;
       return rad;
     }
-    
-    proc dsiTargetLocDom() {
-      compilerError("targetLocDom is unsupported by default domains");
-    }
 
     proc dsiTargetLocales() {
       compilerError("targetLocales is unsupported by default domains");

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -312,10 +312,6 @@ module DefaultSparse {
         data(i) = data(i+1);
       }
     }
-    
-    proc dsiTargetLocDom() {
-      compilerError("targetLocDom is unsuppported by sparse domains");
-    }
 
     proc dsiTargetLocales() {
       compilerError("targetLocales is unsuppported by sparse domains");


### PR DESCRIPTION
These names seem cleaner and more useful than the existing ones. Also, dsiTargetLocDom is removed. Users can instead write "dsiTargetLocales().domain".
