### PR TITLE
Fields narrow by default

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1178,7 +1178,6 @@ GenRet codegenRaddr(GenRet wide)
  
   if( wide.isLVPtr != GEN_WIDE_PTR && isWideString(wide.chplType)) {
    ret = codegenWideThingField(wide, WIDE_GEP_ADDR);
-
    ret.chplType = dtString;
    return ret;
   }
@@ -3302,7 +3301,6 @@ void codegenAssign(GenRet to_ptr, GenRet from)
       }
     } else {
       // not a homogeneous tuple copy
-      // FOOBAR HERE
       if( info->cfile ) {
         std::string stmt = codegenValue(to_ptr).c + " = ";
         stmt += codegenValue(from).c;
@@ -4048,7 +4046,6 @@ GenRet CallExpr::codegen() {
          case PRIM_GET_MEMBER:
          {
           /* Get a pointer to a member */
-          if (this->id == 887352) gdbShouldBreakHere();
           SymExpr* se = toSymExpr(call->get(2));
           if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
               call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
@@ -4263,8 +4260,6 @@ GenRet CallExpr::codegen() {
        }
       } // End of special-case handling for primitives in the RHS of MOVE.
 
-      if (this->id == 1154766) gdbShouldBreakHere();
-
       // Handle general cases of PRIM_MOVE.
       if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) &&
           !get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
@@ -4277,10 +4272,6 @@ GenRet CallExpr::codegen() {
       }
       if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
           get(2)->typeInfo()->symbol->hasFlag(FLAG_REF)) {
-        if (get(1)->getValType() != get(2)->getValType()) {
-          gdbShouldBreakHere();
-          printf("problem for %d\n", this->id);
-        }
         codegenAssign(get(1), codegenAddrOf(codegenWideHere(get(2))));
         break;
       }

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4073,6 +4073,10 @@ GenRet CallExpr::codegen() {
             elemPtr = codegenAddrOf(elemPtr);
             codegenAssign(get(1), elemPtr);
           }
+          else if (get(1)->getValType() != call->getValType()) {
+            GenRet getElem = codegenElementPtr(call->get(1), codegenExprMinusOne(call->get(2)));
+            codegenAssign(get(1), codegenAddrOf(codegenWideThingField(getElem, WIDE_GEP_ADDR)));
+          }
           else
             handled = false;
           break;

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4055,6 +4055,7 @@ GenRet CallExpr::codegen() {
                 get(1), codegenAddrOf(codegenFieldPtr(call->get(1), se))); 
           }
           else if (get(1)->getValType() != call->get(2)->typeInfo()) {
+            // get a narrow reference to the actual 'addr' field of the wide pointer
             GenRet getField = codegenFieldPtr(call->get(1), se);
             codegenAssign(get(1), codegenAddrOf(codegenWideThingField(getField, WIDE_GEP_ADDR)));
           }

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -650,7 +650,10 @@ static void addKnownWides() {
     if (!typeCanBeWide(var)) continue;
 
     if (isField(var)) {
-      // ?
+      TypeSymbol* ts = toTypeSymbol(var->defPoint->parentSymbol);
+      if (strcmp(ts->name, "_class_localson_fn") == 0) {
+        setWide(var);
+      }
     } else {
       Symbol* defParent = var->defPoint->parentSymbol;
 
@@ -1606,6 +1609,8 @@ static void insertWideTemp(Type* type, SymExpr* src) {
     stmt->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_ADDR_OF, wideThing)));
     RHS = new SymExpr(tmp);
   }
