### PR TITLE
Remove --verbose and --hostlist command line options from chpl_launchcmd

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -558,7 +558,7 @@ class AbstractJob(object):
         parser = argparse.ArgumentParser(
             description=__doc__,
             formatter_class=OurFormatter)
-        parser.add_argument('-v', '--verbose', action='store_true',
+        parser.add_argument('--CHPL_LAUNCHCMD_DEBUG', action='store_true',
                             default=('CHPL_LAUNCHCMD_DEBUG' in os.environ),
                             help=('Verbose output. Setting CHPL_LAUNCHCMD_DEBUG '
                                   'in environment also enables verbose output.'))
@@ -567,7 +567,7 @@ class AbstractJob(object):
         parser.add_argument('--n', help='Placeholder')
         parser.add_argument('--walltime', type=cls._cli_walltime,
                             help='Timeout as walltime for qsub.')
-        parser.add_argument('--hostlist',
+        parser.add_argument('--CHPL_LAUNCHCMD_HOSTLIST',
                             help=('Optional hostlist specification for reserving '
                                   'specific nodes. Can also be set with env var '
                                   'CHPL_LAUNCHCMD_HOSTLIST'))


### PR DESCRIPTION
These options can still be set with env vars. Technically they can still be
specified on the command line using the env var name as the option. I did this
because it's easier, and it leaves the info about setting the env vars in the
--help output.

We're moving away from --verbose and --hostlist because some chapel programs
use these and chpl_launchcmd was intercepting these args so the chapel program
would never see them.

This was noticed with xc single node perf testing where some tests throw
--verbose=true. This causes chpl_launchcmd to gripe because it's verbose was
specified with --verbose (=true/false) and it didn't know how to parse the arg.