### PR TITLE
Fix Valgrind error after isLink improvements

### DIFF
--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -155,6 +155,7 @@ qioerr chpl_fs_is_link(int* ret, const char* name) {
   if (exitStatus == -1 && errno == ENOENT) {
     // The link examined does not exist, return false
     *ret = 0;
+    return 0;
   } else if (exitStatus) {
     return qio_mkerror_errno();
   }


### PR DESCRIPTION
I had forgotten to exit the function early if the link was nonexistent, leading
to an attempt to use the empty buf struct when it was not valid to do so.  Fix
that by returning.