### PR TITLE
Rework chpl_getNum{Cores,PUs}OnThisNode().

### DIFF
--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -181,8 +181,8 @@ module LocaleModel {
       extern proc chpl_task_getCallStackSize(): size_t;
       callStackSize = chpl_task_getCallStackSize();
 
-      extern proc chpl_getNumLogCpusOnThisNode(accessible_only: bool): c_int;
-      numCores = chpl_getNumLogCpusOnThisNode(true);
+      extern proc chpl_getNumLogicalCpus(accessible_only: bool): c_int;
+      numCores = chpl_getNumLogicalCpus(true);
 
       extern proc chpl_task_getMaxPar(): uint(32);
       maxTaskPar = chpl_task_getMaxPar();

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -233,8 +233,8 @@ module LocaleModel {
       extern proc chpl_task_getCallStackSize(): size_t;
       callStackSize = chpl_task_getCallStackSize();
 
-      extern proc chpl_getNumLogCpusOnThisNode(accessible_only: bool): c_int;
-      numCores = chpl_getNumLogCpusOnThisNode(true);
+      extern proc chpl_getNumLogicalCpus(accessible_only: bool): c_int;
+      numCores = chpl_getNumLogicalCpus(true);
 
       extern proc chpl_task_getNumSublocales(): int(32);
       numSublocales = chpl_task_getNumSublocales();

--- a/runtime/include/chplsys.h
+++ b/runtime/include/chplsys.h
@@ -26,8 +26,8 @@
 
 uint64_t chpl_bytesPerLocale(void);
 size_t chpl_bytesAvailOnThisLocale(void);
-int chpl_getNumPhysCpusOnThisNode(chpl_bool accessible_only);
-int chpl_getNumLogCpusOnThisNode(chpl_bool accessible_only);
+int chpl_getNumPhysicalCpus(chpl_bool accessible_only);
+int chpl_getNumLogicalCpus(chpl_bool accessible_only);
 
 //
 // returns the name of a locale via uname -n or the like

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -169,7 +169,7 @@ static void getCpuInfo(int* p_numPhysCpus, int* p_numLogCpus) {
 #endif
 
 
-int chpl_getNumPhysCpusOnThisNode(chpl_bool accessible_only) {
+int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
   //
   // Support for the accessible_only flag here is spotty.  For non-Linux
   // systems we ignore it.  For Linux systems we obey it, but we may
@@ -194,7 +194,7 @@ int chpl_getNumPhysCpusOnThisNode(chpl_bool accessible_only) {
   //
   static int numCpus = 0;
   if (numCpus == 0)
-    numCpus = chpl_getNumLogCPUsOnThisNode();
+    numCpus = chpl_getNumLogicalCpus();
   return numCpus;
 #elif defined __linux__
   //
@@ -244,7 +244,7 @@ int chpl_getNumPhysCpusOnThisNode(chpl_bool accessible_only) {
 }
 
 
-int chpl_getNumLogCpusOnThisNode(chpl_bool accessible_only) {
+int chpl_getNumLogicalCpus(chpl_bool accessible_only) {
   //
   // Support for the accessible_only flag here is spotty -- we only obey
   // it for Linux systems.

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -199,7 +199,7 @@ static void sync_wait_and_lock(chpl_sync_aux_t *s,
   // in order to ensure fairness and thus progress.  If we're not, we
   // can spin-wait.
   suspend_using_cond = (chpl_thread_getNumThreads() >=
-                        chpl_getNumLogCpusOnThisNode(true));
+                        chpl_getNumLogicalCpus(true));
 
   while (s->is_full != want_full) {
     if (!suspend_using_cond) {
@@ -856,7 +856,7 @@ uint32_t chpl_task_getMaxPar(void) {
   // lesser of the number of physical CPUs and whatever the threading
   // layer says it can do.
   //
-  max = (uint32_t) chpl_getNumPhysCpusOnThisNode(true);
+  max = (uint32_t) chpl_getNumPhysicalCpus(true);
   maxThreads = chpl_thread_getMaxThreads();
   if (maxThreads < max && maxThreads > 0)
     max = maxThreads;

--- a/runtime/src/tasks/massivethreads/tasks-massivethreads.c
+++ b/runtime/src/tasks/massivethreads/tasks-massivethreads.c
@@ -507,7 +507,7 @@ uint32_t chpl_task_getMaxPar(void) {
   // lesser of the number of physical CPUs and the number of workers
   // we have.
   //
-  max = (uint32_t) chpl_getNumPhysCpusOnThisNode(true);
+  max = (uint32_t) chpl_getNumPhysicalCpus(true);
   if ((uint32_t) s_num_workers < max)
     max = (uint32_t) s_num_workers;
   return max;

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -474,7 +474,7 @@ static int32_t setupAvailableParallelism(int32_t maxThreads) {
 
         hwpar = numThreadsPerLocale;
 
-        numPUsPerLocale = chpl_getNumLogCpusOnThisNode(true);
+        numPUsPerLocale = chpl_getNumLogicalCpus(true);
         if (0 < numPUsPerLocale && numPUsPerLocale < hwpar) {
             if (verbosity >= 2) {
                 printf("QTHREADS: Reduced numThreadsPerLocale=%d to %d "
@@ -493,7 +493,7 @@ static int32_t setupAvailableParallelism(int32_t maxThreads) {
     }
     // User did not set chapel or qthreads vars -- our default
     else {
-        hwpar = chpl_getNumPhysCpusOnThisNode(true);
+        hwpar = chpl_getNumPhysicalCpus(true);
     }
 
     // hwpar will only be <= 0 if the user set QT_NUM_SHEPHERDS and/or
@@ -507,7 +507,7 @@ static int32_t setupAvailableParallelism(int32_t maxThreads) {
 
         // If there is more parallelism requested than the number of cores, set the
         // worker unit to pu, otherwise core.
-        if (hwpar > chpl_getNumPhysCpusOnThisNode(true)) {
+        if (hwpar > chpl_getNumPhysicalCpus(true)) {
           chpl_qt_setenv("WORKER_UNIT", "pu", 0);
         } else {
           chpl_qt_setenv("WORKER_UNIT", "core", 0);


### PR DESCRIPTION
This standardizes naming, making the following changes:
  chpl_getNumCoresOnThisNode() --> chpl_getNumPhysCpusOnThisNode()
  chpl_getNumPUsOnThisNode() --> chpl_getNumLogCpusOnThisNode()

It also adds an argument to both of these, for callers to indicate
whether they want information about all the CPU resources that are
present on the node, or only the ones to which the process has access
(due to kernel affinity restrictions, etc.).

I ran the maxTaskPar test on this change with CHPL_TASKS=qthreads,
CHPL_TASKS=qthreads and CHPL_LOCALE_MODEL=numa, CHPL_TASKS=fifo,
CHPL_TASKS=massivethreads, and CHPL_TASKS=muxed.
