### PR TITLE
Enhance Makefile support for parser development

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -128,11 +128,8 @@ $(CHPLDOC): $(CHPL)
 
 chpldoc: $(CHPLDOC)
 
-parser-force:
+parser:
 	$(MAKE) -C parser parser
-
-parser-update:
-	$(MAKE) -C parser parser-update
 
 $(CHPL_BIN_DIR):
 	mkdir -p $@

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -128,6 +128,12 @@ $(CHPLDOC): $(CHPL)
 
 chpldoc: $(CHPLDOC)
 
+parser-force:
+	$(MAKE) -C parser parser
+
+parser-update:
+	$(MAKE) -C parser parser-update
+
 $(CHPL_BIN_DIR):
 	mkdir -p $@
 

--- a/compiler/parser/Makefile
+++ b/compiler/parser/Makefile
@@ -30,11 +30,7 @@ include $(COMPILER_ROOT)/make/Makefile.compiler.head
 PARSER_OBJDIR = $(OBJ_SUBDIR)
 include Makefile.share
 
-ifdef CHPL_PARSER_DEVELOPER
-TARGETS = parser-update $(PARSER_OBJS)
-else
 TARGETS = $(PARSER_OBJS)
-endif
 
 include $(COMPILER_ROOT)/make/Makefile.compiler.subdirrules
 
@@ -48,22 +44,8 @@ parser: FORCE
 	@rm -f bison-chapel.output bison-chapel.cpp flex-chapel.cpp
 	@rm -f ../include/bison-chapel.h ../include/flex-chapel.h
 	bison chapel.ypp
-	@if [ `grep "conflicts:" bison-chapel.output | wc -l` -ne 0 ]; then echo "PROBLEM: chapel.ypp contains conflicts"; exit 1; fi;
+	@if grep -q "conflicts:" bison-chapel.output; then echo "PROBLEM: chapel.ypp contains conflicts"; exit 1; fi;
 	flex chapel.lex
-
-parser-update: parser-update-prep parser parser-update-compare
-
-parser-update-prep:
-	@[ -r bison-chapel.cpp ] && mv bison-chapel.cpp{,.tmp} || true
-	@[ -r flex-chapel.cpp  ] && mv flex-chapel.cpp{,.tmp} || true
-	@[ -r ../include/bison-chapel.h ] && mv ../include/bison-chapel.h{,.tmp} || true
-	@[ -r ../include/flex-chapel.h ] && mv ../include/flex-chapel.h{,.tmp} || true
-
-parser-update-compare:
-	@cmp -s bison-chapel.cpp{,.tmp} && mv bison-chapel.cpp{.tmp,} || rm -f bison-chapel.cpp.tmp
-	@cmp -s flex-chapel.cpp{,.tmp} && mv flex-chapel.cpp{.tmp,} || rm -f bison-chapel.cpp.tmp
-	@cmp -s ../include/bison-chapel.h{,.tmp} && mv ../include/bison-chapel.h{.tmp,} || rm -f ../include/bison-chapel.h.tmp
-	@cmp -s ../include/flex-chapel.h{,.tmp} && mv ../include/flex-chapel.h{.tmp,} || rm -f ../include/flex-chapel.h.tmp
 
 FORCE:
 

--- a/compiler/parser/Makefile
+++ b/compiler/parser/Makefile
@@ -30,7 +30,11 @@ include $(COMPILER_ROOT)/make/Makefile.compiler.head
 PARSER_OBJDIR = $(OBJ_SUBDIR)
 include Makefile.share
 
+ifdef CHPL_PARSER_DEVELOPER
+TARGETS = parser-update $(PARSER_OBJS)
+else
 TARGETS = $(PARSER_OBJS)
+endif
 
 include $(COMPILER_ROOT)/make/Makefile.compiler.subdirrules
 
@@ -41,9 +45,25 @@ CLEAN_TARGS += \
 endif
 
 parser: FORCE
+	@rm -f bison-chapel.output bison-chapel.cpp flex-chapel.cpp
+	@rm -f ../include/bison-chapel.h ../include/flex-chapel.h
 	bison chapel.ypp
 	@if [ `grep "conflicts:" bison-chapel.output | wc -l` -ne 0 ]; then echo "PROBLEM: chapel.ypp contains conflicts"; exit 1; fi;
 	flex chapel.lex
+
+parser-update: parser-update-prep parser parser-update-compare
+
+parser-update-prep:
+	@[ -r bison-chapel.cpp ] && mv bison-chapel.cpp{,.tmp} || true
+	@[ -r flex-chapel.cpp  ] && mv flex-chapel.cpp{,.tmp} || true
+	@[ -r ../include/bison-chapel.h ] && mv ../include/bison-chapel.h{,.tmp} || true
+	@[ -r ../include/flex-chapel.h ] && mv ../include/flex-chapel.h{,.tmp} || true
+
+parser-update-compare:
+	@cmp -s bison-chapel.cpp{,.tmp} && mv bison-chapel.cpp{.tmp,} || rm -f bison-chapel.cpp.tmp
+	@cmp -s flex-chapel.cpp{,.tmp} && mv flex-chapel.cpp{.tmp,} || rm -f bison-chapel.cpp.tmp
+	@cmp -s ../include/bison-chapel.h{,.tmp} && mv ../include/bison-chapel.h{.tmp,} || rm -f ../include/bison-chapel.h.tmp
+	@cmp -s ../include/flex-chapel.h{,.tmp} && mv ../include/flex-chapel.h{.tmp,} || rm -f ../include/flex-chapel.h.tmp
 
 FORCE:
 


### PR DESCRIPTION
* In compiler/parser/Makefile - provide 'parser-update' target that runs bison and flex like the 'parser' target, then resets the generated files (e.g. bison-chapel.cpp) if they did not change. The goal is: avoid the subsequent C recompilation (into .o) of those generated files and the files that depend on the generated .h files.

* Run the 'parser-update' target automatically when CHPL_PARSER_DEVELOPER is set (e.g. in user's environment). The goal is: convenience for parser developers.

* In that 'parser' target, remove the to-be-generated files before running bison and flex. The goal is: do not retain obsolete files accidentally when bison/flex fail.

* In compiler/Makefile, add 'parser-update' and 'parser-force' targets that redirect to 'parser-update' and 'parser' in compiler/parser/Makefile. The goal is convenience.

