### PR TITLE
Enabled simple-alias-mem-use.chpl under gasnet.

### DIFF
--- a/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.skipif
+++ b/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.skipif
@@ -1,2 +1,0 @@
-# Does not run reliably on gasnet. See crash-memory-module-1.future.
-CHPL_COMM!=none


### PR DESCRIPTION
This test:
  test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.chpl
used to fail intermittently under gasnet.

The failure was represented by
  test/memory/vass/crash-memory-module-1.chpl
which was handled in r22223 aka 7209b2d a year ago.

I propose to enable simple-alias-mem-use.chpl under gasnet and see if it succeeds there consistently.
