### PR TITLE
Change skipif files (again) for new performance suite.

### DIFF
--- a/test/npb/ep/mcahir/perfComp/epMaxLogical.skipif
+++ b/test/npb/ep/mcahir/perfComp/epMaxLogical.skipif
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-import os
-
-compopts =  os.getenv('COMPOPTS', '')
-# skips if we aren't running a performance test (which utilize --fast and
-# --static)
-print('--fast' not in compopts or '--static' not in compopts)
+# These tests are copies of other tests
+# we only want them for performance comparisons
+CHPL_TEST_PERF != on

--- a/test/studies/hpcc/HPL/perfComp/hplMaxLogical.skipif
+++ b/test/studies/hpcc/HPL/perfComp/hplMaxLogical.skipif
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-import os
-
-compopts =  os.getenv('COMPOPTS', '')
-# skips if we aren't running a performance test (which utilize --fast and
-# --static)
-print('--fast' not in compopts or '--static' not in compopts)
+# These tests are copies of other tests
+# we only want them for performance comparisons
+CHPL_TEST_PERF != on

--- a/test/studies/hpcc/STREAMS/perfComp/SKIPIF
+++ b/test/studies/hpcc/STREAMS/perfComp/SKIPIF
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-import os
-
-compopts =  os.getenv('COMPOPTS', '')
-# skips if we aren't running a performance test (which utilize --fast and
-# --static)
-print('--fast' not in compopts or '--static' not in compopts)
+# These tests are copies of other tests
+# we only want them for performance comparisons
+CHPL_TEST_PERF != on

--- a/test/studies/shootout/fannkuch-redux/perfComp/fannkuch-MAXLOGICAL.skipif
+++ b/test/studies/shootout/fannkuch-redux/perfComp/fannkuch-MAXLOGICAL.skipif
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-import os
-
-compopts =  os.getenv('COMPOPTS', '')
-# skips if we aren't running a performance test (which utilize --fast and
-# --static)
-print('--fast' not in compopts or '--static' not in compopts)
+# These tests are copies of other tests
+# we only want them for performance comparisons
+CHPL_TEST_PERF != on

--- a/test/studies/shootout/mandelbrot/perfComp/mandelbrot-MAXLOGICAL.skipif
+++ b/test/studies/shootout/mandelbrot/perfComp/mandelbrot-MAXLOGICAL.skipif
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-import os
-
-compopts =  os.getenv('COMPOPTS', '')
-# skips if we aren't running a performance test (which utilize --fast and
-# --static)
-print('--fast' not in compopts or '--static' not in compopts)
+# These tests are copies of other tests
+# we only want them for performance comparisons
+CHPL_TEST_PERF != on

--- a/test/studies/shootout/spectral-norm/perfComp/spectralnorm-MAXLOGICAL.skipif
+++ b/test/studies/shootout/spectral-norm/perfComp/spectralnorm-MAXLOGICAL.skipif
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-import os
-
-compopts =  os.getenv('COMPOPTS', '')
-# skips if we aren't running a performance test (which utilize --fast and
-# --static)
-print('--fast' not in compopts or '--static' not in compopts)
+# These tests are copies of other tests
+# we only want them for performance comparisons
+CHPL_TEST_PERF != on


### PR DESCRIPTION
I had been a little uncertain about using the presence of --fast and --static
to determine if a performance test was occurring, but hadn't seen an environment
variable that would cover it when I looked in start_test for the handling of
-performance.  That's because the environment variable is assigned when the
variable created by the flag (performance) is checked later on.  We really need
to rewrite start_test.  Anyways, switch the skipifs back to non-executable and
check against this environment variable.

Thanks to Elliot for pointing this out.
