### PR TITLE
 Updating REGRESSIONS based on past few days' runs

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -59,12 +59,7 @@ Reviewed 2015-03-02
 ===================
 
 assert src != dst failure (2015-02-28, michael)
-(gasnet.numa, dist-block)
------------------------------------------------
-[Error matching program output for distributions/robust/arithmetic/basics/test_reshape]
-
-assert src != dst failure (2015-02-28, michael)
-(linux32, fifo, gnu.darwin, verify, linux64, no-local, gasnet.fifo, memleaks, cygwin64, cygwin32, gasnet-fast, xe-wb.gnu, xc-wb.gnu, gasnet-everything)
+(gasnet.fifo, memleaks, cygwin64, cygwin32, gasnet-fast, xe-wb.gnu, xc-wb.gnu, gasnet-everything)
 -----------------------------------------------------------------------------
 [Error matching program output for studies/madness/aniruddha/madchap/test_diff]
 [Error matching program output for studies/madness/aniruddha/madchap/test_likepy]
@@ -78,6 +73,19 @@ assert src != dst failure (2015-02-28, michael)
 [Error matching program output for studies/madness/dinan/mad_chapel/test_likepy (compopts: 1)]
 [Error matching program output for studies/madness/dinan/mad_chapel/test_mul]
 [Error matching program output for studies/madness/dinan/mad_chapel/test_showboxes]
+
+some sort of failure in refactoring of third-party scripts (2015-03-04, gbt)
+(linux32, darwin, fifo, gnu.darwin, fast, baseline, verify, linux64, no-local, numa)
+----------------------------------------------------------------------------
+[Error matching compiler output for runtime/thomasvandoren/rtLibDirWarningsWithDeveloper]
+[Error matching compiler output for runtime/thomasvandoren/rtLibDirWarningsWithModuleAndDeveloper]
+[Error matching compiler output for runtime/thomasvandoren/rtLibDirWarningsWithModule]
+[Error matching compiler output for runtime/thomasvandoren/rtLibDirWarnings]
+[Warning: Did not recognize GMP value: ]
+[Warning: Did not recognize GMP value: ]
+[Warning: Did not recognize GMP value: ]
+[Warning: Did not recognize GMP value: ]
+
 
 
 
@@ -97,17 +105,6 @@ Reviewed 2015-03-02
 Inherits 'general'
 Reviewed 2015-03-02
 ===================
-
-GMP [u]int(64)/32-bit c_[u]long mismatches (since first run, 2014-11-12)
-------------------------------------------------------------------------
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_dist_array]
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_random]
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_test]
-[Error matching compiler output for modules/standard/gmp/ferguson/gmp_writeln]
-[Error matching compiler output for modules/standard/gmp/studies/gmp-chudnovsky (compopts: 1)]
-[Error matching compiler output for studies/shootout/pidigits/hilde/pidigits-hilde]
-[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-BigInt]
-[Error matching compiler output for studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt]
 
 Seg fault since first run (2014-12-07)
 --------------------------------------
@@ -131,6 +128,10 @@ linux32
 Inherits '*32'
 Reviewed 2015-03-02
 ===================
+
+32-/64-bit portability issue (2015-03-04, bradc)
+------------------------------------------------
+[Error matching compiler output for modules/standard/gmp/studies/gmp-chudnovsky (compopts: 1)]
 
 timeout (2015-02-05, first run) - (elliot/michael)
 --------------------------------------------------
@@ -163,6 +164,49 @@ perf*
 Inherits 'general'
 Reviewed 2015-03-02
 ===================
