### PR TITLE
Fix chpl_regexp to use the correct CHPL_TARGET_ARCH value

### DIFF
--- a/util/chplenv/chpl_regexp.py
+++ b/util/chplenv/chpl_regexp.py
@@ -10,7 +10,7 @@ def get():
     if not regexp_val:
         target_platform = chpl_platform.get('target')
         target_compiler = chpl_compiler.get('target')
-        target_arch = chpl_arch.get('target', get_lcd=True)
+        target_arch = chpl_arch.get('target', map_to_compiler=True, get_lcd=True)
         chpl_home = utils.get_chpl_home()
         regexp_target_dir = '{0}-{1}-{2}'.format(target_platform, target_compiler, target_arch)
         regexp_subdir = os.path.join(chpl_home, 'third-party', 're2', 'install',


### PR DESCRIPTION
chpl_regexp was using the displayed target architecture, rather than the value used in Makefiles. This would cause it to look in the wrong directory for a re2 install on some platforms.
