### PR TITLE
Move ScopeResolve.cpp:findOuterLoop() to LoopStmt::findEnclosingLoop()

### DIFF
--- a/compiler/AST/LoopStmt.cpp
+++ b/compiler/AST/LoopStmt.cpp
@@ -55,7 +55,7 @@ void LoopStmt::continueLabelSet(LabelSymbol* sym)
   mContinueLabel = sym;
 }
 
-LoopStmt*LoopStmt::findEnclosingLoop(Expr* expr)
+LoopStmt* LoopStmt::findEnclosingLoop(Expr* expr)
 {
   LoopStmt* retval = NULL;
 
@@ -63,7 +63,7 @@ LoopStmt*LoopStmt::findEnclosingLoop(Expr* expr)
     retval = loop;
 
   else if (expr->parentExpr)
-    retval = LoopStmt::findEnclosingLoop(expr->parentExpr);
+    retval = findEnclosingLoop(expr->parentExpr);
 
   else
     retval = NULL;

--- a/compiler/AST/LoopStmt.cpp
+++ b/compiler/AST/LoopStmt.cpp
@@ -55,3 +55,19 @@ void LoopStmt::continueLabelSet(LabelSymbol* sym)
   mContinueLabel = sym;
 }
 
+LoopStmt*LoopStmt::findEnclosingLoop(Expr* expr)
+{
+  LoopStmt* retval = NULL;
+
+  if (LoopStmt* loop = toLoopStmt(expr))
+    retval = loop;
+
+  else if (expr->parentExpr)
+    retval = LoopStmt::findEnclosingLoop(expr->parentExpr);
+
+  else
+    retval = NULL;
+
+  return retval;
+
+}

--- a/compiler/include/LoopStmt.h
+++ b/compiler/include/LoopStmt.h
@@ -33,6 +33,8 @@ public:
   LabelSymbol*           continueLabelGet()                           const;
   void                   continueLabelSet(LabelSymbol* sym);
 
+  static LoopStmt*       findEnclosingLoop(Expr* expr);
+
 protected:
                          LoopStmt(BlockStmt* initBody);
   virtual               ~LoopStmt();

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1082,15 +1082,13 @@ static void move_constructor_to_outer(FnSymbol* fn, AggregateType* outerType)
 *                                                                           *
 ************************************* | ************************************/
 
-static LoopStmt* findOuterLoop(Expr* stmt);
-
 static void resolveGotoLabels() {
   forv_Vec(GotoStmt, gs, gGotoStmts) {
     SET_LINENO(gs);
 
     if (SymExpr* label = toSymExpr(gs->label)) {
       if (label->var == gNil) {
-        LoopStmt* loop = findOuterLoop(gs);
+        LoopStmt* loop = LoopStmt::findEnclosingLoop(gs);
 
         if (!loop)
           USR_FATAL(gs, "break or continue is not in a loop");
@@ -1113,10 +1111,10 @@ static void resolveGotoLabels() {
 
     } else if (UnresolvedSymExpr* label = toUnresolvedSymExpr(gs->label)) {
       const char* name = label->unresolved;
-      LoopStmt*   loop = findOuterLoop(gs);
+      LoopStmt*   loop = LoopStmt::findEnclosingLoop(gs);
 
       while (loop && (!loop->userLabel || strcmp(loop->userLabel, name))) {
-        loop = findOuterLoop(loop->parentExpr);
+        loop = LoopStmt::findEnclosingLoop(loop->parentExpr);
       }
 
       if (!loop) {
@@ -1133,21 +1131,6 @@ static void resolveGotoLabels() {
         INT_FATAL(gs, "unexpected goto type");
     }
   }
-}
-
-static LoopStmt* findOuterLoop(Expr* stmt) {
-  LoopStmt* retval = 0;
-
-  if (LoopStmt* loop = toLoopStmt(stmt))
-    retval = loop;
-
-  else if (stmt->parentExpr)
-    retval = findOuterLoop(stmt->parentExpr);
-
-  else
-    retval = 0;
-
-  return retval;
 }
 
 /************************************ | *************************************


### PR DESCRIPTION
findOuterLoop() was a static function that lived inside of scope resolve. I need
this function outside of scope resolve for my upcoming vectorize-loop-followers
patch. I also think it will be ideal to use in Loop::insertBefore() in loop
invariant code motion, though I haven't tested it there yet.

This just moves it's definition as a static function in scope resolve to a
static method on LoopStmt. It also renames it from findOuterLoop to
findEnclosingLoop because findOuterLoop implied (at least to me) that it would
find the outer most loop in a nest of loops, which is not accurate.