### PR TITLE
Update these test prediffs to not be sensitive to symlinks

### DIFF
--- a/test/modules/standard/FileSystem/lydia/parallelDirState/chdirAllLocales.prediff
+++ b/test/modules/standard/FileSystem/lydia/parallelDirState/chdirAllLocales.prediff
@@ -1,5 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env python
 
-parentDir=${PWD}
+import os, os.path, sys
+import fileinput
 
-echo "`sed "s%$parentDir%%g" $2`" > $2
+parentDir = os.getenv('PWD')
+parentDir = os.path.realpath(parentDir)
+
+for line in fileinput.input(sys.argv[2], inplace=True):
+  print(line.replace(parentDir, '').rstrip())
+

--- a/test/modules/standard/FileSystem/lydia/parallelDirState/chdirMultiTasks.prediff
+++ b/test/modules/standard/FileSystem/lydia/parallelDirState/chdirMultiTasks.prediff
@@ -1,12 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env python
 
-correctRes="${PWD}/task1/0
-${PWD}/task1/0
-${PWD}/task1/1
-${PWD}/task1/2
-${PWD}/task1/3
-${PWD}/task1/4
-${PWD}/task1/5"
-if [ "`cat $2`" = "${correctRes}" ]; then
-	echo ok > $2
-fi
+import os, os.path, sys
+
+parentDir = os.getenv('PWD')
+parentDir = os.path.realpath(parentDir)
+expected = parentDir + '/task1/0\n' + parentDir + '/task1/0\n' + parentDir + '/task1/1\n' + parentDir + '/task1/2\n' + parentDir + '/task1/3\n' + parentDir + '/task1/4\n' + parentDir + '/task1/5\n'
+
+f = open(sys.argv[2], 'r')
+
+result = ""
+
+# read in entirety of file
+for line in f:
+    result += line
+
+if (result == expected):
+    f.close()
+    f = open(sys.argv[2], 'w')
+    f.write("ok\n")
+
+f.close();

--- a/test/modules/standard/FileSystem/lydia/parallelDirState/chdirMultiTasks.prediff
+++ b/test/modules/standard/FileSystem/lydia/parallelDirState/chdirMultiTasks.prediff
@@ -4,7 +4,10 @@ import os, os.path, sys
 
 parentDir = os.getenv('PWD')
 parentDir = os.path.realpath(parentDir)
-expected = parentDir + '/task1/0\n' + parentDir + '/task1/0\n' + parentDir + '/task1/1\n' + parentDir + '/task1/2\n' + parentDir + '/task1/3\n' + parentDir + '/task1/4\n' + parentDir + '/task1/5\n'
+expected = parentDir + '/task1/0\n' + parentDir + '/task1/0\n'
+expected += parentDir + '/task1/1\n' + parentDir + '/task1/2\n'
+expected += parentDir + '/task1/3\n' + parentDir + '/task1/4\n'
+expected += parentDir + '/task1/5\n'
 
 f = open(sys.argv[2], 'r')
 


### PR DESCRIPTION
Michael noticed that when following a symlink to the test directory, these tests
would fail.  This was because the prediffs relied on $PWD, which is sensitive
to symlinks, but cwd() shouldn't be.  I have updated the prediffs to be
insensitive to symlinks.  This meant switching from bash to python, because
bash's realpath is not necessarily portable to use.