### PR TITLE
Add the '-cc' option to the aprun command.

### DIFF
--- a/runtime/src/launch/aprun/aprun-utils.c
+++ b/runtime/src/launch/aprun/aprun-utils.c
@@ -228,10 +228,12 @@ char** chpl_create_aprun_cmd(int argc, char* argv[],
   }
   sprintf(_nbuf, "%s%d", getNumLocalesStr(), numLocales);
   if (strcmp(CHPL_TARGET_ARCH, "knc")==0) {
+    largv[largc++] = (char *) getAprunArgStr(aprun_cc);
+    largv[largc++] = (char *) ccArg;
     largv[largc++] = _nbuf;
     largv[largc++] = (char *) getAprunArgStr(aprun_k);
     sprintf(_Nbuf, "%s%d", getLocalesPerNodeStr(), getLocalesPerNode());
-    largv[largc++] = _Nbuf;    
+    largv[largc++] = _Nbuf;
   } else {
     largv[largc++] = (char *) getAprunArgStr(aprun_cc);
     largv[largc++] = (char *) ccArg;

--- a/runtime/src/launch/pbs-aprun/aprun-utils.c
+++ b/runtime/src/launch/pbs-aprun/aprun-utils.c
@@ -228,10 +228,12 @@ char** chpl_create_aprun_cmd(int argc, char* argv[],
   }
   sprintf(_nbuf, "%s%d", getNumLocalesStr(), numLocales);
   if (strcmp(CHPL_TARGET_ARCH, "knc")==0) {
+    largv[largc++] = (char *) getAprunArgStr(aprun_cc);
+    largv[largc++] = (char *) ccArg;
     largv[largc++] = _nbuf;
     largv[largc++] = (char *) getAprunArgStr(aprun_k);
     sprintf(_Nbuf, "%s%d", getLocalesPerNodeStr(), getLocalesPerNode());
-    largv[largc++] = _Nbuf;    
+    largv[largc++] = _Nbuf;
   } else {
     largv[largc++] = (char *) getAprunArgStr(aprun_cc);
     largv[largc++] = (char *) ccArg;


### PR DESCRIPTION
With the aprun default of '-cc cpu', we only get kernel scheduling
affinity with a single KNC CPU.  In order to get scheduling affinity
with all of them, we need to give some other option.  The '-cc none'
we give on other Cray system compute nodes seems to work fine for
this.

While here, I also removed some trailing white space on one line.

(cherry picked from commit b6f1c1b663c494684d67dbc7d261bfe185f5e2f5)
