### PR TITLE
Update chpldoc build to create relocatable sphinx-build script.

### DIFF
--- a/third-party/chpldoc-venv/Makefile.include
+++ b/third-party/chpldoc-venv/Makefile.include
@@ -1,4 +1,9 @@
-CHPLDOC_VENV_DIR=$(THIRD_PARTY_DIR)/chpldoc-venv
+# Virtualenv is sensitive to ../../ in the path. Specifically, they are
+# recorded all the way down to the hash bangs in scripts. Removing them here
+# avoids any potential issues when paths are compared (e.g. some things
+# consider a/b/../../a/b/ equal to a/b/, while string matching does not).
+CHPLDOC_VENV_DIR=$(shell cd $(THIRD_PARTY_DIR)/chpldoc-venv && pwd)
+
 CHPLDOC_VENV_UNIQUE_SUBDIR=$(CHPL_MAKE_TARGET_PLATFORM)
 CHPLDOC_VENV_INSTALL_SUBDIR=install/$(CHPLDOC_VENV_UNIQUE_SUBDIR)
 CHPLDOC_VENV_INSTALL_DIR=$(CHPLDOC_VENV_DIR)/$(CHPLDOC_VENV_INSTALL_SUBDIR)


### PR DESCRIPTION
Previously, when calling `cd third-party/chpldoc-venv/ && make` these messages
indicated the sphinx-build script was not being made relocatable:

```
Script /Users/tvandoren/src/chapel/third-party/chpldoc-venv/../../third-party/chpldoc-venv/install/darwin/chpldoc-virtualenv/bin/sphinx-apidoc cannot be made relative (it's not a normal script that starts with #!/Users/tvandoren/src/chapel/third-party/chpldoc-venv/install/darwin/chpldoc-virtualenv/bin/python)
Script /Users/tvandoren/src/chapel/third-party/chpldoc-venv/../../third-party/chpldoc-venv/install/darwin/chpldoc-virtualenv/bin/sphinx-autogen cannot be made relative (it's not a normal script that starts with #!/Users/tvandoren/src/chapel/third-party/chpldoc-venv/install/darwin/chpldoc-virtualenv/bin/python)
Script /Users/tvandoren/src/chapel/third-party/chpldoc-venv/../../third-party/chpldoc-venv/install/darwin/chpldoc-virtualenv/bin/sphinx-build cannot be made relative (it's not a normal script that starts with #!/Users/tvandoren/src/chapel/third-party/chpldoc-venv/install/darwin/chpldoc-virtualenv/bin/python)
Script /Users/tvandoren/src/chapel/third-party/chpldoc-venv/../../third-party/chpldoc-venv/install/darwin/chpldoc-virtualenv/bin/sphinx-quickstart cannot be made relative (it's not a normal script that starts with #!/Users/tvandoren/src/chapel/third-party/chpldoc-venv/install/darwin/chpldoc-virtualenv/bin/python)
```

The virtualenv --relocable call was normalizing the path to the virtualenv dir,
but then using string comparisons when looking at hash bangs in scripts like
sphinx-build. The hash bangs had paths of the form a/b/../../a/b/, which is
logically the same as the normalized a/b/, but a string comparison considers
them different.

Update Makefile.include to use a normalized path from the beginning of time
to avoid the issue entirely.

### Verification:

* [x] Run `cd third-party/chpldoc-venv/ && make` and confirm the above messages are replaced with `Making script <script name> relative`.