### PR TITLE
Added future: should use chain depth matter?

### DIFF
--- a/test/modules/vass/use-depth.bad
+++ b/test/modules/vass/use-depth.bad
@@ -1,0 +1,2 @@
+use-depth.chpl:23: error: Symbol z multiply defined
+use-depth.chpl:33: error: Symbol z multiply defined

--- a/test/modules/vass/use-depth.chpl
+++ b/test/modules/vass/use-depth.chpl
@@ -1,0 +1,38 @@
+// Should the uses of 'x' and 'y' through M1 vs. M2 be in conflict?
+// Or should M1's 'x' shadow M2's 'x' because the use chain for
+// M2's 'x' is deeper?
+
+// main module
+
+use M1;  // depth of use chain: x: 2, y: 2, z: 2
+use M2;  // depth of use chain: x: 3, y: 1, z: 2
+
+compilerWarning("got x: ", typeToString(x.type)); // could prefer M11's x
+compilerWarning("got y: ", typeToString(y.type)); // could prefer M2's y
+compilerWarning("got z: ", typeToString(z.type)); // error anyway
+
+// modules being used
+
+module M1 {
+  use M11;
+}
+
+module M11 {
+  var x: real;
+  var y: real;
+  var z: real;
+}
+
+module M2 {
+  use M22;
+  var y: int;
+}
+
+module M22 {
+  use M222;
+  var z: int;
+}
+
+module M222 {
+  var x: int;
+}

--- a/test/modules/vass/use-depth.future
+++ b/test/modules/vass/use-depth.future
@@ -1,0 +1,38 @@
+semantic: should the depth of the 'use' chain matter?
+
+Context: symbols 'x' are defined in two different modules M11 and M222.
+Those modules are 'use'ed through different-depth use chains
+e.g. by the main module.
+
+Should a reference to 'x' in the main module be an "it is ambiguous" error?
+Or should M11's 'x' shadow M222's 'x' because the depth of the use chain
+of M222 is longer?
+
+Currently Chapel prefers symbols from the shorter-depth-use-chain module.
+In a discussion July 2015, Brad suggested that the depth should be used
+to shadow symbols in deeper modules along the same use chain, e.g.:
+
+  use M1;
+  writeln(x); // OK - use M1's x
+  module M1  { var x: int; use M11; }
+  module M11 { var x: real; } // shadowed by M1's x
+
+and that the depth should not be used to prioritize among independent
+use chains.
+
+Related: when the use chains have a diamond shape and 'x' is defined
+only at the bottom of the diamond, references to 'x' should not be
+considered conflicting under either choice above:
+
+  use M1;
+  use M2;
+  writeln(x); // OK - use M3's x
+  module M1 { use M3; }
+  module M2 { use M3; }
+  module M3 { var x: real; }
+
+Related, not covered in this future: should the depth of 'use'
+affect determination of the more specific function during resolution?
+
+Note that this discussion applies to using modules via 'use' statements.
+It does not apply to explicit naming.

--- a/test/modules/vass/use-depth.good
+++ b/test/modules/vass/use-depth.good
@@ -1,0 +1,2 @@
+use-depth.chpl:21: error: Symbol x multiply defined
+use-depth.chpl:37: error: Symbol x multiply defined


### PR DESCRIPTION
From .future:

Context: symbols 'x' are defined in two different modules M11 and M222.
Those modules are 'use'ed through different-depth use chains
e.g. by the main module.

Should a reference to 'x' in the main module be an "it is ambiguous" error?
Or should M11's 'x' shadow M222's 'x' because the depth of the use chain
of M222 is longer?