### PR TITLE
Factor fix_def_expr() to fit on one page.

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -51,6 +51,11 @@ static void call_constructor_for_class(CallExpr* call);
 static void applyGetterTransform(CallExpr* call);
 static void insert_call_temps(CallExpr* call);
 static void fix_def_expr(VarSymbol* var);
+static void init_array_alias(VarSymbol* var, Expr* type, Expr* init, Expr* stmt);
+static void init_ref_var(VarSymbol* var, Expr* init, Expr* stmt);
+static void init_config_var(VarSymbol* var, Expr*& stmt, VarSymbol* constTemp);
+static void init_typed_var(VarSymbol* var, Expr* type, Expr* init, Expr* stmt, VarSymbol* constTemp);
+static void init_untyped_var(VarSymbol* var, Expr* init, Expr* stmt, VarSymbol* constTemp);
 static void hack_resolve_types(ArgSymbol* arg);
 static void fixup_array_formals(FnSymbol* fn);
 static void clone_parameterized_primitive_methods(FnSymbol* fn);
@@ -893,17 +898,7 @@ fix_def_expr(VarSymbol* var) {
   // handle var ... : ... => ...;
   //
   if (var->hasFlag(FLAG_ARRAY_ALIAS)) {
-    CallExpr* partial;
-    if (!type) {
-      partial = new CallExpr("newAlias", gMethodToken, init->remove());
-      // newAlias is not a method, so we don't set the methodTag
-      stmt->insertAfter(new CallExpr(PRIM_MOVE, var, new CallExpr("chpl__autoCopy", partial)));
-    } else {
-      partial = new CallExpr("reindex", gMethodToken, init->remove());
-      partial->partialTag = true;
-      partial->methodTag = true;
-      stmt->insertAfter(new CallExpr(PRIM_MOVE, var, new CallExpr("chpl__autoCopy", new CallExpr(partial, type->remove()))));
-    }
+    init_array_alias(var, type, init, stmt);
     return;
   }
 
@@ -920,7 +915,45 @@ fix_def_expr(VarSymbol* var) {
   // handle ref variables
   //
   if (var->hasFlag(FLAG_REF_VAR)) {
+    init_ref_var(var, init, stmt);
+    return;
+  }
 
+  //
+  // insert code to initialize config variable from the command line
+  //
+  if (var->hasFlag(FLAG_CONFIG)) {
+    if (!var->hasFlag(FLAG_PARAM)) {
+      init_config_var(var, stmt, constTemp);
+    }
+  }
+
+  if (type) {
+    init_typed_var(var, type, init, stmt, constTemp);
+  } else {
+    init_untyped_var(var, init, stmt, constTemp);
+  }
+}
+
+
+static void init_array_alias(VarSymbol* var, Expr* type, Expr* init, Expr* stmt)
+{
+    CallExpr* partial;
+    if (!type) {
+      partial = new CallExpr("newAlias", gMethodToken, init->remove());
+      // newAlias is not a method, so we don't set the methodTag
+      stmt->insertAfter(new CallExpr(PRIM_MOVE, var, new CallExpr("chpl__autoCopy", partial)));
+    } else {
+      partial = new CallExpr("reindex", gMethodToken, init->remove());
+      partial->partialTag = true;
+      partial->methodTag = true;
+      stmt->insertAfter(new CallExpr(PRIM_MOVE, var, new CallExpr("chpl__autoCopy", new CallExpr(partial, type->remove()))));
+    }
+}
+
+
+static void init_ref_var(VarSymbol* var, Expr* init, Expr* stmt)
+{
     if (!init) {
       USR_FATAL_CONT(var, "References must be initialized when they are defined.");
     }
@@ -952,15 +985,11 @@ fix_def_expr(VarSymbol* var) {
     }
 
     stmt->insertAfter(new CallExpr(PRIM_MOVE, var, new CallExpr(PRIM_ADDR_OF, varLocation)));
+}
 
-    return;
-  }
 
-  //
-  // insert code to initialize config variable from the command line
-  //
-  if (var->hasFlag(FLAG_CONFIG)) {
-    if (!var->hasFlag(FLAG_PARAM)) {
+static void init_config_var(VarSymbol* var, Expr*& stmt, VarSymbol* constTemp)
+{
       Expr* noop = new CallExpr(PRIM_NOOP);
       Symbol* module_name = (var->getModule()->modTag != MOD_INTERNAL ?
                              new_StringSymbol(var->getModule()->name) :
@@ -980,13 +1009,12 @@ fix_def_expr(VarSymbol* var) {
                                     module_name)),
           noop,
           new CallExpr(PRIM_MOVE, constTemp, strToValExpr)));
-
       stmt = noop; // insert regular definition code in then block
-    }
-  }
+}
 
-  if (type) {
 
+static void init_typed_var(VarSymbol* var, Expr* type, Expr* init, Expr* stmt, VarSymbol* constTemp)
+{
     //
     // use cast for parameters to avoid multiple parameter assignments
     //
@@ -1042,9 +1070,11 @@ fix_def_expr(VarSymbol* var) {
 
       stmt->insertAfter(block);
     }
+}
 
-  } else {
 
+static void init_untyped_var(VarSymbol* var, Expr* init, Expr* stmt, VarSymbol* constTemp)
+{
     // See Note 4.
     //
     // initialize untyped variable with initialization expression
@@ -1073,7 +1103,6 @@ fix_def_expr(VarSymbol* var) {
       // when building default type constructors.
       if ((toSymExpr(init) && (toSymExpr(init)->typeInfo() == dtStringC)) &&
           !var->hasFlag(FLAG_PARAM)) {
-        INT_ASSERT(type==NULL);
         // This logic is the same as the case above under 'if (type)',
         // but simplified for this specific case.
         SET_LINENO(stmt);
@@ -1092,8 +1121,8 @@ fix_def_expr(VarSymbol* var) {
             new CallExpr("chpl__initCopy", init->remove())));
       }
     }
-  }
 }
+
 
 static void hack_resolve_types(ArgSymbol* arg) {
   // Look only at unknown or arbitrary types.


### PR DESCRIPTION
TODO: Order and indentation of the original code was preserved to minimize the text
differences.  Sometime later, indentation should be readjusted.
