### PR TITLE
Add config const to allow not printing error when under threshold for fft

### DIFF
--- a/test/studies/hpcc/FFT/marybeth/fft.chpl
+++ b/test/studies/hpcc/FFT/marybeth/fft.chpl
@@ -16,6 +16,7 @@ config const epsilon = 2.0 ** -51.0,
 
 // boolean configs
 config const printTiming = true;
+config const printError = true;
 
 proc main() {
   // compute problem size
@@ -162,8 +163,14 @@ proc verifyResults(z, Z, execTime, Twiddles) {
 
   maxerr = maxerr / logN / epsilon;
 
-  write(if (maxerr < threshold) then "SUCCESS" else "FAILURE");
-  writeln(", error = ", maxerr);
+  if maxerr < threshold {
+    write("SUCCESS");
+    if printError then writeln(", error = ", maxerr);
+    else writeln();
+  } else {
+    write("FAILURE");
+    writeln(", error = ", maxerr);
+  }
   writeln();
   writeln("N      = ", N);
   if (printTiming) {

--- a/test/studies/hpcc/FFT/marybeth/fft.execopts
+++ b/test/studies/hpcc/FFT/marybeth/fft.execopts
@@ -1,2 +1,2 @@
--sprintTiming=false -sdeterministic=true
+-sprintTiming=false -sdeterministic=true -sprintError=false
 

--- a/test/studies/hpcc/FFT/marybeth/fft.good
+++ b/test/studies/hpcc/FFT/marybeth/fft.good
@@ -1,3 +1,3 @@
-SUCCESS, error = 0.05
+SUCCESS
 
 N      = 32


### PR DESCRIPTION
This test is getting a slightly different error amount for prgenv-cray than
for other configurations.  It is still well under the acceptable threshold,
so add an option to not print it unless it is above the threshold.