### PR TITLE
Free heap allocated variables used in cobegin and coforall statements

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -551,10 +551,9 @@ static void
 freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
   Vec<FnSymbol*> fnsContainingTaskll;
 
-  // start with the functions created from begin, cobegin, and coforall statements
+  // start with functions created by begin statements
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->hasFlag(FLAG_BEGIN) || fn->hasFlag(FLAG_COBEGIN_OR_COFORALL) ||
-        fn->hasFlag(FLAG_NON_BLOCKING))
+    if (fn->hasFlag(FLAG_BEGIN))
       fnsContainingTaskll.add(fn);
   }
   // add any functions that call the functions added so far
@@ -589,8 +588,8 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
 
   forv_Vec(Symbol, var, heapAllocatedVars) {
     // find out if a variable that was put on the heap could be passed in as an
-    // argument to a function created from a begin, cobegin, or coforall statement;
-    // if not, free the heap memory just allocated at the end of the block
+    // argument to a function created by a begin statement; if not, free the
+    // heap memory just allocated at the end of the block
     Vec<SymExpr*>* defs = defMap.get(var);
     if (defs == NULL) {
       INT_FATAL(var, "Symbol is never defined.");

--- a/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
+++ b/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	1216 bytes leaked
 Create domain and array:
-	2408 bytes leaked
+	2392 bytes leaked
 total:
-	8470 bytes leaked
+	8454 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	1216 bytes leaked
 Create domain and array:
-	2416 bytes leaked
+	2400 bytes leaked
 total:
-	7406 bytes leaked
+	7390 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,9 +43,9 @@ Return domain map:
 Create domain:
 	1520 bytes leaked
 Create domain and array:
-	3648 bytes leaked
+	3632 bytes leaked
 total:
-	6318 bytes leaked
+	6302 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
@@ -55,6 +55,6 @@ Return domain map:
 Create domain:
 	2184 bytes leaked
 Create domain and array:
-	3512 bytes leaked
+	3496 bytes leaked
 total:
-	7502 bytes leaked
+	7486 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.lm-numa.good
+++ b/test/memory/sungeun/refCount/domainMaps.lm-numa.good
@@ -7,9 +7,9 @@ Return domain map:
 Create domain:
 	0 bytes leaked
 Create domain and array:
-	16 bytes leaked
+	0 bytes leaked
 total:
-	302 bytes leaked
+	286 bytes leaked
 Block Dist
 ==========
 Copy of domain map:
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	288 bytes leaked
 Create domain and array:
-	1152 bytes leaked
+	1136 bytes leaked
 total:
-	1726 bytes leaked
+	1710 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	288 bytes leaked
 Create domain and array:
-	1160 bytes leaked
+	1144 bytes leaked
 total:
-	2022 bytes leaked
+	2006 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -41,11 +41,11 @@ Copy of domain map:
 Return domain map:
 	96 bytes leaked
 Create domain:
-	1168 bytes leaked
+	592 bytes leaked
 Create domain and array:
-	2984 bytes leaked
+	2392 bytes leaked
 total:
-	4678 bytes leaked
+	3510 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
@@ -55,6 +55,6 @@ Return domain map:
 Create domain:
 	408 bytes leaked
 Create domain and array:
-	1256 bytes leaked
+	1240 bytes leaked
 total:
-	2662 bytes leaked
+	2646 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.no-local.good
+++ b/test/memory/sungeun/refCount/domainMaps.no-local.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	1216 bytes leaked
 Create domain and array:
-	2408 bytes leaked
+	2392 bytes leaked
 total:
-	8470 bytes leaked
+	8454 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	1216 bytes leaked
 Create domain and array:
-	2416 bytes leaked
+	2400 bytes leaked
 total:
-	7406 bytes leaked
+	7390 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,9 +43,9 @@ Return domain map:
 Create domain:
 	1520 bytes leaked
 Create domain and array:
-	3648 bytes leaked
+	3632 bytes leaked
 total:
-	6318 bytes leaked
+	6302 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
@@ -55,6 +55,6 @@ Return domain map:
 Create domain:
 	2184 bytes leaked
 Create domain and array:
-	3512 bytes leaked
+	3496 bytes leaked
 total:
-	7502 bytes leaked
+	7486 bytes leaked


### PR DESCRIPTION
Free heap allocated variables used in cobegin and coforall statements

This will resolve all the memory leaks caused by enabling parallel array
initialization with fce777eb4224b84b17e0a965d5f2915fd130279d It also reduces
the exiting memory leaks for memory/sungeun/refCount/domainMaps.

Freeing heap allocated variables was originally added with
04649adee918d0a15dc4a8f365ba83c51831c2cc and
cf2a0a0c1d4474d5ca9ca44d5cddddde20d6d3f7. However, this code was careful to not
free heap allocated variables if they could be used by a task function (begin,
cobegin, coforall)

This was to avoid freeing heap allocated variables that could still be in use
by an asynchronous task. Prior to task intents, we would have had a really hard
time detecting if a heap allocated variable was used inside a begin that was
inside another task function. Because of this, we conservatively assumed that
any heap allocated var passed to any task function could then be passed to a
begin, so we didn't free them.

With task intents, variables used in a begin that outlive the scope they were
declared in will be passed by ref to the begin and any enclosing task
functions. Because of this we no longer need to check for cobegin/coforall
statements as we're be able to directly see if heap vars are used in a begin.

Note that this commit removes the check for FLAG_COBEGIN_OR_COFORALL and
FLAG_NON_BLOCKING. When the code to free heap variables was originally added
begin+on and coforall+on functions weren't always marked with FLAG_BEGIN or
FLAG_COBEGIN_OR_COFORALL so we also had to check the FLAG_NON_BLOCKING. Since
then the AST has been normalized and we don't have to worry about checking for
FLAG_NON_BLOCKING anymore.

Long term I think we want to free heap allocated variables used in begin
statements too. We're moving towards not automatically keeping variables used
by asynchronous tasks alive passed their lexical scope. Making this change
resulted in ~5 regressions, all of which rely on such behavior. That seems like
a big change right before code freeze so that can wait until after the release.


**As background for the memory leaks:**

The problem was that we leaked 16 bytes (a wide pointer to a DefaultRectangular
array) when we did a DefaultRectangular dsiReindex, dsiSlice, or dsiRankChange
with gasnet segment fast/large.

With gasnet segment fast/large, we heap allocate all arguments passed to on
functions (see parallel.cpp:needHeapVars)

The above functions all declare an 'alias' variable, then inside an on
statement they update 'alias', then after the on statement they return 'alias'.
This code causes 'alias' to be passed as an argument to the on function so it
gets heap-ified for gasnet fast/large.

This alias has always been heap allocated for gasnet fast/large. What changed
with the parallel init commit is that it's no longer being freed. We have code
in parallel.cpp to free heap allocated variables, however, we do not free
variables that might be used in a task function. Parallel init added a coforall
to the DefaultRectangular initialization code, so we're no longer freeing the
wide pointer to 'alias'.

Another way to resolve these regressions would be to stop heap allocating on
function arguments for gasnet fast/large and rely on out of segment gets/puts
like we do for ugni. I tried this, but every test that actually uses two or
more locales segfaulted at runtime. I believe that our our support for gasnet
out of segment gets/puts needs more work. This is not code that I'm familiar
with yet and it seems like it would be a big change this close to code freeze.