### PR TITLE
Make syncs and singles marked as not POD

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1024,7 +1024,9 @@ static void build_constructor(AggregateType* ct) {
         CallExpr* init = new CallExpr("initialize", gMethodToken, fn->_this);
         fn->insertAtTail(init);
         // If a type has an initialize method, it's not Plain Old Data.
-        if (!isClass(ct)) {
+        // The only time classes aren't Plain Old Data is when they have the
+        // pragma "no object" associated with them.
+        if (!isClass(ct) || ct->symbol->hasFlag(FLAG_NO_OBJECT)) {
           ct->symbol->addFlag(FLAG_NOT_POD);
         }
         break;


### PR DESCRIPTION
Before my change to allow classes to be plain old data with an initialize
function, syncs and singles were appropriately still having "ignore noinit"
applied to them.  The work in #2432 caused them to no longer ignore noinit,
causing the bad files to mismatch in
expressions/lydia/noinit/usedWith[Single|Sync], because the problem
that was present for syncs and singles hasn't been fixed and we're still
dereferencing nil.  This current fix causes them to be not POD once again.