### PR TITLE
Repair problems in yesterday's third-party integration changes.

### DIFF
--- a/util/chplenv/__init__.py
+++ b/util/chplenv/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     'chpl_threads',
     'chpl_timers',
     'chpl_wide_pointers',
+    'utils',
     # third-party package configuration helpers
     'chpl_3p_dlmalloc_configs',
     'chpl_3p_gmp_configs',

--- a/util/chplenv/chpl_3p_gmp_configs.py
+++ b/util/chplenv/chpl_3p_gmp_configs.py
@@ -8,5 +8,9 @@ def get_uniq_cfg_path():
     return third_party_utils.default_uniq_cfg_path()
 
 @memoize
-def get_link_args():
-    return third_party_utils.default_get_link_args('gmp')
+def get_link_args(gmp):
+    if gmp == 'gmp':
+        return third_party_utils.default_get_link_args('gmp')
+    elif gmp == 'system':
+        return ['-lgmp']
+    return []

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -3,20 +3,19 @@ import sys, os
 
 import chpl_arch, chpl_compiler, chpl_platform, utils
 from utils import memoize
+from chplenv import chpl_3p_gmp_configs
 
 @memoize
 def get():
     gmp_val = os.environ.get('CHPL_GMP')
     if not gmp_val:
         target_platform = chpl_platform.get('target')
-        target_compiler = chpl_compiler.get('target')
-        target_arch = chpl_arch.get('target', map_to_compiler=True, get_lcd=True)
 
         # Detect if gmp has been built for this configuration.
         chpl_home = utils.get_chpl_home()
-        gmp_target_dir = '{0}-{1}-{2}'.format(target_platform, target_compiler, target_arch)
+        uniq_cfg_path = chpl_3p_gmp_configs.get_uniq_cfg_path()
         gmp_subdir = os.path.join(chpl_home, 'third-party', 'gmp',
-                                  'install', gmp_target_dir)
+                                  'install', uniq_cfg_path)
 
         if os.path.exists(os.path.join(gmp_subdir, 'include', 'gmp.h')):
             gmp_val = 'gmp'

--- a/util/chplenv/chpl_regexp.py
+++ b/util/chplenv/chpl_regexp.py
@@ -3,18 +3,16 @@ import sys, os
 
 import chpl_arch, chpl_platform, chpl_compiler, utils
 from utils import memoize
+from chplenv import chpl_3p_re2_configs
 
 @memoize
 def get():
     regexp_val = os.environ.get('CHPL_REGEXP')
     if not regexp_val:
-        target_platform = chpl_platform.get('target')
-        target_compiler = chpl_compiler.get('target')
-        target_arch = chpl_arch.get('target', map_to_compiler=True, get_lcd=True)
         chpl_home = utils.get_chpl_home()
-        regexp_target_dir = '{0}-{1}-{2}'.format(target_platform, target_compiler, target_arch)
+        uniq_cfg_path = chpl_3p_re2_configs.get_uniq_cfg_path()
         regexp_subdir = os.path.join(chpl_home, 'third-party', 're2', 'install',
-                                     regexp_target_dir)
+                                     uniq_cfg_path)
         regexp_header = os.path.join(regexp_subdir, 'include', 're2', 're2.h')
         if os.path.exists(regexp_header):
             regexp_val = 're2'

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -13,10 +13,13 @@ import chpl_locale_model
 #
 @memoize
 def default_uniq_cfg_path():
+    chpl_home = os.environ.get('CHPL_HOME', '')
+    chpl_module_home = os.environ.get('CHPL_MODULE_HOME', '')
+    arch_get_lcd = (chpl_home == chpl_module_home) and (chpl_home != '')
     return '{0}-{1}-{2}'.format(chpl_platform.get('target'),
                                 chpl_compiler.get('target'),
                                 chpl_arch.get('target', map_to_compiler=True,
-                                              get_lcd=False))
+                                              get_lcd=arch_get_lcd))
 
 #
 # Return libraries and other options mentioned in the old_library and

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -13,13 +13,10 @@ import chpl_locale_model
 #
 @memoize
 def default_uniq_cfg_path():
