### PR TITLE
Document Search module

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -70,6 +70,7 @@ MODULES_TO_DOCUMENT = \
 	standard/Path.chpl \
 	standard/Random.chpl \
 	standard/Regexp.chpl \
+	standard/Search.chpl \
 	standard/Sort.chpl \
 	standard/Sys.chpl \
 	$(SYS_CTYPES_MODULE_DOC)

--- a/modules/standard/Search.chpl
+++ b/modules/standard/Search.chpl
@@ -25,7 +25,7 @@
 
 
 /*
-   Searches through the pre-sorted array Data looking for the value val using
+   Searches through the pre-sorted array `Data` looking for the value `val` using
    a sequential linear search.  Returns a tuple indicating (1) whether or not
    the value was found and (2) the location of the value if it was found, or
    the location where the value should have been if it was not found.
@@ -34,7 +34,6 @@
    :arg val: The value to find in the array
 
    :returns: A tuple indicating (1) if the value was found and (2) the location of the value if it was found or the location where the value should have been if it was not found.
-
 
  */
 proc LinearSearch(Data:[?Dom], val) {

--- a/modules/standard/Search.chpl
+++ b/modules/standard/Search.chpl
@@ -22,7 +22,7 @@
    current interface is minimal and should be expected to grow and evolve
    over time.
  */
-
+module Search {
 
 /*
    Searches through the pre-sorted array `Data` looking for the value `val` using
@@ -80,4 +80,5 @@ proc BinarySearch(Data:[?Dom], val, in lo = Dom.low, in hi = Dom.high) {
     }
   }
   return (false, lo);
+}
 }

--- a/modules/standard/Search.chpl
+++ b/modules/standard/Search.chpl
@@ -23,6 +23,7 @@
    over time.
  */
 
+
 /*
    Searches through the pre-sorted array Data looking for the value val using
    a sequential linear search.  Returns a tuple indicating (1) whether or not
@@ -31,10 +32,11 @@
 
    :arg Data: The sorted array to search
    :arg val: The value to find in the array
+
    :returns: A tuple indicating (1) if the value was found and (2) the location of the value if it was found or the location where the value should have been if it was not found.
 
- */
 
+ */
 proc LinearSearch(Data:[?Dom], val) {
   for i in Dom {
     if (Data(i) == val) {
@@ -60,9 +62,10 @@ proc LinearSearch(Data:[?Dom], val) {
    :arg Data: The sorted array to search
    :arg val: The value to find in the array
    :arg lo: The lowest index to consider while searching
-   :type:lo: integral
+   :type lo: `integral`
    :arg hi: The highest index to consider while searching
-   :type hi: integral
+   :type hi: `integral`
+
    :returns: A tuple indicating (1) if the value was found and (2) the location of the value if it was found or the location where the value should have been if it was not found.
 
  */

--- a/modules/standard/Search.chpl
+++ b/modules/standard/Search.chpl
@@ -17,6 +17,24 @@
  * limitations under the License.
  */
 
+/*
+   The `Search` module is designed to support standard search routines. The
+   current interface is minimal and should be expected to grow and evolve
+   over time.
+ */
+
+/*
+   Searches through the pre-sorted array Data looking for the value val using
+   a sequential linear search.  Returns a tuple indicating (1) whether or not
+   the value was found and (2) the location of the value if it was found, or
+   the location where the value should have been if it was not found.
+
+   :arg Data: The sorted array to search
+   :arg val: The value to find in the array
+   :returns: A tuple indicating (1) if the value was found and (2) the location of the value if it was found or the location where the value should have been if it was not found.
+
+ */
+
 proc LinearSearch(Data:[?Dom], val) {
   for i in Dom {
     if (Data(i) == val) {
@@ -31,6 +49,23 @@ proc LinearSearch(Data:[?Dom], val) {
 
 // would really like to drop the lo/hi arguments here, but right now
 // that causes too big of a memory leak
+/*
+   Searches through the pre-sorted array `Data` looking for the value `val`
+   using a sequential binary search.  If provided, only the indices `lo`
+   through `hi` will be considered, otherwise the whole array will be
+   searched. Returns a tuple indicating (1) whether or not the value was
+   found and (2) the location of the value if it was found, or the location
+   where the value should have been if it was not found.
+
+   :arg Data: The sorted array to search
+   :arg val: The value to find in the array
+   :arg lo: The lowest index to consider while searching
+   :type:lo: integral
+   :arg hi: The highest index to consider while searching
+   :type hi: integral
+   :returns: A tuple indicating (1) if the value was found and (2) the location of the value if it was found or the location where the value should have been if it was not found.
+
+ */
 proc BinarySearch(Data:[?Dom], val, in lo = Dom.low, in hi = Dom.high) {
   while (lo <= hi) {
     const mid = (hi - lo)/2 + lo;

--- a/spec/Standard_Modules.tex
+++ b/spec/Standard_Modules.tex
@@ -23,7 +23,6 @@ are as follows:
 
 \begin{tabular}{lll}
 \hspace{1pc} & \chpl{AdvancedIters} & Advanced iterator functions \\
-             & \chpl{Search} & Generic searching routines \\
              & \chpl{UtilMath} & Math-related utilities \\
 \end{tabular}
 
@@ -713,39 +712,6 @@ iter adaptive(r:range(?), numTasks:int = 0)
   splitting in the victim range is performed from its tail.
 \end{itemize}
 
-\end{protobody}
-
-
-\subsection{Search}
-\label{Search}
-\index{modules!optional!Search@\chpl{Search}}
-
-The \chpl{Search} module is designed to support standard search
-routines.  The current interface is minimal and should be expected to
-grow and evolve over time.
-
-\begin{protohead}
-proc LinearSearch(Data: [?Dom], val): (bool, index(Dom))
-\end{protohead}
-\begin{protobody}
-Searches through the pre-sorted array \chpl{Data} looking for the
-value \chpl{val} using a sequential linear search.  Returns a tuple
-indicating (1) whether or not the value was found and (2) the location
-of the value if it was found, or the location where the value should
-have been if it was not found.
-\end{protobody}
-
-\begin{protohead}
-proc BinarySearch(Data: [?Dom], val, in lo = Dom.low, in hi = Dom.high)
-\end{protohead}
-\begin{protobody}
-Searches through the pre-sorted array \chpl{Data} looking for the
-value \chpl{val} using a sequential binary search.  If provided, only
-the indices \chpl{lo} through \chpl{hi} will be considered, otherwise
-the whole array will be searched.  Returns a tuple indicating (1)
-whether or not the value was found and (2) the location of the value
-if it was found, or the location where the value should have been if
-it was not found.
 \end{protobody}
 
 


### PR DESCRIPTION
Move documentation out of the Standard Modules spec section and into chpldoc
comments in the Search module.