### PR TITLE
Enable tests with stdin for slurm

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1226,10 +1226,10 @@ echo \[localeModel: \"$locMod\"\] |& $tee -a $logfile
 setenv CHPL_LOCALE_MODEL $locMod
 
 # we know that stdin redirection doesn't work for most launchers. only do
-# redirection when there's no launcher, or the launcher is amudprun, which we
-# know supports stdin redirection. Only set and alert user unless they threw
-# -nostdinredirect or -stdinredirect
-if ($launcher != "none" && $launcher != "amudprun") then
+# redirection when there's no launcher, or we know the launcher supports stdin
+# redirection (amudprun and slurm currently.) Set and alert user unless they
+# threw -nostdinredirect or -stdinredirect
+if ($launcher != "none" && $launcher != "amudprun" && $launcher != "slurm-srun") then
     if (! $?CHPL_NO_STDIN_REDIRECT && ! $?CHPL_TEST_FORCE_STDIN_REDIRECT ) then
         echo "[Info: assuming stdin redirection is not supported, skipping tests with stdin]" |& $tee -a $logfile
         setenv CHPL_NO_STDIN_REDIRECT true

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -229,7 +229,7 @@ class AbstractJob(object):
         """
         with _temp_dir() as working_dir:
             output_file = os.path.join(working_dir, 'test_output.log')
-            input_file = os.path.join(working_dir, 'test_intput')
+            input_file = os.path.join(working_dir, 'test_input')
             testing_dir = os.getcwd()
 
             job_id = self.submit_job(testing_dir, output_file, input_file)

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -309,7 +309,7 @@ class AbstractJob(object):
                     job_id, output_file))
 
             # try removing the file stdin was copied to, might not exist
-            logging.debug('removing stdin file.'
+            logging.debug('removing stdin file.')
             try:
                 os.unlink(input_file)
             except OSError:


### PR DESCRIPTION
This allows us to test performance test like some of the shootouts during out
single node xc performance testing.

Apparently stdin redirection DOES work with slurm. I guess I thought that since
launchertimeout was required stdinredirect wasn't supported as well since I was
used to throwing those flags at the same time?

This updates start_test so it no longer throws nostdinredirect automatically
for slurm. It also updates chpl_launchcmd to copy stdin to a file, and set an
env var for slurm so it knowns where to look for stdin.

Interactive slurm (not using sbatch) will work with just '<' for redirection.
When sbatch is being used (like with chpl_launchcmd) stdin has to be specified.
In this case we specify the file to use for stdin redirection.

We could just tell slurm to use the actual .stdin in sub_test instead of giving
chpl_launchcmd the stdin, and then having it write the file out again just so
slurm can use it, but I think that logic would be more complicated in sub_test,
and it's not needed unless batch mode is being used, in which case regular
start_test/sub_test don't work anyways.

Tested w/ and w/o chpl_launchcmd for the hellos and a directory that contains a
bunch of .stdins. Also tested release/examples/ w/o chpl_launchcmd