### PR TITLE
Regressions updates for this week's non-Cray-HW runs

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -49,35 +49,40 @@
 
 ===================
 general
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
-Sporadic compiler issue. (brad)
----> Brad committed fix on 2015-02-17
-Appears to be non-deterministic issue when building compiler
-pgi: "PGC-W-0205-Argument mismatch for assert"
-gnu: "error: macro "assert" passed 3 arguments, but takes just 1"
-intel: ""
-(xe-wb.prgenv-pgi on 2015-01-29, xe-wb.prgenv-intel, smoke test whitebox, numa on 2015-02-14)
----------------------------------------------------------------------------------------------
-All tests fail with: [Error matching compiler output for ...]
+extra output in chpldoc (2015-02-27, tvandoren)
+-----------------------------------------------
+[Error matching compiler output for chpldoc/classes/methodOutsideClassDef]
 
 
 ===================
 linux64
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 
 ===================
 *32
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
-Seg fault First run 2014-12-07
-------------------------------
+GMP [u]int(64)/32-bit c_[u]long mismatches (since first run, 2014-11-12)
+------------------------------------------------------------------------
+[Error matching compiler output for modules/standard/gmp/ferguson/gmp_dist_array]
+[Error matching compiler output for modules/standard/gmp/ferguson/gmp_random]
+[Error matching compiler output for modules/standard/gmp/ferguson/gmp_test]
+[Error matching compiler output for modules/standard/gmp/ferguson/gmp_writeln]
+[Error matching compiler output for modules/standard/gmp/studies/gmp-chudnovsky (compopts: 1)]
+[Error matching compiler output for studies/shootout/pidigits/hilde/pidigits-hilde]
+[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-BigInt]
+[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt]
+
+Seg fault since first run (2014-12-07)
+--------------------------------------
 [Error matching compiler output for users/vass/type-tests.isSubtype]
 
 memmax/memthreshold flags are C types; should be Chapel types (2014-11-12)
@@ -107,22 +112,11 @@ some sort of 64-bit assertion fails (2014-11-12, first run)
 -----------------------------------------------------------
 [Error matching program output for optimizations/cache-remote/ferguson/c_tests/chpl-cache-support-test (compopts: 1)]
 
-GMP [u]int(64)/32-bit c_[u]long mismatches (since first run, 2014-11-12)
-------------------------------------------------------------------------
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_dist_array]
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_random]
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_test]
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_writeln]
-[Error matching compiler output for modules/standard/gmp/studies/gmp-chudnovsky (compopts: 1)]
-[Error matching compiler output for studies/shootout/pidigits/hilde/pidigits-hilde]
-[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-BigInt]
-[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt]
-
 
 ===================
 linux32
 Inherits '*32'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 timeout (2015-02-05, first run) - (elliot/michael)
@@ -134,34 +128,33 @@ timeout (2015-02-05, first run) - (elliot/michael)
 ===================
 darwin
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
-Email on chapelmac was not sending through 2015-02-17.
---> Should be fixed on 2015-02-18
+output mismatch 'no change' (2015-02-26, lydia)
+-----------------------------------------------
+[Error matching program output for modules/standard/FileSystem/fsouza/chown/nothing]
 
 
 ===================
 gnu.darwin
 Inherits 'darwin'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 
 ===================
 perf*
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 
 ===================
 perf.bradc-lnx
 Inherits 'perf*'
-Reviewed 2015-02-15
+Reviewed 2015-02-27
 ===================
-
-bradc-lnx crashed 2015-02-16.
 
 consistent failure due to insane memory usage (should get better with strings)
 ------------------------------------------------------------------------------
@@ -172,7 +165,7 @@ consistent failure due to insane memory usage (should get better with strings)
 ===================
 perf.chap03
 Inherits 'perf*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 consistent failure due to insane memory usage (should get better with strings)
@@ -183,18 +176,8 @@ consistent failure due to insane memory usage (should get better with strings)
 ===================
 perf.chap04
 Inherits 'perf*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
-
-
-======================
-perf.chap04.playground
-Inherits 'perf.chap04'
-Reviewed 2015-02-17
-======================
-
-Currently running array slicing testing for Brad, Elliot. There are
-regressions, but they should be ignored until further notice from Elliot.
 
 
 ====================
