### PR TITLE
Workaround for quoting problems in amudprun

### DIFF
--- a/doc/release/README.launcher
+++ b/doc/release/README.launcher
@@ -156,6 +156,11 @@ Settings:
   to specify a different filename for the output.
 
 
+  Other SLURM variables will have an impact; for example, the SLURM
+  partition can be set to 'debug' with this command:
+
+    export SLURM_PARTITION=debug
+
 --------------------
 Additional launchers
 --------------------

--- a/doc/release/README.multilocale
+++ b/doc/release/README.multilocale
@@ -69,16 +69,17 @@ To run Chapel on multiple locales, the following steps are required:
 
 5) Set up GASNet environment variables for execution:
 
-   (a) Set up variables telling GASNet how to spawn program instances.
-       Most of our experience to date has been with two options:
+   (a) If you are using GASNet's udp conduit, set up variables telling GASNet
+       how to spawn program instances.  Most of our experience to date has been
+       with two options:
 
        (i) To run on a network of workstations to which you have
            access via ssh, configure GASNet as follows:
 
              export GASNET_SPAWNFN=S
              export GASNET_SSH_SERVERS="host1 host2 host3 ..."
-             export SSH_CMD=ssh
-             export SSH_OPTIONS=-x
+             export GASNET_SSH_CMD=ssh
+             export GASNET_SSH_OPTIONS=-x
 
            where host1, host2, host3, ... are the names of the
            workstations that will serve as your Chapel locales.  In
@@ -88,15 +89,18 @@ To run Chapel on multiple locales, the following steps are required:
            to use normal ssh-agent/ssh-add capabilities to support
            password-less ssh-ing.
 
-           Note that it is possible to configure GASNet to launch jobs
-           with SLURM using the following command:
+           Also note that if you are using SSH to launch jobs, you might get a
+           login banner printed out along with your program's output. We have
+           found the following setting useful to disable such printing:
+
+             export GASNET_SSH_OPTIONS="-o LogLevel=Error"
+
+           It is also possible to configure GASNet/UDP to launch jobs with
+           SLURM using the following command:
+
+              export GASNET_SPAWNFN=C
               export GASNET_CSPAWN_CMD="srun -N%N %C"
 
-           Also note that if you are using SSH to launch jobs, you
-           might get a login banner printed out along with your program's
-           output. We have found the following setting useful to disable
-           such printing:
-             export SSH_OPTIONS="-o LogLevel=Error"
 
        (ii) To simulate multiple Chapel locales with one workstation,
             you can request that GASNet spawn its child functions on
@@ -111,7 +115,37 @@ To run Chapel on multiple locales, the following steps are required:
                $CHPL_HOME/third-party/gasnet/GASNet-1.*.*/udp-conduit/README
 
 
-   (b) We've had best results with console I/O using:
+   (b) If you are using GASNet's ibv conduit, configure the environment to
+       launch program instances.  We have experience with these configurations:
+
+       (i) For clusters using SLURM, enable slurm-gasnetrun_ibv:
+
+             export CHPL_LAUNCHER=slurm-gasnetrun_ibv
+
+           See README.launcher for other options available, such
+           as setting the time limit or selecting the type of node.
+
+       (ii) To launch InfiniBand jobs with SSH, use the following
+
+             export CHPL_LAUNCHER=gasnetrun_ibv
+             export GASNET_SSH_SERVERS="host1 host2 host3 ..."
+             export GASNET_IBV_SPAWNER=ssh
+
+
+       (iii) We've observed job launch hangs in some systems with InfiniBand
+             that were resolved by limiting the memory available for
+             communication, for example with:
+
+               export GASNET_PHYSMEM_MAX=1G
+
+
+       (iv) For more information on these and other available GASNet options
+            other options, including configuring to launch through MPI,
+            please refer to:
+
+              $CHPL_HOME/third-party/gasnet/GASNet-1.*.*/ibv-conduit/README
+
+   (c) We've had best results with console I/O using:
 
          export GASNET_ROUTE_OUTPUT=0
 

--- a/doc/release/README.multilocale
+++ b/doc/release/README.multilocale
@@ -92,6 +92,12 @@ To run Chapel on multiple locales, the following steps are required:
            with SLURM using the following command:
               export GASNET_CSPAWN_CMD="srun -N%N %C"
 
+           Also note that if you are using SSH to launch jobs, you
+           might get a login banner printed out along with your program's
+           output. We have found the following setting useful to disable
+           such printing:
+             export SSH_OPTIONS="-o LogLevel=Error"
+
        (ii) To simulate multiple Chapel locales with one workstation,
             you can request that GASNet spawn its child functions on
             your local machine using:

--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -59,8 +59,10 @@ static void add_env_options(int* argc, char** argv[]) {
   // Add a -E option for each environment variable.
   //
   for (i = 0; i < envc; i++) {
-    new_argv[*argc + 2 * i + 0] = (char*) "-E";
-    new_argv[*argc + 2 * i + 1] = environ[i];
+    if( ! strchr(environ[i], '`' ) ) {
+      new_argv[*argc + 2 * i + 0] = (char*) "-E";
+      new_argv[*argc + 2 * i + 1] = environ[i];
+    }
   }
 
   //

--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -59,6 +59,13 @@ static void add_env_options(int* argc, char** argv[]) {
   // Add a -E option for each environment variable.
   //
   for (i = 0; i < envc; i++) {
+    // except don't add -E for variables containing a `
+    // this is a workaround for poor quoting,
+    // but this workaround is easy. To do a better job, we
+    // need to know the answers to these questions:
+    //  - which shell are we using?
+    //  - how do you quote strings in that shell?
+    //  - where should the string quoting be done?
     if( ! strchr(environ[i], '`' ) ) {
       new_argv[*argc + 2 * i + 0] = (char*) "-E";
       new_argv[*argc + 2 * i + 1] = environ[i];

--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -60,12 +60,9 @@ static void add_env_options(int* argc, char** argv[]) {
   //
   for (i = 0; i < envc; i++) {
     // except don't add -E for variables containing a `
-    // this is a workaround for poor quoting,
-    // but this workaround is easy. To do a better job, we
-    // need to know the answers to these questions:
-    //  - which shell are we using?
-    //  - how do you quote strings in that shell?
-    //  - where should the string quoting be done?
+    // this is a workaround for poor quoting
+    // in amudprun (see amudp_spawn.cpp AMUDP_SPMDSshSpawn
+    // which just passes all the arguments to 'system')
     if( ! strchr(environ[i], '`' ) ) {
       new_argv[*argc + 2 * i + 0] = (char*) "-E";
       new_argv[*argc + 2 * i + 1] = environ[i];


### PR DESCRIPTION
If an environment variable contained ` then spawning using amudprun over SSH
would run extra commands.

Ideally, this should be fixed in GASNet's function AMUDP_SPMDSshSpawn in
/other/amudp/amudp_spawn.cpp, but for now, I've just added a workaround for the
worst case.
