### PR TITLE
Preserve source line number for cobegins

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2110,6 +2110,7 @@ buildCobeginStmt(CallExpr* byref_vars, BlockStmt* block) {
   for_alist(stmt, block->body) {
     BlockStmt* beginBlk = new BlockStmt();
     beginBlk->blockInfoSet(new CallExpr(PRIM_BLOCK_COBEGIN));
+    beginBlk->astloc = stmt->astloc;
     // the original byref_vars is dead - will be clean_gvec-ed
     addByrefVars(beginBlk, byref_vars ? byref_vars->copy() : NULL);
     stmt->insertBefore(beginBlk);


### PR DESCRIPTION
The task function created for an individual task of a cobegin
statement used to carry the line number of the 'cobegin' keyword,
or in any case not the line number where that task function's
code actually started.

Fixed here. Trivial, not reviewed.
