### PR TITLE
Add a workaround to chpltags for old versions of ctags

### DIFF
--- a/util/chpltags
+++ b/util/chpltags
@@ -61,7 +61,9 @@ def collect_chpl_files(file_list, recurse):
                         result.append(os.path.join(root, f))
                 # skip hidden
                 dirs[:] = [d for d in dirs if d[0] != '.']
-    return result
+    # strip off any leading "./"s from the path to work around a bug in ctags
+    # (which was fixed ~5 years ago) that results in mangled output
+    return [p[2:] if p.startswith("./") else p for p in result]
 
 
 def _main():


### PR DESCRIPTION
Older versions of ctags have a bug when trying to strip off leading
"./"s from paths (overlapping strcpy instead of a memmove).

I've gone though minimal effort to strip off leaing "./"s from file
paths before handing them off to ctags. If a user has a path that looks
like "foo/./bar" this error will still happen. This is not the case for
our use of chpltags in the modules. So, I'm calling it good enough since
this bug has been fixed for multiple years upstream.