### PR TITLE
Fix problems in the tasking layer callback tests.

### DIFF
--- a/test/runtime/gbt/tasks/callbacks/tcb-c.c
+++ b/test/runtime/gbt/tasks/callbacks/tcb-c.c
@@ -43,7 +43,7 @@ static void cb_any_2(const chpl_task_cb_info_t* info) {
  * Public interface
  */
 
-void install_callbacks(void) {
+void tcb_install_callbacks(void) {
   if (chpl_task_install_callback(chpl_task_cb_event_kind_create,
                                  chpl_task_cb_info_kind_full,
                                  cb_create_1)
@@ -91,10 +91,4 @@ void install_callbacks(void) {
     fprintf(stderr, "Cannot install cb_any_2 for end!\n");
     exit(1);
   }
-}
-
-
-void report_callbacks(int nCallbacks) {
-  tcb_wait_for_nCallbacks(nCallbacks);
-  tcb_report();
 }

--- a/test/runtime/gbt/tasks/callbacks/tcb-c.h
+++ b/test/runtime/gbt/tasks/callbacks/tcb-c.h
@@ -1,2 +1,3 @@
-void install_callbacks(void);
-void report_callbacks(int);
+void tcb_install_callbacks(void);
+void tcb_wait_for_nCallbacks(int);
+void tcb_report(void);

--- a/test/runtime/gbt/tasks/callbacks/tcb-unin-c.c
+++ b/test/runtime/gbt/tasks/callbacks/tcb-unin-c.c
@@ -43,7 +43,7 @@ static void cb_any_2(const chpl_task_cb_info_t* info) {
  * Public interface
  */
 
-void install_callbacks(void) {
+void tcb_install_callbacks(void) {
   if (chpl_task_install_callback(chpl_task_cb_event_kind_create,
                                  chpl_task_cb_info_kind_full,
                                  cb_create_1)
@@ -94,9 +94,7 @@ void install_callbacks(void) {
 }
 
 
-void uninstall_one_callback(int nCallbacks) {
-  tcb_wait_for_nCallbacks(nCallbacks);
-
+void tcb_uninstall_one_callback(void) {
   //
   // Uninstall the first callback, thus forcing the tasking layer to
   // compact the list.
@@ -118,10 +116,4 @@ void uninstall_one_callback(int nCallbacks) {
     fprintf(stderr, "Cannot uninstall cb_end_1!\n");
     exit(1);
   }
-}
-
-
-void report_callbacks(int nCallbacks) {
-  tcb_wait_for_nCallbacks(nCallbacks);
-  tcb_report();
 }

--- a/test/runtime/gbt/tasks/callbacks/tcb-unin-c.h
+++ b/test/runtime/gbt/tasks/callbacks/tcb-unin-c.h
@@ -1,3 +1,4 @@
-void install_callbacks(void);
-void uninstall_one_callback(int);
-void report_callbacks(int);
+void tcb_install_callbacks(void);
+void tcb_wait_for_nCallbacks(int);
+void tcb_uninstall_one_callback(void);
+void tcb_report(void);

--- a/test/runtime/gbt/tasks/callbacks/tcb-unin.chpl
+++ b/test/runtime/gbt/tasks/callbacks/tcb-unin.chpl
@@ -1,11 +1,12 @@
 proc main {
-  extern proc install_callbacks();
-  extern proc uninstall_one_callback(nCallbacks: c_int);
-  extern proc report_callbacks(nCallbacks: c_int);
+  extern proc tcb_install_callbacks();
+  extern proc tcb_uninstall_one_callback();
+  extern proc tcb_wait_for_nCallbacks(nCallbacks: c_int);
+  extern proc tcb_report();
 
   var counter: sync int = 0;
 
-  install_callbacks();
+  tcb_install_callbacks();
 
   cobegin {
     counter = counter + 1;
@@ -16,7 +17,8 @@ proc main {
     counter = counter + 1;
   }
 
-  uninstall_one_callback((if numLocales == 1 then 8 else 16): c_int);
+  tcb_wait_for_nCallbacks((if numLocales == 1 then 12 else 24): c_int);
+  tcb_uninstall_one_callback();
 
   cobegin {
     counter = counter + 1;
@@ -27,5 +29,6 @@ proc main {
     counter = counter + 1;
   }
 
-  report_callbacks((if numLocales == 1 then 12 else 24): c_int);
+  tcb_wait_for_nCallbacks((if numLocales == 1 then 18 else 36): c_int);
+  tcb_report();
 }

--- a/test/runtime/gbt/tasks/callbacks/tcb.chpl
+++ b/test/runtime/gbt/tasks/callbacks/tcb.chpl
@@ -1,10 +1,11 @@
 proc main {
-  extern proc install_callbacks();
-  extern proc report_callbacks(nCallbacks: c_int);
+  extern proc tcb_install_callbacks();
+  extern proc tcb_wait_for_nCallbacks(nCallbacks: c_int);
+  extern proc tcb_report();
 
   var counter: sync int = 0;
 
-  install_callbacks();
+  tcb_install_callbacks();
 
   cobegin {
     counter = counter + 1;
@@ -15,5 +16,6 @@ proc main {
     counter = counter + 1;
   }
 
-  report_callbacks((if numLocales == 1 then 8 else 16): c_int);
+  tcb_wait_for_nCallbacks((if numLocales == 1 then 12 else 24): c_int);
+  tcb_report();
 }


### PR DESCRIPTION
The main problem fixed here is that the "wait-for-nCallbacks" values
were wrong.  When I added the create callbacks to the tasking layer and
the tests I failed to update those, so they were too small and thus we
sometimes reported the callbacks or, for tcb-unin, uninstalled the first
one before all the expected callbacks had occurred.  This resulted in
intermittent failures.

While I was here I cleaned up a bit:
- give a "tcb_" prefix to all the C functions
- make the tcb_wait_for_nCallbacks() call explicit, rather than implicit
  in the uninstall and report calls
- remove the pass-through functions in tcb*-c.c in favor of calling the
  underlying common code directly.