### PR TITLE
Rename 'by' in the parser in order to avoid naming conflicts

### DIFF
--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -78,7 +78,7 @@ static void tryToReplaceWithDirectRangeIterator(Expr* iteratorExpr)
   if (CallExpr* call = toCallExpr(iteratorExpr))
   {
     // grab the stride if we have a strided range
-    if (call->isNamed("by"))
+    if (call->isNamed("chpl_by"))
     {
       range = toCallExpr(call->get(1)->copy());
       stride = toExpr(call->get(2)->copy());

--- a/compiler/AST/ParamForLoop.cpp
+++ b/compiler/AST/ParamForLoop.cpp
@@ -46,7 +46,7 @@ BlockStmt* ParamForLoop::buildParamForLoop(VarSymbol* indexVar,
 
   BlockStmt*   outer      = new BlockStmt();
 
-  if (call && call->isNamed("by"))
+  if (call && call->isNamed("chpl_by"))
   {
     stride = call->get(2)->remove();
     call   = toCallExpr(call->get(1));

--- a/compiler/include/bison-chapel.h
+++ b/compiler/include/bison-chapel.h
@@ -32,14 +32,14 @@
 
 /* "%code requires" blocks.  */
 
-/* Line 2132 of yacc.c  */
+/* Line 2068 of yacc.c  */
 #line 33 "chapel.ypp"
 
   extern int  captureTokens;
   extern char captureString[1024];
 
 
-/* Line 2132 of yacc.c  */
+/* Line 2068 of yacc.c  */
 #line 44 "chapel.ypp"
 
   void lexerScanString(const char* string);
@@ -48,7 +48,7 @@
   void processNewline();
 
 
-/* Line 2132 of yacc.c  */
+/* Line 2068 of yacc.c  */
 #line 55 "chapel.ypp"
 
 
@@ -98,7 +98,7 @@
   };
 
 
-/* Line 2132 of yacc.c  */
+/* Line 2068 of yacc.c  */
 #line 107 "chapel.ypp"
 
   struct YYLTYPE {
@@ -114,7 +114,7 @@
 
 
 
-/* Line 2132 of yacc.c  */
+/* Line 2068 of yacc.c  */
 #line 119 "../include/bison-chapel.h"
 
 /* Tokens.  */
@@ -281,7 +281,7 @@ extern YYLTYPE yylloc;
 
 /* "%code provides" blocks.  */
 
-/* Line 2132 of yacc.c  */
+/* Line 2068 of yacc.c  */
 #line 123 "chapel.ypp"
 
   extern int yydebug;
@@ -291,5 +291,5 @@ extern YYLTYPE yylloc;
 
 
 
-/* Line 2132 of yacc.c  */
+/* Line 2068 of yacc.c  */
 #line 296 "../include/bison-chapel.h"

--- a/compiler/include/flex-chapel.h
+++ b/compiler/include/flex-chapel.h
@@ -51,7 +51,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -123,14 +122,14 @@ typedef unsigned int flex_uint32_t;
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #endif
 
+extern int yyleng;
+
+extern FILE *yyin, *yyout;
+
 #ifndef YY_TYPEDEF_YY_SIZE_T
 #define YY_TYPEDEF_YY_SIZE_T
 typedef size_t yy_size_t;
 #endif
-
-extern yy_size_t yyleng;
-
-extern FILE *yyin, *yyout;
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
@@ -149,7 +148,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -193,7 +192,7 @@ void yypop_buffer_state (void );
 
 YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
 YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
+YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,int len  );
 
 void *yyalloc (yy_size_t  );
 void *yyrealloc (void *,yy_size_t  );
@@ -248,7 +247,7 @@ FILE *yyget_out (void );
 
 void yyset_out  (FILE * out_str  );
 
-yy_size_t yyget_leng (void );
+int yyget_leng (void );
 
 char *yyget_text (void );
 
@@ -318,6 +317,6 @@ extern int yylex (void);
 #line 236 "chapel.lex"
 
 
-#line 322 "../include/flex-chapel.h"
+#line 321 "../include/flex-chapel.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/compiler/parser/bison-chapel.cpp
+++ b/compiler/parser/bison-chapel.cpp
@@ -4459,364 +4459,364 @@ yyreduce:
     {
         case 2:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 337 "chapel.ypp"
     { (void)(yylsp[(1) - (1)]).first_line; yyblock = (yyval.pblockstmt); }
     break;
 
   case 3:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 342 "chapel.ypp"
     { (yyval.pblockstmt) = new BlockStmt();     resetTempID(); }
     break;
 
   case 4:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 343 "chapel.ypp"
     { (yyvsp[(1) - (2)].pblockstmt)->appendChapelStmt((yyvsp[(2) - (2)].pblockstmt)); resetTempID(); }
     break;
 
   case 6:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 350 "chapel.ypp"
     { (yyval.pblockstmt) = buildPragmaStmt( (yyvsp[(1) - (2)].vpch), (yyvsp[(2) - (2)].pblockstmt) ); }
     break;
 
   case 7:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 355 "chapel.ypp"
     { (yyval.vpch) = new Vec<const char*>(); (yyval.vpch)->add(astr((yyvsp[(2) - (2)].pch))); }
     break;
 
   case 8:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 356 "chapel.ypp"
     { (yyvsp[(1) - (3)].vpch)->add(astr((yyvsp[(3) - (3)].pch))); }
     break;
 
   case 20:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 372 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt((yyvsp[(1) - (2)].pexpr)); }
     break;
 
   case 21:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 373 "chapel.ypp"
     { (yyval.pblockstmt) = buildAtomicStmt((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 22:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 374 "chapel.ypp"
     { (yyval.pblockstmt) = buildBeginStmt((yyvsp[(2) - (3)].pcallexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 23:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 375 "chapel.ypp"
     { (yyval.pblockstmt) = buildGotoStmt(GOTO_BREAK, (yyvsp[(2) - (3)].pch)); }
     break;
 
   case 24:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 376 "chapel.ypp"
     { (yyval.pblockstmt) = buildCobeginStmt((yyvsp[(2) - (3)].pcallexpr), (yyvsp[(3) - (3)].pblockstmt));  }
     break;
 
   case 25:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 377 "chapel.ypp"
     { (yyval.pblockstmt) = buildGotoStmt(GOTO_CONTINUE, (yyvsp[(2) - (3)].pch)); }
     break;
 
   case 26:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 378 "chapel.ypp"
     { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_DELETE, (yyvsp[(2) - (3)].pexpr)); }
     break;
 
   case 27:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 379 "chapel.ypp"
     { (yyval.pblockstmt) = buildLabelStmt((yyvsp[(2) - (3)].pch), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 28:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 380 "chapel.ypp"
     { (yyval.pblockstmt) = buildLocalStmt((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 29:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 381 "chapel.ypp"
     { (yyval.pblockstmt) = buildOnStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 30:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 382 "chapel.ypp"
     { (yyval.pblockstmt) = buildSerialStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 31:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 383 "chapel.ypp"
     { (yyval.pblockstmt) = buildSerialStmt(new SymExpr(gTrue), (yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 32:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 384 "chapel.ypp"
     { (yyval.pblockstmt) = buildSyncStmt((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 33:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 385 "chapel.ypp"
     { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_YIELD, (yyvsp[(2) - (3)].pexpr)); }
     break;
 
   case 34:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 386 "chapel.ypp"
     { printf("syntax error"); clean_exit(1); }
     break;
 
   case 35:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 391 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[(2) - (4)].pch), new BlockStmt(), yyfilename, (yylsp[(1) - (4)]).comment))); }
     break;
 
   case 36:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 393 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[(2) - (5)].pch), (yyvsp[(4) - (5)].pblockstmt), yyfilename, (yylsp[(1) - (5)]).comment))); }
     break;
 
   case 37:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 397 "chapel.ypp"
     { (yyloc).comment = yylloc.comment; yylloc.comment = NULL;}
     break;
 
   case 38:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 412 "chapel.ypp"
     { (yyval.pblockstmt) = new BlockStmt(); }
     break;
 
   case 39:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 413 "chapel.ypp"
     { (yyval.pblockstmt) = (yyvsp[(2) - (3)].pblockstmt);              }
     break;
 
   case 40:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 418 "chapel.ypp"
     { (yyval.pblockstmt) = new BlockStmt(); (yyval.pblockstmt)->appendChapelStmt((yyvsp[(1) - (1)].pblockstmt)); }
     break;
 
   case 41:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 419 "chapel.ypp"
     { (yyvsp[(1) - (2)].pblockstmt)->appendChapelStmt((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 42:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 424 "chapel.ypp"
     { (yyval.pblockstmt) = buildUseStmt((yyvsp[(2) - (3)].pcallexpr)); }
     break;
 
   case 43:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 428 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "=");   }
     break;
 
   case 44:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 429 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "+=");  }
     break;
 
   case 45:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 430 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "-=");  }
     break;
 
   case 46:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 431 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "*=");  }
     break;
 
   case 47:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 432 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "/=");  }
     break;
 
   case 48:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 433 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "%=");  }
     break;
 
   case 49:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 434 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "**="); }
     break;
 
   case 50:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 435 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "&=");  }
     break;
 
   case 51:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 436 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "|=");  }
     break;
 
   case 52:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 437 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "^=");  }
     break;
 
   case 53:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 438 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), ">>="); }
     break;
 
   case 54:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 439 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "<<="); }
     break;
 
   case 55:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 440 "chapel.ypp"
     { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "<=>"); }
     break;
 
   case 56:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 441 "chapel.ypp"
     { (yyval.pblockstmt) = buildLAndAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr));    }
     break;
 
   case 57:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 442 "chapel.ypp"
     { (yyval.pblockstmt) = buildLOrAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr));     }
     break;
 
   case 58:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 446 "chapel.ypp"
     { (yyval.pch) = NULL; }
     break;
 
   case 60:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 451 "chapel.ypp"
     { (yyval.pch) = astr(yytext); }
     break;
 
   case 61:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 455 "chapel.ypp"
     { (yyval.pblockstmt) = (yyvsp[(2) - (2)].pblockstmt); }
     break;
 
   case 62:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 456 "chapel.ypp"
     { (yyval.pblockstmt) = (yyvsp[(1) - (1)].pblockstmt); }
     break;
 
   case 63:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 460 "chapel.ypp"
     { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_RETURN, new SymExpr(gVoid)); }
     break;
 
   case 64:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 461 "chapel.ypp"
     { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_RETURN, (yyvsp[(2) - (3)].pexpr)); }
     break;
 
   case 65:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 465 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt(new BlockStmt()); }
     break;
 
   case 71:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 475 "chapel.ypp"
     {
 #ifdef HAVE_LLVM
@@ -4833,119 +4833,119 @@ yyreduce:
 
   case 72:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 489 "chapel.ypp"
     { (yyval.pblockstmt) = DoWhileStmt::build((yyvsp[(4) - (5)].pexpr), (yyvsp[(2) - (5)].pblockstmt)); }
     break;
 
   case 73:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 490 "chapel.ypp"
     { (yyval.pblockstmt) = WhileDoStmt::build((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 74:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 491 "chapel.ypp"
     { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr), (yyvsp[(6) - (6)].pblockstmt)); }
     break;
 
   case 75:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 492 "chapel.ypp"
     { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr), (yyvsp[(6) - (6)].pblockstmt), true); }
     break;
 
   case 76:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 493 "chapel.ypp"
     { (yyval.pblockstmt) = buildCoforallLoopStmt(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr), (yyvsp[(4) - (4)].pblockstmt)); }
     break;
 
   case 77:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 494 "chapel.ypp"
     { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), (yyvsp[(5) - (5)].pblockstmt), false, false); }
     break;
 
   case 78:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 495 "chapel.ypp"
     { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), (yyvsp[(5) - (5)].pblockstmt), false,  true); }
     break;
 
   case 79:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 496 "chapel.ypp"
     { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt), false, false); }
     break;
 
   case 80:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 497 "chapel.ypp"
     { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt), false,  true); }
     break;
 
   case 81:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 498 "chapel.ypp"
     { (yyval.pblockstmt) = buildParamForLoopStmt((yyvsp[(3) - (6)].pch), (yyvsp[(5) - (6)].pexpr), (yyvsp[(6) - (6)].pblockstmt)); }
     break;
 
   case 82:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 499 "chapel.ypp"
     { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), NULL, (yyvsp[(5) - (5)].pblockstmt)); }
     break;
 
   case 83:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 500 "chapel.ypp"
     { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr),   (yyvsp[(6) - (6)].pblockstmt)); }
     break;
 
   case 84:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 501 "chapel.ypp"
     { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), NULL, (yyvsp[(5) - (5)].pblockstmt), true); }
     break;
 
   case 85:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 502 "chapel.ypp"
     { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr),   (yyvsp[(6) - (6)].pblockstmt), true); }
     break;
 
   case 86:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 503 "chapel.ypp"
     { (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[(2) - (3)].pexpr), NULL, (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 87:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 504 "chapel.ypp"
     { (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr),   (yyvsp[(4) - (4)].pblockstmt)); }
     break;
 
   case 88:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 506 "chapel.ypp"
     {
       if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
@@ -4956,7 +4956,7 @@ yyreduce:
 
   case 89:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 512 "chapel.ypp"
     {
       if ((yyvsp[(2) - (7)].pcallexpr)->argList.length != 1)
@@ -4967,7 +4967,7 @@ yyreduce:
 
   case 90:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 518 "chapel.ypp"
     {
       if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
@@ -4978,7 +4978,7 @@ yyreduce:
 
   case 91:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 524 "chapel.ypp"
     {
       if ((yyvsp[(2) - (7)].pcallexpr)->argList.length != 1)
@@ -4989,7 +4989,7 @@ yyreduce:
 
   case 92:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 530 "chapel.ypp"
     {
       if ((yyvsp[(2) - (4)].pcallexpr)->argList.length > 1)
@@ -5001,7 +5001,7 @@ yyreduce:
 
   case 93:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 537 "chapel.ypp"
     {
       if ((yyvsp[(2) - (5)].pcallexpr)->argList.length > 1)
@@ -5013,84 +5013,84 @@ yyreduce:
 
   case 94:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 546 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("_build_tuple", (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 95:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 550 "chapel.ypp"
     { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (4)].pexpr), (yyvsp[(4) - (4)].pblockstmt)); }
     break;
 
   case 96:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 551 "chapel.ypp"
     { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 97:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 552 "chapel.ypp"
     { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pblockstmt), (yyvsp[(6) - (6)].pblockstmt)); }
     break;
 
   case 98:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 553 "chapel.ypp"
     { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(3) - (5)].pblockstmt), (yyvsp[(5) - (5)].pblockstmt)); }
     break;
 
   case 99:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 558 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt(buildSelectStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pblockstmt))); }
     break;
 
   case 100:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 562 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt(); }
     break;
 
   case 101:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 563 "chapel.ypp"
     { (yyvsp[(1) - (2)].pblockstmt)->insertAtTail((yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 102:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 568 "chapel.ypp"
     { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN, (yyvsp[(2) - (3)].pcallexpr)), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 103:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 570 "chapel.ypp"
     { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN), (yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 104:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 575 "chapel.ypp"
     { USR_FATAL((yyvsp[(3) - (6)].pcallexpr), "'type select' is no longer supported. Use 'select'"); }
     break;
 
   case 105:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 582 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[(3) - (7)].pch), (yyvsp[(2) - (7)].ptype), (yyvsp[(4) - (7)].pcallexpr), (yyvsp[(6) - (7)].pblockstmt), (yyvsp[(1) - (7)].flag), (yylsp[(1) - (7)]).comment));
       yylloc.comment = NULL; }
