### PR TITLE
Change Travis builds to the new container system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: c
 compiler:
   - gcc
-
-  # TODO: Fix clang build issue and enable for smoke tests.
-  # (thomasvandoren, 2014-09-08)
-  # - clang
-before_script:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq tcsh
+  - clang
 script:
   - ./util/buildRelease/smokeTest
 env:
   - CHPL_DEVELOPER=true
   - NIGHTLY_TEST_SETTINGS=true
+
+addons:
+  apt:
+    packages:
+      - tcsh
+sudo: false


### PR DESCRIPTION
This change will put us onto Travis CI's new build infrastructure which
should let builds complete faster.

Also enabled building with clang on Travis.