### PR TITLE
Make reference count debug code work with --no-local.

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4301,8 +4301,11 @@ GenRet CallExpr::codegen() {
           get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         ret = codegenRaddr(get(1));
       } else {
-        ret = get(1);
+        ret = codegenValue(get(1));
       }
+      // _wide_get_addr promises to return a uint.  Hence the cast.
+      ret = codegenCast(dtUInt[INT_SIZE_64], ret);
+      ret.isUnsigned = true;
       break;
     }
     case PRIM_ADDR_OF:

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -96,15 +96,15 @@ returnInfoDefaultInt(CallExpr* call) {
   return returnInfoInt64(call);
 }
 
+static Type*
+returnInfoUInt64(CallExpr* call) {
+  return dtUInt[INT_SIZE_64];
+}
+
 /*
 static Type*
 returnInfoUInt32(CallExpr* call) { // unexecuted none/gasnet on 4/25/08
   return dtUInt[INT_SIZE_32];
-}
-
-static Type*
-returnInfoUInt64(CallExpr* call) {
-  return dtUInt[INT_SIZE_64];
 }
 
 
@@ -560,7 +560,7 @@ initPrimitive() {
   // This will be unnecessary once the module code calls the corresponding
   // function directly.
   prim_def(PRIM_WIDE_GET_NODE, "_wide_get_node", returnInfoNodeID, false, true);
-  prim_def(PRIM_WIDE_GET_ADDR, "_wide_get_addr", returnInfoInt64, false, true);
+  prim_def(PRIM_WIDE_GET_ADDR, "_wide_get_addr", returnInfoUInt64, false, true);
 
   prim_def(PRIM_ON_LOCALE_NUM, "chpl_on_locale_num", returnInfoLocaleID);
 

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -97,7 +97,7 @@ module ChapelDistribution {
         if debugDistRefCount > 1 {
           extern proc printf(fmt: c_string, arg...);
           printf("----- INC _distCnt (%016lx) was %ld\n",
-                 __primitive("cast", uint(64), this), cnt);
+                 __primitive("_wide_get_addr", this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
           halt("_distCnt ", cnt, " is bogus!");
@@ -112,7 +112,7 @@ module ChapelDistribution {
         if debugDistRefCount > 1 {
           extern proc printf(fmt: c_string, arg...);
           printf("----- DEC _distCnt (%016lx) now %ld\n",
-                 __primitive("cast", uint(64), this), cnt);
+                 __primitive("_wide_get_addr", this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
           halt("_distCnt ", cnt, " is bogus!");
@@ -205,7 +205,7 @@ module ChapelDistribution {
         if debugDomRefCount > 1 {
           extern proc printf(fmt: c_string, arg...);
           printf("----- INC _domCnt (%016lx) was %ld\n", 
-                 __primitive("cast", uint(64), this), cnt);
+                 __primitive("_wide_get_addr", this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
           halt("_domCnt ", cnt, " is bogus!");
@@ -220,7 +220,7 @@ module ChapelDistribution {
         if debugDomRefCount > 1 {
           extern proc printf(fmt: c_string, arg...);
           printf("----- DEC _domCnt (%016lx) now %ld\n", 
-                 __primitive("cast", uint(64), this), cnt);
+                 __primitive("_wide_get_addr", this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
           halt("_domCnt ", cnt, " is bogus!");
@@ -388,8 +388,8 @@ module ChapelDistribution {
         const cnt = _arrCnt.read();
         if debugArrRefCount > 1 {
           extern proc printf(fmt: c_string, arg...);
-          printf("----- INC _arrCnt (%016lx) was %ld\n", 
-                 __primitive("cast", uint(64), this), cnt);
+          printf("----- INC _arrCnt (%016lx) was %ld\n",
+                 __primitive("_wide_get_addr", this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
           halt("_arrCnt ", cnt, " is bogus!");
@@ -403,8 +403,8 @@ module ChapelDistribution {
       if debugArrRefCount > 0 {
         if debugArrRefCount > 1 {
           extern proc printf(fmt: c_string, arg...);
-          printf("----- DEC _arrCnt (%016lx) now %ld\n", 
-                 __primitive("cast", uint(64), this), cnt);
+          printf("----- DEC _arrCnt (%016lx) now %ld\n",
+                 __primitive("_wide_get_addr", this), cnt);
         }
         if cnt < 0 || cnt > 10000 then
           halt("_arrCnt ", cnt, " is bogus!");


### PR DESCRIPTION
This involved changing codegen for PRIM_WIDE_GET_ADDR and using this instead of
the cast in the debug printf calls:
- The primitive promises to return a uint(64), so I made that true for both
  wide and narrow cases.
- The narrow case was returning something of pointer type, but that needed to
  be treated as a value.  So for the narrow case, I added a call to codegenValue().

The primitive is unused except in the ref count debug code, so this change will
not affect other parts of the compiler/module code.