### PR TITLE
Ensure that testenv is available in sub_test for runSkipIf function.

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -444,7 +444,10 @@ def runSkipIf(skipifName):
 
         skipif_env = os.environ.copy()
         skipif_env.update(chpl_env)
+
+        global testenv
         skipif_env.update(testenv)
+
         skiptest = subprocess.Popen([name], stdout=subprocess.PIPE, env=skipif_env).communicate()[0]
     else:
         skiptest = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE).communicate()[0]
@@ -847,6 +850,8 @@ if onetestsrc==None:
 else:
     testsrc=list()
     testsrc.append(onetestsrc)
+
+testenv = {}
 
 for testname in testsrc:
     sys.stdout.flush()


### PR DESCRIPTION
Some configurations (unclear what the differentiating factor was) did not
have `testenv` available in the global namespace. Update sub_test to
ensure `testenv` is available to runSkipIf() function scope.

I verified this change work on a configuration that worked last night (darwin)
and a couple that did not (memleaks, linux64).