### PR TITLE
Update .bad file and retire a future

### DIFF
--- a/test/functions/iterators/sungeun/iterInClass.future
+++ b/test/functions/iterators/sungeun/iterInClass.future
@@ -1,8 +1,0 @@
-bug: Iterator returning locale type gets internal error in resolveIntents
-
-The test gets the following error for the getChildren() method.
-
-  iterInClass.chpl:2: error: Unhandled type in blankIntentForType() [resolveIntents.cpp:59]
-
-Note that this does not happen when there is only one class with a
-method called getChildren().

--- a/test/functions/iterators/tvandoren/enumerate.bad
+++ b/test/functions/iterators/tvandoren/enumerate.bad
@@ -1,2 +1,3 @@
 enumerate.chpl:12: error: illegal use of module 'enumerate'
 enumerate.chpl:17: error: illegal use of module 'enumerate'
+enumerate.chpl:17: error: illegal use of module 'enumerate'


### PR DESCRIPTION
iterInClass now passes so I am retiring the future.

enumerate now has an extra line in the output, but the test still fails.
I've updated the .bad file to match the current output.
