### PR TITLE
Fix numa regression due to #2088.

### DIFF
--- a/test/arrays/deitz/parallelism/test_whole_array_assignment_of_elemental_value_is_parallel.execenv
+++ b/test/arrays/deitz/parallelism/test_whole_array_assignment_of_elemental_value_is_parallel.execenv
@@ -1,0 +1,13 @@
+#
+# The output of debugDataParNuma is different based on the number of
+# sublocales. We currently calculate our number of sublocales using
+# the number of Qthreads shepherds. Qthreads automatically picks
+# it's number of sublocales based on the number of sockets/other hw
+# information unless it is explicitly set so this forces two
+# sublocales even on machines that really only have one. 
+# 
+# When we change how we set the number of sublocals, this will have
+# to be changed as well. 
+#
+
+QT_NUM_SHEPHERDS=2

--- a/test/arrays/deitz/parallelism/test_whole_array_assignment_of_elemental_value_is_parallel.lm-numa.good
+++ b/test/arrays/deitz/parallelism/test_whole_array_assignment_of_elemental_value_is_parallel.lm-numa.good
@@ -1,0 +1,8 @@
+CHPL TEST PAR (test_whole_array_assignment_of_elemental_value_is_parallel.chpl:10): default rectangular domain follower invoked on (0..9)
+CHPL TEST PAR (test_whole_array_assignment_of_elemental_value_is_parallel.chpl:10): default rectangular domain follower invoked on (10..19)
+CHPL TEST PAR (test_whole_array_assignment_of_elemental_value_is_parallel.chpl:12): default rectangular domain follower invoked on (0..9)
+CHPL TEST PAR (test_whole_array_assignment_of_elemental_value_is_parallel.chpl:12): default rectangular domain follower invoked on (10..19)
+CHPL TEST PAR (test_whole_array_assignment_of_elemental_value_is_parallel.chpl:8): default rectangular domain follower invoked on (0..9)
+CHPL TEST PAR (test_whole_array_assignment_of_elemental_value_is_parallel.chpl:8): default rectangular domain follower invoked on (10..19)
+1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0
+2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0


### PR DESCRIPTION
The test test_whole_array_assignment_of_elemental_value_is_parallel.chpl
checks whether the standalone iterator is invoked. However,
the numa locale model does not provide a standalone iterator on arrays.
So we provide a different expected output for numa.

Also we set QT_NUM_SHEPHERDS=2 as presently a way to specify two sublocales,
for consistent output.