### PR TITLE
Fix this autoCopyWithBegin.bad

### DIFF
--- a/test/parallel/begin/sungeun/autoCopyWithBegin.bad
+++ b/test/parallel/begin/sungeun/autoCopyWithBegin.bad
@@ -1,4 +1,4 @@
-autoCopyWithBegin.chpl:15: internal error: CALnnnnfc
+autoCopyWithBegin.chpl:15: internal error: CALnnnn
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 


### PR DESCRIPTION
Somehow, it seems that I added a couple of extra characters to this .bad
after testing yesterday, breaking the .bad diff (?).
