### PR TITLE
Workaround for quoting problems in amudprun

### DIFF
--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -59,8 +59,14 @@ static void add_env_options(int* argc, char** argv[]) {
   // Add a -E option for each environment variable.
   //
   for (i = 0; i < envc; i++) {
-    new_argv[*argc + 2 * i + 0] = (char*) "-E";
-    new_argv[*argc + 2 * i + 1] = environ[i];
+    // except don't add -E for variables containing a `
+    // this is a workaround for poor quoting
+    // in amudprun (see amudp_spawn.cpp AMUDP_SPMDSshSpawn
+    // which just passes all the arguments to 'system')
+    if( ! strchr(environ[i], '`' ) ) {
+      new_argv[*argc + 2 * i + 0] = (char*) "-E";
+      new_argv[*argc + 2 * i + 1] = environ[i];
+    }
   }
 
   //


### PR DESCRIPTION
If an environment variable contained ` then spawning using amudprun over SSH
would run extra commands.

Ideally, this should be fixed in GASNet's function AMUDP_SPMDSshSpawn in
/other/amudp/amudp_spawn.cpp where it uses 'system' to invoke ssh. For now,
I've just added a workaround for a bad case I encountered.

Here is one way to test it:

    export BAD='`$HOSTNAME`'

and then the Chapel launcher runs amudprun like this:

    amudprun  -np 2 ./a.out_real -v -nl 2 -E BAD=`$HOSTNAME`

(but it does so using execvp, so the arguments are all
properly separated). Then, the launch node prints out
errors when doing the 'system' call with the SSH command.

Verified that the example above prints out an error without this change,
and that the error goes away with the change. Verified that 'make check'
works for GASNet+UDP+SSH.

This change is trivial and was not reviewed.