### PR TITLE
One last README.regex -->regex.rst.

### DIFF
--- a/third-party/README
+++ b/third-party/README
@@ -122,7 +122,7 @@ re2/
            library will be downloaded when running 'make re2' in the
            third-party directory.  We use RE2 to support regular
            expression operations as described in
-           doc/technotes/README.regexp).
+           doc/technotes/regexp.rst).
 
   License: New BSD license (see re2/re2/LICENSE)
 


### PR DESCRIPTION
A minor miscommunication caused us not to fix this one earlier today. No harm to the (now building) release results from missing it.