### PR TITLE
Load the target compiler for whitebox testing

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -78,17 +78,22 @@ case $COMP_TYPE in
 esac
 
 # load compiler versions from $CHPL_INTERNAL_REPO/build/compiler_versions.bash
-# This should set define the load_compiler function and CHPL_GCC_VERSION.
+# This should define load_target_compiler function and CHPL_GCC_TARGET_VERSION.
+# The module uses the gen compiler to build the compiler and runtime, and the
+# target version to test. For whitebox testing we use the target compiler for
+# everything because there's no easy way to split up what we build with vs test
+# with. We decided to always use the target compiler to get more exposure
+# building with newer compilers.
 source $CHPL_INTERNAL_REPO/build/compiler_versions.bash
 
 # Always load the right version of GCC since we use it sometimes
 # to e.g. build the Chapel compiler with COMP_TYPE=TARGET
 if [ "${COMPILER}" != "gnu" ] ; then
-    module load gcc/${CHPL_GCC_VERSION}
+    module load gcc/${CHPL_GCC_TARGET_VERSION}
 fi
 
 # Then load the selected compiler
-load_compiler ${COMPILER}
+load_target_compiler ${COMPILER}
 
 # Do minor fixups
 case $COMPILER in


### PR DESCRIPTION
The internal load_compiler function was split into load_gen_compiler and
load_target_compiler versions. This just updates references to it in the public
repo.

The module uses the gen compiler to build the compiler and runtime, and the
target version to test. For whitebox testing we use the target compiler for
everything because there's no easy way to split up what we build with vs test
with. We decided to always use the target compiler to get more exposure
building with newer compilers.