### PR TITLE
Fix start_test when run on a non-relative test

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -152,8 +152,7 @@ def finish():
 def test_file(test):
     path_to_test = os.path.relpath(test)
     test_name = os.path.basename(test)
-
-    with cd(os.path.dirname("./" + test)): # cd into dir, and cd out later
+    with cd(os.path.dirname(test)): # cd into dir, and cd out later
         # clean executables, etc
         logger.write()
         logger.write("[Cleaning file {0}]".format(test))


### PR DESCRIPTION
Things like `start_test ~/chapel/test/release/examples/hello.chpl` or
start_test on an absolute file were broken because we always tried to cd into a
relative directory by prepending './' to the test.

Now we just let the existing python os.path calls figure out the absolute and
relative directories instead of manually prepending './'