### PR TITLE
Fix hwloc build on 32bit platform with OPTIMIZE=1.

### DIFF
--- a/third-party/hwloc/hwloc-1.9.1/include/private/cpuid-x86.h
+++ b/third-party/hwloc/hwloc-1.9.1/include/private/cpuid-x86.h
@@ -32,14 +32,14 @@ static __hwloc_inline int hwloc_have_x86_cpuid(void)
       "pushfl   \n\t"                                           \
       "pop %1   \n\t"                                           \
       "cmp %1,%2\n\t"   /* Compare with expected value */       \
-      "jnz Lhwloc1\n\t"   /* Unexpected, failure */               \
+      "jnz 0f\n\t"   /* Unexpected, failure */               \
 
       TRY_TOGGLE        /* Try to set/clear */
       TRY_TOGGLE        /* Try to clear/set */
 
       "mov $1,%0\n\t"   /* Passed the test! */
 
-      "Lhwloc1: \n\t"
+      "0: \n\t"
       "popfl    \n\t"   /* Restore flags */
 
       : "=r" (ret), "=&r" (tmp), "=&r" (tmp2));


### PR DESCRIPTION
Previously, building hwloc with `OPTIMIZE=1` resulted in this failure:

```
... snip ... 
  CC topology-x86.lo 
/home/vagrant/src/hwloc/include/private/cpuid-x86.h: Assembler messages: 
/home/vagrant/src/hwloc/include/private/cpuid-x86.h:40: Error: symbol 
`Lhwloc1' is already defined 
Makefile:878: recipe for target 'topology-x86.lo' failed 
make[1]: *** [topology-x86.lo] Error 1 
make[1]: Leaving directory '/home/vagrant/src/hwloc/hwloc' 
Makefile:615: recipe for target 'all-recursive' failed 
make: *** [all-recursive] Error 1 
```

Brice Goglin fixed the issue with the changes applied in this pull request.

I applied the patch to the hwloc 1.9.1 in this repo. I also ran the full suite of tests
on linux32 to verify it did not introduce new issues. It did not.

More details here:

  http://www.open-mpi.org/community/lists/hwloc-users/2014/11/1118.php
