### PR TITLE
Allow the _real binary to be wrapped for most launchers

### DIFF
--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -38,6 +38,7 @@ int chpl_launch_using_system(char* command, char* argv0);
 char* chpl_get_enviro_keys(char sep);
 
 void chpl_compute_real_binary_name(const char* argv0);
+const char* chpl_get_real_binary_wrapper(void);
 const char* chpl_get_real_binary_name(void);
 
 //

--- a/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
+++ b/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
@@ -315,7 +315,8 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
     if (verbosity > 2) {
       fprintf(expectFile, "send \"aprun -q %s%d ",
               getNumLocalesStr(), 1 /* only run on one locale */);
-      fprintf(expectFile, "ls %s\\n\"\n", chpl_get_real_binary_name());
+      fprintf(expectFile, "ls %s %s\\n\"\n",
+          chpl_get_real_binary_wrapper(), chpl_get_real_binary_name());
       fprintf(expectFile, "expect {\n");
       fprintf(expectFile, "  \"failed: chdir\" {send_user "
               "\"error: %s must be launched from and/or stored on a "

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -234,9 +234,10 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       fprintf(slurmFile, "#SBATCH --output=%s.%%j.out\n", argv[0]);
     }
 
-    // add the srun command and the binary name
-    fprintf(slurmFile, "srun %s ", chpl_get_real_binary_name());
-    
+    // add the srun command and the (possibly wrapped) binary name.
+    fprintf(slurmFile, "srun %s %s ",
+        chpl_get_real_binary_wrapper(), chpl_get_real_binary_name());
+
     // add any arguments passed to the launcher to the binary 
     for (i=1; i<argc; i++) {
       fprintf(slurmFile, " '%s'", argv[i]);
@@ -298,17 +299,18 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     if (account && strlen(account) > 0) {
       len += sprintf(iCom+len, "--account=%s ", account);
     }
-
-    // add the binary name 
-    len += sprintf(iCom+len, "%s", chpl_get_real_binary_name());
     
+    // add the (possibly wrapped) binary name
+    len += sprintf(iCom+len, "%s %s ",
+        chpl_get_real_binary_wrapper(), chpl_get_real_binary_name());
+
     // add any arguments passed to the launcher to the binary 
     for (i=1; i<argc; i++) {
-      len += sprintf(iCom+len, " %s", argv[i]);
+      len += sprintf(iCom+len, "%s ", argv[i]);
     }
    
     // launch the job using srun
-    sprintf(baseCommand, "srun %s", iCom);
+    sprintf(baseCommand, "srun %s ", iCom);
   }
 
   // copy baseCommand into command and return it 

--- a/runtime/src/main_launcher.c
+++ b/runtime/src/main_launcher.c
@@ -194,7 +194,8 @@ chpl_run_utility1K(const char *command, char *const argv[], char *outbuf, int ou
 //
 char** chpl_bundle_exec_args(int argc, char *const argv[],
                               int largc, char *const largv[]) {
-  int len = argc+largc+1;
+  int len = argc+largc+2;
+  int newargc = 0;
   char **newargv = chpl_mem_allocMany(len, sizeof(char*),
                                       CHPL_RT_MD_COMMAND_BUFFER, -1, "");
   if (!newargv) {
@@ -203,17 +204,23 @@ char** chpl_bundle_exec_args(int argc, char *const argv[],
 
   newargv[len-1] = NULL;
 
+  // add any launcher args
   if (largc > 0) {
-    // launcher args
     memcpy(newargv, largv, largc*sizeof(char *));
+    newargc = largc;
   }
   if (argc > 0) {
-    // binary
+    // if there is a wrapper, add it after the launcher args
+    if (strcmp(chpl_get_real_binary_wrapper(), "") != 0) {
+      newargv[newargc++] = (char *) chpl_get_real_binary_wrapper();
+    }
+
+    // add the _real binary (after launchers args or wrapper)
     chpl_compute_real_binary_name(argv[0]);
-    newargv[largc] = (char *) chpl_get_real_binary_name();
+    newargv[newargc++] = (char *) chpl_get_real_binary_name();
     if (argc > 1) {
-      // other args (skip binary name)
-      memcpy(newargv+largc+1, argv+1, (argc-1)*sizeof(char *));
+      // add args passed to main (skip original binary) after _real binary
+      memcpy(newargv+newargc, argv+1, (argc-1)*sizeof(char *));
     }
   }
 
@@ -365,7 +372,7 @@ void chpl_compute_real_binary_name(const char* argv0) {
   int exe_length = strlen(launcher_exe_suffix);
   int length;
   const char* real_suffix = getenv("CHPL_LAUNCHER_SUFFIX");
-  
+
   if (NULL == real_suffix) {
     real_suffix = launcher_real_suffix;
   }
@@ -384,6 +391,21 @@ void chpl_compute_real_binary_name(const char* argv0) {
   strncpy(cursor, argv0, length);
   cursor += length;
   strcpy(cursor, launcher_real_suffix);
+}
+
+// Undocumented means to wrap the _real binary. Useful for things like timing
+// the _real executable or running it through some other program. Note that
+// this will not work with launchers that add arguments after the first
+// positional argument expecting it to be the binary. e.g. amudprun adds
+// __AMUDP_SLAVE_PROCESS__* and the hostname:port. Returns the value of
+// CHPL_LAUNCHER_REAL_WRAPPER if set, "" otherwise
+const char* chpl_get_real_binary_wrapper(void) {
+  const char* real_wrapper = getenv("CHPL_LAUNCHER_REAL_WRAPPER");
+  if (real_wrapper != NULL) {
+    return real_wrapper;
+  } else {
+    return "";
+  }
 }
 
 const char* chpl_get_real_binary_name(void) {


### PR DESCRIPTION
Add an undocumented function chpl_get_real_binary_wrapper() which returns the
value of CHPL_LAUNCHER_REAL_WRAPPER if set, otherwise it returns "". This is
being added so we can use our whole program execution timers for xc performance
testing. It's not explicitly called CHPL_LAUNCHER_TEST_EXEC_TIMER or something
because it could be used more generally. Still, it doesn't work for all
launchers so I don't really want to advertise it (at least not yet.)

Without this we're including the time to get the resources we requested and any
pre-exec node setup for xc performance testing (and for any performance testing
that might use a queued launcher.) This makes whole program execution widely
inaccurate especially since we have multiple jobs running concurrently that
request the same nodes.

This will work with slurm, pbs-aprun, and aprun. It will "work" for any other
launcher that uses chpl_bundle_exec_args(), but I don't think that includes
many other launchers.

This doesn't really work with the amudprun launcher since the gasnet launcher
adds args to first non-positional argument that gasnet then uses for setting
up. We could make the timers take an optional argument that specifies which
argument is the binary, and reposition any other args to go after the binary.
There's no real need for that yet, since we don't do performance testing with
amudprun and even if we did we're not waiting on a reservation, so timing the
non _real won't be far off.