### PR TITLE
Re-add timeout for studies/madness/aniruddha/madchap/test_likepy

### DIFF
--- a/test/studies/madness/aniruddha/madchap/test_likepy.timeout
+++ b/test/studies/madness/aniruddha/madchap/test_likepy.timeout
@@ -1,0 +1,4 @@
+# As of 02/04/15 this test times out semi-regularly for gasnet-fifo.
+# We should be able to remove this when we test on real hardware
+# instead of using local spawning.
+900


### PR DESCRIPTION
I originally removed this timeout with 8bf9a009a9abfcd3fa66e2c998c6c49e074f3ce5
since it didn't seem to be timing out anymore. However, this test does still
time out semi-regularly for gasnet-fifo.

Re-adding the timeout to quiet the noise. We should be able to remove this when
we test on real hardware instead of using local spawning.