### PR TITLE
Call cygwin's kill in timedexec since perl's doesn't always work

### DIFF
--- a/util/test/timedexec
+++ b/util/test/timedexec
@@ -61,6 +61,8 @@ if ($@) {
         # allow proper cleanup if possible
         print "timedexec sending SIGTERM\n";
         kill SIGTERM, -$child_pid;
+        # also call cygwin's kill since perl's doesn't always work
+        if ("$^O" eq "cygwin") { exec "/bin/kill -s SIGTERM -f $child_pid"; }
         waitpid($child_pid, 0);
         alarm 0;
     };
@@ -69,6 +71,8 @@ if ($@) {
         # hit it with the big hammer
         print "timedexec sending SIGKILL\n";
         kill SIGKILL, -$child_pid;
+        # also call cygwin's kill since perl's doesn't always work
+        if ("$^O" eq "cygwin") { exec "/bin/kill -s SIGKILL -f $child_pid"; }
     }
     # Because they share the same return code, Ctrl-C will look like a timeout.
     # This is OK, because the test timed out due to operator impatience.


### PR DESCRIPTION
We noticed that the `kill` we use in timedexec wasn't always successful on
cygwin for some reason. I think this is because for some tests cygwin had some
resources that windows technically owned and regular kill didn't cut it. Now we
also call cygwin's kill "/bin/kill" and pass "-f" to it so that cygwin will use
the win32 interface to kill if it has to.

For more info see: https://cygwin.com/cygwin-ug-net/using-utils.html#kill

I tested on cygwin with release/examples/primers/fileIO. This test caused
issues after 5 trials before this change, and "worked" for 100 trials after.
"worked" here means it timed out 20 times, but we actually killed the runaway.

I protected the call with `if ("$^O" eq "cygwin")` instead of checking
CHPL_TARGET_PLATFORM since we don't have easy access to that, and timedexec is
pretty chapel agnostic