### PR TITLE
Jira 131

### DIFF
--- a/compiler/adt/bitVec.cpp
+++ b/compiler/adt/bitVec.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2015 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,30 +17,34 @@
  * limitations under the License.
  */
 
-#include "chpl.h"
 #include "bitVec.h"
+
+#include <cstdlib>
 
 #define TYPE unsigned
 
 BitVec::BitVec(size_t in_size) {
   if (in_size == 0) {
-    ndata = 0;
+    ndata         = 0;
     this->in_size = 0;
-    data = NULL;
+    data          = NULL;
   } else {
-    ndata = 1 + (in_size-1) / (sizeof(TYPE)<<3);
+    ndata         = 1 + (in_size - 1) / (sizeof(TYPE) << 3);
     this->in_size = in_size;
-    data = (TYPE*)calloc(ndata, sizeof(TYPE));
+    data          = (TYPE*) calloc(ndata, sizeof(TYPE));
   }
 }
 
 
 BitVec::BitVec(const BitVec& rhs)
-: data(NULL), in_size(rhs.in_size), ndata(rhs.ndata)
+: data(NULL),
+  in_size(rhs.in_size),
+  ndata(rhs.ndata)
 {
   if (ndata > 0)
   {
-    data = (TYPE*)calloc(ndata, sizeof(TYPE));
+    data = (TYPE*) calloc(ndata, sizeof(TYPE));
+
     copy(rhs);
   }
 }
