### PR TITLE
Responded to .bad mismatch in dm/hplx.chpl

### DIFF
--- a/test/distributions/dm/PREDIFF
+++ b/test/distributions/dm/PREDIFF
@@ -27,12 +27,13 @@ case $testname in
      # or similar is sometimes reported in a failed run, sometimes not.
      # Ditto "FATAL ERROR: recursive failure in AMUDP_SPMDShutdown".
      #
-     egrep -i '^start...finish$|error|warning' $outputfile.orig \
-       | grep -v 'error: attempt to dereference nil' \
-       | grep -v 'FATAL ERROR:' \
+     egrep -ai '^start...finish$|error|warning' $outputfile.orig \
+       | grep -av 'error: attempt to dereference nil' \
+       | grep -av 'FATAL ERROR:' \
        > $outputfile
 
      echo retained the original output in $outputfile.orig
+     doSort=false
      ;; #hplx
 esac
 


### PR DESCRIPTION
Perhaps due to moving the testing to a different machine,
the hplx.chpl test output may now include ^@ upon
"*** FATAL ERROR: slave got an unknown command on coord socket"

When that happens, the greps in the PREDIFF report
"Binary file hplx.exec.out.tmp.orig matches"
rather than printing the matching lines.

So I am adding -a to grep commands to force them to do grepping.

While there, I am disabling sorting of the output for this test.