### PR TITLE
Refer to http://chapel.cray.com/docs/latest/... instead of .../master/.....

### DIFF
--- a/doc/release/technotes/README.auxIO
+++ b/doc/release/technotes/README.auxIO
@@ -71,8 +71,8 @@ I/O Systems Supported
 
 Currently, the I/O systems supported are:
  - Lustre
- - HDFS   (see http://chapel.cray.com/docs/master/modules/standard/HDFS.html)
- - Curl   (see http://chapel.cray.com/docs/master/modules/standard/Curl.html)
+ - HDFS   (see http://chapel.cray.com/docs/latest/modules/standard/HDFS.html)
+ - Curl   (see http://chapel.cray.com/docs/latest/modules/standard/Curl.html)
 
 
 Parallel and Distributed I/O Features

--- a/doc/release/technotes/README.local
+++ b/doc/release/technotes/README.local
@@ -31,7 +31,7 @@ execution.
 The 'local' construct does not necessarily indicate the cause of
 communication when present. See
 
-    http://chapel.cray.com/docs/master/modules/standard/CommDiagnostics.html
+    http://chapel.cray.com/docs/latest/modules/standard/CommDiagnostics.html
 
 for ways to diagnose communication.
 


### PR DESCRIPTION
....

With this change, the string "chapel.cray.com/docs/master" does not
occur anywhere in the repo.