### PR TITLE
Replace TABs in FFTW with pairs of spaces

### DIFF
--- a/test/users/npadmana/FFTW.chpl
+++ b/test/users/npadmana/FFTW.chpl
@@ -1,94 +1,94 @@
 // Wrapper for FFTW version 3.
 module FFTW {
 
-	use SysCTypes;
+  use SysCTypes;
 
-	// Define the various planner flags
-	// See Sec. 4.3.2 of FFTW manual "Planner Flags"
-	extern const FFTW_FORWARD : c_int;
-	extern const FFTW_BACKWARD : c_int;
-	extern const FFTW_ESTIMATE : c_uint;
-	extern const FFTW_MEASURE : c_uint;
-	extern const FFTW_PATIENT : c_uint;
-	extern const FFTW_EXHAUSTIVE : c_uint;
-	extern const FFTW_WISDOM_ONLY : c_uint;
-	extern const FFTW_DESTROY_INPUT : c_uint;
-	extern const FFTW_PRESERVE_INPUT : c_uint;
-	extern const FFTW_UNALIGNED : c_uint;
+  // Define the various planner flags
+  // See Sec. 4.3.2 of FFTW manual "Planner Flags"
+  extern const FFTW_FORWARD : c_int;
+  extern const FFTW_BACKWARD : c_int;
+  extern const FFTW_ESTIMATE : c_uint;
+  extern const FFTW_MEASURE : c_uint;
+  extern const FFTW_PATIENT : c_uint;
+  extern const FFTW_EXHAUSTIVE : c_uint;
+  extern const FFTW_WISDOM_ONLY : c_uint;
+  extern const FFTW_DESTROY_INPUT : c_uint;
+  extern const FFTW_PRESERVE_INPUT : c_uint;
+  extern const FFTW_UNALIGNED : c_uint;
 
-	// Define types
-	// NOTE : Ideally, this should be mapped to complex(128), but I seem to run into 
-	// casting issues in the C code. This is a simple workaround for now - although ugly.
-	// Also note that if one used complex types, then one would need to include complex.h at the command line
-	extern type fftw_complex = 2*real(64); // 4.1.1
-	extern type fftw_plan; // opaque type
-	type _cxptr = c_ptr(2*c_double);
-	type _rptr = c_ptr(c_double);
+  // Define types
+  // NOTE : Ideally, this should be mapped to complex(128), but I seem to run into 
+  // casting issues in the C code. This is a simple workaround for now - although ugly.
+  // Also note that if one used complex types, then one would need to include complex.h at the command line
+  extern type fftw_complex = 2*real(64); // 4.1.1
+  extern type fftw_plan; // opaque type
+  type _cxptr = c_ptr(2*c_double);
+  type _rptr = c_ptr(c_double);
 
-	// Planner functions
-	// Complex : 4.3.1
-	// NOTE : We pass in arrays using ref 
-	proc plan_dft(dims, ref in1 : fftw_complex, ref out1 : fftw_complex, sign : c_int, flags :c_uint) : fftw_plan
-		where (isHomogeneousTuple(dims))
-	{
-		extern proc fftw_plan_dft(rank : c_int, const ref n : c_int, in1 : _cxptr, out1 : _cxptr, sign : c_int, flags : c_uint) : fftw_plan;
-		// Make sure types are correct
-		param ndim : c_int = dims.size;
-		return fftw_plan_dft(ndim, dims(1), c_ptrTo(in1) : _cxptr, c_ptrTo(out1) : _cxptr, sign, flags);
-	}
+  // Planner functions
+  // Complex : 4.3.1
+  // NOTE : We pass in arrays using ref 
+  proc plan_dft(dims, ref in1 : fftw_complex, ref out1 : fftw_complex, sign : c_int, flags :c_uint) : fftw_plan
+    where (isHomogeneousTuple(dims))
+    {
+      extern proc fftw_plan_dft(rank : c_int, const ref n : c_int, in1 : _cxptr, out1 : _cxptr, sign : c_int, flags : c_uint) : fftw_plan;
+      // Make sure types are correct
+      param ndim : c_int = dims.size;
+      return fftw_plan_dft(ndim, dims(1), c_ptrTo(in1) : _cxptr, c_ptrTo(out1) : _cxptr, sign, flags);
+    }
 
-	// Real-to-complex and complex-to-real plans
-	// We handle these with a type parameter to let the user pass in an appropriately sized
-	// real array for the complex part, most usually when doing an in-place transform.
-	proc plan_dft_r2c(dims, ref in1 : ?t, ref out1 : ?tt, flags : c_uint) : fftw_plan 
-		where ((t.type==real(64)) || (t.type==fftw_complex)) && ((tt.type==real(64)) || (tt.type==fftw_complex)) && (isHomogeneousTuple(dims))
-	{
-		//-- define the extern proc
-		extern proc fftw_plan_dft_r2c(rank : c_int, const ref n : c_int,  in1 : _rptr,  out1 : _cxptr, flags : c_uint) : fftw_plan;
-		// Make sure types are correct
-		param ndim : c_int = dims.size;
-		return fftw_plan_dft_r2c(ndim,dims(1),c_ptrTo(in1) : c_ptr(c_double), c_ptrTo(out1) : _cxptr, flags);
-	}
-	proc plan_dft_c2r(dims, ref in1 : ?t, ref out1 : ?tt, flags : c_uint) : fftw_plan 
-		where ((t.type==real(64)) || (t.type==fftw_complex)) && ((tt.type==real(64)) || (tt.type==fftw_complex)) && (isHomogeneousTuple(dims))
-	{
-		//-- define the extern proc
-		extern proc fftw_plan_dft_c2r(rank : c_int, const ref n : c_int, in1 : _cxptr,  out1 : _rptr, flags : c_uint) : fftw_plan;
-		// Make sure types are correct
-		param ndim : c_int = dims.size;
-		return fftw_plan_dft_c2r(ndim, dims(1),c_ptrTo(in1) : _cxptr, c_ptrTo(out1) : c_ptr(c_double), flags);
-	}
-
-
+  // Real-to-complex and complex-to-real plans
+  // We handle these with a type parameter to let the user pass in an appropriately sized
+  // real array for the complex part, most usually when doing an in-place transform.
+  proc plan_dft_r2c(dims, ref in1 : ?t, ref out1 : ?tt, flags : c_uint) : fftw_plan 
+    where ((t.type==real(64)) || (t.type==fftw_complex)) && ((tt.type==real(64)) || (tt.type==fftw_complex)) && (isHomogeneousTuple(dims))
+    {
+      //-- define the extern proc
+      extern proc fftw_plan_dft_r2c(rank : c_int, const ref n : c_int,  in1 : _rptr,  out1 : _cxptr, flags : c_uint) : fftw_plan;
+      // Make sure types are correct
+      param ndim : c_int = dims.size;
+      return fftw_plan_dft_r2c(ndim,dims(1),c_ptrTo(in1) : c_ptr(c_double), c_ptrTo(out1) : _cxptr, flags);
+    }
+  proc plan_dft_c2r(dims, ref in1 : ?t, ref out1 : ?tt, flags : c_uint) : fftw_plan 
+    where ((t.type==real(64)) || (t.type==fftw_complex)) && ((tt.type==real(64)) || (tt.type==fftw_complex)) && (isHomogeneousTuple(dims))
+    {
+      //-- define the extern proc
+      extern proc fftw_plan_dft_c2r(rank : c_int, const ref n : c_int, in1 : _cxptr,  out1 : _rptr, flags : c_uint) : fftw_plan;
+      // Make sure types are correct
+      param ndim : c_int = dims.size;
+      return fftw_plan_dft_c2r(ndim, dims(1),c_ptrTo(in1) : _cxptr, c_ptrTo(out1) : c_ptr(c_double), flags);
+    }
 
 
 
-	// Using plans 
-	proc execute(const plan : fftw_plan) {
-		extern proc fftw_execute(const plan : fftw_plan);
-		fftw_execute(plan);
-	}
-	proc destroy_plan(plan : fftw_plan) {
-		extern proc fftw_destroy_plan(plan : fftw_plan);
-		fftw_destroy_plan(plan);
-	}
-	proc cleanup() {
-		extern proc fftw_cleanup();
-		cleanup();
-	}
 
 
-	// Utilities -- not in FFTW
-	proc abs((r,c) : fftw_complex) : real(64) {
-		return sqrt(r*r + c*c);
-	}
+  // Using plans 
+  proc execute(const plan : fftw_plan) {
+    extern proc fftw_execute(const plan : fftw_plan);
+    fftw_execute(plan);
+  }
+  proc destroy_plan(plan : fftw_plan) {
+    extern proc fftw_destroy_plan(plan : fftw_plan);
+    fftw_destroy_plan(plan);
+  }
+  proc cleanup() {
+    extern proc fftw_cleanup();
+    cleanup();
+  }
 
-	proc re((r,c) : fftw_complex) : real(64) {
-		return r;
-	}
-	proc im((r,c) : fftw_complex) : real(64) {
-		return c;
-	}
+
+  // Utilities -- not in FFTW
+  proc abs((r,c) : fftw_complex) : real(64) {
+    return sqrt(r*r + c*c);
+  }
+
+  proc re((r,c) : fftw_complex) : real(64) {
+    return r;
+  }
+  proc im((r,c) : fftw_complex) : real(64) {
+    return c;
+  }
 
 
 }

