### PR TITLE
Patch is no longer required since RE2 moved in-tree

### DIFF
--- a/doc/release/README.prereqs.rst
+++ b/doc/release/README.prereqs.rst
@@ -22,8 +22,6 @@ about your environment for using Chapel:
 
   * You have access to gmake or a GNU-compatible version of make.
 
-  * You have the patch command installed.
-
   * You have access to standard C and C++ compilers. We test our code
     using a range of compilers on a nightly basis; these include
     relatively recent versions of gcc/g++, clang, and compilers from


### PR DESCRIPTION
We moved RE2 in tree with commit #2038.
After that, we no longer need the patch command
as a general prerequisite.