### PR TITLE
Discovered that the NAS Parallel Benchmarks IS and FT took a minor hit w...

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -69,6 +69,14 @@ fasta:
   01/14/14:
     - enabled unlocked I/O on fasta and fasta-printf
 
+ft:
+  09/05/14:
+    - switched uses of <locale>.numCores to <locale>.maxTaskPar
+
+ft-a:
+  09/05/14:
+    - switched uses of <locale>.numCores to <locale>.maxTaskPar
+
 lulesh:
   03/15/14:
     - improved constness of de-nested functions, improved remove value forwarding

--- a/test/npb/is/is.graph
+++ b/test/npb/is/is.graph
@@ -1,24 +1,24 @@
-perfkeys:  Elapsed time for setup    =,  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
-files: intsort.S.dat, intsort.S.dat, intsort.S.dat, intsort.S.dat
-graphkeys: setup time - S, key sort time - S, verify time - S, total time - S
+perfkeys:  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
+files: intsort.S.dat, intsort.S.dat, intsort.S.dat
+graphkeys: key sort time - S, verify time - S, total time - S
 graphtitle: NAS Parallel Benchmarks: IS timings - size S
 
-#perfkeys:  Elapsed time for setup    =,  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
-#files: intsort.W.dat, intsort.W.dat, intsort.W.dat, intsort.W.dat
-#graphkeys: setup time - W, key sort time - W, verify time - W, total time - W
+#perfkeys:  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
+#files: intsort.W.dat, intsort.W.dat, intsort.W.dat
+#graphkeys: key sort time - W, verify time - W, total time - W
 #graphtitle: NAS Parallel Benchmarks: IS timings - size W
 
-#perfkeys:  Elapsed time for setup    =,  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
-#files: intsort.A.dat, intsort.A.dat, intsort.A.dat, intsort.A.dat
-#graphkeys: setup time - A, key sort time - A, verify time - A, total time - A
+#perfkeys:  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
+#files: intsort.A.dat, intsort.A.dat, intsort.A.dat
+#graphkeys: key sort time - A, verify time - A, total time - A
 #graphtitle: NAS Parallel Benchmarks: IS timings - size A
 
-#perfkeys:  Elapsed time for setup    =,  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
-#files: intsort.B.dat, intsort.B.dat, intsort.B.dat, intsort.B.dat
-#graphkeys: setup time - B, key sort time - B, verify time - B, total time - B
+#perfkeys:  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
+#files: intsort.B.dat, intsort.B.dat, intsort.B.dat
+#graphkeys: key sort time - B, verify time - B, total time - B
 #graphtitle: NAS Parallel Benchmarks: IS timings - size B
 
-#perfkeys:  Elapsed time for setup    =,  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
-#files: intsort.C.dat, intsort.C.dat, intsort.C.dat, intsort.C.dat
-#graphkeys: setup time - C, key sort time - C, verify time - C, total time - C
+#perfkeys:  Elapsed time for key sort =,  Elapsed time for full verify =,  Time in seconds =
+#files: intsort.C.dat, intsort.C.dat, intsort.C.dat
+#graphkeys: key sort time - C, verify time - C, total time - C
 #graphtitle: NAS Parallel Benchmarks: IS timings - size C


### PR DESCRIPTION
...ith the

<locale>.numCores to <locale>.maxTaskPar switch on 09/04.  Noting this in the
annotations file.  Also, modify the IS graph so it doesn't display the set up
time, as that hid the change from view (and is really more of an indicator of
how messed up that test is than an indicator of anything useful).
