### PR TITLE
Don't count non-blocking ons as running tasks on the initiating locale

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1366,8 +1366,8 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
     BlockStmt* block = ForLoop::buildForLoop(indices, iterator, body, true, zippered);
     block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc")));
     block->insertAtHead(new DefExpr(coforallCount));
-    body->insertAtHead(new CallExpr("_upEndCount", coforallCount));
-    block->insertAtTail(new CallExpr("_waitEndCount", coforallCount));
+    body->insertAtHead(new CallExpr("_upEndCount", coforallCount, gFalse));
+    block->insertAtTail(new CallExpr("_waitEndCount", coforallCount, gFalse));
     block->insertAtTail(new CallExpr("_endCountFree", coforallCount));
     onBlock->blockInfoGet()->primitive = primitives[PRIM_BLOCK_COFORALL_ON];
     addByrefVars(onBlock, byref_vars);
@@ -2090,7 +2090,7 @@ buildBeginStmt(CallExpr* byref_vars, Expr* stmt) {
   BlockStmt* onBlock = findStmtWithTag(PRIM_BLOCK_ON, body);
 
   if (onBlock) {
-    body->insertAtHead(new CallExpr("_upEndCount"));
+    body->insertAtHead(new CallExpr("_upEndCount", gFalse));
     onBlock->insertAtTail(new CallExpr("_downEndCount"));
     onBlock->blockInfoGet()->primitive = primitives[PRIM_BLOCK_BEGIN_ON];
     addByrefVars(onBlock, byref_vars);


### PR DESCRIPTION
We optimize `coforall on` and `begin on` statements to avoid creating tasks
locally and just do a non-blocking on. However, we were still incrementing and
decrementing the task count in _upEndCount and _waitEndCount respectively. This
adds a config param to _upEndCount and _waitEndCount to not update the running
task count for these types of non-blocking ons.

This was discovered as part of the stream-ep performance investigation.
stream-ep basically has a loop like

```chapel
  coforall loc in Locales do on loc {
    // kernel computation
  }
```
On locale 0, the running task count was 2+numLocales, because the tasks the
coforall was creating were mistakenly being counted on the initiating locale.
This hurt our performance because locale 0 had a very limited number of tasks
to do the actual kernel with.