### PR TITLE
Apply private to some symbols in SysBasic marked "no doc".

### DIFF
--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -293,13 +293,13 @@ inline proc c_ptrTo(ref x:?t):c_ptr(t) {
 // error numbers
 
 pragma "no doc"
-extern proc qio_err_eq(a:syserr, b:syserr):c_int;
+private extern proc qio_err_eq(a:syserr, b:syserr):c_int;
 pragma "no doc"
-extern proc qio_err_to_int(a:syserr):int(32);
+private extern proc qio_err_to_int(a:syserr):int(32);
 pragma "no doc"
-extern proc qio_int_to_err(a:int(32)):syserr;
+private extern proc qio_int_to_err(a:int(32)):syserr;
 pragma "no doc"
-extern proc qio_err_iserr(a:syserr):c_int;
+private extern proc qio_err_iserr(a:syserr):c_int;
 
 /* The error code indicating that no error occured (Chapel specific) */
 inline proc ENOERR return 0:err_t;
@@ -356,14 +356,14 @@ inline proc =(ref ret:err_t, x:syserr)
 
 // end of file
 pragma "no doc"
-extern proc chpl_macro_int_EEOF():err_t;
+private extern proc chpl_macro_int_EEOF():err_t;
 
 /* An error code indicating the end of file has been reached (Chapel specific)
  */
 inline proc EEOF return chpl_macro_int_EEOF():err_t;
 
 pragma "no doc"
-extern proc chpl_macro_int_ESHORT():err_t;
+private extern proc chpl_macro_int_ESHORT():err_t;
 
 /* An error code indicating that the end of file or the end of the
    input was reached before the requested amount of data could be read.
@@ -372,7 +372,7 @@ extern proc chpl_macro_int_ESHORT():err_t;
 inline proc ESHORT return chpl_macro_int_ESHORT():err_t;
 
 pragma "no doc"
-extern proc chpl_macro_int_EFORMAT():err_t;
+private extern proc chpl_macro_int_EFORMAT():err_t;
 
 /* An error code indicating a format error; for example when reading a quoted
    string literal, this would be returned if we never encountered the

--- a/test/users/ferguson/err_tmp.chpl
+++ b/test/users/ferguson/err_tmp.chpl
@@ -1,6 +1,8 @@
 use SysBasic;
 
 proc doDebugWrite(x, y):err_t {
+  extern proc qio_int_to_err(a:int(32)):syserr;
+
   writeln("Debug Write: ", x, y);
   return qio_int_to_err(1);
 }


### PR DESCRIPTION
Most of the "no doc" symbols here will be used in the internal modules, but
there were some that were module local only.  Apply private to those.