### PR TITLE
Overhaul of `make check` and `make check-chpldoc` implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ check: all
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
 
 check-chpldoc: chpldoc
-	@bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall --chpldoc
+	@bash $(CHPL_MAKE_HOME)/util/test/checkChplDoc
 
 -include Makefile.devel
 

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ clobber: FORCE
 depend:
 	@echo "make depend has been deprecated for the time being"
 
-check: all third-party-test-venv
+check: all
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
 
 check-chpldoc: chpldoc

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ depend:
 check: all
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
 
-check-chpldoc: chpldoc
+check-chpldoc: chpldoc third-party-test-venv
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplDoc
 
 -include Makefile.devel

--- a/util/test/checkChplDoc
+++ b/util/test/checkChplDoc
@@ -51,34 +51,8 @@ function log_error()
     echo "[ERROR] ${msg}" 1>&2
 }
 
-bin_name=chpl
-
-for opt in ${*:1} ; do
-case $opt in
-    --debug)
-        debug_chpl_test=true
-        ;;
-    --chpldoc)
-        bin_name=chpldoc
-        ;;
-    --help|-h|*)
-        cat<<EOF
-usage: $0
-
-  Runs hello world example programs to verify chpl installation is working
-  correctly. Exits with zero status code when successful. Expects chpl to be on
-  the PATH and CHPL_HOME to be set correctly.
-
-  By default, programs are compiled and run from \$HOME/.chpl/. Set
-  CHPL_CHECK_INSTALL_DIR environment variable to use an alternate location.
-
-  --chpldoc  Test chpldoc with the chpldoc primer, instead of the chpl.
-
-EOF
-        exit 0
-        ;;
-esac
-done
+# Test chpldoc with the chpldoc primer, instead of the chpl.
+bin_name=chpldoc
 
 CHPL_BIN=$(which ${bin_name} 2> /dev/null)
 

