### PR TITLE
Fix baseline log locations.

### DIFF
--- a/util/cron/test-linux64-baseline-default-full.bash
+++ b/util/cron/test-linux64-baseline-default-full.bash
@@ -4,4 +4,6 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
+source $CWD/common-baseline.bash
+
 $CWD/nightly -cron -baseline -suppress Suppressions/baseline.suppress -no-futures -compopts --inline


### PR DESCRIPTION
Fix baseline log location for nightly testing. This broke in #600.
