### PR TITLE
Report error and stop build when easy_install is not found.

### DIFF
--- a/third-party/chpldoc-venv/Makefile
+++ b/third-party/chpldoc-venv/Makefile
@@ -19,25 +19,25 @@ cleanall: FORCE
 clobber: FORCE
 	rm -rf install
 
-$(PYTHON):
+check-python:
 ifeq ($(wildcard $(PYTHON)),)
 	$(error python and easy_install are required to install chpldoc \
 	        dependencies. See https://www.python.org/)
 endif
 
-$(EASY_INSTALL):
+check-easy-install:
 ifeq ($(wildcard $(EASY_INSTALL)),)
 	$(error python and easy_install are required to install chpldoc \
 	        dependencies. See https://www.python.org/)
 endif
 
-check-exes: $(PYTHON) $(EASY_INSTALL)
+check-exes: check-python check-easy-install
 
 $(CHPLDOC_VENV_INSTALL_DIR):
 	mkdir -p $@
 
 # Install virtualenv program.
-$(CHPLDOC_VENV_VIRTUALENV): $(CHPLDOC_VENV_INSTALL_DIR) $(PYTHON) $(EASY_INSTALL)
+$(CHPLDOC_VENV_VIRTUALENV): $(CHPLDOC_VENV_INSTALL_DIR) check-exes
 	export PYTHONPATH=$(CHPLDOC_VENV_INSTALL_DIR):$$PYTHONPATH && \
 	$(EASY_INSTALL) --install-dir=$(CHPLDOC_VENV_INSTALL_DIR) $(shell cat virtualenv.txt)
 
@@ -79,6 +79,6 @@ rm-sphinx-build: FORCE
 
 FORCE:
 
-.PHONY: install-requirements create-virtualenv virtualenv check-exes rm-sphinx-build
+.PHONY: install-requirements create-virtualenv virtualenv check-exes rm-sphinx-build check-easy-install check-python
 
 .NOTPARALLEL:


### PR DESCRIPTION
Previously, there were make targets in third-party/chpldoc-venv/ that attempted
to check that python and easy_install were available. However, they did not
work in the case that $(which easy_install) returned nothing, since the
$(EASY_INSTALL) variable was empty, which meant $(EASY_INSTALL) as a
dependency did not mean anything.

Update third-party/chpldoc-venv/Makefile to use phony targets for the
python and easy_install checks. This way they will always work, especially when
easy_install or python is not found.

I verified this by running `cd third-party/chpldoc-venv/ && make` on a system
that did not have easy_install. It correctly reported the error, instead of
trying to call easy_install virtualenv (which is what happened before).