### PR TITLE
Add info for reviewers of outside developer commits.

### DIFF
--- a/doc/developer/bestPractices/ContributorInfo.txt
+++ b/doc/developer/bestPractices/ContributorInfo.txt
@@ -154,13 +154,14 @@ Reviewer Responsibilities
   team, be sure they have signed the contributor's agreement (see the
   `Developer Workflow`_ instructions for this).  If the developer cannot
   or will not sign the agreement, bring the situation to the attention
-  of the Chapel manager.  It may be possible to accept their work
-  anyway, but this has to be handled on a case by case basis.
+  of the Chapel project leadership.
 
-  As an example, at one point in the past we committed a copy of an
-  outside commit that had originally been done in one of our third-party
-  package's (git) repositories.  We did that by using git-am to commit a
-  copy of their raw commit (in git-send-mail format) to the appropriate
+  Care may need to be taken when committing third-party code that
+  originates from a different git[hub] repository.  As an example, in
+  one case in the past we brought in a copy of an outside commit that
+  had originally been made in the git repository belonging to one of our
+  third-party packages.  We did that by using git-am to commit a copy of
+  their raw commit (in git-send-mail format) to the appropriate
   third-party directory in the Chapel repository.  For the commit in our
   repo, their developer was listed as the author, but the Chapel core
   team member who did the Chapel commit was listed as the contributor.


### PR DESCRIPTION
Add the start of a section that talks about the responsibilities of
Chapel core team reviewers of outside developers' commits.

While here, fix a typo in a cross-ref.
