### PR TITLE
Change hplx to do reindexing again

### DIFF
--- a/test/distributions/dm/hplx.chpl
+++ b/test/distributions/dm/hplx.chpl
@@ -38,7 +38,7 @@ proc main() {
 
       dgemm(/*replA(aBlkD),
             replB(bBlkD),
-            */Ab(cBlkD));
+            */Ab(cBlkD).reindex({1..blk, 1..blk}));
   }
 
   writeln("finish");
@@ -46,5 +46,5 @@ proc main() {
 
 proc dgemm(/*A: [1..blk, 1..blk] real,
            B: [1..blk, 1..blk] real,
-           */C: [?D] real)
+           */C: [1..blk, 1..blk] real)
 { }


### PR DESCRIPTION
Based on the .future, I thought it would be OK to take reindexing
out of this test without affecting its behavior, but we've seen a
lot of passes of it since I did so.  So I'm putting the implicit
reindexing that was done previously back in explicitly, hoping to
make it fail more consistently again.