### PR TITLE
Update llvm nightly test configs to use python 2.7.

### DIFF
--- a/util/cron/common-llvm.bash
+++ b/util/cron/common-llvm.bash
@@ -6,6 +6,23 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 export CHPL_LLVM=llvm
 
+# Ensure that python 2.7 is at front of PATH. This is only done for
+# llvm configuration because the test systems are _very_ finicky about
+# python 2.6 due to some environmental configurations.
+#
+# Ideally, this would only apply to the `make compile` step in
+# nightly, but there is not a good way to do that right now. One can
+# imagine adding a "pre-make-compile hook" to nightly. Maybe an env
+# var with a comment to executes, but it seems ok for the chpldoc test
+# to fail on llvm for now.
+# (thomasvandoren, 2015-03-11)
+py27_setup=/data/cf/chapel/setup_python27.bash
+if [ -f "${py27_setup}" ] ; then
+    source ${py27_setup}
+else
+    echo "[Warning: llvm may not build correctly with python: $(which python)]"
+fi
+
 # Run examples and test/extern/ferguson/.
 export CHPL_NIGHTLY_TEST_DIRS="extern/ferguson"
 


### PR DESCRIPTION
The llvm build requires python 2.7, which can be added to the front of
PATH on chapel test systems by sourcing a special bash script. Update
common-llvm.bash to source that setup script.

This is only done for llvm configuration because the test systems are
_very_ finicky about python 2.6 due to some environmental configurations.

Ideally, python 2.7 would only be available to the `make compile` step in
nightly, but there is not a good way to do that right now. One can
imagine adding a "pre-make-compile hook" to nightly. Maybe an env
var with a comment to executes, but it seems ok for the chpldoc test
to fail on llvm for now. And someday python 2.7 will work properly on
the test systems.

### Verification:

* [x] run `source common-llvm.bash && ./nightly -cron -hellos`
