### PR TITLE
Add sentence to reStructuredText primer about context.

### DIFF
--- a/doc/release/technotes/README.chpldoc.rst
+++ b/doc/release/technotes/README.chpldoc.rst
@@ -211,6 +211,9 @@ for more detail.
 * `Sphinx reST Primer`_
 * `Python reST Primer`_
 
+This primer is based on the information and text in the Sphinx and Python reST
+primers (some of the text is copied verbatim).
+
 The authoritative `reStructuredText User Guide`_ is also helpful.
 
 .. _Sphinx reST Primer: http://sphinx-doc.org/rest.html


### PR DESCRIPTION
The reStructuredText primer is largely based on the Sphinx and Python reST
primers, which also share a lot of information and text. The primer in
README.chpldoc.rst is catered to chpldoc use cases and therefore has a lot less
information. Some of the text in README.chpldoc.rst is the same as the Sphinx
and Python primers.