### PR TITLE
Make this more likely to fail.

### DIFF
--- a/test/runtime/gbt/atomic-on-stack.chpl
+++ b/test/runtime/gbt/atomic-on-stack.chpl
@@ -1,6 +1,8 @@
 proc main() {
-  var x: atomic int;
-  on Locales[numLocales-1] do
-    x.add(1);
-  writeln(x.read());
+  on Locales[numLocales-1] {
+    var x: atomic int;
+    on Locales[0] do
+      x.add(1);
+    writeln(x.read());
+  }
 }


### PR DESCRIPTION
I encountered a situation in which this future didn't fail as expected.
I'm not entirely sure why, but I've modified it (by moving the atomic
var to a non-0 locale) to make it more likely to fail as expected.