### PR TITLE
Fix threadring slurm complaint

### DIFF
--- a/test/parallel/taskCompare/lydia/coforall-begin.chpl
+++ b/test/parallel/taskCompare/lydia/coforall-begin.chpl
@@ -19,6 +19,10 @@
 
 ***/
 
+// SLURM NOTE: An error of this kind may occur under certain circumstances
+// slurmstepd: Terminating job step 133149.0; task 0 exit code 0 exited without notification
+// We are, in fact, exiting with 0, as it notices.
+
 config const N = 1000, nthreads = 503, verbose = false;
 var D: domain(1) = {1..nthreads};
 var token: [D] sync int;

--- a/test/parallel/taskCompare/lydia/coforall.chpl
+++ b/test/parallel/taskCompare/lydia/coforall.chpl
@@ -19,6 +19,10 @@
 
 ***/
 
+// SLURM NOTE: An error of this kind may occur under certain circumstances
+// slurmstepd: Terminating job step 133149.0; task 0 exit code 0 exited without notification
+// We are, in fact, exiting with 0, as it notices.
+
 config const N = 1000, nthreads = 503, verbose = false;
 var D: domain(1) = {1..nthreads};
 var token: [D] sync int;

--- a/test/parallel/taskCompare/lydia/for-begin.chpl
+++ b/test/parallel/taskCompare/lydia/for-begin.chpl
@@ -19,6 +19,10 @@
 
 ***/
 
+// SLURM NOTE: An error of this kind may occur under certain circumstances
+// slurmstepd: Terminating job step 133149.0; task 0 exit code 0 exited without notification
+// We are, in fact, exiting with 0, as it notices.
+
 config const N = 1000, nthreads = 503, verbose = false;
 var D: domain(1) = {1..nthreads};
 var token: [D] sync int;

--- a/test/release/examples/benchmarks/shootout/threadring.chpl
+++ b/test/release/examples/benchmarks/shootout/threadring.chpl
@@ -42,11 +42,12 @@ proc main() {
 proc passTokens(id) {
   while (true) {
     const t = token$[id];
-    if t <= n {
-      token$[id%nthreads+1] = t+1;
-    } else {
+    token$[id%nthreads+1] = t+1;
+    if t == n + 1 {
       writeln(id);
-      exit(0);
+      return;
+    } else if t > n {
+      return;
     }
   }
 }


### PR DESCRIPTION
Slurm was complaining because threadring was calling exit(0).  Cause that not
to happen, and note that these tests will have it happen if they are run with
Slurm.
