### PR TITLE
Set _DEFAULT_SOURCE to suppress warnings about _BSD_SOURCE

### DIFF
--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -22,6 +22,7 @@
 //
 
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include "chpl-visual-debug.h"
 #include "chplrt.h"


### PR DESCRIPTION
Newer versions of glibc have deprecated _BSD_SOURCE in favor of
_DEFAULT_SOURCE. Set them both to support older versions of glibc and to
suppress the warning in new versions.