### PR TITLE
Added parSafe=false to a test

### DIFF
--- a/test/functions/deitz/iterators/leader_follower/test_neg_stride_range_leader_follower.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_neg_stride_range_leader_follower.chpl
@@ -1,4 +1,4 @@
-var D: domain((int,int));
+var D: domain((int,int), parSafe=false);
 
 var lock: sync bool;
 


### PR DESCRIPTION
This test already locks on domain modifications, so it should work with parSafe=false.
I am adding this to exercise locking/not locking in another test.
