### PR TITLE
Update AstPrintDocs visitor to correctly handle "no doc" pragmas on submodules.

### DIFF
--- a/compiler/AST/AstPrintDocs.cpp
+++ b/compiler/AST/AstPrintDocs.cpp
@@ -78,6 +78,12 @@ bool AstPrintDocs::enterFnSym(FnSymbol* node) {
 
 
 bool AstPrintDocs::enterModSym(ModuleSymbol* node) {
+  // If a module is not supposed to be documented, do not traverse into it (and
+  // skip the documentation).
+  if (node->hasFlag(FLAG_NO_DOC)) {
+      return false;
+  }
+
   // If this is a sub module (i.e. other modules were entered and not yet
   // exited before this one), ensure the docs naming is correct.
   if (!this->moduleNames.empty()) {
@@ -98,6 +104,12 @@ bool AstPrintDocs::enterModSym(ModuleSymbol* node) {
 
 
 void AstPrintDocs::exitModSym(ModuleSymbol* node) {
+  // If module is not supposed to be documented, it was not traversed into or
+  // documented, so exit early from this method.
+  if (node->hasFlag(FLAG_NO_DOC)) {
+    return;
+  }
+
   // Remove the current module from stack of names.
   assert(!this->moduleNames.empty());
   this->moduleNames.pop();

--- a/test/chpldoc/nodoc/noDocPlease.chpl
+++ b/test/chpldoc/nodoc/noDocPlease.chpl
@@ -64,6 +64,14 @@ module Foo {
     var showMe: bool;
     // This is the only field that should be printed
   }
+
+  /* This is an undocumented module. */
+  pragma "no doc"
+  module invisible {
+
+    /* This class is undocumented, since its module is undocumented. */
+    class MyC {}
+  }
 }
 
 pragma "no doc"


### PR DESCRIPTION
Previously, the "no doc" pragma was ignored when traversing submodules. The
module documentation would not be produced (correcty), but traversal would not
stop so anything inside the submodule would be documented (incorrect).

Update the visitor to check if the module has the "no doc" pragma, and, if so,
stop the AST traversal and avoid documenting the submodule.

Update existing no doc test to exercise this issue, and the fix.