### PR TITLE
Add option to dump memory leaks by descriptor string

### DIFF
--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -35,22 +35,22 @@ module MemTracking
   config const
     memLeaksLog: c_ptr(uint(8)) = nil;
 
-  /* Causes the contents of the memory tracking array to be dumped at the end
+  /* Causes the contents of the memory tracking array to be printed at the end
      of the program.
      Entries remaining in the memory tracking array represent leaked memory,
      because they are tracked allocations with no corresponding free.
 
-     The dump is performed only if the --dumpMemLeaks option is present and has
-     a string argument.
-       --dumpMemLeaks="" causes all memory records to be printed.
-       --dumpMemLeaks="<alloc-type-string>" causes only those descriptors
+     The dump is performed only if the --memLeaksByDesc option is present and has
+     a string argument.  
+       --memLeaksByDesc="" causes all memory records to be printed.  Same as --memLeaks.
+       --memLeaksByDesc="<alloc-type-string>" causes only those memory records
          matching the given <alloc-type-string> to be printed.
-     For example, --dumpMemLeaks="string copy data" causes only string copy
+     For example, --memLeaksByDesc="string copy data" causes only string copy
      data leaks to be printed.
   */
   pragma "no auto destroy"
   config const
-    dumpMemLeaks: c_ptr(uint(8)) = nil;
+    memLeaksByDesc: c_ptr(uint(8)) = nil;
 
   // Safely cast to size_t instances of memMax and memThreshold.
   const cMemMax = memMax.safeCast(size_t),
