### PR TITLE
Add 2 suppressions for baseline

### DIFF
--- a/test/Suppressions/baseline.suppress
+++ b/test/Suppressions/baseline.suppress
@@ -1,6 +1,12 @@
 # These generate reports on inlining
 trivial/mjoyner/inlinefunc/inlfunc1_report
 trivial/mjoyner/inlinefunc/inlfunc2_report
-#
+
 # lack of optimizations lead to extra leaked memory
 memory/sungeun/refCount/domainMaps
+
+# Tom H. thinks these are related to modules/hilde/test_module_Sort-baseline.
+# They started failing with 46cb43b36745149a7866e0e38a2379611ac55014 but there
+# was an existing underlying issue.
+types/string/StringImpl/memLeaks/promotion
+memory/vass/memleak-array-of-records-1


### PR DESCRIPTION
My anonymous range optimization (46cb43b36745149a7866e0e38a2379611ac55014)
introduced two baseline regressions:
 - types/string/StringImpl/memLeaks/promotion
 - memory/vass/memleak-array-of-records-1

After some discussion with Tom H, we think this is related to the
modules/hilde/test_module_Sort-baseline error he was looking at. The real fix
is further out, in the meantime adding these suppressions seems best to get the
failures out of the mails, but not forget about them after they are fixed.

Also adding this information to the pivotal story (77820240)