### PR TITLE
Add a parallel init_elts and a config param to select serial or parallel

### DIFF
--- a/compiler/AST/LoopStmt.cpp
+++ b/compiler/AST/LoopStmt.cpp
@@ -97,8 +97,14 @@ void LoopStmt::codegenOrderIndependence()
     std:: string ivdepStr = "CHPL_PRAGMA_IVDEP";
     if (fReportOrderIndependentLoops)
     {
-      printf("Adding %s to %s for %s:%d\n", ivdepStr.c_str(),
-          this->astTagAsString(), this->getModule()->name, this->linenum());
+      ModuleSymbol *mod = toModuleSymbol(this->getModule());
+      INT_ASSERT(mod);
+
+      if (developer || mod->modTag == MOD_USER)
+      {
+        printf("Adding %s to %s for %s:%d\n", ivdepStr.c_str(),
+            this->astTagAsString(), mod->name, this->linenum());
+      }
     }
 
     info->cStatements.push_back(ivdepStr+'\n');

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -665,19 +665,28 @@ module ChapelBase {
     __primitive("chpl_exit_any", status);
   }
   
+  config param parallelInitElts=false;
   proc init_elts(x, s, type t) {
-    for i in 1..s {
-      //
-      // Q: why is the following declaration of 'y' in the loop?
-      //
-      // A: so that if the element type is something like an array,
-      // the element can 'steal' the array rather than copying it.
-      // One effect of having it in the loop is that the reference
-      // count for an array element's domain gets bumped once per
-      // element.  Is this good, bad, necessary?  Unclear.
-      //
-      pragma "no auto destroy" var y: t;  
-      __primitive("array_set_first", x, i-1, y);
+    //
+    // Q: why is the following declaration of 'y' in the loop?
+    //
+    // A: so that if the element type is something like an array,
+    // the element can 'steal' the array rather than copying it.
+    // One effect of having it in the loop is that the reference
+    // count for an array element's domain gets bumped once per
+    // element.  Is this good, bad, necessary?  Unclear.
+    //
+    if parallelInitElts {
+      forall i in 1..s {
+        pragma "no auto destroy" var y: t;
+        __primitive("array_set_first", x, i-1, y);
+      }
+
+    } else {
+      for i in 1..s {
+        pragma "no auto destroy" var y: t;
+        __primitive("array_set_first", x, i-1, y);
+      }
     }
   }
   

--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -6,15 +6,12 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04.playground"
 
-# Do an llvm perf run
+# Test performance of parallel init_elts
 #
 # Graph the default config and this config side by side to make comparison
 # easy, but sync to a different direction so the default chap04 graphs don't
 # have multiple configurations.
 
-source $CWD/common-llvm.bash
-unset CHPL_NIGHTLY_TEST_DIRS
-
-perf_args="-performance-description llvm -performance-configs default:v,llvm:v -sync-dir-suffix llvm"
-perf_args="${perf_args} -numtrials 5 -startdate 04/01/15"
+perf_args="-performance-description par-init -performance-configs default:v,par-init:v -sync-dir-suffix par-init"
+perf_args="${perf_args} -numtrials 5 -startdate 07/30/15 -compopts -sparallelInitElts"
 $CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
Currently init_elts (what gets called to initialize the ddata of arrays) is
serial. This gives us bad first touch behavior because a single task has
touched all our memory.

This adds a parallel version and a config param to switch between the two in
order to test out the performance impact. We know this gives us ideal
performance for things like stream-ep but want to test out the performance in
the perf playground before committing this change.

For now the default is still serial initialization, but this also includes an
update to test the performance of parallel init in the perf playground.

It also includes an update to --report-order-independent-loops to only report
user modules unless CHPL_DEVELOPER is set. This is something I missed
previously but noticed when I did a full test run with the parallel init_elts
because we now have an internal forall loop that was causing vectorization.
