### PR TITLE
Significant REGRESSIONS reformatting/cleanup

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -1,9 +1,55 @@
 # USAGE: the intent of this file is to keep track of current
-# regressions and to keep notes about why they are failing.  We start
-# with general regressions that are seen across a wide variety of
-# platforms, and then move onto linux64 regressions since those are
-# our main development platform.  Other platforms/settings that are
-# currently causing regressions are listed afterwards in some
+# regressions and to keep notes about why they are failing.
+#
+# Each category represents a Cron run that we do nightly and mail to
+# chapel-test-results-all (and chapel-test-results-regressions if
+# anything unusual happened.  The label for each category should match
+# the unique ID of that testing configuration.  In some cases,
+# categories will have a wildcard name such as 'gasnet*' implying that
+# they are an abstract category for all configurations that match that
+# pattern.  In the past we have used specific instances (like
+# 'gasnet-everything', historically) for such purposes, but in
+# practice there often isn't a test configuration that serves as a
+# good root for the hierarchy described in the next paragraph.
+#
+# There is an informal hierarchy embedded in this file in order to try
+# and reduce redundancy in which each suite is marked as inheriting
+# from one or more other suites.  For example, if "hello.chpl" fails
+# everywhere, it should only be noted in "general regressions" (the
+# root of the hierarchy) and not in every configuration.  Similarly,
+# if something fails for every gasnet configuration, it can be listed
+# in gasnet-everything which forms the root of the gasnet sub-tree.
+#
+# Ultimately, the hope is to do more of this filtering and
+# categorization automatically, but for the time being it is manual
+# and rotated among members of the core Chapel team.  Periodically,
+# all failures in a test suite should be reviewed with what's in this
+# file to ensure that they match.  The last time that this full review
+# was done is marked in the "Reviewed" slot in the header of the
+# category.
+#
+# Each regression itself should be marked with a brief (one-line)
+# description of why the failure is occurring, the date on which the
+# failure occurred, and the owner.  All new issues should be assigned
+# an owner; some historical ones may have escaped being assigned one.
+#
+# In some cases, more extensive notes may be in order, but this file
+# should lean towards being spare (for the purposes of maintenance).
+# Soon we will have an issue tracker in which each regression will
+# be tracked and dialogue, notes, etc. can take place there.
+#
+# In some cases, if a bunch of failures share the same behavior but
+# come and go on different nights, dates may be attached to the tests
+# themselves rather than the failure category.  Use judgement and
+# taste.
+#
+# Sporadic timeouts are an ongoing concern about how to track them.
+# As of this writing, I am tracking them here, because there are not
+# so many that it's unwieldy, but ultimately we may need to come up
+# with a better plan.  Ultimately, we should quiet down all such
+# sporadic timeouts, for instance by upping the timeout for a specific
+# test or configuration (slow machine or back-end compiler, e.g.)
+
 # approximation to priority order.  Formatting for each entry can be
 # loose, but should roughly follow the format of brief note on why the
 # test is failing followed by a list of tests that are failing for
@@ -18,286 +64,38 @@
 # The status of failing future tests is detailed in ../STATUS.devel
 
 
-===========================================================
-general regressions (seem to happen in most configurations)
-(Reviewed for accuracy 10/14/14)
-===========================================================
+===================
+general
+Reviewed 2014-10-16
+===================
 
-fails about 2-3x a month (vass)
--------------------------------
+sporadic failure (2-3x a month -- vass)
+---------------------------------------
 [Error matching program output for parallel/taskPar/taskIntents/21-capture-in-cobegin]
 
 
