### PR TITLE
Restructure how chplvis ignores VisualDebug tasks and communication.

### DIFF
--- a/modules/standard/VisualDebug.chpl
+++ b/modules/standard/VisualDebug.chpl
@@ -45,7 +45,7 @@ module VisualDebug
 
   private extern proc chpl_vdebug_pause ();
 
-  private extern proc chpl_vdebug_getTid ();
+  private extern proc chpl_vdebug_mark ();
 
 
 /* Instead of using a "coforall l in Locales" which is an O(n) operation
@@ -76,7 +76,7 @@ private proc VDebugTree (what: vis_op, name: string, time: real, id: int = 0,
       else
          offset = off;
 
-      chpl_vdebug_getTid();
+      chpl_vdebug_mark();
       coforall (rid, shift) in hc_id2com(id, offset) do
          if rid < n then
              on Locales[rid] do VDebugTree (what, name, time, rid, n, offset >> shift);

--- a/runtime/include/chpl-visual-debug.h
+++ b/runtime/include/chpl-visual-debug.h
@@ -38,8 +38,6 @@ extern int chpl_dprintf(int fd, const char * format, ...)
 #endif
    ;
 
-//  don't log messages/forks associated with a tag.
-extern void chpl_vdebug_getTid(void);
 //  start and open file if not NULL
 extern void chpl_vdebug_start(const char *, double now); 
 //  stop collecting data
@@ -48,6 +46,9 @@ extern void chpl_vdebug_stop(void);
 extern void chpl_vdebug_tag(const char *);
 //  resume from a tag point
 extern void chpl_vdebug_pause(void);
+//  mark the current task as a xxxVdebug() task and all children
+extern void chpl_vdebug_mark(void);
+
 
 //  communication logging routines 
 void chpl_vdebug_log_put_nb(void *addr, c_nodeid_t node, void* raddr,

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -374,7 +374,7 @@ void chpl_vdebug_log_fork(c_nodeid_t node, c_sublocid_t subloc,
   // Visual Debug Support
   chpl_taskID_t forkTask;
   forkTask = chpl_task_getId();
-  printf ("fork: fork task %llu %d->%d\n", forkTask, (int)chpl_nodeID, (int)node);
+  // printf ("fork: fork task %llu %d->%d\n", forkTask, (int)chpl_nodeID, (int)node);
   if (chpl_vdebug) {
     struct timeval tv;
     struct timezone tz = {0,0};
@@ -453,9 +453,9 @@ void cb_task_create(const chpl_task_cb_info_t *info) {
   if (!chpl_vdebug) return;
   if (chpl_vdebug_fd >= 0) {
     chpl_taskID_t taskId = chpl_task_getId();
-    printf ("taskCB: event: %d, node %d proc %s task id: %llu, new task id: %llu\n",
-             (int)info->event_kind, (int)info->nodeID,
-            (info->iu.full.is_executeOn ? "O" : "L"), taskId, info->iu.full.id);
+    //printf ("taskCB: event: %d, node %d proc %s task id: %llu, new task id: %llu\n",
+    //         (int)info->event_kind, (int)info->nodeID,
+    //        (info->iu.full.is_executeOn ? "O" : "L"), taskId, info->iu.full.id);
     (void)gettimeofday(&tv, &tz);
     chpl_dprintf (chpl_vdebug_fd, "task: %lld.%06ld %lld %ld %ld %s %ld %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -316,10 +316,13 @@ void chpl_vdebug_log_get(void* addr, c_nodeid_t node, void* raddr,
     struct timezone tz = {0,0};
     chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "get: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
-                  (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  (unsigned long) commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
-                  ln, fn);
+    printf ("log_get/%d, fn is 0x%lx\n",chpl_nodeID, (long) fn); fflush(stdout);
+    printf ("log_get/%d, fn length is %lu\n", chpl_nodeID, strlen(fn));
+    chpl_dprintf (chpl_vdebug_fd,
+             "get: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
+             (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
+             (unsigned long) commTask, (long) addr, (long) raddr, elemSize,
+             typeIndex, len, ln, fn);
   }
 }
 
@@ -333,8 +336,8 @@ void  chpl_vdebug_log_put_strd(void* dstaddr, void* dststrides, c_nodeid_t dstno
   if (chpl_vdebug) {
     struct timeval tv;
     struct timezone tz = {0,0};
-    (void) gettimeofday (&tv, &tz);
     chpl_taskID_t commTask = chpl_task_getId();
+    (void) gettimeofday (&tv, &tz);
     chpl_dprintf (chpl_vdebug_fd, "st_put: %lld.%06ld %d %ld %lu 0x%lx 0x%lx %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, 
                   (long) dstnode_id, (unsigned long) commTask, (long) srcaddr, (long) dstaddr,
@@ -356,8 +359,8 @@ void chpl_vdebug_log_get_strd(void* dstaddr, void* dststrides, c_nodeid_t srcnod
   if (chpl_vdebug) {
     struct timeval tv;
     struct timezone tz = {0,0};
-    (void) gettimeofday (&tv, &tz);
     chpl_taskID_t commTask = chpl_task_getId();
+    (void) gettimeofday (&tv, &tz);
     chpl_dprintf (chpl_vdebug_fd, "st_get: %lld.%06ld %d %ld %lu 0x%lx 0x%lx %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID,
                   (long) srcnode_id, (unsigned long) commTask, (long) dstaddr, (long) srcaddr,

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -46,16 +46,12 @@ extern c_nodeid_t chpl_nodeID; // unique ID for each node: 0, 1, 2,
 int install_callbacks(void);
 int uninstall_callbacks(void);
 
-static void cb_task_create_begin(const chpl_task_cb_info_t *info);
+static void cb_task_create(const chpl_task_cb_info_t *info);
+static void cb_task_begin(const chpl_task_cb_info_t *info);
 static void cb_task_end(const chpl_task_cb_info_t *info);
 
 int chpl_vdebug_fd = -1;
 int chpl_vdebug = 0;
-int chpl_vdebug_task = 0;
-
-void chpl_vdebug_getTid(void) {
-  chpl_vdebug_task = chpl_task_getId();
-}
 
 int chpl_dprintf (int fd, const char * format, ...) {
   char buffer[2048]; 
@@ -102,9 +98,15 @@ static int chpl_make_vdebug_file (const char *rootname) {
       return -1;
     }
     chpl_vdebug = 1;
-    chpl_vdebug_task = 0;
     return 0;
 }
+
+// Record>  ChplVdebug: ver # nid # tid # seq time.sec user.time system.time 
+//
+//  Ver # -- version number, currently 1.1
+//  nid # -- nodeID
+//  tid # -- taskID
+//  seq time.sec -- unique number for this run
 
 void chpl_vdebug_start (const char *fileroot, double now) {
   const char * rootname;
@@ -139,14 +141,15 @@ void chpl_vdebug_start (const char *fileroot, double now) {
     ru.ru_stime.tv_usec = 0;
   }
   chpl_dprintf (chpl_vdebug_fd,
-                "ChplVdebug: nodes %d nid %d tid %d seq %.3lf %lld.%06ld %ld.%06ld %ld.%06ld \n",
+                "ChplVdebug: ver 1.1 nodes %d nid %d tid %d seq %.3lf %lld.%06ld %ld.%06ld %ld.%06ld \n",
                 chpl_numNodes, chpl_nodeID, (int) startTask, now,
                 (long long) tv.tv_sec, (long) tv.tv_usec,
                 (long) ru.ru_utime.tv_sec, (long) ru.ru_utime.tv_usec,
                 (long) ru.ru_stime.tv_sec, (long) ru.ru_stime.tv_usec  );
   chpl_vdebug = 1;
-  chpl_vdebug_task = 0;
 }
+
+// Record>  VdbMark: time.sec user.time system.time nodeID taskID
 
 void chpl_vdebug_stop (void) {
   struct rusage ru;  
@@ -174,7 +177,24 @@ void chpl_vdebug_stop (void) {
   uninstall_callbacks();
 }
 
+// Record>  VdbMark: time.sec nodeId taskId
+//
+// This marks taskID as being a xxxVdebug() call.   Any forks or tasks
+// started by this task and descendants of this task are related to
+// the xxxVdebug() call and chplvis should ignore them.
+
+void chpl_vdebug_mark(void) {
+  struct timeval tv;
+  struct timezone tz = {0,0};
+  chpl_taskID_t tagTask = chpl_task_getId();
+  (void) gettimeofday (&tv, &tz);
+  chpl_dprintf (chpl_vdebug_fd, "VdbMark: %lld.%06ld %d %llu\n",
+                (long long) tv.tv_sec, (long) tv.tv_usec, chpl_nodeID, tagTask );
+}
+
 static int tag_no = 0;  // A unique tag number for sorting tags
+
+// Record>  Tag: time.sec user.time sys.time nodeId taskId tag# tagName
 
 void chpl_vdebug_tag (const char *str) {
   struct rusage ru;
@@ -195,8 +215,9 @@ void chpl_vdebug_tag (const char *str) {
                 (long) ru.ru_stime.tv_sec, (long) ru.ru_stime.tv_usec,
                 chpl_nodeID, (int) tagTask, tag_no++, str);
   chpl_vdebug = 1;
-  chpl_vdebug_task = 0;
 }
+
+// Record>  Pause: time.sec user.time sys.time nodeId taskId tag#
 
 void chpl_vdebug_pause (void) {
   struct rusage ru;
@@ -224,18 +245,29 @@ void chpl_vdebug_pause (void) {
 // Routines to log data ... put here so other places can
 // just call this code to get things logged.
 
+// Record>  nb_put: time.sec srcNodeId dstNodeId commTaskId addr raddr elemsize 
+//                  typeIndex length lineNumber fileName
+//
+
 void chpl_vdebug_log_put_nb(void *addr, c_nodeid_t node, void* raddr,
                             int32_t elemSize, int32_t typeIndex,
                             int32_t len, int ln, c_string fn) {
   if (chpl_vdebug) {
     struct timeval tv;
     struct timezone tz = {0,0};
+    chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "nb_put: %lld.%06ld %d %d 0x%lx 0x%lx %d %d %d %d %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "nb_put: %lld.%06ld %d %d %llu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  (long) addr, (long) raddr, elemSize, typeIndex, len, ln, fn);
+                  commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  ln, fn);
   }
 }
+
+// Record>  nb_get: time.sec dstNodeId srcNodeId commTaskId addr raddr elemsize 
+//                  typeIndex length lineNumber fileName
+//
+// Note: dstNodeId is node requesting Get
 
 void chpl_vdebug_log_get_nb(void* addr, c_nodeid_t node, void* raddr,
                             int32_t elemSize, int32_t typeIndex,
@@ -243,12 +275,18 @@ void chpl_vdebug_log_get_nb(void* addr, c_nodeid_t node, void* raddr,
   if (chpl_vdebug) {
     struct timeval tv;
     struct timezone tz = {0,0};
+    chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "nb_get: %lld.%06ld %d %d 0x%lx 0x%lx %d %d %d %d %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "nb_get: %lld.%06ld %d %d %llu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  (long) addr, (long) raddr, elemSize, typeIndex, len, ln, fn);
+                  commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  ln, fn);
   }
 }
+
+// Record>  put: time.sec srcNodeId dstNodeId commTaskId addr raddr elemsize 
+//               typeIndex length lineNumber fileName
+
 
 void chpl_vdebug_log_put(void* addr, c_nodeid_t node, void* raddr,
                          int32_t elemSize, int32_t typeIndex, int32_t len,
@@ -256,26 +294,37 @@ void chpl_vdebug_log_put(void* addr, c_nodeid_t node, void* raddr,
   if (chpl_vdebug) {
     struct timeval tv;
     struct timezone tz = {0,0};
+    chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "put: %lld.%06ld %d %d 0x%lx 0x%lx %d %d %d %d %s\n",
-                  (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  (long) addr, (long) raddr, elemSize, typeIndex, len, ln, fn);
+    chpl_dprintf (chpl_vdebug_fd, "put: %lld.%06ld %d %d %llu 0x%lx 0x%lx %d %d %d %d %s\n",
+                  (long long) tv.tv_sec, (long) tv.tv_usec, chpl_nodeID, node,
+                  commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  ln, fn);
   }
 }
+
+// Record>  get: time.sec dstNodeId srcNodeId commTaskId addr raddr elemsize 
+//               typeIndex length lineNumber fileName
+//
+// Note:  dstNodeId is for the node makeing the request
 
 void chpl_vdebug_log_get(void* addr, c_nodeid_t node, void* raddr,
                          int32_t elemSize, int32_t typeIndex, int32_t len,
                          int ln, c_string fn) {
-  if (chpl_vdebug && (chpl_task_getId() != chpl_vdebug_task)) {
+  if (chpl_vdebug) {
     struct timeval tv;
     struct timezone tz = {0,0};
+    chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "get: %lld.%06ld %d %d 0x%lx 0x%lx %d %d %d %d %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "get: %lld.%06ld %d %d %llu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  (long) addr, (long) raddr, elemSize, typeIndex, len, ln, fn);
+                  commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  ln, fn);
   }
 }
 
+// Record>  st_put: time.sec srcNodeId dstNodeId commTaskId addr raddr elemsize 
+//                  typeIndex length lineNumber fileName
 
 void  chpl_vdebug_log_put_strd(void* dstaddr, void* dststrides, c_nodeid_t dstnode_id,
                                void* srcaddr, void* srcstrides, void* count,
@@ -285,13 +334,20 @@ void  chpl_vdebug_log_put_strd(void* dstaddr, void* dststrides, c_nodeid_t dstno
     struct timeval tv;
     struct timezone tz = {0,0};
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "st_put: %lld.%06ld %d %ld 0x%lx 0x%lx %d %d %d %s\n",
-                  (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, (long) dstnode_id,
-                  (long) dstaddr, (long) srcaddr, elemSize, typeIndex, ln, fn);
+    chpl_taskID_t commTask = chpl_task_getId();
+    chpl_dprintf (chpl_vdebug_fd, "st_put: %lld.%06ld %d %ld %llu 0x%lx 0x%lx %d %d %d %s\n",
+                  (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, 
+                  (long) dstnode_id, commTask, (long) srcaddr, (long) dstaddr,
+                  elemSize, typeIndex, ln, fn);
     // printout srcstrides and dststrides and stridelevels?
   }
 
 }
+
+// Record>  st_get: time.sec dstNodeId srcNodeId commTaskId addr raddr elemsize 
+//                  typeIndex length lineNumber fileName
+//
+// Note:  dstNode is node makeing request for get
 
 void chpl_vdebug_log_get_strd(void* dstaddr, void* dststrides, c_nodeid_t srcnode_id,
                               void* srcaddr, void* srcstrides, void* count,
@@ -301,20 +357,25 @@ void chpl_vdebug_log_get_strd(void* dstaddr, void* dststrides, c_nodeid_t srcnod
     struct timeval tv;
     struct timezone tz = {0,0};
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "st_get: %lld.%06ld %d %ld 0x%lx 0x%lx %d %d %d %s\n",
-                  (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, (long) srcnode_id,
-                  (long) dstaddr, (long) srcaddr, elemSize, typeIndex, ln, fn);
+    chpl_taskID_t commTask = chpl_task_getId();
+    chpl_dprintf (chpl_vdebug_fd, "st_get: %lld.%06ld %d %ld %llu 0x%lx 0x%lx %d %d %d %s\n",
+                  (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID,
+                  (long) srcnode_id, commTask, (long) dstaddr, (long) srcaddr,
+                  elemSize, typeIndex, ln, fn);
     // print out the srcstrides and dststrides and stridelevels?
   }
 }
 
+// Record>  fork: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
 
 void chpl_vdebug_log_fork(c_nodeid_t node, c_sublocid_t subloc,
                           chpl_fn_int_t fid, void *arg, int32_t arg_size) {
 
   // Visual Debug Support
   chpl_taskID_t forkTask;
-  if (chpl_vdebug && ((forkTask = chpl_task_getId()) != chpl_vdebug_task)) {
+  forkTask = chpl_task_getId();
+  printf ("fork: fork task %llu %d->%d\n", forkTask, (int)chpl_nodeID, (int)node);
+  if (chpl_vdebug) {
     struct timeval tv;
     struct timezone tz = {0,0};
     (void) gettimeofday (&tv, &tz);
@@ -323,6 +384,8 @@ void chpl_vdebug_log_fork(c_nodeid_t node, c_sublocid_t subloc,
                   fid, (long) arg, arg_size, (int)forkTask);
   }
 }
+
+// Record>  fork_nb: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
 
 
 void  chpl_vdebug_log_fork_nb(c_nodeid_t node, c_sublocid_t subloc,
@@ -337,6 +400,8 @@ void  chpl_vdebug_log_fork_nb(c_nodeid_t node, c_sublocid_t subloc,
                   fid, (long) arg, arg_size, (int)forkTask);
   }
 }
+
+// Record>  fork_nb: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
 
 void chpl_vdebug_log_fast_fork(c_nodeid_t node, c_sublocid_t subloc,
                                chpl_fn_int_t fid, void *arg, int32_t arg_size) {
@@ -356,17 +421,17 @@ void chpl_vdebug_log_fast_fork(c_nodeid_t node, c_sublocid_t subloc,
 
 int install_callbacks(void) {
   if (chpl_task_install_callback(chpl_task_cb_event_kind_create, 
-                                 chpl_task_cb_info_kind_full, cb_task_create_begin) != 0)
+                                 chpl_task_cb_info_kind_full, cb_task_create) != 0)
     return 1;
   if (chpl_task_install_callback(chpl_task_cb_event_kind_begin, 
-                                 chpl_task_cb_info_kind_full, cb_task_create_begin) != 0) {
-    (void) chpl_task_uninstall_callback(chpl_task_cb_event_kind_create, cb_task_create_begin);
+                                 chpl_task_cb_info_kind_full, cb_task_begin) != 0) {
+    (void) chpl_task_uninstall_callback(chpl_task_cb_event_kind_create, cb_task_create);
     return 1;
   }
   if (chpl_task_install_callback(chpl_task_cb_event_kind_end,
                                  chpl_task_cb_info_kind_id_only, cb_task_end) != 0) {
-    (void) chpl_task_uninstall_callback(chpl_task_cb_event_kind_create, cb_task_create_begin);
-    (void) chpl_task_uninstall_callback(chpl_task_cb_event_kind_begin, cb_task_create_begin);
+    (void) chpl_task_uninstall_callback(chpl_task_cb_event_kind_create, cb_task_create);
+    (void) chpl_task_uninstall_callback(chpl_task_cb_event_kind_begin, cb_task_begin);
     return 1;
   }
   return 0;
@@ -374,28 +439,50 @@ int install_callbacks(void) {
 
 int uninstall_callbacks(void) {
   int rv = 0;
-  rv = chpl_task_uninstall_callback(chpl_task_cb_event_kind_create, cb_task_create_begin);
-  rv += chpl_task_uninstall_callback(chpl_task_cb_event_kind_begin, cb_task_create_begin);
+  rv = chpl_task_uninstall_callback(chpl_task_cb_event_kind_create, cb_task_create);
+  rv += chpl_task_uninstall_callback(chpl_task_cb_event_kind_begin, cb_task_begin);
   rv += chpl_task_uninstall_callback(chpl_task_cb_event_kind_end, cb_task_end);
   return rv;
 }
 
-void cb_task_create_begin(const chpl_task_cb_info_t *info) {
+// Record>  task: time.sec nodeId taskId parentTaskId On/Local lineNum srcName
+
+void cb_task_create(const chpl_task_cb_info_t *info) {
   struct timeval tv;
   struct timezone tz = {0,0};
   if (!chpl_vdebug) return;
   if (chpl_vdebug_fd >= 0) {
+    chpl_taskID_t taskId = chpl_task_getId();
+    printf ("taskCB: event: %d, node %d proc %s task id: %llu, new task id: %llu\n",
+             (int)info->event_kind, (int)info->nodeID,
+            (info->iu.full.is_executeOn ? "O" : "L"), taskId, info->iu.full.id);
     (void)gettimeofday(&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "%s: %lld.%06ld %lld %ld %s %ld %s\n",
-                  (info->event_kind == chpl_task_cb_event_kind_create ? "task" : "Btask"),
+    chpl_dprintf (chpl_vdebug_fd, "task: %lld.%06ld %lld %ld %ld %s %ld %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,
                   (long long) info->nodeID, (long int) info->iu.full.id,
+                  (long) taskId,
                   (info->iu.full.is_executeOn ? "O" : "L"),
                   (long int) info->iu.full.lineno,
                   (info->iu.full.filename ? info->iu.full.filename : ""));
    }
 }
 
+// Record>  Btask: time.sec nodeId taskId
+
+void cb_task_begin(const chpl_task_cb_info_t *info) {
+  struct timeval tv;
+  struct timezone tz = {0,0};
+  if (!chpl_vdebug) return;
+  if (chpl_vdebug_fd >= 0) {
+    (void)gettimeofday(&tv, &tz);
+    chpl_dprintf (chpl_vdebug_fd, "Btask: %lld.%06ld %lld %ld\n",
+                  (long long) tv.tv_sec, (long) tv.tv_usec,
+                  (long long) info->nodeID, (long int) info->iu.full.id);
+ 
+  }
+}
+
+// Record>  Etask: time.sec nodeId taskId
 
 void cb_task_end(const chpl_task_cb_info_t *info) {
   struct timeval tv;

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -188,8 +188,8 @@ void chpl_vdebug_mark(void) {
   struct timezone tz = {0,0};
   chpl_taskID_t tagTask = chpl_task_getId();
   (void) gettimeofday (&tv, &tz);
-  chpl_dprintf (chpl_vdebug_fd, "VdbMark: %lld.%06ld %d %llu\n",
-                (long long) tv.tv_sec, (long) tv.tv_usec, chpl_nodeID, tagTask );
+  chpl_dprintf (chpl_vdebug_fd, "VdbMark: %lld.%06ld %d %lu\n",
+                (long long) tv.tv_sec, (long) tv.tv_usec, chpl_nodeID, (unsigned long)tagTask );
 }
 
 static int tag_no = 0;  // A unique tag number for sorting tags
@@ -257,9 +257,9 @@ void chpl_vdebug_log_put_nb(void *addr, c_nodeid_t node, void* raddr,
     struct timezone tz = {0,0};
     chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "nb_put: %lld.%06ld %d %d %llu 0x%lx 0x%lx %d %d %d %d %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "nb_put: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  (unsigned long) commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
                   ln, fn);
   }
 }
@@ -277,9 +277,9 @@ void chpl_vdebug_log_get_nb(void* addr, c_nodeid_t node, void* raddr,
     struct timezone tz = {0,0};
     chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "nb_get: %lld.%06ld %d %d %llu 0x%lx 0x%lx %d %d %d %d %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "nb_get: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  (unsigned long)commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
                   ln, fn);
   }
 }
@@ -296,9 +296,9 @@ void chpl_vdebug_log_put(void* addr, c_nodeid_t node, void* raddr,
     struct timezone tz = {0,0};
     chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "put: %lld.%06ld %d %d %llu 0x%lx 0x%lx %d %d %d %d %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "put: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, chpl_nodeID, node,
-                  commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  (unsigned long) commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
                   ln, fn);
   }
 }
@@ -316,9 +316,9 @@ void chpl_vdebug_log_get(void* addr, c_nodeid_t node, void* raddr,
     struct timezone tz = {0,0};
     chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "get: %lld.%06ld %d %d %llu 0x%lx 0x%lx %d %d %d %d %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "get: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  (unsigned long) commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
                   ln, fn);
   }
 }
@@ -335,9 +335,9 @@ void  chpl_vdebug_log_put_strd(void* dstaddr, void* dststrides, c_nodeid_t dstno
     struct timezone tz = {0,0};
     (void) gettimeofday (&tv, &tz);
     chpl_taskID_t commTask = chpl_task_getId();
-    chpl_dprintf (chpl_vdebug_fd, "st_put: %lld.%06ld %d %ld %llu 0x%lx 0x%lx %d %d %d %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "st_put: %lld.%06ld %d %ld %lu 0x%lx 0x%lx %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, 
-                  (long) dstnode_id, commTask, (long) srcaddr, (long) dstaddr,
+                  (long) dstnode_id, (unsigned long) commTask, (long) srcaddr, (long) dstaddr,
                   elemSize, typeIndex, ln, fn);
     // printout srcstrides and dststrides and stridelevels?
   }
@@ -358,9 +358,9 @@ void chpl_vdebug_log_get_strd(void* dstaddr, void* dststrides, c_nodeid_t srcnod
     struct timezone tz = {0,0};
     (void) gettimeofday (&tv, &tz);
     chpl_taskID_t commTask = chpl_task_getId();
-    chpl_dprintf (chpl_vdebug_fd, "st_get: %lld.%06ld %d %ld %llu 0x%lx 0x%lx %d %d %d %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "st_get: %lld.%06ld %d %ld %lu 0x%lx 0x%lx %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID,
-                  (long) srcnode_id, commTask, (long) dstaddr, (long) srcaddr,
+                  (long) srcnode_id, (unsigned long) commTask, (long) dstaddr, (long) srcaddr,
                   elemSize, typeIndex, ln, fn);
     // print out the srcstrides and dststrides and stridelevels?
   }
@@ -379,9 +379,9 @@ void chpl_vdebug_log_fork(c_nodeid_t node, c_sublocid_t subloc,
     struct timeval tv;
     struct timezone tz = {0,0};
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "fork: %lld.%06ld %d %d %d %d 0x%lx %d %d \n",
+    chpl_dprintf (chpl_vdebug_fd, "fork: %lld.%06ld %d %d %d %d 0x%lx %d %lu \n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, chpl_nodeID, node, subloc,
-                  fid, (long) arg, arg_size, (int)forkTask);
+                  fid, (long) arg, arg_size, (unsigned long) forkTask);
   }
 }
 
@@ -395,9 +395,9 @@ void  chpl_vdebug_log_fork_nb(c_nodeid_t node, c_sublocid_t subloc,
     struct timeval tv;
     struct timezone tz = {0,0};
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "fork_nb: %lld.%06ld %d %d %d %d 0x%lx %d %d\n",
+    chpl_dprintf (chpl_vdebug_fd, "fork_nb: %lld.%06ld %d %d %d %d 0x%lx %d %lu\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, chpl_nodeID, node, subloc,
-                  fid, (long) arg, arg_size, (int)forkTask);
+                  fid, (long) arg, arg_size, (unsigned long)forkTask);
   }
 }
 
@@ -410,9 +410,9 @@ void chpl_vdebug_log_fast_fork(c_nodeid_t node, c_sublocid_t subloc,
     struct timeval tv;
     struct timezone tz = {0,0};
     (void) gettimeofday (&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "f_fork: %lld.%06ld %d %d %d %d 0x%lx %d %d\n",
+    chpl_dprintf (chpl_vdebug_fd, "f_fork: %lld.%06ld %d %d %d %d 0x%lx %d %ld\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, chpl_nodeID, node, subloc,
-                  fid, (long) arg, arg_size, (int)forkTask);
+                  fid, (long) arg, arg_size, (unsigned long)forkTask);
   }
 }
 
@@ -457,10 +457,10 @@ void cb_task_create(const chpl_task_cb_info_t *info) {
     //         (int)info->event_kind, (int)info->nodeID,
     //        (info->iu.full.is_executeOn ? "O" : "L"), taskId, info->iu.full.id);
     (void)gettimeofday(&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "task: %lld.%06ld %lld %ld %ld %s %ld %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "task: %lld.%06ld %lld %ld %lu %s %ld %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,
                   (long long) info->nodeID, (long int) info->iu.full.id,
-                  (long) taskId,
+                  (unsigned long) taskId,
                   (info->iu.full.is_executeOn ? "O" : "L"),
                   (long int) info->iu.full.lineno,
                   (info->iu.full.filename ? info->iu.full.filename : ""));
@@ -475,9 +475,9 @@ void cb_task_begin(const chpl_task_cb_info_t *info) {
   if (!chpl_vdebug) return;
   if (chpl_vdebug_fd >= 0) {
     (void)gettimeofday(&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "Btask: %lld.%06ld %lld %ld\n",
+    chpl_dprintf (chpl_vdebug_fd, "Btask: %lld.%06ld %lld %lu\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,
-                  (long long) info->nodeID, (long int) info->iu.full.id);
+                  (long long) info->nodeID, (unsigned long) info->iu.full.id);
  
   }
 }
@@ -490,9 +490,9 @@ void cb_task_end(const chpl_task_cb_info_t *info) {
   if (!chpl_vdebug) return;
   if (chpl_vdebug_fd >= 0) {
     (void)gettimeofday(&tv, &tz);
-    chpl_dprintf (chpl_vdebug_fd, "Etask: %lld.%06ld %lld %ld\n",
+    chpl_dprintf (chpl_vdebug_fd, "Etask: %lld.%06ld %lld %lu\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,
-                  (long long) info->nodeID, (long int) info->iu.id_only.id);
+                  (long long) info->nodeID, (unsigned long) info->iu.id_only.id);
  
   }
 }

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -316,8 +316,8 @@ void chpl_vdebug_log_get(void* addr, c_nodeid_t node, void* raddr,
     struct timezone tz = {0,0};
     chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
-    printf ("log_get/%d, fn is 0x%lx\n",chpl_nodeID, (long) fn); fflush(stdout);
-    printf ("log_get/%d, fn length is %lu\n", chpl_nodeID, strlen(fn));
+    //printf ("log_get/%d, fn is 0x%lx\n",chpl_nodeID, (long) fn); fflush(stdout);
+    //printf ("log_get/%d, fn length is %lu\n", chpl_nodeID, strlen(fn));
     chpl_dprintf (chpl_vdebug_fd,
              "get: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
              (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -316,13 +316,14 @@ void chpl_vdebug_log_get(void* addr, c_nodeid_t node, void* raddr,
     struct timezone tz = {0,0};
     chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, &tz);
+    /// XXXX bug I can't fix!!!
     //printf ("log_get/%d, fn is 0x%lx\n",chpl_nodeID, (long) fn); fflush(stdout);
     //printf ("log_get/%d, fn length is %lu\n", chpl_nodeID, strlen(fn));
     chpl_dprintf (chpl_vdebug_fd,
-             "get: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
+             "get: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d <unknown>\n",
              (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
              (unsigned long) commTask, (long) addr, (long) raddr, elemSize,
-             typeIndex, len, ln, fn);
+             typeIndex, len, ln); // fu
   }
 }
 

--- a/test/chplvis/overhead/overhead.chpl
+++ b/test/chplvis/overhead/overhead.chpl
@@ -1,6 +1,8 @@
+config var dir = "OH";
+
 use VisualDebug;
 
-startVdebug("OH");
+startVdebug(dir);
 tagVdebug("tag 1");
 pauseVdebug();
 resumeVdebug("resume 1");

--- a/tools/chplvis/ConcurrencyWin.cxx
+++ b/tools/chplvis/ConcurrencyWin.cxx
@@ -144,11 +144,12 @@ void ConcurrencyData::buildData(void) {
   if (parent->localeNum == 0)
     greedy[0] = 1;
 
-  // Calculate new height
+  // Calculate new height and width
+  // Default width ... unless we get a more specific one.
+  width = 30 + 60 * VisData.getTagData(DataModel::TagALL)->
+              locales[parent->localeNum].maxConc;
   if (parent->tagNum == DataModel::TagALL) {
     numLines =  VisData.taskTimeline[parent->localeNum].size();
-    width = 30 + 60 * VisData.getTagData(DataModel::TagALL)->
-                      locales[parent->localeNum].maxConc;
     tagStart = VisData.taskTimeline[parent->localeNum].begin();
   } else {
     // Walk the timeline keeping tasks that go past the tag
@@ -166,7 +167,7 @@ void ConcurrencyData::buildData(void) {
 
         case DataModel::Tl_Tag:
           tmpTagNo = tl_itr->second;
-          //tmpTag = VisData.getTagData(tmpTagNo);
+          tmpTag = VisData.getTagData(tmpTagNo);
           if (tmpTagNo == parent->tagNum) {
             tagStart = tl_itr;
             tagStart++; // Move to the first record after the tag
@@ -209,13 +210,13 @@ void ConcurrencyData::buildData(void) {
   if (greedy[0]) numLines++;
   height = 40 + 25 * numLines;
                                    
-  //printf ("data size:  %dx%d\n", width, height);
-  
-  // Start the rebuild by resizing
-  resize (x(), y(), width, height);
-
   // Reset scroll
   parent->scroll->scroll_to(0,0);
+
+  // printf ("resize data size:  %dx%d\n", width, height);
+
+  // Start the rebuild by resizing
+  resize (x(), y(), width, height);
 
   // Build the data
   curLine = 0;

--- a/tools/chplvis/ConcurrencyWin.cxx
+++ b/tools/chplvis/ConcurrencyWin.cxx
@@ -231,7 +231,7 @@ void ConcurrencyData::buildData(void) {
   curCol = 0;
   for (int col = 0; col < progMaxConc; col++)
     if (greedy[col] != 0) {
-      printf ("Building continuation for col %d\n", col);
+      // printf ("Building continuation for col %d\n", col);
       greedy[curCol] = greedy[col];
       greedyStart[curCol] = 0;
       b = new Fl_Box(FL_BORDER_BOX, 15+60*curCol, 40, 60, 20, NULL);

--- a/tools/chplvis/ConcurrencyWin.cxx
+++ b/tools/chplvis/ConcurrencyWin.cxx
@@ -83,12 +83,6 @@ void ConcurrencyData::draw (void) {
       y2_clip = true;
     }
 
-#if 0
-    fl_color(FL_RED);
-    fl_line_style(FL_SOLID, 3, NULL);
-    fl_line(1, 33, 100, 33);
-#endif
-
     // Draw vertical line
     fl_color(FL_BLACK);
     fl_line_style(FL_SOLID, 3, NULL);
@@ -113,7 +107,7 @@ void ConcurrencyData::buildData(void) {
   int width = w();
   int height = h();
   int progMaxConc =  VisData.getTagData(DataModel::TagALL)->maxConc;
-  int greedy[progMaxConc];
+  int greedy[progMaxConc+1];
   int greedyStart[progMaxConc];
   int numLines = 0;
   int curLine;
@@ -139,6 +133,7 @@ void ConcurrencyData::buildData(void) {
     greedy[ix] = 0;
     greedyStart[ix] = 0;
   }
+  greedy[progMaxConc] = 0;  // Sentinal
 
   // Special case for locale 0 .. main thread of 1
   if (parent->localeNum == 0)
@@ -213,6 +208,12 @@ void ConcurrencyData::buildData(void) {
   // Reset scroll
   parent->scroll->scroll_to(0,0);
 
+  // Don't make the size too small.
+  if (width < 400)
+    width = 400;
+  if (height < 400)
+    height = 400;
+
   // printf ("resize data size:  %dx%d\n", width, height);
 
   // Start the rebuild by resizing
@@ -230,6 +231,7 @@ void ConcurrencyData::buildData(void) {
   curCol = 0;
   for (int col = 0; col < progMaxConc; col++)
     if (greedy[col] != 0) {
+      printf ("Building continuation for col %d\n", col);
       greedy[curCol] = greedy[col];
       greedyStart[curCol] = 0;
       b = new Fl_Box(FL_BORDER_BOX, 15+60*curCol, 40, 60, 20, NULL);
@@ -253,9 +255,11 @@ void ConcurrencyData::buildData(void) {
     curLine++;
 
   done = false; 
-  while (!done && tl_itr !=  VisData.taskTimeline[parent->localeNum].end()) {
-    switch (tl_itr->first) {
 
+  while (!done && tl_itr !=  VisData.taskTimeline[parent->localeNum].end()) {
+
+    switch (tl_itr->first) {
+      
       case DataModel::Tl_Tag:
         if (parent->tagNum != DataModel::TagALL) {
           done = true;
@@ -317,15 +321,6 @@ void ConcurrencyData::buildData(void) {
       lineDrawData.startLine = greedyStart[col];
       drawDB.push_back(lineDrawData);
     }
-
-#if 0
-  // Build the task box
-  b = new Fl_Box::Fl_Box(FL_ROUNDED_BOX, 10, 40, 70, 20, NULL);
-  b->copy_label("testing");
-  add(b);
-  snprintf (tmp, sizeof(tmp), "Data: %d", 127853);
-  b->copy_tooltip(tmp);
-#endif
 
   redraw();
   

--- a/tools/chplvis/DataModel.cxx
+++ b/tools/chplvis/DataModel.cxx
@@ -531,8 +531,8 @@ int DataModel::LoadData(const char * filename)
           std::list< timelineEntry >::reverse_iterator tl_itr;
           tl_itr = taskTimeline[curNodeId].rbegin();
           while (tl_itr != taskTimeline[curNodeId].rend()) {
-            if ((*tl_itr).first == Tl_Begin
-                && (*tl_itr).second == etp->taskId()) {
+            if (tl_itr->first == Tl_Begin
+                && tl_itr->second == etp->taskId()) {
               // Found the begin record in the timeline, add the end record
               taskTimeline[curNodeId].push_back(timelineEntry(Tl_End,etp->taskId()));
               curTag->locales[curNodeId].runConc--;
@@ -550,6 +550,28 @@ int DataModel::LoadData(const char * filename)
     // Move to next event record
     itr++;
   }
+
+#if 0
+  // Debug print of full DB
+  printf ("Final Events DB.\n");
+  itr = theEvents.begin();
+  while (itr != theEvents.end()) {
+    (*itr)->print();
+    itr++;
+  }
+
+  // Timeline debug
+  printf ("\nTimeline for node 0.\n");
+  std::list<timelineEntry>::iterator tl_itr = taskTimeline[0].begin();
+  while (tl_itr != taskTimeline[0].end()) {
+    switch (tl_itr->first) {
+      case Tl_Tag: printf ("Tag: %ld\n", tl_itr->second); break;
+      case Tl_Begin: printf ("Begin: %ld\n", tl_itr->second); break;
+      case Tl_End: printf ("End: %ld\n", tl_itr->second); break;
+    }
+    tl_itr++;
+  }
+#endif 
 
   return 1;
 }

--- a/tools/chplvis/Event.h
+++ b/tools/chplvis/Event.h
@@ -92,7 +92,7 @@ class  E_task : public Event {
     char *srcFile;
   
   public:
-    E_task (long esec, long eusec, int nid, int taskId, bool ison, long line, char *file)
+    E_task (long esec, long eusec, int nid, long taskId, bool ison, long line, char *file)
       : Event(esec,eusec, nid), taskid(taskId), isOn(ison), lineNum(line)
     {
       srcFile = strdup(file);
@@ -247,34 +247,34 @@ class E_end : public Event {
 class E_begin_task : public Event {
 
   private:
-    int taskId;
+    long taskid;
 
   public:
-    E_begin_task (long esec, long eusec, int nodeid, int taskid)
-      : Event(esec, eusec, nodeid), taskId(taskid) {};
+    E_begin_task (long esec, long eusec, int nodeid, long tid)
+      : Event(esec, eusec, nodeid), taskid(tid) {};
 
-    int getTaskId() { return taskId; }
+    long taskId() { return taskid; }
     virtual int Ekind() { return Ev_begin_task; }
     virtual void print() {
-      printf ("Btask: node %d time %ld.%06ld taskId %d\n",
-              nodeid, sec, usec, taskId);
+      printf ("Btask: node %d time %ld.%06ld taskId %ld\n",
+              nodeid, sec, usec, taskid);
     }
 };
 
 class E_end_task : public Event {
 
    private:
-     int taskId;
+     long taskid;
 
    public:
-     E_end_task (long esec, long eusec, int nodeid, int taskid)
-       : Event(esec, eusec, nodeid), taskId(taskid) {};
+     E_end_task (long esec, long eusec, int nodeid, long tid)
+       : Event(esec, eusec, nodeid), taskid(tid) {};
 
-     int getTaskId() { return taskId; }
+     long taskId() { return taskid; }
      virtual int Ekind() { return Ev_end_task; }
      virtual void print() {
-       printf ("Etask: node %d time %ld.%06ld taskId %d\n",
-               nodeid, sec, usec, taskId);
+       printf ("Etask: node %d time %ld.%06ld taskId %ld\n",
+               nodeid, sec, usec, taskid);
      }
 };
 

--- a/tools/chplvis/InfoBar.cxx
+++ b/tools/chplvis/InfoBar.cxx
@@ -24,6 +24,8 @@
 #include <FL/fl_draw.H>
 #include <FL/x.H>
 
+#include <string.h>
+
 static const int CR_Left = 220;
 
 #ifdef __APPLE__
@@ -36,15 +38,23 @@ static const int Y_OFF = 0;
 void InfoBar::setFileName(const char *name) {
     const char *sl;
     char *dash;
-    sl = strrchr(name,'/');
+    int nameLen = strlen(name);
+    char tmpNam[nameLen+1];
+
+    strncpy (tmpNam, name, nameLen+1);
+    if (tmpNam[nameLen-1] == '/') {
+      tmpNam[nameLen-1] = 0;
+      nameLen--;
+    }
+    sl = strrchr(tmpNam,'/');
     if (sl == NULL)
-      sl = name;
+      sl = tmpNam;
     else
       sl++;
+    dash = strrchr(sl,'-');
+    if (dash != NULL) *dash = 0;
     if (fileName != NULL) free(fileName);
     fileName = strdup(sl);
-    dash = strrchr(fileName,'-');
-    if (dash != NULL) *dash = 0;
   }
   
 void InfoBar::setTagName(const char *name) {

--- a/tools/chplvis/InfoBar.cxx
+++ b/tools/chplvis/InfoBar.cxx
@@ -43,7 +43,7 @@ void InfoBar::setFileName(const char *name) {
       sl++;
     if (fileName != NULL) free(fileName);
     fileName = strdup(sl);
-    dash = strchr(fileName,'-');
+    dash = strrchr(fileName,'-');
     if (dash != NULL) *dash = 0;
   }
   

--- a/tools/chplvis/chplvis.fl
+++ b/tools/chplvis/chplvis.fl
@@ -114,7 +114,7 @@ Function {make_concurrency_window(long locNum, long tagNum)} {open return_type {
       label Concurrency
       private xywh {0 0 500 30}
     }
-    Fl_Scroll ConcScroll {open selected
+    Fl_Scroll ConcScroll {open
       private xywh {0 30 500 570} box DOWN_BOX color 7 resizable
     } {
       Fl_Box scrollData {
@@ -255,12 +255,10 @@ MainWindow->redraw();}
     if (!VisData.LoadData(argv[1])) {
        exit(1);
     }
-    if (DbgView) {
-      DbgView->setNumLocales(VisData.NumLocales());
-      DbgView->makeTagsMenu();
-      DbgView->selectData(DataModel::TagALL);
-      Info->setFileName(argv[1]);
-    }
+    DbgView->setNumLocales(VisData.NumLocales());
+    DbgView->makeTagsMenu();
+    DbgView->selectData(DataModel::TagALL);
+    Info->setFileName(argv[1]);
     argc--;
     argv++;
 } else {
@@ -273,5 +271,6 @@ MainWindow->redraw();}
       Info->setFileName(".Vdebug (default)");
    }
 }
-MainWindow->callback(mainWinCallback);} {}
+MainWindow->callback(mainWinCallback);} {selected
+  }
 } 


### PR DESCRIPTION
- Add a new record to the files written at runtime to identify a xxxVdebug() task
- Add taskIds to several different kinds of records to be able to track xxxVdebug() activity
- Upgrade chplvis to make use of this information, added a version number to the data files, now at 1.1