### PR TITLE
Allow this test to fail again.

### DIFF
--- a/test/io/ferguson/ctests/qio_test.skipif
+++ b/test/io/ferguson/ctests/qio_test.skipif
@@ -1,8 +1,3 @@
 # For valgrind, instead of this test
 # use its duplicate, qio_test.valgrind.test.c
 CHPL_TEST_VGRND_EXE == on
-# This test will not work on Cygwin, because it
-# depends on lseek and lseek on Cygwin breaks
-# assumptions about bytes read as an indicator
-# of your position in the file.
-CHPL_HOST_PLATFORM <= cygwin


### PR DESCRIPTION
For other's sanity, allow this test to continue to fail on cygwin until we fix
it to be more portable and look into whether qio makes similar assumptions.
