### PR TITLE
Don't force static linking when hwloc is used.

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -7,14 +7,6 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 CHPL_HWLOC_CFG_OPTIONS += --enable-static --disable-shared --disable-libxml2 --disable-pci
 
-ifneq ($(CHPL_MAKE_PLATFORM), darwin)
-ifeq ($(CHPL_MAKE_TARGET_COMPILER), pgi)
-  CHPL_HWLOC_CFG_OPTIONS += LDFLAGS=-Bstatic
-else
-  CHPL_HWLOC_CFG_OPTIONS += LDFLAGS=-static
-endif
-endif
-
 CHPL_HWLOC_CFG_OPTIONS += $(CHPL_HWLOC_MORE_CFG_OPTIONS)
 
 default: all


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/commit/2f9e3f7 we changed to
force static linking when hwloc is used.  This turns out to cause a
problem on certain Linux distros like Centos, where libnuma (which hwloc
uses if it is present) is only available as a shared object (.so), not
as a library archive (.a).  If hwloc configures itself to use libnuma
and only libnuma.so is available, forcing static linking causes an error
at link time when libnuma.a cannot be found.  After checking with the
author of 2f9e3f7 I'm removing forced static linking for hwloc.  The
intent at the time was to ensure that Chapel programs linked libhwloc
itself statically, but we believe this is ensured anyway by the fact
that the same commit enabled building a library archive and disabled
building a shared object.