### PR TITLE
Update a .good and remove a .future and .bad fixed by PR #2712

### DIFF
--- a/STATUS.devel
+++ b/STATUS.devel
@@ -317,11 +317,7 @@ Functions and Iterators
   # functions/sungeun/const_ref_arg_default_value.future
 - Formal argument intents on 'this' can result in incorrect function resolution
   or errors.
-  # functions/bradc/paramThis/funParamThis2.future
   # functions/bradc/paramThis/funParamThis3.future
-- Formal argument intents on 'this' should not be allowed for standalone
-  procedures
-  # functions/bradc/thisIntentStandalone.future
 
 
 Strings

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -197,7 +197,7 @@ checkFunction(FnSymbol* fn) {
     USR_WARN(fn, "providing an explicit return type on a 'param' function currently leads to incorrect results; as a workaround, remove the return type specification in function '%s'", fn->name);
 
   if (fn->thisTag != INTENT_BLANK && !fn->hasFlag(FLAG_METHOD)) {
-    USR_FATAL_CONT(fn, "Cannot apply a 'this' intent to a standalone function");
+    USR_FATAL_CONT(fn, "'this' intents can only be applied to methods");
   }
 
   std::vector<CallExpr*> calls;

--- a/test/functions/bradc/paramThis/funParamThis2.bad
+++ b/test/functions/bradc/paramThis/funParamThis2.bad
@@ -1,1 +1,0 @@
-In foo() with (nonsensical) param this

--- a/test/functions/bradc/paramThis/funParamThis2.future
+++ b/test/functions/bradc/paramThis/funParamThis2.future
@@ -1,5 +1,0 @@
-bug: non-methods should not support 'this' intents
-
-This test case exhibits behavior that we now think should be illegal:
-Applying 'this' intents to non-methods.  Discussed on email with
-Mike and Vass on Monday, Feb 9, 2015.

--- a/test/functions/bradc/paramThis/funParamThis2.good
+++ b/test/functions/bradc/paramThis/funParamThis2.good
@@ -1,1 +1,1 @@
-funParamThis2.chpl:1: error: 'this' intents can only be applied to methods
+funParamThis2.chpl:1: error: Cannot apply a 'this' intent to a standalone function

--- a/test/functions/bradc/paramThis/funParamThis2.good
+++ b/test/functions/bradc/paramThis/funParamThis2.good
@@ -1,1 +1,1 @@
-funParamThis2.chpl:1: error: Cannot apply a 'this' intent to a standalone function
+funParamThis2.chpl:1: error: 'this' intents can only be applied to methods

--- a/test/functions/bradc/thisIntentStandalone.good
+++ b/test/functions/bradc/thisIntentStandalone.good
@@ -1,2 +1,2 @@
-thisIntentStandalone.chpl:7: error: Cannot apply a 'this' intent to a standalone function
-thisIntentStandalone.chpl:11: error: Cannot apply a 'this' intent to a standalone function
+thisIntentStandalone.chpl:7: error: 'this' intents can only be applied to methods
+thisIntentStandalone.chpl:11: error: 'this' intents can only be applied to methods


### PR DESCRIPTION
This .future was fixed by PR #2712 which added an error message for procedures
that have 'this' intents but are not methods.  The .good file was updated to
match the text of the error.

Removed the two fixed .futures from STATUS.devel.