### PR TITLE
Add -valgrindexe option to paratest.

### DIFF
--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -10,7 +10,7 @@
 #  testdir - directory to run start_test on
 #  chplenv - Chapel environment variables
 #  futures-mode - include .futures (0=no, 1=all, 2=futures only, 3=futures with skipifs)
-#  valgrind - run valgrind (0=no, 1=yes)
+#  valgrind - run valgrind (0=no, 1=yes, 2=execs only)
 #  compopts - optional Chapel compiler options
 #
 # NOTE: Assumes paratest.client is run from $CHPL_HOME/test
@@ -60,6 +60,7 @@ sub main {
     $chplenv = $ARGV[3];
     $futures_mode = "-futures-mode \"" . $ARGV[4] . "\"";
     $valgrind = ($ARGV[5] == 1) ? "-valgrind" : "";
+    $valgrind = ($ARGV[5] == 2) ? "-valgrindexe" : "";
 
     print "$id $workingdir $testdir $futures_mode $valgrind" if $debug;
     if ($#ARGV>=7) {

--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -10,7 +10,7 @@
 #  testdir - directory to run start_test on
 #  chplenv - Chapel environment variables
 #  futures-mode - include .futures (0=no, 1=all, 2=futures only, 3=futures with skipifs)
-#  valgrind - run valgrind (0=no, 1=yes, 2=execs only)
+#  valgrind - run valgrind (0=no, 1=both compiler and executable, 2=executable only)
 #  compopts - optional Chapel compiler options
 #
 # NOTE: Assumes paratest.client is run from $CHPL_HOME/test
@@ -59,8 +59,9 @@ sub main {
     $testdir = $ARGV[2];
     $chplenv = $ARGV[3];
     $futures_mode = "-futures-mode \"" . $ARGV[4] . "\"";
-    $valgrind = ($ARGV[5] == 1) ? "-valgrind" : "";
-    $valgrind = ($ARGV[5] == 2) ? "-valgrindexe" : "";
+    $valgrind = "";
+    $valgrind = "-valgrind" if ($ARGV[5] == 1);
+    $valgrind = "-valgrindexe" if ($ARGV[5] == 2);
 
     print "$id $workingdir $testdir $futures_mode $valgrind" if $debug;
     if ($#ARGV>=7) {

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -488,7 +488,7 @@ sub find_files {
 
 
 sub print_help {
-    print "Usage: paratest.server [-compopts s] [-dirfile d] [-execopts s] [-filedist] [-futures] [-logfile l] [-memleaks f] [-nodefile n] [-nodepara m] [-suppress f] [-valgrind] [-help|-h] [-timeout t]\n";
+    print "Usage: paratest.server [-compopts s] [-dirfile d] [-execopts s] [-filedist] [-futures] [-logfile l] [-memleaks f] [-nodefile n] [-nodepara m] [-suppress f] [-valgrind[exe]] [-help|-h] [-timeout t]\n";
     print "    -compopts s: s is a string that is passed with -compopts to start_test.\n";
     print "    -dirfile  d: d is a file listing directories to test. Default is the current diretory.\n";
     print "    -execopts s: s is a string that is passed with -execopts to start_test.\n";
@@ -499,7 +499,7 @@ sub print_help {
     print "    -nodefile n: n is a file listing nodes to run on. Default is current node.\n";
     print "    -nodepara m: Run m paratest.client tasks on each node.\n";
     print "    -suppress f: f is a file with the tests to suppress using filterSuppressions.\n";  
-    print "    -valgrind  : pass -valgrind to start_test.\n";
+    print "    -valgrind[exe]  : pass -valgrind or -valgrindexe to start_test.\n";
     print "    -timeout  t: t is the max time to wait after last directory is served.\n";
     print "    -junit-xml : Create jUnit test report.\n";
     print "    -junit-xml-file f: Put jUnit test report at location 'f' (implies -junit-xml).\n";
@@ -608,6 +608,9 @@ sub main {
             }
         } elsif (/^-valgrind/) {
             $valgrind = 1;
+            if (/^-valgrindexe/) {
+                $valgrind = 2;
+            }
         } elsif (/^-show-all-errors/) {
             $show_all_errors = 1;
         } elsif (/^-junit-xml$/) {


### PR DESCRIPTION
Before, if you typed -valgrindexe as an option to paratest, it would parse the
flag as -valgrind and run valgrind on the compiler as well as the test program.
This is not what the user expects.

I modified the server and client scripts to honor the "exe" suffix if present,
and in that case run valgrind on only the test program.