### PR TITLE
Changes to chpl-cache for compatibility with NDEBUG

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -754,7 +754,9 @@ struct rdcache_s* cache_create(void) {
   pages = buffer + total_size;
   total_size += CACHEPAGE_SIZE * cache_pages;
 
-  assert(total_size <= allocated_size);
+  if (total_size > allocated_size) {
+    chpl_internal_error("cache_create() failed");
+  }
 
   // Now fill in everything else.
   c->next_request_number = 1;
@@ -1432,6 +1434,7 @@ struct cache_entry_s* find_in_tree(struct rdcache_s* tree,
   return bottom_match;
 }
 
+#if VERIFY
 static
 int find_in_dirty(struct rdcache_s* tree, struct dirty_entry_s* entry)
 {
@@ -1497,10 +1500,12 @@ int validate_queue(struct rdcache_s* tree, struct cache_entry_s* head, struct ca
   assert(forward_count == reverse_count);
   return forward_count;
 }
+#endif
 
 static
 void validate_cache(struct rdcache_s* tree)
 {
+#if VERIFY
   int top, bottom;
   struct top_entry_s* top_cur;
   struct cache_entry_s* bottom_cur;
@@ -1608,6 +1613,7 @@ void validate_cache(struct rdcache_s* tree)
     }
     assert( num_used_top_nodes + num_free_top_nodes == tree->max_top_nodes );
   }
+#endif
 }
 
 static
@@ -1824,7 +1830,6 @@ struct cache_entry_s* make_entry(struct rdcache_s* tree,
   struct top_entry_s **head, *top_match, *top_tmp;
   struct cache_entry_s **bottom, *bottom_match, *bottom_tmp;
   struct cache_entry_base_s* bottom_prev;
-  int queue = QUEUE_FREE;
 
   assert(raddr != 0);
 
@@ -1856,9 +1861,8 @@ struct cache_entry_s* make_entry(struct rdcache_s* tree,
   // If X is in A1out then find space for X and add it to the head of Am
     assert( bottom_match->base.node == node );
     assert( bottom_match->raddr == raddr );
-    queue = bottom_match->queue;
     // We shouldn't be replacing something in Ain or Am; use use_entry instead
-    assert(queue == QUEUE_AOUT);
+    assert(bottom_match->queue == QUEUE_AOUT);
 
     DEBUG_PRINT(("%d: Found %p in Aout\n", chpl_nodeID, (void*) raddr));
     // add X to the head of Am
@@ -1881,8 +1885,6 @@ struct cache_entry_s* make_entry(struct rdcache_s* tree,
     bottom_match->max_prefetch_sequence_number = NO_SEQUENCE_NUMBER;
   } else {
   // Else If X is in no queue then find space for X and add it to A1in
-    queue = QUEUE_FREE;
-
     DEBUG_PRINT(("%d: Found %p nowhere\n", chpl_nodeID, (void*) raddr));
 
     // This is our new entry...


### PR DESCRIPTION
chpl-cache has a few verification routines that use a lot of asserts and
don't make much sense with NDEBUG set. These routines are only called if
VERIFY is set to 1 (defaults to 0), so I've added a few #ifs to prevent
the verification routines from being compiled at all when they are not
used.

Add a few other minor fixes to avoid compiler warnings when compiling with NDBEUG.