### PR TITLE
Fix the bugs discovered in copy and friends

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -247,9 +247,6 @@ proc copyFile(out err: syserr, src: string, dest: string) {
       // Some of these routines don't exist with Chapel wrappers now
 
       destChnl.write(line[0..#numRead]);
-      if numRead != line.size {
-        break;
-      }
     }
     if err == EEOF then err = ENOERR;
     destChnl.flush();

--- a/test/modules/standard/FileSystem/lydia/copy/copying.prediff
+++ b/test/modules/standard/FileSystem/lydia/copy/copying.prediff
@@ -22,12 +22,14 @@ with open(sys.argv[2], 'ab') as fp:
     else:
         fp.write("group did match\n")
 
-    if abs(fooStat.st_atime - barStat.st_atime) > .5:
+    if abs(fooStat.st_atime - barStat.st_atime) > 1:
+        # we care about the time to a second, not to a fraction of a second
+        # which may be reported
         fp.write("Expected access time of " + str(fooStat.st_atime) + ", was " + str(barStat.st_atime) + "\n")
     else:
         fp.write("access time did match\n")
 
-    if abs(fooStat.st_mtime - barStat.st_mtime) > .5:
+    if abs(fooStat.st_mtime - barStat.st_mtime) > 1:
         fp.write("Expected modification time of " + str(fooStat.st_mtime) + ", was " + str(barStat.st_mtime) + "\n")
     else:
         fp.write("modification time did match\n")


### PR DESCRIPTION
My comparison of access and modification time failed on our linux32 testing
system because my error tolerance was not high enough.  The decimal place
represents fractions of a second, but we really only care about seconds (if
that).

Also, if the line read was shorter than the expected buffer, copyFile would
stop copying the file as a whole.  Whoops.  Just rely on EOF.