### PR TITLE
Undo trivial ordering change

### DIFF
--- a/compiler/include/bitVec.h
+++ b/compiler/include/bitVec.h
@@ -26,9 +26,9 @@ class BitVec {
   size_t in_size;
   size_t ndata;
 
-  ~BitVec();
   BitVec(size_t in_size);
   BitVec(const BitVec& rhs);
+  ~BitVec();
   void operator=(const BitVec& rhs) { this->copy(rhs); }
 
   void clear();


### PR DESCRIPTION
Moving the BitVec destructor to the same place it is located on master.