### PR TITLE
Update start_test to print summary of errors after suppressions have been checked.

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1736,10 +1736,11 @@ set skipstdinredirectmarker = "^\[Skipping test with .stdin input"
 
 echo \[Test Summary - $datestr\] |& $tee $logfile.summary
 if ($clean_only == 0) then
-    grep "$errormarker" $logfile |& $tee -a $logfile.summary
+    grep "$errormarker" $logfile |& $tee -a $logfile.summary >/dev/null
     if ($suppressions != "") then
         $utildir/test/filterSuppressions $suppressions $logfile.summary
     endif
+    grep "$errormarker" $logfile.summary
 
     grep "$futuremarker" $logfile |& $tee -a $logfile.summary
     grep "$warningmarker" $logfile |& $tee -a $logfile.summary


### PR DESCRIPTION
Previously, the test errors were printed to stdout _and_ added to the summary
logfile. Then suppressions were removed from the summary logfile and any
suppressions that succeeded were reported as an error, in the summary
logfile _only_.

This updates start_test to print to stdout the same summary that ends up in the
summary logfile. So suppressions that are removed will not show up in either
place, and missing suppressions (tests that have a suppression, but succeed)
will show up as an Error in both places.
### TODO
- [x] run regular tests (default config, no suppressions)
- [x] run llvm tests (llvm compopt, examples, with llvm.suppress)
