### PR TITLE
REGRESSIONS updates for this week.

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -49,15 +49,15 @@
 
 ===================
 general
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
-with gcc version >= 4.8.0: "error: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Werror=strict-overflow]" (2015-01-22, xe-wb.gnu, cygwin32, cygwin64, eronagha)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+with gcc version >= 4.8.0: "error: assuming signed overflow ... [-Werror=strict-overflow]" (2015-01-22, xe-wb.gnu, cygwin32, cygwin64, eronagha)
+------------------------------------------------------------------------------------------------------------------------------------------------
 [Error matching compiler output for npb/ft/ft-serial (compopts: 1)]
 
-erroneous used-before-defined gripe from chpl compiler (2015-01-22, xe-wb.pgi, xe-wb.intel, mnoakes)
-----------------------------------------------------------------------------------------------------
+erroneous used-before-defined msg from chpl compiler (2015-01-22, xe-wb.pgi, xe-wb.intel, mnoakes)
+--------------------------------------------------------------------------------------------------
 [Error matching compiler output for studies/graph500/kristyn/Graph500_1D_onV/main (compopts: 1)]
 [Error matching compiler output for studies/graph500/v2/main (compopts: 1)]
 [Error matching compiler output for studies/graph500/v3/main (compopts: 1)]
@@ -66,7 +66,7 @@ erroneous used-before-defined gripe from chpl compiler (2015-01-22, xe-wb.pgi, x
 ===================
 linux64
 Inherits 'general'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 
@@ -141,27 +141,28 @@ sporadic signal 11
 ===================
 darwin
 Inherits 'general'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 
 ===================
 gnu.darwin
 Inherits 'darwin'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 
 ===================
 perf*
 Inherits 'general'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
+
 
 ===================
 perf.bradc-lnx
 Inherits 'perf*'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 consistent failure due to insane memory usage (should get better with strings)
@@ -180,7 +181,7 @@ sporadic execution timeout
 ===================
 perf.chap03
 Inherits 'perf*'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 consistent failure due to insane memory usage (should get better with strings)
@@ -191,14 +192,14 @@ consistent failure due to insane memory usage (should get better with strings)
 ===================
 perf.chap04
 Inherits 'perf*'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 
 ====================
 perf.chapel-shootout
 Inherits 'perf*'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ====================
 
 consistent failure due to insane memory usage (should get better with strings)
@@ -209,28 +210,28 @@ consistent failure due to insane memory usage (should get better with strings)
 ===================
 fast
 Inherits 'general'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 
 ===================
 memleaks.examples
 Inherits 'general'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 
 ============================
 memleaks
 Inherits 'memleaks.examples'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ============================
 
 
 ===================
 verify
 Inherits 'general'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 
@@ -240,16 +241,16 @@ sporadic execution timeout
 --------------------------
 [Error: Timed out executing program stress/deitz/test_10k_begins] (2015-01-08)
 
+
 ==================
 valgrind
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
 
 System I/O error.  Thomas has escalated to sys-ops
 --------------------------------------------------
 [Error running sub_test in /ptmp/jenkins/chapel-ci/workspace/correctness-test-valgrind/test/release/examples/spec/Variables (1)]
-
 
 invalid read in compiler (2014-12-16 -- diten, presumed due to standalone par)
 ------------------------------------------------------------------------------
@@ -286,13 +287,13 @@ read of size 8 in dl_name_match_p
 
 sporadic (?) compilation timeout
 --------------------------------
-[Error: Timed out compilation for functions/iterators/vass/standaloneForallIntents] (2015-01-20)
+[Error: Timed out compilation for functions/iterators/vass/standaloneForallIntents] (2015-01-20.. )
 
 
 ===================
 llvm
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
 
 relies on macro in gmp.h -- not expected to work without effort (2014-09-18)
@@ -303,42 +304,35 @@ relies on macro in gmp.h -- not expected to work without effort (2014-09-18)
 ===================
 fifo
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
 
 
 ===================
 numa
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
 
-malloc memory corruption. New test by Vass and error might be sporadic
-----------------------------------------------------------------------
-[Error matching .bad file for variables/vass/ref-to-domains-arrays] (2015-01-12)
 
 ===================
 no-local
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
-
-malloc memory corruption. New test by Vass and error might be sporadic
-----------------------------------------------------------------------
-[Error matching .bad file for variables/vass/ref-to-domains-arrays] (2015-01-10..2015-01-11)
 
 
 =================================
 no-local.linux32
 Inherits 'linux32' and 'no-local'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 =================================
 
 
 ===================
-gasnet* regressions
+gasnet*
 Inherits 'no-local'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 
@@ -352,14 +346,21 @@ sporadic execution timeout (2015-01-18)
 ===================
 gasnet-everything
 Inherits 'gasnet*'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
+
+
+=== sporadic failures below ===
+
+sporadic execution timeout
+--------------------------
+[Error: Timed out executing program performance/ferguson/remote-tuple-write] (2015-01-23)
 
 
 ===================
 gasnet-fast
 Inherits 'gasnet*'
-Reviewed 2015-01-13
+Reviewed 2015-01-23
 ===================
 
 
@@ -373,14 +374,14 @@ sporadic execution timeout (regularly)
 ===============================
 gasnet.darwin
 Inherits 'darwin' and 'gasnet*'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===============================
 
 
 =============================
 gasnet.fifo
 Inherits 'gasnet*' and 'fifo'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 =============================
 
 consistent execution timeouts
@@ -406,14 +407,14 @@ sporadic execution timeouts (infrequent)
 =============================
 gasnet.llvm
 Inherits 'gasnet*' and 'llvm'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 =============================
 
 
 =============================
 gasnet.numa
 Inherits 'gasnet*' and 'numa'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 =============================
 
 
@@ -731,11 +732,11 @@ sporadic os.unlink calls in sub_test failing due to resource being busy
 [Error running sub_test in *] (2014-12-11, 2014-12-12, 2014-12-15, 2014-12-16, 2014-12-17, 2014-12-18)
 
 
-===================
+================================
 cygwin64
 Inherits 'cygwin*' and 'linux64'
 Reviewed 2015-01-23
-===================
+================================
 
 QIO qio_err_to_int() == EEOF assertion error
 --------------------------------------------

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -5,7 +5,7 @@
 # to chapel-test-results-all (and chapel-test-results-regressions if
 # anything unusual happened).  The label for each category should
 # match the unique ID for that testing configuration.  In some cases,
-# categories will have a wildcard name such as 'gasnet*' or 'x?-wb...'
+# categories will have a wildcard name such as 'gasnet*' or 'x?-wb.*'
 # implying that they are an abstract category for all configurations
 # that match that pattern.  In the past we have used specific testing
 # instances (like 'gasnet-everything') for such purposes, but in
@@ -551,18 +551,18 @@ binary files differ (2014-09-21-2014-09-23)
 [Error matching program output for studies/parboil/SAD/sadSerial]
 
 
-===============================
+================================
 x?-wb.intel
-Inherits 'x?-wb*' and '*intel*'
+Inherits 'x?-wb.*' and '*intel*'
 Reviewed 2015-01-15
-===============================
+================================
 
 
-===============================
+================================
 x?-wb.prgenv-intel
-Inherits 'x?-wb*' and '*intel*'
+Inherits 'x?-wb.*' and '*intel*'
 Reviewed 2015-01-15
-===============================
+================================
 
 Sporadic compilation timeout
 ----------------------------
@@ -583,18 +583,18 @@ Reviewed 2015-01-15
 =======================
 
 
-=============================
+==============================
 x?-wb.gnu
-Inherits 'x?-wb*' and '*gnu*'
+Inherits 'x?-wb.*' and '*gnu*'
 Reviewed 2015-01-15
-=============================
+==============================
 
 
-=============================
+==============================
 x?-wb.prgenv-gnu
-Inherits 'x?-wb*' and '*gnu*'
+Inherits 'x?-wb.*' and '*gnu*'
 Reviewed 2015-01-15
-=============================
+==============================
 
 
 ===========================
@@ -632,18 +632,18 @@ target program died with signal 11, without coredump
 [Error matching program output for stress/deitz/test_10k_begins] (xe-wb.prgenv-pgi  2014-11-16, xe-wb.pgi 2014-11-18, 2014-11-28)
 
 
-=============================
+==============================
 x?-wb.pgi
-Inherits 'x?-wb*' and '*pgi*'
+Inherits 'x?-wb.*' and '*pgi*'
 Reviewed 2015-01-15
-=============================
+==============================
 
 
-=============================
+==============================
 x?-wb.prgenv-pgi
-Inherits 'x?-wb*' and '*pgi*'
+Inherits 'x?-wb.*' and '*pgi*'
 Reviewed 2015-01-16
-=============================
+==============================
 
 
 something going wrong with reservedSymbolNames causes reserved names to show up in generated code.

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -739,7 +739,7 @@ sporadic pthread_cond_init() failed (infrequent)
 ===================
 baseline
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-22
 ===================
 
 Dies with signal 6

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -56,7 +56,7 @@ with gcc version >= 4.8.0: "error: assuming signed overflow does not occur when 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [Error matching compiler output for npb/ft/ft-serial (compopts: 1)]
 
-erroneous used-before-defined gripe from chpl compiler (2015-01-22, darwin, xe-wb.pgi, xe-wb.intel, mnoakes)
+erroneous used-before-defined gripe from chpl compiler (2015-01-22, darwin, xe-wb.pgi, xe-wb.intel, xe-wb.intel, mnoakes)
 ------------------------------------------------------------------------------------------------------------
 [Error matching compiler output for studies/graph500/kristyn/Graph500_1D_onV/main (compopts: 1)]
 [Error matching compiler output for studies/graph500/v2/main (compopts: 1)]
@@ -438,6 +438,7 @@ Sporadic compilation timeouts
 [Error: Timed out compilation for arrays/bradc/slices/outOfBoundsSlice] (xe-wb.prgenv-pgi 2015-01-15)
 [Error: Timed out compilation for arrays/bradc/sliceViaSingleton3d] (xe-wb.intel 2015-01-20)
 [Error: Timed out compilation for arrays/claridge/arraySizeMismatch] (xe-wb.prgenv-cray 2015-01-07)
+[Error: Timed out compilation for arrays/marybeth/CMO_array] (xe-wb.intel 2015-01-22)
 
 sporadic execution timeouts
 ---------------------------
@@ -695,11 +696,6 @@ Generated output "FAILED" (see below for sporadic): First run 2014-12-07
 ------------------------------------------------------------------------
 [Error matching program output for studies/colostate/OMP-Jacobi-1D-Naive-Parallel (compopts: 1)]
 [Error matching program output for studies/colostate/OMP-Jacobi-2D-Naive-Parallel (compopts: 1)]
-
-Error tolerance exceeded?: First run 2014-12-07
------------------------------------------------
-[Error matching program output for studies/hpcc/PTRANS/PTRANS]
-[Error matching program output for studies/hpcc/PTRANS/jglewis/ptrans_2011]
 
 Consistent execution timouts
 ----------------------------

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -40,7 +40,7 @@
 #
 # At the bottom of each category is a list of "sporadic" failures
 # that come and go at different times.  These are followed by a
-# list of dates for a "new failure" was last reported.  If a test
+# list of dates for when a "new failure" was reported.  If a test
 # has not failed in a month, it can probably be removed from this
 # list.
 #
@@ -388,7 +388,7 @@ Reviewed 2015-01-16
 
 consistent timeouts
 -------------------
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_likepy] (2014-11-28 ..)
+[Error: Timed out executing program studies/madness/aniruddha/madchap/test_likepy] (2014-11-28..)
 
 
 === sporadic failures below ===
