### PR TITLE
Lower stack size for parallel/begin/dinan/mvm_coforall

### DIFF
--- a/test/parallel/begin/dinan/mvm_coforall.execenv
+++ b/test/parallel/begin/dinan/mvm_coforall.execenv
@@ -1,1 +1,3 @@
 CHPL_RT_NUM_THREADS_PER_LOCALE=200
+# Lower stack size for systems that have limited memory.
+CHPL_RT_CALL_STACK_SIZE=1M


### PR DESCRIPTION
parallel/begin/dinan/mvm_coforall has been sporadically segfaulting or timing
out for linux32. The test has a big-ish coforall which means a big-ish number
of tasks each with an 8MB stack. Depending on timing it seems the test either
runs out of memory, or uses a lot of swap which drastically increases execution
time.

Lowering the stack size seems to have resolved the regression: tested with 1000
trials.