### PR TITLE
Skip the vectorization reporting tests for llvm

### DIFF
--- a/test/performance/vectorization/vectorPragmas/SKIPIF
+++ b/test/performance/vectorization/vectorPragmas/SKIPIF
@@ -1,3 +1,6 @@
 # These tests require that the --inline-iterators, --inline, --vectorize, and
 # --optimize-loop-iterators flags are thrown. (Might require a few other too.)
 COMPOPTS <= --baseline
+
+# The current reporting mechanism reports what we emit to the C backend only
+COMPOPTS <= --llvm


### PR DESCRIPTION
The current vectorization pragmas are only emitted to the c backend.