### PR TITLE
Set NDEBUG for optimized runtime builds

### DIFF
--- a/runtime/include/qio/qio_formatted.h
+++ b/runtime/include/qio/qio_formatted.h
@@ -24,6 +24,7 @@
 #include "qio.h"
 
 #include "bswap.h"
+#include "error.h"
 
 // true 1 false 0   __bool_true_false_are_defined
 #include <stdbool.h>
@@ -656,7 +657,8 @@ qioerr qio_decode_char_buf(int32_t* restrict chr, int* restrict nbytes, const ch
     QIO_GET_CONSTANT_ERROR(err, ENOSYS, "missing wctype.h");
 #endif
   }
-  assert(0);
+  *chr = 0; // Makes GCC stop complaining about *chr not being set in other locations
+  chpl_internal_error("qio_decode_char_buf");
   QIO_RETURN_CONSTANT_ERROR(EILSEQ, ""); // this should never be reached.
 }
 

--- a/runtime/make/Makefile.runtime.include
+++ b/runtime/make/Makefile.runtime.include
@@ -40,7 +40,7 @@ RUNTIME_DEFS += -DCHPL_COMM_DEBUG
 endif
 
 ifeq ($(OPTIMIZE),1)
-RUNTIME_DEFS += -DCHPL_OPTIMIZE
+RUNTIME_DEFS += -DCHPL_OPTIMIZE -DNDEBUG
 endif
 
 # For HDFS support (and backwards compatibility)

--- a/runtime/src/qio/qbuffer.c
+++ b/runtime/src/qio/qbuffer.c
@@ -25,6 +25,8 @@
 
 #include "qbuffer.h"
 
+#include "error.h"
+
 #include "sys.h"
 
 #include <limits.h>
@@ -70,7 +72,10 @@ void qbytes_free_munmap(qbytes_t* b) {
   */
 
   err = sys_munmap(b->data, b->len);
-  assert( !err );
+
+  if (err) {
+    chpl_internal_error("sys_munmap() failed");
+  }
 
   _qbytes_free_qbytes(b);
 }

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -38,6 +38,8 @@
 #include "qio.h"
 #include "qbuffer.h"
 
+#include "error.h"
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <sys/uio.h>
@@ -1509,7 +1511,9 @@ qioerr _qio_channel_makebuffer_unlocked(qio_channel_t* ch)
   // adding to the qbuffer the file data.
   // We do not check cached_start since we might have moved
   // the mark_stack along with changing cached_start
-  assert( ch->cached_end == expect_end );
+  if ( ch->cached_end != expect_end ) {
+    chpl_internal_error("_qio_channel_makebuffer_unlocked() failed");
+  }
 
   ch->mark_stack[0] = qbuffer_start_offset(&ch->buf);
 

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -21,11 +21,6 @@
 // FIFO implementation of Chapel tasking interface
 //
 
-#ifdef __OPTIMIZE__
-// Turn assert() into a no op if the C compiler defines the macro above.
-#define NDEBUG
-#endif
-
 #include "chplrt.h"
 #include "chpl_rt_utils_static.h"
 #include "chplcgfns.h"

--- a/runtime/src/tasks/massivethreads/tasks-massivethreads.c
+++ b/runtime/src/tasks/massivethreads/tasks-massivethreads.c
@@ -19,11 +19,6 @@
 
 #define _GNU_SOURCE
 
-#ifdef __OPTIMIZE__
-// Turn assert() into a no op if the C compiler defines the macro above.
-#define NDEBUG
-#endif
-
 #include "chplrt.h"
 #include "chplcast.h"
 #include "chplcgfns.h" // for chpl_ftable

--- a/runtime/src/threads/pthreads/threads-pthreads.c
+++ b/runtime/src/threads/pthreads/threads-pthreads.c
@@ -21,11 +21,6 @@
 // Pthread implementation of Chapel threading interface
 //
 
-#ifdef __OPTIMIZE__
-// Turn assert() into a no op if the C compiler defines the macro above.
-#define NDEBUG
-#endif
-
 #include "chplrt.h"
 #include "chpl-comm.h"
 #include "chpl-mem.h"


### PR DESCRIPTION
Setting NDEBUG will turn any asserts in our runtime code into no-ops.

This was being done in an ad-hoc basis in a few files, those checks have
been removed to avoid duplicate definitions.