### PR TITLE
Skip filerator/walk test when subdir-link is not a symlink.

### DIFF
--- a/test/studies/filerator/walk.skipif
+++ b/test/studies/filerator/walk.skipif
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Skip the test if subdir-link is not a link. This can happen if core.symlinks
+# is set to 'false' in the git configuration.
+
+if [ ! -L subdir-link ] ; then
+    echo "True"
+else
+    echo "False"
+fi


### PR DESCRIPTION
On an older test system, the subdir-link is not checked out as a symbolic link
because of how JGit is used (it forces core.symlinks to false). Add new
walk.skipif that checks if subdir-link is a symbolic link and if not returns
True. This should skip the one remaining error case resulting from broken
symlinks in the test system.