### PR TITLE
Save the problem sizes for RA and STREAM variants

### DIFF
--- a/test/release/examples/benchmarks/hpcc/ra-atomics.perfkeys
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.perfkeys
@@ -1,4 +1,8 @@
 # file: hpcc-ra-atomics.dat
 Execution time =
 Performance (GUPS) =
+# file: hpcc-ra-atomics-problem-size.dat
+Problem size =
+Total memory required (GB) =
+Bytes per array =
 verify: Validation: SUCCESS

--- a/test/release/examples/benchmarks/hpcc/ra.perfkeys
+++ b/test/release/examples/benchmarks/hpcc/ra.perfkeys
@@ -1,4 +1,8 @@
 # file: hpcc-ra.dat
 Execution time =
 Performance (GUPS) =
+# file: hpcc-ra-problem-size.dat
+Problem size =
+Total memory required (GB) =
+Bytes per array =
 verify: Validation: SUCCESS

--- a/test/release/examples/benchmarks/hpcc/stream-ep.perfkeys
+++ b/test/release/examples/benchmarks/hpcc/stream-ep.perfkeys
@@ -5,4 +5,8 @@ min (seconds) =
 max =
 avg =
 min =
+# file: hpcc-stream-ep-problem-size.dat
+Problem size =
+Bytes per array =
+Total memory required (GB) =
 verify: Validation: SUCCESS

--- a/test/release/examples/benchmarks/hpcc/stream.perfkeys
+++ b/test/release/examples/benchmarks/hpcc/stream.perfkeys
@@ -2,4 +2,8 @@
 Performance (GB/s) =
 avg =
 min =
+# file: hpcc-stream-problem-size.dat
+Problem size =
+Bytes per array =
+Total memory required (GB) =
 verify: Validation: SUCCESS


### PR DESCRIPTION
We're observing some strange cyclic behavior for RA on one of our performance
test machines that seems related to when the machine gets rebooted.  Since RA
is known to compute some of its size based on memory, we figured that saving
the problem size information from night to night might show us more of the
picture (and if not, at least serve as a sanity check that it is running the
same every night).  STREAM was also not saving this information, so the same
change was made to it.

Implementation details: I decided to create separate .dat files to store this
information as adding information to track to a .dat file has necessitated
adding a column to it manually, the script will not update the columns
otherwise.  These values are sanity checks so I think it is better to clutter
up the directory rather than the information in the files themselves.
