### PR TITLE
Apply private to some helper functions in the AdvancedIters module

### DIFF
--- a/modules/standard/AdvancedIters.chpl
+++ b/modules/standard/AdvancedIters.chpl
@@ -454,7 +454,6 @@ where tag == iterKind.follower
 }
 
 //************************* Helper functions
-pragma "no doc"
 private proc defaultNumTasks(nTasks:int)
 {
   var dnTasks=nTasks;
@@ -467,7 +466,6 @@ private proc defaultNumTasks(nTasks:int)
   return dnTasks;
 }
 
-pragma "no doc"
 private proc adaptSplit(ref rangeToSplit:range(?), splitFactor:int, ref itLeft:bool, ref lock : vlock, splitTail:bool=false)
 {
   type rType=rangeToSplit.type;

--- a/modules/standard/AdvancedIters.chpl
+++ b/modules/standard/AdvancedIters.chpl
@@ -455,7 +455,7 @@ where tag == iterKind.follower
 
 //************************* Helper functions
 pragma "no doc"
-proc defaultNumTasks(nTasks:int)
+private proc defaultNumTasks(nTasks:int)
 {
   var dnTasks=nTasks;
   if nTasks==0 then {
@@ -468,7 +468,7 @@ proc defaultNumTasks(nTasks:int)
 }
 
 pragma "no doc"
-proc adaptSplit(ref rangeToSplit:range(?), splitFactor:int, ref itLeft:bool, ref lock : vlock, splitTail:bool=false)
+private proc adaptSplit(ref rangeToSplit:range(?), splitFactor:int, ref itLeft:bool, ref lock : vlock, splitTail:bool=false)
 {
   type rType=rangeToSplit.type;
   type lenType=rangeToSplit.length.type;


### PR DESCRIPTION
Helpers functions do not need to be visible outside the module in which
they are defined.

Depends on #2231

Reviewed by Ben