### PR TITLE
Fix Coverity bug I introduced with the string realPath

### DIFF
--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -260,9 +260,8 @@ qioerr chpl_fs_mkdir(const char* name, int mode, int parents) {
 
 qioerr chpl_fs_realpath(const char* path, const char **shortened) {
   qioerr err = 0;
-  //shortened = NULL; // Don't want to get confused.
   *shortened = realpath(path, NULL);
-  if (shortened == NULL) {
+  if (*shortened == NULL) {
     // If an error occurred, shortened will be NULL.  Otherwise, it will
     // contain the cleaned up path.
     err = qio_mkerror_errno();


### PR DESCRIPTION
Coverity rightly complained that I should not have been comparing shortened
against NULL.  I really should have been comparing *shortened against NULL,
since that was what was updated in the C realpath call.