### PR TITLE
Specify cross-compilation for third-party packages on Cray-X* targets.

### DIFF
--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -16,8 +16,7 @@ GMP_TARBALL = $(GMP_UNPACKED_DIR)a.tar.bz2
 #
 GMP_CROSS_COMPILED=no
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_GMP_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
-                        --host=x86_64-cnl-linux-gnu
+CHPL_GMP_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 GMP_CROSS_COMPILED=yes
 else ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
 CHPL_GMP_CFG_OPTIONS += --host=x86_64-unknown-linux-gnu

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -14,11 +14,14 @@ GMP_TARBALL = $(GMP_UNPACKED_DIR)a.tar.bz2
 #
 # Cray X* builds are cross-compilations, as are Intel Phi KNC builds.
 #
+GMP_CROSS_COMPILED=no
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
                         --host=x86_64-cnl-linux-gnu
+GMP_CROSS_COMPILED=yes
 else ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
 CHPL_GMP_CFG_OPTIONS += --host=x86_64-unknown-linux-gnu
+GMP_CROSS_COMPILED=yes
 endif
 
 ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
@@ -81,10 +84,8 @@ gmp-build:
 
 $(GMP_H_FILE): $(GMP_MAKEFILE)
 	cd $(GMP_BUILD_DIR) && $(MAKE)
-ifeq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-ifneq ($(CHPL_MAKE_TARGET_ARCH),knc)
+ifeq ($(GMP_CROSS_COMPILED),no)
 	cd $(GMP_BUILD_DIR) && $(MAKE) check
-endif
 endif
 	cd $(GMP_BUILD_DIR) && $(MAKE) install
 

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -11,11 +11,21 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 GMP_UNPACKED_DIR = gmp-$(GMP_VERSION)
 GMP_TARBALL = $(GMP_UNPACKED_DIR)a.tar.bz2
 
+#
+# Cray X* builds are cross-compilations, as are Intel Phi KNC builds.
+#
+ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+CHPL_GMP_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
+                        --host=x86_64-cnl-linux-gnu
+else ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
+CHPL_GMP_CFG_OPTIONS += --host=x86_64-unknown-linux-gnu
+endif
+
 ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
-CHPL_GMP_CFG_OPTIONS=--host=x86_64 --disable-assembly
+CHPL_GMP_CFG_OPTIONS += --disable-assembly
 ifeq ($(CHPL_MAKE_TARGET_COMPILER),intel)
-CHPL_GMP_CFLAGS=-mmic
-CHPL_GMP_CXXFLAGS=-mmic
+CHPL_GMP_CFLAGS = -mmic
+CHPL_GMP_CXXFLAGS = -mmic
 endif
 endif
 
@@ -38,6 +48,8 @@ CHPL_GMP_ABI_ARG = ABI=32
 endif
 
 GMP_MAKEFILE = $(GMP_BUILD_SUBDIR)/Makefile
+
+CHPL_GMP_CFG_OPTIONS += $(CHPL_GMP_MORE_CFG_OPTIONS)
 
 default: all
 
@@ -69,8 +81,10 @@ gmp-build:
 
 $(GMP_H_FILE): $(GMP_MAKEFILE)
 	cd $(GMP_BUILD_DIR) && $(MAKE)
+ifeq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
 ifneq ($(CHPL_MAKE_TARGET_ARCH),knc)
 	cd $(GMP_BUILD_DIR) && $(MAKE) check
+endif
 endif
 	cd $(GMP_BUILD_DIR) && $(MAKE) install
 

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -5,6 +5,14 @@ endif
 CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
+#
+# Cray X* builds are cross-compilations.
+#
+ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+CHPL_HWLOC_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
+                          --host=x86_64-cnl-linux-gnu
+endif
+
 CHPL_HWLOC_CFG_OPTIONS += --enable-static --disable-shared --disable-libxml2 --disable-pci
 
 ifeq ($(CHPL_MAKE_TARGET_COMPILER), pgi)

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -9,8 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_HWLOC_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
-                          --host=x86_64-cnl-linux-gnu
+CHPL_HWLOC_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 endif
 
 CHPL_HWLOC_CFG_OPTIONS += --enable-static --disable-shared --disable-libxml2 --disable-pci

