### PR TITLE
Fix some netbsd build errors

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm $(TARGETS)
 
 man1/%.1: %.txt Makefile
-	mkdir -pv $(shell dirname $@)
+	mkdir -p $(shell dirname $@)
 	$(TXT2MAN) -s 1 -I locale -I pthreads -I "on blocks" -I"Compiler Information Options" -I"Compilation Trace Options" -I"Module Processing Options" -I"Parallelism Control Options" -I"Optimization Control Options" -I"Run-time Semantic Check Options" -I "C Code Generation Options" -I"C Code Compilation Options" -I "LLVM Code Generation Options" -B"h" -B"c" -B"o" -B"cpp" -B"--no-cpp-lines" -I "Miscellaneous Options" -I "Documentation Options" -t $* -r $(VERSION) $< > $@
 
 %.ps: man1/%.1

--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -342,7 +342,12 @@ DECLARE_ATOMICS(uint_least8_t);
 DECLARE_ATOMICS(uint_least16_t);
 DECLARE_ATOMICS(uint_least32_t);
 DECLARE_ATOMICS(uint_least64_t);
-DECLARE_ATOMICS(uintptr_t);
+
+// For some reason using the DECLARE_ATOMICS macro for uintptr_t causes build
+// issues on netbsd.
+DECLARE_ATOMICS_BASE(uintptr_t, uintptr_t);
+DECLARE_ATOMICS_EXCHANGE_OPS(uintptr_t, uintptr_t);
+DECLARE_ATOMICS_FETCH_OPS(uintptr_t);
 
 
 #define DECLARE_REAL_ATOMICS(type, uinttype) \

--- a/runtime/include/atomics/locks/chpl-atomics.h
+++ b/runtime/include/atomics/locks/chpl-atomics.h
@@ -305,7 +305,11 @@ DECLARE_ATOMICS(uint_least8_t);
 DECLARE_ATOMICS(uint_least16_t);
 DECLARE_ATOMICS(uint_least32_t);
 DECLARE_ATOMICS(uint_least64_t);
-DECLARE_ATOMICS(uintptr_t);
+
+// For some reason using the DECLARE_ATOMICS macro for uintptr_t causes build
+// issues on netbsd.
+DECLARE_ATOMICS_BASE(uintptr_t, uintptr_t);
+DECLARE_ATOMICS_FETCH_OPS(uintptr_t);
 
 DECLARE_REAL_ATOMICS(_real32);
 DECLARE_REAL_ATOMICS(_real64);

--- a/runtime/include/sys_basic.h
+++ b/runtime/include/sys_basic.h
@@ -25,9 +25,12 @@
 #define _BSD_SOURCE
 #endif
 
-#ifndef _DARWIN_C_SOURCE
 // to get NI_MAXHOST or NI_MAXSERV
+#ifndef _DARWIN_C_SOURCE
 #define _DARWIN_C_SOURCE
+#endif
+#ifndef _NETBSD_SOURCE
+#define _NETBSD_SOURCE
 #endif
 
 // AIX needs _ALL_SOURCE


### PR DESCRIPTION
This patch fixes 3 issues with building on netbsd (there are a few others yet):

Update use of macros for atomic uintptr_t functions:
For some reason that baffles me using the DECLARE_ATOMICS marco for uintptr_t
causes build issues on netbsd, but calling the 3 macros that it does works
fine.

This seems like an ok, though unfortunate workaround. So far as I can tell we
don't actually use any of the atomic operations on uintptr_t either in the
modules or runtime so it might be easy enough to just remove the declaration of
it.

I wanted to wait and talk to Michael about that, but this seems like an ok fix
in the meantime.

==================================================================

Define _NETBSD_SOURCE to get NI_MAXHOST or NI_MAXSERV on netbsd:
Without this, NI_MAXHOST and NI_MAXSERV won't be defined and will cause build
issues. This is similar to what had to be done to get them for osx.

==================================================================
Remove -v in mkdir for creating man directory:
-v is not supported on netbsd. man mkdir on other systems says "The -v option is
non-standard and its use in scripts is not recommended."

I don't think we lose much by not throwing -v