### PR TITLE
Brad pointed out that this should skip with valgrind EXE, not COMP

### DIFF
--- a/test/parallel/taskPool/figueroa/TooManyThreads.skipif
+++ b/test/parallel/taskPool/figueroa/TooManyThreads.skipif
@@ -2,4 +2,4 @@
 CHPL_TARGET_PLATFORM == cray-xt
 CHPL_TASKS != fifo
 # Valgrind testing sets CHPL_RT_NUM_THREADS_PER_LOCALE, so skip this test
-CHPL_TEST_VGRND_COMP == on
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Fixing that.