@@ -5098,21 +5098,21 @@ yyreduce:
 
   case 106:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 587 "chapel.ypp"
     { (yyval.flag) = FLAG_UNKNOWN; }
     break;
 
   case 107:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 588 "chapel.ypp"
     { (yyval.flag) = FLAG_EXTERN; (yyloc).comment = yylloc.comment; yylloc.comment = NULL;}
     break;
 
   case 108:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 592 "chapel.ypp"
     { (yyval.ptype) = new AggregateType(AGGREGATE_CLASS); (yyloc).comment = yylloc.comment;
              yylloc.comment = NULL;}
@@ -5120,7 +5120,7 @@ yyreduce:
 
   case 109:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 594 "chapel.ypp"
     { (yyval.ptype) = new AggregateType(AGGREGATE_RECORD); (yyloc).comment = yylloc.comment;
              yylloc.comment = NULL;}
@@ -5128,7 +5128,7 @@ yyreduce:
 
   case 110:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 596 "chapel.ypp"
     { (yyval.ptype) = new AggregateType(AGGREGATE_UNION); (yyloc).comment = yylloc.comment;
              yylloc.comment = NULL;}
@@ -5136,42 +5136,42 @@ yyreduce:
 
   case 111:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 601 "chapel.ypp"
     { (yyval.pcallexpr) = NULL; }
     break;
 
   case 112:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 602 "chapel.ypp"
     { (yyval.pcallexpr) = (yyvsp[(2) - (2)].pcallexpr); }
     break;
 
   case 113:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 607 "chapel.ypp"
     { (yyval.pblockstmt) = new BlockStmt(); }
     break;
 
   case 114:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 609 "chapel.ypp"
     { (yyvsp[(1) - (2)].pblockstmt)->insertAtTail((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 115:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 611 "chapel.ypp"
     { (yyvsp[(1) - (3)].pblockstmt)->insertAtTail(buildPragmaStmt((yyvsp[(2) - (3)].vpch), (yyvsp[(3) - (3)].pblockstmt))); }
     break;
 
   case 116:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 616 "chapel.ypp"
     {
       EnumType* pdt = (yyvsp[(4) - (5)].penumtype);
@@ -5183,7 +5183,7 @@ yyreduce:
 
   case 117:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 626 "chapel.ypp"
     {
       (yyval.penumtype) = new EnumType();
@@ -5195,7 +5195,7 @@ yyreduce:
 
   case 118:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 633 "chapel.ypp"
     {
       (yyval.penumtype) = (yyvsp[(1) - (2)].penumtype);
@@ -5204,7 +5204,7 @@ yyreduce:
 
   case 119:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 637 "chapel.ypp"
     {
       (yyvsp[(1) - (3)].penumtype)->constants.insertAtTail((yyvsp[(3) - (3)].pdefexpr));
@@ -5214,21 +5214,21 @@ yyreduce:
 
   case 120:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 644 "chapel.ypp"
     { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[(1) - (1)].pch))); }
     break;
 
   case 121:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 645 "chapel.ypp"
     { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[(1) - (3)].pch)), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 122:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 650 "chapel.ypp"
     {
       captureTokens = 1;
@@ -5238,7 +5238,7 @@ yyreduce:
 
   case 123:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 655 "chapel.ypp"
     {
       captureTokens = 0;
@@ -5248,7 +5248,7 @@ yyreduce:
 
   case 124:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 660 "chapel.ypp"
     {
       (yyvsp[(3) - (8)].pfnsymbol)->retTag = (yyvsp[(5) - (8)].retTag);
@@ -5269,14 +5269,14 @@ yyreduce:
 
   case 125:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 680 "chapel.ypp"
     { (yyval.pfnsymbol) = new FnSymbol(""); }
     break;
 
   case 126:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 681 "chapel.ypp"
     { (yyval.pfnsymbol) = new FnSymbol(""); (yyval.pfnsymbol)->addFlag(FLAG_INLINE);
                   (yyloc).comment = yylloc.comment; yylloc.comment = NULL;}
@@ -5284,7 +5284,7 @@ yyreduce:
 
   case 127:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 683 "chapel.ypp"
     { (yyval.pfnsymbol) = new FnSymbol(""); (yyval.pfnsymbol)->addFlag(FLAG_EXPORT);
                   (yyval.pfnsymbol)->addFlag(FLAG_LOCAL_ARGS);
@@ -5293,7 +5293,7 @@ yyreduce:
 
   case 128:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 686 "chapel.ypp"
     { (yyval.pfnsymbol) = new FnSymbol((yyvsp[(2) - (2)].pch)); (yyval.pfnsymbol)->addFlag(FLAG_EXPORT);
                   (yyval.pfnsymbol)->addFlag(FLAG_LOCAL_ARGS);
@@ -5302,7 +5302,7 @@ yyreduce:
 
   case 129:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 689 "chapel.ypp"
     { (yyval.pfnsymbol) = new FnSymbol(""); (yyval.pfnsymbol)->addFlag(FLAG_EXTERN);
                   (yyval.pfnsymbol)->addFlag(FLAG_LOCAL_ARGS);
@@ -5311,7 +5311,7 @@ yyreduce:
 
   case 130:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 692 "chapel.ypp"
     { (yyval.pfnsymbol) = new FnSymbol((yyvsp[(2) - (2)].pch)); (yyval.pfnsymbol)->addFlag(FLAG_EXTERN);
                   (yyval.pfnsymbol)->addFlag(FLAG_LOCAL_ARGS);
@@ -5320,7 +5320,7 @@ yyreduce:
 
   case 131:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 698 "chapel.ypp"
     {
       // Sets up to capture tokens while parsing the next grammar nonterminal.
@@ -5331,7 +5331,7 @@ yyreduce:
 
   case 132:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 704 "chapel.ypp"
     {
       // Stop capturing and save the result.
@@ -5343,7 +5343,7 @@ yyreduce:
 
   case 133:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 711 "chapel.ypp"
     {
       FnSymbol* fn = (yyvsp[(4) - (9)].pfnsymbol);
@@ -5367,7 +5367,7 @@ yyreduce:
 
   case 134:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 733 "chapel.ypp"
     {
       (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(3) - (3)].pfnsymbol), (yyvsp[(2) - (3)].pch), (yyvsp[(1) - (3)].pt), NULL);
@@ -5376,7 +5376,7 @@ yyreduce:
 
   case 135:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 737 "chapel.ypp"
     {
       (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(3) - (3)].pfnsymbol), (yyvsp[(2) - (3)].pch), (yyvsp[(1) - (3)].pt), NULL);
@@ -5386,7 +5386,7 @@ yyreduce:
 
   case 136:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 742 "chapel.ypp"
     {
       (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(5) - (5)].pfnsymbol), (yyvsp[(4) - (5)].pch), (yyvsp[(1) - (5)].pt), (yyvsp[(2) - (5)].pch));
@@ -5395,7 +5395,7 @@ yyreduce:
 
   case 137:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 746 "chapel.ypp"
     {
       (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(5) - (5)].pfnsymbol), (yyvsp[(4) - (5)].pch), (yyvsp[(1) - (5)].pt), (yyvsp[(2) - (5)].pch));
@@ -5405,560 +5405,560 @@ yyreduce:
 
   case 139:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 754 "chapel.ypp"
     { (yyval.pch) = astr("~", (yyvsp[(2) - (2)].pch)); }
     break;
 
   case 140:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 755 "chapel.ypp"
     { (yyval.pch) = "&"; }
     break;
 
   case 141:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 756 "chapel.ypp"
     { (yyval.pch) = "|"; }
     break;
 
   case 142:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 757 "chapel.ypp"
     { (yyval.pch) = "^"; }
     break;
 
   case 143:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 758 "chapel.ypp"
     { (yyval.pch) = "~"; }
     break;
 
   case 144:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 759 "chapel.ypp"
     { (yyval.pch) = "=="; }
     break;
 
   case 145:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 760 "chapel.ypp"
     { (yyval.pch) = "!="; }
     break;
 
   case 146:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 761 "chapel.ypp"
     { (yyval.pch) = "<="; }
     break;
 
   case 147:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 762 "chapel.ypp"
     { (yyval.pch) = ">="; }
     break;
 
   case 148:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 763 "chapel.ypp"
     { (yyval.pch) = "<"; }
     break;
 
   case 149:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 764 "chapel.ypp"
     { (yyval.pch) = ">"; }
     break;
 
   case 150:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 765 "chapel.ypp"
     { (yyval.pch) = "+"; }
     break;
 
   case 151:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 766 "chapel.ypp"
     { (yyval.pch) = "-"; }
     break;
 
   case 152:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 767 "chapel.ypp"
     { (yyval.pch) = "*"; }
     break;
 
   case 153:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 768 "chapel.ypp"
     { (yyval.pch) = "/"; }
     break;
 
   case 154:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 769 "chapel.ypp"
     { (yyval.pch) = "<<"; }
     break;
 
   case 155:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 770 "chapel.ypp"
     { (yyval.pch) = ">>"; }
     break;
 
   case 156:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 771 "chapel.ypp"
     { (yyval.pch) = "%"; }
     break;
 
   case 157:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 772 "chapel.ypp"
     { (yyval.pch) = "**"; }
     break;
 
   case 158:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 773 "chapel.ypp"
     { (yyval.pch) = "!"; }
     break;
 
   case 159:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 774 "chapel.ypp"
-    { (yyval.pch) = "by"; }
+    { (yyval.pch) = "chpl_by"; }
     break;
 
   case 160:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 775 "chapel.ypp"
     { (yyval.pch) = "#"; }
     break;
 
   case 161:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 776 "chapel.ypp"
     { (yyval.pch) = "align"; }
     break;
 
   case 162:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 777 "chapel.ypp"
     { (yyval.pch) = "<=>"; }
     break;
 
   case 163:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 778 "chapel.ypp"
     { (yyval.pch) = "<~>"; }
     break;
 
   case 164:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 782 "chapel.ypp"
     { (yyval.pch) = "="; }
     break;
 
   case 165:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 783 "chapel.ypp"
     { (yyval.pch) = "+="; }
     break;
 
   case 166:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 784 "chapel.ypp"
     { (yyval.pch) = "-="; }
     break;
 
   case 167:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 785 "chapel.ypp"
     { (yyval.pch) = "*="; }
     break;
 
   case 168:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 786 "chapel.ypp"
     { (yyval.pch) = "/="; }
     break;
 
   case 169:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 787 "chapel.ypp"
     { (yyval.pch) = "%="; }
     break;
 
   case 170:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 788 "chapel.ypp"
     { (yyval.pch) = "**="; }
     break;
 
   case 171:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 789 "chapel.ypp"
     { (yyval.pch) = "&="; }
     break;
 
   case 172:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 790 "chapel.ypp"
     { (yyval.pch) = "|="; }
     break;
 
   case 173:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 791 "chapel.ypp"
     { (yyval.pch) = "^="; }
     break;
 
   case 174:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 792 "chapel.ypp"
     { (yyval.pch) = ">>="; }
     break;
 
   case 175:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 793 "chapel.ypp"
     { (yyval.pch) = "<<="; }
     break;
 
   case 176:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 797 "chapel.ypp"
     { (yyval.pfnsymbol) = new FnSymbol("_"); (yyval.pfnsymbol)->addFlag(FLAG_NO_PARENS); }
     break;
 
   case 177:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 798 "chapel.ypp"
     { (yyval.pfnsymbol) = (yyvsp[(2) - (3)].pfnsymbol); }
     break;
 
   case 178:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 802 "chapel.ypp"
     { (yyval.pfnsymbol) = (yyvsp[(2) - (3)].pfnsymbol); }
     break;
 
   case 179:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 806 "chapel.ypp"
     { (yyval.pfnsymbol) = buildFunctionFormal(NULL, NULL); }
     break;
 
   case 180:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 807 "chapel.ypp"
     { (yyval.pfnsymbol) = buildFunctionFormal(NULL, (yyvsp[(1) - (1)].pdefexpr)); }
     break;
 
   case 181:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 808 "chapel.ypp"
     { (yyval.pfnsymbol) = buildFunctionFormal((yyvsp[(1) - (3)].pfnsymbol), (yyvsp[(3) - (3)].pdefexpr)); }
     break;
 
   case 182:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 813 "chapel.ypp"
     { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[(1) - (4)].pt), (yyvsp[(2) - (4)].pch), (yyvsp[(3) - (4)].pexpr), (yyvsp[(4) - (4)].pexpr), NULL); }
     break;
 
   case 183:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 815 "chapel.ypp"
     { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[(1) - (4)].pt), (yyvsp[(2) - (4)].pch), (yyvsp[(3) - (4)].pexpr), NULL, (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 184:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 817 "chapel.ypp"
     { (yyval.pdefexpr) = buildTupleArgDefExpr((yyvsp[(1) - (6)].pt), (yyvsp[(3) - (6)].pblockstmt), (yyvsp[(5) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)); }
     break;
 
   case 185:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 819 "chapel.ypp"
     { USR_FATAL("variable-length argument may not be grouped in a tuple"); }
     break;
 
   case 186:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 823 "chapel.ypp"
     { (yyval.pt) = INTENT_BLANK; }
     break;
 
   case 187:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 824 "chapel.ypp"
     { (yyval.pt) = INTENT_IN; }
     break;
 
   case 188:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 825 "chapel.ypp"
     { (yyval.pt) = INTENT_INOUT; }
     break;
 
   case 189:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 826 "chapel.ypp"
     { (yyval.pt) = INTENT_OUT; }
     break;
 
   case 190:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 827 "chapel.ypp"
     { (yyval.pt) = INTENT_CONST; }
     break;
 
   case 191:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 828 "chapel.ypp"
     { (yyval.pt) = INTENT_CONST_IN; }
     break;
 
   case 192:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 829 "chapel.ypp"
     { (yyval.pt) = INTENT_CONST_REF; }
     break;
 
   case 193:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 830 "chapel.ypp"
     { (yyval.pt) = INTENT_PARAM; }
     break;
 
   case 194:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 831 "chapel.ypp"
     { (yyval.pt) = INTENT_REF; }
     break;
 
   case 195:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 832 "chapel.ypp"
     { (yyval.pt) = INTENT_TYPE; }
     break;
 
   case 196:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 836 "chapel.ypp"
     { (yyval.pt) = INTENT_BLANK; }
     break;
 
   case 197:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 837 "chapel.ypp"
     { (yyval.pt) = INTENT_PARAM; }
     break;
 
   case 198:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 838 "chapel.ypp"
     { (yyval.pt) = INTENT_REF;   }
     break;
 
   case 199:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 842 "chapel.ypp"
     { (yyval.procIter) = ProcIter_PROC; }
     break;
 
   case 200:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 843 "chapel.ypp"
     { (yyval.procIter) = ProcIter_ITER; }
     break;
 
   case 201:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 847 "chapel.ypp"
     { (yyval.retTag) = RET_VALUE; }
     break;
 
   case 202:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 848 "chapel.ypp"
     { (yyval.retTag) = RET_VALUE; }
     break;
 
   case 203:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 849 "chapel.ypp"
     { (yyval.retTag) = RET_REF; }
     break;
 
   case 204:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 850 "chapel.ypp"
     { (yyval.retTag) = RET_PARAM; }
     break;
 
   case 205:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 851 "chapel.ypp"
     { (yyval.retTag) = RET_TYPE; }
     break;
 
   case 206:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 855 "chapel.ypp"
     { (yyval.pblockstmt) = NULL; }
     break;
 
   case 209:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 861 "chapel.ypp"
     { (yyval.pblockstmt) = new BlockStmt((yyvsp[(1) - (1)].pblockstmt)); }
     break;
 
   case 210:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 866 "chapel.ypp"
     { (yyval.pdefexpr) = new DefExpr(new VarSymbol((yyvsp[(2) - (2)].pch))); }
     break;
 
   case 211:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 868 "chapel.ypp"
     { (yyval.pdefexpr) = new DefExpr(new VarSymbol(astr("chpl__query", istr(query_uid++)))); }
     break;
 
   case 212:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 872 "chapel.ypp"
     { (yyval.pdefexpr) = new DefExpr(new VarSymbol(astr("chpl__query", istr(query_uid++)))); }
     break;
 
   case 214:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 877 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 215:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 878 "chapel.ypp"
     { (yyvsp[(2) - (2)].pdefexpr)->sym->addFlag(FLAG_PARAM); (yyval.pexpr) = (yyvsp[(2) - (2)].pdefexpr); }
     break;
 
   case 216:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 882 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
     break;
 
   case 217:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 883 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 218:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 888 "chapel.ypp"
     { (yyval.pblockstmt) = (yyvsp[(2) - (3)].pblockstmt); }
     break;
 
   case 219:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 890 "chapel.ypp"
     { (yyval.pblockstmt) = handleConfigTypes((yyvsp[(3) - (4)].pblockstmt)); }
     break;
 
   case 220:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 892 "chapel.ypp"
     { (yyval.pblockstmt) = convertTypesToExtern((yyvsp[(3) - (4)].pblockstmt)); }
     break;
 
   case 221:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 897 "chapel.ypp"
     {
       VarSymbol* var = new VarSymbol((yyvsp[(1) - (2)].pch));
@@ -5972,7 +5972,7 @@ yyreduce:
 
   case 222:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 906 "chapel.ypp"
     {
       VarSymbol* var = new VarSymbol((yyvsp[(1) - (4)].pch));
@@ -5987,28 +5987,28 @@ yyreduce:
 
   case 223:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 918 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
     break;
 
   case 224:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 920 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 225:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 922 "chapel.ypp"
     { (yyval.pexpr) = buildForallLoopExprFromArrayType((yyvsp[(2) - (2)].pcallexpr)); }
     break;
 
   case 226:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 927 "chapel.ypp"
     {
       std::set<Flag> flags;
@@ -6020,7 +6020,7 @@ yyreduce:
 
   case 227:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 934 "chapel.ypp"
     {
       std::set<Flag> flags;
@@ -6032,7 +6032,7 @@ yyreduce:
 
   case 228:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 941 "chapel.ypp"
     {
       std::set<Flag> flags;
@@ -6044,7 +6044,7 @@ yyreduce:
 
   case 229:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 948 "chapel.ypp"
     {
       std::set<Flag> flags;
@@ -6057,7 +6057,7 @@ yyreduce:
 
   case 230:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 956 "chapel.ypp"
     {
       std::set<Flag> flags;
@@ -6068,28 +6068,28 @@ yyreduce:
 
   case 231:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 964 "chapel.ypp"
     { (yyval.flag) = FLAG_UNKNOWN; (yyloc).comment = yylloc.comment; yylloc.comment = NULL;}
     break;
 
   case 232:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 965 "chapel.ypp"
     { (yyval.flag) = FLAG_CONFIG; (yyloc).comment = yylloc.comment; yylloc.comment = NULL;}
     break;
 
   case 233:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 966 "chapel.ypp"
     { (yyval.flag) = FLAG_EXTERN; (yyloc).comment = yylloc.comment; yylloc.comment = NULL;}
     break;
 
   case 235:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 972 "chapel.ypp"
     {
       for_alist(expr, (yyvsp[(3) - (3)].pblockstmt)->body)
@@ -6099,14 +6099,14 @@ yyreduce:
 
   case 236:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 980 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(new VarSymbol((yyvsp[(1) - (3)].pch)), (yyvsp[(3) - (3)].pexpr), (yyvsp[(2) - (3)].pexpr))); }
     break;
 
   case 237:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 982 "chapel.ypp"
     {
       VarSymbol* var = new VarSymbol((yyvsp[(1) - (4)].pch));
@@ -6117,119 +6117,119 @@ yyreduce:
 
   case 238:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 988 "chapel.ypp"
     { (yyval.pblockstmt) = buildTupleVarDeclStmt((yyvsp[(2) - (5)].pblockstmt), (yyvsp[(4) - (5)].pexpr), (yyvsp[(5) - (5)].pexpr)); }
     break;
 
   case 239:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 993 "chapel.ypp"
     { (yyval.pexpr) = new DefExpr(new VarSymbol("chpl__tuple_blank")); }
     break;
 
   case 240:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 995 "chapel.ypp"
     { (yyval.pexpr) = new DefExpr(new VarSymbol((yyvsp[(1) - (1)].pch))); }
     break;
 
   case 241:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 997 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (3)].pblockstmt); }
     break;
 
   case 242:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1002 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt((yyvsp[(1) - (1)].pexpr)); }
     break;
 
   case 243:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1004 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt((yyvsp[(1) - (2)].pexpr)); }
     break;
 
   case 244:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1006 "chapel.ypp"
     { (yyval.pblockstmt) = ((yyvsp[(3) - (3)].pblockstmt)->insertAtHead((yyvsp[(1) - (3)].pexpr)), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 245:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1012 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
     break;
 
   case 246:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1013 "chapel.ypp"
     { (yyval.pexpr) = new SymExpr(gNoInit); }
     break;
 
   case 247:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1014 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 248:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1018 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
     break;
 
   case 249:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1020 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__ensureDomainExpr", (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 250:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1024 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
     break;
 
   case 251:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1025 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 252:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1026 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (2)].pcallexpr); }
     break;
 
   case 253:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1027 "chapel.ypp"
     {printf("bad type specification"); }
     break;
 
   case 254:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1048 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr("chpl__buildArrayRuntimeType",
              new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), (yyvsp[(4) - (4)].pexpr));
@@ -6238,7 +6238,7 @@ yyreduce:
 
   case 255:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1052 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr("chpl__buildArrayRuntimeType",
              new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), (yyvsp[(4) - (4)].pcallexpr));
@@ -6247,7 +6247,7 @@ yyreduce:
 
   case 256:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1056 "chapel.ypp"
     {
       if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
@@ -6260,371 +6260,371 @@ yyreduce:
 
   case 257:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1063 "chapel.ypp"
     {printf("bad array type specification"); clean_exit(1); }
     break;
 
   case 258:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1067 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
     break;
 
   case 259:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1068 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(1) - (1)].pexpr); }
     break;
 
   case 260:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1069 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(1) - (1)].pdefexpr); }
     break;
 
   case 261:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1074 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 262:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1076 "chapel.ypp"
     { (yyval.pexpr) = buildFormalArrayType((yyvsp[(2) - (4)].pcallexpr), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 263:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1082 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 264:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1084 "chapel.ypp"
     { (yyval.pexpr) = buildFormalArrayType((yyvsp[(2) - (4)].pcallexpr), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 265:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1086 "chapel.ypp"
     { (yyval.pexpr) = buildFormalArrayType((yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), (yyvsp[(2) - (6)].pcallexpr)); }
     break;
 
   case 266:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1090 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
     break;
 
   case 267:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1091 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 268:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1092 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (2)].pdefexpr); }
     break;
 
   case 269:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1093 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("_domain"); }
     break;
 
   case 270:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1094 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr( "_singlevar"); }
     break;
 
   case 271:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1095 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr( "_syncvar"); }
     break;
 
   case 272:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1096 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 273:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1102 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pexpr)); }
     break;
 
   case 274:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1103 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pdefexpr)); }
     break;
 
   case 275:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1104 "chapel.ypp"
     { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 276:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1105 "chapel.ypp"
     { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pdefexpr)); }
     break;
 
   case 277:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1109 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("chpl__tuple_blank"); }
     break;
 
   case 278:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1110 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(1) - (1)].pexpr); }
     break;
 
   case 279:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1111 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(1) - (1)].pdefexpr); }
     break;
 
   case 280:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1115 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 281:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1116 "chapel.ypp"
     { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 282:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1120 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST); }
     break;
 
   case 284:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1125 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pexpr)); }
     break;
 
   case 285:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1126 "chapel.ypp"
     { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 286:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1130 "chapel.ypp"
     { (yyval.pexpr) = buildNamedActual((yyvsp[(1) - (3)].pch), (yyvsp[(3) - (3)].pdefexpr)); }
     break;
 
   case 287:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1131 "chapel.ypp"
     { (yyval.pexpr) = buildNamedActual((yyvsp[(1) - (3)].pch), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 288:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1132 "chapel.ypp"
     { (yyval.pexpr) = buildNamedAliasActual((yyvsp[(1) - (3)].pch), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 289:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1133 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(1) - (1)].pdefexpr); }
     break;
 
   case 291:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1138 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr((yyvsp[(1) - (1)].pch)); }
     break;
 
   case 297:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1155 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr( "_singlevar", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 298:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1157 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__buildIndexType", (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 299:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1159 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__buildDomainRuntimeType", new UnresolvedSymExpr("defaultDist"), (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 300:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1161 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__buildSubDomainType", (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 301:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1163 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__buildSparseDomainRuntimeType", new UnresolvedSymExpr("defaultDist"), (yyvsp[(4) - (5)].pcallexpr)); }
     break;
 
   case 302:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1165 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__atomicType", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 303:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1167 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr( "_syncvar", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 304:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1172 "chapel.ypp"
     { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)); }
     break;
 
   case 305:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1174 "chapel.ypp"
     { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), NULL, false, true); }
     break;
 
   case 306:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1176 "chapel.ypp"
     { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 307:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1178 "chapel.ypp"
     { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr)); }
     break;
 
   case 308:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1180 "chapel.ypp"
     { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr), false, true); }
     break;
 
   case 309:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1182 "chapel.ypp"
     { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[(2) - (7)].pexpr), (yyvsp[(7) - (7)].pexpr), (yyvsp[(5) - (7)].pexpr)); }
     break;
 
   case 310:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1184 "chapel.ypp"
     { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)); }
     break;
 
   case 311:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1186 "chapel.ypp"
     { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), NULL, false, true); }
     break;
 
   case 312:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1188 "chapel.ypp"
     { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 313:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1190 "chapel.ypp"
     { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr)); }
     break;
 
   case 314:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1192 "chapel.ypp"
     { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr), false, true); }
     break;
 
   case 315:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1194 "chapel.ypp"
     { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[(2) - (7)].pexpr), (yyvsp[(7) - (7)].pexpr), (yyvsp[(5) - (7)].pexpr)); }
     break;
 
   case 316:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1196 "chapel.ypp"
     {
       if ((yyvsp[(2) - (4)].pcallexpr)->argList.length > 1)
@@ -6636,7 +6636,7 @@ yyreduce:
 
   case 317:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1203 "chapel.ypp"
     {
       if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
@@ -6647,7 +6647,7 @@ yyreduce:
 
   case 318:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1209 "chapel.ypp"
     {
       if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
@@ -6658,7 +6658,7 @@ yyreduce:
 
   case 319:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1215 "chapel.ypp"
     {
       if ((yyvsp[(2) - (9)].pcallexpr)->argList.length != 1)
@@ -6669,7 +6669,7 @@ yyreduce:
 
   case 320:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1221 "chapel.ypp"
     {
       if ((yyvsp[(2) - (9)].pcallexpr)->argList.length != 1)
@@ -6680,49 +6680,49 @@ yyreduce:
 
   case 321:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1230 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr(new DefExpr(buildIfExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)))); }
     break;
 
   case 322:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1234 "chapel.ypp"
     { (yyval.pexpr) = new SymExpr(gNil); }
     break;
 
   case 330:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1250 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 331:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1254 "chapel.ypp"
     { (yyval.pcallexpr) = NULL; }
     break;
 
   case 333:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1259 "chapel.ypp"
     { (yyval.pcallexpr) = (yyvsp[(3) - (4)].pcallexpr); }
     break;
 
   case 334:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1264 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pIntentExpr).first, (yyvsp[(1) - (1)].pIntentExpr).second); }
     break;
 
   case 335:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1266 "chapel.ypp"
     {
       (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pIntentExpr).first);
