### PR TITLE
Prevent addition of FLAG_NOT_POD to classes during scopeResolve

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1024,7 +1024,9 @@ static void build_constructor(AggregateType* ct) {
         CallExpr* init = new CallExpr("initialize", gMethodToken, fn->_this);
         fn->insertAtTail(init);
         // If a type has an initialize method, it's not Plain Old Data.
-        ct->symbol->addFlag(FLAG_NOT_POD);
+        if (!isClass(ct)) {
+          ct->symbol->addFlag(FLAG_NOT_POD);
+        }
         break;
       }
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5108,14 +5108,9 @@ preFold(Expr* expr) {
           if (!nowarn)
             USR_WARN(type->symbol, "type %s does not currently support noinit, using default initialization", type->symbol->name);
 
-          if( type->defaultValue ) {
-            result = new SymExpr(type->defaultValue);
-            call->replace(result);
-          } else {
-            result = new CallExpr(PRIM_INIT, call->get(1)->remove());
-            call->replace(result);
-            inits.add((CallExpr *)result);
-          }
+          result = new CallExpr(PRIM_INIT, call->get(1)->remove());
+          call->replace(result);
+          inits.add((CallExpr *)result);
         } else {
           result = call;
           inits.add(call);


### PR DESCRIPTION
Classes are considered POD types, but if a class defined an initialize function,
it was getting marked as not POD during scopeResolve.  This caused "ignore
noinit" to be applied to it, and that caused the defaultValue for classes to
be given to return variables of that type during function resolution.  However,
the defaultValue field for classes is of nilType, and we can't assign to a
nilType from a different type (the defaultValue field is deprecated in favor pf
_defaultOf functions), causing the compiler error we were seeing for the
madness tests.  With this change, the class will again be considered a POD type,
and the six failing madness tests will now pass

Also remove out-of-date use of defaultValue field.  This code was removed in
master but for whatever reason restored in string-as-rec.  Removing it does
not seem to affect correctness (as expected - nothing with a defaultValue field
should have FLAG_NOT_POD attached to it).