### PR TITLE
Better handle FLAG_IGNORE_NOINIT

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1415,6 +1415,7 @@ void initPrimitiveTypes() {
   dtReal[FLOAT_SIZE_64]                = createPrimitiveType("real",     "_real64");
 
   dtStringC                            = createPrimitiveType("c_string", "c_string" );
+  dtStringC->symbol->addFlag(FLAG_IGNORE_NOINIT);
 
   dtString                             = new AggregateType(AGGREGATE_RECORD);
 
@@ -1495,6 +1496,7 @@ void initPrimitiveTypes() {
   dtStringCopy = createPrimitiveType( "c_string_copy", "c_string_copy" );
   dtStringCopy->defaultValue = gOpaque;
   dtStringCopy->symbol->addFlag(FLAG_NO_CODEGEN);
+  dtStringCopy->symbol->addFlag(FLAG_IGNORE_NOINIT);
 
   CREATE_DEFAULT_SYMBOL(dtStringCopy, gStringCopy, "_nullString");
   gStringCopy->cname = "NULL";

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -65,22 +65,22 @@ module CString {
   //       assignment out of these fuctions, causing acess to uninitalized
   //       memory for c_string_copy
   pragma "init copy fn"
-  inline proc chpl__initCopy(x: c_string) /*: c_string*/ {
+  inline proc chpl__initCopy(x: c_string) : c_string {
     return x;
   }
   pragma "init copy fn"
-  inline proc chpl__initCopy(x: c_string_copy) /*: c_string_copy*/ {
+  inline proc chpl__initCopy(x: c_string_copy) : c_string_copy {
     return x;
   }
 
   pragma "donor fn"
   pragma "auto copy fn"
-  inline proc chpl__autoCopy(x: c_string) /*: c_string*/ {
+  inline proc chpl__autoCopy(x: c_string) : c_string {
     return x;
   }
   pragma "donor fn"
   pragma "auto copy fn"
-  inline proc chpl__autoCopy(x: c_string_copy) /*: c_string_copy*/ {
+  inline proc chpl__autoCopy(x: c_string_copy) : c_string_copy {
     return x;
   }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -219,7 +219,7 @@ module String {
     // Localize gets a version of this that is on the currently executing
     // locale. If this is already on the current locale we return a shallow
     // copy, otherwise a remote copy is performed.
-    inline proc localize() /*: string*/ {
+    inline proc localize() : string {
         const ret: string = if this.locale.id != chpl_nodeID
           then this // assignment makes it local
           else new string(this, owned=false);
@@ -238,14 +238,14 @@ module String {
     }
 
     // TODO: cant explicitly state return type right now due to a bug in the
-    // compiler. Uncomment this funciton and others when possible.
-    iter these() /*: string*/ {
+    // compiler. Uncomment this function and others when possible.
+    iter these() : string {
       for i in 1..this.len {
         yield this[i];
       }
     }
 
-    proc this(i: int) /*: string*/ {
+    proc this(i: int) : string {
       if i <= 0 || i > this.len then halt("index out of bounds of string");
 
       var ret: string;
@@ -288,7 +288,7 @@ module String {
     }
 
     // TODO: I wasn't very good about caching variables locally in this one.
-    proc this(r: range(?)) /*: string*/ {
+    proc this(r: range(?)) : string {
       var ret: string;
       if this.isEmptyString() then return ret;
 
@@ -481,7 +481,7 @@ module String {
 
     // TODO: not ideal - count and single allocation probably faster
     //                 - can special case on replacement|needle.length (0, 1)
-    proc replace(needle: string, replacement: string, count: int = -1) /*: string*/ {
+    proc replace(needle: string, replacement: string, count: int = -1) : string {
       var result: string = this;
       var found: int = 0;
       var startIdx: int = 1;
@@ -500,13 +500,13 @@ module String {
     }
 
     // TODO: Make this support spliting on whitespace rather than just a space
-    iter split(maxsplit: int = -1, ignoreEmpty: bool = false) /*: string*/ {
+    iter split(maxsplit: int = -1, ignoreEmpty: bool = false) : string {
       for s in this.split(" ", maxsplit, ignoreEmpty) {
         yield s;
       }
     }
 
-    iter split(sep: string, maxsplit: int = -1, ignoreEmpty: bool = false) /*: string*/ {
+    iter split(sep: string, maxsplit: int = -1, ignoreEmpty: bool = false) : string {
       if !(maxsplit == 0 && ignoreEmpty && this.isEmptyString()) {
         const localThis: string = this.localize();
         const localSep: string = sep.localize();
@@ -551,7 +551,7 @@ module String {
     }
 
     // TODO: could rewrite to have cleaner logic / more efficient for edge cases
-    proc join(S: [] string) /*: string*/ {
+    proc join(S: [] string) : string {
       var newSize: int = 0;
       var ret: string;
       if S.size > 1 {
@@ -589,7 +589,7 @@ module String {
       return ret;
     }
 
-    proc strip(chars: string, leading=true, trailing=true) /*: string*/ {
+    proc strip(chars: string, leading=true, trailing=true) : string {
       if this.isEmptyString() then return "";
       if chars.isEmptyString() then return this;
 
@@ -626,14 +626,14 @@ module String {
       return localThis[start..end];
     }
 
-    inline proc strip(leading=true, trailing=true) /*: string*/ {
+    inline proc strip(leading=true, trailing=true) : string {
       return this.strip(" \t\r\n", leading, trailing);
     }
 
     // TODO: I could make this and other routines that use find faster by
     // making a version of search helper that only takes in local strings and
     // localizing in the calling function
-    proc partition(sep: string) /*: 3*string*/ {
+    proc partition(sep: string) : 3*string {
       const idx = this.find(sep);
       if idx != 0 {
         return (this[..idx-1], sep, this[idx+sep.length..]);
@@ -794,7 +794,7 @@ module String {
       return result;
     }
 
-    proc toLower() /*: string*/ {
+    proc toLower() : string {
       var result: string = this;
       if result.isEmptyString() then return result;
 
@@ -807,7 +807,7 @@ module String {
       return result;
     }
 
-    proc toUpper() /*: string*/ {
+    proc toUpper() : string {
       var result: string = this;
       if result.isEmptyString() then return result;
 
@@ -820,7 +820,7 @@ module String {
       return result;
     }
 
-    proc toTitle() /*: string*/ {
+    proc toTitle() : string {
       var result: string = this;
       if result.isEmptyString() then return result;
 
@@ -847,7 +847,7 @@ module String {
       return result;
     }
 
-    proc capitalize() /*: string*/ {
+    proc capitalize() : string {
       var result: string = this.toLower();
       if result.isEmptyString() then return result;
 
@@ -1222,7 +1222,7 @@ module String {
   //
   // Append
   //
-  proc +=(ref lhs: string, rhs: string) /*: void*/ {
+  proc +=(ref lhs: string, rhs: string) : void {
     // if rhs is empty, nothing to do
     if rhs.len == 0 then return;
 
@@ -1441,11 +1441,11 @@ module String {
   // Developer Extras
   //
 
-  proc chpldev_refToString(ref arg) /*: string*/ {
+  proc chpldev_refToString(ref arg) : string {
     // print out the address of class references as well
-    proc chpldev_classToString(x: object) /*: string*/
+    proc chpldev_classToString(x: object) : string
       return " (class = " + __primitive("ref to string", x) + ")";
-    proc chpldev_classToString(x) /*: string*/ return "";
+    proc chpldev_classToString(x) : string return "";
 
     return __primitive("ref to string", arg) + chpldev_classToString(arg);
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -500,13 +500,15 @@ module String {
     }
 
     // TODO: Make this support spliting on whitespace rather than just a space
-    iter split(maxsplit: int = -1, ignoreEmpty: bool = false) : string {
+    // TODO: specifying return type leads to un-inited string?
+    iter split(maxsplit: int = -1, ignoreEmpty: bool = false) /* : string*/ {
       for s in this.split(" ", maxsplit, ignoreEmpty) {
         yield s;
       }
     }
 
-    iter split(sep: string, maxsplit: int = -1, ignoreEmpty: bool = false) : string {
+    // TODO: specifying return type leads to un-inited string?
+    iter split(sep: string, maxsplit: int = -1, ignoreEmpty: bool = false) /* : string */ {
       if !(maxsplit == 0 && ignoreEmpty && this.isEmptyString()) {
         const localThis: string = this.localize();
         const localSep: string = sep.localize();

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -105,7 +105,7 @@ module StringCasts {
   //
   // real & imag
   //
-  inline proc _real_cast_helper(x: real(64), param isImag: bool) /*: string*/ {
+  inline proc _real_cast_helper(x: real(64), param isImag: bool) : string {
     extern proc real_to_c_string_copy(x:real(64), isImag: bool) : c_string_copy;
     extern proc strlen(const str: c_string_copy) : size_t;
 

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -490,7 +490,7 @@ proc copyTree(src: string, dest: string, copySymbolically: bool=false) {
 }
 
 pragma "no doc"
-proc locale.cwd(out error: syserr)/*: string*/ {
+proc locale.cwd(out error: syserr): string {
   extern proc chpl_fs_cwd(ref working_dir:c_string_copy):syserr;
 
   var ret:string;
@@ -522,7 +522,7 @@ proc locale.cwd(out error: syserr)/*: string*/ {
    :return: The current working directory for the locale in question.
    :rtype: string
 */
-proc locale.cwd()/*: string*/ {
+proc locale.cwd(): string {
   var err: syserr = ENOERR;
   var ret = cwd(err);
   if err != ENOERR then ioerror(err, "in cwd");
@@ -578,7 +578,7 @@ proc exists(name: string): bool {
 */
 
 iter findfiles(const in startdir: string = ".", recursive: bool = false, 
-               hidden: bool = false)/*: string*/ {
+               hidden: bool = false) : string {
   if (recursive) then
     for subdir in walkdirs(startdir, hidden=hidden) do
       for file in listdir(subdir, hidden=hidden, dirs=false, files=true, listlinks=true) do
@@ -590,7 +590,7 @@ iter findfiles(const in startdir: string = ".", recursive: bool = false,
 
 pragma "no doc"
 iter findfiles(const in startdir: string = ".", recursive: bool = false, 
-               hidden: bool = false, param tag: iterKind)/*: string */
+               hidden: bool = false, param tag: iterKind) : string
        where tag == iterKind.standalone {
   if (recursive) then
     forall subdir in walkdirs(startdir, hidden=hidden) do
@@ -740,7 +740,7 @@ module chpl_glob_c_interface {
 
    :yield: The matching filenames as strings
 */
-iter glob(const in pattern: string = "*")/*: string*/ {
+iter glob(const in pattern: string = "*") : string {
   var glb : chpl_glob_c_interface.glob_t;
 
   const err = chpl_glob_c_interface.chpl_glob(pattern.c_str(), 0, glb);
@@ -761,7 +761,7 @@ iter glob(const in pattern: string = "*")/*: string*/ {
 
 
 pragma "no doc"
-  iter glob(const in pattern: string = "*", param tag: iterKind)/*: string*/
+  iter glob(const in pattern: string = "*", param tag: iterKind) : string
        where tag == iterKind.standalone {
   var glb : chpl_glob_c_interface.glob_t;
 
@@ -808,7 +808,7 @@ iter glob(const in pattern: string = "*", param tag: iterKind)
 }
 
 pragma "no doc"
-iter glob(const in pattern: string = "*", followThis, param tag: iterKind)/*: string */
+iter glob(const in pattern: string = "*", followThis, param tag: iterKind) : string
        where tag == iterKind.follower {
   var glb : chpl_glob_c_interface.glob_t;
   if (followThis.size != 1) then
@@ -988,7 +988,7 @@ proc isMount(name: string): bool {
    :yield: The names of the specified directory's contents, as strings
 */
 iter listdir(const in path: string = ".", hidden: bool = false, dirs: bool = true, 
-             files: bool = true, listlinks: bool = true) // : string
+             files: bool = true, listlinks: bool = true) : string
   {
   extern type DIRptr;
   extern type direntptr;
@@ -1281,7 +1281,7 @@ proc locale.umask(mask: int): int {
 */
 iter walkdirs(const in path: string = ".", topdown: bool = true, depth: int = max(int),
               hidden: bool = false, followlinks: bool = false, 
-              sort: bool = false)/*: string*/ {
+              sort: bool = false) : string {
 
   if (topdown) then
     yield path;
@@ -1312,7 +1312,7 @@ iter walkdirs(const in path: string = ".", topdown: bool = true, depth: int = ma
 pragma "no doc"
 iter walkdirs(const in path: string = ".", topdown: bool = true, depth: int =max(int), 
               hidden: bool = false, followlinks: bool = false, 
-              sort: bool = false, param tag: iterKind)//: string 
+              sort: bool = false, param tag: iterKind) : string 
        where tag == iterKind.standalone {
 
   if (sort) then

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -66,7 +66,7 @@ proc realPath(out error: syserr, name: string): string {
    :return: A canonical version of the argument.
    :rtype: string
 */
-proc realPath(name: string) // : string
+proc realPath(name: string) : string
 {
   var err: syserr = ENOERR;
   var ret = realPath(err, name);
@@ -75,7 +75,7 @@ proc realPath(name: string) // : string
 }
 
 pragma "no doc"
-proc file.realPath(out error: syserr)//: string
+proc file.realPath(out error: syserr) : string
 {
   extern proc chpl_fs_realpath_file(path: qio_file_ptr_t, ref shortened: c_string_copy): syserr;
 
@@ -104,7 +104,7 @@ proc file.realPath(out error: syserr)//: string
             occur
    :rtype: string
 */
-proc file.realPath()// : string 
+proc file.realPath() : string 
 {
   var err: syserr = ENOERR;
   var ret = realPath(err);

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -406,7 +406,7 @@ extern proc qio_regexp_replace(ref re:qio_regexp_t, repl:c_string, repllen:int(6
 // (or any way to use 'nil' in pass-by-ref)
 // This one is documented below.
 pragma "no doc"
-proc compile(pattern: string, utf8=true, posix=false, literal=false, nocapture=false, /*i*/ ignorecase=false, /*m*/ multiline=false, /*s*/ dotnl=false, /*U*/ nongreedy=false)//:regexp
+proc compile(pattern: string, utf8=true, posix=false, literal=false, nocapture=false, /*i*/ ignorecase=false, /*m*/ multiline=false, /*s*/ dotnl=false, /*U*/ nongreedy=false) : regexp
 {
   if CHPL_REGEXP == "none" {
     compilerError("Regular expression support not compiled in");
@@ -475,7 +475,7 @@ proc compile(pattern: string, utf8=true, posix=false, literal=false, nocapture=f
                    ``(?U)``.
 
  */
-proc compile(pattern: string, out error:syserr, utf8=true, posix=false, literal=false, nocapture=false, /*i*/ ignorecase=false, /*m*/ multiline=false, /*s*/ dotnl=false, /*U*/ nongreedy=false)//:regexp
+proc compile(pattern: string, out error:syserr, utf8=true, posix=false, literal=false, nocapture=false, /*i*/ ignorecase=false, /*m*/ multiline=false, /*s*/ dotnl=false, /*U*/ nongreedy=false) : regexp
 {
   var opts:qio_regexp_options_t;
   qio_regexp_init_default_options(opts);
@@ -546,7 +546,7 @@ record reMatch {
 }
 
 pragma "no doc"
-proc _to_reMatch(ref p:qio_regexp_string_piece_t)//:reMatch
+proc _to_reMatch(ref p:qio_regexp_string_piece_t) : reMatch
 {
   if qio_regexp_string_piece_isnull(p) {
     return new reMatch(false, -1, 0); 
@@ -598,7 +598,7 @@ record regexp {
      :returns: a string describing any error encountered when compiling this
                regular expression
    */
-  proc error()//:string
+  proc error() : string
   {
     return qio_regexp_error(_regexp):string;
   }
@@ -647,7 +647,7 @@ record regexp {
                where a match occurred
 
     */
-  proc search(text: ?t, ref captures ...?k)//:reMatch
+  proc search(text: ?t, ref captures ...?k) : reMatch
     where t == string || t == stringPart
   {
     var ret:reMatch;
@@ -679,7 +679,7 @@ record regexp {
 
   // documented in the captures version
   pragma "no doc"
-  proc search(text: ?t)//:reMatch
+  proc search(text: ?t) : reMatch
     where t == string || t == stringPart
   {
     var ret:reMatch;
@@ -727,7 +727,7 @@ record regexp {
      :returns: an :record:`reMatch` object representing the offset in text
                where a match occurred
    */
-  proc match(text: ?t, ref captures ...?k)//:reMatch
+  proc match(text: ?t, ref captures ...?k) : reMatch
     where t == string || t == stringPart
   {
     var ret:reMatch;
@@ -759,7 +759,7 @@ record regexp {
 
   // documented in the version taking captures.
   pragma "no doc"
-  proc match(text: ?t)//:reMatch
+  proc match(text: ?t) : reMatch
     where t == string || t == stringPart
   {
     var ret:reMatch;
@@ -922,7 +922,7 @@ record regexp {
      :returns: a tuple containing (new string, number of substitutions made)
    */
   // TODO -- move subn after sub for documentation clarity
-  proc subn(repl:string, text: ?t, global = true )//:(string, int)
+  proc subn(repl:string, text: ?t, global = true ) : (string, int)
     where t == string || t == stringPart 
   {
     var pos:int;
@@ -1054,7 +1054,7 @@ inline proc _cast(type t, x: string) where t == regexp {
    :returns: an :record:`reMatch` object representing the offset in the
              receiving string where a match occurred
  */
-proc string.search(needle: string, ignorecase=false)//:reMatch
+proc string.search(needle: string, ignorecase=false) : reMatch
 {
   // Create a regexp matching the literal for needle
   var re = compile(needle, literal=true, nocapture=true, ignorecase=ignorecase);
@@ -1063,7 +1063,7 @@ proc string.search(needle: string, ignorecase=false)//:reMatch
 
 // documented in the captures version
 pragma "no doc"
-proc string.search(needle: regexp)//:reMatch
+proc string.search(needle: regexp) : reMatch
 {
   return needle.search(this);
 }
@@ -1077,14 +1077,14 @@ proc string.search(needle: regexp)//:reMatch
    :returns: an :record:`reMatch` object representing the offset in the
              receiving string where a match occurred
  */
-proc string.search(needle: regexp, ref captures ...?k)//:reMatch
+proc string.search(needle: regexp, ref captures ...?k) : reMatch
 {
   return needle.search(this, (...captures));
 }
 
 // documented in the captures version
 pragma "no doc"
-proc string.match(pattern: regexp)//:reMatch
+proc string.match(pattern: regexp) : reMatch
 {
   return pattern.match(this);
 }
@@ -1100,7 +1100,7 @@ proc string.match(pattern: regexp)//:reMatch
              receiving string where a match occurred
  */
 
-proc string.match(pattern: regexp, ref captures ...?k)//:reMatch
+proc string.match(pattern: regexp, ref captures ...?k) : reMatch
 {
   return pattern.match(this, (...captures));
 }

--- a/test/types/string/ferguson/ret-string-tuple.chpl
+++ b/test/types/string/ferguson/ret-string-tuple.chpl
@@ -1,0 +1,55 @@
+proc delared_return():1*string {
+  var x = "hi";
+  return (x + " there declared",);
+}
+
+proc inferred_return() {
+  var x = "hi";
+  return (x + " there inferred",);
+}
+
+proc inferred_return_copy_initcopy() {
+  var x = "hi";
+  var ret = (x + " there inferred initcopy",);
+  return ret;
+}
+
+proc inferred_return_copy_noinit_assign() {
+  var x = "hi";
+  var ret:1*string = noinit;
+  ret = (x + " there inferred copy noinit assign",);
+  return ret;
+}
+
+proc inferred_return_copy_defaultinit_assign() {
+  var x = "hi";
+  var ret:1*string;
+  ret = (x + " there inferred copy defaultinit assign",);
+  return ret;
+}
+
+
+
+proc main() {
+
+  var y = delared_return();
+  writeln(y);
+
+  var x = inferred_return_copy_noinit_assign();
+  writeln(x);
+
+  // this one seems to work.
+  var x2 = inferred_return_copy_initcopy();
+  writeln(x2);
+
+  // this one seems to work.
+  var x3 = inferred_return_copy_defaultinit_assign();
+  writeln(x3);
+
+
+
+  // this one seems to work.
+  var z = inferred_return();
+  writeln(z);
+
+}

--- a/test/types/string/ferguson/ret-string-tuple.compopts
+++ b/test/types/string/ferguson/ret-string-tuple.compopts
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/types/string/ferguson/ret-string-tuple.good
+++ b/test/types/string/ferguson/ret-string-tuple.good
@@ -1,0 +1,5 @@
+(hi there declared)
+(hi there inferred copy noinit assign)
+(hi there inferred initcopy)
+(hi there inferred copy defaultinit assign)
+(hi there inferred)


### PR DESCRIPTION
Test cases that returned a tuple of strings were not initializing the tuple.
The problem was that while the string had FLAG_IGNORE_NOINIT set,
the tuple did not. So, in this patch, we set FLAG_IGNORE_NOINIT for
any record or union type containing a field with FLAG_IGNORE_NOINIT.

Then, there were problems with dtStringCopy in which the assignment
operator uses the LHS, and so that type also needs FLAG_IGNORE_NOINIT.
That led to a few minor adjustments in function resolution so that FLAG_IGNORE_NOINIT
is properly respected for primitive types in addition to record types.

Passes test/types/string for single-locale.