### PR TITLE
Update recent changes to timedexec for cygwin

### DIFF
--- a/util/test/timedexec
+++ b/util/test/timedexec
@@ -49,7 +49,9 @@ if ($@) {
 
     # Otherwise, try to halt the running process
     if ($@ eq "alarm\n") {
-        system("ps aux | sort -r -k 3 | head");  # any interference?
+        $myPS = "ps";
+        if ("$^O" eq "cygwin") { $myPS = "procps"; }
+        system("$myPS aux | sort -r -k 3 | head");  # any interference?
         print "timedexec Alarm Clock\n";
     }
     if ($@ eq "abort\n") {
@@ -62,7 +64,7 @@ if ($@) {
         print "timedexec sending SIGTERM\n";
         kill SIGTERM, -$child_pid;
         # also call cygwin's kill since perl's doesn't always work
-        if ("$^O" eq "cygwin") { exec "/bin/kill -s SIGTERM -f $child_pid"; }
+        if ("$^O" eq "cygwin") { system("/bin/kill -s SIGTERM -f $child_pid"); }
         waitpid($child_pid, 0);
         alarm 0;
     };
@@ -72,7 +74,7 @@ if ($@) {
         print "timedexec sending SIGKILL\n";
         kill SIGKILL, -$child_pid;
         # also call cygwin's kill since perl's doesn't always work
-        if ("$^O" eq "cygwin") { exec "/bin/kill -s SIGKILL -f $child_pid"; }
+        if ("$^O" eq "cygwin") { system("/bin/kill -s SIGKILL -f $child_pid"); }
     }
     # Because they share the same return code, Ctrl-C will look like a timeout.
     # This is OK, because the test timed out due to operator impatience.


### PR DESCRIPTION
The changes I made in 9d8065ca16c72611c6d3b8add2d56c962a4ba1ba appear to allow
us to successfully kill runaways on cygwin. However, my fix for having ps alias
procps on cygwin wasn't successful. To get around that we now just directly
call procps on cygwin. This means that if timedexec is run on some other cygwin
box without procps other running processes won't be reported, but that's ok
because the default ps doesn't provide useful information anyway.

Also timeouts weren't being reported as timeouts because cygwin's kill was
being called via exec instead of system.