### PR TITLE
Add --break-on-codegen-id

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3863,6 +3863,9 @@ GenRet CallExpr::codegen() {
 
   // Note (for debugging), function name is in parentSymbol->cname.
 
+  if (id == breakOnCodegenID)
+    gdbShouldBreakHere();
+
   if (getStmtExpr() && getStmtExpr() == this)
     codegenStmt(this);
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -823,8 +823,9 @@ void VarSymbol::codegenDefC(bool global) {
 void VarSymbol::codegenGlobalDef() {
   GenInfo* info = gGenInfo;
 
-  if( breakOnCodegenCname[0] &&
-      0 == strcmp(cname, breakOnCodegenCname) ) {
+  if( id == breakOnCodegenID ||
+      (breakOnCodegenCname[0] &&
+       0 == strcmp(cname, breakOnCodegenCname)) ) {
     gdbShouldBreakHere();
   }
 
@@ -1270,8 +1271,9 @@ void TypeSymbol::codegenPrototype() {
 void TypeSymbol::codegenDef() {
   GenInfo *info = gGenInfo;
 
-  if( breakOnCodegenCname[0] &&
-      0 == strcmp(cname, breakOnCodegenCname) ) {
+  if( id == breakOnCodegenID ||
+      (breakOnCodegenCname[0] &&
+       0 == strcmp(cname, breakOnCodegenCname)) ) {
     gdbShouldBreakHere();
   }
 
@@ -1931,8 +1933,9 @@ void FnSymbol::codegenPrototype() {
   if (hasFlag(FLAG_NO_PROTOTYPE)) return;
   if (hasFlag(FLAG_NO_CODEGEN))   return;
 
-  if( breakOnCodegenCname[0] &&
-      0 == strcmp(cname, breakOnCodegenCname) ) {
+  if( id == breakOnCodegenID ||
+      (breakOnCodegenCname[0] &&
+       0 == strcmp(cname, breakOnCodegenCname)) ) {
     gdbShouldBreakHere();
   }
 
@@ -2012,8 +2015,9 @@ void FnSymbol::codegenDef() {
   llvm::Function *func = NULL;
 #endif
 
-  if( breakOnCodegenCname[0] &&
-      0 == strcmp(cname, breakOnCodegenCname) ) {
+  if( id == breakOnCodegenID ||
+      (breakOnCodegenCname[0] &&
+       0 == strcmp(cname, breakOnCodegenCname)) ) {
     gdbShouldBreakHere();
   }
 

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -134,6 +134,7 @@ extern bool fCacheRemote;
 // with clang and then added to the enclosing module's scope
 extern bool externC;
 extern char breakOnCodegenCname[256];
+extern int breakOnCodegenID;
 
 enum { LS_DEFAULT=0, LS_STATIC, LS_DYNAMIC };
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -189,6 +189,7 @@ bool externC = true;
 bool externC = false;
 #endif
 char breakOnCodegenCname[256] = "";
+int breakOnCodegenID = 0;
 
 bool debugCCode = false;
 bool optimizeCCode = false;
@@ -822,6 +823,7 @@ static ArgumentDescription arg_desc[] = {
  {"break-on-id", ' ', NULL, "Break when AST id is created", "I", &breakOnID, "CHPL_BREAK_ON_ID", NULL},
  {"break-on-delete-id", ' ', NULL, "Break when AST id is deleted", "I", &breakOnDeleteID, "CHPL_BREAK_ON_DELETE_ID", NULL},
  {"break-on-codegen", ' ', NULL, "Break when function cname is code generated", "S256", &breakOnCodegenCname, "CHPL_BREAK_ON_CODEGEN", NULL},
+ {"break-on-codegen-id", ' ', NULL, "Break when id is code generated", "I", &breakOnCodegenID, "CHPL_BREAK_ON_CODEGEN_ID", NULL},
  {"default-dist", ' ', "<distribution>", "Change the default distribution", "S256", defaultDist, "CHPL_DEFAULT_DIST", NULL},
  {"explain-call-id", ' ', "<call-id>", "Explain resolution of call by ID", "I", &explainCallID, NULL, NULL},
  {"break-on-resolve-id", ' ', NULL, "Break when function call with AST id is resolved", "I", &breakOnResolveID, "CHPL_BREAK_ON_RESOLVE_ID", NULL},


### PR DESCRIPTION
I found it useful when doing some debugging to be able to request
a breakpoint on code generation of a particular AST ID.

This patch adds that functionality with --break-on-codegen-id.