### PR TITLE
Quiet domainMaps regression on 32 bit platforms

### DIFF
--- a/test/memory/sungeun/refCount/domainMaps.cygwin32.good
+++ b/test/memory/sungeun/refCount/domainMaps.cygwin32.good
@@ -1,0 +1,60 @@
+Default Dist
+============
+Copy of domain map:
+	0 bytes leaked
+Return domain map:
+	0 bytes leaked
+Create domain:
+	0 bytes leaked
+Create domain and array:
+	0 bytes leaked
+total:
+	143 bytes leaked
+Block Dist
+==========
+Copy of domain map:
+	0 bytes leaked
+Return domain map:
+	0 bytes leaked
+Create domain:
+	192 bytes leaked
+Create domain and array:
+	928 bytes leaked
+total:
+	1263 bytes leaked
+Cyclic Dist
+===========
+Copy of domain map:
+	0 bytes leaked
+Return domain map:
+	96 bytes leaked
+Create domain:
+	192 bytes leaked
+Create domain and array:
+	932 bytes leaked
+total:
+	1459 bytes leaked
+Block-Cyclic Dist
+=================
+Copy of domain map:
+	48 bytes leaked
+Return domain map:
+	96 bytes leaked
+Create domain:
+	384 bytes leaked
+Create domain and array:
+	1744 bytes leaked
+total:
+	2511 bytes leaked
+Replicated Dist
+===============
+Copy of domain map:
+	32 bytes leaked
+Return domain map:
+	168 bytes leaked
+Create domain:
+	280 bytes leaked
+Create domain and array:
+	1012 bytes leaked
+total:
+	1907 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.linux32.good
+++ b/test/memory/sungeun/refCount/domainMaps.linux32.good
@@ -1,0 +1,60 @@
+Default Dist
+============
+Copy of domain map:
+	0 bytes leaked
+Return domain map:
+	0 bytes leaked
+Create domain:
+	0 bytes leaked
+Create domain and array:
+	0 bytes leaked
+total:
+	143 bytes leaked
+Block Dist
+==========
+Copy of domain map:
+	0 bytes leaked
+Return domain map:
+	0 bytes leaked
+Create domain:
+	160 bytes leaked
+Create domain and array:
+	880 bytes leaked
+total:
+	1183 bytes leaked
+Cyclic Dist
+===========
+Copy of domain map:
+	0 bytes leaked
+Return domain map:
+	80 bytes leaked
+Create domain:
+	160 bytes leaked
+Create domain and array:
+	884 bytes leaked
+total:
+	1347 bytes leaked
+Block-Cyclic Dist
+=================
+Copy of domain map:
+	40 bytes leaked
+Return domain map:
+	80 bytes leaked
+Create domain:
+	320 bytes leaked
+Create domain and array:
+	1560 bytes leaked
+total:
+	2223 bytes leaked
+Replicated Dist
+===============
+Copy of domain map:
+	32 bytes leaked
+Return domain map:
+	152 bytes leaked
+Create domain:
+	232 bytes leaked
+Create domain and array:
+	948 bytes leaked
+total:
+	1747 bytes leaked


### PR DESCRIPTION
This test leaks different amounts of memory for different configurations. The
current cases that we don't handle correctly are linux32 and cygwin32. This just
adds linux32 and cygwin32 platform specific .good files.

Long term we expect this test to have zero leaks and in the meantime we just
have different .good files for the configurations that leak different amounts.

I considered skipping this test for 32 bit platforms, or adding a supressif but
this was easier, and will allow us to track if things get worse on 32 bit for
some reason.

See JIRA issue 45 (https://chapel.atlassian.net/browse/CHAPEL-45)