### PR TITLE
Add some css rules for our documentation

### DIFF
--- a/doc/sphinx/source/_static/style.css
+++ b/doc/sphinx/source/_static/style.css
@@ -1,0 +1,9 @@
+/* override table width restrictions */
+.wy-table-responsive table td, .wy-table-responsive table th {
+  white-space: normal;
+}
+
+/* actually apply the .lowerroman class */
+.rst-content .section ol.lowerroman, .rst-content .section ol.lowerroman li {
+  list-style: lower-roman;
+}

--- a/doc/sphinx/source/_templates/page.html
+++ b/doc/sphinx/source/_templates/page.html
@@ -1,4 +1,6 @@
 {% extends "!page.html" %}
+{% set css_files = css_files + ["_static/style.css"] %}
+
 {% block footer %}
 {{ super() }}
 {% if theme_analytics_id %}


### PR DESCRIPTION
Enable white-space wrapping inside of tables.

Add rules for the .lowerroman class so that it is visible in the output.
This will allow triply-nested ordered lists to render correctly.