### PR TITLE
Add perf annotation for reverse-compliment regression from 05/11/15

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -247,6 +247,10 @@ regexdna:
   10/07/14:
     - Add c_string_copy type
 
+revcomp:
+  05/11/15:
+    - various qio changes motivated by cygwin failures (#1943)
+
 spectralnorm:
   01/21/15:
     - qthreads updated to yield every ~100 uncontested sync var locks


### PR DESCRIPTION
A change to qio (#1943) that was motivated by cygwin failures resulted in a
performance regression for reverse-compliment.