### PR TITLE
Fix printFinalMemStat regressions

### DIFF
--- a/test/memory/shannon/printFinalMemStat.lm-numa.good
+++ b/test/memory/shannon/printFinalMemStat.lm-numa.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  368
-Total Allocated Memory                 824
-Total Freed Memory                     568
+Total Allocated Memory                 880
+Total Freed Memory                     624
 ==============================================================

--- a/test/memory/shannon/printFinalMemStat.no-local.good
+++ b/test/memory/shannon/printFinalMemStat.no-local.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  505
-Total Allocated Memory                 2041
-Total Freed Memory                     1785
+Total Allocated Memory                 2097
+Total Freed Memory                     1841
 ==============================================================


### PR DESCRIPTION
This test started regression for numa and --no-local with a83daf117479. This is
just a change in the total amount of allocated and freed memory. The amount
leaked hasn't changed so I'm not investigating further as the responsible
commit seems unrelated.