### PR TITLE
Fix assert and change 1*c_string -> 1*string in IO

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -746,11 +746,12 @@ module DefaultAssociative {
     return _gen_key(u:int(64));
   }
   
+  // TODO: maybe move this into Strings.chpl
   // Use djb2 (Dan Bernstein in comp.lang.c)
   inline proc chpl__defaultHash(x : string): int(64) {
     var hash: int(64) = 0;
     for c in 0..#(x.length) {
-      hash = ((hash << 5) + hash) ^ x.base[c];
+      hash = ((hash << 5) + hash) ^ x.buff[c];
     }
     return _gen_key(hash);
   }

--- a/modules/standard/Assert.chpl
+++ b/modules/standard/Assert.chpl
@@ -21,12 +21,12 @@ proc assert(test: bool) {
   if !test then
     __primitive("chpl_error", "assert failed");
 }
-  
-  
+
+
 proc assert(test: bool, args ...?numArgs) {
   if !test {
-    var tmpstring: c_string;
+    var tmpstring: string;
     tmpstring.write((...args));
-    __primitive("chpl_error", "assert failed - " + tmpstring);
+    __primitive("chpl_error", "assert failed - " + tmpstring.c_str());
   }
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1247,8 +1247,8 @@ proc _isIoPrimitiveType(type t) param return
  proc _isIoPrimitiveTypeOrNewline(type t) param return
   _isIoPrimitiveType(t) || t == ioNewline || t == ioLiteral || t == ioChar || t == ioBits;
 
-const _trues: 1*c_string  = ("true":c_string,);
-const _falses: 1*c_string = ("false":c_string,);
+const _trues: 1*string  = ("true":string,);
+const _falses: 1*string = ("false":string,);
 const _i = "i":c_string;
 
 // Read routines for all primitive types.
@@ -1261,14 +1261,14 @@ proc _read_text_internal(_channel_internal:qio_channel_ptr_t, out x:?t):syserr w
     err = EFORMAT;
 
     for i in 1..num {
-      err = qio_channel_scan_literal(false, _channel_internal, _trues(i), (_trues(i).length):ssize_t, 1);
+      err = qio_channel_scan_literal(false, _channel_internal, _trues(i).c_str(), (_trues(i).length):ssize_t, 1);
       if !err {
         got = true;
         break;
       } else if err == EEOF {
         break;
       }
-      err = qio_channel_scan_literal(false, _channel_internal, _falses(i), (_falses(i).length):ssize_t, 1);
+      err = qio_channel_scan_literal(false, _channel_internal, _falses(i).c_str(), (_falses(i).length):ssize_t, 1);
       if !err {
         got = false;
         break;
@@ -1341,9 +1341,9 @@ proc _read_text_internal(_channel_internal:qio_channel_ptr_t, out x:?t):syserr w
 proc _write_text_internal(_channel_internal:qio_channel_ptr_t, x:?t):syserr where _isIoPrimitiveType(t) {
   if isBoolType(t) {
     if x {
-      return qio_channel_print_literal(false, _channel_internal, _trues(1), _trues(1).length:ssize_t);
+      return qio_channel_print_literal(false, _channel_internal, _trues(1).c_str(), _trues(1).length:ssize_t);
     } else {
-      return qio_channel_print_literal(false, _channel_internal, _falses(1), _falses(1).length:ssize_t);
+      return qio_channel_print_literal(false, _channel_internal, _falses(1).c_str(), _falses(1).length:ssize_t);
     }
   } else if isIntegralType(t) {
     // handles int types

--- a/test/release/examples/primers/sparse.chpl
+++ b/test/release/examples/primers/sparse.chpl
@@ -176,8 +176,6 @@ writeln();
 //
 // ...reductions can be taken...
 //
-writeln("FOO");
-writeln(spsArr);
 var sparseSum = + reduce spsArr;
 var denseSum = + reduce [ij in dnsDom] spsArr(ij);
 


### PR DESCRIPTION
The 1*c_strings caused errors due to tuple type construction doing a
c_string->string->c_string implicit coercion. Also removed some debug
writelns in primers/sparse.chpl that got left in.

Fixed assert to use the new string type correctly.