### PR TITLE
Update platform readmes

### DIFF
--- a/doc/release/platforms/README.ibm.rst
+++ b/doc/release/platforms/README.ibm.rst
@@ -14,11 +14,11 @@ Using Chapel on IBM Systems
     If you are using Chapel on IBM's MareNostrum, you should refer to
     :ref:`readme-marenostrum`.
 
-We only have limited experience using Chapel on IBM systems.
-This file contains notes that reflect our experience, focusing
-first on PowerPC-based systems and then BG systems.  If you are not
-familiar with Chapel, it is recommended that you first try the
-instructions in `$CHPL_HOME/README.md`_ to get started with the language.
+We only have limited experience using Chapel on IBM systems.  This
+file contains notes that reflect our experience, focusing first on
+PowerPC-based systems and then BG systems.  If you are not familiar
+with Chapel, it is recommended that you first try the instructions
+in `$CHPL_HOME/README.md`_ to get started with the language.
 
 .. _$CHPL_HOME/README.md: https://github.com/chapel-lang/chapel/blob/master/README.md
 
@@ -32,8 +32,8 @@ the following settings:
 #. Set ``CHPL_HOME`` and ``MANPATH`` as indicated in :ref:`readme-chplenv`.
 
 
-#. Set ``CHPL_HOST_PLATFORM`` to ``pwr5`` for a Power5 cluster or ``pwr6`` for a
-   Power6 cluster.  For example:
+#. Set ``CHPL_HOST_PLATFORM`` to ``pwr5`` for a Power5 cluster or
+   ``pwr6`` for a Power6 cluster.  For example:
 
    .. code-block:: sh
 
@@ -49,13 +49,13 @@ the following settings:
 
      export CHPL_COMM=gasnet
 
-   See :ref:`readme-multilocale` for further information about running using
-   multiple locales and GASNet.
+   See :ref:`readme-multilocale` for further information about
+   running using multiple locales and GASNet.
 
    Note: if you are using an installation in which your xlc/xlC
    compilers and ``ar`` utility do not use 64-bit object formats by
-   default, you will need to set the ``OBJECT_MODE`` variable to 64 to use
-   GASNet.  For example:
+   default, you will need to set the ``OBJECT_MODE`` variable to 64
+   to use GASNet.  For example:
 
    .. code-block:: sh
 
@@ -75,44 +75,46 @@ the following settings:
      gmake
 
 
-#. Set your ``PATH`` to include the directory ``$CHPL_HOME/bin/$CHPL_HOST_PLATFORM``
-   which is created when you build the compiler.  For example:
+#. Set your ``PATH`` to include the directory
+   ``$CHPL_HOME/bin/$CHPL_HOST_PLATFORM`` which is created when you
+   build the compiler.  For example:
 
    .. code-block:: sh
 
      export PATH="$PATH:$CHPL_HOME/bin/$CHPL_HOST_PLATFORM"
 
 
-#. Compile your Chapel program as usual.  See :ref:`readme-compiling` for
-   details.  For example:
+#. Compile your Chapel program as usual.  See
+   :ref:`readme-compiling` for details.  For example:
 
    .. code-block:: sh
 
      chpl -o hello6-taskpar-dist $CHPL_HOME/examples/hello6-taskpar-dist.chpl
 
 
-#. When you compile a multi-locale program for pwr5 or pwr6, you will
-   get a single binary by default (e.g., ``hello6-taskpar-dist``).  In
+#. When you compile a multi-locale program for, you will get a
+   single binary by default (e.g., ``hello6-taskpar-dist``).  In
    order to run this program properly, you will typically need to
-   write a loadleveler script that requests a number of compute nodes
-   equal to the number of locales that you will specify through the
-   ``-nl`` option, and launches a single copy of the binary per node
-   (either using poe, or on some systems by simply invoking the binary
-   directly, at the bottom of the script).  The parallelism within the
-   node will be generated within the binary using pthreads in order to
-   utilize all of the cores per node.  In our experience, the details
-   of required options for loadleveler scripts vary greatly from one
-   site to another so check with your site's documentation for
-   details.
+   write a loadleveler script that requests a number of compute
+   nodes equal to the number of locales that you will specify
+   through the ``-nl`` option, and launches a single copy of the
+   binary per node (either using poe, or on some systems by simply
+   invoking the binary directly, at the bottom of the script).  The
+   parallelism within the node will be generated within the binary
+   using pthreads in order to utilize all of the cores per node.  In
+   our experience, the details of required options for loadleveler
+   scripts vary greatly from one site to another so check with your
+   site's documentation for details.
 
