### PR TITLE
Third-party integration fix: re2 needs -lpthread.

### DIFF
--- a/util/chplenv/chpl_3p_re2_configs.py
+++ b/util/chplenv/chpl_3p_re2_configs.py
@@ -10,4 +10,4 @@ def get_uniq_cfg_path():
 @memoize
 def get_link_args():
     return third_party_utils.default_get_link_args('re2',
-                                                   libs=['-lre2'])
+                                                   libs=['-lre2', '-lpthread'])


### PR DESCRIPTION
The third-party/re2 install needs -lpthread.  I didn't include that in
the link-args in my original work because I didn't snap to the fact that
because re2 doesn't use libtool it wouldn't get picked up automatically.
Add it manually with this commit.