### PR TITLE
replace sleep with sync{} in test_10k_begins

### DIFF
--- a/test/stress/deitz/test_10k_begins.chpl
+++ b/test/stress/deitz/test_10k_begins.chpl
@@ -4,13 +4,13 @@ config const n = 10000;
 
 var A: [1..n] int;
 
-for i in 1..n {
-  begin {
-    A(i) += 1;
+sync {
+  for i in 1..n {
+    begin {
+      A(i) += 1;
+    }
   }
 }
-
-sleep(2);
 
 for i in 1..n do
   if A(i) != 1 then


### PR DESCRIPTION
This test is inherently racey with the sleep in it, the sync should resolve the
intermittent failures we see with it.

From Brad:
"
As the name (and commit message) suggests, I think it's just a stress test to
make sure we can bash on the tasking interface without things falling apart.  I
don't think it's trying to show any timing implications, and agree that it
shouldn't rely on a sleep() for correctness (old tests used to rely on sleeps
way too much to "coordinate" between tasks -- I think we've generally been
trying to rewrite these to use syncs when possible).

For this specific case, I think wrapping the first for loop in a sync statement
would capture the behavior we want (stressing the task system) while removing
the potential for a race.
"