### PR TITLE
Add a prediff to help debug an intermittent failure.

### DIFF
--- a/test/classes/bradc/arrayInClass/genericArrayInClass-arith.prediff
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-arith.prediff
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [[ .$CRAY_PLATFORM_FROM_JENKINS == .cray-xe ]] ; then
+  if ! diff -q $1.good $2 ; then
+    echo ====================
+    echo "mkdir -p $CHPL_HOME/gbt"
+    mkdir -p $CHPL_HOME/gbt
+    echo ====================
+    echo "cp -p $1 $CHPL_HOME/gbt/."
+    cp -p $1 $CHPL_HOME/gbt/.
+    echo ====================
+    echo "readelf --file-header --program-headers $1"
+    readelf --file-header --program-headers $1
+    echo ====================
+    echo "top -n 1"
+    top -n 1
+    echo ====================
+    echo "sar -u 1 1"
+    sar -u 1 1
+    echo ====================
+  fi
+fi


### PR DESCRIPTION
We've observed very intermittent failures in Cray XE testing with the
CCE compiler for the last several months, whose symptom is dropped
output.  Now the test genericArrayInClass-arith has started failing
solidly in this way. Take advantage of this luck (hoping it will hold)
and gather some more information about the failure.