### PR TITLE
Pass through ref fields in a tuple's autoCopy.

### DIFF
--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -258,7 +258,13 @@ instantiate_tuple_autoCopy(FnSymbol* fn) {
     Symbol* tmp = newTemp();
     block->insertAtTail(new DefExpr(tmp));
     block->insertAtTail(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_GET_MEMBER_VALUE, arg, new_StringSymbol(astr("x", istr(i))))));
-    call->insertAtTail(new CallExpr("chpl__autoCopy", tmp));
+    // If it is a reference, pass it through.
+    DefExpr* def = toDefExpr(ct->fields.get(i+1));
+    INT_ASSERT(def);
+    if (isReferenceType(def->sym->type))
+      call->insertAtTail(tmp);
+    else
+      call->insertAtTail(new CallExpr("chpl__autoCopy", tmp));
   }
   
   block->insertAtTail(new CallExpr(PRIM_RETURN, call));


### PR DESCRIPTION
When generating autoCopy for a tuple, we used to autoCopy
each of its fields. When a field is of a ref type, e.g.
_ref(int), it would get dereferenced while resolving
the autoCopy of that field. The result would look like this:

    fn chpl__autoCopy[784989]:2*int(64)[802618]
    def arg x[784991]:(int(64),_ref(int(64)))[784120]
    {
      def tmp[784999]:int(64)[10]
      move( tmp[784999] .v( arg x[784991] x1[784116] ) )
      def tmp[785009]:_ref(int(64))[479651]
      move( tmp[785009] .v( arg x[784991] x2[784118] ) )
      def coerce_tmp[827924]:int(64)[10]
      move( coerce_tmp[827924] deref( tmp[785009] ) )
      def this[886146]:2*int(64)[802618]
      .=( this[886146] x1[802614] tmp[784999] )
      .=( this[886146] x2[802616] coerce_tmp[827924] )
      return( this[886146] )
    }

With this change, ref fields are passed straight through
without dereferencing:

    fn chpl__autoCopy[784989]:(int(64),_ref(int(64)))[784120]
    def arg x[784991]:(int(64),_ref(int(64)))[784120]
    {
      def ret[785020]:(int(64),_ref(int(64)))[784120]
      def tmp[784999]:int(64)[10]
      move( tmp[784999] .v( arg x[784991] x1[784116] ) )
      def tmp[785009]:_ref(int(64))[479651]
      move( tmp[785009] .v( arg x[784991] x2[784118] ) )
      def call_tmp[785027]:int(64)[10]
      move( call_tmp[785027] call( fn chpl__autoCopy[814911] tmp[784999] ) )
      def call_tmp[785032]:(int(64),_ref(int(64)))[784120]
      move( call_tmp[785032]
        call( fn _build_tuple_always_allow_ref[784059]
              call_tmp[785027] tmp[785009] ) )
      move( ret[785020] call_tmp[785032] )
      return( ret[785020] )
    }