### PR TITLE
Remove a tautological condition that breaks my home Mac build tonight

### DIFF
--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -500,7 +500,6 @@ typedef bool qio_bool;
       (size_t) count <= (SIZE_MAX / sizeof(type)) ) { \
     /* check that count is positive and small enough to go on the stack */ \
     if( (ssize_t) count >= 0 && \
-        (ssize_t) count <= SSIZE_MAX && \
         (size_t) count <= (sizeof(onstack)/sizeof(type)) ) { \
       ptr = onstack; \
     } else { \


### PR DESCRIPTION
When compiling in developer mode, this line breaks my home Mac build (gcc 4.2.1) because it's a tautological conditional.

