### PR TITLE
Update printchplenv 3rd party vars to work, even when CHPL_HOME is not set.

### DIFF
--- a/util/printchplenv
+++ b/util/printchplenv
@@ -129,7 +129,12 @@ def print_mode(mode='list'):
         stdout.write('CHPL_MAKE_LAUNCHER_SUBDIR=')
         print_mode('launcher')
 
-        third_party_pkgs = chpl_home+'/util/chplenv/third-party-pkgs'
+        if chpl_home:
+            util_dir = os.path.join(chpl_home, 'util')
+        else:
+            util_dir = os.path.abspath(os.path.dirname(__file__))
+        third_party_pkgs = os.path.join(util_dir, 'chplenv', 'third-party-pkgs')
+
         all_3p_pkgs=subprocess.Popen([third_party_pkgs],
                                      stdout=subprocess.PIPE).communicate()[0].strip()
 


### PR DESCRIPTION
Previously, if CHPL_HOME was unset, printchplenv would fail with an OSError and
stack trace when trying to run third-party-pkgs. This is due to CHPL_HOME
defaulting to empty string if not set in environment, then calculating the path
to third-party-pkgs script using CHPL_HOME as part of the path (e.g. the path
calculation was: '' + '/util/chplenv/third-party-pkgs').

Update third-party-pkgs path calculation to use path relative to `__file__` (aka
the running printchplenv script) when CHPL_HOME is unset.

To reproduce the error on master (before this change), use:

```bash
( unset CHPL_HOME ; ./util/printchplenv --make )
```