### PR TITLE
Add chpl_error() and chpl_internal_error(), indicating they halt execution.

### DIFF
--- a/util/devel/coverity/coverity_model.cpp
+++ b/util/devel/coverity/coverity_model.cpp
@@ -24,3 +24,17 @@ void setupError(const char *filename, int lineno, int tag) {
     __coverity_panic__();
   }
 }
+
+//==============================
+// runtime
+//
+
+// chpl_error() ends execution
+void chpl_error(const char* message, int32_t lineno, c_string filename) {
+  __coverity_panic__();
+}
+
+// chpl_internal_error() ends execution
+void chpl_internal_error(const char* message) {
+  __coverity_panic__();
+}


### PR DESCRIPTION
These will help Coverity Scan's analysis of NULL pointer dereferences.
Currently it is saying that we might dereference a NULL pointer because
it doesn't realize that a NULL test that does chpl_error() if true will
result in a halt.  It thinks execution will proceed through that.