### PR TITLE
Fix for Coverity issue 1212292

### DIFF
--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -203,7 +203,6 @@ checkResolved(void) {
 // given expression.
 static int
 isDefinedAllPaths(Expr* expr, Symbol* ret, RefSet& refs) {
-  int debug = 0;
   if (!expr)
     return 0;
   if (isDefExpr(expr))
@@ -248,10 +247,12 @@ isDefinedAllPaths(Expr* expr, Symbol* ret, RefSet& refs) {
           // Treat all (non-const) refs as definitions, until we know better.
           // TODO: This may not be needed after moving insertReferenceTemps()
           // after this pass.
-          if (debug)
-            for (RefSet::iterator i = refs.begin();
-                 i != refs.end(); ++i)
-              printf("%d\n", (*i)->id);
+
+          // Commenting out debugging output
+          //for (RefSet::iterator i = refs.begin();
+          //     i != refs.end(); ++i)
+          //  printf("%d\n", (*i)->id);
+
           if (refs.find(se->var) != refs.end() &&
               arg->intent == INTENT_REF)
             return 1;


### PR DESCRIPTION
Coverity correctly pointed out that the variable debug in checkResolved's
isDefinedAllPaths does not change and so the true branch for if (debug) will
never be executed.  This code appears to be solely for debugging purposes and as
such should only be executed intentional by a developer.  To that end, leave the
code present but in a form where it will not be analysized.
