### PR TITLE
Update README.chpldoc to better describe source code highlighting.

### DIFF
--- a/doc/release/technotes/README.chpldoc.rst
+++ b/doc/release/technotes/README.chpldoc.rst
@@ -328,7 +328,8 @@ single code block. For example::
       }
 
 If highlighting with the specified language fails, e.g. if the syntax is not
-parsable, the block is not highlighted in anyway.
+parsable, the block is not highlighted in anyway. Note that there should be a
+blank line betweent he ``code-block`` directive and the indented code snippet.
 
 
 Hyperlinks

--- a/doc/release/technotes/README.chpldoc.rst
+++ b/doc/release/technotes/README.chpldoc.rst
@@ -329,7 +329,7 @@ single code block. For example::
 
 If highlighting with the specified language fails, e.g. if the syntax is not
 parsable, the block is not highlighted in anyway. Note that there should be a
-blank line betweent he ``code-block`` directive and the indented code snippet.
+blank line between the ``code-block`` directive and the indented code snippet.
 
 
 Hyperlinks

--- a/doc/release/technotes/README.chpldoc.rst
+++ b/doc/release/technotes/README.chpldoc.rst
@@ -292,6 +292,44 @@ The handling of the ``::`` marker is smart:
 That way, the second sentence in the above example's first paragraph would be
 rendered as "The next paragraph is a code sample:".
 
+The highlight language is configured with the ``highlight`` directive. The
+configured language is used for all literal blocks until the next highlight
+directive. For example::
+
+   .. highlight:: chapel
+
+   Chapel code::
+
+      writeln("Hello from Chapel!");
+
+   More chapel::
+
+      x <=> y;
+
+   .. highlight:: c
+
+   ::
+
+      printf("Hello from C!\n");
+
+
+Showing code examples
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``code-block`` directive can be used to specify the highlight language of a
+single code block. For example::
+
+   .. code-block:: chapel
+
+      use Foo;
+
+      proc bar() {
+        writeln("Fooy!");
+      }
+
+If highlighting with the specified language fails, e.g. if the syntax is not
+parsable, the block is not highlighted in anyway.
+
 
 Hyperlinks
 ~~~~~~~~~~
@@ -347,24 +385,6 @@ You can indent text after a comment start to form multiline comments::
       is a comment.
 
       Still in the comment.
-
-
-Showing code examples
-~~~~~~~~~~~~~~~~~~~~~
-
-The ``code-block`` directive can be used to specify the highlight language of a
-single code block. For example::
-
-   .. code-block:: chapel
-
-      use Foo;
-
-      proc bar() {
-        writeln("Fooy!");
-      }
-
-If highlighting with the specified language fails, e.g. if the syntax is not
-parsable, the block is not highlighted in anyway.
 
 
 Inline markup


### PR DESCRIPTION
Move "Showing code examples" section right after "Source code" section. Update
"Source code" section with info about syntax highlighting literal code blocks.

This is the rendered form:

https://github.com/thomasvandoren/chapel/blob/massage-chpldoc-readme/doc/release/technotes/README.chpldoc.rst#source-code