### PR TITLE
Change range's 'by' functions for param strides

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -689,52 +689,42 @@ module ChapelRange {
   
     return new range(i, b, true,  lw, hh, st, alt, ald);
   }
-  
-  
+
+
   proc by(r : range(?i,?b,?s), step:chpl__unsignedType(i))
   {
     return chpl_by_help(r, step);
   }
-  
-  
+
   proc by(r : range(?i,?b,?s), step:chpl__signedType(i))
   {
     return chpl_by_help(r, step);
   }
-  
-  proc by(r : range(?i,?b,?s), param step:chpl__unsignedType(i))
+
+  // We want to warn the user at compiler time if they had an invalid param
+  // stride rather than waiting until runtime. However, we don't want to stamp
+  // out a by function for every valid param stride, so these only handle
+  // invalid cases, and let the non-param cases above handle values known at
+  // compile time that are non-zero
+  proc by(r : range(?i,?b,?s), param step:chpl__unsignedType(i)) where step == 0
   {
-    if (step == 0) then
-      compilerError("the 'by' operator cannot take a value of zero");
-  
-  // This should work, but doesn't correctly -- test/types/range/hilde/by.chpl
-  // is max(step.type) not correctly a param in some way?
-  /*
-    if (step == max(step.type)) then
-      compilerError("the 'by' operator cannot take a value this large");
-  */
-  
-    return chpl_by_help(r, step);
+    compilerError("the 'by' operator cannot take a value of zero");
   }
-  
-  
-  proc by(r : range(?i,?b,?s), param step:chpl__signedType(i))
+
+  proc by(r : range(?i,?b,?s), param step:chpl__signedType(i)) where step == 0
   {
-    if (step == 0) then
-      compilerError("the 'by' operator cannot take a value of zero");
-  
-    return chpl_by_help(r, step);
+    compilerError("the 'by' operator cannot take a value of zero");
   }
-  
-  
+
   proc by(r : range(?i,?b,?s), step)
   {
-    compilerError("can't apply 'by' to a range with idxType ", 
-                  typeToString(i), " using a step of type ", 
+    compilerError("can't apply 'by' to a range with idxType ",
+                  typeToString(i), " using a step of type ",
                   typeToString(step.type));
     return r;
   }
-  
+
+
   // This is the syntax processing routine for the "align" keyword.
   // It produces a new range with the specified alignment.
   // By definition, alignment is relative to the low bound of the range.


### PR DESCRIPTION
We have versions of 'by' that take the stride as a param in order to check at
compile time if the stride was 0 rather than waiting until runtime. However
this means that for all non-zero param strides a new function is stamped out
which adds bloat to the generated code. This just adds a "where step == 0"
clause to the functions so that we still get the compiler time warning without
stamping out a function for valid param steps.
