### PR TITLE
Add timing for each sub_test call.

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -131,7 +131,7 @@ def elapsed_sub_test_time():
     test_name = localdir
     if 'CHPL_ONETEST' in os.environ:
         chpl_name = os.environ.get('CHPL_ONETEST')
-        base_name = '.'.join(chpl_name.split('.')[:-1])
+        base_name = os.path.splitext(chpl_name)[0]
         test_name = os.path.join(test_name, base_name)
 
     print('[Finished subtest "{0}" - {1:.3f} seconds]\n'.format(test_name, elapsed_sec))


### PR DESCRIPTION
Register exit handler for sub_test python script that prints the elapsed
seconds from start up to exit (successful exit only). If sub_test is called
without CHPL_ONETEST, e.g. it is called on a directory, it will print a line
like the following when it is complete:

```
[Finished subtest "release/examples" - 16.330 seconds]
```

If sub_test is called with CHPL_ONETEST set, e.g. it is called on a specific
.chpl file, it will print a line like the following when it is complete:

```
[Finished subtest "release/examples/hello" - 2.711 seconds]
```

This will help developers do ad-hoc comparisons of nightly runs as needed. For
example, if a developer things a single test or new suite of tests is adding
significant time to the overall test time, it will be easy to find this line
and compare between two builds.

This is not meant to replace, or even enhance, compiler or runtime performance
tracking that already exists.
### TODO:
- [x] full test pass
