### PR TITLE
Fix problem with sub_test error prints

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -347,15 +347,21 @@ def which(program):
 # print (compopts: XX, execopts: XX) for later decoding of failed tests
 def printTestVariation(compoptsnum, compoptslist,
                        execoptsnum=0, execoptslist=[] ):
-    if ( (compoptsnum==0 or len(compoptslist) == 1) and
-         (execoptsnum==0 or len(execoptslist) == 1) ):
+    printCompOpts = True
+    printExecOpts = True
+    if compoptsnum==0 or len(compoptslist) <= 1:
+        printCompOpts = False
+    if execoptsnum==0 or len(execoptslist) <= 1:
+        printExecOpts = False
+
+    if (not printCompOpts) and (not printExecOpts):
         return;
 
     sys.stdout.write(' (')
-    if compoptsnum != 0 and len(compoptslist) > 1:
+    if printCompOpts:
         sys.stdout.write('compopts: %d'%(compoptsnum))
-    if execoptsnum != 0 and len(execoptslist) > 1:
-        if compoptsnum != 0:
+    if printExecOpts:
+        if printCompOpts:
             sys.stdout.write(', ')
         sys.stdout.write('execopts: %d'%(execoptsnum))
     sys.stdout.write(')')


### PR DESCRIPTION
After PR #1831, sub_test was printing errors like

[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (, execopts: 2)]

Here we clean up printTestVariation to not do that
and to consolidate the decision about when to print.