### PR TITLE
Change some inouts to refs in the IO module

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1555,7 +1555,7 @@ inline proc _write_one_internal(_channel_internal:qio_channel_ptr_t, param kind:
 
 /* Returns true if we read all the args,
    false if we encountered EOF (or possibly another error and didn't halt)*/
-inline proc channel.read(inout args ...?k,
+inline proc channel.read(ref args ...?k,
                   out error:syserr):bool {
   if writing then compilerError("read on write-only channel");
   error = ENOERR;
@@ -1601,7 +1601,7 @@ inline proc channel.read(ref args ...?k):bool {
     return false;
   }
 }
-proc channel.read(inout args ...?k,
+proc channel.read(ref args ...?k,
                   style:iostyle,
                   out error:syserr):bool {
   if writing then compilerError("read on write-only channel");


### PR DESCRIPTION
The use of inout in the IO module predates solid
ref argument intent support. Here I have changed
the final two inouts to refs - these were holdouts
previously due to bugs that appear to since have
been fixed.

Passes local-qthreads full testing