### PR TITLE
Fix gmp build for cygwin32 platform.

### DIFF
--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -27,8 +27,13 @@ ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_CFG_OPTIONS += --enable-static --disable-shared
 endif
 
+#
+# On 32bit platforms (i.e. when CHPL_TARGET_PLATFORM ends with 32), set
+# ABI=32. Because we are setting CFLAGS in the ./configure step, it will not
+# auto-detect ABI=32.
+#
 CHPL_GMP_ABI_ARG =
-ifeq ($(CHPL_MAKE_TARGET_PLATFORM), $(filter $(CHPL_MAKE_TARGET_PLATFORM),linux32 cygwin32))
+ifneq (, $(filter %32,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_ABI_ARG = ABI=32
 endif
 

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -29,7 +29,9 @@ endif
 
 CHPL_GMP_ABI_ARG =
 ifeq (linux32, $(CHPL_MAKE_TARGET_PLATFORM))
+ifeq (cygwin32, $(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_GMP_ABI_ARG = ABI=32
+endif
 endif
 
 GMP_MAKEFILE = $(GMP_BUILD_SUBDIR)/Makefile

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -28,10 +28,8 @@ CHPL_GMP_CFG_OPTIONS += --enable-static --disable-shared
 endif
 
 CHPL_GMP_ABI_ARG =
-ifeq (linux32, $(CHPL_MAKE_TARGET_PLATFORM))
-ifeq (cygwin32, $(CHPL_MAKE_TARGET_PLATFORM))
+ifeq ($(CHPL_MAKE_TARGET_PLATFORM), $(filter $(CHPL_MAKE_TARGET_PLATFORM),linux32 cygwin32))
 CHPL_GMP_ABI_ARG = ABI=32
-endif
 endif
 
 GMP_MAKEFILE = $(GMP_BUILD_SUBDIR)/Makefile


### PR DESCRIPTION
Need to set ABI=32. This fix is the same as #800, which addressed linux32.

### TODO:

* [x] verify gmp builds successfully on cygwin32
* [x] verify gmp still builds on linux32
* [x] run gmp tests on cygwin32 (most pass, some fail with same uint(64) vs. c_ulong issue that exists on linux32 -- see REGRESSIONS)

```bash
start_test \
  test/release/examples/benchmarks/shootout/pidigits.chpl \
  test/modules/standard/ \
  test/studies/shootout/pidigits/
```