### PR TITLE
Fixed activate_virtual_env for Python 2 compatibility

### DIFF
--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import os
 import sys
 
-chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
+chplenv_dir = os.path.join(os.path.dirname(__file__), '..',)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 from chplenv import utils

--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import os
 import sys
 
-chplenv_dir = os.path.join(os.path.dirname(__file__), '..',)
+chplenv_dir = os.path.join(os.path.dirname(__file__), '..')
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 from chplenv import utils


### PR DESCRIPTION
`chplenv` should not be explicitly added to `sys.path` anymore

Paratested :ok: