### PR TITLE
Repair --llvm after PR#2743

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -914,8 +914,9 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
   //      T3 = (T == T2);   // not actual LLVM syntax
   // in LLVM, boolean type is i1
   if (val.val->getType() != ptrValType){
-    val.val = convertValueToType(val.val, ptrValType, !val.isUnsigned);
-    INT_ASSERT(val.val);
+    llvm::Value* v = convertValueToType(val.val, ptrValType, !val.isUnsigned);
+    INT_ASSERT(v);
+    val.val = v;
   }
 
   return codegenStoreLLVM(val.val, ptr.val, valType);

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1953,9 +1953,8 @@ void FnSymbol::codegenPrototype() {
 
     int numArgs = 0;
     for_formals(arg, this) {
-      if(arg->defPoint == formals.head && hasFlag(FLAG_ON_BLOCK)) {
-        continue;
-      }
+      if (arg->hasFlag(FLAG_NO_CODEGEN))
+        continue; // do not print locale argument, end count, dummy class
       argumentTypes.push_back(arg->codegenType().type);
       argumentNames.push_back(arg->cname);
       numArgs++;
@@ -2052,8 +2051,8 @@ void FnSymbol::codegenDef() {
 
     llvm::Function::arg_iterator ai = func->arg_begin();
     for_formals(arg, this) {
-      if (arg->defPoint == formals.head && hasFlag(FLAG_ON_BLOCK))
-        continue; // do not print locale argument for on blocks
+      if (arg->hasFlag(FLAG_NO_CODEGEN))
+        continue; // do not print locale argument, end count, dummy class
 
       if (arg->requiresCPtr()){
         info->lvt->addValue(arg->cname, ai,  GEN_PTR, !is_signed(type));


### PR DESCRIPTION
PR #2743 changed some code to not code generate the first argument of on
block functions to code to not generate arguments marked with
FLAG_NO_CODEGEN.

At the time, I failed to update the LLVM code generation code for those
cases. This patch updates the LLVM code generator in the corresponding
manner.

In addition, this PR makes a minor change to improve the debug-ability of
codegenStoreLLVM.

Trivial bug fix, not reviewed.
Sanity-checked with hello6 for LLVM and non-LLVM configurations.
Verified that hello.chpl works with --no-local and --llvm.
