### PR TITLE
Enable 'vectorization' when --fast is thrown

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -583,7 +583,7 @@ static void setFastFlag(const ArgumentState* state, const char* unused) {
   fNoInline = false;
   fNoInlineIterators = false;
   fNoOptimizeLoopIterators = false;
-  //fNoVectorize = false;
+  fNoVectorize = false;
   fNoLiveAnalysis = false;
   fNoRemoteValueForwarding = false;
   fNoRemoveCopyCalls = false;


### PR DESCRIPTION
The patch that attaches the ivdep pragma to loops inside of follower iterators
was committed on Friday with 241e03b but it wasn't enabled with --fast since we
were waiting to have a few stable days of performance testing since a hardware
change.