### PR TITLE
Update printFinalMemStat.no-local.good

### DIFF
--- a/test/memory/shannon/printFinalMemStat.no-local.good
+++ b/test/memory/shannon/printFinalMemStat.no-local.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  505
-Total Allocated Memory                 1729
-Total Freed Memory                     1473
+Total Allocated Memory                 1937
+Total Freed Memory                     1681
 ==============================================================


### PR DESCRIPTION
[with help from Greg]

The no-local output of this test changed with commit
e0686dd49db.. (Remove remote string copy); the total amount of memory
allocated and freed went up (no additional memory leaked).

The commit changed the global Chapel strings (s_memLog and
sMemLeaksLog) in the MemTracking module to type string_rec, and so the
string_rec variables are now being cleaned up by
chpl__autoDestroyGlobals() in the generated code.  In the --no-local
case, the on statement in the string_rec destructor requires heap
allocated bundled args (even though we're already on the right
locale), which account for the extra allocations and frees.  Greg
notes we really should be checking earlier whether or not we need the
bundled args, but that task is for another day.
