### PR TITLE
Add new rhel.linux64 testing script.

### DIFF
--- a/util/cron/test-linux32.bash
+++ b/util/cron/test-linux32.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test default configuration against examples on 32bit linux.
+# Test default configuration against full suite on 32bit linux.
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash

--- a/util/cron/test-rhel.linux64.bash
+++ b/util/cron/test-rhel.linux64.bash
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# Test default configuration against full suite on RHEL linux64 system.
+# Test default configuration against examples on RHEL linux64 system.
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="rhel.linux64"
 
-$CWD/nightly -cron
+$CWD/nightly -cron -examples

--- a/util/cron/test-rhel.linux64.bash
+++ b/util/cron/test-rhel.linux64.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Test default configuration against full suite on RHEL linux64 system.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="rhel.linux64"
+
+$CWD/nightly -cron


### PR DESCRIPTION
Run examples on a RHEL-like system, to keep us honest.