### PR TITLE
Updates to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ tags
 /SVNLOG
 /.SVNLOG-revnum
 /bin
-/docs
 /lib
 /tar
 
@@ -39,6 +38,8 @@ tags
 # Doc ignores.
 /doc/**/*.aux
 /doc/**/*.log
+/doc/chips/html
+/doc/chips/tmp
 /doc/developer/compilerOverview/compiler.pdf
 /doc/developer/compilerOverview/compiler.dvi
 /doc/developer/compilerOverview/compiler.toc


### PR DESCRIPTION
* Remove /docs

Having /docs in .gitignore has the potential to hide a user's typo.

* Add a couple of subdirs in doc/chips

These are created when building the corresponding webpages.
