### PR TITLE
Resolve ra-atomics pgi performance regression (part of jira issue 19)

### DIFF
--- a/test/release/examples/benchmarks/hpcc/ra-atomics.skipif
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.skipif
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+# This test creates a large array of atomics designed to use ~1/4 of available
+# memory. However, that calculation is done based off the size of the raw type,
+# not the atomic type. When CHPL_ATOMICS=intrinsics, the size of the atomic is
+# the same as the raw type. Unfortunately when CHPL_ATOMICS=locks, atomics are
+# implemented as a struct that contains the raw type and a sync var. Under
+# qthreads each syncvar is currently ~40 bytes which which means we run out of
+# memory since we're using ~6x ~1/4 of available memory. It's even worse under
+# fifo where each syncvar is ~170 bytes.
+
+import os
+print(os.getenv('CHPL_TEST_PERF') == 'on' and 
+      os.getenv('CHPL_ATOMICS') == 'locks')


### PR DESCRIPTION
Skip this test if we're doing a performance test and CHPL_ATOMICS=locks

This test creates a large array of atomics designed to use ~1/4 of available
memory. However, that calculation is done based off the size of the raw type,
not the atomic type. When CHPL_ATOMICS=intrinsics, the size of the atomic is
the same as the raw type. Unfortunately when CHPL_ATOMICS=locks, atomics are
implemented as a struct that contains the raw type and a sync var. Under
qthreads each syncvar is currently ~40 bytes which which means we run out of
memory since we're using ~6x ~1/4 of available memory. It's even worse under
fifo where each syncvar is ~170 bytes.