### PR TITLE
Add safe_cast procedure for checked integral casts

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -81,6 +81,7 @@ VarSymbol *gTrue = NULL;
 VarSymbol *gFalse = NULL;
 VarSymbol *gTryToken = NULL;
 VarSymbol *gBoundsChecking = NULL;
+VarSymbol *gCastChecking = NULL;
 VarSymbol* gPrivatization = NULL;
 VarSymbol* gLocal = NULL;
 VarSymbol* gNodeID = NULL;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1581,40 +1581,36 @@ void initChplProgram(DefExpr* objectDef) {
   rootModule->block->insertAtTail(new DefExpr(theProgram));
 }
 
+// Appends a VarSymbol to the root module and gives it the bool immediate
+// matching 'value'. For use in initCompilerGlobals.
+static void setupBoolGlobal(VarSymbol* globalVar, bool value) {
+  rootModule->block->insertAtTail(new DefExpr(globalVar));
+  if (value) {
+    globalVar->immediate = new Immediate;
+    *globalVar->immediate = *gTrue->immediate;
+  } else {
+    globalVar->immediate = new Immediate;
+    *globalVar->immediate = *gFalse->immediate;
+  }
+}
+
 void initCompilerGlobals() {
 
   gBoundsChecking = new VarSymbol("boundsChecking", dtBool);
   gBoundsChecking->addFlag(FLAG_CONST);
-  rootModule->block->insertAtTail(new DefExpr(gBoundsChecking));
-  if (fNoBoundsChecks) {
-    gBoundsChecking->immediate = new Immediate;
-    *gBoundsChecking->immediate = *gFalse->immediate;
-  } else {
-    gBoundsChecking->immediate = new Immediate;
-    *gBoundsChecking->immediate = *gTrue->immediate;
-  }
+  setupBoolGlobal(gBoundsChecking, !fNoBoundsChecks);
+
+  gCastChecking = new VarSymbol("castChecking", dtBool);
+  gCastChecking->addFlag(FLAG_PARAM);
+  setupBoolGlobal(gCastChecking, !fNoCastChecks);
 
   gPrivatization = new VarSymbol("_privatization", dtBool);
   gPrivatization->addFlag(FLAG_PARAM);
-  rootModule->block->insertAtTail(new DefExpr(gPrivatization));
-  if (fNoPrivatization || fLocal) {
-    gPrivatization->immediate = new Immediate;
-    *gPrivatization->immediate = *gFalse->immediate;
-  } else {
-    gPrivatization->immediate = new Immediate;
-    *gPrivatization->immediate = *gTrue->immediate;
-  }
+  setupBoolGlobal(gPrivatization, !(fNoPrivatization || fLocal));
 
   gLocal = new VarSymbol("_local", dtBool);
   gLocal->addFlag(FLAG_PARAM);
-  rootModule->block->insertAtTail(new DefExpr(gLocal));
-  if (fLocal) {
-    gLocal->immediate = new Immediate;
-    *gLocal->immediate = *gTrue->immediate;
-  } else {
-    gLocal->immediate = new Immediate;
-    *gLocal->immediate = *gFalse->immediate;
-  }
+  setupBoolGlobal(gLocal, fLocal);
 
   // defined and maintained by the runtime
   gNodeID = new VarSymbol("chpl_nodeID", dtInt[INT_SIZE_32]);

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -45,6 +45,7 @@ extern bool fNoLiveAnalysis;
 extern bool fNoLocalChecks;
 extern bool fNoNilChecks;
 extern bool fNoStackChecks;
+extern bool fNoCastChecks;
 extern bool fMungeUserIdents;
 extern bool fEnableTaskTracking;
 extern bool fLLVMWideOpt;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -581,6 +581,7 @@ extern VarSymbol *gTrue;
 extern VarSymbol *gFalse;
 extern VarSymbol *gTryToken; // try token for conditional function resolution
 extern VarSymbol *gBoundsChecking;
+extern VarSymbol *gCastChecking;
 extern VarSymbol *gPrivatization;
 extern VarSymbol *gLocal;
 extern VarSymbol *gNodeID;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -117,6 +117,7 @@ bool fNoBoundsChecks = false;
 bool fNoLocalChecks = false;
 bool fNoNilChecks = false;
 bool fNoStackChecks = false;
+bool fNoCastChecks = false;
 bool fMungeUserIdents = true;
 bool fEnableTaskTracking = false;
 
@@ -550,6 +551,7 @@ static void turnOffChecks(const ArgumentState* state, const char* unused) {
   fNoBoundsChecks = true;
   fNoLocalChecks  = true;
   fNoStackChecks  = true;
+  fNoCastChecks = true;
 }
 
 static void handleStackCheck(const ArgumentState* state, const char* unused) {
@@ -588,6 +590,7 @@ static void setFastFlag(const ArgumentState* state, const char* unused) {
   fNoLocalChecks = true;
   fNoNilChecks = true;
   fNoStackChecks = true;
+  fNoCastChecks = true;
   fNoOptimizeOnClauses = false;
   optimizeCCode = true;
   specializeCCode = true;
@@ -721,6 +724,7 @@ static ArgumentDescription arg_desc[] = {
  {"local-checks", ' ', NULL, "Enable [disable] local block checking", "n", &fNoLocalChecks, NULL, NULL},
  {"nil-checks", ' ', NULL, "Enable [disable] nil checking", "n", &fNoNilChecks, "CHPL_NO_NIL_CHECKS", NULL},
  {"stack-checks", ' ', NULL, "Enable [disable] stack overflow checking", "n", &fNoStackChecks, "CHPL_STACK_CHECKS", handleStackCheck},
+ {"cast-checks", ' ', NULL, "Enable [disable] checks in safe_cast calls", "n", &fNoCastChecks, NULL, NULL},
 
  {"", ' ', NULL, "C Code Generation Options", NULL, NULL, NULL, NULL},
  {"codegen", ' ', NULL, "[Don't] Do code generation", "n", &no_codegen, "CHPL_NO_CODEGEN", NULL},

--- a/man/chpl.txt
+++ b/man/chpl.txt
@@ -198,6 +198,9 @@ OPTIONS
   --[no-]stack-checks   Enable [disable] run-time checking for stack
                     overflow.
 
+  --[no-]cast-checks   Enable [disable] run-time checks in safe_cast calls for
+                    casts that wouldn't preserve the logical value being cast.
+
   C Code Generation Options
 
   --[no-]codegen     Enable [disable] generating C code and the binary

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -450,6 +450,61 @@ proc numBits(type t: enumerated) param {
   return numBits(enum_mintype(t));
 }
 
+//
+// safe up/down casts between all integral types
+// performs the minimum number of runtime checks - uint(8)->uint(64) won't
+// perform any checks for example
+//
+inline proc safe_cast(type T, val: integral) : T where isUintType(T) {
+  if castChecking {
+    if isIntType(val.type) {
+      // int(?) -> uint(?)
+      if val < 0 then // runtime check
+        halt("casting "+typeToString(val.type)+" less than 0 to "+typeToString(T));
+    }
+
+    if max(val.type):uint > max(T):uint {
+      // [u]int(?) -> uint(?)
+      if (val:uint > max(T):uint) then // runtime check
+        halt("casting "+typeToString(val.type)+" with a value greater than the maximum of "+
+             typeToString(T)+" to "+typeToString(T));
+    }
+  }
+  return val:T;
+}
+
+inline proc safe_cast(type T, val: integral) : T where isIntType(T) {
+  if castChecking {
+    if max(val.type):uint > max(T):uint {
+      // this isUintType check lets us avoid a runtime check for val < 0
+      if isUintType(val.type) {
+        // uint(?) -> int(?)
+        if val:uint > max(T):uint then // runtime check
+          halt("casting "+typeToString(val.type)+" with a value greater than the maximum of "+
+               typeToString(T)+" to "+typeToString(T));
+      } else {
+        // int(?) -> int(?)
+        // max(T) <= max(int), so cast to int is safe
+        if val:int > max(T):int then // runtime check
+          halt("casting "+typeToString(val.type)+" with a value greater than the maximum of "+
+               typeToString(T)+" to "+typeToString(T));
+      }
+    }
+    if isIntType(val.type) {
+      if min(val.type):int < min(T):int {
+        // int(?) -> int(?)
+        if val:int < min(T):int then // runtime check
+          halt("casting "+typeToString(val.type)+" with a value less than the minimum of "+
+               typeToString(T)+" to "+typeToString(T));
+      }
+    }
+  }
+  return val:T;
+}
+
+proc safe_cast(type T, val) {
+  compilerError("safe_cast is only supported between integrals");
+}
 
 //
 // identity functions (for reductions)

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -58,6 +58,8 @@ Run-time Semantic Check Options:
       --[no-]local-checks             Enable [disable] local block checking
       --[no-]nil-checks               Enable [disable] nil checking
       --[no-]stack-checks             Enable [disable] stack overflow checking
+      --[no-]cast-checks              Enable [disable] checks in safe_cast
+                                      calls
 
 C Code Generation Options:
       --[no-]codegen                  [Don't] Do code generation

--- a/test/types/scalar/kbrady/SKIPIF
+++ b/test/types/scalar/kbrady/SKIPIF
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast

--- a/test/types/scalar/kbrady/int_int16.chpl
+++ b/test/types/scalar/kbrady/int_int16.chpl
@@ -1,0 +1,3 @@
+writeln(safe_cast(int(16), -1:int(64)));
+writeln(safe_cast(int(16), 1:int(64)));
+writeln(safe_cast(int(16), min(int(64))));

--- a/test/types/scalar/kbrady/int_int16.good
+++ b/test/types/scalar/kbrady/int_int16.good
@@ -1,0 +1,3 @@
+-1
+1
+int_int16.chpl:3: error: halt reached - casting int(64) with a value less than the minimum of int(16) to int(16)

--- a/test/types/scalar/kbrady/int_uint.chpl
+++ b/test/types/scalar/kbrady/int_uint.chpl
@@ -1,0 +1,6 @@
+writeln(safe_cast(uint, 0));
+writeln(safe_cast(uint, max(int(8))));
+writeln(safe_cast(uint, max(int(16))));
+writeln(safe_cast(uint, max(int(32))));
+writeln(safe_cast(uint, max(int(64))));
+writeln(safe_cast(uint, -1));

--- a/test/types/scalar/kbrady/int_uint.good
+++ b/test/types/scalar/kbrady/int_uint.good
@@ -1,0 +1,6 @@
+0
+127
+32767
+2147483647
+9223372036854775807
+int_uint.chpl:6: error: halt reached - casting int(64) less than 0 to uint(64)

--- a/test/types/scalar/kbrady/uint_int.chpl
+++ b/test/types/scalar/kbrady/uint_int.chpl
@@ -1,0 +1,7 @@
+writeln(safe_cast(int, min(uint(64))));
+
+writeln(safe_cast(int, max(uint(8))));
+writeln(safe_cast(int, max(uint(16))));
+writeln(safe_cast(int, max(uint(32))));
+writeln(safe_cast(int, max(int):uint));
+writeln(safe_cast(int, max(uint(64))));

--- a/test/types/scalar/kbrady/uint_int.good
+++ b/test/types/scalar/kbrady/uint_int.good
@@ -1,0 +1,6 @@
+0
+255
+65535
+4294967295
+9223372036854775807
+uint_int.chpl:7: error: halt reached - casting uint(64) with a value greater than the maximum of int(64) to int(64)

--- a/test/types/scalar/kbrady/uint_uint16.chpl
+++ b/test/types/scalar/kbrady/uint_uint16.chpl
@@ -1,0 +1,3 @@
+writeln(safe_cast(uint(16), min(uint(64))));
+writeln(safe_cast(uint(16), 1:uint(64)));
+writeln(safe_cast(uint(16), max(uint(64))));

--- a/test/types/scalar/kbrady/uint_uint16.good
+++ b/test/types/scalar/kbrady/uint_uint16.good
@@ -1,0 +1,3 @@
+0
+1
+uint_uint16.chpl:3: error: halt reached - casting uint(64) with a value greater than the maximum of uint(16) to uint(16)


### PR DESCRIPTION
Adds `safe_cast(type T, val)` between all integral types, halting when a cast would not be able to store the logical value in the new type. Param conditionals are used to perform the minimum number of runtime checks.

Adds a new flag: `--[no-]cast-checks` to enable or disable these runtime checks. `--fast` turns the checks off as well.

I originally wrote this for use in the new string implementation for casts from `int(64)` to `size_t` (which is `uint(32)` or `uint(64)` depending on the platform) for use with extern routines. I think extern routines will be a common place to use `safe_cast` to ensure cross-platform compatibility going forwards.