### PR TITLE
Dont zip nude domains

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1912,7 +1912,6 @@ inlineIterators() {
 // It may be that it needs to be revised and reinserted.  But it is at least 
 // less harried to approach the ideal from the side of leaking memory over
 // approaching from the side where execution fails.
-#if !HILDE_MM
 static void addCrossedFreeIteratorCalls(GotoStmt* stmt)
 {
   // Examine the target label of the goto and find the block containing the
@@ -2014,7 +2013,6 @@ static void addCrossedFreeIteratorCalls()
     }
   }
 }
-#endif
 
 
 static void fixNumericalGetMemberPrims()
@@ -2341,7 +2339,7 @@ void lowerIterators() {
 
   removeUncalledIterators();
 
-//  addCrossedFreeIteratorCalls();
+  addCrossedFreeIteratorCalls();
 
   fixNumericalGetMemberPrims();
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -147,9 +147,14 @@ module ChapelBase {
   config param CHPL_CACHE_REMOTE: bool = false;
 
   config param noRefCount = false;
-  config param debugArrRefCount = false;
-  config param debugDomRefCount = false;
-  config param debugDistRefCount = false;
+  /* Control refCount debugging:
+   * 0 = off
+   * 1 = errors only
+   * 2 = verbose
+   */
+  config param debugArrRefCount = 0;
+  config param debugDomRefCount = 0;
+  config param debugDistRefCount = 0;
 
   config param warnMaximalRange = false;    // Warns if integer rollover will cause
                     // the iterator to yield zero times.

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -92,11 +92,13 @@ module ChapelDistribution {
   
     inline proc incRefCount(cnt=1) {
       compilerAssert(!noRefCount);
-      if debugDistRefCount {
-        extern proc printf(fmt: c_string, arg...);
+      if debugDistRefCount > 0 {
         const cnt = _distCnt.read();
-        printf("----- INC _distCnt (%016lx) was %ld\n",
-               __primitive("cast", uint(64), this), cnt);
+        if debugDistRefCount > 1 {
+          extern proc printf(fmt: c_string, arg...);
+          printf("----- INC _distCnt (%016lx) was %ld\n",
+                 __primitive("cast", uint(64), this), cnt);
+        }
         if cnt < 0 || cnt > 1000 then
             halt("_distCnt is bogus!");
       }
@@ -106,10 +108,12 @@ module ChapelDistribution {
     inline proc decRefCount() {
       compilerAssert(!noRefCount);
       const cnt = _distCnt.dec();
-      if debugDistRefCount {
-        extern proc printf(fmt: c_string, arg...);
-        printf("----- DEC _distCnt (%016lx) now %ld\n",
-               __primitive("cast", uint(64), this), cnt);
+      if debugDistRefCount > 0 {
+        if debugDistRefCount > 1 {
+          extern proc printf(fmt: c_string, arg...);
+          printf("----- DEC _distCnt (%016lx) now %ld\n",
+                 __primitive("cast", uint(64), this), cnt);
+        }
         if cnt < 0 || cnt > 1000 then
             halt("_distCnt is bogus!");
         // Poison the distCount, so an attempt to move it away from zero a
@@ -196,11 +200,13 @@ module ChapelDistribution {
   
     inline proc incRefCount(cnt=1) {
       compilerAssert(!noRefCount);
-      if debugDomRefCount {
-        extern proc printf(fmt: c_string, arg...);
+      if debugDomRefCount > 0 {
         const cnt = _domCnt.read();
-        printf("----- INC _domCnt (%016lx) was %ld\n", 
-               __primitive("cast", uint(64), this), cnt);
+        if debugDomRefCount > 1 {
+          extern proc printf(fmt: c_string, arg...);
+          printf("----- INC _domCnt (%016lx) was %ld\n", 
+                 __primitive("cast", uint(64), this), cnt);
+        }
         if cnt < 0 || cnt > 10000 then
           halt("_domCnt is bogus!");
       }
@@ -210,10 +216,12 @@ module ChapelDistribution {
     inline proc decRefCount() {
       compilerAssert(!noRefCount);
       const cnt = _domCnt.dec(); //_domCnt.fetchSub(1)-1;
-      if debugDomRefCount {
-        extern proc printf(fmt: c_string, arg...);
-        printf("----- DEC _domCnt (%016lx) now %ld\n", 
-               __primitive("cast", uint(64), this), cnt);
+      if debugDomRefCount > 0 {
+        if debugDomRefCount > 1 {
+          extern proc printf(fmt: c_string, arg...);
+          printf("----- DEC _domCnt (%016lx) now %ld\n", 
+                 __primitive("cast", uint(64), this), cnt);
+        }
         if cnt < 0 || cnt > 10000 then
             halt("_domCnt is bogus!");
         // Poison the domCount, so an attempt to move it away from zero a
@@ -376,11 +384,13 @@ module ChapelDistribution {
   
     inline proc incRefCount(cnt=1) {
       compilerAssert(!noRefCount);
-      if debugArrRefCount {
-        extern proc printf(fmt: c_string, arg...);
+      if debugArrRefCount > 0 {
         const cnt = _arrCnt.read();
-        printf("----- INC _arrCnt (%016lx) was %ld\n", 
-               __primitive("cast", uint(64), this), cnt);
+        if debugArrRefCount > 1 {
+          extern proc printf(fmt: c_string, arg...);
+          printf("----- INC _arrCnt (%016lx) was %ld\n", 
+                 __primitive("cast", uint(64), this), cnt);
+        }
         if cnt < 0 || cnt > 10000 then
           halt("_arrCnt is bogus!");
       }
@@ -390,10 +400,12 @@ module ChapelDistribution {
     inline proc decRefCount() {
       compilerAssert(!noRefCount);
       const cnt = _arrCnt.dec(); //_arrCnt.fetchSub(1)-1;
-      if debugArrRefCount {
-        extern proc printf(fmt: c_string, arg...);
-        printf("----- DEC _arrCnt (%016lx) now %ld\n", 
-               __primitive("cast", uint(64), this), cnt);
+      if debugArrRefCount > 0 {
+        if debugArrRefCount > 1 {
+          extern proc printf(fmt: c_string, arg...);
+          printf("----- DEC _arrCnt (%016lx) now %ld\n", 
+                 __primitive("cast", uint(64), this), cnt);
+        }
         if cnt < 0 || cnt > 10000 then
             halt("_arrCnt is bogus!");
         // Poison the arrCount, so an attempt to move it away from zero a

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -112,6 +112,9 @@ module ChapelDistribution {
                __primitive("cast", uint(64), this), cnt);
         if cnt < 0 || cnt > 1000 then
             halt("_distCnt is bogus!");
+        // Poison the distCount, so an attempt to move it away from zero a
+        // second time will fail
+        if cnt == 0 then _distCnt.dec();
       }
       return cnt;
     }
@@ -213,6 +216,9 @@ module ChapelDistribution {
                __primitive("cast", uint(64), this), cnt);
         if cnt < 0 || cnt > 10000 then
             halt("_domCnt is bogus!");
+        // Poison the domCount, so an attempt to move it away from zero a
+        // second time will fail
+        if cnt == 0 then _domCnt.dec();
       }
       return cnt;
     }
@@ -390,6 +396,9 @@ module ChapelDistribution {
                __primitive("cast", uint(64), this), cnt);
         if cnt < 0 || cnt > 10000 then
             halt("_arrCnt is bogus!");
+        // Poison the arrCount, so an attempt to move it away from zero a
+        // second time will fail
+        if cnt == 0 then _arrCnt.dec();
       }
       return cnt;
     }

--- a/test/studies/hpcc/common/bradc/unit/leadFollowOpt.chpl
+++ b/test/studies/hpcc/common/bradc/unit/leadFollowOpt.chpl
@@ -7,5 +7,18 @@ var D2 = Dist.newRectangularDom(1, int(64), false);
 D1.dsiSetIndices({1..9});
 D2.dsiSetIndices({2..10});
 
+// Parallel iteration over "nude" domains is dangerous.
+// This is the other way to avoid the problem.
+D1.incRefCount();
+D2.incRefCount();
+
 forall (i,j) in zip(D1, D2) do
   writeln("(i,j) is: ", (i,j));
+
+var cnt2 = D2.decRefCount();
+if cnt2 == 0 then
+  delete D2;
+
+var cnt1 = D1.decRefCount();
+if cnt1 == 0 then
+  delete D1;

--- a/test/studies/hpcc/common/bradc/unit/parBlock1D.chpl
+++ b/test/studies/hpcc/common/bradc/unit/parBlock1D.chpl
@@ -2,10 +2,16 @@ use BlockDist;
 
 var Dist = new dmap(new Block(boundingBox={1..9}));
 
-var D1 = Dist.newRectangularDom(1, int(64), false);
-var D2 = Dist.newRectangularDom(1, int(64), false);
-D1.dsiSetIndices({1..9});
-D2.dsiSetIndices({2..10});
+// hilde sez: Parallel iteration of "nude" domains can lead to MM errors.
+// One must either adjust the ref count manually, to move it away from zero, or
+// manipulate those domains through record-wrappers, to have the reference
+// counting done automatically.  The latter is the recommended coding style.
+// var D1 = Dist.newRectangularDom(1, int(64), false);
+// var D2 = Dist.newRectangularDom(1, int(64), false);
+var D1 = _newDomain(Dist.newRectangularDom(1, int(64), false));
+var D2 = _newDomain(Dist.newRectangularDom(1, int(64), false));
+D1._value.dsiSetIndices({1..9});
+D2._value.dsiSetIndices({2..10});
 
 forall (i,j) in zip(D1, D2) do
   writeln("on ", here.id, ", (i,j) is: ", (i,j));


### PR DESCRIPTION
This patch also includes improvements to refCount debugging and re-enables the optimization that inserts crossed freeIterator() calls.  The first of these changes was inserted to help with testing -- to detect other places where dom counts were not properly managed.  It exposed cases where dom counts were tending toward infinity.  The second additional change corrected that problem.