### PR TITLE
Update sub_test to process .skipif files before any others.

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -444,10 +444,7 @@ def runSkipIf(skipifName):
 
         skipif_env = os.environ.copy()
         skipif_env.update(chpl_env)
-
-        global testenv
         skipif_env.update(testenv)
-
         skiptest = subprocess.Popen([name], stdout=subprocess.PIPE, env=skipif_env).communicate()[0]
     else:
         skiptest = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE).communicate()[0]
@@ -850,8 +847,6 @@ if onetestsrc==None:
 else:
     testsrc=list()
     testsrc.append(onetestsrc)
-
-testenv = {}
 
 for testname in testsrc:
     sys.stdout.flush()

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -917,7 +917,7 @@ for testname in testsrc:
         if test_filename_file.endswith('.skipif'):
             skipif_i = i
             break
-    if skipif_i >= 0:
+    if skipif_i > 0:
         test_filename_files.insert(0, test_filename_files.pop(skipif_i))
 
     # Deal with these files

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -444,7 +444,6 @@ def runSkipIf(skipifName):
 
         skipif_env = os.environ.copy()
         skipif_env.update(chpl_env)
-        skipif_env.update(testenv)
         skiptest = subprocess.Popen([name], stdout=subprocess.PIPE, env=skipif_env).communicate()[0]
     else:
         skiptest = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE).communicate()[0]

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -918,9 +918,7 @@ for testname in testsrc:
             skipif_i = i
             break
     if skipif_i >= 0:
-        print('inserting .skipif at head of test_filename_files: {0}'.format(test_filename_files))
         test_filename_files.insert(0, test_filename_files.pop(skipif_i))
-        print('inserting .skipif at head of test_filename_files: {0}'.format(test_filename_files))
 
     # Deal with these files
     do_not_test=False

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -911,6 +911,17 @@ for testname in testsrc:
     else:
         redirectin = None
 
+    # If there is a .skipif file, put it at front of list.
+    skipif_i = -1
+    for i, test_filename_file in enumerate(test_filename_files):
+        if test_filename_file.endswith('.skipif'):
+            skipif_i = i
+            break
+    if skipif_i >= 0:
+        print('inserting .skipif at head of test_filename_files: {0}'.format(test_filename_files))
+        test_filename_files.insert(0, test_filename_files.pop(skipif_i))
+        print('inserting .skipif at head of test_filename_files: {0}'.format(test_filename_files))
+
     # Deal with these files
     do_not_test=False
     for f in test_filename_files:


### PR DESCRIPTION
There is one test system that does not support symlinks due to its version of
git. In a happy coincidence, that system also skips one of the two tests failing
due to lack of symlink support.

Aside from the above coincident, it generally seems more efficient to evaluate
the .skipif before doing any other work on the test.

### TODO:

* [x] run full test pass to make sure this change does not break any tests...