### PR TITLE
Fix coverity issue 1298873

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -6070,6 +6070,7 @@ new_Expr(const char* format, va_list vl) {
       const char* str = asubstr(&format[i], &format[i+n]);
       i += n-1;
       if (!strcmp(str, "TYPE")) {
+        INT_ASSERT(stack.size() > 0);
         BlockStmt* block = toBlockStmt(stack.top());
         INT_ASSERT(block);
         block->blockTag = BLOCK_TYPE;
@@ -6109,6 +6110,7 @@ new_Expr(const char* format, va_list vl) {
       Expr* expr = stack.top();
       stack.pop();
       INT_ASSERT(expr);
+      INT_ASSERT(stack.size() > 0);
       CallExpr* call = toCallExpr(stack.top());
       INT_ASSERT(call);
       call->insertAtTail(expr);
@@ -6116,6 +6118,7 @@ new_Expr(const char* format, va_list vl) {
       Expr* expr = stack.top();
       stack.pop();
       INT_ASSERT(expr);
+      INT_ASSERT(stack.size() > 0);
       CallExpr* call = toCallExpr(stack.top());
       INT_ASSERT(call);
       call->insertAtTail(expr);
@@ -6125,6 +6128,7 @@ new_Expr(const char* format, va_list vl) {
       Expr* expr = stack.top();
       stack.pop();
       INT_ASSERT(expr);
+      INT_ASSERT(stack.size() > 0);
       BlockStmt* block = toBlockStmt(stack.top());
       INT_ASSERT(block);
       block->insertAtTail(expr);
@@ -6132,6 +6136,7 @@ new_Expr(const char* format, va_list vl) {
       Expr* expr = stack.top();
       stack.pop();
       INT_ASSERT(expr);
+      INT_ASSERT(stack.size() > 0);
       BlockStmt* block = toBlockStmt(stack.top());
       INT_ASSERT(block);
       block->insertAtTail(expr);

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -6071,6 +6071,8 @@ new_Expr(const char* format, va_list vl) {
       i += n-1;
       if (!strcmp(str, "TYPE")) {
         INT_ASSERT(stack.size() > 0);
+        // You've reached here because you didn't provide "{ TYPE ..." for a
+        // block type statement.
         BlockStmt* block = toBlockStmt(stack.top());
         INT_ASSERT(block);
         block->blockTag = BLOCK_TYPE;
@@ -6111,6 +6113,7 @@ new_Expr(const char* format, va_list vl) {
       stack.pop();
       INT_ASSERT(expr);
       INT_ASSERT(stack.size() > 0);
+      // If you failed the previous assert, there was nothing before the ','
       CallExpr* call = toCallExpr(stack.top());
       INT_ASSERT(call);
       call->insertAtTail(expr);
@@ -6119,6 +6122,8 @@ new_Expr(const char* format, va_list vl) {
       stack.pop();
       INT_ASSERT(expr);
       INT_ASSERT(stack.size() > 0);
+      // If you failed the previous assert, this closing parentheses is
+      // unmatched
       CallExpr* call = toCallExpr(stack.top());
       INT_ASSERT(call);
       call->insertAtTail(expr);
@@ -6129,6 +6134,7 @@ new_Expr(const char* format, va_list vl) {
       stack.pop();
       INT_ASSERT(expr);
       INT_ASSERT(stack.size() > 0);
+      // If you failed the previous assert, there was nothing before the ';'
       BlockStmt* block = toBlockStmt(stack.top());
       INT_ASSERT(block);
       block->insertAtTail(expr);
@@ -6137,6 +6143,8 @@ new_Expr(const char* format, va_list vl) {
       stack.pop();
       INT_ASSERT(expr);
       INT_ASSERT(stack.size() > 0);
+      // If you failed the previous assert, this closing curly bracket is
+      // unmatched
       BlockStmt* block = toBlockStmt(stack.top());
       INT_ASSERT(block);
       block->insertAtTail(expr);

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -6070,9 +6070,9 @@ new_Expr(const char* format, va_list vl) {
       const char* str = asubstr(&format[i], &format[i+n]);
       i += n-1;
       if (!strcmp(str, "TYPE")) {
-        INT_ASSERT(stack.size() > 0);
-        // You've reached here because you didn't provide "{ TYPE ..." for a
-        // block type statement.
+        if (stack.size() == 0) {
+          INT_FATAL("You neglected to provide a \"{ TYPE ...\" for a block type statement.");
+        } // Accessing the stack would result in unspecified behavior
         BlockStmt* block = toBlockStmt(stack.top());
         INT_ASSERT(block);
         block->blockTag = BLOCK_TYPE;
@@ -6112,8 +6112,9 @@ new_Expr(const char* format, va_list vl) {
       Expr* expr = stack.top();
       stack.pop();
       INT_ASSERT(expr);
-      INT_ASSERT(stack.size() > 0);
-      // If you failed the previous assert, there was nothing before the ','
+      if (stack.size() == 0) {
+        INT_FATAL("There was nothing before the \',\'");
+      } // Accessing the stack would result in unspecified behavior
       CallExpr* call = toCallExpr(stack.top());
       INT_ASSERT(call);
       call->insertAtTail(expr);
@@ -6121,9 +6122,9 @@ new_Expr(const char* format, va_list vl) {
       Expr* expr = stack.top();
       stack.pop();
       INT_ASSERT(expr);
-      INT_ASSERT(stack.size() > 0);
-      // If you failed the previous assert, this closing parentheses is
-      // unmatched
+      if (stack.size() == 0) {
+        INT_FATAL("This closing parentheses is unmatched");
+      } // Accessing the stack would result in unspecified behavior
       CallExpr* call = toCallExpr(stack.top());
       INT_ASSERT(call);
       call->insertAtTail(expr);
@@ -6133,8 +6134,9 @@ new_Expr(const char* format, va_list vl) {
       Expr* expr = stack.top();
       stack.pop();
       INT_ASSERT(expr);
-      INT_ASSERT(stack.size() > 0);
-      // If you failed the previous assert, there was nothing before the ';'
+      if (stack.size() == 0) {
+        INT_FATAL("There was nothing before the \';\'");
+      } // Accessing the stack would result in unspecified behavior
       BlockStmt* block = toBlockStmt(stack.top());
       INT_ASSERT(block);
       block->insertAtTail(expr);
@@ -6142,9 +6144,9 @@ new_Expr(const char* format, va_list vl) {
       Expr* expr = stack.top();
       stack.pop();
       INT_ASSERT(expr);
-      INT_ASSERT(stack.size() > 0);
-      // If you failed the previous assert, this closing curly bracket is
-      // unmatched
+      if (stack.size() == 0) {
+        INT_FATAL("This closing curly bracket is unmatched");
+      } // Accessing the stack would result in unspecified behavior
       BlockStmt* block = toBlockStmt(stack.top());
       INT_ASSERT(block);
       block->insertAtTail(expr);

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -42,6 +42,7 @@
 #include <cstring>
 #include <inttypes.h>
 #include <ostream>
+#include <stack>
 
 class FnSymbol;
 
@@ -6059,7 +6060,7 @@ new_Expr(const char* format, ...) {
 
 Expr*
 new_Expr(const char* format, va_list vl) {
-  Vec<Expr*> stack;
+  std::stack<Expr*> stack;
 
   for (int i = 0; format[i] != '\0'; i++) {
     if (isIdentifierChar(format[i])) {
@@ -6069,11 +6070,11 @@ new_Expr(const char* format, va_list vl) {
       const char* str = asubstr(&format[i], &format[i+n]);
       i += n-1;
       if (!strcmp(str, "TYPE")) {
-        BlockStmt* block = toBlockStmt(stack.v[stack.n-1]);
+        BlockStmt* block = toBlockStmt(stack.top());
         INT_ASSERT(block);
         block->blockTag = BLOCK_TYPE;
       } else {
-        stack.add(new UnresolvedSymExpr(str));
+        stack.push(new UnresolvedSymExpr(str));
       }
     } else if (format[i] == '\'') {
       int n = 1;
@@ -6084,54 +6085,59 @@ new_Expr(const char* format, va_list vl) {
       if (format[i+1] == '(') {
         PrimitiveOp* prim = primitives_map.get(str);
         INT_ASSERT(prim);
-        stack.add(new CallExpr(prim));
+        stack.push(new CallExpr(prim));
         i++;
       } else {
-        stack.add(new SymExpr(new_StringSymbol(str)));
+        stack.push(new SymExpr(new_StringSymbol(str)));
       }
     } else if (format[i] == '%') {
       i++;
       if (format[i] == 'S')
-        stack.add(new SymExpr(va_arg(vl, Symbol*)));
+        stack.push(new SymExpr(va_arg(vl, Symbol*)));
       else if (format[i] == 'E')
-        stack.add(va_arg(vl, Expr*));
+        stack.push(va_arg(vl, Expr*));
       else
         INT_FATAL("unknown format specifier in new_Expr");
     } else if (format[i] == '(') {
-      Expr* expr = stack.pop();
+      Expr* expr = stack.top();
+      stack.pop();
       INT_ASSERT(expr);
-      stack.add(new CallExpr(expr));
+      stack.push(new CallExpr(expr));
       if (format[i+1] == ')') // handle empty calls
         i++;
     } else if (format[i] == ',') {
-      Expr* expr = stack.pop();
+      Expr* expr = stack.top();
+      stack.pop();
       INT_ASSERT(expr);
-      CallExpr* call = toCallExpr(stack.v[stack.n-1]);
+      CallExpr* call = toCallExpr(stack.top());
       INT_ASSERT(call);
       call->insertAtTail(expr);
     } else if (format[i] == ')') {
-      Expr* expr = stack.pop();
+      Expr* expr = stack.top();
+      stack.pop();
       INT_ASSERT(expr);
-      CallExpr* call = toCallExpr(stack.v[stack.n-1]);
+      CallExpr* call = toCallExpr(stack.top());
       INT_ASSERT(call);
       call->insertAtTail(expr);
     } else if (format[i] == '{') {
-      stack.add(new BlockStmt());
+      stack.push(new BlockStmt());
     } else if (format[i] == ';') {
-      Expr* expr = stack.pop();
+      Expr* expr = stack.top();
+      stack.pop();
       INT_ASSERT(expr);
-      BlockStmt* block = toBlockStmt(stack.v[stack.n-1]);
+      BlockStmt* block = toBlockStmt(stack.top());
       INT_ASSERT(block);
       block->insertAtTail(expr);
     } else if (format[i] == '}') {
-      Expr* expr = stack.pop();
+      Expr* expr = stack.top();
+      stack.pop();
       INT_ASSERT(expr);
-      BlockStmt* block = toBlockStmt(stack.v[stack.n-1]);
+      BlockStmt* block = toBlockStmt(stack.top());
       INT_ASSERT(block);
       block->insertAtTail(expr);
     }
   }
 
-  INT_ASSERT(stack.n == 1);
-  return stack.v[0];
+  INT_ASSERT(stack.size() == 1);
+  return stack.top();
 }


### PR DESCRIPTION
First, I made new_Expr switch to using std::stack instead of our Vec class

The original variable was only in use in this function and was so obviously a
stack, it was named "stack".  Coverity had complained about this function, so
I figured I'd clean it up while I was here.

I highly doubt that using our Vec class was why Coverity was complaining about
new_Expr (though the switch is a good thing to do anyways).  Instead, I believe
the complaint to be due to not understanding our calls to new_Expr() - namely,
our use should never result in certain characters being encountered first and
so it ought to be safe to look at the top of the stack when those characters
are encountered.  Such failure modes ought to be detected by parsing, or only
introduced by developers in later passes - to that end I'm inserting some
asserts here to validate that assumption.

If someone encounters these asserts, either they are doing something very wrong
or the designer of new_Expr did something wrong. In either case, we would obtain
undefined behavior from the stack otherwise - instead of a mysterious or hidden
error, it will now be out in the open.  std/ testing did not reveal any hidden errors of
this form, so I've added comments in case someone else runs into them, but am
fairly confident these asserts won't cause problems in the current state of things.