### PR TITLE
Disable cairo for the hwloc build

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -12,24 +12,7 @@ ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_HWLOC_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 endif
 
-CHPL_HWLOC_CFG_OPTIONS += --enable-static --disable-shared --disable-libxml2 --disable-pci
-
-ifeq ($(CHPL_MAKE_TARGET_COMPILER), pgi)
-  #
-  # When using the PGI compiler natively (not with the Cray PrgEnv
-  # wrapper), with default dynamic linking, we fail trying to link
-  # lstopo.  The PGI compiler isn't gcc and can't do -print-search-dirs,
-  # so the hwloc libtool ends up using "/usr/lib /lib" as a default
-  # search path and tries to link the 32-bit /usr/lib/libX11.so into the
-  # 64-bit lstopo, getting an architecture mismatch gripe.  To work
-  # around this, disable the cairo graphical backend for lstopo.  This
-  # is the only thing that uses X11, so without it we don't try to link
-  # libX11.  (I also tried using --disable-gl, --x-libraries=/usr/lib64,
-  # and --without-x to solve this problem, and none of those worked.
-  # Forcing static linking does work, but that seems too big a hammer.)
-  #
-  CHPL_HWLOC_CFG_OPTIONS += --disable-cairo
-endif
+CHPL_HWLOC_CFG_OPTIONS += --enable-static --disable-shared --disable-libxml2 --disable-pci --disable-cairo
 
 CHPL_HWLOC_CFG_OPTIONS += $(CHPL_HWLOC_MORE_CFG_OPTIONS)
 


### PR DESCRIPTION
[Reviewed by @gbtitus ]

Autoconf's cairo detection was causing problems for builds on OSX that
had certain libraries installed at the system level. We don't actually
need the cairo backend for lstopo, so just disable it for all builds.