### PR TITLE
Update sub_test to pass walltime to slurm and look for timeouts

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1443,9 +1443,9 @@ for testname in testsrc:
                     status = p.returncode
 
                     launcherTimeout = False
-                    if re.search('PBS: job killed: walltime', output, re.I) != None:
+                    if re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None:
                         launcherTimeout = True
-                    if re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.I) != None:
+                    if re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None:
                         launcherTimeout = True
 
                     if launcherTimeout:


### PR DESCRIPTION
We let slurm handle timeouts instead of using sub_test's mechanisms. However,
we never actually looked for timeouts or told slurm what timeout to use.
Instead we just let the default timeout be used and didn't record the fact that
a timeout occurred.

This updates sub_test to pass --walltime to the executable which will in turn
set the actual slurm timeout. We also not look for the timeout and create an
appropriate error message like we do for pbs.
