### PR TITLE
Null out last two args in list in chpl_bundle_exec_args

### DIFF
--- a/runtime/src/main_launcher.c
+++ b/runtime/src/main_launcher.c
@@ -203,6 +203,7 @@ char** chpl_bundle_exec_args(int argc, char *const argv[],
   }
 
   newargv[len-1] = NULL;
+  newargv[len-2] = NULL;
 
   // add any launcher args
   if (largc > 0) {


### PR DESCRIPTION
chpl_bundle_exec_args can now add a binary wrapper with a2ff5fd8b15c. If the
wrapper is not used there's an empty position in the arg array. A null denotes
the end of the args, but when there was no wrapper our last arg wasn't set to
anything so it was gibberish still fed to the binary. This caused a regression
for test/studies/lulesh/bradc/lulesh-dense. I think there is a cleaner solution
to this (only allocate the space we actually need) but is is simple and it's
the end of the week.

I'll take a look at cleaning it up next week.