### PR TITLE
On string-as-rec, revert #2439

### DIFF
--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -214,7 +214,10 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
               CallExpr* call = toCallExpr(se->parentExpr);
               INT_ASSERT(call);
               FnSymbol* fnc = call->isResolved();
-              if ((call->isPrimitive(PRIM_GET_MEMBER)) ||
+              if ((call->isPrimitive(PRIM_MOVE) && call->get(1) == se) ||
+                  (call->isPrimitive(PRIM_ASSIGN) && call->get(1) == se) ||
+                  (call->isPrimitive(PRIM_SET_MEMBER) && call->get(1) == se) ||
+                  (call->isPrimitive(PRIM_GET_MEMBER)) ||
                   (call->isPrimitive(PRIM_GET_MEMBER_VALUE)) ||
                   (call->isPrimitive(PRIM_WIDE_GET_LOCALE)) ||
                   (call->isPrimitive(PRIM_WIDE_GET_NODE)) ||


### PR DESCRIPTION
#2439 on string-as-rec removed a couple of checks
in replaceVarUsesWithFormals().

This followed up our experiment on master, where we removed them
in #2362, observed it cause a valgrind regression, then reinstated in #2436.

We thought it would be good to have it on SAR, however right now we
believe it should behave the same way as it does on master,
so we are putting them back in on SAR.

Given that the valgrind regression mentioned would still occurs on SAR
without this PR, there is no need to investigate whether/why they are there.

For reference, the valgrind regression would happened in:

    domains/sungeun/sparse/index_not_in_domain_1.chpl
