### PR TITLE
Fix Coverity issue 1212320

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5239,6 +5239,11 @@ preFold(Expr* expr) {
           name = field->name;
         }
       }
+      if (!name) {
+        // In this case, we ran out of fields without finding the number
+        // specified.  This is the user's error.
+        USR_FATAL(call, "'%d' is not a valid field number", fieldnum);
+      }
       result = new SymExpr(new_StringSymbol(name));
       call->replace(result);
     } else if (call->isPrimitive(PRIM_FIELD_VALUE_BY_NUM)) {

--- a/test/users/lydia/fieldNumToNameError.chpl
+++ b/test/users/lydia/fieldNumToNameError.chpl
@@ -1,0 +1,7 @@
+record R {
+  var a: int;
+  var b: string;
+  var c: real;
+}
+
+writeln(__primitive("field num to name", R, 4));

--- a/test/users/lydia/fieldNumToNameError.good
+++ b/test/users/lydia/fieldNumToNameError.good
@@ -1,0 +1,1 @@
+fieldNumToNameError.chpl:7: error: '4' is not a valid field number


### PR DESCRIPTION
Coverity was correctly complaining about the primitive PRIM_FIELD_NUM_TO_NAME.
If the field number specified exceeded the number of fields in the record or
class, then the compiler would not modify the variable name before using it,
causing a dereference of null.  I have added a test for this case and an error
message to the user should this occur in their code.

@mppf or @bradcray would be best to review this change, since Brad merged it in back in 2011 but it was mppf's code.
