### PR TITLE
Param protect all calls to chpl__testPar

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -654,7 +654,9 @@ iter BlockDom.these(param tag: iterKind, followThis) where tag == iterKind.follo
       return if i == rangeTuple.size then rangeTuple(i).stridable
              else rangeTuple(i).stridable || anyStridable(rangeTuple, i+1);
 
-  chpl__testPar("Block domain follower invoked on ", followThis);
+  if chpl__testParFlag then
+    chpl__testPar("Block domain follower invoked on ", followThis);
+
   var t: rank*range(idxType, stridable=stridable||anyStridable(followThis));
   type strType = chpl__signedType(idxType);
   for param i in 1..rank {
@@ -927,10 +929,12 @@ iter BlockArr.these(param tag: iterKind, followThis, param fast: bool = false) r
       return if i == rangeTuple.size then rangeTuple(i).stridable
              else rangeTuple(i).stridable || anyStridable(rangeTuple, i+1);
 
-  if fast then
-    chpl__testPar("Block array fast follower invoked on ", followThis);
-  else
-    chpl__testPar("Block array non-fast follower invoked on ", followThis);
+  if chpl__testParFlag {
+    if fast then
+      chpl__testPar("Block array fast follower invoked on ", followThis);
+    else
+      chpl__testPar("Block array non-fast follower invoked on ", followThis);
+  }
 
   if testFastFollowerOptimization then
     writeln((if fast then "fast" else "regular") + " follower invoked for Block array");

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -658,9 +658,7 @@ module ChapelIO {
     chpl__testParOn = false;
   }
   
-  inline proc chpl__testPar(args...) where chpl__testParFlag == false { }
-  
-  proc chpl__testPar(args...) where chpl__testParFlag == true {
+  proc chpl__testPar(args...)  {
     if chpl__testParFlag && chpl__testParOn {
       const file : c_string = __primitive("_get_user_file");
       const line = __primitive("_get_user_line");

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -658,7 +658,7 @@ module ChapelIO {
     chpl__testParOn = false;
   }
   
-  proc chpl__testPar(args...)  {
+  proc chpl__testPar(args...) {
     if chpl__testParFlag && chpl__testParOn {
       const file : c_string = __primitive("_get_user_file");
       const line = __primitive("_get_user_line");

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -303,8 +303,10 @@ module DefaultRectangular {
       proc anyStridable(rangeTuple, param i: int = 1) param
         return if i == rangeTuple.size then rangeTuple(i).stridable
                else rangeTuple(i).stridable || anyStridable(rangeTuple, i+1);
-  
-      chpl__testPar("default rectangular domain follower invoked on ":string_rec, followThis);
+
+      if chpl__testParFlag then
+        chpl__testPar("default rectangular domain follower invoked on ":string_rec, followThis);
+
       if debugDefaultDist then
         writeln("In domain follower code: Following ", followThis);
       param stridable = this.stridable || anyStridable(followThis);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -305,7 +305,7 @@ module DefaultRectangular {
                else rangeTuple(i).stridable || anyStridable(rangeTuple, i+1);
 
       if chpl__testParFlag then
-        chpl__testPar("default rectangular domain follower invoked on ":string_rec, followThis);
+        chpl__testPar("default rectangular domain follower invoked on ", followThis);
 
       if debugDefaultDist then
         writeln("In domain follower code: Following ", followThis);


### PR DESCRIPTION
Previously chpl__testPar had two definitions. One function did nothing when
chpl__testParFlag was false, the other actually printed some debug information.
Despite the fact that chpl__testPar was empty when chpl__testParFlag==False, it
still added some overhead because the call sites creates strings to pass in.

There was a surprising performance regression for --no-local versions of
miniMD from the innocuous looking df8c3172cc9c. This fixes that regression and
will improve the generated code a little for any foralls over Array's or
BlockDists. I doubt it will have a performance impact beyond resolving this
regression.