### PR TITLE
Disallow arguments of type string for extern procs

### DIFF
--- a/spec/Interoperation.tex
+++ b/spec/Interoperation.tex
@@ -171,7 +171,7 @@ C Type & Chapel Type & C Type & Chapel Type & C Type & Chapel Type \\
 \tt int16\_t & \tt int(16) & \tt uint16\_t & \tt uint(16) & \tt \_real64 & \tt real(64) \\
 \tt int32\_t & \tt int(32) & \tt uint32\_t & \tt uint(32) & \tt \_imag32 & \tt imag(32) \\
 \tt int64\_t & \tt int(64) & \tt uint64\_t & \tt uint(64) & \tt \_imag64 & \tt imag(64) \\
-\tt chpl\_bool & \tt bool & \tt  const char* & \tt string \\
+\tt chpl\_bool & \tt bool & \tt  const char* & \tt c\_string \\
 \tt \_complex64 & \tt complex(64) & \tt \_complex128 & \tt complex(128) \\
 \end{tabular}
 
@@ -422,7 +422,7 @@ C varargs functions can be declared using
 Chapel's \sntx{variable-argument-expression} syntax (\chpl{...}).  For example,
 the C \chpl{printf} function can be declared in Chapel as
 \begin{chapel}
-       extern proc printf(fmt: string, vals...?numvals): int;
+       extern proc printf(fmt: c_string, vals...?numvals): int;
 \end{chapel}
 
 External C functions or macros that accept type arguments can also be

--- a/test/extern/bradc/defaultArgsNoLocal.chpl
+++ b/test/extern/bradc/defaultArgsNoLocal.chpl
@@ -1,4 +1,4 @@
-extern proc chpl_mem_realloc(ptr, size, description, lineno=-1, filename=""): opaque;
+extern proc chpl_mem_realloc(ptr, size, description, lineno=-1, filename:c_string=""): opaque;
 
 var x: opaque;
 chpl_mem_realloc(x, numBytes(int(64)), 0);

--- a/test/extern/ferguson/readme_examples.chpl
+++ b/test/extern/ferguson/readme_examples.chpl
@@ -25,9 +25,7 @@ byRef(x); // ref argument intent allows the variable to be passed directly
 byPtr(c_ptrTo(x)); // c_ptr argument must be constructed explicitly
 
 // both of these correspond to void fn(const char* x)
-extern proc byString(x:string);
 extern proc byCString(x:c_string);
 
-byString("Hello");
 byCString("Hello".c_str());
 

--- a/test/extern/ferguson/readme_examples.good
+++ b/test/extern/ferguson/readme_examples.good
@@ -11,5 +11,4 @@ c_ptr(int(32))
 9
 byRef(ptr to 7)
 byPtr(ptr to 7)
-byString(Hello)
 byCString(Hello)

