### PR TITLE
Skip returnSync future with valgrind

### DIFF
--- a/test/parallel/sync/diten/returnSync.future
+++ b/test/parallel/sync/diten/returnSync.future
@@ -5,4 +5,4 @@ syncs problematic, especially since copying syncs is not recommended.  Should
 it be possible to return a sync which would otherwise be cleaned up?
 
 When resolving this future, please remove the skipif and test with
-TASKS=qthreads
+TASKS=qthreads, as well as fifo+valgrind

--- a/test/parallel/sync/diten/returnSync.skipif
+++ b/test/parallel/sync/diten/returnSync.skipif
@@ -1,3 +1,4 @@
 # The most interesting error message occurs with CHPL_TASKS=fifo.
-# Please run with qthreads when this error is resolved
+# Please run with valgrind, and with qthreads when this error is resolved
 CHPL_TASKS != fifo
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Valgrind is accurately complaining, but the problem is visible with fifo as
well and creates output that is more easily matched against a .bad file under
those circumstances.  To that end, skip the future with valgrind for now but
leave a note in the future file to test over valgrind before removing the skipif