### PR TITLE
Turn of warning when stdin redirection isn't supported

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1175,13 +1175,11 @@ setenv CHPL_LOCALE_MODEL $locMod
 
 # we know that stdin redirection doesn't work for most launchers. only do
 # redirection when there's no launcher, or the launcher is amudprun, which we
-# know supports stdin redirection. Warn user about skipping tests unless they
-# threw -nostdinredirect or -stdinredirect or if env var is set to silence it
+# know supports stdin redirection. Only set and alert user unless they threw
+# -nostdinredirect or -stdinredirect
 if ($launcher != "none" && $launcher != "amudprun") then
     if (! $?CHPL_NO_STDIN_REDIRECT && ! $?CHPL_TEST_FORCE_STDIN_REDIRECT ) then
-        if (! $?CHPL_TEST_NO_WARN_NO_STDIN_REDIRECT) then
-            echo "[Warning: assuming stdin redirection is not supported, skipping tests with stdin]" |& $tee -a $logfile
-        endif
+        echo "[Info: assuming stdin redirection is not supported, skipping tests with stdin]" |& $tee -a $logfile
         setenv CHPL_NO_STDIN_REDIRECT true
     endif
 endif


### PR DESCRIPTION
start_test auto detects when stdin redirection isn't supported and warned the
user that it was going to skip tests with stdin. The warning proved move
annoying than useful especially since it made things like 'make check' fail.
This removes the warning and just turns it into an 'Info' message. The user
won't see it reported at the end of test summary but that seems fine.
