### PR TITLE
Reserving various symbols that appear on darwin

### DIFF
--- a/compiler/passes/reservedSymbolNames
+++ b/compiler/passes/reservedSymbolNames
@@ -256,3 +256,9 @@
   ten23
   ts
   two
+
+  // reserved on darwin
+  fls
+  wait2
+  wait3
+  wait4


### PR DESCRIPTION
This patch should fix the darwin compilation errors for compSampler*. 'fls' is the name of a function in darwin, and should become a reserved word in Chapel to avoid compilation errors.

These changes should also fix parallel/sync/diten/userLevelEndCount . The 'wait' function can conflict with darwin functions (wait2/3/4) during C compilation.
