### PR TITLE
Add a top level make rule for the parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ comprt: FORCE
 compiler: FORCE
 	cd compiler && $(MAKE)
 
+parser: FORCE
+	cd compiler && $(MAKE) parser
+
 modules: FORCE
 	cd modules && $(MAKE)
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -128,7 +128,7 @@ $(CHPLDOC): $(CHPL)
 
 chpldoc: $(CHPLDOC)
 
-parser:
+parser: FORCE
 	$(MAKE) -C parser parser
 
 $(CHPL_BIN_DIR):

--- a/compiler/parser/Makefile
+++ b/compiler/parser/Makefile
@@ -40,14 +40,25 @@ CLEAN_TARGS += \
 
 endif
 
-parser: FORCE
-	@rm -f bison-chapel.output bison-chapel.cpp flex-chapel.cpp
-	@rm -f ../include/bison-chapel.h ../include/flex-chapel.h
+# Removes bison-chapel.cpp after a build with conflicts so make wont think the
+# dependency is met on subsequent builds
+bison-chapel.cpp: chapel.ypp
+	@rm -f bison-chapel.output bison-chapel.cpp
+	@rm -f ../include/bison-chapel.h
 	bison chapel.ypp
-	@if grep -q "conflicts:" bison-chapel.output; then echo "PROBLEM: chapel.ypp contains conflicts"; exit 1; fi;
+	@if grep -q "conflicts:" bison-chapel.output; \
+		then echo "PROBLEM: chapel.ypp contains conflicts"; \
+		rm -f bison-chapel.cpp; \
+		exit 1; \
+	fi;
+
+flex-chapel.cpp: chapel.lex bison-chapel.cpp
+	@rm -f flex-chapel.cpp
+	@rm -f ../include/flex-chapel.h
 	flex chapel.lex
 
-FORCE:
+# Empty recipe (;) to avoid the implicit rules for .cpp files
+parser: bison-chapel.cpp flex-chapel.cpp ;
 
 #
 # standard footer


### PR DESCRIPTION
Adds a top level rule for the parser to make development easier. I've
also changed the build rules for the parser to be a bit smarter. Builds
should now properly detect changes to chapel.ypp and chapel.lex and
rebuild when necessary rather than every time you make the parser.