### PR TITLE
Move most task callback support into common code.

### DIFF
--- a/runtime/include/chpl-tasks-callbacks-internal.h
+++ b/runtime/include/chpl-tasks-callbacks-internal.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_tasks_callbacks_internal_h_
+#define _chpl_tasks_callbacks_internal_h_
+
+#include <assert.h>
+#include <stdint.h>
+
+#include "chpl-tasks-callbacks.h"
+
+
+//
+// Don't refer to this directly.  It's only here in public to support
+// reducing overhead by inlining the test for >0.
+//
+int chpl_task_callback_counts[chpl_task_cb_num_event_kinds];
+
+
+void chpl_task_do_callbacks_really(chpl_task_cb_event_kind_t,
+                                   const char* filename,
+                                   int lineno,
+                                   uint64_t id,
+                                   int is_executeOn);
+
+
+static inline
+int chpl_task_have_callbacks(chpl_task_cb_event_kind_t event_kind) {
+  assert(event_kind < chpl_task_cb_num_event_kinds);
+  return (chpl_task_callback_counts[event_kind] > 0);
+}
+
+
+static inline
+void chpl_task_do_callbacks(chpl_task_cb_event_kind_t event_kind,
+                            const char* filename,
+                            int lineno,
+                            uint64_t id,
+                            int is_executeOn) {
+  if (chpl_task_have_callbacks(event_kind))
+    chpl_task_do_callbacks_really(event_kind,
+                                  filename, lineno, id, is_executeOn);
+}
+
+#endif

--- a/runtime/include/chpl-tasks-callbacks-internal.h
+++ b/runtime/include/chpl-tasks-callbacks-internal.h
@@ -33,11 +33,11 @@
 int chpl_task_callback_counts[chpl_task_cb_num_event_kinds];
 
 
-void chpl_task_do_callbacks_really(chpl_task_cb_event_kind_t,
-                                   const char* filename,
-                                   int lineno,
-                                   uint64_t id,
-                                   int is_executeOn);
+void chpl_task_do_callbacks_internal(chpl_task_cb_event_kind_t,
+                                     const char* filename,
+                                     int lineno,
+                                     uint64_t id,
+                                     int is_executeOn);
 
 
 static inline
@@ -54,8 +54,8 @@ void chpl_task_do_callbacks(chpl_task_cb_event_kind_t event_kind,
                             uint64_t id,
                             int is_executeOn) {
   if (chpl_task_have_callbacks(event_kind))
-    chpl_task_do_callbacks_really(event_kind,
-                                  filename, lineno, id, is_executeOn);
+    chpl_task_do_callbacks_internal(event_kind,
+                                    filename, lineno, id, is_executeOn);
 }
 
 #endif

--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -42,6 +42,7 @@ COMMON_NOGEN_SRCS = \
         chpl-string.c \
 	chplsys.c \
 	chpl-tasks.c \
+	chpl-tasks-callbacks.c \
 	chpl-timers.c \
 	chpl-visual-debug.c \
 	gdb.c \

--- a/runtime/src/chpl-tasks-callbacks.c
+++ b/runtime/src/chpl-tasks-callbacks.c
@@ -101,11 +101,11 @@ int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
 }
 
 
