### PR TITLE
REGRESSIONS update based on the morning's returns

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -52,11 +52,17 @@ general
 Reviewed 2014-12-08
 ===================
 
+
+Should now be fixed, but still working its way out of testing
+(gasnet-everything, gasnet-fast, gasnet.fifo, numa, xe-wb.*)
+-------------------------------------------------------------
+[Error matching .bad file for functions/iterators/tvandoren/enumerate]
+
+
 failure due to lack of symbolic link support in jgit (vass, bradc, thomas)
 (linux32, x?-wb.*)
 --------------------------------------------------------------------------
-[Error (sub_test): Invalid integer value in m-lsms.par-forall.numlocales (studies/lsms/shemmy)] (passed on 2014-11-16, 2014-11-18)
-[Error running sub_test in /.../test/studies/lsms/shemmy (255)] (passed for xe-wb.gnu on 2014-11-16, 2014-11-18)
+[Error (sub_test): Invalid integer value in m-lsms.par-forall.numlocales (studies/lsms/shemmy)]
 [Error matching program output for studies/filerator/walk (execopts: 9)]
 
 ===================
@@ -140,8 +146,8 @@ sporadic timeout
 
 sporadic signal 11
 ------------------
-[Error matching program output for stress/deitz/test_10k_begins] (2014-11-13..2014-12-09)
-[Error matching program output for parallel/begin/dinan/mvm_coforall] (2014-11-21, 2014-11-27)
+[Error matching program output for stress/deitz/test_10k_begins] (2014-11-13..2014-12-09, 2014-12-15)
+[Error matching program output for parallel/begin/dinan/mvm_coforall] (2014-11-21, 2014-11-27, 2014-12-15)
 
 sporadic tasks not being created
 --------------------------------
@@ -247,8 +253,21 @@ Reviewed 2014-12-08
 ==================
 valgrind
 Inherits 'general'
-Reviewed 2014-12-08
+Reviewed 2014-12-16
 ===================
+
+invalid read in compiler (2014-12-13 -- diten, presumed due to standalone par)
+------------------------------------------------------------------------------
+[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader1]
+[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader2]
+[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader3]
+[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader4]
+[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader]
+[Error matching program output for functions/iterators/sungeun/iterInClass]
+[Error matching program output for multilocale/vass/recursive-iterator-twice-multiloc]
+[Error matching program output for studies/colostate/Jacobi-1D-Diamond-Tiling]
+[Error matching program output for studies/colostate/Jacobi-1D-Sliced-Diamond-Tiling]
+[Error matching program output for studies/glob/test_glob (compopts: 1)]
 
 conditional jump depends on uninitialized value (2014-04-08 -- since re2 on)
 ----------------------------------------------------------------------------
@@ -386,7 +405,7 @@ sporadic failures even after Sung quieted it down (frequently -- gbt/diten)
 
 sporadic timeouts (frequent)
 ----------------------------
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_gaxpy] (2014-10-19, 2014-10-24, 2014-11-11, 2014-11-14)
+[Error: Timed out executing program studies/madness/aniruddha/madchap/test_gaxpy] (2014-10-19, 2014-10-24, 2014-11-11, 2014-11-13, 2014-12-13, 2014-12-15)
 [Error: Timed out executing program studies/madness/aniruddha/madchap/test_mul] (2014-10-23, 2014-10-28, 2014-10-31, 2014-11-02, 2014-11-04, 2014-11-08, 2014-11-10)
 
 sporadic timeouts (infrequent)
@@ -709,6 +728,13 @@ Error tolerance exceeded?: First run 2014-12-07
 -----------------------------------------------
 [Error matching program output for studies/hpcc/PTRANS/PTRANS]
 [Error matching program output for studies/hpcc/PTRANS/jglewis/ptrans_2011]
+
+=== sporadic failures below ===
+
+sporadic os.unlink calls in sub_test failing due to resource being busy
+=======================================================================
+[Error running sub_test in *] (2014-12-11, 2014-12-12, 2014-12-15)
+
 
 ===================
 cygwin64


### PR DESCRIPTION
Update to REGRESSIONS based on the morning's returns and some housecleaning:

Improvements:
- removed the general "Error running sub-test for studies/lsms/shemmy" which I think was fixed some time ago when Thomas changed the way start_test/sub_test report known failures

Regressions:
- added an entry for valgrind regressions that started Saturday, apparently due to standalone parallel iterators
- noted the sporadic failures of sub_test due to failed os.unlink calls on cygwin32 which are not resolved as hoped and added back dates for recent cases

Misc:
- tvandoren/enumerate is starting to pass, but hasn't worked its way out of the system yet, so I added an entry to track the remaining failing cases
- added a few recent dates to sporadic failures that happened to be in my inbox
