### PR TITLE
String as rec June 11 leak fixes.

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -1276,6 +1276,9 @@ rebuildIterator(IteratorInfo* ii,
 
   // Return the filled-in iterator record.
   fn->insertAtTail(new CallExpr(PRIM_RETURN, iterator));
+  // TODO: Add a consistency check to ensure that the two clauses in
+  // getReturnSymbol() (retSymbol!=NULL versus ==NULL) always agree.
+  fn->retSymbol = iterator;
   ii->getValue->defPoint->insertAfter(new DefExpr(fn));
   fn->addFlag(FLAG_INLINE);
 }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -99,8 +99,8 @@ module ChapelDistribution {
           printf("----- INC _distCnt (%016lx) was %ld\n",
                  __primitive("cast", uint(64), this), cnt);
         }
-        if cnt < 0 || cnt > 1000 then
-            halt("_distCnt is bogus!");
+        if cnt < 0 || cnt > 10000 then
+          halt("_distCnt ", cnt, " is bogus!");
       }
       _distCnt.inc(cnt);
     }
@@ -114,8 +114,8 @@ module ChapelDistribution {
           printf("----- DEC _distCnt (%016lx) now %ld\n",
                  __primitive("cast", uint(64), this), cnt);
         }
-        if cnt < 0 || cnt > 1000 then
-            halt("_distCnt is bogus!");
+        if cnt < 0 || cnt > 10000 then
+          halt("_distCnt ", cnt, " is bogus!");
         // Poison the distCount, so an attempt to move it away from zero a
         // second time will fail
         if cnt == 0 then _distCnt.dec();
@@ -208,7 +208,7 @@ module ChapelDistribution {
                  __primitive("cast", uint(64), this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
-          halt("_domCnt is bogus!");
+          halt("_domCnt ", cnt, " is bogus!");
       }
       _domCnt.inc(cnt);
     }
@@ -223,7 +223,7 @@ module ChapelDistribution {
                  __primitive("cast", uint(64), this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
-            halt("_domCnt is bogus!");
+          halt("_domCnt ", cnt, " is bogus!");
         // Poison the domCount, so an attempt to move it away from zero a
         // second time will fail
         if cnt == 0 then _domCnt.dec();
@@ -392,7 +392,7 @@ module ChapelDistribution {
                  __primitive("cast", uint(64), this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
-          halt("_arrCnt is bogus!");
+          halt("_arrCnt ", cnt, " is bogus!");
       }
       _arrCnt.inc(cnt);
     }
@@ -407,7 +407,7 @@ module ChapelDistribution {
                  __primitive("cast", uint(64), this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
-            halt("_arrCnt is bogus!");
+          halt("_arrCnt ", cnt, " is bogus!");
         // Poison the arrCount, so an attempt to move it away from zero a
         // second time will fail
         if cnt == 0 then _arrCnt.dec();

--- a/test/release/examples/benchmarks/shootout/chameneosredux.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.chpl
@@ -74,6 +74,12 @@ proc simulate(numChameneos) {
   // print information about the population once we're done
   //
   printInfo(chameneos);
+
+  //
+  // hasta las chameneos, baby.
+  //
+  destroyChameneos(chameneos);
+  delete meetingPlace;
 }
 
 
@@ -263,6 +269,11 @@ proc createChameneos(size): [1..size] Chameneos {
 
   return [i in 1..size] new Chameneos(i, if (size == 10) then colorsFor10[i]
                                                          else ((i-1)%3):Color);
+}
+
+
+proc destroyChameneos(ca: [] Chameneos) {
+  for c in ca do delete c;
 }
 
 


### PR DESCRIPTION
Discovered through -sdebugDomRefCount=1 that ref counts were being double-incremented in some "these" routines.  The cure was to update the return symbol in rebuildIterator.

Also fixed chameneosredux to give back some memory it was neglecting to free.