@@ -492,7 +492,7 @@ error differs but within acceptable margin; should squash error printing
 
 sporadic dropping/mangling of output
 ------------------------------------
-[Error matching program output for classes/bradc/arrayInClass/arrayOfArithInClass]                      (2015-01-12 ..)
+[Error matching program output for classes/bradc/arrayInClass/arrayOfArithInClass]                      (2015-01-12..)
 [Error matching program output for distributions/robust/arithmetic/collapsing/test_domain_rank_change1] (2014-10-24)
 [Error matching program output for domains/sungeun/assoc/index_not_in_domain_2 (compopts: 2)] (2014-11-13)
 [Error matching program output for functions/diten/refIntents] (2014-09-30)
@@ -519,11 +519,11 @@ Reviewed 2015-01-12
 
 sporadic dropping of range separator {1..3} -> {13}
 ---------------------------------------------------
-[Error matching program output for classes/bradc/arrayInClass/genericArrayInClass-arith] (2014-12-25  .. 2015-01-08)
+[Error matching program output for classes/bradc/arrayInClass/genericArrayInClass-arith] (2014-12-25..2015-01-08)
 
 timeout
 -------
-[Error: Timed out compilation for arrays/claridge/arraySizeMismatch] (2015-01-07 ..)
+[Error: Timed out compilation for arrays/claridge/arraySizeMismatch] (2015-01-07.. )
 
 
 
