### PR TITLE
Add localize calls when using .c_str on possibly remote strings

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6064,7 +6064,8 @@ postFold(Expr* expr) {
       INT_ASSERT(se);
       if (se->var->isParameter()) {
         const char* str = get_string(se);
-        result = new SymExpr(new_IntSymbol((int)str[0], INT_SIZE_DEFAULT));
+        const std::string unescaped = unescapeString(str);
+        result = new SymExpr(new_IntSymbol((int)unescaped[0], INT_SIZE_DEFAULT));
         call->replace(result);
       }
     } else if (call->isPrimitive("string_contains")) {

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -148,6 +148,8 @@ module CString {
     __primitive("=", a, b);
   }
 
+  // for a to be a valid c_string after this function it must be on the same
+  // locale as b
   inline proc =(ref a: c_string, b: string) {
     __primitive("=", a, b.c_str());
   }

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -440,11 +440,7 @@ module ChapelIO {
   
   inline proc Reader.readWriteLiteral(lit:string, ignoreWhiteSpace=true)
   {
-    /***
-    var iolit = new ioLiteral(lit.c_str(), ignoreWhiteSpace);
-    this.readwrite(iolit);
-    ***/
-    this.readWriteLiteral(lit.c_str(), ignoreWhiteSpace);
+    this.readWriteLiteral(lit.localize().c_str(), ignoreWhiteSpace);
   }
   inline proc Reader.readWriteLiteral(lit:c_string, ignoreWhiteSpace=true)
   {
@@ -453,11 +449,7 @@ module ChapelIO {
   }
   inline proc Writer.readWriteLiteral(lit:string, ignoreWhiteSpace=true)
   {
-    /***
-    var iolit = new ioLiteral(lit.c_str(), ignoreWhiteSpace);
-    this.readwrite(iolit);
-    ***/
-    this.readWriteLiteral(lit.c_str(), ignoreWhiteSpace);
+    this.readWriteLiteral(lit.localize().c_str(), ignoreWhiteSpace);
   }
   inline proc Writer.readWriteLiteral(lit:c_string, ignoreWhiteSpace=true)
   {
@@ -480,7 +472,7 @@ module ChapelIO {
   }
   
   proc halt(s:string) {
-    halt(s.c_str());
+    halt(s.localize().c_str());
   }
 
   proc halt(s:c_string) {
@@ -494,7 +486,7 @@ module ChapelIO {
   }
   
   proc warning(s:string) {
-    warning(s.c_str());
+    warning(s.localize().c_str());
   }
 
   proc warning(s:c_string) {

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -28,12 +28,22 @@
  *
  */
 
-//TODO: I dont think this module is overly useful anymore
 module BaseStringType {
+  // TODO: figure out why I cant move this defintion into `module String`
+  type bufferType = c_ptr(uint(8));
+}
+
+// Chapel Strings
+module String {
+  use BaseStringType;
   use CString;
   use SysCTypes;
+  use StringCasts;
 
-  type bufferType = c_ptr(uint(8));
+  //
+  // Externs and constants used to implement strings
+  //
+  // TODO: mark most of these as private or move elsewhere
 
   param chpl_string_min_alloc_size: int = 16;
   // Growth factor to use when extending the buffer for appends
@@ -48,7 +58,7 @@ module BaseStringType {
   // as well we will get a duplicate symbol error. I believe this is due to
   // module load ordering issues.
   // TODO: make a proc in ChapelLocale that returns this rather than using the extern
-  extern var chpl_nodeID: chpl_nodeID_t;
+  //extern var chpl_nodeID: chpl_nodeID_t;
 
   // TODO: hook into chpl_here_alloc and friends somehow
   // The runtime exits on errors for these, no need to check for nil on return
@@ -71,7 +81,7 @@ module BaseStringType {
   extern const CHPL_RT_MD_STR_COPY_REMOTE: chpl_mem_descInt_t;
   extern const CHPL_RT_MD_STR_COPY_DATA: chpl_mem_descInt_t;
 
-  inline proc chpl_string_comm_get(dest: bufferType, src_loc_id: int(64),
+  private inline proc chpl_string_comm_get(dest: bufferType, src_loc_id: int(64),
                                    src_addr: bufferType, len: size_t) {
     __primitive("chpl_comm_get", dest, src_loc_id, src_addr, len);
   }
@@ -88,13 +98,10 @@ module BaseStringType {
   extern proc memcmp(s1: c_ptr, s2: c_ptr, n: size_t) : c_int;
 
   config param debugStrings = false;
-}
 
-// Chapel Strings
-module String {
-  use BaseStringType;
-  use StringCasts;
-
+  //
+  // String Implementaion
+  //
   // TODO: We should be able to remove "ignore noinit", but doing so causes
   // memory leaks in various places. Investigate why later and add noinit back
   // in when possible.
@@ -107,25 +114,31 @@ module String {
     var owned: bool = true;
 
     proc string(s: string, owned: bool = true) {
-      this.owned = owned;
       const sRemote = s.locale.id != chpl_nodeID;
-      if !owned && sRemote {
-        // TODO: Should I just ignore the supplied value of owned instead of
-        //       halting?
-        halt("Must take ownership of a copy of a remote string");
-      }
-      var localBuff: bufferType = nil;
       const sLen = s.len;
+      this.owned = owned;
       // Dont need to do anything if s is an empty string
       if sLen != 0 {
-        localBuff = if sRemote
-          then copyRemoteBuffer(s.locale.id, s.buff, sLen)
-          else s.buff;
+        this.len = sLen;
+        if sRemote {
+          // ignore supplied valure of owned for remote strings so we dont leak
+          this.owned = true;
+          this.buff = copyRemoteBuffer(s.locale.id, s.buff, sLen);
+          this._size = sLen+1;
+        } else {
+          if this.owned {
+            const allocSize = chpl_mem_goodAllocSize((sLen+1).safeCast(size_t));
+            this.buff = chpl_mem_alloc(allocSize,
+                                       CHPL_RT_MD_STR_COPY_DATA): bufferType;
+            memcpy(this.buff, s.buff, s.len.safeCast(size_t));
+            this.buff[sLen] = 0;
+            this._size = allocSize.safeCast(int);
+          } else {
+            this.buff = s.buff;
+            this._size = s._size;
+          }
+        }
       }
-      // We only need to copy when the buffer is local
-      // TODO: reinitString does more checks then we actually need but is still
-      // correct. Is it worth just doing the proper copy here?
-      this.reinitString(localBuff, sLen, sLen+1, needToCopy=sRemote);
     }
 
     // This constructor can cause a leak if owned = false and needToCopy = true
@@ -300,14 +313,12 @@ module String {
       return ret;
     }
 
-    // Returns a string containing the character at the given index of
-    // the string, or an empty string if the index is out of bounds.
+    pragma "no doc"
     inline proc substring(i: int) {
       compilerError("substring removed: use string[index]");
     }
 
-    // Returns a string containing the string sliced by the given
-    // range, or an empty string if the range does not overlap.
+    pragma "no doc"
     inline proc substring(r: range) {
       compilerError("substring removed: use string[range]");
     }
@@ -317,6 +328,7 @@ module String {
     }
 
     //TODO: What is this for? nothing uses it...
+    pragma "no doc"
     proc writeThis(f: Writer) {
       compilerWarning("not implemented: writeThis");
     }
@@ -653,10 +665,9 @@ module String {
       on this {
         for i in 0..#this.len {
           const b = buff[i];
-          // TODO: (escaped chars seem to break ascii...)
           if !((b == ascii(' ')) ||
-               (b == 0x09) || // \t
-               (b >= 0x0A && b <= 0x0D)) { // \n \v \f \r
+               (b == ascii('\t')) ||
+               (b >= ascii('\n') && b <= ascii('\r'))) { // \n \v \f \r
             result = false;
             break;
           }
@@ -769,6 +780,7 @@ module String {
       for i in 0..#result.len {
         const b = result.buff[i];
         if _byte_isUpper(b) {
+          // We can just add or subtract 0x20 to change between upper and lower
           result.buff[i] = b + 0x20;
         }
       }
@@ -1228,19 +1240,19 @@ module String {
   //
   // Helper routines
   //
-  inline proc _byte_isUpper(b: uint(8)) : bool {
+  private inline proc _byte_isUpper(b: uint(8)) : bool {
     return b >= ascii('A') && b <= ascii('Z');
   }
 
-  inline proc _byte_isLower(b: uint(8)) : bool {
+  private inline proc _byte_isLower(b: uint(8)) : bool {
     return b >= ascii('a') && b <= ascii('z');
   }
 
-  inline proc _byte_isAlpha(b: uint(8)) : bool {
+  private inline proc _byte_isAlpha(b: uint(8)) : bool {
     return b >= ascii('A')  && b <= ascii('z');
   }
 
-  inline proc _byte_isDigit(b: uint(8)) : bool {
+  private inline proc _byte_isDigit(b: uint(8)) : bool {
     return b >= ascii('0')  && b <= ascii('9');
   }
 
@@ -1294,7 +1306,7 @@ module String {
   //
   // Developer Extras
   //
-
+  pragma "no doc"
   proc chpldev_refToString(ref arg) : string {
     // print out the address of class references as well
     proc chpldev_classToString(x: object) : string

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -83,20 +83,21 @@ module StringCasts {
     pragma "insert line file info"
     extern proc c_string_to_uint64_t(x:c_string) : uint(64);
 
+    const localX = x.localize();
     if isIntType(t) {
       select numBits(t) {
-        when 8  do return c_string_to_int8_t(x.c_str());
-        when 16 do return c_string_to_int16_t(x.c_str());
-        when 32 do return c_string_to_int32_t(x.c_str());
-        when 64 do return c_string_to_int64_t(x.c_str());
+        when 8  do return c_string_to_int8_t(localX.c_str());
+        when 16 do return c_string_to_int16_t(localX.c_str());
+        when 32 do return c_string_to_int32_t(localX.c_str());
+        when 64 do return c_string_to_int64_t(localX.c_str());
         otherwise compilerError("Unsupported bit width ", numBits(t), " in cast to string");
       }
     } else {
       select numBits(t) {
-        when 8  do return c_string_to_uint8_t(x.c_str());
-        when 16 do return c_string_to_uint16_t(x.c_str());
-        when 32 do return c_string_to_uint32_t(x.c_str());
-        when 64 do return c_string_to_uint64_t(x.c_str());
+        when 8  do return c_string_to_uint8_t(localX.c_str());
+        when 16 do return c_string_to_uint16_t(localX.c_str());
+        when 32 do return c_string_to_uint32_t(localX.c_str());
+        when 64 do return c_string_to_uint64_t(localX.c_str());
         otherwise compilerError("Unsupported bit width ", numBits(t), " in cast to string");
       }
     }
@@ -138,9 +139,10 @@ module StringCasts {
     pragma "insert line file info"
     extern proc c_string_to_real64(x: c_string) : real(64);
 
+    const localX = x.localize();
     select numBits(t) {
-      when 32 do return c_string_to_real32(x.c_str());
-      when 64 do return c_string_to_real64(x.c_str());
+      when 32 do return c_string_to_real32(localX.c_str());
+      when 64 do return c_string_to_real64(localX.c_str());
       otherwise compilerError("Unsupported bit width ", numBits(t), " in cast to string");
     }
   }
@@ -151,9 +153,10 @@ module StringCasts {
     pragma "insert line file info"
     extern proc c_string_to_imag64(x: c_string) : imag(64);
 
+    const localX = x.localize();
     select numBits(t) {
-      when 32 do return c_string_to_imag32(x.c_str());
-      when 64 do return c_string_to_imag64(x.c_str());
+      when 32 do return c_string_to_imag32(localX.c_str());
+      when 64 do return c_string_to_imag64(localX.c_str());
       otherwise compilerError("Unsupported bit width ", numBits(t), " in cast to string");
     }
   }
@@ -191,9 +194,10 @@ module StringCasts {
     pragma "insert line file info"
     extern proc c_string_to_complex128(x:c_string) : complex(128);
 
+    const localX = x.localize();
     select numBits(t) {
-      when 64 do return c_string_to_complex64(x.c_str());
-      when 128 do return c_string_to_complex128(x.c_str());
+      when 64 do return c_string_to_complex64(localX.c_str());
+      when 128 do return c_string_to_complex128(localX.c_str());
       otherwise compilerError("Unsupported bit width ", numBits(t), " in cast to string");
     }
   }
@@ -212,15 +216,5 @@ module StringCasts {
     ret.write(x);
     return ret;
   }
-
-  //
-  // Badness
-  //
-  // TODO: I *really* dont like this
-  // Other casts to strings use the bufferType
-  //inline proc _cast(type t, x) where t == string && x.type != c_string && x.type != string {
-  //  compilerError("_cast ":c_string+typeToString(x.type)+"->c_string->string":c_string);
-  //}
-
 
 }

--- a/modules/standard/Curl.chpl
+++ b/modules/standard/Curl.chpl
@@ -427,7 +427,7 @@ record slist {
 proc slist.append(str:string) {
   var err: syserr = ENOERR;
   on this.home {
-    err = chpl_curl_slist_append(this.list, str.c_str());
+    err = chpl_curl_slist_append(this.list, str.localize().c_str());
   }
   if err then ioerror(err, "in slist.append()");
 }

--- a/modules/standard/Error.chpl
+++ b/modules/standard/Error.chpl
@@ -57,7 +57,7 @@ proc quote_string(s:string, len:ssize_t) {
   // 34 is ASCII double quote
   var err: syserr = qio_quote_string(34:uint(8), 34:uint(8),
                                     QIO_STRING_FORMAT_CHPL,
-                                    s.c_str(), len, ret, c_nil);
+                                    s.localize().c_str(), len, ret, c_nil);
 
   // This doesn't handle the case where ret==NULL as did the previous
   // version in QIO, but I'm not sure how that was used.

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -474,7 +474,7 @@ module GMP {
     }
     proc BigInt(str:string, base:int=0) {
       var e:c_int;
-      e = mpz_init_set_str(this.mpz, str.c_str(), base.safeCast(c_int));
+      e = mpz_init_set_str(this.mpz, str.localize().c_str(), base.safeCast(c_int));
       if e {
         mpz_clear(this.mpz);
         halt("Error initializing big integer: bad format");
@@ -483,7 +483,7 @@ module GMP {
     proc BigInt(str:string, base:int=0, out error:syserr) {
       var e:c_int;
       error = ENOERR;
-      e = mpz_init_set_str(this.mpz, str.c_str(), base.safeCast(c_int));
+      e = mpz_init_set_str(this.mpz, str.localize().c_str(), base.safeCast(c_int));
       if e {
         mpz_clear(this.mpz);
         error = EFORMAT;
@@ -560,7 +560,7 @@ module GMP {
     }
     proc set_str(str:string, base:int=0)
     {
-      on this do mpz_set_str(this.mpz, str.c_str(), base.safeCast(c_int));
+      on this do mpz_set_str(this.mpz, str.localize().c_str(), base.safeCast(c_int));
     }
     proc swap(a:BigInt)
     {

--- a/modules/standard/HDFS.chpl
+++ b/modules/standard/HDFS.chpl
@@ -403,10 +403,7 @@ proc hdfsChapelConnect(path: string, port: int): hdfsChapelFileSystem {
   forall loc in Locales {
     on loc {
       var err: syserr;
-      // TODO XXX: HACK: this accessing of locale.id copies the string onto this locale...
-      // If you get rid of this IT WILL BREAK. (at least as strings currently stand)
-      var hack = path.locale.id;
-      const tmpstr = path;
+      const tmpstr = path.localize();
       rcLocal(ret._internal_file) = hdfsChapelConnect(err, tmpstr.c_str(), port);
       if err then ioerror(err, "Unable to connect to HDFS", tmpstr);
     }
@@ -527,7 +524,7 @@ pragma "no doc"
 proc hdfs_chapel_connect(out error:syserr, path:string, port: int): hdfsChapelFileSystem_local{
   var ret:hdfsChapelFileSystem_local;
   ret.home = here;
-  error = hdfs_connect(ret._internal_, path.c_str(), port);
+  error = hdfs_connect(ret._internal_, path.localize().c_str(), port);
   return ret;
 }
 
@@ -537,7 +534,7 @@ proc getHosts(f: file) {
   var ret_num: c_int;
   var arr: char_ptr_ptr = hdfs_alloc_array(numLocales);
   for loc in Locales {
-    hdfs_create_locale_mapping(arr, loc.id, loc.name.c_str());
+    hdfs_create_locale_mapping(arr, loc.id, loc.name.localize().c_str());
   }
   var err = hdfs_get_owners(f._file_internal, ret._internal_, ret_num, arr, numLocales);
   if err then ioerror(err, "Unable to get owners for HDFS file");

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -49,7 +49,7 @@ proc realPath(out error: syserr, name: string): string {
   extern proc chpl_fs_realpath(path: c_string, ref shortened: c_string_copy): syserr;
 
   var res: c_string_copy;
-  error = chpl_fs_realpath(name.c_str(), res);
+  error = chpl_fs_realpath(name.localize().c_str(), res);
   var len = res.length;
   return new string(res:c_ptr(uint(8)), len, len+1, owned=true, needToCopy=false);
 }

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -414,7 +414,7 @@ proc compile(pattern: string, utf8=true, posix=false, literal=false, nocapture=f
   opts.nongreedy = nongreedy;
 
   var ret:regexp;
-  qio_regexp_create_compile(pattern.c_str(), pattern.length, opts, ret._regexp);
+  qio_regexp_create_compile(pattern.localize().c_str(), pattern.length, opts, ret._regexp);
   if ! qio_regexp_ok(ret._regexp) {
     var err_str = qio_regexp_error(ret._regexp);
     var err_msg = "Error " + err_str + " when compiling regexp '" + pattern + "'";
@@ -654,9 +654,9 @@ record regexp {
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
       var got:bool;
       if t == stringPart {
-       got = qio_regexp_match(_regexp, text.from.c_str(), text.from.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
+       got = qio_regexp_match(_regexp, text.from.localize().c_str(), text.from.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
       } else {
-       got = qio_regexp_match(_regexp, text.c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
+       got = qio_regexp_match(_regexp, text.localize().c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
       }
       // Now try to coerce the read strings into the captures.
       _handle_captures(text, matches, nmatches, captures);
@@ -686,9 +686,9 @@ record regexp {
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
       var got:bool;
       if t == stringPart {
-       got = qio_regexp_match(_regexp, text.from.c_str(), text.from.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
+       got = qio_regexp_match(_regexp, text.from.localize().c_str(), text.from.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
       } else {
-       got = qio_regexp_match(_regexp, text.c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
+       got = qio_regexp_match(_regexp, text.localize().c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
       }
       // Now return where we matched.
       ret = new reMatch(got, matches[0].offset, matches[0].len);
@@ -734,9 +734,9 @@ record regexp {
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
       var got:bool;
       if t == stringPart {
-        got = qio_regexp_match(_regexp, text.from.c_str(), text.from.length, pos, endpos, QIO_REGEXP_ANCHOR_START, matches, nmatches);
+        got = qio_regexp_match(_regexp, text.from.localize().c_str(), text.from.length, pos, endpos, QIO_REGEXP_ANCHOR_START, matches, nmatches);
       } else {
-        got = qio_regexp_match(_regexp, text.c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_START, matches, nmatches);
+        got = qio_regexp_match(_regexp, text.localize().c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_START, matches, nmatches);
       }
       // Now try to coerce the read strings into the captures.
       _handle_captures(text, matches, nmatches, captures);
@@ -766,9 +766,9 @@ record regexp {
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
       var got:bool;
       if t == stringPart {
-       got = qio_regexp_match(_regexp, text.from.c_str(), text.from.length, pos, endpos, QIO_REGEXP_ANCHOR_START, matches, nmatches);
+       got = qio_regexp_match(_regexp, text.from.localize().c_str(), text.from.length, pos, endpos, QIO_REGEXP_ANCHOR_START, matches, nmatches);
       } else {
-       got = qio_regexp_match(_regexp, text.c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_START, matches, nmatches);
+       got = qio_regexp_match(_regexp, text.localize().c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_START, matches, nmatches);
       }
       // Now return where we matched.
       ret = new reMatch(got, matches[0].offset, matches[0].len);
@@ -816,7 +816,7 @@ record regexp {
       var got:bool;
       on this.home {
         // This doesn't have a case for stringPart.  Mistake?
-        got = qio_regexp_match(_regexp, text.c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
+        got = qio_regexp_match(_regexp, text.localize().c_str(), text.length, pos, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
       }
 
       splits += 1;
@@ -886,7 +886,7 @@ record regexp {
       var got:bool;
       on this.home {
         // This doesn't have a case for stringPart.  Mistake?
-        got = qio_regexp_match(_regexp, text.c_str(), textLength, cur, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
+        got = qio_regexp_match(_regexp, text.localize().c_str(), textLength, cur, endpos, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
       }
       if !got then break;
       param nret = captures+1;
@@ -926,9 +926,9 @@ record regexp {
     var nreplaced:int; 
     var replaced_len:int(64); 
     if t == stringPart {
-      nreplaced = qio_regexp_replace(_regexp, repl.c_str(), repl.length, text.from.c_str(), text.from.length, pos, endpos, global, replaced, replaced_len);
+      nreplaced = qio_regexp_replace(_regexp, repl.localize().c_str(), repl.length, text.from.localize().c_str(), text.from.length, pos, endpos, global, replaced, replaced_len);
     } else {
-      nreplaced = qio_regexp_replace(_regexp, repl.c_str(), repl.length, text.c_str(), text.length, pos, endpos, global, replaced, replaced_len);
+      nreplaced = qio_regexp_replace(_regexp, repl.localize().c_str(), repl.length, text.localize().c_str(), text.length, pos, endpos, global, replaced, replaced_len);
     }
     const ret = replaced:string;
     return (ret, nreplaced);

--- a/test/extern/bradc/extern_string_test-remote.chpl
+++ b/test/extern/bradc/extern_string_test-remote.chpl
@@ -4,9 +4,9 @@ extern proc return_string_arg_test(ref str:c_string);
 writeln("returned string ",return_string_test()); stdout.flush();
 var s:string;
 on Locales(1) {
-  var tmp:c_string = s.localize().c_str();
-  return_string_arg_test(tmp);
-  s = tmp:string; // TODO -- this cast should not be necessary.
+  var temp_cs: c_string;
+  return_string_arg_test(temp_cs);
+  var temp_s:string = temp_cs;
+  s = temp_s;
 }
 writeln("returned string arg ",s);
-

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -5,7 +5,7 @@ Initializing Modules:
     CString
     String
      BaseStringType
-      SysCTypes
+     SysCTypes
      StringCasts
     MemConsistency
     Atomics


### PR DESCRIPTION
It is necessary to use string.localize() to get a local copy of a string
before calling string.c_str(). This commit adds these calls throughout
the modules if they are needed.

Other minor cleanups to Strings.

extern_string_test-remote.chpl has been updated to work with the
requirement that c_strings must be placed into a string before they can
be sent across locales.