-   There is a prototype loadleveler launcher (see :ref:`readme-launcher`
-   for a general description of the role of launchers in Chapel) which
-   can be utilized by setting the ``CHPL_LAUNCHER`` environment variable
-   to ``loadleveler``.  This launcher is not sufficiently portable,
-   robust, configurable, or interactive to warrant being made the
-   default for Power5 or Power6 machines.  If you are an IBM enthusiast
-   who would like to work with us to improve the utility of this
-   launcher we would greatly appreciate the help.
+   There is a prototype loadleveler launcher, which can be utilized
+   by setting the ``CHPL_LAUNCHER`` environment variable to
+   ``loadleveler``. See :ref:`readme-launcher` for a general
+   description of the role of launchers in Chapel.  This launcher is
+   not sufficiently portable, robust, configurable, or interactive
+   to warrant being made the default for Power5 or Power6 machines.
+   If you are an IBM enthusiast who would like to work with us to
+   improve the utility of this launcher we would greatly appreciate
+   the help.
 
 
 Additional Notes for Power5 Clusters
@@ -120,13 +122,13 @@ Additional Notes for Power5 Clusters
 
 Our current technique for querying the amount of memory per node is
 apparently not portable to the Power5 (which is to say, we get an
-insanely large value back).  When running the hpcc benchmarks with the
-default configuration constants, this will exhibit itself as a halt
-indicating that we can't take the `log()` of a non-positive integer.
-Set the problem size explicitly using the ``--m`` or ``--n`` flags.  If anyone
-has a chance to debug this problem or suggest a better way to query
-the amount of memory before we come up with a solution, please let us
-know.
+insanely large value back).  When running the hpcc benchmarks with
+the default configuration constants, this will exhibit itself as a
+halt indicating that we can't take the `log()` of a non-positive
+integer.  Set the problem size explicitly using the ``--m`` or
+``--n`` flags.  If anyone has a chance to debug this problem or
+suggest a better way to query the amount of memory before we come up
+with a solution, please let us know.
 
 
 Blue Gene/L
@@ -142,8 +144,8 @@ please contact us and let us know.
 Blue Gene/P
 -----------
 
-We have done some initial experimentation with the GASNet team to try
-and run Chapel on BG/P with some limited success, however more effort
-is required to make this a stable and supported platform.  If running
-Chapel on BG/P would be of interest to you, please contact us and let
-us know.
+We have done some initial experimentation with the GASNet team to
+try and run Chapel on BG/P with some limited success, however more
+effort is required to make this a stable and supported platform.  If
+running Chapel on BG/P would be of interest to you, please contact
+us and let us know.

--- a/doc/release/platforms/README.ibm.rst
+++ b/doc/release/platforms/README.ibm.rst
@@ -5,7 +5,7 @@ Using Chapel on IBM Systems
 ===========================
 
 .. warning::
-    Chapel has not been used on IBM Systems in several years.  It is
+    We have not used Chapel on IBM Systems in several years.  It is
     likely the information presented here is stale or outdated.  If
     you are interested in using Chapel on IBM Systems, please let us
     know.

--- a/doc/release/platforms/README.ibm.rst
+++ b/doc/release/platforms/README.ibm.rst
@@ -5,17 +5,17 @@ Using Chapel on IBM Systems
 ===========================
 
 .. warning::
-    Chapel has not been recently tested on IBM systems.  The information
-    presented here may be stale or inaccurate.  If using Chapel on IBM
-    systems is important to you, please let us know at
-    chapel_info@cray.com.
+    Chapel has not been used on IBM Systems in several years.  It is
+    likely the information presented here is stale or outdated.  If
+    you are interested in using Chapel on IBM Systems, please let us
+    know.
 
 .. note::
     If you are using Chapel on IBM's MareNostrum, you should refer to
     :ref:`readme-marenostrum`.
 
 We only have limited experience using Chapel on IBM systems.
-This file contains notes that reflect our current experience, focusing
+This file contains notes that reflect our experience, focusing
 first on PowerPC-based systems and then BG systems.  If you are not
 familiar with Chapel, it is recommended that you first try the
 instructions in `$CHPL_HOME/README.md`_ to get started with the language.
@@ -105,14 +105,14 @@ the following settings:
    site to another so check with your site's documentation for
    details.
 
