### PR TITLE
Override environment setting to always munge user identifiers in anonymousRangeIterator test.

### DIFF
--- a/test/types/range/elliot/anonymousRangeIter.compopts
+++ b/test/types/range/elliot/anonymousRangeIter.compopts
@@ -1,1 +1,1 @@
---no-checks --savec genCode
+--no-checks --savec genCode --munge-user-idents


### PR DESCRIPTION
This test is sensitive to the setting of the --munge-user-idents flag.  Some developers
turn off munging in their environment to declutter source code for debugging purposes, but
then this test fails.  Adding the command-line argument cures this problem.