### PR TITLE
Default to /proc/cpuinfo for maxTaskPar.prediff core counting.

### DIFF
--- a/test/localeModels/gbt/maxTaskPar.prediff
+++ b/test/localeModels/gbt/maxTaskPar.prediff
@@ -8,6 +8,18 @@ tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
 
 function cores_from_proc_cpuinfo() {
   if [[ -f /proc/cpuinfo ]] ; then
+    #
+    # Assumptions about /proc/cpuinfo:
+    # - There is a separate "processor" block for each logical CPU.
+    # - The CPUs are heterogeneous in terms of both cores/socket and
+    #   logical CPUs/core.  (This is true now but someday won't be!)
+    # - The "cpu cores" entry gives physical CPUs/socket.
+    # - The "siblings" entry gives logical CPUs/socket.
+    # - If either "cpu cores" or "siblings" entries are not present,
+    #   each processor block is assumed to represent a hardware core.
+    #   (This is broken in cygwin at least sometimes.)   Otherwise,
+    #   "siblings"/"cpu cores" is the logical/physical CPU ratio.
+    #
     numPUs=$( grep -c '^processor[[:space:]]\+: ' /proc/cpuinfo )
     numCores1=$( grep -m 1 '^cpu cores[[:space:]]\+: ' /proc/cpuinfo |
                  sed 's/^[^[:digit:]]*\([[:digit:]]\+\).*$/\1/' )


### PR DESCRIPTION
Instead of explicitly calling out the configurations for which we use
/proc/cpuinfo to determine the core count, default to /proc/cpuinfo and
arrange for failure (by putting a '0' in the .good) when it's not there.

I've tested in enough configurations to cover all the logic paths.

Brad gets credit for this idea and, as a reward, I'll ask him to review it!
