### PR TITLE
Fix followThis tests that were failing due to freed (stack) memory ac…

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4075,15 +4075,6 @@ formalRequiresTemp(ArgSymbol* formal) {
      //
      ((formal->intent == INTENT_IN || formal->intent == INTENT_CONST_IN) &&
       (backendRequiresCopyForIn(formal->type) || !fn->hasFlag(FLAG_INLINE)))
-     //
-     // The following case reduces memory leaks for zippered forall
-     // leader/follower pairs where the communicated intermediate
-     // result is a tuple of ranges, but I can't explain why it'd be
-     // needed.  Tom has said that iterators haven't really been
-     // bolted down in terms of memory leaks, so future work would be
-     // to remove this hack and close the leak properly.
-     //
-     || strcmp(formal->name, "followThis") == 0
      );
 }
 


### PR DESCRIPTION
…cesses.

There was special-case code inserted at the end of formalRequiresTemp() in
resolution that forced a local copy of the followThis argument.  The local copy
is then captured by reference in an iterator record and returned.  Later
references to the captured copy end up referencing what is effectively garbage
on the stack, since the formal temp is no longer there and that area on the
stack has been converted to other uses.

There are a number of ways to address the problem:
 - Don't create the local formal temp,
 - Mark the local formal temp with the FLAG_TEMP_IN_ITERATOR flag so it gets
   captured by value in the iterator.
 - Move the declaration of the formal temp to an outer scope where it will
   outlast the iteration.
This patch takes the first option.  It relies on the reference passed in by the
caller to also outlast the iteration, but at least it pushes the problem one
level up the stack.

It also addresses the failing test case
  distributions/robust/arithmetic/modules/test_module_Random.chpl
and others.

[on behalf of vass]