### PR TITLE
Bump gasnet timeout again

### DIFF
--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -10,6 +10,9 @@ export GASNET_SPAWNFN=L
 export GASNET_ROUTE_OUTPUT=0
 export CHPL_GASNET_CFG_OPTIONS=--disable-ibv
 
+# Bump the timeout slightly just because we're oversubscribed
+export CHPL_TEST_TIMEOUT=500
+
 tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
 if [ "${tasks}" == "qthreads" ] ; then
     # Set these to use oversubscription to help with timeouts
@@ -32,6 +35,7 @@ if [ "${tasks}" == "qthreads" ] ; then
     if [ $logicalCores -le 8 ] ; then
         export CHPL_TEST_TIMEOUT=900
     fi
-
+    if [ $logicalCores -le 4 ] ; then
+        export CHPL_TEST_TIMEOUT=1800
+    fi
 fi
-


### PR DESCRIPTION
Even at 15 minutes we still have some timeouts for the small core count
machines. Bumping to a ridiculous 30 minutes for machines with <= 4 cores, and
leaving at 15 minutes for <= 8 cores. If we still have timeouts after this,
I'll cry.

As with the previous commits, this is only until we get real hardware to run on
instead of running oversubscribed.

Also bumping the default for all gasnet runs slightly (not just qthreads with
low core count) because we have occasional timeouts for fifo.
