### PR TITLE
Triage update for 2015-02-02 - 2015-02-09

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -628,11 +628,11 @@ Reviewed 2015-02-02
 ===================
 *pgi*
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
-undefined reference to chpl_bitops_debruijn64 (2014-07-14)
-----------------------------------------------------------
+undefined reference to chpl_bitops_debruijn64
+---------------------------------------------
 [Error matching compiler output for optimizations/cache-remote/ferguson/c_tests/chpl-cache-support-test (compopts: 1)]
 
 negative floating point 0.0 not supported
@@ -641,29 +641,22 @@ negative floating point 0.0 not supported
 [Error matching program output for types/complex/bradc/negativeimaginaryliteral]
 [Error matching program output for types/file/bradc/scalar/floatcomplexexceptions]
 
-consistent execution timeout
-----------------------------
+consistent execution timeout (no intrinsics for pgi, test is slow with locks)
+-----------------------------------------------------------------------------
 [Error: Timed out executing program domains/sungeun/assoc/parSafeMember (compopts: 1)]
-
-
-=== sporadic failures below ===
-
-target program died with signal 11, without coredump
-----------------------------------------------------
-[Error matching program output for stress/deitz/test_10k_begins] (xe-wb.prgenv-pgi  2014-11-16, xe-wb.pgi 2014-11-18, 2014-11-28)
 
 
 ==============================
 x?-wb.pgi
 Inherits 'x?-wb.*' and '*pgi*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ==============================
 
 
 ==============================
 x?-wb.prgenv-pgi
 Inherits 'x?-wb.*' and '*pgi*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ==============================
 
 PGC-W-0205-Argument mismatch for assert (xe-wb.prgenv-pgi 2015-01-29, can't reproduce)
@@ -674,7 +667,7 @@ all but a few failed
 ===========================
 xc-wb.host.prgenv-pgi
 Inherits 'x?-wb.prgenv-pgi'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===========================
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -286,14 +286,14 @@ Reviewed 2015-02-09
 ===================
 no-local
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
 =================================
 no-local.linux32
 Inherits 'linux32' and 'no-local'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 =================================
 
 
@@ -311,17 +311,17 @@ Comm count mismatch (lydia)
 
 === sporadic failures below ===
 
-execution timeout (2015-01-18)
----------------------------------------
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 3, execopts: 1)]
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 4, execopts: 1)]
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5, execopts: 1)]
+sporadic failures even after Sung quieted it down (frequently -- gbt/diten)
+ - see "gasnet+fifo: types/string/StringImpl/memLeaks/coforall.chpl" thread for details
+ - frequent for gasnet.fifo, infrequent for gasnet-fast, very infrequent for gasnet-everything
+---------------------------------------------------------------------------
+[Error matching program output for types/string/StringImpl/memLeaks/coforall] (2014-10-23..2014-11-30, ..., 2015-01-26, 2015-02-08)
 
 
 ===================
 gasnet-everything
 Inherits 'gasnet*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
@@ -329,13 +329,13 @@ Reviewed 2015-02-02
 
 sporadic execution timeout
 --------------------------
-[Error: Timed out executing program performance/ferguson/remote-tuple-write] (2015-01-23)
+[Error: Timed out executing program performance/ferguson/remote-tuple-write] (2015-01-23..2015-01-26)
 
 
 ===================
 gasnet-fast
 Inherits 'gasnet*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
@@ -343,53 +343,41 @@ Reviewed 2015-02-02
 
 sporadic execution timeout (regularly)
 --------------------------------------
-[Error: Timed out executing program studies/sudoku/dinan/sudoku] (2014-11-01, 2014-11-06, 2014-12-18)
+[Error: Timed out executing program studies/sudoku/dinan/sudoku] (2014-11-01, 2014-11-06, 2014-12-18, 2015-01-02)
 
 
 ===============================
 gasnet.darwin
 Inherits 'darwin' and 'gasnet*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===============================
 
 
 =============================
 gasnet.fifo
 Inherits 'gasnet*' and 'fifo'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 =============================
-
-consistent execution timeouts
------------------------------
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_likepy] (2014-11-28.. )
 
 
 === sporadic failures below ===
 
