### PR TITLE
Fix TooManyThreads valgrind error

### DIFF
--- a/test/parallel/taskPool/figueroa/TooManyThreads.chpl
+++ b/test/parallel/taskPool/figueroa/TooManyThreads.chpl
@@ -4,6 +4,11 @@
 // usually the system runs out of resources after two or three thousand
 // threads have been created.)
 
+// If CHPL_RT_NUM_THREADS_PER_LOCALE has been set then this test will fail
+// because it won't print out the expected warning.  One could alter the prediff
+// to use an alternate .good file in that case, but this seems like more trouble
+// than it is worth at the moment.
+
 // This test also makes sure that regardless of whether the system runs out of
 // resources, tasks can be placed in the task pool, and these tasks are
 // eventually performed to completion.

--- a/test/parallel/taskPool/figueroa/TooManyThreads.skipif
+++ b/test/parallel/taskPool/figueroa/TooManyThreads.skipif
@@ -1,3 +1,5 @@
 # skip this test on the XT because it is capable of creating lots of threads
 CHPL_TARGET_PLATFORM == cray-xt
 CHPL_TASKS != fifo
+# Valgrind testing sets CHPL_RT_NUM_THREADS_PER_LOCALE, so skip this test
+CHPL_TEST_VGRND_COMP == on


### PR DESCRIPTION
This test requires that CHPL_RT_NUM_THREADS_PER_LOCALE is unset for correct
output, but our valgrind testing sets this variable in order to run.  Therefore,
the test is not useful under these circumstances.  The effort to make the
prediff more correctly react to this variable being set seemed much greater than
the payoff, so I left a note in the test of how it could be done and turned it
off for valgrind.
