### PR TITLE
Update chown/permission_error test to work, even when uid/gid is 1000.

### DIFF
--- a/test/io/fsouza/chown/permission_error.chpl
+++ b/test/io/fsouza/chown/permission_error.chpl
@@ -1,2 +1,9 @@
 use FileSystem;
-chown("file.txt", 1000, 1000);
+
+config const myUserId = 1000;
+config const myGroupId = 1000;
+
+const notMyUserId = myUserId + 1,
+  notMyGroupId = myGroupId + 1;
+
+chown("file.txt", notMyUserId, notMyGroupId);

--- a/test/io/fsouza/chown/permission_error.execopts
+++ b/test/io/fsouza/chown/permission_error.execopts
@@ -1,0 +1,1 @@
+--myUserId=`id -u` --myGroupId=`id -g`

--- a/test/io/fsouza/chown/permission_error.good
+++ b/test/io/fsouza/chown/permission_error.good
@@ -1,1 +1,1 @@
-permission_error.chpl:2: error: SYS_ERR in chown with path "file.txt"
+permission_error.chpl:9: error: SYS_ERR in chown with path "file.txt"


### PR DESCRIPTION
Previously, this test assumed that calling `chown 1000:1000 file.txt` was
invalid. That turns out to be valid if the current uid/gid is 1000/1000.

Update the test to take uid/gid as config consts and then add one to both to
get invalid uid/gid value.
