### PR TITLE
Adding HeapSort and reverse argument to Sort section of spec

### DIFF
--- a/spec/Standard_Modules.tex
+++ b/spec/Standard_Modules.tex
@@ -939,7 +939,7 @@ optional boolean argument, \chpl{reverse}, which is \chpl{false} by
 default. If \chpl{true}, then the sort function will order in reverse.
 
 \begin{protohead}
-proc BubbleSort(Data: [?Dom]) where Dom.rank == 1
+proc BubbleSort(Data: [?Dom], reverse : bool = false) where Dom.rank == 1
 \end{protohead}
 \begin{protobody}
 Sorts the 1D array \chpl{Data} in-place using a sequential bubble sort
@@ -947,7 +947,7 @@ algorithm.
 \end{protobody}
 
 \begin{protohead}
-proc HeapSort(Data: [?Dom]) where Dom.rank == 1
+proc HeapSort(Data: [?Dom], reverse : bool = false) where Dom.rank == 1
 \end{protohead}
 \begin{protobody}
 Sorts the 1D array \chpl{Data} in-place using a sequential heap sort
@@ -955,7 +955,7 @@ algorithm.
 \end{protobody}
 
 \begin{protohead}
-proc InsertionSort(Data: [?Dom]) where Dom.rank == 1
+proc InsertionSort(Data: [?Dom], reverse : bool = false) where Dom.rank == 1
 \end{protohead}
 \begin{protobody}
 Sorts the 1D array \chpl{Data} in-place using a sequential insertion
@@ -963,7 +963,7 @@ sort algorithm.
 \end{protobody}
 
 \begin{protohead}
-proc MergeSort(Data: [?Dom], minlen=16) where Dom.rank == 1
+proc MergeSort(Data: [?Dom], reverse : bool = false, minlen=16) where Dom.rank == 1
 \end{protohead}
 \begin{protobody}
 Sorts the 1D array \chpl{Data} using a parallel merge sort algorithm.
@@ -974,7 +974,7 @@ insertion sort algorithm will be used.
 \end{protobody}
 
 \begin{protohead}
-proc QuickSort(Data: [?Dom], minlen=16) where Dom.rank == 1
+proc QuickSort(Data: [?Dom], reverse : bool = false, minlen=16) where Dom.rank == 1
 \end{protohead}
 \begin{protobody}
 Sorts the 1D array \chpl{Data} in-place using a sequential
@@ -985,7 +985,7 @@ algorithm will be used.
 \end{protobody}
 
 \begin{protohead}
-proc SelectionSort(Data: [?Dom]) where Dom.rank == 1
+proc SelectionSort(Data: [?Dom], reverse : bool = false) where Dom.rank == 1
 \end{protohead}
 \begin{protobody}
 Sorts the 1D array \chpl{Data} in-place using a sequential selection


### PR DESCRIPTION
The 'HeapSort' argument had been overlooked and should be added to the spec. The 'reverse' argument was added during this last release cycle to all standard Sort functions.