@@ -540,12 +540,12 @@ Inherits 'general'
 Reviewed 2015-01-16
 ===================
 
-test assertion failures (2014-09-21-2014-09-23)
+test assertion failures (2014-09-21..2014-09-23)
 -----------------------------------------------
 [Error matching program output for io/ferguson/io_test]
 [Error matching program output for io/ferguson/writef_readf]
 
-binary files differ (2014-09-21-2014-09-23)
+binary files differ (2014-09-21..2014-09-23)
 -------------------------------------------
 [Error matching program output for io/ferguson/writefbinary]
 [Error matching program output for studies/parboil/SAD/sadSerial]
@@ -684,7 +684,7 @@ QIO qio_err_to_int() == EEOF assertion error
 
 consistent timeout (frequent)
 ----------------------------
-[Error: Timed out executing program studies/cholesky/jglewis/version2/performance/test_cholesky_performance (compopts: 1)] (..., 2014-12-01, 2015-01-05 ...)
+[Error: Timed out executing program studies/cholesky/jglewis/version2/performance/test_cholesky_performance (compopts: 1)] (..., 2014-12-01, 2015-01-05.. )
 
 
 ===========================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -178,7 +178,7 @@ consistent failure due to insane memory usage (should get better with strings)
 [Error matching performance keys for studies/shootout/fasta/kbrady/fasta-lines]
 
 
-execution time out (2014-01-16.. )
+execution time out (2015-01-16.. )
 ----------------------------------
 [Error: Timed out executing program performance/bharshbarg/range-forall]
 
@@ -344,7 +344,7 @@ Reviewed 2015-01-19
 ===================
 
 
-sporadic execution timeout (2014-01-18)
+sporadic execution timeout (2015-01-18)
 ---------------------------------------
 [Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 3, execopts: 1)]
 [Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 4, execopts: 1)]
@@ -508,7 +508,7 @@ sporadic dropping/mangling of output
 
 Sporadic compilation timeout
 ----------------------------
-[Error: Timed out compilation for arrays/bradc/intuintarr] (2014-01-16)
+[Error: Timed out compilation for arrays/bradc/intuintarr] (2015-01-16)
 
 
 ======================================
@@ -566,7 +566,7 @@ Reviewed 2015-01-15
 
 Sporadic compilation timeout
 ----------------------------
-[Error: Timed out compilation for arrays/bradc/localSlices/nonlocalslice] (2014-01-15)
+[Error: Timed out compilation for arrays/bradc/localSlices/nonlocalslice] (2015-01-15)
 
 
 =============================
@@ -648,12 +648,12 @@ Reviewed 2015-01-16
 
 something going wrong with reservedSymbolNames causes reserved names to show up in generated code.
 --------------------------------------------------------------------------------------------------
-All tests fail when this happens (2014-01-08, 2014-01-16)
+All tests fail when this happens (2015-01-08, 2015-01-16)
 
 
 Sporadic compilation timeout
 ----------------------------
-[Error: Timed out compilation for arrays/bradc/slices/outOfBoundsSlice] (2014-01-15)
+[Error: Timed out compilation for arrays/bradc/slices/outOfBoundsSlice] (2015-01-15)
 
 
 ===========================
@@ -770,7 +770,7 @@ Reviewed 2015-01-19
 ===================
 
 
-sporadic execution timeout (2014-01-18)
+sporadic execution timeout (2015-01-18)
 ---------------------------------------
 [Error: Timed out executing program distributions/robust/arithmetic/kernels/hpl (compopts: 1)]
 [Error: Timed out executing program distributions/robust/arithmetic/kernels/jacobi]

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -670,10 +670,6 @@ QIO strcmp(got, expect) assertion error
 ---------------------------------------
 [Error matching program output for io/ferguson/ctests/qio_formatted_test (compopts: 1)]
 
-QIO qio_err_to_int() == EEOF assertion error
---------------------------------------------
-[Error matching program output for io/ferguson/ctests/qio_test (compopts: 1)]
-
 consistent execution timeout (frequent)
 ---------------------------------------
 [Error: Timed out executing program studies/cholesky/jglewis/version2/performance/test_cholesky_performance (compopts: 1)] (..., 2014-12-01, 2015-01-05.. )
@@ -719,8 +715,12 @@ sporadic os.unlink calls in sub_test failing due to resource being busy
 ===================
 cygwin64
 Inherits 'cygwin*' and 'linux64'
-Reviewed 2015-01-16
+Reviewed 2015-01-21
 ===================
+
+QIO qio_err_to_int() == EEOF assertion error
+--------------------------------------------
+[Error matching program output for io/ferguson/ctests/qio_test (compopts: 1)]
 
 
 === sporadic failures below ===

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -52,12 +52,12 @@ general
 Reviewed 2015-01-19
 ===================
 
-with gcc version >= 4.8.0: "error: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Werror=strict-overflow]" (2015-01-22, eronagha)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+with gcc version >= 4.8.0: "error: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Werror=strict-overflow]" (2015-01-22, xe-wb.gnu, cygwin32, cygwin64, eronagha)
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [Error matching compiler output for npb/ft/ft-serial (compopts: 1)]
 
-erroneous used-before-defined gripe from chpl compiler (2015-01-22, darwin, xe-wb.pgi, xe-wb.intel, xe-wb.intel, mnoakes)
-------------------------------------------------------------------------------------------------------------
+erroneous used-before-defined gripe from chpl compiler (2015-01-22, xe-wb.pgi, xe-wb.intel, mnoakes)
+----------------------------------------------------------------------------------------------------
 [Error matching compiler output for studies/graph500/kristyn/Graph500_1D_onV/main (compopts: 1)]
 [Error matching compiler output for studies/graph500/v2/main (compopts: 1)]
 [Error matching compiler output for studies/graph500/v3/main (compopts: 1)]

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -52,6 +52,10 @@ general
 Reviewed 2015-01-19
 ===================
 
