### PR TITLE
Added _cast(type t, x:c_string) where t==c_string.

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -435,6 +435,11 @@ module CString {
     __primitive("=", a, b);
   }
 
+  // yes this is invoked sometimes
+  inline proc _cast(type t, x: c_string) where t == c_string {
+    return x;
+  }
+
   inline proc _cast(type t, x: c_string) where t == string {
     return toString(x);
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -435,7 +435,8 @@ module CString {
     __primitive("=", a, b);
   }
 
-  // yes this is invoked sometimes
+  // Yes this is invoked sometimes. In the long run, however,
+  // we'd like the compiler to eliminate casts to the same type instead.
   inline proc _cast(type t, x: c_string) where t == c_string {
     return x;
   }


### PR DESCRIPTION
_cast(c_string, x) is sometimes invoked when x: c_string,
e.g. from _command_line_cast().

Prior to this change, such a cast resulted in converting the actual
to a string then converting that back to c_string.
This change makes the actual go through directly, saving a few lines
in the generated code.

I don't know how this matters for string-as-rec branch.