-==============================================
-linux64 regressions (in addition to the above)
-(Reviewed for accuracy 10/14/14)
-==============================================
-
-
-==========================================================
-linux32 (comm-none) regressions (in addition to the above)
-(Reviewed for accuracy 10/14/14)
-==========================================================
-
-
-================================
-performance-specific regressions
-(Reviewed for accuracy 10/14/14)
-================================
-
-consistent failures on bradc-lnx and chap03 due to insane memory usage
-this should get better with better string memory management
--------------------------------------------------------------------------------
-[Error matching performance keys for studies/shootout/fasta/kbrady/fasta-lines]
-
-
-================================
---fast regressions
-(Reviewed for accuracy 10/14/14)
-================================
-
-
-================================
-memory-leaks regressions
-(Reviewed for accuracy 10/15/14)
-================================
-
-very infrequent segfault (10/03/14)
------------------------------------
-[Error matching program output for stress/deitz/test_10k_begins]
-
-Setting a config that isn't supported for --minimal-modules (1/23/14 - bradc)
------------------------------------------------------------------------------
-[Error matching program output for compflags/bradc/minimalModules/minModDeclPrint]
-[Error matching program output for compflags/bradc/minimalModules/minModFnRefArg]
-
-
-
-================================
-verify regressions
-(Reviewed for accuracy 10/14/14)
-================================
-
-internal error (mike/hilde)
----------------------------
-[Error matching compiler output for types/records/sungeun/recordWithRefCopyFns]
-  (2014/09/03 -- .future file removed 09/02)
-
-
-================================
-valgrind-specific regressions
-(Reviewed for accuracy 10/14/14)
-================================
-
-annoying occasional invalid write of size 8 in dl_lookup_symbol->do_lookup_x,
-read of size 8 in dl_name_match_p (e.g., 10/2/14)
------------------------------------------------------------------------------
-[Error matching program output for performance/sungeun/dgemm]
-
-occasional invalid write of size 8 in buffered_get_mmap (10/2/14 -- sungeun)
-(fixed 10/08/14)
-----------------------------------------------------------------------------
-[Error matching program output for studies/lulesh/bradc/lulesh-dense (compopts: 1)]
-
-infrequent, annoying timeout
-----------------------------
-[Error: Timed out executing program release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 4)]
-[Error: Timed out executing program domains/sungeun/assoc/parSafeMember]
-
-noisy failure due to invalid write of size 8 (e.g., 09/15/14, 09/24/14, ...)
-----------------------------------------------------------------------------
-[Error matching program output for associative/bharshbarg/parSafeAdd (compopts: 1)]
-
-overlapping memcpy (root cause should be eliminated)
-----------------------------------------------------
-[Error matching program output for io/bradc/readWholeArr]
-[Error matching program output for io/ferguson/readThis/readarr]
-[Error matching program output for io/ferguson/writebinaryarray]
-[Error matching program output for release/examples/benchmarks/miniMD/miniMD (compopts: 1, execopts: 1)]
-[Error matching program output for release/examples/primers/fileIO]
-[Error matching program output for studies/parboil/SAD/sadSerial]
-[Error matching program output for studies/parboil/histo/histoSerial]
-[Error matching program output for studies/parboil/stencil/stencil3D]
-[Error matching program output for users/ferguson/bulkerr]
-
-conditional jump depends on uninitialized value (04/08/14 -- since re2 on)
---------------------------------------------------------------------------
-[Error matching program output for io/tzakian/recordReader/test]
-[Error matching program output for regexp/ferguson/rechan]
-
-invalid read (04/08/14 -- since gmp was turned on)
---------------------------------------------------
-[Error matching program output for modules/standard/gmp/ferguson/gmp_dist_array]
-
-stack overflow
---------------
-[Error matching program output for parallel/cobegin/gbt/cobegin-stacksize]
-
-missing "unable to create more than 0000 threads" warning
----------------------------------------------------------
-[Error matching program output for parallel/taskPool/figueroa/TooManyThreads (compopts: 1)]
-  Perhaps not a real error: The program is expected to raise the warning
-"maxThreadsPerLocale is unbounded, but unable to create more than 0000 threads"
-But under valgrind, the program is executed with --numThreadsPerLocale=100,
-so the warning does not apply and is not raised, and .good is not matched.
-
-invalid read/write of size 8 in ftoa() (10/08/14 -- hilde)
-----------------------------------------------------------
-[Error matching program output for performance/sungeun/assign_across_locales]
-
-"Unrecognised instruction" (05/18/2013)
----------------------------------------
-[Error matching program output for types/atomic/ferguson/atomictest]
-[Error matching program output for types/atomic/sungeun/atomic_vars]
-
-continual timeouts
-------------------
-[Error: Timed out executing program io/ferguson/ctests/qio_test (compopts: 1)]
-[Error: Timed out executing program parallel/begin/sungeun/captureAppearsToWork]
-[Error: Timed out executing program parallel/begin/sungeun/capture]
-[Error: Timed out executing program studies/hpcc/PTRANS/PTRANS]
-[Error: Timed out executing program studies/lammps/shemmy/p-lammps-n1]
-[Error: Timed out executing program studies/lammps/shemmy/p-lammps-n2]
-[Error: Timed out executing program studies/lammps/shemmy/p-lammps-n4]
-[Error: Timed out executing program studies/lulesh/sungeun/lulesh (compopts: 1)]
-[Error: Timed out executing program types/range/bradc/overflowInComputeBlock]
-[Error: Timed out executing program types/single/sungeun/stress]
-
-
-
-================================
-no-local regressions
-(Reviewed for accuracy 10/14/14)
-================================
-
-
-====================================================
-gasnet-everything regressions (other than the above)
-(Reviewed for accuracy 10/15/14)
-====================================================
-
-annoying occasional failures even after Sung calmed down (09/18/14 -- sungeun)
-------------------------------------------------------------------------------
-[Error matching program output for types/string/StringImpl/memLeaks/coforall]
-
-seg fault (09/17/14 -- fixed 09/19/14)
---------------------------------------
-[Error matching program output for multilocale/deitz/needMultiLocales/mdblock/test_block2d_2]
-
-error: cannot create C string from remote string (due to r22900 -- sungeun)
----------------------------------------------------------------------------
-[Error matching program output for classes/sungeun/remoteDynamicDispatch (compopts: 1)]
-[Error matching program output for multilocale/diten/needMultiLocales/remoteStringTuple]
-(due to r23558)
-[Error matching program output for optimizations/sungeun/RADOpt/access1d (compopts: 1)] (2014/06/14)
-[Error matching program output for optimizations/sungeun/RADOpt/access2d (compopts: 1)] (2014/06/14)
-[Error matching program output for optimizations/sungeun/RADOpt/access3d (compopts: 1)] (2014/06/14)
-
-
-==============================================
-gasnet-fast regressions (other than the above)
-(Reviewed for accuracy 10/14/14)
-==============================================
-
-noisy failure due to 'slave got an unknown command on coord socket' (09/27/14)
-------------------------------------------------------------------------------
-[Error matching program output for multilocale/diten/localBlock/needMultiLocales/localBlock5]
-
-noisy unresolved access of range by (2) (10/07/14)
---------------------------------------------------
-[Error matching program output for users/jglewis/SSCA2_sync_array_initialization_bug]
-
-consistent timeouts
--------------------
-[Error: Timed out executing program associative/bharshbarg/parSafeAdd (compopts: 1)]
-[Error: Timed out executing program domains/sungeun/assoc/parSafeMember]
-[Error: Timed out executing program memory/shannon/outofmemory/mallocOutOfMemory]
-[Error: Timed out executing program studies/lulesh/sungeun/lulesh (compopts: 1)]
-
-
-
-============================================================
-linux32 (comm-gasnet) regressions (in addition to the above)
-(Reviewed for accuracy 10/14/14)
-============================================================
-
-occasional, annoying timeout
-----------------------------
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 2, execopts: 1)]
-
-fairly consistent timeouts due to qthreads oversubscription (09/15/14)
-----------------------------------------------------------------------
-[Error: Timed out executing program release/examples/benchmarks/hpcc/hpl]
-[Error: Timed out executing program release/examples/benchmarks/hpcc/ptrans]
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 3, execopts: 1)]
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 4, execopts: 1)]
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5, execopts: 1)]
-
-
-========================================================
-none.qthreads.numa-specific tests (other no-local above)
-(Reviewed for accuracy 10/14/14)
-========================================================
-
-
-==========================================================
-gasnet.qthreads.numa-specific tests (other than the above)
-(Reviewed for accuracy 10/14/14)
-==========================================================
-
-occaaional segfault
--------------------
-[Error matching program output for release/examples/programs/quicksort]
-
-frequent, annoying timeout
---------------------------
-[Error: Timed out executing program release/examples/programs/quicksort]
-
-comm count mismatches
----------------------
-[Error matching program output for distributions/robust/arithmetic/performance/multilocale/reduceAlias]
-[Error matching program output for distributions/robust/arithmetic/performance/multilocale/reduceSlice]
-[Error matching program output for distributions/robust/arithmetic/performance/multilocale/reduce]
-
-
-======================================================
-gasnet.fifo.flat-specific tests (other than the above)
-(Reviewed for accuracy 10/13/14)
-======================================================
-
-very infrequent segfault (10/03/14)
------------------------------------
-[Error matching program output for types/string/StringImpl/stress/plusEquals]
-
-infrequent timeouts
--------------------
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_mul]
-
-annoying, noisy timeouts
-------------------------
-[Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dBDtoDRTest]
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_diff]
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_gaxpy]
-[Error: Timed out executing program distributions/robust/arithmetic/slicing/test_array_slicing3]
-
-consistent timeouts
--------------------
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_likepy]
-
-
-================================
-fifo-specific regressions
-(Reviewed for accuracy 10/15/14)
-================================
-
-
-================================
-darwin-specific regressions
-(reviewed for accuracy 10/14/14)
-================================
-
-need machine specific .good file
---------------------------------
+===================
+linux64
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+
+===================
+linux32
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+
+===================
+darwin
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+need machine-specific .good file (bradc)
+----------------------------------------
 [Error cannot locate program output comparison file studies/hpcc/common/testProbSize.good]
 [Error matching program output for modules/standard/memory/countMemory/countMemory]
 
