### PR TITLE
Pipe multiple-configs for perf graphs through start_test and nightly

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -35,9 +35,11 @@ $allhellos = 0;
 $examples = 0;
 $performance = 0;
 $performancedescription = "";
+$performanceconfigs = "";
 $releasePerformance = 0;
 $compperformance = 0;
 $compperformancedescription = "";
+$syncsuffix = "";
 $componly = 0;
 $futuresMode = 3;
 $suppressions = "";
@@ -96,11 +98,15 @@ while (@ARGV) {
     } elsif ($flag eq "-performance-description") {
         $performance = 1;
         $performancedescription = shift @ARGV;
+    } elsif ($flag eq "-performance-configs") {
+        $performanceconfigs = shift @ARGV;
     } elsif ($flag eq "-releasePerformance") {
         $releasePerformance = 1;
     } elsif ($flag eq "-compperformance") {
         $compperformance = 1;
         $compperformancedescription = shift @ARGV;
+    } elsif ($flag eq "-sync-dir-suffix") {
+        $syncsuffix = shift @ARGV;
     } elsif ($flag eq "-numtrials") {
         $numtrials = shift @ARGV;
     } elsif ($flag eq "-compopts") {
@@ -188,7 +194,8 @@ if ($printusage == 1) {
     print "\t-valgrind    : run tests in valgrind mode\n";
 #    print "\t-interpret   : run tests in interpreted mode\n";
     print "\t-performance : run performance tests\n";
-    print "\t-performance-description : run performance tests with additional description";
+    print "\t-performance-description : run performance tests with additional description\n";
+    print "\t-performance-configs : comma seperated configs to graph, ':v' after config to be visible by default\n";
     print "\t-compperformance <description>: run tests with compiler performance tracking\n";
     print "\t-numtrials <number> : number of trials to run\n";
     print "\t-startdate	  : run performance tests providing a common start date to all the graphs\n";
@@ -592,6 +599,10 @@ if ($performance == 1) {
     if ($performancedescription ne "") {
        $testflags = "$testflags -performance-description $performancedescription";
     }
+    if ($performanceconfigs ne "") {
+       $testflags = "$testflags -performance-configs \"$performanceconfigs\"";
+    }
+
 }
 if ($compperformance == 1) { 
     if ($startdate eq "-1") {
@@ -697,7 +708,7 @@ if ($runtests == 0) {
 
     if ($performance == 1 or $compperformance == 1) {
         # sync the performance graphs over to sourceforge
-        $rsyncCommand = "$chplhomedir/util/cron/syncPerfGraphs.py $svnPerfDir/html/ $host --logFile $logdir/syncToSourceForge.errors";
+        $rsyncCommand = "$chplhomedir/util/cron/syncPerfGraphs.py $svnPerfDir/html/ $host/$syncsuffix --logFile $logdir/syncToSourceForge.errors";
         $rsyncMessage = "syncing performance graph to sourceforge -- log file at $logdir/syncToSourceForge.errors";
         mysystem($rsyncCommand, $rsyncMessage , 0, 1, 1);
    }
@@ -756,7 +767,7 @@ if ($runtests == 0) {
             mysystem($genGraphsCommand, $genGraphsMessage, 0, 1, 1);
 
             # sync the perf graphs over to sourceforge
-            $rsyncCommand = "$chplhomedir/util/cron/syncPerfGraphs.py $svnReleasePerfDir/html/ $host/releaseOverRelease/ --logFile $logdir/syncReleaseToSourceForge.errors";
+            $rsyncCommand = "$chplhomedir/util/cron/syncPerfGraphs.py $svnReleasePerfDir/html/ $host/releaseOverRelease/$syncsuffix --logFile $logdir/syncReleaseToSourceForge.errors";
             $rsyncMessage = "syncing release performance graph to sourceforge -- log file at $logdir/syncReleaseToSourceForge.errors";
             mysystem($rsyncCommand, $rsyncMessage , 0, 1, 1);
         }

--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -3,9 +3,12 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-perf.bash
-source $CWD/common-qthreads.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04.playground"
 
-# disabled until there are some more performance comparisons we want to do
-#$CWD/nightly -cron -performance-description 'qthreads --genGraphOpts "-m default -m qthreads"' -releasePerformance -numtrials 5 -startdate 07/28/12
+# do no-local performance runs and create graphs that show local (default) and
+# --no-local side by side. sync the graphs to a no-local directory so the
+# default graphs don't have multiple configurations
+perf_args="performance-description no-local -performance-configs default:v,no-local:v -sync-dir-suffix no-local"
+perf_args="${perf_args} -numtrials 5 -startdate 07/28/12"
+$CWD/nightly -cron -compopts --no-local ${perf_args}

--- a/util/start_test
+++ b/util/start_test
@@ -857,6 +857,14 @@ while ( $#argv > 0 )
         set performancedescription = $argv[1]
         shift
         breaksw
+    case --performance-configurations:
+    case -performance-configurations:
+    case --performance-configs:
+    case -performance-configs:
+        shift
+        set genGraphOpts = "$genGraphOpts --multiple-configurations $argv[1]"
+        shift
+        breaksw
     case --compperformance:
     case -compperformance:
         shift 
@@ -921,7 +929,7 @@ while ( $#argv > 0 )
     case --gengraphopts:
     case -gengraphopts:
         shift
-        set genGraphOpts = "$argv[1]"
+        set genGraphOpts = "$genGraphOpts $argv[1]"
         shift
         breaksw
     case -norecurse:
@@ -1011,6 +1019,8 @@ while ( $#argv > 0 )
         echo "          -norecurse"
         echo "          -comp-only"
         echo "          -performance"
+        echo "          -performance-description"
+        echo "          -performance-configurations"
         echo "          -compperformance"
         echo "          -compperformance-description <description>"
         echo "          -num-trials <number>"


### PR DESCRIPTION
In order to graph local/no-local side by side you can do something like:

start_test -performance-description no-local -performance-configs default,no-local

Where performance-configs is a comma separated list of configurations to graph.
It assumes the data for each config lives at $CHPL_TEST_PERF_DIR/$config.
Putting ':v' after a configuration makes it the config is visible by default in
the perf graphs. e.g. -performance-configs default:v,no-local:v will make it so
both configurations are visible by default in the perf graphs. If no ':v' is
specified on any configuration, the first config listed is visible by default.

performance-description simple enables performance testing (like --performance)
and places the .dat fils in $CHPL_TEST_PER_DIR/$performance-description

For both performance-description and performance-configs, 'default' is a special
value. for performance-description 'default' will just place .dat files in
$CHPL_TEST_PERF_DIR. For performance-configs, default will look for .dat files
in $CHPL_TEST_PERF_DIR, but will still append ' (default)' to the graph keys
since the graphs need some way to distinguish configurations by name.