### PR TITLE
Fix potential segfault in narrowWideReferences

### DIFF
--- a/compiler/optimizations/narrowWideReferences.cpp
+++ b/compiler/optimizations/narrowWideReferences.cpp
@@ -907,13 +907,14 @@ narrowArg(ArgSymbol* arg, WideInfo* wi,
 static bool usedInOn(Symbol* sym, Map<Symbol*, Vec<SymExpr*>*> &useMap, CallGraph* graph) {
   for_uses(use, useMap, sym) {
     if (FnSymbol* fn = toFnSymbol(use->parentSymbol)) {
-      CallGraph::Node* n = graph->vertices[fn];
-      if (n->onDepth != 0 ||
-          fn->hasFlag(FLAG_ON_BLOCK) ||
-          fn->hasFlag(FLAG_ON)) {
-            DEBUG_PRINTF("ON: %s used in %s (%d): %d\n", sym->cname, fn->cname, fn->id, n->onDepth);
-            return true;
-      }
+      if (CallGraph::Node* n = graph->vertices[fn]) {
+        if (n->onDepth != 0 ||
+            fn->hasFlag(FLAG_ON_BLOCK) ||
+            fn->hasFlag(FLAG_ON)) {
+              DEBUG_PRINTF("ON: %s used in %s (%d): %d\n", sym->cname, fn->cname, fn->id, n->onDepth);
+              return true;
+        }
+      } else return true;
     }
   }
   return false;


### PR DESCRIPTION
This patch avoids a potential segfault, so far only caught by --no-local testing for miniMD.

Future development will likely result in a complete rework of this function and the call graph itself.

I'm going to commit this tonight to avoid failures for other unknown cases in nightly testing.