### PR TITLE
Extra blanket of security to prevent horrendous errors in PATH

### DIFF
--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -7,6 +7,7 @@ elif [ -n "${ZSH_VERSION}" ]; then
     filepath=${(%):-%N}
 else
     echo "Error: setchplenv.bash can only be sourced from bash and zsh"
+    return 1
 fi
 
 # Directory of setchplenv script, will not work if script is a symlink
@@ -19,12 +20,20 @@ chpl_home=$( cd $DIR/../../ && pwd )
 if [ ! -d "$chpl_home/util" ] || [ ! -d "$chpl_home/compiler" ] || [ ! -d "$chpl_home/runtime" ] || [ ! -d "$chpl_home/modules" ]; then
     # Chapel home is assumed to be one directory up from setenvchpl.bash script
     echo "Error: \$CHPL_HOME is not where it is expected"
-    return
+    return 1
 fi
 
 # Remove any previously existing CHPL_HOME paths
 MYPATH=`$chpl_home/util/config/fixpath.py PATH`
+exitcode=$?
 MYMANPATH=`$chpl_home/util/config/fixpath.py MANPATH`
+
+# Double check $MYPATH before overwriting $PATH
+if [ -z "${MYPATH}" -o "${exitcode}" -ne 0 ]; then
+    echo "Error:  util/config/fixpath.py failed"
+    echo "        Make sure you have Python 2.5+"
+    return 1
+fi
 
 export CHPL_HOME=$chpl_home
 echo "Setting CHPL_HOME to $CHPL_HOME"

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -6,17 +6,19 @@
 # indicating that we are probably in a Chapel root directory.
 if ( ! -d "util" || ! -d "compiler" || ! -d "runtime" || ! -d "modules" ) then
    echo "Error: source util/setchplenv from within the chapel directory"
-   exit
+   exit 1
 endif
 
 # Remove any previously existing CHPL_HOME paths
 set MYPATH = `./util/config/fixpath.py PATH`
+set exitcode = $?
 set MYMANPATH = `./util/config/fixpath.py MANPATH`
 
-# Sanity check before modifying $PATH
-if ( "$MYPATH" == "" ) then
-  echo "Error running ./util/config/fixpath.py"
-  exit
+# Double check $MYPATH before overwriting $PATH
+if ( "$MYPATH" == "" || "$exitcode" != 0) then
+    echo "Error:  util/config/fixpath.py failed"
+    echo "        Make sure you have Python 2.5+"
+    exit 1
 endif
 
 echo -n "Setting CHPL_HOME "
@@ -30,7 +32,7 @@ echo "to $CHPL_HOST_PLATFORM"
 echo -n "Updating PATH "
 setenv PATH "$CHPL_HOME/bin/$CHPL_HOST_PLATFORM":"$CHPL_HOME/util":"$MYPATH"
 echo "to include $CHPL_HOME/bin/$CHPL_HOST_PLATFORM"
-echo    "                     and $CHPL_HOME/util"
+echo "                     and $CHPL_HOME/util"
 
 echo -n "Updating MANPATH "
 setenv MANPATH "$CHPL_HOME"/man:"$MYMANPATH"

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -9,21 +9,24 @@ set DIR (cd (dirname (status -f)); pwd)
 set chpl_home (fish -c "cd $DIR/../../; pwd")
 if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/runtime" -o ! -d "$chpl_home/modules" ]
     echo "Error: \$CHPL_HOME is not where it is expected"
-    exit
+    exit 1
 end
 
 # Remove any previously existing CHPL_HOME paths
 eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"PATH\" \"fish\"")
+set exitcode $status
 eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"MANPATH\" \"fish\"")
+
+# Double check $MYPATH before overwriting $PATH
+if [ (count $MYPATH) = 0 -o ! $exitcode = 0 ]
+    echo "Error:  util/config/fixpath.py failed"
+    echo "        Make sure you have Python 2.5+"
+    exit 1
+end
 
 echo -n "Setting CHPL_HOME "
 set -x CHPL_HOME $chpl_home
 echo "to $CHPL_HOME"
-
-if [ (count $MYPATH) = 0 ]
-  echo "Error running \$CHPL_HOME/util/config/fixpath"
-  exit
-end
 
 echo -n "Setting CHPL_HOST_PLATFORM "
 set -x CHPL_HOST_PLATFORM (eval "$CHPL_HOME/util/chplenv/chpl_platform.py")

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -6,76 +6,78 @@
 # Shallow test to see if we are in the correct directory
 # Just probe to see if we have a few essential subdirectories --
 # indicating that we are probably in a Chapel root directory.
