### PR TITLE
Add performance timeouts for a couple of tests

### DIFF
--- a/test/release/examples/benchmarks/hpcc/ptrans.perftimeout
+++ b/test/release/examples/benchmarks/hpcc/ptrans.perftimeout
@@ -1,0 +1,3 @@
+# 04/30/15: ptrans takes ~400 seconds for --no-local performance
+# testing and occasionally times out for pgi (normally ~220 seconds)
+600

--- a/test/studies/shootout/nbody/bradc/nbody-blc-slice.perftimeout
+++ b/test/studies/shootout/nbody/bradc/nbody-blc-slice.perftimeout
@@ -1,0 +1,3 @@
+# 04/30/15: The versions of nbody that use slicing take ~550 seconds
+# for --no-local performance testing and ~300 seconds for pgi.
+900

--- a/test/studies/shootout/nbody/sidelnik/nbody_forloop_3.perftimeout
+++ b/test/studies/shootout/nbody/sidelnik/nbody_forloop_3.perftimeout
@@ -1,0 +1,3 @@
+# 04/30/15: The versions of nbody that use slicing take ~550 seconds
+# for --no-local performance testing and ~300 seconds for pgi.
+900


### PR DESCRIPTION
Add timeouts for:

release/examples/benchmarks/hpcc/ptrans.perftimeout
studies/shootout/nbody/bradc/nbody-blc-slice.perftimeout
studies/shootout/nbody/sidelnik/nbody_forloop_3.perftimeout

These tests timeout under --no-local performance testing and occasionally under
pgi. The nbody variations use slicing and are pretty slow even under local for
gnu. ptrans is also a pretty long running test and both --no-local and pgi run
slower than the normal configuration.