### PR TITLE
Remove code to give temporaries the same scope as target variables.

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -908,27 +908,7 @@ static void insert_call_temps(CallExpr* call)
   tmp->addFlag(FLAG_MAYBE_TYPE);
   call->replace(new SymExpr(tmp));
 
-#if 0 // Not needed any more?
-// Not so fast! Since AMM destroys initialized variables (including temps) when
-// they exit the scope in which they are declared, temps which are to read in
-// an outer scope must be declared in an outer scope.  An easy fix is to
-// declare the temp in the same scope as the variable into which the temp is
-// eventually copied.
-  // Just fix the failing case for now.  Add others as needed.
-
-  CallExpr* stmtAsCall = toCallExpr(stmt);
-  if (stmtAsCall && stmtAsCall->isPrimitive(PRIM_MOVE) &&
-      // TODO: Remove this restriction and see if everything still works.
-      parentCall && parentCall->isPrimitive(PRIM_ADDR_OF))
-  {
-    // Declare the temp in the same scope as the target variable.
-    SymExpr* se = toSymExpr(stmtAsCall->get(1));
-    se->var->defPoint->insertBefore(new DefExpr(tmp));
-  }
-  else
-#endif
-    stmt->insertBefore(new DefExpr(tmp));
-
+  stmt->insertBefore(new DefExpr(tmp));
   stmt->insertBefore(new CallExpr(PRIM_MOVE, tmp, call));
 }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -908,6 +908,7 @@ static void insert_call_temps(CallExpr* call)
   tmp->addFlag(FLAG_MAYBE_TYPE);
   call->replace(new SymExpr(tmp));
 
+#if 0 // Not needed any more?
 // Not so fast! Since AMM destroys initialized variables (including temps) when
 // they exit the scope in which they are declared, temps which are to read in
 // an outer scope must be declared in an outer scope.  An easy fix is to
@@ -925,6 +926,7 @@ static void insert_call_temps(CallExpr* call)
     se->var->defPoint->insertBefore(new DefExpr(tmp));
   }
   else
+#endif
     stmt->insertBefore(new DefExpr(tmp));
 
   stmt->insertBefore(new CallExpr(PRIM_MOVE, tmp, call));


### PR DESCRIPTION
This was a workaround that probably became unnecessary after the rule for
inserting autodestroys was revised to place them at the end of the enclosing
scope.  Before, some variables were getting reclaimed after they were no longer
used.  Making them last as long as their declaration scope seems to be long
enough....

The workaround was causing a runtime failure in
  studies/amr/advection/amr/AMR_AdvectionCTUdriver
which is now resolved.