### PR TITLE
Update chpl_launchcmd.py to work from nfs mounted lustre FS.

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -115,6 +115,17 @@ class AbstractJob(object):
         :returns: command to run in qsub with changedir call
         """
         full_test_command = ['cd', '$PBS_O_WORKDIR', '&&']
+
+        # If the first argument of the test command is a file (it should
+        # always be the executable), then add a "test -f ./execname" call
+        # before running the command. This works around some potential nfs
+        # configuration issues that can happen when running from lustre
+        # mounted over nfs.
+        if os.path.exists(self.test_command[0]):
+            logging.debug('Adding "test -f {0}" to launcher command.'.format(
+                self.test_command[0]))
+            full_test_command += ['test', '-f', self.test_command[0], '&&']
+
         full_test_command.extend(self.test_command)
         return full_test_command
 


### PR DESCRIPTION
Previously, some nfs configuration issues were causing lots of failures with
XE testing when the launcher tried to access the executable. The specific
errors were "Text file busy", and this seemed to indicate that the file had
not been synchronized back to the lustre file system. Essentially, the file
was created successfully on the system with lustre mounted over nfs, but it
had not propagated back to the original lustre FS (as least not fully) before
qsub was trying to run ./execname.

It turns out, adding a simple "test -f ./execname" call before trying to run
./execname "fixes" or "works around" the issue. Update chpl_launchcmd.py to
include this check for all launchers.