-void chpl_task_do_callbacks_really(chpl_task_cb_event_kind_t event_kind,
-                                   const char* filename,
-                                   int lineno,
-                                   uint64_t id,
-                                   int is_executeOn) {
+void chpl_task_do_callbacks_internal(chpl_task_cb_event_kind_t event_kind,
+                                     const char* filename,
+                                     int lineno,
+                                     uint64_t id,
+                                     int is_executeOn) {
   struct cb_info* cbp;
   chpl_task_cb_info_t info;
   int i;

--- a/runtime/src/chpl-tasks-callbacks.c
+++ b/runtime/src/chpl-tasks-callbacks.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Shared code for tasking callbacks.
+//
+#include "chplrt.h"
+
+#include "chpl-comm.h"
+#include "error.h"
+#include "chpl-tasks-callbacks.h"
+#include "chpl-tasks-callbacks-internal.h"
+
+
+//
+// Tasking callback support.
+//
+#define MAX_CBS_PER_EVENT 10
+
+static struct cb_info {
+  chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
+  chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
+} cb_info[chpl_task_cb_num_event_kinds];
+
+
+//
+// Tasking callback support.
+//
+int chpl_task_install_callback(chpl_task_cb_event_kind_t event_kind,
+                               chpl_task_cb_info_kind_t info_kind,
+                               chpl_task_cb_fn_t cb_fn) {
+  int i;
+
+  if (event_kind >= chpl_task_cb_num_event_kinds) {
+    errno = ERANGE;
+    return -1;
+  }
+
+  i = chpl_task_callback_counts[event_kind];
+
+  if (i >= MAX_CBS_PER_EVENT) {
+    errno = ENOMEM;
+    return -1;
+  }
+
+  chpl_task_callback_counts[event_kind]++;
+
+  cb_info[event_kind].fns[i]= cb_fn;
+  cb_info[event_kind].info_kinds[i] = info_kind;
+
+  return 0;
+}
+
+
+int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
+                                 chpl_task_cb_fn_t cb_fn) {
+  int i;
+  int found_i;
+
+  if (event_kind >= chpl_task_cb_num_event_kinds) {
+    errno = ERANGE;
+    return -1;
+  }
+
+  for (i = 0, found_i = -1; i < chpl_task_callback_counts[event_kind]; i++) {
+    if (cb_info[event_kind].fns[i] == cb_fn) {
+      found_i = i;
+      break;
+    }
+  }
+
+  if (found_i < 0) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  for (i = found_i + 1; i < chpl_task_callback_counts[event_kind]; i++) {
+    cb_info[event_kind].fns[i - 1] = cb_info[event_kind].fns[i];
+    cb_info[event_kind].info_kinds[i - 1] = cb_info[event_kind].info_kinds[i];
+  }
+
+  chpl_task_callback_counts[event_kind]--;
+
+  return 0;
+}
+
+
+void chpl_task_do_callbacks_really(chpl_task_cb_event_kind_t event_kind,
+                                   const char* filename,
+                                   int lineno,
+                                   uint64_t id,
+                                   int is_executeOn) {
+  struct cb_info* cbp;
+  chpl_task_cb_info_t info;
+  int i;
+
+  cbp = &cb_info[event_kind];
+
+  info.nodeID = chpl_nodeID;
+  info.event_kind = event_kind;
+
+  for (i = 0; i < chpl_task_callback_counts[event_kind]; i++) {
+    info.info_kind = cbp->info_kinds[i];
+
+    switch (cbp->info_kinds[i]) {
+    case chpl_task_cb_info_kind_full:
+      info.iu.full.filename = filename;
+      info.iu.full.lineno = lineno;
+      info.iu.full.id = id;
+      info.iu.full.is_executeOn = is_executeOn;
+      break;
+
+    case chpl_task_cb_info_kind_id_only:
+      info.iu.id_only.id = id;
+      break;
+
+    default:
+      chpl_internal_error("bad callback info kind");
+      break;
+    }
+
+    (*cbp->fns[i])((const chpl_task_cb_info_t*) &info);
+  }
+}

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -29,6 +29,7 @@
 #include "chpl-locale-model.h"
 #include "chpl-mem.h"
 #include "chpl-tasks.h"
+#include "chpl-tasks-callbacks-internal.h"
 #include "chplsys.h"
 #include "error.h"
 #include <stdio.h>
@@ -146,17 +147,6 @@ static c_string idleTaskName = "|idle|";
 static chpl_fn_p comm_task_fn;
 
 //
-// Tasking callback support.
-//
-#define MAX_CBS_PER_EVENT 10
-
-static struct cb_info {
-  chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
-  chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
-  int count;
-} cb_info[chpl_task_cb_num_event_kinds];
-
-//
 // Internal functions.
 //
 static void                    comm_task_wrapper(void*);
@@ -184,8 +174,6 @@ static task_pool_p             add_to_task_pool(chpl_fn_p,
                                                 chpl_bool,
                                                 chpl_task_prvDataImpl_t,
                                                 chpl_task_list_p);
-static void                    do_callbacks(chpl_task_cb_event_kind_t,
-                                            const task_pool_p);
 
 //
 // Condition variable methods
@@ -620,7 +608,11 @@ void chpl_task_processTaskList(chpl_task_list_p task_list) {
     nested_task.lineno       = first_task->lineno;
     nested_task.chpl_data    = curr_ptask->chpl_data;
 
-    do_callbacks(chpl_task_cb_event_kind_create, &nested_task);
+    chpl_task_do_callbacks(chpl_task_cb_event_kind_create,
+                           nested_task.filename,
+                           nested_task.lineno,
+                           nested_task.id,
+                           nested_task.is_executeOn);
 
     set_current_ptask(&nested_task);
 
@@ -645,11 +637,19 @@ void chpl_task_processTaskList(chpl_task_list_p task_list) {
     if (blockreport)
       initializeLockReportForThread();
 
-    do_callbacks(chpl_task_cb_event_kind_begin, &nested_task);
+    chpl_task_do_callbacks(chpl_task_cb_event_kind_begin,
+                           nested_task.filename,
+                           nested_task.lineno,
+                           nested_task.id,
+                           nested_task.is_executeOn);
 
     (*first_task->fun)(first_task->arg);
 
-    do_callbacks(chpl_task_cb_event_kind_end, &nested_task);
+    chpl_task_do_callbacks(chpl_task_cb_event_kind_end,
+                           nested_task.filename,
+                           nested_task.lineno,
+                           nested_task.id,
+                           nested_task.is_executeOn);
 
     // begin critical section
     chpl_thread_mutexLock(&extra_task_lock);
@@ -755,11 +755,19 @@ void chpl_task_executeTasksInList(chpl_task_list_p task_list) {
         if (blockreport)
           initializeLockReportForThread();
 
-        do_callbacks(chpl_task_cb_event_kind_begin, nested_ptask);
+        chpl_task_do_callbacks(chpl_task_cb_event_kind_begin,
+                               nested_ptask->filename,
+                               nested_ptask->lineno,
+                               nested_ptask->id,
+                               nested_ptask->is_executeOn);
 
         (*task_to_run_fun)(task_to_run_arg);
 
-        do_callbacks(chpl_task_cb_event_kind_end, nested_ptask);
+        chpl_task_do_callbacks(chpl_task_cb_event_kind_end,
+                               nested_ptask->filename,
+                               nested_ptask->lineno,
+                               nested_ptask->id,
+                               nested_ptask->is_executeOn);
 
         if (do_taskReport) {
           chpl_thread_mutexLock(&taskTable_lock);
@@ -1208,11 +1216,19 @@ thread_begin(void* ptask_void) {
       chpl_thread_mutexUnlock(&taskTable_lock);
     }
 
-    do_callbacks(chpl_task_cb_event_kind_begin, ptask);
+    chpl_task_do_callbacks(chpl_task_cb_event_kind_begin,
+                           ptask->filename,
+                           ptask->lineno,
+                           ptask->id,
+                           ptask->is_executeOn);
 
     (*ptask->fun)(ptask->arg);
 
-    do_callbacks(chpl_task_cb_event_kind_end, ptask);
+    chpl_task_do_callbacks(chpl_task_cb_event_kind_end,
+                           ptask->filename,
+                           ptask->lineno,
+                           ptask->id,
+                           ptask->is_executeOn);
 
     if (do_taskReport) {
       chpl_thread_mutexLock(&taskTable_lock);
@@ -1501,7 +1517,11 @@ static task_pool_p add_to_task_pool(chpl_fn_p fp,
 
   queued_task_cnt++;
 
-  do_callbacks(chpl_task_cb_event_kind_create, ptask);
+  chpl_task_do_callbacks(chpl_task_cb_event_kind_create,
+                         ptask->filename,
+                         ptask->lineno,
+                         ptask->id,
+                         ptask->is_executeOn);
 
   if (do_taskReport) {
     chpl_thread_mutexLock(&taskTable_lock);
@@ -1535,108 +1555,3 @@ uint32_t chpl_task_getNumIdleThreads(void) {
   assert(numIdleThreads >= 0);
   return numIdleThreads;
 }
-
-
-//
-// Tasking callback support.
-//
-int chpl_task_install_callback(chpl_task_cb_event_kind_t event_kind,
-                               chpl_task_cb_info_kind_t info_kind,
-                               chpl_task_cb_fn_t cb_fn) {
-  int i;
-
-  if (event_kind >= chpl_task_cb_num_event_kinds) {
-    errno = ERANGE;
-    return -1;
-  }
-
-  i = cb_info[event_kind].count;
-
-  if (i >= MAX_CBS_PER_EVENT) {
-    errno = ENOMEM;
-    return -1;
-  }
-
-  cb_info[event_kind].count++;
-  cb_info[event_kind].fns[i]= cb_fn;
-  cb_info[event_kind].info_kinds[i] = info_kind;
-
-  return 0;
-}
-
-
-int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
-                                 chpl_task_cb_fn_t cb_fn) {
-  int i;
-  int found_i;
-
-  if (event_kind >= chpl_task_cb_num_event_kinds) {
-    errno = ERANGE;
-    return -1;
-  }
-
-  for (i = 0, found_i = -1; i < cb_info[event_kind].count; i++) {
-    if (cb_info[event_kind].fns[i] == cb_fn) {
-      found_i = i;
-      break;
-    }
-  }
-
-  if (found_i < 0) {
-    errno = ENOENT;
-    return -1;
-  }
-
-  for (i = found_i + 1; i < cb_info[event_kind].count; i++) {
-    cb_info[event_kind].fns[i - 1] = cb_info[event_kind].fns[i];
-    cb_info[event_kind].info_kinds[i - 1] = cb_info[event_kind].info_kinds[i];
-  }
-
-  cb_info[event_kind].count--;
-
-  return 0;
-}
-
-
-static void do_callbacks(chpl_task_cb_event_kind_t event_kind,
-                         const task_pool_p ptask) {
-  struct cb_info* cbp;
-
-  assert(event_kind < chpl_task_cb_num_event_kinds);
-
-  cbp = &cb_info[event_kind];
-
-  if (cbp->count > 0) {
-    chpl_task_cb_info_t info;
-    int i;
-
-    info.nodeID = chpl_nodeID;
-    info.event_kind = event_kind;
-
-    for (i = 0; i < cbp->count; i++) {
-      info.info_kind = cbp->info_kinds[i];
-
-      switch (cbp->info_kinds[i]) {
-      case chpl_task_cb_info_kind_full:
-        info.iu.full = (struct chpl_task_info_full)
-                       { .filename = ptask->filename,
-                         .lineno = ptask->lineno,
-                         .id = ptask->id,
-                         .is_executeOn = ptask->is_executeOn
-                       };
-        break;
-
-      case chpl_task_cb_info_kind_id_only:
-        info.iu.id_only.id = ptask->id;
-        break;
-
-      default:
-        assert(false);
-        break;
-      }
-
-      (*cbp->fns[i])((const chpl_task_cb_info_t*) &info);
-    }
-  }
-}
-

--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -21,6 +21,7 @@
 #include "chpl-comm.h"
 #include "chpl-locale-model.h"
 #include "chpl-tasks.h"
+#include "chpl-tasks-callbacks-internal.h"
 #include "config.h"
 #include "error.h"
 #include "arg.h"
@@ -623,117 +624,16 @@ void chpl_task_exit(void)
 #endif /* QTHREAD_MULTINODE */
 }
 
-//
-// Tasking callback support.
-//
-#define MAX_CBS_PER_EVENT 10
-
-static struct cb_info {
-    chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
-    chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
-    int count;
-} cb_info[chpl_task_cb_num_event_kinds];
-
-int chpl_task_install_callback(chpl_task_cb_event_kind_t event_kind,
-                               chpl_task_cb_info_kind_t info_kind,
-                               chpl_task_cb_fn_t cb_fn) {
-    int i;
-
-    if (event_kind >= chpl_task_cb_num_event_kinds) {
-        errno = ERANGE;
-        return -1;
-    }
-
-    i = cb_info[event_kind].count;
-
-    if (i >= MAX_CBS_PER_EVENT) {
-        errno = ENOMEM;
-        return -1;
-    }
-
-    cb_info[event_kind].count++;
-    cb_info[event_kind].fns[i]= cb_fn;
-    cb_info[event_kind].info_kinds[i] = info_kind;
-
-    return 0;
-}
-
-int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
-                                 chpl_task_cb_fn_t cb_fn) {
-    int i;
-    int found_i;
-
-    if (event_kind >= chpl_task_cb_num_event_kinds) {
-        errno = ERANGE;
-        return -1;
-    }
-
-    for (i = 0, found_i = -1; i < cb_info[event_kind].count; i++) {
-        if (cb_info[event_kind].fns[i] == cb_fn) {
-            found_i = i;
-            break;
-        }
-    }
-
-    if (found_i < 0) {
-        errno = ENOENT;
-        return -1;
-    }
-
-    for (i = found_i + 1; i < cb_info[event_kind].count; i++) {
-        cb_info[event_kind].fns[i - 1] =
-            cb_info[event_kind].fns[i];
-        cb_info[event_kind].info_kinds[i - 1] =
-            cb_info[event_kind].info_kinds[i];
-    }
-
-    cb_info[event_kind].count--;
-
-    return 0;
-}
-
-static inline void do_callbacks(chpl_task_cb_event_kind_t event_kind,
-                                chpl_task_prvDataImpl_t *chpl_data) {
-    struct cb_info *cbp;
-
-    assert(event_kind < chpl_task_cb_num_event_kinds);
-
-    cbp = &cb_info[event_kind];
-
-    if (cbp->count > 0) {
-        chpl_task_cb_info_t info;
-        int i;
-
-        info.nodeID = chpl_nodeID;
-        info.event_kind = event_kind;
-
+static inline void wrap_callbacks(chpl_task_cb_event_kind_t event_kind,
+                                  chpl_task_prvDataImpl_t *chpl_data) {
+    if (chpl_task_have_callbacks(event_kind)) {
         if (chpl_data->id == chpl_nullTaskID)
             chpl_data->id = qthread_incr(&next_task_id, 1);
-
-        for (i = 0; i < cbp->count; i++) {
-            info.info_kind = cbp->info_kinds[i];
-
-            switch (cbp->info_kinds[i]) {
-            case chpl_task_cb_info_kind_full:
-                info.iu.full = (struct chpl_task_info_full)
-                               { .filename = chpl_data->task_filename,
-                                 .lineno = chpl_data->task_lineno,
-                                 .id = chpl_data->id,
-                                 .is_executeOn = chpl_data->is_executeOn
-                               };
-              break;
-
-            case chpl_task_cb_info_kind_id_only:
-                info.iu.id_only.id = chpl_data->id;
-                break;
-
-            default:
-                assert(false);
-                break;
-            }
-
-            (*cbp->fns[i])((const chpl_task_cb_info_t*) &info);
-        }
+        chpl_task_do_callbacks(event_kind,
+                               chpl_data->task_filename,
+                               chpl_data->task_lineno,
+                               chpl_data->id,
+                               chpl_data->is_executeOn);
     }
 }
 
@@ -750,11 +650,11 @@ static aligned_t chapel_wrapper(void *arg)
         chpl_taskRunningCntInc(0, NULL);
     }
 
-    do_callbacks(chpl_task_cb_event_kind_begin, &data->chpl_data);
+    wrap_callbacks(chpl_task_cb_event_kind_begin, &data->chpl_data);
 
     (*(chpl_fn_p)(rarg->fn))(rarg->args);
 
-    do_callbacks(chpl_task_cb_event_kind_end, &data->chpl_data);
+    wrap_callbacks(chpl_task_cb_event_kind_end, &data->chpl_data);
 
     if (rarg->countRunning) {
         chpl_taskRunningCntDec(0, NULL);
@@ -783,7 +683,7 @@ void chpl_task_callMain(void (*chpl_main)(void))
     assert(SPR_OK == rc);
 #endif /* QTHREAD_MULTINODE */
 
-    do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
+    wrap_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
 
     qthread_fork_syncvar(chapel_wrapper, &wrapper_args, &exit_ret);
     qthread_syncvar_readFF(NULL, &exit_ret);
@@ -838,7 +738,9 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
              PRV_DATA_IMPL_VAL(filename, lineno, chpl_nullTaskID, false,
                                subloc, serial_state) };
 
-        do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
+        wrap_callbacks(chpl_task_cb_event_kind_create,
+                       &wrapper_args.chpl_data);
+
         if (subloc == c_sublocid_any) {
             qthread_fork_copyargs(chapel_wrapper, &wrapper_args,
                                   sizeof(chpl_qthread_wrapper_args_t), NULL);
@@ -881,7 +783,7 @@ void chpl_task_startMovedTask(chpl_fn_p      fp,
 
     PROFILE_INCR(profile_task_startMovedTask,1);
 
-    do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
+    wrap_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
 
     if (subloc == c_sublocid_any) {
         qthread_fork_copyargs(chapel_wrapper, &wrapper_args,


### PR DESCRIPTION
The bulk of task callback support, minus common type definitions and
such, had been implemented separately in tasks=fifo and =qthreads.  Here
we move most of it into common code.  The functions that users call to
install and uninstall callbacks, and the one the tasking layers call to
actually do the callbacks, are in chpl-tasks-callbacks.c.  Definitions
for the latter and wrappers that can be inlined to reduce overhead are
in chpl-tasks-callbacks-internal.h.  All of the callback-related code
except the calls to actually do the callbacks is removed from the
qthreads and fifo tasking layers.