### PR TITLE
Rename chpldoc.chpl to chpldoc.doc.chpl in the primer Makefile

### DIFF
--- a/test/release/examples/primers/Makefile
+++ b/test/release/examples/primers/Makefile
@@ -8,7 +8,7 @@ TARGETS = \
         arrayVectorOps \
 	associative \
 	atomics \
-	chpldoc \
+	chpldoc.doc \
 	classes \
 	distributions \
 	domains \


### PR DESCRIPTION
This test got renamed, but the Makefile update was missed.