### PR TITLE
The recent npb/ft/ft-serial failure is now resolved for cygwin{32,64}.

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -52,8 +52,8 @@ general
 Reviewed 2015-01-23
 ===================
 
-with gcc version >= 4.8.0: "error: assuming signed overflow ... [-Werror=strict-overflow]" (2015-01-22, xe-wb.gnu, cygwin32, cygwin64, eronagha)
-------------------------------------------------------------------------------------------------------------------------------------------------
+with gcc version >= 4.8.0: "error: assuming signed overflow ... [-Werror=strict-overflow]" (2015-01-22, xe-wb.gnu, eronagha)
+----------------------------------------------------------------------------------------------------------------------------
 [Error matching compiler output for npb/ft/ft-serial (compopts: 1)]
 
 erroneous used-before-defined msg from chpl compiler (2015-01-22, xe-wb.pgi, xe-wb.intel, mnoakes)


### PR DESCRIPTION
REGRESSIONS is up to date with respect to all testing completed so far.