### PR TITLE
Factor out defaultInitializer->getFormal(1)->type->defaultInitializer.

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -44,6 +44,10 @@ const char* toString(FnSymbol* fn);
 
 void parseExplainFlag(char* flag, int* line, ModuleSymbol** module);
 
+FnSymbol* getTheIteratorFn(Symbol* ic);
+FnSymbol* getTheIteratorFn(CallExpr* call);
+FnSymbol* getTheIteratorFn(Type* icType);
+
 // forall intents
 void implementForallIntents1(DefExpr* defChplIter);
 void implementForallIntents2(CallExpr* call, CallExpr* origToLeaderCall);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -321,7 +321,8 @@ class FnSymbol : public Symbol {
   BlockStmt* body;
   IntentTag thisTag;
   RetTag retTag;
-  IteratorInfo* iteratorInfo;
+  IteratorInfo* iteratorInfo; // Attached only to iterators, specifically to
+                              // original (user) iterators before lowering.
   Symbol* _this;
   Symbol* _outer;
   FnSymbol *instantiatedFrom;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5269,8 +5269,8 @@ preFold(Expr* expr) {
         call->insertAtTail(tmp);
       }
     } else if (call->isPrimitive(PRIM_TO_STANDALONE)) {
-      FnSymbol* iterator = call->get(1)->typeInfo()->defaultInitializer->getFormal(1)->type->defaultInitializer;
-     CallExpr* standaloneCall = new CallExpr(iterator->name);
+      FnSymbol* iterator = getTheIteratorFn(call);
+      CallExpr* standaloneCall = new CallExpr(iterator->name);
       for_formals(formal, iterator) {
         standaloneCall->insertAtTail(new NamedExpr(formal->name, new SymExpr(formal)));
       }
@@ -5280,7 +5280,7 @@ preFold(Expr* expr) {
       call->replace(standaloneCall);
       result = standaloneCall;
     } else if (call->isPrimitive(PRIM_TO_LEADER)) {
-      FnSymbol* iterator = call->get(1)->typeInfo()->defaultInitializer->getFormal(1)->type->defaultInitializer;
+      FnSymbol* iterator = getTheIteratorFn(call);
       CallExpr* leaderCall;
       if (FnSymbol* leader = iteratorLeaderMap.get(iterator))
         leaderCall = new CallExpr(leader);
@@ -5295,7 +5295,7 @@ preFold(Expr* expr) {
       call->replace(leaderCall);
       result = leaderCall;
     } else if (call->isPrimitive(PRIM_TO_FOLLOWER)) {
-      FnSymbol* iterator = call->get(1)->typeInfo()->defaultInitializer->getFormal(1)->type->defaultInitializer;
+      FnSymbol* iterator = getTheIteratorFn(call);
       CallExpr* followerCall;
       if (FnSymbol* follower = iteratorFollowerMap.get(iterator))
         followerCall = new CallExpr(follower);

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -33,9 +33,9 @@
 #include "symbol.h"
 
 
-// Get the corresponding iterator FnSymbol, insead of:
-//   ...->defaultInitializer->getFormal(1)->type->defaultInitializer
+// getTheIteratorFn(): get the corresponding original iterator's FnSymbol.
 
+// 'ic' must be an instance of _iteratorClass
 FnSymbol* getTheIteratorFn(Symbol* ic) {
   return getTheIteratorFn(ic->type);
 }
@@ -44,6 +44,12 @@ FnSymbol* getTheIteratorFn(CallExpr* call) {
   return getTheIteratorFn(call->get(1)->typeInfo());
 }
 
+// getTheIteratorFn() - was:
+//   ...->defaultInitializer->getFormal(1)->type->defaultInitializer
+//
+// * _iteratorClass's defaultInitializer's first arg type is _iteratorRecord
+// * _iteratorRecord type's defaultInitializer gives us the iterator
+//
 FnSymbol* getTheIteratorFn(Type* icType) {
   // either an IC or a tuple thereof
   // the asserts document the current state

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -33,6 +33,31 @@
 #include "symbol.h"
 
 
+// Get the corresponding iterator FnSymbol, insead of:
+//   ...->defaultInitializer->getFormal(1)->type->defaultInitializer
+
+FnSymbol* getTheIteratorFn(Symbol* ic) {
+  return getTheIteratorFn(ic->type);
+}
+
+FnSymbol* getTheIteratorFn(CallExpr* call) {
+  return getTheIteratorFn(call->get(1)->typeInfo());
+}
+
+FnSymbol* getTheIteratorFn(Type* icType) {
+  // either an IC or a tuple thereof
+  // the asserts document the current state
+  bool gotTuple = icType->symbol->hasFlag(FLAG_TUPLE);
+  INT_ASSERT(gotTuple || icType->symbol->hasFlag(FLAG_ITERATOR_CLASS));
+  Type* irType = icType->defaultInitializer->getFormal(1)->type;
+  INT_ASSERT(irType->symbol->hasFlag(FLAG_ITERATOR_RECORD) ||
+             (gotTuple && irType->symbol->hasFlag(FLAG_ITERATOR_CLASS)));
+  FnSymbol* result = irType->defaultInitializer;
+  INT_ASSERT(gotTuple || result->hasFlag(FLAG_ITERATOR_FN));
+  return result;
+}
+
+
 // This consistency check should probably be moved earlier in the compilation.
 // It needs to be after resolution because it sets FLAG_INLINE_ITERATOR.
 // Does it need to be recursive? (Currently, it is not.)
@@ -1072,7 +1097,7 @@ expandRecursiveIteratorInline(ForLoop* forLoop)
   // passed to it when this function is flattened)
   //
   Symbol*    ic             = forLoop->iteratorGet()->var;
-  FnSymbol*  iterator       = ic->type->defaultInitializer->getFormal(1)->type->defaultInitializer;
+  FnSymbol*  iterator       = getTheIteratorFn(ic);
   CallExpr*  iteratorFnCall = new CallExpr(iterator, ic, new_IntSymbol(ftableMap.get(loopBodyFnWrapper)));
 
   // replace function in iteratorFnCall with iterator function once that is created
@@ -1157,7 +1182,7 @@ static bool
 // the tree); false otherwise.
 expandIteratorInline(ForLoop* forLoop) {
   Symbol*   ic       = forLoop->iteratorGet()->var;
-  FnSymbol* iterator = ic->type->defaultInitializer->getFormal(1)->type->defaultInitializer;
+  FnSymbol* iterator = getTheIteratorFn(ic);
 
   if (iterator->hasFlag(FLAG_RECURSIVE_ITERATOR)) {
     // NOAKES 2014/11/30  Only 6 tests, some with minor variations, use this path
@@ -1417,7 +1442,7 @@ canInlineSingleYieldIterator(Symbol* gIterator) {
   getRecursiveIterators(iterators, gIterator);
 
   for (int i = 0; i < iterators.n; i++) {
-    FnSymbol*      iterator = iterators.v[i]->type->defaultInitializer->getFormal(1)->type->defaultInitializer;
+    FnSymbol*      iterator = getTheIteratorFn(iterators.v[i]);
     BlockStmt*     block    = iterator->body;
     Vec<CallExpr*> calls;
     int            numYields = 0;
@@ -1528,7 +1553,7 @@ getIteratorChildren(Vec<Type*>& children, Type* type) {
 
 static void
 buildIteratorCallInner(BlockStmt* block, Symbol* ret, int fnid, Symbol* iterator) {
-  IteratorInfo* ii = iterator->type->defaultInitializer->getFormal(1)->type->defaultInitializer->iteratorInfo;
+  IteratorInfo* ii = getTheIteratorFn(iterator)->iteratorInfo;
   FnSymbol* fn = NULL;
   switch (fnid) {
   case ZIP1: fn = ii->zip1; break;
@@ -1600,7 +1625,7 @@ inlineSingleYieldIterator(ForLoop* forLoop) {
   forLoop->insertAtHead(noop);
 
   for (int i = 0; i < iterators.n; i++) {
-    FnSymbol*     iterator   = iterators.v[i]->type->defaultInitializer->getFormal(1)->type->defaultInitializer;
+    FnSymbol*     iterator   = getTheIteratorFn(iterators.v[i]);
     BlockStmt*    ibody      = iterator->body->copy();
     bool          afterYield = false;
     int           count      = 1;
@@ -1674,8 +1699,8 @@ expandForLoop(ForLoop* forLoop) {
 
   if (!fNoInlineIterators)
   {
-    if (iterator->type->defaultInitializer->getFormal(1)->type->defaultInitializer->iteratorInfo &&
-        canInlineIterator(iterator->type->defaultInitializer->getFormal(1)->type->defaultInitializer) &&
+    FnSymbol* iterFn = getTheIteratorFn(iterator->type);
+    if (iterFn->iteratorInfo && canInlineIterator(iterFn) &&
         (iterator->type->dispatchChildren.n == 0 ||
          (iterator->type->dispatchChildren.n == 1 &&
           iterator->type->dispatchChildren.v[0] == dtObject))) {
@@ -1771,7 +1796,7 @@ expandForLoop(ForLoop* forLoop) {
       forLoop->insertAtTail(buildIteratorCall(NULL, ZIP3, iterators.v[i], children));
       forLoop->insertAfter (buildIteratorCall(NULL, ZIP4, iterators.v[i], children));
 
-      FnSymbol* iterFn = iterators.v[i]->type->defaultInitializer->getFormal(1)->type->defaultInitializer;
+      FnSymbol* iterFn = getTheIteratorFn(iterators.v[i]);
       if (isBoundedIterator(iterFn)) {
         if (testBlock == NULL) {
           if (isNotDynIter) {


### PR DESCRIPTION
I expect this magic to change slightly in my work of ensuring proper
argument intents during resolution, so I would like it factored out.

While there, I added some assertions. No deep reason to have those,
just documenting what we have today.

The function name has "The" in it so it can be distinguished from
a few other getIterator thingies.