-sporadic failures even after Sung quieted it down (frequently -- gbt/diten)
----------------------------------------------------------------------------
-[Error matching program output for types/string/StringImpl/memLeaks/coforall] (2014-10-23..2014-11-30, 2014-12-14, 2014-12-17, 2015-01-21, 2015-01-26)
-
 sporadic execution timeouts (frequent)
 --------------------------------------
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_gaxpy] (2014-10-19, 2014-10-24, 2014-11-11, 2014-11-13, 2014-12-13, 2014-12-15, 2015-01-07, 2015-01-09, 2015-01-25)
-
-sporadic execution timeouts (infrequent)
-----------------------------------------
-[Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dDRtoBDTest] (2014-10-21, 2014-11-23, 2015-01-26)
+[Error: Timed out executing program studies/madness/aniruddha/madchap/test_gaxpy] (2014-10-19, 2014-10-24, 2014-11-11, 2014-11-13, 2014-12-13, 2014-12-15, 2015-01-07, 2015-01-09, 2015-01-25, 2015-02-08)
 
 
 =============================
 gasnet.llvm
 Inherits 'gasnet*' and 'llvm'
-Reviewed 2015-01-23
+Reviewed 2015-02-09
 =============================
 
 
 =============================
 gasnet.numa
 Inherits 'gasnet*' and 'numa'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 =============================
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -63,14 +63,14 @@ Future (bug: compiler reports an error incorrectly) [Success matching program ou
 ===================
 linux64
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
 ===================
 *32
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 Seg fault First run 2014-12-07
@@ -132,14 +132,14 @@ timeout (2015-02-05, first run) - (elliot/michael)
 ===================
 darwin
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
 ===================
 gnu.darwin
 Inherits 'darwin'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -146,14 +146,14 @@ Reviewed 2015-02-09
 ===================
 perf*
 Inherits 'general'
-Reviewed 2015-01-23
+Reviewed 2015-02-09
 ===================
 
 
 ===================
 perf.bradc-lnx
 Inherits 'perf*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 consistent failure due to insane memory usage (should get better with strings)
@@ -162,17 +162,10 @@ consistent failure due to insane memory usage (should get better with strings)
 [Error matching performance keys for studies/shootout/fasta/kbrady/fasta-lines]
 
 
-=== sporadic failures below ===
-
-sporadic execution timeout
---------------------------
-[Error: Timed out executing program performance/bharshbarg/range-forall] (2015-01-16..2015-01-21)
-
-
 ===================
 perf.chap03
 Inherits 'perf*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 consistent failure due to insane memory usage (should get better with strings)
@@ -183,14 +176,14 @@ consistent failure due to insane memory usage (should get better with strings)
 ===================
 perf.chap04
 Inherits 'perf*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
 ====================
 perf.chapel-shootout
 Inherits 'perf*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ====================
 
 consistent failure due to insane memory usage (should get better with strings)

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -49,12 +49,15 @@
 
 ===================
 general
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
-Whitespace mismatch (tvandoren, lydia)
---------------------------------------
-[Error matching .bad file for chpldoc/compflags/alphabetical/classFields]
+
+Compiler output mismatch for futures with scoping/shadowing (lydia)
+-------------------------------------------------------------------
+[Error matching .bad file for functions/kbrady/proc_scoping]
+[Error matching .bad file for modules/bradc/useFileSystemShadowsPath]
+Future (bug: compiler reports an error incorrectly) [Success matching program output for classes/vass/generic-parenthesesless-big1]
 
 
 ===================
@@ -315,8 +318,13 @@ Reviewed 2015-02-02
 ===================
 gasnet*
 Inherits 'no-local'
-Reviewed 2015-01-23
+Reviewed 2015-02-09
 ===================
+
+
+Comm count mismatch (lydia)
+---------------------------
+[Error matching program output for distributions/deitz/test_block_representation (compopts: 1)]
 
 
 === sporadic failures below ===

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -289,11 +289,6 @@ Inherits 'general'
 Reviewed 2015-02-02
 ===================
 
-Failed since added (2015-01-31) - bradc
----------------------------------------
-[Error matching program output for compflags/bradc/mungeUserIdents/testmunge (compopts: 1)]
-[Error matching program output for compflags/bradc/mungeUserIdents/testmunge (compopts: 2)]
-
 
 =================================
 no-local.linux32

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -558,11 +558,10 @@ $CHPL_HOME/modules/internal/ChapelArray.chpl:2119: error: unresolved call '(list
 --------------------------------------------------------------------------------------------
 
 
-
 ===================
 *intel*
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 test assertion failures (2014-09-21..)
@@ -579,21 +578,21 @@ binary files differ (2014-09-21..)
 ================================
 x?-wb.intel
 Inherits 'x?-wb.*' and '*intel*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ================================
 
 
 ================================
 x?-wb.prgenv-intel
 Inherits 'x?-wb.*' and '*intel*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ================================
 
 
 =============================
 xc-wb.host.prgenv-intel
 Inherits 'x?-wb.prgenv-intel'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 =============================
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -116,19 +116,14 @@ GMP [u]int(64)/32-bit c_[u]long mismatches (since first run, 2014-11-12)
 ===================
 linux32
 Inherits '*32'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
-timeout (2014-11-12, first run)
--------------------------------
-[Error: Timed out executing program domains/sungeun/assoc/parSafeMember (compopts: 1)]
 
-
-=== sporadic failures below ===
-
-sporadic signal 11
-------------------
-[Error matching program output for stress/deitz/test_10k_begins] (2014-11-13..2014-12-09, 2014-12-15, 2014-12-19, 2015-01-04)
+timeout (2015-02-05, first run) - (elliot/michael)
+--------------------------------------------------
+[Error Timed out executing regexp test ./regexp_channel_test Regexp Channels Test]
+[Error Timed out executing regexp test ./regexp_test Regexp Test]
 
 
 ===================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -216,15 +216,8 @@ Reviewed 2015-02-09
 ===================
 verify
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
-
-
-=== sporadic failures below ===
-
-sporadic execution timeout
---------------------------
-[Error: Timed out executing program stress/deitz/test_10k_begins] (2015-01-08)
 
 
 ===================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -384,7 +384,7 @@ Reviewed 2015-02-09
 ===================
 x?-wb.*
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
@@ -414,7 +414,7 @@ sporadic execution timeouts
 ==================
 *prgenv-*
 Inherits 'general'
-Reviewed 2015-01-23
+Reviewed 2015-02-09
 ===================
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -223,7 +223,7 @@ Reviewed 2015-02-09
 ===================
 valgrind
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 System I/O error.  Thomas has escalated to sys-ops

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -54,6 +54,7 @@ Reviewed 2015-02-09
 
 
 Compiler output mismatch for futures with scoping/shadowing (lydia)
+ - Note: Only shows up in configurations that test futures
 -------------------------------------------------------------------
 [Error matching .bad file for functions/kbrady/proc_scoping]
 [Error matching .bad file for modules/bradc/useFileSystemShadowsPath]
@@ -194,21 +195,21 @@ consistent failure due to insane memory usage (should get better with strings)
 ===================
 fast
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
 ===================
 memleaks.examples
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
 ============================
 memleaks
 Inherits 'memleaks.examples'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ============================
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -600,28 +600,28 @@ Reviewed 2015-02-02
 =======================
 *gnu*
 Inherits from 'linux64'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 =======================
 
 
 ==============================
 x?-wb.gnu
 Inherits 'x?-wb.*' and '*gnu*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ==============================
 
 
 ==============================
 x?-wb.prgenv-gnu
 Inherits 'x?-wb.*' and '*gnu*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ==============================
 
 
 ===========================
 xc-wb.host.prgenv-gnu
 Inherits 'x?-wb.prgenv-gnu'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===========================
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -693,12 +693,8 @@ Reviewed 2015-02-02
 ===================
 rhel64
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
-
-lack of -lnuma at user link time - gbt (2015-01-31..)
------------------------------------------------------
-all tests
 
 
 ===================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -421,7 +421,7 @@ Reviewed 2015-02-09
 ====================
 *prgenv-cray*
 Inherits '*prgenv-*'
-Reviewed 2015-02-29
+Reviewed 2015-02-09
 ====================
 
 An invalid option "openmp" appears on the command line. (2014-11-17 -- thomas/ben/et al)
@@ -529,14 +529,14 @@ output mismatch (first seen 2015-01-09, vass) (-hdevelop only?)
 ======================================
 x?-wb.prgenv-cray
 Inherits 'x?-wb.*' and '*prgenv-cray*'
-Reviewed 2015-02-29
+Reviewed 2015-02-09
 ======================================
 
 
 ============================
 xc-wb.prgenv-cray
 Inherits 'x?-wb.prgenv-cray'
-Reviewed 2015-02-29
+Reviewed 2015-02-09
 ============================
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -421,25 +421,8 @@ Reviewed 2015-02-09
 ====================
 *prgenv-cray*
 Inherits '*prgenv-*'
-Reviewed 2015-01-23
+Reviewed 2015-02-29
 ====================
-
-array index out of bounds - elliot (2015-01-30)
------------------------------------------------
-[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 2)]
-[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 3)]
-[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 4)]
-[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 5)]
-[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 2)]
-[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 3)]
-[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 4)]
-[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 5)]
-[Error matching program output for studies/lulesh/bradc/xyztuple/lulesh-dense-3tuple]
-[Error: Timed out executing program performance/compiler/bradc/cg-sparse-timecomp (compopts: 1)]
-
-infinite loop warning (since filed?)
-------------------------------------
-[Error matching compiler output for statements/vass/while-const1]
 
 An invalid option "openmp" appears on the command line. (2014-11-17 -- thomas/ben/et al)
 ----------------------------------------------------------------------------------------
