### PR TITLE
safecast array size to an int for init_elts heuristic

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -698,10 +698,10 @@ module ChapelBase {
     //
 
     extern proc chpl_getSysPageSize():size_t;
-    const pagesizeInBytes = chpl_getSysPageSize():int;
+    const pagesizeInBytes = chpl_getSysPageSize().safeCast(int);
 
     const elemsizeInBytes = if (isNumericType(t)) then numBytes(t) else 8;
-    const arrsizeInBytes = s*elemsizeInBytes;
+    const arrsizeInBytes = s.safeCast(int) * elemsizeInBytes;
     const heuristicThresh = pagesizeInBytes * here.maxTaskPar;
     const heuristicWantsPar = arrsizeInBytes > heuristicThresh;
 


### PR DESCRIPTION
"s" (the number of elements) is generic and for some tests is a uint which was
causing compiler errors because you can't multiply a uint and an int. Add a
safe cast to get rid of this error