### PR TITLE
Support --baseline without --inline

### DIFF
--- a/test/Suppressions/baseline.suppress
+++ b/test/Suppressions/baseline.suppress
@@ -1,8 +1,6 @@
-##Because inlining is turned off when baseline is run:
-#Actually, now it's turned back on when baseline is run.  Hopefully
-#that won't always be the case, so I'm temporarily un-suppressing
-#these.
-#trivial/mjoyner/inlinefunc/inlfunc1_report
-#trivial/mjoyner/inlinefunc/inlfunc2_report
+# These generate reports on inlining
+trivial/mjoyner/inlinefunc/inlfunc1_report
+trivial/mjoyner/inlinefunc/inlfunc2_report
+#
 # lack of optimizations lead to extra leaked memory
 memory/sungeun/refCount/domainMaps

--- a/test/statements/diten/op_equals_using_C_primitive.skipif
+++ b/test/statements/diten/op_equals_using_C_primitive.skipif
@@ -1,1 +1,4 @@
+# --baseline implies no inlining but this test requires inlining
+COMPOPTS <= --baseline
+
 COMPOPTS <= --llvm

--- a/util/cron/test-baseline.bash
+++ b/util/cron/test-baseline.bash
@@ -7,4 +7,4 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="baseline"
 
-$CWD/nightly -cron -baseline -suppress Suppressions/baseline.suppress -no-futures -compopts --inline
+$CWD/nightly -cron -baseline -suppress Suppressions/baseline.suppress -no-futures


### PR DESCRIPTION
Update the baseline suppressions and a .skipif so that --baseline can run without throwing --inline
