### PR TITLE
Test performance of string-as-rec branch in perf playground

### DIFF
--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -6,12 +6,14 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04.playground"
 
-# Test performance of parallel init_elts
+# Test performance of string-as-rec branch
 #
 # Graph the default config and this config side by side to make comparison
 # easy, but sync to a different direction so the default chap04 graphs don't
 # have multiple configurations.
 
-perf_args="-performance-description par-init -performance-configs default:v,par-init:v -sync-dir-suffix par-init"
-perf_args="${perf_args} -numtrials 5 -startdate 07/30/15 -compopts -sparallelInitElts"
-$CWD/nightly -cron ${perf_args} ${nightly_args}
+git checkout string-as-rec
+
+perf_args="-performance-description amm -performance-configs default:v,amm:v -sync-dir-suffix amm"
+perf_args="${perf_args} -numtrials 5 -startdate 08/12/15"
+$CWD/nightly -cron -debug ${perf_args} ${nightly_args}


### PR DESCRIPTION
update perf playground to checkout the string-as-rec branch before kicking off
nightly.