### PR TITLE
Copy README.rst instead of REAMDE for gen_release

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -106,7 +106,7 @@ if ($no_clone == 0) {
        "LICENSE.chapel",
        "Makefile",
        "PERFORMANCE",
-       "README",
+       "README.rst",
        "README.files",
        "STATUS",
        "compiler/passes/reservedSymbolNames",


### PR DESCRIPTION
The top level README has been converted to rst, so we need to look for the new
file