### PR TITLE
Fixing a segfault in the glob() iterator when it's a follower

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -819,8 +819,8 @@ iter glob(pattern: string = "*", followThis, param tag: iterKind): string
   if (err != 0 && err != GLOB_NOMATCH) then
     __primitive("chpl_error", "unhandled error in glob()");
   const num = chpl_glob_num(glb);
-  if (r.high > num.safeCast(int)) then
-    halt("glob() iterator zipped with something too big");
+  if (r.high >= num.safeCast(int)) then
+    halt("glob() is being zipped with something too big; it only has ", num, " matches");
   for i in r do
     //
     // safe cast is used here to turn an int into a size_t

--- a/test/modules/standard/FileSystem/filerator/bradc/testemptyglob.chpl
+++ b/test/modules/standard/FileSystem/filerator/bradc/testemptyglob.chpl
@@ -12,8 +12,5 @@ forall (file,i) in zip(glob("*.goo"), 1..) do
 forall (i,file) in zip(1..0, glob("*.goo")) do
   writeln("file ", i, " is ", file);
 
-// When here.maxTaskPar was >= 10, the following loop segfaulted ~50% of the
-// time. I have no idea why, but I wanted to quiet the regression. See the
-// history for more details.
-forall (i,file) in zip(1..here.maxTaskPar+1, glob("*.goo")) do
+forall (i,file) in zip(1..10, glob("*.goo")) do
   writeln("file ", i, " is ", file);

--- a/test/modules/standard/FileSystem/filerator/bradc/testemptyglob.good
+++ b/test/modules/standard/FileSystem/filerator/bradc/testemptyglob.good
@@ -1,1 +1,1 @@
-testemptyglob.chpl:18: error: halt reached - glob() iterator zipped with something too big
+testemptyglob.chpl:18: error: halt reached - glob() is being zipped with something too big; it only has 0 matches

--- a/test/modules/standard/FileSystem/filerator/bradc/testemptyglob.good
+++ b/test/modules/standard/FileSystem/filerator/bradc/testemptyglob.good
@@ -1,1 +1,1 @@
-testemptyglob.chpl:18: error: halt reached - glob() is being zipped with something too big; it only has 0 matches
+testemptyglob.chpl:15: error: halt reached - glob() is being zipped with something too big; it only has 0 matches


### PR DESCRIPTION
[reviewed and code reviewed by @ronawho]

Due to an off-by-one error, the glob() iterator would sometimes
segfault when asked to be follow the range 0..0.  Specifically,
I was forgetting to take the 0-shifting of the followThis range
into account and so would think that it was OK to follow 0..0
(a 1-element range) when there were 0 matches on the glob() call.
This would then cause us to request the initial match, but there
weren't any, so a segfault would occur.  This would happen
nondeterministically when the number of tasks was greater than
10 when following the range 1..10 depending on whether the task
that owned 0..0 executed before or after another task that
would complain that there were not enough iterations.

While here, I updated the error message slightly to give more
information.

This is a second attempt at this issue -- the first was at
PR #2516