### PR TITLE
Don't speculatively build with the PGI compiler on Cray X*.

### DIFF
--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -71,11 +71,9 @@ $(GASNET_INSTALL_DIR):
 try-gmp: FORCE
 ifeq ($(wildcard $(GMP_BUILD_DIR)),)
 	@echo "Speculatively attempting to build gmp"
-	-@$(MAKE) gmp
-else
-ifeq ($(wildcard $(GMP_H_FILE)),)
+	-@$(MAKE) GMP_SPECULATIVE=yes gmp
+else ifeq ($(wildcard $(GMP_H_FILE)),)
 	$(info Speculative build of gmp squashed due to previous failures.)
-endif
 endif
 
 gmp: $(GMP_H_FILE)

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -32,6 +32,22 @@ endif
 endif
 
 #
+# We have problems (involving alloca()) with PGI-built gmp.  These are
+# used below and record whether we're building on Cray X* with PGI and,
+# if so, whether it's a speculative build.
+#
+GMP_CRAY_X_PGI=no
+GMP_SPECULATIVE_CRAY_X_PGI=no
+ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+ifneq (, $(filter %pgi,$(CHPL_MAKE_TARGET_COMPILER)))
+GMP_CRAY_X_PGI=yes
+ifeq (yes, $(GMP_SPECULATIVE))
+GMP_SPECULATIVE_CRAY_X_PGI=yes
+endif
+endif
+endif
+
+#
 # On Cray systems, building the shared libraries causes issues.
 # On Macs, not building the shared libraries causes warnings.
 #
