### PR TITLE
Quiet cygwin regressions

### DIFF
--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -332,17 +332,13 @@ void chpl_sync_initAux(chpl_sync_aux_t *s) {
 }
 
 static void chpl_thread_condvar_destroy(chpl_thread_condvar_t* cv) {
-  if(pthread_cond_broadcast((pthread_cond_t*) cv))
-    chpl_internal_error("pthread_cond_broadcast() failed, cv was uninitialized");
   if (pthread_cond_destroy((pthread_cond_t*) cv))
     chpl_internal_error("pthread_cond_destroy() failed");
 }
 
 void chpl_sync_destroyAux(chpl_sync_aux_t *s) {
-  chpl_thread_mutexLock(&s->lock);
   chpl_thread_condvar_destroy(&s->signal_full);
   chpl_thread_condvar_destroy(&s->signal_empty);
-  chpl_thread_mutexUnlock(&s->lock);
   chpl_thread_mutexDestroy(&s->lock);
 }
 

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -337,8 +337,13 @@ static void chpl_thread_condvar_destroy(chpl_thread_condvar_t* cv) {
 }
 
 void chpl_sync_destroyAux(chpl_sync_aux_t *s) {
+// Leak condvars on cygwin. Some bug results from condvars still being used at
+// this point on cygwin. For now, just leak them to avoid errors as a result of
+// the undefined behavior of trying to destroy an in-use condvar.
+#ifndef __CYGWIN__
   chpl_thread_condvar_destroy(&s->signal_full);
   chpl_thread_condvar_destroy(&s->signal_empty);
+#endif
   chpl_thread_mutexDestroy(&s->lock);
 }
 

--- a/test/studies/cholesky/jglewis/version2/performance/test_cholesky_performance.suppressif
+++ b/test/studies/cholesky/jglewis/version2/performance/test_cholesky_performance.suppressif
@@ -1,0 +1,4 @@
+# cygwin leaks condition variables (see JIRA issue 74)
+
+CHPL_TARGET_PLATFORM==cygwin32
+CHPL_TARGET_PLATFORM==cygwin64


### PR DESCRIPTION
Cygwin started having several sporadic failures with a patch that improved
sync/single cleanup (5fe4ff78cfb5.) The main change from that patch is that
sync/single variable are actually being destroyed. For fifo, this means that
the mutex and condition variables used to implement the syncs/singles are now
being destroyed. For some reason the destruction of the condition variables
resulted in these sporadic regressions.

In an attempt to quiet some of the cygwin failures, the condvar destruction was
wrapped with a mutex lock/unlock and each condvar destroy was preceded by a
broadcast. This seemed to help cygwin a bit, however according to the man page:

"
It is safe to destroy an initialised condition variable upon which no threads
are currently blocked. Attempting to destroy a condition variable upon which
other threads are currently blocked results in undefined behavior.
"

This means that no other threads should be using the condition variable. It is
a bug if they are, so we shouldn't need the broadcast since there shouldn't be
any blocked threads and the mutex lock and unlock aren't needed because no
others threads should be executing this code concurrently. Based on that
reasoning, this patch removes the lock/unlock as well as the broadcast.

Getting rid of that code does make the situation worse for cygwin (more
timeouts/sporadic failures.) For now we simply leak condition variables under
cygwin. This should resolve all the current sporadic failures. While we're no
longer destroying the condition variables, we are still destroying the mutex so
we're still in a better state than prior to 5fe4ff78cfb5. Note that all
non-cygwin platforms do destroy the condition variables as well.

It's been difficult to track down the root cause of this issue. Since cygwin
isn't a high priority platform and we have a release coming, this is merely
meant to serve as a stopgap solution to quiet nightly testing and to improve
the situation for the release. I'll put all notes in a JIRA story to be picked
up for next release.
