### PR TITLE
Remove numa specific .good files for memory/figueroa/LeakedMemory[2, 5, 6]

### DIFF
--- a/test/memory/figueroa/LeakedMemory2.lm-numa.good
+++ b/test/memory/figueroa/LeakedMemory2.lm-numa.good
@@ -1,2 +1,0 @@
-Amount of leaked memory after calling foo(): 16
-sum is 102

--- a/test/memory/figueroa/LeakedMemory5.lm-numa.good
+++ b/test/memory/figueroa/LeakedMemory5.lm-numa.good
@@ -1,4 +1,0 @@
-1 1 1 1
-Amount of leaked memory after calling foo(): 32
-sum is 100
-0 1 1 1 1

--- a/test/memory/figueroa/LeakedMemory6.lm-numa.good
+++ b/test/memory/figueroa/LeakedMemory6.lm-numa.good
@@ -1,4 +1,0 @@
-1 1 1 1
-Amount of leaked memory after calling foo(): 32
-sum is 100
-0 1 1 1 1


### PR DESCRIPTION
With daf0a0de605fb63e91b18ab5a8bb1dd63b52bb98 we free more variables allocated
on the heap. This reduced numa leaks for memory/figueroa/LeakedMemory[2, 5, 6]
to the point that the leaks are the same as every other configuration. This
means that the numa specific .good files are no longer needed.