### PR TITLE
Double compilation timeout for testing

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1183,6 +1183,18 @@ for testname in testsrc:
         #
         # Compile (with timeout)
         #
+        # compilation timeout defaults to 2 * execution timeout.
+        # This is to quiet compilation timeouts in some oversubscribed test
+        # configurations (since they are generating a lot of testing noise, but
+        # don't represent a real issue.)
+        #
+        # TODO (Elliot 02/27/15): Ideally what we want is separate options for
+        # compiler and testing timeout, but that's more work to thread through
+        # sub_test right now and this is causing a lot of noise in nightly
+        # testing. Hopefully this is just a temporary work around and I'll
+        # remember to add the cleaner solution soon.
+        #
+        comptimeout = 2*timeout
         sys.stdout.write('[Executing compiler %s'%(cmd))
         if args:
             sys.stdout.write(' %s'%(' '.join(args)))
@@ -1190,7 +1202,7 @@ for testname in testsrc:
         sys.stdout.flush()
         if useTimedExec:
             wholecmd = cmd+' '+' '.join(map(ShellEscape, args))
-            p = subprocess.Popen([timedexec, str(timeout), wholecmd],
+            p = subprocess.Popen([timedexec, str(comptimeout), wholecmd],
                                  stdin=open(compstdin, 'r'),
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT)
@@ -1211,7 +1223,7 @@ for testname in testsrc:
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT)
             try:
-                output = SuckOutputWithTimeout(p.stdout, timeout)
+                output = SuckOutputWithTimeout(p.stdout, comptimeout)
             except ReadTimeoutException:
                 sys.stdout.write('%s[Error: Timed out compilation for %s/%s'%
                                  (futuretest, localdir, test_filename))


### PR DESCRIPTION
One of our biggest sources of testing noise right now is compilation timeouts.
These timeouts don't indicate a real issue, they are on systems where we run
heavily oversubscribed and on login nodes where other users could be pegging
the node we're compiling on.

Currently we only have one timeout value for compilation and timeout. Ideally
we want to split these out in sub_test but that change and threading it through
will take more time. This patch just doubles whatever the timeout value is for
compiling. So by default, comp timeout will be 10 minutes.

This is really meant a quick and dirty fix to quiet a big source of testing
noise and I'm planning on adding the more elegant solution next week (and will
try really hard to get to this.)