### PR TITLE
Added chpldocs for UtilMath module.

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -78,6 +78,7 @@ MODULES_TO_DOCUMENT = \
 	standard/Sort.chpl \
 	standard/Sys.chpl \
 	standard/Types.chpl \
+	standard/UtilMath.chpl \
 	$(SYS_CTYPES_MODULE_DOC)
 
 documentation: $(SYS_CTYPES_MODULE_DOC)

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -56,6 +56,7 @@ $(SYS_CTYPES_MODULE_DOC): $(MAKE_SYS_BASIC_TYPES)
 
 
 MODULES_TO_DOCUMENT = \
+	standard/AdvancedIters.chpl \
 	standard/BitOps.chpl \
 	standard/Buffers.chpl \
 	standard/CommDiagnostics.chpl \
@@ -76,9 +77,12 @@ MODULES_TO_DOCUMENT = \
 	standard/Regexp.chpl \
 	standard/Search.chpl \
 	standard/Sort.chpl \
+	standard/startInitCommDiags.chpl \
+	standard/stopInitCommDiags.chpl \
 	standard/Sys.chpl \
 	standard/Types.chpl \
 	standard/UtilMath.chpl \
+	standard/UtilReplicatedVar.chpl \
 	$(SYS_CTYPES_MODULE_DOC)
 
 documentation: $(SYS_CTYPES_MODULE_DOC)

--- a/modules/standard/UtilMath.chpl
+++ b/modules/standard/UtilMath.chpl
@@ -18,7 +18,9 @@
  */
 
 /*
-Various math-related utilities.
+Math-related utilities.
+
+Note: this module will be merged into :mod:`Math` in the next release.
 */
 module UtilMath {
 

--- a/modules/standard/UtilMath.chpl
+++ b/modules/standard/UtilMath.chpl
@@ -17,18 +17,31 @@
  * limitations under the License.
  */
 
-// UtilMath: various math-related utilities that could come handy.
+/*
+Various math-related utilities.
+*/
+module UtilMath {
 
-// for correctness, both arguments must be strictly positive
+/*
+A variant of :proc:`~Math.divceil` that performs no runtime checks.
+The user must ensure that both arguments are strictly positive
+(not 0) and are of a signed integer type (not `uint`).
+*/
 proc divceilpos(m: integral, n: integral) {
   if !isIntType(m.type) || !isIntType(n.type) then
     compilerError("divceilpos() accepts only arguments of signed integer types");
   return (m - 1) / n + 1;
 }
 
-// for correctness, both arguments must be strictly positive
+/*
+A variant of :proc:`~Math.divfloor` that performs no runtime checks.
+The user must ensure that both arguments are strictly positive
+(not 0) and are of a signed integer type (not `uint`).
+*/
 proc divfloorpos(m: integral, n: integral) {
   if !isIntType(m.type) || !isIntType(n.type) then
     compilerError("divfloorpos() accepts only arguments of signed integer types");
   return m / n;
+}
+
 }


### PR DESCRIPTION
I chose not to repeat the definitions of divceil and divfloor in this module.
I added cross-references to those functions in Math module instead.

I suggest in the future to move the contents of UtilMath into Math
and remove UtilMath altogether.
