### PR TITLE
Resolve initial comm counts change

### DIFF
--- a/compiler/optimizations/narrowWideReferences.cpp
+++ b/compiler/optimizations/narrowWideReferences.cpp
@@ -632,8 +632,13 @@ narrowSym(Symbol* sym, WideInfo* wi,
         if (SymExpr* rhs = toSymExpr(call->get(2))) {
             bool isObj = isWideObj || isClass(sym->type);
             bool rhsIsWide = isWideType(rhs->var);
-            if (rhsIsWide && (isRef(sym) || isObj)) {
-              addNarrowDep(rhs->var, sym);
+            if (rhsIsWide) {
+              if (isObj) {
+                addNarrowDep(rhs->var, sym);
+              }
+              if (isRef(rhs->var) && isRef(sym)) {
+                addNarrowDep(rhs->var, sym);
+              }
             }
             if (isRef(sym)) {
               if (rhs->var->type->symbol->hasFlag(FLAG_WIDE_CLASS) ||

--- a/compiler/optimizations/narrowWideReferences.cpp
+++ b/compiler/optimizations/narrowWideReferences.cpp
@@ -633,13 +633,18 @@ narrowSym(Symbol* sym, WideInfo* wi,
             bool isObj = isWideObj || isClass(sym->type);
             bool rhsIsWide = isWideType(rhs->var);
             if (rhsIsWide) {
+              // For 'class = x', the LHS has to be wide if the RHS is wide.
               if (isObj) {
                 addNarrowDep(rhs->var, sym);
               }
+
+              // If the RHS is a wide ref, the LHS must also be wide.
               if (isRef(rhs->var) && isRef(sym)) {
                 addNarrowDep(rhs->var, sym);
               }
             }
+
+            // This handles the 'ref = class' case.
             if (isRef(sym)) {
               if (rhs->var->type->symbol->hasFlag(FLAG_WIDE_CLASS) ||
                   isRef(rhs->var)) {


### PR DESCRIPTION
My recent PR #1449 resulted in fewer fast forks due to conservative widening of references. This patch results in better decision making for assignment to references, leaving more of them narrow.

This should fix the regression for test/modules/sungeun/init/printInitCommCounts.chpl

This change has passed gasnet testing for these directories:
  - distributions
  - multilocale
  - release/examples/benchmarks