### PR TITLE
Allow start_test num trials default to come from the env var

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1236,7 +1236,8 @@ def parser_setup():
             "--compperformance-description", action="store", default="",
             dest="comp_performance_description")
     parser.add_argument("-numtrials", "--numtrials", "-num-trials",
-        "--num-trials", action="store", dest="num_trials", default="1",
+        "--num-trials", action="store", dest="num_trials",
+        default=os.getenv("CHPL_TEST_NUM_TRIALS", "1"),
         help="the number of times to run the performance tests")
     # graphing
     parser.add_argument("-gen-graphs", "--gen-graphs", "-generate-graphs",


### PR DESCRIPTION
With the old start_test, the default value of num trials came from the same env
var that sub_test looks for: CHPL_TEST_NUM_TRIALS. However, this functionality
was lost with the rewrite of start_test, which meant that we were defaulting to
1 trial for tiger performance jobs instead of 5 we wanted by setting
CHPL_TEST_NUM_TRIALS=5