### PR TITLE
Jira-124: Trivial update to master to close a delta

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -451,6 +451,7 @@ void AstDump::visitEblockStmt(ExternBlockStmt* node) {
 // GotoStmt
 //
 bool AstDump::enterGotoStmt(GotoStmt* node) {
+  newline();
   switch (node->gotoTag) {
     case GOTO_NORMAL:      write("goto");           break;
     case GOTO_BREAK:       write("break");          break;


### PR DESCRIPTION
string-as-rec introduced an initial newline() when rendering a gotoStmt via AstDump.
I elected to replicate this trivial change on master.

Verified that the code complies on clang/gcc.
