### PR TITLE
Reduce a few small deltas between string-as-rec and master

### DIFF
--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -288,6 +288,19 @@ BlockStmt::canFlattenChapelStmt(const BlockStmt* stmt) const {
 }
 
 Expr*
+BlockStmt::getFirstChild() {
+  Expr* retval = NULL;
+
+  if (blockInfo)
+    retval = blockInfo;
+
+  else if (body.head)
+    retval = body.head;
+
+  return retval;
+}
+
+Expr*
 BlockStmt::getFirstExpr() {
   Expr* retval = 0;
 
@@ -779,6 +792,11 @@ CondStmt::accept(AstVisitor* visitor) {
 }
 
 Expr*
+CondStmt::getFirstChild() {
+  return (condExpr != 0) ? condExpr : NULL ;
+}
+
+Expr*
 CondStmt::getFirstExpr() {
   return (condExpr != 0) ? condExpr->getFirstExpr() : this;
 }
@@ -1003,6 +1021,10 @@ void GotoStmt::accept(AstVisitor* visitor) {
   }
 }
 
+Expr* GotoStmt::getFirstChild() {
+  return (label != 0) ? label : NULL;
+}
+
 Expr* GotoStmt::getFirstExpr() {
   return (label != 0) ? label->getFirstExpr() : this;
 }
@@ -1050,6 +1072,10 @@ ExternBlockStmt* ExternBlockStmt::copyInner(SymbolMap* map) {
 
 void ExternBlockStmt::accept(AstVisitor* visitor) {
   visitor->visitEblockStmt(this);
+}
+
+Expr* ExternBlockStmt::getFirstChild() {
+  return NULL;
 }
 
 Expr* ExternBlockStmt::getFirstExpr() {

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2237,15 +2237,31 @@ FnSymbol::insertBeforeReturnAfterLabel(Expr* ast) {
 }
 
 
+// Inserts the given ast ahead of the _downEndCount call at the end of this
+// function, if present.  Otherwise, inserts it ahead of the return.
 void
 FnSymbol::insertBeforeDownEndCount(Expr* ast) {
   CallExpr* ret = toCallExpr(body->body.last());
+
   if (!ret || !ret->isPrimitive(PRIM_RETURN))
     INT_FATAL(this, "function is not normal");
-  CallExpr* last = toCallExpr(ret->prev);
-  if (!last || strcmp(last->isResolved()->name, "_downEndCount"))
-    INT_FATAL(last, "Expected call to _downEndCount");
-  last->insertBefore(ast);
+
+  Expr* prev = ret->prev;
+
+  while (isBlockStmt(prev))
+    prev = toBlockStmt(prev)->body.last();
+
+  CallExpr* last = toCallExpr(prev);
+
+  if (last               &&
+      last->isResolved() &&
+      strcmp(last->isResolved()->name, "_downEndCount") == 0) {
+    last->insertBefore(ast);
+
+  } else {
+    // No _downEndCount() call, so insert the ast before the return.
+    ret->insertBefore(ast);
+  }
 }
 
 

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -100,7 +100,7 @@ public:
 
   void                insertAtHead(Expr* ast);
   void                insertAtTail(Expr* ast);
-  void                insertAtTailBeforeGoto(Expr* ast);
+  void                insertAtTailBeforeFlow(Expr* ast);
 
   void                insertAtHead(const char* format, ...);
   void                insertAtTail(const char* format, ...);

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -77,6 +77,7 @@ public:
 
   // Interface to Expr
   virtual void        replaceChild(Expr* oldAst, Expr* newAst);
+  virtual Expr*       getFirstChild();
   virtual Expr*       getFirstExpr();
   virtual Expr*       getNextExpr(Expr* expr);
 
@@ -150,6 +151,7 @@ public:
   virtual void        verify();
   virtual void        accept(AstVisitor* visitor);
 
+  virtual Expr*       getFirstChild();
   virtual Expr*       getFirstExpr();
   virtual Expr*       getNextExpr(Expr* expr);
 
@@ -193,6 +195,7 @@ class GotoStmt : public Stmt {
   virtual void        verify();
   virtual void        accept(AstVisitor* visitor);
 
+  virtual Expr*       getFirstChild();
   virtual Expr*       getFirstExpr();
 
   const char*         getName();
@@ -217,6 +220,7 @@ public:
   // Interface to Expr
   virtual void        replaceChild(Expr* oldAst, Expr* newAst);
 
+  virtual Expr*       getFirstChild();
   virtual Expr*       getFirstExpr();
 
   // Local interface

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -774,18 +774,18 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
         else {
           BlockStmt* block = toBlockStmt(innermostBlock);
           INT_ASSERT(block);
-          block->insertAtTailBeforeGoto(callChplHereFree(move->get(1)->copy()));
+          block->insertAtTailBeforeFlow(callChplHereFree(move->get(1)->copy()));
         }
       }
     }
-    // else ... 
+    // else ...
     // TODO: After the new constructor story is implemented, every declaration
     // should have exactly one definition associated with it, so the
     // (defs-> == 1) test above can be replaced by an assertion.
   }
 }
 
-// Returns false if 
+// Returns false if
 //  fLocal == true
 // or
 //  CHPL_COMM == "ugni"


### PR DESCRIPTION
1) Upgrade insertAtTailBeforeGoto() to support a more general sense of "flow" that includes return etc.

2) Introduce definitions of getFirstChild() to master.  Used on string-as-rec but not currently used
on master.

3) Copied the extended definition of insertBeforeDownEndCount() from string-as-rec to master

Trivial changes.  Passed a full linux64 regression.
