### PR TITLE
Retired doc/technotes and READMEs from the spec.

### DIFF
--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -260,10 +260,12 @@ affect the behavior of a task construct such as a \chpl{coforall} loop.
 \begin{craychapel}
 An initial implementation of "reduce" intents is also available,
 which permits users to reduce values across iterations of a forall loop.
-They are described in:
+They are described in the \emph{Reduce Intents} page
+under \emph{Technical Notes}
+in Cray Chapel online documentation here:
 \\ %formatting
 \mbox{$$ $$ $$} %indent
-\chpl{doc/technotes/README.reduceIntents}
+\url{http://chapel.cray.com/docs/latest/}
 \end{craychapel}
 
 

--- a/spec/Expressions.tex
+++ b/spec/Expressions.tex
@@ -32,7 +32,7 @@ expression:
   locale-access-expression
   mapped-domain-expression
 \end{syntax}
-% in README.firstClassFns: lambda-declaration-expression
+% in firstClassFns.rst: lambda-declaration-expression
 
 Individual expressions are defined in the remainder of this chapter
 and additionally as follows:

--- a/spec/Interoperation.tex
+++ b/spec/Interoperation.tex
@@ -16,11 +16,6 @@ in \rsec{Shared_Language_Elements}.
 %  The creation and use of Chapel libraries is
 %treated in~\rsec{Interop_Libraries}.  
 
-\begin{craychapel}
-For information on specific packages which have been integrated with
-Chapel, see \chpl{doc/technotes}.
-\end{craychapel}
-
 \begin{future}
 
 At present, the backend language for Chapel is C, which makes it relatively

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -310,7 +310,7 @@ structured-type:
   union-type
   tuple-type
 \end{syntax}
-% in README.firstClassFns: function-type
+% todo - firstClassFns.rst: function-type
 
 Classes are discussed in \rsec{Classes}.  Records are discussed
 in \rsec{Records}.  Unions are discussed in \rsec{Unions}.  Tuples are


### PR DESCRIPTION
I found 4 lingering references:

* README.firstClassFns (twice, in comments) -- replaced with firstClassFns.rst

* README.reduceIntents -- replaced with a pointer to online docs

* "specific packages which have been integrated with Chapel"
  -- removed altogether.

  This was added by Tom in 2011 and I am not seeing anything
  under doc/release that talks about such packages at the moment.