### PR TITLE
Add version detection macros to runtime/include/chpl-comp-detect-macros.h

### DIFF
--- a/runtime/include/chpl-comp-detect-macros.h
+++ b/runtime/include/chpl-comp-detect-macros.h
@@ -27,6 +27,8 @@
 #define RT_COMP_GCC 8
 #define RT_COMP_PGI 16
 
+// Detect backend compiler
+
 #if defined(_CRAYC)
 #define RT_COMP_CC RT_COMP_CRAY
 #elif defined(__INTEL_COMPILER)
@@ -35,10 +37,63 @@
 #define RT_COMP_CC RT_COMP_CLANG
 #elif defined(__PGI)
 #define RT_COMP_CC RT_COMP_PGI
+// Note: This check for gcc must come last since other compilers
+// also define __GNUC__ to declare library/extension compatibility
 #elif defined(__GNUC__)
 #define RT_COMP_CC RT_COMP_GCC
 #else
 #define RT_COMP_CC RT_COMP_UNKNOWN
+#endif
+
+
+// Detect backend compiler version. This does not provide a single macro
+// for all compilers but instead provides a unique macro for each
+// compiler since there's no uniform versioning scheme. This primarily
+// serves as a means to avoid looking up each compiler's versioning
+// scheme (they can be surprisingly hard to find.) These could be
+// defined above, but it makes the compiler detection hard to read. See
+// the commit message for links to documentation on these macros.
+
+//  Version number format:
+//  - Cray  : _RELEASE_MAJOR, _RELEASE_MINOR
+//  - Intel : __INTEL_COMPILER
+//  - Clang : < Use Feature Checking Macros Instead >
+//  - GCC   : __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__
+//  - PGI   : __PGIC__, __PGIC_MINOR__, __PGIC_PATCHLEVEL__
+
+#if RT_COMP_CC == RT_COMP_CRAY
+#define RT_COMP_CRAY_VERSION_MAJOR _RELEASE_MAJOR
+#define RT_COMP_CRAY_VERSION_MINOR _RELEASE_MINOR
+
+#elif RT_COMP_CC == RT_COMP_INTEL
+// Intel only has a single macro for the version and the form isn't well
+// documented. I think it's supposed to be VersionMinorPatch, but
+// patch seems to always be zero. I *think* minor is always a single
+// digit and this seems consistent with Boost's usage.
+// For example: 5.0 => 500, 13.1.3 => 1310, 15.0.2 => 1500
+#define RT_COMP_INTEL_VERSION __INTEL_COMPILER
+
+#elif RT_COMP_CC == RT_COMP_CLANG
+// NOTE: Clang version macros are NOT provided as their version
+// macros are the marketing version numbers. From clang's website:
+// "Note that marketing version numbers should not be used to check
+// for language features, as different vendors use different
+// numbering schemes. Instead, use the Feature Checking Macros."
+
+#elif RT_COMP_CC == RT_COMP_PGI
+#define RT_COMP_PGI_VERSION_MAJOR __PGIC__
+#define RT_COMP_PGI_VERSION_MINOR __PGIC_MINOR__
+#define RT_COMP_PGI_VERSION_PATCH __PGIC_PATCHLEVEL__
+
+#elif RT_COMP_CC == RT_COMP_GCC
+#define RT_COMP_GCC_VERSION_MAJOR __GNUC__
+#define RT_COMP_GCC_VERSION_MINOR __GNUC_MINOR__
+#define RT_COMP_GCC_VERSION_PATCH __GNUC_PATCHLEVEL__
+// Easier to read macro, mentioned on the GCC predefined macro page,
+// so it's safe to assume this will always be valid
+#define RT_COMP_GCC_VERSION (__GNUC__ * 10000 \
+                                      + __GNUC_MINOR__ * 100 \
+                                      + __GNUC_PATCHLEVEL__)
 #endif
 
 #endif // _chpl_rt_comp_detect_h_


### PR DESCRIPTION
runtime/include/chpl-comp-detect-macros.h contains code to detect which backend
compiler is being used. This adds version detection macros for all our backend
compilers primarily for feature detection. These are required for the upcoming
vectorize-loop-followers patch that attaches the ivdep pragma to loops in
follower iterators. It is being added separately so the links/info at the end
of this commit message can be easily found in the commit history.

This does not provide a single macro for all compilers but instead provides
unique macros for each compiler (since there's no uniform versioning scheme
between compilers and you want to be explicit about which compiler you're
checking.) This primarily serves as a means to avoid having to look up how each
compiler stores it's version number since the information isn't that easy to
find.

Version number schemes:
```
- Cray  : _RELEASE_MAJOR, _RELEASE_MINOR
- Intel : __INTEL_COMPILER
- Clang : __clang_major__, __clang_minor__, __clang_patchlevel__
- GCC   : __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__
- PGI   : __PGIC__, __PGIC_MINOR__, __PGIC_PATCHLEVEL__
```

These are the links I used for each compiler:
```
- Cray  : http://docs.cray.com/books/S-2179-83/S-2179-83.pdf
- Intel : https://software.intel.com/sites/products/documentation/doclib/iss/2013/compiler/cpp-lin/GUID-603F2191-6FC2-4EE6-8B94-55C7CAD72D2E.htm
- Clang : http://clang.llvm.org/docs/LanguageExtensions.html#builtin-macros
- GCC   : https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
- PGI   : http://sourceforge.net/p/predef/wiki/Compilers/
- Misc  : http://nadeausoftware.com/articles/2012/10/c_c_tip_how_detect_compiler_name_and_version_using_compiler_predefined_macros
```

Confirmed by checking the predefined macros for each compiler:
```
- Cray  : cc -Wp,-list_final_macros -E <test c file (can't be /dev/null)>
- Intel : icc -dM -E -x c /dev/null
- Clang : clang -dM -E -x c /dev/null
- GCC   : gcc -dM -E -x c /dev/null
- PGI   : pgcc  -dM -E
```

Note that the major version for cray is _RELEASE_MAJOR *NOT* _RELEASE. _RELEASE
used to be what the docs specified, but there was a bug where _RELEASE reported
the wrong version for the c compiler. Since 8.3 the docs (and a closed bug) say
to use _RELEASE_MAJOR. The _RELEASE_MAJOR macro has been around for years so we
can rely on it, it just wasn't documented.

Note that the clang version macros are not provided because their version
macros use marketing version numbers. The clang website insists that they are
*NOT* to be used for feature detection as "different vendors use different
numbering schemes." Instead their feature detection macros should be used.
