### PR TITLE
Avoid shallow record copies in miniMD

### DIFF
--- a/test/release/examples/benchmarks/miniMD/helpers/initMD.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/initMD.chpl
@@ -271,7 +271,8 @@ if generating {
     var v : v3;
     var a : int;
     dataReader.readln(a, v(1),v(2),v(3));
-    addatom(new atom(v), x, coord2bin(x));
+    var ta = new atom(v);
+    addatom(ta, x, coord2bin(x));
   }
 
   // cleanup
@@ -446,7 +447,8 @@ proc create_atoms() {
           for m in 1..5 { pmrand(n); }
           v(i) = pmrand(n);
         }
-        addatom(new atom(v), temp, coord2bin(temp));
+        var ta = new atom(v);
+        addatom(ta, temp, coord2bin(temp));
       }
     }
 

--- a/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
@@ -119,7 +119,7 @@ proc buildNeighbors() {
 
 // add an atom 'a' to bin 'b'
 // resize if necessary
-inline proc addatom(a : atom, x : v3, b : v3int) {
+inline proc addatom(ref a : atom, x : v3, b : v3int) {
   // increment bin's # of atoms
   Count[b] += 1;
   const end = if useStencilDist then Count.readRemote(b) else Count[b];
@@ -132,7 +132,8 @@ inline proc addatom(a : atom, x : v3, b : v3int) {
   }
  
   // add to the end of the bin
-  Bins[b][end] = a;
+  Bins[b][end].v = a.v;
+  Bins[b][end].f = a.f;
   Pos[b][end] = x;
 }
 
@@ -152,7 +153,8 @@ proc binAtoms() {
 
         // replace with atom at end of list, if one exists
         if cur < c {
-          bin[cur] = bin[c]; 
+          bin[cur].v = bin[c].v;
+          bin[cur].f = bin[c].f;
           pos[cur] = pos[c];
         }
 

--- a/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
@@ -119,6 +119,9 @@ proc buildNeighbors() {
 
 // add an atom 'a' to bin 'b'
 // resize if necessary
+// 
+// We use the 'ref' intent in order to avoid shallow copy bugs.
+// See test/types/records/bharshbarger/remote*Record.chpl for more.
 inline proc addatom(ref a : atom, x : v3, b : v3int) {
   // increment bin's # of atoms
   Count[b] += 1;


### PR DESCRIPTION
This patch avoids shallow copying of remote records. See #1642 for more information.

The solution is to pass the records by 'ref', and to not copy the array members in these records. This may result in performance improvements.