+
+re2 missing pthread routines? (2015-03-04, gbt)
+-----------------------------------------------
+[Error cannot locate compiler output comparison file release/examples/benchmarks/miniMD/miniMD.simple.perfkeys.good]
+[Error cannot locate compiler output comparison file release/examples/benchmarks/miniMD/miniMD.simple-nolocal.perfkeys.good]
+[Error cannot locate compiler output comparison file release/examples/benchmarks/miniMD/miniMD.simple-block.perfkeys.good]
+[Error cannot locate compiler output comparison file release/examples/benchmarks/miniMD/miniMD.stencil.perfkeys.good]
+[Error cannot locate compiler output comparison file release/examples/benchmarks/miniMD/explicit/miniMD.explicit.perfkeys.good]
+[Error matching compiler output for release/examples/benchmarks/shootout/spectralnorm]
+[Error matching compiler output for release/examples/benchmarks/shootout/meteor-fast]
+[Error matching compiler output for release/examples/benchmarks/shootout/meteor]
+[Error matching compiler output for release/examples/benchmarks/shootout/mandelbrot]
+[Error matching compiler output for release/examples/benchmarks/shootout/nbody]
+[Error cannot locate compiler output comparison file release/examples/benchmarks/lulesh/lulesh.default.perfkeys.good]
+[Error cannot locate compiler output comparison file release/examples/benchmarks/lulesh/lulesh.block.perfkeys.good]
+[Error cannot locate compiler output comparison file release/examples/benchmarks/lulesh/lulesh.default-dense.perfkeys.good]
+[Error cannot locate compiler output comparison file release/examples/benchmarks/lulesh/lulesh.block-dense.perfkeys.good]
+[Error matching compiler output for studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining]
+[Error matching compiler output for studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative]
+[Error matching compiler output for studies/shootout/nbody/bradc/nbody-blc-slicie]
+[Error matching compiler output for studies/shootout/nbody/bradc/nbody-blc-zip]
+[Error matching compiler output for studies/shootout/nbody/bradc/nbody-blc-ref]
+[Error matching compiler output for studies/shootout/nbody/bradc/nbody-blc]
+[Error matching compiler output for studies/shootout/mandelbrot/lydia/mandelbrot-unzipped]
+[Error matching compiler output for studies/shootout/mandelbrot/perfComp/mandelbrot-MAXLOGICAL]
+[Error matching compiler output for studies/shootout/mandelbrot/ferguson/mandelbrot-stdout-putchar]
+[Error matching compiler output for studies/shootout/mandelbrot/ferguson/mandelbrot-stdout]
+[Error matching compiler output for studies/shootout/mandelbrot/bradc/mandelbrot-blc]
+[Error matching compiler output for studies/shootout/mandelbrot/bharshbarg/mandelbrot-unrolled]
+[Error matching compiler output for studies/shootout/spectral-norm/perfComp/spectralnorm-MAXLOGICAL]
+[Error matching compiler output for studies/shootout/spectral-norm/bradc/spectralnorm-blc]
+[Error matching compiler output for studies/shootout/regex-dna/bharshbarg/regexdna]
+[Error matching compiler output for studies/shootout/fasta/kbrady/fasta-qio]
+[Error matching performance keys for studies/shootout/fasta/kbrady/fasta-lines]
+[Error matching compiler output for studies/shootout/fannkuch-redux/kbrady/fannkuch-redux]
+[Error matching compiler output for studies/shootout/meteor/kbrady/meteor-parallel]
+[Error matching compiler output for studies/shootout/meteor/kbrady/meteor-implicit-domain]
+[Error matching compiler output for studies/shootout/meteor/kbrady/meteor-parallel-alt]
+[Error matching compiler output for studies/shootout/meteor/kbrady/meteor]
+[Error matching compiler output for studies/lulesh/bradc/lulesh-dense (compopts: 1)]
+[Error: Timed out executing program performance/bharshbarg/range-forall (execopts: 2)]
+[Error matching compiler output for io/vass/time-write (compopts: 1)]
+
 
 
 ===================
@@ -257,69 +301,6 @@ Inherits 'general'
 Reviewed 2015-03-01
 ===================
 
