### PR TITLE
REGRESSIONS updates based on past several days

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -180,10 +180,6 @@ conditional jump depends on uninitialized value (04/08/14 -- since re2 on)
 [Error matching program output for io/tzakian/recordReader/test]
 [Error matching program output for regexp/ferguson/rechan]
 
-stack overflow
---------------
-[Error matching program output for parallel/cobegin/gbt/cobegin-stacksize]
-
 invalid read/write of size 8 in ftoa() (10/08/14 -- hilde)
 ----------------------------------------------------------
 [Error matching program output for performance/sungeun/assign_across_locales]

--- a/test/REGRESSIONS-stories
+++ b/test/REGRESSIONS-stories
@@ -553,7 +553,7 @@ o 21-capture-in-cobegin: vass
 medium priority (clutter)
 -------------------------
 
-o stack overflow (valgrind): anyone
+* stack overflow (valgrind): anyone
 
   The following test gets a stack overflow -- is there something we
   can/should do about this?  Should we skip if in valgrind testing?


### PR DESCRIPTION
## New regressions
- externRecordLostFields mismatched .bad on prgenv-intel (should be fixed now)
## Improvements
- miniMD darwin failures fixed (thanks Ben!)
- memleaks timeouts fixed by switching machines (thanks Thomas!)
- widecols failure silenced (thanks Lydia!)
- crazyRecord failure fixed (thanks Lydia!)
- cobegin-stacksize failures fixed on baseline and valgrind (thanks Elliot!)
## Misc
- note that darwin and baseline testing are now completely clean!
- retired the gasnet.linux32 configuration (due to timeouts, oversubscription,
  sense that people aren't going to do distributed memory 32-bit programming)
  in favor of no-local.linux32 (which should give us similar coverage of our
  generated code with fewer testing resources required)
- noted dates for new sporadic failures
