### PR TITLE
Update LLVM build to disable zlib.

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -36,6 +36,7 @@ $(LLVM_FILE):
 	--prefix=$(LLVM_INSTALL_DIR) \
 	--enable-optimized --disable-clang-arcmt --disable-clang-static-analyzer \
 	--disable-clang-rewriter --disable-docs \
+	--disable-zlib \
 	--enable-targets=host,x86,x86_64 $(CHPL_LLVM_DEBUG)
 	cd $(LLVM_BUILD_DIR) && $(MAKE)
 	cd $(LLVM_BUILD_DIR) && $(MAKE) install

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -32,7 +32,11 @@ clobber: FORCE
 $(LLVM_FILE):
 	if [ ! -d llvm ]; then ./unpack-llvm.sh; fi
 	mkdir -p $(LLVM_BUILD_DIR)
-	cd $(LLVM_BUILD_DIR) && $(LLVM_SRC_DIR)/configure CC='$(CC)' CXX='$(CXX)' --prefix=$(LLVM_INSTALL_DIR) --enable-optimized --disable-clang-arcmt --disable-clang-static-analyzer --disable-clang-rewriter --disable-docs --enable-targets=host,x86,x86_64 $(CHPL_LLVM_DEBUG)
+	cd $(LLVM_BUILD_DIR) && $(LLVM_SRC_DIR)/configure CC='$(CC)' CXX='$(CXX)' \
+	--prefix=$(LLVM_INSTALL_DIR) \
+	--enable-optimized --disable-clang-arcmt --disable-clang-static-analyzer \
+	--disable-clang-rewriter --disable-docs \
+	--enable-targets=host,x86,x86_64 $(CHPL_LLVM_DEBUG)
 	cd $(LLVM_BUILD_DIR) && $(MAKE)
 	cd $(LLVM_BUILD_DIR) && $(MAKE) install
 	cd $(LLVM_BUILD_DIR) && cd test && $(MAKE) lit.site.cfg


### PR DESCRIPTION
Throw --disable-zlib when configuring llvm build. It is not needed, and when
it is enabled (the default) the chapel cray module ends up depending on libz.so
unnecessarily.

Also, wrap the llvm ./configure options in makefile for easier reading.

### Verification:

* [x] llvm and llvm-enabled compiler build on mac and hellos pass
* [x] llvm and llvm-enabled compiler build on mork-esl