### PR TITLE
Rename FLAG_PRIVATE to FLAG_LOCALE_PRIVATE

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -133,6 +133,7 @@ symbolFlag( FLAG_ITERATOR_RECORD , npr, "iterator record" , ncm )
 symbolFlag( FLAG_ITERATOR_WITH_ON , npr, "iterator with on" , "iterator which contains an on block" )
 symbolFlag( FLAG_LOCALE_MODEL_ALLOC , ypr, "locale model alloc" , "locale model specific alloc" )
 symbolFlag( FLAG_LOCALE_MODEL_FREE , ypr, "locale model free" , "locale model specific free" )
+symbolFlag( FLAG_LOCALE_PRIVATE , ypr, "locale private" , ncm )
 
 // The arguments to this function are all values or narrow pointers.
 // Calls to an extern function use only narrow args and expect a narrow return.
@@ -199,7 +200,6 @@ symbolFlag( FLAG_PARTIAL_TUPLE, npr, "partial tuple", ncm)
 symbolFlag( FLAG_PRIMITIVE_TYPE , ypr, "primitive type" , "attached to primitive types to keep them from being deleted" )
 symbolFlag( FLAG_PRINT_MODULE_INIT_FN , ypr, "print module init fn" , ncm )
 symbolFlag( FLAG_PRINT_MODULE_INIT_INDENT_LEVEL , ypr, "print module init indent level" , ncm )
-symbolFlag( FLAG_PRIVATE , ypr, "private" , ncm )
 symbolFlag( FLAG_PRIVATIZED_CLASS , ypr, "privatized class" , "privatized array or domain class" )
 symbolFlag( FLAG_PROMOTION_WRAPPER , npr, "promotion wrapper" , ncm )
 symbolFlag( FLAG_RANGE , ypr, "range" , "indicates that this type can be iterated" )

--- a/compiler/optimizations/narrowWideReferences.cpp
+++ b/compiler/optimizations/narrowWideReferences.cpp
@@ -1053,7 +1053,7 @@ static void narrowVarsArgsFieldsInMap(Map<Symbol*,Vec<SymExpr*>*>& defMap,
         narrowField(var, wi);
       }
       else {
-        // TODO: Can FLAG_PRIVATE vars be narrow?
+        // TODO: Can FLAG_LOCALE_PRIVATE vars be narrow?
 
         narrowSym(var, wi, defMap, useMap);
 

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -762,7 +762,7 @@ static void findHeapVarsAndRefs(Map<Symbol*,Vec<SymExpr*>*>& defMap,
                isModuleSymbol(def->parentSymbol) &&
                def->parentSymbol != rootModule &&
                isVarSymbol(def->sym) &&
-               !def->sym->hasFlag(FLAG_PRIVATE) &&
+               !def->sym->hasFlag(FLAG_LOCALE_PRIVATE) &&
                !def->sym->hasFlag(FLAG_EXTERN)) {
       if (def->sym->hasFlag(FLAG_CONST) &&
           (is_bool_type(def->sym->type) ||

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -165,7 +165,7 @@ module ChapelLocale {
   // The rootLocale is private to each locale.  It cannot be
   // initialized until LocaleModel is initialized.  To disable this
   // replication, set replicateRootLocale to false.
-  pragma "private" var rootLocale : locale = nil;
+  pragma "locale private" var rootLocale : locale = nil;
   config param replicateRootLocale = true;
 
   // The rootLocale needs to be initalized on all locales prior to

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -69,7 +69,7 @@ module DefaultRectangular {
   // Replicated copies are set up in chpl_initOnLocales() during locale
   // model initialization
   //
-  pragma "private" var defaultDist = new dmap(new DefaultDist());
+  pragma "locale private" var defaultDist = new dmap(new DefaultDist());
   inline proc chpl_defaultDistInitPrivate() {
     if defaultDist._value==nil then defaultDist = new dmap(new DefaultDist());
   }

--- a/modules/internal/LocaleTree.chpl
+++ b/modules/internal/LocaleTree.chpl
@@ -30,7 +30,7 @@ module LocaleTree {
     var left, right: locale;
   }
 
-  pragma "private" var chpl_localeTree: chpl_localeTreeRecord;
+  pragma "locale private" var chpl_localeTree: chpl_localeTreeRecord;
 
   proc chpl_initLocaleTree() {
     for i in LocaleSpace {

--- a/modules/internal/LocalesArray.chpl
+++ b/modules/internal/LocalesArray.chpl
@@ -47,7 +47,7 @@ module LocalesArray {
   // we set up the version on all other locales during LocaleModel
   // initialization (see chpl_rootLocaleInitPrivate()).  The copy for
   // locale 0 is set up here for the declaration.
-  pragma "private"
+  pragma "locale private"
   var Locales => (rootLocale:RootLocale).getDefaultLocaleArray();
 
   // We don't use the same private "trick" as with Locales above with

--- a/modules/internal/tasktable/on/ChapelTaskTable.chpl
+++ b/modules/internal/tasktable/on/ChapelTaskTable.chpl
@@ -63,7 +63,7 @@ module ChapelTaskTable {
     var map : [dom] chpldev_Task;
   }
   
-  pragma "private"
+  pragma "locale private"
   var chpldev_taskTable : chpldev_taskTable_t;
   
   //----------------------------------------------------------------------{

--- a/test/multilocale/deitz/needMultiLocales/privateLimitedDistributedArrayClass1.chpl
+++ b/test/multilocale/deitz/needMultiLocales/privateLimitedDistributedArrayClass1.chpl
@@ -26,7 +26,7 @@ proc DistributedArray.writeThis(W: Writer) {
   }
 }
 
-pragma "private" var A: DistributedArray;
+pragma "locale private" var A: DistributedArray;
 
 //
 // set up DistributedArray

--- a/test/multilocale/deitz/needMultiLocales/privateLimitedDistributedArrayClass2.chpl
+++ b/test/multilocale/deitz/needMultiLocales/privateLimitedDistributedArrayClass2.chpl
@@ -28,7 +28,7 @@ proc DistributedArray.writeThis(W: Writer) {
   }
 }
 
-pragma "private" var A: DistributedArray;
+pragma "locale private" var A: DistributedArray;
 
 //
 // set up DistributedArray

--- a/test/multilocale/diten/needMultiLocales/DijkstraTermination.chpl
+++ b/test/multilocale/diten/needMultiLocales/DijkstraTermination.chpl
@@ -25,8 +25,8 @@ class WakeupSyncVarHack {
   var wakeup: sync WakeupType;
 }
 
-pragma "private" var wakeup: WakeupSyncVarHack;
-pragma "private" var endCount: MyEndCount;
+pragma "locale private" var wakeup: WakeupSyncVarHack;
+pragma "locale private" var endCount: MyEndCount;
 
 proc setupTerminationDetection() {
   for loc in Locales do on loc {

--- a/test/studies/hpcc/RA/diten/ra.chpl
+++ b/test/studies/hpcc/RA/diten/ra.chpl
@@ -89,7 +89,7 @@ var T: [TableSpace] elemType;
 
 config const maxLookahead = 1024;
 
-pragma "private" var myBuckets: Buckets;
+pragma "locale private" var myBuckets: Buckets;
 
 //
 // The program entry point


### PR DESCRIPTION
In working to add the keywords public and private to the compiler, I discovered
that we already had a flag named private, but that it was very much intended to
represent locale-private.  To avoid confusion and simplify things, I renamed
FLAG_PRIVATE to FLAG_LOCALE_PRIVATE and updated all uses of it to reflect the
change made.  This included updating 5 internal module uses and 5 testing
system uses.