### PR TITLE
Remove extra writelns in barrier comm diags test

### DIFF
--- a/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
@@ -45,20 +45,16 @@ proc remoteTestSplitPhase(b: Barrier, numRemoteTasks) {
 }
 
 var b = new Barrier(numRemoteTasks);
-writeln("atomic remote test basic");
 remoteTestBasic(b, numRemoteTasks);
 
 b.reset(numRemoteTasks);
-writeln("atomic remote test split phase");
 remoteTestSplitPhase(b, numRemoteTasks);
 delete b;
 
 var sb1 = new Barrier(numRemoteTasks, BarrierType.Sync);
-writeln("sync remote test basic");
 remoteTestBasic(sb1, numRemoteTasks);
 delete sb1;
 
 var sb2 = new Barrier(numRemoteTasks, BarrierType.Sync);
-writeln("sync remote test split phase");
 remoteTestSplitPhase(sb2, numRemoteTasks);
 delete sb2;


### PR DESCRIPTION
Brad committed this on behalf of David, but it looks like there are some extra
debug writelns. At least I think they were just for debugging, it's possible I
should have instead updated the .good files. This is easier though, and I just
want to make sure it doesn't regress tomorrow.