### PR TITLE
SLURM doc updates

### DIFF
--- a/doc/release/README.launcher
+++ b/doc/release/README.launcher
@@ -53,19 +53,20 @@ Currently supported launchers include:
 A specific launcher can be explicitly requested by setting the CHPL_LAUNCHER
 environment variable. If left unset, a default is picked as follows:
 
-  CHPL_PLATFORM=cray-xc, cray-xe, cray-xk, or cray-xt.
+  if CHPL_PLATFORM=cray-xc, cray-xe, cray-xk, or cray-xt:
+  + both aprun and srun in user's path -> none
   + aprun in user's path        -> aprun
   + srun in user's path         -> slurm-srun
   (otherwise)                   -> none
 
-  CHPL_COMM=gasnet...
+  otherwise if CHPL_COMM=gasnet:
   + CHPL_COMM_SUBSTRATE=ibv     -> gasnetrun_ibv
   + CHPL_COMM_SUBSTRATE=mpi     -> gasnetrun_mpi
   + CHPL_COMM_SUBSTRATE=mxm     -> gasnetrun_ibv
   + CHPL_COMM_SUBSTRATE=udp     -> amudprun
   (otherwise)                   -> none
 
-  (otherwise)                   -> none
+  otherwise:                    -> none
 
 If the launcher binary does not work for your system (due to an
 installation-specific configuration, e.g.), you can often use the -v
@@ -110,18 +111,16 @@ SLURM notes
 
 Prerequisites: 
  
-  To use native SLURM, CHPL_LAUNCHER should automatically be set to
-  slurm-srun so long as srun is found in your path. Note that if srun
-  and aprun are found in your path the launcher defaults to none. If
-  this is the case you must set CHPL_LAUNCHER to slurm-srun manually. 
+  To use native SLURM, set:
 
-  To use SLURM using GASNet over Infiniband), you need to define the
-  following environment variable:
+    export CHPL_LAUNCHER=slurm-srun
+
+  This will happen automatically if srun is found in your path, but
+  not when both srun and aprun are found in your path.
+
+  To use SLURM using GASNet over Infiniband, set:
 
     export CHPL_LAUNCHER=slurm-gasnetrun_ibv
-
-  To specify GASNet over Infiniband, set:
-
     export CHPL_COMM=gasnet
     export CHPL_COMM_SUBSTRATE=ibv
 

--- a/doc/release/platforms/README.cray
+++ b/doc/release/platforms/README.cray
@@ -171,7 +171,7 @@ Using Chapel on a Cray System
    You can use the -v flag to see the commands used by the launcher
    binary to start your program.
 
-   If CHPL_LAUNCHER is set to pbs-aprun or pbs-gasnetrun_ibv:
+   If CHPL_LAUNCHER is pbs-aprun or pbs-gasnetrun_ibv:
 
      a) You can optionally specify a queue name using the environment
         variable CHPL_LAUNCHER_QUEUE.  For example:
@@ -190,6 +190,13 @@ Using Chapel on a Cray System
 
         Alternatively, you can set the wall clock time limit on your
         Chapel program command line using the --walltime flag.
+
+   If CHPL_LAUNCHER is slurm-gasnetrun_ibv:
+
+     You must set the amount of time to request from SLURM.
+     For example, the following requests 15 minutes:
+
+          export CHPL_LAUNCHER_WALLTIME=00:15:00
 
    For further information about launchers, please refer to
    $CHPL_HOME/doc/README.launcher.


### PR DESCRIPTION
Added the requirement to set CHPL_LAUNCHER_WALLTIME for slurm-gasnetrun_ibv launcher.

While there:

  Noted that CHPL_LAUNCHER gets set to none when slurm and aprun are both in user's path.

  Streamlined slurm notes.

  Tweaked the formatting of how CHPL_LAUNCHER is chosen by default.
