### PR TITLE
Do not widen the arguments of functions with FLAG_LOCAL_ARGS

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -510,7 +510,7 @@ static void widenClasses()
     {
       if (Type* wide = wideClassMap.get(def->sym->type)) {
         if (isVarSymbol(def->sym) ||
-            !def->parentSymbol->hasFlag(FLAG_EXTERN)) {
+            !def->parentSymbol->hasFlag(FLAG_LOCAL_ARGS)) {
           if (TypeSymbol* ts = toTypeSymbol(def->parentSymbol)) {
             // Don't widen a ref's _val. We create a duplicate type so that
             // we can have references to both wide and narrow things.


### PR DESCRIPTION
Prior to this patch, we avoided widening args for extern functions only. This was wrong because "export" functions also have the FLAG_LOCAL_ARGS flag. Instead of checking against FLAG_EXTERN, this patch checks against FLAG_LOCAL_ARGS when determining whether or not to widen an argument.

This patch passed --no-local testing for the release/ directory.

This patch resolves a --no-local --verify failure for test/users/ferguson/ddata/cToChapelArray.chpl