### PR TITLE
Bump timeout for gasnet+qthreads testing

### DIFF
--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -15,5 +15,23 @@ if [ "${tasks}" == "qthreads" ] ; then
     # Set these to use oversubscription to help with timeouts
     export QT_AFFINITY=no
     export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
+
+    # Even with oversubscription we still have some timeouts with
+    # qtheads+gasnet on "low" core count machines. The main issue is
+    # that qthreads assumes it owns the whole machine. When running
+    # oversubscribed it attempts to yield the processor in busy loops,
+    # but then threads scheduled behind the thread that yielded the
+    # processor don't get to run. We could limit qthreads to use
+    # numCores/numLocales processors per gasnet instance, but that
+    # doesn't really work for low core count machines. This is meant to
+    # keep testing quiet until we figure out a better solution or start
+    # running in a non-oversubscribed manner. Note that this is NOT
+    # indicative of a real performance issue, and that when run on real
+    # hardware we get the performance we expect
+    logicalCores=`python -c 'import multiprocessing ; print multiprocessing.cpu_count()'`
+    if [ $logicalCores -le 8 ] ; then
+        export CHPL_TEST_TIMEOUT=500
+    fi
+
 fi
 


### PR DESCRIPTION
On low core count machines like the linux32 box, lnx-diten, and lnx-vass we
still have some timeouts with gasnet+qthreads even when built with
oversubscription on and affinity off. The reason we see it on these machines
but not for regular gasnet testing is just because these machines have a lower
core count.

This increase in timeout does NOT reflect true performance issues with
qthreads, but merely the fact that qthreads wasn't designed to run in an
oversubscribed manner. Qthreads expects that it owns the whole machine. With
oversubscription on, amongst other things, busy loops turn into loops with
sched_yield in them. While this yields the processor, the qthread is not
yielded and so there are still situations where it takes much longer to get
work done because qtheads doesn't own the whole machine, but fundamentally
assumes it does.

Increasing the timeout is a stop-gap to quiet nightly testing until I figure
out a better solution, or we start doing gasnet testing on real hardware.

I tried a few things to get rid of timeouts with little success including
modifications to qthreads source, and limiting CHPL_RT_NUM_THREADS_PER_LOCALE
to numCores/numLocales. Limiting the number of threads doesn't help on low core
count machines because you get 1 thread per locale, which is equally as slow as
the contention in most cases.

I can look for a better solution as a background test, but this will quiet
testing in the meantime.
