### PR TITLE
Reverted 5df1b3a on string-as-rec

### DIFF
--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -21,13 +21,7 @@
 //
 module ChapelReduce {
   
-  // The insertion of const in intent here is a workaround for context in which
-  // chpl__scanIterator is called passing a data argument that is a temporary.
-  // The const in intent forces the data argument to be copied by value into
-  // the iterator record representing this iterator, so the problem of a
-  // creating a reference to temporary data is avoided.
-  // This workaround causes a deep copy of arrays and domains, so it is only temporary!
-  iter chpl__scanIteratorZip(op, const in data) {
+  iter chpl__scanIteratorZip(op, data) {
     for e in zip((...data)) {
       op.accumulate(e);
       yield op.generate();
@@ -35,8 +29,7 @@ module ChapelReduce {
     delete op;
   }
   
-  // Reason for const in intent the same as above.
-  iter chpl__scanIterator(op, const in data) {
+  iter chpl__scanIterator(op, data) {
     for e in data {
       op.accumulate(e);
       yield op.generate();


### PR DESCRIPTION
This reverts 5df1b3a366a7a59e819edfba9cb7f313729b1969
Add const in intent to chpl__scanIterator[Zip]() to let some reduce tests pass.

5df1b3a is a follow-up to 92ceee2. The latter was reverted
(albeit referenced as 2d8ceaf) as part of #2397.
This reversion follows up to that.

This closes JIRA issue 108:
  https://chapel.atlassian.net/browse/CHAPEL-108