### PR TITLE
Optimize range follower for non-strided ranges

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1446,22 +1446,36 @@ module ChapelRange {
         } else
           assert(false, "hasFirst && hasLast do not imply isBoundedRange");
       }    
-  
-      // same as undensifyBounded(this, myFollowThis), but on a rangeBase
-      const stride = this.stride * myFollowThis.stride;
-      var low: idxType  = this.orderToIndex(myFollowThis.first);
-      var high: idxType = ( low: strType + stride * (flwlen - 1):strType ):idxType;
+      if this.stridable || myFollowThis.stridable {
+        // same as undensifyBounded(this, myFollowThis), but on a rangeBase
+        const stride = this.stride * myFollowThis.stride;
+        var low: idxType  = this.orderToIndex(myFollowThis.first);
+        var high: idxType = ( low: strType + stride * (flwlen - 1):strType ):idxType;
+        assert(high == this.orderToIndex(myFollowThis.last));
 
-      assert(high == this.orderToIndex(myFollowThis.last));
-      if stride < 0 then low <=> high;
-  
-      const r = low .. high by stride:strType;
-      if debugChapelRange then
-        writeln("Expanded range = ",r);
-  
-      // todo: factor out this loop (and the above writeln) into a function?
-      for i in r do
-        yield i;
+        if stride < 0 then low <=> high;
+
+        const r = low .. high by stride:strType;
+        if debugChapelRange then
+          writeln("Expanded range = ",r);
+
+        // todo: factor out this loop (and the above writeln) into a function?
+        for i in r do
+          yield i;
+      } else {
+        // same as undensifyBounded(this, myFollowThis), but on a rangeBase
+        const low: idxType  = this.orderToIndex(myFollowThis.first);
+        const high: idxType = ( low: strType + (flwlen - 1):strType ):idxType;
+        assert(high == this.orderToIndex(myFollowThis.last));
+
+        const r = low .. high;
+        if debugChapelRange then
+          writeln("Expanded range = ",r);
+
+        // todo: factor out this loop (and the above writeln) into a function?
+        for i in r do
+          yield i;
+      }
     }
     else // ! myFollowThis.hasLast()
     {

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1447,7 +1447,7 @@ module ChapelRange {
           assert(false, "hasFirst && hasLast do not imply isBoundedRange");
       }    
       if this.stridable || myFollowThis.stridable {
-        // same as undensifyBounded(this, myFollowThis), but on a rangeBase
+        // same as undensifyBounded(this, myFollowThis)
         const stride = this.stride * myFollowThis.stride;
         var low: idxType  = this.orderToIndex(myFollowThis.first);
         var high: idxType = ( low: strType + stride * (flwlen - 1):strType ):idxType;
@@ -1463,7 +1463,7 @@ module ChapelRange {
         for i in r do
           yield i;
       } else {
-        // same as undensifyBounded(this, myFollowThis), but on a rangeBase
+        // same as undensifyBounded(this, myFollowThis)
         const low: idxType  = this.orderToIndex(myFollowThis.first);
         const high: idxType = ( low: strType + (flwlen - 1):strType ):idxType;
         assert(high == this.orderToIndex(myFollowThis.last));


### PR DESCRIPTION
Split out the range follower for cases where we know the follower isn't
strided. This allows us to use a non-strided serial iterator in this cases
which results in a nice performance improvement.

This resolves the perf regression between parallel domain and range iteration
(performance/bharshbarg/range-forall vs. performance/bharshbarg/domain-forall.)
Both now take ~1.2 seconds on chap04.

An upcoming patch will clean up the follower iterator and verify that we have
the correct overflow semantics. This patch just gets us the same performance as
parallel domain iteration.