### PR TITLE
Python 3 compatibility with `chplenv` scripts

### DIFF
--- a/util/chplenv/check_huge_pages.py
+++ b/util/chplenv/check_huge_pages.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 import os
+import sys
 from sys import stderr, stdout
 
-from utils import memoize
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-from . import chpl_comm, chpl_comm_substrate, chpl_platform
+import chpl_comm, chpl_comm_substrate, chpl_platform
+from utils import memoize
 
 
 # this one doesnt really need to cache anything, but it doesnt need to run more

--- a/util/chplenv/check_huge_pages.py
+++ b/util/chplenv/check_huge_pages.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 import os
-from sys import stdout, stderr
+from sys import stderr, stdout
 
-import chpl_platform, chpl_comm, chpl_comm_substrate
 from utils import memoize
+
+from . import chpl_comm, chpl_comm_substrate, chpl_platform
+
 
 # this one doesnt really need to cache anything, but it doesnt need to run more
 # than once to print out any warnings

--- a/util/chplenv/chpl_3p_dlmalloc_configs.py
+++ b/util/chplenv/chpl_3p_dlmalloc_configs.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
-from utils import memoize
+import sys
+import os
 
-from . import third_party_utils, utils
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import third_party_utils, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_3p_dlmalloc_configs.py
+++ b/util/chplenv/chpl_3p_dlmalloc_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_dlmalloc_configs.py
+++ b/util/chplenv/chpl_3p_dlmalloc_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_gmp_configs.py
+++ b/util/chplenv/chpl_3p_gmp_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_gmp_configs.py
+++ b/util/chplenv/chpl_3p_gmp_configs.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
+import os
+import sys
 from utils import memoize
 
-from . import third_party_utils, utils
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import third_party_utils, utils
 
 
 @memoize

--- a/util/chplenv/chpl_3p_gmp_configs.py
+++ b/util/chplenv/chpl_3p_gmp_configs.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import os
 import sys
-from utils import memoize
 
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import third_party_utils, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_3p_gmp_configs.py
+++ b/util/chplenv/chpl_3p_gmp_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_hwloc_configs.py
+++ b/util/chplenv/chpl_3p_hwloc_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_hwloc_configs.py
+++ b/util/chplenv/chpl_3p_hwloc_configs.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
+import os
+import sys
 from utils import memoize
 
-from . import third_party_utils, utils
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import third_party_utils, utils
 
 
 @memoize

--- a/util/chplenv/chpl_3p_hwloc_configs.py
+++ b/util/chplenv/chpl_3p_hwloc_configs.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import os
 import sys
-from utils import memoize
 
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import third_party_utils, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_3p_hwloc_configs.py
+++ b/util/chplenv/chpl_3p_hwloc_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_massivethreads_configs.py
+++ b/util/chplenv/chpl_3p_massivethreads_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_massivethreads_configs.py
+++ b/util/chplenv/chpl_3p_massivethreads_configs.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
+import os
+import sys
 from utils import memoize
 
-from . import third_party_utils, utils
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import third_party_utils, utils
 
 
 @memoize

--- a/util/chplenv/chpl_3p_massivethreads_configs.py
+++ b/util/chplenv/chpl_3p_massivethreads_configs.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import os
 import sys
-from utils import memoize
 
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import third_party_utils, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_3p_massivethreads_configs.py
+++ b/util/chplenv/chpl_3p_massivethreads_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import chpl_compiler, chpl_llvm, chpl_locale_model
-from . import third_party_utils
+
+from . import (chpl_compiler, chpl_llvm, chpl_locale_model, third_party_utils,
+               utils)
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
+import os
+import sys
 from utils import memoize
 
-from . import (chpl_compiler, chpl_llvm, chpl_locale_model, third_party_utils,
-               utils)
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_compiler, chpl_llvm, chpl_locale_model, third_party_utils, utils
 
 
 @memoize

--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import chpl_compiler, chpl_llvm, chpl_locale_model
-import third_party_utils
+from . import chpl_compiler, chpl_llvm, chpl_locale_model
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import os
 import sys
-from utils import memoize
 
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_compiler, chpl_llvm, chpl_locale_model, third_party_utils, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_3p_re2_configs.py
+++ b/util/chplenv/chpl_3p_re2_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_re2_configs.py
+++ b/util/chplenv/chpl_3p_re2_configs.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
+import os
+import sys
 from utils import memoize
 
-from . import third_party_utils, utils
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import third_party_utils, utils
 
 
 @memoize

--- a/util/chplenv/chpl_3p_re2_configs.py
+++ b/util/chplenv/chpl_3p_re2_configs.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import os
 import sys
