### PR TITLE
Reducing potential comm counts in dsiAdd

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -237,6 +237,7 @@ module DefaultAssociative {
     }
   
     proc dsiAdd(idx: idxType, in slotNum : index(tableDom) = -1, haveLock = !parSafe): index(tableDom) {
+      const inSlot = slotNum;
       on this {
         const shouldLock = !haveLock && parSafe;
         if shouldLock then lockTable();
@@ -245,8 +246,10 @@ module DefaultAssociative {
           _resize(grow=true);
           findAgain = true;
         }
-        if findAgain then slotNum = -1;
-        slotNum = _add(idx, slotNum);
+        if findAgain then
+          slotNum = _add(idx, -1);
+        else
+          _add(idx, inSlot);
         if shouldLock then unlockTable();
       }
       return slotNum;


### PR DESCRIPTION
Thanks to @vasslitvinov for helping with this change.

Recent changes to dsiAdd resulted in higher comm counts for SSCA2_commDiags. By getting a const copy of the 'slotNum' argument, we can take advantage of remote value forwarding. We also restructure the call to _add based off of the 'findAgain' bool. These two changes should result in fewer comm counts, and in general a cleaner code structure.
