### PR TITLE
Add empty line around class/record description in rst mode.

### DIFF
--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -233,9 +233,22 @@ void printClass(std::ofstream *file, AggregateType *cl) {
   
     NUMTABS++;
     *file << cl->symbol->name << std::endl;
+
+    // In rst mode, ensure there is an empty line between the class/record
+    // signature and its description or the next directive.
+    if (!fDocsTextOnly) {
+      *file << std::endl;
+    }
+
     if (cl->doc != NULL) {
       printTabs(file);
       *file << cl->doc << std::endl;
+
+      // In rst mode, ensure there is an empty line between the class/record
+      // description and the next directive.
+      if (!fDocsTextOnly) {
+        *file << std::endl;
+      }
     }
     printFields(file, cl);
     // If alphabetical option passed, alphabetizes the output

--- a/third-party/chpldoc-venv/requirements.txt
+++ b/third-party/chpldoc-venv/requirements.txt
@@ -4,4 +4,4 @@ Pygments==2.0.2
 Sphinx==1.2.3
 docutils==0.12
 sphinx-rtd-theme==0.1.6
-sphinxcontrib-chapeldomain>=0.0.3
+sphinxcontrib-chapeldomain>=0.0.4


### PR DESCRIPTION
This makes the html output more accurate.