### PR TITLE
Test chpldoc with enums

### DIFF
--- a/test/chpldoc/globals/enums.doc.bad
+++ b/test/chpldoc/globals/enums.doc.bad
@@ -1,0 +1,10 @@
+Module: enums.doc
+   enum Color { Red, Yellow, Blue }
+      This is a color enum. 
+
+   var typed: Color
+      This variable is of type Color 
+   const Red = .(Color, "Red")
+      This constant is for the color Red 
+   var foo: Color = .(Color, "Blue")
+      This variable has a type and a default value 

--- a/test/chpldoc/globals/enums.doc.catfiles
+++ b/test/chpldoc/globals/enums.doc.catfiles
@@ -1,0 +1,1 @@
+docs/enums.doc.txt

--- a/test/chpldoc/globals/enums.doc.chpl
+++ b/test/chpldoc/globals/enums.doc.chpl
@@ -1,0 +1,9 @@
+/* This is a color enum. */
+enum Color { Red, Yellow, Blue };
+
+/* This variable is of type Color */
+var typed: Color;
+/* This constant is for the color Red */
+const Red = Color.Red;
+/* This variable has a type and a default value */
+var foo: Color = Color.Blue;

--- a/test/chpldoc/globals/enums.doc.future
+++ b/test/chpldoc/globals/enums.doc.future
@@ -1,0 +1,16 @@
+bug: documentation of globals with default value that is an enum is ugly
+
+When a global indicates that its default value is an enum, at the moment we
+document it as `.(<enum>, <value>)` instead of <enum>.<value>.  This incorrect
+behavior displays part of our compiler internals and should be fixed.
+
+For example:
+
+var foo = Color.Red;
+
+gets displayed as:
+
+var foo = .(Color, "Red")
+
+It is probably related to a similar problem with fields (see
+test/chpldoc/types/fields/enums.doc.chpl)

--- a/test/chpldoc/globals/enums.doc.good
+++ b/test/chpldoc/globals/enums.doc.good
@@ -1,0 +1,10 @@
+Module: enums.doc
+   enum Color { Red, Yellow, Blue }
+      This is a color enum. 
+
+   var typed: Color
+      This variable is of type Color 
+   const Red = Color.Red
+      This constant is for the color Red 
+   var foo: Color = Color.Blue
+      This variable has a type and a default value 

--- a/test/chpldoc/types/arguments/enums.doc.catfiles
+++ b/test/chpldoc/types/arguments/enums.doc.catfiles
@@ -1,0 +1,1 @@
+docs/enums.doc.txt

--- a/test/chpldoc/types/arguments/enums.doc.chpl
+++ b/test/chpldoc/types/arguments/enums.doc.chpl
@@ -1,0 +1,20 @@
+/* This is a color enum. */
+enum Color { Red, Yellow, Blue };
+
+/* This function takes an enum as an argument */
+proc gimmeAColor(c: Color) {
+
+}
+
+/* This function makes an enum the default value for
+   its argument
+*/
+proc colorDefault(c = Color.Red) {
+
+}
+
+/* This function has both declared that it wants an enum
+   and defined a default value for its argument */
+proc defaultAndType(c: Color = Color.Blue) {
+
+}

--- a/test/chpldoc/types/arguments/enums.doc.good
+++ b/test/chpldoc/types/arguments/enums.doc.good
@@ -1,0 +1,15 @@
+Module: enums.doc
+   enum Color { Red, Yellow, Blue }
+      This is a color enum. 
+
+   proc gimmeAColor(c: Color)
+      This function takes an enum as an argument 
+
+   proc colorDefault(c = Color.Red)
+      This function makes an enum the default value for
+      its argument
+
+   proc defaultAndType(c: Color = Color.Blue)
+      This function has both declared that it wants an enum
+      and defined a default value for its argument 
+

--- a/test/chpldoc/types/fields/enums.doc.bad
+++ b/test/chpldoc/types/fields/enums.doc.bad
@@ -1,0 +1,13 @@
+Module: enums.doc
+   enum Color { Red, Yellow, Blue }
+      This is a color enum. 
+
+   Class: colorCup
+      This class holds many different colors 
+
+      var defOnly = .(Color, "Yellow")
+         Field has only enum as a default value 
+      var typeOnly: Color
+         Field has only enum as its type 
+      var both: Color = .(Color, "Red")
+         Field has both a type and default value 

--- a/test/chpldoc/types/fields/enums.doc.catfiles
+++ b/test/chpldoc/types/fields/enums.doc.catfiles
@@ -1,0 +1,1 @@
+docs/enums.doc.txt

--- a/test/chpldoc/types/fields/enums.doc.chpl
+++ b/test/chpldoc/types/fields/enums.doc.chpl
@@ -1,0 +1,12 @@
+/* This is a color enum. */
+enum Color { Red, Yellow, Blue };
+
+/* This class holds many different colors */
+class colorCup {
+  /* Field has only enum as a default value */
+  var defOnly = Color.Yellow;
+  /* Field has only enum as its type */
+  var typeOnly: Color;
+  /* Field has both a type and default value */
+  var both: Color = Color.Red;
+}

--- a/test/chpldoc/types/fields/enums.doc.future
+++ b/test/chpldoc/types/fields/enums.doc.future
@@ -1,0 +1,8 @@
+bug: documentation of fields with default value that is an enum is ugly
+
+When a field indicates that its default value is an enum, at the moment we
+document it as `.(<enum>, <value>)` instead of <enum>.<value>.  This incorrect
+behavior displays part of our compiler internals and should be fixed.
+
+It is probably related to a similar problem with globals (see
+test/chpldoc/globals/enums.doc.chpl)

--- a/test/chpldoc/types/fields/enums.doc.good
+++ b/test/chpldoc/types/fields/enums.doc.good
@@ -1,0 +1,13 @@
+Module: enums.doc
+   enum Color { Red, Yellow, Blue }
+      This is a color enum. 
+
+   Class: colorCup
+      This class holds many different colors 
+
+      var defOnly = Color.Yellow
+         Field has only enum as a default value 
+      var typeOnly: Color
+         Field has only enum as its type 
+      var both: Color = Color.Red
+         Field has both a type and default value 

--- a/test/chpldoc/types/returns/enums.doc.catfiles
+++ b/test/chpldoc/types/returns/enums.doc.catfiles
@@ -1,0 +1,1 @@
+docs/enums.doc.txt

--- a/test/chpldoc/types/returns/enums.doc.chpl
+++ b/test/chpldoc/types/returns/enums.doc.chpl
@@ -1,0 +1,7 @@
+/* This is a color enum. */
+enum Color { Red, Yellow, Blue };
+
+/* This function returns an enum */
+proc gimmeAColor(): Color {
+
+}

--- a/test/chpldoc/types/returns/enums.doc.good
+++ b/test/chpldoc/types/returns/enums.doc.good
@@ -1,0 +1,7 @@
+Module: enums.doc
+   enum Color { Red, Yellow, Blue }
+      This is a color enum. 
+
+   proc gimmeAColor(): Color
+      This function returns an enum 
+


### PR DESCRIPTION
Adds four tests of chpldoc enum functionality, specifically exercising their use
as the type and default value of different symbols (arguments, fields, and
global variables, and the type when used as an expected return type).  When
we did our documentation push, we noticed that the default value for enum
constants was not displaying correctly, hence the addition of these tests.
The global and field tests are futures at the moment because of this bug.
My next step will be to resolve this bug.