### PR TITLE
Improve error messages for runaway comments

### DIFF
--- a/compiler/include/bison-chapel.h
+++ b/compiler/include/bison-chapel.h
@@ -1,19 +1,19 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 2.5.  */
 
 /* Bison interface for Yacc-like parsers in C
-
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
-
+   
+      Copyright (C) 1984, 1989-1990, 2000-2011 Free Software Foundation, Inc.
+   
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-
+   
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-
+   
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -26,25 +26,21 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-
+   
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-#ifndef YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED
-# define YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED
-/* Debug traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 1
-#endif
-#if YYDEBUG
-extern int yydebug;
-#endif
 /* "%code requires" blocks.  */
-#line 33 "chapel.ypp" /* yacc.c:1915  */
+
+/* Line 2068 of yacc.c  */
+#line 33 "chapel.ypp"
 
   extern int  captureTokens;
   extern char captureString[1024];
-#line 44 "chapel.ypp" /* yacc.c:1915  */
+
+
+/* Line 2068 of yacc.c  */
+#line 44 "chapel.ypp"
 
   #ifndef _BISON_CHAPEL_DEFINES_0_
   #define _BISON_CHAPEL_DEFINES_0_
@@ -58,7 +54,10 @@ extern int yydebug;
   int processNewline(yyscan_t scanner);
 
   #endif
-#line 63 "chapel.ypp" /* yacc.c:1915  */
+
+
+/* Line 2068 of yacc.c  */
+#line 63 "chapel.ypp"
 
   #ifndef _BISON_CHAPEL_DEFINES_1_
   #define _BISON_CHAPEL_DEFINES_1_
@@ -109,7 +108,10 @@ extern int yydebug;
   };
 
   #endif
-#line 119 "chapel.ypp" /* yacc.c:1915  */
+
+
+/* Line 2068 of yacc.c  */
+#line 119 "chapel.ypp"
 
   #ifndef _BISON_CHAPEL_DEFINES_2_
   #define _BISON_CHAPEL_DEFINES_2_
@@ -126,7 +128,10 @@ extern int yydebug;
   #define YYLTYPE_IS_TRIVIAL  1
 
   #endif
-#line 141 "chapel.ypp" /* yacc.c:1915  */
+
+
+/* Line 2068 of yacc.c  */
+#line 141 "chapel.ypp"
 
   #ifndef _BISON_CHAPEL_DEFINES_3_
   #define _BISON_CHAPEL_DEFINES_3_
@@ -154,175 +159,200 @@ extern int yydebug;
 
   #endif
 
-#line 158 "../include/bison-chapel.h" /* yacc.c:1915  */
 
-/* Token type.  */
+
+/* Line 2068 of yacc.c  */
+#line 166 "../include/bison-chapel.h"
+
+/* Tokens.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-  enum yytokentype
-  {
-    TIDENT = 258,
-    INTLITERAL = 259,
-    REALLITERAL = 260,
-    IMAGLITERAL = 261,
-    STRINGLITERAL = 262,
-    EXTERNCODE = 263,
-    TALIGN = 264,
-    TATOMIC = 265,
-    TBEGIN = 266,
-    TBREAK = 267,
-    TBY = 268,
-    TCLASS = 269,
-    TCOBEGIN = 270,
-    TCOFORALL = 271,
-    TCONFIG = 272,
-    TCONST = 273,
-    TCONTINUE = 274,
-    TDELETE = 275,
-    TDMAPPED = 276,
-    TDO = 277,
-    TDOMAIN = 278,
-    TELSE = 279,
-    TENUM = 280,
-    TEXPORT = 281,
-    TEXTERN = 282,
-    TFOR = 283,
-    TFORALL = 284,
-    TIF = 285,
-    TIN = 286,
-    TINDEX = 287,
-    TINLINE = 288,
-    TINOUT = 289,
-    TITER = 290,
-    TLABEL = 291,
-    TLAMBDA = 292,
-    TLET = 293,
-    TLOCAL = 294,
-    TMINUSMINUS = 295,
-    TMODULE = 296,
-    TNEW = 297,
-    TNIL = 298,
-    TNOINIT = 299,
-    TON = 300,
-    TOTHERWISE = 301,
-    TOUT = 302,
-    TPARAM = 303,
-    TPLUSPLUS = 304,
-    TPRAGMA = 305,
-    TPRIMITIVE = 306,
-    TPROC = 307,
-    TRECORD = 308,
-    TREDUCE = 309,
-    TREF = 310,
-    TRETURN = 311,
-    TSCAN = 312,
-    TSELECT = 313,
-    TSERIAL = 314,
-    TSINGLE = 315,
-    TSPARSE = 316,
-    TSUBDOMAIN = 317,
-    TSYNC = 318,
-    TTHEN = 319,
-    TTYPE = 320,
-    TUNDERSCORE = 321,
-    TUNION = 322,
-    TUSE = 323,
-    TVAR = 324,
-    TWHEN = 325,
-    TWHERE = 326,
-    TWHILE = 327,
-    TWITH = 328,
-    TYIELD = 329,
-    TZIP = 330,
-    TALIAS = 331,
-    TAND = 332,
-    TASSIGN = 333,
-    TASSIGNBAND = 334,
-    TASSIGNBOR = 335,
-    TASSIGNBXOR = 336,
-    TASSIGNDIVIDE = 337,
-    TASSIGNEXP = 338,
-    TASSIGNLAND = 339,
-    TASSIGNLOR = 340,
-    TASSIGNMINUS = 341,
-    TASSIGNMOD = 342,
-    TASSIGNMULTIPLY = 343,
-    TASSIGNPLUS = 344,
-    TASSIGNSL = 345,
-    TASSIGNSR = 346,
-    TBAND = 347,
-    TBNOT = 348,
-    TBOR = 349,
-    TBXOR = 350,
-    TCOLON = 351,
-    TCOMMA = 352,
-    TDIVIDE = 353,
-    TDOT = 354,
-    TDOTDOT = 355,
-    TDOTDOTDOT = 356,
-    TEQUAL = 357,
-    TEXP = 358,
-    TGREATER = 359,
-    TGREATEREQUAL = 360,
-    THASH = 361,
-    TLESS = 362,
-    TLESSEQUAL = 363,
-    TMINUS = 364,
-    TMOD = 365,
-    TNOT = 366,
-    TNOTEQUAL = 367,
-    TOR = 368,
-    TPLUS = 369,
-    TQUESTION = 370,
-    TSEMI = 371,
-    TSHIFTLEFT = 372,
-    TSHIFTRIGHT = 373,
-    TSTAR = 374,
-    TSWAP = 375,
-    TIO = 376,
-    TLCBR = 377,
-    TRCBR = 378,
-    TLP = 379,
-    TRP = 380,
-    TLSBR = 381,
-    TRSBR = 382,
-    TNOELSE = 383,
-    TUPLUS = 384,
-    TUMINUS = 385
-  };
+   /* Put the tokens into the symbol table, so that GDB and other debuggers
+      know about them.  */
+   enum yytokentype {
+     TIDENT = 258,
+     INTLITERAL = 259,
+     REALLITERAL = 260,
+     IMAGLITERAL = 261,
+     STRINGLITERAL = 262,
+     EXTERNCODE = 263,
+     TALIGN = 264,
+     TATOMIC = 265,
+     TBEGIN = 266,
+     TBREAK = 267,
+     TBY = 268,
+     TCLASS = 269,
+     TCOBEGIN = 270,
+     TCOFORALL = 271,
+     TCONFIG = 272,
+     TCONST = 273,
+     TCONTINUE = 274,
+     TDELETE = 275,
+     TDMAPPED = 276,
+     TDO = 277,
+     TDOMAIN = 278,
+     TELSE = 279,
+     TENUM = 280,
+     TEXPORT = 281,
+     TEXTERN = 282,
+     TFOR = 283,
+     TFORALL = 284,
+     TIF = 285,
+     TIN = 286,
+     TINDEX = 287,
+     TINLINE = 288,
+     TINOUT = 289,
+     TITER = 290,
+     TLABEL = 291,
+     TLAMBDA = 292,
+     TLET = 293,
+     TLOCAL = 294,
+     TMINUSMINUS = 295,
+     TMODULE = 296,
+     TNEW = 297,
+     TNIL = 298,
+     TNOINIT = 299,
+     TON = 300,
+     TOTHERWISE = 301,
+     TOUT = 302,
+     TPARAM = 303,
+     TPLUSPLUS = 304,
+     TPRAGMA = 305,
+     TPRIMITIVE = 306,
+     TPROC = 307,
+     TRECORD = 308,
+     TREDUCE = 309,
+     TREF = 310,
+     TRETURN = 311,
+     TSCAN = 312,
+     TSELECT = 313,
+     TSERIAL = 314,
+     TSINGLE = 315,
+     TSPARSE = 316,
+     TSUBDOMAIN = 317,
+     TSYNC = 318,
+     TTHEN = 319,
+     TTYPE = 320,
+     TUNDERSCORE = 321,
+     TUNION = 322,
+     TUSE = 323,
+     TVAR = 324,
+     TWHEN = 325,
+     TWHERE = 326,
+     TWHILE = 327,
+     TWITH = 328,
+     TYIELD = 329,
+     TZIP = 330,
+     TALIAS = 331,
+     TAND = 332,
+     TASSIGN = 333,
+     TASSIGNBAND = 334,
+     TASSIGNBOR = 335,
+     TASSIGNBXOR = 336,
+     TASSIGNDIVIDE = 337,
+     TASSIGNEXP = 338,
+     TASSIGNLAND = 339,
+     TASSIGNLOR = 340,
+     TASSIGNMINUS = 341,
+     TASSIGNMOD = 342,
+     TASSIGNMULTIPLY = 343,
+     TASSIGNPLUS = 344,
+     TASSIGNSL = 345,
+     TASSIGNSR = 346,
+     TBAND = 347,
+     TBNOT = 348,
+     TBOR = 349,
+     TBXOR = 350,
+     TCOLON = 351,
+     TCOMMA = 352,
+     TDIVIDE = 353,
+     TDOT = 354,
+     TDOTDOT = 355,
+     TDOTDOTDOT = 356,
+     TEQUAL = 357,
+     TEXP = 358,
+     TGREATER = 359,
+     TGREATEREQUAL = 360,
+     THASH = 361,
+     TLESS = 362,
+     TLESSEQUAL = 363,
+     TMINUS = 364,
+     TMOD = 365,
+     TNOT = 366,
+     TNOTEQUAL = 367,
+     TOR = 368,
+     TPLUS = 369,
+     TQUESTION = 370,
+     TSEMI = 371,
+     TSHIFTLEFT = 372,
+     TSHIFTRIGHT = 373,
+     TSTAR = 374,
+     TSWAP = 375,
+     TIO = 376,
+     TLCBR = 377,
+     TRCBR = 378,
+     TLP = 379,
+     TRP = 380,
+     TLSBR = 381,
+     TRSBR = 382,
+     TNOELSE = 383,
+     TUMINUS = 384,
+     TUPLUS = 385
+   };
 #endif
 
-/* Value type.  */
 
-/* Location type.  */
+
+#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
+
+# define yystype YYSTYPE /* obsolescent; will be withdrawn */
+# define YYSTYPE_IS_DECLARED 1
+#endif
+
+
+
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE YYLTYPE;
-struct YYLTYPE
+typedef struct YYLTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-};
+} YYLTYPE;
+# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
 
 
-#ifndef YYPUSH_MORE_DEFINED
-# define YYPUSH_MORE_DEFINED
+#ifndef YYPUSH_DECLS
+#  define YYPUSH_DECLS
+struct yypstate;
+typedef struct yypstate yypstate;
 enum { YYPUSH_MORE = 4 };
+#if defined __STDC__ || defined __cplusplus
+int yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE const *yypushed_loc, ParserContext* context);
+#else
+int yypush_parse ();
 #endif
 
-typedef struct yypstate yypstate;
-
-int yypush_parse (yypstate *ps, int pushed_char, YYSTYPE const *pushed_val, YYLTYPE *pushed_loc, ParserContext* context);
-
+#if defined __STDC__ || defined __cplusplus
 yypstate * yypstate_new (void);
-void yypstate_delete (yypstate *ps);
+#else
+yypstate * yypstate_new ();
+#endif
+#if defined __STDC__ || defined __cplusplus
+void yypstate_delete (yypstate *yyps);
+#else
+void yypstate_delete ();
+#endif
+#endif
+
 /* "%code provides" blocks.  */
-#line 172 "chapel.ypp" /* yacc.c:1915  */
+
+/* Line 2068 of yacc.c  */
+#line 172 "chapel.ypp"
 
   extern int yydebug;
 
@@ -330,6 +360,7 @@ void yypstate_delete (yypstate *ps);
                ParserContext* context,
                const char*    str);
 
-#line 334 "../include/bison-chapel.h" /* yacc.c:1915  */
 
-#endif /* !YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED  */
+
+/* Line 2068 of yacc.c  */
+#line 367 "../include/bison-chapel.h"

--- a/compiler/include/flex-chapel.h
+++ b/compiler/include/flex-chapel.h
@@ -51,7 +51,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -162,7 +161,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -206,7 +205,7 @@ void yypop_buffer_state (yyscan_t yyscanner );
 
 YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
 
 void *yyalloc (yy_size_t ,yyscan_t yyscanner );
 void *yyrealloc (void *,yy_size_t ,yyscan_t yyscanner );
@@ -262,7 +261,7 @@ FILE *yyget_out (yyscan_t yyscanner );
 
 void yyset_out  (FILE * out_str ,yyscan_t yyscanner );
 
-yy_size_t yyget_leng (yyscan_t yyscanner );
+int yyget_leng (yyscan_t yyscanner );
 
 char *yyget_text (yyscan_t yyscanner );
 
@@ -342,6 +341,6 @@ extern int yylex \
 #line 255 "chapel.lex"
 
 
-#line 346 "../include/flex-chapel.h"
+#line 345 "../include/flex-chapel.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/compiler/parser/bison-chapel.cpp
+++ b/compiler/parser/bison-chapel.cpp
@@ -1,19 +1,19 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 2.5.  */
 
 /* Bison implementation for Yacc-like parsers in C
-
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
-
+   
+      Copyright (C) 1984, 1989-1990, 2000-2011 Free Software Foundation, Inc.
+   
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-
+   
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-
+   
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -26,7 +26,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-
+   
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -44,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "2.5"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -58,20 +58,21 @@
 /* Pull parsers.  */
 #define YYPULL 0
 
+/* Using locations.  */
+#define YYLSP_NEEDED 1
 
 
 
 /* Copy the first part of user declarations.  */
 
-#line 67 "bison-chapel.cpp" /* yacc.c:339  */
 
-# ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
-#  else
-#   define YY_NULLPTR 0
-#  endif
-# endif
+/* Line 268 of yacc.c  */
+#line 71 "bison-chapel.cpp"
+
+/* Enabling traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 1
+#endif
 
 /* Enabling verbose error messages.  */
 #ifdef YYERROR_VERBOSE
@@ -81,23 +82,22 @@
 # define YYERROR_VERBOSE 0
 #endif
 
-/* In a future release of Bison, this section will be replaced
-   by #include "bison-chapel.h".  */
-#ifndef YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED
-# define YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED
-/* Debug traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 1
+/* Enabling the token table.  */
+#ifndef YYTOKEN_TABLE
+# define YYTOKEN_TABLE 0
 #endif
-#if YYDEBUG
-extern int yydebug;
-#endif
+
 /* "%code requires" blocks.  */
-#line 33 "chapel.ypp" /* yacc.c:355  */
+
+/* Line 288 of yacc.c  */
+#line 33 "chapel.ypp"
 
   extern int  captureTokens;
   extern char captureString[1024];
-#line 44 "chapel.ypp" /* yacc.c:355  */
+
+
+/* Line 288 of yacc.c  */
+#line 44 "chapel.ypp"
 
   #ifndef _BISON_CHAPEL_DEFINES_0_
   #define _BISON_CHAPEL_DEFINES_0_
@@ -111,7 +111,10 @@ extern int yydebug;
   int processNewline(yyscan_t scanner);
 
   #endif
-#line 63 "chapel.ypp" /* yacc.c:355  */
+
+
+/* Line 288 of yacc.c  */
+#line 63 "chapel.ypp"
 
   #ifndef _BISON_CHAPEL_DEFINES_1_
   #define _BISON_CHAPEL_DEFINES_1_
@@ -162,7 +165,10 @@ extern int yydebug;
   };
 
   #endif
-#line 119 "chapel.ypp" /* yacc.c:355  */
+
+
+/* Line 288 of yacc.c  */
+#line 119 "chapel.ypp"
 
   #ifndef _BISON_CHAPEL_DEFINES_2_
   #define _BISON_CHAPEL_DEFINES_2_
@@ -179,7 +185,10 @@ extern int yydebug;
   #define YYLTYPE_IS_TRIVIAL  1
 
   #endif
-#line 141 "chapel.ypp" /* yacc.c:355  */
+
+
+/* Line 288 of yacc.c  */
+#line 141 "chapel.ypp"
 
   #ifndef _BISON_CHAPEL_DEFINES_3_
   #define _BISON_CHAPEL_DEFINES_3_
@@ -207,175 +216,197 @@ extern int yydebug;
 
   #endif
 
-#line 211 "bison-chapel.cpp" /* yacc.c:355  */
 
-/* Token type.  */
+
+/* Line 288 of yacc.c  */
+#line 223 "bison-chapel.cpp"
+
+/* Tokens.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-  enum yytokentype
-  {
-    TIDENT = 258,
-    INTLITERAL = 259,
-    REALLITERAL = 260,
-    IMAGLITERAL = 261,
-    STRINGLITERAL = 262,
-    EXTERNCODE = 263,
-    TALIGN = 264,
-    TATOMIC = 265,
-    TBEGIN = 266,
-    TBREAK = 267,
-    TBY = 268,
-    TCLASS = 269,
-    TCOBEGIN = 270,
-    TCOFORALL = 271,
-    TCONFIG = 272,
-    TCONST = 273,
-    TCONTINUE = 274,
-    TDELETE = 275,
-    TDMAPPED = 276,
-    TDO = 277,
-    TDOMAIN = 278,
-    TELSE = 279,
-    TENUM = 280,
-    TEXPORT = 281,
-    TEXTERN = 282,
-    TFOR = 283,
-    TFORALL = 284,
-    TIF = 285,
-    TIN = 286,
-    TINDEX = 287,
-    TINLINE = 288,
-    TINOUT = 289,
-    TITER = 290,
-    TLABEL = 291,
-    TLAMBDA = 292,
-    TLET = 293,
-    TLOCAL = 294,
-    TMINUSMINUS = 295,
-    TMODULE = 296,
-    TNEW = 297,
-    TNIL = 298,
-    TNOINIT = 299,
-    TON = 300,
-    TOTHERWISE = 301,
-    TOUT = 302,
-    TPARAM = 303,
-    TPLUSPLUS = 304,
-    TPRAGMA = 305,
-    TPRIMITIVE = 306,
-    TPROC = 307,
-    TRECORD = 308,
-    TREDUCE = 309,
-    TREF = 310,
-    TRETURN = 311,
-    TSCAN = 312,
-    TSELECT = 313,
-    TSERIAL = 314,
-    TSINGLE = 315,
-    TSPARSE = 316,
-    TSUBDOMAIN = 317,
-    TSYNC = 318,
-    TTHEN = 319,
-    TTYPE = 320,
-    TUNDERSCORE = 321,
-    TUNION = 322,
-    TUSE = 323,
-    TVAR = 324,
-    TWHEN = 325,
-    TWHERE = 326,
-    TWHILE = 327,
-    TWITH = 328,
-    TYIELD = 329,
-    TZIP = 330,
-    TALIAS = 331,
-    TAND = 332,
-    TASSIGN = 333,
-    TASSIGNBAND = 334,
-    TASSIGNBOR = 335,
-    TASSIGNBXOR = 336,
-    TASSIGNDIVIDE = 337,
-    TASSIGNEXP = 338,
-    TASSIGNLAND = 339,
-    TASSIGNLOR = 340,
-    TASSIGNMINUS = 341,
-    TASSIGNMOD = 342,
-    TASSIGNMULTIPLY = 343,
-    TASSIGNPLUS = 344,
-    TASSIGNSL = 345,
-    TASSIGNSR = 346,
-    TBAND = 347,
-    TBNOT = 348,
-    TBOR = 349,
-    TBXOR = 350,
-    TCOLON = 351,
-    TCOMMA = 352,
-    TDIVIDE = 353,
-    TDOT = 354,
-    TDOTDOT = 355,
-    TDOTDOTDOT = 356,
-    TEQUAL = 357,
-    TEXP = 358,
-    TGREATER = 359,
-    TGREATEREQUAL = 360,
-    THASH = 361,
-    TLESS = 362,
-    TLESSEQUAL = 363,
-    TMINUS = 364,
-    TMOD = 365,
-    TNOT = 366,
-    TNOTEQUAL = 367,
-    TOR = 368,
-    TPLUS = 369,
-    TQUESTION = 370,
-    TSEMI = 371,
-    TSHIFTLEFT = 372,
-    TSHIFTRIGHT = 373,
-    TSTAR = 374,
-    TSWAP = 375,
-    TIO = 376,
-    TLCBR = 377,
-    TRCBR = 378,
-    TLP = 379,
-    TRP = 380,
-    TLSBR = 381,
-    TRSBR = 382,
-    TNOELSE = 383,
-    TUPLUS = 384,
-    TUMINUS = 385
-  };
+   /* Put the tokens into the symbol table, so that GDB and other debuggers
+      know about them.  */
+   enum yytokentype {
+     TIDENT = 258,
+     INTLITERAL = 259,
+     REALLITERAL = 260,
+     IMAGLITERAL = 261,
+     STRINGLITERAL = 262,
+     EXTERNCODE = 263,
+     TALIGN = 264,
+     TATOMIC = 265,
+     TBEGIN = 266,
+     TBREAK = 267,
+     TBY = 268,
+     TCLASS = 269,
+     TCOBEGIN = 270,
+     TCOFORALL = 271,
+     TCONFIG = 272,
+     TCONST = 273,
+     TCONTINUE = 274,
+     TDELETE = 275,
+     TDMAPPED = 276,
+     TDO = 277,
+     TDOMAIN = 278,
+     TELSE = 279,
+     TENUM = 280,
+     TEXPORT = 281,
+     TEXTERN = 282,
+     TFOR = 283,
+     TFORALL = 284,
+     TIF = 285,
+     TIN = 286,
+     TINDEX = 287,
+     TINLINE = 288,
+     TINOUT = 289,
+     TITER = 290,
+     TLABEL = 291,
+     TLAMBDA = 292,
+     TLET = 293,
+     TLOCAL = 294,
+     TMINUSMINUS = 295,
+     TMODULE = 296,
+     TNEW = 297,
+     TNIL = 298,
+     TNOINIT = 299,
+     TON = 300,
+     TOTHERWISE = 301,
+     TOUT = 302,
+     TPARAM = 303,
+     TPLUSPLUS = 304,
+     TPRAGMA = 305,
+     TPRIMITIVE = 306,
+     TPROC = 307,
+     TRECORD = 308,
+     TREDUCE = 309,
+     TREF = 310,
+     TRETURN = 311,
+     TSCAN = 312,
+     TSELECT = 313,
+     TSERIAL = 314,
+     TSINGLE = 315,
+     TSPARSE = 316,
+     TSUBDOMAIN = 317,
+     TSYNC = 318,
+     TTHEN = 319,
+     TTYPE = 320,
+     TUNDERSCORE = 321,
+     TUNION = 322,
+     TUSE = 323,
+     TVAR = 324,
+     TWHEN = 325,
+     TWHERE = 326,
+     TWHILE = 327,
+     TWITH = 328,
+     TYIELD = 329,
+     TZIP = 330,
+     TALIAS = 331,
+     TAND = 332,
+     TASSIGN = 333,
+     TASSIGNBAND = 334,
+     TASSIGNBOR = 335,
+     TASSIGNBXOR = 336,
+     TASSIGNDIVIDE = 337,
+     TASSIGNEXP = 338,
+     TASSIGNLAND = 339,
+     TASSIGNLOR = 340,
+     TASSIGNMINUS = 341,
+     TASSIGNMOD = 342,
+     TASSIGNMULTIPLY = 343,
+     TASSIGNPLUS = 344,
+     TASSIGNSL = 345,
+     TASSIGNSR = 346,
+     TBAND = 347,
+     TBNOT = 348,
+     TBOR = 349,
+     TBXOR = 350,
+     TCOLON = 351,
+     TCOMMA = 352,
+     TDIVIDE = 353,
+     TDOT = 354,
+     TDOTDOT = 355,
+     TDOTDOTDOT = 356,
+     TEQUAL = 357,
+     TEXP = 358,
+     TGREATER = 359,
+     TGREATEREQUAL = 360,
+     THASH = 361,
+     TLESS = 362,
+     TLESSEQUAL = 363,
+     TMINUS = 364,
+     TMOD = 365,
+     TNOT = 366,
+     TNOTEQUAL = 367,
+     TOR = 368,
+     TPLUS = 369,
+     TQUESTION = 370,
+     TSEMI = 371,
+     TSHIFTLEFT = 372,
+     TSHIFTRIGHT = 373,
+     TSTAR = 374,
+     TSWAP = 375,
+     TIO = 376,
+     TLCBR = 377,
+     TRCBR = 378,
+     TLP = 379,
+     TRP = 380,
+     TLSBR = 381,
+     TRSBR = 382,
+     TNOELSE = 383,
+     TUMINUS = 384,
+     TUPLUS = 385
+   };
 #endif
 
-/* Value type.  */
 
