### PR TITLE
Resolve time-write.chpl regression (jira issue 25)

### DIFF
--- a/test/io/vass/time-write.chpl
+++ b/test/io/vass/time-write.chpl
@@ -136,6 +136,8 @@ stderr.writef("tries  %i\n", tries);
 
 for t in 1..tries {
   stderr.writef("starting try %i\n", t);
+  stderr.flush();
+
   addTime(tDummy);
 
   cf_trial(n);   addTime(tcf);
@@ -147,6 +149,9 @@ for t in 1..tries {
 
   nb_trial();     addTime(tnb);
   sto_trial();   addTime(tsto);
+
+  // flush any buffered newlines
+  stdout.flush();
 }
 
 stderr.writef("done tries\n");


### PR DESCRIPTION
io/vass/time-write fails with --no-local performance testing. The stdout and
stderr streams are getting intermixed resulting in a verification failure.

This test writes a LOT of newlines to stdout and some info to stderr. The stuff
printed to stderr is part of the performance verification but some newlines
from stdout are getting intermixed so the verification fails. This isn't a real
issue but related to how slurm does stdout and stderr buffering. For srun
(interactive) line buffering occurs so we don't run into this, but with sbatch
only stdout is buffered so we run into this problem.

To solve this issue, this patch just adds some stdout and stderr flushes which
seems to have resolved the issue. I ran 20 trials and it seemed to go well
(normally the test fails within a trial or 2.) If we still get failures we can
update the verification to not look for the "starting trial x" stuff or we can
switch the test to put all output to stdout instead of stderr.

It's possible that we could run into this issue for any test that writes to
stderr and stdout and expects output in the right order, but I highly doubt we
will run into this with any other tests. This test rights some 30 million
newlines and heavily taxes the io buffering system, especially since the
hardware we're running on has limited io nodes.