### PR TITLE
Re-home paths taken from libtool .la files.

### DIFF
--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -35,6 +35,10 @@ def handle_la(la_path):
                     args.append(p.sub(r'-l\1', lib_name))
                 elif 'dependency_libs=' in line:
                     for tok in line.split('\'')[1].split():
+                        # paths reflect built env; replace with $CHPL_HOME
+                        pat = re.compile(r'^((-L\s*)?).*(/third-party/)')
+                        repl = r'\1' + utils.get_chpl_home() + r'\3'
+                        tok = pat.sub(repl, tok)
                         if tok.endswith('.la'):
                             args.extend(handle_la(tok))
                         else:


### PR DESCRIPTION
The paths in libtool .la files reflect where things were when the .la
files were built.  If the Chapel directory hierarchy is subsequently
moved (as for example when we install a module we've built), those paths
are no longer valid.  To deal with this, when interpreting such paths
replace the part prior to the rightmost '/third-party/' component with
the current value of $CHPL_HOME.