### PR TITLE
Fix dygraph zooming

### DIFF
--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -471,7 +471,7 @@ function customDrawCallback(g, initial) {
   // if this isn't the initial draw, and this graph is fully rendered then
   // sync this graphs x-axis with all other ready graphs along the x-axis
   if (!initial && g.isReady) {
-    var range = g.xAxisRange();
+    var range = g.xAxisRange().slice();
     range[0] = roundDate(range[0], false);
     range[1] = roundDate(range[1], true);
 


### PR DESCRIPTION
When we zoom, we round the start and end dates so that they always lie exactly
on a date boundary. This makes the graphs cleaner since we only have 1 data
point per day, and it allows us to store the date in the url in a human
readable format.

This rounding was broken for the graph that was actually zoomed on. When you
zoom on a graph, we then apply the same zoom level on other graphs. However the
graph that was originally zoomed in on wasn't having it's start and end date
rounded correctly.