### PR TITLE
Get rid of warnings about non-literal printf() format strings on darwin.

### DIFF
--- a/test/extern/hilde/namedExtern.chpl
+++ b/test/extern/hilde/namedExtern.chpl
@@ -5,7 +5,8 @@
 // The name following "extern" is the name used by the backend.
 // The name following "proc" is the name used by Chapel.
 //
-extern printf proc cprintf(fmt ...?k): int;
+extern printf proc cprintf(fmt: c_string): int;
+extern printf proc cprintf(fmt: c_string, arg...): int;
 
 var i = 19: int(32); // using an int(32) to up the odds this works with %d
 var f = 63.0;

--- a/test/io/vass/time-write.chpl
+++ b/test/io/vass/time-write.chpl
@@ -71,30 +71,30 @@ extern proc cf_trial(n: int);
 extern proc cs_trial(n: int);
 
 proc lstr_trial() {
-  extern proc printf(format: c_string);
+  extern proc printf(format: c_string, arg...);
   for 1..n do
-    printf("\n");
+    printf("%s", "\n");
 }
 
 proc lcs_trial() {
-  extern proc printf(format: c_string);
+  extern proc printf(format: c_string, arg...);
   const c_newline_local = "\n".c_str();
   for 1..n do
-    printf(c_newline_local);
+    printf("%s", c_newline_local);
 }
 
 const str_newline_global = "\n";
 proc gstr_trial() {
-  extern proc printf(format: c_string);
+  extern proc printf(format: c_string, arg...);
   for 1..n do
-    printf(str_newline_global.c_str());
+    printf("%s", str_newline_global.c_str());
 }
 
 const c_newline_global = "\n".c_str();
 proc gcs_trial() {
-  extern proc printf(format: c_string);
+  extern proc printf(format: c_string, arg...);
   for 1..n do
-    printf(c_newline_global);
+    printf("%s", c_newline_global);
 }
 
 // could do the same with puts() - would be too much, skip it for now

--- a/test/studies/pidigits/bbp/nomem32.chpl
+++ b/test/studies/pidigits/bbp/nomem32.chpl
@@ -8,8 +8,6 @@
 // so it can compute only the first 4 million digits of Pi or so.
 //
 //
-extern proc printf(s...);
-
 use Time;
 
 config param perfTest = false;
@@ -144,7 +142,7 @@ proc print_digits(in d, in nd: I2)
     i -= 1;
     write_digit(tmp[i]);
   }
-  printf("\t");
+  write("\t");
 }
 
 proc write_out()


### PR DESCRIPTION
On darwin we get warnings from the gen compiler about non-literal
printf() format strings in these three tests, causing them to fail.
Resolve these warnings as follows:

test/extern/hilde/namedExtern.chpl
  We declare printf() such that the fmt argument is implicitly typed
  by the corresponding actual argument.  That actual arg is a literal
  string, but of type Chapel string.  The compiler emits code to
  convert it to a c_string for the call to the extern printf(), but
  this ends up making the actual a variable in the emitted code.
  Change the printf() declaration(s) so that the fmt argument is
  explicitly a c_string.  This makes the compiler emit the literal as
  a c_string in the first place, and we don't get conversion code or
  the resulting variable.

test/io/vass/time-write.chpl
  In this case we actually do need to be able to printf() non-literal
  strings.  As the code stands we send these as the first (format)
  argument to printf().  Since we need to prnt non-literal strings,
  change the calls (and declarations) so that we use a "%s" format and
  pass the c_string to print as the second argument.  Arguably this
  adds a slight amount of overhead to the printf() call and thus
  changes the test.  If this is a problem we'll need to discuss the
  point of the test, in particular whether it is testing printf()
  performance or the performance of the C buffered I/O FILE interface.
  If the latter, we could call puts() here instead of printf().

test/studies/pidigits/bbp/nomem32.chpl
  This has the same problem as namedExtern, above.  The printf("\t")
  here is the only printf() call in the program.  Everywhere else we
  use Chapel write.  Convert the printf() to a write().
