### PR TITLE
Fix automatic detection of launcher timeout for slurm and pbs

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -951,9 +951,9 @@ def set_up_executables():
     # launcher timeout
     if (not os.environ.get("CHPL_LAUNCHER_TIMEOUT")
         and not os.environ.get("CHPL_TEST_DONT_SET_LAUNCHER_TIMEOUT")):
-        if launcher.find("slurm") > 0:
+        if "slurm" in launcher:
             os.environ["CHPL_LAUNCHER_TIMEOUT"] = "slurm"
-        if launcher.find("pbs") > 0 or launcher.find("qsub") > 0:
+        if "pbs" in launcher or "qsub" in launcher:
             os.environ["CHPL_LAUNCHER_TIMEOUT"] = "pbs"
 
     # comm


### PR DESCRIPTION
For certain launchers (slurm*, pbs*, qsub*) we automatically use the launcher
timeout instead of doing a timeout ourselves. The previous check for one of
these launchers did something like `if launcher.find("slurm") > 0`. `find()`
would return 0 when launcher was 'slurm-srun' because that's the index 'slurm'
started out.

The check should have been if `find() >= 0`. I changed the checks to use the in
operator instead of just updating the find.