### PR TITLE
Provide for not tracking certain internal memory descriptor types.

### DIFF
--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -20,6 +20,8 @@
 #ifndef _chpl_mem_desc_H_
 #define _chpl_mem_desc_H_
 
+#include "chpltypes.h"
+
 //
 // When defining a new allocation type (for new instances of
 // chpl_mem_allocMany or chpl_mem_realloc in the runtime), add an
@@ -39,109 +41,93 @@
 // of them separately to define the things we need.
 //
 
-#define CHPL_MD_ALL_MEMDESCS(m)                                         \
-        m(UNKNOWN = 0,                                                  \
-          "unknown"),                                                   \
-        m(EXECUTION_COMMAND,                                            \
-          "chapel execution command buffer"),                           \
-        m(ARRAY_ELEMENTS,                                               \
-          "array elements"),                                            \
-        m(SET_WIDE_STRING,                                              \
-          "set wide string"),                                           \
-        m(GET_WIDE_STRING,                                              \
-          "get wide string"),                                           \
-        m(COMMAND_BUFFER,                                               \
-          "command buffer"),                                            \
-        m(COMM_XMIT_RECV_BUF,                                           \
-          "comm layer transmit/receive buffer"),                        \
-        m(COMM_XMIT_RECV_STATUS,                                        \
-          "comm layer transmit/receive status"),                        \
-        m(COMM_FORK_SEND_INFO,                                          \
-          "comm layer sent remote fork info"),                          \
-        m(COMM_FORK_SEND_NB_INFO,                                       \
-          "comm layer sent non-blocking remote fork info"),             \
-        m(COMM_FORK_SEND_LARGE_ARG,                                     \
-          "comm layer sent remote fork large fncall arg"),              \
-        m(COMM_FORK_SEND_NB_LARGE_ARG,                                  \
-          "comm layer sent non-blocking remote fork large fncall arg"), \
-        m(COMM_FORK_SEND_RESPONSE_DATA,                                 \
-          "comm layer sent remote fork response data"),                 \
-        m(COMM_FORK_RECV_INFO,                                          \
-          "comm layer received remote fork info"),                      \
-        m(COMM_FORK_RECV_LARGE_INFO,                                    \
-          "comm layer received remote fork large info"),                \
-        m(COMM_FORK_RECV_NB_INFO,                                       \
-          "comm layer received non-blocking remote fork info"),         \
-        m(COMM_FORK_RECV_NB_LARGE_INFO,                                 \
-          "comm layer received non-blocking remote fork large info"),   \
-        m(COMM_FORK_RECV_LARGE_ARG,                                     \
-          "comm layer received remote fork large fncall arg"),          \
-        m(COMM_FORK_RECV_NB_LARGE_ARG,                                  \
-          "comm layer received non-blocking remote fork large fncall arg "),\
-        m(COMM_FORK_DONE_FLAG,                                          \
-          "comm layer remote fork done flag(s)"),                       \
-        m(COMM_PER_LOCALE_INFO,                                         \
-          "comm layer per-locale information"),                         \
-        m(COMM_PRIVATE_OBJECTS_ARRAY,                                   \
-          "comm layer private objects array"),                          \
-        m(COMM_PRIVATE_BROADCAST_DATA,                                  \
-          "comm layer private broadcast data"),                         \
-        m(GLOM_STRINGS_DATA,                                            \
-          "glom strings data"),                                         \
-        m(STRING_COPY_DATA,                                             \
-          "string copy data"),                                          \
-        m(STRING_COPY_REMOTE,                                           \
-          "remote string copy"),                                        \
-        m(STRING_CONCAT_DATA,                                           \
-          "string concat data"),                                        \
-        m(STRING_MOVE_DATA,                                             \
-          "string move data"),                                          \
-        m(STRING_SELECT_DATA,                                           \
-          "string select data"),                                        \
-        m(CONFIG_ARG_COPY_DATA,                                         \
-          "config arg copy data"),                                      \
-        m(CONFIG_TABLE_DATA,                                            \
-          "config table data"),                                         \
-        m(LOCALE_NAME_BUFFER,                                           \
-          "locale name buffer"),                                        \
-        m(TASK_DESCRIPTOR,                                              \
-          "task descriptor"),                                           \
-        m(TASK_DESCRIPTOR_LINK,                                         \
-          "task descriptor link"),                                      \
-        m(TASK_STACK,                                                   \
-          "task stack"),                                                \
-        m(MUTEX,                                                        \
-          "mutex"),                                                     \
-        m(LOCK_REPORT_DATA,                                             \
-          "lock report data"),                                          \
-        m(TASK_POOL_DESCRIPTOR,                                         \
-          "task pool descriptor"),                                      \
-        m(TASK_LIST_DESCRIPTOR,                                         \
-          "task list descriptor"),                                      \
-        m(THREAD_PRIVATE_DATA,                                          \
-          "thread private data"),                                       \
-        m(THREAD_LIST_DESCRIPTOR,                                       \
-          "thread list descriptor"),                                    \
-        m(IO_BUFFER,                                                    \
-          "io buffer or bytes"),                                        \
-        m(OS_LAYER_TMP_DATA,                                            \
-          "OS layer temporary data"),                                   \
-        m(GMP,                                                          \
-          "gmp data"),                                                  \
-        m(GETS_PUTS_STRIDES,                                            \
-          "put_strd/get_strd array of strides"),                        \
-        m(GETS_PUTS_COUNTS,                                             \
-          "put_strd/get_strd array of count"),                          \
-        m(NUM, "")                      // this must be the last entry
+#define CHPL_MD_ALL_MEMDESCS(m)                                               \
+        m(UNKNOWN = 0,          "unknown",                                    \
+                                true),                                        \
+        m(EXECUTION_COMMAND,    "chapel execution command buffer",            \
+                                true),                                        \
+        m(ARRAY_ELEMENTS,       "array elements",                             \
+                                true),                                        \
+        m(SET_WIDE_STRING,      "set wide string",                            \
+                                true),                                        \
+        m(GET_WIDE_STRING,      "get wide string",                            \
+                                true),                                        \
+        m(COMMAND_BUFFER,       "command buffer",                             \
+                                true),                                        \
+        m(COMM_XMIT_RCV_BUF,    "comm layer transmit/receive buffer",         \
+                                true),                                        \
+        m(COMM_FRK_SND_INFO,    "comm layer sent remote fork info",           \
+                                true),                                        \
+        m(COMM_FRK_SND_ARG,     "comm layer sent remote fork arg",            \
+                                true),                                        \
+        m(COMM_FRK_RCV_INFO,    "comm layer received remote fork info",       \
+                                true),                                        \
+        m(COMM_FRK_RCV_ARG,     "comm layer received remote fork arg",        \
+                                true),                                        \
+        m(COMM_FRK_DONE_FLAG,   "comm layer remote fork done flag(s)",        \
+                                true),                                        \
+        m(COMM_PER_LOC_INFO,    "comm layer per-locale information",          \
+                                true),                                        \
+        m(COMM_PRV_OBJ_ARRAY,   "comm layer private objects array",           \
+                                true),                                        \
+        m(COMM_PRV_BCAST_DATA,  "comm layer private broadcast data",          \
+                                true),                                        \
+        m(GLOM_STRINGS_DATA,    "glom strings data",                          \
+                                true),                                        \
+        m(STR_COPY_DATA,        "string copy data",                           \
+                                true),                                        \
+        m(STR_COPY_REMOTE,      "remote string copy",                         \
+                                true),                                        \
+        m(STR_CONCAT_DATA,      "string concat data",                         \
+                                true),                                        \
+        m(STR_MOVE_DATA,        "string move data",                           \
+                                true),                                        \
+        m(STR_SELECT_DATA,      "string select data",                         \
+                                true),                                        \
+        m(CFG_ARG_COPY_DATA,    "config arg copy data",                       \
+                                true),                                        \
+        m(CF_TABLE_DATA,        "config table data",                          \
+                                true),                                        \
+        m(LOCALE_NAME_BUF,      "locale name buffer",                         \
+                                true),                                        \
+        m(TASK_DESC,            "task descriptor",                            \
+                                true),                                        \
+        m(TASK_DESC_LINK,       "task descriptor link",                       \
+                                true),                                        \
+        m(TASK_STACK,           "task stack",                                 \
+                                true),                                        \
+        m(MUTEX,                "mutex",                                      \
+                                true),                                        \
+        m(LOCK_REPORT_DATA,     "lock report data",                           \
+                                true),                                        \
+        m(TASK_POOL_DESC,       "task pool descriptor",                       \
+                                true),                                        \
+        m(TASK_LIST_DESC,       "task list descriptor",                       \
+                                true),                                        \
+        m(THREAD_PRV_DATA,      "thread private data",                        \
+                                true),                                        \
+        m(THREAD_LIST_DESC,     "thread list descriptor",                     \
+                                true),                                        \
+        m(IO_BUFFER,            "io buffer or bytes",                         \
+                                true),                                        \
+        m(OS_LAYER_TMP_DATA,    "OS layer temporary data",                    \
+                                true),                                        \
+        m(GMP,                  "gmp data",                                   \
+                                true),                                        \
+        m(GETS_PUTS_STRIDES,    "put_strd/get_strd array of strides",         \
+                                true),                                        \
+        m(NUM, "", true) // this must be the last entry
 
 
 //
 // Define the numeration constants for the memory descriptors.
 //
