### PR TITLE
Update docs() pass to check for directories before creating them.

### DIFF
--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -241,7 +241,7 @@ void createDocsFileFolders(std::string filename) {
     dirCutoff += total;
     std::string shorter = filename.substr(dirCutoff+1);
     std::string otherHalf = filename.substr(0, dirCutoff);
-    if (otherHalf.length() > 0) {
+    if (otherHalf.length() > 0 && !existsAndDir(otherHalf.c_str())) {
       makeDir(otherHalf.c_str());
     }
     total = dirCutoff + 1;
@@ -260,6 +260,14 @@ static void makeDir(const char* dirpath) {
     USR_FATAL(astr("Failed to create directory: ", dirpath,
                    " due to: ", strerror(errno)));
   }
+}
+
+
+/* Returns true if dirpath exists on file system and is a directory. */
+static bool existsAndDir(const char* dirpath) {
+  struct stat sb;
+  return stat(dirpath, &sb) == 0 &&
+    S_ISDIR(sb.st_mode);
 }
 
 

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -241,9 +241,12 @@ void createDocsFileFolders(std::string filename) {
     dirCutoff += total;
     std::string shorter = filename.substr(dirCutoff+1);
     std::string otherHalf = filename.substr(0, dirCutoff);
+
+    // Create `otherHalf` iff it is non-empty and does not already exist.
     if (otherHalf.length() > 0 && !existsAndDir(otherHalf.c_str())) {
       makeDir(otherHalf.c_str());
     }
+
     total = dirCutoff + 1;
     dirCutoff = shorter.find("/");
   }

--- a/compiler/passes/docs.h
+++ b/compiler/passes/docs.h
@@ -37,6 +37,8 @@ bool isNotSubmodule(ModuleSymbol *mod);
 
 static void makeDir(const char* dirpath);
 
+static bool existsAndDir(const char* dirpath);
+
 static std::string generateSphinxProject(std::string dirpath);
 
 static void generateSphinxOutput(std::string sphinxDir, std::string outputDir);


### PR DESCRIPTION
Previously, when creating the directories for chpldoc output files, chpldoc
would iterate through each individual directory in the path, attempting to
create it. For example, if the output directory for a particular module was
/path/to/chapel/docs/modules/, it would try to create /, then /path, then
/path/to, etc. The mkdir() calls would fail, but the makeDir() helper only
generates a USR_FATAL() if the error is not EEXIST.

This worked ok and led to a simple solution... except on cygwin. On cygwin,
`mkdir /cygdrive/c` returns "Permission denied" error instead of an EEXIST.

Update the createDocsFileFolders() procedure, which is responsible for creating
all those directories, to only attempt creating directories that do not already
exist. Add new existsAndDir() helper that uses stat() to determine if a
particular directory path exists and is a directory. Use new helper when
deciding whether to call makeDir().

Note that a path can exist, but not be a directory, and makeDir() helper will
still be called. This is expected and intentional, since makeDir() will report a
useful error message like, `Failed to create dir /blah due: <system error>`.

### Verification:

* [x] full test pass
* [x] `make check-chpldoc` works on cygwin system