@@ -214,40 +197,43 @@ consistent failure due to insane memory usage (should get better with strings)
 ===================
 fast
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-26
 ===================
+
+retired future doesn't trip bounds check with --fast (2015-02-26, hilde)
+------------------------------------------------------------------------
+[Error matching program output for classes/bradc/arrayInClass/overrideDefaultArr]
 
 
 ===================
 memleaks.examples
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 
 ============================
 memleaks
 Inherits 'memleaks.examples'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ============================
 
 
 ===================
 verify
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 
 ===================
 valgrind
 Inherits 'general'
-Reviewed 2015-02-23
+Reviewed 2015-02-27
 ===================
 
-> ==15313== Conditional jump or move depends on uninitialised value(s)
-Related to failure under cygwin32.  Lydia is investigating.
-----------------------------------------------------------------------
+Conditional jump or move depends on uninitialised value(s) (2015-02-22, lydia)
+------------------------------------------------------------------------------
 [Error matching compiler output for chpldoc/compflags/comment/loseComments (compopts: 1)]
 
 conditional jump depends on uninitialized value (2014-04-08 -- since re2 on)
@@ -255,8 +241,8 @@ conditional jump depends on uninitialized value (2014-04-08 -- since re2 on)
 [Error matching program output for io/tzakian/recordReader/test]
 [Error matching program output for regexp/ferguson/rechan]
 
-continual compilation timeouts
-------------------------------
+consistent compilation timeouts
+-------------------------------
 [Error: Timed out compilation for functions/iterators/vass/yield-arrays-var-nonvar]
 [Error: Timed out compilation for functions/iterators/vass/standaloneForallIntents] (first seen 2015-01-20)
 
@@ -267,22 +253,17 @@ sporadic invalid write of size 8 in dl_lookup_symbol->do_lookup_x,
 read of size 8 in dl_name_match_p
 -----------------------------------------------------------------------------
 [Error matching program output for performance/sungeun/dgemm] (2014-11-16..2014-11-26, 2014-11-29..2015-01-05, 2015-01-12..)
-[Error matching program output for studies/sudoku/dinan/sudoku] (2015-01-30..2015-02-18, 2015-02-20)
-
-sporadic compilation timeouts
----------------------------------
-[Error: Timed out compilation for distributions/dm/t5a (2015-01-26)]
+[Error matching program output for studies/sudoku/dinan/sudoku] (2015-01-30..2015-02-18, 2015-02-19)
 
 sporadic execution timeout
 --------------------------
-[Error: Timed out executing program domains/sungeun/assoc/stress (compopts: 1, execopts: 2) (2015-01-27)]
-[Error: Timed out executing program domains/sungeun/assoc/stress.numthr (compopts: 1, execopts: 2)] (2015-02-20)
+[Error: Timed out executing program domains/sungeun/assoc/stress.numthr (compopts: 1, execopts: 2)] (..2015-02-21)
 
 
 ===================
 llvm
 Inherits 'general'
-Reviewed 2015-02-18
+Reviewed 2015-02-27
 ===================
 
 relies on macro in gmp.h -- not expected to work without effort (2014-09-18)
@@ -293,35 +274,40 @@ relies on macro in gmp.h -- not expected to work without effort (2014-09-18)
 ===================
 fifo
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 
 ===================
 numa
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
+
+numbering change based on changes to code (2015-02-26, diten)
+-------------------------------------------------------------
+[Error matching .bad file for classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators (compopts: 1)]
+
 
 
 ===================
 no-local
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 
 =================================
 no-local.linux32
 Inherits 'linux32' and 'no-local'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 =================================
 
 
 ===================
 gasnet*
 Inherits 'no-local'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 === sporadic failures below ===
@@ -330,7 +316,7 @@ sporadic failures even after Sung quieted it down (frequently -- gbt/diten)
  - see "gasnet+fifo: types/string/StringImpl/memLeaks/coforall.chpl" thread for details
  - frequent for gasnet.fifo, infrequent for gasnet-fast, very infrequent for gasnet-everything
 ---------------------------------------------------------------------------
