### PR TITLE
Set a maximum problem size to avoid timeouts

### DIFF
--- a/test/performance/bharshbarg/arr-forall.chpl
+++ b/test/performance/bharshbarg/arr-forall.chpl
@@ -11,7 +11,9 @@ config const printPerf = false;
 type elemType = uint(8);
 
 const totalMem = here.physicalMemory(unit = MemUnits.Bytes);
-const n = (totalMem / numBytes(elemType)) / memFraction;
+const target = (totalMem / numBytes(elemType)) / memFraction;
+// set a maximum problem size
+const n = min(target, 8 * 1e9) : int;
 
 const space = 1..n;
 var data : [space] elemType;


### PR DESCRIPTION
This patch avoids timeouts for --no-local on systems with large amounts of memory.