### PR TITLE
Throw -Wno-pointer-sign

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -110,6 +110,11 @@ WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wnested
 WARN_GEN_CFLAGS = $(WARN_CFLAGS) -Wno-unused -Wno-uninitialized
 
 #
+# Don't warn for signed pointer issues (ex. c_ptr(c_char) )
+#
+WARN_GEN_CFLAGS += -Wno-pointer-sign
+
+#
 # compiler warnings settings
 #
 ifeq ($(WARNINGS), 1)

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -119,7 +119,9 @@ WARN_GEN_CFLAGS = $(WARN_CFLAGS) -Wno-unused -Wno-uninitialized
 #
 # Don't warn for signed pointer issues (ex. c_ptr(c_char) )
 #
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -lt 4; echo "$$?"),1)
 WARN_GEN_CFLAGS += -Wno-pointer-sign
+else
 
 ifeq ($(GNU_GPP_SUPPORTS_MISSING_DECLS),1)
 WARN_CXXFLAGS += -Wmissing-declarations

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -121,7 +121,7 @@ WARN_GEN_CFLAGS = $(WARN_CFLAGS) -Wno-unused -Wno-uninitialized
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -lt 4; echo "$$?"),1)
 WARN_GEN_CFLAGS += -Wno-pointer-sign
-else
+endif
 
 ifeq ($(GNU_GPP_SUPPORTS_MISSING_DECLS),1)
 WARN_CXXFLAGS += -Wmissing-declarations

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -116,6 +116,11 @@ WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasi
 WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wdeclaration-after-statement -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS) -Wno-unused -Wno-uninitialized
 
+#
+# Don't warn for signed pointer issues (ex. c_ptr(c_char) )
+#
+WARN_GEN_CFLAGS += -Wno-pointer-sign
+
 ifeq ($(GNU_GPP_SUPPORTS_MISSING_DECLS),1)
 WARN_CXXFLAGS += -Wmissing-declarations
 else

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -119,6 +119,11 @@ WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS) -wr111,174,177
 
 #
+# Don't warn for signed pointer issues (ex. c_ptr(c_char) )
+#
+WARN_GEN_CFLAGS += -Wno-pointer-sign
+
+#
 # compiler warnings settings
 #
 ifeq ($(WARNINGS), 1)


### PR DESCRIPTION
This patch adds -Wno-pointer-sign to list of flags used to compile the generated C code. Some codes working with pointers to c_chars have seen warnings concerning the sign of pointers to chars. A true fix to this problem probably involves compiler work to emit C type names instead of Chapel type names.