### PR TITLE
Make FFTW self-validating

### DIFF
--- a/test/release/examples/primers/FFTWlib.chpl
+++ b/test/release/examples/primers/FFTWlib.chpl
@@ -33,6 +33,19 @@
 use FFTW;
 
 //
+// print out the error values?  Note that values may differ between
+// platforms (so turn off for testing).
+//
+config const printErrors = true;
+
+//
+// If we don't print out error values, we'll print a success/failure
+// message.  This is the epsilon value against which success should
+// be measured.
+//
+config const epsilon = 10e-13;
+
+//
 // Perform the tests and then cleanup.
 //
 proc main() {
@@ -44,12 +57,10 @@ proc main() {
 // A helper function that invokes the test for each rank.
 //
 proc testAllDims() {
-  writeln("1D");
-  runtest(1, "arr1d.dat");
-  writeln("2D");
-  runtest(2, "arr2d.dat");
-  writeln("3D");
-  runtest(3, "arr3d.dat");
+  for param d in 1..3 {
+    writeln(d, "D");
+    runtest(d, "arr"+d+"d.dat");
+  }
 }
 
 //
@@ -336,5 +347,12 @@ proc runtest(param ndim : int, fn : string) {
 //
 proc printcmp(x, y) {
   var err = max reduce abs(x-y);
-  writeln(err);
+  if (printErrors) then
+    writeln(err);
+  else {
+    if err < epsilon then
+      writeln("SUCCESS: error below threshold");
+    else
+      writeln("FAILURE: error (", err, ") exceeds epsilon (", epsilon, ")");
+  }
 }

--- a/test/release/examples/primers/FFTWlib.execopts
+++ b/test/release/examples/primers/FFTWlib.execopts
@@ -1,0 +1,1 @@
+--printErrors=false

--- a/test/release/examples/primers/FFTWlib.good
+++ b/test/release/examples/primers/FFTWlib.good
@@ -1,42 +1,42 @@
 1D
 Data read...
-3.36014e-15
-3.47491e-16
-3.36014e-15
-3.47491e-16
-3.10862e-15
-3.33067e-16
-2.44249e-15
-2.22045e-15
-3.33067e-16
-2.44249e-15
-2.22045e-15
-3.33067e-16
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
 2D
 Data read...
-5.68434e-14
-4.76688e-16
-5.68434e-14
-4.76688e-16
-5.68434e-14
-5.55112e-16
-5.68434e-14
-1.42109e-14
-4.44089e-16
-5.68434e-14
-1.42109e-14
-4.44089e-16
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
 3D
 Data read...
-1.13687e-13
-3.88578e-16
-1.13687e-13
-3.88578e-16
-1.13687e-13
-4.44089e-16
-1.13687e-13
-2.04281e-14
-4.44089e-16
-1.13687e-13
-2.04281e-14
-4.44089e-16
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold

--- a/test/users/npadmana/fftw/testFFTW_MT.execopts
+++ b/test/users/npadmana/fftw/testFFTW_MT.execopts
@@ -1,0 +1,1 @@
+--printErrors=false

--- a/test/users/npadmana/fftw/testFFTW_MT.good
+++ b/test/users/npadmana/fftw/testFFTW_MT.good
@@ -1,42 +1,42 @@
 1D
 Data read...
-3.36014e-15
-3.47491e-16
-3.36014e-15
-3.47491e-16
-3.10862e-15
-3.33067e-16
-2.44249e-15
-2.22045e-15
-3.33067e-16
-2.44249e-15
-2.22045e-15
-3.33067e-16
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
 2D
 Data read...
-5.68434e-14
-4.76688e-16
-5.68434e-14
-4.76688e-16
-5.68434e-14
-5.55112e-16
-5.68434e-14
-1.42109e-14
-4.44089e-16
-5.68434e-14
-1.42109e-14
-4.44089e-16
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
 3D
 Data read...
-1.13687e-13
-3.88578e-16
-1.13687e-13
-3.88578e-16
-1.13687e-13
-4.44089e-16
-1.13687e-13
-2.04281e-14
-4.44089e-16
-1.13687e-13
-2.04281e-14
-4.44089e-16
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold
+SUCCESS: error below threshold


### PR DESCRIPTION
This commit makes FFTW self-validating in order to avoid
differences in precision that may occur across different
architectures or FFTW plans chosen for a given architecture.
It adds two config consts, one to say whether or not the
error values should be printed, and the other to define
the acceptable epsilon in error to tolerate.

Update the .goods to reflect the 'success' messages
expected.

While here, also did a "cute" cleanup to the repetition
in the 1D, 2D, 3D test configurations to loop over them
rather than list them explicitly which I noticed only
after code freeze.