### PR TITLE
Add a python script to activate the test virtual env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ all: comprt
 comprt: FORCE
 	@$(MAKE) compiler
 	@$(MAKE) third-party-try-opt
+	@$(MAKE) always-build-test-venv
 	@$(MAKE) runtime
 	@$(MAKE) modules
 
@@ -104,9 +105,16 @@ third-party-test-venv: FORCE
 third-party-chpldoc-venv: FORCE
 	cd third-party && $(MAKE) chpldoc-venv
 
+test-venv: third-party-test-venv
+
 chpldoc: compiler third-party-chpldoc-venv
 	cd compiler && $(MAKE) chpldoc
 	@test -r Makefile.devel && $(MAKE) man-chpldoc || echo ""
+
+always-build-test-venv: FORCE
+	-@if [ -n "$$CHPL_ALWAYS_BUILD_TEST_VENV" ]; then \
+	$(MAKE) test-venv; \
+	fi
 
 clean-module-docs:
 	cd modules && $(MAKE) clean-documentation

--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import sys
+
+chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import utils
+import chpl_platform
+import chpl_make
+
+# Activate a virtualenv that has testing infrastructure requirements installed
+#
+# By default, we will try to use $CHPL_HOME/third-party/chpl-venv as our
+# virtualenv. We then check for a sentinel file that test-venv creates when
+# it's been successfully installed and finally activate the virtualenv.
+#
+# A user can also set CHPL_TEST_VENV_DIR to specify the path to a custom
+# virtualenv that will be activated. "none" is a special value that means skip
+# activating a virtualenv. If CHPL_TEST_VENV_DIR is set, a user is asserting
+# that their virtualenv or local install has the requirements available.
+#
+# Note that this method does not allow us to specify python versions to use and
+# instead will use the system default. Long term we probably want to have a
+# wrapper script that activates the virtualenv and just calls start_test.
+
+def error(message):
+    print('[Error: {}]'.format(message))
+    exit(1)
+
+def activate_venv():
+
+    custom_venv_dir_var = 'CHPL_TEST_VENV_DIR'
+    custom_venv_dir = os.getenv(custom_venv_dir_var, '').strip()
+
+    # user asserts that system already has the required dependencies installed:
+    if custom_venv_dir == 'none':
+        print('[Skipping virtualenv activation because {}={}. test-venv '
+              'requirements must be available.]'.format(custom_venv_dir_var,
+              custom_venv_dir))
+
+    else:
+        venv_dir = None
+
+        # using custom venv, does not check that our test requirements are met
+        if custom_venv_dir:
+            venv_dir = custom_venv_dir
+            print('[Using custom  virtualenv because {}={}. test-venv '
+                  'requirements must be available]'.format(custom_venv_dir_var,
+                  custom_venv_dir))
+
+        # check Chapel test-venv for successful installation sentinel
+        else:
+            chpl_home = os.path.join(utils.get_chpl_home(), '')
+            third_party = os.path.join(chpl_home, 'third-party')
+            target_platform = chpl_platform.get('target')
+
+            venv_dir = os.path.join(third_party, 'chpl-venv', 'install',
+                                    target_platform, 'chpl-virtualenv')
+            sentinel_file = os.path.join(venv_dir, 'chpl-test-reqs')
+            if not os.path.isfile(sentinel_file):
+                error('Chapel test virtualenv is not available, run `{} '
+                      'test-venv` from {}'.format(chpl_make.get(), chpl_home))
+
+        activation_file = os.path.join(venv_dir, 'bin', 'activate_this.py')
+        if not os.path.isfile(activation_file):
+            error('Activation file {} is missing'.format(activation_file))
+
+        # actually activate
+        execfile(activation_file, dict(__file__=activation_file))
+
+
+activate_venv()


### PR DESCRIPTION
The new start_test needs to make use of the test-venv that has argparse and
subprocess32. This adds an activate_chpl_test_venv.py script that takes care of
locating the virtualenv and activating it. It also allows users to suppress
activation if they are sure they have the requirements installed locally or
they can specify a non-default virtual env.

If the default virtualenv is being used, the script will try to locate it and
warn if test-venv hasn't been built. If test-venv was successfully built, the
script will then find the activation file and activate it.

With this we can just do `from test import activate_chpl_test_venv` in
start_test rather than mixing in all the ugly activation code with the other
imports.

Additionally, this adds a top level Makefile rule for test-venv' which is
identical to 'third-party-test-venv' since that's hard to remember. It also
adds a new rule to always build test-venv if CHPL_ALWAYS_BUILD_TEST_VENV is
set. This way when developers are testing they don't have to remember to
manually build test-venv.  CHPL_ALWAYS_BUILD_TEST_VENV is being used as a key
instead of CHPL_DEVELOPER because CHPL_DEVELOPER shouldn't be set when testing
anyways.