### PR TITLE
Fix skipif to work on --fast (when not a performance run)

### DIFF
--- a/test/npb/ep/mcahir/perfComp/epMaxLogical.skipif
+++ b/test/npb/ep/mcahir/perfComp/epMaxLogical.skipif
@@ -5,4 +5,4 @@ import os
 compopts =  os.getenv('COMPOPTS', '')
 # skips if we aren't running a performance test (which utilize --fast and
 # --static)
-print('--fast' not in compopts and '--static' not in compopts)
+print('--fast' not in compopts or '--static' not in compopts)

--- a/test/studies/hpcc/HPL/perfComp/hplMaxLogical.skipif
+++ b/test/studies/hpcc/HPL/perfComp/hplMaxLogical.skipif
@@ -5,4 +5,4 @@ import os
 compopts =  os.getenv('COMPOPTS', '')
 # skips if we aren't running a performance test (which utilize --fast and
 # --static)
-print('--fast' not in compopts and '--static' not in compopts)
+print('--fast' not in compopts or '--static' not in compopts)

--- a/test/studies/hpcc/STREAMS/perfComp/SKIPIF
+++ b/test/studies/hpcc/STREAMS/perfComp/SKIPIF
@@ -5,4 +5,4 @@ import os
 compopts =  os.getenv('COMPOPTS', '')
 # skips if we aren't running a performance test (which utilize --fast and
 # --static)
-print('--fast' not in compopts and '--static' not in compopts)
+print('--fast' not in compopts or '--static' not in compopts)

--- a/test/studies/shootout/fannkuch-redux/perfComp/fannkuch-MAXLOGICAL.skipif
+++ b/test/studies/shootout/fannkuch-redux/perfComp/fannkuch-MAXLOGICAL.skipif
@@ -5,4 +5,4 @@ import os
 compopts =  os.getenv('COMPOPTS', '')
 # skips if we aren't running a performance test (which utilize --fast and
 # --static)
-print('--fast' not in compopts and '--static' not in compopts)
+print('--fast' not in compopts or '--static' not in compopts)

--- a/test/studies/shootout/mandelbrot/perfComp/mandelbrot-MAXLOGICAL.skipif
+++ b/test/studies/shootout/mandelbrot/perfComp/mandelbrot-MAXLOGICAL.skipif
@@ -5,4 +5,4 @@ import os
 compopts =  os.getenv('COMPOPTS', '')
 # skips if we aren't running a performance test (which utilize --fast and
 # --static)
-print('--fast' not in compopts and '--static' not in compopts)
+print('--fast' not in compopts or '--static' not in compopts)

--- a/test/studies/shootout/spectral-norm/perfComp/spectralnorm-MAXLOGICAL.skipif
+++ b/test/studies/shootout/spectral-norm/perfComp/spectralnorm-MAXLOGICAL.skipif
@@ -5,4 +5,4 @@ import os
 compopts =  os.getenv('COMPOPTS', '')
 # skips if we aren't running a performance test (which utilize --fast and
 # --static)
-print('--fast' not in compopts and '--static' not in compopts)
+print('--fast' not in compopts or '--static' not in compopts)


### PR DESCRIPTION
I mistakenly made the skipif to make sure these new test copies only ran during
performance testing use an "and" instead of an "or", so that when --fast was
detected but --static was not, the skipif still allowed the test to run.