-#define CHPL_MEMDESC_ENUM(md_name, md_desc)  CHPL_RT_MD_ ## md_name
+#define CHPL_MEMDESC_MACRO(_enum, _str, _track)  CHPL_RT_MD_ ## _enum
 typedef enum {
-  CHPL_MD_ALL_MEMDESCS(CHPL_MEMDESC_ENUM)
+  CHPL_MD_ALL_MEMDESCS(CHPL_MEMDESC_MACRO)
 } chpl_mem_rtMemDesc_t;
+
+#undef CHPL_MEMDESC_MACRO
 
 
 //
@@ -159,6 +145,7 @@ typedef int16_t chpl_mem_descInt_t;
 
 
 const char* chpl_mem_descString(chpl_mem_descInt_t mdi);
+chpl_bool chpl_mem_descTrack(chpl_mem_descInt_t mdi);
 
 #endif
 

--- a/runtime/include/chplsys.h
+++ b/runtime/include/chplsys.h
@@ -36,4 +36,9 @@ int chpl_getNumLogicalCpus(chpl_bool accessible_only);
 //
 c_string chpl_nodeName(void);
 
+//
+// Returns the value of a CHPL_RT_* environment variable, with default.
+//
+chpl_bool chpl_env_getBool(const char*, chpl_bool);
+
 #endif

