### PR TITLE
Improve application of FLAG_AUTO_DESTROY_FN in compiler

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -509,6 +509,7 @@ resolveAutoDestroy(Type* type) {
   chpl_gen_main->insertAtHead(new DefExpr(tmp));
   CallExpr* call = new CallExpr("chpl__autoDestroy", tmp);
   FnSymbol* fn = resolveUninsertedCall(type, call);
+  fn->addFlag(FLAG_AUTO_DESTROY_FN);
   resolveFns(fn);
   autoDestroyMap.put(type, fn);
   tmp->defPoint->remove();


### PR DESCRIPTION
This commit just adds the flag FLAG_AUTO_DESTROY_FN to all autoDestroy functions
that are mapped to types in function resolution, as suggested by Michael.  It gets around
what I observed in the module code, which was that some chpl__autoDestroy functions
had the pragma applied to them and some did not (and thus some of these functions
had the flag applied and some didn't).  I believe that if this change works, we will not
need the pragma in the module code any more either, which would be nice, and that
a similar change could be done for FLAG_AUTO_COPY_FN.

I encountered this when investigating a change on the string-as-rec branch.
The problem is likely also visible on master, and this change could lead to
removing the pragma version of the flag and its application in module code, so
I figured it was a good thing independent of its use to me in string-as-rec.