### PR TITLE
Followup: Potential indexing performance improvement

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -702,11 +702,18 @@ module DefaultRectangular {
         return sum;
       } else {
         var sum = if earlyShiftData then 0:idxType else origin;
-        for param i in 1..rank {
-          if assertNoSlicing {
-            if blk(i) == 1 then sum += ind(i);
-            else sum += ind(i) * blk(i);
-          } else {
+
+        // If the user asserts that there is no slicing in their program,
+        // then blk(rank) == 1. Knowing this, we need not multiply the final
+        // ind(...) by anything. This may lead to performance improvements for
+        // array accesses.
+        if assertNoSlicing {
+          for param i in 1..rank-1 {
+            sum += ind(i) * blk(i);
+          }
+          sum += ind(rank);
+        } else {
+          for param i in 1..rank {
             sum += ind(i) * blk(i);
           }
         }


### PR DESCRIPTION
This is a followup to #1030 which made modifications to the way we indexed into a DefaultRectangular array. Performance results indicated that while #1030 positively affected some tests, others regressed.

This patch adds a config param flag that lets users assert that there is no slicing in their program. If there is no slicing, we can avoid using the conditional from #1030, which may lead to better performance. Otherwise, we use the original method of multiplying ind by blk. This flag is off by default.
