### PR TITLE
If chpldoc is not present, skip all remaining chpldocopts for chpldoc test

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1264,7 +1264,7 @@ for testname in testsrc:
                     sys.stdout.write(
                         '[Warning: Could not find chpldoc, skipping test '
                         '{0}/{1}]\n'.format(localdir, test_filename))
-                    continue
+                    break
 
             if valgrindcomp:
                 cmd = valgrindcomp


### PR DESCRIPTION
It was observed that test/chpldoc/compflags/folder/failToCreateDir would fail
when the tester did not have chpldoc built in their environment.  This test had
two compiler options in its .chpldocopts file, but the check to warn and skip
testing if chpldoc was not built only exited the current compopt line, not all
compopt lines.  In that section, the "compiler" value was changed, and so the
second option would not enter the same if statement to determine that it, too,
needed to be skipped.  This changes the behavior of that section so that all
compopt lines were skipped when chpldoc was detected as unbuilt, instead of just
the first.