### PR TITLE
Revert "Disable pidigits for llvm"

### DIFF
--- a/util/cron/common-llvm.bash
+++ b/util/cron/common-llvm.bash
@@ -6,6 +6,3 @@ export CHPL_LLVM=llvm
 
 # Run examples and test/extern/ferguson/.
 export CHPL_START_TEST_ARGS="release/examples extern/ferguson"
-
-# llvm and gmp do not (yet) work together
-export CHPL_GMP=none


### PR DESCRIPTION
Reverts chapel-lang/chapel#487

Upon further discussion, it is desirable to leave this as a regression. If/When llvm becomes the default
backend, the lack of gmp support with llvm will be easier to see with this regression.
