### PR TITLE
Standalone parallel iterators

### DIFF
--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -146,7 +146,7 @@ module ChapelIteratorSupport {
   }
 
   inline proc _toStandalone(x) {
-    _toStandalone(x.these());
+    return _toStandalone(x.these());
   }
 
 

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -152,23 +152,11 @@ module DefaultAssociative {
       if debugDefaultAssoc {
         writeln("*** In associative domain standalone iterator");
       }
-      const numTasks = if dataParTasksPerLocale==0 then here.maxTaskPar
-                       else dataParTasksPerLocale;
-      const ignoreRunning = dataParIgnoreRunningTasks;
-      const minIndicesPerTask = dataParMinGranularity;
       // We are simply slicing up the table here.  Trying to do something
       //  more intelligent (like evenly dividing up the full slots, led
       //  to poor speed ups.
       const numIndices = tableSize;
-      if debugAssocDataPar {
-        writeln("### numTasks = ", numTasks);
-        writeln("### ignoreRunning = ", ignoreRunning);
-        writeln("### minIndicesPerTask = ", minIndicesPerTask);
-      }
-
-      const numChunks = _computeNumChunks(numTasks, ignoreRunning,
-                                          minIndicesPerTask,
-                                          numIndices);
+      const numChunks = _computeNumChunks(numIndices);
 
       if debugAssocDataPar {
         writeln("### numChunks=", numChunks, ", numIndices=", numIndices);
@@ -565,13 +553,8 @@ module DefaultAssociative {
       if debugDefaultAssoc {
         writeln("*** In associative array standalone iterator");
       }
-      const numTasks = if dataParTasksPerLocale==0 then here.maxTaskPar
-                       else dataParTasksPerLocale;
-      const ignoreRunning = dataParIgnoreRunningTasks;
-      const minIndicesPerTask = dataParMinGranularity;
       const numIndices = dom.tableSize;
-      const numChunks = _computeNumChunks(numTasks, ignoreRunning,
-                                          minIndicesPerTask, numIndices);
+      const numChunks = _computeNumChunks(numIndices);
       if numChunks == 1 {
         for slot in 0..#numIndices {
           if dom.table[slot].status == chpl__hash_status.full {

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -163,7 +163,6 @@ module DefaultAssociative {
       }
 
       if numChunks == 1 {
-        var followThisTab = this.table;
         for slot in 0..numIndices-1 {
           if table[slot].status == chpl__hash_status.full {
             yield table[slot].idx;

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -149,8 +149,9 @@ module DefaultAssociative {
     }
  
     iter these(param tag: iterKind) where tag == iterKind.standalone {
-      if debugDefaultAssoc then
+      if debugDefaultAssoc {
         writeln("*** In associative domain standalone iterator");
+      }
       const numTasks = if dataParTasksPerLocale==0 then here.maxTaskPar
                        else dataParTasksPerLocale;
       const ignoreRunning = dataParIgnoreRunningTasks;
@@ -170,13 +171,16 @@ module DefaultAssociative {
                                           minIndicesPerTask,
                                           numIndices);
 
-      if debugAssocDataPar then writeln("### numChunks=", numChunks, ", numIndices=", numIndices);
+      if debugAssocDataPar {
+        writeln("### numChunks=", numChunks, ", numIndices=", numIndices);
+      }
 
       if numChunks == 1 {
         var followThisTab = this.table;
         for slot in 0..numIndices-1 {
-          if table[slot].status == chpl__hash_status.full then
+          if table[slot].status == chpl__hash_status.full {
             yield table[slot].idx;
+          }
         }
       } else {
         coforall chunk in 0..#numChunks {
@@ -185,8 +189,9 @@ module DefaultAssociative {
           if debugAssocDataPar then
             writeln("*** chunk: ", chunk, " owns ", lo..hi);
           for slot in lo..hi {
-            if table[slot].status == chpl__hash_status.full then
+            if table[slot].status == chpl__hash_status.full {
               yield table[slot].idx;
+            }
           }
         }
       }
@@ -558,8 +563,9 @@ module DefaultAssociative {
     }
 
     iter these(param tag: iterKind) ref where tag == iterKind.standalone {
-      if debugDefaultAssoc then
+      if debugDefaultAssoc {
         writeln("*** In associative array standalone iterator");
+      }
       const numTasks = if dataParTasksPerLocale==0 then here.maxTaskPar
                        else dataParTasksPerLocale;
       const ignoreRunning = dataParIgnoreRunningTasks;
@@ -569,19 +575,22 @@ module DefaultAssociative {
                                           minIndicesPerTask, numIndices);
       if numChunks == 1 {
         for slot in 0..#numIndices {
-          if dom.table[slot].status == chpl__hash_status.full then
+          if dom.table[slot].status == chpl__hash_status.full {
             yield data[slot];
+          }
         }
       } else {
         coforall chunk in 0..#numChunks {
           const (lo, hi) = _computeBlock(numIndices, numChunks,
                                          chunk, numIndices-1);
-          if debugAssocDataPar then
+          if debugAssocDataPar {
             writeln("In associative array standalone iterator: chunk = ", chunk);
+          }
           var table = dom.table;
           for slot in lo..hi {
-            if dom.table[slot].status == chpl__hash_status.full then
+            if dom.table[slot].status == chpl__hash_status.full {
               yield data[slot];
+            }
           }
         }
       }

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -159,7 +159,6 @@ module DefaultAssociative {
       // We are simply slicing up the table here.  Trying to do something
       //  more intelligent (like evenly dividing up the full slots, led
       //  to poor speed ups.
-      // This requires that the zipppered domains match.
       const numIndices = tableSize;
       if debugAssocDataPar {
         writeln("### numTasks = ", numTasks);

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -302,8 +302,8 @@ module DefaultSparse {
                 numElems, " elems");
       }
       if numChunks <= 1 {
-        for i in 1..numElems {
-          yield data[i];
+        for e in data[1..numElems] {
+          yield e;
         }
       } else {
         coforall chunk in 1..numChunks {

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -68,9 +68,10 @@ module DefaultSparse {
     iter these(param tag: iterKind) where tag == iterKind.standalone {
       const numElems = nnz;
       const numChunks = _computeNumChunks(numElems): numElems.type;
-      if debugDefaultSparse then
+      if debugDefaultSparse {
         writeln("DefaultSparseDom standalone: ", numChunks, " chunks, ",
                 numElems, " elems");
+      }
 
       // split our numElems elements over numChunks tasks
       if numChunks <= 1 {
@@ -308,8 +309,9 @@ module DefaultSparse {
         coforall chunk in 1..numChunks {
           const (startIx, endIx) =
             _computeChunkStartEnd(numElems, numChunks, chunk);
-          for e in data[startIx..endIx] do
+          for e in data[startIx..endIx] {
             yield e;
+          }
         }
       }
     }

--- a/test/functions/iterators/diten/assocStandalone.chpl
+++ b/test/functions/iterators/diten/assocStandalone.chpl
@@ -1,0 +1,21 @@
+config const n = 1000;
+var D: domain(string);
+
+for i in 1..n do
+  if (i%3 == 0) || (i%7 == 0) then
+    D += i:string;
+
+var A: [D] int;
+
+writeln("first forall");
+forall i in D do
+  A[i] = i:int;
+
+writeln("second forall");
+forall a in A do
+  a += a;
+
+for i in 1..n do
+  if (i%3 == 0) || (i%7 == 0) then
+    if A[i:string] != 2*i then
+      writeln("incorrect value at position: ", i);

--- a/test/functions/iterators/diten/assocStandalone.compopts
+++ b/test/functions/iterators/diten/assocStandalone.compopts
@@ -1,0 +1,1 @@
+-sdebugDefaultAssoc

--- a/test/functions/iterators/diten/assocStandalone.good
+++ b/test/functions/iterators/diten/assocStandalone.good
@@ -1,0 +1,4 @@
+first forall
+*** In associative domain standalone iterator
+second forall
+*** In associative array standalone iterator

--- a/test/functions/iterators/diten/sparseStandalone.chpl
+++ b/test/functions/iterators/diten/sparseStandalone.chpl
@@ -1,0 +1,22 @@
+config const n = 1000;
+
+var D: sparse subdomain({1..n});
+
+for i in 1..n do
+  if (i%3 == 0) || (i%7 == 0) then
+    D += i;
+
+var A: [D] int;
+
+writeln("first forall");
+forall i in D do
+  A[i] = i;
+
+writeln("second forall");
+forall a in A do
+  a += a;
+
+for i in 1..n do
+  if (i%3 == 0) || (i%7 == 0) then
+    if A[i] != 2*i then
+      writeln("incorrect value at position: ", i);

--- a/test/functions/iterators/diten/sparseStandalone.compopts
+++ b/test/functions/iterators/diten/sparseStandalone.compopts
@@ -1,0 +1,1 @@
+-sdebugDefaultSparse

--- a/test/functions/iterators/diten/sparseStandalone.good
+++ b/test/functions/iterators/diten/sparseStandalone.good
@@ -1,0 +1,4 @@
+first forall
+DefaultSparseDom standalone: n chunks, 428 elems
+second forall
+DefaultSparseArr standalone: n chunks, 428 elems

--- a/test/functions/iterators/diten/sparseStandalone.prediff
+++ b/test/functions/iterators/diten/sparseStandalone.prediff
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+testname=$1
+outfile=$2
+
+tmpfile=$outfile.prediff.tmp
+mv $outfile $tmpfile
+sed 's/[0-9][0-9]* chunks/n chunks/g' $tmpfile > $outfile
+rm $tmpfile


### PR DESCRIPTION
Standalone parallel iterators for sparse and associative arrays and domains

Added standalone iterators for sparse and associative arrays and domains.
These iterators are basically copies of the leader iterators with the
follower iterators inlined at yield points.  Added tests for each that use
debug output to verify that the standalone iterators are called for forall
loops over the types.