### PR TITLE
Regressions update for the past few days

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -70,7 +70,7 @@ Reviewed 2014-11-01
 ===================
 
 missing chpl_memcpy() prototypes (11/06/14)
-(valgrind, numa, memleaks)
+(numa, memleaks)
 -------------------------------------------
 [Error compiling C Regexp tests]
 [Error matching compiler output for io/ferguson/ctests/deque_test (compopts: 1)]
@@ -232,11 +232,6 @@ invalid read/write of size 8 in ftoa() (10/08/14 -- hilde)
 ----------------------------------------------------------
 [Error matching program output for performance/sungeun/assign_across_locales]
 
-"Unrecognised instruction" (05/18/2013)
----------------------------------------
-[Error matching program output for types/atomic/ferguson/atomictest]
-[Error matching program output for types/atomic/sungeun/atomic_vars]
-
 continual compilation timeouts
 ------------------------------
 [Error: Timed out compilation for functions/iterators/vass/yield-arrays-var-nonvar]
@@ -247,14 +242,12 @@ continual execution timeouts
 [Error: Timed out executing program parallel/begin/sungeun/capture]
 [Error: Timed out executing program studies/hpcc/PTRANS/PTRANS]
 [Error: Timed out executing program studies/lammps/shemmy/p-lammps-n1]
-[Error: Timed out executing program studies/lammps/shemmy/p-lammps-n2]
-[Error: Timed out executing program studies/lammps/shemmy/p-lammps-n4]
 [Error: Timed out executing program types/range/bradc/overflowInComputeBlock]
 [Error: Timed out executing program types/single/sungeun/stress]
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program io/ferguson/ctests/qio_test (compopts: 1)] (last seen 11/05/14)
+[Error: Timed out executing program io/ferguson/ctests/qio_test (compopts: 1)] (...11/05/14, 11/07/14)
 
 
 sporadic invalid write of size 8 in dl_lookup_symbol->do_lookup_x,

--- a/test/REGRESSIONS-stories
+++ b/test/REGRESSIONS-stories
@@ -572,7 +572,7 @@ o invalid read/write of size 8 in ftoa() (valgrind): hilde
   - performance/sungeun/assign_across_locales
 
 
-o "Unrecognized instruction" (valgrind): anyone
+* "Unrecognized instruction" (valgrind): anyone
 
   The following two tests get an unrecognized instruction error.  Is
   there anything we can/should do about this?  Does it indicate a
@@ -584,7 +584,7 @@ o "Unrecognized instruction" (valgrind): anyone
   - types/atomic/sungeun/atomic_vars
 
 
-o Valgrind timeouts (valgrind): anyone
+~ Valgrind timeouts (valgrind): anyone
 
   The following tests time out very consistently under valgrind.  By
   nature, valgrind testing takes a long time so maybe this is why.


### PR DESCRIPTION
## New regressions
- missing chpl_memcpy() prototypes (fixed now, still filtering through)
- got a recursive AMUDP_SPMDShutdown error in distributions/dm/hplx (vass)
- got a new suite of tests that get the "array index out of bounds error"
  (while the lulesh ones cleaned themselves up a few days ago) -- I think
  this is the qthreads memory fence issue that greg is looking into.
## Improvements
- extern/ferguson/c_ptrs now fixed for Mac (thanks Kyle!)
- overlapping memcpy valgrind issues now fixed (thanks hilde!)
- sungeun/lulesh timeouts resolved (thanks me!)
- leakedmemory5 no longer complaining about lack of suppression (thanks Lydia!)
- valgrind atomic tests silenced (thanks vass!)
- two lammps valgrind timeouts silenced (thanks vass!)
## Misc
- moved qio_test consistent timeout to sporadic unless someone wants to
  take credit for closing it (I couldn't tell)
- noted new dates for sporadic timeouts
