### PR TITLE
Update STATUS.devel

### DIFF
--- a/STATUS.devel
+++ b/STATUS.devel
@@ -38,7 +38,7 @@ run into.
 #  b/c not investigated
 #
 # OMITTED: users/csep524/userDefReduceSlim.future
-#  b/c mutiple errors in the user code and hard to quantify what is wrong
+#  b/c multiple errors in the user code and hard to quantify what is wrong
 #
 # OMITTED: users/npadmana/fftw/testFFTWsegfault.future
 # b/c not investigated or diagnosed
@@ -56,6 +56,8 @@ General (see also portability section at the bottom of this file)
   may not be formatted correctly, or may be garbled.  If needed,
   please ask us for help finding the line in question.
   # parsing/vass/newline-in-string-compiletime-1.future
+- Errors in unused code may not be reported by the compiler
+  # users/kreider/feature_unusedcode.future
 - Names in a Chapel program can collide with names used internally.
   # modules/hilde/Writer.future
   # types/records/sungeun/chapelTypes/record_array.future
@@ -91,6 +93,8 @@ Types, Params, Variables, and Consts
 - Enum types always represented using the smallest integer type
   available, even if the enum values require a larger integer.
   # functions/bradc/resolution/badEnumDispatch.future
+- Compile time integer operations on enum values may result in non-param values
+  # users/kreider/bug_enum.future
 - Cannot define a method on sized types.
   # users/ferguson/int32method.future
 - Declaring enum types in a function body can cause compile time errors
@@ -152,7 +156,10 @@ Conversions
 - Casts to non-type variables do not result in an error at compile time.
   # expressions/vass/cast-to-non-type-1.future
   # expressions/vass/cast-to-non-type-2.future
-
+- Integer to c_string cast promotes from int to real before cast is performed
+  # types/string/thomasvandoren/int-to-c_string.future
+- Cast from string to scalar type does not ignore leading white space
+  # users/ferguson/cast_to_int_ignore_whitespace.future
 
 Statements and Expressions
 --------------------------
@@ -170,7 +177,13 @@ Statements and Expressions
   local execution.
   # multilocale/local/sungeun/local_privatization.future
   # users/jglewis/locClassSegFault.future
-
+- Nested for expressions can cause runtime failure
+  # expressions/diten/forExprs.future
+- Index variable in for expression can interfere with outer var by same name
+  # users/bguarraci/comprehension.future
+- Using domain extraction syntax inside a variable declaration causes
+  compiler failure instead of a clean error
+  # users/bguarraci/domain_extraction.future
 
 Modules
 -------
@@ -273,6 +286,9 @@ Functions and Iterators
 - Iterators with reference variables cause program to crash at runtime
   when compiled with the --baseline flag.
   # studies/shootout/nbody/sidelnik/nbody_iterator_7-refInIterator.future
+- Const checking is incorrect for standalone iterator index variables
+  # performance/vectorization/vectorizeOnly/constChecking/standaloneConstChecking.future
+  # statements/elliot/loops/modifyIndicesStandalone.future
 - The implicit 'setter' argument does not work in var iterators.
   # functions/deitz/iterators/iterator_uses_setter.future
   # functions/deitz/iterators/test_promote_var_function_and_iterate.future
@@ -301,10 +317,15 @@ Functions and Iterators
   or errors.
   # functions/bradc/paramThis/funParamThis2.future
   # functions/bradc/paramThis/funParamThis3.future
+- Formal argument intents on 'this' should not be allowed for standalone
+  procedures
+  # functions/bradc/thisIntentStandalone.future
 
 
 Strings
 -------
+# OMITTED: associative/thomasvandoren/c_string-to-string.future
+# because c_string_copy is not intended to be a user-visible type
 - String assignment across locales is sometimes by reference and
   sometimes by value.
   # distributions/bradc/block1Dlocale.future
@@ -413,6 +434,9 @@ Classes, Records, and Unions
 - Generic domain types in field declarations result in a compile time
   error.
   # domains/vass/generic-domain-field.future
+- Generic types in default value for type fields result in a compile time error
+  # functions/typeMethods/genericRecordTypeMethod.future
+  # users/ferguson/generic_type_method.future
 - Record and class members that are defined to be array aliases fail
   to compile without an explicitly specified element type.
   # classes/stonea/arrayAliasRecordMember.future
@@ -453,6 +477,8 @@ Classes, Records, and Unions
 - Function resolution may be overly conservative for methods of subclasses.
   # classes/bradc/compilerErrorInMethod/testClear.future
   # classes/diten/subclassMethodCall.future
