### PR TITLE
Fix for loop lowering

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -463,10 +463,10 @@ buildZip1(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
     // A for loop has no termination condition, so it just runs all the indices
     // in the underlying iterator.
     SymExpr* iterator = forLoop->iteratorGet()->copy(&map);
-	VarSymbol* more = newTemp("_more_in_for", dtInt[INT_SIZE_DEFAULT]);
-	CallExpr* moreField = new CallExpr(PRIM_GET_MEMBER, iterator,
-									   new_StringSymbol("more"));
-	zip1body->insertAtTail(new CallExpr(PRIM_MOVE, more, moreField));
+    VarSymbol* more = newTemp("_more_in_for", dtInt[INT_SIZE_DEFAULT]);
+    CallExpr* moreField = new CallExpr(PRIM_GET_MEMBER, iterator,
+                                       new_StringSymbol("more"));
+    zip1body->insertAtTail(new CallExpr(PRIM_MOVE, more, moreField));
     zip1body->insertAtTail(new CondStmt(new SymExpr(more),
                                         new CallExpr(PRIM_SET_MEMBER, ii->zip1->_this, ii->iclass->getField("more"), new_IntSymbol(1)),
                                         new CallExpr(PRIM_SET_MEMBER, ii->zip1->_this, ii->iclass->getField("more"), new_IntSymbol(0))));
@@ -560,10 +560,10 @@ buildZip3(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
                                         ii->iclass->getField("more"), condTemp));
   } else if (ForLoop* forLoop = toForLoop(singleLoop)) {
     SymExpr* iterator = forLoop->iteratorGet()->copy(&map);
-	VarSymbol* more = newTemp("_more_in_for", dtInt[INT_SIZE_DEFAULT]);
-	CallExpr* moreField = new CallExpr(PRIM_GET_MEMBER, iterator,
-									   new_StringSymbol("more"));
-	zip3body->insertAtTail(new CallExpr(PRIM_MOVE, more, moreField));
+    VarSymbol* more = newTemp("_more_in_for", dtInt[INT_SIZE_DEFAULT]);
+    CallExpr* moreField = new CallExpr(PRIM_GET_MEMBER, iterator,
+                                       new_StringSymbol("more"));
+    zip3body->insertAtTail(new CallExpr(PRIM_MOVE, more, moreField));
     zip3body->insertAtTail(new CondStmt(new SymExpr(more),
                                         new CallExpr(PRIM_SET_MEMBER, ii->zip3->_this, ii->iclass->getField("more"), new_IntSymbol(1)),
                                         new CallExpr(PRIM_SET_MEMBER, ii->zip3->_this, ii->iclass->getField("more"), new_IntSymbol(0))));

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -458,18 +458,16 @@ buildZip1(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
     zip1body->insertAtTail(new CallExpr(PRIM_SET_MEMBER, ii->zip1->_this,
                                         ii->iclass->getField("more"), condTemp));
   } else if (ForLoop* forLoop = toForLoop(singleLoop)) {
-    // 2015-02-23 hilde: TODO: See if we can apply the above simplification
-    // here and in buildZip3 as well.
     // A for loop has no termination condition, so it just runs all the indices
     // in the underlying iterator.
     SymExpr* iterator = forLoop->iteratorGet()->copy(&map);
     VarSymbol* more = newTemp("_more_in_for", dtInt[INT_SIZE_DEFAULT]);
+    zip1body->insertAtTail(new DefExpr(more));
     CallExpr* moreField = new CallExpr(PRIM_GET_MEMBER, iterator,
-                                       new_StringSymbol("more"));
+                                       iterator->typeInfo()->getField("more"));
     zip1body->insertAtTail(new CallExpr(PRIM_MOVE, more, moreField));
-    zip1body->insertAtTail(new CondStmt(new SymExpr(more),
-                                        new CallExpr(PRIM_SET_MEMBER, ii->zip1->_this, ii->iclass->getField("more"), new_IntSymbol(1)),
-                                        new CallExpr(PRIM_SET_MEMBER, ii->zip1->_this, ii->iclass->getField("more"), new_IntSymbol(0))));
+    zip1body->insertAtTail(new CallExpr(PRIM_SET_MEMBER, ii->zip1->_this,
+                                        ii->iclass->getField("more"), more));
   }
 
   zip1body->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));
