### PR TITLE
Fixed Coverity defect 1231860.

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -434,7 +434,7 @@ void reorderActuals(FnSymbol* fn,
     }
   }
   if (need_to_reorder) {
-    Expr* savedActuals[numArgs];
+    std::vector<Expr*> savedActuals(numArgs);
     int i = 0;
     // remove all actuals in an order
     for_actuals(actual, info->call)


### PR DESCRIPTION
**\* CID 1231860:  Uninitialized pointer read  (UNINIT)
/compiler/resolution/wrappers.cpp: 416
in reorderActuals(FnSymbol *, Vec<ArgSymbol *, (int)4> *, CallInfo *)()

410               need_to_reorder = true;
411             formals_to_formals[i-1] = j-1;
412           }
413         }
414       }
415       if (need_to_reorder) {
     CID 1231860:  Uninitialized pointer read  (UNINIT)
     Declaring variable "savedActuals" without initializer.
416         Expr\* savedActuals[numArgs];
417         int i = 0;
418         // remove all actuals in an order
419         for_actuals(actual, info->call)
420           savedActuals[i++] = actual->remove();
421         // reinsert them in the desired order

The group consensus is that using std::vector is preferable over C arrays.
So I switched 'savedActuals' to be that.
