### PR TITLE
Add explicit ref intent for 'this'

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1745,7 +1745,7 @@ module ChapelRange {
   
   // Write implementation for ranges
   pragma "no doc"
-  proc range.readWriteThis(f)
+  proc ref range.readWriteThis(f)
   {
     if f.writing && !aligned {
       // set things up so alignment does not get printed out

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1992,7 +1992,7 @@ proc file.check() {
 }
 
 pragma "no doc"
-proc file.~file() {
+proc ref file.~file() {
   on this.home {
     qio_file_release(_file_internal);
     this._file_internal = QIO_FILE_PTR_NULL;
@@ -2626,7 +2626,7 @@ proc channel.channel(param writing:bool, param kind:iokind, param locking:bool, 
 }
 
 pragma "no doc"
-proc channel.~channel() {
+proc ref channel.~channel() {
   on this.home {
     qio_channel_release(_channel_internal);
     this._channel_internal = QIO_CHANNEL_PTR_NULL;

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -72,7 +72,7 @@ record list {
   /*
     Append `e` to the list.
    */
-  proc append(e : eltType) {
+  proc ref append(e : eltType) {
     if last {
       last.next = new listNode(eltType, e);
       last = last.next;
@@ -114,7 +114,7 @@ record list {
   /*
     Remove the first encountered instance of `x` from the list.
    */
-  proc remove(x: eltType) {
+  proc ref remove(x: eltType) {
     var tmp = first,
         prev: first.type = nil;
     while tmp != nil && tmp.data != x {

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -591,7 +591,7 @@ record regexp {
 
   // note - more = overloads are below.
   pragma "no doc"
-  proc ~regexp() {
+  proc ref ~regexp() {
     qio_regexp_release(_regexp);
     _regexp = qio_regexp_null();
   }


### PR DESCRIPTION
This applies a part of 9ee323f
which I reverted on string-as-rec in PR #2729
plus a couple of similar cases.

E.g.:

  proc ~regexp() --> proc ref ~regexp()

This change is needed because the destructor updates one of the fields
of 'this'. Without the explicit 'ref' intent, 'this' implicitly has
'const ref' concrete intent, so it is illegal to update its fields.
The compiler lets this code pass because it lacks checking for this case.