--- a/third-party/massivethreads/Makefile
+++ b/third-party/massivethreads/Makefile
@@ -9,8 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_MASSIVETHREADS_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
-                                   --host=x86_64-cnl-linux-gnu
+CHPL_MASSIVETHREADS_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 endif
 
 CHPL_MASSIVETHREADS_CFG_OPTIONS += --enable-malloc-wrapper=no \

--- a/third-party/massivethreads/Makefile
+++ b/third-party/massivethreads/Makefile
@@ -5,6 +5,20 @@ endif
 CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
+#
+# Cray X* builds are cross-compilations.
+#
+ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+CHPL_MASSIVETHREADS_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
+                                   --host=x86_64-cnl-linux-gnu
+endif
+
+CHPL_MASSIVETHREADS_CFG_OPTIONS += --enable-malloc-wrapper=no \
+                                   --enable-eco-mode=no \
+                                   --enable-bind-workers=no
+
+CHPL_MASSIVETHREADS_CFG_OPTIONS += $(CHPL_MASSIVETHREADS_MORE_CFG_OPTIONS)
+
 default: all
 
 all: massivethreads
@@ -21,7 +35,7 @@ clobber: FORCE
 
 massivethreads-config: FORCE
 	mkdir -p $(MASSIVETHREADS_BUILD_DIR)
-	cd $(MASSIVETHREADS_BUILD_DIR) && $(MASSIVETHREADS_SUBDIR)/configure CC='$(CC)' CXX='$(CXX)' --prefix=$(MASSIVETHREADS_INSTALL_DIR) --enable-malloc-wrapper=no --enable-eco-mode=no --enable-bind-workers=no
+	cd $(MASSIVETHREADS_BUILD_DIR) && $(MASSIVETHREADS_SUBDIR)/configure CC='$(CC)' CXX='$(CXX)' --prefix=$(MASSIVETHREADS_INSTALL_DIR) $(CHPL_MASSIVETHREADS_CFG_OPTIONS)
 
 massivethreads-build: FORCE
 	cd $(MASSIVETHREADS_BUILD_DIR) && $(MAKE)

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -15,19 +15,20 @@ QTHREAD_INSTALL_DIR = $(QTHREAD_ABS_DIR)/$(QTHREAD_INSTALL_SUBDIR)
 QTHREAD_BUILD_DIR = $(QTHREAD_ABS_DIR)/$(QTHREAD_BUILD_SUBDIR)
 QTHREAD_DIR = $(QTHREAD_ABS_DIR)
 
-ifeq ($(CHPL_MAKE_TARGET_PLATFORM),cray-xt)
-CHPL_QTHREAD_CFG_OPTIONS += --host=x86_64-pc-linux-gnu --build=x86_64-suse-linux-gnu
+#
+# Cray X* builds are cross-compilations, as are Intel Phi KNC builds.
+#
+ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+CHPL_QTHREAD_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
+                            --host=x86_64-cnl-linux-gnu
+else ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
+CHPL_QTHREAD_CFG_OPTIONS += --host=x86_64-unknown-linux-gnu
 endif
 
 ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
-CHPL_QTHREAD_CFG_OPTIONS += --host=x86_64-unknown-linux-gnu
 ifeq ($(CHPL_MAKE_TARGET_COMPILER),intel)
 CFLAGS += -mmic
 endif
-endif
-
-ifneq (, $(filter $(CHPL_MAKE_TARGET_PLATFORM),cray-xe cray-xk cray-xc))
-CHPL_QTHREAD_CFG_OPTIONS += --host=x86_64-pc-linux-gnu --build=x86_64-suse-linux-gnu
 endif
 
 ifeq ($(CHPL_MAKE_HWLOC),hwloc)

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -19,8 +19,7 @@ QTHREAD_DIR = $(QTHREAD_ABS_DIR)
 # Cray X* builds are cross-compilations, as are Intel Phi KNC builds.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_QTHREAD_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
-                            --host=x86_64-cnl-linux-gnu
+CHPL_QTHREAD_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 else ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
 CHPL_QTHREAD_CFG_OPTIONS += --host=x86_64-unknown-linux-gnu
 endif

--- a/third-party/tcmalloc/Makefile
+++ b/third-party/tcmalloc/Makefile
@@ -5,19 +5,29 @@ endif
 CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
+#
+# Cray X* builds are cross-compilations.
+#
+ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+CHPL_TCMALLOC_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
+                             --host=x86_64-cnl-linux-gnu
+endif
+
 # enable minimal and frame pointers??