@@ -380,8 +178,8 @@ halt reached
 ------------
 [Error matching program output for stress/deitz/test_10k_begins]
 
-surprising timeouts?
---------------------
+consistent timeouts (surprising?)
+---------------------------------
 [Error: Timed out executing program exercises/RandomNumber6]
 [Error: Timed out executing program memory/shannon/outofmemory/mallocOutOfMemory]
 [Error: Timed out executing program parallel/begin/deitz/test_begin2]
@@ -391,16 +189,360 @@ surprising timeouts?
 [Error: Timed out executing program parallel/sync/figueroa/WriteMethods]
 
 
-======================================
-chpbld01 (PrgEnv/XC whitebox) failures
-(Reviewed for accuracy 10/15/14)
-======================================
+===================
+perf*
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+===================
+perf.bradc-lnx
+Inherits 'perf*'
+Reviewed 2014-10-16
+===================
+
+consistent failure due to insane memory usage (should get better with strings)
+------------------------------------------------------------------------------
+[Error matching performance keys for studies/shootout/fasta/kbrady/fasta-lines]
 
 
-======================================
-chpbld02 (PrgEnv/XE whitebox) failures
-(Reviewed for accuracy 10/15/14)
-======================================
+===================
+perf.chap03
+Inherits 'perf*'
+Reviewed 2014-10-16
+===================
+
+consistent failure due to insane memory usage (should get better with strings)
+------------------------------------------------------------------------------
+[Error matching performance keys for studies/shootout/fasta/kbrady/fasta-lines]
+
+
+===================
+perf.chap04
+Inherits 'perf*'
+Reviewed 2014-10-16
+===================
+
+
+======================
+perf.chap04.playground
+Inherits 'perf*'
+Reviewed 2014-10-16
+======================
+
+
+===================
+fast
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+
+===================
+memleaks.examples
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+============================
+memleaks
+Inherits 'memleaks.examples'
+Reviewed ??/??/??
+============================
+
+sporadic segfault (infrequent) (10/03/14)
+-----------------------------------------
+[Error matching program output for stress/deitz/test_10k_begins]
+
+Setting a config that isn't supported for --minimal-modules (1/23/14 - bradc)
+-----------------------------------------------------------------------------
+[Error matching program output for compflags/bradc/minimalModules/minModDeclPrint]
+[Error matching program output for compflags/bradc/minimalModules/minModFnRefArg]
+
+
+
+===================
+verify
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+internal error (mike/hilde)
+---------------------------
+[Error matching compiler output for types/records/sungeun/recordWithRefCopyFns]
+  (2014/09/03 -- .future file removed 09/02)
+
+
+==================
+valgrind
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+annoying occasional invalid write of size 8 in dl_lookup_symbol->do_lookup_x,
+read of size 8 in dl_name_match_p (e.g., 10/2/14)
+-----------------------------------------------------------------------------
+[Error matching program output for performance/sungeun/dgemm]
+
+occasional invalid write of size 8 in buffered_get_mmap (10/2/14 -- sungeun)
+(fixed 10/08/14)
+----------------------------------------------------------------------------
+[Error matching program output for studies/lulesh/bradc/lulesh-dense (compopts: 1)]
+
+infrequent, annoying timeout
+----------------------------
+[Error: Timed out executing program release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 4)]
+[Error: Timed out executing program domains/sungeun/assoc/parSafeMember]
+
+noisy failure due to invalid write of size 8 (e.g., 09/15/14, 09/24/14, ...)
+----------------------------------------------------------------------------
+[Error matching program output for associative/bharshbarg/parSafeAdd (compopts: 1)]
+
+overlapping memcpy (root cause should be eliminated)
+----------------------------------------------------
+[Error matching program output for io/bradc/readWholeArr]
+[Error matching program output for io/ferguson/readThis/readarr]
+[Error matching program output for io/ferguson/writebinaryarray]
+[Error matching program output for release/examples/benchmarks/miniMD/miniMD (compopts: 1, execopts: 1)]
+[Error matching program output for release/examples/primers/fileIO]
+[Error matching program output for studies/parboil/SAD/sadSerial]
+[Error matching program output for studies/parboil/histo/histoSerial]
+[Error matching program output for studies/parboil/stencil/stencil3D]
+[Error matching program output for users/ferguson/bulkerr]
+
+conditional jump depends on uninitialized value (04/08/14 -- since re2 on)
+--------------------------------------------------------------------------
+[Error matching program output for io/tzakian/recordReader/test]
+[Error matching program output for regexp/ferguson/rechan]
+
+invalid read (04/08/14 -- since gmp was turned on)
+--------------------------------------------------
+[Error matching program output for modules/standard/gmp/ferguson/gmp_dist_array]
+
+stack overflow
+--------------
+[Error matching program output for parallel/cobegin/gbt/cobegin-stacksize]
+
+missing "unable to create more than 0000 threads" warning
+---------------------------------------------------------
+[Error matching program output for parallel/taskPool/figueroa/TooManyThreads (compopts: 1)]
+  Perhaps not a real error: The program is expected to raise the warning
+"maxThreadsPerLocale is unbounded, but unable to create more than 0000 threads"
+But under valgrind, the program is executed with --numThreadsPerLocale=100,
+so the warning does not apply and is not raised, and .good is not matched.
+
+invalid read/write of size 8 in ftoa() (10/08/14 -- hilde)
+----------------------------------------------------------
+[Error matching program output for performance/sungeun/assign_across_locales]
+
+"Unrecognised instruction" (05/18/2013)
+---------------------------------------
+[Error matching program output for types/atomic/ferguson/atomictest]
+[Error matching program output for types/atomic/sungeun/atomic_vars]
+
+continual timeouts
+------------------
+[Error: Timed out executing program io/ferguson/ctests/qio_test (compopts: 1)]
+[Error: Timed out executing program parallel/begin/sungeun/captureAppearsToWork]
+[Error: Timed out executing program parallel/begin/sungeun/capture]
+[Error: Timed out executing program studies/hpcc/PTRANS/PTRANS]
+[Error: Timed out executing program studies/lammps/shemmy/p-lammps-n1]
+[Error: Timed out executing program studies/lammps/shemmy/p-lammps-n2]
+[Error: Timed out executing program studies/lammps/shemmy/p-lammps-n4]
+[Error: Timed out executing program studies/lulesh/sungeun/lulesh (compopts: 1)]
+[Error: Timed out executing program types/range/bradc/overflowInComputeBlock]
+[Error: Timed out executing program types/single/sungeun/stress]
+
+
+===================
+llvm
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+relies on macro in gmp.h -- not expected to work without effort (09/18/14)
+***suppressed (but shouldn't be in bradc's NSHO)***
+--------------------------------------------------------------------------
+[Error matching compiler output for release/examples/benchmarks/shootout/pidigits]
+
+
+===================
+fifo
+Inherits 'general'
+reviewed 2014-10-16
+===================
+
+
+===================
+numa
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+
+===================
+no-local
+Inherits 'general'
+Reviewed ????-??-??
+===================
+
+
+===================
+gasnet* regressions
+Inherits 'no-local'
+Reviewed 2014-10-16
+===================
+
+annoying occasional failures even after Sung calmed down (09/18/14 -- sungeun)
+------------------------------------------------------------------------------
+[Error matching program output for types/string/StringImpl/memLeaks/coforall]
+
+error: cannot create C string from remote string (due to r22900 -- sungeun)
+---------------------------------------------------------------------------
+[Error matching program output for classes/sungeun/remoteDynamicDispatch (compopts: 1)]
+[Error matching program output for multilocale/diten/needMultiLocales/remoteStringTuple]
+(due to r23558)
+[Error matching program output for optimizations/sungeun/RADOpt/access1d (compopts: 1)] (2014/06/14)
+[Error matching program output for optimizations/sungeun/RADOpt/access2d (compopts: 1)] (2014/06/14)
+[Error matching program output for optimizations/sungeun/RADOpt/access3d (compopts: 1)] (2014/06/14)
+
+
+===================
+gasnet-everything
+Inherits 'gasnet*'
+Reviewed ????-??-??
+===================
+
+seg fault (09/17/14 -- fixed 09/19/14)
+--------------------------------------
+[Error matching program output for multilocale/deitz/needMultiLocales/mdblock/test_block2d_2]
+
+
+===================
+gasnet-fast
+Inherits 'gasnet*'
+Reviewed ????-??-??
+===================
+
+noisy failure due to 'slave got an unknown command on coord socket' (09/27/14)
+------------------------------------------------------------------------------
+[Error matching program output for multilocale/diten/localBlock/needMultiLocales/localBlock5]
+
+noisy unresolved access of range by (2) (10/07/14)
+--------------------------------------------------
+[Error matching program output for users/jglewis/SSCA2_sync_array_initialization_bug]
+
+consistent timeouts
+-------------------
+[Error: Timed out executing program associative/bharshbarg/parSafeAdd (compopts: 1)]
+[Error: Timed out executing program domains/sungeun/assoc/parSafeMember]
+[Error: Timed out executing program memory/shannon/outofmemory/mallocOutOfMemory]
+[Error: Timed out executing program studies/lulesh/sungeun/lulesh (compopts: 1)]
+
+
+
+================================
+gasnet.linux32
+inherits 'linux32' and 'gasnet*'
+Reviewed 2014-10-16
+================================
+
+fairly consistent timeouts due to qthreads oversubscription (09/15/14)
+----------------------------------------------------------------------
+[Error: Timed out executing program release/examples/benchmarks/hpcc/hpl]
+[Error: Timed out executing program release/examples/benchmarks/hpcc/ptrans]
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 3, execopts: 1)]
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 4, execopts: 1)]
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5, execopts: 1)]
+
+sporadic timeout (infrequent)
+-----------------------------
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 2, execopts: 1)]
+
+
+===============================
+gasnet.darwin
+Inherits 'darwin' and 'gasnet*'
+Reviewed ????-??-??
+===============================
+
+
+
+==========================================================
+gasnet.numa (TODO: checkme)
+Inherits 'gasnet*' and 'numa'
+Reviewed ????-??-??
+==========================================================
+
+occaaional segfault
+-------------------
+[Error matching program output for release/examples/programs/quicksort]
+
+frequent, annoying timeout
+--------------------------
+[Error: Timed out executing program release/examples/programs/quicksort]
+
+comm count mismatches
+---------------------
+[Error matching program output for distributions/robust/arithmetic/performance/multilocale/reduceAlias]
+[Error matching program output for distributions/robust/arithmetic/performance/multilocale/reduceSlice]
+[Error matching program output for distributions/robust/arithmetic/performance/multilocale/reduce]
+
+
+================================
+gasnet.fifo.flat (TODO_ checkme)
+Inherits 'gasnet*' and 'fifo'
+Reviewed ????-??-??
+================================
+
+very infrequent segfault (10/03/14)
+-----------------------------------
+[Error matching program output for types/string/StringImpl/stress/plusEquals]
+
+infrequent timeouts
+-------------------
+[Error: Timed out executing program studies/madness/aniruddha/madchap/test_mul]
+
+annoying, noisy timeouts
+------------------------
+[Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dBDtoDRTest]
+[Error: Timed out executing program studies/madness/aniruddha/madchap/test_diff]
+[Error: Timed out executing program studies/madness/aniruddha/madchap/test_gaxpy]
+[Error: Timed out executing program distributions/robust/arithmetic/slicing/test_array_slicing3]
+
+consistent timeouts
+-------------------
+[Error: Timed out executing program studies/madness/aniruddha/madchap/test_likepy]
+
+
+===================
+gasnet.llvm
+Inherits 'llvm'
+Reviewed 2014-10-16
+===================
+
+occasional sporadic timeout
+---------------------------
+[Error: Timed out compilation for release/examples/benchmarks/lulesh/lulesh (compopts: 1)]
+
+frequent sporadic timeout
+-------------------------
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 4, execopts: 1)]
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5, execopts: 1)]
+
+
+===================
+xc-wb.*
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+
+===================
+xe-wb.*
+Inherits 'general'
+Reviewed ????-??-??
+===================
 
 The following tests fail sporadically on chpbld02 due to a seg fault (10/12/14)
 -------------------------------------------------------------------------------
