### PR TITLE
Attempt to silence coverity error 1267302

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -176,7 +176,9 @@ ModuleSymbol* ParseFile(const char* filename, ModTag modType,
 
   closeInputFile(yyin);
 
-  if (yyblock->body.head == 0 || containsOnlyModules(yyblock, filename) == false) {
+  if (yyblock == NULL) {
+    INT_FATAL("yyblock should always be non-NULL after yyparse()");
+  } else if (yyblock->body.head == 0 || containsOnlyModules(yyblock, filename) == false) {
     const char* modulename = filenameToModulename(filename);
 
     newModule      = buildModule(modulename, yyblock, yyfilename, NULL);


### PR DESCRIPTION
Coverity error 1267302 is complaining about yyblock being potentially
NULL after yyparse() is called, though we don't see any reason that
this could occur.  This has been a long-term issue before my recent
changes to parser.cpp, but showed up as a new issue due to the code
around yyparse() changing to reflect the retirement of MOD_MAIN.

In the interest of being a good Coverity citizen, I'm taking a swing
at silencing it by essentially adding a case that checks for yyblock
being NULL and calling an INT_FATAL if it is.  Then in the else clause
we do the normal thing.  If this doesn't work, I propose we squash
this issue within coverity.

One strangeness that confused both Lydia and myself is why Coverity
seems to think that the conditionals about starting/stopping the
counting of file tokens could prevent yyparse() from assigning
yyblock (i.e., it seems like it should be independent of whether
those conditionals are taken or not).  Boh.