### PR TITLE
Have dygraphs use json

### DIFF
--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -78,18 +78,15 @@ def show_date(value):
     else:
         return time.strftime('%Y-%m-%d', value)
 
-# converts a csv file to json. sets ginfo.labels as labels must be explicitly
-# set in dygraphs when you pass in a native array instead of csv. parses the
-# csv, cleans up the parsed representation and writes out using json.dumps
+# converts a csv file to json. Converts the csv file to json where the json
+# object has two members: the lables and the actual data formatted as required
+# by dygraphs
 def csv_to_json(csvFile, ginfo):
     data = parse_csv(csvFile)
-    labels = data[0]
-    data = data[1:]
-
     # each label is stored in a single element array because of how it is
     # parsed, get rid of that array so labels is no a simple array of strings
-    labels = [a[0] for a in labels]
-    ginfo.labels = json.dumps(labels)
+    labels = [a[0] for a in data[0]]
+    data = data[1:]
 
     lines = []
     for line in data:
@@ -108,8 +105,9 @@ def csv_to_json(csvFile, ginfo):
                 curLine.append([try_parse_float(x) for x in seriesArr])
         lines.append(curLine)
 
+    jsonObj = {'labels': labels, 'data': lines}
     with open(csvFile, 'w') as f:
-        f.write(json.dumps(lines))
+        f.write(json.dumps(jsonObj))
 
 # Helper functions to parse/write/sort a dygraphs compatible csv file.
 #
@@ -331,7 +329,6 @@ class GraphStuff:
         suites =  (', '.join('"' + s + '"' for s in ginfo.suites if s))
         self.gfile.write('   "suites" : [%s],\n'%(suites))
         self.gfile.write('   "datfname" : "%s",\n'%(ginfo.datfname))
-        self.gfile.write('   "labels"   : %s,\n'%(ginfo.labels))
         self.gfile.write('   "ylabel" : "%s",\n'%(ginfo.ylabel))
         self.gfile.write('   "startdate" : "%s",\n'%(ginfo.startdate))
         self.gfile.write('   "enddate" : "%s",\n'%(ginfo.enddate))
@@ -442,7 +439,6 @@ class GraphClass:
         self.title = ''
         self.suites = _suites
         self.graphname = ''
-        self.labels = '[]'
         self.ylabel = ''
         self.startdate = _startdate
         self.enddate = _enddate

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -83,6 +83,12 @@ def show_date(value=time.localtime()):
 # by dygraphs
 def csv_to_json(csvFile, ginfo):
     data = parse_csv(csvFile)
+    os.unlink(csvFile)
+
+    # rename the csv file to indicate that it's a json file
+    jsonFile = os.path.splitext(csvFile)[0]+'.json'
+    ginfo.datfname = os.path.splitext(ginfo.datfname)[0]+'.json'
+
     # each label is stored in a single element array because of how it is
     # parsed, get rid of that array so labels is no a simple array of strings
     labels = [a[0] for a in data[0]]
@@ -114,7 +120,7 @@ def csv_to_json(csvFile, ginfo):
         lines.append(line)
 
     jsonObj = {'labels': labels, 'data': lines}
-    with open(csvFile, 'w') as f:
+    with open(jsonFile, 'w') as f:
         f.write(json.dumps(jsonObj))
 
 # Helper functions to parse/write/sort a dygraphs compatible csv file.

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -90,7 +90,7 @@ def csv_to_json(csvFile, ginfo):
     ginfo.datfname = os.path.splitext(ginfo.datfname)[0]+'.json'
 
     # each label is stored in a single element array because of how it is
-    # parsed, get rid of that array so labels is no a simple array of strings
+    # parsed, get rid of that array so labels is now a simple array of strings
     labels = [a[0] for a in data[0]]
     data = data[1:]
 

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -4,6 +4,7 @@ import sys, os, shutil, time, math, re
 from optparse import OptionParser
 
 import fileReadHelp
+import json
 try:
     import annotate
 except ImportError:
