### PR TITLE
Add binary operators to BitVec implementation.

### DIFF
--- a/compiler/AST/bb.cpp
+++ b/compiler/AST/bb.cpp
@@ -377,7 +377,7 @@ void BasicBlock::backwardFlowAnalysis(FnSymbol*             fn,
     iterate = false;
 
     for_vector(BasicBlock, bb, *fn->basicBlocks) {
-      for (int j = 0; j < IN[i]->ndata; j++) {
+      for (size_t j = 0; j < IN[i]->ndata; j++) {
         unsigned int new_in  = (OUT[i]->data[j] & ~KILL[i]->data[j]) | GEN[i]->data[j];
         unsigned int new_out = 0;
 
@@ -440,7 +440,7 @@ void BasicBlock::forwardFlowAnalysis(FnSymbol*             fn,
     BasicBlock* bb     = (*fn->basicBlocks)[i];
     bool        change = false;
 
-    for (int j = 0; j < IN[i]->ndata; j++) {
+    for (size_t j = 0; j < IN[i]->ndata; j++) {
       if (bb->ins.size() > 0) {
         unsigned int new_in = (intersect) ? (unsigned int) (-1) : 0;
 
@@ -535,7 +535,7 @@ void BasicBlock::printLocalsVectorSets(std::vector<BitVec*>& sets, Vec<Symbol*> 
   for_vector(BitVec, set, sets) {
     printf("%2d: ", i);
 
-    for (int j = 0; j < set->size(); j++) {
+    for (size_t j = 0; j < set->size(); j++) {
       if (set->get(j))
         printf("%s[%d] ", locals.v[j]->name, locals.v[j]->id);
     }
@@ -554,7 +554,7 @@ void BasicBlock::printBitVectorSets(std::vector<BitVec*>& sets) {
   for_vector(BitVec, set, sets) {
     printf("%2d: ", i);
 
-    for (int j = 0; j < set->size(); j++) {
+    for (size_t j = 0; j < set->size(); j++) {
       printf("%d", (set->get(j)) ? 1 : 0);
       if ((j+1) % 10 == 0) printf(" ");
     }

--- a/compiler/adt/bitVec.cpp
+++ b/compiler/adt/bitVec.cpp
@@ -22,7 +22,7 @@
 
 #define TYPE unsigned
 
-BitVec::BitVec(int in_size) {
+BitVec::BitVec(size_t in_size) {
   if (in_size == 0) {
     ndata = 0;
     this->in_size = 0;
@@ -35,39 +35,50 @@ BitVec::BitVec(int in_size) {
 }
 
 
+BitVec::BitVec(const BitVec& rhs)
+: data(NULL), in_size(rhs.in_size), ndata(rhs.ndata)
+{
+  if (ndata > 0)
+  {
+    data = (TYPE*)calloc(ndata, sizeof(TYPE));
+    copy(rhs);
+  }
+}
+
+
 BitVec::~BitVec() {
   free(data);
 }
 
 
 void BitVec::clear() {
-  for (int i = 0; i < ndata; i++)
+  for (size_t i = 0; i < ndata; i++)
     data[i] = 0;
 }
 
 
-bool BitVec::get(int i) {
-  int j = i / (sizeof(TYPE)<<3);
-  int k = i - j*(sizeof(TYPE)<<3);
+bool BitVec::get(size_t i) {
+  size_t j = i / (sizeof(TYPE)<<3);
+  size_t k = i - j*(sizeof(TYPE)<<3);
   return data[j] & (1 << k);
 }
 
 
-void BitVec::unset(int i) {
-  int j = i / (sizeof(TYPE)<<3);
-  int k = i - j*(sizeof(TYPE)<<3);
+void BitVec::unset(size_t i) {
+  size_t j = i / (sizeof(TYPE)<<3);
+  size_t k = i - j*(sizeof(TYPE)<<3);
   data[j] &= ((TYPE)-1) - (1 << k);
 }
 
 
 void BitVec::disjunction(BitVec& other) {
-  for (int i = 0; i < ndata; i++)
+  for (size_t i = 0; i < ndata; i++)
     data[i] |= other.data[i];
 }
 
 
 void BitVec::intersection(BitVec& other) {
-  for (int i = 0; i < ndata; i++)
+  for (size_t i = 0; i < ndata; i++)
     data[i] &= other.data[i];
 }
 
@@ -83,7 +94,7 @@ void BitVec::intersection(BitVec& other) {
 
 
 bool BitVec::equals(BitVec& other) {
-  for(int i = 0; i < ndata; i++) {
+  for(size_t i = 0; i < ndata; i++) {
     if(data[i] != other.data[i]) {
       return false;
     }
@@ -93,40 +104,55 @@ bool BitVec::equals(BitVec& other) {
 
 
 void BitVec::set() {
-  for (int i = 0; i < ndata; i++)
+  for (size_t i = 0; i < ndata; i++)
     data[i] = ~0;
 }
 
 
-void BitVec::set(int i) {
-  int j = i / (sizeof(TYPE)<<3);
-  int k = i - j*(sizeof(TYPE)<<3);
+void BitVec::set(size_t i) {
+  size_t j = i / (sizeof(TYPE)<<3);
+  size_t k = i - j*(sizeof(TYPE)<<3);
   data[j] |= 1 << k;
 }
 
 
 void BitVec::reset() {
-  for (int i = 0; i < ndata; i++)
+  for (size_t i = 0; i < ndata; i++)
     data[i] = 0;
 }
       
         
-void BitVec::reset(int i) {
-  int j = i / (sizeof(TYPE)<<3);
-  int k = i - j*(sizeof(TYPE)<<3);
-  data[j] &= ((int)-1) - (1 << k);
+void BitVec::reset(size_t i) {
+  size_t j = i / (sizeof(TYPE)<<3);
+  size_t k = i - j*(sizeof(TYPE)<<3);
+  data[j] &= ((size_t)-1) - (1 << k);
+}
+
+
+void BitVec::copy(const BitVec& other) {
+  for (size_t i = 0; i < ndata; ++i)
+    data[i] = other.data[i];
+}
+
+
+void BitVec::copy(size_t i, bool value) {
+  size_t j = i / (sizeof(TYPE)<<3);
+  size_t k = i - j*(sizeof(TYPE)<<3);
+  data[j] &= ~(1 << k);
+  if (value)
+    data[j] |= (1 << k);
 }
 
 
 void BitVec::flip() {
-  for (int i = 0; i < ndata; i++)
+  for (size_t i = 0; i < ndata; i++)
     data[i] = ~data[i];
 }
 
 
-void BitVec::flip(int i) {
-  int j = i / (sizeof(TYPE)<<3);
-  int k = i - j*(sizeof(TYPE)<<3);
+void BitVec::flip(size_t i) {
+  size_t j = i / (sizeof(TYPE)<<3);
+  size_t k = i - j*(sizeof(TYPE)<<3);
   data[j] ^= 1 << k;
 }
 
@@ -138,11 +164,11 @@ void BitVec::flip(int i) {
  * hex manipulation (I have no idea what the name of that bit counting 
  * algorithm is called)
  */
-int BitVec::count() {
-  int count = 0;
-  for (int i = 0; i < ndata; i++) {
-    int localCount ;
-    int x = data[i]; 
+size_t BitVec::count() {
+  size_t count = 0;
+  for (size_t i = 0; i < ndata; i++) {
+    size_t localCount ;
+    size_t x = data[i]; 
     for (localCount=0; x; localCount++) {
       x &= x-1;
     }
@@ -152,20 +178,20 @@ int BitVec::count() {
 }
 
 
-int BitVec::size() {
-  return (int)in_size; 
+size_t BitVec::size() {
+  return in_size; 
 }
 
 
-bool BitVec::test(int i) {
-  int j = i / (sizeof(TYPE)<<3);
-  int k = i - j*(sizeof(TYPE)<<3);
+bool BitVec::test(size_t i) {
+  size_t j = i / (sizeof(TYPE)<<3);
+  size_t k = i - j*(sizeof(TYPE)<<3);
   return data[j] & (1 << k);
 }
 
 
 bool BitVec::any() {
-  for (int i = 0; i < ndata; i++) {
+  for (size_t i = 0; i < ndata; i++) {
     if(data[i] > 0) {
       return true;
     }

--- a/compiler/adt/bitVec.cpp
+++ b/compiler/adt/bitVec.cpp
@@ -57,7 +57,11 @@ void BitVec::clear() {
 }
 
 
-bool BitVec::get(size_t i) {
+bool BitVec::get(size_t i) const {
+#if DEBUG
+  if (i >= in_size) 
+    INT_FATAL("BitVec::get -- operand out of range.");
+#endif
   size_t j = i / (sizeof(TYPE)<<3);
   size_t k = i - j*(sizeof(TYPE)<<3);
   return data[j] & (1 << k);
@@ -71,13 +75,21 @@ void BitVec::unset(size_t i) {
 }
 
 
-void BitVec::disjunction(BitVec& other) {
+void BitVec::disjunction(const BitVec& other) {
+#if DEBUG
+  if (other.in_size != in_size)
+    INT_FATAL("BitVec::disjunction -- operand lengths must be equal.");
+#endif
   for (size_t i = 0; i < ndata; i++)
     data[i] |= other.data[i];
 }
 
 
-void BitVec::intersection(BitVec& other) {
+void BitVec::intersection(const BitVec& other) {
+#if DEBUG
+  if (other.in_size != in_size)
+    INT_FATAL("BitVec::intersection -- operand lengths must be equal.");
+#endif
   for (size_t i = 0; i < ndata; i++)
     data[i] &= other.data[i];
 }
@@ -93,7 +105,11 @@ void BitVec::intersection(BitVec& other) {
  */ 
 
 
-bool BitVec::equals(BitVec& other) {
+bool BitVec::equals(const BitVec& other) const {
+#if DEBUG
+  if (other.in_size != in_size)
+    INT_FATAL("BitVec::disjunction -- operand lengths must be equal.");
+#endif
   for(size_t i = 0; i < ndata; i++) {
     if(data[i] != other.data[i]) {
       return false;
@@ -164,7 +180,7 @@ void BitVec::flip(size_t i) {
  * hex manipulation (I have no idea what the name of that bit counting 
  * algorithm is called)
  */
-size_t BitVec::count() {
+size_t BitVec::count() const {
   size_t count = 0;
   for (size_t i = 0; i < ndata; i++) {
     size_t localCount ;
@@ -178,19 +194,19 @@ size_t BitVec::count() {
 }
 
 
-size_t BitVec::size() {
+size_t BitVec::size() const {
   return in_size; 
 }
 
 
-bool BitVec::test(size_t i) {
+bool BitVec::test(size_t i) const {
   size_t j = i / (sizeof(TYPE)<<3);
   size_t k = i - j*(sizeof(TYPE)<<3);
   return data[j] & (1 << k);
 }
 
 
-bool BitVec::any() {
+bool BitVec::any() const {
   for (size_t i = 0; i < ndata; i++) {
     if(data[i] > 0) {
       return true;
@@ -200,7 +216,7 @@ bool BitVec::any() {
 }
 
 
-bool BitVec::none() {
+bool BitVec::none() const {
   return !any();
 }
 

--- a/compiler/include/bitVec.h
+++ b/compiler/include/bitVec.h
@@ -30,16 +30,16 @@ class BitVec {
   BitVec(const BitVec& rhs);
   ~BitVec();
   void clear();
-  bool get(size_t i);
-  bool operator[](size_t i) { return get(i); }
+  bool get(size_t i) const;
+  bool operator[](size_t i) const { return get(i); }
   void unset(size_t i);
-  void disjunction(BitVec& other);
-  void intersection(BitVec& other);
+  void disjunction(const BitVec& other);
+  void intersection(const BitVec& other);
   
   
   // Added functionality to make this compatible with std::bitset and thus 
   // boosts dynamic bitset if that gets into the STL, or we start using boost
-  bool equals(BitVec& other);
+  bool equals(const BitVec& other) const;
   void set();
   void set(size_t i);
   void reset();
@@ -48,43 +48,25 @@ class BitVec {
   void copy(size_t i, bool value);
   void flip();
   void flip(size_t i);
-  size_t count();
-  size_t size();
-  bool test(size_t i);
-  bool any();
-  bool none();
+  size_t count() const;
+  size_t size() const;
+  bool test(size_t i) const;
+  bool any() const;
+  bool none() const;
 };
 
-inline BitVec* operator+(BitVec& a, BitVec& b)
+inline BitVec operator+(const BitVec& a, const BitVec& b)
 {
-  BitVec* result = new BitVec(a);
-  result->disjunction(b);
+  BitVec result(a);
+  result.disjunction(b);
   return result;
 }
 
-// Usurps its left argument according to the optional adoption pattern.
-inline BitVec* operator+(BitVec* a, BitVec& b)
+inline BitVec operator-(const BitVec& a, const BitVec& b)
 {
-  BitVec* result = a;
-  result->disjunction(b);
-  return result;
-}
-
-inline BitVec* operator-(BitVec& a, BitVec& b)
-{
-  BitVec* result = new BitVec(b);
-  result->flip();
-  result->intersection(a);
-  return result;
-}
-
-inline BitVec* operator-(BitVec* a, BitVec& b)
-{
-  BitVec* result = a;
-  BitVec* temp = new BitVec(b);
-  temp->flip();
-  result->intersection(*temp);
-  delete temp; temp = 0;
+  BitVec result(b);
+  result.flip();
+  result.intersection(a);
   return result;
 }
 

--- a/compiler/include/bitVec.h
+++ b/compiler/include/bitVec.h
@@ -23,14 +23,16 @@
 class BitVec {
  public:
   unsigned* data;
-  int in_size;
-  int ndata;
+  size_t in_size;
+  size_t ndata;
 
-  BitVec(int in_size);
+  BitVec(size_t in_size);
+  BitVec(const BitVec& rhs);
   ~BitVec();
   void clear();
-  bool get(int i);
-  void unset(int i);
+  bool get(size_t i);
+  bool operator[](size_t i) { return get(i); }
+  void unset(size_t i);
   void disjunction(BitVec& other);
   void intersection(BitVec& other);
   
@@ -39,16 +41,51 @@ class BitVec {
   // boosts dynamic bitset if that gets into the STL, or we start using boost
   bool equals(BitVec& other);
   void set();
-  void set(int i);
+  void set(size_t i);
   void reset();
-  void reset(int i);
+  void reset(size_t i);
+  void copy(const BitVec& other);
+  void copy(size_t i, bool value);
   void flip();
-  void flip(int i);
-  int count();
-  int size();
-  bool test(int i);
+  void flip(size_t i);
+  size_t count();
+  size_t size();
+  bool test(size_t i);
   bool any();
   bool none();
 };
+
+inline BitVec* operator+(BitVec& a, BitVec& b)
+{
+  BitVec* result = new BitVec(a);
+  result->disjunction(b);
+  return result;
+}
+
+// Usurps its left argument according to the optional adoption pattern.
+inline BitVec* operator+(BitVec* a, BitVec& b)
+{
+  BitVec* result = a;
+  result->disjunction(b);
+  return result;
+}
+
+inline BitVec* operator-(BitVec& a, BitVec& b)
+{
+  BitVec* result = new BitVec(b);
+  result->flip();
+  result->intersection(a);
+  return result;
+}
+
+inline BitVec* operator-(BitVec* a, BitVec& b)
+{
+  BitVec* result = a;
+  BitVec* temp = new BitVec(b);
+  temp->flip();
+  result->intersection(*temp);
+  delete temp; temp = 0;
+  return result;
+}
 
 #endif

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -954,7 +954,7 @@ static void computeKillSets(FnSymbol* fn,
     // Use killSet to initialize the KILL set for this block.
     // It's OK if we include the pairs from this block in KILL[i] because we
     // put them back when we add in the COPY set.
-    for (int j = 0; j < KILL[i]->size(); ++j)
+    for (size_t j = 0; j < KILL[i]->size(); ++j)
       if (killSet.find(availablePairs[j].first) != killSet.end() ||
           killSet.find(availablePairs[j].second) != killSet.end())
         KILL[i]->set(j);

--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -1010,7 +1010,7 @@ static bool defDominatesAllExits(Loop* loop, SymExpr* def, std::vector<BitVec*>&
   
   BitVec* bitExits = loop->getBitExits();
    
-  for(int i = 0; i < bitExits->size(); i++) {
+  for(size_t i = 0; i < bitExits->size(); i++) {
     if(bitExits->test(i)) {
       if(dominates(defBlock, i, dominators) == false) {
         return false;


### PR DESCRIPTION
Also, use size_t in place of int, for closer compatibility with std::bitset and the boost
dynamic_bitset.

Added a copy-constructor and the copy operation to support + (set union) and - (set difference).

Updated bb.cpp, copyPropagation.cpp and loopInvariantCodeMotion.cpp, clients of BitVec,
because now the size it returns and the ndata field are unsigned (size_t).