### PR TITLE
Potential indexing performance improvement for DefaultRectangular

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -701,8 +701,10 @@ module DefaultRectangular {
         return sum;
       } else {
         var sum = if earlyShiftData then 0:idxType else origin;
-        for param i in 1..rank do
-          sum += ind(i) * blk(i);
+        for param i in 1..rank {
+          if blk(i) == 1 then sum += ind(i);
+          else sum += ind(i) * blk(i);
+        }
         if !earlyShiftData then sum -= factoredOffs;
         return sum;
       }


### PR DESCRIPTION
This change was observed to have performance improvements for the CSU Jacobi code with gcc4.7 at both large and small problem sizes. Chapel was competitive with the reference version up to "-O2", but at "-O3" the reference version pulled ahead. This change brings Chapel much closer to the CSU OMP reference version.

This change passed parallel testing for a single node.

I have not measured other performance benchmarks yet to look for an improvement.

This patch was reviewed offline by @bradcray.
