### PR TITLE
[WIP] Update mem tracking to use uint instead of c_ulong.

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -78,6 +78,7 @@ VarSymbol *gTrue = NULL;
 VarSymbol *gFalse = NULL;
 VarSymbol *gTryToken = NULL;
 VarSymbol *gBoundsChecking = NULL;
+VarSymbol *gCastChecking = NULL;
 VarSymbol* gPrivatization = NULL;
 VarSymbol* gLocal = NULL;
 VarSymbol* gNodeID = NULL;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1492,40 +1492,34 @@ void initChplProgram(DefExpr* objectDef) {
   rootModule->block->insertAtTail(new DefExpr(theProgram));
 }
 
+static void setupBoolGlobal(VarSymbol* globalVar, bool value) {
+  rootModule->block->insertAtTail(new DefExpr(globalVar));
+  if (value) {
+    globalVar->immediate = new Immediate;
+    *globalVar->immediate = *gTrue->immediate;
+  } else {
+    globalVar->immediate = new Immediate;
+    *globalVar->immediate = *gFalse->immediate;
+  }
+}
+
 void initCompilerGlobals() {
 
   gBoundsChecking = new VarSymbol("boundsChecking", dtBool);
   gBoundsChecking->addFlag(FLAG_CONST);
-  rootModule->block->insertAtTail(new DefExpr(gBoundsChecking));
-  if (fNoBoundsChecks) {
-    gBoundsChecking->immediate = new Immediate;
-    *gBoundsChecking->immediate = *gFalse->immediate;
-  } else {
-    gBoundsChecking->immediate = new Immediate;
-    *gBoundsChecking->immediate = *gTrue->immediate;
-  }
+  setupBoolGlobal(gBoundsChecking, !fNoBoundsChecks);
+
+  gCastChecking = new VarSymbol("castChecking", dtBool);
+  gCastChecking->addFlag(FLAG_PARAM);
+  setupBoolGlobal(gCastChecking, !fNoCastChecks);
 
   gPrivatization = new VarSymbol("_privatization", dtBool);
   gPrivatization->addFlag(FLAG_PARAM);
-  rootModule->block->insertAtTail(new DefExpr(gPrivatization));
-  if (fNoPrivatization || fLocal) {
-    gPrivatization->immediate = new Immediate;
-    *gPrivatization->immediate = *gFalse->immediate;
-  } else {
-    gPrivatization->immediate = new Immediate;
-    *gPrivatization->immediate = *gTrue->immediate;
-  }
+  setupBoolGlobal(gPrivatization, !(fNoPrivatization || fLocal));
 
   gLocal = new VarSymbol("_local", dtBool);
   gLocal->addFlag(FLAG_PARAM);
-  rootModule->block->insertAtTail(new DefExpr(gLocal));
-  if (fLocal) {
-    gLocal->immediate = new Immediate;
-    *gLocal->immediate = *gTrue->immediate;
-  } else {
-    gLocal->immediate = new Immediate;
-    *gLocal->immediate = *gFalse->immediate;
-  }
+  setupBoolGlobal(gLocal, fLocal);
 
   // defined and maintained by the runtime
   gNodeID = new VarSymbol("chpl_nodeID", dtInt[INT_SIZE_32]);

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -45,6 +45,7 @@ extern bool fNoLiveAnalysis;
 extern bool fNoLocalChecks;
 extern bool fNoNilChecks;
 extern bool fNoStackChecks;
+extern bool fNoCastChecks;
 extern bool fMungeUserIdents;
 extern bool fEnableTaskTracking;
 extern bool fLLVMWideOpt;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -557,6 +557,7 @@ extern VarSymbol *gTrue;
 extern VarSymbol *gFalse;
 extern VarSymbol *gTryToken; // try token for conditional function resolution
 extern VarSymbol *gBoundsChecking;
+extern VarSymbol *gCastChecking;
 extern VarSymbol *gPrivatization;
 extern VarSymbol *gLocal;
 extern VarSymbol *gNodeID;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -117,6 +117,7 @@ bool fNoBoundsChecks = false;
 bool fNoLocalChecks = false;
 bool fNoNilChecks = false;
 bool fNoStackChecks = false;
+bool fNoCastChecks = false;
 bool fMungeUserIdents = true;
 bool fEnableTaskTracking = false;
 
@@ -550,6 +551,7 @@ static void turnOffChecks(const ArgumentState* state, const char* unused) {
   fNoBoundsChecks = true;
   fNoLocalChecks  = true;
   fNoStackChecks  = true;
+  fNoCastChecks = true;
 }
 
 static void handleStackCheck(const ArgumentState* state, const char* unused) {
@@ -588,6 +590,7 @@ static void setFastFlag(const ArgumentState* state, const char* unused) {
   fNoLocalChecks = true;
   fNoNilChecks = true;
   fNoStackChecks = true;
+  fNoCastChecks = true;
   fNoOptimizeOnClauses = false;
   optimizeCCode = true;
   specializeCCode = true;
@@ -721,6 +724,7 @@ static ArgumentDescription arg_desc[] = {
  {"local-checks", ' ', NULL, "Enable [disable] local block checking", "n", &fNoLocalChecks, NULL, NULL},
  {"nil-checks", ' ', NULL, "Enable [disable] nil checking", "n", &fNoNilChecks, "CHPL_NO_NIL_CHECKS", NULL},
  {"stack-checks", ' ', NULL, "Enable [disable] stack overflow checking", "n", &fNoStackChecks, "CHPL_STACK_CHECKS", handleStackCheck},
+ {"cast-checks", ' ', NULL, "Enable [disable] safe cast checking", "n", &fNoCastChecks, NULL, NULL},
 
  {"", ' ', NULL, "C Code Generation Options", NULL, NULL, NULL, NULL},
  {"codegen", ' ', NULL, "[Don't] Do code generation", "n", &no_codegen, "CHPL_NO_CODEGEN", NULL},

--- a/man/chpl.txt
+++ b/man/chpl.txt
@@ -198,6 +198,9 @@ OPTIONS
   --[no-]stack-checks   Enable [disable] run-time checking for stack
                     overflow.
 
+  --[no-]cast-checks   Enable [disable] run-time checking for invalid
+                    casts between types.
+
   C Code Generation Options
 
   --[no-]codegen     Enable [disable] generating C code and the binary

--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -26,13 +26,17 @@ module MemTracking
     memStats: bool = false,
     memLeaks: bool = false,
     memLeaksTable: bool = false,
-    memMax: size_t = 0,
-    memThreshold: size_t = 0,
+    memMax: uint = 0,
+    memThreshold: uint = 0,
     memLog: c_string = "";
 
   pragma "no auto destroy"
   config const
     memLeaksLog: c_string = "";
+
+  // Safely cast to size_t instances of memMax and memThreshold.
+  const cMemMax = safe_cast(size_t, memMax),
+    cMemThreshold = safe_cast(size_t, memThreshold);
 
   // Globally accessible copy of the corresponding c_string consts
   use NewString;
@@ -64,8 +68,8 @@ module MemTracking
     ret_memStats = memStats;
     ret_memLeaks = memLeaks;
     ret_memLeaksTable = memLeaksTable;
-    ret_memMax = memMax;
-    ret_memThreshold = memThreshold;
+    ret_memMax = cMemMax;
+    ret_memThreshold = cMemThreshold;
 
     if (here.id != 0) {
       // These c_strings are going to be leaked

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -305,8 +305,8 @@ module GMP {
     var mpz:mpz_t;
 
     // initializing integers (constructors)
-    proc BigInt(init2:bool, nbits:c_ulong) {
-      mpz_init2(this.mpz, nbits);
+    proc BigInt(init2:bool, nbits:uint) {
+      mpz_init2(this.mpz, safe_cast(c_ulong, nbits));
     }
     proc BigInt(num:c_long) {
       mpz_init_set_si(this.mpz, num);
@@ -417,11 +417,11 @@ module GMP {
         }
       }
     }
-    proc get_ui():c_ulong
+    proc get_ui():uint
     {
       var x:c_ulong;
       on this do x = mpz_get_ui(this.mpz);
-      return x;
+      return safe_cast(uint, x);
     }
     proc get_si():c_long
     {
@@ -520,11 +520,11 @@ module GMP {
         if acopy then delete a_;
       }
     }
-    proc mul_ui(a:BigInt, b:c_ulong)
+    proc mul_ui(a:BigInt, b:uint)
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_mul_ui(this.mpz, a_.mpz, b);
+        mpz_mul_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
         if acopy then delete a_;
       }
     }
@@ -556,11 +556,11 @@ module GMP {
         if bcopy then delete b_;
       }
     }
-    proc submul_ui(a:BigInt, b:c_ulong)
+    proc submul_ui(a:BigInt, b:uint)
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_submul_ui(this.mpz, a_.mpz, b);
+        mpz_submul_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
         if acopy then delete a_;
       }
     }

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -305,8 +305,8 @@ module GMP {
     var mpz:mpz_t;
 
     // initializing integers (constructors)
-    proc BigInt(init2:bool, nbits:uint) {
-      mpz_init2(this.mpz, safe_cast(c_ulong, nbits));
+    proc BigInt(init2:bool, nbits:c_ulong) {
+      mpz_init2(this.mpz, nbits);
     }
     proc BigInt(num:c_long) {
       mpz_init_set_si(this.mpz, num);
@@ -417,11 +417,11 @@ module GMP {
         }
       }
     }
-    proc get_ui():uint
+    proc get_ui():c_ulong
     {
       var x:c_ulong;
       on this do x = mpz_get_ui(this.mpz);
-      return safe_cast(uint, x);
+      return x;
     }
     proc get_si():c_long
     {
@@ -520,11 +520,11 @@ module GMP {
         if acopy then delete a_;
       }
     }
-    proc mul_ui(a:BigInt, b:uint)
+    proc mul_ui(a:BigInt, b:c_ulong)
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_mul_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_mul_ui(this.mpz, a_.mpz, b);
         if acopy then delete a_;
       }
     }
