### PR TITLE
Remove all non-ctest compopts that that throw march=native

### DIFF
--- a/test/parallel/taskCompare/lydia/PERFCOMPOPTS
+++ b/test/parallel/taskCompare/lydia/PERFCOMPOPTS
@@ -1,1 +1,0 @@
---ccflags -march=native

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.perfcompopts
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.perfcompopts
@@ -1,1 +1,0 @@
---ccflags -march=native 

--- a/test/studies/shootout/chameneos-redux/lydia/PERFCOMPOPTS
+++ b/test/studies/shootout/chameneos-redux/lydia/PERFCOMPOPTS
@@ -1,1 +1,0 @@
---ccflags -march=native 


### PR DESCRIPTION
This is handled automatically with all the --specialize and
CHPL_TARGET_ARCHITECTURE machinery so there is no need to throw it anymore. It
also causes issues on cray's where the modules handle what target architecture
the binary is built for.