### PR TITLE
Revert "changes to get GASNet and dlmalloc building with CCE with -hgnu"

### DIFF
--- a/third-party/dlmalloc/src/dlmalloc.c
+++ b/third-party/dlmalloc/src/dlmalloc.c
@@ -1812,7 +1812,7 @@ static FORCEINLINE int win32munmap(void* ptr, size_t size) {
 /* First, define CAS_LOCK and CLEAR_LOCK on ints */
 /* Note CAS_LOCK defined to return 0 on success */
 
-#if defined(__GNUC__)&& (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)) && !defined(_CRAYC)
+#if defined(__GNUC__)&& (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1))
 #define CAS_LOCK(sl)     __sync_lock_test_and_set(sl, 1)
 #define CLEAR_LOCK(sl)   __sync_lock_release(sl)
 

--- a/third-party/gasnet/GASNet-1.24.0/extended-ref/gasnet_vis_strided.c
+++ b/third-party/gasnet/GASNet-1.24.0/extended-ref/gasnet_vis_strided.c
@@ -140,13 +140,8 @@ static int32_t _gasnete_strided_helper_nodst = (int32_t)sizeof(_gasnete_strided_
        int const _gasnete_strided_update_addr_init = (update_addr_init);                               \
        static int8_t _gasnete_strided_helper_havepartial = (int8_t)sizeof(_gasnete_strided_helper_havepartial)
 
-#ifdef _CRAYC
-static int32_t * _gasnete_strided_init = NULL;
-#else
-static int32_t * const _gasnete_strided_init =
+static int32_t * const _gasnete_strided_init = 
    (sizeof(_gasnete_strided_init)?NULL:(void*)&_gasnete_strided_init); /* NULL:NULL triggers gcc -O1 bug on sysx */
-#endif
-
 static int32_t _gasnete_strided_chunkcnt = (int32_t)sizeof(_gasnete_strided_chunkcnt);
 static int32_t const _gasnete_strided_addr_already_offset = (int32_t)sizeof(_gasnete_strided_addr_already_offset);
 static int32_t const _gasnete_strided_update_addr_init = (int32_t)sizeof(_gasnete_strided_update_addr_init);


### PR DESCRIPTION
This reverts commit 3a1bbf95915115d6d90262c5cea60d6bfb95ffee.

We no longer need these mods. CCE 8.4 now supports all the __sync* routines and
they fixed bug gasnet was hitting.