+with gcc version >= 4.8.0: "error: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Werror=strict-overflow]" (2015-01-22, eronagha)
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[Error matching compiler output for npb/ft/ft-serial (compopts: 1)]
+
 
 ===================
 linux64
@@ -117,10 +121,6 @@ Reviewed 2015-01-22
 timeout (2014-11-12, first run)
 -------------------------------
 [Error: Timed out executing program domains/sungeun/assoc/parSafeMember (compopts: 1)]
-
-gcc 4.9.1 "error: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Werror=strict-overflow]" (2015-01-22, eronagha)
-----------------------------------------------------------------------------------------------------------------------------------------------------------
-[Error matching compiler output for npb/ft/ft-serial (compopts: 1)]
 
 
 === sporadic failures below ===

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -81,12 +81,6 @@ memmax/memthreshold flags are C types; should be Chapel types (2014-11-12)
 [Error matching program output for execflags/shannon/help]
 [Error matching program output for memory/shannon/memmaxIntOnly]
 
-tasking #include didn't get a filename (since first run, 2014-11-12)
---------------------------------------------------------------------
-[Error matching compiler output for io/ferguson/ctests/qio_bits_test (compopts: 1)]
-[Error matching compiler output for io/ferguson/ctests/qio_formatted_test (compopts: 1)]
-[Error matching compiler output for io/ferguson/ctests/qio_test (compopts: 1)]
-
 different amounts of memory leaked on 32-bit platforms (2014-11-12, first run)
 ------------------------------------------------------------------------------
 [Error matching program output for memory/sungeun/refCount/domainMaps]
@@ -98,7 +92,6 @@ prefetch instruction not found (2014-11-12, first run)
 some sort of 64-bit assertion fails (2014-11-12, first run)
 -----------------------------------------------------------
 [Error matching program output for optimizations/cache-remote/ferguson/c_tests/chpl-cache-support-test (compopts: 1)]
-
 
 GMP [u]int(64)/32-bit c_[u]long mismatches (since first run, 2014-11-12)
 ------------------------------------------------------------------------
@@ -117,33 +110,17 @@ Inherits '*32'
 Reviewed 2015-01-19
 ===================
 
-seg fault (2014-11-12, first run)
----------------------------------
-[Error matching program output for parallel/cobegin/deitz/test_big_recursive_cobegin]
-
 timeout (2014-11-12, first run)
 -------------------------------
-[Error matching program output for parallel/cobegin/diten/cobeginRace]
 [Error: Timed out executing program domains/sungeun/assoc/parSafeMember (compopts: 1)]
 
 
 === sporadic failures below ===
 
-sporadic timeout
-----------------
-[Error: Timed out executing program stress/deitz/test_10k_begins] (2014-11-12..2014-11-29, 2014-12-16)
-[Error: Timed out executing program parallel/coforall/bradc/manyThreads-inorder] (2014-11-12..2014-12-14, 2014-12-16, 2014-12-18)
-[Error: Timed out executing program studies/shootout/nbody/sidelnik/nbody_reductions_6] (2014-11-24)
-[Error: Timed out executing program statements/lydia/forVersusWhilePerf (compopts: 1)] (2014-11-29)
-
 sporadic signal 11
 ------------------
 [Error matching program output for stress/deitz/test_10k_begins] (2014-11-13..2014-12-09, 2014-12-15, 2014-12-19, 2015-01-04)
 [Error matching program output for parallel/begin/dinan/mvm_coforall] (2014-11-21, 2014-11-27, 2014-12-15)
-
-sporadic tasks not being created
---------------------------------
-[Error matching program output for parallel/coforall/bradc/manyThreads-inorder] (2014-11-14..2014-11-30)
 
 
 ===================
@@ -327,7 +304,7 @@ Reviewed 2015-01-16
 
 malloc memory corruption. New test by Vass and error might be sporadic
 ----------------------------------------------------------------------
-[Error matching .bad file for variables/vass/ref-to-domains-arrays] (2015-01-10 .. 2015-01-11)
+[Error matching .bad file for variables/vass/ref-to-domains-arrays] (2015-01-10..2015-01-11)
 
 
 =================================
@@ -365,7 +342,6 @@ Reviewed 2015-01-13
 ===================
 
 
-
 === sporadic failures below ===
 
 sporadic execution timeout (regularly)
@@ -388,7 +364,7 @@ Reviewed 2015-01-16
 
 consistent timeouts
 -------------------
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_likepy] (2014-11-28..)
+[Error: Timed out executing program studies/madness/aniruddha/madchap/test_likepy] (2014-11-28.. )
 
 
 === sporadic failures below ===
@@ -488,11 +464,12 @@ error differs but within acceptable margin; should squash error printing
 ------------------------------------------------------------------------
 [Error matching program output for studies/hpcc/FFT/marybeth/fft]
 
+
 === sporadic failures below ===
 
 sporadic dropping/mangling of output
 ------------------------------------
-[Error matching program output for classes/bradc/arrayInClass/arrayOfArithInClass]                      (2015-01-12..)
+[Error matching program output for classes/bradc/arrayInClass/arrayOfArithInClass] (2015-01-12..)
 [Error matching program output for distributions/robust/arithmetic/collapsing/test_domain_rank_change1] (2014-10-24)
 [Error matching program output for domains/sungeun/assoc/index_not_in_domain_2 (compopts: 2)] (2014-11-13)
 [Error matching program output for functions/diten/refIntents] (2014-09-30)
@@ -526,7 +503,6 @@ timeout
 [Error: Timed out compilation for arrays/claridge/arraySizeMismatch] (2015-01-07.. )
 
 
-
 ============================
 xc-wb.host.prgenv-cray
 Inherits 'x?-wb.prgenv-cray'
@@ -541,12 +517,12 @@ Reviewed 2015-01-16
 ===================
 
 test assertion failures (2014-09-21..2014-09-23)
------------------------------------------------
+------------------------------------------------
 [Error matching program output for io/ferguson/io_test]
 [Error matching program output for io/ferguson/writef_readf]
 
 binary files differ (2014-09-21..2014-09-23)
--------------------------------------------
+--------------------------------------------
 [Error matching program output for io/ferguson/writefbinary]
 [Error matching program output for studies/parboil/SAD/sadSerial]
 
