### PR TITLE
Chapel Logo is back!

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
-.. image:: http://chapel.cray.com/images/cray-chapel-logo.png
-    :height: 200px
-    :width: 300px
+.. image:: http://chapel.cray.com/images/cray-chapel-logo-200.png
+    :align: center
 
 
 .. _chapelhome-readme:

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+.. image:: http://chapel.cray.com/images/cray-chapel-logo.png
+    :height: 200px
+    :width: 300px
+
+
 .. _chapelhome-readme:
 
 The Chapel Language

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -15,7 +15,6 @@
 import sys
 import os
 import sphinx.environment
-from docutils.utils import get_source_line
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -280,10 +279,11 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
+## Monkey patch to disable nonlocal image warning for Chapel logo
+original_warn_mode = sphinx.environment.BuildEnvironment.warn_node
 
-# Monkey patch to disable nonlocal image warning for Chapel logo
-def _warn_node(self, msg, node):
+def allow_nonlocal_image_warn_node(self, msg, node):
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        original_warn_mode(self, msg, node)
 
-sphinx.environment.BuildEnvironment.warn_node = _warn_node
+sphinx.environment.BuildEnvironment.warn_node = allow_nonlocal_image_warn_node

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -14,6 +14,8 @@
 
 import sys
 import os
+import sphinx.environment
+from docutils.utils import get_source_line
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -277,3 +279,11 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+
+# Monkey patch to disable nonlocal image warning for Chapel logo
+def _warn_node(self, msg, node):
+    if not msg.startswith('nonlocal image URI found:'):
+        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+
+sphinx.environment.BuildEnvironment.warn_node = _warn_node


### PR DESCRIPTION
Had to monkey patch the sphinx/conf.py to override the image from external URL warning.

See [Stack Overflow post](http://stackoverflow.com/a/28778969/2158546) for discussion on the patch. (updated)