### PR TITLE
Coverity fixes

### DIFF
--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -320,10 +320,10 @@ static int processToken(yyscan_t scanner, int t) {
   if (captureTokens) {
     if (t == TASSIGN ||
         t == TDOTDOTDOT)
-      strcat(captureString, " ");
+      strncat(captureString, " ", sizeof(captureString));
 
     if (t != TLCBR)
-      strcat(captureString, yyget_text(scanner));
+      strncat(captureString, yyget_text(scanner), sizeof(captureString));
 
     if (t == TCOMMA  ||
         t == TPARAM  ||
@@ -337,7 +337,7 @@ static int processToken(yyscan_t scanner, int t) {
         t == TCOLON  ||
         t == TASSIGN ||
         t == TRSBR)
-      strcat(captureString, " ");
+      strncat(captureString, " ", sizeof(captureString));
   }
 
   // If the stack has a value then we must be in externmode.
@@ -366,9 +366,9 @@ static int processStringLiteral(yyscan_t scanner, const char* q) {
   countToken(astr(q, yyLval->pch, q));
 
   if (captureTokens) {
-    strcat(captureString, yyText);
-    strcat(captureString, yyLval->pch);
-    strcat(captureString, yyText);
+    strncat(captureString, yyText, sizeof(captureString));
+    strncat(captureString, yyLval->pch, sizeof(captureString));
+    strncat(captureString, yyText, sizeof(captureString));
   }
 
   return STRINGLITERAL;
@@ -434,7 +434,7 @@ static int processExtern(yyscan_t scanner) {
   countToken(yyText);
 
   if (captureTokens) {
-    strcat(captureString, yyText);
+    strncat(captureString, yyText, sizeof(captureString));
   }
 
   // Push a state to record that "extern" has been seen
@@ -460,7 +460,7 @@ static int processExternCode(yyscan_t scanner) {
   countToken(astr(yyLval->pch));
 
   if (captureTokens) {
-    strcat(captureString, yyLval->pch);
+    strncat(captureString, yyLval->pch, sizeof(captureString));
   }
 
   return EXTERNCODE;

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -115,8 +115,9 @@ static const char* getTempDir() {
   }
 #ifdef P_tmpdir
   return P_tmpdir;
-#endif
+#else
   return "/tmp";
+#endif
 }
 
 

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -3586,6 +3586,9 @@ void _qio_channel_write_bits_cached_realign(qio_channel_t* restrict ch, uint64_t
   tmp_live = ch->bit_buffer_bits;
   tmp_bits = ch->bit_buffer;
 
+  // ch->bit_buffer_bits should never exceed the sizeof the bitbuffer
+  assert(0 <= tmp_live && tmp_live <= 8*sizeof(qio_bitbuffer_t));
+
   // We've got > 64 bits to write.
   part_one = 8*sizeof(qio_bitbuffer_t) - tmp_live;
   part_two = nbits - part_one;
@@ -3660,6 +3663,9 @@ qioerr _qio_channel_write_bits_slow(qio_channel_t* restrict ch, uint64_t v, int8
   tmp_live = ch->bit_buffer_bits;
   tmp_bits = ch->bit_buffer;
   if( tmp_live == 0 ) tmp_bits = 0;
+
+  // ch->bit_buffer_bits should never exceed the sizeof the bitbuffer
+  assert(0 <= tmp_live && tmp_live <= 8*sizeof(qio_bitbuffer_t));
 
   //printf("In write bits slow\n");
 

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -727,6 +727,8 @@ qioerr qio_file_init(qio_file_t** file_out, FILE* fp, fd_t fd, qio_hint_t iohint
     if( fd == -1 ) return qio_mkerror_errno();
   }
 
+  if( fd < 0 ) QIO_RETURN_CONSTANT_ERROR(EINVAL, "invalid file descriptor");
+
   err = qio_int_to_err(sys_fstat(fd, &stats));
   if( err ) return err;
 

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -683,6 +683,7 @@ qioerr qio_mmap_initial(qio_file_t* file)
 
     if( file->fdflags & QIO_FDFLAG_WRITEABLE ) prot |= PROT_WRITE;
 
+    // This check is (only) important for 32-bit systems.
     if( len > SSIZE_MAX ) return QIO_ENOMEM;
 
     // mmap the initial length of the file.
@@ -2170,6 +2171,7 @@ qioerr _buffered_get_mmap(qio_channel_t* ch, int64_t amt_in, int writing)
     prot = PROT_READ;
     if( ch->flags & QIO_FDFLAG_WRITEABLE ) prot |= PROT_WRITE;
 
+    // This check is (only) important for 32-bit systems.
     if( len > SSIZE_MAX ) QIO_RETURN_CONSTANT_ERROR(EOVERFLOW, "overflow in mmap");
 
     err = qio_int_to_err(sys_mmap(NULL, len, prot, MAP_SHARED, ch->file->fd, map_start, &data));

--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -1383,18 +1383,22 @@ qioerr qio_quote_string_length(uint8_t string_start, uint8_t string_end, uint8_t
     quoted_cols += elipses_size;
   }
 
-  ti->ret_columns = quoted_cols;
-  ti->ret_chars = quoted_chars;
-  ti->ret_bytes = quoted_bytes;
-  ti->ret_truncated_at_byte = i;
-  ti->ret_truncated = overfull;
+  if( ti ) {
+    ti->ret_columns = quoted_cols;
+    ti->ret_chars = quoted_chars;
+    ti->ret_bytes = quoted_bytes;
+    ti->ret_truncated_at_byte = i;
+    ti->ret_truncated = overfull;
+  }
   return 0;
 error:
-  ti->ret_columns = -1;
-  ti->ret_chars = -1;
-  ti->ret_bytes = -1;
-  ti->ret_truncated_at_byte = -1;
-  ti->ret_truncated = -1;
+  if( ti ) {
+    ti->ret_columns = -1;
+    ti->ret_chars = -1;
+    ti->ret_bytes = -1;
+    ti->ret_truncated_at_byte = -1;
+    ti->ret_truncated = -1;
+  }
   return err;
 }
 


### PR DESCRIPTION
Fix several coverity issues. This patch should address issues
1212379 1212388 1271071 1271069 1271068 1271067 1272315
and perhaps will resolve 1241466 1238860.

Summary of changes:
 - replace strcats to captureString with strncat. I realize that captureString is supposed to go away.
Other fixes are hopefully obvious improvements to error checking.

Passed full local, fifo testing. 