### PR TITLE
Don't include netinet/tcp.h on cygwin

### DIFF
--- a/runtime/include/qio/sys.h
+++ b/runtime/include/qio/sys.h
@@ -32,7 +32,9 @@ extern "C" {
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#ifndef __CYGWIN__
 #include <netinet/tcp.h>
+#endif
 #include <netdb.h>
 #include <unistd.h>
 #include <stdio.h>


### PR DESCRIPTION
We can't build on the most recent version of cygwin because of undefined
references to u_short and a few others types that are used in netinet/tcp.h.
I'm having a hard time tracking down the root cause for this. I can build a
standalone c program that includes netinet/tcp.h and uses the same compilation
options as our runtime, but I can't track down exactly what about our build
causes this issue.

The include was originally added with 621a6d8f75cbd051361d3afa6379221f93ef9c66
in order to make some constants available. I don't think we lose much by not
having this on cygwin. There's also some precedence for this in a few other
open source projects such as open62541.