### PR TITLE
Rewrote radix to use atomics rather than syncs

### DIFF
--- a/test/studies/sort/radix.skipif
+++ b/test/studies/sort/radix.skipif
@@ -1,3 +1,0 @@
-# This test takes an ungodly amount of time on cygwin due to freeing syncs
-CHPL_HOST_PLATFORM == cygwin64
-CHPL_HOST_PLATFORM == cygwin32


### PR DESCRIPTION
@lydia-duncan's note about the large arrays of syncs used by this test made
me curious how they were used, and a quick look made it appear that
atomics could be used instead (this test predates atomics).  Making
the change seems to have worked.  I'm speculatively guessing that
it'll solve the cygwin timeouts as well, so have removed the skipif
(yet have not tested on cygwin).