### PR TITLE
bug fixes to do with memory

### DIFF
--- a/runtime/make/Makefile.runtime.mem-dlmalloc
+++ b/runtime/make/Makefile.runtime.mem-dlmalloc
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-RUNTIME_DEFS += -DUSE_LOCKS -DONLY_MSPACES -DMSPACES
+# dlmalloc mallinfo functions cause warnings when headers
+# are used from C++ (e.g. re2-interface.cc)
+RUNTIME_DEFS += -DUSE_LOCKS -DONLY_MSPACES -DMSPACES -DNO_MALLINFO
 RUNTIME_INCLS += -I$(DLMALLOC_INCLUDE_DIR)
 


### PR DESCRIPTION
This patch fixes two bugs:
1) -lchplmalloc wasn't working with TASKS=qthreads
2) dlmalloc wouldn't build with CHPL_REGEXP=re2 on my GCC

I view the changes as trivial, but @gbtitus can review if he wants to.