### PR TITLE
Add mathematical constants

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -769,6 +769,32 @@ module Math {
   }
 
 
+  /* e - exp(1) or  the base of the natural logarithm */
+  param e = 2.7182818284590452354;
+  /* log2(e) */
+  param log2e = 1.4426950408889634074;
+  /* log10(e) */
+  param log10e = 0.43429448190325182765;
+  /* log(2) (natural logarithm) */
+  param ln_2 = 0.69314718055994530942;
+  /* log(10) (natural logarithm) */
+  param ln_10 = 2.30258509299404568402;
+  /* pi - the circumference/the diameter of a circle */
+  param pi = 3.14159265358979323846;
+  /* pi/2 */
+  param pi2 = 1.57079632679489661923;
+  /* pi/4 */
+  param pi4 = 0.78539816339744830962;
+  /* 1/pi */
+  //param 1_pi = 0.31830988618379067154;
+  /* 2/pi */
+  //param 2_pi = 0.63661977236758134308;
+  /* 2/sqrt(pi) */
+  //param 2_sqrtpi = 1.12837916709551257390;
+  /* sqrt(2) */
+  param sqrt2 = 1.41421356237309504880;
+  /* 1/sqrt(2) */
+  param sqrt1_2 = 0.70710678118654752440;
 } // end of module Math
 
 // TODO: Consolidate overloaded signatures, to simplify the documentation.

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -772,9 +772,9 @@ module Math {
   /* e - exp(1) or  the base of the natural logarithm */
   param e = 2.7182818284590452354;
   /* log2(e) */
-  param log2e = 1.4426950408889634074;
+  param log2_e = 1.4426950408889634074;
   /* log10(e) */
-  param log10e = 0.43429448190325182765;
+  param log10_e = 0.43429448190325182765;
   /* log(2) (natural logarithm) */
   param ln_2 = 0.69314718055994530942;
   /* log(10) (natural logarithm) */
@@ -782,19 +782,19 @@ module Math {
   /* pi - the circumference/the diameter of a circle */
   param pi = 3.14159265358979323846;
   /* pi/2 */
-  param pi2 = 1.57079632679489661923;
+  param half_pi = 1.57079632679489661923;
   /* pi/4 */
-  param pi4 = 0.78539816339744830962;
+  param quarter_pi = 0.78539816339744830962;
   /* 1/pi */
-  //param 1_pi = 0.31830988618379067154;
+  param recipr_pi = 0.31830988618379067154;
   /* 2/pi */
-  //param 2_pi = 0.63661977236758134308;
+  param twice_recipr_pi = 0.63661977236758134308;
   /* 2/sqrt(pi) */
-  //param 2_sqrtpi = 1.12837916709551257390;
+  param twice_recipr_sqrt_pi = 1.12837916709551257390;
   /* sqrt(2) */
-  param sqrt2 = 1.41421356237309504880;
+  param sqrt_2 = 1.41421356237309504880;
   /* 1/sqrt(2) */
-  param sqrt1_2 = 0.70710678118654752440;
+  param recipr_sqrt_2 = 0.70710678118654752440;
 } // end of module Math
 
 // TODO: Consolidate overloaded signatures, to simplify the documentation.

--- a/test/modules/standard/math/constants.chpl
+++ b/test/modules/standard/math/constants.chpl
@@ -1,0 +1,27 @@
+use Math;
+
+proc check(x, y)
+{
+  param threshold = 0.000000000000001;
+  if abs(x-y) < threshold {
+    // OK!
+  } else {
+    writeln("comparison failed between ",
+            x, " and ", y);
+  }
+}
+
+check(e, exp(1));
+check(log2e, log2(e));
+check(log10e, log10(e));
+check(ln_2, log(2));
+check(ln_10, log(10));
+assert(pi:int == 3);
+check(sin(pi), 0.0);
+check(pi2, pi/2.0);
+check(pi4, pi/4.0);
+//check(1_pi, 1.0/pi);
+//check(2_pi, 2.0/pi);
+//check(2_sqrtpi, 2.0/sqrt(pi));
+check(sqrt2, sqrt(2));
+check(sqrt1_2, 1/sqrt(2));

--- a/test/modules/standard/math/constants.chpl
+++ b/test/modules/standard/math/constants.chpl
@@ -12,16 +12,17 @@ proc check(x, y)
 }
 
 check(e, exp(1));
-check(log2e, log2(e));
-check(log10e, log10(e));
+check(log2_e, log2(e));
+check(log10_e, log10(e));
 check(ln_2, log(2));
 check(ln_10, log(10));
 assert(pi:int == 3);
 check(sin(pi), 0.0);
-check(pi2, pi/2.0);
-check(pi4, pi/4.0);
-//check(1_pi, 1.0/pi);
-//check(2_pi, 2.0/pi);
-//check(2_sqrtpi, 2.0/sqrt(pi));
-check(sqrt2, sqrt(2));
-check(sqrt1_2, 1/sqrt(2));
+check(half_pi, pi/2.0);
+check(quarter_pi, pi/4.0);
+check(recipr_pi, 1.0/pi);
+check(twice_recipr_pi, 2.0/pi);
+check(twice_recipr_sqrt_pi, 2.0/sqrt(pi));
+check(sqrt_2, sqrt(2));
+check(recipr_sqrt_2, 1/sqrt(2));
+


### PR DESCRIPTION
Add mathematical constants defined in math.h on POSIX systems
Note: a Chapel identifier can't start with a number, so I wasn't
sure what to call 1/pi for example. Likewise, I wondered if these
constants should always start with a particular letter or something?

Lastly, I'm wishing that param reals would actually compute
at compile time - if that were the case, we would only need
e and pi here (arguably).
