### PR TITLE
Change writeln()s of format()ed strings to writef()s

### DIFF
--- a/test/release/examples/benchmarks/lulesh/lulesh.chpl
+++ b/test/release/examples/benchmarks/lulesh/lulesh.chpl
@@ -297,9 +297,9 @@ proc main() {
       deprint("[[ p, e, q ]]", p, e, q);
     }
     if showProgress then
-      writeln("time = ", format("%e", time), ", dt=", format("%e", deltatime),
-              if doTiming then ", elapsed = " + (getCurrentTime()-iterTime) 
-                          else "");
+      writef("time = %er, dt=%er, %s", time, deltatime,
+             if doTiming then ", elapsed = " + (getCurrentTime()-iterTime) +"\n"
+                         else "\n");
   }
   if (cycle == maxcycles) {
     writeln("Stopped early due to reaching maxnumsteps");
@@ -314,12 +314,10 @@ proc main() {
   if printCoords {
     var outfile = open("coords.out", iomode.cw);
     var writer = outfile.writer();
-    var fmtstr = if debug then "%1.9e" else "%1.4e";
-    for i in Nodes {
-      writer.writeln(format(fmtstr, x[i]), " ", 
-                     format(fmtstr, y[i]), " ", 
-                     format(fmtstr, z[i]));
-    }
+    var fmtstr = if debug then "%1.9re %1.9er %1.9er\n" 
+                          else "%1.4er %1.4er %1.4er\n";
+    for i in Nodes do
+      writer.writef(fmtstr, x[i], y[i], z[i]);
     writer.close();
     outfile.close();
   }
@@ -1681,12 +1679,10 @@ iter elemToNodesTuple(e) {
 
 proc deprint(title:string, x:[?D] real, y:[D]real, z:[D]real) {
   writeln(title);
-  for i in D {
-    writeln(format("%3d", i), ": ", 
-            format("%3.4e", x[i]), " ", 
-            format("%3.4e", y[i]), " ", 
-            format("%3.4e", z[i]));
-  }
+  for i in D do
+    writef("%3i: %3.4er %3.4er %3.4er\n", 
+           if use3DRepresentation then idx3DTo1D(i, nodesPerEdge) else i, 
+           x[i], y[i], z[i]);
 }
 
 

--- a/test/release/examples/benchmarks/lulesh/luleshInit.chpl
+++ b/test/release/examples/benchmarks/lulesh/luleshInit.chpl
@@ -77,7 +77,7 @@ proc initCoordinates(X, Y, Z) {
 
   if debugInit then
     for (x,y,z) in zip(X,Y,Z) do
-      writeln(format("%.6f",x), " ", format("%.6f",y), " ", format("%.6f",z));
+      writef("%6dr %6dr %6dr\n", x, y, z);
 }
 
 


### PR DESCRIPTION
This was written before we had writef() in the library, so it
used a number of format() conversions which are pretty ugly
and heavyweight.  Changing to writef() for simplicity and
clarity.
