### PR TITLE
Remove FLAG_USER_NAMED

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -150,6 +150,10 @@ bool Symbol::isParameter() const {
   return false;
 }
 
+bool Symbol::isRenameable() const {
+  return !(hasFlag(FLAG_EXPORT) || hasFlag(FLAG_EXTERN));
+}
+
 
 GenRet Symbol::codegen() {
   GenInfo* info = gGenInfo;

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -232,7 +232,6 @@ symbolFlag( FLAG_TRIVIAL_ASSIGNMENT, ypr, "trivial assignment", "an assignment w
 symbolFlag( FLAG_TUPLE , ypr, "tuple" , ncm )
 symbolFlag( FLAG_TYPE_CONSTRUCTOR , npr, "type constructor" , ncm )
 symbolFlag( FLAG_TYPE_VARIABLE , npr, "type variable" , "contains a type instead of a value" )
-symbolFlag( FLAG_USER_NAMED , npr, "user named" , "named by the user" /* so leave it alone */ )
 symbolFlag( FLAG_VIRTUAL , npr, "virtual" , ncm )
 // Used to mark where a compiler generated flag was removed (but is desired
 // elsewhere).

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -110,6 +110,7 @@ public:
   virtual bool       isConstValWillNotChange()                 const;
   virtual bool       isImmediate()                             const;
   virtual bool       isParameter()                             const;
+  virtual bool       isRenameable()                            const;
 
   virtual void       codegenDef();
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -110,7 +110,7 @@ public:
   virtual bool       isConstValWillNotChange()                 const;
   virtual bool       isImmediate()                             const;
   virtual bool       isParameter()                             const;
-  virtual bool       isRenameable()                            const;
+          bool       isRenameable()                            const;
 
   virtual void       codegenDef();
 

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -607,8 +607,6 @@ fn_decl_stmt:
 
       fn->copyFlags($1);
       // The user explicitly named this function (controls mangling).
-      if ($1->hasFlag(FLAG_EXPORT) || $1->hasFlag(FLAG_EXTERN))
-        fn->addFlag(FLAG_USER_NAMED);
       if (*$1->name)
         fn->cname = $1->name;
 

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -59,7 +59,7 @@ subChar(Symbol* sym, const char* ch, const char* x) {
 }
 
 static void legalizeName(Symbol* sym) {
-  if (sym->hasFlag(FLAG_EXTERN))
+  if (!sym->isRenameable())
     return;
   for (const char* ch = sym->cname; *ch != '\0'; ch++) {
     switch (*ch) {
@@ -541,14 +541,18 @@ static void protectNameFromC(Symbol* sym) {
   }
 
   //
-  // Let's assume we only have to rename user symbols and that we've
-  // done a good job of protecting our internal and standard module
-  // symbols.  This has the advantage of not having to take special
-  // pains to keep from renaming things like chpl_string and uint64_t
-  // (which perhaps should arguably also have FLAG_EXTERN, but don't
-  // consistently seem to today; and adding FLAG_EXTERN to them seems
-  // to result in it getting propagated to type aliases and such in
-  // ways that caused headaches for me).
+  // For now, we only rename our user and standard symbols.  Internal
+  // modules symbols should arguably similarly be protected, to ensure
+  // that we haven't inadvertantly used a name that some user library
+  // will; most file-level symbols should be protected by 'chpl_' or
+  // somesuch, but of course local symbols may not be, and can cause
+  // conflicts (at present, a local variable named 'socket' would).
+  // The challenges to handling MOD_INTERNAL symbols in the same way
+  // today is that things like chpl_string and uint64_t should not be
+  // renamed, and should arguably have FLAG_EXTERN on them; however,
+  // putting it on them causes it to bleed over onto type aliases in a
+  // way that breaks things and wasn't easy to fix.  So this remains
+  // a TODO (currently in Brad's court).
   //
   ModuleSymbol* symMod = sym->getModule();
   if (symMod->modTag == MOD_INTERNAL) {
@@ -560,7 +564,7 @@ static void protectNameFromC(Symbol* sym) {
   // outside of Chapel is relying on it to have a certain name and we
   // need to respect that.
   //
-  if (sym->hasFlag(FLAG_EXPORT) || sym->hasFlag(FLAG_EXTERN)) {
+  if (!sym->isRenameable()) {
     return;
   }
 
@@ -685,7 +689,7 @@ static void codegen_header() {
   // mangle type names if they clash with other types
   //
   forv_Vec(TypeSymbol, ts, types) {
-    if (!ts->hasFlag(FLAG_EXTERN))
+    if (ts->isRenameable())
       ts->cname = uniquifyName(ts->cname, &cnames);
   }
   uniquifyNameCounts.clear();
@@ -728,7 +732,7 @@ static void codegen_header() {
   // constants, or other global variables
   //
   forv_Vec(VarSymbol, var, globals) {
-    if (!var->hasFlag(FLAG_EXTERN))
+    if (var->isRenameable())
       var->cname = uniquifyName(var->cname, &cnames);
   }
   uniquifyNameCounts.clear();
@@ -738,7 +742,7 @@ static void codegen_header() {
   // global variables, or other functions
   //
   forv_Vec(FnSymbol, fn, functions) {
-    if (!fn->hasFlag(FLAG_USER_NAMED))
+    if (fn->isRenameable())
       fn->cname = uniquifyName(fn->cname, &cnames);
   }
   uniquifyNameCounts.clear();

--- a/compiler/passes/expandExternArrayCalls.cpp
+++ b/compiler/passes/expandExternArrayCalls.cpp
@@ -99,7 +99,6 @@ void expandExternArrayCalls() {
       fn->defPoint->insertAfter(new DefExpr(fcopy));
       fcopy->removeFlag(FLAG_EXTERN);
       fcopy->removeFlag(FLAG_FUNCTION_PROTOTYPE);
-      fcopy->removeFlag(FLAG_USER_NAMED);
       fcopy->addFlag(FLAG_INLINE);
       fcopy->cname = astr("chpl__extern_array_wrapper_", fcopy->cname);
       fn->name = astr("chpl__extern_array_", fn->name);

--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -268,7 +268,6 @@ void convertDeclToChpl(ModuleSymbol* module, const char* name, Vec<Expr*> & resu
     f->addFlag(FLAG_EXTERN);
     f->addFlag(FLAG_LOCAL_ARGS);
     f->addFlag(FLAG_FUNCTION_PROTOTYPE);
-    f->addFlag(FLAG_USER_NAMED);
     Expr* chpl_type = convertToChplType(module, fd->getResultType().getTypePtr(), results);
     BlockStmt* result = buildFunctionDecl(
        f, RET_VALUE, chpl_type, NULL, NULL, NULL);


### PR DESCRIPTION
FLAG_USER_NAMED has been identical to FLAG_EXTERN|FLAG_EXPORT since it
was introduced, and to that end, seems superfluous and to only
potentially introduce bugs (like the one I fixed earlier today).

Replaced it with a method isRenameable() that checks to make sure
neither FLAG_EXTERN nor FLAG_EXPORT are set.  Updated checks of
any of these three flags in codegen.cpp where renaming occurs to
use this method instead.

While here, I updated a comment to reflect the current status of
identifier munging.