### PR TITLE
Use length in string copies

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -5235,6 +5235,9 @@ GenRet CallExpr::codegen() {
       break;
     case PRIM_STRING_COPY:
     {
+      // TODO: Deprecate PRIM_STRING_COPY after the string_rec conversion.
+      // (Ensure that the string copy is local and then call string_copy
+      // directly.)
       GenRet cpyFrom = get(1)->codegen();
       if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         cpyFrom.isLVPtr = GEN_VAL; // Prevent &(char*) syntax.

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -242,7 +242,7 @@ module String {
   //
   inline proc _cast(type t, x: complex(?w)) where t == c_string_copy {
     if isnan(x.re) || isnan(x.im) then
-      return __primitive("string_copy", "nan");
+      return string_copy_len("nan", 3);
     var re = (x.re):c_string_copy;
     var im: c_string_copy;
     var op: c_string;
@@ -463,13 +463,13 @@ module CString {
     return chpl_bool_to_c_string(x:bool);
   }
   inline proc _cast(type t, x: bool(?w)) where t == c_string_copy {
-    return __primitive("string_copy", chpl_bool_to_c_string(x:bool));
+    return string_copy(chpl_bool_to_c_string(x:bool));
   }
 
   inline proc _cast(type t, x:enumerated) where t == c_string_copy {
     // Use the compiler-generated enum to c_string conversion.
     var cs = _cast(c_string, x);
-    return __primitive("string_copy", cs);
+    return string_copy(cs);
   }
 
   inline proc _cast(type t, x:integral) where t == c_string_copy {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -916,7 +916,7 @@ inline proc _cast(type t, x: ioNewline) where t == c_string {
 }
 
 inline proc _cast(type t, x: ioNewline) where t == c_string_copy {
-  return __primitive("string_copy", "\n");
+  return string_copy_len("\n", 1);
 }
 
 // Used to represent a constant string we want to read or write...
@@ -934,7 +934,7 @@ inline proc _cast(type t, x: ioLiteral) where t == c_string {
 }
 
 inline proc _cast(type t, x: ioLiteral) where t == c_string_copy {
-  return __primitive("string_copy", x.val);
+  return string_copy(x.val);
 }
 
 // Used to represent some number of bits we want to read or write...

--- a/modules/standard/NewString.chpl
+++ b/modules/standard/NewString.chpl
@@ -99,6 +99,8 @@ module BaseStringType {
   pragma "insert line file info"
   extern proc stringMove(dest: c_string, src: c_string, len: int): void;
   pragma "insert line file info"
+  extern proc string_copy(src: c_string): c_string_copy;
+  pragma "insert line file info"
   extern proc string_copy_len(src: c_string, len: int): c_string_copy;
   pragma "insert line file info"
   extern proc remoteStringCopy(src_loc: int, src_addr: c_string, len: int): c_string_copy;
@@ -299,6 +301,7 @@ module NewString {
 
     inline proc isEmptyString() {
       if this.isAlias then return false;
+      if this.base == _nullString then return true;
       else return this.len==0; // this should be enough of a check
     }
 
@@ -618,7 +621,7 @@ module NewString {
       halt("Cannot cast a remote "+baseTypeString+" to string.");
     var ret: string_rec;
     ret.len = cs.length;
-    if ret.len != 0 then ret.base = __primitive("string_copy", cs);
+    if ret.len != 0 then ret.base = string_copy(cs);
     ret.incRefCntNoAlias();
     if debugStrings then writeln("leaving _cast() "+baseTypeString+"-string");
     return ret;

--- a/modules/standard/NewString.chpl
+++ b/modules/standard/NewString.chpl
@@ -97,7 +97,9 @@ module BaseStringType {
   }
 
   pragma "insert line file info"
-  extern proc stringMove(dest: c_string, src: c_string, len: int): c_string;
+  extern proc stringMove(dest: c_string, src: c_string, len: int): void;
+  pragma "insert line file info"
+  extern proc string_copy_len(src: c_string, len: int): c_string_copy;
   pragma "insert line file info"
   extern proc remoteStringCopy(src_loc: int, src_addr: c_string, len: int): c_string_copy;
 
@@ -168,13 +170,13 @@ module NewString {
       if new_len != 0 {
         if new_len < this.len {
           // reuse the buffer
-          this.base = stringMove(this.base, s, new_len);
+          stringMove(this.base, s, new_len);
         } else {
           // free the old buffer
           if this.len != 0 then
             on home do free_baseType(this.base);
           // allocate a new buffer
-          this.base = stringMove(_defaultOf(baseType), s, new_len);
+          this.base = string_copy_len(s, new_len);
         }
       } else {
         // free the old buffer
@@ -352,7 +354,7 @@ module NewString {
       const slen = s.len; // cache the remote copy of len
       if s.home.id == here.id {
         if debugStrings then writeln("  local initCopy");
-        ret.base = stringMove(_defaultOf(baseType), s.base, slen);
+        ret.base = string_copy_len(s.base, slen);
       } else {
         if debugStrings then writeln("  remote initCopy: ", s.home.id);
         ret.base = remoteStringCopy(s.home.id, s.base, slen);

--- a/runtime/include/chpl-string-support.h
+++ b/runtime/include/chpl-string-support.h
@@ -81,7 +81,11 @@ c_string_copy chpl_format(c_string format, ...)
 char* chpl_glom_strings(int numstrings, ...);
 
 chpl_bool string_contains(c_string x, c_string y);
-c_string_copy string_copy(c_string x, int32_t lineno, c_string filename);
+
+// len is the length of the result string exclusive of the terminating NUL.
+// Exactly len characters are copied and then the terminating NUL is added
+// explicitly, so the input string need not be NUL-terminated.
+c_string_copy string_copy_len(c_string x, size_t len, int32_t lineno, c_string filename);
 c_string_copy string_concat(c_string x, c_string y, int32_t lineno, c_string filename);
 int string_index_of(c_string x, c_string y);
 c_string_copy string_index(c_string x, int i, int32_t lineno, c_string filename);

--- a/runtime/include/chpl-string-support.h
+++ b/runtime/include/chpl-string-support.h
@@ -81,7 +81,8 @@ c_string_copy chpl_format(c_string format, ...)
 char* chpl_glom_strings(int numstrings, ...);
 
 chpl_bool string_contains(c_string x, c_string y);
-
+// TODO: Remove this from the public interface.
+c_string_copy string_copy(c_string x, int32_t lineno, c_string filename);
 // len is the length of the result string exclusive of the terminating NUL.
 // Exactly len characters are copied and then the terminating NUL is added
 // explicitly, so the input string need not be NUL-terminated.

--- a/runtime/include/chpl-string.h
+++ b/runtime/include/chpl-string.h
@@ -43,13 +43,10 @@ void c_string_from_string(c_string* ret, chpl_string* str, int32_t lineno, c_str
 void c_string_from_wide_string(c_string* ret, struct chpl_chpl____wide_chpl_string_s* str, int32_t lineno, c_string filename);
 
 // Chapel string support functions
-// If dest == NULL then a new string is allocated to accommodate the
-// result of the move.  Otherwise the caller must supply a dest large enough to
-// accommodate the result.  
-// TODO:  This interface is weird.  It would be better to always allocate.  Is
-// it ever called with a non-NULL dest?
-c_string_copy stringMove(c_string_copy dest, c_string src, int64_t len,
-                         int32_t lineno, c_string filename);
+
+// The caller must supply a dest large enough to accommodate the result.  
+void stringMove(c_string dest, c_string src, int64_t len,
+                int32_t lineno, c_string filename);
 
 c_string_copy remoteStringCopy(c_nodeid_t src_locale,
                                c_string src_addr, int64_t src_len,

--- a/runtime/src/chpl-string-support.c
+++ b/runtime/src/chpl-string-support.c
@@ -118,7 +118,7 @@ string_copy_len(c_string x, size_t len, int32_t lineno, c_string filename)
   return buf;
 }
 
-static c_string_copy
+c_string_copy
 string_copy(c_string x, int32_t lineno, c_string filename)
 {
   size_t len;

--- a/runtime/src/chpl-string-support.c
+++ b/runtime/src/chpl-string-support.c
@@ -68,12 +68,17 @@ char* chpl_glom_strings(int numstrings, ...) {
 c_string_copy chpl_format(c_string format, ...) {
   va_list ap;
   char z[128];
+  int len;
 
   va_start(ap, format);
-  if (vsnprintf(z, sizeof(z), format, ap) >= sizeof(z))
-    chpl_error("overflow encountered in format", 0, 0);
+  len = vsnprintf(z, sizeof(z), format, ap);
+  if (len < 0)
+    chpl_error("formatting error encountered in chpl_format", 0, 0);
+  if (len >= sizeof(z))
+    chpl_error("overflow encountered in chpl_format", 0, 0);
   va_end(ap);
-  return string_copy(z, 0, 0);
+
+  return string_copy_len(z, len, 0, NULL);
 }
 
 
@@ -93,18 +98,36 @@ chpltypes_malloc(size_t size, chpl_mem_descInt_t description,
 }
 
 
+// len is the size of the returned string, not counting the terminating NUL.
+// Exactly len characters are copied from the source string.
+// The source string can contain NUL characters and need not contain a
+// terminating NUL.  A terminating NUL is always appended to the result.
+// If len == 0, an empty string ("") is returned.  This string still occpies
+// one byte because of the terminating NUL, so test for len == 0 if that is not
+// what you want.
 c_string_copy
+string_copy_len(c_string x, size_t len, int32_t lineno, c_string filename)
+{
+  char* buf;
+
+  buf = (char*) chpltypes_malloc(len+1, CHPL_RT_MD_STRING_COPY_DATA,
+                                 lineno, filename);
+  memcpy(buf, x, len);
+  buf[len] = '\0';
+
+  return buf;
+}
+
+static c_string_copy
 string_copy(c_string x, int32_t lineno, c_string filename)
 {
-  char *z;
+  size_t len;
 
   // If the input string is null, just return null.
-  if (x == NULL)
-    return NULL;
+  if (x == NULL) return NULL;
 
-  z = (char*)chpltypes_malloc(strlen(x)+1, CHPL_RT_MD_STRING_COPY_DATA,
-                              lineno, filename);
-  return strcpy(z, x);
+  len = strlen(x);
+  return string_copy_len(x, len, lineno, filename);
 }
 
 // string_concat always returns a newly-allocated c_string (or NULL).

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -30,8 +30,11 @@ typedef struct chpl_chpl____wide_chpl_string_s chpl____wide_chpl_string;
 
 chpl_string
 chpl_wide_string_copy(chpl____wide_chpl_string* x, int32_t lineno, chpl_string filename) {
-  if (chpl_rt_nodeFromLocaleID(x->locale) == chpl_nodeID)
-    return string_copy(x->addr, lineno, filename);
+  if (chpl_rt_nodeFromLocaleID(x->locale) == chpl_nodeID) {
+    if (x->size > 0)
+      return string_copy_len(x->addr, x->size, lineno, filename);
+    return NULL;
+  }
   else {
     chpl_string s;
     chpl_comm_wide_get_string(&s, x,

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -197,30 +197,19 @@ void c_string_from_wide_string(c_string* ret, chpl____wide_chpl_string* str, int
  * responsibility to make sure that dest is large enough to hold src.
  * Return the moved string.
  */
-// Even if allocation is done here, the returned string is already owned
-// elsewhere.  So we return a c_string, not a c_string_copy.
-c_string_copy stringMove(c_string_copy dest, c_string src, int64_t len,
-                         int32_t lineno, c_string filename) {
-  char *ret;
+void stringMove(c_string dest, c_string src, int64_t len,
+                int32_t lineno, c_string filename) {
+  char* ret;
+
   if (src == NULL)
-    return NULL;
+    chpl_error("Invalid source string in stringMove.", lineno, filename);
 
-  if (dest == NULL ||
-      // TODO: Want to deprecate indicating an empty string by a string of zero
-      // length.  This works OK if the string is unallocated (such as a string
-      // literal), but does not work well with an allocated string.  An
-      // allocated string of zero length still occupies memory (one byte for
-      // the NUL, at least), so that leaves us with a dilemma.  Which is it?
-      strlen(dest) == 0)
-    ret = chpl_mem_alloc(len+1, CHPL_RT_MD_STRING_MOVE_DATA, lineno, filename);
-  else
-    // reuse the buffer
-    // The cast is necessary so we can write into the buffer (which is declared
-    // to be const).
-    ret = (char *) dest;
-
-  snprintf(ret, len+1, "%s", src);
-  return (c_string) ret;
+  // reuse the buffer
+  // The cast is necessary so we can write into the buffer (which is declared
+  // to be const).
+  ret = (char*) dest;
+  strncpy(ret, src, len);
+  ret[len] = '\0';
 }
 
 /* This function returns a string from src_locale located at src_addr.

--- a/runtime/src/chplio.c
+++ b/runtime/src/chplio.c
@@ -29,13 +29,23 @@
 // These should be moved to chpl-string.c and eventually go away.
 chpl_string chpl_refToString(void* ref) {
   char buff[32];
-  sprintf(buff, "%p", ref);
-  return string_copy(buff, 0, NULL);
+  int len = snprintf(buff, sizeof(buff), "%p", ref);
+  if (len <= 0)
+    // Assume that we format at least one character.
+    chpl_error("Formatting error in chpl_refToString", 0, NULL);
+  if (len >= sizeof(buff))
+    chpl_error("Buffer overflow in chpl_refToString", 0, NULL);
+  return string_copy_len(buff, len, 0, NULL);
 }
 
 
 chpl_string chpl_wideRefToString(c_nodeid_t node, void* addr) {
   char buff[32];
-  sprintf(buff, "%" FORMAT_c_nodeid_t ":%p", node, addr);
-  return string_copy(buff, 0, NULL);
+  int len = snprintf(buff, sizeof(buff), "%" FORMAT_c_nodeid_t ":%p", node, addr);
+  if (len <= 0)
+    // Assume that we format at least one character.
+    chpl_error("Formatting error in chpl_wideRefToString", 0, NULL);
+  if (len >= sizeof(buff))
+    chpl_error("Buffer overflow in chpl_wideRefToString", 0, NULL);
+  return string_copy_len(buff, len, 0, NULL);
 }

--- a/test/parallel/forall/vass/alist-error.future
+++ b/test/parallel/forall/vass/alist-error.future
@@ -11,6 +11,15 @@ Workarounds:
 * replace R.getNext() with a literal (although this changes the behavior)
 
 
+A smaller example that currently crashes in the same way is:
+
+  proc main() {
+    var X = 1..1;
+    var R = 2;
+    var Y = [x in X] R;
+  }
+
+
 Here is the investigation I did:
 
 


### PR DESCRIPTION
This is a little cleanup task left by Sung.

I stumbled across it while trying to reduce string leaks.  The main idea is to reduce redundant calls to strlen where the length of a c_string is already known or has been computed for other reasons.  I also inserted slightly better error checking on the return value from snprintf(), and changed one snprintf() call to a strncpy() instead.

In addition, where possible I replaced calls to __primitve("string_copy") to direct calls to the extern string_copy routine, to position us for the eventual removal of the PRIM_STRING_COPY primitive.  Where the extern call is used, it is equivalent to an assertion that the string being copied is local.  There is one place where that assertion fails[ChapelIO.chpl:550], so I left the __primitive("string_copy") call in place.

Also, I replaced uses of stringMove() that really should have been string_copy() with (you guessed it) string_copy().  This allowed me to simplify stringMove, because it is no longer required to conditionally allocate memory for the result.