--- a/util/test/checkChplDocs
+++ b/util/test/checkChplDocs
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# Currently, this is the old checkChplInstall, but will be converted to a 
+# Doc test, checkChplDocs.
+#
+#
+#
+# Portable script to validate chapel installation by compiling and executing
+# the hello world examples. Exits with zero status code when compilation and
+# execution work as expected. Expects that chpl is available on the PATH and
+# that CHPL_HOME is set correctly.
+#
+# This is morally equivalent to running start_test against the
+# examples/hello*.chpl tests. It works by copying the tests from $CHPL_HOME,
+# which can either be an installation from source/rpm or a working copy of the
+# source repo, to a temporary directory in $HOME/.chpl/. start_test is then run
+# from that temporary directory.
+#
+# Using a temporary directory is necessary for most installations, since the
+# user running the tests will not have the permissions to modify $CHPL_HOME
+# (e.g. a system wide chapel installation) nor would they want to clutter it
+# with test artifacts.
+#
+# $HOME/.chpl/ is used instead of something like $TMPDIR (or /tmp) to improve
+# the likelihood that multi locale tests will succeed. $HOME tends to be
+# consistent and available on all nodes in distributed systems, unlike $TMPDIR
+# which tends to be an in-memory filesystem exclusive to each node.
+#
+# To use something other than $HOME/.chpl, set the CHPL_CHECK_INSTALL_DIR
+# environment variable.
+#
+# To have the start_test logs printed when one or more tests fail, set
+# CHPL_CHECK_INSTALL_PRINT_ERROR to "true". The log file will be kept in
+# $CHPL_CHECK_INSTALL_DIR when there are failures, regardless of the print
+# error setting.
+#
+# There is an undocumented --debug flag, which is useful for development. It
+# produces more verbose output and does not delete the temporary working
+# directory when the script exits.
+
+function log_debug()
+{
+    local msg=$@
+    if [ -n "${debug_chpl_test}" ] ; then
+        echo "[DEBUG] ${msg}"
+    fi
+}
+function log_error()
+{
+    local msg=$@
+    echo "[ERROR] ${msg}" 1>&2
+}
+
+bin_name=chpl
+
+for opt in ${*:1} ; do
+case $opt in
+    --debug)
+        debug_chpl_test=true
+        ;;
+    --chpldoc)
+        bin_name=chpldoc
+        ;;
+    --help|-h|*)
+        cat<<EOF
+usage: $0
+
+  Runs hello world example programs to verify chpl installation is working
+  correctly. Exits with zero status code when successful. Expects chpl to be on
+  the PATH and CHPL_HOME to be set correctly.
+
+  By default, programs are compiled and run from \$HOME/.chpl/. Set
+  CHPL_CHECK_INSTALL_DIR environment variable to use an alternate location.
+
+  --chpldoc  Test chpldoc with the chpldoc primer, instead of the chpl.
+
+EOF
+        exit 0
+        ;;
+esac
+done
+
+CHPL_BIN=$(which ${bin_name} 2> /dev/null)
+
+# Verify chpl binary exists and is executable.
+if [ -z "${CHPL_BIN}" ] ; then
+    log_error "${bin_name} not found. Make sure it available in the current PATH."
+    exit 1
+elif [ ! -x $CHPL_BIN ] ; then
+    log_error "Found ${bin_name} at ${CHPL_BIN} but it is not executable."
+    exit 1
+else
+    log_debug "Found ${bin_name} at: ${CHPL_BIN}"
+fi
+
+# Verify CHPL_HOME is correctly set.
+if [ -z "${CHPL_HOME+x}" ] ; then
+    log_error "CHPL_HOME is not set in environment."
+    exit 1
+elif [ ! -d $CHPL_HOME ] ; then
+    log_error "CHPL_HOME is not a directory: ${CHPL_HOME}"
+    exit 1
+else
+    log_debug "CHPL_HOME is set to: ${CHPL_HOME}"
+fi
+
+# Find examples test directory.
+if [ -d $CHPL_HOME/test/release/examples ] ; then
+    # Install from source repo.
+    TEST_DIR=$CHPL_HOME/test/release/examples
+elif [ -d $CHPL_HOME/examples ] ; then
+    # Install from tarball.
+    TEST_DIR=$CHPL_HOME/examples
+else
+    log_error "Could not find test cases in CHPL_HOME: ${CHPL_HOME}."
+    exit 1
+fi
+
+# For chpldoc, only test the primers/chpldoc.doc.chpl test.
+if [ "${bin_name}" = "chpldoc" ] ; then
+    test_name="chpldoc"
+    TESTS=$TEST_DIR/primers/chpldoc.doc.*
+
+# List all the files in the examples dir. Do not list any subdirectories,
+# though.
+else
+    test_name="hello world"
+    TESTS=$(find $TEST_DIR -maxdepth 1 -mindepth 1 -type f)
+fi
+
+# Copy these tests to a temp file.
+
+chpl_dir=${CHPL_CHECK_INSTALL_DIR:-$HOME/.chpl}
+if [ ! -d $chpl_dir ] ; then
+    log_debug "${chpl_dir} does not exist. Creating it."
+    mkdir -p $chpl_dir || { log_error "Failed to create ${chpl_dir}." && exit 10 ; }
+fi
+
+TMP_TEST_DIR=$(mktemp -d ${chpl_dir}/chapel-test-XXXXX)
+log_debug "TMP_TEST_DIR: ${TMP_TEST_DIR}"
+
+# Ensure the tmp dir is deleted when script exits.
+function cleanup_tmp_dir()
+{
+    # Leave the directory when using --debug.
+    if [ -z "${debug_chpl_test}" ] ; then
+        rm -rf $TMP_TEST_DIR || :
+    else
+        log_debug "Leaving tmp test dir: ${TMP_TEST_DIR}"
+    fi
+}
+trap cleanup_tmp_dir EXIT
+
+test_output_log=$TMP_TEST_DIR/test_output.log
+cp $TESTS $TMP_TEST_DIR/
+
+# Move to the temp directory and run the tests!
+(
+    cd $TMP_TEST_DIR
+    export CHPL_TEST_UTIL_DIR=$CHPL_HOME/util
+
+    # Run the tests.
+    echo "Running the ${test_name} tests found in: $TEST_DIR"
+
+    $CHPL_HOME/util/start_test --no-chpl-home-warn --progress $CHPL_START_TEST_ARGS *.chpl > $test_output_log
+
+    test_status=$?
+    log_debug "start_test exit code: ${test_status}"
+)
+
+# Vars for capturing status info.
+success_key="^\[Success matching"
+error_key="^\[Error"
+warning_key="^\[Warning"
+summary_key="^\[Summary"
+summary_start_key="^\[Test Summary"
+
+function find_test_lines()
+{
+    local key="${1}"
+    local count_arg="${2}"
+
+    # Find the "[Start Summary ...]" line, then grep for $key after it. 100000
+    # is an arbitrarily large number that should include the rest of the file
+    # after [Start Summary ...].
+    grep -A100000 -E "${summary_start_key}" $test_output_log | \
+        grep $count_arg -E "${key}"
+}
+
+successes=$(grep -c -E "${success_key}" $test_output_log)
+errors=$(find_test_lines "${error_key}" -c)
+warnings=$(find_test_lines "${warning_key}" -c)
+
+log_debug "successes: ${successes}"
+log_debug "errors: ${errors}"
+log_debug "warnings: ${warnings}"
+
+# First, check for errors and warnings. Then make sure there was at least one success.
+if (( $errors )) && (( $errors > 0 )) ; then
+    log_error "${errors} tests failed:"
+    find_test_lines "${error_key}"
+    success=false
+elif (( $warnings )) && (( $warnings > 0 )) ; then
+    log_error "${warnings} tests produced warnings:"
+    find_test_lines "${warning_key}"
+    success=false
+elif (( $successes < 1 )) ; then
+    log_error "No tests ran."
+    success=false
+else
+    success=true
+fi
+
+# Print out the summary line.
+log_debug $(grep -E "${summary_key}" $test_output_log)
+
+case $success in
+    true)
+        echo "${bin_name} installation works as expected!"
+        exit 0
+        ;;
+    false|*)
+        # Print the log file if CHPL_CHECK_INSTALL_PRINT_ERROR is set to true.
+        if [ "${CHPL_CHECK_INSTALL_PRINT_ERROR}" = "true" ] ; then
+            cat $test_output_log
+        fi
+
+        echo "Found issues with ${bin_name} installation."
+        echo "  ${bin_name} path: ${CHPL_BIN}"
+        echo "  CHPL_HOME: ${CHPL_HOME}"
+
+        # Copy the output log file to a non-temp location to make it available
+        # for the user.
+        failure_log=$chpl_dir/$(basename $0)-failure.log
+        cp $test_output_log $failure_log
+        echo "Storing complete log in ${failure_log}"
+
+        exit 10
+        ;;
+esac

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -127,9 +127,9 @@ fi
 if [ ${chpl_launcher} == "slurm-srun" -o ${chpl_launcher} == "amudprun" -o ${chpl_launcher} == "none" ]; then
     echo "Launcher, \$CHPL_LAUNCHER = ${chpl_launcher}, is compatible with test script"
 else