-/* Location type.  */
+
+#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
+
+# define yystype YYSTYPE /* obsolescent; will be withdrawn */
+# define YYSTYPE_IS_DECLARED 1
+#endif
+
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE YYLTYPE;
-struct YYLTYPE
+typedef struct YYLTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-};
+} YYLTYPE;
+# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
-
-
-#ifndef YYPUSH_MORE_DEFINED
-# define YYPUSH_MORE_DEFINED
+#ifndef YYPUSH_DECLS
+#  define YYPUSH_DECLS
+struct yypstate;
+typedef struct yypstate yypstate;
 enum { YYPUSH_MORE = 4 };
+
+#if defined __STDC__ || defined __cplusplus
+int yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE const *yypushed_loc, ParserContext* context);
+#else
+int yypush_parse ();
 #endif
 
-typedef struct yypstate yypstate;
-
-int yypush_parse (yypstate *ps, int pushed_char, YYSTYPE const *pushed_val, YYLTYPE *pushed_loc, ParserContext* context);
-
+#if defined __STDC__ || defined __cplusplus
 yypstate * yypstate_new (void);
-void yypstate_delete (yypstate *ps);
+#else
+yypstate * yypstate_new ();
+#endif
+#if defined __STDC__ || defined __cplusplus
+void yypstate_delete (yypstate *yyps);
+#else
+void yypstate_delete ();
+#endif
+#endif
+
 /* "%code provides" blocks.  */
-#line 172 "chapel.ypp" /* yacc.c:355  */
+
+/* Line 340 of yacc.c  */
+#line 172 "chapel.ypp"
 
   extern int yydebug;
 
@@ -383,19 +414,27 @@ void yypstate_delete (yypstate *ps);
                ParserContext* context,
                const char*    str);
 
-#line 387 "bison-chapel.cpp" /* yacc.c:355  */
 
-#endif /* !YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED  */
+
+/* Line 340 of yacc.c  */
+#line 421 "bison-chapel.cpp"
 
 /* Copy the second part of user declarations.  */
 
-#line 393 "bison-chapel.cpp" /* yacc.c:358  */
+
+/* Line 343 of yacc.c  */
+#line 427 "bison-chapel.cpp"
 /* Unqualified %code blocks.  */
-#line 38 "chapel.ypp" /* yacc.c:359  */
+
+/* Line 344 of yacc.c  */
+#line 38 "chapel.ypp"
 
   int         captureTokens;
   char        captureString[1024];
-#line 180 "chapel.ypp" /* yacc.c:359  */
+
+
+/* Line 344 of yacc.c  */
+#line 180 "chapel.ypp"
 
   #include "build.h"
   #include "DoWhileStmt.h"
@@ -433,6 +472,7 @@ void yypstate_delete (yypstate *ps);
   void yyerror(YYLTYPE*       ignored,
                ParserContext* context,
                const char*    str) {
+    // TODO -- should this begin with error:
     if (!chplParseString) {
       const char* yyText = yyget_text(context->scanner);
 
@@ -454,7 +494,10 @@ void yypstate_delete (yypstate *ps);
     clean_exit(1);
   }
 
-#line 458 "bison-chapel.cpp" /* yacc.c:359  */
+
+
+/* Line 344 of yacc.c  */
+#line 501 "bison-chapel.cpp"
 
 #ifdef short
 # undef short
@@ -468,8 +511,11 @@ typedef unsigned char yytype_uint8;
 
 #ifdef YYTYPE_INT8
 typedef YYTYPE_INT8 yytype_int8;
-#else
+#elif (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 typedef signed char yytype_int8;
+#else
+typedef short int yytype_int8;
 #endif
 
 #ifdef YYTYPE_UINT16
@@ -489,7 +535,8 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T
+# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
@@ -503,75 +550,46 @@ typedef short int yytype_int16;
 # if defined YYENABLE_NLS && YYENABLE_NLS
 #  if ENABLE_NLS
 #   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
+#   define YY_(msgid) dgettext ("bison-runtime", msgid)
 #  endif
 # endif
 # ifndef YY_
-#  define YY_(Msgid) Msgid
-# endif
-#endif
-
-#ifndef YY_ATTRIBUTE
-# if (defined __GNUC__                                               \
-      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
-     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
-#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
-# else
-#  define YY_ATTRIBUTE(Spec) /* empty */
-# endif
-#endif
-
-#ifndef YY_ATTRIBUTE_PURE
-# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
-#endif
-
-#ifndef YY_ATTRIBUTE_UNUSED
-# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
-#endif
-
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
-# else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+#  define YY_(msgid) msgid
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YYUSE(e) ((void) (e))
 #else
-# define YYUSE(E) /* empty */
+# define YYUSE(e) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
-/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
-    _Pragma ("GCC diagnostic push") \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
-    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
-    _Pragma ("GCC diagnostic pop")
+/* Identity function, used to suppress warnings about constant conditions.  */
+#ifndef lint
+# define YYID(n) (n)
 #else
-# define YY_INITIAL_VALUE(Value) Value
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
+static int
+YYID (int yyi)
+#else
+static int
+YYID (yyi)
+    int yyi;
 #endif
-#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+{
+  return yyi;
+}
 #endif
-#ifndef YY_INITIAL_VALUE
-# define YY_INITIAL_VALUE(Value) /* Nothing. */
-#endif
-
 
 #if ! defined yyoverflow || YYERROR_VERBOSE
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's 'empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
+   /* Pacify GCC's `empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -587,7 +605,7 @@ typedef short int yytype_int16;
 #  endif
 #  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-             && (defined YYFREE || defined free)))
+	     && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
 #   ifndef EXIT_SUCCESS
 #    define EXIT_SUCCESS 0
@@ -595,13 +613,15 @@ typedef short int yytype_int16;
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined EXIT_SUCCESS
+#   if ! defined malloc && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined EXIT_SUCCESS
+#   if ! defined free && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
@@ -611,8 +631,8 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-         || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
-             && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+	 || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
+	     && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
@@ -638,35 +658,35 @@ union yyalloc
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
-    do                                                                  \
-      {                                                                 \
-        YYSIZE_T yynewbytes;                                            \
-        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
-        Stack = &yyptr->Stack_alloc;                                    \
-        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-        yyptr += yynewbytes / sizeof (*yyptr);                          \
-      }                                                                 \
-    while (0)
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)				\
+    do									\
+      {									\
+	YYSIZE_T yynewbytes;						\
+	YYCOPY (&yyptr->Stack_alloc, Stack, yysize);			\
+	Stack = &yyptr->Stack_alloc;					\
+	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
+	yyptr += yynewbytes / sizeof (*yyptr);				\
+      }									\
+    while (YYID (0))
 
 #endif
 
 #if defined YYCOPY_NEEDED && YYCOPY_NEEDED
-/* Copy COUNT objects from SRC to DST.  The source and destination do
+/* Copy COUNT objects from FROM to TO.  The source and destination do
    not overlap.  */
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
-#   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+#   define YYCOPY(To, From, Count) \
+      __builtin_memcpy (To, From, (Count) * sizeof (*(From)))
 #  else
-#   define YYCOPY(Dst, Src, Count)              \
-      do                                        \
-        {                                       \
-          YYSIZE_T yyi;                         \
-          for (yyi = 0; yyi < (Count); yyi++)   \
-            (Dst)[yyi] = (Src)[yyi];            \
-        }                                       \
-      while (0)
+#   define YYCOPY(To, From, Count)		\
+      do					\
+	{					\
+	  YYSIZE_T yyi;				\
+	  for (yyi = 0; yyi < (Count); yyi++)	\
+	    (To)[yyi] = (From)[yyi];		\
+	}					\
+      while (YYID (0))
 #  endif
 # endif
 #endif /* !YYCOPY_NEEDED */
@@ -682,19 +702,17 @@ union yyalloc
 #define YYNNTS  105
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  423
-/* YYNSTATES -- Number of states.  */
+/* YYNRULES -- Number of states.  */
 #define YYNSTATES  802
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
+/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   385
 
-#define YYTRANSLATE(YYX)                                                \
+#define YYTRANSLATE(YYX)						\
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
+/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -739,56 +757,256 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
+   YYRHS.  */
+static const yytype_uint16 yyprhs[] =
+{
+       0,     0,     3,     5,     6,     9,    11,    14,    17,    21,
+      23,    25,    27,    29,    31,    33,    35,    37,    39,    41,
+      43,    46,    49,    53,    57,    61,    65,    69,    73,    76,
+      80,    84,    87,    90,    94,    96,   101,   107,   109,   112,
+     116,   118,   121,   125,   130,   135,   140,   145,   150,   155,
+     160,   165,   170,   175,   180,   185,   190,   195,   200,   201,
+     203,   205,   208,   210,   213,   217,   219,   221,   223,   225,
+     227,   229,   232,   238,   242,   249,   256,   261,   267,   273,
+     277,   281,   288,   294,   301,   307,   314,   318,   323,   330,
+     338,   345,   353,   358,   364,   369,   374,   378,   385,   391,
+     397,   398,   401,   405,   408,   415,   423,   424,   426,   428,
+     430,   432,   433,   436,   437,   440,   444,   450,   452,   455,
+     459,   461,   465,   466,   467,   476,   477,   479,   481,   484,
+     486,   489,   490,   491,   501,   505,   509,   515,   521,   523,
+     526,   528,   530,   532,   534,   536,   538,   540,   542,   544,
+     546,   548,   550,   552,   554,   556,   558,   560,   562,   564,
+     566,   568,   570,   572,   574,   576,   578,   580,   582,   584,
+     586,   588,   590,   592,   594,   596,   598,   599,   603,   607,
+     608,   610,   614,   619,   624,   631,   638,   639,   641,   643,
+     645,   647,   650,   653,   655,   657,   659,   660,   662,   664,
+     666,   668,   669,   671,   673,   675,   677,   679,   681,   683,
+     685,   688,   690,   691,   693,   696,   699,   700,   703,   707,
+     712,   717,   720,   725,   726,   729,   732,   737,   742,   747,
+     753,   758,   759,   761,   763,   765,   769,   773,   778,   784,
+     786,   788,   792,   794,   797,   801,   802,   805,   808,   809,
+     814,   815,   818,   821,   823,   828,   833,   840,   842,   843,
+     845,   847,   851,   856,   860,   865,   872,   873,   876,   879,
+     882,   885,   888,   891,   893,   895,   899,   903,   905,   907,
+     909,   913,   917,   918,   920,   922,   926,   930,   934,   938,
+     940,   942,   944,   946,   948,   950,   952,   954,   957,   962,
+     967,   972,   978,   981,   984,   991,   998,  1003,  1013,  1023,
+    1031,  1038,  1045,  1050,  1060,  1070,  1078,  1083,  1090,  1097,
+    1107,  1117,  1124,  1126,  1128,  1130,  1132,  1134,  1136,  1138,
+    1140,  1144,  1145,  1147,  1152,  1154,  1158,  1161,  1165,  1167,
+    1171,  1174,  1179,  1181,  1183,  1185,  1187,  1189,  1191,  1193,
+    1195,  1200,  1204,  1208,  1211,  1214,  1216,  1218,  1220,  1222,
+    1224,  1226,  1228,  1233,  1238,  1243,  1247,  1251,  1255,  1259,
+    1264,  1268,  1270,  1272,  1274,  1276,  1280,  1284,  1288,  1292,
+    1298,  1302,  1306,  1310,  1314,  1318,  1322,  1326,  1330,  1334,
+    1338,  1342,  1346,  1350,  1354,  1358,  1362,  1366,  1370,  1374,
+    1378,  1382,  1386,  1390,  1393,  1396,  1399,  1402,  1405,  1408,
+    1412,  1416,  1420,  1424,  1428,  1432,  1436,  1440,  1442,  1444,
+    1446,  1448,  1450,  1452
+};
+
+/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
+static const yytype_int16 yyrhs[] =
+{
+     132,     0,    -1,   133,    -1,    -1,   133,   134,    -1,   136,
+      -1,   135,   136,    -1,    50,     7,    -1,   135,    50,     7,
+      -1,   137,    -1,   139,    -1,   141,    -1,   147,    -1,   142,
+      -1,   148,    -1,   151,    -1,   149,    -1,   152,    -1,   155,
+      -1,   146,    -1,   215,   116,    -1,    10,   136,    -1,    11,
+     216,   136,    -1,    12,   143,   116,    -1,    15,   216,   139,
+      -1,    19,   143,   116,    -1,    20,   223,   116,    -1,    36,
+     144,   136,    -1,    39,   136,    -1,    45,   223,   145,    -1,
+      59,   223,   145,    -1,    59,   145,    -1,    63,   136,    -1,
+      74,   223,   116,    -1,     1,    -1,   138,   144,   122,   123,
+      -1,   138,   144,   122,   140,   123,    -1,    41,    -1,   122,
+     123,    -1,   122,   140,   123,    -1,   134,    -1,   140,   134,
+      -1,    68,   204,   116,    -1,   224,    78,   223,   116,    -1,
+     224,    89,   223,   116,    -1,   224,    86,   223,   116,    -1,
+     224,    88,   223,   116,    -1,   224,    82,   223,   116,    -1,
+     224,    87,   223,   116,    -1,   224,    83,   223,   116,    -1,
+     224,    79,   223,   116,    -1,   224,    80,   223,   116,    -1,
+     224,    81,   223,   116,    -1,   224,    91,   223,   116,    -1,
+     224,    90,   223,   116,    -1,   224,   120,   223,   116,    -1,
+     224,    84,   223,   116,    -1,   224,    85,   223,   116,    -1,
+      -1,   144,    -1,     3,    -1,    22,   136,    -1,   139,    -1,
+      56,   116,    -1,    56,   223,   116,    -1,   116,    -1,   168,
+      -1,   156,    -1,   161,    -1,   188,    -1,   191,    -1,    27,
+       8,    -1,    22,   136,    72,   223,   116,    -1,    72,   223,
+     145,    -1,    16,   223,    31,   223,   216,   145,    -1,    16,
+     223,    31,   150,   216,   145,    -1,    16,   223,   216,   145,
+      -1,    28,   223,    31,   223,   145,    -1,    28,   223,    31,
+     150,   145,    -1,    28,   223,   145,    -1,    28,   150,   145,
+      -1,    28,    48,   144,    31,   223,   145,    -1,    29,   223,
+      31,   223,   145,    -1,    29,   223,    31,   223,   217,   145,
+      -1,    29,   223,    31,   150,   145,    -1,    29,   223,    31,
+     150,   217,   145,    -1,    29,   223,   145,    -1,    29,   223,
+     217,   145,    -1,   126,   204,    31,   223,   127,   136,    -1,
+     126,   204,    31,   223,   217,   127,   136,    -1,   126,   204,
+      31,   150,   127,   136,    -1,   126,   204,    31,   150,   217,
+     127,   136,    -1,   126,   204,   127,   136,    -1,   126,   204,
+     217,   127,   136,    -1,    75,   124,   204,   125,    -1,    30,
+     223,    64,   136,    -1,    30,   223,   139,    -1,    30,   223,
+      64,   136,    24,   136,    -1,    30,   223,   139,    24,   136,
+      -1,    58,   223,   122,   153,   123,    -1,    -1,   153,   154,
+      -1,    70,   204,   145,    -1,    46,   136,    -1,    65,    58,
+     204,   122,   153,   123,    -1,   157,   158,   144,   159,   122,
+     160,   123,    -1,    -1,    27,    -1,    14,    -1,    53,    -1,
+      67,    -1,    -1,    96,   204,    -1,    -1,   160,   147,    -1,
+     160,   135,   147,    -1,    25,   144,   122,   162,   123,    -1,
+     163,    -1,   162,    97,    -1,   162,    97,   163,    -1,   144,
+      -1,   144,    78,   223,    -1,    -1,    -1,    37,   165,   175,
+     166,   181,   199,   187,   183,    -1,    -1,    33,    -1,    26,
+      -1,    26,   144,    -1,    27,    -1,    27,   144,    -1,    -1,
+      -1,   167,   180,   169,   171,   170,   181,   199,   187,   182,
+      -1,   179,   172,   174,    -1,   179,   173,   174,    -1,   179,
+     144,    99,   172,   174,    -1,   179,   144,    99,   173,   174,
+      -1,   144,    -1,    93,   144,    -1,    92,    -1,    94,    -1,
+      95,    -1,    93,    -1,   102,    -1,   112,    -1,   108,    -1,
+     105,    -1,   107,    -1,   104,    -1,   114,    -1,   109,    -1,
+     119,    -1,    98,    -1,   117,    -1,   118,    -1,   110,    -1,
+     103,    -1,   111,    -1,    13,    -1,   106,    -1,     9,    -1,
+     120,    -1,   121,    -1,    78,    -1,    89,    -1,    86,    -1,
+      88,    -1,    82,    -1,    87,    -1,    83,    -1,    79,    -1,
+      80,    -1,    81,    -1,    91,    -1,    90,    -1,    -1,   124,
+     176,   125,    -1,   124,   176,   125,    -1,    -1,   177,    -1,
+     176,    97,   177,    -1,   178,   144,   203,   197,    -1,   178,
+     144,   203,   186,    -1,   178,   124,   196,   125,   203,   197,
+      -1,   178,   124,   196,   125,   203,   186,    -1,    -1,    31,
+      -1,    34,    -1,    47,    -1,    18,    -1,    18,    31,    -1,
+      18,    55,    -1,    48,    -1,    55,    -1,    65,    -1,    -1,
+      48,    -1,    55,    -1,    52,    -1,    35,    -1,    -1,    18,
+      -1,    55,    -1,    48,    -1,    65,    -1,   116,    -1,   183,
+      -1,   139,    -1,   146,    -1,   115,   144,    -1,   115,    -1,
+      -1,   184,    -1,   101,   223,    -1,   101,   185,    -1,    -1,
+      71,   223,    -1,    65,   189,   116,    -1,    17,    65,   189,
+     116,    -1,    27,    65,   189,   116,    -1,   144,   190,    -1,
+     144,   190,    97,   189,    -1,    -1,    78,   211,    -1,    78,
+     200,    -1,   192,    48,   193,   116,    -1,   192,    18,   193,
+     116,    -1,   192,    55,   193,   116,    -1,   192,    18,    55,
+     193,   116,    -1,   192,    69,   193,   116,    -1,    -1,    17,
+      -1,    27,    -1,   194,    -1,   193,    97,   194,    -1,   144,
+     199,   197,    -1,   144,   198,    76,   223,    -1,   124,   196,
+     125,   199,   197,    -1,    66,    -1,   144,    -1,   124,   196,
+     125,    -1,   195,    -1,   195,    97,    -1,   195,    97,   196,
+      -1,    -1,    78,    44,    -1,    78,   223,    -1,    -1,    96,
+     126,   204,   127,    -1,    -1,    96,   211,    -1,    96,   200,
+      -1,     1,    -1,   126,   204,   127,   211,    -1,   126,   204,
+     127,   200,    -1,   126,   204,    31,   223,   127,   211,    -1,
+       1,    -1,    -1,   211,    -1,   184,    -1,   126,   127,   201,
+      -1,   126,   204,   127,   201,    -1,   126,   127,   202,    -1,
+     126,   204,   127,   202,    -1,   126,   204,    31,   223,   127,
+     201,    -1,    -1,    96,   211,    -1,    96,   184,    -1,    96,
+      23,    -1,    96,    60,    -1,    96,    63,    -1,    96,   202,
+      -1,   223,    -1,   184,    -1,   204,    97,   223,    -1,   204,
+      97,   184,    -1,    66,    -1,   223,    -1,   184,    -1,   205,
+      97,   205,    -1,   206,    97,   205,    -1,    -1,   208,    -1,
+     209,    -1,   208,    97,   209,    -1,   144,    78,   184,    -1,
+     144,    78,   223,    -1,   144,    76,   223,    -1,   184,    -1,
+     223,    -1,   144,    -1,   214,    -1,   224,    -1,   213,    -1,
+     232,    -1,   231,    -1,    60,   223,    -1,    32,   124,   207,
+     125,    -1,    23,   124,   207,   125,    -1,    62,   124,   207,
+     125,    -1,    61,    62,   124,   207,   125,    -1,    10,   223,
+      -1,    63,   223,    -1,    28,   223,    31,   223,    22,   223,
+      -1,    28,   223,    31,   150,    22,   223,    -1,    28,   223,
+      22,   223,    -1,    28,   223,    31,   223,    22,    30,   223,
+      64,   223,    -1,    28,   223,    31,   150,    22,    30,   223,
+      64,   223,    -1,    28,   223,    22,    30,   223,    64,   223,
+      -1,    29,   223,    31,   223,    22,   223,    -1,    29,   223,
+      31,   150,    22,   223,    -1,    29,   223,    22,   223,    -1,
+      29,   223,    31,   223,    22,    30,   223,    64,   223,    -1,
+      29,   223,    31,   150,    22,    30,   223,    64,   223,    -1,
+      29,   223,    22,    30,   223,    64,   223,    -1,   126,   204,
+     127,   223,    -1,   126,   204,    31,   223,   127,   223,    -1,
+     126,   204,    31,   150,   127,   223,    -1,   126,   204,    31,
+     223,   127,    30,   223,    64,   223,    -1,   126,   204,    31,
+     150,   127,    30,   223,    64,   223,    -1,    30,   223,    64,
+     223,    24,   223,    -1,    43,    -1,   214,    -1,   210,    -1,
+     227,    -1,   226,    -1,   164,    -1,   221,    -1,   222,    -1,
+     220,   121,   223,    -1,    -1,   217,    -1,    73,   124,   218,
+     125,    -1,   219,    -1,   218,    97,   219,    -1,   178,   210,
+      -1,   235,    54,   210,    -1,   224,    -1,   220,   121,   223,
+      -1,    42,   223,    -1,    38,   193,    31,   223,    -1,   229,
+      -1,   211,    -1,   212,    -1,   233,    -1,   234,    -1,   164,
+      -1,   221,    -1,   222,    -1,   124,   101,   223,   125,    -1,
+     223,    96,   223,    -1,   223,   100,   223,    -1,   223,   100,
+      -1,   100,   223,    -1,   100,    -1,   210,    -1,   226,    -1,
+     227,    -1,   228,    -1,   224,    -1,   164,    -1,   225,   124,
+     207,   125,    -1,   225,   126,   207,   127,    -1,    51,   124,
+     207,   125,    -1,   223,    99,   144,    -1,   223,    99,    65,
+      -1,   223,    99,    23,    -1,   124,   205,   125,    -1,   124,
+     205,    97,   125,    -1,   124,   206,   125,    -1,     4,    -1,
+       5,    -1,     6,    -1,     7,    -1,   122,   204,   123,    -1,
+     126,   204,   127,    -1,   126,   230,   127,    -1,   223,    76,
+     223,    -1,   230,    97,   223,    76,   223,    -1,   223,   114,
+     223,    -1,   223,   109,   223,    -1,   223,   119,   223,    -1,
+     223,    98,   223,    -1,   223,   117,   223,    -1,   223,   118,
+     223,    -1,   223,   110,   223,    -1,   223,   102,   223,    -1,
+     223,   112,   223,    -1,   223,   108,   223,    -1,   223,   105,
+     223,    -1,   223,   107,   223,    -1,   223,   104,   223,    -1,
+     223,    92,   223,    -1,   223,    94,   223,    -1,   223,    95,
+     223,    -1,   223,    77,   223,    -1,   223,   113,   223,    -1,
+     223,   103,   223,    -1,   223,    13,   223,    -1,   223,     9,
+     223,    -1,   223,   106,   223,    -1,   223,    21,   223,    -1,
+     114,   223,    -1,   109,   223,    -1,    40,   223,    -1,    49,
+     223,    -1,   111,   223,    -1,    93,   223,    -1,   223,    54,
+     223,    -1,   223,    54,   150,    -1,   235,    54,   223,    -1,
+     235,    54,   150,    -1,   223,    57,   223,    -1,   223,    57,
+     150,    -1,   235,    57,   223,    -1,   235,    57,   150,    -1,
+     114,    -1,   119,    -1,    77,    -1,   113,    -1,    92,    -1,
+      94,    -1,    95,    -1
+};
+
+/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   399,   399,   404,   405,   411,   412,   417,   418,   423,
-     424,   425,   426,   427,   428,   429,   430,   431,   432,   433,
-     434,   435,   436,   437,   438,   439,   440,   441,   442,   443,
-     444,   445,   446,   447,   448,   452,   454,   459,   474,   475,
-     480,   481,   486,   490,   491,   492,   493,   494,   495,   496,
-     497,   498,   499,   500,   501,   502,   503,   504,   508,   509,
-     513,   517,   518,   522,   523,   527,   528,   529,   530,   531,
-     532,   536,   551,   552,   553,   554,   555,   556,   557,   558,
-     559,   560,   561,   562,   563,   564,   565,   566,   567,   573,
-     579,   585,   591,   598,   608,   612,   613,   614,   615,   619,
-     624,   625,   629,   631,   636,   643,   648,   649,   653,   658,
-     663,   671,   672,   677,   678,   680,   685,   695,   704,   708,
-     716,   717,   722,   727,   721,   752,   758,   765,   773,   781,
-     789,   800,   806,   799,   834,   838,   843,   847,   855,   856,
-     857,   858,   859,   860,   861,   862,   863,   864,   865,   866,
-     867,   868,   869,   870,   871,   872,   873,   874,   875,   876,
-     877,   878,   879,   880,   884,   885,   886,   887,   888,   889,
-     890,   891,   892,   893,   894,   895,   899,   900,   904,   908,
-     909,   910,   914,   916,   918,   920,   925,   926,   927,   928,
-     929,   930,   931,   932,   933,   934,   938,   939,   940,   944,
-     945,   949,   950,   951,   952,   953,   957,   958,   962,   963,
-     967,   969,   974,   975,   979,   980,   984,   985,   989,   991,
-     993,   998,  1011,  1028,  1029,  1031,  1036,  1043,  1050,  1057,
-    1065,  1074,  1075,  1076,  1080,  1081,  1089,  1091,  1097,  1102,
-    1104,  1106,  1111,  1113,  1115,  1122,  1123,  1124,  1128,  1129,
-    1134,  1135,  1136,  1137,  1157,  1161,  1165,  1173,  1177,  1178,
-    1179,  1183,  1185,  1191,  1193,  1195,  1200,  1201,  1202,  1203,
-    1204,  1205,  1206,  1212,  1213,  1214,  1215,  1219,  1220,  1221,
-    1225,  1226,  1230,  1231,  1235,  1236,  1240,  1241,  1242,  1243,
-    1244,  1248,  1259,  1260,  1261,  1262,  1263,  1264,  1266,  1268,
-    1270,  1272,  1274,  1276,  1281,  1283,  1285,  1287,  1289,  1291,
-    1293,  1295,  1297,  1299,  1301,  1303,  1305,  1312,  1318,  1324,
-    1330,  1339,  1344,  1352,  1353,  1354,  1355,  1356,  1357,  1358,
-    1359,  1364,  1365,  1369,  1373,  1375,  1383,  1393,  1397,  1398,
-    1403,  1408,  1416,  1417,  1418,  1419,  1420,  1421,  1422,  1423,
-    1424,  1426,  1428,  1430,  1432,  1434,  1439,  1440,  1441,  1442,
-    1453,  1454,  1458,  1459,  1460,  1464,  1465,  1466,  1474,  1475,
-    1476,  1480,  1481,  1482,  1483,  1484,  1485,  1486,  1493,  1494,
-    1498,  1499,  1500,  1501,  1502,  1503,  1504,  1505,  1506,  1507,
-    1508,  1509,  1510,  1511,  1512,  1513,  1514,  1515,  1516,  1517,
-    1518,  1519,  1520,  1524,  1525,  1526,  1527,  1528,  1529,  1533,
-    1534,  1535,  1536,  1540,  1541,  1542,  1543,  1548,  1549,  1550,
-    1551,  1552,  1553,  1554
+       0,   400,   400,   405,   406,   412,   413,   418,   419,   424,
+     425,   426,   427,   428,   429,   430,   431,   432,   433,   434,
+     435,   436,   437,   438,   439,   440,   441,   442,   443,   444,
+     445,   446,   447,   448,   449,   453,   455,   460,   475,   476,
+     481,   482,   487,   491,   492,   493,   494,   495,   496,   497,
+     498,   499,   500,   501,   502,   503,   504,   505,   509,   510,
+     514,   518,   519,   523,   524,   528,   529,   530,   531,   532,
+     533,   537,   552,   553,   554,   555,   556,   557,   558,   559,
+     560,   561,   562,   563,   564,   565,   566,   567,   568,   574,
+     580,   586,   592,   599,   609,   613,   614,   615,   616,   620,
+     625,   626,   630,   632,   637,   644,   649,   650,   654,   659,
+     664,   672,   673,   678,   679,   681,   686,   696,   705,   709,
+     717,   718,   723,   728,   722,   753,   759,   766,   774,   782,
+     790,   801,   807,   800,   835,   839,   844,   848,   856,   857,
+     858,   859,   860,   861,   862,   863,   864,   865,   866,   867,
+     868,   869,   870,   871,   872,   873,   874,   875,   876,   877,
+     878,   879,   880,   881,   885,   886,   887,   888,   889,   890,
+     891,   892,   893,   894,   895,   896,   900,   901,   905,   909,
+     910,   911,   915,   917,   919,   921,   926,   927,   928,   929,
+     930,   931,   932,   933,   934,   935,   939,   940,   941,   945,
+     946,   950,   951,   952,   953,   954,   958,   959,   963,   964,
+     968,   970,   975,   976,   980,   981,   985,   986,   990,   992,
+     994,   999,  1012,  1029,  1030,  1032,  1037,  1044,  1051,  1058,
+    1066,  1075,  1076,  1077,  1081,  1082,  1090,  1092,  1098,  1103,
+    1105,  1107,  1112,  1114,  1116,  1123,  1124,  1125,  1129,  1130,
+    1135,  1136,  1137,  1138,  1158,  1162,  1166,  1174,  1178,  1179,
+    1180,  1184,  1186,  1192,  1194,  1196,  1201,  1202,  1203,  1204,
+    1205,  1206,  1207,  1213,  1214,  1215,  1216,  1220,  1221,  1222,
+    1226,  1227,  1231,  1232,  1236,  1237,  1241,  1242,  1243,  1244,
+    1245,  1249,  1260,  1261,  1262,  1263,  1264,  1265,  1267,  1269,
+    1271,  1273,  1275,  1277,  1282,  1284,  1286,  1288,  1290,  1292,
+    1294,  1296,  1298,  1300,  1302,  1304,  1306,  1313,  1319,  1325,
+    1331,  1340,  1345,  1353,  1354,  1355,  1356,  1357,  1358,  1359,
+    1360,  1365,  1366,  1370,  1374,  1376,  1384,  1394,  1398,  1399,
+    1404,  1409,  1417,  1418,  1419,  1420,  1421,  1422,  1423,  1424,
+    1425,  1427,  1429,  1431,  1433,  1435,  1440,  1441,  1442,  1443,
+    1454,  1455,  1459,  1460,  1461,  1465,  1466,  1467,  1475,  1476,
+    1477,  1481,  1482,  1483,  1484,  1485,  1486,  1487,  1494,  1495,
+    1499,  1500,  1501,  1502,  1503,  1504,  1505,  1506,  1507,  1508,
+    1509,  1510,  1511,  1512,  1513,  1514,  1515,  1516,  1517,  1518,
+    1519,  1520,  1521,  1525,  1526,  1527,  1528,  1529,  1530,  1534,
+    1535,  1536,  1537,  1541,  1542,  1543,  1544,  1549,  1550,  1551,
+    1552,  1553,  1554,  1555
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 0
+#if YYDEBUG || YYERROR_VERBOSE || YYTOKEN_TABLE
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
@@ -813,7 +1031,7 @@ static const char *const yytname[] =
   "THASH", "TLESS", "TLESSEQUAL", "TMINUS", "TMOD", "TNOT", "TNOTEQUAL",
   "TOR", "TPLUS", "TQUESTION", "TSEMI", "TSHIFTLEFT", "TSHIFTRIGHT",
   "TSTAR", "TSWAP", "TIO", "TLCBR", "TRCBR", "TLP", "TRP", "TLSBR",