@@ -561,12 +559,12 @@ buildZip3(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
   } else if (ForLoop* forLoop = toForLoop(singleLoop)) {
     SymExpr* iterator = forLoop->iteratorGet()->copy(&map);
     VarSymbol* more = newTemp("_more_in_for", dtInt[INT_SIZE_DEFAULT]);
+    zip3body->insertAtTail(new DefExpr(more));
     CallExpr* moreField = new CallExpr(PRIM_GET_MEMBER, iterator,
-                                       new_StringSymbol("more"));
+                                       iterator->typeInfo()->getField("more"));
     zip3body->insertAtTail(new CallExpr(PRIM_MOVE, more, moreField));
-    zip3body->insertAtTail(new CondStmt(new SymExpr(more),
-                                        new CallExpr(PRIM_SET_MEMBER, ii->zip3->_this, ii->iclass->getField("more"), new_IntSymbol(1)),
-                                        new CallExpr(PRIM_SET_MEMBER, ii->zip3->_this, ii->iclass->getField("more"), new_IntSymbol(0))));
+    zip3body->insertAtTail(new CallExpr(PRIM_SET_MEMBER, ii->zip3->_this,
+                                        ii->iclass->getField("more"), more));
   }
 
   zip3body->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -443,7 +443,6 @@ buildZip1(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
       zip1body->insertAtTail(expr->copy(&map));
   }
 
-  INT_ASSERT(singleLoop);
   if (WhileStmt* stmt = toWhileStmt(singleLoop)) {
     // By the time we get here, the condExpr has been passed through _cond_test
     // and the result stored in a temp, so condExprForTmpVariableGet just
@@ -459,8 +458,12 @@ buildZip1(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
     zip1body->insertAtTail(new CallExpr(PRIM_SET_MEMBER, ii->zip1->_this,
                                         ii->iclass->getField("more"), condTemp));
   } else if (isCForLoop(singleLoop)) {
-    // Do nothing.
+    // CForLoops do not use the "more" field in their loop termination test.
+    // See the code for that special case in buildHasMore().
   } else {
+    // ParamForLoops should have been removed during resolution.
+    // DoWhileLoops are not treated as singleLoop iterators.
+    // ForLoops should have been replaceed in expandForLoop().
     INT_FATAL("Unexpected singleLoop iterator type");
   }
 
@@ -540,8 +543,6 @@ buildZip3(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
     }
   }
 
