### PR TITLE
Workaround for the crash in fileNotValid.

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -88,6 +88,9 @@ proc file.realPath(out error: syserr) : string
     error = EBADF;
     return "";
   }
+  // There is a bug in how AMM deals with unnamed temporaries.
+  // an explicit "else" clause was inserted as a workaround.
+  // See test/statements/hilde/return_of_new_string.chpl
   else {
     error = chpl_fs_realpath_file(_file_internal, res);
     var len = res.length;

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -88,9 +88,11 @@ proc file.realPath(out error: syserr) : string
     error = EBADF;
     return "";
   }
-  error = chpl_fs_realpath_file(_file_internal, res);
-  var len = res.length;
-  return new string(res:c_ptr(uint(8)), len, len+1, owned=true, needToCopy=false);
+  else {
+    error = chpl_fs_realpath_file(_file_internal, res);
+    var len = res.length;
+    return new string(res:c_ptr(uint(8)), len, len+1, owned=true, needToCopy=false);
+  }
 }
 
 /* Determines the canonical path referenced by the :type:`~IO.file` record

--- a/test/statements/hilde/return_of_new_string.bad
+++ b/test/statements/hilde/return_of_new_string.bad
@@ -1,0 +1,1 @@
+timedexec: target program died with signal 11, without coredump

--- a/test/statements/hilde/return_of_new_string.chpl
+++ b/test/statements/hilde/return_of_new_string.chpl
@@ -1,0 +1,44 @@
+// return_of_new_string.chpl
+//
+// This test case demonstrates a bug in AMM, regarding where autoDestroys are
+// inserted.
+//
+// The final case, fubar(true) causes the unnamed temporary capturing the
+// string result to be freed without having first been initialized.  This
+// causes an illegal free under valgrind followed by a crash.
+//
+
+proc get_literal() : string return "Free Willy!";
+
+// This one should work in both cases.
+// It demonstrates the source-code workaround for the problem, which is to
+// insert an explicit else clause.
+proc bar(cond:bool, out empty:bool) : string {
+  if (cond) {
+    empty = true;
+    return "";
+  }
+  else {
+    empty = false;
+    return get_literal();
+  }
+}
+
+// This one demonstrates the problem when cond == true.
+// The problem does not surface without the out argument.
+proc fubar(cond:bool, out empty:bool) : string {
+  if (cond) {
+    empty = true;
+    return "";
+  }
+  empty = false;
+  return get_literal();
+}
+
+var is_empty : bool;
+
+writeln(bar(false, is_empty));
+writeln(bar(true, is_empty));
+writeln(fubar(false, is_empty));
+writeln(fubar(true, is_empty));
+

--- a/test/statements/hilde/return_of_new_string.future
+++ b/test/statements/hilde/return_of_new_string.future
@@ -1,0 +1,24 @@
+bug: autoDestroy is incorrectly placed when a conditional clause ends in a return and there is an out argument
+
+Summary: Unnamed temporararies should be placed in scopes that are do not encompass the
+target of the goto used to represent a flow-altering statement.
+
+Reaction: What???
+
+Explanation: In the code following the "if" clause in fubar, there is an unnamed temporary
+that receives the result of the call to get_literal().  This unnamed temporary is then
+copied into the return-value variable by assignment (because the return type of fubar is
+stated explicitly and the RVV is therefore default-initialized).  
+
+Since the unnamed temporary owns the value returned by get_literal() and ownership is not
+transferred by assignment, the unnamed temporary must be destroyed before it goes out of
+scope.  In the current implementation, the autoDestroy gets inserted after the _end_fubar:
+label that is used to implement the embedded return.
+
+In the case that cond == true when fubar is invoked, the unnamed temporary is never
+initialized.  (The code that calls get_literal() and moves the result into that unnamed
+temporary is skipped by the goto at the end of the "if" clause.)  The autoDestroy is still
+encountered, so the program crashes.
+
+The basic correctness requirement is that the autoDestroy be inserted at the right place
+-- in this case, before the _end_fubar label and not after it.

--- a/test/statements/hilde/return_of_new_string.good
+++ b/test/statements/hilde/return_of_new_string.good
@@ -1,0 +1,4 @@
+Free Willy!
+
+Free Willy!
+


### PR DESCRIPTION
In the test modules/standard/Path/lydia/realpath/fileNotValid.chpl, there is a
crash because the autoDestroy for the temporary result of the call to string()
is being inserted in the wrong place.  There is a pivotal item that recommends
a better solution (#101646244).

In the mean time, the problem can be worked around by inserting an explicit
"else" clause into the source code.  This patch contains a new future test,
also to track the error and recommend how it is to be resolved.