### PR TITLE
Fix increased leaks in domainsMaps test due to #860.

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -134,6 +134,15 @@ static void cullExplicitAutoDestroyFlags()
             ! var->hasFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW))
           continue;
 
+        // This test was added just to get leaked byte counts in
+        // memory/sungeun/refCount/domainMaps back down their level prior to
+        // the merge of P.R. #860.  In the future, if ref counts for
+        // ReplicatedDists start going below zero, removing this line should
+        // help.
+        TypeSymbol* ts = ret->type->symbol;
+        if (ts->hasFlag(FLAG_DOMAIN))
+          continue;
+
         // Look for the specific breaking case and amend that.
         for_uses(se, useMap, var)
         {


### PR DESCRIPTION
Internally reference counted types were ignored in the main cullAutoDestroyFlags routine. So to cure the increased memory leaks due to PR #860, I ruled out the offending internally reference counted type: domains.
