### PR TITLE
Update README.chpldoc.rst file

### DIFF
--- a/doc/release/technotes/README.chpldoc.rst
+++ b/doc/release/technotes/README.chpldoc.rst
@@ -1,7 +1,7 @@
 Documenting Chapel
 ==================
 
-The Chapel standard libraries are documenting using ``chpldoc``, which
+The Chapel standard libraries are documented using ``chpldoc``, which
 generates HTML-based documentation for Chapel code from comments embedded
 within the code.
 
@@ -188,6 +188,18 @@ preface the symbol with the pragma "no doc". For example:
    pragma "no doc"
    proc foo() { ... }
 
+Private symbols are not documented by default.
+
+.. code-block:: chapel
+
+   private proc foo() { ... }
+
+.. note::
+
+   Private cannot be applied to all symbols at this time.  It is currently
+   limited to functions, iterators, globals, and modules.  Not supported are
+   type aliases, enum declarations, classes/records/unions, methods, and fields.
+
 
 Creating links to other symbols
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -370,7 +382,7 @@ determined from the succession of headings.
 Comments
 ~~~~~~~~
 
-Every explicit markup block, which is not a valid markup construct is regarded
+Every explicit markup block which is not a valid markup construct is regarded
 as a comment. For example::
 
    This is a normal paragraph.
@@ -631,9 +643,8 @@ Future directions
 If there are other features you would like, please let us know. These are
 currently on our backlog:
 
-* Add visibility control (public/private) to Chapel and have chapeldoc only
-  represent public elements by default (with options for including private
-  elements).
+* Expand visibility control (public/private) to remaining Chapel symbols
+  (with options for including private elements in output if desired).
 
 * Ability to include doctests, which would be code snippets in documentation
   that can be tested. This is similar to Python's doctest feature.


### PR DESCRIPTION
Fixed a couple of typos, expanded the "Stifling documentation" section to
include private as one of the methods of stifling, and updated the "Future
directions" reference to public/private.