### PR TITLE
Revert "Removed unused conditions in flattenFunctions.cpp"

### DIFF
--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -214,7 +214,10 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
               CallExpr* call = toCallExpr(se->parentExpr);
               INT_ASSERT(call);
               FnSymbol* fnc = call->isResolved();
-              if ((call->isPrimitive(PRIM_GET_MEMBER)) ||
+              if ((call->isPrimitive(PRIM_MOVE) && call->get(1) == se) ||
+                  (call->isPrimitive(PRIM_ASSIGN) && call->get(1) == se) ||
+                  (call->isPrimitive(PRIM_SET_MEMBER) && call->get(1) == se) ||
+                  (call->isPrimitive(PRIM_GET_MEMBER)) ||
                   (call->isPrimitive(PRIM_GET_MEMBER_VALUE)) ||
                   (call->isPrimitive(PRIM_WIDE_GET_LOCALE)) ||
                   (call->isPrimitive(PRIM_WIDE_GET_NODE)) ||


### PR DESCRIPTION
This reverts commit 67bc3f8dc497b8318504b6ef2235a7f6c57f291c

Turns out that the removed checks DID fire in this test:

  domains/sungeun/sparse/index_not_in_domain_1

on this expr:

  (894668 CallExpr move
    (894669 SymExpr 'p_i_3[804499]:int(64)[10]')
    (894670 SymExpr 'chpl__saIdxCopy[894663]:int(64)[10]'))

and their removal caused a valgrind failure in that test

I am putting these checks back in for now.

On string-as-rec, we still need to either fix those checks to handle
reference temps - or find a way not to use them.
What were these checks doing in the first place?