### PR TITLE
Add link to chapel module index on main html page.

### DIFF
--- a/third-party/chpldoc-venv/chpldoc-sphinx-project/source/index.rst
+++ b/third-party/chpldoc-venv/chpldoc-sphinx-project/source/index.rst
@@ -19,6 +19,5 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
+* :chpl:chplref:`chplmodindex`
 * :ref:`search`
-

--- a/third-party/chpldoc-venv/requirements.txt
+++ b/third-party/chpldoc-venv/requirements.txt
@@ -4,4 +4,4 @@ Pygments==2.0.2
 Sphinx==1.2.3
 docutils==0.12
 sphinx-rtd-theme==0.1.6
-sphinxcontrib-chapeldomain>=0.0.2
+sphinxcontrib-chapeldomain>=0.0.3


### PR DESCRIPTION
Requires version 0.0.3 of chapel domain and the new chplmodindex
cross-reference.