### PR TITLE
skip prefetch C test on any 32-bit platform

### DIFF
--- a/test/modules/standard/Prefetch/prefetch.skipif
+++ b/test/modules/standard/Prefetch/prefetch.skipif
@@ -5,4 +5,4 @@
 # In fact, this test works for me on 32-bit linux if CHPL_TARGET_ARCH=native
 # is set before testing begins...
 # For now though, we just skip this test on 32-bit systems.
-CHPL_TARGET_PLATFORM == linux32
+CHPL_TARGET_PLATFORM <= 32


### PR DESCRIPTION
Vass pointed out that cygwin32 was also failing, so I
modified the skipif to just look for 32 in CHPL_TARGET_PLATFORM.

I verified it still skips correctly on 32-bit linux.