-  "TRSBR", "TNOELSE", "TUPLUS", "TUMINUS", "$accept", "program",
+  "TRSBR", "TNOELSE", "TUMINUS", "TUPLUS", "$accept", "program",
   "toplevel_stmt_ls", "toplevel_stmt", "pragma_ls", "stmt",
   "module_decl_stmt", "module", "block_stmt", "stmt_ls", "use_stmt",
   "assignment_stmt", "opt_ident", "ident", "do_stmt", "return_stmt",
@@ -839,13 +1057,13 @@ static const char *const yytname[] =
   "task_intent_ls", "intent_expr", "io_expr", "new_expr", "let_expr",
   "expr", "lhs_expr", "fun_expr", "call_expr", "dot_expr",
   "parenthesized_expr", "literal_expr", "assoc_expr_ls", "binary_op_expr",
-  "unary_op_expr", "reduce_expr", "scan_expr", "reduce_scan_op_expr", YY_NULLPTR
+  "unary_op_expr", "reduce_expr", "scan_expr", "reduce_scan_op_expr", 0
 };
 #endif
 
 # ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
+/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
+   token YYLEX-NUM.  */
 static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
@@ -865,106 +1083,105 @@ static const yytype_uint16 yytoknum[] =
 };
 # endif
 
-#define YYPACT_NINF -713
-
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-713)))
-
-#define YYTABLE_NINF -377
-
-#define yytable_value_is_error(Yytable_value) \
-  0
-
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
-static const yytype_int16 yypact[] =
+/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+static const yytype_uint8 yyr1[] =
 {
-    -713,    85,  2391,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
-    3398,    55,    94,    55,  6098,   130,    94,  6098,  3398,    76,
-      94,    94,   988,  2175,  6098,  6098,    77,  -713,    94,  -713,
-      15,  3398,  6098,  -713,  6098,  -713,  6098,  6098,   202,   139,
-    5318,  6098,  5442,  6098,   242,   196,  3398,    89,  5520,  6098,
-    6098,  -713,  -713,  6098,  -713,  -713,  6800,  6098,  6098,  -713,
-    6098,  -713,  -713,  2654,  5018,  5520,  -713,  3274,  -713,  -713,
-      94,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
-    -713,  -713,  -713,   111,  -713,   233,   240,  -713,  -713,  -713,
-     241,   209,  -713,  -713,  -713,   214,   235,   231,   245,   246,
-   10784,  1565,   153,   266,   282,  -713,  -713,  -713,  -713,  -713,
-    -713,   285,  -713, 10784,   232,  3398,  -713,   290,  -713,   299,
-    6098,  6098,  6098,  6098,  6098,  5520,  5520,   191,  -713,  -713,
-    -713,  -713,  8342,   275,  -713,  -713,    94,   296,  8540,   341,
-    5520,   300,  -713,  -713,    94,  -713,    94,   307,    13,  7316,
-    7282,  7484,  5520,  3398,   315,    20,    74,     3,  -713,  -713,
-     346,   342,  7550,   346,  -713,  5520,  -713,  8606,  8210,  3398,
-    -713,  -713,  7550, 10784,   323,  5520,  -713, 10784,  5520,   370,
-     334,    94,  -713,    82, 10784,  7550,  8672,   244,  1211,   346,
-     244,   346,  -713,  -713,  2778,    80,  -713,  6098,  -713,   -46,
-     -23, 10784,    56,  8738,    -6,   445,  -713,   331,  -713,  -713,
-    -713,    94,  -713,  -713,  -713,     7,    15,    15,    15,  -713,
-    6098,  6098,  6098,  6098,  5620,  5620,  6098,  6098,  6098,  6098,
-    6098,  6098,    67,  6800,  6098,  6098,  6098,  6098,  6098,  6098,
-    6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,
-    6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,
-    6098,  6098,  6098,  6098,  5520,  5520,  5620,  5620,   569,  -713,
-    -713,  2902,  -713,  8408,  8474,  8804,    70,  5620,    13,   338,
-    -713,  -713,  6098,   326,  -713,   333,   362,  -713, 10784,    94,
-     347,   436,  5520,  -713,  3522,  5620,  -713,  3646,  5620,  -713,
-      13,  3398,   448,   352,  -713,    34,  -713,  -713,    20,  -713,
-     372,   353,  -713,  4762,   406,   405,  6098,    15,  -713,   359,
-    -713,  -713,  -713,  -713,  5520,   360,    69,  4840,   389,  -713,
-    -713,  5520,  -713,  -713,  -713,  -713,  -713,  -713,  7180,  5118,
-    -713,  5218,  -713,  5620,  2530,   364,  6098,  6098,  -713,  -713,
-    3026,   399,   254,    15,   164,   167,   179,   181,  8276,   867,
-     867,   291,  -713,   291,  -713,   291,  7112,   278,  1319,  1385,
-     342,   244,  -713,  -713,  -713,  1211, 10812,   291,   748,   748,
-     867,   748,   748,   779,   244, 10812,  2253,   779,   346,   346,
-     244,  8870,  8936,  9002,  9068,  9134,  9200,  9266,  9332,  9398,
-    9464,  9530,  9596,  9662,  9728,  9794,   373,   374,  -713,   291,
-    -713,   291,    93,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
-      94,    60,  -713,   449,  6176,  5620,  6254,  5620,  6098,  5620,
-    6978,    55,  9860,  -713,  -713,  9926,  6098,  5520,  -713,  5520,
-     421,   163,  -713,  -713,  6098,    63,  6098, 10784,    41,  7616,
-    6098, 10784,    23,  7418,  -713,   480,  9992,  3398,  -713,    83,
-    -713,    17,   263,   380,    20,    40,  -713,  5520,  -713,   431,
-    6098,  5720,  -713, 10784,  -713,  -713,    -4,   383,  -713,  -713,
-    5520,  -713,   208,    94,  -713, 10784,  -713,  -713,  -713,  -713,
-     -24,  1135,  -713, 10784,  3398, 10784, 10058,  -713,  3150,  5520,
-     388,  -713,  -713,  -713,  7033,   222,  -713,  -713,  -713,  -713,
-    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
-    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
-     569,  -713,    94,  6098,   489, 10124,  6098,   490, 10190,   386,
-    2219,    13,    13,  -713, 10784,  -713, 10784,  -713,  6098,    94,
-    -713,  7550,  -713,  7682,  3770,  -713,  3894,  -713,  7748,  4018,
-    -713,    13,  4142,  -713,    13,  3398,  6098,  -713,   544,  -713,
-      20,   419,  -713,  -713,  -713,  -713,    24,  -713,  -713,  4840,
-     405,    75, 10784,  -713, 10784,  3398,  5520,  -713,  -713,  -713,
-      38,    78,  -713,  4266,   390,  4390,   391,  -713,  6098,  -713,
-     422,  -713,   263,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
-    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,    94,  -713,
-    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
-    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,   423,
-     396,   396,  -713,  -713,  -713, 10256,  6332,  6410, 10322,  6488,
-    6566,  6644,  6722,  -713,  -713, 10784,  -713,  -713,  3398,  6098,
-   10784,  6098, 10784,  3398,  6098, 10784,  -713,  6098, 10784,  -713,
-    -713, 10784,  -713,   400,  5798,    81,   456,  -713,  5620,  4514,
-    -713,    54,  -713,  4638,  6098,  -713, 10784,  3398,  6098,  -713,
-   10784,  3398, 10784,   358,    27,  -713,  7033,    34,  -713,  -713,
-    6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  9992,  7814,
-    7880,  9992,  7946,  8012,   419,    76,  6098,  6098,  4918,  -713,
-    -713,   225,  5520,  -713,  -713,  6098,    32,  6955,  -713,   534,
-    -713,  8078,  -713,  8144,  -713,   313,    94,  -713,   507,  -713,
-     456,  -713,   396,   396,   165, 10388, 10454, 10520, 10586, 10652,
-   10718,  3398,  3398,  3398,  3398,    81,  5898,    95,  -713,  -713,
-   10784, 10784,  -713,  -713,  -713,  6722,  3398,  3398,  -713,    11,
-    -713,  -713,  -713,  6098,  6098,  6098,  6098,  6098,  6098,  9992,
-    9992,  9992,  9992,  -713,  -713,  -713,  -713,  -713,   308,  5620,
-    6878,   550,  9992,  9992,  -713,  -713,  -713,  7146,  -713,  -713,
-    5998,  -713
+       0,   131,   132,   133,   133,   134,   134,   135,   135,   136,
+     136,   136,   136,   136,   136,   136,   136,   136,   136,   136,
+     136,   136,   136,   136,   136,   136,   136,   136,   136,   136,
+     136,   136,   136,   136,   136,   137,   137,   138,   139,   139,
+     140,   140,   141,   142,   142,   142,   142,   142,   142,   142,
+     142,   142,   142,   142,   142,   142,   142,   142,   143,   143,
+     144,   145,   145,   146,   146,   147,   147,   147,   147,   147,
+     147,   148,   149,   149,   149,   149,   149,   149,   149,   149,
+     149,   149,   149,   149,   149,   149,   149,   149,   149,   149,
+     149,   149,   149,   149,   150,   151,   151,   151,   151,   152,
+     153,   153,   154,   154,   155,   156,   157,   157,   158,   158,
+     158,   159,   159,   160,   160,   160,   161,   162,   162,   162,
+     163,   163,   165,   166,   164,   167,   167,   167,   167,   167,
+     167,   169,   170,   168,   171,   171,   171,   171,   172,   172,
+     172,   172,   172,   172,   172,   172,   172,   172,   172,   172,
+     172,   172,   172,   172,   172,   172,   172,   172,   172,   172,
+     172,   172,   172,   172,   173,   173,   173,   173,   173,   173,
+     173,   173,   173,   173,   173,   173,   174,   174,   175,   176,
+     176,   176,   177,   177,   177,   177,   178,   178,   178,   178,
+     178,   178,   178,   178,   178,   178,   179,   179,   179,   180,
+     180,   181,   181,   181,   181,   181,   182,   182,   183,   183,
+     184,   184,   185,   185,   186,   186,   187,   187,   188,   188,
+     188,   189,   189,   190,   190,   190,   191,   191,   191,   191,
+     191,   192,   192,   192,   193,   193,   194,   194,   194,   195,
+     195,   195,   196,   196,   196,   197,   197,   197,   198,   198,
+     199,   199,   199,   199,   200,   200,   200,   200,   201,   201,
+     201,   202,   202,   202,   202,   202,   203,   203,   203,   203,
+     203,   203,   203,   204,   204,   204,   204,   205,   205,   205,
+     206,   206,   207,   207,   208,   208,   209,   209,   209,   209,
+     209,   210,   211,   211,   211,   211,   211,   211,   211,   211,
+     211,   211,   211,   211,   212,   212,   212,   212,   212,   212,
+     212,   212,   212,   212,   212,   212,   212,   212,   212,   212,
+     212,   213,   214,   215,   215,   215,   215,   215,   215,   215,
+     215,   216,   216,   217,   218,   218,   219,   219,   220,   220,
+     221,   222,   223,   223,   223,   223,   223,   223,   223,   223,
+     223,   223,   223,   223,   223,   223,   224,   224,   224,   224,
+     225,   225,   226,   226,   226,   227,   227,   227,   228,   228,
+     228,   229,   229,   229,   229,   229,   229,   229,   230,   230,
+     231,   231,   231,   231,   231,   231,   231,   231,   231,   231,
+     231,   231,   231,   231,   231,   231,   231,   231,   231,   231,
+     231,   231,   231,   232,   232,   232,   232,   232,   232,   233,
+     233,   233,   233,   234,   234,   234,   234,   235,   235,   235,
+     235,   235,   235,   235
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
+/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
+static const yytype_uint8 yyr2[] =
+{
+       0,     2,     1,     0,     2,     1,     2,     2,     3,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       2,     2,     3,     3,     3,     3,     3,     3,     2,     3,
+       3,     2,     2,     3,     1,     4,     5,     1,     2,     3,
+       1,     2,     3,     4,     4,     4,     4,     4,     4,     4,
+       4,     4,     4,     4,     4,     4,     4,     4,     0,     1,
+       1,     2,     1,     2,     3,     1,     1,     1,     1,     1,
+       1,     2,     5,     3,     6,     6,     4,     5,     5,     3,
+       3,     6,     5,     6,     5,     6,     3,     4,     6,     7,
+       6,     7,     4,     5,     4,     4,     3,     6,     5,     5,
+       0,     2,     3,     2,     6,     7,     0,     1,     1,     1,
+       1,     0,     2,     0,     2,     3,     5,     1,     2,     3,
+       1,     3,     0,     0,     8,     0,     1,     1,     2,     1,
+       2,     0,     0,     9,     3,     3,     5,     5,     1,     2,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     0,     3,     3,     0,
+       1,     3,     4,     4,     6,     6,     0,     1,     1,     1,
+       1,     2,     2,     1,     1,     1,     0,     1,     1,     1,
+       1,     0,     1,     1,     1,     1,     1,     1,     1,     1,
+       2,     1,     0,     1,     2,     2,     0,     2,     3,     4,
+       4,     2,     4,     0,     2,     2,     4,     4,     4,     5,
+       4,     0,     1,     1,     1,     3,     3,     4,     5,     1,
+       1,     3,     1,     2,     3,     0,     2,     2,     0,     4,
+       0,     2,     2,     1,     4,     4,     6,     1,     0,     1,
+       1,     3,     4,     3,     4,     6,     0,     2,     2,     2,
+       2,     2,     2,     1,     1,     3,     3,     1,     1,     1,
+       3,     3,     0,     1,     1,     3,     3,     3,     3,     1,
+       1,     1,     1,     1,     1,     1,     1,     2,     4,     4,
+       4,     5,     2,     2,     6,     6,     4,     9,     9,     7,
+       6,     6,     4,     9,     9,     7,     4,     6,     6,     9,
+       9,     6,     1,     1,     1,     1,     1,     1,     1,     1,
+       3,     0,     1,     4,     1,     3,     2,     3,     1,     3,
+       2,     4,     1,     1,     1,     1,     1,     1,     1,     1,
+       4,     3,     3,     2,     2,     1,     1,     1,     1,     1,
+       1,     1,     4,     4,     4,     3,     3,     3,     3,     4,
+       3,     1,     1,     1,     1,     3,     3,     3,     3,     5,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     2,     2,     2,     2,     2,     2,     3,
+       3,     3,     3,     3,     3,     3,     3,     1,     1,     1,
+       1,     1,     1,     1
+};
+
+/* YYDEFACT[STATE-NAME] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE doesn't specify something else to do.  Zero
+   means the default is an error.  */
 static const yytype_uint16 yydefact[] =
 {
        3,     0,     0,     1,    34,    60,   371,   372,   373,   374,
@@ -1050,23 +1267,7 @@ static const yytype_uint16 yydefact[] =
      258,   265
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
-static const yytype_int16 yypgoto[] =
-{
-    -713,  -713,  -713,    -1,  -162,  1697,  -713,  -713,  1403,   185,
-    -713,  -713,   520,  1794,   344,  -705,  -616,  -713,  -713,    46,
-    -713,  -713,    58,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
-    -713,  -713,    -8,   433,  -713,  -713,  -713,  -713,  -713,  -713,
-    -713,  -153,  -151,  -569,  -713,  -158,   -18,  -257,  -713,  -713,
-     -51,  -713,  -215,    29,  -713,  -197,  -179,  -713,  -128,  -713,
-    -713,  -713,  -157,   247,  -713,  -302,  -571,  -713,  -436,  -325,
-    -601,  -712,  -148,     8,    91,  -713,   -58,  -713,   124,   361,
-    -310,  -713,  -713,   707,  -713,     6,  -145,  -713,    37,  -713,
-     789,  1025,   -10,  1107,  -713,  1340,  1423,  -713,  -713,  -713,
-    -713,  -713,  -713,  -713,  -256
-};
-
-  /* YYDEFGOTO[NTERM-NUM].  */
+/* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
       -1,     1,     2,   193,    67,   455,    69,    70,    71,   194,
@@ -1082,9 +1283,114 @@ static const yytype_int16 yydefgoto[] =
      107,   108,   109,   110,   111
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
+#define YYPACT_NINF -713
+static const yytype_int16 yypact[] =
+{
+    -713,    85,  2391,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
+    3398,    55,    94,    55,  6098,   130,    94,  6098,  3398,    76,
+      94,    94,   988,  2175,  6098,  6098,    77,  -713,    94,  -713,
+      15,  3398,  6098,  -713,  6098,  -713,  6098,  6098,   202,   139,
+    5318,  6098,  5442,  6098,   242,   196,  3398,    89,  5520,  6098,
+    6098,  -713,  -713,  6098,  -713,  -713,  6800,  6098,  6098,  -713,
+    6098,  -713,  -713,  2654,  5018,  5520,  -713,  3274,  -713,  -713,
+      94,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
+    -713,  -713,  -713,   111,  -713,   233,   240,  -713,  -713,  -713,
+     241,   209,  -713,  -713,  -713,   214,   235,   231,   245,   246,
+   10784,  1565,   153,   266,   282,  -713,  -713,  -713,  -713,  -713,
+    -713,   285,  -713, 10784,   232,  3398,  -713,   290,  -713,   299,
+    6098,  6098,  6098,  6098,  6098,  5520,  5520,   191,  -713,  -713,
+    -713,  -713,  8342,   275,  -713,  -713,    94,   296,  8540,   341,
+    5520,   300,  -713,  -713,    94,  -713,    94,   307,    13,  7316,
+    7282,  7484,  5520,  3398,   315,    20,    74,     3,  -713,  -713,
+     346,   342,  7550,   346,  -713,  5520,  -713,  8606,  8210,  3398,
+    -713,  -713,  7550, 10784,   323,  5520,  -713, 10784,  5520,   370,
+     334,    94,  -713,    82, 10784,  7550,  8672,   244,  1211,   346,
+     244,   346,  -713,  -713,  2778,    80,  -713,  6098,  -713,   -46,
+     -23, 10784,    56,  8738,    -6,   445,  -713,   331,  -713,  -713,
+    -713,    94,  -713,  -713,  -713,     7,    15,    15,    15,  -713,
+    6098,  6098,  6098,  6098,  5620,  5620,  6098,  6098,  6098,  6098,
+    6098,  6098,    67,  6800,  6098,  6098,  6098,  6098,  6098,  6098,
+    6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,
+    6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,
+    6098,  6098,  6098,  6098,  5520,  5520,  5620,  5620,   569,  -713,
+    -713,  2902,  -713,  8408,  8474,  8804,    70,  5620,    13,   338,
+    -713,  -713,  6098,   326,  -713,   333,   362,  -713, 10784,    94,
+     347,   436,  5520,  -713,  3522,  5620,  -713,  3646,  5620,  -713,
+      13,  3398,   448,   352,  -713,    34,  -713,  -713,    20,  -713,
+     372,   353,  -713,  4762,   406,   405,  6098,    15,  -713,   359,
+    -713,  -713,  -713,  -713,  5520,   360,    69,  4840,   389,  -713,
+    -713,  5520,  -713,  -713,  -713,  -713,  -713,  -713,  7180,  5118,
+    -713,  5218,  -713,  5620,  2530,   364,  6098,  6098,  -713,  -713,
+    3026,   399,   254,    15,   164,   167,   179,   181,  8276,   867,
+     867,   291,  -713,   291,  -713,   291,  7112,   278,  1319,  1385,
+     342,   244,  -713,  -713,  -713,  1211, 10812,   291,   748,   748,
+     867,   748,   748,   779,   244, 10812,  2253,   779,   346,   346,
+     244,  8870,  8936,  9002,  9068,  9134,  9200,  9266,  9332,  9398,
+    9464,  9530,  9596,  9662,  9728,  9794,   373,   374,  -713,   291,
+    -713,   291,    93,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
+      94,    60,  -713,   449,  6176,  5620,  6254,  5620,  6098,  5620,
+    6978,    55,  9860,  -713,  -713,  9926,  6098,  5520,  -713,  5520,
+     421,   163,  -713,  -713,  6098,    63,  6098, 10784,    41,  7616,
+    6098, 10784,    23,  7418,  -713,   480,  9992,  3398,  -713,    83,
+    -713,    17,   263,   380,    20,    40,  -713,  5520,  -713,   431,
+    6098,  5720,  -713, 10784,  -713,  -713,    -4,   383,  -713,  -713,
+    5520,  -713,   208,    94,  -713, 10784,  -713,  -713,  -713,  -713,
+     -24,  1135,  -713, 10784,  3398, 10784, 10058,  -713,  3150,  5520,
+     388,  -713,  -713,  -713,  7033,   222,  -713,  -713,  -713,  -713,
+    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
+    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
+     569,  -713,    94,  6098,   489, 10124,  6098,   490, 10190,   386,
+    2219,    13,    13,  -713, 10784,  -713, 10784,  -713,  6098,    94,
+    -713,  7550,  -713,  7682,  3770,  -713,  3894,  -713,  7748,  4018,
+    -713,    13,  4142,  -713,    13,  3398,  6098,  -713,   544,  -713,
+      20,   419,  -713,  -713,  -713,  -713,    24,  -713,  -713,  4840,
+     405,    75, 10784,  -713, 10784,  3398,  5520,  -713,  -713,  -713,
+      38,    78,  -713,  4266,   390,  4390,   391,  -713,  6098,  -713,
+     422,  -713,   263,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
+    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,    94,  -713,
+    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
+    -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,  -713,   423,
+     396,   396,  -713,  -713,  -713, 10256,  6332,  6410, 10322,  6488,
+    6566,  6644,  6722,  -713,  -713, 10784,  -713,  -713,  3398,  6098,
+   10784,  6098, 10784,  3398,  6098, 10784,  -713,  6098, 10784,  -713,
+    -713, 10784,  -713,   400,  5798,    81,   456,  -713,  5620,  4514,
+    -713,    54,  -713,  4638,  6098,  -713, 10784,  3398,  6098,  -713,
+   10784,  3398, 10784,   358,    27,  -713,  7033,    34,  -713,  -713,
+    6098,  6098,  6098,  6098,  6098,  6098,  6098,  6098,  9992,  7814,
+    7880,  9992,  7946,  8012,   419,    76,  6098,  6098,  4918,  -713,
+    -713,   225,  5520,  -713,  -713,  6098,    32,  6955,  -713,   534,
+    -713,  8078,  -713,  8144,  -713,   313,    94,  -713,   507,  -713,
+     456,  -713,   396,   396,   165, 10388, 10454, 10520, 10586, 10652,
+   10718,  3398,  3398,  3398,  3398,    81,  5898,    95,  -713,  -713,
+   10784, 10784,  -713,  -713,  -713,  6722,  3398,  3398,  -713,    11,
+    -713,  -713,  -713,  6098,  6098,  6098,  6098,  6098,  6098,  9992,
+    9992,  9992,  9992,  -713,  -713,  -713,  -713,  -713,   308,  5620,
+    6878,   550,  9992,  9992,  -713,  -713,  -713,  7146,  -713,  -713,
+    5998,  -713
+};
+
+/* YYPGOTO[NTERM-NUM].  */
+static const yytype_int16 yypgoto[] =
+{
+    -713,  -713,  -713,    -1,  -162,  1697,  -713,  -713,  1403,   185,
+    -713,  -713,   520,  1794,   344,  -705,  -616,  -713,  -713,    46,
+    -713,  -713,    58,  -713,  -713,  -713,  -713,  -713,  -713,  -713,
+    -713,  -713,    -8,   433,  -713,  -713,  -713,  -713,  -713,  -713,
+    -713,  -153,  -151,  -569,  -713,  -158,   -18,  -257,  -713,  -713,
+     -51,  -713,  -215,    29,  -713,  -197,  -179,  -713,  -128,  -713,
+    -713,  -713,  -157,   247,  -713,  -302,  -571,  -713,  -436,  -325,
+    -601,  -712,  -148,     8,    91,  -713,   -58,  -713,   124,   361,
+    -310,  -713,  -713,   707,  -713,     6,  -145,  -713,    37,  -713,
+     789,  1025,   -10,  1107,  -713,  1340,  1423,  -713,  -713,  -713,
+    -713,  -713,  -713,  -713,  -256
+};
+
+/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule which
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
+#define YYTABLE_NINF -377
 static const yytype_int16 yytable[] =
 {
      113,    66,   481,   469,   132,   300,   463,   138,   279,   677,
@@ -2182,6 +2488,12 @@ static const yytype_int16 yytable[] =
      240,   241,   242,     0,     0,     0,   245,     0,     0,   246,
      247,   248
 };
+
+#define yypact_value_is_default(yystate) \
+  ((yystate) == (-713))
+
+#define yytable_value_is_error(yytable_value) \
+  YYID (0)
 
 static const yytype_int16 yycheck[] =
 {
@@ -3281,8 +3593,8 @@ static const yytype_int16 yycheck[] =
      118,   119
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
+/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
+   symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
        0,   132,   133,     0,     1,     3,     4,     5,     6,     7,
@@ -3368,163 +3680,103 @@ static const yytype_uint8 yystos[] =
      127,   201
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
-{
-       0,   131,   132,   133,   133,   134,   134,   135,   135,   136,
-     136,   136,   136,   136,   136,   136,   136,   136,   136,   136,
-     136,   136,   136,   136,   136,   136,   136,   136,   136,   136,
-     136,   136,   136,   136,   136,   137,   137,   138,   139,   139,
-     140,   140,   141,   142,   142,   142,   142,   142,   142,   142,
-     142,   142,   142,   142,   142,   142,   142,   142,   143,   143,
-     144,   145,   145,   146,   146,   147,   147,   147,   147,   147,
-     147,   148,   149,   149,   149,   149,   149,   149,   149,   149,
-     149,   149,   149,   149,   149,   149,   149,   149,   149,   149,
-     149,   149,   149,   149,   150,   151,   151,   151,   151,   152,
-     153,   153,   154,   154,   155,   156,   157,   157,   158,   158,
-     158,   159,   159,   160,   160,   160,   161,   162,   162,   162,
-     163,   163,   165,   166,   164,   167,   167,   167,   167,   167,
-     167,   169,   170,   168,   171,   171,   171,   171,   172,   172,
-     172,   172,   172,   172,   172,   172,   172,   172,   172,   172,
-     172,   172,   172,   172,   172,   172,   172,   172,   172,   172,
-     172,   172,   172,   172,   173,   173,   173,   173,   173,   173,
-     173,   173,   173,   173,   173,   173,   174,   174,   175,   176,
-     176,   176,   177,   177,   177,   177,   178,   178,   178,   178,
-     178,   178,   178,   178,   178,   178,   179,   179,   179,   180,
-     180,   181,   181,   181,   181,   181,   182,   182,   183,   183,
-     184,   184,   185,   185,   186,   186,   187,   187,   188,   188,
-     188,   189,   189,   190,   190,   190,   191,   191,   191,   191,
-     191,   192,   192,   192,   193,   193,   194,   194,   194,   195,
-     195,   195,   196,   196,   196,   197,   197,   197,   198,   198,
-     199,   199,   199,   199,   200,   200,   200,   200,   201,   201,
-     201,   202,   202,   202,   202,   202,   203,   203,   203,   203,
-     203,   203,   203,   204,   204,   204,   204,   205,   205,   205,
-     206,   206,   207,   207,   208,   208,   209,   209,   209,   209,
-     209,   210,   211,   211,   211,   211,   211,   211,   211,   211,
-     211,   211,   211,   211,   212,   212,   212,   212,   212,   212,
-     212,   212,   212,   212,   212,   212,   212,   212,   212,   212,
-     212,   213,   214,   215,   215,   215,   215,   215,   215,   215,
-     215,   216,   216,   217,   218,   218,   219,   219,   220,   220,
-     221,   222,   223,   223,   223,   223,   223,   223,   223,   223,
-     223,   223,   223,   223,   223,   223,   224,   224,   224,   224,
-     225,   225,   226,   226,   226,   227,   227,   227,   228,   228,
-     228,   229,   229,   229,   229,   229,   229,   229,   230,   230,
-     231,   231,   231,   231,   231,   231,   231,   231,   231,   231,
-     231,   231,   231,   231,   231,   231,   231,   231,   231,   231,
-     231,   231,   231,   232,   232,   232,   232,   232,   232,   233,
-     233,   233,   233,   234,   234,   234,   234,   235,   235,   235,
-     235,   235,   235,   235
-};
+#define yyerrok		(yyerrstatus = 0)
+#define yyclearin	(yychar = YYEMPTY)
+#define YYEMPTY		(-2)
+#define YYEOF		0
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
-{
-       0,     2,     1,     0,     2,     1,     2,     2,     3,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       2,     2,     3,     3,     3,     3,     3,     3,     2,     3,
-       3,     2,     2,     3,     1,     4,     5,     1,     2,     3,
-       1,     2,     3,     4,     4,     4,     4,     4,     4,     4,
-       4,     4,     4,     4,     4,     4,     4,     4,     0,     1,
-       1,     2,     1,     2,     3,     1,     1,     1,     1,     1,
-       1,     2,     5,     3,     6,     6,     4,     5,     5,     3,
-       3,     6,     5,     6,     5,     6,     3,     4,     6,     7,
-       6,     7,     4,     5,     4,     4,     3,     6,     5,     5,
-       0,     2,     3,     2,     6,     7,     0,     1,     1,     1,
-       1,     0,     2,     0,     2,     3,     5,     1,     2,     3,
-       1,     3,     0,     0,     8,     0,     1,     1,     2,     1,
-       2,     0,     0,     9,     3,     3,     5,     5,     1,     2,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     0,     3,     3,     0,
-       1,     3,     4,     4,     6,     6,     0,     1,     1,     1,
-       1,     2,     2,     1,     1,     1,     0,     1,     1,     1,
-       1,     0,     1,     1,     1,     1,     1,     1,     1,     1,
-       2,     1,     0,     1,     2,     2,     0,     2,     3,     4,
-       4,     2,     4,     0,     2,     2,     4,     4,     4,     5,
-       4,     0,     1,     1,     1,     3,     3,     4,     5,     1,
-       1,     3,     1,     2,     3,     0,     2,     2,     0,     4,
-       0,     2,     2,     1,     4,     4,     6,     1,     0,     1,
-       1,     3,     4,     3,     4,     6,     0,     2,     2,     2,
-       2,     2,     2,     1,     1,     3,     3,     1,     1,     1,
-       3,     3,     0,     1,     1,     3,     3,     3,     3,     1,
-       1,     1,     1,     1,     1,     1,     1,     2,     4,     4,
-       4,     5,     2,     2,     6,     6,     4,     9,     9,     7,
-       6,     6,     4,     9,     9,     7,     4,     6,     6,     9,
-       9,     6,     1,     1,     1,     1,     1,     1,     1,     1,
-       3,     0,     1,     4,     1,     3,     2,     3,     1,     3,
-       2,     4,     1,     1,     1,     1,     1,     1,     1,     1,
-       4,     3,     3,     2,     2,     1,     1,     1,     1,     1,
-       1,     1,     4,     4,     4,     3,     3,     3,     3,     4,
-       3,     1,     1,     1,     1,     3,     3,     3,     3,     5,
-       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     2,     2,     2,     2,     2,     2,     3,
-       3,     3,     3,     3,     3,     3,     3,     1,     1,     1,
-       1,     1,     1,     1
-};
+#define YYACCEPT	goto yyacceptlab
+#define YYABORT		goto yyabortlab
+#define YYERROR		goto yyerrorlab
 
 
-#define yyerrok         (yyerrstatus = 0)
-#define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
+/* Like YYERROR except do call yyerror.  This remains here temporarily
+   to ease the transition to the new meaning of YYERROR, for GCC.
+   Once GCC version 2 has supplanted version 1, this can go.  However,
+   YYFAIL appears to be in use.  Nevertheless, it is formally deprecated
+   in Bison 2.4.2's NEWS entry, where a plan to phase it out is
+   discussed.  */
 
-#define YYACCEPT        goto yyacceptlab
-#define YYABORT         goto yyabortlab
-#define YYERROR         goto yyerrorlab
-
+#define YYFAIL		goto yyerrlab
+#if defined YYFAIL
+  /* This is here to suppress warnings from the GCC cpp's
+     -Wunused-macros.  Normally we don't worry about that warning, but
+     some users do, and we want to make it easy for users to remove
+     YYFAIL uses, which will produce warnings from Bison 2.5.  */
+#endif
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
+#define YYBACKUP(Token, Value)					\
+do								\
+  if (yychar == YYEMPTY && yylen == 1)				\
+    {								\
+      yychar = (Token);						\
+      yylval = (Value);						\
+      YYPOPSTACK (1);						\
+      goto yybackup;						\
+    }								\
+  else								\
+    {								\
       yyerror (&yylloc, context, YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+      YYERROR;							\
+    }								\
+while (YYID (0))
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
+
+#define YYTERROR	1
+#define YYERRCODE	256
 
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
    If N is 0, then set CURRENT to the empty location which ends
    the previous symbol: RHS[0] (always defined).  */
 
+#define YYRHSLOC(Rhs, K) ((Rhs)[K])
 #ifndef YYLLOC_DEFAULT
-# define YYLLOC_DEFAULT(Current, Rhs, N)                                \
-    do                                                                  \
-      if (N)                                                            \
-        {                                                               \
-          (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;        \
-          (Current).first_column = YYRHSLOC (Rhs, 1).first_column;      \
-          (Current).last_line    = YYRHSLOC (Rhs, N).last_line;         \
-          (Current).last_column  = YYRHSLOC (Rhs, N).last_column;       \
-        }                                                               \
-      else                                                              \
-        {                                                               \
-          (Current).first_line   = (Current).last_line   =              \
-            YYRHSLOC (Rhs, 0).last_line;                                \
-          (Current).first_column = (Current).last_column =              \
-            YYRHSLOC (Rhs, 0).last_column;                              \
-        }                                                               \
-    while (0)
+# define YYLLOC_DEFAULT(Current, Rhs, N)				\
+    do									\
+      if (YYID (N))                                                    \
+	{								\
+	  (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;	\
+	  (Current).first_column = YYRHSLOC (Rhs, 1).first_column;	\
+	  (Current).last_line    = YYRHSLOC (Rhs, N).last_line;		\
+	  (Current).last_column  = YYRHSLOC (Rhs, N).last_column;	\
+	}								\
+      else								\
+	{								\
+	  (Current).first_line   = (Current).last_line   =		\
+	    YYRHSLOC (Rhs, 0).last_line;				\
+	  (Current).first_column = (Current).last_column =		\
+	    YYRHSLOC (Rhs, 0).last_column;				\
+	}								\
+    while (YYID (0))
 #endif
 
-#define YYRHSLOC(Rhs, K) ((Rhs)[K])
 
+/* YY_LOCATION_PRINT -- Print the location on the stream.
+   This macro was not mandated originally: define only if we know
+   we won't break user code: when these are the locations we know.  */
+
+#ifndef YY_LOCATION_PRINT
+# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+#  define YY_LOCATION_PRINT(File, Loc)			\
+     fprintf (File, "%d.%d-%d.%d",			\
+	      (Loc).first_line, (Loc).first_column,	\
+	      (Loc).last_line,  (Loc).last_column)
+# else
+#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
+# endif
+#endif
+
+
+/* YYLEX -- calling `yylex' with the right arguments.  */
+
+#ifdef YYLEX_PARAM
+# define YYLEX yylex (&yylval, &yylloc, YYLEX_PARAM)
+#else
+# define YYLEX yylex (&yylval, &yylloc)
+#endif
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
@@ -3534,87 +3786,58 @@ while (0)
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)                        \
-do {                                            \
-  if (yydebug)                                  \
-    YYFPRINTF Args;                             \
-} while (0)
+# define YYDPRINTF(Args)			\
+do {						\
+  if (yydebug)					\
+    YYFPRINTF Args;				\
+} while (YYID (0))
+
+# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
+do {									  \
+  if (yydebug)								  \
+    {									  \
+      YYFPRINTF (stderr, "%s ", Title);					  \
+      yy_symbol_print (stderr,						  \
+		  Type, Value, Location, context); \
+      YYFPRINTF (stderr, "\n");						  \
+    }									  \
+} while (YYID (0))
 
 
-/* YY_LOCATION_PRINT -- Print the location on the stream.
-   This macro was not mandated originally: define only if we know
-   we won't break user code: when these are the locations we know.  */
+/*--------------------------------.
+| Print this symbol on YYOUTPUT.  |
+`--------------------------------*/
 
-#ifndef YY_LOCATION_PRINT
-# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-
-/* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
-
-YY_ATTRIBUTE_UNUSED
-static unsigned
-yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
-{
-  unsigned res = 0;
-  int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
-  if (0 <= yylocp->first_line)
-    {
-      res += YYFPRINTF (yyo, "%d", yylocp->first_line);
-      if (0 <= yylocp->first_column)
-        res += YYFPRINTF (yyo, ".%d", yylocp->first_column);
-    }
-  if (0 <= yylocp->last_line)
-    {
-      if (yylocp->first_line < yylocp->last_line)
-        {
-          res += YYFPRINTF (yyo, "-%d", yylocp->last_line);
-          if (0 <= end_col)
-            res += YYFPRINTF (yyo, ".%d", end_col);
-        }
-      else if (0 <= end_col && yylocp->first_column < end_col)
-        res += YYFPRINTF (yyo, "-%d", end_col);
-    }
-  return res;
- }
-
-#  define YY_LOCATION_PRINT(File, Loc)          \
-  yy_location_print_ (File, &(Loc))
-
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
-
-
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
-do {                                                                      \
-  if (yydebug)                                                            \
-    {                                                                     \
-      YYFPRINTF (stderr, "%s ", Title);                                   \
-      yy_symbol_print (stderr,                                            \
-                  Type, Value, Location, context); \
-      YYFPRINTF (stderr, "\n");                                           \
-    }                                                                     \
-} while (0)
-
-
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
-
+/*ARGSUSED*/
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, ParserContext* context)
+#else
+static void
+yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp, context)
+    FILE *yyoutput;
+    int yytype;
+    YYSTYPE const * const yyvaluep;
+    YYLTYPE const * const yylocationp;
+    ParserContext* context;
+#endif
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
-  YYUSE (yylocationp);
-  YYUSE (context);
   if (!yyvaluep)
     return;
+  YYUSE (yylocationp);
+  YYUSE (context);
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
     YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
+# else
+  YYUSE (yyoutput);
 # endif
-  YYUSE (yytype);
+  switch (yytype)
+    {
+      default:
+	break;
+    }
 }
 
 
@@ -3622,11 +3845,24 @@ yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvalue
 | Print this symbol on YYOUTPUT.  |
 `--------------------------------*/
 
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, ParserContext* context)
+#else
+static void
+yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp, context)
+    FILE *yyoutput;
+    int yytype;
+    YYSTYPE const * const yyvaluep;
+    YYLTYPE const * const yylocationp;
+    ParserContext* context;
+#endif
 {
-  YYFPRINTF (yyoutput, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+  if (yytype < YYNTOKENS)
+    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
+  else
+    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
 
   YY_LOCATION_PRINT (yyoutput, *yylocationp);
   YYFPRINTF (yyoutput, ": ");
@@ -3639,8 +3875,16 @@ yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYL
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
+#else
+static void
+yy_stack_print (yybottom, yytop)
+    yytype_int16 *yybottom;
+    yytype_int16 *yytop;
+#endif
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -3651,42 +3895,51 @@ yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)                            \
-do {                                                            \
-  if (yydebug)                                                  \
-    yy_stack_print ((Bottom), (Top));                           \
-} while (0)
+# define YY_STACK_PRINT(Bottom, Top)				\
+do {								\
+  if (yydebug)							\
+    yy_stack_print ((Bottom), (Top));				\
+} while (YYID (0))
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, ParserContext* context)
+yy_reduce_print (YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, ParserContext* context)
+#else
+static void
+yy_reduce_print (yyvsp, yylsp, yyrule, context)
+    YYSTYPE *yyvsp;
+    YYLTYPE *yylsp;
+    int yyrule;
+    ParserContext* context;
+#endif
 {
-  unsigned long int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
+  unsigned long int yylno = yyrline[yyrule];
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-             yyrule - 1, yylno);
+	     yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr,
-                       yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
-                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , context);
+      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
+		       &(yyvsp[(yyi + 1) - (yynrhs)])
+		       , &(yylsp[(yyi + 1) - (yynrhs)])		       , context);
       YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)          \
-do {                                    \
-  if (yydebug)                          \
-    yy_reduce_print (yyssp, yyvsp, yylsp, Rule, context); \
-} while (0)
+# define YY_REDUCE_PRINT(Rule)		\
+do {					\
+  if (yydebug)				\
+    yy_reduce_print (yyvsp, yylsp, Rule, context); \
+} while (YYID (0))
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
@@ -3700,7 +3953,7 @@ int yydebug;
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef YYINITDEPTH
+#ifndef	YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -3723,8 +3976,15 @@ int yydebug;
 #   define yystrlen strlen
 #  else
 /* Return the length of YYSTR.  */
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 static YYSIZE_T
 yystrlen (const char *yystr)
+#else
+static YYSIZE_T
+yystrlen (yystr)
+    const char *yystr;
+#endif
 {
   YYSIZE_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
@@ -3740,8 +4000,16 @@ yystrlen (const char *yystr)
 #  else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 static char *
 yystpcpy (char *yydest, const char *yysrc)
+#else
+static char *
+yystpcpy (yydest, yysrc)
+    char *yydest;
+    const char *yysrc;
+#endif
 {
   char *yyd = yydest;
   const char *yys = yysrc;
@@ -3771,27 +4039,27 @@ yytnamerr (char *yyres, const char *yystr)
       char const *yyp = yystr;
 
       for (;;)
-        switch (*++yyp)
-          {
-          case '\'':
-          case ',':
-            goto do_not_strip_quotes;
+	switch (*++yyp)
+	  {
+	  case '\'':
+	  case ',':
+	    goto do_not_strip_quotes;
 
-          case '\\':
-            if (*++yyp != '\\')
-              goto do_not_strip_quotes;
-            /* Fall through.  */
-          default:
-            if (yyres)
-              yyres[yyn] = *yyp;
-            yyn++;
-            break;
+	  case '\\':
+	    if (*++yyp != '\\')
+	      goto do_not_strip_quotes;
+	    /* Fall through.  */
+	  default:
+	    if (yyres)
+	      yyres[yyn] = *yyp;
+	    yyn++;
+	    break;
 
-          case '"':
-            if (yyres)
-              yyres[yyn] = '\0';
-            return yyn;
-          }
+	  case '"':
+	    if (yyres)
+	      yyres[yyn] = '\0';
+	    return yyn;
+	  }
     do_not_strip_quotes: ;
     }
 
@@ -3814,11 +4082,12 @@ static int
 yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                 yytype_int16 *yyssp, int yytoken)
 {
-  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
+  YYSIZE_T yysize0 = yytnamerr (0, yytname[yytoken]);
   YYSIZE_T yysize = yysize0;
+  YYSIZE_T yysize1;
   enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
   /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
+  const char *yyformat = 0;
   /* Arguments of yyformat. */
   char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Number of reported tokens (one for the "unexpected", one per
@@ -3826,6 +4095,10 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
   int yycount = 0;
 
   /* There are many possibilities here to consider:
+     - Assume YYFAIL is not used.  It's too flawed to consider.  See
+       <http://lists.gnu.org/archive/html/bison-patches/2009-12/msg00024.html>
+       for details.  YYERROR is fine as it does not invoke this
+       function.
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
        is an error action.  In that case, don't check for expected
@@ -3874,13 +4147,11 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                     break;
                   }
                 yyarg[yycount++] = yytname[yyx];
-                {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-                    return 2;
-                  yysize = yysize1;
-                }
+                yysize1 = yysize + yytnamerr (0, yytname[yyx]);
+                if (! (yysize <= yysize1
+                       && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+                  return 2;
+                yysize = yysize1;
               }
         }
     }
@@ -3900,12 +4171,10 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 # undef YYCASE_
     }
 
-  {
-    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-      return 2;
-    yysize = yysize1;
-  }
+  yysize1 = yysize + yystrlen (yyformat);
+  if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+    return 2;
+  yysize = yysize1;
 
   if (*yymsg_alloc < yysize)
     {
@@ -3942,21 +4211,36 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
+/*ARGSUSED*/
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 static void
 yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, ParserContext* context)
+#else
+static void
+yydestruct (yymsg, yytype, yyvaluep, yylocationp, context)
+    const char *yymsg;
+    int yytype;
+    YYSTYPE *yyvaluep;
+    YYLTYPE *yylocationp;
+    ParserContext* context;
+#endif
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
   YYUSE (context);
+
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
-  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
-  YY_IGNORE_MAYBE_UNINITIALIZED_END
-}
+  switch (yytype)
+    {
 
+      default:
+	break;
+    }
+}
 
 
 struct yypstate
@@ -3969,11 +4253,11 @@ struct yypstate
     int yyerrstatus;
 
     /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-       'yyls': related to locations.
+       `yyss': related to states.
+       `yyvs': related to semantic values.
+       `yyls': related to locations.
 
-       Refer to the stacks through separate pointers, to allow yyoverflow
+       Refer to the stacks thru separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
     /* The state stack.  */
@@ -4001,19 +4285,33 @@ struct yypstate
   };
 
 /* Initialize the parser data structure.  */
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 yypstate *
 yypstate_new (void)
+#else
+yypstate *
+yypstate_new ()
+
+#endif
 {
   yypstate *yyps;
   yyps = (yypstate *) malloc (sizeof *yyps);
   if (!yyps)
-    return YY_NULLPTR;
+    return 0;
   yyps->yynew = 1;
   return yyps;
 }
 
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 void
 yypstate_delete (yypstate *yyps)
+#else
+void
+yypstate_delete (yyps)
+    yypstate *yyps;
+#endif
 {
 #ifndef yyoverflow
   /* If the stack was reallocated but the parse did not complete, then the
@@ -4044,31 +4342,33 @@ yypstate_delete (yypstate *yyps)
 | yypush_parse.  |
 `---------------*/
 
+#if (defined __STDC__ || defined __C99__FUNC__ \
+     || defined __cplusplus || defined _MSC_VER)
 int
-yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE *yypushed_loc, ParserContext* context)
+yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE const *yypushed_loc, ParserContext* context)
+#else
+int
+yypush_parse (yyps, yypushed_char, yypushed_val, yypushed_loc, context)
+    yypstate *yyps;
+    int yypushed_char;
+    YYSTYPE const *yypushed_val;
+    YYLTYPE const *yypushed_loc;
+    ParserContext* context;
+#endif
 {
 /* The lookahead symbol.  */
 int yychar;
 
-
 /* The semantic value of the lookahead symbol.  */
-/* Default value used for initialization, for pacifying older GCCs
-   or non-GCC compilers.  */
-YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
-YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
+YYSTYPE yylval;
 
 /* Location data for the lookahead symbol.  */
-static YYLTYPE yyloc_default
-# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-  = { 1, 1, 1, 1 }
-# endif
-;
-YYLTYPE yylloc = yyloc_default;
+YYLTYPE yylloc;
 
   int yyn;
   int yyresult;
   /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  int yytoken;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
@@ -4093,9 +4393,10 @@ YYLTYPE yylloc = yyloc_default;
       goto yyread_pushed_token;
     }
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yylsp = yyls = yylsa;
+  yytoken = 0;
+  yyss = yyssa;
+  yyvs = yyvsa;
+  yyls = yylsa;
   yystacksize = YYINITDEPTH;
 
   YYDPRINTF ((stderr, "Starting parse\n"));
