### PR TITLE
Update when CHPL_LAUNCHER_SLURM_BUFFER_STDOUT is set by chpl_launchcmd

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -929,7 +929,7 @@ class SlurmJob(AbstractJob):
         # We could use stdout buffering for other configurations too, but I
         # don't think there's any need. Currently, single locale perf testing
         # is the only config that has any tests that produce a lot of output
-        if os.getenv('CHPL_TEST_PERF') != None and self.num_locales == 1:
+        if os.getenv('CHPL_TEST_PERF') != None and self.num_locales <= 1:
             env['CHPL_LAUNCHER_SLURM_BUFFER_STDOUT'] = 'true'
 
         cmd = self.test_command[:]


### PR DESCRIPTION
num_locales = -1 for comm=none, key off of num_locales <= 1 instead of == 1 to
automatically set the stdout buffering.

I did a full perf test run with this on tiger with gnu and had 0 failures!
Hopefully the nightly run is clean too