### PR TITLE
Adjust no-use-record.bad

### DIFF
--- a/test/modules/sungeun/no-use-record.bad
+++ b/test/modules/sungeun/no-use-record.bad
@@ -92,7 +92,6 @@ $CHPL_HOME/modules/standard/IO.chpl:2845: note:                 _defaultOf(type 
 $CHPL_HOME/modules/standard/IO.chpl:2874: note:                 _defaultOf(type t)
 $CHPL_HOME/modules/standard/IO.chpl:4559: note:                 _defaultOf(type t)
 $CHPL_HOME/modules/standard/IO.chpl:4609: note:                 _defaultOf(type t)
-$CHPL_HOME/modules/standard/gen/linux64-gnu/SysCTypes.chpl:33: note:                 _defaultOf(type t)
 $CHPL_HOME/modules/standard/Regexp.chpl:341: note:                 _defaultOf(type t)
 $CHPL_HOME/modules/standard/Regexp.chpl:344: note:                 _defaultOf(type t)
 $CHPL_HOME/modules/standard/Regexp.chpl:391: note:                 _defaultOf(type t)


### PR DESCRIPTION
PR #2743 moved c_void_ptr out of SysCTypes.chpl and
into the compiler (as a primitive type). One result
is that a _defaultOf function is no longer generated
or reported in this .bad file listing _defaultOf functions.

This patch just removes the SysCTypes line from the .bad file.

Verified that the test now passes.