### PR TITLE
Fix inconsistency with continued tasks and main.

### DIFF
--- a/tools/chplvis/DataModel.cxx
+++ b/tools/chplvis/DataModel.cxx
@@ -1091,6 +1091,7 @@ taskData * DataModel::getTaskData (long locale, long taskId, long tagNo)
   std::map<long,taskData>::iterator tskItr;
   long curTag;
 
+  // may not be taskId 1 ... has been so far.
   if (locale == 0 && taskId == 1)
     return &mainTask;
 

--- a/tools/chplvis/DataModel.h
+++ b/tools/chplvis/DataModel.h
@@ -203,6 +203,10 @@ class DataModel {
   }
 
   taskData * getTaskData (long locale, long taskId, long tagNo = TagALL);
+
+  double start_clock() {
+    return (*theEvents.begin())->clock_time();
+  }
   
   // Constructor for DataModel
   

--- a/tools/chplvis/Event.h
+++ b/tools/chplvis/Event.h
@@ -167,8 +167,9 @@ class E_fork : public Event {
 
      virtual int Ekind() {return Ev_fork;}
      virtual void print() {
-       printf ("Fork%s: node %d time %ld.%06ld to %d datasize %d\n",
-               (isFast ? "(fast)" : ""), nodeid, sec, usec, dstid, argsize);
+       printf ("Fork%s: node %d time %ld.%06ld to %d datasize %d by task %ld\n",
+               (isFast ? "(fast)" : ""), nodeid, sec, usec, dstid,
+               argsize, byTask);
      }
 };
 


### PR DESCRIPTION
Adds code to have main and continued tasks behave the same as all other tasks in the concurrency window, with the same tooltips and showing forks, gets and puts if it has any.

Updated an event to print task id.