### PR TITLE
Enable local blocks on string-as-rec

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -1399,7 +1399,7 @@ static void handleLocalBlocks() {
       if (block->isLoopStmt() == true) {
 
       } else if (block->blockInfoGet()) {
-        if (block->blockInfoGet()->isPrimitive(PRIM_BLOCK_LOCAL) && false) {
+        if (block->blockInfoGet()->isPrimitive(PRIM_BLOCK_LOCAL)) {
           queue.add(block);
         }
       }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -681,7 +681,7 @@ proc chpl__autoDestroy(x: DefaultDist) {
 
     proc ~DefaultRectangularArr() {
       on dom {
-        local dom.remove_arr(this);
+        dom.remove_arr(this);
         if ! noRefCount {
           var cnt = dom.destroyDom();
           if cnt == 0 then


### PR DESCRIPTION
This patch enables local blocks on string-as-rec. It also fixes a now-incorrect usage of the local block in DefaultRectangular.