### PR TITLE
Build gmp re2 with clang included

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ runtime: FORCE
 llvm-runtime-if-needed: FORCE
 	-@if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
 	echo "Building runtime for chpl --llvm"; \
-	cd runtime && CHPL_TARGET_COMPILER=clang-included $(MAKE); \
+	export CHPL_TARGET_COMPILER=clang-included && \
+	$(MAKE) third-party-try-opt && \
+	$(MAKE) runtime ; \
 	fi
 
 third-party: FORCE


### PR DESCRIPTION
Previously, gmp and re2 could only be built manually with the clang-included
target compiler. Update the llvm-runtime-if-needed target name to call the
third-party-try-opt target, which speculatively builds gmp and re2 (and
possibly others in the future).

This makes re2 and gmp functionality available to llvm. gmp does not yet work
with llvm, but it hopefully will some day!

To verify, I ran make with CHPL_LLVM=llvm and then confirmed that re2 and
gmp install/ directories had *clang-included sub dirs.