### PR TITLE
Build gmp static only

### DIFF
--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -27,7 +27,7 @@ endif
 # On Cray systems, building the shared libraries causes issues.
 # On Macs, not building the shared libraries causes warnings.
 #
-ifneq (, $(filter cray-%,$(CHPL_MAKE_TARGET_PLATFORM)))
+ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_CFG_OPTIONS += --enable-static --disable-shared
 endif
 


### PR DESCRIPTION
[co-developed with Thomas]

It turns out that when speculatively building GMP using Cray PrgEnv's
using our existing Makefile logic, we get build errors due to its attempt
to build/test .so files.  Note that for most other third-party packages,
we don't build .so files and that GMP is somewhat of an outlier in this
regard.

For those who track these things, the original proposal was going to be to
disable-shared for all builds, similar to what we do for most other
third-party packages.  The reason we backed away from this and only did it
for Crays was (a) disabling shared resulted in warnings when compiling GMP
programs on Macs and (b) it minimizes the delta for other platforms
relative to what we've been testing for the past several months.
