### PR TITLE
Remove a stray semicolon from walk.execopts

### DIFF
--- a/test/studies/filerator/walk.execopts
+++ b/test/studies/filerator/walk.execopts
@@ -1,9 +1,9 @@
                               # walk.good
---startdir="subdir/subdir2";  #walk-startdir.good
---topdown=false               #walk-bottomup.good
---depth=0                     #walk-depth0.good
---depth=1                     #walk-depth1.good
---depth=2                     #walk-depth2.good
---dotfiles=true               #walk-dotfiles.good
---defaults=true               #walk.good
---followlinks=true            #walk-followlinks.good
+--startdir="subdir/subdir2"   # walk-startdir.good
+--topdown=false               # walk-bottomup.good
+--depth=0                     # walk-depth0.good
+--depth=1                     # walk-depth1.good
+--depth=2                     # walk-depth2.good
+--dotfiles=true               # walk-dotfiles.good
+--defaults=true               # walk.good
+--followlinks=true            # walk-followlinks.good


### PR DESCRIPTION
This caused testing to fail in any configurations that added additional
execution time flags... ugh.
