### PR TITLE
Fix a bug in --cache-remote on 32-bit platforms

### DIFF
--- a/runtime/src/chpl-cache-support.c
+++ b/runtime/src/chpl-cache-support.c
@@ -293,7 +293,7 @@ void set_valids_for_skip_len(uint64_t* valid, uintptr_t skip, uintptr_t len, int
       // entirely after the region -- nothing valid
     } else if( skip <= offset && offset + 64 <= skip+len ) {
       // entirely within the region -- totally valid
-      valid[i] = (uintptr_t) -1;
+      valid[i] = (uint64_t) -1;
     } else {
       use_start = skip - offset;
       if( use_start < 0 ) use_start = 0;


### PR DESCRIPTION
Fix a bug on 32-bit platforms where we lost bits. 
A cast to (uintptr_t) should have been (uint64_t).

Should resolve errors with 
 optimizations/cache-remote/ferguson/c_tests/chpl-cache-support-test