### PR TITLE
Have chpl_array_alloc use alloc instead of calloc

### DIFF
--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -198,7 +198,7 @@ void chpl_check_nil(void* ptr, int32_t lineno, const char* filename)
 
 static inline
 void* chpl_array_alloc(size_t nmemb, size_t eltSize, int32_t lineno, const char* filename) {
-  return chpl_mem_allocManyZero(nmemb, eltSize, CHPL_RT_MD_ARRAY_ELEMENTS, lineno, filename);
+  return chpl_mem_allocMany(nmemb, eltSize, CHPL_RT_MD_ARRAY_ELEMENTS, lineno, filename);
 }
 
 static inline


### PR DESCRIPTION
chpl_array_alloc() was calling chpl_mem_allocManyZero, which is our wrapper for
calloc. This switches to calling chpl_mem_allocMany, which is our wrapper for
alloc.

Using calloc is a mistake for a few reasons. The first one being that it's
called chpl_array_alloc, not chpl_array_calloc. More importantly, calloc has
performance implications. For some memory layers, calloc will touch the memory,
which can give you bad first touch behavior. We initialize arrays after
allocation so not only are we double initializing, but we want the module
initialization to be responsible for first touch.

This was discovered when trying to track down why tcmalloc was still having
poor performance with stream-ep even when all the other memory tasking layers
had good first touch behavior. It turns out that tcmalloc's calloc does a
memset, which caused all memory to be allocated on NUMA domain zero.

The original switch from alloc to calloc was done as part of the early
hierarchical locale work with fd0c12909f8f3785c9212f38d8ece411289bc96f without
any real explanation for why calloc was now being used.