-    chpl_home = os.environ.get('CHPL_HOME', '')
-    chpl_module_home = os.environ.get('CHPL_MODULE_HOME', '')
-    arch_get_lcd = (chpl_home == chpl_module_home) and (chpl_home != '')
     return '{0}-{1}-{2}'.format(chpl_platform.get('target'),
                                 chpl_compiler.get('target'),
                                 chpl_arch.get('target', map_to_compiler=True,
-                                              get_lcd=arch_get_lcd))
+                                              get_lcd=utils.using_chapel_module()))
 
 #
 # Return libraries and other options mentioned in the old_library and

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -25,7 +25,7 @@ def get_chpl_home():
 @memoize
 def using_chapel_module():
     chpl_home = os.environ.get('CHPL_HOME', '')
-    if chpl_home != None:
+    if chpl_home is not None:
         return chpl_home == os.environ.get('CHPL_MODULE_HOME', '')
     return False
 

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -25,7 +25,7 @@ def get_chpl_home():
 @memoize
 def using_chapel_module():
     chpl_home = os.environ.get('CHPL_HOME', '')
-    if chpl_home != '':
+    if chpl_home != None:
         return chpl_home == os.environ.get('CHPL_MODULE_HOME', '')
     return False
 

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -23,6 +23,13 @@ def get_chpl_home():
     return chpl_home
 
 @memoize
+def using_chapel_module():
+    chpl_home = os.environ.get('CHPL_HOME', '')
+    if chpl_home != '':
+        return chpl_home == os.environ.get('CHPL_MODULE_HOME', '')
+    return False
+
+@memoize
 def get_compiler_version(compiler):
     CompVersion = namedtuple('CompVersion', ['major', 'minor'])
     if 'gnu' in compiler:

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -45,7 +45,7 @@ def print_mode(mode='list'):
         print_var('CHPL_TARGET_PLATFORM', target_platform, mode)
         print_var('CHPL_TARGET_COMPILER', target_compiler, mode)
 
