### PR TITLE
Restore honoring --max-c-ident-len for PGI.

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -613,11 +613,13 @@ const char* AggregateType::classStructName(bool standalone) {
       if (symbol->hasFlag(FLAG_EXTERN)) {
         return astr("_", basename);
       } else {
+        // keep in sync with maxCNameAddedChars
         return astr(CLASS_STRUCT_PREFIX, basename, "_object");
       }
     } else
       return basename;
   } else {
+    // keep in sync with maxCNameAddedChars
     return astr(CLASS_STRUCT_PREFIX, symbol->cname, "_s");
   }
 }

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -362,27 +362,33 @@ compareSymbol(const void* v1, const void* v2) {
 // given a name and up to two sets of names, return a name that is in
 // neither set and add the name to the first set; the second set may
 // be omitted; the returned name to be capped at fMaxCIdentLen if non-0
+// less how much can be added to it - maxCNameAddedChars
 //
 // the unique numbering is based on the map uniquifyNameCounts which
 // can be cleared to reset
 //
 int fMaxCIdentLen = 0;
 static const int maxUniquifyAddedChars = 25;
+// keep in sync with AggregateType::classStructName()
+static const int maxCNameAddedChars = 20;
 static char* longCNameReplacementBuffer = NULL;
 static Map<const char*, int> uniquifyNameCounts;
 static const char* uniquifyName(const char* name,
                                 Vec<const char*>* set1,
                                 Vec<const char*>* set2 = NULL) {
   const char* newName = name;
-  if (fMaxCIdentLen > 0 && (int)(strlen(newName)) > fMaxCIdentLen) {
+  if (fMaxCIdentLen > 0 &&
+      (int)(strlen(newName) + maxCNameAddedChars) > fMaxCIdentLen)
+  {
     // how much of the name to preserve
-    int prefixLen = fMaxCIdentLen - maxUniquifyAddedChars;
+    int prefixLen = fMaxCIdentLen - maxUniquifyAddedChars - maxCNameAddedChars;
     if (!longCNameReplacementBuffer) {
       longCNameReplacementBuffer = (char*)malloc(prefixLen+1);
       longCNameReplacementBuffer[prefixLen] = '\0';
     }
     strncpy(longCNameReplacementBuffer, newName, prefixLen);
     INT_ASSERT(longCNameReplacementBuffer[prefixLen] == '\0');
+    longCNameReplacementBuffer[prefixLen-1] = 'X'; //fyi truncation marker
     name = newName = astr(longCNameReplacementBuffer);
   }
   while (set1->set_in(newName) || (set2 && set2->set_in(newName))) {


### PR DESCRIPTION
The compiler was not honoring --max-c-ident-len aka fMaxCIdentLen,
which is set automatically for PGI compilation. As a result,
too-long identifiers got codegen-ed and PGI complained.

The culprit I think was the addition of CLASS_STRUCT_PREFIX and "_s"
(or, possibly, "_object") in AggregateType::classStructName().

Now these additions are accounted for via maxCNameAddedChars.

I do not know how to set maxCNameAddedChars automatically,
so I overshot it by a little and added reminder comments to
AggregateType::classStructName().
