### PR TITLE
Make testIntExp4 no longer sensitive to ChapelBase line #s

### DIFF
--- a/test/trivial/diten/testIntExp4.good
+++ b/test/trivial/diten/testIntExp4.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:463: error: 0 cannot be raised to a negative power
+$CHPL_HOME/modules/internal/ChapelBase.chpl:: error: 0 cannot be raised to a negative power
 Note: This source location is a guess.

--- a/test/trivial/diten/testIntExp4.prediff
+++ b/test/trivial/diten/testIntExp4.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+output=$2
+cat $output | sed 's@:[0-9]*:@::@' > $output.tmp
+mv $output.tmp $output


### PR DESCRIPTION
This test expects an error from an internal module. That could be improved upon,
but at least we'd like it not to cause testing noise if the internal module
line number changes.