### PR TITLE
Minor cleanup of BlockArr follower

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1120,16 +1120,9 @@ iter BlockArr.these(param tag: iterKind, followThis, param fast: bool = false) r
     //
     // we don't necessarily own all the elements we're following
     //
-    proc accessHelper(i) ref {
-      if myLocArr then local {
-        if myLocArr.locDom.member(i) then
-          return myLocArr.this(i);
-      }
-      return dsiAccess(i);
-    }
     const myFollowThisDom = {(...myFollowThis)};
     for i in myFollowThisDom {
-      yield accessHelper(i);
+      yield dsiAccess(i);
     }
   }
 }


### PR DESCRIPTION
The non-fast branch of BlockArr's follower used a small helper function to optimize for the case that the current locale owned the index. dsiAccess already provides this behavior. In the worst case, we would perform the locality check twice before handling the general case.

By simply calling dsiAccess, we can eliminate some complex and redundant code.