### PR TITLE
Jira 128 :- Trivial changes on master to reduce the deltas in AST/iterator.cpp

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -20,16 +20,16 @@
 #include "iterator.h"
 
 #include "astutil.h"
-#include "oldCollectors.h"
 #include "bb.h"
 #include "bitVec.h"
 #include "CForLoop.h"
 #include "expr.h"
 #include "ForLoop.h"
-#include "stmt.h"
-#include "stlUtil.h"
-#include "stringutil.h"
+#include "oldCollectors.h"
 #include "optimizations.h"
+#include "stlUtil.h"
+#include "stmt.h"
+#include "stringutil.h"
 #include "view.h"
 #include "WhileStmt.h"
 
@@ -121,7 +121,7 @@ isSingleLoopIterator(FnSymbol* fn, Vec<BaseAST*>& asts) {
           // We already saw a yield stmt.  This is the second one, so fail.
           return NULL;
         }
-        
+
         // Select yield statements whose parent expression is a loop statement
         // (except for dowhile statements, for some reason....
 
@@ -322,7 +322,7 @@ static void replaceLocalWithFieldTemp(SymExpr*       se,
 // Upon each yield, ic.value aka valField is explicitly updated
 // with yield's expression.
 // E.g. 'yield localvar' is converted to ic.value = ic.FNN_localvar.
-// 
+//
 
 
 // In the body of an iterator function, replace references to local variables
@@ -970,11 +970,13 @@ static bool containsRefVar(Vec<Symbol*>& syms, FnSymbol* fn,
 }
 
 
-static void insertLocalsForRefs(Vec<Symbol*>& syms, FnSymbol* fn,
+static void insertLocalsForRefs(Vec<Symbol*>& syms,
+                                FnSymbol*     fn,
                                 Vec<Symbol*>& yldSymSet)
 {
-  Map<Symbol*,Vec<SymExpr*>*> defMap;
-  Map<Symbol*,Vec<SymExpr*>*> useMap;
+  Map<Symbol*, Vec<SymExpr*>*> defMap;
+  Map<Symbol*, Vec<SymExpr*>*> useMap;
+
   buildDefUseMaps(fn, defMap, useMap);
 
   // Walk the variables in this (iterator) function
@@ -984,20 +986,22 @@ static void insertLocalsForRefs(Vec<Symbol*>& syms, FnSymbol* fn,
       continue;
 
     if (sym->type->symbol->hasFlag(FLAG_REF)) {
-
       Vec<SymExpr*>* defs = defMap.get(sym);
+
       if (defs == NULL || defs->n != 1) {
         INT_FATAL(sym, "Expected sym to have exactly one definition");
       }
 
       // Do we need to consider PRIM_ASSIGN as well?
       CallExpr* move = toCallExpr(defs->v[0]->parentExpr);
+
       INT_ASSERT(move->isPrimitive(PRIM_MOVE));
 
       if (SymExpr* se = toSymExpr(move->get(2)))
       {
         // The symbol is defined through a bitwise (pointer) copy.
         INT_ASSERT(se->var->type->symbol->hasFlag(FLAG_REF));
+
         if (se->var->defPoint->parentSymbol == fn) {
           syms.add_exclusive(se->var);
         }
@@ -1008,6 +1012,7 @@ static void insertLocalsForRefs(Vec<Symbol*>& syms, FnSymbol* fn,
         if (FnSymbol* fn = call->isResolved()) {
           for_actuals(actual, call) {
             SymExpr* se = toSymExpr(actual);
+
             if (se->var->defPoint->parentSymbol == fn) {
               syms.add_exclusive(se->var);
             }
@@ -1016,29 +1021,31 @@ static void insertLocalsForRefs(Vec<Symbol*>& syms, FnSymbol* fn,
         else
         {
           // The RHS is not a function call: it must be a primitive instead.
-
-          if (call->isPrimitive(PRIM_ADDR_OF) ||
+          if (call->isPrimitive(PRIM_ADDR_OF)    ||
               call->isPrimitive(PRIM_GET_MEMBER) ||
-              // If we are reading a reference out of a field, I'm not sure we
-              // capture the right rhs below.  (The actual target of the ref lies
-              // outside the struct that contains the ref.)
+              // If we are reading a reference out of a field, I'm not sure
+              // we capture the right rhs below.  (The actual target of the
+              // ref lies outside the struct that contains the ref.)
               call->isPrimitive(PRIM_GET_MEMBER_VALUE)) {
             SymExpr* rhs = toSymExpr(call->get(1));
+
             syms.add_exclusive(rhs->var);
           }
           else
           {
-            INT_FATAL(sym, "Unhandled case: Ref returned by a primitive from which we did not expect one.");
+            INT_FATAL(sym,
+                      "Unhandled case: Ref returned by a primitive "
+                      "from which we did not expect one.");
           }
         }
       }
       else
       {
-        // What else could it be?
         INT_FATAL(move, "RHS of a move is neither a SymExpr nor a CallExpr.");
       }
     }
   }
+
   freeDefUseMaps(defMap, useMap);
 }
 
@@ -1120,7 +1127,7 @@ noOtherCalls(FnSymbol* callee, CallExpr* theCall) {
 // Preceding calls to the various build...() functions have copied out interesting parts
 // of the iterator function.
 // This function rips the guts out of the original iterator function and replaces them
-// with a simple function that just initializes the fields in the iterator class
+// with a simple function that just initializes the fields in the iterator record
 // with formal arguments of the original iterator that are live at yield sites within it.
 static void
 rebuildIterator(IteratorInfo* ii,
@@ -1151,14 +1158,14 @@ rebuildIterator(IteratorInfo* ii,
 
   // For each live argument
   forv_Vec(Symbol, local, locals) {
-    if (!toArgSymbol(local)) 
+    if (!toArgSymbol(local))
       continue;
 
     // Get the corresponding field in the iterator class
     Symbol* field = local2field.get(local);
 
     if (local->type == field->type->refType) {
-      // If a ref var, 
+      // If a ref var,
       // load the local into a temp and then set the value of the corresponding field.
       Symbol* tmp = newTemp(field->type);
       fn->insertAtTail(new DefExpr(tmp));
@@ -1276,10 +1283,10 @@ static inline Symbol* createICField(int& i, Symbol* local, Type* type,
   return field;
 }
 
-// Fills in the iterator class and record types with fields corresponding to the 
+// Fills in the iterator class and record types with fields corresponding to the
 // local variables defined in the iterator function (or its static context)
 // and live at any yield.
-static void addLocalsToClassAndRecord(Vec<Symbol*>& locals, FnSymbol* fn, 
+static void addLocalsToClassAndRecord(Vec<Symbol*>& locals, FnSymbol* fn,
                                       Vec<Symbol*>& yldSymSet, Type* yieldedType,
                                       Symbol** valFieldRef, bool oneLocalYS,
                                       SymbolMap& local2field, SymbolMap& local2rfield)


### PR DESCRIPTION
1) Match a small number of "whitespace" changes between string-as-rec and master.  These include
sorting the #include statements in alphabetic order, removing trailing whitespace, reformatting some
comments to honor the 80 column goal etc.

2) A non-functional update to rebuildIterator() to partially match string-as-rec.  String-as-rec factors
out the final statement of the clauses of an in-then-else statement while master replicates the
statement in to both clauses.

This factoring helps to highlights that string-as-rec is inserting auto-copies for array/domain/distributions
while master is not.  We do not intend to null this delta at this time.

Passes linux64.
