### PR TITLE
Added html option to chpldoc, on by default

### DIFF
--- a/compiler/include/docsDriver.h
+++ b/compiler/include/docsDriver.h
@@ -30,6 +30,7 @@ extern char fDocsCommentLabel[256];
 extern char fDocsFolder[256];
 extern bool fDocsTextOnly;
 extern char fDocsSphinxDir[256];
+extern bool fDocsHTML;
 
 // TODO: Whether or not to support this flag is an open discussion. Currently,
 //       it is not supported, so the flag is always true.

--- a/compiler/main/docsDriver.cpp
+++ b/compiler/main/docsDriver.cpp
@@ -30,6 +30,7 @@ char fDocsCommentLabel[256] = "";
 char fDocsFolder[256] = "";
 bool fDocsTextOnly = false;
 char fDocsSphinxDir[256] = "";
+bool fDocsHTML = true;
 
 // TODO: Whether or not to support this flag is an open discussion. Currently,
 //       it is not supported, so the flag is always true.
@@ -80,10 +81,12 @@ ArgumentDescription docs_arg_desc[] = {
  // {"alphabetical", ' ', NULL, "Alphabetizes the documentation", "N", &fDocsAlphabetize, NULL, NULL},
 
  {"output-dir", 'o', "<dirname>", "Sets the documentation directory to <dirname>", "S256", fDocsFolder, NULL, NULL},
- {"save-sphinx",  ' ', "<directory>", "Save generated Sphinx project in directory", "S256", fDocsSphinxDir, NULL, NULL},
  {"author", ' ', "<author>", "Documentation author string.", "S256", fDocsAuthor, "CHPLDOC_AUTHOR", NULL},
  {"comment-style", ' ', "<indicator>", "Only includes comments that start with <indicator>", "S256", fDocsCommentLabel, NULL, docsArgSetCommentLabel},
- {"text-only", ' ', NULL, "Generate text only documentation", "F", &fDocsTextOnly, NULL, NULL},
+ {"save-sphinx",  ' ', "<directory>", "Save generated Sphinx project in directory", "S256", fDocsSphinxDir, NULL, NULL},
+ {"text-only", ' ', NULL, "Generate text documentation only", "F", &fDocsTextOnly, NULL, NULL},
+ {"html", ' ', NULL, "[Don't] generate html documentation (on by default)", "N", &fDocsHTML, NULL, NULL},
+
 
  // TODO: Whether or not to support this flag is an open discussion. Currently,
  //       it is not supported, so the flag is always true.

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -110,7 +110,7 @@ void docs(void) {
       }
     }
 
-    if (!fDocsTextOnly) {
+    if (!fDocsTextOnly && fDocsHTML) {
       generateSphinxOutput(docsSphinxDir, docsOutputDir);
     }
 

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -113,7 +113,7 @@ INTERNAL_MODULES_TO_DOCUMENT =                \
 
 documentation: $(SYS_CTYPES_MODULE_DOC)
 	export CHPLDOC_AUTHOR='Cray Inc' && \
-	$(CHPLDOC) --save-sphinx ${MODULE_SPHINX} $(MODULES_TO_DOCUMENT) \
+	$(CHPLDOC) --save-sphinx ${MODULE_SPHINX} --no-html $(MODULES_TO_DOCUMENT) \
 	$(DISTS_TO_DOCUMENT) $(INTERNAL_MODULES_TO_DOCUMENT)
 	./internal/fixInternalDocs.sh ${MODULE_SPHINX}
 	./dists/fixDistDocs.perl      ${MODULE_SPHINX}


### PR DESCRIPTION
One step closer to cleaning up the doc-build process.
This allows us to generate the rst files with chpldoc and not build with
sphinx.