### PR TITLE
Yet another update to PREDIFF for hplx.chpl

### DIFF
--- a/test/distributions/dm/PREDIFF
+++ b/test/distributions/dm/PREDIFF
@@ -30,6 +30,7 @@ case $testname in
      egrep -ai '^start...finish$|error|warning' $outputfile.orig \
        | grep -av 'error: attempt to dereference nil' \
        | grep -av 'FATAL ERROR:' \
+       | grep -avi 'AMUDP.*error' \
        > $outputfile
 
      echo retained the original output in $outputfile.orig


### PR DESCRIPTION
Now that I am used to handling new ways for this test to fail,
I prefer to update PREDIFF to deal with these new ways.
That way, we can keep hplx.bad around, has the advantage
of guarding against unexpected failures.

This commit continues the tradition, see e.g. 007eac5:

This test has been failing in more and more diverse ways.
I keep relaxing PREDIFF to accept these failures,
so we can have .bad and match clean against it.
