### PR TITLE
Add perf test to compare zippered parallel iteration over domain vs range

### DIFF
--- a/test/performance/bharshbarg/dom-forall.chpl
+++ b/test/performance/bharshbarg/dom-forall.chpl
@@ -1,7 +1,13 @@
+config const zipIter = false;
 config const n = 1e6:uint;
 
-var space = {1..n};
-
+const space = {1..n};
 var x : uint = 2;
-forall i in space with (ref x) do
-  x *= i;
+
+if zipIter {
+  forall (i, j) in zip(space, space) with (ref x) do
+    x *= i;
+} else {
+  forall i in space with (ref x) do
+    x *= i;
+}

--- a/test/performance/bharshbarg/dom-forall.perfexecopts
+++ b/test/performance/bharshbarg/dom-forall.perfexecopts
@@ -1,1 +1,2 @@
---n=10000000000
+--n=10000000000 --zipIter=false # dom-forall.dat
+--n=10000000000 --zipIter=true  # dom-forall-zip.dat

--- a/test/performance/bharshbarg/forall-dom-range.graph
+++ b/test/performance/bharshbarg/forall-dom-range.graph
@@ -1,5 +1,5 @@
-perfkeys: real, real
-files: dom-forall.dat, range-forall.dat
-graphkeys: Domain, Range
+perfkeys: real, real, real, real
+files: dom-forall.dat, dom-forall-zip.dat, range-forall.dat, range-forall-zip.dat
+graphkeys: Domain, Zip-Domain, Range, Zip-Range
 graphtitle: 1D Domain vs. Range Parallel Iteration
 ylabel: Time (seconds)

--- a/test/performance/bharshbarg/range-forall.chpl
+++ b/test/performance/bharshbarg/range-forall.chpl
@@ -1,7 +1,13 @@
+config const zipIter = false;
 config const n = 1e6:uint;
 
-var space = 1..n;
-
+const space = 1..n;
 var x : uint = 2;
-forall i in space with (ref x) do
-  x *= i;
+
+if zipIter {
+  forall (i, j) in zip(space, space) with (ref x) do
+    x *= i;
+} else {
+  forall i in space with (ref x) do
+    x *= i;
+}

--- a/test/performance/bharshbarg/range-forall.perfexecopts
+++ b/test/performance/bharshbarg/range-forall.perfexecopts
@@ -1,1 +1,2 @@
---n=10000000000
+--n=10000000000 --zipIter=false # range-forall.dat
+--n=10000000000 --zipIter=true  # range-forall-zip.dat


### PR DESCRIPTION
With 65c825e9bbd6c59fa89ec3ea5de9e88129bd6db7 Ben added a test to show the
performance difference between non-zippered parallel range and domain
iteration. At the time parallel range iteration was ~20 times slower than
domain iteration because the range follower iterator wasn't being inlined by
lowerIterators.

That perf regression was resolved by updating the follower to allow regular
iterator inlining to fire. However, I recently discovered that we have a
similar performance gap between range and domain parallel iteration for the
zippered case. This reason is the same, the range follower can't be inlined
when it's zippered. The checks for inlining zippered vs non-zippered iterators
are pretty different. Some of these differences are for good reasons because it
can be much harder to inline zippered iterators.

In this particular case I think zippered iterator inlining is too conservative.
Zippered inlining isn't firing because of a 'goto' in the follower (really an
early return if followThis.size == 0 in the source code.) I *think* this check
in zippered iterator inlining should only occur if the return is in the body of
the loop that is yielding. Without looking into it too much, I don't see why
one of the iterators being zipped can't return early outside of the loop beyond
ease of implementation.

This test (really an update to Bens' test) is meant to show the current
performance gap, with the thought that it will be resolved in the next few
days. I think it could be resolved by updating the restrictions on zippered
iterator inlining (isSingleLoop()) or by updating the range follower. They both
need to be cleaned up anyway.

Being this close to the release, it seems likely the follower will be updated
and that updating zippered iterator inlining will wait until after release