### PR TITLE
Send darwin regression mail to normal lists

### DIFF
--- a/util/cron/test-darwin.bash
+++ b/util/cron/test-darwin.bash
@@ -7,9 +7,4 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin"
 
-# Do not send modern mac test results to regressions list until
-# nondeterministic compiler errors are fixed.
-# (thomasvandoren, 2014-09-08)
-export CHPL_NIGHTLY_CRON_RECIPIENT="chapel-test-results-all@lists.sourceforge.net"
-
 $CWD/nightly -cron


### PR DESCRIPTION
Previously it was only sent to the all regressions list. The non-deterministic
errors have been cleaned up so it makes sense to send it to all.
