### PR TITLE
Enabled more task/forall intents in the spec

### DIFF
--- a/doc/release/technotes/README.reduceIntents
+++ b/doc/release/technotes/README.reduceIntents
@@ -93,8 +93,17 @@ Open Issues
    var global = 0;
    forall i in iterx() with (+ reduce global) do
      forall j in itery() with (+ reduce global) do
-        global += kernel(i, j);
+        global += kernel(i,j);
    writeln("result = ", global);
+
+  The current implementation would exclude, from the final result,
+  the values of kernel(i,j) for most i. Indeed, assume that each task
+  of the outer forall executes several inner forall loops.
+  The reduction result of the inner loop will be stored into
+  the outer task's 'global' formal. Since the value of that formal
+  is discarded when entering the inner loop, only the result
+  from the last inner loop within the outer task will be retained
+  and reduced into the outer 'global'.
 
 
 -----------

--- a/doc/release/technotes/README.reduceIntents
+++ b/doc/release/technotes/README.reduceIntents
@@ -1,0 +1,111 @@
+==============
+Reduce Intents
+==============
+
+Note: this is work in progress and is subject to change.
+
+--------
+Overview
+--------
+
+Reduce intents are a kind of forall intent - see Section 25.3
+"Forall Intents" of the Chapel Language Specification.
+
+As with any forall intent, a reduce intent can be specified on any
+"outer variable" - that is, a variable used within the body of a
+forall loop and declared outside that loop.  References to such a
+variable within the loop implicitly refer to the corresponding formal
+argument of the task function or the leader iterator.
+
+Reduce intents are distinct:
+
+* Each task formal that corresponds to an outer variable with a reduce
+  intent is initialized, at the beginning of its task, to the identity
+  value for the corresponding reduction.
+
+* The value of the outer variable immediately after the forall loop is a
+  reduction of the values of the corresponding formals at the end of
+  their tasks.
+
+Note that the value of the outer variable immediately before the forall loop
+is discarded.
+
+
+------
+Syntax
+------
+
+The syntax of "task-intent-list" is extended to allow "reduce-intent":
+
+task-intent-list:
+  // no change with these
+  formal-intent identifier
+  formal-intent identifier, task-intent-list
+  // added for reduce intents:
+  reduce-intent
+  reduce-intent, task-intent-list
+
+reduce-intent:
+  reduce-operator 'reduce' identifier
+
+reduce-operator: one of
+   // these have the same meaning as in a reduction expression
+   +  *  &&  ||  &  |  ^
+
+
+--------
+Examples
+--------
+
+  // increment x in the loop
+  var x = 5;
+  forall myIterator() with (+ reduce x) {
+    x += 1;
+  }
+  writeln("The number of loop iterations is: ", x);
+
+  // set x in the loop
+  var x = 5;
+  forall myIterator() with (+ reduce x) {
+    x = 1;
+  }
+  writeln("The number of tasks is: ", x);
+
+
+-----------
+Open Issues
+-----------
+
+* Should reduction occur at task granularity or at
+  loop-iteration granularity?
+
+  The current implementation and the above examples provide the former.
+  Both above examples would report the number of iterations if the latter.
+
+* How to support reductions where the type of the result is different
+  from the type of the values being reduced, e.g. for a min-k reduction?
+
+* Should the initial value of the reduction variable participate
+  in the reduction as well?
+
+* How would we support reductions over nested forall loops, e.g.:
+
+   var global = 0;
+   forall i in iterx() with (+ reduce global) do
+     forall j in itery() with (+ reduce global) do
+        global += kernel(i, j);
+   writeln("result = ", global);
+
+
+-----------
+Future Work
+-----------
+
+* Provide reduce intents as task intents.
+
+* Provide the other predefined reduction operators as reduce intents:
+    min max minloc maxloc
+
+* Allow user-defined reductions as reduce intents.
+
+* Implement reduction expressions using forall loops and reduce intents.

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -258,9 +258,8 @@ affect the behavior of a task construct such as a \chpl{coforall} loop.
 \end{rationale}
 
 \begin{craychapel}
-% "A limited set of" ?
 An initial implementation of "reduce" intents is also available,
-which will let us implement reductions using forall intents.
+which permits users to reduce values across iterations of a forall loop.
 They are described in:
 \\ %formatting
 \mbox{$$ $$ $$} %indent

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -257,10 +257,15 @@ Forall intents affect those tasks in the same way that task intents
 affect the behavior of a task construct such as a \chpl{coforall} loop.
 \end{rationale}
 
