### PR TITLE
Correctly escape @ in new nightly email addresses.

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail@cray.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all@cray.com";
+$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
 $replymail = "chapel-developers\@lists.sourceforge.net";
 
 $printusage = 1;

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -20,8 +20,8 @@ use lib "$FindBin::Bin";
 use nightlysubs;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail@cray.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all@cray.com";
+$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
 $replymail = "chapel-developers\@lists.sourceforge.net";
 
 $valgrind = 0;

--- a/util/cron/start_opt_test
+++ b/util/cron/start_opt_test
@@ -20,8 +20,8 @@ use Cwd 'abs_path';
 use File::Basename;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail@cray.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all@cray.com";
+$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
 
 while (@ARGV) {
   $flag = shift @ARGV;

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -4,7 +4,7 @@ use Cwd 'abs_path';
 use File::Basename;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail@cray.com";
+$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
 $replymail = "chapel-developers\@lists.sourceforge.net";
 
 $printusage = 0;


### PR DESCRIPTION
In #1382 I added internal mailing lists to the nightly scripts. Unfortunately I
forgot to escape the @ sign, so perl interpreted it as a list (or whatever perl
does with @). Anyway, this should fix the issue.

This time, I "tested" nightly by overriding the send_email.py script to simply
print the email addresses it was supposed to send to. When I broke and
fixed hello.chpl, it had the correct @cray.com addresses.