### PR TITLE
Add capability to only test futures that have skipifs

### DIFF
--- a/util/cron/common-fast.bash
+++ b/util/cron/common-fast.bash
@@ -5,4 +5,4 @@
 
 unset CHPL_TARGET_ARCH
 
-nightly_args="-fast -no-futures -suppress Suppressions/fast.suppress"
+nightly_args="-fast -suppress Suppressions/fast.suppress"

--- a/util/cron/common-valgrind.bash
+++ b/util/cron/common-valgrind.bash
@@ -16,4 +16,4 @@ if [ "${tasks}" == "qthreads" ] ; then
     export CHPL_QTHREAD_MORE_CFG_OPTIONS=--enable-valgrind
 fi
 
-nightly_args="-valgrind -no-futures -suppress Suppressions/valgrind.suppress -parnodefile $CWD/../../test/Nodes/valgrind-localhost"
+nightly_args="-valgrind -suppress Suppressions/valgrind.suppress -parnodefile $CWD/../../test/Nodes/valgrind-localhost"

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -39,7 +39,7 @@ $releasePerformance = 0;
 $compperformance = 0;
 $compperformancedescription = "";
 $componly = 0;
-$nofutures = 0;
+$futuresMode = 3;
 $suppressions = "";
 $parnodefile = "";
 $baseline = 0;
