### PR TITLE
Add chpl_task_yield() to assoc stress tests to quiet testing.

### DIFF
--- a/test/domains/sungeun/assoc/stress.chpl
+++ b/test/domains/sungeun/assoc/stress.chpl
@@ -43,6 +43,7 @@ sync serial doSerial || (!doSerial && !parSafe) {
         begin totalRemoved = totalRemoved + 1;
       }
     }
+    chpl_task_yield();
   }
 }
 

--- a/test/domains/sungeun/assoc/stress.numthr.chpl
+++ b/test/domains/sungeun/assoc/stress.numthr.chpl
@@ -43,6 +43,7 @@ sync serial doSerial || (!doSerial && !parSafe) {
         begin totalRemoved = totalRemoved + 1;
       }
     }
+    chpl_task_yield();
   }
 }
 


### PR DESCRIPTION
These tests have been timing out intermittently in nightly testing. They usually
finish fairly quickly, but every now and again they run absurdly slow (though
I'm pretty sure they're still making progress)

This just adds chpl_task_yield()'s to quiet testing. This is NOT a fix for the
core problem.

This is one of the tests that deadlocked with the switch from sherwood to
nemesis for qthreads scheduler. The core issue was that tasks get assigned to
workers round robin and the tasks that are incrementing a sync variable were
being assigned to a worker that was waiting for the sync variable to have a
certain value, and that task was never yielding. There were several commits to
address that and this test always passes given enough time, but for some reason
it finishes slowly sometimes.

There is a pivotal item to make sure we don't forget about this:
https://www.pivotaltracker.com/n/projects/1028642/stories/79146968

We don't believe this is a big issue, or one that has performance/correctness
implications for "real" tests.
