### PR TITLE
Fix prefetch C test for 32-bit

### DIFF
--- a/test/modules/standard/Prefetch/prefetch.compopts
+++ b/test/modules/standard/Prefetch/prefetch.compopts
@@ -1,1 +1,5 @@
--O3
+# All 64-bit x86 has prefetch, but some 32-bit intel did not
+# so it is necessary to supply -march=native for 32-bit testing.
+# This could be achieved working through the CHPL_TARGET_ARCH
+# mechanism to be more robust for different platforms.
+-O3 -march=native

--- a/test/modules/standard/Prefetch/prefetch.compopts
+++ b/test/modules/standard/Prefetch/prefetch.compopts
@@ -1,5 +1,1 @@
-# All 64-bit x86 has prefetch, but some 32-bit intel did not
-# so it is necessary to supply -march=native for 32-bit testing.
-# This could be achieved working through the CHPL_TARGET_ARCH
-# mechanism to be more robust for different platforms.
--O3 -march=native
+-O3

--- a/test/modules/standard/Prefetch/prefetch.skipif
+++ b/test/modules/standard/Prefetch/prefetch.skipif
@@ -2,5 +2,7 @@
 # so it is necessary to supply -march=native for 32-bit testing.
 # This could be achieved working through the CHPL_TARGET_ARCH
 # mechanism to be more robust for different platforms.
+# In fact, this test works for me on 32-bit linux if CHPL_TARGET_ARCH=native
+# is set before testing begins...
 # For now though, we just skip this test on 32-bit systems.
 CHPL_TARGET_PLATFORM == linux32

--- a/test/modules/standard/Prefetch/prefetch.skipif
+++ b/test/modules/standard/Prefetch/prefetch.skipif
@@ -1,0 +1,6 @@
+# All 64-bit x86 has prefetch, but some 32-bit intel did not
+# so it is necessary to supply -march=native for 32-bit testing.
+# This could be achieved working through the CHPL_TARGET_ARCH
+# mechanism to be more robust for different platforms.
+# For now though, we just skip this test on 32-bit systems.
+CHPL_TARGET_PLATFORM <= 32

--- a/test/modules/standard/Prefetch/prefetch.skipif
+++ b/test/modules/standard/Prefetch/prefetch.skipif
@@ -3,4 +3,4 @@
 # This could be achieved working through the CHPL_TARGET_ARCH
 # mechanism to be more robust for different platforms.
 # For now though, we just skip this test on 32-bit systems.
-CHPL_TARGET_PLATFORM <= 32
+CHPL_TARGET_PLATFORM == linux32


### PR DESCRIPTION
All 64-bit x86 has prefetch, but some 32-bit intel did not
so it is necessary to supply -march=native for 32-bit testing.
This could be achieved working through the CHPL_TARGET_ARCH
mechanism to be more robust for different platforms, but I
believe that -march=native will work for all non-MIC architectures.