### PR TITLE
Suppress fasta-lines perf runs on machines with < 8 GB or ram

### DIFF
--- a/test/studies/shootout/fasta/kbrady/fasta-lines.suppressif
+++ b/test/studies/shootout/fasta/kbrady/fasta-lines.suppressif
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+
+# fasta-lines allocates ~5.9 GB of memory (and only frees a few MB). It
+# probably requires a machine with around 6-7GB to run. I'm assuming nobody has
+# a machine with that much ram so I'm using 8GB as the cutoff. We should be
+# able to remove this once strings as records are in.
+
+$memRequiredInGB = 8;
+$memInGB = $memRequiredInGB;
+
+if ($ENV{CHPL_TEST_PERF} eq "on") {
+    $memfile = "/proc/meminfo";
+    if (-r $memfile) {
+      open MEMFILE, "$memfile" or die "can't open $memfile $!";
+      my @memLines = <MEMFILE>;
+      close (MEMFILE);
+
+      foreach my $line (@memLines) {
+        if ($line =~ m/MemTotal: (\s*)(\S*)/) {
+          $memInKB = "$2";
+          $memInGB = $memInKB / (1024 * 1024);
+        }
+      }
+    } else {
+        $platform = `$ENV{CHPL_HOME}/util/chplenv/chpl_platform.py --target`; chomp($platform);
+        if ($platform eq "darwin") {
+            $memInBytes = `sysctl -n hw.memsize`; chomp($memInBytes);
+            $memInGB = $memInBytes / (1024 * 1024 * 1024);
+        }
+    }
+}
+
+if ($memInGB < $memRequiredInGB) {
+    print("True\n");
+} else {
+    print("False\n");
+}


### PR DESCRIPTION
This test concats a bunch of strings and since it ends up leaking all of them
it requires ~6 GB of memory. Until we have strings as records, it makes sense
to just suppress this test since we're expecting it to fail.

The suppressif just checks if perf testing is on and if the system has < 8GB of
ram. Tested on linux64 and darwin.

Suppressif based off of modules/standard/memory/countMemory/countMemory.prediff