### PR TITLE
Update chplenv compiler version comparisons

### DIFF
--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -5,7 +5,7 @@ from sys import stdout, stderr
 from string import punctuation
 
 import utils, chpl_platform, chpl_comm, chpl_compiler
-from utils import memoize
+from utils import memoize, CompVersion
 
 class argument_map(object):
     # intel does not support amd archs... it may be worth testing setting the
@@ -109,15 +109,12 @@ class argument_map(object):
             return arch
 
         if compiler == 'gnu':
-            if version.major > 4:
+            if version >= CompVersion('4.9'):
                 return cls.gcc49.get(arch, '')
-            elif version.major == 4:
-                if version.minor >= 9:
-                    return cls.gcc49.get(arch, '')
-                elif version.minor >= 7:
-                    return cls.gcc47.get(arch, '')
-                elif version.minor >= 3:
-                    return cls.gcc43.get(arch, '')
+            elif version >= CompVersion('4.7'):
+                return cls.gcc47.get(arch, '')
+            elif version >= CompVersion('4.3'):
+                return cls.gcc43.get(arch, '')
             return 'none'
         elif compiler == 'intel':
             return cls.intel.get(arch, '')

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -2,7 +2,7 @@
 import sys, os, optparse
 
 import chpl_platform, chpl_comm, chpl_compiler, utils
-from utils import memoize
+from utils import memoize, CompVersion
 
 @memoize
 def get(flag='target'):
@@ -27,13 +27,10 @@ def get(flag='target'):
             # with an older gcc, we fall back to locks
             if compiler_val == 'gnu' or compiler_val == 'cray-prgenv-gnu':
                 version = utils.get_compiler_version('gnu')
-                if version.major > 4:
+                if version >= CompVersion('4.8'):
                     atomics_val = 'intrinsics'
-                if version.major == 4:
-                    if version.minor >= 8:
-                        atomics_val = 'intrinsics'
-                    elif version.minor >= 1 and not platform_val.endswith('32'):
-                        atomics_val = 'intrinsics'
+                elif version >= CompVersion('4.1') and not platform_val.endswith('32'):
+                    atomics_val = 'intrinsics'
             elif compiler_val == 'intel' or compiler_val == 'cray-prgenv-intel':
                 atomics_val = 'intrinsics'
             elif compiler_val == 'cray-prgenv-cray':

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -31,16 +31,27 @@ def using_chapel_module():
 
 @memoize
 def get_compiler_version(compiler):
-    CompVersion = namedtuple('CompVersion', ['major', 'minor'])
+    version_string = '0'
     if 'gnu' in compiler:
-        output = run_command(['gcc', '-dumpversion'])
-        match = re.search(r'(\d+)\.(\d+)', output)
-        if match:
-            return CompVersion(major=int(match.group(1)), minor=int(match.group(2)))
-        else:
-            raise ValueError("Could not find the GCC version")
+        version_string = run_command(['gcc', '-dumpversion'])
+    return CompVersion(version_string)
+
+# Takes a version string of the form 'major', 'major.minor',
+# 'major.minor.revision', or 'major.minor,revision.build' and returns the named
+# tuple (major, minor, revision, build). If minor, revision, or build are not
+# specified, 0 will be used for their value(s)
+@memoize
+def CompVersion(version_string):
+    CompVersionT = namedtuple('CompVersion', ['major', 'minor', 'revision', 'build'])
+    match = re.search(r'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', version_string)
+    if match:
+        major    = int(match.group(1))
+        minor    = int(match.group(3) or 0)
+        revision = int(match.group(5) or 0)
+        build    = int(match.group(7) or 0)
+        return CompVersionT(major=major, minor=minor, revision=revision, build=build)
     else:
-        return CompVersion(major=0, minor=0)
+        raise ValueError("Could not convert version to tuple")
 
 class CommandError(Exception):
     pass


### PR DESCRIPTION
A while back we changed get_compiler_version to return a named tuple instead of
a float because floating point comparison didn't work correctly for things like
comparing 4.1 to 4.10. This updates get_compiler_version to include the
revision and build in the tuple returned just in case we need it in the future.
It also moves the regex logic that was in get_compiler_version() into
CompVersion() so clients can use it to compare against values returned by
get_compiler_version()

This converts comparisons against major and then minor number to just compare
against a compiler version tuple.

Things like:

  'if version.major > 4 or (version.major == 4 and version.minor >= 1):'

are now just:

  "if version >= CompVersion('4.1'):"

which I think is much easier to read. You could also just do:

  "if version >= (4, 1, 0):"

but I don't think this is as easy to read

I need to make some changes to the chplenv scripts that will need the cce
version number. I've had this change in a branch for a while and figured this
is a good time to pull it into master since it'll make the cce version number
comparison easier.