@@ -433,20 +575,20 @@ the following failures (should valgrind these on whiteboxes to diagnose)
 [Error matching program output for types/file/fwriteIntFailed]
 
 
-==========================================================
-cray-prgenv-*-specific failures (in addition to the above)
-(Reviewed for accuracy 10/15/14)
-==========================================================
+========================
+*prgenv-* TODO: reviewme
+Reviewed ????-??-??
+========================
 
 problem with static/dynamic linking?
 ------------------------------------
 [Error matching compiler output for link/sungeun/static_dynamic (compopts: 6)] (started 10/26/2012)
 
 
-=========================================
-cray-prgenv-cray/cce-specific regressions
-(Reviewed for accuracy 10/14/14)
-=========================================
+=============================
+prgenv-cray* (TODO: reviewme)
+Reviewed ????-??-??
+=============================
 
 some output dropped nondeterministically 
 ----------------------------------------
@@ -535,10 +677,18 @@ compilation timeouts (since at least 02/23/14)
 [Error: Timed out compilation for users/franzf/v1/chpl/main (compopts: 1)]
 
 
-==================================================
-cray-prgenv-pgi regressions (in addition to above)
-(Reviewed for accuracy 10/14/14)
-==================================================
+===================
+*pgi*
+Inherits 'general'
+Reviewed 2014-10-16
+===================
+
+
+=============================
+x?-wb.host.prgenv.pgi
+Inherits 'x?-wb*' and '*pgi*'
+Reviewed 2014-10-16
+=============================
 
 problem with empty initializer (1/25/14 -- bradc)
 -------------------------------------------------
