### PR TITLE
Update whitebox tests to only use fftw when using prgenv.

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -129,8 +129,10 @@ if [ "${my_arch}" = "none" ] ; then
     module load craype-shanghai
 fi
 
-log_info "Loading fftw module."
-module load fftw
+if [ "${COMP_TYPE}" != "HOST-TARGET-no-PrgEnv" ] ; then
+    log_info "Loading fftw module."
+    module load fftw
+fi
 
 log_info "Current loaded modules:"
 module list


### PR DESCRIPTION
Previously, the non-PrgEnv tests would fail because FFTW_DIR was set, but the
include/library paths were not set correctly (not surprising when running
outside the programming environment). Update common-whitebox.bash to only load
fftw when using a programming environment.

### Verification:

* [x] Ensure fftw is not loaded when using no-PrgEnv config:

```bash
(
  export CRAY_PLATFORM_FROM_JENKINS=cray-xc
  export COMPILER=gnu
  export COMP_TYPE=HOST-TARGET-no-PrgEnv
  source util/cron/common-whitebox.bash
  module list
)
```

* [x] Ensure fftw is loaded when using regular prgenv config:

```bash
(
  export CRAY_PLATFORM_FROM_JENKINS=cray-xc
  export COMPILER=pgi
  export COMP_TYPE=HOST-TARGET
  source util/cron/common-whitebox.bash
  module list
)
```

```bash
(
  export CRAY_PLATFORM_FROM_JENKINS=cray-xc
  export COMPILER=cray
  export COMP_TYPE=TARGET
  source util/cron/common-whitebox.bash
  module list
)
```