@@ -49,8 +65,6 @@ ifneq (, $(filter %32,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_ABI_ARG = ABI=32
 endif
 
-GMP_MAKEFILE = $(GMP_BUILD_SUBDIR)/Makefile
-
 CHPL_GMP_CFG_OPTIONS += $(CHPL_GMP_MORE_CFG_OPTIONS)
 
 default: all
@@ -59,6 +73,7 @@ all: gmp
 
 clean: FORCE
 	rm -rf $(GMP_BUILD_SUBDIR)
+	rm -rf $(GMP_INSTALL_SUBDIR)
 
 cleanall: FORCE
 	rm -rf build
@@ -66,27 +81,32 @@ cleanall: FORCE
 clobber: FORCE
 	rm -rf build install $(GMP_SUBDIR)
 
-$(GMP_UNPACKED_DIR):
-	cd $(GMP_DIR) && tar --bzip2 -xf $(GMP_TARBALL)
-
 $(GMP_BUILD_SUBDIR):
 	mkdir -p $@
 
-gmp-config:
-	$(MAKE) $(GMP_MAKEFILE)
-
-$(GMP_MAKEFILE): $(GMP_BUILD_SUBDIR) $(GMP_UNPACKED_DIR)
-	cd $(GMP_BUILD_DIR) && $(GMP_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS) $(CHPL_GMP_CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS) $(CHPL_GMP_CXXFLAGS)' $(CHPL_GMP_ABI_ARG) --prefix=$(GMP_INSTALL_DIR) $(CHPL_GMP_CFG_OPTIONS)
+$(GMP_UNPACKED_DIR):
+	cd $(GMP_DIR) && tar --bzip2 -xf $(GMP_TARBALL)
 
 gmp-build:
 	$(MAKE) $(GMP_H_FILE)
 
-$(GMP_H_FILE): $(GMP_MAKEFILE)
+$(GMP_H_FILE): $(GMP_BUILD_SUBDIR)
+ifeq (yes, $(GMP_SPECULATIVE_CRAY_X_PGI))
+	@echo 'Speculative build of gmp squashed due to PGI target compiler on Cray X*.'
+else
+ifeq (yes, $(GMP_CRAY_X_PGI))
+	@echo 'Forced gmp build with PGI on Cray X* fails some Chapel tests.'
+endif
+	@if [[ ! -e $(GMP_UNPACKED_DIR) ]]; then \
+	  $(MAKE) $(GMP_UNPACKED_DIR) ; \
+	fi
+	cd $(GMP_BUILD_DIR) && $(GMP_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS) $(CHPL_GMP_CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS) $(CHPL_GMP_CXXFLAGS)' $(CHPL_GMP_ABI_ARG) --prefix=$(GMP_INSTALL_DIR) $(CHPL_GMP_CFG_OPTIONS)
 	cd $(GMP_BUILD_DIR) && $(MAKE)
 ifeq ($(GMP_CROSS_COMPILED),no)
 	cd $(GMP_BUILD_DIR) && $(MAKE) check
 endif
 	cd $(GMP_BUILD_DIR) && $(MAKE) install
+endif
 
 gmp: $(GMP_H_FILE)
 

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -96,9 +96,7 @@ else
 ifeq (yes, $(GMP_CRAY_X_PGI))
 	$(warning Forced gmp build with PGI on Cray X* fails some Chapel tests.)
 endif
-	@if [[ ! -e $(GMP_UNPACKED_DIR) ]]; then \
-	  $(MAKE) $(GMP_UNPACKED_DIR) ; \
-	fi
+	$(MAKE) $(GMP_UNPACKED_DIR)
 	cd $(GMP_BUILD_DIR) && $(GMP_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS) $(CHPL_GMP_CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS) $(CHPL_GMP_CXXFLAGS)' $(CHPL_GMP_ABI_ARG) --prefix=$(GMP_INSTALL_DIR) $(CHPL_GMP_CFG_OPTIONS)
 	cd $(GMP_BUILD_DIR) && $(MAKE)
 ifeq ($(GMP_CROSS_COMPILED),no)

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -73,7 +73,6 @@ all: gmp
 
 clean: FORCE
 	rm -rf $(GMP_BUILD_SUBDIR)
-	rm -rf $(GMP_INSTALL_SUBDIR)
 
 cleanall: FORCE
 	rm -rf build

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -91,10 +91,10 @@ gmp-build:
 
 $(GMP_H_FILE): $(GMP_BUILD_SUBDIR)
 ifeq (yes, $(GMP_SPECULATIVE_CRAY_X_PGI))
-	@echo 'Speculative build of gmp squashed due to PGI target compiler on Cray X*.'
+	$(info Speculative build of gmp squashed due to PGI target compiler on Cray X*.)
 else
 ifeq (yes, $(GMP_CRAY_X_PGI))
-	@echo 'Forced gmp build with PGI on Cray X* fails some Chapel tests.'
+	$(warning Forced gmp build with PGI on Cray X* fails some Chapel tests.)
 endif
 	@if [[ ! -e $(GMP_UNPACKED_DIR) ]]; then \
 	  $(MAKE) $(GMP_UNPACKED_DIR) ; \


### PR DESCRIPTION
We have problems involving alloca() in gmp when it's built with the PGI
target compiler on Cray X* platforms.  So, don't speculatively build gmp
in that situation.  The specific file changes are as follows:

third-party/Makefile:
Set a GMP_SPECULATIVE make variable when invoking the third-party/gmp
Makefile for a speculative build.

third-party/gmp/Makefile:
For speculative builds, squash them entirely and print a message when
target=cray-x* and target compiler=*pgi.  For non-speculative builds
with this target and target compiler, warn that the resulting gmp may
have problems, but do the build anyway.

While here, I also rearranged the make targets so that we don't unpack
the tar file or do the configure step unless we're going to build gmp.
With the previous arrangement, there wasn't a good place to squash the
build until after the unpack and configure had been done, which take a
bit of time.

While here, for a 'clean', delete not only the configuration-specific
build subdir but also the config-specific install subdir.  This makes
things a little easier when testing Makefile changes, since for the
speculatively built packages we depend not only on the build subdir but
also the install subdir (for the .h file, whose presence tells us that
we have already speculatively built).