### PR TITLE
Adding mpz_clear() calls to pidigits tests to plug memory leaks

### DIFF
--- a/test/studies/shootout/pidigits/bradc/pidigits-blc.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-blc.chpl
@@ -38,6 +38,15 @@ proc main() {
     if i % 10 == 0 then
       writeln("\t:", i);
   }
+
+  //
+  // Free memory associated with multi-precision valuesx
+  //
+  mpz_clear(tmp2);
+  mpz_clear(tmp1);
+  mpz_clear(denom);
+  mpz_clear(accum);
+  mpz_clear(numer);
 }
 
 

--- a/test/studies/shootout/pidigits/bradc/pidigits-iter.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-iter.chpl
@@ -86,4 +86,13 @@ iter gen_digits(numDigits) {
     mpz_mul_ui(accum, accum, 10);          // accum *= 10
     mpz_mul_ui(numer, numer, 10);          // numer *= 10
   }
+
+  //
+  // Free memory associated with multi-precision valuesx
+  //
+  mpz_clear(tmp2);
+  mpz_clear(tmp1);
+  mpz_clear(denom);
+  mpz_clear(accum);
+  mpz_clear(numer);
 }

--- a/test/studies/shootout/pidigits/bradc/pidigits-ledrug-pretty.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-ledrug-pretty.chpl
@@ -62,6 +62,15 @@ iter gen_digits(numDigits) {
   }
 
   //
+  // Free memory associated with multi-precision valuesx
+  //
+  mpz_clear(num);
+  mpz_clear(den);
+  mpz_clear(acc);
+  mpz_clear(tmp2);
+  mpz_clear(tmp1);
+
+  //
   // Helper function to extract the nth digit
   //
   proc extract_digit(nth: c_ulong) {

--- a/test/studies/shootout/pidigits/bradc/pidigits-ledrug.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-ledrug.chpl
@@ -62,6 +62,15 @@ iter gen_digits(numDigits) {
   }
 
   //
+  // Free memory associated with multi-precision valuesx
+  //
+  mpz_clear(num);
+  mpz_clear(den);
+  mpz_clear(acc);
+  mpz_clear(tmp2);
+  mpz_clear(tmp1);
+
+  //
   // Helper function to extract the nth digit
   //
   proc extract_digit(nth: c_ulong) {

--- a/test/studies/shootout/pidigits/bradc/pidigits-pretty1.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-pretty1.chpl
@@ -110,4 +110,13 @@ iter gen_digits(numDigits) {
     accum *= 10;
     numer *= 10;
   }
+
+  //
+  // Free memory associated with multi-precision valuesx
+  //
+  mpz_clear(tmp2);
+  mpz_clear(tmp1);
+  mpz_clear(denom);
+  mpz_clear(accum);
+  mpz_clear(numer);
 }

--- a/test/studies/shootout/pidigits/bradc/pidigits-pretty2.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-pretty2.chpl
@@ -120,6 +120,10 @@ iter gen_digits(numDigits) {
     accum *= 10;
     numer *= 10;
   }
+
+  //
+  // Free memory associated with multi-precision valuesx
+  //
   mpz_clear(numer);
   mpz_clear(accum);
   mpz_clear(denom);

--- a/test/studies/shootout/pidigits/hilde/pidigits-hilde.chpl
+++ b/test/studies/shootout/pidigits/hilde/pidigits-hilde.chpl
@@ -61,6 +61,12 @@ proc pidigits
     if i >= n then break;
     eliminate_digit(d:uint);
   }
+
+  mpz_clear(denom);
+  mpz_clear(accum);
+  mpz_clear(numer);
+  mpz_clear(tmp2);
+  mpz_clear(tmp1);
 }
 
 proc next_term(k:uint)


### PR DESCRIPTION
These changes were motivated by tvandoren's BigInt version
which is leak-free, causing him to point out that most of
our existing versions were not (and the hypothesis is that
making them leak-free won't add significant overhead, based
on the difference between his version and mine).

The ultimate version would be one in which BigInt was a record
in order to have it clean up after itself when its destructor
is called.  This is a background TODO that the two of us are
interested in getting done.
