### PR TITLE
Fix two prediffs to work on all OSes

### DIFF
--- a/test/parallel/coforall/gbt/time-sync-incs.prediff
+++ b/test/parallel/coforall/gbt/time-sync-incs.prediff
@@ -1,4 +1,14 @@
-#! /bin/sh
-sed -e 's/^[0-9]\+ \([a-z ]*\) [0-9e.]\+ \([a-z ]*\)$/N \1 T1 \2/' \
-    -e 's/^[0-9e.]\+ \([a-z ]*\)$/T2 \1/' <$2 >$1.prediff.tmp \
-&& mv $1.prediff.tmp $2
+#!/usr/bin/env python
+import sys, re, shutil
+
+test_name = sys.argv[1]
+out_file = sys.argv[2]
+tmp_file = out_file+'.prediff.tmp'
+
+with open(tmp_file, 'w') as tf:
+    with open(out_file) as of:
+        for line in of:
+            line = re.sub(r'^[0-9]+ ([a-z ]*) [0-9e.]+ ([a-z ]*)$', r'N \1 T1 \2', line)
+            line = re.sub(r'^[0-9e.]+ ([a-z ]*)$', r'T2 \1', line)
+            tf.write(line)
+shutil.move(tmp_file, out_file)

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample5.prediff
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample5.prediff
@@ -1,14 +1,14 @@
-#!/bin/csh -f
-set testname = $1
-set outfile  = $2
-set tmpfile  = $outfile.prediff.tmp
+#!/usr/bin/env python
+import sys, re, shutil
 
-echo "Outfile: " $outfile
-echo "tmpFile: " $tmpfile
+test_name = sys.argv[1]
+out_file = sys.argv[2]
+tmp_file = out_file+'.prediff.tmp'
 
-# Replace seconds and gflops values with "NUM"
-sed 's/[0-9]*\.[0-9]* seconds./NUM seconds./' $outfile > $tmpfile
-sed 's/[0-9]*\.[0-9]*\(e[+-][0-9]\+\)\? Gflops\/s/NUM Gflops\/s/' $tmpfile > $outfile
-
-rm $tmpfile
-
+with open(tmp_file, 'w') as tf:
+    with open(out_file) as of:
+        for line in of:
+            line = re.sub(r'[0-9]*\.[0-9]* seconds', 'NUM seconds', line)
+            line = re.sub(r'[0-9]*\.[0-9]*(e[+-][0-9]+)? Gflops/s', 'NUM Gflops/s', line)
+            tf.write(line)
+shutil.move(tmp_file, out_file)


### PR DESCRIPTION
The stock sed on darwin is not GNU or even a modern BSD version and you
can not write an extend regex command that works in both. I've changed
the scripts to be python which will work the same on all the platforms
we support.
