### PR TITLE
Fix valgrind nightly testing.

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -469,7 +469,7 @@ if ($examples == 1) {
             $testdirs .= " localeModels memory distributions/robust/arithmetic";
         }
     }
-    if ($parnodefile neq "") {
+    if ($parnodefile ne "") {
         mysystem("cd $testdir && find $testdirs -wholename \"*.svn\" -prune -o -type d > DIRFILE", 
                  "making directory file", 1, 1);
         $testflags = "$testflags -dirfile DIRFILE";


### PR DESCRIPTION
I moved a block into the global scope in #647 that caused a DIRFILE to be created, which included directories such as ./Share that are not intended to be run. Move that part of the block back to its original location, leaving the half that concats testdirs onto testflags when not using paratest.
