### PR TITLE
Add annotation for BFS

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -45,6 +45,10 @@ all:
   09/12/14:
     - switch default memory allocator back to cstdlib
 
+bfs:
+  09/25/14:
+    - addition of octal to, reformatting of format printing.
+
 chameneos-redux:
   07/08/13:
     - altered output order for chameneos data, old data incompatible


### PR DESCRIPTION
The Parboil test BFS improved on September 25th due to some clean up to
formatted printing when adding octal.
