### PR TITLE
Use testEnv to evaluate executable skipifs as well

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -217,13 +217,8 @@ def test_directory(test, test_type):
                 skip_test = False
                 if os.path.isfile("SKIPIF"):
                     try:
-                        # if executable
-                        if os.access("./SKIPIF", os.X_OK):
-                            skip_test = subprocess.check_output(
-                                    ["./SKIPIF"]).strip()
-                        else: # if not, run a script to check SKIPIF condition
-                            skip_test = subprocess.check_output(
-                                    [test_env, "SKIPIF"]).strip()
+                        skip_test = subprocess.check_output(
+                                [test_env, "SKIPIF"]).strip()
                         # check output and skip if true
                         if skip_test == "1" or skip_test == "True":
                             logger.write("[Skipping directory based on SKIPIF "
@@ -240,13 +235,8 @@ def test_directory(test, test_type):
                 skip_file_name = os.path.normpath(skip_file_name)
                 if os.path.isfile(skip_file_name):
                     try:
-                        # if executable
-                        if os.access(skip_file_name, os.X_OK):
-                            prune_if = subprocess.check_output(
-                                    [skip_file_name]).strip()
-                        else: # if not, run a script to check SKIPIF condition
-                            prune_if = subprocess.check_output(
-                                    [test_env, skip_file_name]).strip()
+                        prune_if = subprocess.check_output(
+                                [test_env, skip_file_name]).strip()
                         # check output and skip if true
                         if prune_if == "1" or prune_if == "True":
                             logger.write("[Skipping directory and children bas"

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -433,13 +433,8 @@ sub find_subdirs {
         my $skipfilen = "$targetdir/$filen.skipif";
         if (-e "$skipfilen") {
             my $skip;
-            if (-x "$skipfilen") {
-                print "$skipfilen = " . `$skipfilen` if $debug;
-                $skip = `$skipfilen`;
-            } else {
-                print "$ENV{CHPL_HOME}/util/test/testEnv $skipfilen = " . `$ENV{CHPL_HOME}/util/test/testEnv $skipfilen` if $debug;
-                $skip = `$ENV{CHPL_HOME}/util/test/testEnv $skipfilen`;
-            }
+            print "$ENV{CHPL_HOME}/util/test/testEnv $skipfilen = " . `$ENV{CHPL_HOME}/util/test/testEnv $skipfilen` if $debug;
+            $skip = `$ENV{CHPL_HOME}/util/test/testEnv $skipfilen`;
             next if $skip > '0' or $skip =~ m/true/i;
         }
 	    if ($debug) {for ($i=0; $i<$level; $i++)  {print "    ";}}

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -460,22 +460,10 @@ def get_exec_log_name(execname, comp_opts_count=None, exec_opts_count=None):
     else:
         return '{0}.{1}-{2}{3}'.format(execname, comp_opts_count, exec_opts_count, suffix)
 
-# If the first line of the skipif file contains '/usr/bin/env', then just execute it.
-# (Don't forget to add execute permission to a script skipif file.)
-# Otherwise, use testEnv to process it the old way.
+# Use testEnv to process skipif files, it works for executable and
+# non-executable versions
 def runSkipIf(skipifName):
-    name = './' + skipifName
-    # Already a file because os.R_OK is true?
-    if os.access(name, os.X_OK):
-        env_cmd = [os.path.join(utildir, 'printchplenv'), '--simple']
-        chpl_env = subprocess.Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0]
-        chpl_env = dict(map(lambda l: l.split('='), chpl_env.splitlines()))
-
-        skipif_env = os.environ.copy()
-        skipif_env.update(chpl_env)
-        skiptest = subprocess.Popen([name], stdout=subprocess.PIPE, env=skipif_env).communicate()[0]
-    else:
-        skiptest = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE).communicate()[0]
+    skiptest = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE).communicate()[0]
     return skiptest
 
 # Start of sub_test proper

--- a/util/test/testEnv
+++ b/util/test/testEnv
@@ -1,5 +1,7 @@
 #!/usr/bin/env perl
 
+use Cwd 'abs_path';
+
 #
 # Set standard CHPL_* environment variables, if they are not already set.
 #
@@ -19,6 +21,19 @@ for my $line (@lines) {
 
 $envfile = $ARGV[0];
 
+#
+# If the envfile is executable, just execute it
+#
+if (-x "$envfile") {
+  $envfile = abs_path($envfile);
+  $execskiptest = `$envfile`;
+  print "$execskiptest";
+  exit("$?");
+}
+
+#
+# otherwise, process using special skipif language
+#
 open ENVFILE, "$envfile" or die "can't open $envfile $!";
 my @envlist = <ENVFILE>;
 close (ENVFILE);


### PR DESCRIPTION
Previously testEnv only processed our special skipif language. When we added
executable skipifs, we ran them directly instead of calling testEnv. This
occurred twice in start_test, once in paratest, and once in sub_test.

However, it was only in sub_test that we stuffed the chplenv in the environment
of the executable skipifs. This meant that directory level skipifs couldn't
see inferred chplenv values. We want to be able to see the values of inferred
chplenv variables in any skipif. I originally started adding the chplenv to the
executable skipif calls in all our scripts, but quickly realized how many
places we were doing that. Instead, it seems simpler and cleaner to just let
testEnv detect if the file is executable. It already stuffs the chplenv in the
env so there's no need to duplicate that logic elsewhere.

This commit has testEnv execute the file instead of running our skipif language
processing on it if the file is executable. Otherwise it's business as usual.
I them removed all the special checks for executable skipif files in
start_test, paratest, and sub_test since testEnv does the check itself now.