### PR TITLE
Fix make_sys_basic_types.py for Fedora 22

### DIFF
--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -129,11 +129,11 @@ def get_sys_c_types(docs=False):
 
         # Ignore lines starting with # since they could be #line
         # type directives.
-        elif line.startswith("#"):
+        elif line.strip().startswith("#"):
             continue
 
         # Ignore blank lines
-        elif line.isspace() or line == '':
+        elif line.strip() == '':
             continue
 
         # The start of the max macros has already been found. Record every

--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -127,6 +127,15 @@ def get_sys_c_types(docs=False):
         elif 'FIND_INT_SIZES_START' in line:
             keep = True
 
+        # Ignore lines starting with # since they could be #line
+        # type directives.
+        elif line.startswith("#"):
+            continue
+
+        # Ignore blank lines
+        elif line.isspace() or line == '':
+            continue
+
         # The start of the max macros has already been found. Record every
         # line, stripping it of whitespace.
         else:


### PR DESCRIPTION
Continuing #1748. I wanted to check if 'make check' worked on Fedora 22
and ran into errors with this script. That version of the compiler is emitting
#line type directives and whitespace between the relevant numbers for some reason.
Update the script to ignore these lines.