### PR TITLE
Update more noinit tests

### DIFF
--- a/test/compflags/lydia/noUseNoinit/noinitSkippedCase.base.good
+++ b/test/compflags/lydia/noUseNoinit/noinitSkippedCase.base.good
@@ -1,3 +1,3 @@
-noinitSkippedCase.chpl:10: warning: type R does not currently support noinit, using default initialization
+noinitSkippedCase.chpl:20: warning: type R does not currently support noinit, using default initialization
 default init!
 default init!

--- a/test/expressions/lydia/noinit/usedWithSingle.bad
+++ b/test/expressions/lydia/noinit/usedWithSingle.bad
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:187: warning: type _singlevar(int(64)) does not currently support noinit, using default initialization
-$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:187: warning: type _singlevar(bool) does not currently support noinit, using default initialization
+usedWithSingle.chpl:1: warning: type _singlevar(int(64)) does not currently support noinit, using default initialization
+usedWithSingle.chpl:2: warning: type _singlevar(bool) does not currently support noinit, using default initialization
 Task 1 finishing
 Task 2 done!
 4

--- a/test/expressions/lydia/noinit/usedWithSync.bad
+++ b/test/expressions/lydia/noinit/usedWithSync.bad
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:36: warning: type _syncvar(int(64)) does not currently support noinit, using default initialization
-$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:36: warning: type _syncvar(bool) does not currently support noinit, using default initialization
+usedWithSync.chpl:1: warning: type _syncvar(int(64)) does not currently support noinit, using default initialization
+usedWithSync.chpl:2: warning: type _syncvar(bool) does not currently support noinit, using default initialization
 4
 true


### PR DESCRIPTION
[trivial, not reviewed]

Follow-up to PR #2455 (i.e., "This is why you shouldn't fix
regressions before you've fully woken up in the morning."  :)

PR #2455 improved the location of noinit error messages this morning
to improve some failing futures, but in writing it, I failed to do a
full test or grep to see whether other, possibly passing, tests would
be affected/improved by the change.  Turns out that there are --
whoops.

This commit updates the location of the warning in these tests to
similarly point to the noinit.  As in the previous cases, I think this
is an improvement for the user.