### PR TITLE
Add public and private to the spec

### DIFF
--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -83,6 +83,12 @@ by a library or the execution environment.  See the chapter on interoperability
 (\rsec{Interoperability}) for more information on external classes.
 % External class inheritance is not currently supported.
 
+\begin{future}
+Privacy controls for classes and records is currently not specified,
+as discussion is needed regarding its impact on inheritance, for
+instance.
+\end{future}
+
 \subsection{Class Types}
 \label{Class_Types}
 \index{classes!types}

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -84,7 +84,7 @@ by a library or the execution environment.  See the chapter on interoperability
 % External class inheritance is not currently supported.
 
 \begin{future}
-Privacy controls for classes and records is currently not specified,
+Privacy controls for classes and records are currently not specified,
 as discussion is needed regarding its impact on inheritance, for
 instance.
 \end{future}

--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -117,8 +117,12 @@ Calls to methods are defined in Section~\rsec{Class_Method_Calls}.
 Procedures are defined with the following syntax:
 \begin{syntax}
 procedure-declaration-statement:
-  linkage-specifier[OPT] `proc' function-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
+  privacy-specifier[OPT] linkage-specifier[OPT] `proc' function-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
     function-body
+
+privacy-specifier:
+  `private'
+  `public'
 
 linkage-specifier:
   `inline'
@@ -226,6 +230,11 @@ Function and operator overloading is supported in Chapel and is
 discussed in~\rsec{Function_Overloading}.
 Operator overloading is supported on the operators listed
 above (see \sntx{operator-name}).
+
+The optional \sntx{privacy-specifier} keywords indicate the visibility
+of module level functions to outside modules.  By default, functions are
+publicly visible.  More details on visibility can be found in
+~\rsec{Visibility}.
 
 The linkage specifier \chpl{inline} indicates that the function body must be inlined at
 every call site.
@@ -1076,9 +1085,9 @@ Given a function call, a function is determined to be a \emph{visible
 function} if the name of the function is the same as the name of the
 function call and the function is defined in the same scope as the
 function call or a lexical outer scope of the function call, or if the
-function is defined in a module that is used from the same scope as
-the function call or a lexical outer scope of the function call.
-Function visibility in generic functions is discussed
+function is publicly defined in a module that is used from the same
+scope as the function call or a lexical outer scope of the function
+call.  Function visibility in generic functions is discussed
 in~\rsec{Function_Visibility_in_Generic_Functions}.
 
 \subsection{Determining Candidate Functions}

--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -230,7 +230,7 @@ above (see \sntx{operator-name}).
 The optional \sntx{privacy-specifier} keywords indicate the visibility
 of module level procedures to outside modules.  By default, procedures are
 publicly visible.  More details on visibility can be found in
-~\rsec{Visibility}.
+~\rsec{Visibility_Of_Symbols}.
 
 The linkage specifier \chpl{inline} indicates that the function body must be inlined at
 every call site.

--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -120,10 +120,6 @@ procedure-declaration-statement:
   privacy-specifier[OPT] linkage-specifier[OPT] `proc' function-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
     function-body
 
-privacy-specifier:
-  `private'
-  `public'
-
 linkage-specifier:
   `inline'
 
@@ -232,7 +228,7 @@ Operator overloading is supported on the operators listed
 above (see \sntx{operator-name}).
 
 The optional \sntx{privacy-specifier} keywords indicate the visibility
-of module level functions to outside modules.  By default, functions are
+of module level procedures to outside modules.  By default, procedures are
 publicly visible.  More details on visibility can be found in
 ~\rsec{Visibility}.
 
@@ -1085,7 +1081,7 @@ Given a function call, a function is determined to be a \emph{visible
 function} if the name of the function is the same as the name of the
 function call and the function is defined in the same scope as the
 function call or a lexical outer scope of the function call, or if the
-function is publicly defined in a module that is used from the same
+function is publicly declared in a module that is used from the same
 scope as the function call or a lexical outer scope of the function
 call.  Function visibility in generic functions is discussed
 in~\rsec{Function_Visibility_in_Generic_Functions}.

--- a/spec/Iterators.tex
+++ b/spec/Iterators.tex
@@ -18,8 +18,12 @@ The syntax to declare an iterator is given
 by:
 \begin{syntax}
 iterator-declaration-statement:
-  `iter' iterator-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
+  privacy-specifier[OPT] `iter' iterator-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
   iterator-body
+
+privacy-specifier:
+  `private'
+  `public'
 
 iterator-name:
   identifier

--- a/spec/Iterators.tex
+++ b/spec/Iterators.tex
@@ -21,10 +21,6 @@ iterator-declaration-statement:
   privacy-specifier[OPT] `iter' iterator-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
   iterator-body
 
