### PR TITLE
Fix this future so that its behavior more accurately reflects our vision

### DIFF
--- a/test/types/string/sungeun/c_string/intents.bad
+++ b/test/types/string/sungeun/c_string/intents.bad
@@ -1,2 +1,0 @@
-intents.chpl:11: error: unresolved call 'fo("hi")'
-intents.chpl:5: note: candidates are: fo(out s: string)

--- a/test/types/string/sungeun/c_string/intents.chpl
+++ b/test/types/string/sungeun/c_string/intents.chpl
@@ -12,14 +12,6 @@ fo("hi");
 fio("hi");
 fr("hi");
 
-var s: c_string = "hi";
-s += s;
-f(s);
-fi(s);
-fo(s);
-fio(s);
-fr(s);
-
 proc g(s) {  checkType(s.type); }
 proc gi(in s) { checkType(s.type); }
 proc go(out s) { checkType(s.type); }
@@ -31,3 +23,11 @@ gi("hi");
 go("hi");
 gio("hi");
 gr("hi");
+
+var s: c_string = "hi";
+s += s;
+f(s);
+fi(s);
+fo(s);
+fio(s);
+fr(s);

--- a/test/types/string/sungeun/c_string/intents.future
+++ b/test/types/string/sungeun/c_string/intents.future
@@ -1,2 +1,0 @@
-bug: Implicit conversion of c_string to string does not work for ref, out, or inout intents.
-

--- a/test/types/string/sungeun/c_string/intents.good
+++ b/test/types/string/sungeun/c_string/intents.good
@@ -1,0 +1,8 @@
+intents.chpl:11: error: non-lvalue actual is passed to 'out' formal 's' of fo()
+intents.chpl:12: error: non-lvalue actual is passed to 'inout' formal 's' of fio()
+intents.chpl:13: error: non-lvalue actual is passed to 'ref' formal 's' of fr()
+intents.chpl:23: error: non-lvalue actual is passed to 'out' formal 's' of go()
+intents.chpl:24: error: non-lvalue actual is passed to 'inout' formal 's' of gio()
+intents.chpl:25: error: non-lvalue actual is passed to 'ref' formal 's' of gr()
+intents.chpl:31: error: unresolved call 'fo(c_string)'
+intents.chpl:5: note: candidates are: fo(out s: string)


### PR DESCRIPTION
And remove the .future and .bad files, since we believe the state of the
compiler is correct.  Basically, we expect string literals to be immutable,
meaning they can't be passed as out, inout, or ref arguments to functions.  And
since literals are no longer c_string, only the new last section exercises
c_strings to these functions.  We also believe that c_strings should not be
implicitly converted to strings when passed to functions, so the .bad error
output is now correct output.

Change details made by Vass, ok'ed by Tom and Kyle