### PR TITLE
Use printchplenv from CHPL_HOME, if set, for nightly emails.

### DIFF
--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -117,7 +117,11 @@ sub endMailHeader {
 }
 
 sub endMailChplenv {
-    my $chplenv = `$chplhomedir/util/printchplenv --debug`;
+    my $ch = $chplhomedir;
+    if (exists($ENV{"CHPL_HOME"})) {
+        $ch = $ENV{"CHPL_HOME"};
+    }
+    my $chplenv = `$ch/util/printchplenv --debug`;
 
     my $mystr = 
         "===============================================================\n" .


### PR DESCRIPTION
Previously, the nightly emails would run printchplenv relative to the
nightly/nightly_email.pl script. This works fine when the compiler is located
in the same location as the scripts. If the compiler is somewhere else (for
example in a binary installation like homebrew or cray module), however, it
would still use the version next to nightly/nightly_email.pl script instead of
the printchplenv used by the compiler.

Update nightlysubs.pm to check for CHPL_HOME in the environment, and if it
exists use it to find printchplenv. When CHPL_HOME is not set in the
environment, it will go back to the old behavior of using the relative path.