### PR TITLE
Default to using different colors for each line for multi-locale perf graphs

### DIFF
--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -119,8 +119,8 @@ if (!multiConfs) { configurations = ['']; }
 var defaultConfiguration = configurations[0];
 
 // Experimental: used to toggle how stroke pattern and line colors are used for
-// multi-configs
-var diffColorForEachConfig = false;
+// multi-configs. Default to using it for 16 node xc in a hacky way
+var diffColorForEachConfig = pageTitle.indexOf("16 node XC") >= 0;
 
 // This is used to get the next div for the graph and legend. This is important
 // for graph expansion because we need to be able to add the expanded graphs


### PR DESCRIPTION
There's been an to use different colors instead of different stroke patterns
for lines. This is especially useful on xc graphs where there's usually only 1
line per config. Making this the default, so you don't always have to toggle
it.