### PR TITLE
Repair setchplenv*

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -717,7 +717,7 @@ if ($runtests == 0) {
 
     # Confirm Chapel built correctly before start_test / paratest
     if ($buildcheck == 1) {
-        $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.bash && make check";
+        $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.sh && make check";
         mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
     }
 

--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -1,12 +1,12 @@
 # bash/zsh shell script to set the Chapel environment variables
 
-# If BASH_SOURCE not defined, assume we are using zsh
-if [ ! -z ${BASH_SOURCE} ]; then
-    echo "bash"
+# Find out filepath depending on shell
+if [ -n "${BASH_VERSION}" ]; then
     filepath=${BASH_SOURCE[0]}
-else
-    echo "zsh"
+elif [ -n "${ZSH_VERSION}" ]; then
     filepath=${(%):-%N}
+else
+    echo "Error: setchplenv.bash can only be sourced from bash and zsh"
 fi
 
 # Directory of setchplenv script, will not work if script is a symlink

--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -1,8 +1,16 @@
-# bash shell script to set the Chapel environment variables
+# bash/zsh shell script to set the Chapel environment variables
+
+# If BASH_SOURCE not defined, assume we are using zsh
+if [ ! -z ${BASH_SOURCE} ]; then
+    echo "bash"
+    filepath=${BASH_SOURCE[0]}
+else
+    echo "zsh"
+    filepath=${(%):-%N}
+fi
 
 # Directory of setchplenv script, will not work if script is a symlink
-DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-echo $DIR
+DIR=$(cd "$(dirname "${filepath}")" && pwd)
 
 # Shallow test to see if we are in the correct directory
 # Just probe to see if we have a few essential subdirectories --

--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -14,21 +14,22 @@ if [ ! -d "$chpl_home/util" ] || [ ! -d "$chpl_home/compiler" ] || [ ! -d "$chpl
     return
 fi
 
+# Remove any previously existing CHPL_HOME paths
+MYPATH=`$chpl_home/util/config/fixpath.py PATH`
+MYMANPATH=`$chpl_home/util/config/fixpath.py MANPATH`
+
 export CHPL_HOME=$chpl_home
 echo "Setting CHPL_HOME to $CHPL_HOME"
-
-MYPATH=`$CHPL_HOME/util/config/fixpath.py PATH`
-MYMANPATH=`$CHPL_HOME/util/config/fixpath.py MANPATH`
 
 export CHPL_HOST_PLATFORM=`"$CHPL_HOME"/util/chplenv/chpl_platform.py`
 echo "Setting CHPL_HOST_PLATFORM to $CHPL_HOST_PLATFORM"
 
 export PATH="$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM:"$CHPL_HOME"/util:"$MYPATH"
-echo "Updating PATH to include $CHPL_HOME"/bin/$CHPL_HOST_PLATFORM
-echo    "                     and ""$CHPL_HOME"/util
+echo "Updating PATH to include $CHPL_HOME/bin/$CHPL_HOST_PLATFORM"
+echo "                     and $CHPL_HOME/util"
 
 export MANPATH="$CHPL_HOME"/man:"$MYMANPATH"
-echo "Updating MANPATH to include $CHPL_HOME"/man
+echo "Updating MANPATH to include $CHPL_HOME/man"
 
 echo "Setting CHPL_COMM to none"
 export CHPL_COMM=none

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -1,31 +1,27 @@
-# csh/tcsh shell script to set the Chapel environment variables
-
-set sourced=($_)
-set filedir = `dirname $sourced[2]`
-
-# Directory of setchplenv script, will not work if script is a symlink
-set DIR = `cd $filedir && pwd`
+# csh/tcsh-compatibility shell script to set the Chapel environment variables
+# Due to csh/tcsh limitations and inconsistencies, source this from $CHPL_HOME
 
 # Shallow test to see if we are in the correct directory
 # Just probe to see if we have a few essential subdirectories --
 # indicating that we are probably in a Chapel root directory.
-set chpl_home = `cd $DIR/../../ && pwd`
-if ( ! -d "$chpl_home/util" || ! -d "$chpl_home/compiler" || ! -d "$chpl_home/runtime" || ! -d "$chpl_home/modules" ) then
-    echo "Error: \$CHPL_HOME is not where it is expected"
-    return
+if ( ! -d "util" || ! -d "compiler" || ! -d "runtime" || ! -d "modules" ) then
+   echo "Error: source util/setchplenv from within the chapel directory"
+   exit
+endif
+
+# Remove any previously existing CHPL_HOME paths
+set MYPATH = `./util/config/fixpath.py PATH`
+set MYMANPATH = `./util/config/fixpath.py MANPATH`
+
+# Sanity check before modifying $PATH
+if ( "$MYPATH" == "" ) then
+  echo "Error running ./util/config/fixpath.py"
+  exit
 endif
 
 echo -n "Setting CHPL_HOME "
-setenv CHPL_HOME $chpl_home
+setenv CHPL_HOME "$cwd"
 echo "to $CHPL_HOME"
-
-set MYPATH = `$CHPL_HOME/util/config/fixpath.py PATH`
-set MYMANPATH = `$CHPL_HOME/util/config/fixpath.py MANPATH`
-
-if ( "$MYPATH" == "" ) then
-  echo "Error running \$CHPL_HOME/util/config/fixpath"
-  exit
-endif
 
 echo -n "Setting CHPL_HOST_PLATFORM "
 setenv CHPL_HOST_PLATFORM `"$CHPL_HOME/util/chplenv/chpl_platform.py"`

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -12,12 +12,13 @@ if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/ru
     exit
 end
 
+# Remove any previously existing CHPL_HOME paths
+eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"PATH\" \"fish\"")
+eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"MANPATH\" \"fish\"")
+
 echo -n "Setting CHPL_HOME "
 set -x CHPL_HOME $chpl_home
 echo "to $CHPL_HOME"
