### PR TITLE
Fix a variety of README.blah references.

### DIFF
--- a/doc/developer/bestPractices/GASNetOnDesktops.txt
+++ b/doc/developer/bestPractices/GASNetOnDesktops.txt
@@ -4,7 +4,7 @@ Running Chapel Programs with GASNet on your Desktop
 
 This document give a few pointers on using Chapel with the GASNet
 communication layer on your desktop.  For more general information
-about using the GASNet communication layer, see README.multilocale in
+about using the GASNet communication layer, see multilocale.rst in
 the release docs.
 
 
@@ -12,7 +12,7 @@ RUNNING
 =======
 
 Set GASNet environment variables for simulating multiple Chapel
-locales on a single workstation as described in README.multilocale.
+locales on a single workstation as described in multilocale.rst.
 
 GASNet may detect the existence of an Infiniband network even if one
 does not exist (due to the inclusion of Infiniband in the Linux

--- a/modules/standard/HDFS.chpl
+++ b/modules/standard/HDFS.chpl
@@ -35,7 +35,7 @@ environment variables must be set as described below in
 the flags are set. As well, the HDFS functionality is also dependent upon the
 ``CHPL_AUXIO_INCLUDE`` and ``CHPL_AUXIO_LIBS`` environment variables being set
 properly. For more information on how to set these properly, see 
-doc/technotes/README.auxIO in a Chapel release.
+doc/technotes/auxIO.rst in a Chapel release.
 
 
 Enabling HDFS Support
@@ -269,7 +269,7 @@ First reflect your directory structure and version numbers (etc) in the
 6. Set up Chapel to run in distributed mode:
 
    * You'll need to set up your Chapel environment to target multiple
-     locales in the standard way (see README.multilocale and the
+     locales in the standard way (see multilocale.rst and the
      "Settings to run Chapel on multiple nodes" section of the
      .bashrc below).
 

--- a/runtime/src/comm/none/comm-none-locales.c
+++ b/runtime/src/comm/none/comm-none-locales.c
@@ -28,7 +28,7 @@ int64_t chpl_comm_default_num_locales(void) {
 void chpl_comm_verify_num_locales(int64_t proposedNumLocales) {
   if (proposedNumLocales != 1) {
     chpl_error("Only 1 locale may be used for CHPL_COMM layer 'none'\n"
-               "To use multiple locales, see $CHPL_HOME/doc/README.multilocale",
+               "To use multiple locales, see $CHPL_HOME/doc/multilocale.rst",
                0, 0);
   }
 }

--- a/test/extern/ferguson/externblock/extern_block_primer.chpl
+++ b/test/extern/ferguson/externblock/extern_block_primer.chpl
@@ -1,7 +1,7 @@
 /*
    This primer demonstrates how to work with C functions
    (called "extern functions" by Chapel). More information
-   is available in doc/technotes/README.extern.
+   is available in doc/technotes/extern.rst.
  */
 
 

--- a/test/multilocale/numLocales/bradc/numLocales2.comm-none.good
+++ b/test/multilocale/numLocales/bradc/numLocales2.comm-none.good
@@ -1,2 +1,2 @@
 error: Only 1 locale may be used for CHPL_COMM layer 'none'
-To use multiple locales, see $CHPL_HOME/doc/README.multilocale
+To use multiple locales, see $CHPL_HOME/doc/multilocale.rst

--- a/test/multilocale/numLocales/bradc/numLocales2Space.comm-none.good
+++ b/test/multilocale/numLocales/bradc/numLocales2Space.comm-none.good
@@ -1,2 +1,2 @@
 error: Only 1 locale may be used for CHPL_COMM layer 'none'
-To use multiple locales, see $CHPL_HOME/doc/README.multilocale
+To use multiple locales, see $CHPL_HOME/doc/multilocale.rst

--- a/test/multilocale/numLocales/bradc/printNumLocalesTwo.comm-none.good
+++ b/test/multilocale/numLocales/bradc/printNumLocalesTwo.comm-none.good
@@ -1,2 +1,2 @@
 error: Only 1 locale may be used for CHPL_COMM layer 'none'
-To use multiple locales, see $CHPL_HOME/doc/README.multilocale
+To use multiple locales, see $CHPL_HOME/doc/multilocale.rst

--- a/test/release/examples/hello3-datapar.chpl
+++ b/test/release/examples/hello3-datapar.chpl
@@ -16,7 +16,7 @@ config const numMessages = 100;
 // representing the number of messages to print.  In a forall loop,
 // the number of tasks used to implement the parallelism is determined
 // by the implementation of the thing driving the iteration -- in this
-// case, the range.  See $CHPL_HOME/doc/README.executing (controlling
+// case, the range.  See $CHPL_HOME/doc/executing.rst (controlling
 // degree of data parallelism) for more information about controlling
 // this number of tasks.
 //

--- a/test/release/examples/primers/chpldoc.doc.chpl
+++ b/test/release/examples/primers/chpldoc.doc.chpl
@@ -2,7 +2,7 @@
   chpldoc Primer
  
   This primer covers the use of chpldoc to document source code. For further
-  information, please see $CHPL_HOME/doc/technotes/README.chpldoc
+  information, please see $CHPL_HOME/doc/technotes/chpldoc.rst
  
 */
 

--- a/test/release/examples/primers/locales.chpl
+++ b/test/release/examples/primers/locales.chpl
@@ -3,7 +3,7 @@
  *
  * This example showcases Chapel's locale types.  To run this example
  * using multiple locales set up your envionment as described in
- * README.multilocale and execute it using the "-nl #" flag to specify
+ * multilocale.rst and execute it using the "-nl #" flag to specify
  * the number of locales.  For example, to run on 2 locales, run
  * "./a.out -nl 2".
  *

--- a/test/release/examples/primers/parIters.chpl
+++ b/test/release/examples/primers/parIters.chpl
@@ -363,7 +363,7 @@ writeln();
 // A's leader iterator (defined as part of its domain map) is invoked.
 // For standard Chapel arrays and domain maps, these leader-follower
 // iterators are controlled by the dataPar* configuration constants
-// as described in doc/README.executing.
+// as described in doc/executing.rst.
 //
 forall (a, i) in zip(A, count(probSize)) do
   a = i/100.0;

--- a/test/studies/HDFS/tzakian/multiloc/README.csep524.multiloc
+++ b/test/studies/HDFS/tzakian/multiloc/README.csep524.multiloc
@@ -33,4 +33,4 @@ source setenv.multiloc-ssh.bash
 
 
 You can also refer to the official documentation in
-$CHPL_HOME/doc/README.multilocale.
+$CHPL_HOME/doc/multilocale.rst.


### PR DESCRIPTION
This changes all the README.multilocale references to multilocale.rst,
everywhere. It changes all the README.blah references to blah.rst in
runtime/ and test/. It also fixes a reference to README.auxIO in
modules/standard/HDFS.chpl, whichhad a README.multilocale ref
I needed to fix anyway.