### PR TITLE
Move the registered trademark in README.cray from the title to the body

### DIFF
--- a/doc/release/platforms/README.cray.rst
+++ b/doc/release/platforms/README.cray.rst
@@ -1,12 +1,12 @@
 .. _readme-cray:
 
-===================================
-Using Chapel on Cray\ |reg| Systems
-===================================
+============================
+Using Chapel on Cray Systems
+============================
 
 The following information is assembled to help Chapel users get up and running
-on Cray systems including the Cray XC\ |trade|, XE\ |trade|, XK\ |trade|, and
-CS\ |trade| series systems.
+on Cray\ |reg| systems including the Cray XC\ |trade|, XE\ |trade|, XK\
+|trade|, and CS\ |trade| series systems.
 
 .. contents::
 


### PR DESCRIPTION
This just moves "Cray\ |reg|" to the main body of the file, so it doesn't show
up in references to README.cray and the title.