### PR TITLE
Update directory to find perf graphs in for syncing to SF in nightly

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -611,7 +611,12 @@ if ($runtests == 0) {
     close(MAIL);
     
 } else {
-    my $svnPerfDir = $cronlogdir;
+
+    my $svnPerfDir = $ENV{'CHPL_TEST_PERF_DIR'};
+    if ($compperformance == 1) {
+        $svnPerfDir = $ENV{'CHPL_TEST_COMP_PERF_DIR'};
+    }
+
     my $svnPerfMsgXtra = ".\nData dir: $svnPerfDir\n(Testing continues despite failure.) Error code";
     if ($performance == 1 || $compperformance == 1) {
 


### PR DESCRIPTION
I thought cronlogdir would be NightlyPerformance for performance and compiler
performance testing, but that's only true for performance testing. This
switches to use CHPL_TEST_PERF_DIR and CHPL_TEST_COMP_PERF_DIR which are
directly responsible for telling start_test where to put the graphs and html
directory.
