### PR TITLE
OK to leave "#include view.h" in functionResolution.cpp

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -43,7 +43,6 @@
 #include "symbol.h"
 #include "WhileStmt.h"
 #include "../ifa/prim_data.h"
-// view.h is here for debugging convenience
 #include "view.h"
 
 #include <inttypes.h>

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -25,7 +25,6 @@
 #endif
 
 #include "resolution.h"
-
 #include "astutil.h"
 #include "stlUtil.h"
 #include "build.h"
@@ -43,12 +42,9 @@
 #include "stringutil.h"
 #include "symbol.h"
 #include "WhileStmt.h"
-
 #include "../ifa/prim_data.h"
-
-
+// view.h is here for debugging convenience
 #include "view.h"
-
 
 #include <inttypes.h>
 #include <map>


### PR DESCRIPTION
Having seen so many times that #include "view.h" gets added to functionResolution.cpp and left there in svn commits and PR merges, I propose that we just leave it there for good.

This PR adds a comment to that effect. We could even leave "view.h" there without any comment.

While there, I have removed a couple of seemingly-arbitrary empty lines between #includes.
