### PR TITLE
Quickstart links

### DIFF
--- a/doc/release/platforms/ibm.rst
+++ b/doc/release/platforms/ibm.rst
@@ -17,10 +17,8 @@ Using Chapel on IBM Systems
 We only have limited experience using Chapel on IBM systems.  This
 file contains notes that reflect our experience, focusing first on
 PowerPC-based systems and then BG systems.  If you are not familiar
-with Chapel, it is recommended that you first try the instructions
-in `$CHPL_HOME/README.md`_ to get started with the language.
-
-.. _$CHPL_HOME/README.md: https://github.com/chapel-lang/chapel/blob/master/README.md
+with Chapel, it is recommended that you first try the
+:ref:`chapelhome-quickstart` to get started with the language.
 
 
 PowerPC SMP clusters

--- a/doc/release/platforms/macosx.rst
+++ b/doc/release/platforms/macosx.rst
@@ -5,8 +5,8 @@ Using Chapel on Mac OS X
 ========================
 
 By and large, Chapel can be used on a Macintosh running OS X just like
-any other platform -- refer to the top-level README file for general
-instructions on building and using Chapel.
+any other platform -- refer to the :ref:`chapelhome-quickstart` on building
+and using Chapel.
 
 For Macintosh developers, there is an Xcode project file located in
 

--- a/doc/release/platforms/macosx.rst
+++ b/doc/release/platforms/macosx.rst
@@ -5,8 +5,8 @@ Using Chapel on Mac OS X
 ========================
 
 By and large, Chapel can be used on a Macintosh running OS X just like
-any other platform -- refer to the :ref:`chapelhome-quickstart` on building
-and using Chapel.
+any other platform -- refer to the :ref:`chapelhome-quickstart` for more
+information on building and using Chapel.
 
 For Macintosh developers, there is an Xcode project file located in
 

--- a/doc/release/platforms/marenostrum.rst
+++ b/doc/release/platforms/marenostrum.rst
@@ -13,11 +13,8 @@ Using Chapel on MareNostrum
 The following information describes how to build and use Chapel on
 Barcelona Supercomputing Center's MareNostrum machine for users who
 have an account there.  If you are not familiar with Chapel, it is
-recommended that you first try the instructions in
-`$CHPL_HOME/README.md`_ on a traditional workstation to get started
-with the language.
-
-.. _$CHPL_HOME/README.md: https://github.com/chapel-lang/chapel/blob/master/README.md
+recommended that you first try the :ref:`chapelhome-quickstart`
+to get started with the language.
 
 #. Set ``CHPL_HOME`` to point to the directory of your installation as
    usual.  For example:

--- a/doc/release/platforms/sgi.rst
+++ b/doc/release/platforms/sgi.rst
@@ -48,10 +48,9 @@ organized as multi-partition machines, you will need to treat it as a
 multi-locale machine if you want to span multiple partitions.
 
 For the single-locale version, you should be able to build Chapel in
-the standard way as described in `$CHPL_HOME/README.md`_, making sure that
-the ``CHPL_COMM`` environment variable is unset or set to ``none``.
-
-.. _$CHPL_HOME/README.md: https://github.com/chapel-lang/chapel/blob/master/README.md
+the standard way as described in :ref:`chapelhome-quickstart`,
+making sure that the ``CHPL_COMM`` environment variable is unset or set to
+``none``.
 
 For multi-locale executions, Chapel uses GASNet as our means of
 specifying inter-locale communication.  Left to its own devices,

--- a/doc/release/platforms/sgi.rst
+++ b/doc/release/platforms/sgi.rst
@@ -48,7 +48,7 @@ organized as multi-partition machines, you will need to treat it as a
 multi-locale machine if you want to span multiple partitions.
 
 For the single-locale version, you should be able to build Chapel in
-the standard way as described in :ref:`chapelhome-quickstart`,
+the standard way as described in the :ref:`chapelhome-quickstart`,
 making sure that the ``CHPL_COMM`` environment variable is unset or set to
 ``none``.
 

--- a/doc/release/tasks.rst
+++ b/doc/release/tasks.rst
@@ -217,7 +217,7 @@ and is the default for Intel KNC, Cygwin, NetBSD, or when Cray is the
 target compiler.  It is attractive in its portability, though on most
 platforms it will tend to be heavier weight than Chapel strictly
 requires.  FIFO tasking is also used when Chapel is configured in
-'Quick Start' mode (see $CHPL_HOME/README for details).  To use FIFO
+'Quick Start' mode (see :ref:`chapelhome-quickstart`).  To use FIFO
 tasking, please take the following steps:
 
 1) Ensure that the environment variable ``CHPL_HOME`` points to the
@@ -284,7 +284,7 @@ following steps:
 
      export CHPL_TASKS=massivethreads
 
-3) Follow the "Quick Start" instructions in $CHPL_HOME/README
+3) Follow the :ref:`chapelhome-quickstart` 
    to set up, compile and run your Chapel programs.
 
 For more information on MassiveThreads, please see its entry in:


### PR DESCRIPTION
Replaces references to a top-level readme with links to the quickstart instructions.