### PR TITLE
Run the sphinx makefile inside our chpldoc virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ symlink-docs:
 	cd doc/sphinx && ./symlinks.py
 
 docs: module-docs symlink-docs
-	cd doc/sphinx && ${MAKE} html
+	cd doc/sphinx && ./run-in-venv.bash ${MAKE} html
 
 chplvis: compiler third-party-fltk FORCE 
 	cd tools/chplvis && $(MAKE)

--- a/doc/sphinx/run-in-venv.bash
+++ b/doc/sphinx/run-in-venv.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Active the virtual environment and run the command supplied
+# usage: ./run-in-venv prog [args]
+
+if [ -z "$CHPL_HOME" ]; then
+  echo "Error: CHPL_HOME is not set"
+  exit 1
+fi
+
+platform=$("$CHPL_HOME/util/chplenv/chpl_platform.py" --target)
+venv_path="$CHPL_HOME/third-party/chpl-venv/install/$platform/chpl-virtualenv/"
+
+if [ ! -d "$venv_path" ]; then
+  echo "Error: virtualenv '$venv_path' does not exist"
+  exit 1
+fi
+
+source "$venv_path/bin/activate"
+
+exec "$1" "${@:2}"


### PR DESCRIPTION
The sphinx makefile expects several python packages to be installed. We
have these inside the virtualenv we use for chpldoc, so activate it
before we run the makefile.