### PR TITLE
Chpldoc startInitCommDiags.chpl and stopInitCommDiags.chpl.

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -75,6 +75,8 @@ MODULES_TO_DOCUMENT = \
 	standard/Regexp.chpl \
 	standard/Search.chpl \
 	standard/Sort.chpl \
+	standard/startInitCommDiags.chpl \
+	standard/stopInitCommDiags.chpl \
 	standard/Sys.chpl \
 	$(SYS_CTYPES_MODULE_DOC)
 

--- a/modules/standard/startInitCommDiags.chpl
+++ b/modules/standard/startInitCommDiags.chpl
@@ -19,8 +19,57 @@
 
 pragma "no use ChapelStandard"
 
+/*
+  This module defines config params that allow observing inter-locale
+  communication during module initialization and teardown.
+
+  It is hard for a programmer to determine exactly what happens during
+  initialization or teardown of a module, because the code that runs
+  then does so implicitly, as a result of the declarations present.
+  And even if that code can be identified, doing debug output or
+  logging data for later reporting might not work because the Chapel
+  capabilities needed to do so could be unavailable due to being
+  implemented by built-in modules which themselves are not yet
+  initialized, or have already been torn down.
+
+  This module is designed to help with that problem, by providing
+  built-in support for doing on-the-fly reporting and/or background
+  counting of inter-locale communication operations during module
+  initialization and teardown.  To use it, set either or both of the
+  config params below using appropriate ``-sconfigParamName=value``
+  command line options when you compile your program.
+
+  The reporting and/or counting enabled by this module covers all of
+  program execution, from just before the first module is initialized
+  until just after the last one is torn down.  This is almost always a
+  superset of the part of the program that is of interest, which is
+  often just a single module.  To learn what communication is being
+  done by a single module during its initialization and teardown it is
+  usually necessary to run a small test program twice, once with the
+  module present and once without it.
+
+  Do not ``use`` this module.  It is already included in every program
+  automatically.  Using compiler command line options to set the
+  config params it provides is the only way to interact with it.
+ */
 module startInitCommDiags {
+  /*
+    If this is set, on-the-fly reporting of communication operations
+    will be turned on before any module initialization begins and
+    turned off after all module teardown ends.  See module
+    :mod:`CommDiagnostics` and its procedures :proc:`startVerboseComm`
+    and :proc:`stopVerboseComm` for more information.
+   */
   config param printInitVerboseComm = false;
+
+  /*
+    If this is set, communication operations are counted from before
+    any module initialization begins until after all module teardown
+    ends, and then the aggregate counts are printed.  See module
+    :mod:`CommDiagnostics` and its procedures
+    :proc:`startCommDiagnostics`, :proc:`stopCommDiagnostics`, and
+    :proc:`getCommDiagnostics` for more information.
+   */
   config param printInitCommCounts = false;
 
   if printInitVerboseComm {

--- a/modules/standard/startInitCommDiags.chpl
+++ b/modules/standard/startInitCommDiags.chpl
@@ -48,9 +48,10 @@ pragma "no use ChapelStandard"
   usually necessary to run a small test program twice, once with the
   module present and once without it.
 
-  Do not ``use`` this module.  It is already included in every program
-  automatically.  Using compiler command line options to set the
-  config params it provides is the only way to interact with it.
+  *Note:* It is not necessary to ``use`` this module.  It is included
+  in every program automatically.  Using compiler command line options
+  to set the config params it provides is the only way to interact
+  with it.
  */
 module startInitCommDiags {
   /*

--- a/modules/standard/stopInitCommDiags.chpl
+++ b/modules/standard/stopInitCommDiags.chpl
@@ -20,9 +20,10 @@
 pragma "no use ChapelStandard"
 
 /*
-  This is a companion module to :mod:`startInitCommDiags` and has no
-  interface of its own.  Do not ``use`` this.  See the documentation
-  for :mod:`startInitCommDiags` for more information.
+  This is a companion to module :mod:`startInitCommDiags` and has no
+  interface of its own.  There is no benefit to naming it in a ``use``
+  statement.  See the documentation for :mod:`startInitCommDiags` for
+  more information.
  */
 module stopInitCommDiags {
   use startInitCommDiags;

--- a/modules/standard/stopInitCommDiags.chpl
+++ b/modules/standard/stopInitCommDiags.chpl
@@ -19,6 +19,11 @@
 
 pragma "no use ChapelStandard"
 
+/*
+  This is a companion module to :mod:`startInitCommDiags` and has no
+  interface of its own.  Do not ``use`` this.  See the documentation
+  for :mod:`startInitCommDiags` for more information.
+ */
 module stopInitCommDiags {
   use startInitCommDiags;
 


### PR DESCRIPTION
These should be moved into modules/internal, it seems to me, but now is
not the time for that.  I've made a note to myself to pursue that after
the release is done.