### PR TITLE
Silencing coverity issues

### DIFF
--- a/runtime/src/chplisdir.c
+++ b/runtime/src/chplisdir.c
@@ -24,15 +24,22 @@
 #include <unistd.h>
 #include "chplisdir.h"
 #include "chplrt.h"
+#include "error.h"
 
 int chpl_rt_isDir(const char* pathname, chpl_bool followLinks) {
   struct stat fileinfo;
   if (followLinks) {
-    stat(pathname, &fileinfo);
+    int status = stat(pathname, &fileinfo);
+    if (status) {
+      chpl_internal_error("Fatal error in stat()");
+    }
     return S_ISDIR(fileinfo.st_mode);
     /*  return fileinfo.st_mode & S_IFDIR;*/
   } else {
-    lstat(pathname, &fileinfo);
+    int status = lstat(pathname, &fileinfo);
+    if (status) {
+      chpl_internal_error("Fatal error in lstat()");
+    }
     if (fileinfo.st_mode & S_IFLNK) {
       return false;
     } else {


### PR DESCRIPTION
[trivial, not reviewed]

Coverity wisely warned about not looking at the return values of
stat() and lstat(), which I had ignored in my first implementation.
Here, I throw an internal error if they fail which is a lame-ish
short-term fix that I took, knowing that the isDir()/isLink()
utilities are right around the corner, will have good error
handling, and that I can use them once they're available.
