### PR TITLE
Execute system prediffs for tests that are only compiled

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1380,6 +1380,14 @@ for testname in testsrc:
             complogfile.write('%s'%(output))
             complogfile.close()
 
+            if systemPrediff:
+                sys.stdout.write('[Executing system-wide prediff]\n')
+                sys.stdout.flush()
+                subprocess.Popen([systemPrediff,
+                                  execname,complog,compiler,
+                                  ' '.join(envCompopts)+' '+compopts,
+                                  ' '.join(args)]).wait()
+
             if globalPrediff:
                 sys.stdout.write('[Executing ./PREDIFF]\n')
                 sys.stdout.flush()


### PR DESCRIPTION
We executes directory and individual prediffs for tests that were only compiled
but not executed, however we missed doing the system prediff.

This resulted in a few tests still failing for XC whitebox w/ CCE.