### PR TITLE
Bug fix: Stash a pristine copy of standalone iters like we do for leaders

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6251,6 +6251,8 @@ resolveFns(FnSymbol* fn) {
       }
       if (formal->type == gStandaloneTag->type &&
           paramMap.get(formal) == gStandaloneTag) {
+        // need to do the following before 'fn' gets resolved
+        stashPristineCopyOfLeaderIter(fn, /*ignore_isResolved:*/ true);
         // Standalone iterators are always inlined.
         fn->addFlag(FLAG_INLINE_ITERATOR);
       }


### PR DESCRIPTION
Noticed during a review of a patch that cleans up the code that marks leader
and standalone iterators for inlining.

A better description from Vass:
"
With the introduction of standalone iterators, the forall intent
machinery has been extended to apply to them, too. Standalone iterators
are treated much like leader iterators for forall intents. (The function
names and comments in implementForallIntents.cpp are still heavy in
leader-follower terminology - for historical reasons.)

This change fixes an omission in the above - we need to "stash pristine
copies" of standalone iterators just like we do leader iterators. The
omission has not caused us trouble yet perhaps because we have not used
standalone iterators in some ways that we have leaders.
"