### PR TITLE
Replace FLAG_WIDE with FLAG_WIDE_REF.

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -337,7 +337,7 @@ Type* BaseAST::getValType() {
   INT_ASSERT(type);
   if (type->symbol->hasFlag(FLAG_REF))
     return type->getField("_val")->type;
-  else if (type->symbol->hasFlag(FLAG_WIDE))
+  else if (type->symbol->hasFlag(FLAG_WIDE_REF))
     return type->getField("addr")->getValType();
   else
     return type;
@@ -348,7 +348,7 @@ Type* BaseAST::getRefType() {
   INT_ASSERT(type);
   if (type->symbol->hasFlag(FLAG_REF))
     return type;
-  else if (type->symbol->hasFlag(FLAG_WIDE))
+  else if (type->symbol->hasFlag(FLAG_WIDE_REF))
     return type->getField("addr")->type;
   else
     return type->refType;
@@ -359,7 +359,7 @@ Type* BaseAST::getWideRefType() {
   INT_ASSERT(type);
   if (type->symbol->hasFlag(FLAG_REF))
     return wideRefMap.get(type);
-  else if (type->symbol->hasFlag(FLAG_WIDE))
+  else if (type->symbol->hasFlag(FLAG_WIDE_REF))
     return type;
   else
     return wideRefMap.get(type->getRefType());

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -55,7 +55,7 @@ static GenRet createTempVar(Type* t);
 // These functions operate on wide pointers. There are several different
 // kinds of wide pointers:
 //  1 wide reference to something
-//    (wide.chplType->symbol->hasFlag(FLAG_WIDE))
+//    (wide.chplType->symbol->hasFlag(FLAG_WIDE_REF))
 //  2 wide class pointer
 //    (wide.chplType->symbol->hasFlag(FLAG_WIDE_CLASS))
 //  3 wide result of codegenFieldPtr or codegenElementPtr etc
@@ -923,7 +923,7 @@ GenRet codegenWideHere(GenRet addr, Type* wideType = NULL)
 static bool isWide(GenRet x)
 {
   if( x.isLVPtr == GEN_WIDE_PTR ) return true;
-  if( x.chplType && x.chplType->symbol->hasEitherFlag(FLAG_WIDE,FLAG_WIDE_CLASS) ) return true;
+  if( x.chplType && x.chplType->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS) ) return true;
   return false;
 }
 
@@ -947,7 +947,7 @@ Type* getRefTypesForWideThing(GenRet wide, Type** wideRefTypeOut)
       // local lv-pointer or value; in such cases they are wide
       // only if they are a wide reference or a wide class.
       // Then the wide type is the current Chapel type.
-      if( wide.chplType->symbol->hasEitherFlag(FLAG_WIDE,FLAG_WIDE_CLASS) ) {
+      if( wide.chplType->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS) ) {
         ret = wide.chplType->getField("addr")->typeInfo();
         wideRefType = wide.chplType;
       } else {
@@ -965,7 +965,7 @@ static GenRet codegenCastWideToVoid(GenRet wide) {
 
   INT_ASSERT(wide.isLVPtr == GEN_WIDE_PTR ||
              (wide.chplType &&
-              wide.chplType->symbol->hasEitherFlag(FLAG_WIDE,FLAG_WIDE_CLASS)));
+              wide.chplType->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS)));
 
   // If we have a local pointer to a wide reference,
   // codegen value it.
@@ -1227,7 +1227,7 @@ GenRet codegenFieldPtr(
 
     // Reduce the Chapel reference or wide reference cases
     // to GEN_PTR or GEN_WIDE_PTR cases.
-    if (baseType->symbol->hasEitherFlag(FLAG_REF,FLAG_WIDE)) {
+    if (baseType->symbol->hasEitherFlag(FLAG_REF,FLAG_WIDE_REF)) {
       base = codegenDeref(base);
       return codegenFieldPtr(base, c_field_name, chpl_field_name, special);
     }
@@ -1439,7 +1439,7 @@ GenRet codegenElementPtr(GenRet base, GenRet index, bool ddataPtr=false) {
 
   // Handle references to arrays or star tuples
   // by converting them to isLVPtr != GEN_VAL
-  if( base.chplType->symbol->hasEitherFlag(FLAG_REF,FLAG_WIDE) ) {
+  if( base.chplType->symbol->hasEitherFlag(FLAG_REF,FLAG_WIDE_REF) ) {
     base = codegenDeref(base);
   }
 
@@ -1734,7 +1734,7 @@ GenRet codegenLocalDeref(GenRet r)
   GenRet ret;
   // LocalDeref on a wide pointer should just give
   // the address field as a reference.
-  if( r.chplType && r.chplType->symbol->hasFlag(FLAG_WIDE) ) {
+  if( r.chplType && r.chplType->symbol->hasFlag(FLAG_WIDE_REF) ) {
     ret = codegenRaddr(r);
     return ret;
   }
@@ -1753,7 +1753,7 @@ GenRet codegenDeref(GenRet r)
   GenRet ret;
 
   INT_ASSERT(r.chplType);
-  if (r.chplType->symbol->hasEitherFlag(FLAG_WIDE, FLAG_WIDE_CLASS)) {
+  if (r.chplType->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS)) {
     ret = codegenValue(r);
     ret.isLVPtr = GEN_WIDE_PTR;
     ret.chplType = r.chplType->getValType();
@@ -2183,7 +2183,7 @@ GenRet codegenIsZero(GenRet x)
 {
   GenInfo* info = gGenInfo;
   GenRet ret;
-  if (x.chplType->symbol->hasEitherFlag(FLAG_WIDE,FLAG_WIDE_CLASS) ) {
+  if (x.chplType->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS) ) {
     x = codegenRaddr(x);
     if (info->cfile) {
       ret.c = x.c;
@@ -2212,7 +2212,7 @@ GenRet codegenIsNotZero(GenRet x)
 {
   GenInfo* info = gGenInfo;
   GenRet ret;
-  if (x.chplType->symbol->hasEitherFlag(FLAG_WIDE,FLAG_WIDE_CLASS) ) {
+  if (x.chplType->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS) ) {
     x = codegenRaddr(x);
     if (info->cfile) {
       ret.c = x.c;
@@ -2752,12 +2752,12 @@ GenRet codegenBasicPrimitiveExpr(CallExpr* call) {
 
     // Make wide pointers/classes local
     if (actual->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-        actual->typeInfo()->symbol->hasFlag(FLAG_WIDE))
+        actual->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF))
       gen = codegenRaddr(gen);
 
     // Dereference reference or now-local wide reference
     if (actual->typeInfo()->symbol->hasFlag(FLAG_REF) ||
-        actual->typeInfo()->symbol->hasFlag(FLAG_WIDE))
+        actual->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF))
       gen = codegenDeref(gen);
 
     gen = codegenValue(gen);
@@ -3130,7 +3130,7 @@ void codegenAssign(GenRet to_ptr, GenRet from)
   // a nil pointer of the correct type.
   if (from.chplType && to_ptr.chplType){
     AggregateType* ct = toAggregateType(from.chplType);
-    if (ct && ct->symbol->hasEitherFlag(FLAG_WIDE, FLAG_WIDE_CLASS)) {
+    if (ct && ct->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS)) {
       Symbol* valField = ct->getField("addr");
       if (valField && valField->getValType() == dtNil) {
          from = codegenAddrOf(
@@ -3139,7 +3139,7 @@ void codegenAssign(GenRet to_ptr, GenRet from)
     }
     if (from.chplType == dtNil)
     {
-      if (to_ptr.chplType->symbol->hasEitherFlag(FLAG_WIDE, FLAG_WIDE_CLASS))
+      if (to_ptr.chplType->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS))
       {
         from = codegenWideHere(codegenNullPointer(), to_ptr.chplType);
         type = to_ptr.chplType->getValType();
@@ -3643,7 +3643,7 @@ void codegenOpAssign(GenRet a, GenRet b, const char* op,
   // deref 'a' if it is a 'ref' argument
   GenRet ap;
   if (a.chplType->symbol->hasFlag(FLAG_REF) ||
-      a.chplType->symbol->hasFlag(FLAG_WIDE) ||
+      a.chplType->symbol->hasFlag(FLAG_WIDE_REF) ||
       a.chplType->symbol->hasFlag(FLAG_WIDE_CLASS)) {
     ap = codegenDeref(a);
   } else {
@@ -3812,10 +3812,10 @@ GenRet CallExpr::codegen() {
         {
          case PRIM_DEREF:
          {
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
               call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
             Type* valueType;
-            if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE))
+            if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF))
               valueType = call->get(1)->getValType();
             else
               valueType = call->get(1)->typeInfo()->getField("addr")->type;
@@ -3863,7 +3863,7 @@ GenRet CallExpr::codegen() {
             } else {
               codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
             }
-          } else if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+          } else if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
             INT_ASSERT(se);
             // codegenAssign will dereference.
             codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
@@ -3892,7 +3892,7 @@ GenRet CallExpr::codegen() {
           /* Get a pointer to a member */
           SymExpr* se = toSymExpr(call->get(2));
           if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-              call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+              call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
               get(2)->typeInfo()->symbol->hasFlag(FLAG_STAR_TUPLE))
           {
             codegenAssign(
@@ -3904,7 +3904,7 @@ GenRet CallExpr::codegen() {
          }
          case PRIM_GET_SVEC_MEMBER:
          {
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
             /* Get a pointer to the i'th element of a homogenous tuple */
             GenRet elemPtr =
               codegenElementPtr(call->get(1),codegenExprMinusOne(call->get(2)));
@@ -3919,7 +3919,7 @@ GenRet CallExpr::codegen() {
          case PRIM_GET_SVEC_MEMBER_VALUE:
          {
           /* Get the i'th value from a homogeneous tuple */
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
             // codegenElementPtr/codegenAssign handle wide pointers
             codegenAssign(
                 get(1),
@@ -3940,7 +3940,7 @@ GenRet CallExpr::codegen() {
           if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
             codegenAssign(get(1),
                 codegenAddrOf(codegenElementPtr(call->get(1), call->get(2))));
-          } else if( get(1)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE,FLAG_WIDE_CLASS)) {
+          } else if( get(1)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS)) {
             // resulting reference is wide, but the array is local.
             // This can happen with c_ptr for extern integration...
             codegenAssign(
@@ -3966,7 +3966,7 @@ GenRet CallExpr::codegen() {
          }
          case PRIM_GET_UNION_ID:
          {
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
             codegenAssign(get(1), codegenFieldUidPtr(call->get(1)));
           }
           else
@@ -4000,7 +4000,7 @@ GenRet CallExpr::codegen() {
          case PRIM_CAST:
          {
           if (call->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-              call->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+              call->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
             GenRet tmp = call->get(2);
             tmp = codegenWideAddrWithAddr(tmp,
                                   codegenCast(call->get(1)->typeInfo(), 
@@ -4110,20 +4110,20 @@ GenRet CallExpr::codegen() {
                       get(3), get(4)); 
         break;
       }
-      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) &&
+      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
           get(2)->typeInfo()->symbol->hasFlag(FLAG_REF)) {
         codegenAssign(get(1), codegenAddrOf(codegenWideHere(get(2))));
         break;
       }
-      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) &&
-          !get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE) &&
+      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
+          !get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
           !get(2)->typeInfo()->symbol->hasFlag(FLAG_REF)) {
         GenRet to_ptr = codegenDeref(get(1));
         codegenAssign(to_ptr, get(2));
         break;
       }
       if (get(1)->typeInfo()->symbol->hasFlag(FLAG_REF) &&
-          get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+          get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         // get(1) = Raddr(get(2));
         codegenAssign(get(1), codegenRaddr(get(2))); 
         break;
@@ -4156,7 +4156,7 @@ GenRet CallExpr::codegen() {
       break;
     case PRIM_WIDE_GET_LOCALE:
     {
-      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
           get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         ret = codegenRlocale(get(1));
       } else {
@@ -4166,7 +4166,7 @@ GenRet CallExpr::codegen() {
     }
     case PRIM_WIDE_GET_NODE:
     {
-      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
           get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         ret = codegenRnode(get(1));
       } else {
@@ -4176,7 +4176,7 @@ GenRet CallExpr::codegen() {
     }
     case PRIM_WIDE_GET_ADDR:
     {
-      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
           get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         ret = codegenRaddr(get(1));
       } else {
@@ -4191,7 +4191,7 @@ GenRet CallExpr::codegen() {
     }
     case PRIM_REF_TO_STRING:
     {
-      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
           get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         GenRet wide = get(1);
         ret = codegenCallExpr("chpl_wideRefToString",
@@ -4435,7 +4435,7 @@ GenRet CallExpr::codegen() {
           codegenCall("chpl_string_widen", codegenAddrOf(get(1)), get(2),
                       get(3), get(4));
       } else if (get(1)->typeInfo()->symbol->hasFlag(FLAG_REF) ||
-          get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+          get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
           get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         codegenAssign(codegenDeref(get(1)), get(2));
       } else {
@@ -4635,7 +4635,7 @@ GenRet CallExpr::codegen() {
     {
       // arguments are (wide ptr, line, function/file, error string)
       const char *error;
-      if (!get(1)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE, FLAG_WIDE_CLASS))
+      if (!get(1)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS))
         break;
       if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) &&
           get(1)->typeInfo()->getField("addr")->typeInfo()->symbol->
@@ -4833,7 +4833,7 @@ GenRet CallExpr::codegen() {
       GenRet localAddr = codegenValuePtr(get(1));
 
       // destination data array
-      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         Symbol *sym = get(1)->typeInfo()->getField("addr", true);
         INT_ASSERT(sym);
         dt = sym->typeInfo()->getValType()->symbol;
@@ -4846,7 +4846,7 @@ GenRet CallExpr::codegen() {
       }
 
       GenRet locale;
-      if( get(2)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE,FLAG_REF) ) {
+      if( get(2)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_REF) ) {
         locale = codegenValue(codegenDeref(get(2)));
       } else {
         locale = codegenValue(get(2));
@@ -4856,7 +4856,7 @@ GenRet CallExpr::codegen() {
       GenRet remoteAddr = get(3);
       SymExpr *sym = toSymExpr(get(3));
       INT_ASSERT(sym);
-      if( sym->typeInfo()->symbol->hasFlag(FLAG_WIDE) ) {
+      if( sym->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ) {
         remoteAddr = codegenRaddr(remoteAddr);
       } else {
         if( !sym->typeInfo()->symbol->hasFlag(FLAG_REF) ) {
@@ -4870,7 +4870,7 @@ GenRet CallExpr::codegen() {
       }*/
       GenRet eltSize = codegenSizeof(dt->typeInfo());
       GenRet len;
-      if( get(4)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE,FLAG_REF) ) {
+      if( get(4)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_REF) ) {
         len = codegenValue(codegenDeref(get(4)));
       } else {
         len = codegenValue(get(4));
@@ -4906,7 +4906,7 @@ GenRet CallExpr::codegen() {
 
       TypeSymbol *dt;
       // Get the element type.
-      if (get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+      if (get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         Symbol *sym = get(2)->typeInfo()->getField("addr", true);
         INT_ASSERT(sym);
         dt = sym->typeInfo()->getValType()->symbol;
@@ -4916,7 +4916,7 @@ GenRet CallExpr::codegen() {
 
       // Get the locale
       GenRet locale;
-      if( get(1)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE,FLAG_REF) ) {
+      if( get(1)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_REF) ) {
         locale = codegenValue(codegenDeref(get(1)));
       } else {
         locale = codegenValue(get(1));
@@ -4926,7 +4926,7 @@ GenRet CallExpr::codegen() {
       GenRet remoteAddr = get(2);
       SymExpr *sym = toSymExpr(get(2));
       INT_ASSERT(sym);
-      if( sym->typeInfo()->symbol->hasFlag(FLAG_WIDE) ) {
+      if( sym->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ) {
         remoteAddr = codegenRaddr(remoteAddr);
       } else {
         if( !sym->typeInfo()->symbol->hasFlag(FLAG_REF) ) {
@@ -4935,7 +4935,7 @@ GenRet CallExpr::codegen() {
       }
       GenRet eltSize = codegenSizeof(dt->typeInfo());
       GenRet len;
-      if( get(3)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE,FLAG_REF) ) {
+      if( get(3)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_REF) ) {
         len = codegenValue(codegenDeref(get(3)));
       } else {
         len = codegenValue(get(3));
@@ -4960,7 +4960,7 @@ GenRet CallExpr::codegen() {
       GenRet localAddr = codegenValuePtr(get(1));
 
       // destination data array
-      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+      if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         Symbol *sym = get(1)->typeInfo()->getField("addr", true);
         INT_ASSERT(sym);
         dt = sym->typeInfo()->getValType()->symbol;
@@ -4975,7 +4975,7 @@ GenRet CallExpr::codegen() {
       // destination strides local array
       GenRet dststr = codegenValuePtr(get(2));
 
-      if (get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+      if (get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         Symbol *sym = get(2)->typeInfo()->getField("addr", true);
         INT_ASSERT(sym);
         dststr = codegenRaddr(dststr);
@@ -4987,7 +4987,7 @@ GenRet CallExpr::codegen() {
 
       // locale id 
       GenRet locale;
-      if( get(3)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE,FLAG_REF) ) {
+      if( get(3)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_REF) ) {
         locale = codegenValue(codegenDeref(get(3)));
       } else {
         locale = codegenValue(get(3));
@@ -4997,7 +4997,7 @@ GenRet CallExpr::codegen() {
       GenRet remoteAddr = get(4);
       SymExpr *sym = toSymExpr(get(4));
       INT_ASSERT(sym);
-      if( sym->typeInfo()->symbol->hasFlag(FLAG_WIDE) ) {
+      if( sym->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ) {
         remoteAddr = codegenRaddr(remoteAddr);
       } else {
         if( !sym->typeInfo()->symbol->hasFlag(FLAG_REF) ) {
@@ -5008,7 +5008,7 @@ GenRet CallExpr::codegen() {
       // source strides local array
       GenRet srcstr = codegenValuePtr(get(5));
 
-      if (get(5)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+      if (get(5)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         Symbol *sym = get(5)->typeInfo()->getField("addr", true);
         INT_ASSERT(sym);
         srcstr = codegenRaddr(srcstr);
@@ -5021,7 +5021,7 @@ GenRet CallExpr::codegen() {
       // count local array
       GenRet count = codegenValuePtr(get(6));
 
-      if (get(6)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+      if (get(6)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         Symbol *sym = get(6)->typeInfo()->getField("addr", true);
         INT_ASSERT(sym);
         count = codegenRaddr(count);
@@ -5033,7 +5033,7 @@ GenRet CallExpr::codegen() {
 
       // stridelevels
       GenRet stridelevels;
-      if( get(7)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE,FLAG_REF) ) {
+      if( get(7)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_REF) ) {
         stridelevels = codegenValue(codegenDeref(get(7)));
       } else {
         stridelevels = codegenValue(get(7));
@@ -5055,7 +5055,7 @@ GenRet CallExpr::codegen() {
     {
       Type* type = get(1)->typeInfo();
       if (type->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-          type->symbol->hasFlag(FLAG_WIDE))
+          type->symbol->hasFlag(FLAG_WIDE_REF))
         // If wide, get the value type.
         type = toAggregateType(type)->getField("addr", true)->typeInfo();
 
@@ -5073,7 +5073,7 @@ GenRet CallExpr::codegen() {
     case PRIM_CAST: 
     {
       if (typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-          typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+          typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         GenRet tmp = get(2);
         ret = codegenWideAddrWithAddr(tmp,
                               codegenCast(get(1)->typeInfo(), 
@@ -5177,7 +5177,7 @@ GenRet CallExpr::codegen() {
     {
       Type* t = get(1)->typeInfo();
       GenRet ptr;
-      if (t->symbol->hasEitherFlag(FLAG_WIDE, FLAG_WIDE_CLASS))
+      if (t->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS))
         // Get the local address.
         // Assume that we have already tested to ensure that this wide pointer
         // is local.  That is, caller should have called chpl_check_local.
@@ -5385,9 +5385,9 @@ GenRet CallExpr::codegen() {
     GenRet endCountValue = codegenValue(endCountPtr);
     GenRet taskList;
 
-    if (endCountType->symbol->hasFlag(FLAG_WIDE)) {
+    if (endCountType->symbol->hasFlag(FLAG_WIDE_REF)) {
       GenRet node = codegenRnode(endCountValue);
-      while(endCountValue.chplType->symbol->hasEitherFlag(FLAG_WIDE,FLAG_REF)){
+      while(endCountValue.chplType->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_REF)){
         endCountValue = codegenLocalDeref(endCountValue);
       }
       // Now, we should have a wide pointer to a class
@@ -5487,7 +5487,7 @@ GenRet CallExpr::codegen() {
         arg = codegenCastToCharStar(codegenValue(arg));
       else if (isRefWideString(actualType))// checks for ref(widestr)
         arg = codegenAddrOf(codegenWideThingField(codegenDeref(arg),WIDE_GEP_ADDR));
-      else if( actualType->symbol->hasFlag(FLAG_WIDE) ||
+      else if( actualType->symbol->hasFlag(FLAG_WIDE_REF) ||
                arg.isLVPtr == GEN_WIDE_PTR) {
         arg = codegenRaddr(codegenValue(arg));
       } else if (formal->type->symbol->hasFlag(FLAG_REF) &&

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -148,7 +148,7 @@ returnInfoCast(CallExpr* call) {
   if (t2->symbol->hasFlag(FLAG_WIDE_CLASS))
     if (wideClassMap.get(t1))
       t1 = wideClassMap.get(t1);
-  if (t2->symbol->hasFlag(FLAG_WIDE))
+  if (t2->symbol->hasFlag(FLAG_WIDE_REF))
     if (wideRefMap.get(t1))
       t1 = wideRefMap.get(t1);
   return t1;

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -666,7 +666,7 @@ void VarSymbol::codegenDefC(bool global) {
       if (isFnSymbol(defPoint->parentSymbol)) {
         str += " = NULL";
       }
-    } else if (ct->symbol->hasFlag(FLAG_WIDE) ||
+    } else if (ct->symbol->hasFlag(FLAG_WIDE_REF) ||
                ct->symbol->hasFlag(FLAG_WIDE_CLASS)) {
       if (isFnSymbol(defPoint->parentSymbol)) {
         if( widePointersStruct || isWideString(ct) ) {
@@ -797,7 +797,7 @@ void VarSymbol::codegenDef() {
 
     if(AggregateType *ctype = toAggregateType(type)) {
       if(ctype->isClass() ||
-         ctype->symbol->hasFlag(FLAG_WIDE) ||
+         ctype->symbol->hasFlag(FLAG_WIDE_REF) ||
          ctype->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         if(isFnSymbol(defPoint->parentSymbol)) {
           info->builder->CreateStore(
@@ -1178,7 +1178,7 @@ void TypeSymbol::codegenMetadata() {
   // get simple TBAA (they can get struct tbaa).
   if( is_bool_type(type) || is_int_type(type) || is_uint_type(type) ||
       is_real_type(type) || is_imag_type(type) || is_enum_type(type) ||
-      isClass(type) || hasEitherFlag(FLAG_REF,FLAG_WIDE) ||
+      isClass(type) || hasEitherFlag(FLAG_REF,FLAG_WIDE_REF) ||
       hasEitherFlag(FLAG_DATA_CLASS,FLAG_WIDE_CLASS) ) {
     // Now create tbaa metadata, one for const and one for not.
     {
@@ -1201,7 +1201,7 @@ void TypeSymbol::codegenMetadata() {
       hasFlag(FLAG_STAR_TUPLE) ||
       hasFlag(FLAG_REF) ||
       hasFlag(FLAG_DATA_CLASS) ||
-      hasEitherFlag(FLAG_WIDE,FLAG_WIDE_CLASS) ) {
+      hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS) ) {
     return;
   }
 

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -701,7 +701,7 @@ void AggregateType::codegenDef() {
     }
   } else {
     if( outfile ) {
-      if( symbol->hasEitherFlag(FLAG_WIDE, FLAG_WIDE_CLASS) &&
+      if( symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS) &&
           (! isWideString(this)) &&
           (! widePointersStruct ) ) {
         // Reach this branch when generating a wide/wide class as a
@@ -819,7 +819,7 @@ void AggregateType::codegenDef() {
       // if it's a record, we make the new type now.
       // if it's a class, we update the existing type.
       
-      if( symbol->hasEitherFlag(FLAG_WIDE, FLAG_WIDE_CLASS) &&
+      if( symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS) &&
           (! isWideString(this)) &&
           (! widePointersStruct ) ) {
         // Reach this branch when generating a wide/wide class as a

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -234,7 +234,7 @@ symbolFlag( FLAG_VIRTUAL , npr, "virtual" , ncm )
 // Used to mark where a compiler generated flag was removed (but is desired
 // elsewhere).
 symbolFlag( FLAG_WAS_COMPILER_GENERATED, npr, "was compiler generated", "used to be marked compiler generated")
-symbolFlag( FLAG_WIDE , npr, "wide" , ncm )
+symbolFlag( FLAG_WIDE_REF , npr, "wide" , ncm )
 symbolFlag( FLAG_WIDE_CLASS , npr, "wide class" , ncm )
 symbolFlag( FLAG_WRAPPER , npr, "wrapper" , "wrapper function" )
 symbolFlag( FLAG_WRAP_WRITTEN_FORMAL , npr, "wrap written formal" , "formal argument for wrapper for out/inout intent" )

--- a/compiler/optimizations/narrowWideReferences.cpp
+++ b/compiler/optimizations/narrowWideReferences.cpp
@@ -159,7 +159,7 @@ narrowField(Symbol* field, WideInfo* wi) {
     return;
   }
   if (ts->hasFlag(FLAG_REF) ||
-      ts->hasFlag(FLAG_WIDE) ||
+      ts->hasFlag(FLAG_WIDE_REF) ||
       ts->hasFlag(FLAG_WIDE_CLASS)) {
     wi->mustBeWide = true;
     return;
@@ -174,10 +174,10 @@ narrowField(Symbol* field, WideInfo* wi) {
 //       if (call->isPrimitive(PRIM_SET_MEMBER) && call->get(2) == use) {
 //         SymExpr* base = toSymExpr(call->get(1));
 //         SymExpr* rhs = toSymExpr(call->get(3));
-//         if (base->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+//         if (base->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
 //             base->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS))
 //           addNarrowDep(base->var, field);
-//         if (rhs->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+//         if (rhs->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
 //             rhs->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS))
 //           addNarrowDep(rhs->var, field);
 //         continue;
@@ -203,7 +203,7 @@ narrowSym(Symbol* sym, WideInfo* wi,
           Map<Symbol*,Vec<SymExpr*>*>& useMap)
 {
   bool isWideObj = sym->type->symbol->hasFlag(FLAG_WIDE_CLASS);
-  bool isWideRef = sym->type->symbol->hasFlag(FLAG_WIDE);
+  bool isWideRef = sym->type->symbol->hasFlag(FLAG_WIDE_REF);
   INT_ASSERT(isWideObj ^ isWideRef);
 
   // This scans the definitions of the given symbol and weeds out calls that can
@@ -220,7 +220,7 @@ narrowSym(Symbol* sym, WideInfo* wi,
           if (rhs->isPrimitive(PRIM_GET_MEMBER)) {
             INT_ASSERT(isWideRef);
             SymExpr* base = toSymExpr(rhs->get(1));
-            if (base->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+            if (base->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
                 base->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS))
               addNarrowDep(base->var, sym);
             continue;
@@ -228,24 +228,24 @@ narrowSym(Symbol* sym, WideInfo* wi,
           if (rhs->isPrimitive(PRIM_GET_MEMBER_VALUE)) {
             SymExpr* base = toSymExpr(rhs->get(1));
             SymExpr* member = toSymExpr(rhs->get(2));
-            if (base->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+            if (base->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
                 base->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS))
               addNarrowDep(base->var, sym);
-            if (member->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+            if (member->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
                 member->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS))
               addNarrowDep(member->var, sym);
             continue;
           }
           if (rhs->isPrimitive(PRIM_STRING_COPY)) {
             SymExpr* se = toSymExpr(rhs->get(1));
-            if (se->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+            if (se->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
                 se->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS))
               addNarrowDep(se->var, sym);
             continue;
           }
           if (rhs->isPrimitive(PRIM_CAST)) {
             SymExpr* se = toSymExpr(rhs->get(2));
-            if (se->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+            if (se->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
                 se->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS))
               addNarrowDep(se->var, sym);
             continue;
@@ -253,14 +253,14 @@ narrowSym(Symbol* sym, WideInfo* wi,
           if (FnSymbol* fn = rhs->isResolved()) {
             if (fn->hasFlag(FLAG_LOCALE_MODEL_ALLOC))
               continue;
-            if ((isWideRef && fn->retType->symbol->hasFlag(FLAG_WIDE)) ||
+            if ((isWideRef && fn->retType->symbol->hasFlag(FLAG_WIDE_REF)) ||
                 (isWideObj && fn->retType->symbol->hasFlag(FLAG_WIDE_CLASS)))
               addNarrowDep(fn->getReturnSymbol(), sym);
             continue;
           }
         }
         if (SymExpr* rhs = toSymExpr(call->get(2))) {
-          if ((isWideRef && rhs->var->type->symbol->hasFlag(FLAG_WIDE)) ||
+          if ((isWideRef && rhs->var->type->symbol->hasFlag(FLAG_WIDE_REF)) ||
               (isWideObj && rhs->var->type->symbol->hasFlag(FLAG_WIDE_CLASS)))
             addNarrowDep(rhs->var, sym);
           continue;
@@ -323,7 +323,7 @@ narrowSym(Symbol* sym, WideInfo* wi,
       }
       if (call->isPrimitive(PRIM_RETURN)) {
         FnSymbol* fn = toFnSymbol(call->parentSymbol);
-        if (!fn->retType->symbol->hasEitherFlag(FLAG_WIDE, FLAG_WIDE_CLASS))
+        if (!fn->retType->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS))
           // already narrow, so skip it.
           continue;
         wi->fnToNarrow = fn;
@@ -394,7 +394,7 @@ narrowArg(ArgSymbol* arg, WideInfo* wi,
     } else {
       SymExpr* actual = toSymExpr(formal_to_actual(call, arg));
       INT_ASSERT(actual);
-      if (actual->var->type->symbol->hasFlag(FLAG_WIDE) ||
+      if (actual->var->type->symbol->hasFlag(FLAG_WIDE_REF) ||
           actual->var->type->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         addNarrowDep(actual->var, arg);
       }
@@ -459,13 +459,13 @@ static void populateWideInfoMap()
 {
   // Insert all wide variables and arguments into wideInfoMap.
   forv_Vec(VarSymbol, var, gVarSymbols) {
-    if (var->type->symbol->hasFlag(FLAG_WIDE) ||
+    if (var->type->symbol->hasFlag(FLAG_WIDE_REF) ||
         var->type->symbol->hasFlag(FLAG_WIDE_CLASS)) {
       wideInfoMap->put(var, new WideInfo(var));
     }
   }
   forv_Vec(ArgSymbol, arg, gArgSymbols) {
-    if (arg->type->symbol->hasFlag(FLAG_WIDE) ||
+    if (arg->type->symbol->hasFlag(FLAG_WIDE_REF) ||
         arg->type->symbol->hasFlag(FLAG_WIDE_CLASS)) {
       wideInfoMap->put(arg, new WideInfo(arg));
     }
@@ -576,14 +576,14 @@ static void printNarrowEffectSummary()
 {
 #ifdef PRINT_NARROW_EFFECT_SUMMARY
   forv_Vec(VarSymbol, var, gVarSymbols) {
-    if (var->type->symbol->hasFlag(FLAG_WIDE) ||
+    if (var->type->symbol->hasFlag(FLAG_WIDE_REF) ||
         var->type->symbol->hasFlag(FLAG_WIDE_CLASS)) {
       wideCount++;
     }
   }
 
   forv_Vec(ArgSymbol, arg, gArgSymbols) {
-    if (arg->type->symbol->hasFlag(FLAG_WIDE) ||
+    if (arg->type->symbol->hasFlag(FLAG_WIDE_REF) ||
         arg->type->symbol->hasFlag(FLAG_WIDE_CLASS)) {
       wideCount++;
     }
@@ -625,7 +625,7 @@ static void moveAddressSourcesToTemp()
 {
   forv_Vec(CallExpr, call, gCallExprs) {
     if (call->isPrimitive(PRIM_MOVE) || call->isPrimitive(PRIM_ASSIGN)) {
-      if ((call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+      if ((call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
            call->get(1)->typeInfo()->symbol->hasFlag(FLAG_REF)) &&
           call->get(1)->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS) &&
           call->get(2)->typeInfo() == call->get(1)->getValType()->getField("addr")->type) {

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -127,8 +127,8 @@ isFastPrimitive(CallExpr *call, bool isLocal) {
   case PRIM_OR_ASSIGN:
   case PRIM_XOR_ASSIGN:
     if (!isCallExpr(call->get(2))) { // callExprs checked in calling function
-      if (!call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) &&
-          !call->get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+      if (!call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
+          !call->get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         DEBUG_PRINTF(" *** OK (PRIM_MOVE 1): %s\n", call->primitive->name);
         return true;
       }
@@ -146,7 +146,7 @@ isFastPrimitive(CallExpr *call, bool isLocal) {
   case PRIM_WIDE_GET_NODE:
   case PRIM_WIDE_GET_ADDR:
     // If this test is true, a remote get is required.
-    if (!(call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) &&
+    if (!(call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
           call->get(1)->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS))) {
       DEBUG_PRINTF(" *** OK (PRIM_WIDE_GET_LOCALE, etc.): %s\n",
                    call->primitive->name);
@@ -158,7 +158,7 @@ isFastPrimitive(CallExpr *call, bool isLocal) {
   case PRIM_GET_UNION_ID:
   case PRIM_GET_MEMBER_VALUE:
   case PRIM_GET_SVEC_MEMBER_VALUE:
-    if (!call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+    if (!call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
       return true;
       DEBUG_PRINTF(" *** OK (PRIM_SET_UNION_ID, etc.): %s\n",
                    call->primitive->name);
@@ -183,7 +183,7 @@ isFastPrimitive(CallExpr *call, bool isLocal) {
   case PRIM_DEREF:
   case PRIM_SET_MEMBER:
   case PRIM_SET_SVEC_MEMBER:
-    if (!call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) &&
+    if (!call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
         !call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
       DEBUG_PRINTF(" *** OK (PRIM_DEREF, etc.): %s\n", call->primitive->name);
       return true;

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -421,7 +421,7 @@ static inline bool shouldCodegenAggregate(AggregateType* ct)
   //   we do visit.
   if( isClass(ct) ) { // is it actually a class?
     if( ct->symbol->hasFlag(FLAG_REF) ||
-        ct->symbol->hasFlag(FLAG_WIDE) ||
+        ct->symbol->hasFlag(FLAG_WIDE_REF) ||
         ct->symbol->hasFlag(FLAG_DATA_CLASS)) return true;
     else return false;
   }

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -119,7 +119,7 @@ static void localizeCall(CallExpr* call) {
     case PRIM_ASSIGN: // Not sure about this one.
       if (CallExpr* rhs = toCallExpr(call->get(2))) {
         if (rhs->isPrimitive(PRIM_DEREF)) {
-          if (rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+          if (rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
               rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
             insertLocalTemp(rhs->get(1));
             if (!rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_REF)) {
@@ -134,7 +134,7 @@ static void localizeCall(CallExpr* call) {
                    rhs->isPrimitive(PRIM_GET_SVEC_MEMBER) ||
                    rhs->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
                    rhs->isPrimitive(PRIM_GET_SVEC_MEMBER_VALUE)) {
-          if (rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) ||
+          if (rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
               rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
             SymExpr* sym = toSymExpr(rhs->get(2));
             INT_ASSERT(sym);
@@ -166,7 +166,7 @@ static void localizeCall(CallExpr* call) {
           }
           break;
         } else if (rhs->isPrimitive(PRIM_GET_UNION_ID)) {
-          if (rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+          if (rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
             insertLocalTemp(rhs->get(1));
           }
           break;
@@ -183,8 +183,8 @@ static void localizeCall(CallExpr* call) {
           !call->get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         break;
       }
-      if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) &&
-          !call->get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE) &&
+      if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
+          !call->get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
           !call->get(2)->typeInfo()->symbol->hasFlag(FLAG_REF)) {
         insertLocalTemp(call->get(1));
       }
@@ -193,7 +193,7 @@ static void localizeCall(CallExpr* call) {
       if (call->get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         insertLocalTemp(call->get(2));
         if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-            call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+            call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
           toSymExpr(call->get(1))->var->type = call->get(1)->typeInfo()->getField("addr")->type;
         }
       }
@@ -204,14 +204,14 @@ static void localizeCall(CallExpr* call) {
       }
       break;
     case PRIM_SET_UNION_ID:
-      if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+      if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         insertLocalTemp(call->get(1));
       }
       break;
     case PRIM_SET_MEMBER:
     case PRIM_SET_SVEC_MEMBER:
       if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-          call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE)) {
+          call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
         insertLocalTemp(call->get(1));
       }
       break;
@@ -260,7 +260,7 @@ static void handleLocalBlocks() {
             queue.add(local->body);
             cache.put(fn, local);
             cache.put(local, local); // to handle recursion
-            if (local->retType->symbol->hasFlag(FLAG_WIDE)) {
+            if (local->retType->symbol->hasFlag(FLAG_WIDE_REF)) {
               CallExpr* ret = toCallExpr(local->body->body.tail);
               INT_ASSERT(ret && ret->isPrimitive(PRIM_RETURN));
               // Capture the return expression in a local temp.
@@ -524,7 +524,7 @@ static void buildWideRefMap()
 
       AggregateType* wide = new AggregateType(AGGREGATE_RECORD);
       TypeSymbol* wts = new TypeSymbol(astr("__wide_", ts->cname), wide);
-      wts->addFlag(FLAG_WIDE);
+      wts->addFlag(FLAG_WIDE_REF);
       theProgram->block->insertAtTail(new DefExpr(wts));
       wide->fields.insertAtTail(new DefExpr(new VarSymbol("locale", dtLocaleID)));
       wide->fields.insertAtTail(new DefExpr(new VarSymbol("addr", ts->type)));
@@ -546,7 +546,7 @@ static void widenRefs()
     // do not change the reference field in a wide reference type
     //
     if (TypeSymbol* ts = toTypeSymbol(def->parentSymbol))
-      if (ts->hasFlag(FLAG_WIDE))
+      if (ts->hasFlag(FLAG_WIDE_REF))
         continue;
 
     //
@@ -669,7 +669,7 @@ static void narrowWideClassesThroughCalls()
 
         // Select symbols with wide types.
         if (symType->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-            symType->symbol->hasFlag(FLAG_WIDE)) {
+            symType->symbol->hasFlag(FLAG_WIDE_REF)) {
           Type* narrowType = symType->getField("addr")->type;
 
           // Copy 
@@ -729,7 +729,7 @@ static void insertWideClassTempsForNil()
           }
         } else if (call->isPrimitive(PRIM_MOVE)) {
           if (Type* wtype = call->get(1)->typeInfo()) {
-            if (wtype->symbol->hasFlag(FLAG_WIDE)) {
+            if (wtype->symbol->hasFlag(FLAG_WIDE_REF)) {
               if (Type* wctype = wtype->getField("addr")->type->getField("_val")->type) {
                 if (wctype->symbol->hasFlag(FLAG_WIDE_CLASS)) {
                   VarSymbol* tmp = newTemp(wctype);
@@ -743,7 +743,7 @@ static void insertWideClassTempsForNil()
         } else if (call->isPrimitive(PRIM_SET_MEMBER)) {
           if (Type* wctype = call->get(2)->typeInfo()) {
             if (wctype->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-                wctype->symbol->hasFlag(FLAG_WIDE)) {
+                wctype->symbol->hasFlag(FLAG_WIDE_REF)) {
               VarSymbol* tmp = newTemp(wctype);
               call->insertBefore(new DefExpr(tmp));
               se->replace(new SymExpr(tmp));
@@ -754,7 +754,7 @@ static void insertWideClassTempsForNil()
           Type* valueType = call->get(1)->getValType();
           Type* componentType = valueType->getField("x1")->type;
           if (componentType->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-              componentType->symbol->hasFlag(FLAG_WIDE)) {
+              componentType->symbol->hasFlag(FLAG_WIDE_REF)) {
             VarSymbol* tmp = newTemp(componentType);
             call->insertBefore(new DefExpr(tmp));
             se->replace(new SymExpr(tmp));
@@ -837,7 +837,7 @@ static void derefWideRefsToWideClasses()
         call->isPrimitive(PRIM_WIDE_GET_NODE) ||
         call->isPrimitive(PRIM_WIDE_GET_ADDR) ||
         call->isPrimitive(PRIM_SET_MEMBER)) {
-      if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE) &&
+      if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
           call->get(1)->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS) &&
           // This should be removed when string_rec is the default string type
           call->get(1)->getValType() != wideStringType) {

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1233,7 +1233,7 @@ Type* getOrMakeWideTypeDuringCodegen(Type* refType) {
   AggregateType* wide = new AggregateType(AGGREGATE_RECORD);
   TypeSymbol* wts = new TypeSymbol(astr("chpl____wide_", refType->symbol->cname), wide);
   if( refType->symbol->hasFlag(FLAG_REF) || refType == dtNil )
-    wts->addFlag(FLAG_WIDE);
+    wts->addFlag(FLAG_WIDE_REF);
   else
     wts->addFlag(FLAG_WIDE_CLASS);
   theProgram->block->insertAtTail(new DefExpr(wts));


### PR DESCRIPTION
FLAG_WIDE really really means that the variable to which it is attached is both wide and a reference.  This renaming is a first step toward making the flags FLAG_REF and FLAG_WIDE orthogonal.
There are quite a few (32) conditionals that contain either
  hasEitherFlag(FLAG_REF, FLAG_WIDE) // The variable is a reference
or 
  hasEitherFlag(FLAG_WIDE, FLAG_WIDE_CLASS) // The variable is wide
and several other instances where these pairs are spelled out rather than using "hasEitherFlag()".  With an orthogonal flag set, we can replace these with the test of a single flag, and reduce by one the number of flags required.