-from utils import memoize
 
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import third_party_utils, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_3p_re2_configs.py
+++ b/util/chplenv/chpl_3p_re2_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_tcmalloc_configs.py
+++ b/util/chplenv/chpl_3p_tcmalloc_configs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import utils
+from . import utils
 from utils import memoize
-import third_party_utils
+from . import third_party_utils
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_3p_tcmalloc_configs.py
+++ b/util/chplenv/chpl_3p_tcmalloc_configs.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
+import os
+import sys
 from utils import memoize
 
-from . import third_party_utils, utils
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import third_party_utils, utils
 
 
 @memoize

--- a/util/chplenv/chpl_3p_tcmalloc_configs.py
+++ b/util/chplenv/chpl_3p_tcmalloc_configs.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import os
 import sys
-from utils import memoize
 
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import third_party_utils, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_3p_tcmalloc_configs.py
+++ b/util/chplenv/chpl_3p_tcmalloc_configs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from . import utils
 from utils import memoize
-from . import third_party_utils
+
+from . import third_party_utils, utils
+
 
 @memoize
 def get_uniq_cfg_path():

--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 
-import os, optparse
-from sys import stdout, stderr
+import optparse
+import os
 from string import punctuation
+from sys import stderr, stdout
 
-from . import utils, chpl_platform, chpl_comm, chpl_compiler
-from utils import memoize, CompVersion
+from utils import CompVersion, memoize
+
+from . import chpl_comm, chpl_compiler, chpl_platform, utils
+
 
 class argument_map(object):
     # intel does not support amd archs... it may be worth testing setting the

--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -4,7 +4,7 @@ import os, optparse
 from sys import stdout, stderr
 from string import punctuation
 
-import utils, chpl_platform, chpl_comm, chpl_compiler
+from . import utils, chpl_platform, chpl_comm, chpl_compiler
 from utils import memoize, CompVersion
 
 class argument_map(object):

--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
-
 import optparse
 import os
 from string import punctuation
 from sys import stderr, stdout
+import sys
 
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_comm, chpl_compiler, chpl_platform, utils
 from utils import CompVersion, memoize
-
-from . import chpl_comm, chpl_compiler, chpl_platform, utils
 
 
 class argument_map(object):

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os, optparse
 
-import chpl_platform, chpl_comm, chpl_compiler, utils
+from . import chpl_platform, chpl_comm, chpl_compiler, utils
 from utils import memoize, CompVersion
 
 @memoize

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -5,7 +5,10 @@ import sys
 
 from utils import CompVersion, memoize
 
-from . import chpl_comm, chpl_compiler, chpl_platform, utils
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_comm, chpl_compiler, chpl_platform, utils
 
 
 @memoize

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-import sys, os, optparse
+import optparse
+import os
+import sys
 
-from . import chpl_platform, chpl_comm, chpl_compiler, utils
-from utils import memoize, CompVersion
+from utils import CompVersion, memoize
+
+from . import chpl_comm, chpl_compiler, chpl_platform, utils
+
 
 @memoize
 def get(flag='target'):

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -3,12 +3,11 @@ import optparse
 import os
 import sys
 
-from utils import CompVersion, memoize
-
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_comm, chpl_compiler, chpl_platform, utils
+from utils import CompVersion, memoize
 
 
 @memoize

--- a/util/chplenv/chpl_aux_filesys.py
+++ b/util/chplenv/chpl_aux_filesys.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 import os
-from sys import stdout, stderr
+from sys import stderr, stdout
 
 from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_aux_filesys.py
+++ b/util/chplenv/chpl_aux_filesys.py
@@ -3,6 +3,9 @@ import sys
 import os
 from sys import stderr, stdout
 
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
 from utils import memoize
 
 

--- a/util/chplenv/chpl_aux_filesys.py
+++ b/util/chplenv/chpl_aux_filesys.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import sys
 import os
 from sys import stderr, stdout
 

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -2,12 +2,11 @@
 import os
 import sys
 
-from utils import memoize
-
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_compiler, chpl_platform, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_compiler
-import chpl_platform
+from . import chpl_compiler, chpl_platform, utils
 from utils import memoize
-import utils
 
 @memoize
 def get():

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
+
+from utils import memoize
 
 from . import chpl_compiler, chpl_platform, utils
-from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -4,7 +4,10 @@ import sys
 
 from utils import memoize
 
-from . import chpl_compiler, chpl_platform, utils
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_compiler, chpl_platform, utils
 
 
 @memoize

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -2,12 +2,11 @@
 import os
 import sys
 
