### PR TITLE
Fix test .good after PR #1751

### DIFF
--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -20,12 +20,11 @@ Parsing module files:
   subdir2/bap.chpl
   subdir4/subdir/bax.chpl
   ./bah.chpl
-  $CHPL_HOME/modules/standard/startInitCommDiags.chpl
   $CHPL_HOME/modules/standard/NewString.chpl
   $CHPL_HOME/modules/standard/Assert.chpl
   $CHPL_HOME/modules/standard/Types.chpl
   $CHPL_HOME/modules/standard/Math.chpl
-  $CHPL_HOME/modules/standard/stopInitCommDiags.chpl
+  $CHPL_HOME/modules/standard/CommDiagnostics.chpl
   $CHPL_HOME/modules/standard/Sys.chpl
   $CHPL_HOME/modules/dists/DSIUtil.chpl
   $CHPL_HOME/modules/standard/List.chpl
@@ -33,7 +32,6 @@ Parsing module files:
   $CHPL_HOME/modules/standard/IO.chpl
   $CHPL_HOME/modules/standard/Sort.chpl
   $CHPL_HOME/modules/standard/Search.chpl
-  $CHPL_HOME/modules/standard/CommDiagnostics.chpl
   $CHPL_HOME/modules/standard/gen/.../SysCTypes.chpl
   $CHPL_HOME/modules/standard/Error.chpl
   $CHPL_HOME/modules/standard/Regexp.chpl


### PR DESCRIPTION
The test modules/bradc/printModStuff/foo.chpl prints out the
modules and their initialization order. Greg's PR #1751 moved
startInitCommDiags and stopInitCommDiags and changed the module
initialization order. This test just needed to be updated
to reflect the new order.