### PR TITLE
Add tolerance to fileIO2 test.

### DIFF
--- a/test/types/file/fileIO2.chpl
+++ b/test/types/file/fileIO2.chpl
@@ -1,5 +1,6 @@
 config var n = 10,
            filename = "arr2.out";
+config const epsilon = 10e-13;
 
 const ADom = {1..n, 1..n};
 
@@ -8,7 +9,7 @@ var A: [ADom] real = [(i,j) in ADom] (i-1) + ((j-1)/10.0);
 writeArray(n, A, filename);
 var B = readArray(filename);
 
-const numErrors = + reduce [i in ADom] (A(i) != B(i));
+const numErrors = + reduce [i in ADom] (abs(A(i) - B(i)) > epsilon);
 
 writeln("B is:\n", B);
 


### PR DESCRIPTION
Note: This is a similar change as the one made to the fileIO primer that is
partially based off of this test: d7a6e0bb7ef1d2e557637d7e9611e2545fb26c37

This test started failing when we stopped passing -Kieee to the pgi compiler by
default with c110486aacb9

This test calculates the values of an array in memory, write it out to a file,
and then create a new array from that file. However, we only write out 2 digits
of precision to the file so the values we read back in might not be identical.
To compensate for this, a tolerance is being added.

The particular issue was that when we calculate (1+7/10) pgi was turning that
into (1+7*.1) which has a slightly different value than the literal 1.7 that we
were writing out to a file. We recently ran into this same issue on knc with
the fileIO primer.