### PR TITLE
Adding perf annotations for tcmalloc as default

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -40,6 +40,10 @@ all:
     - no testing occurred, machine update
   08/26/14:
     - switched default tasking layer to qthreads from fifo
+  09/06/14:
+    - switch default memory allocator from cstdlib to tcmalloc
+  09/12/14:
+    - switch default memory allocator back to cstdlib
 
 chameneos-redux:
   07/08/13:


### PR DESCRIPTION
Adding annotations to the perf graphs for the time periods where tcmalloc was the default allocator during nightly testing.
