### PR TITLE
Add .suppressif feature for testing

### DIFF
--- a/test/io/ferguson/writef_readf.suppressif
+++ b/test/io/ferguson/writef_readf.suppressif
@@ -1,0 +1,3 @@
+# intel compiler bug jira 33
+CHPL_TARGET_COMPILER==intel
+CHPL_TARGET_COMPILER==cray-prgenv-intel

--- a/test/io/ferguson/writefbinary.suppressif
+++ b/test/io/ferguson/writefbinary.suppressif
@@ -1,0 +1,3 @@
+# intel compiler bug jira 34
+CHPL_TARGET_COMPILER==intel
+CHPL_TARGET_COMPILER==cray-prgenv-intel

--- a/util/cron/nightly_email.pl
+++ b/util/cron/nightly_email.pl
@@ -80,17 +80,20 @@ if ($status == 0) {
 # send mail
 #
 $futuremarker = "^Future";
+$suppressmarker = "^Suppress";
 
 $newfailures = "???";
 if ($status == 0) {
-    $newfailures = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | wc -l`; chomp($newfailures);
-    $newresolved = `LC_ALL=C comm -23 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | wc -l`; chomp($newresolved);
+    $newfailures = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | grep -v "$suppressmarker" | wc -l`; chomp($newfailures);
+    $newresolved = `LC_ALL=C comm -23 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | grep -v "$suppressmarker" | wc -l`; chomp($newresolved);
     $newpassingfutures = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Success" | wc -l`; chomp($newpassingfutures);
     $passingfutures = `grep "$futuremarker" $sortedsummary | grep "\\[Success" | wc -l`; chomp($passingfutures);
+    $newpassingsuppress = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$suppressmarker" | grep "\\[Success" | wc -l`; chomp($newpassingsuppresss);
+    $passingsuppresss = `grep "$suppressmarker" $sortedsummary | grep "\\[Success" | wc -l`; chomp($passingsuppresss);
     $newfailures += 0;
 }
 
-if ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0) {
+if ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpassingsuppress == 0) {
     print "Mailing to minimal group\n";
     $recipient = $nochangerecipient;
 } else {
@@ -110,28 +113,36 @@ print MAIL endMailHeader();
 
 if ($status == 0) {
     print MAIL "--- New Errors -------------------------------\n";
-    print MAIL `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker"`;
+    print MAIL `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | grep -v "$suppressmarker"`;
     print MAIL "\n";
 
     print MAIL "--- Resolved Errors --------------------------\n";
-    print MAIL `LC_ALL=C comm -23 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker"`;
+    print MAIL `LC_ALL=C comm -23 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | grep -v "$suppressmarker"`;
     print MAIL "\n";
     
     print MAIL "--- New Passing Future tests------------------\n";
     print MAIL `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Success"`;
-    print MAIL "\n";    
+    print MAIL "\n";
 
     print MAIL "--- Passing Future tests ---------------------\n";
     print MAIL `LC_ALL=C comm -12 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Success"`;
-    print MAIL "\n";    
+    print MAIL "\n";
+
+    print MAIL "--- New Passing Suppress tests------------------\n";
+    print MAIL `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$suppressmarker" | grep "\\[Success"`;
+    print MAIL "\n";
+
+    print MAIL "--- Passing Suppress tests ---------------------\n";
+    print MAIL `LC_ALL=C comm -12 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$suppressmarker" | grep "\\[Success"`;
+    print MAIL "\n";
 
     print MAIL "--- Unresolved Errors ------------------------\n";
-    print MAIL `LC_ALL=C comm -12 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker"`;
+    print MAIL `LC_ALL=C comm -12 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | grep -v "$suppressmarker"`;
     print MAIL "\n";
 
     print MAIL "--- New Failing Future tests -----------------\n";
     print MAIL `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Error"`;
-    print MAIL "\n";    
+    print MAIL "\n";
 
     print MAIL "--- Unresolved Future tests ------------------\n";
     print MAIL `LC_ALL=C comm -12 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Error"`;

--- a/util/start_test
+++ b/util/start_test
@@ -1881,6 +1881,7 @@ echo " " |& $tee -a $logfile
 
 # Output grep to a temp file, don't want to infinite loop
 set futuremarker = "^Future"
+set suppressmarker = "^Suppress"
 set errormarker = "^\[Error"
 set warningmarker = "^\[Warning"
 if ($performance == 0 && $gengraphs) then
@@ -1902,6 +1903,7 @@ if ($clean_only == 0) then
     endif
     grep "$errormarker" $logfile.summary
 
+    grep "$suppressmarker" $logfile |& $tee -a $logfile.summary
     grep "$futuremarker" $logfile |& $tee -a $logfile.summary
     grep "$warningmarker" $logfile |& $tee -a $logfile.summary
 

--- a/util/start_test
+++ b/util/start_test
@@ -441,6 +441,15 @@
 # is not updated, it will fail forever with "Syntax Error" and never
 # pass.
 #
+# .suppressif files work like a combination of .skipif and .future.
+# The .suppressif file is meant to indicate that a test fails in
+# some configurations for reasons outside of the control of the Chapel
+# compiler.
+# The first line of a .suppressif should be a comment (starting with #)
+# describing the issue. The rest of the file should indicate the
+# configuration in which the error is to be suppressed. A .bad
+# file can be provided.
+#
 # If the test-writer wants to redirect standard input from a file,
 # they may do so by supplying a .stdin file with the same base
 # name as the test itself (e.g., if mytest.stdin exists, it will

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -108,6 +108,7 @@
 # .ifuture: Future test
 # .noexec: Do not execute this test
 # .skipif: Skip this test if certain environment conditions hold true
+# .suppressif: Suppress this test if certain environment conditions hold true
 # .timeout: Test timeout (overrides TIMEOUT)
 # .perftimeout: Performance test timeout
 # .killtimeout: Kill timeout (overrides KILLTIMEOUT)
@@ -1031,6 +1032,26 @@ for testname in testsrc:
                 do_not_test=True
             if do_not_test:
                 break
+
+        elif (suffix=='.suppressif' and (os.access(f, os.R_OK))):
+            testskipiffile=True
+            skiptest=runSkipIf(f)
+            try:
+                skipme=False
+                if skiptest.strip() != "False":
+                    skipme = skiptest.strip() == "True" or int(skiptest) == 1
+                if skipme:
+                    suppressfile = open('./'+test_filename+'.suppressif', 'r')
+                    suppressline = suppressfile.readline().strip();
+                    suppressfile.close()
+                    if suppressline.startswith("#"):
+                      suppressline = suppressline.replace("#","");
+                    else:
+                      suppressline = ""
+                    suppressline = suppressline.strip()
+                    futuretest='Suppress (' + suppressline + ') '
+            except ValueError:
+                sys.stdout.write('[Error processing .suppressif file %s/%s]\n'%(localdir,f))
 
         elif (suffix==timeoutsuffix and os.access(f, os.R_OK)):
             timeout=ReadIntegerValue(f, localdir)

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1040,7 +1040,7 @@ for testname in testsrc:
                     suppressme = suppresstest.strip() == "True" or int(suppresstest) == 1
                 if suppressme:
                     with open('./'+test_filename+'.suppressif', 'r') as suppressfile:
-                        suppressline = suppressfile.readline().strip();
+                        suppressline = suppressfile.readline().strip()
                     if suppressline.startswith("#"):
                       suppressline = suppressline.replace("#","");
                     else:

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -243,9 +243,8 @@ def PerfTFile(test_filename, sfx):
 # read file with comments
 def ReadFileWithComments(f, ignoreLeadingSpace=True):
     # sys.stdout.write('Opening: %s\n'%(f))
-    myfile = open(f, 'r')
-    mylines = myfile.readlines()
-    myfile.close()
+    with open(f, 'r') as myfile:
+      mylines = myfile.readlines()
     mylist=list()
     for line in mylines:
         line = line.rstrip()
@@ -1034,16 +1033,14 @@ for testname in testsrc:
                 break
 
         elif (suffix=='.suppressif' and (os.access(f, os.R_OK))):
-            testskipiffile=True
-            skiptest=runSkipIf(f)
+            suppresstest=runSkipIf(f)
             try:
-                skipme=False
-                if skiptest.strip() != "False":
-                    skipme = skiptest.strip() == "True" or int(skiptest) == 1
-                if skipme:
-                    suppressfile = open('./'+test_filename+'.suppressif', 'r')
-                    suppressline = suppressfile.readline().strip();
-                    suppressfile.close()
+                suppressme=False
+                if suppresstest.strip() != "False":
+                    suppressme = suppresstest.strip() == "True" or int(suppresstest) == 1
+                if suppressme:
+                    with open('./'+test_filename+'.suppressif', 'r') as suppressfile:
+                        suppressline = suppressfile.readline().strip();
                     if suppressline.startswith("#"):
                       suppressline = suppressline.replace("#","");
                     else:
@@ -1084,9 +1081,8 @@ for testname in testsrc:
             numlocales=ReadIntegerValue(f, localdir)
 
         elif suffix==futureSuffix and os.access(f, os.R_OK):
-            futurefile = open('./'+test_filename+futureSuffix, 'r')
-            futuretest='Future ('+futurefile.readline().strip()+') '
-            futurefile.close()
+            with open('./'+test_filename+futureSuffix, 'r') as futurefile:
+                futuretest='Future ('+futurefile.readline().strip()+') '
 
         elif (suffix=='.noexec' and os.access(f, os.R_OK)):
             noexecfile=True


### PR DESCRIPTION
.suppressif files work like a combination of .skipif and .future.
The .suppressif file is meant to indicate that a test fails in
some configurations for reasons outside of the control of the Chapel
compiler.
The first line of a .suppressif should be a comment (starting with #)
describing the issue. The rest of the file should indicate the
configuration in which the error is to be suppressed. A .bad
file can be provided.

I've verified that it prints out Suppress (description) [Error ...] or [Success ..]
as expected.