### PR TITLE
Skip parallel/forall/vass/ri-3-stress on chpbld01 with CCE

### DIFF
--- a/test/parallel/forall/vass/ri-3-stress.skipif
+++ b/test/parallel/forall/vass/ri-3-stress.skipif
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+# This test takes ~600 seconds to execute on chpbld01 with both 8.3 and 8.4
+# versions of the cray compiler. It only takes ~60 seconds with gcc 4.8.2. For
+# reference, on real XC hardware it takes ~5 seconds for both compilers. It
+# seems like a result of chpbld01 having an unusual setup (cray might have bad
+# code gen for an "XC" with old AMD hardware or something) and just being an
+# older/slower machine in general. 
+import os
+
+machine=os.uname()[1].split('.', 1)[0]
+targ_comp = os.environ.get('CHPL_TARGET_COMPILER', '')
+
+print (machine =='chpbld01' and targ_comp == 'cray-prgenv-cray')


### PR DESCRIPTION
This test takes ~600 seconds to execute on chpbld01 with both 8.3 and 8.4
versions of the cray compiler. It only takes ~60 seconds with gcc 4.8.2. For
reference, on real XC hardware it takes ~5 seconds for both compilers. It seems
like a result of chpbld01 having an unusual setup (cray might have bad code gen
for an "XC" with old AMD hardware or something) and just being an older/slower
machine in general.