@@ -59,18 +63,21 @@ void BitVec::clear() {
 
 bool BitVec::get(size_t i) const {
 #if DEBUG
-  if (i >= in_size) 
+  if (i >= in_size)
     INT_FATAL("BitVec::get -- operand out of range.");
 #endif
-  size_t j = i / (sizeof(TYPE)<<3);
-  size_t k = i - j*(sizeof(TYPE)<<3);
+
+  size_t j = i / (sizeof(TYPE) << 3);
+  size_t k = i - j * (sizeof(TYPE) << 3);
+
   return data[j] & (1 << k);
 }
 
 
 void BitVec::unset(size_t i) {
-  size_t j = i / (sizeof(TYPE)<<3);
-  size_t k = i - j*(sizeof(TYPE)<<3);
+  size_t j = i / (sizeof(TYPE) << 3);
+  size_t k = i - j * (sizeof(TYPE) << 3);
+
   data[j] &= ((TYPE)-1) - (1 << k);
 }
 
@@ -80,6 +87,7 @@ void BitVec::disjunction(const BitVec& other) {
   if (other.in_size != in_size)
     INT_FATAL("BitVec::disjunction -- operand lengths must be equal.");
 #endif
+
   for (size_t i = 0; i < ndata; i++)
     data[i] |= other.data[i];
 }
@@ -90,32 +98,35 @@ void BitVec::intersection(const BitVec& other) {
   if (other.in_size != in_size)
     INT_FATAL("BitVec::intersection -- operand lengths must be equal.");
 #endif
+
   for (size_t i = 0; i < ndata; i++)
     data[i] &= other.data[i];
 }
 
 
-
-
 /*
- * Added functionality to make this compatible with std::bitset and thus 
- * boosts dynamic bitset if that gets into the STL 
- * I would also like to implement operator overloading and a copy constructor 
- * if nobody is against that
- */ 
-
+ * Added functionality to make this compatible with std::bitset
+ * and thus boosts dynamic bitset if that gets into the STL
+ *
+ * I would also like to implement operator overloading and a copy
+ * constructor if nobody is against that
+ */
 
 bool BitVec::equals(const BitVec& other) const {
 #if DEBUG
   if (other.in_size != in_size)
     INT_FATAL("BitVec::disjunction -- operand lengths must be equal.");
 #endif
-  for(size_t i = 0; i < ndata; i++) {
-    if(data[i] != other.data[i]) {
-      return false;
+
+  bool retval = true;
+
+  for (size_t i = 0; i < ndata && retval == true; i++) {
+    if (data[i] != other.data[i]) {
+      retval = false;
     }
   }
-  return true;
+
+  return retval;
 }
 
 
@@ -126,8 +137,9 @@ void BitVec::set() {
 
 
 void BitVec::set(size_t i) {
-  size_t j = i / (sizeof(TYPE)<<3);
-  size_t k = i - j*(sizeof(TYPE)<<3);
+  size_t j = i / (sizeof(TYPE) << 3);
+  size_t k = i - j * (sizeof(TYPE) << 3);
+
   data[j] |= 1 << k;
 }
 
@@ -136,11 +148,12 @@ void BitVec::reset() {
   for (size_t i = 0; i < ndata; i++)
     data[i] = 0;
 }
-      
-        
+
+
 void BitVec::reset(size_t i) {
-  size_t j = i / (sizeof(TYPE)<<3);
-  size_t k = i - j*(sizeof(TYPE)<<3);
+  size_t j = i / (sizeof(TYPE) << 3);
+  size_t k = i - j * (sizeof(TYPE) << 3);
+
   data[j] &= ((size_t)-1) - (1 << k);
 }
 
@@ -152,9 +165,11 @@ void BitVec::copy(const BitVec& other) {
 
 
 void BitVec::copy(size_t i, bool value) {
-  size_t j = i / (sizeof(TYPE)<<3);
-  size_t k = i - j*(sizeof(TYPE)<<3);
+  size_t j = i / (sizeof(TYPE) << 3);
+  size_t k = i - j * (sizeof(TYPE) << 3);
+
   data[j] &= ~(1 << k);
+
   if (value)
     data[j] |= (1 << k);
 }
@@ -169,57 +184,62 @@ void BitVec::flip() {
 void BitVec::flip(size_t i) {
   size_t j = i / (sizeof(TYPE)<<3);
   size_t k = i - j*(sizeof(TYPE)<<3);
+
   data[j] ^= 1 << k;
 }
 
 
 /*
- * The current use of this function expect there to be almost no 1's
+ * The current use of this function expects there to be almost no 1's
  * in which case this algorithm is the most efficient instead of an
  * implementation that uses divide and conquer shifting and counting with
- * hex manipulation (I have no idea what the name of that bit counting 
- * algorithm is called)
+ * hex manipulation (I have no idea what the name of that bit counting
+ * algorithm is)
  */
 size_t BitVec::count() const {
   size_t count = 0;
+
   for (size_t i = 0; i < ndata; i++) {
-    size_t localCount ;
-    size_t x = data[i]; 
-    for (localCount=0; x; localCount++) {
+    size_t localCount = 0;
+    size_t x          = data[i];
+
+    for (localCount = 0; x; localCount++) {
       x &= x-1;
     }
+
     count += localCount;
   }
+
   return count;
 }
 
 
 size_t BitVec::size() const {
-  return in_size; 
+  return in_size;
 }
 
 
 bool BitVec::test(size_t i) const {
-  size_t j = i / (sizeof(TYPE)<<3);
-  size_t k = i - j*(sizeof(TYPE)<<3);
+  size_t j = i / (sizeof(TYPE) << 3);
+  size_t k = i - j * (sizeof(TYPE) << 3);
+
   return data[j] & (1 << k);
 }
 
 
 bool BitVec::any() const {
-  for (size_t i = 0; i < ndata; i++) {
-    if(data[i] > 0) {
-      return true;
+  bool retval = false;
+
+  for (size_t i = 0; i < ndata && retval == false; i++) {
+    if (data[i] > 0) {
+      retval = true;
     }
   }
-  return false;
+
+  return retval;
 }
 
 
 bool BitVec::none() const {
   return !any();
 }
-
-
-
-

--- a/compiler/adt/bitVec.cpp
+++ b/compiler/adt/bitVec.cpp
@@ -204,7 +204,7 @@ size_t BitVec::count() const {
     size_t x          = data[i];
 
     for (localCount = 0; x; localCount++) {
-      x &= x-1;
+      x &= x - 1;
     }
 
     count += localCount;

--- a/compiler/include/bitVec.h
+++ b/compiler/include/bitVec.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2015 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,53 +20,67 @@
 #ifndef _CHPL_BIT_VEC_H_
 #define _CHPL_BIT_VEC_H_
 
+#include <cstddef>
+
 class BitVec {
  public:
   unsigned* data;
-  size_t in_size;
-  size_t ndata;
+  size_t    in_size;
+  size_t    ndata;
 
-  BitVec(size_t in_size);
-  BitVec(const BitVec& rhs);
-  ~BitVec();
-  void operator=(const BitVec& rhs) { this->copy(rhs); }
+         BitVec(size_t in_size);
+         BitVec(const BitVec& rhs);
 
-  void clear();
-  bool get(size_t i) const;
-  bool operator[](size_t i) const { return get(i); }
-  void unset(size_t i);
-  void disjunction(const BitVec& other);
-  void intersection(const BitVec& other);
-  
+        ~BitVec();
+
+  void   clear();
+  bool   get(size_t i) const;
+  bool   operator[](size_t i) const { return get(i); }
+
+  void   unset(size_t i);
+
+  void   disjunction(const BitVec& other);
+  void   intersection(const BitVec& other);
+
+  void   operator =  (const BitVec& other) { this->copy(other);         }
+
   // Synonyms for disjunction (union) and (conjunction) intersection above.
-  void operator|=(const BitVec& other) { this->disjunction(other); }
-  void operator+=(const BitVec& other) { this->disjunction(other); }
-  void operator&=(const BitVec& other) { this->intersection(other); }
-  void operator-=(const BitVec& other);
+  void   operator |= (const BitVec& other) { this->disjunction(other);  }
+  void   operator += (const BitVec& other) { this->disjunction(other);  }
+  void   operator &= (const BitVec& other) { this->intersection(other); }
+  void   operator -= (const BitVec& other);
 
-  // Added functionality to make this compatible with std::bitset and thus 
+  // Added functionality to make this compatible with std::bitset and thus
   // boosts dynamic bitset if that gets into the STL, or we start using boost
-  bool equals(const BitVec& other) const;
-  void set();
-  void set(size_t i);
-  void reset();
-  void reset(size_t i);
-  void copy(const BitVec& other);
-  void copy(size_t i, bool value);
-  void flip();
-  void flip(size_t i);
-  size_t count() const;
-  size_t size() const;
-  bool test(size_t i) const;
-  bool any() const;
-  bool none() const;
+  bool   equals(const BitVec& other) const;
+
+  void   set();
+  void   set(size_t i);
+
+  void   reset();
+  void   reset(size_t i);
+
+  void   copy(const BitVec& other);
+  void   copy(size_t i, bool value);
+
+  void   flip();
+  void   flip(size_t i);
+
+  size_t count()                                                     const;
+  size_t size()                                                      const;
+
+  bool   test(size_t i)                                              const;
+
+  bool   any()                                                       const;
+  bool   none()                                                      const;
 };
 
-inline void
-BitVec::operator-=(const BitVec& other)
+inline void BitVec::operator-=(const BitVec& other)
 {
   BitVec not_other(other);
+
   not_other.flip();
+
   this->intersection(not_other);
 }
 
@@ -83,26 +97,34 @@ inline bool operator!=(const BitVec& a, const BitVec& b)
 inline BitVec operator&(const BitVec& a, const BitVec& b)
 {
   BitVec result(a);
+
   result.intersection(b);
+
   return result;
 }
 
 inline BitVec operator|(const BitVec& a, const BitVec& b)
 {
   BitVec result(a);
+
   result.disjunction(b);
+
   return result;
 }
 
 // An alias for operator|.
 inline BitVec operator+(const BitVec& a, const BitVec& b)
-{ return a | b; }
+{
+  return a | b;
+}
 
 inline BitVec operator-(const BitVec& a, const BitVec& b)
 {
   BitVec result(b);
+
   result.flip();
   result.intersection(a);
+
   return result;
 }
 

--- a/compiler/include/bitVec.h
+++ b/compiler/include/bitVec.h
@@ -23,10 +23,11 @@
 #include <cstddef>
 
 class BitVec {
- public:
+public:
   unsigned* data;
   size_t    in_size;
   size_t    ndata;
+
 
          BitVec(size_t in_size);
          BitVec(const BitVec& rhs);


### PR DESCRIPTION
Cleaning up bitVec.{h,cpp} on master in preparation for resolving deltas with string-as-rec.

Straighten out #includes (i.e. bitVec.h relied on definitions via #includes within C files),
drop trailing whitespace, etc.

Trivial changes.  Ran para-test on linux64 to confirm.
