### PR TITLE
Make this test less based on string literals

### DIFF
--- a/test/param/bradc/foldUintZeroes.chpl
+++ b/test/param/bradc/foldUintZeroes.chpl
@@ -1,22 +1,26 @@
 config var u: uint = 1;
 
+proc FoldMeOut() {
+  writeln("This should get folded out");
+}
+
 if (u >= 0) then
   writeln("Whew!");
 else
-  writeln("This should get folded out");
+  FoldMeOut();
 
 if (u < 0) then
-  writeln("This should get folded out");
+  FoldMeOut();
 else
   writeln("Whew!");
 
 if (0 <= u) then
   writeln("Whew!");
 else
-  writeln("This should get folded out");
+  FoldMeOut();
 
 if (0 > u) then
-  writeln("This should get folded out");
+  FoldMeOut();
 else
   writeln("Whew!");
 

--- a/test/param/bradc/foldUintZeroes.prediff
+++ b/test/param/bradc/foldUintZeroes.prediff
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-grep folded output/*.c output/*.h >> $1.exec.out.tmp
+grep FoldMeOut output/*.c output/*.h >> $1.exec.out.tmp


### PR DESCRIPTION
With Kyle's string work, string literals are handled differently,
making this test fail even though the params are still getting
folded.  I'm changing from a string to a function call to make
this test robust to that change.