### PR TITLE
Two tweaks to fix wide string copy errors exposed by dlmalloc.

### DIFF
--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -86,6 +86,7 @@ chpl_string_widen(chpl____wide_chpl_string* x, chpl_string from, int32_t lineno,
   if (from == NULL)
   {
     x->addr = NULL;
+    x->size = 0;
     return;
   }
     
@@ -110,7 +111,15 @@ chpl_string_widen(chpl____wide_chpl_string* x, chpl_string from, int32_t lineno,
 void
 chpl_comm_wide_get_string(chpl_string* local, struct chpl_chpl____wide_chpl_string_s* x, int32_t tid, int32_t lineno, chpl_string filename)
 {
-  char* chpl_macro_tmp =
+  char* chpl_macro_tmp;
+
+  if (x->addr == NULL)
+  {
+    *local = NULL;
+    return;
+  }
+
+  chpl_macro_tmp =
       chpl_mem_calloc(x->size, CHPL_RT_MD_GET_WIDE_STRING, lineno, filename);
   if (chpl_nodeID == chpl_rt_nodeFromLocaleID(x->locale))
     memcpy(chpl_macro_tmp, x->addr, x->size);


### PR DESCRIPTION
Handling of the distinguished value for an empty c_string_copy was not fully implemented
in the remote string routines.  Wide strings should report a length of zero if the string
itself is a NULL.  If the remote string pointer is null, the local one should be, too.
