### PR TITLE
`util/chplenv/*.py` scripts extended to Python 3.x compatibility

### DIFF
--- a/util/chplenv/check_huge_pages.py
+++ b/util/chplenv/check_huge_pages.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 import os
-from sys import stdout, stderr
+from sys import stderr, stdout
 
-import chpl_platform, chpl_comm, chpl_comm_substrate
 from utils import memoize
+
+from . import chpl_comm, chpl_comm_substrate, chpl_platform
+
 
 # this one doesnt really need to cache anything, but it doesnt need to run more
 # than once to print out any warnings

--- a/util/chplenv/chpl_3p_dlmalloc_configs.py
+++ b/util/chplenv/chpl_3p_dlmalloc_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_dlmalloc_configs.py
+++ b/util/chplenv/chpl_3p_dlmalloc_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_gmp_configs.py
+++ b/util/chplenv/chpl_3p_gmp_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_gmp_configs.py
+++ b/util/chplenv/chpl_3p_gmp_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_hwloc_configs.py
+++ b/util/chplenv/chpl_3p_hwloc_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_hwloc_configs.py
+++ b/util/chplenv/chpl_3p_hwloc_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_massivethreads_configs.py
+++ b/util/chplenv/chpl_3p_massivethreads_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_massivethreads_configs.py
+++ b/util/chplenv/chpl_3p_massivethreads_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import chpl_compiler, chpl_llvm, chpl_locale_model
-from . import third_party_utils
+
+from . import (chpl_compiler, chpl_llvm, chpl_locale_model, third_party_utils,
+               utils)
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import chpl_compiler, chpl_llvm, chpl_locale_model
-import third_party_utils
+from . import chpl_compiler, chpl_llvm, chpl_locale_model
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_re2_configs.py
+++ b/util/chplenv/chpl_3p_re2_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_re2_configs.py
+++ b/util/chplenv/chpl_3p_re2_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_tcmalloc_configs.py
+++ b/util/chplenv/chpl_3p_tcmalloc_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_tcmalloc_configs.py
+++ b/util/chplenv/chpl_3p_tcmalloc_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 
-import os, optparse
-from sys import stdout, stderr
+import optparse
+import os
 from string import punctuation
+from sys import stderr, stdout
 
-from . import utils, chpl_platform, chpl_comm, chpl_compiler
-from utils import memoize, CompVersion
+from utils import CompVersion, memoize
+
+from . import chpl_comm, chpl_compiler, chpl_platform, utils
+
 
 class argument_map(object):
     # intel does not support amd archs... it may be worth testing setting the

--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -4,7 +4,7 @@ import os, optparse
 from sys import stdout, stderr
 from string import punctuation
 
-import utils, chpl_platform, chpl_comm, chpl_compiler
+from . import utils, chpl_platform, chpl_comm, chpl_compiler
 from utils import memoize, CompVersion
 
 class argument_map(object):

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os, optparse
 
-import chpl_platform, chpl_comm, chpl_compiler, utils
+from . import chpl_platform, chpl_comm, chpl_compiler, utils
 from utils import memoize, CompVersion
 
 @memoize

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-import sys, os, optparse
+import optparse
+import os
+import sys
 
-from . import chpl_platform, chpl_comm, chpl_compiler, utils
-from utils import memoize, CompVersion
+from utils import CompVersion, memoize
+
+from . import chpl_comm, chpl_compiler, chpl_platform, utils
+
 
 @memoize
 def get(flag='target'):

--- a/util/chplenv/chpl_aux_filesys.py
+++ b/util/chplenv/chpl_aux_filesys.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 import os
-from sys import stdout, stderr
+from sys import stderr, stdout
 
 from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_compiler
-import chpl_platform
+from . import chpl_compiler, chpl_platform, utils
 from utils import memoize
-import utils
 
 @memoize
 def get():

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
+
+from utils import memoize
 
 from . import chpl_compiler, chpl_platform, utils
-from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_comm, chpl_comm_substrate
+from . import chpl_comm, chpl_comm_substrate
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
+
+from utils import memoize
 
 from . import chpl_comm, chpl_comm_substrate
-from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_platform, chpl_comm
+from . import chpl_arch, chpl_platform, chpl_comm
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_arch, chpl_platform, chpl_comm
 from utils import memoize
+
+from . import chpl_arch, chpl_comm, chpl_platform
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
-import os, optparse
-from sys import stdout, stderr
+import optparse
+import os
+from sys import stderr, stdout
+
+from utils import memoize
 
 from . import chpl_platform, utils
-from utils import memoize
+
 
 @memoize
 def get(flag='host'):

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -2,7 +2,7 @@
 import os, optparse
 from sys import stdout, stderr
 
-import chpl_platform, utils
+from . import chpl_platform, utils
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_arch, chpl_compiler, chpl_platform, utils, chpl_3p_gmp_configs
 from utils import memoize
+
+from . import (chpl_3p_gmp_configs, chpl_arch, chpl_compiler, chpl_platform,
+               utils)
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_compiler, chpl_platform, utils
+from . import chpl_arch, chpl_compiler, chpl_platform, utils, chpl_3p_gmp_configs
 from utils import memoize
