### PR TITLE
Wrap some launcher errors to get better test reporting

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1717,16 +1717,19 @@ for testname in testsrc:
                     output = p.communicate()[0]
                     status = p.returncode
 
-                    launcherTimeout = False
-                    if re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None:
-                        launcherTimeout = True
-                    if re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None:
-                        launcherTimeout = True
-
-                    if launcherTimeout:
+                    launcherError = ''
+                    if re.search('slurmstepd: Munge decode failed: Expired credential', output, re.IGNORECASE) != None:
+                        launcherError = 'Jira 18 -- Expired slurm credential for'
+                    elif re.search('output file from job .* does not exist', output, re.IGNORECASE) != None:
+                        launcherError = 'Jira 17 -- Missing output file for'
+                    elif (re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None or
+                          re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None):
                         exectimeout = True
-                        sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
-                                        (futuretest, localdir, test_filename))
+                        launcherError = 'Timed out executing program'
+
+                    if launcherError != '':
+                        sys.stdout.write('%s[Error: %s %s/%s'%
+                                        (futuretest, launcherError, localdir, test_filename))
                         printTestVariation(compoptsnum, compoptslist,
                                            execoptsnum, execoptslist);
                         sys.stdout.write(']\n')

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1696,6 +1696,7 @@ for testname in testsrc:
             #
             for count in xrange(numTrials):
                 exectimeout = False  # 'exectimeout' is specific to one trial of one execopt setting
+                launcher_error = ''  # used to suppress output/timeout errors that are the result of a launcher error 
                 sys.stdout.write('[Executing program %s %s'%(cmd, ' '.join(args)))
                 if redirectin:
                     sys.stdout.write(' < %s'%(redirectin))
@@ -1717,19 +1718,19 @@ for testname in testsrc:
                     output = p.communicate()[0]
                     status = p.returncode
 
-                    launcherError = ''
+                    launcher_error = ''
                     if re.search('slurmstepd: Munge decode failed: Expired credential', output, re.IGNORECASE) != None:
-                        launcherError = 'Jira 18 -- Expired slurm credential for'
+                        launcher_error = 'Jira 18 -- Expired slurm credential for'
                     elif re.search('output file from job .* does not exist', output, re.IGNORECASE) != None:
-                        launcherError = 'Jira 17 -- Missing output file for'
+                        launcher_error = 'Jira 17 -- Missing output file for'
                     elif (re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None or
                           re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None):
                         exectimeout = True
-                        launcherError = 'Timed out executing program'
+                        launcher_error = 'Timed out executing program'
 
-                    if launcherError != '':
+                    if launcher_error:
                         sys.stdout.write('%s[Error: %s %s/%s'%
-                                        (futuretest, launcherError, localdir, test_filename))
+                                        (futuretest, launcher_error, localdir, test_filename))
                         printTestVariation(compoptsnum, compoptslist,
                                            execoptsnum, execoptslist);
                         sys.stdout.write(']\n')
@@ -1837,7 +1838,7 @@ for testname in testsrc:
                     execlogfile.write(pre_exec_output)
                     execlogfile.write(output)
 
-                if not exectimeout:
+                if not exectimeout and not launcher_error:
                     if systemPrediff:
                         sys.stdout.write('[Executing system-wide prediff]\n')
                         sys.stdout.flush()
@@ -1959,7 +1960,7 @@ for testname in testsrc:
                     sys.stdout.flush()
 
                     status = p.returncode
-                    if not exectimeout:
+                    if not exectimeout and not launcher_error:
                         if status == 0:
                             os.unlink(execlog)
                             sys.stdout.write('[Success')

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1696,7 +1696,7 @@ for testname in testsrc:
             #
             for count in xrange(numTrials):
                 exectimeout = False  # 'exectimeout' is specific to one trial of one execopt setting
-                launcher_error = ''  # used to suppress output/timeout errors that are the result of a launcher error 
+                launcher_error = ''  # used to suppress output/timeout errors whose root cause is a launcher error
                 sys.stdout.write('[Executing program %s %s'%(cmd, ' '.join(args)))
                 if redirectin:
                     sys.stdout.write(' < %s'%(redirectin))
@@ -1718,7 +1718,6 @@ for testname in testsrc:
                     output = p.communicate()[0]
                     status = p.returncode
 
-                    launcher_error = ''
                     if re.search('slurmstepd: Munge decode failed: Expired credential', output, re.IGNORECASE) != None:
                         launcher_error = 'Jira 18 -- Expired slurm credential for'
                     elif re.search('output file from job .* does not exist', output, re.IGNORECASE) != None:


### PR DESCRIPTION
We have two common errors that come from our launchers. One is an aprun missing
output file (Jira 17) and the other is a slurm expired credential (Jira 18).
The first first shows up as an error matching output and the second shows up as
a timeout. These failure modes force you to dig through the logs to see what's
actually going on. Since these are known errors that are being investigated
(but might take a pretty long time to solve) this catches those errors and
prints out a meaningful error message that makes it obvious what's going on
without having to go to the log.

Ideally we'd like to be able to get rid of these errors, but I have no idea
what the root cause it yet.

This refactors the previous timeout reporting for launchers and adds checks for
these two specific errors. We then silence any additional errors if either of
these errors is reported. That way we don't get duplicate error message for the
same test as that would be confusing.

I tested this by modifying hello.chpl to print out the error messages the
launcher would spew and made sure we get the report we want from start_test.

For the slurm expired credential we used to get a timeout and now get:
"[Error: Jira 18 -- Expired slurm credential for release/examples/hello]"

For the missing output we used to get an error matching output and now get:
"[Error: Jira 17 -- Missing output file for release/examples/hello]"

And note that we only get a single error message, we don't also get a timeout
and/or error matching program output error for these.