### PR TITLE
Replace use of our Vec class with use of std::vector in codegen of ModuleSymbols

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -44,6 +44,7 @@
 #include "AstVisitor.h"
 #include "CollapseBlocks.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <inttypes.h>
 #include <iostream>
@@ -2573,7 +2574,7 @@ void ModuleSymbol::codegenDef() {
   info->cStatements.clear();
   info->cLocalDecls.clear();
 
-  Vec<FnSymbol*> fns;
+  std::vector<FnSymbol*> fns;
 
   for_alist(expr, block->body) {
     if (DefExpr* def = toDefExpr(expr))
@@ -2583,13 +2584,13 @@ void ModuleSymbol::codegenDef() {
             fn->hasFlag(FLAG_FUNCTION_PROTOTYPE))
           continue;
 
-        fns.add(fn);
+        fns.push_back(fn);
       }
   }
 
-  qsort(fns.v, fns.n, sizeof(fns.v[0]), compareLineno);
+  std::sort(fns.begin(), fns.end(), compareLineno);
 
-  forv_Vec(FnSymbol, fn, fns) {
+  for_vector(FnSymbol, fn, fns) {
     fn->codegenDef();
   }
 

--- a/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
+++ b/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
@@ -1,2 +1,2 @@
-Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:15
 Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:10
+Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:15


### PR DESCRIPTION
Coverity was complaining about sending the Vec's n field to qsort because it
was possible the n field was a null pointer.  Since the Vec in question is a
local variable, I switched it to a std::vector and sent it to std::sort instead
of qsort (because the internet told me it that was a better sort to use
anyways).  Using vector's begin() and end() iterators also gets rid of the
complaint Coverity had, because the iterators won't dereference if there is
nothing in the vector.