### PR TITLE
Improve runaway comment error message

### DIFF
--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -735,7 +735,7 @@ static int processBlockComment(yyscan_t scanner) {
               startFilename, startLine);
       if( nestedStartLine >= 0 ) {
         fprintf(stderr, "%s:%d: start of nested comment\n",
-                startFilename, startLine);
+                startFilename, nestedStartLine);
       }
       yyerror(yyLloc, &context, "EOF in comment");
     }

--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -677,6 +677,10 @@ static int processBlockComment(yyscan_t scanner) {
   YYSTYPE*    yyLval       = yyget_lval(scanner);
   YYLTYPE*    yyLloc       = yyget_lloc(scanner);
 
+  int nestedStartLine = -1;
+  int startLine = chplLineno;
+  const char* startFilename = yyfilename;
+
   int         len          = strlen(fDocsCommentLabel);
   int         labelIndex   = (len >= 2) ? 2 : 0;
 
@@ -722,9 +726,17 @@ static int processBlockComment(yyscan_t scanner) {
 
     } else if (lastc == '/' && c == '*') { // start nested
       depth++;
+      // keep track of the start of the last nested comment
+      nestedStartLine = chplLineno;
     } else if (c == 0) {
       ParserContext context(scanner);
 
+      fprintf(stderr, "%s:%d: start of unterminated comment\n",
+              startFilename, startLine);
+      if( nestedStartLine >= 0 ) {
+        fprintf(stderr, "%s:%d: start of nested comment\n",
+                startFilename, startLine);
+      }
       yyerror(yyLloc, &context, "EOF in comment");
     }
   }

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -553,24 +553,14 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname, bool skip_com
   // factor of 5 or so in time in running the test system, as opposed
   // to specifying BINNAME on the C compiler command line.
 
-  fprintf(makefile.fptr, "COMP_GEN_CFLAGS =");
-  if (ccwarnings) {
-    fprintf(makefile.fptr, " $(WARN_GEN_CFLAGS)");
-  }
-  if (debugCCode) {
-    fprintf(makefile.fptr, " $(DEBUG_CFLAGS)");
-  }
-  if (optimizeCCode) {
-    fprintf(makefile.fptr, " $(OPT_CFLAGS)");
-  }
-  if (specializeCCode) {
-    fprintf(makefile.fptr, " $(SPECIALIZE_CFLAGS)");
-  }
-  if (fieeefloat) {
-    fprintf(makefile.fptr, " $(IEEE_FLOAT_GEN_CFLAGS)");
-  } else {
-    fprintf(makefile.fptr, " $(NO_IEEE_FLOAT_GEN_CFLAGS)");
-  }
+  fprintf(makefile.fptr, "COMP_GEN_WARN = %i\n", ccwarnings!=0);
+  fprintf(makefile.fptr, "COMP_GEN_DEBUG = %i\n", debugCCode!=0);
+  fprintf(makefile.fptr, "COMP_GEN_OPT = %i\n", optimizeCCode!=0);
+  fprintf(makefile.fptr, "COMP_GEN_SPECIALIZE = %i\n", specializeCCode!=0);
+  fprintf(makefile.fptr, "COMP_GEN_IEEE_FLOAT = %i\n", fieeefloat!=0);
+  
+  fprintf(makefile.fptr, "COMP_GEN_USER_CFLAGS =");
+
   if (fLibraryCompile && (fLinkStyle==LS_DYNAMIC))
     fprintf(makefile.fptr, " $(SHARED_LIB_CFLAGS)");
   forv_Vec(const char*, dirName, incDirs) {

--- a/runtime/etc/Makefile.include
+++ b/runtime/etc/Makefile.include
@@ -52,6 +52,30 @@ CHPL_RT_INC_DIR = $(RUNTIME_INCLS)
 
 CHPL_RT_LIB_DIR = $(CHPL_MAKE_HOME)/$(LIB_RT_DIR)
 
+MAKE_COMP_GEN_CFLAGS =
+
+# These Make ifdefs are used for printcompileline and printcflags
+# in order to correctly set COMP_GEN_CFLAGS.
+ifeq ($(COMP_GEN_WARN), 1)
+  MAKE_COMP_GEN_CFLAGS += $(WARN_GEN_CFLAGS)
+endif
+ifeq ($(COMP_GEN_DEBUG), 1)
+  MAKE_COMP_GEN_CFLAGS += $(DEBUG_CFLAGS)
+endif
+ifeq ($(COMP_GEN_OPT), 1)
+  MAKE_COMP_GEN_CFLAGS += $(OPT_CFLAGS)
+endif
+ifeq ($(COMP_GEN_SPECIALIZE), 1)
+  MAKE_COMP_GEN_CFLAGS += $(SPECIALIZE_CFLAGS)
+endif
+ifeq ($(COMP_GEN_IEEE_FLOAT), 1)
+  MAKE_COMP_GEN_CFLAGS += $(IEEE_FLOAT_GEN_CFLAGS)
+else
+  MAKE_COMP_GEN_CFLAGS += $(NO_IEEE_FLOAT_GEN_CFLAGS)
+endif
+
+COMP_GEN_CFLAGS = $(MAKE_COMP_GEN_CFLAGS) $(COMP_GEN_USER_CFLAGS)
+
 printincludesanddefines:
 	@echo $(RUNTIME_DEFS) $(RUNTIME_INCLS)
 

--- a/test/parsing/ferguson/comment-test.chpl
+++ b/test/parsing/ferguson/comment-test.chpl
@@ -1,0 +1,9 @@
+/* This
+   comment
+   ends
+ */
+
+/*
+   This comment does not end
+
+

--- a/test/parsing/ferguson/comment-test2.chpl
+++ b/test/parsing/ferguson/comment-test2.chpl
@@ -1,0 +1,13 @@
+/* This
+   comment
+   ends
+ */
+
+/*
+   This comment does not end
+   because it has a nested comment
+   /*
+
+ */
+
+

--- a/test/parsing/vass/comment-nested-slashstarslash-1.good
+++ b/test/parsing/vass/comment-nested-slashstarslash-1.good
@@ -1,1 +1,3 @@
+comment-nested-slashstarslash-1.chpl:1: start of unterminated comment
+comment-nested-slashstarslash-1.chpl:3: start of nested comment
 comment-nested-slashstarslash-1.chpl:6: EOF in comment


### PR DESCRIPTION
Previously, unterminated comments just printed out like this:
file.chpl:6: EOF in comment

I've updated the error message to be more useful with the start
of the comment and of the last nested comment:
file.chpl:1: start of unterminated comment
file.chpl:3: start of nested comment
file.chpl:6: EOF in comment

To keep the PR diff small, I havn't committed the result of 'make parser'. I will do
so when merging, however.

test/parsing passes. There are no other tests that have the string "EOF in comment".