### PR TITLE
Propagate ownership of strings through auto/initCopy

### DIFF
--- a/test/types/records/kbrady/return-record.good
+++ b/test/types/records/kbrady/return-record.good
@@ -22,7 +22,6 @@ type specified
 in gob()
 in Zed(1)
 in =(Zed, Zed)
-in chpl__initCopy({y = 2}:Zed)
 in ~Zed({y = 1})
 in chpl__initCopy({y = 2}:Zed)
 in chpl__initCopy({y = 2}:Zed)

--- a/test/types/string/StringImpl/memLeaks/SKIPIF
+++ b/test/types/string/StringImpl/memLeaks/SKIPIF
@@ -1,3 +1,0 @@
-# Skip this directory for comm!=none for now, because it's noisy.  We
-# can turn it back on when the string-as-rec implementation arrives.
-CHPL_COMM != none

--- a/test/types/string/StringImpl/memLeaks/substring.chpl
+++ b/test/types/string/StringImpl/memLeaks/substring.chpl
@@ -20,20 +20,17 @@ module unitTest {
       checkMemLeaks(m0);
     }
 
-    var idx = -3;
+    var idx = 3;
     substringHelp(idx);
-    var slice = idx..#abs(idx);
+
+    var slice = ..idx;
     substringHelp(slice);
 
-    idx = 3;
-    substringHelp(idx);
-    slice = idx..#idx;
-    substringHelp(slice);
+    var slice2 = idx..#idx;
+    substringHelp(slice2);
 
-    idx = 300;
-    substringHelp(idx);
-    slice = idx..#idx;
-    substringHelp(slice);
+    var slice3 = idx..;
+    substringHelp(slice3);
   }
 
   proc substringRemote(type t, useExpr=false) {
@@ -66,20 +63,17 @@ module unitTest {
       checkMemLeaks(m0);
     }
 
-    var idx = -3;
+    var idx = 3;
     substringHelp(idx);
-    var slice = idx..#abs(idx);
+
+    var slice = ..idx;
     substringHelp(slice);
 
-    idx = 3;
-    substringHelp(idx);
-    slice = idx..#idx;
-    substringHelp(slice);
+    var slice2 = idx..#idx;
+    substringHelp(slice2);
 
-    idx = 300;
-    substringHelp(idx);
-    slice = idx..#idx;
-    substringHelp(slice);
+    var slice3 = idx..;
+    substringHelp(slice3);
   }
 
   proc doIt(type t) {

--- a/test/types/string/StringImpl/memLeaks/substring.future
+++ b/test/types/string/StringImpl/memLeaks/substring.future
@@ -1,6 +1,0 @@
-bug: Implementation of this() and expected output of test do not agree.
-
-The test feeds in a negative index, expecting an empty string to be returned.
-Instead the 'this' function errors out due to an invalid index.
-
-A design decision needs to be made regarding the desired behavior.

--- a/test/types/string/StringImpl/memLeaks/substring.good
+++ b/test/types/string/StringImpl/memLeaks/substring.good
@@ -1,40 +1,28 @@
 === local substring
-
-
 b
+sub
 bst
-
-
+bstring
 === local substring
-
-
 b
+sub
 bst
-
-
+bstring
 === remote substring
-
-
-
-
 b
 b
+sub
+sub
 bst
 bst
-
-
-
-
+bstring
+bstring
 === remote substring
-
-
-
-
 b
 b
+sub
+sub
 bst
 bst
-
-
-
-
+bstring
+bstring


### PR DESCRIPTION
string's autoCopy and initCopy use the value of owned from the source
string to chose whether to allocate a new buffer or not. This should
significantly speed up copies of string literals.

Also fixes up some tests.