### PR TITLE
Print out a best guess Chapel code location on seg fault

### DIFF
--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -255,7 +255,8 @@ void   trace_remove(BaseAST* ast, char flag);
 
 //
 // macro to update the global line number used to set the line number
-// of an AST node when it is constructed
+// of an AST node when it is constructed - or to print out the line
+// number of code related to a core dump.
 //
 // This should be used before constructing new nodes to make sure the
 // line number is correctly set. The global line number reverts to

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4796,7 +4796,7 @@ preFold(Expr* expr) {
             }
           }
           if (!nowarn)
-            USR_WARN("type %s does not currently support noinit, using default initialization", type->symbol->name);
+            USR_WARN(type->symbol, "type %s does not currently support noinit, using default initialization", type->symbol->name);
           result = new CallExpr(PRIM_INIT, call->get(1)->remove());
           call->replace(result);
           inits.add((CallExpr *)result);

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -268,7 +268,6 @@ printDevelErrorHeader(BaseAST* ast) {
     print_user_internal_error();
   }
 
-
 }
 
 static void printDevelErrorFooter(void) {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -36,7 +36,7 @@
 #include <sys/stat.h>
 
 
-static const char* help_url = "http://chapel.cray.com";
+static const char* help_url = "http://chapel.cray.com/getinvolved.html";
 
 static void cleanup_for_exit(void) {
   deleteTmpDir();
@@ -205,13 +205,13 @@ printDevelErrorHeader(BaseAST* ast) {
   }
 
 
-  if( ast && ast->linenum() ) {
+  if ( ast && ast->linenum() ) {
     have_ast_line = 1;
     filename = cleanFilename(ast);
     linenum = ast->linenum();
   } else {
     have_ast_line = 0;
-    if( !err_print && currentAstLoc.filename && currentAstLoc.lineno > 0 ) {
+    if ( !err_print && currentAstLoc.filename && currentAstLoc.lineno > 0 ) {
       // Use our best guess for the line number for user errors,
       // but don't do that for err_print (USR_PRINT) notes that don't
       // come with line numbers.
@@ -228,14 +228,14 @@ printDevelErrorHeader(BaseAST* ast) {
   else
     apologize = 1;
 
-  if( apologize ) {
+  if ( apologize ) {
     fprintf(stderr, " Unfortunately the Chapel compiler has encountered\n"
                     " an internal error. Please file a bug report that\n"
                     " includes a program reproducing the problem as well\n"
                     " as this output. See %s for\n"
                     " further instructions on filing bug reports.\n"
                     "\n", help_url);
-    if( !have_ast_line && filename) {
+    if ( !have_ast_line && filename) {
       // Print out our best guess for the location of an error
       // if we had no source location
       fprintf(stderr, " The error may be related to this location:\n"

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -199,6 +199,11 @@ printDevelErrorHeader(BaseAST* ast) {
 
   if (ast && ast->linenum())
     fprintf(stderr, "%s:%d: ", cleanFilename(ast), ast->linenum());
+  else if( currentAstLoc.filename && currentAstLoc.lineno > 0 ) {
+    // Print out our best guess for the location of an error
+    // if we had no source location
+    fprintf(stderr, "%s:%d: ", currentAstLoc.filename, currentAstLoc.lineno);
+  }
 
   if (err_print) {
     fprintf(stderr, "note: ");

--- a/test/compflags/lydia/noUseNoinit/noinitSkippedCase.base.good
+++ b/test/compflags/lydia/noUseNoinit/noinitSkippedCase.base.good
@@ -1,3 +1,3 @@
-warning: type R does not currently support noinit, using default initialization
+noinitSkippedCase.chpl:10: warning: type R does not currently support noinit, using default initialization
 default init!
 default init!

--- a/test/trivial/diten/testIntExp4.good
+++ b/test/trivial/diten/testIntExp4.good
@@ -1,1 +1,1 @@
-error: 0 cannot be raised to a negative power
+$CHPL_HOME/modules/internal/ChapelBase.chpl:462: error: 0 cannot be raised to a negative power

--- a/test/users/vass/internal-error-message.good
+++ b/test/users/vass/internal-error-message.good
@@ -2,7 +2,7 @@ internal-error-message.chpl:72: In function 'scalar_outer_product_cholesky':
  Unfortunately the Chapel compiler has encountered
  an internal error. Please file a bug report that
  includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com for
+ as this output. See http://chapel.cray.com/getinvolved.html for
  further instructions on filing bug reports.
 
 internal-error-message.chpl:90: internal error: the type of the actual argument 'A' is generic [callInfo.cpp:56]

--- a/test/users/vass/internal-error-message.good
+++ b/test/users/vass/internal-error-message.good
@@ -1,2 +1,8 @@
 internal-error-message.chpl:72: In function 'scalar_outer_product_cholesky':
+ Unfortunately the Chapel compiler has encountered
+ an internal error. Please file a bug report that
+ includes a program reproducing the problem as well
+ as this output. See http://chapel.cray.com for
+ further instructions on filing bug reports.
+
 internal-error-message.chpl:90: internal error: the type of the actual argument 'A' is generic [callInfo.cpp:56]

--- a/test/users/vass/type-tests.isSubtype.good
+++ b/test/users/vass/type-tests.isSubtype.good
@@ -75,7 +75,7 @@ type-tests.isSubtype.chpl:92: warning: U1,       AA1.type false
 type-tests.isSubtype.chpl:93: warning: U1,       C1       false
 type-tests.isSubtype.chpl:94: warning: U1,       R1       false
 type-tests.isSubtype.chpl:96: warning: isProperSubtype - scalars
-warning: int, real   false
+type-tests.isSubtype.chpl:97: warning: int, real   false
 type-tests.isSubtype.chpl:97: warning: int, real   false
 type-tests.isSubtype.chpl:98: warning: real, real  false
 type-tests.isSubtype.chpl:100: warning: isProperSubtype - domains and arrays
@@ -86,124 +86,124 @@ type-tests.isSubtype.chpl:104: warning: {AA1,AA2}.domain  false
 type-tests.isSubtype.chpl:105: warning: {AA1,AA2}._value  false
 type-tests.isSubtype.chpl:107: warning: isProperSubtype - classes
 type-tests.isSubtype.chpl:108: warning: C1, C1  false
-warning: C1, C2  false
 type-tests.isSubtype.chpl:109: warning: C1, C2  false
-warning: C1, C3  false
+type-tests.isSubtype.chpl:109: warning: C1, C2  false
 type-tests.isSubtype.chpl:110: warning: C1, C3  false
-warning: C1, C4  false
+type-tests.isSubtype.chpl:110: warning: C1, C3  false
 type-tests.isSubtype.chpl:111: warning: C1, C4  false
-warning: C2, C1  true
+type-tests.isSubtype.chpl:111: warning: C1, C4  false
+type-tests.isSubtype.chpl:112: warning: C2, C1  true
 type-tests.isSubtype.chpl:112: warning: C2, C1  true
 type-tests.isSubtype.chpl:113: warning: C2, C2  false
-warning: C2, C3  false
 type-tests.isSubtype.chpl:114: warning: C2, C3  false
-warning: C2, C4  false
+type-tests.isSubtype.chpl:114: warning: C2, C3  false
 type-tests.isSubtype.chpl:115: warning: C2, C4  false
-warning: C3, C1  true
+type-tests.isSubtype.chpl:115: warning: C2, C4  false
 type-tests.isSubtype.chpl:116: warning: C3, C1  true
-warning: C3, C2  false
+type-tests.isSubtype.chpl:116: warning: C3, C1  true
+type-tests.isSubtype.chpl:117: warning: C3, C2  false
 type-tests.isSubtype.chpl:117: warning: C3, C2  false
 type-tests.isSubtype.chpl:118: warning: C3, C3  false
-warning: C3, C4  false
 type-tests.isSubtype.chpl:119: warning: C3, C4  false
-warning: C4, C1  true
+type-tests.isSubtype.chpl:119: warning: C3, C4  false
 type-tests.isSubtype.chpl:120: warning: C4, C1  true
-warning: C4, C2  true
+type-tests.isSubtype.chpl:120: warning: C4, C1  true
 type-tests.isSubtype.chpl:121: warning: C4, C2  true
-warning: C4, C3  false
+type-tests.isSubtype.chpl:121: warning: C4, C2  true
+type-tests.isSubtype.chpl:122: warning: C4, C3  false
 type-tests.isSubtype.chpl:122: warning: C4, C3  false
 type-tests.isSubtype.chpl:123: warning: C4, C4  false
 type-tests.isSubtype.chpl:125: warning: isProperSubtype - records
 type-tests.isSubtype.chpl:126: warning: R1, R1  false
-warning: R1, R2  false
 type-tests.isSubtype.chpl:127: warning: R1, R2  false
-warning: R1, R3  false
+type-tests.isSubtype.chpl:127: warning: R1, R2  false
 type-tests.isSubtype.chpl:128: warning: R1, R3  false
-warning: R1, R4  false
+type-tests.isSubtype.chpl:128: warning: R1, R3  false
 type-tests.isSubtype.chpl:129: warning: R1, R4  false
-warning: R2, R1  true
+type-tests.isSubtype.chpl:129: warning: R1, R4  false
+type-tests.isSubtype.chpl:130: warning: R2, R1  true
 type-tests.isSubtype.chpl:130: warning: R2, R1  true
 type-tests.isSubtype.chpl:131: warning: R2, R2  false
-warning: R2, R3  false
 type-tests.isSubtype.chpl:132: warning: R2, R3  false
-warning: R2, R4  false
+type-tests.isSubtype.chpl:132: warning: R2, R3  false
 type-tests.isSubtype.chpl:133: warning: R2, R4  false
-warning: R3, R1  true
+type-tests.isSubtype.chpl:133: warning: R2, R4  false
 type-tests.isSubtype.chpl:134: warning: R3, R1  true
-warning: R3, R2  false
+type-tests.isSubtype.chpl:134: warning: R3, R1  true
+type-tests.isSubtype.chpl:135: warning: R3, R2  false
 type-tests.isSubtype.chpl:135: warning: R3, R2  false
 type-tests.isSubtype.chpl:136: warning: R3, R3  false
-warning: R3, R4  false
 type-tests.isSubtype.chpl:137: warning: R3, R4  false
-warning: R4, R1  true
+type-tests.isSubtype.chpl:137: warning: R3, R4  false
 type-tests.isSubtype.chpl:138: warning: R4, R1  true
-warning: R4, R2  true
+type-tests.isSubtype.chpl:138: warning: R4, R1  true
 type-tests.isSubtype.chpl:139: warning: R4, R2  true
-warning: R4, R3  false
+type-tests.isSubtype.chpl:139: warning: R4, R2  true
+type-tests.isSubtype.chpl:140: warning: R4, R3  false
 type-tests.isSubtype.chpl:140: warning: R4, R3  false
 type-tests.isSubtype.chpl:141: warning: R4, R4  false
 type-tests.isSubtype.chpl:143: warning: isProperSubtype - mixing up
-warning: real,     D1.type  false
 type-tests.isSubtype.chpl:144: warning: real,     D1.type  false
-warning: real,     AA1.type false
+type-tests.isSubtype.chpl:144: warning: real,     D1.type  false
 type-tests.isSubtype.chpl:145: warning: real,     AA1.type false
-warning: real,     C1       false
+type-tests.isSubtype.chpl:145: warning: real,     AA1.type false
 type-tests.isSubtype.chpl:146: warning: real,     C1       false
-warning: real,     R1       false
+type-tests.isSubtype.chpl:146: warning: real,     C1       false
 type-tests.isSubtype.chpl:147: warning: real,     R1       false
-warning: real,     U1       false
+type-tests.isSubtype.chpl:147: warning: real,     R1       false
 type-tests.isSubtype.chpl:148: warning: real,     U1       false
-warning: D1.type,  real     false
+type-tests.isSubtype.chpl:148: warning: real,     U1       false
+type-tests.isSubtype.chpl:149: warning: D1.type,  real     false
 type-tests.isSubtype.chpl:149: warning: D1.type,  real     false
 type-tests.isSubtype.chpl:150: warning: D1.type,  D1.type  false
-warning: D1.type,  AA1.type false
 type-tests.isSubtype.chpl:151: warning: D1.type,  AA1.type false
-warning: D1.type,  C1       false
+type-tests.isSubtype.chpl:151: warning: D1.type,  AA1.type false
 type-tests.isSubtype.chpl:152: warning: D1.type,  C1       false
-warning: D1.type,  R1       false
+type-tests.isSubtype.chpl:152: warning: D1.type,  C1       false
 type-tests.isSubtype.chpl:153: warning: D1.type,  R1       false
-warning: D1.type,  U1       false
+type-tests.isSubtype.chpl:153: warning: D1.type,  R1       false
 type-tests.isSubtype.chpl:154: warning: D1.type,  U1       false
-warning: AA1.type, real     false
+type-tests.isSubtype.chpl:154: warning: D1.type,  U1       false
 type-tests.isSubtype.chpl:155: warning: AA1.type, real     false
-warning: AA1.type, D1.type  false
+type-tests.isSubtype.chpl:155: warning: AA1.type, real     false
+type-tests.isSubtype.chpl:156: warning: AA1.type, D1.type  false
 type-tests.isSubtype.chpl:156: warning: AA1.type, D1.type  false
 type-tests.isSubtype.chpl:157: warning: AA1.type, AA1.type false
 type-tests.isSubtype.chpl:158: warning: AA1.type, C        false
 type-tests.isSubtype.chpl:159: warning: AA1.type, R        false
-warning: AA1.type, U1       false
 type-tests.isSubtype.chpl:160: warning: AA1.type, U1       false
-warning: C1,       real     false
+type-tests.isSubtype.chpl:160: warning: AA1.type, U1       false
 type-tests.isSubtype.chpl:161: warning: C1,       real     false
-warning: C1,       D1.type  false
+type-tests.isSubtype.chpl:161: warning: C1,       real     false
 type-tests.isSubtype.chpl:162: warning: C1,       D1.type  false
-warning: C1,       AA1.type false
+type-tests.isSubtype.chpl:162: warning: C1,       D1.type  false
 type-tests.isSubtype.chpl:163: warning: C1,       AA1.type false
-warning: C1,       R1       false
+type-tests.isSubtype.chpl:163: warning: C1,       AA1.type false
 type-tests.isSubtype.chpl:164: warning: C1,       R1       false
-warning: C1,       U1       false
+type-tests.isSubtype.chpl:164: warning: C1,       R1       false
 type-tests.isSubtype.chpl:165: warning: C1,       U1       false
-warning: R1,       real     false
+type-tests.isSubtype.chpl:165: warning: C1,       U1       false
 type-tests.isSubtype.chpl:166: warning: R1,       real     false
-warning: R1,       D1.type  false
+type-tests.isSubtype.chpl:166: warning: R1,       real     false
 type-tests.isSubtype.chpl:167: warning: R1,       D1.type  false
-warning: R1,       AA1.type false
+type-tests.isSubtype.chpl:167: warning: R1,       D1.type  false
 type-tests.isSubtype.chpl:168: warning: R1,       AA1.type false
-warning: R1,       C1       false
+type-tests.isSubtype.chpl:168: warning: R1,       AA1.type false
 type-tests.isSubtype.chpl:169: warning: R1,       C1       false
-warning: R1,       U1       false
+type-tests.isSubtype.chpl:169: warning: R1,       C1       false
 type-tests.isSubtype.chpl:170: warning: R1,       U1       false
-warning: U1,       real     false
+type-tests.isSubtype.chpl:170: warning: R1,       U1       false
 type-tests.isSubtype.chpl:171: warning: U1,       real     false
-warning: U1,       D1.type  false
+type-tests.isSubtype.chpl:171: warning: U1,       real     false
 type-tests.isSubtype.chpl:172: warning: U1,       D1.type  false
-warning: U1,       AA1.type false
+type-tests.isSubtype.chpl:172: warning: U1,       D1.type  false
 type-tests.isSubtype.chpl:173: warning: U1,       AA1.type false
-warning: U1,       C1       false
+type-tests.isSubtype.chpl:173: warning: U1,       AA1.type false
 type-tests.isSubtype.chpl:174: warning: U1,       C1       false
-warning: U1,       R1       false
+type-tests.isSubtype.chpl:174: warning: U1,       C1       false
+type-tests.isSubtype.chpl:175: warning: U1,       R1       false
 type-tests.isSubtype.chpl:175: warning: U1,       R1       false
 type-tests.isSubtype.chpl:178: warning: U1, U2  false
-warning: U1, U2  false
+type-tests.isSubtype.chpl:179: warning: U1, U2  false
 type-tests.isSubtype.chpl:179: warning: U1, U2  false
 type-tests.isSubtype.chpl:181: error: done


### PR DESCRIPTION
Since we call SET_LINENO and have a global AST location already, print out
that location when the compiler core dumps.

Prints out a nicer message with a link to getting help on an internal
error. Also attempts to print out when the line number is guessed.

TODO: indicate that the file/line is a guess if (err_user && filename &&
guess && !developer) which will almost certainly change some .good files

Passed full local testing.
Reviewed by @vasslitvinov.
