### PR TITLE
Update SSCA2 comm count improvements!

### DIFF
--- a/test/studies/ssca2/performance/SSCA2_commDiags.good
+++ b/test/studies/ssca2/performance/SSCA2_commDiags.good
@@ -35,7 +35,7 @@ max number of outgoing edges 12
 number of disconnected vertices 2
 
 Kernel 2: (get = 10, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 7, fork = 0, fork_fast = 0, fork_nb = 6) (get = 44, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 0, fork = 8, fork_fast = 0, fork_nb = 0) (get = 40, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 0, fork = 4, fork_fast = 0, fork_nb = 0) (get = 40, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 0, fork = 4, fork_fast = 0, fork_nb = 0)
-Kernel 3: (get = 3670, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 0, fork = 1506, fork_fast = 0, fork_nb = 48) (get = 239, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 598, fork = 25, fork_fast = 0, fork_nb = 0) (get = 239, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 378, fork = 16, fork_fast = 0, fork_nb = 0) (get = 239, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 488, fork = 16, fork_fast = 0, fork_nb = 0)
+Kernel 3: (get = 3670, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 0, fork = 1464, fork_fast = 0, fork_nb = 48) (get = 158, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 598, fork = 25, fork_fast = 0, fork_nb = 0) (get = 158, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 378, fork = 16, fork_fast = 0, fork_nb = 0) (get = 158, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 488, fork = 16, fork_fast = 0, fork_nb = 0)
 
 
 Computing Betweenness Centrality exactly


### PR DESCRIPTION
SSCA2_commDiags has been failing for a while. Originally some associative changes
resulted in regressions for kernel 2. Those regressions should be addressed in
a separate commit. As a result of the regression there were two rather
significant improvements to kernel 3 that went unnoticed.

The number of forks improved with Vass's removal of coercion wrapper
elimination. cd0edadbfd0b599ef0f64471e52b5fe8ab057d60

The number of gets improved with my update to licm to hoist wide things.
75ada8e3483f72acfb50a9e1b3660fdb19ad2ebd
