### PR TITLE
Update testReleasesPerformance for new start_test

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -87,6 +87,8 @@ export CHPL_TEST_PERF_DATE="03/25/15"
 export CHPL_HOME=$chpl_release_home/chapel-1.11.0
 testReleasePerformance
 
+export -n CHPL_TEST_PERF_DATE
+export CHPL_HOME=$CHPL_HOME_ORIG
 start_test --gen-graphs
 
 #

--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -17,6 +17,9 @@
 #   you want to make the results comparable to the ones we gather
 #   nightly) and up-to-date with the master.
 #
+# * set CHPL_TEST_VENV_DIR=\
+#     $CHPL_HOME/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/chpl-virtualenv
+#
 # * optionally, set CHPL_TEST_PERF_DIR to indicate where you want
 #   the output .dat and html/ files to be placed.  By default, it
 #   will use $CHPL_HOME/test/perfdat-releases/
@@ -83,6 +86,8 @@ testReleasePerformance
 export CHPL_TEST_PERF_DATE="03/25/15"
 export CHPL_HOME=$chpl_release_home/chapel-1.11.0
 testReleasePerformance
+
+start_test --gen-graphs
 
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.  


### PR DESCRIPTION
Code-wise, there wasn't anything required here, I just noted that you
have to set your venv location for the test system before launching
it (since, otherwise, it will try to use venv environments for the
old releases which didn't have/support them).

While here, I also noted that if we did a --gen-graphs at the end of
the run, the results could be inspected and verified more easily, so
did that.