### PR TITLE
Fix a race in studies/jacobi/waynew/example2.chpl

### DIFF
--- a/test/studies/jacobi/waynew/example2.chpl
+++ b/test/studies/jacobi/waynew/example2.chpl
@@ -29,14 +29,14 @@ var Temp:[outerD] real;
 [e in eastOfD]  Temp(e) = 0.63;
 
 
-var moving: bool;
+var moving: atomic int;
 do {
-  moving = false;
+  moving.write(0);
   forall (i,j) in D do {                       // calc new World
     World(i,j) = (Temp(i-1,j) + Temp(i+1,j) + Temp(i,j-1) + Temp(i,j+1)) / 4.0;
-    moving |= abs( World(i,j) - Temp(i,j)) > THRESHOLD;
+    moving.add(abs( World(i,j) - Temp(i,j)) > THRESHOLD);
   }
   [e in D] Temp(e) = World(e);               // copy back World->Temp
- } while (moving);
+ } while (moving.read());
 
 writeln( World);


### PR DESCRIPTION
This test had been very rarely generating incorrect output due to failing to
detect that sufficient change had occurred between late passes.  This happened
because the variable used to determine if sufficient change had occurred was
being updated by all running tasks without locking, so there was a race.  Since
we don't support atomic |= for booleans, I replaced the boolean with an atomic
integer, and the |= call with atomically adding the old boolean check (so if
the result of comparing the new and old values was above the tolerance for a
change, then an integer representation of true would be added).  After 150 runs,
it appears that this has solved the problem (100 runs was sufficient to see 6
failures in this manner with fifo before this change).
