### PR TITLE
Change spec to one-sided format

### DIFF
--- a/spec/spec.tex
+++ b/spec/spec.tex
@@ -114,8 +114,8 @@
            }
 
 \oddsidemargin 0.0in
-\evensidemargin 0.5in
-\textwidth 6in
+% not needed with onesided version \evensidemargin 0.5in
+\textwidth 6.5in
 \headheight 0.2in
 \topmargin 0in
 \headsep 0.3in

--- a/spec/spec.tex
+++ b/spec/spec.tex
@@ -1,4 +1,4 @@
-\documentclass[10pt,twoside,titlepage]{spec}
+\documentclass[10pt,oneside,titlepage]{spec}
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{color}


### PR DESCRIPTION
Change from twoside to oneside document class options in order to keep the
margins the same width on even and odd pages. This document is primarily
viewed online, and it looks better this way in a PDF viewer. Turning it
into a real book would presumably require other formatting changes.

Concept approved by @vasslitvinov . Detail reviewed by @hildeth .