### PR TITLE
Update GET counts in output to reflect r23004.

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.cyclic.good
@@ -1,5 +1,5 @@
 Dom1D
-(get = 0, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 0, fork = 2, fork_fast = 0, fork_nb = 3) (get = 36, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 1, fork = 12, fork_fast = 0, fork_nb = 0) (get = 36, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 1, fork = 11, fork_fast = 0, fork_nb = 0) (get = 36, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 1, fork = 11, fork_fast = 0, fork_nb = 0)
+(get = 0, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 0, fork = 2, fork_fast = 0, fork_nb = 3) (get = 39, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 1, fork = 12, fork_fast = 0, fork_nb = 0) (get = 39, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 1, fork = 11, fork_fast = 0, fork_nb = 0) (get = 39, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 1, fork = 11, fork_fast = 0, fork_nb = 0)
 Dom2D
 (get = 0, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 0, fork = 2, fork_fast = 0, fork_nb = 3) (get = 44, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 1, fork = 12, fork_fast = 0, fork_nb = 0) (get = 44, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 1, fork = 11, fork_fast = 0, fork_nb = 0) (get = 44, get_nb = 0, get_nb_test = 0, get_nb_wait = 0, put = 1, fork = 11, fork_fast = 0, fork_nb = 0)
 Dom3D


### PR DESCRIPTION
As a result of (svn) r23004, the GET counts changed from 36 to 39, for
the Dom1D subtest of the alloc test when the distribution is cyclic.
The test has been in regression ever since.  r23004 made the current
task count more accurate by updating it in a more timely way with
respect to the beginnings and endings of the parallel constructs in a
program.  Since the task count is used to throttle forall parallelism
with dataParIgnoreRunningTasks=false (the default), in some cases this
changed the number of tasks used for a forall-stmt.  In the particular
case of this test I've now concluded that the new counts are due to this
effect and are correct.  r23004 caused the number of tasks to change
from 3 to 4, for an internal forall-stmt at ChapelArrays.chpl:1805
invoked indirectly from what is now line 288 of DefaultRectangular.chpl
(was line 266 at the time of r23004).  Managing more tasks for the loop
increased the remote GET count.  This commit updates the GET counts from
36 to 39 to reflect this.

Note that this test still fails.  Some subsequent change caused the FORK
counts for all the subtests to decrease by 6, but this was not noticed
because the test was already failing due to the GET mismatch.  I'll
figure out the FORK change separately.