--- a/test/extern/ferguson/readme_examples.h
+++ b/test/extern/ferguson/readme_examples.h
@@ -4,10 +4,6 @@ static void byRef(int* x) {
 static void byPtr(int* x) {
   printf("byPtr(ptr to %i)\n", *x);
 }
-static void byString(const char* x)
-{
-  printf("byString(%s)\n", x);
-}
 static void byCString(const char* x)
 {
   printf("byCString(%s)\n", x);

--- a/test/extern/hilde/namedExtern.chpl
+++ b/test/extern/hilde/namedExtern.chpl
@@ -10,7 +10,7 @@ extern printf proc cprintf(fmt: c_string, arg...): int;
 
 var i = 19: int(32); // using an int(32) to up the odds this works with %d
 var f = 63.0;
-var s = "pwh";
+var s: c_string = "pwh";
 
 cprintf("%d %f %s\n", i, f, s);
 cprintf("Done.\n");

--- a/test/extern/kbrady/extern_string.chpl
+++ b/test/extern/kbrady/extern_string.chpl
@@ -1,0 +1,2 @@
+extern proc printf(str: string);
+printf("test string\n");

--- a/test/extern/kbrady/extern_string.good
+++ b/test/extern/kbrady/extern_string.good
@@ -1,0 +1,1 @@
+extern_string.chpl:1: error: extern procedures should not take arguments of type string, use c_string instead

--- a/test/extern/kbrady/extern_string_generic.chpl
+++ b/test/extern/kbrady/extern_string_generic.chpl
@@ -1,0 +1,5 @@
+extern proc printf(format: c_string, args ...);
+printf("%s", "test1\n");
+printf("%s", "test2\n");
+printf("%s", "test3\n");
+printf("%s", "test4\n");

--- a/test/extern/kbrady/extern_string_generic.good
+++ b/test/extern/kbrady/extern_string_generic.good
@@ -1,0 +1,6 @@
+extern_string_generic.chpl:1: error: extern procedure has arguments of type string
+extern_string_generic.chpl:2: note: when instantiated from here
+extern_string_generic.chpl:3: note: when instantiated from here
+extern_string_generic.chpl:4: note: when instantiated from here
+extern_string_generic.chpl:5: note: when instantiated from here
+extern_string_generic.chpl:1: note: use c_string instead

--- a/test/io/vass/time-write.chpl
+++ b/test/io/vass/time-write.chpl
@@ -73,12 +73,12 @@ extern proc cs_trial(n: int);
 proc lstr_trial() {
   extern proc printf(format: c_string, arg...);
   for 1..n do
-    printf("%s", "\n");
+    printf("%s", "\n".c_str());
 }
 
 proc lcs_trial() {
   extern proc printf(format: c_string, arg...);
-  const c_newline_local = "\n".c_str();
+  const c_newline_local: c_string = "\n";
   for 1..n do
     printf("%s", c_newline_local);
 }
@@ -90,7 +90,7 @@ proc gstr_trial() {
     printf("%s", str_newline_global.c_str());
 }
 
-const c_newline_global = "\n".c_str();
+const c_newline_global: c_string = "\n";
 proc gcs_trial() {
   extern proc printf(format: c_string, arg...);
   for 1..n do

--- a/test/memory/shannon/outofmemory/mallocOutOfMemory.chpl
+++ b/test/memory/shannon/outofmemory/mallocOutOfMemory.chpl
@@ -1,4 +1,4 @@
-extern proc chpl_mem_allocMany(number, size, description, lineno = -1, filename = ""): opaque;
+extern proc chpl_mem_allocMany(number, size, description, lineno = -1, filename: c_string = ""): opaque;
 
 for 1..1000 {
   var i = 1000000;

--- a/test/optimizations/cache-remote/ferguson/correctness/acqrel-sync-subtask.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/acqrel-sync-subtask.chpl
@@ -4,7 +4,7 @@ config const max=100;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/acqrel-sync.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/acqrel-sync.chpl
@@ -4,7 +4,7 @@ config const max=100;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/acqrel.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/acqrel.chpl
@@ -4,7 +4,7 @@ config const max=100;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/atomic1.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/atomic1.chpl
@@ -1,5 +1,5 @@
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 
 //
 // privateSpace.chpl: This example demonstrates the use of PrivateSpace to

--- a/test/optimizations/cache-remote/ferguson/correctness/atomic2.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/atomic2.chpl
@@ -1,5 +1,5 @@
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 
 config var n: int = 8;
 

--- a/test/optimizations/cache-remote/ferguson/correctness/atomic3.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/atomic3.chpl
@@ -1,5 +1,5 @@
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 
 use BlockDist;
 

--- a/test/optimizations/cache-remote/ferguson/correctness/cobegin.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/cobegin.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/cobegin2.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/cobegin2.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/cobegin3.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/cobegin3.chpl
@@ -7,7 +7,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/cobegin4.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/cobegin4.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/coforall.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/coforall.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/coforall2.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/coforall2.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/coforall3.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/coforall3.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/coforall4.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/coforall4.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/forall.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/forall.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/forall2.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/forall2.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/forall3.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/forall3.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/forall4.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/forall4.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/ontest.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/ontest.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/ontest0-begin.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/ontest0-begin.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose {

--- a/test/optimizations/cache-remote/ferguson/correctness/ontest0.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/ontest0.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose {

--- a/test/optimizations/cache-remote/ferguson/correctness/ontest1.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/ontest1.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose {

--- a/test/optimizations/cache-remote/ferguson/correctness/ontest2-begin.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/ontest2-begin.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/ontest2.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/ontest2.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/ontest3.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/ontest3.chpl
@@ -3,7 +3,7 @@ config const verbose=false;
 
 proc doit(a:locale, b:locale, c:locale)
 {
-  extern proc printf(fmt: string, vals...?numvals): int;
+  extern proc printf(fmt: c_string, vals...?numvals): int;
  
   on a {
     if verbose then printf("on %d\n", here.id:c_int);

--- a/test/optimizations/cache-remote/ferguson/correctness/ontest4.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/ontest4.chpl
@@ -1,6 +1,6 @@
 extern proc chpl_cache_print();
-extern proc chpl_cache_fence(acquire:c_int, release:c_int, ln:int(32), fn:string);
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc chpl_cache_fence(acquire:c_int, release:c_int, ln:int(32), fn:c_string);
+extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
 var barriers:[1..16] int;

--- a/test/optimizations/cache-remote/ferguson/correctness/prefetch.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/prefetch.chpl
@@ -1,5 +1,5 @@
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
 on Locales[1] {

--- a/test/optimizations/cache-remote/ferguson/correctness/prefetch_rev.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/prefetch_rev.chpl
@@ -1,5 +1,5 @@
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
 on Locales[1] {

--- a/test/optimizations/cache-remote/ferguson/correctness/prefetch_rev_strided.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/prefetch_rev_strided.chpl
@@ -1,5 +1,5 @@
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
 on Locales[1] {

--- a/test/optimizations/cache-remote/ferguson/correctness/prefetch_strided.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/prefetch_strided.chpl
@@ -1,5 +1,5 @@
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
 on Locales[1] {

--- a/test/optimizations/cache-remote/ferguson/correctness/seqABCread.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/seqABCread.chpl
@@ -1,6 +1,6 @@
 config const n = 40000;
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
 proc doit(memory:locale, running:locale) {

--- a/test/optimizations/cache-remote/ferguson/correctness/seqABread.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/seqABread.chpl
@@ -1,6 +1,6 @@
 config const n = 40000;
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
 proc doit(memory:locale, running:locale) {

--- a/test/optimizations/cache-remote/ferguson/correctness/seqread.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/seqread.chpl
@@ -1,6 +1,6 @@
 config const n = 40000;
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
 proc doit(memory:locale, running:locale) {

--- a/test/optimizations/cache-remote/ferguson/correctness/seqreread.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/seqreread.chpl
@@ -2,7 +2,7 @@ use Time;
 
 config const n = 10000;
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 
 proc doit(memory:locale, running:locale) {
   on memory {

--- a/test/optimizations/cache-remote/ferguson/correctness/seqrevread.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/seqrevread.chpl
@@ -1,6 +1,6 @@
 config const n = 40000;
 extern proc chpl_cache_print();
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
 proc doit(memory:locale, running:locale) {

--- a/test/optimizations/cache-remote/ferguson/correctness/t9-3.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/t9-3.chpl
@@ -3,7 +3,7 @@
 extern proc chpl_cache_print();
 pragma "insert line file info"
 config const verbose=false;
-extern proc printf(fmt: string, vals...?numvals): int;
+extern proc printf(fmt: c_string, vals...?numvals): int;
 
 
 /// label the output with "phases" //////////////////////////////////////////

--- a/test/parallel/cobegin/deitz/test_big_recursive_cobegin.chpl
+++ b/test/parallel/cobegin/deitz/test_big_recursive_cobegin.chpl
@@ -1,15 +1,15 @@
 config const n: int = 768;
 
-extern proc printf(x...);
+extern proc printf(fmt:c_string, x...);
 
 proc foo(i: int) {
   if i < n {
-    printf("%s\n", here.id + " pre " + i);
+    printf("%s\n", (here.id + " pre " + i).c_str());
     cobegin {
       foo(i+1);
       ;
     }
-    printf("%s\n", here.id + " post " + i);
+    printf("%s\n", (here.id + " post " + i).c_str());
   }
 }
 

--- a/test/studies/HDFS/tzakian/HDFS.chpl
+++ b/test/studies/HDFS/tzakian/HDFS.chpl
@@ -5,40 +5,40 @@ use SysBasic; // For c_types
 
 // Record returned by HDFS
 extern record chadoopFileInfo {
-	var mLastMod: int(32);
-	var mSize: int(64);
-	var mReplication: int(16);
-	var mBlockSize: int(64);
-	var mPermissions: int(16);
-	var mLastAccess: int(32);
+  var mLastMod: int(32);
+  var mSize: int(64);
+  var mReplication: int(16);
+  var mBlockSize: int(64);
+  var mPermissions: int(16);
+  var mLastAccess: int(32);
 }
 
 /* chadoop.h */
 extern const IS_NULL_FALSE: c_int; // To see if it is null from 
 extern const IS_NULL_TRUE: c_int;
 
-extern proc printBlockHosts_C(b: c_void_ptr, l: string);
+extern proc printBlockHosts_C(b: c_void_ptr, l: c_string);
 
 extern proc IS_NULL(ptr: c_void_ptr): c_int;
 
 extern proc chadoopFree(ptr: c_void_ptr);
-extern proc chadoopFreeString(str: string);
+extern proc chadoopFreeString(str: c_string);
 
-extern proc chadoopGetFileInfo(hdfsFS: c_void_ptr, path: string): chadoopFileInfo;
+extern proc chadoopGetFileInfo(hdfsFS: c_void_ptr, path: c_string): chadoopFileInfo;
 
 extern proc chadoopGetBlockCount(hostBlocks: c_void_ptr): int(32);
 extern proc chadoopGetHostCount(hostBlocks: c_void_ptr, block: int(32)): int(32);
-extern proc chadoopGetHost(hostBlocks: c_void_ptr, block: int(32), host: int(32)): string;
+extern proc chadoopGetHost(hostBlocks: c_void_ptr, block: int(32), host: int(32)): c_string;
 
-extern proc chadoopReadFile(hdfsFS: c_void_ptr, hdfsFile: c_void_ptr, length: int(32)): string;
-extern proc chadoopReadFilePositional(hdfsFS: c_void_ptr, hdfsFile: c_void_ptr, position: int(64), length: int(32)): string;
+extern proc chadoopReadFile(hdfsFS: c_void_ptr, hdfsFile: c_void_ptr, length: int(32)): c_string;
+extern proc chadoopReadFilePositional(hdfsFS: c_void_ptr, hdfsFile: c_void_ptr, position: int(64), length: int(32)): c_string;
 
 /* libhdfs */
 
 extern proc hdfsCloseFile(hdfsFS: c_void_ptr, hdfsFile: c_void_ptr): c_int;
 
 /* Returns hdfsFS */
-extern proc hdfsConnect(nn: string, port: c_int): c_void_ptr;
+extern proc hdfsConnect(nn: c_string, port: c_int): c_void_ptr;
 
 /* Returns tOffset (int64) */
 extern proc hdfsGetDefaultBlockSize(hdfsFS: c_void_ptr): int(64);
@@ -46,11 +46,11 @@ extern proc hdfsGetDefaultBlockSize(hdfsFS: c_void_ptr): int(64);
 extern proc hdfsFlush(hdfsFS: c_void_ptr, hdfsFile: c_void_ptr): c_int;
 
 /* Returns char*** -- see chadoopGetHosts/Blocks for more info */
-extern proc hdfsGetHosts(hdfsFS: c_void_ptr, path: string, start: int(64), length: int(64)): c_void_ptr;
+extern proc hdfsGetHosts(hdfsFS: c_void_ptr, path: c_string, start: int(64), length: int(64)): c_void_ptr;
 
 /* Returns hdfsFile */
-extern proc hdfsOpenFile(hdfsFS: c_void_ptr, path: string, flags: c_int, bufferSize: c_int, replication: int(16), blocksize: int(32)): c_void_ptr;
+extern proc hdfsOpenFile(hdfsFS: c_void_ptr, path: c_string, flags: c_int, bufferSize: c_int, replication: int(16), blocksize: int(32)): c_void_ptr;
 
 /* Returns tSize (int32) */
-extern proc hdfsWrite(hdfsFS: c_void_ptr, hdfsFile: c_void_ptr, buffer: string, length: int(32)): int(32);
+extern proc hdfsWrite(hdfsFS: c_void_ptr, hdfsFile: c_void_ptr, buffer: c_string, length: int(32)): int(32);
 

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
@@ -1,7 +1,7 @@
 use IO;
 use AdvancedIters;
 
-extern proc memcpy(x : [], b, len:int);
+extern proc memcpy(x : [], b:c_string , len:int);
 
 config const tableSize = 1 << 16;
 config const lineSize = 61;
@@ -81,7 +81,7 @@ proc write_count(data : [] uint(8), str : string) {
 
 proc string.toBytes() ref {
    var b : [1..this.length] uint(8);
-   memcpy(b, this, this.length);
+   memcpy(b, this.c_str(), this.length);
    return b;
 }
 

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
@@ -1,7 +1,7 @@
 use IO;
 use AdvancedIters;
 
-extern proc memcpy(x : [], b, len:int);
+extern proc memcpy(x : [], b:c_string, len:int);
 
 config const tableSize = 1 << 16;
 config const lineSize = 61;
@@ -135,7 +135,7 @@ proc write_count(data : [] uint(8), str : string) {
 
 proc string.toBytes() ref {
    var b : [1..this.length] uint(8);
-   memcpy(b, this, this.length);
+   memcpy(b, this.c_str(), this.length);
    return b;
 }
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
@@ -1,8 +1,8 @@
-extern proc memcpy(a:[], b, len);
+extern proc memcpy(a:[], b:c_string, len);
 
 proc string.toBytes() {
    var b : [1..this.length] uint(8);
-   memcpy(b, this, this.length);
+   memcpy(b, this.c_str(), this.length);
    return b;
 }
 

--- a/test/users/shetag/iteratorWithOn.chpl
+++ b/test/users/shetag/iteratorWithOn.chpl
@@ -1,6 +1,6 @@
 config const n = 10;
 
-extern proc printf(x...);
+extern proc printf(fmt:c_string, x...);
 
 iter g() {
   var loc = 0;
@@ -11,4 +11,4 @@ iter g() {
 }
 
 for i in g() do
-  printf("%s\n", here.id + ":i=" + i);
+  printf("%s\n", (here.id + ":i=" + i).c_str());


### PR DESCRIPTION
This change makes it a compiler error to use a string in the
prototype of a extern proc, and recommends the use of c_string instead.

Using string can cause problems due to wideness when used with extern
procedures. Additionally, when 'strings as records' goes in, users will
probably never want the actual string record to be passed out (and they
will get a C compile time error if they expected a c_string).

If it becomes necessary we can add a pragma that disables this check on
a function.