### PR TITLE
Added README.typeQueries and references to it.

### DIFF
--- a/doc/release/README
+++ b/doc/release/README
@@ -53,6 +53,7 @@ This directory contains the following documentation:
     README.main             :  defining the 'main()' routine  TODO
     README.module_search    :  how modules are searched for to fulfill 'use's
     README.regexp           :  using regular expressions in Chapel
+    README.typeQueries      :  type query functions provided by Types module
     README.sets             :  set operations on associative arrays and domains
     README.subquery         :  querying the index set owned by a locale
 

--- a/doc/release/technotes/README.typeQueries
+++ b/doc/release/technotes/README.typeQueries
@@ -1,0 +1,74 @@
+================
+is* Type Queries
+================
+
+The Types module provides the a set of type query functions
+in addition to the ones documented in the Spec.
+
+These functions:
+* are 'param' procedures
+* are not methods
+* return a boolean
+* are always available to a Chapel program
+
+The naming and interface of these functions follow this pattern:
+
+  // is the argument a 'record' type?
+  proc isRecordType(type t) param ...
+  proc isRecord(type t)     param return isRecordType(t);
+
+  // is the type of the argument a 'record' type?
+  proc isRecord(e)          param ...
+
+
+(A) These queries check whether the argument is or has the
+corresponding type:
+
+  isVoid
+  isBool
+  isInt
+  isUint
+  isReal
+  isImag
+  isComplex
+  isString
+
+  isEnum
+  isTuple
+  isHomogeneousTuple  // see NOTE at end
+
+  isClass
+  isRecord
+  isUnion
+
+  isRange
+  isDmap              // a dmap-wrapped distribution
+  isDomain
+  isArray
+
+  isSync
+  isSingle
+  isAtomic
+
+
+(B) These aggregate queries are also provided:
+
+  isFloat      // real, imag
+  isIntegral   // int, uint
+  isNumeric    // int, uint, real, imag, complex
+
+  isPrimitive  // primitive type as defined by the spec:
+               //   void, bool, int, uint, real, imag, complex, string
+
+
+(C) These queries indicate the kind of argument:
+
+  isType(arg)   - true when the argument is a type, false otherwise
+  isParam(arg)  - true when the argument is a param, false otherwise
+
+There is no isTypeType or isParamType variants of these functions.
+
+
+NOTE: isHomogeneousTuple(arg) is not defined when 'arg' is of a non-tuple
+type. It is always defined if 'arg' itself is a type, whether it is
+a tuple type or not.

--- a/spec/Standard_Modules.tex
+++ b/spec/Standard_Modules.tex
@@ -630,6 +630,9 @@ This is implemented for all numeric types and fixed-width \chpl{bool} types.
 It is not implemented for default-width \chpl{bool}.
 \end{protobody}
 
+The \chpl{Types} module also provides a set of type queries.
+These are documented in the following README in the Chapel release:
+\chpl{doc/technotes/README.typeQueries} .
 
 
 \section{Optional Modules}


### PR DESCRIPTION
This file documents the isXxx functions added in #212.

Brad and I decided not to document these functions properly in Standard_Modules.tex to save time. We expect that Standard_Modules.tex will be replaced with chapeldocs soon.

I reference this README from doc/release/README and from Standard_Modules.tex.