-    echo "This script is not compatible with the \$CHPL_LAUNCHER value of ${CHPL_LAUNCHER}"
+    echo "This script is not compatible with the \$CHPL_LAUNCHER value of ${chpl_launcher}"
     echo "This does not necessarily indicate that your Chapel installation is incorrect"
-    echo "See ${CHPL_HOME}/doc/README.launcher for more information on how to manually run a Chapel program"
+    echo "See \$CHPL_HOME/doc/README.launcher for more information on how to manually run a Chapel program"
     exit 10
 fi
 

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -94,7 +94,7 @@ chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"
 TEST_COMP_OUT=${TEST_JOB}.comp.out
 
 # Compile test job into temporary directory
-chpl ${TEST_DIR}/${TEST_JOB}.chpl -o ${TMP_TEST_DIR}/${TEST_JOB} > ${TMP_TEST_DIR}/${TEST_COMP_OUT} 2>&1
+${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl -o ${TMP_TEST_DIR}/${TEST_JOB} > ${TMP_TEST_DIR}/${TEST_COMP_OUT} 2>&1
 
 # Check that compile was successful
 COMPILE_STATUS=$?

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -93,8 +93,11 @@ chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"
 # Log file for compile output
 TEST_COMP_OUT=${TEST_JOB}.comp.out
 
+# Necessary to suppress warnings when WARNINGS=1 (e.g. nightly build settings)
+COMP_FLAGS="--cc-warnings"
+
 # Compile test job into temporary directory
-${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl -o ${TMP_TEST_DIR}/${TEST_JOB} > ${TMP_TEST_DIR}/${TEST_COMP_OUT} 2>&1
+${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} > ${TMP_TEST_DIR}/${TEST_COMP_OUT} 2>&1
 
 # Check that compile was successful
 COMPILE_STATUS=$?

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
+
+# Validate Chapel installation by compiling and executing an example job.
 #
-# Portable script to validate chapel installation by compiling and executing
-# the hello world examples. Exits with zero status code when compilation and
-# execution work as expected. Expects that chpl is available on the PATH and
-# that CHPL_HOME is set correctly.
 #
-# This is morally equivalent to running start_test against the
-# examples/hello*.chpl tests. It works by copying the tests from $CHPL_HOME,
-# which can either be an installation from source/rpm or a working copy of the
-# source repo, to a temporary directory in $HOME/.chpl/. start_test is then run
-# from that temporary directory.
+# Exits with zero status code when compilation and execution work as
+# expected. Expects that chpl is available on the PATH and that CHPL_HOME is
+# set correctly.
+#
+# It works by copying the test from $CHPL_HOME, which can  either be an
+# installation from source/rpm or a working copy of the source repo, to a
+# temporary directory in $HOME/.chpl/, then executing the binary and diffing
+# the output with the .good file.
 #
 # Using a temporary directory is necessary for most installations, since the
 # user running the tests will not have the permissions to modify $CHPL_HOME
@@ -23,213 +24,152 @@
 #
 # To use something other than $HOME/.chpl, set the CHPL_CHECK_INSTALL_DIR
 # environment variable.
+
+
+
+# TODO:
+#   4.5 Stage, commit, push to dev branch
 #
-# To have the start_test logs printed when one or more tests fail, set
-# CHPL_CHECK_INSTALL_PRINT_ERROR to "true". The log file will be kept in
-# $CHPL_CHECK_INSTALL_DIR when there are failures, regardless of the print
-# error setting.
-#
-# There is an undocumented --debug flag, which is useful for development. It
-# produces more verbose output and does not delete the temporary working
-# directory when the script exits.
+#   5. Test on machines:
+#       * tiger (module swap PrgEnv-{cray,gnu})
+#       * kay-esl (module swap PrgEnv-{cray,gnu})
+#       * OS X (this guy)
+#       * sealcs01 (linux)
+#       * mork (pbs-system) -> should fail
+#       * stpwchap (Cygwin - ask someone how to do this)
 
-function log_debug()
-{
-    local msg=$@
-    if [ -n "${debug_chpl_test}" ] ; then
-        echo "[DEBUG] ${msg}"
-    fi
-}
-function log_error()
-{
-    local msg=$@
-    echo "[ERROR] ${msg}" 1>&2
+
+# Base name for test job in $CHPL_HOME/test/release/examples
+TEST_JOB_BASENAME=hello6-taskpar-dist
+
+err() {
+    #echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')] error: $@" >&2
+    echo "error: $@" >&2
 }
 
-bin_name=chpl
+# Notify user we are running this script
+echo "Running minimal test script, checkChplInstall"
 
-for opt in ${*:1} ; do
-case $opt in
-    --debug)
-        debug_chpl_test=true
-        ;;
-    --chpldoc)
-        bin_name=chpldoc
-        ;;
-    --help|-h|*)
-        cat<<EOF
-usage: $0
+BIN_NAME=chpl
 
