### PR TITLE
Add a check in the bulk optimization to avoid memcpy(a,a)

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1057,11 +1057,13 @@ module DefaultRectangular {
         writeln("\tlocal get() from ", B._value.locale.id);
       const dest = this.theData;
       const src = B._value.theData;
-      __primitive("chpl_comm_get",
+      if dest != src {
+        __primitive("chpl_comm_get",
                   __primitive("array_get", dest, getDataIndex(Alo)),
                   B._value.data.locale.id,
                   __primitive("array_get", src, B._value.getDataIndex(Blo)),
                   len);
+      }
     } else if B._value.data.locale.id==here.id {
       if debugDefaultDistBulkTransfer then
         writeln("\tlocal put() to ", this.locale.id);


### PR DESCRIPTION
Continuing PR #1410, it seems that sometimes two Chapel
arrays can have the same underlying data even if the _value
is different. I think this is from array slicing or aliasing,
and the symptom is that the madness tests fail with the
previous patch.

In this patch, I adjust the module code for bulk optimization
to directly check for src==dst before doing the call to
comm get. That resolves the errors with the madness tests.