### PR TITLE
Add .bad file for the test I added last week

### DIFF
--- a/test/modules/bradc/modNamedNewStringBreaks.bad
+++ b/test/modules/bradc/modNamedNewStringBreaks.bad
@@ -1,0 +1,1 @@
+internal error: PAR0322 chpl Version 1.10.0.63a2ca2


### PR DESCRIPTION
I held off on adding a .bad file for this test because of
sensitivity to changes in internal error line numbers.
Now that Vass has added the filter for such differences,
I'm adding it in after the fact.