### PR TITLE
Modify nightly to include checkChplInstall

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -718,8 +718,7 @@ if ($runtests == 0) {
     # Confirm Chapel built correctly before start_test / paratest
     if ($buildcheck == 1) {
         $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && make check";
-        $buildcheckstatus = mysystem($buildcheckcommand, "Running `make check`", 1, 1, 1);
-        print "$buildcheckstatus";
+        mysystem($buildcheckcommand, "Running `make check`", 1, 1, 1);
     }
 
     if ($parnodefile eq "") {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -42,6 +42,7 @@ $compperformancedescription = "";
 $syncsuffix = "";
 $componly = 0;
 $futuresMode = 3;
+$checkchplinstall = 1;
 $parnodefile = "";
 $baseline = 0;
 $fast = 0;
@@ -128,6 +129,8 @@ while (@ARGV) {
         $futuresMode = 1;
     } elsif ($flag eq "-no-futures") {
         $futuresMode = 0;
+    } elsif ($flag eq "-no-checkchplinstall") {
+        $checkchplinstall = 0;
     } elsif ($flag eq "-parnodefile") {
         $parnodefile = shift @ARGV;
     } elsif ($flag eq "-no-local") {
@@ -205,6 +208,7 @@ if ($printusage == 1) {
     print "\t-componly    : only run the compiler, not the generated binary\n";
     print "\t-futures     : run all futures, not just those with skipifs\n";
     print "\t-no-futures  : do not run future tests\n";
+    print "\t-no-checkchplinstall : do not run checkChplInstall before running tests\n";
     print "\t-parnodefile : specify a node file to use for parallel testing\n";
     print "\t-cron-recipient : send -cron emails to this address instead of SourceForge mailing list(s)\n";
     print "\t-junit-xml   : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
@@ -709,11 +713,16 @@ if ($runtests == 0) {
         $svnPerfDir = $ENV{'CHPL_TEST_COMP_PERF_DIR'};
     }
 
-    # Always call `make check` before start_test
-    # TODO
-
-
     $ENV{'CHPL_HOME'} = $chplhomedir;
+
+    # Always check chapel installation before start_test / paratest
+    if ($checkchplinstall eq 1) {
+        $checkinstallcommand = "bash ../test/checkChplInstall";
+        print "Executing $checkinstallcommand\n";
+        $chplinstallstatus = mysystem($checkinstallcommand);
+        print "$chplinstallstatus";
+    }
+
     if ($parnodefile eq "") {
         $testcommand = "cd $testdir && ../util/start_test $testflags";
         print "Executing $testcommand\n";

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -42,7 +42,7 @@ $compperformancedescription = "";
 $syncsuffix = "";
 $componly = 0;
 $futuresMode = 3;
-$checkchplinstall = 1;
+$buildcheck = 1;
 $parnodefile = "";
 $baseline = 0;
 $fast = 0;
@@ -129,8 +129,8 @@ while (@ARGV) {
         $futuresMode = 1;
     } elsif ($flag eq "-no-futures") {
         $futuresMode = 0;
-    } elsif ($flag eq "-no-checkchplinstall") {
-        $checkchplinstall = 0;
+    } elsif ($flag eq "-no-buildcheck") {
+        $buildcheck = 0;
     } elsif ($flag eq "-parnodefile") {
         $parnodefile = shift @ARGV;
     } elsif ($flag eq "-no-local") {
@@ -182,36 +182,36 @@ if (@ARGV) {
 
 if ($printusage == 1) {
     print "nightly [-debug|-cron] {[-notest] [-valgrind] [-componly] [-[no-]futures] [-performance]}\n";
-    print "\t-debug       : check out sources and run for individual user (default)\n";
-    print "\t-cron        : use for nightly cron runs only\n";
-    print "\t-notest      : don't run the tests (check the build only)\n";
-    print "\t-noruntime   : don't build the runtime or run the tests\n";
-    print "\t-examples    : run the release/examples tests only\n";
-    print "\t-localeModel : run localeModel suite only\n";
-    print "\t-multilocale : run multilocale suite only\n";
-    print "\t-hello       : run the release/examples/hello.chpl test only\n";
-    print "\t-hellos      : run the release/examples/hello*.chpl tests only\n";
-    print "\t-valgrind    : run tests in valgrind mode\n";
-#    print "\t-interpret   : run tests in interpreted mode\n";
-    print "\t-performance : run performance tests\n";
-    print "\t-performance-description : run performance tests with additional description\n";
-    print "\t-performance-configs : comma seperated configs to graph, ':v' after config to be visible by default\n";
-    print "\t-compperformance <description>: run tests with compiler performance tracking\n";
-    print "\t-numtrials <number> : number of trials to run\n";
-    print "\t-startdate          : run performance tests providing a common start date to all the graphs\n";
-    print "\t-baseline    : run testins using --baseline\n";
-    print "\t-dist <dist> : run distribution robustness tests\n";
-    print "\t-fast        : run tests using --fast\n";
-    print "\t-llvm        : run tests using --llvm\n";
-    print "\t-memleaks <log> : run memleaks tests\n";
-    print "\t-no-local    : run tests using --no-local\n";
-    print "\t-componly    : only run the compiler, not the generated binary\n";
-    print "\t-futures     : run all futures, not just those with skipifs\n";
-    print "\t-no-futures  : do not run future tests\n";
-    print "\t-no-checkchplinstall : do not run checkChplInstall before running tests\n";
-    print "\t-parnodefile : specify a node file to use for parallel testing\n";
-    print "\t-cron-recipient : send -cron emails to this address instead of SourceForge mailing list(s)\n";
-    print "\t-junit-xml   : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
+    print "\t-debug                         : check out sources and run for individual user (default)\n";
+    print "\t-cron                          : use for nightly cron runs only\n";
+    print "\t-notest                        : don't run the tests (check the build only)\n";
+    print "\t-noruntime                     : don't build the runtime or run the tests\n";
+    print "\t-examples                      : run the release/examples tests only\n";
+    print "\t-localeModel                   : run localeModel suite only\n";
+    print "\t-multilocale                   : run multilocale suite only\n";
+    print "\t-hello                         : run the release/examples/hello.chpl test only\n";
+    print "\t-hellos                        : run the release/examples/hello*.chpl tests only\n";
+    print "\t-valgrind                      : run tests in valgrind mode\n";
+#    print "\t-interpret                    : run tests in interpreted mode\n";
+    print "\t-performance                   : run performance tests\n";
+    print "\t-performance-description       : run performance tests with additional description\n";
+    print "\t-performance-configs           : comma seperated configs to graph, ': v' after config to be visible by default\n";
+    print "\t-compperformance <description> : run tests with compiler performance tracking\n";
+    print "\t-numtrials <number>            : number of trials to run\n";
+    print "\t-startdate                     : run performance tests providing a common start date to all the graphs\n";
+    print "\t-baseline                      : run testins using --baseline\n";
+    print "\t-dist <dist>                   : run distribution robustness tests\n";
+    print "\t-fast                          : run tests using --fast\n";
+    print "\t-llvm                          : run tests using --llvm\n";
+    print "\t-memleaks <log>                : run memleaks tests\n";
+    print "\t-no-local                      : run tests using --no-local\n";
+    print "\t-componly                      : only run the compiler, not the generated binary\n";
+    print "\t-futures                       : run all futures, not just those with skipifs\n";
+    print "\t-no-futures                    : do not run future tests\n";
+    print "\t-no-buildcheck                 : do not run checkChplInstall before running tests\n";
+    print "\t-parnodefile                   : specify a node file to use for parallel testing\n";
+    print "\t-cron-recipient                : send -cron emails to this address instead of SourceForge mailing list(s)\n";
+    print "\t-junit-xml                     : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
     exit 1;
 }
 
@@ -715,12 +715,12 @@ if ($runtests == 0) {
 
     $ENV{'CHPL_HOME'} = $chplhomedir;
 
-    # Always check chapel installation before start_test / paratest
-    if ($checkchplinstall eq 1) {
-        $checkinstallcommand = "bash ../test/checkChplInstall";
-        print "Executing $checkinstallcommand\n";
-        $chplinstallstatus = mysystem($checkinstallcommand);
-        print "$chplinstallstatus";
+    # Confirm Chapel built correctly before start_test / paratest
+    if ($buildcheck eq 1) {
+        $buildcheckcommand = "bash ../test/checkChplInstall";
+        print "Executing $buildcheckcommand\n";
+        $buildcheckstatus = mysystem($buildcheckcommand);
+        print "$buildcheckstatus";
     }
 
     if ($parnodefile eq "") {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -64,24 +64,24 @@ $junit_xml = 0;
 while (@ARGV) {
     $flag = shift @ARGV;
     if ($flag eq "-debug") {
-	$debug = 1;
+        $debug = 1;
         $printusage = 0;
     } elsif ($flag eq "-cron") {
-	$debug = 0;
+        $debug = 0;
         $printusage = 0;
     } elsif ($flag eq "-valgrind") {
-	$valgrind = 1;
+        $valgrind = 1;
     } elsif ($flag eq "-interpret") {
         $interpret = 1;
     } elsif ($flag eq "-notest") {
         $runtests = 0;
     } elsif ($flag eq "-noruntime") {
-	$buildruntime = 0;
+        $buildruntime = 0;
     } elsif ($flag eq "-hello") {
-	$hello = 1;
+        $hello = 1;
     } elsif ($flag eq "-hellos") {
-	$hello = 1;
-	$allhellos = 1;
+        $hello = 1;
+        $allhellos = 1;
     } elsif ($flag eq "-examples") {
         $examples = 1;
     } elsif ($flag eq "-multilocale") {
@@ -109,11 +109,11 @@ while (@ARGV) {
     } elsif ($flag eq "-numtrials") {
         $numtrials = shift @ARGV;
     } elsif ($flag eq "-compopts") {
-	$compopts = shift @ARGV;
+        $compopts = shift @ARGV;
     } elsif ($flag eq "-execopts") {
-	$execopts = shift @ARGV;
+        $execopts = shift @ARGV;
     } elsif ($flag eq "-startdate") {
-	$startdate = shift @ARGV;
+        $startdate = shift @ARGV;
     } elsif ($flag eq "-baseline") {
         $baseline = 1;
     } elsif ($flag eq "-dist") {
@@ -123,11 +123,11 @@ while (@ARGV) {
     } elsif ($flag eq "-memleaks") {
         $memleaks = shift @ARGV;
     } elsif ($flag eq "-componly") {
-	$componly = 1;
+        $componly = 1;
     } elsif ($flag eq "-futures") {
-	$futuresMode = 1;
+        $futuresMode = 1;
     } elsif ($flag eq "-no-futures") {
-	$futuresMode = 0;
+        $futuresMode = 0;
     } elsif ($flag eq "-parnodefile") {
         $parnodefile = shift @ARGV;
     } elsif ($flag eq "-no-local") {
@@ -195,7 +195,7 @@ if ($printusage == 1) {
     print "\t-performance-configs : comma seperated configs to graph, ':v' after config to be visible by default\n";
     print "\t-compperformance <description>: run tests with compiler performance tracking\n";
     print "\t-numtrials <number> : number of trials to run\n";
-    print "\t-startdate	  : run performance tests providing a common start date to all the graphs\n";
+    print "\t-startdate          : run performance tests providing a common start date to all the graphs\n";
     print "\t-baseline    : run testins using --baseline\n";
     print "\t-dist <dist> : run distribution robustness tests\n";
     print "\t-fast        : run tests using --fast\n";
@@ -257,13 +257,13 @@ if ($cronrecipient ne "") {
 #
 # directory locations
 #
-$basetmpdir = $ENV{'CHPL_NIGHTLY_TMPDIR'}; 
-if ($basetmpdir eq "") { 
-    $basetmpdir = $ENV{'TMPDIR'}; 
-} 
-if ($basetmpdir eq "") { 
-    $basetmpdir = "/tmp"; 
-} 
+$basetmpdir = $ENV{'CHPL_NIGHTLY_TMPDIR'};
+if ($basetmpdir eq "") {
+    $basetmpdir = $ENV{'TMPDIR'};
+}
+if ($basetmpdir eq "") {
+    $basetmpdir = "/tmp";
+}
 
 
 # Number of logical processes on current system. Will be used as number of jobs
@@ -512,10 +512,10 @@ if ($buildruntime == 0) {
 
     $mailsubject = "$subjectid $config_name";
     $mailcommand = "| $mailer -s \"$mailsubject \" $nochangerecipient";
-    
+
     print "Mailing to minimal group\n";
     open(MAIL, $mailcommand);
-    
+
     print MAIL startMailHeader($revision, "<no logfile>", $starttime, $endtime, $crontab, "");
     print MAIL "Built compiler but not runtime, and did not run tests\n";
     print MAIL endMailHeader();
@@ -582,7 +582,7 @@ if ($examples == 1) {
         }
     }
     if ($parnodefile ne "") {
-        mysystem("cd $testdir && find $testdirs -wholename \"*.svn\" -prune -o -type d > DIRFILE", 
+        mysystem("cd $testdir && find $testdirs -wholename \"*.svn\" -prune -o -type d > DIRFILE",
                  "making directory file", 1, 1);
         $testflags = "$testflags -dirfile DIRFILE";
     }
@@ -603,22 +603,22 @@ if ($parnodefile eq "") {
         $testflags = "$testflags -comm mpi";
     }
 }
-    
+
 if ($hello == 1) {
     if ($parnodefile eq "") {
-	if ($allhellos == 1) {
+        if ($allhellos == 1) {
         $testdirs .= " release/examples/hello*.chpl";
-	    $testflags = "$testflags --no-recurse release/examples";
-	} else {
+            $testflags = "$testflags --no-recurse release/examples";
+        } else {
         $testdirs .= " release/examples/hello.chpl";
-	    $testflags = "$testflags release/examples/hello.chpl";
-	}
+            $testflags = "$testflags release/examples/hello.chpl";
+        }
     } else {
-	mysystem("cd $testdir && echo $testdir > DIRFILE", "making directory file", 1, 1);
-	$testflags = "$testflags -dirfile DIRFILE";
+        mysystem("cd $testdir && echo $testdir > DIRFILE", "making directory file", 1, 1);
+        $testflags = "$testflags -dirfile DIRFILE";
     }
 }
-if ($performance == 1) { 
+if ($performance == 1) {
     if ($startdate eq "-1") {
         $testflags = "$testflags -performance";
     } else {
@@ -632,7 +632,7 @@ if ($performance == 1) {
     }
 
 }
-if ($compperformance == 1) { 
+if ($compperformance == 1) {
     if ($startdate eq "-1") {
         $testflags = "$testflags -compperformance-description \"$compperformancedescription\"";
     } else {
@@ -692,22 +692,26 @@ if ($runtests == 0) {
 
     $mailsubject = "$subjectid $config_name";
     $mailcommand = "| $mailer -s \"$mailsubject \" $recipient";
-    
+
     open(MAIL, $mailcommand);
-    
+
     print MAIL startMailHeader($revision, "<no logfile>", $starttime, $endtime, $crontab, "");
     print MAIL "Built compiler and runtime but did not run tests\n";
     print MAIL endMailHeader();
     print MAIL endMailChplenv();
-    
+
     close(MAIL);
-    
+
 } else {
 
     my $svnPerfDir = $ENV{'CHPL_TEST_PERF_DIR'};
     if ($compperformance == 1) {
         $svnPerfDir = $ENV{'CHPL_TEST_COMP_PERF_DIR'};
     }
+
+    # Always call `make check` before start_test
+    # TODO
+
 
     $ENV{'CHPL_HOME'} = $chplhomedir;
     if ($parnodefile eq "") {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -208,7 +208,7 @@ if ($printusage == 1) {
     print "\t-componly                      : only run the compiler, not the generated binary\n";
     print "\t-futures                       : run all futures, not just those with skipifs\n";
     print "\t-no-futures                    : do not run future tests\n";
-    print "\t-no-buildcheck                 : do not run checkChplInstall before running tests\n";
+    print "\t-no-buildcheck                 : do not run `make check` before running tests\n";
     print "\t-parnodefile                   : specify a node file to use for parallel testing\n";
     print "\t-cron-recipient                : send -cron emails to this address instead of SourceForge mailing list(s)\n";
     print "\t-junit-xml                     : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
@@ -718,7 +718,7 @@ if ($runtests == 0) {
     # Confirm Chapel built correctly before start_test / paratest
     if ($buildcheck == 1) {
         $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && make check";
-        mysystem($buildcheckcommand, "Running `make check`", 1, 1, 1);
+        mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
     }
 
     if ($parnodefile eq "") {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -716,10 +716,9 @@ if ($runtests == 0) {
     $ENV{'CHPL_HOME'} = $chplhomedir;
 
     # Confirm Chapel built correctly before start_test / paratest
-    if ($buildcheck eq 1) {
-        $buildcheckcommand = "bash ../test/checkChplInstall";
-        print "Executing $buildcheckcommand\n";
-        $buildcheckstatus = mysystem($buildcheckcommand);
+    if ($buildcheck == 1) {
+        $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && make check";
+        $buildcheckstatus = mysystem($buildcheckcommand, "Running `make check`", 1, 1, 1);
         print "$buildcheckstatus";
     }
 

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -22,23 +22,23 @@ sub mysystem {
     my $status = system($command);
     if ($status != 0) {
         $endtime = localtime;
-	$somethingfailed = 1;
+        $somethingfailed = 1;
         if($status != -1) {$status = $status / 256; }
-	print "Error $errorname: $status\n";
+        print "Error $errorname: $status\n";
 
-	if ($mailmsg != 0) {
+        if ($mailmsg != 0) {
             $mailsubject = "$subjectid $config_name Failure";
             $mailcommand = "| $mailer -s \"$mailsubject \" $recipient";
 
             print "Trying to mail message... using $mailcommand\n";
-	    open(MAIL, $mailcommand);
+            open(MAIL, $mailcommand);
             print MAIL startMailHeader($revision, $rawlog, $starttime, $endtime, $crontab, "");
-	    print MAIL "ERROR $errorname: $status\n";
-	    print MAIL "(workspace left at $tmpdir)\n";
+            print MAIL "ERROR $errorname: $status\n";
+            print MAIL "(workspace left at $tmpdir)\n";
             print MAIL endMailHeader();
             print MAIL endMailChplenv();
-	    close(MAIL);
-	}
+            close(MAIL);
+        }
 
         if ($fatal != 0) {
             exit 1;
@@ -129,7 +129,7 @@ sub endMailChplenv {
     }
     my $chplenv = `$ch/util/printchplenv --debug`;
 
-    my $mystr = 
+    my $mystr =
         "===============================================================\n" .
         "Chapel Environment:\n" .
         $chplenv . "\n";

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -140,7 +140,9 @@ else
     echo "\$CHPL_LAUNCHER=${chpl_launcher} is not compatible with test script."
     echo "This does not necessarily indicate that your Chapel installation is incorrect."
     echo "See \$CHPL_HOME/doc/launcher.rst for information on manually launching Chapel programs."
-    exit 0
+    # This exit code should be recognized as a failure to complete check, but
+    # not necessarily failure of build
+    exit 10
 fi
 
 TEST_EXEC_OUT=${TEST_JOB}.exec.out
@@ -171,7 +173,9 @@ TEST_EXEC_OUT=${TEST_JOB}.exec.out
         echo ""
         echo "== Diff Log =="
         echo "$(diff ${TEST_EXEC_OUT} ${GOOD})"
-    exit 10
+        # This exit code should be recognized as successfully building, but
+        # with some errors
+        exit 20
     fi
 )
 

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -66,7 +66,7 @@ fi
 CHPL_DIR=${CHPL_CHECK_INSTALL_DIR:-${HOME}/.chpl}
 if [ ! -d ${CHPL_DIR} ] ; then
     echo "${CHPL_DIR} does not exist. Creating it."
-    mkdir -p ${CHPL_DIR} || { echo "Failed to create ${CHPL_DIR}." && exit 10 ; }
+    mkdir -p ${CHPL_DIR} || { echo "Failed to create ${CHPL_DIR}." && exit 1 ; }
 fi
 
 # Location of test job
@@ -140,7 +140,7 @@ else
     echo "\$CHPL_LAUNCHER=${chpl_launcher} is not compatible with test script."
     echo "This does not necessarily indicate that your Chapel installation is incorrect."
     echo "See \$CHPL_HOME/doc/launcher.rst for information on manually launching Chapel programs."
-    exit 10
+    exit 0
 fi
 
 TEST_EXEC_OUT=${TEST_JOB}.exec.out


### PR DESCRIPTION
* `/util/cron/nightly` always run `checkChplInstall` unless `-no-buildcheck` flag is provided.
* Many minor formatting changes (trailing whitespaces, `'s/\t/         /g'`, print alignment)
* `checkChplInstall` modified to return 0 exit status when failing due to launcher incompatibilities (we don't want Jenkins jobs to fail if there is an incompatibility issue)

