### PR TITLE
string-as-rec: Undo change in passByRef for non-POD records

### DIFF
--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -93,11 +93,6 @@ passableByVal(Type* type) {
 // Otherwise passing by value is more efficient.
 static bool
 passByRef(Symbol* sym) {
-
-  // Is it a non-POD record type?
-  if( sym->type->symbol->hasFlag(FLAG_NOT_POD) )
-    return true;
-
   //
   // If it's constant (in the sense that the value will not change),
   // there's no need to pass it by reference


### PR DESCRIPTION
This change was causing failures in

     test/types/records/ferguson/parallel/coforall.chpl

because the record was being heap allocated, passed by reference to the
task function, but freed before the task could run.

At this point, I think that the change to passByRef is no longer
necessary and I can't remember what caused me to add it...

Reduces the number of failures in local testing.
make check still works with GASNet.
make check works with clang.