### PR TITLE
Fixing over-sensitivity to output code format in testmunge.prediff

### DIFF
--- a/test/compflags/bradc/mungeUserIdents/testmunge.good
+++ b/test/compflags/bradc/mungeUserIdents/testmunge.good
@@ -1,2 +1,2 @@
 0.0
-Found match(es)
+SUCCESS: Matched as expected

--- a/test/compflags/bradc/mungeUserIdents/testmunge.prediff
+++ b/test/compflags/bradc/mungeUserIdents/testmunge.prediff
@@ -7,11 +7,9 @@ genCodeDir = 'genCode'
 actualGenCodeFile = os.path.join(genCodeDir, sys.argv[1]+'.c')
 testOutputFile = sys.argv[2]
 
-searchString = "thisNameProbablyWontConflictWithOthers"
+searchString = "thisNameProbablyWontConflictWithOthers_chpl"
 
-if (testOutputFile.find("1") != -1):
-    searchString += "_chpl"
-searchString += " "
+wantmatch = (testOutputFile.find("1") != -1)
 
 count = 0
 
@@ -21,8 +19,14 @@ for line in open(actualGenCodeFile):
 
 with open (testOutputFile, 'a') as f:
     if (count > 0):
-        f.write('Found match(es)\n')
+        if wantmatch:
+            f.write('SUCCESS: Matched as expected\n')
+        else:
+            f.write('ERROR: Incorrectly found matches against "{0}"\n'.format(searchstring))
     else:
-        f.write('Didn\'t find matches against "{0}"'.format(searchString))
+        if wantmatch:
+            f.write('ERROR: Didn\'t find matches against "{0}"\n'.format(searchString))
+        else:
+            f.write('SUCCESS: Matched as expected\n')
 
 shutil.rmtree(genCodeDir)


### PR DESCRIPTION
My previous prediff script for this test was too specific to a given
format of generated code which caused it to break for --no-local and
gasnet testing.  Here, I'm making the test more general.  Previously,
for a given variable 'x' I was checking for 'x ' and 'x_chpl ' in the
generated code depending on whether the --munge-user-idents flag was
set or not.  Now I'm just checking for the presence/absence of
'x_chpl' in the code depending on the state of the flag which should
be much more robust.