### PR TITLE
Add a suppressif for rotl for C compiler bug

### DIFF
--- a/test/modules/standard/BitOps/rotl.suppressif
+++ b/test/modules/standard/BitOps/rotl.suppressif
@@ -1,0 +1,2 @@
+# cray compiler bug jira 28
+CHPL_TARGET_COMPILER==cray-prgenv-cray


### PR DESCRIPTION
This test fails on cray-prgenv-cray due to a C compiler bug.