### PR TITLE
Switch uses of AstToText to stack allocated

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2422,10 +2422,9 @@ void FnSymbol::printDocs(std::ostream *file, unsigned int tabs) {
   }
 
   // Print name and arguments.
-  AstToText *info = new AstToText();
-  info->appendNameAndFormals(this);
-  *file << info->text();
-  delete info;
+  AstToText info;
+  info.appendNameAndFormals(this);
+  *file << info.text();
 
   // Print return intent, if one exists.
   switch (this->retTag) {

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -509,10 +509,9 @@ void EnumType::printDocs(std::ostream *file, unsigned int tabs) {
   this->printTabs(file, tabs);
   *file << this->docsDirective();
   *file << "enum ";
-  AstToText* info = new AstToText();
-  info->appendEnumDecl(this);
-  *file << info->text();
-  delete info;
+  AstToText info;
+  info.appendEnumDecl(this);
+  *file << info.text();
   *file << std::endl;
 
   // In rst mode, ensure there is an empty line between the enum signature and


### PR DESCRIPTION
These uses of AstToText were heap allocated instead of stack allocated, but
since they only live in those functions, that didn't really make sense.  I must
not have been thinking deeply that day.