### PR TITLE
Remove "all" as a dependency of `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ clobber: FORCE
 depend:
 	@echo "make depend has been deprecated for the time being"
 
-check: all
+check:
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
 
 check-chpldoc: chpldoc third-party-test-venv


### PR DESCRIPTION
`make check` has historically depended on "all" (runtime, compiler, modules,
etc.) However, this isn't really appropriate since we expect a user to have
already run make, and not use `make check` to both build and test.

This dependency also causes issues for installed versions of chapel such as
homebrew and the cray module. Users don't have write access to $CHPL_HOME, but
the make target for the compiler will often try to re-create BUILD_VERSION,
which results in a make error, preventing the actual check from running.

This should also fix some regressions for whitebox testing. `make check` was
being run with different options then the original `make`, resulting in an
unexpected version number. Now that `make check` won't rebuild the version
number this shouldn't be an issue.