@@ -467,23 +450,14 @@ filenames get printed by C compiler when multiple .c files are specified in one 
 [Error matching program output for modules/standard/BitOps/c-tests/popcount (compopts: 1)]
 [Error matching program output for modules/standard/BitOps/c-tests/popcount (compopts: 2)]
 
-unexpected compiler output (listing the source files) (2014-07-23)
+unexpected compiler output (listing the source files) (2014-07-23..)
 ------------------------------------------------------------------
 [Error matching program output for optimizations/cache-remote/ferguson/c_tests/chpl-cache-support-test (compopts: 1)]
 gbt is working on getting rid of this
 
-signal 11 (first seen 2014-03-02)
----------------------------------
-[Error matching program output for release/examples/benchmarks/shootout/meteor-fast]
-[Error matching program output for studies/shootout/meteor/kbrady/meteor-parallel-alt]
-
 error differs but within acceptable margin; should squash error printing
 ------------------------------------------------------------------------
 [Error matching program output for studies/hpcc/FFT/marybeth/fft]
-
-output mismatch (first seen 2015-01-09, vass)
----------------------------------------------
-[Error matching program output for modules/sungeun/test_safeSub]
 
 
 === sporadic failures below ===
@@ -506,6 +480,7 @@ sporadic dropping/mangling of output
 [Error matching program output for studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall (compopts: 1)] (2014-12-19)
 [Error matching program output for studies/hpcc/STREAMS/diten/stream-fragmented-local (compopts: 1)] (2015-01-26..2015-02-01)
 [Error matching program output for studies/shootout/nbody/sidelnik/nbody_orig_1] (2014-12-16)
