### PR TITLE
Suppress GMP failures on linux32.

### DIFF
--- a/test/Suppressions/linux32.suppress
+++ b/test/Suppressions/linux32.suppress
@@ -1,0 +1,9 @@
+# For details on linux32 GMP suppressions, see: https://www.pivotaltracker.com/story/show/82526190
+modules/standard/gmp/studies/gmp-chudnovsky
+modules/standard/gmp/ferguson/gmp_dist_array
+modules/standard/gmp/ferguson/gmp_test
+modules/standard/gmp/ferguson/gmp_random
+modules/standard/gmp/ferguson/gmp_writeln
+studies/shootout/pidigits/hilde/pidigits-hilde
+studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt
+studies/shootout/pidigits/thomasvandoren/pidigits-BigInt

--- a/util/cron/test-linux32.bash
+++ b/util/cron/test-linux32.bash
@@ -7,4 +7,5 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux32"
 
-$CWD/nightly -cron -no-futures
+suppression_file=$CWD/../../test/Suppressions/linux32.suppress
+$CWD/nightly -cron -no-futures -suppress ${suppression_file}


### PR DESCRIPTION
There is story for fixing these, which requires some effort. For now, just suppress
the errors to avoid the noise in the nightly emails.
