### PR TITLE
Update smoke test to verify chpldoc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,9 @@ depend:
 check: all
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
 
+check-chpldoc: chpldoc
+	@bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall --chpldoc
+
 -include Makefile.devel
 
 FORCE:

--- a/doc/release/technotes/README.chpldoc.rst
+++ b/doc/release/technotes/README.chpldoc.rst
@@ -33,7 +33,7 @@ This will downloads the required Python package dependencies and creates the
 ``chpldoc`` program in the same location as the ``chpl`` compiler.
 
 To ensure chpldoc is installed properly, optionally run the automatic sanity
-check using an example program::
+check::
 
     [g]make check-chpldoc
 

--- a/doc/release/technotes/README.chpldoc.rst
+++ b/doc/release/technotes/README.chpldoc.rst
@@ -29,6 +29,11 @@ Pydoc. To build ``chpldoc``, use::
 
     [g]make chpldoc
 
+To ensure chpldoc is installed properly, optionally run an automatic sanity
+check using an example program::
+
+    [g]make check-chpldoc
+
 This will downloads the required Python package dependencies and creates the
 ``chpldoc`` program in the same location as the ``chpl`` compiler.
 

--- a/doc/release/technotes/README.chpldoc.rst
+++ b/doc/release/technotes/README.chpldoc.rst
@@ -29,13 +29,13 @@ Pydoc. To build ``chpldoc``, use::
 
     [g]make chpldoc
 
-To ensure chpldoc is installed properly, optionally run an automatic sanity
+This will downloads the required Python package dependencies and creates the
+``chpldoc`` program in the same location as the ``chpl`` compiler.
+
+To ensure chpldoc is installed properly, optionally run the automatic sanity
 check using an example program::
 
     [g]make check-chpldoc
-
-This will downloads the required Python package dependencies and creates the
-``chpldoc`` program in the same location as the ``chpl`` compiler.
 
 
 .. _Prerequisites:

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -114,3 +114,8 @@ fi
 # parallel execution, but call `make check` without it.
 make -j${num_procs} $chpl_make_args && \
     make $chpl_make_args check
+
+# Build chpldoc and make sure the chpldoc primer runs. Build chpldoc with
+# parallel execution, but call `make check-chpldoc` without it.
+make -j${num_procs} $chpl_make_args chpldoc && \
+    make $chpl_make_args check-chpldoc

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -46,12 +46,18 @@ function log_error()
     echo "[ERROR] ${msg}" 1>&2
 }
 
-case $1 in
-    "")
-        # nothing special when no args are given
-        ;;
+bin_name=chpl
+
+for opt in ${*:1} ; do
+case $opt in
+    # "")
+    #     # nothing special when no args are given
+    #     ;;
     --debug)
         debug_chpl_test=true
+        ;;
+    --chpldoc)
+        bin_name=chpldoc
         ;;
     --help|-h|*)
         cat<<EOF
@@ -64,22 +70,25 @@ usage: $0
   By default, programs are compiled and run from \$HOME/.chpl/. Set
   CHPL_CHECK_INSTALL_DIR environment variable to use an alternate location.
 
+  --chpldoc  Test chpldoc with the chpldoc primer, instead of the chpl.
+
 EOF
         exit 0
         ;;
 esac
+done
 
-CHPL_BIN=$(which chpl 2> /dev/null)
+CHPL_BIN=$(which ${bin_name} 2> /dev/null)
 
 # Verify chpl binary exists and is executable.
 if [ -z "${CHPL_BIN}" ] ; then
-    log_error "chpl compiler not found. Make sure it available in the current PATH."
+    log_error "${bin_name} not found. Make sure it available in the current PATH."
     exit 1
 elif [ ! -x $CHPL_BIN ] ; then
-    log_error "Found chpl at ${CHPL_BIN} but it is not executable."
+    log_error "Found ${bin_name} at ${CHPL_BIN} but it is not executable."
     exit 1
 else
-    log_debug "Found chpl compiler at: ${CHPL_BIN}"
+    log_debug "Found ${bin_name} at: ${CHPL_BIN}"
 fi
 
 # Verify CHPL_HOME is correctly set.
@@ -105,18 +114,24 @@ else
     exit 1
 fi
 
+# For chpldoc, only test the primers/chpldoc.doc.chpl test.
+if [ "${bin_name}" = "chpldoc" ] ; then
+    test_name="chpldoc"
+    TESTS=$TEST_DIR/primers/chpldoc.doc.*
+
 # List all the files in the examples dir. Do not list any subdirectories,
 # though.
-TESTS=$(find $TEST_DIR -maxdepth 1 -mindepth 1 -type f)
+else
+    test_name="hello world"
+    TESTS=$(find $TEST_DIR -maxdepth 1 -mindepth 1 -type f)
+fi
 
 # Copy these tests to a temp file.
 
 chpl_dir=${CHPL_CHECK_INSTALL_DIR:-$HOME/.chpl}
 if [ ! -d $chpl_dir ] ; then
     log_debug "${chpl_dir} does not exist. Creating it."
-    # Do not use -p/--parents. $HOME should exist and if it doesn't many other
-    # things will probably fail.
-    mkdir $chpl_dir || { log_error "Failed to create ${chpl_dir}." && exit 10 ; }
+    mkdir -p $chpl_dir || { log_error "Failed to create ${chpl_dir}." && exit 10 ; }
 fi
 
 TMP_TEST_DIR=$(mktemp -d ${chpl_dir}/chapel-test-XXXXX)
@@ -143,7 +158,7 @@ cp $TESTS $TMP_TEST_DIR/
     export CHPL_TEST_UTIL_DIR=$CHPL_HOME/util
 
     # Run the tests.
-    echo "Running the hello world tests found in: $TEST_DIR"
+    echo "Running the ${test_name} tests found in: $TEST_DIR"
 
     $CHPL_HOME/util/start_test --no-chpl-home-warn --progress $CHPL_START_TEST_ARGS *.chpl > $test_output_log
 
@@ -199,7 +214,7 @@ log_debug $(grep -E "${summary_key}" $test_output_log)
 
 case $success in
     true)
-        echo "chpl installation works as expected!"
+        echo "${bin_name} installation works as expected!"
         exit 0
         ;;
     false|*)
@@ -208,8 +223,8 @@ case $success in
             cat $test_output_log
         fi
 
-        echo "Found issues with chpl installation."
-        echo "  chpl path: ${CHPL_BIN}"
+        echo "Found issues with ${bin_name} installation."
+        echo "  ${bin_name} path: ${CHPL_BIN}"
         echo "  CHPL_HOME: ${CHPL_HOME}"
 
         # Copy the output log file to a non-temp location to make it available

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -50,9 +50,6 @@ bin_name=chpl
 
 for opt in ${*:1} ; do
 case $opt in
-    # "")
-    #     # nothing special when no args are given
-    #     ;;
     --debug)
         debug_chpl_test=true
         ;;


### PR DESCRIPTION
Update checkChplInstall script to support testing chpldoc. Add --chpldoc
option to checkChplInstall, which then tests chpldoc with
examples/primers/chpldoc.doc.chpl instead of chpl and the hellos.

Add check-chpldoc target to top level makefile. It calls through to
checkChplInstall with --chpldoc option. It depends on the chpldoc target,
ensuring chpldoc is built and up-to-date before "checking" it. This is similar
to the check target for chpl compiler.

Finally, update smokeTest script to call `make check-chpldoc`.