### PR TITLE
State the dependence that codegen.o has on reservedSymbolNames.h

### DIFF
--- a/compiler/passes/Makefile
+++ b/compiler/passes/Makefile
@@ -43,3 +43,6 @@ include $(COMPILER_ROOT)/make/Makefile.compiler.foot
 
 reservedSymbolNames.h: reservedSymbolNames
 	sed -e 's/^\([ 	]*\)\([A-Za-z_][A-Za-z0-9_]*\)/\1cnames.set_add(astr("\2"));/' <$< >$@
+
+$(OBJ_SUBDIR)/codegen.o: reservedSymbolNames.h
+


### PR DESCRIPTION
Up until recently, we only build the compiler sequentially,
so this dependence was not strictly necessary due to the order
things were listed in the TARGETS variable.

With parallel make now being used a lot more, it is theorized
that the lack of this dependence caused a race in which
codegen.cpp would get compiled before reservedSymbolNames.h
was completely formed, and that, as a result, some of the
reserved names were not protected (particularly 'assert').

It was theorized that it seems unlikely that the .h file
would be (a) partially formed, (b) syntactically legal,
and yet (c) incomplete, but Mike posits (and I agree)
that it may be likely that the file is created but empty
in a way that it would be OK.  Or else, perhaps output
is buffered a line at a time, which would also result in
a legal .h file.

In any case, the dependence seems worth stating.