### PR TITLE
Revert "Stop heap allocating because of non-blocking ons"

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -702,15 +702,16 @@ needHeapVars() {
 //   varSet, varVec - symbols that themselves need to be heap-allocated
 //
 
-// Traverses all 'on' task functions flagged as needing heap
-// allocation (for its formals), as determined by the comm layer
-// and/or --local setting..
+// Traverses all 'on' task functions flagged as nonblocking or
+// as needing heap allocation (for its formals), as determined
+// by the comm layer and/or --local setting..
 // Traverses all ref formals of these functions and adds them to the refSet and
 // refVec.
 static void findBlockRefActuals(Vec<Symbol*>& refSet, Vec<Symbol*>& refVec)
 {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->hasFlag(FLAG_ON) && needHeapVars()) {
+    if (fn->hasFlag(FLAG_ON) &&
+        (needHeapVars() || fn->hasFlag(FLAG_NON_BLOCKING))) {
       for_formals(formal, fn) {
         if (formal->type->symbol->hasFlag(FLAG_REF)) {
           refSet.set_add(formal);


### PR DESCRIPTION
#2745 caused some ugni-qthreads regressions, so we're going to revert it for
the time being. The issue is basically that the target variable of a network
AMO has to registered with the NIC (and can't be trampolined through a
registered segment.)

Under ugni-muxed, task stacks are allocated out of the registered heap, but
qthreads just grabs task stacks from the system allocator. #2475 stopped heap
allocating some arguments to nonblocking on functions causing regressions for
SSCA2 and a few performance tests.

We either need to force heap allocation for network AMOs when stacks aren't
from registered heap memory, or update qthreads to grab stacks from the
registered heap. Either way, this isn't likely to be fixed in the next few
days, so we're reverting the change.

Note that we believe that the same issue probably exists for blocking on
functions, it's just not exposed by any tests. Whatever future work we do needs
to adds tests for these other cases