-from utils import memoize
-
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_comm, chpl_comm_substrate
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_comm, chpl_comm_substrate
+from . import chpl_comm, chpl_comm_substrate
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -4,7 +4,10 @@ import sys
 
 from utils import memoize
 
-from . import chpl_comm, chpl_comm_substrate
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_comm, chpl_comm_substrate
 
 
 @memoize

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
+
+from utils import memoize
 
 from . import chpl_comm, chpl_comm_substrate
-from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -2,12 +2,11 @@
 import os
 import sys
 
-from utils import memoize
-
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_arch, chpl_comm, chpl_platform
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_platform, chpl_comm
+from . import chpl_arch, chpl_platform, chpl_comm
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -4,7 +4,10 @@ import sys
 
 from utils import memoize
 
-from . import chpl_arch, chpl_comm, chpl_platform
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_arch, chpl_comm, chpl_platform
 
 
 @memoize

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_arch, chpl_platform, chpl_comm
 from utils import memoize
+
+from . import chpl_arch, chpl_comm, chpl_platform
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
-import os, optparse
-from sys import stdout, stderr
+import optparse
+import os
+from sys import stderr, stdout
+
+from utils import memoize
 
 from . import chpl_platform, utils
-from utils import memoize
+
 
 @memoize
 def get(flag='host'):

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -2,7 +2,7 @@
 import os, optparse
 from sys import stdout, stderr
 
-import chpl_platform, utils
+from . import chpl_platform, utils
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -2,10 +2,13 @@
 import optparse
 import os
 from sys import stderr, stdout
+import sys
 
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_platform, utils
 from utils import memoize
-
-from . import chpl_platform, utils
 
 
 @memoize

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -2,10 +2,12 @@
 import os
 import sys
 
-from utils import memoize
 
-from . import (chpl_3p_gmp_configs, chpl_arch, chpl_compiler, chpl_platform,
-               utils)
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_3p_gmp_configs, chpl_arch, chpl_compiler, chpl_platform, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_arch, chpl_compiler, chpl_platform, utils, chpl_3p_gmp_configs
 from utils import memoize
+
+from . import (chpl_3p_gmp_configs, chpl_arch, chpl_compiler, chpl_platform,
+               utils)
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_compiler, chpl_platform, utils
+from . import chpl_arch, chpl_compiler, chpl_platform, utils, chpl_3p_gmp_configs
 from utils import memoize
-import chpl_3p_gmp_configs
 
 @memoize
 def get():

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -2,7 +2,6 @@
 import os
 import sys
 
-
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_tasks, chpl_arch
+from . import chpl_tasks, chpl_arch
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_tasks, chpl_arch
 from utils import memoize
+
+from . import chpl_arch, chpl_tasks
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -2,9 +2,12 @@
 import os
 import sys
 
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_arch, chpl_tasks
 from utils import memoize
 
-from . import chpl_arch, chpl_tasks
 
 
 @memoize

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -2,10 +2,11 @@
 import os
 import sys
 
-from utils import memoize
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-from . import (chpl_comm, chpl_comm_substrate, chpl_compiler, chpl_platform,
-               utils)
+import chpl_comm, chpl_comm_substrate, chpl_compiler, chpl_platform, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_comm, chpl_comm_substrate, chpl_platform, chpl_compiler, utils
 from utils import memoize
+
+from . import (chpl_comm, chpl_comm_substrate, chpl_compiler, chpl_platform,
+               utils)
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_comm, chpl_comm_substrate, chpl_platform, chpl_compiler, utils
+from . import chpl_comm, chpl_comm_substrate, chpl_platform, chpl_compiler, utils
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_platform, chpl_compiler, utils
 from utils import memoize
+
+from . import chpl_compiler, chpl_platform, utils
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -2,9 +2,11 @@
 import os
 import sys
 
-from utils import memoize
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-from . import chpl_compiler, chpl_platform, utils
+import chpl_compiler, chpl_platform, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_platform, chpl_compiler, utils
+from . import chpl_platform, chpl_compiler, utils
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_locale_model.py
+++ b/util/chplenv/chpl_locale_model.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
 from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_locale_model.py
+++ b/util/chplenv/chpl_locale_model.py
@@ -2,6 +2,9 @@
 import os
 import sys
 
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
 from utils import memoize
 
 

--- a/util/chplenv/chpl_make.py
+++ b/util/chplenv/chpl_make.py
@@ -2,9 +2,11 @@
 import os
 import sys
 
-from utils import memoize
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-from . import chpl_platform, utils
+import chpl_platform, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_make.py
+++ b/util/chplenv/chpl_make.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
+
+from utils import memoize
 
 from . import chpl_platform, utils
