### PR TITLE
Update testRelease and tokctnightly to _actually_ use send_email.py.

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -6,6 +6,7 @@ use Cwd 'abs_path';
 $cwd = abs_path(dirname(__FILE__));
 $chplhomedir = abs_path("$cwd/../..");
 
+
 # Mailing lists.
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
 $allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";

--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -1,5 +1,11 @@
 #!/usr/bin/env perl
 
+use File::Basename;
+use Cwd 'abs_path';
+
+$cwd = abs_path(dirname(__FILE__));
+$chplhomedir = abs_path("$cwd/../..");
+
 # Mailing lists.
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
 $allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
@@ -100,10 +106,12 @@ if ($mailer eq "") {
     if ($? == 0) {
         $mailer = "$chplsendemail --header=Reply-To=$replymail,Precedence=bulk";
     } else {
+        print "[Error: send_email.py failed to run. Defaulting to 'mail'.]\n";
         $mailer = "mail";
     }
 }
 print "\$mailer = $mailer\n";
+
 
 $somethingfailed = 0;
 

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -7,6 +7,10 @@ use File::Basename;
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
 $replymail = "chapel-developers\@lists.sourceforge.net";
 
+$tokctdir = abs_path(dirname(__FILE__));
+$tokctr = "$tokctdir/tokencount.cron";
+$chplhomedir = abs_path("$tokctdir/../..");
+
 $printusage = 0;
 if (@ARGV) {
     $debugflag = shift @ARGV;
@@ -72,10 +76,12 @@ if ($mailer eq "") {
     if ($? == 0) {
         $mailer = "$chplsendemail --header=Reply-To=$replymail,Precedence=bulk";
     } else {
+        print "[Error: send_email.py failed to run. Defaulting to 'mail'.]\n";
         $mailer = "mail";
     }
 }
 print "\$mailer = $mailer\n";
+
 
 if ($cronrecipient eq "" and exists($ENV{"CHPL_NIGHTLY_CRON_RECIPIENT"})) {
     $cronrecipient = $ENV{"CHPL_NIGHTLY_CRON_RECIPIENT"};
@@ -100,9 +106,6 @@ if ($debug == 1) {
 #
 # directory locations
 #
-$tokctdir = abs_path(dirname(__FILE__));
-$tokctr = "$tokctdir/tokencount.cron";
-$chplhomedir = abs_path("$tokctdir/../..");
 $logdir = "/data/sea/chapel/Nightly";
 $statdir = "$logdir/Stats";
 if ($debug == 1) {


### PR DESCRIPTION
Previously, these scripts were not setting $chplhomedir before testing
send_email.py, so the test would fail and they would revert to using the
regular mail program. Update the scripts to set $chplhomedir before testing the
mailer.