### PR TITLE
Track zippered ForLoops throughout compilation

### DIFF
--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -129,7 +129,7 @@ BlockStmt* ForLoop::buildForLoop(Expr*      indices,
   VarSymbol*   iterator      = newTemp("_iterator");
   CallExpr*    iterInit      = 0;
   CallExpr*    iterMove      = 0;
-  ForLoop*     loop          = new ForLoop(index, iterator, body);
+  ForLoop*     loop          = new ForLoop(index, iterator, body, zippered);
   LabelSymbol* continueLabel = new LabelSymbol("_continueLabel");
   LabelSymbol* breakLabel    = new LabelSymbol("_breakLabel");
   BlockStmt*   retval        = new BlockStmt();
@@ -190,14 +190,17 @@ ForLoop::ForLoop() : LoopStmt(0)
 {
   mIndex    = 0;
   mIterator = 0;
+  mZippered = false;
 }
 
 ForLoop::ForLoop(VarSymbol* index,
                  VarSymbol* iterator,
-                 BlockStmt* initBody) : LoopStmt(initBody)
+                 BlockStmt* initBody,
+                 bool       zippered) : LoopStmt(initBody)
 {
   mIndex    = new SymExpr(index);
   mIterator = new SymExpr(iterator);
+  mZippered = zippered;
 }
 
 ForLoop::~ForLoop()
@@ -220,6 +223,7 @@ ForLoop* ForLoop::copy(SymbolMap* mapRef, bool internal)
 
   retval->mIndex            = mIndex->copy(map, true),
   retval->mIterator         = mIterator->copy(map, true);
+  retval->mZippered         = mZippered;
 
   for_alist(expr, body)
     retval->insertAtTail(expr->copy(map, true));
