### PR TITLE
Make start_test more multi-locale friendly

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -81,7 +81,7 @@
 #   -sysprediff <path>
 #   -suppress <suppression file>
 #   -nostdinredirect
-#   -launchertimeout pbs
+#   -launchertimeout <queueing system>
 #   -logfile   <log filename>         $testdir/Logs/<username>.<tgt-platform>.log
 #                                     (where $testdir is $CHPL_HOME/test if
 #                                     it exists, $CHPL_HOME/examples, if it
@@ -724,6 +724,7 @@ set recurse = 1
 set tee = "tee"
 set numlocales = 0
 set comm = `$utildir/chplenv/chpl_comm.py`
+set launcher = `$utildir/chplenv/chpl_launcher.py`
 set locMod = `$utildir/chplenv/chpl_locale_model.py`
 set suppressions = ""
 set optionerr = 0
@@ -938,6 +939,12 @@ while ( $#argv > 0 )
         shift
         setenv CHPL_NO_STDIN_REDIRECT true
         breaksw
+    case -stdinredirect:
+    case --stdinredirect:
+        shift
+        unset CHPL_NO_STDIN_REDIRECT true
+        setenv CHPL_TEST_FORCE_STDIN_REDIRECT true
+        breaksw
     case -launchertimeout:
     case --launchertimeout:
         shift
@@ -984,8 +991,8 @@ while ( $#argv > 0 )
         echo "          -sysprediff <path>"
         echo "          -suppress <filename>"
         echo "          -numlocales <number>"
-        echo "          -nostdinredirect"
-        echo "          -launchertimeout pbs"
+        echo "          -[no]stdinredirect"
+        echo "          -launchertimeout <queueing system>"
 #       echo "          -interpret (or -i)"
         echo "          -logfile <file>      (currently: $logfile)"
         echo "          -memleaks <file>"
@@ -1165,6 +1172,33 @@ setenv CHPL_GASNET_SEGMENT `$utildir/chplenv/chpl_comm_segment.py`
 
 echo \[localeModel: \"$locMod\"\] |& $tee -a $logfile
 setenv CHPL_LOCALE_MODEL $locMod
+
+# we know that stdin redirection doesn't work for most launchers. only do
+# redirection when there's no launcher, or the launcher is amudprun, which we
+# know supports stdin redirection. Warn user about skipping tests unless they
+# threw -nostdinredirect or -stdinredirect or if env var is set to silence it
+if ($launcher != "none" && $launcher != "amudprun") then
+    if (! $?CHPL_NO_STDIN_REDIRECT && ! $?CHPL_TEST_FORCE_STDIN_REDIRECT ) then
+        if (! $?CHPL_TEST_NO_WARN_NO_STDIN_REDIRECT) then
+            echo "[Warning: assuming stdin redirection is not supported, skipping tests with stdin]" |& $tee -a $logfile
+        endif
+        setenv CHPL_NO_STDIN_REDIRECT true
+    endif
+endif
+
+# sub_test supports using slurm and pbs/qsub to handle timeouts instead of
+# managing timeouts itself. Use the launcher timeout by default if the
+# supported launcher is detected.
+if (! $?CHPL_LAUNCHER_TIMEOUT && ! $?CHPL_TEST_DONT_SET_LAUNCHER_TIMEOUT) then
+    if ($launcher =~ *slurm*) then
+        setenv CHPL_LAUNCHER_TIMEOUT slurm
+    endif
+
+    if ($launcher =~ *pbs* || $launcher =~ *qsub*) then
+        setenv CHPL_LAUNCHER_TIMEOUT pbs
+    endif
+endif
+
 
 if ($comm != "none" && $numlocales == 0) then
     set numlocales = "1"


### PR DESCRIPTION
For multi-locale testing on crays we always have to throw --nostdinredirect and
--launchertimeout <launcher>. This just makes start_test infer those values for
most situations to make our lives easier when running start_test.

Previously start_test would not be able to run any tests or would never
complete execution if you didn't throw these on a cray and it wasn't obvious
what was going wrong

Throw --nostdinredirect unless there is no launcher or the launcher is
amudprun.  we know that stdin redirection doesn't work for most launchers. only
do redirection when there's no launcher, or the launcher is amudprun, which we
know supports stdin redirection. Warn user about skipping tests unless they
threw -nostdinredirect or -stdinredirect or an env var is set to silence it

If the launcher name contains slurm set CHPL_LAUNCHER_TIMEOUT to slurm, and if
the launcher name contains pbs or qsub set CHPL_LAUNCHER_TIMEOUT to pbs. These
launchers handle timeouts themselves, and we don't need/want sub_test to be
trying to do it's own timeout mechanism.