@@ -572,16 +722,25 @@ consistent timeout
 [Error: Timed out executing program domains/sungeun/assoc/parSafeMember]
 
 
-===============================================
-pgi-specific regressions (in addition to above)
-(Reviewed for accuracy 09/29/14)
-===============================================
+=============================
+x?-wb.pgi (TODO: checkme)
+Inherits 'x?-wb*' and '*pgi*'
+Reviewed ????-??-??
+=============================
 
 
-==========================================================================
-cray-prgenv-intel-specific regressions (in addition to cray-prgenv* above)
-(Reviewed for accuracy 10/14/14)
-==========================================================================
+===================
+*intel*
+Inherits 'general'
+Reviewed ????-??-??
+===================
+
+
+=============================
+x?-wb.prgenv-intel (TODO: checkme)
+Inherits 'x?-wb*' and 'intel'
+Reviewed ????-??-??
+=============================
 
 test assertion failures (09/21-23/14)
 -------------------------------------
@@ -598,11 +757,11 @@ alignment mismatch in output
 [Error matching program output for types/range/hilde/align]
 
 
-==============================================================================
-intel-specific regressions (in addition to cray-prgenv-intel + chpbld02 above)
-(reviewed for accuracy 09/24/14)
-==============================================================================
-
+=============================
+x?-wb.intel (TODO: checkme)
+Inherits 'x?-wb*' and 'intel'
+Reviewed ????-??-??
+=============================
 
 static/dynamic linking issues
 -----------------------------
