### PR TITLE
Switched HPCC time-reporting graph titles from "Performance" to "Time"

### DIFF
--- a/test/release/examples/benchmarks/hpcc/fft.graph
+++ b/test/release/examples/benchmarks/hpcc/fft.graph
@@ -1,6 +1,6 @@
 perfkeys: Execution time =
 graphkeys: fft
 files: fft.dat
-graphtitle: HPCC FFT Performance
+graphtitle: HPCC FFT Time
 ylabel: Time (seconds)
 graphname: fft

--- a/test/release/examples/benchmarks/hpcc/hpl.graph
+++ b/test/release/examples/benchmarks/hpcc/hpl.graph
@@ -1,6 +1,6 @@
 perfkeys: Execution time =, Execution time =
 graphkeys: hpl, hpl MAX_LOGICAL
 files: hpl.dat, hplMaxLogical.dat
-graphtitle: HPCC HPL Performance
+graphtitle: HPCC HPL Time
 ylabel: Time (seconds)
 graphname: hpl

--- a/test/release/examples/benchmarks/hpcc/ptrans.graph
+++ b/test/release/examples/benchmarks/hpcc/ptrans.graph
@@ -1,6 +1,6 @@
 perfkeys: Execution time =
 graphkeys: ptrans
 files: ptrans.5733.dat
-graphtitle: HPCC PTRANS Performance (numrows=5733)
+graphtitle: HPCC PTRANS Time (numrows=5733)
 ylabel: Time (seconds)
 graphname: ptrans

--- a/test/release/examples/benchmarks/hpcc/ra.graph
+++ b/test/release/examples/benchmarks/hpcc/ra.graph
@@ -1,6 +1,6 @@
 perfkeys: Execution time =, Execution time =
 graphkeys: RA, RA w/atomics
 files: hpcc-ra.dat, hpcc-ra-atomics.dat
-graphtitle: HPCC RA Performance
+graphtitle: HPCC RA Time
 ylabel: Time (seconds)
 graphname: hpcc-ra

--- a/test/release/examples/benchmarks/hpcc/stream-ep.graph
+++ b/test/release/examples/benchmarks/hpcc/stream-ep.graph
@@ -1,5 +1,5 @@
 perfkeys: max (seconds) =, avg (seconds) =, min (seconds) =
 files: hpcc-stream-ep.dat, hpcc-stream-ep.dat, hpcc-stream-ep.dat
-graphtitle: HPCC STREAM-EP Performance
+graphtitle: HPCC STREAM-EP Time
 ylabel: Time (seconds)
 graphname: hpcc-stream-ep

--- a/test/release/examples/benchmarks/hpcc/stream.graph
+++ b/test/release/examples/benchmarks/hpcc/stream.graph
@@ -1,5 +1,5 @@
 perfkeys: min =, avg =
 files: hpcc-stream.dat, hpcc-stream.dat
-graphtitle: Global STREAM Performance
+graphtitle: Global STREAM Time
 ylabel: Time (seconds)
 graphname: global-stream


### PR DESCRIPTION
In a discussion on our internal mailing list, we supported the convention to use the terms "performance" and "time" for two reciprocal performance metrics.

This change implements that in a couple of performance graph titles, with the goal to distinguish the two metrics clearly on our performance graph pages.