-from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_make.py
+++ b/util/chplenv/chpl_make.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_platform, utils
+from . import chpl_platform, utils
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -3,10 +3,11 @@ import optparse
 import os
 import sys
 
-from utils import memoize
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-from . import (chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler,
-               chpl_platform)
+import chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler, chpl_platform
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
-import sys, os, optparse
+import optparse
+import os
+import sys
 
-from . import chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler, chpl_platform
 from utils import memoize
+
+from . import (chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler,
+               chpl_platform)
+
 
 @memoize
 def get(flag='host'):

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys, os, optparse
 
-import chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler, chpl_platform
+from . import chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler, chpl_platform
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -6,8 +6,11 @@ import platform
 import re
 import sys
 
-from utils import memoize
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
+import utils
+from utils import memoize
 
 @memoize
 def get(flag='host'):

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
-import platform, os, os.path, re, sys, optparse
+import optparse
+import os
+import os.path
+import platform
+import re
+import sys
 
 from utils import memoize
+
 
 @memoize
 def get(flag='host'):

--- a/util/chplenv/chpl_regexp.py
+++ b/util/chplenv/chpl_regexp.py
@@ -2,10 +2,11 @@
 import os
 import sys
 
-from utils import memoize
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-from . import (chpl_3p_re2_configs, chpl_arch, chpl_compiler, chpl_platform,
-               utils)
+import chpl_3p_re2_configs, chpl_arch, chpl_compiler, chpl_platform, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_regexp.py
+++ b/util/chplenv/chpl_regexp.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_arch, chpl_platform, chpl_compiler, utils
 from utils import memoize
-from . import chpl_3p_re2_configs
+
+from . import (chpl_3p_re2_configs, chpl_arch, chpl_compiler, chpl_platform,
+               utils)
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_regexp.py
+++ b/util/chplenv/chpl_regexp.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_platform, chpl_compiler, utils
+from . import chpl_arch, chpl_platform, chpl_compiler, utils
 from utils import memoize
-import chpl_3p_re2_configs
+from . import chpl_3p_re2_configs
 
 @memoize
 def get():

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
-from . import chpl_arch, chpl_platform, chpl_compiler, chpl_comm, utils
 from utils import memoize
+
+from . import chpl_arch, chpl_comm, chpl_compiler, chpl_platform, utils
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 import sys, os
 
-import chpl_arch, chpl_platform, chpl_compiler, chpl_comm
+from . import chpl_arch, chpl_platform, chpl_compiler, chpl_comm, utils
 from utils import memoize
-import utils
 
 @memoize
 def get():

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -2,9 +2,11 @@
 import os
 import sys
 
-from utils import memoize
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-from . import chpl_arch, chpl_comm, chpl_compiler, chpl_platform, utils
+import chpl_arch, chpl_comm, chpl_compiler, chpl_platform, utils
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/chpl_threads.py
+++ b/util/chplenv/chpl_threads.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 import os
 from sys import stderr, stdout
+import sys
 
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_tasks
 from utils import memoize
-
-from . import chpl_tasks
 
 
 @memoize

--- a/util/chplenv/chpl_threads.py
+++ b/util/chplenv/chpl_threads.py
@@ -2,7 +2,7 @@
 import os
 from sys import stdout, stderr
 
-import chpl_tasks
+from . import chpl_tasks
 from utils import memoize
 
 @memoize

--- a/util/chplenv/chpl_threads.py
+++ b/util/chplenv/chpl_threads.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 import os
-from sys import stdout, stderr
+from sys import stderr, stdout
+
+from utils import memoize
 
 from . import chpl_tasks
-from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_timers.py
+++ b/util/chplenv/chpl_timers.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
-import sys, os
+import os
+import sys
 
 from utils import memoize
+
 
 @memoize
 def get():

--- a/util/chplenv/chpl_timers.py
+++ b/util/chplenv/chpl_timers.py
@@ -2,6 +2,9 @@
 import os
 import sys
 
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
 from utils import memoize
 
 

--- a/util/chplenv/chpl_wide_pointers.py
+++ b/util/chplenv/chpl_wide_pointers.py
@@ -3,6 +3,10 @@ import optparse
 import os
 import re
 from sys import stderr, stdout
+import sys
+
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 from utils import memoize
 

--- a/util/chplenv/chpl_wide_pointers.py
+++ b/util/chplenv/chpl_wide_pointers.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
-import os, re, optparse
-from sys import stdout, stderr
+import optparse
+import os
+import re
+from sys import stderr, stdout
 
 from utils import memoize
+
 
 @memoize
 def get(flag='wide'):