-  Runs hello world example programs to verify chpl installation is working
-  correctly. Exits with zero status code when successful. Expects chpl to be on
-  the PATH and CHPL_HOME to be set correctly.
+CHPL_BIN="$(which ${BIN_NAME} 2> /dev/null)"
 
-  By default, programs are compiled and run from \$HOME/.chpl/. Set
-  CHPL_CHECK_INSTALL_DIR environment variable to use an alternate location.
-
-  --chpldoc  Test chpldoc with the chpldoc primer, instead of the chpl.
-
-EOF
-        exit 0
-        ;;
-esac
-done
-
-CHPL_BIN=$(which ${bin_name} 2> /dev/null)
-
-# Verify chpl binary exists and is executable.
+# Verify chpl is in $PATH
 if [ -z "${CHPL_BIN}" ] ; then
-    log_error "${bin_name} not found. Make sure it available in the current PATH."
+    err "${BIN_NAME} not found. Make sure it available in the current PATH."
     exit 1
-elif [ ! -x $CHPL_BIN ] ; then
-    log_error "Found ${bin_name} at ${CHPL_BIN} but it is not executable."
+elif [ ! -x ${CHPL_BIN} ] ; then
+    err "Found ${BIN_NAME} at ${CHPL_BIN} but it is not executable."
     exit 1
 else
