### PR TITLE
Set GASNET_QUIET for gasnet-everything and gasnet-fast testing

### DIFF
--- a/util/cron/test-gasnet-everything.bash
+++ b/util/cron/test-gasnet-everything.bash
@@ -7,6 +7,8 @@ source $CWD/common-gasnet.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet-everything"
 
+export GASNET_QUIET=Y
+
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 

--- a/util/cron/test-gasnet-fast.bash
+++ b/util/cron/test-gasnet-fast.bash
@@ -7,6 +7,8 @@ source $CWD/common-gasnet.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet-fast"
 
+export GASNET_QUIET=Y
+
 # Test a GASNet compile using the fast segment
 export CHPL_GASNET_SEGMENT=fast
 


### PR DESCRIPTION
These test runs have been moved on the chapcs boxes, but do not use
ibv yet, so we will have to set GASNET_QUIET for now to suppress
warnings.