### PR TITLE
Make some tests no longer sensitive to internal line numbers

### DIFF
--- a/test/trivial/diten/testIntExp4.good
+++ b/test/trivial/diten/testIntExp4.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:463: error: 0 cannot be raised to a negative power
+$CHPL_HOME/modules/internal/ChapelBase.chpl:: error: 0 cannot be raised to a negative power
 Note: This source location is a guess.

--- a/test/trivial/diten/testIntExp4.prediff
+++ b/test/trivial/diten/testIntExp4.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+output=$2
+cat $output | sed 's@:[0-9]*:@::@' > $output.tmp
+mv $output.tmp $output

--- a/test/users/vass/tuple-crash-1.bad
+++ b/test/users/vass/tuple-crash-1.bad
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:172: internal error: FUN2570 chpl Version 1.11.0.e5a07fc
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: internal error: FUN2570 chpl Version mmmm
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/users/vass/tuple-crash-1.prediff
+++ b/test/users/vass/tuple-crash-1.prediff
@@ -1,3 +1,5 @@
 #!/bin/bash
-sed "s/^\(internal error: FUN\).*$/\1/" < $2 > $2.tmp
-mv $2.tmp $2
+
+output=$2
+cat $output | sed 's@ChapelBase.chpl:[0-9]*:@::@' > $output.tmp
+mv $output.tmp $output

--- a/test/users/vass/tuple-crash-1.prediff
+++ b/test/users/vass/tuple-crash-1.prediff
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed 's@ChapelBase.chpl:[0-9]*:@::@' > $output.tmp
-mv $output.tmp $output


### PR DESCRIPTION
* Added a prediff for test/trivial/diten/testIntExp4 so that it is not sensitive to ChapelBase line numbers
* Removed prediff from test/users/vass/tuple-crash-1.bad since diff-ignoring-module-line-numbers already removes internal line numbers (and does a better job at it)