### PR TITLE
Add ability to "capture" or get a screenshot of perf graphs

### DIFF
--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -1020,7 +1020,8 @@ def main():
 
     # Copy the index.html and support css and js files
     auxdir = os.path.dirname(os.path.realpath(__file__))+'/perf'
-    copiedAllFiles = True 
+    chpl_home = os.environ.get('CHPL_HOME', '')
+    copiedAllFiles = True
     try:
         shutil.copy(auxdir+'/index.html', outdir)
     except IOError:
@@ -1037,11 +1038,7 @@ def main():
         sys.stderr.write('WARNING: Could not copy perfgraph.js\n')
         copiedAllFiles = False
 
-    # TODO point these to the right location
-    dygraphDir = os.path.join(
-        os.environ.get('CHPL_HOME', ''),
-        'third-party',
-        'dygraphs')
+    dygraphDir = os.path.join(chpl_home, 'third-party', 'dygraphs')
     try:
         shutil.copy(os.path.join(dygraphDir, 'dygraph-combined.js'), outdir)
     except IOError:
@@ -1049,11 +1046,11 @@ def main():
         copiedAllFiles = False
 
     graphInfo.finish()
-    
+
     sys.stdout.write('Read %d graph files in %d suites\n'%(numGraphfiles, numSuites))
-   
-    if copiedAllFiles: 
-        with open(outdir + "/SUCCESS", 'w') as f: 
+
+    if copiedAllFiles:
+        with open(outdir + "/SUCCESS", 'w') as f:
             # do nothing, we just want to create the file so we know that no
             # errors that we currently detect occurred and all the requires
             # files were copied over. This is used to see if we should sync the

--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <!-- In order to support IE7 and IE8, we use excanvas, emulate certain IE
          versions, and use jquery version 1 instead of 2. Future versions of
          dygraphs will remove support for anything older than IE9, so we can
          remove that code, and use a newer jquery version. -->
-    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9">
+    <title>Chapel Performance Graphs</title>
     <link rel="stylesheet" href="perfgraph.css">
     <!--[if IE]>
         <script src="http://dygraphs.com/excanvas.js"></script>
         <![endif]-->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"</script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.min.js"></script>
     <script src="dygraph-combined.js"></script>
     <script src="graphdata.js"></script>
@@ -20,7 +21,7 @@
   <body onload="perfGraphInit()">
     <center><h2 id="titleElem"></h2></center>
     <center><h4 id="dateElem"></h4></center>
-    <script language="javascript" type="text/javascript" >
+    <script>
       <!-- hide
            function jumpto(x){
              if (document.form1.jumpmenu.value != "null") {
@@ -59,5 +60,4 @@
     <script src="perfgraph.js"></script>
   </body>
 </html>
-
 

--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -1,20 +1,32 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <!-- In order to support IE7 and IE8, we use excanvas, emulate certain IE
+         versions, and use jquery version 1 instead of 2. Future versions of
+         dygraphs will remove support for anything older than IE9, so we can
+         remove that code, and use a newer jquery version. -->
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9">
     <link rel="stylesheet" href="perfgraph.css">
     <!--[if IE]>
-        <script type="text/javascript"
-                src="http://dygraphs.com/excanvas.js"></script>
+        <script src="http://dygraphs.com/excanvas.js"></script>
         <![endif]-->
-    <script src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
-    <script type="text/javascript"
-      src="dygraph-combined.js"></script>
-    <!-- <script type="text/javascript"
-            src="http://dygraphs.com/dygraph-dev.js"></script>
-      -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"</script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.min.js"></script>
+    <script src="dygraph-combined.js"></script>
     <script src="graphdata.js"></script>
+
+      <!-- dev (non-minified versions)
+           TODO: when developing our perf graphs, I always use the non-minified
+           versions. I end up just changing them manually while developing, but
+           it be nice to be able to set some flag in the URL and conditionally
+           load these non-minified versions instead.) -->
+    <!--
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.js"</script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/1.1.0/dygraph-combined.js"></script>
+    -->
+
   </head>
   <body onload="perfGraphInit()">
     <center><h2 id="titleElem"></h2></center>

--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -16,17 +16,6 @@
     <script src="dygraph-combined.js"></script>
     <script src="graphdata.js"></script>
 
-      <!-- dev (non-minified versions)
-           TODO: when developing our perf graphs, I always use the non-minified
-           versions. I end up just changing them manually while developing, but
-           it be nice to be able to set some flag in the URL and conditionally
-           load these non-minified versions instead.) -->
-    <!--
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.js"</script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/1.1.0/dygraph-combined.js"></script>
-    -->
-
   </head>
   <body onload="perfGraphInit()">
     <center><h2 id="titleElem"></h2></center>

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -112,11 +112,20 @@ function getNextDivs(afterDiv, afterLDiv) {
   annToggle.style.visibility = 'hidden';
   gspacer.appendChild(annToggle);
 
+  // create a screenshot button and put it next to the annotation button
+  var screenshotToggle = document.createElement('input');
+  screenshotToggle.type = 'button';
+  screenshotToggle.className = 'toggle';
+  screenshotToggle.value = 'screenshot';
+  screenshotToggle.style.visibility = 'hidden';
+  gspacer.appendChild(screenshotToggle);
+
   return {
     div: div,
       ldiv: ldiv,
       logToggle: logToggle,
-      annToggle: annToggle
+      annToggle: annToggle,
+      screenshotToggle: screenshotToggle
   }
 }
 
