### PR TITLE
Rework noinit warning to point to use, not type's def

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4995,7 +4995,7 @@ preFold(Expr* expr) {
             }
           }
           if (!nowarn)
-            USR_WARN(type->symbol, "type %s does not currently support noinit, using default initialization", type->symbol->name);
+            USR_WARN(call, "type %s does not currently support noinit, using default initialization", type->symbol->name);
           result = new CallExpr(PRIM_INIT, call->get(1)->remove());
           call->replace(result);
           inits.add((CallExpr *)result);

--- a/test/expressions/lydia/noinit/arrayFullAssign.bad
+++ b/test/expressions/lydia/noinit/arrayFullAssign.bad
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1288: warning: type [domain(1,int(64),false)] int(64) does not currently support noinit, using default initialization
+arrayFullAssign.chpl:1: warning: type [domain(1,int(64),false)] int(64) does not currently support noinit, using default initialization
 1 2 3 4 5

--- a/test/expressions/lydia/noinit/arrayIndividualAssign.bad
+++ b/test/expressions/lydia/noinit/arrayIndividualAssign.bad
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1288: warning: type [domain(1,int(64),false)] int(64) does not currently support noinit, using default initialization
+arrayIndividualAssign.chpl:1: warning: type [domain(1,int(64),false)] int(64) does not currently support noinit, using default initialization
 1 2 3 4 5

--- a/test/expressions/lydia/noinit/usedWithDomain.bad
+++ b/test/expressions/lydia/noinit/usedWithDomain.bad
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:678: warning: type domain(1,int(64),false) does not currently support noinit, using default initialization
+usedWithDomain.chpl:1: warning: type domain(1,int(64),false) does not currently support noinit, using default initialization
 {1..5}


### PR DESCRIPTION
These futures failed because the line numbers in ChapelArray.chpl
changed, causing the declaration point of arrays and domains to
change.  Looking at the code, it seems to me that one would prefer
the warnings to point to the point where 'noinit' was used (since
that's where the user's code was wrong and since the type name is
printed out) rather than where the type was defined (which has no
bearing on where its noinit function may or may not have been
defined).  This also has the side benefit of making these futures
more maintainable as ChapelArray.chpl continues to evolve, as it
will.