### PR TITLE
Resolve main iterator inlining bug on string-as-rec branch.

### DIFF
--- a/compiler/include/OwnershipFlowManager.h
+++ b/compiler/include/OwnershipFlowManager.h
@@ -306,8 +306,10 @@ inline static bool isCreated(SymExpr* se)
             // result.  An autoCopy needs to be inserted where an owned copy is required.
             return false;
            case PRIM_GET_MEMBER_VALUE:
+           case PRIM_GET_SVEC_MEMBER_VALUE:
             // Returns a bitwise copy of the referenced field which is, as a
             // consequence, unowned.
+            return false;
            case PRIM_ARRAY_GET_VALUE:
             // Returns a bitwise copy of the selected array element which is, as a
             // consequence, unowned.

--- a/test/distributions/jglewis/cyclicOnEvenNumLocales.compopts
+++ b/test/distributions/jglewis/cyclicOnEvenNumLocales.compopts
@@ -1,2 +1,0 @@
-# Another victim of the iterator inlining bug.
---no-inline-iterators

--- a/test/records/ferguson/local-array-forallexpr.compopts
+++ b/test/records/ferguson/local-array-forallexpr.compopts
@@ -1,2 +1,0 @@
-# This test does not work when iterator inlining is enabled
---no-inline-iterators

--- a/test/studies/beer/bradc/beer-promoted-infer-explicit.compopts
+++ b/test/studies/beer/bradc/beer-promoted-infer-explicit.compopts
@@ -1,2 +1,0 @@
-# Here is another test that does not run correctly unless iterator inlining is disabled.
---no-inline-iterators

--- a/test/studies/hpcc/common/bradc/unit/leadFollowOpt.compopts
+++ b/test/studies/hpcc/common/bradc/unit/leadFollowOpt.compopts
@@ -1,2 +1,1 @@
-# This test succeeds if either iterator inlining or regular inlining is turned off
--O --no-inline-iterators
+-O

--- a/test/types/tuple/sungeun/iteration/forall.compopts
+++ b/test/types/tuple/sungeun/iteration/forall.compopts
@@ -1,2 +1,0 @@
-# Iterator inlining does not work correctly with foralls (FIXME).
---no-inline-iterators

--- a/test/types/tuple/sungeun/iteration/tupleOfDomains.compopts
+++ b/test/types/tuple/sungeun/iteration/tupleOfDomains.compopts
@@ -1,2 +1,0 @@
-# Another case that passes only with --no-inline-iterators.
---no-inline-iterators


### PR DESCRIPTION
Reference counts were going below zero leading to premature deletion when
inlined iterators were enabled for certain test cases.

Wholly different code is used to implement inlined vs. non-inlined iterators.
Integer indices might be returned from the non-inlined version, while domains
or arrays are returned from the inlined version.

The latter version was failing to insert an autocopy before the return in the
"tuple.this" function, expanded to return a wrapped array type.  I traced the
problem down to the PRIM_GET_SVEC_MEMBER_VALUE call in the implementation of
tuple.this().  Because this primitive returns an element from an array, the
returned value is unowned.  I had to add that primitive to the explicit list
that claims the result is unowned.  With that change the needed autocopies are
inserted.

I updated or removed the compopts files corresponding to the tests that were
failing that now work.  There are two test cases that were not cured by this
fix.  Further investigation is required.