### PR TITLE
Skip cobegin-stacksize for CHPL_COMM!=none

### DIFF
--- a/test/parallel/cobegin/gbt/cobegin-stacksize.skipif
+++ b/test/parallel/cobegin/gbt/cobegin-stacksize.skipif
@@ -6,3 +6,9 @@ COMPOPTS <= --fast
 # cygwin doesn't support changing the stack size
 CHPL_TARGET_PLATFORM == cygwin
 
+# The -E option is being used to set CHPL_RT_CALL_STACK_SIZE because the test
+# tries to test two modes and I didn't want to create two identical tests with
+# different .execenvs. However, the -E option doesn't work with launchers so I
+# opted to just skip those configurations for now.
+CHPL_COMM != none
+


### PR DESCRIPTION
The -E option is being used to set CHPL_RT_CALL_STACK_SIZE because the test
tries to test two modes and I didn't want to create two identical tests with
different .execenvs. However, the -E option doesn't work with launchers so I
opted to just skip those configurations for now.

I'll work with Greg to see if there's a better solution but this will quiet
testing for now. The other two options that I see are a quick but ugly fix that
creates two identical versions of the test with different execenvs or the
cleaner but much more involved solution of implementing -E for launchers.
