### PR TITLE
Fix toc for layouts and dists

### DIFF
--- a/doc/sphinx/source/modules/distributions.rst
+++ b/doc/sphinx/source/modules/distributions.rst
@@ -2,5 +2,13 @@
 
 Distributions
 -------------
+Contents:
 
+.. toctree::
+   :hidden:
 
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   dists/**

--- a/doc/sphinx/source/modules/layouts.rst
+++ b/doc/sphinx/source/modules/layouts.rst
@@ -2,3 +2,13 @@
 
 Layouts
 -------
+Contents:
+
+.. toctree::
+   :hidden:
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   layouts/*


### PR DESCRIPTION
Clean up broken 'make docs' by listing layouts and distributions in their table of contents.

[co-developed by @ben-albrecht ]
