### PR TITLE
Update README.chplenv for release.

### DIFF
--- a/man/chpl.txt
+++ b/man/chpl.txt
@@ -439,21 +439,58 @@ ENVIRONMENT
   settings (as explicitly set and inferred). Some of the most
   commonly-used environment variables are summarized here.
 
-  CHPL_ATOMICS        Specifies the implementation to use for Chapel's atomic
-                      variables (defaults to a best guess based on
-                      $CHPL_TARGET_COMPILER, $CHPL_TARGET_PLATFORM, and
-                      $CHPL_COMM).
+  CHPL_HOME           Specifies the location of the Chapel installation directory.
 
-  CHPL_AUX_FILESYS    Specify runtime support for additional file
-                      systems (defaults to 'none').
+  CHPL_HOST_PLATFORM  Specifies the platform on which the Chapel compiler is
+                      running (defaults to our best guess).
+
+  CHPL_TARGET_PLATFORM   Specifies the platform on which the target executable
+                         is to be run for the purposes of cross-compiling
+                         (defaults to $CHPL_HOST_PLATFORM).
+
+  CHPL_HOST_COMPILER  Specifies the compiler suite that should be used
+                      to build the Chapel compiler (defaults to a best
+                      guess based on $CHPL_HOST_PLATFORM).
+
+  CHPL_TARGET_COMPILER  Specifies the compiler suite that should be used
+                      to build the generated C code for a Chapel program
+                      and the Chapel runtime (defaults to a best guess 
+                      based on $CHPL_HOST_PLATFORM, $CHPL_TARGET_PLATFORM,
+                      and $CHPL_HOST_COMPILER).
+
+  CHPL_TARGET_ARCH    Specifies the architecture that the compiled executable
+                      will be specialized to when --specialize is enabled
+                      (defaults to a best guess based on $CHPL_COMM,
+                      $CHPL_TARGET_COMPILER, and $CHPL_TARGET_PLATFORM).
+
+  CHPL_LOCALE_MODEL   Specifies the locale model to use for describing
+                      your locale architecture (defaults to 'flat')
 
   CHPL_COMM           Specifies the communication layer to use for
                       inter-locale data transfers (defaults to 'none').
 
-  CHPL_DEVELOPER      When set, build and compile in developer mode,
-                      which generates line numbers in internal module
-                      code and throws extra warning flags when
-                      compiling the generated C code.
+  CHPL_TASKS          Specifies the tasking layer to use for implementing
+                      tasks (defaults to a best guess based on
+                      $CHPL_TARGET_PLATFORM).
+
+  CHPL_LAUNCHER       Specifies the launcher, if any, used to start job
+                      execution (defaults to a best guess based on
+                      $CHPL_COMM and $CHPL_TARGET_PLATFORM).
+
+  CHPL_TIMERS         Specifies a timer implementation to be used by
+                      the Time module (defaults to 'generic').
+
+  CHPL_MEM            Specifies the memory allocator used for dynamic memory
+                      management (defaults to a best guess based on $CHPL_COMM).
+
+  CHPL_MAKE           Specifies the GNU compatible make utility
+                      (defaults to a best guess based on
+                      $CHPL_HOST_PLATFORM).
+
+  CHPL_ATOMICS        Specifies the implementation to use for Chapel's atomic
+                      variables (defaults to a best guess based on
+                      $CHPL_TARGET_COMPILER, $CHPL_TARGET_PLATFORM, and
+                      $CHPL_COMM).
 
   CHPL_GMP            Specifies the GMP library implementation to be
                       used by the GMP module (defaults to a best guess
@@ -461,36 +498,28 @@ ENVIRONMENT
                       you've built the included GMP library in the
                       third-party directory).
 
-  CHPL_HOME           Specifies the location of the Chapel installation directory.
-
-  CHPL_HOST_COMPILER  Specifies the compiler suite that should be used
-                      to build the Chapel compiler (defaults to a best
-                      guess based on $CHPL_HOST_PLATFORM).
-
-  CHPL_HOST_PLATFORM  Specifies the platform on which the Chapel compiler is
-                      running (defaults to our best guess).
-
   CHPL_HWLOC          Specifies whether or not to use the hwloc library
                       (defaults to a best guess based on whether you've
                       built the included library in the third-party
                       hwloc directory).
 
-  CHPL_LAUNCHER       Specifies the launcher, if any, used to start job
-                      execution (defaults to a best guess based on
-                      $CHPL_COMM and $CHPL_TARGET_PLATFORM).
+  CHPL_REGEXP         Specifies the regular expression library to use
+                      (defaults to 'none' or 're2' if you've installed
+                      the re2 package in the third-party directory).
+
+  CHPL_WIDE_POINTERS  Specifies the wide porter format format
+                      (defaults to 'struct').
 
   CHPL_LLVM           When set to 'llvm', use the LLVM/Clang back-end
                       (defaults to 'none').
 
-  CHPL_LOCALE_MODEL   Specifies the locale model to use for describing
-                      your locale architecture (defaults to 'flat')
+  CHPL_AUX_FILESYS    Specify runtime support for additional file
+                      systems (defaults to 'none').
 
-  CHPL_MAKE           Specifies the GNU compatible make utility
-                      (defaults to a best guess based on
-                      $CHPL_HOST_PLATFORM).
-
-  CHPL_MEM            Specifies the memory allocator used for dynamic memory
-                      management (defaults to a best guess based on $CHPL_COMM).
+  CHPL_DEVELOPER      When set, build and compile in developer mode,
+                      which generates line numbers in internal module
+                      code and throws extra warning flags when
+                      compiling the generated C code.
 
   CHPL_MODULE_PATH    Specifies a list of colon-separated directories to be 
                       added to the module search path. The module search path
@@ -511,35 +540,6 @@ ENVIRONMENT
                       left-to-right order), (3) all directories specified by the
                       $CHPL_MODULE_PATH environment variable, (4) the
                       compiler's standard module search path. 
-
-  CHPL_REGEXP         Specifies the regular expression library to use
-                      (defaults to 'none' or 're2' if you've installed
-                      the re2 package in the third-party directory).
-
-  CHPL_TARGET_ARCH    Specifies the architecture that the compiled executable
-                      will be specialized to when --specialize is enabled
-                      (defaults to a best guess based on $CHPL_COMM,
-                      $CHPL_TARGET_COMPILER, and $CHPL_TARGET_PLATFORM).
-
-  CHPL_TARGET_COMPILER  Specifies the compiler suite that should be used
-                      to build the generated C code for a Chapel program
-                      and the Chapel runtime (defaults to a best guess 
-                      based on $CHPL_HOST_PLATFORM, $CHPL_TARGET_PLATFORM,
-                      and $CHPL_HOST_COMPILER).
-
-  CHPL_TARGET_PLATFORM   Specifies the platform on which the target executable
-                         is to be run for the purposes of cross-compiling
-                         (defaults to $CHPL_HOST_PLATFORM).
-
-  CHPL_TASKS          Specifies the tasking layer to use for implementing
-                      tasks (defaults to a best guess based on
-                      $CHPL_TARGET_PLATFORM).
-
-  CHPL_TIMERS         Specifies a timer implementation to be used by
-                      the Time module (defaults to 'generic').
-
-  CHPL_WIDE_POINTERS  Specifies the wide porter format format
-                      (defaults to 'struct').
 
 
 BUGS


### PR DESCRIPTION
In README.chplenv, CHPL_MODULE_PATH was not mentioned, so I added an "Optionally ..."
section to cover it.  I also mention that "curl" is now a valid setting for
CHPL_AUX_FILESYS, and direct readers to technotes/README.curl for details.
