### PR TITLE
Improve nightly emails with reply-to and bulk headers.

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -39,7 +39,9 @@ chomp($user);
 $debugmail = $ENV{'CHPL_NIGHTLY_DEBUG_EMAIL'};
 if ($debugmail eq "") {
     $debugmail = "$user\@cray.com";
-    $replymail = $debugemail;
+    if ($debug == 1) {
+        $replymail = $debugemail;
+    }
 }
 
 if ($cronrecipient eq "" and exists($ENV{"CHPL_NIGHTLY_CRON_RECIPIENT"})) {

--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -85,12 +85,20 @@ if ($debug == 1) {
 
 
 #
-# set mail options
+# set mail options. Default to util/test/send_email.py, if available and
+# working. If not available or not working, default to 'mail'.
 #
 $mailer = $ENV{'CHPL_MAILER'};
 if ($mailer eq "") {
-    $mailer = "mail";
+    $chplsendemail = "$chplhomedir/util/test/send_email.py";
+    `$chplsendemail --help >/dev/null 2>&1`;
+    if ($? == 0) {
+        $mailer = "$chplsendemail";
+    } else {
+        $mailer = "mail";
+    }
 }
+print "\$mailer = $mailer\n";
 
 $somethingfailed = 0;
 

--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -3,6 +3,7 @@
 # Mailing lists.
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net";
 $allmail = "chapel-test-results-all\@lists.sourceforge.net";
+$replymail = "chapel-developers\@lists.sourceforge.net";
 
 $printusage = 1;
 $debug = 1;
@@ -38,6 +39,7 @@ chomp($user);
 $debugmail = $ENV{'CHPL_NIGHTLY_DEBUG_EMAIL'};
 if ($debugmail eq "") {
     $debugmail = "$user\@cray.com";
+    $replymail = $debugemail;
 }
 
 if ($cronrecipient eq "" and exists($ENV{"CHPL_NIGHTLY_CRON_RECIPIENT"})) {
@@ -48,6 +50,7 @@ if ($cronrecipient ne "") {
     print "Overriding \$failuremail and \$allmail with: $cronrecipient.\n";
     $failuremail = $cronrecipient;
     $allmail = $cronrecipient;
+    $replymail = $cronrecipient;
 }
 
 
@@ -93,7 +96,7 @@ if ($mailer eq "") {
     $chplsendemail = "$chplhomedir/util/test/send_email.py";
     `$chplsendemail --help >/dev/null 2>&1`;
     if ($? == 0) {
-        $mailer = "$chplsendemail";
+        $mailer = "$chplsendemail --header=Reply-To=$replymail,Precedence=bulk";
     } else {
         $mailer = "mail";
     }

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -17,6 +17,7 @@ use Sys::Hostname;
 # Mailing lists.
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net";
 $allmail = "chapel-test-results-all\@lists.sourceforge.net";
+$replymail = "chapel-developers\@lists.sourceforge.net";
 
 $valgrind = 0;
 $interpret = 0;
@@ -220,6 +221,7 @@ chomp($user);
 $debugmail = $ENV{'CHPL_NIGHTLY_DEBUG_EMAIL'};
 if ($debugmail eq "") {
     $debugmail = "$user\@cray.com";
+    $replymail = $debugemail;
 }
 $today = `date +%w-%a`; chomp($today);
 $starttime = localtime;
@@ -235,6 +237,7 @@ if ($cronrecipient ne "") {
     print "Overriding \$failuremail and \$allmail with: $cronrecipient.\n";
     $failuremail = $cronrecipient;
     $allmail = $cronrecipient;
+    $replymail = $cronrecipient;
 }
 
 #
@@ -354,7 +357,7 @@ if ($mailer eq "") {
     $chplsendemail = "$chplhomedir/util/test/send_email.py";
     `$chplsendemail --help >/dev/null 2>&1`;
     if ($? == 0) {
-        $mailer = "$chplsendemail";
+        $mailer = "$chplsendemail --header=Reply-To=$replymail,Precedence=bulk";
     } else {
         $mailer = "mail";
     }

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -221,7 +221,9 @@ chomp($user);
 $debugmail = $ENV{'CHPL_NIGHTLY_DEBUG_EMAIL'};
 if ($debugmail eq "") {
     $debugmail = "$user\@cray.com";
-    $replymail = $debugemail;
+    if ($debug == 1) {
+        $replymail = $debugemail;
+    }
 }
 $today = `date +%w-%a`; chomp($today);
 $starttime = localtime;
@@ -363,6 +365,7 @@ if ($mailer eq "") {
     }
 }
 print "\$mailer = $mailer\n";
+
 
 $launchcmd = "$ENV{'CHPL_APP_LAUNCH_CMD'}";
 

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -361,6 +361,7 @@ if ($mailer eq "") {
     if ($? == 0) {
         $mailer = "$chplsendemail --header=Reply-To=$replymail,Precedence=bulk";
     } else {
+        print "[Error: send_email.py failed to run. Defaulting to 'mail'.]\n";
         $mailer = "mail";
     }
 }

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -324,14 +324,6 @@ $utildir = "$testbindirname/../../util";
 
 
 #
-# set mail options
-#
-$mailer = $ENV{'CHPL_MAILER'};
-if ($mailer eq "") {
-    $mailer = "mail";
-}
-
-#
 # Get test configuration name.
 #
 if (exists($ENV{'CHPL_NIGHTLY_TEST_CONFIG_NAME'})) {
@@ -352,6 +344,22 @@ $chplhomedir = abs_path("$cwd/../..");
 $testdir = "$chplhomedir/test";
 print "\$chplhomedir = $chplhomedir\n";
 
+
+#
+# set mail options. Default to util/test/send_email.py, if available and
+# working. If not available or not working, default to 'mail'.
+#
+$mailer = $ENV{'CHPL_MAILER'};
+if ($mailer eq "") {
+    $chplsendemail = "$chplhomedir/util/test/send_email.py";
+    `$chplsendemail --help >/dev/null 2>&1`;
+    if ($? == 0) {
+        $mailer = "$chplsendemail";
+    } else {
+        $mailer = "mail";
+    }
+}
+print "\$mailer = $mailer\n";
 
 $launchcmd = "$ENV{'CHPL_APP_LAUNCH_CMD'}";
 

--- a/util/cron/test-cygwin32.bat
+++ b/util/cron/test-cygwin32.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/cygdrive/c/Program Files/emacs-24.4/bin' ; export CHPL_HOME=$PWD ; export CHPL_MAILER=email ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -no-futures"
+c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/cygdrive/c/Program Files/emacs-24.4/bin' ; export CHPL_HOME=$PWD ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -no-futures"
 GOTO End
 
 :ErrExit

--- a/util/cron/test-cygwin64.bat
+++ b/util/cron/test-cygwin64.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows:/cygdrive/c/windows/System32/Wbem:/cygdrive/c/windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/usr/bin:/cygdrive/c/emacs-24.3/bin' ; export CHPL_HOME=$PWD ; export CHPL_MAILER=email ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -no-futures"
+c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows:/cygdrive/c/windows/System32/Wbem:/cygdrive/c/windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/usr/bin:/cygdrive/c/emacs-24.3/bin' ; export CHPL_HOME=$PWD ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -no-futures"
 GOTO End
 
 :ErrExit

--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -26,7 +26,7 @@ def main():
     send_email(args.recipients, body, args.subject, args.header, args.sender, args.smtp_host)
 
 
-def send_email(recipients, body, subject=None, headers=None, sender=None, smtp_host='localhost'):
+def send_email(recipients, body, subject=None, headers=None, sender=None, smtp_host=None):
     """Send email!
 
     :arg recipients: list of recipients. If only one, may be a string.
@@ -40,6 +40,7 @@ def send_email(recipients, body, subject=None, headers=None, sender=None, smtp_h
         recipients = [recipients]
     sender = sender or _default_sender()
     subject = subject or ''
+    smtp_host = smtp_host or _default_smtp_host()
 
     msg = email.mime.text.MIMEText(body)
 

--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -10,6 +10,7 @@ import email.mime.text
 import getpass
 import logging
 import optparse
+import os
 import smtplib
 import socket
 import sys
@@ -131,12 +132,12 @@ def _parse_args():
     mail_group.add_option(
         '-S', '--sender',
         default=_default_sender(),
-        help='Sender email address.'
+        help='Sender email address. (default: %default)'
     )
     mail_group.add_option(
         '--smtp-host',
         default=_default_smtp_host(),
-        help='SMTP host to use when sending email.'
+        help='SMTP host to use when sending email. (default: %default)'
     )
 
     parser.add_option_group(mail_group)

--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -54,7 +54,9 @@ def send_email(recipients, body, subject=None, headers=None, sender=None, smtp_h
     smtp = smtplib.SMTP(smtp_host)
     try:
         logging.info('Sending email to: {0} from: {1} subject: {2}'.format(
-            sender, ','.join(recipients), subject))
+            ','.join(recipients), sender, subject))
+        logging.debug('Email headers: {0}'.format(headers))
+        logging.debug('Email body length: {0}'.format(len(body)))
         smtp.sendmail(sender, recipients, msg.as_string())
     finally:
         smtp.quit()

--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -88,6 +88,12 @@ def _default_sender():
     return '{0}@{1}'.format(getpass.getuser(), socket.getfqdn())
 
 
+def _default_smtp_host():
+    """Return default smtp host, which is localhost unless CHPL_UTIL_SMTP_HOST is
+    set in environment.
+    """
+    return os.environ.get('CHPL_UTIL_SMTP_HOST', 'localhost')
+
 def _parse_args():
     """Parse and return command line arguments."""
     class NoWrapHelpFormatter(optparse.IndentedHelpFormatter):
@@ -129,7 +135,7 @@ def _parse_args():
     )
     mail_group.add_option(
         '--smtp-host',
-        default='localhost',
+        default=_default_smtp_host(),
         help='SMTP host to use when sending email.'
     )
 

--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+"""Portable email sender. Acts as replacement for mail, Mail, mailx,
+email (cygwin). Message body is taken from stdin.
+"""
+
+from __future__ import print_function
+
+try:
+    import envelopes
+except ImportError:
+    import traceback
+    traceback.print_exc()
+    print()
+    print('"envelopes" package is required. To install: pip install envelopes')
+    print('Alternatively, use a mail client like: mail, Mail, email, etc')
+    exit(1)
+
+import getpass
+import logging
+import optparse
+import socket
+import sys
+
+
+def main():
+    """Parse command line arguments and send email!"""
+    args = _parse_args()
+    _setup_logging(args.verbose)
+    body = sys.stdin.read()
+
+    # Send the email!
+    send_email(args.recipients, body, args.subject, args.header, args.sender, args.smtp_host)
+
+
+def send_email(recipients, body, subject=None, headers=None, sender=None, smtp_host='localhost'):
+    """Send email!
+
+    :arg recipients: list of recipients. If only one, may be a string.
+    :arg body: The email message body.
+    :arg subject: Optional subject. Defaults to ''.
+    :arg headers: Optional dict of headers to add.
+    :arg sender: Optional sender address. Defaults to <user>@<fqdn>
+    :arg smtp_host: Optional SMTP host. Defaults to 'localhost'.
+    """
+    if sender is None:
+        sender = _default_sender()
+
+    msg = envelopes.Envelope(
+        to_addr=recipients,
+        from_addr=sender,
+        subject=subject,
+        headers=headers,
+        text_body=body
+    )
+
+    logging.info('Sending email via {0}: {1}'.format(smtp_host, msg))
+    msg.send(smtp_host)
+
+
+def _parse_headers(option, opt, value, parser, *args, **kwargs):
+    """OptionParser callback function for parsing header values passed by user.
+
+    It takes values that have commas (e.g. the user specified
+    --header=Reply-To=X@y.com,Precedence=bulk), breaks them apart and adds the
+    individual name/value pairs to the dict of values.
+    """
+    # Get the existing values the parser knows about for this particular
+    # option.
+    value_dict = getattr(parser.values, option.dest, None) or {}
+
+    # Split the value provided.
+    parsed_vals = value.split(',')
+    for v in parsed_vals:
+        key, value = v.split('=')
+        value_dict[key] = value
+
+    # Set the updated dict to the oiption value.
+    setattr(parser.values, option.dest, value_dict)
+
+
+def _default_sender():
+    """Return default sender address, which is <user>@<hostname>."""
+    return '{0}@{1}'.format(getpass.getuser(), socket.getfqdn())
+
+
+def _parse_args():
+    """Parse and return command line arguments."""
+    class NoWrapHelpFormatter(optparse.IndentedHelpFormatter):
+        """Help formatter that does not wrap the description text."""
+
+        def _format_text(self, text):
+            return text
+
+    parser = optparse.OptionParser(
+        usage='usage: %prog [options] recipient_email [...]',
+        description=__doc__,
+        formatter=NoWrapHelpFormatter()
+    )
+
+    parser.add_option(
+        '-v', '--verbose',
+        action='store_true',
+        help='Verbose output.'
+    )
+
+    mail_group = optparse.OptionGroup(parser, 'Mail Options')
+
+    mail_group.add_option(
+        '-s', '--subject',
+        default=None,
+        help='Email subject.'
+    )
+    mail_group.add_option(
+        '-H', '--header',
+        action='callback', type='string',
+        callback=_parse_headers,
+        help=('Email header(s) of form NAME=VALUE. '
+              'Specify more than one with comma delimited list.')
+    )
+    mail_group.add_option(
+        '-S', '--sender',
+        default=_default_sender(),
+        help='Sender email address.'
+    )
+    mail_group.add_option(
+        '--smtp-host',
+        default='localhost',
+        help='SMTP host to use when sending email.'
+    )
+
+    parser.add_option_group(mail_group)
+
+    opts, args = parser.parse_args()
+
+    # Add all positional arguments as recipients.
+    opts.recipients = args
+    return opts
+
+
+def _setup_logging(verbose=False):
+    """Initialize logging and set level based on verbose.
+
+    :type verbose: bool
+    :arg verbose: When True, set log level to DEBUG.
+    """
+    log_level = logging.DEBUG if verbose else logging.WARN
+    logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s',
+                        level=log_level)
+    logging.debug('Verbose output enabled.')
+
+
+if __name__ == '__main__':
+    main()

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -5,6 +5,7 @@ use File::Basename;
 
 # Mailing lists.
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net";
+$replymail = "chapel-developers\@lists.sourceforge.net";
 
 $printusage = 0;
 if (@ARGV) {
@@ -43,6 +44,7 @@ chomp($user);
 $debugmail = $ENV{'CHPL_NIGHTLY_DEBUG_EMAIL'};
 if ($debugmail eq "") {
     $debugmail = "$user\@cray.com";
+    $replymail = $debugemail;
 }
 $today = `date +%w-%a`; chomp($today);
 
@@ -66,7 +68,7 @@ if ($mailer eq "") {
     $chplsendemail = "$chplhomedir/util/test/send_email.py";
     `$chplsendemail --help >/dev/null 2>&1`;
     if ($? == 0) {
-        $mailer = "$chplsendemail";
+        $mailer = "$chplsendemail --header=Reply-To=$replymail,Precedence=bulk";
     } else {
         $mailer = "mail";
     }
@@ -80,6 +82,7 @@ if ($cronrecipient eq "" and exists($ENV{"CHPL_NIGHTLY_CRON_RECIPIENT"})) {
 if ($cronrecipient ne "") {
     print "Overriding \$failuremail with: $cronrecipient.\n";
     $failuremail = $cronrecipient;
+    $replymail = $cronrecipient;
 }
 
 

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -58,12 +58,20 @@ if (exists($ENV{"BUILD_URL"})) {
 
 
 #
-# set mail options
+# set mail options. Default to util/test/send_email.py, if available and
+# working. If not available or not working, default to 'mail'.
 #
 $mailer = $ENV{'CHPL_MAILER'};
 if ($mailer eq "") {
-    $mailer = "mail";
+    $chplsendemail = "$chplhomedir/util/test/send_email.py";
+    `$chplsendemail --help >/dev/null 2>&1`;
+    if ($? == 0) {
+        $mailer = "$chplsendemail";
+    } else {
+        $mailer = "mail";
+    }
 }
+print "\$mailer = $mailer\n";
 
 if ($cronrecipient eq "" and exists($ENV{"CHPL_NIGHTLY_CRON_RECIPIENT"})) {
     $cronrecipient = $ENV{"CHPL_NIGHTLY_CRON_RECIPIENT"};

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -44,7 +44,9 @@ chomp($user);
 $debugmail = $ENV{'CHPL_NIGHTLY_DEBUG_EMAIL'};
 if ($debugmail eq "") {
     $debugmail = "$user\@cray.com";
-    $replymail = $debugemail;
+    if ($debug == 1) {
+        $replymail = $debugemail;
+    }
 }
 $today = `date +%w-%a`; chomp($today);
 


### PR DESCRIPTION
Add python send_email.py helper that provides portable mail client.

send_email.py acts like mail, Mail, mailx, email (cygwin), etc and provides a
command line interface for sending email. It provides a consistent, portable
feature set, unlike the other clients listed. This is done using python libraries.

Use new send_email.py util, when working, as nightly mailer. When using new
mail util, add reply-to and precedence headers to nightly emails. Reply-To goes
to chapel-developers. Precedence: bulk informs email clients that these messages
are not sent from a real person, so autoresponders etc will not be activated.