-    log_debug "Found ${bin_name} at: ${CHPL_BIN}"
+    echo "Found executable ${BIN_NAME} in ${CHPL_BIN}."
 fi
 
 # Verify CHPL_HOME is correctly set.
 if [ -z "${CHPL_HOME+x}" ] ; then
-    log_error "CHPL_HOME is not set in environment."
+    err "CHPL_HOME is not set in environment."
     exit 1
-elif [ ! -d $CHPL_HOME ] ; then
-    log_error "CHPL_HOME is not a directory: ${CHPL_HOME}"
+elif [ ! -d ${CHPL_HOME} ] ; then
+    err "CHPL_HOME is not a directory: ${CHPL_HOME}"
     exit 1
 else
-    log_debug "CHPL_HOME is set to: ${CHPL_HOME}"
+    echo "Found \$CHPL_HOME directory: ${CHPL_HOME}"
 fi
 
-# Find examples test directory.
-if [ -d $CHPL_HOME/test/release/examples ] ; then
+# Create ~/.chpl directory, if it does not already exist
+CHPL_DIR=${CHPL_CHECK_INSTALL_DIR:-${HOME}/.chpl}
+if [ ! -d ${CHPL_DIR} ] ; then
+    echo "${CHPL_DIR} does not exist. Creating it."
+    mkdir -p ${CHPL_DIR} || { echo "Failed to create ${CHPL_DIR}." && exit 10 ; }
+fi
+
+# Location of test job
+if [ -d ${CHPL_HOME}/test/release/examples ] ; then
     # Install from source repo.
-    TEST_DIR=$CHPL_HOME/test/release/examples
-elif [ -d $CHPL_HOME/examples ] ; then
+    TEST_DIR=${CHPL_HOME}/test/release/examples
+elif [ -d ${CHPL_HOME}/examples ] ; then
     # Install from tarball.
-    TEST_DIR=$CHPL_HOME/examples
+    TEST_DIR=${CHPL_HOME}/examples
 else
-    log_error "Could not find test cases in CHPL_HOME: ${CHPL_HOME}."
+    err "Could not find test cases in CHPL_HOME: ${CHPL_HOME}."
     exit 1
 fi
 
-# For chpldoc, only test the primers/chpldoc.doc.chpl test.
-if [ "${bin_name}" = "chpldoc" ] ; then
-    test_name="chpldoc"
-    TESTS=$TEST_DIR/primers/chpldoc.doc.*
+# Create temporary directory with randomly generated name, for test job
+TMP_TEST_DIR="$(mktemp -d ${CHPL_DIR}/chapel-test-XXXXX)"
+echo "Temporary test job directory: ${TMP_TEST_DIR}"
 
-# List all the files in the examples dir. Do not list any subdirectories,
-# though.
+# Single test job (subject to change in future)
+TEST_JOB=${TEST_JOB_BASENAME}
+
+# Collect comm protocol environment variables (lowercase to avoid conflicts)
+chpl_comm="$($CHPL_HOME/util/chplenv/chpl_comm.py)"
+chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"
+
+# Compile test job into temporary directory
+chpl ${TEST_DIR}/${TEST_JOB}.chpl -o ${TMP_TEST_DIR}/${TEST_JOB}
+
+# Check that compile was successful
+COMPILE_STATUS=$?
+if [ ${COMPILE_STATUS} -ne 0 ]; then
+    err "Test job failed to compile, Chapel is not installed correctly"
+    exit 1
 else