@@ -78,7 +78,7 @@ module MemTracking
   proc chpl_memTracking_returnConfigVals(ref ret_memTrack: bool,
                                          ref ret_memStats: bool,
                                          ref ret_memLeaksByType: bool,
-                                         ref ret_dumpMemLeaks: c_ptr(uint(8)),
+                                         ref ret_memLeaksByDesc: c_ptr(uint(8)),
                                          ref ret_memLeaks: bool,
                                          ref ret_memMax: size_t,
                                          ref ret_memThreshold: size_t,
@@ -87,7 +87,7 @@ module MemTracking
     ret_memTrack = memTrack;
     ret_memStats = memStats;
     ret_memLeaksByType = memLeaksByType;
-    ret_dumpMemLeaks = dumpMemLeaks;
+    ret_memLeaksByDesc = memLeaksByDesc;
     ret_memLeaks = memLeaks;
     ret_memMax = cMemMax;
     ret_memThreshold = cMemThreshold;

--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -35,6 +35,10 @@ module MemTracking
   config const
     memLeaksLog: c_ptr(uint(8)) = nil;
 
+  pragma "no auto destroy"
+  config const
+    dumpMemLeaks: c_ptr(uint(8)) = nil;
+
   // Safely cast to size_t instances of memMax and memThreshold.
   const cMemMax = memMax.safeCast(size_t),
     cMemThreshold = memThreshold.safeCast(size_t);
@@ -61,6 +65,7 @@ module MemTracking
   proc chpl_memTracking_returnConfigVals(ref ret_memTrack: bool,
                                          ref ret_memStats: bool,
                                          ref ret_memLeaksByType: bool,
+                                         ref ret_dumpMemLeaks: c_ptr(uint(8)),
                                          ref ret_memLeaks: bool,
                                          ref ret_memMax: size_t,
                                          ref ret_memThreshold: size_t,
@@ -69,6 +74,7 @@ module MemTracking
     ret_memTrack = memTrack;
     ret_memStats = memStats;
     ret_memLeaksByType = memLeaksByType;
+    ret_dumpMemLeaks = dumpMemLeaks;
     ret_memLeaks = memLeaks;
     ret_memMax = cMemMax;
     ret_memThreshold = cMemThreshold;

--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -35,6 +35,19 @@ module MemTracking
   config const
     memLeaksLog: c_ptr(uint(8)) = nil;
 
+  /* Causes the contents of the memory tracking array to be dumped at the end
+     of the program.
+     Entries remaining in the memory tracking array represent leaked memory,
+     because they are tracked allocations with no corresponding free.
+
+     The dump is performed only if the --dumpMemLeaks option is present and has
+     a string argument.
+       --dumpMemLeaks="" causes all memory records to be printed.
+       --dumpMemLeaks="<alloc-type-string>" causes only those descriptors
+         matching the given <alloc-type-string> to be printed.
+     For example, --dumpMemLeaks="string copy data" causes only string copy
+     data leaks to be printed.
+  */
   pragma "no auto destroy"
   config const
     dumpMemLeaks: c_ptr(uint(8)) = nil;

--- a/runtime/include/chplmemtrack.h
+++ b/runtime/include/chplmemtrack.h
@@ -29,6 +29,8 @@
 #include <stdlib.h>
 
 
+///// These entry points support debugging.
+
 // Memory tracking activated?
 extern chpl_bool chpl_memTrack;
 
@@ -36,8 +38,17 @@ void chpl_setMemFlags(void);
 uint64_t chpl_memoryUsed(int32_t lineno, c_string filename);
 void chpl_printMemAllocStats(int32_t lineno, c_string filename);
 void chpl_printMemAllocsByType(int32_t lineno, c_string filename);
-void chpl_printMemAllocs(int64_t threshold, int32_t lineno, c_string filename);
-void chpl_dumpMemAllocs(const char* descString, int32_t lineno, c_string filename);
+void chpl_printMemAllocs(chpl_mem_descInt_t description, int64_t threshold,
+                         int32_t lineno, c_string filename);
+void chpl_printMemAllocsByDesc(const char* descString, int64_t threshold,
+                               int32_t lineno, c_string filename);
+void chpl_startVerboseMem(void);
+void chpl_stopVerboseMem(void);
+void chpl_startVerboseMemHere(void);
+void chpl_stopVerboseMemHere(void);
+
+
+///// These entry points are the essential memory tracking interface.
 void chpl_reportMemInfo(void);
 void chpl_track_malloc(void* memAlloc, size_t number, size_t size,
                        chpl_mem_descInt_t description,
@@ -50,11 +61,6 @@ void chpl_track_realloc_post(void* moreMemAlloc,
                          void* memAlloc, size_t size,
                          chpl_mem_descInt_t description,
                          int32_t lineno, c_string filename);
-
-void chpl_startVerboseMem(void);
-void chpl_stopVerboseMem(void);
-void chpl_startVerboseMemHere(void);
-void chpl_stopVerboseMemHere(void);
 
 #else // LAUNCHER
 

--- a/runtime/include/chplmemtrack.h
+++ b/runtime/include/chplmemtrack.h
@@ -37,6 +37,7 @@ uint64_t chpl_memoryUsed(int32_t lineno, c_string filename);
 void chpl_printMemAllocStats(int32_t lineno, c_string filename);
 void chpl_printMemAllocsByType(int32_t lineno, c_string filename);
 void chpl_printMemAllocs(int64_t threshold, int32_t lineno, c_string filename);
+void chpl_dumpMemAllocs(const char* descString, int32_t lineno, c_string filename);
 void chpl_reportMemInfo(void);
 void chpl_track_malloc(void* memAlloc, size_t number, size_t size,
                        chpl_mem_descInt_t description,

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -546,7 +546,7 @@ void chpl_reportMemInfo() {
     fprintf(memLogFile, "\n");
     printMemAllocsByType(true /* forLeaks */, 0, 0);
   }
-  if (dumpMemLeaks[0]) {
+  if (dumpMemLeaks) {
     fprintf(memLogFile, "\n");
     chpl_dumpMemAllocs(dumpMemLeaks, 0, 0);
   }

--- a/test/execflags/ferguson/help2.good
+++ b/test/execflags/ferguson/help2.good
@@ -31,4 +31,5 @@ CONFIG VARS:
                memThreshold: uint(64)
                      memLog: c_ptr(uint(8))
                 memLeaksLog: c_ptr(uint(8))
+             memLeaksByDesc: c_ptr(uint(8))
                  numLocales: int(64)

--- a/test/execflags/shannon/configs/help/basehelp.txt
+++ b/test/execflags/shannon/configs/help/basehelp.txt
@@ -32,5 +32,6 @@ Built-in config vars:
                memThreshold: uint(64)
                      memLog: c_ptr(uint(8))
                 memLeaksLog: c_ptr(uint(8))
+             memLeaksByDesc: c_ptr(uint(8)) 
                  numLocales: int(64)
 

--- a/test/execflags/shannon/help.good
+++ b/test/execflags/shannon/help.good
@@ -31,4 +31,5 @@ CONFIG VARS:
                memThreshold: uint(64)
                      memLog: c_ptr(uint(8))
                 memLeaksLog: c_ptr(uint(8))
+             memLeaksByDesc: c_ptr(uint(8))
                  numLocales: int(64)


### PR DESCRIPTION
Add a new config const in MemTracking.chpl, to support printing just the memTable records corresponding to a given memory descriptor string.  Since these are printed at the end of the program run, they represent leaked memory.

This option refines the existing "memLeaks" option, which merely causes *all* memTable records to be printed.  In addition, I now pass through the memThreshold option to both --memLeaks and --memLeaksByDesc options, to support further filtering of the output.