### PR TITLE
Revert "Add tests failing valgrind in dl_ functions to suppressions"

### DIFF
--- a/test/Suppressions/valgrind.suppress
+++ b/test/Suppressions/valgrind.suppress
@@ -9,10 +9,3 @@
 # whereas we are running valgrind 3.8.1.
 types/atomic/ferguson/atomictest
 types/atomic/sungeun/atomic_vars
-# These tests fail with invalid reads/writes in dl_ routines,
-# which are probably from a bug in glibc.
-# The fail only sporadically, so we suppress them
-# here instead of in a .suppressif file. See jira issue 7.
-reductions/bradc/manual/promote
-performance/sungeun/dgemm
-studies/sudoku/dinan/sudoku


### PR DESCRIPTION
Reverts chapel-lang/chapel#1915

Elliot pointed out that the Suppressions file will generate errors if these test do not fail,
so that's not appropriate if they're sporadic.