### PR TITLE
Silence Coverity error 1298872

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -817,6 +817,10 @@ makeHeapAllocations() {
           if (formal == arg)
             se = toSymExpr(actual);
         }
+        INT_ASSERT(se);
+        // Previous passes mean that we should always get a formal SymExpr
+        // to match the ArgSymbol.  And that formal should have the
+        // ref flag, since we obtained it through the refVec.
         INT_ASSERT(se->var->type->symbol->hasFlag(FLAG_REF));
         if (!refSet.set_in(se->var)) {
           refSet.set_add(se->var);


### PR DESCRIPTION
Coverity complains that in parallel.cpp's makeHeapAllocations(), a SymExpr whose
fields we access could be NULL.  I think this is very unlikely, but we should
catch it if it does happen, so I'm adding an assertion.

Note that I don't think additional assertions for se->var, se->var->type, or
se->var->type->symbol are reasonable, so if Coverity complains about those
after this addition, I will choose to "ignore" those errors instead.