### PR TITLE
Only redirect stdout of the actual program for slurm

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -287,18 +287,15 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       sprintf(stdoutFileNoFmt, "%s.%s.out", argv[0], "$SLURM_JOB_ID");
     }
 
+    // We have slurm use the real output file to capture slurm errors/timeouts
+    // We only redirect the program output to the tmp file
+    fprintf(slurmFile, "#SBATCH --output=%s\n", stdoutFile);
+
     // If we're buffering the output, set the temp output file name.
     // It's always <tmpDir>/binaryName.<jobID>.out.
     if (bufferStdout != NULL) {
       sprintf(tmpStdoutFile,      "%s/%s.%s.out", tmpDir, argv[0], "%j");
       sprintf(tmpStdoutFileNoFmt, "%s/%s.%s.out", tmpDir, argv[0], "$SLURM_JOB_ID");
-    }
-
-    // set actual output file based on if we're buffering stdout
-    if (bufferStdout != NULL) {
-      fprintf(slurmFile, "#SBATCH --output=%s\n", tmpStdoutFile);
-    } else {
-      fprintf(slurmFile, "#SBATCH --output=%s\n", stdoutFile);
     }
 
     // add the srun command and the (possibly wrapped) binary name.
@@ -307,7 +304,12 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     // add any arguments passed to the launcher to the binary 
     for (i=1; i<argc; i++) {
-      fprintf(slurmFile, " '%s'", argv[i]);
+      fprintf(slurmFile, "'%s' ", argv[i]);
+    }
+
+    // buffer program output to the tmp stdout file
+    if (bufferStdout != NULL) {
+      fprintf(slurmFile, "&> %s", tmpStdoutFileNoFmt);
     }
     fprintf(slurmFile, "\n");
 
@@ -315,7 +317,8 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // to copy the output to the actual output file. The <tmpDir> output
     // will only exist on one node, ignore failures on the other nodes
     if (bufferStdout != NULL) {
-      fprintf(slurmFile, "srun mv %s %s 2>/dev/null\n", tmpStdoutFileNoFmt, stdoutFileNoFmt);
+      fprintf(slurmFile, "cat %s >> %s\n", tmpStdoutFileNoFmt, stdoutFileNoFmt);
+      fprintf(slurmFile, "rm  %s &> /dev/null\n", tmpStdoutFileNoFmt);
     }
 
     // close the batch file and change permissions 


### PR DESCRIPTION
We don't want to redirect all slurm output. We want slurm to give us timeout
and error messages, but if we redirect that output and an error or timeout
occurs we never get to copy the file containing those messages back to 
the login node.

This updates the slurm launcher to put it's output in the final output file, and
only redirect the program execution output to the tmp file. Then instead of just 
mv'ing the tmp output file, we have to cat and rm it since slurm may have put 
output in the final output file that we want to preserve.

This should allow sub_test to report timeouts again for perf tests using slurm
and hopefully help track down the xc --no-local perf failures that currently just
report that the output file is missing.