### PR TITLE
Add todo extension to chpldoc sphinx project.

### DIFF
--- a/third-party/chpldoc-venv/chpldoc-sphinx-project/source/conf.py
+++ b/third-party/chpldoc-venv/chpldoc-sphinx-project/source/conf.py
@@ -31,6 +31,7 @@ needs_sphinx = '1.0'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.todo',
     'sphinxcontrib.chapeldomain',
 ]
 

--- a/third-party/chpldoc-venv/requirements.txt
+++ b/third-party/chpldoc-venv/requirements.txt
@@ -4,4 +4,4 @@ Pygments==2.0.2
 Sphinx==1.2.3
 docutils==0.12
 sphinx-rtd-theme==0.1.6
-sphinxcontrib-chapeldomain>=0.0.4
+sphinxcontrib-chapeldomain>=0.0.5


### PR DESCRIPTION
Add todo extension to the chpldoc sphinx project. …
This allows the todo and todolist directives to be used. E.g.

```chapel
/*
 * Foo does foo-y stuff.
 *
 * .. todo::
 *
 *     1. implement this procedure
 *     2. test it
 *     3. document it
 *
 *     In general, this might not be the best
 *     way to develop procs...
 */
proc foo() {}
```

Right now, the todo will not be displayed. If we want to display them, which we
probably do, we'll need to set the following in
third-party/chpldoc-venv/chpldoc-sphinx-project/source/conf.py:

```python
todo_include_todos = True
```

Also, bump sphinxcontrib-chapeldomain to use version 0.0.5 or higher.