@@ -4104,7 +4405,21 @@ YYLTYPE yylloc = yyloc_default;
   yyerrstatus = 0;
   yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
-  yylsp[0] = *yypushed_loc;
+
+  /* Initialize stack pointers.
+     Waste one element of value and location stack
+     so that they stay on the same level as the state stack.
+     The wasted elements are never initialized.  */
+  yyssp = yyss;
+  yyvsp = yyvs;
+  yylsp = yyls;
+
+#if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+  /* Initialize the default location before parsing starts.  */
+  yylloc.first_line   = yylloc.last_line   = 1;
+  yylloc.first_column = yylloc.last_column = 1;
+#endif
+
   goto yysetstate;
 
 /*------------------------------------------------------------.
@@ -4125,26 +4440,26 @@ YYLTYPE yylloc = yyloc_default;
 
 #ifdef yyoverflow
       {
-        /* Give user a chance to reallocate the stack.  Use copies of
-           these so that the &'s don't force the real ones into
-           memory.  */
-        YYSTYPE *yyvs1 = yyvs;
-        yytype_int16 *yyss1 = yyss;
-        YYLTYPE *yyls1 = yyls;
+	/* Give user a chance to reallocate the stack.  Use copies of
+	   these so that the &'s don't force the real ones into
+	   memory.  */
+	YYSTYPE *yyvs1 = yyvs;
+	yytype_int16 *yyss1 = yyss;
+	YYLTYPE *yyls1 = yyls;
 