-   We started work on a loadleveler launcher (see :ref:`readme-launcher` for
-   a general description of the role of launchers in Chapel) which can
-   be utilized by setting the ``CHPL_LAUNCHER`` environment variable to
-   ``loadleveler``.  At the time of the release, this launcher was not
-   sufficiently portable, robust, configurable, or interactive to
-   warrant being made the default for Power5 or Power6 machines.  If
-   you are an IBM enthusiast who would like to work with us to improve
-   the utility of this launcher, we would greatly appreciate the help.
+   There is a prototype loadleveler launcher (see :ref:`readme-launcher`
+   for a general description of the role of launchers in Chapel) which
+   can be utilized by setting the ``CHPL_LAUNCHER`` environment variable
+   to ``loadleveler``.  This launcher is not sufficiently portable,
+   robust, configurable, or interactive to warrant being made the
+   default for Power5 or Power6 machines.  If you are an IBM enthusiast
+   who would like to work with us to improve the utility of this
+   launcher we would greatly appreciate the help.
 
 
 Additional Notes for Power5 Clusters
@@ -126,7 +126,7 @@ indicating that we can't take the `log()` of a non-positive integer.
 Set the problem size explicitly using the ``--m`` or ``--n`` flags.  If anyone
 has a chance to debug this problem or suggest a better way to query
 the amount of memory before we come up with a solution, please let us
-know at chapel_info@cray.com.
+know.
 
 
 Blue Gene/L
@@ -145,5 +145,5 @@ Blue Gene/P
 We have done some initial experimentation with the GASNet team to try
 and run Chapel on BG/P with some limited success, however more effort
 is required to make this a stable and supported platform.  If running
-Chapel on BG/P would be of interest to you, please let us know at
-chapel_info@cray.com.
+Chapel on BG/P would be of interest to you, please contact us and let
+us know.

--- a/doc/release/platforms/README.marenostrum.rst
+++ b/doc/release/platforms/README.marenostrum.rst
@@ -5,10 +5,10 @@ Using Chapel on MareNostrum
 ===========================
 
 .. warning::
-    Chapel has not been recently tested on MareNostrum.  The information
-    presented here may be stale or inaccurate.  If using Chapel on
-    MareNostrum systems is important to you, please let us know at
-    chapel_info@cray.com.
+    Chapel has not been used on MareNostrum in several years.  It is
+    likely the information presented here is stale or outdated.  If
+    you are interested in using Chapel on MareNostrum, please let us
+    know.
 
 The following information describes how to build and use Chapel on
 Barcelona Supercomputing Center's MareNostrum machine for users who

--- a/doc/release/platforms/README.marenostrum.rst
+++ b/doc/release/platforms/README.marenostrum.rst
@@ -5,7 +5,7 @@ Using Chapel on MareNostrum
 ===========================
 
 .. warning::
-    Chapel has not been used on MareNostrum in several years.  It is
+    We have not used Chapel on MareNostrum in several years.  It is
     likely the information presented here is stale or outdated.  If
     you are interested in using Chapel on MareNostrum, please let us
     know.

--- a/doc/release/platforms/README.marenostrum.rst
+++ b/doc/release/platforms/README.marenostrum.rst
@@ -13,8 +13,9 @@ Using Chapel on MareNostrum
 The following information describes how to build and use Chapel on
 Barcelona Supercomputing Center's MareNostrum machine for users who
 have an account there.  If you are not familiar with Chapel, it is
-recommended that you first try the instructions in `$CHPL_HOME/README.md`_
-on a traditional workstation to get started with the language.
+recommended that you first try the instructions in
+`$CHPL_HOME/README.md`_ on a traditional workstation to get started
+with the language.
 
 .. _$CHPL_HOME/README.md: https://github.com/chapel-lang/chapel/blob/master/README.md
 
@@ -25,8 +26,8 @@ on a traditional workstation to get started with the language.
 
      export CHPL_HOME=~/chapel-x.y.z/chapel
 
-#. Set ``CHPL_HOST_PLATFORM`` to ``marenostrum`` and ``CHPL_COMM`` to ``gasnet``.
-   For example:
+#. Set ``CHPL_HOST_PLATFORM`` to ``marenostrum`` and ``CHPL_COMM`` to
+   ``gasnet``.  For example:
 
    .. code-block:: sh
 
@@ -48,8 +49,8 @@ on a traditional workstation to get started with the language.
 
      gmake
 
-#. Set your ``PATH`` to include the directory ``$CHPL_HOME/bin/marenostrum``
-   which is created when you build the compiler.  For example:
+#. Set your ``PATH`` to include ``$CHPL_HOME/bin/marenostrum`` which
+   is created when you build the compiler.  For example:
 
    .. code-block:: sh
 
