### PR TITLE
Update how we detect using intrinsics or locks for chpl_atomics

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -19,22 +19,24 @@ def get(flag='target'):
             compiler_val = chpl_compiler.get('target')
             platform_val = chpl_platform.get('target')
 
-            # we currently support intrinsics for 64 bit platforms using gcc,
-            # intel, or cray compilers but not pgi. pgi does not have support
-            # for atomic intrinsics so we revert to locks for that case. We
-            # could add support for 32-bit platforms and only use locks for
-            # 64-bit atomics but we can cross that bridge when we get there.
-            if platform_val != "linux32":
-                if compiler_val == 'gnu' or compiler_val == 'cray-prgenv-gnu':
-                    version = utils.get_compiler_version('gnu')
-                    if version >= 4.1:
-                        atomics_val = 'intrinsics'
-                elif 'intel' in compiler_val or compiler_val == 'cray-prgenv-intel':
+            # we currently support intrinsics for gcc, intel, cray and clang.
+            # gcc added initial support in 4.1, and added support for 64 bit
+            # atomics on 32 bit platforms with 4.8. clang and intel support 64
+            # bit atomics on 32 bit platforms and the cray compiler will never
+            # run on a 32 bit machine. For pgi, or 32 bit platforms with older
+            # gcc, we fall back to locks
+            if compiler_val == 'gnu' or compiler_val == 'cray-prgenv-gnu':
+                version = utils.get_compiler_version('gnu')
+                if version >= 4.8:
                     atomics_val = 'intrinsics'
-                elif compiler_val == 'cray-prgenv-cray':
+                elif version >= 4.1 and not platform_val.endswith('32'):
                     atomics_val = 'intrinsics'
-                elif 'clang' in compiler_val:
-                    atomics_val = 'intrinsics'
+            elif 'intel' in compiler_val or compiler_val == 'cray-prgenv-intel':
+                atomics_val = 'intrinsics'
+            elif compiler_val == 'cray-prgenv-cray':
+                atomics_val = 'intrinsics'
+            elif 'clang' in compiler_val:
+                atomics_val = 'intrinsics'
 
             # we can't use intrinsics, fall back to locks
             if not atomics_val:

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -21,21 +21,21 @@ def get(flag='target'):
 
             # we currently support intrinsics for gcc, intel, cray and clang.
             # gcc added initial support in 4.1, and added support for 64 bit
-            # atomics on 32 bit platforms with 4.8. clang and intel support 64
-            # bit atomics on 32 bit platforms and the cray compiler will never
-            # run on a 32 bit machine. For pgi, or 32 bit platforms with older
-            # gcc, we fall back to locks
+            # atomics on 32 bit platforms with 4.8. clang and intel also
+            # support 64 bit atomics on 32 bit platforms and the cray compiler
+            # will never run on a 32 bit machine. For pgi or 32 bit platforms
+            # with an older gcc, we fall back to locks
             if compiler_val == 'gnu' or compiler_val == 'cray-prgenv-gnu':
                 version = utils.get_compiler_version('gnu')
                 if version >= 4.8:
                     atomics_val = 'intrinsics'
                 elif version >= 4.1 and not platform_val.endswith('32'):
                     atomics_val = 'intrinsics'
-            elif 'intel' in compiler_val or compiler_val == 'cray-prgenv-intel':
+            elif compiler_val == 'intel' or compiler_val == 'cray-prgenv-intel':
                 atomics_val = 'intrinsics'
             elif compiler_val == 'cray-prgenv-cray':
                 atomics_val = 'intrinsics'
-            elif 'clang' in compiler_val:
+            elif compiler_val == 'clang':
                 atomics_val = 'intrinsics'
 
             # we can't use intrinsics, fall back to locks


### PR DESCRIPTION
This will fix a build issue on netbsd32 where we mistakenly tried to use
atomics.

It also cleans up the checks so that it should work out of the box for future
platforms more easily. Previously we tried to use intrinsics for certain
versions of compilers so long as we weren't on linux32. This was a fragile
check from before we tested on other 32 bit platforms such as cygwin32 or
netbsd32.

I was going to update this script to special case for netbsd32 when I noticed
that we somehow get away with using the intrinsic atomic implementation on
cygwin32. After a little digging it turns out that gcc added support for 64 bit
atomics on 32 bit platforms with gcc 4.8. clang has always done this, and intel
also appears to (tested by looking at assembly when compiled with -m32.) They
basically use pthread locks to do atomic operations on 64 bit variables when
the hardware support isn't available.

There used to be a note in this script that mentioned we could do something
similar ourselves and use our intrinsics implement for 32 bit machines and
just use locks for 64 bit operations. gcc has done this for us, so we get it
for free if the backend compiler is new enough.