### PR TITLE
Update use of macros for atomic uintptr_t functions

### DIFF
--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -343,8 +343,20 @@ DECLARE_ATOMICS(uint_least16_t);
 DECLARE_ATOMICS(uint_least32_t);
 DECLARE_ATOMICS(uint_least64_t);
 
-// For some reason using the DECLARE_ATOMICS macro for uintptr_t causes build
-// issues on netbsd.
+// On netbsd the DECLARE_ATOMICS macro doesn't work for uintptr_t. From gbt:
+// The root of the problem is the fact the on netbsd <stdint.h> (indirectly via
+// <sys.stdint.h>) #defines uintptr_t as __uintptr_t.  (__uintptr_t is in turn
+// typedef'd as unsigned long, but that doesn't matter to us.)  The C standard
+// (6.3.10.1(1) for C99) says that the actual arguments in a macro invocation
+// are themselves macro-expanded before being substituted into the replacement
+// text, unless they are preceded by a # or ## token.  In our case, the "type"
+// formal argument of DECLARE_ATOMICS_BASE has a ## before it in the
+// replacement text, so uintptr_t is not macro-expanded and the concatenation
+// produces the expected atomic_uintptr_t typedef name.  But in the case of
+// DECLARE_ATOMICS there is neither a # or ## before "type" in the replacement
+// text, so the uintptr_t actual becomes __uintptr_t via macro expansion before
+// DECLARE_ATOMICS_BASE is invoked, and we get a syntax error on the resulting
+// atomic___uintptr_t because it's not a typedef type.
 DECLARE_ATOMICS_BASE(uintptr_t, uintptr_t);
 DECLARE_ATOMICS_EXCHANGE_OPS(uintptr_t, uintptr_t);
 DECLARE_ATOMICS_FETCH_OPS(uintptr_t);

--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -342,7 +342,12 @@ DECLARE_ATOMICS(uint_least8_t);
 DECLARE_ATOMICS(uint_least16_t);
 DECLARE_ATOMICS(uint_least32_t);
 DECLARE_ATOMICS(uint_least64_t);
-DECLARE_ATOMICS(uintptr_t);
+
+// For some reason using the DECLARE_ATOMICS macro for uintptr_t causes build
+// issues on netbsd.
+DECLARE_ATOMICS_BASE(uintptr_t, uintptr_t);
+DECLARE_ATOMICS_EXCHANGE_OPS(uintptr_t, uintptr_t);
+DECLARE_ATOMICS_FETCH_OPS(uintptr_t);
 
 
 #define DECLARE_REAL_ATOMICS(type, uinttype) \

--- a/runtime/include/atomics/locks/chpl-atomics.h
+++ b/runtime/include/atomics/locks/chpl-atomics.h
@@ -305,7 +305,11 @@ DECLARE_ATOMICS(uint_least8_t);
 DECLARE_ATOMICS(uint_least16_t);
 DECLARE_ATOMICS(uint_least32_t);
 DECLARE_ATOMICS(uint_least64_t);
-DECLARE_ATOMICS(uintptr_t);
+
+// For some reason using the DECLARE_ATOMICS macro for uintptr_t causes build
+// issues on netbsd.
+DECLARE_ATOMICS_BASE(uintptr_t, uintptr_t);
+DECLARE_ATOMICS_FETCH_OPS(uintptr_t);
 
 DECLARE_REAL_ATOMICS(_real32);
 DECLARE_REAL_ATOMICS(_real64);

--- a/runtime/include/atomics/locks/chpl-atomics.h
+++ b/runtime/include/atomics/locks/chpl-atomics.h
@@ -306,8 +306,20 @@ DECLARE_ATOMICS(uint_least16_t);
 DECLARE_ATOMICS(uint_least32_t);
 DECLARE_ATOMICS(uint_least64_t);
 
-// For some reason using the DECLARE_ATOMICS macro for uintptr_t causes build
-// issues on netbsd.
+// On netbsd the DECLARE_ATOMICS macro doesn't work for uintptr_t. From gbt:
+// The root of the problem is the fact the on netbsd <stdint.h> (indirectly via
+// <sys.stdint.h>) #defines uintptr_t as __uintptr_t.  (__uintptr_t is in turn
+// typedef'd as unsigned long, but that doesn't matter to us.)  The C standard
+// (6.3.10.1(1) for C99) says that the actual arguments in a macro invocation
+// are themselves macro-expanded before being substituted into the replacement
+// text, unless they are preceded by a # or ## token.  In our case, the "type"
+// formal argument of DECLARE_ATOMICS_BASE has a ## before it in the
+// replacement text, so uintptr_t is not macro-expanded and the concatenation
+// produces the expected atomic_uintptr_t typedef name.  But in the case of
+// DECLARE_ATOMICS there is neither a # or ## before "type" in the replacement
+// text, so the uintptr_t actual becomes __uintptr_t via macro expansion before
+// DECLARE_ATOMICS_BASE is invoked, and we get a syntax error on the resulting
+// atomic___uintptr_t because it's not a typedef type.
 DECLARE_ATOMICS_BASE(uintptr_t, uintptr_t);
 DECLARE_ATOMICS_FETCH_OPS(uintptr_t);
 


### PR DESCRIPTION
For some reason that baffles me using the DECLARE_ATOMICS marco for uintptr_t
causes build issues on netbsd, but calling the 3 macros that it does works
fine.

This seems like an ok, though unfortunate workaround. So far as I can tell we
don't actually use any of the atomic operations on uintptr_t either in the
modules or runtime so it might be easy enough to just remove the declaration of
it.

I wanted to wait and talk to Michael about that, but this seems like an ok fix
in the meantime.