### PR TITLE
Revert "Test perf of parallel init_elts after string-as-rec"

### DIFF
--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -18,13 +18,3 @@ git checkout string-as-rec
 perf_args="-performance-description amm -performance-configs default:v,amm:v -sync-dir-suffix amm"
 perf_args="${perf_args} -numtrials 5 -startdate 08/12/15"
 $CWD/nightly -cron ${perf_args} ${nightly_args}
-
-
-
-# Also test performance of par-init
-
-git checkout master
-
-perf_args="-performance-description par-init -performance-configs default:v,par-init:v -sync-dir-suffix par-init"
-perf_args="${perf_args} -numtrials 5 -startdate 07/30/15 -compopts -sparallelInitElts"
-$CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
This reverts commit f4967252d1ba7d19b90223a3cc77eaf4a9c0a1b3.

Stop testing parallel init in playground, it's committed to master now