### PR TITLE
Remove FLAG_USER_NAMED from chpl_extern_array_wrapper routines

### DIFF
--- a/compiler/passes/expandExternArrayCalls.cpp
+++ b/compiler/passes/expandExternArrayCalls.cpp
@@ -99,6 +99,7 @@ void expandExternArrayCalls() {
       fn->defPoint->insertAfter(new DefExpr(fcopy));
       fcopy->removeFlag(FLAG_EXTERN);
       fcopy->removeFlag(FLAG_FUNCTION_PROTOTYPE);
+      fcopy->removeFlag(FLAG_USER_NAMED);
       fcopy->addFlag(FLAG_INLINE);
       fcopy->cname = astr("chpl__extern_array_wrapper_", fcopy->cname);
       fn->name = astr("chpl__extern_array_", fn->name);


### PR DESCRIPTION
Due to the way that chpl_extern_array_wrapper routines are created in
the compiler (these are functions that take care of passing Chapel
arrays out to extern arrays), they inherit the flags of the original
extern routine unless they're explicitly removed.  In previous work,
the FLAG_USER_NAMED was not removed from the new routine, meaning
that the code generator was not allowed to rename the routine.  This
caused problems in cases where we create multiple instantiations of
the chpl_extern_array_wrapper routine (as in multidimArrToExtern.chpl
when arrays of different ranks are passed to the extern), as the
instantiations would all have the same name and not be renamed in
the code generator.

The fix here is to simply remove FLAG_USER_NAMED from the new
function.

Editorializing, given that FLAG_USER_NAMED is equivalent to
FLAG_EXTERN | FLAG_EXPORT, and is only referenced in 3 places in the
compiler, I'd prefer to deprecate it and either rely on querying
FLAG_EXTERN | FLAG_EXPORT in such cases, or adding a
Symbol::mayRename() query that checks for either of those two flags.
My motivation being to reduce the number of flags in cases where
there's such a clear isomorphism between them (and no currently
anticiapted cases of other cases resulting in this flag that I'm aware
of).