### PR TITLE
Send darwin regression mail to normal lists (for gasnet.darwin)

### DIFF
--- a/util/cron/test-gasnet.darwin.bash
+++ b/util/cron/test-gasnet.darwin.bash
@@ -7,8 +7,4 @@ source $CWD/common-gasnet.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin"
 
-# Do not send modern mac test results to regressions list until
-# nondeterministic compiler errors are fixed.
-# (thomasvandoren, 2014-09-08)
-export CHPL_NIGHTLY_CRON_RECIPIENT="chapel-test-results-all@lists.sourceforge.net"
 $CWD/nightly -cron -examples


### PR DESCRIPTION
Previously it was only sent to the all regressions list. The non-deterministic
errors have been cleaned up so it makes sense to send it to the normal lists.

Same idea as 7ad1f14e2a6f5febba3a03754c3487b5be7869f4, but I missed this file
