### PR TITLE
Add annotation for miniMD --no-local regression

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -190,6 +190,8 @@ meteor:
 miniMD:
   12/21/13:
     - clean up of noRefCount related code in modules/internal (22473)
+  11/04/14:
+    - surprising regression from cast in DefaultRectangular (df8c3172cc9c)
 
 nbody:
   03/17/14:


### PR DESCRIPTION
Rather surprisingly df8c3172cc9c resulted in a performance regression for
--no-local versions of miniMD on 11/04/2014.

I have an upcoming patch that resolves this regression by param protecting
calls to chpl__testPar