--- a/test/users/npadmana/FFTWsegfault.chpl
+++ b/test/users/npadmana/FFTWsegfault.chpl
@@ -6,100 +6,100 @@ module FFTWsegfault {
   // NOTE: See the three writeln's below which, when uncommented, make
   // the code work
 
-	use SysCTypes;
+  use SysCTypes;
 
-	// Define the various planner flags
-	// See Sec. 4.3.2 of FFTW manual "Planner Flags"
-	extern const FFTW_FORWARD : c_int;
-	extern const FFTW_BACKWARD : c_int;
-	extern const FFTW_ESTIMATE : c_uint;
-	extern const FFTW_MEASURE : c_uint;
-	extern const FFTW_PATIENT : c_uint;
-	extern const FFTW_EXHAUSTIVE : c_uint;
-	extern const FFTW_WISDOM_ONLY : c_uint;
-	extern const FFTW_DESTROY_INPUT : c_uint;
-	extern const FFTW_PRESERVE_INPUT : c_uint;
-	extern const FFTW_UNALIGNED : c_uint;
+  // Define the various planner flags
+  // See Sec. 4.3.2 of FFTW manual "Planner Flags"
+  extern const FFTW_FORWARD : c_int;
+  extern const FFTW_BACKWARD : c_int;
+  extern const FFTW_ESTIMATE : c_uint;
+  extern const FFTW_MEASURE : c_uint;
+  extern const FFTW_PATIENT : c_uint;
+  extern const FFTW_EXHAUSTIVE : c_uint;
+  extern const FFTW_WISDOM_ONLY : c_uint;
+  extern const FFTW_DESTROY_INPUT : c_uint;
+  extern const FFTW_PRESERVE_INPUT : c_uint;
+  extern const FFTW_UNALIGNED : c_uint;
 
-	// Define types
-	// NOTE : Ideally, this should be mapped to complex(128), but I seem to run into 
-	// casting issues in the C code. This is a simple workaround for now - although ugly.
-	// Also note that if one used complex types, then one would need to include complex.h at the command line
-	extern type fftw_complex = 2*real(64); // 4.1.1
-	extern type fftw_plan; // opaque type
-	type _cxptr = c_ptr(2*c_double);
-	type _rptr = c_ptr(c_double);
+  // Define types
+  // NOTE : Ideally, this should be mapped to complex(128), but I seem to run into 
+  // casting issues in the C code. This is a simple workaround for now - although ugly.
+  // Also note that if one used complex types, then one would need to include complex.h at the command line
+  extern type fftw_complex = 2*real(64); // 4.1.1
+  extern type fftw_plan; // opaque type
+  type _cxptr = c_ptr(2*c_double);
+  type _rptr = c_ptr(c_double);
 
-	// Planner functions
-	// Complex : 4.3.1
-	// NOTE : We pass in arrays using ref 
-	proc plan_dft(dims, ref in1 : fftw_complex, ref out1 : fftw_complex, sign : c_int, flags :c_uint) : fftw_plan
-		where (isHomogeneousTuple(dims))
-	{
-		extern proc fftw_plan_dft(rank : c_int, const ref n : c_int, in1 : _cxptr, out1 : _cxptr, sign : c_int, flags : c_uint) : fftw_plan;
-		// Make sure types are correct
-		param ndim : c_int = dims.size;
-		var dims1 : ndim*c_int = dims;
-                if useWorkaround then writeln(dims1);
-		return fftw_plan_dft(ndim, dims1(1), c_ptrTo(in1) : _cxptr, c_ptrTo(out1) : _cxptr, sign, flags);
-	}
+  // Planner functions
+  // Complex : 4.3.1
+  // NOTE : We pass in arrays using ref 
+  proc plan_dft(dims, ref in1 : fftw_complex, ref out1 : fftw_complex, sign : c_int, flags :c_uint) : fftw_plan
+    where (isHomogeneousTuple(dims))
+    {
+      extern proc fftw_plan_dft(rank : c_int, const ref n : c_int, in1 : _cxptr, out1 : _cxptr, sign : c_int, flags : c_uint) : fftw_plan;
+      // Make sure types are correct
+      param ndim : c_int = dims.size;
+      var dims1 : ndim*c_int = dims;
+      if useWorkaround then writeln(dims1);
+      return fftw_plan_dft(ndim, dims1(1), c_ptrTo(in1) : _cxptr, c_ptrTo(out1) : _cxptr, sign, flags);
+    }
 
-	// Real-to-complex and complex-to-real plans
-	// We handle these with a type parameter to let the user pass in an appropriately sized
-	// real array for the complex part, most usually when doing an in-place transform.
-	proc plan_dft_r2c(dims, ref in1 : ?t, ref out1 : ?tt, flags : c_uint) : fftw_plan 
-		where ((t.type==real(64)) || (t.type==fftw_complex)) && ((tt.type==real(64)) || (tt.type==fftw_complex)) && (isHomogeneousTuple(dims))
-	{
-		//-- define the extern proc
-		extern proc fftw_plan_dft_r2c(rank : c_int, const ref n : c_int,  in1 : _rptr,  out1 : _cxptr, flags : c_uint) : fftw_plan;
-		// Make sure types are correct
-		param ndim : c_int = dims.size;
-		var dims1 : ndim*c_int = dims;
-                if useWorkaround then writeln(dims1);
-		return fftw_plan_dft_r2c(ndim,dims1(1),c_ptrTo(in1) : c_ptr(c_double), c_ptrTo(out1) : _cxptr, flags);
-	}
-	proc plan_dft_c2r(dims, ref in1 : ?t, ref out1 : ?tt, flags : c_uint) : fftw_plan 
-		where ((t.type==real(64)) || (t.type==fftw_complex)) && ((tt.type==real(64)) || (tt.type==fftw_complex)) && (isHomogeneousTuple(dims))
-	{
-		//-- define the extern proc
-		extern proc fftw_plan_dft_c2r(rank : c_int, const ref n : c_int, in1 : _cxptr,  out1 : _rptr, flags : c_uint) : fftw_plan;
-		// Make sure types are correct
-		param ndim : c_int = dims.size;
-		var dims1 : ndim*c_int = dims;
-                if useWorkaround then writeln(dims1);
-		return fftw_plan_dft_c2r(ndim, dims1(1),c_ptrTo(in1) : _cxptr, c_ptrTo(out1) : c_ptr(c_double), flags);
-	}
-
-
+  // Real-to-complex and complex-to-real plans
+  // We handle these with a type parameter to let the user pass in an appropriately sized
+  // real array for the complex part, most usually when doing an in-place transform.
+  proc plan_dft_r2c(dims, ref in1 : ?t, ref out1 : ?tt, flags : c_uint) : fftw_plan 
+    where ((t.type==real(64)) || (t.type==fftw_complex)) && ((tt.type==real(64)) || (tt.type==fftw_complex)) && (isHomogeneousTuple(dims))
+    {
+      //-- define the extern proc
+      extern proc fftw_plan_dft_r2c(rank : c_int, const ref n : c_int,  in1 : _rptr,  out1 : _cxptr, flags : c_uint) : fftw_plan;
+      // Make sure types are correct
+      param ndim : c_int = dims.size;
+      var dims1 : ndim*c_int = dims;
+      if useWorkaround then writeln(dims1);
+      return fftw_plan_dft_r2c(ndim,dims1(1),c_ptrTo(in1) : c_ptr(c_double), c_ptrTo(out1) : _cxptr, flags);
+    }
+  proc plan_dft_c2r(dims, ref in1 : ?t, ref out1 : ?tt, flags : c_uint) : fftw_plan 
+    where ((t.type==real(64)) || (t.type==fftw_complex)) && ((tt.type==real(64)) || (tt.type==fftw_complex)) && (isHomogeneousTuple(dims))
+    {
+      //-- define the extern proc
+      extern proc fftw_plan_dft_c2r(rank : c_int, const ref n : c_int, in1 : _cxptr,  out1 : _rptr, flags : c_uint) : fftw_plan;
+      // Make sure types are correct
+      param ndim : c_int = dims.size;
+      var dims1 : ndim*c_int = dims;
+      if useWorkaround then writeln(dims1);
+      return fftw_plan_dft_c2r(ndim, dims1(1),c_ptrTo(in1) : _cxptr, c_ptrTo(out1) : c_ptr(c_double), flags);
+    }
 
 
 
-	// Using plans 
-	proc execute(const plan : fftw_plan) {
-		extern proc fftw_execute(const plan : fftw_plan);
-		fftw_execute(plan);
-	}
-	proc destroy_plan(plan : fftw_plan) {
-		extern proc fftw_destroy_plan(plan : fftw_plan);
-		fftw_destroy_plan(plan);
-	}
-	proc cleanup() {
-		extern proc fftw_cleanup();
-		cleanup();
-	}
 
 
-	// Utilities -- not in FFTW
-	proc abs((r,c) : fftw_complex) : real(64) {
-		return sqrt(r*r + c*c);
-	}
+  // Using plans 
+  proc execute(const plan : fftw_plan) {
+    extern proc fftw_execute(const plan : fftw_plan);
+    fftw_execute(plan);
+  }
+  proc destroy_plan(plan : fftw_plan) {
+    extern proc fftw_destroy_plan(plan : fftw_plan);
+    fftw_destroy_plan(plan);
+  }
+  proc cleanup() {
+    extern proc fftw_cleanup();
+    cleanup();
+  }
 
-	proc re((r,c) : fftw_complex) : real(64) {
-		return r;
-	}
-	proc im((r,c) : fftw_complex) : real(64) {
-		return c;
-	}
+
+  // Utilities -- not in FFTW
+  proc abs((r,c) : fftw_complex) : real(64) {
+    return sqrt(r*r + c*c);
+  }
+
+  proc re((r,c) : fftw_complex) : real(64) {
+    return r;
+  }
+  proc im((r,c) : fftw_complex) : real(64) {
+    return c;
+  }
 
 
 }

