### PR TITLE
Skip parSafeMember if CHPL_ATOMICS != intrinsics

### DIFF
--- a/test/domains/sungeun/assoc/parSafeMember.skipif
+++ b/test/domains/sungeun/assoc/parSafeMember.skipif
@@ -3,3 +3,4 @@
 # stress test meant to ensure no race conditions. This isn't a very elegant
 # solution, but if we stop using this machine, this skipif can be removed.
 HOSTNAME==cflbs32
+CHPL_ATOMICS!=intrinsics


### PR DESCRIPTION
As a stress test, this program takes quite a while to run. When CHPL_ATOMICS is not set to intrinsics it takes much, much longer. This patch adds this case to the skipif for this test.