### PR TITLE
Fixing C declaration of main() in test

### DIFF
--- a/test/Samples/Performance/foo-c.test.c
+++ b/test/Samples/Performance/foo-c.test.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-int main(int argc, char* argv) {
+int main(int argc, char* argv[]) {
   printf("Time: %g seconds\n", 183.7);
   printf("Memory: %d GB\n", 24);
   printf("Validation: SUCCESS\n");


### PR DESCRIPTION
Sadly, darwin was the only platform kind enough to complain about this
thinko.
