### PR TITLE
Add custom value and label formatters for dygraphs

### DIFF
--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -151,7 +151,9 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
       y: {
         drawGrid: true,
         // So y values don't overlap with the y label
-        axisLabelWidth: 80
+        axisLabelWidth: 80,
+        valueFormatter: customValueFormatter,
+        axisLabelFormatter: customAxisLabelFormatter
       }
     },
     includeZero: true,
@@ -406,36 +408,50 @@ function setColors(g, origColors, blockRedraw) {
   g.updateOptions({ 'colors' : colors }, blockRedraw);
 }
 
+// We use a custom value formatter so that we can adjust the number of digits
+// displayed based on min and max y values. This makes the graphs look a lot
+// cleaner, especially since many of our graphs have widely varying y axis
+// ranges. e.g. you don't care if a test takes 500.21 vs 500.29 seconds, but do
+// care about 0.21 vs 0.29 seconds.
+//
+// Previously we did this in the zoom callback, but that forced us to re-render
+// the dygraph which is slow. This adds some overhead to updating the value
+// displayed in the label and legend, but there doesn't appear to be any
+// performance issues.
+function customValueFormatter(val, opts, series_name, dygraph) {
 
-// synchronize our graphs along the x-axis and update the number of decimals
-// being displayed per graph based on the range of data being displayed
+  // Find the range we're displaying and adjust digits accordingly
+  var yRange = dygraph.yAxisRange();
+  var yDiff = yRange[1] - yRange[0];
+  var digits = 0;
+  if (yDiff < 1.0) {
+    digits = 4;
+  } else if (yDiff < 100.0) {
+    digits = 2;
+  } else if (yDiff < 1000.0) {
+    digits = 1;
+  } else if (yDiff < 1000000.0) {
+    digits = 0;
+  } else {
+    digits = 2;
+  }
+
+  // update digits, but do NOT redraw. Then use the default value formatter
+  dygraph.updateOptions({digitsAfterDecimal: digits}, true);
+  return Dygraph.numberValueFormatter(val, opts);
+}
+
+// custom formatter for the y axis labels, calls the legend value formatter
+function customAxisLabelFormatter(val, granularity, opts, dygraph) {
+  return customValueFormatter(val, opts, '', dygraph);
+}
+
+
+// synchronize our graphs along the x-axis and check if we should warn that
+// using a log scale will result in wonky behavior.
 function customDrawCallback(g, initial) {
   if (blockRedraw) return;
   blockRedraw = true;
-
-  // Find the range we're displaying and adjust the number of decimals
-  // accordingly. setAnnotations() is used to redraw the graph. Normally
-  // updateOptions should redraw the graph, but it doesn't always work as
-  // expected in a callback.
-  var oldNumDigits = g.getOption('digitsAfterDecimal');
-  var newNumDigits = 0;
-  var yRange = g.yAxisRange();
-  var yDiff = yRange[1] - yRange[0];
-
-  if (yDiff < 1.0) {
-    newNumDigits = 4;
-  } else if (yDiff < 100.0) {
-    newNumDigits = 2;
-  } else if (yDiff < 1000000.0) {
-    newNumDigits = 0;
-  } else {
-    newNumDigits = 2;
-  }
-
-  if(newNumDigits !== oldNumDigits) {
-    g.updateOptions({digitsAfterDecimal: newNumDigits}, true);
-    g.setAnnotations(g.annotations());
-  }
 
   // if a user has explicitly zoomed in on zero or negative value and they
   // attempt to take the log the graph will not render. This is a known
@@ -444,6 +460,7 @@ function customDrawCallback(g, initial) {
   // requested a range, it will keep the same range for the log scale and
   // will attempt to take the log of zero.
   if (!initial) {
+    var yRange = g.yAxisRange();
     if (yRange[0] <= 0 && g.isZoomed('y')) {
       g.divs.logToggle.style.color = 'red';
     } else {


### PR DESCRIPTION
The value and label formatters change the formatting of the values in y-axis
and in the legend. The custom formatters just adjust the number of digits. This
replaces the logic that used to be in the zoom callback to adjust the number of
digits displayed after decimals.

Doing it in the zoom callback required re-rendering the dygraph which is slow.
This should give a substantial performance boost when a graph is first loaded
since we avoid a re-render that we ended up doing on the initial load for most
graphs.  It should also help a little bit with zooming, but not as much since
most of the time the number of decimals didn't change much on zooming.