### PR TITLE
Add 6 tests of realPath

### DIFF
--- a/test/modules/standard/Path/lydia/realpath/doesNotExist.chpl
+++ b/test/modules/standard/Path/lydia/realpath/doesNotExist.chpl
@@ -1,0 +1,4 @@
+use Path;
+
+var nonexistent = "foo.txt";
+writeln(realPath("foo.txt"));

--- a/test/modules/standard/Path/lydia/realpath/doesNotExist.good
+++ b/test/modules/standard/Path/lydia/realpath/doesNotExist.good
@@ -1,0 +1,1 @@
+errorcase.chpl:4: error: No such file or directory in realPath of with path "foo.txt"

--- a/test/modules/standard/Path/lydia/realpath/doesNotExist.good
+++ b/test/modules/standard/Path/lydia/realpath/doesNotExist.good
@@ -1,1 +1,1 @@
-errorcase.chpl:4: error: No such file or directory in realPath of with path "foo.txt"
+doesNotExist.chpl:4: error: No such file or directory in realPath of with path "foo.txt"

--- a/test/modules/standard/Path/lydia/realpath/fileNotValid.chpl
+++ b/test/modules/standard/Path/lydia/realpath/fileNotValid.chpl
@@ -1,0 +1,6 @@
+use Path;
+
+var f: file;
+// File records are initialised to not point to a valid file pointer.
+var fPath = f.realPath();
+writeln(fPath); // Shouldn't reach here

--- a/test/modules/standard/Path/lydia/realpath/fileNotValid.good
+++ b/test/modules/standard/Path/lydia/realpath/fileNotValid.good
@@ -1,0 +1,1 @@
+fileNotValid.chpl:5: error: Bad file descriptor in file.realPath

--- a/test/modules/standard/Path/lydia/realpath/fileVersion.chpl
+++ b/test/modules/standard/Path/lydia/realpath/fileVersion.chpl
@@ -7,7 +7,7 @@ var openedFile = open(filename, iomode.cw);
 
 var path = openedFile.realPath();
 var shouldMatch = here.cwd() + "/blahblahblah.txt";
-// May want to us joinPath and basename here when available.
+// May want to use joinPath and basename here when available.
 if path != shouldMatch {
   writeln("Whoops, expected " + shouldMatch + " but got " + path);
 } else {

--- a/test/modules/standard/Path/lydia/realpath/onFileInDir.chpl
+++ b/test/modules/standard/Path/lydia/realpath/onFileInDir.chpl
@@ -1,0 +1,14 @@
+use Path;
+use FileSystem;
+
+var unmodified = "onFileInDir.chpl";
+var f = open(unmodified, iomode.r);
+// I know I exist (update name if changed)
+var result = f.realPath();
+var expected = here.cwd() + pathSep + unmodified;
+// Will want to use joinPath here when it is implemented.
+if (result != expected) {
+  writeln("Expected " + expected + " but got " + result);
+} else {
+  writeln("realPath on a path without symlinks, curDir, or parentDir references behaved as expected");
+ }

--- a/test/modules/standard/Path/lydia/realpath/onFileInDir.good
+++ b/test/modules/standard/Path/lydia/realpath/onFileInDir.good
@@ -1,0 +1,1 @@
+realPath on a path without symlinks, curDir, or parentDir references behaved as expected

--- a/test/modules/standard/Path/lydia/realpath/onFilePathInDir.chpl
+++ b/test/modules/standard/Path/lydia/realpath/onFilePathInDir.chpl
@@ -1,0 +1,13 @@
+use Path;
+use FileSystem;
+
+var unmodified = "onFilePathInDir.chpl";
+// I know I exist (update name if changed)
+var result = realPath(unmodified);
+var expected = here.cwd() + pathSep + unmodified;
+// Will want to use joinPath here when it is implemented.
+if (result != expected) {
+  writeln("Expected " + expected + " but got " + result);
+} else {
+  writeln("realPath on a path without symlinks, curDir, or parentDir references behaved as expected");
+ }

--- a/test/modules/standard/Path/lydia/realpath/onFilePathInDir.good
+++ b/test/modules/standard/Path/lydia/realpath/onFilePathInDir.good
@@ -1,0 +1,1 @@
+realPath on a path without symlinks, curDir, or parentDir references behaved as expected

--- a/test/modules/standard/Path/lydia/realpath/resultSameAsArgument.chpl
+++ b/test/modules/standard/Path/lydia/realpath/resultSameAsArgument.chpl
@@ -1,0 +1,14 @@
+use Path;
+
+var originalPath = "resultSameAsArgument.chpl";
+// Well, I know this file exists, better not rename it.
+var firstRun = realPath(originalPath);
+// firstRun will be an exact path
+var secondTimeThrough = realPath(firstRun);
+// Nothing should need to be done to firstRun, so the result of that
+// call should match the argument.
+if (firstRun == secondTimeThrough) {
+  writeln("Yay, realPath works on a path that has already been fixed!");
+} else {
+  writeln("Expected " + firstRun + " but was " + secondTimeThrough);
+ }

--- a/test/modules/standard/Path/lydia/realpath/resultSameAsArgument.good
+++ b/test/modules/standard/Path/lydia/realpath/resultSameAsArgument.good
@@ -1,0 +1,1 @@
+Yay, realPath works on a path that has already been fixed!

--- a/test/modules/standard/Path/lydia/realpath/resultSameAsFilePath.chpl
+++ b/test/modules/standard/Path/lydia/realpath/resultSameAsFilePath.chpl
@@ -1,0 +1,17 @@
+use Path;
+
+var originalPath = "resultSameAsFilePath.chpl";
+// Well, I know this file exists, better not rename it.
+var firstRun = realPath(originalPath);
+// firstRun will be an exact path
+// use the exact path to open a file
+var f = open(firstRun, iomode.r);
+
+var secondTimeThrough = f.realPath();
+// Nothing should need to be done to f's path, so the result of that
+// call should match the argument.
+if (firstRun == secondTimeThrough) {
+  writeln("Yay, realPath works on a path that has already been fixed!");
+} else {
+  writeln("Expected " + firstRun + " but was " + secondTimeThrough);
+ }

--- a/test/modules/standard/Path/lydia/realpath/resultSameAsFilePath.good
+++ b/test/modules/standard/Path/lydia/realpath/resultSameAsFilePath.good
@@ -1,0 +1,1 @@
+Yay, realPath works on a path that has already been fixed!


### PR DESCRIPTION
These include:
- That realPath on a path that doesn't exist fails
- That realPath on a path that has already been run through realPath
  doesn't change the outcome.
- A file which was opened with an exact path will return the same,
  unaltered path with the realPath method
- A file and a string version of checking a file that lives in the current
  working directory (and was not specified fully).
- If realPath is called on a file record which doesn't point to a valid
  file, correct behavior occurs.