### PR TITLE
Remove 'assert (low <= high)' in range follower

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1454,7 +1454,6 @@ module ChapelRange {
 
       assert(high == this.orderToIndex(myFollowThis.last));
       if stride < 0 then low <=> high;
-      assert(low <= high);
   
       const r = low .. high by stride:strType;
       if debugChapelRange then


### PR DESCRIPTION
With "--cc-warnings" and "-O", newer versions of gcc warn saying:
  "assuming signed overflow does not occur when assuming that (X + c) < X is
   always false."

This is basically a warning telling you that a conditional is going to be
optimized away because gcc is assuming signed overflow can't occur so the
condition is always true. Note that signed overflow is undefined in C so gcc is
allowed to make this assumption unless you explicitly tell it not to, which we
don't want to do. In this case it's warning that it's going to optimize the
check that low <= high since it knows the condition will always be true (unless
overflow occurred, which it's assuming can't happen.)

There are two cases to consider (assuming no overflow):

stride < 0:
high will be <= low in high's initialization
then low <= high after the swap in "if stride < 0"

stride >= 0:
low <= high in high's initialization
low and high are not switched so low <= high

To eliminate the warning (which caused a regression for "npb/ft/ft-serial" I'm
simply removing the assert. It's not possible for low > high so there's no need
for the runtime assert.