### PR TITLE
Add a .future about passing a subclass to ref arg of superclass type

### DIFF
--- a/test/classes/diten/passSubClassByRef.chpl
+++ b/test/classes/diten/passSubClassByRef.chpl
@@ -1,0 +1,6 @@
+class C {}
+var c = new C();
+proc foo(ref obj: object) {
+  writeln("called foo(obj)");
+}
+foo(c);

--- a/test/classes/diten/passSubClassByRef.future
+++ b/test/classes/diten/passSubClassByRef.future
@@ -1,0 +1,5 @@
+error message: passing subclass to ref arg of super class type needs clean error
+
+This test currently makes it to codegen and then gets an error from the C
+compiler.  It should get a clean error message instead, most likely the
+unresolved call error in the .good.

--- a/test/classes/diten/passSubClassByRef.good
+++ b/test/classes/diten/passSubClassByRef.good
@@ -1,0 +1,2 @@
+passSubClassByRef.chpl:6: error: unresolved call 'foo(C)'
+passSubClassByRef.chpl:3: note: candidates are: foo(ref obj: object)


### PR DESCRIPTION
Currently it fails to compile the generated C code.  Instead it should issue
a clean error message.  Most likely it should be an unresolved call error.