-[Error matching program output for types/string/StringImpl/memLeaks/coforall] (2014-10-23..2014-11-30, ..., 2015-01-26, 2015-02-10)
+[Error matching program output for types/string/StringImpl/memLeaks/coforall] (2014-10-23..2014-11-30, ..., 2015-01-26, 2015-02-10, 2015-02-24)
 
 execution timeout
 (happens on: gasnet.fifo, gasnet-fast)
@@ -342,46 +328,32 @@ execution timeout
 ===================
 gasnet-everything
 Inherits 'gasnet*'
-Reviewed 2015-02-16
+Reviewed 2015-02-27
 ===================
-
-
-=== sporadic failures below ===
-
-sporadic execution timeout
---------------------------
-[Error: Timed out executing program performance/ferguson/remote-tuple-write] (2015-01-23..2015-01-26)
 
 
 ===================
 gasnet-fast
 Inherits 'gasnet*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
-
-=== sporadic failures below ===
-
-Segfault (2015-02-22)
----------------------
+Segfault (2015-02-22, michael)
+------------------------------
 [Error matching program output for multilocale/deitz/needMultiLocales/test_remote_file_read]
-
-sporadic execution timeout (regularly)
---------------------------------------
-[Error: Timed out executing program studies/sudoku/dinan/sudoku] (2014-11-01, 2014-11-06, 2014-12-18, 2015-01-02)
 
 
 ===============================
 gasnet.darwin
 Inherits 'darwin' and 'gasnet*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===============================
 
 
 =============================
 gasnet.fifo
 Inherits 'gasnet*' and 'fifo'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 =============================
 
 === sporadic failures below ===
@@ -389,45 +361,36 @@ Reviewed 2015-02-17
 sporadic execution timeouts (frequent)
 --------------------------------------
 [Error: Timed out executing program studies/madness/aniruddha/madchap/test_gaxpy] (2014-10-19, 2014-10-24, 2014-11-11, 2014-11-13, 2014-12-13, 2014-12-15, 2015-01-07, 2015-01-09, 2015-01-25, 2015-02-08)
-
-Elliot - I'll take a look at it to see if it makes sense to add a .timeout to it
-until we start running on real harware.
---------------------------------------------------------------------------------
-[Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dDRtoBDTest] (2015-02-10)
+[Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dDRtoBDTest] (2015-02-10) (elliot)
 
 
 =============================
 gasnet.llvm
 Inherits 'gasnet*' and 'llvm'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 =============================
 
 
 =============================
 gasnet.numa
 Inherits 'gasnet*' and 'numa'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 =============================
 
 
 ===================
 x?-wb.*
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 Compilation timeout (2015-02-17)
 Normally takes ~10s to compile. Started timing out (300s) on 2015-02-17.
 (happened on: xe-wb.prgenv-gnu, xe-wb.prgenv-pgi, xc-wb.prgenv-pgi)
 --------------------------------------------------------------------------------
-[Error: Timed out compilation for compflags/bradc/html/testit (compopts: 1)]
 
 
 === sporadic failures below ===
-
-something going wrong with reservedSymbolNames causes reserved names to show up in generated code.
---------------------------------------------------------------------------------------------------
-All tests fail when this happens (xc-wb.host.prgenv-pgi 2015-01-08, xc-wb.prgenv-pgi 2015-01-16, xc-wb.prgenv-pgi 2015-01-21, xc-wb.prgenv-gnu 2015-01-22, xc-wb.intel 2015-01-30)
 
 Sporadic compilation timeouts
 -----------------------------
@@ -439,30 +402,35 @@ Sporadic compilation timeouts
 [Error: Timed out compilation for arrays/bradc/sliceViaSingleton3d] (xe-wb.intel 2015-01-20, xe-wb.prgenv-pgi 2015-02-22)
 [Error: Timed out compilation for arrays/claridge/arraySizeMismatch] (xe-wb.prgenv-cray 2015-01-07)
 [Error: Timed out compilation for arrays/marybeth/CMO_array] (xe-wb.intel 2015-01-22)
