### PR TITLE
Make sed REs work properly on Mac.

### DIFF
--- a/test/runtime/gbt/tasks/callbacks/tcb-unin.prediff
+++ b/test/runtime/gbt/tasks/callbacks/tcb-unin.prediff
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-sed -e 's/^\(CB.* ([0-9*]) \(create\|begin\|end\) task\) [0-9]*/\1 N/' \
-    -e 's/@.*[0-9]\+, /@filename:lineno, /' < $2 | \
+sed -e 's/^\(CB.* ([0-9*]) [a-z]* task\) [0-9]*/\1 N/' \
+    -e 's/@.*[0-9]*, /@filename:lineno, /' < $2 | \
   sort > $2.prediff.tmp && \
   mv $2.prediff.tmp $2

--- a/test/runtime/gbt/tasks/callbacks/tcb.prediff
+++ b/test/runtime/gbt/tasks/callbacks/tcb.prediff
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-sed -e 's/^\(CB.* ([0-9*]) \(create\|begin\|end\) task\) [0-9]*/\1 N/' \
-    -e 's/@.*[0-9]\+, /@filename:lineno, /' < $2 | \
+sed -e 's/^\(CB.* ([0-9*]) [a-z]* task\) [0-9]*/\1 N/' \
+    -e 's/@.*[0-9]*, /@filename:lineno, /' < $2 | \
   sort > $2.prediff.tmp && \
   mv $2.prediff.tmp $2


### PR DESCRIPTION
GNU sed on Linux and sed on the Mac differ in terms of the differences
between basic (default) and extended regular expressions (REs).  In
particular, the '\\|' and '\\+' elements indicate alternatives and
one-or-more-instances in basic REs in GNU sed don't exist in Mac sed.
Here we simplify the REs so that they work on both.

We could instead put sed in extended-RE mode, but that would be much
more trouble because doing so requires a different command line option
for GNU sed and Mac sed.