### PR TITLE
Remove info about python-devel in top level readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,9 +94,7 @@ the Bourne shell (sh)                    ``. util/quickstart/setchplenv.sh``
 
 
 5) To ensure you have installed Chapel properly, you can optionally run an
-   automatic sanity check using a few example programs. For this to work
-   correctly, you will need python, and ``python-devel`` packages installed on your
-   system. See `prereqs.rst`_ for more information.
+   automatic sanity check using a few example programs.
 
         ``gmake check``
 

--- a/README.rst
+++ b/README.rst
@@ -93,8 +93,7 @@ the Bourne shell (sh)                    ``. util/quickstart/setchplenv.sh``
 
 
 
-5) To ensure you have installed Chapel properly, you can optionally run an
-   automatic sanity check using a few example programs.
+5) Optionally, check that your Chapel installation is working correctly:
 
         ``gmake check``
 


### PR DESCRIPTION
This isn't needed since `make check` no longer relies on start_test