### PR TITLE
Support older LLVMs

### DIFF
--- a/compiler/util/llvmGlobalToWide.cpp
+++ b/compiler/util/llvmGlobalToWide.cpp
@@ -1243,8 +1243,12 @@ namespace {
 
         for(Function::use_iterator UI = F->use_begin(), UE = F->use_end();
                 UI!=UE; ) {
+#if HAVE_LLVM_VER >= 35
           Use &U = *UI;
-          User *Old = U.getUser(); //UI->getUser(); //*UI; //UI->getUser();
+          User *Old = U.getUser();
+#else
+          User *Old = *UI;
+#endif
           ++UI;
           CallSite CS(Old);
           if (CS.getInstruction()) {

--- a/third-party/llvm/Makefile.include-llvm
+++ b/third-party/llvm/Makefile.include-llvm
@@ -6,7 +6,10 @@ include $(THIRD_PARTY_DIR)/llvm/Makefile.share
 # and LLVM #includes are in $(LLVM_INCLUDE_DIR)/llvm
 LLVM_CLANG_CODEGEN_INCLUDE_DIR=$(LLVM_DIR)/$(LLVM_SUBDIR)/tools/clang/lib/CodeGen/
 LLVM_LIB_DIR=$(LLVM_INSTALL_DIR)/lib
+# Use this version for LLVM 3.6
 LLVM_LLVM_LIBS=$(shell $(LLVM_INSTALL_DIR)/bin/llvm-config --ldflags --system-libs --libs bitreader bitwriter ipo instrumentation option objcarcopts profiledata all-targets)
+# Use this version for LLVM 3.4 and 3.3
+#LLVM_LLVM_LIBS=$(shell $(LLVM_INSTALL_DIR)/bin/llvm-config --ldflags --libs bitreader bitwriter ipo instrumentation option objcarcopts all-targets)
 
 LLVM_CLANG_LIBS=-lclangFrontend -lclangSerialization -lclangDriver -lclangCodeGen -lclangParse -lclangSema -lclangAnalysis -lclangEdit -lclangAST -lclangLex -lclangBasic
 


### PR DESCRIPTION
Make very minor changes - mostly comment changes - to leave
breadcrumbs on how to compile with older LLVMs. Add an ifdef
around some code that only compiles that way with LLVM 3.6
so that older LLVMs get the older version of the code.

Trivial change. Tested make clean and LLVM Hello works
with LLVM 3.6 or 3.3 (with the appropriate Makefile.include-llvm
comments changed).