### PR TITLE
Also set CHPL_LLVM=none in quickstart scripts

### DIFF
--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -46,6 +46,9 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
 
           echo "Setting CHPL_LLVM to none"
           export CHPL_LLVM=none
+
+          echo "Setting CHPL_LAUNCHER to none"
+          export CHPL_LAUNCHER=none
         fi
    else
       echo "Error: util/setchplenv must be sourced from within the chapel root directory"

--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -43,6 +43,9 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
 
           echo "Setting CHPL_REGEXP to none"
           export CHPL_REGEXP=none
+
+          echo "Setting CHPL_LLVM to none"
+          export CHPL_LLVM=none
         fi
    else
       echo "Error: util/setchplenv must be sourced from within the chapel root directory"

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -48,3 +48,6 @@ setenv CHPL_GMP none
 echo "Setting CHPL_REGEXP to none"
 setenv CHPL_REGEXP none
 
+echo "Setting CHPL_LLVM to none"
+setenv CHPL_LLVM none
+

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -51,3 +51,6 @@ setenv CHPL_REGEXP none
 echo "Setting CHPL_LLVM to none"
 setenv CHPL_LLVM none
 
+echo "Setting CHPL_LAUNCHER to none"
+setenv CHPL_LAUNCHER none
+

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -47,3 +47,6 @@ set -x CHPL_GMP none
 
 echo "Setting CHPL_REGEXP to none"
 set -x CHPL_REGEXP none
+
+echo "Setting CHPL_LLVM to none"
+set -x CHPL_LLVM none

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -50,3 +50,6 @@ set -x CHPL_REGEXP none
 
 echo "Setting CHPL_LLVM to none"
 set -x CHPL_LLVM none
+
+echo "Setting CHPL_LAUNCHER to none"
+set -x CHPL_LAUNCHER none

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -72,6 +72,12 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
           export CHPL_LLVM
           echo "                           ...none"
           echo " "
+ 
+          echo "Setting CHPL_LAUNCHER to..."
+          CHPL_LAUNCHER=none
+          export CHPL_LAUNCHER
+          echo "                           ...none"
+          echo " "
           
         fi
    else

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -66,6 +66,12 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
           export CHPL_REGEXP
           echo "                           ...none"
           echo " "
+ 
+          echo "Setting CHPL_LLVM to..."
+          CHPL_LLVM=none
+          export CHPL_LLVM
+          echo "                           ...none"
+          echo " "
           
         fi
    else


### PR DESCRIPTION
I find I've been using quickstart/setchplenv.bash in order to
quickly get a Chapel up for example when I'm testing
on several different platforms. I find that every time I do that,
I also set CHPL_LLVM=none (since many of my chapel
source trees already have LLVM built, the default is
CHPL_LLVM=llvm). This patch updates the quickstart
scripts to also set CHPL_LLVM=none. I think that's consistent
with how they set CHPL_REGEXP=none or CHPL_COMM=none.

