### PR TITLE
Update chpldoc-venv/Makefile to support installing updates for chapel domain.

### DIFF
--- a/third-party/chpldoc-venv/Makefile
+++ b/third-party/chpldoc-venv/Makefile
@@ -12,11 +12,11 @@ default: all
 
 all: $(CHPLDOC_VENV_SPHINX_BUILD)
 
-clean:
+clean: FORCE
 
-cleanall:
+cleanall: FORCE
 
-clobber: clean
+clobber: FORCE
 	rm -rf install
 
 $(PYTHON):
@@ -59,8 +59,14 @@ $(CHPLDOC_VENV_SPHINX_BUILD): $(CHPLDOC_VENV_VIRTUALENV_DIR)
 	pip install -U --force-reinstall -r requirements.txt
 
 # Phony convenience target for install python packages.
-install-requirements: $(CHPLDOC_VENV_SPHINX_BUILD)
+install-requirements: rm-sphinx-build $(CHPLDOC_VENV_SPHINX_BUILD)
+
+# Remove sphinx-build, forcing install-requirements to be rebuilt.
+rm-sphinx-build: FORCE
+	@rm -f $(CHPLDOC_VENV_SPHINX_BUILD)
 
 FORCE:
 
-.PHONY: install-requirements create-virtualenv virtualenv check-exes
+.PHONY: install-requirements create-virtualenv virtualenv check-exes rm-sphinx-build
+
+.NOTPARALLEL:

--- a/third-party/chpldoc-venv/README.md
+++ b/third-party/chpldoc-venv/README.md
@@ -7,6 +7,16 @@ the various formats.
 The Makefile in this third-party directory creates a Python virtualenv and
 installs the python packages required by `chpldoc` inside it.
 
+To re-install the packages, e.g. to pick up updates to the
+sphinxcontrib-chapeldomain package, use this command:
+
+```bash
+gmake install-requirements
+
+# or on mac, cygwin:
+make install-requirements
+```
+
 Python Packages
 ---------------
 

--- a/third-party/chpldoc-venv/requirements.txt
+++ b/third-party/chpldoc-venv/requirements.txt
@@ -4,4 +4,4 @@ Pygments==2.0.2
 Sphinx==1.2.3
 docutils==0.12
 sphinx-rtd-theme==0.1.6
-sphinxcontrib-chapeldomain>=0.0.5
+sphinxcontrib-chapeldomain>=0.0.6

--- a/third-party/chpldoc-venv/requirements.txt
+++ b/third-party/chpldoc-venv/requirements.txt
@@ -4,4 +4,4 @@ Pygments==2.0.2
 Sphinx==1.2.3
 docutils==0.12
 sphinx-rtd-theme==0.1.6
-sphinxcontrib-chapeldomain>=0.0.6
+sphinxcontrib-chapeldomain>=0.0.7


### PR DESCRIPTION
Update install-requirements phony target to first remove the sphinx-build
binary (used to indicate whether or not all the packages are installed) and
then (re)install all the packages. Since sphinxcontrib-chapeldomain uses a >=
requirement, this will pick up new versions if available.

While there, also bump minimum required version of chapel domain to 0.0.7.