### PR TITLE
Use "is pod type" primitive when checking for bulk transfer support

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2257,14 +2257,17 @@ module ChapelArray {
   proc chpl__supportedDataTypeForBulkTransfer(x: []) param return false;
   proc chpl__supportedDataTypeForBulkTransfer(x: _distribution) param return true;
   proc chpl__supportedDataTypeForBulkTransfer(x: ?t) param where isComplexType(t) return true;
-  proc chpl__supportedDataTypeForBulkTransfer(x: ?t) param where isRecordType(t) return false;
-  proc chpl__supportedDataTypeForBulkTransfer(x: ?t) param where isUnionType(t) return false;
-  proc chpl__supportedDataTypeForBulkTransfer(x: ?t) param where isTupleType(t) {
-    for param i in 1..x.size {
-      if !chpl__supportedDataTypeForBulkTransfer(x[i]) then return false;
-    }
-    return true;
+  proc chpl__supportedDataTypeForBulkTransfer(x: ?t) param where isRecordType(t) || isTupleType(t) {
+    // TODO: In the future it seems like we could bulk transfer anything that
+    //       is POD, but some types that are POD (according to the primitive)
+    //       have explicit falses here. I'm not sure if the 'is pod type'
+    //       primitive is incorrect, or if we have other reasons for not
+    //       wanting to bulk transfer certain types
+    // We can bulk transfer any record or tuple that is 'Plain Old Data' ie. a
+    // bag of bits
+    return isPODType(t);
   }
+  proc chpl__supportedDataTypeForBulkTransfer(x: ?t) param where isUnionType(t) return false;
   proc chpl__supportedDataTypeForBulkTransfer(x: object) param return false;
   proc chpl__supportedDataTypeForBulkTransfer(x) param return true;
   

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2258,11 +2258,13 @@ module ChapelArray {
   proc chpl__supportedDataTypeForBulkTransfer(x: _distribution) param return true;
   proc chpl__supportedDataTypeForBulkTransfer(x: ?t) param where isComplexType(t) return true;
   proc chpl__supportedDataTypeForBulkTransfer(x: ?t) param where isRecordType(t) || isTupleType(t) {
-    // TODO: In the future it seems like we could bulk transfer anything that
-    //       is POD, but some types that are POD (according to the primitive)
-    //       have explicit falses here. I'm not sure if the 'is pod type'
-    //       primitive is incorrect, or if we have other reasons for not
-    //       wanting to bulk transfer certain types
+    // TODO: The current implementations of isPODType and
+    //       supportedDataTypeForBulkTransfer do not completely align. I'm
+    //       leaving it as future work to enable bulk transfer for other types
+    //       that are POD. In the long run it seems like we should be able to
+    //       have only one method for supportedDataType that just calls
+    //       isPODType.
+
     // We can bulk transfer any record or tuple that is 'Plain Old Data' ie. a
     // bag of bits
     return isPODType(t);

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -130,6 +130,12 @@ The argument must be a type.
 pragma "no instantiation limit"
 proc isStringType(type t) param return t == string;
 
+pragma "no instantiation limit"
+pragma "no doc" // Not sure how we want to document isPOD* right now
+proc isPODType(type t) param {
+  return __primitive("is pod type", t);
+}
+
 // Returns the unsigned equivalent of the input type.
 pragma "no doc"
 proc chpl__unsignedType(type t) type 
@@ -214,6 +220,8 @@ pragma "no doc"
 proc isAtomicValue(e)    param  return isAtomicType(e.type);
 pragma "no doc"
 proc isRefIterValue(e)   param  return isRefIterType(e.type);
+pragma "no doc"
+proc isPODValue(e)       param  return isPODType(e.type);
 
 
 //
@@ -272,6 +280,8 @@ pragma "no doc"
 proc isAtomic(type t)    param  return isAtomicType(t);
 pragma "no doc"
 proc isRefIter(type t)   param  return isRefIterType(t);
+pragma "no doc"
+proc isPOD(type t)       param  return isPODType(t);
 
 // Set 2 - values.
 /*
@@ -326,6 +336,8 @@ a corresponding type or a value of such a type.
 */
 proc isRefIter(e)   param  return isRefIterValue(e);
 
+pragma "no doc" // Not sure how we want to document isPOD* right now
+proc isPOD(e)       param  return isPODValue(e);
 
 // for internal use until we have a better name
 pragma "no doc"

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -130,8 +130,30 @@ The argument must be a type.
 pragma "no instantiation limit"
 proc isStringType(type t) param return t == string;
 
+/*
+POD stands for Plain Old Data and roughly corresponds to the meaning of Plain
+Old Data in C++.
+
+A record, tuple, or union type in Chapel is a POD type if:
+
+  * it does not set pragma "ignore noinit"
+  * it has only a compiler generated autoCopy
+  * it has only a compiler generated autoDestroy
+  * it has only a compiler generated default initialization/construction
+    routine
+  * it has only a compiler generated = routine (when the left hand side
+    and right hand side have the same type. Assignment overloads covering cases
+    where left hand side and right hand side are different types are allowed
+    for POD types)
+  * it contains only POD type fields
+
+Class types in Chapel are always considered POD types (because an instance of
+the class is actually a pointer to the class object, and this pointer is POD).
+
+Primitive numeric Chapel types are POD types as well.
+ */
 pragma "no instantiation limit"
-pragma "no doc" // Not sure how we want to document isPOD* right now
+pragma "no doc" // I don't think we want to make this public yet
 proc isPODType(type t) param {
   return __primitive("is pod type", t);
 }


### PR DESCRIPTION
Adds new functions to Types.chpl that query the "is pod type" primitive.
These are "no doc"ed for now, but could be exposed if we want to. We
should probably define what a POD type is in the spec before making
these functions public.

isPODType is now used to check if a given record or tuple type can
support bulk transfer.