### PR TITLE
Fix build error on GCC 4.7

### DIFF
--- a/compiler/include/arg.h
+++ b/compiler/include/arg.h
@@ -56,7 +56,7 @@ typedef void ArgumentFunction(const ArgumentState* state, const char* arg);
 
 struct ArgumentState
 {
-  char**               file_argument;
+  const char**         file_argument;
   int                  nfile_arguments;
 
   const char*          program_name;

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -66,7 +66,7 @@ bool isChplSource(const char* filename);
 bool isCHeader(const char* filename);
 bool isCSource(const char* filename);
 bool isObjFile(const char* filename);
-void addSourceFiles(int numFilenames, char* filename[]);
+void addSourceFiles(int numFilenames, const char* filename[]);
 void addSourceFile(const char* filename);
 const char* nthFilename(int i);
 void addLibInfo(const char* filename);

--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -599,7 +599,7 @@ static void ProcessCommandLine(ArgumentState* state, int argc, char* aargv[])
     }
     else
     {
-      state->file_argument = (char **)realloc(
+      state->file_argument = (const char **)realloc(
         state->file_argument,
         sizeof(char*) * (state->nfile_arguments + 2));
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -350,7 +350,7 @@ static bool isRecognizedSource(const char* filename) {
 }
 
 
-void addSourceFiles(int numNewFilenames, char* filename[]) {
+void addSourceFiles(int numNewFilenames, const char* filename[]) {
   static int numInputFiles = 0;
   int cursor = numInputFiles;
   char achar;
@@ -386,7 +386,7 @@ void addSourceFiles(int numNewFilenames, char* filename[]) {
 }
 
 void addSourceFile(const char* filename) {
-  char* filenamearr[1] = {(char*)filename};
+  const char* filenamearr[1] = {filename};
   addSourceFiles(1, filenamearr);
 }
 


### PR DESCRIPTION
I was getting errors like this:
 files.cpp:389:34: error: cast from type const char* to type char*
with GCC 4.7.

This patch just changes that string to const char* in a bunch
of places.