### PR TITLE
Attach private to "no doc"ed symbols in the standard module VisualDebug

### DIFF
--- a/modules/standard/VisualDebug.chpl
+++ b/modules/standard/VisualDebug.chpl
@@ -32,35 +32,35 @@ module VisualDebug
   use String;
 
   pragma "no doc"
-  extern proc chpl_now_time():real;
+  private extern proc chpl_now_time():real;
 
   //
   // Data Generation for the Visual Debug tool  (offline)
   //
 
   pragma "no doc"
-  extern proc chpl_vdebug_start ( rootname: c_string, time:real);
+  private extern proc chpl_vdebug_start ( rootname: c_string, time:real);
 
   pragma "no doc"
-  extern proc chpl_vdebug_stop ();
+  private extern proc chpl_vdebug_stop ();
 
   pragma "no doc"
-  extern proc chpl_vdebug_tag ( tagname: c_string);
+  private extern proc chpl_vdebug_tag ( tagname: c_string);
 
   pragma "no doc"
-  extern proc chpl_vdebug_pause ();
+  private extern proc chpl_vdebug_pause ();
 
   pragma "no doc"
-  extern proc chpl_vdebug_nolog ();
+  private extern proc chpl_vdebug_nolog ();
 
 
-/* Tree "coforall procedure .... calls one of the above rotunes */
+/* Tree "coforall procedure .... calls one of the above routines */
 
 pragma "no doc"
   enum vis_op {v_start, v_stop, v_tag, v_pause};
 
 pragma "no doc"
-  proc VDebugTree (what: vis_op, name: string, time: real, id: int = 0) {
+  private proc VDebugTree (what: vis_op, name: string, time: real, id: int = 0) {
       var child = id * 2 + 1;
       chpl_vdebug_nolog();
       cobegin {


### PR DESCRIPTION
These symbols all seemed to be intended for module-local use only and were
marked with "no doc".  When chpldoc can react appropriately to private symbols,
the pragmas can be removed.

@tomyhoi, would you mind giving this a review?