### PR TITLE
Update hwloc notes in README.chplenv

### DIFF
--- a/doc/release/README.chplenv
+++ b/doc/release/README.chplenv
@@ -356,17 +356,20 @@ Optional Settings
 
 *  Optionally, the CHPL_HWLOC environment variable can select between
    no hwloc support or using the hwloc package distributed with Chapel
-   in third-party.  Current options are:
+   in third-party.  Note that hwloc is only used by the qthreads
+   tasking layer, and does not need to be built for other tasking
+   layers.  Current options are:
 
        none   : do not build hwloc support into the Chapel runtime
        hwloc  : use the hwloc distribution bundled with Chapel in
                 third-party
 
    If unset, CHPL_HWLOC defaults to "hwloc" if CHPL_TASKS is qthreads,
-   unless the target platform is knc.  In all other cases it defaults to
-   "none".  Note that the bundled hwloc distribution will not build on
-   some targets (Mac, for example), but the CHPL_HWLOC default does not
-   reflect that.
+   unless the target platform is knc.  In all other cases it defaults
+   to "none".  If the bundled hwloc distribution does not build
+   successfully, it should still be possible to use qthreads so long
+   as CHPL_LOCALE_MODEL is flat.  Manually set CHPL_HWLOC to "none" and
+   rebuild in this case (and please file a bug with the Chapel team.)
 
 
 *  Optionally, the CHPL_REGEXP environment variable can be used to

--- a/doc/release/README.chplenv
+++ b/doc/release/README.chplenv
@@ -364,12 +364,14 @@ Optional Settings
        hwloc  : use the hwloc distribution bundled with Chapel in
                 third-party
 
-   If unset, CHPL_HWLOC defaults to "hwloc" if CHPL_TASKS is qthreads,
-   unless the target platform is knc.  In all other cases it defaults
-   to "none".  If the bundled hwloc distribution does not build
-   successfully, it should still be possible to use qthreads so long
-   as CHPL_LOCALE_MODEL is flat.  Manually set CHPL_HWLOC to "none" and
-   rebuild in this case (and please file a bug with the Chapel team.)
+   If unset, CHPL_HWLOC defaults to "hwloc" if CHPL_TASKS is "qthreads",
+   unless the target platform is knc.  In all other cases it defaults to
+   "none".  If the bundled hwloc distribution does not build
+   successfully, it should still be possible to use qthreads.  Manually
+   set CHPL_HWLOC to "none" and rebuild in this case (and please file a
+   bug with the Chapel team.)  Building without hwloc should not have a
+   drastic impact on performance when CHPL_LOCALE_MODEL is "flat", but
+   will drastically hurt performance for "numa".
 
 
 *  Optionally, the CHPL_REGEXP environment variable can be used to

--- a/doc/release/README.chplenv
+++ b/doc/release/README.chplenv
@@ -366,12 +366,12 @@ Optional Settings
 
    If unset, CHPL_HWLOC defaults to "hwloc" if CHPL_TASKS is "qthreads",
    unless the target platform is knc.  In all other cases it defaults to
-   "none".  If the bundled hwloc distribution does not build
-   successfully, it should still be possible to use qthreads.  Manually
-   set CHPL_HWLOC to "none" and rebuild in this case (and please file a
-   bug with the Chapel team.)  Building without hwloc should not have a
-   drastic impact on performance when CHPL_LOCALE_MODEL is "flat", but
-   will drastically hurt performance for "numa".
+   "none".  In the unlikely event the bundled hwloc distribution does
+   not build successfully, it should still be possible to use qthreads.
+   Manually set CHPL_HWLOC to "none" and rebuild in this case (and
+   please file a bug with the Chapel team.)  Building without hwloc
+   should not have a large performance impact when CHPL_LOCALE_MODEL
+   is "flat" but will drastically hurt performance for "numa".
 
 
 *  Optionally, the CHPL_REGEXP environment variable can be used to


### PR DESCRIPTION
Remove note saying that hwloc doesn't build on mac.

Add first draft of some new wording to indicate when hwloc is actually needed
(only for qthreads) and that if it doesn't build cleanly you should still be
able to run if you manually set it to "none" and rebuild, at least when you're
using flat. It *might* work for numa as well, but qthreads is really hampered
in what information it can get so it doesn't seem worthwhile to recommend.