### PR TITLE
Guard against param divide-by-zero errors

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -417,8 +417,14 @@ module ChapelBase {
   inline proc *(param a: int(?w), param b: int(w)) param return __primitive("*", a, b);
   inline proc *(param a: uint(?w), param b: uint(w)) param return __primitive("*", a, b);
   
-  inline proc /(param a: int(?w), param b: int(w)) param return __primitive("/", a, b);
-  inline proc /(param a: uint(?w), param b: uint(w)) param return __primitive("/", a, b);
+  inline proc /(param a: int(?w), param b: int(w)) param {
+    if b == 0 then compilerError("param divide by zero");
+    return __primitive("/", a, b);
+  }
+  inline proc /(param a: uint(?w), param b: uint(w)) param {
+    if b == 0 then compilerError("param divide by zero");
+    return __primitive("/", a, b);
+  }
   
   //
   // % on primitive types
@@ -1317,7 +1323,14 @@ module ChapelBase {
   inline proc /(a: int(64), b: uint(64)) { _throwOpError("/"); }
   
   // non-param/param and param/non-param
+  // The int version is only defined so we can catch the divide by zero error
+  // at compile time
+  inline proc /(a: int(64), param b: int(64)) {
+    if b == 0 then compilerError("param divide by zero");
+    return __primitive("/", a, b);
+  }
   inline proc /(a: uint(64), param b: uint(64)) {
+    if b == 0 then compilerError("param divide by zero");
     return __primitive("/", a, b);
   }
   inline proc /(param a: uint(64), b: uint(64)) {

--- a/test/param/kbrady/mismatchIntDivZero.chpl
+++ b/test/param/kbrady/mismatchIntDivZero.chpl
@@ -1,0 +1,4 @@
+param zero = 0;
+var six = 6;
+var bad = six/zero;
+writeln(bad);

--- a/test/param/kbrady/mismatchIntDivZero.good
+++ b/test/param/kbrady/mismatchIntDivZero.good
@@ -1,0 +1,1 @@
+mismatchIntDivZero.chpl:3: error: param divide by zero

--- a/test/param/kbrady/mismatchUintDivZero.chpl
+++ b/test/param/kbrady/mismatchUintDivZero.chpl
@@ -1,0 +1,4 @@
+param zero = 0;
+var six: uint = 6;
+var bad = six/zero;
+writeln(bad);

--- a/test/param/kbrady/mismatchUintDivZero.good
+++ b/test/param/kbrady/mismatchUintDivZero.good
@@ -1,0 +1,1 @@
+mismatchUintDivZero.chpl:3: error: param divide by zero

--- a/test/param/kbrady/paramIntDivZero.chpl
+++ b/test/param/kbrady/paramIntDivZero.chpl
@@ -1,0 +1,3 @@
+param zero = 0;
+param bad = 6/zero;
+writeln(bad);

--- a/test/param/kbrady/paramIntDivZero.good
+++ b/test/param/kbrady/paramIntDivZero.good
@@ -1,0 +1,1 @@
+paramIntDivZero.chpl:2: error: param divide by zero

--- a/test/param/kbrady/paramUintDivZero.chpl
+++ b/test/param/kbrady/paramUintDivZero.chpl
@@ -1,0 +1,3 @@
+param zero: uint = 0;
+param bad:uint = (6:uint)/zero;
+writeln(bad);

--- a/test/param/kbrady/paramUintDivZero.good
+++ b/test/param/kbrady/paramUintDivZero.good
@@ -1,0 +1,1 @@
+paramUintDivZero.chpl:2: error: param divide by zero


### PR DESCRIPTION
Add checks to the param division routines in ChapelBase to look for divide by zero errors. Without these checks a param divide by zero causes a floating point exception inside fold_constant (ifa/num.cpp).