### PR TITLE
Add a missing function call argument.

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -194,7 +194,7 @@ int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
   //
   static int numCpus = 0;
   if (numCpus == 0)
-    numCpus = chpl_getNumLogicalCpus();
+    numCpus = chpl_getNumLogicalCpus(true);
   return numCpus;
 #elif defined __linux__
   //


### PR DESCRIPTION
Oops!  Left the argument out of a call.  Add it.
