### PR TITLE
Forgot to update the release README when removing README.fileUtil

### DIFF
--- a/doc/release/README
+++ b/doc/release/README
@@ -40,7 +40,6 @@ This directory contains the following documentation:
     README.curl             :  information about curl and Chapel
     README.dsi              :  requirements/guidelines on writing a domain map
     README.extern           :  calling external C routines
-    README.fileUtil         :  information about new file capabilities
     README.firstClassFns    :  first-class functions
     README.format           :  value-to-string formatting
     README.formattedIO      :  readf()/writef() and formatting strings


### PR DESCRIPTION
This README keeps track of all the READMEs in the directory hierarchy beneath
it.