### PR TITLE
Various improvements to narrowWideReferences

### DIFF
--- a/compiler/optimizations/narrowWideReferences.cpp
+++ b/compiler/optimizations/narrowWideReferences.cpp
@@ -602,8 +602,6 @@ narrowSym(Symbol* sym, WideInfo* wi,
             continue;
           }
           if (rhs->isPrimitive(PRIM_STRING_FROM_C_STRING)) {
-            // The destination string need not be wide if we're initializing from
-            // a c_string.
             wi->mustBeWide = true;
             continue;
           }

--- a/compiler/optimizations/narrowWideReferences.cpp
+++ b/compiler/optimizations/narrowWideReferences.cpp
@@ -113,11 +113,12 @@ public:
   // destinations of a deref can also be narrow.
   std::vector<SymExpr*> destsToNarrow;
 
-  WideInfo() : sym(NULL), mustBeWide(false), valIsWide(false), fnToNarrow(NULL) { }
+  WideInfo() : sym(NULL), mustBeWide(false), wideType(NULL), valIsWide(false), fnToNarrow(NULL) { }
   WideInfo(Symbol* isym) : sym(isym), mustBeWide(false), valIsWide(false), fnToNarrow(NULL) {
     if (isWideType(sym)) {
       wideType = toAggregateType(sym->type);
-    }
+    } else
+      wideType = NULL;
   }
 
   void setWide(SymExpr* se, const char* msg) {
@@ -603,6 +604,7 @@ narrowSym(Symbol* sym, WideInfo* wi,
           if (rhs->isPrimitive(PRIM_STRING_FROM_C_STRING)) {
             // The destination string need not be wide if we're initializing from
             // a c_string.
+            wi->mustBeWide = true;
             continue;
           }
           if (rhs->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
@@ -617,7 +619,7 @@ narrowSym(Symbol* sym, WideInfo* wi,
             if (fn->hasFlag(FLAG_LOCALE_MODEL_ALLOC))
               continue;
             bool retIsWide = isWideType(fn->retType->symbol);
-            if (retIsWide && (isWideRef || isWideObj)) {
+            if (retIsWide && (isWideObj)) {
                 addNarrowDep(fn->getReturnSymbol(), sym);
             }
             if (isRef(sym)) {
@@ -903,8 +905,10 @@ narrowArg(ArgSymbol* arg, WideInfo* wi,
         wideInfoMap->get(actual->var)->exprsToWiden.push_back(actual);
         
         // sync _val wideness
-        wi->refsToNarrow.push_back(actual->var);
-        wideInfoMap->get(actual->var)->refsToNarrow.push_back(arg);
+        if (isRef(actual->var))
+          wi->refsToNarrow.push_back(actual->var);
+        if (isRef(arg))
+          wideInfoMap->get(actual->var)->refsToNarrow.push_back(arg);
       }
     }
 
@@ -1081,6 +1085,7 @@ static void resolveHelper(WideInfo* wi) {
     }
     for_vector(Symbol, se, wi->refsToNarrow) {
       WideInfo* nwi = wideInfoMap->get(se);
+      INT_ASSERT(isRef(nwi->sym));
       DEBUG_PRINTF("REF %s (%d)", nwi->sym->cname, nwi->sym->id);
       if (!nwi->valIsWide) {
         DEBUG_PRINTF(" (%d)\n", wi->sym->id);
@@ -1112,6 +1117,7 @@ static void resolveHelper(WideInfo* wi) {
     // refs to this variable should wrap a narrow _val.
     for_vector(Symbol, se, wi->refsToNarrow) {
       WideInfo* nwi = wideInfoMap->get(se);
+      INT_ASSERT(nwi->sym);
       DEBUG_PRINTF("REF %s (%d): val is ", nwi->sym->cname, nwi->sym->id);
       if (wi->valIsWide) DEBUG_PRINTF("wide");
       else DEBUG_PRINTF("not wide");


### PR DESCRIPTION
This patch fixes some more fallout from #1449 

This patch widens strings created from c_strings by default. This seems to result in fewer memory leaks, and should resolve the failures for memory/sungeun/refCount/domainMaps.chpl. I believe that the narrow strings were being copied into wide strings at some point, and never being free'd.

The changes to the WideInfo constructors should resolve coverity warnings about uninitialized pointers.

The 'refsToNarrow' member of WideInfo is used to narrow the _val field of references. This patch fixes a case where non-references were added to this vector. This change should result in more narrowing.

Finally, references were being incorrectly widened when assigned to from a function return. The fix here is to only widen references if a wide reference is returned. This change should also result in more narrowing.