### PR TITLE
Change released nbody to use 'ref' variables

### DIFF
--- a/test/release/examples/benchmarks/shootout/nbody.chpl
+++ b/test/release/examples/benchmarks/shootout/nbody.chpl
@@ -109,8 +109,8 @@ proc advance(dt) {
       const dpos = b1.pos - b2.pos,
             mag = dt / sqrt(sumOfSquares(dpos))**3;
         
-        b1.v -= dpos * b2.mass * mag;
-        b2.v += dpos * b1.mass * mag;
+      b1.v -= dpos * b2.mass * mag;
+      b2.v += dpos * b1.mass * mag;
     }
   }
   

--- a/test/release/examples/benchmarks/shootout/nbody.chpl
+++ b/test/release/examples/benchmarks/shootout/nbody.chpl
@@ -103,15 +103,14 @@ proc initSun() {
 proc advance(dt) {
   for i in 1..numbodies {
     for j in i+1..numbodies {
-      updateVelocities(bodies[i], bodies[j]);
-      
-      inline proc updateVelocities(ref b1, ref b2) {
-        const dpos = b1.pos - b2.pos,
-               mag = dt / sqrt(sumOfSquares(dpos))**3;
+      ref b1 = bodies[i],
+          b2 = bodies[j];
+
+      const dpos = b1.pos - b2.pos,
+            mag = dt / sqrt(sumOfSquares(dpos))**3;
         
         b1.v -= dpos * b2.mass * mag;
         b2.v += dpos * b1.mass * mag;
-      }
     }
   }
   


### PR DESCRIPTION
[trivial, not reviewed]

Previously we were using a nested procedure with 'ref' intents to work around
the lack of 'ref' variables at the time this version was written.

It'll be interesting to see whether this hurts the performance of this version.
Currently, there's a gap on the shootout machine between the "ref var version"
(nbody-blc-ref.chpl) and the release version, though there are other differences
than this one.