### PR TITLE
Update .good/.prediff for chown file to support cygwin platform.

### DIFF
--- a/test/io/fsouza/chown/permission_error.good
+++ b/test/io/fsouza/chown/permission_error.good
@@ -1,1 +1,1 @@
-permission_error.chpl:2: error: Operation not permitted in chown with path "file.txt"
+permission_error.chpl:2: error: SYS_ERR in chown with path "file.txt"

--- a/test/io/fsouza/chown/permission_error.prediff
+++ b/test/io/fsouza/chown/permission_error.prediff
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+outfile=$2
+
+cat $outfile | \
+    sed 's/Operation not permitted/SYS_ERR/' | \
+    sed 's/Invalid argument/SYS_ERR/' > \
+    $outfile.tmp
+mv $outfile.tmp $outfile


### PR DESCRIPTION
On cygwin, chown is reporting an "Invalid argument" error instead of the
expected "Operation not permitted" error. The new prediff replaces both
of these with "SYS_ERR", which is what the .good file now expects.
