### PR TITLE
Remove -v in mkdir for creating man directory

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm $(TARGETS)
 
 man1/%.1: %.txt Makefile
-	mkdir -pv $(shell dirname $@)
+	mkdir -p $(shell dirname $@)
 	$(TXT2MAN) -s 1 -I locale -I pthreads -I "on blocks" -I"Compiler Information Options" -I"Compilation Trace Options" -I"Module Processing Options" -I"Parallelism Control Options" -I"Optimization Control Options" -I"Run-time Semantic Check Options" -I "C Code Generation Options" -I"C Code Compilation Options" -I "LLVM Code Generation Options" -B"h" -B"c" -B"o" -B"cpp" -B"--no-cpp-lines" -I "Miscellaneous Options" -I "Documentation Options" -t $* -r $(VERSION) $< > $@
 
 %.ps: man1/%.1


### PR DESCRIPTION
-v is not supported on netbsd. man mkdir on other systems says "The -v option is
non-standard and its use in scripts is not recommended."

I don't think we lose much by not throwing -v