-Invalid read of size 1 (2015-02-28, thomas)
--------------------------------------------
-[Error matching compiler output for chpldoc/basics/disconnectedComment]
-[Error matching compiler output for chpldoc/basics/empty]
-[Error matching compiler output for chpldoc/basics/fullyCommented]
-[Error matching compiler output for chpldoc/basics/hello]
-[Error matching compiler output for chpldoc/basics/longerComments]
-[Error matching compiler output for chpldoc/basics/nestFunctions]
-[Error matching compiler output for chpldoc/basics/parenthesesLess]
-[Error matching compiler output for chpldoc/basics/sparselyCommented]
-[Error matching compiler output for chpldoc/classes/basic (compopts: 1)]
-[Error matching compiler output for chpldoc/classes/fieldInheritance]
-[Error matching compiler output for chpldoc/classes/fields]
-[Error matching compiler output for chpldoc/classes/inheritance]
-[Error matching compiler output for chpldoc/classes/methods]
-[Error matching compiler output for chpldoc/classes/multipleInheritance]
-[Error matching compiler output for chpldoc/classes/paramFields]
-[Error matching compiler output for chpldoc/compflags/comment/basic (compopts: 1)]
-[Error matching compiler output for chpldoc/compflags/comment/specifiedDefault (compopts: 1)]
-[Error matching compiler output for chpldoc/globals/constants]
-[Error matching compiler output for chpldoc/globals/globalOrdering]
-[Error matching compiler output for chpldoc/globals/paramVars]
-[Error matching compiler output for chpldoc/globals/typeVars]
-[Error matching compiler output for chpldoc/globals/variables]
-[Error matching compiler output for chpldoc/intents]
-[Error matching compiler output for chpldoc/iterators]
-[Error matching compiler output for chpldoc/linkage-spec/exportTest]
-[Error matching compiler output for chpldoc/linkage-spec/externTest]
-[Error matching compiler output for chpldoc/linkage-spec/inlineTest]
-[Error matching compiler output for chpldoc/module/config]
-[Error matching compiler output for chpldoc/module/defaultModule]
-[Error matching compiler output for chpldoc/module/module]
-[Error matching compiler output for chpldoc/module/nestModules (compopts: 1)]
-[Error matching compiler output for chpldoc/module/nestWithFns]
-[Error matching compiler output for chpldoc/module/ordering]
-[Error matching compiler output for chpldoc/module/sameName2]
-[Error matching compiler output for chpldoc/module/sameName]
-[Error matching compiler output for chpldoc/module/surroundingModule]
-[Error matching compiler output for chpldoc/multifile]
-[Error matching compiler output for chpldoc/nodoc/noDocPlease (compopts: 1)]
-[Error matching compiler output for chpldoc/types/arguments/arrays]
-[Error matching compiler output for chpldoc/types/arguments/domains]
-[Error matching compiler output for chpldoc/types/arguments/explicitImplicit]
-[Error matching compiler output for chpldoc/types/arguments/methodCall]
-[Error matching compiler output for chpldoc/types/arguments/queried]
-[Error matching compiler output for chpldoc/types/arguments/recordsAndClasses]
-[Error matching compiler output for chpldoc/types/arguments/tuples]
-[Error matching compiler output for chpldoc/types/config/basic]
-[Error matching compiler output for chpldoc/types/fields/arrays]
-[Error matching compiler output for chpldoc/types/fields/basic]
-[Error matching compiler output for chpldoc/types/fields/domains]
-[Error matching compiler output for chpldoc/types/fields/recordsAndClasses]
-[Error matching compiler output for chpldoc/types/fields/tuples]
-[Error matching compiler output for chpldoc/types/fields/typevar]
-[Error matching compiler output for chpldoc/types/fields/usesTypeVar]
-[Error matching compiler output for chpldoc/types/returns/arrays]
-[Error matching compiler output for chpldoc/types/returns/basic]
-[Error matching compiler output for chpldoc/types/returns/domains]
-[Error matching compiler output for chpldoc/types/returns/recordsAndClasses]
-[Error matching compiler output for chpldoc/types/returns/tuples]
-[Error matching compiler output for chpldoc/variableArguments]
-[Error matching compiler output for release/examples/primers/chpldoc (compopts: 1)]
-
 Conditional jump or move depends on uninitialised value(s) (2015-02-22, mike)
 -----------------------------------------------------------------------------
 [Error matching compiler output for chpldoc/compflags/comment/loseComments (compopts: 1)]
@@ -339,6 +320,7 @@ sporadic invalid write in dl_lookup_symbol->do_lookup_x, read in dl_name_match_p
 sporadic execution timeout
 --------------------------
 [Error: Timed out executing program domains/sungeun/assoc/stress.numthr (compopts: 1, execopts: 2)] (..2015-02-21)
+[Error: Timed out executing program domains/sungeun/assoc/stress (compopts: 1, execopts: 2) (2015-03-02..)]
 
 
 
@@ -372,6 +354,9 @@ Inherits 'general'
 Reviewed 2015-03-02
 ===================
 
