### PR TITLE
Make parSafeMember's num trials proportional to here.maxTaskPar

### DIFF
--- a/test/domains/sungeun/assoc/parSafeMember.chpl
+++ b/test/domains/sungeun/assoc/parSafeMember.chpl
@@ -1,5 +1,5 @@
 config const iters = 300;
-config const trials = 400;
+config const trials = 2000/here.maxTaskPar;
 config const n = 80;
 
 var D: domain(real);

--- a/test/domains/sungeun/assoc/parSafeMember.skipif
+++ b/test/domains/sungeun/assoc/parSafeMember.skipif
@@ -1,6 +1,1 @@
-# This machine is a really slow vm, and this test takes a really long time on
-# it. We don't want to lower the problem size or number of tasks because it's a
-# stress test meant to ensure no race conditions. This isn't a very elegant
-# solution, but if we stop using this machine, this skipif can be removed.
-HOSTNAME==cflbs32
 CHPL_ATOMICS!=intrinsics


### PR DESCRIPTION
The more cores a machine is actually using, the more contention this test will
have. The more contention, the longer it takes. This just decreases the number
of trials smaller as core count increases to avoid timeouts on machines with
lots of cores. The extra cores will increase contention per trial, so I don't
think we're losing anything by lowering the number of trials.

With gasnet segment fast on one of the new chapcs* machines, this takes
2 minutes (down from 8 that it was taking.)

Also removed a skipif for a retired machine.