### PR TITLE
Add suppression capability for whitebox testing

### DIFF
--- a/test/Suppressions/xe-wb.prgenv-cray.suppress
+++ b/test/Suppressions/xe-wb.prgenv-cray.suppress
@@ -1,0 +1,2 @@
+# This test fails under xe-wb.prgenv-cray due to BUG 822194.
+modules/sungeun/test_safeSub

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -122,6 +122,12 @@ export CHPL_COMM=none
 export CHPL_NIGHTLY_LOGDIR=/data/sea/chapel/Nightly
 export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 
+# Request config-specific suppressions, if applicable.
+suppfile=Suppressions/$CHPL_NIGHTLY_TEST_CONFIG_NAME.suppress
+if [ -r "$CHPL_HOME/test/$suppfile" ] ; then
+  nightly_args="-suppress $suppfile"
+fi
+
 # Ensure that one of the CPU modules is loaded.
 my_arch=$($CHPL_HOME/util/chplenv/chpl_arch.py 2> /dev/null)
 if [ "${my_arch}" = "none" ] ; then

--- a/util/cron/test-xe-wb.bash
+++ b/util/cron/test-xe-wb.bash
@@ -8,7 +8,7 @@ source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 
 # Run the tests!
-nightly_args="-cron"
+nightly_args="${nightly_args:-} -cron"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."


### PR DESCRIPTION
and a specific instance for test/modules/sungeun/test_safeSub under xe-wb.prgenv-cray

Currently test_safeSub fails due to BUG 822194, only under xe-wb.prgenv-cray.
So I am adding a suppression for this test.

To do so, I expand common-whitebox.bash and test-xe-wb.bash to pass -suppress to 'nightly' whenever a configuration-specific suppression file exists.
