### PR TITLE
Add isCoforallLoop() method

### DIFF
--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -256,6 +256,11 @@ bool ForLoop::isForLoop() const
   return true;
 }
 
+// TODO (Elliot 03/03/15): coforall loops are currently represented
+// as ForLoops in the compiler. This is a start at distinguishing
+// them. Note that for coforall loops, this method and isForLoop
+// with both return true. Eventually CoforallLoop should become it's
+// own class that shares a common parent with ForLoop.
 bool ForLoop::isCoforallLoop() const
 {
   return mIndex->var->hasFlag(FLAG_COFORALL_INDEX_VAR);

--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -256,6 +256,11 @@ bool ForLoop::isForLoop() const
   return true;
 }
 
+bool ForLoop::isCoforallLoop() const
+{
+  return mIndex->var->hasFlag(FLAG_COFORALL_INDEX_VAR);
+}
+
 SymExpr* ForLoop::indexGet() const
 {
   return mIndex;

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -635,6 +635,13 @@ bool isForLoop(const BaseAST* a)
   return (stmt != 0 && stmt->isForLoop()) ? true : false;
 }
 
+bool isCoforallLoop(const BaseAST* a)
+{
+  const BlockStmt* stmt = toConstBlockStmt(a);
+
+  return (stmt != 0 && stmt->isCoforallLoop()) ? true : false;
+}
+
 bool isCForLoop(const BaseAST* a)
 {
   const BlockStmt* stmt = toConstBlockStmt(a);

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -400,6 +400,11 @@ BlockStmt::isForLoop() const {
 }
 
 bool
+BlockStmt::isCoforallLoop() const {
+  return false;
+}
+
+bool
 BlockStmt::isCForLoop() const {
   return false;
 }

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -56,6 +56,7 @@ public:
   virtual Expr*          getNextExpr(Expr* expr);
 
   virtual bool           isForLoop()                                  const;
+  virtual bool           isCoforallLoop()                             const;
 
   virtual bool           deadBlockCleanup();
 

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -331,6 +331,7 @@ bool isWhileDoStmt(const BaseAST* a);
 bool isDoWhileStmt(const BaseAST* a);
 bool isParamForLoop(const BaseAST* a);
 bool isForLoop(const BaseAST* a);
+bool isCoforallLoop(const BaseAST* a);
 bool isCForLoop(const BaseAST* a);
 
 //
@@ -431,6 +432,11 @@ static inline const LcnSymbol* toConstLcnSymbol(const BaseAST* a)
       AST_CALL_CHILD(stmt, WhileStmt,    condExprGet(),  call, __VA_ARGS__);   \
                                                                                \
     } else if (stmt->isForLoop()      == true) {                               \
+      AST_CALL_LIST (stmt, ForLoop,      body,           call, __VA_ARGS__);   \
+      AST_CALL_CHILD(stmt, ForLoop,      indexGet(),     call, __VA_ARGS__);   \
+      AST_CALL_CHILD(stmt, ForLoop,      iteratorGet(),  call, __VA_ARGS__);   \
+                                                                               \
+    } else if (stmt->isCoforallLoop() == true) {                               \
       AST_CALL_LIST (stmt, ForLoop,      body,           call, __VA_ARGS__);   \
       AST_CALL_CHILD(stmt, ForLoop,      indexGet(),     call, __VA_ARGS__);   \
       AST_CALL_CHILD(stmt, ForLoop,      iteratorGet(),  call, __VA_ARGS__);   \

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -89,6 +89,7 @@ public:
 
   virtual bool        isParamForLoop()                             const;
   virtual bool        isForLoop()                                  const;
+  virtual bool        isCoforallLoop()                             const;
   virtual bool        isCForLoop()                                 const;
 
   virtual void        checkConstLoops();


### PR DESCRIPTION
Currently coforall loops are just represented as ForLoops within the compiler.
This is a start at separating them. This is a peeled off commit from my
vectorize-loop-followers branch where I want a clean way to distinguish which
loops are really coforall loops.

Eventually CoforallLoop should be it's own class that shares a parent with
ForLoop. That's more work than I want to tackle this close to the release.
Having a new class would continue the work Mike started with the other loop
types and should allow us to retire PRIM_BLOCK_COFORALL and
FLAG_COFORALL_INDEX_VAR.