### PR TITLE
Build clang-included runtime, et al with associated top-level targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ comprt: FORCE
 	@$(MAKE) compiler
 	@$(MAKE) third-party-try-opt
 	@$(MAKE) runtime
-	@$(MAKE) llvm-runtime-if-needed
 	@$(MAKE) modules
 
 compiler: FORCE
@@ -69,37 +68,31 @@ modules: FORCE
 runtime: FORCE
 	cd runtime && $(MAKE)
 	-@if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
-	echo "Building runtime for chpl --llvm"; \
+	echo "Building runtime for chpl --llvm" ; \
 	export CHPL_TARGET_COMPILER=clang-included && \
-	cd runtime && $(MAKE) \
+	cd runtime && $(MAKE) ; \
 	fi
-
-llvm-runtime-if-needed: FORCE
-
 
 third-party: FORCE
 	cd third-party && $(MAKE)
 
 third-party-try-opt: third-party-try-re2 third-party-try-gmp
-	
 
 third-party-try-re2: FORCE
 	-@if [ -z "$$CHPL_REGEXP" ]; then \
 	cd third-party && $(MAKE) try-re2; \
-	-@if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
-	echo "Building runtime for chpl --llvm"; \
+	if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
 	export CHPL_TARGET_COMPILER=clang-included && \
-	$(MAKE) third-party-try-re2 && \
+	$(MAKE) try-re2; \
 	fi \
 	fi
 
 third-party-try-gmp: FORCE
 	-@if [ -z "$$CHPL_GMP" ]; then \
 	cd third-party && $(MAKE) try-gmp; \
-	-@if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
-	echo "Building runtime for chpl --llvm"; \
+	if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
 	export CHPL_TARGET_COMPILER=clang-included && \
-	$(MAKE) third-party&& $(MAKE) try-gmp \
+	$(MAKE) try-gmp; \
 	fi \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ modules: FORCE
 runtime: FORCE
 	cd runtime && $(MAKE)
 	-@if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
-	echo "Building runtime for chpl --llvm" ; \
 	export CHPL_TARGET_COMPILER=clang-included && \
 	cd runtime && $(MAKE) ; \
 	fi


### PR DESCRIPTION
Previously, the clang-included runtime and speculative third party builds were
a separate target, llvm-runtime-if-needed, which was invoked from comprt. This
worked well when the default target or the comprt target was called. However,
it was less than ideal when runtime or third-party-try-opt was invoked
directly.

For example, if a developer was working on the runtime and iteratively calling
`make runtime` from the top level, the clang-included runtime was not rebuilt
with each rebuild.

Update the makefile to build the clang-included runtime as a part of each of
the runtime and third-party-try-{gmp,re2} targets. Now, when the runtime is
built, the clang-included runtime will be built. The same is true for the
speculative gmp and re2 builds.

This will fix the issue with llvm and gasnet.llvm nightly testing configs. ./nightly
does not call `make` at the top-level, instead it calls the individual targets
in comprt (this is done for better failure reporting as well as to retry some
when they fail). It was not updated to call llvm-runtime-if-needed.

### Verification:

* [x] Call `make runtime` and ensure gen/ directories have regular and clang-included variations.
* [x] Call `make third-party-try-opt` and ensure gmp/install/ and re2/install/ dirs have clang-included variations.
* [x] Verify nightly -cron -hello  passes with llvm enabled.

paired with @bradcray on initial implementation