### PR TITLE
Eliminated _build_tuple_always().

### DIFF
--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -232,7 +232,7 @@ instantiate_tuple_initCopy(FnSymbol* fn) {
     INT_FATAL(fn, "tuple initCopy function has more than one argument");
   ArgSymbol  *arg = fn->getFormal(1);
   AggregateType  *ct = toAggregateType(arg->type);
-  CallExpr *call = new CallExpr("_build_tuple_always");
+  CallExpr *call = new CallExpr("_build_tuple");
   BlockStmt* block = new BlockStmt();
   for (int i=1; i<ct->fields.length; i++) {
     call->insertAtTail(new CallExpr("chpl__initCopy", new CallExpr(arg, new_IntSymbol(i))));

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -30,27 +30,25 @@ module ChapelTuple {
   //
   // syntactic support for tuples
   //
+
+  // tuple type
+  pragma "build tuple"
+  inline proc _build_tuple(type t...) type
+    return t;
+
+  // tuple value with intents by default
   pragma "build tuple"
   inline proc _build_tuple(x...) {
       return x;
   }
   
+  // tuple value with ref intents for actuals of ref types
   pragma "allow ref" 
   pragma "build tuple"
-  inline proc _build_tuple_always_allow_ref(x ...?size)
+  inline proc _build_tuple_always_allow_ref(x...)
     return x;
   
-  pragma "build tuple"
-  inline proc _build_tuple(type t ...?size) type
-    return t;
-  
-  pragma "build tuple"
-  inline proc _build_tuple_always(x ...?size)
-    return x;
-  
-  //
-  // homogeneous tuple type syntax
-  //
+  // homogeneous tuple type
   proc *(param p: int, type t) type {
     var oneTuple: _build_tuple(t);
     proc _fill(param p: int, x: _tuple) {

--- a/test/compflags/bradc/minimalModules/minModDeclPrint.chpl
+++ b/test/compflags/bradc/minimalModules/minModDeclPrint.chpl
@@ -15,6 +15,6 @@ printf("%d\n", xyz);
   }
   
   pragma "build tuple"
-  inline proc _build_tuple_always(x ...?size)
+  inline proc _build_tuple(x...)
     return x;
   

--- a/test/compflags/bradc/minimalModules/minModFnRefArg.chpl
+++ b/test/compflags/bradc/minimalModules/minModFnRefArg.chpl
@@ -26,6 +26,6 @@ printf("%d\n", x);
   }
   
   pragma "build tuple"
-  inline proc _build_tuple_always(x ...?size)
+  inline proc _build_tuple(x...)
     return x;
   


### PR DESCRIPTION
_build_tuple_always() was identical to _build_tuple()
and only used in a coupld of places.
It was introduced in e4dbf86a aka r13264 without an explanation.

I replaced the uses of _build_tuple_always() with _build_tuple()
so we do not have to wonder why one and not the other.

While there, removed ?size in varargs because it was not used.

The comments I added on _build_tuple() and _build_tuple_always_allow_ref()
are motivated by my intention to distinguish between these two kinds of tuples:

* "default-intent" tuple - ref-ness of each component
  is determined by language rules based on the component's type
  -- created using _build_tuple()

* "allow ref" tuple - ref-ness of each component is determined by
  ref-ness of the type of the corresponding actual argument
  when the tuple was created
  -- created using _build_tuple_always_allow_ref()
