### PR TITLE
Stop converting c_string to string for generic extern funcs

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1444,9 +1444,10 @@ computeGenericSubs(SymbolMap &subs,
           // declarations with non-typed initializing expressions and
           // non-param formals with string literal default expressions
           // (see fix_def_expr() and hack_resolve_types() in
-          // normalize.cpp).
-          if ((formal->type == dtAny) && (!formal->hasFlag(FLAG_PARAM)) &&
-              (type == dtStringC) &&
+          // normalize.cpp). This conversion is not performed for extern
+          // functions.
+          if ((!fn->hasFlag(FLAG_EXTERN)) && (formal->type == dtAny) &&
+              (!formal->hasFlag(FLAG_PARAM)) && (type == dtStringC) &&
               (alignedActuals.v[i]->type == dtStringC) &&
               (alignedActuals.v[i]->isImmediate()))
             subs.put(formal, dtString->symbol);

--- a/test/extern/kbrady/extern_c_string_generic.chpl
+++ b/test/extern/kbrady/extern_c_string_generic.chpl
@@ -1,0 +1,6 @@
+extern proc printf(fmt, args...);
+
+// The string literals should be preserved as c_strings when being passed into
+// the generic args of printf because it is extern. If printf wasn't extern
+// they would be converted to string.
+printf("%s\n", "Hello, World!");

--- a/test/extern/kbrady/extern_c_string_generic.good
+++ b/test/extern/kbrady/extern_c_string_generic.good
@@ -1,0 +1,1 @@
+Hello, World!

--- a/test/extern/kbrady/extern_string_generic.chpl
+++ b/test/extern/kbrady/extern_string_generic.chpl
@@ -1,5 +1,6 @@
 extern proc printf(format: c_string, args ...);
-printf("%s", "test1\n");
-printf("%s", "test2\n");
-printf("%s", "test3\n");
-printf("%s", "test4\n");
+var s:string = "test\n";
+printf("%s", s);
+printf("%s", s);
+printf("%s", s);
+printf("%s", s);

--- a/test/extern/kbrady/extern_string_generic.good
+++ b/test/extern/kbrady/extern_string_generic.good
@@ -1,6 +1,6 @@
 extern_string_generic.chpl:1: error: extern procedure has arguments of type string
-extern_string_generic.chpl:2: note: when instantiated from here
 extern_string_generic.chpl:3: note: when instantiated from here
 extern_string_generic.chpl:4: note: when instantiated from here
 extern_string_generic.chpl:5: note: when instantiated from here
+extern_string_generic.chpl:6: note: when instantiated from here
 extern_string_generic.chpl:1: note: use c_string instead

--- a/test/memory/bradc/allocBig.chpl
+++ b/test/memory/bradc/allocBig.chpl
@@ -1,3 +1,3 @@
 extern proc chpl_mem_allocMany(number, size, description, lineno, filename);
 
-chpl_mem_allocMany(max(int(32)), max(int(32)), 0, 3, "allocBig.chpl":c_string);
+chpl_mem_allocMany(max(int(32)), max(int(32)), 0, 3, "allocBig.chpl");


### PR DESCRIPTION
When a function gets passed a c_string to a generic argument, it is
implicitly converted into a string. We don't want to do this for extern
functions.