### PR TITLE
Add tolerances to the remaining tests in users/aroonsharma

### DIFF
--- a/test/users/aroonsharma/2mm.chpl
+++ b/test/users/aroonsharma/2mm.chpl
@@ -51,6 +51,10 @@ proc initialize_matrix(distribution, matrix_size: int, adder: int) {
     return matrix;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* The process which runs the benchmark */
 proc kernel_2mm(alpha: int, beta: int, distribution, matrix_size: int) {
   var still_correct = true;
@@ -167,7 +171,7 @@ proc kernel_2mm(alpha: int, beta: int, distribution, matrix_size: int) {
     
     for ii in 1..matrix_size {
       for jj in 1..matrix_size {
-        still_correct &&= E[ii,jj] == Etest[ii,jj];
+        still_correct &&= within_epsilon(E[ii,jj], Etest[ii,jj]);
       }
     }
     writeln("Is the calculation correct? ", still_correct);

--- a/test/users/aroonsharma/cholesky.chpl
+++ b/test/users/aroonsharma/cholesky.chpl
@@ -36,6 +36,10 @@ proc initialize_matrix(distribution, n_dim: int) {
     return matrix;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the matrix passed in */
 proc print_matrix(A: [], n_dim: int) {
     for i in 1..n_dim {
@@ -136,7 +140,7 @@ proc kernel_cholesky(dist_square, n_dim: int) {
     
     for ii in 1..n_dim {
       for jj in 1..n_dim {
-        still_correct &&= C[ii,jj] == Ctest[ii,jj];
+        still_correct &&= within_epsilon(C[ii,jj], Ctest[ii,jj]);
       }
     }
     still_correct &&= s == sTest;

--- a/test/users/aroonsharma/correlation.chpl
+++ b/test/users/aroonsharma/correlation.chpl
@@ -31,6 +31,10 @@ proc initialize_matrix(distribution, m_dim: int) {
     return matrix;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the matrix passed in */
 proc print_matrix(A: [], m_dim: int, n_dim: int) {
     for i in 1..m_dim {
@@ -169,7 +173,7 @@ proc kernel_correlation(dist_square, dist_linear, m_dim: int, n_dim: int) {
     
     for ii in 1..m_dim {
       for jj in 1..m_dim {
-        still_correct &&= symmat[ii,jj] == symmatTest[ii,jj];
+        still_correct &&= within_epsilon(symmat[ii,jj], symmatTest[ii,jj]);
       }
     }
     writeln("Is the calculation correct? ", still_correct);

--- a/test/users/aroonsharma/covariance.chpl
+++ b/test/users/aroonsharma/covariance.chpl
@@ -31,6 +31,10 @@ proc initialize_matrix(distribution, m_dim: int) {
     return matrix;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the matrix passed in */
 proc print_matrix(A: [], m_dim: int, n_dim: int) {
     for i in 1..m_dim {
@@ -142,7 +146,7 @@ proc kernel_covariance(dist_square, dist_linear, m_dim: int, n_dim: int) {
     
     for ii in 1..m_dim {
       for jj in 1..m_dim {
-        still_correct &&= symmat[ii,jj] == symmatTest[ii,jj];
+        still_correct &&= within_epsilon(symmat[ii,jj], symmatTest[ii,jj]);
       }
     }
     writeln("Is the calculation correct? ", still_correct);

--- a/test/users/aroonsharma/fdtd-2d.chpl
+++ b/test/users/aroonsharma/fdtd-2d.chpl
@@ -48,6 +48,10 @@ proc initialize_2D(distribution, adder: int, divider: int) {
     return matrix;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the 1D structure passed in */
 proc print_1D(A: []) {
     writeln(A);
@@ -152,7 +156,9 @@ proc kernel_fdtd2d(dist_1D, dist_2D, m_dim: int, n_dim: int) {
     
     for ii in 1..m_dim {
       for jj in 1..m_dim {
-        still_correct &&= (Z[ii,jj] == Ztest[ii,jj]) && (Y[ii,jj] == Ytest[ii,jj]) && (X[ii,jj] == Xtest[ii,jj]);
+        still_correct &&= within_epsilon(Z[ii,jj], Ztest[ii,jj]) &&
+                          within_epsilon(Y[ii,jj], Ytest[ii,jj]) &&
+                          within_epsilon(X[ii,jj], Xtest[ii,jj]);
       }
     }
     writeln("Is the computation correct? ", still_correct);

--- a/test/users/aroonsharma/fdtd-apml.chpl
+++ b/test/users/aroonsharma/fdtd-apml.chpl
@@ -59,6 +59,10 @@ proc initialize_3D(distribution, adder_1: int, adder_2: int, divider: int) {
     return matrix;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the 1D structure passed in */
 proc print_1D(A: []) {
     write("     ");
@@ -293,8 +297,10 @@ proc kernel_fdtdapml(dist_1D, dist_2D, dist_3D, m_dim: int, n_dim: int, p_dim: i
     for ii in 1..m_dim {
       for jj in 1..n_dim {
         for kk in 1..p_dim {
-          still_correct &&= (ExTest[ii,jj,kk] == Ex[ii,jj,kk]) && (EyTest[ii,jj,kk] == Ey[ii,jj,kk])
-                    && (HzTest[ii,jj,kk] == Hz[ii,jj,kk]) && (BzaTest[ii,jj,kk] == Bza[ii,jj,kk]);
+          still_correct &&= within_epsilon(ExTest[ii,jj,kk], Ex[ii,jj,kk]) &&
+                            within_epsilon(EyTest[ii,jj,kk], Ey[ii,jj,kk]) &&
+                            within_epsilon(HzTest[ii,jj,kk], Hz[ii,jj,kk]) &&
+                            within_epsilon(BzaTest[ii,jj,kk], Bza[ii,jj,kk]);
         }
       }
     }

--- a/test/users/aroonsharma/floyd-warshall.chpl
+++ b/test/users/aroonsharma/floyd-warshall.chpl
@@ -28,6 +28,10 @@ proc initialize_matrix(distribution, n_dim: int) {
     return matrix;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the matrix passed in */
 proc print_matrix(A: [], n_dim: int) {
     for i in 1..n_dim {
@@ -124,7 +128,7 @@ proc kernel_fw(dist_square, n_dim: int) {
     
     for ii in 1..n_dim {
       for jj in 1..n_dim {
-        still_correct &&= path[ii,jj] == pathTest[ii,jj];
+        still_correct &&= within_epsilon(path[ii,jj], pathTest[ii,jj]);
       }
     }
     writeln("Is the calculation correct? ", still_correct);

--- a/test/users/aroonsharma/jacobi-1d.chpl
+++ b/test/users/aroonsharma/jacobi-1d.chpl
@@ -39,6 +39,10 @@ proc initialize_1D(distribution, adder: int, divider: int) {
     return array;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the 1D structure passed in */
 proc print_1D(A: []) {
     writeln(A);
@@ -105,7 +109,7 @@ proc kernel_jacobi1d(dist_1D, m_dim: int) {
       }
     
     for ii in 1..m_dim {
-      still_correct &&= Atest[ii] == A[ii];
+      still_correct &&= within_epsilon(Atest[ii], A[ii]);
     }
     writeln("Is the calculation correct? ", still_correct);
     writeln("jacobi-1d computation complete");

--- a/test/users/aroonsharma/jacobi-2d.chpl
+++ b/test/users/aroonsharma/jacobi-2d.chpl
@@ -31,6 +31,10 @@ if dist=='NONE' {
   dobench(mydist, mydom);
 } 
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 proc dobench(mydist, mydom) {
   var still_correct = true;
 
@@ -92,7 +96,8 @@ proc dobench(mydist, mydom) {
         XNewt(ProblemSpace) = (Xt(north) + Xt(south) + Xt(east) + Xt(west))/4.0;
         Xt[ProblemSpace] = XNewt[ProblemSpace];
         for ii in mydom {
-          still_correct &&= Xt[ii]==X[ii] && XNewt[ii]==XNew[ii];
+          still_correct &&= within_epsilon(Xt[ii], X[ii]) &&
+                            within_epsilon(XNewt[ii], XNew[ii]);
         }
       }
 

--- a/test/users/aroonsharma/lu.chpl
+++ b/test/users/aroonsharma/lu.chpl
@@ -39,9 +39,8 @@ proc print_matrix(A: [], n_dim: int) {
     }
 }
 
-proc within_epsilon(a: real, b: real)
-{
-  return abs(a-b) < 0.00001;
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
 }
 
 /* The process which runs the benchmark */

--- a/test/users/aroonsharma/mvt.chpl
+++ b/test/users/aroonsharma/mvt.chpl
@@ -49,6 +49,10 @@ proc initialize_array(distribution, dim: int, array_name: string) {
     return array;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the matrix passed in */
 proc print_matrix(A: [], dim: int) {
     for i in 1..dim {
@@ -146,7 +150,8 @@ proc kernel_mvt(dist, dim: int) {
       } 
     
     for ii in 1..dim {
-      still_correct &&= (x1[ii] == x1Test[ii]) && (x2[ii] == x2Test[ii]);
+      still_correct &&= within_epsilon(x1[ii], x1Test[ii]) &&
+                        within_epsilon(x2[ii],  x2Test[ii]);
     }
     writeln("Is the calculation correct? ", still_correct);
     writeln("mvt computation complete");

--- a/test/users/aroonsharma/stencil9.chpl
+++ b/test/users/aroonsharma/stencil9.chpl
@@ -12,6 +12,10 @@ config var timeit = false;
 config var messages = false;
 config var correct = false;
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 proc kernel_stencil9(dist_little, dist_big, dom_little, dom_big) {
   var still_correct = true;
   var t: Timer;
@@ -21,7 +25,7 @@ proc kernel_stencil9(dist_little, dist_big, dom_little, dom_big) {
     const southWest = {2..n+1, 0..n-1}, south = {2..n+1, 1..n}, southEast = {2..n+1, 2..n+1};
 
     var A, B: [dist_big] real;
-  var Atest, Btest: [dom_big] real;
+    var Atest, Btest: [dom_big] real;
 
     A[  n/4+1,   n/4+1] =  1.0;
     A[3*n/4+1, 3*n/4+1] =  1.0;
@@ -110,7 +114,8 @@ proc kernel_stencil9(dist_little, dist_big, dom_little, dom_big) {
        } while (delta > epsilon);
      
       for ii in dom_big {
-        still_correct &&= A[ii]==Atest[ii] && B[ii]==Btest[ii];
+        still_correct &&= within_epsilon(A[ii], Atest[ii]) &&
+                          within_epsilon(B[ii], Btest[ii]);
       }
     writeln("it is correct? ", still_correct);
     writeln("stencil9 computation complete.");

--- a/test/users/aroonsharma/syr2k.chpl
+++ b/test/users/aroonsharma/syr2k.chpl
@@ -37,6 +37,10 @@ proc initialize_2D(distribution, m_dim: int) {
     return matrix;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the 2D structure passed in */
 proc print_2D(A: [], m_dim: int, n_dim: int) {
     for i in 1..m_dim {
@@ -123,7 +127,7 @@ proc kernel_syr2k(dist_2D, m_dim: int, n_dim: int) {
     
     for ii in 1..m_dim {
       for jj in 1..n_dim {
-        still_correct &&= (C[ii,jj] == CTest[ii,jj]);
+        still_correct &&= within_epsilon(C[ii,jj], CTest[ii,jj]);
       }
     }
     writeln("Is the computation correct? ", still_correct);

--- a/test/users/aroonsharma/syrk.chpl
+++ b/test/users/aroonsharma/syrk.chpl
@@ -37,6 +37,10 @@ proc initialize_2D(distribution, m_dim: int) {
     return matrix;
 }
 
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
+}
+
 /* Prints out the 2D structure passed in */
 proc print_2D(A: [], m_dim: int, n_dim: int) {
     for i in 1..m_dim {
@@ -117,7 +121,7 @@ proc kernel_syrk(dist_2D, m_dim: int, n_dim: int) {
     
     for ii in 1..m_dim {
       for jj in 1..m_dim {
-        still_correct &&= (C[ii,jj] == CTest[ii,jj]);
+        still_correct &&= within_epsilon(C[ii,jj], CTest[ii,jj]);
       }
     }
     writeln("Is the calculation correct? ", still_correct);

--- a/test/users/aroonsharma/trmm.chpl
+++ b/test/users/aroonsharma/trmm.chpl
@@ -41,11 +41,9 @@ proc print_matrix(A: [], dim: int) {
     }
 }
 
-proc within_epsilon(a: real, b: real)
-{
-  return fabs(a-b) < 0.00001;
+proc within_epsilon(a: real, b: real, eps=1e-6) {
+    return abs(a-b) < eps;
 }
-
 
 /* The process which runs the benchmark */
 proc kernel_trmm(dist, dim: int) {
@@ -107,8 +105,7 @@ proc kernel_trmm(dist, dim: int) {
     
     for ii in 1..dim {
       for jj in 1..dim {
-        still_correct &&=
-                                  within_epsilon(B[ii,jj], BTest[ii,jj]);
+        still_correct &&= within_epsilon(B[ii,jj], BTest[ii,jj]);
       }
     }
     writeln("Is the calculation correct? ", still_correct);


### PR DESCRIPTION
Most of the tests in this directory do correctness tests comparing floating
point values. Only a few of them allowed for some tolerance using a
"within_epsilon" function. The rest tried to do direct floating point
comparison using '=='.

A few of these that do direct comparison started failing with a83daf117479.
That commit corrected the running task count and some of the reductions were
actually being done in parallel. Previously they were serial so the order the
floating point operations were done was the same. Since they are done in
parallel now, we have to add a tolerance.

This adds a tolerance to all the tests that did floating point comparison not
just the ones that were failing. I used a cleaned up copy of the
"within_epsilon" that a few of the tests already used.