### PR TITLE
Add heuristic to toggle between parallel and serial init_elts

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -668,7 +668,7 @@ module ChapelBase {
   config param parallelInitElts=false;
   proc init_elts(x, s, type t) {
     //
-    // Q: why is the following declaration of 'y' in the loop?
+    // Q: why is the declaration of 'y' in the following loops?
     //
     // A: so that if the element type is something like an array,
     // the element can 'steal' the array rather than copying it.
@@ -676,32 +676,42 @@ module ChapelBase {
     // count for an array element's domain gets bumped once per
     // element.  Is this good, bad, necessary?  Unclear.
     //
-    const pagesizeInBytes = 4096; // TODO: query this from the runtime
-    // TODO: improve the heuristic below for non-numeric types
+
+    //
+    // Heuristically determine if we should do parallel initialization. We want
+    // each task to "own" at least a page in order to get good first-touch
+    // behavior and to avoid false-sharing. We naively assume the parallel
+    // range iterator will create maxTaskPar tasks so we want the array to be
+    // at least (maxTaskPar * pagesizes) big. For non-numeric element types we
+    // guess that each element is at least 8 bytes with the assumption that
+    // most record/classes/arrays will be at least 8 bytes.
+    //
+    // TODO: improve the heuristic for non-numeric types
+    //
+    // TODO: Note that we could do even better if the range had an iterator
+    // that supported local overrides of dataParTasksPerLocale or
+    // MinGranularity. The current heuristic will always try to use
+    // dataParTasksPerLocale even if, say, arrsize is pagesize+1, where we'd
+    // really only want to use 2 tasks there or set minGranularity to pagesize.
+    // But at the very least, the current approach differentiates between
+    // larger and smaller arrays.
+    //
+
+    extern proc chpl_getSysPageSize():size_t;
+    const pagesizeInBytes = chpl_getSysPageSize():int;
+
     const elemsizeInBytes = if (isNumericType(t)) then numBytes(t) else 8;
     const arrsizeInBytes = s*elemsizeInBytes;
-    const heuristicWantsPar = arrsizeInBytes > pagesizeInBytes;
-    //
-    // TODO: Note that we could do even better if the range had
-    // an iterator that supported local overrides of
-    // dataParTasksPerLocale or MinGranularity.  The current heuristic
-    // will always try to use dataParTasksPerLocale even if, say,
-    // arrsize is pagesize+1, where we'd really only want to use 2
-    // tasks there or set minGranularity to pagesize.  But at the very
-    // least, the current approach differentiates between larger
-    // and smaller arrays.
-    //
-    //    extern proc printf(x...);
+    const heuristicThresh = pagesizeInBytes * here.maxTaskPar;
+    const heuristicWantsPar = arrsizeInBytes > heuristicThresh;
 
     if parallelInitElts && heuristicWantsPar {
-      //      printf("%s\n", "Using parallel array initialization");
       forall i in 1..s {
         pragma "no auto destroy" var y: t;
         __primitive("array_set_first", x, i-1, y);
       }
 
     } else {
-      //      printf("%s\n", "Using serial array initialization");
       for i in 1..s {
         pragma "no auto destroy" var y: t;
         __primitive("array_set_first", x, i-1, y);


### PR DESCRIPTION
2d3432b0aeddeb2b9d53d8748be7bf9ecdf40022 added a parallel init_elts that could
be toggled with a config param. This extends that work to heuristically use
serial init even if parallel is allowed for "small" arrays.

The basic idea of the heuristic is that we will only use parallel init if we
believe the array is at least (here.maxTaskPar * pagesize) big. This way we
shouldn't have any false-sharing, page contention, or bad first-touch behavior
for small arrays. For non-numeric types we assume each element is at least 8
bytes for simplicity. It's possible for them to be smaller, but pretty
unlikely.

Some remaining work is to improve the heuristic for non-numeric types and to
add a dataParMinGranularity to a range iterator. See the comments above 
the parallel init_elts for more details.

This will resolve the lulesh performance regression (and likely others) that
we're seeing the perf playground