### PR TITLE
jira-141 : update master to eliminate 2 trivial deltas

### DIFF
--- a/compiler/passes/returnStarTuplesByRefArgs.cpp
+++ b/compiler/passes/returnStarTuplesByRefArgs.cpp
@@ -45,7 +45,7 @@ void returnStarTuplesByRefArgs() {
       ArgSymbol* arg = new ArgSymbol(INTENT_REF, "_ret", ret->type->refType);
       fn->insertFormalAtTail(arg);
       fn->retType = dtVoid;
-      fn->insertBeforeReturn(new CallExpr(PRIM_MOVE, arg, ret));
+      fn->insertBeforeReturnAfterLabel(new CallExpr(PRIM_MOVE, arg, ret));
       CallExpr* call = toCallExpr(fn->body->body.tail);
       INT_ASSERT(call && call->isPrimitive(PRIM_RETURN));
       call->get(1)->replace(new SymExpr(gVoid));
@@ -85,6 +85,9 @@ void returnStarTuplesByRefArgs() {
   // SET/GET_SVEC_MEMBER primitives
   //
   forv_Vec(CallExpr, call, gCallExprs) {
+    if (! call->inTree())
+      continue;
+
     if (call->isPrimitive(PRIM_SET_MEMBER) ||
         call->isPrimitive(PRIM_GET_MEMBER) ||
         call->isPrimitive(PRIM_GET_MEMBER_VALUE)) {


### PR DESCRIPTION
string-as-rec include 2 minor deltas for passes/returnStarTuplesByRefArgs.cpp.
I believe both could/should be imported to master although they do not currently have
an observable impact on master.

1) A check that a node is still live before performing some minor transformations on it

2) A change to insert a node using insertBeforeReturnAfterLabel rather than insertBeforeReturn.

I was curious about the latter change on master.  With a little work I determined that the call site
is only invoked for 4 tests in the standard test suite.  In each of these cases there is not a label
immediately before the return.  Hence it doesn't matter to master which call is used.

Ignoring the meta-issue about "hunting for a label", I think it makes sense to ensure that the
code be executed after the label (e.g. a function with multiple returns) and expect that Tom
found an error case for this.

Trivial changes.  Passes paratest on linux64.
