### PR TITLE
Define _DEFAULT_SOURCE to suppress a warning in glibc >= 2.20

### DIFF
--- a/runtime/include/sys_basic.h
+++ b/runtime/include/sys_basic.h
@@ -52,6 +52,12 @@
 #define _POSIX_C_SOURCE 200112L
 #endif
 
+#ifndef _DEFAULT_SOURCE
+// Quiets warnings about _BSD_SOURCE being deprecated in glbic >= 2.20
+// This define enables everything _BSD_SOURCE does (and more) with glibc >= 2.19
+#define _DEFAULT_SOURCE
+#endif
+
 //
 // The following breaks #include of "glob.h" with the Cray CCE
 // compiler and also complicates things for the #inclusion of dirent.h


### PR DESCRIPTION
glibc 2.20 deprecated _BSD_SOURCE and _SVID_SOURCE in favor of
_DEFAULT_SOURCE. glibc will issue a warning if _BSD_SOURCE is defined,
but _DEFAULT_SOURCE is not. We need to set both to maintain
compatibility with other versions of libc.