### PR TITLE
Bug fixes, cleanup, and some experimental features for multi-config graphs

### DIFF
--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -1001,9 +1001,9 @@ def main():
                     graphList.append((l, [currSuite]))
             else:
                 # parse for suite name
-                ls = l[1:].split(':')
+                ls = l[1:].split(': ')
                 if ls[0].strip() == 'suite':
-                    currSuite = ls[1].strip()
+                    currSuite = ls[1].rstrip()
                     graphInfo.suites.append(currSuite)
                     numSuites += 1
                     if verbose:

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -635,28 +635,44 @@ function setupGraphSelectionPane() {
   });
 
   $(window).ready(function(){
-    // we don't know the width of the graph selection pane until the graphs are
-    // added ot the graphlist. Once that is done figure out where to position
-    // the graph display. This is needed since the graph selection pane is
-    // 'fixed' meaning it's outside the normal flow and other elements act like
-    // it doesn't exist so we have to manualy move the graph display to avoid
-    // overlap. This doesn't change after page load.
-    var selectPaneWidth = parseInt($("#graphSelectionPane").outerWidth());
-    $('#graphdisplay').css({ 'margin-left': selectPaneWidth });
-
+    setDygraphPanePos();
     setGraphListHeight();
     setGraphSelectionPanePos();
   });
 
   $(window).resize(function(){
+    setDygraphPanePos();
     setGraphListHeight();
     setGraphSelectionPanePos();
   });
 
-  // set the selection panes horizontal positional based on the scroll so the
-  // selection pane isn't always visible when scrolling horizontally
+  // We don't know the width of the graph selection pane until the list of
+  // graph names are added. Once that is done figure out the position of pane
+  // that holds the dygraphs. This is needed since the graph selection pane
+  // is 'fixed' meaning it's outside the normal flow and other elements act
+  // like it doesn't exist so we have to manually move the graph display to
+  // avoid overlap. After the page is setup, the graph selection pane size
+  // only changes if the browser zoom changes.
+  function setDygraphPanePos() {
+    var selectPaneWidth = parseInt($("#graphSelectionPane").outerWidth());
+    $('#graphdisplay').css({ 'margin-left': selectPaneWidth });
+  }
+
+  // set the selection pane's horizontal positional based on the scroll so the
+  // selection pane isn't always visible when scrolling horizontally. Some
+  // browsers allow scrolling past the edge of the screen so we limit the
+  // scroll amount to prevent weird overlaps.
   function setGraphSelectionPanePos() {
-    $('#graphSelectionPane').css({ 'left': -$(window).scrollLeft() });
+    // number of pixels hidden from view to the left visible window
+    var scrollLeft = $(window).scrollLeft();
+    // number of pixels hidden from view ('true' page size - visible amount)
+    var numHiddenPixels = $(document).width() - $(window).width();
+
+    scrollLeft = Math.max(0, scrollLeft);
+    scrollLeft = Math.min(numHiddenPixels, scrollLeft);
+
+    // move pane the opposite of scrolling so it moves out of view
+    $('#graphSelectionPane').css({ 'left': -scrollLeft });
   }
 
   // determine the height to use for the graphlist. We want it to use most of

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -602,8 +602,13 @@ function perfGraphInit() {
   fselect.appendChild(o);
   for (var i = 0; i < perfSuites.length; i++) {
     var o = document.createElement('option');
-    o.innerHTML = perfSuites[i].suite;
-    o.setAttribute('value', perfSuites[i].suite);
+    var suiteName = perfSuites[i].suite;
+    if (suiteName.trim() === '<empty>') {
+      suiteName = '';
+      o.disabled = true;
+    }
+    o.innerHTML = suiteName.replace(/ /g, '&nbsp');
+    o.setAttribute('value', suiteName);
     fselect.appendChild(o);
   }
   suiteMenu.appendChild(f);
@@ -986,6 +991,9 @@ function findSelectedSuite() {
       graphsInSuite[curGraph.suites[suiteIndex]] += allGraphs[i].title;
     }
   }
+
+  // if no graphs were selected, return no suite sentinel
+  if (displayedGraphs.length === 0) { return NO_SUITE; }
 
   // see if the currently selected representation  matches any of the suites
   for (var suite in graphsInSuite) {

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -259,7 +259,7 @@ function expandGraphs(graph, graphInfo, graphDivs, graphData, graphLabels) {
       if (confIndex >= 0) {
         newLabels.push(graphLabels[confIndex]);
         newData = newData.concat(transposedData.slice(confIndex, confIndex+1));
-        newColors.push(graph.getPropertiesForSeries(graphLabels[i]).color);
+        newColors.push(graph.getPropertiesForSeries(graphLabels[confIndex]).color);
       } else {
         console.log('Warning: expected to find label "' + confLabel + '" for ' +
                     'graph "' + graphInfo.title + '" but it was missing');


### PR DESCRIPTION
This is to make multi-config graphs faster and more usable. Currently it's
really hard to differentiate the lines when we have 3 or more configs being
graphed. This speeds them up, fixes some bugs, and adds some features to play
with to see if they make it easier to differentiate lines on graphs with a lot
of configurations.

There's a high level summary of each commit below with a lot of details in the
individual commit messages themselves. It's probably not worth reading the
summary below, and especially not worth reading the commit messages unless
you're trying to find the history of some graph change.

High level summary:

 - Faster multi-config graphs (was really slow to toggle configs on/off. Much
   faster now, though still a little slow from code in dygraphs, not our js.)

 - Add helper routines to apply updates to all graphs (makes it easy to block
   graph redraws, which is why the mutli-config was as slow as it was.)

 - Bug fix for multi-config graphs with graph expansion (comp perf graphs only)

 - Update annotations to work with multi-config graphs (annotations have to be
   attached to a specific series. We pick one randomly, but if we hide that
   series when we hide a config, we now pick a new series that is visible and
   re-attach the annotations to that.)

 - Make the graph selection pane better with scrolling and zooming (the pane
   where you select the graphs/suites to display didn't resize on zoom.)

 - Add support for 'empty' suites and spaces before suite names (useful for
   making logical groups more visible in suite dropdown menu. Will be used for
   multi-locale performance graphs.)

 - Bug fix with storing graphs in URL when they contained a comma

 - Add two experimental features for multi-config graphs with >=3 configs:

   - Reset stroke pattern button: Set stroke patterns based on visible configs
     only, not all configs (should be most useful for xc single locale perf)

   - Invert stroke pattern and color choice for configs. By default we use the
     same colors for a config, and differentiate the configs with the stroke
     pattern. This makes the graphs hard to follow for 3 or more configs, so
     this allows you to use colors instead (should be useful for xc
     multi-locale perf testing.)
