### PR TITLE
Update tests to avoid using 'this' intents on non-methods

### DIFF
--- a/test/functions/bradc/paramThis/funParamThis.chpl
+++ b/test/functions/bradc/paramThis/funParamThis.chpl
@@ -1,9 +1,10 @@
-proc param foo() {
+proc param int.foo() {
   writeln("In foo() with (nonsensical) param this");
 }
 
-proc foo() {
+proc int.foo() {
   writeln("In foo() with non-param this");
 }
 
-foo();
+2.foo("hi");
+

--- a/test/functions/bradc/paramThis/funParamThis.good
+++ b/test/functions/bradc/paramThis/funParamThis.good
@@ -1,3 +1,3 @@
-funParamThis.chpl:9: error: ambiguous call 'foo()'
-funParamThis.chpl:1: note: candidates are: param foo()
-funParamThis.chpl:5: note:                 foo()
+funParamThis.chpl:9: error: unresolved call 'int(64).foo("hi")'
+funParamThis.chpl:1: note: candidates are: param int.foo()
+funParamThis.chpl:5: note:                 int.foo()

--- a/test/functions/bradc/paramThis/funParamThis2.bad
+++ b/test/functions/bradc/paramThis/funParamThis2.bad
@@ -1,0 +1,1 @@
+In foo() with (nonsensical) param this

--- a/test/functions/bradc/paramThis/funParamThis2.future
+++ b/test/functions/bradc/paramThis/funParamThis2.future
@@ -1,0 +1,5 @@
+bug: non-methods should not support 'this' intents
+
+This test case exhibits behavior that we now think should be illegal:
+Applying 'this' intents to non-methods.  Discussed on email with
+Mike and Vass on Monday, Feb 9, 2015.

--- a/test/functions/bradc/paramThis/funParamThis2.good
+++ b/test/functions/bradc/paramThis/funParamThis2.good
@@ -1,1 +1,1 @@
-In foo() with (nonsensical) param this
+funParamThis2.chpl:1: error: 'this' intents can only be applied to methods


### PR DESCRIPTION
In a discussion with Mike and Vass today, it seemed odd to all of us
that one could/should be able to apply 'this' intents to functions
that are not methods.  To that end, I repurposed the two tests that
did this in my directory.

I changed funParamThis so that it still generates an error, but one
based on argument mismatch for two methods, in order to preserve that
resolution error messages distinguish between 'param' and 'non-param'
overloads.

I changed funParamThis2.chpl into a future, converting its current
.good into a .bad and putting a proposed error message into the .good
file.  If/when someone implements this, I'm open to other equivalently
useful wordings of the error message.