### PR TITLE
Remove yieldArrayByRef because it does nothing

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -843,61 +843,9 @@ static void localizeIteratorReturnSymbols() {
   }
 }
 
-
-//
-// Convert:
-// (248842 CallExpr move
-//   (248843 SymExpr 'ret[248825]:[domain(...)] int(64)[803094]')
-//   (248839 CallExpr
-//     (838015 SymExpr 'fn =[835984]:[domain(...)] int(64)[803094]')
-//     (248841 SymExpr 'ret[248825]:[domain(...)] int(64)[803094]')
-//     (193499 SymExpr 'p[113796]:[domain(...)] int(64)[803094]'))
-// to:
-// (248842 CallExpr move
-//   (248843 SymExpr 'ret[248825]:[domain(...)] int(64)[803094]')
-//   (193499 SymExpr 'p[113796]:[domain(...)] int(64)[803094]'))
-//
-static void
-yieldArraysByRef() {
-  forv_Vec(CallExpr, call, gCallExprs) {
-    // The ifs are ordered with simpler checks first.
-    // Watch out for *initializations* of 'ret' - they look similar.
-    if (call->isPrimitive(PRIM_MOVE)) {
-      if (FnSymbol* fn = toFnSymbol(call->parentSymbol)) {
-        if (fn->isIterator() &&
-            fn->hasFlag(FLAG_SPECIFIED_RETURN_TYPE))
-        {
-          Symbol* ret = fn->getReturnSymbol();
-          INT_ASSERT(ret);
-          if (ret->type->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE)) {
-            if (SymExpr* dest = toSymExpr(call->get(1))) {
-              if (dest->var == ret) {
-                CallExpr* source = toCallExpr(call->get(2));
-                INT_ASSERT(source);
-                FnSymbol* sourceFun = source->isResolved();
-                INT_ASSERT(sourceFun);
-                INT_ASSERT(!strcmp(sourceFun->name, "="));
-                SymExpr* sourceArg1 = toSymExpr(source->get(1));
-                INT_ASSERT(sourceArg1);
-                INT_ASSERT(sourceArg1->var == ret);
-                Expr* sourceArg2 = source->get(2);
-                INT_ASSERT(sourceArg2);
-                // OK, got it. Do the replacement.
-                source->replace(sourceArg2->remove());
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-
 // processIteratorYields is a separate pass, called before flattenFunctions.
 // TODO: Move this and supporting functions into their own source file.
 void processIteratorYields() {
-  yieldArraysByRef();
   localizeIteratorReturnSymbols();
 }
 


### PR DESCRIPTION
We prepared this patch because on string-as-rec, the location in the compiler passes where insertReferenceTemps is run moved from callDestructors to resolveIntents. Therefore, Vass and Michael checked over the code that now has to work with reference temps and identified code patterns that would be wrong (unless they are updated). In particular, we identified this case and also the case in PR #2362. Neither of them appear to matter.

This code never runs. Verified that by adding asserts and doing full test runs with GASNet and single locale. Reviewed by Vass.