### PR TITLE
Fix regexp c tests

### DIFF
--- a/runtime/include/qio/qio_error.h
+++ b/runtime/include/qio/qio_error.h
@@ -20,6 +20,10 @@
 #ifndef _QIO_ERROR_H
 #define _QIO_ERROR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "sys_basic.h"
 #include <assert.h>
 
@@ -165,5 +169,9 @@ typedef qioerr syserr;
 static inline int chpl_macro_int_EEOF(void) { return EEOF; }
 static inline int chpl_macro_int_ESHORT(void) { return ESHORT; }
 static inline int chpl_macro_int_EFORMAT(void) { return EFORMAT; }
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
 
 #endif

--- a/test/regexp/ferguson/ctests/sub_test
+++ b/test/regexp/ferguson/ctests/sub_test
@@ -66,7 +66,7 @@ else
   OPTS="-static"
 fi
 
-DEPS="$OPTS -Wall -DCHPL_RT_UNIT_TEST $DEFS $RSRC/qio.c $RSRC/sys.c $RSRC/sys_xsi_strerror_r.c $RSRC/qbuffer.c $RSRC/deque.c $RSRC/regexp/re2/re2-interface.cc $RE2INCLS $RE2LIB -lpthread"
+DEPS="$OPTS -Wall -DCHPL_RT_UNIT_TEST $DEFS $RSRC/qio.c $RSRC/sys.c $RSRC/sys_xsi_strerror_r.c $RSRC/qbuffer.c $RSRC/qio_error.c $RSRC/deque.c $RSRC/regexp/re2/re2-interface.cc $RE2INCLS $RE2LIB -lpthread"
 
 T1="$CXX $DEPS -g regexp_test.cc -o regexp_test"
 T2="$CXX $DEPS -g regexp_channel_test.cc -o regexp_channel_test"


### PR DESCRIPTION
* Add C++ only extern "C" block around qio_error.h declarations
  so that header can be used from re2-interface.cc
* Add qio_error.c to regexp test source files