### PR TITLE
Fix the gasnet regressions caused by closing sync and single leaks

### DIFF
--- a/test/multilocale/bradc/needMultiLocales/remoteReal.chpl
+++ b/test/multilocale/bradc/needMultiLocales/remoteReal.chpl
@@ -18,11 +18,13 @@ proc main() {
   var s2: real;
   var flag2: sync bool;
 
-  s2 = 1.0;
-  on Locales(1) do begin with (ref s2) {
-    const tmp = flag2;
-    printf("%s\n", ("s2 is: " + s2).c_str());
+  sync {
+    s2 = 1.0;
+    on Locales(1) do begin with (ref s2) {
+        const tmp = flag2;
+        printf("%s\n", ("s2 is: " + s2).c_str());
+      }
+    s2 = 2.0;
+    flag2 = true;
   }
-  s2 = 2.0;
-  flag2 = true;
 }

--- a/test/multilocale/bradc/needMultiLocales/remoteString.chpl
+++ b/test/multilocale/bradc/needMultiLocales/remoteString.chpl
@@ -18,11 +18,13 @@ proc main() {
   var s2: string;
   var flag2: sync bool;
 
-  s2 = "foo";
-  on Locales(1) do begin with (ref s2) {
-    const tmp = flag2;
-    printf("%s\n", ("s2 is: " + s2).c_str());
+  sync {
+    s2 = "foo";
+    on Locales(1) do begin with (ref s2) {
+        const tmp = flag2;
+        printf("%s\n", ("s2 is: " + s2).c_str());
+      }
+    s2 = "boohoo";
+    flag2 = true;
   }
-  s2 = "boohoo";
-  flag2 = true;
 }

--- a/test/multilocale/deitz/needMultiLocales/test_termination2.chpl
+++ b/test/multilocale/deitz/needMultiLocales/test_termination2.chpl
@@ -2,19 +2,21 @@ use Time;
 
 proc main {
   var s1, s2: sync bool;
-  on Locales(1) {
-    begin {
-      s1;
-      on Locales(0) {
-        begin {
-          s2;
-          writeln("executing on locale ", here.id);
+  sync {
+    on Locales(1) {
+      begin {
+        s1;
+        on Locales(0) {
+          begin {
+            s2;
+            writeln("executing on locale ", here.id);
+          }
         }
+        writeln("executing on locale ", here.id);
+        s2 = true;
       }
-      writeln("executing on locale ", here.id);
-      s2 = true;
     }
+    writeln("executing on locale ", here.id);
+    s1 = true;
   }
-  writeln("executing on locale ", here.id);
-  s1 = true;
 }


### PR DESCRIPTION
These tests were encountering errors similar to what I fixed in #1955, and the
fix was the same.  Basically, a sync would sometimes go out of scope and be
destroyed before we were done using it.  This patch inserts sync blocks
around the usage of the syncs to prevent this error.