### PR TITLE
Do not inline iterators that should be dynamically dispatched

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1646,7 +1646,10 @@ expandForLoop(ForLoop* forLoop) {
         iterator->type->dispatchChildren.v[0] == dtObject))) {
     expandIteratorInline(forLoop);
 
-  } else if (!fNoInlineIterators && canInlineSingleYieldIterator(iterator)) {
+  } else if (!fNoInlineIterators && canInlineSingleYieldIterator(iterator) &&
+            (iterator->type->dispatchChildren.n == 0 ||
+             (iterator->type->dispatchChildren.n == 1 &&
+              iterator->type->dispatchChildren.v[0] == dtObject))) {
     inlineSingleYieldIterator(forLoop);
 
   } else {


### PR DESCRIPTION
Fix an iterator lowering bug where we inlined an iterator that should be
dynamically dispatched.

We have 3 forms of iterator lowering: expandIteratorInline(),
inlineSingleYieldIterator(), and producing the zip* functions. We were already
careful about not inlining dynamically dispatched iterators with
expandIteratorInline(). This copies the logic for that and applies it to
inlineSingleYieldIterator() as well. The zip* lowering already correctly
handle dynamically dispatched iterators so this just makes sure the right form
of iterator lowering is called for dynamically dispatched iterators.

Some boring details:

This is motivated by a recent bug report (and some old futures) of the form:
```chapel
class Super {
  iter these() { yield 0; }
}
class Sub: Super {
  iter these() { yield 1; }
}

var c: Super = new Sub();
for i in c do writeln(i);
```
Previously, we mistakenly directly inlined Super's iter into the call site.
This patch fixes this so that for the above case we do not inline the iterator,
and instead dynamic dispatch is used.

If you have `var c: Super = new Super();` we directly inline the iterator.
This is legal, and a good thing for performance. Similarly we directly inline
the iterator for `var c: Sub = new Sub();`

This fixes the above bug, and should allow us to retire a couple of futures.