### PR TITLE
Updating re2 build to use -mmic for intel+knc builds

### DIFF
--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -20,6 +20,15 @@ else
   RE_DEBUG_CXX += -DNDEBUG
 endif
 
+#
+# if compiling for knc with intel, add the -mmic flag
+#
+ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),intel)
+CHPL_RE2_CXXFLAGS=-mmic
+endif
+endif
+
 RE2_FILE := $(RE2_INSTALL_DIR)/include/re2/re2.h
 
 default: $(RE2_FILE)
@@ -37,7 +46,13 @@ clobber: FORCE
 
 $(RE2_FILE):
 	if [ ! -d re2 ]; then ./unpack-re2.sh; fi
-	cd re2 && $(MAKE) clean && $(MAKE) CC=$(CC) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX)" && $(MAKE) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX)" prefix=$(RE2_INSTALL_DIR) install && mkdir -p ../build/$(RE2_UNIQUE_SUBDIR) && rm -rf ../build/$(RE2_UNIQUE_SUBDIR) && mv obj ../build/$(RE2_UNIQUE_SUBDIR)
+	cd re2 && \
+	$(MAKE) clean && \
+	$(MAKE) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)" && \
+	$(MAKE) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)" prefix=$(RE2_INSTALL_DIR) install && \
+	mkdir -p ../build/$(RE2_UNIQUE_SUBDIR) && \
+	rm -rf ../build/$(RE2_UNIQUE_SUBDIR) && \
+	mv obj ../build/$(RE2_UNIQUE_SUBDIR)
 
 re2: $(RE2_FILE)
 


### PR DESCRIPTION
Following the lead of other third-party Makefiles, if we're building for
KNC using the intel compiler, throw the -mmic flag when building re2.
While here, I did some other cleanup:
- broke a long line of commands across several lines
- passed CXX into both recursive make steps just for symmetry (I don't
  believe it's used for the install step)
- removed the set of CC as it doesn't seem to be used by re2's Makefile
