### PR TITLE
Add documentation for class and record destructors.

### DIFF
--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -923,6 +923,11 @@ of \chpl{C}.
 The value \chpl{nil} can be implicitly converted to any class type.
 These conversions do not change the value.
 
+
+%TODO: Move memory management explanation up, closer to class constructors.
+% Perhaps make the memory management part of the introduction, and then let the
+% description of destructors appear naturally at the same indentation level as
+% constructors.
 \section{Dynamic Memory Management}
 \label{Dynamic_Memory_Management}
 \label{Class_Delete}
@@ -996,8 +1001,8 @@ features become supported.
 
 \subsection{Class Destructor}
 \label{Class_Destructor}
-\label{classes!destructor}
-\label{destructor!classes}
+\index{classes!destructor}
+\index{destructor!classes}
 
 A class author may specify additional actions to be performed before a class object is
 reclaimed, by defining a class destructor.  A class destructor is a method that has the

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -992,3 +992,36 @@ a region-based memory management scheme similar to that used in the Titanium
 language.  Support of \chpl{delete} will likely continue even as these optional
 features become supported.
 \end{openissue}
+
+
+\subsection{Class Destructor}
+\label{Class_Destructor}
+\label{classes!destructor}
+\label{destructor!classes}
+
+A class author may specify additional actions to be performed before a class object is
+reclaimed, by defining a class destructor.  A class destructor is a method that has the
+same name as the class prefixed by a tilde.  A class destructor takes no arguments (aside from
+the implicit \chpl{this} argument).  If defined, the destructor is called each time
+a \chpl{delete} statement is invoked with a valid instance of that class type.  The
+destructor is not called if the argument of \chpl{delete} evaluates to \chpl{nil}.
+
+\begin{chapelexample}{classDestructor.chpl}
+\begin{chapel}
+class C {
+  var i,j,k: int;
+  proc ~C() { writeln("Bye, bye."); }
+}
+
+var c : C = nil;
+delete c;        // Does nothing: c is nil.
+
+c = new C();     // Creates a new object.
+delete c;        // Deletes that object: Writes out "Bye, bye." 
+                 // and reclaims the memory that was held by c.
+\end{chapel}
+\begin{chapeloutput}
+Bye, bye.
+Bye, bye.
+\end{chapeloutput}
+\end{chapelexample}

--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -345,18 +345,36 @@ supplied, the default initializer cannot be called directly.
 
 \subsection{Record Destructor}
 \label{Record_Destructor}
-\label{records!destructor}
-\label{destructor!records}
+\index{records!destructor}
+\index{destructor!records}
 
-A record author may specify addditional actions to be performed before a record object is
-reclaimed, by defining a record destructor.  A record destructor is a method that has the
+A record author may specify addditional actions to be performed before record storage is
+reclaimed by defining a record destructor.  A record destructor is a method that has the
 same name as the record prefixed by a tilde.  A record destructor takes no arguments
 (aside from the implicit \chpl{this} argument).  If defined, the destructor is called
 on a record object after it goes out of scope and before its memory is reclaimed.
 
+% TODO: The above ambiguous language is intended to allow optimizations involving extending
+% the lifetime of an object.  However, we leave unspecified the means by which a user may
+% demand avid running of the destructor and reclamation of memory (as in C\#).  We need to
+% specify this so the above language can be tightened up for that case.
+
+% For now, the actual lifetime of a record object is under the control of the compiler.  For
+% example, as an optimization, ownership of an object may be transferred between variables with
+% non-overlapping lifetimes.  When this happens, there will be no observable destruction of
+% one of those variables.  The compiler may also choose to insert temporary copies e.g. of
+% record formals or of a record return value.
+
+% The compiler guarantees that every record constructor call will have exactly one
+% corresponding record destructor call.  However, the exact number of constructor-destructor
+% pairs is determined by the compiler, and may also be influenced by various compiler
+% options.
+
 \begin{chapelexample}{recordDestructor.chpl}
 \begin{chapel}
 class C { var x: int; } // A class with nonzero size.
+// If the class were empty, whether or not its memory was reclaimed 
+// would not be observable.
 
 // Defines a record implementing simple memory management.
 record R {
@@ -391,19 +409,6 @@ Number of leaked allocations
 --memLeaks
 \end{chapelexecopts}
 \end{chapelexample}
-
-\begin{note}
-The actual lifetime of an object is under the control of the compiler.  For example, as an
-optimization, ownership of an object may be transferred between variables with
-non-overlapping lifetimes.  When this happens, there will be no observable destruction of
-one of those variables.  The compiler may also choose to insert temporary copies e.g. of
-record formals or of a record return value.  
-
-The compiler guarantees that every record constructor call will have exactly one
-corresponding record destructor call.  However, the exact number of constructor-destructor
-pairs is determined by the compiler, and may also be influenced by various compiler
-options.
-\end{note}
 
 
 \section{Record Arguments}

--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -343,6 +343,69 @@ As with classes, the user can provide his own constructors
 (\rsec{User_Defined_Constructors}).  If any user-defined constructors are
 supplied, the default initializer cannot be called directly.  
 
+\subsection{Record Destructor}
+\label{Record_Destructor}
+\label{records!destructor}
+\label{destructor!records}
+
+A record author may specify addditional actions to be performed before a record object is
+reclaimed, by defining a record destructor.  A record destructor is a method that has the
+same name as the record prefixed by a tilde.  A record destructor takes no arguments
+(aside from the implicit \chpl{this} argument).  If defined, the destructor is called
+on a record object after it goes out of scope and before its memory is reclaimed.
+
+\begin{chapelexample}{recordDestructor.chpl}
+\begin{chapel}
+class C { var x: int; } // A class with nonzero size.
+
+// Defines a record implementing simple memory management.
+record R {
+  var c: C;
+  proc R() { c = new C(0); }
+  proc ~R() { delete c; c = nil; }
+}
+
+proc foo()
+{
+  var r: R; // Initialized using default constructor.
+  writeln(r);
+  // r will go out of scope here.
+  // Its destructor will be called to free the C object it contains.
+}
+
+foo();
+\end{chapel}
+\begin{chapeloutput}
+(c = {x = 0})
+
+====================
+Leaked Memory Report
+==============================================================
+Number of leaked allocations
+           Total leaked memory (bytes)
+                      Description of allocation
+==============================================================
+==============================================================
+\end{chapeloutput}
+\begin{chapelexecopts}
+--memLeaks
+\end{chapelexecopts}
+\end{chapelexample}
+
+\begin{note}
+The actual lifetime of an object is under the control of the compiler.  For example, as an
+optimization, ownership of an object may be transferred between variables with
+non-overlapping lifetimes.  When this happens, there will be no observable destruction of
+one of those variables.  The compiler may also choose to insert temporary copies e.g. of
+record formals or of a record return value.  
+
+The compiler guarantees that every record constructor call will have exactly one
+corresponding record destructor call.  However, the exact number of constructor-destructor
+pairs is determined by the compiler, and may also be influenced by various compiler
+options.
+\end{note}
+
+
 \section{Record Arguments}
 \label{Record_Arguments}
 \index{records!arguments}


### PR DESCRIPTION
Described destructors as a hook for performing extra tasks prior to releasing object
memory.

For classes, said that the destructor is called when a "delete" is executed.
For records, indicated that when the destructor is called is controlled by the compiler.

Added code examples for each.