### PR TITLE
Add routine to trim output from tests in sub_test

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -197,6 +197,15 @@ def LauncherTimeoutArgs(seconds):
 def ShellEscape(str):
     return re.sub(r'([\\!@#$%^&*()?\'"|<>[\]{} ])', r'\\\1', str)
 
+# Grabs the start and end of the output and replaces non-printable chars with ~
+def trim_output(output):
+    max_size = 256*1024 # ~1/4 MB
+    if len(output) > max_size:
+        new_output = output[:max_size/2]
+        new_output += output[-max_size/2:]
+        output = new_output
+    return ''.join(s if s in string.printable else "~" for s in output)
+
 # return True if f has .chpl extension
 def IsChplTest(f):
     if re.match(r'^.+\.(chpl|test\.c)$', f):
@@ -246,7 +255,7 @@ def DiffFiles(f1, f2):
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
     if p.returncode != 0:
-        sys.stdout.write(myoutput)
+        sys.stdout.write(trim_output(myoutput))
     return p.returncode
 
 # diff output vs. .bad file, filtering line numbers out of error messages that arise
@@ -448,15 +457,6 @@ def runSkipIf(skipifName):
     else:
         skiptest = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE).communicate()[0]
     return skiptest
-
-# Grabs first and last 1000 characters and replaces non-printable ones with ~
-def trim_output(output):
-    if len(output) > 2000:
-        new_output = output[:1000]
-        new_output += output[-1000:]
-        output = new_output
-    return ''.join(s if s in string.printable else "~" for s in output)
-
 
 # Start of sub_test proper
 #
@@ -1730,10 +1730,9 @@ for testname in testsrc:
                         if not os.path.isfile(execgoodfile) or not os.access(execgoodfile, os.R_OK):
                             sys.stdout.write('[Error cannot locate program output comparison file %s/%s]\n'%(localdir, execgoodfile))
                             sys.stdout.write('[Execution output was as follows:]\n')
-                            combined = subprocess.Popen(['cat', execlog],
-                                                        stdout=subprocess.PIPE).
-                                                        communicate()[0]
-                            sys.stdout.write(trim_output(combined))
+                            exec_output = subprocess.Popen(['cat', execlog],
+                                stdout=subprocess.PIPE).communicate()[0]
+                            sys.stdout.write(trim_output(exec_output))
 
                             continue # on to next execopts
 

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -449,6 +449,15 @@ def runSkipIf(skipifName):
         skiptest = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE).communicate()[0]
     return skiptest
 
+# Grabs first and last 1000 characters and replaces non-printable ones with ~
+def trim_output(output):
+    if len(output) > 2000:
+        new_output = output[:1000]
+        new_output += output[-1000:]
+        output = new_output
+    return ''.join(s if s in string.printable else "~" for s in output)
+
+
 # Start of sub_test proper
 #
 
@@ -1563,7 +1572,7 @@ for testname in testsrc:
                         printTestVariation(compoptsnum, execoptsnum);
                         sys.stdout.write(']\n')
                         sys.stdout.write('[Execution output was as follows:]\n')
-                        sys.stdout.write(output)
+                        sys.stdout.write(trim_output(output))
 
                 elif useTimedExec:
                     wholecmd = cmd+' '+' '.join(map(ShellEscape, args))
@@ -1587,7 +1596,7 @@ for testname in testsrc:
                         printTestVariation(compoptsnum, execoptsnum);
                         sys.stdout.write(']\n')
                         sys.stdout.write('[Execution output was as follows:]\n')
-                        sys.stdout.write(output)
+                        sys.stdout.write(trim_output(output))
                     else:
                         # for perf runs print out the 5 processes with the
                         # highest cpu usage. This should help identify if other
@@ -1708,7 +1717,7 @@ for testname in testsrc:
                         # .good file that corresponds to that run 
                         if not onlyone:
                             commExecNum.insert(0,'.'+str(compoptsnum)+'-'+str(execoptsnum))
-                        
+
                         # if the .good file was explicitly specified, look for
                         # that version instead of the multiple
                         # compopts/execopts or just the base .good file 
@@ -1721,9 +1730,10 @@ for testname in testsrc:
                         if not os.path.isfile(execgoodfile) or not os.access(execgoodfile, os.R_OK):
                             sys.stdout.write('[Error cannot locate program output comparison file %s/%s]\n'%(localdir, execgoodfile))
                             sys.stdout.write('[Execution output was as follows:]\n')
-                            sys.stdout.write(subprocess.Popen(['cat', execlog],
-                                                              stdout=subprocess.PIPE).
-                                            communicate()[0])
+                            combined = subprocess.Popen(['cat', execlog],
+                                                        stdout=subprocess.PIPE).
+                                                        communicate()[0]
+                            sys.stdout.write(trim_output(combined))
 
                             continue # on to next execopts
 


### PR DESCRIPTION
We were previously triming output from tests in computePerfStats, but
that didnt' handle all cases (timeout, ...). This change should prevent
us from making 400MB+ log files.