### PR TITLE
Add two new configs for string-as-rec nightly testing

### DIFF
--- a/util/cron/test-str-as-rec-gasnet-everything.bash
+++ b/util/cron/test-str-as-rec-gasnet-everything.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Test gasnet (segment everything) against full suite on linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-gasnet.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="string-as-rec-gasnet-everything"
+
+export GASNET_QUIET=Y
+
+# Test a GASNet compile using the default segment (everything for linux64)
+export CHPL_GASNET_SEGMENT=everything
+
+git checkout string-as-rec
+
+$CWD/nightly -cron -futures

--- a/util/cron/test-str-as-rec-linux64.bash
+++ b/util/cron/test-str-as-rec-linux64.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on full suite with compiler performance enabled on
+# linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="string-as-rec-linux64"
+
+git checkout string-as-rec
+
+nightly_args="-compperformance (default)"
+$CWD/nightly -cron -futures ${nightly_args}


### PR DESCRIPTION
We don't have a clean way to do this purely within jenkins at the
moment, so I have to add these two files.