### PR TITLE
Change name of README.libraries

### DIFF
--- a/doc/release/technotes/README.libraries.rst
+++ b/doc/release/technotes/README.libraries.rst
@@ -1,7 +1,7 @@
 .. _readme-libraries:
 
-Chapel Libraries
-================
+Exporting Chapel as a Library
+=============================
 
 .. note::
 


### PR DESCRIPTION
This one at least won't cause confusion over whether we're creating a standard
library for the language.  There may be a better name out there, but none
of us can think of one.