### PR TITLE
Add annotations for some perf changes

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -92,6 +92,8 @@ ep-b:
 fannkuch-redux:
   07/22/14:
     - Error due to cleaning up file incompletely
+  09/04/14:
+    - LICM no longer hoisting globals (bug fix related to hoisting wide things)
 
 fasta:
   01/14/14:
@@ -174,12 +176,28 @@ mandelbrot:
     - Chapel level improvement by using a nonlocking writer
   03/19/14:
     - Bulk IO optimization
+  09/05/14:
+    - maxTaskPar change delayed fifo->qthreads performance hit
+
+mandelbrot-extras:
+  01/03/14:
+    - Chapel level improvement by using a nonlocking writer
+  09/05/14:
+    - maxTaskPar change delayed fifo->qthreads performance hit
 
 parOpEquals:
   09/06/13:
     - (no-local) chpl_localeID_t's ignore_subloc field minimized to 1 bit
   09/27/13:
     - (no-local) Reversion of chpl_localeID_t's ignore subloc field being minimized to 1 bit
+
+spectralnorm:
+  01/21/15:
+    - qthreads updated to yield every ~100 uncontested sync var locks
+
+spectral-norm-specify-step:
+  01/21/15:
+    - qthreads updated to yield every ~100 uncontested sync var locks
 
 SSCA2_main:
   06/12/13:


### PR DESCRIPTION
Add note for spectral norm improvement as a result of
919a60e8019ebd65a26a192027127f8937155d30

Add note for fannkuck regression as a result of
75ada8e3483f72acfb50a9e1b3660fdb19ad2ebd

Add note for mandelbrot regression as a result
of27ce3207bdffb7c0207d429a979b94b1c7ba50c0 and
36eeab03a6bf852c123c036544794ac188711562. The switch to qtheads is what hurt
performance (this test prefers logical num cores) but the regression only
really became obvious with the maxTaskPar change