### PR TITLE
Remove pragma "auto destroy fn" from module and test code, and remove pragmaness

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -45,7 +45,7 @@ symbolFlag( FLAG_ASSIGNOP, npr, "assignop", "this fn is assignment or an <op>= o
 symbolFlag( FLAG_ATOMIC_MODULE , ypr, "atomic module" , "module containing implementations of atomic types" )
 symbolFlag( FLAG_ATOMIC_TYPE , ypr, "atomic type" , "type that implements an atomic" )
 symbolFlag( FLAG_AUTO_COPY_FN,  ypr, "auto copy fn" , "auto copy function" )
-symbolFlag( FLAG_AUTO_DESTROY_FN,  ypr, "auto destroy fn" , "auto destroy function" )
+symbolFlag( FLAG_AUTO_DESTROY_FN,  npr, "auto destroy fn" , "auto destroy function" )
 symbolFlag( FLAG_AUTO_DESTROY_FN_SYNC, ypr, "auto destroy fn sync", "auto destroy function for sync/single" )
 symbolFlag( FLAG_AUTO_II , npr, "auto ii" , ncm )
 symbolFlag( FLAG_BASE_ARRAY , ypr, "base array" , ncm )

--- a/modules-minimal/internal/ChapelBase.chpl
+++ b/modules-minimal/internal/ChapelBase.chpl
@@ -46,7 +46,6 @@ module ChapelBase {
   pragma "auto copy fn"
   inline proc chpl__autoCopy(x) return chpl__initCopy(x);
 
-  pragma "auto destroy fn"
   inline proc chpl__autoDestroy(x: ?t) {
     __primitive("call destructor", x);
   }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1122,29 +1122,27 @@ module ChapelBase {
   inline proc chpl__maybeAutoDestroyed(x: object) param return false;
   inline proc chpl__maybeAutoDestroyed(x) param return true;
 
-  pragma "auto destroy fn" inline proc chpl__autoDestroy(x: object) { }
-  pragma "auto destroy fn" inline proc chpl__autoDestroy(type t)  { }
-  pragma "auto destroy fn"
+  inline proc chpl__autoDestroy(x: object) { }
+  inline proc chpl__autoDestroy(type t)  { }
   inline proc chpl__autoDestroy(x: ?t) {
     __primitive("call destructor", x);
   }
-  pragma "auto destroy fn"
   inline proc chpl__autoDestroy(ir: _iteratorRecord) {
     // body inserted during call destructors pass
   }
   pragma "dont disable remote value forwarding"
   pragma "removable auto destroy"
-  pragma "auto destroy fn" proc chpl__autoDestroy(x: _distribution) {
+  proc chpl__autoDestroy(x: _distribution) {
     __primitive("call destructor", x);
   }
   pragma "dont disable remote value forwarding"
   pragma "removable auto destroy"
-  pragma "auto destroy fn" proc chpl__autoDestroy(x: domain) {
+  proc chpl__autoDestroy(x: domain) {
     __primitive("call destructor", x);
   }
   pragma "dont disable remote value forwarding"
   pragma "removable auto destroy"
-  pragma "auto destroy fn" proc chpl__autoDestroy(x: []) {
+  proc chpl__autoDestroy(x: []) {
     __primitive("call destructor", x);
   }
   

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -316,12 +316,10 @@ module ChapelSyncvar {
   inline proc chpl__maybeAutoDestroyed(x: _syncvar) param return true;
   inline proc chpl__maybeAutoDestroyed(x: _singlevar) param return true;
 
-  pragma "auto destroy fn"
   pragma "auto destroy fn sync"
   inline proc chpl__autoDestroy(x: _syncvar) {
     delete x;
   }
-  pragma "auto destroy fn"
   pragma "auto destroy fn sync"
   inline proc chpl__autoDestroy(x: _singlevar) {
     delete x;

--- a/test/types/records/sungeun/classInRecord.chpl
+++ b/test/types/records/sungeun/classInRecord.chpl
@@ -9,7 +9,6 @@ record myR {
   proc ~myR() { delete c; }
 }
 
-pragma "auto destroy fn"
 inline proc chpl__autoDestroy(x: myR) { }
 
 proc =(ref a: myR, b: myR) {


### PR DESCRIPTION
Since I added this flag during resolution, these functions no longer needed to
be labeled with a pragma, they will be recognized as autoDestroys on their own.
With those removed, I disabled the ability for the flag to be added via a pragma
(since it wasn't applied to anything beyond chpl__autoDestroy()s in the module
code).