### PR TITLE
Temporarily work around a missing -lrt with 'chpl --llvm ...'.

### DIFF
--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -15,4 +15,5 @@ def get_link_args():
                                                    ucp=get_uniq_cfg_path(),
                                                    libs=['libqthread_chpl.la',
                                                          '-lchpl',
-                                                         'libqthread.la'])
+                                                         'libqthread.la',
+                                                         '-lrt'])


### PR DESCRIPTION
With CHPL_LLVM=llvm we enable using clang as the target compiler when
the --llvm option is thrown to chpl.  But when we do this, we are using
different target compilers for the runtime and third-party packages, and
the user code.  Unfortunately this causes a problem if we're on a Cray
system and using a PrgEnv-* target compiler.  That compiler's command
line driver throws -lrt at link time itself.  Because it does so, the
qthreads configuration step concludes that it doesn't need to arrange to
throw -lrt at link time to satisfy the clock_gettime() extern, and we
end up with -lrt not being in the libqthread.la dependency_libs= line.
If we then link the user code with clang as a result of throwing --llvm
to chpl, we get an undefined external for clock_gettime() because we
don't search librt.

To work around this for now, throw an extra -lrt into the link-args
needed for qthreads.  The de-duplication code in printchplenv will
remove all but one of these anyway, so we won't be searching more than
we need to.

At some point (not yet clear when) we'll arrange for --llvm to imply a
different CHPL_TARGET_COMPILER, and then we can remove this.