### PR TITLE
Pay attention to 'inherited_linker_flags' in .la files.

### DIFF
--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -33,6 +33,9 @@ def handle_la(la_path):
                     lib_name = line.split('\'')[1]
                     p = re.compile(r'^lib([^/]+)\.a$')
                     args.append(p.sub(r'-l\1', lib_name))
+                elif 'inherited_linker_flags=' in line:
+                    for tok in line.split('\'')[1].split():
+                        args.append(tok)
                 elif 'dependency_libs=' in line:
                     for tok in line.split('\'')[1].split():
                         # paths reflect built env; replace with $CHPL_HOME


### PR DESCRIPTION
We were already looking at 'old_library' and 'dependency_libs'
entries, for library information in third-party .la files.  Now
add 'inherited_linker_flags' to the things we pull link-time
arguments from.