### PR TITLE
Also set CHPL_LLVM=none in quickstart scripts

### DIFF
--- a/test/setchplenv/verify_setchplenv_scripts.py
+++ b/test/setchplenv/verify_setchplenv_scripts.py
@@ -161,6 +161,7 @@ class SetChplEnvTests(unittest.TestCase):
             self.assertEqual('fifo', get_var('CHPL_TASKS'))
             self.assertEqual('none', get_var('CHPL_GMP'))
             self.assertEqual('none', get_var('CHPL_REGEXP'))
+            self.assertEqual('none', get_var('CHPL_LLVM'))
 
             # TODO: Re-add this check when/if tcmalloc becomes
             #       default. (thomasvandoren, 2015-01-13)

--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -43,6 +43,9 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
 
           echo "Setting CHPL_REGEXP to none"
           export CHPL_REGEXP=none
+
+          echo "Setting CHPL_LLVM to none"
+          export CHPL_LLVM=none
         fi
    else
       echo "Error: util/setchplenv must be sourced from within the chapel root directory"

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -48,3 +48,6 @@ setenv CHPL_GMP none
 echo "Setting CHPL_REGEXP to none"
 setenv CHPL_REGEXP none
 
+echo "Setting CHPL_LLVM to none"
+setenv CHPL_LLVM none
+

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -47,3 +47,6 @@ set -x CHPL_GMP none
 
 echo "Setting CHPL_REGEXP to none"
 set -x CHPL_REGEXP none
+
+echo "Setting CHPL_LLVM to none"
+set -x CHPL_LLVM none

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -66,6 +66,12 @@ if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
           export CHPL_REGEXP
           echo "                           ...none"
           echo " "
+ 
+          echo "Setting CHPL_LLVM to..."
+          CHPL_LLVM=none
+          export CHPL_LLVM
+          echo "                           ...none"
+          echo " "
           
         fi
    else


### PR DESCRIPTION
I find I've been using quickstart/setchplenv.bash in order to
quickly get a Chapel up for example when I'm testing
on several different platforms. I find that every time I do that,
I also set CHPL_LLVM=none (since many of my chapel
source trees already have LLVM built, the default is
CHPL_LLVM=llvm). This patch updates the quickstart
scripts to also set CHPL_LLVM=none. I think that's consistent
with how they set CHPL_REGEXP=none or CHPL_COMM=none.

Replaces PR #1794