### PR TITLE
Update mem tracking to use uint instead of c_ulong.

### DIFF
--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -26,13 +26,17 @@ module MemTracking
     memStats: bool = false,
     memLeaks: bool = false,
     memLeaksTable: bool = false,
-    memMax: size_t = 0,
-    memThreshold: size_t = 0,
+    memMax: uint = 0,
+    memThreshold: uint = 0,
     memLog: c_string = "";
 
   pragma "no auto destroy"
   config const
     memLeaksLog: c_string = "";
+
+  // Safely cast to size_t instances of memMax and memThreshold.
+  const cMemMax = safe_cast(size_t, memMax),
+    cMemThreshold = safe_cast(size_t, memThreshold);
 
   // Globally accessible copy of the corresponding c_string consts
   use NewString;
@@ -64,8 +68,8 @@ module MemTracking
     ret_memStats = memStats;
     ret_memLeaks = memLeaks;
     ret_memLeaksTable = memLeaksTable;
-    ret_memMax = memMax;
-    ret_memThreshold = memThreshold;
+    ret_memMax = cMemMax;
+    ret_memThreshold = cMemThreshold;
 
     if (here.id != 0) {
       // These c_strings are going to be leaked

--- a/test/execflags/thomasvandoren/exceedMemInts.chpl
+++ b/test/execflags/thomasvandoren/exceedMemInts.chpl
@@ -1,0 +1,3 @@
+writeln(max(uint(64)));
+writeln("memMax = ", MemTracking.memMax);
+writeln("memThreshold = ", MemTracking.memThreshold);

--- a/test/execflags/thomasvandoren/exceedMemInts.execopts
+++ b/test/execflags/thomasvandoren/exceedMemInts.execopts
@@ -1,0 +1,4 @@
+# Try to set memMax, then memThreshold to max(uint64). This only runs on 32-bit
+# platforms, so this will not be a valid value.
+--memMax 18446744073709551615
+--memThreshold 18446744073709551615

--- a/test/execflags/thomasvandoren/exceedMemInts.good
+++ b/test/execflags/thomasvandoren/exceedMemInts.good
@@ -1,0 +1,1 @@
+<internal>: error: halt reached - casting uint(64) > max(uint(32)) to uint(32)

--- a/test/execflags/thomasvandoren/exceedMemInts.good
+++ b/test/execflags/thomasvandoren/exceedMemInts.good
@@ -1,1 +1,1 @@
-<internal>: error: halt reached - casting uint(64) > max(uint(32)) to uint(32)
+<internal>: error: halt reached - casting uint(64) with a value greater than the maximum of uint(32) to uint(32)

--- a/test/execflags/thomasvandoren/exceedMemInts.skipif
+++ b/test/execflags/thomasvandoren/exceedMemInts.skipif
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+"""Only run this test on 32-bit platforms."""
+
+import os
+print(not os.environ.get('CHPL_TARGET_PLATFORM').endswith('32'))


### PR DESCRIPTION
Update memMax and memThreshold config consts in MemTracking module
to be type uint (instead of size_t). Later, create new cMemMax and cMemThreshold
that come from calling safe_cast on the config consts. This makes the help document
portable across 32- and 64-bit platforms (fixing several *32 regressions), and will
now report errors when these values exceed the max of size_t.

Previously, the type that holds a memory size was platform specific (size_t), which is
not strictly a issue but a bit of a nuisance. With these updates, the mem tracking
interface uses the same type across platforms for holding memory sizes and adds
runtime checks to ensure the values are appropriate for the platform.

Also, add test that calls --memMax and --memThreshold on 32bit platforms with
something that won't fit in a size_t (i.e. max(uint(64))) and verifies that an
occurs.