### PR TITLE
Adjust handling of PRIM_ASSIGN

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4594,7 +4594,13 @@ GenRet CallExpr::codegen() {
       ret = codegenXor(get(1), get(2));
       break;
     case PRIM_ASSIGN:
-      // The original, simplistic implementation.  Works but may be slow.
+      // PRIM_ASSIGN differs from PRIM_MOVE in that PRIM_ASSIGN always copies
+      // objects.
+      // PRIM_MOVE can be used to copy a pointer (i.e. reference) into another
+      // pointer, but if you try this with PRIM_ASSIGN, instead it will
+      // overwrite what the LHS points to with what the RHS points to.
+
+      // TODO:  Works but may be slow.
       // (See the implementation of PRIM_MOVE above for several peephole
       // optimizations depending on specifics of the RHS expression.)
 
@@ -4613,7 +4619,10 @@ GenRet CallExpr::codegen() {
       } else if (get(1)->typeInfo()->symbol->hasFlag(FLAG_REF) ||
           get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
           get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-        codegenAssign(codegenDeref(get(1)), get(2));
+        if (get(2)->typeInfo()->symbol->hasFlag(FLAG_REF))
+          codegenAssign(codegenDeref(get(1)), codegenDeref(get(2)));
+        else
+          codegenAssign(codegenDeref(get(1)), get(2));
       } else {
         codegenAssign(get(1), get(2));
       }

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -773,6 +773,21 @@ static void extractCopies(Expr* expr,
             !rhs->type->symbol->hasFlag(FLAG_REF))
           return; // Not a pair.
 
+        // Assignment between two references "peels" the RHS, so performs a
+        // copy of the *value* of the RHS into the lvalue pointed to by the
+        // LHS.  In contrast a move between two refs just copies one ref into
+        // the other.
+        // In the PRIM_ASSIGN case, the two references may point to different
+        // objects, so the primitive does not create a pair as far as CP is
+        // concerned.
+        // TODO: Based on the semantics of PRIM_ASSIGN, if both LHS and RHS are
+        // references, we *could* create a pair between the symbols they refer
+        // to.  There might be a neat recursive way to do this....
+        if (lhs->type->symbol->hasFlag(FLAG_REF) &&
+            rhs->type->symbol->hasFlag(FLAG_REF))
+          if (call->isPrimitive(PRIM_ASSIGN))
+            return;
+
         // We can't make substitutions if the lhs or rhs may change at any
         // time.
         if (maybeVolatile(lhe) || maybeVolatile(rhe))

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -882,7 +882,14 @@ static void propagateVar(Symbol* sym) {
           setWide(lhs);
         }
         else if (isRef(lhs) && isRef(rhs)) {
-          widenRef(sym, lhs);
+          // Here is a place where PRIM_MOVE and PRIM_ASSIGN diverge.
+          // PRIM_MOVE between two references means that one reference is copied
+          // into the other; this is a pointer copy.
+          // PRIM_ASSIGN means that the contents of the value or reference on the
+          // RHS are copied into the object pointed to by the LHS.
+          // Therefore, this clause applies only to PRIM_MOVE.
+          if (call->isPrimitive(PRIM_MOVE))
+            widenRef(sym, lhs);
         }
         else if (isRef(lhs) && isObj(rhs)) {
           debug(sym, "_val of ref %s (%d) needs to be wide\n", lhs->cname, lhs->id);


### PR DESCRIPTION
PRIM_ASSIGN differs from PRIM_MOVE. In particular,
it would be legal AST to do a PRIM_ASSIGN with LHS and RHS
both references. In that case, it should mean copying the
value.

Compare with PRIM_MOVE, which in that case would update
the reference on the LHS.

This patch adjusts handling of PRIM_ASSIGN in several places:
 * updates code generation in expr.cpp to handle LHS and RHS both wide
 * updates copy propagation to handle LHS and RHS both ref
 * updates insertWideReferences to handle this case better

These changes are originally from string-as-rec in commits:
5f4119abc0830951b378eedb2cfe1d112a8c746b
261df21406ea039e0424bb1b559b24a4e99880ef
03621cf471977dacc1f84d4734823592bc2b1748

- [x] full local testing
- [x] full gasnet testing

Reviewed by @noakesmichael.