### PR TITLE
Do not copy qthreads mailing list with test results.

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -352,9 +352,6 @@ if ($debug == 1) {
 } else {
     $subjectid = "Cron$subjectid";
     $recipient = "$failuremail $allmail";
-    if ($tasks eq "qthreads") {
-      $recipient = "$recipient qthreads-chapel\@googlegroups.com";
-    }
     $nochangerecipient = $allmail;
 }
 


### PR DESCRIPTION
Now that qthreads is the default, it does not make sense to copy that list.
