### PR TITLE
Update LICENSE for chpldoc-related information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -27,7 +27,20 @@ The Chapel implementation is composed of two categories of code:
      vim              vim-based syntax coloring                    VIM
 
    third-party/
-     chpldoc-venv     python packages supporting chpldoc           see third-party/README
+     chpldoc-venv/    python packages supporting chpldoc
+       Sphinx         Python documentation generator               BSD
+       sphinxcontrib-chapeldomain
+                      The Chapel language domain for Sphinx        Apache v2.0
+       sphinx_rtd_theme
+                      ReadTheDocs.org theme for Sphinx             MIT
+       Jinja2         A template engine written in Python          BSD
+       MarkupSafe     XML/HTML/XHTML Markup safe string impl.      BSD
+       Pygments       A syntax highlighting package                BSD
+       docutils       Python Documentation Utilities               public domain
+                                                                   Python
+                                                                   BSD
+                                                                   GPL 3
+
      dlmalloc         alternative memory allocator option          public domain
      dygraphs         Javascript graph generator and display       MIT
      gasnet           portable communication library               BSD-like
@@ -71,7 +84,7 @@ The Chapel implementation is composed of two categories of code:
      vim              only used if a user modifies their vim environment
 
    third-party/
-     chpldoc-venv     only used when running 'chpldoc'/'chpl --docs'
+     chpldoc-venv     only used when running 'chpldoc'
      dlmalloc         only used when CHPL_MEM is 'dlmalloc'
      dygraphs         only used to make and display performance graphs
      gasnet           only used when CHPL_COMM is 'gasnet'

--- a/LICENSE
+++ b/LICENSE
@@ -27,7 +27,7 @@ The Chapel implementation is composed of two categories of code:
      vim              vim-based syntax coloring                    VIM
 
    third-party/
-     chpldoc-venv/    python packages supporting chpldoc
+     chpldoc-venv    python packages supporting chpldoc
        Sphinx         Python documentation generator               BSD
        sphinxcontrib-chapeldomain
                       The Chapel language domain for Sphinx        Apache v2.0


### PR DESCRIPTION
In looking at the LICENSE file to make sure it was up to date, I figured it was
better to specify all the licenses of the packages required there, instead of
forcing curious parties to go all the way into the hierarchy (now they will only
do that if they are curious about a particular package).

I also removed a reference to chpl --docs, since we no longer support that
mode.