### PR TITLE
Save the sha for perf and compiler perf runs

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1385,7 +1385,7 @@ if ($performance || $compperformance) then
 
   if ( $status != 0 ) then
       echo "[Error: Failed to save current sha to $shaDatFilePath]" |& $tee -a $logfile
-  else
+  endif
 endif
 
 

--- a/util/start_test
+++ b/util/start_test
@@ -1369,19 +1369,19 @@ if ($performance || $compperformance) then
   # output the key to a temp .perfkeys file for computePerfStats to use
   set shaKey = "sha"
   set shaPerfKeys = "$chplTestTmpDir/sha.perfkeys"
-  echo "$shaKey " > $shaPerfKeys
+  echo "$shaKey " > "$shaPerfKeys"
 
   # output the shaKey and current sha to a temp file for computePerfStats to use
   set shaOut = "$chplTestTmpDir/sha.exec.out.tmp"
-  echo "$shaKey `git rev-parse HEAD`" >  $shaOut
+  echo "$shaKey `git rev-parse HEAD`" > "$shaOut"
 
   # the name of the .dat file to store the sha (store in env var for gengraphs)
   set shaDatFileName = "perfSha"
   set shaDatFilePath = "$perfdir/$shaDatFileName.dat"
-  setenv CHPL_TEST_SHA_DAT_FILE $shaDatFilePath
+  setenv CHPL_TEST_SHA_DAT_FILE "$shaDatFilePath"
 
   echo "[Saving current git sha to $shaDatFilePath]" |& $tee -a $logfile
-  $utildir/test/computePerfStats $shaDatFileName $datdir $shaPerfKeys $shaOut
+  "$utildir/test/computePerfStats" "$shaDatFileName" "$datdir" "$shaPerfKeys" "$shaOut"
 
   if ( $status != 0 ) then
       echo "[Error: Failed to save current sha to $shaDatFilePath]" |& $tee -a $logfile

--- a/util/start_test
+++ b/util/start_test
@@ -1351,6 +1351,42 @@ if ($compperformance) then
     set combineCompPerf = $utildir/test/combineCompPerfData
 endif
 
+# save the sha for the current run so we can map dates to shas in the
+# performance and compiler performance graphs
+if ($performance || $compperformance) then
+
+  set datdir = ""
+  if ($performance) then
+    set datdir = $perfdir
+  else
+    set datdir = $compperfdir
+  endif
+
+  if (! -e $datdir) then
+      mkdir -p $datdir
+  endif
+
+  # output the key to a temp .perfkeys file for computePerfStats to use
+  set shaKey = "sha"
+  set shaPerfKeys = "$chplTestTmpDir/sha.perfkeys"
+  echo "$shaKey " > $shaPerfKeys
+
+  # output the shaKey and current sha to a temp file for computePerfStats to use
+  set shaOut = "$chplTestTmpDir/sha.exec.out.tmp"
+  echo "$shaKey `git rev-parse HEAD`" >  $shaOut
+
+  # the name of the .dat file to store the sha (store in env var for gengraphs)
+  set shaDatFileName = "perfSha"
+  set shaDatFilePath = "$perfdir/$shaDatFileName.dat"
+  setenv CHPL_TEST_SHA_DAT_FILE $shaDatFilePath
+
+  echo "[Saving current git sha to $shaDatFilePath]" |& $tee -a $logfile
+  $utildir/test/computePerfStats $shaDatFileName $datdir $shaPerfKeys $shaOut
+
+  if ( $status != 0 ) then
+      echo "[Error: Failed to save current sha to $shaDatFilePath]" |& $tee -a $logfile
+  else
+endif
 
 
 # Auto-generate tests from the spec

--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -45,7 +45,7 @@ if ($argc >= 7) {
     $mon += 1;
     $year -= 100;
 
-    $perfdate = sprintf("%.2d/%.2d/%.2d ", $mon, $mday, $year);
+    $perfdate = sprintf("%.2d/%.2d/%.2d", $mon, $mday, $year);
     print "Using default date $perfdate\n";
 }
 


### PR DESCRIPTION
We want to be able to map a specific date back to the sha easily. For now we're
just putting the long sha in a special .dat file. The long term plan is to
have gengraphs do something special with this dat file, and make the sha for
each date available to dygraphs. Dygraphs will then display the sha for the
day either in the legend above the date, or if you hover over a point.

This stores the long sha, since the short sha could become ambiguous over time.
My current thinking is that the .dat file will always store just the long sha,
and then gengraphs can run "git rev-parse --short <long sha>" every night. This
way we can display the short sha on the graphs, without having to worry about
them becoming ambiguous.