### PR TITLE
Allow the main process to run Chapel task bodies.

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -122,7 +122,12 @@ struct chpl_task_list {
     chpl_task_list_p next;
 };
 
+pthread_t chpl_qthread_process_pthread;
 pthread_t chpl_qthread_comm_pthread;
+
+chpl_qthread_tls_t chpl_qthread_process_tls = {
+  PRV_DATA_IMPL_VAL(c_sublocid_any_val, false),
+  NULL, 0, NULL, 0 };
 
 chpl_qthread_tls_t chpl_qthread_comm_task_tls = {
   PRV_DATA_IMPL_VAL(c_sublocid_any_val, false),
@@ -585,6 +590,8 @@ void chpl_task_init(void)
     int32_t   commMaxThreads;
     int32_t   hwpar;
     pthread_t initer;
+
+    chpl_qthread_process_pthread = pthread_self();
 
     commMaxThreads = chpl_comm_getMaxThreads();
 

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
@@ -314,12 +314,13 @@ static inline chpl_qthread_tls_t * chpl_qthread_get_tasklocal(void)
     if (chpl_qthread_done_initializing) {
         tls = (chpl_qthread_tls_t *)
               qthread_get_tasklocal(sizeof(chpl_qthread_tls_t));
-        if (tls == NULL &&
-            pthread_equal(pthread_self(), chpl_qthread_comm_pthread))
-            tls = &chpl_qthread_comm_task_tls;
-        if (tls == NULL &&
-            pthread_equal(pthread_self(), chpl_qthread_process_pthread))
-            tls = &chpl_qthread_process_tls;
+        if (tls == NULL) {
+            pthread_t me = pthread_self();
+            if (pthread_equal(me, chpl_qthread_comm_pthread))
+                tls = &chpl_qthread_comm_task_tls;
+            else if (pthread_equal(me, chpl_qthread_process_pthread))
+                tls = &chpl_qthread_process_tls;
+        }
         assert(tls);
     }
     else

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
@@ -297,8 +297,10 @@ typedef struct chpl_qthread_tls_s {
     size_t      task_lineno;
 } chpl_qthread_tls_t;
 
+extern pthread_t chpl_qthread_process_pthread;
 extern pthread_t chpl_qthread_comm_pthread;
 
+extern chpl_qthread_tls_t chpl_qthread_process_tls;
 extern chpl_qthread_tls_t chpl_qthread_comm_task_tls;
 
 #define CHPL_TASK_STD_MODULES_INITIALIZED chpl_task_stdModulesInitialized
@@ -307,14 +309,17 @@ void chpl_task_stdModulesInitialized(void);
 // Wrap qthread_get_tasklocal() and assert that it is always available.
 static inline chpl_qthread_tls_t * chpl_qthread_get_tasklocal(void)
 {
-    chpl_qthread_tls_t * tls;
+    chpl_qthread_tls_t* tls;
 
     if (chpl_qthread_done_initializing) {
         tls = (chpl_qthread_tls_t *)
               qthread_get_tasklocal(sizeof(chpl_qthread_tls_t));
         if (tls == NULL &&
             pthread_equal(pthread_self(), chpl_qthread_comm_pthread))
-          tls = &chpl_qthread_comm_task_tls;
+            tls = &chpl_qthread_comm_task_tls;
+        if (tls == NULL &&
+            pthread_equal(pthread_self(), chpl_qthread_process_pthread))
+            tls = &chpl_qthread_process_tls;
         assert(tls);
     }
     else


### PR DESCRIPTION
We can't run a Chapel task body unless we have Qthreads thread (task)
local storage, because that's where the serial state and sublocale info
are stored.  But only actual qthreads have Qthreads TLS.  The comm layer
polling thread doesn't, for example.  However, we provide fake TLS for
the comm thread and return that in chpl_qthread_get_tasklocal(), so that
the comm thread AM handler can execute "fast" task bodies directly.

Here we add the same support for the main process on each locale, since
at least for non-0 locales that process can end up doing AM handling in
certain comm layers (notably GASNet) as a result of calling into
chpl_comm_barrier() to handle exit.

This fixes 3 intermittent SIGABRT failures in
  optimizations/sungeun/optimized-on/test_OptimizedOn_Block1
resulting from commit 870da1a80cde31c30d3dc49a83313e1845b6ae3f.