### PR TITLE
Update chpl_task to only default to muxed when ugni comm is used.

### DIFF
--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_platform, chpl_compiler
+import chpl_arch, chpl_platform, chpl_compiler, chpl_comm
 from utils import memoize
 import utils
 
@@ -12,9 +12,11 @@ def get():
         arch_val = chpl_arch.get('target', get_lcd=True)
         platform_val = chpl_platform.get()
         compiler_val = chpl_compiler.get('target')
+        comm_val = chpl_comm.get()
 
         # use muxed on cray-x* machines using the module and supported compiler
-        if (platform_val.startswith('cray-x') and
+        if (comm_val == 'ugni' and
+                platform_val.startswith('cray-x') and
                 utils.using_chapel_module() and
                 compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel') and
                 arch_val != 'knc'):


### PR DESCRIPTION
This expands upon (and fixes) #1640 and #1635.

* [x] Run printchplenv on mac and confirm it still works.
* [x] Emulate cray-x* with module and confirm comm, tasks are ugni, muxed.

```bash
(
  export CHPL_MODULE_HOME=$CHPL_HOME
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-gnu
  printchplenv
)
```

* [x] Emulate cray-x* with module but not supported compiler and confirm comm, tasks are gasnet, default tasks.

```bash
(
  export CHPL_MODULE_HOME=$CHPL_HOME
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-cray
  printchplenv
)
```

* [x] Emulate cray-x* without module and confirm comm, tasks settings are gasnet, default tasks.

```bash
(
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-gnu
  printchplenv
)
```

* [x] Emulate cray-x* with module and intel compiler, but knc target arch and confirm comm, tasks are gasnet, default tasks.

```bash
(
  export CHPL_MODULE_HOME=$CHPL_HOME
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-intel
  export CRAY_CPU_TARGET=knc
  printchplenv
)
```

* [x] Emulate cray-x* with module, supported compiler, but none ugni comm and confirm tasks are default tasks.

```bash
(
  export CHPL_MODULE_HOME=$CHPL_HOME
  export CHPL_HOST_PLATFORM=cray-xc
  export CHPL_TARGET_COMPILER=cray-prgenv-gnu
  export CHPL_COMM=none
  printchplenv
)
```