### PR TITLE
strip newline for new comp perf .dat files

### DIFF
--- a/util/test/combineCompPerfData
+++ b/util/test/combineCompPerfData
@@ -134,6 +134,7 @@ def main():
     percentTimeCompiling = (totalTimeCompiling/elapsedTestTime) * 100
 
     # remove the colons in the compiler pass keys
+    perfKeysString = perfKeysString.rstrip()
     allOutputPerfKeys = perfKeysString.replace(' :', ' (all)')
     releaseExampleOutputPerfKeys = perfKeysString.replace(' :', ' (examples)')
     # combine the date, and each averaged value


### PR DESCRIPTION
New comp perf .dat files were created like:

  #Date perfKey

  00/00/00  perfVal

this just strips a newline so there is no newline after the header in a new .dat file:

  #Date perfKey
  00/00/00  perfVal
