### PR TITLE
Remove extraneous #includes of scopeResolve.h

### DIFF
--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -23,7 +23,6 @@
 #include "build.h"
 #include "codegen.h"
 #include "expr.h"
-#include "scopeResolve.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"

--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -44,7 +44,6 @@
 #include "clangSupport.h"
 
 #include "build.h"
-#include "scopeResolve.h"
 
 typedef Type ChapelType;
 


### PR DESCRIPTION
Both externCResolve and clangUtil had a #include for scopeResolve.h, but no
uses of the functions defined in that header file.  This seemed like an
oversight.  In the interest of moving a function definition to scopeResolve.h
and not having it bleed without warrant, I'm investigating the effects of
removing these unnecessary calls.

Still testing (don't have llvm built on my testing branch).