### PR TITLE
Add CHPL_TEST_LOG_PREFIX as an option to our nightly testing

### DIFF
--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -83,7 +83,7 @@ export CHPL_TARGET_ARCH=none
 #       working tree (under $CHPL_HOME), and b) less specific to our file
 #       system hierarchy. (thomasvandoren, 2014-01-24)
 
-default_prefix=${TMPDIR:-/tmp}/chapel_logs
+default_prefix=${CHPL_TEST_LOG_PREFIX:-${TMPDIR:-/tmp}/chapel_logs}
 cascade_prefix=/data/sea/chapel
 if [ -d $cascade_prefix ] ; then
     logdir_prefix=$cascade_prefix


### PR DESCRIPTION
This env var will change set the default_prefix used in our scripts,
allowing us to change the root of the tree used to store log files and
performance data.