### PR TITLE
Update nightly testing scripts to send to internal email lists.

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net";
+$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail@cray.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all@cray.com";
 $replymail = "chapel-developers\@lists.sourceforge.net";
 
 $printusage = 1;

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -20,8 +20,8 @@ use lib "$FindBin::Bin";
 use nightlysubs;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net";
+$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail@cray.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all@cray.com";
 $replymail = "chapel-developers\@lists.sourceforge.net";
 
 $valgrind = 0;

--- a/util/cron/start_opt_test
+++ b/util/cron/start_opt_test
@@ -20,8 +20,8 @@ use Cwd 'abs_path';
 use File::Basename;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net";
+$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail@cray.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all@cray.com";
 
 while (@ARGV) {
   $flag = shift @ARGV;

--- a/util/cron/test-darwin.bash
+++ b/util/cron/test-darwin.bash
@@ -5,6 +5,10 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 
+# Use relay SMTP server, since postfix does not reliably start when test
+# machine is rebooted.
+export CHPL_UTIL_SMTP_HOST=relaya
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin"
 
 $CWD/nightly -cron

--- a/util/cron/test-gasnet.darwin.bash
+++ b/util/cron/test-gasnet.darwin.bash
@@ -5,6 +5,10 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
 
+# Use relay SMTP server, since postfix does not reliably start when test
+# machine is rebooted.
+export CHPL_UTIL_SMTP_HOST=relaya
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin"
 
 $CWD/nightly -cron -examples

--- a/util/cron/test-gnu.darwin.bash
+++ b/util/cron/test-gnu.darwin.bash
@@ -5,6 +5,10 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 
+# Use relay SMTP server, since postfix does not reliably start when test
+# machine is rebooted.
+export CHPL_UTIL_SMTP_HOST=relaya
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gnu.darwin"
 
 export CHPL_HOST_COMPILER=gnu

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -4,8 +4,8 @@ use Cwd 'abs_path';
 use File::Basename;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net";
-$replymail = "chapel-developers\@lists.sourceforge.net";
+$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail@cray.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all@cray.com";
 
 $printusage = 0;
 if (@ARGV) {

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -5,7 +5,7 @@ use File::Basename;
 
 # Mailing lists.
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail@cray.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all@cray.com";
+$replymail = "chapel-developers\@lists.sourceforge.net";
 
 $printusage = 0;
 if (@ARGV) {


### PR DESCRIPTION
The external ones are dropping lots of messages...

Also, send darwin emails using relay smtp server. The last few
times chapelmac has rebooted, the postfix mail service has not
started. Just use the relay server directly instead of fiddling with
the postfix service.