### PR TITLE
Run all of the tests for gasnet testing on OSX

### DIFF
--- a/util/cron/test-gasnet.darwin.bash
+++ b/util/cron/test-gasnet.darwin.bash
@@ -11,4 +11,4 @@ export CHPL_UTIL_SMTP_HOST=relaya
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin"
 
-$CWD/nightly -cron -examples
+$CWD/nightly -cron


### PR DESCRIPTION
We were only running the examples directory, and we've been finding a
fair number of tests that fail on OSX when run under gasnet that are
outside that directory. A common cause for failure is the more
aggressive ASLR used by OSX.