### PR TITLE
Fix the ref count on local variables passed to cobegin and coforall task functions

### DIFF
--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.compopts
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.compopts
@@ -1,2 +1,1 @@
-# Yet another test that now fails due to iterator inlining.
-../../common/probSize.chpl ../../common/bradc/BradsBlock1DPar.chpl --no-inline-iterators
+../../common/probSize.chpl ../../common/bradc/BradsBlock1DPar.chpl

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.compopts
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.compopts
@@ -1,2 +1,1 @@
-# Yet another test now failing due to iterator inlining.
-../../common/probSize.chpl ../../common/bradc/BradsBlock1DPar.chpl --no-inline-iterators
+../../common/probSize.chpl ../../common/bradc/BradsBlock1DPar.chpl

--- a/test/studies/hpcc/common/bradc/unit/parBlock1D.compopts
+++ b/test/studies/hpcc/common/bradc/unit/parBlock1D.compopts
@@ -1,2 +1,0 @@
-# Another victim of the iterator inlining bug.
---no-inline-iterators


### PR DESCRIPTION
This takes care of the remaining "iterator inlining" bugs.

The reason this bug was associated with iterator inlining is that whether
iterator inlining is turned on or off controls whether the iterand in the
follower loop is a range or a domain.  (This property may not push iterator
inlining into a region where it is no longer really an "optimization" -- by
definition, a modification of the generated code which has no visible
first-order effect on the behavior of the program -- but it still makes
debugging more challenging.)

The manifestation of the error was that reference counts go below zero in
attempting to execute a task function.  The cause of the error is in how we
translate a coforall::

    coforall block in ProblemSpace.newThese(IteratorType.leader) {
      on block {
        for i in ProblemSpace.newThese(IteratorType.follower, block) {
          A(i) = B(i) + alpha * C(i);
        }
      }
    }
    
    iter newThese(param iterator: IteratorType)
          where iterator == IteratorType.leader {
      for locDom in locDoms do
        yield locDom.myBlock.translate(-whole.low);
    }

The variable ``block`` is local to the body of the coforall, so once the call to
the task implementing the body of the coforall is set up, ``block`` goes out of
scope and is reclaimed.

In this case, ``block`` is the result of a call to translate(), which returns a
domain.  The ref count on the domain is 1 at the ``yield`` in ``newThese()``,
because the domain is not shared with any other variable or structure.  If the
domain were owned elsewhere, its reference count would not hit zero and the code
would run correctly.

However, since the reference count *does* hit zero, we have to arrange to
prevent this.  The code in insertAutoCopyDestroyForTaskArg was modified to also
call autoCopy on record args when setting up a call to a task function in a
cobegin or coforall.  This takes care of the main problem.

----------

While there, however, I noticed that the domain is first copied into a
heap-allocated variable.  The reference counts are right, but the task function
will still end up pointing to deallocated memory if the heap-allocated data is
freed at the end of the body of the coforall.

The problem was due to a missing case in the test at the top of
freeHeapAllocatedVars().  We also want to skip the free if the primitive is a
"get member value" primitive, so I added that case.

The other two changes in parallel.cpp are gratuitous.

These tweaks allowed me to remove the --no-inline-iterators flags from the
remaining 3 test cases where they were used as a workaround.