### PR TITLE
Guard test/man against absent chpldoc

### DIFF
--- a/test/man/sub_test
+++ b/test/man/sub_test
@@ -7,6 +7,11 @@ if [ $# -lt 1 ]; then
     exit -1
 fi
 
+if [ ! -x ${1}doc ]; then
+    echo "[Error (sub_test): chpldoc not found at ${1}doc]"
+    exit -1
+fi
+
 $CWD/checkManPages $1
 if [ $? != 0 ]; then
     echo '[Error matching man page(s) with compiler environment]'


### PR DESCRIPTION
If chpldoc has not been built, running start_test in test/man results in a python stack trace. This should indicate clearly what the issue is.

I wonder whether the error message should say "please cd $CHPL_HOME and run: make chpldoc"