-    test_name="hello world"
-    TESTS=$(find $TEST_DIR -maxdepth 1 -mindepth 1 -type f)
+    echo "Test job compiled into ${TMP_TEST_DIR}/${TEST_JOB}"
 fi
 
-# Copy these tests to a temp file.
-
-chpl_dir=${CHPL_CHECK_INSTALL_DIR:-$HOME/.chpl}
-if [ ! -d $chpl_dir ] ; then
-    log_debug "${chpl_dir} does not exist. Creating it."
-    mkdir -p $chpl_dir || { log_error "Failed to create ${chpl_dir}." && exit 10 ; }
-fi
-
-TMP_TEST_DIR=$(mktemp -d ${chpl_dir}/chapel-test-XXXXX)
-log_debug "TMP_TEST_DIR: ${TMP_TEST_DIR}"
-
-# Ensure the tmp dir is deleted when script exits.
+# Cleanup the tmp directory whenever exit is invoked
 function cleanup_tmp_dir()
 {
-    # Leave the directory when using --debug.
-    if [ -z "${debug_chpl_test}" ] ; then
-        rm -rf $TMP_TEST_DIR || :
-    else
-        log_debug "Leaving tmp test dir: ${TMP_TEST_DIR}"
-    fi
+    rm -rf ${TMP_TEST_DIR}
 }
 trap cleanup_tmp_dir EXIT
 
-test_output_log=$TMP_TEST_DIR/test_output.log
-cp $TESTS $TMP_TEST_DIR/
-
-# Move to the temp directory and run the tests!
-(
-    cd $TMP_TEST_DIR
-    export CHPL_TEST_UTIL_DIR=$CHPL_HOME/util
-
-    # Run the tests.
-    echo "Running the ${test_name} tests found in: $TEST_DIR"
-
-    $CHPL_HOME/util/start_test --no-chpl-home-warn --progress $CHPL_START_TEST_ARGS *.chpl > $test_output_log
-
-    test_status=$?
-    log_debug "start_test exit code: ${test_status}"
-)
-
-# Vars for capturing status info.
-success_key="^\[Success matching"
-error_key="^\[Error"
-warning_key="^\[Warning"
-summary_key="^\[Summary"
-summary_start_key="^\[Test Summary"
-
-function find_test_lines()
-{
-    local key="${1}"
-    local count_arg="${2}"
-
-    # Find the "[Start Summary ...]" line, then grep for $key after it. 100000
-    # is an arbitrarily large number that should include the rest of the file
-    # after [Start Summary ...].
-    grep -A100000 -E "${summary_start_key}" $test_output_log | \
-        grep $count_arg -E "${key}"
-}
-
-successes=$(grep -c -E "${success_key}" $test_output_log)
-errors=$(find_test_lines "${error_key}" -c)
-warnings=$(find_test_lines "${warning_key}" -c)
-
-log_debug "successes: ${successes}"
-log_debug "errors: ${errors}"
-log_debug "warnings: ${warnings}"
-
-# First, check for errors and warnings. Then make sure there was at least one success.
-if (( $errors )) && (( $errors > 0 )) ; then
-    log_error "${errors} tests failed:"
-    find_test_lines "${error_key}"
-    success=false
-elif (( $warnings )) && (( $warnings > 0 )) ; then
-    log_error "${warnings} tests produced warnings:"
-    find_test_lines "${warning_key}"
-    success=false
-elif (( $successes < 1 )) ; then
-    log_error "No tests ran."
-    success=false
+# Find number of locales and .good file
+if [ ${chpl_comm} == "none" ]; then
+    NUMLOCALES=1
+    GOOD=${TEST_DIR}/${TEST_JOB}.comm-none.good
 else
