### PR TITLE
Removed unused conditions in flattenFunctions.cpp

### DIFF
--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -214,10 +214,7 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
               CallExpr* call = toCallExpr(se->parentExpr);
               INT_ASSERT(call);
               FnSymbol* fnc = call->isResolved();
-              if ((call->isPrimitive(PRIM_MOVE) && call->get(1) == se) ||
-                  (call->isPrimitive(PRIM_ASSIGN) && call->get(1) == se) ||
-                  (call->isPrimitive(PRIM_SET_MEMBER) && call->get(1) == se) ||
-                  (call->isPrimitive(PRIM_GET_MEMBER)) ||
+              if ((call->isPrimitive(PRIM_GET_MEMBER)) ||
                   (call->isPrimitive(PRIM_GET_MEMBER_VALUE)) ||
                   (call->isPrimitive(PRIM_WIDE_GET_LOCALE)) ||
                   (call->isPrimitive(PRIM_WIDE_GET_NODE)) ||


### PR DESCRIPTION
With Michael's lead, testing showed that a couple of checks
in replaceVarUsesWithFormals() either do not fire
or in any case do not affect compilation.

This PR removes those checks.
