### PR TITLE
Need to define _NETBSD_SOURCE to get NI_MAXHOST or NI_MAXSERV on netbsd

### DIFF
--- a/runtime/include/sys_basic.h
+++ b/runtime/include/sys_basic.h
@@ -25,9 +25,12 @@
 #define _BSD_SOURCE
 #endif
 
-#ifndef _DARWIN_C_SOURCE
 // to get NI_MAXHOST or NI_MAXSERV
+#ifndef _DARWIN_C_SOURCE
 #define _DARWIN_C_SOURCE
+#endif
+#ifndef _NETBSD_SOURCE
+#define _NETBSD_SOURCE
 #endif
 
 // AIX needs _ALL_SOURCE


### PR DESCRIPTION
Without this, NI_MAXHOST and NI_MAXSERV won't be defined and will cause build
issues. This is similar to what had to be done to get them for osx.

This is also required in order to be able to use the copysign() which is used in
runtime/src/qio/qio_formatted.c