### PR TITLE
Do not send email when chpldoc build fails in nightly.

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -496,10 +496,10 @@ if ($makestat != 0) {
 print "Making $make_vars_opt third-party-try-opt\n";
 mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt third-party-try-opt", "make chapel third-party-try-opt", 1, 1);
 
-# Build chpldoc. Do not fail the build if it does not succeed. Send a message
-# if the build fails, though.
+# Build chpldoc. Do not fail the build if it does not succeed. Do not send
+# mail either.
 print "Making $make_vars_opt chpldoc\n";
-mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt chpldoc", "make chapel chpldoc", 0, 1);
+mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt chpldoc", "make chapel chpldoc", 0, 0);
 
 if ($buildruntime == 0) {
     $endtime = localtime;


### PR DESCRIPTION
Use the warning from sub_test to indicate the chpldoc build failed.