### PR TITLE
Quiet parallel/forall/vass/memleaks* regression

### DIFF
--- a/test/parallel/forall/vass/memleaks1-minimal.chpl
+++ b/test/parallel/forall/vass/memleaks1-minimal.chpl
@@ -7,8 +7,10 @@ proc main() {
   var MY_VAR = 1;
   const m1 = memoryUsed();
 
-  forall idx in MYITER() do
-    useMe(MY_VAR);
+  // serial to quiet a sporadic (1 in 1000) regression (see JIRA issue 112)
+  serial do
+    forall idx in MYITER() do
+      useMe(MY_VAR);
 
   const m2 = memoryUsed();
   writeln("leaked: ", m2-m1);

--- a/test/parallel/forall/vass/memleaks2-BlockDist.chpl
+++ b/test/parallel/forall/vass/memleaks2-BlockDist.chpl
@@ -11,8 +11,10 @@ proc main() {
   var myvar = initval;
   const m1 = memoryUsed();
 
-  forall da in DARRAY do
-    da = myvar;
+  // serial to quiet a sporadic (1 in 1000) regression (see JIRA issue 112)
+  serial do
+    forall da in DARRAY do
+      da = myvar;
 
   const m2 = memoryUsed();
 


### PR DESCRIPTION
I had to run ~1000 times to see the regression so it appears to be very
sporadic and we were unlucky enough for it to occur on the first night of
testing.

This adds a serial to the forall statements to quiet the regressions. Serial
was attached to the forall in memleaks2-BlockDist, but I thought I could remove
it in 880d1520e57c8b9979d4ea9fce47e48dc520f22e. I'm re-adding that and adding
it to memleaks1-minimal as well.

See JIRA issue 112: https://chapel.atlassian.net/browse/CHAPEL-112