### PR TITLE
Suppress test_glob --baseline testing for the time being

### DIFF
--- a/test/studies/glob/test_glob.suppressif
+++ b/test/studies/glob/test_glob.suppressif
@@ -1,0 +1,7 @@
+# AMM-related bug; should be fixed when string-as-rec is merged
+# -------------------------------------------------------------
+# With --baseline, we free the domain(string) in the parallel glob
+# iterator too aggressively; the AMM work on the string-as-rec branch
+# seems to correct this, so let's suppress this case until that fix
+# can be integrated.
+COMPOPTS <= --baseline


### PR DESCRIPTION
Investigating yesterday, I verified that the test_glob failure
is an AMM-related issue due to double-freeing of a domain(string).
Tom verified that on the AMM branch it works as expected.  For
that reason, suppress this test for the time being and when AMM
is incorporated, we should be good to go.