### PR TITLE
Remove unnecessary case in fits_in_uint_helper

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -999,8 +999,6 @@ static bool fits_in_int(int width, Immediate* imm) {
 static bool fits_in_uint_helper(int width, uint64_t val) {
   switch (width) {
   default: INT_FATAL("bad width in fits_in_uint_helper");
-  case 1:
-    return (val <= 1);
   case 8:
     return (val <= UINT8_MAX);
   case 16:


### PR DESCRIPTION
The width == 1 case in this switch statement was left over from when booleans
were stored as uint(1)s, which is not relevant as of my boolean immediate size
work on June 17th.  I think I missed this case because it didn't involve an
immediate directly.
