### PR TITLE
Fix failing future test_return1.

### DIFF
--- a/compiler/AST/WhileStmt.cpp
+++ b/compiler/AST/WhileStmt.cpp
@@ -143,65 +143,94 @@ bool WhileStmt::deadBlockCleanup()
 *                                                                           *
 ************************************* | ************************************/
 
+// This routine looks for loops in which the condition variable is *not*
+// updated within the body of the loop, and issues a warning for places in the
+// code where that occurs.
 void WhileStmt::checkConstLoops()
 {
   SymExpr* tmpVar  = condExprForTmpVariableGet();
-  bool     foundit = false;
+  // This gets set to 'true' if an update of the loop condition is found.
 
+  // Get the loop condition variable.
   if (VarSymbol* condSym = toVarSymbol(tmpVar->var))
   {
+    // Look for definitions of the loop condition variable within the body of
+    // the loop.
     if (SymExpr* condDef = getWhileCondDef(condSym))
     {
-      // Parse the move expr.
+      // Get the call expression (we assume) that updates the condition variable.
       if (CallExpr* outerCall = toCallExpr(condDef->parentExpr))
       {
+        // We assume the outer call is a move expression and that its LHS is
+        // the (SymExpr that contains the) loop condition variable.
         if (outerCall->get(1) == condDef)
         {
           if (outerCall->isPrimitive(PRIM_MOVE))
           {
+            // We expect the update to be the result of a call to _cond_test.
             if (CallExpr* innerCall = toCallExpr(outerCall->get(2)))
             {
               if (innerCall->numActuals()          == 1 &&
-                  innerCall->isNamed("_cond_test") == true)
+                  strcmp(innerCall->isResolved()->name, "_cond_test") == 0)
               {
-                foundit = true;
                 checkWhileLoopCondition(innerCall->get(1));
               }
+              else
+                INT_FATAL(innerCall, "Expected the update of a loop conditional to be piped through _cond_test().");
             }
-
+            // The RHS of the move can also be a SymExpr as the result of param
+            // folding ...
             else if (SymExpr* moveSrc = toSymExpr(outerCall->get(2)))
             {
-              // Sometimes _cond_test resolves to a param version, so
-              // we get either true or false.
+              // ... in which case, we exprect it to be a literal 'true' or 'false'.
               if (moveSrc->var == gTrue)
               {
-                foundit = true;
+                // while true do ... ;  -- probably OK.
+                // User said to loop forever ... .
               }
 
               else if (moveSrc->var == gFalse)
               {
-                foundit = true;
                 // while false do ...; -- probably nothing to worry about
+                // We probably don't get here unless fRemoveUnreachableBlocks
+                // is false.
               }
 
               else
               {
                 // What else can it be?
+                INT_FATAL(moveSrc, "Expected const loop condition variable to be true or false.");
               }
             }
+            else
+              // The RHS was neither a CallExpr nor a SymExpr.
+              INT_FATAL(outerCall, "Invalid RHS in a loop condition variable update expression.");
           }
+          else
+            INT_FATAL(outerCall, "Expected a loop condition variable update to be a MOVE.");
         }
+        else
+          // Note that this being true depends on the compiler inserting a temp
+          // that is the result of applying _cond_test to a more-general loop
+          // conditional expression.
+          // Copy propagation could potentially make this false again....
+          INT_FATAL(condDef, "Expected loop condition variable to be only updated (not read).");
       }
+      else
+        INT_FATAL(condDef, "The update of a loop condition variable could not be converted to a call.");
+    }
+    else
+    {
+      // There was no update of the loop condition variable in the body of the loop.
+      USR_WARN(condSym, "Infinite loop? The loop condition variable is never updated within the loop.");
     }
   }
-
-  // Let us notify ourselves if the block structure is something else,
-  // so we can adjust the code to handle those cases as well.
-  // If desired, disable this assert - the only outcome of that may be
-  // that the warning will not be issued in some cases.
-  INT_ASSERT(foundit);
+  else
+    INT_FATAL(tmpVar, "The loop condition variable could not be converted to a VarSymbol.");
 }
 
+// Find a defintion of the condition variable in the body of the loop.
+// Returns null if no such expression is found.
 SymExpr* WhileStmt::getWhileCondDef(VarSymbol* condSym)
 {
   std::vector<SymExpr*> symExprs;

--- a/test/functions/deitz/test_return1.bad
+++ b/test/functions/deitz/test_return1.bad
@@ -1,2 +1,3 @@
 test_return1.chpl:1: In function 'foo':
 test_return1.chpl:1: error: control reaches end of function that returns a value
+test_return1.chpl:3: warning: Infinite loop? The loop condition variable is never updated within the loop.


### PR DESCRIPTION
The check function WhileStmt::checkConstLoops() contained a mixture of structural tests and a semantic test.  As the
routine was written, both would result in an assertion error.

The structural tests determine whether the check code itself is correctly interpreting the
structure of the tree.  The semantic test determines whether the code represents a loop in
which the condition variable is never updated.  The first set of tests should result in an
internal error.  The second test is appropriately rendered as a user-level warning.

I separated out the two kinds of tests, and added helpful error messages for the caes
where the structural tests are violated.  It should be noted that future changes to the
structure of the AST may lead to violations of some of these tests, in which case the
appropriate course of action is to revise the test to allow for the revised structure of
the tree.  None of the structural tests is set in stone.

Added comments to checkConstLoops().  Updated test_return1.bad so it expects the new warning.