### PR TITLE
Added missing tests to READMEs/Makefiles

### DIFF
--- a/test/release/examples/README.features
+++ b/test/release/examples/README.features
@@ -35,8 +35,10 @@ benchmarks/
     fannkuchredux     : arrays
     mandelbrot        : uints; multidimensional arrays; bit ops; binary output
     meteor            : coforall loops; forall loops; recursion
+    meteor-fast       : less readable, much faster version of meteor
     nbody             : tuples; records; inlined functions
     pidigits          : GMP; iterators
+    regexdna          : strings, regular expressions
     spectralnorm      : reductions; domains; arrays
     threadring        : syncs; coforall loops
   ssca2/       : graph algorithms, generic programming, distributed
@@ -47,10 +49,11 @@ primers/
   arrayVectorOps : vector-like operations on rectangular arrays
   associative    : associative domains and arrays; set operations
   atomics        : atomic variables and operations on them
-  chpldoc        : the comment-based documentation generation feature
+  chpldoc.doc    : the comment-based documentation generation feature
   classes        : classes and objects; dynamic dispatch; 'this' and 'these'
   distributions  : distributions; Block; Cyclic; Block-Cyclic; Replicated
   domains        : domains and operations on domains
+  FFTWlib        : use of the standard module FFTW
   fileIO         : file I/O of scalars and arrays
   genericClasses : generic classes and objects; generic types
   iterators      : iterators of various styles

--- a/test/release/examples/benchmarks/Makefile
+++ b/test/release/examples/benchmarks/Makefile
@@ -24,7 +24,7 @@ miniMD: FORCE
 	cd miniMD && $(MAKE)
 
 shootout: FORCE
-	cd miniMD && $(MAKE)
+	cd shootout && $(MAKE)
 
 ssca2: FORCE
 	cd ssca2 && $(MAKE)

--- a/test/release/examples/benchmarks/hpcc/Makefile
+++ b/test/release/examples/benchmarks/hpcc/Makefile
@@ -7,6 +7,7 @@ TARGETS = \
 	stream \
 	stream-ep \
 	ra \
+	ra-atomics \
 	fft \
 	ptrans \
 	hpl \

--- a/test/release/examples/benchmarks/miniMD/README
+++ b/test/release/examples/benchmarks/miniMD/README
@@ -63,6 +63,7 @@ This directory's contents are as follows:
     forces.chpl         : implementations for EAM and LJ force computations
     thermo.chpl         : calculation of energy, temperature, pressure
     neighbor.chpl       : calculation and updating of neighbor atoms
+    StencilDist.chpl    : domain map used for stencil computations
   
   miniMD.*              : other files used in the Chapel testing system
 

--- a/test/release/examples/benchmarks/shootout/Makefile
+++ b/test/release/examples/benchmarks/shootout/Makefile
@@ -11,6 +11,7 @@ TARGETS = \
 	meteor-fast \
 	nbody \
 	pidigits \
+	regexdna \
 	spectralnorm \
 	threadring
 
@@ -46,6 +47,9 @@ nbody: nbody.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) --no-warnings $<
 
 pidigits: pidigits.chpl
+	$(CHPL) -o $@ $(CHPL_FLAGS) $<
+
+regexdna: regexdna.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) $<
 
 spectralnorm: spectralnorm.chpl

--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -20,6 +20,7 @@ At present, this directory contains the following codes:
     meteor-fast.chpl    : A less readable, but much faster version of meteor.
     nbody.chpl          : Performs an n-body simulation of the Jovian planets
     pidigits.chpl       : Computes digits of pi using GMP, if available
+    regexdna            : Performs DNA matching
     spectralnorm.chpl   : Calculates the spectral norm of an infinite matrix
     threadring.chpl     : Passes a token between a large number of threads
 
@@ -32,4 +33,4 @@ The provided Makefile can be used to compile the programs, or they can
 be run in correctness or performance modes using the Chapel testing
 system (see $CHPL_HOME/util/sub_test).
 
-Note that chameneosredux.chpl has non-deterministic output
+Note that chameneosredux.chpl has non-deterministic output.

--- a/test/release/examples/primers/Makefile
+++ b/test/release/examples/primers/Makefile
@@ -5,7 +5,7 @@ CHPL = chpl
 
 TARGETS = \
 	arrays \
-        arrayVectorOps \
+	arrayVectorOps \
 	associative \
 	atomics \
 	chpldoc.doc \
@@ -19,7 +19,7 @@ TARGETS = \
 	opaque \
 	parIters \
 	procedures \
-        randomNumbers \
+	randomNumbers \
 	ranges \
 	reductions \
 	slices \

--- a/test/release/examples/primers/README
+++ b/test/release/examples/primers/README
@@ -9,7 +9,7 @@ demonstrate Chapel feature areas in detail.
      arrayVectorOps.chpl    : Vector-like operations on 1D arrays
      associative.chpl       : Associative arrays/domains and set operations
      atomics.chpl           : Atomic variables
-     chpldoc.chpl           : The chpldoc feature
+     chpldoc.doc.chpl       : The chpldoc feature
      classes.chpl           : Defining and using classes
      distributions.chpl     : Chapel standard distributions
      domains.chpl           : Domains and methods on domains


### PR DESCRIPTION
... in test/release/examples

Please double-check me on the phrasing:

README.features:
* meteor-fast : less readable, much faster version of meteor
* regexdna : strings, regular expressions
* FFTWlib : use of the standard module FFTW

benchmarks/hpcc/Makefile:
* ra-atomics

benchmarks/miniMD/README
* StencilDist.chpl : domain map used for stencil computations

benchmarks/shootout/README
* regexdna : Performs DNA matching
