### PR TITLE
Replace uses of sleep with sync variables

### DIFF
--- a/test/multilocale/vass/this-in-taskfns-in-ctors.chpl
+++ b/test/multilocale/vass/this-in-taskfns-in-ctors.chpl
@@ -13,23 +13,27 @@ record RR {
   var xx, yy: int;
   // the default constructor
   proc RR() {
+    var done$: sync bool;
     on loc {
       this.xx = 555;
     }
     begin {
       this.yy = 666;
+      done$ = true;
     }
-    chpl_task_sleep(1);
+    done$;
   }
   // method with args
   proc modify(ee: int, ff: int) {
+    var done$: sync bool;
     on loc {
       this.xx = ee;
     }
     begin {
       this.yy = ff;
+      done$ = true;
     }
-    chpl_task_sleep(1);
+    done$;
   }
 } // record RR
 
@@ -37,23 +41,27 @@ record QQ {
   var aa, bb: int;
   // non-default constructor
   proc QQ(cc: int, dd: int) {
+    var done$: sync bool;
     on loc {
       this.aa = cc;
     }
     begin {
       this.bb = dd;
+      done$ = true;
     }
-    chpl_task_sleep(1);
+    done$;
   }
   // method with no args
   proc modify() {
+    var done$: sync bool;
     on loc {
       this.aa = 171717;
     }
     begin {
       this.bb = 181818;
+      done$ = true;
     }
-    chpl_task_sleep(1);
+    done$;
   }
 } // record QQ
 


### PR DESCRIPTION
As has been pointed out in several different tests, using sleeps
to try and order tasks is an unsafe practice.  This test was
failing on my Mac using array views which seemed surprising
given that it doesn't even use arrays.  Turns out that it's
just a race condition.  Replacing the sleeps with sync variables
avoids the race.

The comment states that this practice was done for debugging
which is all well and good when debugging, but once tests
are being committed for long-term testing across various
environments (that may have limited theads or different timing
characteristics), let's avoid sleeps in order to avoid false
negatives and time spent debugging by others please.