### PR TITLE
Wrap push_back calls in test/types/records/ferguson/tracking with a lock

### DIFF
--- a/test/types/records/ferguson/tracking/Tracking.chpl
+++ b/test/types/records/ferguson/tracking/Tracking.chpl
@@ -1,13 +1,18 @@
 var ops:[1..0] (int,object,int, int, int);
+var opsLock$: sync bool = true;
 
 var counter: atomic int;
 
 proc trackAllocation(c: object, id:int, x:int) {
+  opsLock$.readFE();
   ops.push_back( (1, c, id, x, 1+counter.fetchAdd(1)) );
+  opsLock$.writeEF(true);
 }
 
 proc trackFree(c: object, id:int, x:int) {
+  opsLock$.readFE();
   ops.push_back( (-1, c, id, x, 1+counter.fetchAdd(1)) );
+  opsLock$.writeEF(true);
 }
 
 proc checkAllocations() {


### PR DESCRIPTION
push_back is not thread-safe and is used in a parallel context in this directory. This patch wraps the calls with a lock to prevent memory corruption.