### PR TITLE
Removed checks and assertions used with form_Map().

### DIFF
--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -132,7 +132,7 @@ void pruneOuterVars(SymbolMap* uses, CallExpr* byrefVars) {
 // While there, we prune other things for forall intents.
 void pruneThisArg(Symbol* parent, SymbolMap* uses, bool pruneMore) {
   form_Map(SymbolMapElem, e, *uses) {
-    if (Symbol* sym = e->key) {
+      Symbol* sym = e->key;
       if (e->value != markPruned) {
         if (sym->hasFlag(FLAG_ARG_THIS) ||
             // If we do not prune MT, _toLeader(..., _mt...) does not get
@@ -152,14 +152,13 @@ void pruneThisArg(Symbol* parent, SymbolMap* uses, bool pruneMore) {
           e->value = markPruned;
         }
       }
-    }
   }
 }
 
 static void
 addVarsToFormals(FnSymbol* fn, SymbolMap* vars) {
   form_Map(SymbolMapElem, e, *vars) {
-    if (Symbol* sym = e->key) {
+      Symbol* sym = e->key;
       if (e->value != markPruned) {
         SET_LINENO(sym);
         ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, sym->name, sym->type);
@@ -167,9 +166,8 @@ addVarsToFormals(FnSymbol* fn, SymbolMap* vars) {
           if (symArg->hasFlag(FLAG_MARKED_GENERIC))
             arg->addFlag(FLAG_MARKED_GENERIC);
         fn->insertFormalAtTail(new DefExpr(arg));
-        vars->put(sym, arg); // todo: instead e->value = arg; ?? see also in implementForallIntents
+        e->value = arg;  // aka vars->put(sym, arg);
       }
-    }
   }
 }
 
@@ -179,8 +177,7 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
   Vec<BaseAST*> asts;
   collect_asts(fn->body, asts);
   form_Map(SymbolMapElem, e, *vars) {
-    INT_ASSERT(e->key); // todo: if this succeeds, remove such 'if' throughout
-    if (Symbol* sym = e->key) {
+      Symbol* sym = e->key;
       if (e->value != markPruned) {
         SET_LINENO(sym);
         ArgSymbol* arg = toArgSymbol(e->value);
@@ -192,19 +189,17 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
           }
         }
       }
-    }
   }
 }
 
 static void
 addVarsToActuals(CallExpr* call, SymbolMap* vars) {
   form_Map(SymbolMapElem, e, *vars) {
-    if (Symbol* sym = e->key) {
+      Symbol* sym = e->key;
       if (e->value != markPruned) {
         SET_LINENO(sym);
         call->insertAtTail(sym);
       }
-    }
   }
 }
 

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -125,7 +125,6 @@ static void createShadowVars(SymbolMap* uses, int& numOuterVars,
   numOuterVars = 0;
 
   form_Map(SymbolMapElem, e, *uses) {
-    INT_ASSERT(e->key); // todo: if holds, remove 'if' throughout
     if (e->value != markPruned) {
       Symbol* ovar = e->key;
       // If ovar is a reference, e.g. an index variable of
@@ -296,7 +295,6 @@ replaceVarUsesWithFormals(Expr* block, SymbolMap* vars) {
   collectSymExprsSTL(block, symExprs);
   form_Map(SymbolMapElem, e, *vars) {
     Symbol* sym = e->key;
-    INT_ASSERT(sym); // todo: if this succeeds, remove such 'if' elsewhere
     if (e->value != markPruned) {
       SET_LINENO(sym);
       Symbol* arg = e->value;


### PR DESCRIPTION
The files createTaskFunctions.cpp and implementForallIntents.cpp
contained these idioms:

  form_Map(SymbolMapElem, e, ...) {
    INT_ASSERT(e->key);
    ...

and/or

  form_Map(SymbolMapElem, e, ...) {
    if (Symbol\* sym = e->key) {
      ...

Since the 'form_Map' macro only yields non-NULL things by design,
the above assert and check are not needed. I am removing them.

I also replaced:      vars->put(sym, arg);
with the equivalent:  e->value = arg;
for efficiency.

These changes can also be applied to flattenFunctions.cpp.
I did not do so, to keep that code undisturbed.
