### PR TITLE
Add tolerance to fileIO primer

### DIFF
--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -11,11 +11,12 @@
    Seventh example: binary I/O with bits at a time
 */
 
-config var n = 9,            // the problem size for example 1
+config var n = 9,                 // the problem size for example 1
            filename = "Arr.dat";  // the filename for writing/reading the array
 config const num = 128*1024;
 config const example = 0;
 config const testfile = "test.bin";
+config const epsilon = 10e-13;
 
 use IO;
 
@@ -42,9 +43,9 @@ if example == 0 || example == 1 {
   writeln("B is:\n", B);
   
   //
-  // verify that A and B contain the same values and print success or failure
+  // verify that the values in A and B are within tolerance
   //
-  const numErrors = + reduce [i in ADom] (A(i) != B(i));
+  const numErrors = + reduce [i in ADom] (abs(A(i) - B(i)) > epsilon);
 
   if (numErrors > 0) {
     writeln("FAILURE");


### PR DESCRIPTION
This test fails under knc because of a floating point mismatch. We calculate
the values of an array in memory, write it out to a file, and then create a new
array from that file. However, we only write out 2 digits of precision to the
file so the values we read back in might not be identical. To compensate for
this, a tolerance is being added.

The particular issue was that when we calculate (1+7/10) intel was turning that
into (1+7*.1) which has a slightly different value than the literal 1.7 that we
were writing out to a file. It's likely this could have caused problems with
any configuration that enables replacing division with multiplication of a
reciprocal, but we only saw it on knc likely because of knc's different cost
model.

See JIRA issue 51 for more information