### PR TITLE
Fixed compiler crash in type-tests.isSubtype.chpl on *32

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3323,8 +3323,9 @@ void resolveNormalCall(CallExpr* call) {
 
   if (const char* str = innerCompilerWarningMap.get(resolvedFn)) {
     reissueCompilerWarning(str, 2);
-    if (FnSymbol* fn = toFnSymbol(callStack.v[callStack.n-2]->isResolved()))
-      outerCompilerWarningMap.put(fn, str);
+    if (callStack.n >= 2)
+      if (FnSymbol* fn = toFnSymbol(callStack.v[callStack.n-2]->isResolved()))
+        outerCompilerWarningMap.put(fn, str);
   }
 
   if (const char* str = outerCompilerWarningMap.get(resolvedFn)) {


### PR DESCRIPTION
This fixes the *32 regression in type-tests.isSubtype.chpl
that we have seen since the test was added.

Turns out that in the following expression, executed when
we deal with the warning cache:

```
  callStack.v[callStack.n-2]->isResolved()
```

callStack.n happens to be 1 while compiling that test.

Since our warning cache machinery needs to be redone in order
to do what we want it to do, I did not investigate further.
I simply added a check that callStack.n>=2, and do nothing otherwise.

Q: why has it always worked reliably under *64 and not *32?
Read on...

callStack is a Vec, and in the troubling case callStack.v
still points to callStack.e[0]. Therefore callStack.v[-1]
is the address of callStack.v.

In other words, the memory starting at callStack.v
is interpreted as a CallExpr object.
I will call it CSCE (callStack CallExpr).

Then, isResolved() is invoked on CSCE:

```
FnSymbol* CallExpr::isResolved(void) {
  SymExpr* base = toSymExpr(baseExpr);
  return base ? toFnSymbol(base->var) : NULL;
}
```

which does:

* read 'baseExpr' field of CSCE, then
* if that's not NULL, it reads 'baseExpr->astTag', as part of toSymExpr().

Given that callStack is a global variable, and the way the global
variables are laid out by the compiler/linker...

Under ubuntu-32, CSCE.baseExpr falls onto the first word of 'paramMap'.
paramMap being a Map, its first word is paramMap.n, and it happens
to be 0x1ffff (probably the number of allocated buckets of the map).
That's not NULL, and it's not a good address to read astTag off of.
Hence the crash.

Under linux64, CSCE.baseExpr falls onto autoCopyMap+(24 bytes).
Apparently up to this point in the test autoCopyMap has not been touched,
so that it's all zeros.
So CSCE.baseExpr is NULL, 'base' in isResolved() is NULL, isResolved()
returns NULL, and everything progresses smoothly.

How about that...
