### PR TITLE
Optimize range follower iter

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1448,18 +1448,10 @@ module ChapelRange {
       }    
   
       // same as undensifyBounded(this, myFollowThis), but on a rangeBase
-      var low: idxType  = this.orderToIndex(myFollowThis.first);
-      if flwlen == 1
-      {
-        if debugChapelRange then
-          writeln("Expanded range = ", low..low);
-        yield low;
-        return;
-      }
-  
       const stride = this.stride * myFollowThis.stride;
-  
+      var low: idxType  = this.orderToIndex(myFollowThis.first);
       var high: idxType = ( low: strType + stride * (flwlen - 1):strType ):idxType;
+
       assert(high == this.orderToIndex(myFollowThis.last));
       if stride < 0 then low <=> high;
       assert(low <= high);


### PR DESCRIPTION
Remove flwlen==1 check in range follower

I'm guessing this was an "optimization" to avoid creating the range, but the
second yield in here prevents the optimize-loop-iterator optimization from
firing which kills performance.

I'm pretty confident that removing this check doesn't have any correctness
implications. The calculation to find high (for flwlen==1, low must equal high)
is "high = low + stride * (flwlen - 1)" which will just be "high = low +
stride * 0" or "high = low" So correctness wise this is fine. It means we're
building up a range for flwlen = 1, but that overhead is far far far less than
the overhead of the optimize range iterators optimization not firing.

For test/performance/bharshbarg/range-forall.chpl, this drops the execution
time from ~90 seconds to ~2 seconds on chap04. domain-forall.chpl is around
~1.2 seconds.  A future patch will address the remaining gap (by using a
non-strided range in the follower when we can.)

This code was originally added with b35c16e6f2dd124ed5ec0595fa4ec466d382e9ee
