### PR TITLE
Reduce some GMP memory leaks using explicit frees.

### DIFF
--- a/test/modules/standard/gmp/ferguson/gmp_dist_array.chpl
+++ b/test/modules/standard/gmp/ferguson/gmp_dist_array.chpl
@@ -30,6 +30,7 @@ forall (a,b,c) in zip(A,B,C) {
   //c = a + b;
 }
 //writeln(C);
+
 var sum = new BigInt(0);
 for c in C {
   //writeln(c.locale, " ", c.sizeinbase(10));
@@ -43,4 +44,16 @@ modulus.nextprime(modulus);
 writeln(modulus);
 sum.mod(sum, modulus);
 writeln(sum);
+delete modulus;
+delete sum;
 
+// Release the array elements.
+forall a in A {
+  delete a;
+}
+forall b in B {
+  delete b;
+}
+forall c in C {
+  delete c;
+}

--- a/test/modules/standard/gmp/ferguson/gmp_random.chpl
+++ b/test/modules/standard/gmp/ferguson/gmp_random.chpl
@@ -17,4 +17,5 @@ r.urandomm(b, n);
 if printrandom then writeln(b);
 
 delete r;
-
+delete b;
+delete n;

--- a/test/modules/standard/gmp/ferguson/gmp_test.chpl
+++ b/test/modules/standard/gmp/ferguson/gmp_test.chpl
@@ -31,3 +31,5 @@ on Locales[numLocales-1] {
 //b.debugprint();
 writeln(b);
 
+delete b;
+delete a;

--- a/test/modules/standard/gmp/ferguson/gmp_writeln.chpl
+++ b/test/modules/standard/gmp/ferguson/gmp_writeln.chpl
@@ -3,3 +3,5 @@ use GMP;
 var a = new BigInt(1);
 
 writeln(a);
+
+delete a;

--- a/test/modules/standard/gmp/studies/gmp-simple-long-inout.chpl
+++ b/test/modules/standard/gmp/studies/gmp-simple-long-inout.chpl
@@ -11,4 +11,6 @@ proc main() {
   mpz_set_ui(x[0], 123);
 
   gmp_printf("x[0] is: %Zd\n", x[0]);
+
+  mpz_clear(x[0]);
 }


### PR DESCRIPTION
Call delete on BigInt (class) instances to release them.

Call mpz_clear() on mpz_t instances to release them.
