### PR TITLE
Let compiler choose atomic types for _EndCount

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1364,7 +1364,7 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
     //
     VarSymbol* coforallCount = newTemp("_coforallCount");
     BlockStmt* block = ForLoop::buildForLoop(indices, iterator, body, true, zippered);
-    block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc", gFalse)));
+    block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc", /* forceLocalTypes= */gFalse)));
     block->insertAtHead(new DefExpr(coforallCount));
     body->insertAtHead(new CallExpr("_upEndCount", coforallCount, gFalse));
     block->insertAtTail(new CallExpr("_waitEndCount", coforallCount, gFalse));
@@ -1386,7 +1386,7 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
     beginBlk->insertAtHead(body);
     beginBlk->insertAtTail(new CallExpr("_downEndCount", coforallCount));
     BlockStmt* block = ForLoop::buildForLoop(indices, iterator, beginBlk, true, zippered);
-    block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc", gTrue)));
+    block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc", /* forceLocalTypes= */gTrue)));
     block->insertAtHead(new DefExpr(coforallCount));
     block->insertAtTail(new CallExpr(PRIM_PROCESS_TASK_LIST, coforallCount));
     beginBlk->insertBefore(new CallExpr("_upEndCount", coforallCount));
@@ -2116,7 +2116,7 @@ buildSyncStmt(Expr* stmt) {
   VarSymbol* endCountSave = newTemp("_endCountSave");
   block->insertAtTail(new DefExpr(endCountSave));
   block->insertAtTail(new CallExpr(PRIM_MOVE, endCountSave, new CallExpr(PRIM_GET_END_COUNT)));
-  block->insertAtTail(new CallExpr(PRIM_SET_END_COUNT, new CallExpr("_endCountAlloc", gFalse)));
+  block->insertAtTail(new CallExpr(PRIM_SET_END_COUNT, new CallExpr("_endCountAlloc", /* forceLocalTypes= */gFalse)));
   block->insertAtTail(stmt);
   block->insertAtTail(new CallExpr("_waitEndCount"));
   block->insertAtTail(new CallExpr("_endCountFree", new CallExpr(PRIM_GET_END_COUNT)));
@@ -2158,7 +2158,7 @@ buildCobeginStmt(CallExpr* byref_vars, BlockStmt* block) {
     block->insertAtHead(new CallExpr("_upEndCount", cobeginCount));
   }
 
-  block->insertAtHead(new CallExpr(PRIM_MOVE, cobeginCount, new CallExpr("_endCountAlloc", gTrue)));
+  block->insertAtHead(new CallExpr(PRIM_MOVE, cobeginCount, new CallExpr("_endCountAlloc", /* forceLocalTypes= */gTrue)));
   block->insertAtHead(new DefExpr(cobeginCount));
   block->insertAtTail(new CallExpr(PRIM_PROCESS_TASK_LIST, cobeginCount));
   block->insertAtTail(new CallExpr("_waitEndCount", cobeginCount));

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1364,7 +1364,7 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
     //
     VarSymbol* coforallCount = newTemp("_coforallCount");
     BlockStmt* block = ForLoop::buildForLoop(indices, iterator, body, true, zippered);
-    block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc")));
+    block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc", gFalse)));
     block->insertAtHead(new DefExpr(coforallCount));
     body->insertAtHead(new CallExpr("_upEndCount", coforallCount, gFalse));
     block->insertAtTail(new CallExpr("_waitEndCount", coforallCount, gFalse));
@@ -1386,7 +1386,7 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
     beginBlk->insertAtHead(body);
     beginBlk->insertAtTail(new CallExpr("_downEndCount", coforallCount));
     BlockStmt* block = ForLoop::buildForLoop(indices, iterator, beginBlk, true, zippered);
-    block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc")));
+    block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc", gTrue)));
     block->insertAtHead(new DefExpr(coforallCount));
     block->insertAtTail(new CallExpr(PRIM_PROCESS_TASK_LIST, coforallCount));
     beginBlk->insertBefore(new CallExpr("_upEndCount", coforallCount));
@@ -2116,7 +2116,7 @@ buildSyncStmt(Expr* stmt) {
   VarSymbol* endCountSave = newTemp("_endCountSave");
   block->insertAtTail(new DefExpr(endCountSave));
   block->insertAtTail(new CallExpr(PRIM_MOVE, endCountSave, new CallExpr(PRIM_GET_END_COUNT)));
-  block->insertAtTail(new CallExpr(PRIM_SET_END_COUNT, new CallExpr("_endCountAlloc")));
+  block->insertAtTail(new CallExpr(PRIM_SET_END_COUNT, new CallExpr("_endCountAlloc", gFalse)));
   block->insertAtTail(stmt);
   block->insertAtTail(new CallExpr("_waitEndCount"));
   block->insertAtTail(new CallExpr("_endCountFree", new CallExpr(PRIM_GET_END_COUNT)));
@@ -2158,7 +2158,7 @@ buildCobeginStmt(CallExpr* byref_vars, BlockStmt* block) {
     block->insertAtHead(new CallExpr("_upEndCount", cobeginCount));
   }
 
-  block->insertAtHead(new CallExpr(PRIM_MOVE, cobeginCount, new CallExpr("_endCountAlloc")));
+  block->insertAtHead(new CallExpr(PRIM_MOVE, cobeginCount, new CallExpr("_endCountAlloc", gTrue)));
   block->insertAtHead(new DefExpr(cobeginCount));
   block->insertAtTail(new CallExpr(PRIM_PROCESS_TASK_LIST, cobeginCount));
   block->insertAtTail(new CallExpr("_waitEndCount", cobeginCount));

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -5531,14 +5531,7 @@ GenRet CallExpr::codegen() {
     AggregateType *bundledArgsType = toAggregateType(toSymExpr(get(1))->typeInfo());
     int endCountField = 0;
     for (int i = 1; i <= bundledArgsType->fields.length; i++) {
-      if (!strcmp(bundledArgsType->getField(i)->typeInfo()->symbol->name,
-                  "_ref(_EndCount)")
-          || !strcmp(bundledArgsType->getField(i)->typeInfo()->symbol->name,
-                     "__wide__ref__wide__EndCount")
-          || !strcmp(bundledArgsType->getField(i)->typeInfo()->symbol->name,
-                     "_EndCount")
-          || !strcmp(bundledArgsType->getField(i)->typeInfo()->symbol->name,
-                     "__wide__EndCount")) {
+      if (strstr(bundledArgsType->getField(i)->typeInfo()->symbol->name, "_EndCount") != NULL) {
         // Turns out there can be more than one such field. See e.g.
         //   spectests:Task_Parallelism_and_Synchronization/singleVar.chpl
         // INT_ASSERT(endCountField == 0);

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -281,21 +281,11 @@ static Type*
 returnInfoEndCount(CallExpr* call) {
   static Type* endCountType = NULL;
   if (endCountType == NULL) {
-    // Ugly hack. Basically we want to use network atomics when possible
-    // for begins and sync stmts. A nicer way to do this would be to use
-    // the return-type of "_endCountAlloc(false)".
-    const char* net = "_EndCount_r";
-    const char* proc = "_EndCount_a";
-    const char* prefix = NULL;
-    if (!strcmp(CHPL_NETWORK_ATOMICS, "none")) {
-      prefix = proc;
-    } else {
-      prefix = net;
-    }
-    forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-      bool startsWith = strncmp(prefix, ts->cname, strlen(prefix)) == 0;
-      if (startsWith) {
-        endCountType = ts->type;
+    // Look for the type var `_remoteEndCountType` in ChapelBase.
+    forv_Vec(VarSymbol, var, gVarSymbols) {
+      const char* searchStr = "_remoteEndCountType";
+      if (strcmp(var->cname, searchStr) == 0) {
+        endCountType = var->type;
         break;
       }
     }

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -281,15 +281,18 @@ static Type*
 returnInfoEndCount(CallExpr* call) {
   static Type* endCountType = NULL;
   if (endCountType == NULL) {
+    // Ugly hack. Basically we want to use network atomics when possible
+    // for begins and sync stmts. A nicer way to do this would be to use
+    // the return-type of "_endCountAlloc(false)".
+    const char* net = "_EndCount_r";
+    const char* proc = "_EndCount_a";
+    const char* prefix = NULL;
+    if (!strcmp(CHPL_NETWORK_ATOMICS, "none")) {
+      prefix = proc;
+    } else {
+      prefix = net;
+    }
     forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-      const char* net = "_EndCount_r";
-      const char* proc = "_EndCount_a";
-      const char* prefix = NULL;
-      if (!strcmp(CHPL_NETWORK_ATOMICS, "none")) {
-        prefix = proc;
-      } else {
-        prefix = net;
-      }
       bool startsWith = strncmp(prefix, ts->cname, strlen(prefix)) == 0;
       if (startsWith) {
         endCountType = ts->type;

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -282,7 +282,16 @@ returnInfoEndCount(CallExpr* call) {
   static Type* endCountType = NULL;
   if (endCountType == NULL) {
     forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-      if (!strcmp(ts->name, "_EndCount")) {
+      const char* net = "_EndCount_r";
+      const char* proc = "_EndCount_a";
+      const char* prefix = NULL;
+      if (!strcmp(CHPL_NETWORK_ATOMICS, "none")) {
+        prefix = proc;
+      } else {
+        prefix = net;
+      }
+      bool startsWith = strncmp(prefix, ts->cname, strlen(prefix)) == 0;
+      if (startsWith) {
         endCountType = ts->type;
         break;
       }

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -461,7 +461,7 @@ static void build_chpl_entry_points() {
   // support them).
   //
   if (fMinimalModules == false) {
-    chpl_gen_main->insertAtTail(new CallExpr(PRIM_MOVE, endCount, new CallExpr("_endCountAlloc")));
+    chpl_gen_main->insertAtTail(new CallExpr(PRIM_MOVE, endCount, new CallExpr("_endCountAlloc", gFalse)));
     chpl_gen_main->insertAtTail(new CallExpr(PRIM_SET_END_COUNT, endCount));
   }
 

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -461,7 +461,7 @@ static void build_chpl_entry_points() {
   // support them).
   //
   if (fMinimalModules == false) {
-    chpl_gen_main->insertAtTail(new CallExpr(PRIM_MOVE, endCount, new CallExpr("_endCountAlloc", gFalse)));
+    chpl_gen_main->insertAtTail(new CallExpr(PRIM_MOVE, endCount, new CallExpr("_endCountAlloc", /* forceLocalTypes= */gFalse)));
     chpl_gen_main->insertAtTail(new CallExpr(PRIM_SET_END_COUNT, endCount));
   }
 

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -248,20 +248,24 @@ module Atomics {
     chpl_rmem_consist_fence(order);
   }
 
+  proc chpl__processorAtomicType(type base_type) type {
+    if base_type==bool then return atomicflag;
+    else if base_type==uint(8) then return atomic_uint8;
+    else if base_type==uint(16) then return atomic_uint16;
+    else if base_type==uint(32) then return atomic_uint32;
+    else if base_type==uint(64) then return atomic_uint64;
+    else if base_type==int(8) then return atomic_int8;
+    else if base_type==int(16) then return atomic_int16;
+    else if base_type==int(32) then return atomic_int32;
+    else if base_type==int(64) then return atomic_int64;
+    else if base_type==real(64) then return atomic_real64;
+    else if base_type==real(32) then return atomic_real32;
+    else compilerError("Unsupported atomic type");
+  }
+
   proc chpl__atomicType(type base_type) type {
     if CHPL_NETWORK_ATOMICS == "none" {
-      if base_type==bool then return atomicflag;
-      else if base_type==uint(8) then return atomic_uint8;
-      else if base_type==uint(16) then return atomic_uint16;
-      else if base_type==uint(32) then return atomic_uint32;
-      else if base_type==uint(64) then return atomic_uint64;
-      else if base_type==int(8) then return atomic_int8;
-      else if base_type==int(16) then return atomic_int16;
-      else if base_type==int(32) then return atomic_int32;
-      else if base_type==int(64) then return atomic_int64;
-      else if base_type==real(64) then return atomic_real64;
-      else if base_type==real(32) then return atomic_real32;
-      else compilerError("Unsupported atomic type");
+      return chpl__processorAtomicType(base_type);
     } else {
       return chpl__networkAtomicType(base_type);
     }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -840,6 +840,11 @@ module ChapelBase {
   // statement needed, because the task should be running on the same
   // locale as the sync/cofall/cobegin was initiated on and thus the
   // same locale on which the object is allocated.
+  //
+  // TODO: 'taskCnt' can sometimes be local even if 'i' has to be remote.
+  // It is currently believed that only a remote-begin will want a network
+  // atomic 'taskCnt'. There should be a separate argument to control the type
+  // of 'taskCnt'.
   pragma "dont disable remote value forwarding"
   inline proc _endCountAlloc(param forceLocalTypes : bool) {
     type taskCntType = if !forceLocalTypes && useAtomicTaskCnt then atomic int
@@ -851,6 +856,8 @@ module ChapelBase {
     }
   }
 
+  // Compiler looks for this variable to determine the return type of
+  // the "get end count" primitive.
   type _remoteEndCountType = _endCountAlloc(false).type;
   
   // This function is called once by the initiating task.  As above, no

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -850,6 +850,8 @@ module ChapelBase {
       return new _EndCount(chpl__atomicType(int), taskCntType);
     }
   }
+
+  type _remoteEndCountType = _endCountAlloc(false).type;
   
   // This function is called once by the initiating task.  As above, no
   // on statement needed.
@@ -864,7 +866,7 @@ module ChapelBase {
   pragma "dont disable remote value forwarding"
   pragma "no remote memory fence"
   proc _upEndCount(e: _EndCount, param countRunningTasks=true) {
-    if isAtomicType(e.taskCnt.type) {
+    if isAtomic(e.taskCnt) {
       e.i.add(1, memory_order_release);
       e.taskCnt.add(1, memory_order_release);
     } else {
@@ -906,7 +908,7 @@ module ChapelBase {
     e.i.waitFor(0, memory_order_acquire);
 
     if countRunningTasks {
-      const taskDec = if isAtomicType(e.taskCnt.type) then e.taskCnt.read() else e.taskCnt;
+      const taskDec = if isAtomic(e.taskCnt) then e.taskCnt.read() else e.taskCnt;
       // taskDec-1 to adjust for the task that was waiting for others to finish
       here.runningTaskCntSub(taskDec-1);  // increment is in _upEndCount()
     } else {

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -72,7 +72,7 @@ module ChapelLocale {
     // now, we make the assumption that all requests for the number of
     // running tasks want the count from the locale the calling task is
     // running on, so the minimum possible value must be 1.
-    var runningTaskCounter : atomic int;
+    var runningTaskCounter : chpl__processorAtomicType(int);
 
     inline proc runningTaskCntSet(val : int) {
       runningTaskCounter.write(val, memory_order_relaxed);

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -72,6 +72,9 @@ module ChapelLocale {
     // now, we make the assumption that all requests for the number of
     // running tasks want the count from the locale the calling task is
     // running on, so the minimum possible value must be 1.
+    //
+    // This field should only be accessed locally, so we will have better
+    // performance if we always use a processor atomic.
     var runningTaskCounter : chpl__processorAtomicType(int);
 
     inline proc runningTaskCntSet(val : int) {


### PR DESCRIPTION
This patch allows the compiler to choose between network and processor atomics for the fields in the _EndCount class.

Remote non-blocking constructs (begin-on, coforall-on) will want network atomics over on-stmts for better performance. Blocking constructs (coforall, cobegin) can use processor atomics for better performance, because all updates are local. Sync-stmts and begins will also want network atomics as they might update an _EndCount on another locale.

The motivation for this change came from the stream-ep test, which can perform less than optimal with network atomics (if first-touch is good).

This patch adds the function "chpl__processorAtomicType" for convenience. This patch also changes a locale's running task counter to always be a processor atomic.

- [x] local paratest
- [x] XC release/examples testing
- [x] gasnet paratest