### PR TITLE
Fix chpldoc directory skipif for cygwin32 testing.

### DIFF
--- a/test/chpldoc.skipif
+++ b/test/chpldoc.skipif
@@ -1,2 +1,26 @@
-# cygwin32 nightly test system cannot install chpldoc
-CHPL_TARGET_PLATFORM == cygwin32
+#!/usr/bin/env python
+
+"""Skip chpldoc tests on cygwin32.
+
+The test system wants to check this file out with executable bits, so instead
+of fiddling with that, just use the executable skipif file format.
+
+This is what the permissions look like after a fresh clone on the cygwin32 test
+system using the simple .skipif file format:
+
+$ ls -l $CHPL_HOME/test/chpldoc.skipif
+-rw-rwxr--+ 1 chapelu nologon 87 May  4 12:35 $CHPL_HOME/test/chpldoc.skipif
+"""
+
+import os
+import os.path
+import sys
+
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+chpl_home = os.environ.get('CHPL_HOME', repo_root)
+chplenv_dir = os.path.join(chpl_home, 'util', 'chplenv')
+
+sys.path.insert(0, chplenv_dir)
+import chpl_platform
+
+print(chpl_platform.get('target') == 'cygwin32')


### PR DESCRIPTION
The test system wants to check this file out with executable bits, so instead
of fiddling with that, just use the executable skipif file format.

This is what the permissions look like after a fresh clone on the cygwin32 test
system using the simple .skipif file format:

$ ls -l $CHPL_HOME/test/chpldoc.skipif
-rw-rwxr--+ 1 chapelu nologon 87 May  4 12:35 $CHPL_HOME/test/chpldoc.skipif

The chpldoc.skipif now has 0755 permissions, so it should work as expected.