+[Error matching program output for studies/hpcc/STREAMS/bradc/stream-slice (compopts: 1)] (2015-02-08)
 
 signal 11 (first seen ????-??-??)
 ---------------------------------
@@ -522,24 +497,53 @@ sporadic "error: attempt to dereference nil" (xe-wb.prgenv-cray 2015-01-18)
 [Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt]
 
 
+=== Only fail with optimizer on (CCE bugs/not seen nightly since using -O0) ===
+
+array index out of bounds (2015-01-30) (-hdevelop only?)
+-----------------------------------------------
+[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 2)]
+[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 3)]
+[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 4)]
+[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 5)]
+[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 2)]
+[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 3)]
+[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 4)]
+[Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 5)]
+[Error matching program output for studies/lulesh/bradc/xyztuple/lulesh-dense-3tuple]
+[Error: Timed out executing program performance/compiler/bradc/cg-sparse-timecomp (compopts: 1)]
+
+infinite loop warning (since filed?)
+------------------------------------
+[Error matching compiler output for statements/vass/while-const1]
+
+signal 11 (first seen 2014-03-02) (Note resolved with CCE 8.3.8)
+---------------------------------
+[Error matching program output for release/examples/benchmarks/shootout/meteor-fast]
+[Error matching program output for studies/shootout/meteor/kbrady/meteor-parallel-alt]
+
+output mismatch (first seen 2015-01-09, vass) (-hdevelop only?)
+---------------------------------------------
+[Error matching program output for modules/sungeun/test_safeSub]
+
+
 ======================================
 x?-wb.prgenv-cray
 Inherits 'x?-wb.*' and '*prgenv-cray*'
-Reviewed 2015-01-02
+Reviewed 2015-02-29
 ======================================
 
 
 ============================
 xc-wb.prgenv-cray
 Inherits 'x?-wb.prgenv-cray'
