### PR TITLE
Range standalone parallel iterator

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -68,7 +68,8 @@ static void nonLeaderParCheckInt(FnSymbol* fn, bool allowYields)
       (taskFn->hasFlag(FLAG_BEGIN) ||
        taskFn->hasFlag(FLAG_COBEGIN_OR_COFORALL));
     if (isParallelConstruct ||
-        (call->isNamed("_toLeader"))) {
+        call->isNamed("_toLeader") ||
+        call->isNamed("_toStandalone")) {
       USR_FATAL_CONT(call, "invalid use of parallel construct in serial iterator");
     }
     if ((call->isPrimitive(PRIM_BLOCK_ON)) ||

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1317,11 +1317,7 @@ module ChapelRange {
       writeln("*** RI: length=", v, " numChunks=", numChunks);
     }
 
-    if v == 0 {
-      return;
-    }
-
-    if numChunks == 1 {
+    if numChunks <= 1 {
       for i in this {
         yield i;
       }

--- a/test/functions/iterators/diten/standaloneParallelInSerialIterator.chpl
+++ b/test/functions/iterators/diten/standaloneParallelInSerialIterator.chpl
@@ -1,0 +1,36 @@
+iter myiter(n: int) {
+  for i in 1..n do yield i;
+}
+
+iter myiter(n: int, param tag: iterKind) where tag == iterKind.leader {
+  assert(n % 2 == 0);
+  yield 1..(n/2);
+  yield (n/2+1)..n;
+}
+
+iter myiter(followThis, param tag: iterKind) where tag  == iterKind.follower {
+  for i in followThis {
+    yield i;
+  }
+}
+
+config param useStandalone = true;
+
+iter myiter(n: int, param tag: iterKind) where tag == iterKind.standalone &&
+                                               useStandalone {
+  assert(n % 2 == 0);
+  cobegin {
+    for i in 1..(n/2) do yield i;
+    for i in (n/2+1)..n do yield i;
+  }
+}
+
+iter mySerialIter(n: int) {
+  forall i in myiter(n) {
+    yield i;
+  }
+}
+
+for i in mySerialIter(10) {
+  writeln(i);
+}

--- a/test/functions/iterators/diten/standaloneParallelInSerialIterator.good
+++ b/test/functions/iterators/diten/standaloneParallelInSerialIterator.good
@@ -1,0 +1,2 @@
+standaloneParallelInSerialIterator.chpl:28: In iterator 'mySerialIter':
+standaloneParallelInSerialIterator.chpl:29: error: invalid use of parallel construct in serial iterator


### PR DESCRIPTION
The standalone iterator is much simpler than the leader/follower because
it is only used on bounded ranges and doesn't need to zip with unbounded
ranges.

It currently does nothing special for sublocales, so includes
!localeModelHasSublocales in the where clause.

Also fixed a bug where standalone iterators weren't handled along with
leaders and added a test that would fail without this fix.