### PR TITLE
Numa widens pointers, so the amount of memory "leaked" is larger.

### DIFF
--- a/test/memory/figueroa/LeakedMemory6.lm-numa.good
+++ b/test/memory/figueroa/LeakedMemory6.lm-numa.good
@@ -1,0 +1,4 @@
+1 1 1 1
+Amount of leaked memory after calling foo(): 16
+sum is 100
+0 1 1 1 1


### PR DESCRIPTION
LeakedMemory6 looks at the memory before and after a function that increases
the length of an array.  Therefore "memory leaked" should be one pointer greater
than before the function is run.  On numa, this means 16 instead of 8
