### PR TITLE
Fix Coverity error

### DIFF
--- a/runtime/src/qio/qio_popen.c
+++ b/runtime/src/qio/qio_popen.c
@@ -475,15 +475,15 @@ qioerr qio_proc_communicate(
     FD_ZERO(&wfds);
     FD_ZERO(&efds);
 
-    if( do_input ) {
+    if( do_input && input_fd != -1 ) {
       FD_SET(input_fd, &wfds);
       FD_SET(input_fd, &efds);
     }
-    if( do_output ) {
+    if( do_output && output_fd != -1 ) {
       FD_SET(output_fd, &rfds);
       FD_SET(output_fd, &efds);
     }
-    if( do_error ) {
+    if( do_error && error_fd != -1 ) {
       FD_SET(error_fd, &rfds);
       FD_SET(error_fd, &efds);
     }


### PR DESCRIPTION
I don't think it's possible for do_error
to be set when error_fd == -1, but Coverity
is complaining about it, and this code isn't
performance sensitive, so I just added an extra
check.