### PR TITLE
Update test-release.bash to use public repo, instead of working copy.

### DIFF
--- a/util/cron/test-release.bash
+++ b/util/cron/test-release.bash
@@ -8,10 +8,4 @@ WORKSPACE=${WORKSPACE:-$CWD/../..}
 export TMPDIR=$(mktemp -d $WORKSPACE/chapel-test-release.XXXXX)
 export CHPL_GEN_RELEASE_TMPDIR=$TMPDIR
 
-# Clone from the current workspace, which is a clean, up-to-date working copy
-# of the repo in Chapel's testing system.
-if [ -d "${WORKSPACE}/.git" ] ; then
-    export CHPL_HOME_REPOSITORY=$WORKSPACE/.git
-fi
-
 $CWD/../buildRelease/testRelease -cron


### PR DESCRIPTION
The test systems clones the repo in a way that doesn't work so well with this
test. Remove the CHPL_HOME_REPOSITORY var, so gen_release will simply clone
from the github repo.
