### PR TITLE
Fix 16 node xc annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -65,12 +65,12 @@ all:
     - new 1-pass implementation of widening
   08/13/15:
     - text: remove restriction of soft-threads to 16 only
-      config: 16-node-xc
+      config: 16 node XC
   08/18/15:
     - fix task counting for coforall+on
   08/26/15:
     - text: re-enable optimization of op= in local blocks
-      config: 16-node-xc
+      config: 16 node XC
   09/01/15:
     - parallel array initialization
   09/02/15:
@@ -79,7 +79,7 @@ all:
     - domains of formal array args no longer mean reindex
   09/08/15:
     - text: localization optimization for endcounts
-      config: 16-node-xc
+      config: 16 node XC
   09/09/15:
     - text: ubuntu update to 15.04 (gcc upgraded to 4.9.2)
       config: shootout


### PR DESCRIPTION
I mistakenly told Brad to use "16-node-xc" as the configuration name, but it
should actually have been "16 node XC"