### PR TITLE
Additions for compiler debugging.

### DIFF
--- a/compiler/AST/flags.cpp
+++ b/compiler/AST/flags.cpp
@@ -75,6 +75,7 @@ bool viewFlagsShort = true;
 bool viewFlagsPragma = false;
 bool viewFlagsName  = false;
 bool viewFlagsComment = false;
+bool viewFlagsExtras = true;
 
 void
 viewFlags(BaseAST* ast) {
@@ -93,6 +94,31 @@ viewFlags(BaseAST* ast) {
           printf("// %s",
                  *flagComments[e->value] ? flagComments[e->value] : "ncm");
         printf("\n");
+      }
+    }
+    if (viewFlagsExtras) {
+      if (VarSymbol* vs = toVarSymbol(sym)) {
+        if (vs->immediate) {
+          printf("immediate ");
+          fprint_imm(stdout, *toVarSymbol(sym)->immediate, true);
+          printf("\n");
+        }
+      } else if (ArgSymbol* as = toArgSymbol(sym)) {
+        printf("%s arg\n", as->intentDescrString());
+      } else if (toTypeSymbol(sym)) {
+        printf("a TypeSymbol\n");
+      } else if (FnSymbol* fs = toFnSymbol(sym)) {
+        printf("fn %s(%d args) %s\n",
+               fs->_this ? intentDescrString(fs->thisTag) : "",
+               fs->numFormals(), retTagDescrString(fs->retTag));
+      } else if (toEnumSymbol(sym)) {
+        printf("an EnumSymbol\n");
+      } else if (ModuleSymbol* ms = toModuleSymbol(sym)) {
+        printf("module %s\n", modTagDescrString(ms->modTag));
+      } else if (toLabelSymbol(sym)) {
+        printf("a LabelSymbol\n");
+      } else {
+        printf("unknown symbol kind\n");
       }
     }
   } else {

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -955,6 +955,27 @@ bool ArgSymbol::isParameter() const {
 }
 
 
+const char* retTagDescrString(RetTag retTag) {
+  switch (retTag) {
+    case RET_VALUE: return "value";
+    case RET_REF:   return "ref";
+    case RET_PARAM: return "param";
+    case RET_TYPE:  return "type";
+    default:        return "<unknown RetTag>";
+  }
+}
+
+
+const char* modTagDescrString(ModTag modTag) {
+  switch (modTag) {
+    case MOD_INTERNAL:  return "internal";
+    case MOD_STANDARD:  return "standard";
+    case MOD_USER:      return "user";
+    default:            return "<unknown ModTag>";
+  }
+}
+
+
 // describes this argument's intent (for use in an English sentence)
 const char* ArgSymbol::intentDescrString(void) {
   switch (intent) {

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -201,24 +201,52 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
 static bool aidIgnore(int id) { return id < 9; }
 
 static const char*
-aidError(const char* callerMsg, int id) {
+aidErrorMessage(const char* callerMsg, int id, const char* errorMsg) {
   const int tmpBuffSize = 256;
   static char tmpBuff[tmpBuffSize];
   snprintf(tmpBuff, tmpBuffSize, "<%s%s""the ID %d %s>",
-           callerMsg ? callerMsg : "", callerMsg ? ": " : "", id,
-           aidIgnore(id) ? " is small, use aid09(id) to examine it" :
-             "does not correspond to an AST node");
+           callerMsg ? callerMsg : "", callerMsg ? ": " : "",
+           id, errorMsg);
   return tmpBuff;
 }
-
-static void
-printAidError(const char* callerMsg, int id) {
-  printf("%s\n", aidError(callerMsg, id));
+static const char* aidNotFoundError(const char* callerMsg, int id) {
+  return aidErrorMessage(callerMsg, id, "does not correspond to an AST node");
+}
+static const char* aidIgnoreError(const char* callerMsg, int id) {
+  return aidErrorMessage(callerMsg, id,
+                         " is small, use aid09(id) to examine it");
 }
 
+// This version of aid*() does not exlude any id.
+BaseAST* aid09(int id) {
+  #define match_id(type)                        \
+    forv_Vec(type, a, g##type##s) {             \
+      if (a->id == id)                          \
+        return a;                               \
+    }
+  foreach_ast(match_id);
+  return NULL;
+}
+
+static BaseAST* aidWithError(int id, const char* callerMsg) {
+  if (aidIgnore(id)) {
+    printf("%s\n", aidIgnoreError(callerMsg, id));
+    return NULL;
+  } else {
+    BaseAST* result = aid09(id);
+    if (!result) printf("%s\n", aidNotFoundError(callerMsg, id));
+    return result;
+  }
+}
+
+BaseAST* aid(int id) {
+  return aidWithError(id, "aid");
+}
+
+
 void viewFlags(int id) {
-  BaseAST* ast = aid(id);
-  if (ast) viewFlags(ast); else printAidError("viewFlags", id);
+  if (BaseAST* ast = aidWithError(id, "viewFlags"))
+    viewFlags(ast);
 }
 
 
@@ -330,8 +358,8 @@ static void type_print_view(BaseAST* ast) {
 }
 
 void list_view(int id) {
-  BaseAST* ast = aid(id);
-  if (ast) list_view(ast); else printAidError("list_view", id);
+  if (BaseAST* ast = aidWithError(id, "list_view"))
+    list_view(ast);
 }
 
 void list_view(BaseAST* ast) {
@@ -379,8 +407,8 @@ void print_view_noline(BaseAST* ast) {
 }
 
 void nprint_view(int id) {
-  BaseAST* ast = aid(id);
-  if (ast) nprint_view(ast); else printAidError("nprint_view", id);
+  if (BaseAST* ast = aidWithError(id, "nprint_view"))
+    nprint_view(ast);
 }
 
 void nprint_view(BaseAST* ast) {
@@ -405,29 +433,9 @@ void nprint_view_noline(BaseAST* ast) {
 }
 
 
-// This version does not exlude any id.
-BaseAST* aid09(int id) {
-  #define match_id(type)                        \
-    forv_Vec(type, a, g##type##s) {             \
-      if (a->id == id)                          \
-        return a;                               \
-    }
-  foreach_ast(match_id);
-  return NULL;
-}
-
-BaseAST* aid(int id) {
-  if (aidIgnore(id)) {
-    printAidError("aid", id);
-    return NULL;
-  } else {
-    return aid09(id);
-  }
-}
-
-
 void iprint_view(int id) {
-  nprint_view(aid(id));
+  if (BaseAST* ast = aidWithError(id, "iprint_view"))
+    nprint_view(ast);
 }
 
 
@@ -491,6 +499,7 @@ log_ast_symbol(FILE* file, Symbol* sym, bool def) {
   log_need_space = true;
 }
 
+
 //
 // stringLoc, shortLoc, debugLoc: return "file:line", where 'file' is:
 //  - stringLoc: AST's fname()
@@ -504,13 +513,13 @@ log_ast_symbol(FILE* file, Symbol* sym, bool def) {
 static char locBuff[locBuffSize];
 
 const char* stringLoc(int id) {
-  BaseAST* ast = aid(id);
-  return ast ? stringLoc(ast) : aidError("stringLoc", id);
+  BaseAST* ast = aid09(id);
+  return ast ? stringLoc(ast) : aidNotFoundError("stringLoc", id);
 }
 
 const char* shortLoc(int id) {
-  BaseAST* ast = aid(id);
-  return ast ? shortLoc(ast) : aidError("shortLoc", id);
+  BaseAST* ast = aid09(id);
+  return ast ? shortLoc(ast) : aidNotFoundError("shortLoc", id);
 }
 
 const char* debugLoc(int id) {
@@ -537,6 +546,15 @@ const char* shortLoc(BaseAST* ast) {
 const char* debugLoc(BaseAST* ast) {
   return debugShortLoc ? shortLoc(ast) : stringLoc(ast);
 }
+
+// helper for printing IDs
+int debugID(int id) {
+  return id;
+}
+int debugID(BaseAST* ast) {
+  return ast ? ast->id : -1;
+}
+
 
 //
 // map_view: print the contents of a SymbolMap

--- a/compiler/etc/gdb.commands
+++ b/compiler/etc/gdb.commands
@@ -45,7 +45,8 @@ define loc
  p ::stringLoc($arg0)
 end
 define locid
- set $r837 = ($arg0)
- printf "%d  %s\n", debugID($r837), debugLoc($r837)
+  # evaluate $arg0 only once
+  set $eval_temp = ($arg0)
+  printf "%d  %s\n", debugID($eval_temp), debugLoc($eval_temp)
 end
 break gdbShouldBreakHere

--- a/compiler/etc/gdb.commands
+++ b/compiler/etc/gdb.commands
@@ -44,4 +44,8 @@ end
 define loc
  p ::stringLoc($arg0)
 end
+define locid
+ set $r837 = ($arg0)
+ printf "%d  %s\n", debugID($r837), debugLoc($r837)
+end
 break gdbShouldBreakHere

--- a/compiler/ifa/num.cpp
+++ b/compiler/ifa/num.cpp
@@ -187,28 +187,33 @@ fprint_imm(FILE *fp, Immediate &imm, bool showType) {
   int res = -1;
   switch (imm.const_kind) {
     case NUM_KIND_NONE:
-      if (showType) res = fputs(":NONE", fp); break;
+      if (showType) res = fputs(":NONE", fp);
       break;
     case NUM_KIND_BOOL: {
       // Since I'm using uints to store the bools, should cast to the
       // same to be consistent.
-      res = fprintf(fp, "%"PRIu64, imm.bool_value()); break;
-      if (showType) res += fprintf(fp, " :bool"); break;
+      res = fprintf(fp, "%"PRIu64, imm.bool_value());
+      if (showType) res += fputs(" :bool", fp);
+      break;
     }
     case NUM_KIND_UINT: {
       switch (imm.num_index) {
         case INT_SIZE_8: 
           res = fprintf(fp, "%u", (unsigned)imm.v_uint8);
-          if (showType) res += fputs(" :uint(8)", fp); break;
+          if (showType) res += fputs(" :uint(8)", fp);
+          break;
         case INT_SIZE_16:
           res = fprintf(fp, "%u", (unsigned)imm.v_uint16);
-          if (showType) res += fputs(" :uint(16)", fp); break;
+          if (showType) res += fputs(" :uint(16)", fp);
+          break;
         case INT_SIZE_32:
           res = fprintf(fp, "%u", (unsigned)imm.v_uint32);
-          if (showType) res += fputs(" :uint(32)", fp); break;
+          if (showType) res += fputs(" :uint(32)", fp);
+          break;
         case INT_SIZE_64:
           res = fprintf(fp, "%"PRIu64, imm.v_uint64);
-          if (showType) res += fputs(" :uint(64)", fp); break;
+          if (showType) res += fputs(" :uint(64)", fp);
+          break;
         default: INT_FATAL("Unhandled case in switch statement");
       }
       break;
@@ -217,16 +222,20 @@ fprint_imm(FILE *fp, Immediate &imm, bool showType) {
       switch (imm.num_index) {
         case INT_SIZE_8: 
           res = fprintf(fp, "%d", imm.v_int8);
-          if (showType) res += fputs(" :int(8)", fp); break;
+          if (showType) res += fputs(" :int(8)", fp);
+          break;
         case INT_SIZE_16:
           res = fprintf(fp, "%d", imm.v_int16);
-          if (showType) res += fputs(" :int(16)", fp); break;
+          if (showType) res += fputs(" :int(16)", fp);
+          break;
         case INT_SIZE_32:
           res = fprintf(fp, "%"PRId32, imm.v_int32);
-          if (showType) res += fputs(" :int(32)", fp); break;
+          if (showType) res += fputs(" :int(32)", fp);
+          break;
         case INT_SIZE_64:
           res = fprintf(fp, "%"PRId64, imm.v_int64);
-          if (showType) res += fputs(" :int(64)", fp); break;
+          if (showType) res += fputs(" :int(64)", fp);
+          break;
         default: INT_FATAL("Unhandled case in switch statement");
       }
       break;

--- a/compiler/ifa/num.cpp
+++ b/compiler/ifa/num.cpp
@@ -183,26 +183,32 @@ snprint_imm(char *str, size_t max, Immediate &imm) {
 }
 
 int 
-fprint_imm(FILE *fp, Immediate &imm) {
+fprint_imm(FILE *fp, Immediate &imm, bool showType) {
   int res = -1;
   switch (imm.const_kind) {
     case NUM_KIND_NONE:
+      if (showType) res = fputs(":NONE", fp); break;
       break;
     case NUM_KIND_BOOL: {
       // Since I'm using uints to store the bools, should cast to the
       // same to be consistent.
       res = fprintf(fp, "%"PRIu64, imm.bool_value()); break;
+      if (showType) res += fprintf(fp, " :bool"); break;
     }
     case NUM_KIND_UINT: {
       switch (imm.num_index) {
         case INT_SIZE_8: 
-          res = fprintf(fp, "%u", (unsigned)imm.v_uint8); break;
+          res = fprintf(fp, "%u", (unsigned)imm.v_uint8);
+          if (showType) res += fputs(" :uint(8)", fp); break;
         case INT_SIZE_16:
-          res = fprintf(fp, "%u", (unsigned)imm.v_uint16); break;
+          res = fprintf(fp, "%u", (unsigned)imm.v_uint16);
+          if (showType) res += fputs(" :uint(16)", fp); break;
         case INT_SIZE_32:
-          res = fprintf(fp, "%u", (unsigned)imm.v_uint32); break;
+          res = fprintf(fp, "%u", (unsigned)imm.v_uint32);
+          if (showType) res += fputs(" :uint(32)", fp); break;
         case INT_SIZE_64:
-          res = fprintf(fp, "%"PRIu64, imm.v_uint64); break;
+          res = fprintf(fp, "%"PRIu64, imm.v_uint64);
+          if (showType) res += fputs(" :uint(64)", fp); break;
         default: INT_FATAL("Unhandled case in switch statement");
       }
       break;
@@ -210,37 +216,50 @@ fprint_imm(FILE *fp, Immediate &imm) {
     case NUM_KIND_INT: {
       switch (imm.num_index) {
         case INT_SIZE_8: 
-          res = fprintf(fp, "%d", imm.v_int8); break;
+          res = fprintf(fp, "%d", imm.v_int8);
+          if (showType) res += fputs(" :int(8)", fp); break;
         case INT_SIZE_16:
-          res = fprintf(fp, "%d", imm.v_int16); break;
+          res = fprintf(fp, "%d", imm.v_int16);
+          if (showType) res += fputs(" :int(16)", fp); break;
         case INT_SIZE_32:
-          res = fprintf(fp, "%"PRId32, imm.v_int32); break;
+          res = fprintf(fp, "%"PRId32, imm.v_int32);
+          if (showType) res += fputs(" :int(32)", fp); break;
         case INT_SIZE_64:
-          res = fprintf(fp, "%"PRId64, imm.v_int64); break;
+          res = fprintf(fp, "%"PRId64, imm.v_int64);
+          if (showType) res += fputs(" :int(64)", fp); break;
         default: INT_FATAL("Unhandled case in switch statement");
       }
       break;
     }
-    case NUM_KIND_REAL: case NUM_KIND_IMAG:
+    case NUM_KIND_REAL: case NUM_KIND_IMAG: {
       char str[80];
+      const char* size = NULL;
       switch (imm.num_index) {
         case FLOAT_SIZE_32:  
-          res = sprint_float_val(str, imm.v_float32); 
+          res = sprint_float_val(str, imm.v_float32);
+          size = "(32)";
           break;
         case FLOAT_SIZE_64: {
           res = sprint_float_val(str, imm.v_float64); 
+          size = "(64)";
           break;
         }
         default: INT_FATAL("Unhandled case in switch statement");
       }
       fputs(str, fp);
+      if (showType) {
+        res += fputs(imm.const_kind == NUM_KIND_IMAG?" :imag":" :real", fp);
+        res += fputs(size, fp);
+      }
       break;
+    }
     case NUM_KIND_COMPLEX:
       switch (imm.num_index) {
         case COMPLEX_SIZE_64: {
           char str[80];
           res = sprint_complex_val(str, imm.v_complex64.r, imm.v_complex64.i); 
           fputs(str, fp);
+          if (showType) res += fputs(" :complex(64)", fp);
           break;
         }
         case COMPLEX_SIZE_128: {
@@ -248,6 +267,7 @@ fprint_imm(FILE *fp, Immediate &imm) {
           res = sprint_complex_val(str, 
                                    imm.v_complex128.r, imm.v_complex128.i); 
           fputs(str, fp);
+          if (showType) res += fputs(" :complex(128)", fp);
           break;
         }
         default: INT_FATAL("Unhandled case in switch statement");
@@ -255,7 +275,9 @@ fprint_imm(FILE *fp, Immediate &imm) {
       break;
     case CONST_KIND_STRING:
       res = fprintf(fp, "\"%s\"", imm.v_string);
+      // obvious, skip: if (showType) res += fputs(" :string", fp);
       break;
+    default: INT_FATAL("Unhandled case in switch statement");
   }
   return res;
 }

--- a/compiler/ifa/num.h
+++ b/compiler/ifa/num.h
@@ -206,7 +206,7 @@ ImmHashFns::equal(Immediate *imm1, Immediate *imm2) {
   return !memcmp(imm1, imm2, sizeof(*imm1));
 }
 
-int fprint_imm(FILE *fp, Immediate &imm);
+int fprint_imm(FILE *fp, Immediate &imm, bool showType = false);
 int snprint_imm(char *s, size_t max, Immediate &imm);
 int snprint_imm(char *str, size_t max, char *control_string, Immediate &imm);
 void coerce_immediate(Immediate *from, Immediate *to);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -41,6 +41,7 @@ class IteratorInfo;
 class Stmt;
 class SymExpr;
 
+// keep in sync with retTagDescrString()
 enum RetTag {
   RET_VALUE,
   RET_REF,
@@ -71,6 +72,7 @@ enum IntentTag {
   INTENT_BLANK     = INTENT_FLAG_BLANK
 };
 
+// keep in sync with modTagDescrString()
 enum ModTag {
   MOD_INTERNAL,  // an internal module that the user shouldn't know about
   MOD_STANDARD,  // a standard module from the Chapel libraries
@@ -476,6 +478,10 @@ FlagSet getRecordWrappedFlags(Symbol* s);
 FlagSet getSyncFlags(Symbol* s);
 VarSymbol* newTemp(const char* name = NULL, Type* type = dtUnknown);
 VarSymbol* newTemp(Type* type);
+
+// for use in an English sentence
+const char* retTagDescrString(RetTag retTag);
+const char* modTagDescrString(ModTag modTag);
 const char* intentDescrString(IntentTag intent);
 
 // Return true if the arg must use a C pointer whether or not

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -81,4 +81,8 @@ const char* shortLoc(BaseAST* ast);
 const char* debugLoc(int id);
 const char* debugLoc(BaseAST* ast);
 
+int debugID(int id);
+int debugID(BaseAST* ast);
+
+
 #endif


### PR DESCRIPTION
I have been using these for a while and find them helpful.

* Upon viewFlags(), print some additional information about the Symbol,
e.g. the immediate value, argument intent, module tag, etc.

For enums and labels, print "an EnumSymbol" or "a LabelSymbol",
so I can see what it is. This is an experimental feature,
improvements are welcome.

This change can be disabled by setting viewFlagsExtras=false.

* Added retTagDescrString() and modTagDescrString() to support the above.
Like ::intentDescrString(), these return "unknown" in an error case -
so I can continue debugging.

* In fprint_imm(), optionally print the type of the immediate,
based on imm.const_kind and imm.num_index. Use that in viewFlags().

Given that string literals are printed in quotes,
do not print :string for them.

* Added a gdb command 'locid', which prints the AST id and location
in a minimalistic fashion, e.g.

    (gdb) locid 389180
    389180  ChapelArray.chpl:37
    
    (gdb) locid e->prev
    389180  ChapelArray.chpl:37

Added debugID() to support this.

* Shuffled the details of how aid() and aidWithError() are used and
implemented  in view.cpp. This fixed one case where I was not getting
  "id NNN does not correspond to an AST node"
and slightly simplified list_view() et al.
