### PR TITLE
Implement parentDir and curDir, take two.

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -18,6 +18,10 @@
  */
 use Error;
 
+const curDir = ".";
+const parentDir = "..";
+const pathSep = "/";
+
 /* Returns the canonical path specified, eliminating symbolic links.  If an
    error occurred, it will be returned via the out parameter.
    err: a syserr used to indicate if an error occurred during this operation.

--- a/test/modules/standard/Path/lydia/curOrParentDir/curOrParent.chpl
+++ b/test/modules/standard/Path/lydia/curOrParentDir/curOrParent.chpl
@@ -1,0 +1,18 @@
+use Path;
+use FileSystem;
+
+var filename = "foo.txt";
+var anotherVersion = curDir + pathSep + filename;
+var parentDirectory = parentDir + pathSep + filename;
+
+if (sameFile(filename, anotherVersion)) {
+  writeln("Sweet, curDir and pathSep worked");
+} else {
+  writeln("Expected " + anotherVersion + " to refer to the same file as " + filename);
+}
+
+if (sameFile("../" + filename, parentDirectory)) {
+  writeln("parentDir matched as expected");
+} else {
+  writeln("error testing parentDir, it gave us " + parentDirectory);
+}

--- a/test/modules/standard/Path/lydia/curOrParentDir/curOrParent.good
+++ b/test/modules/standard/Path/lydia/curOrParentDir/curOrParent.good
@@ -1,0 +1,2 @@
+Sweet, curDir and pathSep worked
+parentDir matched as expected

--- a/test/modules/standard/Path/lydia/curOrParentDir/foo.txt
+++ b/test/modules/standard/Path/lydia/curOrParentDir/foo.txt
@@ -1,0 +1,1 @@
+blah blah blah

--- a/test/modules/standard/Path/lydia/foo.txt
+++ b/test/modules/standard/Path/lydia/foo.txt
@@ -1,0 +1,1 @@
+Oh look, another toy file.


### PR DESCRIPTION
They are now just constant strings in the Path module, per Michael's suggestion.
The test also seemed too stupid, so I made one relying on sameFile.