### PR TITLE
Fixed domain literal syntax and writeThis-on.chpl

### DIFF
--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -257,7 +257,7 @@ proc newDimensionalDist2D(
 ) {
   if targetLocales.rank != 1 then compilerError("newDimensionalDist2D() is provided only for 1D targetLocales arrays");
   const (nl1, nl2) = (di1.numLocales, di2.numLocales);
-  var reshapedLocales => reshape(targetLocales[0..#nl1*nl2],[0..#nl1,0..#nl2]);
+  var reshapedLocales => reshape(targetLocales[0..#nl1*nl2],{0..#nl1,0..#nl2});
 
   return new DimensionalDist2D(reshapedLocales, di1, di2, name, idxType,
    dataParTasksPerLocale, dataParIgnoreRunningTasks, dataParMinGranularity);

--- a/test/io/vass/writeThis-on.bad
+++ b/test/io/vass/writeThis-on.bad
@@ -1,0 +1,17 @@
+here=0 home=0
+here=0 home=1
+here=0 home=2
+
+initializing
+printing element directly
+0
+1
+2
+printing array directly
+0
+0
+0
+printing array via temp
+0
+1
+2

--- a/test/io/vass/writeThis-on.chpl
+++ b/test/io/vass/writeThis-on.chpl
@@ -18,7 +18,7 @@ const dim2 = new BlockCyclicDim(1, 1, 2);
 const dmp = newDimensionalDist2D(dim1, dim2, Locales);
 
 const ix = (1, 1);
-const D = [1..1, 1..1];
+const D = {1..1, 1..1};
 const R = D dmapped new dmap(dmp);
 var A: [R] int;
 


### PR DESCRIPTION
Fixed two instances where the old [] syntax was used for domain literals.

Also created .bad for the test writeThis-on.chpl .
I did that simply by capturing the current output of the test -
I did not investigate whether the .future is still relevant
(it may well be).