+gets wrong output (2015-03-03, gbt)
+-----------------------------------
+[Error matching program output for localeModels/gbt/maxTaskPar]
 
 
 
@@ -494,7 +479,7 @@ Reviewed 2015-03-01
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (last seen: 2015-03-01.. on xc-wb.prgenv-intel)
+[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (last seen: 2015-03-01..2014-03-03 on xc-wb.prgenv-intel)
 [Error: Timed out executing program domains/johnk/capacityParSafe (compopts: 1)] (last seen: 2015-02-24 on xc-wb.pgi)
 
 
@@ -503,25 +488,6 @@ xe-wb.*
 Inherits 'x?-wb.*'
 Reviewed 2015-03-01
 ===================
-
-
-=== sporadic failures below ===
-
-Sporadic compilation timeouts
------------------------------
-[Error: Timed out compilation for arrays/bradc/slices/outOfBoundsSlice] (last seen: 2015-02-22)
-[Error: Timed out compilation for release/examples/primers/arrays] (last seen: 2015-02-22)
-[Error: Timed out compilation for release/examples/benchmarks/lulesh/lulesh (compopts: 2)] (last seen: 2015-02-28 on xe-wb.host.prgenv-intel)
-[Error: Timed out compilation for arrays/bradc/array_init_should_copy] (last seen: 2015-02-24)
-[Error: Timed out compilation for arrays/deitz/test_remote_cyclic_slicing] (last seen: 2015-02-28 on xe-wb.prgenv-pgi)
-[Error: Timed out compilation for arrays/deitz/part6/test_basic1d2] (last seen: 2015-02-28 on xe-wb.pgi)
-[Error: Timed out compilation for arrays/bradc/reindex/reindex] (last seen: 2015-02-22)
-[Error: Timed out compilation for arrays/bradc/sliceViaSingleton3d] (last seen: 2015-03-01.. on xe-wb.prgenv-cray)
-[Error: Timed out compilation for arrays/bradc/badParZip] (last seen: 2015-02-24)
-[Error: Timed out compilation for arrays/deitz/jacobi5-no-local] (last seen: 2016-02-26)
-[Error: Timed out compilation for compflags/bradc/html/testit (compopts: 1)] (last seen: 2015-02-17)
-[Error: Timed out compilation for release/examples/primers/distributions] (last seen: 2015-03-01.. on xe-wb.host.prgenv-intel)
-[Error: Timed out compilation for arrays/bradc/localSlices/nonlocalslice] (last seen: 2015-03-01.. on xe-wb.prgenv-pgi)
 
 
 =======================
@@ -649,7 +615,7 @@ sporadic dropping/mangling of output
 [Error matching program output for functions/iterators/bradc/leadFollow/localfollow2 (compopts: 1)] (2014-10-07)
 [Error matching program output for multilocale/diten/nolocalArgDefaultGlobal/fieldDefaultGlobalRecordMember] (2014-12-16)
 [Error matching program output for optimizations/sungeun/RADOpt/access1d (compopts: 1)] (2014-10-10)
-[Error matching program output for release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5, execopts: 1)] (2014-10-03)
+[Error matching program output for release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5, execopts: 1)] (2014-10-03, 2015-03-04)
 [Error matching program output for release/examples/primers/arrays] (2014-10-03)
 [Error matching program output for studies/cholesky/jglewis/version2/elemental/test_elemental_cholesky] (2015-01-14)
 [Error matching program output for studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall (compopts: 1)] (2014-12-19)
@@ -668,6 +634,10 @@ x?-wb.prgenv-cray
 Inherits 'x?-wb.*' and '*prgenv-cray*'
 Reviewed 2015-03-01
 ======================================
+
+new test times out (2015-03-03, vass)
+-------------------------------------
+[Error: Timed out executing program parallel/forall/vass/ri-3-stress (compopts: 1)]
 
 
 ============================
@@ -736,12 +706,42 @@ Inherits 'x?.wb-*'
 Reviewed 2015-03-02
 ===================
 
+third-party linkage issues (2015-03-04, gbt)
+(all configurations other than CCE?)
+--------------------------------------------
+*** pretty much everything ***
 
 ===================
 xc.*
 Inherits 'x?.*'
 Reviewed 2015-03-02
 ===================