@@ -614,9 +773,10 @@ static/dynamic linking issues
 3)]
 
 
-================================
-gnu failures on whiteboxes
-(Reviewed for accuracy 07/13/14)
+===============================
+*gnu*
+Inherits 'x?-wb*' and 'linux64'
+Reviewed ????-??-??
 ================================
 
 gcc warning about assuming strict overflow
@@ -625,42 +785,18 @@ gcc warning about assuming strict overflow
 
 
 =================================
-cray-prgenv-gnu specific failures
-(in addition to the above)
-(Reviewed for accuracy 09/25/14)
+x?-wb.prgenv-gnu (TODO: checkme)
+Inherits 'x?-wb*' and '*gnu*'
+Reviewed ????-??-??
 =================================
 
 
 
-================================
-LLVM specific regressions
-(Reviewed for accuracy 10/14/14)
-================================
-
-relies on macro in gmp.h -- not expected to work without effort (09/18/14)
-***suppressed***
---------------------------------------------------------------------------
-[Error matching compiler output for release/examples/benchmarks/shootout/pidigits]
-
-================================
-LLVM gasnet specific regressions
-(Reviewed for accuracy 10/15/14)
-================================
-
-occasional, annoying timeout
-----------------------------
-[Error: Timed out compilation for release/examples/benchmarks/lulesh/lulesh (compopts: 1)]
-
-frequent, annoying timeout
---------------------------
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 4, execopts: 1)]
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5, execopts: 1)]
-
-
-===================================
-cygwin-specific failures
-(Reviewed for accuracy on 10/14/14)
-===================================
+===================
+cygwin
+Inherits 'linux64'
+Reviewed ????-??-??
+===================
 
 very infrequent "CreateProcessW failed"
 ---------------------------------------
@@ -757,10 +893,11 @@ consistent timeouts
 [Error: Timed out executing program studies/lulesh/sungeun/lulesh (compopts: 1)]
 
 
-================================
-baseline-specific tests
-(Reviewed for accuracy 10/14/14)
-================================
+===================
+baseline
+Inherits 'general'
+Reviewed 2014-10-16
+===================
 
 incorrect output -- expected? (04/03/10)
 ----------------------------------------
@@ -790,6 +927,10 @@ email on 5/9/14) that it could be modified to fail even without giving
 ------------------------------------------------------------------------
 [Error matching program output for extern/bradc/structs/externFloat4calls.someFields (compopts: 1)]
 
+??? (wrong output)
+------------------
+[Error matching program output for extern/ferguson/crazyRecord (compopts: 1)]
+
 segv due to turning on inlining (12/7/12)
 -----------------------------------------
 sungeun: I have confirmed that almost all of these are due to running
@@ -799,9 +940,8 @@ think we would prefer these errors.
 
 [Error matching program output for parallel/cobegin/gbt/cobegin-stacksize]
 
-glibc: double free or corruption (09/28/13)
-(some of these and more are also in TRIAGE as they seem to flit in and out)
----------------------------------------------------------------------------
+sporadic glibc: double free or corruption (frequent) (09/28/13)
+---------------------------------------------------------------
 [Error matching program output for release/examples/benchmarks/hpcc/hpl]
 [Error matching program output for studies/glob/test_glob (compopts: 1)]
 [Error matching program output for studies/hpcc/FFT/marybeth/fft-test-even]