-
-eval set MYPATH (eval "$CHPL_HOME/util/config/fixpath.py \"PATH\" \"fish\"")
-eval set MYMANPATH (eval "$CHPL_HOME/util/config/fixpath.py \"MANPATH\" \"fish\"")
 
 if [ (count $MYPATH) = 0 ]
   echo "Error running \$CHPL_HOME/util/config/fixpath"

--- a/util/setchplenv.bash
+++ b/util/setchplenv.bash
@@ -1,12 +1,12 @@
 # bash/zsh shell script to set the Chapel environment variables
 
-# If BASH_SOURCE not defined, assume we are using zsh
-if [ ! -z ${BASH_SOURCE} ]; then
-    echo "bash"
+# Find out filepath depending on shell
+if [ -n "${BASH_VERSION}" ]; then
     filepath=${BASH_SOURCE[0]}
-else
-    echo "zsh"
+elif [ -n "${ZSH_VERSION}" ]; then
     filepath=${(%):-%N}
+else
+    echo "Error: setchplenv.bash can only be sourced from bash and zsh"
 fi
 
 # Directory of setchplenv script, will not work if script is a symlink

--- a/util/setchplenv.bash
+++ b/util/setchplenv.bash
@@ -1,8 +1,16 @@
-# bash shell script to set the Chapel environment variables
+# bash/zsh shell script to set the Chapel environment variables
+
+# If BASH_SOURCE not defined, assume we are using zsh
+if [ ! -z ${BASH_SOURCE} ]; then
+    echo "bash"
+    filepath=${BASH_SOURCE[0]}
+else
+    echo "zsh"
+    filepath=${(%):-%N}
+fi
 
 # Directory of setchplenv script, will not work if script is a symlink
-DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-echo $DIR
+DIR=$(cd "$(dirname "${filepath}")" && pwd)
 
 # Shallow test to see if we are in the correct directory
 # Just probe to see if we have a few essential subdirectories --

--- a/util/setchplenv.bash
+++ b/util/setchplenv.bash
@@ -1,6 +1,5 @@
 # bash shell script to set the Chapel environment variables
 
