### PR TITLE
Fix `make check` in nightly

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -717,7 +717,7 @@ if ($runtests == 0) {
 
     # Confirm Chapel built correctly before start_test / paratest
     if ($buildcheck == 1) {
-        $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && make check";
+        $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && source util/setchplenv.bash && make check";
         mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
     }
 


### PR DESCRIPTION
#2721 added some code in nightly that calls `make check` before actually
running the tests. This has two purposes: It ensures that we test that `make
check` actually works and it avoids running all of our tests in the event that
the build is broken.

However, it was slightly broken because `make check` couldn't find the chpl
binary. start_test will figure out the path to the chpl binary from $CHPL_HOME,
but we don't want `make check` to do that. This was hard to test because the
method we use to check changes to nightly sources a setchplenv script, so the
problem only showed up in nightly testing.

To fix this issue, this patch just adds a `source util/setchplenv.bash` before
calling `make check`. This is all done in a mysystem call, so it won't impact
the anything in nightly outside of the `make check`.