### PR TITLE
Fixing race in the .bad file I just submitted …

### DIFF
--- a/test/types/range/bradc/forallAlignedRange.bad
+++ b/test/types/range/bradc/forallAlignedRange.bad
@@ -3,4 +3,4 @@
 41
 57
 true
-forallAlignedRange.chpl:8: error: halt reached - array index out of bounds: (49)
+forallAlignedRange.chpl:8: error: halt reached - array index out of bounds: (1)

--- a/test/types/range/bradc/forallAlignedRange.execopts
+++ b/test/types/range/bradc/forallAlignedRange.execopts
@@ -1,0 +1,1 @@
+--dataParTasksPerLocale=1


### PR DESCRIPTION
This test was race-y depending on how many tasks were
used (which one would report the OOB error first), but
I didn't realize before committing because I almost
always got the same index.  Fixing that by dialing down
the number of tasks.  When the issue is fixed, the
.execopts should be removed.