### PR TITLE
Print symbol flags in a deterministic order.

### DIFF
--- a/compiler/AST/flags.cpp
+++ b/compiler/AST/flags.cpp
@@ -64,7 +64,7 @@ initFlags() {
 }
 
 void writeFlags(FILE* fp, Symbol* sym) {
-  for (int flagNum = FLAG_UNKNOWN+1; flagNum < NUM_FLAGS; flagNum++) {
+  for (int flagNum = FLAG_FIRST; flagNum <= FLAG_LAST; flagNum++) {
     if (sym->flags[flagNum]) {
       fprintf(fp, " \"%s\"", flagShortNames[flagNum]);
     }
@@ -84,7 +84,7 @@ viewFlags(BaseAST* ast) {
   if (!viewFlagsShort && !viewFlagsName && !viewFlagsComment)
     viewFlagsName = true;
   if (Symbol* sym = toSymbol(ast)) {
-    for (int flagNum = FLAG_UNKNOWN+1; flagNum < NUM_FLAGS; flagNum++) {
+    for (int flagNum = FLAG_FIRST; flagNum <= FLAG_LAST; flagNum++) {
       if (sym->flags[flagNum]) {
         if (viewFlagsName)
           printf("%s ", flagNames[flagNum]);

--- a/compiler/AST/flags.cpp
+++ b/compiler/AST/flags.cpp
@@ -29,6 +29,7 @@ typedef MapElem<const char*, int> FlagMapElem;
 // see also flags_list.h for description
 static FlagMap flagMap;
 static const char* flagNames[NUM_FLAGS];
+static const char* flagShortNames[NUM_FLAGS];
 static const char* flagComments[NUM_FLAGS];
 static bool flagPragma[NUM_FLAGS];
 
@@ -48,6 +49,7 @@ initFlags() {
 # define symbolFlag(NAME,PRAGMA,MAPNAME,COMMENT) \
     flagMap.put(astr(MAPNAME), NAME); \
     flagNames[NAME] = #NAME; \
+    flagShortNames[NAME] = astr(MAPNAME); \
     flagComments[NAME] = COMMENT; \
     flagPragma[NAME] = PRAGMA;
 # include "flags_list.h"
@@ -62,9 +64,9 @@ initFlags() {
 }
 
 void writeFlags(FILE* fp, Symbol* sym) {
-  form_Map(FlagMapElem, e, flagMap) {
-    if (sym->flags[e->value]) {
-      fprintf(fp, " \"%s\"", e->key);
+  for (int flagNum = FLAG_UNKNOWN+1; flagNum < NUM_FLAGS; flagNum++) {
+    if (sym->flags[flagNum]) {
+      fprintf(fp, " \"%s\"", flagShortNames[flagNum]);
     }
   }
 }
@@ -82,17 +84,17 @@ viewFlags(BaseAST* ast) {
   if (!viewFlagsShort && !viewFlagsName && !viewFlagsComment)
     viewFlagsName = true;
   if (Symbol* sym = toSymbol(ast)) {
-    form_Map(FlagMapElem, e, flagMap) {
-      if (sym->flags[e->value]) {
+    for (int flagNum = FLAG_UNKNOWN+1; flagNum < NUM_FLAGS; flagNum++) {
+      if (sym->flags[flagNum]) {
         if (viewFlagsName)
-          printf("%s ", flagNames[e->value]);
+          printf("%s ", flagNames[flagNum]);
         if (viewFlagsPragma)
-          printf("%s", flagPragma[e->value] ? "ypr " : "npr ");
+          printf("%s", flagPragma[flagNum] ? "ypr " : "npr ");
         if (viewFlagsShort)
-          printf("\"%s\" ", e->key);
+          printf("\"%s\" ", flagShortNames[flagNum]);
         if (viewFlagsComment)
           printf("// %s",
-                 *flagComments[e->value] ? flagComments[e->value] : "ncm");
+                 *flagComments[flagNum] ? flagComments[flagNum] : "ncm");
         printf("\n");
       }
     }

--- a/compiler/include/flags.h
+++ b/compiler/include/flags.h
@@ -52,12 +52,14 @@ enum Flag {
 # define symbolFlag(NAME,PRAGMA,MAPNAME,COMMENT) NAME,
 # include "flags_list.h"
 # undef symbolFlag
-  NUM_FLAGS
+  NUM_FLAGS,
+  FLAG_FIRST = FLAG_UNKNOWN + 1, // index of the first flag
+  FLAG_LAST  = NUM_FLAGS - 1     // index of the last flag
 };
 
 // only meaningful flags are allowed
 #define CHECK_FLAG(FLAG) \
-  INT_ASSERT(FLAG_UNKNOWN < (FLAG) && (FLAG) < NUM_FLAGS)
+  INT_ASSERT(FLAG_FIRST <= (FLAG) && (FLAG) <= FLAG_LAST)
 
 
 Flag pragma2flag(const char* str);


### PR DESCRIPTION
writeFlags() and viewFlags() used to iterate over the flags
via form_Map(..., flagMap), which results in non-deterministic order.
(These are presently used for debugging and logging only.)

Instead, use "for flagNum in FLAG_UNKNOWN+1..NUM_FLAGS-1".

To support the current printing functionality, I created
'flagShortNames', which stores flagMap's keys
in flagNum order, like flagNames[] et al.
