### PR TITLE
Update AstToText to support outputing secondary methods in developer mode.

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -59,10 +59,7 @@ void AstToText::appendNameAndFormals(FnSymbol* fn)
 
 void AstToText::appendName(FnSymbol* fn)
 {
-  if (developer == true)
-    mText += fn->name;
-
-  else if (fn->hasFlag(FLAG_MODULE_INIT))
+  if (fn->hasFlag(FLAG_MODULE_INIT))
   {
     INT_ASSERT(strncmp(fn->name, "chpl__init_",      11) == 0);
 

--- a/test/chpldoc/classes/methodOutsideClassDef.chpl
+++ b/test/chpldoc/classes/methodOutsideClassDef.chpl
@@ -16,3 +16,12 @@ proc Foo.externalMeth1() {
 proc Foo.externalMeth2() {
 
 }
+
+/* Declares one primary and one secondary method... */
+record Bar {
+  /* A primary method declaration. */
+  proc internal() {}
+}
+
+/* A secondary method declaration. */
+proc Bar.external() {}


### PR DESCRIPTION
Remove developer==true branch from AstToText::appendName(). It is not clear to
Mike, Lydia, or I why it is needed, and removing it fixes the chpldoc issue where
secondary methods are missing their class names in the documentation (only in
developer mode).

Worked with @noakesmichael and @lydia-duncan  on change. Ran make check to
confirm nothing was fundamentally broken.