### PR TITLE
Fix problems with Spawn with GASNet segment=fast

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -40,8 +40,8 @@ module Spawn {
   // the C allocator instead of the Chapel one.
 
   private extern proc qio_spawn_strdup(str: c_string): c_string;
-  private extern proc qio_spawn_allocate_args(count: size_t): c_ptr(c_string);
-  private extern proc qio_spawn_free_args(args: c_ptr(c_string));
+  private extern proc qio_spawn_allocate_ptrvec(count: size_t): c_ptr(c_string);
+  private extern proc qio_spawn_free_ptrvec(args: c_ptr(c_string));
   private extern proc qio_spawn_free_str(str: c_string);
 
 
@@ -153,14 +153,14 @@ module Spawn {
     // that are NULL terminated and consist of C strings.
 
     var nargs = args.size + 1;
-    var use_args = qio_spawn_allocate_args( nargs.safeCast(size_t) );
+    var use_args = qio_spawn_allocate_ptrvec( nargs.safeCast(size_t) );
     for (a,i) in zip(args, 0..) {
       use_args[i] = qio_spawn_strdup(a.c_str());
     }
     var use_env:c_ptr(c_string) = nil;
     if env.size != 0 {
       var nenv = env.size + 1;
-      use_env = qio_spawn_allocate_args( nenv.safeCast(size_t) );
+      use_env = qio_spawn_allocate_ptrvec( nenv.safeCast(size_t) );
       for (a,i) in zip(env, 0..) {
         use_env[i] = qio_spawn_strdup(a.c_str());
       }
@@ -178,8 +178,8 @@ module Spawn {
     for i in 0..#env.size {
       qio_spawn_free_str(use_env[i]);
     }
-    qio_spawn_free_args(use_args);
-    qio_spawn_free_args(use_env);
+    qio_spawn_free_ptrvec(use_args);
+    qio_spawn_free_ptrvec(use_env);
 
     var ret = new subprocess(kind=kind, locking=locking,
                              home=here,

--- a/runtime/include/qio/qio_popen.h
+++ b/runtime/include/qio/qio_popen.h
@@ -36,8 +36,8 @@ extern "C" {
 // Helper functions to allocate/free memory available
 // to a forked child process
 const char* qio_spawn_strdup(const char* str);
-const char** qio_spawn_allocate_args(size_t count);
-void qio_spawn_free_args(const char** args);
+const char** qio_spawn_allocate_ptrvec(size_t count);
+void qio_spawn_free_ptrvec(const char** args);
 void qio_spawn_free_str(const char* str);
 
 

--- a/runtime/include/qio/qio_popen.h
+++ b/runtime/include/qio/qio_popen.h
@@ -33,6 +33,13 @@ extern "C" {
 #define QIO_FD_PIPE (-3)
 #define QIO_FD_TO_STDOUT (-4)
 
+// Helper functions to allocate/free memory available
+// to a forked child process
+const char* qio_spawn_strdup(const char* str);
+const char** qio_spawn_allocate_args(size_t count);
+void qio_spawn_free_args(const char** args);
+void qio_spawn_free_str(const char* str);
+
 
 qioerr qio_openproc(const char** argv,
                     const char** envp,

--- a/runtime/src/qio/qio_popen.c
+++ b/runtime/src/qio/qio_popen.c
@@ -45,6 +45,10 @@ extern char** environ;
    a forked process, and we need args for exec
    (command, arguments, environment) to be available
    after a fork.
+
+   Using these routines resolves problems with
+    * Gasnet/aries with segment=fast
+    * Gasnet/udp with segment=fast
  */
 
 const char* qio_spawn_strdup(const char* str)
@@ -56,13 +60,13 @@ const char* qio_spawn_strdup(const char* str)
   return ret;
 }
 
-const char** qio_spawn_allocate_args(size_t count)
+const char** qio_spawn_allocate_ptrvec(size_t count)
 {
   char** ret = calloc(count, sizeof(char*));
   return (const char**) ret;
 }
 
-void qio_spawn_free_args(const char** args)
+void qio_spawn_free_ptrvec(const char** args)
 {
   free((void*) args);
 }


### PR DESCRIPTION
With GASNet and segment=fast, the Chapel heap is not
necessarily available to a forked process. As a result,
if the command, arguments, and environment for the spawned
process are allocated on the Chapel heap, the spawn
will fail.

In this patch, I added some simple support functions in
qio_popen.h/qio_popen.c that use the C allocator. I modified
the Spawn.chpl module to use these support functions.

While there, I switched from using c_string_copy to c_string
since c_string_copy is not strictly necessary and it
is removed on the string-as-rec branch.

Reviewed by @gbtitus.

Future work: qio_popen doesn't necessarily belong in qio.