### PR TITLE
Robustify sub_test when os errors occur during unlinking.

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -284,7 +284,43 @@ def cleanup(execname):
                 os.unlink(execname+'_real')
     except (IOError, OSError) as ex:
         sys.stdout.write('[Warning: could not remove {0}: {1}]\n'.format(execname, ex))
+
+        # If the error is "Device or resource busy", call lsof on the file (or
+        # handle for windows) to see what is holding the file handle, to help
+        # debug the issue.
+        if isinstance(ex, OSError) and ex.errno == 16:
+            handle = which('handle')
+            lsof = which('lsof')
+            if handle is not None:
+                sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(handle))
+                subprocess.Popen([handle]).communicate()
+            elif lsof is not None:
+                cmd = [lsof, execname]
+                sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(' '.join(cmd)))
+                subprocess.Popen(cmd).communicate()
     return
+
+def which(program):
+    """Returns absolute path to program, if it exists in $PATH. If not found,
+    returns None.
+
+    From: http://stackoverflow.com/a/377028
+    """
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ.get('PATH', '').split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+    return None
+
 
 # print (compopts: XX, execopts: XX) for later decoding of failed tests
 def printTestVariation(compoptsnum, execoptsnum=0):


### PR DESCRIPTION
Ignore errors when deleting the executable during testing.
There was already an exception block that was ignoring IOErrors in sub_test
when trying to unlink the executable. Update the except block to also catch
OSErrors.

Also add lsof/handle call when "Device or resource busy" error occurs. This
will help debug the core issue that is now swept under the covers (see
above paragraph).
