### PR TITLE
Updates related to replaceVarUsesWithFormals()

### DIFF
--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -97,8 +97,9 @@ void buildDefaultDestructor(AggregateType* ct);
 // createTaskFunctions.cpp -> implementForallIntents.cpp
 extern Symbol* markPruned;
 extern Symbol* markUnspecified;
-void markOuterVarsWithIntents(SymbolMap* uses, CallExpr* byrefVars);
-void pruneThisArg(Symbol* parent, SymbolMap* uses);
+void markOuterVarsWithIntents(CallExpr* byrefVars, SymbolMap& uses);
+void replaceVarUses(Expr* topAst, SymbolMap& vars);
+void pruneThisArg(Symbol* parent, SymbolMap& uses);
 
 // deadCodeElimination.cpp
 void deadBlockElimination();

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -23,6 +23,7 @@
 #include "passes.h"
 #include "resolveIntents.h"
 #include "stmt.h"
+#include "stlUtil.h"
 
 
 //
@@ -198,14 +199,14 @@ addVarsToFormals(FnSymbol* fn, SymbolMap* vars) {
 
 static void
 replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
-  Vec<BaseAST*> asts;
-  collect_asts(fn->body, asts);
+  if (vars->n == 0) return;
+  std::vector<SymExpr*> symExprs;
+  collectSymExprsSTL(fn->body, symExprs);
   form_Map(SymbolMapElem, e, *vars) {
     if (Symbol* sym = e->key) {
       ArgSymbol* arg = toArgSymbol(e->value);
       Type* type = arg->type;
-      forv_Vec(BaseAST, ast, asts) {
-        if (SymExpr* se = toSymExpr(ast)) {
+      for_vector(SymExpr, se, symExprs) {
           if (se->var == sym) {
             if (type == sym->type) {
               se->var = arg;
@@ -234,7 +235,6 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
               }
             }
           }
-        }
       }
     }
   }


### PR DESCRIPTION
... and  replaceVarUsesWithFormals() -> replaceVarUses()

* Merged the two variants of replaceVarUsesWithFormals()
formerly in createTaskFunctions.cpp and implementForallIntents.cpp
into one, replaceVarUses().

* In the merged version, use collectSymExprsSTL() instead of collect_asts():
** use STL
** collect only SymExprs

* Also switched from collect_asts() to collectSymExprsSTL()
in replaceVarUsesWithFormals() in flattenFunctions.cpp.

* Changed the SymbolMap 'uses' in createTaskFunctions()
from heap-allocated (and not deleted) to stack-allocated
(so it is deallocated automatically). Changed the corresponding
formals from SymbolMap* to SymbolMap&.
** This change is similar to PR #1149
** While there, changed the order of formals in markOuterVarsWithIntents(), for consistency.
