### PR TITLE
Scroll the graph selection pane with the performance graphs

### DIFF
--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -9,7 +9,7 @@
         <![endif]-->
     <script src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
     <script type="text/javascript"
-            src="dygraph-combined.js"></script>
+      src="dygraph-combined.js"></script>
     <!-- <script type="text/javascript"
             src="http://dygraphs.com/dygraph-dev.js"></script>
       -->
@@ -30,25 +30,26 @@
     </script>
     <table>
       <tr>
-        <td id="suiteOptions" class="graphList">
-          <p id='toggleConf'><em>Toggle configurations</em></p>
-          <p><em>Select a test suite</em></p>
-          <div id="suiteMenu"></div>
-          <p><strong>OR</strong></p>
-          <p><em>Select and display specific tests</em></p>
-          <input type="button" onclick="displaySelectedGraphs()"
-          value="Display">
-           <input type="button" onclick="clearDates()"
-          value="Clear Dates">
-          <br>
-          <input type="button" onclick="selectAllGraphs()"
-          value="Select All">
-          <input type="button" onclick="unselectAllGraphs()"
-          value="Unselect All">
-          <div id="graphlist"></div>
-        <td id="graphdisplay" valign="top">
-        </td>
-        <td id="legenddisplay" valign="top">
+        <td id="graphSelectionPane" class="graphSelectionPane">
+            <p id='toggleConf'><em>Toggle configurations</em></p>
+            <p><em>Select a test suite</em></p>
+            <div id="suiteMenu"></div>
+            <p><strong>OR</strong></p>
+            <p><em>Select and display specific tests</em></p>
+            <input type="button" onclick="displaySelectedGraphs()"
+            value="Display">
+             <input type="button" onclick="clearDates()"
+            value="Clear Dates">
+            <br>
+            <input type="button" onclick="selectAllGraphs()"
+            value="Select All">
+            <input type="button" onclick="unselectAllGraphs()"
+            value="Unselect All">
+            <div id="graphlist" class="graphList"></div>
+          <td valign="top">
+            <div id="graphdisplay" class=graphdisplay></div>
+          </td>
+          <td id="legenddisplay" valign="top">
         </td>
       </tr>
     </table>

