### PR TITLE
These changes seem to fix the linux32 build (for real)

### DIFF
--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -124,7 +124,7 @@ typedef qioerr (*qio_seek_fptr)(void*,  // plugin fp
                                 void*); // plugin filesystem pointer
 
 typedef qioerr (*qio_filelength_fptr)(void*,     // file information 
-                                      off_t*,  // length on return
+                                      int64_t*,  // length on return
                                       void*);    // plugin filesystem pointer
 
 typedef qioerr (*qio_getpath_fptr)(void*,        // file information

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -850,7 +850,7 @@ error:
 qioerr qio_file_init_usr(qio_file_t** file_out, void* file_info, qio_hint_t iohints, int flags, const qio_style_t* style, void* fs_info, const qio_file_functions_t* fns)
 {
   off_t initial_pos = 0;
-  off_t initial_length = 0;
+  int64_t initial_length = 0;
   qioerr err = 0;
   err_t err_code;
   qio_file_t* file = NULL;


### PR DESCRIPTION
Sorry for shooting in the blind on my previous commit -- I couldn't
figure out why my linux32 builds weren't matching the smoke-test ones;
turns out it was because I didn't have CHPL_DEVELOPER set on that
linux32 box (D'oh!).

Rather than pushing off_t through the callchains as started by my
previous approach, here I back off, realizing that doing so would
require changing HDFS, cURL, and Lustre interfaces (scary!)
Meanwhile, keeping the file length an int64_t only required changing
one other variable to fix the linux32 builds.  Whew!
