### PR TITLE
Fix llvm failures

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -874,13 +874,12 @@ void runClang(const char* just_parse_filename) {
              so that we could automatically set CHPL_HOME. */
   std::string home(CHPL_HOME);
   std::string compileline = home + "/util/config/compileline";
-  std::string one = "1";
-  std::string zero = "0";
-  compileline += " COMP_GEN_WARN=" + (ccwarnings?one:zero);
-  compileline += " COMP_GEN_DEBUG=" + (debugCCode?one:zero);
-  compileline += " COMP_GEN_OPT=" + (optimizeCCode?one:zero);
-  compileline += " COMP_GEN_SPECIALIZE=" + (specializeCCode?one:zero);
-  compileline += " COMP_GEN_FLOAT_OPT=" + ffloatOpt;
+  compileline += " COMP_GEN_WARN="; compileline += istr(ccwarnings);
+  compileline += " COMP_GEN_DEBUG="; compileline += istr(debugCCode);
+  compileline += " COMP_GEN_OPT="; compileline += istr(optimizeCCode);
+  compileline += " COMP_GEN_SPECIALIZE="; compileline += istr(specializeCCode);
+  compileline += " COMP_GEN_FLOAT_OPT="; compileline += istr(ffloatOpt);
+
   std::string readargsfrom;
 
   if( just_parse_filename ) {

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -552,10 +552,10 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname, bool skip_com
   // factor of 5 or so in time in running the test system, as opposed
   // to specifying BINNAME on the C compiler command line.
 
-  fprintf(makefile.fptr, "COMP_GEN_WARN = %i\n", ccwarnings!=0);
-  fprintf(makefile.fptr, "COMP_GEN_DEBUG = %i\n", debugCCode!=0);
-  fprintf(makefile.fptr, "COMP_GEN_OPT = %i\n", optimizeCCode!=0);
-  fprintf(makefile.fptr, "COMP_GEN_SPECIALIZE = %i\n", specializeCCode!=0);
+  fprintf(makefile.fptr, "COMP_GEN_WARN = %i\n", ccwarnings);
+  fprintf(makefile.fptr, "COMP_GEN_DEBUG = %i\n", debugCCode);
+  fprintf(makefile.fptr, "COMP_GEN_OPT = %i\n", optimizeCCode);
+  fprintf(makefile.fptr, "COMP_GEN_SPECIALIZE = %i\n", specializeCCode);
   fprintf(makefile.fptr, "COMP_GEN_FLOAT_OPT = %i\n", ffloatOpt);
   
   fprintf(makefile.fptr, "COMP_GEN_USER_CFLAGS =");


### PR DESCRIPTION
IEEE float support patch broke LLVM builds. Here I repair it
and also switch to using istr for these variables instead of
a pattern using the ternary operator and constant std:strings.


Remove redundant !=0. These variables are all bools anyway.
