### PR TITLE
Have serial tasks directly execute the function for qthreads

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -713,9 +713,8 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
                              int               lineno,
                              c_string          filename)
 {
-    qthread_shepherd_id_t const here_shep_id = qthread_shep();
     chpl_bool serial_state = chpl_task_getSerial();
-    chpl_qthread_wrapper_args_t wrapper_args = 
+    chpl_qthread_wrapper_args_t wrapper_args =
         {chpl_ftable[fid], arg, filename, lineno, false,
          PRV_DATA_IMPL_VAL(subloc, serial_state) };
 
@@ -724,11 +723,8 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
     PROFILE_INCR(profile_task_addToTaskList,1);
 
     if (serial_state) {
-        syncvar_t ret = SYNCVAR_STATIC_EMPTY_INITIALIZER;
-        qthread_fork_syncvar_copyargs_to(chapel_wrapper, &wrapper_args,
-                                         sizeof(chpl_qthread_wrapper_args_t), &ret,
-                                         here_shep_id);
-        qthread_syncvar_readFF(NULL, &ret);
+        // call the function directly.
+        (chpl_ftable[fid])(arg);
     } else if (subloc == c_sublocid_any) {
         qthread_fork_copyargs(chapel_wrapper, &wrapper_args,
                               sizeof(chpl_qthread_wrapper_args_t), NULL);


### PR DESCRIPTION
Previously, serial task creation spawned a new task, and the original task
would wait for that task to complete. We believe the original motivation for
this is from the days when qthreads had a lower stack size. If you have
recursive serial tasks being created you're going to run out of stack pretty
quickly.

This was changed with the qthreads commit 82a0224513ec

With our current default stack size of 8MB you end up wasting a lot of memory
because you're creating a task for each serialized task. For schedulers that
have more than one worker per shepeherd you can also schedule the serial task
on a different core, which can cause you to lose some cache and can result in
slowdown because many qthreads are constantly yielding waiting for one to
finish.