@@ -77,6 +78,38 @@ def show_date(value):
     else:
         return time.strftime('%Y-%m-%d', value)
 
+# converts a csv file to json. sets ginfo.labels as labels must be explicitly
+# set in dygraphs when you pass in a native array instead of csv. parses the
+# csv, cleans up the parsed representation and writes out using json.dumps
+def csv_to_json(csvFile, ginfo):
+    data = parse_csv(csvFile)
+    labels = data[0]
+    data = data[1:]
+
+    # each label is stored in a single element array because of how it is
+    # parsed, get rid of that array so labels is no a simple array of strings
+    labels = [a[0] for a in labels]
+    ginfo.labels = json.dumps(labels)
+
+    lines = []
+    for line in data:
+        # like for the labels, strip the array surrounding the date
+        curDate = line[0][0]
+        dataForCurDate = line[1:]
+        curLine = [curDate]
+        # the data for a series on the current date is stored as ['val'],
+        # ['low', 'med', 'high'], or ['']. Need to parse as floats, and turn
+        # [''] (no data for this series on this date) into None so json.dumps
+        # turns it into null.
+        for seriesArr in dataForCurDate:
+            if len(seriesArr) == 1 and seriesArr[0] == '':
+                curLine.append(None)
+            else:
+                curLine.append([try_parse_float(x) for x in seriesArr])
+        lines.append(curLine)
+
+    with open(csvFile, 'w') as f:
+        f.write(json.dumps(lines))
 
 # Helper functions to parse/write/sort a dygraphs compatible csv file.
 #
@@ -166,7 +199,6 @@ def sort_csv(csvFile):
     data = zip(*data)
 
     data_to_csv(data, csvFile)
-
 
 ############
 
@@ -299,6 +331,7 @@ class GraphStuff:
         suites =  (', '.join('"' + s + '"' for s in ginfo.suites if s))
         self.gfile.write('   "suites" : [%s],\n'%(suites))
         self.gfile.write('   "datfname" : "%s",\n'%(ginfo.datfname))
+        self.gfile.write('   "labels"   : %s,\n'%(ginfo.labels))
         self.gfile.write('   "ylabel" : "%s",\n'%(ginfo.ylabel))
         self.gfile.write('   "startdate" : "%s",\n'%(ginfo.startdate))
         self.gfile.write('   "enddate" : "%s",\n'%(ginfo.enddate))
@@ -409,6 +442,7 @@ class GraphClass:
         self.title = ''
         self.suites = _suites
         self.graphname = ''
+        self.labels = '[]'
         self.ylabel = ''
         self.startdate = _startdate
         self.enddate = _enddate
@@ -628,6 +662,8 @@ class GraphClass:
         # functions section above, you can eliminate the intermediate step.
         if self.sort:
             sort_csv(fname)
+
+        csv_to_json(fname, self)
 
         if startdate == None:
             startdate = time.localtime()

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -72,14 +72,14 @@ def parse_date(value, dateformat='%m/%d/%y'):
     else:
         return time.strptime(value.strip(), dateformat)
 
-def show_date(value):
+def show_date(value=time.localtime()):
     if numericX:
         return value
     else:
         return time.strftime('%Y-%m-%d', value)
 
 # converts a csv file to json. Converts the csv file to json where the json
-# object has two members: the lables and the actual data formatted as required
+# object has two members: the labels and the actual data formatted as required
 # by dygraphs
 def csv_to_json(csvFile, ginfo):
     data = parse_csv(csvFile)
@@ -104,6 +104,14 @@ def csv_to_json(csvFile, ginfo):
             else:
                 curLine.append([try_parse_float(x) for x in seriesArr])
         lines.append(curLine)
+
+    # if there was no data in the csvFile, create an empty entry for todays
+    # date. Dygraphs does not accept a zero length array for the data so we add
+    # a single entry for today's date with null data for each series
+    if len(lines) == 0:
+        line = [None for label in labels]
+        line[0] = show_date()
+        lines.append(line)
 
     jsonObj = {'labels': labels, 'data': lines}
     with open(csvFile, 'w') as f:
