### PR TITLE
Qthreads: don't use guard pages when the needed mprotect(2) won't work.

### DIFF
--- a/runtime/include/chplsys.h
+++ b/runtime/include/chplsys.h
@@ -24,6 +24,8 @@
 
 #include <stdint.h>
 
+size_t chpl_getSysPageSize(void);
+size_t chpl_getHeapPageSize(void);
 uint64_t chpl_bytesPerLocale(void);
 size_t chpl_bytesAvailOnThisLocale(void);
 int chpl_getNumPhysicalCpus(chpl_bool accessible_only);

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -52,9 +52,65 @@
 #include <unistd.h>
 
 
-#ifndef chplGetPageSize
-#define chplGetPageSize() sysconf(_SC_PAGE_SIZE)
+size_t chpl_getSysPageSize(void) {
+  static size_t pageSize = 0;
+
+  //
+  // No conflict management.  We assume this is set once, early, before
+  // we have multiple threads that might be querying the value.
+  //
+  if (pageSize == 0) {
+#if defined _SC_PAGESIZE
+    pageSize = (size_t) sysconf(_SC_PAGESIZE);
+#elif defined _SC_PAGE_SIZE
+    pageSize = (size_t) sysconf(_SC_PAGE_SIZE);
+#else
+    chpl_internal_error("cannot determine page size");
 #endif
+  }
+
+  return pageSize;
+}
+
+
+size_t chpl_getHeapPageSize(void) {
+  static size_t pageSize = 0;
+
+  //
+  // No conflict management.  We assume this is set once, early, before
+  // we have multiple threads that might be querying the value.
+  //
+  if (pageSize == 0) {
+#if defined __linux__
+    char* ev;
+    if ((ev = getenv("HUGETLB_DEFAULT_PAGE_SIZE")) == NULL)
+      pageSize = chpl_getSysPageSize();
+    else {
+      int scanCnt;
+      size_t tmpPageSize;
+      char units;
+
+      if ((scanCnt = sscanf(ev, "%zd%1[kKmMgG]", &tmpPageSize, &units)) > 0) {
+        if (scanCnt == 2) {
+          switch (units) {
+          case 'k': case 'K': tmpPageSize <<= 10; break;
+          case 'm': case 'M': tmpPageSize <<= 20; break;
+          case 'g': case 'G': tmpPageSize <<= 30; break;
+          }
+        }
+      }
+      else
+        chpl_internal_error("unexpected HUGETLB_DEFAULT_PAGE_SIZE syntax");
+      pageSize = tmpPageSize;
+    }
+#else
+    pageSize = chpl_getSysPageSize();
+#endif
+  }
+
+  return pageSize;
+}
+
 
 uint64_t chpl_bytesPerLocale(void) {
 #ifdef NO_BYTES_PER_LOCALE
@@ -90,7 +146,7 @@ uint64_t chpl_bytesPerLocale(void) {
   numPages = sysconf(_SC_PHYS_PAGES);
   if (numPages < 0)
     chpl_internal_error("query of physical memory failed");
-  pageSize = chplGetPageSize();
+  pageSize = chpl_getSysPageSize();
   if (pageSize < 0)
     chpl_internal_error("query of physical memory failed");
   return (uint64_t)numPages * (uint64_t)pageSize;

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -504,8 +504,18 @@ static void setupCallStacks(int32_t hwpar) {
     // If the user compiled with no stack checks (either explicitly or
     // implicitly) turn off qthread guard pages. TODO there should also be a
     // chpl level env var backing this at runtime (can be the same var.)
+    // Also turn off guard pages if the heap page size isn't the same as
+    // the system page size, because when that's the case we can reliably
+    // make the guard pages un-referenceable.  (This typically arises when
+    // the heap is on hugepages, as is often the case on Cray systems.)
+    //
+    // Note that we won't override an explicit setting of QT_GUARD_PAGES
+    // in the former case, but we do in the latter case.
     if (CHPL_STACK_CHECKS == 0) {
         chpl_qt_setenv("GUARD_PAGES", "false", 0);
+    }
+    else if (chpl_getHeapPageSize() != chpl_getSysPageSize()) {
+        chpl_qt_setenv("GUARD_PAGES", "false", 1);
     }
 
     // Precedence (high-to-low):


### PR DESCRIPTION
Qthreads uses unreferenceable guard pages at the ends of qthread (Chapel
task) stacks to provide stack overflow protection.  But the mprotect(2)
sys call to make these guard pages unreferenceable is invalid when the
memory involved comes from hugepage space.  Qthreads continues execution
when those mprotect(2) calls fail, but it also produces error messages
about the failures.  For various reasons we often use hugepages on Cray
X* systems.  To avoid the noisy output, here we turn off guard pages in
Qthreads whenever the heap page size appears not to be the same as the
system page size.

There are also supporting changes in chplsys.{h,c}, to return the system
and heap page sizes.  Note that the logic for the latter is not totally
solid at this point and we may need to revisit it at some point.  For
example, it doesn't catch the case in which we have a hugepage module
loaded but have not enabled automatic placement of the program's heap on
hugepages.  However, certainly for now this will do.

There is future follow-up work here.  For various reasons, in several
places in the runtime we acquire the page size.  These should be changed
to call the appropriate new chplsys.c function.  However, that work can
wait until after the upcoming release is done.