### PR TITLE
Apply private to the module level symbols in UtilReplicatedVar.

### DIFF
--- a/modules/standard/UtilReplicatedVar.chpl
+++ b/modules/standard/UtilReplicatedVar.chpl
@@ -104,24 +104,24 @@ module UtilReplicatedVar {
 use ReplicatedDist;
 
 pragma "no doc"
-const rcDomainIx   = 1; // todo convert to param
+private const rcDomainIx   = 1; // todo convert to param
 /* Use this domain when replicating over a subset of locales,
    as shown :ref:`above <subset-of-locales>`. */
 const rcDomainBase = {rcDomainIx..rcDomainIx};
 pragma "no doc"
-const rcLocales    = Locales;
+private const rcLocales    = Locales;
 pragma "no doc"
-const rcDomainMap  = new ReplicatedDist(rcLocales);
+private const rcDomainMap  = new ReplicatedDist(rcLocales);
 /* Use this domain to declare a user-level replicated variable,
    as shown :ref:`above <basic-usage>` . */
 const rcDomain     = rcDomainBase dmapped new dmap(rcDomainMap);
 pragma "no doc" // todo - remove this?  our examples use LocaleSpace instead
-const rcCollectDomaim = rcLocales.domain;
+private const rcCollectDomaim = rcLocales.domain;
 pragma "no doc"
-param _rcErr1 = " must be 'rcDomain' or 'rcDomainBase dmapped ReplicatedDist(an array of locales)'";
+private param _rcErr1 = " must be 'rcDomain' or 'rcDomainBase dmapped ReplicatedDist(an array of locales)'";
 
 pragma "no doc"
-proc _rcTargetLocalesHelper(replicatedVar: [?D])
+private proc _rcTargetLocalesHelper(replicatedVar: [?D])
   where replicatedVar._value.type: ReplicatedArr
 {
   return replicatedVar._value.dom.dist.targetLocales;


### PR DESCRIPTION
Now that variables and functions can be private, let's mark some of the
symbols that we were "no doc"ing as private.  Then, when chpldoc cues off
private, those "no doc" pragmas can be removed.

@vasslitvinov, would you mind reviewing please?