### PR TITLE
Fix problem where removeWrapRecords left in type for cast

### DIFF
--- a/compiler/optimizations/removeWrapRecords.cpp
+++ b/compiler/optimizations/removeWrapRecords.cpp
@@ -176,6 +176,15 @@ removeWrapRecords() {
           }
         }
       }
+    } else if(call->isPrimitive(PRIM_CAST)) {
+      // Replace PRIM_CAST ref(_array(ArrayType)) tmp
+      // with PRIM_CAST ref(ArrayType) tmp
+      if (SymExpr* se = toSymExpr(call->get(1))) {
+        Type* type = getWrapRecordBaseType(se->var->type);
+        if (type) {
+          se->var = type->symbol;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
in support of string-as-rec

I was getting errors from the C compiler because a cast to a reference to an array type (created in parallel.cpp) still had the wrapper record type even though the variables involved did not.