### PR TITLE
Only strip whitespace to the right of output when writing to the logger

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1330,7 +1330,7 @@ class Logger():
         self.logger.addHandler(self.file_out)
 
     def write(self, msg=" "):
-        self.logger.info(msg.strip())
+        self.logger.info(msg.rstrip())
 
     def flush(self):
         self.console_out.flush()


### PR DESCRIPTION
We want to get rid of misc new lines since the logger will add it's own.
However, we don't want to strip spaces to the left of any output as they many
be intentional