### PR TITLE
Remove .dat from output file name in perfexecopts

### DIFF
--- a/test/performance/bharshbarg/dom-forall.perfexecopts
+++ b/test/performance/bharshbarg/dom-forall.perfexecopts
@@ -1,2 +1,2 @@
---n=10000000000 --zipIter=false # dom-forall.dat
---n=10000000000 --zipIter=true  # dom-forall-zip.dat
+--n=10000000000 --zipIter=false
+--n=10000000000 --zipIter=true # dom-forall-zip

--- a/test/performance/bharshbarg/range-forall.perfexecopts
+++ b/test/performance/bharshbarg/range-forall.perfexecopts
@@ -1,2 +1,2 @@
---n=10000000000 --zipIter=false # range-forall.dat
---n=10000000000 --zipIter=true  # range-forall-zip.dat
+--n=10000000000 --zipIter=false
+--n=10000000000 --zipIter=true # range-forall-zip


### PR DESCRIPTION
Previously I had something like "# dom-forall.dat", however compute perf stats
adds the .dat ending, so specifying here resulted in the .dat files like
"dom-forall.dat.dat". This just updates the perfexecopts to place the perf
results in the right file.

I removed the *.dat.dat files and moved the data over to the right files in the
chapel-perf repo already.