### PR TITLE
paratest.server to set CHPL_TEST_VGRND_EXE, _COMP

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -57,6 +57,11 @@ $junit_remove_prefix = "";
 $timeout = -1;
 if (exists $ENV{CHPL_PARATEST_TIMEOUT}) { $timeout = $ENV{CHPL_PARATEST_TIMEOUT}; } 
 
+# updated if -valgrind options are given
+$ENV{'CHPL_TEST_VGRND_COMP'} = "off";
+$ENV{'CHPL_TEST_VGRND_EXE'} = "off";
+
+
 $localhost = `uname -n`;
 ($localnode, $junk) = split (/\./, $localhost, 2);
 chomp $localnode;
@@ -592,9 +597,13 @@ sub main {
                 exit (8);
             }
         } elsif (/^-valgrind/) {
-            $valgrind = 1;
             if (/^-valgrindexe/) {
                 $valgrind = 2;
+                $ENV{'CHPL_TEST_VGRND_EXE'} = "on";
+            } else {
+                $valgrind = 1;
+                $ENV{'CHPL_TEST_VGRND_COMP'} = "on";
+                $ENV{'CHPL_TEST_VGRND_EXE'} = "on";
             }
         } elsif (/^-show-all-errors/) {
             $show_all_errors = 1;


### PR DESCRIPTION
I noticed that studies/madness and its subdirectories are tested in Jenkins and are not tested when I run paratest.server. Both for linux64 configuration.

I think it's because start_test sets CHPL_TEST_VGRND_EXE always and paratest.server/client never. This skipif:

  test/studies/madness.skipif

contains

  CHPL_TEST_VGRND_EXE!=off

which makes testEnv produce an incorrect/unintended result when CHPL_TEST_VGRND_EXE is not set.

So this commit makes paratest.server set CHPL_TEST_VGRND_EXE, CHPL_TEST_VGRND_COMP

Alternative solutions were considered:

(a) replace checking for "off" with checking for "on" in .skipif files - there are only a couple of those:

test/functions/sungeun/promotionWithNoInline.skipif
test/studies/madness.skipif
test/trivial/figueroa/UnmangledSymbols.skipif
test/types/records/sungeun/stringInRecordInClass.skipif
test/types/string/sungeun/string2InRecordInClass.skipif

(b) fix testEnv:

---------------------------------
diff --git util/test/testEnv util/test/testEnv
--- util/test/testEnv
+++ util/test/testEnv
@@ -48,6 +48,9 @@
     } elsif ($envsetting =~ m/\#(.*)/) {
         # comment
     } elsif ($envsetting =~ m/(\w*)\s*(.)=\s*(\S*)/) {
+        if ($ENV{$1} eq "") {
+           $ENV{$1} = "off";
+        }
 #        print "checking whether $1 $2 $3\n";
         if ($2 eq "=") {
             if ($ENV{$1} eq $3) {
---------------------------------

Elliot voted for updating paratest.server over (a) or (b).