### PR TITLE
Refactor the Barrier standard module into a single main class

### DIFF
--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -19,7 +19,7 @@
 
 /* Support for task barriers.
 
-   The Barrier record provided in this module can be used to prevent tasks
+   The Barrier type provided in this module can be used to prevent tasks
    from proceeding until all other related tasks have also reached the
    barrier.
 

--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -19,7 +19,7 @@
 
 /* Support for task barriers.
 
-   The Barrier records provided in this module can be used to prevent tasks
+   The Barrier record provided in this module can be used to prevent tasks
    from proceeding until all other related tasks have also reached the
    barrier.
 
@@ -33,11 +33,13 @@
      config const numTasks = here.maxTaskPar;
      var b = new Barrier(numTasks);
 
-     coforall tid in 1..numTasks with (ref b) {
+     coforall tid in 1..numTasks {
        writeln("Task ", tid, " is entering the barrier");
        b.barrier();
        writeln("Task ", tid, " is past the barrier");
      }
+
+     delete b;
 
    Future direction
    ----------------
@@ -51,27 +53,116 @@
    implemented and optimized.
 */
 module Barrier {
-  /* The BarrierBaseType record provides an abstract base type for barriers
+  /* An enumeration of the different barrier implementations.  Used to choose
+     the implementation to use when constructing a new barrier object.
+
+     * `BarrierType.Atomic` uses Chapel atomic variables to control the barrier.
+     * `BarrierType.Sync` uses Chapel sync variables to control the barrier.
+  */
+  enum BarrierType {Atomic, Sync}
+
+  /* A barrier that will cause `numTasks` to wait before proceeding. */
+  class Barrier {
+    pragma "no doc"
+    var bar: BarrierBaseType;
+
+    /* Construct a new barrier object.
+
+       :arg numTasks: The number of tasks that will use this barrier
+       :arg barrierType: The barrier implementation to use
+       :arg reusable: Encure some extra overhead to allow reuse of this barrier?
+
+    */
+    proc Barrier(numTasks: int,
+                 barrierType: BarrierType = BarrierType.Atomic,
+                 reusable: bool = (barrierType == BarrierType.Atomic)) {
+      select barrierType {
+        when BarrierType.Atomic {
+          if reusable {
+            bar = new aBarrier(numTasks, reusable=true);
+          } else {
+            bar = new aBarrier(numTasks, reusable=false);
+          }
+        }
+        when BarrierType.Sync {
+          if reusable {
+            halt("reusable barriers not implemented for ", barrierType);
+          } else {
+            bar = new sBarrier(numTasks);
+          }
+        }
+        otherwise {
+          halt("unknown barrier type");
+        }
+      }
+    }
+
+    pragma "no doc"
+    proc ~Barrier() {
+      if bar != nil {
+        delete bar;
+      }
+    }
+
+    /* Block until all related tasks have called this method.  If `reusable`
+       is true, reset the barrier to be used again.
+     */
+    inline proc barrier() {
+      bar.barrier();
+    }
+
+    /* Notify the barrier that this task has reached this point. */
+    inline proc notify() {
+      bar.notify();
+    }
+
+    /* Wait until `n` tasks have called :proc:`notify`.  If `reusable` is true,
+       reset the barrier to be used again.  Note: if `reusable` is true
+       :proc:`wait` will block until `n` tasks have called it after calling
+       :proc:`notify`.
+     */
+    inline proc wait() {
+      bar.wait();
+    }
+
+    /* return `true` if `n` tasks have called :proc:`notify`
+     */
+    inline proc try(): bool {
+      return bar.try();
+    }
+
+    pragma "no doc"
+    inline proc reset(_n: int) {
+      bar.reset(_n);
+    }
+  }
+
+  /* The BarrierBaseType class provides an abstract base type for barriers
    */
-  record BarrierBaseType {
+  pragma "no doc" class BarrierBaseType {
     pragma "no doc"
     proc barrier() {
-      compilerError("barrier() not implemented");
+      halt("barrier() not implemented");
     }
 
     pragma "no doc"
     proc notify() {
-      compilerWarning("notify() not implemented");
+      halt("notify() not implemented");
     }
 
     pragma "no doc"
     proc wait() {
-      compilerWarning("wait() not implemented");
+      halt("wait() not implemented");
     }
 
     pragma "no doc"
-    proc try(): int {
-      compilerWarning("try() not implemented");
+    proc try(): bool {
+      halt("try() not implemented");
+    }
+
+    pragma "no doc"
+    proc reset(_n: int) {
+      halt("reset() not implemented");
     }
   }
 
@@ -79,7 +170,7 @@ module Barrier {
 /* A task barrier implemented using atomics. Can be used as a simple barrier
    or as a split-phase barrier.
  */
-  record Barrier: BarrierBaseType {
+  pragma "no doc" class aBarrier: BarrierBaseType {
     /* If true the barrier can be used multiple times.  When using this as a
        split-phase barrier this causes :proc:`wait` to block until all tasks
        have reached the wait */
@@ -96,7 +187,7 @@ module Barrier {
 
        :arg n: The number of tasks involved in this barrier
      */
-    proc Barrier(n: int) {
+    proc aBarrier(n: int, param reusable: bool) {
       reset(n);
     }
 
@@ -171,7 +262,7 @@ module Barrier {
   /* A task barrier implemented using sync and single variables. Can be used
      as a simple barrier or as a split-phase barrier.
    */
-  record sBarrier: BarrierBaseType {
+  pragma "no doc" class sBarrier: BarrierBaseType {
     pragma "no doc"
     var count: sync int;
     pragma "no doc"
@@ -183,6 +274,9 @@ module Barrier {
      */
     proc sBarrier(n: int) {
       count = n;
+    }
+    proc reset(_n: int) {
+      halt("cannot reset sync based barrier");
     }
 
     /* Block until `n` tasks have called this method.

--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -47,6 +47,12 @@
    "task-team" concept.  A task-team will more directly support collective
    operations such as barriers between the tasks within a team.
 
+   The Barrier type is currently implemented as a class, requiring it to be
+   explicitly deleted before it goes out of scope.  It is expected that this
+   type will be changed into a record allowing it to be automatically
+   reclaimed.  When this change happens, code that uses this Barrier will need
+   to have the explicit deletes removed, but should require no other changes.
+
    The current implementation is designed for correctness, but is not expected
    to perform well at scale.  We expect performance at scale to improve as
    this barrier implementation is optimized and as the task-team concept is
@@ -70,7 +76,7 @@ module Barrier {
 
        :arg numTasks: The number of tasks that will use this barrier
        :arg barrierType: The barrier implementation to use
-       :arg reusable: Encure some extra overhead to allow reuse of this barrier?
+       :arg reusable: Incur some extra overhead to allow reuse of this barrier?
 
     */
     proc Barrier(numTasks: int,

--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -30,6 +30,8 @@
    "entering the barrier" messages will be printed before any of the
    "past the barrier" messages. ::
 
+     use Barrier;
+
      config const numTasks = here.maxTaskPar;
      var b = new Barrier(numTasks);
 

--- a/test/parallel/taskPar/sungeun/barrier/basic.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/basic.chpl
@@ -4,37 +4,38 @@ use BlockDist;
 config const numTasks = 31;
 config const numRemoteTasks = numLocales*11;
 
-proc localTest(ref b, numTasks) {
+proc localTest(b: Barrier, numTasks) {
   const barSpace = 0..#numTasks;
   var A: [barSpace] int = -1;
-  coforall t in barSpace with (ref b) do {
+  coforall t in barSpace do {
     A[t] = t;
     b.barrier();
     if t==0 then writeln(A);
   }
 }
 
-proc remoteTest(ref b, numRemoteTasks) {
+proc remoteTest(b: Barrier, numRemoteTasks) {
   const barSpace = 0..#numRemoteTasks;
   var A: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = barSpace;
   var B: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = -1;
-  coforall t in barSpace with (ref b) do on A.domain.dist.idxToLocale(t) {
+  coforall t in barSpace do on A.domain.dist.idxToLocale(t) {
     B[t] = A[t];
     b.barrier();
     if t==0 then writeln(B);
   }
 }
 
-
-var b: Barrier(reusable=false) = new Barrier(numTasks);
+var b: Barrier = new Barrier(numTasks);
 localTest(b, numTasks);
 
 b.reset(numRemoteTasks);
 remoteTest(b, numRemoteTasks);
+delete b;
 
-var sb1 = new sBarrier(numTasks);
+var sb1 = new Barrier(numTasks, BarrierType.Sync);
 localTest(sb1, numTasks);
+delete sb1;
 
-var sb2 = new sBarrier(numRemoteTasks);
+var sb2 = new Barrier(numRemoteTasks, BarrierType.Sync);
 remoteTest(sb2, numRemoteTasks);
-
+delete sb2;

--- a/test/parallel/taskPar/sungeun/barrier/reuse.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/reuse.chpl
@@ -5,10 +5,10 @@ config const printResults = false;
 config const numTasks = 31;
 config const numRemoteTasks = numLocales*11;
 
-proc localTest(ref b, numTasks) {
+proc localTest(b: Barrier, numTasks) {
   const barSpace = 0..#numTasks;
   var A: [barSpace] int = -1;
-  coforall t in barSpace with (ref b) do {
+  coforall t in barSpace do {
     A[t] = t;
     for i in 1..numTasks {
       if i%2 {
@@ -22,11 +22,11 @@ proc localTest(ref b, numTasks) {
   }
 }
 
-proc remoteTest(ref b, numRemoteTasks) {
+proc remoteTest(b: Barrier, numRemoteTasks) {
   const barSpace = 0..#numRemoteTasks;
   var A: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = barSpace;
   var B: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = -1;
-  coforall t in barSpace with (ref b) do on A.domain.dist.idxToLocale(t) {
+  coforall t in barSpace do on A.domain.dist.idxToLocale(t) {
     B[t] = A[t];
     for i in 1..numRemoteTasks {
       if i%2 {
@@ -46,3 +46,4 @@ localTest(b, numTasks);
 
 b.reset(numRemoteTasks);
 remoteTest(b, numRemoteTasks);
+delete b;

--- a/test/parallel/taskPar/sungeun/barrier/split-phase.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/split-phase.chpl
@@ -4,10 +4,10 @@ use BlockDist;
 config const numTasks = 31;
 config const numRemoteTasks = numLocales*11;
 
-proc localTest(ref b, numTasks) {
+proc localTest(b: Barrier, numTasks) {
   const barSpace = 0..#numTasks;
   var A: [barSpace] int = -1;
-  coforall t in barSpace with (ref b) do {
+  coforall t in barSpace do {
     A[t] = t;
     b.notify();
     if t!=barSpace.high {
@@ -19,11 +19,11 @@ proc localTest(ref b, numTasks) {
   }
 }
 
-proc remoteTest(ref b, numRemoteTasks) {
+proc remoteTest(b: Barrier, numRemoteTasks) {
   const barSpace = 0..#numRemoteTasks;
   var A: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = barSpace;
   var B: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = -1;
-  coforall t in barSpace with (ref b) do on A.domain.dist.idxToLocale(t) {
+  coforall t in barSpace do on A.domain.dist.idxToLocale(t) {
     B[t] = A[t];
     b.notify();
     if t!=barSpace.high {
@@ -41,10 +41,12 @@ localTest(b, numTasks);
 
 b.reset(numRemoteTasks);
 remoteTest(b, numRemoteTasks);
+delete b;
 
-var sb1 = new sBarrier(numTasks);
+var sb1 = new Barrier(numTasks, BarrierType.Sync);
 localTest(sb1, numTasks);
+delete sb1;
 
-var sb2 = new sBarrier(numRemoteTasks);
+var sb2 = new Barrier(numRemoteTasks, BarrierType.Sync);
 remoteTest(sb2, numRemoteTasks);
-
+delete sb2;

--- a/test/studies/cholesky/jglewis/version2/elemental/block_distribution/elemental_cholesky_symmetric_index_ranges_block.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/block_distribution/elemental_cholesky_symmetric_index_ranges_block.chpl
@@ -109,7 +109,7 @@ module elemental_cholesky_symmetric_index_ranges_block {
     // SPMD -- launch a separate task on each processor
     // ------------------------------------------------
 
-    coforall processor in A_grid_domain with (ref bar) do {
+    coforall processor in A_grid_domain do {
 
       on A_locale_grid (processor) do {
 
@@ -267,6 +267,7 @@ module elemental_cholesky_symmetric_index_ranges_block {
 	  }
       }
     }
+    delete bar;
 
     // return success 
 

--- a/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges.chpl
@@ -106,7 +106,7 @@ module elemental_cholesky_symmetric_index_ranges {
     // SPMD -- launch a separate task on each processor
     // ------------------------------------------------
 
-    coforall processor in A_grid_domain with (ref bar) do {
+    coforall processor in A_grid_domain do {
 
       on A_locale_grid (processor) do {
 
@@ -264,6 +264,7 @@ module elemental_cholesky_symmetric_index_ranges {
 	  }
       }
     }
+    delete bar;
 
     // return success 
 

--- a/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges_alt.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges_alt.chpl
@@ -108,7 +108,7 @@ module elemental_cholesky_symmetric_index_ranges_alt {
     // SPMD -- launch a separate task on each processor
     // ------------------------------------------------
 
-    coforall processor in A_grid_domain with (ref bar) do {
+    coforall processor in A_grid_domain do {
 
       on A_locale_grid (processor) do {
 
@@ -253,7 +253,7 @@ module elemental_cholesky_symmetric_index_ranges_alt {
 	  }
       }
     }
-
+    delete bar;
     // return success 
 
     return true;

--- a/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/elemental_cholesky_fully_blocked.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/elemental_cholesky_fully_blocked.chpl
@@ -106,7 +106,7 @@ module elemental_cholesky_fully_blocked {
     // SPMD -- launch a separate task on each processor
     // ------------------------------------------------
 
-    coforall processor in A_grid_domain with (ref bar) do {
+    coforall processor in A_grid_domain do {
 
       on A_locale_grid (processor) do {
 
@@ -264,6 +264,7 @@ module elemental_cholesky_fully_blocked {
 	  }
       }
     }
+    delete bar;
 
     // return success 
 

--- a/test/studies/cholesky/jglewis/version2/elemental/strided/elemental_cholesky_symmetric_strided.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/strided/elemental_cholesky_symmetric_strided.chpl
@@ -109,7 +109,7 @@ module elemental_cholesky_symmetric_strided {
     // SPMD -- launch a separate task on each processor
     // ------------------------------------------------
 
-    coforall processor in A_grid_domain with (ref bar) do {
+    coforall processor in A_grid_domain do {
 
       on A_locale_grid (processor) do {
 
@@ -274,6 +274,7 @@ module elemental_cholesky_symmetric_strided {
 	  }
       }
     }
+    delete bar;
 
     // return success 
 

--- a/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/elemental_cholesky_unsymmetric_index_ranges.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/elemental_cholesky_unsymmetric_index_ranges.chpl
@@ -101,7 +101,7 @@ module elemental_cholesky_unsymmetric_index_ranges {
 
     const diag_offset = A.domain.low(1) - A.domain.low(2);
 
-    coforall processor in A_grid_domain with (ref bar) do {
+    coforall processor in A_grid_domain do {
 
       on A_locale_grid (processor) do {
 
@@ -259,6 +259,7 @@ module elemental_cholesky_unsymmetric_index_ranges {
 	  }
       }
     }
+    delete bar;
 
     // return success 
 


### PR DESCRIPTION
The Barrier class is now the single type for barriers in this module, but it is
implemented using either atomics or syncs chosen with an enum at construction
time.

Updated the tests that use this module to choose the same version they had been
using (atomics or syncs) and to delete the class instances when they are done
with them and to remove "with (ref bar)" clauses from coforall loops.

test/parallel/taskPar/sungeun/barrier/commDiags.chpl is currently regressing
for comm-gasnet due to a few extra gets.  I suspect this is due to an extra layer
of indirection vs. using a single record for each barrier type.