### PR TITLE
Fix start_test junit processing

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1138,14 +1138,14 @@ def cleanup():
 def jUnit():
     junit_args = ["--start-test-log={0}".format(log_file)]
     if args.junit_xml_file:
-        junit_args.append(" --junit-xml={0}".format(args.junit_xml_file))
+        junit_args.append("--junit-xml={0}".format(args.junit_xml_file))
 
     if args.junit_remove_prefix:
         junit_args.append(
-                " --remove-prefix={0}".format(args.junit_remove_prefix))
+                "--remove-prefix={0}".format(args.junit_remove_prefix))
     elif args.test_root_dir:
         # if --test-root was thrown, remove it from junit report
-        junit_args.append(" --remove-prefix={0}".format(args.test_root_dir))
+        junit_args.append("--remove-prefix={0}".format(args.test_root_dir))
 
     cmd = [os.path.join(util_dir, "test", 
             "convert_start_test_log_to_junit_xml.py")]


### PR DESCRIPTION
Extra spaces around arguments passed to convert_start_test_log_to_junit_xml.py
screwed up where the xml file was actually put which meant the xc and xe jobs
couldn't find the xml output files for jenkins to parse.