### PR TITLE
Triage3

### DIFF
--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -180,10 +180,6 @@ Inherits 'general'
 Reviewed 2015-04-20
 ===================
 
-Seg fault
----------
-[Error matching compiler output for ipe/powerOfTwo] (2015-04-19, noakes)
-
 Seg fault since first run (2014-12-07)
 --------------------------------------
 [Error matching compiler output for users/vass/type-tests.isSubtype]
@@ -214,6 +210,12 @@ darwin
 Inherits 'general'
 Reviewed 2015-04-20
 ===================
+
+=== sporadic failures below ===
+
+Bus failure (not test specific?)
+--------------------------------
+[Error matching .bad file for users/vass/crash1callDestructorsMain] (2015-04-25)
 
 
 ===================
@@ -362,7 +364,7 @@ sporadic execution timeout
 --------------------------
 [Error: Timed out executing program domains/sungeun/assoc/stress.numthr (compopts: 1, execopts: 2)] (..2015-02-21, 2015-03-27, 2015-04-11)]
 [Error: Timed out executing program performance/bharshbarg/arr-forall] (2015-03-20, 2015-03-29..2015-04-02, 2015-04-04..)]
-[Error: Timed out executing program studies/shootout/fannkuch-redux/sungeun/fannkuch-redux (execopts: 2)] (2015-03-28..2015-04-02, 2015-04-03..2015-04-19, 2015-04-22..)
+[Error: Timed out executing program studies/shootout/fannkuch-redux/sungeun/fannkuch-redux (execopts: 2)] (2015-03-28..2015-04-02, 2015-04-03..2015-04-19, 2015-04-22..2015-04-23, 2015-04-25..)
 
 
 sporadic invalid reads/writes
@@ -438,7 +440,7 @@ sporadic memory leaks
 sporadic failures even after Sung quieted it down (gbt/diten)
 (gasnet.fifo, gasnet-fast, gasnet-everything)
 -------------------------------------------------------------
-[Error matching program output for types/string/StringImpl/memLeaks/coforall] gasnet.fifo (2015-03-24, 2015-03-31, 2015-04-04)
+[Error matching program output for types/string/StringImpl/memLeaks/coforall] gasnet.fifo (2015-03-24, 2015-03-31, 2015-04-04, 2015-04-26..)
 
 sporadic execution timeout
 (gasnet.fifo, gasnet-fast)
@@ -489,7 +491,7 @@ Reviewed 2015-04-20
 sporadic execution timeouts
 ---------------------------
 [Error: Timed out executing program studies/madness/aniruddha/madchap/test_mul] (2015-03-01, 2015-04-02, 2015-04-20)
-[Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dBDtoDRTest] (2015-03-24, 2015-03-28, 2015-04-08)
+[Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dBDtoDRTest] (2015-03-24, 2015-03-28, 2015-04-08, 2015-04-24)
 [Error: Timed out executing program optimizations/bulkcomm/alberto/Block/2dDRtoBDTest] (2015-04-15)
 
 segfault
@@ -528,9 +530,9 @@ Reviewed 2015-04-20
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (xc-wb.prgenv-pgi   2015-03-29, 2015-04-12, 2015-04-16..2015-04-22)
+[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (xc-wb.prgenv-pgi   2015-03-29, 2015-04-12, 2015-04-16..2015-04-22, 2015-04-26)
                                                                            (xc-wb.prgenv-gnu   2015-03-24, 2015-03-29, 2015-04-02, 2015-04-07, 2015-04-14)
-                                                                           (xc-wb.prgenv-intel 2015-03-24, 2015-03-31, 2015-04-02, 2015-04-07..2015-04-09, 2015-04-14, 2015-04-23..)
+                                                                           (xc-wb.prgenv-intel 2015-03-24, 2015-03-31, 2015-04-02, 2015-04-07..2015-04-09, 2015-04-14, 2015-04-23..2015-04-25)
 
 
 =======================
@@ -743,7 +745,7 @@ Reviewed 2015-04-20
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program release/examples/benchmarks/hpcc/variants/ra-cleanloop (compopts: 1)] (xe.ugni.gnu:            2015-03-25, 2015-03-27, 2015-04-01, 2015-04-20)
+[Error: Timed out executing program release/examples/benchmarks/hpcc/variants/ra-cleanloop (compopts: 1)] (xe.ugni.gnu:            2015-03-25, 2015-03-27, 2015-04-01, 2015-04-20, 2015-04-26)
                                                                                                           (xe.ugni.intel:          2015-03-30, 2015-04-24)
                                                                                                           (xe.ugni-qthreads.intel: ?? .. 2015-03-22)
 [Error: Timed out executing program release/examples/benchmarks/lulesh/lulesh (compopts: 2, execopts: 5)] (xe.mpi.pgi:  2015-03-19)