+- Cannot call a standalone function from a class method of the same name
+  # functions/lydia/method-iter-resolution-bug.future
 - Declaring class members using type aliases may result in unresolved
   type errors.
   # arrays/deitz/part5/test_array_type_field_type.future 
@@ -471,6 +497,8 @@ Classes, Records, and Unions
 - Non-sync arguments to default constructors that expect sync vars are
   not properly coerced to sync type.
   # classes/hannah/coercingIntToSyncIntOnConstructor.future
+- Assigning to param class members from constructors may fail to compile
+  # classes/constructors/assign-param-segfault.future
 - Subclassing uninstantiated generic classes should be prohibited but is not.
 - Implicit casting of record parameters not implemented.
   # users/ferguson/recordEquivalence.future
@@ -487,6 +515,8 @@ Classes, Records, and Unions
   # types/records/vass/method-of-parent-record-1.future
 - Nested record inheritance results in a compilation error.
   # types/records/vass/nested-record-with-outer-1.future
+- Nested record constructor should not need an explicit generic outer
+  # users/bguarraci/nested_record.future
 - Unused records defined in procedures result in an internal compiler error.
   # types/records/vass/unused-decl-in-proc-1.future
   # types/records/vass/unused-decl-in-proc-2.future
@@ -533,6 +563,8 @@ Domain Maps, Domains and Arrays
   # distributions/vass/dmap-var-decl.future
   # studies/graph500/v1/main.future
   # studies/hpcc/HPL/vass/bug.future
+- The default domain map is currently a single type for all default domains
+  # distributions/bradc/layoutEquality.future
 - Distributed domain maps are currently only supported for dense,
   rectangular domains.
 - Assignment to domain maps with declared domains not supported for
@@ -558,6 +590,8 @@ Domain Maps, Domains and Arrays
 - Arrays of arrays where the inner arrays vary in size are not supported.
   # arrays/deitz/test_skyline_array.future
   # studies/590o/wk3/02arrOfArr-irregular.future
+- Array of array procedure arguments may cause compile time errors
+  # users/kreider/bug_array_of_arrays.future
 - Array values are permitted to be detupled in an iterator
   # functions/iterators/bradc/badzip/misZipArrays.future
 - Arrays of subdomains may not work.
@@ -569,6 +603,9 @@ Domain Maps, Domains and Arrays
 - Array and domain runtime type information is not preserved through
   generic instantiation.
   # arrays/vass/initialization-mapped-1.future
+- Multidimensional Domain functions 'exterior', 'interior', and 'translate'
+  that take a single scalar operand are missing.
+  # users/kreider/bug_domfn.future
 - Modifications to Sparse domains are not thread-safe.
   # domains/sungeun/sparse/forall.future
   # domains/sungeun/sparse/stress.future
@@ -619,7 +656,10 @@ Task Parallelism and Synchronization
   # types/sync/vass/autodestroy-with-begin-ref.future
 - Sync variables cannot be used in conditional expressions
   # types/sync/vass/if-sync-int.future
-
+- Default 'const ref' task intent for record does not prevent updates to sync
+  variable field in the record from within task.
+  # parallel/sync/waynew/record2.future
+  # parallel/sync/waynew/record2c.future
 
 Data Parallelism
 ----------------
@@ -681,10 +721,15 @@ Data Parallelism
   internal compiler error.
   # parallel/taskPar/vass/field-in-task-ref-clause.future
 - Iterating over a range where bound+stride overflows the index type
-  overflows can result in incorrect execution.
+  results in runtime halt
+  # users/bguarraci/for_byte.future
 - Overloaded xor used in a reduction may result in an internal
   compiler error.
   # reductions/bradc/badoverload.future
+- Zipping an associative domain with another iterator in a forall loop can
+  result in compile time errors.
+  # users/ferguson/assoc_domain_zip_range1.future
+  # users/ferguson/assoc_domain_zip_range.future
 
 
 Standard Modules, Standard Distributions, and Standard Layouts
@@ -738,6 +783,8 @@ Optimizations
 - Disabling inlining may cause incorrect code to be generated.
   # SEE NIGHTLY BASELINE TESTING NOTES
   # functions/deitz/nested/test_nested_var_iterator3.future
+- Module scope runtime constants are not replicated across locales
+  # users/bguarraci/const_locale.future
 
 
 Miscellaneous
