### PR TITLE
Add description of the I/O statement <~>

### DIFF
--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -261,7 +261,7 @@ io-expression:
   io-expression io-operator expression
 
 io-operator:
-  <~>
+  `<(*$\sim$*)>'
 \end{syntax}
 
 See the module documentation on I/O for details on how to use the
@@ -274,7 +274,7 @@ var w: Writer;
 var a: real;
 var b: int;
 
-w <~> a <~> b;
+w <(*$\sim$*)> a <(*$\sim$*)> b;
 \end{chapel}
 the I/O operator is left-associative and indicates writing \chpl{a}
 and then \chpl{b} to \chpl{w} in this case.

--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -246,9 +246,10 @@ a = t;
 \index{IO!operator}
 \index{operators!IO}
 
-The I/O operator indicates writing to the left-hand-side the value
-in the write-hand-side. This operator can be chained with other IO
-operator calls.
+The I/O operator indicates writing to the left-hand-side the value in the
+right-hand-side; or reading from the left-hand-side and storing the result
+in the variable on the right-hand-side. This operator can be chained with
+other IO operator calls.
 
 The I/O operator can be overloaded for different types using operator
 overloading~(\rsec{Function_Overloading}).

--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -249,7 +249,7 @@ a = t;
 The I/O operator indicates writing to the left-hand-side the value in the
 right-hand-side; or reading from the left-hand-side and storing the result
 in the variable on the right-hand-side. This operator can be chained with
-other IO operator calls.
+other I/O operator calls.
 
 The I/O operator can be overloaded for different types using operator
 overloading~(\rsec{Function_Overloading}).

--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -12,6 +12,7 @@ statement:
   expression-statement
   assignment-statement
   swap-statement
+  io-statement
   conditional-statement
   select-statement
   while-do-statement
@@ -237,6 +238,48 @@ b = a;
 a = t;
 \end{chapel}
 \end{example}
+
+\section{The I/O Statement}
+\label{The_IO_Statement}
+\index{IO!statement}
+\index{statements!IO}
+\index{IO!operator}
+\index{operators!IO}
+
+The I/O operator indicates writing to the left-hand-side the value
+in the write-hand-side. This operator can be chained with other IO
+operator calls.
+
+The I/O operator can be overloaded for different types using operator
+overloading~(\rsec{Function_Overloading}).
+\begin{syntax}
+io-statement:
+  io-expression io-operator expression
+
+io-expression:
+  expression
+  io-expression io-operator expression
+
+io-operator:
+  <~>
+\end{syntax}
+
+See the module documentation on I/O for details on how to use the
+I/O statement.
+
+\begin{example}
+In the example below,
+\begin{chapel}
+var w: Writer;
+var a: real;
+var b: int;
+
+w <~> a <~> b;
+\end{chapel}
+the I/O operator is left-associative and indicates writing \chpl{a}
+and then \chpl{b} to \chpl{w} in this case.
+\end{example}
+
 
 \section{The Conditional Statement}
 \label{The_Conditional_Statement}


### PR DESCRIPTION
Adds a subsection to the Statements part of the spec to describe the <~> operator.
I focused on describing the syntax and referred to the library documentation for
details on what it actually does.

I used the funny <(*$\sim$*)> in the .tex in order to make it paste
as   <~> in ascii.