### PR TITLE
Minor update to README.localeModel

### DIFF
--- a/doc/release/technotes/README.localeModels.rst
+++ b/doc/release/technotes/README.localeModels.rst
@@ -70,7 +70,7 @@ locale, please see :ref:`readme-tasks`.
 
 To use the NUMA locale model:
 
-1) Set the ``CHPL_LOCALE_MODEL`` environment variable to "numa".
+1) Set the ``CHPL_LOCALE_MODEL`` environment variable to ``numa``.
 
 .. code-block:: sh
 


### PR DESCRIPTION
It was actually in really good shape content wise. This just an occurrence of
"numa" to ``numa``