@@ -744,13 +720,6 @@ baseline
 Inherits 'general'
 Reviewed 2015-01-16
 ===================
-
-
-new memory leaks  2014-12-20  Elliot has claimed these
-------------------------------------------------------
-[Error matching program output for memory/vass/memleak-array-of-records-1]          (2014-12-20)
-[Error matching program output for types/string/StringImpl/memLeaks/promotion]      (2014-12-20)
-
 
 Dies with signal 6
 ------------------

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -229,8 +229,8 @@ Reviewed 2015-01-19
 
 === sporadic failures below ===
 
-sporadic timeout
-----------------
+sporadic execution timeout
+--------------------------
 [Error: Timed out executing program stress/deitz/test_10k_begins] (2015-01-08)
 
 ==================
@@ -372,8 +372,8 @@ Inherits 'gasnet*' and 'fifo'
 Reviewed 2015-01-16
 =============================
 
-consistent timeouts
--------------------
+consistent execution timeouts
+-----------------------------
 [Error: Timed out executing program studies/madness/aniruddha/madchap/test_likepy] (2014-11-28.. )
 
 
@@ -383,12 +383,12 @@ sporadic failures even after Sung quieted it down (frequently -- gbt/diten)
 ---------------------------------------------------------------------------
 [Error matching program output for types/string/StringImpl/memLeaks/coforall] (2014-10-23..2014-11-30, 2014-12-14, 2014-12-17)
 
-sporadic timeouts (frequent)
-----------------------------
+sporadic execution timeouts (frequent)
+--------------------------------------
 [Error: Timed out executing program studies/madness/aniruddha/madchap/test_gaxpy] (2014-10-19, 2014-10-24, 2014-11-11, 2014-11-13, 2014-12-13, 2014-12-15, 2015-01-07, 2015-01-09)
 
-sporadic timeouts (infrequent)
-------------------------------
+sporadic execution timeouts (infrequent)
+----------------------------------------
 [Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dDRtoBDTest] (2014-10-21, 2014-11-23)
 
 
@@ -623,8 +623,8 @@ negative floating point 0.0 not supported
 [Error matching program output for types/complex/bradc/negativeimaginaryliteral]
 [Error matching program output for types/file/bradc/scalar/floatcomplexexceptions]
 
-consistent timeout
-------------------
+consistent execution timeout
+----------------------------
 [Error: Timed out executing program domains/sungeun/assoc/parSafeMember (compopts: 1)]
 
 
@@ -674,8 +674,8 @@ QIO qio_err_to_int() == EEOF assertion error
 --------------------------------------------
 [Error matching program output for io/ferguson/ctests/qio_test (compopts: 1)]
 
-consistent timeout (frequent)
-----------------------------
+consistent execution timeout (frequent)
+---------------------------------------
 [Error: Timed out executing program studies/cholesky/jglewis/version2/performance/test_cholesky_performance (compopts: 1)] (..., 2014-12-01, 2015-01-05.. )
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -66,6 +66,10 @@ Inherits 'general'
 Reviewed 2015-01-19
 ===================
 
+Seg fault First run 2014-12-07
+------------------------------
+[Error matching compiler output for users/vass/type-tests.isSubtype]
+
 memmax/memthreshold flags are C types; should be Chapel types (2014-11-12)
 --------------------------------------------------------------------------
 [Error matching program output for execflags/ferguson/help2]
@@ -107,12 +111,16 @@ GMP [u]int(64)/32-bit c_[u]long mismatches (since first run, 2014-11-12)
 ===================
 linux32
 Inherits '*32'
-Reviewed 2015-01-19
+Reviewed 2015-01-22
 ===================
 
 timeout (2014-11-12, first run)
 -------------------------------
 [Error: Timed out executing program domains/sungeun/assoc/parSafeMember (compopts: 1)]
+
+gcc 4.9.1 "error: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Werror=strict-overflow]" (2015-01-22, eronagha)
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+[Error matching compiler output for npb/ft/ft-serial (compopts: 1)]
 
 
 === sporadic failures below ===
@@ -120,7 +128,7 @@ timeout (2014-11-12, first run)
 sporadic signal 11
 ------------------
 [Error matching program output for stress/deitz/test_10k_begins] (2014-11-13..2014-12-09, 2014-12-15, 2014-12-19, 2015-01-04)
-[Error matching program output for parallel/begin/dinan/mvm_coforall] (2014-11-21, 2014-11-27, 2014-12-15)
+[Error matching program output for parallel/begin/dinan/mvm_coforall] (2014-11-21, 2014-11-27, 2014-12-15, 2015-01-22)
 
 
 ===================
@@ -666,17 +674,12 @@ consistent timeout (frequent)
 ===========================
 cygwin32
 Inherits 'cygwin*' and '*32'
-Reviewed 2015-01-16
+Reviewed 2015-01-21
 ===========================
 
-Seg fault First run 2014-12-07
-------------------------------
-[Error matching compiler output for users/vass/type-tests.isSubtype]
-
-Generated output "FAILED": First run 2014-12-07
------------------------------------------------
+Generated output "FAILED" (see below for sporadic): First run 2014-12-07
+------------------------------------------------------------------------
 [Error matching program output for studies/colostate/OMP-Jacobi-1D-Naive-Parallel (compopts: 1)]
-[Error matching program output for studies/colostate/OMP-Jacobi-1D-Sliced-Diamond-Tiling (compopts: 1)]
 [Error matching program output for studies/colostate/OMP-Jacobi-2D-Naive-Parallel (compopts: 1)]
 
 Error tolerance exceeded?: First run 2014-12-07
@@ -695,6 +698,10 @@ Consistent execution timouts
 
 
 === sporadic failures below ===
+
+sporadic generated output "FAILED" (see above for solid): First run 2014-12-07
+------------------------------------------------------------------------------
+[Error matching program output for studies/colostate/OMP-Jacobi-1D-Sliced-Diamond-Tiling (compopts: 1)] (2015-01-16..2015-01-19, 2015-01-21)
 
 sporadic os.unlink calls in sub_test failing due to resource being busy
 =======================================================================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -163,9 +163,11 @@ consistent failure due to insane memory usage (should get better with strings)
 [Error matching performance keys for studies/shootout/fasta/kbrady/fasta-lines]
 
 
