### PR TITLE
Update functions to get memory and cpu/pu count in chplsys for netbsd

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -20,7 +20,7 @@
 #if defined __CYGWIN__
 #include <windows.h>
 #endif
-#if defined __APPLE__
+#if defined(__APPLE__) || defined(__NetBSD__)
 #include <sys/sysctl.h>
 #endif
 #if defined _AIX
@@ -124,7 +124,7 @@ size_t chpl_bytesAvailOnThisLocale(void) {
 }
 
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__NetBSD__)
 //
 // Return information about the processors on the system.
 //
@@ -210,7 +210,7 @@ int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
   if (numCpus == 0)
     numCpus = chpl_getNumLogicalCpus(true);
   return numCpus;
-#elif defined __linux__
+#elif defined(__linux__) || defined(__NetBSD__)
   //
   // Linux
   //
@@ -223,11 +223,13 @@ int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
     static int numCpus = 0;
 
     if (numCpus == 0) {
-#ifdef __MIC__
+#if defined __MIC__
       //
       // On Intel MIC, we seem (for now at least) not to have kernel
       // scheduling affinity information.
       //
+      numCpus = numPhysCpus;
+#elif defined __NetBSD__
       numCpus = numPhysCpus;
 #else
       //
@@ -294,7 +296,7 @@ int chpl_getNumLogicalCpus(chpl_bool accessible_only) {
   if (numCpus == 0)
     numCpus = sysconf(_SC_NPROCESSORS_ONLN);
   return numCpus;
-#elif defined __linux__
+#elif defined(__linux__) || defined(__NetBSD__)
   //
   // Linux
   //
@@ -307,11 +309,13 @@ int chpl_getNumLogicalCpus(chpl_bool accessible_only) {
     static int numCpus = 0;
 
     if (numCpus == 0) {
-#ifdef __MIC__
+#if defined __MIC__
       //
       // On Intel MIC, we seem (for now at least) not to have kernel
       // scheduling affinity information.
       //
+      numCpus = numLogCpus;
+#elif defined __NetBSD__
       numCpus = numLogCpus;
 #else
       cpu_set_t m;


### PR DESCRIPTION
We already had implementations for getting the amount of memory on a machine.
Just needed to include sys/sysctl.h to get those routines to work again. We
didn't have implementations to get the number of physical and logical cores.
However the logic we use for linux (getting it from /proc/cpuinfo) works on
netbsd.

Getting the available cores/pus based on accessibility information
(sched_getaffinity) is different than linux and I didn't implement that for
netbsd.

It's similar-ish to how it's done for linux:

Instead of cpu_set_t there is a cpuset_t which has to be created with
cpuset_create()/cpuset_destroy(). The call is sched_getaffinity_np() instead of
sched_getaffinity() and CPU_COUNT isn't implemented. I based my initial attempt
off of code in hwloc-1.9.1/src/topology-netbsd.c, but wasn't sure how to get
around CPU_COUNT not working so I gave up for now. I can work on this later,
though I am starting to feel we should rely on using hwloc for these types of
questions.