### PR TITLE
Fix the regression in types/string/sungeun/c_string/substr.good.

### DIFF
--- a/test/types/string/sungeun/c_string/substr.good
+++ b/test/types/string/sungeun/c_string/substr.good
@@ -1,0 +1,1 @@
+substr.chpl:5: error: halt reached - index out of bounds of string


### PR DESCRIPTION
This was a matter of specifying the expected behavior and adjusting the good file
accordingly.

For now, we error out if the given index lies outside of the set of valid indices for the
given string.