### PR TITLE
Reduce problem size for ri-4-arrdom.chpl

### DIFF
--- a/test/distributions/robust/arithmetic/intents/ri-4-arrdom.chpl
+++ b/test/distributions/robust/arithmetic/intents/ri-4-arrdom.chpl
@@ -3,9 +3,9 @@
 use driver;
 
 config var
-  r = 15000,  // how many times to repeat
+  r = 5000,   // how many times to repeat
   d = n2,     // each dimension of the domain and array
-  f = 5000;   // frequency of reports, 0 if none
+  f = 1000;   // frequency of reports, 0 if none
 
 var nErr = 0;
 

--- a/test/distributions/robust/arithmetic/intents/ri-4-arrdom.good
+++ b/test/distributions/robust/arithmetic/intents/ri-4-arrdom.good
@@ -1,5 +1,7 @@
-starting  15000 tests  100 size
+starting  5000 tests  100 size
+1000 tests
+2000 tests
+3000 tests
+4000 tests
 5000 tests
-10000 tests
-15000 tests
-done  15000 tests  100 size   all good
+done  5000 tests  100 size   all good


### PR DESCRIPTION
... so it does not time out.

Interesting that reducing 'r' by 3x results
in faster test execution than reducing 'n2' by 2x
(and so n2**2 by 4x).

Still skipif-ing cyclic (takes a lot longer)
and blockcyclic (reports a compiler error
with 32-bit index types).