### PR TITLE
Annotate the nights where NPB EP and IS performed better, used -E

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -61,6 +61,18 @@ dgemm.64:
   09/06/13:
     - LICM bug fixes
 
+ep:
+  11/18/14:
+    - added -E to tests which would benefit from it
+  11/22/14:
+    - revert -E use for nightly on 21st (which failed, unrelatedly)
+
+ep-b:
+  11/18/14:
+    - added -E to tests which would benefit from it
+  11/22/14:
+    - revert -E use for nightly on 21st (which failed, unrelatedly)
+
 fannkuch-redux:
   07/22/14:
     - Error due to cleaning up file incompletely
@@ -80,6 +92,10 @@ ft-a:
 is:
   09/05/14:
     - switched uses of locale.numCores to locale.maxTaskPar
+  11/18/14:
+    - added -E to tests which would benefit from it
+  11/22/14:
+    - revert -E use for nightly on 21st (which failed, unrelatedly)
 
 lulesh:
   03/15/14:


### PR DESCRIPTION
I had misinterpretted the desire to use -E as a desire to use it nightly rather
than a desire to maintain default behavior but compare it to tweaked behavior.
Since there isn't a good way to compare them (our execenvs don't allow multiple
settings), we decided to just leave the default for now.  Since that churn is
reflected in the nightly graphs, annotate it so we don't forget.

Note, the commit in question also affected FT, but for sizes we don't run nightly.
