### PR TITLE
Stop leaking the hash table for knucleotide

### DIFF
--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
@@ -69,7 +69,7 @@ class Table {
     for n in table do {
       var cur = n;
       while cur != nil {
-        refvar next = cur.next;
+        var next = cur.next;
         delete cur;
         cur = next;
       }


### PR DESCRIPTION
This PR stops the leaking of Node objects, greatly reducing the total amount of memory leaked by this test.
