### PR TITLE
Fixing quickstart shells w.r.t. quickstart on Crays problem TMac hit tod...

### DIFF
--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -29,11 +29,14 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
           export MANPATH="$MYMANPATH":"$CHPL_HOME"/man
           echo "$CHPL_HOME"/man
 
+          echo "Setting CHPL_COMM to none"
+          export CHPL_COMM=none
+
           echo "Setting CHPL_TASKS to fifo"
           export CHPL_TASKS=fifo
 
-          echo "Setting CHPL_MEM to cstdlib"
-          export CHPL_MEM=cstdlib
+#          echo "Setting CHPL_MEM to cstdlib"
+#          export CHPL_MEM=cstdlib
 
           echo "Setting CHPL_GMP to none"
           export CHPL_GMP=none

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -33,11 +33,14 @@ echo -n "Updating MANPATH "
 setenv MANPATH "$MYMANPATH":"$CHPL_HOME"/man
 echo "to include $CHPL_HOME/man"
 
+echo "Setting CHPL_COMM to none"
+setenv CHPL_COMM none
+
 echo "Setting CHPL_TASKS to fifo"
 setenv CHPL_TASKS fifo
 
-echo "Setting CHPL_MEM to cstdlib"
-setenv CHPL_MEM cstdlib
+#echo "Setting CHPL_MEM to cstdlib"
+#setenv CHPL_MEM cstdlib
 
 echo "Setting CHPL_GMP to none"
 setenv CHPL_GMP none

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -33,11 +33,14 @@ echo -n "Updating MANPATH "
 set -x MANPATH "$MYMANPATH" "$CHPL_HOME"/man
 echo "to include $CHPL_HOME/man"
 
+echo "Setting CHPL_COMM to none"
+set -x CHPL_COMM none
+
 echo "Setting CHPL_TASKS to fifo"
 set -x CHPL_TASKS fifo
 
-echo "Setting CHPL_MEM to cstdlib"
-set -x CHPL_MEM cstdlib
+#echo "Setting CHPL_MEM to cstdlib"
+#set -x CHPL_MEM cstdlib
 
 echo "Setting CHPL_GMP to none"
 set -x CHPL_GMP none

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -37,17 +37,23 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
           echo "                           ...$CHPL_HOME"/man
           echo " "
 
+          echo "Setting CHPL_COMM to..."
+          CHPL_COMM=none
+          export CHPL_COMM
+          echo "                           ...none"
+          echo ""
+
           echo "Setting CHPL_TASKS to..."
           CHPL_TASKS=fifo
           export CHPL_TASKS
           echo "                           ...fifo"
           echo " "
 
-          echo "Setting CHPL_MEM to..."
-          CHPL_MEM=cstdlib
-          export CHPL_MEM
-          echo "                           ...cstdlib"
-          echo " "
+#          echo "Setting CHPL_MEM to..."
+#          CHPL_MEM=cstdlib
+#          export CHPL_MEM
+#          echo "                           ...cstdlib"
+#          echo " "
 
           echo "Setting CHPL_GMP to..."
           CHPL_GMP=none


### PR DESCRIPTION
...ay

Today, TMac started up a Cray Chapel environment building from source
in which CHPL_COMM would default to gasnet/aries or gasnet/gemini due
to being on a Cray, but the CHPL_MEM layer would be set to cstdlib
because of a seemingly innocuous change made to
util/quickstart/setchplenv.\* when we made tcmalloc the default.
Because these GASNet conduits require tcmalloc or dlmalloc or the like
to register memory, an (vague) error is generated.

Here I'm addressing this by:

(a) making the quickstart files set CHPL_COMM to 'none' which arguably
    is what we might want people to start with, even on a Cray if
    they're building from source (and is already the default
    everywhere else);

(b) making the quickstart files not set CHPL_MEM.  This is something
    we will probably want to undo if/when we make tcmalloc the default
    at some point in the future.

Either one of these changes should be sufficient by itself.  Both
seemed like a better reflection of what we would want the quickstart
to do when building from source today.

Note that these changes won't affect Cray module users because they
get a different README and tend not to use the setchplenv.\* scripts.
