### PR TITLE
Support generic methods on the value type.

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1457,6 +1457,7 @@ void initPrimitiveTypes() {
   CREATE_DEFAULT_SYMBOL (dtVoid, gVoid, "_void");
 
   dtValue = createInternalType("value", "_chpl_value");
+  dtValue->symbol->addFlag(FLAG_GENERIC);
 
   INIT_PRIM_BOOL("bool(1)", 1);
   INIT_PRIM_BOOL("bool(8)", 8);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1111,6 +1111,8 @@ canInstantiate(Type* actualType, Type* formalType) {
     return true;
   if (formalType == dtIntegral && (is_int_type(actualType) || is_uint_type(actualType)))
     return true;
+  if (formalType == dtValue && isRecord(actualType) )
+    return true;
   if (formalType == dtAnyEnumerated && (is_enum_type(actualType)))
     return true;
   if (formalType == dtNumeric &&


### PR DESCRIPTION
dtValue (in the compiler) and value (in the modules) are the names for the
root of the type heirarchy for record types. These should probably be
renamed something more descriptive - _record and dtRecordType for example.

For example:

    proc value.doit() { writeln(this); }


For example:

    proc value.doit() { writeln(this); }

Here value means any Chapel record type.  We do it by marking dtValue as
generic and allowing any record to dispatch to arguments of type dtValue.
If dtValue is not generic, a call to this example method would not trigger
generic function resolution, and so would fail to resolve. Since you can't
ever actually create a dtValue, it is a generic type.

I prepared this patch as a spin-off of my effort to make user-defined
coercion and cast methods. The part of that patch that ran into a lot of
mess is turning cast into a method - it's currently a function.

For example, the string module defines casts from any type to string, so
we need to support:

    proc value.cast(type t) where t == string { ... }

if casts are to become methods.


Future work:
 - rename dtValue and value to dtRecordType and _record (or better names)
 - comment dtValue
 - clean up scope and function resolution

Other Notes:
 * This is currently the main user of value in the module code:

        proc isRecordType(type t) param where t: value { ... }

 * in isRecordType, the where clause is converted from a cast to
   PRIM_IS_SUBTYPE in  cleanup.cpp (in change_cast_in_where). Then
   function resolution replaces such PRIM_IS_SUBTYPE calls with param true
   or param false in postFold.
 * postFold is checking dispatchParents to check the type relationship.
   The dispatchParents field is currently populated in scopeResolve.

- [x] pass full local testing
