### PR TITLE
Address glibc memory error for some I/O routines

### DIFF
--- a/runtime/src/qio/auxFilesys/hdfs/qio_plugin_hdfs.c
+++ b/runtime/src/qio/auxFilesys/hdfs/qio_plugin_hdfs.c
@@ -339,32 +339,40 @@ qioerr hdfs_fsync(void* fl, void* fs)
 
 qioerr hdfs_getcwd(void* file, const char** path_out, void* fs)
 {
-  int sz = 128;
-  char* buf;
-  char* got;
+  int    sz   = 128;
+  char*  buf  = (char*) qio_malloc(sz);
   qioerr err = 0;
 
-  buf = (char*) qio_malloc(sz);
-  if( !buf )
+  if ( !buf )
     QIO_GET_CONSTANT_ERROR(err, ENOMEM, "Out of memory in hdfs_getcwd");
-  while( 1 ) {
-    got = hdfsGetWorkingDirectory(to_hdfs_fs(fs)->hfs, buf, sz);
-    if( got != NULL ) break;
-    else if( errno == ERANGE ) {
-      // keep looping but with bigger buffer.
-      sz = 2*sz;
-      got = (char*) qio_realloc(buf, sz);
-      if( ! got ) {
-        qio_free(buf);
+
+  // hdfsGetWorkingDirectory will return 0 if buf[] is not large enough
+  // If this happens, grow the buffer and try again
+  while (err == 0 && hdfsGetWorkingDirectory(to_hdfs_fs(fs)->hfs, buf, sz) == 0) {
+    if (errno == ERANGE) {
+      int   newSz  = 2 * sz;
+      char* newBuf = (char*) qio_realloc(buf, newSz);
+
+      if (newBuf == 0) {
         QIO_GET_CONSTANT_ERROR(err, ENOMEM, "Out of memory in hdfs_getcwd");
+      } else {
+        sz  = newSz;
+        buf = newBuf;
       }
+
     } else {
       // Other error, stop.
-        QIO_GET_CONSTANT_ERROR(err, EREMOTEIO, "Unable to get path to file in HDFS");
+      QIO_GET_CONSTANT_ERROR(err, EREMOTEIO, "Unable to get path to file in HDFS");
     }
   }
 
+  if (err != 0) {
+    qio_free(buf);
+    buf = 0;
+  }
+
   *path_out = buf;
+
   return err;
 }
 


### PR DESCRIPTION
A number of I/O tests have been failing in nightly testing on a range of configurations.
These tests pass for typical efforts to reproduce; eventually I determined that the failure
is triggered by a long argv[0].

The error turned out to be in the utility sys_getcwd() which relies on the clunky posix
function get_cwd().  The QIO code needs to provide a buffer to get_cwd() without
knowing how large the buffer needs to be. This is resolved by trying calls with buffers
of increasing size using realloc() to expand the buffer each time.  Unfortunately the
original code did not correctly capture the result of the realloc().

Once this was found and fixed I scanned all of runtime/qio and found a second instance
of this error in code that was likely to have started as an unfortunate cut/paste.

Compiled on Mac/Linux.
Ran on several tests that had been failing and now pass.
Ran on standard regression suite.

Did one test run where I made the original buffer 8 bytes long with an input
path of over 150.
