### PR TITLE
Nbody speed improvements

### DIFF
--- a/test/studies/shootout/nbody/sidelnik/nbody_forloop_3.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_forloop_3.chpl
@@ -20,8 +20,8 @@ record Planet {
 }
 
 proc advance(B: [] Planet, dt: real) {
-  for (b1, i) in zip(B, 0..) do {
-    for b2 in B[i+1..] do {
+  for (b1, i) in zip(B, 0..) {
+    for b2 in B[i+1..] {
       var dx = b1.x - b2.x;
       var dy = b1.y - b2.y;
       var dz = b1.z - b2.z;
@@ -36,7 +36,7 @@ proc advance(B: [] Planet, dt: real) {
     }
   }
 
-  for b in B do {
+  for b in B {
     b.x += dt * b.vx;
     b.y += dt * b.vy;
     b.z += dt * b.vz;
@@ -45,9 +45,9 @@ proc advance(B: [] Planet, dt: real) {
 
 proc energy(B : [] Planet) : real {
   var e : real;
-  for (b1, i) in zip(B, 0..) do {
+  for (b1, i) in zip(B, 0..) {
     e += 0.5 * b1.mass * (b1.vx * b1.vx + b1.vy * b1.vy + b1.vz * b1.vz);
-    for b2 in B[i+1..] do {
+    for b2 in B[i+1..] {
       var dx = b1.x - b2.x;
       var dy = b1.y - b2.y;
       var dz = b1.z - b2.z;
@@ -60,7 +60,7 @@ proc energy(B : [] Planet) : real {
 
 proc offset_momentum(B : [] Planet) {
   var px,py,pz : real;
-  for b in B do {
+  for b in B {
     px += b.vx * b.mass;
     py += b.vy * b.mass;
     pz += b.vz * b.mass;
@@ -109,7 +109,7 @@ proc main() {
                          );
   offset_momentum(bodies);
   writeln(format("#.#########", energy(bodies)));
-  for 1..n do {
+  for 1..n {
     advance(bodies, 0.01);
   }
   writeln(format("#.#########", energy(bodies)));

--- a/test/studies/shootout/nbody/sidelnik/nbody_fullreduction.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_fullreduction.chpl
@@ -21,8 +21,8 @@ class Planet {
 }
 
 proc advance(B: [] Planet, dt: real) {
-  for (b1, i) in zip(B, NBODIES) do {
-    for b2 in B[i+1..] do {
+  for (b1, i) in zip(B, NBODIES) {
+    for b2 in B[i+1..] {
       var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(+ reduce d**2);
       var mag = dt / (distance**3);
@@ -31,16 +31,16 @@ proc advance(B: [] Planet, dt: real) {
     }
   }
   B.coord_vector = + reduce [b in B] (dt * b.vel_vector);
-//	for b in B do {
+//	for b in B {
 //		b.coord_vector += dt * b.vel_vector;
 //	}
 }
 
 proc energy(B : [] Planet) : real {
   var e : real;
-  for (b1,i) in zip(B,NBODIES) do {
+  for (b1,i) in zip(B,NBODIES) {
     e += 0.5 * b1.mass * (+ reduce b1.vel_vector**2);
-    for b2 in B[i+1..] do {
+    for b2 in B[i+1..] {
       var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(+ reduce d**2);
       e -= (b1.mass * b2.mass) / distance;
@@ -94,7 +94,7 @@ proc main() {
   
   offset_momentum(bodies);
   writeln(energy(bodies));
-  for 1..n do {
+  for 1..n {
     advance(bodies, 0.01);
   }
   writeln(energy(bodies));

--- a/test/studies/shootout/nbody/sidelnik/nbody_iterator_7.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_iterator_7.chpl
@@ -31,23 +31,23 @@ iter TriangleIter(B: [] Planet) {
 }
 
 proc advance(B: [] Planet, dt: real) {
-  for (b1,b2) in TriangleIter(B) do {
+  for (b1,b2) in TriangleIter(B) {
     var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
     var distance = sqrt(+ reduce d**2);
     var mag = dt / (distance**3);
     b1.vel_vector -= d * b2.mass * mag;
     b2.vel_vector += d * b1.mass * mag;
   }
-  for b in B do {
+  for b in B {
     b.coord_vector += dt * b.vel_vector;
   }
 }
 
 proc energy(B : [] Planet) : real {
   var e : real;
-  for (b1,i) in zip(B,NBODIES) do {
+  for (b1,i) in zip(B,NBODIES) {
     e += 0.5 * b1.mass * (+ reduce b1.vel_vector**2);
-    for b2 in B[i+1..] do {
+    for b2 in B[i+1..] {
       var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(+ reduce d**2);
       e -= (b1.mass * b2.mass) / distance;
@@ -99,7 +99,7 @@ proc main() {
   
   offset_momentum(bodies);
   writeln(format("#.#########", energy(bodies)));
-  for 1..n do {
+  for 1..n {
     advance(bodies, 0.01);
   }
   writeln(format("#.#########", energy(bodies)));

--- a/test/studies/shootout/nbody/sidelnik/nbody_orig_1.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_orig_1.chpl
@@ -22,8 +22,8 @@ class Planet {
 proc advance(nbodies:int, B: [] Planet, dt: real) {
   var b2 : Planet;
   
-  for (b1, i) in zip(B, 0..) do {
-    for j in i+1..nbodies-1 do {
+  for (b1, i) in zip(B, 0..) {
+    for j in i+1..nbodies-1 {
       b2 = B(j);
       var dx = b1.x - b2.x;
       var dy = b1.y - b2.y;
@@ -39,7 +39,7 @@ proc advance(nbodies:int, B: [] Planet, dt: real) {
     }
   }
   
-  for b in B do {
+  for b in B {
     b.x += dt * b.vx;
     b.y += dt * b.vy;
     b.z += dt * b.vz;
@@ -50,10 +50,10 @@ proc energy(nbodies:int, B : [] Planet) : real {
   var b2 : Planet;
   var e : real;
   
-  for (b1, i) in zip(B, 0..) do {
+  for (b1, i) in zip(B, 0..) {
     e += 0.5 * b1.mass * (b1.vx * b1.vx + b1.vy * b1.vy + b1.vz * b1.vz);
     
-    for j in i+1..nbodies-1 do {
+    for j in i+1..nbodies-1 {
       b2 = B(j);
       var dx = b1.x - b2.x;
       var dy = b1.y - b2.y;
@@ -67,7 +67,7 @@ proc energy(nbodies:int, B : [] Planet) : real {
 
 proc offset_momentum(nbodies:int, B : [] Planet) {
   var px,py,pz : real;
-  for b in B do {
+  for b in B {
     px += b.vx * b.mass;
     py += b.vy * b.mass;
     pz += b.vz * b.mass;
@@ -116,7 +116,7 @@ proc main() {
                          );
   offset_momentum(NBODIES, bodies);
   writeln(format("#.#########", energy(NBODIES, bodies)));
-  for 1..n do {
+  for 1..n {
     advance(NBODIES, bodies, 0.01);
   }
   writeln(format("#.#########", energy(NBODIES, bodies)));

--- a/test/studies/shootout/nbody/sidelnik/nbody_rangesub_5.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_rangesub_5.chpl
@@ -11,8 +11,9 @@ config var n = 10000;
 param PI = 3.141592653589793;
 const solar_mass = (4 * PI * PI);
 param days_per_year = 365.24;
-const vecLen = 0..2;
-const NBODIES = 0..4;
+const vecLen = {0..2};
+const numBodies = 4;
+const NBODIES = 0..numBodies;
 
 record Planet {
   var coord_vector : [vecLen] real; // x,y,z
@@ -21,8 +22,10 @@ record Planet {
 }
 
 proc advance(B: [] Planet, dt: real) {
-  for (b1, i) in zip(B, NBODIES) do {
-    for b2 in B[i+1..] do {
+  for i in NBODIES {
+    refvar b1 = B[i];
+    for j in i+1..numBodies {
+      refvar b2 = B[j];
       var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(d[0]**2 + d[1]**2 + d[2]**2);
       var mag = dt / (distance**3);
@@ -36,11 +39,11 @@ proc advance(B: [] Planet, dt: real) {
 
 proc energy(B : [] Planet) : real {
   var e : real;
-  for (b1,i) in zip(B,NBODIES) do {
+  for (b1,i) in zip(B,NBODIES) {
     e += 0.5 * b1.mass * (b1.vel_vector(0)**2 +
                           b1.vel_vector(1)**2 + 
                           b1.vel_vector(2)**2);
-    for b2 in B[i+1..] do {
+    for b2 in B[i+1..] {
       var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(d[0]**2 + d[1]**2 + d[2]**2);
       e -= (b1.mass * b2.mass) / distance;
@@ -92,7 +95,7 @@ proc main() {
   
   offset_momentum(bodies);
   writeln(format("#.#########", energy(bodies)));
-  for 1..n do {
+  for 1..n {
     advance(bodies, 0.01);
   }
   writeln(format("#.#########", energy(bodies)));

--- a/test/studies/shootout/nbody/sidelnik/nbody_record_2.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_record_2.chpl
@@ -21,8 +21,8 @@ record Planet {
 proc advance(nbodies:int, B: [] Planet, dt: real) {
   var b2 : Planet;
   
-  for (b1, i) in zip(B, 0..) do {
-    for j in i+1..nbodies-1 do {
+  for (b1, i) in zip(B, 0..) {
+    for j in i+1..nbodies-1 {
       var b2 = B(j);
       var dx = b1.x - b2.x;
       var dy = b1.y - b2.y;
@@ -39,7 +39,7 @@ proc advance(nbodies:int, B: [] Planet, dt: real) {
     }
   }
   
-  for b in B do {
+  for b in B {
     b.x += dt * b.vx;
     b.y += dt * b.vy;
     b.z += dt * b.vz;
@@ -50,9 +50,9 @@ proc energy(nbodies:int, B : [] Planet) : real {
   var b2 : Planet;
   var e : real;
   
-  for (b1, i) in zip(B, 0..) do {
+  for (b1, i) in zip(B, 0..) {
     e += 0.5 * b1.mass * (b1.vx * b1.vx + b1.vy * b1.vy + b1.vz * b1.vz);
-    for j in i+1..nbodies-1 do {
+    for j in i+1..nbodies-1 {
       b2 = B(j);
       var dx = b1.x - b2.x;
       var dy = b1.y - b2.y;
@@ -66,7 +66,7 @@ proc energy(nbodies:int, B : [] Planet) : real {
 
 proc offset_momentum(nbodies:int, B : [] Planet) {
   var px,py,pz : real;
-  for b in B do {
+  for b in B {
     px += b.vx * b.mass;
     py += b.vy * b.mass;
     pz += b.vz * b.mass;
@@ -115,7 +115,7 @@ proc main() {
                          );
   offset_momentum(NBODIES, bodies);
   writeln(format("#.#########", energy(NBODIES, bodies)));
-  for 1..n do {
+  for 1..n {
     advance(NBODIES, bodies, 0.01);
   }
   writeln(format("#.#########", energy(NBODIES, bodies)));

--- a/test/studies/shootout/nbody/sidelnik/nbody_record_domain_2a.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_record_domain_2a.chpl
@@ -21,8 +21,8 @@ record Planet {
 proc advance(nbodies:int, B: [0..#nbodies] Planet, dt: real) {
   var b2 : Planet;
   
-  for (b1, i) in zip(B, 0..) do {
-    for j in {i+1..nbodies-1} do {
+  for (b1, i) in zip(B, 0..) {
+    for j in {i+1..nbodies-1} {
       var b2 = B(j);
       var dx = b1.x - b2.x;
       var dy = b1.y - b2.y;
@@ -39,7 +39,7 @@ proc advance(nbodies:int, B: [0..#nbodies] Planet, dt: real) {
     }
   }
   
-  for b in B do {
+  for b in B {
     b.x += dt * b.vx;
     b.y += dt * b.vy;
     b.z += dt * b.vz;
@@ -50,9 +50,9 @@ proc energy(nbodies:int, B : [0..#nbodies] Planet) : real {
   var b2 : Planet;
   var e : real;
   
-  for (b1, i) in zip(B, 0..) do {
+  for (b1, i) in zip(B, 0..) {
     e += 0.5 * b1.mass * (b1.vx * b1.vx + b1.vy * b1.vy + b1.vz * b1.vz);
-    for j in {i+1..nbodies-1} do {
+    for j in {i+1..nbodies-1} {
       b2 = B(j);
       var dx = b1.x - b2.x;
       var dy = b1.y - b2.y;
@@ -66,7 +66,7 @@ proc energy(nbodies:int, B : [0..#nbodies] Planet) : real {
 
 proc offset_momentum(nbodies:int, B : [0..#nbodies] Planet) {
   var px,py,pz : real;
-  for b in B do {
+  for b in B {
     px += b.vx * b.mass;
     py += b.vy * b.mass;
     pz += b.vz * b.mass;
@@ -115,7 +115,7 @@ proc main() {
                          );
   offset_momentum(NBODIES, bodies);
   writeln(format("#.#########", energy(NBODIES, bodies)));
-  for 1..n do {
+  for 1..n {
     advance(NBODIES, bodies, 0.01);
   }
   writeln(format("#.#########", energy(NBODIES, bodies)));

--- a/test/studies/shootout/nbody/sidelnik/nbody_recorditerator.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_recorditerator.chpl
@@ -21,31 +21,31 @@ record Planet {
 }
 
 iter TriangleIter(B: [] Planet) ref {
-  for (b1,i) in (B,NBODIES) do {
-    for b2 in B[i+1..] do {
+  for (b1,i) in (B,NBODIES) {
+    for b2 in B[i+1..] {
       yield (b1,b2);
     }
   }
 }
 
 proc advance(B: [] Planet, dt: real) {
-  for (b1,b2) in TriangleIter(B) do {
+  for (b1,b2) in TriangleIter(B) {
     var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
     var distance = sqrt(+ reduce d**2);
     var mag = dt / (distance**3);
     b1.vel_vector -= d * b2.mass * mag;
     b2.vel_vector += d * b1.mass * mag;
   }
-  for b in B do {
+  for b in B {
     b.coord_vector += dt * b.vel_vector;
   }
 }
 
 proc energy(B : [] Planet) : real {
   var e : real;
-  for (b1,i) in (B,NBODIES) do {
+  for (b1,i) in (B,NBODIES) {
     e += 0.5 * b1.mass * (+ reduce b1.vel_vector**2);
-    for b2 in B[i+1..] do {
+    for b2 in B[i+1..] {
       var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(+ reduce d**2);
       e -= (b1.mass * b2.mass) / distance;
@@ -97,7 +97,7 @@ proc main() {
   
   offset_momentum(bodies);
   writeln(energy(bodies));
-  for 1..n do {
+  for 1..n {
     advance(bodies, 0.01);
   }
   writeln(energy(bodies));

--- a/test/studies/shootout/nbody/sidelnik/nbody_reductions_6.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_reductions_6.chpl
@@ -11,8 +11,9 @@ config var n = 10000;
 param PI = 3.141592653589793;
 const solar_mass = (4 * PI * PI);
 param days_per_year = 365.24;
-const vecLen = 0..2;
-const NBODIES = 0..4;
+const vecLen = {0..2};
+const nbodies = 4;
+const NBODIES = 0..nbodies;
 
 class Planet {
   var coord_vector : [vecLen] real; // x,y,z
@@ -21,8 +22,10 @@ class Planet {
 }
 
 proc advance(B: [] Planet, dt: real) {
-  for (b1, i) in zip(B, NBODIES) do {
-    for b2 in B[i+1..] do {
+  for i in NBODIES {
+    refvar b1 = B[i];
+    for j in i+1..nbodies {
+      refvar b2 = B[j];
       var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(+ reduce d**2);
       var mag = dt / (distance**3);
@@ -31,16 +34,16 @@ proc advance(B: [] Planet, dt: real) {
     }
   }
   //b.coord_vector = + reduce [b in B] (dt * b.vel_vector); <--- FAILS
-  for b in B do {
+  for b in B {
     b.coord_vector += dt * b.vel_vector;
   }
 }
 
 proc energy(B : [] Planet) : real {
   var e : real;
-  for (b1,i) in zip(B,NBODIES) do {
+  for (b1,i) in zip(B,NBODIES) {
     e += 0.5 * b1.mass * (+ reduce b1.vel_vector**2);
-    for b2 in B[i+1..] do {
+    for b2 in B[i+1..] {
       var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(+ reduce d**2);
       e -= (b1.mass * b2.mass) / distance;
@@ -94,7 +97,7 @@ proc main() {
   
   offset_momentum(bodies);
   writeln(format("#.#########", energy(bodies)));
-  for 1..n do {
+  for 1..n {
     advance(bodies, 0.01);
   }
   writeln(format("#.#########", energy(bodies)));

--- a/test/studies/shootout/nbody/sidelnik/nbody_vector_4.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_vector_4.chpl
@@ -12,18 +12,19 @@
 config var n = 10000;
 param PI = 3.141592653589793;
 const solar_mass = (4 * PI * PI);
+const vecLen = {0..2};
 param days_per_year = 365.24;
 
 record Planet {
-  var coord_vector : [0..2] real; // x,y,z
-  var vel_vector : [0..2] real;   // vx,vy,vz
+  var coord_vector : [vecLen] real; // x,y,z
+  var vel_vector : [vecLen] real;   // vx,vy,vz
   var mass : real;
 }
 
 proc advance(B: [] Planet, dt: real) {
-  for (b1, i) in zip(B, 0..) do {
-    for b2 in B[i+1..] do {
-      var d : [0..2] real = b1.coord_vector - b2.coord_vector;
+  for (b1, i) in zip(B, 0..) {
+    for b2 in B[i+1..] {
+      var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       //var d : [] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(d[0]**2 + d[1]**2 + d[2]**2);
       var mag = dt / (distance**3);
@@ -37,12 +38,12 @@ proc advance(B: [] Planet, dt: real) {
 
 proc energy(B : [] Planet) : real {
   var e : real;
-  for (b1,i) in zip(B,0..) do {
+  for (b1,i) in zip(B,0..) {
     e += 0.5 * b1.mass * (b1.vel_vector(0)**2 +
                           b1.vel_vector(1)**2 + 
                           b1.vel_vector(2)**2);
-    for b2 in B[i+1..] do {
-      var d : [0..2] real = b1.coord_vector - b2.coord_vector;
+    for b2 in B[i+1..] {
+      var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
       var distance = sqrt(d[0]**2 + d[1]**2 + d[2]**2);
       e -= (b1.mass * b2.mass) / distance;
     }
@@ -51,7 +52,7 @@ proc energy(B : [] Planet) : real {
 }
 
 proc offset_momentum(B : [] Planet) {
-  var p : [0..2] real;
+  var p : [vecLen] real;
   for b in B do
     p += b.vel_vector * b.mass;
   B(0).vel_vector = -p / solar_mass;
@@ -61,40 +62,40 @@ proc main() {
   param NBODIES = 5;
   var bodies : [0..#NBODIES] Planet;
   
-  var p0,v0 : [0..2] real = (0,0,0);
+  var p0,v0 : [vecLen] real = (0,0,0);
   bodies(0) = new Planet(p0,v0, solar_mass);
-  var p1 : [0..2] real = (4.84143144246472090e+00,
+  var p1 : [vecLen] real = (4.84143144246472090e+00,
                           -1.16032004402742839e+00,
                           -1.03622044471123109e-01);
-  var v1 : [0..2] real = (1.66007664274403694e-03 * days_per_year,
+  var v1 : [vecLen] real = (1.66007664274403694e-03 * days_per_year,
                           7.69901118419740425e-03 * days_per_year,
                           -6.90460016972063023e-05 * days_per_year);
   bodies(1) = new Planet(p1, v1, 9.54791938424326609e-04 * solar_mass);
-  var p2 : [0..2] real = (8.34336671824457987e+00,
+  var p2 : [vecLen] real = (8.34336671824457987e+00,
                           4.12479856412430479e+00,
                           -4.03523417114321381e-01);
-  var v2 : [0..2] real = (-2.76742510726862411e-03 * days_per_year,
+  var v2 : [vecLen] real = (-2.76742510726862411e-03 * days_per_year,
                           4.99852801234917238e-03 * days_per_year,
                           2.30417297573763929e-05 * days_per_year);
   bodies(2) = new Planet(p2, v2, 2.85885980666130812e-04 * solar_mass);
-  var p3 : [0..2] real = (1.28943695621391310e+01,
+  var p3 : [vecLen] real = (1.28943695621391310e+01,
                           -1.51111514016986312e+01,
                           -2.23307578892655734e-01);
-  var v3 : [0..2] real = (2.96460137564761618e-03 * days_per_year,
+  var v3 : [vecLen] real = (2.96460137564761618e-03 * days_per_year,
                           2.37847173959480950e-03 * days_per_year,
                           -2.96589568540237556e-05 * days_per_year);
   bodies(3) = new Planet(p3,v3, 4.36624404335156298e-05 * solar_mass);
-  var p4 : [0..2] real = (1.53796971148509165e+01,
+  var p4 : [vecLen] real = (1.53796971148509165e+01,
                           -2.59193146099879641e+01,
                           1.79258772950371181e-01);
-  var v4 : [0..2] real = (2.68067772490389322e-03 * days_per_year,
+  var v4 : [vecLen] real = (2.68067772490389322e-03 * days_per_year,
                           1.62824170038242295e-03 * days_per_year,
                           -9.51592254519715870e-05 * days_per_year);
   bodies(4) = new Planet(p4,v4, 5.15138902046611451e-05 * solar_mass);
   
   offset_momentum(bodies);
   writeln(format("#.#########", energy(bodies)));
-  for 1..n do {
+  for 1..n {
     advance(bodies, 0.01);
   }
   writeln(format("#.#########", energy(bodies)));


### PR DESCRIPTION
[trivial, not reviewed]

Several of Albert's nbody variations have been timing
out on memleaks testing since being moved to a
(slower?) virtual machine.  This gives a good excuse
to speed up some of the slower ones that remain
interesting.

The meat of the changes included:
- pulling out some zippered iterators (which have
  proven slower than ideal in other cases) and
  replaced them with domain/range iterations
  and random access
- avoided the use of array slicing in the inner loop
- used 'refvar' declarations to capture references
  to the bodies in question instead of the previous
  two idioms.

This seems to reduce execution time by about 50%.

While here, I also did some cleanup:
- For all the tests, I reformatted them to not use such
  crazy wide indentation in favor of 2-space indentation.
- While here, I also made 'do {' idioms into simply '{'
- Also did a bit of reformatting of the bodies: removed
  TAB characters and got rid of some needlessly blank
  lines.