-    get_module_lcd = ( (chpl_home == chpl_module_home) and (chpl_home != '') and
+    get_module_lcd = ( utils.using_chapel_module() and
                      (mode == 'runtime' or mode == 'make') )
     if m != 'compiler' and m != 'launcher':
         target_arch = chpl_arch.get('target', mode == 'make', get_module_lcd)

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -129,52 +129,48 @@ def print_mode(mode='list'):
         stdout.write('CHPL_MAKE_LAUNCHER_SUBDIR=')
         print_mode('launcher')
 
-        if chpl_home:
-            util_dir = os.path.join(chpl_home, 'util')
-        else:
-            util_dir = os.path.abspath(os.path.dirname(__file__))
-        third_party_pkgs = os.path.join(util_dir, 'chplenv', 'third-party-pkgs')
-
-        all_3p_pkgs=subprocess.Popen([third_party_pkgs],
-                                     stdout=subprocess.PIPE).communicate()[0].strip()
-
         link_args_3p = []
-        for pkg in all_3p_pkgs.split(' '):
-            if pkg == 'dlmalloc':
-                print_var('  CHPL_DLMALLOC_UNIQ_CFG_PATH',
-                          chpl_3p_dlmalloc_configs.get_uniq_cfg_path(),
-                          mode, filters=('runtime',))
-                link_args_3p.extend(chpl_3p_dlmalloc_configs.get_link_args())
-            elif pkg == 'gmp':
-                print_var('  CHPL_GMP_UNIQ_CFG_PATH',
-                          chpl_3p_gmp_configs.get_uniq_cfg_path(),
-                          mode, filters=('runtime',))
-                link_args_3p.extend(chpl_3p_gmp_configs.get_link_args())
-            elif pkg == 'hwloc':
-                print_var('  CHPL_HWLOC_UNIQ_CFG_PATH',
-                          chpl_3p_hwloc_configs.get_uniq_cfg_path(),
-                          mode, filters=('runtime',))
-                link_args_3p.extend(chpl_3p_hwloc_configs.get_link_args())
-            elif pkg == 'massivethreads':
-                print_var('  CHPL_MASSIVETHREADS_UNIQ_CFG_PATH',
-                          chpl_3p_massivethreads_configs.get_uniq_cfg_path(),
-                          mode, filters=('runtime',))
-                link_args_3p.extend(chpl_3p_massivethreads_configs.get_link_args())
-            elif pkg == 'qthreads':
-                print_var('  CHPL_QTHREAD_UNIQ_CFG_PATH',
-                          chpl_3p_qthreads_configs.get_uniq_cfg_path(),
-                          mode, filters=('runtime',))
-                link_args_3p.extend(chpl_3p_qthreads_configs.get_link_args())
-            elif pkg == 're2':
-                print_var('  CHPL_RE2_UNIQ_CFG_PATH',
-                          chpl_3p_re2_configs.get_uniq_cfg_path(),
-                          mode, filters=('runtime',))
-                link_args_3p.extend(chpl_3p_re2_configs.get_link_args())
-            elif pkg == 'tcmalloc':
-                print_var('  CHPL_TCMALLOC_UNIQ_CFG_PATH',
-                          chpl_3p_tcmalloc_configs.get_uniq_cfg_path(),
-                          mode, filters=('runtime',))
-                link_args_3p.extend(chpl_3p_tcmalloc_configs.get_link_args())
+
+        print_var('  CHPL_DLMALLOC_UNIQ_CFG_PATH',
+                  chpl_3p_dlmalloc_configs.get_uniq_cfg_path(),
+                  mode, filters=('runtime',))
+        if target_mem == 'dlmalloc':
+            link_args_3p.extend(chpl_3p_dlmalloc_configs.get_link_args())
+
+        print_var('  CHPL_GMP_UNIQ_CFG_PATH',
+                  chpl_3p_gmp_configs.get_uniq_cfg_path(),
+                  mode, filters=('runtime',))
+        link_args_3p.extend(chpl_3p_gmp_configs.get_link_args(gmp))
+
+        print_var('  CHPL_HWLOC_UNIQ_CFG_PATH',
+                  chpl_3p_hwloc_configs.get_uniq_cfg_path(),
+                  mode, filters=('runtime',))
+        if hwloc == 'hwloc':
+            link_args_3p.extend(chpl_3p_hwloc_configs.get_link_args())
+
+        print_var('  CHPL_MASSIVETHREADS_UNIQ_CFG_PATH',
+                  chpl_3p_massivethreads_configs.get_uniq_cfg_path(),
+                  mode, filters=('runtime',))
+        if tasks == 'massivethreads':
+            link_args_3p.extend(chpl_3p_massivethreads_configs.get_link_args())
+
+        print_var('  CHPL_QTHREAD_UNIQ_CFG_PATH',
+                  chpl_3p_qthreads_configs.get_uniq_cfg_path(),
+                  mode, filters=('runtime',))
+        if tasks == 'qthreads':
+            link_args_3p.extend(chpl_3p_qthreads_configs.get_link_args())
+
+        print_var('  CHPL_RE2_UNIQ_CFG_PATH',
+                  chpl_3p_re2_configs.get_uniq_cfg_path(),
+                  mode, filters=('runtime',))
+        if regexp == 're2':
+            link_args_3p.extend(chpl_3p_re2_configs.get_link_args())
+
+        print_var('  CHPL_TCMALLOC_UNIQ_CFG_PATH',
+                  chpl_3p_tcmalloc_configs.get_uniq_cfg_path(),
+                  mode, filters=('runtime',))
+        if target_mem == 'tcmalloc':
+            link_args_3p.extend(chpl_3p_tcmalloc_configs.get_link_args())
 
         link_args_3p_dedup=[]
         for arg in reversed(link_args_3p):


### PR DESCRIPTION
PR #1343 made big changes in how third-party packages are integrated
into Chapel, but unfortunately it also broke some things.  Here I'm
fixing those errors.

The major problem was that we ended up with a mismatch in the unique
configuration path for gmp and re2, between the chpl_*pkg*.py scripts
which needed that path to see if an install had already been done, and
(effectively) the chpl_3p_*pkg*\_configs.py scripts which specified that
path.  There were actually two problems.  One was that we didn't have
the uniq-cfg-path set at all on a clean checkout, because printchplenv
was only running the chpl_3p_*pkg*_configs.py scripts for the third-party
packages that had already been built.  The other was that in some cases
we were using the LCD of the target architecture and in others we were
not.

The major change here is that now we set the uniq-cfg-path make vars
in printchplenv for all third-party packages, whether or not we've built
them yet.  (We still only set the link-args variables for those that
have been built, though.)

The other change is in third_party_utils.py, where we use the same logic
that printchplenv does to decide whether or not to ask for the LCD of
the target architecture when building the default uniq-cfg-path.

In chpl_gmp.py and chpl_re2.py, we now get the uniq-cfg-path from the
corresponding chpl_3p_*pkg*_configs.py scripts instead of building it
ourselves.  This ensures that the installs and the subsequent checks for
installs use the same uniq-cfg-path.

And finally, now chpl_3p_gmp_configs.py returns the right link-args when
CHPL_GMP=system, with a little bit of help from printchplenv.  It didn't
do this before.  That problem hadn't yet been noticed but I spotted it
when I was working on the other stuff here.