### PR TITLE
Remove extraneous add to inits in function resolution.

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4690,8 +4690,6 @@ preFold(Expr* expr) {
           result = call;
           inits.add(call);
         }
-
-        inits.add(call);
       }
 
     } else if (call->isPrimitive(PRIM_TYPEOF)) {


### PR DESCRIPTION
This line was the result of a bad "cut" command.  It was part of a previous if
clause that got removed, and somehow that left it in a different if clause than
where it started.  I reviewed the commit that allowed this, I should've caught
it.  The add was harmless, as it would be dead code the second time it was
reached and so skipped, but still.
