### PR TITLE
Fix chpl-env-gen test for pgi

### DIFF
--- a/test/runtime/sungeun/chpl-env-gen.cleanfiles
+++ b/test/runtime/sungeun/chpl-env-gen.cleanfiles
@@ -1,1 +1,2 @@
 chpl-env-gen.test.gen.c
+chpl-env-gen.h

--- a/test/runtime/sungeun/chpl-env-gen.compopts
+++ b/test/runtime/sungeun/chpl-env-gen.compopts
@@ -1,1 +1,0 @@
--I. -I$CHPL_HOME/runtime/src/gen/`$CHPL_HOME/util/printchplenv --runtime`

--- a/test/runtime/sungeun/chpl-env-gen.precomp
+++ b/test/runtime/sungeun/chpl-env-gen.precomp
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
 
-import os, sys, subprocess
+import os
+import shutil
+import subprocess
+import sys
 
 chpl_home = os.getenv('CHPL_HOME')
 
+# copy the current chplenv and stuff it into a c file that will fail if the
+# values for current chplenv aren't defined in the runtime
 printchplenv = os.path.join(chpl_home, 'util', 'printchplenv')
 printchplenv_cmd = [printchplenv, '--simple']
 
@@ -19,4 +24,13 @@ with open(genfile, 'w') as f:
         f.write('#error "%s undefined or does not match runtime definition"\n'%(val))
         f.write('#endif\n')
 
-f.close()
+
+# copy chpl-env-gen.h to this directory, rather than just including it. On some
+# test systems the include path is too long for pgi
+runtime_path_cmd = [printchplenv, '--runtime']
+runtime_path = subprocess.Popen(runtime_path_cmd, stdout=subprocess.PIPE).communicate()[0]
+runtime_path = runtime_path.strip()
+gen_env_f = os.path.join(chpl_home, 'runtime', 'src', 'gen', runtime_path, 'chpl-env-gen.h')
+
+here_gen_env_f = os.path.join(os.path.dirname(__file__), 'chpl-env-gen.h')
+shutil.copyfile(gen_env_f, here_gen_env_f)


### PR DESCRIPTION
The test included (-I) the runtime gen path so it could find the chpl-env-gen.h
file. However, on the gen path for whitebox testing is really long and pgi
silently truncates so we weren't able to find the file.

Now we just copy the file to the test directory instead of including it.