### PR TITLE
Fake lineno and filename for calls to c_string_from_wide_string

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4245,7 +4245,7 @@ GenRet CallExpr::codegen() {
             if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
               // The source is a wide string.
               codegenCall("c_string_from_wide_string",
-                          dst, src, call->get(2), call->get(3));
+                          dst, src, info->lineno, info->filename);
             } else {
               codegenCall("c_string_from_string",
                           dst, src, call->get(2), call->get(3));


### PR DESCRIPTION
For some reason that's been really hard to track down, the filename passed to
c_string_from_wide_string is garbage when CHPL_DEVELOPER isn't set. Phil ran
into this with some visual debug stuff where he's trying to print the filename
to a log. He was grabbing the filename in a chpl_comm_get call, which was
called from chpl_comm_wide_get_string, which was being called from
c_string_from_wide_string where the filename being passed in wasn't valid.

I'm timing out trying to figure out the root cause. Instead of generating the
real lineno and filename passed to the primitive, I'm just using the global
info lineo and filename. This avoids the segfault Phil was running into.

These string primitives and runtime calls are removed in string-as-rec so I'm
not too worried about not understanding the root cause, although it is
disappointing not to have figured it what was going on.