### PR TITLE
Implement umask

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -498,6 +498,16 @@ proc symlink(oldName: string, newName: string) {
   if err != ENOERR then ioerror(err, "in symlink " + oldName, newName);
 }
 
+/* Sets the file creation mask of the current process to mask, and returns
+   the previous value of the file creation mask.
+   mask: the file creation mask to use now.
+*/
+proc umask(mask: int): int {
+  extern proc chpl_fs_umask(mask: mode_t): mode_t;
+
+  return chpl_fs_umask(mask.safeCast(mode_t));
+}
+
 /* Returns an integer representing the current permissions of the file specified
    by name.  May generate an error message.
    err: a syserr used to indicate if an error occurred during this function

--- a/runtime/include/chpl-file-utils.h
+++ b/runtime/include/chpl-file-utils.h
@@ -24,6 +24,7 @@
 #include "qio.h"
 #include "sys_basic.h"
 
+#include "sys/stat.h"
 
 qioerr chpl_fs_chdir(const char* name);
 
@@ -60,6 +61,8 @@ qioerr chpl_fs_samefile(int* ret, qio_file_t* file1, qio_file_t* file2);
 qioerr chpl_fs_samefile_string(int* ret, const char* file1, const char* file2);
 
 qioerr chpl_fs_symlink(const char* orig, const char* linkName);
+
+mode_t chpl_fs_umask(mode_t mask);
 
 qioerr chpl_fs_viewmode(int* ret, const char* name);
 

--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -287,6 +287,10 @@ qioerr chpl_fs_symlink(const char* orig, const char* linkName) {
 
 }
 
+mode_t chpl_fs_umask(mode_t mask) {
+  return umask(mask);
+}
+
 /* Returns the current permissions on a file specified by name */
 qioerr chpl_fs_viewmode(int* ret, const char* name) {
   struct stat buf;

--- a/test/modules/standard/FileSystem/lydia/umask/changeMask.chpl
+++ b/test/modules/standard/FileSystem/lydia/umask/changeMask.chpl
@@ -1,0 +1,12 @@
+use FileSystem;
+
+var newMask = 0o777;
+var oldMask = umask(newMask);
+var shouldMatchFirst = umask(oldMask);
+
+if newMask != shouldMatchFirst {
+  writeln("Uh oh, I didn't get the right umask back!");
+  writef("Expected umask %oi but got %oi\n", newMask, shouldMatchFirst);
+} else {
+  writeln("Phew, the returned umask value matched what I sent it!");
+}

--- a/test/modules/standard/FileSystem/lydia/umask/changeMask.good
+++ b/test/modules/standard/FileSystem/lydia/umask/changeMask.good
@@ -1,0 +1,1 @@
+Phew, the returned umask value matched what I sent it!


### PR DESCRIPTION
Basically, wraps a call to the C function umask in Chapel.  The test ensures
that you can change the umask to an appropriate value, and that changing it back
to the old value returns the umask you gave it.  I verified that other umask
functionality behaved as expected.