### PR TITLE
Remove string-as-rec difference in addKnownWides

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -739,23 +739,6 @@ static void addKnownWides() {
             }
           }
         }
-        else if (rhs->isPrimitive(PRIM_GET_SVEC_MEMBER) ||
-                 rhs->isPrimitive(PRIM_GET_SVEC_MEMBER_VALUE)) {
-          //
-          // TODO: Tuples fields can be accessed with an int, so we can't
-          // currently rely on propagateField to widen for us.
-          //
-          Symbol* field = getTupleField(rhs);
-
-          // If the field of the tuple is wide, so is the lhs
-          if (isFullyWide(field)) {
-            if (rhs->isPrimitive(PRIM_GET_SVEC_MEMBER)) {
-              setValWide(lhs);
-            } else {
-              setWide(lhs);
-            }
-          }
-        }
       }
     }
     else if (call->isPrimitive(PRIM_HEAP_REGISTER_GLOBAL_VAR) ||


### PR DESCRIPTION
string-as-rec seemed to have new code in addKnownWides,
but further investigation indicates that it was the
result of an incorrect merge. The code in question
was added in
 28fa2f51d7d2eadf536b2c964d34bc86422dde54
and then removed in
 dd9bb6d0ab2f1e57feb74c25cf3a077dd7dc6703
both of which were in PR #2303.

So, this patch removes this difference so that string-as-rec matches master better.
Sanity checks:
 * test/release/examples/hello*.chpl passes with --no-local.
 * test/release/examples/primers passes in local configuration.