-execution time out (2015-01-16.. )
-----------------------------------
-[Error: Timed out executing program performance/bharshbarg/range-forall]
+=== sporadic failures below ===
+
+sporadic execution timeout
+--------------------------
+[Error: Timed out executing program performance/bharshbarg/range-forall] (2015-01-16..2015-01-21)
 
 
 ===================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -411,6 +411,29 @@ Reviewed 2015-01-16
 ===================
 
 
+=== sporadic failures below ===
+
+something going wrong with reservedSymbolNames causes reserved names to show up in generated code.
+--------------------------------------------------------------------------------------------------
+All tests fail when this happens (xc-wb.host.prgenv-pgi 2015-01-08, xc-wb.prgenv-pgi 2015-01-16, xc-wb.prgenv-pgi 2015-01-21, xc-wb.prgenv-gnu 2015-01-22)
+
+Sporadic compilation timeouts
+-----------------------------
+[Error: Timed out compilation for arrays/bradc/arrOfDom/arrOfDom2] (xe-wb.gnu 2015-01-20)
+[Error: Timed out compilation for arrays/bradc/intuintarr] (xe-wb.prgenv-cray 2015-01-16)
+[Error: Timed out compilation for arrays/bradc/localSlices/nonlocalslice] (xe-wb.prgenv-intel 2015-01-15)
+[Error: Timed out compilation for arrays/bradc/paulslice] (xe-wb.pgi 2015-01-20)
+[Error: Timed out compilation for arrays/bradc/slices/outOfBoundsSlice] (xe-wb.prgenv-pgi 2015-01-15)
+[Error: Timed out compilation for arrays/bradc/sliceViaSingleton3d] (xe-wb.intel 2015-01-20)
+[Error: Timed out compilation for arrays/claridge/arraySizeMismatch] (xe-wb.prgenv-cray 2015-01-07)
+
+sporadic execution timeouts
+---------------------------
+[Error matching program output for studies/590o/alaska/graph] (xe-wb.prgenv-cray ..2015-01-18, 2015-01-21.. )
+[Error: Timed out executing program studies/shootout/nbody/sidelnik/nbody_rangesub_5] (xe-wb.pgi 2015-01-22)
+[Error: Timed out executing program studies/shootout/nbody/sidelnik/nbody_vector_4] (xe-wb.prgenv-pgi 2015-01-22)
+
+
 ==================
 *prgenv-*
 Inherits 'general'
@@ -478,6 +501,8 @@ error differs but within acceptable margin; should squash error printing
 sporadic dropping/mangling of output
 ------------------------------------
 [Error matching program output for classes/bradc/arrayInClass/arrayOfArithInClass] (2015-01-12..)
+[Error matching program output for classes/bradc/arrayInClass/genericArrayInClass-arith] (2014-12-25..2015-01-08)
+[Error matching program output for distributions/deitz/exBlockExample/block2D] (2015-01-21)
 [Error matching program output for distributions/robust/arithmetic/collapsing/test_domain_rank_change1] (2014-10-24)
 [Error matching program output for domains/sungeun/assoc/index_not_in_domain_2 (compopts: 2)] (2014-11-13)
 [Error matching program output for functions/diten/refIntents] (2014-09-30)
@@ -490,10 +515,14 @@ sporadic dropping/mangling of output
 [Error matching program output for studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall (compopts: 1)] (2014-12-19)
 [Error matching program output for studies/shootout/nbody/sidelnik/nbody_orig_1] (2014-12-16)
 
-
-Sporadic compilation timeout
-----------------------------
-[Error: Timed out compilation for arrays/bradc/intuintarr] (2015-01-16)
+sporadic "error: attempt to dereference nil" (xe-wb.prgenv-cray 2015-01-18)
+---------------------------------------------------------------------------
+[Error matching compiler output for modules/standard/gmp/ferguson/gmp_dist_array]
+[Error matching compiler output for modules/standard/gmp/ferguson/gmp_random]
+[Error matching compiler output for modules/standard/gmp/ferguson/gmp_test]
+[Error matching compiler output for modules/standard/gmp/ferguson/gmp_writeln]
+[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-BigInt]
+[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt]
 
 
 ======================================
@@ -501,14 +530,6 @@ x?-wb.prgenv-cray
 Inherits 'x?-wb.*' and '*prgenv-cray*'
 Reviewed 2015-01-12
 ======================================
-
-sporadic dropping of range separator {1..3} -> {13}
----------------------------------------------------
-[Error matching program output for classes/bradc/arrayInClass/genericArrayInClass-arith] (2014-12-25..2015-01-08)
-
-timeout
--------
-[Error: Timed out compilation for arrays/claridge/arraySizeMismatch] (2015-01-07.. )
 
 
 ============================
@@ -547,10 +568,6 @@ x?-wb.prgenv-intel
 Inherits 'x?-wb.*' and '*intel*'
 Reviewed 2015-01-15
 ================================
-
-Sporadic compilation timeout
-----------------------------
-[Error: Timed out compilation for arrays/bradc/localSlices/nonlocalslice] (2015-01-15)
 
 
 =============================
@@ -630,16 +647,6 @@ Reviewed 2015-01-16
 ==============================
 
 
-something going wrong with reservedSymbolNames causes reserved names to show up in generated code.
---------------------------------------------------------------------------------------------------
-All tests fail when this happens (2015-01-08, 2015-01-16)
-
-
-Sporadic compilation timeout
-----------------------------
-[Error: Timed out compilation for arrays/bradc/slices/outOfBoundsSlice] (2015-01-15)
-
-
 ===========================
 xc-wb.host.prgenv-pgi
 Inherits 'x?-wb.prgenv-pgi'
@@ -664,7 +671,6 @@ QIO strcmp(got, expect) assertion error
 QIO qio_err_to_int() == EEOF assertion error
 --------------------------------------------
 [Error matching program output for io/ferguson/ctests/qio_test (compopts: 1)]
-
 
 consistent timeout (frequent)
 ----------------------------

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -56,6 +56,12 @@ with gcc version >= 4.8.0: "error: assuming signed overflow does not occur when 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [Error matching compiler output for npb/ft/ft-serial (compopts: 1)]
 
+erroneous used-before-defined gripe from chpl compiler (2015-01-22, darwin, xe-wb.pgi, xe-wb.intel, mnoakes)
+------------------------------------------------------------------------------------------------------------
+[Error matching compiler output for studies/graph500/kristyn/Graph500_1D_onV/main (compopts: 1)]
+[Error matching compiler output for studies/graph500/v2/main (compopts: 1)]
+[Error matching compiler output for studies/graph500/v3/main (compopts: 1)]
+
 
 ===================
 linux64