@@ -823,40 +963,27 @@ Tests suppressions that now succeed due to turning on inlining (12/7/12)
 [Error: did not find expected suppression trivial/mjoyner/inlinefunc/inlfunc2_report]
 
 
-================================
-block distribution regressions
-(Reviewed for accuracy 10/14/14)
-================================
+===================
+dist-block
+Reviewed 2014-10-16
+===================
 
-frequent, annoying timeout
---------------------------
+sporadic timeout (frequent)
+---------------------------
 [Error: Timed out executing program distributions/robust/arithmetic/kernels/jacobi]
 
 
-================================
-cyclic distribution regressions
-(Reviewed for accuracy 10/15/14)
-================================
-
-sporadic extent mismatch errors (10/11/14)
-------------------------------------------
-[Error matching program output for distributions/robust/arithmetic/reindexing/test_strided_reindex2 (compopts: 1)]
-
-constant, annoying shift in timeouts -- due to machine load or qthreads oversub?
---------------------------------------------------------------------------------
-[Error: Timed out compilation for distributions/robust/arithmetic/basics/test_array_assignment]
-[Error: Timed out compilation for distributions/robust/arithmetic/basics/test_array_swap]
-[Error: Timed out compilation for distributions/robust/arithmetic/reindexing/test_array_alias1]
-[Error: Timed out compilation for distributions/robust/arithmetic/basics/test_zipper_default]
-[Error: Timed out compilation for distributions/robust/arithmetic/modules/test_module_Random]
-[Error: Timed out compilation for distributions/robust/arithmetic/modules/test_module_Search]
+===================
+dist-cyclic
+Reviewed 2014-10-16
+===================
 
 communication counts changed due to r23004, gbt (03/30/14)
 ----------------------------------------------------------
 [Error matching program output for distributions/robust/arithmetic/performance/multilocale/alloc]
 
-communication counts changed due to Vass' task functions commit (05/30/13)
----------------------------------------------------------------------------
+communication counts changed due to task functions commit (05/30/13 -- vass)
+----------------------------------------------------------------------------
 [Error matching program output for distributions/robust/arithmetic/performance/multilocale/assign]
 [Error matching program output for distributions/robust/arithmetic/performance/multilocale/reduce]
 
@@ -870,17 +997,27 @@ regular timeouts due to oversubscription under qthreads (08/26/14)
 [Error: Timed out executing program distributions/robust/arithmetic/stress/test_many_array]
 [Error: Timed out executing program distributions/robust/arithmetic/stress/test_many_domains]
 
+sporadic extent mismatch errors (infrequent) (10/11/14)
+-------------------------------------------------------
+[Error matching program output for distributions/robust/arithmetic/reindexing/test_strided_reindex2 (compopts: 1)]
 
-===================================
-replicated distribution regressions
-(Reviewed for accuracy 09/25/14)
-===================================
+sporadic timeouts (frequent)
+----------------------------
+[Error: Timed out compilation for distributions/robust/arithmetic/basics/test_array_assignment]
+[Error: Timed out compilation for distributions/robust/arithmetic/basics/test_array_swap]
+[Error: Timed out compilation for distributions/robust/arithmetic/reindexing/test_array_alias1]
+[Error: Timed out compilation for distributions/robust/arithmetic/basics/test_zipper_default]
+[Error: Timed out compilation for distributions/robust/arithmetic/modules/test_module_Random]
+[Error: Timed out compilation for distributions/robust/arithmetic/modules/test_module_Search]
 
-SIGSEGV at execution time (started 7/24/14)
--------------------------------------------
-NightlyDists/day4-Thu-linux64.gnu.gasnet.fifo.flat-distreplicated.log:
-  [Error matching program output for distributions/robust/arithmetic/kernels/hpl (compopts: 1)]
 
+
+===================
+dist-replicated
+Reviewed 2014-10-16
+===================
+
+is replicated testing really of any value at present? (vass)
 See chapel_dev email thread starting 2/12/14 12:42:46 CST (David Iten) with
 subject "Re: FW: Cron Dist replicated (linux64.gnu.gasnet.fifo.flat) 60/0/60".
 ------------------------------------------------------------------------------
@@ -917,7 +1054,6 @@ subject "Re: FW: Cron Dist replicated (linux64.gnu.gasnet.fifo.flat) 60/0/60".
 [Error matching program output for distributions/robust/arithmetic/optimizations/optimizeOnClauses_basic_record]
 [Error matching program output for distributions/robust/arithmetic/optimizations/optimizeOnClauses_basic_tuple]
 [Error matching program output for distributions/robust/arithmetic/performance/multilocale/alloc]
-[Error matching program output for distributions/robust/arithmetic/performance/multilocale/alloc_all]
 [Error matching program output for distributions/robust/arithmetic/performance/multilocale/assignAlias]
 [Error matching program output for distributions/robust/arithmetic/performance/multilocale/assignSlice]
 [Error matching program output for distributions/robust/arithmetic/performance/multilocale/reduceAlias]
@@ -930,7 +1066,6 @@ subject "Re: FW: Cron Dist replicated (linux64.gnu.gasnet.fifo.flat) 60/0/60".
 [Error matching program output for distributions/robust/arithmetic/resizing/test_domain_resize1]
 [Error matching program output for distributions/robust/arithmetic/slicing/test_array_slicing1]
 [Error matching program output for distributions/robust/arithmetic/slicing/test_array_slicing2]
