### PR TITLE
Remove 'Module: ' prefix from chpldoc'd modules

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -114,8 +114,8 @@ documentation: $(SYS_CTYPES_MODULE_DOC)
 	export CHPLDOC_AUTHOR='Cray Inc' && \
 	$(CHPLDOC) --save-sphinx ${MODULE_SPHINX} $(MODULES_TO_DOCUMENT) \
 	$(DISTS_TO_DOCUMENT) $(INTERNAL_MODULES_TO_DOCUMENT)
-	./internal/fixInternalDocs.sh ${MODULE_SPHINX}
 	./dists/fixDistDocs.perl      ${MODULE_SPHINX}
+	./internal/fixInternalDocs.sh ${MODULE_SPHINX}
 	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/dists    ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/layouts  ${DOC_SPHINX}/source/modules/

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -202,3 +202,12 @@ removePrefixFunctions $file
 fixTitle "Misc Functions" $file
 
 # End UtilMisc_forDocs ##
+
+# Remove "Module: " prefix #
+
+cd "${TEMPDIR}/source/modules/"
+
+for file in `find . -iname "*.rst"`; do
+  base="$(basename $file .rst)"
+  fixTitle $base $file
+done


### PR DESCRIPTION
- modules/dists/fixDistDocs.perl seemed to test if the "Module:" prefix existed, so I now call fixInternalDocs.sh after that script to avoid any issues.