### PR TITLE
Revert "Construct, not copy, records into arg bundles."

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2217,32 +2217,12 @@ FnSymbol::insertBeforeReturnAfterLabel(Expr* ast) {
 }
 
 
-// Return the last, outermost Expr within 'ast' that is not a local block.
-static Expr* descendIntoLocalBlocks(Expr* ast) {
-  while (ast) {
-    if (BlockStmt* block = toBlockStmt(ast))
-      if (CallExpr* bInfo = block->blockInfoGet())
-        if (bInfo->isPrimitive(PRIM_BLOCK_LOCAL)) {
-          // descend into 'block'
-          ast = block->body.last();
-          continue;
-        }
-    // not a local block
-    break;
-  }
-  return ast;
-}
-
 void
-FnSymbol::insertBeforeDownEndCount(Expr* ast,
-                                   bool descendLocalBlocks)
-{
+FnSymbol::insertBeforeDownEndCount(Expr* ast) {
   CallExpr* ret = toCallExpr(body->body.last());
   if (!ret || !ret->isPrimitive(PRIM_RETURN))
     INT_FATAL(this, "function is not normal");
   CallExpr* last = toCallExpr(ret->prev);
-  if (!last && descendLocalBlocks)
-    last = toCallExpr(descendIntoLocalBlocks(ret->prev));
   if (!last || strcmp(last->isResolved()->name, "_downEndCount"))
     INT_FATAL(last, "Expected call to _downEndCount");
   last->insertBefore(ast);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -378,8 +378,7 @@ class FnSymbol : public Symbol {
 
   void            insertBeforeReturn(Expr* ast);
   void            insertBeforeReturnAfterLabel(Expr* ast);
-  void            insertBeforeDownEndCount(Expr* ast,
-                                           bool descendLocalBlocks = false);
+  void            insertBeforeDownEndCount(Expr* ast);
 
   void            insertFormalAtHead(BaseAST* ast);
   void            insertFormalAtTail(BaseAST* ast);

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -169,11 +169,9 @@ static void create_arg_bundle_class(FnSymbol* fn, CallExpr* fcall, ModuleSymbol*
 
 /// Optionally autoCopies an argument being inserted into an argument bundle.
 ///
-/// This routine inserts an autoCopy of a record being passed into
-/// a task function, so the shadow record is properly constructed.
-/// For internal reference-counted types, we need this only for begins;
-/// for the other task functions we optimize away refcnt increment/decrement.
-///
+/// This routine optionally inserts an autoCopy ahead of each invocation of a
+/// task function that begins asynchronous execution (currently just "begin" and
+/// "nonblocking on" functions).  
 /// If such an autoCopy call is inserted, a matching autoDestroy call is placed
 /// at the end of the tasking routine before the call to _downEndCount.  Since a
 /// tasking function may be called from several call sites, the task function is
@@ -198,24 +196,16 @@ static Symbol* insertAutoCopyDestroyForTaskArg
 {
   SymExpr* s = toSymExpr(arg);
   Symbol* var = s->var;
-  Type* baseType = arg->getValType();
 
-  // for reference-counted types in a 'begin'
-  bool needForRefCnt = false;
-  // for records passed by value to any task function
-  bool needForRecord = false;
-
-  if (isRefCountedType(baseType))
-    needForRefCnt = fn->hasFlag(FLAG_BEGIN);
-  else if (isRecord(baseType)) // important: !isRefCountedType(baseType)
-    needForRecord =  arg->typeInfo() == baseType;
-
-  if (needForRefCnt || needForRecord)
+  // This applies only to arguments being passed to asynchronous task functions.
+  // No need to increment+decrement the reference counters for cobegins/coforalls.
+  if (fn->hasFlag(FLAG_BEGIN))
   {
+    Type* baseType = arg->getValType();
     FnSymbol* autoCopyFn = getAutoCopy(baseType);
     FnSymbol* autoDestroyFn = getAutoDestroy(baseType);
 
-    if (needForRefCnt)
+    if (isRefCountedType(baseType))
     {
       // TODO: Can we consolidate these two clauses?
       // Does arg->typeInfo() != baseType mean that arg is passed by ref?
@@ -265,56 +255,14 @@ static Symbol* insertAutoCopyDestroyForTaskArg
         insertReferenceTemps(autoDestroyCall);
       }
     }
-    else
+    else if (isRecord(baseType))
     {
-      INT_ASSERT(needForRecord);
-      // This gotta be a task function, possibly for an 'on'.
-      // Otherwise why are we here?
-      INT_ASSERT(isTaskFun(fn));
-
-      // TODO: Find out why _RuntimeTypeInfo records do not have autoCopy
-      // functions, so we can get rid of this special test.
-      if (autoCopyFn == NULL)
+      // Do this only if the record is passed by value.
+      if (arg->typeInfo() == baseType)
       {
-        // nothing to do
-      }
-      else if (autoCopyFn->hasFlag(FLAG_COMPILER_GENERATED) &&
-               autoDestroyFn->hasFlag(FLAG_COMPILER_GENERATED))
-      {
-        // Check whether autoCopy/autoDestroy have no side effects.
-        // Ideally we would use FLAG_HAS_USER_DESTRUCTOR and
-        // extend markPODtypes() to compute FLAG_HAS_USER_COPY_CONSTRUCTOR.
-        //
-        // If no side effects, we do not need to insert them, and do not need
-        // the USR_FATAL_CONT in the "else" case.
-      }
-      else if (fn->hasFlag(FLAG_ON) && arg == fcall->get(1))
-      {
-        // Also we do not want to generate the USR_FATAL_CONT
-        // when passing dummy_locale_arg: chpl_localeID_t,
-        // which is a record that is passed to any on_fn.
-        //
-        // TODO: annotate chpl_localeID_t's autocopy/destroy
-        // with FLAG_COMPILER_GENERATED to avoid this special case?
-      }
-      else
-      {
-        // Beware of record destructors with 'on', e.g.:
-        //   proc ~R.R() { on ... { ... this ... } }
-        //
-        // There, currently 'this' will be autoCopy-ed into the on_fn,
-        // then autoDestroy-ed there. That will call the destructor,
-        // autoDestroy-ing, etc. -- resulting in an infinite loop.
-        //
-        // The bug is that we pass records by value, whereas it should be
-        // by const ref - in which case there will be no construction or
-        // destruction, so no infinite loop.
-        //
-        if (fcall->parentSymbol->hasEitherFlag(FLAG_AUTO_COPY_FN,
-                                               FLAG_AUTO_DESTROY_FN))
-          USR_FATAL_CONT(fn, "record constructors or destructors"
-                         " with task constructs or 'on' clauses"
-                         " are currently not implemented");
+        // TODO: Find out why _RuntimeTypeInfo records do not have autoCopy
+        // functions, so we can get rid of this special test.
+        if (autoCopyFn == NULL) return var;
 
         // Insert a call to the autoCopy function ahead of the call.
         VarSymbol* valTmp = newTemp(baseType);
@@ -330,11 +278,7 @@ static Symbol* insertAutoCopyDestroyForTaskArg
           // (But only once per function for each affected argument.)
           Symbol* formal = actual_to_formal(arg);
           CallExpr* autoDestroyCall = new CallExpr(autoDestroyFn,formal);
-          // Sometimes there is _downEndCount, sometimes there isn't.
-          if (fn->hasFlag(FLAG_ON) && !fn->hasFlag(FLAG_NON_BLOCKING))
-            fn->insertBeforeReturn(autoDestroyCall);
-          else
-            fn->insertBeforeDownEndCount(autoDestroyCall, true);
+          fn->insertBeforeDownEndCount(autoDestroyCall);
           insertReferenceTemps(autoDestroyCall);
         }
       }


### PR DESCRIPTION
Reverts chapel-lang/chapel#2010

Reverting because #2010 did not fix the bugs it intended to, and caused increased reference counts it all/most of the following tests in dist-replicated and dist-cyclic configurations:

  distributions/robust/arithmetic/performance/multilocale/alloc
  distributions/robust/arithmetic/performance/multilocale/alloc_all
  distributions/robust/arithmetic/performance/multilocale/assignAlias
  distributions/robust/arithmetic/performance/multilocale/assignSlice
  distributions/robust/arithmetic/performance/multilocale/reduceAlias
  distributions/robust/arithmetic/performance/multilocale/reduceSlice

Why are we getting extra comm counts? In Replicated, for example, creating a domain involves copying the DefaultRectantular array (I believe) of locales as part of privatization. Such copying involves this:

    // A, B are arrays
    forall ... in zip(A,B) {BODY;}

This gets translated into:

    chpl__iterLF = tuple(A,B);
    ...
    for ... leader iterator ... {
      chpl__followerIter = _getIteratorZip(_toFollowerZip(chpl__iterLF, chpl__leadIdxCopy));
      for ... follower loop ... {
        BODY;
      }
    }

When the leader iterator has a coforall, we get this after inlining:

    chpl__iterLF = tuple(A,B);
    ...
    coforall ... {
      chpl__followerIter = _getIteratorZip(_toFollowerZip(chpl__iterLF, chpl__leadIdxCopy));
      ...
    }

Since chpl__iterLF is going into a task function, with this PR
it get autoCopy'ed into the argument bundle, and then autoDestroyed
after the task completes. This means updating reference counts.
If one/both of A,B are remote, this entails communication.
Before this PR, these autoCopy/autoDestroy were not added
so comm counts were lower.

When it's just one array, we can tell it's an array and avoid
manipulating reference counts. However, since this iterates over zip(A,B),
autoCopy/autoDestroy are done on a tuple as a whole, treating it as an
anonymous record, and it is unclear how we can have autoCopy/autoDestroy
on a record component if it is a proper record and not if it is
an array wrapper record.

I could change this PR to avoid autoCopy/autoDestroy
on variables named 'chpl__iterLF' and 'chpl_iterSA'.
Backing this out is simpler, avoids more cludges,
and is Brad's preference.
