### PR TITLE
Fix failing .bad file diff comparison on Mac.

### DIFF
--- a/util/test/diff-ignoring-module-line-numbers
+++ b/util/test/diff-ignoring-module-line-numbers
@@ -9,8 +9,8 @@
 badfile=$1
 tmpfile=$2
 
-badtmp=`mktemp`
-tmptmp=`mktemp`
+badtmp=`mktemp "bad.XXXXXX"`
+tmptmp=`mktemp "tmp.XXXXXX"`
 
 sed -e "\|CHPL_HOME/modules|s/:[0-9]\+:/:nnnn:/" $badfile > $badtmp
 sed -e "\|CHPL_HOME/modules|s/:[0-9]\+:/:nnnn:/" $tmpfile > $tmptmp


### PR DESCRIPTION
The Mac version of "mktemp" requires a template argument.  "How quaint."
