### PR TITLE
Changes on string-as-rec to support Jira 125

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -460,12 +460,12 @@ void SymExpr::replaceChild(Expr* old_ast, Expr* new_ast) {
   INT_FATAL(this, "Unexpected case in SymExpr::replaceChild");
 }
 
-Expr* SymExpr::getFirstExpr() {
-  return this;
-}
-
 Expr* SymExpr::getFirstChild() {
   return NULL;
+}
+
+Expr* SymExpr::getFirstExpr() {
+  return this;
 }
 
 void SymExpr::verify() {
@@ -563,12 +563,12 @@ UnresolvedSymExpr::replaceChild(Expr* old_ast, Expr* new_ast) {
 }
 
 
-Expr* UnresolvedSymExpr::getFirstExpr() {
-  return this;
-}
-
 Expr* UnresolvedSymExpr::getFirstChild() {
   return NULL;
+}
+
+Expr* UnresolvedSymExpr::getFirstExpr() {
+  return this;
 }
 
 void
@@ -649,12 +649,12 @@ DefExpr::DefExpr(Symbol* initSym, BaseAST* initInit, BaseAST* initExprType) :
   gDefExprs.add(this);
 }
 
-Expr* DefExpr::getFirstExpr() {
-  return this;
-}
-
 Expr* DefExpr::getFirstChild() {
   return NULL;
+}
+
+Expr* DefExpr::getFirstExpr() {
+  return this;
 }
 
 void DefExpr::verify() {
@@ -3483,6 +3483,18 @@ CallExpr::CallExpr(const char* name, BaseAST* arg1, BaseAST* arg2,
 CallExpr::~CallExpr() { }
 
 
+Expr* CallExpr::getFirstChild() {
+  Expr* retval = NULL;
+
+  if (baseExpr)
+    retval = baseExpr;
+
+  else if (argList.head)
+    retval = argList.head;
+
+  return retval;
+}
+
 Expr* CallExpr::getFirstExpr() {
   Expr* retval = NULL;
 
@@ -3496,16 +3508,6 @@ Expr* CallExpr::getFirstExpr() {
     retval = this;
 
   return retval;
-}
-
-Expr* CallExpr::getFirstChild() {
-  if (baseExpr)
-    return baseExpr;
-
-  if (argList.head)
-    return argList.head;
-
-  return NULL;
 }
 
 Expr* CallExpr::getNextExpr(Expr* expr) {
@@ -5620,12 +5622,12 @@ NamedExpr::NamedExpr(const char* init_name, Expr* init_actual) :
 }
 
 
-Expr* NamedExpr::getFirstExpr() {
-  return (actual != NULL) ? actual->getFirstExpr() : this;
-}
-
 Expr* NamedExpr::getFirstChild() {
   return (actual != NULL) ? actual : NULL ;
+}
+
+Expr* NamedExpr::getFirstExpr() {
+  return (actual != NULL) ? actual->getFirstExpr() : this;
 }
 
 void NamedExpr::verify() {

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -224,6 +224,9 @@ Expr* Expr::getStmtExpr() {
   return NULL;
 }
 
+Expr* Expr::getNextExpr(Expr* expr) {
+  return this;
+}
 
 // Returns the nearest enclosing block statement (excluding 'this') that
 // contains 'this' and is a scoped block.
@@ -245,10 +248,6 @@ BlockStmt* Expr::getScopeBlock()
   return NULL;
 }
 
-
-Expr* Expr::getNextExpr(Expr* expr) {
-  return this;
-}
 
 void Expr::verify() {
   if (prev || next)

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -140,6 +140,17 @@ const char* DefExpr::name() const {
   return retval;
 }
 
+// Returns true if 'this' properly contains the given expr, false otherwise.
+bool Expr::contains(const Expr* expr) const {
+  const Expr* parent = expr->parentExpr;
+
+  while (parent != NULL && parent != this) {
+    parent = parent->parentExpr;
+  }
+
+  return (parent == this) ? true : false;
+}
+
 // Return true if this expression is a ModuleDefinition i.e. it
 // is a DefExpr and the referenced symbol is a Module Symbol
 

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -5604,7 +5604,6 @@ GenRet CallExpr::codegen() {
   return ret;
 }
 
-
 bool CallExpr::isPrimitive() const {
   return primitive != NULL;
 }
@@ -5612,7 +5611,6 @@ bool CallExpr::isPrimitive() const {
 bool CallExpr::isPrimitive(PrimitiveTag primitiveTag) const {
   return primitive != NULL && primitive->tag == primitiveTag;
 }
-
 
 bool CallExpr::isPrimitive(const char* primitiveName) const {
   return primitive != NULL && !strcmp(primitive->name, primitiveName);

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -228,26 +228,26 @@ Expr* Expr::getNextExpr(Expr* expr) {
   return this;
 }
 
-// Returns the nearest enclosing block statement (excluding 'this') that
-// contains 'this' and is a scoped block.
-// Returns NULL if no such scope exists (which probably represents an error in
-// the structure of the AST.
-BlockStmt* Expr::getScopeBlock()
-{
-  Expr* expr = this;
-  while ((expr = expr->parentExpr))
-  {
+// Returns the nearest enclosing *scoped* block statement (excluding 'this')
+// that contains 'this'
+
+// It is probably an error if there is no such BlockStmt.
+// Currently return NULL.  Consider throwing aninternal error in the future.
+BlockStmt* Expr::getScopeBlock() {
+  Expr*      expr   = this->parentExpr;
+  BlockStmt* retval = NULL;
+
+  while (expr != NULL && retval == NULL) {
     BlockStmt* block = toBlockStmt(expr);
-    if (block && ! (block->blockTag & BLOCK_SCOPELESS))
-      // This is a scoped block containing the Expr, so this is what we want.
-      return block;
+
+    if (block != NULL && (block->blockTag & BLOCK_SCOPELESS) == 0)
+      retval = block;
+    else
+      expr   = expr->parentExpr;
   }
 
-  // The symbol has no scope associated with it.  Maybe we can add an assert
-  // here.
-  return NULL;
+  return retval;
 }
-
 
 void Expr::verify() {
   if (prev || next)

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -168,17 +168,10 @@ bool Symbol::isRenameable() const {
   return !(hasFlag(FLAG_EXPORT) || hasFlag(FLAG_EXTERN));
 }
 
-
 // Returns the scope in which the given symbol is declared; NULL otherwise.
-BlockStmt*
-Symbol::getDeclarationScope() const
-{
-  if (defPoint == NULL)
-    return NULL;
-
-  return defPoint->getScopeBlock();
+BlockStmt* Symbol::getDeclarationScope() const {
+  return (defPoint != NULL) ? defPoint->getScopeBlock() : NULL;
 }
-
 
 GenRet Symbol::codegen() {
   GenInfo* info = gGenInfo;

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -71,6 +71,7 @@ public:
 
   bool            isStmtExpr()                                       const;
   Expr*           getStmtExpr();
+
   BlockStmt*      getScopeBlock();
 
   Symbol*         parentSymbol;

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -54,8 +54,9 @@ public:
 
   virtual void    prettyPrint(std::ostream* o);
 
-  /* Returns true if the given expressions is contained by this one. */
-  bool            contains(Expr const * const expr) const;
+  /* Returns true if the given expression is contained by this one. */
+  bool            contains(const Expr* expr)                         const;
+
   bool            isModuleDefinition();
 
   void            insertBefore(Expr* new_ast);
@@ -234,18 +235,6 @@ class NamedExpr : public Expr {
 
   virtual Expr*   getFirstExpr();
 };
-
-
-// Returns true if 'this' properly contains the given expr, false otherwise.
-inline bool
-Expr::contains(Expr const * const expr) const
-{
-  Expr const * parent = expr;
-  while ((parent = parent->parentExpr))
-    if (parent == this)
-      return true;
-  return false;
-}
 
 
 // Determines whether a node is in the AST (vs. has been removed

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -45,8 +45,9 @@ public:
   virtual Expr*   copy(SymbolMap* map = NULL, bool internal = false)   = 0;
   virtual void    replaceChild(Expr* old_ast, Expr* new_ast)           = 0;
 
-  virtual Expr*   getFirstExpr()                                       = 0;
   virtual Expr*   getFirstChild()                                      = 0;
+
+  virtual Expr*   getFirstExpr()                                       = 0;
   virtual Expr*   getNextExpr(Expr* expr);
 
   virtual bool    isNoInitExpr()                                     const;
@@ -101,8 +102,9 @@ public:
 
   virtual GenRet  codegen();
 
-  virtual Expr*   getFirstExpr();
   virtual Expr*   getFirstChild();
+
+  virtual Expr*   getFirstExpr();
 
   const char*     name()                               const;
 
@@ -129,8 +131,9 @@ class SymExpr : public Expr {
   virtual GenRet  codegen();
   virtual void    prettyPrint(std::ostream* o);
 
-  virtual Expr*   getFirstExpr();
   virtual Expr*   getFirstChild();
+
+  virtual Expr*   getFirstExpr();
 };
 
 
@@ -149,8 +152,9 @@ class UnresolvedSymExpr : public Expr {
   virtual GenRet  codegen();
   virtual void    prettyPrint(std::ostream *o);
 
-  virtual Expr*   getFirstExpr();
   virtual Expr*   getFirstChild();
+
+  virtual Expr*   getFirstExpr();
 };
 
 
@@ -189,8 +193,9 @@ class CallExpr : public Expr {
   virtual void    prettyPrint(std::ostream* o);
   virtual Type*   typeInfo();
 
-  virtual Expr*   getFirstExpr();
   virtual Expr*   getFirstChild();
+
+  virtual Expr*   getFirstExpr();
   virtual Expr*   getNextExpr(Expr* expr);
 
   void            insertAtHead(BaseAST* ast);
@@ -225,8 +230,9 @@ class NamedExpr : public Expr {
   virtual GenRet  codegen();
   virtual void    prettyPrint(std::ostream* o);
 
-  virtual Expr*   getFirstExpr();
   virtual Expr*   getFirstChild();
+
+  virtual Expr*   getFirstExpr();
 };
 
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -113,10 +113,10 @@ public:
   virtual bool       isParameter()                             const;
           bool       isRenameable()                            const;
 
-  // Returns the scope block in which this symbol is declared.
-          BlockStmt* getDeclarationScope()                     const;
-
   virtual void       codegenDef();
+
+  // Returns the scope block in which this symbol is declared.
+  BlockStmt*         getDeclarationScope()                     const;
 
   bool               hasFlag(Flag flag)                        const;
   bool               hasEitherFlag(Flag aflag, Flag bflag)     const;


### PR DESCRIPTION
A few non-functional changes on string-as-rec to streamline the effort for Jira-125.

Trivial changes but ran a full para-test on linux64 with expected number of errors.
