### PR TITLE
Generate a compiler error upon read() of a sync or single variable

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -168,6 +168,11 @@ module ChapelSyncvar {
     return b;
   }
 
+  // Do not allow implicit reads of sync/single vars.
+  proc _syncvar.readThis(x: Reader) {
+    compilerError("sync/single variables cannot currently be read - use writeEF/writeFF instead");
+  }
+
   // Do not allow implicit writes of sync/single vars.
   proc _syncvar.writeThis(x: Writer) {
     compilerError("sync/single variables cannot currently be written - apply readFE/readFF() to those variables first");
@@ -266,6 +271,11 @@ module ChapelSyncvar {
     return b;
   }
 
+
+  // Do not allow implicit reads of sync/single vars.
+  proc _singlevar.readThis(x: Reader) {
+    compilerError("single/sync variables cannot currently be read - use writeEF/writeFF instead");
+  }
 
   // Do not allow implicit writes of sync/single vars.
   proc _singlevar.writeThis(x: Writer) {

--- a/test/types/single/vass/readThis.chpl
+++ b/test/types/single/vass/readThis.chpl
@@ -1,0 +1,6 @@
+// Test reading of single vars - currently generates an error.
+// See also test/types/sync/vass/readThis.chpl
+
+var g2: single real;
+read(g2);
+writeln("g2 = ", g2);

--- a/test/types/single/vass/readThis.good
+++ b/test/types/single/vass/readThis.good
@@ -1,0 +1,1 @@
+$CHPL_HOME/modules/standard/IO.chpl:: error: single/sync variables cannot currently be read - use writeEF/writeFF instead

--- a/test/types/single/vass/readThis.prediff
+++ b/test/types/single/vass/readThis.prediff
@@ -1,0 +1,1 @@
+writeThis.prediff

--- a/test/types/sync/vass/readThis.chpl
+++ b/test/types/sync/vass/readThis.chpl
@@ -1,0 +1,6 @@
+// Test reading of syng vars - currently generates an error.
+// See also test/types/single/vass/readThis.chpl
+
+var g2: sync real;
+read(g2);
+writeln("g2 = ", g2);

--- a/test/types/sync/vass/readThis.good
+++ b/test/types/sync/vass/readThis.good
@@ -1,0 +1,1 @@
+$CHPL_HOME/modules/standard/IO.chpl:: error: sync/single variables cannot currently be read - use writeEF/writeFF instead

--- a/test/types/sync/vass/readThis.prediff
+++ b/test/types/sync/vass/readThis.prediff
@@ -1,0 +1,1 @@
+writeThis.prediff


### PR DESCRIPTION
This parallels the change for writing sync/single variables in #420
aka 6c2e3a6. In earlier group discussions we concluded that we
do not want reads of sync/single variables to be legal, for now:

Both for reading and for writing sync/singles, it is unclear at the
moment what the default semantics should be. So we disallowed writing
in #420, and analogously disallowing reading in this change.

A while back I observed that reading a sync variable was allowed,
and the program would hang upon such a read at run time.
This time, right before my change, reading a sync would not compile
at all, reporting "unresolved error" on _syncvar.readThis(Reader).
