### PR TITLE
Improve memcpy fix vs empty arrays

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2329,6 +2329,10 @@ module ChapelArray {
       return;
     }
 
+    if a.size == 0 && b.size == 0 then
+      // Do nothing for zero-length assignments
+      return;
+
     if boundsChecking then
       checkArrayShapesUponAssignment(a, b);
   

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1040,6 +1040,9 @@ module DefaultRectangular {
       Blo(i) = Bdims(i).first;
   
     const len = dom.dsiNumIndices:int(32);
+
+    if len == 0 then return;
+
     if debugBulkTransfer {
       pragma "no prototype"
       extern proc sizeof(type x): int;

--- a/test/performance/ferguson/array-assign-block-get.chpl
+++ b/test/performance/ferguson/array-assign-block-get.chpl
@@ -1,0 +1,32 @@
+use BlockDist;
+use CommDiagnostics;
+
+config const n = 100000;
+
+const Space = {1..n};
+const D = Space dmapped Block(boundingBox=Space);
+var A: [D] int;
+
+var saveB1: int;
+var saveBn: int;
+
+for i in 1..n {
+  A[i] = i;
+}
+
+resetCommDiagnostics();
+startCommDiagnostics();
+
+on Locales[1] {
+  var B: [D] int;
+  B = A;
+  saveB1 = B[1];
+  saveBn = B[n];
+}
+
+stopCommDiagnostics();
+
+writeln(saveB1);
+writeln(saveBn);
+
+writeln(getCommDiagnostics());

--- a/test/performance/ferguson/array-assign-block-get.good
+++ b/test/performance/ferguson/array-assign-block-get.good
@@ -1,0 +1,3 @@
+1
+100000
+(get = 13, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 4, fork_fast = 0, fork_nb = 0) (get = 14, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 2, fork_fast = 0, fork_nb = 2)

--- a/test/performance/ferguson/array-assign-block.chpl
+++ b/test/performance/ferguson/array-assign-block.chpl
@@ -1,0 +1,30 @@
+use BlockDist;
+use CommDiagnostics;
+
+config const n = 100000;
+
+const Space = {1..n};
+const D = Space dmapped Block(boundingBox=Space);
+var A: [D] int;
+var B: [D] int;
+
+var saveB1: int;
+var saveBn: int;
+
+for i in 1..n {
+  A[i] = i;
+}
+
+resetCommDiagnostics();
+startCommDiagnostics();
+
+B = A;
+saveB1 = B[1];
+saveBn = B[n];
+
+stopCommDiagnostics();
+
+writeln(saveB1);
+writeln(saveBn);
+
+writeln(getCommDiagnostics());

--- a/test/performance/ferguson/array-assign-block.good
+++ b/test/performance/ferguson/array-assign-block.good
@@ -1,0 +1,3 @@
+1
+100000
+(get = 14, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 0, fork_fast = 0, fork_nb = 1) (get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0)

--- a/test/performance/ferguson/array-assign-get.chpl
+++ b/test/performance/ferguson/array-assign-get.chpl
@@ -1,0 +1,28 @@
+use CommDiagnostics;
+
+
+config const n = 100000;
+var A: [1..n] int;
+var saveB1: int;
+var saveBn: int;
+
+for i in 1..n {
+  A[i] = i;
+}
+
+resetCommDiagnostics();
+startCommDiagnostics();
+
+on Locales[1] {
+  var B: [1..n] int;
+  B = A;
+  saveB1 = B[1];
+  saveBn = B[n];
+}
+
+stopCommDiagnostics();
+
+writeln(saveB1);
+writeln(saveBn);
+
+writeln(getCommDiagnostics());

--- a/test/performance/ferguson/array-assign-get.good
+++ b/test/performance/ferguson/array-assign-get.good
@@ -1,0 +1,3 @@
+1
+100000
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0) (get = 11, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 2, fork_fast = 0, fork_nb = 0)

--- a/test/performance/ferguson/array-assign.chpl
+++ b/test/performance/ferguson/array-assign.chpl
@@ -1,0 +1,22 @@
+use CommDiagnostics;
+
+
+config const n = 100000;
+var A: [1..n] int;
+var B: [1..n] int;
+
+for i in 1..n {
+  A[i] = i;
+}
+
+resetCommDiagnostics();
+startCommDiagnostics();
+
+B = A;
+
+stopCommDiagnostics();
+
+writeln(B[1]);
+writeln(B[n]);
+
+writeln(getCommDiagnostics());

--- a/test/performance/ferguson/array-assign.good
+++ b/test/performance/ferguson/array-assign.good
@@ -1,0 +1,3 @@
+1
+100000
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 0, fork_fast = 0, fork_nb = 0) (get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 0, fork_fast = 0, fork_nb = 0)


### PR DESCRIPTION
The earlier memcpy fix did not detect the cause of
memcpy with src==dst at the array assignment
level. The problem was occurring with default-inited
arrays. Note that overlapping memcpys might still
need to be handled in the distributions when array
aliasing or slicing is going on, but those details
depend on the distribution.

Also check for zero-length copies before
doing the GET in doiBulkTransfer. This is
really just extra security.

I've verified that this passes full local testing and that
the comms counts do not change before/after
this patch with GASNET.