### PR TITLE
Update .bad file for test_distribution_syntax2

### DIFF
--- a/test/distributions/deitz/test_distribution_syntax2.bad
+++ b/test/distributions/deitz/test_distribution_syntax2.bad
@@ -1,1 +1,7 @@
-test_distribution_syntax2.chpl:6: error: attempt to dereference nil
+Block-Distributed Array
+-----------------------
+(0, 1) (0, 2) (1, 3) (1, 4)
+(0, 5) (0, 6) (1, 7) (1, 8)
+(2, 9) (2, 10) (3, 11) (3, 12)
+(2, 13) (2, 14) (3, 15) (3, 16)
+test_distribution_syntax2.chpl:21: error: halt reached - assignment to distributions with declared domains is not yet supported


### PR DESCRIPTION
This test started passing for Block-Distributed arrays, getting pas, but the test fails in the original manner for Cyclic-Distributed arrays.
TODO: Update the future if the uninitialized privatized class index problem has been resolved.
