### PR TITLE
Run the sphinx Makefile in the venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,8 @@ module-docs: chpldoc
 # dependency so parallel make executions correctly build chpldoc first.
 	$(MAKE) module-docs-only
 
-doc-sphinx: module-docs
-	cd doc/sphinx && ${MAKE} symlink-docs
-	cd doc/sphinx && ./run-in-venv.bash ${MAKE} html
-
-docs: doc-sphinx
+docs: module-docs
+	cd doc/sphinx && ./run-in-venv.bash ${MAKE} docs
 
 chplvis: compiler third-party-fltk FORCE
 	cd tools/chplvis && $(MAKE)

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -9,6 +9,8 @@ help-source:
 	@echo "Source Help:"
 	@echo "  symlinks-docs to symlink doc/release contents to source"
 
+docs: html
+
 symlink-docs:
 # Set up symlinks between `/doc/release` and `/doc/sphinx/source`
 	./symlinks.py

--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -47,7 +47,7 @@ help-sphinx:
 	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
 	@echo "  linkcheck  to check all external links for integrity"
 
-html:
+html: symlink-docs
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."


### PR DESCRIPTION
The symlink.py script also needs to run in the venv. Change the
Makefiles to add explicit dependencies between html and symlink-docs.