### PR TITLE
Fix cutoff of compopts and execopts passed from paratest to start_test

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1300,14 +1300,14 @@ def parser_setup():
 def preprocess_options():
     index = 0
     for arg in sys.argv:
-        if (arg == "-compopts" or arg == "--compopts" 
-                or arg == "-execopts" or arg == "--execopts"):
+        arg = arg.replace('\"', '').replace('\'', '')
+        if arg in ["-compopts", "--compopts", "-execopts", "--execopts"]:
             escape_next_argument(sys.argv, index)
         index += 1
 
 
 def escape_next_argument(args, index):
-    next = args[index + 1]
+    next = args[index + 1].strip()
     if next and next[0] == "-": # single argument, not escaped
         args[index + 1] = "'{0}'".format(next)
     print(args)


### PR DESCRIPTION
Previously compopts and execopts that were passed to paratest were cutoff when
they were passed to start_test. i.e. something like '-compopts --no-checks'
would be seen by start_test as "--no-check".

This is because we have to handle compopts and execopts processing specially
since argparse doesn't support argument values that start with dashes. It
interprets something like '-compopts --no-checks' as two separate optional
arguments rather than --no-checks being the value of -compopts. To get around
this we pre-process sys.args and quote any values after '-compopts',
'--compopts', '-execopts', and '--execopts'. We then strip the extra quotes out
later.  However, we weren't quoting the compopts and execopts that came form
paratest because paratest added a space before them which threw off of
conditional check.