### PR TITLE
Add annotations for performance changes from 12/05, 11/09

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -44,10 +44,16 @@ all:
     - switch default memory allocator from cstdlib to tcmalloc
   09/12/14:
     - switch default memory allocator back to cstdlib
+  11/09/14:
+    - disable the task table by default
 
 bfs:
   09/25/14:
     - addition of octal to, reformatting of format printing.
+
+binary-trees:
+  12/05/14:
+    - introduce "library mode"
 
 chameneos-redux:
   07/08/13:
@@ -100,6 +106,8 @@ is:
 lulesh:
   03/15/14:
     - improved constness of de-nested functions, improved remove value forwarding
+  12/05/14:
+    - introduce "library mode"
 
 lulesh-dense:
   03/15/14:


### PR DESCRIPTION
Simon's library mode commit seems to have impacted LULESH and binary-trees.
This doesn't quite make sense, but it's definitely the commit.  I will
investigate further into why this changed and if the impact can be reversed.

We also forgot to note when Brad turned off the task table, improving
compilation and the size of the generated code
