### PR TITLE
Solve numa error with memory/shannon/printFinalMemStat

### DIFF
--- a/test/memory/shannon/printFinalMemStat.lm-numa.good
+++ b/test/memory/shannon/printFinalMemStat.lm-numa.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  368
-Total Allocated Memory                 880
-Total Freed Memory                     624
+Total Allocated Memory                 824
+Total Freed Memory                     568
 ==============================================================


### PR DESCRIPTION
Pointed out in the release status meeting as failing recently, this test has
actually been failing since July 11th, 2014.  The failure mode was a positive
change in the amount of memory allocated, possibly due to Michael's cache
commit on the 10th (though tracking that down has proved really painful).  It
seems correct to just update the .good file with the new numbers.
