### PR TITLE
Fix nightly sendmail call arguments for multiple addresses.

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -351,7 +351,14 @@ if ($debug == 1) {
     $nochangerecipient = $debugmail;
 } else {
     $subjectid = "Cron$subjectid";
-    $recipient = "$failuremail $allmail";
+
+    # "email", the mailer program used on cygwin platform, requires multiple
+    # recipient addresses to be comma delimited instead of space delimited.
+    if ($mailer eq "email") {
+        $recipient = "$failuremail,$allmail";
+    } else {
+        $recipient = "$failuremail $allmail";
+    }
     $nochangerecipient = $allmail;
 }
 


### PR DESCRIPTION
On cygwin, the mailer program is "email" instead of "Mail". "email" requires
multiple recipient addresses to be comma delimited instead of space
delimited. Update "nightly" script to comma delimit the addresses when using
email program.
