### PR TITLE
Decode our perf graph query string before looking at it

### DIFF
--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9">
     <link rel="stylesheet" href="perfgraph.css">
     <!--[if IE]>

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -447,19 +447,14 @@ function customDrawCallback(g, initial) {
     range[0] = roundDate(range[0], false);
     range[1] = roundDate(range[1], true);
 
-    var changedXAxis = false;
+    setURLFromDate(OptionsEnum.STARTDATE, Dygraph.dateString_(range[0]));
+    setURLFromDate(OptionsEnum.ENDDATE, Dygraph.dateString_(range[1]));
+
     for (var j = 0; j < gs.length; j++) {
       if (gs[j].isReady && differentDateRanges(range, gs[j].xAxisRange())) {
         gs[j].updateOptions({ dateWindow: range });
-        changedXAxis = true;
       }
     }
-
-    if (changedXAxis) {
-      setURLFromDate(OptionsEnum.STARTDATE, Dygraph.dateString_(range[0]));
-      setURLFromDate(OptionsEnum.ENDDATE, Dygraph.dateString_(range[1]));
-    }
-
   }
   blockRedraw = false;
 }

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -712,7 +712,7 @@ function getDateFromURL(whichDate, defaultDate) {
   if (dateString === normalizeForURL('today'))
     return getTodaysDate();
 
-  return dateString
+  return dateString;
 }
 
 
@@ -989,6 +989,7 @@ function getOptions() {
   for (option in OptionsEnum) { options[OptionsEnum[option]] = '';}
 
   var queryString = document.location.search.slice(1);
+  queryString = decodeURIComponent(queryString);
   var queryStrings = queryString.split('&');
   for (var i = 0; i < queryStrings.length; i++) {
     var curOption = queryStrings[i].split('=');


### PR DESCRIPTION
Our query string uses ','s and '/'s to store lists of graphs/configurations and
store the startdate and enddate so that we can share graphs with each other.
One could argue that we should % encode them since they are technically still
reserved characters in the query string even though they have no reserved
purpose for us. % encoding is used because certain characters have reserved
purposes in the URI so you need some way to encode them in URI without actually
using the characters. e.g. '/' is encoded as '%2F'.

From a percent-encoding article: "In the 'query' component of a URI (the part
after a ? character), for example, '/' is still considered a reserved character
but it normally has no reserved purpose, unless a particular URI scheme says
otherwise. The character does not need to be percent-encoded when it has no
reserved purpose."

Some other sites where we might post perf graph links (i.e. facebook) have
reserved purposes for some of the characters in the query string, so they
percent encode our query string.

Previously we didn't decode the string so our graphs couldn't parse the
encoded date. This just updates our graphs to use the URI decoder before
we look at the query string. We don't have to encode the query string ourselves
since we have no reserved uses of the reserved symbols and I *think* any site
we post to will do the encoding themselves if they use any of the reserved
characters. We could always encode it just to be safe, but that makes the URI
uglier