### PR TITLE
Skip the string memleaks tests when CHPL_COMM!=none.

### DIFF
--- a/test/types/string/StringImpl/memLeaks/SKIPIF
+++ b/test/types/string/StringImpl/memLeaks/SKIPIF
@@ -1,0 +1,3 @@
+# Skip this directory for comm!=none for now, because it's noisy.  We
+# can turn it back on when the string-as-rec implementation arrives.
+CHPL_COMM != none


### PR DESCRIPTION
These are noisy when comm!=none right now, so turn them off.  We can
turn them back on when the strings-as-recs implementation arrives.