### PR TITLE
Remove chap11 from all-cf list and add chap13

### DIFF
--- a/test/Nodes/all-cf
+++ b/test/Nodes/all-cf
@@ -3,6 +3,6 @@ chap05
 chap06
 chap07
 chap08
-chap11
 chap12
+chap13
 chap14


### PR DESCRIPTION
gasnet testing has moved to chap11, switching which machines are listed in the
all-cf file