+[Error: Timed out compilation for release/examples/primers/arrays] (xe-wb.host.prgenv-intel 2015-02-22)
+[Error: Timed out compilation for release/examples/benchmarks/lulesh/lulesh (compopts: 2)] (xe-wb.host.prgenv-intel 2015-02-26..)
+[Error: Timed out compilation for arrays/bradc/array_init_should_copy] (xe-wb.prgenv-pgi 2015-02-24)
+[Error: Timed out compilation for arrays/deitz/test_remote_cyclic_slicing] (xe-wb.prgenv-pgi 2015-02-26..)
+[Error: Timed out compilation for arrays/deitz/part6/test_basic1d2] (xe-wb.pgi 2015-02-26..)
+[Error: Timed out compilation for arrays/bradc/reindex/reindex] (xe-wb.prgenv-cray 2015-02-22)
+[Error: Timed out compilation for arrays/bradc/sliceViaSingleton3d] (x?-wb.prgenv-pgi 2015-02-22..)
+[Error: Timed out compilation for arrays/bradc/badParZip] (xe-wb.prgenv-cray 2015-02-24)
+[Error: Timed out compilation for arrays/deitz/jacobi5-no-local] (xe-wb.prgenv-cray 2016-02-26)
+[Error: Timed out compilation for compflags/bradc/html/testit (compopts: 1)] (xe-wb.prgenv-gnu, xe-wb.prgenv-pgi, xc-wb.prgenv-pgi 2015-02-17)
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program studies/shootout/nbody/sidelnik/nbody_rangesub_5] (xe-wb.pgi 2015-01-22)
-[Error: Timed out executing program studies/shootout/nbody/sidelnik/nbody_vector_4] (xe-wb.prgenv-pgi 2015-01-22)
-[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (xc-wb.pgi, xc-wb.prgenv-gnu 2015-02-15; xc-wb.prgenv-intel 2015-02-17; xc-wb.prgenv-gnu 2015-02-22)
+[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (xc-wb.pgi, xc-wb.prgenv-gnu 2015-02-15; xc-wb.prgenv-intel 2015-02-17; xc-wb.prgenv-gnu 2015-02-22; xc-wb.pgi 2015-02-24)
+[Error: Timed out executing program domains/johnk/capacityParSafe (compopts: 1)] (xc-wb.pgi 2015-02-24)
 
 
 ==================
 *prgenv-*
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 
 ====================
 *prgenv-cray*
 Inherits '*prgenv-*'
-Reviewed 2015-02-20
+Reviewed 2015-02-27
 ====================
-
-Execution timeout on 2015-02-15..
--------------------------------
-[Error: Timed out executing program performance/compiler/bradc/cg-sparse-timecomp (compopts: 1)]
 
 An invalid option "openmp" appears on the command line. (2014-11-17 -- thomas/ben/et al)
 ----------------------------------------------------------------------------------------
@@ -490,14 +458,17 @@ filenames get printed by C compiler when multiple .c files are specified in one 
 [Error matching program output for modules/standard/BitOps/c-tests/popcount (compopts: 1)]
 [Error matching program output for modules/standard/BitOps/c-tests/popcount (compopts: 2)]
 
-unexpected compiler output (listing the source files) (2014-07-23..)
-------------------------------------------------------------------
+unexpected compiler output (listing the source files) (2014-07-23, gbt)
+-----------------------------------------------------------------------
 [Error matching program output for optimizations/cache-remote/ferguson/c_tests/chpl-cache-support-test (compopts: 1)]
-gbt is working on getting rid of this
 
 error differs but within acceptable margin; should squash error printing (..)
 ------------------------------------------------------------------------
 [Error matching program output for studies/hpcc/FFT/marybeth/fft]
+
+Execution timeout (2015-02-15)
+------------------------------
+[Error: Timed out executing program performance/compiler/bradc/cg-sparse-timecomp (compopts: 1)]
 
 
 === sporadic failures below ===
@@ -521,118 +492,36 @@ sporadic dropping/mangling of output
 [Error matching program output for studies/hpcc/STREAMS/diten/stream-fragmented-local (compopts: 1)] (2015-01-26..2015-02-01)
 [Error matching program output for studies/shootout/nbody/sidelnik/nbody_orig_1] (2014-12-16)
 [Error matching program output for studies/hpcc/STREAMS/bradc/stream-slice (compopts: 1)] (2015-02-08)
-
-signal 11 (first seen ????-??-??)
----------------------------------
-[Error matching program output for studies/590o/alaska/graph] ( ..2015-01-18, 2015-01-21..2015-02-01 )
-[Error matching program output for reductions/thomasvandoren/test/TestCounts] (2015-01-23..2015-02-01)
-
-
-=== Only fail with optimizer on (CCE bugs/not seen nightly since using -O0) ===
-
-infinite loop warning (since filed?)
-------------------------------------
-[Error matching compiler output for statements/vass/while-const1]
-
-signal 11 (first seen 2014-03-02) (Note resolved with CCE 8.3.8)
----------------------------------
-[Error matching program output for release/examples/benchmarks/shootout/meteor-fast]
-[Error matching program output for studies/shootout/meteor/kbrady/meteor-parallel-alt]
+[Error matching program output for modules/vass/SSCA2-with-Private-2] (2015-02-19)
+[Error matching program output for reductions/waynew/reductions] (2015-02-19, 2015-02-22)
+[Error matching program output for users/hilde/refcnt] (2015-02-20)
+[Error matching program output for studies/590o/alaska/graph] (2015-02-25)
 
 
 ======================================
 x?-wb.prgenv-cray
 Inherits 'x?-wb.*' and '*prgenv-cray*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ======================================
 
 
 ============================
 x?-wb.host.prgenv-cray
 Inherits 'x?-wb.prgenv-cray'
-Reviewed 2015-02-20
+Reviewed 2015-02-27
 ============================
 
 === sporadic failures below ===
 
-unresolved call in Types.chpl (2015-02-15, brad)
---> xe-wb.host.prgenv-cray passed on  2015-02-17 (fixed or fluke?)
-Fluke: Failed again on 2015-02-19
-$CHPL_HOME/modules/standard/Types.chpl:72: In function 'isIntType':
-$CHPL_HOME/modules/standard/Types.chpl:73: error: unresolved call '||(0, 0)'
-----------------------------------------------------------------------------
-All tests fail to compile.
-
-terminate called after throwing an instance of 'std::out_of_range' - happens when making the directory in which to place documentation
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
-[Error matching compiler output for release/examples/primers/chpldoc (compopts: 1)] (2015-01-30)
-
-
-"$CHPL_HOME/modules/internal/ChapelDistribution.chpl:65: error: unresolved call '(bool)'" (2015-01-19..2015-01-26)
-------------------------------------------------------------------------------------------------------------------
-all tests fail compilation
-
-or "$CHPL_HOME/modules/internal/ChapelArray.chpl:2117: In function '='
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2119: error: unresolved call '(list(BaseArr))'" (2015-01-27..2015-01-28)
---------------------------------------------------------------------------------------------
-
-for param loop in String.chpl --> "$CHPL_HOME/modules/internal/String.chpl:120: error: " (2015-02-11)
------------------------------------------------------------------------------------------------------
-all tests fail compilation
-
-
-============================
-xc-wb.prgenv-cray
-Inherits 'x?-wb.prgenv-cray'
-Reviewed 2015-02-22
-============================
-
-=== sporadic failures below ===
-
-error: attempt to dereference nil (2015-01-18)
----------------------------------------------------------------------------
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_dist_array]
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_random]
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_test]
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_writeln]
-[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-BigInt]
-[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt]
-
-Missing output on stdout
--------------------------------------
-[Error matching program output for modules/vass/SSCA2-with-Private-2] (2015-02-19)
-[Error matching program output for users/hilde/refcnt] (2015-02-20)
-
-Missing whitespace in output on stdout
---------------------------------------
-[Error matching program output for reductions/waynew/reductions] (2015-02-19)
-
-
-============================
-xe-wb.prgenv-cray
-Inherits 'x?-wb.prgenv-cray'
-Reviewed 2015-02-22
-============================
-
-=== sporadic failures below ===
-
-(2015-02-22)
-------------------------------
-[Error: Timed out compilation for arrays/bradc/reindex/reindex]
-
-Missing output on stdout
--------------------------------------
-[Error matching program output for modules/vass/SSCA2-with-Private-2] (2015-02-22)
-
-Missing whitespace in output on stdout
---------------------------------------
-[Error matching program output for reductions/waynew/reductions] (2015-02-22)
+unresolved call on ||(0,0) in Types.chpl (bradc)
+------------------------------------------------
+All tests fail to compile. (2015-02-15..2015-02-16, 2015-02-19)
 
 
 ===================
 *intel*
 Inherits 'general'
