### PR TITLE
Triage update, morning of wednesday 4/22

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -772,9 +772,10 @@ slurm 'Expired credential' problem after executable termination (2015-04-13)
 [Error: Timed out executing program release/examples/primers/randomNumbers] (xc.aries.pgi.slurm: 2015-04-16)
 [Error: Timed out executing program release/examples/benchmarks/hpcc/stream] (xc.ugni.intel.slurm: 2015-04-16)
 
-timeout on 24-25 example tests
-------------------------------
+sporadic timeout on tests that normally complete quickly
+--------------------------------------------------------
 (xc.aries.pgi.aprun, xc.ugni.intel.aprun, xc.aries.cray.aprun: 2015-04-21)
+(perf.xc.no-local.gnu, perf.xc.local.cray, xc.aries.intel.slurm, xc.aries.pgi.slurm, perf.xc.local.pgi: 2015-04-22)
 
 
 ===================
@@ -946,7 +947,7 @@ sporadic execution timeout
 --------------------------
 [Error: Timed out executing program release/examples/benchmarks/hpcc/stream-ep] (2015-02-25..2015-02-28, 2015-03-12..)
 [Error: Timed out executing program release/examples/benchmarks/miniMD/miniMD    (compopts: 1)]              (2015-??-??..2015-03-17)
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (execopts: *)] (2015-03-22, 2015-03-25, 2015-03-31, 2015-04-04..2015-04-07, 2015-04-09, 2015-04-11..2015-04-15, 2015-04-19)
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (execopts: *)] (2015-03-22, 2015-03-25, 2015-03-31, 2015-04-04..2015-04-07, 2015-04-09, 2015-04-11..2015-04-15, 2015-04-19, 2015-04-22)
 
 
 ==================================
@@ -957,8 +958,8 @@ Reviewed 2015-04-20
 
 === sporadic failures below ===
 
-sporadic chameneos-redux-cas output mismatch (lydia)
-----------------------------------------------------
+sporadic output mismatch (lydia)
+--------------------------------
 [Error matching performance keys for studies/parboil/SAD/sadSerial]                               (????-??-??..2015-03-26, 2015-04-02..)
 
 
@@ -978,6 +979,7 @@ cause is unknown (2015-03-20..)
 cause is unknown
 ----------------
 [Error matching performance keys for release/examples/benchmarks/hpcc/ptrans] (2015-03-20..2015-03-24)
+[Error matching performance keys for studies/shootout/fasta/kbrady/fasta-printf] (2015-04-22)
 
 
 ================================
@@ -1154,11 +1156,12 @@ A package needed for chpldoc is not installed (2015-03-12, Thomas)
 sporadic generated output "FAILED" (see above for solid): First run 2014-12-07
 ------------------------------------------------------------------------------
 [Error matching program output for studies/colostate/OMP-Jacobi-1D-Sliced-Diamond-Tiling (compopts: 1)] (2015-01-16..2015-01-19, 2015-01-21, 2015-01-25..2015-01-28,
-                                                                                                         2015-01-31..2015-02-18, 2015-02-20..2015-02-22, 2015-02-24,
-                                                                                                         2015-03-01..2015-03-05, 2015-03-11..2015-03-14,
-                                                                                                         2015-03-17..2015-03-18, 2015-03-22..2015-03-26,
-                                                                                                         2015-03-28..2105-04-01, 2015-04-04..2015-04-08,
-                                                                                                         2015-04-10..2015-04-13, 2015-04-15..2015-04-19)
+                         2015-01-31..2015-02-18, 2015-02-20..2015-02-22,
+                         2015-02-24, 2015-03-01..2015-03-05,
+                         2015-03-11..2015-03-14, 2015-03-17..2015-03-18,
+                         2015-03-22..2015-03-26, 2015-03-28..2015-04-01,
+                         2015-04-04..2015-04-08, 2015-04-10..2015-04-13,
+                         2015-04-15..2015-04-19, 2015-04-21..)
 
 
 ================================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -180,17 +180,13 @@ Inherits 'general'
 Reviewed 2015-04-20
 ===================
 
