### PR TITLE
Fix nondeterministic output from walkdir() by requesting sorted output

### DIFF
--- a/test/studies/filerator/testboth.chpl
+++ b/test/studies/filerator/testboth.chpl
@@ -1,6 +1,6 @@
 use Filerator;
 
-for dir in walkdirs("subdir") {
+for dir in walkdirs("subdir", sort=true) {
   writeln("dir ", dir, " contains:");
   for file in glob(dir+"/*") do
     writeln("  ", file);


### PR DESCRIPTION
I forgot to request sorted output in my new test yesterday, which
resulted in nondeterministic behavior across file systems/machines.
This broken in one configuration last night (and could break in others
over time).