-        /* Each stack pointer address is followed by the size of the
-           data in use in that stack, in bytes.  This used to be a
-           conditional around just the two extra args, but that might
-           be undefined if yyoverflow is a macro.  */
-        yyoverflow (YY_("memory exhausted"),
-                    &yyss1, yysize * sizeof (*yyssp),
-                    &yyvs1, yysize * sizeof (*yyvsp),
-                    &yyls1, yysize * sizeof (*yylsp),
-                    &yystacksize);
+	/* Each stack pointer address is followed by the size of the
+	   data in use in that stack, in bytes.  This used to be a
+	   conditional around just the two extra args, but that might
+	   be undefined if yyoverflow is a macro.  */
+	yyoverflow (YY_("memory exhausted"),
+		    &yyss1, yysize * sizeof (*yyssp),
+		    &yyvs1, yysize * sizeof (*yyvsp),
+		    &yyls1, yysize * sizeof (*yylsp),
+		    &yystacksize);
 
-        yyls = yyls1;
-        yyss = yyss1;
-        yyvs = yyvs1;
+	yyls = yyls1;
+	yyss = yyss1;
+	yyvs = yyvs1;
       }
 #else /* no yyoverflow */
 # ifndef YYSTACK_RELOCATE
@@ -4152,23 +4467,23 @@ YYLTYPE yylloc = yyloc_default;
 # else
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+	goto yyexhaustedlab;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-        yystacksize = YYMAXDEPTH;
+	yystacksize = YYMAXDEPTH;
 
       {
-        yytype_int16 *yyss1 = yyss;
-        union yyalloc *yyptr =
-          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-        if (! yyptr)
-          goto yyexhaustedlab;
-        YYSTACK_RELOCATE (yyss_alloc, yyss);
-        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-        YYSTACK_RELOCATE (yyls_alloc, yyls);
+	yytype_int16 *yyss1 = yyss;
+	union yyalloc *yyptr =
+	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+	if (! yyptr)
+	  goto yyexhaustedlab;
+	YYSTACK_RELOCATE (yyss_alloc, yyss);
+	YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+	YYSTACK_RELOCATE (yyls_alloc, yyls);
 #  undef YYSTACK_RELOCATE
-        if (yyss1 != yyssa)
-          YYSTACK_FREE (yyss1);
+	if (yyss1 != yyssa)
+	  YYSTACK_FREE (yyss1);
       }
 # endif
 #endif /* no yyoverflow */
@@ -4178,10 +4493,10 @@ YYLTYPE yylloc = yyloc_default;
       yylsp = yyls + yysize - 1;
 
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+		  (unsigned long int) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
-        YYABORT;
+	YYABORT;
     }
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
@@ -4262,9 +4577,7 @@ yyread_pushed_token:
   yychar = YYEMPTY;
 
   yystate = yyn;
-  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
-  YY_IGNORE_MAYBE_UNINITIALIZED_END
   *++yylsp = yylloc;
   goto yynewstate;
 
