### PR TITLE
Time the _real binary for perf testing when using a supported launcher

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1196,6 +1196,7 @@ setenv LAUNCHCMD "$launchcmd"
 echo \[comm: \"$comm\"\] |& $tee -a $logfile
 setenv CHPL_COMM $comm
 setenv CHPL_GASNET_SEGMENT `$utildir/chplenv/chpl_comm_segment.py`
+setenv CHPL_LAUNCHER $launcher
 
 echo \[localeModel: \"$locMod\"\] |& $tee -a $logfile
 setenv CHPL_LOCALE_MODEL $locMod

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1454,7 +1454,7 @@ for testname in testsrc:
             timereal = chpllauncher in ['pbs-aprun', 'aprun', 'slurm-srun']
 
             args=list()
-            if timer and timereal
+            if timer and timereal:
                 cmd='./'+execname
                 os.environ['CHPL_LAUNCHER_REAL_WRAPPER'] = timer
             elif timer:

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1446,22 +1446,42 @@ for testname in testsrc:
                 sys.stdout.write(']\n')
                 break; # on to next compopts
 
+            # When doing whole program execution, we want to time the _real
+            # binary for launchers that use a queue so we don't include the
+            # time to get the reservation. These are the launchers known to
+            # support timing the _real using CHPL_LAUNCHER_REAL_WRAPPER.
+            chpllauncher=os.getenv('CHPL_LAUNCHER','none').strip()
+            timereal = chpllauncher in ['pbs-aprun', 'aprun', 'slurm-srun']
+
             args=list()
-            if timer:
+            if timer and timereal
+                cmd='./'+execname
+                os.environ['CHPL_LAUNCHER_REAL_WRAPPER'] = timer
+            elif timer:
                 cmd=timer
                 args+=['./'+execname]
-            elif launchcmd:
-                launchcmd_exec_time_file = execname + '_launchcmd_exec_time.txt'
-                os.environ['CHPL_LAUNCHCMD_EXEC_TIME_FILE'] = launchcmd_exec_time_file
-                launch_cmd_list = shlex.split(launchcmd)
-                cmd = launch_cmd_list[0]
-                args += launch_cmd_list[1:]
-                args += ['./'+execname]
             elif valgrindbin:
                 cmd=valgrindbin
                 args+=valgrindbinopts+['./'+execname]
             else:
                 cmd='./'+execname
+
+            # if we're using a launchcmd, build up the command to call
+            # launchcmd, and have it run the cmd and args built above
+            if launchcmd:
+                # have chpl_launchcmd time execution and place results in a
+                # file since sub_test time will include time to get reservation
+                launchcmd_exec_time_file = execname + '_launchcmd_exec_time.txt'
+                os.environ['CHPL_LAUNCHCMD_EXEC_TIME_FILE'] = launchcmd_exec_time_file
+
+                # save old cmd and args and add them after launchcmd args.
+                oldcmd = cmd
+                oldargs = list(args)
+                launch_cmd_list = shlex.split(launchcmd)
+                cmd = launch_cmd_list[0]
+                args = launch_cmd_list[1:]
+                args += [oldcmd]
+                args += oldargs
 
             args+=globalExecopts
             args+=shlex.split(execopts)
@@ -1505,7 +1525,7 @@ for testname in testsrc:
                         my_stdin = None
                     else:
                         my_stdin=file(redirectin, 'r')
-                    test_command = [cmd] + LauncherTimeoutArgs(timeout) + args
+                    test_command = [cmd] + args + LauncherTimeoutArgs(timeout)
                     p = subprocess.Popen(test_command,
                                         env=dict(os.environ.items() + testenv.items()),
                                         stdin=my_stdin,


### PR DESCRIPTION
For xc performance testing, our whole program execution timings are way off
since they're timing the executable that launches the job, not the _real
executable. This updates sub_test to time the _real binary using the new
CHPL_LAUNCHER_REAL_WRAPPER env var for launchers that are known to support it.
Currently that's pbs-aprun, aprun, and slurm-srun which is all the ones we
might care about in the near future.

Some details:
 - Updates how we set the timer if one of the above launchers is used
 - move launchcmd setup out of conditional nest so that whole program execution
   can be used at the same time as launchmd.
 - Swap the order that we add the launcher timeout. For whole program execution
   not using launchcmd, cmd will be the timer, and args will be the binary. The
   timeout needs to go after the binary. I think this means that launchcmd
   doesn't really need to support --walltime anymore since --walltime is always
   given to the executable now, but it doesn't hurt to leave it in.