### PR TITLE
Fix makefile race when compiling driver.cpp.

### DIFF
--- a/compiler/main/Makefile
+++ b/compiler/main/Makefile
@@ -34,6 +34,11 @@ TARGETS = COPYRIGHT \
 	LICENSE \
 	$(MAIN_OBJS)
 
+# Ensure LICENSE and COPYRIGHT are complete before building driver.o (from
+# driver.cpp). Otherwise, compiling driver.o can fail with a #include error
+# (i.e. the file is not yet available).
+OBJ_PREREQS = LICENSE COPYRIGHT
+
 include $(COMPILER_ROOT)/make/Makefile.compiler.subdirrules
 
 FORCE:

--- a/compiler/make/Makefile.compiler.foot
+++ b/compiler/make/Makefile.compiler.foot
@@ -50,7 +50,7 @@ echocompilerdir:
 # pattern-based rules
 #
 
-$(OBJ_SUBDIR)/%.o: %.cpp $(OBJ_SUBDIR_MADE)
+$(OBJ_SUBDIR)/%.o: %.cpp $(OBJ_SUBDIR_MADE) $(OBJ_PREREQS)
 	$(CXX) -c $(COMP_CXXFLAGS) -o $@ $<
 
 FORCE:


### PR DESCRIPTION
The LICENSE, COPYRIGHT, and driver.o recipe did not state their dependencies,
so previously they could all run simultaneously. Note that driver.cpp #include
the LICENSE and COPYRIGHT files from compiler/main/. In most cases this worked
as expected, but on some systems (probably those with slow file systems) the
driver.cpp compilation could start before LICENSE or COPYRIGHT rules were
finished. This resulted in a #include error (could not find file) for the
driver.cpp.

Update object rule, `$(OBJ_SUBDIR)/%.o` to have an optional dependency
specified by `$(OBJ_PREREQS)`. Then update compiler/main/Makefile to declare
OBJ_PREREQS as LICENSE and COPYRIGHT. This ensures the LICENSE and COPYRIGHT
will be processed before any of the object files are built. (It is a big
hammer, but it was the simplest solution I could think of.)

To verify this works, I ran the following on the system that was exhibiting the issue:

``` bash
for i in $(seq 0 200) ; do
  echo $i && \
  git clean -dxf main/gen/ main/LICENSE main/COPYRIGHT ifa/ && \
  make -j8 DEBUG=0 WARNINGS=1 OPTIMIZE=1 || \
  break
done
```
