### PR TITLE
Plugging user-level memory leaks in do_smu tests

### DIFF
--- a/test/users/npadmana/twopt/do_smu.chpl
+++ b/test/users/npadmana/twopt/do_smu.chpl
@@ -252,36 +252,24 @@ proc TreeAccumulate(hh : UniformBins, p1, p2 : SOA_WeightedParticle3D, node1, no
 
 // A simple testHarness
 proc testPairs() {
-  var totTimer: Timer;
-  totTimer.start();
-  totTimer.clear();
-  var timer: Timer;
-  timer.start();
-  timer.clear();
   
   // Read in the file
   var nlines = countLines(fn1);
   var pp1 : [0.. #nlines] WeightedParticle3D;
   readFile("test.dat",pp1);
-  const inputTime = timer.elapsed();  timer.clear();
 
   // Build the tree
   var scr : [0.. #nlines] WeightedParticle3D;
   var root1 = BuildTree(pp1,scr,0);
-  const buildTreeTime = timer.elapsed();  timer.clear();
 
   // Set up the histogram
   var hh = new UniformBins(2,(nsbins,nmubins), ((0.0,smax),(0.0,1.0+1.e-10)));
-  const histSetupTime = timer.elapsed();  timer.clear();
 
   // AOS -> SOA
   var soa1 = new SOA_WeightedParticle3D(pp1);
-  //  delete pp1;
-  const aos2soaTime = timer.elapsed(); timer.clear();
 
   // Do the paircounts with a tree
   sync TreeAccumulate(hh, soa1, soa1, root1, root1);
-  const accumTreeTime = timer.elapsed();  timer.clear();
   for xx in hh.bins(1) do writef("%12.4dr",xx); 
   writeln();
   for xx in hh.bins(2) do writef("%12.4dr",xx); 
@@ -292,19 +280,6 @@ proc testPairs() {
     }
     writeln();
   }
-  const output2Time = timer.elapsed();  timer.clear();
-  const totTime = totTimer.elapsed();
-
-  writeln("input:      ", inputTime);
-  //  writeln("shuffle:    ", shuffleTime);
-  writeln("hist setup: ", histSetupTime);
-  //  writeln("accum:      ", accumTime);
-  //  writeln("output1:    ", outputTime);
-  writeln("build tree: ", buildTreeTime);
-  writeln("accum tree: ", accumTreeTime);
-  writeln("output2:    ", output2Time);
-  writeln("------------");
-  writeln("total:      ", totTime);
 
   //
   // clean up
@@ -351,8 +326,6 @@ proc doPairs() {
   tt.clear(); tt.start();
   var soa1 = new SOA_WeightedParticle3D(pp1);
   var soa2 = new SOA_WeightedParticle3D(pp2);
-  //  delete pp1;
-  //  delete pp2;
   tt.stop();
   writef("Time to SOA : %r \n", tt.elapsed());
 

--- a/test/users/npadmana/twopt/do_smu.chpl
+++ b/test/users/npadmana/twopt/do_smu.chpl
@@ -252,24 +252,36 @@ proc TreeAccumulate(hh : UniformBins, p1, p2 : SOA_WeightedParticle3D, node1, no
 
 // A simple testHarness
 proc testPairs() {
+  var totTimer: Timer;
+  totTimer.start();
+  totTimer.clear();
+  var timer: Timer;
+  timer.start();
+  timer.clear();
   
   // Read in the file
   var nlines = countLines(fn1);
   var pp1 : [0.. #nlines] WeightedParticle3D;
   readFile("test.dat",pp1);
+  const inputTime = timer.elapsed();  timer.clear();
 
   // Build the tree
   var scr : [0.. #nlines] WeightedParticle3D;
   var root1 = BuildTree(pp1,scr,0);
+  const buildTreeTime = timer.elapsed();  timer.clear();
 
   // Set up the histogram
   var hh = new UniformBins(2,(nsbins,nmubins), ((0.0,smax),(0.0,1.0+1.e-10)));
+  const histSetupTime = timer.elapsed();  timer.clear();
 
   // AOS -> SOA
   var soa1 = new SOA_WeightedParticle3D(pp1);
+  //  delete pp1;
+  const aos2soaTime = timer.elapsed(); timer.clear();
 
   // Do the paircounts with a tree
   sync TreeAccumulate(hh, soa1, soa1, root1, root1);
+  const accumTreeTime = timer.elapsed();  timer.clear();
   for xx in hh.bins(1) do writef("%12.4dr",xx); 
   writeln();
   for xx in hh.bins(2) do writef("%12.4dr",xx); 
@@ -280,6 +292,26 @@ proc testPairs() {
     }
     writeln();
   }
+  const output2Time = timer.elapsed();  timer.clear();
+  const totTime = totTimer.elapsed();
+
+  writeln("input:      ", inputTime);
+  //  writeln("shuffle:    ", shuffleTime);
+  writeln("hist setup: ", histSetupTime);
+  //  writeln("accum:      ", accumTime);
+  //  writeln("output1:    ", outputTime);
+  writeln("build tree: ", buildTreeTime);
+  writeln("accum tree: ", accumTreeTime);
+  writeln("output2:    ", output2Time);
+  writeln("------------");
+  writeln("total:      ", totTime);
+
+  //
+  // clean up
+  //
+  delete soa1;
+  delete hh;
+  delete root1;
 }
 
 
@@ -319,6 +351,8 @@ proc doPairs() {
   tt.clear(); tt.start();
   var soa1 = new SOA_WeightedParticle3D(pp1);
   var soa2 = new SOA_WeightedParticle3D(pp2);
+  //  delete pp1;
+  //  delete pp2;
   tt.stop();
   writef("Time to SOA : %r \n", tt.elapsed());
 
@@ -338,5 +372,14 @@ proc doPairs() {
   tt.stop();
   writef("Time to tree paircount : %r \n", tt.elapsed());
   writeHist("%s.tree".format(pairfn),hh);
+
+  //
+  // clean up
+  //
+  delete soa1;
+  delete soa2;
+  delete hh;
+  delete root1;
+  delete root2;
 }
 

--- a/test/users/npadmana/twopt/do_smu_soa.chpl
+++ b/test/users/npadmana/twopt/do_smu_soa.chpl
@@ -282,26 +282,15 @@ proc smuAccumulate(hh : UniformBins, p1,p2 : Particle3D, d1,d2 : domain(1), scal
 
 
 proc testPairs() {
-  var totTimer: Timer;
-  totTimer.start();
-  totTimer.clear();
-  var timer: Timer;
-  timer.start();
-  timer.clear();
-
   var pp = readFile("test.dat");
-  const inputTime = timer.elapsed();  timer.clear();
   // Put in a shuffle
   pp.shuffle();
-  const shuffleTime = timer.elapsed();  timer.clear();
 
   // Set up the histogram
   var hh = new UniformBins(2,(nsbins,nmubins), ((0.0,smax),(0.0,1.0+1.e-10)));
-  const histSetupTime = timer.elapsed();  timer.clear();
 
   // Do the paircounts with a tree
   smuAccumulate(hh,pp,pp,pp.Dpart,pp.Dpart,1.0);
-  const accumTime = timer.elapsed();  timer.clear();
   for xx in hh.bins(1) do writef("%12.4dr",xx); 
   writeln();
   for xx in hh.bins(2) do writef("%12.4dr",xx); 
@@ -312,14 +301,11 @@ proc testPairs() {
     }
     writeln();
   }
-  const outputTime = timer.elapsed();  timer.clear();
 
   // Build the tree
   var root1 = BuildTree(pp, 0, pp.npart-1, 0); 
-  const buildTreeTime = timer.elapsed();  timer.clear();
   hh.reset();
   sync TreeAccumulate(hh,pp,pp,root1,root1);
-  const accumTreeTime = timer.elapsed();  timer.clear();
   for xx in hh.bins(1) do writef("%12.4dr",xx); 
   writeln();
   for xx in hh.bins(2) do writef("%12.4dr",xx); 
@@ -330,20 +316,6 @@ proc testPairs() {
     }
     writeln();
   }
-
-  const output2Time = timer.elapsed();  timer.clear();
-  const totTime = totTimer.elapsed();
-
-  writeln("input:      ", inputTime);
-  writeln("shuffle:    ", shuffleTime);
-  writeln("hist setup: ", histSetupTime);
-  writeln("accum:      ", accumTime);
-  writeln("output1:    ", outputTime);
-  writeln("build tree: ", buildTreeTime);
-  writeln("accum tree: ", accumTreeTime);
-  writeln("output2:    ", output2Time);
-  writeln("-------------");
-  writeln("total:      ", totTime);
 
   //
   // clean up
@@ -393,6 +365,7 @@ proc doPairs() {
   sync TreeAccumulate(hh, pp1,pp2, root1, root2);
   tt.stop();
   writef("Time to tree paircount : %r \n", tt.elapsed());
+  //writeHist("%s.tree".format(pairfn),hh);
 
   //
   // clean up
@@ -402,6 +375,5 @@ proc doPairs() {
   delete root1;
   delete root2;
   delete hh;
-  //writeHist("%s.tree".format(pairfn),hh);
 }
 


### PR DESCRIPTION
While looking at the memleaks graphs this morning, I was noticing that
we had an uptick in leaks when these tests were committed.  Cleaning
out most of their data is fairly easy; I anticipate that remaining cases will
be closed as string memory leaks are closed.