### PR TITLE
Don't remove ref temps for PRIM_SET_MEMBER

### DIFF
--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -107,8 +107,11 @@ static bool canRemoveRefTemps(FnSymbol* fn) {
   collectCallExprsSTL(fn, callExprs);
 
   for_vector(CallExpr, call, callExprs) {
-    if (!call->primitive)
+    if (!call->primitive) {
       return false;
+    } else if (call->isPrimitive(PRIM_SET_MEMBER)) {
+      return false;
+    }
   }
 
   return true;


### PR DESCRIPTION
Ref temps for PRIM_SET_MEMBER are always needed.