--- a/util/test/perf/perfgraph.css
+++ b/util/test/perf/perfgraph.css
@@ -34,7 +34,7 @@ div.lspacer {
 .graphSelectionPane {
     padding-left: 20px;
     padding-right: 20px;
-    position:absolute;
+    position:fixed;
     vertical-align: top;
     border-right: 1px solid black;
 }

--- a/util/test/perf/perfgraph.css
+++ b/util/test/perf/perfgraph.css
@@ -1,6 +1,9 @@
 body {
     font-family: "Arial";
 }
+.graphdisplay {
+    margin-left: 375px;
+}
 .graph {
     vertical-align: top;
     white-space: nowrap;
@@ -19,7 +22,7 @@ div.perfLegend {
     vertical-align: top;
     width: 400px;
     height: 300px;
-    overflow: auto
+    overflow: auto;
 }
 span.highlight {
     border: 1px solid grey;
@@ -28,12 +31,17 @@ div.lspacer {
     width: 400px;
     height: 30px;
 }
-.graphList {
-    vertical-align: top;
-    width: 200px;
+.graphSelectionPane {
     padding-left: 20px;
     padding-right: 20px;
+    position:absolute;
+    vertical-align: top;
     border-right: 1px solid black;
+}
+.graphList {
+    margin-top: 10px;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 .toggle {
     height: 20px;

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -612,25 +612,28 @@ function perfGraphInit() {
 }
 
 
-// We want the graph selection pane to scroll with the page vertically so it's
-// always visible. In order to do that we have to calculate the height of the
-// graphlist so it fits within the page, and scroll the entire graph selection
-// pane when the window scrolls. This sets up the initial dimensions and
-// listens for scrolling and resizing.
+// We use 'fixed' css positioning to keep the graph selection pane always
+// visible (scrolls when the page scrolls.) However we don't want it to scroll
+// horizontally to so we move it when horizontal scross occur. Since it scrolls
+// veritcally we also need to make sure it fits in the page height. This sets
+// the initial dimensions and then listens for scrolling and resizes
 function setupGraphSelectionPane() {
   $(window).scroll(function(){
     setGraphSelectionPanePos();
   });
 
   $(window).ready(function(){
+    // we don't know the width of the graph selection pane until the graphs are
+    // added ot the graphlist. Once that is done figure out where to position
+    // the graph display. This is needed since the graph selection pane is
+    // 'fixed' meaning it's outside the normal flow and other elements act like
+    // it doesn't exist so we have to manualy move the graph display to avoid
+    // overlap. This doesn't change after page load.
+    var selectPaneWidth = parseInt($("#graphSelectionPane").outerWidth());
+    $('#graphdisplay').css({ 'margin-left': selectPaneWidth });
+
     setGraphListHeight();
     setGraphSelectionPanePos();
-
-    // The width of the selection pane depends on the length of the graph
-    // names, it doesn't change after the graphlist is loaded, but can be
-    // different for different graphs (e.g. perf vs compperf)
-    var selectPaneWidth = parseInt($("#graphSelectionPane").outerWidth());
-    $('#graphdisplay').css({ 'margin-left': selectPaneWidth + 10 });
   });
 
   $(window).resize(function(){
@@ -638,23 +641,17 @@ function setupGraphSelectionPane() {
     setGraphSelectionPanePos();
   });
 
-  // set the selection pane pos based based on the top of the graph display
-  // area (so it's aligned with the top graph) and the current scrolling
+  // set the selection panes horizontal positional based on the scroll so the
+  // selection pane isn't always visible when scrolling horizontally
   function setGraphSelectionPanePos() {
-    var graphListTop = parseInt($("#graphdisplay").offset().top);
-    var newTop = $(this).scrollTop() + graphListTop;
-    $('#graphSelectionPane').css({ 'top': newTop });
+    $('#graphSelectionPane').css({ 'left': -$(window).scrollLeft() });
   }
 
   // determine the height to use for the graphlist. We want it to use most of
-  // the rest of the page. We realign the entire selection pane, then figure
-  // out the top of the graphlist and use 90% of the height between the top of
-  // the graphlist and the page bottom, with a minimum of 100 pixels.
+  // the rest of the page. We use 90% of the height between the top of the
+  // graphlist and the bottom of the page (with a min of 100 pixels.)
   function setGraphListHeight() {
-    var graphListTop = parseInt($("#graphdisplay").offset().top);
-    $('#graphSelectionPane').css({ 'top': graphListTop });
-
-    var topPos = parseInt($("#graphlist").offset().top);
+    var topPos = parseInt($("#graphlist").offset().top) - $(window).scrollTop();
     var w = $(window).height();
     var height = (w-topPos)*.9;
     if (height < 100) { height = 100;}

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -575,6 +575,7 @@ function perfGraphInit() {
     toggleConf.textContent = '';
   }
 
+
   // generate the suite menu
   var suiteMenu = document.getElementById('suiteMenu');
   var f = document.createElement('form');
@@ -604,8 +605,61 @@ function perfGraphInit() {
     graphlist.appendChild(elem);
   }
 
+  setupGraphSelectionPane();
+
   setGraphsFromURL();
   displaySelectedGraphs();
+}
+
+
+// We want the graph selection pane to scroll with the page vertically so it's
+// always visible. In order to do that we have to calculate the height of the
+// graphlist so it fits within the page, and scroll the entire graph selection
+// pane when the window scrolls. This sets up the initial dimensions and
+// listens for scrolling and resizing.
+function setupGraphSelectionPane() {
+  $(window).scroll(function(){
+    setGraphSelectionPanePos();
+  });
+
+  $(window).ready(function(){
+    setGraphListHeight();
+    setGraphSelectionPanePos();
+
+    // The width of the selection pane depends on the length of the graph
+    // names, it doesn't change after the graphlist is loaded, but can be
+    // different for different graphs (e.g. perf vs compperf)
+    var selectPaneWidth = parseInt($("#graphSelectionPane").outerWidth());
+    $('#graphdisplay').css({ 'margin-left': selectPaneWidth + 10 });
+  });
+
+  $(window).resize(function(){
+    setGraphListHeight();
+    setGraphSelectionPanePos();
+  });
+
+  // set the selection pane pos based based on the top of the graph display
+  // area (so it's aligned with the top graph) and the current scrolling
+  function setGraphSelectionPanePos() {
+    var graphListTop = parseInt($("#graphdisplay").offset().top);
+    var newTop = $(this).scrollTop() + graphListTop;
+    $('#graphSelectionPane').css({ 'top': newTop });
+  }
+
+  // determine the height to use for the graphlist. We want it to use most of
+  // the rest of the page. We realign the entire selection pane, then figure
+  // out the top of the graphlist and use 90% of the height between the top of
+  // the graphlist and the page bottom, with a minimum of 100 pixels.
+  function setGraphListHeight() {
+    var graphListTop = parseInt($("#graphdisplay").offset().top);
+    $('#graphSelectionPane').css({ 'top': graphListTop });
+
+    var topPos = parseInt($("#graphlist").offset().top);
+    var w = $(window).height();
+    var height = (w-topPos)*.9;
+    if (height < 100) { height = 100;}
+    $('#graphlist').css({ 'height': height });
+  }
 }
 
 


### PR DESCRIPTION
Previously the graph selection pane (suite selection, individual graph
selection, etc) stayed stationary and you had to scroll back up to the top of
the page to select different graphs. Now it scrolls as you scroll the page. In
order to do that the individual graph selection list had to be put inside a new
pane so it can scroll if there's more graphs than can fit on the current page.

This adds logic to do the scrolling and automatically adjust the height of the
graph list on resizes and set the initial position of the graphPane based on
the width of the graphSelectionPane