### PR TITLE
Attempt to build re2/gmp by default and use CHPL_TARGET_COMPILER for re2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,12 @@
 # the current state of the world, not the
 # post-attempt-to-build-gmp/re2 world.
 #
+
+#
+# We set this to avoid extraneous printing of Makefile subdirectories
+# by default.  Having this un-set will break the Travis builds.
+# Normally, Makefile.base sets this for our other Makefiles.
+#
 MAKEFLAGS = --no-print-directory
 
 export CHPL_MAKE_HOME=$(shell pwd)
@@ -106,7 +112,7 @@ depend:
 	@echo "make depend has been deprecated for the time being"
 
 check: all
-	@bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall --debug
+	@bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
 
 -include Makefile.devel
 

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -137,7 +137,7 @@ cp $TESTS $TMP_TEST_DIR/
     # Run the tests.
     echo "Running the hello world tests found in: $TEST_DIR"
 
-    $CHPL_HOME/util/start_test --no-chpl-home-warn --progress $CHPL_START_TEST_ARGS *.chpl 2>&1 | tee $test_output_log
+    $CHPL_HOME/util/start_test --no-chpl-home-warn --progress $CHPL_START_TEST_ARGS *.chpl > $test_output_log
 
     test_status=$?
     log_debug "start_test exit code: ${test_status}"


### PR DESCRIPTION
This commit makes two main changes:

1) When building with CHPL_RE2 and CHPL_GMP unset, by default,
the make environment will attempt to build those packages,
ignoring errors if they fail.  If they succeed, this will result
in these packages being enabled by default (since their presence
causes the util/chplenv/ scripts to default them to being on).
If they fail, they fail.

2) It changes the re2 package to build using the
CHPL_TARGET_COMPILER whereas before it always built with gnu.
This aligns it more with what you would expect (use the compiler
you're using for target code) and avoids cases where the target
compiler may not be compatible with gnu.  On the other hand, it
also reduces the number of configurations that will support re2
because aspects of their Makefiles are specific to gnu compilers
and those that are compatible with them.  Future work
could/should port these Makefiles to be more generic (and
contribute it back to the re2 project) if they don't get to this
before we do.

The main approach taken for step 1 is as follows:
- if CHPL_RE2/GMP is unset, then the user hasn't expressed an
  opinion, so let's try to  build them. If they are set, it will
  either suppress the attempt to build them or build them at the
  normal point (when the runtime is being built), so nothing
  special needs to be done.
- the rules to attempt to build them are third-party-try-*:
  - third-party-try-opt says to try building the optional packages
  - third-party-try-re2 says to try building re2
  - third-party-try-gmp says to try building gmp
- the other change required to the Makefile was to remove its
  inclusion of Makefile.base.  This makes it the one Makefile
  that does not include Makefile.base, and it cannot, for doing
  so would set CHPL_REGEXP and CHPL_GMP for all subsequent
  Makefiles before we know whether or not the attempts to build
  were successful.

For step 2, the only work was to pass CC and CXX on to the make
step for re2.
