### PR TITLE
Add classes/figueroa/RecordConstructor2.skipif

### DIFF
--- a/test/classes/figueroa/RecordConstructor2.skipif
+++ b/test/classes/figueroa/RecordConstructor2.skipif
@@ -1,0 +1,12 @@
+# There is different behavior when --baseline is tossed, due to
+# fNoRemoveCopyCalls preventing removeUnnecessaryAutoCopyCalls() from running.
+# Given that the compiler may remove autoCopy calls as long as it can prove they
+# are not needed, the change in behavior is acceptable.
+# On the other hand, the dependence of this behavior on the hidden call to
+# initialize() makes it difficult to reason about.  The automatic call to
+# initialize() should be deprecated.
+# Also, if autoCopy calls are inserted only where they are needed, then the
+# removeUnnecessaryAutoCopyCalls() pass can go away, and this skipif will also
+# be unnecessary.
+COMPOPTS<=--baseline
+COMPOPTS<=--no-remove-copy-calls


### PR DESCRIPTION
This test arguably works correctly in both configurations, even though its output differs
when run with the --baseline option compared to when run without it.  That is because
--baseline disables the removeUnnecessaryAutoCopyCalls() optimization.  The compiler may
add or remove autoCopy calls at will, so the user should not write code that depends upon
its having run (except as needed for memory management reasons).

In this test, running autoCopy has a side-effect (setting the contents of the record to
2).  The autoCopy function does this because every constructor implicitly calls the
initialize() function, and that is what is done by the initialize() function for this
record type.

The compiler could do a better job of aligning --baseline vs. optimized behavior by
inserting fewer autoCopy calls to begin with.  Also, the fact that the compiler-generated
autoCopy calls initialize is quite hidden.
