### PR TITLE
Renamed chpl_glob to chpl_study_glob to avoid name conflict

### DIFF
--- a/test/studies/glob/Glob.chpl
+++ b/test/studies/glob/Glob.chpl
@@ -4,7 +4,7 @@ use SysBasic;
 extern type glob_t;
 extern type wordexp_t;
 
-extern proc chpl_glob(pattern:c_string, flags:c_int, ref ret_glob:glob_t):c_int;
+extern proc chpl_study_glob(pattern:c_string, flags:c_int, ref ret_glob:glob_t):c_int;
 extern proc chpl_wordexp(pattern:c_string, flags:c_int, ref ret_glob:wordexp_t):c_int;
 
 extern proc glob_num(x:glob_t): size_t;
@@ -90,7 +90,7 @@ iter my_glob(pattern:string, recursive:bool = false, flags:int = 0, directory:st
   var tx  : c_string;
   var glb : glob_t;
 
-  err = chpl_glob((directory + pattern).c_str(), flags:c_int, glb);
+  err = chpl_study_glob((directory + pattern).c_str(), flags:c_int, glb);
 
   for i in 0..glob_num(glb) - 1 {
     tx = glob_index(glb, i);

--- a/test/studies/glob/globerator.chpl
+++ b/test/studies/glob/globerator.chpl
@@ -3,7 +3,7 @@ use SysBasic;
 extern type glob_t;
 extern type wordexp_t;
 
-extern proc chpl_glob(pattern:c_string, flags:c_int, ref ret_glob:glob_t):c_int;
+extern proc chpl_study_glob(pattern:c_string, flags:c_int, ref ret_glob:glob_t):c_int;
 extern proc chpl_wordexp(pattern:c_string, flags:c_int, ref ret_glob:wordexp_t):c_int;
 extern proc chpl_isdir(path:c_string):c_int;
 extern proc glob_num(x:glob_t): size_t;
@@ -30,7 +30,7 @@ iter glob(pattern:string, flags:int, expand:bool = false, recursive:bool = false
         }
     } else { // else, use glob
         var glb:glob_t;
-        err = chpl_glob((extension + pattern).c_str(), flags:c_int, glb);
+        err = chpl_study_glob((extension + pattern).c_str(), flags:c_int, glb);
         for i in 0..glob_num(glb) - 1 {
             tx = glob_index(glb, i);
             if recursive {
@@ -58,7 +58,7 @@ where tag == iterKind.leader {
     } else { // else, use glob
         var glb:glob_t;
         // Make this spawn a task if we encounter a dir, else yield in parallel
-        err = chpl_glob(pattern.c_str(), flags:c_int, glb);
+        err = chpl_study_glob(pattern.c_str(), flags:c_int, glb);
         for i in 0..glob_num(glb) - 1 do 
             yield toString(glob_index(glb, i));
     }

--- a/test/studies/glob/globhelp.h
+++ b/test/studies/glob/globhelp.h
@@ -25,11 +25,11 @@ const char* wordexp_index(const wordexp_t wexp, size_t i) {
 }
 
 // to make --cc-warnings happy
-int chpl_glob(const char* pattern, int flags, glob_t* ret_glob);
+int chpl_study_glob(const char* pattern, int flags, glob_t* ret_glob);
 int chpl_wordexp(const char* pattern, int flags, wordexp_t* ret_glob);
 int chpl_isdir(const char* path);
 
-int chpl_glob(const char* pattern, int flags, glob_t* ret_glob)
+int chpl_study_glob(const char* pattern, int flags, glob_t* ret_glob)
 {
   int err;
   err = glob(pattern, flags, NULL, ret_glob);

--- a/test/studies/glob/recursive-par-glob.chpl
+++ b/test/studies/glob/recursive-par-glob.chpl
@@ -3,7 +3,7 @@ use SysBasic;
 extern type glob_t;
 extern type wordexp_t;
 
-extern proc chpl_glob(pattern:c_string, flags:c_int, ref ret_glob:glob_t):c_int;
+extern proc chpl_study_glob(pattern:c_string, flags:c_int, ref ret_glob:glob_t):c_int;
 extern proc chpl_wordexp(pattern:c_string, flags:c_int, ref ret_glob:wordexp_t):c_int;
 extern proc chpl_isdir(path:c_string):c_int;
 extern proc glob_num(x:glob_t): size_t;
@@ -29,7 +29,7 @@ iter glob(pattern:string, flags:int, expand:bool = false, recursive:bool = false
         }
     } else { // else, use glob
         var glb:glob_t;
-        err = chpl_glob((extension + pattern).c_str(), flags:c_int, glb);
+        err = chpl_study_glob((extension + pattern).c_str(), flags:c_int, glb);
         for i in 0..glob_num(glb) - 1 {
             tx = glob_index(glb, i);
             if recursive {
@@ -62,7 +62,7 @@ where tag == iterKind.leader {
   } else { // else, use glob
     var glb:glob_t;
     // Spawn a task if we encounter a dir, else yield in parallel
-    err = chpl_glob(pattern.c_str(), flags:c_int, glb);
+    err = chpl_study_glob(pattern.c_str(), flags:c_int, glb);
     for i in 0..glob_num(glb) - 1 {
       tx = glob_index(glb, i);
       if recursive && chpl_isdir(tx) == 1 {


### PR DESCRIPTION
Continuing my game of glob whack-a-mole, when adding our
new runtime chpl_glob() routine yesterday, it failed to occur
to me that it would conflict in name with this routine that Tim
used in his test when he was doing an initial prototype of
glob().  I've had a long-term TODO to rewrite Tim's test to
use filerator routines (and move both sets of tests into the
test/modules/standard hierarchy), but for now am just renaming
his chpl_glob() to silence last night's failures.
