### PR TITLE
Update nightly to conditionally build with optimizations.

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -274,6 +274,7 @@ if ($make eq "") {
 if ($make eq "") {
     $make = "make";
 }
+print "Using make: $make\n";
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
@@ -461,23 +462,36 @@ if ($hostplatform =~ "cygwin") {
     mysystem("cd $chplhomedir && find . -name FILES -exec rm {} \\;");
 }
 
+$hostcompiler = `$utildir/chplenv/chpl_compiler.py --host`; chomp($hostcompiler);
 
-print "Making DEBUG=0 OPTIMIZE=1 WARNINGS=1 compiler\n";
-$makestat = mysystem("cd $chplhomedir && $make -j$num_procs DEBUG=0 OPTIMIZE=1 WARNINGS=1 compiler", "making chapel compiler", 0, 1);
+# Setup variables to pass to all make calls.
+$make_vars_no_opt = "DEBUG=0 WARNINGS=1";
+
+# Add OPTIMIZE=1 for most environments. If using the cray programming
+# environment, disable optimizations when building the compiler.
+if ($hostcompiler eq "cray-prgenv-cray") {
+    $make_vars_opt .= " OPTIMIZE=0";
+} else {
+    $make_vars_opt .= " OPTIMIZE=1";
+}
+
+
+print "Making $make_vars_opt compiler\n";
+$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt compiler", "making chapel compiler", 0, 1);
 if ($makestat != 0) {
-    print "Making DEBUG=0 WARNINGS=1 compiler\n";
+    print "Making $make_vars_no_opt compiler\n";
     # Since the rest of the compiler is being built unoptimized, disable
     # compiler performance testing so we don't get unexplained hiccups in
     # the perf graphs.
     print "compiler performance testing will be disabled\n";
     $compperformance = 0;
-    mysystem("cd $chplhomedir && $make -j$num_procs DEBUG=0 WARNINGS=1 compiler", "making chapel compiler", 1, 1);
+    mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_no_opt compiler", "making chapel compiler", 1, 1);
 }
 
 # Speculatively build a couple third-party libraries. This command should not
 # fail, even if it fails to build the libraries.
-print "Making DEBUG=0 OPTIMIZE=1 WARNINGS=1 third-party-try-opt\n";
-mysystem("cd $chplhomedir && $make -j$num_procs DEBUG=0 OPTIMIZE=1 WARNINGS=1 third-party-try-opt", "make chapel third-party-try-opt", 1, 1);
+print "Making $make_vars_opt third-party-try-opt\n";
+mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt third-party-try-opt", "make chapel third-party-try-opt", 1, 1);
 
 if ($buildruntime == 0) {
     $endtime = localtime;
@@ -499,15 +513,15 @@ if ($buildruntime == 0) {
 # if this is a performance test run then failing to build the runtime with
 # optimizations is a fatal error.  Otherwise we could get hiccups in the
 # performance graphs that are difficult to track.
-print "Making DEBUG=0 OPTIMIZE=1 WARNINGS=1 $qthreadopts runtime\n";
-$makestat = mysystem("cd $chplhomedir && $make -j$num_procs DEBUG=0 OPTIMIZE=1 WARNINGS=1 $qthreadopts runtime", "making chapel runtime", $performance, 1);
+print "Making $make_vars_opt $qthreadopts runtime\n";
+$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt $qthreadopts runtime", "making chapel runtime", $performance, 1);
 if ($makestat != 0) {
-    print "Making DEBUG=0 WARNINGS=1 $qthreadopts runtime\n";
-    mysystem("cd $chplhomedir && $make -j$num_procs DEBUG=0 WARNINGS=1 $qthreadopts runtime", "making chapel runtime", 1, 1);
+    print "Making $make_vars_no_opt $qthreadopts runtime\n";
+    mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_no_opt $qthreadopts runtime", "making chapel runtime", 1, 1);
 }
 
 print "Making modules\n";
-$makestat = mysystem("cd $chplhomedir && $make -j$num_procs WARNINGS=1 modules", "making chapel modules", 0, 1);
+$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt modules", "making chapel modules", 0, 1);
 
 
 #

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -470,9 +470,9 @@ $make_vars_no_opt = "DEBUG=0 WARNINGS=1";
 # Add OPTIMIZE=1 for most environments. If using the cray programming
 # environment, disable optimizations when building the compiler.
 if ($hostcompiler eq "cray-prgenv-cray") {
-    $make_vars_opt .= " OPTIMIZE=0";
+    $make_vars_opt = "$make_vars_no_opt OPTIMIZE=0";
 } else {
-    $make_vars_opt .= " OPTIMIZE=1";
+    $make_vars_opt = "$make_vars_no_opt OPTIMIZE=1";
 }
 
 

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -474,7 +474,9 @@ $hostcompiler = `$utildir/chplenv/chpl_compiler.py --host`; chomp($hostcompiler)
 $make_vars_no_opt = "DEBUG=0 WARNINGS=1";
 
 # Add OPTIMIZE=1 for most environments. If using the cray programming
-# environment, disable optimizations when building the compiler.
+# environment, disable optimizations when building the compiler. This is an
+# experiment to see if it stabilizes the tests for the compiler when built with
+# cray C++/C compiler.
 if ($hostcompiler eq "cray-prgenv-cray") {
     $make_vars_opt = "$make_vars_no_opt OPTIMIZE=0";
 } else {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -267,14 +267,7 @@ if ($basetmpdir eq "") {
 if ($basetmpdir eq "") { 
     $basetmpdir = "/tmp"; 
 } 
-$make = $ENV{'CHPL_NIGHTLY_MAKE'};
-if ($make eq "") {
-    $make = $ENV{'MAKE'};
-}
-if ($make eq "") {
-    $make = "make";
-}
-print "Using make: $make\n";
+
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
@@ -342,6 +335,19 @@ if ($memleaks ne "") {
 
 $testbindirname = dirname($0);
 $utildir = "$testbindirname/../../util";
+
+
+# Determine which make to use.
+$make = "";
+if (exists($ENV{'CHPL_NIGHTLY_MAKE'})) {
+    $make = $ENV{'CHPL_NIGHTLY_MAKE'};
+} elsif (exists($ENV{'MAKE'})) {
+    $make = $ENV{'MAKE'};
+} else {
+    $make = `$utildir/chplenv/chpl_make.py`;
+    chomp($make);
+}
+print "Using make: $make\n";
 
 
 #


### PR DESCRIPTION
Update nightly to check host compiler and build without optimizations for cray
compiler. This is an experiment to see if it stabilizes the tests for this
compiler.

Also, update nightly to find make program by looking at $CHPL_NIGHTLY_MAKE
in environment, then $MAKE in environment, and finally calling chpl_make.py
script. Previously, it was defaulting to "make", which will not work on some
platforms.