### PR TITLE
Add a bug future for returning records from functions

### DIFF
--- a/test/types/records/kbrady/return-record.chpl
+++ b/test/types/records/kbrady/return-record.chpl
@@ -1,0 +1,63 @@
+config const debugAssign = false;
+
+module foo {
+  class helper {
+    var y: int;
+  }
+  record Zed {
+    var x: helper;
+
+    proc Zed(x) {
+      writeln("in Zed(",x,")");
+      this.x = new helper(x);
+    }
+
+    proc ~Zed() {
+      writeln("in ~Zed(",x,")");
+      delete this.x;
+    }
+  }
+
+  proc =(ref lhs: Zed, rhs: Zed) {
+    if debugAssign then writeln("in =(Zed(",lhs.x,"), Zed(",rhs.x,"))");
+    else writeln("in =(Zed, Zed)");
+    delete lhs.x;
+    lhs.x = new helper(rhs.x.y + 1);
+  }
+
+  /////////////////////////////////
+
+  proc baz() {
+    writeln("in baz()");
+    var ret = new Zed(1);
+    return ret;
+  }
+  proc gob() : Zed {
+    writeln("in gob()");
+    var ret = new Zed(1);
+    return ret;
+  }
+
+  /////////////////////////////////
+
+  proc try_baz() {
+    writeln("type inferred");
+    writeln("-------------");
+    var z1 = baz();
+    writeln(z1);
+  }
+
+  proc try_gob() {
+    writeln("\ntype specified");
+    writeln("--------------");
+    var z2 = gob();
+    writeln(z2);
+  }
+
+  /////////////////////////////////
+
+  proc main() {
+    try_baz();
+    try_gob();
+  }
+}

--- a/test/types/records/kbrady/return-record.future
+++ b/test/types/records/kbrady/return-record.future
@@ -1,0 +1,23 @@
+bug: records being returned from functions are not handled properly
+
+There are two bugs here, depending on if the return type from the function is
+inferred or not. Both cases should eventually do the same thing.
+
+When the return type is inferred (baz in this test):
+  =(...) is not called when assigning to the return variable, and a PRIM_MOVE
+  is used instead. This causes a bitwise copy in the generated C, including the
+  pointer to a 'helper' instance. So when the local Zed is destroyed on leaving
+  the function, the pointer in the returned value becomes invalid.
+
+When the return type is specified:
+  =(...) is correctly called in this case, but both the left and right hand
+  sides of the assignment are deallocated before returning. Only the right hand
+  side should be deallocated.
+
+So we either need to perform the move into the return temp, and not destroy it
+before returning (this would be faster, but I'm not sure it if will miss some
+edge cases), or we should only destroy the rhs of the =(...) before returning.
+
+To make this bug easier to observe, I recommend setting M_PERTURB (glibc),
+MallocScribble (osx), MALLOC_OPTIONS=J (bsd), or whatever the relevant setting
+for your implementation of malloc/free is to write a value to any freed memory.

--- a/test/types/records/kbrady/return-record.good
+++ b/test/types/records/kbrady/return-record.good
@@ -1,0 +1,17 @@
+type inferred
+-------------
+in baz()
+in Zed(1)
+in =(Zed, Zed)
+in ~Zed({y = 1})
+(x = {y = 2})
+in ~Zed({y = 2})
+
+type specified
+--------------
+in gob()
+in Zed(1)
+in =(Zed, Zed)
+in ~Zed({y = 1})
+(x = {y = 2})
+in ~Zed({y = 2})


### PR DESCRIPTION
From return-record.future:

bug: records being returned from functions are not handled properly

There are two bugs here, depending on if the return type from the function is
inferred or not. Both cases should eventually do the same thing.

When the return type is inferred (baz in this test):
  =(...) is not called when assigning to the return variable, and a PRIM_MOVE
  is used instead. This causes a bitwise copy in the generated C, including the
  pointer to a 'helper' instance. So when the local Zed is destroyed on leaving
  the function, the pointer in the returned value becomes invalid.

When the return type is specified:
  =(...) is correctly called in this case, but both the left and right hand
  sides of the assignment are deallocated before returning. Only the right hand
  side should be deallocated.

So we either need to perform the move into the return temp, and not destroy it
before returning (this would be faster, but I'm not sure it if will miss some
edge cases), or we should only destroy the rhs of the =(...) before returning.

To make this bug easier to observe, I recommend setting M_PERTURB (glibc),
MallocScribble (osx), MALLOC_OPTIONS=J (bsd), or whatever the relevant setting
for your implementation of malloc/free is to write a value to any freed memory.
