### PR TITLE
Filing a bug that Thomas identified

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -318,6 +318,13 @@ void parseDependentModules(ModTag modtype) {
           if (foundUsr) {
             SET_LINENO(oldModNameExpr);
 
+            if (mod == NULL) {
+              INT_FATAL("Trying to rename a standard module that's part of\n"
+                        "a file defining multiple\nmodules doesn't work yet;\n"
+                        "see test/modules/bradc/modNamedNewStringBreaks.future"
+                        " for details");
+            }
+            
             mod->name = astr("chpl_", modName);
 
             UnresolvedSymExpr* newModNameExpr = new UnresolvedSymExpr(mod->name);

--- a/test/modules/bradc/modNamedNewStringBreaks.chpl
+++ b/test/modules/bradc/modNamedNewStringBreaks.chpl
@@ -1,0 +1,3 @@
+module NewString {
+  writeln("In my NewString");
+}

--- a/test/modules/bradc/modNamedNewStringBreaks.future
+++ b/test/modules/bradc/modNamedNewStringBreaks.future
@@ -1,0 +1,26 @@
+bug: logic to protect module conflict names breaks
+
+(bradc would be willing to work on this more when it becomes a real
+issue for someone)
+
+When user modules have the same name as standard modules, and those
+standard modules are defined within files that define multiple
+modules, it can break compilation.  This test shows this for a module
+named NewString, which is currently a standard module that has
+multiple modules within it.
+
+Looking at parser.cpp, the problem stems from having the ParseFile()/
+ParseMod() routines return "NULL" in the event that the file contains
+multiple modules which is a pretty dumb interface.  My two thoughts
+about fixing this would be either:
+
+(a) to have any logic that needs to be applied to such modules get
+pushed into ParseFile()/ParseMod() rather than taking place at the
+callsite.  There aren't many cases that actually do something with the
+returned value, and one of them seems (unless I'm reading it wrong) to
+duplicate logic that is already done within the function anyway.
+
+(b) to improve the interface to return a vector/list/something of the
+modules that the file contained.  While this is a "smarter" interface,
+the small number of cases that use the return value suggest trying to
+take approach (a) to me.

--- a/test/modules/bradc/modNamedNewStringBreaks.good
+++ b/test/modules/bradc/modNamedNewStringBreaks.good
@@ -1,0 +1,1 @@
+In my NewString


### PR DESCRIPTION
While working on chpldocs, Thomas noted that compiling the NewString
module causes a segfault.  The reason for this is subtle and unlikely
to be something that an end-user runs into.  It essentially relates to:

(a) naming on the command line a file that defines a module with the
    same name as an internal/standard module and

(b) the internal/standard module being defined in a file that defines
    multiple modules.

This is related to the fact that we rename standard/internal modules
when the user had one of the same name in order to ensure that
the user doesn't hijack a module that the internal modules are
depending on.  The logic around this is somewhat overly complicated,
for not-so-good reasons.  I've suggested some fixes in the .future
file here.

Here, I've captured a variation that fails in a similar way by having
a module named NewString in user code.  I've also put an
assertion into the compiler to replace the segfault with an internal
error (which may also make Coverity happy?)

The fix is probably not too difficult, but I didn't undertake it today
in order to focus on higher priority work.  In the specific instance
of chpldoc and NewString, I'm betting that NewString will go away as
new strings come online and/or not be something we want to document
before they do (at which point, we may want to update this test to
point to another such internal/standard module if one can be found).
I'm also guessing that there aren't many standard/internal module files
that define multiple modules, so that the chances of a user running into
this is low.

I did minimal testing on this mod since it seems pretty clear that
I'm protecting against a segfault, so current testing shouldn't go down
this path anyway.  I did enough to make sure that tests related to
modules seem to be working as expected.