### PR TITLE
Fix 32 bit portability issue for getFileSize()

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -658,9 +658,9 @@ proc getMode(name: string): int {
 
 pragma "no doc"
 proc getFileSize(out error: syserr, name: string): int {
-  extern proc chpl_fs_get_size(ref result: off_t, filename: c_string):syserr;
+  extern proc chpl_fs_get_size(ref result: int, filename: c_string):syserr;
 
-  var result: off_t;
+  var result: int;
   error = chpl_fs_get_size(result, name.c_str());
   return result;
 }

--- a/runtime/include/chpl-file-utils.h
+++ b/runtime/include/chpl-file-utils.h
@@ -40,7 +40,7 @@ qioerr chpl_fs_cwd(const char** working_dir);
 
 qioerr chpl_fs_exists(int* ret, const char* name);
 
-qioerr chpl_fs_get_size(off_t* ret, const char* name);
+qioerr chpl_fs_get_size(int64_t* ret, const char* name);
 qioerr chpl_fs_get_uid(int* ret, const char* name);
 qioerr chpl_fs_get_gid(int* ret, const char* name);
 

--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -111,7 +111,7 @@ qioerr chpl_fs_exists(int* ret, const char* name) {
   return err;
 }
 
-qioerr chpl_fs_get_size(off_t* ret, const char* name) {
+qioerr chpl_fs_get_size(int64_t* ret, const char* name) {
   struct stat buf;
   int exitStatus = stat(name, &buf);
   if (exitStatus)


### PR DESCRIPTION
Our Linux 32 testing failed on the tests for getFileSize because we had
hard-coded the definition of off_t at the Chapel level to be 64 bits when it
would be 32 bits on 32 bit platforms.  Unfortunately, there is not a good way
to vary the size of the Chapel definition of off_t similar to our other C
types - off_t is not as standard as the others and its size variations are not
as easily visible.  The portable solution recommended is to expect the largest
size available.  Which isn't future-proof, but so it goes.  With this in mind,
instead of having the runtime support functions give an off_t, I will have them
return an int64_t.