### PR TITLE
Update chplvis prog4 comm-none.good now that prediff is executable

### DIFF
--- a/test/release/examples/primers/chplvis/prog4.comm-none.good
+++ b/test/release/examples/primers/chplvis/prog4.comm-none.good
@@ -1,2 +1,2 @@
-Hello from 0
 Finishing running the 'begin' statement on locale 0.
+Hello from 0


### PR DESCRIPTION
I didn't think to check that the comm-none.good file was still right after
making the prediff executable.