### PR TITLE
Fix read style

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3770,7 +3770,7 @@ pragma "no doc"
 proc channel.read(ref args ...?k,
                   style:iostyle):bool {
   var e:syserr = ENOERR;
-  this.read((...args), style=iostyle, error=e);
+  this.read((...args), style=style, error=e);
   if !e then return true;
   else if e == EEOF then return false;
   else {

--- a/test/io/ferguson/CLEANFILES
+++ b/test/io/ferguson/CLEANFILES
@@ -1,3 +1,4 @@
 asserteof.test.nums
 error.data
 binary-output.bin
+test_file.txt

--- a/test/io/ferguson/read-style.chpl
+++ b/test/io/ferguson/read-style.chpl
@@ -1,0 +1,18 @@
+use IO;
+
+var file_name = "test_file.txt";
+var writer = open( file_name, iomode.cw ).writer();
+
+writer.writeln( "This is the first line" );
+writer.writeln( "Isnt this easy?." );
+writer.writeln( "Right! lets add our third and last line." );
+writer.close();
+
+var reader = open( file_name, iomode.r ).reader();
+
+var line_style = new iostyle();
+var line: string;
+line_style.string_format = QIO_STRING_FORMAT_TOEND;
+line_style.string_end = 0x0a; // ascii newline.
+while( reader.read( line, style=line_style ) ) do writeln( line );
+

--- a/test/io/ferguson/read-style.good
+++ b/test/io/ferguson/read-style.good
@@ -1,0 +1,6 @@
+This is the first line
+
+Isnt this easy?.
+
+Right! lets add our third and last line.
+


### PR DESCRIPTION
Fix bug in channel.read(style)
    
It was calling this.read with a type (iostyle) instead of its style argument.

Add test case for read with a style based on the bug report.


Thanks to @ian-bertolacci for pointing out this bug and its fix.

Trivial and not reviewed.