-32-/64-bit portability issue (2015-03-04, bradc)
-------------------------------------------------
-[Error matching compiler output for modules/standard/gmp/studies/gmp-chudnovsky]
-
 Seg fault
 ---------
 [Error matching compiler output for ipe/powerOfTwo] (2015-04-19, noakes)
 
 Seg fault since first run (2014-12-07)
 --------------------------------------
-[Error matching compiler output for users/vass/ype-tests.isSubtype]
+[Error matching compiler output for users/vass/type-tests.isSubtype]
 
 different amounts of memory leaked on 32-bit platforms (2014-11-12, first run)
 ------------------------------------------------------------------------------
@@ -336,8 +332,8 @@ new errors on 2015-03-28 (vass)
 [Error: Timed out executing program studies/amr/diffusion/level/Level_DiffusionBE_driver]
 [Error: Timed out executing program studies/lulesh/bradc/xyztuple/lulesh-dense-3tuple]
 
-invalid reads/writes
---------------------
+invalid reads/writes (noakes)
+-----------------------------
 [Error matching compiler output for ipe/powerOfTwo] (2015-04-19)
 
 invalid reads/writes, not manually reproducible (2015-04-11..)
@@ -347,7 +343,6 @@ invalid reads/writes, not manually reproducible (2015-04-11..)
 [Error matching program output for domains/bradc/subdomain]
 [Error matching program output for spec/marybeth/for]
 [Error matching program output for spec/marybeth/select]
-[Error matching program output for trivial/bradc/formatoutput]
 [Error matching program output for users/ferguson/forall_expr]
 
 
@@ -361,18 +356,20 @@ conditional jump depends on uninitialized value (2014-04-08 -- since re2 on)
 sporadic invalid write in dl_lookup_symbol->do_lookup_x, read in dl_name_match_p
 --------------------------------------------------------------------------------
 [Error matching program output for performance/sungeun/dgemm] (..., 2014-11-29..2015-03-27)
-[Error matching program output for reductions/bradc/manual/promote] (2015-04-11
+[Error matching program output for reductions/bradc/manual/promote] (2015-04-11..2015-04-18)
 
 sporadic execution timeout
 --------------------------
 [Error: Timed out executing program domains/sungeun/assoc/stress.numthr (compopts: 1, execopts: 2)] (..2015-02-21, 2015-03-27, 2015-04-11)]
 [Error: Timed out executing program performance/bharshbarg/arr-forall] (2015-03-20, 2015-03-29..2015-04-02, 2015-04-04..)]
-[Error: Timed out executing program studies/shootout/fannkuch-redux/sungeun/fannkuch-redux (execopts: 2)] (2015-03-28..2015-04-02, 2015-04-03..)]
+[Error: Timed out executing program studies/shootout/fannkuch-redux/sungeun/fannkuch-redux (execopts: 2)] (2015-03-28..2015-04-02, 2015-04-03..2015-04-19)]
 
 
-sporadic invalid reads/writes (2015-04-11..2015-04-15, 2015-04-17)
-------------------------------------------------------
-[Error matching program output for exercises/boundedBuffer2]
+sporadic invalid reads/writes
+-----------------------------
+[Error matching program output for exercises/boundedBuffer2] (2015-04-11..2015-04-15, 2015-04-17..2015-04-18)
+[Error matching program output for trivial/bradc/formatoutput] (2015-04-11..2015-04-18)
+
 
 ****************************************************************************
 *                   Different build configurations                         *
@@ -435,7 +432,7 @@ Reviewed 2015-04-20
 sporadic memory leaks
 ---------------------
 [Error matching program output for types/string/StringImpl/memLeaks/ascii] (2015-04-15)
-[Error matching program output for types/string/StringImpl/memLeaks/substring] (2015-04-19)
+[Error matching program output for types/string/StringImpl/memLeaks/substring] (2015-04-19..2015-04-20)
 
 
 sporadic failures even after Sung quieted it down (gbt/diten)
@@ -491,7 +488,7 @@ Reviewed 2015-04-20
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_mul] (2015-03-01, 2015-04-02)
+[Error: Timed out executing program studies/madness/aniruddha/madchap/test_mul] (2015-03-01, 2015-04-02, 2015-04-20)
 [Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dBDtoDRTest] (2015-03-24, 2015-03-28, 2015-04-08)
 [Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dDRtoBDTest] (2015-04-15)
 
