### PR TITLE
Skip pidigits if --llvm is a compopts flag.

### DIFF
--- a/test/release/examples/benchmarks/shootout/pidigits.skipif
+++ b/test/release/examples/benchmarks/shootout/pidigits.skipif
@@ -1,2 +1,3 @@
 # Tests in this directory assume we can use GMP
 CHPL_GMP == none
+COMPOPTS <= llvm


### PR DESCRIPTION
LLVM and GMP do not play well together. This updates pidigits.chpl to only run when `--llvm`
is not set for compile. This should fix the pidigits issue under llvm testing.
