### PR TITLE
Fix static_dynamic for intel compiler

### DIFF
--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -55,7 +55,7 @@ RUNTIME_CFLAGS = -std=c99 $(CFLAGS) -wr181,188
 RUNTIME_GEN_CFLAGS = $(RUNTIME_CFLAGS)
 GEN_CFLAGS = -std=c99 -fp-model strict -wr592
 # NOTE: These are only supported for Linux
-GEN_STATIC_FLAG = -Bstatic
+GEN_STATIC_FLAG = -static-intel -static-libgcc -static
 GEN_DYNAMIC_FLAG = -Bdynamic
 LIB_STATIC_FLAG =
 LIB_DYNAMIC_FLAG = -shared


### PR DESCRIPTION
It turns out that -Bstatic fails to find a static library in one case and
causes compilation to fail.  The correct combination to ensure complete and
static compilation is -static-intel -static-libgcc -static.  These tests should
now pass (phew!).
