### PR TITLE
Use copy and remove instead of move in nightly.

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -702,7 +702,7 @@ if ($runtests == 0) {
         print "Executing $testcommand\n";
         $status = mysystem($testcommand, "running standard tests", 0, 0);
         print "Moving the log and summary files\n";
-        mysystem("cd $testdir && mv -v $rawlog $permlog && mv -v $rawsummary $permsum", "moving the log files", 0, 0);
+        mysystem("cd $testdir && cp -v $rawlog $permlog && rm $rawlog && cp -v $rawsummary $permsum && rm $rawsummary", "moving the log files", 0, 0);
         $rawlog = $permlog;
         $rawsummary = $permsum;
     } else {


### PR DESCRIPTION
This works around a permissions issue when the destination is a CIFS share on a mac.
