### PR TITLE
Update ACKs for 1.12 (should've been done earlier)

### DIFF
--- a/ACKNOWLEDGEMENTS
+++ b/ACKNOWLEDGEMENTS
@@ -2,8 +2,11 @@
 Chapel Acknowledgements
 =======================
 
-This project is currently hosted by SourceForge and we are grateful to
-them for their ongoing support.
+This project is currently hosted by GitHub and we are grateful to them
+for their ongoing support.  Its mailing lists are supported by
+SourceForge, which also serves as an alternative download site, and we
+appreciate their support for this and for years of source hosting
+prior to our move to GitHub.
 
 This material is based upon work that was supported by the Defense
 Advanced Research Projects Agency under its Agreement


### PR DESCRIPTION
Specifically, we seemingly never acknowledged the move to GitHub
here.