### PR TITLE
Skip these tests if using LLVM codegen

### DIFF
--- a/test/compflags/bradc/mungeUserIdents/SKIPIF
+++ b/test/compflags/bradc/mungeUserIdents/SKIPIF
@@ -1,0 +1,2 @@
+# test greps generated c code, will fail for llvm
+COMPOPTS <= --llvm


### PR DESCRIPTION
[suggested by Elliot]

These tests grep the generated code, so don't make sense in LLVM
mode.