### PR TITLE
Triage update, morning of Friday 4/24

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -362,7 +362,7 @@ sporadic execution timeout
 --------------------------
 [Error: Timed out executing program domains/sungeun/assoc/stress.numthr (compopts: 1, execopts: 2)] (..2015-02-21, 2015-03-27, 2015-04-11)]
 [Error: Timed out executing program performance/bharshbarg/arr-forall] (2015-03-20, 2015-03-29..2015-04-02, 2015-04-04..)]
-[Error: Timed out executing program studies/shootout/fannkuch-redux/sungeun/fannkuch-redux (execopts: 2)] (2015-03-28..2015-04-02, 2015-04-03..2015-04-19)]
+[Error: Timed out executing program studies/shootout/fannkuch-redux/sungeun/fannkuch-redux (execopts: 2)] (2015-03-28..2015-04-02, 2015-04-03..2015-04-19, 2015-04-22..)
 
 
 sporadic invalid reads/writes
@@ -765,6 +765,7 @@ Reviewed 2015-04-20
 [Error matching program output for release/examples/primers/procedures] (xc.ugni.intel.aprun 2015-04-15)
 [Error matching program output for release/examples/primers/sparse] (xc.ugni.-qthreads.gnu.aprun 2015-04-16)
 [Error matching program output for release/examples/benchmarks/hpcc/variants/stream-promoted] (xc.ugni.gnu.aprun: 2015-04-17)
+[Error matching program output for release/examples/programs/quicksort] (xc.mpi.cray.aprun, 2015-04-23)
 
 slurm 'Expired credential' problem after executable termination (2015-04-13)
 ----------------------------------------------------------------------------

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -528,9 +528,9 @@ Reviewed 2015-04-20
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (xc-wb.prgenv-pgi   2015-03-29, 2015-04-12, 2015-04-16..)
+[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (xc-wb.prgenv-pgi   2015-03-29, 2015-04-12, 2015-04-16..2015-04-22)
                                                                            (xc-wb.prgenv-gnu   2015-03-24, 2015-03-29, 2015-04-02, 2015-04-07, 2015-04-14)
-                                                                           (xc-wb.prgenv-intel 2015-03-24, 2015-03-31, 2015-04-02, 2015-04-07..2015-04-09, 2015-04-14)
+                                                                           (xc-wb.prgenv-intel 2015-03-24, 2015-03-31, 2015-04-02, 2015-04-07..2015-04-09, 2015-04-14, 2015-04-23..)
 
 
 =======================
@@ -743,10 +743,10 @@ Reviewed 2015-04-20
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program release/examples/benchmarks/hpcc/variants/ra-cleanloop (compopts: 1)] (xe.ugni.gnu:            2015-03-25, 2015-03-27, 2015-04-01, 2015-04-20
-                                                                                                          (xe.ugni.intel:          2015-03-30,
-                                                                                                          (xe.ugni-qthreads.intel: ?? .. 2015-03-22
-[Error: Timed out executing program release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 5)] (xe.mpi.pgi:  2015-03-19
+[Error: Timed out executing program release/examples/benchmarks/hpcc/variants/ra-cleanloop (compopts: 1)] (xe.ugni.gnu:            2015-03-25, 2015-03-27, 2015-04-01, 2015-04-20)
+                                                                                                          (xe.ugni.intel:          2015-03-30, 2015-04-24)
+                                                                                                          (xe.ugni-qthreads.intel: ?? .. 2015-03-22)
+[Error: Timed out executing program release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 5)] (xe.mpi.pgi:  2015-03-19)
 
 
 ===================
@@ -784,7 +784,6 @@ xe.*
 Inherits 'x?.*'
 Reviewed 2015-04-20
 ===================
-All XE Builds have been failing since 2015-04-03 with a git error.
 
 
 === sporadic failures below ===
@@ -792,7 +791,7 @@ All XE Builds have been failing since 2015-04-03 with a git error.
 sporadic compilation timeouts - perhaps test-independent
 --------------------------------------------------------
 [Error: Timed out compilation for release/examples/benchmarks/lulesh/lulesh (compopts: 1)] (xe.gemini.cray: 2015-03-23)
-[Error: Timed out compilation for release/examples/benchmarks/miniMD/miniMD (compopts: 1)] (xe.mpi.cray: 2015-03-25, xe.mpi.cray: 2015-03-27)
+[Error: Timed out compilation for release/examples/benchmarks/miniMD/miniMD (compopts: 1)] (xe.mpi.cray: 2015-03-25, xe.mpi.cray: 2015-03-27, xe.gemini.cray: 2015-04-24)
 [Error: Timed out compilation for release/examples/benchmarks/ssca2/SSCA2_main (compopts: *, execopts: 1)] (xe.gemini.cray:        2015-03-19)
                                                                                                            (xe.ugni-qthreads.intel 2015-03-27, 2015-03-31)
                                                                                                            (xe.ugni.gnu            2015-03-24..2015-04-01
@@ -809,9 +808,11 @@ Reviewed 2015-04-20
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program release/examples/benchmarks/hpcc/ra          (compopts: 1)]              (xe.ugni-qthreads.gnu 2015-03-24
-                                                                                                             (xe.ugni.intel        2015-03-24, 2015-03-30, 2015-04-01 .. 2015-04-02
-                                                                                                             (xe.ugni.gnu          2015-03-24, 2015-03-30
+[Error: Timed out executing program release/examples/benchmarks/hpcc/ra          (compopts: 1)]              (xe.ugni-qthreads.gnu 2015-03-24)
+                                                                                                             (xe.ugni.intel        2015-03-24, 2015-03-30, 2015-04-01 .. 2015-04-02, 2015-04-24)
+                                                                                                             (xe.ugni.gnu          2015-03-24, 2015-03-30, 2015-04-24)
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5)] (xe.ugni.intel 2015-04-24)
+                (xe.ugni.gnu   2015-04-24)
 
 
 ==========================================
@@ -1162,7 +1163,7 @@ sporadic generated output "FAILED" (see above for solid): First run 2014-12-07
                          2015-03-11..2015-03-14, 2015-03-17..2015-03-18,
                          2015-03-22..2015-03-26, 2015-03-28..2015-04-01,
                          2015-04-04..2015-04-08, 2015-04-10..2015-04-13,
-                         2015-04-15..2015-04-19, 2015-04-21..)
+                         2015-04-15..2015-04-19, 2015-04-21..2015-04-22)
 
 
 ================================


### PR DESCRIPTION
- Noted that the fannkuchredux error had returned to valgrind.  Given its
  history of failing for long periods of time between passing, I left it as
  open.
- Noted another instance of the 'Output file from job does not exist' error.
  I may collapse this error into less detail as the test that fails doesn't
  seem to matter.
- Added an end date for the latest sporadic gdbSetConfig failure with prgenv-pgi
- Added a start date for the same test on prgenv-intel
- Now that XE testing is no longer failing (thanks Thomas!), added some new
  sporadic failure dates: hpcc/variants/ra-cleanloop on xe.ugni.intel (and
  closed some opened parentheses), miniMD on xe.gemini.cray,
  release/examples/benchmarks/hpcc/ra on xe.ugni.intel and xe.ugni.gnu and
  release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5) on xe.ugni.intel
  and xe.ugni.gnu
- Yet another colorado state Jacobi Diamond update for cygwin32