### PR TITLE
Make sure to use the value type of formals/actuals in testArgMapping

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1006,10 +1006,6 @@ module ChapelBase {
     compilerError("illegal assignment of type to value");
   }
   
-  pragma "ref"
-  pragma "init copy fn"
-  inline proc chpl__initCopy(r: _ref) return chpl__initCopy(__primitive("deref", r));
-  
   pragma "init copy fn"
   inline proc chpl__initCopy(x: _tuple) { 
     // body inserted during generic instantiation
@@ -1061,11 +1057,6 @@ module ChapelBase {
   pragma "donor fn"
   pragma "auto copy fn"
   inline proc chpl__autoCopy(x) return chpl__initCopy(x);
-  
-  pragma "ref" 
-  pragma "donor fn"
-  pragma "auto copy fn"
-  inline proc chpl__autoCopy(r: _ref) ref return r;
   
   inline proc chpl__maybeAutoDestroyed(x: numeric) param return false;
   inline proc chpl__maybeAutoDestroyed(x: enumerated) param return false;

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -238,7 +238,7 @@ module GMP {
   extern proc mpz_mul_ui(ref ROP: mpz_t, ref OP1: mpz_t, OP2: c_ulong);
 
   extern proc mpz_addmul(ref ROP: mpz_t, ref OP1: mpz_t, ref OP2: mpz_t);
-  extern proc mpz_addmul_ui(ref ROP: mpz_t, ref OP1: mpz_t, ref OP2: c_ulong);
+  extern proc mpz_addmul_ui(ref ROP: mpz_t, ref OP1: mpz_t, OP2: c_ulong);
 
   extern proc mpz_submul(ref ROP: mpz_t, ref OP1: mpz_t, ref OP2: mpz_t);
   extern proc mpz_submul_ui(ref ROP: mpz_t, ref OP1: mpz_t, OP2: c_ulong);
@@ -395,8 +395,6 @@ module GMP {
   extern proc mpz_sizeinbase(ref OP: mpz_t, BASE: c_int): size_t;
 
   extern proc mpf_set_default_prec(PREC: mp_bitcnt_t);
-
-  extern proc mpz_addmul_ui(ref ROP: mpz_t, ref OP1: mpz_t, OPT2: c_ulong);
 
   // floating-point functions
   extern proc mpf_init(ref X: mpf_t);


### PR DESCRIPTION
If we don't use the actual type some functions that should or shouldn't
be ambiguous are messed up due to _ref types. For example, these two
functions will not be ambiguous without this patch:

    proc foo(const ref x: RecordX) {...};
    proc foo(const in x: RecordX) {...};

I've fixed an instance of this ambiguity that became apparent in the GMP wrapper after making this change.