### PR TITLE
Qthreads yield after x uncontested locks

### DIFF
--- a/test/domains/sungeun/assoc/stress.chpl
+++ b/test/domains/sungeun/assoc/stress.chpl
@@ -43,7 +43,6 @@ sync serial doSerial || (!doSerial && !parSafe) {
         begin totalRemoved = totalRemoved + 1;
       }
     }
-    chpl_task_yield();
   }
 }
 

--- a/test/domains/sungeun/assoc/stress.numthr.chpl
+++ b/test/domains/sungeun/assoc/stress.numthr.chpl
@@ -43,7 +43,6 @@ sync serial doSerial || (!doSerial && !parSafe) {
         begin totalRemoved = totalRemoved + 1;
       }
     }
-    chpl_task_yield();
   }
 }
 

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -167,13 +167,15 @@ void chpl_sync_lock(chpl_sync_aux_t *s)
     PROFILE_INCR(profile_sync_lock, 1);
 
     //
-    // To prevent starvation due to never switching away from a task
-    // that is spinning while doing readXX() on a sync variable, yield
-    // if this sync var has a "lot" of uncontested locks. Note that the
-    // uncontested locks do not have to be consecutive. Also note that
-    // the number of uncontested locks is a lossy counter. Currently a
-    // "lot" is defined as ~100 uncontested locks, with care taken to
-    // not yield on the first uncontested lock.
+    // To prevent starvation due to never switching away from a task that is
+    // spinning while doing readXX() on a sync variable, yield if this sync var
+    // has a "lot" of uncontested locks. Note that the uncontested locks do not
+    // have to be consecutive. Also note that the number of uncontested locks
+    // is a lossy counter. Currently a "lot" is defined as ~100 uncontested
+    // locks, with care taken to not yield on the first uncontested lock.
+    //
+    // If real qthreads sync vars were used, it's possible this wouldn't be
+    // needed.
     //
 
     l = qthread_incr(&s->lockers_in, 1);

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -173,7 +173,7 @@ void chpl_sync_lock(chpl_sync_aux_t *s)
     // uncontested locks do not have to be consecutive. Also note that
     // the number of uncontested locks is a lossy counter. Currently a
     // "lot" is defined as ~100 uncontested locks, with care taken to
