### PR TITLE
Removing inline-oriented suppressions from baseline.suppress

### DIFF
--- a/test/Suppressions/baseline.suppress
+++ b/test/Suppressions/baseline.suppress
@@ -1,6 +1,9 @@
-#Because inlining is turned off when baseline is run:
-trivial/mjoyner/inlinefunc/inlfunc1_report
-trivial/mjoyner/inlinefunc/inlfunc2_report
+##Because inlining is turned off when baseline is run:
+#Actually, now it's turned back on when baseline is run.  Hopefully
+#that won't always be the case, so I'm temporarily un-suppressing
+#these.
+#trivial/mjoyner/inlinefunc/inlfunc1_report
+#trivial/mjoyner/inlinefunc/inlfunc2_report
 #Removing unnecessary autocopies necessary to get to minimum number of leaks
 memory/figueroa/LeakedMemory5
 # lack of optimizations lead to extra leaked memory


### PR DESCRIPTION
For some time now, we've thrown --inline when doing --baseline
testing for reasons that I can't quite recall.  This has caused
tests that used to be suppressed for baseline testing (because
they test that inlining is working) to result in errors because
the expected suppression wasn't found.

This commit comments out those suppressions and adds an
explanation such that, if/when we make --baseline testing
just throw --baseline again, the history is visible in the
file.
