### PR TITLE
Reword internal errors / enable --print-callstack-on-error for users

### DIFF
--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -251,7 +251,6 @@ printErrorHeader(BaseAST* ast) {
 
 
 static void printErrorFooter(bool guess) {
-  fprintf(stderr, "I'm in!");
   if (developer)
     fprintf(stderr, " [%s:%d]", err_filename, err_lineno);
 
@@ -259,7 +258,8 @@ static void printErrorFooter(bool guess) {
     fprintf(stderr, "\n(this source location is a guess)");
   }
   if (!developer) {
-    fprintf(stderr, "\nThis is the new apology message which references %s\n", 
+    fprintf(stderr, "\n\n"
+            "This is the new apology message which references %s\n", 
             help_url);
   }
   if (!err_user && !developer && err_fatal)

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -36,7 +36,7 @@
 #include <sys/stat.h>
 
 
-static const char* help_url = "http://chapel.cray.com/getinvolved.html";
+static const char* help_url = "http://chapel.cray.com/bugs.html";
 
 static void cleanup_for_exit(void) {
   deleteTmpDir();
@@ -252,14 +252,17 @@ printErrorHeader(BaseAST* ast) {
 
 static void printErrorFooter(bool guess) {
   if (developer)
-    fprintf(stderr, " [%s:%d]", err_filename, err_lineno);
+    fprintf(stderr, " [%s:%d]\n", err_filename, err_lineno);
 
   if (guess) {
-    fprintf(stderr, "\n(this source location is a guess)");
+    fprintf(stderr, "Note: This source location is a guess.\n");
   }
   if (!developer) {
-    fprintf(stderr, "\n\n"
-            "This is the new apology message which references %s\n", 
+    fprintf(stderr, "\n"
+            "Internal errors indicate a bug in the Chapel compiler (\"It's us, not you\"),\n"
+            "and we're sorry for the hassle.  We would appreciate your reporting this bug -- \n"
+            "please see %s for instructions.  In the meantime,\n"
+            "the filename + line number above may be useful in working around the issue.\n\n", 
             help_url);
   }
   if (!err_user && !developer && err_fatal)
@@ -340,8 +343,6 @@ void handleError(const char *fmt, ...) {
 
   printErrorFooter(guess);
 
-  fprintf(stderr, "\n");
-
   printCallStackOnError();
 
   if (!err_user && !developer)
@@ -390,8 +391,6 @@ static void vhandleError(FILE* file, BaseAST* ast, const char *fmt, va_list args
 
   if (file == stderr)
     printErrorFooter(guess);
-
-  fprintf(file, "\n");
 
   if (file == stderr)
     printCallStackOnError();

--- a/test/associative/thomasvandoren/c_string-to-string.bad
+++ b/test/associative/thomasvandoren/c_string-to-string.bad
@@ -1,9 +1,8 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+c_string-to-string.chpl:6: internal error: FUN3038 chpl Version 1.11.0.e5a07fc
+Note: This source location is a guess.
 
- The error may be related to this location:
- c_string-to-string.chpl:6
-c_string-to-string.chpl:6: internal error: FUN3024 chpl Version 1.11.0.559e3c7
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/classes/constructors/assign-param-segfault.bad
+++ b/test/classes/constructors/assign-param-segfault.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+internal error: MIS0453 chpl Version 1.11.0.e5a07fc
 
-internal error: MIS0438 chpl Version 1.11.0.559e3c7
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/classes/vass/ref-like-intents/inout-subclass.bad
+++ b/test/classes/vass/ref-like-intents/inout-subclass.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
-
 inout-subclass.chpl:14: internal error: CHE
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/classes/vass/ref-like-intents/out-subclass.bad
+++ b/test/classes/vass/ref-like-intents/out-subclass.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
-
 out-subclass.chpl:14: internal error: CHE
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/classes/vass/ref-like-intents/ref-subclass.bad
+++ b/test/classes/vass/ref-like-intents/ref-subclass.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
-
 ref-subclass.chpl:14: internal error: CHE
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/exits/sungeun/exitWithNoParensNoArgs.bad
+++ b/test/exits/sungeun/exitWithNoParensNoArgs.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
-
 exitWithNoParensNoArgs.chpl:1: internal error:
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/bradc/paramThis/funParamThis3.bad
+++ b/test/functions/bradc/paramThis/funParamThis3.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+funParamThis3.chpl:2: internal error: SYM1507 chpl Version 1.11.0.e5a07fc
 
-funParamThis3.chpl:2: internal error: SYM1497 chpl Version 1.11.0.559e3c7
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/iterators/vass/forall-without-leaderfollower.bad
+++ b/test/functions/iterators/vass/forall-without-leaderfollower.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
-
 internal error:
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/modules/bradc/modNamedNewStringBreaks.bad
+++ b/test/modules/bradc/modNamedNewStringBreaks.bad
@@ -1,9 +1,8 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+$CHPL_HOME/modules/internal/ChapelStandard.chpl:34: internal error: PAR0332 chpl Version 1.11.0.e5a07fc
+Note: This source location is a guess.
 
- The error may be related to this location:
- $CHPL_HOME/modules/internal/ChapelStandard.chpl:34
-$CHPL_HOME/modules/internal/ChapelStandard.chpl:34: internal error: PAR0329 chpl Version 1.11.0.559e3c7
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/parallel/begin/sungeun/autoCopyWithBegin.bad
+++ b/test/parallel/begin/sungeun/autoCopyWithBegin.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+autoCopyWithBegin.chpl:15: internal error: CALnnnnfc
 
-autoCopyWithBegin.chpl:15: internal error: CALnnnn
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/parallel/begin/sungeun/initCopyWithBegin.bad
+++ b/test/parallel/begin/sungeun/initCopyWithBegin.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+internal error: REM0411 chpl Version 1.11.0.e5a07fc
 
-internal error: REM0411 chpl Version 1.11.0.559e3c7
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/parallel/begin/vass/begin-in-module-init.bad
+++ b/test/parallel/begin/vass/begin-in-module-init.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
-
 begin-in-module-init.chpl:1: internal error: CHE
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/parallel/taskPar/vass/field-in-task-ref-clause.bad
+++ b/test/parallel/taskPar/vass/field-in-task-ref-clause.bad
@@ -1,8 +1,8 @@
 field-in-task-ref-clause.chpl-- In function...
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
-
 field-in-task-ref-clause.chpl-- internal error: STM
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/trivial/diten/testIntExp4.good
+++ b/test/trivial/diten/testIntExp4.good
@@ -1,1 +1,2 @@
 $CHPL_HOME/modules/internal/ChapelBase.chpl:463: error: 0 cannot be raised to a negative power
+Note: This source location is a guess.

--- a/test/types/scalar/bradc/index-int.bad
+++ b/test/types/scalar/bradc/index-int.bad
@@ -1,9 +1,8 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+index-int.chpl:1: internal error: TYP0104 chpl Version 1.11.0.e5a07fc
+Note: This source location is a guess.
 
- The error may be related to this location:
- index-int.chpl:1
-index-int.chpl:1: internal error: TYP0104 chpl Version 1.11.0.559e3c7
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/users/vass/crash1callDestructorsMain.bad
+++ b/test/users/vass/crash1callDestructorsMain.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
-
 internal error: CAL or MIS
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/users/vass/internal-error-message.good
+++ b/test/users/vass/internal-error-message.good
@@ -1,8 +1,2 @@
 internal-error-message.chpl:72: In function 'scalar_outer_product_cholesky':
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
-
 internal-error-message.chpl:90: internal error: the type of the actual argument 'A' is generic [callInfo.cpp:56]

--- a/test/users/vass/tuple-crash-1.bad
+++ b/test/users/vass/tuple-crash-1.bad
@@ -1,9 +1,8 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+$CHPL_HOME/modules/internal/ChapelBase.chpl:172: internal error: FUN2570 chpl Version 1.11.0.e5a07fc
+Note: This source location is a guess.
 
- The error may be related to this location:
- $CHPL_HOME/modules/internal/ChapelBase.chpl:172
-$CHPL_HOME/modules/internal/ChapelBase.chpl:172: internal error: FUN2567 chpl Version 1.11.0.559e3c7
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/users/vass/type-tests.isSubtype.good
+++ b/test/users/vass/type-tests.isSubtype.good
@@ -76,6 +76,7 @@ type-tests.isSubtype.chpl:93: warning: U1,       C1       false
 type-tests.isSubtype.chpl:94: warning: U1,       R1       false
 type-tests.isSubtype.chpl:96: warning: isProperSubtype - scalars
 type-tests.isSubtype.chpl:97: warning: int, real   false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:97: warning: int, real   false
 type-tests.isSubtype.chpl:98: warning: real, real  false
 type-tests.isSubtype.chpl:100: warning: isProperSubtype - domains and arrays
@@ -87,123 +88,176 @@ type-tests.isSubtype.chpl:105: warning: {AA1,AA2}._value  false
 type-tests.isSubtype.chpl:107: warning: isProperSubtype - classes
 type-tests.isSubtype.chpl:108: warning: C1, C1  false
 type-tests.isSubtype.chpl:109: warning: C1, C2  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:109: warning: C1, C2  false
 type-tests.isSubtype.chpl:110: warning: C1, C3  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:110: warning: C1, C3  false
 type-tests.isSubtype.chpl:111: warning: C1, C4  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:111: warning: C1, C4  false
 type-tests.isSubtype.chpl:112: warning: C2, C1  true
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:112: warning: C2, C1  true
 type-tests.isSubtype.chpl:113: warning: C2, C2  false
 type-tests.isSubtype.chpl:114: warning: C2, C3  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:114: warning: C2, C3  false
 type-tests.isSubtype.chpl:115: warning: C2, C4  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:115: warning: C2, C4  false
 type-tests.isSubtype.chpl:116: warning: C3, C1  true
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:116: warning: C3, C1  true
 type-tests.isSubtype.chpl:117: warning: C3, C2  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:117: warning: C3, C2  false
 type-tests.isSubtype.chpl:118: warning: C3, C3  false
 type-tests.isSubtype.chpl:119: warning: C3, C4  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:119: warning: C3, C4  false
 type-tests.isSubtype.chpl:120: warning: C4, C1  true
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:120: warning: C4, C1  true
 type-tests.isSubtype.chpl:121: warning: C4, C2  true
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:121: warning: C4, C2  true
 type-tests.isSubtype.chpl:122: warning: C4, C3  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:122: warning: C4, C3  false
 type-tests.isSubtype.chpl:123: warning: C4, C4  false
 type-tests.isSubtype.chpl:125: warning: isProperSubtype - records
 type-tests.isSubtype.chpl:126: warning: R1, R1  false
 type-tests.isSubtype.chpl:127: warning: R1, R2  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:127: warning: R1, R2  false
 type-tests.isSubtype.chpl:128: warning: R1, R3  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:128: warning: R1, R3  false
 type-tests.isSubtype.chpl:129: warning: R1, R4  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:129: warning: R1, R4  false
 type-tests.isSubtype.chpl:130: warning: R2, R1  true
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:130: warning: R2, R1  true
 type-tests.isSubtype.chpl:131: warning: R2, R2  false
 type-tests.isSubtype.chpl:132: warning: R2, R3  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:132: warning: R2, R3  false
 type-tests.isSubtype.chpl:133: warning: R2, R4  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:133: warning: R2, R4  false
 type-tests.isSubtype.chpl:134: warning: R3, R1  true
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:134: warning: R3, R1  true
 type-tests.isSubtype.chpl:135: warning: R3, R2  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:135: warning: R3, R2  false
 type-tests.isSubtype.chpl:136: warning: R3, R3  false
 type-tests.isSubtype.chpl:137: warning: R3, R4  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:137: warning: R3, R4  false
 type-tests.isSubtype.chpl:138: warning: R4, R1  true
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:138: warning: R4, R1  true
 type-tests.isSubtype.chpl:139: warning: R4, R2  true
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:139: warning: R4, R2  true
 type-tests.isSubtype.chpl:140: warning: R4, R3  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:140: warning: R4, R3  false
 type-tests.isSubtype.chpl:141: warning: R4, R4  false
 type-tests.isSubtype.chpl:143: warning: isProperSubtype - mixing up
 type-tests.isSubtype.chpl:144: warning: real,     D1.type  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:144: warning: real,     D1.type  false
 type-tests.isSubtype.chpl:145: warning: real,     AA1.type false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:145: warning: real,     AA1.type false
 type-tests.isSubtype.chpl:146: warning: real,     C1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:146: warning: real,     C1       false
 type-tests.isSubtype.chpl:147: warning: real,     R1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:147: warning: real,     R1       false
 type-tests.isSubtype.chpl:148: warning: real,     U1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:148: warning: real,     U1       false
 type-tests.isSubtype.chpl:149: warning: D1.type,  real     false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:149: warning: D1.type,  real     false
 type-tests.isSubtype.chpl:150: warning: D1.type,  D1.type  false
 type-tests.isSubtype.chpl:151: warning: D1.type,  AA1.type false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:151: warning: D1.type,  AA1.type false
 type-tests.isSubtype.chpl:152: warning: D1.type,  C1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:152: warning: D1.type,  C1       false
 type-tests.isSubtype.chpl:153: warning: D1.type,  R1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:153: warning: D1.type,  R1       false
 type-tests.isSubtype.chpl:154: warning: D1.type,  U1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:154: warning: D1.type,  U1       false
 type-tests.isSubtype.chpl:155: warning: AA1.type, real     false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:155: warning: AA1.type, real     false
 type-tests.isSubtype.chpl:156: warning: AA1.type, D1.type  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:156: warning: AA1.type, D1.type  false
 type-tests.isSubtype.chpl:157: warning: AA1.type, AA1.type false
 type-tests.isSubtype.chpl:158: warning: AA1.type, C        false
 type-tests.isSubtype.chpl:159: warning: AA1.type, R        false
 type-tests.isSubtype.chpl:160: warning: AA1.type, U1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:160: warning: AA1.type, U1       false
 type-tests.isSubtype.chpl:161: warning: C1,       real     false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:161: warning: C1,       real     false
 type-tests.isSubtype.chpl:162: warning: C1,       D1.type  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:162: warning: C1,       D1.type  false
 type-tests.isSubtype.chpl:163: warning: C1,       AA1.type false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:163: warning: C1,       AA1.type false
 type-tests.isSubtype.chpl:164: warning: C1,       R1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:164: warning: C1,       R1       false
 type-tests.isSubtype.chpl:165: warning: C1,       U1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:165: warning: C1,       U1       false
 type-tests.isSubtype.chpl:166: warning: R1,       real     false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:166: warning: R1,       real     false
 type-tests.isSubtype.chpl:167: warning: R1,       D1.type  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:167: warning: R1,       D1.type  false
 type-tests.isSubtype.chpl:168: warning: R1,       AA1.type false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:168: warning: R1,       AA1.type false
 type-tests.isSubtype.chpl:169: warning: R1,       C1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:169: warning: R1,       C1       false
 type-tests.isSubtype.chpl:170: warning: R1,       U1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:170: warning: R1,       U1       false
 type-tests.isSubtype.chpl:171: warning: U1,       real     false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:171: warning: U1,       real     false
 type-tests.isSubtype.chpl:172: warning: U1,       D1.type  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:172: warning: U1,       D1.type  false
 type-tests.isSubtype.chpl:173: warning: U1,       AA1.type false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:173: warning: U1,       AA1.type false
 type-tests.isSubtype.chpl:174: warning: U1,       C1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:174: warning: U1,       C1       false
 type-tests.isSubtype.chpl:175: warning: U1,       R1       false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:175: warning: U1,       R1       false
 type-tests.isSubtype.chpl:178: warning: U1, U2  false
 type-tests.isSubtype.chpl:179: warning: U1, U2  false
+Note: This source location is a guess.
 type-tests.isSubtype.chpl:179: warning: U1, U2  false
 type-tests.isSubtype.chpl:181: error: done

--- a/test/variables/sungeun/refvar-assign-with-cast.bad
+++ b/test/variables/sungeun/refvar-assign-with-cast.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+refvar-assign-with-cast.chpl:2: internal error: FUN5235 chpl Version 1.11.0.e5a07fc
 
-refvar-assign-with-cast.chpl:2: internal error: FUN5221 chpl Version 1.11.0.559e3c7
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/variables/vass/ref-to-const-domain.bad
+++ b/test/variables/vass/ref-to-const-domain.bad
@@ -1,7 +1,7 @@
- Unfortunately the Chapel compiler has encountered
- an internal error. Please file a bug report that
- includes a program reproducing the problem as well
- as this output. See http://chapel.cray.com/getinvolved.html for
- further instructions on filing bug reports.
+ref-to-const-domain.chpl:5: internal error: FUN5235 chpl Version 1.11.0.e5a07fc
 
-ref-to-const-domain.chpl:5: internal error: FUN5221 chpl Version 1.11.0.559e3c7
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+


### PR DESCRIPTION
This changes the way we print internal errors, drawing a bigger distinction between the user's view and the developer's view.  It also reorders elements of what we print and rewords the message we print for users.

Previous to this commit, a user's internal error would look like:

     Unfortunately the Chapel compiler has encountered
     an internal error. Please file a bug report that
     includes a program reproducing the problem as well
     as this output. See http://chapel.cray.com/getinvolved.html for
     further instructions on filing bug reports.

     The error may be related to this location:
     $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:188
    $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:188: internal error: AST0614 chpl Version 1.11.0.21dc621

and a developer's view would look like:

     Unfortunately the Chapel compiler has encountered
     an internal error. Please file a bug report that
     includes a program reproducing the problem as well
     as this output. See http://chapel.cray.com/getinvolved.html for
     further instructions on filing bug reports.
    
     The error may be related to this location:
     $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:188
    $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:188: [source location guessed] internal error: assertion error [astutil.cpp:614]


With this change, the user's view is:

    $CHPL_HOME/modules/internal/DefaultRectangular.chpl:751: In iterator 'these':
    $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:163: internal error: PRI0236 chpl Version 1.11.0.52b3f06
    
    Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
    and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
    please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
    the filename + line number above may be useful in working around the issue.

And the developer's view is:

    $CHPL_HOME/modules/internal/DefaultRectangular.chpl:751: In iterator 'these':
    $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:163: internal error: bad member primitive [primitive.cpp:236]

With this change, we also now print out a note about a source location being a guess for all error types whereas before we only did it for internal errors.  This required updating two .goods that now reflect guessed locations.  (Note: A "guessed" location is one in which no AST was passed in with the error, so the location set by SET_LINENO() is used instead).

While here, I also enabled a user to throw --print-callstack-on-error without throwing --devel, because I find one of the most useful flags and often suggest users utilize it.  Though I knew that it was a developer flag, I didn't realize that its capability was disabled for users -- I thought it was only not documented (note that I haven't changed anything in terms of its documentation).

Updated .bads for .futures that are sensitive to the internal error messages.

Updated the .good for a test that reflects the current developer error message.

TODO: Create the bugs.html web page.

