### PR TITLE
Updated html_title to just the version number

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -131,7 +131,7 @@ if not on_rtd:
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = version
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None


### PR DESCRIPTION
The Sphinx-generated HTML title content is now: `Chapel Documentation - 1.12`