+
+===================
+xe.*
+Inherits 'x?.*'
+Reviewed 2015-03-02
+===================
+
+
+===================
+x?.ugni-qthreads.*
+Inherits 'x?.*'
+Reviewed 2015-03-02
+===================
+
+
+===============
+xe.ugni.*
+Inherits 'xe.*'
+===============
+
+=== sporadic failures below ===
+
+[Error: Timed out executing program release/examples/benchmarks/hpcc/ra (compopts: 1)] (last seen 2015-03-04 on xe.ugni.gnu)
+[Error: Timed out executing program release/examples/benchmarks/hpcc/variants/ra-cleanloop (compopts: 1)] (last seen 2015-02-28 on xe.ugni.gnu and xe.ugni.intel)
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: *, execopts: 1)] (last seen 2015-03-03 on xe.ugni.gnu)
+
 
 ==========================================
 xc.knc
@@ -761,73 +761,25 @@ Reviewed 2015-03-02
 ==========================
 
 
-===================
-xe.*
-Inherits 'x?.*'
-Reviewed 2015-03-02
-===================
-
-
-===================
-x?.ugni-qthreads.*
-Inherits 'x?.*'
-Reviewed 2015-03-02
-===================
-
-do_remote_put(): remote address is not known to the NIC (2015-03-02, gbt)
--------------------------------------------------------------------------
-[Error matching program output for release/examples/benchmarks/hpcc/fft]
-[Error matching program output for release/examples/benchmarks/hpcc/hpl]
-[Error matching program output for release/examples/benchmarks/hpcc/ptrans]
-[Error matching program output for release/examples/benchmarks/hpcc/ra (compopts: 1)]
-[Error matching program output for release/examples/benchmarks/hpcc/ra-atomics (compopts: 1)]
-[Error matching program output for release/examples/benchmarks/hpcc/stream-ep]
-[Error matching program output for release/examples/benchmarks/hpcc/stream]
-[Error matching program output for release/examples/benchmarks/hpcc/variants/ra-cleanloop (compopts: 1)]
-[Error matching program output for release/examples/benchmarks/hpcc/variants/stream-promoted]
-[Error matching program output for release/examples/benchmarks/ssca2/SSCA2_main (compopts: 1, execopts: 1)]
-[Error matching program output for release/examples/benchmarks/ssca2/SSCA2_main (compopts: 2, execopts: 1)]
-[Error matching program output for release/examples/benchmarks/ssca2/SSCA2_main (compopts: 3, execopts: 1)]
-[Error matching program output for release/examples/benchmarks/ssca2/SSCA2_main (compopts: 4, execopts: 1)]
-[Error matching program output for release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5, execopts: 1)]
-[Error matching program output for release/examples/hello2-module]
-[Error matching program output for release/examples/hello3-datapar]
-[Error matching program output for release/examples/hello4-datapar-dist]
-[Error matching program output for release/examples/hello5-taskpar]
-[Error matching program output for release/examples/hello6-taskpar-dist]
-[Error matching program output for release/examples/hello]
-[Error matching program output for release/examples/primers/distributions]
-[Error matching program output for release/examples/primers/locales]
-
-
-===============
-xe.ugni.*
-Inherits 'xe.*'
-===============
-
-=== sporadic failures below ===
-
-[Error: Timed out executing program release/examples/benchmarks/hpcc/ra (compopts: 1)] (last seen 2015-03-01 on xe.ugni.intel)
-[Error: Timed out executing program release/examples/benchmarks/hpcc/variants/ra-cleanloop (compopts: 1)] (last seen 2015-02-28 on xe.ugni.gnu and xe.ugni.intel)
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: *, execopts: 1)] (last seen 2015-03-01 on xe.ugni.gnu)
-
-
-
 
 ****************************************************************************
-*              XE/XC hardware performance configurations                   *
+*                 XC hardware performance configurations                   *
 ****************************************************************************
 
 ===========================
-perf.x?.*
+perf.xc.*
 Inherits 'perf*' and 'x?.*'
 Reviewed 2015-03-01
 ===========================
 
+missing third-party stuff (2015-03-04, gbt)
+-------------------------------------------
+*** pretty much everything ***
+
 
 ================================
 perf.xc.local.gnu