@@ -4287,7 +4600,7 @@ yyreduce:
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     '$$ = $1'.
+     `$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -4302,317 +4615,370 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 399 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 400 "chapel.ypp"
     { yyblock = (yyval.pblockstmt); }
-#line 4308 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 3:
-#line 404 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 405 "chapel.ypp"
     { (yyval.pblockstmt) = new BlockStmt();                                  resetTempID(); }
-#line 4314 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 4:
-#line 405 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-1].pblockstmt)->appendChapelStmt((yyvsp[0].pblockstmt)); context->generatedStmt = (yyvsp[-1].pblockstmt); resetTempID(); }
-#line 4320 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 406 "chapel.ypp"
+    { (yyvsp[(1) - (2)].pblockstmt)->appendChapelStmt((yyvsp[(2) - (2)].pblockstmt)); context->generatedStmt = (yyvsp[(1) - (2)].pblockstmt); resetTempID(); }
     break;
 
   case 6:
-#line 412 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildPragmaStmt( (yyvsp[-1].vpch), (yyvsp[0].pblockstmt) ); }
-#line 4326 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 413 "chapel.ypp"
+    { (yyval.pblockstmt) = buildPragmaStmt( (yyvsp[(1) - (2)].vpch), (yyvsp[(2) - (2)].pblockstmt) ); }
     break;
 
   case 7:
-#line 417 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.vpch) = new Vec<const char*>(); (yyval.vpch)->add(astr((yyvsp[0].pch))); }
-#line 4332 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 418 "chapel.ypp"
+    { (yyval.vpch) = new Vec<const char*>(); (yyval.vpch)->add(astr((yyvsp[(2) - (2)].pch))); }
     break;
 
   case 8:
-#line 418 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-2].vpch)->add(astr((yyvsp[0].pch))); }
-#line 4338 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 419 "chapel.ypp"
+    { (yyvsp[(1) - (3)].vpch)->add(astr((yyvsp[(3) - (3)].pch))); }
     break;
 
   case 20:
-#line 434 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[-1].pexpr)); }
-#line 4344 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 435 "chapel.ypp"
+    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[(1) - (2)].pexpr)); }
     break;
 
   case 21:
-#line 435 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAtomicStmt((yyvsp[0].pblockstmt)); }
-#line 4350 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 436 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAtomicStmt((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 22:
-#line 436 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildBeginStmt((yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt)); }
-#line 4356 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 437 "chapel.ypp"
+    { (yyval.pblockstmt) = buildBeginStmt((yyvsp[(2) - (3)].pcallexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 23:
-#line 437 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildGotoStmt(GOTO_BREAK, (yyvsp[-1].pch)); }
-#line 4362 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 438 "chapel.ypp"
+    { (yyval.pblockstmt) = buildGotoStmt(GOTO_BREAK, (yyvsp[(2) - (3)].pch)); }
     break;
 
   case 24:
-#line 438 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildCobeginStmt((yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt));  }
-#line 4368 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 439 "chapel.ypp"
+    { (yyval.pblockstmt) = buildCobeginStmt((yyvsp[(2) - (3)].pcallexpr), (yyvsp[(3) - (3)].pblockstmt));  }
     break;
 
   case 25:
-#line 439 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildGotoStmt(GOTO_CONTINUE, (yyvsp[-1].pch)); }
-#line 4374 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 440 "chapel.ypp"
+    { (yyval.pblockstmt) = buildGotoStmt(GOTO_CONTINUE, (yyvsp[(2) - (3)].pch)); }
     break;
 
   case 26:
-#line 440 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_DELETE, (yyvsp[-1].pexpr)); }
-#line 4380 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 441 "chapel.ypp"
+    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_DELETE, (yyvsp[(2) - (3)].pexpr)); }
     break;
 
   case 27:
-#line 441 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildLabelStmt((yyvsp[-1].pch), (yyvsp[0].pblockstmt)); }
-#line 4386 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 442 "chapel.ypp"
+    { (yyval.pblockstmt) = buildLabelStmt((yyvsp[(2) - (3)].pch), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 28:
-#line 442 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildLocalStmt((yyvsp[0].pblockstmt)); }
-#line 4392 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 443 "chapel.ypp"
+    { (yyval.pblockstmt) = buildLocalStmt((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 29:
-#line 443 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildOnStmt((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
-#line 4398 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 444 "chapel.ypp"
+    { (yyval.pblockstmt) = buildOnStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 30:
-#line 444 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildSerialStmt((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
-#line 4404 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 445 "chapel.ypp"
+    { (yyval.pblockstmt) = buildSerialStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 31:
-#line 445 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildSerialStmt(new SymExpr(gTrue), (yyvsp[0].pblockstmt)); }
-#line 4410 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 446 "chapel.ypp"
+    { (yyval.pblockstmt) = buildSerialStmt(new SymExpr(gTrue), (yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 32:
-#line 446 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildSyncStmt((yyvsp[0].pblockstmt)); }
-#line 4416 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 447 "chapel.ypp"
+    { (yyval.pblockstmt) = buildSyncStmt((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 33:
-#line 447 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_YIELD, (yyvsp[-1].pexpr)); }
-#line 4422 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 448 "chapel.ypp"
+    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_YIELD, (yyvsp[(2) - (3)].pexpr)); }
     break;
 
   case 34:
-#line 448 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 449 "chapel.ypp"
     { printf("syntax error"); clean_exit(1); }
-#line 4428 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 35:
-#line 453 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[-2].pch), new BlockStmt(), yyfilename, (yylsp[-3]).comment))); }
-#line 4434 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 454 "chapel.ypp"
+    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[(2) - (4)].pch), new BlockStmt(), yyfilename, (yylsp[(1) - (4)]).comment))); }
     break;
 
   case 36:
-#line 455 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[-3].pch), (yyvsp[-1].pblockstmt), yyfilename, (yylsp[-4]).comment))); }
-#line 4440 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 456 "chapel.ypp"
+    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[(2) - (5)].pch), (yyvsp[(4) - (5)].pblockstmt), yyfilename, (yylsp[(1) - (5)]).comment))); }
     break;
 
   case 37:
-#line 459 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 460 "chapel.ypp"
     { (yyloc).comment = context->latestComment; context->latestComment = NULL; }
-#line 4446 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 38:
-#line 474 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 475 "chapel.ypp"
     { (yyval.pblockstmt) = new BlockStmt(); }
-#line 4452 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 39:
-#line 475 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = (yyvsp[-1].pblockstmt);              }
-#line 4458 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 476 "chapel.ypp"
+    { (yyval.pblockstmt) = (yyvsp[(2) - (3)].pblockstmt);              }
     break;
 
   case 40:
-#line 480 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = new BlockStmt(); (yyval.pblockstmt)->appendChapelStmt((yyvsp[0].pblockstmt)); }
-#line 4464 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 481 "chapel.ypp"
+    { (yyval.pblockstmt) = new BlockStmt(); (yyval.pblockstmt)->appendChapelStmt((yyvsp[(1) - (1)].pblockstmt)); }
     break;
 
   case 41:
-#line 481 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-1].pblockstmt)->appendChapelStmt((yyvsp[0].pblockstmt)); }
-#line 4470 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 482 "chapel.ypp"
+    { (yyvsp[(1) - (2)].pblockstmt)->appendChapelStmt((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 42:
-#line 486 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildUseStmt((yyvsp[-1].pcallexpr)); }
-#line 4476 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 487 "chapel.ypp"
+    { (yyval.pblockstmt) = buildUseStmt((yyvsp[(2) - (3)].pcallexpr)); }
     break;
 
   case 43:
-#line 490 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "=");   }
-#line 4482 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 491 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "=");   }
     break;
 
   case 44:
-#line 491 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "+=");  }
-#line 4488 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 492 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "+=");  }
     break;
 
   case 45:
-#line 492 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "-=");  }
-#line 4494 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 493 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "-=");  }
     break;
 
   case 46:
-#line 493 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "*=");  }
-#line 4500 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 494 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "*=");  }
     break;
 
   case 47:
-#line 494 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "/=");  }
-#line 4506 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 495 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "/=");  }
     break;
 
   case 48:
-#line 495 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "%=");  }
-#line 4512 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 496 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "%=");  }
     break;
 
   case 49:
-#line 496 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "**="); }
-#line 4518 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 497 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "**="); }
     break;
 
   case 50:
-#line 497 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "&=");  }
-#line 4524 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 498 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "&=");  }
     break;
 
   case 51:
-#line 498 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "|=");  }
-#line 4530 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 499 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "|=");  }
     break;
 
   case 52:
-#line 499 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "^=");  }
-#line 4536 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 500 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "^=");  }
     break;
 
   case 53:
-#line 500 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), ">>="); }
-#line 4542 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 501 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), ">>="); }
     break;
 
   case 54:
-#line 501 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "<<="); }
-#line 4548 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 502 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "<<="); }
     break;
 
   case 55:
-#line 502 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "<=>"); }
-#line 4554 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 503 "chapel.ypp"
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "<=>"); }
     break;
 
   case 56:
-#line 503 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildLAndAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr));    }
-#line 4560 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 504 "chapel.ypp"
+    { (yyval.pblockstmt) = buildLAndAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr));    }
     break;
 
   case 57:
-#line 504 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildLOrAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr));     }
-#line 4566 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 505 "chapel.ypp"
+    { (yyval.pblockstmt) = buildLOrAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr));     }
     break;
 
   case 58:
-#line 508 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 509 "chapel.ypp"
     { (yyval.pch) = NULL; }
-#line 4572 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 60:
-#line 513 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pch) = (yyvsp[0].pch); }
-#line 4578 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 514 "chapel.ypp"
+    { (yyval.pch) = (yyvsp[(1) - (1)].pch); }
     break;
 
   case 61:
-#line 517 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = (yyvsp[0].pblockstmt); }
-#line 4584 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 518 "chapel.ypp"
+    { (yyval.pblockstmt) = (yyvsp[(2) - (2)].pblockstmt); }
     break;
 
   case 62:
-#line 518 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = (yyvsp[0].pblockstmt); }
-#line 4590 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 519 "chapel.ypp"
+    { (yyval.pblockstmt) = (yyvsp[(1) - (1)].pblockstmt); }
     break;
 
   case 63:
-#line 522 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 523 "chapel.ypp"
     { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_RETURN, new SymExpr(gVoid)); }
-#line 4596 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 64:
-#line 523 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_RETURN, (yyvsp[-1].pexpr)); }
-#line 4602 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 524 "chapel.ypp"
+    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_RETURN, (yyvsp[(2) - (3)].pexpr)); }
     break;
 
   case 65:
-#line 527 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 528 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt(new BlockStmt()); }
-#line 4608 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 71:
-#line 537 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 538 "chapel.ypp"
     {
 #ifdef HAVE_LLVM
       if (externC) {
-        (yyval.pblockstmt) = buildExternBlockStmt(astr((yyvsp[0].pch)));
+        (yyval.pblockstmt) = buildExternBlockStmt(astr((yyvsp[(2) - (2)].pch)));
       } else {
         USR_FATAL(new BlockStmt(), "extern block syntax is turned off. Use --extern-c flag to turn on.");
       }
@@ -4620,415 +4986,470 @@ yyreduce:
       USR_FATAL(new BlockStmt(), "Chapel must be built with llvm in order to use the extern block syntax");
 #endif
     }
-#line 4624 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 72:
-#line 551 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = DoWhileStmt::build((yyvsp[-1].pexpr), (yyvsp[-3].pblockstmt)); }
-#line 4630 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 552 "chapel.ypp"
+    { (yyval.pblockstmt) = DoWhileStmt::build((yyvsp[(4) - (5)].pexpr), (yyvsp[(2) - (5)].pblockstmt)); }
     break;
 
   case 73:
-#line 552 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = WhileDoStmt::build((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
-#line 4636 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 553 "chapel.ypp"
+    { (yyval.pblockstmt) = WhileDoStmt::build((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 74:
-#line 553 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt)); }
-#line 4642 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 554 "chapel.ypp"
+    { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr), (yyvsp[(6) - (6)].pblockstmt)); }
     break;
 
   case 75:
-#line 554 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt), true); }
-#line 4648 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 555 "chapel.ypp"
+    { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr), (yyvsp[(6) - (6)].pblockstmt), true); }
     break;
 
   case 76:
-#line 555 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildCoforallLoopStmt(NULL, (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt)); }
-#line 4654 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 556 "chapel.ypp"
+    { (yyval.pblockstmt) = buildCoforallLoopStmt(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr), (yyvsp[(4) - (4)].pblockstmt)); }
     break;
 
   case 77:
-#line 556 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[-3].pexpr), (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt), false, false); }
-#line 4660 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 557 "chapel.ypp"
+    { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), (yyvsp[(5) - (5)].pblockstmt), false, false); }
     break;
 
   case 78:
-#line 557 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[-3].pexpr), (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt), false,  true); }
-#line 4666 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 558 "chapel.ypp"
+    { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), (yyvsp[(5) - (5)].pblockstmt), false,  true); }
     break;
 
   case 79:
-#line 558 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt), false, false); }
-#line 4672 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 559 "chapel.ypp"
+    { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt), false, false); }
     break;
 
   case 80:
-#line 559 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt), false,  true); }
-#line 4678 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 560 "chapel.ypp"
+    { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt), false,  true); }
     break;
 
   case 81:
-#line 560 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildParamForLoopStmt((yyvsp[-3].pch), (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
-#line 4684 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 561 "chapel.ypp"
+    { (yyval.pblockstmt) = buildParamForLoopStmt((yyvsp[(3) - (6)].pch), (yyvsp[(5) - (6)].pexpr), (yyvsp[(6) - (6)].pblockstmt)); }
     break;
 
   case 82:
-#line 561 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), NULL, (yyvsp[0].pblockstmt)); }
-#line 4690 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 562 "chapel.ypp"
+    { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), NULL, (yyvsp[(5) - (5)].pblockstmt)); }
     break;
 
   case 83:
-#line 562 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr),   (yyvsp[0].pblockstmt)); }
-#line 4696 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 563 "chapel.ypp"
+    { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr),   (yyvsp[(6) - (6)].pblockstmt)); }
     break;
 
   case 84:
-#line 563 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), NULL, (yyvsp[0].pblockstmt), true); }
-#line 4702 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 564 "chapel.ypp"
+    { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), NULL, (yyvsp[(5) - (5)].pblockstmt), true); }
     break;
 
   case 85:
-#line 564 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr),   (yyvsp[0].pblockstmt), true); }
-#line 4708 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 565 "chapel.ypp"
+    { (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr),   (yyvsp[(6) - (6)].pblockstmt), true); }
     break;
 
   case 86:
-#line 565 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[-1].pexpr), NULL, (yyvsp[0].pblockstmt)); }
-#line 4714 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 566 "chapel.ypp"
+    { (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[(2) - (3)].pexpr), NULL, (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 87:
-#line 566 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr),   (yyvsp[0].pblockstmt)); }
-#line 4720 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 567 "chapel.ypp"
+    { (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr),   (yyvsp[(4) - (4)].pblockstmt)); }
     break;
 
   case 88:
-#line 568 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 569 "chapel.ypp"
     {
-      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[-2].pexpr), "invalid index expression");
-      (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[-4].pcallexpr)->get(1)->remove(), (yyvsp[-2].pexpr), NULL, new BlockStmt((yyvsp[0].pblockstmt)));
+      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[(4) - (6)].pexpr), "invalid index expression");
+      (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (6)].pexpr), NULL, new BlockStmt((yyvsp[(6) - (6)].pblockstmt)));
     }
-#line 4730 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 89:
-#line 574 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 575 "chapel.ypp"
     {
-      if ((yyvsp[-5].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[-3].pexpr), "invalid index expression");
-      (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[-5].pcallexpr)->get(1)->remove(), (yyvsp[-3].pexpr), (yyvsp[-2].pcallexpr),   new BlockStmt((yyvsp[0].pblockstmt)));
+      if ((yyvsp[(2) - (7)].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[(4) - (7)].pexpr), "invalid index expression");
+      (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (7)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (7)].pexpr), (yyvsp[(5) - (7)].pcallexpr),   new BlockStmt((yyvsp[(7) - (7)].pblockstmt)));
     }
-#line 4740 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 90:
-#line 580 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 581 "chapel.ypp"
     {
-      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[-2].pexpr), "invalid index expression");
-      (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[-4].pcallexpr)->get(1)->remove(), (yyvsp[-2].pexpr), NULL, new BlockStmt((yyvsp[0].pblockstmt)), true);
+      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[(4) - (6)].pexpr), "invalid index expression");
+      (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (6)].pexpr), NULL, new BlockStmt((yyvsp[(6) - (6)].pblockstmt)), true);
     }
-#line 4750 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 91:
-#line 586 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 587 "chapel.ypp"
     {
-      if ((yyvsp[-5].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[-3].pexpr), "invalid index expression");
-      (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[-5].pcallexpr)->get(1)->remove(), (yyvsp[-3].pexpr), (yyvsp[-2].pcallexpr),   new BlockStmt((yyvsp[0].pblockstmt)), true);
+      if ((yyvsp[(2) - (7)].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[(4) - (7)].pexpr), "invalid index expression");
+      (yyval.pblockstmt) = buildForallLoopStmt((yyvsp[(2) - (7)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (7)].pexpr), (yyvsp[(5) - (7)].pcallexpr),   new BlockStmt((yyvsp[(7) - (7)].pblockstmt)), true);
     }
-#line 4760 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 92:
-#line 592 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 593 "chapel.ypp"
     {
-      if ((yyvsp[-2].pcallexpr)->argList.length > 1)
-        (yyval.pblockstmt) = buildForallLoopStmt(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pcallexpr)), NULL, new BlockStmt((yyvsp[0].pblockstmt)));
+      if ((yyvsp[(2) - (4)].pcallexpr)->argList.length > 1)
+        (yyval.pblockstmt) = buildForallLoopStmt(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), NULL, new BlockStmt((yyvsp[(4) - (4)].pblockstmt)));
       else
-        (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[-2].pcallexpr)->get(1)->remove(), NULL, new BlockStmt((yyvsp[0].pblockstmt)));
+        (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[(2) - (4)].pcallexpr)->get(1)->remove(), NULL, new BlockStmt((yyvsp[(4) - (4)].pblockstmt)));
     }
-#line 4771 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 93:
-#line 599 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 600 "chapel.ypp"
     {
-      if ((yyvsp[-3].pcallexpr)->argList.length > 1)
-        (yyval.pblockstmt) = buildForallLoopStmt(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[-3].pcallexpr)), (yyvsp[-2].pcallexpr),   new BlockStmt((yyvsp[0].pblockstmt)));
+      if ((yyvsp[(2) - (5)].pcallexpr)->argList.length > 1)
+        (yyval.pblockstmt) = buildForallLoopStmt(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (5)].pcallexpr)), (yyvsp[(3) - (5)].pcallexpr),   new BlockStmt((yyvsp[(5) - (5)].pblockstmt)));
       else
-        (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[-3].pcallexpr)->get(1)->remove(), (yyvsp[-2].pcallexpr),   new BlockStmt((yyvsp[0].pblockstmt)));
+        (yyval.pblockstmt) = buildForallLoopStmt(NULL, (yyvsp[(2) - (5)].pcallexpr)->get(1)->remove(), (yyvsp[(3) - (5)].pcallexpr),   new BlockStmt((yyvsp[(5) - (5)].pblockstmt)));
     }
-#line 4782 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 94:
-#line 608 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("_build_tuple", (yyvsp[-1].pcallexpr)); }
-#line 4788 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 609 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("_build_tuple", (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 95:
-#line 612 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildIfStmt((yyvsp[-2].pexpr), (yyvsp[0].pblockstmt)); }
-#line 4794 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 613 "chapel.ypp"
+    { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (4)].pexpr), (yyvsp[(4) - (4)].pblockstmt)); }
     break;
 
   case 96:
-#line 613 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildIfStmt((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
-#line 4800 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 614 "chapel.ypp"
+    { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 97:
-#line 614 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildIfStmt((yyvsp[-4].pexpr), (yyvsp[-2].pblockstmt), (yyvsp[0].pblockstmt)); }
-#line 4806 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 615 "chapel.ypp"
+    { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pblockstmt), (yyvsp[(6) - (6)].pblockstmt)); }
     break;
 
   case 98:
-#line 615 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildIfStmt((yyvsp[-3].pexpr), (yyvsp[-2].pblockstmt), (yyvsp[0].pblockstmt)); }
-#line 4812 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 616 "chapel.ypp"
+    { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(3) - (5)].pblockstmt), (yyvsp[(5) - (5)].pblockstmt)); }
     break;
 
   case 99:
-#line 620 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildChapelStmt(buildSelectStmt((yyvsp[-3].pexpr), (yyvsp[-1].pblockstmt))); }
-#line 4818 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 621 "chapel.ypp"
+    { (yyval.pblockstmt) = buildChapelStmt(buildSelectStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pblockstmt))); }
     break;
 
   case 100:
-#line 624 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 625 "chapel.ypp"
     { (yyval.pblockstmt) = buildChapelStmt(); }
-#line 4824 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 101:
-#line 625 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-1].pblockstmt)->insertAtTail((yyvsp[0].pexpr)); }
-#line 4830 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 626 "chapel.ypp"
+    { (yyvsp[(1) - (2)].pblockstmt)->insertAtTail((yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 102:
-#line 630 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN, (yyvsp[-1].pcallexpr)), (yyvsp[0].pblockstmt)); }
-#line 4836 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 631 "chapel.ypp"
+    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN, (yyvsp[(2) - (3)].pcallexpr)), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 103:
-#line 632 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN), (yyvsp[0].pblockstmt)); }
-#line 4842 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 633 "chapel.ypp"
+    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN), (yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 104:
-#line 637 "chapel.ypp" /* yacc.c:1661  */
-    { USR_FATAL((yyvsp[-3].pcallexpr), "'type select' is no longer supported. Use 'select'"); }
-#line 4848 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 638 "chapel.ypp"
+    { USR_FATAL((yyvsp[(3) - (6)].pcallexpr), "'type select' is no longer supported. Use 'select'"); }
     break;
 
   case 105:
-#line 644 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[-4].pch), (yyvsp[-5].ptype), (yyvsp[-3].pcallexpr), (yyvsp[-1].pblockstmt), (yyvsp[-6].flag), (yylsp[-6]).comment)); }
-#line 4854 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 645 "chapel.ypp"
+    { (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[(3) - (7)].pch), (yyvsp[(2) - (7)].ptype), (yyvsp[(4) - (7)].pcallexpr), (yyvsp[(6) - (7)].pblockstmt), (yyvsp[(1) - (7)].flag), (yylsp[(1) - (7)]).comment)); }
     break;
 
   case 106:
-#line 648 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 649 "chapel.ypp"
     { (yyval.flag) = FLAG_UNKNOWN; (yyloc).comment = context->latestComment; context->latestComment = NULL; }
-#line 4860 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 107:
-#line 649 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 650 "chapel.ypp"
     { (yyval.flag) = FLAG_EXTERN;  (yyloc).comment = context->latestComment; context->latestComment = NULL; }
-#line 4866 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 108:
-#line 653 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 654 "chapel.ypp"
     {
              (yyval.ptype)                     = new AggregateType(AGGREGATE_CLASS);
              (yyloc).comment             = context->latestComment;
              context->latestComment = NULL;
            }
-#line 4876 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 109:
-#line 658 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 659 "chapel.ypp"
     {
              (yyval.ptype)                     = new AggregateType(AGGREGATE_RECORD);
              (yyloc).comment             = context->latestComment;
              context->latestComment = NULL;
            }
-#line 4886 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 110:
-#line 663 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 664 "chapel.ypp"
     {
              (yyval.ptype)                     = new AggregateType(AGGREGATE_UNION);
              (yyloc).comment             = context->latestComment;
              context->latestComment = NULL;
            }
-#line 4896 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 111:
-#line 671 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 672 "chapel.ypp"
     { (yyval.pcallexpr) = NULL; }
-#line 4902 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 112:
-#line 672 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pcallexpr) = (yyvsp[0].pcallexpr); }
-#line 4908 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 673 "chapel.ypp"
+    { (yyval.pcallexpr) = (yyvsp[(2) - (2)].pcallexpr); }
     break;
 
   case 113:
-#line 677 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 678 "chapel.ypp"
     { (yyval.pblockstmt) = new BlockStmt(); }
-#line 4914 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 114:
-#line 679 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-1].pblockstmt)->insertAtTail((yyvsp[0].pblockstmt)); }
-#line 4920 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 680 "chapel.ypp"
+    { (yyvsp[(1) - (2)].pblockstmt)->insertAtTail((yyvsp[(2) - (2)].pblockstmt)); }
     break;
 
   case 115:
-#line 681 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-2].pblockstmt)->insertAtTail(buildPragmaStmt((yyvsp[-1].vpch), (yyvsp[0].pblockstmt))); }
-#line 4926 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 682 "chapel.ypp"
+    { (yyvsp[(1) - (3)].pblockstmt)->insertAtTail(buildPragmaStmt((yyvsp[(2) - (3)].vpch), (yyvsp[(3) - (3)].pblockstmt))); }
     break;
 
   case 116:
-#line 686 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 687 "chapel.ypp"
     {
-      EnumType* pdt = (yyvsp[-1].penumtype);
-      TypeSymbol* pst = new TypeSymbol((yyvsp[-3].pch), pdt);
-      (yyvsp[-1].penumtype)->symbol = pst;
+      EnumType* pdt = (yyvsp[(4) - (5)].penumtype);
+      TypeSymbol* pst = new TypeSymbol((yyvsp[(2) - (5)].pch), pdt);
+      (yyvsp[(4) - (5)].penumtype)->symbol = pst;
       (yyval.pblockstmt) = buildChapelStmt(new DefExpr(pst));
     }
-#line 4937 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 117:
-#line 696 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 697 "chapel.ypp"
     {
       (yyval.penumtype) = new EnumType();
-      (yyvsp[0].pdefexpr)->sym->type = (yyval.penumtype);
-      (yyval.penumtype)->constants.insertAtTail((yyvsp[0].pdefexpr));
-      (yyval.penumtype)->defaultValue = (yyvsp[0].pdefexpr)->sym;
+      (yyvsp[(1) - (1)].pdefexpr)->sym->type = (yyval.penumtype);
+      (yyval.penumtype)->constants.insertAtTail((yyvsp[(1) - (1)].pdefexpr));
+      (yyval.penumtype)->defaultValue = (yyvsp[(1) - (1)].pdefexpr)->sym;
       (yyval.penumtype)->doc = context->latestComment;
       context->latestComment = NULL;
     }
-#line 4950 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 118:
-#line 705 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 706 "chapel.ypp"
     {
-      (yyval.penumtype) = (yyvsp[-1].penumtype);
+      (yyval.penumtype) = (yyvsp[(1) - (2)].penumtype);
     }
-#line 4958 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 119:
-#line 709 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 710 "chapel.ypp"
     {
-      (yyvsp[-2].penumtype)->constants.insertAtTail((yyvsp[0].pdefexpr));
-      (yyvsp[0].pdefexpr)->sym->type = (yyvsp[-2].penumtype);
+      (yyvsp[(1) - (3)].penumtype)->constants.insertAtTail((yyvsp[(3) - (3)].pdefexpr));
+      (yyvsp[(3) - (3)].pdefexpr)->sym->type = (yyvsp[(1) - (3)].penumtype);
     }
-#line 4967 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 120:
-#line 716 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[0].pch))); }
-#line 4973 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 717 "chapel.ypp"
+    { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[(1) - (1)].pch))); }
     break;
 
   case 121:
-#line 717 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[-2].pch)), (yyvsp[0].pexpr)); }
-#line 4979 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 718 "chapel.ypp"
+    { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[(1) - (3)].pch)), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 122:
-#line 722 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 723 "chapel.ypp"
     {
       captureTokens = 1;
       captureString[0] = '\0';
     }
-#line 4988 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 123:
-#line 727 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 728 "chapel.ypp"
     {
       captureTokens = 0;
-      (yyvsp[0].pfnsymbol)->userString = astr(captureString);
+      (yyvsp[(3) - (3)].pfnsymbol)->userString = astr(captureString);
     }
-#line 4997 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 124:
-#line 732 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 733 "chapel.ypp"
     {
-      (yyvsp[-5].pfnsymbol)->retTag = (yyvsp[-3].retTag);
-      if ((yyvsp[-3].retTag) == RET_REF)
+      (yyvsp[(3) - (8)].pfnsymbol)->retTag = (yyvsp[(5) - (8)].retTag);
+      if ((yyvsp[(5) - (8)].retTag) == RET_REF)
         USR_FATAL("'ref' return types are not allowed in lambdas");
-      if ((yyvsp[-3].retTag) == RET_PARAM)
+      if ((yyvsp[(5) - (8)].retTag) == RET_PARAM)
         USR_FATAL("'param' return types are not allowed in lambdas");
-      if ((yyvsp[-3].retTag) == RET_TYPE)
+      if ((yyvsp[(5) - (8)].retTag) == RET_TYPE)
         USR_FATAL("'type' return types are not allowed in lambdas");
-      if ((yyvsp[-2].pexpr))
-        (yyvsp[-5].pfnsymbol)->retExprType = new BlockStmt((yyvsp[-2].pexpr), BLOCK_SCOPELESS);
-      if ((yyvsp[-1].pexpr))
-        (yyvsp[-5].pfnsymbol)->where = new BlockStmt((yyvsp[-1].pexpr));
-      (yyvsp[-5].pfnsymbol)->insertAtTail((yyvsp[0].pblockstmt));
-      (yyval.pexpr) = new DefExpr(buildLambda((yyvsp[-5].pfnsymbol)));
+      if ((yyvsp[(6) - (8)].pexpr))
+        (yyvsp[(3) - (8)].pfnsymbol)->retExprType = new BlockStmt((yyvsp[(6) - (8)].pexpr), BLOCK_SCOPELESS);
+      if ((yyvsp[(7) - (8)].pexpr))
+        (yyvsp[(3) - (8)].pfnsymbol)->where = new BlockStmt((yyvsp[(7) - (8)].pexpr));
+      (yyvsp[(3) - (8)].pfnsymbol)->insertAtTail((yyvsp[(8) - (8)].pblockstmt));
+      (yyval.pexpr) = new DefExpr(buildLambda((yyvsp[(3) - (8)].pfnsymbol)));
     }
-#line 5017 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 125:
-#line 752 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 753 "chapel.ypp"
     {
                   (yyval.pfnsymbol) = new FnSymbol("");
 
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
-#line 5028 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 126:
-#line 758 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 759 "chapel.ypp"
     {
                   (yyval.pfnsymbol) = new FnSymbol("");
                   (yyval.pfnsymbol)->addFlag(FLAG_INLINE);
@@ -5036,11 +5457,12 @@ yyreduce:
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
-#line 5040 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 127:
-#line 765 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 766 "chapel.ypp"
     {
                   (yyval.pfnsymbol) = new FnSymbol("");
                   (yyval.pfnsymbol)->addFlag(FLAG_EXPORT);
@@ -5049,24 +5471,26 @@ yyreduce:
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
-#line 5053 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 128:
-#line 773 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 774 "chapel.ypp"
     {
-                  (yyval.pfnsymbol) = new FnSymbol((yyvsp[0].pch));
+                  (yyval.pfnsymbol) = new FnSymbol((yyvsp[(2) - (2)].pch));
                   (yyval.pfnsymbol)->addFlag(FLAG_EXPORT);
                   (yyval.pfnsymbol)->addFlag(FLAG_LOCAL_ARGS);
 
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
-#line 5066 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 129:
-#line 781 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 782 "chapel.ypp"
     {
                   (yyval.pfnsymbol) = new FnSymbol("");
                   (yyval.pfnsymbol)->addFlag(FLAG_EXTERN);
@@ -5075,1705 +5499,1965 @@ yyreduce:
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
-#line 5079 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 130:
-#line 789 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 790 "chapel.ypp"
     {
-                  (yyval.pfnsymbol) = new FnSymbol((yyvsp[0].pch));
+                  (yyval.pfnsymbol) = new FnSymbol((yyvsp[(2) - (2)].pch));
                   (yyval.pfnsymbol)->addFlag(FLAG_EXTERN);
                   (yyval.pfnsymbol)->addFlag(FLAG_LOCAL_ARGS);
 
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
-#line 5092 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 131:
-#line 800 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 801 "chapel.ypp"
     {
       // Sets up to capture tokens while parsing the next grammar nonterminal.
       captureTokens = 1;
       captureString[0] = '\0';
     }
-#line 5102 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 132:
-#line 806 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 807 "chapel.ypp"
     {
       // Stop capturing and save the result.
       captureTokens = 0;
 
-      (yyvsp[0].pfnsymbol)->userString = astr(captureString);
+      (yyvsp[(4) - (4)].pfnsymbol)->userString = astr(captureString);
     }
-#line 5113 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 133:
-#line 813 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 814 "chapel.ypp"
     {
-      FnSymbol* fn = (yyvsp[-5].pfnsymbol);
+      FnSymbol* fn = (yyvsp[(4) - (9)].pfnsymbol);
 
-      fn->copyFlags((yyvsp[-8].pfnsymbol));
+      fn->copyFlags((yyvsp[(1) - (9)].pfnsymbol));
       // The user explicitly named this function (controls mangling).
-      if (*(yyvsp[-8].pfnsymbol)->name)
-        fn->cname = (yyvsp[-8].pfnsymbol)->name;
+      if (*(yyvsp[(1) - (9)].pfnsymbol)->name)
+        fn->cname = (yyvsp[(1) - (9)].pfnsymbol)->name;
 
-      if ((yyvsp[-7].procIter) == ProcIter_ITER)
+      if ((yyvsp[(2) - (9)].procIter) == ProcIter_ITER)
       {
         if (fn->hasFlag(FLAG_EXTERN))
           USR_FATAL_CONT(fn, "'iter' is not legal with 'extern'");
         fn->addFlag(FLAG_ITERATOR_FN);
       }
 
-      (yyval.pblockstmt) = buildFunctionDecl((yyvsp[-5].pfnsymbol), (yyvsp[-3].retTag), (yyvsp[-2].pexpr), (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt), (yylsp[-8]).comment);
+      (yyval.pblockstmt) = buildFunctionDecl((yyvsp[(4) - (9)].pfnsymbol), (yyvsp[(6) - (9)].retTag), (yyvsp[(7) - (9)].pexpr), (yyvsp[(8) - (9)].pexpr), (yyvsp[(9) - (9)].pblockstmt), (yylsp[(1) - (9)]).comment);
       context->latestComment = NULL;
     }
-#line 5136 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 134:
-#line 835 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 836 "chapel.ypp"
     {
-      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[0].pfnsymbol), (yyvsp[-1].pch), (yyvsp[-2].pt), NULL);
+      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(3) - (3)].pfnsymbol), (yyvsp[(2) - (3)].pch), (yyvsp[(1) - (3)].pt), NULL);
     }
-#line 5144 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 135:
-#line 839 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 840 "chapel.ypp"
     {
-      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[0].pfnsymbol), (yyvsp[-1].pch), (yyvsp[-2].pt), NULL);
+      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(3) - (3)].pfnsymbol), (yyvsp[(2) - (3)].pch), (yyvsp[(1) - (3)].pt), NULL);
       (yyval.pfnsymbol)->addFlag(FLAG_ASSIGNOP);
     }
-#line 5153 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 136:
-#line 844 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 845 "chapel.ypp"
     {
-      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[0].pfnsymbol), (yyvsp[-1].pch), (yyvsp[-4].pt), (yyvsp[-3].pch));
+      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(5) - (5)].pfnsymbol), (yyvsp[(4) - (5)].pch), (yyvsp[(1) - (5)].pt), (yyvsp[(2) - (5)].pch));
     }
-#line 5161 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 137:
-#line 848 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 849 "chapel.ypp"
     {
-      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[0].pfnsymbol), (yyvsp[-1].pch), (yyvsp[-4].pt), (yyvsp[-3].pch));
+      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(5) - (5)].pfnsymbol), (yyvsp[(4) - (5)].pch), (yyvsp[(1) - (5)].pt), (yyvsp[(2) - (5)].pch));
       (yyval.pfnsymbol)->addFlag(FLAG_ASSIGNOP);
     }
-#line 5170 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 139:
-#line 856 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pch) = astr("~", (yyvsp[0].pch)); }
-#line 5176 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 857 "chapel.ypp"
+    { (yyval.pch) = astr("~", (yyvsp[(2) - (2)].pch)); }
     break;
 
   case 140:
-#line 857 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 858 "chapel.ypp"
     { (yyval.pch) = "&"; }
-#line 5182 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 141:
-#line 858 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 859 "chapel.ypp"
     { (yyval.pch) = "|"; }
-#line 5188 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 142:
-#line 859 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 860 "chapel.ypp"
     { (yyval.pch) = "^"; }
-#line 5194 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 143:
-#line 860 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 861 "chapel.ypp"
     { (yyval.pch) = "~"; }
-#line 5200 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 144:
-#line 861 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 862 "chapel.ypp"
     { (yyval.pch) = "=="; }
-#line 5206 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 145:
-#line 862 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 863 "chapel.ypp"
     { (yyval.pch) = "!="; }
-#line 5212 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 146:
-#line 863 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 864 "chapel.ypp"
     { (yyval.pch) = "<="; }
-#line 5218 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 147:
-#line 864 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 865 "chapel.ypp"
     { (yyval.pch) = ">="; }
-#line 5224 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 148:
-#line 865 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 866 "chapel.ypp"
     { (yyval.pch) = "<"; }
-#line 5230 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 149:
-#line 866 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 867 "chapel.ypp"
     { (yyval.pch) = ">"; }
-#line 5236 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 150:
-#line 867 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 868 "chapel.ypp"
     { (yyval.pch) = "+"; }
-#line 5242 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 151:
-#line 868 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 869 "chapel.ypp"
     { (yyval.pch) = "-"; }
-#line 5248 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 152:
-#line 869 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 870 "chapel.ypp"
     { (yyval.pch) = "*"; }
-#line 5254 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 153:
-#line 870 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 871 "chapel.ypp"
     { (yyval.pch) = "/"; }
-#line 5260 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 154:
-#line 871 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 872 "chapel.ypp"
     { (yyval.pch) = "<<"; }
-#line 5266 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 155:
-#line 872 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 873 "chapel.ypp"
     { (yyval.pch) = ">>"; }
-#line 5272 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 156:
-#line 873 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 874 "chapel.ypp"
     { (yyval.pch) = "%"; }
-#line 5278 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 157:
-#line 874 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 875 "chapel.ypp"
     { (yyval.pch) = "**"; }
-#line 5284 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 158:
-#line 875 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 876 "chapel.ypp"
     { (yyval.pch) = "!"; }
-#line 5290 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 159:
-#line 876 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 877 "chapel.ypp"
     { (yyval.pch) = "chpl_by"; }
-#line 5296 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 160:
-#line 877 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 878 "chapel.ypp"
     { (yyval.pch) = "#"; }
-#line 5302 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 161:
-#line 878 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 879 "chapel.ypp"
     { (yyval.pch) = "align"; }
-#line 5308 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 162:
-#line 879 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 880 "chapel.ypp"
     { (yyval.pch) = "<=>"; }
-#line 5314 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 163:
-#line 880 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 881 "chapel.ypp"
     { (yyval.pch) = "<~>"; }
-#line 5320 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 164:
-#line 884 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 885 "chapel.ypp"
     { (yyval.pch) = "="; }
-#line 5326 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 165:
-#line 885 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 886 "chapel.ypp"
     { (yyval.pch) = "+="; }
-#line 5332 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 166:
-#line 886 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 887 "chapel.ypp"
     { (yyval.pch) = "-="; }
-#line 5338 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 167:
-#line 887 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 888 "chapel.ypp"
     { (yyval.pch) = "*="; }
-#line 5344 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 168:
-#line 888 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 889 "chapel.ypp"
     { (yyval.pch) = "/="; }
-#line 5350 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 169:
-#line 889 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 890 "chapel.ypp"
     { (yyval.pch) = "%="; }
-#line 5356 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 170:
-#line 890 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 891 "chapel.ypp"
     { (yyval.pch) = "**="; }
-#line 5362 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 171:
-#line 891 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 892 "chapel.ypp"
     { (yyval.pch) = "&="; }
-#line 5368 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 172:
-#line 892 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 893 "chapel.ypp"
     { (yyval.pch) = "|="; }
-#line 5374 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 173:
-#line 893 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 894 "chapel.ypp"
     { (yyval.pch) = "^="; }
-#line 5380 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 174:
-#line 894 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 895 "chapel.ypp"
     { (yyval.pch) = ">>="; }
-#line 5386 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 175:
-#line 895 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 896 "chapel.ypp"
     { (yyval.pch) = "<<="; }
-#line 5392 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 176:
-#line 899 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 900 "chapel.ypp"
     { (yyval.pfnsymbol) = new FnSymbol("_"); (yyval.pfnsymbol)->addFlag(FLAG_NO_PARENS); }
-#line 5398 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 177:
-#line 900 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pfnsymbol) = (yyvsp[-1].pfnsymbol); }
-#line 5404 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 901 "chapel.ypp"
+    { (yyval.pfnsymbol) = (yyvsp[(2) - (3)].pfnsymbol); }
     break;
 
   case 178:
-#line 904 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pfnsymbol) = (yyvsp[-1].pfnsymbol); }
-#line 5410 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 905 "chapel.ypp"
+    { (yyval.pfnsymbol) = (yyvsp[(2) - (3)].pfnsymbol); }
     break;
 
   case 179:
-#line 908 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 909 "chapel.ypp"
     { (yyval.pfnsymbol) = buildFunctionFormal(NULL, NULL); }
-#line 5416 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 180:
-#line 909 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pfnsymbol) = buildFunctionFormal(NULL, (yyvsp[0].pdefexpr)); }
-#line 5422 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 910 "chapel.ypp"
+    { (yyval.pfnsymbol) = buildFunctionFormal(NULL, (yyvsp[(1) - (1)].pdefexpr)); }
     break;
 
   case 181:
-#line 910 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pfnsymbol) = buildFunctionFormal((yyvsp[-2].pfnsymbol), (yyvsp[0].pdefexpr)); }
-#line 5428 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 911 "chapel.ypp"
+    { (yyval.pfnsymbol) = buildFunctionFormal((yyvsp[(1) - (3)].pfnsymbol), (yyvsp[(3) - (3)].pdefexpr)); }
     break;
 
   case 182:
-#line 915 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[-3].pt), (yyvsp[-2].pch), (yyvsp[-1].pexpr), (yyvsp[0].pexpr), NULL); }
-#line 5434 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 916 "chapel.ypp"
+    { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[(1) - (4)].pt), (yyvsp[(2) - (4)].pch), (yyvsp[(3) - (4)].pexpr), (yyvsp[(4) - (4)].pexpr), NULL); }
     break;
 
   case 183:
-#line 917 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[-3].pt), (yyvsp[-2].pch), (yyvsp[-1].pexpr), NULL, (yyvsp[0].pexpr)); }
-#line 5440 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 918 "chapel.ypp"
+    { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[(1) - (4)].pt), (yyvsp[(2) - (4)].pch), (yyvsp[(3) - (4)].pexpr), NULL, (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 184:
-#line 919 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pdefexpr) = buildTupleArgDefExpr((yyvsp[-5].pt), (yyvsp[-3].pblockstmt), (yyvsp[-1].pexpr), (yyvsp[0].pexpr)); }
-#line 5446 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 920 "chapel.ypp"
+    { (yyval.pdefexpr) = buildTupleArgDefExpr((yyvsp[(1) - (6)].pt), (yyvsp[(3) - (6)].pblockstmt), (yyvsp[(5) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)); }
     break;
 
   case 185:
-#line 921 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 922 "chapel.ypp"
     { USR_FATAL("variable-length argument may not be grouped in a tuple"); }
-#line 5452 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 186:
-#line 925 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 926 "chapel.ypp"
     { (yyval.pt) = INTENT_BLANK; }
-#line 5458 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 187:
-#line 926 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 927 "chapel.ypp"
     { (yyval.pt) = INTENT_IN; }
-#line 5464 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 188:
-#line 927 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 928 "chapel.ypp"
     { (yyval.pt) = INTENT_INOUT; }
-#line 5470 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 189:
-#line 928 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 929 "chapel.ypp"
     { (yyval.pt) = INTENT_OUT; }
-#line 5476 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 190:
-#line 929 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 930 "chapel.ypp"
     { (yyval.pt) = INTENT_CONST; }
-#line 5482 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 191:
-#line 930 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 931 "chapel.ypp"
     { (yyval.pt) = INTENT_CONST_IN; }
-#line 5488 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 192:
-#line 931 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 932 "chapel.ypp"
     { (yyval.pt) = INTENT_CONST_REF; }
-#line 5494 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 193:
-#line 932 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 933 "chapel.ypp"
     { (yyval.pt) = INTENT_PARAM; }
-#line 5500 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 194:
-#line 933 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 934 "chapel.ypp"
     { (yyval.pt) = INTENT_REF; }
-#line 5506 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 195:
-#line 934 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 935 "chapel.ypp"
     { (yyval.pt) = INTENT_TYPE; }
-#line 5512 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 196:
-#line 938 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 939 "chapel.ypp"
     { (yyval.pt) = INTENT_BLANK; }
-#line 5518 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 197:
-#line 939 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 940 "chapel.ypp"
     { (yyval.pt) = INTENT_PARAM; }
-#line 5524 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 198:
-#line 940 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 941 "chapel.ypp"
     { (yyval.pt) = INTENT_REF;   }
-#line 5530 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 199:
-#line 944 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 945 "chapel.ypp"
     { (yyval.procIter) = ProcIter_PROC; }
-#line 5536 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 200:
-#line 945 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 946 "chapel.ypp"
     { (yyval.procIter) = ProcIter_ITER; }
-#line 5542 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 201:
-#line 949 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 950 "chapel.ypp"
     { (yyval.retTag) = RET_VALUE; }
-#line 5548 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 202:
-#line 950 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 951 "chapel.ypp"
     { (yyval.retTag) = RET_VALUE; }
-#line 5554 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 203:
-#line 951 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 952 "chapel.ypp"
     { (yyval.retTag) = RET_REF; }
-#line 5560 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 204:
-#line 952 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 953 "chapel.ypp"
     { (yyval.retTag) = RET_PARAM; }
-#line 5566 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 205:
-#line 953 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 954 "chapel.ypp"
     { (yyval.retTag) = RET_TYPE; }
-#line 5572 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 206:
-#line 957 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 958 "chapel.ypp"
     { (yyval.pblockstmt) = NULL; }
-#line 5578 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 209:
-#line 963 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = new BlockStmt((yyvsp[0].pblockstmt)); }
-#line 5584 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 964 "chapel.ypp"
+    { (yyval.pblockstmt) = new BlockStmt((yyvsp[(1) - (1)].pblockstmt)); }
     break;
 
   case 210:
-#line 968 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pdefexpr) = new DefExpr(new VarSymbol((yyvsp[0].pch))); }
-#line 5590 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 969 "chapel.ypp"
+    { (yyval.pdefexpr) = new DefExpr(new VarSymbol((yyvsp[(2) - (2)].pch))); }
     break;
 
   case 211:
-#line 970 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 971 "chapel.ypp"
     { (yyval.pdefexpr) = new DefExpr(new VarSymbol(astr("chpl__query", istr(query_uid++)))); }
-#line 5596 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 212:
-#line 974 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 975 "chapel.ypp"
     { (yyval.pdefexpr) = new DefExpr(new VarSymbol(astr("chpl__query", istr(query_uid++)))); }
-#line 5602 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 214:
-#line 979 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pexpr); }
-#line 5608 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 980 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 215:
-#line 980 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[0].pdefexpr)->sym->addFlag(FLAG_PARAM); (yyval.pexpr) = (yyvsp[0].pdefexpr); }
-#line 5614 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 981 "chapel.ypp"
+    { (yyvsp[(2) - (2)].pdefexpr)->sym->addFlag(FLAG_PARAM); (yyval.pexpr) = (yyvsp[(2) - (2)].pdefexpr); }
     break;
 
   case 216:
-#line 984 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 985 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
-#line 5620 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 217:
-#line 985 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pexpr); }
-#line 5626 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 986 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 218:
-#line 990 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = (yyvsp[-1].pblockstmt); }
-#line 5632 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 991 "chapel.ypp"
+    { (yyval.pblockstmt) = (yyvsp[(2) - (3)].pblockstmt); }
     break;
 
   case 219:
-#line 992 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = handleConfigTypes((yyvsp[-1].pblockstmt)); }
-#line 5638 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 993 "chapel.ypp"
+    { (yyval.pblockstmt) = handleConfigTypes((yyvsp[(3) - (4)].pblockstmt)); }
     break;
 
   case 220:
-#line 994 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = convertTypesToExtern((yyvsp[-1].pblockstmt)); }
-#line 5644 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 995 "chapel.ypp"
+    { (yyval.pblockstmt) = convertTypesToExtern((yyvsp[(3) - (4)].pblockstmt)); }
     break;
 
   case 221:
-#line 999 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1000 "chapel.ypp"
     {
-      VarSymbol* var = new VarSymbol((yyvsp[-1].pch));
+      VarSymbol* var = new VarSymbol((yyvsp[(1) - (2)].pch));
 
       var->addFlag(FLAG_TYPE_VARIABLE);
 
       var->doc               = context->latestComment;
       context->latestComment = NULL;
 
-      DefExpr* def = new DefExpr(var, (yyvsp[0].pexpr));
+      DefExpr* def = new DefExpr(var, (yyvsp[(2) - (2)].pexpr));
 
       (yyval.pblockstmt) = buildChapelStmt(def);
     }
-#line 5661 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 222:
-#line 1012 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1013 "chapel.ypp"
     {
-      VarSymbol* var = new VarSymbol((yyvsp[-3].pch));
+      VarSymbol* var = new VarSymbol((yyvsp[(1) - (4)].pch));
 
       var->addFlag(FLAG_TYPE_VARIABLE);
 
       var->doc               = context->latestComment;
       context->latestComment = NULL;
 
-      DefExpr* def = new DefExpr(var, (yyvsp[-2].pexpr));
+      DefExpr* def = new DefExpr(var, (yyvsp[(2) - (4)].pexpr));
 
-      (yyvsp[0].pblockstmt)->insertAtHead(def);
-      (yyval.pblockstmt) = buildChapelStmt((yyvsp[0].pblockstmt));
+      (yyvsp[(4) - (4)].pblockstmt)->insertAtHead(def);
+      (yyval.pblockstmt) = buildChapelStmt((yyvsp[(4) - (4)].pblockstmt));
     }
-#line 5679 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 223:
-#line 1028 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1029 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
-#line 5685 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 224:
-#line 1030 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pexpr); }
-#line 5691 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1031 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 225:
-#line 1032 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForallLoopExprFromArrayType((yyvsp[0].pcallexpr)); }
-#line 5697 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1033 "chapel.ypp"
+    { (yyval.pexpr) = buildForallLoopExprFromArrayType((yyvsp[(2) - (2)].pcallexpr)); }
     break;
 
   case 226:
-#line 1037 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1038 "chapel.ypp"
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[-3].flag));
+      flags.insert((yyvsp[(1) - (4)].flag));
       flags.insert(FLAG_PARAM);
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-3]).comment);
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[(3) - (4)].pblockstmt), flags, (yylsp[(1) - (4)]).comment);
     }
-#line 5708 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 227:
-#line 1044 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1045 "chapel.ypp"
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[-3].flag));
+      flags.insert((yyvsp[(1) - (4)].flag));
       flags.insert(FLAG_CONST);
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-3]).comment);
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[(3) - (4)].pblockstmt), flags, (yylsp[(1) - (4)]).comment);
     }
-#line 5719 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 228:
-#line 1051 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1052 "chapel.ypp"
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[-3].flag));
+      flags.insert((yyvsp[(1) - (4)].flag));
       flags.insert(FLAG_REF_VAR);
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-3]).comment);
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[(3) - (4)].pblockstmt), flags, (yylsp[(1) - (4)]).comment);
     }
-#line 5730 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 229:
-#line 1058 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1059 "chapel.ypp"
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[-4].flag));
+      flags.insert((yyvsp[(1) - (5)].flag));
       flags.insert(FLAG_CONST);
       flags.insert(FLAG_REF_VAR);
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-4]).comment);
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[(4) - (5)].pblockstmt), flags, (yylsp[(1) - (5)]).comment);
     }
-#line 5742 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 230:
-#line 1066 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1067 "chapel.ypp"
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[-3].flag));
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-3]).comment);
+      flags.insert((yyvsp[(1) - (4)].flag));
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[(3) - (4)].pblockstmt), flags, (yylsp[(1) - (4)]).comment);
     }
-#line 5752 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 231:
-#line 1074 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1075 "chapel.ypp"
     { (yyval.flag) = FLAG_UNKNOWN; (yyloc).comment = context->latestComment; context->latestComment = NULL; }
-#line 5758 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 232:
-#line 1075 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1076 "chapel.ypp"
     { (yyval.flag) = FLAG_CONFIG;  (yyloc).comment = context->latestComment; context->latestComment = NULL; }
-#line 5764 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 233:
-#line 1076 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1077 "chapel.ypp"
     { (yyval.flag) = FLAG_EXTERN;  (yyloc).comment = context->latestComment; context->latestComment = NULL; }
-#line 5770 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 235:
-#line 1082 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1083 "chapel.ypp"
     {
-      for_alist(expr, (yyvsp[0].pblockstmt)->body)
-        (yyvsp[-2].pblockstmt)->insertAtTail(expr->remove());
+      for_alist(expr, (yyvsp[(3) - (3)].pblockstmt)->body)
+        (yyvsp[(1) - (3)].pblockstmt)->insertAtTail(expr->remove());
     }
-#line 5779 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 236:
-#line 1090 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(new VarSymbol((yyvsp[-2].pch)), (yyvsp[0].pexpr), (yyvsp[-1].pexpr))); }
-#line 5785 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1091 "chapel.ypp"
+    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(new VarSymbol((yyvsp[(1) - (3)].pch)), (yyvsp[(3) - (3)].pexpr), (yyvsp[(2) - (3)].pexpr))); }
     break;
 
   case 237:
-#line 1092 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1093 "chapel.ypp"
     {
-      VarSymbol* var = new VarSymbol((yyvsp[-3].pch));
+      VarSymbol* var = new VarSymbol((yyvsp[(1) - (4)].pch));
       var->addFlag(FLAG_ARRAY_ALIAS);
-      (yyval.pblockstmt) = buildChapelStmt(new DefExpr(var, (yyvsp[0].pexpr), (yyvsp[-2].pexpr)));
+      (yyval.pblockstmt) = buildChapelStmt(new DefExpr(var, (yyvsp[(4) - (4)].pexpr), (yyvsp[(2) - (4)].pexpr)));
     }
-#line 5795 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 238:
-#line 1098 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildTupleVarDeclStmt((yyvsp[-3].pblockstmt), (yyvsp[-1].pexpr), (yyvsp[0].pexpr)); }
-#line 5801 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1099 "chapel.ypp"
+    { (yyval.pblockstmt) = buildTupleVarDeclStmt((yyvsp[(2) - (5)].pblockstmt), (yyvsp[(4) - (5)].pexpr), (yyvsp[(5) - (5)].pexpr)); }
     break;
 
   case 239:
-#line 1103 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1104 "chapel.ypp"
     { (yyval.pexpr) = new DefExpr(new VarSymbol("chpl__tuple_blank")); }
-#line 5807 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 240:
-#line 1105 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new DefExpr(new VarSymbol((yyvsp[0].pch))); }
-#line 5813 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1106 "chapel.ypp"
+    { (yyval.pexpr) = new DefExpr(new VarSymbol((yyvsp[(1) - (1)].pch))); }
     break;
 
   case 241:
-#line 1107 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[-1].pblockstmt); }
-#line 5819 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1108 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (3)].pblockstmt); }
     break;
 
   case 242:
-#line 1112 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[0].pexpr)); }
-#line 5825 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1113 "chapel.ypp"
+    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[(1) - (1)].pexpr)); }
     break;
 
   case 243:
-#line 1114 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[-1].pexpr)); }
-#line 5831 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1115 "chapel.ypp"
+    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[(1) - (2)].pexpr)); }
     break;
 
   case 244:
-#line 1116 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pblockstmt) = ((yyvsp[0].pblockstmt)->insertAtHead((yyvsp[-2].pexpr)), (yyvsp[0].pblockstmt)); }
-#line 5837 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1117 "chapel.ypp"
+    { (yyval.pblockstmt) = ((yyvsp[(3) - (3)].pblockstmt)->insertAtHead((yyvsp[(1) - (3)].pexpr)), (yyvsp[(3) - (3)].pblockstmt)); }
     break;
 
   case 245:
-#line 1122 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1123 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
-#line 5843 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 246:
-#line 1123 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1124 "chapel.ypp"
     { (yyval.pexpr) = new SymExpr(gNoInit); }
-#line 5849 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 247:
-#line 1124 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pexpr); }
-#line 5855 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1125 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 248:
-#line 1128 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1129 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
-#line 5861 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 249:
-#line 1130 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__ensureDomainExpr", (yyvsp[-1].pcallexpr)); }
-#line 5867 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1131 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__ensureDomainExpr", (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 250:
-#line 1134 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1135 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
-#line 5873 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 251:
-#line 1135 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pexpr); }
-#line 5879 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1136 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 252:
-#line 1136 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pcallexpr); }
-#line 5885 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1137 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (2)].pcallexpr); }
     break;
 
   case 253:
-#line 1137 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1138 "chapel.ypp"
     {printf("bad type specification"); }
-#line 5891 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 254:
-#line 1158 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1159 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr("chpl__buildArrayRuntimeType",
-             new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pcallexpr)), (yyvsp[0].pexpr));
+             new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), (yyvsp[(4) - (4)].pexpr));
     }
-#line 5899 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 255:
-#line 1162 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1163 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr("chpl__buildArrayRuntimeType",
-             new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pcallexpr)), (yyvsp[0].pcallexpr));
+             new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), (yyvsp[(4) - (4)].pcallexpr));
     }
-#line 5907 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 256:
-#line 1166 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1167 "chapel.ypp"
     {
-      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[-2].pexpr), "invalid index expression");
+      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[(4) - (6)].pexpr), "invalid index expression");
       (yyval.pcallexpr) = new CallExpr("chpl__buildArrayRuntimeType",
-             new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pexpr)), (yyvsp[0].pexpr), (yyvsp[-4].pcallexpr)->get(1)->remove(),
-             new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pexpr)->copy()));
+             new CallExpr("chpl__ensureDomainExpr", (yyvsp[(4) - (6)].pexpr)), (yyvsp[(6) - (6)].pexpr), (yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(),
+             new CallExpr("chpl__ensureDomainExpr", (yyvsp[(4) - (6)].pexpr)->copy()));
     }
-#line 5919 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 257:
-#line 1173 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1174 "chapel.ypp"
     {printf("bad array type specification"); clean_exit(1); }
-#line 5925 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 258:
-#line 1177 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1178 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
-#line 5931 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 259:
-#line 1178 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pexpr); }
-#line 5937 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1179 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(1) - (1)].pexpr); }
     break;
 
   case 260:
-#line 1179 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pdefexpr); }
-#line 5943 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1180 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(1) - (1)].pdefexpr); }
     break;
 
   case 261:
-#line 1184 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[0].pexpr)); }
-#line 5949 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1185 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 262:
-#line 1186 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildFormalArrayType((yyvsp[-2].pcallexpr), (yyvsp[0].pexpr)); }
-#line 5955 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1187 "chapel.ypp"
+    { (yyval.pexpr) = buildFormalArrayType((yyvsp[(2) - (4)].pcallexpr), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 263:
-#line 1192 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[0].pexpr)); }
-#line 5961 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1193 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 264:
-#line 1194 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildFormalArrayType((yyvsp[-2].pcallexpr), (yyvsp[0].pexpr)); }
-#line 5967 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1195 "chapel.ypp"
+    { (yyval.pexpr) = buildFormalArrayType((yyvsp[(2) - (4)].pcallexpr), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 265:
-#line 1196 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildFormalArrayType((yyvsp[-2].pexpr), (yyvsp[0].pexpr), (yyvsp[-4].pcallexpr)); }
-#line 5973 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1197 "chapel.ypp"
+    { (yyval.pexpr) = buildFormalArrayType((yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), (yyvsp[(2) - (6)].pcallexpr)); }
     break;
 
   case 266:
-#line 1200 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1201 "chapel.ypp"
     { (yyval.pexpr) = NULL; }
-#line 5979 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 267:
-#line 1201 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pexpr); }
-#line 5985 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1202 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 268:
-#line 1202 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pdefexpr); }
-#line 5991 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1203 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (2)].pdefexpr); }
     break;
 
   case 269:
-#line 1203 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1204 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("_domain"); }
-#line 5997 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 270:
-#line 1204 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1205 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr( "_singlevar"); }
-#line 6003 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 271:
-#line 1205 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1206 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr( "_syncvar"); }
-#line 6009 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 272:
-#line 1206 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pexpr); }
-#line 6015 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1207 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
     break;
 
   case 273:
-#line 1212 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[0].pexpr)); }
-#line 6021 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1213 "chapel.ypp"
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pexpr)); }
     break;
 
   case 274:
-#line 1213 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[0].pdefexpr)); }
-#line 6027 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1214 "chapel.ypp"
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pdefexpr)); }
     break;
 
   case 275:
-#line 1214 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pexpr)); }
-#line 6033 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1215 "chapel.ypp"
+    { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 276:
-#line 1215 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pdefexpr)); }
-#line 6039 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1216 "chapel.ypp"
+    { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pdefexpr)); }
     break;
 
   case 277:
-#line 1219 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1220 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("chpl__tuple_blank"); }
-#line 6045 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 278:
-#line 1220 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pexpr); }
-#line 6051 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1221 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(1) - (1)].pexpr); }
     break;
 
   case 279:
-#line 1221 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pdefexpr); }
-#line 6057 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1222 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(1) - (1)].pdefexpr); }
     break;
 
   case 280:
-#line 1225 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6063 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1226 "chapel.ypp"
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 281:
-#line 1226 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pexpr)); }
-#line 6069 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1227 "chapel.ypp"
+    { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 282:
-#line 1230 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1231 "chapel.ypp"
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST); }
-#line 6075 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 284:
-#line 1235 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[0].pexpr)); }
-#line 6081 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1236 "chapel.ypp"
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pexpr)); }
     break;
 
   case 285:
-#line 1236 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pexpr)); }
-#line 6087 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1237 "chapel.ypp"
+    { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 286:
-#line 1240 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildNamedActual((yyvsp[-2].pch), (yyvsp[0].pdefexpr)); }
-#line 6093 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1241 "chapel.ypp"
+    { (yyval.pexpr) = buildNamedActual((yyvsp[(1) - (3)].pch), (yyvsp[(3) - (3)].pdefexpr)); }
     break;
 
   case 287:
-#line 1241 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildNamedActual((yyvsp[-2].pch), (yyvsp[0].pexpr)); }
-#line 6099 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1242 "chapel.ypp"
+    { (yyval.pexpr) = buildNamedActual((yyvsp[(1) - (3)].pch), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 288:
-#line 1242 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildNamedAliasActual((yyvsp[-2].pch), (yyvsp[0].pexpr)); }
-#line 6105 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1243 "chapel.ypp"
+    { (yyval.pexpr) = buildNamedAliasActual((yyvsp[(1) - (3)].pch), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 289:
-#line 1243 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[0].pdefexpr); }
-#line 6111 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1244 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(1) - (1)].pdefexpr); }
     break;
 
   case 291:
-#line 1248 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new UnresolvedSymExpr((yyvsp[0].pch)); }
-#line 6117 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1249 "chapel.ypp"
+    { (yyval.pexpr) = new UnresolvedSymExpr((yyvsp[(1) - (1)].pch)); }
     break;
 
   case 297:
-#line 1265 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr( "_singlevar", (yyvsp[0].pexpr)); }
-#line 6123 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1266 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr( "_singlevar", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 298:
-#line 1267 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__buildIndexType", (yyvsp[-1].pcallexpr)); }
-#line 6129 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1268 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__buildIndexType", (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 299:
-#line 1269 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__buildDomainRuntimeType", new UnresolvedSymExpr("defaultDist"), (yyvsp[-1].pcallexpr)); }
-#line 6135 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1270 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__buildDomainRuntimeType", new UnresolvedSymExpr("defaultDist"), (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 300:
-#line 1271 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__buildSubDomainType", (yyvsp[-1].pcallexpr)); }
-#line 6141 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1272 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__buildSubDomainType", (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 301:
-#line 1273 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__buildSparseDomainRuntimeType", new UnresolvedSymExpr("defaultDist"), (yyvsp[-1].pcallexpr)); }
-#line 6147 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1274 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__buildSparseDomainRuntimeType", new UnresolvedSymExpr("defaultDist"), (yyvsp[(4) - (5)].pcallexpr)); }
     break;
 
   case 302:
-#line 1275 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__atomicType", (yyvsp[0].pexpr)); }
-#line 6153 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1276 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__atomicType", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 303:
-#line 1277 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr( "_syncvar", (yyvsp[0].pexpr)); }
-#line 6159 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1278 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr( "_syncvar", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 304:
-#line 1282 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForLoopExpr((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6165 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1283 "chapel.ypp"
+    { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)); }
     break;
 
   case 305:
-#line 1284 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForLoopExpr((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[0].pexpr), NULL, false, true); }
-#line 6171 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1285 "chapel.ypp"
+    { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), NULL, false, true); }
     break;
 
   case 306:
-#line 1286 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6177 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1287 "chapel.ypp"
+    { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 307:
-#line 1288 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForLoopExpr((yyvsp[-7].pexpr), (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
-#line 6183 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1289 "chapel.ypp"
+    { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr)); }
     break;
 
   case 308:
-#line 1290 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForLoopExpr((yyvsp[-7].pexpr), (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr), false, true); }
-#line 6189 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1291 "chapel.ypp"
+    { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr), false, true); }
     break;
 
   case 309:
-#line 1292 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
-#line 6195 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1293 "chapel.ypp"
+    { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[(2) - (7)].pexpr), (yyvsp[(7) - (7)].pexpr), (yyvsp[(5) - (7)].pexpr)); }
     break;
 
   case 310:
-#line 1294 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6201 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1295 "chapel.ypp"
+    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)); }
     break;
 
   case 311:
-#line 1296 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[0].pexpr), NULL, false, true); }
-#line 6207 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1297 "chapel.ypp"
+    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), NULL, false, true); }
     break;
 
   case 312:
-#line 1298 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6213 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1299 "chapel.ypp"
+    { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 313:
-#line 1300 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[-7].pexpr), (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
-#line 6219 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1301 "chapel.ypp"
+    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr)); }
     break;
 
   case 314:
-#line 1302 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[-7].pexpr), (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr), false, true); }
-#line 6225 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1303 "chapel.ypp"
+    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr), false, true); }
     break;
 
   case 315:
-#line 1304 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
-#line 6231 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1305 "chapel.ypp"
+    { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[(2) - (7)].pexpr), (yyvsp[(7) - (7)].pexpr), (yyvsp[(5) - (7)].pexpr)); }
     break;
 
   case 316:
-#line 1306 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1307 "chapel.ypp"
     {
-      if ((yyvsp[-2].pcallexpr)->argList.length > 1)
-        (yyval.pexpr) = buildForallLoopExpr(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pcallexpr)), (yyvsp[0].pexpr), NULL, true);
+      if ((yyvsp[(2) - (4)].pcallexpr)->argList.length > 1)
+        (yyval.pexpr) = buildForallLoopExpr(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), (yyvsp[(4) - (4)].pexpr), NULL, true);
       else
-        (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[-2].pcallexpr)->get(1)->remove(), (yyvsp[0].pexpr), NULL, true);
+        (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[(2) - (4)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (4)].pexpr), NULL, true);
     }
-#line 6242 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 317:
-#line 1313 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1314 "chapel.ypp"
     {
-      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[-2].pexpr), "invalid index expression");
-      (yyval.pexpr) = buildForallLoopExpr((yyvsp[-4].pcallexpr)->get(1)->remove(), (yyvsp[-2].pexpr), (yyvsp[0].pexpr), NULL, true);
+      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[(4) - (6)].pexpr), "invalid index expression");
+      (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), NULL, true);
     }
-#line 6252 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 318:
-#line 1319 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1320 "chapel.ypp"
     {
-      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[-2].pexpr), "invalid index expression");
-      (yyval.pexpr) = buildForallLoopExpr((yyvsp[-4].pcallexpr)->get(1)->remove(), (yyvsp[-2].pexpr), (yyvsp[0].pexpr), NULL, false, true);
+      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[(4) - (6)].pexpr), "invalid index expression");
+      (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), NULL, false, true);
     }
-#line 6262 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 319:
-#line 1325 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1326 "chapel.ypp"
     {
-      if ((yyvsp[-7].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[-5].pexpr), "invalid index expression");
-      (yyval.pexpr) = buildForallLoopExpr((yyvsp[-7].pcallexpr)->get(1)->remove(), (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr));
+      if ((yyvsp[(2) - (9)].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[(4) - (9)].pexpr), "invalid index expression");
+      (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr));
     }
-#line 6272 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 320:
-#line 1331 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1332 "chapel.ypp"
     {
-      if ((yyvsp[-7].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[-5].pexpr), "invalid index expression");
-      (yyval.pexpr) = buildForallLoopExpr((yyvsp[-7].pcallexpr)->get(1)->remove(), (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr), false, true);
+      if ((yyvsp[(2) - (9)].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[(4) - (9)].pexpr), "invalid index expression");
+      (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr), false, true);
     }
-#line 6282 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 321:
-#line 1340 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr(new DefExpr(buildIfExpr((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[0].pexpr)))); }
-#line 6288 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1341 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr(new DefExpr(buildIfExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)))); }
     break;
 
   case 322:
-#line 1344 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1345 "chapel.ypp"
     { (yyval.pexpr) = new SymExpr(gNil); }
-#line 6294 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 330:
-#line 1360 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6300 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1361 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 331:
-#line 1364 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1365 "chapel.ypp"
     { (yyval.pcallexpr) = NULL; }
-#line 6306 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 333:
-#line 1369 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pcallexpr) = (yyvsp[-1].pcallexpr); }
-#line 6312 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1370 "chapel.ypp"
+    { (yyval.pcallexpr) = (yyvsp[(3) - (4)].pcallexpr); }
     break;
 
   case 334:
-#line 1374 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[0].pIntentExpr).first, (yyvsp[0].pIntentExpr).second); }
-#line 6318 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1375 "chapel.ypp"
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pIntentExpr).first, (yyvsp[(1) - (1)].pIntentExpr).second); }
     break;
 
   case 335:
-#line 1376 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1377 "chapel.ypp"
     {
-      (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pIntentExpr).first);
-      (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pIntentExpr).second);
+      (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pIntentExpr).first);
+      (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pIntentExpr).second);
     }
-#line 6327 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 336:
-#line 1384 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1385 "chapel.ypp"
     {
-      ArgSymbol* tiMark = tiMarkForIntent((yyvsp[-1].pt));
+      ArgSymbol* tiMark = tiMarkForIntent((yyvsp[(1) - (2)].pt));
       if (!tiMark)
-        USR_FATAL_CONT((yyvsp[0].pexpr), "Unsupported intent in with clause");
+        USR_FATAL_CONT((yyvsp[(2) - (2)].pexpr), "Unsupported intent in with clause");
       (yyval.pIntentExpr).first = new SymExpr(tiMark);
-      (yyval.pIntentExpr).second = (yyvsp[0].pexpr);
+      (yyval.pIntentExpr).second = (yyvsp[(2) - (2)].pexpr);
     }
-#line 6339 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 337:
-#line 1393 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pIntentExpr).first = (yyvsp[-2].pexpr), (yyval.pIntentExpr).second = (yyvsp[0].pexpr); }
-#line 6345 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1394 "chapel.ypp"
+    { (yyval.pIntentExpr).first = (yyvsp[(1) - (3)].pexpr), (yyval.pIntentExpr).second = (yyvsp[(3) - (3)].pexpr); }
     break;
 
   case 339:
-#line 1399 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6351 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1400 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 340:
-#line 1404 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr(PRIM_NEW, (yyvsp[0].pexpr)); }
-#line 6357 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1405 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr(PRIM_NEW, (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 341:
-#line 1409 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildLetExpr((yyvsp[-2].pblockstmt), (yyvsp[0].pexpr)); }
-#line 6363 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1410 "chapel.ypp"
+    { (yyval.pexpr) = buildLetExpr((yyvsp[(2) - (4)].pblockstmt), (yyvsp[(4) - (4)].pexpr)); }
     break;
 
   case 350:
-#line 1425 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr(PRIM_TUPLE_EXPAND, (yyvsp[-1].pexpr)); }
-#line 6369 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1426 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr(PRIM_TUPLE_EXPAND, (yyvsp[(3) - (4)].pexpr)); }
     break;
 
   case 351:
-#line 1427 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("_cast", (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
-#line 6375 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1428 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("_cast", (yyvsp[(3) - (3)].pexpr), (yyvsp[(1) - (3)].pexpr)); }
     break;
 
   case 352:
-#line 1429 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl_build_bounded_range", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6381 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1430 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl_build_bounded_range", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 353:
-#line 1431 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl_build_partially_bounded_range", buildDotExpr("BoundedRangeType", "boundedLow"), (yyvsp[-1].pexpr)); }
-#line 6387 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1432 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl_build_partially_bounded_range", buildDotExpr("BoundedRangeType", "boundedLow"), (yyvsp[(1) - (2)].pexpr)); }
     break;
 
   case 354:
-#line 1433 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl_build_partially_bounded_range", buildDotExpr("BoundedRangeType", "boundedHigh"), (yyvsp[0].pexpr)); }
-#line 6393 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1434 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl_build_partially_bounded_range", buildDotExpr("BoundedRangeType", "boundedHigh"), (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 355:
-#line 1435 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1436 "chapel.ypp"
     { (yyval.pexpr) = new CallExpr("chpl_build_unbounded_range", buildDotExpr("BoundedRangeType", "boundedNone")); }
-#line 6399 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 362:
-#line 1458 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr((yyvsp[-3].pexpr), (yyvsp[-1].pcallexpr)); }
-#line 6405 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1459 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 363:
-#line 1459 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildSquareCallExpr((yyvsp[-3].pexpr), (yyvsp[-1].pcallexpr)); }
-#line 6411 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1460 "chapel.ypp"
+    { (yyval.pexpr) = buildSquareCallExpr((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 364:
-#line 1460 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildPrimitiveExpr((yyvsp[-1].pcallexpr)); }
-#line 6417 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1461 "chapel.ypp"
+    { (yyval.pexpr) = buildPrimitiveExpr((yyvsp[(3) - (4)].pcallexpr)); }
     break;
 
   case 365:
-#line 1464 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildDotExpr((yyvsp[-2].pexpr), (yyvsp[0].pch)); }
-#line 6423 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1465 "chapel.ypp"
+    { (yyval.pexpr) = buildDotExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pch)); }
     break;
 
   case 366:
-#line 1465 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr(PRIM_TYPEOF, (yyvsp[-2].pexpr)); }
-#line 6429 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1466 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr(PRIM_TYPEOF, (yyvsp[(1) - (3)].pexpr)); }
     break;
 
   case 367:
-#line 1466 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildDotExpr((yyvsp[-2].pexpr), "_dom"); }
-#line 6435 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1467 "chapel.ypp"
+    { (yyval.pexpr) = buildDotExpr((yyvsp[(1) - (3)].pexpr), "_dom"); }
     break;
 
   case 368:
-#line 1474 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = (yyvsp[-1].pexpr); }
-#line 6441 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1475 "chapel.ypp"
+    { (yyval.pexpr) = (yyvsp[(2) - (3)].pexpr); }
     break;
 
   case 369:
-#line 1475 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildOneTuple((yyvsp[-2].pexpr)); }
-#line 6447 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1476 "chapel.ypp"
+    { (yyval.pexpr) = buildOneTuple((yyvsp[(2) - (4)].pexpr)); }
     break;
 
   case 370:
-#line 1476 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildTuple((yyvsp[-1].pcallexpr)); }
-#line 6453 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1477 "chapel.ypp"
+    { (yyval.pexpr) = buildTuple((yyvsp[(2) - (3)].pcallexpr)); }
     break;
 
   case 371:
-#line 1480 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildIntLiteral((yyvsp[0].pch));    }
-#line 6459 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1481 "chapel.ypp"
+    { (yyval.pexpr) = buildIntLiteral((yyvsp[(1) - (1)].pch));    }
     break;
 
   case 372:
-#line 1481 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildRealLiteral((yyvsp[0].pch));   }
-#line 6465 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1482 "chapel.ypp"
+    { (yyval.pexpr) = buildRealLiteral((yyvsp[(1) - (1)].pch));   }
     break;
 
   case 373:
-#line 1482 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildImagLiteral((yyvsp[0].pch));   }
-#line 6471 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1483 "chapel.ypp"
+    { (yyval.pexpr) = buildImagLiteral((yyvsp[(1) - (1)].pch));   }
     break;
 
   case 374:
-#line 1483 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildStringLiteral((yyvsp[0].pch)); }
-#line 6477 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1484 "chapel.ypp"
+    { (yyval.pexpr) = buildStringLiteral((yyvsp[(1) - (1)].pch)); }
     break;
 
   case 375:
-#line 1484 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__buildDomainExpr", (yyvsp[-1].pcallexpr)); }
-#line 6483 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1485 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__buildDomainExpr", (yyvsp[(2) - (3)].pcallexpr)); }
     break;
 
   case 376:
-#line 1485 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__buildArrayExpr",  (yyvsp[-1].pcallexpr)); }
-#line 6489 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1486 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__buildArrayExpr",  (yyvsp[(2) - (3)].pcallexpr)); }
     break;
 
   case 377:
-#line 1487 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1488 "chapel.ypp"
     {
-      (yyval.pexpr) = new CallExpr("chpl__buildAssociativeArrayExpr", (yyvsp[-1].pcallexpr));
+      (yyval.pexpr) = new CallExpr("chpl__buildAssociativeArrayExpr", (yyvsp[(2) - (3)].pcallexpr));
     }
-#line 6497 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 378:
-#line 1493 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6503 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1494 "chapel.ypp"
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 379:
-#line 1494 "chapel.ypp" /* yacc.c:1661  */
-    { (yyvsp[-4].pcallexpr)->insertAtTail((yyvsp[-2].pexpr)); (yyvsp[-4].pcallexpr)->insertAtTail((yyvsp[0].pexpr)); }
-#line 6509 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1495 "chapel.ypp"
+    { (yyvsp[(1) - (5)].pcallexpr)->insertAtTail((yyvsp[(3) - (5)].pexpr)); (yyvsp[(1) - (5)].pcallexpr)->insertAtTail((yyvsp[(5) - (5)].pexpr)); }
     break;
 
   case 380:
-#line 1498 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("+", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6515 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1499 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("+", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 381:
-#line 1499 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("-", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6521 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1500 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("-", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 382:
-#line 1500 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("*", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6527 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1501 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("*", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 383:
-#line 1501 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("/", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6533 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1502 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("/", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 384:
-#line 1502 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("<<", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6539 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1503 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("<<", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 385:
-#line 1503 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr(">>", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6545 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1504 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr(">>", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 386:
-#line 1504 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("%", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6551 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1505 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("%", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 387:
-#line 1505 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("==", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6557 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1506 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("==", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 388:
-#line 1506 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("!=", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6563 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1507 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("!=", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 389:
-#line 1507 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("<=", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6569 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1508 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("<=", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 390:
-#line 1508 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr(">=", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6575 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1509 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr(">=", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 391:
-#line 1509 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("<", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6581 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1510 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("<", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 392:
-#line 1510 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr(">", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6587 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1511 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr(">", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 393:
-#line 1511 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("&", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6593 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1512 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("&", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 394:
-#line 1512 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("|", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6599 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1513 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("|", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 395:
-#line 1513 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("^", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6605 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1514 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("^", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 396:
-#line 1514 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("&&", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6611 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1515 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("&&", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 397:
-#line 1515 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("||", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6617 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1516 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("||", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 398:
-#line 1516 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("**", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6623 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1517 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("**", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 399:
-#line 1517 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl_by", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6629 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1518 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl_by", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 400:
-#line 1518 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("align", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6635 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1519 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("align", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 401:
-#line 1519 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("#", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6641 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1520 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("#", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 402:
-#line 1520 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("chpl__distributed", (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
-#line 6647 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1521 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("chpl__distributed", (yyvsp[(3) - (3)].pexpr), (yyvsp[(1) - (3)].pexpr)); }
     break;
 
   case 403:
-#line 1524 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("+", (yyvsp[0].pexpr)); }
-#line 6653 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1525 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("+", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 404:
-#line 1525 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("-", (yyvsp[0].pexpr)); }
-#line 6659 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1526 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("-", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 405:
-#line 1526 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[0].pexpr), '-'); }
-#line 6665 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1527 "chapel.ypp"
+    { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[(2) - (2)].pexpr), '-'); }
     break;
 
   case 406:
-#line 1527 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[0].pexpr), '+'); }
-#line 6671 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1528 "chapel.ypp"
+    { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[(2) - (2)].pexpr), '+'); }
     break;
 
   case 407:
-#line 1528 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("!", (yyvsp[0].pexpr)); }
-#line 6677 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1529 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("!", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 408:
-#line 1529 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("~", (yyvsp[0].pexpr)); }
-#line 6683 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1530 "chapel.ypp"
+    { (yyval.pexpr) = new CallExpr("~", (yyvsp[(2) - (2)].pexpr)); }
     break;
 
   case 409:
-#line 1533 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildReduceExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6689 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1534 "chapel.ypp"
+    { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 410:
-#line 1534 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildReduceExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr), true); }
-#line 6695 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1535 "chapel.ypp"
+    { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr), true); }
     break;
 
   case 411:
-#line 1535 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildReduceExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6701 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1536 "chapel.ypp"
+    { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 412:
-#line 1536 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildReduceExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr), true); }
-#line 6707 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1537 "chapel.ypp"
+    { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr), true); }
     break;
 
   case 413:
-#line 1540 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildScanExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6713 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1541 "chapel.ypp"
+    { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 414:
-#line 1541 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildScanExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr), true); }
-#line 6719 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1542 "chapel.ypp"
+    { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr), true); }
     break;
 
   case 415:
-#line 1542 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildScanExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
-#line 6725 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1543 "chapel.ypp"
+    { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 416:
-#line 1543 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = buildScanExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr), true); }
-#line 6731 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1544 "chapel.ypp"
+    { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr), true); }
     break;
 
   case 417:
-#line 1548 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1549 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("SumReduceScanOp"); }
-#line 6737 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 418:
-#line 1549 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1550 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("ProductReduceScanOp"); }
-#line 6743 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 419:
-#line 1550 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1551 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("LogicalAndReduceScanOp"); }
-#line 6749 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 420:
-#line 1551 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1552 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("LogicalOrReduceScanOp"); }
-#line 6755 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 421:
-#line 1552 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1553 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("BitwiseAndReduceScanOp"); }
-#line 6761 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 422:
-#line 1553 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1554 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("BitwiseOrReduceScanOp"); }
-#line 6767 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 423:
-#line 1554 "chapel.ypp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 1555 "chapel.ypp"
     { (yyval.pexpr) = new UnresolvedSymExpr("BitwiseXorReduceScanOp"); }
-#line 6773 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
 
-#line 6777 "bison-chapel.cpp" /* yacc.c:1661  */
+
+/* Line 1806 of yacc.c  */
+#line 7461 "bison-chapel.cpp"
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -6796,7 +7480,7 @@ yyreduce:
   *++yyvsp = yyval;
   *++yylsp = yyloc;
 
-  /* Now 'shift' the result of the reduction.  Determine what state
+  /* Now `shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
 