@@ -556,11 +556,11 @@ module GMP {
         if bcopy then delete b_;
       }
     }
-    proc submul_ui(a:BigInt, b:uint)
+    proc submul_ui(a:BigInt, b:c_ulong)
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_submul_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_submul_ui(this.mpz, a_.mpz, b);
         if acopy then delete a_;
       }
     }

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -492,6 +492,7 @@ inline proc safe_cast(type T, val) : T where isIntType(T) && isIntegralType(val.
   return val:T;
 }
 
+
 //
 // identity functions (for reductions)
 //

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -492,7 +492,6 @@ inline proc safe_cast(type T, val) : T where isIntType(T) && isIntegralType(val.
   return val:T;
 }
 
-
 //
 // identity functions (for reductions)
 //

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -58,6 +58,7 @@ Run-time Semantic Check Options:
       --[no-]local-checks             Enable [disable] local block checking
       --[no-]nil-checks               Enable [disable] nil checking
       --[no-]stack-checks             Enable [disable] stack overflow checking
+      --[no-]cast-checks              Enable [disable] safe cast checking
 
 C Code Generation Options:
       --[no-]codegen                  [Don't] Do code generation

--- a/test/execflags/thomasvandoren/exceedMemInts.chpl
+++ b/test/execflags/thomasvandoren/exceedMemInts.chpl
@@ -1,0 +1,3 @@
+writeln(max(uint(64)));
+writeln("memMax = ", MemTracking.memMax);
+writeln("memThreshold = ", MemTracking.memThreshold);

--- a/test/execflags/thomasvandoren/exceedMemInts.execopts
+++ b/test/execflags/thomasvandoren/exceedMemInts.execopts
@@ -1,4 +1,4 @@
 # Try to set memMax, then memThreshold to max(uint64). This only runs on 32-bit
-# platforms, so this will not be a valid values.
+# platforms, so this will not be a valid value.
 --memMax 18446744073709551615
 --memThreshold 18446744073709551615

--- a/test/execflags/thomasvandoren/exceedMemInts.execopts
+++ b/test/execflags/thomasvandoren/exceedMemInts.execopts
@@ -1,0 +1,4 @@
+# Try to set memMax, then memThreshold to max(uint64). This only runs on 32-bit
+# platforms, so this will not be a valid values.
+--memMax 18446744073709551615
+--memThreshold 18446744073709551615

--- a/test/execflags/thomasvandoren/exceedMemInts.good
+++ b/test/execflags/thomasvandoren/exceedMemInts.good
@@ -1,0 +1,1 @@
+<internal>: error: halt reached - casting uint(64) > max(uint(32)) to uint(32)

--- a/test/execflags/thomasvandoren/exceedMemInts.skipif
+++ b/test/execflags/thomasvandoren/exceedMemInts.skipif
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+"""Only run this test on 32-bit platforms."""
+
+import os
+print(not os.environ.get('CHPL_TARGET_PLATFORM').endswith('32'))

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
@@ -56,8 +56,8 @@ iter genDigits(numDigits) {
   }
 
   // Helper function to extract the nth digit.
-  proc extractDigit(nth: uint) {
-    tmp1.mul_ui(numer, safe_cast(c_ulong, nth));
+  proc extractDigit(nth: c_ulong) {
+    tmp1.mul_ui(numer, nth);
     tmp2.add(tmp1, accum);
     tmp1.div_q(Round.ZERO, tmp2, denom);
 

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
@@ -56,8 +56,8 @@ iter genDigits(numDigits) {
   }
 
   // Helper function to extract the nth digit.
-  proc extractDigit(nth: c_ulong) {
-    tmp1.mul_ui(numer, nth);
+  proc extractDigit(nth: uint) {
+    tmp1.mul_ui(numer, safe_cast(c_ulong, nth));
     tmp2.add(tmp1, accum);
     tmp1.div_q(Round.ZERO, tmp2, denom);
 

--- a/test/types/scalar/kbrady/int_int16.chpl
+++ b/test/types/scalar/kbrady/int_int16.chpl
@@ -1,0 +1,3 @@
+writeln(safe_cast(int(16), -1:int(64)));
+writeln(safe_cast(int(16), 1:int(64)));
+writeln(safe_cast(int(16), min(int(64))));

--- a/test/types/scalar/kbrady/int_int16.good
+++ b/test/types/scalar/kbrady/int_int16.good
@@ -1,0 +1,3 @@
+-1
+1
+int_int16.chpl:3: error: halt reached - casting int(64) < min(int(16)) to int(16)

--- a/test/types/scalar/kbrady/int_uint.chpl
+++ b/test/types/scalar/kbrady/int_uint.chpl
@@ -1,0 +1,6 @@
+writeln(safe_cast(uint, 0));
+writeln(safe_cast(uint, max(int(8))));
+writeln(safe_cast(uint, max(int(16))));
+writeln(safe_cast(uint, max(int(32))));
+writeln(safe_cast(uint, max(int(64))));
+writeln(safe_cast(uint, -1));

--- a/test/types/scalar/kbrady/int_uint.good
+++ b/test/types/scalar/kbrady/int_uint.good
@@ -1,0 +1,6 @@
+0
+127
+32767
+2147483647
+9223372036854775807
+int_uint.chpl:6: error: halt reached - casting int(64) < 0 to uint(64)

--- a/test/types/scalar/kbrady/uint_int.chpl
+++ b/test/types/scalar/kbrady/uint_int.chpl
@@ -1,0 +1,7 @@
+writeln(safe_cast(int, min(uint(64))));
+
+writeln(safe_cast(int, max(uint(8))));
+writeln(safe_cast(int, max(uint(16))));
+writeln(safe_cast(int, max(uint(32))));
+writeln(safe_cast(int, max(int):uint));
+writeln(safe_cast(int, max(uint(64))));

--- a/test/types/scalar/kbrady/uint_int.good
+++ b/test/types/scalar/kbrady/uint_int.good
@@ -1,0 +1,6 @@
+0
+255
+65535
+4294967295
+9223372036854775807
+uint_int.chpl:7: error: halt reached - casting uint(64) > max(int(64)) to int(64)

--- a/test/types/scalar/kbrady/uint_uint16.chpl
+++ b/test/types/scalar/kbrady/uint_uint16.chpl
@@ -1,0 +1,3 @@
+writeln(safe_cast(uint(16), min(uint(64))));
+writeln(safe_cast(uint(16), 1:uint(64)));
+writeln(safe_cast(uint(16), max(uint(64))));

--- a/test/types/scalar/kbrady/uint_uint16.good
+++ b/test/types/scalar/kbrady/uint_uint16.good
@@ -1,0 +1,3 @@
+0
+1
+uint_uint16.chpl:3: error: halt reached - casting uint(64) > max(uint(16)) to uint(16)


### PR DESCRIPTION
Update memMax and memThreshold config consts in MemTracking module
to be type uint (instead of size_t). Later, create new cMemMax and cMemThreshold
that come from calling safe_cast on the config consts. This makes the help document
portable across 32- and 64-bit platforms (fixing several *32 regressions), and will
now report errors when these values exceed the max of size_t.