### PR TITLE
initCopy and autoCopy need to be defined for c_string*

### DIFF
--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -61,9 +61,25 @@ module CString {
   //  return string_from_c_string_copy(cstrc, true, len);
   //}
 
+  // We can't use the catch-all initCopy or autoCopy because of the
+  // transformation of c_strings into string for generic parameters
+  pragma "init copy fn"
+  inline proc chpl__initCopy(x: c_string) : c_string {
+    return x;
+  }
+  pragma "init copy fn"
+  inline proc chpl__initCopy(x: c_string_copy) : c_string_copy {
+    return x;
+  }
+
   pragma "donor fn"
   pragma "auto copy fn"
-  inline proc chpl__autoCopy(x: c_string) {
+  inline proc chpl__autoCopy(x: c_string) : c_string {
+    return x;
+  }
+  pragma "donor fn"
+  pragma "auto copy fn"
+  inline proc chpl__autoCopy(x: c_string_copy) : c_string_copy {
     return x;
   }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -423,7 +423,7 @@ module String {
    * used by initCopy().
    */
   pragma "init copy fn"
-  proc chpl__initCopy(ref s: string) {
+  proc chpl__initCopy(s: string) {
     if debugStrings then
       chpl_debug_string_print("in initCopy()");
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3506,8 +3506,8 @@ proc _write_text_internal(_channel_internal:qio_channel_ptr_t, x:?t):syserr wher
     // handle string
     return qio_channel_print_string(false, _channel_internal, x.c_str(), x.length:ssize_t);
   } else if isEnumType(t) {
-    var s = x:c_string;
-    return qio_channel_print_literal(false, _channel_internal, s, s.length:ssize_t);
+    var s = x:string;
+    return qio_channel_print_literal(false, _channel_internal, s.c_str(), s.length:ssize_t);
   } else {
     compilerError("Unknown primitive type in _write_text_internal ", typeToString(t));
   }


### PR DESCRIPTION
Not having these caused us to fallback to the generic verison, and then
we would convert the c_string to a string before calling the copy.
Fixing this lets us drop back to a const ref initCopy on string which
also fixes some bugs.