### PR TITLE
Revert all changes made to debug the cygwn permission_error regression

### DIFF
--- a/test/modules/standard/FileSystem/fsouza/chown/permission_error.suppressif
+++ b/test/modules/standard/FileSystem/fsouza/chown/permission_error.suppressif
@@ -1,0 +1,2 @@
+# Fails when run as a windows service, see JIRA issue 81
+SERVICE_ID == jenkinsslave-c__jenkins_chapel-ci


### PR DESCRIPTION
This test has been regressing in nightly testing for a while, but we haven't
been able to reproduce even running as chapelu and manually calling the nightly
script.

I believe the reason for this is because jenkins runs as a windows service for
cygwin64 which gives it higher permissions which allows the chown call to
succeed. There might be a way to change the permissions of the jenkins service,
but for now I'm just suppressing it when run under a windows service.

Note that the reason this doesn't fail under cygwin32 is because cygwin32
doesn't run as a windows service.

See JIRA issue 81 for more info (https://chapel.atlassian.net/browse/CHAPEL-81)
