### PR TITLE
Revert Do not submit an email address when uploading a build to Coverity

### DIFF
--- a/util/devel/coverity/submit_build.bash
+++ b/util/devel/coverity/submit_build.bash
@@ -42,10 +42,9 @@ $COV_BUILD_PREFIX/cov-build --dir cov-int make
 # Create compressed tarball.
 tar --create --bzip2 --verbose --file chapel.tar.bz2 cov-int
 
-echo Note: omitting "'--form email=$COV_SCAN_EMAIL'"
-
 curl --verbose --silent \
     --form token="${COV_SCAN_TOKEN}" \
+    --form email="${COV_SCAN_EMAIL}" \
     --form file=@chapel.tar.bz2 \
     --form version="${version}" \
     --form description="${description}" \


### PR DESCRIPTION
Reverts chapel-lang/chapel#1985

The two days that we ran with this, coverity has been getting back to us with "HTTP/1.1 404 Not Found"
and (I think) curl says "HTTP error before end of send, stop sending".

