### PR TITLE
Update BaseAST::astTagAsString() for BlockStmt

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -395,7 +395,7 @@ const char* BaseAST::astTagAsString() const {
     case E_BlockStmt:
       {
         // see AST_CHILDREN_CALL
-        BlockStmt* stmt = toBlockStmt(this);
+        const BlockStmt* stmt = toConstBlockStmt(this);
         if (false) retval = "";
         else if (stmt->isCForLoop())     retval = "CForLoop";
         else if (stmt->isForLoop())      retval = "ForLoop";
@@ -564,49 +564,49 @@ GenRet baseASTCodegenString(const char* str)
 
 bool isLoopStmt(const BaseAST* a)
 {
-  BlockStmt* stmt = toBlockStmt(a);
+  const BlockStmt* stmt = toConstBlockStmt(a);
 
   return (stmt != 0 && stmt->isLoopStmt()) ? true : false;
 }
 
 bool isWhileStmt(const BaseAST* a)
 {
-  BlockStmt* stmt = toBlockStmt(a);
+  const BlockStmt* stmt = toConstBlockStmt(a);
 
   return (stmt != 0 && stmt->isWhileStmt()) ? true : false;
 }
 
 bool isWhileDoStmt(const BaseAST* a)
 {
-  BlockStmt* stmt = toBlockStmt(a);
+  const BlockStmt* stmt = toConstBlockStmt(a);
 
   return (stmt != 0 && stmt->isWhileDoStmt()) ? true : false;
 }
 
 bool isDoWhileStmt(const BaseAST* a)
 {
-  BlockStmt* stmt = toBlockStmt(a);
+  const BlockStmt* stmt = toConstBlockStmt(a);
 
   return (stmt != 0 && stmt->isDoWhileStmt()) ? true : false;
 }
 
 bool isParamForLoop(const BaseAST* a)
 {
-  BlockStmt* stmt = toBlockStmt(a);
+  const BlockStmt* stmt = toConstBlockStmt(a);
 
   return (stmt != 0 && stmt->isParamForLoop()) ? true : false;
 }
 
 bool isForLoop(const BaseAST* a)
 {
-  BlockStmt* stmt = toBlockStmt(a);
+  const BlockStmt* stmt = toConstBlockStmt(a);
 
   return (stmt != 0 && stmt->isForLoop()) ? true : false;
 }
 
 bool isCForLoop(const BaseAST* a)
 {
-  BlockStmt* stmt = toBlockStmt(a);
+  const BlockStmt* stmt = toConstBlockStmt(a);
 
   return (stmt != 0 && stmt->isCForLoop()) ? true : false;
 }

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -393,7 +393,17 @@ const char* BaseAST::astTagAsString() const {
       break;
 
     case E_BlockStmt:
-      retval = "BlockStmt";
+      {
+        // see AST_CHILDREN_CALL
+        BlockStmt* stmt = toBlockStmt(this);
+        if (false) retval = "";
+        else if (stmt->isCForLoop())     retval = "CForLoop";
+        else if (stmt->isForLoop())      retval = "ForLoop";
+        else if (stmt->isParamForLoop()) retval = "ParamForLoop";
+        else if (stmt->isWhileDoStmt())  retval = "WhileDoStmt";
+        else if (stmt->isDoWhileStmt())  retval = "DoWhileStmt";
+        else retval = "BlockStmt";
+      }
       break;
 
     case E_CondStmt:
@@ -552,49 +562,49 @@ GenRet baseASTCodegenString(const char* str)
 *                                                                             *
 ************************************** | *************************************/
 
-bool isLoopStmt(BaseAST* a)
+bool isLoopStmt(const BaseAST* a)
 {
   BlockStmt* stmt = toBlockStmt(a);
 
   return (stmt != 0 && stmt->isLoopStmt()) ? true : false;
 }
 
-bool isWhileStmt(BaseAST* a)
+bool isWhileStmt(const BaseAST* a)
 {
   BlockStmt* stmt = toBlockStmt(a);
 
   return (stmt != 0 && stmt->isWhileStmt()) ? true : false;
 }
 
-bool isWhileDoStmt(BaseAST* a)
+bool isWhileDoStmt(const BaseAST* a)
 {
   BlockStmt* stmt = toBlockStmt(a);
 
   return (stmt != 0 && stmt->isWhileDoStmt()) ? true : false;
 }
 
-bool isDoWhileStmt(BaseAST* a)
+bool isDoWhileStmt(const BaseAST* a)
 {
   BlockStmt* stmt = toBlockStmt(a);
 
   return (stmt != 0 && stmt->isDoWhileStmt()) ? true : false;
 }
 
-bool isParamForLoop(BaseAST* a)
+bool isParamForLoop(const BaseAST* a)
 {
   BlockStmt* stmt = toBlockStmt(a);
 
   return (stmt != 0 && stmt->isParamForLoop()) ? true : false;
 }
 
-bool isForLoop(BaseAST* a)
+bool isForLoop(const BaseAST* a)
 {
   BlockStmt* stmt = toBlockStmt(a);
 
   return (stmt != 0 && stmt->isForLoop()) ? true : false;
 }
 
-bool isCForLoop(BaseAST* a)
+bool isCForLoop(const BaseAST* a)
 {
   BlockStmt* stmt = toBlockStmt(a);
 

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -332,7 +332,9 @@ bool isCForLoop(const BaseAST* a);
 //   note: toDerivedClass is equivalent to dynamic_cast<DerivedClass*>
 //
 #define def_to_ast(Type) \
-  static inline Type * to##Type(const BaseAST* a) { return is##Type(a) ? (Type*)a : NULL; }
+  static inline Type * to##Type(BaseAST* a) { return is##Type(a) ? (Type*)a : NULL; } \
+  static inline const Type * toConst##Type(const BaseAST* a) \
+    { return is##Type(a) ? (const Type*)a : NULL; }
 
 def_to_ast(SymExpr)
 def_to_ast(UnresolvedSymExpr)

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -319,20 +319,20 @@ def_is_ast(EnumType)
 def_is_ast(AggregateType)
 #undef def_is_ast
 
-bool isLoopStmt(BaseAST* a);
-bool isWhileStmt(BaseAST* a);
-bool isWhileDoStmt(BaseAST* a);
-bool isDoWhileStmt(BaseAST* a);
-bool isParamForLoop(BaseAST* a);
-bool isForLoop(BaseAST* a);
-bool isCForLoop(BaseAST* a);
+bool isLoopStmt(const BaseAST* a);
+bool isWhileStmt(const BaseAST* a);
+bool isWhileDoStmt(const BaseAST* a);
+bool isDoWhileStmt(const BaseAST* a);
+bool isParamForLoop(const BaseAST* a);
+bool isForLoop(const BaseAST* a);
+bool isCForLoop(const BaseAST* a);
 
 //
 // safe downcast inlines: downcast BaseAST*, Expr*, Symbol*, or Type*
 //   note: toDerivedClass is equivalent to dynamic_cast<DerivedClass*>
 //
 #define def_to_ast(Type) \
-  static inline Type * to##Type(BaseAST* a) { return is##Type(a) ? (Type*)a : NULL; }
+  static inline Type * to##Type(const BaseAST* a) { return is##Type(a) ? (Type*)a : NULL; }
 
 def_to_ast(SymExpr)
 def_to_ast(UnresolvedSymExpr)


### PR DESCRIPTION
to return specific strings
for BlockStmt, such as "CForLoop", "ParamForLoop", etc.

This makes astTagAsString() structure similar to the current AST_CHILDREN_CALL().

While there, make the various isXXX and toXXX non-method functions
accept a pointer to 'const', making them available in more contexts,
e.g. in BaseAST::astTagAsString() (if I wanted to).
