### PR TITLE
Update sphinx project to support CHPLDOC_AUTHOR env var as author.

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -86,6 +86,7 @@ MODULES_TO_DOCUMENT = \
 	$(SYS_CTYPES_MODULE_DOC)
 
 documentation: $(SYS_CTYPES_MODULE_DOC)
+	export CHPLDOC_AUTHOR='Cray Inc' && \
 	$(CHPLDOC) $(MODULES_TO_DOCUMENT)
 
 clean-documentation:

--- a/third-party/chpldoc-venv/chpldoc-sphinx-project/source/conf.py
+++ b/third-party/chpldoc-venv/chpldoc-sphinx-project/source/conf.py
@@ -49,7 +49,10 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'chpldoc'
-copyright = u'2015, AUTHOR TEXT'
+
+author_text = os.environ.get('CHPLDOC_AUTHOR', 'AUTHOR TEXT')
+
+copyright = u'2015, {0}'.format(author_text)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -205,7 +208,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
   ('index', 'chpldoc.tex', u'chpldoc Documentation',
-   u'AUTHOR TEXT', 'manual'),
+   author_text, 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -235,7 +238,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'chpldoc', u'chpldoc Documentation',
-     [u'AUTHOR TEXT'], 1)
+     [author_text], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -249,7 +252,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'chpldoc', u'chpldoc Documentation',
-   u'AUTHOR TEXT', 'chpldoc', 'One line description of project.',
+   author_text, 'chpldoc', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/third-party/chpldoc-venv/chpldoc-sphinx-project/source/index.rst
+++ b/third-party/chpldoc-venv/chpldoc-sphinx-project/source/index.rst
@@ -9,7 +9,7 @@ Contents:
    self
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    modules/**


### PR DESCRIPTION
Previously, the literal string "AUTHOR TEXT" was used as the author in the HTML
(et al) output. There is work to make this more accessible via command line
flag and env var, but that will be committed for the next release. It seems
necessary to provide some way to change this value for the current, 1.11,
release.

Update the sphinx project conf.py to look for the author string in the
CHPLDOC_AUTHOR environment variable. If it is not set default to the literal
string "AUTHOR TEXT" as before.

Set "Cray Inc" as the author for the module documentation. In the copyright
on all pages, this shows up as "(c) Copyright 2015, Cray Inc.", which is inline
with other copyrights in the repo.

Also, update the index.rst page to only include the titles for the modules.
Previously the first level subtitles were also included, which is not very helpful
and makes the TOC harder to use.

### Verification:

* [x] build `make module-docs` and verify the copyright and index page menu look correct