### PR TITLE
Report error when assigning to const arrays/domains.

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1065,7 +1065,9 @@ isLegalLvalueActualArg(ArgSymbol* formal, Expr* actual) {
         se->var->hasFlag(FLAG_REF_TO_CONST) ||
         (se->var->isConstant() && !formal->hasFlag(FLAG_ARG_THIS)) ||
         se->var->isParameter())
-      if (okToConvertFormalToRefType(formal->type))
+      if (okToConvertFormalToRefType(formal->type) ||
+          // If the user says 'const', it means 'const'.
+          (se->var->hasFlag(FLAG_CONST) && !se->var->hasFlag(FLAG_TEMP)))
         return false;
   // Perhaps more checks are needed.
   return true;
@@ -3472,15 +3474,17 @@ static void resolveMove(CallExpr* call) {
   // If this assigns into a loop index variable from a non-var iterator,
   // mark the variable constant.
   if (SymExpr* rhsSE = toSymExpr(rhs)) {
+    // If RHS is this special variable...
     if (rhsSE->var->hasFlag(FLAG_INDEX_OF_INTEREST)) {
-      // If RHS is this special variable...
       INT_ASSERT(lhs->hasFlag(FLAG_INDEX_VAR));
-      if (!isReferenceType(rhsSE->var->type)) {
-        // ... and not of a reference type, mark LHS constant.
-        // todo: differentiate based on ref-ness, not _ref type
-        // todo: not all const if it is zippered and one of iterators is var
+      // ... and not of a reference type
+      // todo: differentiate based on ref-ness, not _ref type
+      // todo: not all const if it is zippered and one of iterators is var
+      if (!isReferenceType(rhsSE->var->type))
+       // ... and not an array (arrays are always yielded by reference)
+       if (!rhsSE->var->type->symbol->hasFlag(FLAG_ARRAY))
+        // ... then mark LHS constant.
         lhs->addFlag(FLAG_CONST);
-      }
     }
   }
 
@@ -4505,7 +4509,11 @@ static Expr* resolveTupleIndexing(CallExpr* call, Symbol* baseVar)
       if (destSE->var->hasFlag(FLAG_INDEX_VAR)) {
         // The destination is constant only if both the tuple
         // and the current component are non-references.
-        destSE->var->addFlag(FLAG_CONST);
+        // And it's not an array (arrays are always yielded by reference)
+        // - see boundaries() in release/examples/benchmarks/miniMD/miniMD.
+        if (!fieldType->symbol->hasFlag(FLAG_ARRAY)) {
+          destSE->var->addFlag(FLAG_CONST);
+        }
       } else {
         INT_ASSERT(destSE->var->hasFlag(FLAG_TEMP));
         // We are detupling into another tuple,


### PR DESCRIPTION
For now, this error is enabled only for user-level variables,
i.e. ones with FLAG_CONST and not FLAG_TEMP.
This probably could be tuned to catch more errors.

While there: a loop index variable of an array type
is never const. That's because we currently yield
arrays by reference even from non-'ref' iterators.
See e.g. svn:r21676 aka 8d3b2c4
aka 8d3b2c4065d6466dbaadab0ae0c8444e6645dae6

Non-constness applies even when the array is a part
of a tuple yielded by the iterator. Which is done
by the iterators boundaries() and dsiBoundaries()
in the test release/examples/benchmarks/miniMD/miniMD.chpl
