### PR TITLE
When OPTIMIZE!=1, use the -hdevelop feature on CCE.

### DIFF
--- a/make/compiler/Makefile.cray-prgenv-cray
+++ b/make/compiler/Makefile.cray-prgenv-cray
@@ -21,6 +21,14 @@ CRAYPE_GEN_CFLAGS = -hnomessage=7212 -hipa2
 NO_IEEE_FLOAT_GEN_CFLAGS = -hfp1
 IEEE_FLOAT_GEN_CFLAGS = -hfp0
 
+# If this is not a --fast compilation or OPTIMIZE=1 is not set, use the cce
+# develop feature. It improves compiler time by throtting certain things in the
+# compiler that are known to add time. It is not the same as -O0. See the man
+# page for details.
+ifneq ($(OPTIMIZE),1)
+CFLAGS += -hdevelop
+endif
+
 #
 # The current Cray compiler does not compile GASNet cleanly, so we have
 # to compile GASNet code using the gnu version instead


### PR DESCRIPTION
If this is not a --fast compilation or OPTIMIZE=1 is not set, use the cce
-hdevelop feature. It improves compiler time by throttling certain things in the
compiler that are known to add time. It is not the same as -O0. See the man
page for details.
### How much of a difference does -hdevelop make?

On a Cray system, using the quickstart configuration and
CHPL_LAUCHER=none, using `-hdevelop` is ~20% faster when
compiling `hello.chpl`. 

I did this with master and this branch to get the above results:

``` bash
git checkout <branch>
source util/quickstart/setchplenv.bash
module load PrgEnv-cray
export CHPL_LAUNCHER=none
make -j
make check  # verify things work

# verify -hdevelop is present, or not
chpl --print-commands test/release/examples/hello.chpl
# -hdevelop should never be present with --fast
chpl --fast --print-commands test/release/examples/hello.chpl

# test it
for i in $(seq 1 5) ; do echo $i ; time chpl test/release/examples/hello.chpl ; done
```

With -hdevelop the real time for each of the compiles was 8.0 seconds (+/- some
hundredths). Without -hdevelop (i.e. on master) the real time for each of the compiles
was 9.8-10.3 seconds.

I did not test compile time for bigger codes or other configurations.
