### PR TITLE
Fix Coverity issues 1212401 and 1212402

### DIFF
--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -788,10 +788,10 @@ void CondStmt::verify() {
     INT_FATAL(this, "CondStmt::elseStmt is a list");
   }
 
-  if (condExpr && condExpr->parentExpr != this)
+  if (condExpr->parentExpr != this)
     INT_FATAL(this, "Bad CondStmt::condExpr::parentExpr");
 
-  if (thenStmt && thenStmt->parentExpr != this)
+  if (thenStmt->parentExpr != this)
     INT_FATAL(this, "Bad CondStmt::thenStmt::parentExpr");
 
   if (elseStmt && elseStmt->parentExpr != this)


### PR DESCRIPTION
In stmt.cpp, Coverity noticed that there were null checks for two variables that
had already been checked.  While what it complained about was the possibility
that the later dereference was to a null pointer, it was fair to point out that
the variables did not need to be checked again.  I believe that removing the
additional check will resolve these issues.