@@ -277,6 +283,10 @@ read of size 8 in dl_name_match_p
 -----------------------------------------------------------------------------
 [Error matching program output for performance/sungeun/dgemm] (2014-11-16..2014-11-26, 2014-11-29..2015-01-05)
 
+sporadic (?) compilation timeout
+--------------------------------
+[Error: Timed out compilation for functions/iterators/vass/standaloneForallIntents] (2015-01-20)
+
 
 ===================
 llvm
@@ -381,7 +391,7 @@ consistent execution timeouts
 
 sporadic failures even after Sung quieted it down (frequently -- gbt/diten)
 ---------------------------------------------------------------------------
-[Error matching program output for types/string/StringImpl/memLeaks/coforall] (2014-10-23..2014-11-30, 2014-12-14, 2014-12-17)
+[Error matching program output for types/string/StringImpl/memLeaks/coforall] (2014-10-23..2014-11-30, 2014-12-14, 2014-12-17, 2015-01-21)
 
 sporadic execution timeouts (frequent)
 --------------------------------------

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -73,7 +73,7 @@ Reviewed 2015-01-19
 ===================
 *32
 Inherits 'general'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
 Seg fault First run 2014-12-07
@@ -118,10 +118,11 @@ GMP [u]int(64)/32-bit c_[u]long mismatches (since first run, 2014-11-12)
 [Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-BigInt]
 [Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt]
 
+
 ===================
 linux32
 Inherits '*32'
-Reviewed 2015-01-22
+Reviewed 2015-01-23
 ===================
 
 timeout (2014-11-12, first run)
@@ -419,7 +420,7 @@ Reviewed 2015-01-16
 ===================
 x?-wb.*
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
 
 
@@ -442,7 +443,6 @@ Sporadic compilation timeouts
 
 sporadic execution timeouts
 ---------------------------
-[Error matching program output for studies/590o/alaska/graph] (xe-wb.prgenv-cray ..2015-01-18, 2015-01-21.. )
 [Error: Timed out executing program studies/shootout/nbody/sidelnik/nbody_rangesub_5] (xe-wb.pgi 2015-01-22)
 [Error: Timed out executing program studies/shootout/nbody/sidelnik/nbody_vector_4] (xe-wb.prgenv-pgi 2015-01-22)
 
@@ -450,14 +450,14 @@ sporadic execution timeouts
 ==================
 *prgenv-*
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
 
 
 ====================
 *prgenv-cray*
 Inherits '*prgenv-*'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ====================
 
 infinite loop warning (since filed?)
@@ -500,14 +500,14 @@ signal 11 (first seen 2014-03-02)
 [Error matching compiler output for release/examples/benchmarks/shootout/meteor-fast]
 [Error matching program output for studies/shootout/meteor/kbrady/meteor-parallel-alt]
 
-signal 11 (first seen ????-??-??)
----------------------------------
-[Error matching program output for studies/590o/alaska/graph]
-
 error differs but within acceptable margin; should squash error printing
 ------------------------------------------------------------------------
 [Error matching program output for studies/hpcc/FFT/marybeth/fft]
 
+output mismatch (first seen 2015-01-09, vass)
+---------------------------------------------
+[Error matching program output for modules/sungeun/test_safeSub]
+bisect
 
 === sporadic failures below ===
 
@@ -515,6 +515,7 @@ sporadic dropping/mangling of output
 ------------------------------------
 [Error matching program output for classes/bradc/arrayInClass/arrayOfArithInClass] (2015-01-12..)
 [Error matching program output for classes/bradc/arrayInClass/genericArrayInClass-arith] (2014-12-25..2015-01-08)
+[Error matching program output for distributions/dm/t5a] (2015-01-23)
 [Error matching program output for distributions/deitz/exBlockExample/block2D] (2015-01-21)
 [Error matching program output for distributions/robust/arithmetic/collapsing/test_domain_rank_change1] (2014-10-24)
 [Error matching program output for domains/sungeun/assoc/index_not_in_domain_2 (compopts: 2)] (2014-11-13)
@@ -527,6 +528,11 @@ sporadic dropping/mangling of output
 [Error matching program output for studies/cholesky/jglewis/version2/elemental/test_elemental_cholesky] (2015-01-14)
 [Error matching program output for studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall (compopts: 1)] (2014-12-19)
 [Error matching program output for studies/shootout/nbody/sidelnik/nbody_orig_1] (2014-12-16)
+
+signal 11 (first seen ????-??-??)
+---------------------------------
+[Error matching program output for studies/590o/alaska/graph] ( ..2015-01-18, 2015-01-21.. )
+[Error matching program output for reductions/thomasvandoren/test/TestCounts] (2015-01-23)
 
 sporadic "error: attempt to dereference nil" (xe-wb.prgenv-cray 2015-01-18)
 ---------------------------------------------------------------------------
@@ -541,21 +547,28 @@ sporadic "error: attempt to dereference nil" (xe-wb.prgenv-cray 2015-01-18)
 ======================================
 x?-wb.prgenv-cray
 Inherits 'x?-wb.*' and '*prgenv-cray*'
-Reviewed 2015-01-12
+Reviewed 2015-01-23
 ======================================
 
 
 ============================
 xc-wb.host.prgenv-cray
 Inherits 'x?-wb.prgenv-cray'
-Reviewed 2015-01-12
+Reviewed 2015-01-23
 ============================
+
+
+=== sporadic failures below ===
+
+all tests fail compilation with "$CHPL_HOME/modules/internal/ChapelDistribution.chpl:65: error: unresolved call '(bool)'"
+-------------------------------------------------------------------------------------------------------------------------
+(2015-01-19.. )
 
 
 ===================
 *intel*
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
 
 test assertion failures (2014-09-21..2014-09-23)
@@ -572,56 +585,56 @@ binary files differ (2014-09-21..2014-09-23)
 ================================
 x?-wb.intel
 Inherits 'x?-wb.*' and '*intel*'
-Reviewed 2015-01-15
+Reviewed 2015-01-23
 ================================
 
 
 ================================
 x?-wb.prgenv-intel
 Inherits 'x?-wb.*' and '*intel*'
