### PR TITLE
Store a locale in the string record

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -39,7 +39,6 @@ module String {
   use CString;
   use SysCTypes;
   use StringCasts;
-  use ChapelLocaleTypes;
 
   //
   // Externs and constants used to implement strings
@@ -113,7 +112,7 @@ module String {
     var _size: int = 0; // size of the buffer we own
     var buff: bufferType = nil;
     var owned: bool = true;
-    var locale_id : chpl_nodeID_t = chpl_nodeID;
+    var locale_id /* : chpl_nodeID_t */ = chpl_nodeID;
 
     proc string(s: string, owned: bool = true) {
       const sRemote = s.locale_id != chpl_nodeID;


### PR DESCRIPTION
For multilocale, we're running into many issues where the compiler is
bit-copying a string record across locales.

It's not clear that is the semantics we want in the end, but I've prepared this
patch in order to possibly get a working string implementation more quickly.

This patch was complicated by internal module ordering issues.
I needed to:
* use an integer instead of a locale class instance to
* use the chpl_on_locale_num primitive for on statements

In addition, I was not able to explicitly use chpl_nodeID_t as the type of the
locale_id field; also I have commented out a fatal error in the cast from
c_string to string because it led to some kind of circular definition with
LocaleModels.

Another way to make this change would be to store the string buffer with ddata
instead of c_ptr (to make it a wide pointer). I opted to add a field named
locale_id instead because then the code is more textually similar to the
original version which uses .locale.id in order to reason about the locale of
strings.

Passes full local testing on string-as-rec without additional failures.

With this patch, hello6 works in a GASNet configuration.