### PR TITLE
Iff hwloc config found libnuma, throw -lnuma when linking user programs.

### DIFF
--- a/runtime/etc/Makefile.hwloc-hwloc
+++ b/runtime/etc/Makefile.hwloc-hwloc
@@ -16,6 +16,10 @@
 # limitations under the License.
 
 GEN_CFLAGS += -I$(HWLOC_INCLUDE_DIR)
-GEN_LFLAGS += -L$(HWLOC_LIB_DIR) -Wl,-rpath -Wl,$(HWLOC_LIB_DIR)
+GEN_LFLAGS += -L$(HWLOC_LIB_DIR) -Wl,-rpath,$(HWLOC_LIB_DIR)
 
 LIBS += -lhwloc
+
+ifeq ($(CHPL_MAKE_HWLOC_NUMA),numa)
+LIBS += -lnuma
+endif

--- a/util/chplenv/__init__.py
+++ b/util/chplenv/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     'chpl_compiler',
     'chpl_gmp',
     'chpl_hwloc',
+    'chpl_hwloc_numa',
     'chpl_launcher',
     'chpl_llvm',
     'chpl_locale_model',

--- a/util/chplenv/chpl_hwloc_numa.py
+++ b/util/chplenv/chpl_hwloc_numa.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import sys, os
+
+import chpl_hwloc, chpl_arch, chpl_compiler, chpl_platform, utils
+from utils import memoize
+
+@memoize
+def get():
+    numa_val = 'none'
+    hwloc_val = chpl_hwloc.get()
+    if hwloc_val == 'hwloc':
+        target_platform = chpl_platform.get('target')
+        target_compiler = chpl_compiler.get('target')
+        target_arch = chpl_arch.get('target', map_to_compiler=True, get_lcd=True)
+
+        chpl_home = utils.get_chpl_home()
+        hwloc_target_dir = '{0}-{1}-{2}'.format(target_platform,
+                                                target_compiler, target_arch)
+        hwloc_subdir = os.path.join(chpl_home, 'third-party', 'hwloc',
+                                    'install', hwloc_target_dir)
+        libhwloc_la = os.path.join(hwloc_subdir, 'lib', 'libhwloc.la')
+
+        if os.path.isfile(libhwloc_la):
+            with open(libhwloc_la) as f:
+                la_info = f.readlines()
+            for line in la_info:
+                if 'dependency_libs=' in line and '-lnuma' in line:
+                    numa_val = 'numa'
+                    break
+    return numa_val
+
+
+def _main():
+    numa_val = get()
+    sys.stdout.write("{0}\n".format(numa_val))
+
+
+if __name__ == '__main__':
+    _main()

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -100,6 +100,10 @@ def print_mode(mode='list'):
 
     hwloc = chpl_hwloc.get()
     print_var('CHPL_HWLOC', hwloc, mode, 'hwloc', ('runtime',))
+    # only 'make' needs this value (for linking user programs)
+    if mode == 'make' and hwloc == 'hwloc':
+        hwloc_numa = chpl_hwloc_numa.get()
+        print_var('  CHPL_HWLOC_NUMA', hwloc_numa, mode, filters=('runtime',))
 
     regexp = chpl_regexp.get()
     print_var('CHPL_REGEXP', regexp, mode, 're', ('runtime',))


### PR DESCRIPTION
Arrange to throw -lnuma so as to search libnuma, iff we're using hwloc
and it configured itself with libnuma support.  This involves:
- In runtime/etc/Makefile.hwloc-hwloc, if CHPL_MAKE_HWLOC_NUMA indicates
  that hwloc is using libnuma, arrange (by appending it to LIBS) to
  throw '-lnuma' when linking using programs.  CHPL_MAKE_HWLOC_NUMA is
  set in make/Makefile.base along with all the other config-related
  vars printed by 'printchplenv --make'.
- Have 'printchplenv --make' run chpl_hwloc_numa.py iff we're using
  hwloc.  We only need this in 'make' mode, because we only use it as
  described in the above item.
- Add a util/chplenv/chpl_hwloc_numa.py script that prints 'numa' iff
  we're using hwloc and the hwloc installation depends on libnuma, or
  'none' otherwise.