### PR TITLE
In the spec, reconcile pdf page numbers

### DIFF
--- a/spec/spec.tex
+++ b/spec/spec.tex
@@ -124,7 +124,7 @@
 \makeindex
 \title{Chapel Language Specification\\Version 0.97}
 
-\author{\copyright 2015 Cray Inc.\\
+\author{Cray Inc\\
 901 Fifth Avenue, Suite 1000\\
 Seattle, WA 98164}
 
@@ -142,11 +142,20 @@ Seattle, WA 98164}
 \fi
 \maketitle
 
+\setcounter{page}{2}
+\null\vfill
+\noindent
+\begin{center}
+\copyright 2015 Cray Inc.
+\end{center}
+
+\cleardoublepage
+\include{tm}
+\cleardoublepage
+
 \pagestyle{myheadings}
 \markboth{Chapel Language Specification}{Chapel Language Specification}
 %\pagenumbering{roman}
-
-\setcounter{page}{2}
 
 \ifpdf
 \pdfbookmark[1]{Table of Contents}{tablecontents}

--- a/spec/spec.tex
+++ b/spec/spec.tex
@@ -124,7 +124,7 @@
 \makeindex
 \title{Chapel Language Specification\\Version 0.97}
 
-\author{Cray Inc\\
+\author{\copyright 2015 Cray Inc.\\
 901 Fifth Avenue, Suite 1000\\
 Seattle, WA 98164}
 
@@ -142,19 +142,11 @@ Seattle, WA 98164}
 \fi
 \maketitle
 
-\null\vfill
-\noindent
-\begin{center}
-\copyright 2015 Cray Inc.
-\end{center}
-
-\cleardoublepage
-\include{tm}
-\cleardoublepage
-
 \pagestyle{myheadings}
 \markboth{Chapel Language Specification}{Chapel Language Specification}
 %\pagenumbering{roman}
+
+\setcounter{page}{2}
 
 \ifpdf
 \pdfbookmark[1]{Table of Contents}{tablecontents}


### PR DESCRIPTION
The observable page numbers in the spec used to be off by 1
from the printed page numbers, starting with the Contents page.
It was the third page in the document, while being labeled as Page 2.

This commit makes the Contents page be the second page,
still labeled as such.

While there -- I also moved "(C) 2015" into the title page,
eliminating the almost-empty second page in the document.

I am not sure that the new place of the copyright is great.
Since we are using the \maketitle command for that page,
there is not much flexibility. We could put copyright at the bottom
using \thanks within either \author or \title. That will not be
as pretty - it will be a left-justified footnote.
Still, having an almost-empty page with just the copyright
at the bottom does not feel worth the aesthetic advantage to me.