### PR TITLE
Run shootout tests only on new perf machine.

### DIFF
--- a/util/cron/test-perf.chapel-shootout.bash
+++ b/util/cron/test-perf.chapel-shootout.bash
@@ -8,4 +8,5 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout"
 
+export CHPL_NIGHTLY_TEST_DIRS="release/examples/benchmarks/shootout studies/shootout"
 $CWD/nightly -cron -performance -numtrials 5 -startdate 11/17/14


### PR DESCRIPTION
Per discussion with @ronawho.
