### PR TITLE
Switch whitebox testing to CCE 8.3.9

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -83,8 +83,8 @@ case $COMPILER in
         log_info "Loading module: ${module_name}"
         module load ${module_name}
 
-        # Use cce version 8.3.0 for consistency.
-        module swap cce cce/8.3.0
+        # Use cce version 8.3.9 for consistency.
+        module swap cce cce/8.3.9
 
         # swap out network modules to get "host-only" environment
         log_info "Swap network module for host-only environment."


### PR DESCRIPTION
Verification:
* ran util/cron/test-{xc,xe}-wb.bash on chpbld02 - with appropriate envirnment
  variable settings (e.g. to email to me rather than the usual lists) and where
  these were modified to just test -hellos
* verified that all hellos passed

We will learn about other failures in the next night's testing, but we expect
the newer CCE to resolve some issues.

This patch is trivial but was suggested by @ronawho and discussed by several
others including @thomasvandoren .
