### PR TITLE
Undo commenting out of halt() in #2734

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1318,10 +1318,8 @@ module String {
 
   // Cast from c_string to string
   proc _cast(type t, cs: c_string) where t == string {
-    // TODO: uncommenting this creates a circular definition loop?
-    // since LocaleModel uses this cast and this cast uses LocaleModel?
-    //if cs.locale_id != chpl_nodeID then
-    //  halt("Cannot cast a remote c_string to string.");
+    if cs.locale.id != chpl_nodeID then
+      halt("Cannot cast a remote c_string to string.");
 
     var ret: string;
     ret.len = cs.length;


### PR DESCRIPTION
That PR unintentionally renamed .locale.id to .locale_id on a c_string.
That was in _cast() from c_string to string. That generated a compile-time
error. Due to poor error handling in the compiler (mea culpa), the compiler
was not clear about the cause. To avoid the error, some code got commented out.

This corrects the typo and uncomments the code, reverting it to pre-2734.

#2764 on master improves error reporting in this case.
