### PR TITLE
add all-cs nodefile, add chap02 to all-cf, decease valgrind over-subscription

### DIFF
--- a/test/Nodes/all-cf
+++ b/test/Nodes/all-cf
@@ -1,4 +1,5 @@
 chap01
+chap02
 chap05
 chap06
 chap08

--- a/test/Nodes/all-cs
+++ b/test/Nodes/all-cs
@@ -1,0 +1,12 @@
+chapcs00
+chapcs01
+chapcs02
+chapcs03
+chapcs04
+chapcs05
+chapcs06
+chapcs07
+chapcs08
+chapcs09
+chapcs10
+chapcs11

--- a/test/Nodes/valgrind-localhost
+++ b/test/Nodes/valgrind-localhost
@@ -6,5 +6,3 @@ chap11
 chap11
 chap11
 chap11
-chap11
-chap11


### PR DESCRIPTION
- Add an all-cs nodefile that has chapcs00-chapcs11.

- Also re-add chap02 to all-cf now that it's not doing gasnet testing. 

- Decrease valgrind over-subscription from 10 instances to 8:

  - We over-subscribed with valgrind testing because valgrind is slow. Valgrind
    serializes things so it's pretty safe to run over-subscribed because
    different processes won't be stepping on each other. However, chap11 (where
    valgrind currently runs) only has 8 physical cores (16) logical. I'm
    decreasing over-subscription to 8 instances so the hyperthreads don't have
    to contend with physical threads. Hopefully this resolves the recent do_smu
    timeout without increasing overall running time.

