### PR TITLE
Fix start_test when run with --clean-only

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -141,7 +141,7 @@ def finish():
     logger.stop()
 
     # exit, returning 0 if no failures and 2 if there were some
-    if failures == 0:
+    if args.clean_only or failures == 0:
         sys.exit(0)
     else:
         sys.exit(2)


### PR DESCRIPTION
Don't try to print out failures when run with --clean-only