### PR TITLE
Add private to some symbols in the Sort module

### DIFF
--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -28,7 +28,7 @@
 module Sort {
 
 pragma "no doc"
-inline proc chpl_sort_cmp(a, b, param reverse=false, param eq=false) {
+private inline proc chpl_sort_cmp(a, b, param reverse=false, param eq=false) {
   if eq {
     if reverse then return a >= b;
     else return a <= b;
@@ -173,7 +173,7 @@ proc MergeSort(Data: [?Dom], minlen=16, doublecheck=false, param reverse=false) 
 
 
 pragma "no doc"
-proc _MergeSort(Data: [?Dom], minlen=16, param reverse=false) where Dom.rank == 1 {
+private proc _MergeSort(Data: [?Dom], minlen=16, param reverse=false) where Dom.rank == 1 {
   const lo = Dom.dim(1).low;
   const hi = Dom.dim(1).high;
   if hi-lo < minlen {
@@ -193,7 +193,7 @@ proc _MergeSort(Data: [?Dom], minlen=16, param reverse=false) where Dom.rank == 
 
 
 pragma "no doc"
-iter _MergeIterator(A1: [] ?elType, A2: [] elType, param reverse=false) {
+private iter _MergeIterator(A1: [] ?elType, A2: [] elType, param reverse=false) {
   var a1 = A1.domain.dim(1).low;
   const a1hi = A1.domain.dim(1).high;
   var a2 = A2.domain.dim(1).low;


### PR DESCRIPTION
These symbols were marked with the "no doc" pragma and seemed to be module
internal, so I'm marking them as private.  When chpldoc is able to recognize
private symbols, the pragmas can be removed.