### PR TITLE
Fix coverity, llvm build errors, and sub_test warning message.

### DIFF
--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <fstream>
-#include <glob.h>
 #include <iostream>
 #include <iterator>
 #include <sstream>
@@ -270,31 +269,6 @@ std::string generateSphinxProject(std::string dirpath) {
 }
 
 
-/* Returns the first path found matching '$venvDir/lib/python*\/site-packages' */
-static const char* getPythonPath(const char* venvDir) {
-  glob_t globResult;
-  const char* globPattern = astr(venvDir, "/lib/python*/site-packages");
-  glob(globPattern, 0, NULL, &globResult);
-  const size_t count = globResult.gl_pathc;
-
-  // No results found. Return "".
-
-  // FIXME: This should report error (chpldoc is not properly built/installed),
-  //        and stop processing...
-  //        (thomasvandoren, 2015-03-10)
-  char* result;
-  if (count == 0) {
-    result = (char*)"";
-  // At least one result found, so return first.
-  } else {
-    result = new char[strlen(globResult.gl_pathv[0])];
-    strcpy(result, globResult.gl_pathv[0]);
-  }
-  globfree(&globResult);
-  return result;
-}
-
-
 /*
  * Invoke sphinx-build using sphinxDir to find conf.py and rst sources, and
  * outputDir for generated html files.
@@ -308,11 +282,9 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir) {
     CHPL_TARGET_PLATFORM, "/chpldoc-virtualenv");
   const char * venvBinDir = astr(venvDir, "/bin");
   const char * sphinxBuild = astr(venvBinDir, "/sphinx-build");
-  const char * pythonPath = getPythonPath(venvDir);
 
   const char * envVars = astr("export PATH=", venvBinDir, ":$PATH && ",
-                              "export VIRTUAL_ENV=", venvDir, " && ",
-                              "export PYTHONPATH=", pythonPath);
+                              "export VIRTUAL_ENV=", venvDir);
 
   // Run:
   //   $envVars &&

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1230,8 +1230,9 @@ for testname in testsrc:
                 cmd = compiler + 'doc'
 
                 if which(cmd) is None:
-                    sys.stderr.write('[Warning: Skipping test; could not find chpldoc '
-                                     'at: {0}'.format(cmd))
+                    sys.stdout.write(
+                        '[Warning: Could not find chpldoc, skipping test '
+                        '{0}/{1}]\n'.format(localdir, test_filename))
                     continue
             else:
                 cmd = compiler


### PR DESCRIPTION
Remove the getPythonPath() function from docs.cpp and the associated code for
setting PYTHONPATH.

Previously, I thought this fixed the build on our test systems. It turns out
that was not the case, as the python path settings were very strange on that
system.

In general, setting the PYTHONPATH should not be necessary as long as the PATH
is set and the correct sphinx-build is used. We might need to ensure PYTHONPATH
is unset, but that is not clear yet.

Also, fix sub_test warning to include line break and information about test
that is being run.