### PR TITLE
Fix text file busy

### DIFF
--- a/runtime/etc/Makefile.exe
+++ b/runtime/etc/Makefile.exe
@@ -34,6 +34,7 @@ ifneq ($(CHPL_MAKE_LAUNCHER),none)
 	$(MAKE) -f $(CHPL_MAKE_HOME)/runtime/etc/Makefile.launcher all CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) TMPBINNAME=$(TMPBINNAME) BINNAME=$(BINNAME) TMPDIRNAME=$(TMPDIRNAME)
 endif
 ifneq ($(TMPBINNAME),$(BINNAME))
+	rm $(BINNAME)
 	cp -p $(TMPBINNAME) $(BINNAME)
 	rm $(TMPBINNAME)
 endif

--- a/runtime/etc/Makefile.exe
+++ b/runtime/etc/Makefile.exe
@@ -34,7 +34,7 @@ ifneq ($(CHPL_MAKE_LAUNCHER),none)
 	$(MAKE) -f $(CHPL_MAKE_HOME)/runtime/etc/Makefile.launcher all CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) TMPBINNAME=$(TMPBINNAME) BINNAME=$(BINNAME) TMPDIRNAME=$(TMPDIRNAME)
 endif
 ifneq ($(TMPBINNAME),$(BINNAME))
-	rm $(BINNAME)
+	rm -f $(BINNAME)
 	cp -p $(TMPBINNAME) $(BINNAME)
 	rm $(TMPBINNAME)
 endif

--- a/runtime/etc/Makefile.launcher
+++ b/runtime/etc/Makefile.launcher
@@ -34,7 +34,7 @@ LAUNCHER_SRC_NAME = $(TMPDIRNAME)/launcher_support.c
 REAL_BINARY_NAME = $(BINNAME:%$(EXE_SUFFIX)=%)$(REAL_SUFFIX)
 
 all: FORCE
-	rm $(REAL_BINARY_NAME)
+	rm -f $(REAL_BINARY_NAME)
 	cp $(TMPBINNAME) $(REAL_BINARY_NAME)
 	rm $(TMPBINNAME)
 	echo "#include \"chplcgfns.h\"" > $(LAUNCHER_SRC_NAME)

--- a/runtime/etc/Makefile.launcher
+++ b/runtime/etc/Makefile.launcher
@@ -34,6 +34,7 @@ LAUNCHER_SRC_NAME = $(TMPDIRNAME)/launcher_support.c
 REAL_BINARY_NAME = $(BINNAME:%$(EXE_SUFFIX)=%)$(REAL_SUFFIX)
 
 all: FORCE
+	rm $(REAL_BINARY_NAME)
 	cp $(TMPBINNAME) $(REAL_BINARY_NAME)
 	rm $(TMPBINNAME)
 	echo "#include \"chplcgfns.h\"" > $(LAUNCHER_SRC_NAME)


### PR DESCRIPTION
When running a program in GDB, if you recompile it with Chapel, you get an
error like:
 cp: cannot create regular file `a.out': Text file busy

Removing the file and then compiling it solves the problem. GDB finds that the
program changed and reloads it:
 `a.out' has changed; re-reading symbols.

Also, on some systems using a launcher, I get "Text file busy" when compiling a
Chapel program from my home directory if that program was recently run.

Steps to reproduce the GDB issue:
 $ chpl hello.chpl
 $ gdb ./a.out
 (gdb) break main
 (gdb) run
 (gdb) Control-Z (ie suspend gdb)
 $ chpl hello.chpl
 cp: cannot create regular file `a.out': Text file busy

This patch just rm's the destination of the copy before performing the copy.
That solves the problem in both of these cases. Removing the destination file
is not a big deal since we'll replace the file anyway.

