### PR TITLE
Use "mail" instead of "Mail" as the default nightly testing mailer.

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -101,7 +101,7 @@ if ($debug == 1) {
 #
 $mailer = $ENV{'CHPL_MAILER'};
 if ($mailer eq "") {
-    $mailer = "Mail";
+    $mailer = "mail";
 }
 
 $somethingfailed = 0;

--- a/util/cron/lookForTabs.cron
+++ b/util/cron/lookForTabs.cron
@@ -5,7 +5,7 @@ use File::Basename;
 
 $user = `whoami`;
 chomp($user);
-$mailcommand = "| Mail -s \"Cron Nightly TAB check\" $user\@cray.com";
+$mailcommand = "| mail -s \"Cron Nightly TAB check\" $user\@cray.com";
 $cwd = abs_path(dirname(__FILE__));
 $chplhomedir = abs_path("$cwd/../..");
 
@@ -16,7 +16,7 @@ $matches = `wc -l $matchfile`;
 chomp($matches);
 if ($matches != 0) {
   print "matches!\n";
-  open(MAIL, "| Mail -s 'Cron Nightly TAB check' chapel_dev\@cray.com");
+  open(MAIL, "| mail -s 'Cron Nightly TAB check' chapel_dev\@cray.com");
     open(MESSAGE, "<$matchfile");
     while (<MESSAGE>) {
       my($line) = $_;

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -279,7 +279,7 @@ $utildir = "$testbindirname/../../util";
 #
 $mailer = $ENV{'CHPL_MAILER'};
 if ($mailer eq "") {
-    $mailer = "Mail";
+    $mailer = "mail";
 }
 
 #

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -62,7 +62,7 @@ if (exists($ENV{"BUILD_URL"})) {
 #
 $mailer = $ENV{'CHPL_MAILER'};
 if ($mailer eq "") {
-    $mailer = "Mail";
+    $mailer = "mail";
 }
 
 if ($cronrecipient eq "" and exists($ENV{"CHPL_NIGHTLY_CRON_RECIPIENT"})) {


### PR DESCRIPTION
On Ubuntu "Mail" is not provided. On all existing test systems both "mail" and
"Mail" are provided and are the same. Using "mail" as the default will allow
Ubuntu testing to use the default instead of having to set CHPL_MAILER.
