### PR TITLE
Use qthreads w/o hwloc with cce when we can

### DIFF
--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_tasks, chpl_arch
+import chpl_tasks, chpl_arch, chpl_compiler
 from utils import memoize
 
 @memoize
@@ -10,7 +10,10 @@ def get():
     if not hwloc_val:
         tasks_val = chpl_tasks.get()
         arch_val = chpl_arch.get('target', get_lcd=True)
-        if tasks_val == 'qthreads' and arch_val != 'knc':
+        compiler_val = chpl_compiler.get('target')
+
+        if (tasks_val == 'qthreads' and arch_val != 'knc' and
+                compiler_val != 'cray-prgenv-cray'):
             hwloc_val = 'hwloc'
         else:
             hwloc_val = 'none'

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -2,7 +2,7 @@
 import sys, os
 
 import chpl_arch, chpl_platform, chpl_compiler, chpl_comm
-from utils import memoize
+from utils import memoize, CompVersion
 import utils
 
 @memoize
@@ -12,12 +12,20 @@ def get():
         arch_val = chpl_arch.get('target', get_lcd=True)
         platform_val = chpl_platform.get()
         compiler_val = chpl_compiler.get('target')
-        comm_val = chpl_comm.get()
+
+        # CCE 8.4 or newer is required to build qthreads. We build the module
+        # with a new enough version so we know the we can use the qthreads it
+        # provides even if the user has an older CCE loaded
+        using_qthreads_incompatible_cce = False
+        if compiler_val == 'cray-prgenv-cray':
+            if (utils.get_compiler_version(compiler_val) < CompVersion('8.4') and
+                    not using_chapel_module()):
+                using_qthreads_incompatible_cce = True
 
         if (arch_val == 'knc' or
                 platform_val.startswith('cygwin') or
                 platform_val.startswith('netbsd') or
-                compiler_val == 'cray-prgenv-cray'):
+                using_qthreads_incompatible_cce):
             tasks_val = 'fifo'
         else:
             tasks_val = 'qthreads'


### PR DESCRIPTION
Default to qthreads for cce if we have 8.4 or newer or if the module is being
used. CCE 8.4 is required to build qthreads since it has inline assembly.

We build the module with 8.4 so we know we can use qthreads if the module is
being used even if an older cce is loaded.

hwloc doesn't build with CCE 8.4, so turn it off for now. Once CCE 8.4 is
released I'll file some bug reports with the hwloc team.