-\begin{future}
-We would like to introduce "reduction" intents
-that will let us implement reductions using forall intents.
-\end{future}
+\begin{craychapel}
+% "A limited set of" ?
+An initial implementation of "reduce" intents is also available,
+which will let us implement reductions using forall intents.
+They are described in:
+\\ %formatting
+\mbox{$$ $$ $$} %indent
+\chpl{doc/technotes/README.reduceIntents}
+\end{craychapel}
 
 
 \section{Promotion}

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -262,11 +262,6 @@ We would like to introduce "reduction" intents
 that will let us implement reductions using forall intents.
 \end{future}
 
-\begin{future}
-As with task intents, we may want to disallow some intents,
-for example \chpl{inout} and \chpl{out}.
-\end{future}
-
 
 \section{Promotion}
 \label{Promotion}

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -836,6 +836,10 @@ task-intent-list:
   formal-intent identifier, task-intent-list
 \end{syntax}
 
+where the following intents can be used as a \sntx{formal-intent}:
+the blank intent, \chpl{ref}, \chpl{const ref}, \chpl{const},
+\chpl{const in}, \chpl{in}.
+
 The implicit treatment of outer scope variables as the task function's
 formal arguments applies to both module level and local variables.
 It applies to variable references within the lexical scope
@@ -906,25 +910,18 @@ intents can be obtained by examining just the lexical scope of the
 task construct. In general, the set of closure variables can be hard
 to determine, unweildy to implement and reason about, it is unclear
 what to do with extern functions, etc.
-\end{rationale}
 
+We do not provide \chpl{inout} or \chpl{out} as task intents because they
+will necessarily create a data race in a \chpl{cobegin} or \chpl{coforall}.
+\chpl{type} and \chpl{param} intents are not available either
+as they do not seem useful as task intents.
+\end{rationale}
 
 \begin{future}
 For a given intent, we would also like to provide a blanket clause,
 which would apply the intent to all variables.
 An example of syntax for a blanket \chpl{ref} intent would be \chpl{ref *}.
 \end{future}
-
-\begin{future}
-We may want to disallow some intents because they do not make sense
-in this context. For example, an \chpl{inout} or \chpl{out} intent
-will necessarily create a data race in a \chpl{cobegin} or \chpl{coforall}.
-Also, \chpl{type} and \chpl{param} intents do not seem useful.
-\end{future}
-
-\begin{craychapel}
-At present, only the \chpl{ref} task intent is implemented.
-\end{craychapel}
 
 
 \section{The Sync Statement}

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -837,8 +837,15 @@ task-intent-list:
 \end{syntax}
 
 where the following intents can be used as a \sntx{formal-intent}:
-the blank intent, \chpl{ref}, \chpl{const ref}, \chpl{const},
-\chpl{const in}, \chpl{in}.
+\chpl{ref}, \chpl{in}, \chpl{const}, \chpl{const in}, \chpl{const ref}.
+
+% TODO for task intents:
+% * Introduce a 'task-formal-intent' syntactic rule
+%   that expands to the legal intents - far preferable than
+%   qualifying which intents are legal in the text of this paragraph.
+% * That's assuming we do not support 'out' and 'inout',
+%   which is still up for debate; otherwise leave as-is.
+% * Do we want to allow blank intents? Current implementation allows them.
 
 The implicit treatment of outer scope variables as the task function's
 formal arguments applies to both module level and local variables.
@@ -913,6 +920,7 @@ what to do with extern functions, etc.
 
 We do not provide \chpl{inout} or \chpl{out} as task intents because they
 will necessarily create a data race in a \chpl{cobegin} or \chpl{coforall}.
+% that does not necessarily apply to a 'begin'
 \chpl{type} and \chpl{param} intents are not available either
 as they do not seem useful as task intents.
 \end{rationale}


### PR DESCRIPTION
With these changes, the spec says:

* Here are the intents available for task intents: .....

* Here is the rationale why we do not provide the other intents
as task intents: ...

* For forall intents, I removed "future work" on disallowing certain
forall intents. As a result, forall intents redirect to task intents
without any reservations.

* Reduce intents are now a reference to README.reduceIntents
instead of future work. They are mentioned only for forall intents.
I suggest that for now the spec will say nothing about
reduce intents for tasks.
