### PR TITLE
Fix `make check` for multi-locale

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -134,11 +134,12 @@ fi
 
 # Check for valid launchers
 if [ ${chpl_launcher} == "slurm-srun" -o ${chpl_launcher} == "amudprun" -o ${chpl_launcher} == "none" ]; then
-    echo "\$CHPL_LAUNCHER = ${chpl_launcher} - this is compatible with test script."
+    echo "\$CHPL_LAUNCHER=${chpl_launcher} is compatible with test script."
 else
-    echo "\$CHPL_LAUNCHER = ${chpl_launcher} - this is not compatible with test script."
+    echo ""
+    echo "\$CHPL_LAUNCHER=${chpl_launcher} is not compatible with test script."
     echo "This does not necessarily indicate that your Chapel installation is incorrect."
-    echo "See \$CHPL_HOME/doc/README.launcher for more information on how to manually run a Chapel program."
+    echo "See \$CHPL_HOME/doc/launcher.rst for information on manually launching Chapel programs."
     exit 10
 fi
 
@@ -151,7 +152,7 @@ TEST_EXEC_OUT=${TEST_JOB}.exec.out
     EXEC_OPTS="$(cat ${TEST_DIR}/${TEST_JOB}.execopts)"
 
     echo "Running test job."
-    ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} > ${TEST_EXEC_OUT} 2>&1
+    ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} | sort > ${TEST_EXEC_OUT} 2>&1
     echo "Test job complete."
 
     # Check result


### PR DESCRIPTION
The output wasn't being sorted so, we'd get the "wrong" output when diffing.
Also fixed pointer to launcher.rst while I was there.