### PR TITLE
Fix baseline identifier munging issue

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -302,8 +302,9 @@ static void build_getter(AggregateType* ct, Symbol *field) {
   normalize(fn);
   ct->methods.add(fn);
   fn->addFlag(FLAG_METHOD);
-  fn->cname = astr("_", ct->symbol->cname, "_", fn->cname);
+  fn->cname = astr("chpl_", ct->symbol->cname, "_", fn->cname);
   fn->addFlag(FLAG_NO_PARENS);
+  fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->_this = _this;
 }
 

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -304,7 +304,6 @@ static void build_getter(AggregateType* ct, Symbol *field) {
   fn->addFlag(FLAG_METHOD);
   fn->cname = astr("chpl_", ct->symbol->cname, "_", fn->cname);
   fn->addFlag(FLAG_NO_PARENS);
-  fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->_this = _this;
 }
 

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -302,7 +302,7 @@ static void build_getter(AggregateType* ct, Symbol *field) {
   normalize(fn);
   ct->methods.add(fn);
   fn->addFlag(FLAG_METHOD);
-  fn->cname = astr("chpl_", ct->symbol->cname, "_", fn->cname);
+  fn->cname = astr("chpl_get_", ct->symbol->cname, "_", fn->cname);
   fn->addFlag(FLAG_NO_PARENS);
   fn->_this = _this;
 }

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -532,8 +532,9 @@ static void codegen_header_compilation_config() {
 
 static void protectNameFromC(Symbol* sym) {
   //
-  // Symbols that start with 'chpl_' are presumably compiler-generated
-  // and sufficiently unique not to require further munging.
+  // Symbols that start with 'chpl_' were presumably named by the
+  // implementation (compiler, internal modules, runtime) and
+  // sufficiently unique to not require further munging.
   //
   if (strncmp(sym->cname, "chpl_", 5) == 0) {
     return;

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -532,11 +532,10 @@ static void codegen_header_compilation_config() {
 
 static void protectNameFromC(Symbol* sym) {
   //
-  // If we've done our job right, compiler-generated symbols should
-  // already be munged by starting with 'chpl_' so shouldn't require
-  // additional munging here.
+  // Symbols that start with 'chpl_' are presumably compiler-generated
+  // and sufficiently unique not to require further munging.
   //
-  if (sym->hasFlag(FLAG_COMPILER_GENERATED)) {
+  if (strncmp(sym->cname, "chpl_", 5) == 0) {
     return;
   }
 

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -532,6 +532,15 @@ static void codegen_header_compilation_config() {
 
 static void protectNameFromC(Symbol* sym) {
   //
+  // If we've done our job right, compiler-generated symbols should
+  // already be munged by starting with 'chpl_' so shouldn't require
+  // additional munging here.
+  //
+  if (sym->hasFlag(FLAG_COMPILER_GENERATED)) {
+    return;
+  }
+
+  //
   // Let's assume we only have to rename user symbols and that we've
   // done a good job of protecting our internal and standard module
   // symbols.  This has the advantage of not having to take special

--- a/test/trivial/mjoyner/inlinefunc/inlfunc1_report.good
+++ b/test/trivial/mjoyner/inlinefunc/inlfunc1_report.good
@@ -1,5 +1,5 @@
-chapel compiler: reporting inlining, _Foo_x function was inlined
-chapel compiler: reporting inlining, _Foo_y function was inlined
-chapel compiler: reporting inlining, _Foo_y function was inlined
-chapel compiler: reporting inlining, _Foo_z function was inlined
+chapel compiler: reporting inlining, chpl_Foo_x function was inlined
+chapel compiler: reporting inlining, chpl_Foo_y function was inlined
+chapel compiler: reporting inlining, chpl_Foo_y function was inlined
+chapel compiler: reporting inlining, chpl_Foo_z function was inlined
 2

--- a/test/trivial/mjoyner/inlinefunc/inlfunc1_report.good
+++ b/test/trivial/mjoyner/inlinefunc/inlfunc1_report.good
@@ -1,5 +1,5 @@
-chapel compiler: reporting inlining, chpl_Foo_x function was inlined
-chapel compiler: reporting inlining, chpl_Foo_y function was inlined
-chapel compiler: reporting inlining, chpl_Foo_y function was inlined
-chapel compiler: reporting inlining, chpl_Foo_z function was inlined
+chapel compiler: reporting inlining, chpl_get_Foo_x function was inlined
+chapel compiler: reporting inlining, chpl_get_Foo_y function was inlined
+chapel compiler: reporting inlining, chpl_get_Foo_y function was inlined
+chapel compiler: reporting inlining, chpl_get_Foo_z function was inlined
 2


### PR DESCRIPTION
This is a roundabout (but ultimately positive!) fix for a baseline failure in one of my identifier munging tests.  Specifically, my .prediff script looked for instances of foo_chpl (because the test was written such that there weren't intended to be any), but in --baseline mode, it found one because the compiler introduced a getter named "_bar_foo" and then the "munge all identifiers" pass would make this into "_bar_foo_chpl" resulting in a match against foo_chpl.  (This getter is inlined in the non-baseline case, which is why we didn't see it there).

The fix was the following:

1) Make this getter start with "chpl_" rather than simply "_" for goodness' sake...  We're trying to get away from using "_" as though it's a safe identifier since C doesn't guarantee that.

2) Make the munging pass skip over symbols that start with "chpl_" on the argument that they're already plenty unique and that the compiler/Chapel implementers introduced them.

This isn't a particularly satisfying fix for the baseline regression itself, but both changes independently of the regression feel positive and more like the world we want to be living in, so I'm not at all ashamed.
