### PR TITLE
Change sparse iterators to avoid use of slicing for performance benefits

### DIFF
--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -289,7 +289,7 @@ module DefaultSparse {
     }
 
     iter these() ref {
-      for e in data[1..dom.nnz] do yield e;
+      for i in 1..dom.nnz do yield data[i];
     }
 
     iter these(param tag: iterKind) ref where tag == iterKind.standalone {
@@ -300,15 +300,15 @@ module DefaultSparse {
                 numElems, " elems");
       }
       if numChunks <= 1 {
-        for e in data[1..numElems] {
-          yield e;
+        for i in 1..numElems {
+          yield data[i];
         }
       } else {
         coforall chunk in 1..numChunks {
           const (startIx, endIx) =
             _computeChunkStartEnd(numElems, numChunks, chunk);
-          for e in data[startIx..endIx] {
-            yield e;
+          for i in startIx..endIx {
+            yield data[i];
           }
         }
       }
@@ -330,7 +330,7 @@ module DefaultSparse {
       if debugDefaultSparse then
         writeln("DefaultSparseArr follower: ", startIx, "..", endIx);
 
-      for e in data[startIx..endIx] do yield e;
+      for i in startIx..endIx do yield data[i];
     }
 
     iter these(param tag: iterKind, followThis) where tag == iterKind.follower {

--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -305,8 +305,8 @@ class CSRDom: BaseSparseDom {
     if (d != 2) {
       compilerError("dimIter(1, ...) not supported on CSR domains");
     }
-    for c in colIdx[rowStart(ind)..rowStop(ind)] do
-      yield c;
+    for i in rowStart[ind]..rowStop[ind] do
+      yield colIdx[i];
   }
 }
 
@@ -340,7 +340,7 @@ class CSRArr: BaseArr {
   }
 
   iter these() ref {
-    for e in data[1..dom.nnz] do yield e;
+    for i in 1..dom.nnz do yield data[i];
   }
 
   iter these(param tag: iterKind) where tag == iterKind.leader {
@@ -360,7 +360,7 @@ class CSRArr: BaseArr {
     if debugCSR then
       writeln("CSRArr follower: ", startIx, "..", endIx);
 
-    for e in data[startIx..endIx] do yield e;
+    for i in startIx..endIx do yield data[i];
   }
 
   iter these(param tag: iterKind, followThis) where tag == iterKind.follower {


### PR DESCRIPTION
In reviewing David's standalone parallel iteration changes yesterday, I noticed
that we're using array slicing in our iterators over sparse domains and arrays
unnecessarily.  Given that slicing is not particularly cheap and that array
accesses have gotten so much better with LICM and other recent changes, it
seemed smart to rewrite these to loop over ranges and index into arrays.
