### PR TITLE
Default to using CHPL_TASKS=fifo for netbsd

### DIFF
--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -11,7 +11,9 @@ def get():
         arch_val = chpl_arch.get('target', get_lcd=True)
         platform_val = chpl_platform.get()
         compiler_val = chpl_compiler.get('target')
-        if (arch_val == 'knc' or platform_val.startswith('cygwin') or
+        if (arch_val == 'knc' or
+                platform_val.startswith('cygwin') or
+                platform_val.startswith('netbsd') or
                 compiler_val == 'cray-prgenv-cray'):
             tasks_val = 'fifo'
         else:


### PR DESCRIPTION
There were some build issues on netbsd. I think it was that makecontext()
couldn't be found. That might just be because the gcc version on the machine I
tested on is older and makecontext() was only added with glibc 2.1. This is
meant as a temporary solution.

While reworking this script I realized we should probably default to fifo for
platforms we aren't sure qthreads will build on whereas we default to qthreads
except for a few platforms now.

As I was thinking I realized a better solution would be to speculatively build
hwloc and qthreads like we do for re2 and gmp. This way if hwloc/qthreads build
we use them, and if not no big deal we can try to fall back to fifo. This
should give us more portability on systems we haven't tested while still
allowing qthreads to be used when it builds.

It should also allow us to use qthreads without hwloc in the case that hwloc
build failed, but qthreads was successful.

I'll work on that for 1.11