### PR TITLE
Remove extraneous warning for scope resolution of private symbols

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1902,7 +1902,6 @@ static bool lookupThisScopeAndUses(BaseAST* scope, const char * name,
         // symbols
         if (!sym->isVisible(callingContext)) {
           rejectedPrivateIds.insert(sym->id);
-          USR_WARN(callingContext, "A visible '%s' is an inaccessible private symbol, defined at:\n %s", name, sym->stringLoc());
         } else {
           symbols.push_back(sym);
         }
@@ -1962,7 +1961,6 @@ static bool lookupThisScopeAndUses(BaseAST* scope, const char * name,
                   // private symbols
                   if (!sym->isVisible(callingContext)) {
                     rejectedPrivateIds.insert(sym->id);
-                    USR_WARN(callingContext, "A visible '%s' is an inaccessible private symbol, defined at:\n %s", name, sym->stringLoc());
                   } else {
                     if (!isRepeat(symbols, sym)) {
                       symbols.push_back(sym);

--- a/test/modules/figueroa/PrivateSymbols/PrivateSymbols.future
+++ b/test/modules/figueroa/PrivateSymbols/PrivateSymbols.future
@@ -1,9 +1,0 @@
-feature request: private variables in modules
-
-RandomNumber.chpl defines arraySize and seed as configuration variables,
-but they are intended only for use within the main program defined in
-this source file.  Trying to make use of this module in some other program
-should not cause these configuration variables to be visible in other
-modules, but there is currently no way to avoid this.  This test case
-proposes the use of a keyword called private, but it is merely a placeholder
-for this feature.

--- a/test/visibility/private/config/constants/useMultiple1.good
+++ b/test/visibility/private/config/constants/useMultiple1.good
@@ -1,3 +1,1 @@
-useMultiple1.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple1.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/config/constants/useMultiple2.good
+++ b/test/visibility/private/config/constants/useMultiple2.good
@@ -1,3 +1,1 @@
-useMultiple2.chpl:3: warning: A visible 'bar' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple2.chpl:3: error: 'bar' undeclared (first use this function)

--- a/test/visibility/private/config/constants/useMultiple3.good
+++ b/test/visibility/private/config/constants/useMultiple3.good
@@ -1,3 +1,1 @@
-useMultiple3.chpl:3: warning: A visible 'baz' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:2
 useMultiple3.chpl:3: error: 'baz' undeclared (first use this function)

--- a/test/visibility/private/config/constants/useOtherSibling.good
+++ b/test/visibility/private/config/constants/useOtherSibling.good
@@ -1,4 +1,2 @@
 useOtherSibling.chpl:9: In function 'main':
-useOtherSibling.chpl:10: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- useOtherSibling.chpl:2
 useOtherSibling.chpl:10: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/config/constants/usesOther.good
+++ b/test/visibility/private/config/constants/usesOther.good
@@ -1,3 +1,1 @@
-usesOther.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./definesPrivate.chpl:1
 usesOther.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/config/params/useMultiple1.good
+++ b/test/visibility/private/config/params/useMultiple1.good
@@ -1,3 +1,1 @@
-useMultiple1.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple1.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/config/params/useMultiple2.good
+++ b/test/visibility/private/config/params/useMultiple2.good
@@ -1,3 +1,1 @@
-useMultiple2.chpl:3: warning: A visible 'bar' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple2.chpl:3: error: 'bar' undeclared (first use this function)

--- a/test/visibility/private/config/params/useMultiple3.good
+++ b/test/visibility/private/config/params/useMultiple3.good
@@ -1,3 +1,1 @@
-useMultiple3.chpl:3: warning: A visible 'baz' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:2
 useMultiple3.chpl:3: error: 'baz' undeclared (first use this function)

--- a/test/visibility/private/config/params/useOtherSibling.good
+++ b/test/visibility/private/config/params/useOtherSibling.good
@@ -1,4 +1,2 @@
 useOtherSibling.chpl:9: In function 'main':
-useOtherSibling.chpl:10: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- useOtherSibling.chpl:2
 useOtherSibling.chpl:10: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/config/params/usesOther.good
+++ b/test/visibility/private/config/params/usesOther.good
@@ -1,3 +1,1 @@
-usesOther.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./definesPrivate.chpl:1
 usesOther.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/config/variables/useMultiple1.good
+++ b/test/visibility/private/config/variables/useMultiple1.good
@@ -1,3 +1,1 @@
-useMultiple1.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple1.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/config/variables/useMultiple2.good
+++ b/test/visibility/private/config/variables/useMultiple2.good
@@ -1,3 +1,1 @@
-useMultiple2.chpl:3: warning: A visible 'bar' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple2.chpl:3: error: 'bar' undeclared (first use this function)

--- a/test/visibility/private/config/variables/useMultiple3.good
+++ b/test/visibility/private/config/variables/useMultiple3.good
@@ -1,3 +1,1 @@
-useMultiple3.chpl:3: warning: A visible 'baz' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:2
 useMultiple3.chpl:3: error: 'baz' undeclared (first use this function)

--- a/test/visibility/private/config/variables/useOtherSibling.good
+++ b/test/visibility/private/config/variables/useOtherSibling.good
@@ -1,4 +1,2 @@
 useOtherSibling.chpl:9: In function 'main':
-useOtherSibling.chpl:10: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- useOtherSibling.chpl:2
 useOtherSibling.chpl:10: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/config/variables/usesOther.good
+++ b/test/visibility/private/config/variables/usesOther.good
@@ -1,3 +1,1 @@
-usesOther.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./definesPrivate.chpl:1
 usesOther.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/constants/useMultiple1.good
+++ b/test/visibility/private/constants/useMultiple1.good
@@ -1,3 +1,1 @@
-useMultiple1.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple1.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/constants/useMultiple2.good
+++ b/test/visibility/private/constants/useMultiple2.good
@@ -1,3 +1,1 @@
-useMultiple2.chpl:3: warning: A visible 'bar' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple2.chpl:3: error: 'bar' undeclared (first use this function)

--- a/test/visibility/private/constants/useMultiple3.good
+++ b/test/visibility/private/constants/useMultiple3.good
@@ -1,3 +1,1 @@
-useMultiple3.chpl:3: warning: A visible 'baz' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:2
 useMultiple3.chpl:3: error: 'baz' undeclared (first use this function)

--- a/test/visibility/private/constants/useOtherSibling.good
+++ b/test/visibility/private/constants/useOtherSibling.good
@@ -1,4 +1,2 @@
 useOtherSibling.chpl:9: In function 'main':
-useOtherSibling.chpl:10: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- useOtherSibling.chpl:2
 useOtherSibling.chpl:10: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/constants/usesOther.good
+++ b/test/visibility/private/constants/usesOther.good
@@ -1,3 +1,1 @@
-usesOther.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./definesPrivate.chpl:1
 usesOther.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/functions/useOtherSibling.good
+++ b/test/visibility/private/functions/useOtherSibling.good
@@ -1,4 +1,2 @@
 useOtherSibling.chpl:12: In function 'main':
-useOtherSibling.chpl:13: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- useOtherSibling.chpl:2
 useOtherSibling.chpl:13: error: unresolved call 'foo(6)'

--- a/test/visibility/private/functions/usesOther.good
+++ b/test/visibility/private/functions/usesOther.good
@@ -1,3 +1,1 @@
-usesOther.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./definesPrivate.chpl:1
 usesOther.chpl:3: error: unresolved call 'foo(2)'

--- a/test/visibility/private/iters/useOtherSibling.good
+++ b/test/visibility/private/iters/useOtherSibling.good
@@ -1,4 +1,2 @@
 useOtherSibling.chpl:13: In function 'main':
-useOtherSibling.chpl:14: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- useOtherSibling.chpl:2
 useOtherSibling.chpl:14: error: unresolved call 'foo(6)'

--- a/test/visibility/private/iters/usesOther.good
+++ b/test/visibility/private/iters/usesOther.good
@@ -1,3 +1,1 @@
-usesOther.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./definesPrivate.chpl:1
 usesOther.chpl:3: error: unresolved call 'foo(2)'

--- a/test/visibility/private/moduleSymbols/accessPrivateUsedNephew2.good
+++ b/test/visibility/private/moduleSymbols/accessPrivateUsedNephew2.good
@@ -1,4 +1,2 @@
 accessPrivateUsedNephew2.chpl:17: In function 'main':
-accessPrivateUsedNephew2.chpl:18: warning: A visible 'child' is an inaccessible private symbol, defined at:
- accessPrivateUsedNephew2.chpl:4
 accessPrivateUsedNephew2.chpl:18: error: 'child' undeclared (first use this function)

--- a/test/visibility/private/params/useMultiple1.good
+++ b/test/visibility/private/params/useMultiple1.good
@@ -1,3 +1,1 @@
-useMultiple1.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple1.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/params/useMultiple2.good
+++ b/test/visibility/private/params/useMultiple2.good
@@ -1,3 +1,1 @@
-useMultiple2.chpl:3: warning: A visible 'bar' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple2.chpl:3: error: 'bar' undeclared (first use this function)

--- a/test/visibility/private/params/useMultiple3.good
+++ b/test/visibility/private/params/useMultiple3.good
@@ -1,3 +1,1 @@
-useMultiple3.chpl:3: warning: A visible 'baz' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:2
 useMultiple3.chpl:3: error: 'baz' undeclared (first use this function)

--- a/test/visibility/private/params/useOtherSibling.good
+++ b/test/visibility/private/params/useOtherSibling.good
@@ -1,4 +1,2 @@
 useOtherSibling.chpl:9: In function 'main':
-useOtherSibling.chpl:10: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- useOtherSibling.chpl:2
 useOtherSibling.chpl:10: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/params/usesOther.good
+++ b/test/visibility/private/params/usesOther.good
@@ -1,3 +1,1 @@
-usesOther.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./definesPrivate.chpl:1
 usesOther.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/variables/useMultiple1.good
+++ b/test/visibility/private/variables/useMultiple1.good
@@ -1,3 +1,1 @@
-useMultiple1.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple1.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/variables/useMultiple2.good
+++ b/test/visibility/private/variables/useMultiple2.good
@@ -1,3 +1,1 @@
-useMultiple2.chpl:3: warning: A visible 'bar' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:1
 useMultiple2.chpl:3: error: 'bar' undeclared (first use this function)

--- a/test/visibility/private/variables/useMultiple3.good
+++ b/test/visibility/private/variables/useMultiple3.good
@@ -1,3 +1,1 @@
-useMultiple3.chpl:3: warning: A visible 'baz' is an inaccessible private symbol, defined at:
- ./multipleDecl.chpl:2
 useMultiple3.chpl:3: error: 'baz' undeclared (first use this function)

--- a/test/visibility/private/variables/useOtherSibling.good
+++ b/test/visibility/private/variables/useOtherSibling.good
@@ -1,4 +1,2 @@
 useOtherSibling.chpl:9: In function 'main':
-useOtherSibling.chpl:10: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- useOtherSibling.chpl:2
 useOtherSibling.chpl:10: error: 'foo' undeclared (first use this function)

--- a/test/visibility/private/variables/usesOther.good
+++ b/test/visibility/private/variables/usesOther.good
@@ -1,3 +1,1 @@
-usesOther.chpl:3: warning: A visible 'foo' is an inaccessible private symbol, defined at:
- ./definesPrivate.chpl:1
 usesOther.chpl:3: error: 'foo' undeclared (first use this function)


### PR DESCRIPTION
When I had initially implemented private symbols, I thought it would be useful
to generate a warning message if we were ignoring a private symbol during
scope resolution.  The case this would catch would be when a user is 'use'ing
a module A and trying to access its private symbol 'foo', and due to another
module at a further distance (say, B, which is used by A or used by another
module their program uses) this compiles but because B.foo is different than
A.foo, the user experiences unexpected behavior without a warning on our part.

In the case where the public 'foo' was intended, this warning message would be
quite annoying.  I had debated about making this warning opt-in, but have been
convinced by others to just remove the message entirely.

I updated my tests which had expected this error message, and removed the
future file for a test which now passes.