### PR TITLE
Update references to doc/technotes/*

### DIFF
--- a/man/chpl.txt
+++ b/man/chpl.txt
@@ -298,7 +298,7 @@ OPTIONS
   LLVM Code Generation Options
 
   --[no-]llvm       Use LLVM as the code generation target rather than C. See
-                    $CHPL_HOME/doc/technotes/README.llvm for details.
+                    $CHPL_HOME/doc/technotes/llvm.rst for details.
 
   --[no-]llvm-wide-opt   Enable [disable] LLVM wide pointer communication
                     optimizations.
@@ -308,7 +308,7 @@ OPTIONS
                     to enable wide pointer optimizations. This flag allows
                     existing LLVM optimizations to work with wide pointers -
                     for example, they might be able to hoist a 'get' out of a
-                    loop. See $CHPL_HOME/doc/technotes/README.llvm for details.
+                    loop. See $CHPL_HOME/doc/technotes/llvm.rst for details.
 
   Compilation Trace Options
 

--- a/modules/standard/Curl.chpl
+++ b/modules/standard/Curl.chpl
@@ -42,7 +42,7 @@ how to install libcurl, see the
 
 The environment variables CHPL_AUXIO_INCLUDE and CHPL_AUXIO_LIBS must be set to
 point to the include and lib directories for libcurl respectively. More
-information on these variables can be found in README.auxIO
+information on these variables can be found in auxIO.rst
 
 .. note::
 
@@ -75,7 +75,7 @@ Then, rebuild Chapel by executing 'make' from $CHPL_HOME:
 
 For information on how to enable and use Curl while also using other auxiliary
 IO extensions, as well as how to setup the CHPL_AUXIO_INCLUDE and
-CHPL_AUXIO_LIBS environment variables see doc/technotes/README.auxIO in a
+CHPL_AUXIO_LIBS environment variables see doc/technotes/auxIO.rst in a
 Chapel release.
 
 

--- a/modules/standard/Help.chpl
+++ b/modules/standard/Help.chpl
@@ -30,7 +30,7 @@
        }
      }
 
-   See doc/release/technotes/README.main in a Chapel release for more
+   See doc/release/technotes/main.rst in a Chapel release for more
    information on this feature.
 
    Programs that use this feature might need to expand upon the usage message

--- a/third-party/README
+++ b/third-party/README
@@ -71,7 +71,7 @@ hwloc/
 llvm/
   Summary: This directory holds LLVM and Clang.  LLVM is provided as
            an optional back-end target in place of C (see
-           doc/technotes/README.llvm for details).  CLANG is used to
+           doc/technotes/llvm.rst for details).  CLANG is used to
            support "extern blocks" within Chapel -- a capability for
            embedding C code into a Chapel source file.
 

--- a/third-party/llvm/README
+++ b/third-party/llvm/README
@@ -7,7 +7,7 @@ Chapel can be built (by setting CHPL_LLVM=llvm) to include LLVM
 generation.
 
 For more information on the current support for LLVM within Chapel,
-please refer to $CHPL_HOME/doc/technotes/README.llvm.  For more
+please refer to $CHPL_HOME/doc/technotes/llvm.rst.  For more
 information about LLVM itself, please refer to the website above or to
 the README in the llvm/ subdirectory of this directory.
 


### PR DESCRIPTION
There were a couple of mentions of these in the modules Curl and Help, the
third-party and llvm READMEs and the man page.  I tested the man page and uses
of the modules mentioned in our testing system and observed no problems.

I didn't update HDFS.chpl since I was told @gbtitus already handled it.