### PR TITLE
Avoid relying on qthreads syscall interception for chpl_task_sleep

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -803,7 +803,16 @@ chpl_taskID_t chpl_task_getId(void)
 
 void chpl_task_sleep(int secs)
 {
-    sleep(secs); // goes into the syscall interception system
+    if (qthread_shep() == NO_SHEPHERD) {
+        sleep(secs);
+    } else {
+        qtimer_t t = qtimer_create();
+        qtimer_start(t);
+        do {
+            qthread_yield();
+            qtimer_stop(t);
+        } while (qtimer_secs(t) < secs);
+    }
 }
 
 /* The get- and setSerial() methods assume the beginning of the task-local


### PR DESCRIPTION
chpl_task_sleep() was previously just a call to sleep(). This system call is
supposed to be intercepted by qthreads, and qthreads will perform
qthread_yields until the specified sleep time is up. If that doesn't happen
sleep, would cause the entire worker to sleep, preventing other tasks on the
same worker from running.

The system call interception does not seem to be working on darwin currently.
As a result any test with sleep() in it fails on darwin.  We're working with
the qthreads team to figure out what's going on but in the meantime (and
possibly longer term) we will just perform what the syscall interception is
supposed to do directly.
