### PR TITLE
Support testing fftw on whitebox systems.

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -129,6 +129,9 @@ if [ "${my_arch}" = "none" ] ; then
     module load craype-shanghai
 fi
 
+log_info "Loading fftw module."
+module load fftw
+
 log_info "Current loaded modules:"
 module list
 


### PR DESCRIPTION
Load the fftw module on the whiteboxes. This will allow the FFTW tests
to run for whitebox testing. This was enabled for the Cray HW testing
last week and seems to be working.