### PR TITLE
Make comm pthread arg static; won't be referenced until long from now.

### DIFF
--- a/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
+++ b/third-party/qthread/qthread-1.10/src/interfaces/chapel/tasks-qthreads.c
@@ -663,11 +663,16 @@ static aligned_t chapel_wrapper(void *arg)
     return 0;
 }
 
+typedef struct {
+    chpl_fn_p fn;
+    void *arg;
+} comm_task_wrapper_info_t;
+
 static void *comm_task_wrapper(void *arg)
 {
-    chpl_qthread_wrapper_args_t *rarg = arg;
+    comm_task_wrapper_info_t *rarg = arg;
     chpl_moveToLastCPU();
-    (*(chpl_fn_p)(rarg->fn))(rarg->args);
+    (*(chpl_fn_p)(rarg->fn))(rarg->arg);
     return 0;
 }
 
@@ -715,9 +720,18 @@ int chpl_task_createCommTask(chpl_fn_p fn,
                              void     *arg)
 {
 #ifndef QTHREAD_MULTINODE
-    chpl_qthread_wrapper_args_t wrapper_args = {fn, arg, false, {0}};
+    //
+    // The wrapper info must be static because it won't be referred to
+    // until the new pthread calls comm_task_wrapper().  And, it is
+    // safe for it to be static because we will be called at most once
+    // on each node.
+    //
+    static
+        comm_task_wrapper_info_t wrapper_info;
+    wrapper_info.fn = fn;
+    wrapper_info.arg = arg;
     return pthread_create(&chpl_qthread_comm_pthread,
-                          NULL, comm_task_wrapper, &wrapper_args);
+                          NULL, comm_task_wrapper, &wrapper_info);
 #else
     return 0;
 #endif


### PR DESCRIPTION
Silly me.  The argument block for the comm pthread has to outlast the
activation of chpl_task_createCommTask(), since it won't be referenced
until the comm pthread actually calls the wrapper.  That being so, make
it static.  (This is safe because it's only used precisely once on each
node).  While here, give it its own type.  Reusing the one for qthread
wrappers is inelegant.