### PR TITLE
Modified gen_release to include html-docs

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -163,6 +163,10 @@ system("make man-chpldoc");
 print "Building the STATUS file...\n";
 system("make STATUS");
 
+print "Building the docs...\n";
+system("make docs");
+system("mv doc/sphinx/build/html doc/release");
+
 print "Creating the docs directory...\n";
 system("mv doc doctmp");
 system("mv doctmp/release doc");


### PR DESCRIPTION
### gen_release

Calls `make docs` then moves `/doc/sphinx/build/html` directly into `/doc/release` before overwriting `/doc` with `/doc/release`