### PR TITLE
Fix for verify failure in recordWithRefCopyFns

### DIFF
--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -97,6 +97,9 @@ void buildDefaultDestructor(AggregateType* ct);
 // flattenFunctions.cpp
 void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions);
 
+// callDestructors.cpp
+void insertReferenceTemps(CallExpr* call);
+
 // parallel.cpp
 bool isRefWideString(Type* t);
 bool isWideString(Type* t);

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -261,6 +261,7 @@ static Symbol* insertAutoCopyDestroyForTaskArg
         fcall->insertBefore(new DefExpr(valTmp));
         CallExpr* autoCopyCall = new CallExpr(autoCopyFn, var);
         fcall->insertBefore(new CallExpr(PRIM_MOVE, valTmp, autoCopyCall));
+        insertReferenceTemps(autoCopyCall);
         var = valTmp;
 
         if (firstCall)

--- a/test/types/records/sungeun/recordWithRefCopyFns.future
+++ b/test/types/records/sungeun/recordWithRefCopyFns.future
@@ -1,8 +1,0 @@
-bug: Verify error. Generated calls to autoCopy functions do not insert reference temps.
-
-Ref temp insertion is performed during resolution, but not in later passes
-(e.g. parallel).  So if the autoCopy funciton takes an argument by reference
-there will be a mismatch.
-
-Reference levels are adjusted in the backend, so this mismatch only shows up
-when verification is enabled.

--- a/test/types/records/sungeun/recordWithRefCopyFns.skipif
+++ b/test/types/records/sungeun/recordWithRefCopyFns.skipif
@@ -1,2 +1,0 @@
-# This error only shows up when --verify is tossed.
-COMPOPTS >= --verify


### PR DESCRIPTION
Auto-copy calls were being inserted in the parallel() pass.  These calls were not being
passed through insertReferenceTemps, which inserts reference temps as necessary to make
the reference level of the formal and actual arguments match up.  Since this step was
skipped, verify() flagged it reference level mismatch as an error.

For a quick fix, I added a call to insertReferenceTemps() after the offending call is
inserted into the tree.  A more general solution would involve moving that mini-pass later
in translation or calling it redundantly after any pass that inserts additional calls to
functions that might contain formals having ref intent.

Removed the recordWithRefCopyFns.future and recordWithRefCopyFns.skipif.

TODO: Make a general sweep of the passes that occur after callDestructors and ensure that
### DETAILS
#### compiler/include/passes.h
#### compiler/resolution/callDestructors.cpp

Factored out a per-call version of insertReferenceTemps(CallExpr*) and inserted this into
the global namespace.
#### compiler/passes/parallel.cpp

Call insertReferenceTemps(autoCopyCall) after the autoCopyCall is inserted.
