### PR TITLE
Update reported line numbers for forallInStandalone

### DIFF
--- a/test/performance/vectorization/vectorPragmas/forallInStandalone.compgood
+++ b/test/performance/vectorization/vectorPragmas/forallInStandalone.compgood
@@ -1,3 +1,3 @@
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeLeaderFollower:15
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23
-Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23
+Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:1340


### PR DESCRIPTION
For some reason with the standalone range iterator, the line numbers aren't
reset so the line number of the for loop within the coforall fn still has the
ChapelRange line number. Curiously the same iterator inlined into the numChunks
<=1 case does get the right number.

I think this is an old problem that leader iterators also exhibit, but didn't
affect this test before since the follower was the one being inlined into the
coforall fn.

This test is already skipped for numa, so we don't have to worry about getting
the wrong results with numa (since the leader/follower will be used.)

This doesn't indicate a "real" problem just line numbers not getting reset
correctly