### PR TITLE
Add future for broken const checking on index var of standalone iters

### DIFF
--- a/test/statements/elliot/loops/modifyIndicesLeaderFollower.chpl
+++ b/test/statements/elliot/loops/modifyIndicesLeaderFollower.chpl
@@ -1,0 +1,7 @@
+// verify that const checking of loop indices is working correctly for
+// leader/follower iters
+
+forall (i, j) in zip(1..10, 1..10) {
+  i = 1;
+  j = 1;
+}

--- a/test/statements/elliot/loops/modifyIndicesLeaderFollower.good
+++ b/test/statements/elliot/loops/modifyIndicesLeaderFollower.good
@@ -1,0 +1,2 @@
+modifyIndicesLeaderFollower.chpl:5: error: illegal lvalue in assignment
+modifyIndicesLeaderFollower.chpl:6: error: illegal lvalue in assignment

--- a/test/statements/elliot/loops/modifyIndicesSerial.chpl
+++ b/test/statements/elliot/loops/modifyIndicesSerial.chpl
@@ -1,0 +1,7 @@
+// verify that const checking of loop indices is working correctly for
+// serial iters
+
+for i in 1..10 {
+  i = 1;
+  writeln(i);
+}

--- a/test/statements/elliot/loops/modifyIndicesSerial.good
+++ b/test/statements/elliot/loops/modifyIndicesSerial.good
@@ -1,0 +1,1 @@
+modifyIndicesSerial.chpl:5: error: illegal lvalue in assignment

--- a/test/statements/elliot/loops/modifyIndicesStandalone.bad
+++ b/test/statements/elliot/loops/modifyIndicesStandalone.bad
@@ -1,0 +1,1 @@
+modifyIndicesStandalone.chpl:15: error: illegal lvalue in assignment

--- a/test/statements/elliot/loops/modifyIndicesStandalone.chpl
+++ b/test/statements/elliot/loops/modifyIndicesStandalone.chpl
@@ -1,0 +1,17 @@
+// verify that const checking of loop indices is working correctly for
+// standalone iters
+
+forall i in 1..10 {
+  i = 1;
+  writeln(i);
+}
+
+forall i in (1..10).these() {
+  i = 1;
+  writeln(i);
+}
+
+for i in (1..10).these(tag=iterKind.standalone) {
+  i = 1;
+  writeln(i);
+}

--- a/test/statements/elliot/loops/modifyIndicesStandalone.future
+++ b/test/statements/elliot/loops/modifyIndicesStandalone.future
@@ -1,0 +1,6 @@
+bug: Const checking on the index var of standalone iters is broken.
+
+Const checking _does_ work when the standalone iter is invoked through a `for`
+loop by tag. That's probably because it's just a normal for loop at resolution
+time when the const error would be reported and it's only during LowerIterators
+that the standalone iterator is inlined.

--- a/test/statements/elliot/loops/modifyIndicesStandalone.good
+++ b/test/statements/elliot/loops/modifyIndicesStandalone.good
@@ -1,0 +1,3 @@
+modifyIndicesStandalone.chpl:5: error: illegal lvalue in assignment
+modifyIndicesStandalone.chpl:10: error: illegal lvalue in assignment
+modifyIndicesStandalone.chpl:15: error: illegal lvalue in assignment


### PR DESCRIPTION
Also adds tests to show const checking is working correctly for serial and
leader/follower iters.