### PR TITLE
Update start_test to correctly find util/ dir in release tarball.

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -646,7 +646,7 @@ if ($?CHPL_TEST_UTIL_DIR) then
     set utildir = "$CHPL_TEST_UTIL_DIR"
 else
     set start_test_dir = `dirname $0`
-    set utildir = `cd $start_test_dir && pwd`
+    set utildir = `cd $start_test_dir/../util && pwd`
     setenv CHPL_TEST_UTIL_DIR $utildir
 endif
 if (! -d $utildir || ! -x $utildir) then


### PR DESCRIPTION
In release tarball, start_test is located under examples/ instead of
util/. Update $utildir default to find util/ relative to start_test, even when
start_test is under examples/.

Verified this by building a tarball off this branch and off master, unpacking
them, building them, and then running `cd examples && ./start_test`. The
one built from master reproduced the failure that happens in nightly testing.
The one built from this branch worked as expected.