### PR TITLE
Default to fifo for cray compiler

### DIFF
--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_platform
+import chpl_arch, chpl_platform, chpl_compiler
 from utils import memoize
 
 @memoize
@@ -10,7 +10,9 @@ def get():
     if not tasks_val:
         arch_val = chpl_arch.get('target', get_lcd=True)
         platform_val = chpl_platform.get()
-        if arch_val == 'knc' or platform_val.startswith('cygwin'):
+        compiler_val = chpl_compiler.get('target')
+        if (arch_val == 'knc' or platform_val.startswith('cygwin') or
+                compiler_val == 'cray-prgenv-cray'):
             tasks_val = 'fifo'
         else:
             tasks_val = 'qthreads'


### PR DESCRIPTION
We have some things to address with qthreads and the cray compiler that are
causing noise in nightly testing (because cce doesn't support inline asm, but
qthreads doesn't properly detect or handle this.)

Until we get the issue resolved, default to fifo to quiet nightly testing.
