### PR TITLE
Use '0' instead of 'nil' as the followThis for isRefIter() tests

### DIFF
--- a/test/functions/iterators/elliot/isRefIter/class-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/class-isRefIter.chpl
@@ -40,8 +40,8 @@ writeln(isRefIter(c.myRefIter(tag=iterKind.standalone)));
 writeln(isRefIter(c.myValIter(tag=iterKind.leader)));
 writeln(isRefIter(c.myRefIter(tag=iterKind.leader)));
 
-writeln(isRefIter(c.myValIter(tag=iterKind.follower, nil)));
-writeln(isRefIter(c.myRefIter(tag=iterKind.follower, nil)));
+writeln(isRefIter(c.myValIter(tag=iterKind.follower, 0)));
+writeln(isRefIter(c.myRefIter(tag=iterKind.follower, 0)));
 
 
 //
@@ -59,8 +59,8 @@ printIterRefness(c.myRefIter(tag=iterKind.standalone));
 printIterRefness(c.myValIter(tag=iterKind.leader));
 printIterRefness(c.myRefIter(tag=iterKind.leader));
 
-printIterRefness(c.myValIter(tag=iterKind.follower, nil));
-printIterRefness(c.myRefIter(tag=iterKind.follower, nil));
+printIterRefness(c.myValIter(tag=iterKind.follower, 0));
+printIterRefness(c.myRefIter(tag=iterKind.follower, 0));
 
 
 //
@@ -84,5 +84,5 @@ for i in printIterRefnessWrapper(c.myRefIter(tag=iterKind.standalone)) do;
 for i in printIterRefnessWrapper(c.myValIter(tag=iterKind.leader)) do;
 for i in printIterRefnessWrapper(c.myRefIter(tag=iterKind.leader)) do
 
-for i in printIterRefnessWrapper(c.myValIter(tag=iterKind.follower, nil)) do;
-for i in printIterRefnessWrapper(c.myRefIter(tag=iterKind.follower, nil)) do;
+for i in printIterRefnessWrapper(c.myValIter(tag=iterKind.follower, 0)) do;
+for i in printIterRefnessWrapper(c.myRefIter(tag=iterKind.follower, 0)) do;

--- a/test/functions/iterators/elliot/isRefIter/class-ref-these-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/class-ref-these-isRefIter.chpl
@@ -30,7 +30,7 @@ writeln(isRefIter(c.these(tag=iterKind.standalone)));
 
 writeln(isRefIter(c.these(tag=iterKind.leader)));
 
-writeln(isRefIter(c.these(tag=iterKind.follower, nil)));
+writeln(isRefIter(c.these(tag=iterKind.follower, 0)));
 
 
 //
@@ -46,7 +46,7 @@ printIterRefness(c.these(tag=iterKind.standalone));
 
 printIterRefness(c.these(tag=iterKind.leader));
 
-printIterRefness(c.these(tag=iterKind.follower, nil));
+printIterRefness(c.these(tag=iterKind.follower, 0));
 
 
 //
@@ -68,7 +68,7 @@ for i in printIterRefnessWrapper(c.these(tag=iterKind.standalone)) do;
 
 for i in printIterRefnessWrapper(c.these(tag=iterKind.leader)) do;
 
-for i in printIterRefnessWrapper(c.these(tag=iterKind.follower, nil)) do;
+for i in printIterRefnessWrapper(c.these(tag=iterKind.follower, 0)) do;
 
 
 //

--- a/test/functions/iterators/elliot/isRefIter/class-val-these-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/class-val-these-isRefIter.chpl
@@ -30,7 +30,7 @@ writeln(isRefIter(c.these(tag=iterKind.standalone)));
 
 writeln(isRefIter(c.these(tag=iterKind.leader)));
 
-writeln(isRefIter(c.these(tag=iterKind.follower, nil)));
+writeln(isRefIter(c.these(tag=iterKind.follower, 0)));
 
 
 //
@@ -46,7 +46,7 @@ printIterRefness(c.these(tag=iterKind.standalone));
 
 printIterRefness(c.these(tag=iterKind.leader));
 
-printIterRefness(c.these(tag=iterKind.follower, nil));
+printIterRefness(c.these(tag=iterKind.follower, 0));
 
 
 //
@@ -68,7 +68,7 @@ for i in printIterRefnessWrapper(c.these(tag=iterKind.standalone)) do;
 
 for i in printIterRefnessWrapper(c.these(tag=iterKind.leader)) do;
 
-for i in printIterRefnessWrapper(c.these(tag=iterKind.follower, nil)) do;
+for i in printIterRefnessWrapper(c.these(tag=iterKind.follower, 0)) do;
 
 
 //

--- a/test/functions/iterators/elliot/isRefIter/record-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/record-isRefIter.chpl
@@ -40,8 +40,8 @@ writeln(isRefIter(r.myRefIter(tag=iterKind.standalone)));
 writeln(isRefIter(r.myValIter(tag=iterKind.leader)));
 writeln(isRefIter(r.myRefIter(tag=iterKind.leader)));
 
-writeln(isRefIter(r.myValIter(tag=iterKind.follower, nil)));
-writeln(isRefIter(r.myRefIter(tag=iterKind.follower, nil)));
+writeln(isRefIter(r.myValIter(tag=iterKind.follower, 0)));
+writeln(isRefIter(r.myRefIter(tag=iterKind.follower, 0)));
 
 
 //
@@ -59,8 +59,8 @@ printIterRefness(r.myRefIter(tag=iterKind.standalone));
 printIterRefness(r.myValIter(tag=iterKind.leader));
 printIterRefness(r.myRefIter(tag=iterKind.leader));
 
