### PR TITLE
Update fielderator tests to account for small diff in reals.

### DIFF
--- a/test/users/ferguson/fielderator-ref.chpl
+++ b/test/users/ferguson/fielderator-ref.chpl
@@ -18,6 +18,7 @@ class C {
 
 var rec = new R(3, "hi", 17.23);
 var cls = new C(3, "hi", 17.23);
+const epsilon = 1e-8; // for comparing reals.
 
 myproc(R, rec);
 myproc(C, cls);
@@ -29,13 +30,17 @@ proc myproc(type t, ref m) {
   assert(__primitive("field num to name", t, 3) == "z");
   assert(__primitive("field value by num", m, 1) == 3);
   assert(__primitive("field value by num", m, 2) == "hi");
-  assert(__primitive("field value by num", m, 3) == 17.23);
+  assert(realEqual(__primitive("field value by num", m, 3), 17.23));
   assert(__primitive("field value by name", m, "x") == 3);
   assert(__primitive("field value by name", m, "y") == "hi");
-  assert(__primitive("field value by name", m, "z") == 17.23);
+  assert(realEqual(__primitive("field value by name", m, "z"), 17.23));
   for param i in 1..(__primitive("num fields", t)) {
     writeln(__primitive("field num to name", t, i));
     writeln(__primitive("field value by num", m, i));
   }
 }
 
+proc realEqual(a: real, b: real): bool {
+  var diff = abs(a - b);
+  return diff < epsilon;
+}

--- a/test/users/ferguson/fielderator.chpl
+++ b/test/users/ferguson/fielderator.chpl
@@ -8,6 +8,7 @@ record R {
 }
 
 var m = new R(3, "hi", 17.23);
+const epsilon = 1e-8; // for comparing reals.
 
 assert(__primitive("num fields", R) == 3);
 
@@ -17,14 +18,18 @@ assert(__primitive("field num to name", R, 3) == "z");
 
 assert(__primitive("field value by num", m, 1) == 3);
 assert(__primitive("field value by num", m, 2) == "hi");
-assert(__primitive("field value by num", m, 3) == 17.23);
+assert(realEqual(__primitive("field value by num", m, 3), 17.23));
 
 assert(__primitive("field value by name", m, "x") == 3);
 assert(__primitive("field value by name", m, "y") == "hi");
-assert(__primitive("field value by name", m, "z") == 17.23);
-
+assert(realEqual(__primitive("field value by name", m, "z"), 17.23));
 
 for param i in 1..(__primitive("num fields", R)) {
   writeln(__primitive("field num to name", R, i));
   writeln(__primitive("field value by num", m, i));
+}
+
+proc realEqual(a: real, b: real): bool {
+  var diff = abs(a - b);
+  return diff < epsilon;
 }


### PR DESCRIPTION
These were failing on an Ubuntu 32bit utopic (14.10) system with gcc 4.9.1 due
to a very small (0.00000000000000043) difference between two instances of
17.23.

Update the comparison to find the absolute difference between the two reals and
ensure the difference is less than 1e-8.
