### PR TITLE
added bug future: passing sync/single vars to generic const args

### DIFF
--- a/STATUS.devel
+++ b/STATUS.devel
@@ -240,8 +240,10 @@ Functions and Iterators
 - Actual arguments for formals with out intent do not follow implicit
   conversion rules and must match exactly in type.
   # functions/vass/out-intent-desired.future
-- Sync and single vars incorrectly passed to generic ref intent arguments.
+- Sync and single vars incorrectly passed to generic ref or const intent
+  arguments.
   # types/sync/vass/ref-sync-2.future
+  # users/vass/isX/isX.sync-by-const.future
 - Sync and single variables in records are not properly copied out
   when the record is passed as an out or inout argument.
   # types/single/sungeun/writeRecordInOutProc.future

--- a/test/users/vass/isX/README
+++ b/test/users/vass/isX/README
@@ -25,3 +25,7 @@ These tests were generated automatically by running:
   src/isX.gen
 
 and added to version control for ease of use.
+
+* isX.sync-by-const.chpl
+
+This test is a bug future, created by hand.

--- a/test/users/vass/isX/isX.sync-by-const.bad
+++ b/test/users/vass/isX/isX.sync-by-const.bad
@@ -1,0 +1,15 @@
+isX.sync-by-const.chpl:7: warning: true
+isX.sync-by-const.chpl:8: warning: true
+Note: This source location is a guess.
+isX.sync-by-const.chpl:8: warning: true
+isX.sync-by-const.chpl:9: warning: true
+Note: This source location is a guess.
+isX.sync-by-const.chpl:9: warning: true
+isX.sync-by-const.chpl:12: warning: false
+isX.sync-by-const.chpl:13: warning: false
+Note: This source location is a guess.
+isX.sync-by-const.chpl:13: warning: false
+isX.sync-by-const.chpl:14: warning: true
+Note: This source location is a guess.
+isX.sync-by-const.chpl:14: warning: true
+isX.sync-by-const.chpl:16: error: done

--- a/test/users/vass/isX/isX.sync-by-const.chpl
+++ b/test/users/vass/isX/isX.sync-by-const.chpl
@@ -1,0 +1,16 @@
+
+proc isInt1(          e) param return isIntValue(e);
+proc isInt2(const ref e) param return isIntValue(e);
+proc isInt3(const     e) param return isIntValue(e);
+
+var myInt: int;
+compilerWarning(isInt1(myInt):c_string);
+compilerWarning(isInt2(myInt):c_string);
+compilerWarning(isInt3(myInt):c_string);
+
+var syInt:  sync int;
+compilerWarning(isInt1(syInt):c_string);
+compilerWarning(isInt2(syInt):c_string);
+compilerWarning(isInt3(syInt):c_string);
+
+compilerError("done");

--- a/test/users/vass/isX/isX.sync-by-const.future
+++ b/test/users/vass/isX/isX.sync-by-const.future
@@ -1,0 +1,8 @@
+bug: Sync and single vars incorrectly passed to generic const intent arguments.
+
+When a 'sync' or 'single' variable is passed to a generic 'const' formal,
+it is read out and passed as its base type, rather than being passed
+as sync/single type directly, by reference.
+
+See also:
+  types/sync/vass/ref-sync-2.future

--- a/test/users/vass/isX/isX.sync-by-const.good
+++ b/test/users/vass/isX/isX.sync-by-const.good
@@ -1,0 +1,15 @@
+isX.sync-by-const.chpl:7: warning: true
+isX.sync-by-const.chpl:8: warning: true
+Note: This source location is a guess.
+isX.sync-by-const.chpl:8: warning: true
+isX.sync-by-const.chpl:9: warning: true
+Note: This source location is a guess.
+isX.sync-by-const.chpl:9: warning: true
+isX.sync-by-const.chpl:12: warning: false
+isX.sync-by-const.chpl:13: warning: false
+Note: This source location is a guess.
+isX.sync-by-const.chpl:13: warning: false
+isX.sync-by-const.chpl:14: warning: false
+Note: This source location is a guess.
+isX.sync-by-const.chpl:14: warning: false
+isX.sync-by-const.chpl:16: error: done


### PR DESCRIPTION
When a 'sync' or 'single' variable is passed to a generic 'const' formal,
it is read out and passed as its base type, rather than being passed
as sync/single type directly, by reference.

var syInt:  sync int;
if isInt(syInt) then ...;

// correctly returns false
proc isInt(          e) param return isIntValue(e);
proc isInt(const ref e) param return isIntValue(e);
// incorrectly returns true
proc isInt(const     e) param return isIntValue(e);

See also:
  types/sync/vass/ref-sync-2.future