+  
+  // Now make the fully wide thing
   VarSymbol* tmp = newTemp(type);
   stmt->insertBefore(new DefExpr(tmp));
   stmt->insertBefore(new CallExpr(PRIM_MOVE, tmp, RHS->copy()));

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -437,7 +437,7 @@ static void widenRef(Symbol* src, Symbol* dest) {
 // Abstract special casing for refs away if we just want an easy
 // way to say that two variables need to have the same wideness.
 static void matchWide(Symbol* src, Symbol* dest) {
-  if (isRef(src)) {
+  if (isRef(src) && isRef(dest)) {
     widenRef(src, dest);
   } else {
     setWide(dest);

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -262,8 +262,8 @@ static Type* getNarrowType(BaseAST* bs) {
   }
 }
 
-static bool hasSomeWideness(Symbol* sym) {
-  return isFullyWide(sym) || valIsWideClass(sym);
+static bool hasSomeWideness(BaseAST* bs) {
+  return isFullyWide(bs) || valIsWideClass(bs);
 }
 
 static bool isRef(BaseAST* bs) {
@@ -913,6 +913,9 @@ static void propagateVar(Symbol* sym) {
             SymExpr* se = toSymExpr(rhs->get(1));
             debug(sym, "ref has a wide _val, src %s (%d) of addr_of must be wide\n", se->var->cname, se->var->id);
             setWide(se);
+          }
+          else if (rhs->isResolved()) {
+            matchWide(sym, rhs->isResolved()->getReturnSymbol());
           }
           else if (isRef(sym)) {
             if (rhs->isPrimitive(PRIM_GET_MEMBER_VALUE) || 


### PR DESCRIPTION
This patch is an optimization for --no-local programs. Previously, fields with a class or ref type were widened by default. While this results in correct behavior, there are a few cases where performance is worse off.

An example of poor performance can be found in the stream-ep benchmark. This benchmark has a simple loop iteration like this:

```chpl
forall (a, b, c) in zip(A, B, C) do 
  a = b + alpha * c
```

At some point the compiler wraps the arrays `A`, `B`, and `C` into a tuple. Because fields were widened by default, when these tuple fields were later accessed we had to assume that they were wide. This results in overhead for array accesses, which is bad for a memory-bound benchmark like stream-ep.

My solution to this problem is to no longer assume that fields are wide by default. This is fairly straightforward for most classes and records.

### Uses of Tuple Fields

Tuples are more challenging to deal with because buildDefUseMaps doesn't correctly account for uses and defs of tuple fields. Within this pass I have written code to update the useMap and defMap to account for tuple fields.

Star tuples are another challenge. Because they can be indexed by runtime values, it can be impossible to tell which field is used. If the use would call for a field to be widened, we then have to widen all fields in that tuple.

### Fixing the AST

Once the semantic wideness has been propagated through the AST, we still have to fix some types so that codegen can run correctly. Mainly, if a field is read on another locale (such that it's containing aggregate type is wide), then that field must have a wide type. Ref fields are a problem here, because I'm not sure how to do an assignment like this:

```
baseType->refToWideClass = refToNarrowClass
```
My initial reaction was to create a wide temporary and to get the address of that wide temp. This is bad because that wide temporary is on the stack, and any pointer to it is useless. Future development should try to improve this situation.

----

If a field is never read from another locale, then it will remain narrow. This is convenient for tuple wrappers and results in fewer wide temporaries in the program.

However, this leaves the AST in a weird state where fields with wide types are accessed as though they were narrow. More work on the fixAST function was required to insert more temporaries to get down to a completely (or mostly) narrow type.

Some work was required in codegen for cases that required references to fields. The problem was that we needed a reference to the `addr` field in the wide pointer. Usual AST primitives tend to create copies of the wide pointer struct, which is bad if the `addr` field is null. To avoid creating such copies, the easiest solution seemed to be to fix this case directly in codegen.

### Tuples in on-stmt Bundles

The last peculiar issue is with tuples again. Sometimes a tuple will be wrapped in an arg bundle for an on-statement. Within the body of the on-statement, assignments to fields of that tuple may occur. If assigned to with data local to the on-statement body, then my usual code couldn't detect that the field now had to be wide. The solution was to recursively widen fields in tuples that are members of arg bundles for on-statements. This tries to identify fields that cross a locale, and should be wide if assigned to on the destination locale.

-----

### Misc
While developing this patch, I came across a couple of small-ish things to fix:
- Fixed the 'refType' for wide classes
- Actuals in ftable calls were widened unnecessarily

-----

This isn't a perfect solution to wide fields, but should be a good first-step for fields that never cross a locale.

#### TODO
- [x] Complete --local testing
- [x] Complete --no-local testing
- [x] Partial multilocale testing