### PR TITLE
Don't use expect script for slurm-srun launcher

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -173,11 +173,11 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     mypid = getpid();
   }
 
-  // TODO we have a bunch of similar commands to build up the interactive and
-  // batch versions. It would be nicer to build up the commands and postprocess
-  // depending on interactive vs batch. As in build up "--quiet --nodes ..."
-  // and afterwards split on ' ' and then add #SBATCH and a newline for batch
-  // mode and leave it as is for interactive"
+  // Elliot, 12/02/14: TODO we have a bunch of similar commands to build up the
+  // interactive and batch versions. It would be nicer to build up the commands
+  // and postprocess depending on interactive vs batch. As in build up "--quiet
+  // --nodes ..." and afterwards split on ' ' and then add #SBATCH and a
+  // newline for batch mode and leave it as is for interactive"
 
   // if were running a batch job 
   if (getenv("CHPL_LAUNCHER_USE_SBATCH") != NULL || generate_sbatch_script) {
@@ -402,9 +402,9 @@ int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
     return 1;
   }
 
-  // TODO we should have a core binding option here similar to aprun's -cc to
-  // handle binding to cores / numa domains, etc
-  // For now you can just set the SLURM_CPU_BIND env var
+  // Elliot, 12/02/14: TODO we should have a core binding option here similar
+  // to aprun's -cc to handle binding to cores / numa domains, etc For now you
+  // can just set the SLURM_CPU_BIND env var
 
   return 0;
 }


### PR DESCRIPTION
An expect script was used to launch interactive jobs for slurm. This was
because the slurm-gasnetrun_ibv launcher it was originally copied from also
used an expect script. I think the only reason that launcher used it is because
some others that it was pieced together from also used it. So far as I know the
only good reason to launch with an expect script is if the launcher will have
some real interaction with the user. e.g. ask them if they're sure they want to
continue even if they're not on the correct file system or something.

Using the expect script added a carriage return to all output lines which
screwed up testing diffs. This just removes the use of expect and replaces it
with a direct call to srun for interactive jobs. This makes no changes for
batch jobs.

With this change things like "start_test test/release/examples/hello.chpl" will
just work on slurm systems without needing to throw any extra arguments or
having to use the launchcmd
