### PR TITLE
Make genGraphs recursively chmod html/ directory

### DIFF
--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -1061,13 +1061,15 @@ def main():
             sys.stdout.write('Created SUCCESS file\n')
             #
             # recursively chmod the html/ directory for access via web servers
+            #  - for directories, chmod u+rwx and go+rx
+            #  - for directories, chmod go+r
             #
             for root, dirs, files in os.walk(outdir):
                 os.chmod(root, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
                 for momo in dirs:
                     os.chmod(os.path.join(root, momo), stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
                 for momo in files:
-                    os.chmod(os.path.join(root, momo), stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH)
+                    os.chmod(os.path.join(root, momo), stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
 
 
     return 0

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import sys, os, shutil, time, math, re
+import sys, os, shutil, time, math, re, stat
 from optparse import OptionParser
 
 import fileReadHelp
@@ -1059,6 +1059,16 @@ def main():
             # files were copied over. This is used to see if we should sync the
             # files over to sourceforge.
             sys.stdout.write('Created SUCCESS file\n')
+            #
+            # recursively chmod the html/ directory for access via web servers
+            #
+            for root, dirs, files in os.walk(outdir):
+                os.chmod(root, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+                for momo in dirs:
+                    os.chmod(os.path.join(root, momo), stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+                for momo in files:
+                    os.chmod(os.path.join(root, momo), stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH)
+
 
     return 0
 


### PR DESCRIPTION
Every time I make graphs and try to browse them via a local web share,
I have to re-chmod the directory by hand.  This commit proposes doing
it automatically (directories become u+rwx, go+rx; files become u+rwx, go+r.
My Python is probably terrible, characteristically, and I'm open to feedback
on it.
