### PR TITLE
Remove old symlinks any time we create new symlinks

### DIFF
--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -11,7 +11,7 @@ help-source:
 
 docs: html
 
-symlink-docs:
+symlink-docs: clean-symlink-docs
 	@echo "Setting up symlinks from /doc/release to /doc/sphinx/source"
 	./symlinks.py
 


### PR DESCRIPTION
Previously, if there were dead symlinks left over in doc/source, a user would have to call `make clean` in `/doc/sphinx` in order to remove them.

With this change, this extra step is removed - the old symlinks are removed every time we generate new symlinks via a new Makefile rule dependency.