### PR TITLE
Fixed `make docs` for the release tar ball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,9 @@ module-docs: chpldoc
 	$(MAKE) module-docs-only
 
 docs: module-docs
-	cd doc/sphinx && ./run-in-venv.bash ${MAKE} docs
+	-@if [ -d "doc/sphinx" ]; then \
+	cd doc/sphinx && ./run-in-venv.bash ${MAKE} docs; \
+	fi
 
 chplvis: compiler third-party-fltk FORCE
 	cd tools/chplvis && $(MAKE)
@@ -148,7 +150,7 @@ cleanall: FORCE
 	cd modules && $(MAKE) cleanall
 	cd runtime && $(MAKE) cleanall
 	cd third-party && $(MAKE) cleanall
-	cd doc/sphinx && $(MAKE) clean
+	-@if [ -d "doc/sphinx" ]; then cd doc/sphinx && $(MAKE) clean; fi
 
 cleandeps: FORCE
 	cd compiler && $(MAKE) cleandeps
@@ -160,7 +162,7 @@ clobber: FORCE
 	cd runtime && $(MAKE) clobber
 	cd third-party && $(MAKE) clobber
 	cd tools/chplvis && $(MAKE) clobber
-	cd doc/sphinx && $(MAKE) clean
+	-@if [ -d "doc/sphinx" ]; then cd doc/sphinx && $(MAKE) clean; fi
 	rm -rf bin
 	rm -rf lib
 


### PR DESCRIPTION
The tar ball generated by gen_release does not include `/doc/sphinx`
The `/Makefile` now checks for `/doc/sphinx` before trying to
build/clean in it