### PR TITLE
Implemented forall intents for standalone iterators.

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4326,7 +4326,8 @@ isNormalField(Symbol* field)
 
 static CallExpr* toPrimToLeaderCall(Expr* expr) {
   if (CallExpr* call = toCallExpr(expr))
-    if (call->isPrimitive(PRIM_TO_LEADER))
+    if (call->isPrimitive(PRIM_TO_LEADER) ||
+        call->isPrimitive(PRIM_TO_STANDALONE))
       return call;
   return NULL;
 }

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -392,6 +392,8 @@ static void discoverForallBodies(DefExpr* defChplIter,
   if (sa) {
     // standalone case - get the first (and only) block that follows
 
+    firstForallBody  = NULL;
+    secondForallBody = NULL;
     for (Expr* curr = defLeadIdxCopy->next; curr; curr = curr->next)
       if (BlockStmt* block = toBlockStmt(curr)) {
         INT_ASSERT(block->byrefVars->isPrimitive(PRIM_FORALL_LOOP));
@@ -401,7 +403,7 @@ static void discoverForallBodies(DefExpr* defChplIter,
           INT_ASSERT(!isBlockStmt(check));
         break;
       }
-    secondForallBody = NULL;
+    INT_ASSERT(firstForallBody);
 
   } else if (fNoFastFollowers) {
     // no fast followers

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -196,7 +196,7 @@ checkForRecordsWithArrayFields(Expr* ref, std::vector<Symbol*>& outerVars) {
 }
 
 
-// ForallLeaderArgs: add actuals to _toLeader/Zip()
+// ForallLeaderArgs: add actuals to _toLeader/_toLeaderZip()/_toStandalone().
 // (The leader will be converted to accept them during resolution.)
 static void addActualsTo_toLeader(Symbol* serIterSym,
                                   std::vector<Symbol*>& outerVars)
@@ -210,7 +210,8 @@ static void addActualsTo_toLeader(Symbol* serIterSym,
       if (seekCall->isPrimitive(PRIM_MOVE))
         if (CallExpr* seekSubCall = toCallExpr(seekCall->get(2)))
           if (seekSubCall->isNamed("_toLeader") ||
-              seekSubCall->isNamed("_toLeaderZip")) {
+              seekSubCall->isNamed("_toLeaderZip") ||
+              seekSubCall->isNamed("_toStandalone")) {
             tlCall = seekSubCall;
             break;
           }
@@ -382,10 +383,27 @@ static void discoverForallBodies(DefExpr* defChplIter,
 
   BlockStmt* b1;
   DefExpr*   defLeadIdxCopy;
-  findBlockWithDefOf(defChplIter->next, "chpl__leadIdxCopy",
+  bool       sa = !strcmp(defChplIter->sym->name, "chpl__iterSA");
+
+  findBlockWithDefOf(defChplIter->next,
+                     sa ? "chpl__saIdxCopy" : "chpl__leadIdxCopy",
                      b1, defLeadIdxCopy);
 
-  if (fNoFastFollowers) {
+  if (sa) {
+    // standalone case - get the first (and only) block that follows
+
+    for (Expr* curr = defLeadIdxCopy->next; curr; curr = curr->next)
+      if (BlockStmt* block = toBlockStmt(curr)) {
+        INT_ASSERT(block->byrefVars->isPrimitive(PRIM_FORALL_LOOP));
+        firstForallBody = block;
+        // this loop is for asserts only
+        for (Expr* check = firstForallBody->next; check; check = check->next)
+          INT_ASSERT(!isBlockStmt(check));
+        break;
+      }
+    secondForallBody = NULL;
+
+  } else if (fNoFastFollowers) {
     // no fast followers
 
     BlockStmt* b2;
@@ -445,14 +463,14 @@ static void discoverForallBodies(DefExpr* defChplIter,
   }
 }
 
-static void getOuterVars(BlockStmt* body, Symbol*& serIterSym,
-                         Symbol*& leadIdxSym, Symbol*& leadIdxCopySym,
-                         SymbolMap*& uses)
+static void getIterSymbols(BlockStmt* body, Symbol*& serIterSym,
+                           Symbol*& leadIdxSym, Symbol*& leadIdxCopySym)
 {
   CallExpr* const byrefVars = body->byrefVars;
   INT_ASSERT(byrefVars->isPrimitive(PRIM_FORALL_LOOP));
 
-  // Extract  chpl__iter,  chpl__leadIdx,  chpl__leadIdxCopy.
+  // Extract  chpl__iterLF,  chpl__leadIdx,  chpl__leadIdxCopy
+  // or       chpl__iterSA,  chpl__saIdx,    chpl__saIdxCopy
   SymExpr* serIterSE     = toSymExpr(byrefVars->get(1)->remove());
   SymExpr* leadIdxSE     = toSymExpr(byrefVars->get(1)->remove());
   SymExpr* leadIdxCopySE = toSymExpr(byrefVars->get(1)->remove());
@@ -461,25 +479,25 @@ static void getOuterVars(BlockStmt* body, Symbol*& serIterSym,
   serIterSym     = serIterSE->var;
   leadIdxSym     = leadIdxSE->var;
   leadIdxCopySym = leadIdxCopySE->var;
+}
 
-  // do the same as in 'if (needsCapture(fn))' below
+static void getOuterVars(BlockStmt* body, SymbolMap*& uses)
+{
+  CallExpr* const byrefVars = body->byrefVars;
+  INT_ASSERT(byrefVars->isPrimitive(PRIM_FORALL_LOOP));
+
+  // do the same as in 'if (needsCapture(fn))' createTaskFunctions()
   uses = new SymbolMap();
   findOuterVars(body, uses);
   pruneOuterVars(uses, byrefVars, true);
   pruneThisArg(body->parentSymbol, uses, true);
 }
 
-static void verifyOuterVars(BlockStmt* body2, Symbol* serIterSym1,
-                            Symbol* leadIdxSym1, Symbol* leadIdxCopySym1,
+static void verifyOuterVars(BlockStmt* body2,
                             SymbolMap* uses1, int numOuterVars1)
 {
-  Symbol *serIterSym2, *leadIdxSym2, *leadIdxCopySym2;
   SymbolMap* uses2;
-  getOuterVars(body2, serIterSym2, leadIdxSym2, leadIdxCopySym2, uses2);
-
-  INT_ASSERT(serIterSym1     == serIterSym2);
-  INT_ASSERT(leadIdxSym1     == leadIdxSym2);
-  INT_ASSERT(leadIdxCopySym1 == leadIdxCopySym2);
+  getOuterVars(body2, uses2);
 
   int numOuterVars2 = 0;
   form_Map(SymbolMapElem, e, *uses2) {
@@ -501,25 +519,49 @@ static void verifyOuterVars(BlockStmt* body2, Symbol* serIterSym1,
 //
 void implementForallIntents1(DefExpr* defChplIter)
 {
-  // Find the corresponding forall loop body,
-  // or two bodies if fast followers are enabled.
+  //
+  // Find the corresponding forall loop body(s).
+  //
+  // The following scenarios are defined in build.cpp
+  // and matched against in the following:
+  //
+  // - Leader-follower case, when fast followers are enabled:
+  //  - forallBody1 and forallBody2 are non-NULL
+  //  - forallBody2->byrefVars is a PRIM_FORALL_LOOP whose first arguments are:
+  //      chpl__iterLF, chpl__leadIdx, chpl__leadIdxCopy
+  //
+  // - Leader-follower case, when fast followers are disabled:
+  //  - forallBody2 == NULL
+  //  - forallBody1->byrefVars is what forallBody2->byrefVars is above
+  //
+  // - In all three cases, the user-speicified contents of the 'with' clause
+  //   are appended to forallBody1/2->byrefVars specified above
+  //
+  // - Standalone case:
+  //  - forallBody2 == NULL
+  //  - forallBody1->byrefVars is a PRIM_FORALL_LOOP whose first arguments are:
+  //      chpl__iterSA, chpl__saIdx, chpl__saIdxCopy
+  //
   BlockStmt* forallBody1;
   BlockStmt* forallBody2;
   discoverForallBodies(defChplIter, forallBody1, forallBody2);
 
-  // If both bodies are present, I expect them to be copies of one another.
+  // If both bodies are present, I expect them to be copies of one another,
+  // except for byrefVars field (see above).
   // So we discover everything for the first one and verify
   // that it's the same for the second one.
-  // I think swapping the first and the second in the below
-  // would be equivalent, when both are present.
-
   // Once we found it/them, process the first forall body clone.
   // Stash away misc things for comparison with the second one.
 
-  Symbol *serIterSym1, *leadIdxSym1, *leadIdxCopySym1;
+  Symbol *serIterSym, *leadIdxSym, *leadIdxCopySym;
   SymbolMap* uses1;
 
-  getOuterVars(forallBody1, serIterSym1, leadIdxSym1, leadIdxCopySym1, uses1);
+  if (forallBody2)
+    getIterSymbols(forallBody2, serIterSym, leadIdxSym, leadIdxCopySym);
+  else
+    getIterSymbols(forallBody1, serIterSym, leadIdxSym, leadIdxCopySym);
+
+  getOuterVars(forallBody1, uses1);
 
   // Create shadow variables. We keep the vectors to ensure consistent
   // iteration order in for_vector(outerVars) vs. for_vector(shadowVars).
@@ -534,9 +576,9 @@ void implementForallIntents1(DefExpr* defChplIter)
 
     checkForRecordsWithArrayFields(defChplIter, outerVars);
 
-    addActualsTo_toLeader(serIterSym1, outerVars);
+    addActualsTo_toLeader(serIterSym, outerVars);
 
-    detupleLeadIdx(leadIdxSym1, leadIdxCopySym1, shadowVars);
+    detupleLeadIdx(leadIdxSym, leadIdxCopySym, shadowVars);
 
     // replace outer vars with shadows in the loop body
     replaceVarUsesWithFormals(forallBody1, uses1);
@@ -550,8 +592,7 @@ void implementForallIntents1(DefExpr* defChplIter)
   {
     // for assertions only
     if (fVerify)
-      verifyOuterVars(forallBody2, serIterSym1, leadIdxSym1, leadIdxCopySym1,
-                      uses1, numOuterVars1);
+      verifyOuterVars(forallBody2, uses1, numOuterVars1);
 
     // Threading through the leader call was done for forallBody1.
 
@@ -571,7 +612,11 @@ void implementForallIntents1(DefExpr* defChplIter)
 //  implementForallIntents2()
 //-----------------------------------------------------------------------------
 //
-// This is Part 2 - it processes each call to _toLeader() or _toLeaderZip().
+// This is Part 2 - it processes each call to _toLeader() or _toLeaderZip()
+// or _toStandalone().
+//
+// Throughout this file, for historical reasons, terms/identifiers with
+// "leader" relate to both leader and standalone iterators.
 //
 
 

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -182,6 +182,19 @@ module ChapelIteratorSupport {
   inline proc _toLeaderZip(x: _tuple, args...)
     return _toLeader(x(1), (...args));
 
+  pragma "no implicit copy"
+  pragma "expand tuples with values"
+  inline proc _toStandalone(iterator: _iteratorClass, args...)
+    return chpl__autoCopy(__primitive("to standalone", iterator, (...args)));
+
+  pragma "expand tuples with values"
+  inline proc _toStandalone(ir: _iteratorRecord, args...) {
+    pragma "no copy" var ic = _getIterator(ir);
+    pragma "no copy" var standalone = _toStandalone(ic, (...args));
+    _freeIterator(ic);
+    return standalone;
+  }
+
   //
   // return true if any iterator supports fast followers
   //

--- a/test/functions/iterators/vass/standaloneForallIntents.chpl
+++ b/test/functions/iterators/vass/standaloneForallIntents.chpl
@@ -1,0 +1,107 @@
+config const n: int = 10;
+config const ntasks: int = 2;
+
+// from test/functions/iterators/diten/standaloneArgs.chpl
+
+iter myiter(nn: int, nt: int) {
+  writeln("Serial");
+  for i in 0..#nt {
+    for i in i*nn..#nn {
+      yield i;
+    }
+  }
+}
+
+iter myiter(nn: int, nt: int, param tag: iterKind) where tag == iterKind.standalone {
+  writeln("Standalone, with args");
+  coforall i in 0..#nt {
+    for i in i*nn..#nn {
+      yield i;
+    }
+  }
+}
+
+iter myiter(nn: int, nt: int, param tag: iterKind) where tag == iterKind.leader {
+  writeln("Leader");
+  coforall i in 0..#nt {
+    yield i*nn..#nn;
+  }
+}
+
+iter myiter(nn:int, nt: int, followThis, param tag: iterKind) where tag == iterKind.follower {
+  writeln("Follower");
+  for i in followThis {
+    yield i;
+  }
+}
+
+// from test/functions/iterators/diten/standaloneParallelIter.chpl
+
+iter myiter() {
+  writeln("Serial");
+  for i in 0..#n*ntasks do yield i;
+}
+
+iter myiter(param tag:iterKind) where tag == iterKind.leader {
+  writeln("Leader");
+  coforall i in 0..#ntasks {
+    const tmp = i*n..#n;
+    yield tmp;
+  }
+}
+
+iter myiter(param tag:iterKind, followThis: range) where tag == iterKind.follower {
+  writeln("Follower");
+  for i in followThis {
+    yield i;
+  }
+}
+
+iter myiter(param tag:iterKind) where tag == iterKind.standalone {
+  writeln("Standalone, no args");
+  coforall i in 0..#ntasks {
+    for i in i*n..#n {
+      yield i;
+    }
+  }
+}
+
+proc checkNoIntent() {
+  var xxx = 222;
+  var sss$, qqq$: sync int;
+  cobegin with (ref xxx) {
+    {
+      sss$;
+      xxx = 333;
+      writeln("  updated to: ", xxx);
+      qqq$ = 1;
+    }
+    // 'xxx' is passed implicitly by blank intent
+    forall iii in myiter(1,1) {
+      sss$ = 1; // enable update to xxx
+      qqq$;     // wait for the update to complete
+      writeln("  within forall: ", xxx);
+    }
+  }
+  writeln("  after forall: ", xxx);
+}
+
+proc checkRefIntent() {
+  var xxx = 100;
+  var sss$: sync int = 1;
+
+  // 'xxx' is passed implicitly by blank intent
+  forall iii in myiter() with (ref xxx) {
+    sss$;
+    xxx += 1;
+    writeln(xxx);
+    sss$ = 1;
+  }
+  writeln("After forall: ", xxx);
+}
+
+
+proc main {
+  checkNoIntent();
+  checkRefIntent();
+}

--- a/test/functions/iterators/vass/standaloneForallIntents.good
+++ b/test/functions/iterators/vass/standaloneForallIntents.good
@@ -1,0 +1,26 @@
+Standalone, with args
+  updated to: 333
+  within forall: 222
+  after forall: 333
+Standalone, no args
+101
+102
+103
+104
+105
+106
+107
+108
+109
+110
+111
+112
+113
+114
+115
+116
+117
+118
+119
+120
+After forall: 120


### PR DESCRIPTION
The case of a standalone iterator is largely parallel
to the case of a leader-follower iterator.
The transformations performed on/with the standalone iterator
parallel those for the leader iterator.

While there, did minor changes for clarity and improved similarity
between handling of the two cases.

Reference: standalone iterators were added in #1006:
  https://github.com/chapel-lang/chapel/pull/1006


* In buildStandaloneForallLoopStmt():

 - Added what's done for the leader iterator in buildForallLoopStmt().

 - In SABlock:

  - Use destructureIndices() immediately, instead of inlining
    destructureIndices()'s outer if-elseif-else chain.

  - Destructure into saIdxCopy, not saIdx.

  - NB "new DefExpr(saIdxCopy)" and a move into saIdxCopy
    need to be inserted after destructureIndices(), because the latter
    always inserts at the top of the target block, SABlock in this case.

 - Eliminated a copy() on 'loopBody', seems we can do without it.

* In buildForallLoopStmt():

 - Reverted back from loopBodyCopy to loopBody.
   loopBodyCopy was needed while forall intents machinery was not working
   for standalone iterators.

 - Created copies of loopBody for fast-follower and standalone
   cases ahead of when they are used.

  - This avoids the addition of SymExprs for iterRec, leadIdx, leadIdxCopy
    into those copies' byrefVars (done via byref_vars->insertAtHead(...)).
    For fast-follower case those three are no longer wanted (see below).
    For standalone, buildStandaloneForallLoopStmt() inserts its own instead.

  - This let me create one copy of loopBody fewer (for 'followBlock').

* Changes to:

    functionResolution.cpp
    implementForallIntents.cpp
    ChapelIteratorSupport.chpl

  that add "standalone" counterparts to _toLeader, straightforwardly.

* In implementForallIntents1(), when both forallBody1 and forallBody2
  are present, chpl__iterLF, chpl__leadIdx, chpl__leadIdxCopy
  are no longer the first three args of forallBody1->byrefVars.
  (Due to a change in buildForallLoopStmt() - see above.)

  So we extract them into serIterSym, leadIdxSym, leadIdxCopySym
  from forallBody2 only, and do not verify them against forallBody1.

  For this, I teased getIterSymbols() out from getOuterVars().

  I continue checking that getOuterVars() produce the same set of
  outer variables for forallBody1 and forallBody2 (when both are present).

* "While there":

 - Moved INT_FATAL("Unexpected") from the former destructureIndices()'s clone
   in buildStandaloneForallLoopStmt() into destructureIndices() proper.

 - Restored camel case in "chpl__saIdxCopy".

 - Reordered some declarations in the generated code, to my taste.

* Added a test that exercises an implicit blank intent
  and an explicit ref intent in foralls over standalone iterators.
