### PR TITLE
Unload cray-libsci for whitebox testing.

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -78,8 +78,11 @@ case $COMPILER in
         ;;
 esac
 
-log_info "Unloading cray-libsci module."
-module unload cray-libsci
+libsci_module=$(module list -t 2>&1 | grep libsci)
+if [ -n "${libsci_module}" ] ; then
+    log_info "Unloading cray-libsci module: ${libsci_module}"
+    module unload $libsci_module
+fi
 
 export CHPL_HOME=$(cd $CWD/../.. ; pwd)
 


### PR DESCRIPTION
This was previously done when testing the cray compiler (cce) on
whiteboxes. However, cray-libsci's precense started having issues with other
programming environments recently. So, it is time to unload it for all envs.

It is worth noting, internally the Chapel binary release for Cray systems is
built and tested with cray-libsci module loaded.
