### PR TITLE
Fix re2 tests and mac llvm build

### DIFF
--- a/test/regexp/ferguson/ctests.skipif
+++ b/test/regexp/ferguson/ctests.skipif
@@ -5,3 +5,8 @@ COMPOPTS <= --baseline
 COMPOPTS <= --no-local
 CHPL_TEST_PERF == on
 CHPL_TEST_VGRND_EXE == on
+# This test works with clang or gcc only
+CHPL_TARGET_COMPILER==pgi
+CHPL_TARGET_COMPILER==intel
+CHPL_TARGET_COMPILER==cray-prgenv-pgi
+CHPL_TARGET_COMPILER==cray-prgenv-intel

--- a/test/regexp/ferguson/ctests/sub_test
+++ b/test/regexp/ferguson/ctests/sub_test
@@ -21,21 +21,21 @@ RE2_INSTALL_DIR=$($CHPL_HOME/util/config/compileline --libraries | \
 RE2INCLS=-I$RE2_INSTALL_DIR/include
 RE2LIB="-L$RE2_INSTALL_DIR/lib -Wl,-rpath,$RE2_INSTALL_DIR/lib -lre2"
 
-echo $DEFS | grep atomics/intrinsics
-if [ $? -eq 0 ]
-then
-  echo C tests will run using atomics/intrinsics
-else
-  echo Skipping C I/O tests without atomics/intrinsics
-  exit
-fi
-
 RE=`$CHPL_HOME/util/chplenv/chpl_regexp.py`
 if [ "$RE" = "re2" ]
 then
-  echo C tests will run using RE2
+  echo "[Working on $DIR with RE2]"
 else
-  echo Skipping C Regexp tests without RE2
+  echo "[Skipping directory $DIR without RE2]"
+  exit
+fi
+
+echo $DEFS | grep atomics/intrinsics
+if [ $? -eq 0 ]
+then
+  echo "[Working on $DIR with atomics/intrinsics]"
+else
+  echo "[Skipping directory $DIR without atomics/intrinsics]"
   exit
 fi
 
@@ -52,7 +52,7 @@ then
   CC=clang
   CXX=clang++
 else
-  echo Skipping C Regexp tests without gnu compilers
+  echo "[Skipping directory $DIR without gcc or clang]"
   exit
 fi
 

--- a/test/regexp/ferguson/ctests/sub_test
+++ b/test/regexp/ferguson/ctests/sub_test
@@ -11,6 +11,7 @@ then
   export CHPL_HOME=$SAVE_HOME
 fi
 
+DIR=regexp/ferguson/ctests
 CC=gcc
 CXX=g++
 DEFS=`$CHPL_HOME/util/config/compileline --includes-and-defines`
@@ -68,38 +69,36 @@ DEPS="$OPTS -Wall -DCHPL_RT_UNIT_TEST $DEFS $RSRC/qio.c $RSRC/sys.c $RSRC/sys_xs
 T1="$CXX $DEPS -g regexp_test.cc -o regexp_test"
 T2="$CXX $DEPS -g regexp_channel_test.cc -o regexp_channel_test"
 
-echo $T1
-echo $T2
 
-$T1 && $T2
-
-RETVAL=$?
-
-runtest() {
+dotest() {
   EXE=$1
-  DESC=$2
-  echo Running $EXE
-  `$CHPL_HOME/util/test/timedexec 500 $EXE > /dev/null`
+  COMPLINE=$2
+  echo "[Executing compiler $COMPLINE]"
+  $COMPLINE
   RETVAL=$?
   if [ $RETVAL -eq 0 ]
   then
-    echo "[Success matching C regexp test $EXE $DESC]"
-    rm $EXE
-  elif [ $RETVAL -eq 222 ]
-  then
-    echo "[Error Timed out executing regexp test $EXE $DESC]"
+    echo "[Success compiling $DIR/$EXE]"
+    echo "[Executing program ./$EXE]"
+    `$CHPL_HOME/util/test/timedexec 500 ./$EXE > /dev/null`
+    RETVAL=$?
+    if [ $RETVAL -eq 0 ]
+    then
+      echo "[Success matching program output for $DIR/$EXE]"
+
+      rm ./$EXE
+    elif [ $RETVAL -eq 222 ]
+    then
+      echo "[Error Timed out executing program $DIR/$EXE]"
+    else
+      echo "[Error matching program output for $DIR/$EXE]"
+    fi
   else
-    echo "[Error matching C regexp test $EXE $DESC]"
+    echo "[Error matching compiler output for $DIR/$EXE]"
   fi
 }
 
-if [ $RETVAL -eq 0 ]
-then
-  echo "[Success compiling C Regexp tests]"
 
-  runtest ./regexp_test "Regexp Test"
-  runtest ./regexp_channel_test "Regexp Channels Test"
-else
-  echo "[Error compiling C Regexp tests]"
-fi
+dotest regexp_test "$T1"
+dotest regexp_channel_test "$T2"
 

--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -45,8 +45,8 @@ $(RE2_UNPACKED_DIR):
 $(RE2_H_FILE): $(RE2_BUILD_SUBDIR) $(RE2_UNPACKED_DIR)
 	cd re2 && \
 	$(MAKE) clean && \
-	$(MAKE) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)" obj/libre2.a && \
-	$(MAKE) CXX=$(CXX) NODEBUG= CXXFLAGS="$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)" prefix=$(RE2_INSTALL_DIR) install-static && \
+	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' obj/libre2.a && \
+	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' prefix=$(RE2_INSTALL_DIR) install-static && \
 	mkdir -p ../build/$(RE2_UNIQUE_SUBDIR) && \
 	rm -rf ../build/$(RE2_UNIQUE_SUBDIR) && \
 	mv obj ../build/$(RE2_UNIQUE_SUBDIR)


### PR DESCRIPTION
Fix C++ RE2 tests to have better error messages and to be skipped by .skipif when
gnu or clang are not in use.

Fix a build problem with LLVM and RE2 used together with Mac OS X:
After PR #1539, we build third-party libraries (including RE2)
with the included clang compiler to support --llvm. When we
do that on Mac OS X, we set CXX (and CC) to be more than
one word, which breaks because we weren't properly quoting
those variables in third-party/re2/Makefile. Here we add
single quotes (as that is how the other third-party Makefiles
do it) and change the other quoted variables to use single
quotes as well.