### PR TITLE
Resolve Coverity issues 1212285 and 1212286

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -961,7 +961,8 @@ static bool fits_in_int_helper(int width, int64_t val) {
     case 32:
       return (val >= INT32_MIN && val <= INT32_MAX);
     case 64:
-      return (val >= INT64_MIN && val <= INT64_MAX);
+      // As an int64_t will always fit within a 64 bit int.
+      return true;
   }
 }
 
@@ -1007,7 +1008,8 @@ static bool fits_in_uint_helper(int width, uint64_t val) {
   case 32:
     return (val <= UINT32_MAX);
   case 64:
-    return (val <= UINT64_MAX);
+    // As a uint64_t will always fit inside a 64 bit uint.
+    return true;
   }
 }
 


### PR DESCRIPTION
Coverity accurately pointed out that the old return statements would always
result in the same value.  This replaces those statements with the value you
would get anyways.  When we add larger sized uints and ints, this case will
stay as the max size's result anyways, so I think no maintainability is lost.
