### PR TITLE
Fixed a compiler failure in autoCopy.chpl

### DIFF
--- a/compiler/include/OwnershipFlowManager.h
+++ b/compiler/include/OwnershipFlowManager.h
@@ -112,18 +112,21 @@ class OwnershipFlowManager
   // Properties
  private:
   FnSymbol* _fn; // Records the function being analyzed (un-owned).
+  Symbol*   fnRetSym;  // The return symbol of _fn.
+
   // The vector of basic blocks is a property of the function being analyzed.
   // It is copied here for convience.  This pointer must be whenever basic
   // block analysis is re-run.
   BasicBlockVector* basicBlocks; // Cached basic block vector (un-owned).
   size_t nbbs; // Cached basic block count.  Valid after BB analysis is run.
+
   // A vector of symbols of interest in this function.
   // The bits in each  BitVec in the flow sets correspond to symbols in this
   // vector.
   SymbolVector symbols;
   size_t nsyms; // Cached symbol count.  Valid after the symbols is populated.
-  SymbolIndexMap symbolIndex; // A map from a symbol to its index in the bit
-                              // vectors.
+  SymbolIndexMap symbolIndex; // A map from a symbol to its index in BitVecs.
+
   // The map contains one entry for each symbol.
   // Each entry is a list of symbols with which the given symbol is an alias.
   AliasVectorMap aliases;
@@ -587,7 +590,7 @@ OwnershipFlowManager::~OwnershipFlowManager()
 
 inline
 OwnershipFlowManager::OwnershipFlowManager(FnSymbol* fn)
-  : _fn(fn)
+  : _fn(fn), fnRetSym(fn->getReturnSymbol())
   , PROD(0), CONS(0), USE(0), USED_LATER(0), EXIT(0), IN(0), OUT(0)
 #if DEBUG_AMM
   , debug(0)

--- a/compiler/util/OwnershipFlowManager.cpp
+++ b/compiler/util/OwnershipFlowManager.cpp
@@ -1464,8 +1464,7 @@ OwnershipFlowManager::insertAutoDestroyAtScopeExit(Symbol* sym)
   // Note that if all return statements (of a function marked "return value is
   // not owned") return unowned values, then we do not reach this code, because
   // the RVV will be unowned (so its corresponding to_cons bit will be false).
-  if (_fn->hasFlag(FLAG_RETURN_VALUE_IS_NOT_OWNED) &&
-      sym == _fn->getReturnSymbol())
+  if (_fn->hasFlag(FLAG_RETURN_VALUE_IS_NOT_OWNED) && sym == fnRetSym)
     return;
 
   FnSymbol* autoDestroy = toFnSymbol(autoDestroyMap.get(sym->type));


### PR DESCRIPTION
The code in OwnershipFlowManager::insertAutoDestroys() does this:

...........
  // Move away the return statement so insertAtTail() do not add after it.
  CallExpr* ret = removeReturnStmt(_fn);

  // and then destroy each symbol at the end of its containing scope.
  insertAutoDestroy(&to_cons);

  // Reinsert the return statement.
  if (ret) _fn->body->insertAtTail(ret);
...........

This temporary removal of the return statement is done so that this code
in OwnershipFlowManager::insertAutoDestroyAtScopeExit(Symbol* sym):

...........
  BlockStmt* scope = sym->getDeclarationScope();
  scope->insertAtTail(autoDestroyCall);
...........

does not insert *after* the return statement.

That same function also contained _fn->getReturnSymbol()
which does *not* work without the return statement.

As a workaround, I stash away the return symbol in the OwnershipFlowManager
itself, in its constructor.

Note that the only test where this fires is:

  test/performance/sungeun/multilocale/autoCopy.chpl

because of:

...........
pragma "return value is not owned"
proc autoCopy(x) { return chpl__autoCopy(x); }
...........

See commit 325b0894 for details on this.