-
 # Directory of setchplenv script, will not work if script is a symlink
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 echo $DIR
@@ -15,17 +14,18 @@ if [ ! -d "$chpl_home/util" ] || [ ! -d "$chpl_home/compiler" ] || [ ! -d "$chpl
     return
 fi
 
+# Remove any previously existing CHPL_HOME paths
+MYPATH=`$chpl_home/util/config/fixpath.py PATH`
+MYMANPATH=`$chpl_home/util/config/fixpath.py MANPATH`
+
 export CHPL_HOME=$chpl_home
 echo "Setting CHPL_HOME to $CHPL_HOME"
-
-MYPATH=`$CHPL_HOME/util/config/fixpath.py PATH`
-MYMANPATH=`$CHPL_HOME/util/config/fixpath.py MANPATH`
 
 export CHPL_HOST_PLATFORM=`"$CHPL_HOME"/util/chplenv/chpl_platform.py`
 echo "Setting CHPL_HOST_PLATFORM to $CHPL_HOST_PLATFORM"
 
 export PATH="$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM:"$CHPL_HOME"/util:"$MYPATH"
-echo "Updating PATH to include $CHPL_HOME"/bin/$CHPL_HOST_PLATFORM
+echo "Updating PATH to include $CHPL_HOME/bin/$CHPL_HOST_PLATFORM"
 echo "                     and $CHPL_HOME/util"
 
 export MANPATH="$CHPL_HOME"/man:"$MYMANPATH"

--- a/util/setchplenv.csh
+++ b/util/setchplenv.csh
@@ -1,31 +1,27 @@
-# csh/tcsh shell script to set the Chapel environment variables
-
-set sourced=($_)
-set filedir = `dirname $sourced[2]`
-
-# Directory of setchplenv script, will not work if script is a symlink
-set DIR = `cd $filedir && pwd`
+# csh/tcsh-compatibility shell script to set the Chapel environment variables
+# Due to csh/tcsh limitations and inconsistencies, source this from $CHPL_HOME
 
 # Shallow test to see if we are in the correct directory
 # Just probe to see if we have a few essential subdirectories --
 # indicating that we are probably in a Chapel root directory.
-set chpl_home = `cd $DIR/../ && pwd`
-if ( ! -d "$chpl_home/util" || ! -d "$chpl_home/compiler" || ! -d "$chpl_home/runtime" || ! -d "$chpl_home/modules" ) then
-    echo "Error: \$CHPL_HOME is not where it is expected"
-    return
+if ( ! -d "util" || ! -d "compiler" || ! -d "runtime" || ! -d "modules" ) then
+   echo "Error: source util/setchplenv from within the chapel directory"
+   exit
+endif
+
+# Remove any previously existing CHPL_HOME paths
+set MYPATH = `./util/config/fixpath.py PATH`
+set MYMANPATH = `./util/config/fixpath.py MANPATH`
+
+# Sanity check before modifying $PATH
+if ( "$MYPATH" == "" ) then
+  echo "Error running ./util/config/fixpath"
+  exit
 endif
 
 echo -n "Setting CHPL_HOME "
-setenv CHPL_HOME $chpl_home
+setenv CHPL_HOME "$cwd"
 echo "to $CHPL_HOME"
-
-set MYPATH = `$CHPL_HOME/util/config/fixpath.py PATH`
-set MYMANPATH = `$CHPL_HOME/util/config/fixpath.py MANPATH`
-
-if ( "$MYPATH" == "" ) then
-  echo "Error running \$CHPL_HOME/util/config/fixpath"
-  exit
-endif
 
 echo -n "Setting CHPL_HOST_PLATFORM "
 setenv CHPL_HOST_PLATFORM `"$CHPL_HOME/util/chplenv/chpl_platform.py"`

--- a/util/setchplenv.fish
+++ b/util/setchplenv.fish
@@ -12,12 +12,13 @@ if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/ru
     exit
 end
 
+# Remove any previously existing CHPL_HOME paths
+eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"PATH\" \"fish\"")
+eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"MANPATH\" \"fish\"")
+
 echo -n "Setting CHPL_HOME "
 set -x CHPL_HOME $chpl_home
 echo "to $CHPL_HOME"
-
-eval set MYPATH (eval "$CHPL_HOME/util/config/fixpath.py \"PATH\" \"fish\"")
-eval set MYMANPATH (eval "$CHPL_HOME/util/config/fixpath.py \"MANPATH\" \"fish\"")
 
 if [ (count $MYPATH) = 0 ]
   echo "Error running \$CHPL_HOME/util/config/fixpath"


### PR DESCRIPTION
This PR should repair the broken tests that resulted from errors in sourcing `setchplenv.bash/csh`.

* `util/cron/nightly` now sources (dots) `setchplenv.sh` (POSIX-compatibility) script because some testing machines use sh/dash
* `setchplenv.csh` has been reverted so that it must be sourced from `$CHPL_HOME` like it used to. This is due to csh limitations in finding the file path consistently. (This limitation contributed to the many reasons some considered ["csh a tool utterly inadequate for programming..."](http://www.perl.com/doc/FMTEYEWTK/versus/csh.whynot) over 20 years ago.)
* Swapped order of the `fixpath.py` call and `CHPL_HOME` definition so taht we get its originally intended result: removal of _previously_ defined `CHPL_HOME` paths from `$PATH` and `$MANPATH`
* Minor formatting improvements