### PR TITLE
Have start_test check for existing mem leaks file.

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -625,7 +625,11 @@ def set_up_environment():
     # memory leak log
     if args.mem_leaks_log:
         os.environ["CHPL_MEM_LEAK_TESTING"] = "true"
-        args.execopts += " --memLeaksLog=" + os.path.abspath(args.mem_leaks_log)
+        memleaksfile = os.path.abspath(args.mem_leaks_log)
+        args.execopts += " --memLeaksLog=" + memleaksfile
+        if os.path.isfile(memleaksfile):
+            logger.write("[Error: mem leaks log file already exists: {0}]"
+                         .format(memleaksfile))
 
     # create temporary directory
     global chpl_test_tmp_dir


### PR DESCRIPTION
When start_test is run the second time on the same mem leaks file,
e.g. when 'nightly' is killed and restarted,
it appends to that file, increasing the leaks total.
Issue an error - and proceed nonetheless - when that happens.
