### PR TITLE
Add test/runtime/kbrady/goodAllocSize.good to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -325,6 +325,7 @@ tags
 
 /test/runtime/gbt/numThreadsSymbolicLogical.good
 /test/runtime/gbt/numThreadsSymbolicPhysical.good
+/test/runtime/kbrady/goodAllocSize.good
 
 /test/studies/590o/alexco/*.txt
 /test/studies/amr/**/_output


### PR DESCRIPTION
This good file is created via a prediff and should be removed by the
testing system. If something goes wrong it may be left behind in which
case it should be ignored.