-[Error matching program output for distributions/robust/arithmetic/slicing/test_array_slicing3]
 [Error matching program output for distributions/robust/arithmetic/slicing/test_domain_slicing1]
 [Error matching program output for distributions/robust/arithmetic/slicing/test_strided_slice1]
 [Error matching program output for distributions/robust/arithmetic/slicing/test_strided_slice2]
@@ -945,9 +1080,13 @@ subject "Re: FW: Cron Dist replicated (linux64.gnu.gasnet.fifo.flat) 60/0/60".
 [Error matching program output for distributions/robust/arithmetic/trivial/test_tuple_to_array]
 [Error matching program output for distributions/robust/arithmetic/trivial/test_writeln]
 
-[Error: Timed out executing program distributions/robust/arithmetic/stress/test_many_domains]
-[Error: Timed out executing program distributions/robust/arithmetic/stress/test_many_array]
+stable timeout
+--------------
+[Error: Timed out executing program distributions/robust/arithmetic/slicing/test_array_slicing3]
 
+
+
+TODO: Need to bring this up-to-snuff, automate mailings
 
 ============================================
 CHPL_COMM=ugni, CHPL_TASKS=muxed regressions


### PR DESCRIPTION
To go along with our nice, clean, new cron job identifiers, I've
refactored the REGRESSIONS file, in part inspired by the cleanup, in
part enabled by it.  This doesn't do anything like get us to a
completely happy place with REGRESSIONS, but hopefully people will
understand it better and it'll be useful for regressions week.
(And hopefully after REGRESSIONS week, it'll be much emptier).

There's still more to do here (esp. since not all tests have come
in yet under the new system), but this is a good enough start
that it's worth snapshotting and pushing out for people to see.

The major changes were:
- Updated comments at top of file to reflect current thinking/format
- Reformatted category entries to match nightly runs
- Made the implied/mental inheritance between categories explicit in
  the category header itself rather than vague entries like "along
  with the above"
- Introduced new "wildcard/abstract categories" (other than just
  "general" before) to serve as roots for common configurations
  like "gasnet*" rather than relying on "gasnet-everything" to
  be the base case for all GASNet testing (it wasn't always
  accurate in this respect)
- Tightened up the wording for the category names, reviewed by
  dates, etc. to be pithier.
- Reordered tests to reflect what seems like a more logical ordering:
  Primary environments, interesting configurations, gasnet, xe/xc,
  lower-priority environments, then distribution testing.
- Also tried to unify more on the name "sporadic" when describing
  nondeterministic cases and move these to the end of sections,
  but more work remains here.

Here are some excerpts for reference:

```
===================
general
Reviewed 2014-10-16
===================

sporadic failure (2-3x a month -- vass)
---------------------------------------
[Error matching program output for parallel/taskPar/taskIntents/21-capture-in-cobegin]


...

===================
no-local
Inherits 'general'
Reviewed ????-??-??
===================


===================
gasnet* regressions
Inherits 'no-local'
Reviewed 2014-10-16
===================

annoying occasional failures even after Sung calmed down (09/18/14 -- sungeun)
------------------------------------------------------------------------------
[Error matching program output for types/string/StringImpl/memLeaks/coforall]

error: cannot create C string from remote string (due to r22900 -- sungeun)
---------------------------------------------------------------------------
[Error matching program output for classes/sungeun/remoteDynamicDispatch (compopts: 1)]
[Error matching program output for multilocale/diten/needMultiLocales/remoteStringTuple] (due to r23558)
[Error matching program output for optimizations/sungeun/RADOpt/access1d (compopts: 1)] (2014/06/14)
[Error matching program output for optimizations/sungeun/RADOpt/access2d (compopts: 1)] (2014/06/14)
[Error matching program output for optimizations/sungeun/RADOpt/access3d (compopts: 1)] (2014/06/14)


===================
gasnet-fast
Inherits 'gasnet*'
Reviewed ????-??-??
===================

noisy failure due to 'slave got an unknown command on coord socket' (09/27/14)
------------------------------------------------------------------------------
[Error matching program output for multilocale/diten/localBlock/needMultiLocales/localBlock5]

noisy unresolved access of range by (2) (10/07/14)
--------------------------------------------------
[Error matching program output for users/jglewis/SSCA2_sync_array_initialization_bug]

consistent timeouts
-------------------
[Error: Timed out executing program associative/bharshbarg/parSafeAdd (compopts: 1)]
[Error: Timed out executing program domains/sungeun/assoc/parSafeMember]
[Error: Timed out executing program memory/shannon/outofmemory/mallocOutOfMemory]
[Error: Timed out executing program studies/lulesh/sungeun/lulesh (compopts: 1)]



================================
gasnet.linux32
inherits 'linux32' and 'gasnet*'
Reviewed 2014-10-16
================================

fairly consistent timeouts due to qthreads oversubscription (09/15/14)
----------------------------------------------------------------------
[Error: Timed out executing program release/examples/benchmarks/hpcc/hpl]
[Error: Timed out executing program release/examples/benchmarks/hpcc/ptrans]
[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 3, execopts: 1)]
[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 4, execopts: 1)]
[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5, execopts: 1)]

sporadic timeout (infrequent)
-----------------------------
[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 2, execopts: 1)]
```
