### PR TITLE
Fix RE2 c tests to work on linux32

### DIFF
--- a/test/regexp/ferguson/ctests/sub_test
+++ b/test/regexp/ferguson/ctests/sub_test
@@ -58,18 +58,11 @@ else
   exit
 fi
 
-if [ "$PLAT" = "darwin" ]
-then
-  # Don't use --static with because it doesn't work on Mac OS X
-  OPTS=
-else
-  OPTS="-static"
-fi
+DEPS="$OPTS -Wall -DCHPL_RT_UNIT_TEST $DEFS $RE2INCLS"
+LDEPS="$RSRC/qio.c $RSRC/sys.c $RSRC/sys_xsi_strerror_r.c $RSRC/qbuffer.c $RSRC/qio_error.c $RSRC/deque.c $RSRC/regexp/re2/re2-interface.cc $RE2LIB -lpthread"
 
-DEPS="$OPTS -Wall -DCHPL_RT_UNIT_TEST $DEFS $RSRC/qio.c $RSRC/sys.c $RSRC/sys_xsi_strerror_r.c $RSRC/qbuffer.c $RSRC/qio_error.c $RSRC/deque.c $RSRC/regexp/re2/re2-interface.cc $RE2INCLS $RE2LIB -lpthread"
-
-T1="$CXX $DEPS -g regexp_test.cc -o regexp_test"
-T2="$CXX $DEPS -g regexp_channel_test.cc -o regexp_channel_test"
+T1="$CXX $DEPS -g regexp_test.cc -o regexp_test $LDEPS"
+T2="$CXX $DEPS -g regexp_channel_test.cc -o regexp_channel_test $LDEPS"
 
 
 dotest() {


### PR DESCRIPTION
Any RE2 program seems to hang with --static, on Ubuntu 14.10, so I removed that.
Also adjusted the -l commands to come at the end of the compile
line since that matters too sometimes.