-import chpl_3p_gmp_configs
 
 @memoize
 def get():

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_tasks, chpl_arch
+from . import chpl_tasks, chpl_arch
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_tasks, chpl_arch
 from utils import memoize
+
+from . import chpl_arch, chpl_tasks
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_comm, chpl_comm_substrate, chpl_platform, chpl_compiler, utils
 from utils import memoize
+
+from . import (chpl_comm, chpl_comm_substrate, chpl_compiler, chpl_platform,
+               utils)
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_comm, chpl_comm_substrate, chpl_platform, chpl_compiler, utils
+from . import chpl_comm, chpl_comm_substrate, chpl_platform, chpl_compiler, utils
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_platform, chpl_compiler, utils
 from utils import memoize
+
+from . import chpl_compiler, chpl_platform, utils
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_platform, chpl_compiler, utils
+from . import chpl_platform, chpl_compiler, utils
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_locale_model.py
+++ b/util/chplenv/chpl_locale_model.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
 from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_make.py
+++ b/util/chplenv/chpl_make.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
+
+from utils import memoize
 
 from . import chpl_platform, utils
-from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_make.py
+++ b/util/chplenv/chpl_make.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_platform, utils
+from . import chpl_platform, utils
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
-import sys, os, optparse
+import optparse
+import os
+import sys
 
-from . import chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler, chpl_platform
 from utils import memoize
+
+from . import (chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler,
+               chpl_platform)
+
 
 @memoize
 def get(flag='host'):

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os, optparse
 
-import chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler, chpl_platform
+from . import chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler, chpl_platform
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
-import platform, os, os.path, re, sys, optparse
+import optparse
+import os
+import os.path
+import platform
+import re
+import sys
 
 from utils import memoize
+
 
 @memoize
 def get(flag='host'):

--- a/util/chplenv/chpl_regexp.py
+++ b/util/chplenv/chpl_regexp.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_arch, chpl_platform, chpl_compiler, utils
 from utils import memoize
-from . import chpl_3p_re2_configs
+
+from . import (chpl_3p_re2_configs, chpl_arch, chpl_compiler, chpl_platform,
+               utils)
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_regexp.py
+++ b/util/chplenv/chpl_regexp.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_platform, chpl_compiler, utils
+from . import chpl_arch, chpl_platform, chpl_compiler, utils
 from utils import memoize
-import chpl_3p_re2_configs
+from . import chpl_3p_re2_configs
 
 @memoize
 def get():

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_arch, chpl_platform, chpl_compiler, chpl_comm, utils
 from utils import memoize
+
+from . import chpl_arch, chpl_comm, chpl_compiler, chpl_platform, utils
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_platform, chpl_compiler, chpl_comm
+from . import chpl_arch, chpl_platform, chpl_compiler, chpl_comm, utils
 from utils import memoize
-import utils
 
 @memoize
 def get():

--- a/util/chplenv/chpl_threads.py
+++ b/util/chplenv/chpl_threads.py
@@ -2,7 +2,7 @@
 import os
 from sys import stdout, stderr
 
-import chpl_tasks
+from . import chpl_tasks
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_threads.py
+++ b/util/chplenv/chpl_threads.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 import os
-from sys import stdout, stderr
+from sys import stderr, stdout
+
+from utils import memoize
 
 from . import chpl_tasks
-from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_timers.py
+++ b/util/chplenv/chpl_timers.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
 from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_wide_pointers.py
+++ b/util/chplenv/chpl_wide_pointers.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import os, re, optparse
-from sys import stdout, stderr
+import optparse
+import os
+import re
+from sys import stderr, stdout
 
 from utils import memoize
+
 
 @memoize
 def get(flag='wide'):

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 import os, re
 
-import utils
+from . import utils
 from utils import memoize
 
-import chpl_arch, chpl_compiler, chpl_platform
-import chpl_locale_model
+from . import chpl_arch, chpl_compiler, chpl_platform
+from . import chpl_locale_model
 
 
 #

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-import os, re
+import os
+import re
 
-from . import utils
 from utils import memoize
 
-from . import chpl_arch, chpl_compiler, chpl_platform
-from . import chpl_locale_model
+from . import chpl_arch, chpl_compiler, chpl_locale_model, chpl_platform, utils
 
 
 #

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -1,6 +1,9 @@
-import os, re, subprocess
-from distutils.spawn import find_executable
+import os
+import re
+import subprocess
 from collections import namedtuple
+from distutils.spawn import find_executable
+
 
 def memoize(func):
     cache = func.cache = {}
@@ -83,5 +86,3 @@ def run_command(command, stdout=True, stderr=False):
 def compiler_is_prgenv(compiler_val):
   return (compiler_val.startswith('cray-prgenv') or
      os.environ.get('CHPL_ORIG_TARGET_COMPILER','').startswith('cray-prgenv'))
-
-


### PR DESCRIPTION
* The problem: 
    * Scripts would fail in Python 3 due to legacy style relative imports, e.g. `import utils`
* The solution: 
    * Updated to Python 2/3 compatible relative imports, e.g. `from . import utils`

* Also sorted/cleaned up Python imports with [`isort`](https://github.com/timothycrosley/isort)

* Tested with Python 2.7.10 and 3.5.0 so far.