@@ -65,22 +66,24 @@ on a traditional workstation to get started with the language.
 
 #. The above settings will result in a multi-locale compilation.  When
    you compile a Chapel program, you should see two binaries (e.g.,
-   ``hello6-taskpar-dist`` and ``hello6-taskpar-dist_real``).  The first
-   binary contains code to launch the Chapel program onto the compute
-   nodes using ``mnsubmit``.  The second contains the program code itself;
-   it is not intended to be executed directly from the shell prompt.
+   ``hello6-taskpar-dist`` and ``hello6-taskpar-dist_real``).  The
+   first binary contains code to launch the Chapel program onto the
+   compute nodes using ``mnsubmit``.  The second contains the program
+   code itself; it is not intended to be executed directly from the
+   shell prompt.
 
 #. On MareNostrum, a marenostrum-specific launcher is used by default
-   to wrap the ``mnsubmit`` and ``slurm`` scripts required to launch a job on the
-   compute nodes.  This launcher accepts the following flags:
+   to wrap the ``mnsubmit`` and ``slurm`` scripts required to launch a
+   job on the compute nodes.  This launcher accepts the following
+   flags:
 
    .. code-block:: sh
 
      --walltime <HH:MM:SS> : (required) set the max wallclock time
      --queue <name>        : (optional) specify the debug or interactive queue
 
-   These options can also be set using the ``CHPL_LAUNCHER_WALLTIME`` and
-   ``CHPL_LAUNCHER_QUEUE`` environment variables, respectively.
+   These options can also be set using the ``CHPL_LAUNCHER_WALLTIME``
+   and ``CHPL_LAUNCHER_QUEUE`` environment variables, respectively.
 
 #. Multi-locale binaries require the number of locales to be specified
    on the command line.  Other than this, execute your Chapel program

--- a/doc/release/platforms/README.sgi.rst
+++ b/doc/release/platforms/README.sgi.rst
@@ -5,10 +5,10 @@ Using Chapel on SGI Altix
 =========================
 
 .. warning::
-    Chapel has not been recently tested on SGI Altix.  The information
-    presented here may be stale or inaccurate.  If using Chapel on SGI
-    Altix  is important to you, please let us know at
-    chapel_info@cray.com.
+    Chapel has not been used on SGI Altix in several years.  It is
+    likely the information presented here is stale or outdated.  If
+    you are interested in using Chapel on SGI Altix, please let us
+    know.
 
 The Chapel team does not have access to an SGI Altix for the purposes
 of testing, so this file describes the experiences that other users
@@ -29,6 +29,16 @@ possible area of future work would be to look into how our runtime
 might be modified to do this binding and/or to utilize a user-level
 tasking library that multiplexes logical tasks onto a fixed set of
 pthreads equal to (and bound to) the number of cores.
+
+    .. note::
+        This performance characterization was written when ``fifo``
+        was the default tasking layer. It is likely that ``qthreads``
+        performs substantially better on Altix as it provides all of
+        the desired runtime capabilities listed above.  Additionally,
+        previous studies performanced by the qthreads team have shown
+        strong performance on Altix. See :ref:`readme-tasks` for more
+        information on Chapel's tasking layers.
+
 
 Due to its support for shared memory, an Altix machine can either be
 viewed as a large single locale, or as a multi-locale machine.  Our

--- a/doc/release/platforms/README.sgi.rst
+++ b/doc/release/platforms/README.sgi.rst
@@ -5,7 +5,7 @@ Using Chapel on SGI Altix
 =========================
 
 .. warning::
-    Chapel has not been used on SGI Altix in several years.  It is
+    We have not used Chapel on SGI Altix in several years.  It is
     likely the information presented here is stale or outdated.  If
     you are interested in using Chapel on SGI Altix, please let us
     know.

--- a/doc/release/platforms/README.sgi.rst
+++ b/doc/release/platforms/README.sgi.rst
@@ -35,8 +35,8 @@ pthreads equal to (and bound to) the number of cores.
         was the default tasking layer. It is likely that ``qthreads``
         performs substantially better on Altix as it provides all of
         the desired runtime capabilities listed above.  Additionally,
-        previous studies performanced by the qthreads team have shown
-        strong performance on Altix. See :ref:`readme-tasks` for more
+        previous studies done by the qthreads team have shown strong
+        performance on Altix. See :ref:`readme-tasks` for more
         information on Chapel's tasking layers.
 
 


### PR DESCRIPTION
Some changes brought on by the initial review.

Most of the changes relate to improving our warning for "out of date" READMEs
to make it more obvious that the info is probably wrong, rather than "may be
stale". There are also some wording changes and some notes to make it more
obvious that none of the things talked about in these files was done recently.
This also removes references to chapel_info per Brad's request.

The individual commits have details on what specifically was changed.
