### PR TITLE
Fixed a minor glitch in each of sub_test and paratest.server

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -254,8 +254,11 @@ sub feed_nodes {
                 } else {
                     systemd ("$rem_cmd 2>&1 | grep -i 'Error in paratest.client:'");
                 }
-                $pe_command = $show_all_errors ?
-                  '/^\\[Error/p; /^\\[Test Summary/q' : '/^\\[Error/{p;q}';
+                $pe_command = $show_all_errors
+                  # print Error lines; terminate when we reach Test Summary
+                  ? '/^\\[Error/p; /^\\[Test Summary/q'
+                  # once an Error line is seen, print it and terminate
+                  : '/^\\[Error/{p;q}';
                 $partial_errors = `sed -n '$pe_command' $logfile`;
                 if ($partial_errors) {
                     print "\n:( $partial_errors";

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -755,6 +755,7 @@ if systemPreexec:
 if systemPrediff:
     sys.stdout.write('[system-wide prediff: \'%s\']\n'%(systemPrediff))
 
+# consistently look only at the files in the current directory
 dirlist=os.listdir(".")
 
 onetestsrc = os.getenv('CHPL_ONETEST')


### PR DESCRIPTION
- In sub_test, eliminate the confusion between $CHPL_HOME/test/users/USERNAME/... and /users/USERNAME.
- In paratest.server --show-all-errors, show each error just once. While there, streamlined the code.
