### PR TITLE
Default to ugni comm and muxed tasking for cray-x* platforms using module.

### DIFF
--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -3,14 +3,18 @@ import sys, os
 
 import chpl_platform
 from utils import memoize
+import utils
 
 @memoize
 def get():
     comm_val = os.environ.get('CHPL_COMM')
     if not comm_val:
         platform_val = chpl_platform.get('target')
+        # use ugni when on a cray-x* machine using the module
+        if platform_val.startswith('cray-x') and utils.using_chapel_module():
+            comm_val = 'ugni'
         # automatically uses gasnet when on a cray-x* or cray-cs machine
-        if platform_val.startswith('cray-'):
+        elif platform_val.startswith('cray-'):
             comm_val = 'gasnet'
         else:
             comm_val = 'none'

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
+import chpl_compiler
 import chpl_platform
 from utils import memoize
 import utils
@@ -10,8 +11,11 @@ def get():
     comm_val = os.environ.get('CHPL_COMM')
     if not comm_val:
         platform_val = chpl_platform.get('target')
-        # use ugni when on a cray-x* machine using the module
-        if platform_val.startswith('cray-x') and utils.using_chapel_module():
+        compiler_val = chpl_compiler.get('target')
+        # use ugni on cray-x* machines using the module and supported compiler
+        if (platform_val.startswith('cray-x') and
+                utils.using_chapel_module() and
+                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel')):
             comm_val = 'ugni'
         # automatically uses gasnet when on a cray-x* or cray-cs machine
         elif platform_val.startswith('cray-'):

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -3,6 +3,7 @@ import sys, os
 
 import chpl_arch, chpl_platform, chpl_compiler
 from utils import memoize
+import utils
 
 @memoize
 def get():
@@ -11,7 +12,11 @@ def get():
         arch_val = chpl_arch.get('target', get_lcd=True)
         platform_val = chpl_platform.get()
         compiler_val = chpl_compiler.get('target')
-        if (arch_val == 'knc' or
+
+        # use muxed when on a cray-x* machine using the module
+        if platform_val.startswith('cray-x') and utils.using_chapel_module():
+            tasks_val = 'muxed'
+        elif (arch_val == 'knc' or
                 platform_val.startswith('cygwin') or
                 platform_val.startswith('netbsd') or
                 compiler_val == 'cray-prgenv-cray'):

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -13,8 +13,10 @@ def get():
         platform_val = chpl_platform.get()
         compiler_val = chpl_compiler.get('target')
 
-        # use muxed when on a cray-x* machine using the module
-        if platform_val.startswith('cray-x') and utils.using_chapel_module():
+        # use muxed on cray-x* machines using the module and supported compiler
+        if (platform_val.startswith('cray-x') and
+                utils.using_chapel_module() and
+                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel')):
             tasks_val = 'muxed'
         elif (arch_val == 'knc' or
                 platform_val.startswith('cygwin') or


### PR DESCRIPTION
Update chpl_comm.py to default to ugni for cray-x* platforms when using the
Chapel module. Similarly, update chpl_tasks.py to default to muxed for cray-x*
platforms when using the module and a supported target compiler.

* [x] Run printchplenv on mac and confirm it still works.
* [x] Emulate cray-x* with module and confirm comm, tasks are ugni, muxed.

```bash
(
  export CHPL_MODULE_HOME=$CHPL_HOME
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-gnu
  printchplenv
)
```

* [x] Emulate cray-x* with module but not supported compiler and confirm comm, tasks are gasnet, default tasks.

```bash
(
  export CHPL_MODULE_HOME=$CHPL_HOME
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-cray
  printchplenv
)
```

* [x] Emulate cray-x* without module and confirm comm, tasks settings are gasnet, default tasks.


```bash
(
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-gnu
  printchplenv
)
```
