### PR TITLE
Update PRIM_WIDE_GET_ADDR/_wide_get_addr to return a UInt64

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4356,8 +4356,11 @@ GenRet CallExpr::codegen() {
           get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         ret = codegenRaddr(get(1));
       } else {
-        ret = get(1);
+        ret = codegenValue(get(1));
       }
+      // _wide_get_addr promises to return a uint.  Hence the cast.
+      ret = codegenCast(dtUInt[INT_SIZE_64], ret);
+      ret.isUnsigned = true;
       break;
     }
     case PRIM_ADDR_OF:

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -96,16 +96,17 @@ returnInfoDefaultInt(CallExpr* call) {
   return returnInfoInt64(call);
 }
 
+static Type*
+returnInfoUInt64(CallExpr* call) {
+  return dtUInt[INT_SIZE_64];
+}
+
 /*
 static Type*
 returnInfoUInt32(CallExpr* call) { // unexecuted none/gasnet on 4/25/08
   return dtUInt[INT_SIZE_32];
 }
 
-static Type*
-returnInfoUInt64(CallExpr* call) {
-  return dtUInt[INT_SIZE_64];
-}
 
 static Type*
 returnInfoReal32(CallExpr* call) {
@@ -558,10 +559,12 @@ initPrimitive() {
   prim_def(PRIM_LOGICAL_FOLDER, "_paramFoldLogical", returnInfoBool);
 
   prim_def(PRIM_WIDE_GET_LOCALE, "_wide_get_locale", returnInfoLocaleID, false, true);
-  // This will be unnecessary once the module code calls the corresponding
-  // function directly.
+  // MPF - 10/9/2015 - neither _wide_get_node nor _wide_get_addr
+  // is used in the module or test code. insertWideReferences uses
+  // PRIM_WIDE_GET_NODE. It might make sense to keep both of these
+  // functions for debugging.
   prim_def(PRIM_WIDE_GET_NODE, "_wide_get_node", returnInfoNodeID, false, true);
-  prim_def(PRIM_WIDE_GET_ADDR, "_wide_get_addr", returnInfoInt64, false, true);
+  prim_def(PRIM_WIDE_GET_ADDR, "_wide_get_addr", returnInfoUInt64, false, true);
 
   prim_def(PRIM_ON_LOCALE_NUM, "chpl_on_locale_num", returnInfoLocaleID);
 


### PR DESCRIPTION
Before this patch, PRIM_WIDE_GET_ADDR returned an int.  This patch changes it
to return a uint.  Storing an address in a signed int doesn't really make much
sense. It makes a little bit more sense to store an address in an unsigned
integer. Since _wide_get_addr right now is only used for debugging, this change
makes sense.

Since the primitive is only used for debugging, this code is not actually run
in any tests right now on master.

If we were to start using PRIM_WIDE_GET_ADDR elsewhere, it might make sense to
have it return some sort of pointer type (e.g. c_void_ptr, if that is known to
the compiler).

This change started out on string-as-rec as commit
 bc18e40329f3fa5a9733445f1819113dc7ee2aec
but that commit included changes to other files, so I opted to manually
re-create a minimal patch.

Sanity checks:
  - passes GASNet test/release/examples/hello*
  - passes GASNet test/release/examples/primers/

Tom created the original version of these changes. You could think of me as
reviewing the changes in the process of creating this PR.

Reviewed by @lydia-duncan, thanks!