### PR TITLE
Fix assignment to coforall bundled args

### DIFF
--- a/compiler/optimizations/narrowWideReferences.cpp
+++ b/compiler/optimizations/narrowWideReferences.cpp
@@ -1200,6 +1200,10 @@ static void pruneWidenMap(SymExprTypeMap& widenMap)
   // Prune the map of expressions to widen because of arguments that
   // have been narrowed.
   //
+  // For every narrow ArgSymbol, use corresponding actuals as keys
+  // to set the value to null in the widenMap. If the value is null,
+  // a wide temporary will not be made for the actual.
+  //
   form_Map(WideInfoMapElem, e, *wideInfoMap) {
     WideInfo* wi = e->value;
     if (!wi->mustBeWide) {
@@ -1214,6 +1218,13 @@ static void pruneWidenMap(SymExprTypeMap& widenMap)
       }
     }
   }
+
+
+  //
+  // For every SymExpr remaining in the widenMap that is used
+  // in PRIM_SET_MEMBER, set the value to null if the member
+  // is narrow.
+  //
   form_Map(SymExprTypeMapElem, e, widenMap) {
     SymExpr* key = e->key;
     Type* value = e->value;

--- a/compiler/optimizations/narrowWideReferences.cpp
+++ b/compiler/optimizations/narrowWideReferences.cpp
@@ -343,7 +343,7 @@ static void resolveHelper(WideInfo* wi);
 static void doNarrowing(SymExprTypeMap&);
 static void handleLocalFields(Map<Symbol*,Vec<SymExpr*>*>& defMap,
                               Map<Symbol*,Vec<SymExpr*>*>& useMap);
-static void pruneNarrowedActuals(SymExprTypeMap&);
+static void pruneWidenMap(SymExprTypeMap&);
 static void printNarrowEffectSummary();
 static void insertWideReferenceTemps(SymExprTypeMap&);
 static void moveAddressSourcesToTemp();
@@ -661,8 +661,8 @@ narrowSym(Symbol* sym, WideInfo* wi,
       }
     }
 #ifdef PRINT_NARROW_ANALYSIS
-    DEBUG_PRINTF("No case to narrow def %d %s in %s", wi->sym->id, wi->sym->cname, se->getModule()->cname);
-    print_view(se->getStmtExpr());
+    DEBUG_PRINTF("No case to narrow def %d %s in %s", wi->sym->id, wi->sym->cname, def->getModule()->cname);
+    print_view(def->getStmtExpr());
 #endif
   }
 
@@ -712,7 +712,7 @@ narrowSym(Symbol* sym, WideInfo* wi,
         continue;
           }
       if (call->isResolved()) {
-        // pruneNarrowedActuals will clean up
+        // pruneWidenMap will clean up
         DEBUG_PRINTF("call: widening expr %d\n", sym->id);
         wi->exprsToWiden.push_back(use);
         continue;
@@ -733,6 +733,7 @@ narrowSym(Symbol* sym, WideInfo* wi,
           if (strcmp(base->var->type->symbol->cname, "_class_localscoforall_fn") == 0) {
             DEBUG_PRINTF("trying to narrow coforall arg: %d -> %d\n", sym->id, member->var->id);
             addNarrowDep(sym, member->var);
+            wi->exprsToWiden.push_back(use);
           } else {
             // For all other types, we assume the fields are wide.
             DEBUG_PRINTF("set: widening expr %d\n", sym->id);
@@ -953,7 +954,7 @@ narrowWideReferences() {
 
   doNarrowing(*widenMap);
 
-  pruneNarrowedActuals(*widenMap);
+  pruneWidenMap(*widenMap);
 
   printNarrowEffectSummary();
 
@@ -1193,7 +1194,7 @@ static void doNarrowing(SymExprTypeMap& widenMap)
 }
 
 
-static void pruneNarrowedActuals(SymExprTypeMap& widenMap)
+static void pruneWidenMap(SymExprTypeMap& widenMap)
 {
   //
   // Prune the map of expressions to widen because of arguments that
@@ -1209,6 +1210,20 @@ static void pruneNarrowedActuals(SymExprTypeMap& widenMap)
           SymExpr* actual = toSymExpr(formal_to_actual(call, arg));
           widenMap.put(actual, NULL);
           DEBUG_PRINTF("PRUNE: %d\n", actual->var->id);
+        }
+      }
+    }
+  }
+  form_Map(SymExprTypeMapElem, e, widenMap) {
+    SymExpr* key = e->key;
+    Type* value = e->value;
+    if (value) {
+      if (CallExpr* call = toCallExpr(key->parentExpr)) {
+        if (call->isPrimitive(PRIM_SET_MEMBER)) {
+          SymExpr* member = toSymExpr(call->get(2));
+          if (!isWideType(member->var)) {
+            widenMap.put(key, NULL);
+          }
         }
       }
     }


### PR DESCRIPTION
This patch fixes an error that may occur in the generated C code of a multilocale program.

The 'narrowWideReferences' pass will attempt to narrow the fields in coforall bundled args. Under certain circumstances this pass chooses incorrect types when assigning to such fields.

The solution is to sometimes make a wide temporary for the RHS of PRIM_SET_MEMBER, but only if the field is wide.