### PR TITLE
Correct code to add quotes to strings in records, etc

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1609,6 +1609,7 @@ private extern proc qio_channel_set_style(ch:qio_channel_ptr_t, const ref style:
 private extern proc qio_channel_binary(ch:qio_channel_ptr_t):uint(8);
 private extern proc qio_channel_byteorder(ch:qio_channel_ptr_t):uint(8);
 private extern proc qio_channel_str_style(ch:qio_channel_ptr_t):int(64);
+private extern proc qio_channel_string_format(ch:qio_channel_ptr_t):uint(8);
 private extern proc qio_channel_style_element(ch:qio_channel_ptr_t, element:int(64)):int(64);
 
 private extern proc qio_channel_flush(threadsafe:c_int, ch:qio_channel_ptr_t):syserr;
@@ -3617,7 +3618,7 @@ private inline proc _read_one_internal(_channel_internal:qio_channel_ptr_t, para
   // Adjust the style to use Chapel strings in quotes
   // unless the string style was already overridden
   // (that way, writef("%j") will still use JSON-style strings)
-  if qio_channel_str_style(_channel_internal) == QIO_STRING_FORMAT_WORD {
+  if qio_channel_string_format(_channel_internal) == QIO_STRING_FORMAT_WORD {
     qio_channel_get_style(_channel_internal, save_style);
     var mystyle = save_style;
     mystyle.string_format = QIO_STRING_FORMAT_CHPL;
@@ -3647,7 +3648,7 @@ private inline proc _write_one_internal(_channel_internal:qio_channel_ptr_t, par
   // Adjust the style to use Chapel strings in quotes
   // unless the string style was already overridden
   // (that way, writef("%j") will still use JSON-style strings)
-  if qio_channel_str_style(_channel_internal) == QIO_STRING_FORMAT_WORD {
+  if qio_channel_string_format(_channel_internal) == QIO_STRING_FORMAT_WORD {
     qio_channel_get_style(_channel_internal, save_style);
     var mystyle = save_style;
     mystyle.string_format = QIO_STRING_FORMAT_CHPL;

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -1050,11 +1050,21 @@ uint8_t qio_channel_byteorder(qio_channel_t* ch)
 {
   return ch->style.byteorder;
 }
+
+/* Returns a channel's current style for *binary* string I/O */
 static inline
 int64_t qio_channel_str_style(qio_channel_t* ch)
 {
   return ch->style.str_style;
 }
+
+/* Returns a channel's current style for *text* string I/O */
+static inline
+uint8_t qio_channel_string_format(qio_channel_t* ch)
+{
+  return ch->style.string_format;
+}
+
 
 int64_t qio_channel_style_element(qio_channel_t* ch, int64_t element);
  

--- a/test/io/ferguson/read-string-inside.chpl
+++ b/test/io/ferguson/read-string-inside.chpl
@@ -1,0 +1,22 @@
+record R {
+  var str: string;
+}
+
+var r = new R("x");
+var a = ["x", "x"];
+var t = ("x", "x");
+var s = "x";
+
+readln(r);
+readln(a);
+readln(t);
+readln(s);
+
+assert(r.str == "string in record");
+assert(a[1] == "string in array");
+assert(a[2] == "other string in array");
+
+assert(t(1) == "string in tuple");
+assert(t(2) == "other string in tuple");
+
+assert(s == "string");

--- a/test/io/ferguson/read-string-inside.stdin
+++ b/test/io/ferguson/read-string-inside.stdin
@@ -1,0 +1,4 @@
+(str = "string in record")
+"string in array" "other string in array"
+("string in tuple", "other string in tuple")
+string on its own

--- a/test/io/ferguson/write-string-inside.chpl
+++ b/test/io/ferguson/write-string-inside.chpl
@@ -1,0 +1,17 @@
+record R {
+  var str: string;
+}
+
+var r = new R("string in record");
+var a = ["string in array", "other string in array"];
+var t = ("string in tuple", "other string in tuple");
+var s = "string on its own";
+
+writeln(r);
+writeln(a);
+writeln(t);
+writeln(s);
+
+writeln("this ", "is ", "a ", "test.");
+
+

--- a/test/io/ferguson/write-string-inside.good
+++ b/test/io/ferguson/write-string-inside.good
@@ -1,0 +1,5 @@
+(str = "string in record")
+"string in array" "other string in array"
+("string in tuple", "other string in tuple")
+string on its own
+this is a test.


### PR DESCRIPTION
PR #2001 claimed to implement this change, but in fact it had
an error that prevented it from working.

This PR fixes the error
 * uses string_format instead of str_style when deciding to do it
   (string_format is for text I/O, str_style is for binary)
 * adds QIO methods to easily retrieve string_format
 * comments QIO methods to emphasize binary vs text difference
   between string_format and str_style.

Adds test cases that verify this functionality for both reading
and writing.