### PR TITLE
Fix intel performance failure with original chameneos

### DIFF
--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
@@ -48,10 +48,30 @@ class MeetingPlace {
    if this and the other color are of the same value, return own value
    otherwise return the color that is neither this or the other color */
 proc getComplement(myColor : Color, otherColor : Color) {
-  if (myColor == otherColor) {
-    return myColor;
+  select myColor {
+    when otherColor do return myColor;
+    when Color.blue {
+      if (otherColor == Color.red) then return Color.yellow;
+      else
+        // otherColor == Color.yellow, because first when statement
+        // eliminates Color.blue
+        return Color.red;
+    }
+    when Color.red {
+      if (otherColor == Color.blue) then return Color.yellow;
+      else
+        // otherColor == Color.yellow, because first when statement
+        // eliminates Color.red
+        return Color.blue;
+    }
+    otherwise {
+      if (otherColor == Color.blue) then return Color.red;
+      else
+        // otherColor == Color.red, because first when statement
+        // eliminates Color.yellow
+        return Color.blue;
+    }
   }
-  return (3 - myColor - otherColor) : Color;
 }
 
 class Chameneos {


### PR DESCRIPTION
During performance runs with the intel compiler, we discovered that the original
chameneos shootout implementation was failing to get the correct number of
meetings.  In investigating, this seemed to be triggered by using casts and
arithmetic on the Color enum to determine the complement, instead of using a
select/if statement as required by the benchmark.  Because we had updated all
the other implementations to use the select statement, none of them showed
this problem.

It's possible that messing up the color to store caused overlap to the meetings
for the individual chameneos, as the two fields are right next to each other,
though that would depend on the endianness of the system for why it was only a
small number of mistakes instead of orders of magnitude off . . .

The right solution for the benchmark itself is to update to use the select
statement.  It may be worth investigating if something strange and mysterious is
happening to cause enums values to appear that shouldn't by the laws of
reasonable arithmetic . . .