### PR TITLE
Bug fix for limiting the max size of qthreads memory pools

### DIFF
--- a/third-party/qthread/qthread-1.10/src/mpool.c
+++ b/third-party/qthread/qthread-1.10/src/mpool.c
@@ -172,6 +172,15 @@ qt_mpool INTERNAL qt_mpool_create_aligned(size_t item_size,
      * that the allocation size will be a multiple of pagesize (fast!
      * efficient!). */
     alloc_size = qt_lcm(item_size, pagesize);
+
+    if (alloc_size > max_alloc_size) {
+      size_t max_num_items;
+      /* adjust item_size to be a multiple of pagesize */
+      item_size += pagesize - (item_size % pagesize);
+      max_num_items = max_alloc_size / item_size; /* floor */
+      alloc_size = item_size * max_num_items;
+    }
+
     if (alloc_size == 0) {             /* degenerative case */
         if (item_size > pagesize) {
             alloc_size = item_size;


### PR DESCRIPTION
In cee911bf5a2e we added code to limit the max size of qthreads memory pools.
However, this code only limited the pool size when qthreads was adjusting the
initial alloc_size up if it thought it wasn't allocating enough bundles for
pooling to be worthwhile. It did not handle if the initial alloc_size was too
large.

Now if the initial alloc_size is too large, we round item_size up so it's a
multiple of pagesize (since qthreads expects allocations to be a multiple of
pagesize) and we find the max number items of that size that will fit within
max_alloc_size.

This bug was discovered while trying to figure out why ugni+qthreads seemed to
use so much more memory. The reason we noticed this bug there is because we ran
on some resource limited machines and guard pages don't work when ugni is being
used as the comm layer. In reality this was broken anytime we turned off guard
pages we just didn't notice it before.

With guard pages on, item_size just happened to work out to be a multiple of
pagesize so we got lucky and successfully limited the pool size. With guard
pages off stack size wasn't a multiple of pagesize, and the initial alloc_size
was over 1GB.