### PR TITLE
Fix sub_test env var setting

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1007,10 +1007,8 @@ for testname in testsrc:
     else:
         execenv = list()
 
-    if len(globalExecenv)==0 and len(execenv)==0:
-        testenv = os.environ
-    else:
-        testenv = os.environ.copy()
+    testenv = {}
+    if len(globalExecenv)!=0 or len(execenv)!=0:
         for tev in globalExecenv:
             testenv[tev.split('=')[0].strip()] = tev.split('=')[1].strip()
         for tev in execenv:
@@ -1459,7 +1457,7 @@ for testname in testsrc:
                         my_stdin=file(redirectin, 'r')
                     test_command = [cmd] + LauncherTimeoutArgs(timeout) + args
                     p = subprocess.Popen(test_command,
-                                        env=testenv,
+                                        env=dict(os.environ.items() + testenv.items()),
                                         stdin=my_stdin,
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.STDOUT)
@@ -1489,7 +1487,7 @@ for testname in testsrc:
                     else:
                         my_stdin = file(redirectin, 'r')
                     p = subprocess.Popen([timedexec, str(timeout), wholecmd],
-                                        env=testenv,
+                                        env=dict(os.environ.items() + testenv.items()),
                                         stdin=my_stdin,
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.STDOUT)
@@ -1511,7 +1509,7 @@ for testname in testsrc:
                     else:
                         my_stdin=file(redirectin, 'r')
                     p = subprocess.Popen([cmd]+args,
-                                        env=testenv,
+                                        env=dict(os.environ.items() + testenv.items()),
                                         stdin=my_stdin,
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.STDOUT)


### PR DESCRIPTION
If a .execenv or EXECENV file existed, subtest would copy the environment and
add whatever things were in the execenv  to it and then pass that new
environment to the test. However if sub_test set an env var after that new env
was created, that env var was not passed to the test.

This just updates how subtest adds .execenvs or EXECENV entries to the
environment. Not it just adds those to a temp list and adds that temp list to
the real environment as it's passing it to the test
