### PR TITLE
Track processes with highest cpu usage for performance runs

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1552,6 +1552,17 @@ for testname in testsrc:
                         sys.stdout.write(']\n')
                         sys.stdout.write('[Execution output was as follows:]\n')
                         sys.stdout.write(output)
+                    else:
+                        # for perf runs print out the 5 processes with the
+                        # highest cpu usage. This should help identify if other
+                        # processes might have interfered with a test.
+                        if perftest:
+                            print('[Reporting processes with top 5 highest cpu usages]')
+                            sys.stdout.flush()
+                            psCom = 'ps ax -o user,pid,pcpu,command '
+                            subprocess.call(psCom + '| head -n 1', shell=True)
+                            subprocess.call(psCom + '| tail -n +2 | sort -r -k 3 | head -n 5', shell=True)
+
 
                 else:
                     if redirectin == None:


### PR DESCRIPTION
After each trial of a performance run, print out 5 processes with the highest
cpu usage. This is to try and track down performance mysteries that may be the
result of other processes interfering.

Current performance mysteries are --no-local versions of lulesh, for vs while
time comparisons and possibly some tests whose performance differs based on how
long it's been since the machine was rebooted.

This isn't perfect since for long running tests it can miss interference, but
it's a start.