### PR TITLE
Add align.skipif to squelch weird Intel codegen error

### DIFF
--- a/test/types/range/hilde/align.skipif
+++ b/test/types/range/hilde/align.skipif
@@ -6,4 +6,8 @@
 # the result of '%' tracks the sign of the first argument (if the second
 # argument is positive).  But the Intel compiler changes its mind for this
 # particular test case.
-CHPL_TARGET_COMPILER==intel
+CHPL_TARGET_COMPILER<=intel
+# The PGI compiler exhibits the same behavior.  Both are apparently GCC
+# derivatives, so the similar behavior is not too surprising.
+CHPL_TARGET_COMPILER<=pgi
+


### PR DESCRIPTION
The Intel compiler causes the result of the modulo operator to have the "wrong" sign, but
only under very special circumstances (no -g flag, only in chpl__mod() so far).  In a
similar test, the modulo operator gives a result with the "right" sign.  The C spec does
not require that the sign of the result match the sign of the dividend (with a positive
modulus), but it seems reasonable to expect that the compiler is at least self-consistent.