--- a/runtime/src/chpl-mem-desc.c
+++ b/runtime/src/chpl-mem-desc.c
@@ -34,16 +34,29 @@
 
 
 //
-// Define the description strings for the memory descriptors.
+// Define the description strings and track indicators for the memory
+// descriptors.
 //
-#define CHPL_MEMDESC_DESC(md_name, md_desc)  md_desc
-static const char* rt_memDescs[] = {
-  CHPL_MD_ALL_MEMDESCS(CHPL_MEMDESC_DESC)
+#define CHPL_MEMDESC_MACRO(_enum, _str, _track)  { _str, _track }
+static struct {
+  const char* string;
+  chpl_bool track;
+} rt_md[] = {
+  CHPL_MD_ALL_MEMDESCS(CHPL_MEMDESC_MACRO)
 };
+
+#undef CHPL_MEMDESC_MACRO
+
 
 const char* chpl_mem_descString(chpl_mem_descInt_t mdi) {
   if (mdi < CHPL_RT_MD_NUM)
-    return rt_memDescs[mdi];
-  else
-    return chpl_mem_descs[mdi-CHPL_RT_MD_NUM];
+    return rt_md[mdi].string;
+  return chpl_mem_descs[mdi-CHPL_RT_MD_NUM];
+}
+
+
+chpl_bool chpl_mem_descTrack(chpl_mem_descInt_t mdi) {
+  if (mdi < CHPL_RT_MD_NUM)
+    return rt_md[mdi].track;
+  return true;
 }

--- a/runtime/src/chpl-privatization.c
+++ b/runtime/src/chpl-privatization.c
@@ -42,12 +42,12 @@ void chpl_newPrivatizedClass(void* v, int64_t pid) {
   if (pid == 1) {
     chpl_capPrivateObjects = 8;
     // "private" means "node-private", so we can use the system allocator.
-    chpl_privateObjects = chpl_mem_allocMany(chpl_capPrivateObjects, sizeof(void*), CHPL_RT_MD_COMM_PRIVATE_OBJECTS_ARRAY, 0, "");
+    chpl_privateObjects = chpl_mem_allocMany(chpl_capPrivateObjects, sizeof(void*), CHPL_RT_MD_COMM_PRV_OBJ_ARRAY, 0, "");
   } else {
     if (pid > chpl_capPrivateObjects) {
       void** tmp;
       chpl_capPrivateObjects *= 2;
-      tmp = chpl_mem_allocMany(chpl_capPrivateObjects, sizeof(void*), CHPL_RT_MD_COMM_PRIVATE_OBJECTS_ARRAY, 0, "");
+      tmp = chpl_mem_allocMany(chpl_capPrivateObjects, sizeof(void*), CHPL_RT_MD_COMM_PRV_OBJ_ARRAY, 0, "");
       chpl_memcpy((void*)tmp, (void*)chpl_privateObjects, (pid-1)*sizeof(void*));
       chpl_privateObjects = tmp;
       // purposely leak old copies of chpl_privateObject to avoid the need to

--- a/runtime/src/chpl-string-support.c
+++ b/runtime/src/chpl-string-support.c
@@ -102,7 +102,7 @@ string_copy(c_string x, int32_t lineno, c_string filename)
   if (x == NULL)
     return NULL;
 
-  z = (char*)chpltypes_malloc(strlen(x)+1, CHPL_RT_MD_STRING_COPY_DATA,
+  z = (char*)chpltypes_malloc(strlen(x)+1, CHPL_RT_MD_STR_COPY_DATA,
                               lineno, filename);
   return strcpy(z, x);
 }
@@ -123,7 +123,7 @@ string_concat(c_string x, c_string y, int32_t lineno, c_string filename) {
   ylen = strlen(y);
 
   z = (char*)chpltypes_malloc(xlen + ylen + 1,
-                              CHPL_RT_MD_STRING_CONCAT_DATA,
+                              CHPL_RT_MD_STR_CONCAT_DATA,
                               lineno, filename);
 
   // memcpy can be more efficient than the str??? functions because it does not
@@ -159,7 +159,7 @@ string_select(c_string x, int low, int high, int stride, int32_t lineno, c_strin
   if (high < low) return NULL;
 
   size = high - low + 1;
-  result = chpltypes_malloc(size + 1, CHPL_RT_MD_STRING_SELECT_DATA,
+  result = chpltypes_malloc(size + 1, CHPL_RT_MD_STR_SELECT_DATA,
                             lineno, filename);
   src = stride > 0 ? x + low - 1 : x + high - 1;
   dst = result;
@@ -191,7 +191,7 @@ string_index(c_string x, int i, int32_t lineno, c_string filename) {
   {
     return NULL;
   }
-  buffer = chpltypes_malloc(2, CHPL_RT_MD_STRING_COPY_DATA,
+  buffer = chpltypes_malloc(2, CHPL_RT_MD_STR_COPY_DATA,
                             lineno, filename);
   sprintf(buffer, "%c", x[i-1]);
   return buffer;

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -130,7 +130,7 @@ void string_from_c_string(chpl_string *ret, c_string str, int haslen, int64_t le
   }
   if( ! haslen ) len = strlen(str);
 
-  s = (char*)chpl_mem_alloc(len+1, CHPL_RT_MD_STRING_COPY_DATA,
+  s = (char*)chpl_mem_alloc(len+1, CHPL_RT_MD_STR_COPY_DATA,
                               lineno, filename);
   chpl_memcpy(s, str, len);
   s[len] = '\0';
@@ -161,7 +161,7 @@ void wide_string_from_c_string(chpl____wide_chpl_string *ret, c_string str, int 
   }
   if( ! haslen ) len = strlen(str);
 
-  s = chpl_mem_alloc(len+1, CHPL_RT_MD_STRING_COPY_DATA, lineno, filename);
+  s = chpl_mem_alloc(len+1, CHPL_RT_MD_STR_COPY_DATA, lineno, filename);
   chpl_memcpy(s, str, len);
   s[len] = '\0';
 
@@ -209,7 +209,7 @@ c_string_copy stringMove(c_string_copy dest, c_string src, int64_t len,
       // allocated string of zero length still occupies memory (one byte for
       // the NUL, at least), so that leaves us with a dilemma.  Which is it?
       strlen(dest) == 0)
-    ret = chpl_mem_alloc(len+1, CHPL_RT_MD_STRING_MOVE_DATA, lineno, filename);
+    ret = chpl_mem_alloc(len+1, CHPL_RT_MD_STR_MOVE_DATA, lineno, filename);
   else
     // reuse the buffer
     // The cast is necessary so we can write into the buffer (which is declared
@@ -232,7 +232,7 @@ c_string_copy remoteStringCopy(c_nodeid_t src_locale,
                                int32_t lineno, c_string filename) {
   char* ret;
   if (src_addr == NULL) return NULL;
-  ret = chpl_mem_alloc(src_len+1, CHPL_RT_MD_STRING_COPY_REMOTE,
+  ret = chpl_mem_alloc(src_len+1, CHPL_RT_MD_STR_COPY_REMOTE,
                        lineno, filename);
   chpl_gen_comm_get((void*)ret, src_locale, (void*)src_addr, sizeof(char),
                     CHPL_TYPE_uint8_t, src_len+1, lineno, filename);

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -26,6 +26,7 @@
 #include "chpltypes.h"
 #include "chpl-comm.h"
 #include "chplcgfns.h"
+#include "chplsys.h"
 #include "config.h"
 #include "error.h"
 
@@ -76,6 +77,9 @@ static int hashSizes[NUM_HASH_SIZE_INDICES] = { 1543, 3079, 6151, 12289, 24593, 
 static int hashSizeIndex = 0;
 static int hashSize = 0;
 
+static chpl_bool track_all_mds = false;
+#define DO_TRACK_MD(md) (chpl_mem_descTrack(md) || track_all_mds)
+
 static memTableEntry** memTable = NULL;
 
 static _Bool memLeaks = false;
@@ -98,6 +102,8 @@ static chpl_sync_aux_t memTrack_sync;
 
 void chpl_setMemFlags(void) {
   chpl_bool local_memTrack = false;
+
+  track_all_mds = chpl_env_getBool("MEMTRACK_ALL_MDS", false);
 
   //
   // Get the values of the memTracking config consts from the module.
@@ -493,7 +499,7 @@ void chpl_track_malloc(void* memAlloc, size_t number, size_t size,
                        chpl_mem_descInt_t description,
                        int32_t lineno, c_string filename) {
   if (number * size > memThreshold) {
-    if (chpl_memTrack) {
+    if (chpl_memTrack && DO_TRACK_MD(description)) {
       chpl_sync_lock(&memTrack_sync);
       addMemTableEntry(memAlloc, number, size, description, lineno, filename);
       chpl_sync_unlock(&memTrack_sync);
@@ -556,7 +562,7 @@ void chpl_track_realloc_post(void* moreMemAlloc,
                          chpl_mem_descInt_t description,
                          int32_t lineno, c_string filename) {
   if (size > memThreshold) {
-    if (chpl_memTrack) {
+    if (chpl_memTrack && DO_TRACK_MD(description)) {
       chpl_sync_lock(&memTrack_sync);
       addMemTableEntry(moreMemAlloc, 1, size, description, lineno, filename);
       chpl_sync_unlock(&memTrack_sync);

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -409,8 +409,30 @@ c_string chpl_nodeName(void) {
     uname(&utsinfo);
     namelen = strlen(utsinfo.nodename)+1;
     namespace = chpl_mem_realloc(namespace, namelen * sizeof(char), 
-                                 CHPL_RT_MD_LOCALE_NAME_BUFFER, 0, NULL);
+                                 CHPL_RT_MD_LOCALE_NAME_BUF, 0, NULL);
     strcpy(namespace, utsinfo.nodename);
   }
   return namespace;
+}
+
+
+chpl_bool chpl_env_getBool(const char* evs, chpl_bool dflt) {
+  char evName[100];
+  const char* evVal;
+
+  if (snprintf(evName, sizeof(evName), "CHPL_RT_%s", evs) >= sizeof(evName))
+    chpl_internal_error("environment variable name buffer too small");
+
+  evVal = getenv(evName);
+  if (evVal == NULL)
+    return dflt;
+  if (strchr("0fFnN", evVal[0]) != NULL)
+    return false;
+  if (strchr("1tTyY", evVal[0]) != NULL)
+    return true;
+
+  chpl_msg(1,
+           "warning: unknown setting for %s; should be T or F, assuming %c\n",
+           evName, (dflt ? 'T' : 'F'));
+  return dflt;
 }

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -184,7 +184,7 @@ static void fork_wrapper(fork_t *f) {
 
 static void AM_fork(gasnet_token_t token, void* buf, size_t nbytes) {
   fork_t *f = (fork_t*)chpl_mem_allocMany(nbytes, sizeof(char),
-                                          CHPL_RT_MD_COMM_FORK_RECV_INFO, 0, 0);
+                                          CHPL_RT_MD_COMM_FRK_RCV_INFO, 0, 0);
   chpl_memcpy(f, buf, nbytes);
   chpl_task_startMovedTask((chpl_fn_p)fork_wrapper, (void*)f,
                            f->subloc, chpl_nullTaskID,
@@ -193,7 +193,7 @@ static void AM_fork(gasnet_token_t token, void* buf, size_t nbytes) {
 
 static void fork_large_wrapper(fork_t* f) {
   void* arg = chpl_mem_allocMany(1, f->arg_size,
-                                 CHPL_RT_MD_COMM_FORK_RECV_LARGE_ARG, 0, 0);
+                                 CHPL_RT_MD_COMM_FRK_RCV_ARG, 0, 0);
 
   // A note on strict aliasing:
   // We used to say something like *(void**)f->arg,
@@ -219,7 +219,7 @@ static void fork_large_wrapper(fork_t* f) {
 ////GASNET - can we allocate f big enough so as not to need malloc in wrapper
 static void AM_fork_large(gasnet_token_t token, void* buf, size_t nbytes) {
   fork_t* f = (fork_t*)chpl_mem_allocMany(1, nbytes,
-                                          CHPL_RT_MD_COMM_FORK_RECV_LARGE_INFO,
+                                          CHPL_RT_MD_COMM_FRK_RCV_INFO,
                                           0, 0);
   chpl_memcpy(f, buf, nbytes);
   chpl_task_startMovedTask((chpl_fn_p)fork_large_wrapper, (void*)f,
@@ -239,7 +239,7 @@ static void AM_fork_nb(gasnet_token_t  token,
                         void           *buf,
                         size_t          nbytes) {
   fork_t *f = (fork_t*)chpl_mem_allocMany(nbytes, sizeof(char),
-                                          CHPL_RT_MD_COMM_FORK_RECV_NB_INFO,
+                                          CHPL_RT_MD_COMM_FRK_RCV_INFO,
                                           0, 0);
   chpl_memcpy(f, buf, nbytes);
   chpl_task_startMovedTask((chpl_fn_p)fork_nb_wrapper, (void*)f,
@@ -249,7 +249,7 @@ static void AM_fork_nb(gasnet_token_t  token,
 
 static void fork_nb_large_wrapper(fork_t* f) {
   void* arg = chpl_mem_allocMany(1, f->arg_size,
-                                 CHPL_RT_MD_COMM_FORK_RECV_NB_LARGE_ARG, 0, 0);
+                                 CHPL_RT_MD_COMM_FRK_RCV_ARG, 0, 0);
 
   // See "A note on strict aliasing" in fork_large_wrapper
   void* f_arg;
@@ -268,7 +268,7 @@ static void fork_nb_large_wrapper(fork_t* f) {
 
 static void AM_fork_nb_large(gasnet_token_t token, void* buf, size_t nbytes) {
   fork_t* f = (fork_t*)chpl_mem_allocMany(1, nbytes,
-                                          CHPL_RT_MD_COMM_FORK_RECV_NB_LARGE_INFO,
+                                          CHPL_RT_MD_COMM_FRK_RCV_INFO,
                                           0, 0);
   chpl_memcpy(f, buf, nbytes);
   chpl_task_startMovedTask((chpl_fn_p)fork_nb_large_wrapper, (void*)f,
@@ -651,10 +651,10 @@ void chpl_comm_broadcast_private(int id, int32_t size, int32_t tid) {
 
   // This can use the system allocator because it involves internode communication.
   done = (done_t*) chpl_mem_allocManyZero(chpl_numNodes, sizeof(*done),
-                                          CHPL_RT_MD_COMM_FORK_DONE_FLAG,
+                                          CHPL_RT_MD_COMM_FRK_DONE_FLAG,
                                           0, 0);
   if (payloadSize <= gasnet_AMMaxMedium()) {
-    priv_bcast_t* pbp = chpl_mem_allocMany(1, payloadSize, CHPL_RT_MD_COMM_PRIVATE_BROADCAST_DATA, 0, 0);
+    priv_bcast_t* pbp = chpl_mem_allocMany(1, payloadSize, CHPL_RT_MD_COMM_PRV_BCAST_DATA, 0, 0);
     chpl_memcpy(pbp->data, chpl_private_broadcast_table[id], size);
     pbp->id = id;
     pbp->size = size;
@@ -669,7 +669,7 @@ void chpl_comm_broadcast_private(int id, int32_t size, int32_t tid) {
   } else {
     int maxpayloadsize = gasnet_AMMaxMedium();
     int maxsize = maxpayloadsize - sizeof(priv_bcast_large_t);
-    priv_bcast_large_t* pblp = chpl_mem_allocMany(1, maxpayloadsize, CHPL_RT_MD_COMM_PRIVATE_BROADCAST_DATA, 0, 0);
+    priv_bcast_large_t* pblp = chpl_mem_allocMany(1, maxpayloadsize, CHPL_RT_MD_COMM_PRV_BCAST_DATA, 0, 0);
     pblp->id = id;
     numOffsets = (size+maxsize)/maxsize;
     for (node = 0; node < chpl_numNodes; node++) {
@@ -973,7 +973,7 @@ void  chpl_comm_fork(c_nodeid_t node, c_sublocid_t subloc,
       info_size = sizeof(fork_t) + sizeof(void*);
     }
     info = (fork_t*)chpl_mem_allocMany(1, info_size,
-                                       CHPL_RT_MD_COMM_FORK_SEND_INFO, 0, 0);
+                                       CHPL_RT_MD_COMM_FRK_SND_INFO, 0, 0);
     info->caller = chpl_nodeID;
     info->subloc = subloc;
     info->ack = &done;
@@ -1017,7 +1017,7 @@ void  chpl_comm_fork_nb(c_nodeid_t node, c_sublocid_t subloc,
   } else {
     info_size = sizeof(fork_t) + sizeof(void*);
   }
-  info = (fork_t*)chpl_mem_allocMany(info_size, sizeof(char), CHPL_RT_MD_COMM_FORK_SEND_NB_INFO, 0, 0);
+  info = (fork_t*)chpl_mem_allocMany(info_size, sizeof(char), CHPL_RT_MD_COMM_FRK_SND_INFO, 0, 0);
   info->caller = chpl_nodeID;
   info->subloc = subloc;
   info->ack = info; // pass address to free after get in large case
@@ -1031,7 +1031,7 @@ void  chpl_comm_fork_nb(c_nodeid_t node, c_sublocid_t subloc,
     // If the arg bundle is too large to fit in fork_t (i.e. passArg == false), 
     // Copy the args into auxilliary memory and pass a pointer to this instead.
     argCopy = chpl_mem_allocMany(1, arg_size,
-                                 CHPL_RT_MD_COMM_FORK_SEND_NB_LARGE_ARG, 0, 0);
+                                 CHPL_RT_MD_COMM_FRK_SND_ARG, 0, 0);
     chpl_memcpy(argCopy, arg, arg_size);
     *(void**)(&(info->arg)) = argCopy;
   }

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -500,7 +500,7 @@ void chpl_comm_fork_nb(c_nodeid_t node, c_sublocid_t subloc,
 
   info_size = sizeof(fork_t) + arg_size;
   info = (fork_t*)chpl_mem_allocMany(info_size, sizeof(char),
-                                     CHPL_RT_MD_COMM_FORK_SEND_NB_INFO, 0, 0);
+                                     CHPL_RT_MD_COMM_FRK_SND_INFO, 0, 0);
   info->fid = fid;
   info->arg_size = arg_size;
   if (arg_size)

--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -328,7 +328,7 @@ void installConfigVar(const char* varName, const char* value,
                       const char* moduleName) {
   unsigned hashValue;
   configVarType* configVar = (configVarType*) 
-    chpl_mem_allocMany(1, sizeof(configVarType), CHPL_RT_MD_CONFIG_TABLE_DATA, 0, 0);
+    chpl_mem_allocMany(1, sizeof(configVarType), CHPL_RT_MD_CF_TABLE_DATA, 0, 0);
 
   hashValue = hash(varName);
   configVar->nextInBucket = configVarTable[hashValue]; 
@@ -396,7 +396,7 @@ int handlePossibleConfigVar(int* argc, char* argv[], int argnum,
   int retval = 0;
   int arglen = strlen(argv[argnum]+2)+1;
   char* argCopy = chpl_mem_allocMany(arglen, sizeof(char),
-                                     CHPL_RT_MD_CONFIG_ARG_COPY_DATA, argnum,
+                                     CHPL_RT_MD_CFG_ARG_COPY_DATA, argnum,
                                      "<command-line>");
   char* equalsSign;
   const char* moduleName;

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -346,11 +346,11 @@ void chpl_task_init(void) {
     thread_private_data_t* tp;
 
     tp = (thread_private_data_t*) chpl_mem_alloc(sizeof(thread_private_data_t),
-                                                 CHPL_RT_MD_THREAD_PRIVATE_DATA,
+                                                 CHPL_RT_MD_THREAD_PRV_DATA,
                                                  0, 0);
 
     tp->ptask = (task_pool_p) chpl_mem_alloc(sizeof(task_pool_t),
-                                             CHPL_RT_MD_TASK_POOL_DESCRIPTOR,
+                                             CHPL_RT_MD_TASK_POOL_DESC,
                                              0, 0);
     tp->ptask->id           = get_next_task_id();
     tp->ptask->fun          = NULL;
@@ -443,11 +443,11 @@ static void comm_task_wrapper(void* arg) {
   thread_private_data_t* tp;
 
   tp = (thread_private_data_t*) chpl_mem_alloc(sizeof(thread_private_data_t),
-                                               CHPL_RT_MD_THREAD_PRIVATE_DATA,
+                                               CHPL_RT_MD_THREAD_PRV_DATA,
                                                0, 0);
 
   tp->ptask = (task_pool_p) chpl_mem_alloc(sizeof(task_pool_t),
-                                           CHPL_RT_MD_TASK_POOL_DESCRIPTOR,
+                                           CHPL_RT_MD_TASK_POOL_DESC,
                                            0, 0);
   tp->ptask->id           = get_next_task_id();
   tp->ptask->fun          = comm_task_fn;
@@ -487,7 +487,7 @@ void chpl_task_addToTaskList(chpl_fn_int_t fid, void* arg,
     chpl_task_list_p ltask;
 
     ltask = (chpl_task_list_p) chpl_mem_alloc(sizeof(struct chpl_task_list),
-                                              CHPL_RT_MD_TASK_LIST_DESCRIPTOR,
+                                              CHPL_RT_MD_TASK_LIST_DESC,
                                               0, 0);
     ltask->filename = filename;
     ltask->lineno   = lineno;
@@ -775,7 +775,7 @@ void chpl_task_startMovedTask(chpl_fn_p fp,
 
   pmtwd = (movedTaskWrapperDesc_t*)
           chpl_mem_alloc(sizeof(*pmtwd),
-                         CHPL_RT_MD_THREAD_PRIVATE_DATA,
+                         CHPL_RT_MD_THREAD_PRV_DATA,
                          0, 0);
   *pmtwd = (movedTaskWrapperDesc_t)
            { fp, a, canCountRunningTasks,
@@ -1147,7 +1147,7 @@ thread_begin(void* ptask_void) {
   thread_private_data_t *tp;
 
   tp = (thread_private_data_t*) chpl_mem_alloc(sizeof(thread_private_data_t),
-                                               CHPL_RT_MD_THREAD_PRIVATE_DATA,
+                                               CHPL_RT_MD_THREAD_PRV_DATA,
                                                0, 0);
   tp->ptask    = ptask;
   tp->lockRprt = NULL;
@@ -1424,7 +1424,7 @@ static task_pool_p add_to_task_pool(chpl_fn_p fp,
                                     chpl_task_list_p ltask) {
   task_pool_p ptask =
     (task_pool_p) chpl_mem_alloc(sizeof(task_pool_t),
-                                        CHPL_RT_MD_TASK_POOL_DESCRIPTOR,
+                                        CHPL_RT_MD_TASK_POOL_DESC,
                                         0, 0);
   ptask->id           = get_next_task_id();
   ptask->fun          = fp;

--- a/runtime/src/threads/pthreads/threads-pthreads.c
+++ b/runtime/src/threads/pthreads/threads-pthreads.c
@@ -365,7 +365,7 @@ static void* pthread_func(void* arg) {
 
   // add us to the list of threads
   tlp = (thread_list_p) chpl_mem_alloc(sizeof(struct thread_list),
-                                       CHPL_RT_MD_THREAD_LIST_DESCRIPTOR, 0, 0);
+                                       CHPL_RT_MD_THREAD_LIST_DESC, 0, 0);
 
   tlp->thread = pthread_self();
   tlp->next   = NULL;


### PR DESCRIPTION
Add a "track this" indicator to the table of memory descriptors, along
with a function to return that indicator and code to pay attention to it
in the memory tracking implementation.  This will allow us to not track
certain runtime internal allocations that don't have a well-defined
connection to constructs in Chapel code, such as internal descriptors
for Active Memory handling.

For now all such indicators are actually set so that everything is still
tracked.  In the future I will change some of them to turn tracking off,
in order to help resolve https://chapel.atlassian.net/browse/CHAPEL-8.

The modification with the largest impact in this commit is actually not
a functional one.  In order to reformat the CHPL_MD_ALL_MEMDESCS() macro
definition to make it still be readable with the addition of the "track"
indicator, I shortened a number of the memory descriptor enum names and
some of the corresponding strings.  This part of the commit is wholly
responsible for the following files changing:
  runtime/src/chpl-privatization.c
  runtime/src/chpl-string-support.c
  runtime/src/chpl-string.c
  runtime/src/comm/gasnet/comm-gasnet.c
  runtime/src/comm/none/comm-none.c
  runtime/src/config.c
  runtime/src/tasks/fifo/tasks-fifo.c
  runtime/src/threads/pthreads/threads-pthreads.c

The other files changed as follows.

runtime/include/chpl-mem-desc.h
runtime/src/chpl-mem-desc.c
  Add the "track" indicator to CHPL_MD_ALL_MEMDESCS() and adjust uses of
  this macro to take that indicator into account.  Make some associated
  internal changes to improve readability.  Add chpl_mem_descTrack(), to
  return the "track" indicator.
  And of course, while here, change a number of the enum names and a few
  of the corresponding description strings, as described above.

runtime/src/chplmemtrack.c
  Track or don't track specific memory descriptor types depending on the
  setting of the "track" indicator for that type and the value of the
  overriding CHPL_RT_MEMTRACK_ALL_MDS environment variable.

runtime/include/chplsys.h
runtime/src/chplsys.c
  Add chpl_env_getBool(), which gets the presumed boolean value of a
  specified CHPL_RT_* environment variable, with a default.  (This new
  function can also now be reused in a few other places in the runtime
  where we need the value of a boolean environment variable.)