@@ -6811,9 +7495,9 @@ yyreduce:
   goto yynewstate;
 
 
-/*--------------------------------------.
-| yyerrlab -- here on detecting error.  |
-`--------------------------------------*/
+/*------------------------------------.
+| yyerrlab -- here on detecting error |
+`------------------------------------*/
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
@@ -6864,20 +7548,20 @@ yyerrlab:
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
-         error, discard it.  */
+	 error, discard it.  */
 
       if (yychar <= YYEOF)
-        {
-          /* Return failure if at end of input.  */
-          if (yychar == YYEOF)
-            YYABORT;
-        }
+	{
+	  /* Return failure if at end of input.  */
+	  if (yychar == YYEOF)
+	    YYABORT;
+	}
       else
-        {
-          yydestruct ("Error: discarding",
-                      yytoken, &yylval, &yylloc, context);
-          yychar = YYEMPTY;
-        }
+	{
+	  yydestruct ("Error: discarding",
+		      yytoken, &yylval, &yylloc, context);
+	  yychar = YYEMPTY;
+	}
     }
 
   /* Else will try to reuse lookahead token after shifting the error
@@ -6897,7 +7581,7 @@ yyerrorlab:
      goto yyerrorlab;
 
   yyerror_range[1] = yylsp[1-yylen];
-  /* Do not reclaim the symbols of the rule whose action triggered
+  /* Do not reclaim the symbols of the rule which action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -6910,37 +7594,35 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
+  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
 
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
-        {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-            {
-              yyn = yytable[yyn];
-              if (0 < yyn)
-                break;
-            }
-        }
+	{
+	  yyn += YYTERROR;
+	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+	    {
+	      yyn = yytable[yyn];
+	      if (0 < yyn)
+		break;
+	    }
+	}
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-        YYABORT;
+	YYABORT;
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, yylsp, context);
+		  yystos[yystate], yyvsp, yylsp, context);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
     }
 
-  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
-  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
   yyerror_range[2] = yylloc;
   /* Using YYLLOC is tempting, but would change the location of
@@ -6969,7 +7651,7 @@ yyabortlab:
   yyresult = 1;
   goto yyreturn;
 
-#if !defined yyoverflow || YYERROR_VERBOSE
+#if !defined(yyoverflow) || YYERROR_VERBOSE
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
@@ -6988,14 +7670,14 @@ yyreturn:
       yydestruct ("Cleanup: discarding lookahead",
                   yytoken, &yylval, &yylloc, context);
     }
-  /* Do not reclaim the symbols of the rule whose action triggered
+  /* Do not reclaim the symbols of the rule which action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp, yylsp, context);
+		  yystos[*yyssp], yyvsp, yylsp, context);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -7009,5 +7691,9 @@ yypushreturn:
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
 #endif
-  return yyresult;
+  /* Make sure YYID is used.  */
+  return YYID (yyresult);
 }
