### PR TITLE
Rename CHPL_NIGHTLY_PERF_CONFIG_NAME to CHPL_TEST_PERF_CONFIG_NAME

### DIFF
--- a/util/cron/common-perf.bash
+++ b/util/cron/common-perf.bash
@@ -9,10 +9,10 @@ source $(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)/common-fast.bash
 # It is tempting to use hostname --short, but macs only support the short form
 # of the argument.
 
-if [ -z "${CHPL_NIGHTLY_PERF_CONFIG_NAME}" ] ; then
-  export CHPL_NIGHTLY_PERF_CONFIG_NAME="$(hostname -s)"
+if [ -z "${CHPL_TEST_PERF_CONFIG_NAME}" ] ; then
+  export CHPL_TEST_PERF_CONFIG_NAME="$(hostname -s)"
 fi
-export CHPL_NIGHTLY_LOGDIR="$logdir_prefix/NightlyPerformance/$CHPL_NIGHTLY_PERF_CONFIG_NAME"
+export CHPL_NIGHTLY_LOGDIR="$logdir_prefix/NightlyPerformance/$CHPL_TEST_PERF_CONFIG_NAME"
 export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 
 export CHPL_TEST_PERF_DIR="$CHPL_NIGHTLY_LOGDIR"

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -273,7 +273,7 @@ chomp($num_procs);
 
 $cronlogdir = $ENV{'CHPL_NIGHTLY_CRON_LOGDIR'};
 
-$perfConfigName = $ENV{'CHPL_NIGHTLY_PERF_CONFIG_NAME'};
+$perfConfigName = $ENV{'CHPL_TEST_PERF_CONFIG_NAME'};
 if ($perfConfigName eq "") {
   $perfConfigName = hostname;
 }

--- a/util/cron/test-perf.chapcs.bash
+++ b/util/cron/test-perf.chapcs.bash
@@ -4,7 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-export CHPL_NIGHTLY_PERF_CONFIG_NAME='chapcs'
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 
 source $CWD/common-perf.bash
 

--- a/util/start_test
+++ b/util/start_test
@@ -803,7 +803,7 @@ def set_up_performance_testing_B():
         # set global variables for later access and use
         global perf_dir, perf_html_dir, perf_test_name
 
-        perf_test_name = os.environ.get('CHPL_NIGHTLY_PERF_CONFIG_NAME',
+        perf_test_name = os.environ.get('CHPL_TEST_PERF_CONFIG_NAME',
                                         platform.node().split(".")[0].lower())
 
         if not os.environ.get("CHPL_TEST_PERF_DIR"):
@@ -832,7 +832,7 @@ def set_up_performance_testing_B():
         global compperf_test_name, comp_perf_dir, temp_dat_dir, comp_perf_html_dir
         global combine_comp_perf
 
-        compperf_test_name = os.environ.get('CHPL_NIGHTLY_PERF_CONFIG_NAME',
+        compperf_test_name = os.environ.get('CHPL_TEST_PERF_CONFIG_NAME',
                                             platform.node().split(".")[0].lower())
 
         if "CHPL_TEST_COMP_PERF_DIR" in os.environ:

--- a/util/test/combineCompPerfData
+++ b/util/test/combineCompPerfData
@@ -27,7 +27,7 @@ def main():
     (options, args) = parser.parse_args()
 
     chpl_home = os.environ.get('CHPL_HOME', '')
-    configName = os.environ.get('CHPL_NIGHTLY_PERF_CONFIG_NAME',
+    configName = os.environ.get('CHPL_TEST_PERF_CONFIG_NAME',
                                 os.uname()[1].split('.', 1)[0])
     compPerfDir = os.path.join(chpl_home, 'test/compperfdat/', configName)
 


### PR DESCRIPTION
A change that got lost in my previous PR for this feature.