### PR TITLE
Fix problems when $CHPL_HOME has a symbolic link

### DIFF
--- a/test/regexp/ferguson/ctests/sub_test
+++ b/test/regexp/ferguson/ctests/sub_test
@@ -3,6 +3,14 @@
 # These C tests don't conform to -Wall
 unset CHPL_DEVELOPER
 
+# Normalize $CHPL_HOME to fix problems with symbolic links
+SAVE_HOME=$CHPL_HOME
+export CHPL_HOME=`readlink -f $CHPL_HOME`
+if [ "x$CHPL_HOME" = "x" ]
+then
+  export CHPL_HOME=$SAVE_HOME
+fi
+
 CC=gcc
 CXX=g++
 DEFS=`$CHPL_HOME/util/config/compileline --includes-and-defines`


### PR DESCRIPTION
I was having problems when I cd to a symbolic link to a Chapel
home directory and then run the unit tests.

The test/setchplenv tests also fail for me in this case.

Note that the fix should be harmless if readlink is not available,
but enables such symbolic links in CHPL_HOME if readlink is
available.