### PR TITLE
Added chpldocs+support for distributions, tuples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ tags
 /doc/sphinx/source/technotes/*.rst
 /doc/sphinx/source/usingchapel/*.rst
 /doc/sphinx/source/modules/standard
+/doc/sphinx/source/modules/dists
+/doc/sphinx/source/modules/layouts
 /doc/sphinx/source/modules/internal
 !/doc/sphinx/source/index.rst
 !/doc/sphinx/source/technotes/index.rst

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -86,7 +86,20 @@ MODULES_TO_DOCUMENT = \
 	standard/UtilReplicatedVar.chpl \
 	$(SYS_CTYPES_MODULE_DOC)
 
+DISTS_TO_DOCUMENT = \
+	dists/BlockCycDist.chpl \
+	dists/BlockDist.chpl \
+	dists/CyclicDist.chpl \
+	dists/DimensionalDist2D.chpl \
+	dists/PrivateDist.chpl \
+	dists/ReplicatedDist.chpl \
+	dists/dims/BlockCycDim.chpl \
+	dists/dims/BlockDim.chpl \
+	dists/dims/ReplicatedDim.chpl \
+	layouts/LayoutCSR.chpl \
+
 INTERNAL_MODULES_TO_DOCUMENT = \
+	internal/ChapelTuple.chpl \
 	internal/ChapelIO.chpl \
 	internal/ChapelRange.chpl \
 	internal/ChapelSyncvar.chpl \
@@ -95,9 +108,12 @@ INTERNAL_MODULES_TO_DOCUMENT = \
 documentation: $(SYS_CTYPES_MODULE_DOC)
 	export CHPLDOC_AUTHOR='Cray Inc' && \
 	$(CHPLDOC) --save-sphinx ${MODULE_SPHINX} $(MODULES_TO_DOCUMENT) \
-	$(INTERNAL_MODULES_TO_DOCUMENT)
+	$(DISTS_TO_DOCUMENT) $(INTERNAL_MODULES_TO_DOCUMENT)
 	./internal/fixInternalDocs.sh ${MODULE_SPHINX}
+	./dists/fixDistDocs.perl      ${MODULE_SPHINX}
 	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC_SPHINX}/source/modules/
+	cp -rf ${MODULE_SPHINX}/source/modules/dists    ${DOC_SPHINX}/source/modules/
+	cp -rf ${MODULE_SPHINX}/source/modules/layouts  ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/internal ${DOC_SPHINX}/source/modules/
 	rm -rf ${MODULE_SPHINX}
 

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -60,6 +60,126 @@ proc _ensureTuple(arg) {
 ////////////////////////////////////////////////////////////////////////////////
 // BlockCyclic Distribution Class
 //
+/*
+
+This Block-Cyclic distribution maps maps blocks of indices to locales in a
+round-robin pattern according to a given block size and start index.
+
+Formally, consider a Block-Cyclic distribution with:
+
+  =============  ====================================================
+  rank           ``d``
+  start index    ``(s_1, ...., s_d)``
+  block size     ``(b_1, ...., b_d)``
+  over locales   ``targetLocales: [0..N_1-1, ...., 0..N_d-1] locale``
+  =============  ====================================================
+
+It maps an index ``(i_1, ...., i_d)``
+to the locale ``targetLocales[j_1, ...., j_d]``
+where, for each ``k`` in ``1..d``,
+we have:
+
+  ``j_k = (  (i_k - s_k) / b_k  ) (mod N_k)``
+
+
+**Limitations**
+
+This distribution is work in progress and so has significant limitations.
+
+It has not been tuned for performance.
+
+The only ``idxType`` currently supported is `int` or `int(64)`.
+
+A `forall` loop over a Cyclic-distributed domain or array
+currently executes at most a single task on each locale.
+
+
+**Example**
+
+The following code declares a domain ``D`` distributed over
+a Block-Cyclic distribution with a start index of ``(1,1)``
+and a block size of ``(2,3)``,
+and declares an array ``A`` over that domain.
+The `forall` loop sets each array element
+to the ID of the locale to which it is mapped.
+
+  .. code-block:: chapel
+
+    use BlockCycDist;
+
+    const Space = {1..8, 1..8};
+    const D: domain(2)
+      dmapped BlockCyclic(startIdx=Space.low,blocksize=(2,3)) 
+      = Space;
+    var A: [D] int;
+
+    forall a in A do
+      a = a.locale.id;
+
+    writeln(A);
+
+When run on 6 locales, the output is:
+
+  ::
+
+    0 0 0 1 1 1 0 0
+    0 0 0 1 1 1 0 0
+    2 2 2 3 3 3 2 2
+    2 2 2 3 3 3 2 2
+    4 4 4 5 5 5 4 4
+    4 4 4 5 5 5 4 4
+    0 0 0 1 1 1 0 0
+    0 0 0 1 1 1 0 0
+
+
+**Constructor Arguments**
+
+The ``BlockCyclic`` class constructor is defined as follows:
+
+  .. code-block:: chapel
+
+    proc BlockCyclic(
+      startIdx,
+      blocksize,
+      targetLocales: [] locale = Locales, 
+      tasksPerLocale = 0,
+      param rank: int  = // inferred from startIdx argument,
+      type idxType     = // inferred from startIdx argument )
+
+The argument ``startIdx`` is a tuple of integers defining an index
+that will be distributed to the first locale in ``targetLocales``.
+For a single dimensional distribution ``startIdx`` can be an integer
+or a tuple with a single element.
+
+The argument ``blocksize`` is a tuple of integers defining the block
+size of indices that will be used in dealing out indices to the
+locales. For a single dimensional distribution ``blocksize`` can be an
+integer or a tuple with a single element.
+
+The argument ``targetLocales`` is an array containing the target
+locales to which this distribution maps indices and data.  The rank of
+``targetLocales`` must match the rank of the distribution, or be one.
+If the rank of ``targetLocales`` is one, a greedy heuristic is used to
+reshape the array of target locales so that it matches the rank of the
+distribution and each dimension contains an approximately equal number
+of indices.
+
+The argument ``tasksPerLocale`` is currently unused.
+If specified explicitly, it must be either ``0`` or ``1``.
+
+The ``rank`` and ``idxType`` arguments are inferred from the
+``startIdx`` argument unless explicitly set.
+They must match the rank and index type of the domains
+"dmapped" using that BlockCyclic instance.
+
+
+**Data-Parallel Iteration**
+
+A `forall` loop over a Cyclic-distributed domain or array
+executes each iteration on the locale where that iteration's index
+is mapped to. Currently all iterations on a given locale
+execute within a single task.
+*/
 class BlockCyclic : BaseDist {
   param rank: int;
   type idxType = int;

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -119,6 +119,136 @@ config param disableBlockLazyRAD = defaultDisableLazyRADOpt;
 // dataParMinGranularity: the minimum required number of elements per
 //                        task created
 //
+
+// chpldoc TODO:
+//   a good reference to
+//     dataParTasksPerLocale, dataParIgnoreRunningTasks, dataParMinGranularity
+//   remove the above comments to avoid duplication/maintenance?
+//   talk about RAD - here or in DefaultRectangular?
+//   supports RAD opt, Bulk Transfer optimization, localSubdomain
+//   disableBlockLazyRAD
+//   disableAliasedBulkTransfer
+//
+/*
+This Block distribution partitions indices into blocks
+according to a ``boundingBox`` domain
+and maps each entire block onto a locale from a ``targetLocales`` array.
+
+The indices inside the bounding box are partitioned "evenly" across
+the target locales. An index outside the bounding box is mapped to the
+same locale as the nearest index inside the bounding box.
+
+Formally, an index ``idx`` is mapped to ``targetLocales[locIdx]``,
+where ``locIdx`` is computed as follows.
+
+In the 1-dimensional case, for a Block distribution with:
+
+
+  =================   ====================
+  ``boundingBox``     ``{low..high}``
+  ``targetLocales``   ``[0..N-1] locale``
+  =================   ====================
+
+we have:
+
+  ===================    ==========================================
+  if ``idx`` is ...      ``locIdx`` is ...
+  ===================    ==========================================
+  ``low<=idx<=high``     ``floor(  (idx-low)*N / (high-low+1)  )``
+  ``idx < low``          ``0``
+  ``idx > high``         ``N-1``
+  ===================    ==========================================
+
+In the multidimensional case, ``idx`` and ``locIdx`` are tuples
+of indices; ``boundingBox`` and ``targetLocales`` are multi-dimensional;
+the above computation is applied in each dimension.
+
+
+**Example**
+
+The following code declares a domain ``D`` distributed over
+a Block distribution with a bounding box equal to the domain ``Space``,
+and declares an array ``A`` over that domain.
+The `forall` loop sets each array element
+to the ID of the locale to which it is mapped.
+
+  .. code-block:: chapel
+
+    use BlockDist;
+
+    const Space = {1..8, 1..8};
+    const D: domain(2) dmapped Block(boundingBox=Space) = Space;
+    var A: [D] int;
+
+    forall a in A do
+      a = a.locale.id;
+
+    writeln(A);
+
+When run on 6 locales, the output is:
+
+  ::
+
+    0 0 0 0 1 1 1 1
+    0 0 0 0 1 1 1 1
+    0 0 0 0 1 1 1 1
+    2 2 2 2 3 3 3 3
+    2 2 2 2 3 3 3 3
+    2 2 2 2 3 3 3 3
+    4 4 4 4 5 5 5 5
+    4 4 4 4 5 5 5 5
+
+
+**Constructor Arguments**
+
+The ``Block`` class constructor is defined as follows:
+
+  .. code-block:: chapel
+
+    proc Block(
+      boundingBox: domain,
+      targetLocales: [] locale  = Locales, 
+      dataParTasksPerLocale     = // value of  dataParTasksPerLocale      config const,
+      dataParIgnoreRunningTasks = // value of  dataParIgnoreRunningTasks  config const,
+      dataParMinGranularity     = // value of  dataParMinGranularity      config const,
+      param rank                = boundingBox.rank,
+      type  idxType             = boundingBox.idxType)
+
+The arguments ``boundingBox`` (a domain) and ``targetLocales`` (an array)
+define the mapping of any index of ``idxType`` type to a locale
+as described above.
+
+The rank of ``targetLocales`` must match the rank of the distribution,
+or be ``1``.  If the rank of ``targetLocales`` is ``1``, a greedy
+heuristic is used to reshape the array of target locales so that it
+matches the rank of the distribution and each dimension contains an
+approximately equal number of indices.
+
+The arguments ``dataParTasksPerLocale``, ``dataParIgnoreRunningTasks``,
+and ``dataParMinGranularity`` set the knobs that are used to
+control intra-locale data parallelism for Block-distributed domains
+and arrays in the same way that the like-named config constants
+control data parallelism for ranges and default-distributed domains
+and arrays.
+
+The ``rank`` and ``idxType`` arguments are inferred from the
+``boundingBox`` argument unless explicitly set.
+They must match the rank and index type of the domains
+"dmapped" using that Block instance.
+
+
+**Data-Parallel Iteration**
+
+A `forall` loop over a Block-distributed domain or array
+executes each iteration on the locale where that iteration's index
+is mapped to.
+
+Parallelism within each locale is guided by the values of
+``dataParTasksPerLocale``, ``dataParIgnoreRunningTasks``, and
+``dataParMinGranularity`` of the respective Block instance.
+Updates to these values, if any, take effect only on the locale
+where the updates are made.
+*/
 class Block : BaseDist {
   param rank: int;
   type idxType = int;

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -44,6 +44,125 @@ config param testFastFollowerOptimization = false;
 //
 config param disableCyclicLazyRAD = defaultDisableLazyRADOpt;
 
+// chpldoc TODO:
+//   a good reference to
+//     dataParTasksPerLocale, dataParIgnoreRunningTasks, dataParMinGranularity
+//   supports RAD opt, Bulk Transfer optimization, localSubdomain
+//   disableCyclicLazyRAD
+//   
+/*
+This Cyclic distribution maps indices to locales in a round-robin pattern
+starting at a given index.
+
+Formally, consider a Cyclic distribution with:
+
+  =============  ====================================================
+  rank           ``d``
+  start index    ``(s_1, ...., s_d)``
+  over locales   ``targetLocales: [0..N_1-1, ...., 0..N_d-1] locale``
+  =============  ====================================================
+
+It maps an index ``(i_1, ...., i_d)``
+to the locale ``targetLocales[j_1, ...., j_d]``
+where, for each ``k`` in ``1..d``,
+we have:
+
+  ``j_k = (i_k - s_k) (mod N_k)``
+
+
+**Example**
+
+The following code declares a domain ``D`` distributed
+using a Cyclic distribution with a start index of ``(1,1)``,
+and declares an array ``A`` over that domain.
+The `forall` loop sets each array element
+to the ID of the locale to which it is mapped.
+
+  .. code-block:: chapel
+
+    use CyclicDist;
+
+    const Space = {1..8, 1..8};
+    const D: domain(2) dmapped Cyclic(startIdx=Space.low) = Space;
+    var A: [D] int;
+
+    forall a in A do
+      a = a.locale.id;
+
+    writeln(A);
+
+When run on 6 locales, the output is:
+
+  ::
+
+    0 1 0 1 0 1 0 1
+    2 3 2 3 2 3 2 3
+    4 5 4 5 4 5 4 5
+    0 1 0 1 0 1 0 1
+    2 3 2 3 2 3 2 3
+    4 5 4 5 4 5 4 5
+    0 1 0 1 0 1 0 1
+    2 3 2 3 2 3 2 3
+
+
+**Constructor Arguments**
+
+The ``Cyclic`` class constructor is defined as follows:
+
+  .. code-block:: chapel
+
+    proc Cyclic(
+      startIdx,
+      targetLocales: [] locale = Locales,
+      dataParTasksPerLocale     = // value of  dataParTasksPerLocale      config const,
+      dataParIgnoreRunningTasks = // value of  dataParIgnoreRunningTasks  config const,
+      dataParMinGranularity     = // value of  dataParMinGranularity      config const,
+      param rank: int  = // inferred from startIdx argument,
+      type idxType     = // inferred from startIdx argument )
+
+The argument ``startIdx`` is a tuple of integers defining an index that
+will be distributed to the first locale in ``targetLocales``.
+In the 1-dimensional case, ``startIdx`` can be an integer
+or a tuple with a single element.
+
+The argument ``targetLocales`` is an array containing the target
+locales to which this distribution maps indices and data.
+The rank of ``targetLocales`` must match the rank of the distribution,
+or be ``1``.  If the rank of ``targetLocales`` is ``1``, a greedy
+heuristic is used to reshape the array of target locales so that it
+matches the rank of the distribution and each dimension contains an
+approximately equal number of indices.
+
+The arguments ``dataParTasksPerLocale``, ``dataParIgnoreRunningTasks``,
+and ``dataParMinGranularity`` set the knobs that are used to
+control intra-locale data parallelism for Cyclic-distributed domains
+and arrays in the same way that the like-named config constants
+control data parallelism for ranges and default-distributed domains
+and arrays.
+
+The ``rank`` and ``idxType`` arguments are inferred from the
+``startIdx`` argument unless explicitly set.
+They must match the rank and index type of the domains
+"dmapped" using that Cyclic instance.
+
+
+**Data-Parallel Iteration**
+
+A `forall` loop over a Cyclic-distributed domain or array
+executes each iteration on the locale where that iteration's index
+is mapped to.
+
+Parallelism within each locale is guided by the values of
+``dataParTasksPerLocale``, ``dataParIgnoreRunningTasks``, and
+``dataParMinGranularity`` of the respective Cyclic instance.
+Updates to these values, if any, take effect only on the locale
+where the updates are made.
+
+
+**Limitations**
+
+This distribution has not been tuned for performance.
+*/
 class Cyclic: BaseDist {
   param rank: int;
   type idxType = int;

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -74,7 +74,174 @@ param invalidLocID =
 
 
 /// class declarations //////////////////////////////////////////////////////
+// chpldoc TODO
+//  link to dimension specifiers - ideally an inlined list of those
+//    otherwise manual list
+//
+/*
+This Dimensional distribution allows the mapping from indices
+to locales to be specified as a composition of independent mappings
+along each dimension. For example, when implementing the HPL
+benchmark, the user may wish to use 2D arrays that are Block-distributed
+along one dimension and replicated along the other dimension.
+Currently only 2D domains and arrays are supported.
 
+Formally, consider a Dimensional distribution with:
+
+  ====================  ====================================================
+  rank                  ``d``
+  dimension specifiers  ``dim_1``, ...., ``dim_d``
+  over locales          ``targetLocales: [0..N_1-1, ...., 0..N_d-1] locale``
+  ====================  ====================================================
+
+It maps an index ``(i_1, ...., i_d)``
+to the locale ``targetLocales[j_1, ...., j_d]``
+where, for each ``k`` in ``1..d``,
+the mapping is obtained using the dimension specifier:
+
+  ``j_k = dim_k(i_k, N_k)``
+
+**Example**
+
+The following code declares a domain ``D`` distributed
+using a 2D Dimensional distribution that
+replicates over 2 locales (when available) in the first dimemsion
+and distributes using block-cyclic distribution in the second dimension.
+
+  .. code-block:: chapel
+
+    use DimensionalDist2D, ReplicatedDim, BlockCycDim;
+
+    const Space = {1..3, 1..8};
+
+    // Compute N_1 and N_2 and reshapes Locales correspondingly.
+
+    var (N_1, N_2) =
+      if numLocales == 1
+        then (1, 1)
+        else (2, numLocales/2);
+
+    var MyLocaleView = {0..N_1-1, 0..N_2-1};
+    var MyLocales = reshape(Locales[0..N_1*N_2-1], MyLocaleView);
+
+    const D = Space
+      dmapped DimensionalDist2D(MyLocales,
+                                new ReplicatedDim(numLocales = N_1),
+                                new BlockCyclicDim(numLocales = N_2,
+                                                   lowIdx     = 1,
+                                                   blockSize  = 2));
+    var A: [D] int;
+
+    for loc in MyLocales do on loc {
+
+      // The ReplicatedDim specifier always accesses the local replicand.
+      // (This differs from how the ReplicatedDist distribution works.)
+      //
+      // Therefore, 'forall a in A' when executed on MyLocales[loc1,loc2]
+      // visits only the replicands on MyLocales[loc1,0..N_2-1].
+
+      forall a in A do
+        a = here.id;
+
+      // Technicality: 'writeln(A)' would read A always on Locale 0.
+      // Since we want to see what A contains on the current locale,
+      // we use default-distributed 'Helper'.
+      // 'Helper = A' captures the view of A on the current locale,
+      // which we then print out.
+
+      writeln("On ", here, ":");
+      const Helper: [Space] int = A;
+      writeln(Helper);
+      writeln();
+    }
+
+When run on 6 locales, the output is:
+
+  ::
+
+    On LOCALE0:
+    0 0 1 1 2 2 0 0
+    0 0 1 1 2 2 0 0
+    0 0 1 1 2 2 0 0
+
+    On LOCALE1:
+    0 0 1 1 2 2 0 0
+    0 0 1 1 2 2 0 0
+    0 0 1 1 2 2 0 0
+
+    On LOCALE2:
+    0 0 1 1 2 2 0 0
+    0 0 1 1 2 2 0 0
+    0 0 1 1 2 2 0 0
+
+    On LOCALE3:
+    3 3 4 4 5 5 3 3
+    3 3 4 4 5 5 3 3
+    3 3 4 4 5 5 3 3
+
+    On LOCALE4:
+    3 3 4 4 5 5 3 3
+    3 3 4 4 5 5 3 3
+    3 3 4 4 5 5 3 3
+
+    On LOCALE5:
+    3 3 4 4 5 5 3 3
+    3 3 4 4 5 5 3 3
+    3 3 4 4 5 5 3 3
+
+
+**Constructor Arguments**
+
+The ``DimensionalDist2D`` class constructor is defined as follows:
+
+  .. code-block:: chapel
+
+    proc DimensionalDist2D.DimensionalDist2D(
+      targetLocales: [] locale,
+      di1,
+      di2,
+      name: string = "dimensional distribution",
+      type idxType = int,
+      dataParTasksPerLocale     = // value of  dataParTasksPerLocale      config const,
+      dataParIgnoreRunningTasks = // value of  dataParIgnoreRunningTasks  config const,
+      dataParMinGranularity     = // value of  dataParMinGranularity      config const )
+
+The argument ``targetLocales`` must be a 2D array indicating
+the locales to distribute over.
+
+The arguments ``di1`` and ``di2`` are the desired dimension specifiers
+for the first and second dimension, respectively.
+
+The ``name`` argument may be useful for debugging.
+It is stored and otherwise ignored by the implementation.
+
+The ``idxType`` argument must match the index type of the domains
+"dmapped" using that DimensionalDist2D instance.
+
+The arguments ``dataParTasksPerLocale``, ``dataParIgnoreRunningTasks``,
+and ``dataParMinGranularity`` set the knobs that are used to
+control intra-locale data parallelism for Block-distributed domains
+and arrays in the same way that the like-named config constants
+control data parallelism for ranges and default-distributed domains
+and arrays.
+
+
+**Dimension Specifiers**
+
+Presently, the following dimension specifiers are available
+(shown here with their constructor arguments):
+
+* :class:`ReplicatedDim(numLocales) <ReplicatedDim>`
+* :class:`BlockDim(numLocales, boundingBox, idxType=boundingBox.idxType) <BlockDim>`
+* :class:`BlockCyclicDim(numLocales, lowIdx, blockSize) <BlockCycDim>`
+
+
+**Limitations**
+
+Only 2D domains and arrays are supported.
+
+There may be performance issues when scaling to a large number of locales.
+*/
 class DimensionalDist2D : BaseDist {
   // the desired locales to distribute things over;
   // must be a [domain(2, locIdT, false)] locale
@@ -975,6 +1142,7 @@ proc DimensionalArr.dsiRankChange(sliceDefDom: WrapperRectDom,
 }
 
 */
+/* do not use the above comment for chpldoc */
 
 proc DimensionalArr.dsiReallocate(d: domain) {
   // nothing

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -21,6 +21,51 @@
 // Private Distribution, Domain, and Array
 //  Defines PrivateSpace, an instance of PrivateDom
 //
+/*
+This Private distribution maps each index ``i``
+between ``0`` and ``numLocales-1`` to ``Locales[i]``.
+
+The index set of a domain distributed over a Private distribution
+is always ``0..numLocales-1``, regardless of the domain's rank,
+and cannot be changed.
+
+The following domain is available as a convenience,
+so user programs do not need to declare their own:
+
+  .. code-block:: chapel
+
+    const PrivateSpace: domain(1) dmapped Private();
+
+
+**Example**
+
+The following code declares a Private-distributed array ``A``.
+The `forall` loop visits each locale and sets the array element
+corresponding to that locale to that locale's number of cores.
+
+  .. code-block:: chapel
+
+    var A: [PrivateSpace] int;
+    forall a in A do
+      a = here.numCores;
+
+
+**Data-Parallel Iteration**
+
+A `forall` loop over a Private-distributed domain or array
+runs a single task on each locale.
+That task executes the loop's iteration corresponding to
+that locale's index in the ``Locales`` array.
+
+
+**Limitations**
+
+Domains and arrays distributed over this distribution
+do not provide some standard domain/array functionality.
+
+This distribution may perform unnecessary communication
+between locales.
+*/
 class Private: BaseDist {
   proc dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool) {
     return new PrivateDom(rank=rank, idxType=idxType, stridable=stridable);

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -17,96 +17,7 @@
  * limitations under the License.
  */
 
-/*****************************************************************************
-*** THE REPLICATED DISTRIBUTION ***
 
-This ReplicatedDist distribution causes a domain and its arrays
-to be replicated across the desired locales (all the locales by default).
-An array receives a distinct set of elements - a "replicand" -
-allocated on each locale.
-
-In other words, mapping a domain with ReplicatedDist gives it
-an implicit additional dimension - over the locales,
-making it behave as if there is one copy of its indices per locale.
-
-Replication over locales is observable:
-- when iterating over a domain or array
-- when printing with write() et al.
-- when zippering and the replicated domain/array is
-  the first among the zippered items
-- when assigning into the replicated array
-- when inquiring about the domain's numIndices
-  or the array's numElements
-- when accessing array element(s) from a locale that was not included
-  in the array passed explicitly to the ReplicatedDist constructor,
-  an out-of-bounds error will result
-
-Only the replicand *on the current locale* is accessed
-(i.e. replication is not observable):
-- when examining certain domain properties:
-  dim(d), dims(), low, high, stride;
-  but not numIndices
-- when indexing into an array
-- when slicing an array  TODO: right?
-- when zippering and the first zippered item is not replicated
-- when assigning to a non-replicated array,
-  i.e. the replicated array is on the right-hand side of the assignment
-- when there is only a single locale (trivially: only one replicand)
-
-E.g. when iterating, the number of iterations will be (the number of
-locales involved) times (the number of iterations over this domain if
-it were distributed with the default distribution).
-
-Note that the above behavior may change in the future.
-
-Features/limitations:
-* Consistency/coherence among replicands' array elements is NOT maintained.
-* Only rectangular domains are presently supported.
-* Serial iteration over a replicated domain (or array) visits the indices
-  (or array elements) of all replicands *from the current locale*.
-* When replicating over user-provided array of locales, that array
-  must be "consistent" (see below).
-
-"Consistent" array requirement:
-* The array of locales passed to the ReplicatedDist constructor, if any,
-  must be "consistent".
-* A is "consistent" if for each ix in A.domain, A[ix].id == ix.
-* Tip: if the domain of the desired array of locales cannot be described
-  as a rectangular domain (which could be strided, multi-dimensional,
-  and/or sparse), make that array's domain associative over int.
-
-Examples:
-
-const Dbase = {1..5};
-const Drepl: domain(1) dmapped ReplicatedDist() = Dbase;
-var Abase: [Dbase] int;
-var Arepl: [Drepl] int;
-
-// only the current locale's replicand is accessed
-Arepl[3] = 4;
-
-// these iterate over Dbase, so
-// only the current locale's replicand is accessed
-forall (b,r) in zip(Abase,Arepl) b = r;
-Abase = Arepl;
-
-// these iterate over Drepl;
-// each replicand will be zippered against (and copied from) the entire Abase
-forall (r,b) in zip(Arepl,Abase) r = b;
-Arepl = Abase;
-
-// sequential zippering will detect difference in sizes
-// (if multiple locales)
-for (b,r) in zip(Abase,Arepl) ... // error
-for (r,b) in zip(Arepl,Abase) ... // error
-
-Potential extensions:
-- support other kinds of domains
-- allow run-time change in locales
-*/
-
-
-/*****************************************************************************/
 // THE REPLICATED DISTRIBUTION IMPLEMENTATION
 //
 // Classes defined:
@@ -115,6 +26,10 @@ Potential extensions:
 //  LocReplicatedDom -- Local domain descriptor
 //  ReplicatedArray -- Global array descriptor
 //  LocReplicatedArray -- Local array descriptor
+//
+// Potential extensions:
+// - support other kinds of domains
+// - allow run-time change in locales
 
 // include locale information when printing out domains and arrays
 config param printReplicatedLocales = true;
@@ -129,6 +44,138 @@ config param traceReplicatedDist = false;
 //
 // (global) distribution class
 //
+// chpldoc TODO
+//   nicer example - pull from primers/distributions.chpl
+
+/*
+This Replicated distribution causes a domain and its arrays
+to be replicated across the desired locales (all the locales by default).
+An array receives a distinct set of elements - a "replicand" -
+allocated on each locale.
+
+In other words, a ReplicatedDist-distributed domain has
+an implicit additional dimension - over the locales,
+making it behave as if there is one copy of its indices per locale.
+
+Consistency among the replicands is not preserved automatically.
+That is, changes to one replicand of an array are never propagated to
+the other replicands by the distribution implementation.
+If desired, consistency needs to be maintained by the user.
+
+Replication over locales is observable when:
+
+* iterating over a domain or array
+
+* printing with ``writeln()`` et al.
+
+* zippering, when the replicated domain/array is
+  the first among the zippered items
+
+* assigning into the replicated array
+  (each replicand gets a copy)
+
+* inquiring about the domain's ``numIndices``
+  or the array's ``numElements``
+
+* accessing array element(s) from a locale *not* in the set of desired locales,
+  i.e. from a locale which the array is not replicated onto.
+  Upon such an access, an out-of-bounds error is reported.
+
+Only the replicand *on the current locale* is accessed
+(i.e. existence of multiple replicands is not observable) when:
+
+* examining certain domain properties:
+  ``dim(d)``, ``dims()``, ``low``, ``high``, ``stride``
+  -- not ``numIndices``
+
+* indexing into an array
+
+* zippering, when the first zippered item is not replicated
+
+* assigning to a non-replicated array,
+  i.e. the replicated array is on the right-hand side of the assignment
+
+* there is only a single locale
+  (trivially: there is only one replicand in this case)
+
+.. when slicing an array?
+
+E.g. when iterating, the number of iterations will be (the number of
+locales involved) times (the number of iterations over this domain if
+it were distributed with the default distribution).
+
+Note that the above behavior may change in the future. In particular,
+we are considering changing it so that replication is never observable.
+For example, only the local replicand would be accessed in all cases.
+
+
+**Example**
+
+  .. code-block:: chapel
+
+    const Dbase = {1..5};  // a default-distributed domain
+    const Drepl: domain(1) dmapped ReplicatedDist() = Dbase;
+    var Abase: [Dbase] int;
+    var Arepl: [Drepl] int;
+
+    // only the current locale's replicand is accessed
+    Arepl[3] = 4;
+
+    // these iterate over Dbase;
+    // only the current locale's replicand is accessed
+    forall (b,r) in zip(Abase,Arepl) do b = r;
+    Abase = Arepl;
+
+    // these iterate over Drepl; each replicand of Drepl
+    // will be zippered against (and copied from) the entire Abase
+    forall (r,b) in zip(Arepl,Abase) do r = b;
+    Arepl = Abase;
+
+    // sequential zippering will detect difference in sizes
+    // (if multiple locales)
+    for (b,r) in zip(Abase,Arepl) ... // error
+    for (r,b) in zip(Arepl,Abase) ... // error
+
+
+**Constructor Arguments**
+
+The ``ReplicatedDist`` class constructor is defined as follows:
+
+  .. code-block:: chapel
+
+    proc ReplicatedDist(
+      targetLocales: [] locale = Locales,
+      purposeMessage: string = "used to create a ReplicatedDist")
+
+The array ``targetLocales`` must be "consistent", as defined below.
+
+The optional ``purposeMessage`` may be useful for debugging
+when the constructor encounters an error.
+
+
+**Features/Limitations**
+
+* Only rectangular domains are presently supported.
+
+* Serial iteration over a replicated domain (or array) visits the indices
+  (or array elements) of all replicands *from the current locale*.
+
+* When replicating over user-provided array of locales, that array
+  must be "consistent" (see below).
+
+"Consistent" array requirement:
+
+* The array of desired locales, if passed explicitly as ``targetLocales``
+  to the ReplicatedDist constructor, must be "consistent".
+
+* The array ``A`` is "consistent" if
+  for each ``ix`` in ``A.domain``, this holds: ``A[ix].id == ix``.
+
+* Tip: if the domain of your ``targetLocales`` cannot be described
+  as a rectangular domain (whether strided, multi-dimensional,
+  and/or sparse), make the domain associative over the `int` type.
+
+*/
 class ReplicatedDist : BaseDist {
   // the desired locales (an array of locales)
   const targetLocales;

--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -31,6 +31,48 @@ config const BlockCyclicDim_printAdjustedLowIdx = false;
 // the values of this type must always be positive
 type bcdPosInt = int;
 
+// chpldoc TODO
+// * Get the BlockCyclic distribution references to be presented
+//   as links. Currently they are not perhaps because chpldoc does not find
+//   that module while creating this documentation.
+//   Cf. it finds ReplicatedDist while processing ReplicatedDim.
+//   That is perhaps because the name of the class and the name of the file
+//   match in the ReplicatedDist case.
+//
+/*
+This Block-Cyclic dimension specifier is for use with the
+:class:`DimensionalDist2D` distribution.
+
+It specifies the mapping of indices in its dimension
+that would be produced by a 1D :class:`BlockCyclic` distribution.
+
+**Constructor Arguments**
+
+The ``BlockCyclicDim`` class constructor is defined as follows:
+
+  .. code-block:: chapel
+
+    proc BlockCyclicDim(
+      numLocales:   int,
+      lowIdx:       int,
+      blockSize:    int,
+      name:         string,
+      cycleSizePos: int = // computed by the implementation )
+
+The arguments are as follows:
+
+  ``numLocales``
+      the number of locales that this dimension's indices are
+      to be distributed over
+  ``lowIdx``, ``blockSize``
+      are the counterparts to ``startIdx`` and ``blocksize``
+      in the :class:`BlockCyclic` distribution
+  ``name``
+      may be used for debugging; it is ignored by the implementation
+  ``cycleSizePos``
+      is used internally by the implementation and
+      should not be specified by the user code
+*/
 class BlockCyclicDim {
   // distribution parameters
   const numLocales: int;
@@ -287,6 +329,7 @@ user's domain index (a member of 'whole'):
         advanced: i = wLo + iSt * |wSt| where iSt - a non-negative integer
 
 *** Notation:
+
  floor(a,b) = floor((real)a/(real)b)
  a div b = { assert a>=0 && b>=0; return floor(a,b); }
  a mod b = { assert b >= 0; return a - b*floor(a,b); }
@@ -360,6 +403,7 @@ where storagePerCycle is determined to ensure uniqueness of storageIdx(i)
    = 1 + ((blockSize-1) div |wSt|)
 
 *** Advanced: replacing mod with Chapel's %.
+
 Calculate i0 using the following:
 
  i0 = i - lowIdx + cycSize * cycAdj
@@ -378,6 +422,8 @@ This implies that the same cycAdj should accomodate wLo for any
 domain bounds that can be assigned to our domain descriptor.
 That may not be convenient in practice.
 */
+
+/* do not use the above comment for chpldoc */
 
 inline proc BlockCyclic1dom._dsiInd0(ind: idxType): idxType
   return ind + adjLowIdx;

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -24,6 +24,47 @@
 use DimensionalDist2D;
 
 
+/*
+This Block dimension specifier is for use with the
+:class:`DimensionalDist2D` distribution.
+
+It specifies the mapping of indices in its dimension
+that would be produced by a 1D :class:`Block` distribution.
+
+**Constructor Arguments**
+
+The following ``BlockDim`` class constructors are available:
+
+  .. code-block:: chapel
+
+    proc BlockDim.BlockDim(
+      numLocales,
+      boundingBoxLow,
+      boundingBoxHigh,
+      type idxType = boundingBoxLow.type)
+
+    proc BlockDim.BlockDim(
+      numLocales: int,
+      boundingBox: range(?),
+      type idxType = boundingBox.idxType)
+
+.. Is there also the compiler-generated constructor:
+   proc BlockDim.BlockDim(type idxType, numLocales: int, bbStart, bbLength)
+   If so, do we want to list it here?
+   Ideally, the compiler will not generate that constructor
+   since user-defined constructors are provided
+
+The ``numLocales`` argument specifies the number of locales
+that this dimension's bounding box is to be distributed over.
+
+The ``boundingBoxLow`` and ``boundingBoxHigh`` arguments are
+a convenient replacement for the ``boundingBox`` argument,
+which specifies the bounding box in this dimension.
+
+The ``idxType``, whether provided or inferred, must match
+the index type of the domains "dmapped" using the corresponding
+``DimensionalDist2D`` distribution.
+*/
 class BlockDim {
   // the type of bbStart, bbLength
   // (also (ab)used as the idxType of the domains created over this dist.)

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -26,7 +26,27 @@
 
 use DimensionalDist2D;
 
+/*
+This Replicated dimension specifier is for use with the
+:class:`DimensionalDist2D` distribution.
 
+The dimension of a domain or array for which this specifier is used
+has a *replicand* for each element of ``targetLocales``
+in the same dimension. This is similar to the Replicated distribution
+(:class:`ReplicatedDist`). The dimension specifies differs
+in that it always accesses the local replicand, whereas the Replicated
+distribution accesses all replicands in certain cases, as specified there.
+
+**Constructor Arguments**
+
+The ``ReplicatedDim`` class constructor is available as follows:
+
+  .. code-block:: chapel
+
+    proc ReplicatedDim.ReplicatedDim(numLocales:int)
+
+It creates a dimension specifier for replication over ``numLocales`` locales.
+*/
 class ReplicatedDim {
   // REQ over how many locales
   // todo: can the Dimensional do without this one?

--- a/modules/dists/fixDistDocs.perl
+++ b/modules/dists/fixDistDocs.perl
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+
+# A counterpart for modules/internal/fixInternalDocs.sh
+# for modules/dists, modules/layouts.
+
+use English;
+use strict;
+use warnings;
+use open OUT => ":raw";
+
+$#ARGV == 0 or die "Error: This script takes one argument," .
+    " the path of the intermediate sphinx project\n";
+
+my $TEMPDIR = "$ARGV[0]/source/modules/dists";
+chdir $TEMPDIR or die "Could not cd to $TEMPDIR";
+
+my $errors = 0;
+
+process("../layouts/LayoutCSR.rst");
+process("BlockDist.rst");
+process("CyclicDist.rst");
+process("BlockCycDist.rst");
+process("ReplicatedDist.rst");
+process("PrivateDist.rst");
+process("DimensionalDist2D.rst");
+process("dims/ReplicatedDim.rst");
+process("dims/BlockDim.rst");
+process("dims/BlockCycDim.rst");
+
+# There is nothing user-facing there.
+# chpldoc creates this .rst because DSIUtil is imported from the above modules.
+unlink "DSIUtil.rst" or warn "Could you remove DSIUtil.rst: $!";
+
+#or: for my $rst (@ARGV) { process($rst); }
+
+print "done\n";
+exit $errors;
+
+# non-fatal error
+sub errorNF { print "Error: ", @_, "\n"; $errors++; }
+
+sub process {
+   my ($rst) = @_;
+   my $tmp = "$rst.tmp";
+   #print "processing $rst\n";
+
+   open RST, $rst or
+       ( errorNF("could not open the input file '$rst'"), return );
+   open MOD, ">", $tmp or
+       ( errorNF("could not open the temp file '$tmp'"), close RST, return );
+
+   # Print all lines until the one after "Module:",
+   # which is the underline.
+   while (<RST>) {
+      print MOD;
+      if (/^Module:/) {
+	 my $next = <RST>;
+	 $next =~ /^=+$/ or die "Expected a line after Module:, got $next";
+	 print MOD $next;
+	 last;
+      }
+   }
+
+   # Skip everything until "class::", edit that line and print.
+   while (<RST>) {
+      if (/^.. class::/) {
+	 s/ : Base.*//;
+	 print MOD;
+	 last;
+      }
+   }
+
+   # Print until a chpldoc line for the next declaration.
+   while (<RST>) {
+      m/ attribute::| class::| method::/ and last;
+      print MOD;
+   }
+
+   # That's all we will retain.
+   close RST;
+   close MOD;
+   rename $tmp, $rst or
+       errorNF("could not update $rst");
+}

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -17,10 +17,26 @@
  * limitations under the License.
  */
 
-// ChapelTuple.chpl
-//
-// tuple data implementation as a record
-//
+/*
+Predefined Functions on Tuples.
+
+Tuples are a predefined structured type in Chapel. They are specified
+in the Tuples chapter of the Chapel Language Specification.
+This page lists the predefined functions on tuples.
+They are always available to all Chapel programs.
+
+Besides the functions defined here, the Chapel Language specification
+defines other operations available on tuples: indexing, iteration,
+assignment, and unary, binary, and relational operators.
+
+The following method is also availble:
+
+  .. code-block:: chapel
+
+    proc tuple.size param
+
+It returns the number of components of the tuple.
+*/
 module ChapelTuple {
   
   pragma "tuple" record _tuple {
@@ -76,18 +92,29 @@ module ChapelTuple {
   //
   // isTuple, isTupleType and isHomogeneousTuple param functions
   //
+  pragma "no doc" // we are not advertising isXxxValue() functions at present
   proc isTupleValue(x: _tuple) param
     return true;
   
+  pragma "no doc"
   proc isTupleValue(x) param
     return false;
-
+  
+  pragma "no doc"
   proc isHomogeneousTupleValue(x: _tuple) param
     return __primitive("is star tuple type", x);
   
+  /*
+    Returns `true` if its argument is a tuple type.
+    The argument must be a type.
+  */
   proc isTupleType(type t) param
     return __primitive("is tuple type", t);
   
+  /*
+    Returns `true` if its argument is a homogeneous tuple type.
+    The argument must be a type.
+  */
   proc isHomogeneousTupleType(type t) param
     return __primitive("is star tuple type", t);
   
@@ -104,6 +131,7 @@ module ChapelTuple {
   // homogeneous tuple accessor
   // the result is const when the tuple is
   //
+  pragma "no doc"
   pragma "reference to const when const this"
   proc _tuple.this(i : integral) ref {
     if !isHomogeneousTuple(this) then
@@ -114,10 +142,23 @@ module ChapelTuple {
     return __primitive("get svec member", this, i);
   }
 
+  // This is controlled with --[no-]warn-tuple-iteration
+  // so we are not chpldoc-ing it.
+  //
+  // When this param is set to the string "true",
+  // the compiler will issue a warning when iterating over components
+  // of a homogeneous tuple, e.g. ``for i in (A,B,C)``.
+  //
+  // This is useful to expose code where zippered iteration,
+  // e.g. ``for abc in zip(A,B,C)``, may have been intended.
+  //
+  pragma "no doc"
   config param CHPL_WARN_TUPLE_ITERATION = "unset";
+  
   //
   // iterator support for tuples
   //
+  pragma "no doc"
   iter _tuple.these() {
 
     if !isHomogeneousTuple(this) then
@@ -131,6 +172,7 @@ module ChapelTuple {
     }
   }
   
+  pragma "no doc"
   iter _tuple.these(param tag:iterKind) 
       where tag == iterKind.leader 
   {
@@ -158,6 +200,7 @@ module ChapelTuple {
     }
   }
   
+  pragma "no doc"
   iter _tuple.these(param tag:iterKind, followThis)
       where tag == iterKind.follower
   {
@@ -167,6 +210,7 @@ module ChapelTuple {
   //
   // tuple methods
   //
+  pragma "no doc"
   proc _tuple.readWriteThis(f) {
     var st = f.styleElement(QIO_STYLE_ELEMENT_TUPLE);
     var start:ioLiteral;
@@ -267,9 +311,10 @@ module ChapelTuple {
     return result;
   }
   
-  //
-  // Return a tuple of type t with all values set to the max/min for that type
-  //
+  /*
+    Returns a tuple of type t with each component set to ``max``
+    of the type in the corresponding component of the argument.
+  */
   proc max(type t): t where isTupleType(t) {
     var result: t;
     for param i in 1..result.size {
@@ -278,6 +323,10 @@ module ChapelTuple {
     return result;
   }
   
+  /*
+  Returns a tuple of type t with each component set to ``min``
+  of the type in the corresponding component of the argument.
+  */
   proc min(type t): t where isTupleType(t) {
     var result: t;
     for param i in 1..result.size {

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -38,7 +38,7 @@ function removePattern() {
 # Replace a given pattern with another
 function replace() {
   if [ $# -ne 3 ] || [ ! -f $3 ]; then
-    echo "Bad call to removePattern."
+    echo "Bad call to replace."
     exit 1
   fi
   sed "s/$1/$2/g" $3 > $3.tmp
@@ -52,7 +52,7 @@ function replace() {
 # Note: It does not rename the .html file, it will still be ChapelSyncvar.html`
 function fixTitle() {
   if [ $# -ne 2 ] || [ ! -f $2 ]; then
-    echo "Bad call to removePattern."
+    echo "Bad call to fixTitle."
     exit 1
   fi
   local base="$(basename $2 .rst)"
@@ -71,7 +71,7 @@ function fixTitle() {
 #    overloads, and functions starting with a underscores
 function removePrefixFunctions() {
   if [ $# -ne 1 ] || [ ! -f $1 ]; then
-    echo "Bad call to removePattern."
+    echo "Bad call to removePrefixFunctions."
     exit 1
   fi
   removePattern "proc [^a-zA-Z]" $1
@@ -86,6 +86,15 @@ function removePrefixFunctions() {
 ###############################################################################
 ## Modules to fixup listed in the same order as INTERNAL_MODULES_TO_DOCUMENT ##
 ###############################################################################
+
+## ChapelTuple ##
+
+file=ChapelTuple.rst
+removePrefixFunctions $file
+removePattern "param size" $file
+removePattern "record:: _tuple" $file
+fixTitle "Tuples" $file
+
 
 ## ChapelIO ##
 

--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -19,7 +19,34 @@
 
 config param debugCSR = false;
 
-// Compressed Sparse Row
+// In the following, I insist on SUBdomains because
+// I have not seen us test a non-"sub" CSR domain
+// and I do not want untested code in the docs.
+// TODO: change to 'sparse domain' and add that code to the test suite.
+/*
+This CSR layout provides a Compressed Sparse Row implementation
+for Chapel's sparse domains and arrays.
+
+To declare a CSR domain, invoke the ``CSR`` constructor without arguments
+in a `dmapped` clause. For example:
+
+  .. code-block:: chapel
+
+    use LayoutCSR;
+    var D = {1..n, 1..m};  // a default-distributed domain
+    var CSR_Domain: sparse subdomain(D) dmapped CSR();
+
+To declare a CSR array, use a CSR domain, for example:
+
+  .. code-block:: chapel
+
+    // assume the above declarations
+    var CSR_Array: [CSR_Domain] real;
+
+This domain map is a layout, i.e. it maps all indices to the current locale.
+All elements of a CSR-distributed array are stored
+on the locale where the array variable is declared.
+*/
 class CSR: BaseDist {
   proc dsiNewSparseDom(param rank: int, type idxType, dom: domain) {
     return new CSRDom(rank=rank, idxType=idxType, dist=this, parentDom=dom);


### PR DESCRIPTION
This is a replacement for #2611 and #2583 
for clean revision history.

For distributions, given it is code freeze so we do not get to modify
'chpldoc', I took the approach - suggested by Elliot - to put all
documentation into the comment associated with the distribution class decl.

fixDistDocs.perl ensures that no other decls for each file
make it into the html page.

I ended up with a style of presenting each distribution that's somewhere
between a formal spec and a narrative-like tutorial. We can revisit that.

The diffs for ReplicatedDist.chpl show a couple of param decls moved.
That's just because of 'diff' - there are no code changes,
at least not intentional.

I listed some chpldoc TODOs in each file. Most notably:

    Move the notes about constructors and selected other functions
    from that monolithic comment to the comment on the actual declaration.

    There will be a challenge because some constructors use the functions
    like _determineRankFromStartIdx() and _determineIdxTypeFromStartIdx()
    that we might not want the users to know about.

    The benefit of such a move is that the documentation will be kept
    in sync with the code.

    I rephrased and toned down this piece from the spec - OK?

    It is parameterized by the rank and index type of the domains it
    supports. Thus domains of different ranks or different index types
    must be distributed with different Cyclic [or whatever] distributions.

    Need automatic testing of examples that appear in chpldocs.

Separately, we have been considering chpldocs for Tuples to replace
the section "Predefined Functions and Methods on Tuples" in the spec.
For now we decided to keep that section and at the same time
provide chpldocs for those functions.

This follows up on feedback by @ronawho on #2611 and
on email feedback by @bradcray .