### PR TITLE
Avoid "Font...undefined" warning in the spec

### DIFF
--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -262,7 +262,7 @@ io-expression:
   io-expression io-operator expression
 
 io-operator:
-  `<(*$\sim$*)>'
+  <`(*$\sim$*)'>
 \end{syntax}
 
 See the module documentation on I/O for details on how to use the


### PR DESCRIPTION
Having the following:

  `<>'

inside \begin{syntax} environment causes me to get:

  LaTeX Font Warning: Font shape `OML/ptm/bx/n' undefined

So I made this change in the I/O Statement section:

-  `<(*$\sim$*)>'
+  <`(*$\sim$*)'>

and the warning went away.

Upon a visual examination of the resulting PDF, it looks good.