### PR TITLE
Update re2 build to propagate errors during unpack process.

### DIFF
--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -21,6 +21,8 @@ CHPL_RE2_CXXFLAGS=-mmic
 endif
 endif
 
+RE2_UNPACKED_DIR = $(RE2_SUBDIR)
+
 default: all
 
 all: re2
@@ -37,8 +39,10 @@ clobber: FORCE
 $(RE2_BUILD_SUBDIR):
 	mkdir -p $@
 
-$(RE2_H_FILE): $(RE2_BUILD_SUBDIR)
+$(RE2_UNPACKED_DIR):
 	if [ ! -d re2 ]; then ./unpack-re2.sh; fi
+
+$(RE2_H_FILE): $(RE2_BUILD_SUBDIR) $(RE2_UNPACKED_DIR)
 	cd re2 && \
 	$(MAKE) clean && \
 	$(MAKE) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)" obj/libre2.a && \

--- a/third-party/re2/unpack-re2.sh
+++ b/third-party/re2/unpack-re2.sh
@@ -1,19 +1,18 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -e
 
 if [ -d re2 ]
 then
-
-echo RE2 already unpacked
-
+    echo RE2 already unpacked
 else
-
-echo Unpacking RE2
-tar xzf re2-20140111.tgz
-echo Applying Patches
-cd re2
-patch -p1 < ../hg_diff_g.patch
-cat ../Makefile.install-static >> Makefile 
-echo Copying file_strings.h and file_strings.cc
-cp ../file_strings.h re2/
-cp ../file_strings.cc re2/
+    echo Unpacking RE2
+    tar xzf re2-20140111.tgz
+    echo Applying Patches
+    cd re2
+    patch -p1 < ../hg_diff_g.patch
+    cat ../Makefile.install-static >> Makefile
+    echo Copying file_strings.h and file_strings.cc
+    cp ../file_strings.h re2/
+    cp ../file_strings.cc re2/
 fi


### PR DESCRIPTION
Update the unpack script to fail if any of its commands fail. For systems without
patch, this will mean re2 will not be built and the error message about missing
patch will be more visible to the user.

Previously, systems without patch installed (often the case on *EL) would print
the missing patch program message, but continue building re2. This resulted
in a successful re2 build that was missing the `file_strings.{h,cc}` files provided
by the patch. The runtime would then fail to compile re2-interface.cc because it
could not find `FilePiece`, which is provided by file_strings.h.