### PR TITLE
Removed unused conditions in flattenFunctions.cpp for SAR

### DIFF
--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -219,10 +219,7 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
               CallExpr* call = toCallExpr(se->parentExpr);
               INT_ASSERT(call);
               FnSymbol* fnc = call->isResolved();
-              if ((call->isPrimitive(PRIM_MOVE) && call->get(1) == se) ||
-                  (call->isPrimitive(PRIM_ASSIGN) && call->get(1) == se) ||
-                  (call->isPrimitive(PRIM_SET_MEMBER) && call->get(1) == se) ||
-                  (call->isPrimitive(PRIM_GET_MEMBER)) ||
+              if ((call->isPrimitive(PRIM_GET_MEMBER)) ||
                   (call->isPrimitive(PRIM_GET_MEMBER_VALUE)) ||
                   (call->isPrimitive(PRIM_WIDE_GET_LOCALE)) ||
                   (call->isPrimitive(PRIM_WIDE_GET_NODE)) ||


### PR DESCRIPTION
I am re-introducing, on string-as-rec, the PR #2362 that I reverted in #2436
// corresponding commits:  67bc3f8 and 5758082

The motivation for removing those checks (see #2362) was that
on string-as-rec they would be wrong because reference temps are now
inserted earlier and these checks would not fire in their presence.

However, turns out that these checks are needed in this test:

  domains/sungeun/sparse/index_not_in_domain_1.chpl

where valgrind reports an error when the checks are removed.
So I re-introduced these checks back on master (#2436)
so valgrind succeeds.

However, for string-as-rec we need to investigate whether these checks
are working correctly. Towards that end, I am again removing them.
The above test continue failing under valgrind for now,
and I will add a JIRA issue for us to come back and investigate.