### PR TITLE
Output *everything* to stdout in time-write.chpl.

### DIFF
--- a/test/io/vass/time-write.chpl
+++ b/test/io/vass/time-write.chpl
@@ -62,6 +62,9 @@ config const n = 3;
 config const tries = 2;
 config const fmt = "%7.3dr";
 config const compareTimes = false;
+config const useStderr = false;
+const info = if useStderr then stderr else stdout;
+
 
 // Each trial() function writes a newline 'n' times.
 
@@ -128,14 +131,14 @@ inline proc addTime(ref t: real) {
 
 const reportFormat = "%-24s " + fmt + "\n";
 inline proc reportTime(title: string, time: real) {
-  stderr.writef(reportFormat, title, time);
+  info.writef(reportFormat, title, time);
 }
 
-stderr.writef("n      %i\n", n);
-stderr.writef("tries  %i\n", tries);
+info.writef("n      %i\n", n);
+info.writef("tries  %i\n", tries);
 
 for t in 1..tries {
-  stderr.writef("starting try %i\n", t);
+  info.writef("starting try %i\n", t);
   addTime(tDummy);
 
   cf_trial(n);   addTime(tcf);
@@ -149,9 +152,9 @@ for t in 1..tries {
   sto_trial();   addTime(tsto);
 }
 
-stderr.writef("done tries\n");
-//stderr.writef("n      %i\n", n);
-//stderr.writef("tries  %i\n", tries);
+info.writef("done tries\n");
+//info.writef("n      %i\n", n);
+//info.writef("tries  %i\n", tries);
 
 if compareTimes {
   reportTime("C printf", tcf);


### PR DESCRIPTION
This test historically printed newlines to stdout - this is what it is designed to measure - while printing informational output, such as the problem sizes and timings to stderr.

This has caused issues under perf.xc.no-local.gnu (through April 2015) and perf.xc.local.pgi (recently) where stdout and stderr merge randomly, causing verification to fail under nightly testing.

PR #1907 aka 04b5937 resolved it for perf.xc.no-local.gnu, apparently not for perf.xc.local.pgi. So this time I am just printing everything to stdout, see if this makes the issue go away.

The old behavior can be obtained using the 'useStderr' config.