### PR TITLE
Re-add logdirs in whitebox scripts.

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -106,7 +106,7 @@ export CHPL_LAUNCHER=none
 export CHPL_COMM=none
 
 # Set some vars that nightly cares about.
-export CHPL_NIGHTLY_LOGDIR=/data/sea/chapel/Nightly/${platform}
+export CHPL_NIGHTLY_LOGDIR=/data/sea/chapel/Nightly
 export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 
 # Ensure that one of the CPU modules is loaded.


### PR DESCRIPTION
These scripts do not source common.bash, so it is not set by default. They were
accidentally removed in c2c3e9b.
