### PR TITLE
Fixed the --no-local regression in leadFollowOpt.chpl

### DIFF
--- a/test/studies/hpcc/common/bradc/unit/leadFollowOpt.chpl
+++ b/test/studies/hpcc/common/bradc/unit/leadFollowOpt.chpl
@@ -11,6 +11,8 @@ D2.dsiSetIndices({2..10});
 // This is the other way to avoid the problem.
 D1.incRefCount();
 D2.incRefCount();
+_newPrivatizedClass(D1);
+_newPrivatizedClass(D2);
 
 forall (i,j) in zip(D1, D2) do
   writeln("(i,j) is: ", (i,j));


### PR DESCRIPTION
This test operates "naked" BlockDom objects, so some things
that would happen when using a Block-distributed domain
do not happen here. In particular, (a) reference counting
and (b) looking up in the privatized-class table.

(a) was already compensated for before string-as-rec.

(b) was not exposed before string-as-rec. However,
even before string-as-rec, if we added this line to the test:

  _isPrivatized(D1);

we would get the same crashing behavior, due to a lookup
in the privatized-class table with pid == -1.

pid == -1 is because "naked" BlockDom objects are not privatized
implicitly. So the solution is to privatize them explicitly,
just like the correction already in place for (a).

The lookup happens due to re-privatization of iterator fields
aka reprivatizeIterators(), introduced in 6ea8a445 aka r15209.
The iterator class in question is due to this loop:
  forall (i,j) in zip(D1, D2) do

Before string-as-rec the compiler did not label BlockDom
with FLAG_PRIVATIZED_CLASS. That's because _isPrivatized()
was not invoked on any BlockDom instances.

string-as-rec adds autoCopy/autoDestroy on BlockDom
that invokes _isPrivatized() on BlockDom.
So the compiler labels BlockDom with FLAG_PRIVATIZED_CLASS
and applies re-privatization to the BlockDom field
of the iterator class. This results in a lookup with pid==-1.