@@ -752,11 +799,16 @@ Miscellaneous
 #  b/c it's a bit difficult to describe.
 - Nil extern class references not properly handled.
   # users/ferguson/extern_class_test.future
+- Extern functions with array arguments cannot have specified 'void' return type
+  # users/ibertolacc/void_extern_proc_array.future
 - Boolean literals do not preserve their sizes.
   # portability/boolLiteralSizes.future
 - Functions from extern includes that have naming conflicts with
   internal functions result in a back-end C compiler error.
   # extern/tzakian/shadow.future
+- Functions and variables declared with the same name at the same scope result
+  in multiple definition errors
+  # users/bguarraci/function_name.future
 - An exported function that returns a record results in two versions
   in the generated code.
   # functions/gbt/retRecordMultiDef.future
@@ -887,6 +939,8 @@ PGI compilers:
 Intel compilers:
 - Floating point literals of -0.0 may not work as intended.
 - Static linking may not work.
+# OMITTED: studies/lulesh/intelVectBug/lulesh.future
+# We suspect that there is a vectorization bug with icc
 
 IEEE floating-point standard conformance:
   The --ieee-float flag is implemented by passing appropriate flags to
@@ -895,3 +949,19 @@ IEEE floating-point standard conformance:
   flag will request the most standard conformant floating-point
   behavior (if such behavior can be identified).
 
+
+# Not Really Bugs
+# OMITTED: modules/standard/LAPACK/dgees.future
+# c_ptr(c_char) is the same signedness as the underlying c_char. I believe this
+# test is incorrect about this point.
+# OMITTED: users/bguarraci/count_type.future
+# The range count operator's argument type shouldn't change the range's index type
+# OMITTED: users/bguarraci/ref_nil_conjunction.future
+# "if (classRef) then ..." is true if not nil, but
+# "if (classRef1 && classRef2) then ..." doesn't treat each value as a boolean
+# OMITTED: users/bguarraci/sorted_access.future
+# iterator or promoted expressions cannot be accessed as arrays without
+# assigning to an array first
+# OMITTED: users/bguarraci/string_compilation.future
+# string(1) is an unresolved call to a function named string, not a cast from
+# int to string

--- a/STATUS.devel
+++ b/STATUS.devel
@@ -40,9 +40,6 @@ run into.
 # OMITTED: users/csep524/userDefReduceSlim.future
 #  b/c mutiple errors in the user code and hard to quantify what is wrong
 #
-# OMITTED: users/ferguson/override_overload.future
-#  b/c I really don't know how to describe it.
-#
 # OMITTED: users/npadmana/fftw/testFFTWsegfault.future
 # b/c not investigated or diagnosed
 
@@ -61,7 +58,6 @@ General (see also portability section at the bottom of this file)
   # parsing/vass/newline-in-string-compiletime-1.future
 - Names in a Chapel program can collide with names used internally.
   # modules/hilde/Writer.future
-  # modules/diten/module_use_hides_size_var.future
   # types/records/sungeun/chapelTypes/record_array.future
   # extern/vass/c_sublocid_any.inner-extern.future
 - There are several internal memory leaks
@@ -97,8 +93,6 @@ Types, Params, Variables, and Consts
   # functions/bradc/resolution/badEnumDispatch.future
 - Cannot define a method on sized types.
   # users/ferguson/int32method.future
-- Invoking a method directly on an enum constant results in a compiler error
-  # types/enum/vass/enum-receiver-1.future
 - Declaring enum types in a function body can cause compile time errors
   # types/enum/diten/enumDeclInFn.future
   # types/enum/diten/unusedEnumDeclInFn.future
@@ -135,10 +129,6 @@ Types, Params, Variables, and Consts
 - Attempting to instantiate a generic class in a type alias context results
   in an unresolved call error.
   # functions/vass/param-formal-in-ctor.future
-- Some symbols are incorrectly masked by other statements and an undeclared
-  symbol error is issued.
-  # functions/kbrady/proc_scoping.future
-  # modules/bradc/useFileSystemShadowsPath.future
 - Type aliases and enum declarations cannot be declared private/public.
   # visibility/private/typeAlias.future
   # visibility/private/privateEnum.future
@@ -170,9 +160,6 @@ Statements and Expressions
   # statements/diten/continueInForall.future
   # statements/sungeun/continue_coforall_label.future
   # statements/sungeun/continue_forall_label.future
-- Unlabeled break and continue statements fail to compile in param for
-  loops.
-  # statements/sungeun/continue_nolabel_param.future
 - On statement variable declarations are not yet supported.
   E.g., on Locales(1) var x: real;
   # multilocale/sungeun/on_statement_var_decl.future