@@ -754,6 +756,9 @@ xc.*
 Inherits 'x?.*'
 Reviewed 2015-04-20
 ===================
+
+knc configuration fails to build gasnet since 2015-04-25
+
 
 === sporadic failures below ===
 
@@ -808,11 +813,12 @@ Reviewed 2015-04-20
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program release/examples/benchmarks/hpcc/ra          (compopts: 1)]              (xe.ugni-qthreads.gnu 2015-03-24)
+[Error: Timed out executing program release/examples/benchmarks/hpcc/ra          (compopts: 1)]              (xe.ugni-qthreads.gnu 2015-03-24, 2015-04-26)
                                                                                                              (xe.ugni.intel        2015-03-24, 2015-03-30, 2015-04-01 .. 2015-04-02, 2015-04-24)
                                                                                                              (xe.ugni.gnu          2015-03-24, 2015-03-30, 2015-04-24)
-[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5)] (xe.ugni.intel 2015-04-24)
+[Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (compopts: 5)] (xe.ugni.intel 2015-04-24, 2015-04-27)
                 (xe.ugni.gnu   2015-04-24)
+                (xe.ugni-qthreads.gnu 2015-04-25)
 
 
 ==========================================
@@ -1163,7 +1169,8 @@ sporadic generated output "FAILED" (see above for solid): First run 2014-12-07
                          2015-03-11..2015-03-14, 2015-03-17..2015-03-18,
                          2015-03-22..2015-03-26, 2015-03-28..2015-04-01,
                          2015-04-04..2015-04-08, 2015-04-10..2015-04-13,
-                         2015-04-15..2015-04-19, 2015-04-21..2015-04-22)
+                         2015-04-15..2015-04-19, 2015-04-21..2015-04-22
+                         2015-04-24, 2015-04-26..)
 
 
 ================================

--- a/test/REGRESSIONS
+++ b/test/REGRESSIONS
@@ -159,7 +159,7 @@
 
 ===================
 general
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
@@ -170,14 +170,14 @@ Reviewed 2015-04-20
 ===================
 linux64
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
 ===================
 *32
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 Seg fault since first run (2014-12-07)
@@ -192,7 +192,7 @@ different amounts of memory leaked on 32-bit platforms (2014-11-12, first run)
 ===================
 linux32
 Inherits '*32'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 timeout (2015-02-05, first run) - (elliot/michael)
@@ -208,7 +208,7 @@ Chapel string passed to external routine (2015-03-05, kyleb)
 ===================
 darwin
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 === sporadic failures below ===
@@ -221,7 +221,7 @@ Bus failure (not test specific?)
 ===================
 gnu.darwin
 Inherits 'darwin'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
@@ -234,7 +234,7 @@ Reviewed 2015-04-20
 ===================
 perf*
 Inherits 'general'
-Reviewed 2015-04-17
+Reviewed 2015-04-27
 ===================
 
 consistent failure due to insane memory usage (should get better with strings)
@@ -246,36 +246,31 @@ consistent failure due to insane memory usage (should get better with strings)
 ===================
 perf.bradc-lnx
 Inherits 'perf*'
-Reviewed 2015-04-17
+Reviewed 2015-04-27
 ===================
-
-=== sporadic failures below ===
-
-failure due to insane memory usage? (should get better with strings) (vass)
-------------------------------------------------------------------------------
-[Error matching performance keys for io/vass/time-write (compopts: 1)] (2014-11-01..2015-03-01, 2015-03-05..2015-03-18)
-
 
 
 ===================
 perf.chap03
 Inherits 'perf*'
