### PR TITLE
Fix `make check` in nightly (round 2)

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -717,7 +717,7 @@ if ($runtests == 0) {
 
     # Confirm Chapel built correctly before start_test / paratest
     if ($buildcheck == 1) {
-        $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && source util/setchplenv.bash && make check";
+        $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.bash && make check";
         mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
     }
 


### PR DESCRIPTION
#2728 fixed `make check` in nightly by source-ing a setchplenv script first.
However, it was still failing on ubutnu based systems. This was because perl's
system() function uses /bin/sh and not /bin/bash. In bash `.` and `source` are
synonymous, but that's not necessarily true for sh.  Since it's /bin/sh, the
`.` operator is the right thing to use instead of `source`