### PR TITLE
Added nprint_view()-like funs that invoke AstDump and AstDumpToNode.

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -40,7 +40,17 @@ AstDump::AstDump() {
   mPath      =     0;
   mFP        =     0;
   mIndent    =     0;
-  mNeedSpace = false;
+  mNeedSpace   = false;
+  mDontCloseFP = false;
+}
+
+AstDump::AstDump(FILE* fp) {
+  mName      =     0;
+  mPath      =     0;
+  mFP        =     fp;
+  mIndent    =     0;
+  mNeedSpace   = false;
+  mDontCloseFP = true;
 }
 
 AstDump::~AstDump() {
@@ -80,6 +90,9 @@ bool AstDump::open(const ModuleSymbol* module, const char* passName, int passNum
 
 bool AstDump::close() {
   bool retval = false;
+
+  if (mDontCloseFP)
+    mFP = 0;
 
   if (mFP != 0 && fclose(mFP) == 0) {
     mFP    =    0;

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -33,6 +33,8 @@
 #include "stringutil.h"
 #include "symbol.h"
 #include "WhileStmt.h"
+#include "AstDump.h"
+#include "AstDumpToNode.h"
 
 #include <inttypes.h>
 
@@ -444,6 +446,43 @@ void mark_view(BaseAST* ast, int id) {
   printf("\n\n");
   fflush(stdout);
 }
+
+
+// feel free to propose a better name
+void astDump_view(int id) {
+  if (BaseAST* ast = aidWithError(id, "astDump_view"))
+    astDump_view(ast);
+}
+
+void astDump_view(BaseAST* ast) {
+  if (ast==NULL) {
+    printf("<NULL>");
+  } else {
+    AstDump logger(stdout);
+    ast->accept(&logger);
+  }
+  printf("\n\n");
+  fflush(stdout);
+}
+
+
+// feel free to propose a better name
+void astDumpToNode_view(int id) {
+  if (BaseAST* ast = aidWithError(id, "astDumpToNode_view"))
+    astDumpToNode_view(ast);
+}
+
+void astDumpToNode_view(BaseAST* ast) {
+  if (ast==NULL) {
+    printf("<NULL>");
+  } else {
+    AstDumpToNode logger(stdout);
+    ast->accept(&logger);
+  }
+  printf("\n\n");
+  fflush(stdout);
+}
+
 
 static bool log_need_space;
 

--- a/compiler/include/AstDump.h
+++ b/compiler/include/AstDump.h
@@ -43,6 +43,8 @@ public:
   //
   static  void     view(const char* passName, int passNum);
 
+                   AstDump(FILE* fp);
+                  ~AstDump();
 
   //
   // These functions are the "implementation" interface for the
@@ -92,7 +94,6 @@ public:
 
 private:
                    AstDump();
-                  ~AstDump();
 
   bool             open(const ModuleSymbol* module, const char* passName, int passNum);
   bool             close();
@@ -116,6 +117,7 @@ private:
   FILE*            mFP;             // The FILE* to the log file if the file is open
   int              mIndent;         // The indentation level.  Increments for each BlockStmt
   bool             mNeedSpace;      // Control inter-token spaces
+  bool             mDontCloseFP;    // true if mFP is owned by the user
 };
 
 #endif

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -55,6 +55,11 @@ void        mark_view(BaseAST* ast, int id);
 void        list_view(int id);
 void        list_view(BaseAST* ast);
 
+void        astDump_view(int id);
+void        astDump_view(BaseAST* ast);
+void        astDumpToNode_view(int id);
+void        astDumpToNode_view(BaseAST* ast);
+
 void        viewFlags(int id);
 
 void        map_view(SymbolMap* map);


### PR DESCRIPTION
This makes AstDump and AstDumpToNode loggers
invocable from gdb on individual AST nodes.

AstDumpToNode already supported the needed functionality.
AstDump required some changes.

The new functions' names, astDump*_view,
welcome improvement suggestions.
