### PR TITLE
Resolve lulesh regressions under slurm

### DIFF
--- a/test/release/examples/benchmarks/lulesh/PREDIFF
+++ b/test/release/examples/benchmarks/lulesh/PREDIFF
@@ -11,6 +11,7 @@
 outfile=$2
 cat $outfile | \
     grep -v -E 'srun: error: .* Exited with exit code 1' | \
-    grep -v -E 'slurmstepd: Terminating job step .* exit code 1 exited without notification' \
+    grep -v -E 'slurmstepd: Terminating job step .* exit code 1 exited without notification' | \
+    grep -v -E 'srun: Terminating job step .*' \
     > $outfile.tmp
 mv $outfile.tmp $outfile


### PR DESCRIPTION
94e3167b888aca545a855286d0c4850d9423d84c started throwing --kill-on-bad-exit to
slurm. Some versions of lulesh and test3DLulesh halt and are expected to fail.

However, slurm prints out some stuff when a job returns with a non-zero exit
code (and we haven't found a way to suppress such messages.) Because of this,
we have a PREDIFF to filter out some stuff slurm prints about terminating job
steps. This just adds another filter to get rid of an additional termination
warning that is now printed because the srun job step is now killed as well.

This additional message only occurs under batch mode, not interactive mode
since srun is an additional job step when batch is being used. i.e. this was
only seen when chpl_launchcmd was being used in nightly testing, you would not
see it if you ran start_test without launchcmd.