### PR TITLE
Update the do-while section with a discussion of unusual variable scoping

### DIFF
--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -434,8 +434,9 @@ one important regard.  If the body of a do-while statement is a block
 statement and new variables are defined within that block statement,
 then the scope of those variables extends to cover the loop's
 termination expression.
-\begin{chapelexample}{dowhile.chpl} The following example demonstrates that
-the scope of the variable t includes the loop termination expression.
+\begin{chapelexample}{do-while.chpl}
+The following example demonstrates that the scope of the variable t 
+includes the loop termination expression.
 \begin{chapel}
 var i = 0;
 do {


### PR DESCRIPTION
It is unusual, but appealing, that the scope of variables defined in the body of a do-while loop
extends to cover the do-while termination expression.  Update the spec to discuss this.

Tested the example code off-line to avoid any problems in weekend nightly builds.
