### PR TITLE
Add task callback support in qthreads tasking.

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -624,65 +624,67 @@ void chpl_task_exit(void)
 #define MAX_CBS_PER_EVENT 10
 
 static struct cb_info {
-  chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
-  chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
-  int count;
+    chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
+    chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
+    int count;
 } cb_info[chpl_task_cb_num_event_kinds];
 
 int chpl_task_install_callback(chpl_task_cb_event_kind_t event_kind,
                                chpl_task_cb_info_kind_t info_kind,
                                chpl_task_cb_fn_t cb_fn) {
-  int i;
+    int i;
 
-  if (event_kind >= chpl_task_cb_num_event_kinds) {
-    errno = ERANGE;
-    return -1;
-  }
+    if (event_kind >= chpl_task_cb_num_event_kinds) {
+        errno = ERANGE;
+        return -1;
+    }
 
-  i = cb_info[event_kind].count;
+    i = cb_info[event_kind].count;
 
-  if (i >= MAX_CBS_PER_EVENT) {
-    errno = ENOMEM;
-    return -1;
-  }
+    if (i >= MAX_CBS_PER_EVENT) {
+        errno = ENOMEM;
+        return -1;
+    }
 
-  cb_info[event_kind].count++;
-  cb_info[event_kind].fns[i]= cb_fn;
-  cb_info[event_kind].info_kinds[i] = info_kind;
+    cb_info[event_kind].count++;
+    cb_info[event_kind].fns[i]= cb_fn;
+    cb_info[event_kind].info_kinds[i] = info_kind;
 
-  return 0;
+    return 0;
 }
 
 int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
                                  chpl_task_cb_fn_t cb_fn) {
-  int i;
-  int found_i;
+    int i;
+    int found_i;
 
-  if (event_kind >= chpl_task_cb_num_event_kinds) {
-    errno = ERANGE;
-    return -1;
-  }
-
-  for (i = 0, found_i = -1; i < cb_info[event_kind].count; i++) {
-    if (cb_info[event_kind].fns[i] == cb_fn) {
-      found_i = i;
-      break;
+    if (event_kind >= chpl_task_cb_num_event_kinds) {
+        errno = ERANGE;
+        return -1;
     }
-  }
 
-  if (found_i < 0) {
-    errno = ENOENT;
-    return -1;
-  }
+    for (i = 0, found_i = -1; i < cb_info[event_kind].count; i++) {
+        if (cb_info[event_kind].fns[i] == cb_fn) {
+            found_i = i;
+            break;
+        }
+    }
 
-  for (i = found_i + 1; i < cb_info[event_kind].count; i++) {
-    cb_info[event_kind].fns[i - 1] = cb_info[event_kind].fns[i];
-    cb_info[event_kind].info_kinds[i - 1] = cb_info[event_kind].info_kinds[i];
-  }
+    if (found_i < 0) {
+        errno = ENOENT;
+        return -1;
+    }
 
-  cb_info[event_kind].count--;
+    for (i = found_i + 1; i < cb_info[event_kind].count; i++) {
+        cb_info[event_kind].fns[i - 1] =
+            cb_info[event_kind].fns[i];
+        cb_info[event_kind].info_kinds[i - 1] =
+            cb_info[event_kind].info_kinds[i];
+    }
 
-  return 0;
+    cb_info[event_kind].count--;
+
+    return 0;
 }
 
 static inline void do_callbacks(chpl_task_cb_event_kind_t event_kind,

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -123,19 +123,21 @@ struct chpl_task_list {
     chpl_task_list_p next;
 };
 
+static aligned_t next_task_id = 1;
+
 pthread_t chpl_qthread_process_pthread;
 pthread_t chpl_qthread_comm_pthread;
 
 chpl_qthread_tls_t chpl_qthread_process_tls = {
-    PRV_DATA_IMPL_VAL(c_sublocid_any_val, false),
-    NULL, 0, NULL, 0 };
+    PRV_DATA_IMPL_VAL("<main task>", 0, chpl_nullTaskID, false,
+                      c_sublocid_any_val, false),
+    NULL, 0 };
 
 chpl_qthread_tls_t chpl_qthread_comm_task_tls = {
-    PRV_DATA_IMPL_VAL(c_sublocid_any_val, false),
-    NULL, 0, NULL, 0 };
- 
- //
- 
+    PRV_DATA_IMPL_VAL("<comm thread>", 0, chpl_nullTaskID, false,
+                      c_sublocid_any_val, false),
+    NULL, 0 };
+
 //
 // structs chpl_task_prvDataImpl_t, chpl_qthread_wrapper_args_t and
 // chpl_qthread_tls_t have been moved to tasks-qthreads.h
