### PR TITLE
Quiet new string tests.

### DIFF
--- a/test/types/string/StringImpl/memLeaks/promotion.compopts
+++ b/test/types/string/StringImpl/memLeaks/promotion.compopts
@@ -1,0 +1,1 @@
+--dataParTasksPerLocale=1


### PR DESCRIPTION
- Throw --dataParTasksPerLocale=1 for promotion.chpl.  Using one tasks
  leads to consistent results and still tests what was originally
  intended (promotion, not task creation).
- Clarify comment in promotion.chpl
- Add another leakable type to begin.prediff (string reference count).
- Flush writes before checking memory to make sure that I/O buffers
  are freed.
