### PR TITLE
Fix yet another program in my third-party integration changes.

### DIFF
--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -3,7 +3,7 @@ import sys, os
 
 import chpl_arch, chpl_compiler, chpl_platform, utils
 from utils import memoize
-from chplenv import chpl_3p_gmp_configs
+import chpl_3p_gmp_configs
 
 @memoize
 def get():

--- a/util/chplenv/chpl_regexp.py
+++ b/util/chplenv/chpl_regexp.py
@@ -3,7 +3,7 @@ import sys, os
 
 import chpl_arch, chpl_platform, chpl_compiler, utils
 from utils import memoize
-from chplenv import chpl_3p_re2_configs
+import chpl_3p_re2_configs
 
 @memoize
 def get():


### PR DESCRIPTION
The "from chplenv" clause when importing the script that contains
get_uniq_cfg_path() is neither necessary nor desirable -- remove it.