### PR TITLE
Default to fifo with pgi compiler

### DIFF
--- a/doc/release/README.chplenv
+++ b/doc/release/README.chplenv
@@ -244,12 +244,12 @@ Optional Settings
         muxed          : use Cray-specific lightweight threading (with
                          Cray pre-built module only)
 
-   If CHPL_TASKS is not set it defaults to "qthreads" unless the
-   target platform is either "cygwin*" or "netbsd*", the target
-   compiler is "cray-prgenv-cray", or the target architecture is
-   "knc". For those configurations it defaults to "fifo".  On
-   Cray XC and XE (TM) systems when using the pre-built module,
-   it defaults to "muxed".
+   If CHPL_TASKS is not set it defaults to "qthreads" unless the target
+   platform is either "cygwin*" or "netbsd*", the target compiler is
+   "cray-prgenv-cray", "pgi", or "cray-prgenv-pgi", or the target
+   architecture is "knc". For those configurations it defaults to
+   "fifo".  On Cray XC and XE (TM) systems when using the pre-built
+   module, it defaults to "muxed".
 
    Note that the Chapel util/quickstart/setchplenv.* source scripts
    set CHPL_TASKS to 'fifo' to reduce build-time and third-party

--- a/doc/release/README.tasks
+++ b/doc/release/README.tasks
@@ -42,7 +42,8 @@ environment variable to one of the following options:
 
 qthreads       : best performance; default for most targets
 fifo           : most portable, but heavyweight; default for Intel KNC,
-                 NetBSD, Cygwin, or when Cray is the target compiler
+                 NetBSD, Cygwin, or when target compiler is
+                 "cray-prgenv-cray", "pgi", or "cray-prgenv-pgi"
 massivethreads : based on U Tokyo's MassiveThreads library
 muxed          : available only on Cray Inc. systems; not documented
                  here, see $CHPL_HOME/doc/platforms/README.cray instead
@@ -182,13 +183,14 @@ For more information on Qthreads, see $CHPL_HOME/third-party/README.
 CHPL_TASKS == fifo
 ------------------
 
-FIFO tasking over POSIX threads (or pthreads) works on all platforms
-and is the default for Intel KNC, Cygwin, NetBSD, or when Cray is the
-target compiler.  It is attractive in its portability, though on most
-platforms it will tend to be heavier weight than Chapel strictly
-requires.  FIFO tasking is also used when Chapel is configured in
-'Quick Start' mode (see $CHPL_HOME/README for details).  To use FIFO
-tasking, please take the following steps:
+FIFO tasking over POSIX threads (or pthreads) works on all platforms and
+is the default for Intel KNC, Cygwin, NetBSD, or when the target
+compiler is "cray-prgenv-cray", "pgi", or "cray-prgenv-pgi".  It is
+attractive in its portability, though on most platforms it will tend to
+be heavier weight than Chapel strictly requires.  FIFO tasking is also
+used when Chapel is configured in 'Quick Start' mode (see
+$CHPL_HOME/README for details).  To use FIFO tasking, please take the
+following steps:
 
 1) Ensure that the environment variable CHPL_HOME points to the
    top-level Chapel directory, as always.

--- a/doc/release/platforms/README.cray
+++ b/doc/release/platforms/README.cray
@@ -127,8 +127,9 @@ Building Chapel for a Cray System from Source
    configure the Chapel build.  These are described in greater detail in
    README.chplenv.
 
-     CHPL_TASKS : tasking implementation, default "fifo" when using
-                  target compiler "cray", otherwise "qthreads"
+     CHPL_TASKS : tasking implementation, default is"fifo" when target
+                  compiler is "cray-prgenv-cray", "pgi" or
+                  "cray-prgenv-pgi", otherwise "qthreads"
      CHPL_COMM : communication implementation, default "gasnet"
 
    Other configuration environment variables such as CHPL_MEM can also
@@ -182,9 +183,10 @@ Using Chapel on a Cray System
    select a Chapel configuration.  These are described in greater detail
    in README.chplenv.
 
-     CHPL_TASKS : tasking implementation, default "fifo" with target
-                  compiler "cray", "muxed" on Cray XC/XE with pre-built
-                  module, otherwise "qthreads"
+     CHPL_TASKS : tasking implementation, default "fifo" when target
+                  compiler is "cray-prgenv-cray", "pgi", or
+                  "cray-prgenv-pgi", "muxed" on Cray XC/XE with
+                  pre-built module, otherwise "qthreads"
      CHPL_COMM  : communication implementation, default "ugni" on Cray
                   XC/XE with pre-built module, else "gasnet"
 

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -24,6 +24,8 @@ def get():
         elif (arch_val == 'knc' or
                 platform_val.startswith('cygwin') or
                 platform_val.startswith('netbsd') or
+                compiler_val == 'pgi'             or
+                compiler_val == 'cray-prgenv-pgi' or
                 compiler_val == 'cray-prgenv-cray'):
             tasks_val = 'fifo'
         else:


### PR DESCRIPTION
We're running into some weird build issues with pgi right now because of a .S
file in qthreads source. This is preventing the entire module from building so
we're swapping to use fifo until we figure out a real solution.

Updating the docs to mention when fifo is the default in case we never remember
to swap back or fifo ends up being a better option for pgi.