### PR TITLE
Fix verify errors by adding cast to c_void_ptr in parallel.cpp

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -320,7 +320,8 @@ bundleArgs(CallExpr* fcall, BundleArgsFnData &baData) {
   // Put the bundle into a void* argument
   VarSymbol *allocated_args = newTemp(astr("_args_vfor", fn->name), dtCVoidPtr);
   fcall->insertBefore(new DefExpr(allocated_args));
-  fcall->insertBefore(new CallExpr(PRIM_MOVE, allocated_args, tempc));
+  fcall->insertBefore(new CallExpr(PRIM_MOVE, allocated_args,
+                               new CallExpr(PRIM_CAST_TO_VOID_STAR, tempc)));
 
   // Put the size of the bundle into the next argument
   VarSymbol *tmpsz = newTemp(astr("_args_size", fn->name),


### PR DESCRIPTION
We had PRIM_MOVE allocated_args arg_bundle_class which optimization turned
into replacing allocated_args with arg_bundle_class. But they have
different types: allocated_args should be a void* and arg_bundle_class is
not.

This patch corrects the problem by adding an explicit cast to the code
generating this move in parallel.cpp.

This patch should resolve problems with --verify not working for any test
and also the error matching the .bad file for begin-in-module-init.chpl.

Passed full local testing. Checked that hello.chpl works with --verify and gasnet.

Reviewed by @vasslitvinov 
