### PR TITLE
Turn off stdin redirect warning in checkChplInstall (used by 'make check')

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -145,6 +145,10 @@ cp $TESTS $TMP_TEST_DIR/
     # Run the tests.
     echo "Running the hello world tests found in: $TEST_DIR"
 
+    # Silence warning if running without stdin redirection support (should not
+    # matter for hello tests anyways)
+    export CHPL_TEST_NO_WARN_NO_STDIN_REDIRECT=true
+
     $CHPL_HOME/util/start_test --no-chpl-home-warn --progress $CHPL_START_TEST_ARGS *.chpl > $test_output_log
 
     test_status=$?


### PR DESCRIPTION
Silence warning if running without stdin redirection support (should not matter
for hello tests anyways)

Depending on the launcher being used stdin redirection is not supported, we
warn if we automatically detect that stdinredirection is not supported. This
just silences that warning for the checkChplInstall script so that make check
works on such systems
