### PR TITLE
Bug fix for routine in LICM that finds nested fn calls

### DIFF
--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -1030,9 +1030,7 @@ static void collectUsedFnSymbolsSTL(BaseAST* ast, std::set<FnSymbol*>& fnSymbols
     if (FnSymbol* fnSymbol = call->isResolved()) {
       if(fnSymbols.count(fnSymbol) == 0) {
         fnSymbols.insert(fnSymbol);
-        for_alist(expr, fnSymbol->body->body) {
-          AST_CHILDREN_CALL(expr, collectUsedFnSymbolsSTL, fnSymbols);
-        }
+        AST_CHILDREN_CALL(fnSymbol->body, collectUsedFnSymbolsSTL, fnSymbols);
       }
     }
   }


### PR DESCRIPTION
LICM has a function to find all function calls in a given AST element
(including nested function calls.) However, the logic to find nested function
calls was broken.

If you had:

```chapel

  for i in 1..10 do fn();
  proc fn() { fn2(); }
```

`fn2()` would **not** have been found.

But if you had:

```chapel
  for i in 1..10 do fn();
  proc fn() { var a = fn2(); }
```

then `fn2()` would have been found

The issue was with how we found nested function calls. The previous logic was:

```c
  for_alist(expr, fnSymbol->body->body) {
    AST_CHILDREN_CALL(expr, collectUsedFnSymbolsSTL, fnSymbols);
  }
```

For the case where expr was a CallExpr, AST_CHILDREN_CALL won't call
collectUsedFnSymbolsSTL() on the CallExpr itself, only it's baseExpr and it's
argList. This updates the routine to do the AST_CHILDREN_CALL directly on the
fnSymbol's body and find nested function calls recursivly instead of iterating
over the function's body. This also could have been resolved by doing:

```c
  for_list(expr, fnSymbol->body->body) {
    collectUsedFnSymbolsSTL(expr, fnSymbols);
  }
```
since the routine will check if expr was itself a CallExpr.

This will fix the advanced iters segfaults with --no-local performance testing.
The issue was that we had some sync variables in a function call that should
have prevented LICM from firing. For the --local case these sync variables were
in a top level function call, but for --no-local that function call was wrapped
with a 'wrap_on' function.