-if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
-   then
-      MYPATH=`./util/config/fixpath.py PATH`
-      MYMANPATH=`./util/config/fixpath.py MANPATH`
-      if [ -z "$MYPATH" ]
-        then
-          echo "Error running ./util/config/fixpath";
-        else
-          echo "Setting CHPL_HOME..."
-          CHPL_HOME=`pwd`
-          export CHPL_HOME
-          echo "                    ...to $CHPL_HOME"
-          echo " "
-
-          echo "Setting CHPL_HOST_PLATFORM..."
-          CHPL_HOST_PLATFORM=`"$CHPL_HOME"/util/chplenv/chpl_platform.py`
-          export CHPL_HOST_PLATFORM
-          echo "                        ...to $CHPL_HOST_PLATFORM"
-          echo " "
-
-          echo "Updating PATH to include..."
-          PATH="$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM:"$CHPL_HOME"/util:"$MYPATH"
-          export PATH
-          echo "                           ...$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM
-          echo "                       and ...$CHPL_HOME"/util
-          echo " "
-
-          echo "Updating MANPATH to include..."
-          MANPATH="$CHPL_HOME"/man:"$MYMANPATH"
-          export MANPATH
-          echo "                           ...$CHPL_HOME"/man
-          echo " "
-
-          echo "Setting CHPL_COMM to..."
-          CHPL_COMM=none
-          export CHPL_COMM
-          echo "                           ...none"
-          echo ""
-
-          echo "Setting CHPL_TASKS to..."
-          CHPL_TASKS=fifo
-          export CHPL_TASKS
-          echo "                           ...fifo"
-          echo " "
-
-#          echo "Setting CHPL_MEM to..."
-#          CHPL_MEM=cstdlib
-#          export CHPL_MEM
-#          echo "                           ...cstdlib"
-#          echo " "
-
-          echo "Setting CHPL_GMP to..."
-          CHPL_GMP=none
-          export CHPL_GMP
-          echo "                           ...none"
-          echo " "
-
-          echo "Setting CHPL_REGEXP to..."
-          CHPL_REGEXP=none
-          export CHPL_REGEXP
-          echo "                           ...none"
-          echo " "
-
-          echo "Setting CHPL_LLVM to..."
-          CHPL_LLVM=none
-          export CHPL_LLVM
-          echo "                           ...none"
-          echo " "
-
-        fi
-   else
-      echo "Error: You must use '. util/setchplenv.sh' from within the chapel root directory."
+if [ ! -d "util" ] || [ ! -d "compiler" ] || [ ! -d "runtime" ] || [ ! -d "modules" ]; then
+    echo "Error: You must use '. util/setchplenv.sh' from within the chapel root directory."
+    return 1
 fi
+MYPATH=`./util/config/fixpath.py PATH`
+exitcode=$?
+MYMANPATH=`./util/config/fixpath.py MANPATH`
+
+# Double check $MYPATH before overwriting $PATH
+if [ -z "${MYPATH}" -o "${exitcode}" -ne 0 ]; then
+    echo "Error:  util/config/fixpath.py failed"
+    echo "        Make sure you have Python 2.5+"
+    return 1
+fi
+
+echo "Setting CHPL_HOME..."
+CHPL_HOME=`pwd`
+export CHPL_HOME
+echo "                    ...to $CHPL_HOME"
+echo " "
+
+echo "Setting CHPL_HOST_PLATFORM..."
+CHPL_HOST_PLATFORM=`"$CHPL_HOME"/util/chplenv/chpl_platform.py`
+export CHPL_HOST_PLATFORM
+echo "                        ...to $CHPL_HOST_PLATFORM"
+echo " "
+
+echo "Updating PATH to include..."
+PATH="$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM:"$CHPL_HOME"/util:"$MYPATH"
+export PATH
+echo "                           ...$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM
+echo "                       and ...$CHPL_HOME"/util
+echo " "
+
+echo "Updating MANPATH to include..."
+MANPATH="$CHPL_HOME"/man:"$MYMANPATH"
+export MANPATH
+echo "                           ...$CHPL_HOME"/man
+echo " "
+
+echo "Setting CHPL_COMM to..."
+CHPL_COMM=none
+export CHPL_COMM
+echo "                           ...none"
+echo ""
+
+echo "Setting CHPL_TASKS to..."
+CHPL_TASKS=fifo
+export CHPL_TASKS
+echo "                           ...fifo"
+echo " "
+
+#echo "Setting CHPL_MEM to..."
+#CHPL_MEM=cstdlib
+#export CHPL_MEM
+#echo "                           ...cstdlib"
+#echo " "
+
+echo "Setting CHPL_GMP to..."
+CHPL_GMP=none
+export CHPL_GMP
+echo "                           ...none"
+echo " "
+
+echo "Setting CHPL_REGEXP to..."
+CHPL_REGEXP=none
+export CHPL_REGEXP
+echo "                           ...none"
+echo " "
+
+echo "Setting CHPL_LLVM to..."
+CHPL_LLVM=none
+export CHPL_LLVM
+echo "                           ...none"
+echo " "

