### PR TITLE
Bug fix for extern block w/o clang-included runtime

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -832,7 +832,7 @@ void runClang(const char* just_parse_filename) {
   compileline += " COMP_GEN_OPT=" + (optimizeCCode?one:zero);
   compileline += " COMP_GEN_SPECIALIZE=" + (specializeCCode?one:zero);
   compileline += " COMP_GEN_IEEE_FLOAT=" + (fieeefloat?one:zero);
-  std::string readargsfrom = compileline + " --llvm"
+  std::string readargsfrom = compileline + (just_parse_filename?"":" --llvm") +
                               " --llvm-install-dir"
                               " --clang-sysroot-arguments"
                               " --cflags"


### PR DESCRIPTION
The --llvm option to compileline changes CHPL_TARGET_PLATFORM in order to use
clang-included and prevent ABI issues when linking in the runtime. However,
when I originally added that flag I neglected to remember that runClang runs
both as an initial step in --llvm compiles but also as a parsing step with
extern { } blocks even without --llvm. When it's just parsing the extern
blocks, we shouldn't be changing the CHPL_TARGET_PLATFORM at all. Now we just
leave out  --llvm from the compileline flags if just_parse_filename is set.

By removing the --llvm option to compileline if we're only parsing extern
blocks (and not compiling with the LLVM backend), we remove the check
that the runtime has been built with clang-included in that case.