### PR TITLE
Make chpldoc use AstToText for some function output

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -100,6 +100,10 @@ void AstToText::appendName(FnSymbol* fn)
       appendClassName(fn);
     }
 
+    else if (fn->isPrimaryMethod())
+    {
+      mText += fn->name;
+    }
     else
     {
       appendClassName(fn);
@@ -344,7 +348,7 @@ void AstToText::appendFormalType(ArgSymbol* arg)
       if (typeExprCopiedFromDefaultExpr(arg) == false)
       {
         mText += ": ";
-        appendExpr(arg->typeExpr->body.get(1));
+        appendExpr(arg->typeExpr->body.get(1), true);
       }
     }
 
@@ -537,7 +541,7 @@ bool AstToText::handleNormalizedTypeOf(BlockStmt* bs)
           if (moveSrc->numActuals() == 1)
           {
             mText  += ": ";
-            appendExpr(moveSrc);
+            appendExpr(moveSrc, true);
             mText  += ".type ";
 
             retval =  true;
@@ -582,7 +586,7 @@ void AstToText::appendFormalVariableExpr(ArgSymbol* arg)
 
         else
         {
-          appendExpr(expr);
+          appendExpr(expr, false);
         }
       }
       else
@@ -616,9 +620,9 @@ void AstToText::appendFormalDefault(ArgSymbol* arg)
         mText += " = ";
 
         if (SymExpr* sym = toSymExpr(expr))
-          appendExpr(sym, true);
+          appendExpr(sym, false, true);
         else
-          appendExpr(expr);
+          appendExpr(expr, false);
       }
     }
 
@@ -720,22 +724,22 @@ ArgSymbol* AstToText::formalGet(FnSymbol* fn, int oneBasedIndex) const
 *                                                                           *
 ************************************* | ************************************/
 
-void AstToText::appendExpr(Expr* expr)
+void AstToText::appendExpr(Expr* expr, bool printingType)
 {
   if      (UnresolvedSymExpr* sel = toUnresolvedSymExpr(expr))
     appendExpr(sel);
 
   else if (SymExpr*           sel = toSymExpr(expr))
-    appendExpr(sel, false);
+    appendExpr(sel, printingType, false);
 
   else if (CallExpr*          sel = toCallExpr(expr))
-    appendExpr(sel);
+    appendExpr(sel, printingType);
 
   else if (DefExpr*           sel = toDefExpr(expr))
-    appendExpr(sel);
+    appendExpr(sel, printingType);
 
   else if (NamedExpr*         sel = toNamedExpr(expr))
-    appendExpr(sel);
+    appendExpr(sel, printingType);
 
   else
   {
@@ -750,7 +754,7 @@ void AstToText::appendExpr(UnresolvedSymExpr* expr)
   appendExpr(expr->unresolved);
 }
 
-void AstToText::appendExpr(SymExpr* expr, bool quoteStrings)
+void AstToText::appendExpr(SymExpr* expr, bool printingType, bool quoteStrings)
 {
   if (VarSymbol* var = toVarSymbol(expr->var))
   {
@@ -841,7 +845,7 @@ void AstToText::appendExpr(SymExpr* expr, bool quoteStrings)
   }
 }
 
-void AstToText::appendExpr(CallExpr* expr)
+void AstToText::appendExpr(CallExpr* expr, bool printingType)
 {
   if (expr->primitive == 0)
   {
@@ -853,7 +857,7 @@ void AstToText::appendExpr(CallExpr* expr)
       if     (strcmp(fnName, "!")                            == 0)
       {
         mText += "!";
-        appendExpr(expr->get(1));
+        appendExpr(expr->get(1), printingType);
       }
 
       // UnaryOp negate
@@ -861,25 +865,30 @@ void AstToText::appendExpr(CallExpr* expr)
                expr->numActuals()                            == 1)
       {
         mText += "-";
-        appendExpr(expr->get(1));
+        appendExpr(expr->get(1), printingType);
       }
 
       else if (strcmp(fnName, "_cast")                        == 0)
       {
-        appendExpr(expr->get(2));
+        appendExpr(expr->get(2), printingType);
         mText += ": ";
-        appendExpr(expr->get(1));
+        appendExpr(expr->get(1), printingType);
       }
 
       else if (strcmp(fnName, "chpl__atomicType")             == 0)
       {
         mText += "atomic";
-        appendExpr(expr->get(1));
+        appendExpr(expr->get(1), printingType);
       }
 
       else if (strcmp(fnName, "chpl__ensureDomainExpr")       == 0)
       {
-        appendExpr(expr->get(1));
+        appendExpr(expr->get(1), printingType);
+        for (int index = 2; index <= expr->numActuals(); index++)
+        {
+          mText += ", ";
+          appendExpr(expr->get(index), printingType);
+        }
       }
 
       else if (strcmp(fnName, "chpl__buildDomainRuntimeType") == 0)
@@ -895,7 +904,7 @@ void AstToText::appendExpr(CallExpr* expr)
             if (strcmp(sym1->unresolved, "defaultDist") == 0)
             {
               mText += "domain(";
-              appendExpr(sym2);
+              appendExpr(sym2, printingType);
               mText += ")";
             }
 
@@ -918,7 +927,7 @@ void AstToText::appendExpr(CallExpr* expr)
             if (arg1 != 0 && arg2 != 0 && strcmp(arg1->name, "defaultDist") == 0)
             {
               mText += "domain(";
-              appendExpr(sym2);
+              appendExpr(sym2, printingType);
               mText += ")";
             }
 
@@ -927,6 +936,25 @@ void AstToText::appendExpr(CallExpr* expr)
               // NOAKES 2015/02/05  Debugging support.
               // Might become ASSERT in the future
               mText += "AppendExpr.Call01";
+            }
+          }
+
+          else if (isUnresolvedSymExpr(expr->get(1)) && isSymExpr(expr->get(2)))
+          {
+            UnresolvedSymExpr* sym1 = toUnresolvedSymExpr(expr->get(1));
+            SymExpr*   sym2 = toSymExpr(expr->get(2));
+            if (strcmp(sym1->unresolved, "defaultDist") == 0)
+            {
+              mText += "domain(";
+              appendExpr(sym2, printingType);
+              mText += ")";
+            }
+
+            else
+            {
+              // Lydia 2015/02/17 Debugging support.
+              // Might become ASSERT in the future
+              mText += "AppendExpr.Call10";
             }
           }
 