--- a/util/setchplenv.bash
+++ b/util/setchplenv.bash
@@ -7,6 +7,7 @@ elif [ -n "${ZSH_VERSION}" ]; then
     filepath=${(%):-%N}
 else
     echo "Error: setchplenv.bash can only be sourced from bash and zsh"
+    return 1
 fi
 
 # Directory of setchplenv script, will not work if script is a symlink
@@ -19,12 +20,20 @@ chpl_home=$( cd $DIR/../ && pwd )
 if [ ! -d "$chpl_home/util" ] || [ ! -d "$chpl_home/compiler" ] || [ ! -d "$chpl_home/runtime" ] || [ ! -d "$chpl_home/modules" ]; then
     # Chapel home is assumed to be one directory up from setenvchpl.bash script
     echo "Error: \$CHPL_HOME is not where it is expected"
-    return
+    return 1
 fi
 
 # Remove any previously existing CHPL_HOME paths
 MYPATH=`$chpl_home/util/config/fixpath.py PATH`
+exitcode=$?
 MYMANPATH=`$chpl_home/util/config/fixpath.py MANPATH`
+
+# Double check $MYPATH before overwriting $PATH
+if [ -z "${MYPATH}" -o "${exitcode}" -ne 0 ]; then
+    echo "Error:  util/config/fixpath.py failed"
+    echo "        Make sure you have Python 2.5+"
+    return 1
+fi
 
 export CHPL_HOME=$chpl_home
 echo "Setting CHPL_HOME to $CHPL_HOME"

--- a/util/setchplenv.csh
+++ b/util/setchplenv.csh
@@ -6,17 +6,19 @@
 # indicating that we are probably in a Chapel root directory.
 if ( ! -d "util" || ! -d "compiler" || ! -d "runtime" || ! -d "modules" ) then
    echo "Error: source util/setchplenv from within the chapel directory"
-   exit
+   exit 1
 endif
 
 # Remove any previously existing CHPL_HOME paths
 set MYPATH = `./util/config/fixpath.py PATH`
+set exitcode = $?
 set MYMANPATH = `./util/config/fixpath.py MANPATH`
 
-# Sanity check before modifying $PATH
-if ( "$MYPATH" == "" ) then
-  echo "Error running ./util/config/fixpath"
-  exit
+# Double check $MYPATH before overwriting $PATH
+if ( "$MYPATH" == "" || "$exitcode" != 0) then
+    echo "Error:  util/config/fixpath.py failed"
+    echo "        Make sure you have Python 2.5+"
+    exit 1
 endif
 
 echo -n "Setting CHPL_HOME "
@@ -30,7 +32,7 @@ echo "to $CHPL_HOST_PLATFORM"
 echo -n "Updating PATH "
 setenv PATH "$CHPL_HOME/bin/$CHPL_HOST_PLATFORM":"$CHPL_HOME/util":"$MYPATH"
 echo "to include $CHPL_HOME/bin/$CHPL_HOST_PLATFORM"
-echo    "                     and $CHPL_HOME/util"
+echo "                     and $CHPL_HOME/util"
 
 echo -n "Updating MANPATH "
 setenv MANPATH "$CHPL_HOME"/man:"$MYMANPATH"

--- a/util/setchplenv.fish
+++ b/util/setchplenv.fish
@@ -9,21 +9,24 @@ set DIR (cd (dirname (status -f)); pwd)
 set chpl_home (fish -c "cd $DIR/../; pwd")
 if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/runtime" -o ! -d "$chpl_home/modules" ]
     echo "Error: \$CHPL_HOME is not where it is expected"
-    exit
+    exit 1
 end
 
 # Remove any previously existing CHPL_HOME paths
 eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"PATH\" \"fish\"")
+set exitcode $status
 eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"MANPATH\" \"fish\"")
