### PR TITLE
Revert "Add suppressions for pgi negative 0.0 floating point bugs"

### DIFF
--- a/test/types/complex/bradc/negateimaginary3.suppressif
+++ b/test/types/complex/bradc/negateimaginary3.suppressif
@@ -1,3 +1,0 @@
-# pgi compiler bug, see jira issue 48
-CHPL_TARGET_COMPILER==pgi
-CHPL_TARGET_COMPILER==cray-prgenv-pgi

--- a/test/types/complex/bradc/negativeimaginaryliteral.suppressif
+++ b/test/types/complex/bradc/negativeimaginaryliteral.suppressif
@@ -1,3 +1,0 @@
-# pgi compiler bug, see jira issue 48
-CHPL_TARGET_COMPILER==pgi
-CHPL_TARGET_COMPILER==cray-prgenv-pgi

--- a/test/types/file/bradc/scalar/floatcomplexexceptions.suppressif
+++ b/test/types/file/bradc/scalar/floatcomplexexceptions.suppressif
@@ -1,3 +1,0 @@
-# pgi compiler bug, see jira issue 48
-CHPL_TARGET_COMPILER==pgi
-CHPL_TARGET_COMPILER==cray-prgenv-pgi


### PR DESCRIPTION
This reverts commit 1a38ace37fb08264e3628aab7ef3a8ecdb9b7f07.

The pgi negative 0.0 floating point bug has been fixed with pgi 15.9.0.

See JIRA issue 48 for more info (https://chapel.atlassian.net/browse/CHAPEL-48)