### PR TITLE
Fix localizeReturnSymbols to handle = with ref LHS

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -851,6 +851,7 @@ static void localizeReturnSymbols(FnSymbol* iteratorFn, std::vector<BaseAST*> as
       }
     }
   }
+  // TODO - check for multiple definitions for one of the addr_of symbols. 
 
   // Walk all SymExprs in the function and select those that refer to ret (the
   // function return symbol).

--- a/test/types/string/ferguson/iterate-string.chpl
+++ b/test/types/string/ferguson/iterate-string.chpl
@@ -1,0 +1,15 @@
+var A = ["this", "is", "a", "test"];
+
+iter myiter() : string {
+  for a in A do yield a;
+}
+
+proc main() {
+
+  var baz: string;
+
+  for x in myiter() {
+    writeln(x);
+  }
+}
+

--- a/test/types/string/ferguson/iterate-string.good
+++ b/test/types/string/ferguson/iterate-string.good
@@ -1,0 +1,4 @@
+this
+is
+a
+test


### PR DESCRIPTION
The condition to replace = with PRIM_MOVE no longer
fires because we are doing insertReferenceTemps before
this code is run, and we did not in the past.

The fix is to track symbols storing addr_of the
ret argument. Two options for better fixes:
 - delay the insertion of reference temps until later
   in the program translation.
 - rework normalization for iterators so that
   there is no need to localize iterator symbols
   (possibly following Note #1 at the end
    of lowerIterators.cpp).