### PR TITLE
Revert "Replace use of our Vec class with use of std::vector in codeg…

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -44,7 +44,6 @@
 #include "AstVisitor.h"
 #include "CollapseBlocks.h"
 
-#include <algorithm>
 #include <cstdlib>
 #include <inttypes.h>
 #include <iostream>
@@ -2574,7 +2573,7 @@ void ModuleSymbol::codegenDef() {
   info->cStatements.clear();
   info->cLocalDecls.clear();
 
-  std::vector<FnSymbol*> fns;
+  Vec<FnSymbol*> fns;
 
   for_alist(expr, block->body) {
     if (DefExpr* def = toDefExpr(expr))
@@ -2584,13 +2583,13 @@ void ModuleSymbol::codegenDef() {
             fn->hasFlag(FLAG_FUNCTION_PROTOTYPE))
           continue;
 
-        fns.push_back(fn);
+        fns.add(fn);
       }
   }
 
-  std::sort(fns.begin(), fns.end(), compareLineno);
+  qsort(fns.v, fns.n, sizeof(fns.v[0]), compareLineno);
 
-  for_vector(FnSymbol, fn, fns) {
+  forv_Vec(FnSymbol, fn, fns) {
     fn->codegenDef();
   }
 

--- a/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
+++ b/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
@@ -1,2 +1,2 @@
-Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:10
 Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:15
+Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:10


### PR DESCRIPTION
Reverts chapel-lang/chapel#1990

For some reason, PGI is getting an invalid pointer passed to it by the std::vector iterator.  I'm not sure why it's happening, but I was seeing something similar in my attempts to fix Coverity issue 1298875 so this feels like an actual problem that'll require more thought.  In the meanwhile, let's revert the change.