### PR TITLE
Add two tests of outside module access

### DIFF
--- a/test/modules/lydia/accessOfOutsideFunctionNoBleed.chpl
+++ b/test/modules/lydia/accessOfOutsideFunctionNoBleed.chpl
@@ -1,0 +1,20 @@
+// This test is intended to ensure that the access of some of a module's
+// contents does not cause its contents to be visible without its name as a
+// predicate.
+
+module M {
+  proc a(x: bool) {
+    return !x;
+  }
+
+  proc b(y: int) {
+    return 4 + y;
+  }
+}
+
+module M2 {
+  proc main() {
+    writeln(M.a(true));
+    writeln(a(false));
+  }
+}

--- a/test/modules/lydia/accessOfOutsideFunctionNoBleed.good
+++ b/test/modules/lydia/accessOfOutsideFunctionNoBleed.good
@@ -1,0 +1,2 @@
+accessOfOutsideFunctionNoBleed.chpl:16: In function 'main':
+accessOfOutsideFunctionNoBleed.chpl:18: error: unresolved call 'a(0)'

--- a/test/modules/lydia/accessOfOutsideFunctionNoBleed2.chpl
+++ b/test/modules/lydia/accessOfOutsideFunctionNoBleed2.chpl
@@ -1,0 +1,20 @@
+// This test is intended to ensure that the access of some of a module's
+// contents does not cause its contents to be visible without its name as a
+// predicate.
+
+module M {
+  proc a(x: bool) {
+    return !x;
+  }
+
+  proc b(y: int) {
+    return 4 + y;
+  }
+}
+
+module M2 {
+  proc main() {
+    writeln(M.a(true));
+    writeln(b(3));
+  }
+}

--- a/test/modules/lydia/accessOfOutsideFunctionNoBleed2.good
+++ b/test/modules/lydia/accessOfOutsideFunctionNoBleed2.good
@@ -1,0 +1,2 @@
+accessOfOutsideFunctionNoBleed2.chpl:16: In function 'main':
+accessOfOutsideFunctionNoBleed2.chpl:18: error: unresolved call 'b(3)'


### PR DESCRIPTION
In looking at our scopeResolve code, I got a little worried that access of
symbols in an outside module without a use would allow its symbols to be more
generally visible.  Thankfully, such fears were unfounded.  Since I didn't see
a test of that specific situation, I figured I should add one so that we don't
accidentally break this behavior in the future.