### PR TITLE
Bump call stacks parallel/cobegin/deitz/test_big_recursive_cobegin

### DIFF
--- a/test/parallel/cobegin/deitz/test_big_recursive_cobegin.execenv
+++ b/test/parallel/cobegin/deitz/test_big_recursive_cobegin.execenv
@@ -1,1 +1,5 @@
-CHPL_RT_CALL_STACK_SIZE=256K
+# This number is chosen to try to limit the test to use less than
+# 4GB of ram, but to have large enough callstacks to deal with a
+# recursively called function that already has large call stacks
+# because of how we generate begins (especially for --no-local)
+CHPL_RT_CALL_STACK_SIZE=4M


### PR DESCRIPTION
Made call stack size too low yesterday
