### PR TITLE
Don't show stopInitCommDiags in chpldocs.

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -78,7 +78,6 @@ MODULES_TO_DOCUMENT = \
 	standard/Search.chpl \
 	standard/Sort.chpl \
 	standard/startInitCommDiags.chpl \
-	standard/stopInitCommDiags.chpl \
 	standard/Sys.chpl \
 	standard/Types.chpl \
 	standard/UtilMath.chpl \


### PR DESCRIPTION
Given that stopInitCommDiags module has nothing in its interface,
and that it is not useful to 'use' it,
we want to spare the users the trouble to read its chpldoc.

If a user stumbles over it, there are comments in the module itself
to explain what's going on.
