### PR TITLE
Fix paratest.server to respect skipif files.

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -403,12 +403,12 @@ sub find_subdirs {
             my $skip;
             if (-x "$skipfilen") {
                 print "$skipfilen = " . `$skipfilen` if $debug;
-                my $skip = `$skipfilen`;
+                $skip = `$skipfilen`;
             } else {
                 print "$ENV{CHPL_HOME}/util/test/testEnv $skipfilen = " . `$ENV{CHPL_HOME}/util/test/testEnv $skipfilen` if $debug;
                 $skip = `$ENV{CHPL_HOME}/util/test/testEnv $skipfilen`;
             }
-            next if $skip eq '1' or $skip eq 'True';
+            next if $skip > '0' or $skip =~ m/true/i;
         }
 	    if ($debug) {for ($i=0; $i<$level; $i++)  {print "    ";}}
 	    push @founddirs, find_subdirs ("$targetdir/$filen", $level+1);
@@ -576,6 +576,10 @@ sub main {
     }
 
     die "Error: CHPL_HOME must be set\n" unless defined $ENV{CHPL_HOME};
+
+# Set some more environment variables so they can be tested by skipif
+    $ENV{'COMPOPTS'} = $compopts;
+    $ENV{'EXECOPTS'} = $execopts;
 
     if (defined $nodefile) {
         open nodefile or die "Cannot open node file '$nodefile'\n";


### PR DESCRIPTION
This was a typo I introduced when adding support for python returning "True".
Note the "my" on line 406, which made that variable local.  Dumb.

Revised the test to be a bit more accommodating:
  Any numerical result greater than zero means "skip this test".
  A text result containing "tRuE" (any combination of UC and LC) will mean "skip this test".

Noticed that tests against COMPOPTS did not succeed, because paratest.server does not
export it (nor EXECOPTS) to the environment.  Did that.
