### PR TITLE
Update how we detect 32 vs 64 bit for netbsd

### DIFF
--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -50,7 +50,7 @@ def get(flag='host'):
             else:
                 platform_val = "cygwin32"
         elif platform_val.startswith('netbsd'):
-            if machine == 'x86_64':
+            if machine == 'amd64':
                 platform_val = 'netbsd64'
             else:
                 platform_val = 'netbsd32'


### PR DESCRIPTION
Phil (NetBSD expert) says we should key off of machine == 'amd64' to figure out
if we're on a 64 bit machine instead of machine == 'x86_64'