-printIterRefness(r.myValIter(tag=iterKind.follower, nil));
-printIterRefness(r.myRefIter(tag=iterKind.follower, nil));
+printIterRefness(r.myValIter(tag=iterKind.follower, 0));
+printIterRefness(r.myRefIter(tag=iterKind.follower, 0));
 
 
 //
@@ -84,5 +84,5 @@ for i in printIterRefnessWrapper(r.myRefIter(tag=iterKind.standalone)) do;
 for i in printIterRefnessWrapper(r.myValIter(tag=iterKind.leader)) do;
 for i in printIterRefnessWrapper(r.myRefIter(tag=iterKind.leader)) do
 
-for i in printIterRefnessWrapper(r.myValIter(tag=iterKind.follower, nil)) do;
-for i in printIterRefnessWrapper(r.myRefIter(tag=iterKind.follower, nil)) do;
+for i in printIterRefnessWrapper(r.myValIter(tag=iterKind.follower, 0)) do;
+for i in printIterRefnessWrapper(r.myRefIter(tag=iterKind.follower, 0)) do;

--- a/test/functions/iterators/elliot/isRefIter/record-ref-these-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/record-ref-these-isRefIter.chpl
@@ -30,7 +30,7 @@ writeln(isRefIter(r.these(tag=iterKind.standalone)));
 
 writeln(isRefIter(r.these(tag=iterKind.leader)));
 
-writeln(isRefIter(r.these(tag=iterKind.follower, nil)));
+writeln(isRefIter(r.these(tag=iterKind.follower, 0)));
 
 
 //
@@ -46,7 +46,7 @@ printIterRefness(r.these(tag=iterKind.standalone));
 
 printIterRefness(r.these(tag=iterKind.leader));
 
-printIterRefness(r.these(tag=iterKind.follower, nil));
+printIterRefness(r.these(tag=iterKind.follower, 0));
 
 
 //
@@ -68,7 +68,7 @@ for i in printIterRefnessWrapper(r.these(tag=iterKind.standalone)) do;
 
 for i in printIterRefnessWrapper(r.these(tag=iterKind.leader)) do;
 
-for i in printIterRefnessWrapper(r.these(tag=iterKind.follower, nil)) do;
+for i in printIterRefnessWrapper(r.these(tag=iterKind.follower, 0)) do;
 
 
 //

--- a/test/functions/iterators/elliot/isRefIter/record-val-these-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/record-val-these-isRefIter.chpl
@@ -30,7 +30,7 @@ writeln(isRefIter(r.these(tag=iterKind.standalone)));
 
 writeln(isRefIter(r.these(tag=iterKind.leader)));
 
-writeln(isRefIter(r.these(tag=iterKind.follower, nil)));
+writeln(isRefIter(r.these(tag=iterKind.follower, 0)));
 
 
 //
@@ -46,7 +46,7 @@ printIterRefness(r.these(tag=iterKind.standalone));
 
 printIterRefness(r.these(tag=iterKind.leader));
 
-printIterRefness(r.these(tag=iterKind.follower, nil));
+printIterRefness(r.these(tag=iterKind.follower, 0));
 
 
 //
@@ -68,7 +68,7 @@ for i in printIterRefnessWrapper(r.these(tag=iterKind.standalone)) do;
 
 for i in printIterRefnessWrapper(r.these(tag=iterKind.leader)) do;
 
-for i in printIterRefnessWrapper(r.these(tag=iterKind.follower, nil)) do;
+for i in printIterRefnessWrapper(r.these(tag=iterKind.follower, 0)) do;
 
 
 //

--- a/test/functions/iterators/elliot/isRefIter/standalone-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/standalone-isRefIter.chpl
@@ -38,8 +38,8 @@ writeln(isRefIter(myRefIter(tag=iterKind.standalone)));
 writeln(isRefIter(myValIter(tag=iterKind.leader)));
 writeln(isRefIter(myRefIter(tag=iterKind.leader)));
 
-writeln(isRefIter(myValIter(tag=iterKind.follower, nil)));
-writeln(isRefIter(myRefIter(tag=iterKind.follower, nil)));
+writeln(isRefIter(myValIter(tag=iterKind.follower, 0)));
+writeln(isRefIter(myRefIter(tag=iterKind.follower, 0)));
 
 
 //
@@ -57,8 +57,8 @@ printIterRefness(myRefIter(tag=iterKind.standalone));
 printIterRefness(myValIter(tag=iterKind.leader));
 printIterRefness(myRefIter(tag=iterKind.leader));
 
-printIterRefness(myValIter(tag=iterKind.follower, nil));
-printIterRefness(myRefIter(tag=iterKind.follower, nil));
+printIterRefness(myValIter(tag=iterKind.follower, 0));
+printIterRefness(myRefIter(tag=iterKind.follower, 0));
 
 
 //
@@ -82,5 +82,5 @@ for i in printIterRefnessWrapper(myRefIter(tag=iterKind.standalone)) do;
 for i in printIterRefnessWrapper(myValIter(tag=iterKind.leader)) do;
 for i in printIterRefnessWrapper(myRefIter(tag=iterKind.leader)) do
 
-for i in printIterRefnessWrapper(myValIter(tag=iterKind.follower, nil)) do;
-for i in printIterRefnessWrapper(myRefIter(tag=iterKind.follower, nil)) do;
+for i in printIterRefnessWrapper(myValIter(tag=iterKind.follower, 0)) do;
+for i in printIterRefnessWrapper(myRefIter(tag=iterKind.follower, 0)) do;


### PR DESCRIPTION
Use '0' instead of 'nil' as the followThis for isRefIter() tests to avoid a
--no-local error.
