### PR TITLE
Add a .skipif to skip lulesh-dense in valgrind testing

### DIFF
--- a/test/studies/lulesh/bradc/lulesh-dense.skipif
+++ b/test/studies/lulesh/bradc/lulesh-dense.skipif
@@ -1,0 +1,4 @@
+# This performance test runs too long under valgrind.  We test other
+# versions of lulesh with valgrind, so it doesn't seem worth cloning
+# this version to reduce the problem size
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
The lulesh-dense test times out under valgrind.  We already test other
lulesh variants under valgrind, so cloning this one to dial down the
problem size doesn't seem worthwhile.