### PR TITLE
Tweak some arrayInClass tests.

### DIFF
--- a/test/Suppressions/fast.suppress
+++ b/test/Suppressions/fast.suppress
@@ -21,6 +21,7 @@ arrays/deitz/part4/test_array_rankchange_error
 arrays/deitz/part6/test_bounds1
 arrays/deitz/part6/test_bounds2
 arrays/waynew/init2
+classes/bradc/arrayInClass/overrideDefaultArr
 classes/diten/callNilClassesMethod
 classes/diten/nilDynamicDispatch
 compflags/deitz/test_no_bounds_checking

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.bad
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.bad
@@ -3,7 +3,7 @@ obj/DefaultRectangular.c:nnnn: error: used struct type value where scalar is req
 obj/DefaultRectangular.c:nnnn: error: used struct type value where scalar is required
 obj/DefaultRectangular.c:nnnn: error: used struct type value where scalar is required
 obj/DefaultRectangular.c:nnnn: error: used struct type value where scalar is required
-obj/ChapelArray.c: In function 'coforall_fn9':
+obj/ChapelArray.c: In function 'coforall_fn7':
 obj/ChapelArray.c:nnnn: error: used struct type value where scalar is required
 obj/ChapelArray.c:nnnn: error: used struct type value where scalar is required
 obj/ChapelArray.c:nnnn: error: used struct type value where scalar is required

--- a/test/classes/bradc/arrayInClass/overrideDefaultArr.skipif
+++ b/test/classes/bradc/arrayInClass/overrideDefaultArr.skipif
@@ -1,0 +1,3 @@
+# Bounds-checking is turned off when --fast is tossed, so this test will not
+# generate the expected error message in that case.
+COMPOPTS <= --fast

--- a/test/classes/bradc/arrayInClass/overrideDefaultArr.skipif
+++ b/test/classes/bradc/arrayInClass/overrideDefaultArr.skipif
@@ -1,3 +1,0 @@
-# Bounds-checking is turned off when --fast is tossed, so this test will not
-# generate the expected error message in that case.
-COMPOPTS <= --fast


### PR DESCRIPTION
On Wednesday, the test overrideDefaultArr was un-futurized.  But it depends on an array
message being generated from bounds checking.  When --fast is tossed, bounds-checking is
turned off.  In that case, this test will not produce the expected error message.

Added a .skipif file so we now avoid running the test when --fast is tossed.

The output for genericArrayInClass-otharrs-inline-iterators changed -- most likely due to
#1381 (Standalone parallel iterators for sparse and assoc).  The observed change in the
output is:

-obj/ChapelArray.c: In function 'coforall_fn9':
+obj/ChapelArray.c: In function 'coforall_fn7':

It seems plausible that the addition of standalone parallel iterators could have changed
the number or ordering of coforall functions in the generated code, and that would have
led to a renumbering and the change in the output.

I just updated the .bad file to track the observed output.  This test is run in the numa
configuration only -- which explains why the .bad file mismatch was only observed for that
configuration.  That fact also means that this change will not cause .bad file mismatches
to show up in other configurations.  (It's effectively a very surgical fix.)