### PR TITLE
Update .gitignore for new test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,16 @@ gen
 /test/io/ferguson/binary-output.bin
 /test/io/fsouza/chdir/destination
 /test/io/fsouza/chown/file.txt
+/test/io/fsouza/isdir/my_file
+/test/io/fsouza/isfile/my_file
+/test/io/lydia/chmod/file
+/test/io/lydia/exists/broken_link
+/test/io/lydia/exists/dir_link
+/test/io/lydia/exists/file
+/test/io/lydia/exists/file_link
+/test/io/lydia/isLink/my_file
+/test/io/lydia/isLink/my_link_dir
+/test/io/lydia/isLink/my_link_file
 
 /test/localeModels/gbt/maxTaskPar.good
 


### PR DESCRIPTION
The file utilities functions that Francisco and I have added recently create
stub files and links that don't need to exist in the repository.  After any
test run that includes these directories, git status will flag these files as
untracked.  This will correctly ignore them.
