### PR TITLE
Fix stdin support when multiple lines in .execopts.

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1336,8 +1336,16 @@ for testname in testsrc:
         if len(clist)!=0:
             if len(clist[0].split('#')) > 1:
                 explicitcompgoodfile = clist[0].split('#')[1].strip()
+        redirectin_set_in_loop = False
+        redirectin_original_value = redirectin
         for texecopts in execoptslist:
             sys.stdout.flush()
+
+            # Reset redirectin, in case execopts has multiple lines with
+            # different stdin files.
+            if redirectin_set_in_loop:
+                redirectin = redirectin_original_value
+                redirectin_set_in_loop = False
 
             if (len(compoptslist)==1) and (len(execoptslist)==1):
                 onlyone = True
@@ -1422,6 +1430,7 @@ for testname in testsrc:
               if redirectin == None or redirectin == "/dev/null":
                 if os.access(execOptRedirect, os.R_OK):
                   redirectin = execOptRedirect
+                  redirectin_set_in_loop = True
                 else:
                   sys.stdout.write('[Error: redirection file %s does not exist]\n'%(execOptRedirect))
                   break


### PR DESCRIPTION
Previously, a .execopts file like the one below would successfully run with
green.txt, but would fail when running the second configuration for red.txt:

```
< green.txt  # cond.if.green.good
< red.txt    # cond.if.red.good
< yellow.txt # cond.if.yellow.good
```

Error message:

```
...
[Executing program ./cond.if  < green.txt]
[Executing diff cond.if.green.good cond.if.0-1.exec.out.tmp]
[Success matching program output for /Users/tvandoren/src/pytochpl/docs/source/examples/cond.if]
[Error: a redirection file already exists: green.txt]
```

The error is coming from the second iteration of the .execopts loop because the
stdin file is not reset with each loop.

Update sub_test to track when stdin file is modified by .execopts and reset at
the beginning of each .execopts iteration.
