### PR TITLE
Changed chplvis/prog3.good to match the output

### DIFF
--- a/test/release/examples/primers/chplvis/prog3.comm-none.good
+++ b/test/release/examples/primers/chplvis/prog3.comm-none.good
@@ -1,3 +1,3 @@
 Jacobi computation complete.
-Delta is 9.81084e-05 (< epsilon = 0.0001)
-# of iterations: 124
+Delta is 9.74452e-05 (< epsilon = 0.0001)
+# of iterations: 89


### PR DESCRIPTION
The output of  prog3.chpl  that I am observing
did not match   prog3.comm-none.good
I am updating the .good to match the observed output
to reduce the chance of noise in nightly testing.

@tomyhoi  needs to look more closely
to see whether there is a bug somewhere.
