### PR TITLE
Run full suite of tests for XC whitebox configurations.

### DIFF
--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -8,7 +8,7 @@ source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 
 # Run the tests!
-nightly_args="-cron -examples"
+nightly_args="-cron"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."

--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -8,7 +8,7 @@ source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 
 # Run the tests!
-nightly_args="-cron -examples -no-futures"
+nightly_args="-cron -examples"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."

--- a/util/cron/test-xe-wb.bash
+++ b/util/cron/test-xe-wb.bash
@@ -8,7 +8,7 @@ source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 
 # Run the tests!
-nightly_args="-cron -no-futures"
+nightly_args="-cron"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."


### PR DESCRIPTION
Also, run .skipif'd futures for both XE and XC configurations.

The test matrix will now look the same for XE and XC:

|       | TARGET       | HOST-TARGET       | HOST-TARGET-no-PrgEnv |
|-------|--------------|-------------------|-----------------------|
| **cray**  | full (17 hr) | examples (1 hr)   | X                     |
| **intel** | full (15 hr) | examples (1 hr)   | full (15 hr)          |
| **pgi**   | full (10 hr) | examples (40 min) | full (10 hr)          |
| **gnu**   | full (10 hr) | examples (40 min) | full (10 hr)            |