### PR TITLE
Add a work around for non-default size bools in ref temp removal

### DIFF
--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -103,6 +103,18 @@ static bool canRemoveRefTemps(FnSymbol* fn) {
   if (!fn) // primitive
     return true;
 
+  // Work around for a bug with non-default size bools in no-local. I believe
+  // they dont work in no-local due to not preserving thier size during
+  // codegen.
+  // TODO: Check if this can be removed onces bool sizes are preserved
+  //       ( test/types/scalar/bradc/bools[2].chpl )
+  if (!fLocal) {
+    for_formals(formal, fn) {
+      if (is_bool_type(formal->typeInfo()))
+        return false;
+    }
+  }
+
   std::vector<CallExpr*> callExprs;
   collectCallExprsSTL(fn, callExprs);
 


### PR DESCRIPTION
Non-default sized bools don't have their sizes properly preserved in
codegen. Removing ref temps causes these issues to be exposed. For now
just dont remove ref temps for any bool in a no-local compilation.
