### PR TITLE
Cleanups to Atomics documentation

### DIFF
--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -107,8 +107,12 @@ removePattern "proc atomic_" $file
 removePattern "proc create_" $file
 removePrefixFunctions $file
 
-replace "atomic_int64" "atomic\(T\)" $file
+replace "record" "type" $file
+
+replace "atomicflag" "atomic \(bool\)" $file
+replace "atomic_int64" "atomic \(T\)" $file
 replace "int(64)" "T" $file
+
 fixTitle "Atomics" $file
 
 ## End Atomics ##


### PR DESCRIPTION
Minor cleanup to atomics in fixInternalDocs.sh:
 - replace "atomicflag" with "atomic (bool)"
 - replace "atomic(T)" with "atomic (T)" (it's easier to read in the html)
 - replace "record" with "type", this abstracts our implementation details