### PR TITLE
Remove part of the change I made to these .perfkeys last Friday

### DIFF
--- a/test/release/examples/benchmarks/hpcc/ra-atomics.perfkeys
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.perfkeys
@@ -1,7 +1,6 @@
 # file: hpcc-ra-atomics.dat
 Execution time =
 Performance (GUPS) =
-# file: hpcc-ra-atomics-problem-size.dat
 Problem size =
 Total memory required (GB) =
 Bytes per array =

--- a/test/release/examples/benchmarks/hpcc/ra.perfkeys
+++ b/test/release/examples/benchmarks/hpcc/ra.perfkeys
@@ -1,7 +1,6 @@
 # file: hpcc-ra.dat
 Execution time =
 Performance (GUPS) =
-# file: hpcc-ra-problem-size.dat
 Problem size =
 Total memory required (GB) =
 Bytes per array =

--- a/test/release/examples/benchmarks/hpcc/stream-ep.perfkeys
+++ b/test/release/examples/benchmarks/hpcc/stream-ep.perfkeys
@@ -5,7 +5,6 @@ min (seconds) =
 max =
 avg =
 min =
-# file: hpcc-stream-ep-problem-size.dat
 Problem size =
 Bytes per array =
 Total memory required (GB) =

--- a/test/release/examples/benchmarks/hpcc/stream.perfkeys
+++ b/test/release/examples/benchmarks/hpcc/stream.perfkeys
@@ -2,7 +2,6 @@
 Performance (GB/s) =
 avg =
 min =
-# file: hpcc-stream-problem-size.dat
 Problem size =
 Bytes per array =
 Total memory required (GB) =


### PR DESCRIPTION
It turns out that I didn't look as closely at my results when testing on Friday
as I should have.  Adding the additional .dat file declaration to the .perfkeys
overrode the previous declaration, so all the information from over the weekend
was written to the last one instead of half and half like I thought it would.
Oops.

There was some merging needed anyways, the old file had a column that has been
replaced by our performance run verification step.  So when I fixed the .dat
files so all the data would be present, I removed all previous references to
the verification field (they were all successes anyways) and merged the file
headers.  When the graphs get generated for tomorrow's run, everything should
be back to normal.

For those following along at home, the data from over the weekend seems to
indicate that we are not adjusting our problem size as it gets faster.  Still
a mystery as to what is causing the improvement over time, further analysis is
needed.
