### PR TITLE
Removing 64-bit workaround text from chpldirent.h

### DIFF
--- a/runtime/include/chpldirent.h
+++ b/runtime/include/chpldirent.h
@@ -24,15 +24,7 @@
 
 typedef DIR* DIRptr;
 
-#ifndef __USE_FILE_OFFSET64
 typedef struct dirent* direntptr;
-#else
-#ifdef __REDIRECT
-typedef struct dirent* direntptr;
-#else
-typedef struct dirent64* direntptr;
-#endif
-#endif
 
 #define chpl_rt_direntptr_getname(x) ((x)->d_name)
 


### PR DESCRIPTION
When first implementing chpldirent.h as a helper header
in the test/studies/filerator/ directory, I had to put
in a bunch of #ifdef logic to mimic what was happening
on Crays in order to get it working with all PrgEnv's.
It seems to be that this was related to the #define of
_FILE_OFFSET_BITS in sys_basic.h, and that now that
that's commented out, this logic is no longer needed,
so I'm removing it.

I tested this by testing the filerator module on Cray HW
with the four Cray PrgEnvs.  The only failures were the
globberator.chpl runs, which seem to fail even without
the change.