-CONFIG_FLAGS = --config-cache \
-               --enable-shared=no \
-               --enable-minimal \
-               --disable-libc-malloc-override \
-               --prefix=$(TCMALLOC_INSTALL_DIR)
+CHPL_TCMALLOC_CFG_OPTIONS += --config-cache \
+                             --enable-shared=no \
+                             --enable-minimal \
+                             --disable-libc-malloc-override \
+                             --prefix=$(TCMALLOC_INSTALL_DIR)
 
 ifneq (, $(filter cray-%,$(CHPL_MAKE_TARGET_PLATFORM)))
 # On some Cray systems we need to bring in libpthread explicitly when
 # building internal tests, to satisfy references from other packages that
 # don't do it themselves.  This is expected to be temporary.
-CONFIG_FLAGS += LDFLAGS='$(LDFLAGS) -lpthread'
+CHPL_TCMALLOC_CFG_OPTIONS += LDFLAGS='$(LDFLAGS) -lpthread'
 endif
+
+CHPL_TCMALLOC_CFG_OPTIONS += $(CHPL_TCMALLOC_MORE_CFG_OPTIONS)
 
 default: all
 
@@ -36,7 +46,7 @@ tcmalloc: configure-tcmalloc build-tcmalloc install-tcmalloc
 
 configure-tcmalloc: FORCE
 	mkdir -p $(TCMALLOC_BUILD_DIR)
-	cd $(TCMALLOC_BUILD_DIR) && $(TCMALLOC_SUBDIR)/configure CC='$(CC)' CXX='$(CXX)' $(CONFIG_FLAGS)
+	cd $(TCMALLOC_BUILD_DIR) && $(TCMALLOC_SUBDIR)/configure CC='$(CC)' CXX='$(CXX)' $(CHPL_TCMALLOC_CFG_OPTIONS)
 
 build-tcmalloc: FORCE
 	cd $(TCMALLOC_BUILD_DIR) && CRAYPE_LINK_TYPE=dynamic $(MAKE)

--- a/third-party/tcmalloc/Makefile
+++ b/third-party/tcmalloc/Makefile
@@ -9,8 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_TCMALLOC_CFG_OPTIONS += --build=x86_64-unknown-linux-gnu \
-                             --host=x86_64-cnl-linux-gnu
+CHPL_TCMALLOC_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 endif
 
 # enable minimal and frame pointers??


### PR DESCRIPTION
For third-party package builds on Cray X* target systems that use
autoconf for configuration, specify x86_64-unknown-linux-gnu as the
build system type (where we're building) and x86_64-cnl-linux-gnu as the
host system type (where the emitted code will run).  Making these
different tells autoconf (etc.) that we are cross-compiling, which among
other things prevents it from trying to run, on the build system, little
test executables compiled for the host system type.

The need for this was pointed out by our inability to build hwloc on a
Cray-XC system with the Intel compiler, optimizing for an ivybridge
target.  Not knowing we were cross-compiling led the configure script to
try to run an executable that had been built for ivybridge with -O3,
which led to an Intel library internal error message about an ISA
mismatch.  The message and an unexpected process exit status from the
executable then led to the configure script aborting.

Here we add the appropriate settings for gmp, hwloc, massivethreads,
qthreads, and tcmalloc.  For gmp and qthreads the logic builds on and
integrates with what was already there to handle target=knc.

While here, I did some other cleanup:
* gmp:
  * Allow for providing configure options from outside the Makefile by
    setting CHPL_GMP_MORE_CFG_OPTIONS.
  * Don't do the 'check' step if we're cross-compiling.
* massivethreads:
  * Put all the configure options in a CHPL_MASSIVETHREADS_CFG_OPTIONS,
    like we do for the other packages.
  * Allow for providing configure options from outside the Makefile by
    setting CHPL_MASSIVETHREADS_MORE_CFG_OPTIONS.
* tcmalloc:
  * Put all the configure options in a CHPL_TCMALLOC_CFG_OPTIONS, like
    we do for the other packages.
  * Allow for providing configure options from outside the Makefile by
    setting CHPL_TCMALLOC_MORE_CFG_OPTIONS.

The other third-party packages don't have this problem for one reason or
another; either they target the build system (for example llvm) or they
target the host system but they don't use autoconf (for example gasnet,
dlmalloc, re2).  These I didn't modify.