### PR TITLE
Slurm add nodelist

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -398,7 +398,7 @@ int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
     return 1;
   }
 
-  // handle --nodelist <nodelist> or --nolist=<nodelist>
+  // handle --nodelist <nodelist> or --nodelist=<nodelist>
   if (!strcmp(argv[argNum], CHPL_NODELIST_FLAG)) {
     nodelist = argv[argNum+1];
     return 2;


### PR DESCRIPTION
Allow a nodelist to be specified for the slurm launcher. This can either be set
by passing the executable --nodelist or by setting the env var
CHPL_LAUNCHER_NODELIST
