### PR TITLE
Update `checkChplInstall`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,7 @@ Release Changes List
 ====================
 
 ==============
-version 1.11.0
+version 1.12.0
 ==============
 
 Fourteenth public release of Chapel, April 2, 2015

--- a/GOALS
+++ b/GOALS
@@ -1,5 +1,5 @@
 ============================================
-Chapel Public Release Goals (version 1.11.0)
+Chapel Public Release Goals (version 1.12.0)
 ============================================
 
 The goals of this release are as follows:

--- a/README
+++ b/README
@@ -2,7 +2,7 @@
 Chapel Compiler Release: README
 ===============================
 
-This is the 1.11.0 release of the Chapel compiler, intended to give
+This is the 1.12.0 release of the Chapel compiler, intended to give
 potential users a look at what we're doing and the opportunity to
 provide us with feedback.  See the LICENSE file for the release's
 licensing terms.
@@ -23,7 +23,7 @@ capabilities in the interest of a simple and clean build.
 1) Make sure that your shell is in the directory containing this
    README file.  For example:
 
-        cd ~/chapel-1.11.0
+        cd ~/chapel-1.12.0
 
 
 2) Set up your environment to use Chapel in "Quick Start" mode.

--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -21,7 +21,7 @@
 #define _version_num_H_
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION "11"
+#define MINOR_VERSION "12"
 #define UPDATE_VERSION "0"
 
 static const char* BUILD_VERSION =

--- a/doc/release/README
+++ b/doc/release/README
@@ -69,7 +69,7 @@ reST files are rendered as nicely formatted HTML automatically.
 You can navigate to the root of the documentation for this release using
 the URL
 
-https://github.com/chapel-lang/chapel/blob/1.11.0/doc/release
+https://github.com/chapel-lang/chapel/blob/1.12.0/doc/release
 
 
 --------------------

--- a/doc/release/README.chplenv
+++ b/doc/release/README.chplenv
@@ -25,7 +25,7 @@ Recommended Settings
    release.  This is the parent of the directory containing this file.
    For example:
 
-        export CHPL_HOME=~/chapel-1.11.0
+        export CHPL_HOME=~/chapel-1.12.0
 
    [This, and all other examples in Chapel READMEs, assumes you're
     using the 'bash' shell.  If using 'csh' or 'tcsh', mentally change

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- Version 1.11.0
+ Version 1.12.0

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -97,12 +97,18 @@ TEST_COMP_OUT=${TEST_JOB}.comp.out
 COMP_FLAGS="--cc-warnings"
 
 # Compile test job into temporary directory
+echo "Compiling \$CHPL_HOME/${TEST_DIR}/${TEST_JOB}.chpl"
 ${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} > ${TMP_TEST_DIR}/${TEST_COMP_OUT} 2>&1
 
 # Check that compile was successful
 COMPILE_STATUS=$?
 if [ ${COMPILE_STATUS} -ne 0 ]; then
-    err "Test job failed to compile, Chapel is not installed correctly"
+    err "Test job failed to compile - Chapel is not installed correctly"
+    echo "Compilation output:"
+    cat ${TMP_TEST_DIR}/${TEST_COMP_OUT}
+    exit 1
+elif [ -s ${TMP_TEST_DIR}/${TEST_COMP_OUT} ]; then
+    err "Test job compiled with output - Chapel is not installed correctly"
     echo "Compilation output:"
     cat ${TMP_TEST_DIR}/${TEST_COMP_OUT}
     exit 1
@@ -128,11 +134,11 @@ fi
 
 # Check for valid launchers
 if [ ${chpl_launcher} == "slurm-srun" -o ${chpl_launcher} == "amudprun" -o ${chpl_launcher} == "none" ]; then
-    echo "Launcher, \$CHPL_LAUNCHER = ${chpl_launcher}, is compatible with test script"
+    echo "\$CHPL_LAUNCHER = ${chpl_launcher} - this is compatible with test script."
 else
-    echo "This script is not compatible with the \$CHPL_LAUNCHER value of ${chpl_launcher}"
-    echo "This does not necessarily indicate that your Chapel installation is incorrect"
-    echo "See \$CHPL_HOME/doc/README.launcher for more information on how to manually run a Chapel program"
+    echo "\$CHPL_LAUNCHER = ${chpl_launcher} - this is not compatible with test script."
+    echo "This does not necessarily indicate that your Chapel installation is incorrect."
+    echo "See \$CHPL_HOME/doc/README.launcher for more information on how to manually run a Chapel program."
     exit 10
 fi
 
@@ -144,26 +150,26 @@ TEST_EXEC_OUT=${TEST_JOB}.exec.out
 
     EXEC_OPTS="$(cat ${TEST_DIR}/${TEST_JOB}.execopts)"
 
-    echo "Running test job"
+    echo "Running test job."
     ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} > ${TEST_EXEC_OUT} 2>&1
-    echo "Test job complete"
+    echo "Test job complete."
 
-    # Quick test to verify fail case
-    #echo "this should break the test" >> ${TEST_EXEC_OUT}
+    # Check result
+    DIFF_OUTPUT=$(diff -q ${TEST_EXEC_OUT} ${GOOD})
 
+    # Return success code (0) if diff is good
+    if [ -z "${DIFF_OUTPUT}" ]; then
+        echo "Installation works as expected!"
+        exit 0
+    else
+        # Rerun test job with -v flag to help user identify discrepancy
+        echo "There was an issue with the installation, test job output incorrect."
+        echo ""
+        echo "== Verbose Test Job Execution Output =="
+        ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} -v
+        echo ""
+        echo "== Diff Log =="
+        echo "$(diff ${TEST_EXEC_OUT} ${GOOD})"
+        exit 10
+    fi
 )
-
-# Check result
-DIFF_OUTPUT=$(diff -q ${TMP_TEST_DIR}/${TEST_EXEC_OUT} ${GOOD})
-
-# Return 0 if diff is good
-if [ -z "${DIFF_OUTPUT}" ]; then
-    echo "Installation works as expected!"
-    exit 0
-else
-    echo "There was an issue with the installation, test job output incorrect"
-    echo "== Log =="
-    echo "diff ${TMP_TEST_DIR}/${TEST_EXEC_OUT} ${GOOD}"
-    echo "$(diff ${TMP_TEST_DIR}/${TEST_EXEC_OUT} ${GOOD})"
-    exit 10
-fi


### PR DESCRIPTION
In response to comments by @mppf in the previous [pull request](https://github.com/chapel-lang/chapel/pull/2487), `checkChplInstall` was further updated:

- If there is any output from the test job compilation, fail the test.
- If there is any discrepancy with the execution output, rerun test job with `-v` to help user solve their problem.
- More clear and consistent error messages.