### PR TITLE
Add stdout "buffering" to slurm

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -926,6 +926,12 @@ class SlurmJob(AbstractJob):
             fp.write(sys.stdin.read())
         env['SLURM_STDINMODE'] = input_file
 
+        # We could use stdout buffering for other configurations too, but I
+        # don't think there's any need. Currently, single locale perf testing
+        # is the only config that has any tests that produce a lot of output
+        if os.getenv('CHPL_TEST_PERF') != None and self.num_locales == 1:
+            env['CHPL_LAUNCHER_SLURM_BUFFER_STDOUT'] = 'true'
+
         cmd = self.test_command[:]
         # Add --nodelist into the command line
         if self.hostlist is not None:


### PR DESCRIPTION
For single locale performance testing we have a couple tests that generate
massive output files (fasta, a writeln test, and a few others.)

For batch mode, slurm buffers stdout on a per line basis and syncs the stdout
buffer to a file on the login node every so often. This constant syncing really
slows down these programs. For instance fasta generates a ~250 MB file and
previously this test took ~100 seconds to run. By sending output to /tmp and
then copying it, the tests only takes ~4 seconds (roughly the same time it
takes on chap04!, and the same time it takes for interactive mode)

This buffering works by setting slurm's --output to /tmp/<jobid>.out and then
after the job is completed moving the /tmp file to the output file that a user
specified or slurm auto-generated. In my (limited) testing, this also works for
multi-locale tests since all output is piped through a single node.

There's a pretty fat comment in in the slurm-srun launcher that goes into some
more detail.

I'm not sure if there's a similar issue for tests with a large stdin, but if
there is we can use slurms sbcast to take care of it.

This also updates chpl_launchcmd to use the stdout buffer for single locale
performance testing. I think it could set it in general, but there's no need to
since that's the only configuration with tests that produce massive amounts of
output
