### PR TITLE
Turn off mallocOutOfMemory for cygwin

### DIFF
--- a/test/memory/shannon/outofmemory/mallocOutOfMemory.skipif
+++ b/test/memory/shannon/outofmemory/mallocOutOfMemory.skipif
@@ -1,3 +1,5 @@
 # Valgrind fails on this test, so let us skip it.
-CHPL_TEST_VGRND_COMP == on
+CHPL_TEST_VGRND_EXE == on
+# Both cygwin and darwin fail to define ulimit or anything similar
 CHPL_HOST_PLATFORM == darwin
+CHPL_HOST_PLATFORM == cygwin


### PR DESCRIPTION
Cygwin also fails to define a useful ulimit function, so any attempts to limit
the memory of this test will not work.  Even though the test will still run and
complete with a higher number of iterations, I think we should treat it the way
we treat darwin and skip it.
