### PR TITLE
Switch the string shootouts to having main take an argument

### DIFF
--- a/test/release/examples/benchmarks/shootout/regexdna.chpl
+++ b/test/release/examples/benchmarks/shootout/regexdna.chpl
@@ -5,13 +5,7 @@
    based on C++ RE2 implementation by Alexey Zolotov
 */
 
-// For consistency with the other shootouts, a value is passed to this
-// benchmark in the Computer Language Benchmarks Game test suite, even though
-// the input set provided is used to determine the problem size.  Store that
-// passed value here.
-config const n = 0;
-
-proc main() {
+proc main(args: [] string) {
   var variants = [
     "agggtaaa|tttaccct",
     "[cgt]gggtaaa|tttaccc[acg]",

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
@@ -3,12 +3,6 @@ use AdvancedIters;
 
 extern proc memcpy(x : [], b, len:int);
 
-// For consistency with the other shootouts, a value is passed to this
-// benchmark in the Computer Language Benchmarks Game test suite, even though
-// the input set provided is used to determine the problem size.  Store that
-// passed value here.
-config const n = 0;
-
 config const tableSize = 1 << 16;
 config const lineSize = 61;
 
@@ -95,7 +89,7 @@ inline proc startsWithThree(data : []) {
   return data[1] == 0x3E && data[2] == 0x54 && data[3] == 0x48;
 }
 
-proc main() {
+proc main(args: [] string) {
   // Open stdin and a binary reader channel
   const inFile = openfd(0);
   const fileLen = inFile.length();

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
@@ -3,12 +3,6 @@ use AdvancedIters;
 
 extern proc memcpy(x : [], b, len:int);
 
-// For consistency with the other shootouts, a value is passed to this
-// benchmark in the Computer Language Benchmarks Game test suite, even though
-// the input set provided is used to determine the problem size.  Store that
-// passed value here.
-config const n = 0;
-
 config const tableSize = 1 << 16;
 config const lineSize = 61;
 
@@ -149,7 +143,7 @@ inline proc startsWithThree(data : []) {
   return data[1] == 0x3E && data[2] == 0x54 && data[3] == 0x48;
 }
 
-proc main() {
+proc main(args: [] string) {
   // Open stdin and a binary reader channel
   const inFile = openfd(0);
   const fileLen = inFile.length();

--- a/test/studies/shootout/regex-dna/bharshbarg/regexdna.chpl
+++ b/test/studies/shootout/regex-dna/bharshbarg/regexdna.chpl
@@ -5,13 +5,7 @@
    based on C++ RE2 implementation by Alexey Zolotov
 */
 
-// For consistency with the other shootouts, a value is passed to this
-// benchmark in the Computer Language Benchmarks Game test suite, even though
-// the input set provided is used to determine the problem size.  Store that
-// passed value here.
-config const n = 0;
-
-proc main() {
+proc main(args: [] string) {
   var variants = [
     "agggtaaa|tttaccct",
     "[cgt]gggtaaa|tttaccc[acg]",

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
@@ -1,11 +1,5 @@
 extern proc memcpy(a:[], b, len);
 
-// For consistency with the other shootouts, a value is passed to this
-// benchmark in the Computer Language Benchmarks Game test suite, even though
-// the input set provided is used to determine the problem size.  Store that
-// passed value here.
-config const n = 0;
-
 proc string.toBytes() {
    var b : [1..this.length] uint(8);
    memcpy(b, this, this.length);
@@ -15,7 +9,7 @@ proc string.toBytes() {
 const pairs = "ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n".toBytes();
 var table : [1..128] uint(8);
 
-proc main() {
+proc main(args: [] string) {
   param newLineChar = 0x0A;
   param greaterThan = 0x3E;
   var inFile = openfd(0); // stdin


### PR DESCRIPTION
The Computer Language Benchmarks Game treats all its benchmarks the same in its
bencher script by sending in their size to the executable.  However, the string
shootouts (Regex DNA, Reverse Complement, and K-nucleotide) require an input
file instead of a problem size.  To get around the bogus size value sent to
them, we previously had a similarly bogus config variable, to match the set up
for our other benchmarks.  However, it seems somewhat cleaner to make use of our
command line argument syntax and then ignore the argument in main itself.
