### PR TITLE
Switched the order of sleep() and status().

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -284,10 +284,12 @@ class AbstractJob(object):
             status = job_status(job_id, output_file)
             while status != 'C':
                 if not alreadyRunning and status == 'R':
+                    # It would be great, at this point, to have 'start_test'
+                    # print a message "execution started". Unclear how to.
                     alreadyRunning = True
                     exec_start_time = time.time()
-                status = job_status(job_id, output_file)
                 time.sleep(.5)
+                status = job_status(job_id, output_file)
 
             exec_time = time.time() - exec_start_time
             # Note that this time isn't very accurate as we don't get the exact

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -284,8 +284,6 @@ class AbstractJob(object):
             status = job_status(job_id, output_file)
             while status != 'C':
                 if not alreadyRunning and status == 'R':
-                    # It would be great, at this point, to have 'start_test'
-                    # print a message "execution started". Unclear how to.
                     alreadyRunning = True
                     exec_start_time = time.time()
                 time.sleep(.5)


### PR DESCRIPTION
Query job_status after sleeping, not before.

While there, noticed that it would be great for start_test to print a note 
"the job started executing", for those impatiently looking at start_test
output on the console. However, it is not simple, as chpl_launchcmd.py
cannot just print it out - it would be considered part of test output
and start_test would not print it. Some out-of-band mechanism analogous
to CHPL_LAUNCHCMD_EXEC_TIME_FILE?