-Reviewed 2015-04-17
+Reviewed 2015-04-27
 ===================
 
 
 ===================
 perf.chap04
 Inherits 'perf*'
-Reviewed 2015-04-15
+Reviewed 2015-04-27
 ===================
 
 
 ====================
 perf.chapel-shootout
 Inherits 'perf*'
-Reviewed 2015-04-10
+Reviewed 2015-04-27
 ====================
+
+Machine is may have kicked the bucket.
 
 
 ****************************************************************************
@@ -286,14 +281,14 @@ Reviewed 2015-04-10
 ===================
 fast
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
 ===================
 baseline
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 Dies with signal 6
@@ -304,27 +299,27 @@ Dies with signal 6
 ===================
 memleaks.examples
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 ============================
 memleaks
 Inherits 'memleaks.examples'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ============================
 
 
 ===================
 verify
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
 ===================
 valgrind
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 new errors on 2015-03-28 (vass)
@@ -357,7 +352,6 @@ conditional jump depends on uninitialized value (2014-04-08 -- since re2 on)
 
 sporadic invalid write in dl_lookup_symbol->do_lookup_x, read in dl_name_match_p
 --------------------------------------------------------------------------------
-[Error matching program output for performance/sungeun/dgemm] (..., 2014-11-29..2015-03-27)
 [Error matching program output for reductions/bradc/manual/promote] (2015-04-11..2015-04-18)
 
 sporadic execution timeout
@@ -381,7 +375,7 @@ sporadic invalid reads/writes
 ===================
 llvm
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 relies on macro in gmp.h -- not expected to work without effort (2014-09-18)
@@ -392,14 +386,14 @@ relies on macro in gmp.h -- not expected to work without effort (2014-09-18)
 ===================
 fifo
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
 ===================
 numa
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
@@ -412,29 +406,29 @@ Reviewed 2015-04-20
 ===================
 no-local
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
 =================================
 no-local.linux32
 Inherits 'linux32' and 'no-local'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 =================================
 
 
 ===================
 gasnet*
 Inherits 'no-local'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 === sporadic failures below ===
 
 sporadic memory leaks
 ---------------------
-[Error matching program output for types/string/StringImpl/memLeaks/ascii] (2015-04-15)
-[Error matching program output for types/string/StringImpl/memLeaks/substring] (2015-04-19..2015-04-20)
+[Error matching program output for types/string/StringImpl/memLeaks/ascii] (last seen with gasnet.everything on 2015-04-15)
+[Error matching program output for types/string/StringImpl/memLeaks/substring] (last seen with gasnet.fast on 2015-04-19..2015-04-20)
 
 
 sporadic failures even after Sung quieted it down (gbt/diten)
@@ -442,24 +436,18 @@ sporadic failures even after Sung quieted it down (gbt/diten)
 -------------------------------------------------------------
 [Error matching program output for types/string/StringImpl/memLeaks/coforall] gasnet.fifo (2015-03-24, 2015-03-31, 2015-04-04, 2015-04-26..)
 
-sporadic execution timeout
-(gasnet.fifo, gasnet-fast)
---------------------------
-[Error: Timed out executing program studies/madness/aniruddha/madchap/test_likepy] (last seen: 2015-02-17)
-
-
 
 ===================
 gasnet-everything
 Inherits 'gasnet*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
 ===================
 gasnet-fast
 Inherits 'gasnet*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 Segfault (2015-02-22, michael)
@@ -476,14 +464,14 @@ keep this failure past 30-day mark - see Pivotal story 91235766
 ===============================
 gasnet.darwin
 Inherits 'darwin' and 'gasnet*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===============================
 
 
 =============================
 gasnet.fifo
 Inherits 'gasnet*' and 'fifo'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 =============================
 
 === sporadic failures below ===
@@ -503,14 +491,14 @@ segfault
 =============================
 gasnet.llvm
 Inherits 'gasnet*' and 'llvm'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 =============================
 
 
 =============================
 gasnet.numa
 Inherits 'gasnet*' and 'numa'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 =============================
 
 
@@ -523,50 +511,50 @@ Reviewed 2015-04-20
 ===================
 xc-wb.*
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 === sporadic failures below ===
 
 sporadic execution timeouts
 ---------------------------