@@ -950,21 +978,31 @@ void AstToText::appendExpr(CallExpr* expr)
       else if (strcmp(fnName, "chpl__buildArrayRuntimeType") == 0)
       {
         mText += "[";
-        appendExpr(expr->get(1));
-        mText += "] ";
+        appendExpr(expr->get(1), printingType);
+        mText += "]";
 
         if (expr->numActuals() == 2)
-          appendExpr(expr->get(2));
+        {
+          mText += " ";
+          appendExpr(expr->get(2), printingType);
+        }
       }
 
       else if (strcmp(fnName, "_build_tuple")                == 0)
-        appendExpr(expr, "");
+        appendExpr(expr, "", printingType);
 
       else if (strcmp(fnName, "chpl__buildIndexType")        == 0)
-        appendExpr(expr, "index");
+        appendExpr(expr, "index", printingType);
 
       else if (strcmp(fnName, "range")                       == 0)
-        appendExpr(expr, "range");
+        appendExpr(expr, "range", printingType);
+
+      else if (strcmp(fnName, "chpl_build_bounded_range")    == 0)
+      {
+        appendExpr(expr->get(1), printingType);
+        mText += "..";
+        appendExpr(expr->get(2), printingType);
+      }
 
       else if (strcmp(fnName, ".")                           == 0)
       {
@@ -979,13 +1017,13 @@ void AstToText::appendExpr(CallExpr* expr)
 
             if (strcmp(sym1->name, "this") == 0)
             {
-              appendExpr(symExpr2);
+              appendExpr(symExpr2, printingType);
             }
             else
             {
-              appendExpr(symExpr1);
+              appendExpr(symExpr1, printingType);
               mText += '.';
-              appendExpr(symExpr2);
+              appendExpr(symExpr2, printingType);
             }
           }
 
@@ -995,13 +1033,13 @@ void AstToText::appendExpr(CallExpr* expr)
 
             if (strcmp(sym1->name, "this") == 0)
             {
-              appendExpr(symExpr2);
+              appendExpr(symExpr2, printingType);
             }
             else
             {
-              appendExpr(symExpr1);
+              appendExpr(symExpr1, printingType);
               mText += '.';
-              appendExpr(symExpr2);
+              appendExpr(symExpr2, printingType);
             }
           }
 
