### PR TITLE
Fix prgenv-cray portability issue for glob() call

### DIFF
--- a/modules/standard/Filerator.chpl
+++ b/modules/standard/Filerator.chpl
@@ -180,7 +180,9 @@ iter wordexp(pattern="*") {
 
 iter glob(pattern="*") {
   extern type glob_t;
-  extern proc glob(pattern:c_string, flags: c_int, errfunc:c_void_ptr, 
+  extern type glob_err_fn_t;
+  extern const NULL: glob_err_fn_t;
+  extern proc glob(pattern:c_string, flags: c_int, errfunc:glob_err_fn_t, 
                    ref ret_glob:glob_t):c_int;
   extern proc chpl_glob_num(x:glob_t): size_t;
   extern proc chpl_glob_index(x:glob_t, idx:size_t): c_string;
@@ -188,7 +190,7 @@ iter glob(pattern="*") {
 
   var glb : glob_t;
 
-  const err = glob(pattern:c_string, 0, c_nil, glb);
+  const err = glob(pattern:c_string, 0, NULL, glb);
   const num = chpl_glob_num(glb);
   if (num) then
     for i in 0..num-1 do


### PR DESCRIPTION
The glob() call takes an optional function pointer as an argument, and
I had just been passing c_nil into it.  However, the Cray compiler
doesn't like this because of the fact that it isn't a literal "NULL"
being passed in, but a Chapel variable of type void\* which isn't
of pointer-to-function type.

As an easy workaround for this, I invented an external type to
represent the function pointer type and declared a (local to the
scope in question) extern var named NULL of that type.  This has
the effect of passing the NULL straight through to glob() which
makes the complaint go away.

If this didn't work on some other platform (though I believe it
will), we could always push the glob() into the runtime, wrapping
it as chpl_glob() and have it supply the NULL argument for the
function pointer.  But the current approach feels more lightweight
without seeming crufty to me.
