### PR TITLE
Increase timeout for test systems w/ <= 8 logical cores.

### DIFF
--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -33,9 +33,6 @@ if [ "${tasks}" == "qthreads" ] ; then
     # hardware we get the performance we expect
     logicalCores=`python -c 'import multiprocessing ; print multiprocessing.cpu_count()'`
     if [ $logicalCores -le 8 ] ; then
-        export CHPL_TEST_TIMEOUT=900
-    fi
-    if [ $logicalCores -le 4 ] ; then
         export CHPL_TEST_TIMEOUT=1800
     fi
 fi


### PR DESCRIPTION
Suggested by @ronawho to get rid of final timeouts.
