### PR TITLE
Fix counts in nightly emails.

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -889,21 +889,21 @@ sub mysystem {
 sub numsuccesses {
   $mystr = $_[0];
   $mystr =~ s/.* #Successes = //;
-  $mystr =~ s/ \|.*//;
+  $mystr =~ s/( \|\]).*//;
   $mystr;
 }
 
 sub numfailures {
   $mystr = $_[0];
   $mystr =~ s/.* #Failures = //;
-  $mystr =~ s/ \|.*//;
+  $mystr =~ s/( \|\]).*//;
   $mystr;
 }
 
 sub numfutures {
   $mystr = $_[0];
   $mystr =~ s/.* #Futures = //;
-  $mystr =~ s/ \|.*//;
+  $mystr =~ s/( \|\]).*//;
   $mystr;
 }
 


### PR DESCRIPTION
Fix nightly so it correctly get "0" futures, instead of "0]" futures for this
summary:

```
[Summary: #Successes = 5021 | #Failures = 4 | #Futures = 0]
```