@@ -294,11 +296,11 @@ static void chapel_display_thread(qt_key_t     addr,
 
     if (rep) {
         if ((rep->lock_lineno > 0) && rep->lock_filename) {
-            fprintf(stderr, "Waiting at: %s:%zu (task %s:%zu)\n", rep->lock_filename, rep->lock_lineno, rep->task_filename, rep->task_lineno);
+            fprintf(stderr, "Waiting at: %s:%zu (task %s:%zu)\n", rep->lock_filename, rep->lock_lineno, rep->chpl_data.task_filename, rep->chpl_data.task_lineno);
         } else if (rep->lock_lineno == 0 && rep->lock_filename) {
-            fprintf(stderr, "Waiting for more work (line 0? file:%s) (task %s:%zu)\n", rep->lock_filename, rep->task_filename, rep->task_lineno);
+            fprintf(stderr, "Waiting for more work (line 0? file:%s) (task %s:%zu)\n", rep->lock_filename, rep->chpl_data.task_filename, rep->chpl_data.task_lineno);
         } else if (rep->lock_lineno == 0) {
-            fprintf(stderr, "Waiting for dependencies (uninitialized task %s:%zu)\n", rep->task_filename, rep->task_lineno);
+            fprintf(stderr, "Waiting for dependencies (uninitialized task %s:%zu)\n", rep->chpl_data.task_filename, rep->chpl_data.task_lineno);
         }
         fflush(stderr);
     }
@@ -567,6 +569,7 @@ void chpl_task_init(void)
     pthread_t initer;
 
     chpl_qthread_process_pthread = pthread_self();
+    chpl_qthread_process_tls.chpl_data.id = qthread_incr(&next_task_id, 1);
 
     commMaxThreads = chpl_comm_getMaxThreads();
 
@@ -615,13 +618,123 @@ void chpl_task_exit(void)
 #endif /* QTHREAD_MULTINODE */
 }
 
+//
+// Tasking callback support.
+//
+#define MAX_CBS_PER_EVENT 10
+
+static struct cb_info {
+  chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
+  chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
+  int count;
+} cb_info[chpl_task_cb_num_event_kinds];
+
+int chpl_task_install_callback(chpl_task_cb_event_kind_t event_kind,
+                               chpl_task_cb_info_kind_t info_kind,
+                               chpl_task_cb_fn_t cb_fn) {
+  int i;
+
+  if (event_kind >= chpl_task_cb_num_event_kinds) {
+    errno = ERANGE;
+    return -1;
+  }
+
+  i = cb_info[event_kind].count;
+
+  if (i >= MAX_CBS_PER_EVENT) {
+    errno = ENOMEM;
+    return -1;
+  }
+
+  cb_info[event_kind].count++;
+  cb_info[event_kind].fns[i]= cb_fn;
+  cb_info[event_kind].info_kinds[i] = info_kind;
+
+  return 0;
+}
+
+int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
+                                 chpl_task_cb_fn_t cb_fn) {
+  int i;
+  int found_i;
+
+  if (event_kind >= chpl_task_cb_num_event_kinds) {
+    errno = ERANGE;
+    return -1;
+  }
+
+  for (i = 0, found_i = -1; i < cb_info[event_kind].count; i++) {
+    if (cb_info[event_kind].fns[i] == cb_fn) {
+      found_i = i;
+      break;
+    }
+  }
+
+  if (found_i < 0) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  for (i = found_i + 1; i < cb_info[event_kind].count; i++) {
+    cb_info[event_kind].fns[i - 1] = cb_info[event_kind].fns[i];
+    cb_info[event_kind].info_kinds[i - 1] = cb_info[event_kind].info_kinds[i];
+  }
+
+  cb_info[event_kind].count--;
+
+  return 0;
+}
+
+static inline void do_callbacks(chpl_task_cb_event_kind_t event_kind,
+                                chpl_task_prvDataImpl_t *chpl_data) {
+    struct cb_info *cbp;
+
+    assert(event_kind < chpl_task_cb_num_event_kinds);
+
+    cbp = &cb_info[event_kind];
+
+    if (cbp->count > 0) {
+        chpl_task_cb_info_t info;
+        int i;
+
+        info.nodeID = chpl_nodeID;
+        info.event_kind = event_kind;
+
+        if (chpl_data->id == chpl_nullTaskID)
+            chpl_data->id = qthread_incr(&next_task_id, 1);
+
+        for (i = 0; i < cbp->count; i++) {
+            info.info_kind = cbp->info_kinds[i];
+
+            switch (cbp->info_kinds[i]) {
+            case chpl_task_cb_info_kind_full:
+                info.iu.full = (struct chpl_task_info_full)
+                               { .filename = chpl_data->task_filename,
+                                 .lineno = chpl_data->task_lineno,
+                                 .id = chpl_data->id,
+                                 .is_executeOn = chpl_data->is_executeOn
+                               };
+              break;
+
+            case chpl_task_cb_info_kind_id_only:
+                info.iu.id_only.id = chpl_data->id;
+                break;
+
+            default:
+                assert(false);
+                break;
+            }
+
+            (*cbp->fns[i])((const chpl_task_cb_info_t*) &info);
+        }
+    }
+}
+
 static aligned_t chapel_wrapper(void *arg)
 {
     chpl_qthread_wrapper_args_t *rarg = arg;
     chpl_qthread_tls_t * data = chpl_qthread_get_tasklocal();
 
-    data->task_filename = rarg->task_filename;
-    data->task_lineno = rarg->lineno;
     data->chpl_data = rarg->chpl_data;
     data->lock_filename = NULL;
     data->lock_lineno = 0;
@@ -630,7 +743,11 @@ static aligned_t chapel_wrapper(void *arg)
         chpl_taskRunningCntInc(0, NULL);
     }
 
