### PR TITLE
Add isLink functionality

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -23,6 +23,7 @@ extern proc chpl_fs_chown(name: c_string, uid: c_int, gid: c_int):syserr;
 extern proc chpl_fs_cwd(ref working_dir:c_string):syserr;
 extern proc chpl_fs_is_dir(ref result:c_int, name: c_string):syserr;
 extern proc chpl_fs_is_file(ref result:c_int, name: c_string):syserr;
+extern proc chpl_fs_is_link(ref result:c_int, name: c_string): syserr;
 extern proc chpl_fs_mkdir(name: c_string, mode: int, parents: bool):syserr;
 extern proc chpl_fs_rename(oldname: c_string, newname: c_string):syserr;
 extern proc chpl_fs_remove(name: c_string):syserr;
@@ -149,6 +150,28 @@ proc isFile(name:string):bool {
   var err:syserr;
   var ret = isFile(err, name);
   if err then ioerror(err, "in isFile", name);
+  return ret;
+}
+
+/* Returns true if the name corresponds to a symbolic link, false if not
+   or if symbolic links are not supported.
+   name: a string that could be the name of a symbolic link.
+*/
+proc isLink(out err:syserr, name: string): bool {
+  var ret:c_int;
+  err = chpl_fs_is_link(ret, name.c_str());
+  return ret != 0;
+}
+
+/* Returns true if the name corresponds to a symbolic link, false if not
+   or if symbolic links are not supported.  Generates an error message if one
+   occurs
+   name: a string that could be the name of a symbolic link.
+*/
+proc isLink(name: string): bool {
+  var err:syserr;
+  var ret = isLink(err, name);
+  if err then ioerror(err, "in isLink", name);
   return ret;
 }
 

--- a/runtime/include/chpl-file-utils.h
+++ b/runtime/include/chpl-file-utils.h
@@ -34,6 +34,7 @@ qioerr _chpl_fs_check_mode(int* ret, const char* name, int mode_flag);
 
 qioerr chpl_fs_is_dir(int* ret, const char* name);
 qioerr chpl_fs_is_file(int* ret, const char* name);
+qioerr chpl_fs_is_link(int* ret, const char* name);
 
 // Creates a directory with the given name and settings if possible,
 // returning a qioerr if not.

--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -78,6 +78,18 @@ qioerr chpl_fs_is_file(int* ret, const char* name) {
   return _chpl_fs_check_mode(ret, name, S_IFREG);
 }
 
+qioerr chpl_fs_is_link(int* ret, const char* name) {
+  // Note: Cannot use _chpl_fs_check_mode in this case because stat follows
+  // symbolic links instead of evaluating the link itself.  The similar
+  // comparison is also not valid when an unlinked file is provided.
+  struct stat buf;
+  int exitStatus = lstat(name, &buf);
+  if (exitStatus)
+    return qio_mkerror_errno();
+  *ret = S_ISLNK(buf.st_mode);
+  return 0;
+}
+
 /* Creates a directory with the given name and settings if possible,
    returning a qioerr if not. If parents != 0, then the callee wishes
    to create all interim directories necessary as well. */

--- a/test/io/lydia/isLink/cases.chpl
+++ b/test/io/lydia/isLink/cases.chpl
@@ -1,0 +1,5 @@
+use FileSystem;
+writeln(isLink("my_dir")); // false
+writeln(isLink("my_file")); // false
+writeln(isLink("my_link_dir")); // true
+writeln(isLink("my_link_file")); // true

--- a/test/io/lydia/isLink/cases.cleanfiles
+++ b/test/io/lydia/isLink/cases.cleanfiles
@@ -1,0 +1,2 @@
+my_dir
+my_file

--- a/test/io/lydia/isLink/cases.good
+++ b/test/io/lydia/isLink/cases.good
@@ -1,0 +1,4 @@
+false
+false
+true
+true

--- a/test/io/lydia/isLink/cases.preexec
+++ b/test/io/lydia/isLink/cases.preexec
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir -p my_dir
+touch my_file
+if [ ! -e my_link_dir ]; then
+    ln -s my_dir my_link_dir
+    ln -s my_file my_link_file
+fi

--- a/test/io/lydia/isLink/no_such_file_or_dir.chpl
+++ b/test/io/lydia/isLink/no_such_file_or_dir.chpl
@@ -1,0 +1,2 @@
+use FileSystem;
+isLink("unknown.txt");

--- a/test/io/lydia/isLink/no_such_file_or_dir.good
+++ b/test/io/lydia/isLink/no_such_file_or_dir.good
@@ -1,0 +1,1 @@
+no_such_file_or_dir.chpl:2: error: No such file or directory in isLink with path "unknown.txt"


### PR DESCRIPTION
This adds the ability to check within Chapel code if a provided name corresponds
to a soft link.  The interface is visible in the FileSystem module, the
implementation itself lies in chpl-file-utils.c.  Also provide two test cases:
one to exercise files and directories that are and are not links, and one to
exercise the case where the link itself does not exist.

Tested over std on linux, ran only the new tests on cygwin and darwin to
make sure it worked there, too.

@bradcray should review this one, since similar capability lives in his glob implementation
and he wanted this interface prioritized (ha!)
