### PR TITLE
Reverted 80cc930 and 9ee323f on string-as-rec

### DIFF
--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -56,7 +56,7 @@ module LocaleModel {
   // a correct one for a record type whose members are not known to it.
   pragma "init copy fn"
   extern chpl__initCopy_chpl_rt_localeID_t
-  proc chpl__initCopy(in initial: chpl_localeID_t): chpl_localeID_t;
+  proc chpl__initCopy(initial: chpl_localeID_t): chpl_localeID_t;
 
   extern var chpl_nodeID: chpl_nodeID_t;
 
@@ -65,10 +65,10 @@ module LocaleModel {
     proc chpl_rt_buildLocaleID(node: chpl_nodeID_t,
                                subloc: chpl_sublocID_t): chpl_localeID_t;
   extern
-    proc chpl_rt_nodeFromLocaleID(in loc: chpl_localeID_t): chpl_nodeID_t;
+    proc chpl_rt_nodeFromLocaleID(loc: chpl_localeID_t): chpl_nodeID_t;
 
   extern
-    proc chpl_rt_sublocFromLocaleID(in loc: chpl_localeID_t): chpl_sublocID_t;
+    proc chpl_rt_sublocFromLocaleID(loc: chpl_localeID_t): chpl_sublocID_t;
 
   // Compiler (and module code) interface for manipulating global locale IDs..
   pragma "insert line file info"

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -58,7 +58,7 @@ module LocaleModel {
   // a correct one for a record type whose members are not known to it.
   pragma "init copy fn"
   extern chpl__initCopy_chpl_rt_localeID_t
-  proc chpl__initCopy(in initial: chpl_localeID_t): chpl_localeID_t;
+  proc chpl__initCopy(initial: chpl_localeID_t): chpl_localeID_t;
 
   extern var chpl_nodeID: chpl_nodeID_t;
 
@@ -68,10 +68,10 @@ module LocaleModel {
                                subloc: chpl_sublocID_t): chpl_localeID_t;
 
   extern
-    proc chpl_rt_nodeFromLocaleID(in loc: chpl_localeID_t): chpl_nodeID_t;
+    proc chpl_rt_nodeFromLocaleID(loc: chpl_localeID_t): chpl_nodeID_t;
 
   extern
-    proc chpl_rt_sublocFromLocaleID(in loc: chpl_localeID_t): chpl_sublocID_t;
+    proc chpl_rt_sublocFromLocaleID(loc: chpl_localeID_t): chpl_sublocID_t;
 
   // Compiler (and module code) interface for manipulating global locale IDs..
   pragma "insert line file info"

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1992,7 +1992,7 @@ proc file.check() {
 }
 
 pragma "no doc"
-proc ref file.~file() {
+proc file.~file() {
   on this.home {
     qio_file_release(_file_internal);
     this._file_internal = QIO_FILE_PTR_NULL;
@@ -2637,7 +2637,7 @@ proc channel.channel(param writing:bool, param kind:iokind, param locking:bool, 
 }
 
 pragma "no doc"
-proc ref channel.~channel() {
+proc channel.~channel() {
   on this.home {
     qio_channel_release(_channel_internal);
     this._channel_internal = QIO_CHANNEL_PTR_NULL;

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -77,7 +77,7 @@ record list {
   /*
     Append `e` to the list.
    */
-  proc ref append(e : eltType) {
+  proc append(e : eltType) {
     if last {
       last.next = new listNode(eltType, e);
       last = last.next;
@@ -119,7 +119,7 @@ record list {
   /*
     Remove the first encountered instance of `x` from the list.
    */
-  proc ref remove(x: eltType) {
+  proc remove(x: eltType) {
     var tmp = first,
         prev: first.type = nil;
     while tmp != nil && tmp.data != x {

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -595,7 +595,7 @@ record regexp {
 
   // note - more = overloads are below.
   pragma "no doc"
-  proc ref ~regexp() {
+  proc ~regexp() {
     qio_regexp_release(_regexp);
     _regexp = qio_regexp_null();
   }

--- a/test/extern/bradc/emptyRecords/emptyexternrecord.chpl
+++ b/test/extern/bradc/emptyRecords/emptyexternrecord.chpl
@@ -5,6 +5,6 @@ extern record R {
 
 var myR: R;
 
-extern proc foo(const in myR:R);
+extern proc foo(myR:R);
 
 foo(myR);

--- a/test/extern/bradc/structs/externFloat4calls.chpl
+++ b/test/extern/bradc/structs/externFloat4calls.chpl
@@ -3,7 +3,7 @@ extern record float4 {
 }
 
 extern proc getfloat4(): float4;
-extern proc printme(const in val: float4);
+extern proc printme(val: float4);
 
 var myf42: float4 = getfloat4();
 writeln("myf42 = ", myf42);

--- a/test/extern/bradc/structs/externFloat4calls.someFields.chpl
+++ b/test/extern/bradc/structs/externFloat4calls.someFields.chpl
@@ -3,7 +3,7 @@ extern record float4 {
 }
 
 extern proc getfloat4(): float4;
-extern proc printme(const in val: float4);
+extern proc printme(val: float4);
 
 var myf42: float4 = getfloat4();
 writeln("myf42 = ", myf42);

--- a/test/extern/ferguson/crazyRecord.chpl
+++ b/test/extern/ferguson/crazyRecord.chpl
@@ -10,37 +10,37 @@
 extern record A_BCde {
 }
 extern proc return_A_BCde():A_BCde;
-extern proc print_A_BCde(const in r:A_BCde);
+extern proc print_A_BCde(r:A_BCde);
 
 extern record iAbc {
 }
 extern proc return_iAbc():iAbc;
-extern proc print_iAbc(const in r:iAbc);
+extern proc print_iAbc(r:iAbc);
 
 extern record iaBc {
 }
 extern proc return_iaBc():iaBc;
-extern proc print_iaBc(const in r:iaBc);
+extern proc print_iaBc(r:iaBc);
 
 extern record iabC {
 }
 extern proc return_iabC():iabC;
-extern proc print_iabC(const in r:iabC);
+extern proc print_iabC(r:iabC);
 
 extern record iABc {
 }
 extern proc return_iABc():iABc;
-extern proc print_iABc(const in r:iABc);
+extern proc print_iABc(r:iABc);
 
 extern record iaBC {
 }
 extern proc return_iaBC():iaBC;
-extern proc print_iaBC(const in r:iaBC);
+extern proc print_iaBC(r:iaBC);
 
 extern record iaBCd {
 }
 extern proc return_iaBCd():iaBCd;
-extern proc print_iaBCd(const in r:iaBCd);
+extern proc print_iaBCd(r:iaBCd);
 
 { var r:A_BCde; r = return_A_BCde(); print_A_BCde(r); }
 { var r:iAbc; r = return_iAbc(); print_iAbc(r); }


### PR DESCRIPTION
80cc930 and 9ee323f made these two kinds of changes, which are being reverted in this PR:

(A) proc ~regexp()  -->  proc ref ~regexp()

This change is needed because the destructor updates one of the fields of 'this'. Without the explicit 'ref' intent, 'this' implicitly has 'const ref' concrete intent, so it is illegal to update its fields. The compiler lets this code pass because it lacks checking for this case.

This change is good. We want to do it on master and propagate to string-as-rec from there.

(B) extern proc printme(val: float4)  -->  extern proc printme(const in val: float4)

where 'float4' is an 'extern' record. This change is not needed because the default intent for 'extern' formals already corresponds to "const in" in C code, according to the Interoperability chapter in the spec (almost) and the current implementation.


Passes linux64 testing on string-as-rec, i.e. does not affect the set of failing tests.

This PR closes JIRA issue 105:
  https://chapel.atlassian.net/browse/CHAPEL-105
