### PR TITLE
Do not use ugni+muxed on cray-x* when target arch is knc.

### DIFF
--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch
 import chpl_compiler
 import chpl_platform
 from utils import memoize

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
+import chpl_arch
 import chpl_compiler
 import chpl_platform
 from utils import memoize
@@ -12,10 +13,18 @@ def get():
     if not comm_val:
         platform_val = chpl_platform.get('target')
         compiler_val = chpl_compiler.get('target')
+
         # use ugni on cray-x* machines using the module and supported compiler
+        #
+        # Check that target arch is not knc. Don't use chpl_arch.get(), though,
+        # since it already calls into this get() function. This check only
+        # happens for X* systems using the Cray programming environment, so it
+        # is safe to assume the relevant craype module will be used that sets
+        # CRAY_CPU_TARGET.
         if (platform_val.startswith('cray-x') and
                 utils.using_chapel_module() and
-                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel')):
+                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel') and
+                os.getenv('CRAY_CPU_TARGET', '') != 'knc'):
             comm_val = 'ugni'
         # automatically uses gasnet when on a cray-x* or cray-cs machine
         elif platform_val.startswith('cray-'):

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -16,7 +16,8 @@ def get():
         # use muxed on cray-x* machines using the module and supported compiler
         if (platform_val.startswith('cray-x') and
                 utils.using_chapel_module() and
-                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel')):
+                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel') and
+                arch_val != 'knc'):
             tasks_val = 'muxed'
         elif (arch_val == 'knc' or
                 platform_val.startswith('cygwin') or


### PR DESCRIPTION
#1635 made ugni+muxed the default on cray-x* platforms, but knc
 was not taken into consideration. This fixes that.

### Verification:

* [x] Run printchplenv on mac and confirm it still works.
* [x] Emulate cray-x* with module and confirm comm, tasks are ugni, muxed.

```bash
(
  export CHPL_MODULE_HOME=$CHPL_HOME
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-gnu
  printchplenv
)
```

* [x] Emulate cray-x* with module but not supported compiler and confirm comm, tasks are gasnet, default tasks.

```bash
(
  export CHPL_MODULE_HOME=$CHPL_HOME
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-cray
  printchplenv
)
```

* [x] Emulate cray-x* without module and confirm comm, tasks settings are gasnet, default tasks.


```bash
(
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-gnu
  printchplenv
)
```

* [x] Emulate cray-x* with module and intel compiler, but knc target arch and confirm comm, tasks are gasnet, default tasks.


```bash
(
  export CHPL_MODULE_HOME=$CHPL_HOME
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-intel
  export CRAY_CPU_TARGET=knc
  printchplenv
)
```
