### PR TITLE
Add support for google analytics and default to sticky nav.

### DIFF
--- a/third-party/chpldoc-venv/chpldoc-sphinx-project/source/_templates/page.html
+++ b/third-party/chpldoc-venv/chpldoc-sphinx-project/source/_templates/page.html
@@ -1,0 +1,16 @@
+{% extends "!page.html" %}
+{% block footer %}
+{{ super() }}
+{% if theme_analytics_id %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ theme_analytics_id }}', 'auto');
+  ga('send', 'pageview');
+
+</script>
+{% endif %}
+{% endblock %}

--- a/third-party/chpldoc-venv/chpldoc-sphinx-project/source/conf.py
+++ b/third-party/chpldoc-venv/chpldoc-sphinx-project/source/conf.py
@@ -111,6 +111,15 @@ if not on_rtd:
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
+    html_theme_options = {
+        'sticky_navigation': True,
+    }
+
+    analytics_id = os.environ.get('CHPLDOC_ANALYTICS_ID')
+    if analytics_id:
+        html_theme_options['analytics_id'] = analytics_id
+
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.


### PR DESCRIPTION
Update sphinx project to enable sticky navigation. It will only really be
enabled if the window height is greater than the nav bar height.

Also add support for using google analytics by setting CHPLDOC_ANALYTICS_ID to
the `UA-...` value. This requires injecting the GA snippet into the page.html
template.

### Verification:

* [x] build with `( export CHPLDOC_ANALYTICS_ID='UA-123123123-1' && make module-docs-only  )` and verify GA script snippet is at the bottom of the index.html source.
* [x] build with `make module-docs-only` and verify GA script snippet *is not* at the bottom of index.html source.
* [x] view a page in a browser window that is taller than the nav bar and verify the left nav menu does not move when scrolling through the page content. (Using the browser to zoom to 50% size and viewing the GMP module, worked for Thomas.)