### PR TITLE
Fix for last night's --baseline regressions

### DIFF
--- a/compiler/passes/reservedSymbolNames
+++ b/compiler/passes/reservedSymbolNames
@@ -262,3 +262,9 @@
   wait2
   wait3
   wait4
+
+  // symbols in wordexp.h
+  wordexp
+
+  // symbols in glob.h
+  glob

--- a/runtime/include/chplglob.h
+++ b/runtime/include/chplglob.h
@@ -26,6 +26,8 @@
 // from qio runtime
 #include "sys.h"
 
+typedef int (*glob_err_fn_t)(const char*, int);
+
 static inline
 size_t chpl_glob_num(const glob_t glb) {
   return glb.gl_pathc;


### PR DESCRIPTION
[trivial, not reviewed]

This commit fixes last night's glob baseline regressions.  The
cause of the problem is that, in --baseline mode, we introduce
variables of the fake glob_err_fn_t type that I declared in the
Chapel module; but since that type is never defined in C, we
get C runtime link errors.  This may be similar to the "extra
copies of extern types under baseline" issue that Lydia's been
running into.

I also found that I had to add wordexp and glob to the reserved
symbol names list even though I don't think we've had to do this
in the past (even though it makes sense that we would need to).
I wonder if this is somehow a darwin+baseline-specific thing?
