### PR TITLE
Include chpldoc.1 man page in tarball.

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -112,6 +112,7 @@ if ($no_clone == 0) {
        "compiler/passes/reservedSymbolNames",
        "etc/README",
        "man/man1/chpl.1",
+       "man/man1/chpldoc.1",
        "util/README",
        "util/build_configs.py",
        "util/printchplenv",
@@ -156,8 +157,9 @@ system("cp -r test/release/examples .");
 system("cd util && cp start_test ../examples/");
 system("./util/devel/test/extract_tests --no-futures -o ./examples/spec spec/*.tex");
 
-print "Building the man page...\n";
+print "Building the man pages...\n";
 system("make man");
+system("make man-chpldoc");
 
 print "Building the STATUS file...\n";
 system("make STATUS");


### PR DESCRIPTION
Previously, a chpldoc man page did not exist, and when it was added gen_release
was not updated to include it. Update gen_release to call `make man-chpldoc`
and include man/man1/chpldoc.1 in the tarball.

### Verification:

* [x] build tarball (e.g. `./util/buildRelease/gen_release testing` and verify man/man1/chpldoc.1 exists