### PR TITLE
Remove compilerWarnings after they have been issued

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6694,8 +6694,6 @@ resolve() {
 
   pruneResolvedTree();
 
-  removeCompilerWarnings();
-
   freeCache(ordersCache);
   freeCache(defaultsCache);
   freeCache(genericsCache);
@@ -7305,6 +7303,7 @@ pruneResolvedTree() {
   removeWhereClauses();
   removeMootFields();
   expandInitFieldPrims();
+  removeCompilerWarnings();
 }
 
 static void removeUnusedFunctions() {


### PR DESCRIPTION
This patch removes compilerWarnings at the end of function resolution, after they have served their purpose. When they were left in the program, we would leak the string every time the function was called.
- [x] Passed single-node testing
