### PR TITLE
Change sub_test to not pass numLocales to C tests

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -980,7 +980,7 @@ for testname in testsrc:
         continue # on to next test
 
     # Set numlocales
-    if (numlocales == 0) or (chplcomm=='none'):
+    if (numlocales == 0) or (chplcomm=='none') or is_c_test:
         numlocexecopts = None
     else:
         numlocexecopts = ' -nl '+str(numlocales)


### PR DESCRIPTION
Passing `-nl #` to some C tests would cause errors in when they tried to parse their arguments.
