### PR TITLE
Revert "Add declint2.skipif to skip when --fast is tossed."

### DIFF
--- a/test/execflags/bradc/gdbddash/declint2.skipif
+++ b/test/execflags/bradc/gdbddash/declint2.skipif
@@ -1,4 +1,0 @@
-# This test is supposed to show that GDB will break on a halt when the
-# "array index out of bounds" error occurs.  But when --fast is tossed, the 
-# array bounds check is disabled.
-COMPOPTS<=--fast


### PR DESCRIPTION
This reverts commit 1436e0245e4936149156884f400dae173f4effa5.

The failure is already coveredy in Suppressions.
