### PR TITLE
Take Greg's comment on mkdir into account

### DIFF
--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1091,9 +1091,8 @@ qioerr qio_mkdir(const char* name, int mode, int parents) {
         tmp[index+1] = '\0';
         exitStatus = stat(tmp, &statRes);
         if (exitStatus == -1 && errno == ENOENT) {
-          // This error means we should stop checking each successive
-          // directory is there and start creating them, beginning with this
-          // one
+          // This error means we could not find the parent directory, so need
+          // to create it.
           exitStatus = mkdir(tmp, mode);
         }
         if (exitStatus) {


### PR DESCRIPTION
This adds a check to see if we need to create a parent directory and returns
the first error we find that is either mkdir generated, or found by stat but not
a "file or directory does not exist" error (which we would've solved by calling
mkdir afterwards).
