### PR TITLE
Hot fix for modules build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ tags
 /doc/sphinx/source/*.rst
 /doc/sphinx/source/platforms/*.rst
 /doc/sphinx/source/technotes/*.rst
-/doc/sphinx/source/modules
+/doc/sphinx/source/modules/standard
 !/doc/sphinx/source/index.rst
 !/doc/sphinx/source/technotes/index.rst
 !/doc/sphinx/source/platforms/index.rst

--- a/doc/sphinx/source/modules/index.rst
+++ b/doc/sphinx/source/modules/index.rst
@@ -1,0 +1,23 @@
+Modules
+=======
+
+Contents:
+
+.. toctree::
+   :hidden:
+
+   self
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :chpl:chplref:`chplmodindex`
+* :ref:`search`

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -88,7 +88,7 @@ MODULES_TO_DOCUMENT = \
 documentation: $(SYS_CTYPES_MODULE_DOC)
 	export CHPLDOC_AUTHOR='Cray Inc' && \
 	$(CHPLDOC) --save-sphinx ${MODULE_SPHINX} $(MODULES_TO_DOCUMENT)
-	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC_SPHINX}/source/modules/standard
+	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC_SPHINX}/source/modules/
 	rm -rf ${MODULE_SPHINX}
 
 clean-documentation:

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -88,7 +88,7 @@ MODULES_TO_DOCUMENT = \
 documentation: $(SYS_CTYPES_MODULE_DOC)
 	export CHPLDOC_AUTHOR='Cray Inc' && \
 	$(CHPLDOC) --save-sphinx ${MODULE_SPHINX} $(MODULES_TO_DOCUMENT)
-	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC_SPHINX}/source/modules/
+	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC_SPHINX}/source/modules/standard
 	rm -rf ${MODULE_SPHINX}
 
 clean-documentation:


### PR DESCRIPTION
We need to copy over just the `modules/standard` directory rather than the entire `modules` directory for the sphinx project source. `make html` actually fails without this fix.