### PR TITLE
Allow record arguments by ref

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3863,6 +3863,9 @@ GenRet CallExpr::codegen() {
 
   // Note (for debugging), function name is in parentSymbol->cname.
 
+  if (id == breakOnCodegenID)
+    gdbShouldBreakHere();
+
   if (getStmtExpr() && getStmtExpr() == this)
     codegenStmt(this);
 

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -2498,6 +2498,10 @@ GenRet codegenArgForFormal(GenRet arg,
     if (!isExtern &&
         formal->requiresCPtr() &&
         !formal->type->symbol->hasFlag(FLAG_REF)) { 
+      if( arg.isLVPtr == GEN_WIDE_PTR ) {
+        // communicate wide pointer values
+        arg = codegenValue(arg);
+      }
       if( arg.isLVPtr == GEN_VAL ) {
         arg = codegenValuePtr(arg);
       }

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -823,8 +823,9 @@ void VarSymbol::codegenDefC(bool global) {
 void VarSymbol::codegenGlobalDef() {
   GenInfo* info = gGenInfo;
 
-  if( breakOnCodegenCname[0] &&
-      0 == strcmp(cname, breakOnCodegenCname) ) {
+  if( id == breakOnCodegenID ||
+      (breakOnCodegenCname[0] &&
+       0 == strcmp(cname, breakOnCodegenCname)) ) {
     gdbShouldBreakHere();
   }
 
@@ -1270,8 +1271,9 @@ void TypeSymbol::codegenPrototype() {
 void TypeSymbol::codegenDef() {
   GenInfo *info = gGenInfo;
 
-  if( breakOnCodegenCname[0] &&
-      0 == strcmp(cname, breakOnCodegenCname) ) {
+  if( id == breakOnCodegenID ||
+      (breakOnCodegenCname[0] &&
+       0 == strcmp(cname, breakOnCodegenCname)) ) {
     gdbShouldBreakHere();
   }
 
@@ -1931,8 +1933,9 @@ void FnSymbol::codegenPrototype() {
   if (hasFlag(FLAG_NO_PROTOTYPE)) return;
   if (hasFlag(FLAG_NO_CODEGEN))   return;
 
-  if( breakOnCodegenCname[0] &&
-      0 == strcmp(cname, breakOnCodegenCname) ) {
+  if( id == breakOnCodegenID ||
+      (breakOnCodegenCname[0] &&
+       0 == strcmp(cname, breakOnCodegenCname)) ) {
     gdbShouldBreakHere();
   }
 
@@ -2012,8 +2015,9 @@ void FnSymbol::codegenDef() {
   llvm::Function *func = NULL;
 #endif
 
-  if( breakOnCodegenCname[0] &&
-      0 == strcmp(cname, breakOnCodegenCname) ) {
+  if( id == breakOnCodegenID ||
+      (breakOnCodegenCname[0] &&
+       0 == strcmp(cname, breakOnCodegenCname)) ) {
     gdbShouldBreakHere();
   }
 

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -134,6 +134,7 @@ extern bool fCacheRemote;
 // with clang and then added to the enclosing module's scope
 extern bool externC;
 extern char breakOnCodegenCname[256];
+extern int breakOnCodegenID;
 
 enum { LS_DEFAULT=0, LS_STATIC, LS_DYNAMIC };
 

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -669,6 +669,13 @@ checkFormalActualTypesMatch()
                     formal->name);
         }
 
+
+        if (isRecord(formal->type) &&
+            actual->typeInfo()->getValType() == formal->type )
+          // allow ref actuals for records
+          // since they are always passed by ref
+          continue;
+
         if (formal->type != actual->typeInfo())
           INT_FATAL(call,
                     "actual formal type mismatch for %s: %s != %s",

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -189,6 +189,7 @@ bool externC = true;
 bool externC = false;
 #endif
 char breakOnCodegenCname[256] = "";
+int breakOnCodegenID = 0;
 
 bool debugCCode = false;
 bool optimizeCCode = false;
@@ -822,6 +823,7 @@ static ArgumentDescription arg_desc[] = {
  {"break-on-id", ' ', NULL, "Break when AST id is created", "I", &breakOnID, "CHPL_BREAK_ON_ID", NULL},
  {"break-on-delete-id", ' ', NULL, "Break when AST id is deleted", "I", &breakOnDeleteID, "CHPL_BREAK_ON_DELETE_ID", NULL},
  {"break-on-codegen", ' ', NULL, "Break when function cname is code generated", "S256", &breakOnCodegenCname, "CHPL_BREAK_ON_CODEGEN", NULL},
+ {"break-on-codegen-id", ' ', NULL, "Break when id is code generated", "I", &breakOnCodegenID, "CHPL_BREAK_ON_CODEGEN_ID", NULL},
  {"default-dist", ' ', "<distribution>", "Change the default distribution", "S256", defaultDist, "CHPL_DEFAULT_DIST", NULL},
  {"explain-call-id", ' ', "<call-id>", "Explain resolution of call by ID", "I", &explainCallID, NULL, NULL},
  {"break-on-resolve-id", ' ', NULL, "Break when function call with AST id is resolved", "I", &breakOnResolveID, "CHPL_BREAK_ON_RESOLVE_ID", NULL},

--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -79,10 +79,10 @@ inlineCall(FnSymbol* fn, CallExpr* call, Vec<FnSymbol*>& canRemoveRefTempSet) {
                                       actual->typeInfo()->getValType());
       stmt->insertBefore(new DefExpr(deref_tmp));
       stmt->insertBefore(
-          new CallExpr(PRIM_MOVE, deref_tmp, 
+          new CallExpr(PRIM_MOVE, deref_tmp,
                        new CallExpr(PRIM_DEREF, se->var)) );
 
-      se = new SymExpr(deref_tmp); 
+      se = new SymExpr(deref_tmp);
     }
 
     map.put(formal, se->var);

--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -66,6 +66,25 @@ inlineCall(FnSymbol* fn, CallExpr* call, Vec<FnSymbol*>& canRemoveRefTempSet) {
         }
       }
     }
+
+    // record arguments passed to functions could have
+    // a reference actual but a non-reference formal.
+    // To inline correctly, we need to add a PRIM_DEREF on the actual.
+    if (actual->typeInfo()->symbol->hasFlag(FLAG_REF) &&
+        actual->typeInfo()->getValType() == formal->type &&
+        isRecord(formal->type) ) {
+      // Add a new variable storing the result of PRIM_DEREF.
+
+      VarSymbol * deref_tmp = newTemp(astr("deref_tmp"),
+                                      actual->typeInfo()->getValType());
+      stmt->insertBefore(new DefExpr(deref_tmp));
+      stmt->insertBefore(
+          new CallExpr(PRIM_MOVE, deref_tmp, 
+                       new CallExpr(PRIM_DEREF, se->var)) );
+
+      se = new SymExpr(deref_tmp); 
+    }
+
     map.put(formal, se->var);
   }
 

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -465,9 +465,21 @@ static bool needToAddCoercion(Type* actualType, Symbol* actualSym,
                               Type* formalType, FnSymbol* fn) {
   if (actualType == formalType)
     return false;
-  else
-    return canCoerce(actualType, actualSym, formalType, fn) ||
-           isDispatchParent(actualType, formalType);
+
+  // Handle the case in which the formal is a record
+  // differently. In particular, records are always
+  // passed by reference. If a copy is created (e.g. for
+  // in intent), that copy is created in the callee.
+  // Therefore, we should not add temporary values
+  // that store record values when passing a
+  // reference to a record into a function with
+  // any record argument.
+  Type* actualValType = actualType->getValType();
+  if ( isRecord(actualValType) && actualValType == formalType )
+    return false;
+
+  return canCoerce(actualType, actualSym, formalType, fn) ||
+         isDispatchParent(actualType, formalType);
 }
 
 // Add a coercion; replace prevActual and actualSym - the actual to 'call' -


### PR DESCRIPTION
Before this patch, function resolution adds coercion temporaries
so that the actual argument for a record formal is never a reference.

For example, if you have code like

    proc myproc(r:R)
    {
      writeln(r);
    }

    proc byref(ref r:R)
    {
      myproc(r);
    }

the body of byref will generate

    coerce_tmp  = deref r
    myproc(&coerce_tmp)

when in fact there is no reason (that I can think of)
for this temporary to be created. In particular, functions
with 'in' intent will create the copy in the callee.

- [ ] solve problem with wide ref -> local ref argument
- [ ] single-locale testing
- [ ] multi-locale testing