-    success=true
+    NUMLOCALES="$(cat ${TEST_DIR}/NUMLOCALES)"
+    GOOD=${TEST_DIR}/${TEST_JOB}.good
 fi
 
-# Print out the summary line.
-log_debug $(grep -E "${summary_key}" $test_output_log)
+# Check for valid launchers
+if [ ${chpl_launcher} == "slurm-srun" -o ${chpl_launcher} == "amudprun" -o ${chpl_launcher} == "none" ]; then
+    echo "Launcher, \$CHPL_LAUNCHER = ${chpl_launcher}, is compatible with test script"
+else
+    echo "This script is not compatible with the \$CHPL_LAUNCHER value of ${CHPL_LAUNCHER}"
+    echo "This does not necessarily indicate that your Chapel installation is incorrect"
+    echo "See ${CHPL_HOME}/doc/README.launcher for more information on how to manually run a Chapel program"
+    exit 10
+fi
 
-case $success in
-    true)
-        echo "${bin_name} installation works as expected!"
-        exit 0
-        ;;
-    false|*)
-        # Print the log file if CHPL_CHECK_INSTALL_PRINT_ERROR is set to true.
-        if [ "${CHPL_CHECK_INSTALL_PRINT_ERROR}" = "true" ] ; then
-            cat $test_output_log
-        fi
+# Run compiled binary with parsed execution options
+(
+    cd ${TMP_TEST_DIR}
 
-        echo "Found issues with ${bin_name} installation."
-        echo "  ${bin_name} path: ${CHPL_BIN}"
-        echo "  CHPL_HOME: ${CHPL_HOME}"
+    EXEC_OPTS="$(cat ${TEST_DIR}/${TEST_JOB}.execopts)"
 
-        # Copy the output log file to a non-temp location to make it available
-        # for the user.
-        failure_log=$chpl_dir/$(basename $0)-failure.log
-        cp $test_output_log $failure_log
-        echo "Storing complete log in ${failure_log}"
+    echo "Running test job"
+    ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} > ${TEST_JOB}.exec.out 2>&1
+    echo "Test job complete"
 
-        exit 10
-        ;;
-esac
+    # Quick test to verify fail case
+    #echo "this should break the test" >> ${TEST_JOB}.out
+
+)
+
+
+# Call diff on the output with .good file
+DIFF_OUTPUT="$(diff -q ${TMP_TEST_DIR}/${TEST_JOB}.exec.out ${GOOD})"
+
+# Return 0 if diff is good
+if [ -z "${DIFF_OUTPUT}" ]; then
+    echo "Installation works as expected!"
+    exit 0
+else
+    echo "There was an issue with the installation"
+    echo "diff log:"
+    echo "$(diff ${TMP_TEST_DIR}/${TEST_JOB}.out ${TEST_DIR}/${TEST_JOB}.comm-none.good)"
+    exit 10
+fi

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -26,29 +26,15 @@
 # environment variable.
 
 
-
-# TODO:
-#   4.5 Stage, commit, push to dev branch
-#
-#   5. Test on machines:
-#       * tiger (module swap PrgEnv-{cray,gnu})
-#       * kay-esl (module swap PrgEnv-{cray,gnu})
-#       * OS X (this guy)
-#       * sealcs01 (linux)
-#       * mork (pbs-system) -> should fail
-#       * stpwchap (Cygwin - ask someone how to do this)
-
-
 # Base name for test job in $CHPL_HOME/test/release/examples
 TEST_JOB_BASENAME=hello6-taskpar-dist
 
 err() {
-    #echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')] error: $@" >&2
     echo "error: $@" >&2
 }
 
 # Notify user we are running this script
-echo "Running minimal test script, checkChplInstall"
+echo "Running minimal test script: checkChplInstall"
 
 BIN_NAME=chpl
 
@@ -95,24 +81,27 @@ else
     exit 1
 fi
 
-# Create temporary directory with randomly generated name, for test job
 TMP_TEST_DIR="$(mktemp -d ${CHPL_DIR}/chapel-test-XXXXX)"
 echo "Temporary test job directory: ${TMP_TEST_DIR}"
 
