### PR TITLE
Fix for Coverity bug 1212416

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -271,8 +271,6 @@ returnInfoGetMemberRef(CallExpr* call) {
     return field->type->refType ? field->type->refType : field->type;
   } else
     return var->type->refType ? var->type->refType : var->type;
-  INT_FATAL(call, "bad member primitive");
-  return NULL;
 }
 
 static Type*


### PR DESCRIPTION
Coverity correctly pointed out that returnInfoGetMemberRef had an INT_FATAL call
and a return statement that would never be reached, as the if/else branch above
it had a return statement at the close of both branches.  I have removed these
lines and tested this over std.