--- a/util/chplenv/third-party-pkgs
+++ b/util/chplenv/third-party-pkgs
@@ -23,6 +23,8 @@
 #   that package is emitted if --compiler is passed,
 #   and not by default (which gives dependencies for runtime).
 #
+from __future__ import print_function, absolute_import
+
 import os, os.path, sys, subprocess
 
 utildir = os.path.split(sys.argv[0])
@@ -53,7 +55,7 @@ for dir in third_party_pkgs:
 
 printchplenv = chpl_home+'/util/printchplenv'
 chplenv=subprocess.Popen([printchplenv, '--simple'],
-                         stdout=subprocess.PIPE).communicate()[0]
+                         stdout=subprocess.PIPE).communicate()[0].decode()
 
 pkgs=''
 for l in chplenv.split('\n'):
@@ -86,5 +88,5 @@ else:
 
 pkgs = pkgs.strip()
 
-print pkgs
+print(pkgs)
 

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 import os, re
 
-import utils
+from . import utils
 from utils import memoize
 
-import chpl_arch, chpl_compiler, chpl_platform
-import chpl_locale_model
+from . import chpl_arch, chpl_compiler, chpl_platform
+from . import chpl_locale_model
 
 
 #

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-import os, re
+import os
+import re
 
-from . import utils
 from utils import memoize
 
-from . import chpl_arch, chpl_compiler, chpl_platform
-from . import chpl_locale_model
+from . import chpl_arch, chpl_compiler, chpl_locale_model, chpl_platform, utils
 
 
 #

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -6,7 +6,6 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-
 import chpl_arch, chpl_compiler, chpl_locale_model, chpl_platform, utils
 from utils import memoize
 

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 import os
 import re
+import sys
 
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+
+import chpl_arch, chpl_compiler, chpl_locale_model, chpl_platform, utils
 from utils import memoize
-
-from . import chpl_arch, chpl_compiler, chpl_locale_model, chpl_platform, utils
 
 
 #

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -48,7 +48,7 @@ def get_compiler_version(compiler):
 @memoize
 def CompVersion(version_string):
     CompVersionT = namedtuple('CompVersion', ['major', 'minor', 'revision', 'build'])
-    match = re.search(u'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', version_string)
+    match = re.search(u'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', str(version_string))
     if match:
         major    = int(match.group(1))
         minor    = int(match.group(3) or 0)

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -48,7 +48,7 @@ def get_compiler_version(compiler):
 @memoize
 def CompVersion(version_string):
     CompVersionT = namedtuple('CompVersion', ['major', 'minor', 'revision', 'build'])
-    match = re.search(r'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', version_string)
+    match = re.search(u'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', version_string)
     if match:
         major    = int(match.group(1))
         minor    = int(match.group(3) or 0)

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -1,6 +1,9 @@
-import os, re, subprocess
-from distutils.spawn import find_executable
+import os
+import re
+import subprocess
 from collections import namedtuple
+from distutils.spawn import find_executable
+
 
 def memoize(func):
     cache = func.cache = {}
@@ -83,5 +86,3 @@ def run_command(command, stdout=True, stderr=False):
 def compiler_is_prgenv(compiler_val):
   return (compiler_val.startswith('cray-prgenv') or
      os.environ.get('CHPL_ORIG_TARGET_COMPILER','').startswith('cray-prgenv'))
-
-

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
-import optparse, os, subprocess
+import optparse, os, subprocess, sys
 from sys import stdout
+
+chplenv_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 from chplenv import *
 

--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -8,9 +8,9 @@ import sys
 chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import utils
-import chpl_platform
-import chpl_make
+from chplenv import utils
+from chplenv import chpl_platform
+from chplenv import chpl_make
 
 # Activate a virtualenv that has testing infrastructure requirements installed
 #


### PR DESCRIPTION
* The problem: 
    * `util/chplenv/*py` scripts would fail in Python 3 due to legacy style relative imports, 
         * e.g. `import utils`

* The solution: 
    * Updated to `$PYTHONPATH` to include `$CHPL_HOME/util/chplenv` so absolute imports work in Python 2 & 3 
    * Unfortunately, the 2/3 compatible relative import: `from . import foo`, required a large amount of messy changes throughout the code base, and was ultimately determined to be an inferior solution

* Also tried to clean/sort Python imports with [`isort`](https://github.com/timothycrosley/isort)
    * Still looks a little ugly because the relative imports must follow the `$PYTHONPATH` injection

* Tested with Python 2.7.10 and 3.5.0.

* A new Jenkins job: `correctness-test-python3` will ensure we maintain Python 3 compatibility in the future.