### PR TITLE
Support annotations for xc single and multi-locale perf graphs

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -10,7 +10,7 @@
 #     - example annotation 3
 #   mm/dd/yy:
 #     - text: example annotation 4
-#       host: [hostname1, hostname2]
+#       config: [config1, config2]
 #
 #
 # where 'group' is the base name of the .graph file that attached set
@@ -18,9 +18,10 @@
 # annotations are added to to every single graph.
 #
 # When the long form of an annotation is used (where 'text:' and
-# 'host:' are specified), the annotation is only added to the graphs
-# if the current hostname is in the host list.  Note that in this
-# form, the 'host:' line does not (cannot) have a leading '-' sign.
+# 'config:' are specified), the annotation is only added to the graphs
+# if the current configuration is in the configuration list. Note
+# that in this form, the 'config:' line does not (cannot) have a
+# leading '-' sign.
 #
 # Groups are listed in case insensitive alphabetical order
 #
@@ -59,7 +60,7 @@ all:
     - move chpl_getLocaleID into the modules
   02/12/15:
     - text: zombie process on chap04 was causing noise
-      host: chap04
+      config: chap04
 
 AllCompTime:
   11/09/14:
@@ -68,7 +69,7 @@ AllCompTime:
 arrayPerformance-1d:
   03/19/15:
     - text: memory related, qthreads memory pool bug fix
-      host: chap03
+      config: chap03
 
 arr-forall:
   03/24/15:
@@ -279,7 +280,7 @@ testSerialReductions:
 thread-ring:
   03/19/15:
     - text: memory related, qthreads memory pool bug fix
-      host: chap03
+      config: chap03
 
 time_array_vs_ddata:
   05/31/14:

--- a/util/test/annotate.py
+++ b/util/test/annotate.py
@@ -70,7 +70,7 @@ def _find_annotations(graph, matches, data, start, end, config_name):
       if start <= date and date <= end:
         for ann in annotations:
           if isinstance(ann, dict):
-            if config_name in ann['host']:
+            if config_name in ann['config']:
               matches[date].append(ann['text'])
           else:
             matches[date].append(ann)

--- a/util/test/annotate.py
+++ b/util/test/annotate.py
@@ -10,7 +10,6 @@ except ImportError:
   # Fall back to the python Loader otherwise
   from yaml import Loader
 
-_hostname = socket.gethostname().split('.')[0]
 _dat_date_format = '%m/%d/%y'
 _csv_date_format = '%Y-%m-%d'
 # doubled up braces are the escape in .format
@@ -45,10 +44,10 @@ def load(path):
   return data
 
 
-def get(data, graph, series, start, end, hostname=_hostname):
+def get(data, graph, series, start, end, config_name):
   matches = defaultdict(list)
-  _find_annotations('all', matches, data, start, end, hostname)
-  _find_annotations(graph, matches, data, start, end, hostname)
+  _find_annotations('all', matches, data, start, end, config_name)
+  _find_annotations(graph, matches, data, start, end, config_name)
 
   formatted = []
   for i, date in enumerate(sorted(matches.keys()), start=1):
@@ -65,13 +64,13 @@ def get(data, graph, series, start, end, hostname=_hostname):
   return formatted
 
 
-def _find_annotations(graph, matches, data, start, end, hostname):
+def _find_annotations(graph, matches, data, start, end, config_name):
   if graph in data:
     for date, annotations in data[graph].iteritems():
       if start <= date and date <= end:
         for ann in annotations:
           if isinstance(ann, dict):
-            if hostname in ann['host']:
+            if config_name in ann['host']:
               matches[date].append(ann['text'])
           else:
             matches[date].append(ann)

--- a/util/test/annotate.py
+++ b/util/test/annotate.py
@@ -45,10 +45,10 @@ def load(path):
   return data
 
 
-def get(data, graph, series, start, end):
+def get(data, graph, series, start, end, hostname=_hostname):
   matches = defaultdict(list)
-  _find_annotations('all', matches, data, start, end)
-  _find_annotations(graph, matches, data, start, end)
+  _find_annotations('all', matches, data, start, end, hostname)
+  _find_annotations(graph, matches, data, start, end, hostname)
 
   formatted = []
   for i, date in enumerate(sorted(matches.keys()), start=1):
@@ -65,13 +65,13 @@ def get(data, graph, series, start, end):
   return formatted
 
 
-def _find_annotations(graph, matches, data, start, end):
+def _find_annotations(graph, matches, data, start, end, hostname):
   if graph in data:
     for date, annotations in data[graph].iteritems():
       if start <= date and date <= end:
         for ann in annotations:
           if isinstance(ann, dict):
-            if _hostname in ann['host']:
+            if hostname in ann['host']:
               matches[date].append(ann['text'])
           else:
             matches[date].append(ann)

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -263,7 +263,8 @@ def strip_series(csvFile, numseries):
 class GraphStuff:
     def __init__(self, _name, _testdir, _perfdir, _outdir, _startdate, _enddate,
                  _reduce, _display_bounds, _alttitle, _annotation_file):
-        self.numGraphs = 0;
+        self.numGraphs = 0
+        self.hostname = _name
         self.testdir = _testdir
         self.perfdir = _perfdir
         self.outdir = _outdir
@@ -378,7 +379,7 @@ class GraphStuff:
             ginfo.annotations = annotate.get(
                 self.all_annotations, ginfo.name, series,
                 parse_date(ginfo.startdate, '%Y-%m-%d'),
-                parse_date(ginfo.enddate,'%Y-%m-%d'))
+                parse_date(ginfo.enddate,'%Y-%m-%d'), self.hostname)
 
         self.gfile.write('{\n')
         if ginfo.title != '':

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -264,7 +264,7 @@ class GraphStuff:
     def __init__(self, _name, _testdir, _perfdir, _outdir, _startdate, _enddate,
                  _reduce, _display_bounds, _alttitle, _annotation_file):
         self.numGraphs = 0
-        self.hostname = _name
+        self.config_name = _name
         self.testdir = _testdir
         self.perfdir = _perfdir
         self.outdir = _outdir
@@ -379,7 +379,7 @@ class GraphStuff:
             ginfo.annotations = annotate.get(
                 self.all_annotations, ginfo.name, series,
                 parse_date(ginfo.startdate, '%Y-%m-%d'),
-                parse_date(ginfo.enddate,'%Y-%m-%d'), self.hostname)
+                parse_date(ginfo.enddate,'%Y-%m-%d'), self.config_name)
 
         self.gfile.write('{\n')
         if ginfo.title != '':


### PR DESCRIPTION
Previously the script that grabbed annotations computed hostname by effectively
doing `hostname` which worked for chap03, chap04, bradc-lnx because the graph
generation ran on the same machine as the testing.

We run xc multi-locale graph generation on a random linux box, and we don't use
the actual machine name it runs on anyways so we need some way to specify which
hostname to use rather than just using the real hostname of the machine the
script is running on.

Now instead of using `hostname` we use the 'name' that was passed to gengraphs.