### PR TITLE
Using default memory layer in quickstart scripts

### DIFF
--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -32,6 +32,9 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
           echo "Setting CHPL_TASKS to fifo"
           export CHPL_TASKS=fifo
 
+          echo "Setting CHPL_MEM to default"
+          export CHPL_MEM=default
+
           echo "Setting CHPL_GMP to none"
           export CHPL_GMP=none
 

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -36,6 +36,9 @@ echo "to include $CHPL_HOME/man"
 echo "Setting CHPL_TASKS to fifo"
 setenv CHPL_TASKS fifo
 
+echo "Setting CHPL_MEM to default"
+setenv CHPL_MEM default
+
 echo "Setting CHPL_GMP to none"
 setenv CHPL_GMP none
 

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -36,6 +36,9 @@ echo "to include $CHPL_HOME/man"
 echo "Setting CHPL_TASKS to fifo"
 set -x CHPL_TASKS fifo
 
+echo "Setting CHPL_MEM to default"
+set -x CHPL_MEM default
+
 echo "Setting CHPL_GMP to none"
 set -x CHPL_GMP none
 

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -43,6 +43,12 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
           echo "                           ...fifo"
           echo " "
 
+          echo "Setting CHPL_MEM to..."
+          CHPL_MEM=default
+          export CHPL_MEM
+          echo "                           ...default"
+          echo " "
+
           echo "Setting CHPL_GMP to..."
           CHPL_GMP=none
           export CHPL_GMP


### PR DESCRIPTION
This PR sets CHPL_MEM to "default" (soon to be cstdlib) for the quickstart scripts. This is done so that users looking to try Chapel don't have to build an allocator.
