### PR TITLE
Do not print warning on cygwin32 platform when device busy error occurs.

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -297,9 +297,9 @@ def cleanup(execname):
                 sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(' '.join(cmd)))
                 subprocess.Popen(cmd).communicate()
 
-            # For non-cygwin32 platforms, also print a warning.
-            if platform != 'cygwin32':
-                sys.stdout.write('[Warning: could not remove {0}: {1}]\n'.format(execname, ex))
+        # Do not print the warning for cygwin32 when errno is 16 (Device or resource busy).
+        if not (getattr(ex, 'errno', 0) == 16 and platform == 'cygwin32'):
+            sys.stdout.write('[Warning: could not remove {0}: {1}]\n'.format(execname, ex))
 
 def which(program):
     """Returns absolute path to program, if it exists in $PATH. If not found,

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -283,8 +283,6 @@ def cleanup(execname):
             if os.path.isfile(execname+'_real'):
                 os.unlink(execname+'_real')
     except (IOError, OSError) as ex:
-        sys.stdout.write('[Warning: could not remove {0}: {1}]\n'.format(execname, ex))
-
         # If the error is "Device or resource busy", call lsof on the file (or
         # handle for windows) to see what is holding the file handle, to help
         # debug the issue.
@@ -298,7 +296,10 @@ def cleanup(execname):
                 cmd = [lsof, execname]
                 sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(' '.join(cmd)))
                 subprocess.Popen(cmd).communicate()
-    return
+
+            # For non-cygwin32 platforms, also print a warning.
+            if platform != 'cygwin32':
+                sys.stdout.write('[Warning: could not remove {0}: {1}]\n'.format(execname, ex))
 
 def which(program):
     """Returns absolute path to program, if it exists in $PATH. If not found,


### PR DESCRIPTION
The system used for cygwin32 testing has been experiencing random
failures when removing the binary files created during testing. Only ~10
or so tests (of the the thousands that run) experience this. The system
admins are investigating the issue. To avoid the test noise until the issue
is resolved, do not print the warnings for cygwin32 when errno 16 occurs
(i.e. `Device or resource busy`) and platform=`cygwin32`
