### PR TITLE
Add public and private as keywords to other tools

### DIFF
--- a/etc/highlight/langDefs/chpl.lang
+++ b/etc/highlight/langDefs/chpl.lang
@@ -10,7 +10,7 @@
 $DESCRIPTION=CHPL
 
 # Putting reserved identifiers here from spec section 6.4.2 Keywords
-$KEYWORDS(kwa)=atomic begin break by class cobegin coforall config const continue proc iter delete dmapped do domain else enum false for forall if in index inout label lambda let local module new nil noinit on otherwise out param record reduce return scan select serial single sparse subdomain sync then true type union use var when where while with yield zip
+$KEYWORDS(kwa)=atomic begin break by class cobegin coforall config const continue proc iter delete dmapped do domain else enum false for forall if in index inout label lambda let local module new nil noinit on otherwise out param private public record reduce return scan select serial single sparse subdomain sync then true type union use var when where while with yield zip
 
 # Putting built-in things that are not types things here
 $KEYWORDS(kwb)=bool complex int opaque range real string uint

--- a/etc/pygments/README.md
+++ b/etc/pygments/README.md
@@ -13,7 +13,7 @@ If and when the lexer needs to be updated, follow these instructions to setup
 your local environment and test changes locally.
 
 * Fork and clone the [pygments-main project from bitbucket][1].
-* The `ChapelLexer` is in `pygments/lexers/compiler.py`.
+* The `ChapelLexer` is in `pygments/lexers/chapel.py`.
 * See the [pygments developer docs][2] for specific information.
 * There is a test Chapel program that can be used to validate any changes. A
   convenient way to see how it works from the command line is:

--- a/etc/source-highlight/chpl.lang
+++ b/etc/source-highlight/chpl.lang
@@ -12,7 +12,7 @@ number =
 string delim "\"" "\"" escape "\\"
 
 # double-quotes mean that parens are interpreted literally
-keyword = "atomic|begin|break|by|class|cobegin|coforall|config|const|continue|proc|iter|delete|dmapped|do|domain|else|enum|export|extern|false|for|forall|if|in|index|inline|inout|label|lambda|let|local|module|new|nil|noinit|on|otherwise|out|param|record|reduce|ref|return|scan|select|serial|single|sparse|subdomain|sync|then|true|type|union|use|var|when|where|while|with|yield|zip"
+keyword = "atomic|begin|break|by|class|cobegin|coforall|config|const|continue|proc|iter|delete|dmapped|do|domain|else|enum|export|extern|false|for|forall|if|in|index|inline|inout|label|lambda|let|local|module|new|nil|noinit|on|otherwise|out|param|private|public|record|reduce|ref|return|scan|select|serial|single|sparse|subdomain|sync|then|true|type|union|use|var|when|where|while|with|yield|zip"
 
 
 # double-quotes mean that parens are interpreted literally


### PR DESCRIPTION
Add public and private to highlight and source-highlight, and update the
pygments README to point to the new location of the Chapel lexer in the
pygments repository.

tm-bundle has been updated via that repository.