--- a/test/users/npadmana/testFFTW.chpl
+++ b/test/users/npadmana/testFFTW.chpl
@@ -2,137 +2,137 @@ use FFTW;
 
 
 proc printcmp(x, y) {
-	var err = max reduce abs(x-y);
-	//writeln("----");
-	//writeln(x);
-	//writeln("**");
-	//writeln(y);
-	//writeln("----");
-	writeln(err);
+  var err = max reduce abs(x-y);
+  //writeln("----");
+  //writeln(x);
+  //writeln("**");
+  //writeln(y);
+  //writeln("----");
+  writeln(err);
 }
 
 proc runtest(param ndim : int, fn : string) {
-	/* Read in the data and set up the domains appropriately */
-	var dims : ndim*int(32); 
-	var D : domain(ndim);
-	// Define ranges here
-	var rD,cD,reD,imD : domain(ndim,int,true); 
-	var A,B,goodA,goodB : [D] fftw_complex;
-	{
-		var f = open(fn,iomode.r).reader(kind=iokind.little);
-		for ii in 1..ndim {
-			f.read(dims(ii));
-		}
-		// Note compiler does not automatically fold select on params
-		if (ndim == 1) {
-			D = 0.. #dims(ndim);
-		}
-		if (ndim == 2) {
-			D = {0.. #dims(1),0.. #dims(ndim)};
-		}
-		if (ndim == 3) {
-			D = {0.. #dims(1),0.. #dims(2), 0.. #dims(ndim)};
-		}
-		for (r,c) in goodA {
-			f.read(r);
-			c = 0;
-		}
-		for (r,c) in goodB {
-			f.read(r); f.read(c);
-		}
-		f.close();
-		writeln("Data read...");
-	}
-	// Set up domains based on dimension size
-	var first : ndim*int;
-	if (ndim==1) {
-		var ldim = dims(1)/2 + 1;
-		// Domains for real FFT
-		rD = 0.. #(2*ldim); // Padding to do in place transforms
-		cD = 0.. #ldim;
-		// Define domains to extract the real and imaginary parts for inplace transforms
-		reD = rD[0..(2*ldim-1) by 2]; // Padding to do in place transforms
-		imD = rD[1..(2*ldim-1) by 2]; // Padding to do in place transforms
-		first=(0,);
-	}
-	if (ndim==2) {
-		// Domains for real FFT
-		var ldim = dims(2)/2+1;
-		rD = {0.. #dims(1),0.. #(2*ldim)}; // Padding to do in place transforms
-		cD = {0.. #dims(1),0.. #ldim};
-		// Define domains to extract the real and imaginary parts for in place transforms
-		reD = rD[..,0..(2*ldim-1) by 2]; // Padding to do in place transforms
-		imD = rD[..,1..(2*ldim-1) by 2]; // Padding to do in place transforms
-		first=(0,0);
-	}
-	if (ndim==3) {
-		// Domains for real FFT
-		var ldim = dims(3)/2+1;
-		rD = {0.. #dims(1),0.. #dims(2),0.. #(2*ldim)}; // Padding to do in place transforms
-		cD = {0.. #dims(1),0.. #dims(2),0.. #ldim};
-		// Define domains to extract the real and imaginary parts for in place transforms
-		reD = rD[..,..,0..(2*ldim-1) by 2]; // Padding to do in place transforms
-		imD = rD[..,..,1..(2*ldim-1) by 2]; // Padding to do in place transforms
-		first=(0,0,0);
-	}
+  /* Read in the data and set up the domains appropriately */
+  var dims : ndim*int(32); 
+  var D : domain(ndim);
+  // Define ranges here
+  var rD,cD,reD,imD : domain(ndim,int,true); 
+  var A,B,goodA,goodB : [D] fftw_complex;
+  {
+    var f = open(fn,iomode.r).reader(kind=iokind.little);
+    for ii in 1..ndim {
+      f.read(dims(ii));
+    }
+    // Note compiler does not automatically fold select on params
+    if (ndim == 1) {
+      D = 0.. #dims(ndim);
+    }
+    if (ndim == 2) {
+      D = {0.. #dims(1),0.. #dims(ndim)};
+    }
+    if (ndim == 3) {
+      D = {0.. #dims(1),0.. #dims(2), 0.. #dims(ndim)};
+    }
+    for (r,c) in goodA {
+      f.read(r);
+      c = 0;
+    }
+    for (r,c) in goodB {
+      f.read(r); f.read(c);
+    }
+    f.close();
+    writeln("Data read...");
+  }
+  // Set up domains based on dimension size
+  var first : ndim*int;
+  if (ndim==1) {
+    var ldim = dims(1)/2 + 1;
+    // Domains for real FFT
+    rD = 0.. #(2*ldim); // Padding to do in place transforms
+    cD = 0.. #ldim;
+    // Define domains to extract the real and imaginary parts for inplace transforms
+    reD = rD[0..(2*ldim-1) by 2]; // Padding to do in place transforms
+    imD = rD[1..(2*ldim-1) by 2]; // Padding to do in place transforms
+    first=(0,);
+  }
+  if (ndim==2) {
+    // Domains for real FFT
+    var ldim = dims(2)/2+1;
+    rD = {0.. #dims(1),0.. #(2*ldim)}; // Padding to do in place transforms
+    cD = {0.. #dims(1),0.. #ldim};
+    // Define domains to extract the real and imaginary parts for in place transforms
+    reD = rD[..,0..(2*ldim-1) by 2]; // Padding to do in place transforms
+    imD = rD[..,1..(2*ldim-1) by 2]; // Padding to do in place transforms
+    first=(0,0);
+  }
+  if (ndim==3) {
+    // Domains for real FFT
+    var ldim = dims(3)/2+1;
+    rD = {0.. #dims(1),0.. #dims(2),0.. #(2*ldim)}; // Padding to do in place transforms
+    cD = {0.. #dims(1),0.. #dims(2),0.. #ldim};
+    // Define domains to extract the real and imaginary parts for in place transforms
+    reD = rD[..,..,0..(2*ldim-1) by 2]; // Padding to do in place transforms
+    imD = rD[..,..,1..(2*ldim-1) by 2]; // Padding to do in place transforms
+    first=(0,0,0);
+  }
 
-	// FFTW does not normalize inverse transform, set up norm
-	var norm = * reduce dims;
+  // FFTW does not normalize inverse transform, set up norm
+  var norm = * reduce dims;
 
 
-	// FFT testing here
-	var fwd = plan_dft(dims, A[first],B[first],FFTW_FORWARD,FFTW_ESTIMATE);
-	var rev = plan_dft(dims, B[first],A[first],FFTW_BACKWARD,FFTW_ESTIMATE);
-	// Test forward and reverse transform
-	A = goodA;
-	execute(fwd);
-	printcmp(B,goodB);
-	execute(rev);
-	A /= norm; 
-	printcmp(A,goodA);
-	destroy_plan(fwd);
-	destroy_plan(rev);
+  // FFT testing here
+  var fwd = plan_dft(dims, A[first],B[first],FFTW_FORWARD,FFTW_ESTIMATE);
+  var rev = plan_dft(dims, B[first],A[first],FFTW_BACKWARD,FFTW_ESTIMATE);
+  // Test forward and reverse transform
+  A = goodA;
+  execute(fwd);
+  printcmp(B,goodB);
+  execute(rev);
+  A /= norm; 
+  printcmp(A,goodA);
+  destroy_plan(fwd);
+  destroy_plan(rev);
 
-	// Test in-place transforms
-	fwd = plan_dft(dims,A[first],A[first],FFTW_FORWARD,FFTW_ESTIMATE);
-	rev = plan_dft(dims,A[first],A[first],FFTW_BACKWARD,FFTW_ESTIMATE);
-	A = goodA;
-	// Test forward and reverse transform
-	A = goodA;
-	execute(fwd);
-	printcmp(A,goodB);
-	execute(rev);
-	A /= norm; // FFTW does an unnormalized transform
-	printcmp(A,goodA);
-	destroy_plan(fwd);
-	destroy_plan(rev);
+  // Test in-place transforms
+  fwd = plan_dft(dims,A[first],A[first],FFTW_FORWARD,FFTW_ESTIMATE);
+  rev = plan_dft(dims,A[first],A[first],FFTW_BACKWARD,FFTW_ESTIMATE);
+  A = goodA;
+  // Test forward and reverse transform
+  A = goodA;
+  execute(fwd);
+  printcmp(A,goodB);
+  execute(rev);
+  A /= norm; // FFTW does an unnormalized transform
+  printcmp(A,goodA);
+  destroy_plan(fwd);
+  destroy_plan(rev);
 
-	// Testing r2c and c2r
-	var rA : [D] real(64); // No padding for an out-of place transform
-	var cB : [cD] fftw_complex;
-	fwd = plan_dft_r2c(dims,rA[first],cB[first],FFTW_ESTIMATE);
-	rev = plan_dft_c2r(dims,cB[first],rA[first],FFTW_ESTIMATE);
-	rA[D] = re(goodA);
-	execute(fwd);
-	printcmp(cB,goodB[cD]);
-	execute(rev);
-	rA /= norm;
-	printcmp(rA[D],re(goodA));
-	destroy_plan(fwd);
-	destroy_plan(rev);
-	// In place transform
-	var rA2 : [rD] real(64);
-	fwd = plan_dft_r2c(dims,rA2[first],rA2[first],FFTW_ESTIMATE);
-	rev = plan_dft_c2r(dims,rA2[first],rA2[first],FFTW_ESTIMATE);
-	rA2[D] = re(goodA);
-	execute(fwd);
-	printcmp(rA2[reD],re(goodB[cD]));
-	printcmp(rA2[imD],im(goodB[cD]));
-	execute(rev);
-	rA2 /= norm;
-	printcmp(rA2[D],re(goodA));
-	destroy_plan(fwd);
-	destroy_plan(rev);
+  // Testing r2c and c2r
+  var rA : [D] real(64); // No padding for an out-of place transform
+  var cB : [cD] fftw_complex;
+  fwd = plan_dft_r2c(dims,rA[first],cB[first],FFTW_ESTIMATE);
+  rev = plan_dft_c2r(dims,cB[first],rA[first],FFTW_ESTIMATE);
+  rA[D] = re(goodA);
+  execute(fwd);
+  printcmp(cB,goodB[cD]);
+  execute(rev);
+  rA /= norm;
+  printcmp(rA[D],re(goodA));
+  destroy_plan(fwd);
+  destroy_plan(rev);
+  // In place transform
+  var rA2 : [rD] real(64);
+  fwd = plan_dft_r2c(dims,rA2[first],rA2[first],FFTW_ESTIMATE);
+  rev = plan_dft_c2r(dims,rA2[first],rA2[first],FFTW_ESTIMATE);
+  rA2[D] = re(goodA);
+  execute(fwd);
+  printcmp(rA2[reD],re(goodB[cD]));
+  printcmp(rA2[imD],im(goodB[cD]));
+  execute(rev);
+  rA2 /= norm;
+  printcmp(rA2[D],re(goodA));
+  destroy_plan(fwd);
+  destroy_plan(rev);
 
 }
 

--- a/test/users/npadmana/testFFTWsegfault.chpl
+++ b/test/users/npadmana/testFFTWsegfault.chpl
@@ -2,137 +2,137 @@ use FFTWsegfault;
 
 
 proc printcmp(x, y) {
-	var err = max reduce abs(x-y);
-	//writeln("----");
-	//writeln(x);
-	//writeln("**");
-	//writeln(y);
-	//writeln("----");
-	writeln(err);
+  var err = max reduce abs(x-y);
+  //writeln("----");
+  //writeln(x);
+  //writeln("**");
+  //writeln(y);
+  //writeln("----");
+  writeln(err);
 }
 
 proc runtest(param ndim : int, fn : string) {
-	/* Read in the data and set up the domains appropriately */
-	var dims : ndim*int(32); 
-	var D : domain(ndim);
-	// Define ranges here
-	var rD,cD,reD,imD : domain(ndim,int,true); 
-	var A,B,goodA,goodB : [D] fftw_complex;
-	{
-		var f = open(fn,iomode.r).reader(kind=iokind.little);
-		for ii in 1..ndim {
-			f.read(dims(ii));
-		}
-		// Note compiler does not automatically fold select on params
-		if (ndim == 1) {
-			D = 0.. #dims(ndim);
-		}
-		if (ndim == 2) {
-			D = {0.. #dims(1),0.. #dims(ndim)};
-		}
-		if (ndim == 3) {
-			D = {0.. #dims(1),0.. #dims(2), 0.. #dims(ndim)};
-		}
-		for (r,c) in goodA {
-			f.read(r);
-			c = 0;
-		}
-		for (r,c) in goodB {
-			f.read(r); f.read(c);
-		}
-		f.close();
-		writeln("Data read...");
-	}
-	// Set up domains based on dimension size
-	var first : ndim*int;
-	if (ndim==1) {
-		var ldim = dims(1)/2 + 1;
-		// Domains for real FFT
-		rD = 0.. #(2*ldim); // Padding to do in place transforms
-		cD = 0.. #ldim;
-		// Define domains to extract the real and imaginary parts for inplace transforms
-		reD = rD[0..(2*ldim-1) by 2]; // Padding to do in place transforms
-		imD = rD[1..(2*ldim-1) by 2]; // Padding to do in place transforms
-		first=(0,);
-	}
-	if (ndim==2) {
-		// Domains for real FFT
-		var ldim = dims(2)/2+1;
-		rD = {0.. #dims(1),0.. #(2*ldim)}; // Padding to do in place transforms
-		cD = {0.. #dims(1),0.. #ldim};
-		// Define domains to extract the real and imaginary parts for in place transforms
-		reD = rD[..,0..(2*ldim-1) by 2]; // Padding to do in place transforms
-		imD = rD[..,1..(2*ldim-1) by 2]; // Padding to do in place transforms
-		first=(0,0);
-	}
-	if (ndim==3) {
-		// Domains for real FFT
-		var ldim = dims(3)/2+1;
-		rD = {0.. #dims(1),0.. #dims(2),0.. #(2*ldim)}; // Padding to do in place transforms
-		cD = {0.. #dims(1),0.. #dims(2),0.. #ldim};
-		// Define domains to extract the real and imaginary parts for in place transforms
-		reD = rD[..,..,0..(2*ldim-1) by 2]; // Padding to do in place transforms
-		imD = rD[..,..,1..(2*ldim-1) by 2]; // Padding to do in place transforms
-		first=(0,0,0);
-	}
+  /* Read in the data and set up the domains appropriately */
+  var dims : ndim*int(32); 
+  var D : domain(ndim);
+  // Define ranges here
+  var rD,cD,reD,imD : domain(ndim,int,true); 
+  var A,B,goodA,goodB : [D] fftw_complex;
+  {
+    var f = open(fn,iomode.r).reader(kind=iokind.little);
+    for ii in 1..ndim {
+      f.read(dims(ii));
+    }
+    // Note compiler does not automatically fold select on params
+    if (ndim == 1) {
+      D = 0.. #dims(ndim);
+    }
+    if (ndim == 2) {
+      D = {0.. #dims(1),0.. #dims(ndim)};
+    }
+    if (ndim == 3) {
+      D = {0.. #dims(1),0.. #dims(2), 0.. #dims(ndim)};
+    }
+    for (r,c) in goodA {
+      f.read(r);
+      c = 0;
+    }
+    for (r,c) in goodB {
+      f.read(r); f.read(c);
+    }
+    f.close();
+    writeln("Data read...");
+  }
+  // Set up domains based on dimension size
+  var first : ndim*int;
+  if (ndim==1) {
+    var ldim = dims(1)/2 + 1;
+    // Domains for real FFT
+    rD = 0.. #(2*ldim); // Padding to do in place transforms
+    cD = 0.. #ldim;
+    // Define domains to extract the real and imaginary parts for inplace transforms
+    reD = rD[0..(2*ldim-1) by 2]; // Padding to do in place transforms
+    imD = rD[1..(2*ldim-1) by 2]; // Padding to do in place transforms
+    first=(0,);
+  }
+  if (ndim==2) {
+    // Domains for real FFT
+    var ldim = dims(2)/2+1;
+    rD = {0.. #dims(1),0.. #(2*ldim)}; // Padding to do in place transforms
+    cD = {0.. #dims(1),0.. #ldim};
+    // Define domains to extract the real and imaginary parts for in place transforms
+    reD = rD[..,0..(2*ldim-1) by 2]; // Padding to do in place transforms
+    imD = rD[..,1..(2*ldim-1) by 2]; // Padding to do in place transforms
+    first=(0,0);
+  }
+  if (ndim==3) {
+    // Domains for real FFT
+    var ldim = dims(3)/2+1;
+    rD = {0.. #dims(1),0.. #dims(2),0.. #(2*ldim)}; // Padding to do in place transforms
+    cD = {0.. #dims(1),0.. #dims(2),0.. #ldim};
+    // Define domains to extract the real and imaginary parts for in place transforms
+    reD = rD[..,..,0..(2*ldim-1) by 2]; // Padding to do in place transforms
+    imD = rD[..,..,1..(2*ldim-1) by 2]; // Padding to do in place transforms
+    first=(0,0,0);
+  }
 
-	// FFTW does not normalize inverse transform, set up norm
-	var norm = * reduce dims;
+  // FFTW does not normalize inverse transform, set up norm
+  var norm = * reduce dims;
 
 
-	// FFT testing here
-	var fwd = plan_dft(dims, A[first],B[first],FFTW_FORWARD,FFTW_ESTIMATE);
-	var rev = plan_dft(dims, B[first],A[first],FFTW_BACKWARD,FFTW_ESTIMATE);
-	// Test forward and reverse transform
-	A = goodA;
-	execute(fwd);
-	printcmp(B,goodB);
-	execute(rev);
-	A /= norm; 
-	printcmp(A,goodA);
-	destroy_plan(fwd);
-	destroy_plan(rev);
+  // FFT testing here
+  var fwd = plan_dft(dims, A[first],B[first],FFTW_FORWARD,FFTW_ESTIMATE);
+  var rev = plan_dft(dims, B[first],A[first],FFTW_BACKWARD,FFTW_ESTIMATE);
+  // Test forward and reverse transform
+  A = goodA;
+  execute(fwd);
+  printcmp(B,goodB);
+  execute(rev);
+  A /= norm; 
+  printcmp(A,goodA);
+  destroy_plan(fwd);
+  destroy_plan(rev);
 
-	// Test in-place transforms
-	fwd = plan_dft(dims,A[first],A[first],FFTW_FORWARD,FFTW_ESTIMATE);
-	rev = plan_dft(dims,A[first],A[first],FFTW_BACKWARD,FFTW_ESTIMATE);
-	A = goodA;
-	// Test forward and reverse transform
-	A = goodA;
-	execute(fwd);
-	printcmp(A,goodB);
-	execute(rev);
-	A /= norm; // FFTW does an unnormalized transform
-	printcmp(A,goodA);
-	destroy_plan(fwd);
-	destroy_plan(rev);
+  // Test in-place transforms
+  fwd = plan_dft(dims,A[first],A[first],FFTW_FORWARD,FFTW_ESTIMATE);
+  rev = plan_dft(dims,A[first],A[first],FFTW_BACKWARD,FFTW_ESTIMATE);
+  A = goodA;
+  // Test forward and reverse transform
+  A = goodA;
+  execute(fwd);
+  printcmp(A,goodB);
+  execute(rev);
+  A /= norm; // FFTW does an unnormalized transform
+  printcmp(A,goodA);
+  destroy_plan(fwd);
+  destroy_plan(rev);
 
-	// Testing r2c and c2r
-	var rA : [D] real(64); // No padding for an out-of place transform
-	var cB : [cD] fftw_complex;
-	fwd = plan_dft_r2c(dims,rA[first],cB[first],FFTW_ESTIMATE);
-	rev = plan_dft_c2r(dims,cB[first],rA[first],FFTW_ESTIMATE);
-	rA[D] = re(goodA);
-	execute(fwd);
-	printcmp(cB,goodB[cD]);
-	execute(rev);
-	rA /= norm;
-	printcmp(rA[D],re(goodA));
-	destroy_plan(fwd);
-	destroy_plan(rev);
-	// In place transform
-	var rA2 : [rD] real(64);
-	fwd = plan_dft_r2c(dims,rA2[first],rA2[first],FFTW_ESTIMATE);
-	rev = plan_dft_c2r(dims,rA2[first],rA2[first],FFTW_ESTIMATE);
-	rA2[D] = re(goodA);
-	execute(fwd);
-	printcmp(rA2[reD],re(goodB[cD]));
-	printcmp(rA2[imD],im(goodB[cD]));
-	execute(rev);
-	rA2 /= norm;
-	printcmp(rA2[D],re(goodA));
-	destroy_plan(fwd);
-	destroy_plan(rev);
+  // Testing r2c and c2r
+  var rA : [D] real(64); // No padding for an out-of place transform
+  var cB : [cD] fftw_complex;
+  fwd = plan_dft_r2c(dims,rA[first],cB[first],FFTW_ESTIMATE);
+  rev = plan_dft_c2r(dims,cB[first],rA[first],FFTW_ESTIMATE);
+  rA[D] = re(goodA);
+  execute(fwd);
+  printcmp(cB,goodB[cD]);
+  execute(rev);
+  rA /= norm;
+  printcmp(rA[D],re(goodA));
+  destroy_plan(fwd);
+  destroy_plan(rev);
+  // In place transform
+  var rA2 : [rD] real(64);
+  fwd = plan_dft_r2c(dims,rA2[first],rA2[first],FFTW_ESTIMATE);
+  rev = plan_dft_c2r(dims,rA2[first],rA2[first],FFTW_ESTIMATE);
+  rA2[D] = re(goodA);
+  execute(fwd);
+  printcmp(rA2[reD],re(goodB[cD]));
+  printcmp(rA2[imD],im(goodB[cD]));
+  execute(rev);
+  rA2 /= norm;
+  printcmp(rA2[D],re(goodA));
+  destroy_plan(fwd);
+  destroy_plan(rev);
 
 }
 


### PR DESCRIPTION
[discussed with Nikhil]

To reduce the extent to which the code wraps around in 80-column
settings, replace TABs with pairs of spaces.
