### PR TITLE
Turn off futures for whitebox testing

### DIFF
--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -8,7 +8,7 @@ source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 
 # Run the tests!
-nightly_args="-cron -examples"
+nightly_args="-cron -examples -no-futures"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."

--- a/util/cron/test-xe-wb.bash
+++ b/util/cron/test-xe-wb.bash
@@ -8,7 +8,7 @@ source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 
 # Run the tests!
-nightly_args="-cron"
+nightly_args="-cron -no-futures"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."


### PR DESCRIPTION
No need to test futures on whiteboxes.

This should save a considerable amount of time for xe whitebox testing:
 - ~800 futures for each of the 7 configurations = a lot less tests

Probably won't do much for xc since xc just tests examples