### PR TITLE
Allow empty lines in suppression files and cleanup filterSuppressions

### DIFF
--- a/util/test/filterSuppressions
+++ b/util/test/filterSuppressions
@@ -1,54 +1,50 @@
 #!/usr/bin/env python
 
 import sys, re
+import fileReadHelp
 
 suppfile = sys.argv[1]
 summaryfile = sys.argv[2]
 
-f = open(suppfile, 'r')
-suppressions = f.readlines()
-f.close()
+# Need to remove comment and blank lines so we don't try to match against them.
+# Then strip leading spaces, since ReadFileWithComments doesn't
+suppressions = fileReadHelp.ReadFileWithComments(suppfile)
+suppressions = [supp.strip() for supp in suppressions]
 
-f = open(summaryfile, 'r')
-summary = f.readlines()
-f.close()
+# don't want to use ReadFileWithComments since we want to preserve any formatting
+with open(summaryfile, 'r') as f:
+    summary = f.readlines()
 
+# remove the error message for tests that were successfully suppressed
 newsummary = list()
 removedsupps = list()
 for l in summary:
     line = l.strip()
     if line.startswith('[Error'):
         removed = False
-        for s in suppressions:
-            supp = s.strip()
-            if not supp.startswith('#'):
-                if re.search(r'\b'+supp+r'\b', line):
-                    print 'Removing suppression for: '+supp
-                    removedsupps.append(supp)
-                    removed = True
-                    break
+        for supp in suppressions:
+            if re.search(r'\b'+supp+r'\b', line):
+                print 'Removing suppression for: '+supp
+                removedsupps.append(supp)
+                removed = True
+                break
         if not removed:
             newsummary.append(line)
     else:
         newsummary.append(line)
 
 # overwrite old summary file
+with open(summaryfile, 'w') as f:
+    # date 'n stuff
+    f.write(newsummary.pop(0)+'\n')
 
-# date 'n stuff
-f = open(summaryfile, 'w')
-f.write(newsummary.pop(0)+'\n')
-
-# missing suppressions
-for s in suppressions:
-    supp = s.strip()
-    if not supp.startswith('#'):
+    # add an error if a test that was supposed to be suppressed didn't fail
+    for supp in suppressions:
         if removedsupps.count(supp) == 0:
             f.write('[Error: did not find expected suppression '+supp+']\n')
 
-# new summary
-for l in newsummary:
-    f.write(l+'\n')
-
-f.close()
+    # new summary
+    for l in newsummary:
+        f.write(l+'\n')
 
 sys.exit(0)


### PR DESCRIPTION
Previously empty lines in a suppression file would cause problems. This was
because we do a regex match against each non-comment line and so we matched
against the empty string and would remove the first failure found incorrectly.

This updates filterSuppressions to use the ReadFileWithComments helper we
already had to avoid this issue. This lets us get rid of some lines that
checked for comments and tried to strip the "real" lines in a suppression file

I ran into this while adding suppressing for baseline regressions