### PR TITLE
Adding a segfault for trying to assign a param member in a constructor

### DIFF
--- a/test/classes/constructors/assign-param-segfault.bad
+++ b/test/classes/constructors/assign-param-segfault.bad
@@ -1,0 +1,1 @@
+internal error: MIS0386 chpl Version 1.11.0.a1066db

--- a/test/classes/constructors/assign-param-segfault.chpl
+++ b/test/classes/constructors/assign-param-segfault.chpl
@@ -1,0 +1,22 @@
+enum Foo { Foo0, Foo1, Foo2, Foo3 };
+enum Baz { Baz0, Baz1, Baz2, Baz3 };
+class Bar {
+param foo: Foo;
+var baz: Baz;
+proc Bar (param foo: Foo = Foo.Foo0) {
+  //
+  // This isn't legal, but shouldn't cause a segfault either
+  //
+  this.foo = foo;
+    select foo {
+      when Foo.Foo0 do this.baz = Baz.Baz0;
+      when Foo.Foo1 do this.baz = Baz.Baz1;
+      when Foo.Foo2 do this.baz = Baz.Baz2;
+      when Foo.Foo3 do this.baz = Baz.Baz3;
+      otherwise this.baz = Baz.Baz0;
+        }
+      }
+}
+var bar = new Bar(Foo.Foo1);
+writeln(bar);
+delete bar;

--- a/test/classes/constructors/assign-param-segfault.future
+++ b/test/classes/constructors/assign-param-segfault.future
@@ -1,0 +1,6 @@
+bug: assigning param member causes segfault
+
+For some reason, assigning the param 'foo' member in its constructor
+causes a segfault rather than a useful error message.  Strangely,
+looking at the IR, it appears that we're creating a foo[0] expression
+somewhere along the line (indexing into a param enum?!?  Why?)

--- a/test/classes/constructors/assign-param-segfault.good
+++ b/test/classes/constructors/assign-param-segfault.good
@@ -1,0 +1,1 @@
+{foo = Foo1, baz = Baz1}


### PR DESCRIPTION
This test declares a class with a param member and tries to assign it
within the constructor (which is not legal).  Rather than generating a
useful error message, it segfaults.  Looking at the segfault, it
appears that a context that is expecting a direct variable reference
is actually getting an array access ('foo[0]'), yet it's not clear to
me why we would ever generate an array access to a param enum member
(or any param/enum for that matter).

The fix for the user is to avoid assigning to the param and rely on
Chapel's auto-transferring of param/type information from constructor
arguments to param/type fields of the same type.  But the user should
get a useful error message rather than a segfault.

This is something we should also work on cleaning up in our new
constructor world with its support for initialization sections
(specifically, it seems like assignments to param/type fields may be
something we'd consider legal in the initialization section since it's
constrained and similar to an initialization context).