### PR TITLE
More task callbacks test improvements.

### DIFF
--- a/test/runtime/gbt/tasks/callbacks/SKIPIF
+++ b/test/runtime/gbt/tasks/callbacks/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_TASKS == muxed

--- a/test/runtime/gbt/tasks/callbacks/tcb-unin.chpl
+++ b/test/runtime/gbt/tasks/callbacks/tcb-unin.chpl
@@ -1,7 +1,8 @@
 proc main {
   extern proc tcb_install_callbacks_1();
-  extern proc tcb_install_callbacks_2();
   extern proc tcb_uninstall_callbacks_1();
+  extern proc tcb_install_callbacks_2();
+  extern proc tcb_uninstall_callbacks_2();
   extern proc tcb_wait_for_nCallbacks(nCallbacks: c_int);
   extern proc tcb_report();
 
@@ -32,5 +33,6 @@ proc main {
   }
 
   tcb_wait_for_nCallbacks((if numLocales == 1 then 18 else 36): c_int);
+  tcb_uninstall_callbacks_2();
   tcb_report();
 }

--- a/test/runtime/gbt/tasks/callbacks/tcb-unin.skipif
+++ b/test/runtime/gbt/tasks/callbacks/tcb-unin.skipif
@@ -1,1 +1,0 @@
-CHPL_TASKS != fifo

--- a/test/runtime/gbt/tasks/callbacks/tcb-util.h
+++ b/test/runtime/gbt/tasks/callbacks/tcb-util.h
@@ -4,8 +4,9 @@
 //
 
 void tcb_install_callbacks_1(void);
-void tcb_install_callbacks_2(void);
 void tcb_uninstall_callbacks_1(void);
+void tcb_install_callbacks_2(void);
+void tcb_uninstall_callbacks_2(void);
 void tcb_wait_for_nCallbacks(int nCallbacks);
 void tcb_report(void);
 
@@ -143,6 +144,27 @@ void tcb_install_callbacks_1(void) {
 }
 
 
+void tcb_uninstall_callbacks_1(void) {
+  if (chpl_task_uninstall_callback(chpl_task_cb_event_kind_create, cb_create_1)
+      != 0) {
+    fprintf(stderr, "Cannot uninstall cb_create_1!\n");
+    exit(1);
+  }
+
+  if (chpl_task_uninstall_callback(chpl_task_cb_event_kind_begin, cb_begin_1)
+      != 0) {
+    fprintf(stderr, "Cannot uninstall cb_begin_1!\n");
+    exit(1);
+  }
+
+  if (chpl_task_uninstall_callback(chpl_task_cb_event_kind_end, cb_end_1)
+      != 0) {
+    fprintf(stderr, "Cannot uninstall cb_end_1!\n");
+    exit(1);
+  }
+}
+
+
 void tcb_install_callbacks_2(void) {
   if (chpl_task_install_callback(chpl_task_cb_event_kind_create,
                                  chpl_task_cb_info_kind_full,
@@ -170,26 +192,25 @@ void tcb_install_callbacks_2(void) {
 }
 
 
-void tcb_uninstall_callbacks_1(void) {
-  //
-  // Uninstall the first callback, thus forcing the tasking layer to
-  // compact the list.
-  //
-  if (chpl_task_uninstall_callback(chpl_task_cb_event_kind_create, cb_create_1)
+void tcb_uninstall_callbacks_2(void) {
+  if (chpl_task_uninstall_callback(chpl_task_cb_event_kind_create,
+                                   cb_any_2)
       != 0) {
-    fprintf(stderr, "Cannot uninstall cb_create_1!\n");
+    fprintf(stderr, "Cannot uninstall cb_any_2 for create!\n");
     exit(1);
   }
 
-  if (chpl_task_uninstall_callback(chpl_task_cb_event_kind_begin, cb_begin_1)
+  if (chpl_task_uninstall_callback(chpl_task_cb_event_kind_begin,
+                                   cb_any_2)
       != 0) {
-    fprintf(stderr, "Cannot uninstall cb_begin_1!\n");
+    fprintf(stderr, "Cannot uninstall cb_any_2 for begin!\n");
     exit(1);
   }
 
-  if (chpl_task_uninstall_callback(chpl_task_cb_event_kind_end, cb_end_1)
+  if (chpl_task_uninstall_callback(chpl_task_cb_event_kind_end,
+                                   cb_any_2)
       != 0) {
-    fprintf(stderr, "Cannot uninstall cb_end_1!\n");
+    fprintf(stderr, "Cannot uninstall cb_any_2 for end!\n");
     exit(1);
   }
 }

--- a/test/runtime/gbt/tasks/callbacks/tcb.chpl
+++ b/test/runtime/gbt/tasks/callbacks/tcb.chpl
@@ -1,6 +1,8 @@
 proc main {
   extern proc tcb_install_callbacks_1();
+  extern proc tcb_uninstall_callbacks_1();
   extern proc tcb_install_callbacks_2();
+  extern proc tcb_uninstall_callbacks_2();
   extern proc tcb_wait_for_nCallbacks(nCallbacks: c_int);
   extern proc tcb_report();
 
@@ -19,5 +21,7 @@ proc main {
   }
 
   tcb_wait_for_nCallbacks((if numLocales == 1 then 12 else 24): c_int);
+  tcb_uninstall_callbacks_2();
+  tcb_uninstall_callbacks_1();
   tcb_report();
 }

--- a/test/runtime/gbt/tasks/callbacks/tcb.skipif
+++ b/test/runtime/gbt/tasks/callbacks/tcb.skipif
@@ -1,1 +1,0 @@
-CHPL_TASKS != fifo


### PR DESCRIPTION
Uninstall all the callbacks after the final wait, so that we don't get
one more callback (which could cause recording buffer overflow) in
tasking layer implementations which run main() in a task, as qthreads
does.

Replace the per-test .skipif files with a dir-wide SKIPIF.