### PR TITLE
Converted READMEs to reST and added `make webdocs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ gen
 *.tmp
 TAGS
 tags
+*.DS_Store
+
 
 # Top level ignores.
 /BUILD_VERSION
@@ -64,6 +66,7 @@ tags
 /modules/docs
 /modules/internal/tasks/muxed
 /modules/internal/threads/soft-threads
+/modules/webdocs
 
 # Runtime ignores.
 /runtime/etc/Makefile.comm-ugni

--- a/doc/release/platforms/README.macosx.rst
+++ b/doc/release/platforms/README.macosx.rst
@@ -8,11 +8,11 @@ instructions on building and using Chapel.
 
 For Macintosh developers, there is an Xcode project file located in
 
-$CHPL_HOME/make/Chapel.xcodeproj/project.pbxproj
+``$CHPL_HOME/make/Chapel.xcodeproj/project.pbxproj``
 
 that can be used to develop Chapel within Xcode by opening the project
 
-$CHPL_HOME/make/Chapel.xcodeproj.
+``$CHPL_HOME/make/Chapel.xcodeproj``
 
 Be forewarned that we do not maintain this project very regularly and
 appreciate updates to the project file from external contributors.

--- a/doc/release/technotes/README.atomics.rst
+++ b/doc/release/technotes/README.atomics.rst
@@ -44,18 +44,18 @@ which the atomic variable was allocated and performing the atomic
 operations locally.
 
 If supported, the network atomics implementation can be selected via
-the environment variable CHPL_NETWORK_ATOMICS. If set, all variables
+the environment variable ``CHPL_NETWORK_ATOMICS``. If set, all variables
 declared to be atomic will use the specified network's atomic
 operations. It is possible to override this default by using the
 explicit type name for the processor-based atomics (available in the
-type function chpl__atomicType() defined in the file
-$CHPL_HOME/modules/internal/Atomics.chpl).
+type function ``chpl__atomicType()`` defined in the file
+``$CHPL_HOME/modules/internal/Atomics.chpl``).
 
 For more information about the runtime implementation see
-$CHPL_HOME/runtime/include/atomics/README.
+``$CHPL_HOME/runtime/include/atomics/README``.
 
 To see a full list of available functions, see
-$CHPL_HOME/modules/internal/Atomics.chpl.
+``$CHPL_HOME/modules/internal/Atomics.chpl``.
 
 
 ------------------
@@ -74,7 +74,7 @@ locking and unlocking of sync vars.
 We expect to begin using the specified memory order with a C11
 implementation of the atomics.
 
-------------------------------
+-------------------------------
 Variances from the C11 standard
 -------------------------------
 
@@ -91,7 +91,7 @@ reads and writes with more relaxed memory constraints. Currently they
 are implemented as reads and writes with memory_order_relaxed but since
 our implementations ignore memory_order, they are semantically the same
 as read and write. waitFor is method that waits until an atomic value
-has a specific value.  It can yield to other tasks while waiting. 
+has a specific value.  It can yield to other tasks while waiting.
 
 Chapel currently does not support the memory fences and isLockFree
 methods from the C11 spec. They are defined in the runtime but not in
@@ -113,9 +113,9 @@ Open issues
 Below are a few of the known open issues with Chapel atomics.
 
 - Atomic bools are only supported for the default size and not
-  implemented for all sizes of bools. 
+  implemented for all sizes of bools.
 
-- The memory_order is currently ignored by all implementations. 
+- The memory_order is currently ignored by all implementations.
 
 - Chapel's memory consistency model is still a work-in-progress.
 
@@ -126,4 +126,3 @@ Feedback
 
 If you have any questions regarding atomics in Chapel, please send
 mail to chapel_info@cray.com.
-

--- a/doc/release/technotes/README.auxIO.rst
+++ b/doc/release/technotes/README.auxIO.rst
@@ -15,9 +15,9 @@ this directory detailing how to install and use them.
 
 The AIO system depends upon three environment variables:
 
-    CHPL_AUX_FILESYS
-    CHPL_AUXIO_INCLUDE
-    CHPL_AUXIO_LIBS
+    ``CHPL_AUX_FILESYS``
+    ``CHPL_AUXIO_INCLUDE``
+    ``CHPL_AUXIO_LIBS``
 
 In the following sections, we will explain what they should be set to, and give
 the general idea of what they do.
@@ -28,23 +28,25 @@ CHPL_AUXIO_INCLUDE & CHPL_AUXIO_LIBS
 
 These paths are for the extra libraries that will be linked in with the runtime
 when it is compiled. For instance, if I installed libcurl, and had it install in
-~/include and ~/lib you would set them to be:
+``~/include`` and ``~/lib`` you would set them to be:
 
 
-export CHPL_AUXIO_LIBS="-L~/include"
-export CHPL_AUXIO_INCLUDE="-I~/lib"
+.. code-block:: sh
+
+    export CHPL_AUXIO_LIBS="-L~/include"
+    export CHPL_AUXIO_INCLUDE="-I~/lib"
 
 In general, you want it so that if you had a .c file that used the libraries
 that you wish to compile Chapel with, all you would need to do to compile this
 file would be:
 
-cc $CHPL_AUXIO_LIBS $CHPL_AUXIO_INCLUDE <any libraries> <the .c file>
+``cc $CHPL_AUXIO_LIBS $CHPL_AUXIO_INCLUDE <any libraries> <the .c file>``
 
-where <any libraries> might be -lcurl, -lhdfs, -ljvm etc.
+where <any libraries> might be ``-lcurl``, ``-lhdfs``, ``-ljvm`` etc.
 
 Note: It is not necessary to pass these library flags, or library/include paths
-      to the Chapel compiler invocations (chpl) as the values in CHPL_AUXIO_LIBS
-      and CHPL_AUXIO_INCLUDE will be used there as well as in building the
+      to the Chapel compiler invocations (chpl) as the values in ``CHPL_AUXIO_LIBS``
+      and ``CHPL_AUXIO_INCLUDE`` will be used there as well as in building the
       Chapel runtime
 
 CHPL_AUX_FILESYS
@@ -54,16 +56,16 @@ This is a space delimited string detailing what AIO systems we wish to compile
 Chapel with (and use). For example if we wanted to enable Curl and HDFS support
 simultaneously we would set:
 
-    CHPL_AUX_FILESYS="hdfs curl"
+    ``CHPL_AUX_FILESYS="hdfs curl"``
 
-Assuming that you have correctly defined CHPL_AUXIO_INCLUDES and CHPL_AUXIO_LIBS
+Assuming that you have correctly defined ``CHPL_AUXIO_INCLUDES`` and ``CHPL_AUXIO_LIBS``
 as detailed above, and have the correct libraries installed.
 
 If you only have one AIO system that you wish to use, you may simply set
-CHPL_AUX_FILESYS=<system>. For example, if we only wanted HDFS support, we would
+``CHPL_AUX_FILESYS=<system>``. For example, if we only wanted HDFS support, we would
 set:
 
-    CHPL_AUX_FILESYS=hdfs
+    ``CHPL_AUX_FILESYS=hdfs``
 
 
 I/O Systems Supported
@@ -81,23 +83,30 @@ Parallel and Distributed I/O Features
 We support two functions for Parallel and Distributed file systems (these also
 work on "standard" file systems as well).
 
-file.getchunk(start:int(64), end:int(64)):(int(64), int(64))
+``file.getchunk(start:int(64), end:int(64)):(int(64), int(64))``
+
  - This returns the first logical "chunk" of the file that is inside this
    section. If no "chunk" can be found inside this region, (0,0) is returned. If
    no arguments are provided, we return the start and end of the first logical
    chunk for this file.
-   - On Lustre, this returns the first stripe for the file that is inside this
-     region.
-   - On HDFS, this returns the first block for the file that is inside this
-     region.
-   - On "local" file systems, it returns the first "optimal transfer block"
-     (from fstatfs) inside this section of the file.
 
-file.localesForRegion(start:int(64), end:int(64)):domain(locale)
+     - On Lustre, this returns the first stripe for the file that is inside this region.
+
+     - On HDFS, this returns the first block for the file that is inside this
+       region.
+
+     - On "local" file systems, it returns the first "optimal transfer block"
+       (from fstatfs) inside this section of the file.
+
+``file.localesForRegion(start:int(64), end:int(64)):domain(locale)``
+
  - This returns the "best locales" for a given chunk of the file. If no
    individual or set of locales are "best" (i.e., there is some sort of data
    affinity that we can exploit), we return all locales.
-   - On Lustre, no locale are "best", so we return all locales
-   - On HDFS, we return the block owners for that specific block
-   - On "local" file systems, we return all locales, since no individual locale
-     is best.
+
+     - On Lustre, no locale are "best", so we return all locales
+
+     - On HDFS, we return the block owners for that specific block
+
+     - On "local" file systems, we return all locales, since no individual
+       locale is best.

--- a/doc/release/technotes/README.chpl-ipe.rst
+++ b/doc/release/technotes/README.chpl-ipe.rst
@@ -29,7 +29,7 @@ to track our progress on Github.
 #. `No Additional Installation`_
 #. Overview_
 #. `The IPE subset of Chapel`_
-#. `Future directions`_
+#. `chpl-ipe Future directions`_
 
 
 .. _No Additional Installation:
@@ -131,7 +131,7 @@ Arithmetic operators
 ~~~~~~~~~~~~~~~~~~~~
 
 The IPE implements the unary +, - operators on int and real and the
-binary operators +, -, *, / on int and real.  Once again the IPE
+binary operators +, -, \*, / on int and real.  Once again the IPE
 does not currently implement implicit coercion from int to real.
 
 
@@ -269,10 +269,10 @@ prints the c_string followed by a representation of the second argument e.g.::
 
 
 
-.. _Future directions:
+.. _chpl-ipe Future directions:
 
-Future directions
------------------
+chpl-ipe Future directions
+--------------------------
 
 We expect the IPE to mature rapidly during the development for release 1.12.  In the
 immediate term we plan to

--- a/doc/release/technotes/README.firstClassFns.rst
+++ b/doc/release/technotes/README.firstClassFns.rst
@@ -59,7 +59,7 @@ Lambda functions are anonymous first-class function objects. In other
 words, they are expressions rather than formally-defined named
 functions. They are available with the following syntax:
 
-.. code-block:: chapel
+.. code-block::
 
   lambda-declaration-expression:
     lambda argument-list return-type_opt function-body

--- a/doc/release/technotes/README.firstClassFns.rst
+++ b/doc/release/technotes/README.firstClassFns.rst
@@ -18,17 +18,25 @@ values may be passed around as other value types.
 
 For example:
 
+.. code-block:: chapel
+
   proc myfunc(x:int) { return x + 1; }
   var f = myfunc;
   writeln(f(3));  // outputs: 4
 
 To be captured, a function must not be any of the following:
+
 - A generic function (all captured functions must be fully-qualified
   with no generic arguments)
+
 - A function with special return types (type, param)
+
 - An iterator
+
 - The method of an object
+
 - An operator
+
 - An overloaded function
 
 Rationale. Generic functions would require manipulating generic,
@@ -51,13 +59,17 @@ Lambda functions are anonymous first-class function objects. In other
 words, they are expressions rather than formally-defined named
 functions. They are available with the following syntax:
 
+.. code-block:: chapel
+
   lambda-declaration-expression:
     lambda argument-list return-type_opt function-body
 
-where 'lambda' is a Chapel keyword and return-type_opt is an optional
+where ``lambda`` is a Chapel keyword and ``return-type_opt`` is an optional
 return-type.
 
 For example:
+
+.. code-block:: chapel
 
   var f = lambda(x:int, y:int) { return x + y; };
   writeln(f(1,2));  // outputs: 3
@@ -74,6 +86,8 @@ on the stack, i.e. while these functions are still executing.
 
 Example. For example the following is acceptable:
 
+.. code-block:: chapel
+
   proc myfunc() {
     var x = 3;
     var f = lambda() { x = 4; };
@@ -83,7 +97,7 @@ Example. For example the following is acceptable:
 
   writeln(myfunc());  // outputs: 4
 
-whereas having myfunc() return its 'f' variable is not supported.
+whereas having ``myfunc()`` return its ``f`` variable is not supported.
 
 
 Function type signatures
@@ -91,6 +105,8 @@ Function type signatures
 
 The types of first-class functions can be obtained by using
 the 'func' type functions that are provided as follows:
+
+.. code-block:: chapel
 
   // no arguments, void return type (returns no value)
   proc func() type
@@ -102,6 +118,8 @@ the 'func' type functions that are provided as follows:
   proc func(type argtypes...?n, type rettype) type
 
 For example:
+
+.. code-block:: chapel
 
   var f : func(void);  // A function with no arguments, no return value
   var f1: func();      // A shortcut for the above

--- a/doc/release/technotes/README.format.rst
+++ b/doc/release/technotes/README.format.rst
@@ -21,12 +21,14 @@ numeric value to a string.
 
 The prototype for the format function is as follows:
 
+.. code-block:: chapel
+
    proc format(fmt: string, val): string;
 
 where "fmt" is a format string and "val" is a scalar value.  This
 function can currently be used in one of two forms:
 
-1) format(<C format string>, val)
+1) ``format(<C format string>, val)``
 
    In this form, the first argument is expected to be a string that
    can serve as a C sprintf()-style format string for the second
@@ -37,11 +39,14 @@ function can currently be used in one of two forms:
 
    As an example:
 
-     var onethird = 1.0/3.0;
-     var numItems = 32;
+    .. code-block:: chapel
 
-     writeln("onethird is: ", format("%13.8f", onethird));
-     var myString: string = format("%12d", numItems);
+            var onethird = 1.0/3.0;
+            var numItems = 32;
+
+            writeln("onethird is: ", format("%13.8f", onethird));
+            var myString: string = format("%12d", numItems);
+
 
    The current implementation of format does not provide good support
    for complex numbers, requiring the user to treat the real and
@@ -50,16 +55,18 @@ function can currently be used in one of two forms:
    format string.
 
 
-2) format(<pattern string>, val)
+2) ``format(<pattern string>, val)``
 
-   In this form, the first argument is a string composed of "#" and
-   "." characters that indicates the pattern that should be used to
-   print the value.  In this pattern, a "#" character indicates a
-   digit or a blank while "." indicates where the decimal place should
+   In this form, the first argument is a string composed of ``#`` and
+   ``.`` characters that indicates the pattern that should be used to
+   print the value.  In this pattern, a ``#`` character indicates a
+   digit or a blank while ``.`` indicates where the decimal place should
    fall.  The second argument must be a numeric type -- integral,
    real, imaginary, or complex.
 
    As an example:
+
+.. code-block:: chapel
 
      var pi = 3.14159265;
      var numItems = 32;

--- a/doc/release/technotes/README.libraries.rst
+++ b/doc/release/technotes/README.libraries.rst
@@ -1,46 +1,49 @@
 Chapel Libraries
+================
 
 [This readme discusses the implementation of libraries, which are still under
 development.  The idea is to allow components to be developed in Chapel and
 linked with other programs and languages.]
 
 Normally, Chapel assumes that you are building a main program, and produces a
-main routine whether one is explicitly coded or not.  When the "--library"
+main routine whether one is explicitly coded or not.  When the ``--library``
 flag is provided on the command line, it tells the Chapel compiler to produce a
-library instead.  The user can further specify (through the "--static"
-and "--dynamic" flags) which type of library to produce.  If
-neither "--static" nor "--dynamic" is specified, a platform-dependent
+library instead.  The user can further specify (through the ``--static``
+and ``--dynamic`` flags) which type of library to produce.  If
+neither ``--static`` nor ``--dynamic`` is specified, a platform-dependent
 default library type is produced.
 
 Some platforms support linking against both static and dynamic versions of
-the same library.  On those platforms, the "--static" or "--dynamic"
+the same library.  On those platforms, the ``--static`` or ``--dynamic``
 flag can be used to select which type of library (and thus which kind of
 linking) is performed by default.  Library files which are named explicitly on
-the "chpl" command line take precedence over any found through object
-library paths ("-L").  Where there is a conflict, the last library
+the ``chpl`` command line take precedence over any found through object
+library paths (``-L``).  Where there is a conflict, the last library
 specified takes precedence.
 
 When Chapel code is accessed as library code, it is the user's responsibility to
 ensure that modules are initialized before they are used.  For a module
-named "<myModule>", the corresponding initialization routine is
-named "chpl__init_<myModule>".  Therefore, for example, a C program that
-makes use of the standard Chapel module "Random" should
-call "chpl__init_Random" at some point before the Random interface is first
+named ``<myModule>``, the corresponding initialization routine is
+named ``chpl__init_<myModule>``.  Therefore, for example, a C program that
+makes use of the standard Chapel module ``Random`` should
+call ``chpl__init_Random`` at some point before the Random interface is first
 used.
 
-// C code using the Chapel Random module.
-int main()
-{
-  _int64 seed = 0;
-  double rand;
+.. code-block:: C
 
-  chpl__init_Random();
-  RandomStream* rs = RandomStream_RandomStream(seed);
+    // C code using the Chapel Random module.
+    int main()
+    {
+      _int64 seed = 0;
+      double rand;
 
-  // ...
+      chpl__init_Random();
+      RandomStream* rs = RandomStream_RandomStream(seed);
 
-  rand = RandomStream_getNext(rs);
-}
+      // ...
+
+      rand = RandomStream_getNext(rs);
+    }
 
 The interface to the Random module has not yet been exported, so the code above
 is provided as an example only.  It is not expected to be functional.
@@ -50,4 +53,4 @@ other criteria could be mentioned in a "use" statement within a Chapel
 program.  As long as this module was also declared as "extern", the Chapel
 compiler could arrange to link against it and call its initialization routine.
 In that way, external code could be made to behave exactly like a native Chapel module.
-  
+

--- a/doc/release/technotes/README.llvm
+++ b/doc/release/technotes/README.llvm
@@ -9,7 +9,7 @@ block support uses the clang parser, and so it is necessary to build a Chapel
 compiler with LLVM support in order to use that feature. See README.extern
 for more information on extern blocks, and the discussion below in this
 file for more information about the LLVM communication optimizations.
- 
+
 -------------------------
 Building the LLVM support
 -------------------------
@@ -108,6 +108,7 @@ from it - for example when constructing a global pointer from a node number and
 a local address, or extracting the node number or the address - the LLVM code
 generated with --llvm-wide-opt includes calls to nonexistent functions to mark
 these operations:
+
 * .gf.addr extracts an address from a global pointer
 * .gf.loc extracts a locale from a global pointer
 * .gf.node extracts a node number from a global pointer

--- a/doc/release/technotes/README.local.rst
+++ b/doc/release/technotes/README.local.rst
@@ -15,23 +15,25 @@ communication within the construct. If communication occurs, an error
 is reported. The checks are performed in the code within the lexical
 scope of the construct, as well as in all function calls performed by
 that code, directly or indirectly, explicitly or implicitly. The
-checks can be disabled with the --no-local-checks flag, which is implied
-by the --no-checks and --fast flags.
+checks can be disabled with the ``--no-local-checks`` flag, which is implied
+by the ``--no-checks`` and ``--fast`` flags.
 
 Communication occurs in the following cases:
+
 * remote memory (i.e. data not located on the current locale)
   is referenced (read from or assigned to), or
-* an 'on' statement attempts to execute on a remote locale.
 
-The 'local' construct is useful to establish that certain code is
+* an ``on`` statement attempts to execute on a remote locale.
+
+The ``local`` construct is useful to establish that certain code is
 communication free. This may be desired, for example, when tuning
 the performance of a program, as communication usually slows down
 execution.
 
 The 'local' construct does not necessarily indicate the cause of
-communication when present. See
+communication when present. See `a link`_.
 
-    http://chapel.cray.com/docs/latest/modules/standard/CommDiagnostics.html
+.. _a link:    http://chapel.cray.com/docs/latest/modules/standard/CommDiagnostics.html
 
 for ways to diagnose communication.
 
@@ -39,8 +41,10 @@ for ways to diagnose communication.
 Syntax
 ------
 
-The 'local' construct is a statement. It consists of the "local" keyword
+The ``local`` construct is a statement. It consists of the ``local`` keyword
 followed by a statement:
+
+.. code-block:: chapel
 
     local-statement:
         "local" statement
@@ -49,7 +53,9 @@ followed by a statement:
 Examples
 --------
 
-Here is an example of a 'local' statement:
+Here is an example of a ``local`` statement:
+
+.. code-block:: chapel
 
     local
       x = A(5);
@@ -57,14 +63,16 @@ Here is an example of a 'local' statement:
 The inner statement is often a block, commonly referred to as a
 "local block":
 
+.. code-block:: chapel
+
     local {
       initializeMyData();
       compute();
     }
 
-In the above examples, the Chapel implementation checks whether 'x',
-as well as all memory referenced during the calls of A.this(5)
-(an implicit call for A(5)), initializeMyData(), and compute(),
+In the above examples, the Chapel implementation checks whether ``x``,
+as well as all memory referenced during the calls of ``A.this(5)``
+(an implicit call for ``A(5)``), initializeMyData(), and compute(),
 are located on the current locale. Otherwise an error is reported.
-Analogously, if 'on' statement(s) are executed during these calls
+Analogously, if ``on`` statement(s) are executed during these calls
 that attempt to execute on a different locale, an error is reported.

--- a/doc/release/technotes/README.local.rst
+++ b/doc/release/technotes/README.local.rst
@@ -2,7 +2,7 @@
 The 'local' statement
 =====================
 
-This README describes the 'local' statement in the Chapel language.
+This README describes the ``local`` statement in the Chapel language.
 Its definition and implementation is an area of ongoing work and it
 should be used with caution.
 
@@ -10,7 +10,7 @@ should be used with caution.
 Overview
 --------
 
-The 'local' construct in Chapel performs runtime checks for any
+The ``local`` construct in Chapel performs runtime checks for any
 communication within the construct. If communication occurs, an error
 is reported. The checks are performed in the code within the lexical
 scope of the construct, as well as in all function calls performed by
@@ -30,12 +30,12 @@ communication free. This may be desired, for example, when tuning
 the performance of a program, as communication usually slows down
 execution.
 
-The 'local' construct does not necessarily indicate the cause of
-communication when present. See `a link`_.
+The ``local`` construct does not necessarily indicate the cause of
+communication when present. See the `Module\: CommDiagnostics`_ for ways to
+diagnose communication.
 
-.. _a link:    http://chapel.cray.com/docs/latest/modules/standard/CommDiagnostics.html
+.. _Module\: CommDiagnostics:    http://chapel.cray.com/docs/latest/modules/standard/CommDiagnostics.html
 
-for ways to diagnose communication.
 
 
 Syntax
@@ -44,7 +44,7 @@ Syntax
 The ``local`` construct is a statement. It consists of the ``local`` keyword
 followed by a statement:
 
-.. code-block:: chapel
+.. code-block::
 
     local-statement:
         "local" statement

--- a/doc/release/technotes/README.localeModels.rst
+++ b/doc/release/technotes/README.localeModels.rst
@@ -38,7 +38,7 @@ hierarchical locale support was added, these calls were all satisfied
 directly by the runtime.  With hierarchical locales, now they are
 satisfied by the Chapel module code that defines the architecture of a
 locale.  The required interface for this is defined by ChapelLocale and
-implemented by LocaleModel.chpl.  The required interface is still a work
+implemented by ``LocaleModel.chpl``.  The required interface is still a work
 in progress and will continue to evolve.
 
 
@@ -68,16 +68,22 @@ locale, please see $CHPL_HOME/doc/README.tasks.
 
 To use the NUMA locale model:
 
-1) Set the CHPL_LOCALE_MODEL environment variable to "numa".
+1) Set the ``CHPL_LOCALE_MODEL`` environment variable to "numa".
+
+.. code-block:: sh
 
     export CHPL_LOCALE_MODEL=numa
 
-2) Re-make the compiler and runtime from CHPL_HOME
+2) Re-make the compiler and runtime from ``CHPL_HOME``
+
+.. code-block:: sh
 
     cd $CHPL_HOME
     make
 
 3) Compile your Chapel program as usual.
+
+.. code-block:: sh
 
     chpl -o jacobi $CHPL_HOME/examples/programs/jacobi.chpl
 
@@ -85,7 +91,7 @@ To use the NUMA locale model:
 * Qthreads thread scheduling
 
 When qthreads tasking is used, different Qthreads thread schedulers are
-selected depending upon the CHPL_LOCALE_MODEL setting.  For the flat
+selected depending upon the ``CHPL_LOCALE_MODEL`` setting.  For the flat
 locale model the "nemesis" thread scheduler is used, and for the NUMA
 locale model the "sherwood" thread scheduler is used.  This selection is
 done at the time the Qthreads third-party package is built, and cannot
@@ -97,6 +103,9 @@ Caveats for using the NUMA locale model
 ---------------------------------------
 
 * Explicit memory allocation for NUMA domains is not yet implemented.
+
 * Distributed arrays other than Block do not yet map iterations to NUMA
   domains.
+
 * Performance for NUMA has not been optimized.
+

--- a/doc/release/technotes/README.main.rst
+++ b/doc/release/technotes/README.main.rst
@@ -46,6 +46,8 @@ Usage
 -----
 To use this feature, declare main as follows:
 
+.. code-block:: chapel
+
   proc main(args: [] string) {
     // ...body...
   }
@@ -54,28 +56,30 @@ When main is so declared, Chapel's default command line argument
 processing changes. Rather than generate an error message when an
 unknown argument is encountered, that argument will instead be passed
 on to this main(args) function. Arguments corresponding to config
-variables or Chapel's predefined flags (like -nl, -b, etc) will still
+variables or Chapel's predefined flags (like ``-nl``, ``-b``, etc) will still
 be processed and will not be passed on to the main(args) function.
 
 To be clear, the arguments that would be handled without using this
 feature will continue to behave as usual. The difference is that other
 arguments will be passed to main(args) rather than generating an error
-message. The only exception to this, is --help and -h.
+message. The only exception to this, is ``--help`` and ``-h``.
 
 Prior to this feature, a Chapel program would always exit immediately
 after printing the help message. A programmer might want to print
 other information explaining what non-config-var command line
 arguments are available and what they might do. For this reason, when
-a Chapel program includes a main declared to take arguments, --help
-and -h will be passed on to the main(args) function.  The function
+a Chapel program includes a main declared to take arguments, ``--help``
+and ``-h`` will be passed on to the main(args) function.  The function
 Help.printUsage() will print out the familiar config var table.
 
 To gain access to this new function requires a module:
 
-use Help;
+``use Help;``
 
 From that module, the function printDefaultUsage() is available. For
 example, consider the following program:
+
+.. code-block:: chapel
 
   use Help;
 
@@ -91,26 +95,26 @@ example, consider the following program:
     }
   }
 
-This program scans its argument list for "--help", and if found, it
+This program scans its argument list for ``--help``, and if found, it
 prints the standard usage message as well as some additional text
 explaining the purpose of the extra arguments. Note that this could be
 used by a program which simply wants to add explanatory text to the
---help output without actually handling any additional arguments.
+``--help`` output without actually handling any additional arguments.
 
 Finally, as is common in GNU programs, there is a way to suspend
 argument processing when main is declared to take arguments. Suppose
-you are writing "rm" in Chapel and need to delete a file named
-"--memTrack=true". Your program will consume this flag during startup,
+you are writing ``rm`` in Chapel and need to delete a file named
+``--memTrack=true``. Your program will consume this flag during startup,
 rather than passing it on to the declared main function. However,
-placing the argument "--" in the argument list will cause all
+placing the argument ``--`` in the argument list will cause all
 following arguments to be passed to the declared main function and
 will suspend handling of any builtin command line
 arguments. Specifically, if a.out is a Chapel program which has
 declared main to take arguments:
 
-  ./a.out -- --memTrack=true
+``./a.out -- --memTrack=true``
 
-will result in the program receiving "--memTrack=true" as the first
+will result in the program receiving ``--memTrack=true`` as the first
 argument after the executable name.
 
 

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -86,6 +86,10 @@ documentation: $(SYS_CTYPES_MODULE_DOC)
 	export CHPLDOC_AUTHOR='Cray Inc' && \
 	$(CHPLDOC) $(MODULES_TO_DOCUMENT)
 
+webdocs: $(SYS_CTYPES_MODULE_DOC)
+	export CHPLDOC_AUTHOR='Cray Inc' && \
+	$(CHPLDOC) --save-sphinx webdocs $(MODULES_TO_DOCUMENT)
+
 clean-documentation:
 	rm -rf ./docs
 


### PR DESCRIPTION
Inside the modules directory, make webdocs will now do the same thing as
make docs, but keep the intermediate reST files for splicing in the
remaining webdocs (using the new build_webdocs.py script in the the
internal repo). It's a bit of a hack for now, but we can make it better
post-release by modifying chpldoc.

The build_webdocs.py script will only copy over and render *rst files
from `$CHPL_HOME/doc/release/`

Here I've made headway in converting several READMEs to reST.

Updated `$CHPL_HOME/.gitignore` to include those pesky `.DS_Store` files generated by OS X.
Also ignoring `$CHPL_HOME/modules/webdocs` generated by `make webdocs`