### PR TITLE
Add missing READMEs to list of READMEs.

### DIFF
--- a/doc/release/README
+++ b/doc/release/README
@@ -26,7 +26,7 @@ This directory contains the following documentation:
                           Cray CS(TM) series
     README.cygwin      :  Cygwin
     README.ibm         :  IBM
-    README.knc         :  using Chapel with Intel Phi
+    README.knc         :  Intel Xeon Phi (Knights Corner)
     README.macosx      :  Mac
     README.marenostrum :  MareNostrum (at BSC)
     README.sgi         :  SGI Altix


### PR DESCRIPTION
We were missing references to README.knc, README.curl, README.auxIO