-Inherits 'perf.x?.*' and '*gnu*'
+Inherits 'perf.xc.*' and '*gnu*'
 Reviewed 2015-03-01
 ================================
 
@@ -877,11 +829,11 @@ Sporadic execution timeout
 [Error: Timed out executing program release/examples/benchmarks/hpcc/ra (compopts: 2, execopts: 1)] (2015-02-26)
 
 
-==================================================
+===============================
 perf.xc.16.aries.gnu
-Inherits 'perf.xc.*'
+Inherits 'perf.xc.no-local.gnu'
 Reviewed 2015-02-17
-==================================================
+===============================
 
 Execution timeout (2015-02-02..)
 --------------------------------
@@ -911,7 +863,7 @@ sporadic execution timeout
 
 ==================================
 perf.xc.local.intel
-Inherits 'perf.x?.*' and '*intel*'
+Inherits 'perf.xc.*' and '*intel*'
 Reviewed 2015-03-01
 ==================================
 
@@ -924,7 +876,7 @@ sporadic chameneos-redux-cas output mismatch (lydia)
 
 ========================================
 perf.xc.local.cray
-Inherits 'perf.x?.*' and '*prgenv-cray*'
+Inherits 'perf.xc.*' and '*prgenv-cray*'
 Reviewed 2015-02-27
 ========================================
 
@@ -933,16 +885,21 @@ known CCE bug
 [Error matching performance keys for release/examples/benchmarks/shootout/meteor-fast]
 [Error matching performance keys for studies/shootout/meteor/kbrady/meteor-parallel-alt]
 
+segfault (2015-03-04, sporadic?)
+--------------------------------
+[Error matching performance keys for npb/is/mcahir/intsort.mtml]
+
+
 === sporadic failures below ===
 
 sporadic execution timeout
 --------------------------
-[Error: Timed out executing program studies/shootout/mandelbrot/ferguson/mandelbrot-opt2] (2015-03-01..)
+[Error: Timed out executing program studies/shootout/mandelbrot/ferguson/mandelbrot-opt2] (2015-03-01..2015-03-03)
 
 
 ================================
 perf.xc.local.pgi
-Inherits 'perf.x?.*' and '*pgi*'
+Inherits 'perf.xc.*' and '*pgi*'
 Reviewed 2015-02-27
 ================================
 
@@ -974,6 +931,10 @@ cygwin*
 Inherits 'general'
 Reviewed 2015-03-02
 ===================
+
+new test results in pthread_mutex_init() failed (2015-03-03, vass)
+------------------------------------------------------------------
+[Error matching program output for parallel/forall/vass/ri-3-stress (compopts: 1)]
 
 check_channel assertion failure
 -------------------------------
@@ -1064,6 +1025,6 @@ Reviewed 2015-03-01
 
 === sporadic failures below ===
 
-sporadic segfault/error in sendAll (2014-03-02)
------------------------------------------------
+sporadic segfault/error in sendAll (2014-03-02, looks like a one-off)
+---------------------------------------------------------------------
 [Error matching program output for distributions/robust/arithmetic/modules/test_module_Search]


### PR DESCRIPTION
Regressions
-----------
* failures due to third-party script refactoring (gbt owns)
  - runtime/thomasvandoren/rtLib* tests for most configurations that run them
  - perf.* runs
  - x*. runs for all compilers other than CCE

* localeModels/gbt/maxTaskPar failing for numa (gbt owns)

* new test ri-3-stress times out/fails on cygwin (vass owns)

* now that GMP is working generally on 32-bit, gmp-chudnovsky is now failing
  due to an issue in the test itself (bradc owns)

* new segfault on perf.xc.local.cray that I'm waiting to see if it's
  sporadic

* a few other familiar sporadic failures: timeouts on xe-ugni, dropped output
  on CCE

Improvements
------------
* long-standing GMP 32-/64-bit issues improved (thanks Thomas!)

* long-standing sporadic compilation timeouts all fixed (thanks Elliot
  and Thomas!)

* do_remote_put() ugni+qthreads regressions fixed

* fix for assert src != dst regression is draining through the system

* valgrind invalid read of size 1 regression fixed


Misc cleanup
------------
* moved xc.knc and xc.llvm to the bottom of their section

* renamed perf.x?.* to perf.xc.* because we don't do perf testing on
  xe (right?)

