### PR TITLE
Remove module prefix

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2674,7 +2674,7 @@ void ModuleSymbol::printDocs(std::ostream *file, unsigned int tabs) {
   }
 
   this->printTabs(file, tabs);
-  const char *moduleTitle = astr("Module: ", this->docsName().c_str());
+  const char *moduleTitle = astr(this->docsName().c_str());
   *file << moduleTitle << std::endl;
 
   if (!fDocsTextOnly) {

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -62,7 +62,7 @@ function fixTitle() {
   # Module: ChapelFoo
   local titleLen=${#1}
   local header="$(printf '=%.0s' $(seq 1 $titleLen))"
-  perl -0777 -i -pe "s/Module: $base\n=+\n/$1\n$header\n/g" $2
+  perl -0777 -i -pe "s/$base\n=+\n/$1\n$header\n/g" $2
 }
 
 # Remove unwanted functions:

--- a/test/chpldoc/basics/disconnectedComment.doc.good
+++ b/test/chpldoc/basics/disconnectedComment.doc.good
@@ -1,4 +1,4 @@
-Module: unattached
+unattached
    This comment should be attached to unattached but not reallyCommentless, 
    even when before the defined module 
    proc reallyCommentless()

--- a/test/chpldoc/basics/empty.doc.good
+++ b/test/chpldoc/basics/empty.doc.good
@@ -1,4 +1,4 @@
-Module: empty.doc
+empty.doc
    proc noComment()
    proc noBody()
    proc noBodyButArgs(num: int, bleah: bool)

--- a/test/chpldoc/basics/fullyCommented.doc.good
+++ b/test/chpldoc/basics/fullyCommented.doc.good
@@ -1,5 +1,5 @@
-Module: fullyCommented.doc
-   Module: fullyCommented.doc.Other
+fullyCommented.doc
+   fullyCommented.doc.Other
       proc inside
          Comment for method inside module 
 

--- a/test/chpldoc/basics/fullyCommented.logical.doc.good
+++ b/test/chpldoc/basics/fullyCommented.logical.doc.good
@@ -1,4 +1,4 @@
-Module: fullyCommented
+fullyCommented
    proc method1()
       Comment for method1 
 
@@ -11,7 +11,7 @@ Module: fullyCommented
    proc argAndBody(val: int)
       Comment for method with argument and body 
 
-   Module: fullyCommented.Other
+   fullyCommented.Other
       proc inside
          Comment for method inside module 
 

--- a/test/chpldoc/basics/hello.doc.good
+++ b/test/chpldoc/basics/hello.doc.good
@@ -1,4 +1,4 @@
-Module: hello.doc
+hello.doc
    proc hello()
       This method prints out a greeting.
 

--- a/test/chpldoc/basics/longerComments.doc.good
+++ b/test/chpldoc/basics/longerComments.doc.good
@@ -1,5 +1,5 @@
-Module: longerComments.doc
-   Module: longerComments.doc.Other
+longerComments.doc
+   longerComments.doc.Other
       proc inside
          This is a comment for a method inside of
          a module 

--- a/test/chpldoc/basics/longerComments.logical.doc.good
+++ b/test/chpldoc/basics/longerComments.logical.doc.good
@@ -1,4 +1,4 @@
-Module: longerComments
+longerComments
    proc method1()
       This is a comment for method1, which lies
       outside of a defined module 
@@ -17,7 +17,7 @@ Module: longerComments
       argument and body which lies outside of a
       defined module 
 
-   Module: longerComments.Other
+   longerComments.Other
       proc inside
          This is a comment for a method inside of
          a module 

--- a/test/chpldoc/basics/main.doc.bad
+++ b/test/chpldoc/basics/main.doc.bad
@@ -1,4 +1,4 @@
-Module: main
+main
    This is the only valid doc string in this modules. 
    Record: beginR
       This should not be documented 

--- a/test/chpldoc/basics/main.doc.good
+++ b/test/chpldoc/basics/main.doc.good
@@ -1,4 +1,4 @@
-Module: main
+main
    This is the only valid doc string in this modules. 
 
    proc foo()

--- a/test/chpldoc/basics/nestFunctions.doc.good
+++ b/test/chpldoc/basics/nestFunctions.doc.good
@@ -1,4 +1,4 @@
-Module: nestFunctions.doc
+nestFunctions.doc
    proc outer()
       This the comment for the outer function 
 

--- a/test/chpldoc/basics/parenthesesLess.doc.good
+++ b/test/chpldoc/basics/parenthesesLess.doc.good
@@ -1,4 +1,4 @@
-Module: parenthesesLess.doc
+parenthesesLess.doc
    proc foo
    proc bar: bool
    proc foo2

--- a/test/chpldoc/basics/sparselyCommented.doc.good
+++ b/test/chpldoc/basics/sparselyCommented.doc.good
@@ -1,5 +1,5 @@
-Module: sparselyCommented.doc
-   Module: sparselyCommented.doc.Other
+sparselyCommented.doc
+   sparselyCommented.doc.Other
       proc inside()
          Comment for method inside module 
 

--- a/test/chpldoc/basics/sparselyCommented.logical.doc.good
+++ b/test/chpldoc/basics/sparselyCommented.logical.doc.good
@@ -1,4 +1,4 @@
-Module: sparselyCommented
+sparselyCommented
    proc method1()
       Comment for method1 
 
@@ -15,7 +15,7 @@ Module: sparselyCommented
       Comment for method with argument and body 
 
    proc argAndBodyCommentless(val: int)
-   Module: sparselyCommented.Other
+   sparselyCommented.Other
       proc inside()
          Comment for method inside module 
 

--- a/test/chpldoc/classes/basic.doc.good
+++ b/test/chpldoc/classes/basic.doc.good
@@ -1,9 +1,9 @@
-Module: basic
+basic
    This is the module that Lydia built 
    proc inner()
       This is the proc that lies in the module that Lydia built 
 
-   Module: basic.sadAndAlone
+   basic.sadAndAlone
       This is the module all sad and alone, listed behind the proc
       that lies in the module that Lydia built 
       Class: naryATone
@@ -11,7 +11,7 @@ Module: basic
          sad and alone, listed behind the proc that lies in the module
          that Lydia built 
 
-      Module: basic.sadAndAlone.classesAreGrown
+      basic.sadAndAlone.classesAreGrown
          This is the module whose classes are grown, sister of the
          class with nary a tone, declared in the module all sad and
          alone, listed behind the proc that lies in the module that

--- a/test/chpldoc/classes/basic.logical.doc.good
+++ b/test/chpldoc/classes/basic.logical.doc.good
@@ -1,9 +1,9 @@
-Module: basic
+basic
    This is the module that Lydia built 
    proc inner()
       This is the proc that lies in the module that Lydia built 
 
-   Module: basic.sadAndAlone
+   basic.sadAndAlone
       This is the module all sad and alone, listed behind the proc
       that lies in the module that Lydia built 
       Class: naryATone
@@ -11,7 +11,7 @@ Module: basic
          sad and alone, listed behind the proc that lies in the module
          that Lydia built 
 
-      Module: basic.sadAndAlone.classesAreGrown
+      basic.sadAndAlone.classesAreGrown
          This is the module whose classes are grown, sister of the
          class with nary a tone, declared in the module all sad and
          alone, listed behind the proc that lies in the module that

--- a/test/chpldoc/classes/fieldInheritance.doc.good
+++ b/test/chpldoc/classes/fieldInheritance.doc.good
@@ -1,4 +1,4 @@
-Module: fieldInheritance.doc
+fieldInheritance.doc
    Class: Elder
       This class has two fields 
 

--- a/test/chpldoc/classes/fields.doc.good
+++ b/test/chpldoc/classes/fields.doc.good
@@ -1,4 +1,4 @@
-Module: fields.doc
+fields.doc
    Class: fullOfFields
       type eltType
          This is a generic type. 

--- a/test/chpldoc/classes/inheritance.doc.good
+++ b/test/chpldoc/classes/inheritance.doc.good
@@ -1,4 +1,4 @@
-Module: inheritance.doc
+inheritance.doc
    Class: Grandparent
       The eldest 
 

--- a/test/chpldoc/classes/methodOutsideClassDef.doc.good
+++ b/test/chpldoc/classes/methodOutsideClassDef.doc.good
@@ -1,4 +1,4 @@
-Module: methodOutsideClassDef.doc
+methodOutsideClassDef.doc
    Class: Foo
       This class will declare a method inside itself, but will have a
       method declared outside it as well 

--- a/test/chpldoc/classes/methodOutsideClassDef.logical.doc.good
+++ b/test/chpldoc/classes/methodOutsideClassDef.logical.doc.good
@@ -1,4 +1,4 @@
-Module: methodOutsideClassDef
+methodOutsideClassDef
    proc Foo.externalMeth1()
    proc Foo.externalMeth2()
       This method has a comment attached to it 

--- a/test/chpldoc/classes/methods.doc.good
+++ b/test/chpldoc/classes/methods.doc.good
@@ -1,4 +1,4 @@
-Module: methods.doc
+methods.doc
    Class: fullOfMethods
       proc commented()
          This is just a normal method with a comment.  I shouldn't

--- a/test/chpldoc/classes/multipleInheritance.doc.good
+++ b/test/chpldoc/classes/multipleInheritance.doc.good
@@ -1,4 +1,4 @@
-Module: multipleInheritance.doc
+multipleInheritance.doc
    Class: Mother
       proc eyes()
          One of Mother's methods 

--- a/test/chpldoc/classes/paramFields.doc.good
+++ b/test/chpldoc/classes/paramFields.doc.good
@@ -1,4 +1,4 @@
-Module: paramFields.doc
+paramFields.doc
    Class: hasParams
       param typeless
       param docTyped: int

--- a/test/chpldoc/compflags/alphabetical/alphabetized.doc.good
+++ b/test/chpldoc/compflags/alphabetical/alphabetized.doc.good
@@ -1,4 +1,4 @@
-Module: alphabetized.doc
+alphabetized.doc
    proc alpha()
       This method should be first 
 

--- a/test/chpldoc/compflags/alphabetical/classFields.doc.bad
+++ b/test/chpldoc/compflags/alphabetical/classFields.doc.bad
@@ -1,4 +1,4 @@
-Module: classFields
+classFields
    Class: Parent
       var niece
          This field should be third 

--- a/test/chpldoc/compflags/alphabetical/classFields.doc.good
+++ b/test/chpldoc/compflags/alphabetical/classFields.doc.good
@@ -1,4 +1,4 @@
-Module: classFields.doc
+classFields.doc
    Class: Parent
       var alone
          This field should be first 

--- a/test/chpldoc/compflags/alphabetical/config.doc.good
+++ b/test/chpldoc/compflags/alphabetical/config.doc.good
@@ -1,4 +1,4 @@
-Module: config.doc
+config.doc
    config const constant
       This is a config const 
    config const constantTyped: bool

--- a/test/chpldoc/compflags/alphabetical/constants.doc.good
+++ b/test/chpldoc/compflags/alphabetical/constants.doc.good
@@ -1,4 +1,4 @@
-Module: hasGlobalConstants.doc
+hasGlobalConstants.doc
    This module has some global scoped constants. 
    const fifth
       This constant has an associated comment and a value 

--- a/test/chpldoc/compflags/alphabetical/globalOrdering.doc.good
+++ b/test/chpldoc/compflags/alphabetical/globalOrdering.doc.good
@@ -1,4 +1,4 @@
-Module: globalOrdering.doc
+globalOrdering.doc
    config var goop: bool
       I should be first 
    config const resorted

--- a/test/chpldoc/compflags/alphabetical/methods.doc.good
+++ b/test/chpldoc/compflags/alphabetical/methods.doc.good
@@ -1,4 +1,4 @@
-Module: methods.doc
+methods.doc
    Class: fullOfMethods
       proc commentless()
       proc hasComment()

--- a/test/chpldoc/compflags/alphabetical/multipleInheritance.doc.good
+++ b/test/chpldoc/compflags/alphabetical/multipleInheritance.doc.good
@@ -1,4 +1,4 @@
-Module: multipleInheritance.doc
+multipleInheritance.doc
    Class: Child
       proc nose()
          A method all its own 

--- a/test/chpldoc/compflags/alphabetical/paramVars.doc.good
+++ b/test/chpldoc/compflags/alphabetical/paramVars.doc.good
@@ -1,4 +1,4 @@
-Module: hasGlobalParams.doc
+hasGlobalParams.doc
    This module has some global scoped params. 
    param first
    param fourth: bool

--- a/test/chpldoc/compflags/alphabetical/submodules.doc.good
+++ b/test/chpldoc/compflags/alphabetical/submodules.doc.good
@@ -1,7 +1,7 @@
-Module: Parent.doc
-   Module: Parent.Caroline
+Parent.doc
+   Parent.Caroline
       This child should be listed first 
-   Module: Parent.Elaine
+   Parent.Elaine
       This child should be in the middle 
-   Module: Parent.Frank
+   Parent.Frank
       This child should be listed last 

--- a/test/chpldoc/compflags/alphabetical/typeVars.doc.good
+++ b/test/chpldoc/compflags/alphabetical/typeVars.doc.good
@@ -1,4 +1,4 @@
-Module: hasGlobalTypes.doc
+hasGlobalTypes.doc
    This module has some global scoped types. 
    type first
    type second

--- a/test/chpldoc/compflags/alphabetical/variables.doc.good
+++ b/test/chpldoc/compflags/alphabetical/variables.doc.good
@@ -1,4 +1,4 @@
-Module: hasGlobalVariables.doc
+hasGlobalVariables.doc
    This module has some global scoped variables. 
    var fifth
       This variable has an associated comment and a value 

--- a/test/chpldoc/compflags/comment/badClose.doc.bad
+++ b/test/chpldoc/compflags/comment/badClose.doc.bad
@@ -1,4 +1,4 @@
-Module: badClose.doc
+badClose.doc
    proc bad()
       This comment is not closed properly
 

--- a/test/chpldoc/compflags/comment/basic.doc.good
+++ b/test/chpldoc/compflags/comment/basic.doc.good
@@ -1,4 +1,4 @@
-Module: basic.doc
+basic.doc
    proc commented()
       This is one way to make your own comment 
 

--- a/test/chpldoc/compflags/comment/loseComments.doc.good
+++ b/test/chpldoc/compflags/comment/loseComments.doc.good
@@ -1,2 +1,2 @@
-Module: loseComments.doc
+loseComments.doc
    proc found()

--- a/test/chpldoc/compflags/comment/specifiedDefault.doc.good
+++ b/test/chpldoc/compflags/comment/specifiedDefault.doc.good
@@ -1,4 +1,4 @@
-Module: specifiedDefault.doc
+specifiedDefault.doc
    proc found()
       This comment should be seen 
 

--- a/test/chpldoc/compflags/creole/classes.doc.good
+++ b/test/chpldoc/compflags/creole/classes.doc.good
@@ -1,11 +1,11 @@
 ----
-==Module: classes
+==classes
  This is the module that Lydia built 
 ====proc inner()
  This is the proc that lies in the module that Lydia built 
 
 ----
-==Module: classes.sadAndAlone
+==classes.sadAndAlone
  This is the module all sad and alone, listed behind the proc
      that lies in the module that Lydia built 
 ===Class: naryATone
@@ -13,7 +13,7 @@
        sad and alone, listed behind the proc that lies in the module
        that Lydia built 
 ----
-==Module: classes.sadAndAlone.classesAreGrown
+==classes.sadAndAlone.classesAreGrown
  This is the module whose classes are grown, sister of the
        class with nary a tone, declared in the module all sad and
        alone, listed behind the proc that lies in the module that

--- a/test/chpldoc/compflags/creole/config.doc.good
+++ b/test/chpldoc/compflags/creole/config.doc.good
@@ -1,5 +1,5 @@
 ----
-==Module: config
+==config
 **config** **var **normal\\
  This is a normal config var \\
 **config** **param **other\\

--- a/test/chpldoc/compflags/creole/module.doc.good
+++ b/test/chpldoc/compflags/creole/module.doc.good
@@ -1,32 +1,32 @@
 ----
-==Module: M
+==M
  This module has a comment 
 ====proc commentless()
 
 ----
-==Module: N
+==N
  So does this module 
 ====proc hasArgCommentless(val: int(64))
 
 ----
-==Module: O
+==O
  And this one 
 ====proc hasBodyCommentless()
 
 ----
-==Module: P
+==P
  What?  Even this one! 
 ====proc hasBodyAndArgCommentless(val: int(64))
 
 ====proc useless()
 
 ----
-==Module: Q
+==Q
 ====proc main()
  Sadly, this method's module does not 
 
 ----
-==Module: R
+==R
 ====proc furthermore()
  Nor this method's module 
 

--- a/test/chpldoc/compflags/externs/externTest.doc.good
+++ b/test/chpldoc/compflags/externs/externTest.doc.good
@@ -1,2 +1,2 @@
-Module: externTest.doc
-   Module: externTest.Other
+externTest.doc
+   externTest.Other

--- a/test/chpldoc/compflags/folder/oneWord.doc.good
+++ b/test/chpldoc/compflags/folder/oneWord.doc.good
@@ -1,4 +1,4 @@
-Module: oneWord.doc
+oneWord.doc
    proc dummy()
       Should be located in myDocs/unspecified.txt 
 

--- a/test/chpldoc/compflags/folder/withHyphen.doc.good
+++ b/test/chpldoc/compflags/folder/withHyphen.doc.good
@@ -1,4 +1,4 @@
-Module: withHyphen.doc
+withHyphen.doc
    proc example()
       This should end up in my-docs/withHyphen.txt 
 

--- a/test/chpldoc/compflags/folder/withUnderscore.doc.good
+++ b/test/chpldoc/compflags/folder/withUnderscore.doc.good
@@ -1,4 +1,4 @@
-Module: withUnderscore.doc
+withUnderscore.doc
    proc example()
       This should end up in my_docs/withUnderscore.txt 
 

--- a/test/chpldoc/devel/classMethods.doc.good
+++ b/test/chpldoc/devel/classMethods.doc.good
@@ -1,4 +1,4 @@
-Module: classMethods.doc
+classMethods.doc
    proc method(_mt: _MT, this: named)
        This method has a comment 
 

--- a/test/chpldoc/devel/hello.doc.good
+++ b/test/chpldoc/devel/hello.doc.good
@@ -1,4 +1,4 @@
-Module: hello.doc
+hello.doc
    proc hello()
        This method prints out a greeting.
 

--- a/test/chpldoc/enum.doc.good
+++ b/test/chpldoc/enum.doc.good
@@ -1,4 +1,4 @@
-Module: enum.doc
+enum.doc
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/enum/docConstants.doc.bad
+++ b/test/chpldoc/enum/docConstants.doc.bad
@@ -1,4 +1,4 @@
-Module: docConstants.doc
+docConstants.doc
    enum Color { Red, Yellow }
       first constant doc 
 

--- a/test/chpldoc/enum/docConstants.doc.good
+++ b/test/chpldoc/enum/docConstants.doc.good
@@ -1,4 +1,4 @@
-Module: docConstants.doc
+docConstants.doc
    enum Color { Red, Yellow }
       enum documentation 
 

--- a/test/chpldoc/globals/constants.doc.good
+++ b/test/chpldoc/globals/constants.doc.good
@@ -1,4 +1,4 @@
-Module: hasGlobalConstants
+hasGlobalConstants
    This module has some global scoped constants. 
    const first: int
    const second = 16

--- a/test/chpldoc/globals/enums.doc.good
+++ b/test/chpldoc/globals/enums.doc.good
@@ -1,4 +1,4 @@
-Module: enums.doc
+enums.doc
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/globals/globalOrdering.doc.good
+++ b/test/chpldoc/globals/globalOrdering.doc.good
@@ -1,4 +1,4 @@
-Module: globalOrdering.doc
+globalOrdering.doc
    config var goop: bool
       hello 
    param after = 35

--- a/test/chpldoc/globals/globalOrdering.logical.doc.good
+++ b/test/chpldoc/globals/globalOrdering.logical.doc.good
@@ -1,4 +1,4 @@
-Module: globalOrdering
+globalOrdering
    config var goop: bool
       I should be first 
    config const resorted

--- a/test/chpldoc/globals/paramVars.doc.good
+++ b/test/chpldoc/globals/paramVars.doc.good
@@ -1,4 +1,4 @@
-Module: hasGlobalParams
+hasGlobalParams
    This module has some global scoped params. 
    param first = 16
    param second: bool = false

--- a/test/chpldoc/globals/typeVars.doc.good
+++ b/test/chpldoc/globals/typeVars.doc.good
@@ -1,4 +1,4 @@
-Module: hasGlobalTypes
+hasGlobalTypes
    This module has some global scoped types. 
    type first = bool
    type second = int(64)

--- a/test/chpldoc/globals/variables.doc.good
+++ b/test/chpldoc/globals/variables.doc.good
@@ -1,4 +1,4 @@
-Module: hasGlobalVariables
+hasGlobalVariables
    This module has some global scoped variables. 
    var first: int
    var second = 16

--- a/test/chpldoc/intents.doc.good
+++ b/test/chpldoc/intents.doc.good
@@ -1,5 +1,5 @@
-Module: intents.doc
-   Module: intents.doc.Inner
+intents.doc
+   intents.doc.Inner
       proc one(in val)
          This function has an argument with the in intent 
 

--- a/test/chpldoc/intents.logical.doc.good
+++ b/test/chpldoc/intents.logical.doc.good
@@ -1,4 +1,4 @@
-Module: intents
+intents
    proc one(in val)
       This function has an argument with the in intent 
 
@@ -44,7 +44,7 @@ Module: intents
    proc fourteen()
       This function has a return intent (other than ref) and a body 
 
-   Module: intents.Inner
+   intents.Inner
       proc one(in val)
          This function has an argument with the in intent 
 

--- a/test/chpldoc/iterators.doc.good
+++ b/test/chpldoc/iterators.doc.good
@@ -1,4 +1,4 @@
-Module: iterators.doc
+iterators.doc
    iter body()
       This iterator should output its comment 
 

--- a/test/chpldoc/linkage-spec/exportTest.doc.good
+++ b/test/chpldoc/linkage-spec/exportTest.doc.good
@@ -1,5 +1,5 @@
-Module: exportTest.doc
-   Module: exportTest.doc.Other
+exportTest.doc
+   exportTest.doc.Other
       export proc inside()
          Comment for method inside module 
 

--- a/test/chpldoc/linkage-spec/exportTest.logical.doc.good
+++ b/test/chpldoc/linkage-spec/exportTest.logical.doc.good
@@ -1,4 +1,4 @@
-Module: exportTest
+exportTest
    export proc method1()
       Comment for method1 
 
@@ -36,7 +36,7 @@ Module: exportTest
       This method has a return type, an argument, and a function body 
 
    export proc allThreeCommentless2(val: int): int
-   Module: exportTest.Other
+   exportTest.Other
       export proc inside()
          Comment for method inside module 
 

--- a/test/chpldoc/linkage-spec/externTest.doc.good
+++ b/test/chpldoc/linkage-spec/externTest.doc.good
@@ -1,5 +1,5 @@
-Module: externTest.doc
-   Module: externTest.doc.Other
+externTest.doc
+   externTest.doc.Other
       proc inside
          Comment for method inside module 
 

--- a/test/chpldoc/linkage-spec/externTest.logical.doc.good
+++ b/test/chpldoc/linkage-spec/externTest.logical.doc.good
@@ -1,4 +1,4 @@
-Module: externTest
+externTest
    proc method1()
       Comment for method1 
 
@@ -20,7 +20,7 @@ Module: externTest
       This method has a return type and an argument 
 
    proc hasReturnTypeAndArgCommentless(val: int): int
-   Module: externTest.Other
+   externTest.Other
       proc inside
          Comment for method inside module 
 

--- a/test/chpldoc/linkage-spec/inlineTest.doc.good
+++ b/test/chpldoc/linkage-spec/inlineTest.doc.good
@@ -1,5 +1,5 @@
-Module: inlineTest.doc
-   Module: inlineTest.doc.Other
+inlineTest.doc
+   inlineTest.doc.Other
       proc inside
          Comment for inline method inside module 
 

--- a/test/chpldoc/linkage-spec/inlineTest.logical.doc.good
+++ b/test/chpldoc/linkage-spec/inlineTest.logical.doc.good
@@ -1,4 +1,4 @@
-Module: inlineTest
+inlineTest
    proc method1()
       Comment for method1 
 
@@ -36,7 +36,7 @@ Module: inlineTest
       This method has a return type, an argument, and a function body 
 
    proc allThreeCommentless(val: int): int
-   Module: inlineTest.Other
+   inlineTest.Other
       proc inside
          Comment for inline method inside module 
 

--- a/test/chpldoc/module/config.doc.good
+++ b/test/chpldoc/module/config.doc.good
@@ -1,4 +1,4 @@
-Module: config.doc
+config.doc
    config var normal = "hello"
       This is a normal config var 
    config param other = 1

--- a/test/chpldoc/module/defaultModule.doc.good
+++ b/test/chpldoc/module/defaultModule.doc.good
@@ -1,4 +1,4 @@
-Module: defaultModule.doc
+defaultModule.doc
    proc foo()
       This proc doesn't matter very much 
 

--- a/test/chpldoc/module/module.doc.good
+++ b/test/chpldoc/module/module.doc.good
@@ -1,21 +1,21 @@
-Module: M
+M
    This module has a comment 
    proc commentless()
-Module: N
+N
    So does this module 
    proc hasArgCommentless(val: int)
-Module: O
+O
    And this one 
    proc hasBodyCommentless()
-Module: P
+P
    What?  Even this one! 
    proc hasBodyAndArgCommentless(val: int)
    proc useless()
-Module: Q
+Q
    proc main()
       Sadly, this method's module does not 
 
-Module: R
+R
    proc furthermore()
       Nor this method's module 
 

--- a/test/chpldoc/module/nestModules.doc.good
+++ b/test/chpldoc/module/nestModules.doc.good
@@ -1,6 +1,6 @@
-Module: outer
+outer
    This is the outer module's comment 
-   Module: outer.inner
+   outer.inner
       This is the inner module's comment 
-      Module: outer.inner.innermost
+      outer.inner.innermost
          This is the innermost module's comment 

--- a/test/chpldoc/module/nestWithFns.doc.good
+++ b/test/chpldoc/module/nestWithFns.doc.good
@@ -1,10 +1,10 @@
-Module: OuterMod
+OuterMod
    This module has a comment, but uncommented first method 
    proc outerFn()
    proc outerCommented()
       The second method is commented 
 
-   Module: OuterMod.Inner
+   OuterMod.Inner
       proc innerFn()
          This module has no comment, but it's inner function does! 
 

--- a/test/chpldoc/module/ordering.doc.good
+++ b/test/chpldoc/module/ordering.doc.good
@@ -1,4 +1,4 @@
-Module: ordering.doc
+ordering.doc
    proc second()
       This is a proc... 
 

--- a/test/chpldoc/module/ordering.logical.doc.good
+++ b/test/chpldoc/module/ordering.logical.doc.good
@@ -1,4 +1,4 @@
-Module: ordering
+ordering
    config var first: string
       This config var should be printed first 
    proc second()

--- a/test/chpldoc/module/sameName.doc.good
+++ b/test/chpldoc/module/sameName.doc.good
@@ -1,8 +1,8 @@
-Module: sameName.doc
+sameName.doc
    proc outerFn()
       This function is outside the defined module 
 
-   Module: sameName.doc.sameName
+   sameName.doc.sameName
       This module has the same name as its file but doesn't
       contain all the code within the file 
       proc innerFn()

--- a/test/chpldoc/module/sameName2.doc.good
+++ b/test/chpldoc/module/sameName2.doc.good
@@ -1,4 +1,4 @@
-Module: sameName2
+sameName2
    This module with the same name actually contains all 
    the code in the file 
    proc inner()

--- a/test/chpldoc/module/surroundingModule.doc.good
+++ b/test/chpldoc/module/surroundingModule.doc.good
@@ -1,8 +1,8 @@
-Module: surroundingModule.doc
+surroundingModule.doc
    proc before()
       This comment and its proc lies before the defined module 
 
-   Module: surroundingModule.doc.Middle
+   surroundingModule.doc.Middle
       proc inside()
          This comment and its proc lies inside the defined module 
 

--- a/test/chpldoc/module/surroundingModule.logical.doc.good
+++ b/test/chpldoc/module/surroundingModule.logical.doc.good
@@ -1,11 +1,11 @@
-Module: surroundingModule
+surroundingModule
    proc before()
       This comment and its proc lies before the defined module 
 
    proc after()
       This comment and its proc lies after the defined module 
 
-   Module: surroundingModule.Middle
+   surroundingModule.Middle
       proc inside()
          This comment and its proc lies inside the defined module 
 

--- a/test/chpldoc/multifile.doc.good
+++ b/test/chpldoc/multifile.doc.good
@@ -1,9 +1,9 @@
-Module: first
+first
    This module uses another module in a separate file 
    proc main()
       This function calls the other module's function 
 
-Module: second
+second
    proc method()
       This method is called by a method in another file 
 

--- a/test/chpldoc/nodoc/noDocPlease.doc.good
+++ b/test/chpldoc/nodoc/noDocPlease.doc.good
@@ -1,4 +1,4 @@
-Module: Foo
+Foo
    config var blah4: int
    proc d()
    Class: bar

--- a/test/chpldoc/nodoc/privateClasses.doc.good
+++ b/test/chpldoc/nodoc/privateClasses.doc.good
@@ -1,3 +1,3 @@
-Module: privateClasses
+privateClasses
    Class: bar
       var showMe: bool

--- a/test/chpldoc/nodoc/privatePlease.doc.good
+++ b/test/chpldoc/nodoc/privatePlease.doc.good
@@ -1,4 +1,4 @@
-Module: Bar
+Bar
    config var blah3: int
    proc c()
 cat: docs/toBeIgnored.txt: No such file or directory

--- a/test/chpldoc/nodoc/privateTypeAlias.doc.good
+++ b/test/chpldoc/nodoc/privateTypeAlias.doc.good
@@ -1,1 +1,1 @@
-Module: privateTypeAlias
+privateTypeAlias

--- a/test/chpldoc/types/arguments/arrays.doc.good
+++ b/test/chpldoc/types/arguments/arrays.doc.good
@@ -1,4 +1,4 @@
-Module: arrays.doc
+arrays.doc
    proc smallArray(val: [1..4] bool)
       This method takes an array of bools as an argument 
 

--- a/test/chpldoc/types/arguments/domains.doc.good
+++ b/test/chpldoc/types/arguments/domains.doc.good
@@ -1,4 +1,4 @@
-Module: domains.doc
+domains.doc
    proc baseCase(dom: domain(1))
       This proc takes in a one dimensional array 
 

--- a/test/chpldoc/types/arguments/enums.doc.good
+++ b/test/chpldoc/types/arguments/enums.doc.good
@@ -1,4 +1,4 @@
-Module: enums.doc
+enums.doc
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/types/arguments/explicitImplicit.doc.good
+++ b/test/chpldoc/types/arguments/explicitImplicit.doc.good
@@ -1,4 +1,4 @@
-Module: explicitImplicit.doc
+explicitImplicit.doc
    proc foo(bar: int)
       This proc has an explicit type argument of type int 
 

--- a/test/chpldoc/types/arguments/methodCall.doc.good
+++ b/test/chpldoc/types/arguments/methodCall.doc.good
@@ -1,4 +1,4 @@
-Module: methodCall.doc
+methodCall.doc
    proc nada() type
       This proc specifies the type of the next method's argument 
 

--- a/test/chpldoc/types/arguments/queried.doc.good
+++ b/test/chpldoc/types/arguments/queried.doc.good
@@ -1,4 +1,4 @@
-Module: queried.doc
+queried.doc
    proc queried(x: ?t)
       This proc queries the type of its argument 
 

--- a/test/chpldoc/types/arguments/recordsAndClasses.doc.good
+++ b/test/chpldoc/types/arguments/recordsAndClasses.doc.good
@@ -1,4 +1,4 @@
-Module: recordsAndClasses.doc
+recordsAndClasses.doc
    Record: thingy
    proc takesAThingy(val: thingy)
       This method takes a record as its argument 

--- a/test/chpldoc/types/arguments/recordsAndClasses.logical.doc.good
+++ b/test/chpldoc/types/arguments/recordsAndClasses.logical.doc.good
@@ -1,4 +1,4 @@
-Module: recordsAndClasses
+recordsAndClasses
    proc takesAThingy(val: thingy)
       This method takes a record as its argument 
 

--- a/test/chpldoc/types/arguments/tuples.doc.good
+++ b/test/chpldoc/types/arguments/tuples.doc.good
@@ -1,4 +1,4 @@
-Module: tuples.doc
+tuples.doc
    proc smallTuple(val: (bool, bool))
       This method takes a tuple of bools as an argument 
 

--- a/test/chpldoc/types/config/basic.doc.good
+++ b/test/chpldoc/types/config/basic.doc.good
@@ -1,4 +1,4 @@
-Module: basic.doc
+basic.doc
    config var isInt: int
       Comment for config var that is an int 
    config var isIntCommentless: int

--- a/test/chpldoc/types/fields/arrays.doc.good
+++ b/test/chpldoc/types/fields/arrays.doc.good
@@ -1,4 +1,4 @@
-Module: arrays.doc
+arrays.doc
    Class: fullOfArrays
       var smallArray: [1..4] bool
          This field contains an array of bools 

--- a/test/chpldoc/types/fields/basic.doc.good
+++ b/test/chpldoc/types/fields/basic.doc.good
@@ -1,4 +1,4 @@
-Module: basic.doc
+basic.doc
    Class: Other
       var isInt: int
          Comment for field that is an int 

--- a/test/chpldoc/types/fields/complexes.doc.good
+++ b/test/chpldoc/types/fields/complexes.doc.good
@@ -1,4 +1,4 @@
-Module: complexes.doc
+complexes.doc
    Record: Foo
       var aComplex: complex = 1.0+2.0i
       const bar = 0.0+1.0i

--- a/test/chpldoc/types/fields/domains.doc.good
+++ b/test/chpldoc/types/fields/domains.doc.good
@@ -1,4 +1,4 @@
-Module: domains.doc
+domains.doc
    Class: fullOfDomains
       var baseCase: domain(1)
          This field contains a one dimensional array 

--- a/test/chpldoc/types/fields/enums.doc.good
+++ b/test/chpldoc/types/fields/enums.doc.good
@@ -1,4 +1,4 @@
-Module: enums.doc
+enums.doc
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/types/fields/imags.doc.good
+++ b/test/chpldoc/types/fields/imags.doc.good
@@ -1,4 +1,4 @@
-Module: imags.doc
+imags.doc
    Record: Foo
       var anImag: imag = 2.0i
       const bar = 1.0i

--- a/test/chpldoc/types/fields/reals.doc.good
+++ b/test/chpldoc/types/fields/reals.doc.good
@@ -1,4 +1,4 @@
-Module: reals.doc
+reals.doc
    Record: Foo
       var aReal: real = 2.0
       const bar = 1.0

--- a/test/chpldoc/types/fields/recordsAndClasses.doc.good
+++ b/test/chpldoc/types/fields/recordsAndClasses.doc.good
@@ -1,4 +1,4 @@
-Module: recordsAndClasses.doc
+recordsAndClasses.doc
    Record: thingy
    Class: whatchamacallit
       var aThingy: thingy

--- a/test/chpldoc/types/fields/tuples.doc.good
+++ b/test/chpldoc/types/fields/tuples.doc.good
@@ -1,4 +1,4 @@
-Module: tuples.doc
+tuples.doc
    Class: fullOfTuples
       var smallTuple: (bool, bool)
          This field contains a tuple of bools 

--- a/test/chpldoc/types/fields/typevar.doc.good
+++ b/test/chpldoc/types/fields/typevar.doc.good
@@ -1,4 +1,4 @@
-Module: typevar.doc
+typevar.doc
    Class: Foo
       This class has type fields 
 

--- a/test/chpldoc/types/fields/usesTypeVar.doc.good
+++ b/test/chpldoc/types/fields/usesTypeVar.doc.good
@@ -1,4 +1,4 @@
-Module: usesTypeVar.doc
+usesTypeVar.doc
    Class: Bar
       This class uses the type field as the type of another field 
 

--- a/test/chpldoc/types/returns/arrays.doc.good
+++ b/test/chpldoc/types/returns/arrays.doc.good
@@ -1,4 +1,4 @@
-Module: arrays.doc
+arrays.doc
    proc smallArray(): [1..4] bool
       This method returns an array of bools as an argument 
 

--- a/test/chpldoc/types/returns/basic.doc.good
+++ b/test/chpldoc/types/returns/basic.doc.good
@@ -1,5 +1,5 @@
-Module: basic.doc
-   Module: basic.doc.Other
+basic.doc
+   basic.doc.Other
       proc inside(): int
          Comment for method inside module 
 

--- a/test/chpldoc/types/returns/basic.logical.doc.good
+++ b/test/chpldoc/types/returns/basic.logical.doc.good
@@ -1,4 +1,4 @@
-Module: basic
+basic
    proc method1(): string
       Comment for method1 
 
@@ -28,7 +28,7 @@ Module: basic
       This proc has an implicit return type and a return statement 
 
    proc returnCommentless()
-   Module: basic.Other
+   basic.Other
       proc inside(): int
          Comment for method inside module 
 

--- a/test/chpldoc/types/returns/domains.doc.good
+++ b/test/chpldoc/types/returns/domains.doc.good
@@ -1,4 +1,4 @@
-Module: domains.doc
+domains.doc
    proc baseCase(): domain(1)
       This proc returns a one dimensional array 
 

--- a/test/chpldoc/types/returns/enums.doc.good
+++ b/test/chpldoc/types/returns/enums.doc.good
@@ -1,4 +1,4 @@
-Module: enums.doc
+enums.doc
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/types/returns/recordsAndClasses.doc.good
+++ b/test/chpldoc/types/returns/recordsAndClasses.doc.good
@@ -1,4 +1,4 @@
-Module: recordsAndClasses.doc
+recordsAndClasses.doc
    Record: thingy
    proc takesAThingy(): thingy
       This method returns a record 

--- a/test/chpldoc/types/returns/recordsAndClasses.logical.doc.good
+++ b/test/chpldoc/types/returns/recordsAndClasses.logical.doc.good
@@ -1,4 +1,4 @@
-Module: recordsAndClasses
+recordsAndClasses
    proc takesAThingy(): thingy
       This method returns a record 
 

--- a/test/chpldoc/types/returns/tuples.doc.good
+++ b/test/chpldoc/types/returns/tuples.doc.good
@@ -1,4 +1,4 @@
-Module: tuples.doc
+tuples.doc
    proc smallTuple(): (bool, bool)
       This method returns a tuple of bools as an argument 
 

--- a/test/chpldoc/variableArguments.doc.good
+++ b/test/chpldoc/variableArguments.doc.good
@@ -1,5 +1,5 @@
-Module: variableArguments.doc
-   Module: variableArguments.doc.Other
+variableArguments.doc
+   variableArguments.doc.Other
       proc variable(x ...)
          This method has a variable number of arguments 
 

--- a/test/chpldoc/variableArguments.logical.doc.good
+++ b/test/chpldoc/variableArguments.logical.doc.good
@@ -1,4 +1,4 @@
-Module: variableArguments
+variableArguments
    proc variable(x ...)
       This method has a variable number of arguments 
 
@@ -12,7 +12,7 @@ Module: variableArguments
       be specified by the caller 
 
    proc specifyMeCommentless(q ...?p)
-   Module: variableArguments.Other
+   variableArguments.Other
       proc variable(x ...)
          This method has a variable number of arguments 
 

--- a/test/compflags/thomasvandoren/chpldoc/copyright.doc.goodend
+++ b/test/compflags/thomasvandoren/chpldoc/copyright.doc.goodend
@@ -1,4 +1,4 @@
-Module: copyright.doc
+copyright.doc
    proc foo()
       this is a proc 
 

--- a/test/release/examples/primers/chpldoc.doc.good
+++ b/test/release/examples/primers/chpldoc.doc.good
@@ -1,4 +1,4 @@
-Module: chpldoc.doc
+chpldoc.doc
    proc commented(val: int): string
       
       Multiline comments found before a function are associated with that function
@@ -9,7 +9,7 @@ Module: chpldoc.doc
       The function can be a stub and still output its comment
 
    proc uncommented()
-   Module: chpldoc.doc.Defined
+   chpldoc.doc.Defined
       
       If the source code defines a module, it can also have a comment associated
       with it

--- a/test/variables/bradc/pragmaMultipleVars.doc.good
+++ b/test/variables/bradc/pragmaMultipleVars.doc.good
@@ -1,1 +1,1 @@
-Module: pragmaMultipleVars.doc
+pragmaMultipleVars.doc


### PR DESCRIPTION
* Removed redundant `Module:` in documentation, and all the tests expecting it.

* Also removed the (now useless) perl sed command from `fixInternalDocs.sh`