### PR TITLE
Retire c_str_on_remote_string as a future, open new related future

### DIFF
--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.bad
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.bad
@@ -1,1 +1,0 @@
-c_str_on_remote_string.chpl:4: error: cannot create a C string from a remote string

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.chpl
@@ -1,6 +1,8 @@
 {
   var s = "0123456789";
   on Locales[numLocales-1] {
-    writeln(s.c_str());
+    var cs = s.c_str();
+    var s2 = cs: string;
+    writeln(s2);
   }
 }

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.future
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.future
@@ -1,1 +1,0 @@
-bug: Calling c_str() on a string from a remote locale results in a runtime error

--- a/test/types/string/sungeun/c_string/multilocale/write_c_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/write_c_string.chpl
@@ -1,0 +1,6 @@
+{
+  var s = "0123456789";
+  on Locales[numLocales-1] {
+    writeln(s.c_str());
+  }
+}

--- a/test/types/string/sungeun/c_string/multilocale/write_c_string.future
+++ b/test/types/string/sungeun/c_string/multilocale/write_c_string.future
@@ -1,0 +1,6 @@
+bug: c_string variables should not be used with write
+
+c_strings are only valid in the locale they were created on. Trying to write
+one from a locale other than the channel's home will cause a the use of a bad
+pointer. We should disallow the use of c_string in our IO system. If users
+really want to print one they can cast to string.

--- a/test/types/string/sungeun/c_string/multilocale/write_c_string.good
+++ b/test/types/string/sungeun/c_string/multilocale/write_c_string.good
@@ -1,0 +1,1 @@
+write_c_string.chpl:4: error: Cannot write out a c_string, cast to string for multi-locale IO.


### PR DESCRIPTION
The intended functionality of c_str_on_remote_string works correctly,
but the test was still failing due to reasons that have been spun out
into write_c_string.

write_c_string.future:

bug: c_string variables should not be used with write

c_strings are only valid in the locale they were created on. Trying to write
one from a locale other than the channel's home will cause the use of a bad
pointer. We should disallow the use of c_string in our IO system. If users
really want to print one they can cast to string.
