### PR TITLE
Update record_from_string.bad file.

### DIFF
--- a/test/users/ferguson/record_from_string.bad
+++ b/test/users/ferguson/record_from_string.bad
@@ -1,1 +1,1 @@
-record_from_string.chpl:1: error: type mismatch in assignment from string to Point
+record_from_string.chpl:11: error: type mismatch in assignment from string to Point


### PR DESCRIPTION
This is an improvement resulting from PR#667.

Because FLAG_COMPILER_GENERATED was not attached to the compiler-generated record
assignment function, the assignment type mismatch error was attributed to the first line
of the record definition (line 1) rather than the line on which it is invoked (line 11).
Now the error is attributed to the user source code line that causes it, which is at once
more accurate and more useful.