@@ -1015,9 +1053,9 @@ void AstToText::appendExpr(CallExpr* expr)
         }
         else
         {
-          appendExpr(expr->get(1));
+          appendExpr(expr->get(1), printingType);
           mText += '.';
-          appendExpr(expr->get(2));
+          appendExpr(expr->get(2), printingType);
         }
       }
 
@@ -1041,15 +1079,36 @@ void AstToText::appendExpr(CallExpr* expr)
       }
 
       // NOAKES 2015/02/09 Treating all calls with 2 actuals as binary operators
+      // Lydia 2015/02/17 ... except homogenuous tuple inner workings.
       else if (expr->numActuals() == 2)
       {
-        appendExpr(expr->get(1));
-        appendExpr(expr->baseExpr);
-        appendExpr(expr->get(2));
+        UnresolvedSymExpr* name     = toUnresolvedSymExpr(expr->baseExpr);
+        if (printingType && strcmp(name->unresolved, "*") == 0)
+        {
+          // This is not a multiply, it's the symbol for a homogenuous tuple.
+
+          // I found that some multiplies would match this (even though they
+          // really should be PRIM_MULT), so we must rely on context to
+          // differentiate between the two cases: if we're in a type expression,
+          // either something has gone terribly wrong or a homogenuous tuple is
+          // intended.  If we're in another expression, it's more likely to be
+          // a multiply.
+          appendExpr(expr->get(1), printingType);
+          mText += "*(";
+          appendExpr(expr->get(2), printingType);
+          mText += ")";
+        }
+
+        else
+        {
+          appendExpr(expr->get(1), printingType);
+          appendExpr(expr->baseExpr, printingType);
+          appendExpr(expr->get(2), printingType);
+        }
       }
 
       else
-        appendExpr(expr, fnName);
+        appendExpr(expr, fnName, printingType);
     }
 
     else if (isSymExpr(expr->baseExpr))
@@ -1063,15 +1122,15 @@ void AstToText::appendExpr(CallExpr* expr)
 
       else if (expr->numActuals() == 1)
       {
-        appendExpr(expr->baseExpr);
+        appendExpr(expr->baseExpr, printingType);
         mText += '(';
-        appendExpr(expr->get(1));
+        appendExpr(expr->get(1), printingType);
         mText += ')';
       }
 
       else
       {
-        appendExpr(expr->baseExpr);
+        appendExpr(expr->baseExpr, printingType);
         mText += '(';
 
         for (int i = 1; i <= expr->numActuals(); i++)
@@ -1079,7 +1138,7 @@ void AstToText::appendExpr(CallExpr* expr)
           if (i > 1)
             mText += ", ";
 
-          appendExpr(expr->get(i));
+          appendExpr(expr->get(i), printingType);
         }
 
         mText += ')';
@@ -1098,7 +1157,7 @@ void AstToText::appendExpr(CallExpr* expr)
   {
     if (expr->isPrimitive(PRIM_TYPEOF))
     {
-      appendExpr(expr->get(1));
+      appendExpr(expr->get(1), printingType);
       mText += ".type ";
     }
     else
@@ -1110,7 +1169,7 @@ void AstToText::appendExpr(CallExpr* expr)
   }
 }
 
-void AstToText::appendExpr(DefExpr* expr)
+void AstToText::appendExpr(DefExpr* expr, bool printingType)
 {
   mText += '?';
 
@@ -1128,14 +1187,14 @@ void AstToText::appendExpr(DefExpr* expr)
   }
 }
 
-void AstToText::appendExpr(NamedExpr* expr)
+void AstToText::appendExpr(NamedExpr* expr, bool printingType)
 {
   mText += expr->name;
   mText += " = ";
-  appendExpr(expr->actual);
+  appendExpr(expr->actual, printingType);
 }
 
-void AstToText::appendExpr(CallExpr* expr, const char* fnName)
+void AstToText::appendExpr(CallExpr* expr, const char* fnName, bool printingType)
 {
   appendExpr(fnName);
   mText += '(';
@@ -1145,7 +1204,7 @@ void AstToText::appendExpr(CallExpr* expr, const char* fnName)
     if (i > 1)
       mText += ", ";
 
-    appendExpr(expr->get(i));
+    appendExpr(expr->get(i), printingType);
   }
 
   mText += ')';

--- a/compiler/include/AstToText.h
+++ b/compiler/include/AstToText.h
@@ -125,21 +125,27 @@ private:
   //
   // Formatting the expressions found in formals (skeleton)
   //