-    // note yield on the first uncontested lock.
+    // not yield on the first uncontested lock.
     //
 
     l = qthread_incr(&s->lockers_in, 1);

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -162,77 +162,62 @@ void chpl_task_yield(void)
 void chpl_sync_lock(chpl_sync_aux_t *s)
 {
     aligned_t l;
+    chpl_bool uncontested_lock = true;
 
     PROFILE_INCR(profile_sync_lock, 1);
 
+    //
+    // To prevent starvation due to never switching away from a task
+    // that is spinning while doing readXX() on a sync variable, yield
+    // if this sync var has a "lot" of uncontested locks in a row. Note that
+    // the number of uncontested locks is a lossy counter.
+    //
+
     l = qthread_incr(&s->lockers_in, 1);
 
-    // Yield if somebody else has the lock. If the current task can't get the
-    // lock then it can't make progress until the lock is released, so let
-    // somebody else do some work. It might be better to yield only after X
-    // number of failures to acquire the lock for cases where the lock would be
-    // released "soon", but we didn't see any performance impacts of doing it
-    // every time.
-    //
-    // A core issue is that it's possible that a task scheduled on the same
-    // worker could be the one responsible for unlocking the sync var. For
-    // instance if a task locked the sync var, then does a chpl_task_yield, it
-    // could now be scheduled to run after the current task so this task must
-    // yield in order to prevent deadlock. However, if the task that will
-    // unlock is on another worker, then a spinloop would result in lower
-    // latency. That tension between deadlock avoidance and latency
-    // minimization is what pushes us to even consider spinning in addition to
-    // yielding, and to worry about how much of it we should do.
-    //
-    // If real qthreads sync vars were used, it's possible this wouldn't be
-    // needed.
-    while (l != s->lockers_out) qthread_yield();
+    while (l != s->lockers_out) {
+      uncontested_lock = false;
+      qthread_yield();
+    }
+
+    if (uncontested_lock) {
+      if ((s->uncontested_locks++ & 0x5F) == 0x5F) {
+        qthread_yield();
+      }
+    }
+
+// TODO does it make sense to be doing a qthread_yield above? Should it be a
+// chpl_task_yield()? The recent issue greg ran into with code being called
+// from the main process on non-zero locales is making me wonder. I'm pretty
+// sure it should be a qthread_yield and that a non-qthread would never call
+// this function since I think the fast-on optimization will be thwarted by
+// anything calling a sync var lock. This is mostly a note to double check this
+// with Greg.
+
+// TODO test the performance implications of this change (and see if it
+// hurts to use the version below.)
+
+// This version is probably a little clearer about the intent, and I
+// doubt if there'll be any real performance difference between this and
+// the above version. I went with the above version because it is sort
+// of how we checked for when we needed to do yield in the unlock
+// before, but we were forced to do that since we we're using
+// s->lockers_out to key the yield, and we couldn't reset that.
+/*
+   if (uncontested_lock) {
+      if (s->uncontested_locks++ > 100) {
+        s->uncontested_locks = 0;
+        qthread_yield();
+      }
+    }
+*/
 }
 
 void chpl_sync_unlock(chpl_sync_aux_t *s)
 {
     PROFILE_INCR(profile_sync_unlock, 1);
 
-    // Give other tasks that might be waiting on a sync var a chance to run.
-    // Currently this is every 1024 unlocks. [x % 2n == x & (2n - 1)] This
-    // number was chosen with trial and error and is a good balance of
-    // not hurting performance and allowing progress. Determined by modifying
-    // the value over several days and examining performance and correctness
-    // testing.
-    //
-    // It's possible that two tasks can deadlock if they are both on the same
-    // worker and the running task relies on the work the second task is
-    // supposed to do to make progress. The first task will never yield
-    // automatically, so this forces a yield on sync var unlock every so often
-    // to allow progress.
-    //
-    // Consider this example:
-    //
-    // var alreadySet: [1..10] bool;
-    // while (syncVar.readXX() != 10) {
-    //   for i in 1..10 {
-    //     if alreadySet[i] == false then
-    //       begin syncVar += 1;
-    //     alreadySet[i] = true;
-    //   }
-    // }
-    //
-    // Some of the incrementing tasks might get placed on the same worker as
-    // the task waiting for the syncVar to be 10. That task will never yield,
-    // so the value would never get set to 10 and we'd be stuck in the loop
-    //
-    // qthread_yield is used over chpl_task_yield. chpl_task_yield just adds
-    // calling a sched yield if there are no shepherds. If we don't have any
-    // shepherds we are either setting up or tearing down in which case the
-    // pthread unlock will guarantee progress. When qthread_yield() is called
-    // from a non-qthread it's just a no-op.
-    //
-    // I believe this is still necessary even if we used real qthread sync
-    // vars. As the second task would never get a chance to try and acquire the
-    // lock, so other tasks wouldn't know a task is waiting on the sync var.
-    if ((qthread_incr(&s->lockers_out, 1) & 0x3FF) == 0x3FF) {
-        qthread_yield();
-    }
+    qthread_incr(&s->lockers_out, 1);
 }
 
 static inline void about_to_block(int32_t  lineno,

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
@@ -93,6 +93,7 @@ typedef syncvar_t chpl_mutex_t;
 typedef struct {
     aligned_t lockers_in;
     aligned_t lockers_out;
+    uint_fast32_t uncontested_locks;
     int       is_full;
     syncvar_t signal_full;
     syncvar_t signal_empty;


### PR DESCRIPTION
yield after every ~100 uncontested locks of a sync var (qthreads)
To prevent starvation due to never switching away from a task that is spinning
while doing readXX() on a sync variable we currently do a qthread_yield every
4096 unlocks of a sync var. However, this doesn't seem to be enough and we
still got occasional timeouts with tests like domains/sungeun/assoc/stress.chpl

This patch attempts to solve the same problem in a different manner. This
yields every ~100 uncontested locks of a sync var instead of every 4096 unlocks
of a sync var. There is precedent for this in some of our other tasking layers.
It seems to have the desired effect of eliminating starvation (at least for
1,000 trials of domains/sungeun/assoc/stress.chpl)

I did a full performance run as well. I didn't see any regressions, and I did see
some improvements to Spectral Norm. 