### PR TITLE
Disable performance playground

### DIFF
--- a/util/cron/test-perf.chap03.bash
+++ b/util/cron/test-perf.chap03.bash
@@ -7,4 +7,4 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap03"
 
-$CWD/nightly -cron -performance-description 'default --genGraphOpts "-m default -m qthreads"' -numtrials 5 -startdate 08/21/07
+$CWD/nightly -cron -performance -numtrials 5 -startdate 08/21/07

--- a/util/cron/test-perf.chap03.playground.bash
+++ b/util/cron/test-perf.chap03.playground.bash
@@ -7,4 +7,5 @@ source $CWD/common-qthreads.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap03.playground"
 
-$CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -numtrials 5 -startdate 08/21/07
+# disabled until there are some more performance comparisons we want to do
+#$CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -numtrials 5 -startdate 08/21/07

--- a/util/cron/test-perf.chap04.bash
+++ b/util/cron/test-perf.chap04.bash
@@ -7,4 +7,4 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04"
 
-$CWD/nightly -cron -performance-description 'default --genGraphOpts "-m default -m qthreads"' -releasePerformance -numtrials 5 -startdate 07/28/12
+$CWD/nightly -cron -performance -releasePerformance -numtrials 5 -startdate 07/28/12

--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -7,8 +7,5 @@ source $CWD/common-qthreads.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04.playground"
 
-export CHPL_RT_NUM_THREADS_PER_LOCALE=16
-# releasePerformance still generates results based on the fifo timings. It's
-# run here again, otherwise syncing the qthreads results blows away the
-# directory with the releaseOverRelease graphs in
-$CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -releasePerformance -numtrials 5 -startdate 07/28/12
+# disabled until there are some more performance comparisons we want to do
+#$CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -releasePerformance -numtrials 5 -startdate 07/28/12


### PR DESCRIPTION
They playground isn't doing anything useful right now so there's no point in
running the tests. It generates extra mail and increases load times for the
graphs. Leaving the bash files around since it's likely these will be used in
the near future.
