### PR TITLE
Added instrumentation for time-write.chpl failures.

### DIFF
--- a/test/io/vass/time-write.prediff
+++ b/test/io/vass/time-write.prediff
@@ -1,3 +1,10 @@
 #!/bin/sh
 
 sed '/^$/d' $2 > $2.tmp && mv $2.tmp $2
+if grep -q '^starting try $' $2; then
+  echo $0: found incorrect output, saving the executables
+  echo + cd $PWD
+  set -x
+  mv time-write time-write.SAVED
+  mv time-write_real time-write.SAVED_real
+fi


### PR DESCRIPTION
I have not found a way to reproduce the failure that has reliably happened in perf.xc.no-local.gnu.

This change saves away the compiled executables of time-write so I can try them later.
