### PR TITLE
Add some op= primitives to local block implementation

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -1496,7 +1496,16 @@ static void localizeCall(CallExpr* call) {
         insertLocalTemp(call->get(1));
       }
       break;
+    case PRIM_MULT_ASSIGN:
+    case PRIM_ADD_ASSIGN:
+    case PRIM_SUBTRACT_ASSIGN:
+    case PRIM_DIV_ASSIGN:
+      if (isFullyWide(call->get(1))) {
+        insertLocalTemp(call->get(1));
+      }
+      break;
     default:
+      DEBUG_PRINTF("Local block cannot handle primitive: %s\n", call->primitive->name);
       break;
     }
   }


### PR DESCRIPTION
The implementation of local blocks was written in the old two-pass world prior to #2178, which basically copied the same implementation. This implementation isn't as effective in the new one-pass approach, and in a few cases has resulted in less-effective local blocks. One particular case is found in the hpcc 2012 version of HPL and causes a significant performance regression due to a PRIM_SUBTRACT_ASSIGN.

The short-term solution is to handle some op= primitives that may cause communication.

This has passed no-local and gasnet testing.