### PR TITLE
Make HPCCProblemSize.notest own file instead of symlink from original location

### DIFF
--- a/test/studies/hpcc/HPL/perfComp/HPCCProblemSize.notest
+++ b/test/studies/hpcc/HPL/perfComp/HPCCProblemSize.notest
@@ -1,1 +1,0 @@
-/users/lydia/Documents/git-trunk/chapel/test/release/examples/benchmarks/hpcc/HPCCProblemSize.notest


### PR DESCRIPTION
Making it a symlink was unnecessary laziness on my part, as notests are just
empty files.