-Reviewed 2015-01-15
+Reviewed 2015-01-23
 ================================
 
 
 =============================
 xc-wb.host.prgenv-intel
 Inherits 'x?-wb.prgenv-intel'
-Reviewed 2015-01-15
+Reviewed 2015-01-23
 =============================
 
 
 =======================
 *gnu*
 Inherits from 'linux64'
-Reviewed 2015-01-15
+Reviewed 2015-01-23
 =======================
 
 
 ==============================
 x?-wb.gnu
 Inherits 'x?-wb.*' and '*gnu*'
-Reviewed 2015-01-15
+Reviewed 2015-01-23
 ==============================
 
 
 ==============================
 x?-wb.prgenv-gnu
 Inherits 'x?-wb.*' and '*gnu*'
-Reviewed 2015-01-15
+Reviewed 2015-01-23
 ==============================
 
 
 ===========================
 xc-wb.host.prgenv-gnu
 Inherits 'x?-wb.prgenv-gnu'
-Reviewed 2015-01-15
+Reviewed 2015-01-23
 ===========================
 
 
 ===================
 *pgi*
 Inherits 'general'
-Reviewed 2015-01-15
+Reviewed 2015-01-23
 ===================
 
 undefined reference to chpl_bitops_debruijn64 (2014-07-14)
@@ -649,28 +662,28 @@ target program died with signal 11, without coredump
 ==============================
 x?-wb.pgi
 Inherits 'x?-wb.*' and '*pgi*'
-Reviewed 2015-01-15
+Reviewed 2015-01-23
 ==============================
 
 
 ==============================
 x?-wb.prgenv-pgi
 Inherits 'x?-wb.*' and '*pgi*'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ==============================
 
 
 ===========================
 xc-wb.host.prgenv-pgi
 Inherits 'x?-wb.prgenv-pgi'
-Reviewed 2015-01-12
+Reviewed 2015-01-23
 ===========================
 
 
 ===================
 cygwin*
 Inherits 'general'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
 
 check_channel assertion failure
@@ -689,7 +702,7 @@ consistent execution timeout (frequent)
 ===========================
 cygwin32
 Inherits 'cygwin*' and '*32'
-Reviewed 2015-01-21
+Reviewed 2015-01-23
 ===========================
 
 Generated output "FAILED" (see below for sporadic): First run 2014-12-07
@@ -721,7 +734,7 @@ sporadic os.unlink calls in sub_test failing due to resource being busy
 ===================
 cygwin64
 Inherits 'cygwin*' and 'linux64'
-Reviewed 2015-01-21
+Reviewed 2015-01-23
 ===================
 
 QIO qio_err_to_int() == EEOF assertion error
@@ -739,26 +752,29 @@ sporadic pthread_cond_init() failed (infrequent)
 ===================
 baseline
 Inherits 'general'
-Reviewed 2015-01-22
+Reviewed 2015-01-23
 ===================
 
 Dies with signal 6
 ------------------
 [Error matching program output for studies/glob/test_glob (compopts: 1)] (Brad)
 
+
 ===================
 dist-block
 Inherits 'gasnet*'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================
 
 
 ===================
 dist-cyclic
 Inherits 'gasnet*'
-Reviewed 2015-01-19
+Reviewed 2015-01-23
 ===================
 
+
+=== sporadic failures below ===
 
 sporadic execution timeout (2015-01-18)
 ---------------------------------------
@@ -769,5 +785,5 @@ sporadic execution timeout (2015-01-18)
 ===================
 dist-replicated
 Inherits 'gasnet*'
-Reviewed 2015-01-16
+Reviewed 2015-01-23
 ===================


### PR DESCRIPTION
Test pass/fail maintenance
==========================
- general: add a new gen compiler (gcc version >= 4.8.0) failure due to
  a spurious message about signed overflow, which Elliot has fixed but
  not all suites have shown as resolved yet
- general: add a new erroneous used-before-defined failure, which
  Michael has fixed but not all suites have shown as resolved yet
- remove a number of things we think are fixed and which indeed have
  stopped failing
- perf.bradc-lnx: performance/bharshbarg/range-forall turns out to be
  sporadic
- cygwin32:
  - one of the studies/colostate/OMP-Jacobi-* failures turns out
    to be sporadic; give it its own listing, but cross-reference the
    solid and sporadic failures to each other
  - remove the PTRANS failures, which now work
- x?-wb and prgenv*:
  - add a one-time "error: attempt to dereference nil" entry for 6 tests
    on xe-wb.prgenv-cray
  - remove the spurious timeout entry for studies/590o/alaska/graph; I
    read the test log too fast; it was a signal 11
  - the studies/590o/alaska/graph signal 11 failure is sporadic
  - add modules/sungeun/test_safeSub
  - add entry for xc-wb.host.prgenv-cray solid "unresolved call
    '(bool)'" failure
- add a few new sporadic timeouts and execution mismatches

Reorganization
==============
- linux32: users/vass/type-tests.isSubtype fails on linux32 in the same
  way it does on cygwin32, so move it to *32
- cygwin64: The io/ferguson/ctests/qio_test "qio_err_to_int() == EEOF"
  error only occurs in cygwin64, not in cygwin32, so move it from
  cygwin* to cygwin64
- Move common failures to x?-wb.*.  We've now seen:
  - the massive reservedSymbolNames failure with xc-wb.host.prgenv-pgi,
    xc-wb.prgenv-pgi, and xc-wb.prgenv-gnu
  - compilation timeouts with xe-wb.gnu, xe-wb.prgenv-cray, xe-wb.intel,
    xe-wb.prgenv-intel, xe-wb.pgi, and xe-wb.prgenv-pgi
  - execution timeouts with xe-wb.prgenv-cray, xe-wb.pgi, and
    xe-wb.prgenv-pgi
  Since it looks like these kinds of failures are common to all whitebox
  testing, consolidate them into x?-wb.*

Review
======
- Review all suites, update review dates.

Cleanup
=======
- Slightly rephrase top comment regarding data ranges.
- Be clear in the headers as to compilation vs. execution timeouts.
- Replace middle '-' with '..' in two instances of YYYY-MM-DD-YYYY-MM-DD.
- Fix check-writing errors (year 2014 used when 2015 intended).
- Standardize on x?-wb.* (was x?-wb* in some places).
- Standardize on '..' without white space.
- Repair/standardize white space, blank lines, punctuation.
