### PR TITLE
Work around problem building RE2 and tcmalloc with clang-included

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -104,7 +104,8 @@ endif
 #
 # Flags for turning on warnings for C++/C code
 #
-WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing -Wmissing-declarations
+# -Wno-return-type-c-linkage: Don't warn about tc_mallinfo
+WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing -Wmissing-declarations -Wno-return-type-c-linkage
 # decl-after-stmt for non c99 compilers. See commit message 21665
 WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wdeclaration-after-statement -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS) -Wno-unused -Wno-uninitialized


### PR DESCRIPTION
When building re2-interface.cc with clang-included and
with CHPL_MEM=tcmalloc, we were getting an error
about tc_mallinfo that mallinfo
"has C-linkage specified, but returns incomplete type" ...
"which could be incompatible with C".

I don't believe we use tc_mallinfo, so another option would be
to comment out its declaration in tcmalloc.h. However, I don't
see any way to do that without modifying tcmalloc.