### PR TITLE
Fix compiler perf testing.

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1391,7 +1391,7 @@ if ($performance || $compperformance) then
 
   # the name of the .dat file to store the sha (store in env var for gengraphs)
   set shaDatFileName = "perfSha"
-  set shaDatFilePath = "$perfdir/$shaDatFileName.dat"
+  set shaDatFilePath = "$datdir/$shaDatFileName.dat"
   setenv CHPL_TEST_SHA_DAT_FILE "$shaDatFilePath"
 
   echo "[Saving current git sha to $shaDatFilePath]" |& $tee -a $logfile


### PR DESCRIPTION
Update sha1 dat file code to use $datdir instead of $perfdir when computing the
dat file path. This looks like it was a simple typo, as $datdir is computed a
handful of lines above.

pr: @ronawho