### PR TITLE
Use maxTaskPar for knucleotide's coforalls

### DIFF
--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
@@ -1,5 +1,4 @@
 use IO;
-use AdvancedIters;
 
 extern proc memcpy(x : [], b:c_string , len:int);
 
@@ -41,14 +40,13 @@ proc calculate(data : [] uint(8), size : int) {
   var freqDom : domain(uint);
   var freqs : [freqDom] int;
 
-  const ntasks = defaultNumTasks(0);
   var lock : sync bool;
   lock = true;
   const sizeRange = 0..size-1;
-  coforall tid in 1..ntasks {
+  coforall tid in 1..here.maxTaskPar {
     var curDom : domain(uint);
     var curArr : [curDom] int;
-    for i in tid .. data.size-size by ntasks {
+    for i in tid .. data.size-size by here.maxTaskPar {
       curArr[hash(data, i, sizeRange)] += 1;
     }
     lock; // acquire lock

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
@@ -1,5 +1,4 @@
 use IO;
-use AdvancedIters;
 
 extern proc memcpy(x : [], b:c_string, len:int);
 
@@ -93,13 +92,12 @@ proc decode(data : uint, size : int) {
 proc calculate(data : [] uint(8), size : int) {
   var freqs = new Table();
 
-  const ntasks = defaultNumTasks(0);
   var lock : sync bool;
   lock = true;
   const sizeRange = 0..size-1;
-  coforall tid in 1..ntasks {
+  coforall tid in 1..here.maxTaskPar {
     var curArr = new Table();
-    for i in tid .. data.size-size by ntasks {
+    for i in tid .. data.size-size by here.maxTaskPar {
       curArr[hash(data, i, sizeRange)] += 1;
     }
     lock; // acquire lock


### PR DESCRIPTION
These tests were using a helper function in AdvancedIters to determine the number of tasks create with a coforall. This patch instead uses here.maxTaskPar, which seems less confusing to someone reading over the code.