### PR TITLE
Revert Resolve time-write.chpl regression

### DIFF
--- a/test/io/vass/time-write.chpl
+++ b/test/io/vass/time-write.chpl
@@ -136,8 +136,6 @@ stderr.writef("tries  %i\n", tries);
 
 for t in 1..tries {
   stderr.writef("starting try %i\n", t);
-  stderr.flush();
-
   addTime(tDummy);
 
   cf_trial(n);   addTime(tcf);
@@ -149,9 +147,6 @@ for t in 1..tries {
 
   nb_trial();     addTime(tnb);
   sto_trial();   addTime(tsto);
-
-  // flush any buffered newlines
-  stdout.flush();
 }
 
 stderr.writef("done tries\n");


### PR DESCRIPTION
Reverts PR #1907 aka JIRA-25

#1907 aimed at ensuring that under perf.xc.no-local.gnu the newlines do not get mingled with the other output of the test io/vass/time-write

However we have recently been observing the same issue under perf.xc.local.pgi

So I am going to replace stderr with stdout. I am reverting #1907 first - to minimize changes/diffs.
