### PR TITLE
Multilocale strings, take 2

### DIFF
--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -118,6 +118,9 @@ void insertDerefTemps(CallExpr* call);
 void insertDerefTemps(FnSymbol* fn);
 void insertDerefTemps();
 
+void replaceValArgsWithRefArgs(FnSymbol* fn);
+void replaceValArgsWithRefArgs();
+
 // parallel.cpp
 Type* getOrMakeRefTypeDuringCodegen(Type* type);
 Type* getOrMakeWideTypeDuringCodegen(Type* refType);

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -223,7 +223,11 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
                   (call->isPrimitive(PRIM_WIDE_GET_NODE)) ||
                   (fnc && arg->type == actual_to_formal(se)->type)) {
                 se->var = arg; // do not dereference argument in these cases
-              } else if (call->isPrimitive(PRIM_ADDR_OF)) {
+              } 
+              // The following two clauses may be redundant, since
+              // insertReferenceTemps() and insertDerefTemps() now do the same
+              // thing.
+              else if (call->isPrimitive(PRIM_ADDR_OF)) {
                 SET_LINENO(se);
                 call->replace(new SymExpr(arg));
               } else {

--- a/compiler/passes/insertAutoCopyAutoDestroy.cpp
+++ b/compiler/passes/insertAutoCopyAutoDestroy.cpp
@@ -403,8 +403,9 @@ void insertAutoCopyAutoDestroy()
     insertAutoCopyAutoDestroy(fn);
   }
 
-  // Re-run insertReferenceTemps, to cover autoDestroy calls that may have been
-  // inserted by this pass.
+  // Re-run replaceValArgsWithRefArgs and insertReferenceTemps, to cover
+  // autoDestroy calls that may have been inserted by this pass.
+  replaceValArgsWithRefArgs();
   insertReferenceTemps();
 }
 

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -127,6 +127,10 @@ static void adjustRefLevel(ArgSymbol* arg)
       return;
 
     // Type arguments are always passed by "value".
+    // TODO: This test should really be:
+    //    if (arg->hasFlag(FLAG_TYPE_VARIABLE))
+    // but this causes many more arguments to be passed by reference, and about
+    // 150 standard test cases fail as a result.
     if (t->symbol->hasFlag(FLAG_TYPE_VARIABLE))
       return;
 

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -151,6 +151,7 @@ void resolveIntents() {
     resolveArgIntent(arg);
     adjustRefLevel(arg);
   }
+  replaceValArgsWithRefArgs();
   insertReferenceTemps();
   insertDerefTemps();
   intentsResolved = true;

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1106,6 +1106,128 @@ void insertDerefTemps() {
 }
 
 
