### PR TITLE
Skipping miminal modules tests for memleaks testing

### DIFF
--- a/test/compflags/bradc/minimalModules/SKIPIF
+++ b/test/compflags/bradc/minimalModules/SKIPIF
@@ -2,3 +2,7 @@ COMPOPTS <= --baseline
 CHPL_COMM == gasnet
 COMPOPTS  <= --no-local
 CHPL_LOCALE_MODEL != flat
+#
+# when doing memory testing, the configs used are not available, so skip
+#
+EXECOPTS <= memLeaksLog


### PR DESCRIPTION
I hadn't had the chance to diagnose this before, but
when running memleaks testing, we refer to configs
that are not present in minimal modules mode, so it
doesn't make sense to run these tests in that mode.
