### PR TITLE
Fix GCC version number detection in chplenv

### DIFF
--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -109,12 +109,15 @@ class argument_map(object):
             return arch
 
         if compiler == 'gnu':
-            if version >= 4.9:
+            if version.major > 4:
                 return cls.gcc49.get(arch, '')
-            if version >= 4.7:
-                return cls.gcc47.get(arch, '')
-            if version >= 4.3:
-                return cls.gcc43.get(arch, '')
+            elif version.major == 4:
+                if version.minor >= 9:
+                    return cls.gcc49.get(arch, '')
+                elif version.minor >= 7:
+                    return cls.gcc47.get(arch, '')
+                elif version.minor >= 3:
+                    return cls.gcc43.get(arch, '')
             return 'none'
         elif compiler == 'intel':
             return cls.intel.get(arch, '')

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -27,10 +27,13 @@ def get(flag='target'):
             # with an older gcc, we fall back to locks
             if compiler_val == 'gnu' or compiler_val == 'cray-prgenv-gnu':
                 version = utils.get_compiler_version('gnu')
-                if version >= 4.8:
+                if version.major > 4:
                     atomics_val = 'intrinsics'
-                elif version >= 4.1 and not platform_val.endswith('32'):
-                    atomics_val = 'intrinsics'
+                if version.major == 4:
+                    if version.minor >= 8:
+                        atomics_val = 'intrinsics'
+                    elif version.minor >= 1 and not platform_val.endswith('32'):
+                        atomics_val = 'intrinsics'
             elif compiler_val == 'intel' or compiler_val == 'cray-prgenv-intel':
                 atomics_val = 'intrinsics'
             elif compiler_val == 'cray-prgenv-cray':

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -1,5 +1,6 @@
 import os, re, subprocess
 from distutils.spawn import find_executable
+from collections import namedtuple
 
 def memoize(func):
     cache = func.cache = {}
@@ -23,15 +24,16 @@ def get_chpl_home():
 
 @memoize
 def get_compiler_version(compiler):
+    CompVersion = namedtuple('CompVersion', ['major', 'minor'])
     if 'gnu' in compiler:
         output = run_command(['gcc', '-dumpversion'])
-        match = re.search(r'(\d+\.\d+)', output)
+        match = re.search(r'(\d+)\.(\d+)', output)
         if match:
-            return float(match.group(1))
+            return CompVersion(major=int(match.group(1)), minor=int(match.group(2)))
         else:
             raise ValueError("Could not find the GCC version")
     else:
-        return 0
+        return CompVersion(major=0, minor=0)
 
 class CommandError(Exception):
     pass


### PR DESCRIPTION
While reviewing a patch today I realized I did a horrible job of
handling the comparisons for GCC version numbers. This has been fixed so
we no longer do a float comparison, and instead use a named tuple of
(Major, Minor) version numbers.