### PR TITLE
Delete Chameneos test classes after we're done with them

### DIFF
--- a/test/release/examples/benchmarks/shootout/chameneosredux.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.chpl
@@ -74,6 +74,12 @@ proc simulate(numChameneos) {
   // print information about the population once we're done
   //
   printInfo(chameneos);
+
+  //
+  // Clean up after ourselves
+  //
+  destroyChameneos(chameneos);
+  delete meetingPlace;
 }
 
 
@@ -265,6 +271,12 @@ proc createChameneos(size): [1..size] Chameneos {
                                                          else ((i-1)%3):Color);
 }
 
+//
+// Destroy the array of chameneos
+//
+proc destroyChameneos(ca: [] Chameneos) {
+  for c in ca do delete c;
+}
 
 //
 // getNewColor() returns the complement of two colors; if the two colors

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -86,6 +86,12 @@ proc simulate(numChameneos) {
   // print information about the population once we're done
   //
   printInfo(chameneos);
+
+  //
+  // Clean up after ourselves
+  //
+  destroyChameneos(chameneos);
+  delete meetingPlace;
 }
 
 
@@ -289,6 +295,13 @@ proc createChameneos(size): [1..size] Chameneos {
                                                          else ((i-1)%3):Color);
 }
 
+
+//
+// Destroy the array of chameneos
+//
+proc destroyChameneos(ca: [] Chameneos) {
+  for c in ca do delete c;
+}
 
 //
 // getNewColor() returns the complement of two colors; if the two colors

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
@@ -245,6 +245,15 @@ proc main() {
 
     run(population2, forest);
     printInfo(population2);
+
+
+    // clean up after ourselves
+    destroyChameneos(population1);
+    destroyChameneos(population2);
+    delete forest;
   }
 }
 
+proc destroyChameneos(ca: [] Chameneos) {
+  for c in ca do delete c;
+}

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
@@ -222,6 +222,14 @@ proc main() {
 
     run(population2, forest);
     printInfo(population2);
+
+    // clean up after ourselves
+    destroyChameneos(population1);
+    destroyChameneos(population2);
+    delete forest;
   }
 }
 
+proc destroyChameneos(ca: [] Chameneos) {
+  for c in ca do delete c;
+}

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
@@ -226,6 +226,14 @@ proc main() {
 
     run(population2, forest);
     printInfo(population2);
+
+    // clean up after ourselves
+    destroyChameneos(population1);
+    destroyChameneos(population2);
+    delete forest;
   }
 }
 
+proc destroyChameneos(ca: [] Chameneos) {
+  for c in ca do delete c;
+}


### PR DESCRIPTION
@hildeth noticed on the string-as-rec branch that we weren't deleting the
meetingPlace and Chameneos classes after we were done with them.  He fixed it
for the release directory, but I figured we were doing the same thing for the
studies/ directory as well, so propogate the change.

I noticed no difference in performance and no failure in a normal run.