### PR TITLE
Removed the unused FLAG_NO_USE_CHAPELSTANDARD

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2855,7 +2855,7 @@ void ModuleSymbol::accept(AstVisitor* visitor) {
 }
 
 void ModuleSymbol::addDefaultUses() {
-  if (modTag != MOD_INTERNAL && hasFlag(FLAG_NO_USE_CHAPELSTANDARD) == false) {
+  if (modTag != MOD_INTERNAL) {
     UnresolvedSymExpr* modRef = 0;
 
     SET_LINENO(this);

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1667,7 +1667,6 @@ void initChplProgram(DefExpr* objectDef) {
   theProgram           = new ModuleSymbol("chpl__Program", MOD_INTERNAL, new BlockStmt());
   theProgram->filename = astr("<internal>");
 
-  theProgram->addFlag(FLAG_NO_USE_CHAPELSTANDARD);
   theProgram->addFlag(FLAG_NO_CODEGEN);
 
   base = new CallExpr(PRIM_USE, new UnresolvedSymExpr("ChapelBase"));

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -166,7 +166,6 @@ symbolFlag( FLAG_NO_INSTANTIATION_LIMIT , ypr, "no instantiation limit", "The in
 symbolFlag( FLAG_NO_OBJECT , ypr, "no object" , ncm )
 symbolFlag( FLAG_NO_PARENS , npr, "no parens" , "function without parentheses" )
 symbolFlag( FLAG_NO_PROTOTYPE , ypr, "no prototype" , "do not generate a prototype this symbol" )
-symbolFlag( FLAG_NO_USE_CHAPELSTANDARD , ypr, "no use ChapelStandard" , "Do not implicitly use ChapelStandard" )
 symbolFlag( FLAG_NO_WIDE_CLASS , ypr, "no wide class" , ncm )
 symbolFlag( FLAG_NO_REMOTE_MEMORY_FENCE , ypr, "no remote memory fence" , ncm)
 symbolFlag( FLAG_OBJECT_CLASS , npr, "object class" , ncm )


### PR DESCRIPTION
The last occurrence of the corresponding pragma was removed from the modules in #1751.
With that, its use (including addFlag) in the compiler can be eliminated.

This is a simple change. If we need this flag in the future, this commit can be reverted.
