### PR TITLE
Make fifo allocate all task stacks from the Chapel heap

### DIFF
--- a/runtime/src/chpl-mem.c
+++ b/runtime/src/chpl-mem.c
@@ -93,15 +93,15 @@ int chpl_posix_memalign(void** ptr, size_t alignment, size_t size) {
 
 void* chpl_valloc(size_t size)
 {
-  return chpl_memalign(chpl_getHeapPageSize(), size);
+  return chpl_memalign(chpl_getSysPageSize(), size);
 }
 
 void* chpl_pvalloc(size_t size)
 {
-  size_t page_size = chpl_getHeapPageSize();
+  size_t page_size = chpl_getSysPageSize();
   size_t num_pages = (size + page_size - 1) / page_size;
   size_t rounded_up = num_pages * page_size; 
-  return chpl_memalign(chpl_getHeapPageSize(), rounded_up);
+  return chpl_memalign(page_size, rounded_up);
 }
 
 

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -84,11 +84,11 @@ size_t chpl_getHeapPageSize(void) {
     else {
       int scanCnt;
       size_t tmpPageSize;
-      char units;
+      char units[4]; // leave room for terminating null byte
 
-      if ((scanCnt = sscanf(ev, "%zd%1[kKmMgG]", &tmpPageSize, &units)) > 0) {
+      if ((scanCnt = sscanf(ev, "%zd%1[kKmMgG]", &tmpPageSize, units)) > 0) {
         if (scanCnt == 2) {
-          switch (units) {
+          switch (units[0]) {
           case 'k': case 'K': tmpPageSize <<= 10; break;
           case 'm': case 'M': tmpPageSize <<= 20; break;
           case 'g': case 'G': tmpPageSize <<= 30; break;
@@ -98,6 +98,9 @@ size_t chpl_getHeapPageSize(void) {
       else
         chpl_internal_error("unexpected HUGETLB_DEFAULT_PAGE_SIZE syntax");
       pageSize = tmpPageSize;
+
+      if (pageSize <= 0L)
+        chpl_internal_error("heap page size must be positive");
     }
 #else
     pageSize = chpl_getSysPageSize();

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -328,6 +328,34 @@ void chpl_sync_destroyAux(chpl_sync_aux_t *s) {
   chpl_thread_mutexDestroy(&s->lock);
 }
 
+static void setup_main_thread_private_data(void)
+{
+  thread_private_data_t* tp;
+
+  tp = (thread_private_data_t*) chpl_mem_alloc(sizeof(thread_private_data_t),
+                                               CHPL_RT_MD_THREAD_PRV_DATA,
+                                               0, 0);
+
+  tp->ptask = (task_pool_p) chpl_mem_alloc(sizeof(task_pool_t),
+                                           CHPL_RT_MD_TASK_POOL_DESC,
+                                           0, 0);
+  tp->ptask->id           = get_next_task_id();
+  tp->ptask->fun          = NULL;
+  tp->ptask->arg          = NULL;
+  tp->ptask->ltask        = NULL;
+  tp->ptask->begun        = true;
+  tp->ptask->filename     = "main program";
+  tp->ptask->lineno       = 0;
+  tp->ptask->next         = NULL;
+  tp->lockRprt            = NULL;
+
+  // Set up task-private data for locale (architectural) support.
+  tp->ptask->chpl_data.prvdata.serial_state = true;     // Set to false in chpl_task_callMain().
+
+  chpl_thread_setPrivateData(tp);
+}
+
+
 // Tasks
 
 void chpl_task_init(void) {
@@ -355,31 +383,7 @@ void chpl_task_init(void) {
   // install the signal handlers, because when those are invoked they
   // may use the thread private data.
   //
-  {
-    thread_private_data_t* tp;
-
-    tp = (thread_private_data_t*) chpl_mem_alloc(sizeof(thread_private_data_t),
-                                                 CHPL_RT_MD_THREAD_PRV_DATA,
-                                                 0, 0);
-
-    tp->ptask = (task_pool_p) chpl_mem_alloc(sizeof(task_pool_t),
-                                             CHPL_RT_MD_TASK_POOL_DESC,
-                                             0, 0);
-    tp->ptask->id           = get_next_task_id();
-    tp->ptask->fun          = NULL;
-    tp->ptask->arg          = NULL;
-    tp->ptask->ltask        = NULL;
-    tp->ptask->begun        = true;
-    tp->ptask->filename     = "main program";
-    tp->ptask->lineno       = 0;
-    tp->ptask->next         = NULL;
-    tp->lockRprt            = NULL;
-
-    // Set up task-private data for locale (architectural) support.
-    tp->ptask->chpl_data.prvdata.serial_state = true;     // Set to false in chpl_task_callMain().
-
-    chpl_thread_setPrivateData(tp);
-  }
+  setup_main_thread_private_data();
 
   if (blockreport) {
     progress_cnt = 0;
@@ -406,6 +410,10 @@ void chpl_task_exit(void) {
 typedef void (*main_ptr_t)(void); 
 static void* do_callMain(void* arg) {
   main_ptr_t chpl_main = (main_ptr_t) arg;
+
+  // make sure this thread has thread-private data.
+  setup_main_thread_private_data();
+
   chpl_main();
   return NULL;
 }
@@ -424,14 +432,14 @@ void chpl_task_callMain(void (*chpl_main)(void)) {
 
   pthread_attr_setstack(&attr, stack, stack_size);
   
-  rc = pthread_create(&thread, &attr, do_callMain, NULL);
+  rc = pthread_create(&thread, &attr, do_callMain, chpl_main);
   if( rc != 0 ) {
-    chpl_internal_error("pthread_create failed");
+    chpl_internal_error("pthread_create main failed");
   }
 
   rc = pthread_join(thread, NULL);
   if( rc != 0 ) {
-    chpl_internal_error("pthread_create failed");
+    chpl_internal_error("pthread_join main failed");
   } 
 }
 

--- a/runtime/src/threads/pthreads/threads-pthreads.c
+++ b/runtime/src/threads/pthreads/threads-pthreads.c
@@ -81,6 +81,22 @@ static void            (*saved_threadEndFn)(void);
 static void*           initial_pthread_func(void*);
 static void*           pthread_func(void*);
 
+static int do_pthread_create(pthread_t* thread,
+                             pthread_attr_t* attr,
+                             void *(*start_routine)(void *),
+                             void *restrict arg) {
+
+  // update the attributes with a mem-layer allocated
+  // thread stack
+
+  size_t stack_size = threadCallStackSize;
+  // TODO -- guard pages...
+  void* stack = chpl_valloc(stack_size);
+
+  pthread_attr_setstack(attr, stack, stack_size);
+
+  return pthread_create(thread, attr, start_routine, arg);
+}
 
 // Mutexes
 
@@ -279,7 +295,7 @@ static void* initial_pthread_func(void* ignore) {
 
 int chpl_thread_createCommThread(chpl_fn_p fn, void* arg) {
   pthread_t polling_thread;
-  return pthread_create(&polling_thread, NULL, (void*(*)(void*))fn, arg);
+  return do_pthread_create(&polling_thread, &thread_attributes, (void*(*)(void*))fn, arg);
 }
 
 void chpl_thread_exit(void) {
@@ -349,7 +365,7 @@ int chpl_thread_create(void* arg)
   numThreads++;
   pthread_mutex_unlock(&numThreadsLock);
 
-  if (pthread_create(&pthread, &thread_attributes, pthread_func, arg)) {
+  if (do_pthread_create(&pthread, &thread_attributes, pthread_func, arg)) {
     pthread_mutex_lock(&numThreadsLock);
     numThreads--;
     pthread_mutex_unlock(&numThreadsLock);


### PR DESCRIPTION
I ran into problems when experimenting with ugni+fifo and --cache-remote.
The problem was that UGNI does not support get_nb for addresses
that are not in the segment - and that includes task stacks.

So, this patch does two things:
1. Updates threads-pthreads.c to allocate task stacks from the Chapel heap and then associates that with the pthread_create call through pthread_attr_setstack.
2. Updates  chpl_task_callMain in tasks-fifo.c to execute chpl_main in a pthread with an appropriately allocated stack.

Greg and I have talked about wanting both
* comms layers to handle out-of-segment operations; and
* tasking layers to allocate stacks from the registered segment.

One question: should these stacks ever be freed?
Passed full local testing.