### PR TITLE
Remove trivial ordering difference from master

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -45,13 +45,13 @@ returnInfoBool(CallExpr* call) {
 }
 
 static Type*
-returnInfoStringC(CallExpr* call) {
-  return dtStringC;
+returnInfoString(CallExpr* call) {
+  return dtString;
 }
 
 static Type*
-returnInfoString(CallExpr* call) {
-  return dtString;
+returnInfoStringC(CallExpr* call) {
+  return dtStringC;
 }
 
 static Type*


### PR DESCRIPTION
This patch backs out an ordering change between returnInfoString
and returnInfoStringC from string-as-rec so that the ordering
matches master.

Trivial and not reviewed.