### PR TITLE
Extend munging of identifiers to standard modules

### DIFF
--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -542,7 +542,7 @@ static void protectNameFromC(Symbol* sym) {
   // ways that caused headaches for me).
   //
   ModuleSymbol* symMod = sym->getModule();
-  if (symMod->modTag != MOD_USER) {
+  if (symMod->modTag == MOD_INTERNAL) {
     return;
   }
 


### PR DESCRIPTION
As noted in my earlier munge-user-identifiers commit, internal
modules caused issues when trying to munge those symbols, so I
switched to doing user modules only.  Elliot pointed out the
problem with this (noted in my commit message).  This commit
loosens things slightly by munging identifiers in standard
modules (those tagged with MOD_STANDARD) in addition to those
in MOD_USER.

Next step is to work through the issues in the MOD_INTERNAL
cases.