### PR TITLE
Bug fix and cleanup for leader/standalone iter marking during resolution

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6163,8 +6163,6 @@ static void resolveReturnType(FnSymbol* fn)
 }
 
 // Simple wrappers to check if a function is a specific type of iterator
-// TODO (Elliot 03/03/15): These should become methods on FnSymbol, especially
-// if they become useful anywhere else.
 static bool isIteratorOfType(FnSymbol* fn, Symbol* iterTag) {
   if (fn->isIterator()) {
     for_formals(formal, fn) {
@@ -6199,14 +6197,12 @@ resolveFns(FnSymbol* fn) {
     return;
 
   //
-  // mark leaders and standalone parallel iterators for inlining
+  // Mark leader and standalone parallel iterators for inlining. Also stash a
+  // pristine copy of the iterator (required by forall intents)
   //
-  if (isLeaderIterator(fn)) {
+  if (isLeaderIterator(fn) || isStandaloneIterator(fn)) {
     fn->addFlag(FLAG_INLINE_ITERATOR);
-    // need to do the following before 'fn' gets resolved
     stashPristineCopyOfLeaderIter(fn, /*ignore_isResolved:*/ true);
-  } else if (isStandaloneIterator(fn)) {
-    fn->addFlag(FLAG_INLINE_ITERATOR);
   }
 
   if (fn->retTag == RET_REF) {


### PR DESCRIPTION
Cleans up how leader and standalone iterators are marked for inlining during
function resolution and fixes a bug where a pristine copy of the standalone
iterator (required for forall intents) was not being stashed.

Adds helper routines that check if a function is a specific type of iterator
(leader, standalone, follower.) These functions are then used to find leader
and standalone iterators and mark them for inlining. This separates the logic
of checking if a fn is a particular iterator from whatever you want to do with
the iterator.

This also moves the standalone marking up with the leader marking.

This is a peeled off commit from my vectorize-follower-loops patch (which also
adds and uses an isFollowerIterator function())


During review Vass noticed that we should also be stashing a pristine copy of
the standalone iterator.

A better description from Vass:
"
With the introduction of standalone iterators, the forall intent
machinery has been extended to apply to them, too. Standalone iterators
are treated much like leader iterators for forall intents. (The function
names and comments in implementForallIntents.cpp are still heavy in
leader-follower terminology - for historical reasons.)

This change fixes an omission in the above - we need to "stash pristine
copies" of standalone iterators just like we do leader iterators. The
omission has not caused us trouble yet perhaps because we have not used
standalone iterators in some ways that we have leaders.