### PR TITLE
Proposed split of FFTW into FFTW and FFTW_MT

### DIFF
--- a/modules/standard/FFTW.chpl
+++ b/modules/standard/FFTW.chpl
@@ -26,10 +26,7 @@
   version 3.  Over time, the intention is to expand this support to
   additional routines, prioritizing based on user feedback.
 
-  As in general FFTW, the flow is to:
-
-  0) Call init_threads() and plan_with_nthreads() if using the
-     multithreaded FFTW interface.
+  As in standard FFTW usage, the flow is to:
 
   1) Create plan(s) using the plan_dft*() routines.
 
@@ -37,10 +34,7 @@
 
   3) Destroy the plan(s) using the destroy_plan() routine.
 
-  4) If using the multithreaded FFTW interface, call
-     cleanup_threads().  
-
-  5) Call cleanup().
+  4) Call cleanup().
 
   At present, clients of the FFTW module must specify fftw3.h and -I,
   -L, -l flags sufficient to specify the required libraries and find
@@ -107,28 +101,6 @@ module FFTW {
     plans between routines.
   */
   extern type fftw_plan; // opaque type
-
-
-  // Multi-threaded setup routines below
-  /*
-    Initialize the threads used for multi-threaded FFTW plans.
-
-    :returns: Zero if there was an error, non-zero otherwise.
-  */
-  proc init_threads() : c_int {
-    return C_FFTW.fftw_init_threads();
-  }
-
-  /*
-    Registers the number of threads to use for multi-threaded FFTW
-    plans.
-
-    :arg nthreads: The number of threads to use.
-    :type nthreads: int
-   */
-  proc plan_with_nthreads(nthreads: int) {
-    C_FFTW.fftw_plan_with_nthreads(nthreads.safeCast(c_int));
-  }
 
 
   // Planner functions
@@ -246,14 +218,6 @@ module FFTW {
     C_FFTW.fftw_destroy_plan(plan);
   }
 
-
-  /*
-    Cleans up the threads if multi-threaded FFTW's were enabled using
-    :proc:`init_threads()`.
-  */
-  proc cleanup_threads() {
-    C_FFTW.fftw_cleanup_threads();
-  }
 
   /*
     Cleans up FFTW overall.

--- a/modules/standard/FFTW_MT.chpl
+++ b/modules/standard/FFTW_MT.chpl
@@ -93,10 +93,15 @@ module FFTW_MT {
   }
 
 
+  //
+  // TODO: As with the previous routine, we could consider making
+  // this a method on locales if users want.
+  //
   /*
     Registers the number of threads to use for multi-threaded FFTW
     plans on all locales.  If fewer than one thread is requested, each
-    locale will default to here.maxTaskPar threads.
+    locale will default to here.maxTaskPar threads.  Note that this
+    routine can be called multiple times, overwriting previous values.
 
     :arg nthreads: The number of threads to use.
     :type nthreads: int

--- a/modules/standard/FFTW_MT.chpl
+++ b/modules/standard/FFTW_MT.chpl
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Wrapper for multithreaded FFTW version 3.
+
+/*
+  Support for key multithreaded FFTW version 3 routines in Chapel trappings
+
+  This module defines a Chapel wrapper around key routines from the
+  multithreaded support of FFTW version 3.  This module builds on the
+  FFTW module itself and inherits all of its functionality, so refer there
+  for most of the documentation.
+
+  The main differences in using this module are:
+
+  0) By default, the module will initialize itself to use
+     here.maxTaskPar threads per locale when calling plan_dft*()
+     routines.  To override this default or change it during program
+     execution, call plan_with_nthreads() manually.
+  
+  1-3) As in FFTW
+
+  3a) Call cleanup_threads() to release memory used by the FFTW threads.
+
+  Note that whereas the main FFTW.chpl module is a single-locale
+  module, this module is multi-locale in that, once it is loaded, any
+  locale can create and execute plans, though those plans will only be
+  valid on that locale.  Calls to plan_with_nthreads() and
+  cleanup_threads() will make those actions occur on all locales.
+
+  At present, clients of the FFTW module must specify fftw3.h,
+  -lfftw3, -lfftw3_threads on the command line with the appropriate -I
+  and -L flags sufficient to find the files.
+*/
+
+module FFTW_MT {
+  use FFTW;
+
+  //
+  // If this module is used, it should init_threads() upon start-up on
+  // all locales and request here.maxTaskPar threads by default.
+  //
+  coforall loc in Locales {
+    on loc do {
+      if (C_FFTW.fftw_init_threads() == 0) then
+        halt("Failed to properly initialize FFTW threads on locale ", here.id);
+    }
+  }
+  plan_with_nthreads(here.maxTaskPar);
+
+
+  /*
+    Registers the number of threads to use for multi-threaded FFTW
+    plans on all locales.
+
+    :arg nthreads: The number of threads to use.
+    :type nthreads: int
+   */
+  proc plan_with_nthreads(nthreads: int) {
+    coforall loc in Locales {
+      on loc do {
+        C_FFTW.fftw_plan_with_nthreads(nthreads.safeCast(c_int));
+      }
+    }
+  }
+
+
+  /*
+    Cleans up the threads if multi-threaded FFTW's were enabled using
+    :proc:`init_threads()`.
+  */
+  proc cleanup_threads() {
+    coforall loc in Locales {
+      on loc do {
+        C_FFTW.fftw_cleanup_threads();
+      }
+    }
+  }
+}

--- a/test/users/npadmana/fftw/testFFTW.chpl
+++ b/test/users/npadmana/fftw/testFFTW.chpl
@@ -1,8 +1,5 @@
 use FFTW;
 
-config param usethread : bool = false; // Compile in the multithreaded setup
-config var nthread : int(32) = 1; // Number of threads
-
 
 proc printcmp(x, y) {
   var err = max reduce abs(x-y);
@@ -134,22 +131,17 @@ proc runtest(param ndim : int, fn : string) {
 
 }
 
-// Initialize multi-threaded support if desired
-if (usethread) {
-  if (init_threads() == 0) then halt("Failed to initialize thread support:");
-  plan_with_nthreads(nthread);
+
+proc testAllDims() {
+  writeln("1D");
+  runtest(1, "arr1d.dat");
+  writeln("2D");
+  runtest(2, "arr2d.dat");
+  writeln("3D");
+  runtest(3, "arr3d.dat");
 }
 
-
-writeln("1D");
-runtest(1, "arr1d.dat");
-writeln("2D");
-runtest(2, "arr2d.dat");
-writeln("3D");
-runtest(3, "arr3d.dat");
-
-if (usethread) {
-  cleanup_threads();
+proc main() {
+  testAllDims();
+  cleanup();
 }
-cleanup();
-

--- a/test/users/npadmana/fftw/testFFTW.compopts
+++ b/test/users/npadmana/fftw/testFFTW.compopts
@@ -1,6 +1,1 @@
-## The basic case goes here
 fftw3.h -I$FFTW_DIR/include -L$FFTW_DIR/lib -lfftw3
-#testFFTW.good
-## Multithreaded support
-fftw3.h -susethread=true -I$FFTW_DIR/include -L$FFTW_DIR/lib -lfftw3 -lfftw3_threads -lpthread
-#testFFTW.good

--- a/test/users/npadmana/fftw/testFFTW.execopts
+++ b/test/users/npadmana/fftw/testFFTW.execopts
@@ -1,3 +1,0 @@
-## This is ignored if not compiled multithreaded
---nthread=2
-

--- a/test/users/npadmana/fftw/testFFTW_MT.chpl
+++ b/test/users/npadmana/fftw/testFFTW_MT.chpl
@@ -1,6 +1,5 @@
 use FFTW_MT, testFFTW;
 
-config param usethread : bool = false; // Compile in the multithreaded setup
 config var nthread = 2; // Number of threads
 
 

--- a/test/users/npadmana/fftw/testFFTW_MT.chpl
+++ b/test/users/npadmana/fftw/testFFTW_MT.chpl
@@ -1,0 +1,12 @@
+use FFTW_MT, testFFTW;
+
+config param usethread : bool = false; // Compile in the multithreaded setup
+config var nthread = 2; // Number of threads
+
+
+proc main() {
+  plan_with_nthreads(nthread);
+  testAllDims();
+  cleanup_threads();
+  cleanup();
+}

--- a/test/users/npadmana/fftw/testFFTW_MT.compopts
+++ b/test/users/npadmana/fftw/testFFTW_MT.compopts
@@ -1,1 +1,1 @@
-fftw3.h -susethread=true -I$FFTW_DIR/include -L$FFTW_DIR/lib -lfftw3 -lfftw3_threads -lpthread #testFFTW.good
+fftw3.h -I$FFTW_DIR/include -L$FFTW_DIR/lib -lfftw3 -lfftw3_threads -lpthread #testFFTW.good

--- a/test/users/npadmana/fftw/testFFTW_MT.compopts
+++ b/test/users/npadmana/fftw/testFFTW_MT.compopts
@@ -1,0 +1,1 @@
+fftw3.h -susethread=true -I$FFTW_DIR/include -L$FFTW_DIR/lib -lfftw3 -lfftw3_threads -lpthread #testFFTW.good


### PR DESCRIPTION
Spltting the FFTW module into a single- and multi-threaded
component is nice in that it permits the multi-threaded
version to initialize itself at module initialization time.
It also permits each file to list its own "requires"
dependence if I can get that agreed upon and committed in
time to make use of it.  Committing this for Nikhil's
purusal.