### PR TITLE
String as rec bugs May 6

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -225,9 +225,12 @@ static void replaceLocalWithFieldTemp(SymExpr*       se,
 
   if (call && call->isPrimitive(PRIM_GET_MEMBER)) {
     // Get member returns the address of the member, so we convert the
-    // type of the corresponding temp to a reference type.
-    INT_ASSERT(tmp->type->refType);
-    tmp->type = tmp->type->refType;
+    // type of the corresponding temp to a reference type if necessary.
+    if (! tmp->type->symbol->hasFlag(FLAG_REF))
+    {
+      INT_ASSERT(tmp->type->refType);
+      tmp->type = tmp->type->refType;
+    }
   }
 
   // OK, insert the declaration.

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2224,6 +2224,8 @@ FnSymbol::insertBeforeReturnAfterLabel(Expr* ast) {
 }
 
 
+// Inserts the given ast ahead of the _downEndCount call at the end of this
+// function, if present.  Otherwise, inserts it ahead of the return.
 void
 FnSymbol::insertBeforeDownEndCount(Expr* ast) {
   CallExpr* ret = toCallExpr(body->body.last());
@@ -2234,8 +2236,12 @@ FnSymbol::insertBeforeDownEndCount(Expr* ast) {
     prev = toBlockStmt(prev)->body.last();
   CallExpr* last = toCallExpr(prev);
   if (!last || strcmp(last->isResolved()->name, "_downEndCount"))
-    INT_FATAL(last, "Expected call to _downEndCount");
-  last->insertBefore(ast);
+  {
+    // No _downEndCount() call, so insert the ast before the return.
+    ret->insertBefore(ast);
+  }
+  else
+    last->insertBefore(ast);
 }
 
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2235,13 +2235,16 @@ FnSymbol::insertBeforeDownEndCount(Expr* ast) {
   while (isBlockStmt(prev))
     prev = toBlockStmt(prev)->body.last();
   CallExpr* last = toCallExpr(prev);
-  if (!last || strcmp(last->isResolved()->name, "_downEndCount"))
+  if (last && last->isResolved() &&
+      ! strcmp(last->isResolved()->name, "_downEndCount"))
+  {
+    last->insertBefore(ast);
+  }
+  else
   {
     // No _downEndCount() call, so insert the ast before the return.
     ret->insertBefore(ast);
   }
-  else
-    last->insertBefore(ast);
 }
 
 


### PR DESCRIPTION
Fixed compile-time bugs that came along with the string-as-rec_a29bugs merge.
Now at 55 regressions overall > 26 run-time > 8 non-leak.