### PR TITLE
Couple of edits to the third-party README.

### DIFF
--- a/third-party/README
+++ b/third-party/README
@@ -10,9 +10,10 @@ Chapel itself.  Current subdirectories include:
 chpldoc-venv/
 
   Summary: Directory where several python packages are downloaded and installed
-           when running 'make chpldoc-venv' in the third-party directory. See
-           requirements.txt and virtualenv.txt files for a complete list of
-           packages that are installed.
+           when running 'make chpldoc-venv' in the third-party directory, or
+           when running 'make chpldoc' in $CHPL_HOME. See requirements.txt and
+           virtualenv.txt files for a complete list of packages that are
+           installed.
 
   License: Varies, see chpldoc-venv/README.md
 
@@ -57,7 +58,7 @@ gasnet/
 gmp/
   Summary: the GNU Multiple Precision Arithmetic Library
 
-  License: L-GPL (see gmp/gmp-*/COPYING and gmp/gmp-*/COPYING.LIB)
+  License: L-GPL (see gmp/gmp-*/COPYING and gmp/gmp-*/COPYING.LESSERv3)
 
   Website: http://gmplib.org
 


### PR DESCRIPTION
Update third-party general README entry for chpldoc-venv to mention that the
packages are also downloaded and built when 'make chpldoc' is run.  Also,
updated the pointer for GMP's license files to reference COPYING.LESSERv3
instead of COPYING.LIB.  At some point between GMP 5 and 6 this was moved, but
we missed that and so were referencing a file that did not exist.

Note: This does not update any specific third-party READMEs.  In particular, our
GASNet and llvm READMEs are a little out of date.