### PR TITLE
Allow for /proc/cpuinfo files lacking "cpu cores" and/or "siblings" entries.

### DIFF
--- a/test/runtime/gbt/numThreadsSymbolicPhysical.prediff
+++ b/test/runtime/gbt/numThreadsSymbolicPhysical.prediff
@@ -4,6 +4,11 @@ numCores1=$( grep -m 1 '^cpu cores[[:space:]]\+: ' /proc/cpuinfo |
              sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
 numSibs1=$( grep -m 1 '^siblings[[:space:]]\+: ' /proc/cpuinfo |
             sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
-numCores=$(( $numPUs / ( $numSibs1 / $numCores1 ) ))
+if [[ -z $numCores1 || -z $numSibs1 ]] ; then
+  numCores=$numPUs
+else
+  sibsPerCore=$(( $numSibs1 / $numCores1 ))
+  numCores=$(( $numPUs / $sibsPerCore ))
+fi
 
 echo $numCores > $1.good


### PR DESCRIPTION
Borrow code from localeModels/gbt/maxTaskPar to handle the case where
/proc/cpuinfo doesn't have the entries we expect for hyperthreads.
