### PR TITLE
Skip chpldoc tests on cygwin32 platform.

### DIFF
--- a/test/chpldoc.skipif
+++ b/test/chpldoc.skipif
@@ -1,0 +1,2 @@
+# cygwin32 nightly test system cannot install chpldoc
+CHPL_TARGET_PLATFORM == cygwin32

--- a/test/compflags/thomasvandoren/chpldoc.doc.skipif
+++ b/test/compflags/thomasvandoren/chpldoc.doc.skipif
@@ -1,0 +1,2 @@
+# cygwin32 nightly test system cannot install chpldoc
+CHPL_TARGET_PLATFORM == cygwin32

--- a/test/compflags/thomasvandoren/chpldoc.skipif
+++ b/test/compflags/thomasvandoren/chpldoc.skipif
@@ -1,0 +1,2 @@
+# cygwin32 nightly test system cannot install chpldoc
+CHPL_TARGET_PLATFORM == cygwin32

--- a/test/release/examples/primers/chpldoc.doc.skipif
+++ b/test/release/examples/primers/chpldoc.doc.skipif
@@ -1,0 +1,2 @@
+# cygwin32 nightly test system cannot install chpldoc
+CHPL_TARGET_PLATFORM == cygwin32


### PR DESCRIPTION
The cygwin32 nightly test system does not have python setuptools due to
installation errors, so it cannot build chpldoc.

Testing chpldoc on this platform is not important, so just skip these tests.

This addresses [CHAPEL-31](https://chapel.atlassian.net/browse/CHAPEL-31).

I verified the .skipif works on stpwchap02.