### PR TITLE
avoid using an exported function in a non-exported function

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -361,17 +361,15 @@ module ChapelLocale {
   pragma "insert line file info"
   export
   proc chpl_getLocaleID(ref localeID: chpl_localeID_t) {
-    if localeModelHasSublocales then
-      localeID = chpl_rt_buildLocaleID(chpl_nodeID, chpl_task_getRequestedSubloc());
-    else
-      localeID = chpl_rt_buildLocaleID(chpl_nodeID, c_sublocid_any);
+    localeID = here_id;
   }
 
   // Return the locale ID of the current locale
   inline proc here_id {
-    var localeID: chpl_localeID_t;
-    chpl_getLocaleID(localeID);
-    return localeID;
+     if localeModelHasSublocales then
+      return chpl_rt_buildLocaleID(chpl_nodeID, chpl_task_getRequestedSubloc());
+    else
+      return chpl_rt_buildLocaleID(chpl_nodeID, c_sublocid_any);
   }
   // Return the current locale
   inline proc here {


### PR DESCRIPTION
Previously I had "here_id" call the exported "chpl_getLocaleID" This caused
verify regressions with --no-local compilation. The issue was because the
compiler wanted to widen a record being passed by ref at the call sites of the
exported function, but since it's exported the function isn't actually widened
by the compiler leaving a mismatch between actual and formal args.

Now, here_id calls chpl_rt_buildLocaleId and chpl_getLocaleID simply uses
here_id. In doing so the exported function is never called in the modules. I
also think this is a cleaner looking solution anyways, especially since here_id
gets inlined by the chapel compiler.