### PR TITLE
Disable OpenCL support in hwloc for now.

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -12,7 +12,12 @@ ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_HWLOC_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 endif
 
-CHPL_HWLOC_CFG_OPTIONS += --enable-static --disable-shared --disable-libxml2 --disable-pci --disable-cairo
+CHPL_HWLOC_CFG_OPTIONS += --enable-static \
+                          --disable-shared \
+                          --disable-cairo \
+                          --disable-libxml2 \
+                          --disable-opencl \
+                          --disable-pci
 
 CHPL_HWLOC_CFG_OPTIONS += $(CHPL_HWLOC_MORE_CFG_OPTIONS)
 


### PR DESCRIPTION
(Inspired by Jason Riedy.)

Disable OpenCL support for now.  It's conceivable we might like to add
it back in later for specific targets, but that can wait until there's a
need.

While here, I reformatted the configure flags so that future changes will
have a more obvious effect on the diff output.