### PR TITLE
Add =, op=, op overloads for bitVec

### DIFF
--- a/compiler/include/bitVec.h
+++ b/compiler/include/bitVec.h
@@ -29,6 +29,8 @@ class BitVec {
   BitVec(size_t in_size);
   BitVec(const BitVec& rhs);
   ~BitVec();
+  void operator=(const BitVec& rhs) { this->copy(rhs); }
+
   void clear();
   bool get(size_t i) const;
   bool operator[](size_t i) const { return get(i); }
@@ -36,7 +38,12 @@ class BitVec {
   void disjunction(const BitVec& other);
   void intersection(const BitVec& other);
   
-  
+  // Synonyms for disjunction (union) and (conjunction) intersection above.
+  void operator|=(const BitVec& other) { this->disjunction(other); }
+  void operator+=(const BitVec& other) { this->disjunction(other); }
+  void operator&=(const BitVec& other) { this->intersection(other); }
+  void operator-=(const BitVec& other);
+
   // Added functionality to make this compatible with std::bitset and thus 
   // boosts dynamic bitset if that gets into the STL, or we start using boost
   bool equals(const BitVec& other) const;
@@ -55,12 +62,41 @@ class BitVec {
   bool none() const;
 };
 
-inline BitVec operator+(const BitVec& a, const BitVec& b)
+inline void
+BitVec::operator-=(const BitVec& other)
+{
+  BitVec not_other(other);
+  not_other.flip();
+  this->intersection(not_other);
+}
+
+inline bool operator==(const BitVec& a, const BitVec& b)
+{
+  return a.equals(b);
+}
+
+inline bool operator!=(const BitVec& a, const BitVec& b)
+{
+  return ! a.equals(b);
+}
+
+inline BitVec operator&(const BitVec& a, const BitVec& b)
+{
+  BitVec result(a);
+  result.intersection(b);
+  return result;
+}
+
+inline BitVec operator|(const BitVec& a, const BitVec& b)
 {
   BitVec result(a);
   result.disjunction(b);
   return result;
 }
+
+// An alias for operator|.
+inline BitVec operator+(const BitVec& a, const BitVec& b)
+{ return a | b; }
 
 inline BitVec operator-(const BitVec& a, const BitVec& b)
 {


### PR DESCRIPTION
Adds = overload
Adds |=, += for union
Adds &= for intersection
Adds -= for set subtraction

Adds ==, != overloads

Adds & for creating a new intersection
Adds | for creating a new union

These changes started out on string-as-rec:
 2aaad4725b38767576258c81fe66142198c24853
 3c08de955bdf1a22b0b6fb57381bb97241c2c533
 7a08ef6ceafd2efa67dab490dc5e743e516ca164
 f3b4938f3d4f9902e40a7153ddf4a79b45f7cf46

Because the changes are simple but were mixed
in with other changes in their commits, I
am just applying the patch here (rather
than trying to git cherry-pick).