### PR TITLE
fix GMP Chudnovsky test for 32-bit testing

### DIFF
--- a/test/modules/standard/gmp/studies/gmp-chudnovsky.chpl
+++ b/test/modules/standard/gmp/studies/gmp-chudnovsky.chpl
@@ -72,7 +72,7 @@ const terms   = (d/DIGITS_PER_ITER): c_long,
 
 record fac_t {
   var num_facs: c_long;
-  var sdom: domain(1, idxType=c_long);
+  var sdom: domain(1);
   var fac, pow: [sdom] c_ulong;
 };
 


### PR DESCRIPTION
This test had a problem in it for 32-bit systems due to believing
that a domain assigned the index set {0..#s} where s: int(32)
would have idxType=int(32) when in fact it's int(64).  The reason
is that 0..#s is (0..)#s and (0..) is a range with idxType=int(64); so
pulling off the first 's' elements preserves idxType=int(64) rather
than changing it to int(32).

If we had param ranges, we might apply similar param coercion
rules for them as we do for integers and determine that this
should result in an int(32) range, but we don't now, and it'll
be awhile before we do I expect.

So the fix is simple, just declare the domain to have idxType of
int(64) instead.