### PR TITLE
Fix annotation generation

### DIFF
--- a/util/cron/common-perf.bash
+++ b/util/cron/common-perf.bash
@@ -17,3 +17,7 @@ export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 
 export CHPL_TEST_PERF_DIR="$CHPL_NIGHTLY_LOGDIR"
 export CHPL_TEST_COMP_PERF_DIR="$CHPL_NIGHTLY_LOGDIR"
+
+# Our perf jobs require PyYAML for generating annotations but we don't have
+# approval to include it in the regular test-venv requirements globally
+echo "PyYAML==3.11" >> "$CHPL_HOME/third-party/chpl-venv/test-requirements.txt"


### PR DESCRIPTION
Our annotations require PyYAML. This used to be installed on our testing
machines, but doesn't appear to be anymore. To get around this I'm just adding
it to the list of test-venv requirements for performance runs. We don't have
approval to add it to the test-venv in general, so I'm just appending it in
common-perf