### PR TITLE
Use timedexec for custom regexp sub_test

### DIFF
--- a/test/regexp/ferguson/ctests/sub_test
+++ b/test/regexp/ferguson/ctests/sub_test
@@ -71,12 +71,15 @@ runtest() {
   EXE=$1
   DESC=$2
   echo Running $EXE
-  $EXE > /dev/null
+  `$CHPL_HOME/util/test/timedexec 500 $EXE > /dev/null`
   RETVAL=$?
   if [ $RETVAL -eq 0 ]
   then
     echo "[Success matching C regexp test $EXE $DESC]"
     rm $EXE
+  elif [ $RETVAL -eq 222 ]
+  then
+    echo "[Error Timed out executing regexp test $EXE $DESC]"
   else
     echo "[Error matching C regexp test $EXE $DESC]"
   fi


### PR DESCRIPTION
test/regexp/ferguson/ctests/sub_test is a custom sub_used for some regexp
stuff. I noticed linux32 testing was stuck on it for many hours even though I
expected timedexec to have killed it. Turns out that it uses a custom sub_test
that didn't have a time limit on it.

This fixes that so the custom sub_test uses timed exec with the default timeout
of 500 seconds. It doesn't honor a user set timeout or .timeout files or
anything, but this is better than it was.

Note that we didn't run into this before since the test only runs if
CHPL_ATOMICS=intrinsics and it was only with ae5101bdfd23 that linux32 (since
it has a newer version of gcc) started using intrinsics over locks.

I'm not sure why the test is timing out. I'll try to look at that tomorrow, but
I might end up punting and ask Michael.