### PR TITLE
Revert some changes to the parser Makefile

### DIFF
--- a/compiler/parser/Makefile
+++ b/compiler/parser/Makefile
@@ -40,25 +40,20 @@ CLEAN_TARGS += \
 
 endif
 
-# Removes bison-chapel.cpp after a build with conflicts so make wont think the
-# dependency is met on subsequent builds
-bison-chapel.cpp: chapel.ypp
-	@rm -f bison-chapel.output bison-chapel.cpp
-	@rm -f ../include/bison-chapel.h
+# Don't create rules for bison-chapel.cpp or flex-chapel.cpp since we don't
+# want them to be rebuilt automatically. (This is because of the bison version
+# 2.5 requirement)
+parser: FORCE
+	@rm -f bison-chapel.output bison-chapel.cpp flex-chapel.cpp
+	@rm -f ../include/bison-chapel.h ../include/flex-chapel.h
 	bison chapel.ypp
 	@if grep -q "conflicts:" bison-chapel.output; \
 		then echo "PROBLEM: chapel.ypp contains conflicts"; \
 		rm -f bison-chapel.cpp; \
 		exit 1; \
 	fi;
-
-flex-chapel.cpp: chapel.lex bison-chapel.cpp
-	@rm -f flex-chapel.cpp
-	@rm -f ../include/flex-chapel.h
 	flex chapel.lex
 
-# Empty recipe (;) to avoid the implicit rules for .cpp files
-parser: bison-chapel.cpp flex-chapel.cpp ;
 
 #
 # standard footer


### PR DESCRIPTION
I was over-eager in improving the parser Makefile and committed some
rules that caused automatic rebuilds when the parser or lexer changed.
We don't want this to happen because of the requirement on bison 2.5.