### PR TITLE
Skip gdbSetConfig.chpl on the whitebox testing for XC

### DIFF
--- a/test/execflags/bradc/gdbddash/gdbSetConfig.skipif
+++ b/test/execflags/bradc/gdbddash/gdbSetConfig.skipif
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import os, os.path
+
+# Our whitebox testing encountered an hang with this test when run which
+# CHPL_TARGET_PLATFORM=cray-xc, CHPL_TASKS=qthreads, and various target
+# compilers.  As we are unable to reproduce the error on an actual XC box,
+# it is assumed that the problem is related to some portion of the whitebox
+# installation and thus nothing to worry about.  To squash the noise, we will
+# avoid running it there.
+if os.getenv('CHPL_TARGET_PLATFORM') == 'cray-xc':
+    if not os.path.exists('/etc/opt/cray/release') or not os.path.exists('/etc/opt/cray/release/CLEinfo'):
+        print(True)
+    else:
+        print(False)
+else:
+    print(False)


### PR DESCRIPTION
We had been experiencing sporadic hangs with this test, which consists of a
single writeln of a config variable and then runs with the --gdb flag during
whitebox testing of our XC TARGET builds (and infrequently our TARGET-noPrgEnv
builds).  The hang occurred during program shutdown once the test program had
actually completed, and disappeared when the tasking layer was switched to
fifo or when we switched to the same builds aimed at an XE.  The problem also
disappeared when run on a proper XC machine.  With this information in mind,
it seems likely that the problem is specific to our whitebox installation and
not an actual issue - so the solution is to skip the test for these
configurations.