### PR TITLE
Use -lpthread, instead of -pthread in io/ferguson/ctests.

### DIFF
--- a/test/io/ferguson/ctests/deque_test.compopts
+++ b/test/io/ferguson/ctests/deque_test.compopts
@@ -1,1 +1,1 @@
--DCHPL_RT_UNIT_TEST $CHPL_HOME/runtime/src/qio/deque.c
+-DCHPL_RT_UNIT_TEST $CHPL_HOME/runtime/src/qio/deque.c -lpthread

--- a/test/io/ferguson/ctests/deque_test.compopts
+++ b/test/io/ferguson/ctests/deque_test.compopts
@@ -1,1 +1,1 @@
--DCHPL_RT_UNIT_TEST $CHPL_HOME/runtime/src/qio/deque.c -pthread
+-DCHPL_RT_UNIT_TEST $CHPL_HOME/runtime/src/qio/deque.c

--- a/test/io/ferguson/ctests/qbuffer_test.compopts
+++ b/test/io/ferguson/ctests/qbuffer_test.compopts
@@ -1,1 +1,1 @@
--DCHPL_RT_UNIT_TEST $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
+-DCHPL_RT_UNIT_TEST $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread

--- a/test/io/ferguson/ctests/qbuffer_test.compopts
+++ b/test/io/ferguson/ctests/qbuffer_test.compopts
@@ -1,1 +1,1 @@
--DCHPL_RT_UNIT_TEST $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -pthread
+-DCHPL_RT_UNIT_TEST $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c

--- a/test/io/ferguson/ctests/qio_bits_test.compopts
+++ b/test/io/ferguson/ctests/qio_bits_test.compopts
@@ -1,1 +1,1 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -pthread
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c

--- a/test/io/ferguson/ctests/qio_bits_test.compopts
+++ b/test/io/ferguson/ctests/qio_bits_test.compopts
@@ -1,1 +1,1 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread

--- a/test/io/ferguson/ctests/qio_formatted_test.compopts
+++ b/test/io/ferguson/ctests/qio_formatted_test.compopts
@@ -1,1 +1,1 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio_formatted.c $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -pthread
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio_formatted.c $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c

--- a/test/io/ferguson/ctests/qio_formatted_test.compopts
+++ b/test/io/ferguson/ctests/qio_formatted_test.compopts
@@ -1,1 +1,1 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio_formatted.c $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio_formatted.c $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread

--- a/test/io/ferguson/ctests/qio_mark_test.compopts
+++ b/test/io/ferguson/ctests/qio_mark_test.compopts
@@ -1,2 +1,2 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread
 

--- a/test/io/ferguson/ctests/qio_mark_test.compopts
+++ b/test/io/ferguson/ctests/qio_mark_test.compopts
@@ -1,2 +1,2 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -pthread
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
 

--- a/test/io/ferguson/ctests/qio_memfile_test.compopts
+++ b/test/io/ferguson/ctests/qio_memfile_test.compopts
@@ -1,2 +1,2 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio_formatted.c $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -pthread
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio_formatted.c $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
 

--- a/test/io/ferguson/ctests/qio_memfile_test.compopts
+++ b/test/io/ferguson/ctests/qio_memfile_test.compopts
@@ -1,2 +1,2 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio_formatted.c $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio_formatted.c $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread
 

--- a/test/io/ferguson/ctests/qio_test.compopts
+++ b/test/io/ferguson/ctests/qio_test.compopts
@@ -1,2 +1,2 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread
 

--- a/test/io/ferguson/ctests/qio_test.compopts
+++ b/test/io/ferguson/ctests/qio_test.compopts
@@ -1,2 +1,2 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -pthread
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
 

--- a/test/io/ferguson/ctests/qio_test.valgrind.compopts
+++ b/test/io/ferguson/ctests/qio_test.valgrind.compopts
@@ -1,2 +1,2 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread
 

--- a/test/io/ferguson/ctests/qio_test.valgrind.compopts
+++ b/test/io/ferguson/ctests/qio_test.valgrind.compopts
@@ -1,2 +1,2 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c -pthread
+-DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/deque.c
 


### PR DESCRIPTION
The latest gcc available in cygwin does not support the -pthread argument.
Update .compopts for io/ferguson/ctests to use `-lpthread` instead of `-pthread`.

`-lpthread` is used in the runtime makefiles, so it seems reasonable to use it in
these tests.

### TODO:

* [x] verify io/ferguson/ctests still passes on a few configs:
  * [x] darwin
  * [x] gasnet + darwin
  * [x] cygwin (success here means most of these ctests pass and two go back to their old failure mode listed in REGRESSIONS)
  * [x] linux64
  * [x] gasnet + linux64