@@ -132,16 +140,17 @@ def csv_to_json(csvFile, ginfo):
 # that date
 
 def parse_csv(csvFile):
-    with open(csvFile, 'r') as f:
-        lines = f.readlines();
+    lines = fileReadHelp.ReadFileWithComments(csvFile)
 
     data = []
     for line in lines:
-        valuesString = line.strip('\n').split(',')
-        values = []
-        for valueString in valuesString:
-             values.append(valueString.split(';'))
-        data.append(values)
+        line = line.rstrip()
+        if len(line) > 0:
+            valuesString = line.split(',')
+            values = []
+            for valueString in valuesString:
+                 values.append(valueString.split(';'))
+            data.append(values)
 
     return data
 

--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -7,6 +7,7 @@
         <script type="text/javascript"
                 src="http://dygraphs.com/excanvas.js"></script>
         <![endif]-->
+    <script src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
     <script type="text/javascript"
             src="dygraph-combined.js"></script>
     <!-- <script type="text/javascript"

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -795,6 +795,16 @@ function displaySelectedGraphs() {
 // Load the data, and create a new dygraphs
 function getDataAndGenGraph(graphInfo) {
   var dataFile = 'CSVfiles/'+graphInfo.datfname;
+
+  // convert annotations to millis since epoch since we're using a native
+  // array. We could do this in genGraphs, but then we have to think about
+  // timezones and all that stuff, it's fast enough and far easier to just let
+  // dygraphs do it
+  var ann = graphInfo.annotations;
+  for (var i=0; i<ann.length; i++) {
+    ann[i].x = parseDate(ann[i].x);
+  }
+
   // need to get the divs before the async call to get the json so graphs are
   // displayed in the order they are listed, regardless of the order they are
   // loaded.

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -128,7 +128,7 @@ function getNextDivs(afterDiv, afterLDiv) {
 
 // Gen a new dygraph, if an existing graph is being expanded then expandInfo
 // will contain the expansion information, else it is null
-function genDygraph(graphInfo, graphDivs, graphData, expandInfo) {
+function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
 
   var div = graphDivs.div;
   var ldiv = graphDivs.ldiv;
@@ -167,7 +167,7 @@ function genDygraph(graphInfo, graphDivs, graphData, expandInfo) {
     highlightSeriesBackgroundAlpha: 1,
     // So it's easier to zoom in on the right side
     rightGap: 15,
-    labels: graphInfo.labels,
+    labels: graphLabels,
     labelsDiv: ldiv,
     labelsSeparateLines: true,
     dateWindow: [startdate, enddate],
@@ -225,7 +225,7 @@ function genDygraph(graphInfo, graphDivs, graphData, expandInfo) {
       g.setAnnotations(g.annotations());
     }
 
-    expandGraphs(g, graphInfo, graphDivs, graphData);
+    expandGraphs(g, graphInfo, graphDivs, graphData, graphLabels);
 
   });
 
@@ -241,11 +241,11 @@ function genDygraph(graphInfo, graphDivs, graphData, expandInfo) {
 // series that have the same name but one ends with ' (examples)' and the other
 // ' (all') They will both be shown on the expanded graph but the examples one
 // will not be shown on the graph containing all of them.
-function expandGraphs(graph, graphInfo, graphDivs, graphData) {
+function expandGraphs(graph, graphInfo, graphDivs, graphData, graphLabels) {
 
   var expandAllSentinel = -1;
   var expandNum = graphInfo.expand;
-  var labels = graphInfo.labels;
+  var labels = graphLabels;
 
   // if we don't need to expand just return
   if (!expandNum || expandNum === 0) {
@@ -306,7 +306,6 @@ function expandGraphs(graph, graphInfo, graphDivs, graphData) {
     var newLabels = labels.slice(0,1);
     newLabels.push(labels[j]);
     newLabels.push(labels[exampleIndex]);
-    newInfo.labels = newLabels;
 
     var newData = transposedData.slice(0,1);
     newData = newData.concat(transposedData.slice(j, j+1), transposedData.slice(exampleIndex, exampleIndex+1));
@@ -322,7 +321,7 @@ function expandGraphs(graph, graphInfo, graphDivs, graphData) {
     expandInfo = {
       colors: colors
     }
-    genDygraph(newInfo, newDivs, newData, expandInfo);
+    genDygraph(newInfo, newDivs, newData, newLabels, expandInfo);
     i++;
   }
 }
@@ -800,14 +799,16 @@ function getDataAndGenGraph(graphInfo) {
   // displayed in the order they are listed, regardless of the order they are
   // loaded.
   var graphDivs = getNextDivs();
-  $.getJSON(dataFile)
-    .done( function(graphData) {
+  var json = $.getJSON(dataFile)
+    .done( function(json) {
+      var graphData = json.data;
+      var graphLabels = json.labels;
       for (var j = 0; j < graphData.length; j++) {
         graphData[j][0] = new Date(parseDate(graphData[j][0]));
       }
-      genDygraph(graphInfo, graphDivs, graphData);
+      genDygraph(graphInfo, graphDivs, graphData, graphLabels);
     })
-    .fail( function( jqxhr, textStatus, error ) {
+    .fail( function(jqxhr, textStatus, error) {
       var err = textStatus + ', ' + error;
       console.log( 'Request for ' + dataFile + ' Failed: ' + err );
     });

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -800,9 +800,12 @@ function getDataAndGenGraph(graphInfo) {
   // array. We could do this in genGraphs, but then we have to think about
   // timezones and all that stuff, it's fast enough and far easier to just let
   // dygraphs do it
-  var ann = graphInfo.annotations;
-  for (var i=0; i<ann.length; i++) {
-    ann[i].x = parseDate(ann[i].x);
+  if (!graphInfo.loadedAnnotations) {
+    var ann = graphInfo.annotations;
+    for (var i=0; i<ann.length; i++) {
+      ann[i].x = parseDate(ann[i].x);
+    }
+    graphInfo.loadedAnnotations = true;
   }
 
   // need to get the divs before the async call to get the json so graphs are

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -128,122 +128,108 @@ function getNextDivs(afterDiv, afterLDiv) {
 
 // Gen a new dygraph, if an existing graph is being expanded then expandInfo
 // will contain the expansion information, else it is null
-function genDygraph(graphInfo, expandInfo) {
+function genDygraph(graphInfo, graphDivs, graphData, expandInfo) {
 
-  // setup the divs
-  var afterDiv = null;
-  var afterLDiv = null;
-  if (expandInfo) {
-    afterDiv = expandInfo.afterDiv;
-    afterLDiv = expandInfo.afterLDiv;
-  }
-  var divs = getNextDivs(afterDiv, afterLDiv);
-  var div = divs.div;
-  var ldiv = divs.ldiv;
-  var logToggle = divs.logToggle;
-  var annToggle = divs.annToggle;
+  var div = graphDivs.div;
+  var ldiv = graphDivs.ldiv;
+  var logToggle = graphDivs.logToggle;
+  var annToggle = graphDivs.annToggle;
 
   var startdate = getOption(OptionsEnum.STARTDATE) || graphInfo.startdate;
   var enddate = getOption(OptionsEnum.ENDDATE) || graphInfo.enddate;
   startdate = parseDate(startdate);
   enddate = parseDate(enddate);
-  $.getJSON('CSVfiles/'+graphInfo.datfname, function (data) {
-//    console.log(data);
-    for (var i = 0; i < data.length; i++) {
-      data[i][0] = new Date(parseDate(data[i][0]));
-    }
-    // setup our options
-    var graphOptions = {
-      title: graphInfo.title,
-      ylabel: graphInfo.ylabel,
-      axes: {
-        x: {
-          drawGrid: false
-        },
-        y: {
-          drawGrid: true,
-          // So y values don't overlap with the y label
-          axisLabelWidth: 80
-        }
+
+  // setup our options
+  var graphOptions = {
+    title: graphInfo.title,
+    ylabel: graphInfo.ylabel,
+    axes: {
+      x: {
+        drawGrid: false
       },
-      includeZero: true,
-      showRoller: true,
-      legend: 'always',
-      customBars: graphInfo.displayrange,
-      highlightSeriesOpts: {
-        strokeWidth: 2,
-        strokeBorderWidth: 0,
-        highlightCircleSize: 4
-      },
-      // don't "dim" the  series when one is highlighted
-      highlightSeriesBackgroundAlpha: 1,
-      // So it's easier to zoom in on the right side
-      rightGap: 15,
-      labels: graphInfo.labels,
-      labelsDiv: ldiv,
-      labelsSeparateLines: true,
-      dateWindow: [startdate, enddate],
-      // sync graphs anytime we pan, zoom, or at initial draw
-      drawCallback: customDrawCallback,
-      // mark the release dates on the graph before the chart gets drawn
-      underlayCallback: markReleaseDates
+      y: {
+        drawGrid: true,
+        // So y values don't overlap with the y label
+        axisLabelWidth: 80
+      }
+    },
+    includeZero: true,
+    showRoller: true,
+    legend: 'always',
+    customBars: graphInfo.displayrange,
+    highlightSeriesOpts: {
+      strokeWidth: 2,
+      strokeBorderWidth: 0,
+      highlightCircleSize: 4
+    },
+    // don't "dim" the  series when one is highlighted
+    highlightSeriesBackgroundAlpha: 1,
+    // So it's easier to zoom in on the right side
+    rightGap: 15,
+    labels: graphInfo.labels,
+    labelsDiv: ldiv,
+    labelsSeparateLines: true,
+    dateWindow: [startdate, enddate],
+    // sync graphs anytime we pan, zoom, or at initial draw
+    drawCallback: customDrawCallback,
+    // mark the release dates on the graph before the chart gets drawn
+    underlayCallback: markReleaseDates
+  }
+
+  if (expandInfo) {
+    graphOptions.colors = expandInfo.colors;
+  }
+
+  // actually create the dygraph
+  var g = new Dygraph(div, graphData, graphOptions);
+  g.isReady = false;
+  setupSeriesLocking(g);
+
+  // The dygraph is now setting up and rendering. Once the graph is fully
+  // drawn this ready state gets fired. We don't want to synchronize this
+  // grpahs x-axis until it has been fully rendered, or we will be modifying
+  // properties that don't exist yet. We use the isReady state to handle
+  // that. We also make our buttons visible here that way they don't show up
+  // before the graph does.
+  g.ready(function() {
+    // we use options in graphinfo in dygraph callbacks that we can't pass
+    // arguments to so we add it to the graph to be able to pass it around
+    g.divs = graphDivs;
+    g.graphInfo = graphInfo;
+
+
+    setupLogToggle(g, graphInfo, logToggle);
+    setupAnnToggle(g, graphInfo, annToggle);
+    g.isReady = true;
+
+
+    // We let dygraphs handle reading the data and parsing it into an array. We
+    // then sort that data on the first draw. This is a little weird because
+    // we're creating a graph, and while it's rendering we sort it but having
+    // to parse the data ourselves would be a real pain. Since the series
+    // colors don't get sorted with the data we save the original and then
+    // reset so that multiple series that are next to each other don't have the
+    // same color. After sorting is done, we may expand the graph.
+
+    var expandNum = graphInfo.expand;
+
+    // if we're expanding a graph, or we have multiple configs, set new colors
+    if ((expandNum !== undefined && expandNum !== 0) || descriptions.length > 0) {
+      setColors(g, g.getColors().slice(), true);
+      g.setAnnotations(g.annotations());
     }
 
-    if (expandInfo) {
-      graphOptions.visibility = expandInfo.visibility;
-      graphOptions.colors = expandInfo.colors;
+    if (descriptions.length > 0) {
+      setConfigurationVisibility(g, true);
+      g.setAnnotations(g.annotations());
     }
 
-    // actually create the dygraph
-    var g = new Dygraph(div, data, graphOptions);
-    g.isReady = false;
-    setupSeriesLocking(g);
+    expandGraphs(g, graphInfo, graphDivs, graphData);
 
-    // The dygraph is now setting up and rendering. Once the graph is fully
-    // drawn this ready state gets fired. We don't want to synchronize this
-    // grpahs x-axis until it has been fully rendered, or we will be modifying
-    // properties that don't exist yet. We use the isReady state to handle
-    // that. We also make our buttons visible here that way they don't show up
-    // before the graph does.
-    g.ready(function() {
-      // we use options in graphinfo in dygraph callbacks that we can't pass
-      // arguments to so we add it to the graph to be able to pass it around
-      g.divs = divs;
-      g.graphInfo = graphInfo;
-
-
-      setupLogToggle(g, graphInfo, logToggle);
-      setupAnnToggle(g, graphInfo, annToggle);
-      g.isReady = true;
-
-
-      // We let dygraphs handle reading the data and parsing it into an array. We
-      // then sort that data on the first draw. This is a little weird because
-      // we're creating a graph, and while it's rendering we sort it but having
-      // to parse the data ourselves would be a real pain. Since the series
-      // colors don't get sorted with the data we save the original and then
-      // reset so that multiple series that are next to each other don't have the
-      // same color. After sorting is done, we may expand the graph.
-
-      var expandNum = graphInfo.expand;
-
-      // if we're expanding a graph, or we have multiple configs, set new colors
-      if ((expandNum !== undefined && expandNum !== 0) || descriptions.length > 0) {
-        setColors(g, g.getColors().slice(), true);
-        g.setAnnotations(g.annotations());
-      }
-
-      if (descriptions.length > 0) {
-        setConfigurationVisibility(g, true);
-        g.setAnnotations(g.annotations());
-      }
-
-      expandGraphs(g);
-
-    });
-
-    gs.push(g);
   });
+
+  gs.push(g);
 }
 
 
@@ -255,12 +241,11 @@ function genDygraph(graphInfo, expandInfo) {
 // series that have the same name but one ends with ' (examples)' and the other
 // ' (all') They will both be shown on the expanded graph but the examples one
 // will not be shown on the graph containing all of them.
-function expandGraphs(graph) {
+function expandGraphs(graph, graphInfo, graphDivs, graphData) {
 
-  var graphInfo = graph.graphInfo;
   var expandAllSentinel = -1;
   var expandNum = graphInfo.expand;
-  var labels = graph.getLabels();
+  var labels = graphInfo.labels;
 
   // if we don't need to expand just return
   if (!expandNum || expandNum === 0) {
@@ -299,7 +284,7 @@ function expandGraphs(graph) {
     }
     j++;
   }
-
+  var transposedData = transpose(graphData);
   // for each expanded graph
   var i = 0;
   while (i < expandNum && j > 1 ) {
@@ -316,27 +301,28 @@ function expandGraphs(graph) {
     newInfo.title = newInfo.title + ": " + labels[j].replace(' (all)', '');
     newInfo.expand = 0;
 
-    // gen the expanded graph with visibility set for the current series
-    for (var k = 0; k < visibility.length; k++) { visibility[k] = false; }
     var exampleLabel = labels[j].replace(primaryString, secondaryString);
-    var exampleIndex = graph.getPropertiesForSeries(exampleLabel).column;
-    visibility[j-1] = true;
-    visibility[exampleIndex-1] = true;
+    var exampleIndex = labels.indexOf(exampleLabel);
+    var newLabels = labels.slice(0,1);
+    newLabels.push(labels[j]);
+    newLabels.push(labels[exampleIndex]);
+    newInfo.labels = newLabels;
 
+    var newData = transposedData.slice(0,1);
+    newData = newData.concat(transposedData.slice(j, j+1), transposedData.slice(exampleIndex, exampleIndex+1));
+    newData = transpose(newData);
     // make sure the colors for the series in the expanded graph match the
     // colors for the series in the original graph
-    var colors = graph.getColors().slice();
-    for ( var k = 0; k < colors.length; k++) {
+    var colors = [];
+    for ( var k = 0; k < 2; k++) {
       colors[k] = graph.getPropertiesForSeries(labels[j]).color;
     }
 
+    var newDivs = getNextDivs(graphDivs.div, graphDivs.ldiv);
     expandInfo = {
-      afterDiv: graph.divs.div,
-      afterLDiv: graph.divs.ldiv,
-      visibility: visibility.slice(),
       colors: colors
     }
-    genDygraph(newInfo, expandInfo);
+    genDygraph(newInfo, newDivs, newData, expandInfo);
     i++;
   }
 }
@@ -796,7 +782,7 @@ function displaySelectedGraphs() {
   for (var i = 0; i < allGraphs.length; i++) {
     var checkbox = document.getElementById('graph' + i);
     if (checkbox.checked) {
-      genDygraph(allGraphs[i]);
+      getDataAndGenGraph(allGraphs[i]);
     }
   }
 
@@ -804,6 +790,27 @@ function displaySelectedGraphs() {
   setURLFromGraphs(normalizeForURL(findSelectedSuite()));
   // set the dropdown box selection
   document.getElementsByName('jumpmenu')[0].value = findSelectedSuite();
+}
+
+
+// Load the data, and create a new dygraphs
+function getDataAndGenGraph(graphInfo) {
+  var dataFile = 'CSVfiles/'+graphInfo.datfname;
+  // need to get the divs before the async call to get the json so graphs are
+  // displayed in the order they are listed, regardless of the order they are
+  // loaded.
+  var graphDivs = getNextDivs();
+  $.getJSON(dataFile)
+    .done( function(graphData) {
+      for (var j = 0; j < graphData.length; j++) {
+        graphData[j][0] = new Date(parseDate(graphData[j][0]));
+      }
+      genDygraph(graphInfo, graphDivs, graphData);
+    })
+    .fail( function( jqxhr, textStatus, error ) {
+      var err = textStatus + ', ' + error;
+      console.log( 'Request for ' + dataFile + ' Failed: ' + err );
+    });
 }
 
 
@@ -921,6 +928,23 @@ function setQueryStringFromOption(option, optionValue) {
 //////////////////////
 // Helper functions //
 //////////////////////
+
+
+// Transpose a 2 dimensional array
+function transpose(array) {
+  var temp = [];
+  var cols = array.length;
+  var rows = array[0].length;
+  if (cols === 0 || rows === 0) { return temp; }
+
+  for (var r = 0; r < rows; r++) {
+    temp[r] = [];
+    for (var c = 0; c < cols; c++) {
+      temp[r][c] = array[c][r];
+    }
+  }
+  return temp;
+}
 
 
 // Remove a trailing character from a string. Removes any character by default,


### PR DESCRIPTION
Instead of gengraphs generating a csv we now generate json. jquery is used to
load and parse the json which is passed to dygraphs as a native array instead 
of dygraphs having to parse the csv.

This adds a function to gengraphs to convert the csv to json and add labels to
the json (since labels must be explicitly set when using dygraphs native
array format.)

Instead of taking a csv, dygraphs now takes the native array. Jquery is used to
parse the json, and then we date-ify the data since json doesn't have a way to
specify dates.

This is a stepping stone towards simplifying compiler performance, beefing up
multiple configuration support (to be used with compiler performance, --local
vs --no-local and the various comm layers for multi-locale performance.) It
will also allow graph expansion to be simplified and sped up so that we can add
an expand button to any graph. 

This patch will also drastically speed up graph expansion. This is nice for compiler 
performance graphs, and will allow expansion to be used for other graphs too (I 
want to add an 'expand' button to our graphs.) It will also allow expanded graphs
to work with multi-configurations .