-[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (xc-wb.prgenv-pgi   2015-03-29, 2015-04-12, 2015-04-16..2015-04-22, 2015-04-26)
+[Error: Timed out executing program execflags/bradc/gdbddash/gdbSetConfig] (xc-wb.prgenv-pgi   2015-03-29, 2015-04-12, 2015-04-16..2015-04-21, 2015-04-26)
                                                                            (xc-wb.prgenv-gnu   2015-03-24, 2015-03-29, 2015-04-02, 2015-04-07, 2015-04-14)
-                                                                           (xc-wb.prgenv-intel 2015-03-24, 2015-03-31, 2015-04-02, 2015-04-07..2015-04-09, 2015-04-14, 2015-04-23..2015-04-25)
+                                                                           (xc-wb.prgenv-intel 2015-03-24, 2015-03-31, 2015-04-02, 2015-04-07, 2015-04-14, 2015-04-23)
 
 
 =======================
 *gnu*
 Inherits from 'linux64'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 =======================
 
 
 ==============================
 xc-wb.gnu
 Inherits 'xc-wb.*' and '*gnu*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ==============================
 
 
 ==============================
 xc-wb.prgenv-gnu
 Inherits 'xc-wb.*' and '*gnu*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ==============================
 
 
 ===========================
 xc-wb.host.prgenv-gnu
 Inherits 'xc-wb.prgenv-gnu'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===========================
 
 
 ===================
 *intel*
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 test assertion failures (2014-09-21..)
@@ -583,7 +571,7 @@ binary files differ (2014-09-21..)
 ================================
 xc-wb.intel
 Inherits 'xc-wb.*' and '*intel*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ================================
 
 factorization failed for non-positive semi-definite matrix (2015-03-12.., not attributed)
@@ -594,21 +582,21 @@ factorization failed for non-positive semi-definite matrix (2015-03-12.., not at
 ================================
 xc-wb.prgenv-intel
 Inherits 'xc-wb.*' and '*intel*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ================================
 
 
 =============================
 xc-wb.host.prgenv-intel
 Inherits 'xc-wb.prgenv-intel'
-Reviewed 2015-04-10
+Reviewed 2015-04-27
 =============================
 
 
 ====================
 *prgenv-cray*
 Also includes: xc.*.cray.*, xe.*.cray.*
-Reviewed 2015-04-10
+Reviewed 2015-04-27
 ====================
 
 === sporadic failures below ===
@@ -644,7 +632,7 @@ sporadic dropping/mangling of output
 xc-wb.prgenv-cray
 Inherits 'xc-wb.*' and '*prgenv-cray*'
 Also includes: xe-wb.prgenv-cray (not tested after 2015-03-05)
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ======================================
 
 :46: error: Text file busy in open with path "mandelbrot" -- Thomas owns
@@ -682,7 +670,7 @@ Execution timeout (2015-02-15 ..)
 ============================
 xc-wb.host.prgenv-cray
 Inherits 'xc-wb.prgenv-cray'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ============================
 
 === sporadic failures below ===
@@ -695,7 +683,7 @@ All tests fail to compile. (2015-02-15..2015-02-16, 2015-02-19, 2015-03-10, 2015
 ===================
 *pgi*
 Inherits 'general'
-Reviewed 2015-04-10
+Reviewed 2015-04-27
 ===================
 
 negative floating point 0.0 not supported
@@ -712,21 +700,21 @@ consistent execution timeout (no intrinsics for pgi, test is slow with locks)
 ==============================
 xc-wb.pgi
 Inherits 'xc-wb.*' and '*pgi*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ==============================
 
 
 ==============================
 xc-wb.prgenv-pgi
 Inherits 'xc-wb.*' and '*pgi*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ==============================
 
 
 ===========================
 xc-wb.host.prgenv-pgi
 Inherits 'xc-wb.prgenv-pgi'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===========================
 
 
@@ -738,7 +726,7 @@ Reviewed 2015-04-20
 ===================
 x?.*
 Inherits 'xc-wb.*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 === sporadic failures below ===
@@ -754,7 +742,7 @@ sporadic execution timeouts
 ===================
 xc.*
 Inherits 'x?.*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 knc configuration fails to build gasnet since 2015-04-25
@@ -787,7 +775,7 @@ sporadic timeout on tests that normally complete quickly
 ===================
 xe.*
 Inherits 'x?.*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
@@ -806,7 +794,7 @@ sporadic compilation timeouts - perhaps test-independent
 ===================
 xe.ugni*.*
 Inherits 'xe.*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 === sporadic failures below ===
@@ -824,7 +812,7 @@ sporadic execution timeouts
 ==========================================
 xc.knc
 Inherits 'xc.*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ==========================================
 
 Unclear how KNCs interact with the file system on Crays (since first run)
@@ -837,21 +825,11 @@ SIGBUS at execution time
 ------------------------
 [Error matching program output for release/examples/benchmarks/lulesh/lulesh (compopts: 1, execopts: 4)] (2015-04-10)
 
-sporadic execution timeouts
----------------------------
-[Error: Timed out executing program release/examples/hello2-module] (2015-03-27)
-[Error: Timed out executing program release/examples/hello3-datapar] (2015-03-27)
-[Error: Timed out executing program release/examples/hello4-datapar-dist] (2015-03-27)
-[Error: Timed out executing program release/examples/hello5-taskpar] (2015-03-27)
-[Error: Timed out executing program release/examples/hello6-taskpar-dist] (2015-03-27)
-[Error: Timed out executing program release/examples/hello] (2015-03-27)
-[Error: Timed out executing program release/examples/programs/beer] (2015-03-27)
-
 
 ==========================
 xc.llvm
 Inherits 'xc.*' and 'llvm'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ==========================
 
 <command line>:11:10: fatal error: 'fftw3.h' file not found (2015-03-19, tvandoren)
@@ -866,7 +844,7 @@ Reviewed 2015-04-20
 ===========================
 perf.xc.*
 Inherits 'perf*' and 'x?.*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===========================
 
 OOB array access when core counts are not a power of 2 (2015-03-04, 2015-04-17 ben)
@@ -887,14 +865,14 @@ sporadic timeout
 ================================
 perf.xc.local.gnu
 Inherits 'perf.xc.*' and '*gnu*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ================================
 
 
 ============================
 perf.xc.no-local.gnu
 Inherits 'perf.xc.local.gnu'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ============================
 
 consistent timeouts (2015-02-18)
@@ -914,7 +892,7 @@ Differing whitespace (vass)
 ===============================
 perf.xc.16.mpi.gnu
 Inherits 'perf.xc.no-local.gnu'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===============================
 
 consistent execution timeouts
@@ -926,7 +904,7 @@ consistent execution timeouts
 ===============================
 perf.xc.16.aries.gnu
 Inherits 'perf.xc.no-local.gnu'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===============================
 
 Consistent execution timeout
@@ -939,14 +917,14 @@ Consistent execution timeout
 ===============================
 perf.xc.16.ugni-qthreads.gnu
 Inherits 'perf.xc.no-local.gnu'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===============================
 
 
 ===============================
 perf.xc.16.ugni.gnu
 Inherits 'perf.xc.no-local.gnu'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===============================
 
 === sporadic failures below ===
@@ -954,14 +932,13 @@ Reviewed 2015-04-20
 sporadic execution timeout
 --------------------------
 [Error: Timed out executing program release/examples/benchmarks/hpcc/stream-ep] (2015-02-25..2015-02-28, 2015-03-12..)
-[Error: Timed out executing program release/examples/benchmarks/miniMD/miniMD    (compopts: 1)]              (2015-??-??..2015-03-17)
 [Error: Timed out executing program release/examples/benchmarks/ssca2/SSCA2_main (execopts: *)] (2015-03-22, 2015-03-25, 2015-03-31, 2015-04-04..2015-04-07, 2015-04-09, 2015-04-11..2015-04-15, 2015-04-19, 2015-04-22)
 
 
 ==================================
 perf.xc.local.intel
 Inherits 'perf.xc.*' and '*intel*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ==================================
 
 === sporadic failures below ===
@@ -974,7 +951,7 @@ sporadic output mismatch (lydia)
 ========================================
 perf.xc.local.cray
 Inherits 'perf.xc.*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ========================================
 
 cause is unknown (2015-03-20..)
@@ -986,14 +963,13 @@ cause is unknown (2015-03-20..)
 
 cause is unknown
 ----------------
-[Error matching performance keys for release/examples/benchmarks/hpcc/ptrans] (2015-03-20..2015-03-24)
 [Error matching performance keys for studies/shootout/fasta/kbrady/fasta-printf] (2015-04-22)
 
 
 ================================
 perf.xc.local.pgi
 Inherits 'perf.xc.*' and '*pgi*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ================================
 
 out of memory allocating array elements (2015-02-15..2015-02-20)
@@ -1016,14 +992,14 @@ cause is unknown
 ===================
 rhel.linux64
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
 ===================
 cygwin*
 Inherits 'general'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 check_channel assertion failure
@@ -1049,12 +1025,11 @@ sporadic execution timeout
                                                                                                                                           2015-03-10, 2015-03-12..2015-03-28, 2015-03-30..2015-04-04,
                                                                                                                                           2015-04-07..
                                                                                                                             cygwin32: ... 2015-03-11, 2015-03-13..2015-03-20, 2015-03-22..)
-[Error: Timed out executing program reductions/diten/testSerialReductions (compopts: 1)] (cygwin64: 2015-03-07..2015-03-12, 2015-03-22)
 
 ===========================
 cygwin32
 Inherits 'cygwin*' and '*32'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===========================
 
 "got == expect[i]" assertion error
@@ -1176,7 +1151,7 @@ sporadic generated output "FAILED" (see above for solid): First run 2014-12-07
 ================================
 cygwin64
 Inherits 'cygwin*' and 'linux64'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ================================
 
 QIO qio_err_to_int() == EEOF assertion error
@@ -1196,20 +1171,20 @@ Compiler errors in runtime/src/qio/sys.c  signed vs unsigned
 ===================
 dist-block
 Inherits 'gasnet*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
 ===================
 dist-cyclic
 Inherits 'gasnet*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 
 
 ===================
 dist-replicated
 Inherits 'gasnet*'
-Reviewed 2015-04-20
+Reviewed 2015-04-27
 ===================
 


### PR DESCRIPTION
- Mike fixed the ipe/powerOfTwo failure *32 failure
- We encountered a one-time bus error with users/vass/crash1callDestructorsMain
  I don't think it is related to the test specifically, but I noted it anyways,
  in case we run into again.
- Added more dates for the valgrind fannkuch error (competing for most obnoxious
  test!)
- Added dates to the sporadic gasnet.fifo failure with
  types/string/StringImpl/memLeaks/coforall.  Is this potentially a gasnet.fifo
  specific error now?
- Added a 2dBDtoDRTest gasnet.fifo date
- Added a white box execflags/bradc/gdbddash/gdbSetConfig date for pgi and
  end date for the intel setting.
- Added another ra-cleanloop date to the general hardware category
- Noted the xc build failure that Thomas pointed out.  Still need a volunteer
  to investigate and fix this.
- Noted the ra and SSCA2 additional dates.
- Added another colostate Jacobi diamond tiling failure (still the most
  obnoxious test!)

Triage sanity pass:
- Removed perf.bradc-lnx entry for io/vass/time-write as it hasn't turned up
  since March 18th
- Note that the shootout performance box may be dead (Elliot is having trouble
  reviving it)
- Remove entry for performance/sungeun/dgemm entry from valgrind, as we haven't
  seen it in exactly a month
- Added some information to the gasnet sporadic string memory leaks tests
- Removed the gasnet* entry for studies/madness/aniruddha/madchap/test_likepy
  as it hadn't been seen since mid-February
- Fixed some of the dates for the gdbSetConfig failures to match the last date
  we saw the failure rather than the date before we first saw it passed (those
  test runs are every other day, so this is more accurate)
- Removed an entry in xc.knc for a single sporadic timeout for all the hellos
  as it has been exactly a month since we saw it
- Removed the sporadic execution timeout for miniMD with perf.xc.16.ugni.gnu
- Removed an old xc.local.cray performance timeout
- Removed an old cygwin64 error