### PR TITLE
uniquify dygraph csv names

### DIFF
--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -404,7 +404,7 @@ class GraphClass:
                  _expand=0, _sort=True):
         self.id = GraphClass.gid
         GraphClass.gid += 1
-        self.name = _name.strip()
+        self.name = str(GraphClass.gid) + _name.strip()
         self.srcdatfname = self.name+'.dat'
         self.title = ''
         self.suites = _suites
@@ -420,7 +420,7 @@ class GraphClass:
         self.displayrange = _displayrange
         self._reduce = _reduce
         self.expand = _expand
-        self.sort = _sort 
+        self.sort = _sort
         self.annotations = []
 
     def __str__(self):


### PR DESCRIPTION
We had a STREAM.graph and stream.graph file. One of which overrode the other.
This makes the filename unique. This isn't a great means of making the name
unique.

I'll come back to it later (I ran into this with my other graph work) and add
a check or a better way to make it unique.  There should also probably be a
check to make sure the graph titles are unique.