+
+
+

--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -731,10 +731,10 @@ static int processBlockComment(yyscan_t scanner) {
     } else if (c == 0) {
       ParserContext context(scanner);
 
-      fprintf(stderr, "%s:%d: start of unterminated comment\n",
+      fprintf(stderr, "%s:%d: unterminated comment started here\n",
               startFilename, startLine);
       if( nestedStartLine >= 0 ) {
-        fprintf(stderr, "%s:%d: start of nested comment\n",
+        fprintf(stderr, "%s:%d: nested comment started here\n",
                 startFilename, nestedStartLine);
       }
       yyerror(yyLloc, &context, "EOF in comment");

--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -677,6 +677,10 @@ static int processBlockComment(yyscan_t scanner) {
   YYSTYPE*    yyLval       = yyget_lval(scanner);
   YYLTYPE*    yyLloc       = yyget_lloc(scanner);
 
+  int nestedStartLine = -1;
+  int startLine = chplLineno;
+  const char* startFilename = yyfilename;
+
   int         len          = strlen(fDocsCommentLabel);
   int         labelIndex   = (len >= 2) ? 2 : 0;
 
@@ -722,9 +726,17 @@ static int processBlockComment(yyscan_t scanner) {
 
     } else if (lastc == '/' && c == '*') { // start nested
       depth++;
+      // keep track of the start of the last nested comment
+      nestedStartLine = chplLineno;
     } else if (c == 0) {
       ParserContext context(scanner);
 
+      fprintf(stderr, "%s:%d: start of unterminated comment\n",
+              startFilename, startLine);
+      if( nestedStartLine >= 0 ) {
+        fprintf(stderr, "%s:%d: start of nested comment\n",
+                startFilename, nestedStartLine);
+      }
       yyerror(yyLloc, &context, "EOF in comment");
     }
   }

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -214,6 +214,7 @@
   void yyerror(YYLTYPE*       ignored,
                ParserContext* context,
                const char*    str) {
+    // TODO -- should this begin with error:
     if (!chplParseString) {
       const char* yyText = yyget_text(context->scanner);
 

--- a/compiler/parser/flex-chapel.cpp
+++ b/compiler/parser/flex-chapel.cpp
@@ -47,7 +47,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -171,11 +170,6 @@ typedef void* yyscan_t;
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #endif
 
-#ifndef YY_TYPEDEF_YY_SIZE_T
-#define YY_TYPEDEF_YY_SIZE_T
-typedef size_t yy_size_t;
-#endif
-
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
@@ -198,6 +192,11 @@ typedef size_t yy_size_t;
 
 #define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
 
+#ifndef YY_TYPEDEF_YY_SIZE_T
+#define YY_TYPEDEF_YY_SIZE_T
+typedef size_t yy_size_t;
+#endif
+
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
 struct yy_buffer_state
@@ -215,7 +214,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -294,7 +293,7 @@ static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner );
 
 YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
 
 void *yyalloc (yy_size_t ,yyscan_t yyscanner );
 void *yyrealloc (void *,yy_size_t ,yyscan_t yyscanner );
@@ -345,7 +344,7 @@ static void yy_fatal_error (yyconst char msg[] ,yyscan_t yyscanner );
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (yy_size_t) (yy_cp - yy_bp); \
+	yyleng = (size_t) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
@@ -719,7 +718,7 @@ static void processInvalidToken(yyscan_t scanner);
 static bool yy_has_state(yyscan_t scanner);
 
 
-#line 723 "flex-chapel.cpp"
+#line 722 "flex-chapel.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -749,8 +748,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    yy_size_t yy_n_chars;
-    yy_size_t yyleng_r;
+    int yy_n_chars;
+    int yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -807,7 +806,7 @@ FILE *yyget_out (yyscan_t yyscanner );
 
 void yyset_out  (FILE * out_str ,yyscan_t yyscanner );
 
-yy_size_t yyget_leng (yyscan_t yyscanner );
+int yyget_leng (yyscan_t yyscanner );
 
 char *yyget_text (yyscan_t yyscanner );
 
@@ -880,7 +879,7 @@ static int input (yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -968,7 +967,7 @@ YY_DECL
 #line 102 "chapel.lex"
 
 
-#line 972 "flex-chapel.cpp"
+#line 971 "flex-chapel.cpp"
 
     yylval = yylval_param;
 
@@ -1721,7 +1720,7 @@ YY_RULE_SETUP
 #line 255 "chapel.lex"
 ECHO;
 	YY_BREAK
-#line 1725 "flex-chapel.cpp"
+#line 1724 "flex-chapel.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();
@@ -1909,7 +1908,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1923,7 +1922,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1954,7 +1953,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		/* Read in more data. */
 		YY_INPUT( (&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move]),
-			yyg->yy_n_chars, num_to_read );
+			yyg->yy_n_chars, (size_t) num_to_read );
 
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars;
 		}
@@ -2079,7 +2078,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2103,7 +2102,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 				case EOB_ACT_END_OF_FILE:
 					{
 					if ( yywrap(yyscanner ) )
-						return 0;
+						return EOF;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
@@ -2363,7 +2362,7 @@ void yypop_buffer_state (yyscan_t yyscanner)
  */
 static void yyensure_buffer_stack (yyscan_t yyscanner)
 {
-	yy_size_t num_to_alloc;
+	int num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if (!yyg->yy_buffer_stack) {
@@ -2461,11 +2460,12 @@ YY_BUFFER_STATE yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
-	yy_size_t n, i;
+	yy_size_t n;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
@@ -2615,7 +2615,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yyget_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -3329,6 +3329,10 @@ static int processBlockComment(yyscan_t scanner) {
   YYSTYPE*    yyLval       = yyget_lval(scanner);
   YYLTYPE*    yyLloc       = yyget_lloc(scanner);
 
+  int nestedStartLine = -1;
+  int startLine = chplLineno;
+  const char* startFilename = yyfilename;
+
   int         len          = strlen(fDocsCommentLabel);
   int         labelIndex   = (len >= 2) ? 2 : 0;
 
@@ -3374,9 +3378,17 @@ static int processBlockComment(yyscan_t scanner) {
 
     } else if (lastc == '/' && c == '*') { // start nested
       depth++;
+      // keep track of the start of the last nested comment
+      nestedStartLine = chplLineno;
     } else if (c == 0) {
       ParserContext context(scanner);
 
+      fprintf(stderr, "%s:%d: unterminated comment started here\n",
+              startFilename, startLine);
+      if( nestedStartLine >= 0 ) {
+        fprintf(stderr, "%s:%d: nested comment started here\n",
+                startFilename, nestedStartLine);
+      }
       yyerror(yyLloc, &context, "EOF in comment");
     }
   }

--- a/test/parsing/ferguson/comment-test.chpl
+++ b/test/parsing/ferguson/comment-test.chpl
@@ -1,0 +1,9 @@
+/* This
+   comment
+   ends
+ */
+
+/*
+   This comment does not end
+
+

--- a/test/parsing/ferguson/comment-test.good
+++ b/test/parsing/ferguson/comment-test.good
@@ -1,0 +1,2 @@
+comment-test.chpl:6: unterminated comment started here
+comment-test.chpl:10: EOF in comment

--- a/test/parsing/ferguson/comment-test2.chpl
+++ b/test/parsing/ferguson/comment-test2.chpl
@@ -1,0 +1,13 @@
+/* This
+   comment
+   ends
+ */
+
+/*
+   This comment does not end
+   because it has a nested comment
+   /*
+
+ */
+
+

--- a/test/parsing/ferguson/comment-test2.good
+++ b/test/parsing/ferguson/comment-test2.good
@@ -1,0 +1,3 @@
+comment-test2.chpl:6: unterminated comment started here
+comment-test2.chpl:9: nested comment started here
+comment-test2.chpl:14: EOF in comment

--- a/test/parsing/vass/comment-nested-slashstarslash-1.good
+++ b/test/parsing/vass/comment-nested-slashstarslash-1.good
@@ -1,3 +1,3 @@
-comment-nested-slashstarslash-1.chpl:1: start of unterminated comment
-comment-nested-slashstarslash-1.chpl:3: start of nested comment
+comment-nested-slashstarslash-1.chpl:1: unterminated comment started here
+comment-nested-slashstarslash-1.chpl:3: nested comment started here
 comment-nested-slashstarslash-1.chpl:6: EOF in comment

--- a/test/parsing/vass/comment-nested-slashstarslash-1.good
+++ b/test/parsing/vass/comment-nested-slashstarslash-1.good
@@ -1,1 +1,3 @@
+comment-nested-slashstarslash-1.chpl:1: start of unterminated comment
+comment-nested-slashstarslash-1.chpl:3: start of nested comment
 comment-nested-slashstarslash-1.chpl:6: EOF in comment


### PR DESCRIPTION
Previously, unterminated comments created errors like this:
 file.chpl:6: EOF in comment

I've updated the error message to be more useful with the start
of the comment and of the last nested comment:
 file.chpl:1: start of unterminated comment
 file.chpl:3: start of nested comment
 file.chpl:6: EOF in comment

To keep the PR diff small, I havn't committed the result of 'make parser'. I
will do so when merging, however.

test/parsing passes. There are no other tests that have the string "EOF in
comment".