### PR TITLE
Remove self comparisons in test/extern/ferguson/c_ptrs.chpl

### DIFF
--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -105,6 +105,12 @@ inline proc c_free(data: c_ptr) {
 inline proc ==(a: c_ptr, b: c_ptr) where a.eltType == b.eltType {
   return __primitive("ptr_eq", a, b);
 }
+inline proc ==(a: c_ptr, b: c_void_ptr) {
+  return __primitive("ptr_eq", a, b);
+}
+inline proc ==(a: c_void_ptr, b: c_ptr) {
+  return __primitive("ptr_eq", a, b);
+}
 inline proc ==(a: c_ptr, b: _nilType) {
   return __primitive("ptr_eq", a, nil);
 }
@@ -115,6 +121,12 @@ inline proc ==(a: _nilType, b: c_ptr) {
 inline proc !=(a: c_ptr, b: c_ptr) where a.eltType == b.eltType {
   return __primitive("ptr_neq", a, b);
 }
+inline proc !=(a: c_ptr, b: c_void_ptr) {
+  return __primitive("ptr_neq", a, b);
+}
+inline proc !=(a: c_void_ptr, b: c_ptr) {
+  return __primitive("ptr_neq", a, b);
+}
 inline proc !=(a: c_ptr, b: _nilType) {
   return __primitive("ptr_neq", a, nil);
 }
@@ -122,9 +134,9 @@ inline proc !=(a: _nilType, b: c_ptr) {
   return __primitive("ptr_neq", nil, b);
 }
 
-inline proc _cond_test(x: c_ptr) return x != nil;
+inline proc _cond_test(x: c_ptr) return x != c_nil;
 
-inline proc !(x: c_ptr) return x == nil;
+inline proc !(x: c_ptr) return x == c_nil;
 extern proc c_pointer_return(ref x:?t):c_ptr(t);
 
 inline proc c_ptrTo(arr: []) where isRectangularArr(arr) && arr.rank == 1 {

--- a/test/extern/ferguson/c_ptrs.chpl
+++ b/test/extern/ferguson/c_ptrs.chpl
@@ -9,10 +9,10 @@ proc go() {
   var my_ptr_copy = returnit(my_ptr);
   var it_ptr_copy = returnit(it_ptr);
 
-  assert(my_ptr == my_ptr);
+  assert(my_ptr != c_nil);
   assert(my_ptr == my_ptr_copy);
 
-  assert(it_ptr == it_ptr);
+  assert(c_nil != it_ptr);
   assert(it_ptr == it_ptr_copy);
 
   assert(my_ptr != it_ptr);


### PR DESCRIPTION
c_ptrs.chpl had comparisons that looked like:

assert(my_ptr == my_ptr);

These now check that my_ptr != c_nil. I added a couple of overloads in
SysBasic to allow comparison between c_ptr and c_void_ptr to let us do
this.
