### PR TITLE
Clarify license of Docutils package

### DIFF
--- a/third-party/chpldoc-venv/README.md
+++ b/third-party/chpldoc-venv/README.md
@@ -111,6 +111,6 @@ Python Documentation Utilities
 
 Required by Sphinx.
 
-**License**: public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)
+**License**: public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt, also found at http://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/COPYING.txt)
 
 **Website**: https://pypi.python.org/pypi/docutils


### PR DESCRIPTION
Since Docutils is public domain but has portions which are under various other
licenses, including the GPL, we decided to include an outside pointer to their
license file to be as clear as possible.