### PR TITLE
Refactor: remove duplicate code in buildForLoopExpr

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -34,6 +34,9 @@
 #include "type.h"
 
 static BlockStmt* findStmtWithTag(PrimitiveTag tag, BlockStmt* blockStmt);
+static void buildSerialIteratorFn(FnSymbol* fn, const char* iteratorName,
+                                  Expr* expr, Expr* cond, Expr* indices,
+                                  bool zippered, Expr*& stmt);
 
 static void
 checkControlFlow(Expr* expr, const char* context) {
@@ -822,25 +825,6 @@ handleArrayTypeCase(FnSymbol* fn, Expr* indices, Expr* iteratorExpr, Expr* expr)
 }
 
 
-//
-// build serial iterator function
-//
-static void buildSerialIteratorFn(FnSymbol* fn, const char* iteratorName,
-                                  Expr* expr, Expr* cond, Expr* indices,
-                                  bool zippered, Expr*& stmt)
-{
-  FnSymbol* sifn = new FnSymbol(iteratorName);
-  sifn->addFlag(FLAG_ITERATOR_FN);
-  ArgSymbol* sifnIterator = new ArgSymbol(INTENT_BLANK, "iterator", dtAny);
-  sifn->insertFormalAtTail(sifnIterator);
-  fn->insertAtHead(new DefExpr(sifn));
-  stmt = new CallExpr(PRIM_YIELD, expr);
-  if (cond)
-    stmt = new CondStmt(new CallExpr("_cond_test", cond), stmt);
-  sifn->insertAtTail(ForLoop::buildForLoop(indices, new SymExpr(sifnIterator), new BlockStmt(stmt), false, zippered));
-}
-
-
 static int loopexpr_uid = 1;
 
 // builds body of for expression iterator
@@ -862,25 +846,29 @@ buildForLoopExpr(Expr* indices, Expr* iteratorExpr, Expr* expr, Expr* cond, bool
   const char* iteratorName = astr("_iterator_for_loopexpr", istr(loopexpr_uid-1));
   block->insertAtTail(new CallExpr(PRIM_RETURN, new CallExpr(iteratorName, iterator)));
 
-  //
-  // build serial iterator function
-  //
-  FnSymbol* sifn = new FnSymbol(iteratorName);
-  sifn->addFlag(FLAG_ITERATOR_FN);
-  ArgSymbol* sifnIterator = new ArgSymbol(INTENT_CONST_IN, "iterator", dtAny);
-  sifn->insertFormalAtTail(sifnIterator);
-  fn->insertAtHead(new DefExpr(sifn));
-  Expr* stmt = new CallExpr(PRIM_YIELD, expr);
-  if (cond)
-    stmt = new CondStmt(new CallExpr("_cond_test", cond), stmt);
-  sifn->insertAtTail(ForLoop::buildForLoop(indices, new SymExpr(sifnIterator), new BlockStmt(stmt), false, zippered));
-  return new CallExpr(new DefExpr(fn));
-}
-
   Expr* stmt = NULL; // Initialized by buldSerialIteratorFn
   buildSerialIteratorFn(fn, iteratorName, expr, cond, indices, zippered, stmt);
 
   return new CallExpr(new DefExpr(fn));
+}
+
+
+//
+// build serial iterator function
+//
+static void buildSerialIteratorFn(FnSymbol* fn, const char* iteratorName,
+                                  Expr* expr, Expr* cond, Expr* indices,
+                                  bool zippered, Expr*& stmt)
+{
+  FnSymbol* sifn = new FnSymbol(iteratorName);
+  sifn->addFlag(FLAG_ITERATOR_FN);
+  ArgSymbol* sifnIterator = new ArgSymbol(INTENT_BLANK, "iterator", dtAny);
+  sifn->insertFormalAtTail(sifnIterator);
+  fn->insertAtHead(new DefExpr(sifn));
+  stmt = new CallExpr(PRIM_YIELD, expr);
+  if (cond)
+    stmt = new CondStmt(new CallExpr("_cond_test", cond), stmt);
+  sifn->insertAtTail(ForLoop::buildForLoop(indices, new SymExpr(sifnIterator), new BlockStmt(stmt), false, zippered));
 }
 
 

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -822,6 +822,25 @@ handleArrayTypeCase(FnSymbol* fn, Expr* indices, Expr* iteratorExpr, Expr* expr)
 }
 
 
