### PR TITLE
Skip anonymous iter optimization test for llvm

### DIFF
--- a/test/types/range/elliot/anonymousRangeIter.skipif
+++ b/test/types/range/elliot/anonymousRangeIter.skipif
@@ -4,3 +4,6 @@ CHPL_COMM != none
 # baseline will leave the generated code without iterator optimizations and
 # inlining turned on so the output will be drastically different
 COMPOPTS <= --baseline
+
+# test greps generated c code, will fail for llvm
+COMPOPTS <= --llvm


### PR DESCRIPTION
Mike pointed out that this test started failing for llvm. It's a test that
essentially greps the generated code to make sure the optimization fired. It's
greping the c code, so it needs to be skipped for llvm.
