### PR TITLE
Bump timeouts for two intermittent gasnet regressions

### DIFF
--- a/test/studies/madness/aniruddha/madchap/test_gaxpy.timeout
+++ b/test/studies/madness/aniruddha/madchap/test_gaxpy.timeout
@@ -1,4 +1,4 @@
 # As of 02/09/15 this test times out occasionally for gasnet-fifo.
 # We should be able to remove this when we test on real hardware
 # instead of using local spawning.
-900
+1800

--- a/test/studies/madness/aniruddha/madchap/test_likepy.timeout
+++ b/test/studies/madness/aniruddha/madchap/test_likepy.timeout
@@ -1,4 +1,4 @@
 # As of 02/04/15 this test times out semi-regularly for gasnet-fifo.
 # We should be able to remove this when we test on real hardware
 # instead of using local spawning.
-900
+1800


### PR DESCRIPTION
Bump timeouts for:
 - test/studies/madness/aniruddha/madchap/test_gaxpy
 - test/studies/madness/aniruddha/madchap/test_likepy

These tests are pretty noisy for gasnet-fifo. I added timeouts for these two
tests but we still get timeouts occasionally. Looking at the logs for the last
few days, when test_likepy does finish it seems to do so in just under 900s so
I'm bumping the timeout again. If they still timeout, then there's probably
some deadlock or livelock occurring and it will need further investigation.