### PR TITLE
Fixed problem with invalid file resulting in running all tests

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -46,6 +46,7 @@ def main():
 def run_tests(tests):
     files = []
     dirs = []
+    had_invalid_file = False
     for i in tests:
         if os.path.isdir(i): # a directory (also get absolute path)
             dirs.append(os.path.abspath(i))
@@ -54,6 +55,10 @@ def run_tests(tests):
         else:
             print("[Error: {0} is not a valid file or directory]"
                     .format(i))
+            had_invalid_file = True
+
+    if had_invalid_file and len(files) == 0 and len(dirs) == 0:
+        sys.exit(2)
 
     # set up
     set_up_environment()


### PR DESCRIPTION
If a user entered a test that didn't exist, start_test would note the problem,
then start running all tests in the current directory.  This PR fixes that,
stopping execution if all the tests the user specified aren't valid.