### PR TITLE
Strip new lines from proc count in nightly (et al).

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -247,6 +247,7 @@ if ($make eq "") {
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
 $num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`;
+chomp($num_procs);
 
 $cronlogdir = $ENV{'CHPL_NIGHTLY_CRON_LOGDIR'};
 

--- a/util/pastPerformance/getoldperf
+++ b/util/pastPerformance/getoldperf
@@ -64,6 +64,7 @@ $somethingfailed = 0;
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
 $num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`;
+chomp($num_procs);
 
 #
 # make temp directory

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -101,6 +101,7 @@ if ($debug == 1) {
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
 $num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`;
+chomp($num_procs);
 
 mysystem("cd $tokctdir && make > /dev/null", "building token counter", 1, 1);
 


### PR DESCRIPTION
Before this change, the make calls, `make -j$num_procs ... compiler`, were
putting the target on a separate line. This caused everything that uses these
scripts to fail last night.
