### PR TITLE
Ensure last-* exists when configuration is run for first time.

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -431,11 +431,6 @@ if ($parnodefile eq "") {
   $permsum = "<invalid use of permsum>";
 }
 
-#
-# make "prev" logs if they don't already exist
-#
-ensureSummaryExists($prevsummary);
-
 
 $somethingfailed = 0;
 

--- a/util/cron/nightly_email.pl
+++ b/util/cron/nightly_email.pl
@@ -31,6 +31,12 @@ $crontab = $ARGV[13];
 $testdirs = $ARGV[14];
 $debug = $ARGV[15];
 
+
+# Ensure the "previous" summary exists, e.g. if this is the first run of the
+# configuration they won't.
+ensureSummaryExists($prevsummary);
+
+
 #
 # sort output
 #


### PR DESCRIPTION
Previously, nightly tests that only used nightly_email.pl would report a number
of a failures but fail to include the actual failure. This was due to the
last-* file not existing, so the comm commands failed. This would not have
happened for tests that use nightly, since it was ensuring the last-* file
existed.

Update nightly_email.pl to create an empty last-* file if it does not already
exist. This way, any errors that show up on the first run will be reported as
new errors.