### PR TITLE
Lower number of tasks to avoid verification error for NPB IS

### DIFF
--- a/test/npb/is/mcahir/intsort.mtml.perfexecopts
+++ b/test/npb/is/mcahir/intsort.mtml.perfexecopts
@@ -1,4 +1,4 @@
---probClass=S # intsort.S
+--probClass=S --dataParTasksPerLocale=2 # intsort.S
 #--probClass=W # intsort.W
 #--probClass=A # intsort.A
 #--probClass=B # intsort.B


### PR DESCRIPTION
We have observed this test sporadically failing for --no-local performance testing during verification. Reducing the number of tasks appears to resolve this issue.

OK'd by @bradcray 