### PR TITLE
Don't use the option -hipa2 for CCE backend compiler

### DIFF
--- a/make/compiler/Makefile.cray-prgenv-cray
+++ b/make/compiler/Makefile.cray-prgenv-cray
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Suppress warning about variables used before defined
-CRAYPE_GEN_CFLAGS = -hnomessage=7212 -hipa2
+CRAYPE_GEN_CFLAGS = -hnomessage=7212
 
 NO_IEEE_FLOAT_GEN_CFLAGS = -hfp1
 IEEE_FLOAT_GEN_CFLAGS = -hfp0


### PR DESCRIPTION
The -hipa2 option was originally added to limit the amount of inlining done
by the backend compiler when we used CCE's default optimization level (-O2)
by default.

Now that we use -O0 by default for CCE, -hipa2 actually dramatically
increases the amount of inlining done vs. not using the option.  Remove
-hipa2 from make/compiler/Makefile.cray-prgenv-cray.