### PR TITLE
Don't follow symlinks when creating a test directory list in paratest

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -443,7 +443,9 @@ sub find_subdirs {
             next if $skip > '0' or $skip =~ m/true/i;
         }
 	    if ($debug) {for ($i=0; $i<$level; $i++)  {print "    ";}}
-	    push @founddirs, find_subdirs ("$targetdir/$filen", $level+1);
+            if (! -l "$targetdir/$filen") {
+                push @founddirs, find_subdirs ("$targetdir/$filen", $level+1);
+            }
         }
     }
     return @founddirs;


### PR DESCRIPTION
I ran into a situation where a test left behind a symlink pointing to "/",
which resulted in an attempted traversal of the whole filesystem and/or an
infinite loop while building the list of test directories.  To avoid that,
check for and avoid following directory symlinks.