### PR TITLE
Add exit() as program terminator; remove chpl_error(), chpl_internal_error().

### DIFF
--- a/util/devel/coverity/coverity_model.cpp
+++ b/util/devel/coverity/coverity_model.cpp
@@ -29,14 +29,9 @@ void setupError(const char *filename, int lineno, int tag) {
 // runtime
 //
 
-// chpl_error() ends execution
-// Note: this signature doesn't match the real one precisely, but it's
-//       close enough.
-void chpl_error(const char* message, int lineno, const char* filename) {
-  __coverity_panic__();
-}
-
-// chpl_internal_error() ends execution
-void chpl_internal_error(const char* message) {
+//
+// exit() ends execution
+//
+void exit(int status) {
   __coverity_panic__();
 }


### PR DESCRIPTION
I had thought Coverity would assume that exit() in C code would halt the
program, but indications are that it does not.  If it did, then Coverity
would see that chpl_error() and chpl_internal_error() both caused
program termination, because both call chpl_exit_any(), which calls
chpl_exit_common(), which calls exit().  Coverity did not seem to be
picking this up, and it also failed to respond to the modelling file
telling it that chpl_error() and chpl_internal_error() caused a halt.
I've found an indication on the web that Coverity does not by default
assume that exit() cause a halt, so here I'm saying so explicitly.