@@ -129,6 +138,7 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
   var ldiv = graphDivs.ldiv;
   var logToggle = graphDivs.logToggle;
   var annToggle = graphDivs.annToggle;
+  var screenshotToggle = graphDivs.screenshotToggle;
 
   var startdate = getDateFromURL(OptionsEnum.STARTDATE, graphInfo.startdate);
   var enddate = getDateFromURL(OptionsEnum.ENDDATE, graphInfo.enddate);
@@ -212,6 +222,7 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
 
     setupLogToggle(g, graphInfo, logToggle);
     setupAnnToggle(g, graphInfo, annToggle);
+    setupScreenshotToggle(g, graphInfo, screenshotToggle);
 
     g.isReady = true;
 
@@ -302,6 +313,78 @@ function setupAnnToggle(g, graphInfo, annToggle) {
       g.setAnnotations([]);
     }
   }
+}
+
+
+// Setup the screenshot button
+function setupScreenshotToggle(g, graphInfo, screenshotToggle) {
+  screenshotToggle.style.visibility = 'visible';
+
+  screenshotToggle.onclick = function() {
+    captureScreenshot(g, graphInfo);
+  }
+}
+
+
+// Function to capture a screenshot of a graph and open the image in a new
+// window.
+//
+// TODO: A nicer alternative would be to open a new window, and have that
+// window create and render the screenshot and also have boxes to change the
+// size of the rendered image. Right now it just defaults to making an image
+// that is the same size as the actual graph.
+//
+// TODO: right now our graph and legend are in 2 separate divs so this is a
+// little clunky because it renders each div separately and then combines them
+// into a single canvas. It would be cleaner to have a div that wraps the graph
+// and legend and just render that one.
+function captureScreenshot(g, graphInfo) {
+
+  var gWidth = g.divs.div.clientWidth + g.divs.ldiv.clientWidth;
+  var gHeight = g.divs.div.clientHeight;
+
+  var captureCanvas = document.createElement('canvas');
+  captureCanvas.width = gWidth;
+  captureCanvas.height = gHeight;
+  var ctx = captureCanvas.getContext('2d');
+
+  // html2canvas doesn't render transformed ccs3 text (like our ylabel.) We
+  // make the label inivisible and we also hide the roll button box since
+  // theres no point in capturing it in a screenshot
+  g.updateOptions({showRoller: false, ylabel:''});
+  var label = graphInfo.ylabel;
+
+  // generate the graph
+  html2canvas(g.divs.div, {
+    // once the graph is rendered
+    onrendered: function(graphCanvas) {
+      // genenerate the legend
+       html2canvas(g.divs.ldiv, {
+        // once the legend is rendered
+        onrendered: function(legendCanvas) {
+          // draw the graph and legend canvas on a combined canvas.
+          ctx.drawImage(graphCanvas, 0, 0);
+          ctx.drawImage(legendCanvas, g.divs.div.clientWidth, 0);
+
+          // get the graphs ylabel font properties
+          var fontSize = g.getOption('axisLabelFontSize');
+          ctx.font = '16px Arial';
+
+          // rotate the canvas and draw the title
+          ctx.translate(0, gHeight/2);
+          ctx.rotate(-0.5*Math.PI);
+          ctx.textAlign = 'center';
+          ctx.fillText(label, 0, fontSize);
+
+          // open the screenshot in a new window
+          window.open(captureCanvas.toDataURL());
+
+          // restore the roll box and ylabel
+          g.updateOptions({showRoller: true, ylabel:label});
+        }
+      });
+    }
+  });
 }
 
 


### PR DESCRIPTION
We often grab screenshots of perf graphs to quickly share with others or to use
in ad-hoc presentations. I think most people just used whatever screenshot
tool they had available or crop the image afterwards, which is annoying and if
you have a bunch of graphs you want to display next to each others it's really
hard to crop them all in the same place so they look decent.

This adds a button below each graph to capture a screenshot of the graph and
legend. Because of browser security issues, it's not possible to directly
generate a screenshot so we use html2canvas (http://html2canvas.hertzen.com/)
and generate an image from the canvas it produces.

From html2canvas' website:
"
This script allows you to take "screenshots" of webpages or parts of it,
directly on the users browser. The screenshot is based on the DOM and as such
may not be 100% accurate to the real representation as it does not make an
actual screenshot, but builds the screenshot based on the information available
on the page.
"

This adds html2canvas to our third party directory, and adds some code in
perfgraph.js to capture and render the image.

Currently this opens up a new window and generates a static image that's the
same size as the original graph (and from there you can right click and save
image or whatever.) It would be nice to avoid opening up another window (since
most browsers block this behavior by default until you tell it to allow pop-ups
from our site.) It would also be nice if you could specify the width/height of
the image you want to generate so you don't have to scale the image after the
fact.