### PR TITLE
Move catch-all definition of initCopy from String.chpl to ChapelBase.chpl

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1004,7 +1004,12 @@ module ChapelBase {
   inline proc chpl__initCopy(x: _tuple) { 
     // body inserted during generic instantiation
   }
-  
+
+  // Catch-all initCopy implementation:
+  pragma "compiler generated"
+  pragma "init copy fn"
+  inline proc chpl__initCopy(x) return x;
+
   pragma "dont disable remote value forwarding"
   pragma "removable auto copy"
   pragma "donor fn"

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -273,9 +273,9 @@ module String {
     return _cast(c_string_copy, x);
 
   
-  pragma "compiler generated"
   pragma "init copy fn"
-  inline proc chpl__initCopy(a) {
+  inline proc chpl__initCopy(a)
+    where a.type == c_string || a.type == c_string_copy {
     // Currently, string representations are shared.
     // (See note on proc =(a:string, b:string) above.)
       return a;


### PR DESCRIPTION
Just a small cleanup.  The 2014 update of the Chapel string implementation added a definition of chpl__initCopy that is too broad.  It ends up manufacturing initCopy functions for types of which the String module should have no knowledge.  I cured this by placing the catchall version in ChapelBase.chpl and adding a where clause to the version appearing in the String module.

The version in String.chpl has the same semantics as that in ChapelBase, so the String.chpl version could be removed.  However, it was introduced to document that c_string (and now c_string_copy) objects are shared (i.e. they behave like class instances).  This is true even in the strings-as-records implementation, so the documentation may as well be left in place.

I came across this while working on my rework of automatic memory management.  "Why are all these types completely unrelated to strings being defined in the Strings module?" I said to myself.

[Tested on examples/ (std).  No regressions.]