### PR TITLE
Sort output of Functions/ref-return-intent.chpl test.

### DIFF
--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -780,6 +780,22 @@ if setter && i == 1 && x <= 0 then
 A2(0) = 0;
 A2(1) = 1;
 \end{chapelpost}
+\begin{chapelprediff}
+\#!/usr/bin/env python
+
+"""Sort the output file. Some platforms (especially WLMs) seem to reverse the
+order (probably because one line is on stdout and the other is on stderr).
+"""
+
+import sys
+
+with open(sys.argv[2], 'r') as fp:
+    content = fp.read()
+lines = content.splitlines(True)
+lines.sort()
+with open(sys.argv[2], 'w') as fp:
+    fp.write(''.join(lines))
+\end{chapelprediff}
 \begin{chapeloutput}
 3
 ref-return-intent.chpl:18: error: halt reached - cannot assign value to A(1) if A(0) <= 0


### PR DESCRIPTION
On a cray with a WLM (e.g. slurm) the output of this test is not in the same
order. Presumably the WLM is handling the stdout vs. stderr slightly different,
which results in the different ordering. Regardless, sorting the output with a
.prediff will ensure the test passes.
