### PR TITLE
Close begin heap regressions

### DIFF
--- a/test/parallel/begin/waynew/record2.chpl
+++ b/test/parallel/begin/waynew/record2.chpl
@@ -9,9 +9,11 @@ proc jam() {
   r.x = 7;
   writeln( r);
 
-  begin with (ref r) {
-    r.x = 14;
-    writeln( r);
+  sync {  // make sure we don't de-allocate 'r' prior to leaving jam()'s scope
+    begin with (ref r) {
+      r.x = 14;
+      writeln( r);
+    }
   }
 }
 

--- a/test/parallel/begin/waynew/simple2.chpl
+++ b/test/parallel/begin/waynew/simple2.chpl
@@ -7,13 +7,15 @@ var c = 1;
 proc work() {
   var b = 2;
 
-  begin with (ref b, ref c) {
-    go;
-    b = 2 * c;
-    writeln("b is ", b);
-    c = 2 * b;
-    a = 2 * b;
-    go = true;
+  sync {  // make sure we don't leave b's scope before begin ends
+    begin with (ref b, ref c) {
+      go;
+      b = 2 * c;
+      writeln("b is ", b);
+      c = 2 * b;
+      a = 2 * b;
+      go = true;
+    }
   }
 }
 

--- a/test/parallel/begin/waynew/simple2.chpl
+++ b/test/parallel/begin/waynew/simple2.chpl
@@ -7,15 +7,13 @@ var c = 1;
 proc work() {
   var b = 2;
 
-  sync {  // make sure we don't leave b's scope before begin ends
-    begin with (ref b, ref c) {
-      go;
-      b = 2 * c;
-      writeln("b is ", b);
-      c = 2 * b;
-      a = 2 * b;
-      go = true;
-    }
+  begin with (in b, ref c) {
+    go;
+    b = 2 * c;
+    writeln("b is ", b);
+    c = 2 * b;
+    a = 2 * b;
+    go = true;
   }
 }
 


### PR DESCRIPTION
These two tests regressed in certain configurations last night due to races in the test that didn't follow the new "live references to variables whose scopes have closed are the user's problem" semantics.

* For record2, the fix is to use a sync { } block to ensure that the task has ended before we leave the function's scope.

* For simple2, the fix is to make the variable have an 'in' task intent rather than 'ref' since no other tasks will have simultaneous access to it (and using a sync can cause deadlock in this case)