### PR TITLE
Comment BitOps for use with chpldoc

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -56,8 +56,9 @@ $(SYS_CTYPES_MODULE_DOC): $(MAKE_SYS_BASIC_TYPES)
 
 
 MODULES_TO_DOCUMENT = \
-	standard/Random.chpl \
+	standard/BitOps.chpl \
 	standard/Buffers.chpl \
+	standard/Random.chpl \
 	$(SYS_CTYPES_MODULE_DOC)
 
 documentation: $(SYS_CTYPES_MODULE_DOC)

--- a/modules/standard/BitOps.chpl
+++ b/modules/standard/BitOps.chpl
@@ -17,248 +17,76 @@
  * limitations under the License.
  */
 
-/**
- *  Bit Manipulation Functions
+/*
+  Bitwise operations implemented using C intrinsics when possible.
  */
 module BitOps {
 
   /*
-    count leading zeros
+    Count leading zeros in `x`.
 
-    x: unsigned integer of size `bits`
-    bits: 8, 16, 32, 64
-
-    returns: the number of 0 bits before the most significant 1 bit in `x` as
-             `x.type`
+    :returns: the number of 0 bits before the most significant 1 bit in `x`
+    :rtype: `x.type`
    */
-  inline proc clz(x: uint(?bits)) {
-    // the select will be folded out at compile time.
-    select bits {
-      when 64 do
-        return BitOps_internal.chpl_bitops_clz_64(x);
-      when 32 do
-        return BitOps_internal.chpl_bitops_clz_32(x);
-      when 16 do
-        // gets promoted to 32bit, subtract the extra leading 0s
-        return (BitOps_internal.chpl_bitops_clz_32(x)-16):uint(16);
-      when 8 do
-        // gets promoted to 32bit, subtract the extra leading 0s
-        return (BitOps_internal.chpl_bitops_clz_32(x)-24):uint(8);
-      otherwise
-        // NOTE: this actually cant happen with how the integer types are setup
-        //       right now - leaving it here for the future when we support
-        //       >64bit types
-        compilerError("clz is not supported for that bit width.");
-    }
+  inline proc clz(x: integral) {
+    return BitOps_internal.clz(x);
   }
 
   /*
-    count leading zeros
+    Count trailing zeros in `x`.
 
-    x: integer of size `bits`
-    bits: 8, 16, 32, 64
-
-    returns: the number of 0 bits before the most significant 1 bit in `x` as
-             `x.type`
+    :returns: the number of 0 bits after the least significant 1 bit in `x`
+    :rtype: `x.type`
    */
-  inline proc clz(x: int(?bits)) {
-    return clz(x:uint(bits)):int(bits);
+  inline proc ctz(x: integral) {
+    return BitOps_internal.ctz(x);
   }
 
   /*
-    count trailing zeros
+    Find the population count of `x`.
 
-    x: unsigned integer of size `bits`
-    bits: 8, 16, 32, 64
-
-    returns: the number of 0 bits after the least significant 1 bit in `x` as
-             `x.type`
+    :returns: the number of 1 bits set in `x` as `x.type`
+    :rtype: `x.type`
    */
-  inline proc ctz(x: uint(?bits)) {
-    // the select will be folded out at compile time.
-    select bits {
-      when 64 do
-        return BitOps_internal.chpl_bitops_ctz_64(x);
-      when 32 do
-        return BitOps_internal.chpl_bitops_ctz_32(x);
-      when 16 do
-        return BitOps_internal.chpl_bitops_ctz_32(x):uint(16);
-      when 8 do
-        return BitOps_internal.chpl_bitops_ctz_32(x):uint(8);
-      otherwise
-        // NOTE: this actually cant happen with how the integer types are setup
-        //       right now - leaving it here for the future when we support
-        //       >64bit types
-        compilerError("ctz is not supported for that bit width.");
-    }
+  inline proc popcount(x: integral) {
+    return BitOps_internal.popcount(x);
   }
 
   /*
-    count trailing zeros
+    Find the parity of `x`.
 
-    x: integer of size `bits`
-    bits: 8, 16, 32, 64
-
-    returns: the number of 0 bits after the least significant 1 bit in `x` as
-             `x.type`
+    :returns: * 0 -- when an even number of bits are set in `x`
+              * 1 -- when an odd number of bits are set in `x`
+    :rtype: `x.type`
    */
-  inline proc ctz(x: int(?bits)) {
-    return ctz(x:uint(bits)):int(bits);
+  inline proc parity(x: integral) {
+    return BitOps_internal.parity(x);
   }
 
   /*
-    population count
+    Rotate `x` left.
 
-    x: unsigned integer of size `bits`
-    bits: 8, 16, 32, 64
+    :arg x: integral of size `bits`
+    :arg n: rotation amount, must be less than `bits`
 
-    returns: the number of 1 bits set in `x` as `x.type`
+    :returns: `x` rotated left by `n` bits
+    :rtype: `x.type`
    */
-  inline proc popcount(x: uint(?bits)) {
-    // the select will be folded out at compile time.
-    select bits {
-      when 64 do
-        return BitOps_internal.chpl_bitops_popcount_64(x);
-      when 32 do
-        return BitOps_internal.chpl_bitops_popcount_32(x);
-      when 16 do
-        return BitOps_internal.chpl_bitops_popcount_32(x):uint(16);
-      when 8 do
-        return BitOps_internal.chpl_bitops_popcount_32(x):uint(8);
-      // In the future we could also break a large int (128+) into 64bit chucks
-      // and add up the results.
-      otherwise
-        // NOTE: this actually cant happen with how the integer types are setup
-        //       right now - leaving it here for the future when we support
-        //       >64bit types
-        compilerError("popcount is not supported for that bit width.");
-    }
+  inline proc rotl(x: integral, n: integral) {
+    return BitOps_internal.rotl(x, n);
   }
 
   /*
-    population count
+    Rotate `x` right.
 
-    x: integer of size `bits`
-    bits: 8, 16, 32, 64
+    :arg x: integral of size `bits`
+    :arg n: rotation amount, must be less than `bits`
 
-    returns: the number of 1 bits set in `x` as `x.type`
+    :returns: `x` rotated right by `n` bits
+    :rtype: `x.type`
    */
-  inline proc popcount(x: int(?bits)) {
-    return popcount(x:uint(bits)):int(bits);
-  }
-
-  /*
-    parity
-
-    x: unsigned integer of size `bits`
-    bits: 8, 16, 32, 64
-
-    returns: 0 (as `x.type`) if an even number of bits are set in `x`
-             1 (as `x.type`) if an odd number of bits are set in `x`
-  */
-  inline proc parity(x: uint(?bits)) {
-    // the select will be folded out at compile time.
-    select bits {
-      when 64 do
-        return BitOps_internal.chpl_bitops_parity_64(x);
-      when 32 do
-        return BitOps_internal.chpl_bitops_parity_32(x);
-      when 16 do
-        return BitOps_internal.chpl_bitops_parity_32(x):uint(16);
-      when 8 do
-        return BitOps_internal.chpl_bitops_parity_32(x):uint(8);
-      otherwise
-        compilerError("parity is not supported for that bit width.");
-    }
-  }
-
-  /*
-    parity
-
-    x: signed integer of size `bits`
-    bits: 8, 16, 32, 64
-
-    returns: 0 (as `x.type`) if an even number of bits are set in `x`
-             1 (as `x.type`) if an odd number of bits are set in `x`
-  */
-  inline proc parity(x: int(?bits)) {
-    return parity(x:uint(bits)):int(bits);
-  }
-
-  /*
-    rotate left
-
-    x: unsigned integer of size `bits`
-    bits: 8, 16, 32, 64
-    n: shift amount, must be less than `bits`
-
-    returns: `x` rotated left by `n` bits
-  */
-  inline proc rotl(x: uint(?bits), n: integral) {
-    // the select will be folded out at compile time.
-    select bits {
-      when 64 do
-        return BitOps_internal.chpl_bitops_rotl_64(x, n:uint(bits));
-      when 32 do
-        return BitOps_internal.chpl_bitops_rotl_32(x, n:uint(bits));
-      when 16 do
-        return BitOps_internal.chpl_bitops_rotl_16(x, n:uint(bits));
-      when 8 do
-        return BitOps_internal.chpl_bitops_rotl_8(x, n:uint(bits));
-      otherwise
-        compilerError("rotl is not supported for that bit width.");
-    }
-  }
-
-  /*
-    rotate left
-
-    x: signed integer of size `bits`
-    bits: 8, 16, 32, 64
-    n: shift amount, must be less than `bits`
-
-    returns: `x` rotated left by `n` bits
-  */
-  inline proc rotl(x: int(?bits), n: integral) {
-    return rotl(x:uint(bits), n):int(bits);
-  }
-
-  /*
-    rotate right
-
-    x: unsigned integer of size `bits`
-    bits: 8, 16, 32, 64
-    n: shift amount, must be less than `bits`
-
-    returns: `x` rotated right by `n` bits
-  */
-  inline proc rotr(x: uint(?bits), n: integral) {
-    // the select will be folded out at compile time.
-    select bits {
-      when 64 do
-        return BitOps_internal.chpl_bitops_rotr_64(x, n:uint(bits));
-      when 32 do
-        return BitOps_internal.chpl_bitops_rotr_32(x, n:uint(bits));
-      when 16 do
-        return BitOps_internal.chpl_bitops_rotr_16(x, n:uint(bits));
-      when 8 do
-        return BitOps_internal.chpl_bitops_rotr_8(x, n:uint(bits));
-      otherwise
-        compilerError("rotr is not supported for that bit width.");
-    }
-  }
-
-  /*
-    rotate right
-
-    x: signed integer of size `bits`
-    bits: 8, 16, 32, 64
-    n: shift amount, must be less than `bits`
-
-    returns: `x` rotated left by `n` bits
-  */
-  inline proc rotr(x: int(?bits), n: integral) {
-    return rotr(x:uint(bits), n):int(bits);
+  inline proc rotr(x: integral, n: integral) {
+    return BitOps_internal.rotr(x, n);
   }
 
   // Legacy operations
@@ -270,6 +98,7 @@ module BitOps {
   // function.  There should be a similar version using xor
   // as the combinator, but I'm not sure where that would
   // go to be perfectly truthful
+  pragma "no doc"
   proc bitMatMultOr(x: uint(64), y: uint(64)): uint(64) {
     // return the transpose of x, treating it as an 8x8 bit-matrix.
     proc bitMatTrans(x: uint(64))
@@ -350,4 +179,137 @@ module BitOps_internal {
   extern proc chpl_bitops_rotr_16(x: uint(16), n: uint(16)) : uint(16);
   extern proc chpl_bitops_rotr_32(x: uint(32), n: uint(32)) : uint(32);
   extern proc chpl_bitops_rotr_64(x: uint(64), n: uint(64)) : uint(64);
+
+  inline proc clz(x: uint(?bits)) {
+    // the select will be folded out at compile time.
+    select bits {
+      when 64 do
+        return chpl_bitops_clz_64(x);
+      when 32 do
+        return chpl_bitops_clz_32(x);
+      when 16 do
+        // gets promoted to 32bit, subtract the extra leading 0s
+        return (chpl_bitops_clz_32(x)-16):uint(16);
+      when 8 do
+        // gets promoted to 32bit, subtract the extra leading 0s
+        return (chpl_bitops_clz_32(x)-24):uint(8);
+      otherwise
+        // NOTE: this actually cant happen with how the integer types are setup
+        //       right now - leaving it here for the future when we support
+        //       >64bit types
+        compilerError("clz is not supported for that bit width.");
+    }
+  }
+
+  inline proc clz(x: int(?bits)) {
+    return BitOps_internal.clz(x:uint(bits)):int(bits);
+  }
+
+  inline proc ctz(x: uint(?bits)) {
+    // the select will be folded out at compile time.
+    select bits {
+      when 64 do
+        return chpl_bitops_ctz_64(x);
+      when 32 do
+        return chpl_bitops_ctz_32(x);
+      when 16 do
+        return chpl_bitops_ctz_32(x):uint(16);
+      when 8 do
+        return chpl_bitops_ctz_32(x):uint(8);
+      otherwise
+        // NOTE: this actually cant happen with how the integer types are setup
+        //       right now - leaving it here for the future when we support
+        //       >64bit types
+        compilerError("ctz is not supported for that bit width.");
+    }
+  }
+
+  inline proc ctz(x: int(?bits)) {
+    return BitOps_internal.ctz(x:uint(bits)):int(bits);
+  }
+
+  inline proc popcount(x: uint(?bits)) {
+    // the select will be folded out at compile time.
+    select bits {
+      when 64 do
+        return chpl_bitops_popcount_64(x);
+      when 32 do
+        return chpl_bitops_popcount_32(x);
+      when 16 do
+        return chpl_bitops_popcount_32(x):uint(16);
+      when 8 do
+        return chpl_bitops_popcount_32(x):uint(8);
+      // In the future we could also break a large int (128+) into 64bit chucks
+      // and add up the results.
+      otherwise
+        // NOTE: this actually cant happen with how the integer types are setup
+        //       right now - leaving it here for the future when we support
+        //       >64bit types
+        compilerError("popcount is not supported for that bit width.");
+    }
+  }
+
+  inline proc popcount(x: int(?bits)) {
+    return BitOps_internal.popcount(x:uint(bits)):int(bits);
+  }
+
+  inline proc parity(x: uint(?bits)) {
+    // the select will be folded out at compile time.
+    select bits {
+      when 64 do
+        return chpl_bitops_parity_64(x);
+      when 32 do
+        return chpl_bitops_parity_32(x);
+      when 16 do
+        return chpl_bitops_parity_32(x):uint(16);
+      when 8 do
+        return chpl_bitops_parity_32(x):uint(8);
+      otherwise
+        compilerError("parity is not supported for that bit width.");
+    }
+  }
+
+  inline proc parity(x: int(?bits)) {
+    return BitOps_internal.parity(x:uint(bits)):int(bits);
+  }
+
+  inline proc rotl(x: uint(?bits), n: integral) {
+    // the select will be folded out at compile time.
+    select bits {
+      when 64 do
+        return chpl_bitops_rotl_64(x, n:uint(bits));
+      when 32 do
+        return chpl_bitops_rotl_32(x, n:uint(bits));
+      when 16 do
+        return chpl_bitops_rotl_16(x, n:uint(bits));
+      when 8 do
+        return chpl_bitops_rotl_8(x, n:uint(bits));
+      otherwise
+        compilerError("rotl is not supported for that bit width.");
+    }
+  }
+
+  inline proc rotl(x: int(?bits), n: integral) {
+    return BitOps_internal.rotl(x:uint(bits), n):int(bits);
+  }
+
+  inline proc rotr(x: uint(?bits), n: integral) {
+    // the select will be folded out at compile time.
+    select bits {
+      when 64 do
+        return chpl_bitops_rotr_64(x, n:uint(bits));
+      when 32 do
+        return chpl_bitops_rotr_32(x, n:uint(bits));
+      when 16 do
+        return chpl_bitops_rotr_16(x, n:uint(bits));
+      when 8 do
+        return chpl_bitops_rotr_8(x, n:uint(bits));
+      otherwise
+        compilerError("rotr is not supported for that bit width.");
+    }
+  }
+
+  inline proc rotr(x: int(?bits), n: integral) {
+    return BitOps_internal.rotr(x:uint(bits), n):int(bits);
+  }
 }


### PR DESCRIPTION
I've shuffled code around in BitOps to make the documentation clearer.
Each operation now has one (public) function that takes in `integral`
and calls into BitOps_internal for the correct `int`/`uint` overload.