### PR TITLE
Implemented compact printing mode for AstDumpToNode logger

### DIFF
--- a/compiler/include/AstDumpToNode.h
+++ b/compiler/include/AstDumpToNode.h
@@ -53,6 +53,12 @@ public:
 
   void             offsetSet(int offset);
 
+  // These adjust the printing format. Could be per-instance.
+  static bool          compact;
+  static const char*   delimitEnter;
+  static const char*   delimitExit;
+  static bool          showNodeIDs;
+
   //
   // These functions are the "implementation" interface for the
   // Visitor pattern.
@@ -127,7 +133,8 @@ private:
   void             ast_symbol(Symbol* sym, bool def);
 
   void             writeSymbol(Symbol* sym)                             const;
-  void             writeType  (Type*   type)                            const;
+  void             writeSymbolCompact(Symbol* sym)                      const;
+  void             writeType(Type* type, bool announce = true)          const;
 
   void             write(const char* text);
   void             write(bool spaceBefore, const char* text, bool spaceAfter);
@@ -145,6 +152,14 @@ private:
   void             logVisit(const char* fmt, ...);
 
   void             logWrite(const char* fmt, ...);
+
+  // enable compact mode
+  void             enterNode(BaseAST* node)                             const;
+  void             enterNodeSym(Symbol* node, const char* name = 0)     const;
+  void             exitNode(BaseAST* node, bool addNewline = false)     const;
+  void             writeField(const char* msg, int offset, BaseAST* field);
+  const char*      longString(const char* arg)                          const;
+  const char*      nodeIdString(BaseAST* node, bool spaceBefore, bool spaceAfter)  const;
 
   const char*      mPath;
   FILE*            mFP;

--- a/compiler/include/AstDumpToNode.h
+++ b/compiler/include/AstDumpToNode.h
@@ -158,8 +158,10 @@ private:
   void             enterNodeSym(Symbol* node, const char* name = 0)     const;
   void             exitNode(BaseAST* node, bool addNewline = false)     const;
   void             writeField(const char* msg, int offset, BaseAST* field);
-  const char*      longString(const char* arg)                          const;
-  const char*      nodeIdString(BaseAST* node, bool spaceBefore, bool spaceAfter)  const;
+  void             writeLongString(const char* msg, const char* arg)    const;
+  void             writeNodeID(BaseAST* node,
+                               bool spaceBefore,
+                               bool spaceAfter)                         const;
 
   const char*      mPath;
   FILE*            mFP;


### PR DESCRIPTION
Refactored some code in AstDumpToNode.cpp so I can switch
from the current wide printouts to narrower printouts.

Introduced these static variables as control knobs:

  AstDumpToNode::compact
  AstDumpToNode::delimitEnter
  AstDumpToNode::delimitExit
  AstDumpToNode::showNodeIDs

The output under the default settings should be mostly unchanged, except:

* The indentation of CondStmt's else-block (printed under "alt:")
  is 6 instead of 5, for consistency with the then-block.

* A module's modTag is printed using modTagDescrString(),
  so capitalization and the unknown-tag case changed.

  I am open to adjusting modTagDescrString() if desired.

* I did not do this in non-compact mode, however I suggest doing it -
  at the beginning of AstDumpToNode::writeSymbol, replace the current way
  of printing the Symbol's module with symPrefixString().
  That way function-local variables will not be prefixed by the (largely
  irrelevant) module name.

The output in the compact mode differs, among others:

* The say the Symbol's module is printed in AstDumpToNode::writeSymbol().

* Variables in SymExpr and primitive types are printed in an abbreviated way,
  which saves a lot of space.

* Indentation of FnSymbol's body, then- and else- blocks, and some others
  is greatly reduced.  writeField() is used for that.

I chose particular ways to factor out code; improvements are certainly welcome.
