### PR TITLE
Changing the declaration of a QIO argument to be more portable

### DIFF
--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -124,7 +124,7 @@ typedef qioerr (*qio_seek_fptr)(void*,  // plugin fp
                                 void*); // plugin filesystem pointer
 
 typedef qioerr (*qio_filelength_fptr)(void*,     // file information 
-                                      int64_t*,  // length on return
+                                      off_t*,  // length on return
                                       void*);    // plugin filesystem pointer
 
 typedef qioerr (*qio_getpath_fptr)(void*,        // file information


### PR DESCRIPTION
Hardcoded as an int64_t made it incompatible with off_t if it
wasn't 64-bits.  I believe that this should fix the linux32
smoke-test builds (which, for some reason, I can't reproduce
myself on linux32).
