### PR TITLE
Save original output of permission_error for debugging

### DIFF
--- a/test/modules/standard/FileSystem/fsouza/chown/permission_error.prediff
+++ b/test/modules/standard/FileSystem/fsouza/chown/permission_error.prediff
@@ -2,6 +2,8 @@
 
 outfile=$2
 
+cp $outfile $outfile.orig
+
 cat $outfile | \
     sed 's/Operation not permitted/SYS_ERR/' | \
     sed 's/Invalid argument/SYS_ERR/' | \


### PR DESCRIPTION
modules/standard/FileSystem/fsouza/chown/permission_error is still failing
under cygwin64 but we can't reproduce even as chapelu using the nightly
workspace. Tuck the original output away in hopes of seeing the failure mode
from a nightly run.