### PR TITLE
Change the interface for safe_cast

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -729,7 +729,7 @@ static ArgumentDescription arg_desc[] = {
  {"local-checks", ' ', NULL, "Enable [disable] local block checking", "n", &fNoLocalChecks, NULL, NULL},
  {"nil-checks", ' ', NULL, "Enable [disable] nil checking", "n", &fNoNilChecks, "CHPL_NO_NIL_CHECKS", NULL},
  {"stack-checks", ' ', NULL, "Enable [disable] stack overflow checking", "n", &fNoStackChecks, "CHPL_STACK_CHECKS", handleStackCheck},
- {"cast-checks", ' ', NULL, "Enable [disable] checks in safe_cast calls", "n", &fNoCastChecks, NULL, NULL},
+ {"cast-checks", ' ', NULL, "Enable [disable] checks in safeCast calls", "n", &fNoCastChecks, NULL, NULL},
 
  {"", ' ', NULL, "C Code Generation Options", NULL, NULL, NULL, NULL},
  {"codegen", ' ', NULL, "[Don't] Do code generation", "n", &no_codegen, "CHPL_NO_CODEGEN", NULL},

--- a/man/chpl.txt
+++ b/man/chpl.txt
@@ -200,7 +200,7 @@ OPTIONS
   --[no-]stack-checks   Enable [disable] run-time checking for stack
                     overflow.
 
-  --[no-]cast-checks   Enable [disable] run-time checks in safe_cast calls for
+  --[no-]cast-checks   Enable [disable] run-time checks in safeCast calls for
                     casts that wouldn't preserve the logical value being cast.
 
   C Code Generation Options

--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -35,8 +35,8 @@ module MemTracking
     memLeaksLog: c_string = "";
 
   // Safely cast to size_t instances of memMax and memThreshold.
-  const cMemMax = safe_cast(size_t, memMax),
-    cMemThreshold = safe_cast(size_t, memThreshold);
+  const cMemMax = memMax.safeCast(size_t),
+    cMemThreshold = memThreshold.safeCast(size_t);
 
   // Globally accessible copy of the corresponding c_string consts
   use NewString;

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -321,14 +321,14 @@ module GMP {
 
     // initializing integers (constructors)
     proc BigInt(init2:bool, nbits:uint) {
-      mpz_init2(this.mpz, safe_cast(c_ulong, nbits));
+      mpz_init2(this.mpz, nbits.safeCast(c_ulong));
     }
     proc BigInt(num:int) {
-      mpz_init_set_si(this.mpz, safe_cast(c_long, num));
+      mpz_init_set_si(this.mpz, num.safeCast(c_long));
     }
     proc BigInt(str:string, base:int=0) {
       var e:c_int;
-      e = mpz_init_set_str(this.mpz, str.c_str(), safe_cast(c_int, base));
+      e = mpz_init_set_str(this.mpz, str.c_str(), base.safeCast(c_int));
       if e {
         mpz_clear(this.mpz);
         halt("Error initializing big integer: bad format");
@@ -337,7 +337,7 @@ module GMP {
     proc BigInt(str:string, base:int=0, out error:syserr) {
       var e:c_int;
       error = ENOERR;
-      e = mpz_init_set_str(this.mpz, str.c_str(), safe_cast(c_int, base));
+      e = mpz_init_set_str(this.mpz, str.c_str(), base.safeCast(c_int));
       if e {
         mpz_clear(this.mpz);
         error = EFORMAT;
@@ -398,15 +398,15 @@ module GMP {
     }
     proc set_ui(num:uint)
     {
-      on this do mpz_set_ui(this.mpz, safe_cast(c_ulong, num));
+      on this do mpz_set_ui(this.mpz, num.safeCast(c_ulong));
     }
     proc set_si(num:int)
     {
-      on this do mpz_set_si(this.mpz, safe_cast(c_long, num));
+      on this do mpz_set_si(this.mpz, num.safeCast(c_long));
     }
     proc set(num:int)
     {
-      set_si(safe_cast(c_long, num));
+      set_si(num.safeCast(c_long));
     }
     proc set_d(num:real)
     {
@@ -414,7 +414,7 @@ module GMP {
     }
     proc set_str(str:string, base:int=0)
     {
-      on this do mpz_set_str(this.mpz, str.c_str(), safe_cast(c_int, base));
+      on this do mpz_set_str(this.mpz, str.c_str(), base.safeCast(c_int));
     }
     proc swap(a:BigInt)
     {
@@ -436,13 +436,13 @@ module GMP {
     {
       var x:c_ulong;
       on this do x = mpz_get_ui(this.mpz);
-      return safe_cast(uint, x);
+      return x.safeCast(uint);
     }
     proc get_si():int
     {
       var x:c_long;
       on this do x = mpz_get_si(this.mpz);
-      return safe_cast(int, x);
+      return x.safeCast(int);
     }
     proc get_d():real
     {
@@ -460,13 +460,13 @@ module GMP {
         dbl = mpz_get_d_2exp(tmp, this.mpz);
         exp = tmp;
       }
-      return (safe_cast(int, exp), dbl: real);
+      return (exp.safeCast(int), dbl: real);
     }
     proc get_str(base:int=10):string
     {
       var ret:string;
       on this {
-        var tmp = chpl_gmp_mpz_get_str(safe_cast(c_int, base), this.mpz);
+        var tmp = chpl_gmp_mpz_get_str(base.safeCast(c_int), this.mpz);
         ret = toString(tmp);
       }
       return ret;
@@ -487,7 +487,7 @@ module GMP {
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_add_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_add_ui(this.mpz, a_.mpz, b.safeCast(c_ulong));
         if acopy then delete a_;
       }
     }
@@ -505,7 +505,7 @@ module GMP {
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_sub_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_sub_ui(this.mpz, a_.mpz, b.safeCast(c_ulong));
         if acopy then delete a_;
       }
     }
@@ -513,7 +513,7 @@ module GMP {
     {
       on this {
         var (bcopy,b_) = b.maybeCopy();
-        mpz_ui_sub(this.mpz, safe_cast(c_ulong, a), b_.mpz);
+        mpz_ui_sub(this.mpz, a.safeCast(c_ulong), b_.mpz);
         if bcopy then delete b_;
       }
     }
@@ -531,7 +531,7 @@ module GMP {
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_mul_si(this.mpz, a_.mpz, safe_cast(c_long, b));
+        mpz_mul_si(this.mpz, a_.mpz, b.safeCast(c_long));
         if acopy then delete a_;
       }
     }
@@ -539,7 +539,7 @@ module GMP {
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_mul_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_mul_ui(this.mpz, a_.mpz, b.safeCast(c_ulong));
         if acopy then delete a_;
       }
     }
@@ -557,7 +557,7 @@ module GMP {
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_addmul_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_addmul_ui(this.mpz, a_.mpz, b.safeCast(c_ulong));
         if acopy then delete a_;
       }
     }
@@ -575,7 +575,7 @@ module GMP {
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_submul_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_submul_ui(this.mpz, a_.mpz, b.safeCast(c_ulong));
         if acopy then delete a_;
       }
     }
@@ -583,7 +583,7 @@ module GMP {
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_mul_2exp(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_mul_2exp(this.mpz, a_.mpz, b.safeCast(c_ulong));
         if acopy then delete a_;
       }
     }
@@ -659,7 +659,7 @@ module GMP {
       var ret:c_ulong;
       on this {
         var (ncopy,n_) = n.maybeCopy();
-        const cd = safe_cast(c_ulong, d);
+        const cd = d.safeCast(c_ulong);
         select rounding {
           when Round.UP   do ret=mpz_cdiv_q_ui(this.mpz, n_.mpz, cd);
           when Round.DOWN do ret=mpz_fdiv_q_ui(this.mpz, n_.mpz, cd);
@@ -667,14 +667,14 @@ module GMP {
         }
         if ncopy then delete n_;
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc div_r_ui(param rounding:Round, n:BigInt, d:uint):uint
     {
       var ret:c_ulong;
       on this {
         var (ncopy,n_) = n.maybeCopy();
-        const cd = safe_cast(c_ulong, d);
+        const cd = d.safeCast(c_ulong);
         select rounding {
           when Round.UP   do ret=mpz_cdiv_r_ui(this.mpz, n_.mpz, cd);
           when Round.DOWN do ret=mpz_fdiv_r_ui(this.mpz, n_.mpz, cd);
@@ -682,13 +682,13 @@ module GMP {
         }
         if ncopy then delete n_;
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     // this gets quotient, r gets remainder
     proc div_qr_ui(param rounding:Round, r:BigInt, n:BigInt, d:uint):uint
     {
       var ret:c_ulong;
-      const cd = safe_cast(c_ulong, d);
+      const cd = d.safeCast(c_ulong);
       on this {
         var (rcopy,r_) = r.maybeCopy();
         var (ncopy,n_) = n.maybeCopy();
@@ -703,12 +703,12 @@ module GMP {
         }
         if ncopy then delete n_;
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc div_ui(param rounding:Round, n:BigInt, d:uint):uint
     {
       var ret:c_ulong;
-      const cd = safe_cast(c_ulong, d);
+      const cd = d.safeCast(c_ulong);
       on this {
         var (ncopy,n_) = n.maybeCopy();
         select rounding {
@@ -718,13 +718,13 @@ module GMP {
         }
         if ncopy then delete n_;
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc div_q_2exp(param rounding:Round, n:BigInt, b:uint)
     {
       on this {
         var (ncopy,n_) = n.maybeCopy();
-        const cb = safe_cast(c_ulong, b);
+        const cb = b.safeCast(c_ulong);
         select rounding {
           when Round.UP   do mpz_cdiv_q_2exp(this.mpz, n_.mpz, cb);
           when Round.DOWN do mpz_fdiv_q_2exp(this.mpz, n_.mpz, cb);
@@ -737,7 +737,7 @@ module GMP {
     {
       on this {
         var (ncopy,n_) = n.maybeCopy();
-        const cb = safe_cast(c_ulong, b);
+        const cb = b.safeCast(c_ulong);
         select rounding {
           when Round.UP   do mpz_cdiv_r_2exp(this.mpz, n_.mpz, cb);
           when Round.DOWN do mpz_fdiv_r_2exp(this.mpz, n_.mpz, cb);
@@ -761,10 +761,10 @@ module GMP {
       var ret:c_ulong;
       on this {
         var (ncopy,n_) = n.maybeCopy();
-        ret=mpz_mod(this.mpz, n_.mpz, safe_cast(c_ulong, d));
+        ret=mpz_mod(this.mpz, n_.mpz, d.safeCast(c_ulong));
         if ncopy then delete n_;
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc divexact(n:BigInt, d:BigInt)
     {
@@ -780,7 +780,7 @@ module GMP {
     {
       on this {
         var (ncopy,n_) = n.maybeCopy();
-        mpz_divexact(this.mpz, n_.mpz, safe_cast(c_ulong, d));
+        mpz_divexact(this.mpz, n_.mpz, d.safeCast(c_ulong));
         if ncopy then delete n_;
       }
     }
@@ -792,23 +792,23 @@ module GMP {
         ret=mpz_divisible_p(this.mpz, d_.mpz);
         if dcopy then delete d_;
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc divisible_ui_p(d:uint):int
     {
       var ret:c_int;
       on this {
-        ret=mpz_divisible_ui_p(this.mpz, safe_cast(c_ulong, d));
+        ret=mpz_divisible_ui_p(this.mpz, d.safeCast(c_ulong));
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc divisible_2exp_p(b:uint):int
     {
       var ret:c_int;
       on this {
-        mpz_divisible_2exp_p(this.mpz, safe_cast(c_ulong, b));
+        mpz_divisible_2exp_p(this.mpz, b.safeCast(c_ulong));
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc congruent_p(c:BigInt, d:BigInt):int
     {
@@ -820,25 +820,25 @@ module GMP {
         if ccopy then delete c_;
         if dcopy then delete d_;
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc congruent_ui_p(c:uint, d:uint):int
     {
       var ret:c_int;
       on this {
-        ret=mpz_congruent_ui_p(this.mpz, safe_cast(c_ulong, c), safe_cast(c_ulong, d));
+        ret=mpz_congruent_ui_p(this.mpz, c.safeCast(c_ulong), d.safeCast(c_ulong));
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc congruent_2exp_p(c:BigInt, b:uint):int
     {
       var ret:c_int;
       on this {
         var (ccopy,c_) = c.maybeCopy();
-        ret=mpz_congruent_2exp_p(this.mpz, c, safe_cast(c_ulong, b));
+        ret=mpz_congruent_2exp_p(this.mpz, c, b.safeCast(c_ulong));
         if ccopy then delete c_;
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
 
 
@@ -860,7 +860,7 @@ module GMP {
       on this {
         var (bcopy,b_) = base.maybeCopy();
         var (mcopy,m_) = mod.maybeCopy();
-        mpz_powm_ui(this.mpz, b_.mpz, safe_cast(c_ulong, exp), m_.mpz);
+        mpz_powm_ui(this.mpz, b_.mpz, exp.safeCast(c_ulong), m_.mpz);
         if bcopy then delete b_;
         if mcopy then delete m_;
       }
@@ -869,14 +869,14 @@ module GMP {
     {
       on this {
         var (bcopy,b_) = base.maybeCopy();
-        mpz_pow_ui(this.mpz, b_.mpz, safe_cast(c_ulong, exp));
+        mpz_pow_ui(this.mpz, b_.mpz, exp.safeCast(c_ulong));
         if bcopy then delete b_;
       }
     }
     proc ui_pow_ui(base:uint, exp:uint)
     {
       on this {
-        mpz_ui_pow_ui(this.mpz, safe_cast(c_ulong, base), safe_cast(c_ulong, exp));
+        mpz_ui_pow_ui(this.mpz, base.safeCast(c_ulong), exp.safeCast(c_ulong));
       }
     }
 
@@ -886,10 +886,10 @@ module GMP {
       var ret:c_int;
       on this {
         var (acopy,a_) = a.maybeCopy();
-        ret=mpz_root(this.mpz, a_.mpz, safe_cast(c_ulong, n));
+        ret=mpz_root(this.mpz, a_.mpz, n.safeCast(c_ulong));
         if acopy then delete a_;
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     // this gets root, rem gets remainder.
     proc mpz_rootrem(rem:BigInt, u:BigInt, n:uint)
@@ -897,7 +897,7 @@ module GMP {
       on this {
         var (rcopy,r_) = rem.maybeCopy();
         var (ucopy,u_) = u.maybeCopy();
-        mpz_rootrem(this.mpz, r_.mpz, u_.mpz, safe_cast(c_ulong, n));
+        mpz_rootrem(this.mpz, r_.mpz, u_.mpz, n.safeCast(c_ulong));
         if rcopy {
           rem.set(r_);
           delete r_;
@@ -933,7 +933,7 @@ module GMP {
       on this {
         ret=mpz_perfect_power_p(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc perfect_square():int
     {
@@ -941,7 +941,7 @@ module GMP {
       on this {
         ret=mpz_perfect_square(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
 
     // Number Theoretic Functions
@@ -949,9 +949,9 @@ module GMP {
     {
       var ret:c_int;
       on this {
-        ret=mpz_probab_prime_p(this.mpz, safe_cast(c_int, reps));
+        ret=mpz_probab_prime_p(this.mpz, reps.safeCast(c_int));
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc nextprime(a: BigInt)
     {
@@ -975,7 +975,7 @@ module GMP {
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_gcd_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_gcd_ui(this.mpz, a_.mpz, b.safeCast(c_ulong));
         if acopy then delete a_;
       }
     }
@@ -1015,7 +1015,7 @@ module GMP {
     {
       on this {
         var (acopy,a_) = a.maybeCopy();
-        mpz_lcm_ui(this.mpz, a_.mpz, safe_cast(c_ulong, b));
+        mpz_lcm_ui(this.mpz, a_.mpz, b.safeCast(c_ulong));
         if acopy then delete a_;
       }
     }
@@ -1029,7 +1029,7 @@ module GMP {
         if acopy then delete a_;
         if bcopy then delete b_;
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
 
     // jacobi, legendre, kronecker are procedures outside this class.
@@ -1044,39 +1044,39 @@ module GMP {
         if acopy then delete a_;
         if fcopy then delete f_;
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc fac_ui(a: uint)
     {
       on this {
-        mpz_fac_ui(this.mpz, safe_cast(c_ulong, a));
+        mpz_fac_ui(this.mpz, a.safeCast(c_ulong));
       }
     }
     proc bin_ui(n: BigInt, k: uint)
     {
       on this {
         var (ncopy,n_) = n.maybeCopy();
-        mpz_bin_ui(this.mpz, n_.mpz, safe_cast(c_ulong, k));
+        mpz_bin_ui(this.mpz, n_.mpz, k.safeCast(c_ulong));
         if ncopy then delete n_;
       }
     }
     proc bin_uiui(n: uint, k: uint)
     {
       on this {
-        mpz_bin_uiui(this.mpz, safe_cast(c_ulong, n), safe_cast(c_ulong, k));
+        mpz_bin_uiui(this.mpz, n.safeCast(c_ulong), k.safeCast(c_ulong));
       }
     }
     proc fib_ui(n: uint)
     {
       on this {
-        mpz_fib_ui(this.mpz, safe_cast(c_ulong, n));
+        mpz_fib_ui(this.mpz, n.safeCast(c_ulong));
       }
     }
     proc fib2_ui(fnsub1: BigInt, n: uint)
     {
       on this {
         var (fcopy,f_) = fnsub1.maybeCopy();
-        mpz_fib2_ui(this.mpz, f_.mpz, safe_cast(c_ulong, n));
+        mpz_fib2_ui(this.mpz, f_.mpz, n.safeCast(c_ulong));
         if fcopy {
           fnsub1.set(f_);
           delete f_;
@@ -1086,14 +1086,14 @@ module GMP {
     proc lucnum_ui(n: uint)
     {
       on this {
-        mpz_lucnum_ui(this.mpz, safe_cast(c_ulong, n));
+        mpz_lucnum_ui(this.mpz, n.safeCast(c_ulong));
       }
     }
     proc lucnum2_ui(lnsub1: BigInt, n: uint)
     {
       on this {
         var (fcopy,f_) = lnsub1.maybeCopy();
-        mpz_lucnum2_ui(this.mpz, f_.mpz, safe_cast(c_ulong, n));
+        mpz_lucnum2_ui(this.mpz, f_.mpz, n.safeCast(c_ulong));
         if fcopy {
           lnsub1.set(f_);
           delete f_;
@@ -1111,7 +1111,7 @@ module GMP {
         ret=mpz_cmp(this.mpz,b_.mpz);
         if bcopy then delete b_;
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc cmp_d(b:real):int
     {
@@ -1119,23 +1119,23 @@ module GMP {
       on this {
         ret=mpz_cmp_d(this.mpz, b: c_double);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc cmp_si(b:int):int
     {
       var ret:c_int;
       on this {
-        ret=mpz_cmp_si(this.mpz, safe_cast(c_long, b));
+        ret=mpz_cmp_si(this.mpz, b.safeCast(c_long));
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc cmp_ui(b:uint):int
     {
       var ret:c_int;
       on this {
-        ret=mpz_cmp_ui(this.mpz, safe_cast(c_ulong, b));
+        ret=mpz_cmp_ui(this.mpz, b.safeCast(c_ulong));
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc cmpabs(b:BigInt):int
     {
@@ -1145,7 +1145,7 @@ module GMP {
         ret=mpz_cmpabs(this.mpz,b_.mpz);
         if acopy then delete b_;
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc cmpabs_d(b:real):int
     {
@@ -1153,15 +1153,15 @@ module GMP {
       on this {
         ret=mpz_cmpabs_d(this.mpz, b: c_double);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc cmp_abs_ui(b:uint):int
     {
       var ret:c_int;
       on this {
-        ret=mpz_cmpabs_ui(this.mpz, safe_cast(c_ulong, b));
+        ret=mpz_cmpabs_ui(this.mpz, b.safeCast(c_ulong));
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc sgn():int
     {
@@ -1169,7 +1169,7 @@ module GMP {
       on this {
         ret=mpz_sgn(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
 
     // Logical and Bit Manipulation Functions
@@ -1217,7 +1217,7 @@ module GMP {
       on this {
         ret = mpz_popcount(this.mpz);
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc hamdist(b:BigInt):uint
     {
@@ -1227,49 +1227,49 @@ module GMP {
         ret=mpz_hamdist(this.mpz, b_.mpz);
         if bcopy then delete b_;
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc scan0(starting_bit:uint):uint
     {
       var ret:c_ulong;
       on this {
-        ret = mpz_scan0(this.mpz, safe_cast(c_ulong, starting_bit));
+        ret = mpz_scan0(this.mpz, starting_bit.safeCast(c_ulong));
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc scan1(starting_bit:uint):uint
     {
       var ret:c_ulong;
       on this {
-        ret = mpz_scan1(this.mpz, safe_cast(c_ulong, starting_bit));
+        ret = mpz_scan1(this.mpz, starting_bit.safeCast(c_ulong));
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc setbit(bit_index:uint)
     {
       on this {
-        mpz_setbit(this.mpz, safe_cast(c_ulong, bit_index));
+        mpz_setbit(this.mpz, bit_index.safeCast(c_ulong));
       }
     }
     proc clrbit(bit_index:uint)
     {
       on this {
-        mpz_clrbit(this.mpz, safe_cast(c_ulong, bit_index));
+        mpz_clrbit(this.mpz, bit_index.safeCast(c_ulong));
       }
     }
     proc combit(bit_index:uint)
     {
       on this {
-        mpz_combit(this.mpz, safe_cast(c_ulong, bit_index));
+        mpz_combit(this.mpz, bit_index.safeCast(c_ulong));
       }
     }
     proc tstbit(bit_index:uint):int
     {
       var ret:c_int;
       on this {
-        ret = mpz_tstbit(this.mpz, safe_cast(c_ulong, bit_index));
+        ret = mpz_tstbit(this.mpz, bit_index.safeCast(c_ulong));
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
 
     // Miscellaneous Functions
@@ -1279,7 +1279,7 @@ module GMP {
       on this {
         ret = mpz_fits_ulong_p(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc fits_slong_p():int
     {
@@ -1287,7 +1287,7 @@ module GMP {
       on this {
         ret = mpz_fits_ulong_p(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc fits_uint_p():int
     {
@@ -1295,7 +1295,7 @@ module GMP {
       on this {
         ret = mpz_fits_uint_p(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc fits_sint_p():int
     {
@@ -1303,7 +1303,7 @@ module GMP {
       on this {
         ret = mpz_fits_sint_p(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc fits_ushort_p():int
     {
@@ -1311,7 +1311,7 @@ module GMP {
       on this {
         ret = mpz_fits_ushort_p(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc fits_sshort_p():int
     {
@@ -1319,7 +1319,7 @@ module GMP {
       on this {
         ret = mpz_fits_sshort_p(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc odd_p():int
     {
@@ -1327,7 +1327,7 @@ module GMP {
       on this {
         ret = mpz_odd_p(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc even_p():int
     {
@@ -1335,15 +1335,15 @@ module GMP {
       on this {
         ret = mpz_even_p(this.mpz);
       }
-      return safe_cast(int, ret);
+      return ret.safeCast(int);
     }
     proc sizeinbase(base:int):uint
     {
       var ret:size_t;
       on this {
-        ret = mpz_sizeinbase(this.mpz, safe_cast(c_int, base));
+        ret = mpz_sizeinbase(this.mpz, base.safeCast(c_int));
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
 
     // left out integer random functions
@@ -1352,16 +1352,16 @@ module GMP {
     proc realloc2(nbits:uint)
     {
       on this {
-        mpz_realloc2(this.mpz, safe_cast(c_ulong, nbits));
+        mpz_realloc2(this.mpz, nbits.safeCast(c_ulong));
       }
     }
     proc get_limbn(n:uint):uint
     {
       var ret:mp_limb_t;
       on this {
-        ret = mpz_getlimbn(this.mpz, safe_cast(mp_size_t, n));
+        ret = mpz_getlimbn(this.mpz, n.safeCast(mp_size_t));
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc size():size_t
     {
@@ -1397,7 +1397,7 @@ module GMP {
       ret=mpz_jacobi(a.mpz, b_.mpz);
       if bcopy then delete b_;
     }
-    return safe_cast(int, ret);
+    return ret.safeCast(int);
   }
   proc legendre(a: BigInt, p: BigInt):int
   {
@@ -1407,7 +1407,7 @@ module GMP {
       ret=mpz_legendre(a.mpz, p_.mpz);
       if pcopy then delete p_;
     }
-    return safe_cast(int, ret);
+    return ret.safeCast(int);
   }
   proc kronecker(a: BigInt, b: BigInt):int
   {
@@ -1417,39 +1417,39 @@ module GMP {
       ret=mpz_kronecker(a.mpz, b_.mpz);
       if bcopy then delete b_;
     }
-    return safe_cast(int, ret);
+    return ret.safeCast(int);
   }
   proc kronecker_si(a: BigInt, b: int):int
   {
     var ret:c_int;
     on a {
-      ret=mpz_kronecker_si(a.mpz, safe_cast(c_long, b));
+      ret=mpz_kronecker_si(a.mpz, b.safeCast(c_long));
     }
-    return safe_cast(int, ret);
+    return ret.safeCast(int);
   }
   proc kronecker_ui(a: BigInt, b: uint):int
   {
     var ret:c_int;
     on a {
-      ret=mpz_kronecker_ui(a.mpz, safe_cast(c_ulong, b));
+      ret=mpz_kronecker_ui(a.mpz, b.safeCast(c_ulong));
     }
-    return safe_cast(int, ret);
+    return ret.safeCast(int);
   }
   proc si_kronecker(a: int, b: BigInt):int
   {
     var ret:c_int;
     on b {
-      ret=mpz_si_kronecker(safe_cast(c_long, a), b.mpz);
+      ret=mpz_si_kronecker(b.mpz.safeCast(c_long, a));
     }
-    return safe_cast(int, ret);
+    return ret.safeCast(int);
   }
   proc ui_kronecker(a: uint, b: BigInt):int
   {
     var ret:c_int;
     on b {
-      ret=mpz_ui_kronecker(safe_cast(c_ulong, a), b.mpz);
+      ret=mpz_ui_kronecker(b.mpz.safeCast(c_ulong, a));
     }
-    return safe_cast(int, ret);
+    return ret.safeCast(int);
   }
 
   class GMPRandom {
@@ -1466,12 +1466,12 @@ module GMP {
     proc GMPRandom(a: BigInt, c: uint, m2exp: uint)
     {
       var (acopy,a_) = a.maybeCopy();
-      gmp_randinit_lc_2exp(this.state, a_.mpz, safe_cast(c_ulong, c), safe_cast(c_ulong, m2exp));
+      gmp_randinit_lc_2exp(this.state, a_.mpz, c.safeCast(c_ulong), m2exp.safeCast(c_ulong));
       if acopy then delete a_;
     }
     proc GMPRandom(size: uint)
     {
-      gmp_randinit_lc_2exp_esize(this.state, safe_cast(c_ulong, size));
+      gmp_randinit_lc_2exp_esize(this.state, size.safeCast(c_ulong));
     }
     proc GMPRandom(a: GMPRandom)
     {
@@ -1496,30 +1496,30 @@ module GMP {
     proc seed(seed: uint)
     {
       on this {
-        gmp_randseed_ui(this.state, safe_cast(c_ulong, seed));
+        gmp_randseed_ui(this.state, seed.safeCast(c_ulong));
       }
     }
     proc urandomb_ui(nbits: uint):uint
     {
       var ret: c_ulong;
       on this {
-        ret=gmp_urandomb_ui(this.state, safe_cast(c_ulong, nbits));
+        ret=gmp_urandomb_ui(this.state, nbits.safeCast(c_ulong));
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc urandomm_ui(n: uint):uint
     {
       var ret: c_ulong;
       on this {
-        ret=gmp_urandomm_ui(this.state, safe_cast(c_ulong, n));
+        ret=gmp_urandomm_ui(this.state, n.safeCast(c_ulong));
       }
-      return safe_cast(uint, ret);
+      return ret.safeCast(uint);
     }
     proc urandomb(r: BigInt, nbits: uint)
     {
       on this {
         var (rcopy,r_) = r.maybeCopy();
-        mpz_urandomb(r_.mpz, this.state, safe_cast(c_ulong, nbits));
+        mpz_urandomb(r_.mpz, this.state, nbits.safeCast(c_ulong));
         if rcopy {
           r.set(r_);
           delete r_;
@@ -1543,7 +1543,7 @@ module GMP {
     {
       on this {
         var (rcopy,r_) = r.maybeCopy();
-        mpz_rrandomb(r_.mpz, this.state, safe_cast(c_ulong, nbits));
+        mpz_rrandomb(r_.mpz, this.state, nbits.safeCast(c_ulong));
         if rcopy {
           r.set(r_);
           delete r_;

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -455,55 +455,55 @@ proc numBits(type t: enumerated) param {
 // performs the minimum number of runtime checks - uint(8)->uint(64) won't
 // perform any checks for example
 //
-inline proc safe_cast(type T, val: integral) : T where isUintType(T) {
+inline proc integral.safeCast(type T) : T where isUintType(T) {
   if castChecking {
-    if isIntType(val.type) {
+    if isIntType(this.type) {
       // int(?) -> uint(?)
-      if val < 0 then // runtime check
-        halt("casting "+typeToString(val.type)+" less than 0 to "+typeToString(T));
+      if this < 0 then // runtime check
+        halt("casting "+typeToString(this.type)+" less than 0 to "+typeToString(T));
     }
 
-    if max(val.type):uint > max(T):uint {
+    if max(this.type):uint > max(T):uint {
       // [u]int(?) -> uint(?)
-      if (val:uint > max(T):uint) then // runtime check
-        halt("casting "+typeToString(val.type)+" with a value greater than the maximum of "+
+      if (this:uint > max(T):uint) then // runtime check
+        halt("casting "+typeToString(this.type)+" with a value greater than the maximum of "+
              typeToString(T)+" to "+typeToString(T));
     }
   }
-  return val:T;
+  return this:T;
 }
 
-inline proc safe_cast(type T, val: integral) : T where isIntType(T) {
+inline proc integral.safeCast(type T) : T where isIntType(T) {
   if castChecking {
-    if max(val.type):uint > max(T):uint {
-      // this isUintType check lets us avoid a runtime check for val < 0
-      if isUintType(val.type) {
+    if max(this.type):uint > max(T):uint {
+      // this isUintType check lets us avoid a runtime check for this < 0
+      if isUintType(this.type) {
         // uint(?) -> int(?)
-        if val:uint > max(T):uint then // runtime check
-          halt("casting "+typeToString(val.type)+" with a value greater than the maximum of "+
+        if this:uint > max(T):uint then // runtime check
+          halt("casting "+typeToString(this.type)+" with a value greater than the maximum of "+
                typeToString(T)+" to "+typeToString(T));
       } else {
         // int(?) -> int(?)
         // max(T) <= max(int), so cast to int is safe
-        if val:int > max(T):int then // runtime check
-          halt("casting "+typeToString(val.type)+" with a value greater than the maximum of "+
+        if this:int > max(T):int then // runtime check
+          halt("casting "+typeToString(this.type)+" with a value greater than the maximum of "+
                typeToString(T)+" to "+typeToString(T));
       }
     }
-    if isIntType(val.type) {
-      if min(val.type):int < min(T):int {
+    if isIntType(this.type) {
+      if min(this.type):int < min(T):int {
         // int(?) -> int(?)
-        if val:int < min(T):int then // runtime check
-          halt("casting "+typeToString(val.type)+" with a value less than the minimum of "+
+        if this:int < min(T):int then // runtime check
+          halt("casting "+typeToString(this.type)+" with a value less than the minimum of "+
                typeToString(T)+" to "+typeToString(T));
       }
     }
   }
-  return val:T;
+  return this:T;
 }
 
-proc safe_cast(type T, val) {
-  compilerError("safe_cast is only supported between integrals");
+proc integral.safeCast(type T) {
+  compilerError("safeCast is only supported between integral types");
 }
 
 //

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -59,7 +59,7 @@ Run-time Semantic Check Options:
       --[no-]local-checks             Enable [disable] local block checking
       --[no-]nil-checks               Enable [disable] nil checking
       --[no-]stack-checks             Enable [disable] stack overflow checking
-      --[no-]cast-checks              Enable [disable] checks in safe_cast
+      --[no-]cast-checks              Enable [disable] checks in safeCast
                                       calls
 
 C Code Generation Options:

--- a/test/studies/shootout/pidigits/hilde/pidigits-hilde.chpl
+++ b/test/studies/shootout/pidigits/hilde/pidigits-hilde.chpl
@@ -72,8 +72,8 @@ proc pidigits
 proc next_term(k:uint)
 {
   var y2_tmp:uint = 2 * k + 1,
-    y2 = safe_cast(c_ulong, y2_tmp),
-    ck = safe_cast(c_ulong, k);
+    y2 = y2_tmp.safeCast(c_ulong),
+    ck = k.safeCast(c_ulong);
 
   mpz_mul_2exp(tmp1, numer, 1:c_ulong);
   mpz_add(accum, accum, tmp1);		// accum <- accum + numer * 2
@@ -104,7 +104,7 @@ proc extract_digit : int
 
 proc eliminate_digit(d: uint)
 {
-  mpz_submul_ui(accum, denom, safe_cast(c_ulong, d));
+  mpz_submul_ui(accum, denom, d.safeCast(c_ulong));
   mpz_mul_ui(accum, accum, 10);
   mpz_mul_ui(numer, numer, 10);
 }

--- a/test/types/scalar/kbrady/int_int16.chpl
+++ b/test/types/scalar/kbrady/int_int16.chpl
@@ -1,3 +1,3 @@
-writeln(safe_cast(int(16), -1:int(64)));
-writeln(safe_cast(int(16), 1:int(64)));
-writeln(safe_cast(int(16), min(int(64))));
+writeln((-1:int(64)).safeCast(int(16)));
+writeln((1:int(64)).safeCast(int(16)));
+writeln(min(int(64)).safeCast(int(16)));

--- a/test/types/scalar/kbrady/int_uint.chpl
+++ b/test/types/scalar/kbrady/int_uint.chpl
@@ -1,6 +1,6 @@
-writeln(safe_cast(uint, 0));
-writeln(safe_cast(uint, max(int(8))));
-writeln(safe_cast(uint, max(int(16))));
-writeln(safe_cast(uint, max(int(32))));
-writeln(safe_cast(uint, max(int(64))));
-writeln(safe_cast(uint, -1));
+writeln(0.safeCast(uint));
+writeln(max(int(8)).safeCast(uint));
+writeln(max(int(16)).safeCast(uint));
+writeln(max(int(32)).safeCast(uint));
+writeln(max(int(64)).safeCast(uint));
+writeln((-1).safeCast(uint));

--- a/test/types/scalar/kbrady/uint_int.chpl
+++ b/test/types/scalar/kbrady/uint_int.chpl
@@ -1,7 +1,7 @@
-writeln(safe_cast(int, min(uint(64))));
+writeln(min(uint(64)).safeCast(int));
 
-writeln(safe_cast(int, max(uint(8))));
-writeln(safe_cast(int, max(uint(16))));
-writeln(safe_cast(int, max(uint(32))));
-writeln(safe_cast(int, max(int):uint));
-writeln(safe_cast(int, max(uint(64))));
+writeln(max(uint(8)).safeCast(int));
+writeln(max(uint(16)).safeCast(int));
+writeln(max(uint(32)).safeCast(int));
+writeln((max(int):uint).safeCast(int));
+writeln(max(uint(64)).safeCast(int));

--- a/test/types/scalar/kbrady/uint_uint16.chpl
+++ b/test/types/scalar/kbrady/uint_uint16.chpl
@@ -1,3 +1,3 @@
-writeln(safe_cast(uint(16), min(uint(64))));
-writeln(safe_cast(uint(16), 1:uint(64)));
-writeln(safe_cast(uint(16), max(uint(64))));
+writeln(min(uint(64)).safeCast(uint(16)));
+writeln((1:uint(64)).safeCast(uint(16)));
+writeln(max(uint(64)).safeCast(uint(16)));

--- a/test/users/npadmana/fftw/FFTW.chpl
+++ b/test/users/npadmana/fftw/FFTW.chpl
@@ -108,7 +108,7 @@ module FFTW {
     :type nthreads: int
    */
   proc plan_with_nthreads(nthreads: int) {
-    C_FFTW.fftw_plan_with_nthreads(safe_cast(c_int, nthreads));
+    C_FFTW.fftw_plan_with_nthreads(nthreads.safeCast(c_int));
   }
 
 
@@ -147,9 +147,9 @@ module FFTW {
 
     var dims: rank*c_int;
     for param i in 1..rank do
-      dims(i) = safe_cast(c_int, input.domain.dim(i).size);
+      dims(i) = input.domain.dim(i).size.safeCast(c_int);
 
-    return C_FFTW.fftw_plan_dft(safe_cast(c_int, rank), dims, input, 
+    return C_FFTW.fftw_plan_dft(rank.safeCast(c_int), dims, input, 
                                      output, sign, flags);
   }
 


### PR DESCRIPTION
It was brought up that doing `val.safeCast(type)` is nicer than `safe_cast(type, val)`. This commit implements the switch in syntax.