### PR TITLE
Jira 137 sar

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -243,7 +243,7 @@ remoteValueForwarding(Vec<FnSymbol*>& fns) {
               INT_ASSERT(call);
               SET_LINENO(call);
               if (call->isPrimitive(PRIM_SET_MEMBER)) {
-                Symbol* tmp = newTemp("derefTmp", vt);
+                Symbol* tmp = newTemp(vt);
                 call->insertBefore(new DefExpr(tmp));
                 call->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_DEREF, call->get(3)->remove())));
                 call->insertAtTail(tmp);
@@ -306,7 +306,7 @@ remoteValueForwarding(Vec<FnSymbol*>& fns) {
         //
         // Insert de-reference temp of value.
         //
-        VarSymbol* deref = newTemp("RVFderefTmp", arg->type);
+        VarSymbol* deref = newTemp("rvfDerefTmp", arg->type);
         call->insertBefore(new DefExpr(deref));
         call->insertBefore(new CallExpr(PRIM_MOVE, deref,
                                         new CallExpr(PRIM_DEREF, actual->var)));
@@ -325,7 +325,7 @@ remoteValueForwarding(Vec<FnSymbol*>& fns) {
             use->replace(new CallExpr(PRIM_ADDR_OF, arg));
           } else {
             Expr* stmt = use->getStmtExpr();
-            VarSymbol* reref = newTemp("RVFrerefTmp", prevArgType);
+            VarSymbol* reref = newTemp("rvfRerefTmp", prevArgType);
             stmt->insertBefore(new DefExpr(reref));
             stmt->insertBefore(new CallExpr(PRIM_MOVE, reref,
                                             new CallExpr(PRIM_ADDR_OF, arg)));

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -220,16 +220,12 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
                   (call->isPrimitive(PRIM_WIDE_GET_NODE)) ||
                   (fnc && arg->type == actual_to_formal(se)->type)) {
                 se->var = arg; // do not dereference argument in these cases
-              } 
-              // The following two clauses may be redundant, since
-              // insertReferenceTemps() and insertDerefTemps() now do the same
-              // thing.
-              else if (call->isPrimitive(PRIM_ADDR_OF)) {
+              } else if (call->isPrimitive(PRIM_ADDR_OF)) {
                 SET_LINENO(se);
                 call->replace(new SymExpr(arg));
               } else {
                 SET_LINENO(se);
-                VarSymbol* tmp = newTemp("derefTmp", sym->type);
+                VarSymbol* tmp = newTemp(sym->type);
                 se->getStmtExpr()->insertBefore(new DefExpr(tmp));
                 se->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_DEREF, arg)));
                 se->var = tmp;

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -335,7 +335,7 @@ static Symbol* insertAutoCopyDestroyForTaskArg
       {
         // For internally reference-counted types, this punches through
         // references to bump the reference count.
-        VarSymbol* derefTmp = newTemp("derefTmp", baseType);
+        VarSymbol* derefTmp = newTemp(baseType);
         fcall->insertBefore(new DefExpr(derefTmp));
         fcall->insertBefore(new CallExpr(PRIM_MOVE, derefTmp,
                                          new CallExpr(PRIM_DEREF, var)));
@@ -367,7 +367,7 @@ static Symbol* insertAutoCopyDestroyForTaskArg
         Symbol* formal = actual_to_formal(arg);
         if (arg->typeInfo() != baseType)
         {
-          VarSymbol* derefTmp = newTemp("derefTmp", baseType);
+          VarSymbol* derefTmp = newTemp(baseType);
           fn->insertBeforeDownEndCount(new DefExpr(derefTmp));
           fn->insertBeforeDownEndCount(
             new CallExpr(PRIM_MOVE, derefTmp, new CallExpr(PRIM_DEREF,  formal)));


### PR DESCRIPTION
Several almost inconsequential changes to remove a few deltas

optimizations/remoteValueForwarding is now clean
passes/flattenFunctions.cpp is pretty close

but passes/parallel.cpp and resolution/functionResolution.cpp remain far apart


Changes appear trivial to me but a full run on linux64 was used to confirm.