@@ -121,8 +121,10 @@ while (@ARGV) {
         $suppressions = shift @ARGV;
     } elsif ($flag eq "-componly") {
 	$componly = 1;
+    } elsif ($flag eq "-futures") {
+	$futuresMode = 1;
     } elsif ($flag eq "-no-futures") {
-	$nofutures = 1;
+	$futuresMode = 0;
     } elsif ($flag eq "-parnodefile") {
         $parnodefile = shift @ARGV;
     } elsif ($flag eq "-no-local") {
@@ -173,7 +175,7 @@ if (@ARGV) {
 }
 
 if ($printusage == 1) {
-    print "nightly [-debug|-cron] {[-notest] [-valgrind] [-componly] [-no-futures] [-performance]}\n";
+    print "nightly [-debug|-cron] {[-notest] [-valgrind] [-componly] [-[no-]futures] [-performance]}\n";
     print "\t-debug       : check out sources and run for individual user (default)\n";
     print "\t-cron        : use for nightly cron runs only\n";
     print "\t-notest      : don't run the tests (check the build only)\n";
@@ -197,6 +199,7 @@ if ($printusage == 1) {
     print "\t-memleaks <log> : run memleaks tests\n";
     print "\t-no-local    : run tests using --no-local\n";
     print "\t-componly    : only run the compiler, not the generated binary\n";
+    print "\t-futures     : run all futures, not just those with skipifs\n";
     print "\t-no-futures  : do not run future tests\n";
     print "\t-parnodefile : specify a node file to use for parallel testing\n";
     print "\t-cron-recipient : send -cron emails to this address instead of SourceForge mailing list(s)\n";
@@ -511,9 +514,8 @@ if ($interpret == 1) {
 if ($valgrind == 1) {
     $testflags = "$testflags -valgrind";
 }
-if ($nofutures == 0) {
-    $testflags = "$testflags -futures";
-}
+
+$testflags = "$testflags -futures-mode $futuresMode";
 
 #
 # Test directories to run.

--- a/util/cron/test-baseline.bash
+++ b/util/cron/test-baseline.bash
@@ -7,4 +7,4 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="baseline"
 
-$CWD/nightly -cron -baseline -suppress Suppressions/baseline.suppress -no-futures
+$CWD/nightly -cron -baseline -suppress Suppressions/baseline.suppress

--- a/util/cron/test-cygwin32.bat
+++ b/util/cron/test-cygwin32.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/cygdrive/c/Program Files/emacs-24.4/bin' ; export CHPL_HOME=$PWD ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -no-futures"
+c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/cygdrive/c/Program Files/emacs-24.4/bin' ; export CHPL_HOME=$PWD ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron"
 GOTO End
 
 :ErrExit

--- a/util/cron/test-cygwin64.bat
+++ b/util/cron/test-cygwin64.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows:/cygdrive/c/windows/System32/Wbem:/cygdrive/c/windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/usr/bin:/cygdrive/c/emacs-24.3/bin' ; export CHPL_HOME=$PWD ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -no-futures"
+c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows:/cygdrive/c/windows/System32/Wbem:/cygdrive/c/windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/usr/bin:/cygdrive/c/emacs-24.3/bin' ; export CHPL_HOME=$PWD ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron"
 GOTO End
 
 :ErrExit

--- a/util/cron/test-gasnet-everything.bash
+++ b/util/cron/test-gasnet-everything.bash
@@ -10,4 +10,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet-everything"
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron
+$CWD/nightly -cron -futures

--- a/util/cron/test-gasnet.numa.bash
+++ b/util/cron/test-gasnet.numa.bash
@@ -11,4 +11,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.numa"
 # TODO: Do we need/want this? (thomasvandoren, 2014-07-01)
 export GASNET_QUIET=Y
 
-$CWD/nightly -cron -multilocale -no-futures
+$CWD/nightly -cron -multilocale

--- a/util/cron/test-gasnet.tcmalloc.bash
+++ b/util/cron/test-gasnet.tcmalloc.bash
@@ -10,4 +10,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.tcmalloc"
 
 export GASNET_QUIET=Y
 
-$CWD/nightly -cron -multilocale -no-futures
+$CWD/nightly -cron -multilocale

--- a/util/cron/test-linux32.bash
+++ b/util/cron/test-linux32.bash
@@ -7,4 +7,4 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux32"
 
-$CWD/nightly -cron -no-futures
+$CWD/nightly -cron

--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -9,4 +9,4 @@ source $CWD/common.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
 
 nightly_args="-compperformance (default)"
-$CWD/nightly -cron ${nightly_args}
+$CWD/nightly -cron -futures ${nightly_args}

--- a/util/cron/test-memleaks.bash
+++ b/util/cron/test-memleaks.bash
@@ -8,5 +8,5 @@ source $CWD/common-memleaks.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="memleaks"
 
-$CWD/nightly -cron -memleaks $(memleaks_log full) -no-futures
+$CWD/nightly -cron -memleaks $(memleaks_log full)
 save_memleaks_log full

--- a/util/cron/test-memleaks.bash
+++ b/util/cron/test-memleaks.bash
@@ -8,5 +8,5 @@ source $CWD/common-memleaks.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="memleaks"
 
-$CWD/nightly -cron -memleaks $(memleaks_log full)
+$CWD/nightly -cron -memleaks $(memleaks_log full) -no-futures
 save_memleaks_log full

--- a/util/cron/test-tcmalloc.bash
+++ b/util/cron/test-tcmalloc.bash
@@ -8,4 +8,4 @@ source $CWD/common-tcmalloc.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="tcmalloc"
 
-$CWD/nightly -cron -no-futures
+$CWD/nightly -cron

--- a/util/cron/test-verify.bash
+++ b/util/cron/test-verify.bash
@@ -7,4 +7,4 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="verify"
 
-$CWD/nightly -cron -no-futures -verify
+$CWD/nightly -cron -verify

--- a/util/start_test
+++ b/util/start_test
@@ -720,8 +720,7 @@ set graphsdisprange = 1
 set graphsgendefault = "avg"
 set startdate = ""
 set genGraphOpts = ""
-set testfutures = 0
-set testfuturesonly = 0
+set futuresMode = 0
 set testnotests = 0
 set recurse = 1
 set tee = "tee"
@@ -807,14 +806,28 @@ while ( $#argv > 0 )
     case -futures:
     case --futures:
         shift
-        set testfutures = 1
+        set futuresMode = 1
         breaksw
     case -futures-only
     case --futures-only
     case -futuresonly
     case --futuresonly
         shift
-        set testfuturesonly = 1
+        set futuresMode = 2
+        breaksw
+    case -futures-skipif
+    case --futures-skipif
+    case -futuresskipif
+    case --futuresskipif
+        shift
+        set futuresMode = 3
+        breaksw
+    # "undocumented" option, only meant to be used by nightly
+    case -futures-mode:
+    case --futures-mode:
+        shift
+        set futuresMode = "$argv[1]"
+        shift
         breaksw
     case -i:
     case --interpret:
@@ -1008,7 +1021,8 @@ while ( $#argv > 0 )
         echo "          -startdate <MM/DD/YY> (currently: '')"
         echo "          -genGraphOpts OPT or -genGraphOpts 'OPT1 OPT2 ...'"
         echo "          -futures"
-        echo "          -futuresonly"
+        echo "          -futures-only"
+        echo "          -futures-skipif"
         echo "          -valgrind"
         echo "          -valgrindexe"
         echo "          -syspreexec <path>"
@@ -1563,17 +1577,9 @@ end
 
 setenv CHPL_TEST_SINGLES 0
 
-# for this mode, only test futures and notests as specified
-# by the command-line flags
-if ($testfuturesonly == 1) then
-    setenv CHPL_TEST_FUTURES 2
-else
-    if ($testfutures == 1) then
-        setenv CHPL_TEST_FUTURES 1
-    else
-        setenv CHPL_TEST_FUTURES 0
-    endif
-endif
+# for this mode, test only futures that were specified on the command-line
+# (defaults to no futures)
+setenv CHPL_TEST_FUTURES $futuresMode
 
 if ($testnotests == 1) then
     setenv CHPL_TEST_NOTESTS 1

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1028,7 +1028,7 @@ for testname in testsrc:
         continue # on to next test
     # 1: test all futures
     elif testfutures == 1:
-      pass
+        pass
     # 2: test only futures
     elif testfutures == 2 and testfuturesfile == False:
         sys.stdout.write('[Skipping non-future test: %s/%s]\n'%(localdir,test_filename))

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -894,6 +894,7 @@ for testname in testsrc:
     futuretest=''
     executebin=execute
     testfuturesfile=False
+    testskipiffile=False
     noexecfile=False
     execoptsfile=False
     precomp=None
@@ -940,6 +941,7 @@ for testname in testsrc:
 
         elif (suffix=='.skipif' and (os.access(f, os.R_OK) and
                (os.getenv('CHPL_TEST_SINGLES')=='0'))):
+            testskipiffile=True
             skiptest=runSkipIf(f)
             try:
                 skipme=False
@@ -1011,10 +1013,6 @@ for testname in testsrc:
                 redirectin=f
 
         if suffix==futureSuffix:
-            if testfutures==0:
-                sys.stdout.write('[Skipping future test: %s/%s]\n'%(localdir,test_filename))
-                do_not_test=True
-                break
             testfuturesfile=True
 
     del test_filename_files
@@ -1023,10 +1021,23 @@ for testname in testsrc:
     if do_not_test:
         continue # on to next test
 
-    # Skip non-future tests if specified
-    if (testfuturesfile==False and testfutures==2):
+
+    # 0: test no futures
+    if testfutures == 0 and testfuturesfile == True:
+        sys.stdout.write('[Skipping future test: %s/%s]\n'%(localdir,test_filename))
+        continue # on to next test
+    # 1: test all futures
+    elif testfutures == 1:
+      pass
+    # 2: test only futures
+    elif testfutures == 2 and testfuturesfile == False:
         sys.stdout.write('[Skipping non-future test: %s/%s]\n'%(localdir,test_filename))
         continue # on to next test
+    # 3: test futures that have a .skipif file
+    elif testfutures == 3 and testfuturesfile == True and testskipiffile == False:
+        sys.stdout.write('[Skipping future test without a skipif: %s/%s]\n'%(localdir,test_filename))
+        continue # on to next test
+
 
     # Set numlocales
     if (numlocales == 0) or (chplcomm=='none') or is_c_test:


### PR DESCRIPTION
For a while we've wanted a testing mode where futures are run if and only if
there's a skipif for the test. Historically there was no middle ground and we
either ran 0 or all ~800 futures. We turned futures off for most configurations
since we didn't want to waste time running them everywhere with little reward.
However, some futures are platform specific and we would never have noticed if
they started passing.

This allows us to test configuration specific futures, without have to run all
the futures. There are only ~60 future tests that also have .skipifs. I would
guess that maybe 5-30 futures will run for any given configuration so it
shouldn't add much overhead to testing.

The current default for nightly is to only test futures with skipifs. You can
toss -futures to test all futures, or -no-futures to skip all futures.

Only the "standard" linux64 configuration is tossing -futures for now. I'll
ping the group to see what other configurations we might want to add. I thought
about gasnet-everything and darwin, but wasn't sure.

I was originally thinking that -no-futures wouldn't be used much if at all now.
I removed all uses of it, but now I'm wondering if it makes sense to use it for
verify and memleaks still.