### PR TITLE
Quiet forallInStandalone regression

### DIFF
--- a/test/performance/vectorization/vectorPragmas/forallInStandalone.compgood
+++ b/test/performance/vectorization/vectorPragmas/forallInStandalone.compgood
@@ -1,3 +1,3 @@
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeLeaderFollower:15
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23
-Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:1340
+Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:1522


### PR DESCRIPTION
This test is part of the vectorization suite that reports line numbers for user
level loops that generate vectorization hints. However, for standalone
iterators, we currently report the line number of the yield points in the
standalone iterator. Documentation was added to ChapelRange so the reported
line number changed. I'm just updating the reported line number here.

Right after the release, I'll convert this test to a future so it doesn't cause
noise because of changes to our ChapelRange line numbers. I'll also take a look
and see if it's easy enough to just fix whatever is causing us to not report
user line numbers.