-Reviewed 2015-02-20
+Reviewed 2015-02-27
 ===================
 
 test assertion failures (2014-09-21..)
@@ -649,62 +538,56 @@ binary files differ (2014-09-21..)
 ================================
 x?-wb.intel
 Inherits 'x?-wb.*' and '*intel*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ================================
 
 
 ================================
 x?-wb.prgenv-intel
 Inherits 'x?-wb.*' and '*intel*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ================================
 
 
 =============================
 x?-wb.host.prgenv-intel
 Inherits 'x?-wb.prgenv-intel'
-Reviewed 2015-02-23
+Reviewed 2015-02-27
 =============================
-
-=== sporadic issues ===
-
-(2015-02-22)
-------------------------------
-[Error: Timed out compilation for release/examples/primers/arrays]
 
 
 =======================
 *gnu*
 Inherits from 'linux64'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 =======================
 
 
 ==============================
 x?-wb.gnu
 Inherits 'x?-wb.*' and '*gnu*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ==============================
 
 
 ==============================
 x?-wb.prgenv-gnu
 Inherits 'x?-wb.*' and '*gnu*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ==============================
 
 
 ===========================
 x?-wb.host.prgenv-gnu
 Inherits 'x?-wb.prgenv-gnu'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===========================
 
 
 ===================
 *pgi*
 Inherits 'general'