+// If the given symbol is a temporary that is defined uniqely as the LHS of a
+// deref primitive, then return the SymExpr that is the operand of the deref;
+// otherwise, return NULL.
+static SymExpr* rhsOfDerefTmp(Symbol* sym,
+                              Map<Symbol*,Vec<SymExpr*>*>& defMap)
+{
+  // Is this symbol a temporary?
+  if (! sym->hasFlag(FLAG_TEMP))
+    // Nope. Fail outright.
+    return NULL;
+
+  // Find the definitions of the given symbol
+  if (Vec<SymExpr*>* defs = defMap.get(sym))
+  {
+    // Ensure that it is uniquely defined.
+    if (defs->n != 1)
+      return NULL;
+
+    SymExpr* def = defs->only();
+    if (CallExpr* move = toCallExpr(def->parentExpr))
+      if (move->isPrimitive(PRIM_MOVE))
+      {
+        // If this is a simple transfer, punch through and see if we get a
+        // deref somewhere back up the def-use chain.
+        if (SymExpr* rhs = toSymExpr(move->get(2)))
+          return rhsOfDerefTmp(rhs->var, defMap);
+
+        if (CallExpr* deref = toCallExpr(move->get(2)))
+          if (deref->isPrimitive(PRIM_DEREF))
+          {
+            SymExpr* ref = toSymExpr(deref->get(1));
+            // We expect the RHS of a deref primitive to be a SymExpr.
+            INT_ASSERT(ref);
+            return ref;
+          }
+        // fall through
+      }
+    // fall through
+  }
+  return NULL;
+}
+
+
+static void replaceValArgsWithRefArgs(CallExpr* call,
+                                      Map<Symbol*,Vec<SymExpr*>*>& defMap,
+                                      Map<Symbol*,Vec<SymExpr*>*>& useMap)
+{
+  for_formals_actuals(/*ArgSymbol*/ formal, /*Expr*/ actual, call)
+  {
+    // Check: Is the formal of ref type?
+    // If not, then there is nothing to do here.
+    if (! formal->type->symbol->hasFlag(FLAG_REF))
+      continue;
+
+    // Check: Is the actual of value type?
+    // If not, there is nothing to do here.
+    SymExpr* actualSE = toSymExpr(actual);
+    // We assume that this actual argument is a SymExpr.
+    INT_ASSERT(actualSE);
+    Symbol* actualSym = actualSE->var;
+    if (actualSym->type->symbol->hasFlag(FLAG_REF))
+      continue;
+
+    // If the argument is a deref temp, use the rhs of the deref primitive to
+    // get an actual argument of ref type.
+    if (SymExpr* refActual = rhsOfDerefTmp(actualSym, defMap))
+    {
+      // Replace the deref temp argument of the autoCopy call
+      // with the reference arg that created the deref temp.
+      SET_LINENO(actualSE);
+      actualSE->replace(new SymExpr(refActual->var));
+
+      // If possible, remove the deref temp creation and the
+      // deref temp itself.
+      Vec<SymExpr*>* uses = useMap.get(refActual->var);
+      if (uses->n == 1 && uses->only() == actual)
+      {
+        // This is the MOVE that defines actualSym.
+        Expr* move = refActual->parentExpr->parentExpr;
+        move->remove();
+        actualSym->defPoint->remove();
+      }
+    }
+  }
+}
+
+
+void replaceValArgsWithRefArgs(FnSymbol* fn)
+{
+  Map<Symbol*,Vec<SymExpr*>*> defMap;
+  Map<Symbol*,Vec<SymExpr*>*> useMap;
+  buildDefUseMaps(fn, defMap, useMap);
+
+  std::vector<CallExpr*> callExprs;
+  collectCallExprs(fn, callExprs);
+  for_vector(CallExpr, call, callExprs)
+  {
+    // Ignore calls that are not in the tree.
+    if (! call->parentSymbol)
+      continue;
+
+    // Weed out primitives
+    // This probably catches virtual method calls, so we may need a more
+    // precise test later.
+    if (! call->isResolved())
+      continue;
+
+    replaceValArgsWithRefArgs(call, defMap, useMap);
+  }
+
+  freeDefUseMaps(defMap, useMap);
+}
+
+                              
+void replaceValArgsWithRefArgs()
+{
+  forv_Vec(FnSymbol, fn, gFnSymbols)
+  {
+    replaceValArgsWithRefArgs(fn);
+  }
+}
+
 void
 callDestructors() {
   fixupDestructors();

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -61,7 +61,7 @@ FnSymbol* getTheIteratorFn(Type* icType) {
   // the asserts document the current state
   bool gotTuple = icType->symbol->hasFlag(FLAG_TUPLE);
   INT_ASSERT(gotTuple || icType->symbol->hasFlag(FLAG_ITERATOR_CLASS));
-  Type* irType = icType->defaultInitializer->getFormal(1)->type;
+  Type* irType = icType->defaultInitializer->getFormal(1)->type->getValType();
   INT_ASSERT(irType->symbol->hasFlag(FLAG_ITERATOR_RECORD) ||
              (gotTuple && irType->symbol->hasFlag(FLAG_ITERATOR_CLASS)));
   FnSymbol* result = irType->defaultInitializer;

--- a/compiler/util/OwnershipFlowManager.cpp
+++ b/compiler/util/OwnershipFlowManager.cpp
@@ -968,7 +968,7 @@ static void insertAutoDestroyAfterStmt(SymExpr* se)
   SET_LINENO(sym->defPoint);
   CallExpr* autoDestroyCall = new CallExpr(autoDestroy, sym);
   lastStmtInBB->insertAfter(autoDestroyCall);
-  insertReferenceTemps(autoDestroyCall);
+//  insertReferenceTemps(autoDestroyCall);
 }
 
 
@@ -1223,7 +1223,7 @@ static void insertAutoCopy(SymExpr* se)
   stmt->insertBefore(new DefExpr(tmp));
   stmt->insertBefore(new CallExpr(PRIM_MOVE, tmp, autoCopyCall));
   se->replace(new SymExpr(tmp));
-  insertReferenceTemps(autoCopyCall);
+//  insertReferenceTemps(autoCopyCall);
 }
 
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3529,7 +3529,10 @@ proc _write_text_internal(_channel_internal:qio_channel_ptr_t, x:?t):syserr wher
     return qio_channel_print_string(false, _channel_internal, x, x.length:ssize_t);
   } else if t == string {
     // handle string
-    return qio_channel_print_string(false, _channel_internal, x.c_str(), x.length:ssize_t);
+    const local_x: string = if x.locale.id != chpl_nodeID
+        then x // assignment makes it local
+        else new string(x, owned=false);
+    return qio_channel_print_string(false, _channel_internal, local_x.c_str(), local_x.length:ssize_t);
   } else if isEnumType(t) {
     var s = x:string;
     return qio_channel_print_literal(false, _channel_internal, s.c_str(), s.length:ssize_t);

--- a/test/extern/bradc/emptyRecords/emptyexternrecord.chpl
+++ b/test/extern/bradc/emptyRecords/emptyexternrecord.chpl
@@ -5,6 +5,6 @@ extern record R {
 
 var myR: R;
 
-extern proc foo(myR:R);
+extern proc foo(const in myR:R);
 
 foo(myR);

--- a/test/extern/bradc/structs/externFloat4calls.chpl
+++ b/test/extern/bradc/structs/externFloat4calls.chpl
@@ -3,7 +3,7 @@ extern record float4 {
 }
 
 extern proc getfloat4(): float4;
-extern proc printme(val: float4);
+extern proc printme(const in val: float4);
 
 var myf42: float4 = getfloat4();
 writeln("myf42 = ", myf42);

--- a/test/extern/bradc/structs/externFloat4calls.someFields.chpl
+++ b/test/extern/bradc/structs/externFloat4calls.someFields.chpl
@@ -3,7 +3,7 @@ extern record float4 {
 }
 
 extern proc getfloat4(): float4;
-extern proc printme(val: float4);
+extern proc printme(const in val: float4);
 
 var myf42: float4 = getfloat4();
 writeln("myf42 = ", myf42);

--- a/test/extern/ferguson/crazyRecord.chpl
+++ b/test/extern/ferguson/crazyRecord.chpl
@@ -10,37 +10,37 @@
 extern record A_BCde {
 }
 extern proc return_A_BCde():A_BCde;
-extern proc print_A_BCde(r:A_BCde);
+extern proc print_A_BCde(const in r:A_BCde);
 
 extern record iAbc {
 }
 extern proc return_iAbc():iAbc;
-extern proc print_iAbc(r:iAbc);
+extern proc print_iAbc(const in r:iAbc);
 
 extern record iaBc {
 }
 extern proc return_iaBc():iaBc;
-extern proc print_iaBc(r:iaBc);
+extern proc print_iaBc(const in r:iaBc);
 
 extern record iabC {
 }
 extern proc return_iabC():iabC;
-extern proc print_iabC(r:iabC);
+extern proc print_iabC(const in r:iabC);
 
 extern record iABc {
 }
 extern proc return_iABc():iABc;
-extern proc print_iABc(r:iABc);
+extern proc print_iABc(const in r:iABc);
 
 extern record iaBC {
 }
 extern proc return_iaBC():iaBC;
-extern proc print_iaBC(r:iaBC);
+extern proc print_iaBC(const in r:iaBC);
 
 extern record iaBCd {
 }
 extern proc return_iaBCd():iaBCd;
-extern proc print_iaBCd(r:iaBCd);
+extern proc print_iaBCd(const in r:iaBCd);
 
 { var r:A_BCde; r = return_A_BCde(); print_A_BCde(r); }
 { var r:iAbc; r = return_iAbc(); print_iAbc(r); }


### PR DESCRIPTION
This PR lays some of the groundwork for handling strings (and other non-POD record types) across multiple locales.

The new Chapel string implementation relies on locality information being forwarded with the object, and the team approved the idea as a general language design point.  The main effects of this design choice are:
* When objects are copied across locales, they must be piped through a copy-constructor, so that a local copy can be made of the remote object.
* Objects should be passed by reference as much as possible, to avoid this copying overhead while preserving locality information.

Regression counts should remain unchanged after this patch, but a small pending change lets some multilocale tests pass while introducing a number of regressions in the standard configuration.  Work going forward is to enable this change while eliminating the new regressions.