### PR TITLE
Clang included use atomics

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -40,6 +40,8 @@ def get(flag='target'):
                 atomics_val = 'intrinsics'
             elif compiler_val == 'clang':
                 atomics_val = 'intrinsics'
+            elif compiler_val == 'clang-included':
+                atomics_val = 'intrinsics'
 
             # we can't use intrinsics, fall back to locks
             if not atomics_val:

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -12,9 +12,9 @@ def get(flag='host'):
         mem_val = os.environ.get('CHPL_MEM')
         if not mem_val:
             comm_val = chpl_comm.get()
-            platform_val = chpl_platform.get('host')
-            arch_val = chpl_arch.get('target', get_lcd=True)
-            tcmallocCompat = ["gnu", "clang", "intel"]
+            #platform_val = chpl_platform.get('host')
+            #arch_val = chpl_arch.get('target', get_lcd=True)
+            #tcmallocCompat = ["gnu", "clang", "clang-included", "intel"]
 
             # true if tcmalloc is compatible with the target compiler
             #if (not (platform_val == 'cray-xc' and arch_val == 'knc') and


### PR DESCRIPTION
Continuing PR #1539, we should allow clang-included builds to use intrinsics
for atomics. I checked for other uses of "clang" in the chplenv scripts and
noticed it was used in chpl_mem.py, so I added clang-included there too but
then realized that code section just sets variables that are never used
(the would be used but the uses are commented out). So I commented
out that code section too.