-Reviewed 2015-02-20
+Reviewed 2015-02-27
 ===================
 
 undefined reference to chpl_bitops_debruijn64
@@ -725,35 +608,35 @@ consistent execution timeout (no intrinsics for pgi, test is slow with locks)
 ==============================
 x?-wb.pgi
 Inherits 'x?-wb.*' and '*pgi*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ==============================
 
 
 ==============================
 x?-wb.prgenv-pgi
 Inherits 'x?-wb.*' and '*pgi*'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ==============================
 
 
 ===========================
 x?-wb.host.prgenv-pgi
 Inherits 'x?-wb.prgenv-pgi'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===========================
 
 
 ===================
 rhel.linux64
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-27
 ===================
 
 
 ===================
 cygwin*
 Inherits 'general'
-Reviewed 2015-02-16
+Reviewed 2015-02-27
 ===================
 
 check_channel assertion failure
@@ -764,21 +647,30 @@ QIO strcmp(got, expect) assertion error
 ---------------------------------------
 [Error matching program output for io/ferguson/ctests/qio_formatted_test (compopts: 1)]
 
-consistent execution timeout (frequent)
----------------------------------------
-[Error: Timed out executing program studies/cholesky/jglewis/version2/performance/test_cholesky_performance (compopts: 1)] (..., 2014-12-01, 2015-01-05.. )
+=== sporadic failures below ===
+
+sporadic pthread_cond_init failed
+---------------------------------
+[Error matching program output for studies/cholesky/jglewis/version2/performance/test_cholesky_performance (compopts: 1)] (2015-02-25)
+
+sporadic execution timeout
+--------------------------
+[Error: Timed out executing program studies/cholesky/jglewis/version2/performance/test_cholesky_performance (compopts: 1)] (..., 2014-12-01, 2015-01-05..2015-02-24)
 
 
 ===========================
 cygwin32
 Inherits 'cygwin*' and '*32'
-Reviewed 2015-02-20
+Reviewed 2015-02-27
 ===========================
 
-Compiler segfault (2015-02-22)
-Lydia is investigating.
-------------------------------
+Compiler segfault (2015-02-22, lydia)
+-------------------------------------
 [Error matching compiler output for chpldoc/compflags/comment/loseComments (compopts: 1)]
+
+"got == expect[i]" assertion error
+----------------------------------
+[Error matching program output for io/ferguson/ctests/qio_bits_test (compopts: 1)]
 
 Generated output "FAILED" (see below for sporadic): First run 2014-12-07
 ------------------------------------------------------------------------
@@ -790,22 +682,17 @@ Consistent execution timouts
 [Error: Timed out executing program io/ferguson/ctests/qio_test (compopts: 1)]
 
 
