### PR TITLE
Fix array and domain double deletion regressions

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -716,10 +716,19 @@ proc BlockCyclicArr.setup() {
 }
 
 proc BlockCyclicArr.~BlockCyclicArr() {
+  // Delete the locArr elements.
   coforall localeIdx in dom.dist.targetLocDom {
     on locArr(localeIdx) {
       delete locArr(localeIdx);
     }
+  }
+
+  // Release my reference to the distributed domain.
+  on dom {
+    local dom.remove_arr(this);
+    var cnt = dom.destroyDom();
+    if cnt == 0 then
+      delete dom;
   }
 }
 

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -518,10 +518,16 @@ proc BlockCyclicDom.setup() {
 }
 
 proc BlockCyclicDom.~BlockCyclicDom() {
+  // Free the locDoms array.
   coforall localeIdx in dist.targetLocDom do
     if locDoms(localeIdx) != nil then
       on locDoms(localeIdx) do
         delete locDoms(localeIdx);
+
+  // Release our reference to the distribution.
+  var cnt = dist.decRefCount();
+  if cnt == 0 then
+    delete dist;
 }
 
 proc BlockCyclicDom.enumerateBlocks() {

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -784,6 +784,9 @@ proc BlockDom.~BlockDom() {
     on locDoms(localeIdx) do
       delete locDoms(localeIdx);
   }
+  var cnt = dist.decRefCount();
+  if cnt==0 then
+    delete dist;
 }
 
 proc BlockDom.dsiMember(i) {

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -885,10 +885,19 @@ proc BlockArr.setup() {
 }
 
 proc BlockArr.~BlockArr() {
+  // Delete the locArr elements.
   coforall localeIdx in dom.dist.targetLocDom {
     on locArr(localeIdx) {
       delete locArr(localeIdx);
     }
+  }
+
+  // Release my reference to the distributed domain.
+  on dom {
+    local dom.remove_arr(this);
+    var cnt = dom.destroyDom();
+    if cnt == 0 then
+      delete dom;
   }
 }
 

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -416,6 +416,9 @@ proc CyclicDom.~CyclicDom() {
       on locDoms(localeIdx) do
         delete locDoms(localeIdx);
   }
+  var cnt = dist.decRefCount();
+  if cnt==0 then
+    delete dist;
 }
 
 proc CyclicDom.dsiBuildArray(type eltType) {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -799,10 +799,19 @@ proc CyclicArr.setup() {
 }
 
 proc CyclicArr.~CyclicArr() {
+  // Delete the locArr elements
   coforall localeIdx in dom.dist.targetLocDom {
     on locArr(localeIdx) {
       delete locArr(localeIdx);
     }
+  }
+
+  // Release my reference to the distributed domain.
+  on dom {
+    local dom.remove_arr(this);
+    var cnt = dom.destroyDom();
+    if cnt == 0 then
+      delete dom;
   }
 }
 

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -313,15 +313,6 @@ module ChapelDistribution {
           dsiDestroyData();
         }
       }
-      if cnt == 0 {
-          var dom = dsiGetBaseDom();
-          on dom {
-            local dom.remove_arr(this);
-            var cnt = dom.destroyDom();
-            if cnt == 0 then
-              delete dom;
-          }
-      }
       return cnt;
     }
   

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -32,7 +32,7 @@ module ChapelDistribution {
     // will use explicit processor atomics, even when network
     // atomics are available
     var _distCnt: atomic_refcnt; // distribution reference count
-    var _doms: list(BaseDom);   // domains declared over this domain
+    var _doms: list(BaseDom);   // domains declared over this distribution
     var _domsLock: atomicflag;  //   and lock for concurrent access
   
     pragma "dont disable remote value forwarding"
@@ -145,18 +145,9 @@ module ChapelDistribution {
     proc destroyDom(): int {
       compilerAssert(!noRefCount);
       var cnt = decRefCount();
-      if cnt == 0 && dsiLinksDistribution() {
-          var dist = dsiMyDist();
-          on dist {
-            local dist.remove_dom(this);
-            var cnt = dist.destroyDist();
-            if cnt == 0 then
-              delete dist;
-          }
-      }
       return cnt;
     }
-  
+
     inline proc remove_arr(x) {
       on this {
         _lock_arrs();


### PR DESCRIPTION
This fixes most (96) of the regressions that surfaced when I did a full valgrind test run.

The domain read-after-free errors were due to the distribution associated with a distributed domain being deleted after the domain reference count reached zero but before the distributed domain's destructor was entered.  The destructor uses the distributed domains' distribution to destroy elements of the locDom array.  But since the distribution has already been deleted, valgrind complains.

The array read-after-free error is similar.  After the ref count on a distributed array goes to zero, the corresponding domain is deleted.  But the same domain is used later in the distributed array's destructor to destroy elements of the locArr array.

The cure in both cases was to remove the early deletion code (from BaseDom.destroyDom() and BaseArr.destroyArr(), respectively).  Code for destroying the distribution was placed in the distributed doms' destructors; code for destroying the distributed dom was placed in the distributed arrays' destructors.

A few new leaks were introduced as a result of this change.  These will be addressed in a separate patch.