### PR TITLE
Adjusted line numbers in .good for PR #2011

### DIFF
--- a/test/parallel/cobegin/hilde/reports.good
+++ b/test/parallel/cobegin/hilde/reports.good
@@ -1,9 +1,9 @@
 
 - main program:0 is suspended
-- reports.chpl:12 is active
-- reports.chpl:12 is active
-- reports.chpl:12 is active
-- reports.chpl:12 is active
+- reports.chpl:13 is active
+- reports.chpl:14 is active
+- reports.chpl:15 is active
+- reports.chpl:16 is active
 --------------------------------
 Known tasks:
 Pending tasks:

--- a/test/parallel/cobegin/stonea/reports.good
+++ b/test/parallel/cobegin/stonea/reports.good
@@ -1,11 +1,11 @@
 
 - main program:0 is suspended
-- reports.chpl:5
-- reports.chpl:5
-- reports.chpl:5 is active
-- reports.chpl:5 is active
-- reports.chpl:5 is pending
-- reports.chpl:5 is pending
+- reports.chpl:6 is active
+- reports.chpl:7 is active
+- reports.chpl:8
+- reports.chpl:8 is pending
+- reports.chpl:9
+- reports.chpl:9 is pending
 --------------------------------
 Known tasks:
 Pending tasks:


### PR DESCRIPTION
Now that line numbers for cobegin tasks are reported correctly,
these .good files need adjustment.

My understanding why stonea/reports.good consistently distinguishes
between tasks at Lines 6 and 7 vs. Lines 8 and 9 is that the test is run
with CHPL_RT_NUM_THREADS_PER_LOCALE=2, so (our
implementation) launches the first two tasks OK and the second two
tasks then get stuck 'cause there aren't pthreads for them.