-# Single test job (subject to change in future)
 TEST_JOB=${TEST_JOB_BASENAME}
 
 # Collect comm protocol environment variables (lowercase to avoid conflicts)
 chpl_comm="$($CHPL_HOME/util/chplenv/chpl_comm.py)"
 chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"
 
+# Log file for compile output
+TEST_COMP_OUT=${TEST_JOB}.comp.out
+
 # Compile test job into temporary directory
-chpl ${TEST_DIR}/${TEST_JOB}.chpl -o ${TMP_TEST_DIR}/${TEST_JOB}
+chpl ${TEST_DIR}/${TEST_JOB}.chpl -o ${TMP_TEST_DIR}/${TEST_JOB} > ${TMP_TEST_DIR}/${TEST_COMP_OUT} 2>&1
 
 # Check that compile was successful
 COMPILE_STATUS=$?
 if [ ${COMPILE_STATUS} -ne 0 ]; then
     err "Test job failed to compile, Chapel is not installed correctly"
+    echo "Compilation output:"
+    cat ${TMP_TEST_DIR}/${TEST_COMP_OUT}
     exit 1
 else
     echo "Test job compiled into ${TMP_TEST_DIR}/${TEST_JOB}"
@@ -144,6 +133,8 @@ else
     exit 10
 fi
 
+TEST_EXEC_OUT=${TEST_JOB}.exec.out
+
 # Run compiled binary with parsed execution options
 (
     cd ${TMP_TEST_DIR}
@@ -151,25 +142,25 @@ fi
     EXEC_OPTS="$(cat ${TEST_DIR}/${TEST_JOB}.execopts)"
 
     echo "Running test job"
-    ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} > ${TEST_JOB}.exec.out 2>&1
+    ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} > ${TEST_EXEC_OUT} 2>&1
     echo "Test job complete"
 
     # Quick test to verify fail case
-    #echo "this should break the test" >> ${TEST_JOB}.out
+    #echo "this should break the test" >> ${TEST_EXEC_OUT}
 
 )
 
-
-# Call diff on the output with .good file
-DIFF_OUTPUT="$(diff -q ${TMP_TEST_DIR}/${TEST_JOB}.exec.out ${GOOD})"
+# Check result
+DIFF_OUTPUT=$(diff -q ${TMP_TEST_DIR}/${TEST_EXEC_OUT} ${GOOD})
 
 # Return 0 if diff is good
 if [ -z "${DIFF_OUTPUT}" ]; then
     echo "Installation works as expected!"
     exit 0
 else
-    echo "There was an issue with the installation"
-    echo "diff log:"
-    echo "$(diff ${TMP_TEST_DIR}/${TEST_JOB}.out ${TEST_DIR}/${TEST_JOB}.comm-none.good)"
+    echo "There was an issue with the installation, test job output incorrect"
+    echo "== Log =="
+    echo "diff ${TMP_TEST_DIR}/${TEST_EXEC_OUT} ${GOOD}"
+    echo "$(diff ${TMP_TEST_DIR}/${TEST_EXEC_OUT} ${GOOD})"
     exit 10
 fi


### PR DESCRIPTION
`checkChplInstall`, the script called from `make check`, previously dished
out the execution and diff portion of testing to `start_test`, a complex
script with some third-party dependencies. If a third-party dependency
was missing (most notably `python-dev`), a user would get a
false negative in their `make check` call. A user would be led to believe that
their Chapel installation was incorrect when they were actually just
missing a third-party package only necessary for the testing suite.

The new `checkChplInstall` no longer calls `start_test`, and consequently no longer depends on the `third-party-test-venv` packages. `checkChplInstall` will now check the environment variable, `$CHPL_LAUNCHER`, and will notify the user if their launcher "mode" is not supported by the test script (e.g. `aprun`). The test cases have also been reduced from all 6 hello world examples to just `hello6-taskpar-dist.chpl`, which will run as a multi-locale job if `$CHPL_COMM != none`.

`make check-chpldoc` now calls a separate script called `checkChplDoc`, which behaves the same way as the the old `checkChplInstall --chpldoc`, which `make check-chpldoc` used to call.