### PR TITLE
Cleanups suggested by reviewer for DefaultRectangular standalone iterators

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -187,14 +187,8 @@ module DefaultRectangular {
       }
 
       if numChunks <= 1 {
-        if rank == 1 {
-          for i in ranges(1) {
-            yield i;
-          }
-        } else {
-          for i in these_help(1) {
-            yield i;
-          }
+        for i in these_help(1) {
+          yield i;
         }
       } else {
         var locBlock: rank*range(idxType);
@@ -734,7 +728,7 @@ module DefaultRectangular {
       if debugDefaultDist {
         writeln("*** In array standalone code");
       }
-      for i in dom.these(iterKind.standalone, tasksPerLocale,
+      for i in dom.these(tag, tasksPerLocale,
                          ignoreRunning, minIndicesPerTask) {
         yield dsiAccess(i);
       }


### PR DESCRIPTION
[suggested by Elliot]

Merged rank == 1 case with rank > 1 case now that these_help() are generalized

Replaced iterKind.standalone with the tag argument known to be equal to
iterKind.standalone.