### PR TITLE
Add a future for the widecols.chpl cygwin output.

### DIFF
--- a/test/io/ferguson/utf8/widecols-cygwin-copy.bad
+++ b/test/io/ferguson/utf8/widecols-cygwin-copy.bad
@@ -1,0 +1,35 @@
+First group contains control characters (bell) and newlines and so is uneven
+hello                                                                          |
+찠찠o                                                                          |
+bel=                                                                           |
+\
+                                                                              |
+snomwan ☃ snowflake ❄ gclef 𝄞  end                                            |
+                                                                          hello|
+                                                                          찠찠o|
+                                                                           bel=|
+                                                                              \
+|
+                                            snomwan ☃ snowflake ❄ gclef 𝄞  end|
+Second group should be nicely aligned with Chapel-style escapes
+"hello"                                                                        |
+"찠찠o"                                                                        |
+"bel=\x07"                                                                     |
+"\\\n"                                                                         |
+"snomwan ☃ snowflake ❄ gclef 𝄞  end"                                          |
+                                                                        "hello"|
+                                                                        "찠찠o"|
+                                                                     "bel=\x07"|
+                                                                         "\\\n"|
+                                          "snomwan ☃ snowflake ❄ gclef 𝄞  end"|
+Third group should be nicely aligned with JSON-style escapes
+"hello"                                                                        |
+"찠찠o"                                                                        |
+"bel=\u0007"                                                                   |
+"\\\n"                                                                         |
+"snomwan ☃ snowflake ❄ gclef 𝄞  end"                                          |
+                                                                        "hello"|
+                                                                        "찠찠o"|
+                                                                   "bel=\u0007"|
+                                                                         "\\\n"|
+                                          "snomwan ☃ snowflake ❄ gclef 𝄞  end"|

--- a/test/io/ferguson/utf8/widecols-cygwin-copy.chpl
+++ b/test/io/ferguson/utf8/widecols-cygwin-copy.chpl
@@ -1,0 +1,1 @@
+widecols.chpl

--- a/test/io/ferguson/utf8/widecols-cygwin-copy.future
+++ b/test/io/ferguson/utf8/widecols-cygwin-copy.future
@@ -1,0 +1,10 @@
+bug: Certain utf8 characters miscount their width on cygwin
+
+On Linux, the character G Clef takes up one character width,
+while cygwin thinks it takes up two when determining how to
+fill a line, making the output line which includes it
+shorter than it would be if the length was counted correctly.
+
+This test is a symlink to the original, widecols.chpl.  Once
+this future has been resolved, remove this test and the
+skipif for widecols on cygwin.

--- a/test/io/ferguson/utf8/widecols-cygwin-copy.good
+++ b/test/io/ferguson/utf8/widecols-cygwin-copy.good
@@ -1,0 +1,1 @@
+widecols.good

--- a/test/io/ferguson/utf8/widecols-cygwin-copy.skipif
+++ b/test/io/ferguson/utf8/widecols-cygwin-copy.skipif
@@ -1,0 +1,2 @@
+# This is to test the behavior of widecols.chpl on cygwin
+CHPL_HOST_PLATFORM != cygwin

--- a/test/io/ferguson/utf8/widecols.skipif
+++ b/test/io/ferguson/utf8/widecols.skipif
@@ -1,0 +1,2 @@
+# This test is broken for cygwin.  There is a future for it
+CHPL_HOST_PLATFORM == cygwin


### PR DESCRIPTION
Cygwin thinks that the character G clef takes up more
space than it does when output, so is missing a space
in its final output.  This is a bug, so futurize the
failing case (by making a link to the original) and
skip the cygwin run of the original.
