### PR TITLE
Support valgrind testing on chpldoc tests.

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1221,19 +1221,21 @@ for testname in testsrc:
             args = ['-o', test_filename]+directoryCompopts+shlex.split(compopts)+[testname]
             cmd = c_compiler
         else:
-            if valgrindcomp:
-                cmd = valgrindcomp
-                args = valgrindcompopts+[compiler]+args
-            elif test_is_chpldoc and not compiler.endswith('chpldoc'):
+            if test_is_chpldoc and not compiler.endswith('chpldoc'):
                 # For tests with .doc.chpl suffix, use chpldoc compiler. Update
                 # the compopts accordingly. Add 'doc' prefix to existing compiler.
-                cmd = compiler + 'doc'
+                compiler += 'doc'
+                cmd = compiler
 
                 if which(cmd) is None:
                     sys.stdout.write(
                         '[Warning: Could not find chpldoc, skipping test '
                         '{0}/{1}]\n'.format(localdir, test_filename))
                     continue
+
+            if valgrindcomp:
+                cmd = valgrindcomp
+                args = valgrindcompopts+[compiler]+args
             else:
                 cmd = compiler
 


### PR DESCRIPTION
Update sub_test to correctly wrap chpldoc compiler commands with valgrind.
Previously, the chpldoc tests (i.e. those with .doc.chpl suffix) were using the
chpl compiler when running under valgrind due to an incorrect if/else block.
This led to invalid option errors, because chpl was called with chpldoc options
(e.g. --text-only).

### Verification:

* [x] Run `start_test -valgrind test/release/examples/primers/chpldoc.doc.chpl`
  and confirm it passes.