### PR TITLE
Fixed a minor typo in compiler

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -83,8 +83,7 @@ checkControlFlow(Expr* expr, const char* context) {
       if (call->isPrimitive(PRIM_RETURN)) {
         USR_FATAL_CONT(call, "return is not allowed in %s", context);
       } else if (call->isPrimitive(PRIM_YIELD)) {
-        if (!strcmp(context, "begin statement") ||
-            !strcmp(context, "yield statement"))
+        if (!strcmp(context, "begin statement"))
           USR_FATAL_CONT(call, "yield is not allowed in %s", context);
       }
     } else if (GotoStmt* gs = toGotoStmt(ast1)) {


### PR DESCRIPTION
The check of 'context' against "begin statement" in build.cpp/checkControlFlow()
was introduced in 6367b99b aka r14557 to allow yield statements inside cobegin-,
coforall-, forall-, and on-statements.

Further, given that 'context' is never "yield statement",
it does not make sense to compare these two for equality.

Confirmed by running the full test suite in the standard configuration.
This PR simply removes this check, for clarity.

BTW: currently yields are (continue to be) disallowed
within 'begin' and 'sync' statements.
