### PR TITLE
Alter -E annotation.

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -63,15 +63,15 @@ dgemm.64:
 
 ep:
   11/18/14:
-    - added -E to tests which would benefit from it
+    - added E option to tests which would benefit from it
   11/22/14:
-    - revert -E use for nightly on 21st (which failed, unrelatedly)
+    - revert E option use for nightly on 21st (which failed, unrelatedly)
 
 ep-b:
   11/18/14:
-    - added -E to tests which would benefit from it
+    - added E option to tests which would benefit from it
   11/22/14:
-    - revert -E use for nightly on 21st (which failed, unrelatedly)
+    - revert E option use for nightly on 21st (which failed, unrelatedly)
 
 fannkuch-redux:
   07/22/14:
@@ -93,9 +93,9 @@ is:
   09/05/14:
     - switched uses of locale.numCores to locale.maxTaskPar
   11/18/14:
-    - added -E to tests which would benefit from it
+    - added E option to tests which would benefit from it
   11/22/14:
-    - revert -E use for nightly on 21st (which failed, unrelatedly)
+    - revert E option use for nightly on 21st (which failed, unrelatedly)
 
 lulesh:
   03/15/14:


### PR DESCRIPTION
I noticed that annotations were not turning up for any category other than those
under "all".  This was my most recent change to the ANNOTATIONS file, so check
that this isn't the problem (I know it last worked around October 15th-16th, that
was the only change to it since then).
