### PR TITLE
Fix valgrind regressions from the standalone parallel iterators commit

### DIFF
--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -56,6 +56,7 @@ checkResolved() {
     checkReturnPaths(fn);
     if (fn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
         !fn->hasFlag(FLAG_ITERATOR_FN) &&
+        fn->retType->defaultInitializer &&
         fn->retType->defaultInitializer->defPoint->parentSymbol == fn)
       USR_FATAL_CONT(fn, "functions cannot return nested iterators or loop expressions");
     if (fn->hasFlag(FLAG_ASSIGNOP) && fn->retType != dtVoid)

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7315,13 +7315,12 @@ pruneResolvedTree() {
 }
 
 static void clearDefaultInitFns(FnSymbol* unusedFn) {
-  // Before removing an unused function, check if it is the default initializer
-  // for any type.  If it is, set the defaultInitializer field for the type
-  // to NULL so the removed function doesn't leave behind a garbage pointer.
-  forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-    if (ts->type->defaultInitializer == unusedFn) {
-      ts->type->defaultInitializer = NULL;
-    }
+  // Before removing an unused function, check if it is a defaultInitializer.
+  // If unusedFn is a defaultInitializer, its retType's defaultInitializer
+  // field will be unusedFn. Set the defaultInitializer field to NULL so the
+  // removed function doesn't leave behind a garbage pointer.
+  if (unusedFn->retType->defaultInitializer == unusedFn) {
+    unusedFn->retType->defaultInitializer = NULL;
   }
 }
 


### PR DESCRIPTION
In some cases, the defaultInitializer function for a type gets removed as
unused at the end of function resolution, but the type's defaultInitializer
field is left pointing at the removed function.  Later, checkResolved looks
at the defaultInitializer for some return types involving iterators.  Before
removing the function, check if it is the defaultInitializer for any type and
set the defaultInitializer field for that type to NULL if it is.

Tested on the regressed tests with valgrind, and the whole suite with
linux64+fifo and linux64+qthreads.