### PR TITLE
Lower stacksize to eliminate noisy linux32 timeouts

### DIFF
--- a/test/parallel/coforall/bradc/manyThreads-inorder.execenv
+++ b/test/parallel/coforall/bradc/manyThreads-inorder.execenv
@@ -1,1 +1,3 @@
 CHPL_RT_NUM_THREADS_PER_LOCALE=254
+# Limit stack size for systems that have limited memory.
+CHPL_RT_CALL_STACK_SIZE=1M

--- a/test/stress/deitz/test_10k_begins.execenv
+++ b/test/stress/deitz/test_10k_begins.execenv
@@ -1,0 +1,4 @@
+# Limit stack size for systems that have limited memory. Limited to 256 so that
+# in the event all 10,000 stacks exists at the same time (highly, highly
+# unlikely) you won't run out of memory on systems with less than 4GB of ram.
+CHPL_RT_CALL_STACK_SIZE=256K


### PR DESCRIPTION
Lower stacksize for:
- parallel/coforall/bradc/manyThreads-inorder.chpl
- test/stress/deitz/test_10k_begins.chpl

These tests create a bunch of tasks. On systems with limited memory (such as
our linux32 box) we run out of memory for these tests and start using swap
space which drastically increases the running time of these tests sometimes.

This just lowers the stack size to avoid this. I did 100 trails with each.
manyThreads-inorder finishes in ~.2 seconds, while test_10k_begins finishes in
4.5 seconds. Previously the time varied a lot, and they would often timeout.