### PR TITLE
Update start_test to work better outside of CHPL_HOME.

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -993,7 +993,7 @@ while ( $#argv > 0 )
     case -test-root:
     case --test-root:
         shift
-        set testRootDir = shift $argv[1]
+        set testRootDir = $argv[1]
         shift
         breaksw
     case -junit-xml:
@@ -1085,7 +1085,7 @@ if ($optionerr == 1) then
 endif
 
 if ($testRootDir != "") then
-    setenv CHPL_TEST_ROOT_DIR = "$testRootDir"
+    setenv CHPL_TEST_ROOT_DIR "$testRootDir"
 endif
 
 set invocationDir = "$cwd"
@@ -1912,10 +1912,12 @@ if ($junit_xml_file != 0) then
 endif
 if ($junit_remove_prefix != 0) then
     set junit_args = "$junit_args --remove-prefix=$junit_remove_prefix"
-else if ($testRootDir = "") then
-    # If --test-root was thrown, also remove it from the junit report (in case
-    # something slipped through in sub_test).
-    set junit_args = "$junit_args --remove-prefix=$testRootDir"
+else
+    if ($testRootDir != "") then
+	# If --test-root was thrown, also remove it from the junit report (in case
+	# something slipped through in sub_test).
+	set junit_args = "$junit_args --remove-prefix=$testRootDir"
+    endif
 endif
 if ($suppressions != "") then
     set junit_args = "$junit_args --suppress=$suppressions"

--- a/util/start_test
+++ b/util/start_test
@@ -645,7 +645,7 @@ endif
 if ($?CHPL_TEST_UTIL_DIR) then
     set utildir = "$CHPL_TEST_UTIL_DIR"
 else
-    set utildir = "$CHPL_HOME/util"
+    set utildir = `dirname $0`
     setenv CHPL_TEST_UTIL_DIR $utildir
 endif
 if (! -d $utildir || ! -x $utildir) then
@@ -1912,12 +1912,10 @@ if ($junit_xml_file != 0) then
 endif
 if ($junit_remove_prefix != 0) then
     set junit_args = "$junit_args --remove-prefix=$junit_remove_prefix"
-else
-    if ($testRootDir != "") then
-	# If --test-root was thrown, also remove it from the junit report (in case
-	# something slipped through in sub_test).
-	set junit_args = "$junit_args --remove-prefix=$testRootDir"
-    endif
+else if ($testRootDir != "") then
+    # If --test-root was thrown, also remove it from the junit report (in case
+    # something slipped through in sub_test).
+    set junit_args = "$junit_args --remove-prefix=$testRootDir"
 endif
 if ($suppressions != "") then
     set junit_args = "$junit_args --suppress=$suppressions"

--- a/util/start_test
+++ b/util/start_test
@@ -645,7 +645,8 @@ endif
 if ($?CHPL_TEST_UTIL_DIR) then
     set utildir = "$CHPL_TEST_UTIL_DIR"
 else
-    set utildir = `dirname $0`
+    set start_test_dir = `dirname $0`
+    set utildir = `cd $start_test_dir && pwd`
     setenv CHPL_TEST_UTIL_DIR $utildir
 endif
 if (! -d $utildir || ! -x $utildir) then

--- a/util/start_test
+++ b/util/start_test
@@ -89,6 +89,7 @@
 #   -memleaks
 #   -no-chpl-home-warn                Do not show warning when start_test invoked outside CHPL_HOME
 #   -progress                         Print pass/fail to stderr for each test. Does not work for directories.
+#   -test-root                        Absolute path to test dir. Set when test dir is not under CHPL_HOME.
 #   -junit-xml                        Create jUnit XML style report.
 #   -junit-xml-file <file>            Path to store jUnit XML report. When set, -junit-xml is implied.
 #   -junit-remove-prefix <prefix>     Remove <prefix> from all tests in jUnit report.
@@ -732,6 +733,7 @@ set suppressions = ""
 set optionerr = 0
 set chplHomeWarn = 1
 set progress = 0
+set testRootDir = ""
 set junit_xml = 0
 set junit_xml_file = 0
 set junit_remove_prefix = 0
@@ -988,6 +990,12 @@ while ( $#argv > 0 )
         shift
         set progress = 1
         breaksw
+    case -test-root:
+    case --test-root:
+        shift
+        set testRootDir = shift $argv[1]
+        shift
+        breaksw
     case -junit-xml:
     case --junit-xml:
         shift
@@ -1046,6 +1054,7 @@ while ( $#argv > 0 )
         echo "          -memleaks <file>"
         echo "          -no-chpl-home-warn"
         echo "          -progress"
+        echo "          -test-root"
         echo "          -junit-xml"
         echo "          -junit-xml-file <file>  (implies -junit-xml)"
         echo "          -junit-remove-prefix <prefix>"
@@ -1073,6 +1082,10 @@ end
 
 if ($optionerr == 1) then
     exit 1
+endif
+
+if ($testRootDir != "") then
+    setenv CHPL_TEST_ROOT_DIR = "$testRootDir"
 endif
 
 set invocationDir = "$cwd"

--- a/util/start_test
+++ b/util/start_test
@@ -1912,6 +1912,10 @@ if ($junit_xml_file != 0) then
 endif
 if ($junit_remove_prefix != 0) then
     set junit_args = "$junit_args --remove-prefix=$junit_remove_prefix"
+else if ($testRootDir = "") then
+    # If --test-root was thrown, also remove it from the junit report (in case
+    # something slipped through in sub_test).
+    set junit_args = "$junit_args --remove-prefix=$testRootDir"
 endif
 if ($suppressions != "") then
     set junit_args = "$junit_args --suppress=$suppressions"

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -58,6 +58,10 @@
 #                         system. CAUTION: This wont necessarily work for all
 #                         tests, but can allow for running multiple start_tests
 #                         over a directory in parallel.
+# CHPL_TEST_ROOT_DIR: Absolute path to the test/ dir. Useful when test dir is
+#                     not under $CHPL_HOME. Should not be set when test/ is
+#                     under $CHPL_HOME. When it is set and the path prefixes a
+#                     test in the logs, it will be removed (from the logs).
 #
 #
 # DIRECTORY-WIDE FILES:  These settings are for the entire directory and
@@ -205,6 +209,7 @@ def trim_output(output):
         new_output += output[-max_size/2:]
         output = new_output
     return ''.join(s if s in string.printable else "~" for s in output)
+
 
 # return True if f has .chpl extension
 def IsChplTest(f):
@@ -511,6 +516,12 @@ if os.path.isdir(testdir)==0:
 # Needed for MacOS mount points
 testdir = os.path.realpath(testdir)
 # sys.stdout.write('testdir='+testdir+'\n');
+
+# If user specified a different test directory (e.g. with --test-root flag on
+# start_test), use it instead.
+test_root_dir = os.environ.get('CHPL_TEST_ROOT_DIR')
+if test_root_dir is not None:
+    testdir = test_root_dir
 
 # Use timedexec
 # As much as I hate calling out to another script for the time out stuff,


### PR DESCRIPTION
Add --test-root `<dir>` flag, which tells start_test and subsequently sub_test to
use that dir as the base for relative paths. This means when the test/ dir is outside
of CHPL_HOME, as is the case for cray module testing, --test-root can be used to
get relative paths in the logs.

If --test-root is provided and --junit-remove-prefix is not, --test-root value is also
passed to the junit report generator to be removed (though it probably won't be
needed).

Also, update `$utildir` to default to the same dir as start_test as opposed to using
$CHPL_HOME/util. This means start_test and util/sub_test (and other util scripts)
will be from the same location as opposed to start_test potentially being in
some/non/CHPL_HOME/path/start-test and sub_test being in $CHPL_HOME/util/sub_test.