### PR TITLE
Issue an error if a 'this' intent is used on a non-method

### DIFF
--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -196,6 +196,10 @@ checkFunction(FnSymbol* fn) {
   if (fn->retTag == RET_PARAM && fn->retExprType != NULL)
     USR_WARN(fn, "providing an explicit return type on a 'param' function currently leads to incorrect results; as a workaround, remove the return type specification in function '%s'", fn->name);
 
+  if (fn->thisTag != INTENT_BLANK && !fn->hasFlag(FLAG_METHOD)) {
+    USR_FATAL_CONT(fn, "Cannot apply a 'this' intent to a standalone function");
+  }
+
   std::vector<CallExpr*> calls;
   collectMyCallExprs(fn, calls, fn);
   bool isIterator = fn->isIterator();

--- a/test/functions/bradc/thisIntentStandalone.bad
+++ b/test/functions/bradc/thisIntentStandalone.bad
@@ -1,2 +1,0 @@
-In foo()
-In bar()

--- a/test/functions/bradc/thisIntentStandalone.future
+++ b/test/functions/bradc/thisIntentStandalone.future
@@ -1,6 +1,0 @@
-bug: compiler doesn't flag an error for 'this' intents on standalone functions
-
-Syntactically, the compiler can't distinguish between standalone
-functions and primary methods, so some post-parsing pass ought to
-flag the following as illegal since there is no 'this' to add an
-intent to.


### PR DESCRIPTION
In checkParsed, check for functions that have a non-blank 'this' intent and
issue an error if they are not methods.

Removed a .future and corresponding .bad for a test asking for this error.
Remove the .future from STATUS.devel.

Passed vanilla linux64 paratest.