### PR TITLE
Revise the algorithm for computing exits

### DIFF
--- a/test/execflags/ferguson/help2.good
+++ b/test/execflags/ferguson/help2.good
@@ -29,6 +29,6 @@ CONFIG VARS:
               memLeaksTable: bool
                      memMax: uint(64)
                memThreshold: uint(64)
-                     memLog: c_string
-                memLeaksLog: c_string
+                     memLog: c_ptr(uint(8))
+                memLeaksLog: c_ptr(uint(8))
                  numLocales: int(64)

--- a/test/execflags/shannon/configs/help/basehelp.txt
+++ b/test/execflags/shannon/configs/help/basehelp.txt
@@ -30,7 +30,7 @@ Built-in config vars:
               memLeaksTable: bool
                      memMax: uint(64)
                memThreshold: uint(64)
-                     memLog: c_string
-                memLeaksLog: c_string
+                     memLog: c_ptr(uint(8))
+                memLeaksLog: c_ptr(uint(8))
                  numLocales: int(64)
 

--- a/test/execflags/shannon/help.good
+++ b/test/execflags/shannon/help.good
@@ -29,6 +29,6 @@ CONFIG VARS:
               memLeaksTable: bool
                      memMax: uint(64)
                memThreshold: uint(64)
-                     memLog: c_string
-                memLeaksLog: c_string
+                     memLog: c_ptr(uint(8))
+                memLeaksLog: c_ptr(uint(8))
                  numLocales: int(64)

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -21,11 +21,11 @@ Parsing module files:
   subdir4/subdir/bax.chpl
   ./bah.chpl
   $CHPL_HOME/modules/standard/startInitCommDiags.chpl
-  $CHPL_HOME/modules/standard/NewString.chpl
   $CHPL_HOME/modules/standard/Assert.chpl
   $CHPL_HOME/modules/standard/Types.chpl
   $CHPL_HOME/modules/standard/Math.chpl
   $CHPL_HOME/modules/standard/stopInitCommDiags.chpl
+  $CHPL_HOME/modules/standard/gen/.../SysCTypes.chpl
   $CHPL_HOME/modules/standard/Sys.chpl
   $CHPL_HOME/modules/dists/DSIUtil.chpl
   $CHPL_HOME/modules/standard/List.chpl
@@ -34,7 +34,6 @@ Parsing module files:
   $CHPL_HOME/modules/standard/Sort.chpl
   $CHPL_HOME/modules/standard/Search.chpl
   $CHPL_HOME/modules/standard/CommDiagnostics.chpl
-  $CHPL_HOME/modules/standard/gen/.../SysCTypes.chpl
   $CHPL_HOME/modules/standard/Error.chpl
   $CHPL_HOME/modules/standard/Regexp.chpl
 In bar

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -1,14 +1,15 @@
 Initializing Modules:
    ChapelStandard
     ChapelBase
+    CString
     String
-     CString
+     BaseStringType
+      SysCTypes
+     StringCasts
     MemConsistency
     Atomics
     NetworkAtomics
     AtomicsCommon
-    NewString
-     BaseStringType
     ChapelThreads
     ChapelTuple
     ChapelRange
@@ -20,7 +21,6 @@ Initializing Modules:
      ChapelNumLocales
      Sys
       SysBasic
-       SysCTypes
     LocalesArray
     ChapelDistribution
      List


### PR DESCRIPTION
Where autoDestroys are inserted depends on the correspondence between the ends of basic blocks and the ends of scopes.  The code used for computing this correspondence was improved.

Down to 239 regressions (67 run-time).