### PR TITLE
Enhance vim style for chpldoc-ing

### DIFF
--- a/etc/vim/README
+++ b/etc/vim/README
@@ -10,6 +10,7 @@ File Descriptions:
 
  *ftdetect/chpl.vim* -- Allows vim to auto-detect the syntax highlighting
                         scheme for chapel files.
+ *ftplugin/chpl.vim* -- Nice settings for Chapel editing
  *syntax/chpl.vim*   -- Syntax highlighting scheme for chapel
  *indent/chpl.vim*   -- Indenting scheme for chapel
  *sample-vimrc*      -- Sample .vimrc configuration file

--- a/etc/vim/ftplugin/chpl.vim
+++ b/etc/vim/ftplugin/chpl.vim
@@ -1,0 +1,16 @@
+" Disable repeating * in comments, because chpldoc doesn't understand them,
+" so that isn't the Chapel style.
+setlocal comments=s1:/*,ex:*/,://
+
+" Use list formatting at all
+setlocal formatoptions+=n
+" Allow 1. * - lists (for use in chpl-doc comments)
+setlocal formatlistpat=^\\s*\\(\\d\\+[\\]:.)}\\t\ ]\\\|[*-][\\t\ ]\\)\\s*
+
+" If you prefer spaces to tabs, uncomment the following:
+"  (To get a real tab with these settings, do CTRL-V TAB)
+setlocal expandtab       " replace indents with spaces
+setlocal shiftwidth=2    " set how many spaces per indent
+setlocal smarttab        " use spaces as indents at the beginning of lines
+
+


### PR DESCRIPTION
Make formatting * and - lists in RST in chpldoc comments more fun.
Also make comment style not add *s since that is not chpldoc friendly.