### PR TITLE
Allow start_test to work when located outside of $CHPL_HOME/util/

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -3,9 +3,17 @@
 # CHAPEL TESTING
 
 from __future__ import print_function
-from test import activate_chpl_test_venv
+
 import os
 import sys
+
+# need to be able to find the util director even when start_test doesn't live
+# in $CHPL_HOME/util (such as for the release tarball)
+util_dir = os.path.join(os.path.dirname(__file__), '..', 'util')
+sys.path.insert(0, os.path.abspath(util_dir))
+
+from test import activate_chpl_test_venv
+
 import time
 import subprocess32 as subprocess
 import argparse

--- a/util/start_test
+++ b/util/start_test
@@ -4,30 +4,30 @@
 
 from __future__ import print_function
 
+import atexit
+import contextlib
+import fnmatch
+import getpass
+import glob
+import logging
 import os
+import platform
+import re
+import shutil
 import sys
+import tempfile
+import time
 
-# need to be able to find the util director even when start_test doesn't live
+# need to be able to find the util directory even when start_test doesn't live
 # in $CHPL_HOME/util (such as for the release tarball)
 util_dir = os.path.join(os.path.dirname(__file__), '..', 'util')
 sys.path.insert(0, os.path.abspath(util_dir))
 
-from test import activate_chpl_test_venv
-
-import time
-import subprocess32 as subprocess
-import argparse
-import platform
-import re
-import getpass
-import shutil
-import tempfile
-import fnmatch
-import glob
-import contextlib
-import logging
-import atexit
 from chplenv import *
+
+from test import activate_chpl_test_venv
+import argparse
+import subprocess32 as subprocess
 
 # PROGRAM ENTRY POINT
 def main():


### PR DESCRIPTION
The imports for chplenv and the virtualenv activation were expecting start_test
to be located in a $CHPL_HOME/util/. However, we copy start_test into the
examples directory so we need to manually add $CHPL_HOME/util/ to the path
before we can activate the virtualenv and chplenv.

Also reorder the imports to make them easier to follow