### PR TITLE
Renaming Tim's glob/wordexp -> my_glob/my_wordexp

### DIFF
--- a/test/studies/glob/Glob.chpl
+++ b/test/studies/glob/Glob.chpl
@@ -32,7 +32,7 @@ extern const WRDE_DOOFFS : c_int;
 extern const WRDE_NOCMD  : c_int;
 extern const WRDE_REUSE  : c_int;
 
-iter wordexp(pattern:string, recursive:bool = false, flags:int = 0, directory:string = ""):string {
+iter my_wordexp(pattern:string, recursive:bool = false, flags:int = 0, directory:string = ""):string {
   var err : c_int;
   var tx  : c_string;
   var glb : wordexp_t;
@@ -43,7 +43,7 @@ iter wordexp(pattern:string, recursive:bool = false, flags:int = 0, directory:st
     tx = wordexp_index(glb, i);
     if recursive && chpl_isdir(tx) == 1 {
       const pth = toString(tx) + "/";
-      for fl in wordexp(pattern, recursive, flags, pth) do
+      for fl in my_wordexp(pattern, recursive, flags, pth) do
         yield fl;
     } else yield toString(tx);
   }
@@ -51,7 +51,7 @@ iter wordexp(pattern:string, recursive:bool = false, flags:int = 0, directory:st
   wordfree(glb);
 }
 
-iter wordexp(param tag:iterKind, pattern:string, recursive:bool = false,
+iter my_wordexp(param tag:iterKind, pattern:string, recursive:bool = false,
              flags:int = 0, directory:string = "") : string where tag == iterKind.leader {
   var err     : c_int;
   var tx      : c_string;
@@ -68,7 +68,7 @@ iter wordexp(param tag:iterKind, pattern:string, recursive:bool = false,
     // Now spawn off tasks for each dir
     coforall dir in dirBuff {
       dirBuff -= dir;
-      for flConst in wordexp(pattern, false, flags, dir) {
+      for flConst in my_wordexp(pattern, false, flags, dir) {
         var fl = flConst;
         if recursive && chpl_isdir(fl.c_str()) == 1 {
           fl += "/";
@@ -80,12 +80,12 @@ iter wordexp(param tag:iterKind, pattern:string, recursive:bool = false,
   } while (true);
 }
 
-iter wordexp(param tag:iterKind, pattern:string, recursive:bool = false,
+iter my_wordexp(param tag:iterKind, pattern:string, recursive:bool = false,
     flags:int = 0, directory:string = "", followThis) : string where tag == iterKind.follower {
   yield followThis;
 }
 
-iter glob(pattern:string, recursive:bool = false, flags:int = 0, directory:string = ""):string {
+iter my_glob(pattern:string, recursive:bool = false, flags:int = 0, directory:string = ""):string {
   var err : c_int;
   var tx  : c_string;
   var glb : glob_t;
@@ -96,7 +96,7 @@ iter glob(pattern:string, recursive:bool = false, flags:int = 0, directory:strin
     tx = glob_index(glb, i);
     if recursive && chpl_isdir(tx) == 1 {
       const pth = toString(tx) + "/";
-      for fl in glob(pattern, recursive, flags, pth) do
+      for fl in my_glob(pattern, recursive, flags, pth) do
         yield fl;
     } else yield toString(tx);
   }
@@ -104,7 +104,7 @@ iter glob(pattern:string, recursive:bool = false, flags:int = 0, directory:strin
   globfree(glb);
 }
 
-iter glob(param tag:iterKind, pattern:string, recursive:bool = false,
+iter my_glob(param tag:iterKind, pattern:string, recursive:bool = false,
           flags:int = 0, directory:string = "") : string where tag == iterKind.leader {
   var err     : c_int;
   var tx      : c_string;
@@ -122,7 +122,7 @@ iter glob(param tag:iterKind, pattern:string, recursive:bool = false,
     // Now spawn off tasks for each dir
     coforall dir in dirBuff {
       dirBuff -= dir;
-      for flConst in glob(pattern, false, flags, dir) {
+      for flConst in my_glob(pattern, false, flags, dir) {
         var fl = flConst;
         if recursive && chpl_isdir(fl.c_str()) == 1 {
           fl += "/";
@@ -134,7 +134,7 @@ iter glob(param tag:iterKind, pattern:string, recursive:bool = false,
   } while (true);
 }
 
-iter glob(param tag:iterKind, pattern:string, recursive:bool = false,
+iter my_glob(param tag:iterKind, pattern:string, recursive:bool = false,
     flags:int = 0, directory:string = "", followThis) : string where tag == iterKind.follower {
   yield followThis;
 }

--- a/test/studies/glob/test_glob.chpl
+++ b/test/studies/glob/test_glob.chpl
@@ -3,55 +3,55 @@ use Glob;
 writeln("======== SERIAL ITERATORS (recursive) ==========");
 
 writeln("-------- GLOB ----------");
-for s in glob("[a-p]*",recursive=true) do
+for s in my_glob("[a-p]*",recursive=true) do
     writeln(s);
 
 writeln("-------- WORDEXP ----------");
-for s in wordexp("[a-p]*",recursive=true) do
+for s in my_wordexp("[a-p]*",recursive=true) do
     writeln(s);
 
 writeln("-------- WORDEXP `zip` GLOB ----------");
-for s in zip(wordexp("[a-p]*", recursive=true), glob("[a-p]*",recursive=true)) do 
+for s in zip(my_wordexp("[a-p]*", recursive=true), my_glob("[a-p]*",recursive=true)) do 
   writeln(s);
 
 writeln("======== SERIAL ITERATORS (non-recursive) ==========");
 
 writeln("-------- GLOB ----------");
-for s in glob("[a-p]*") do
+for s in my_glob("[a-p]*") do
     writeln(s);
 
 writeln("-------- WORDEXP ----------");
-for s in wordexp("[a-p]*") do
+for s in my_wordexp("[a-p]*") do
     writeln(s);
 
 writeln("-------- WORDEXP `zip` GLOB ----------");
-for s in zip(wordexp("[a-p]*"), glob("[a-p]*")) do 
+for s in zip(my_wordexp("[a-p]*"), my_glob("[a-p]*")) do 
   writeln(s);
 
 writeln("======== PARALLEL ITERATORS (recursive) ==========");
 
 writeln("-------- GLOB ----------");
-forall s in glob("[a-p]*",recursive=true) do
+forall s in my_glob("[a-p]*",recursive=true) do
     writeln(s);
 
 writeln("-------- WORDEXP ----------");
-forall s in wordexp("[a-p]*",recursive=true) do
+forall s in my_wordexp("[a-p]*",recursive=true) do
     writeln(s);
 
 writeln("-------- WORDEXP `zip` GLOB ----------");
-forall s in zip(wordexp("[a-p]*",recursive=true), glob("[a-p]*",recursive=true)) do 
+forall s in zip(my_wordexp("[a-p]*",recursive=true), my_glob("[a-p]*",recursive=true)) do 
   writeln(s);
 
 writeln("======== PARALLEL ITERATORS (non-recursive) ==========");
 
 writeln("-------- GLOB ----------");
-forall s in glob("[a-p]*") do
+forall s in my_glob("[a-p]*") do
     writeln(s);
 
 writeln("-------- WORDEXP ----------");
-forall s in wordexp("[a-p]*") do
+forall s in my_wordexp("[a-p]*") do
     writeln(s);
 
 writeln("-------- WORDEXP `zip` GLOB ----------");
-forall s in zip(wordexp("[a-p]*"), glob("[a-p]*")) do 
+forall s in zip(my_wordexp("[a-p]*"), my_glob("[a-p]*")) do 
   writeln(s);


### PR DESCRIPTION
When testing with --baseline, the C compiler complained because
Tim's glob()/wordexp() conflicted with those of the standard C
headers.  Since this is a standalone test for experimental
purposes, I took the easy approach of renaming his iterators
rather than adding more symbols to the reservedCSymbols list.