+//
+// build serial iterator function
+//
+static void buildSerialIteratorFn(FnSymbol* fn, const char* iteratorName,
+                                  Expr* expr, Expr* cond, Expr* indices,
+                                  bool zippered, Expr*& stmt)
+{
+  FnSymbol* sifn = new FnSymbol(iteratorName);
+  sifn->addFlag(FLAG_ITERATOR_FN);
+  ArgSymbol* sifnIterator = new ArgSymbol(INTENT_BLANK, "iterator", dtAny);
+  sifn->insertFormalAtTail(sifnIterator);
+  fn->insertAtHead(new DefExpr(sifn));
+  stmt = new CallExpr(PRIM_YIELD, expr);
+  if (cond)
+    stmt = new CondStmt(new CallExpr("_cond_test", cond), stmt);
+  sifn->insertAtTail(ForLoop::buildForLoop(indices, new SymExpr(sifnIterator), new BlockStmt(stmt), false, zippered));
+}
+
+
 static int loopexpr_uid = 1;
 
 // builds body of for expression iterator
@@ -858,23 +877,10 @@ buildForLoopExpr(Expr* indices, Expr* iteratorExpr, Expr* expr, Expr* cond, bool
   return new CallExpr(new DefExpr(fn));
 }
 
+  Expr* stmt = NULL; // Initialized by buldSerialIteratorFn
+  buildSerialIteratorFn(fn, iteratorName, expr, cond, indices, zippered, stmt);
 
-//
-// build serial iterator function
-//
-static void buildSerialIteratorFn(FnSymbol* fn, const char* iteratorName,
-                                  Expr* expr, Expr* cond, Expr* indices,
-                                  bool zippered, Expr*& stmt)
-{
-  FnSymbol* sifn = new FnSymbol(iteratorName);
-  sifn->addFlag(FLAG_ITERATOR_FN);
-  ArgSymbol* sifnIterator = new ArgSymbol(INTENT_BLANK, "iterator", dtAny);
-  sifn->insertFormalAtTail(sifnIterator);
-  fn->insertAtHead(new DefExpr(sifn));
-  stmt = new CallExpr(PRIM_YIELD, expr);
-  if (cond)
-    stmt = new CondStmt(new CallExpr("_cond_test", cond), stmt);
-  sifn->insertAtTail(ForLoop::buildForLoop(indices, new SymExpr(sifnIterator), new BlockStmt(stmt), false, zippered));
+  return new CallExpr(new DefExpr(fn));
 }
 
 
@@ -964,7 +970,7 @@ buildForallLoopExpr(Expr* indices, Expr* iteratorExpr, Expr* expr, Expr* cond, b
   const char* iteratorName = astr("_iterator_for_loopexpr", istr(loopexpr_uid-1));
   block->insertAtTail(new CallExpr(PRIM_RETURN, new CallExpr(iteratorName, iterator)));
 
-  Expr* stmt; // Initialized by buildSerialIteratorFn.
+  Expr* stmt = NULL; // Initialized by buildSerialIteratorFn.
   buildSerialIteratorFn(fn, iteratorName, expr, cond, indices, zippered, stmt);
   buildLeaderIteratorFn(fn, iteratorName, zippered);
   VarSymbol* followerIterator; // Initialized by buildFollowerIteratorFn.


### PR DESCRIPTION
buildForLoopExpr had a copy of the body of buildSerialIteratorFn, with the
difference that the iterator argument was made with INTENT_CONST_IN vs.
INTENT_BLANK. I believe that this difference was just that one was not updated
when it should have been. In any case, it is best to remove the duplicate code.

This patch makes buildForLoopExpr call buildSerialIteratorFn. It
started out a as b8742520c82f1e979f0267401e89b96bb9017b7c
on string-as-rec.

- [x] full local testing