### PR TITLE
String as rec leak fixes -- June 17

### DIFF
--- a/test/release/examples/primers/iterators.chpl
+++ b/test/release/examples/primers/iterators.chpl
@@ -87,6 +87,10 @@ writeln(); // line break
 class Tree {
   var data: string;
   var left, right: Tree;
+  proc ~Tree() {
+    if left != nil then delete left;
+    if right != nil then delete right;
+  }
 }
 
 var tree = new Tree("a", new Tree("b"), new Tree("c", new Tree("d"),
@@ -169,3 +173,5 @@ coforall node in postorder(tree) do
   node.data = decorate(node.data);
 writeln(tree);
 writeln();
+
+delete tree;


### PR DESCRIPTION
Remove special code for incrementing the domain reference count on domain temporaries used in array elements that are themselves arrays.

A correct implementation of reference counting should immediately increment the domain reference count when an array creates a reference to it, which renders this special code moot.  Whether or not the current implementation is correct, a full regression test run completed without errors.

Also modified the iterators primer to destroy all the class objects it creates.