### PR TITLE
Move deallocation of heap-allocated variables to incr clause of a CForLoop

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -33,6 +33,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "CForLoop.h"
 
 // Notes on
 //   makeHeapAllocations()    //invoked from parallel()
@@ -666,11 +667,29 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
         FnSymbol* fn = toFnSymbol(move->parentSymbol);
         SET_LINENO(var);
         if (fn && innermostBlock == fn->body)
+          // The block is a function body.
           fn->insertBeforeReturnAfterLabel(callChplHereFree(move->get(1)->copy()));
         else {
-          BlockStmt* block = toBlockStmt(innermostBlock);
-          INT_ASSERT(block);
-          block->insertAtTailBeforeGoto(callChplHereFree(move->get(1)->copy()));
+          // The block is some other kind of block.
+          if (CForLoop* cfl = toCForLoop(innermostBlock))
+          {
+            // The logical end of the loop block is as at the end of the
+            // increment clause.  It is assumed here, that if the innerMost
+            // block contained the entire for loop, then that block would not
+            // be the CForLoop block itself.  If a block contains nothing but a
+            // CForLoop and then the block structure is smashed flat, we lose
+            // the ability to distinguish these two cases.
+            BlockStmt* incr = cfl->incrBlockGet();
+            incr->insertAtTailBeforeGoto(callChplHereFree(move->get(1)->copy()));
+          }
+          // Other cases may need to be added here.
+          else
+          {
+            // A "normal" block.
+            BlockStmt* block = toBlockStmt(innermostBlock);
+            INT_ASSERT(block);
+            block->insertAtTailBeforeGoto(callChplHereFree(move->get(1)->copy()));
+          }
         }
       }
     }


### PR DESCRIPTION
In a C-style for loop, the code in the increment clause can depend on variables that are
declared within the body of the loop.  To avoid read-after-free errors, the freeing of
heap-allocated variable is moved to the end of the increment clause.

This sometimes leads to rather "fat" for-statements in the generated C output, but our
code generator does the right thing and it is still legal C code.  We could make the code
a bit prettier by enumerating the heap-allocated variables that are actually accessed in
the incr clause and then moving the free() calls for the rest of them back to the end of
the loop body.

[x] Full regression test run.