### PR TITLE
Move toward implementing the remaining forall intents.

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -902,14 +902,6 @@ CallExpr* buildForallLoopExprFromArrayType(CallExpr* buildArrRTTypeCall,
   }
 }
 
-static void
-checkForNonRefIntents(CallExpr* byrefVars) {
-  for_actuals(actual, byrefVars)
-    if (ArgSymbol* arg = toArgSymbol(actual))
-      if (arg->intent != INTENT_REF)
-        USR_FATAL_CONT(byrefVars, "intents other than 'ref' are not allowed in a 'with' clause of a 'forall' loop or expression");
-}
-
 static BlockStmt*
 buildFollowLoop(VarSymbol* iter,
                 VarSymbol* leadIdxCopy,
@@ -1041,8 +1033,6 @@ buildForallLoopStmt(Expr*      indices,
   //
   INT_ASSERT(!loopBody->byrefVars);
   if (byref_vars) {
-    // todo: push this check downstream, e.g. into checkParsed()
-    checkForNonRefIntents(byref_vars);
     INT_ASSERT(byref_vars->isPrimitive(PRIM_ACTUALS_LIST));
     byref_vars->primitive = primitives[PRIM_FORALL_LOOP];
   } else {

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -97,7 +97,7 @@ void buildDefaultDestructor(AggregateType* ct);
 // createTaskFunctions.cpp -> implementForallIntents.cpp
 extern Symbol* markPruned;
 extern Symbol* markUnspecified;
-void pruneOuterVars(SymbolMap* uses, CallExpr* byrefVars, bool usePrune);
+void pruneOuterVars(SymbolMap* uses, CallExpr* byrefVars);
 void pruneThisArg(Symbol* parent, SymbolMap* uses, bool pruneMore);
 
 // flattenFunctions.cpp

--- a/compiler/include/resolveIntents.h
+++ b/compiler/include/resolveIntents.h
@@ -24,6 +24,7 @@
 #include "type.h"
 
 IntentTag blankIntentForType(Type* t);
+IntentTag concreteIntent(IntentTag existingIntent, Type* t);
 void resolveArgIntent(ArgSymbol* arg);
 
 #endif

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -157,8 +157,7 @@ findOuterVars(FnSymbol* fn, SymbolMap* uses) {
 }
 
 // Mark the variables listed in 'with' clauses, if any, with tiMark markers.
-// If 'usePrune', only 'ref' intent is allowed, implemented it with markPrune.
-void pruneOuterVars(SymbolMap* uses, CallExpr* byrefVars, bool usePrune) {
+void pruneOuterVars(SymbolMap* uses, CallExpr* byrefVars) {
   if (!byrefVars) return;
   ArgSymbol* tiMarker = NULL;
   // the actuals alternate: tiMark arg, task-intent variable [, repeat]
@@ -170,14 +169,8 @@ void pruneOuterVars(SymbolMap* uses, CallExpr* byrefVars, bool usePrune) {
     Symbol* var = se->var;
     if (tiMarker) {
       SymbolMapElem* elem = uses->get_record(var);
-      if (elem) {
-       if (usePrune) {
-        INT_ASSERT(tiMarker->intent == INTENT_REF); // checkForNonRefIntents()
-        elem->value = markPruned;
-       } else {
+      if (elem)
         elem->value = tiMarker;
-       }
-      }
       tiMarker = NULL;
     } else {
       tiMarker =  toArgSymbol(var);
@@ -495,7 +488,7 @@ void createTaskFunctions(void) {
           SymbolMap* uses = new SymbolMap();
           findOuterVars(fn, uses);
 
-          pruneOuterVars(uses, block->byrefVars, false);
+          pruneOuterVars(uses, block->byrefVars);
           pruneThisArg(call->parentSymbol, uses, false);
           block->byrefVars->remove();
 

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -84,23 +84,26 @@ IntentTag blankIntentForType(Type* t) {
   return INTENT_BLANK;
 }
 
+IntentTag concreteIntent(IntentTag existingIntent, Type* t) {
+  if (existingIntent == INTENT_BLANK) {
+    return blankIntentForType(t);
+  } else if (existingIntent == INTENT_CONST) {
+    return constIntentForType(t);
+  } else {
+    return existingIntent;
+  }
+}
+
+static IntentTag blankIntentForThisArg(Type* t) {
+  // todo: be honest when 't' is an array or domain
+  return INTENT_CONST_IN;
+}
+
 void resolveArgIntent(ArgSymbol* arg) {
-  if (arg->intent == INTENT_BLANK) {
-    if (arg->hasFlag(FLAG_ARG_THIS)) {
-      //
-      // BLC: If we eventually support 'var' intents for 'this' as
-      // part of the opt_this_intent_tag rule in the parser, we would
-      // need to cue off of that information in setting the intent for
-      // "this" here.
-      //
-      arg->intent = INTENT_CONST_IN;
-    } else {
-      arg->intent = blankIntentForType(arg->type);
-    }
-  }
-  if (arg->intent == INTENT_CONST) {
-    arg->intent = constIntentForType(arg->type);
-  }
+  arg->intent = 
+    arg->hasFlag(FLAG_ARG_THIS) && arg->intent == INTENT_BLANK ?
+    blankIntentForThisArg(arg->type) :
+    concreteIntent(arg->intent, arg->type);
 }
 
 void resolveIntents() {


### PR DESCRIPTION
* Removed the restriction in buildForallLoopStmt() on what intents can be
used in the with-clause of a forall loop.

* Propagated the intents from with-clause into implementForallIntents1().

Prior to this change, the outer variables that were listed with the 'ref'
intent in the with-clause were dropped from the outer-variable list
during createTaskFunctions(). Which ensured the 'ref' semantics for these
variables.

With this change, variables listed with 'ref' or 'const 'ref' intent
in the with-clause or ones for which 'blank' or 'const' intent means
'[const] ref' are dropped in implementForallIntents1().

I will keep this implementation, for the near future, for 'ref'-intent
variables and will modify it for 'const ref'-variables to ensure constness.

* In resolveIntents.cpp, factored out the 'const' and blank intents
into the new function concreteIntent(IntentTag existingIntent, Type* t).

Removed BLC's comment because it seemed irrelevant where it was placed:
it talked about 'var' intents whereas at that point the intent is blank.

* Minor adjustment: since some outer variables are now dropped (see above)
in createShadowVars(), I distinguish between the total number of variables
detected in a forallBody (totOuterVars1) vs. the number of variables that
are handled further (numShadowVars).
