### PR TITLE
Fixes for .suppressif feature

### DIFF
--- a/test/studies/shootout/fasta/kbrady/fasta-lines.suppressif
+++ b/test/studies/shootout/fasta/kbrady/fasta-lines.suppressif
@@ -1,4 +1,5 @@
 #!/usr/bin/env perl
+# too much memory in fasta-lines
 
 # fasta-lines allocates ~5.9 GB of memory (and only frees a few MB). It
 # probably requires a machine with around 6-7GB to run. I'm assuming nobody has

--- a/util/start_test
+++ b/util/start_test
@@ -1885,14 +1885,20 @@ set suppressmarker = "^Suppress"
 set errormarker = "^\[Error"
 set warningmarker = "^\[Warning"
 if ($performance == 0 && $gengraphs) then
-    set successmarker = "^\[Success generating"
+    set successmarker = "\[Success generating"
 else
     if ($?CHPL_COMPONLY) then
-        set successmarker = "^\[Success compiling"
+        set successmarker = "\[Success compiling"
     else
-        set successmarker = "^\[Success matching"
+        set successmarker = "\[Success matching"
     endif
 endif
+
+set passingSuppresionsMarker = "$suppressmarker.*$successmarker"
+set passingFuturesMarker = "$futuremarker.*$successmarker"
+
+set successmarker = "^$successmarker"
+
 set skipstdinredirectmarker = "^\[Skipping test with .stdin input"
 
 echo \[Test Summary - $datestr\] |& $tee $logfile.summary
@@ -1917,8 +1923,12 @@ if ($clean_only == 0) then
     set futures = `grep -c "$futuremarker" $logfile.summary`
     set warnings = `grep -c "$warningmarker" $logfile.summary`
 
+    set passingsuppress = `grep -c "$passingSuppresionsMarker" $logfile.summary`
+    set passingfutures = `grep -c "$passingFuturesMarker" $logfile.summary`
+
     if ($skipstdinredirs != 0) echo \[Skipped $skipstdinredirs tests with .stdin input\]
     echo "[Summary: #Successes = $successes | #Failures = $failures | #Futures = $futures | #Warnings = $warnings ]" |& $tee -a $logfile.summary
+    echo "[Summary: #Passing Suppressions = $passingsuppress | #Passing Futures = $passingfutures ]" |& $tee -a $logfile.summary
 else
     echo \[Summary: CLEAN ONLY\] |& $tee $logfile.summary
 endif

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1039,16 +1039,14 @@ for testname in testsrc:
                 if suppresstest.strip() != "False":
                     suppressme = suppresstest.strip() == "True" or int(suppresstest) == 1
                 if suppressme:
+                    suppressline = ""
                     with open('./'+test_filename+'.suppressif', 'r') as suppressfile:
-                        suppressline = suppressfile.readline().strip()
-                        if suppressline.startswith("#!"):
-                            # read the next line to skip e.g. #!/bin/bash
-                            suppressline = suppressfile.readline().strip()
-                        if suppressline.startswith("#"):
-                          suppressline = suppressline.replace("#","");
-                        else:
-                          suppressline = ""
-                        suppressline = suppressline.strip()
+                        for line in suppressfile:
+                            line = line.strip()
+                            if (line.startswith("#") and
+                                not line.startswith("#!")):
+                                suppressline = line.replace('#','').strip()
+                                break
                     futuretest='Suppress (' + suppressline + ') '
             except ValueError:
                 sys.stdout.write('[Error processing .suppressif file %s/%s]\n'%(localdir,f))

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1041,11 +1041,14 @@ for testname in testsrc:
                 if suppressme:
                     with open('./'+test_filename+'.suppressif', 'r') as suppressfile:
                         suppressline = suppressfile.readline().strip()
-                    if suppressline.startswith("#"):
-                      suppressline = suppressline.replace("#","");
-                    else:
-                      suppressline = ""
-                    suppressline = suppressline.strip()
+                        if suppressline.startswith("#!"):
+                            # read the next line to skip e.g. #!/bin/bash
+                            suppressline = suppressfile.readline().strip()
+                        if suppressline.startswith("#"):
+                          suppressline = suppressline.replace("#","");
+                        else:
+                          suppressline = ""
+                        suppressline = suppressline.strip()
                     futuretest='Suppress (' + suppressline + ') '
             except ValueError:
                 sys.stdout.write('[Error processing .suppressif file %s/%s]\n'%(localdir,f))
@@ -1959,10 +1962,10 @@ for testname in testsrc:
                     if not exectimeout:
                         if status == 0:
                             os.unlink(execlog)
-                            sys.stdout.write('[Success')
+                            sys.stdout.write('%s[Success '%(futuretest))
                         else:
-                            sys.stdout.write('[Error')
-                        sys.stdout.write(' matching performance keys for %s/%s'%
+                            sys.stdout.write('%s[Error '%(futuretest))
+                        sys.stdout.write('matching performance keys for %s/%s'%
                                         (localdir, test_filename))
                         if status!=0:
                             printTestVariation(compoptsnum, compoptslist,


### PR DESCRIPTION
* Makes passing futures and passing suppresses count get printed out in summary
* Adjusts sub_test to allow .suppressif for performance tests

Does not make passing suppressions "failures" since that would change
a whole pile of other code using specific interpretation of [Error lines.