### PR TITLE
Skip chpldoc test that tries to create /docs on cygwin platforms.

### DIFF
--- a/test/chpldoc/compflags/folder/failToCreateDir.doc.skipif
+++ b/test/chpldoc/compflags/folder/failToCreateDir.doc.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM <= cygwin


### PR DESCRIPTION
A non-root user can create /docs on cygwin without issue.

### Verification:

* [x] run `start_test test/chpldoc/compflags/folder/` on mac and ensure failToCreateDir.doc.chpl test runs
* [x] run `start_test test/chpldoc/compflags/folder/` on cygwin and ensure failToCreateDir.doc.chpl test does not run
