### PR TITLE
Different approach to the mallocOutOfMemory problem: limit the heap size

### DIFF
--- a/test/memory/shannon/outofmemory/mallocOutOfMemory.chpl
+++ b/test/memory/shannon/outofmemory/mallocOutOfMemory.chpl
@@ -1,6 +1,7 @@
 extern proc chpl_mem_allocMany(number, size, description, lineno = -1, filename = ""): opaque;
 
-while (1) {
+for i in 1..1000 {
   var i = 1000000;
   chpl_mem_allocMany(i, numBytes(int(64)), 0, 5, "mallocOutOfMemory.chpl");
 }
+halt("If everything works as expected, we should have run out of memory first");

--- a/test/memory/shannon/outofmemory/sub_test
+++ b/test/memory/shannon/outofmemory/sub_test
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Set virtual memory limit
-ulimit -v 40000000
+ulimit -v 400000
+export CHPL_RT_MAX_HEAP_SIZE=4M
 
 ../../../../util/test/sub_test $1


### PR DESCRIPTION
Also made the test have a set end to its loop as Brad suggested instead of
letting it run to infinity when things don't work right.
