### PR TITLE
Pass "record-wrapped" types by 'const in' after resolution.

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -150,10 +150,17 @@ isSafeToDeref(Symbol* ref,
 }
 
 
-
+//
+// vass 3'2015: This function feels useless now.
+// Indeed, RVF is done only when arg's type is non-FLAG_REF.
+// In these cases isSufficientlyConst() always returns false.
+// I am leaving this function around in case we RVF of non-REF things.
+//
 static bool isSufficientlyConst(ArgSymbol* arg) {
   Type* argvaltype = arg->getValType();
 
+  // The intention of this assert is mostly to document the current state.
+  // If it fails, we are probaly missing some pass-by-value opportunity.
   if (isRecordWrappedType(argvaltype))
     INT_ASSERT(arg->intent == INTENT_CONST_IN  &&
                !arg->type->symbol->hasFlag(FLAG_REF));

--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -154,11 +154,9 @@ isSafeToDeref(Symbol* ref,
 static bool isSufficientlyConst(ArgSymbol* arg) {
   Type* argvaltype = arg->getValType();
 
-  if (argvaltype->symbol->hasFlag(FLAG_ARRAY)) {
-    // Arg is an array, so it's sufficiently constant (because this
-    // refers to the descriptor, not the array's values\n");
-    return true;
-  }
+  if (isRecordWrappedType(argvaltype))
+    INT_ASSERT(arg->intent == INTENT_CONST_IN  &&
+               !arg->type->symbol->hasFlag(FLAG_REF));
 
   //
   // See if this argument is 'const in'; if it is, it's a good

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -139,6 +139,14 @@ isDefinedAllPaths(Expr* expr, Symbol* ret, RefSet& refs)
                arg->intent == INTENT_REF))
             return 1;
 
+          // For arrays/domains/distributions, we just converted all 'ref' args
+          // to 'const in'. So we will count those cases as definitions, too.
+          // Todo: distinguish between what was 'ref' vs. 'const ref'.
+          if (se->var == ret &&
+              isRecordWrappedType(arg->type) &&
+              arg->intent == INTENT_CONST_IN)
+            return 1;
+
           // Treat all (non-const) refs as definitions, until we know better.
           // TODO: This may not be needed after moving insertReferenceTemps()
           // after this pass.

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -141,7 +141,8 @@ isDefinedAllPaths(Expr* expr, Symbol* ret, RefSet& refs)
 
           // For arrays/domains/distributions, we just converted all 'ref' args
           // to 'const in'. So we will count those cases as definitions, too.
-          // Todo: distinguish between what was 'ref' vs. 'const ref'.
+          // This is a workaround until we get initialization right.
+          // Todo also: distinguish between what was 'ref' vs. 'const ref'.
           if (se->var == ret &&
               isRecordWrappedType(arg->type) &&
               arg->intent == INTENT_CONST_IN)

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -101,11 +101,10 @@ passByRef(Symbol* sym) {
     return false;
   }
 
-  if (sym->hasFlag(FLAG_DISTRIBUTION) ||
-      sym->hasFlag(FLAG_DOMAIN) ||
-      sym->hasFlag(FLAG_ARRAY)
-  ) {
-    // These values *are* constant. E.g the symbol with FLAG_ARRAY
+  Type* type = sym->type;
+
+  if (isRecordWrappedType(type)) {
+    // These values *are* constant. E.g. an _array-typed symbol
     // stores a pointer to the corresponding array descriptor.  Since
     // each Chapel variable corresponds to a single Chapel array
     // throughout the variable's lifetime, the descriptor object stays
@@ -113,8 +112,6 @@ passByRef(Symbol* sym) {
     // object *can* change, however.
     return false;
   }
-
-  Type* type = sym->type;
 
   if (sym->hasFlag(FLAG_ARG_THIS))
    if (passableByVal(type)) // NB this-in-taskfns-in-ctors.chpl

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -22,7 +22,13 @@
 
 bool intentsResolved = false;
 
+static inline bool rwtLowlevel(Type* t) {
+  return resolved && isRecordWrappedType(t);
+}
+
 static IntentTag constIntentForType(Type* t) {
+  if (rwtLowlevel(t)) // low-level semantics for domain, array, or distribution
+    return INTENT_CONST_IN;
   if (isSyncType(t) ||
       isRecordWrappedType(t) ||  // domain, array, or distribution
       isRecord(t) ||  // may eventually want to decide based on size
@@ -53,6 +59,8 @@ static IntentTag constIntentForType(Type* t) {
 }
 
 IntentTag blankIntentForType(Type* t) {
+  if (rwtLowlevel(t)) // low-level semantics for domain, array, or distribution
+    return INTENT_CONST_IN;
   if (isSyncType(t) ||
       isAtomicType(t) ||
       t->symbol->hasFlag(FLAG_ARRAY)) {
@@ -104,6 +112,10 @@ void resolveArgIntent(ArgSymbol* arg) {
     arg->hasFlag(FLAG_ARG_THIS) && arg->intent == INTENT_BLANK ?
     blankIntentForThisArg(arg->type) :
     concreteIntent(arg->intent, arg->type);
+  // enact low-level semantics for domain, array, or distribution
+  if (isRecordWrappedType(arg->type) &&
+      (arg->intent & INTENT_FLAG_REF))
+    arg->intent = INTENT_CONST_IN;
 }
 
 void resolveIntents() {

--- a/test/studies/ssca2/performance/SSCA2_commDiags.good
+++ b/test/studies/ssca2/performance/SSCA2_commDiags.good
@@ -34,7 +34,7 @@ Starting Graph Generation in parallel
 max number of outgoing edges 12
 number of disconnected vertices 2
 
-Kernel 2: (get = 10, get_nb = 0, put = 7, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 0, fork_fast = 0, fork_nb = 6) (get = 44, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 8, fork_fast = 0, fork_nb = 0) (get = 40, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 4, fork_fast = 0, fork_nb = 0) (get = 40, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 4, fork_fast = 0, fork_nb = 0)
+Kernel 2: (get = 10, get_nb = 0, put = 7, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 0, fork_fast = 0, fork_nb = 6) (get = 38, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 8, fork_fast = 0, fork_nb = 0) (get = 38, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 4, fork_fast = 0, fork_nb = 0) (get = 38, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 4, fork_fast = 0, fork_nb = 0)
 Kernel 3: (get = 3670, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1464, fork_fast = 0, fork_nb = 48) (get = 158, get_nb = 0, put = 598, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 25, fork_fast = 0, fork_nb = 0) (get = 158, get_nb = 0, put = 378, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 16, fork_fast = 0, fork_nb = 0) (get = 158, get_nb = 0, put = 488, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 16, fork_fast = 0, fork_nb = 0)
 
 


### PR DESCRIPTION
A.k.a. somebody tell me why we were passing them by reference?

This change reaffirms that after resolution the values of
record-wrapped types, i.e. _array, _domain, _distribution,
are treated as records -- not as arrays/domains/distributions
that they implement.

Therefore these records are always passed around by value,
i.e. 'const in'. In the generated code this corresponds to
passing pointers to implementation classes, e.g. BlockArr,
DefaultRectangularDom, etc.

These records and pointers are always constant. That's because,
in Chapel, once an array/... variable is created, it is associated
always with the same array/..., i.e. the same instance of BaseArr/...

Before this change, these records/pointers were themselves passed
by reference, in a few cases. This inflates the size of the AST
and the generated code and may reduce optimization opportunities
for the C compiler.


IMPLEMENTATION DETAILS

* These functions now return 'const in' for record-wrapped types
after resolution:

  constIntentForType()
  blankIntentForType()

Also resolveIntents() switches the existing 'ref' and 'const ref'
intents for record-wrapped types to 'const in'.

* Additionally, flattenFunctions.cpp/passByRef() returns 'false'
for symbols of record-wrapped types.

This comes handy when the function being flattened has an outer variable
of a record-wrapped type, such as a temp. We make sure it is passed
by value as well.

Note that the former checks sym->hasFlag(FLAG_ARRAY) et al.
never fired I think, because these flags are on the type symbols,
not the argument/variable symbols.

* Notes on remoteValueForwarding.cpp/isSufficientlyConst():

** The following assert:

```
  if (isRecordWrappedType(argvaltype))
    INT_ASSERT(arg->intent == INTENT_CONST_IN  &&
               !arg->type->symbol->hasFlag(FLAG_REF));
```

mostly documents the current state. If it fails, we are probaly
missing some pass-by-value opportunity somewhere.

** The isSufficientlyConst() function itself is now useless.
Indeed, RVF is done only when arg's type is non-FLAG_REF.
In these cases isSufficientlyConst() always returns false.

I am leaving this function around in case we start RVF
non-REF things.

* I had to tweak checkResolved.cpp/isDefinedAllPaths(),
which counts the number of definitions of 'ret'.
For arrays, a "definition" used to come from passing 'ret'
into =() by 'ref' intent. Now the code is the same,
except the intent is 'const in'.
(Recall that checkResolved comes after resolution and
resolveIntents.)
So I have isDefinedAllPaths() accept 'const in'
for record-wrapped types as a "definition" as well.

This loses precision, because we cannot tell passing
an array by 'ref' from 'const ref'. So potentially
we can now create AST where an array 'ret' is left
uninitialized, yet passed by 'const ref' into something.
I accepted this in order to keep the semantics straight.

Alternatively we could do our 'ref'->'const in' conversion
after checkResolved. I chose against this because there is
really no good place to put such conversion: checkResolved
is followed immediately by processIteratorYields.
The conversion itself would be very simple:

```
  forv_Vec(ArgSymbol, arg, gArgSymbols) {
    if (isRecordWrappedType(arg->type) &&
        (arg->intent & INTENT_FLAG_REF))
      // enact low-level semantics for domain, array, or distribution
    arg->intent = INTENT_CONST_IN;
  }
```


ALSO

* There is a small improvement in comm counts in SSCA2.
