### PR TITLE
Update pbs-aprun launcher to use place/select for pbspro

### DIFF
--- a/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
+++ b/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
@@ -173,10 +173,10 @@ static char* genQsubOptions(char* genFilename, char* projectString, qsubVersion 
     }
     break;
   case pbspro:
-    if (generate_qsub_script) { 
+    if (generate_qsub_script) {
       // We always want to use scatter since we use one PE per node
       fprintf(qsubScript, "#PBS -l place=scatter\n");
-      fprintf(qsubScript, "#PBS -lselect=%d:ncpus=%d\n", numLocales, numCoresPerLocale);
+      fprintf(qsubScript, "#PBS -l select=%d:ncpus=%d\n", numLocales, numCoresPerLocale);
     } else {
       // We always want to use scatter since we use one PE per node
       length += snprintf(optionString + length, maxOptLength - length,


### PR DESCRIPTION
The mpp\* options have been deprecated (but still functional) for a while. Many
systems are completely disabling the mpp\* options so we need to adjust to use
the place/select options for pbspro. For moab/torque we already used a different
set of options to request resources.
