### PR TITLE
Update genGraphs to work when PyYAML is available, but ANNOTATIONS file is missing.

### DIFF
--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -310,12 +310,14 @@ class GraphStuff:
         except IOError:
             sys.stderr.write('ERROR: Could not open file: %s\n'%(self.gfname))
 
-        if annotate:
+        if self.annotation_file:
             try:
                 self.all_annotations = annotate.load(self.annotation_file)
             except IOError:
                 sys.stderr.write('ERROR: Could not open file: %s\n'%(self.annotation_file))
                 raise
+        else:
+            self.all_annotations = None
 
         self.gfile.write('// AUTOMATICALLY GENERATED GRAPH DESCRIPTION\n')
         self.gfile.write('document.title = "%s";\n'%(self.title))
@@ -372,7 +374,7 @@ class GraphStuff:
             series = ginfo.graphkeys[0]
 
         # generate the annotations for this graph
-        if series and annotate and not numericX:
+        if series and annotate and self.all_annotations and not numericX:
             ginfo.annotations = annotate.get(
                 self.all_annotations, ginfo.name, series,
                 parse_date(ginfo.startdate, '%Y-%m-%d'),

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -310,7 +310,7 @@ class GraphStuff:
         except IOError:
             sys.stderr.write('ERROR: Could not open file: %s\n'%(self.gfname))
 
-        if self.annotation_file:
+        if annotate and self.annotation_file:
             try:
                 self.all_annotations = annotate.load(self.annotation_file)
             except IOError:


### PR DESCRIPTION
Previously, genGraphs assumed an ANNOTATIONS.yaml file was available or
provided if it could import the annotate module, which only works when PyYAML
is installed. If PyYAML was installed, but an ANNOTATIONS.yaml file was not
found or specified, genGraphs ultimately tried to open a NoneType file which raises
an error.

Update genGraphs to check for annotations file, while still checking for
ability to import annotate module.