### PR TITLE
Add suppressions for pgi negative 0.0 floating point bugs

### DIFF
--- a/test/types/complex/bradc/negateimaginary3.suppressif
+++ b/test/types/complex/bradc/negateimaginary3.suppressif
@@ -1,0 +1,3 @@
+# pgi compiler bug, see jira issue 48
+CHPL_TARGET_COMPILER==pgi
+CHPL_TARGET_COMPILER==cray-prgenv-pgi

--- a/test/types/complex/bradc/negativeimaginaryliteral.suppressif
+++ b/test/types/complex/bradc/negativeimaginaryliteral.suppressif
@@ -1,0 +1,3 @@
+# pgi compiler bug, see jira issue 48
+CHPL_TARGET_COMPILER==pgi
+CHPL_TARGET_COMPILER==cray-prgenv-pgi

--- a/test/types/file/bradc/scalar/floatcomplexexceptions.suppressif
+++ b/test/types/file/bradc/scalar/floatcomplexexceptions.suppressif
@@ -1,0 +1,3 @@
+# pgi compiler bug, see jira issue 48
+CHPL_TARGET_COMPILER==pgi
+CHPL_TARGET_COMPILER==cray-prgenv-pgi


### PR DESCRIPTION
These regressions under pgi are the result of a bug in the pgi compiler. This
suppresses them so they don't show up in our nightly mails, but we will still
find out when they are resolved.

See JIRA issue 48 for more info (https://chapel.atlassian.net/browse/CHAPEL-48)