### PR TITLE
Place polling threads on the last available CPU.

### DIFF
--- a/runtime/include/chplsys.h
+++ b/runtime/include/chplsys.h
@@ -31,6 +31,8 @@ size_t chpl_bytesAvailOnThisLocale(void);
 int chpl_getNumPhysicalCpus(chpl_bool accessible_only);
 int chpl_getNumLogicalCpus(chpl_bool accessible_only);
 
+void chpl_moveToLastCPU(void);
+
 //
 // returns the name of a locale via uname -n or the like
 //

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -40,6 +40,7 @@
 #include "error.h"
 
 #ifdef __linux__
+#include <pthread.h>
 #include <sched.h>
 #endif
 #include <stdio.h>
@@ -394,6 +395,37 @@ int chpl_getNumLogicalCpus(chpl_bool accessible_only) {
 #warning "Target architecture is not yet supported."
   return 1;
 #endif
+}
+
+
+//
+// Move to the last available hardware thread.  Tasking layers use
+// this to get predictable placement for comm layer polling threads,
+// in order to help manage execution resources.
+//
+void chpl_moveToLastCPU(void) {
+  //
+  // This is currently a no-op except on non-MIC Linux.
+  //
+#if defined(__linux__) && !defined(__MIC__)
+  {
+    cpu_set_t mask;
+    int i, cnt;
+
+    if (pthread_getaffinity_np(pthread_self(), sizeof(mask), &mask) < 0)
+      chpl_internal_error("sched_getaffinity() failed");
+
+    for (i = cnt = 0; !CPU_ISSET(i, &mask) || ++cnt < CPU_COUNT(&mask); i++)
+      ;
+
+    CPU_ZERO(&mask);
+    CPU_SET(i, &mask);
+    if (pthread_setaffinity_np(pthread_self(), sizeof(mask), &mask) < 0)
+      chpl_internal_error("sched_setaffinity() failed");
+  }
+#endif
+
+  return;
 }
 
 


### PR DESCRIPTION
Putting the polling thread in a predictable place may help the tasking
layer avoid interference from it.  In particular, the current tasking
layers that do place their threads put them by default on cores starting
at the first available one, so this new polling thread placement should
maximize how many hardware threads we can use for hosting tasks before
we start to see interference from the polling thread.  While this is a
bit of a simplification, nevertheless the new placement seems like it
should always be as good or better than leaving the polling thread
unplaced.

The new chplsys:chpl_moveToLastCPU() function is a bit of a hack.  In an
ideal world we would use something like hwloc for this.  But hwloc is
not yet a first-class package for us, only an adjunct to qthreads, so we
can't depend on its presence.  And the affinity calls we're using are
only available for (non-MIC) Linux.  It's best to hide all this detail
in chplsys, and only have one copy of it, instead of putting it out in
public in the tasking layers.