-Reviewed 2015-02-02
+Reviewed 2015-02-29
 ============================
 
 
 ============================
 xc-wb.host.prgenv-cray
 Inherits 'xc-wb.prgenv-cray'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ============================
 
 === sporadic failures below ===

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -770,21 +770,21 @@ Dies with signal 6
 ===================
 dist-block
 Inherits 'gasnet*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
 ===================
 dist-cyclic
 Inherits 'gasnet*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
 === sporadic failures below ===
 
-sporadic execution timeout (2015-01-18)
----------------------------------------
+sporadic execution timeout (very infrequent) (2014-11-04, 2015-01-18)
+---------------------------------------------------------------------
 [Error: Timed out executing program distributions/robust/arithmetic/kernels/hpl (compopts: 1)]
 [Error: Timed out executing program distributions/robust/arithmetic/kernels/jacobi]
 
@@ -792,5 +792,5 @@ sporadic execution timeout (2015-01-18)
 ===================
 dist-replicated
 Inherits 'gasnet*'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -758,12 +758,9 @@ QIO qio_err_to_int() == EEOF assertion error
 ===================
 baseline
 Inherits 'general'
-Reviewed 2015-01-23
+Reviewed 2015-02-09
 ===================
 
-Munge failure since added (2015-01-31) - bradc
-----------------------------------------------
-[Error matching program output for compflags/bradc/mungeUserIdents/testmunge-extern (compopts: 1)]
 
 Dies with signal 6
 ------------------

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -261,7 +261,7 @@ sporadic execution timeout
 ===================
 llvm
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 relies on macro in gmp.h -- not expected to work without effort (2014-09-18)
@@ -272,14 +272,14 @@ relies on macro in gmp.h -- not expected to work without effort (2014-09-18)
 ===================
 fifo
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 
 ===================
 numa
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -700,7 +700,7 @@ Reviewed 2015-02-09
 ===================
 cygwin*
 Inherits 'general'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===================
 
 check_channel assertion failure
@@ -719,7 +719,7 @@ consistent execution timeout (frequent)
 ===========================
 cygwin32
 Inherits 'cygwin*' and '*32'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ===========================
 
 Generated output "FAILED" (see below for sporadic): First run 2014-12-07
@@ -743,15 +743,11 @@ sporadic generated output "FAILED" (see above for solid): First run 2014-12-07
 ------------------------------------------------------------------------------
 [Error matching program output for studies/colostate/OMP-Jacobi-1D-Sliced-Diamond-Tiling (compopts: 1)] (2015-01-16..2015-01-19, 2015-01-21, 2015-01-25..2015-01-28, 2015-01-31..)
 
-sporadic os.unlink calls in sub_test failing due to resource being busy
-=======================================================================
-[Error running sub_test in *] (2014-12-11, 2014-12-12, 2014-12-15, 2014-12-16, 2014-12-17, 2014-12-18)
-
 
 ================================
 cygwin64
 Inherits 'cygwin*' and 'linux64'
-Reviewed 2015-02-02
+Reviewed 2015-02-09
 ================================
 
 QIO qio_err_to_int() == EEOF assertion error


### PR DESCRIPTION
Individual commits have a lot more detail about why things were added/removed.
There's roughly 1 commit per 'logical' grouping of configurations to make sure
I reviewed all configs. This is a high level summary of the important changes
from this week:

general:
 - remove chpldoc failures
 - add regressions for lydia's compiler output mismatch for futures with
   scoping/shadowing things (should be resolved tonight)

linux32:
 - Remove timeout for domains/sungeun/assoc/parSafeMember and add two timeouts
   for regexp tests. Both related to using intrinsics instead of locks

baseline and --no-local:
 - Remove munging failures

rhel:
 - remove the 'all failure' note, we have 0 failing tests with greg's -lnuma!

gasnet:
 - Add regression for lydia's distributions/deitz/test_block_representation
 - Remove some old timeouts
 - Add a note about types/string/StringImpl/memLeaks/coforall with a pointer to
   the email thread about it (it took me a while to track down what was going
   on when I was looking into this regression.)

pgi whitebox:
 - updated a few notes for and removed a regression from 12/2014

cray whitebox:
 - added a new instance of a dropped output test
 - pulled any tests that failed with the optimizer into a sub-section. I
   debated deleting them entirely, but figured I should leave them around for a
   little in case we don't stick with -O0 or we start a config that uses the
   optimizer or something
