### PR TITLE
Do not run futures for full suite testing on linux32.

### DIFF
--- a/util/cron/test-linux32.bash
+++ b/util/cron/test-linux32.bash
@@ -7,4 +7,4 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux32"
 
-$CWD/nightly -cron
+$CWD/nightly -cron -no-futures


### PR DESCRIPTION
Suggested by @bradcray.
