### PR TITLE
Do more combing in diff-ignoring-module-line-numbers.

### DIFF
--- a/test/parallel/begin/sungeun/initCopyWithBegin.prediff
+++ b/test/parallel/begin/sungeun/initCopyWithBegin.prediff
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-sed -e "s/REM[0-9]*/REMnnnn/" $2 > $2.prediff.tmp && mv $2.prediff.tmp $2

--- a/test/variables/sungeun/refvar-assign-with-cast.prediff
+++ b/test/variables/sungeun/refvar-assign-with-cast.prediff
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-sed -e "s/FUN[0-9]*/FUNnnnn/" $2 > $2.prediff.tmp && mv $2.prediff.tmp $2

--- a/test/variables/vass/ref-to-const-domain.prediff
+++ b/test/variables/vass/ref-to-const-domain.prediff
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-sed 's@internal error: FUN[0-9][0-9][0-9][0-9]@internal error: FUNnnnn@' \
-  $2 > $2.tmp
-mv $2.tmp $2

--- a/util/test/diff-ignoring-module-line-numbers
+++ b/util/test/diff-ignoring-module-line-numbers
@@ -16,6 +16,7 @@ tmptmp=`mktemp "tmp.XXXXXX"`
 command='
   \|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/
   s/chpl Version [0-9a-f.-]*$/chpl Version mmmm/
+  s/internal error: \([A-Z][A-Z][A-Z]\)[0-9][0-9][0-9][0-9] chpl Version mmmm/internal error: \1nnnn chpl Version mmmm/
 '
 
 sed -e "$command" $badfile > $badtmp


### PR DESCRIPTION
Recall that this script combs the actual output of a .future test to replace "nnnn":
* line number of an error message in internal/standard module
* chpl compiler version

This PR extends that with:
* line number of a compiler internal error