@@ -762,7 +759,7 @@ Reviewed 2015-04-20
 
 [chpl_launchcmd] ... [ERROR] Output file from job does not exist at: ... (2015-03-25)
 -------------------------------------------------------------------------------------
-[Error matching program output for release/examples/benchmarks/hpcc/fft] (xc.mpi.gnu.aprun: 2015-04-09)
+[Error matching program output for release/examples/benchmarks/hpcc/fft] (last seen: 2015-04-21 on xc.ugni-qthreads.intel.aprun)
 [Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 2)] (last seen 2015-03-25 on xc.mpi.pgi.aprun)
 [Error matching program output for release/examples/benchmarks/lulesh/test3DLulesh (compopts: 1, execopts: 2)] (xc.ugni.gnu.aprun: 2015-04-11)
 [Error matching program output for release/examples/primers/procedures] (xc.ugni.intel.aprun 2015-04-15)
@@ -774,6 +771,10 @@ slurm 'Expired credential' problem after executable termination (2015-04-13)
 [Error matching program output for release/examples/primers/genericClasses] (xc.aries.cray.slurm: 2015-04-13)
 [Error: Timed out executing program release/examples/primers/randomNumbers] (xc.aries.pgi.slurm: 2015-04-16)
 [Error: Timed out executing program release/examples/benchmarks/hpcc/stream] (xc.ugni.intel.slurm: 2015-04-16)
+
+timeout on 24-25 example tests
+------------------------------
+(xc.aries.pgi.aprun, xc.ugni.intel.aprun, xc.aries.cray.aprun: 2015-04-21)
 
 
 ===================
@@ -1158,7 +1159,7 @@ sporadic generated output "FAILED" (see above for solid): First run 2014-12-07
                                                                                                          2015-03-01..2015-03-05, 2015-03-11..2015-03-14,
                                                                                                          2015-03-17..2015-03-18, 2015-03-22..2015-03-26,
                                                                                                          2015-03-28..2105-04-01, 2015-04-04..2015-04-08,
-                                                                                                         2015-04-10..2015-04-13, 2015-04-15)
+                                                                                                         2015-04-10..2015-04-13, 2015-04-15..2015-04-19)
 
 
 ================================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -959,7 +959,6 @@ Reviewed 2015-04-20
 
 sporadic chameneos-redux-cas output mismatch (lydia)
 ----------------------------------------------------
-[Error matching performance keys for studies/shootout/chameneos-redux/hannah/chameneos-redux-cas] (2015-02-28, 2015-03-06..2015-03-23)
 [Error matching performance keys for studies/parboil/SAD/sadSerial]                               (????-??-??..2015-03-26, 2015-04-02..)
 
 


### PR DESCRIPTION
- Removed failure for modules/standard/gmp/studies/gmp-chudnovsky on 32 bit
platforms (thanks Brad!)
- Fixed a typo on users/vass/type-tests.isSubtype
- Made Mike the owner of an ipe bug
- Moved an unreproducible valgrind bug to the sporadic failures section, since
  we haven't seen it in a few days and there didn't seem to be a reason for it to
  be fixed.
- Added an end date/single occurrence for multiple sporadic failures including
  reductions/bradc/manual/promote,
  studies/shootout/fannkuch-redux/sungeun/fannkuch-redux (execopts: 2),
  exercises/boundedBuffer2 on valgrind,
  types/string/StringImpl/memLeaks/substring on gasnet*,
  studies/madness/aniruddha/madchap/test_mul on gasnet.fifo,
  studies/colostate/OMP-Jacobi-1D-Sliced-Diamond-Tiling on cygwin32,
  release/examples/benchmarks/ssca2/SSCA2_main on perf.xc.16.ugni.gnu
- Updated the last seen date and setting for
  release/examples/benchmarks/hpcc/fft
- Added the sporadic group of timeouts to the xc configuration
- Removed entry on chameneos-cas performance timeout and relabeled
  its category
- Noted a fasta-printf output mismatch as sporadic for now, will update this
  pending tomorrow's run if necessary.  I did this because it didn't make
  sense for the test to have failed last night after last night's changes.