### PR TITLE
Skip test/studies/sort/radix.chpl for cygwin

### DIFF
--- a/test/studies/sort/radix.skipif
+++ b/test/studies/sort/radix.skipif
@@ -1,0 +1,3 @@
+# This test takes an ungodly amount of time on cygwin due to freeing syncs
+CHPL_HOST_PLATFORM == cygwin64
+CHPL_HOST_PLATFORM == cygwin32


### PR DESCRIPTION
This test takes a very long time on cygwin, even on my personal machine (which
was much faster than our testing system).  The reason is that it creates and
deletes 8 arrays of ~6000 sync variables and takes a very long time to delete
each one (roughly 20 minutes per array).  Since production code is unlikely in
this situation, there's little point running this test.