### PR TITLE
Fix qio_file_path_for_fd so it works in cygwin

### DIFF
--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1304,7 +1304,7 @@ qioerr qio_file_open_tmp(qio_file_t** file_out, qio_hint_t iohints, const qio_st
 // string_out must be freed by the caller.
 qioerr qio_file_path_for_fd(fd_t fd, const char** string_out)
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(__CYGWIN__)
   char pathbuf[500];
   qioerr err;
   const char* result;


### PR DESCRIPTION
`qio_file_path_for_fd` has three paths that are selected via `#ifdef`s, cygwin was
hitting the fall-back case that always returned "unknown" as the file path.

cygwin can actually use the same code as linux for this operation, so I've
added a check for `__CYGWIN__` to that `#if`.
