### PR TITLE
Do not submit an email address when uploading a build to Coverity.

### DIFF
--- a/util/devel/coverity/submit_build.bash
+++ b/util/devel/coverity/submit_build.bash
@@ -42,9 +42,10 @@ $COV_BUILD_PREFIX/cov-build --dir cov-int make
 # Create compressed tarball.
 tar --create --bzip2 --verbose --file chapel.tar.bz2 cov-int
 
+echo Note: omitting "'--form email=$COV_SCAN_EMAIL'"
+
 curl --verbose --silent \
     --form token="${COV_SCAN_TOKEN}" \
-    --form email="${COV_SCAN_EMAIL}" \
     --form file=@chapel.tar.bz2 \
     --form version="${version}" \
     --form description="${description}" \


### PR DESCRIPTION
It seems like Coverity sends only a "heartbeat" email to that address.
See an example below.

Currently we do not wish to receive such an email.
When needed, we can check Jenkins and Coverity instead.

So I am trying this change. If Coverity complains about the lack
of the 'email' field, we can revert this.

Sample email:

Date: .....
From: <scan-admin@coverity.com>
To: <the email address provided>
Subject: Coverity Scan: Analysis completed for chapel

    Your request for analysis of chapel has been completed successfully.
    The results are available at https://scan.coverity.com/projects/1222

    Analysis Summary:
       New defects found: 0
       Defects eliminated: 3