### PR TITLE
Add three new futures for chpldoc.

### DIFF
--- a/test/chpldoc/types/fields/complexes.bad
+++ b/test/chpldoc/types/fields/complexes.bad
@@ -1,0 +1,11 @@
+Module: complexes
+   Record: Foo
+      var aComplex: complex = +(, )
+      const bar = +(, )
+      param baz: complex
+      var aComplex2: complex = +(, )
+         This one has a comment 
+      const bar2 = +(, )
+         So does this one 
+      param baz2: complex
+         And this one 

--- a/test/chpldoc/types/fields/complexes.catfiles
+++ b/test/chpldoc/types/fields/complexes.catfiles
@@ -1,0 +1,1 @@
+docs/complexes.txt

--- a/test/chpldoc/types/fields/complexes.chpl
+++ b/test/chpldoc/types/fields/complexes.chpl
@@ -1,0 +1,12 @@
+record Foo {
+  var aComplex: complex = 1.0 + 2.0i;
+  const bar = 0.0 + 1.0i;
+  param baz: complex;
+
+  /* This one has a comment */
+  var aComplex2: complex = 1.0 + 2.0i;
+  /* So does this one */
+  const bar2 = 0.0 + 1.0i;
+  /* And this one */
+  param baz2: complex;
+}

--- a/test/chpldoc/types/fields/complexes.future
+++ b/test/chpldoc/types/fields/complexes.future
@@ -1,0 +1,15 @@
+bug: default values for complexes dropped in chpldoc
+
+When attempting to display a complex with a defined default value, chpldoc
+understands that a default value is present (and so generates an "= ") but does
+not know how to output its value.  This is because the pretty printer for
+VarSymbols that wrap Immediates is incomplete, which is partially a result of
+Immediates only defining a "type_value" method for ints, uints, and bools, but
+none for reals, complexes or imags.
+
+Action items:
+We need to revisit/improve the role of Immediates in the compiler
+We need to finish transitioning chpldoc from using prettyPrint to expanding
+  and using AstToText.
+
+See also reals.future and imags.future

--- a/test/chpldoc/types/fields/complexes.good
+++ b/test/chpldoc/types/fields/complexes.good
@@ -1,0 +1,11 @@
+Module: complexes
+   Record: Foo
+      var aComplex: complex = 1.0 + 2.0i
+      const bar = 0.0 + 1.0i
+      param baz: complex
+      var anComplex2: complex = 1.0 + 2.0i
+         This one has a comment 
+      const bar2 = 0.0 + 1.0i
+         So does this one 
+      param baz2: complex
+         And this one 

--- a/test/chpldoc/types/fields/imags.bad
+++ b/test/chpldoc/types/fields/imags.bad
@@ -1,0 +1,11 @@
+Module: imags
+   Record: Foo
+      var anImag: imag = 
+      const bar = 
+      param baz: imag
+      var anImag2: imag = 
+         This one has a comment 
+      const bar2 = 
+         So does this one 
+      param baz2: imag
+         And this one 

--- a/test/chpldoc/types/fields/imags.catfiles
+++ b/test/chpldoc/types/fields/imags.catfiles
@@ -1,0 +1,1 @@
+docs/imags.txt

--- a/test/chpldoc/types/fields/imags.chpl
+++ b/test/chpldoc/types/fields/imags.chpl
@@ -1,0 +1,12 @@
+record Foo {
+  var anImag: imag = 2.0i;
+  const bar = 1.0i;
+  param baz: imag;
+
+  /* This one has a comment */
+  var anImag2: imag = 2.0i;
+  /* So does this one */
+  const bar2 = 1.0i;
+  /* And this one */
+  param baz2: imag;
+}

--- a/test/chpldoc/types/fields/imags.future
+++ b/test/chpldoc/types/fields/imags.future
@@ -1,0 +1,15 @@
+bug: default values for imags dropped in chpldoc
+
+When attempting to display an imag with a defined default value, chpldoc
+understands that a default value is present (and so generates an "= ") but does
+not know how to output its value.  This is because the pretty printer for
+VarSymbols that wrap Immediates is incomplete, which is partially a result of
+Immediates only defining a "type_value" method for ints, uints, and bools, but
+none for reals, complexes or imags.
+
+Action items:
+We need to revisit/improve the role of Immediates in the compiler
+We need to finish transitioning chpldoc from using prettyPrint to expanding
+  and using AstToText.
+
+See also reals.future and complexes.future

--- a/test/chpldoc/types/fields/imags.good
+++ b/test/chpldoc/types/fields/imags.good
@@ -1,0 +1,11 @@
+Module: imags
+   Record: Foo
+      var anImag: imag = 2.0i
+      const bar = 1.0i
+      param baz: imag
+      var anImag2: imag = 2.0i
+         This one has a comment 
+      const bar2 = 1.0i
+         So does this one 
+      param baz2: imag
+         And this one 

--- a/test/chpldoc/types/fields/reals.bad
+++ b/test/chpldoc/types/fields/reals.bad
@@ -1,0 +1,11 @@
+Module: reals
+   Record: Foo
+      var aReal: real = 
+      const bar = 
+      param baz: real
+      var aReal2: real = 
+         This one has a comment 
+      const bar2 = 
+         So does this one 
+      param baz2: real
+         And this one 

--- a/test/chpldoc/types/fields/reals.catfiles
+++ b/test/chpldoc/types/fields/reals.catfiles
@@ -1,0 +1,1 @@
+docs/reals.txt

--- a/test/chpldoc/types/fields/reals.chpl
+++ b/test/chpldoc/types/fields/reals.chpl
@@ -1,0 +1,12 @@
+record Foo {
+  var aReal: real = 2.0;
+  const bar = 1.0;
+  param baz: real;
+
+  /* This one has a comment */
+  var aReal2: real = 2.0;
+  /* So does this one */
+  const bar2 = 1.0;
+  /* And this one */
+  param baz2: real;
+}

--- a/test/chpldoc/types/fields/reals.future
+++ b/test/chpldoc/types/fields/reals.future
@@ -1,0 +1,15 @@
+bug: default values for reals dropped in chpldoc
+
+When attempting to display a real with a defined default value, chpldoc
+understands that a default value is present (and so generates an "= ") but does
+not know how to output its value.  This is because the pretty printer for
+VarSymbols that wrap Immediates is incomplete, which is partially a result of
+Immediates only defining a "type_value" method for ints, uints, and bools, but
+none for reals, complexes or imags.
+
+Action items:
+We need to revisit/improve the role of Immediates in the compiler
+We need to finish transitioning chpldoc from using prettyPrint to expanding
+  and using AstToText.
+
+See also imags.future and complexes.future

--- a/test/chpldoc/types/fields/reals.good
+++ b/test/chpldoc/types/fields/reals.good
@@ -1,0 +1,11 @@
+Module: reals
+   Record: Foo
+      var aReal: real = 2.0
+      const bar = 1.0
+      param baz: real
+      var aReal2: real = 2.0
+         This one has a comment 
+      const bar2 = 1.0
+         So does this one 
+      param baz2: real
+         And this one 


### PR DESCRIPTION
Mike discovered that default value output for reals, imags, and complexes were
handled incorrectly.  Since a good solution would involve more effort and
planning, we have decided to delay and implement it after the release, rather
than implement a poor solution that relies on behavior that will change in the
near future.  To make sure this is not forgotten, add a future to handle these
cases.