### PR TITLE
Update chpl_launchcmd.py to wait a couple seconds for output file before raising.

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -237,11 +237,10 @@ class AbstractJob(object):
 
             def wait_for_file(filename):
                 """Wait for filename for a few seconds. If it shows up, return early."""
-                for i in xrange(10):
-                    if os.path.exists(filename):
-                        break
-                    else:
-                        time.sleep(0.5)
+                t = 0
+                while not os.path.exists(filename) and t < 5:
+                    time.sleep(0.5)
+                    t += 0.5
 
             def job_status(job_id, output_file):
                 """Returns the status of the job specified by job_id


### PR DESCRIPTION
We have observed sporadic missing output files when running with PBS
launcher. @ronawho and I think we might be be hitting a slight period of time
where qstat reports the job complete, but the output file does not yet show up
in the file system (due to network latency, etc).

Update chpl_launchcmd.py to check for the output file for a couple seconds
after the job completes.