### PR TITLE
Update llvm nightly tests to run spectests.

### DIFF
--- a/util/cron/common-llvm.bash
+++ b/util/cron/common-llvm.bash
@@ -7,7 +7,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 export CHPL_LLVM=llvm
 
 # Run examples and test/extern/ferguson/.
-export CHPL_NIGHTLY_TEST_DIRS="release/examples extern/ferguson"
+export CHPL_NIGHTLY_TEST_DIRS="extern/ferguson"
 
 suppression_file=$CWD/../../test/Suppressions/llvm.suppress
 nightly_args="-llvm -suppress ${suppression_file}"

--- a/util/cron/test-gasnet.llvm.bash
+++ b/util/cron/test-gasnet.llvm.bash
@@ -9,4 +9,4 @@ source $CWD/common-llvm.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.llvm"
 
-$CWD/nightly -cron ${nightly_args}
+$CWD/nightly -cron -examples ${nightly_args}

--- a/util/cron/test-llvm.bash
+++ b/util/cron/test-llvm.bash
@@ -9,4 +9,4 @@ source $CWD/common-llvm.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="llvm"
 
-$CWD/nightly -cron ${nightly_args}
+$CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
It turns out nightly does not build the spec tests unless -examples is set. So,
instead of setting the start_test dirs to "release/examples extern/ferguson",
just set extern/ferguson and call nightly with -examples flag.