-privacy-specifier:
-  `private'
-  `public'
-
 iterator-name:
   identifier
 

--- a/spec/Lexical_Structure.tex
+++ b/spec/Lexical_Structure.tex
@@ -149,8 +149,8 @@ forall
 if
 in
 index
-\end{chapel} & \begin{chapel}
 inline
+\end{chapel} & \begin{chapel}
 inout
 iter
 label
@@ -162,10 +162,12 @@ nil
 noinit
 on
 otherwise
-\end{chapel} & \begin{chapel}
 out
 param
+\end{chapel} & \begin{chapel}
+private
 proc
+public
 record
 reduce
 ref

--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -203,30 +203,34 @@ statement~(\rsec{Using_Modules}).
 \label{Visibility_Of_A_Module}
 \index{modules!access}
 
-The privacy of a module may place limitations on when outside access
-of its contents is valid. While public modules can be used and
-accessed through explicit naming in arbitrary contexts, only scopes
-defined beneath the parent scope of a private module will have the
-ability to use or explicitly name its symbols. Modules are public by
-default.
+A top-level module is visible anywhere if the \sntx{privacy-specifier}
+of its declaration is \chpl{public} or is omitted (i.e. by default).
+A top-level module declared \chpl{private} is visible only within that
+module.  The visibility of a nested module is subject to the rules
+of~\rsec{Visibility_Of_Symbols}. There, the nested module is
+considered a "symbol defined at the top level scope" of its outer
+module.
 
 \subsection{Visibility Of Module's Symbols}
 \label{Visibility_Of_Symbols}
 \index{modules!access}
-All symbols defined at the top level scope of a module are considered
-public by default.  This means that if the module itself is accessible
-by outside scopes, symbols defined within it may be accessible through
-explicit naming or when a use of the defining module is present.  When
-a symbol is declared as private, however, such access is not permitted
-and the symbol in question is only visible to the contents of the
-defining module.
+
+A symbol defined at the top level scope of a module is \emph{visible}
+from outside the module when the \sntx{privacy-specifier} of its
+definition is \chpl{public} or is omitted (i.e. by default).  A
+symbol's visibility inside its module is controlled by normal lexical
+scoping and is not affected by its \sntx{privacy-specifier}.  A
+module's visible symbols are accessible via explicit
+naming~(\rsec{Explicit_Naming}) or the use
+statement~(\rsec{Using_Modules}) only where the module's symbol is
+visible~(\rsec{Visibility_Of_A_Module}).
 
 \subsection{Explicit Naming}
 \label{Explicit_Naming}
 \index{modules!explicitly named}
 
-All top-level module symbols can be named explicitly with the
-following syntax:
+All publicly visible top-level module symbols can be named explicitly
+with the following syntax:
 \begin{syntax}
 module-access-expression:
   module-identifier-list . identifier
@@ -309,11 +313,11 @@ compiler error.
 \label{Using_Modules}
 \index{modules!using}
 
-If a module is public or defined in a common parent scope to where
-accessing its symbols is desirable, then a use statement on that
-module may be employed.  Use statements make the public symbols
-defined by a module available without requiring them to be prefixed by
-the module's name.  The syntax of the use statement is given by:
+If a module is visible to where accessing its symbols is desirable,
+then a use statement on that module may be employed.  Use statements
+make a module's visible symbols available without requiring them to be
+prefixed by the module's name.  The syntax of the use statement is
+given by:
 
 \begin{syntax}
 use-statement:
@@ -333,12 +337,13 @@ defined directly in the scope where the use statement occurs, but at a
 nearer scope than symbols defined in the scope containing the scope where
 the use statement occurs.
 
-Use statements are transitive by default: if used modules themselves
-use other modules, these symbols are also available and are scoped
-according to the depth of use statements followed to find them.  However,
-if a used module is private, this use is not transitive and any uses
-of the module which made use of the private module will not bring the
-private module's symbols into scope.
+Use statements are transitive by default: if a module A used by
+another module B also contains a use of a further module C, C's
+symbols will also be considered visible within B, at a further scope
+than the symbols of other modules immediately used by B.
+
+% We would like to provide a way to specify that a use should not be
+% transitive
 
 It is an error for two public variables, types, or modules to be
 defined at the same depth.

--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -10,7 +10,7 @@ Module definitions are described in~\rsec{Module_Definitions}.  The
 relation between files and modules is described
 in~\rsec{Implicit_Modules}.  Nested modules are described
 in~\rsec{Nested_Modules}.  The visibility of a module's symbols by
-users of the module is described in~\rsec{Visibility}.  The execution
+users of the module is described in~\rsec{Visibility_Of_Symbols}.  The execution
 of a program and module initialization is described
 in~\rsec{Program_Execution}.
 
@@ -36,7 +36,7 @@ A module's name is specified after the \chpl{module} keyword.
 The \sntx{block-statement} opens the module's scope.  Symbols defined
 in this block statement are defined in the module's scope and are
 called \emph{top-level module symbols}.  The visibility of a module is
-defined by its \sntx{privacy-specifier}~(\rsec{Visibility}).
+defined by its \sntx{privacy-specifier}~(\rsec{Visibility_Of_A_Module}).
 
 Module declaration statements must be top-level statements within a
 module.  A module that is declared within another module is called a
@@ -188,14 +188,20 @@ printY();
 \end{chapelexample}
 
 
-\section{Visibility}
-\label{Visibility}
-\index{modules!visibility}
+\section{Access of Module Contents}
+\label{Access_Of_Module_Contents}
+\index{modules!access}
 
-A module can be used by code outside of that module.  This allows
-access to the top-level module symbols without the need for explicit
-naming~(\rsec{Explicit_Naming}).  Using modules is accomplished via
-the use statement as defined in~\rsec{Using_Modules}.
+A module can be used by code outside of that module depending on the
+visibility of the module itself~(\rsec{Visibility_Of_A_Module}).  This
+allows access to its visible contents~(\rsec{Visibility_Of_Symbols})
+without the need for explicit naming~(\rsec{Explicit_Naming}).  Using
+modules is accomplished via the use statement as defined
+in~\rsec{Using_Modules}.
+
+\subsection{Visibility Of A Module}
+\label{Visibility_Of_A_Module}
+\index{modules!access}
 
 The privacy of a module may place limitations on when outside access
 of its contents is valid. While public modules can be used and
@@ -204,6 +210,9 @@ defined beneath the parent scope of a private module will have the
 ability to use or explicitly name its symbols. Modules are public by
 default.
 
+\subsection{Visibility Of Module's Symbols}
+\label{Visibility_Of_Symbols}
+\index{modules!access}
 All symbols defined at the top level scope of a module are considered
 public by default.  This means that if the module itself is accessible
 by outside scopes, symbols defined within it may be accessible through
@@ -302,9 +311,9 @@ compiler error.
 
 If a module is public or defined in a common parent scope to where
 accessing its symbols is desirable, then a use statement on that
-module may be employed.  Use statements make the symbols defined by a
-module available without requiring them to be prefixed by the module's
-name.  The syntax of the use statement is given by:
+module may be employed.  Use statements make the public symbols
+defined by a module available without requiring them to be prefixed by
+the module's name.  The syntax of the use statement is given by:
 
 \begin{syntax}
 use-statement:

--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -9,9 +9,9 @@ and types, is associated with some module.
 Module definitions are described in~\rsec{Module_Definitions}.  The
 relation between files and modules is described
 in~\rsec{Implicit_Modules}.  Nested modules are described
-in~\rsec{Nested_Modules}.  The visibility of symbols within a module
-in relation to other modules is described in~\rsec{Visibility}.  The
-execution of a program and module initialization is described
+in~\rsec{Nested_Modules}.  The visibility of a module's symbols by
+users of the module is described in~\rsec{Visibility}.  The execution
+of a program and module initialization is described
 in~\rsec{Program_Execution}.
 
 \section{Module Definitions}

--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -9,9 +9,10 @@ and types, is associated with some module.
 Module definitions are described in~\rsec{Module_Definitions}.  The
 relation between files and modules is described
 in~\rsec{Implicit_Modules}.  Nested modules are described
-in~\rsec{Nested_Modules}.  Module uses and explicit naming of symbols
-are described in~\rsec{Using_Modules}.  The execution of a program and
-module initialization is described in~\rsec{Program_Execution}.
+in~\rsec{Nested_Modules}.  The visibility of symbols within a module
+in relation to other modules is described in~\rsec{Visibility}.  The
+execution of a program and module initialization is described
+in~\rsec{Program_Execution}.
 
 \section{Module Definitions}
 \label{Module_Definitions}
@@ -21,7 +22,11 @@ module initialization is described in~\rsec{Program_Execution}.
 A module is declared with the following syntax:
 \begin{syntax}
 module-declaration-statement:
-  `module' module-identifier block-statement
+  privacy-specifier[OPT] `module' module-identifier block-statement
+
+privacy-specifier:
+  `private'
+  `public'
 
 module-identifier:
   identifier
@@ -30,7 +35,8 @@ module-identifier:
 A module's name is specified after the \chpl{module} keyword.
 The \sntx{block-statement} opens the module's scope.  Symbols defined
 in this block statement are defined in the module's scope and are
-called \emph{top-level module symbols}.
+called \emph{top-level module symbols}.  The visibility of a module is
+defined by its \sntx{privacy-specifier}~(\rsec{Visibility}).
 
 Module declaration statements must be top-level statements within a
 module.  A module that is declared within another module is called a
@@ -182,14 +188,29 @@ printY();
 \end{chapelexample}
 
 
-\section{Using Modules}
-\label{Using_Modules}
-\index{modules!using}
+\section{Visibility}
+\label{Visibility}
+\index{modules!visibility}
 
 A module can be used by code outside of that module.  This allows
 access to the top-level module symbols without the need for explicit
 naming~(\rsec{Explicit_Naming}).  Using modules is accomplished via
-the use statement as defined in~\rsec{The_Use_Statement}.
+the use statement as defined in~\rsec{Using_Modules}.
+
+The privacy of a module may place limitations on when outside access
+of its contents is valid. While public modules can be used and
+accessed through explicit naming in arbitrary contexts, only scopes
+defined beneath the parent scope of a private module will have the
+ability to use or explicitly name its symbols. Modules are public by
+default.
+
+All symbols defined at the top level scope of a module are considered
+public by default.  This means that if the module itself is accessible
+by outside scopes, symbols defined within it may be accessible through
+explicit naming or when a use of the defining module is present.  When
+a symbol is declared as private, however, such access is not permitted
+and the symbol in question is only visible to the contents of the
+defining module.
 
 \subsection{Explicit Naming}
 \label{Explicit_Naming}
@@ -274,6 +295,83 @@ that of M1.  On the other hand, the call to printY() is ambiguous
 because it is defined in both M1 and M3.  This will result in a
 compiler error.
 \end{chapelexample}
+
+\subsection{Using Modules}
+\label{Using_Modules}
+\index{modules!using}
+
+If a module is public or defined in a common parent scope to where
+accessing its symbols is desirable, then a use statement on that
+module may be employed.  Use statements make the symbols defined by a
+module available without requiring them to be prefixed by the module's
+name.  The syntax of the use statement is given by:
+
+\begin{syntax}
+use-statement:
+  `use' module-name-list ;
+
+module-name-list:
+  module-name
+  module-name , module-name-list
+
+module-name:
+  identifier
+  module-name . module-name
+\end{syntax}
+
+Symbols made available by a use statement are at an outer scope from those
+defined directly in the scope where the use statement occurs, but at a
+nearer scope than symbols defined in the scope containing the scope where
+the use statement occurs.
+
+Use statements are transitive by default: if used modules themselves
+use other modules, these symbols are also available and are scoped
+according to the depth of use statements followed to find them.  However,
+if a used module is private, this use is not transitive and any uses
+of the module which made use of the private module will not bring the
+private module's symbols into scope.
+
+It is an error for two public variables, types, or modules to be
+defined at the same depth.
+
+\begin{openissue}
+There is an expectation that this statement will be extended to allow
+the programmer to restrict which symbols are 'used' as well as to
+rename symbols that are 'used.'
+\end{openissue}
+
+\begin{chapelexample}{use.chpl}
+  The following example illustrates how the use statement makes
+  symbols declared in \chpl{M1}'s scope (like procedure
+  \chpl{foo()}) visible within the scope of \chpl{M2}'s \chpl{main}
+  function.  Without the \chpl{use} statement, the procedure call to
+  \chpl{foo} could not be resolved since \chpl{M2} would not have
+  access to symbols in \chpl{M1}.
+
+  When executed, the program
+\begin{chapel}
+module M1 {
+  proc foo() {
+    writeln("In M1's foo.");
+  }
+}
+
+module M2 {
+  proc main() {
+    use M1;
+
+    writeln("In M2's main.");
+    foo();
+  }
+}
+\end{chapel}
+prints out
+\begin{chapelprintoutput}{}
+In M2's main.
+In M1's foo.
+\end{chapelprintoutput}
+\end{chapelexample}
+
 
 
 \subsection{Module Initialization}

--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -192,12 +192,12 @@ printY();
 \label{Access_Of_Module_Contents}
 \index{modules!access}
 
-A module can be used by code outside of that module depending on the
-visibility of the module itself~(\rsec{Visibility_Of_A_Module}).  This
-allows access to its visible contents~(\rsec{Visibility_Of_Symbols})
-without the need for explicit naming~(\rsec{Explicit_Naming}).  Using
-modules is accomplished via the use statement as defined
-in~\rsec{Using_Modules}.
+A module's contents can be accessed by code outside of that module
+depending on the visibility of the module
+itself~(\rsec{Visibility_Of_A_Module}) and the visibility of each
+individual symbol~(\rsec{Visibility_Of_Symbols}).  This can be done
+via explicit naming~(\rsec{Explicit_Naming}) or the use
+statement~(\rsec{Using_Modules}).
 
 \subsection{Visibility Of A Module}
 \label{Visibility_Of_A_Module}

--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -98,7 +98,7 @@ by a library or the execution environment.  See the chapter on interoperability
 % External record inheritance is not currently supported.
 
 \begin{future}
-Privacy controls for classes and records is currently not specified,
+Privacy controls for classes and records are currently not specified,
 as discussion is needed regarding its impact on inheritance, for
 instance.
 \end{future}

--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -97,6 +97,12 @@ by a library or the execution environment.  See the chapter on interoperability
 (\rsec{Interoperability}) for more information on external records.
 % External record inheritance is not currently supported.
 
+\begin{future}
+Privacy controls for classes and records is currently not specified,
+as discussion is needed regarding its impact on inheritance, for
+instance.
+\end{future}
+
 \subsection{Record Types}
 \label{Record_Types}
 \index{records!record types}

--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -620,72 +620,9 @@ label outer for i in 1..n {
 \index{statements!use@\chpl{use}}
 \index{modules!using}
 
-The use statement makes the symbols defined by a module available
-within the scope containing the use statement without requiring them
-to be prefixed by the module's name.  The syntax of the use statement
-is given by:
-
-\begin{syntax}
-use-statement:
-  `use' module-name-list ;
-
-module-name-list:
-  module-name
-  module-name , module-name-list
-
-module-name:
-  identifier
-  module-name . module-name
-\end{syntax}
-The use statement makes symbols in each listed module's scope available
-from the scope where the use statement occurs.
-
-Symbols made available by a use statement are at an outer scope from those
-defined directly in the scope where the use statement occurs, but at a
-nearer scope than symbols defined in the scope containing the scope where
-the use statement occurs.
-
-If used modules themselves use other modules, symbols are scoped according
-the depth of use statements followed to find them. It is an error for two
-variables, types, or modules to be defined at the same depth.
-
-\begin{openissue}
-There is an expectation that this statement will be extended to allow
-the programmer to restrict which symbols are 'used' as well as to
-rename symbols that are 'used.'
-\end{openissue}
-
-\begin{chapelexample}{use.chpl}
-  The following example illustrates how the use statement makes
-  symbols declared in \chpl{M1}'s scope (like procedure
-  \chpl{foo()}) visible within the scope of \chpl{M2}'s \chpl{main}
-  function.  Without the \chpl{use} statement, the procedure call to
-  \chpl{foo} could not be resolved since \chpl{M2} would not have
-  access to symbols in \chpl{M1}.
-
-  When executed, the program
-\begin{chapel}
-module M1 {
-  proc foo() {
-    writeln("In M1's foo.");
-  }
-}
-
-module M2 {
-  proc main() {
-    use M1;
-
-    writeln("In M2's main.");
-    foo();
-  }
-}
-\end{chapel}
-prints out
-\begin{chapelprintoutput}{}
-In M2's main.
-In M1's foo.
-\end{chapelprintoutput}
-\end{chapelexample}
+The use statement makes symbols in each listed module's scope
+available from the scope where the use statement occurs.  For more
+information on use statements, see~\rsec{Using_Modules}.
 
 \section{The Empty Statement}
 \label{The_Empty_Statement}

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -408,8 +408,12 @@ The atomic type is discussed in \rsec{Atomic_Variables}.
 Type aliases are declared with the following syntax:
 \begin{syntax}
 type-alias-declaration-statement:
-  `config'[OPT] `type' type-alias-declaration-list ;
+  privacy-specifier[OPT] `config'[OPT] `type' type-alias-declaration-list ;
   external-type-alias-declaration-statement
+
+privacy-specifier:
+  `private'
+  `public'
 
 type-alias-declaration-list:
   type-alias-declaration
@@ -423,10 +427,15 @@ A type alias is a symbol that aliases the type specified in the
 \sntx{type-part}.  A use of a type alias has the same meaning as using
 the type specified by \sntx{type-part} directly.
 
+Type aliases defined at the module level are public by default.  The
+optional \sntx{privacy-specifier} keywords are provided to specify or
+change this behavior.  For more details on the visibility of symbols,
+see ~\rsec{Visibility}.
+
 If the keyword \chpl{config} precedes the keyword \chpl{type}, the
 type alias is called a configuration type alias.  Configuration type
 aliases can be set at compilation time via compilation flags or other
-implementation-defined means.  The \chpl{type-specifier} in the
+implementation-defined means.  The \sntx{type-specifier} in the
 program is ignored if the type-alias is alternatively set.
 
 If the keyword \chpl{extern} precedes the \chpl{type} keyword, the type alias is

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -426,7 +426,7 @@ the type specified by \sntx{type-part} directly.
 Type aliases defined at the module level are public by default.  The
 optional \sntx{privacy-specifier} keywords are provided to specify or
 change this behavior.  For more details on the visibility of symbols,
-see ~\rsec{Visibility}.
+see ~\rsec{Visibility_Of_Symbols}.
 
 If the keyword \chpl{config} precedes the keyword \chpl{type}, the
 type alias is called a configuration type alias.  Configuration type

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -411,10 +411,6 @@ type-alias-declaration-statement:
   privacy-specifier[OPT] `config'[OPT] `type' type-alias-declaration-list ;
   external-type-alias-declaration-statement
 
-privacy-specifier:
-  `private'
-  `public'
-
 type-alias-declaration-list:
   type-alias-declaration
   type-alias-declaration , type-alias-declaration-list

--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -60,7 +60,7 @@ in~\rsec{Local_Variables}.
 The optional \sntx{privacy-specifier} keywords indicate the visibility
 of module level variables to outside modules.  By default, variables
 are publicly visible.  More details on visibility can be found in
-~\rsec{Visibility}.
+~\rsec{Visibility_Of_Symbols}.
 
 The optional keyword \chpl{config} specifies that the variables are
 configuration variables, described in

--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -18,10 +18,6 @@ Variables are declared with the following syntax:
 variable-declaration-statement:
   privacy-specifier[OPT] config-or-extern[OPT] variable-kind variable-declaration-list ;
 
-privacy-specifier:
-  `private'
-  `public'
-
 config-or-extern: one of
   `config' $ $ $ $ `extern'
 

--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -16,7 +16,11 @@ by its type.
 Variables are declared with the following syntax:
 \begin{syntax}
 variable-declaration-statement:
-  config-or-extern[OPT] variable-kind variable-declaration-list ;
+  privacy-specifier[OPT] config-or-extern[OPT] variable-kind variable-declaration-list ;
+
+privacy-specifier:
+  `private'
+  `public'
 
 config-or-extern: one of
   `config' $ $ $ $ `extern'
@@ -56,6 +60,11 @@ variables.  If the statement is a top-level module statement, the
 variables are module level; otherwise they are local.  Module level variables are
 discussed in~\rsec{Module_Level_Variables}.  Local variables are discussed
 in~\rsec{Local_Variables}.
+
+The optional \sntx{privacy-specifier} keywords indicate the visibility
+of module level variables to outside modules.  By default, variables
+are publicly visible.  More details on visibility can be found in
+~\rsec{Visibility}.
 
 The optional keyword \chpl{config} specifies that the variables are
 configuration variables, described in
@@ -288,8 +297,8 @@ state.
 Variables declared in statements that are in a module but not in a
 function or block within that module are module level variables.
 Module level variables can be accessed anywhere within that module
-after the declaration of that variable.  They can also be accessed
-in other modules that use that module.
+after the declaration of that variable.  If they are public, they can
+also be accessed in other modules that use that module.
 
 \section{Local Variables}
 \label{Local_Variables}

--- a/spec/chapel_listing.tex
+++ b/spec/chapel_listing.tex
@@ -12,7 +12,7 @@
       module,
       new, nil, noinit,
       on, opaque, otherwise, out,
-      param, proc,
+      param, private, proc, public,
       range, real, record, reduce, ref, return,
       scan, select, serial, single, sparse, string, subdomain, sync,
       then, true, type,


### PR DESCRIPTION
This change specifies the behavior of modules, variables, functions,
iterators, and type aliases when declared to be public or private.  In
the sections for records and classes, it lists the behavior as
unspecified until we have a discussion on the topic (since inheritance
makes the story more tricky than the other cases).  I have not updated
the section for unions, though it should not be tricky like the case of
classes and records.

While here, I altered a reference to "type-specifier" in the type alias
section to match that of similar references to the syntax declarations.
I also moved the majority of the Use Statement section under the
renamed Visibility section in the Modules chapter, as it seemed logical
to keep the different ways of accessing a module's symbols together.