### PR TITLE
Fix up more futures

### DIFF
--- a/test/users/ferguson/err_tmp.chpl
+++ b/test/users/ferguson/err_tmp.chpl
@@ -2,7 +2,7 @@ use SysBasic;
 
 proc doDebugWrite(x, y):err_t {
   writeln("Debug Write: ", x, y);
-  return chpl_int_to_err(1);
+  return qio_int_to_err(1);
 }
 
 proc test(arg:string, out error:err_t):bool {
@@ -12,6 +12,7 @@ proc test(arg:string, out error:err_t):bool {
       error = doDebugWrite("test ", arg);
     }
   }
+  return error==ENOERR;
 }
 
 var e:err_t = ENOERR;

--- a/test/users/ferguson/histogram/reductionex_class.bad
+++ b/test/users/ferguson/histogram/reductionex_class.bad
@@ -1,0 +1,2 @@
+reductionex_class.chpl:43: error: 'new' must be followed by a type expression
+reductionex_class.chpl:43: error: 'new' must be followed by a type expression

--- a/test/users/ferguson/histogram/reductionex_record.bad
+++ b/test/users/ferguson/histogram/reductionex_record.bad
@@ -1,0 +1,2 @@
+reductionex_record.chpl:43: error: 'new' must be followed by a type expression
+reductionex_record.chpl:43: error: 'new' must be followed by a type expression

--- a/test/users/ferguson/int32method.bad
+++ b/test/users/ferguson/int32method.bad
@@ -1,0 +1,1 @@
+int32method.chpl:1: syntax error: near '32'

--- a/test/users/ferguson/module_new.bad
+++ b/test/users/ferguson/module_new.bad
@@ -1,0 +1,2 @@
+module_new.chpl:8: In function 'main':
+module_new.chpl:9: error: unresolved call 'X(1)'

--- a/test/users/ferguson/override_overload.future
+++ b/test/users/ferguson/override_overload.future
@@ -1,4 +1,9 @@
 bug: compiler segfault override/overload
 
-Compiler segfaults when compiling this one.
+Non-deterministic compiler seg faults when compiling this program.
+
+9/11/14 (sungeun): This doesn't seg fault all the time.  The seg fault
+is in add_internal() of the Vec class called from
+compute_call_sites(), but I've seen it happen during inlineFunctions
+as well as removeUnnecessaryAutoCopyCalls.
 


### PR DESCRIPTION
More future cleanup.

err_tmp.chpl: Fixed test program which was incorrect and removed the
              future because it works now (future was accidentally
              removed in the previous commit).

override_overload.future: Added more info.  This is a
              non-deterministic failure.  Point Noakes to it for his
              OS/X bug hunt.

New .bad files:
- histogram/reductionex_class.bad
- histogram/reductionex_record.bad
- int32method.bad
- module_new.bad
