### PR TITLE
Default to qthreads over muxed

### DIFF
--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -14,14 +14,7 @@ def get():
         compiler_val = chpl_compiler.get('target')
         comm_val = chpl_comm.get()
 
-        # use muxed on cray-x* machines using the module and supported compiler
-        if (comm_val == 'ugni' and
-                platform_val.startswith('cray-x') and
-                utils.using_chapel_module() and
-                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel') and
-                arch_val != 'knc'):
-            tasks_val = 'muxed'
-        elif (arch_val == 'knc' or
+        if (arch_val == 'knc' or
                 platform_val.startswith('cygwin') or
                 platform_val.startswith('netbsd') or
                 compiler_val == 'cray-prgenv-cray'):


### PR DESCRIPTION
ugni+qthreads performance has steadily been improving and for most cases is
better than or the same as ugni+muxed. The perf team and Greg have agreed that
it's time to use qthreads over muxed, especially since we'd like to retire
muxed.

Muxed is still being built into the module and tested, it just won't be the
default.