### PR TITLE
Fix the additional string leaks detected with --baseline

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -305,7 +305,7 @@ module DefaultRectangular {
         return if i == rangeTuple.size then rangeTuple(i).stridable
                else rangeTuple(i).stridable || anyStridable(rangeTuple, i+1);
   
-      chpl__testPar("default rectangular domain follower invoked on ", followThis);
+      chpl__testPar("default rectangular domain follower invoked on ":string_rec, followThis);
       if debugDefaultDist then
         writeln("In domain follower code: Following ", followThis);
       param stridable = this.stridable || anyStridable(followThis);


### PR DESCRIPTION
Skipping dead code elimination leaves the array debugging calls to chpl__testPar
in the code (while the contents of this call would never be exercised because of
the appropriate boolean flag, the call is still made).  Since these calls send
in a message in the form of a string, additional memory leaks are generated.
To combat that, we now cast the message to our new string record - this seemed
fine because 1) only developers use chpl__testPar or baseline to our knowledge,
and 2) ChapelStandard already includes the NewString module so the cast was the
only thing that needed to be added.  When the string record is our default, this
cast will no longer be necessary and should be removed.
