### PR TITLE
Update chown/nothing test to verify file perms before and after execution.

### DIFF
--- a/test/modules/standard/FileSystem/fsouza/chown/nothing.prediff
+++ b/test/modules/standard/FileSystem/fsouza/chown/nothing.prediff
@@ -5,14 +5,18 @@
 # directory and the group id is different than the effective group id.
 #
 
-file_user=$(ls -l file.txt | awk '{print $3}')
-file_group=$(ls -l file.txt | awk '{print $4}')
+set -e
 
-current_user=$(id -un)
-current_groups=$(groups)
+file_user=$(python -c 'import os ; print(os.stat("file.txt").st_uid)')
+file_group=$(python -c 'import os ; print(os.stat("file.txt").st_gid)')
 
-group_result=$(python -c "print('${file_group}' in '${current_groups}')")
+expected_file_group=$(cat file.gid)
+expected_file_user=$(cat file.uid)
+rm -f file.gid file.uid || :
 
-if [ "${file_user}" = "${current_user}" -a "${group_result}" = "True" ] ; then
+if [ "${file_user}" = "${expected_file_user}" -a "${file_group}" = "${expected_file_group}" ] ; then
   echo "no change" >> $2
+else
+  echo "Expected uid ${expected_file_user}, actual uid ${file_user}" >> $2
+  echo "Expected gid ${expected_file_group}, actual gid ${file_group}" >> $2
 fi

--- a/test/modules/standard/FileSystem/fsouza/chown/nothing.preexec
+++ b/test/modules/standard/FileSystem/fsouza/chown/nothing.preexec
@@ -1,3 +1,6 @@
 #!/bin/bash
 
 touch file.txt
+
+python -c 'import os ; print(os.stat("file.txt").st_uid)' > file.uid
+python -c 'import os ; print(os.stat("file.txt").st_gid)' > file.gid


### PR DESCRIPTION
Previously, it was trying to compare file permissions to current user/group,
but that has been error prone on the mac test system which has network users
and groups (they change magically).

Update the tests to use more robust comparison between file uid and gid before
execution and after.

coauthored with @lydia-duncan 