### PR TITLE
Skip the two tests in test/arrays/deitz/parallelism/stream/ for --baseline

### DIFF
--- a/test/arrays/deitz/parallelism/stream/SKIPIF
+++ b/test/arrays/deitz/parallelism/stream/SKIPIF
@@ -1,0 +1,6 @@
+# This test requires the use of --fast-followers to generate correct output
+# and since the test is examining if our default behavior makes the entire test
+# use fast followers, it doesn't make sense to force the flag to be thrown in
+# all cases.  So turn it off for the cases where we would normally expect this
+# optimization not to be in use.
+COMPOPTS <= --baseline


### PR DESCRIPTION
These tests are to ensure that our default settings (--fast-follower enabled)
utilize fast followers and create the right number of tasks for parallel work.
Since both are intended and --baseline turns off --fast-followers, it doesn't
make sense to run these tests under --baseline.
