### PR TITLE
Documentation for standard modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ tags
 /man/man1/chpl.1
 
 # Modules ignores.
+/modules/docs
 /modules/internal/tasks/muxed
 /modules/internal/threads/soft-threads
 

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ third-party-chpldoc-venv: FORCE
 chpldoc: compiler third-party-chpldoc-venv
 	cd compiler && $(MAKE) chpldoc
 
+modules-docs: chpldoc
+	cd modules && $(MAKE) documentation
+
 clean: FORCE
 	cd compiler && $(MAKE) clean
 	cd modules && $(MAKE) clean

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -48,5 +48,12 @@ $(SYS_CTYPES_MODULE): $(MAKE_SYS_BASIC_TYPES)
 # created, but still make sure the command fails.
 	cd $(@D) && ( $(MAKE_SYS_BASIC_TYPES) > $(@F) || { rm -f $(@F) && false ; } )
 
+MODULES_TO_DOCUMENT = \
+	standard/BitOps.chpl \
+	standard/Random.chpl
+
+documentation:
+	$(CHPLDOC) $(MODULES_TO_DOCUMENT)
+
 FORCE:
 

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -54,6 +54,7 @@ MODULES_TO_DOCUMENT = \
 
 documentation:
 	$(CHPLDOC) $(MODULES_TO_DOCUMENT)
+	@echo "HTML files are at \$$CHPL_HOME/modules/docs/html/build/html/."
 
 FORCE:
 

--- a/modules/standard/BitOps.chpl
+++ b/modules/standard/BitOps.chpl
@@ -224,6 +224,7 @@ module BitOps {
 /**
  * module to hide the extern procedures
  */
+pragma "no doc"
 module BitOps_internal {
   extern proc chpl_bitops_popcount_32(x: c_uint) : uint(32);
   extern proc chpl_bitops_popcount_64(x: c_ulonglong) : uint(64);

--- a/third-party/chpldoc-venv/chpldoc-sphinx-project/source/index.rst
+++ b/third-party/chpldoc-venv/chpldoc-sphinx-project/source/index.rst
@@ -12,7 +12,7 @@ Contents:
    :maxdepth: 2
    :glob:
 
-   modules/*
+   modules/**
 
 
 Indices and tables


### PR DESCRIPTION
* Add `modules-docs` target to top level makefile. It depends on the
  chpldoc target and then traverses into modules/ and calls `make documentation`.
* Add documentation target to modules/Makefile. It builds documentation for a
  whitelist of the standard modules, for now.

Also...

* Add no doc pragma to BitOps_internal.
* Support multiple levels of directories in the sphinx project sources.

Regarding the last point: If chpldoc is run from $CHPL_HOME or even
$CHPL_HOME/modules, the rst files will be put in sub directories matching
the directory structure (e.g. modules/standard/ or standard/, respectively).
Update the toctree in index.rst to grab rst files at all depths.