@@ -275,6 +279,11 @@ SymExpr* ForLoop::indexGet() const
 SymExpr* ForLoop::iteratorGet() const
 {
   return mIterator;
+}
+
+bool ForLoop::zipperedGet() const
+{
+  return mZippered;
 }
 
 CallExpr* ForLoop::blockInfoGet() const

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -991,7 +991,7 @@ buildFollowLoop(VarSymbol* iter,
                 bool       fast,
                 bool       zippered) {
   BlockStmt* followBlock = new BlockStmt();
-  ForLoop*   followBody  = new ForLoop(followIdx, followIter, loopBody);
+  ForLoop*   followBody  = new ForLoop(followIdx, followIter, loopBody, zippered);
 
   destructureIndices(followBody, indices, new SymExpr(followIdx), false);
 
@@ -1129,7 +1129,7 @@ buildStandaloneForallLoopStmt(Expr* indices,
   SABlock->insertAtTail("'move'(%S, _getIterator(_toStandalone(%S)))", saIter, iterRec);
   SABlock->insertAtTail("{TYPE 'move'(%S, iteratorIndex(%S)) }", saIdx, saIter);
 
-  ForLoop* SABody = new ForLoop(saIdx, saIter, NULL);
+  ForLoop* SABody = new ForLoop(saIdx, saIter, NULL, false);
   destructureIndices(SABody, indices, new SymExpr(saIdxCopy), false);
   SABody->insertAtHead("'move'(%S, %S)", saIdxCopy, saIdx);
   SABody->insertAtHead(new DefExpr(saIdxCopy));
@@ -1211,7 +1211,7 @@ buildForallLoopStmt(Expr*      indices,
   VarSymbol* leadIter        = newTemp("chpl__leadIter");
   VarSymbol* leadIdx         = newTemp("chpl__leadIdx");
   VarSymbol* leadIdxCopy     = newTemp("chpl__leadIdxCopy");
-  ForLoop*   leadForLoop     = new ForLoop(leadIdx, leadIter, NULL);
+  ForLoop*   leadForLoop     = new ForLoop(leadIdx, leadIter, NULL, zippered);
 
   VarSymbol* followIdx       = newTemp("chpl__followIdx");
   VarSymbol* followIter      = newTemp("chpl__followIter");
@@ -1552,7 +1552,7 @@ CallExpr* buildReduceExpr(Expr* opExpr, Expr* dataExpr, bool zippered) {
   leadIdxCopy->addFlag(FLAG_INDEX_VAR);
   leadIdxCopy->addFlag(FLAG_INSERT_AUTO_DESTROY);
 
-  ForLoop* followBody = new ForLoop(followIdx, followIter, NULL);
+  ForLoop* followBody = new ForLoop(followIdx, followIter, NULL, zippered);
 
   followBody->insertAtTail(".(%S, 'accumulate')(%S)", localOp, followIdx);
 
@@ -1575,7 +1575,7 @@ CallExpr* buildReduceExpr(Expr* opExpr, Expr* dataExpr, bool zippered) {
   followBlock->insertAtTail("'delete'(%S)", localOp);
   followBlock->insertAtTail("_freeIterator(%S)", followIter);
 
-  ForLoop* leadBody = new ForLoop(leadIdx, leadIter, NULL);
+  ForLoop* leadBody = new ForLoop(leadIdx, leadIter, NULL, zippered);
 
   leadBody->insertAtTail(new DefExpr(leadIdxCopy));
   leadBody->insertAtTail("'move'(%S, %S)", leadIdxCopy, leadIdx);

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -46,7 +46,8 @@ public:
 public:
                          ForLoop(VarSymbol* index,
                                  VarSymbol* iterator,
-                                 BlockStmt* initBody);
+                                 BlockStmt* initBody,
+                                 bool       zippered);
   virtual               ~ForLoop();
 
   virtual ForLoop*       copy(SymbolMap* map      = NULL,
@@ -57,7 +58,7 @@ public:
   virtual void           accept(AstVisitor* visitor);
 
   // Interface to Expr
-  virtual void        replaceChild(Expr* oldAst, Expr* newAst);
+  virtual void           replaceChild(Expr* oldAst, Expr* newAst);
   virtual Expr*          getFirstExpr();
   virtual Expr*          getNextExpr(Expr* expr);
 
@@ -71,6 +72,7 @@ public:
 
   SymExpr*               indexGet()                                   const;
   SymExpr*               iteratorGet()                                const;
+  bool                   zipperedGet()                                const;
 
   virtual CallExpr*      blockInfoGet()                               const;
   virtual CallExpr*      blockInfoSet(CallExpr* expr);
@@ -80,6 +82,7 @@ private:
 
   SymExpr*               mIndex;
   SymExpr*               mIterator;
+  bool                   mZippered;
 };
 
 #endif


### PR DESCRIPTION
Previously the "zip-ness" of an iterator was lost during AST building. It was
used to build the ForLoop but there was no reliable way to determine if a
ForLoop was iterating over a zippered iterator after parsing.

This adds zippered as an argument to the ForLoop's constructor which is then
stored as a private immutable member variable that has an assessor method.

This will be used in an upcoming patch to prevent zippering of certain
iterators. It will be used to find zippered iterators and check for a pragma
that denotes that zippering illegal.

The zippered state was already passed to the factory builder `buildForLoop` so
we just forward that to the actual ForLoop constructor. The actual ForLoop
constructor is directly called from a few other builders so they just had to be
updated to take the appropriate zippered state.

In order of occurrence in build.cpp:

 - In buildFollowLoop, we pass the zippered state along to the follower
 - In buildStandaloneForallLoopStmt, standalone iters can't be zipped
 - In buildForallLoopStmt, we pass the zippered state along to the leader
 - In buildReduceExpr, we pass the zipperd state to the follower and leader

Note that as stated above, the ForLoops that invoke leader iterators will be
marked as zippered if the forall was zippered. You could argue that leaders
can't really be zippered since there can only ever be a single leader. However
something like:

```chapel
forall i in zip(myIter1(), myIter2()) do writeln(i);
```

is effectively transformed into:

```chapel
for i in zip(myIter(tag=iterKind.leader)) do
  for j in zip(myIter1(tag=iterKind.follower, followthis=i),
               myIter2(tag=iterKind.follower, followThis=i) do writeln(j);
```

and the ForLoop invoking the leader is still zippered even though there can
never be more than one leader.