### PR TITLE
Added release cut dates to performance graph files

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -87,12 +87,16 @@ export CHPL_TEST_PERF_DATE="03/25/15"
 export CHPL_HOME=$chpl_release_home/chapel-1.11.0
 testReleasePerformance
 
+export CHPL_TEST_PERF_DATE="09/24/15"
+export CHPL_HOME=$chpl_release_home/chapel-1.12.0
+testReleasePerformance
+
 export -n CHPL_TEST_PERF_DATE
 export CHPL_HOME=$CHPL_HOME_ORIG
 start_test --gen-graphs
 
 #
-# ADD NEW RELEASES HERE AS THEY ARE CREATED.  
+# ADD NEW RELEASES HERE AS THEY ARE CREATED.
 #
 # (The date should be the date of the release branch, which should
 # match the date in $CHPL_HOME/util/test/perf/perfgraph.js)

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -67,6 +67,10 @@ var branchInfo = [
                     "releaseDate": "2015-04-02",
                     "branchDate" : "2015-03-25",
                     "revision" : -1}
+                  { "release" : "1.12",
+                    "releaseDate": "2015-10-01",
+                    "branchDate" : "2015-09-24",
+                    "revision" : -1}
                   ];
 
 var rebootDates = [

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -66,7 +66,7 @@ var branchInfo = [
                   { "release" : "1.11",
                     "releaseDate": "2015-04-02",
                     "branchDate" : "2015-03-25",
-                    "revision" : -1}
+                    "revision" : -1},
                   { "release" : "1.12",
                     "releaseDate": "2015-10-01",
                     "branchDate" : "2015-09-24",


### PR DESCRIPTION
As per release procedures:

Add dates for branch to the following files:

* util/pastPerformance/testReleasesPerformance
* util/test/perf/perfgraph.js