### PR TITLE
Remove util/docs/ from gen_release.

### DIFF
--- a/README
+++ b/README
@@ -62,7 +62,7 @@ capabilities in the interest of a simple and clean build.
 
 
 5) To ensure you have installed Chapel properly, you can optionally
-   run an automatic sanity check using few example programs:
+   run an automatic sanity check using a few example programs:
 
         gmake check
 

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -143,7 +143,6 @@ if ($no_clone == 0) {
     "third-party",
     "util/chplenv",
     "util/config",
-    "util/docs",
     "util/quickstart",
     "util/test"
 );


### PR DESCRIPTION
util/docs/ was removed with e90ae79, so it does not need to be bundled with the
release tarball.

Also, Fix typo in README.
"... check using few example programs:" -> "... check using a few example programs:"