### PR TITLE
Add a space after node ID (upon --gen-ids).

### DIFF
--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -55,7 +55,7 @@ void codegenStmt(Expr* stmt) {
     }
 
     if (fGenIDS)
-      info->cStatements.push_back("/* " + numToString(stmt->id) + "*/ ");
+      info->cStatements.push_back("/* " + numToString(stmt->id) + " */ ");
   }
 
   ++gStmtCount;


### PR DESCRIPTION
There is often a space missing after the node ID in the generated code, e.g.:

  /\* 889339*/ ret = type_tmp;

This space disappeared due to 23311c03 aka r20461, which commit
was unrelated:

before:     info->cStatements.push_back("/\* " + numToString(stmt->id) + "_/ ");
after:     fprintf(outfile, "/_ %7d */ ", stmt->id);

I am restoring this space for convenience highlighting in emacs
and for consistency.
