### PR TITLE
Fix an oversight that blew up smoke test

### DIFF
--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -206,7 +206,7 @@ void deadExpressionElimination(FnSymbol* fn) {
 
         // Invert the condition and shuffle the alternative
         if (cond->thenStmt == NULL) {
-          Expr* condExpr = new CallExpr(PRIM_UNARY_LNOT, condExpr);
+          Expr* condExpr = new CallExpr(PRIM_UNARY_LNOT, cond->condExpr);
 
           cond->replaceChild(cond->condExpr, condExpr);
           cond->replaceChild(cond->thenStmt, cond->elseStmt);


### PR DESCRIPTION
I introduced a minor compile time bug that slips past one of the two compilation modes for Clang
and both of our compilation modes for GCC.  Was caught by smoke test.
