### PR TITLE
Fix QIO ctests after #746.

### DIFF
--- a/runtime/include/qio/deque.h
+++ b/runtime/include/qio/deque.h
@@ -47,9 +47,11 @@ extern "C" {
 #include "chpl-mem.h"
 #define deque_calloc(nmemb, size) chpl_mem_allocManyZero(nmemb, size, CHPL_RT_MD_IO_BUFFER, __LINE__, __FILE__)
 #define deque_free(ptr) chpl_mem_free(ptr, __LINE__, __FILE__)
+#define deque_memcpy(dest, src, num) chpl_memcpy(dest, src, num)
 #else
 #define deque_calloc(nmemb, size) calloc(nmemb,size)
 #define deque_free(ptr) free(ptr)
+#define deque_memcpy(dest, src, num) memcpy(dest, src, num)
 #endif
 
 typedef struct deque_node_s {
@@ -143,7 +145,7 @@ void deque_it_forward_n(const ssize_t item_size, deque_iterator_t* it, ssize_t n
 static inline
 void deque_it_get_cur(const ssize_t item_size, const deque_iterator_t it, void* out)
 {
-  chpl_memcpy(out, it.cur, item_size);
+  deque_memcpy(out, it.cur, item_size);
 }
 
 static inline
@@ -155,7 +157,7 @@ void* deque_it_get_cur_ptr(const ssize_t item_size, const deque_iterator_t it)
 static inline
 void deque_it_set_cur(const ssize_t item_size, const deque_iterator_t it, void* in)
 {
-  chpl_memcpy(it.cur, in, item_size);
+  deque_memcpy(it.cur, in, item_size);
 }
 
 static inline
@@ -339,7 +341,7 @@ qioerr _deque_push_back_aux(const ssize_t item_size, deque_t* d, void* value)
   (d->finish.node + 1)->data = newdata;
 
   //construct(d->finish.cur, v);
-  chpl_memcpy(d->finish.cur, value, item_size);
+  deque_memcpy(d->finish.cur, value, item_size);
 
   _deque_set_node(item_size, __deque_buf_size(item_size), & d->finish, d->finish.node + 1);
   d->finish.cur = d->finish.first;
@@ -369,7 +371,7 @@ qioerr _deque_push_front_aux(const ssize_t item_size, deque_t* d, void* value)
   d->start.cur = PTR_ADDBYTES(d->start.last, -item_size);
 
   //construct(d->start.cur, v); // calls the constructor
-  chpl_memcpy(d->start.cur, value, item_size);
+  deque_memcpy(d->start.cur, value, item_size);
 
   return 0;
 }
@@ -410,7 +412,7 @@ qioerr deque_push_front(const ssize_t item_size, deque_t* d, void* value)
 {
   if( d->start.cur != d->start.first ) {
     //construct(d->start.cur - item_size, value);
-    chpl_memcpy(PTR_ADDBYTES(d->start.cur, -item_size), value, item_size);
+    deque_memcpy(PTR_ADDBYTES(d->start.cur, -item_size), value, item_size);
 
     d->start.cur = PTR_ADDBYTES(d->start.cur, -item_size);
 
@@ -425,7 +427,7 @@ qioerr deque_push_back(const ssize_t item_size, deque_t* d, void* value)
 {
   if( d->finish.cur != PTR_ADDBYTES(d->finish.last, -item_size) ) {
     //construct(d->finish.cur, value);
-    chpl_memcpy(d->finish.cur, value, item_size);
+    deque_memcpy(d->finish.cur, value, item_size);
 
     d->finish.cur = PTR_ADDBYTES(d->finish.cur, item_size);
 

--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -463,6 +463,7 @@ qioerr qbuffer_memset(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end, 
 #define qio_calloc(nmemb, size) chpl_mem_allocManyZero(nmemb, size, CHPL_RT_MD_IO_BUFFER, __LINE__, __FILE__)
 #define qio_realloc(ptr, size) chpl_mem_realloc(ptr, size, CHPL_RT_MD_IO_BUFFER, __LINE__, __FILE__)
 #define qio_free(ptr) chpl_mem_free(ptr, __LINE__, __FILE__)
+#define qio_memcpy(dest, src, num) chpl_memcpy(dest, src, num)
 
 static inline char* qio_strdup(const char* ptr)
 {
@@ -481,6 +482,7 @@ typedef chpl_bool qio_bool;
 #define qio_free(ptr) free(ptr)
 #define sys_free(ptr) free(ptr)
 #define qio_strdup(ptr) strdup(ptr)
+#define qio_memcpy(dest, src, num) memcpy(dest, src, num)
 
 typedef bool qio_bool;
 

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -914,7 +914,7 @@ qioerr qio_channel_read(const int threadsafe, qio_channel_t* restrict ch, void* 
 
   // Is there room in our fast path buffer?
   if( len <= VOID_PTR_DIFF(ch->cached_end, ch->cached_cur) ) {
-    chpl_memcpy( ptr, ch->cached_cur, len );
+    qio_memcpy( ptr, ch->cached_cur, len );
     ch->cached_cur = VOID_PTR_ADD(ch->cached_cur, len);
     *amt_read = len;
     err = 0;
@@ -1068,7 +1068,7 @@ qioerr qio_channel_write(const int threadsafe, qio_channel_t* restrict ch, const
 
   // Is there room in our fast path buffer?
   if( len <= VOID_PTR_DIFF(ch->cached_end, ch->cached_cur) ) {
-    chpl_memcpy( ch->cached_cur, ptr, len );
+    qio_memcpy( ch->cached_cur, ptr, len );
     ch->cached_cur = VOID_PTR_ADD(ch->cached_cur, len);
     *amt_written = len;
     err = _qio_channel_post_cached_write(ch);
@@ -1098,7 +1098,7 @@ qioerr qio_channel_read_amt(const int threadsafe, qio_channel_t* restrict ch, vo
 
   // Is there room in our fast path buffer?
   if( len <= VOID_PTR_DIFF(ch->cached_end, ch->cached_cur) ) {
-    chpl_memcpy( ptr, ch->cached_cur, len );
+    qio_memcpy( ptr, ch->cached_cur, len );
     ch->cached_cur = VOID_PTR_ADD(ch->cached_cur, len);
     err = 0;
   } else {
@@ -1128,7 +1128,7 @@ qioerr qio_channel_write_amt(const int threadsafe, qio_channel_t* restrict ch, c
 
   // Is there room in our fast path buffer?
   if( len <= VOID_PTR_DIFF(ch->cached_end, ch->cached_cur) ) {
-    chpl_memcpy( ch->cached_cur, ptr, len );
+    qio_memcpy( ch->cached_cur, ptr, len );
     ch->cached_cur = VOID_PTR_ADD(ch->cached_cur, len);
     err = _qio_channel_post_cached_write(ch);
   } else {

--- a/runtime/include/qio/qio_style.h
+++ b/runtime/include/qio/qio_style.h
@@ -253,7 +253,7 @@ qio_style_t qio_style_default(void)
 static inline
 void qio_style_copy(qio_style_t* dst, const qio_style_t* src)
 {
-  chpl_memcpy(dst, src, sizeof(qio_style_t));
+  qio_memcpy(dst, src, sizeof(qio_style_t));
 }
 
 static inline

--- a/runtime/src/qio/qbuffer.c
+++ b/runtime/src/qio/qbuffer.c
@@ -237,7 +237,7 @@ int qbytes_append_realloc(qbytes_t* qb, size_t item_size, void* item)
       qb->data = a;
    }
    // now put the new value in.
-   chpl_memcpy(a + len, item, item_size);
+   qio_memcpy(a + len, item, item_size);
    qb->len += item_size; // increment the item size.
 
    return 0;
@@ -916,7 +916,7 @@ qioerr qbuffer_flatten(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end,
 
   j = 0;
   for( i = 0; i < iovcnt; i++ ) {
-    chpl_memcpy(PTR_ADDBYTES(ret->data, j), iov[i].iov_base, iov[i].iov_len);
+    qio_memcpy(PTR_ADDBYTES(ret->data, j), iov[i].iov_base, iov[i].iov_len);
     j += iov[i].iov_len;
   }
 
@@ -1006,7 +1006,7 @@ qioerr qbuffer_copyout(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end,
   j = 0;
   for( i = 0; i < iovcnt; i++ ) {
     if( j + iov[i].iov_len > ret_len ) goto error_nospace;
-    chpl_memcpy(PTR_ADDBYTES(ptr, j), iov[i].iov_base, iov[i].iov_len);
+    qio_memcpy(PTR_ADDBYTES(ptr, j), iov[i].iov_base, iov[i].iov_len);
     j += iov[i].iov_len;
   }
 
@@ -1044,7 +1044,7 @@ qioerr qbuffer_copyin(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end, 
   j = 0;
   for( i = 0; i < iovcnt; i++ ) {
     if( j + iov[i].iov_len > ret_len ) goto error_nospace;
-    chpl_memcpy(iov[i].iov_base, PTR_ADDBYTES(ptr, j), iov[i].iov_len);
+    qio_memcpy(iov[i].iov_base, PTR_ADDBYTES(ptr, j), iov[i].iov_len);
     j += iov[i].iov_len;
   }
 

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1671,7 +1671,7 @@ qioerr qio_relative_path(const char** path_out, const char* cwd, const char* pat
     tmp[j++] = '/';
   }
   // Now, copy the path after last_common_slash, including trailing '\0'
-  chpl_memcpy(&tmp[j], &path[last_common_slash + 1], after_len+1);
+  qio_memcpy(&tmp[j], &path[last_common_slash + 1], after_len+1);
 
   *path_out = tmp;
   return 0;
@@ -2674,7 +2674,7 @@ qioerr _qio_unbuffered_write(qio_channel_t* ch, const void* ptr, ssize_t len_in,
   if( method == QIO_METHOD_MMAP &&
       ch->file->mmap && _right_mark_start(ch) + len <= ch->file->mmap->len) {
     // Copy the data to the mmap.
-    chpl_memcpy( VOID_PTR_ADD(ch->file->mmap->data,_right_mark_start(ch)), ptr, len);
+    qio_memcpy( VOID_PTR_ADD(ch->file->mmap->data,_right_mark_start(ch)), ptr, len);
     _add_right_mark_start(ch, len);
   } else {
     while( len > 0 ) {
@@ -2765,7 +2765,7 @@ qioerr _qio_unbuffered_read(qio_channel_t* ch, void* ptr, ssize_t len_in, ssize_
       _right_mark_start(ch) + len <= ch->file->mmap->len) {
     // As long as we're using an I/O method that seeks on every read,
     // copy the data out of the mmap.
-    chpl_memcpy( ptr, VOID_PTR_ADD(ch->file->mmap->data,_right_mark_start(ch)), len);
+    qio_memcpy( ptr, VOID_PTR_ADD(ch->file->mmap->data,_right_mark_start(ch)), len);
     _add_right_mark_start(ch, len);
   } else {
     while( len > 0 ) {
@@ -3591,7 +3591,7 @@ void _qio_channel_write_bits_cached_realign(qio_channel_t* restrict ch, uint64_t
   
   //printf("WRITE BITS REALIGNALIGNED WRITING %llx %i\n", (long long int) part_one_bits, (int) (8*to_copy));
   // memcpy will work because part_one_bits is big endian now.
-  chpl_memcpy(ch->cached_cur, &part_one_bits_be, to_copy);
+  qio_memcpy(ch->cached_cur, &part_one_bits_be, to_copy);
   ch->cached_cur = VOID_PTR_ADD(ch->cached_cur, to_copy);
 
   // Remove junk from the top of tmp_bits, so only bottom tmp_live bits are set.
@@ -3791,7 +3791,7 @@ void _qio_channel_read_bits_cached_realign(qio_channel_t* restrict ch, uint64_t*
   to_copy = (7 + value_part) / 8;
 
   buf = 0;
-  chpl_memcpy(&buf, ch->cached_cur, to_copy);
+  qio_memcpy(&buf, ch->cached_cur, to_copy);
   ch->cached_cur = VOID_PTR_ADD(ch->cached_cur, to_copy);
 
   // now we've set the top several bytes of buf.
@@ -3819,7 +3819,7 @@ void _qio_channel_read_bits_cached_realign(qio_channel_t* restrict ch, uint64_t*
 
   buf = 0;
   if( to_copy )
-    chpl_memcpy(&buf, ch->cached_cur, to_copy);
+    qio_memcpy(&buf, ch->cached_cur, to_copy);
   tmp_read = to_copy;
   part_two = 8*to_copy;
 

--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -2163,7 +2163,7 @@ int _ltoa(char* restrict dst, size_t size, uint64_t num, int isnegative,
   }
 
   // now output the digits.
-  chpl_memcpy(dst + i, tmp+tmp_skip, tmp_len);
+  qio_memcpy(dst + i, tmp+tmp_skip, tmp_len);
   i += tmp_len;
 
   // Now if we're left justified we might need padding.
@@ -2441,7 +2441,7 @@ int _ftoa(char* restrict dst, size_t size, double num, int base, bool needs_i, c
   }
 
   // now output the digits
-  chpl_memcpy(dst + i, buf + j, buf_len);
+  qio_memcpy(dst + i, buf + j, buf_len);
   i += buf_len;
 
   if( needs_i ) {

--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -403,7 +403,7 @@ const char* sys_strerror_syserr_str(qioerr error, err_t* err_in_strerror)
     start = strlen(ret);
     ret[start] = ':';
     ret[start+1] = ' ';
-    chpl_memcpy(&ret[start+2], msg, msg_len);
+    qio_memcpy(&ret[start+2], msg, msg_len);
     ret[start+2+msg_len] = '\0';
   }
   return ret;
@@ -1296,7 +1296,7 @@ int sys_getaddrinfo_socktype(sys_addrinfo_ptr_t a) {return a->ai_socktype;}
 int sys_getaddrinfo_protocol(sys_addrinfo_ptr_t a) {return a->ai_protocol;}
 sys_sockaddr_t sys_getaddrinfo_addr(sys_addrinfo_ptr_t a) {
   sys_sockaddr_t ret;
-  chpl_memcpy(&ret.addr, a->ai_addr, a->ai_addrlen);
+  qio_memcpy(&ret.addr, a->ai_addr, a->ai_addrlen);
   ret.len = a->ai_addrlen;
   return ret;
 }


### PR DESCRIPTION
The QIO ctests do not pull in the definition of chpl_memcpy from chpl-mem.h, so an
alternate definition must be supplied when SIMPLETEST is true.

I changed renamed chpl_memcpy() calls to qio_memcpy() or deque_memcpy() as appropriate and
provided macro definitions for these functions.
