### PR TITLE
Run full suite of tests for linux32 configuration.

### DIFF
--- a/util/cron/test-linux32.bash
+++ b/util/cron/test-linux32.bash
@@ -7,4 +7,4 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux32"
 
-$CWD/nightly -cron -examples
+$CWD/nightly -cron


### PR DESCRIPTION
So far only the examples have been regularly tested on linux32. Try running the
full suite to see what comes up.

If this goes well, we can consider running the full suite for no-local.linux32
too.
