### PR TITLE
Adding one typeselect future and one test showing its pointless

### DIFF
--- a/test/statements/typeselect/deprecateTypeSelect-real.good
+++ b/test/statements/typeselect/deprecateTypeSelect-real.good
@@ -1,0 +1,2 @@
+x is real!
+pickType() returns real!

--- a/test/statements/typeselect/deprecateTypeSelect.chpl
+++ b/test/statements/typeselect/deprecateTypeSelect.chpl
@@ -1,0 +1,31 @@
+//
+// The point of this test is that 'type select' is an unnecessary
+// concept.  We should just use select on type expressions.  I was
+// going to make this a feature request future, but it turns out
+// that it already works.  Nice!
+//
+
+config param useInt = true;
+
+proc pickType() type {
+  if useInt then 
+    return int;
+  else 
+    return real;
+}
+
+var x: pickType();
+
+write("x is ");
+select (x.type) {
+ when int do writeln("int!");
+ when real do writeln("real!");
+ otherwise writeln("confused!");
+}
+
+write("pickType() returns ");
+select (pickType()) {
+ when int do writeln("int!");
+ when real do writeln("real!");
+ otherwise writeln("confused!");
+}

--- a/test/statements/typeselect/deprecateTypeSelect.compopts
+++ b/test/statements/typeselect/deprecateTypeSelect.compopts
@@ -1,0 +1,3 @@
+-suseInt=true
+-suseInt=false #deprecateTypeSelect-real.good
+

--- a/test/statements/typeselect/deprecateTypeSelect.good
+++ b/test/statements/typeselect/deprecateTypeSelect.good
@@ -1,0 +1,2 @@
+x is int!
+pickType() returns int!

--- a/test/statements/typeselect/twoTypeSelects.bad
+++ b/test/statements/typeselect/twoTypeSelects.bad
@@ -1,0 +1,7 @@
+twoTypeSelects.chpl:13: error: ambiguous call '_typeselect1(int(64))'
+twoTypeSelects.chpl:13: note: candidates are: _typeselect1(_t1: int(64))
+twoTypeSelects.chpl:13: note:                 _typeselect1(_t1: real(64))
+twoTypeSelects.chpl:13: note:                 _typeselect1(_t1)
+twoTypeSelects.chpl:20: note:                 _typeselect1(_t1: int(64))
+twoTypeSelects.chpl:20: note:                 _typeselect1(_t1: real(64))
+twoTypeSelects.chpl:20: note:                 _typeselect1(_t1)

--- a/test/statements/typeselect/twoTypeSelects.chpl
+++ b/test/statements/typeselect/twoTypeSelects.chpl
@@ -1,0 +1,24 @@
+config param useInt = true;
+
+proc pickType() type {
+  if useInt then 
+    return int;
+  else 
+    return real;
+}
+
+var x, y: pickType();
+
+write("x is ");
+type select x {
+  when int do writeln("int!");
+  when real do writeln("real!");
+  otherwise writeln("confused!");
+}
+
+write("y is ");
+type select x {
+  when int do writeln("int!");
+  when real do writeln("real!");
+  otherwise writeln("confused!");
+}

--- a/test/statements/typeselect/twoTypeSelects.future
+++ b/test/statements/typeselect/twoTypeSelects.future
@@ -1,0 +1,10 @@
+bug: multiple type selects (with overlapping cases?) break compilation
+
+This test seems to show that if a single file contains multiple type
+selects (or perhaps "multiple type selects with overlapping type
+cases"), the compilation breaks due to the implementation approach
+used for the type selects.  In particular, it seems that functions are
+created for each case but without making the function names unique for
+each type select statement.  This could probably be fixed simply by
+keeping a counter of type select statements and using that to uniquify
+the names of the functions for each statement.

--- a/test/statements/typeselect/twoTypeSelects.good
+++ b/test/statements/typeselect/twoTypeSelects.good
@@ -1,0 +1,2 @@
+x is int!
+y is int!


### PR DESCRIPTION
twoTypeSelects.chpl shows that the current implementation of
type select does not support multiple type selects in a single
Chapel program.  D'oh!  It's probably a five-minute fix to get
this working if one cared to.  By the time I'd written up the
description in the .future, it seemed like I also had the
solution.  But...

deprecateTypeSlect.chpl shows the syntax I'd prefer to use for
"type select" statements and was intended as a feature request
future; but it turns out to work.  So it raises the question
"Do we even need a type select anymore?"  Until someone argues
convincingly otherwise, my answer is "no, it seems like we
don't."