-  void                   appendExpr(Expr*              expr);
+  void                   appendExpr(Expr*              expr,
+                                    bool               printingType);
 
   void                   appendExpr(UnresolvedSymExpr* expr);
 
   void                   appendExpr(SymExpr*           expr,
+                                    bool               printingType,
                                     bool               quoteStrings);
 
-  void                   appendExpr(CallExpr*          expr);
+  void                   appendExpr(CallExpr*          expr,
+                                    bool               printingType);
 
   void                   appendExpr(CallExpr*          expr,
-                                    const char*        fnName);
+                                    const char*        fnName,
+                                    bool               printingType);
 
-  void                   appendExpr(DefExpr*           expr);
+  void                   appendExpr(DefExpr*           expr,
+                                    bool               printingType);
 
-  void                   appendExpr(NamedExpr*         expr);
+  void                   appendExpr(NamedExpr*         expr,
+                                    bool               printingType);
 
   void                   appendExpr(const char*        name);
 

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -36,6 +36,7 @@
 #include "mysystem.h"
 #include "stringutil.h"
 #include "scopeResolve.h"
+#include "AstToText.h"
 
 int NUMTABS = 0;
 
@@ -204,27 +205,6 @@ void printFields(std::ofstream *file, AggregateType *cl) {
           *file << " = ";
           var->defPoint->init->prettyPrint(file);
         }
-        /*
-        // These aren't modes the ArgSymbol would know about, so cover them
-        // here.
-        if (var->isConstant())
-          *file << "const ";
-        else if (!var->hasFlag(FLAG_TYPE_VARIABLE) && !var->isParameter())
-          *file << "var ";
-
-        // Use AstToText to generate correct output based on the arg symbol
-        // in the default initializer that corresponds to this field.
-        AstToText *argOutput = new AstToText();
-        if (cl->isClass()) {
-          argOutput->appendFormal(cl->defaultInitializer, i-1);
-          // argVersion = cl->defaultInitializer->getFormal(i-1);
-        } else {
-          argOutput->appendFormal(cl->defaultInitializer, i);
-          //argVersion = cl->defaultInitializer->getFormal(i);
-        }
-        *file << argOutput->text();
-        delete argOutput;
-        */
         *file << std::endl;
         printVarDocs(file, var);
       }
@@ -513,6 +493,11 @@ void printFunction(std::ofstream *file, FnSymbol *fn, bool method) {
     } else {
       *file << "proc ";
     }
+    AstToText *fnInfo = new AstToText();
+    fnInfo->appendNameAndFormals(fn);
+    *file << fnInfo->text();
+    delete fnInfo;
+    /*
     // if fn is not primary method
     //   get type name from 'this' argument
     //   output it + '.' before fn->name
@@ -554,6 +539,7 @@ void printFunction(std::ofstream *file, FnSymbol *fn, bool method) {
     }
     if (!fn->hasFlag(FLAG_NO_PARENS))
       *file << ")";
+    */
     switch (fn->retTag) {
     case RET_REF:
       *file << " ref"; break;

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -143,45 +143,6 @@ bool isNotSubmodule(ModuleSymbol *mod) {
           strcmp("_root", mod->defPoint->parentSymbol->name) == 0);
 }
 
