### PR TITLE
Update module init and dead module count from network atomic lineno rework

### DIFF
--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -5,7 +5,6 @@ Initializing Modules:
      CString
     MemConsistency
     Atomics
-    NetworkAtomics
     AtomicsCommon
     NewString
      BaseStringType

--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
@@ -1,1 +1,1 @@
-Removed 15 dead modules.
+Removed 16 dead modules.


### PR DESCRIPTION
Previously network atomics passed a dummy line number to the runtime. LINENO
was a module level variable "const LINENO = -1:int(32)".

Because it was a global, it wasn't dead code eliminated and since the module
wasn't empty, we couldn't just get rid of it. Now, when network atomics aren't
actually used, the entire module is dead code eliminated. LINENO was removed as
part of the recent rework to use the "insert line file info" pragma instead of
previous manual method with: 949580cc673c6652741fb7bc4b011a3fdc57d69f

This updates the test that tracks how many modules are dead code eliminated and
the test that reports module init order (since this module is eliminated,
there's nothing to initialize.)