### PR TITLE
Building static re2 library only by default

### DIFF
--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -48,8 +48,8 @@ $(RE2_FILE):
 	if [ ! -d re2 ]; then ./unpack-re2.sh; fi
 	cd re2 && \
 	$(MAKE) clean && \
-	$(MAKE) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)" && \
-	$(MAKE) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)" prefix=$(RE2_INSTALL_DIR) install && \
+	$(MAKE) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)" obj/libre2.a && \
+	$(MAKE) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)" prefix=$(RE2_INSTALL_DIR) install-static && \
 	mkdir -p ../build/$(RE2_UNIQUE_SUBDIR) && \
 	rm -rf ../build/$(RE2_UNIQUE_SUBDIR) && \
 	mv obj ../build/$(RE2_UNIQUE_SUBDIR)

--- a/third-party/re2/Makefile.install-static
+++ b/third-party/re2/Makefile.install-static
@@ -1,0 +1,5 @@
+
+install-static: obj/libre2.a
+	mkdir -p $(DESTDIR)$(includedir)/re2 $(DESTDIR)$(libdir)
+	$(INSTALL_DATA) $(INSTALL_HFILES) $(DESTDIR)$(includedir)/re2
+	$(INSTALL) obj/libre2.a $(DESTDIR)$(libdir)/libre2.a

--- a/third-party/re2/unpack-re2.sh
+++ b/third-party/re2/unpack-re2.sh
@@ -12,6 +12,7 @@ tar xzf re2-20140111.tgz
 echo Applying Patches
 cd re2
 patch -p1 < ../hg_diff_g.patch
+cat ../Makefile.install-static >> Makefile 
 echo Copying file_strings.h and file_strings.cc
 cp ../file_strings.h re2/
 cp ../file_strings.cc re2/


### PR DESCRIPTION
Prior to this change, we built .a and .so libraries for re2.  This
causes problems for the Cray module build because the .so carries
dependences in the RPM that we don't intend for it to.  Looking
at other third-party packages (qthreads, hwloc), we seem to get
away with building static libraries only, so let's do the same for
re2 to keep things simple.

Unfortunately, implementing this change was not as simple as hoped
since re2 is not an autoconf package (I never thought I'd wish for
an autoconf package).  Its makefiles are hardcoded to build both
the .a and .so, so I changed our first build command to target
the .a directly and then had to add a new install-static command
that only installed the static library, not the .so.  Because re2
lives its life in git as a bundle, this meant tacking a little
Makefile stub onto the end of their Makefile after unpacking (ugh--
maybe we've crossed the barrier where keeping re2 bundled is not
worth the pain anymore?  But I didn't have the guts to make that
change this late in the release cycle).

Tested by clobbering re2, making, inspecting that the .so was not
there and that test/regexp/ferguson/regex.chpl still worked.
