### PR TITLE
Fix coverity 1212409 by using std::vector.

### DIFF
--- a/compiler/optimizations/reachingDefinitionsAnalysis.cpp
+++ b/compiler/optimizations/reachingDefinitionsAnalysis.cpp
@@ -49,8 +49,6 @@ reachingDefinitionsAnalysis(FnSymbol* fn,
   // efficient manner
   //
   std::vector<int> localDefs(locals.n);
-  for (int i = 0; i < locals.n; i++)
-    localDefs[i] = 0;
   forv_Vec(SymExpr, se, defSet) {
     if (se) {
       localDefs[localMap.get(se->var)]++;


### PR DESCRIPTION
Update int array that was not initialized in reachingDefinitionsAnalysis.cpp to
simply be a std::vector<int>. std::vector will take care of the initialization,
and coverity should be happy.
### TODO:
- [x] full test pass
- [x] full test pass with `--fast`
