### PR TITLE
Fix coverity defects related to mkdir() and chpldoc.

### DIFF
--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -252,8 +252,8 @@ void createDocsFileFolders(std::string filename) {
  */
 static void makeDir(const char* dirpath) {
   static const int dirPerms = S_IRWXU | S_IRWXG | S_IRWXO;
-  mkdir(dirpath, dirPerms);
-  if (errno != 0 && errno != EEXIST) {
+  int result = mkdir(dirpath, dirPerms);
+  if (result != 0 && errno != 0 && errno != EEXIST) {
     USR_FATAL(astr("Failed to create directory: ", dirpath,
                    " due to: ", strerror(errno)));
   }

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -240,7 +240,7 @@ void createDocsFileFolders(std::string filename) {
     dirCutoff += total;
     std::string shorter = filename.substr(dirCutoff+1);
     std::string otherHalf = filename.substr(0, dirCutoff);
-    mkdir(otherHalf.c_str(), S_IWUSR|S_IRUSR|S_IXUSR);
+    makeDir(otherHalf.c_str());
     total = dirCutoff + 1;
     dirCutoff = shorter.find("/");
   }

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -240,7 +240,9 @@ void createDocsFileFolders(std::string filename) {
     dirCutoff += total;
     std::string shorter = filename.substr(dirCutoff+1);
     std::string otherHalf = filename.substr(0, dirCutoff);
-    makeDir(otherHalf.c_str());
+    if (otherHalf.length() > 0) {
+      makeDir(otherHalf.c_str());
+    }
     total = dirCutoff + 1;
     dirCutoff = shorter.find("/");
   }


### PR DESCRIPTION
Fix coverity defects [1292664][0] and [1212283][1]. Both were mkdir() calls in
docs.cpp that were not checking the result.

[0]: https://scan7.coverity.com:8443/reports.htm#v14223/p10115/fileInstanceId=1891288&defectInstanceId=575513&mergedDefectId=745657
[1]: https://scan7.coverity.com:8443/reports.htm#v14223/p10115/fileInstanceId=1891288&defectInstanceId=575511&mergedDefectId=665268
1292664
Update chpldoc makeDir() function to check result of mkdir() call. It was
already checking errno, but it is also good to check the return value of
mkdir().

1292664
Update createDocsFileFolders() to use makeDir() helper instead of calling
mkdir() directly. The makeDir() helper checks the results and reports an error
if it failed to create the dir.

### Verification:

* [x] run chpldoc tests on my mac with: `start_test test/chpldoc test/release/examples/primers/chpldoc.doc.chpl  test/compflags/thomasvandoren/`
* [x] full test pass