### PR TITLE
Treat 'make modules' failures as fatal,

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -529,7 +529,7 @@ if ($makestat != 0) {
 }
 
 print "Making modules\n";
-$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt modules", "making chapel modules", 0, 1);
+$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt modules", "making chapel modules", 1, 1);
 
 
 #


### PR DESCRIPTION
If 'make modules' fails, we can't run the compiler and all tests
will fail.  That's a waste of time and triage, so let's just make
such cases fatal instead.