+    do_callbacks(chpl_task_cb_event_kind_begin, &data->chpl_data);
+
     (*(chpl_fn_p)(rarg->fn))(rarg->args);
+
+    do_callbacks(chpl_task_cb_event_kind_end, &data->chpl_data);
 
     if (rarg->countRunning) {
         chpl_taskRunningCntDec(0, NULL);
@@ -645,9 +762,11 @@ static aligned_t chapel_wrapper(void *arg)
 // not use methods that require task context (e.g., task-local storage).
 void chpl_task_callMain(void (*chpl_main)(void))
 {
-    const chpl_qthread_wrapper_args_t wrapper_args = 
-        {chpl_main, NULL, NULL, 0, false,
-         PRV_DATA_IMPL_VAL(c_sublocid_any_val, false) };
+    chpl_qthread_wrapper_args_t wrapper_args =
+        {chpl_main, NULL, false,
+         PRV_DATA_IMPL_VAL("<main task>", 0,
+                           chpl_qthread_process_tls.chpl_data.id, false,
+                           c_sublocid_any_val, false) };
 
     qthread_debug(CHAPEL_CALLS, "[%d] begin chpl_task_callMain()\n", chpl_nodeID);
 
@@ -656,6 +775,8 @@ void chpl_task_callMain(void (*chpl_main)(void))
     int const rc = spr_unify();
     assert(SPR_OK == rc);
 #endif /* QTHREAD_MULTINODE */
+
+    do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
 
     qthread_fork_syncvar(chapel_wrapper, &wrapper_args, &exit_ret);
     qthread_syncvar_readFF(NULL, &exit_ret);
@@ -696,9 +817,6 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
                              c_string          filename)
 {
     chpl_bool serial_state = chpl_task_getSerial();
-    chpl_qthread_wrapper_args_t wrapper_args =
-        {chpl_ftable[fid], arg, filename, lineno, false,
-         PRV_DATA_IMPL_VAL(subloc, serial_state) };
 
     assert(subloc != c_sublocid_none);
 
@@ -711,13 +829,21 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
     if (serial_state) {
         // call the function directly.
         (chpl_ftable[fid])(arg);
-    } else if (subloc == c_sublocid_any) {
-        qthread_fork_copyargs(chapel_wrapper, &wrapper_args,
-                              sizeof(chpl_qthread_wrapper_args_t), NULL);
     } else {
-        qthread_fork_copyargs_to(chapel_wrapper, &wrapper_args,
-                                 sizeof(chpl_qthread_wrapper_args_t), NULL,
-                                 (qthread_shepherd_id_t) subloc);
+        chpl_qthread_wrapper_args_t wrapper_args =
+            {chpl_ftable[fid], arg, false,
+             PRV_DATA_IMPL_VAL(filename, lineno, chpl_nullTaskID, false,
+                               subloc, serial_state) };
+
+        do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
+        if (subloc == c_sublocid_any) {
+            qthread_fork_copyargs(chapel_wrapper, &wrapper_args,
+                                  sizeof(chpl_qthread_wrapper_args_t), NULL);
+        } else {
+            qthread_fork_copyargs_to(chapel_wrapper, &wrapper_args,
+                                     sizeof(chpl_qthread_wrapper_args_t), NULL,
+                                     (qthread_shepherd_id_t) subloc);
+        }
     }
 }
 
@@ -745,12 +871,14 @@ void chpl_task_startMovedTask(chpl_fn_p      fp,
     assert(subloc != c_sublocid_none);
     assert(id == chpl_nullTaskID);
 
-    chpl_qthread_wrapper_args_t wrapper_args = 
-        {fp, arg, NULL, 0, canCountRunningTasks,
-         PRV_DATA_IMPL_VAL(subloc, serial_state) };
-
+    chpl_qthread_wrapper_args_t wrapper_args =
+        {fp, arg, canCountRunningTasks,
+         PRV_DATA_IMPL_VAL("<unknown>", 0, chpl_nullTaskID, true,
+                           subloc, serial_state) };
 
     PROFILE_INCR(profile_task_startMovedTask,1);
+
+    do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
 
     if (subloc == c_sublocid_any) {
         qthread_fork_copyargs(chapel_wrapper, &wrapper_args,
@@ -778,9 +906,17 @@ void chpl_task_startMovedTask(chpl_fn_p      fp,
 // Returns '(unsigned int)-1' if called outside of the tasking layer.
 chpl_taskID_t chpl_task_getId(void)
 {
+    chpl_qthread_tls_t * tls = chpl_qthread_get_tasklocal();
+
     PROFILE_INCR(profile_task_getId,1);
 
-    return (chpl_taskID_t)qthread_id();
+    if (tls == NULL)
+        return (chpl_taskID_t) -1;
+
+    if (tls->chpl_data.id == chpl_nullTaskID)
+        tls->chpl_data.id = qthread_incr(&next_task_id, 1);
+
+    return tls->chpl_data.id;
 }
 
 void chpl_task_sleep(int secs)

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.h
@@ -269,20 +269,26 @@ volatile int chpl_qthread_done_initializing;
 #endif
 
 typedef struct {
+    c_string task_filename;
+    int task_lineno;
+    chpl_taskID_t id;
+    chpl_bool is_executeOn;
     c_sublocid_t requestedSubloc;  // requested sublocal for task
     chpl_task_prvData_t prvdata;
 } chpl_task_prvDataImpl_t;
 
 // Define PRV_DATA_IMPL_VAL to set up a chpl_task_prvData_t.
-#define PRV_DATA_IMPL_VAL(subloc, serial) \
-        { .requestedSubloc = subloc, \
-          .prvdata = { .serial_state = serial } }
+#define PRV_DATA_IMPL_VAL(_fn, _ln, _id, _is_execOn, _subloc, _serial) \
+        { .task_filename = _fn, \
+          .task_lineno = _ln, \
+          .id = _id, \
+          .is_executeOn = _is_execOn, \
+          .requestedSubloc = _subloc, \
+          .prvdata = { .serial_state = _serial } }
 
 typedef struct {
     void                     *fn;
     void                     *args;
-    c_string                 task_filename;
-    int                      lineno;
     chpl_bool                countRunning;
     chpl_task_prvDataImpl_t  chpl_data;
 } chpl_qthread_wrapper_args_t;
@@ -294,8 +300,6 @@ typedef struct chpl_qthread_tls_s {
     /* Reports */
     c_string    lock_filename;
     size_t      lock_lineno;
-    const char *task_filename;
-    size_t      task_lineno;
 } chpl_qthread_tls_t;
 
 extern pthread_t chpl_qthread_process_pthread;


### PR DESCRIPTION
For the most part this is straightforward and follows the model of the
same support in tasks=fifo.  The notable differences are:
- In fifo the information passed to the callback functions comes from
  the task pool descriptors.  But qthreads tasking doesn't have a task
  pool, so here it comes from the task local storage for each task.  A
  side effect is that the qthreads task-local storage is expanded to
  include a task ID and an is_executeOn indicator.
- chpl_task_getID() now returns the task ID from the task local storage,
  instead of the Qthread ID.
- The task ID is gotten by atomically incrementing a counter, using the
  available Qthreads atomic ops interface.  However, we don't assign an
  ID to a task unless we need that ID and one hasn't been assigned
  already, so this should not add significant overhead.
- While here, I cleaned up a bit by moving the task source filename and
  line number from the wrapper_args and qthread_tls structs into the
  chpl_data struct that they both contain an instance of.