### PR TITLE
Make c_string_from_wide_string work with remote strings

### DIFF
--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -206,10 +206,13 @@ void c_string_from_string(c_string* ret, chpl_string* str, int32_t lineno, chpl_
 void c_string_from_wide_string(c_string* ret, chpl____wide_chpl_string* str, int32_t lineno, chpl_string filename)
 {
   if( chpl_nodeID != chpl_rt_nodeFromLocaleID(str->locale) ) {
-    chpl_error("cannot create a C string from a remote string",
-               lineno, filename);
+    // TODO: ret gets leaked
+    chpl_comm_wide_get_string(ret, str,
+                              -CHPL_TYPE_chpl_string,
+                              lineno, filename);
+  } else {
+    *ret = str->addr;
   }
-  *ret = str->addr;
 }
 
 //


### PR DESCRIPTION
Removes the error message that you "cannot create a C string from a
remote string", and instead creates a local copy of the remote string.

This local copy is leaked, we should be able to fix the leak when
switching over to the new string implementation.

Fixes:
- classes/sungeun/remoteDynamicDispatch (compopts: 1)
- multilocale/diten/needMultiLocales/remoteStringTuple
- optimizations/sungeun/RADOpt/access1d (compopts: 1)
- optimizations/sungeun/RADOpt/access2d (compopts: 1)
- optimizations/sungeun/RADOpt/access3d (compopts: 1)
