### PR TITLE
Fix --walltime parsing for sub_test

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -177,15 +177,13 @@ def SuckOutputWithTimeout(stream, timeout):
             # to timeout  which doesn't seem quite right either.
     return buffer
 
-def LauncherTimeoutArgs(timeout):
+def LauncherTimeoutArgs(seconds):
     if useLauncherTimeout == 'pbs' or useLauncherTimeout == 'slurm':
         # --walltime=hh:mm:ss
-        hours = 0
-        minutes = timeout / 60  # might be OK even if over an hour
-        seconds = timeout % 60
-        option = '--walltime=' + str(hours) + ':' + str(minutes) \
-                 + ':' + str(seconds)
-        return [option]
+        m, s = divmod(seconds, 60)
+        h, m = divmod(m, 60)
+        fmttime = '--walltime={0:02d}:{1:02d}:{2:02d}'.format(h, m, s)
+        return [fmttime]
     else:
         Fatal('LauncherTimeoutArgs encountered an unknown format spec: ' + \
               useLauncherTimeout)


### PR DESCRIPTION
When passing --walltime to the executable (for slurm and pbs) the string we
created was only valid for times under 100 minutes. After that it became
invalid. We never run into this in nightly testing, but I ran into it when
trying to see how long hpl release would take to finish for gasnet+mpi
