### PR TITLE
Remove --no-local perf variants of lulesh and suppress for cce

### DIFF
--- a/test/release/examples/benchmarks/lulesh/lulesh.block-dense.perfkeys
+++ b/test/release/examples/benchmarks/lulesh/lulesh.block-dense.perfkeys
@@ -1,3 +1,0 @@
-Total Time:
-Number of cycles:
-verify:3: Number of cycles: 529

--- a/test/release/examples/benchmarks/lulesh/lulesh.block.perfkeys
+++ b/test/release/examples/benchmarks/lulesh/lulesh.block.perfkeys
@@ -1,3 +1,0 @@
-Total Time:
-Number of cycles:
-verify:3: Number of cycles: 529

--- a/test/release/examples/benchmarks/lulesh/lulesh.graph
+++ b/test/release/examples/benchmarks/lulesh/lulesh.graph
@@ -1,5 +1,5 @@
-perfkeys: Total Time:, Total Time:, Total Time:, Total Time:
-graphkeys: sparse (local), sparse (no-local), dense (local), dense (no-local)
-files: lulesh.default.dat, lulesh.block.dat, lulesh.default-dense.dat, lulesh.block-dense.dat
+perfkeys: Total Time:, Total Time:
+graphkeys: sparse (local), dense (local)
+files: lulesh.default.dat, lulesh.default-dense.dat
 graphtitle: LULESH (release)
 ylabel: Time (seconds)

--- a/test/release/examples/benchmarks/lulesh/lulesh.perfcompopts
+++ b/test/release/examples/benchmarks/lulesh/lulesh.perfcompopts
@@ -1,4 +1,2 @@
 --fast # lulesh.default.perfkeys
--suseBlockDist --no-local  # lulesh.block.perfkeys
 -suseSparseMaterials=false    # lulesh.default-dense.perfkeys
--suseBlockDist --no-local -suseSparseMaterials=false    # lulesh.block-dense.perfkeys

--- a/test/release/examples/benchmarks/lulesh/lulesh.suppressif
+++ b/test/release/examples/benchmarks/lulesh/lulesh.suppressif
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# cray compiler bug (should be fixed w/ 8.4), see JIRA issue 16
+
+if [ "$CHPL_TEST_PERF" = "on" ] && [ "$CHPL_TARGET_COMPILER" = "cray-prgenv-cray" ]
+then
+  echo "True"
+else
+  echo "False"
+fi


### PR DESCRIPTION
We now have --no-local performance testing running against the entire
performance suite,  so it's redundant and unnecessary to do no-local testing
normally. This does mean we "lose" the history for the no-local runs, but we're
not too worried about that. The old data will still be in the .dat file it just
won't be graphed nightly.

There is also a cce bug (that will be fixed with 8.4) that causes the local
versions of this test to fail. The --no-local cases passed, so we couldn't
suppress this test with those still there. Since this removes the --no-local
variations, we can now suppress the failing --local versions.