### PR TITLE
Simplify non-performance PTRANS pass/fail checking.

### DIFF
--- a/test/studies/hpcc/PTRANS/PTRANS.chpl
+++ b/test/studies/hpcc/PTRANS/PTRANS.chpl
@@ -7,6 +7,8 @@ module HPCC_PTRANS {
   //  ===============================================
 
 
+  config const printPassFailOnly = false;
+
   //  default dimensions (overridable from command line)
 
   config const n_rows : int (64) = 800, n_cols : int (64) = 800, beta = 1.0;
@@ -138,12 +140,18 @@ module HPCC_PTRANS {
     //	break;
     //    }
       
-    if ( error > error_tolerance ) then 
-      writeln ( "    *** FAILURE *** error     : ", error );
-    else if ( error != zero ) then
-      writeln ( "    *** SUCCESS ***  error    : ", error );
-    else
-      writeln ( "    *** SUCCESS***  exact match" );
+    if printPassFailOnly then
+      writeln ( if error > error_tolerance
+                then "    *** FAILURE ***"
+                else "    *** SUCCESS ***" );
+    else {
+      if ( error > error_tolerance ) then
+        writeln ( "    *** FAILURE *** error     : ", error );
+      else if ( error != zero ) then
+        writeln ( "    *** SUCCESS ***  error    : ", error );
+      else
+        writeln ( "    *** SUCCESS ***  exact match" );
+    }
 
     if (printStats) {
       elapsed_time = PTRANS_time.elapsed (TimeUnits.seconds);

--- a/test/studies/hpcc/PTRANS/PTRANS.execopts
+++ b/test/studies/hpcc/PTRANS/PTRANS.execopts
@@ -1,1 +1,1 @@
---n_rows=5792 --n_cols=5792 --printStats=false
+--n_rows=5792 --n_cols=5792 --printPassFailOnly=true --printStats=false

--- a/test/studies/hpcc/PTRANS/PTRANS.good
+++ b/test/studies/hpcc/PTRANS/PTRANS.good
@@ -10,4 +10,4 @@ Distributed Matrix Transpose
     max acceptable discrepancy: 1.34369e-11
 
   Results
-    *** SUCCESS***  exact match
+    *** SUCCESS ***

--- a/test/studies/hpcc/PTRANS/PTRANS.valgrind.execopts
+++ b/test/studies/hpcc/PTRANS/PTRANS.valgrind.execopts
@@ -1,1 +1,1 @@
---n_rows=92 --n_cols=92 --printStats=false
+--n_rows=92 --n_cols=92 --printPassFailOnly=true --printStats=false

--- a/test/studies/hpcc/PTRANS/PTRANS.valgrind.good
+++ b/test/studies/hpcc/PTRANS/PTRANS.valgrind.good
@@ -10,4 +10,4 @@ Distributed Matrix Transpose
     max acceptable discrepancy: 6.46147e-14
 
   Results
-    *** SUCCESS***  exact match
+    *** SUCCESS ***

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.chpl
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.chpl
@@ -8,6 +8,7 @@ module HPCC_PTRANS {
 
 
   config param printTimings = true;
+  config const printPassFailOnly = false;
 
   //  default dimensions (overridable from command line)
 
@@ -389,12 +390,18 @@ module HPCC_PTRANS {
     //  break;
     //    }
       
-    if ( error > error_tolerance ) then 
-      writeln ( "    *** FAILURE *** error     : ", error );
-    else if ( error != zero ) then
-      writeln ( "    *** SUCCESS ***  error    : ", error );
-    else
-      writeln ( "    *** SUCCESS***  exact match" );
+    if printPassFailOnly then
+      writeln ( if error > error_tolerance
+                then "    *** FAILURE ***"
+                else "    *** SUCCESS ***" );
+    else {
+      if ( error > error_tolerance ) then 
+        writeln ( "    *** FAILURE *** error     : ", error );
+      else if ( error != zero ) then
+        writeln ( "    *** SUCCESS ***  error    : ", error );
+      else
+        writeln ( "    *** SUCCESS ***  exact match" );
+    }
 
     const elapsed_time = PTRANS_time.elapsed (TimeUnits.seconds);
     

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.execopts
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.execopts
@@ -1,0 +1,1 @@
+--printPassFailOnly=true

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.good
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.good
@@ -10,8 +10,8 @@ Distributed Matrix Transpose
     max acceptable discrepancy: 7.1802e-14
 
   Unblocked Results
-    *** SUCCESS***  exact match
+    *** SUCCESS ***
  Blocked Results V1
-    *** SUCCESS***  exact match
+    *** SUCCESS ***
  Blocked Results V2
-    *** SUCCESS***  exact match
+    *** SUCCESS ***

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.chpl
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.chpl
@@ -8,6 +8,7 @@ module HPCC_PTRANS {
 
 
   config param printTimings = true;
+  config const printPassFailOnly = false;
 
   //  default dimensions (overridable from command line)
 
@@ -388,12 +389,18 @@ module HPCC_PTRANS {
     //  break;
     //    }
       
-    if ( error > error_tolerance ) then 
-      writeln ( "    *** FAILURE *** error     : ", error );
-    else if ( error != zero ) then
-      writeln ( "    *** SUCCESS ***  error    : ", error );
-    else
-      writeln ( "    *** SUCCESS***  exact match" );
+    if printPassFailOnly then
+      writeln ( if error > error_tolerance
+                then "    *** FAILURE ***"
+                else "    *** SUCCESS ***" );
+    else {
+      if ( error > error_tolerance ) then
+        writeln ( "    *** FAILURE *** error     : ", error );
+      else if ( error != zero ) then
+        writeln ( "    *** SUCCESS ***  error    : ", error );
+      else
+        writeln ( "    *** SUCCESS ***  exact match" );
+    }
 
     const elapsed_time = PTRANS_time.elapsed (TimeUnits.seconds);
     

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.execopts
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.execopts
@@ -1,0 +1,1 @@
+--printPassFailOnly=true

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.good
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.good
@@ -10,8 +10,8 @@ Distributed Matrix Transpose
     max acceptable discrepancy: 7.1802e-14
 
   Unblocked Results
-    *** SUCCESS***  exact match
+    *** SUCCESS ***
  Blocked Results V1
-    *** SUCCESS***  exact match
+    *** SUCCESS ***
  Blocked Results V2
-    *** SUCCESS***  exact match
+    *** SUCCESS ***


### PR DESCRIPTION
These versions of PTRANS report both success or failure and the
discrepancy between their result and the expected result range.  Testing
was passing everywhere we ran it, but it passed differently on different
platforms: matching the expected result exactly everywhere but cygwin32
and merely falling within the expected range on cygwin32.  This caused
false failures on cygwin32 due to the .good not matching.

Here we simplify pass/fail checking for testing by adding a config const
that allows limiting the success/failure output to merely whether or not
the result was within the expected range, not how closely.  This will
allow the simple .good files to match on all platforms.