### PR TITLE
Remove brackets around invalid output error in computePerfStats

### DIFF
--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -151,7 +151,7 @@ def validate_output(verify_keys, output_file):
                 print(not_found_msg)
 
         if not valid_output:
-            print("[Error: Invalid output found in {0}]".format(output_file))
+            print("Error: Invalid output found in {0}".format(output_file))
     
     return valid_output
 


### PR DESCRIPTION
start_test already reports this error. This is the only error computePerfStat
reports that is a result of a bad execution instead of a bad .dat or .perfkey
file. We want to be able to suppress this error, so we don't want the second
error from computePerfStats.

For the other failure modes we still want the double reporting because one of
the errors gives more details on the specific failure mode.