-"got == expect[i]" assertion error
-----------------------------------
-[Error matching program output for io/ferguson/ctests/qio_bits_test (compopts: 1)]
-
-
 === sporadic failures below ===
 
 sporadic generated output "FAILED" (see above for solid): First run 2014-12-07
 ------------------------------------------------------------------------------
-[Error matching program output for studies/colostate/OMP-Jacobi-1D-Sliced-Diamond-Tiling (compopts: 1)] (2015-01-16..2015-01-19, 2015-01-21, 2015-01-25..2015-01-28, 2015-01-31..2015-02-18, 2015-02-20..)
+[Error matching program output for studies/colostate/OMP-Jacobi-1D-Sliced-Diamond-Tiling (compopts: 1)] (2015-01-16..2015-01-19, 2015-01-21, 2015-01-25..2015-01-28, 2015-01-31..2015-02-18, 2015-02-20..2015-02-22, 2015-02-24)
 
 
 ================================
 cygwin64
 Inherits 'cygwin*' and 'linux64'
-Reviewed 2015-02-16
+Reviewed 2015-02-27
 ================================
 
 QIO qio_err_to_int() == EEOF assertion error
@@ -816,7 +703,7 @@ QIO qio_err_to_int() == EEOF assertion error
 ===================
 baseline
 Inherits 'general'
-Reviewed 2015-02-17
+Reviewed 2015-02-26
 ===================
 
 Dies with signal 6
@@ -827,28 +714,20 @@ Dies with signal 6
 ===================
 dist-block
 Inherits 'gasnet*'
-Reviewed 2015-02-17
+Reviewed 2015-02-26
 ===================
 
 
 ===================
 dist-cyclic
 Inherits 'gasnet*'
-Reviewed 2015-02-17
+Reviewed 2015-02-26
 ===================
-
-
-=== sporadic failures below ===
-
-sporadic execution timeout (very infrequent) (2014-11-04, 2015-01-18)
----------------------------------------------------------------------
-[Error: Timed out executing program distributions/robust/arithmetic/kernels/hpl (compopts: 1)]
-[Error: Timed out executing program distributions/robust/arithmetic/kernels/jacobi]
 
 
 ===================
 dist-replicated
 Inherits 'gasnet*'
-Reviewed 2015-02-17
+Reviewed 2015-02-26
 ===================
 

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -384,11 +384,6 @@ Inherits 'general'
 Reviewed 2015-02-27
 ===================
 
-Compilation timeout (2015-02-17)
-Normally takes ~10s to compile. Started timing out (300s) on 2015-02-17.
-(happened on: xe-wb.prgenv-gnu, xe-wb.prgenv-pgi, xc-wb.prgenv-pgi)
---------------------------------------------------------------------------------
-
 
 === sporadic failures below ===
 
@@ -513,8 +508,8 @@ Reviewed 2015-02-27
 
 === sporadic failures below ===
 
-unresolved call on ||(0,0) in Types.chpl (bradc)
-------------------------------------------------
+unresolved call on ||(0,0) in Types.chpl and related crazy errors (bradc)
+-------------------------------------------------------------------------
 All tests fail to compile. (2015-02-15..2015-02-16, 2015-02-19)
 
 


### PR DESCRIPTION
Regressions
-----------
* methodOutsideClassDef failed everywhere (tvandoren owns)

* fsouza/chown/nothing failed on darwin (lydia owns)

* retired overrideDefaultArr future fails .bad check (hilde owns)

* genericArrInClass future fails .bad check (hilde owns)

* when not timing out, test_cholesky_performance seems to get a
  pthread_cond_init failed error (unowned at present)


Improvements
------------
* retired non-deterministic general failure related to build race


Misc cleanup
------------
* moved all x?-wb sporadic compilation timeouts to a common section

* removed miscellaneous floating notes, trimmed long entries down to
  one-liners, and unified cases where owner was mentioned verbosely
  or title of failure only included a date

* reordered tests to match mail order for ease of comparing results

* removed the playground area which we're not going to track as a
  group

* retired long-silent sporadic failures and noted new sporadic
  failures

* removed -O3-specific failures now that we're not compiling with
  -O3 anymore

* compressed all the crazy host.prgenv-cray build errors into a 
  single item that I own