### PR TITLE
Skip test/io/ferguson/qio_test.test.c for Cygwin

### DIFF
--- a/test/io/ferguson/ctests/qio_test.skipif
+++ b/test/io/ferguson/ctests/qio_test.skipif
@@ -1,3 +1,8 @@
 # For valgrind, instead of this test
 # use its duplicate, qio_test.valgrind.test.c
 CHPL_TEST_VGRND_EXE == on
+# This test will not work on Cygwin, because it
+# depends on lseek and lseek on Cygwin breaks
+# assumptions about bytes read as an indicator
+# of your position in the file.
+CHPL_HOST_PLATFORM == cygwin

--- a/test/io/ferguson/ctests/qio_test.test.c
+++ b/test/io/ferguson/ctests/qio_test.test.c
@@ -2,6 +2,13 @@
 #include <assert.h>
 #include <stdio.h>
 
+// TODO (12/05/14): This test makes use of lseek and then
+// reads through the file, using bytes read as an indicator
+// of position.  On Cygwin, you can't depend on that
+// indicator being accurate, so the test fails. We should
+// rewrite this test to be more portable and look for
+// similar assumptions in our qio code.
+
 int verbose = 0;
 
 unsigned char data_at(int64_t offset)


### PR DESCRIPTION
This test depends on lseek to reset its position within a file,
and then reads a certain number of bytes to determine the file's
length.  However, on Cygwin, the use of lseek means that processes
reading text files can't depend on the number of bytes read to
determine their position within a file.  This test should be
rewritten for cygwin portability, and our qio runtime code checked
for similar assumptions.  Until then, it is not useful there.
