### PR TITLE
Fix for Filerator valgrind regressions

### DIFF
--- a/modules/standard/Filerator.chpl
+++ b/modules/standard/Filerator.chpl
@@ -180,17 +180,15 @@ iter wordexp(pattern="*") {
 
 iter glob(pattern="*") {
   extern type glob_t;
-  extern type glob_err_fn_t;
-  extern const NULL: glob_err_fn_t;
-  extern proc glob(pattern:c_string, flags: c_int, errfunc:glob_err_fn_t, 
-                   ref ret_glob:glob_t):c_int;
+  extern proc chpl_glob(pattern:c_string, flags: c_int, 
+                        ref ret_glob:glob_t):c_int;
   extern proc chpl_glob_num(x:glob_t): size_t;
   extern proc chpl_glob_index(x:glob_t, idx:size_t): c_string;
   extern proc globfree(ref glb:glob_t);
 
   var glb : glob_t;
 
-  const err = glob(pattern:c_string, 0, NULL, glb);
+  const err = chpl_glob(pattern:c_string, 0, glb);
   const num = chpl_glob_num(glb);
   if (num) then
     for i in 0..num-1 do

--- a/runtime/include/chplglob.h
+++ b/runtime/include/chplglob.h
@@ -26,7 +26,10 @@
 // from qio runtime
 #include "sys.h"
 
-typedef int (*glob_err_fn_t)(const char*, int);
+static inline
+int chpl_glob(const char* pattern, int flags, glob_t* ret_glob) {
+  return glob(pattern, flags, NULL, ret_glob);
+}
 
 static inline
 size_t chpl_glob_num(const glob_t glb) {


### PR DESCRIPTION
I'm not 100% sure why yet, but something about my use of an
extern opaque type to represent a function pointer and
declaration of NULL for the actual to that argument caused
a valgrind error in getValType() (worth exploring further).

In the interest of closing this down quickly and cleanly,
I went back to the original implementation approach of simply
wrapping glob() in a chpl_glob() wrapper that only deals with
the three arguments we need to deal with in Chapel.  This
resolves both the valgrind and baseline issues.
