### PR TITLE
Quiet a false gripe when using gcc 4.4.*.

### DIFF
--- a/runtime/src/qio/bulkget.c
+++ b/runtime/src/qio/bulkget.c
@@ -28,7 +28,7 @@
 qbytes_t* bulk_get_bytes(int64_t src_locale, qbytes_t* src_addr)
 {
   qbytes_t* ret;
-  int64_t src_len;
+  int64_t src_len = 0; // init prevents "may be used uninited" with gcc 4.4.*
   qioerr err;
 
   // First, get the length of the bytes.


### PR DESCRIPTION
At bulkget.c:35 the chpl_gen_comm_get() fills (or should fill) src_len,
and then at line 39 we use src_len.  But if you look at the definition
of chpl_gen_comm_get() in chpl-comm-compiler-macros.h, you'll see that
if (chpl_nodeID == node && raddr!=addr) we actually won't do anything at
all to src_len.  Of course we don't need to if this is the case, because
it means we're doing a self-copy.  Unfortunately, at least gcc 4.4.7
can't see this and issues a warning when compiling bulkget.c saying that
src_len may be used uninitialized.  Also unfortunately, gcc 4.4.7 is the
default compiler for Centos 6 and RHEL 6, and when WARNINGS=1 (which is
how we build for nightly testing) this warning prevents building the
runtime.  That makes this gen compiler problem our problem.

Therefore, add an initializer to quiet the compiler in this case, with a
comment that might allow us to realize when the time has come that we no
longer need it.