### PR TITLE
Update docs() pass to create output directory with 0777 permissions by default.

### DIFF
--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -84,8 +84,9 @@ void docs(void) {
     }
 
     // TODO: Check for errors here... (thomasvandoren, 2015-02-25)
-    mkdir(docsRstDir.c_str(), 0777);
-    mkdir(docsOutputDir.c_str(), 0777);
+    const int dirPerms = S_IRWXU | S_IRWXG | S_IRWXO;
+    mkdir(docsRstDir.c_str(), dirPerms);
+    mkdir(docsOutputDir.c_str(), dirPerms);
 
 
     forv_Vec(ModuleSymbol, mod, gModuleSymbols) {

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -84,8 +84,8 @@ void docs(void) {
     }
 
     // TODO: Check for errors here... (thomasvandoren, 2015-02-25)
-    mkdir(docsRstDir.c_str(), S_IWUSR|S_IRUSR|S_IXUSR);
-    mkdir(docsOutputDir.c_str(), S_IWUSR|S_IRUSR|S_IXUSR);
+    mkdir(docsRstDir.c_str(), 0777);
+    mkdir(docsOutputDir.c_str(), 0777);
 
 
     forv_Vec(ModuleSymbol, mod, gModuleSymbols) {


### PR DESCRIPTION
Previously, the permissions on the docs output directory were always 0700. This
makes the directory unreadable by other group members and users, by
default.

Update the permissions to be completely open by default, and rely on the umask
to appropriately restrict them. For example, when the umask is 0022, the
output directory will end up with 0755 permissions. If the umask is 0077, the
output directory will end up with 0700 permissions.

I verified the chpldoc tests still pass.