### PR TITLE
Fix syntax change refvar->ref in baseline-only future

### DIFF
--- a/test/studies/shootout/nbody/sidelnik/nbody_iterator_7-refInIterator.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_iterator_7-refInIterator.chpl
@@ -23,7 +23,7 @@ class Planet {
 
 iter TriangleIter(B: [] Planet) {
   for i in NBODIES {
-    refvar b1 = B[i];
+    ref b1 = B[i];
     for j in i+1..numBodies {
       yield (b1,B[j]);
     }


### PR DESCRIPTION
The new run skipif futures only feature has already proven its worth, catching a syntax error in this test which had gone unnoticed because we haven't run futures on baseline for some time now.
