### PR TITLE
Fix Coverity defects 1287041 thru 1287043.

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -900,8 +900,8 @@ static void insertLocalsForRefs(Vec<Symbol*>& syms, FnSymbol* fn,
     if (sym->type->symbol->hasFlag(FLAG_REF)) {
 
       Vec<SymExpr*>* defs = defMap.get(sym);
-      if (defs->n != 1) {
-        INT_FATAL(sym, "invalid assumption about reference");
+      if (defs == NULL || defs->n != 1) {
+        INT_FATAL(sym, "Expected sym to have exactly one definition");
       }
 
       // Do we need to consider PRIM_ASSIGN as well?

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -1220,7 +1220,12 @@ eliminateSingleAssignmentReference(Map<Symbol*,Vec<SymExpr*>*>& defMap,
         }
         if (!stillAlive) {
           var->defPoint->remove();
-          defMap.get(var)->v[0]->getStmtExpr()->remove();
+          Vec<SymExpr*>* defs = defMap.get(var);
+          if (defs == NULL) {
+            INT_FATAL(var, "Expected var to be defined");
+          }
+          // Remove the first definition from the AST.
+          defs->v[0]->getStmtExpr()->remove();
         }
       } else if (rhs->isPrimitive(PRIM_GET_MEMBER) ||
                  rhs->isPrimitive(PRIM_GET_SVEC_MEMBER)) {

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -591,7 +591,11 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
     // find out if a variable that was put on the heap could be passed in as an
     // argument to a function created from a begin, cobegin, or coforall statement;
     // if not, free the heap memory just allocated at the end of the block
-    if (defMap.get(var)->n == 1) {
+    Vec<SymExpr*>* defs = defMap.get(var);
+    if (defs == NULL) {
+      INT_FATAL(var, "Symbol is never defined.");
+    }
+    if (defs->n == 1) {
       bool freeVar = true;
       Vec<Symbol*> varsToTrack;
       varsToTrack.add(var);
@@ -618,7 +622,7 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
         }
       }
       if (freeVar) {
-        CallExpr* move = toCallExpr(defMap.get(var)->v[0]->parentExpr);
+        CallExpr* move = toCallExpr(defs->v[0]->parentExpr);
         INT_ASSERT(move && move->isPrimitive(PRIM_MOVE));
         Expr* innermostBlock = NULL;
         // find the innermost block that contains all uses of var
@@ -674,6 +678,10 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
         }
       }
     }
+    // else ... 
+    // TODO: After the new constructor story is implemented, every declaration
+    // should have exactly one definition associated with it, so the
+    // (defs-> == 1) test above can be replaced by an assertion.
   }
 }
 


### PR DESCRIPTION
These defects are all possible null dereferences.  They were resolved by adding specific
null pointer tests ahead of the suspect code.

[x] Regression test run (std)