### PR TITLE
Upon discussion with Brad, make externs never output "extern " beforehand

### DIFF
--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -446,7 +446,7 @@ void printFunction(std::ofstream *file, FnSymbol *fn, bool method) {
     } else if (fn->hasFlag(FLAG_EXPORT)) {
       *file << "export ";
     } else if (fn->hasFlag(FLAG_EXTERN)) {
-      *file << "extern ";
+      // Do nothing.  Being extern is an implementation detail.
     }
 
     if (iterator) {

--- a/test/chpldoc/linkage-spec/externTest.good
+++ b/test/chpldoc/linkage-spec/externTest.good
@@ -1,39 +1,39 @@
 Module: externTest
-   extern proc method1()
+   proc method1()
       Comment for method1 
 
-   extern proc commentless()
-   extern proc hasArg(val: int)
+   proc commentless()
+   proc hasArg(val: int)
       Comment for method with an argument 
 
-   extern proc hasArgCommentless(val: int)
-   extern proc longComment()
+   proc hasArgCommentless(val: int)
+   proc longComment()
       This comment is rather long
       And spans for
       Multiple lines 
 
-   extern proc hasReturnType(): int
+   proc hasReturnType(): int
       This method has a return type 
 
-   extern proc hasReturnTypeCommentless(): int
-   extern proc hasReturnTypeAndArg(val: int): int
+   proc hasReturnTypeCommentless(): int
+   proc hasReturnTypeAndArg(val: int): int
       This method has a return type and an argument 
 
-   extern proc hasReturnTypeAndArgCommentless(val: int): int
+   proc hasReturnTypeAndArgCommentless(val: int): int
    Module: externTest.Other
-      extern proc inside
+      proc inside
          Comment for method inside module 
 
-      extern proc commentless
-      extern proc hasArg(val: int)
+      proc commentless
+      proc hasArg(val: int)
          Comment for method with an argument inside module 
 
-      extern proc hasArgCommentless(val: int)
-      extern proc hasReturnType(): int
+      proc hasArgCommentless(val: int)
+      proc hasReturnType(): int
          This method has a return type 
 
-      extern proc hasReturnTypeCommentless(): int
-      extern proc hasReturnTypeAndArg(val: int): int
+      proc hasReturnTypeCommentless(): int
+      proc hasReturnTypeAndArg(val: int): int
          This method has a return type and an argument 
 
-      extern proc hasReturnTypeAndArgCommentless(val: int): int
+      proc hasReturnTypeAndArgCommentless(val: int): int


### PR DESCRIPTION
Whether a function is specifically defined or just a callover to C (etc.) is
really an implementation detail.  The user will probably not care one way or
the other.