### PR TITLE
Make adding .0 for distinguishing floating point numbers add .digit

### DIFF
--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -2480,7 +2480,18 @@ int _ftoa(char* restrict dst, size_t size, double num, int base, bool needs_i, c
         got++;
 
         if( style->showpointzero ) {
-          if( got < size ) dst[got] = '0';
+          // if we're adding a .0 for integers, but
+          // we're printing out a floating point that
+          // just happened to have no decimal digits after a
+          // %g conversion, add a .x digit
+          if( got < size ) {
+            // figure out which digit to print.
+            // Alternatively, we could have _ftoa_core handle this...
+            // assumes num is positive.
+            double intpart = trunc(num);
+            double first_after_point = round(10.0*(num - intpart));
+            dst[got] = '0' + first_after_point;
+          }
           got++;
         }
       }

--- a/test/io/ferguson/sixdigits.chpl
+++ b/test/io/ferguson/sixdigits.chpl
@@ -1,0 +1,12 @@
+var p1 = 31415.92654;
+writef("%dr\n", p1);
+writeln(p1);
+
+var p2 = 314159.2654;
+writef("%dr\n", p2);
+writeln(p2);
+
+var p3 = 3141592.654;
+writef("%dr\n", p3);
+writeln(p3);
+


### PR DESCRIPTION
Nikhil reported this bug and was suprised:

    var pi = 314159.2654;
    writeln(pi);

produced

    314159.0

but he would have expected 314159.3 or an exponential notation number.