### PR TITLE
Fix cygwin error on chown test

### DIFF
--- a/test/modules/standard/FileSystem/fsouza/chown/permission_error.prediff
+++ b/test/modules/standard/FileSystem/fsouza/chown/permission_error.prediff
@@ -5,5 +5,6 @@ outfile=$2
 cat $outfile | \
     sed 's/Operation not permitted/SYS_ERR/' | \
     sed 's/Invalid argument/SYS_ERR/' > \
+    sed 's/Permission denied/SYS_ERR/' > \
     $outfile.tmp
 mv $outfile.tmp $outfile


### PR DESCRIPTION
This test started failing because the cygwin we use on nightly testing got
updated, changing the error message for incorrect chown calls.  The old error
message is still present for my cygwin checkout, so I just added the new
message to the prediff's list of expected variations.