### PR TITLE
Repair retrieval of the hwloc install dir.

### DIFF
--- a/test/localeModels/gbt/maxTaskPar.prediff
+++ b/test/localeModels/gbt/maxTaskPar.prediff
@@ -40,10 +40,10 @@ case $target in
   linux*|cray-xc|cray-xe|cygwin*)
     case $locModel-$tasks in
       numa-qthreads)
-        hwld=$( $CHPL_HOME/util/config/compileline --libraries |
-                tr ' ' '\n' |
-                grep '^[-]L.*/hwloc/install/' |
-                sed -e 's,^-L,,' -e 's,/lib$,,' )
+        ucp=$( $CHPL_HOME/util/printchplenv --make |
+               grep HWLOC_UNIQ_CFG_PATH |
+               cut -d= -f2 )
+        hwld=$CHPL_HOME/third-party/hwloc/install/$ucp
         if [[ -n $hwld && -d $hwld/bin ]] ; then
           numNuma=$( $hwld/bin/lstopo --only numa | wc -l )
           numCores=$( $hwld/bin/lstopo --only cores | wc -l )


### PR DESCRIPTION
A side effect of the recent third-party integration changes is that a
given third-party package install directory will appear in the output
from 'compilelink --libraries' more than once if it is referred to both
explicitly by Chapel's user program Make infrastructure and implicitly
by at least one of the other third-party packages.  Hwloc is an example
of this.  Once things settle down I intend to clean this up, but in the
meantime it's breaking how maxTaskPar.prediff finds the lstopo utility
in order to collect hardware info.  Here we simplify this by getting the
hwloc install directory in a more straightforward way.