### PR TITLE
Skip c tests if CHPL_LAUNCHER!=none

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -556,6 +556,9 @@ chplcomm=os.getenv('CHPL_COMM','none').strip()
 chplcommstr='.comm-'+chplcomm
 # sys.stdout.write('chplcomm=%s\n'%(chplcomm))
 
+# CHPL_LAUNCHER
+chpllauncher=os.getenv('CHPL_LAUNCHER','none').strip()
+
 # CHPL_LOCALE_MODEL
 chpllm=os.getenv('CHPL_LOCALE_MODEL','flat').strip()
 chpllmstr='.lm-'+chpllm
@@ -1021,7 +1024,6 @@ for testname in testsrc:
     if do_not_test:
         continue # on to next test
 
-
     # 0: test no futures
     if testfutures == 0 and testfuturesfile == True:
         sys.stdout.write('[Skipping future test: %s/%s]\n'%(localdir,test_filename))
@@ -1038,6 +1040,10 @@ for testname in testsrc:
         sys.stdout.write('[Skipping future test without a skipif: %s/%s]\n'%(localdir,test_filename))
         continue # on to next test
 
+    # c tests don't have a way to launch themselves
+    if is_c_test and chpllauncher != 'none':
+        sys.stdout.write('[Skipping c test: %s/%s]\n'%(localdir,test_filename))
+        continue
 
     # Set numlocales
     if (numlocales == 0) or (chplcomm=='none') or is_c_test:
@@ -1461,7 +1467,6 @@ for testname in testsrc:
             # binary for launchers that use a queue so we don't include the
             # time to get the reservation. These are the launchers known to
             # support timing the _real using CHPL_LAUNCHER_REAL_WRAPPER.
-            chpllauncher=os.getenv('CHPL_LAUNCHER','none').strip()
             timereal = chpllauncher in ['pbs-aprun', 'aprun', 'slurm-srun']
 
             args=list()


### PR DESCRIPTION
c tests have no launcher, so they will always run locally or on a login node,
which doesn't really make sense.

This caused issues with performance testing on xc

Previously we were testing c tests for things like gasnet with the amudpt
launcher. The c test wasn't actually "launched" it was just run without a
launcher on the local machine. If there's any use to that, this check can be
updated to only skip c tests if launcher!=none for performance tests.