### PR TITLE
Housekeeping on CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,7 +43,7 @@ James Dinan, Cray Inc./The Ohio State University
 Martha Dumler, Cray Inc.
 Saliya Ekanayake, Indiana University
 Samuel Figueroa, Cray Inc.
-Roald Frederickx, personal
+Roald Frederickx, individual contributor
 Alexey Gokhberg, Unicorn Enterprises SA
 Paul Hargrove, Lawrence Berkeley National Laboratory
 Akihiro Hayashi, Rice University
@@ -51,7 +51,6 @@ Hannah Hemmaplardh, Cray Inc./University of Washington
 Steven Hemmy, Cray Inc./University of Wisconsin
 Shannon Hoffswell, Cray Inc.
 Mary Beth Hribar, Cray Inc.
-Mark James, JPL
 Mackale Joyner, Cray Inc./Rice University
 Jessica Jueckstock, MITRE
 John Koenig, Cray Inc.
@@ -71,11 +70,10 @@ Darren Smith, University of Maryland
 Rachel Sobel, Cray Inc./University of Washington
 Srinivas Sridharan, University of Notre Dame/ORNL
 Andy Stone, Cray Inc./University of Colorado
-Chris Swenson
+Chris Swenson, individual contributor
 Jonathan Turner, Cray Inc./CU Boulder
 Wayne Wong, Cray Inc.
 Joe Yan, University of Maryland
-Hans Zima, CalTech/JPL
 
 
 We are also grateful to our many enthusiastic and vocal users for


### PR DESCRIPTION
We've decided to focus the CONTRIBUTORS file here on those who have
contributed to the implementation rather than the language design
itself (such contributors are acknowledged in the language spec
itself).  To that end, removing Mark James and Hans Zima who did not
contribute code that ended up in the release or repository I can
recall or find in the logs.

Unifying to the term "individual contributor" for those who did not
contribute through an official organization or whose affiliation has
been lost.
