### PR TITLE
Fix BB analysis bug

### DIFF
--- a/compiler/AST/bb.cpp
+++ b/compiler/AST/bb.cpp
@@ -71,7 +71,10 @@ void BasicBlock::buildBasicBlocks(FnSymbol* fn) {
 
   fn->basicBlocks->push_back(BasicBlock::steal());
 
-  INT_ASSERT(verifyBasicBlocks(fn));
+  removeEmptyBlocks(fn);
+
+  if (fVerify)
+    INT_ASSERT(verifyBasicBlocks(fn));
 }
 
 BasicBlock* BasicBlock::steal() {
@@ -202,9 +205,11 @@ void BasicBlock::buildBasicBlocks(FnSymbol* fn, Expr* stmt, bool mark) {
     LabelSymbol* label = toLabelSymbol(toSymExpr(s->label)->var);
 
     if (BasicBlock* bb = labelMaps.get(label)) {
+      // Thread this block to its destination label.
       thread(basicBlock, bb);
 
     } else {
+      // Set up goto map, so this block's successor can be back-patched later.
       std::vector<BasicBlock*>* vbb = gotoMaps.get(label);
 
       if (!vbb)
@@ -216,6 +221,10 @@ void BasicBlock::buildBasicBlocks(FnSymbol* fn, Expr* stmt, bool mark) {
     }
 
     append(s, mark); // Put the goto at the end of its block.
+
+    // We need a new block, so we can not thread the one containing the goto to
+    // this new one.  There is a break in the flow.  If the new block does not
+    // begin with a label, it is unreachable and can be removed.
     restart(fn);
 
   } else {
@@ -291,9 +300,49 @@ void BasicBlock::thread(BasicBlock* src, BasicBlock* dst) {
   src->outs.push_back(dst);
 }
 
+// Look for and remove empty blocks with no predecessor and whose successor is
+// the next block in sequence.  These blocks get created when a block ends in a
+// goto statement and the enclosing construct calls restart immediately.
+// We have to wait until basic block analysis is done, because we don't know if
+// a block has predecessors until after threading is performed, and this is
+// sometimes delayed.
+void BasicBlock::removeEmptyBlocks(FnSymbol* fn)
+{
+  // Create a new vector that contains just the items we want to preserve.
+  int new_id = 0;
+  BasicBlockVector* new_blocks = new BasicBlockVector();
+  for_vector(BasicBlock, bb, *fn->basicBlocks)
+  {
+    // Skip empty blocks with no predecessors.
+    if (bb->ins.size() == 0 &&
+        bb->exprs.size() == 0)
+    {
+      // This block will be removed.  It is no longer a predecessor of anyone,
+      // so we must update the back links.
+      for_vector(BasicBlock, succ, bb->outs)
+      {
+        BasicBlockVector::iterator i;
+        for (i = succ->ins.begin(); i != succ->ins.end(); ++i)
+          if (*i == bb)
+            break;
+
+        INT_ASSERT(i != succ->ins.end());
+        succ->ins.erase(i);
+      }
+    }
+    else
+    {
+      bb->id = new_id++;
+      new_blocks->push_back(bb);
+    }
+  }
+  delete fn->basicBlocks; fn->basicBlocks = new_blocks;
+}
+
 // Returns true if the basic block structure is OK, false otherwise.
 bool BasicBlock::verifyBasicBlocks(FnSymbol* fn) {
-  for_vector(BasicBlock, bb, *fn->basicBlocks) {
+  for_vector(BasicBlock, bb, *fn->basicBlocks)
+  {
     if (bb->isOK() == false)
       return false;
   }
@@ -305,6 +354,15 @@ bool BasicBlock::verifyBasicBlocks(FnSymbol* fn) {
 bool BasicBlock::isOK() {
   // Ensure exprs[] and marks[] are same length
   if (exprs.size() != marks.size())
+    return false;
+
+  // Every empty interior block must have a predecessor.
+  // Non-empty blocks with no predecessors are dead code, which may be
+  // removed by a client of BB analysis.  These dead blocks cannot be
+  // identified without BB analysis, so non-empty blocks with no
+  // predecessors are valid.
+  if (ins.size() == 0 &&
+      exprs.size() == 0)
     return false;
 
   // Expressions must be live (non-NULL);

--- a/compiler/include/bb.h
+++ b/compiler/include/bb.h
@@ -37,6 +37,13 @@ class SymExpr;
 class BasicBlock
 {
   //
+  // Typedefs
+  //
+ public:
+  typedef std::vector<BasicBlock*> BasicBlockVector;
+  typedef std::vector<BitVec*> BitVecVector;
+
+  //
   // Class methods/variables
   //
 public:
@@ -51,16 +58,16 @@ public:
                                                  Map<Symbol*,int>&     localMap);
 
   static void               backwardFlowAnalysis(FnSymbol*             fn,
-                                                 std::vector<BitVec*>& GEN,
-                                                 std::vector<BitVec*>& KILL,
-                                                 std::vector<BitVec*>& IN,
-                                                 std::vector<BitVec*>& OUT);
+                                                 BitVecVector& GEN,
+                                                 BitVecVector& KILL,
+                                                 BitVecVector& IN,
+                                                 BitVecVector& OUT);
 
   static void               forwardFlowAnalysis (FnSymbol*             fn,
-                                                 std::vector<BitVec*>& GEN,
-                                                 std::vector<BitVec*>& KILL,
-                                                 std::vector<BitVec*>& IN,
-                                                 std::vector<BitVec*>& OUT,
+                                                 BitVecVector& GEN,
+                                                 BitVecVector& KILL,
+                                                 BitVecVector& IN,
+                                                 BitVecVector& OUT,
                                                  bool                  intersect = true);
 
   static void               printLocalsVector(Vec<Symbol*>      locals,
@@ -69,10 +76,10 @@ public:
   static void               printDefsVector(std::vector<SymExpr*> defs,
                                             Map<SymExpr*, int>&   defMap);
 
-  static void               printLocalsVectorSets(std::vector<BitVec*>& sets,
+  static void               printLocalsVectorSets(BitVecVector& sets,
                                                   Vec<Symbol*>          locals);
 
-  static void               printBitVectorSets(std::vector<BitVec*>& sets);
+  static void               printBitVectorSets(BitVecVector& sets);
 
   static BasicBlock*        basicBlock;
 
@@ -80,7 +87,7 @@ public:
              BasicBlock*>   labelMaps;
 
   static Map<LabelSymbol*,
-             std::vector<BasicBlock*>*> gotoMaps;
+             BasicBlockVector*> gotoMaps;
 
 private:
   static void               buildBasicBlocks(FnSymbol* fn,
@@ -109,8 +116,8 @@ public:
   std::vector<Expr*>        exprs;
   std::vector<bool>         marks;
 
-  std::vector<BasicBlock*>  ins;
-  std::vector<BasicBlock*>  outs;
+  BasicBlockVector  ins;
+  BasicBlockVector  outs;
 
 private:
   bool                      isOK();

--- a/compiler/include/bb.h
+++ b/compiler/include/bb.h
@@ -101,6 +101,7 @@ private:
 
   static BasicBlock*        steal();
 
+  static void removeEmptyBlocks(FnSymbol* fn);
   static bool               verifyBasicBlocks(FnSymbol* fn);
 
   static int                nextID;

--- a/compiler/include/bb.h
+++ b/compiler/include/bb.h
@@ -101,7 +101,7 @@ private:
 
   static BasicBlock*        steal();
 
-  static void removeEmptyBlocks(FnSymbol* fn);
+  static void               removeEmptyBlocks(FnSymbol* fn);
   static bool               verifyBasicBlocks(FnSymbol* fn);
 
   static int                nextID;
@@ -117,8 +117,8 @@ public:
   std::vector<Expr*>        exprs;
   std::vector<bool>         marks;
 
-  BasicBlockVector  ins;
-  BasicBlockVector  outs;
+  BasicBlockVector          ins;
+  BasicBlockVector          outs;
 
 private:
   bool                      isOK();

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -992,8 +992,10 @@ static void initCopySets(std::vector<BitVec*>& COPY, std::vector<size_t>& ends,
 // When these are corrected and the test becomes true, then we can drop back
 // to the simpler form given here:
 #ifdef INLINING_DOES_NOT_LEAVE_INTERNAL_BASIC_BLOCKS_WITHOUT_PREDECESSORS
-static void initInSets(std::vector<BitVec*>& IN, size_t nbbs)
+static void initInSets(std::vector<BitVec*>& IN, FnSymbol* fn)
 {
+  size_t nbbs = fn->basicBlocks->size();
+
   // Note that we start with i = 1, so that IN[0] is left as all zeroes.
   for (size_t i = 1; i < nbbs; i++)
     IN[i]->set();


### PR DESCRIPTION
This resolves a long-standing bug with basic block analysis.  After analysis was complete, the graph contained empty blocks with no predecessors.  These spurious blocks complicate algorithms that depend on basic block analysis.  (See, for example, the #ifdef block starting at copyPropagation.cpp:994.)

The solution is to go through the list of basic blocks after the main analysis is complete, and remove empty blocks having no predecessors.  Back-links to the block being removed must be removed at the same time.  The blocks are renumbered, because algorithms rely on the id of a block being equal to its index in the vector of basic blocks attached to the given function.

Note that blocks with no predecessors that are **not** empty are not removed.  These represent dead blocks that may be removed.  However, it is not the job of BB analysis to remove these blocks.  Further, if BB analysis hid them, then the necessary information would be unavailable to client code wanting to perform dead block removal.

As a lagniappe, I noticed that the signature on the simpler version of initInSets() in copyPropagation.cpp did not match the call (since it is currently disabled).  I updated the function signature so it matches the call.  I tried setting INLINING_DOES_NOT_LEAVE_INTERNAL_BASIC_BLOCKS_WITHOUT_PREDECESSORS to true, but that did not work because (at least) param conditional inlining leaves in the tree non-empty blocks with no predecessors.  An earlier attempt at dead block removal failed -- possibly due to the presence of empty blocks with no predecessors.  Following commission of this PR, we may try again to add dead block removal.