### PR TITLE
Check for resolveFns() error in addArgCoercion()

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -584,8 +584,7 @@ static void addArgCoercion(FnSymbol* fn, CallExpr* call, ArgSymbol* formal,
   call->getStmtExpr()->insertBefore(castMove);
 
   resolveCall(castCall);
-  FnSymbol* castTarget = castCall->isResolved();
-  if (castTarget) {
+  if (FnSymbol* castTarget = castCall->isResolved()) {
     resolveFns(castTarget);
 
     // Perhaps equivalently, we could check "if (tryToken)",


### PR DESCRIPTION
The standard way to resolve a newly-created call has been:

  resolveCall(call);
  if (call->isResolved())
    resolveFns(call->isResolved());

which is what has been in addArgCoercion() for a while.

However, if the function that resolveFns() is invoked on
contains a resolution error e.g. "unresolved call",
resolveFns() may set tryError and unset FLAG_RESOLVED
in that FnSymbol:

  if (tryFailure) {
    fn->removeFlag(FLAG_RESOLVED);
    return;
  }

No diagnostics gets printed out until downstream,
when resolve() notices that tryError is set.
The resulting error message is likely not helpful.

To observe such behavior, check out string-as-rec branch as of
  4866894
aka
  48668944ec590bb650129d0f3ca99b5c7fe3395a

and uncomment Lines 1323, 1324 in modules/internal/String.chpl
to have:

  if cs.locale_id != chpl_nodeID then
    halt("Cannot cast a remote c_string to string.");

Here, .locale_id is invalid on 'cs', which is a c_string.

Without this PR, we get the following e.g. on hello6:

  String.chpl:1320: error: unable to resolve return type of function '_cast'
  LocaleModel.chpl:170: error: called recursively at this point

whereas there are no recursive calls in sight.

I added a check in addArgCoercion() for FLAG_RESOLVED.
Even so, the specific expression that caused tryFailure
is not available any more, so all I can do is to point
to the function in which that happened. So we get:

  LocaleModel.chpl:170: error: Error resolving a cast from c_string_copy to string
  String.chpl:1320: note:   the troublesome function is here
