### PR TITLE
Update some error messages related to var functions

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5047,9 +5047,9 @@ preFold(Expr* expr) {
                     !ret->var->type->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
                     !ret->var->type->symbol->hasFlag(FLAG_ARRAY))
                   // Should this conditional include domains, distributions, sync and/or single?
-                  USR_FATAL(ret, "illegal return expression in var function");
+                  USR_FATAL(ret, "illegal expression to return by ref");
                 if (ret->var->isConstant() || ret->var->isParameter())
-                  USR_FATAL(ret, "var function returns constant value");
+                  USR_FATAL(ret, "function cannot return constant by ref");
               }
             }
           }

--- a/test/functions/bradc/varFns/retLitFromVarFn.good
+++ b/test/functions/bradc/varFns/retLitFromVarFn.good
@@ -1,2 +1,2 @@
 retLitFromVarFn.chpl:4: In function 'this':
-retLitFromVarFn.chpl:6: error: var function returns constant value
+retLitFromVarFn.chpl:6: error: function cannot return constant by ref

--- a/test/functions/bradc/varFns/retLocFromVarFn.good
+++ b/test/functions/bradc/varFns/retLocFromVarFn.good
@@ -1,2 +1,2 @@
 retLocFromVarFn.chpl:4: In function 'this':
-retLocFromVarFn.chpl:8: error: illegal return expression in var function
+retLocFromVarFn.chpl:8: error: illegal expression to return by ref

--- a/test/functions/deitz/test_var_function1.good
+++ b/test/functions/deitz/test_var_function1.good
@@ -1,2 +1,2 @@
 test_var_function1.chpl:5: In function 'bar':
-test_var_function1.chpl:6: error: illegal return expression in var function
+test_var_function1.chpl:6: error: illegal expression to return by ref

--- a/test/functions/deitz/test_var_function2.good
+++ b/test/functions/deitz/test_var_function2.good
@@ -1,2 +1,2 @@
 test_var_function2.chpl:2: In function 'A':
-test_var_function2.chpl:5: error: illegal return expression in var function
+test_var_function2.chpl:5: error: illegal expression to return by ref

--- a/test/functions/deitz/test_var_function_access.good
+++ b/test/functions/deitz/test_var_function_access.good
@@ -1,2 +1,2 @@
 test_var_function_access.chpl:5: In function 'bar':
-test_var_function_access.chpl:6: error: illegal return expression in var function
+test_var_function_access.chpl:6: error: illegal expression to return by ref

--- a/test/functions/deitz/test_var_function_access2.good
+++ b/test/functions/deitz/test_var_function_access2.good
@@ -1,2 +1,2 @@
 test_var_function_access2.chpl:5: In function 'bar':
-test_var_function_access2.chpl:6: error: illegal return expression in var function
+test_var_function_access2.chpl:6: error: illegal expression to return by ref

--- a/test/functions/deitz/test_var_function_return_expr.good
+++ b/test/functions/deitz/test_var_function_return_expr.good
@@ -1,2 +1,2 @@
 test_var_function_return_expr.chpl:3: In function 'foo':
-test_var_function_return_expr.chpl:4: error: illegal return expression in var function
+test_var_function_return_expr.chpl:4: error: illegal expression to return by ref

--- a/test/functions/diten/varFnRetClasses.good
+++ b/test/functions/diten/varFnRetClasses.good
@@ -1,1 +1,1 @@
-varFnRetClasses.chpl: 11: error: all return types must match exactly in var function
+varFnRetClasses.chpl: 11: error: all return types must match exactly to return by ref

--- a/test/functions/diten/varFnRetClasses2.good
+++ b/test/functions/diten/varFnRetClasses2.good
@@ -1,1 +1,1 @@
-varFnRetClasses2.chpl: 11: error: all return types must match in var function
+varFnRetClasses2.chpl: 11: error: all return types must match exactly to return by ref

--- a/test/functions/jplevyak/var_return-2.good
+++ b/test/functions/jplevyak/var_return-2.good
@@ -1,2 +1,2 @@
 var_return-2.chpl:4: In function 'f':
-var_return-2.chpl:5: error: illegal return expression in var function
+var_return-2.chpl:5: error: illegal expression to return by ref


### PR DESCRIPTION
After changing from `var` to `ref` for return intent, some error messages no longer made sense. These have been updated.
