### PR TITLE
Add prediff for test3DLulesh to filter error codes in slurm.

### DIFF
--- a/test/release/examples/benchmarks/lulesh/test3DLulesh.prediff
+++ b/test/release/examples/benchmarks/lulesh/test3DLulesh.prediff
@@ -8,5 +8,5 @@
 # be intentional because the .good files have the halt error messages in them.
 
 outfile=$2
-cat $outfile | grep -v 'srun: error: ' > $outfile.tmp
+cat $outfile | grep -v -E 'srun: error: .* Exited with exit code 1' > $outfile.tmp
 mv $outfile.tmp $outfile


### PR DESCRIPTION
I verified this worked on an XC with slurm launcher and on my mac with no launcher.
