### PR TITLE
Move chpl_getLocaleID into the modules.

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -651,7 +651,7 @@ returnRecordsByReferenceArguments() {
   forv_Vec(CallExpr, call, gCallExprs) {
     if (call->parentSymbol) {
       if (FnSymbol* fn = requiresImplicitDestroy(call)) {
-        if (fn->hasFlag(FLAG_EXTERN))
+        if (fn->hasFlag(FLAG_EXTERN) || fn->hasFlag(FLAG_EXPORT))
           continue;
         CallExpr* move = toCallExpr(call->parentExpr);
         INT_ASSERT(move->isPrimitive(PRIM_MOVE));

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -651,7 +651,7 @@ returnRecordsByReferenceArguments() {
   forv_Vec(CallExpr, call, gCallExprs) {
     if (call->parentSymbol) {
       if (FnSymbol* fn = requiresImplicitDestroy(call)) {
-        if (fn->hasFlag(FLAG_EXTERN) || fn->hasFlag(FLAG_EXPORT))
+        if (fn->hasFlag(FLAG_EXTERN))
           continue;
         CallExpr* move = toCallExpr(call->parentExpr);
         INT_ASSERT(move->isPrimitive(PRIM_MOVE));

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -358,9 +358,18 @@ module ChapelLocale {
 
   extern proc chpl_task_getRequestedSubloc(): chpl_sublocID_t;
 
+  pragma "insert line file info"
+  export
+  proc chpl_getLocaleID() : chpl_localeID_t{
+    if localeModelHasSublocales then
+      return chpl_rt_buildLocaleID(chpl_nodeID, chpl_task_getRequestedSubloc());
+    else
+      return chpl_rt_buildLocaleID(chpl_nodeID, c_sublocid_any);
+  }
+
   // Return the locale ID of the current locale
   inline proc here_id {
-    return chpl_buildLocaleID(chpl_nodeID,chpl_task_getRequestedSubloc());
+    return chpl_getLocaleID();
   }
   // Return the current locale
   inline proc here {

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -360,16 +360,18 @@ module ChapelLocale {
 
   pragma "insert line file info"
   export
-  proc chpl_getLocaleID() : chpl_localeID_t{
+  proc chpl_getLocaleID(ref localeID: chpl_localeID_t) {
     if localeModelHasSublocales then
-      return chpl_rt_buildLocaleID(chpl_nodeID, chpl_task_getRequestedSubloc());
+      localeID = chpl_rt_buildLocaleID(chpl_nodeID, chpl_task_getRequestedSubloc());
     else
-      return chpl_rt_buildLocaleID(chpl_nodeID, c_sublocid_any);
+      localeID = chpl_rt_buildLocaleID(chpl_nodeID, c_sublocid_any);
   }
 
   // Return the locale ID of the current locale
   inline proc here_id {
-    return chpl_getLocaleID();
+    var localeID: chpl_localeID_t;
+    chpl_getLocaleID(localeID);
+    return localeID;
   }
   // Return the current locale
   inline proc here {

--- a/runtime/include/chpl-gen-includes.h
+++ b/runtime/include/chpl-gen-includes.h
@@ -56,10 +56,11 @@ chpl_localeID_t id_rt2pub(c_localeid_t i)
 {
   return chpl_rt_buildLocaleID(i >> 32, i & 0xffffffff);
 }
-
-extern chpl_localeID_t chpl_getLocaleID (int64_t _ln, c_string _fn);
+extern void chpl_getLocaleID (chpl_localeID_t* localdID,  int64_t _ln, c_string _fn);
 static ___always_inline
 chpl_localeID_t chpl_gen_getLocaleID(void)
 {
-  return chpl_getLocaleID(0, NULL);
+  chpl_localeID_t localeID;
+  chpl_getLocaleID(&localeID, 0, NULL);
+  return localeID;
 }

--- a/runtime/include/chpl-gen-includes.h
+++ b/runtime/include/chpl-gen-includes.h
@@ -57,8 +57,9 @@ chpl_localeID_t id_rt2pub(c_localeid_t i)
   return chpl_rt_buildLocaleID(i >> 32, i & 0xffffffff);
 }
 
+extern chpl_localeID_t chpl_getLocaleID (int64_t _ln, c_string _fn);
 static ___always_inline
 chpl_localeID_t chpl_gen_getLocaleID(void)
 {
-  return chpl_rt_buildLocaleID(chpl_nodeID, chpl_task_getRequestedSubloc());
+  return chpl_getLocaleID(0, NULL);
 }

--- a/runtime/include/chpl-gen-includes.h
+++ b/runtime/include/chpl-gen-includes.h
@@ -56,7 +56,7 @@ chpl_localeID_t id_rt2pub(c_localeid_t i)
 {
   return chpl_rt_buildLocaleID(i >> 32, i & 0xffffffff);
 }
-extern void chpl_getLocaleID (chpl_localeID_t* localdID,  int64_t _ln, c_string _fn);
+extern void chpl_getLocaleID (chpl_localeID_t* localeID,  int64_t _ln, c_string _fn);
 static ___always_inline
 chpl_localeID_t chpl_gen_getLocaleID(void)
 {


### PR DESCRIPTION
chpl_getLocaleID (really chpl_gen_getLocaleID) previously lived in the runtime
and was defined as:

"
static ___always_inline
chpl_localeID_t chpl_gen_getLocaleID(void)
{
  return chpl_rt_buildLocaleID(chpl_nodeID, chpl_task_getRequestedSubloc());
}
"

For the flat locale model, the call to chpl_task_getRequestedSubloc() should
just return c_sublocid_any. With 50588bdcef0c7c1ebd15aecd3245ae65f4f95dfd this
call became more expensive for flat. It still returns c_sublocid_any, but it
goes through task local storage to figure that out. chpl_gen_getLocaleID is
a heavily called function and so this overhead resulted in a drastic
performance regression for --no-local and multi-locale tests.

This patch moves the definition of chpl_get_localeID into the modules, where we
know if we're compiling with or without sublocales. If we do not have
sublocales we simply use c_sublocid_any instead of calling into
chpl_task_getRequestedSubloc(). chpl_gen_getLocaleID is still defined in the
runtime, but it is simply a wrapper that calls chpl_getLocaleID. It preserves
the old function signature, and handles calling chpl_getLocaleID with the
right arguments.

This appears to have solved the performance regressions, at least in the case
I looked at (/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl). We might
need to come back to it again after a few nights of testing, since this does
introduce slightly more overhead than we had prior to
50588bdcef0c7c1ebd15aecd3245ae65f4f95dfd. This current approach adds an extra
function call that can't be inlined anymore. I believe this can be addressed,
but this current patch should get rid of the most of the overhead. The
performance regression was caused by calls to chpl_gen_getLocaleID that are
inserted by the compiler in AST/expr.cpp. I believe we can just update the
compiler to emit a call to chpl_getLocaleID which should let the backend
compiler inline the call. I'm not quite sure how to build the arguments for the
function at codegen time yet though.

Note that this doesn't address any performance issues for numa, and that we
need to address this performance hit of calling chpl_task_getRequestedSubloc
somehow.

As a last note, the initial version of this patch had chpl_getLocaleID return
a record, instead of having it take a record by ref. However we currently
transform functions that return records to take them by ref anyways. I had
originally disabled that transformation for exported functions, but it wasn't
clear if that was the right solution or if we just wanted to say exported
functions that return records are not allowed. To avoid having to deal with
this, I just changed the signature to explicitly take the chpl_localeID_t by
ref.