@@ -6732,7 +6732,7 @@ yyreduce:
 
   case 336:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1274 "chapel.ypp"
     {
       ArgSymbol* tiMark = tiMarkForIntent((yyvsp[(1) - (2)].pt));
@@ -6745,175 +6745,175 @@ yyreduce:
 
   case 338:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1286 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 339:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1291 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr(PRIM_NEW, (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 340:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1296 "chapel.ypp"
     { (yyval.pexpr) = buildLetExpr((yyvsp[(2) - (4)].pblockstmt), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 349:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1312 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr(PRIM_TUPLE_EXPAND, (yyvsp[(3) - (4)].pexpr)); }
     break;
 
   case 350:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1314 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("_cast", (yyvsp[(3) - (3)].pexpr), (yyvsp[(1) - (3)].pexpr)); }
     break;
 
   case 351:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1316 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl_build_bounded_range", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 352:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1318 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl_build_partially_bounded_range", buildDotExpr("BoundedRangeType", "boundedLow"), (yyvsp[(1) - (2)].pexpr)); }
     break;
 
   case 353:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1320 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl_build_partially_bounded_range", buildDotExpr("BoundedRangeType", "boundedHigh"), (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 354:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1322 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl_build_unbounded_range", buildDotExpr("BoundedRangeType", "boundedNone")); }
     break;
 
   case 361:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1345 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 362:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1346 "chapel.ypp"
     { (yyval.pexpr) = buildSquareCallExpr((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 363:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1347 "chapel.ypp"
     { (yyval.pexpr) = buildPrimitiveExpr((yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 364:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1351 "chapel.ypp"
     { (yyval.pexpr) = buildDotExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pch)); }
     break;
 
   case 365:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1352 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr(PRIM_TYPEOF, (yyvsp[(1) - (3)].pexpr)); }
     break;
 
   case 366:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1353 "chapel.ypp"
     { (yyval.pexpr) = buildDotExpr((yyvsp[(1) - (3)].pexpr), "_dom"); }
     break;
 
   case 367:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1361 "chapel.ypp"
     { (yyval.pexpr) = (yyvsp[(2) - (3)].pexpr); }
     break;
 
   case 368:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1362 "chapel.ypp"
     { (yyval.pexpr) = buildOneTuple((yyvsp[(2) - (4)].pexpr)); }
     break;
 
   case 369:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1363 "chapel.ypp"
     { (yyval.pexpr) = buildTuple((yyvsp[(2) - (3)].pcallexpr)); }
     break;
 
   case 370:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1367 "chapel.ypp"
     { (yyval.pexpr) = buildIntLiteral(yytext);  }
     break;
 
   case 371:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1368 "chapel.ypp"
     { (yyval.pexpr) = buildRealLiteral(yytext); }
     break;
 
   case 372:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1369 "chapel.ypp"
     { (yyval.pexpr) = buildImagLiteral(yytext); }
     break;
 
   case 373:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1370 "chapel.ypp"
     { (yyval.pexpr) = buildStringLiteral((yyvsp[(1) - (1)].pch)); }
     break;
 
   case 374:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1371 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__buildDomainExpr", (yyvsp[(2) - (3)].pcallexpr)); }
     break;
 
   case 375:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1372 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__buildArrayExpr", (yyvsp[(2) - (3)].pcallexpr)); }
     break;
 
   case 376:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1374 "chapel.ypp"
     {
       (yyval.pexpr) = new CallExpr("chpl__buildAssociativeArrayExpr", (yyvsp[(2) - (3)].pcallexpr));
@@ -6922,329 +6922,329 @@ yyreduce:
 
   case 377:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1380 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 378:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1381 "chapel.ypp"
     { (yyvsp[(1) - (5)].pcallexpr)->insertAtTail((yyvsp[(3) - (5)].pexpr)); (yyvsp[(1) - (5)].pcallexpr)->insertAtTail((yyvsp[(5) - (5)].pexpr)); }
     break;
 
   case 379:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1385 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("+", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 380:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1386 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("-", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 381:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1387 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("*", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 382:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1388 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("/", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 383:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1389 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("<<", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 384:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1390 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr(">>", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 385:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1391 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("%", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 386:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1392 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("==", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 387:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1393 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("!=", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 388:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1394 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("<=", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 389:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1395 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr(">=", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 390:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1396 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("<", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 391:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1397 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr(">", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 392:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1398 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("&", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 393:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1399 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("|", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 394:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1400 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("^", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 395:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1401 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("&&", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 396:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1402 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("||", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 397:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1403 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("**", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 398:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1404 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("by", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+    { (yyval.pexpr) = new CallExpr("chpl_by", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 399:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1405 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("align", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 400:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1406 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("#", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 401:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1407 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl__distributed", (yyvsp[(3) - (3)].pexpr), (yyvsp[(1) - (3)].pexpr)); }
     break;
 
   case 402:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1411 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("+", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 403:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1412 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("-", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 404:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1413 "chapel.ypp"
     { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[(2) - (2)].pexpr), '-'); }
     break;
 
   case 405:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1414 "chapel.ypp"
     { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[(2) - (2)].pexpr), '+'); }
     break;
 
   case 406:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1415 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("!", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 407:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1416 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("~", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 408:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1420 "chapel.ypp"
     { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 409:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1421 "chapel.ypp"
     { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr), true); }
     break;
 
   case 410:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1422 "chapel.ypp"
     { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 411:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1423 "chapel.ypp"
     { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr), true); }
     break;
 
   case 412:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1427 "chapel.ypp"
     { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 413:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1428 "chapel.ypp"
     { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr), true); }
     break;
 
   case 414:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1429 "chapel.ypp"
     { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 415:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1430 "chapel.ypp"
     { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr), true); }
     break;
 
   case 416:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1435 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("SumReduceScanOp"); }
     break;
 
   case 417:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1436 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("ProductReduceScanOp"); }
     break;
 
   case 418:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1437 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("LogicalAndReduceScanOp"); }
     break;
 
   case 419:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1438 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("LogicalOrReduceScanOp"); }
     break;
 
   case 420:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1439 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("BitwiseAndReduceScanOp"); }
     break;
 
   case 421:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1440 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("BitwiseOrReduceScanOp"); }
     break;
 
   case 422:
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 1441 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("BitwiseXorReduceScanOp"); }
     break;
 
 
 
-/* Line 1821 of yacc.c  */
+/* Line 1806 of yacc.c  */
 #line 7249 "bison-chapel.cpp"
       default: break;
     }

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -771,7 +771,7 @@ fn_ident:
 | TMOD           { $$ = "%"; }
 | TEXP           { $$ = "**"; }
 | TNOT           { $$ = "!"; }
-| TBY            { $$ = "by"; }
+| TBY            { $$ = "chpl_by"; }
 | THASH          { $$ = "#"; }
 | TALIGN         { $$ = "align"; }
 | TSWAP          { $$ = "<=>"; }
@@ -1401,7 +1401,7 @@ binary_op_expr:
 | expr TAND expr           { $$ = new CallExpr("&&", $1, $3); }
 | expr TOR  expr           { $$ = new CallExpr("||", $1, $3); }
 | expr TEXP expr           { $$ = new CallExpr("**", $1, $3); }
-| expr TBY expr            { $$ = new CallExpr("by", $1, $3); }
+| expr TBY expr            { $$ = new CallExpr("chpl_by", $1, $3); }
 | expr TALIGN expr         { $$ = new CallExpr("align", $1, $3); }
 | expr THASH expr          { $$ = new CallExpr("#", $1, $3); }
 | expr TDMAPPED expr       { $$ = new CallExpr("chpl__distributed", $3, $1); }

--- a/compiler/parser/flex-chapel.cpp
+++ b/compiler/parser/flex-chapel.cpp
@@ -47,7 +47,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -154,12 +153,7 @@ typedef unsigned int flex_uint32_t;
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #endif
 
-#ifndef YY_TYPEDEF_YY_SIZE_T
-#define YY_TYPEDEF_YY_SIZE_T
-typedef size_t yy_size_t;
-#endif
-
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
@@ -185,6 +179,11 @@ extern FILE *yyin, *yyout;
 
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
+#ifndef YY_TYPEDEF_YY_SIZE_T
+#define YY_TYPEDEF_YY_SIZE_T
+typedef size_t yy_size_t;
+#endif
+
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
 struct yy_buffer_state
@@ -202,7 +201,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -272,8 +271,8 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
 static char *yy_c_buf_p = (char *) 0;
@@ -301,7 +300,7 @@ static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
 
 YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
 YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
+YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,int len  );
 
 void *yyalloc (yy_size_t  );
 void *yyrealloc (void *,yy_size_t  );
@@ -359,7 +358,7 @@ static void yy_fatal_error (yyconst char msg[]  );
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (yy_size_t) (yy_cp - yy_bp); \
+	yyleng = (size_t) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
@@ -726,7 +725,7 @@ static void processMultiLineComment();
 static void processInvalidToken();
 
 
-#line 730 "flex-chapel.cpp"
+#line 729 "flex-chapel.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -766,7 +765,7 @@ FILE *yyget_out (void );
 
 void yyset_out  (FILE * out_str  );
 
-yy_size_t yyget_leng (void );
+int yyget_leng (void );
 
 char *yyget_text (void );
 
@@ -825,7 +824,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -910,7 +909,7 @@ YY_DECL
 #line 80 "chapel.lex"
 
 
-#line 914 "flex-chapel.cpp"
+#line 913 "flex-chapel.cpp"
 
 	if ( !(yy_init) )
 		{
@@ -1659,7 +1658,7 @@ YY_RULE_SETUP
 #line 236 "chapel.lex"
 ECHO;
 	YY_BREAK
-#line 1663 "flex-chapel.cpp"
+#line 1662 "flex-chapel.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();
@@ -1846,7 +1845,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1860,7 +1859,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1891,7 +1890,7 @@ static int yy_get_next_buffer (void)
 
 		/* Read in more data. */
 		YY_INPUT( (&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move]),
-			(yy_n_chars), num_to_read );
+			(yy_n_chars), (size_t) num_to_read );
 
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
 		}
@@ -2013,7 +2012,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (yy_c_buf_p) - (yytext_ptr);
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -2037,7 +2036,7 @@ static int yy_get_next_buffer (void)
 				case EOB_ACT_END_OF_FILE:
 					{
 					if ( yywrap( ) )
-						return 0;
+						return EOF;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -2289,7 +2288,7 @@ void yypop_buffer_state (void)
  */
 static void yyensure_buffer_stack (void)
 {
-	yy_size_t num_to_alloc;
+	int num_to_alloc;
     
 	if (!(yy_buffer_stack)) {
 
@@ -2386,11 +2385,12 @@ YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
-	yy_size_t n, i;
+	yy_size_t n;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
@@ -2472,7 +2472,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -720,7 +720,7 @@ module ChapelRange {
   }
   
   
-  proc chpl_by(r: range(?i,?b,?s), step) {
+  proc chpl_by_help(r: range(?i,?b,?s), step) {
     const lw: i = r.low,
           hh: i = r.high,
           st: r.strType = r.stride * step:r.strType;
@@ -740,14 +740,14 @@ module ChapelRange {
     if !isRange(r) then
       compilerError("the first argument of the 'by' operator is not a range");
     chpl_range_check_stride(step, r.idxType);
-    return chpl_by(r, step);
+    return chpl_by_help(r, step);
   }
   
   // We want to warn the user at compiler time if they had an invalid param
   // stride rather than waiting until runtime.
   inline proc by(r : range(?), param step) {
     chpl_range_check_stride(step, r.idxType);
-    return chpl_by(r, step:r.strType);
+    return chpl_by_help(r, step:r.strType);
   }
   
   


### PR DESCRIPTION
In one of my working patches, I ran into an issue because a
test/types/range/hilde/by.chpl introduces a module named 'by'
which conflicted with references to the 'by' operator in the
internal module I was working on.  While this surprised me
at first (isn't "by" a reserved keyword?!) it makes sense given
that we convert instances of the 'by' operator, including
user-defined overloads of it, into functions named 'by' and then
(intentionally) don't distinguish namespaces for different symbol
types.  So, OK.

[I'm not quite sure what it is about my patch that ran into this
when other things haven't -- though I also noticed that not
many internal modules use the 'by' operator, so maybe that's
it.  In any case...]

This pull request renames 'by' to 'chpl_by' in the parser
to protect against such issues (since users should not name
modules chpl_<anything>).  It turned out there was also a
helper function in ChapelRange.chpl named 'chpl_by', so then
I had to rename that to 'chpl_by_help' (which seems like an
appropriate name).

I think this is a step forward, albeit a somewhat silly one.

The diff is larger than ideal (though doesn't require reviewing)
primarily due to differences in the parser-generated files.