### PR TITLE
Update paratest to work with new -futures-mode option

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -822,7 +822,7 @@ while ( $#argv > 0 )
         shift
         set futuresMode = 3
         breaksw
-    # "undocumented" option, only meant to be used by nightly
+    # "undocumented" option, only meant to be used by other scripts
     case -futures-mode:
     case --futures-mode:
         shift

--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -58,7 +58,7 @@ sub main {
     $workingdir = $ARGV[1];
     $testdir = $ARGV[2];
     $chplenv = $ARGV[3];
-    $futures_mode = "-futures-mode $ARGV[4]"
+    $futures_mode = "-futures-mode \"" . $ARGV[4] . "\"";
     $valgrind = ($ARGV[5] == 1) ? "-valgrind" : "";
 
     print "$id $workingdir $testdir $futures_mode $valgrind" if $debug;

--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -3,13 +3,13 @@
 # Client-side of the parallel testing script, paratest.server.
 # Used remotely by paratest.server to run start_test locally.
 #
-# Usage: paratest.client id chapeltestdir testdir chplenv futures valgrind [compopts]
+# Usage: paratest.client id chapeltestdir testdir chplenv futures-mode valgrind [compopts]
 #  
 #  id - used to create a file to synchronize with paratest.server
 #  chapeltestdir - root dir of Chapel test infrastructure
 #  testdir - directory to run start_test on
 #  chplenv - Chapel environment variables
-#  futures - include .future tests (0=no, 1=yes)
+#  futures-mode - include .futures (0=no, 1=all, 2=futures only, 3=futures with skipifs)
 #  valgrind - run valgrind (0=no, 1=yes)
 #  compopts - optional Chapel compiler options
 #
@@ -51,17 +51,17 @@ sub main {
 
     if ($#ARGV < 5) {
         fatal("insufficient arguments: '@ARGV'\n" .
-	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures valgrind memleaks [compopts] [execopts]");
+	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks [compopts] [execopts]");
     }
 
     $id = $ARGV[0];
     $workingdir = $ARGV[1];
     $testdir = $ARGV[2];
     $chplenv = $ARGV[3];
-    $incl_futures = ($ARGV[4] == 1) ? "-futures" : "";
+    $futures_mode = "-futures-mode $ARGV[4]"
     $valgrind = ($ARGV[5] == 1) ? "-valgrind" : "";
 
-    print "$id $workingdir $testdir $incl_futures $valgrind" if $debug;
+    print "$id $workingdir $testdir $futures_mode $valgrind" if $debug;
     if ($#ARGV>=7) {
         $compopts = "-compopts \"" . $ARGV[7] . "\"";
     }
@@ -95,7 +95,7 @@ sub main {
 
     $memleaks = ($ARGV[6] == 1) ? "-memleaks $logdir/tmp.$dirfname.$node.memleaks" : "";
 
-    $testarg = "-compiler $compiler -logfile $logfile $incl_futures $valgrind $compopts $execopts $memleaks";
+    $testarg = "-compiler $compiler -logfile $logfile $futures_mode $valgrind $compopts $execopts $memleaks";
     $testarg = "$testarg $testdir -norecurse";
 
     # Set up the Chapel environment passed in by paratest.server

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -41,7 +41,7 @@ $pwd = `pwd`; chomp $pwd;
 $client_script = "$pwd/../util/test/paratest.client";
 $summary_len = 2;
 $sleep_time = 1;                       # polling time (sec) to distribute work
-$incl_futures = 0;
+$futures_mode = 0;
 $filedist = 0;
 $node_para = 1;				                 # the number of tasks to run on each node
 $valgrind = 0;
@@ -251,7 +251,7 @@ sub feed_nodes {
                     $execopts = "\\\"$execopts\\\"";
                 }
                 # If the command line gets too long, consider using xargs
-                $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $incl_futures $valgrind $memleaksflag $compopts $execopts";
+                $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $futures_mode $valgrind $memleaksflag $compopts $execopts";
                 if ($verbose) {
                     systemd ($rem_cmd);
                 } else {
@@ -534,8 +534,17 @@ sub main {
                 print "missing -dirfile arg\n";
                 exit (8);
             }
+         # "undocumented" option, only meant to be used by other scripts
+        } elsif (/^-futures-mode/) {
+            shift @ARGV;
+            if ($#ARGV >= 0) {
+                $futures_mode = "$ARGV[0]";
+            } else {
+                print "missing -futures-mode arg\n";
+                exit (8);
+            }
         } elsif (/^-futures/) {
-            $incl_futures = 1;
+            $futures_mode = 1;
         } elsif (/^-logfile/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
@@ -659,7 +668,7 @@ sub main {
             next if /^$|^\#/;
             chomp;
             if ($filedist) {
-                push @testdir_list, find_files( $_, 0, !$incl_futures, 0);
+                push @testdir_list, find_files( $_, 0, !$futures_mode, 0);
             } else {
                 push @testdir_list, $_;
             }
@@ -674,7 +683,7 @@ sub main {
         chdir $cwd;
         if ($filedist) {
 	    print "[Collecting test files in $cwd]\n";
-            @testdir_list = find_files (".", 0, !$incl_futures, 1);
+            @testdir_list = find_files (".", 0, !$futures_mode, 1);
         } else {
 	    print "[Collecting test directories in $cwd]\n";
             @testdir_list = find_subdirs (".", 0);

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -538,7 +538,7 @@ sub main {
         } elsif (/^-futures-mode/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
-                $futures_mode = "$ARGV[0]";
+                $futures_mode = $ARGV[0];
             } else {
                 print "missing -futures-mode arg\n";
                 exit (8);


### PR DESCRIPTION
Follow up of 0b914e5. nightly now passes -futures-mode to either
start_test or paratest, but I forgot nightly uses paratest so I didn't update
it previously.

This updates paratest to support -futures-mode like start_test does and pipes it
through to when paratest.client cals start_test.

I did *not* add -futures-skipif to paratest, because it didn't seem like it
would get much use, but it's easy to add if it feels valuable to others.