### PR TITLE
Fix Coverity error 1298874, attempt 2

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -44,6 +44,7 @@
 #include "AstVisitor.h"
 #include "CollapseBlocks.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <inttypes.h>
 #include <iostream>
@@ -2573,14 +2574,7 @@ static int compareLineno(const void* v1, const void* v2) {
   FnSymbol* fn1 = *(FnSymbol* const *)v1;
   FnSymbol* fn2 = *(FnSymbol* const *)v2;
 
-  if (fn1->linenum() > fn2->linenum())
-    return 1;
-
-  else if (fn1->linenum() < fn2->linenum())
-    return -1;
-
-  else
-    return 0;
+  return fn1->linenum() < fn2->linenum();
 }
 
 
@@ -2593,7 +2587,7 @@ void ModuleSymbol::codegenDef() {
   info->cStatements.clear();
   info->cLocalDecls.clear();
 
-  Vec<FnSymbol*> fns;
+  std::vector<FnSymbol*> fns;
 
   for_alist(expr, block->body) {
     if (DefExpr* def = toDefExpr(expr))
@@ -2603,13 +2597,13 @@ void ModuleSymbol::codegenDef() {
             fn->hasFlag(FLAG_FUNCTION_PROTOTYPE))
           continue;
 
-        fns.add(fn);
+        fns.push_back(fn);
       }
   }
 
-  qsort(fns.v, fns.n, sizeof(fns.v[0]), compareLineno);
+  std::sort(fns.begin(), fns.end(), compareLineno);
 
-  forv_Vec(FnSymbol, fn, fns) {
+  for_vector(FnSymbol, fn, fns) {
     fn->codegenDef();
   }
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2570,9 +2570,9 @@ ModuleSymbol::copyInner(SymbolMap* map) {
 }
 
 
-static int compareLineno(const void* v1, const void* v2) {
-  FnSymbol* fn1 = *(FnSymbol* const *)v1;
-  FnSymbol* fn2 = *(FnSymbol* const *)v2;
+static int compareLineno(void* v1, void* v2) {
+  FnSymbol* fn1 = (FnSymbol*)v1;
+  FnSymbol* fn2 = (FnSymbol*)v2;
 
   return fn1->linenum() < fn2->linenum();
 }

--- a/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
+++ b/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
@@ -1,2 +1,2 @@
-Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:15
 Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:10
+Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:15

--- a/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
+++ b/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
@@ -1,2 +1,2 @@
-Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:10
 Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:15
+Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:10


### PR DESCRIPTION
Similar to #2018, the comparison function used when sorting needed to
be changed to reflect the use of std::sort instead of qsort with the vector.
It couldn't take a const pointer to a FnSymbol pointer and it needed to
return the equivalent of a "<" call instead of a choice between -1, 0,
and 1 for ordering.