### PR TITLE
Ensure that locales are setup before attempting parallel init

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -697,7 +697,7 @@ module ChapelBase {
     // larger and smaller arrays.
     //
 
-    if parallelInitElts {
+    if parallelInitElts && here != dummyLocale {
       extern proc chpl_getSysPageSize():size_t;
       const pagesizeInBytes = chpl_getSysPageSize().safeCast(int);
 


### PR DESCRIPTION
Check that here != dummyLocale before trying to do parallel init. We need here
to be setup before were try to do parallel iteration over a range. Numa
requires this for correctness and flat wants it so that it can get a correct
value out of here.maxTaskPar.