### PR TITLE
Add --no-inline to some skipif files that contain --baseline.

### DIFF
--- a/test/execflags/sungeun/about.skipif
+++ b/test/execflags/sungeun/about.skipif
@@ -1,4 +1,5 @@
 COMPOPTS <= --baseline
+COMPOPTS <= --no-inline
 COMPOPTS <= --no-local
 COMPOPTS <= --fast
 COMPOPTS <= --verify

--- a/test/modules/sungeun/init/printModuleInitOrder.skipif
+++ b/test/modules/sungeun/init/printModuleInitOrder.skipif
@@ -3,3 +3,4 @@
 # This skips baseline testing so that we only test the
 # initialization output when those modules are eliminated.
 COMPOPTS <= --baseline
+COMPOPTS <= --no-inline

--- a/test/optimizations/deadCodeElimination/elliot/SKIPIF
+++ b/test/optimizations/deadCodeElimination/elliot/SKIPIF
@@ -1,2 +1,3 @@
 # dead mod elim does not run with baseline, so skip these tests
 COMPOPTS <= baseline
+COMPOPTS <= --no-inline

--- a/test/param/bradc/foldUintZeroes.skipif
+++ b/test/param/bradc/foldUintZeroes.skipif
@@ -1,1 +1,2 @@
 COMPOPTS <= --baseline
+COMPOPTS <= --no-inline

--- a/test/statements/diten/op_equals_using_C_primitive.skipif
+++ b/test/statements/diten/op_equals_using_C_primitive.skipif
@@ -1,4 +1,5 @@
 # --baseline implies no inlining but this test requires inlining
 COMPOPTS <= --baseline
+COMPOPTS <= --no-inline
 
 COMPOPTS <= --llvm

--- a/test/types/range/elliot/anonymousRangeIter.skipif
+++ b/test/types/range/elliot/anonymousRangeIter.skipif
@@ -5,5 +5,8 @@ CHPL_COMM != none
 # inlining turned on so the output will be drastically different
 COMPOPTS <= --baseline
 
+# Ditto for no-inline
+COMPOPTS <= --no-inline
+
 # test greps generated c code, will fail for llvm
 COMPOPTS <= --llvm


### PR DESCRIPTION
These tests fail if you test with "-compopts --no-inline".  The same tests have COMPOPTS
<= --baseline in their .skipif files to avoid running the test when inlining is turned
off.  These tests should also be skipped if only --no-inline is tossed.