### PR TITLE
Allow LICM to hoist some global variables

### DIFF
--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -675,12 +675,14 @@ static bool allOperandsAreLoopInvariant(Expr* expr, std::set<SymExpr*>& loopInva
 static void computeLoopInvariants(std::vector<SymExpr*>& loopInvariants, Loop*
     loop, symToVecSymExprMap& localDefMap, FnSymbol* fn) {
  
-  //collect all of the symExpr and defExpr in the loop 
+  // collect all of the symExprs, defExprs, and callExprs in the loop
   startTimer(collectSymExprAndDefTimer);
   std::vector<SymExpr*> loopSymExprs;
   std::set<Symbol*> defsInLoop;
+  std::vector<CallExpr*> callsInLoop;
   for_vector(BasicBlock, block, *loop->getBlocks()) {
     for_vector(Expr, expr, block->exprs) {
+      collectFnCallsSTL(expr, callsInLoop);
       collectSymExprsSTL(expr, loopSymExprs);
       if (DefExpr* defExpr = toDefExpr(expr)) {
         if (toVarSymbol(defExpr->sym)) {
@@ -880,13 +882,7 @@ static void computeLoopInvariants(std::vector<SymExpr*>& loopInvariants, Loop*
       // definitions.
       // TODO this could be improved to check which functions modify the global
       // and see if any of those functions are being called in this loop.
-      std::vector<CallExpr*> calls;
-      for_vector(BasicBlock, block, *loop->getBlocks()) {
-        for_vector(Expr, expr, block->exprs) {
-          collectFnCallsSTL(expr, calls);
-        }
-      }
-      if (calls.size() != 0) {
+      if (callsInLoop.size() != 0) {
         mightHaveBeenDeffedElseWhere = true;
       }
     }

--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -867,10 +867,28 @@ static void computeLoopInvariants(std::vector<SymExpr*>& loopInvariants, Loop*
         }
       }
     }
-    // Where the variable is defined.
+    // Find where the variable is defined.
     Symbol* defScope = symExpr->var->defPoint->parentSymbol;
+    // if the variable is a module level (global) variable
     if (isModuleSymbol(defScope)) {
-      mightHaveBeenDeffedElseWhere = true;
+      // if there are any function calls inside the loop, assume that one of
+      // the functions may have changed the value of the global. Note that we
+      // don't have to worry about a different task updating the global since
+      // that would have to be protected with a sync or be atomic in which case
+      // no hoisting will occur in the function at all. Any defs to the global
+      // inside of this loop will be detected just like any other variable
+      // definitions.
+      // TODO this could be improved to check which functions modify the global
+      // and see if any of those functions are being called in this loop.
+      std::vector<CallExpr*> calls;
+      for_vector(BasicBlock, block, *loop->getBlocks()) {
+        for_vector(Expr, expr, block->exprs) {
+          collectFnCallsSTL(expr, calls);
+        }
+      }
+      if (calls.size() != 0) {
+        mightHaveBeenDeffedElseWhere = true;
+      }
     }
     //if there were no defs of the symbol, it is invariant 
     if(actualDefs.count(symExpr) == 0 && !mightHaveBeenDeffedElseWhere) {

--- a/test/performance/ferguson/remote-array-copy.good
+++ b/test/performance/ferguson/remote-array-copy.good
@@ -1,3 +1,3 @@
 1
 100000
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0) (get = 500000, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 0, fork_fast = 0, fork_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0) (get = 100004, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 0, fork_fast = 0, fork_nb = 0)

--- a/test/performance/ferguson/remote-array-read-1.good
+++ b/test/performance/ferguson/remote-array-read-1.good
@@ -1,4 +1,4 @@
 100000
 1
 1
-(get = 9, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0) (get = 300000, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0)
+(get = 9, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0) (get = 100002, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0)

--- a/test/performance/ferguson/remote-array-write-1.good
+++ b/test/performance/ferguson/remote-array-write-1.good
@@ -1,3 +1,3 @@
 1
 1
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0) (get = 200000, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 0, fork_fast = 0, fork_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 1, fork_fast = 0, fork_nb = 0) (get = 2, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, fork = 0, fork_fast = 0, fork_nb = 0)


### PR DESCRIPTION
This is a conservative modification that will allow LICM to hoist invariant
globals from loops that do not contain any function calls.

Currently we mark that all global variables might have be modified elsewhere
(outside the immediate scope of the loop that we're hoisting from.) Because of
this no global variables were considered as candidates for LICM. There are
three ways a global can be modified:
 - Directly in the loop
 - Indirectly in the loop by a possibly nested function call
 - By some other task anywhere in the program

We already detect if the current loop directly modifies a global. If some other
task modifies a global, then in order for the program to be correct a
sync/single or atomic must be used. Currently LICM will not be performed on
functions that contain any sync/single or atomic variables so we don't have to
worry about this case. The currently un-handled case is if a possibly nested
function call inside of the loop modifies the global.

This patch updates marking that globals might have been defined elsewhere to
only do such marking if there are any functions calls inside of the loop. We
could be more aggressive and do some inter-procedural analysis to find out if
the function call actually modified the global but this will take care of most
cases, and is a much cheaper computation. It is also much less of a code
change, which is nice this close to release.

This is primarily for tests that do not define a main procedure and instead use
the implicit main. This change is motivated by a performance regression with
some of our slower fannkuck versions from the last update to LICM
(75ada8e3483f)

This also includes comm count improvements for 3 tests since the meta-data for
global arrays is now hoisted in these tests.