### PR TITLE
Set GASNET_QUIET for gasnet-fifo

### DIFF
--- a/util/cron/test-gasnet.fifo.bash
+++ b/util/cron/test-gasnet.fifo.bash
@@ -9,4 +9,6 @@ source $CWD/common-gasnet.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.fifo"
 
+export GASNET_QUIET=Y
+
 $CWD/nightly -cron


### PR DESCRIPTION
gasnet-fifo is now running on a machine with infiniband enabled. Since
gasnet-fifo uses the udp conduit instead of ibv, gasnet warns that we
could get better performance by switching. Quiet this message for now.