### PR TITLE
Check only once for overflow, do it with a uint64 to work on 32-bit

### DIFF
--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -497,10 +497,9 @@ typedef bool qio_bool;
 { \
   /* check for integer overflow or negative count */ \
   if( count >= 0 && \
-      (size_t) count <= (SIZE_MAX / sizeof(type)) ) { \
+      (uint64_t) count <= (SIZE_MAX / sizeof(type)) ) { \
     /* check that count is positive and small enough to go on the stack */ \
-    if( (ssize_t) count >= 0 && \
-        (size_t) count <= (sizeof(onstack)/sizeof(type)) ) { \
+    if( (size_t) count <= (sizeof(onstack)/sizeof(type)) ) { \
       ptr = onstack; \
     } else { \
       ptr = (type*) qio_malloc(count*sizeof(type)); \


### PR DESCRIPTION
... even if the count argument has type uint64_t.

My last attempt at fixing MAYBE_STACK_ALLOC had problems on
some systems with a tautological comparison. Here I'm trying
to solve the same problem (count is 64-bit but size is 32-bit)
with a different strategy - using a uint64_t explicitly.

This is a continuation of #1457 and #1476.

Future work: make all callers of MAYBE_STACK_ALLOC
pass in a ssize_t, replace MAYBE_STACK_SPACE with
inline code, possibly replace these macros with something
better.

Passes full local testing.

Thanks to @noakesmichael for reviewing. 