### PR TITLE
Suppress enum_mintype_test.chpl failure with Cray compiler

### DIFF
--- a/test/types/enum/ferguson/enum_mintype_test.suppressif
+++ b/test/types/enum/ferguson/enum_mintype_test.suppressif
@@ -1,0 +1,2 @@
+# cray compiler bug jira 39, should be resolved when 8.4 is released
+CHPL_TARGET_COMPILER==cray-prgenv-cray


### PR DESCRIPTION
The issue is related to the compiler not supporting maximum sized ints in their
enums, but this support should be present shortly.  Until support comes in, we
can safely ignore this bug.