### PR TITLE
Clean up the string implementation

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -226,7 +226,6 @@ symbolFlag( FLAG_SINGLE , ypr, "single" , ncm )
 // or something similar <hilde>.
 symbolFlag( FLAG_SPECIFIED_RETURN_TYPE , npr, "specified return type" , ncm )
 symbolFlag( FLAG_STAR_TUPLE , npr, "star tuple" , "mark tuple types as star tuple types" )
-symbolFlag( FLAG_STRING_RECORD , ypr, "string record" , ncm )
 symbolFlag( FLAG_SUPER_CLASS , npr, "super class" , ncm )
 symbolFlag( FLAG_SUPPRESS_LVALUE_ERRORS , ypr, "suppress lvalue error" , "do not report an lvalue error if it occurs in a function with this flag" )
 symbolFlag( FLAG_SYNC , ypr, "sync" , ncm )

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1208,32 +1208,9 @@ static void init_untyped_var(VarSymbol* var, Expr* init, Expr* stmt, VarSymbol* 
     if (initCall && initCall->isPrimitive(PRIM_NEW)) {
       stmt->insertAfter(new CallExpr(PRIM_MOVE, constTemp, init->remove()));
     } else {
-      // Non-param variables initialized with a string literal but
-      // without a type are assumed to be of type string.  This case
-      // must be handled here, rather than in resolution because we
-      // cannot recognize this situtation easily (if at all) during
-      // resolution due to PRIM_INIT handling.
-      //
-      // Note that we have to do a similar thing during scope resolve
-      // when building default type constructors.
-      if ((toSymExpr(init) && (toSymExpr(init)->typeInfo() == dtStringC)) &&
-          !var->hasFlag(FLAG_PARAM)) {
-        // This logic is the same as the case above under 'if (type)',
-        // but simplified for this specific case.
-        SET_LINENO(stmt);
-        VarSymbol* typeTemp = newTemp("type_tmp");
-        stmt->insertBefore(new DefExpr(typeTemp));
-        CallExpr* newInit;
-        newInit = new CallExpr(PRIM_MOVE, typeTemp,
-                               new CallExpr(PRIM_INIT, new SymExpr(dtString->symbol)));
-        stmt->insertBefore(newInit);
-        stmt->insertAfter(new CallExpr(PRIM_MOVE, constTemp, typeTemp));
-        stmt->insertAfter(new CallExpr("=", typeTemp, init->remove()));
-      } else {
-        stmt->insertAfter(
-          new CallExpr(PRIM_MOVE, constTemp,
-            new CallExpr("chpl__initCopy", init->remove())));
-      }
+      stmt->insertAfter(
+        new CallExpr(PRIM_MOVE, constTemp,
+          new CallExpr("chpl__initCopy", init->remove())));
     }
 }
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -698,33 +698,10 @@ static void build_type_constructor(AggregateType* ct) {
           fn->insertAtTail(newSet);
 
         } else if (init) {
-          // Non-param fields initialized with a string literal but
-          // without a type are assumed to be of type string.  Note
-          // that we do this for other functions/methods in
-          // fix_def_expr() in normalize.cpp.
-          if ((toSymExpr(init) &&
-               (toSymExpr(init)->typeInfo() == dtStringC)) &&
-              !field->hasFlag(FLAG_PARAM)) {
-
-            // Put in an explicit type expression for string
-            exprType = new UnresolvedSymExpr("string");
-
-            field->defPoint->exprType = exprType;
-            insert_help(exprType, init->parentExpr, init->parentSymbol);
-
-            // Now do the same as above in the 'if (exprType)' case
-            CallExpr* newInit = new CallExpr(PRIM_TYPE_INIT, exprType->copy());
-            CallExpr* newSet  = new CallExpr(PRIM_SET_MEMBER,
-                                             fn->_this,
-                                             new_CStringSymbol(field->name),
-                                             newInit);
-            fn->insertAtTail(newSet);
-          } else {
-            fn->insertAtTail(new CallExpr(PRIM_SET_MEMBER,
-                                          fn->_this,
-                                          new_CStringSymbol(field->name),
-                                          new CallExpr("chpl__initCopy", init->copy())));
-          }
+          fn->insertAtTail(new CallExpr(PRIM_SET_MEMBER,
+                                        fn->_this,
+                                        new_CStringSymbol(field->name),
+                                        new CallExpr("chpl__initCopy", init->copy())));
         }
       }
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6351,6 +6351,9 @@ resolveExpr(Expr* expr) {
         !sym->var->hasFlag(FLAG_TYPE_VARIABLE)) {
 
       if (AggregateType* ct = toAggregateType(sym->typeInfo())) {
+        // Dont try to resolve the defaultTypeConstructor for string literals
+        // (resolution ordering issue, string literals are encoutred too early
+        // on and we dont know enough to be able to resolve them at that point)
         if (!(ct == dtString && (sym->var->isParameter() || sym->var->hasFlag(FLAG_INSTANTIATED_PARAM))) &&
             !ct->symbol->hasFlag(FLAG_GENERIC) &&
             !ct->symbol->hasFlag(FLAG_ITERATOR_CLASS) &&

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -151,6 +151,13 @@ module CPtr {
   inline proc !(x: c_ptr) return x == c_nil;
 
   pragma "no doc"
+  inline proc +(a: c_ptr, b: integral) return __primitive("+", a, b);
+
+  pragma "no doc"
+  inline proc -(a: c_ptr, b: integral) return __primitive("-", a, b);
+
+
+  pragma "no doc"
   extern proc c_pointer_return(ref x:?t):c_ptr(t);
 
 

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -534,40 +534,13 @@ module ChapelIO {
   }
   
   pragma "dont disable remote value forwarding"
-  proc ref c_string.write(args ...?n) {
-    compilerError("c_string.write()");
-    //TODO strings: something...
-    /*
-    var sc = new StringWriter(this:string);
-    sc.write((...args));
-    this = sc.s._steal_base();
-    delete sc;
-    */
-  }
-  
-  pragma "dont disable remote value forwarding"
   proc ref string.write(args ...?n) {
     var sc = new StringWriter(this);
     sc.write((...args));
     this = sc.s;
     delete sc;
   }
-  
- 
-  proc _getoutputformat(s: c_string):c_string {
-    var sn = s.length;
-    var afterdot = false;
-    var dplaces = 0;
-    for i in 1..sn {
-      var ss = s.substring(i);
-      if ((ss == '#') & afterdot) then dplaces += 1;
-      if (ss == '.') then afterdot=true;
-      chpl_free_c_string_copy(ss);
-    }
-    // FIX ME: leak c_string due to concatenation
-    return("%" + sn + "." + dplaces + "f");
-  }
-  
+
   //
   // When this flag is used during compilation, calls to chpl__testPar
   // will output a message to indicate that a portion of the code has been

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -768,15 +768,6 @@ module DefaultAssociative {
     return _gen_key(hash);
   }
 
-  // TODO strings: can remove defaultHash(c_string)?
-  //inline proc chpl__defaultHash(x : c_string): int(64) {
-  //  var hash: int(64) = 0;
-  //  for c in 1..(x.length) {
-  //    hash = ((hash << 5) + hash) ^ ascii(x.substring(c));
-  //  }
-  //  return _gen_key(hash);
-  //}
-  
   inline proc chpl__defaultHash(l : []) {
       var hash : int(64) = 0;
       for obj in l {

--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -21,7 +21,6 @@
 //
 module MemTracking
 {
-  //TODO strings: super broken now
   config const
     memTrack: bool = false,
     memStats: bool = false,
@@ -95,8 +94,8 @@ module MemTracking
       // These c_strings are going to be leaked
       if s_memLeaksByDesc.len != 0 then
         ret_memLeaksByDesc = copyRemoteBuffer(s_memLeaksByDesc.locale.id,
-                                      s_memLeaksByDesc.buff,
-                                      s_memLeaksByDesc.len);
+                                              s_memLeaksByDesc.buff,
+                                              s_memLeaksByDesc.len);
       else ret_memLeaksByDesc = nil;
       if s_memLog.len != 0 then
         ret_memLog = copyRemoteBuffer(s_memLog.locale.id,


### PR DESCRIPTION
Removed some code that was left over from before the string literal type
conversion.

Also removed some debug code in String.chpl which wasn't too useful
anymore.

Various other cleanups from Michael's review.