### PR TITLE
Delete the string-as-rec branch before checking it out

### DIFF
--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -12,6 +12,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04.playground"
 # easy, but sync to a different direction so the default chap04 graphs don't
 # have multiple configurations.
 
+git branch -D string-as-rec
 git checkout string-as-rec
 
 perf_args="-performance-description amm -performance-configs default:v,amm:v -sync-dir-suffix amm"

--- a/util/cron/test-str-as-rec-gasnet-everything.bash
+++ b/util/cron/test-str-as-rec-gasnet-everything.bash
@@ -12,6 +12,7 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
+git branch -D string-as-rec
 git checkout string-as-rec
 
 $CWD/nightly -cron -futures

--- a/util/cron/test-str-as-rec-linux64.bash
+++ b/util/cron/test-str-as-rec-linux64.bash
@@ -8,6 +8,7 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="str-as-rec-linux64"
 
+git branch -D string-as-rec
 git checkout string-as-rec
 
 nightly_args="-compperformance (default)"


### PR DESCRIPTION
We have some hacks in place to test the string-as-rec branch in a few
configurations. However, all of the repo management is done by jenkins and it
doesn't know that its being lied to about what branch to test so it's never
updating string-as-rec

It's hard to have jenkins use a different branch, so just delete the branch
before checking it out to make sure we get an up to date copy.