### PR TITLE
Retiring this future by making it a NOTEST

### DIFF
--- a/test/studies/590o/telmas/NOTEST
+++ b/test/studies/590o/telmas/NOTEST
@@ -1,0 +1,2 @@
+This test is nondeterministic and can't be run; the code seems worth keeping around
+but we can't test it without additional effort to make it deterministic.

--- a/test/studies/590o/telmas/dpll.future
+++ b/test/studies/590o/telmas/dpll.future
@@ -1,6 +1,0 @@
-bug: test is nondeterministic
-
-Fixed bug that this test was originally showing.  Now the
-problem is that the output is nondeterministic.  Working
-with the author to try to address this.
-


### PR DESCRIPTION
This was marked as a bug future due to its nondeterminism; this isn't
really appropriate -- it should've been marked as a NOTEST since it
isn't a bug in Chapel itself.  Doing that now.
