### PR TITLE
Update release tarball script to always clone fresh repo.

### DIFF
--- a/util/cron/create_release_tarball.bash
+++ b/util/cron/create_release_tarball.bash
@@ -18,10 +18,6 @@ else
     no_tarball_dir=true
 fi
 
-# Tell gen_release to use existing repo instead of creating a new one with
-# git-archive.
-export CHPL_GEN_RELEASE_NO_CLONE=true
-
 export CHPL_HOME=$(cd $CWD/../.. ; pwd)
 log_info "Setting CHPL_HOME to: ${CHPL_HOME}"
 


### PR DESCRIPTION
Previously it relied on the workspace, but that may not be the right revision
for the release tarball.