+
+# Double check $MYPATH before overwriting $PATH
+if [ (count $MYPATH) = 0 -o ! $exitcode = 0 ]
+    echo "Error:  util/config/fixpath.py failed"
+    echo "        Make sure you have Python 2.5+"
+    exit 1
+end
 
 echo -n "Setting CHPL_HOME "
 set -x CHPL_HOME $chpl_home
 echo "to $CHPL_HOME"
-
-if [ (count $MYPATH) = 0 ]
-  echo "Error running \$CHPL_HOME/util/config/fixpath"
-  exit
-end
 
 echo -n "Setting CHPL_HOST_PLATFORM "
 set -x CHPL_HOST_PLATFORM (eval "$CHPL_HOME/util/chplenv/chpl_platform.py")

--- a/util/setchplenv.sh
+++ b/util/setchplenv.sh
@@ -6,39 +6,42 @@
 # Shallow test to see if we are in the correct directory
 # Just probe to see if we have a few essential subdirectories --
 # indicating that we are probably in a Chapel root directory.
-if [ -d "util" ] && [ -d "compiler" ] && [ -d "runtime" ] && [ -d "modules" ]
-   then
-      MYPATH=`./util/config/fixpath.py PATH`
-      MYMANPATH=`./util/config/fixpath.py MANPATH`
-      if [ -z "$MYPATH" ]
-        then
-          echo "Error running ./util/config/fixpath";
-        else
-          echo "Setting CHPL_HOME..."
-          CHPL_HOME=`pwd`
-          export CHPL_HOME
-          echo "                    ...to $CHPL_HOME"
-          echo " "
-
-          echo "Setting CHPL_HOST_PLATFORM..."
-          CHPL_HOST_PLATFORM=`"$CHPL_HOME"/util/chplenv/chpl_platform.py`
-          export CHPL_HOST_PLATFORM
-          echo "                        ...to $CHPL_HOST_PLATFORM"
-          echo " "
-
-          echo "Updating PATH to include..."
-          PATH="$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM:"$CHPL_HOME"/util:"$MYPATH"
-          export PATH
-          echo "                           ...$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM
-          echo "                       and ...$CHPL_HOME"/util
-          echo " "
-
-          echo "Updating MANPATH to include..."
-          MANPATH="$CHPL_HOME"/man:"$MYMANPATH"
-          export MANPATH
-          echo "                           ...$CHPL_HOME"/man
-          echo " "
-        fi
-   else
-      echo "Error: You must use '. util/setchplenv.sh' from within the chapel root directory."
+if [ ! -d "util" ] || [ ! -d "compiler" ] || [ ! -d "runtime" ] || [ ! -d "modules" ]; then
+    echo "Error: You must use '. util/setchplenv.sh' from within the chapel root directory."
+    return 1
 fi
+MYPATH=`./util/config/fixpath.py PATH`
+exitcode=$?
+MYMANPATH=`./util/config/fixpath.py MANPATH`
+
+# Double check $MYPATH before overwriting $PATH
+if [ -z "${MYPATH}" -o "${exitcode}" -ne 0 ]; then
+    echo "Error:  util/config/fixpath.py failed"
+    echo "        Make sure you have Python 2.5+"
+    return 1
+fi
+
+echo "Setting CHPL_HOME..."
+CHPL_HOME=`pwd`
+export CHPL_HOME
+echo "                    ...to $CHPL_HOME"
+echo " "
+
+echo "Setting CHPL_HOST_PLATFORM..."
+CHPL_HOST_PLATFORM=`"$CHPL_HOME"/util/chplenv/chpl_platform.py`
+export CHPL_HOST_PLATFORM
+echo "                        ...to $CHPL_HOST_PLATFORM"
+echo " "
+
+echo "Updating PATH to include..."
+PATH="$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM:"$CHPL_HOME"/util:"$MYPATH"
+export PATH
+echo "                           ...$CHPL_HOME"/bin/$CHPL_HOST_PLATFORM
+echo "                       and ...$CHPL_HOME"/util
+echo " "
+
+echo "Updating MANPATH to include..."
+MANPATH="$CHPL_HOME"/man:"$MYMANPATH"
+export MANPATH
+echo "                           ...$CHPL_HOME"/man
+echo " "


### PR DESCRIPTION
Previously, sourcing these scripts from a broken Python install or legacy Python (<2.5), the failure would result in `$PATH` being unset, i.e. a catastrophic error. In this PR, we now check for the exit code and the resulting `$MYPATH` before overwriting the user `$PATH`.

Also, some minor formatting changes to maintain consistency among all setchplenv scripts.