### PR TITLE
Turn off cygwin testing for TooManyThreads.chpl

### DIFF
--- a/test/parallel/taskPool/figueroa/TooManyThreads.skipif
+++ b/test/parallel/taskPool/figueroa/TooManyThreads.skipif
@@ -3,3 +3,5 @@ CHPL_TARGET_PLATFORM == cray-xt
 CHPL_TASKS != fifo
 # Valgrind testing sets CHPL_RT_NUM_THREADS_PER_LOCALE, so skip this test
 CHPL_TEST_VGRND_EXE == on
+# Cygwin doesn't allow you to set the number of threads, so skip this test.
+CHPL_HOST_PLATFORM == cygwin


### PR DESCRIPTION
Cygwin doesn't allow you to set the number of threads, so this test is not
useful on cygwin.
