### PR TITLE
Fix bug in using inherited destructors

### DIFF
--- a/test/classes/lydia/useInheritedDestructor.chpl
+++ b/test/classes/lydia/useInheritedDestructor.chpl
@@ -1,0 +1,20 @@
+class storage {
+  var a: int;
+}
+
+class A {
+  var stored: storage = new storage();
+  var uninit: storage;
+
+  proc ~A() {
+    delete stored;
+    delete uninit;
+  }
+}
+
+class B: A {
+  var count: int = 1;
+}
+
+var instantiated: B = new B();
+writeln(instantiated);

--- a/test/classes/lydia/useInheritedDestructor.chpl
+++ b/test/classes/lydia/useInheritedDestructor.chpl
@@ -18,3 +18,4 @@ class B: A {
 
 var instantiated: B = new B();
 writeln(instantiated);
+delete instantiated;

--- a/test/classes/lydia/useInheritedDestructor.good
+++ b/test/classes/lydia/useInheritedDestructor.good
@@ -1,0 +1,1 @@
+{stored = {a = 0}, uninit = nil, count = 1}


### PR DESCRIPTION
I discovered that if a class used its parent destructor, we'd encounter an
internal assertion error, because for some reason we didn't expect to insert
coercion temps.  This was a really dumb assertion, made from pure laziness, so
I removed it and wrapped the code in a block that could be removed so that what
the assertion was worried about didn't come to pass either (as suggested by
@hildeth and the comment on the assertion).

Add a test to ensure this case will continue to work.