### PR TITLE
Add some .timeout files to quiet gasnet timeouts

### DIFF
--- a/test/performance/ferguson/remote-tuple-write.timeout
+++ b/test/performance/ferguson/remote-tuple-write.timeout
@@ -1,0 +1,5 @@
+# This test has widely varying execution times for gasnet-qthreads.
+# Running with multiple trials on an empty machine timings are
+# between ~40 and ~600 seconds. We should be able to remove this
+# when we test on real hardware instead of using local spawning.
+900

--- a/test/studies/madness/aniruddha/madchap/test_gaxpy.timeout
+++ b/test/studies/madness/aniruddha/madchap/test_gaxpy.timeout
@@ -1,0 +1,4 @@
+# As of 02/09/15 this test times out occasionally for gasnet-fifo.
+# We should be able to remove this when we test on real hardware
+# instead of using local spawning.
+900

--- a/test/studies/sudoku/dinan/sudoku.timeout
+++ b/test/studies/sudoku/dinan/sudoku.timeout
@@ -1,0 +1,8 @@
+# This is a long running test that has occasional timeouts for
+# gasnet+qthreads. This test only uses 1 locale for gasnet testing
+# so it's not obvious if this timeout can be removed when we test on
+# real hardware. I would guess it can be, and that the slowdown is
+# because qthreads is built with over-subscription which makes
+# performance for an individual qthreads instance worse so that
+# multiple ones can run on a machine simultaneously.
+900


### PR DESCRIPTION
These three tests have pretty frequent timeouts in one or more gasnet
configuration. Adding .timeouts to eliminate the noise. We *should* be able to
remove all of them when we start testing on real hardware instead of doing
local spawning.

performance/ferguson/remote-tuple-write:
 - This test has widely varying execution times for gasnet-qthreads. Running
   with multiple trials on an empty machine timings are between ~40 and ~600
   seconds. We should be able to remove this when we test on real hardware
   instead of using local spawning.

studies/madness/aniruddha/madchap/test_gaxpy:
 - Added for same reasons as timeout for test_likepy in the same dir with #1236
 - As of 02/09/15 this test times out occasionally for gasnet-fifo.  We should
   be able to remove this when we test on real hardware instead of using local
   spawning.

studies/sudoku/dinan/sudoku:
 - This is a long running test that has occasional timeouts for
   gasnet+qthreads. This test only uses 1 locale for gasnet testing so it's not
   obvious if this timeout can be removed when we test on real hardware. I
   would guess it can be, and that the slowdown is because qthreads is built
   with over-subscription which makes performance for an individual qthreads
   instance worse so that multiple ones can run on a machine simultaneously.