-void printIntent(std::ofstream *file, IntentTag intent) {
-  switch(intent) {
-  case INTENT_IN:
-    *file << "in "; break;
-  case INTENT_INOUT:
-    *file << "inout "; break;
-  case INTENT_OUT:
-    *file << "out "; break;
-  case INTENT_CONST:
-    *file << "const "; break;
-  case INTENT_CONST_IN:
-    *file << "const in "; break;
-  case INTENT_CONST_REF:
-    *file << "const ref "; break;
-  case INTENT_REF:
-    *file << "ref "; break;
-  case INTENT_PARAM:
-    *file << "param "; break;
-  default:
-    break;
-  }
-}
-
-void printArg(std::ofstream *file, ArgSymbol *arg) {
-  printIntent(file, arg->intent);
-  if (arg->hasFlag(FLAG_TYPE_VARIABLE)) {
-    *file << "type ";  
-    // Because type intents are handled differently during parsing
-  } 
-    
-  *file << arg->name;
-  if (arg->typeExpr != NULL) {
-    *file << ": ";
-    arg->typeExpr->body.tail->prettyPrint(file);
-  } else if (arg->type != NULL && arg->type != dtAny) {
-    *file << ": " << arg->type->symbol->name;
-  }
-}
-
 void printFields(std::ofstream *file, AggregateType *cl) {
   for (int i = 1; i <= cl->fields.length; i++) {
     if (VarSymbol *var = toVarSymbol(((DefExpr *)cl->fields.get(i))->sym)) {

--- a/compiler/passes/docs.h
+++ b/compiler/passes/docs.h
@@ -19,10 +19,6 @@
 
 #include <string>
 
-void printArg(std::ofstream *file, ArgSymbol *arg);
-
-void printIntent(std::ofstream *file, IntentTag intent);
-
 void printTabs(std::ofstream *file);
 
 void createDocsFileFolders(std::string filename);

--- a/test/chpldoc/types/arguments/queried.bad
+++ b/test/chpldoc/types/arguments/queried.bad
@@ -1,4 +1,0 @@
-Module: queried
-   proc queried(x: <DefExprType>)
-      This proc queries the type of its argument 
-

--- a/test/chpldoc/types/arguments/queried.future
+++ b/test/chpldoc/types/arguments/queried.future
@@ -1,6 +1,0 @@
-bug: incorrect type output
-
-This future is two-fold: a semantic question about how queried types should be
-output, and a bug in its current output.  At the moment, <DefExprType> is
-printed, exposing compiler implementation details and failing to print anything
-understandable.

--- a/test/chpldoc/variableArguments.future
+++ b/test/chpldoc/variableArguments.future
@@ -1,1 +1,0 @@
-semantic: How should variable arguments be handled?

--- a/test/chpldoc/variableArguments.good
+++ b/test/chpldoc/variableArguments.good
@@ -1,34 +1,28 @@
 Module: variableArguments
-   proc variable(x..)
-       This method has a variable number of arguments 
+   proc variable(x ...)
+      This method has a variable number of arguments 
 
-   proc variableCommentless(c..)
+   proc variableCommentless(c ...)
+   proc limited(x ...5)
+      This method requires a specific number of arguments, w/o limiting type 
 
-   proc limited(x..)
-       This method requires a specific number of arguments, w/o limiting type 
+   proc limitedCommentless(x ...5)
+   proc specifyMe(q ...?k)
+      This methods can take any number of arguments, but that number must 
+      be specified by the caller 
 
-   proc limitedCommentless(x..)
-
-   proc specifyMe(q..)
-       This methods can take any number of arguments, but that number must 
-   be specified by the caller 
-
-   proc specifyMeCommentless(q..)
-
+   proc specifyMeCommentless(q ...?p)
    Module: variableArguments.Other
-      proc variable(x..)
-          This method has a variable number of arguments 
+      proc variable(x ...)
+         This method has a variable number of arguments 
 
-      proc variableCommentless(c..)
+      proc variableCommentless(c ...)
+      proc limited(x ...5)
+         This method requires a specific number of arguments, w/o limiting type 
 
-      proc limited(x..)
-          This method requires a specific number of arguments, w/o limiting type 
+      proc limitedCommentless(x ...5)
+      proc specifyMe(q ...?k)
+         This methods can take any number of arguments, but that number must 
+         be specified by the caller 
 
-      proc limitedCommentless(x..)
-
-      proc specifyMe(q..)
-          This methods can take any number of arguments, but that number must 
-     be specified by the caller 
-
-      proc specifyMeCommentless(q..)
-
+      proc specifyMeCommentless(q ...?p)


### PR DESCRIPTION
I switched the name generation and formal output for functions and
methods to purely relying on AstToText's appendNamesAndFormals.
This fixes four bugs: arguments that query portions of their definition now
output correctly, default values for arguments are now printed, arguments
with a default value but no defined type no longer output "_unknown" as
their type, and functions with a variable number of arguments indicate that
properly (needed to update the .good file for this).

In making this switch, I discovered some bugs in AstToText.  Ranges within
array arguments would output `[1..4, 1..3]` as `[1chpl_build_bounded_range4]`,
declaring an argument of type `domain(rank)` would fall into an unexpected
case, and homogeneous tuples would turn `3*(4*complex)` into 3*4*complex,
looking as if you forgot to perform multiplication on your tuple size.  Additionally,
the method name would always prepend the name of the class to itself.  Since
I wanted chpldoc to only do this for secondary methods, Mike gave me
permission to modify AstToText to suit my purpose.  So really, this merge
fixes 7 to 9 bugs, depending on how you count things.

Using AstToText in this way meant that the functions printIntents and printArgs
were no longer necessary for the docs pass.  So I removed them entirely.

I tested over test/chpldoc and test/release/examples/primers/chpldoc.chpl