### PR TITLE
Fully param protect parallel init_elts heuristic

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -697,26 +697,34 @@ module ChapelBase {
     // larger and smaller arrays.
     //
 
-    extern proc chpl_getSysPageSize():size_t;
-    const pagesizeInBytes = chpl_getSysPageSize().safeCast(int);
+    if parallelInitElts {
+      extern proc chpl_getSysPageSize():size_t;
+      const pagesizeInBytes = chpl_getSysPageSize().safeCast(int);
 
-    const elemsizeInBytes = if (isNumericType(t)) then numBytes(t) else 8;
-    const arrsizeInBytes = s.safeCast(int) * elemsizeInBytes;
-    const heuristicThresh = pagesizeInBytes * here.maxTaskPar;
-    const heuristicWantsPar = arrsizeInBytes > heuristicThresh;
+      const elemsizeInBytes = if (isNumericType(t)) then numBytes(t) else 8;
+      const arrsizeInBytes = s.safeCast(int) * elemsizeInBytes;
+      const heuristicThresh = pagesizeInBytes * here.maxTaskPar;
+      const heuristicWantsPar = arrsizeInBytes > heuristicThresh;
 
-    if parallelInitElts && heuristicWantsPar {
-      forall i in 1..s {
-        pragma "no auto destroy" var y: t;
-        __primitive("array_set_first", x, i-1, y);
+      if heuristicWantsPar {
+        forall i in 1..s {
+          pragma "no auto destroy" var y: t;
+          __primitive("array_set_first", x, i-1, y);
+        }
+
+      } else {
+        for i in 1..s {
+          pragma "no auto destroy" var y: t;
+          __primitive("array_set_first", x, i-1, y);
+        }
       }
-
     } else {
       for i in 1..s {
         pragma "no auto destroy" var y: t;
         __primitive("array_set_first", x, i-1, y);
       }
     }
+
   }
   
   // dynamic data block class


### PR DESCRIPTION
Previously the actual parallel init was param protected, but a small
computation to see if parallel init was worthwhile wasn't. This was so that I
didn't have to duplicate code (and I didn't expect there to be any noticeable
performance overhead.)

Unfortunately here.maxTaskPar results in communication (which seems odd) so the
tests that counts initialization comm counts was higher than expected.

This fully param protects the heuristic code but duplicates the code to do
serial initialization.