### PR TITLE
Fix glob for CCE

### DIFF
--- a/runtime/include/chpldirent.h
+++ b/runtime/include/chpldirent.h
@@ -24,7 +24,15 @@
 
 typedef DIR* DIRptr;
 
+#ifndef __USE_FILE_OFFSET64
 typedef struct dirent* direntptr;
+#else
+#ifdef __REDIRECT
+typedef struct dirent* direntptr;
+#else
+typedef struct dirent64* direntptr;
+#endif
+#endif
 
 #define chpl_rt_direntptr_getname(x) ((x)->d_name)
 


### PR DESCRIPTION
[approved by @mppf]

This commit comments out the #define of _FILE_OFFSET_BITS from
sys_basic.h because it has been causing portability issues for
various file-related routines like dirent.h and glob.h.  The
latest issue is that an #include of glob.h for the Cray CCE
compiler breaks compilation.  I think this was also the cause
of the complexity in chpldirent.h that I inserted to get it
compiling in all Cray configurations (and future work should
try backing out those changes; but I wanted to take things
one step at a time).

Michael was worried that this would break 32-bit builds, but I'm not
seeing that.  As I understand it, his original rationale for this was
to guarantee support for files larger than 4GB.  If/when we get to
needing that, we can reconsider this change.
