### PR TITLE
Triage Update for the last couple of days (partial)

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -52,6 +52,10 @@ general
 Reviewed 2015-01-23
 ===================
 
+unexpected block structure in WhileStmt.cpp (hilde, noakes)
+-----------------------------------------------------------
+[Error matching .bad file for functions/deitz/test_return1] (2015-01-30..)
+
 
 ===================
 linux64
@@ -119,17 +123,13 @@ timeout (2014-11-12, first run)
 -------------------------------
 [Error: Timed out executing program domains/sungeun/assoc/parSafeMember (compopts: 1)]
 
-timeout (2015-01-29, elliot, should be fixed with #1196)
-------------------------------
-[Error: Timed out executing program parallel/begin/dinan/mvm_coforall]
-
 
 === sporadic failures below ===
 
 sporadic signal 11
 ------------------
 [Error matching program output for stress/deitz/test_10k_begins] (2014-11-13..2014-12-09, 2014-12-15, 2014-12-19, 2015-01-04)
-[Error matching program output for parallel/begin/dinan/mvm_coforall] (2014-11-21, 2014-11-27, 2014-12-15, 2015-01-22, 2015-01-27..2015-01-28)
+[Error matching program output for parallel/begin/dinan/mvm_coforall] (2014-11-21, 2014-11-27, 2014-12-15, 2015-01-22, 2015-01-27..2015-01-28) - believed fixed
 
 
 ===================
@@ -246,22 +246,6 @@ System I/O error.  Thomas has escalated to sys-ops
 --------------------------------------------------
 [Error running sub_test in /ptmp/jenkins/chapel-ci/workspace/correctness-test-valgrind/test/release/examples/spec/Variables (1)]
 
-invalid read in compiler (2014-12-16 -- diten, presumed due to standalone par)
-------------------------------------------------------------------------------
-[Error matching program output for functions/iterators/sungeun/iterInClass]
-
-invalid read in compiler (2014-12-13 -- diten, presumed due to standalone par)
-------------------------------------------------------------------------------
-[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader1]
-[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader2]
-[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader3]
-[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader4]
-[Error matching program output for functions/deitz/iterators/leader_follower/test_recursive_leader]
-[Error matching program output for multilocale/vass/recursive-iterator-twice-multiloc]
-[Error matching program output for studies/colostate/Jacobi-1D-Diamond-Tiling]
-[Error matching program output for studies/colostate/Jacobi-1D-Sliced-Diamond-Tiling]
-[Error matching program output for studies/glob/test_glob (compopts: 1)]
-
 conditional jump depends on uninitialized value (2014-04-08 -- since re2 on)
 ----------------------------------------------------------------------------
 [Error matching program output for io/tzakian/recordReader/test]
@@ -310,7 +294,7 @@ Reviewed 2015-01-23
 ===================
 numa
 Inherits 'general'
-Reviewed 2015-01-29
+Reviewed 2015-01-30
 ===================
 
 
@@ -1401,7 +1385,7 @@ Consistent execution timouts
 
 sporadic generated output "FAILED" (see above for solid): First run 2014-12-07
 ------------------------------------------------------------------------------
-[Error matching program output for studies/colostate/OMP-Jacobi-1D-Sliced-Diamond-Tiling (compopts: 1)] (2015-01-16..2015-01-19, 2015-01-21, 2015-01-25)
+[Error matching program output for studies/colostate/OMP-Jacobi-1D-Sliced-Diamond-Tiling (compopts: 1)] (2015-01-16..2015-01-19, 2015-01-21, 2015-01-25..2015-01-28)
 
 sporadic os.unlink calls in sub_test failing due to resource being busy
 =======================================================================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -119,13 +119,17 @@ timeout (2014-11-12, first run)
 -------------------------------
 [Error: Timed out executing program domains/sungeun/assoc/parSafeMember (compopts: 1)]
 
+timeout (2015-01-29, elliot, should be fixed with #1196)
+------------------------------
+[Error: Timed out executing program parallel/begin/dinan/mvm_coforall]
+
 
 === sporadic failures below ===
 
 sporadic signal 11
 ------------------
 [Error matching program output for stress/deitz/test_10k_begins] (2014-11-13..2014-12-09, 2014-12-15, 2014-12-19, 2015-01-04)
-[Error matching program output for parallel/begin/dinan/mvm_coforall] (2014-11-21, 2014-11-27, 2014-12-15, 2015-01-22, 2014-01-27)
+[Error matching program output for parallel/begin/dinan/mvm_coforall] (2014-11-21, 2014-11-27, 2014-12-15, 2015-01-22, 2015-01-27..2015-01-28)
 
 
 ===================
@@ -306,12 +310,8 @@ Reviewed 2015-01-23
 ===================
 numa
 Inherits 'general'
-Reviewed 2015-01-23
+Reviewed 2015-01-29
 ===================
-
-expected memory leak no longer occurs (first seen 2015-01-24, vass)
--------------------------------------------------------------------
-[Error matching program output for types/string/StringImpl/memLeaks/promotion]
 
 
 ===================
@@ -426,6 +426,10 @@ Reviewed 2015-01-23
 
 === sporadic failures below ===
 
+PGC-W-0205-Argument mismatch for assert - all but a few failed
+--------------------------------------------------------------
+(xe-wb.prgenv-pgi 2015-01-29)
+
 something going wrong with reservedSymbolNames causes reserved names to show up in generated code.
 --------------------------------------------------------------------------------------------------
 All tests fail when this happens (xc-wb.host.prgenv-pgi 2015-01-08, xc-wb.prgenv-pgi 2015-01-16, xc-wb.prgenv-pgi 2015-01-21, xc-wb.prgenv-gnu 2015-01-22)
@@ -497,7 +501,7 @@ gbt is working on getting rid of this
 
 signal 11 (first seen 2014-03-02)
 ---------------------------------
-[Error matching compiler output for release/examples/benchmarks/shootout/meteor-fast]
+[Error matching program output for release/examples/benchmarks/shootout/meteor-fast]
 [Error matching program output for studies/shootout/meteor/kbrady/meteor-parallel-alt]
 
 error differs but within acceptable margin; should squash error printing
@@ -568,7 +572,12 @@ Reviewed 2015-01-23
 
 all tests fail compilation with "$CHPL_HOME/modules/internal/ChapelDistribution.chpl:65: error: unresolved call '(bool)'"
 -------------------------------------------------------------------------------------------------------------------------
-(2015-01-19.. )
+(2015-01-19..2015-01-26)
+
+or "$CHPL_HOME/modules/internal/ChapelArray.chpl:2117: In function '='
+$CHPL_HOME/modules/internal/ChapelArray.chpl:2119: error: unresolved call '(list(BaseArr))'"
+--------------------------------------------------------------------------------------------
+(2015-01-27..2015-01-28)
 
 
 ===================
@@ -684,6 +693,374 @@ xc-wb.host.prgenv-pgi
 Inherits 'x?-wb.prgenv-pgi'
 Reviewed 2015-01-23
 ===========================
+
+
+===============================
+cray-module-correctness-cray-x?
+Inherits 'cray-module*'
+Reviewed 2015-01-29
+===============================
+
+
+==========================================
+cray-module-correctness-cray-x?-none*
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+==========================================
+
+
+=============================================
+cray-module-correctness-cray-x?-gasnet-aries*
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+=============================================
+
+
+===========================================
+cray-module-correctness-cray-x?-gasnet-mpi*
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+===========================================
+
+
+==========================================
+cray-module-correctness-cray-x?-ugni*
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+==========================================
+
+
+==========================================
+cray-module-correctness-cray-x?-*-cray
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+==========================================
+
+
+==========================================
+cray-module-correctness-cray-x?-*-pgi
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+==========================================
+
+
+==========================================
+cray-module-correctness-cray-x?-*-intel
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+==========================================
+
+
+==========================================
+cray-module-correctness-cray-x?-*-gnu
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+==========================================
+
+
+================================================
+cray-module-correctness-cray-xc-none*
+Inherits 'cray-module-correctness-cray-x?-none*'
+Reviewed 2015-01-29
+================================================
+
+
+========================================================
+cray-module-correctness-cray-xc-gasnet-aries*
+Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
+Reviewed 2015-01-29
+========================================================
+
+
+======================================================
+cray-module-correctness-cray-xc-gasnet-mpi*
+Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+Reviewed 2015-01-29
+======================================================
+
+
+===============================================
+cray-module-correctness-cray-xc-ugni*
+Inherits 'cray-module-correctness-cray-x?-ugni*'
+Reviewed 2015-01-29
+===============================================
+
+floating point issues
+----------------------------
+FAILED:  release/examples/benchmarks/lulesh.lulesh
+FAILED:  release/examples/benchmarks/miniMD.miniMD
+FAILED:  release/examples/benchmarks/miniMD/explicit.miniMD
+
+
+=================================================
+cray-module-correctness-cray-xc-*-cray
+Inherits 'cray-module-correctness-cray-x?-*-cray'
+Reviewed 2015-01-29
+=================================================
+
+
+================================================
+cray-module-correctness-cray-xc-*-pgi
+Inherits 'cray-module-correctness-cray-x?-*-pgi'
+Reviewed 2015-01-29
+================================================
+
+
+==================================================
+cray-module-correctness-cray-xc-*-intel
+Inherits 'cray-module-correctness-cray-x?-*-intel'
+Reviewed 2015-01-29
+==================================================
+
+
+==========================================
+cray-module-correctness-cray-xc-*-gnu
+Inherits 'cray-module-correctness-cray-x?-*-gnu'
+Reviewed 2015-01-29
+==========================================
+
+
+================================================
+cray-module-correctness-cray-xc-none-cray
+Inherits 'cray-module-correctness-cray-x?-none*'
+and 'cray-module-correctness-cray-x?-*-cray'
+Reviewed 2015-01-29
+================================================
+
+
+================================================
+cray-module-correctness-cray-xc-none-pgi
+Inherits 'cray-module-correctness-cray-x?-none*'
+and 'cray-module-correctness-cray-x?-*-pgi'
+Reviewed 2015-01-29
+================================================
+
+
+================================================
+cray-module-correctness-cray-xc-none-intel
+Inherits 'cray-module-correctness-cray-x?-none*'
+and 'cray-module-correctness-cray-x?-*-intel'
+Reviewed 2015-01-29
+================================================
+
+
+================================================
+cray-module-correctness-cray-xc-none-gnu
+Inherits 'cray-module-correctness-cray-x?-none*'
+and 'cray-module-correctness-cray-x?-*-gnu'
+Reviewed 2015-01-29
+================================================
+
+
+========================================================
+cray-module-correctness-cray-xc-gasnet-aries-cray
+Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
+and ''cray-module-correctness-cray-x?-*-cray'
+Reviewed 2015-01-29
+========================================================
+
+
+========================================================
+cray-module-correctness-cray-xc-gasnet-aries-pgi
+Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
+and ''cray-module-correctness-cray-x?-*-pgi'
+Reviewed 2015-01-29
+========================================================
+
+
+========================================================
+cray-module-correctness-cray-xc-gasnet-aries-intel
+Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
+and ''cray-module-correctness-cray-x?-*-intel'
+Reviewed 2015-01-29
+========================================================
+
+
+========================================================
+cray-module-correctness-cray-xc-gasnet-aries-gnu
+Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
+and ''cray-module-correctness-cray-x?-*-gnu'
+Reviewed 2015-01-29
+========================================================
+
+
+======================================================
+cray-module-correctness-cray-xc-gasnet-mpi-cray
+Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+and 'cray-module-correctness-cray-xc-*-cray'
+Reviewed 2015-01-29
+======================================================
+
+
+======================================================
+cray-module-correctness-cray-xc-gasnet-mpi-pgi
+Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+and 'cray-module-correctness-cray-xc-*-pgi'
+Reviewed 2015-01-29
+======================================================
+
+
+======================================================
+cray-module-correctness-cray-xc-gasnet-mpi-intel
+Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+and 'cray-module-correctness-cray-xc-*-intel'
+Reviewed 2015-01-29
+======================================================
+
+
+======================================================
+cray-module-correctness-cray-xc-gasnet-mpi-gnu
+Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+and 'cray-module-correctness-cray-xc-*-gnu'
+Reviewed 2015-01-29
+======================================================
+
+
+===============================================
+cray-module-correctness-cray-xc-ugni-cray
+Inherits 'cray-module-correctness-cray-x?-ugni*'
+and 'cray-module-correctness-cray-xc-*-cray'
+Reviewed 2015-01-29
+===============================================
+
+
+===============================================
+cray-module-correctness-cray-xc-ugni-pgi
+Inherits 'cray-module-correctness-cray-x?-ugni*'
+and 'cray-module-correctness-cray-xc-*-pgi'
+Reviewed 2015-01-29
+===============================================
+
+
+================================================
+cray-module-correctness-cray-xc-ugni-intel
+Inherits 'cray-module-correctness-cray-x?-ugni*'
+and 'cray-module-correctness-cray-xc-*-intel'
+Reviewed 2015-01-29
+================================================
+
+
+================================================
+cray-module-correctness-cray-xc-ugni-gnu
+Inherits 'cray-module-correctness-cray-x?-ugni*'
+and 'cray-module-correctness-cray-xc-*-gnu'
+Reviewed 2015-01-29
+================================================
+
+
+==========================================
+cray-module-correctness-cray-xc-knc
+Inherits 'cray-module-correctness-cray-xc*'
+Reviewed 2015-01-29
+==========================================
+
+
+==========================================
+cray-module-correctness-cray-xc-llvm
+Inherits 'cray-module-correctness-cray-xc*'
+Reviewed 2015-01-29
+==========================================
+
+
+==========================================
+cray-module-correctness-cray-xc-slurm
+Inherits 'cray-module-correctness-cray-xc*'
+Reviewed 2015-01-29
+==========================================
+
+
+
+=== sporadic failures below ===
+
+floating point issues (ugni, intel)
+-----------------------------------
+FAILED:  release/examples/benchmarks/lulesh.test3DLulesh (compopts: 1, execopts: 3) (2015-01-29)
+
+
+
+================================================
+cray-module-correctness-cray-xe-none*
+Inherits 'cray-module-correctness-cray-x?-none*'
+Reviewed 2015-01-29
+================================================
+
+
+========================================================
+cray-module-correctness-cray-xe-gasnet-aries*
+Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
+Reviewed 2015-01-29
+========================================================
+
+
+======================================================
+cray-module-correctness-cray-xe-gasnet-mpi*
+Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+Reviewed 2015-01-29
+======================================================
+
+
+================================================
+cray-module-correctness-cray-xe-ugni*
+Inherits 'cray-module-correctness-cray-x?-ugni*'
+Reviewed 2015-01-29
+================================================
+
+
+==========================================
+cray-module-correctness-cray-xe
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+==========================================
+
+Out of memory - (ugni, gnu)
+---------------------------
+release/examples/benchmarks/ssca2/SSCA2_main (compopts: 1, execopts: 1)
+release/examples/benchmarks/ssca2/SSCA2_main (compopts: 3, execopts: 1)
+
+
+=== sporadic failures below ===
+
+Compilation timeout (gasnet-gemini, intel)
+------------------------------------------
+FAILED:  release/examples/benchmarks/miniMD.miniMD
+
+
+================================
+cray-module-performance-cray-xc*
+Inherits 'general'
+Reviewed 2015-01-29
+================================
+
+
+============================================
+cray-module-performance-cray-xc-gasnet-aries
+Inherits 'cray-module-performance-cray-xc*'
+Reviewed 2015-01-29
+============================================
+
+Execution timeout
+-----------------
+FAILED:  release/examples/benchmarks/ssca2.SSCA2_main
+FAILED:  release/examples/benchmarks/hpcc.ra-atomics
+
+
+===========================================
+cray-module-performance-cray-xc-gasnet-mpi
+Inherits 'cray-module-performance-cray-xc*'
+Reviewed 2015-01-29
+===========================================
+
+Execution timeout
+-----------------
+FAILED:  release/examples/benchmarks/ssca2.SSCA2_main (compopts: 1, execopts: 2)
+FAILED:  release/examples/benchmarks/miniMD.miniMD (compopts: 1)
+
+
+===========================================
+cray-module-performance-cray-xc-ugni
+Inherits 'cray-module-performance-cray-xc*'
+Reviewed 2015-01-29
+===========================================
 
 
 ===================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -697,9 +697,20 @@ Reviewed 2015-01-23
 
 ===============================
 cray-module-correctness-cray-x?
-Inherits 'cray-module*'
+Inherits 'general'
 Reviewed 2015-01-29
 ===============================
+
+nonblocking comm interface update needed - Greg
+-----------------------------------------------
+build failed in commDiagnostics (2015-01-30..)
+
+
+=== sporadic failures below ===
+
+Occasional "unexpected termination of the channel"
+--------------------------------------------------
+any
 
 
 ==========================================
@@ -709,18 +720,18 @@ Reviewed 2015-01-29
 ==========================================
 
 
-=============================================
-cray-module-correctness-cray-x?-gasnet-aries*
+===========================================
+cray-module-correctness-cray-x?-gasnet*
 Inherits 'cray-module-correctness-cray-x?'
 Reviewed 2015-01-29
-=============================================
-
-
 ===========================================
+
+
+==================================================
 cray-module-correctness-cray-x?-gasnet-mpi*
-Inherits 'cray-module-correctness-cray-x?'
+Inherits 'cray-module-correctness-cray-x?-gasnet*'
 Reviewed 2015-01-29
-===========================================
+==================================================
 
 
 ==========================================
@@ -728,6 +739,12 @@ cray-module-correctness-cray-x?-ugni*
 Inherits 'cray-module-correctness-cray-x?'
 Reviewed 2015-01-29
 ==========================================
+
+floating point issues (except xc-slurm-ugni-gnu)
+------------------------------------------------
+FAILED:  release/examples/benchmarks/lulesh.lulesh
+FAILED:  release/examples/benchmarks/miniMD.miniMD
+FAILED:  release/examples/benchmarks/miniMD/explicit.miniMD
 
 
 ==========================================
@@ -758,23 +775,40 @@ Reviewed 2015-01-29
 ==========================================
 
 
+==========================================
+cray-module-correctness-cray-xc*
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+==========================================
+
+
 ================================================
 cray-module-correctness-cray-xc-none*
 Inherits 'cray-module-correctness-cray-x?-none*'
+and 'cray-module-correctness-cray-xc*'
 Reviewed 2015-01-29
 ================================================
 
 
-========================================================
-cray-module-correctness-cray-xc-gasnet-aries*
-Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
+=============================================
+cray-module-correctness-cray-xc-gasnet*
+Inherits 'cray-module-correctness-cray-xc*'
+and 'cray-module-correctness-cray-x?-gasnet*'
 Reviewed 2015-01-29
-========================================================
+=============================================
+
+
+==================================================
+cray-module-correctness-cray-xc-gasnet-aries*
+Inherits 'cray-module-correctness-cray-xc-gasnet*'
+Reviewed 2015-01-29
+==================================================
 
 
 ======================================================
 cray-module-correctness-cray-xc-gasnet-mpi*
 Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+and 'cray-module-correctness-cray-xc-gasnet*'
 Reviewed 2015-01-29
 ======================================================
 
@@ -782,19 +816,15 @@ Reviewed 2015-01-29
 ===============================================
 cray-module-correctness-cray-xc-ugni*
 Inherits 'cray-module-correctness-cray-x?-ugni*'
+and 'cray-module-correctness-cray-xc*'
 Reviewed 2015-01-29
 ===============================================
-
-floating point issues
-----------------------------
-FAILED:  release/examples/benchmarks/lulesh.lulesh
-FAILED:  release/examples/benchmarks/miniMD.miniMD
-FAILED:  release/examples/benchmarks/miniMD/explicit.miniMD
 
 
 =================================================
 cray-module-correctness-cray-xc-*-cray
 Inherits 'cray-module-correctness-cray-x?-*-cray'
+and 'cray-module-correctness-cray-xc*'
 Reviewed 2015-01-29
 =================================================
 
@@ -802,6 +832,7 @@ Reviewed 2015-01-29
 ================================================
 cray-module-correctness-cray-xc-*-pgi
 Inherits 'cray-module-correctness-cray-x?-*-pgi'
+and 'cray-module-correctness-cray-xc*'
 Reviewed 2015-01-29
 ================================================
 
@@ -809,6 +840,7 @@ Reviewed 2015-01-29
 ==================================================
 cray-module-correctness-cray-xc-*-intel
 Inherits 'cray-module-correctness-cray-x?-*-intel'
+and 'cray-module-correctness-cray-xc*'
 Reviewed 2015-01-29
 ==================================================
 
@@ -816,77 +848,78 @@ Reviewed 2015-01-29
 ==========================================
 cray-module-correctness-cray-xc-*-gnu
 Inherits 'cray-module-correctness-cray-x?-*-gnu'
+and 'cray-module-correctness-cray-xc*'
 Reviewed 2015-01-29
 ==========================================
 
 
 ================================================
 cray-module-correctness-cray-xc-none-cray
-Inherits 'cray-module-correctness-cray-x?-none*'
-and 'cray-module-correctness-cray-x?-*-cray'
+Inherits 'cray-module-correctness-cray-xc-none*'
+and 'cray-module-correctness-cray-xc-*-cray'
 Reviewed 2015-01-29
 ================================================
 
 
 ================================================
 cray-module-correctness-cray-xc-none-pgi
-Inherits 'cray-module-correctness-cray-x?-none*'
-and 'cray-module-correctness-cray-x?-*-pgi'
+Inherits 'cray-module-correctness-cray-xc-none*'
+and 'cray-module-correctness-cray-xc-*-pgi'
 Reviewed 2015-01-29
 ================================================
 
 
 ================================================
 cray-module-correctness-cray-xc-none-intel
-Inherits 'cray-module-correctness-cray-x?-none*'
-and 'cray-module-correctness-cray-x?-*-intel'
+Inherits 'cray-module-correctness-cray-xc-none*'
+and 'cray-module-correctness-cray-xc-*-intel'
 Reviewed 2015-01-29
 ================================================
 
 
 ================================================
 cray-module-correctness-cray-xc-none-gnu
-Inherits 'cray-module-correctness-cray-x?-none*'
-and 'cray-module-correctness-cray-x?-*-gnu'
+Inherits 'cray-module-correctness-cray-xc-none*'
+and 'cray-module-correctness-cray-xc-*-gnu'
 Reviewed 2015-01-29
 ================================================
 
 
 ========================================================
 cray-module-correctness-cray-xc-gasnet-aries-cray
-Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
-and ''cray-module-correctness-cray-x?-*-cray'
+Inherits 'cray-module-correctness-cray-xc-gasnet-aries*'
+and ''cray-module-correctness-cray-xc-*-cray'
 Reviewed 2015-01-29
 ========================================================
 
 
 ========================================================
 cray-module-correctness-cray-xc-gasnet-aries-pgi
-Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
-and ''cray-module-correctness-cray-x?-*-pgi'
+Inherits 'cray-module-correctness-cray-xc-gasnet-aries*'
+and ''cray-module-correctness-cray-xc-*-pgi'
 Reviewed 2015-01-29
 ========================================================
 
 
 ========================================================
 cray-module-correctness-cray-xc-gasnet-aries-intel
-Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
-and ''cray-module-correctness-cray-x?-*-intel'
+Inherits 'cray-module-correctness-cray-xc-gasnet-aries*'
+and ''cray-module-correctness-cray-xc-*-intel'
 Reviewed 2015-01-29
 ========================================================
 
 
 ========================================================
 cray-module-correctness-cray-xc-gasnet-aries-gnu
-Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
-and ''cray-module-correctness-cray-x?-*-gnu'
+Inherits 'cray-module-correctness-cray-xc-gasnet-aries*'
+and ''cray-module-correctness-cray-xc-*-gnu'
 Reviewed 2015-01-29
 ========================================================
 
 
 ======================================================
 cray-module-correctness-cray-xc-gasnet-mpi-cray
-Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+Inherits 'cray-module-correctness-cray-xc-gasnet-mpi*'
 and 'cray-module-correctness-cray-xc-*-cray'
 Reviewed 2015-01-29
 ======================================================
@@ -894,7 +927,7 @@ Reviewed 2015-01-29
 
 ======================================================
 cray-module-correctness-cray-xc-gasnet-mpi-pgi
-Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+Inherits 'cray-module-correctness-cray-xc-gasnet-mpi*'
 and 'cray-module-correctness-cray-xc-*-pgi'
 Reviewed 2015-01-29
 ======================================================
@@ -902,7 +935,7 @@ Reviewed 2015-01-29
 
 ======================================================
 cray-module-correctness-cray-xc-gasnet-mpi-intel
-Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+Inherits 'cray-module-correctness-cray-xc-gasnet-mpi*'
 and 'cray-module-correctness-cray-xc-*-intel'
 Reviewed 2015-01-29
 ======================================================
@@ -910,31 +943,15 @@ Reviewed 2015-01-29
 
 ======================================================
 cray-module-correctness-cray-xc-gasnet-mpi-gnu
-Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+Inherits 'cray-module-correctness-cray-xc-gasnet-mpi*'
 and 'cray-module-correctness-cray-xc-*-gnu'
 Reviewed 2015-01-29
 ======================================================
 
 
-===============================================
-cray-module-correctness-cray-xc-ugni-cray
-Inherits 'cray-module-correctness-cray-x?-ugni*'
-and 'cray-module-correctness-cray-xc-*-cray'
-Reviewed 2015-01-29
-===============================================
-
-
-===============================================
-cray-module-correctness-cray-xc-ugni-pgi
-Inherits 'cray-module-correctness-cray-x?-ugni*'
-and 'cray-module-correctness-cray-xc-*-pgi'
-Reviewed 2015-01-29
-===============================================
-
-
 ================================================
 cray-module-correctness-cray-xc-ugni-intel
-Inherits 'cray-module-correctness-cray-x?-ugni*'
+Inherits 'cray-module-correctness-cray-xc-ugni*'
 and 'cray-module-correctness-cray-xc-*-intel'
 Reviewed 2015-01-29
 ================================================
@@ -942,7 +959,7 @@ Reviewed 2015-01-29
 
 ================================================
 cray-module-correctness-cray-xc-ugni-gnu
-Inherits 'cray-module-correctness-cray-x?-ugni*'
+Inherits 'cray-module-correctness-cray-xc-ugni*'
 and 'cray-module-correctness-cray-xc-*-gnu'
 Reviewed 2015-01-29
 ================================================
@@ -969,32 +986,161 @@ Reviewed 2015-01-29
 ==========================================
 
 
+====================================================
+cray-module-correctness-cray-xc-slurm-none-cray
+Inherits 'cray-module-correctness-cray-xc-none-cray'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+====================================================
+
+
+===================================================
+cray-module-correctness-cray-xc-slurm-none-pgi
+Inherits 'cray-module-correctness-cray-xc-none-pgi'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+===================================================
+
+
+=====================================================
+cray-module-correctness-cray-xc-slurm-none-intel
+Inherits 'cray-module-correctness-cray-xc-none-intel'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+=====================================================
+
+
+===================================================
+cray-module-correctness-cray-xc-slurm-none-gnu
+Inherits 'cray-module-correctness-cray-xc-none-gnu'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+===================================================
+
+
+============================================================
+cray-module-correctness-cray-xc-slurm-gasnet-aries-cray
+Inherits 'cray-module-correctness-cray-xc-gasnet-aries-cray'
+and ''cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+============================================================
+
+
+===========================================================
+cray-module-correctness-cray-xc-slurm-gasnet-aries-pgi
+Inherits 'cray-module-correctness-cray-xc-gasnet-aries-pgi'
+and ''cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+===========================================================
+
+
+=============================================================
+cray-module-correctness-cray-xc-slurm-gasnet-aries-intel
+Inherits 'cray-module-correctness-cray-xc-gasnet-aries-intel'
+and ''cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+=============================================================
+
+
+===========================================================
+cray-module-correctness-cray-xc-slurm-gasnet-aries-gnu
+Inherits 'cray-module-correctness-cray-xc-gasnet-aries-gnu'
+and ''cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+===========================================================
+
+
+==========================================================
+cray-module-correctness-cray-xc-slurm-gasnet-mpi-cray
+Inherits 'cray-module-correctness-cray-xc-gasnet-mpi-cray'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+==========================================================
+
+
+=========================================================
+cray-module-correctness-cray-xc-slurm-gasnet-mpi-pgi
+Inherits 'cray-module-correctness-cray-xc-gasnet-mpi-pgi'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+=========================================================
+
+
+===========================================================
+cray-module-correctness-cray-xc-slurm-gasnet-mpi-intel
+Inherits 'cray-module-correctness-cray-xc-gasnet-mpi-intel'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+===========================================================
+
+
+=========================================================
+cray-module-correctness-cray-xc-slurm-gasnet-mpi-gnu
+Inherits 'cray-module-correctness-cray-xc-gasnet-mpi-gnu'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+=========================================================
+
+
+=====================================================
+cray-module-correctness-cray-xc-slurm-ugni-intel
+Inherits 'cray-module-correctness-cray-xc-ugni-intel'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+=====================================================
+
+
 
 === sporadic failures below ===
 
-floating point issues (ugni, intel)
------------------------------------
+floating point issues
+---------------------
 FAILED:  release/examples/benchmarks/lulesh.test3DLulesh (compopts: 1, execopts: 3) (2015-01-29)
 
+
+
+===================================================
+cray-module-correctness-cray-xc-slurm-ugni-gnu
+Inherits 'cray-module-correctness-cray-xc-ugni-gnu'
+and 'cray-module-correctness-cray-xc-slurm'
+Reviewed 2015-01-29
+===================================================
+
+
+==========================================
+cray-module-correctness-cray-xe*
+Inherits 'cray-module-correctness-cray-x?'
+Reviewed 2015-01-29
+==========================================
 
 
 ================================================
 cray-module-correctness-cray-xe-none*
 Inherits 'cray-module-correctness-cray-x?-none*'
+and 'cray-module-correctness-cray-xe*'
 Reviewed 2015-01-29
 ================================================
 
 
-========================================================
-cray-module-correctness-cray-xe-gasnet-aries*
-Inherits 'cray-module-correctness-cray-x?-gasnet-aries*'
+=============================================
+cray-module-correctness-cray-xe-gasnet*
+Inherits 'cray-module-correctness-cray-xe*'
+and 'cray-module-correctness-cray-x?-gasnet*'
 Reviewed 2015-01-29
-========================================================
+=============================================
+
+
+==================================================
+cray-module-correctness-cray-xe-gasnet-gemini*
+Inherits 'cray-module-correctness-cray-xe-gasnet*'
+Reviewed 2015-01-29
+==================================================
 
 
 ======================================================
 cray-module-correctness-cray-xe-gasnet-mpi*
 Inherits 'cray-module-correctness-cray-x?-gasnet-mpi*'
+and 'cray-module-correctness-cray-xe-gasnet*'
 Reviewed 2015-01-29
 ======================================================
 
@@ -1002,27 +1148,166 @@ Reviewed 2015-01-29
 ================================================
 cray-module-correctness-cray-xe-ugni*
 Inherits 'cray-module-correctness-cray-x?-ugni*'
+and 'cray-module-correctness-cray-xe*'
 Reviewed 2015-01-29
 ================================================
 
 
+=================================================
+cray-module-correctness-cray-xe-*-cray
+Inherits 'cray-module-correctness-cray-x?-*-cray'
+and 'cray-module-correctness-cray-xe*'
+Reviewed 2015-01-29
+=================================================
+
+
+================================================
+cray-module-correctness-cray-xe-*-pgi
+Inherits 'cray-module-correctness-cray-x?-*-pgi'
+and 'cray-module-correctness-cray-xe*'
+Reviewed 2015-01-29
+================================================
+
+
+==================================================
+cray-module-correctness-cray-xe-*-intel
+Inherits 'cray-module-correctness-cray-x?-*-intel'
+and 'cray-module-correctness-cray-xe*'
+Reviewed 2015-01-29
+==================================================
+
+
 ==========================================
-cray-module-correctness-cray-xe
-Inherits 'cray-module-correctness-cray-x?'
+cray-module-correctness-cray-xe-*-gnu
+Inherits 'cray-module-correctness-cray-x?-*-gnu'
+and 'cray-module-correctness-cray-xe*'
 Reviewed 2015-01-29
 ==========================================
 
-Out of memory - (ugni, gnu)
----------------------------
-release/examples/benchmarks/ssca2/SSCA2_main (compopts: 1, execopts: 1)
-release/examples/benchmarks/ssca2/SSCA2_main (compopts: 3, execopts: 1)
+
+================================================
+cray-module-correctness-cray-xe-none-cray
+Inherits 'cray-module-correctness-cray-xe-none*'
+and 'cray-module-correctness-cray-xe-*-cray'
+Reviewed 2015-01-29
+================================================
+
+
+================================================
+cray-module-correctness-cray-xe-none-pgi
+Inherits 'cray-module-correctness-cray-xe-none*'
+and 'cray-module-correctness-cray-xe-*-pgi'
+Reviewed 2015-01-29
+================================================
+
+
+================================================
+cray-module-correctness-cray-xe-none-intel
+Inherits 'cray-module-correctness-cray-xe-none*'
+and 'cray-module-correctness-cray-xe-*-intel'
+Reviewed 2015-01-29
+================================================
+
+
+================================================
+cray-module-correctness-cray-xe-none-gnu
+Inherits 'cray-module-correctness-cray-xe-none*'
+and 'cray-module-correctness-cray-xe-*-gnu'
+Reviewed 2015-01-29
+================================================
+
+
+========================================================
+cray-module-correctness-cray-xe-gasnet-gemini-cray
+Inherits 'cray-module-correctness-cray-xe-gasnet-gemini*'
+and ''cray-module-correctness-cray-xe-*-cray'
+Reviewed 2015-01-29
+========================================================
+
+
+========================================================
+cray-module-correctness-cray-xe-gasnet-gemini-pgi
+Inherits 'cray-module-correctness-cray-xe-gasnet-gemini*'
+and ''cray-module-correctness-cray-xe-*-pgi'
+Reviewed 2015-01-29
+========================================================
+
+
+========================================================
+cray-module-correctness-cray-xe-gasnet-gemini-intel
+Inherits 'cray-module-correctness-cray-xe-gasnet-gemini*'
+and ''cray-module-correctness-cray-xe-*-intel'
+Reviewed 2015-01-29
+========================================================
 
 
 === sporadic failures below ===
 
-Compilation timeout (gasnet-gemini, intel)
-------------------------------------------
+Compilation timeout
+-------------------
 FAILED:  release/examples/benchmarks/miniMD.miniMD
+
+
+========================================================
+cray-module-correctness-cray-xe-gasnet-gemini-gnu
+Inherits 'cray-module-correctness-cray-xe-gasnet-gemini*'
+and ''cray-module-correctness-cray-xe-*-gnu'
+Reviewed 2015-01-29
+========================================================
+
+
+======================================================
+cray-module-correctness-cray-xe-gasnet-mpi-cray
+Inherits 'cray-module-correctness-cray-xe-gasnet-mpi*'
+and 'cray-module-correctness-cray-xe-*-cray'
+Reviewed 2015-01-29
+======================================================
+
+
+======================================================
+cray-module-correctness-cray-xe-gasnet-mpi-pgi
+Inherits 'cray-module-correctness-cray-xe-gasnet-mpi*'
+and 'cray-module-correctness-cray-xe-*-pgi'
+Reviewed 2015-01-29
+======================================================
+
+
+======================================================
+cray-module-correctness-cray-xe-gasnet-mpi-intel
+Inherits 'cray-module-correctness-cray-xe-gasnet-mpi*'
+and 'cray-module-correctness-cray-xe-*-intel'
+Reviewed 2015-01-29
+======================================================
+
+
+======================================================
+cray-module-correctness-cray-xe-gasnet-mpi-gnu
+Inherits 'cray-module-correctness-cray-xe-gasnet-mpi*'
+and 'cray-module-correctness-cray-xe-*-gnu'
+Reviewed 2015-01-29
+======================================================
+
+
+================================================
+cray-module-correctness-cray-xe-ugni-intel
+Inherits 'cray-module-correctness-cray-xe-ugni*'
+and 'cray-module-correctness-cray-xe-*-intel'
+Reviewed 2015-01-29
+================================================
+
+
+================================================
+cray-module-correctness-cray-xe-ugni-gnu
+Inherits 'cray-module-correctness-cray-xe-ugni*'
+and 'cray-module-correctness-cray-xe-*-gnu'
+Reviewed 2015-01-29
+================================================
+
+
+Out of memory
+-------------
+release/examples/benchmarks/ssca2/SSCA2_main (compopts: 1, execopts: 1)
+release/examples/benchmarks/ssca2/SSCA2_main (compopts: 3, execopts: 1)
 
 
 ================================
@@ -1033,26 +1318,35 @@ Reviewed 2015-01-29
 
 
 ============================================
-cray-module-performance-cray-xc-gasnet-aries
+cray-module-performance-cray-xc-gasnet*
 Inherits 'cray-module-performance-cray-xc*'
 Reviewed 2015-01-29
 ============================================
 
 Execution timeout
 -----------------
-FAILED:  release/examples/benchmarks/ssca2.SSCA2_main
+FAILED:  release/examples/benchmarks/ssca2.SSCA2_main (compopts: 1, execopts: 2)
+
+
+==================================================
+cray-module-performance-cray-xc-gasnet-aries
+Inherits 'cray-module-performance-cray-xc-gasnet*'
+Reviewed 2015-01-29
+==================================================
+
+Execution timeout
+-----------------
 FAILED:  release/examples/benchmarks/hpcc.ra-atomics
 
 
 ===========================================
 cray-module-performance-cray-xc-gasnet-mpi
-Inherits 'cray-module-performance-cray-xc*'
+Inherits 'cray-module-performance-cray-xc-gasnet*'
 Reviewed 2015-01-29
 ===========================================
 
 Execution timeout
 -----------------
-FAILED:  release/examples/benchmarks/ssca2.SSCA2_main (compopts: 1, execopts: 2)
 FAILED:  release/examples/benchmarks/miniMD.miniMD (compopts: 1)
 
 


### PR DESCRIPTION
The most significant change is that I added 79(!) new sections to cover the
hw builds that are getting reported to the whole group nightly now and their
intersections.

Other than that, noted:
- mvm_coforall had timed out instead of segfaulting on linux32, but it seems like
Elliot has fixed both those problems. (though I decided to wait to remove the
segfault just yet)
- Vass fixed the memleaks mismatch for StringImpl/memLeaks/promotion on numa
- Recorded an extensive failure for pgi on the whitebox.
- Fixed the entry for meteor-fast on the cray to reflect that it is failing with
program output instead of compiler output (and hasn't failed w/ compiler output
since September).
- added additional failure mode for the prgenv-cray failure.
- Tom broke a future with his dead block elimination commit
- David fixed the invalid read in compiler errors for valgrind that were due to
standalone parallel iterators
- I added an end date for the latest sporadic cygwin32 colostate benchmark failure.

I have not done a clean sweep of the continuing tests yet, but intend to shortly.