### PR TITLE
Added a policy about Coverity annotations

### DIFF
--- a/util/devel/coverity/README.md
+++ b/util/devel/coverity/README.md
@@ -17,6 +17,15 @@ https://scan.coverity.com/tune
 Remember that changes to the model file must be committed to the repository
 (for auditing purposes) **and** uploaded to the project page.
 
+As of May 2015, we prefer to add to the model file instead of
+annotating the source code, when we want to convey something
+to Coverity and both options are available. E.g. to indicate
+that a function never returns, such a function can be placed
+in the model file with the body of __coverity_panic__();
+or it can be preceeded with // coverity[+kill] in the source
+code. The policy is to do the former, on the grounds that
+this is useful only for Coverity.
+
 Running the Scan
 ----------------
 

--- a/util/devel/coverity/README.md
+++ b/util/devel/coverity/README.md
@@ -21,8 +21,8 @@ As of May 2015, we prefer to add to the model file instead of
 annotating the source code, when we want to convey something
 to Coverity and both options are available. E.g. to indicate
 that a function never returns, such a function can be placed
-in the model file with the body of __coverity_panic__();
-or it can be preceeded with // coverity[+kill] in the source
+in the model file with the body of `__coverity_panic__();`
+or it can be preceeded with `// coverity[+kill]` in the source
 code. The policy is to do the former, on the grounds that
 this is useful only for Coverity.
 


### PR DESCRIPTION
to Coverity readme.

This is based on Thomas's explanation.