-  // Check for more (only for non c for loops)
-  INT_ASSERT(singleLoop);
   if (WhileStmt* stmt = toWhileStmt(singleLoop)) {
     SymExpr* condExpr = stmt->condExprForTmpVariableGet()->copy(&map);
     Type* moreType = ii->iclass->getField("more")->type;
@@ -552,8 +553,12 @@ buildZip3(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
     zip3body->insertAtTail(new CallExpr(PRIM_SET_MEMBER, ii->zip3->_this,
                                         ii->iclass->getField("more"), condTemp));
   } else if (isCForLoop(singleLoop)) {
-    // Do nothing.
+    // CForLoops do not use the "more" field in their loop termination test.
+    // See the code for that special case in buildHasMore().
   } else {
+    // ParamForLoops should have been removed during resolution.
+    // DoWhileLoops are not treated as singleLoop iterators.
+    // ForLoops should have been replaceed in expandForLoop().
     INT_FATAL("Unexpected singleLoop iterator type");
   }
 

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -460,9 +460,14 @@ buildZip1(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
   } else if (ForLoop* forLoop = toForLoop(singleLoop)) {
     // 2015-02-23 hilde: TODO: See if we can apply the above simplification
     // here and in buildZip3 as well.
-    SymExpr* index = forLoop->indexGet()->copy(&map);
-
-    zip1body->insertAtTail(new CondStmt(index,
+    // A for loop has no termination condition, so it just runs all the indices
+    // in the underlying iterator.
+    SymExpr* iterator = forLoop->iteratorGet()->copy(&map);
+	VarSymbol* more = newTemp("_more_in_for", dtInt[INT_SIZE_DEFAULT]);
+	CallExpr* moreField = new CallExpr(PRIM_GET_MEMBER, iterator,
+									   new_StringSymbol("more"));
+	zip1body->insertAtTail(new CallExpr(PRIM_MOVE, more, moreField));
+    zip1body->insertAtTail(new CondStmt(new SymExpr(more),
                                         new CallExpr(PRIM_SET_MEMBER, ii->zip1->_this, ii->iclass->getField("more"), new_IntSymbol(1)),
                                         new CallExpr(PRIM_SET_MEMBER, ii->zip1->_this, ii->iclass->getField("more"), new_IntSymbol(0))));
   }
@@ -554,9 +559,12 @@ buildZip3(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
     zip3body->insertAtTail(new CallExpr(PRIM_SET_MEMBER, ii->zip3->_this,
                                         ii->iclass->getField("more"), condTemp));
   } else if (ForLoop* forLoop = toForLoop(singleLoop)) {
-    SymExpr* index = forLoop->indexGet()->copy(&map);
-
-    zip3body->insertAtTail(new CondStmt(index,
+    SymExpr* iterator = forLoop->iteratorGet()->copy(&map);
+	VarSymbol* more = newTemp("_more_in_for", dtInt[INT_SIZE_DEFAULT]);
+	CallExpr* moreField = new CallExpr(PRIM_GET_MEMBER, iterator,
+									   new_StringSymbol("more"));
+	zip3body->insertAtTail(new CallExpr(PRIM_MOVE, more, moreField));
+    zip3body->insertAtTail(new CondStmt(new SymExpr(more),
                                         new CallExpr(PRIM_SET_MEMBER, ii->zip3->_this, ii->iclass->getField("more"), new_IntSymbol(1)),
                                         new CallExpr(PRIM_SET_MEMBER, ii->zip3->_this, ii->iclass->getField("more"), new_IntSymbol(0))));
   }

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -22,6 +22,24 @@
 
 #include "LoopStmt.h"
 
+// A ForLoop represents the language construct:
+//  for <idx> in <iterator> do <body>
+// Its semantics are to let <idx> assume the value of each of the "indices"
+// yielded by the iterator and execute the body once for each of these.
+//
+// Structurally, a ForLoop implies that there must be an underlying iterator.
+// A reference to the underlying iterator is stored in the mIterator field.
+// If the ForLoop is built with an <iterator> expression that is not an
+// iterator, code must added to promote that index set to an iterator.  In the
+// current implementation, this promotion is performed by _getIterator in
+// ChapelIteratorSupport.chpl.
+//
+// If the <idx> symbol is NULL, that means that the value of each
+// yielded element is not used in the body of the loop: the ForLoop effectively
+// just "counts" the elements in the underlying iterator -- executing the body
+// of the loop once for each.  A reference to the index symbol is stored in the
+// mIndex field.
+//
 class ForLoop : public LoopStmt
 {
   //

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -22,24 +22,11 @@
 
 #include "LoopStmt.h"
 
-// A ForLoop represents the language construct:
-//  for <idx> in <iterator> do <body>
-// Its semantics are to let <idx> assume the value of each of the "indices"
-// yielded by the iterator and execute the body once for each of these.
-//
-// Structurally, a ForLoop implies that there must be an underlying iterator.
-// A reference to the underlying iterator is stored in the mIterator field.
-// If the ForLoop is built with an <iterator> expression that is not an
-// iterator, code must added to promote that index set to an iterator.  In the
-// current implementation, this promotion is performed by _getIterator in
-// ChapelIteratorSupport.chpl.
-//
-// If the <idx> symbol is NULL, that means that the value of each
-// yielded element is not used in the body of the loop: the ForLoop effectively
-// just "counts" the elements in the underlying iterator -- executing the body
-// of the loop once for each.  A reference to the index symbol is stored in the
-// mIndex field.
-//
+// A ForLoop represents the for-statement language construct as described in
+// section 11.8 of the specification.  The buildForLoop() method transforms the
+// elements of the for-statement parrser production into its internal representation.
+// ForLoop objects are also used to represent coforall-statements and zippered
+// iteration.
 class ForLoop : public LoopStmt
 {
   //

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -23,8 +23,9 @@
 #include "LoopStmt.h"
 
 // A ForLoop represents the for-statement language construct as described in
-// section 11.8 of the specification.  The buildForLoop() method transforms the
-// elements of the for-statement parrser production into its internal representation.
+// the specification (see "The For Loop" section in the chapter on "Statements").
+// The buildForLoop() method transforms the elements of the for-statement
+// parser production into its internal representation.
 // ForLoop objects are also used to represent coforall-statements and zippered
 // iteration.
 class ForLoop : public LoopStmt


### PR DESCRIPTION
The patch ports to the master branch a fix for an error in the translation of ForLoop AST elements that was uncovered on the string-as-rec branch.  The unmodified code passes all tests on master, so committing this fix will have no visible effect upon test results in master.  It will merely pave the way for other changes pending on the string-as-rec branch.  

The undesirable behavior was observed on string-as-rec when testing the test genericArrayInClass-otharrs with -valgrindexe.  In that case, the "value" field of an iterator class instance is getting accessed before it is initialized.  Examination of the generated code reveals that valgrind is quite correct: the value field for that iterator is never initialized at all.  It is then apparently an error in iterator lowering to use a value that has never been established.  

The offending C code appears in the zip1 and zip3 functions for a follower iterator.  It examines the value of the "value" field (converted to a Boolean) and sets the "more" field in the same iterator to 1 if it is "true" and 0 otherwise.  The zip1() function is called before the body of an iterator is ever entered.  That being the case, it is quite reasonable the valgrind complains.

The second clue that ForLoop lowering is incorrect comes from the fact that the type of the "value" field in an iterator can be anything.  If a record, for example, how would one convert that to a Boolean value?  Even if _condTest is defined, why should there be any relation between the _condTest of a yielded value being false and whether or not there are more elements in the iterator?  Such an equivalence does not make any sense.

Given that a ForLoop AST element is intended to represent the language-level concept:
```
for index in iterator do body;
```
It seems logical that instead of testing the "value" field in the iterator itself (the lowered version of the ForLoop in question), the conditional should instead examine the "more" field in the contained iterator.  That is the change that I made.

The valgrind error is not observed on master, because extra initialization is inserted which is not present on the string-as-rec branch.  The call to PRIM_INIT_FIELDS that is inserted on line 193 of wrappers.cpp is removed on string-as-rec because it results in double-initialization, and this violates the AMM model.  The modification on the string-as-rec branch exposed the problem as a memory error (read before initialization), but the root cause was the error in iterator lowering.

I was unable to duplicate the error on the valgrind error on the master branch, even after removing the indicated line.  Other differences between the two branches apparent still mask the error on the master branch.

Functionally, I suspect that the change has no effect because (if I am right), ForLoops never appear as the outermost looping construct, and where they are used, the value of the more field is actually ignored.  I left the update of the "more" field in place, because that is consistent with the behavior I describe in the documentation I added to the ForLoop declaration.  However, given how it is currently used, it should be possible to replace the ForLoop constructs that remain in the tree at that point in the translation (i.e. lowerIterators) with "degenerate" iterators that merely serve up the next index value without performing any control flow at all.  Flow-of-control is left to the iterator controlling a containing loop.

TODO: See if this simplification can actually be performed.