### PR TITLE
Add temporary prediff for whitebox testing to quiet libu warning

### DIFF
--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -7,6 +7,9 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 
+# quiet libu warning about cpuid detection failure untill it's fixed in CCE 8.4
+export CHPL_SYSTEM_PREDIFF="${CHPL_HOME}/util/test/prediff-for-libu-warning"
+
 # Run the tests!
 nightly_args="-cron"
 log_info "Calling nightly with args: ${nightly_args}"

--- a/util/test/prediff-for-libu-warning
+++ b/util/test/prediff-for-libu-warning
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+#
+# Filter out warnings about libu not detecting which processor we're on with
+# CCE 8.4 on our whitebox machines.
+#
+
+import sys
+
+logfile = sys.argv[2]
+
+data = ''
+with open(logfile, 'r') as f:
+    data = f.read()
+    data = data.replace('WARNING: libu: memcpy AMD cpuid detection failed\n\0', '')
+
+with open(logfile, 'w') as f:
+    f.write(data)


### PR DESCRIPTION
Since upgrading to cce 8.4 we get a warning from libu saying:
  "WARNING: libu: memcpy AMD cpuid detection failed"

Until this can be resolved, I'm adding a prediff to filter the warning out.