### PR TITLE
Fix tuple early autoDestroy bug.

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -130,7 +130,8 @@ static void cullExplicitAutoDestroyFlags()
       if (VarSymbol* var = toVarSymbol(def->sym))
       {
         // Examine only those bearing the explicit autodestroy flag.
-        if (! var->hasFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW))
+        if (! var->hasFlag(FLAG_INSERT_AUTO_DESTROY) &&
+            ! var->hasFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW))
           continue;
 
         // Look for the specific breaking case and amend that.
@@ -139,6 +140,7 @@ static void cullExplicitAutoDestroyFlags()
           CallExpr* call = toCallExpr(se->parentExpr);
           if (call->isPrimitive(PRIM_MOVE) &&
               toSymExpr(call->get(1))->var == retVar)
+            var->removeFlag(FLAG_INSERT_AUTO_DESTROY);
             var->removeFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW);
         }
       }


### PR DESCRIPTION
In cullExplicitAutoDestroyFlags(), expand the effect to also include "regular" insert auto
destroy flags.

This function removes the autoDestroy flags from values that are copied (through a move)
into the return value variable of a function.  The case that was resolved before dealt
only with explicit autodestroy flags, but since tuples are created through a call to
_build_tuple_always rather than a constructor call (which would be an explicit new), it is
necessary to add the "normal" auto destroy case to the routine.

The original code was written to be very narrow, to avoid surprises.  But testing should
reveal if there are any associated with this small expansion.
