### PR TITLE
Fix for Coverity Issue 1308139

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -412,6 +412,12 @@ replaceLocalsWithFields(FnSymbol* fn,           // the iterator function
 // singleLoop construct).
 static void
 buildZip1(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
+
+  // Expects to be called inside a clause that already tests singleLoop !=
+  // NULL.  This restriction can be removed if the != NULL test is pushed down
+  // into this routine.
+  INT_ASSERT(singleLoop != NULL);
+
   BlockStmt* zip1body = new BlockStmt();
 
   // See Note #1.
@@ -480,6 +486,11 @@ buildZip1(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
 static void
 buildZip2(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
 
+  // Expects to be called inside a clause that already tests singleLoop !=
+  // NULL.  This restriction can be removed if the != NULL test is pushed down
+  // into this routine.
+  INT_ASSERT(singleLoop != NULL);
+
   // In copied expressions, replace _ic with zip2->_this .
   // See Note #1.
   SymbolMap map;
@@ -500,7 +511,7 @@ buildZip2(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
         zip2body->insertAtTail(def->copy(&map));
   }
 
-  if (singleLoop && singleLoop->isForLoop())
+  if (singleLoop->isForLoop())
   {
     INT_FATAL(singleLoop, "Unexpected singleLoop iterator type.");
   }
@@ -524,6 +535,11 @@ buildZip2(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
 // body that are *after* the yield
 static void
 buildZip3(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
+
+  // Expects to be called inside a clause that already tests singleLoop !=
+  // NULL.  This restriction can be removed if the != NULL test is pushed down
+  // into this routine.
+  INT_ASSERT(singleLoop != NULL);
 
   BlockStmt* zip3body = new BlockStmt();
 
@@ -588,6 +604,11 @@ buildZip3(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
 static void
 buildZip4(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
 
+  // Expects to be called inside a clause that already tests singleLoop !=
+  // NULL.  This restriction can be removed if the != NULL test is pushed down
+  // into this routine.
+  INT_ASSERT(singleLoop != NULL);
+
   // In copied expressions, replace _ic with zip4->_this .
   // See Note #1.
   SymbolMap map;
@@ -608,7 +629,7 @@ buildZip4(IteratorInfo* ii, Vec<BaseAST*>& asts, BlockStmt* singleLoop) {
         zip4body->insertAtTail(def->copy(&map));
   }
 
-  if (singleLoop && singleLoop->isForLoop())
+  if (singleLoop->isForLoop())
   {
     INT_FATAL(singleLoop, "Unexpected singleLoop iterator type.");
   }

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1171,14 +1171,11 @@ expandIteratorInline(ForLoop* forLoop) {
     // to be handled in the recursive iterator function
     //
     if (forLoop->parentSymbol->hasFlag(FLAG_RECURSIVE_ITERATOR)) {
-//      printf("ForLoop %d parent %d has FLAG_RECURSIVE_ITERATOR\n", forLoop->id, forLoop->parentSymbol->id);
       return false;
     // vass: ditto for task functions called from recursive iterators
     } else if (taskFunInRecursiveIteratorSet.set_in(forLoop->parentSymbol)) {
-//      printf("ForLoop %d parent %d is in taskFunInRecursiveIteratorSet\n", forLoop->id, forLoop->parentSymbol->id);
       return false;
     } else {
-//      printf("ForLoop %d calling %d expanded inline\n", forLoop->id, iterator->id);
       expandRecursiveIteratorInline(forLoop);
       INT_ASSERT(!forLoop->inTree());
       return true;


### PR DESCRIPTION
Add asserts for singleLoop != NULL in buildZip?() routines.

Remove NULL tests rendered moot by the assertions.

As a small cleanup, remove debug printf calls from expandIteratorInline().