### PR TITLE
Dodge an interaction problem with the PGI compiler and GNU libtool.

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -7,6 +7,23 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 CHPL_HWLOC_CFG_OPTIONS += --enable-static --disable-shared --disable-libxml2 --disable-pci
 
+ifeq ($(CHPL_MAKE_TARGET_COMPILER), pgi)
+  #
+  # When using the PGI compiler natively (not with the Cray PrgEnv
+  # wrapper), with default dynamic linking, we fail trying to link
+  # lstopo.  The PGI compiler isn't gcc and can't do -print-search-dirs,
+  # so the hwloc libtool ends up using "/usr/lib /lib" as a default
+  # search path and tries to link the 32-bit /usr/lib/libX11.so into the
+  # 64-bit lstopo, getting an architecture mismatch gripe.  To work
+  # around this, disable the cairo graphical backend for lstopo.  This
+  # is the only thing that uses X11, so without it we don't try to link
+  # libX11.  (I also tried using --disable-gl, --x-libraries=/usr/lib64,
+  # and --without-x to solve this problem, and none of those worked.
+  # Forcing static linking does work, but that seems too big a hammer.)
+  #
+  CHPL_HWLOC_CFG_OPTIONS += --disable-cairo
+endif
+
 CHPL_HWLOC_CFG_OPTIONS += $(CHPL_HWLOC_MORE_CFG_OPTIONS)
 
 default: all


### PR DESCRIPTION
When using the PGI compiler natively (not with the Cray PrgEnv wrapper),
with default dynamic linking, we fail trying to link lstopo.  The hwloc
libtool doesn't know how to figure out the compiler's link-time library
search directories, so it uses "/usr/lib /lib" as a default search path
and ends up trying to link the 32-bit /usr/lib/libX11.so into the 64-bit
lstopo, getting an architecture mismatch gripe.  To work around this,
disable the cairo graphical backend for lstopo.  This is the only thing
that uses X11, so without it we don't try to link libX11.  (I also tried
using --disable-gl, --x-libraries=/usr/lib64, and --without-x to solve
this problem, but none of those worked.  Forcing static linking did
work, but seems too big a hammer.)