### PR TITLE
Fix .bad file comparison on darwin.

### DIFF
--- a/util/test/diff-ignoring-module-line-numbers
+++ b/util/test/diff-ignoring-module-line-numbers
@@ -12,8 +12,8 @@ tmpfile=$2
 badtmp=`mktemp "bad.XXXXXX"`
 tmptmp=`mktemp "tmp.XXXXXX"`
 
-sed -e "\|CHPL_HOME/modules|s/:[0-9]\+:/:nnnn:/" $badfile > $badtmp
-sed -e "\|CHPL_HOME/modules|s/:[0-9]\+:/:nnnn:/" $tmpfile > $tmptmp
+sed -e "\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/" $badfile > $badtmp
+sed -e "\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/" $tmpfile > $tmptmp
 
 diff $badtmp $tmptmp
 result=$?


### PR DESCRIPTION
Darwin's sed doesn't understand + so use \* instead.
Tested on darwin and SUSE Linux.
