### PR TITLE
Make the recursive version of mkdir ignore EEXIST errors

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -269,11 +269,11 @@ extern const S_ISVTX: int;
             occur.
 
    Important note: In the case where parents is true, there is a potential
-   security vulnerability.  The existence of each parent directory is checked
-   before attempting to create it, and it is possible for an attacker to create
-   the directory in between the check and the intentional creation.  If this
-   should occur, an error about creating a directory that already exists will
-   be stored in err.
+   security vulnerability.  Checking whether parent directories exist and
+   creating them if not are separate events. So even if parents==true and a
+   parent directory didn't exist before this function is called but does exist
+   afterward, it's still not necessarily true that this function created that
+   parent. Some other concurrent operation could have done so.
 */
 proc mkdir(out err: syserr, name: string, mode: int = 0o777,
            parents: bool=false) {
@@ -292,11 +292,11 @@ proc mkdir(out err: syserr, name: string, mode: int = 0o777,
             occur.
 
    Important note: In the case where parents is true, there is a potential
-   security vulnerability.  The existence of each parent directory is checked
-   before attempting to create it, and it is possible for an attacker to create
-   the directory in between the check and the intentional creation.  If this
-   should occur, an error message about creating a directory that already exists
-   will be generated.
+   security vulnerability.  Checking whether parent directories exist and
+   creating them if not are separate events. So even if parents==true and a
+   parent directory didn't exist before this function is called but does exist
+   afterward, it's still not necessarily true that this function created that
+   parent. Some other concurrent operation could have done so.
 */
 proc mkdir(name: string, mode: int = 0o777, parents: bool=false) {
   var err: syserr = ENOERR;

--- a/test/modules/standard/FileSystem/lydia/mkdir/makeRecursive.chpl
+++ b/test/modules/standard/FileSystem/lydia/mkdir/makeRecursive.chpl
@@ -3,3 +3,6 @@ use FileSystem;
 // when we also wish to create parent directories
 var dirname = "make/recursive/new/directory";
 mkdir(dirname, parents=true);
+// This also guarantees that the recursive call will not fail if any or all
+// of the directories listed have previously been created.
+mkdir(dirname, parents=true); // This call should not fail.


### PR DESCRIPTION
To summarize the issue:

Our implementation of mkdir in the recursive case checks if a directory exists
and if it does not, attempts to create it.  Coverity flagged this as a TOCTOU
(time of check, time of use) vulnerability, which basically means that in the
space between the check and when we attempt to create the directory, the
directory may have been created.  In the case where it was created by an
attacker, the directory may point somewhere completely unsafe.  It is not
currently possible to lock a file or directory that has not been created yet, so
there is no way around this error, and our detection of this error depends on it
being created only during that brief window between checking its existence and
attempting to create it - if the parent directories did not exist at the start
of the recursive mkdir call and came into being just before we checked their
existence, we would not notice.  Since we cannot guarantee to notice directory
creation outside of ourselves, we will drop any time we do notice this on the
floor.

Personally, I think we should warn if we do happen to detect it.  But I have
been overruled, and the behavior is consistent with the command mkdir -p.  It
also has the nice side effect of a clearer error message in the case where we
attempt to create a/b/c when b is not a directory (if such a race had occurred).

Updated a test to guarantee we don't warn on EEXIST in the recursive case.  And
updated the mkdir interface comment.

Those curious about the discussion may view
https://github.com/chapel-lang/chapel/pull/402, though I will be quite cross if I
have to change things again.
