### PR TITLE
Triage update after first two days of "regressions week"

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -69,9 +69,9 @@ general
 Reviewed 2014-10-16
 ===================
 
-something related to Tom's constructor/defaultOf change (10/29/14)
-(fifo, linux64, darwin)
-------------------------------------------------------------------
+something related to the constructor/defaultOf change (10/29/14 -- hilde)
+(fifo, linux64, darwin, no-local)
+-------------------------------------------------------------------------
 [Error matching .bad file for modules/sungeun/no-use-record (compopts: 1)]
 
 bad mismatch (10/22/14 -- hilde -- should be fixed on next run)


### PR DESCRIPTION
## New regressions
- a bunch of lulesh out-of-bound failures on prgenv-cray for unknown
  reasons (hilde investigating, thanks Tom!)
- .bad mistmatch for no-use-record due to improved behavior now
  (hilde updated .bad -- should be fixed on next run)
## Improvements
- one gdbddash tests passing on darwin now, though three remain
  (thanks hilde!)
- parSafeAdd retired for valgrind testing, though still failing under
  gasnet-fast (thanks Ben!)
- record_from_string .bad mismatch now passing in most configurations
  other than xe-wb.*, just due to normal testing lag (thanks hilde!)
- testProbSize, countMemory now working for darwin (thanks me!)
- refArgIsWide now passing for darwin (thanks Kyle!)
- io/sungeun/ioerror now passing on darwin (thanks hilde!)
- time-sync-incs and hplExample5 now passing on darwin (thanks Kyle!)
- remoteStringTuple now passing for gasnet (thanks Kyle!)
- hpl and fft variants no longer getting double free or corruption under
  baseline testing (thanks Mike!)
- inlfunc*_report no longer complaining about missing suppression under
  baseline (thanks me!)
- cyclic communication counts now working for assign and reduce (thanks
  Vass!)
## Misc
- moved some nbody_\* tests to the sporadic category because they are
- ditto some sporadic cyclic failures
- added some new dates to sporadic failures
