### PR TITLE
String as rec June 30 bug fixes

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -757,6 +757,10 @@ static void addAutoDestroyCallsForModule(ModuleSymbol* mod, FnSymbol* fn,
         if (var->hasFlag(FLAG_NO_AUTO_DESTROY))
           continue;
 
+        // Don't destroy type variables (they have no run-time representation).
+        if (var->hasFlag(FLAG_TYPE_VARIABLE))
+          continue;
+
         if (FnSymbol* autoDestroy = autoDestroyMap.get(var->type))
         {
           // Skip destructors for class types (only nude RWT types at this point).

--- a/test/memory/shannon/printFinalMemStat.no-local.good
+++ b/test/memory/shannon/printFinalMemStat.no-local.good
@@ -3,7 +3,7 @@
 Memory Statistics
 ==============================================================
 Current Allocated Memory               256
-Maximum Simultaneous Allocated Memory  505
-Total Allocated Memory                 2041
-Total Freed Memory                     1785
+Maximum Simultaneous Allocated Memory  489
+Total Allocated Memory                 3266
+Total Freed Memory                     3010
 ==============================================================


### PR DESCRIPTION
Don't add global destructor calls for type aliases.

This was an oversight when type aliases were added. We should not emit autodestroy calls on variables that represent type aliases.

Apparently, shallow zero-initialization keeps the problem (deleting an uninitialized variable) from surfacing unless --no-local is tossed.  The problem is likely also present on multilocale runs.

Also, updated no-local.good file for memory/shannon/printFinalMemStat.  This can be considered a workaround: we really should not be leaking memory every time we write to a channel across locales....