@@ -216,8 +203,6 @@ Modules
 
 Functions and Iterators
 -----------------------
-# OMITTED: classes/bradc/arrayInClass/genericArrayInClass-otharrs-inline-iterators.future
-#  b/c can't really describe this in a way that would be useful
 - Invalid where clauses may result in an internal compiler error.
   # functions/bradc/resolution/uintParamInWhere.future
 - Querying the type of a function is not supported and currently
@@ -316,7 +301,6 @@ Functions and Iterators
   or errors.
   # functions/bradc/paramThis/funParamThis2.future
   # functions/bradc/paramThis/funParamThis3.future
-  # functions/bradc/paramThis/funParamThis4.future
 
 
 Strings
@@ -716,9 +700,6 @@ Standard Modules, Standard Distributions, and Standard Layouts
 - Array assignment fails for Block distributions with bounding boxes
   that do not overlap with the bounds of the domain.
   # arrays/sungeun/multilocale/weird_bbox_block.future
-- Distribution equality is not implemented properly.
-  # distributions/sungeun/equality1.future
-  # distributions/sungeun/equality2.future
 - Records with domain map fields do not work.
   # types/records/sungeun/distInRecord.future
   # types/records/sungeun/distInRecordInClass.future
@@ -761,7 +742,7 @@ Optimizations
 
 Miscellaneous
 -------------
-# OMITTED: chpldoc/compflags/alphabetical/classFields.future
+# OMITTED: chpldoc/compflags/alphabetical/classFields.doc.future
 #  b/c the future is terse, and I have no idea what is wrong
 # OMITTED: memory/shannon/memstatEquals.future
 #  b/c it's pretty benign and probably will not cause a problem
@@ -779,9 +760,6 @@ Miscellaneous
 - An exported function that returns a record results in two versions
   in the generated code.
   # functions/gbt/retRecordMultiDef.future
-- An array variable and function that share the same name at the same
-  scope result in one of the two being arbitrarily chosen.
-  # functions/bradc/resolution/arrayVsFn.future
 - Leaving off () when calling exit results in an internal compiler
   error.
   # exits/sungeun/exitWithNoParensNoArgs.future
@@ -832,15 +810,12 @@ chpldoc
 -------
 - chpldoc comments that are not closed with using the specified
   comment style are not detected.
-  # chpldoc/compflags/comment/badClose.future
+  # chpldoc/compflags/comment/badClose.doc.future
 - chpldoc generates documentation for some symbols that should not be
   documented
-  # chpldoc/basics/main.future
+  # chpldoc/basics/main.doc.future
 - chpldoc is incorrect or incomplete for some types
-  # chpldoc/enum/docConstants.future
-  # chpldoc/types/fields/complexes.future
-  # chpldoc/types/fields/imags.future
-  # chpldoc/types/fields/reals.future
+  # chpldoc/enum/docConstants.doc.future
 
 
 Developer

--- a/test/users/bguarraci/domain_extraction.future
+++ b/test/users/bguarraci/domain_extraction.future
@@ -1,3 +1,3 @@
-bug: using domain extraction syntax inside a class causes compiler failure
+bug: using domain extraction syntax inside a variable declaration causes compiler failure
 
 internal error: CAL0051 chpl Version 1.11.0

--- a/test/visibility/private/privateEnum.future
+++ b/test/visibility/private/privateEnum.future
@@ -1,4 +1,4 @@
-feature request: allow private enum declarations
+unimplemented feature: allow private enum declarations
 
 Right now, public and private can't be applied to enum declarations.  We would
 like to be able to do that, and catch any outside use of publicly visible

--- a/test/visibility/private/typeAlias.future
+++ b/test/visibility/private/typeAlias.future
@@ -1,4 +1,4 @@
-feature request: allow private type aliases
+unimplemented feature: allow private type aliases
 
 Right now, public and private can't be applied to type aliases.  We would like
 to be able to do that, and catch any outside use of publicly visible instances


### PR DESCRIPTION
Removed .futures that no longer exist from STATUS.devel, renamed a few
entries for .futures that got renamed.

Categorized all futures listed as "Futures missing from the STATUS file" by
"make future_stats" and added them to STATUS.devel.

Recategorized the following two from "feature request" to
"unimplemented feature" with Lydia's approval.

test/visibility/private/typeAlias.future
test/visibility/private/privateEnum.future

Updated the wording in a .future to make it more accurately describe the
test.