### PR TITLE
Apply private to a couple of functions in the standard module Types

### DIFF
--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -375,7 +375,7 @@ proc chpl__legalIntCoerce(type t1, type t2) param
 // Returns the type with which both s and t are compatible
 // That is, both s and t can be coerced to the returned type.
 pragma "no doc"
-proc chpl__commonType(type s, type t) type
+private proc chpl__commonType(type s, type t) type
 {
   if ! isIntegralType(s) then
     compilerError("Type ", typeToString(s) , " is non-integral: ");
@@ -540,11 +540,11 @@ iter chpl_enumerate(type t: enumerated) {
 
 // TODO add chpl_ to these functions' names - they are not intended for user.
 pragma "no doc"
-proc enum_minbits(type t: enumerated) param {
+private proc enum_minbits(type t: enumerated) param {
   return __primitive( "enum min bits", t);
 }
 pragma "no doc"
-proc enum_issigned(type t: enumerated) param {
+private proc enum_issigned(type t: enumerated) param {
   return __primitive( "enum is signed", t);
 }
 // TODO - maybe this function can be useful for the user, for C interop?


### PR DESCRIPTION
When chpldoc recognizes private symbols, the pragmas can be removed.

@vasslitvinov, would you mind reviewing to make sure these should be private?