### PR TITLE
Remove ugni muxed as default on cray-x* platforms.

### DIFF
--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,24 +1,16 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_compiler
 import chpl_platform
 from utils import memoize
-import utils
 
 @memoize
 def get():
     comm_val = os.environ.get('CHPL_COMM')
     if not comm_val:
         platform_val = chpl_platform.get('target')
-        compiler_val = chpl_compiler.get('target')
-        # use ugni on cray-x* machines using the module and supported compiler
-        if (platform_val.startswith('cray-x') and
-                utils.using_chapel_module() and
-                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel')):
-            comm_val = 'ugni'
         # automatically uses gasnet when on a cray-x* or cray-cs machine
-        elif platform_val.startswith('cray-'):
+        if platform_val.startswith('cray-'):
             comm_val = 'gasnet'
         else:
             comm_val = 'none'

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -12,18 +12,10 @@ def get():
     if not comm_val:
         platform_val = chpl_platform.get('target')
         compiler_val = chpl_compiler.get('target')
-
         # use ugni on cray-x* machines using the module and supported compiler
-        #
-        # Check that target arch is not knc. Don't use chpl_arch.get(), though,
-        # since it already calls into this get() function. This check only
-        # happens for X* systems using the Cray programming environment, so it
-        # is safe to assume the relevant craype module will be used that sets
-        # CRAY_CPU_TARGET.
         if (platform_val.startswith('cray-x') and
                 utils.using_chapel_module() and
-                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel') and
-                os.getenv('CRAY_CPU_TARGET', '') != 'knc'):
+                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel')):
             comm_val = 'ugni'
         # automatically uses gasnet when on a cray-x* or cray-cs machine
         elif platform_val.startswith('cray-'):

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -3,7 +3,6 @@ import sys, os
 
 import chpl_arch, chpl_platform, chpl_compiler
 from utils import memoize
-import utils
 
 @memoize
 def get():
@@ -12,13 +11,7 @@ def get():
         arch_val = chpl_arch.get('target', get_lcd=True)
         platform_val = chpl_platform.get()
         compiler_val = chpl_compiler.get('target')
-
-        # use muxed on cray-x* machines using the module and supported compiler
-        if (platform_val.startswith('cray-x') and
-                utils.using_chapel_module() and
-                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel')):
-            tasks_val = 'muxed'
-        elif (arch_val == 'knc' or
+        if (arch_val == 'knc' or
                 platform_val.startswith('cygwin') or
                 platform_val.startswith('netbsd') or
                 compiler_val == 'cray-prgenv-cray'):

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -16,8 +16,7 @@ def get():
         # use muxed on cray-x* machines using the module and supported compiler
         if (platform_val.startswith('cray-x') and
                 utils.using_chapel_module() and
-                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel') and
-                arch_val != 'knc'):
+                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel')):
             tasks_val = 'muxed'
         elif (arch_val == 'knc' or
                 platform_val.startswith('cygwin') or


### PR DESCRIPTION
Many configurations that ran on XC and XE last night chose muxed as
their tasking layer, incorrectly. Revert this change until a better solution
is implemented.

The core issue is muxed tasking should only be chosen when ugni is
the comm layer. It is a little tricky to detect that, so I'm choosing to back
this out completely.