### PR TITLE
Fix chpldoc issues.

### DIFF
--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -581,9 +581,9 @@ void generateSphinxOutput(std::string dirpath) {
     CHPL_HOME, "/third-party/chpldoc-venv/install/",
     CHPL_TARGET_PLATFORM, "/chpdoc-virtualenv/bin/activate");
 
-  // Run: `source $activate && cd $htmldir && $CHPL_MAKE html`
+  // Run: `. $activate && cd $htmldir && $CHPL_MAKE html`
   const char * cmd = astr(
-    "source ", activate,
+    ". ", activate,
     " && cd ", htmldir, " && ",
     CHPL_MAKE, " html");
   mysystem(cmd, "building html output from chpldoc sphinx project");

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -621,7 +621,17 @@ static std::string erase(std::string s, int count) {
       first = false;
       continue;
     }
-    line.erase(line.begin(), line.begin() + count);
+
+    // Check that string has at least 'count' characters to erase. If there are
+    // fewer than 'count', erase all characters in line.
+    size_t endIndex;
+    if (line.length() >= (size_t)count) {
+      endIndex = count;
+    } else {
+      endIndex = line.length();
+    }
+
+    line.erase(line.begin(), line.begin() + endIndex);
     result += line;
     result += std::string("\n");
   }

--- a/test/chpldoc/basics/hello.doc.out
+++ b/test/chpldoc/basics/hello.doc.out
@@ -1,4 +1,4 @@
-Module: nestFunctions
-   proc outer()
-      This the comment for the outer function 
+Module: hello
+   proc hello()
+      This method prints out a greeting.
 

--- a/test/chpldoc/basics/nestFunctions.doc.out
+++ b/test/chpldoc/basics/nestFunctions.doc.out
@@ -1,4 +1,4 @@
 Module: nestFunctions
    proc outer()
-       This the comment for the outer function 
+      This the comment for the outer function 
 

--- a/test/chpldoc/basics/parenthesesLess.doc.out
+++ b/test/chpldoc/basics/parenthesesLess.doc.out
@@ -1,11 +1,9 @@
 Module: parenthesesLess
    proc foo
-
    proc bar: bool
-
    proc foo2
-       Check to make sure they keep comments 
+      Check to make sure they keep comments 
 
    proc bar2: bool
-       Check to make sure this also keeps its comment 
+      Check to make sure this also keeps its comment 
 

--- a/test/chpldoc/linkage-spec/externTest.doc.out
+++ b/test/chpldoc/linkage-spec/externTest.doc.out
@@ -24,7 +24,7 @@ Module: externTest
       extern proc inside
          Comment for method inside module 
 
-      extern proc commentless()
+      extern proc commentless
       extern proc hasArg(val: int(64))
          Comment for method with an argument inside module 
 


### PR DESCRIPTION
When "erasing" comment prefixes, do not erase more chars than are in string.

For example, if line is empty, trying to "erase" three characters will result
in an exception in some compilers.

It appears that different STL implementations treat erasing non-existent
characters in different ways. Some consider it an error and raise, while other
silently ignore it. This solution should work regardless of STL implementation.

Also, use . instead of source when calling venv activate script. This portable
across sh shells, whereas source is a bash-ism.

Also also, fix chpldoc tests that were missed in merge.