### PR TITLE
Skip domains/sungeun/assoc/parSafeMember on cflbs32

### DIFF
--- a/test/domains/sungeun/assoc/parSafeMember.skipif
+++ b/test/domains/sungeun/assoc/parSafeMember.skipif
@@ -1,0 +1,5 @@
+# This machine is a really slow vm, and this test takes a really long time on
+# it. We don't want to lower the problem size or number of tasks because it's a
+# stress test meant to ensure no race conditions. This isn't a very elegant
+# solution, but if we stop using this machine, this skipif can be removed.
+HOSTNAME==cflbs32


### PR DESCRIPTION
This machine is a really slow vm, and this test takes a really long time on it.
We don't want to lower the problem size or number of tasks because it's a
stress test meant to ensure no race conditions. This isn't a very elegant
solution, but if we stop using this machine, this skipif can be removed.