### PR TITLE
Adding cygwin to the list of platforms that use /proc/cpuinfo for this test

### DIFF
--- a/test/localeModels/gbt/maxTaskPar.prediff
+++ b/test/localeModels/gbt/maxTaskPar.prediff
@@ -7,7 +7,7 @@ locModel=$($CHPL_HOME/util/chplenv/chpl_locale_model.py)
 tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
 
 case $target in
-  linux*|cray-xc|cray-xe)
+  linux*|cray-xc|cray-xe|cygwin)
     case $locModel-$tasks in
       *-fifo|*-massivethreads|flat-qthreads)
         numPUs=$( grep -c '^processor[[:space:]]\+: ' /proc/cpuinfo )


### PR DESCRIPTION
Cygwin has a /proc/cpuinfo, so should use the same rule as other
platforms.  Unfortunately, it doesn't have a 'siblings' entry
(at least for my laptop), so it doesn't work.  We may have better
luck on the official test platform.  In any case, this is a
step in the right direction.

I've proposed to Greg that we should make the default case
optimistically use /proc/cpuinfo rather than making it an
error case so that other platforms that support /proc/cpuinfo
will work without human intervention (and if they don't work,
a similar amount of developer intervention is required as if
it gets a cleaner error message).
