### PR TITLE
Fix third-party READMES

### DIFF
--- a/third-party/gmp/README
+++ b/third-party/gmp/README
@@ -6,6 +6,7 @@ This copy of GMP is being release with Chapel for convenience and uses
 a snapshot of GMP obtained from the GMP team at: http://gmplib.org
 
 For more information on the current support for GMP within Chapel,
-please refer to $CHPL_HOME/doc/technotes/README.gmp.  For more
-information about GMP itself, please refer to the website above or to
-the README in the gmp-*/ subdirectory of this directory.
+please refer to the GMP module documentation available at:
+ http://chapel.cray.com/docs/latest/modules/standard/GMP.html
+For more information about GMP itself, please refer to the website above
+or to the README in the gmp-*/ subdirectory of this directory.

--- a/third-party/re2/README
+++ b/third-party/re2/README
@@ -6,9 +6,10 @@ Chapel can be built (by setting CHPL_REGEXP=re2) to include the RE2 library
 (see http://code.google.com/p/re2/).
 
 For more information on the current support for RE2 within Chapel,
-please refer to $CHPL_HOME/doc/technotes/README.regexp.  For more
-information about RE2 itself, please refer to the website above or to
-the README in the re2/ subdirectory of this directory.
+please refer to the Regexp module documentation available at
+ http://chapel.cray.com/docs/latest/modules/standard/Regexp.html
+For more information about RE2 itself, please refer to the website above
+or to the README in the re2/ subdirectory of this directory.
 
 We modify the RE2 library to allow regular expressions in the format
 string for Chapel's readf() for searching on QIO channels.


### PR DESCRIPTION
Fix re2 and gmp readmes to refer to module docs (not removed READMEs)