### PR TITLE
Update chown/nothing.prediff to check all user groups.

### DIFF
--- a/test/io/fsouza/chown/nothing.prediff
+++ b/test/io/fsouza/chown/nothing.prediff
@@ -1,15 +1,18 @@
-#!/bin/csh
+#!/usr/bin/env bash
 
 #
 # Note that this test will fail if the setgid bit is set on this
 # directory and the group id is different than the effective group id.
 #
 
-set file_user = `ls -l file.txt | awk '{print $3}'`
-set file_group = `ls -l file.txt | awk '{print $4}'`
-set current_user = `id -un`
-set current_group = `id -gn`
+file_user=$(ls -l file.txt | awk '{print $3}')
+file_group=$(ls -l file.txt | awk '{print $4}')
 
-if ($file_user == $current_user && $file_group == $current_group) then
+current_user=$(id -un)
+current_groups=$(groups)
+
+group_result=$(python -c "print('${file_group}' in '${current_groups}')")
+
+if [ "${file_user}" = "${current_user}" -a "${group_result}" = "True" ] ; then
   echo "no change" >> $2
-endif
+fi


### PR DESCRIPTION
The group assigned to a particular file will not necessarily be the group
reported by `$(id -gn)`. Update nothing.prediff to check that the group
assigned to the file is one of the groups reported by `$(groups)`.

bash-ify the prediff along the way.
