### PR TITLE
Apply private to the internal helper module in the BitOps standard module

### DIFF
--- a/modules/standard/BitOps.chpl
+++ b/modules/standard/BitOps.chpl
@@ -157,7 +157,7 @@ module BitOps {
  * module to hide the extern procedures
  */
 pragma "no doc"
-module BitOps_internal {
+private module BitOps_internal {
   extern proc chpl_bitops_popcount_32(x: c_uint) : uint(32);
   extern proc chpl_bitops_popcount_64(x: c_ulonglong) : uint(64);
 

--- a/modules/standard/BitOps.chpl
+++ b/modules/standard/BitOps.chpl
@@ -156,7 +156,6 @@ module BitOps {
 /**
  * module to hide the extern procedures
  */
-pragma "no doc"
 private module BitOps_internal {
   extern proc chpl_bitops_popcount_32(x: c_uint) : uint(32);
   extern proc chpl_bitops_popcount_64(x: c_ulonglong) : uint(64);


### PR DESCRIPTION
Now no outside module can use BitOps_internal.

@Kyle-B, would you mind giving this a review?