### PR TITLE
Minor fixes to top-level READMEs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1079,7 +1079,7 @@ New Semantic Checks (for old semantics)
 Bug Fixes
 ---------
 * fixed a bug in which int literals > max(int(32)) could not coerce to uint(32)
-* fixed support for uppercase binary and hexidecimal literals
+* fixed support for uppercase binary and hexadecimal literals
   (e.g. 0B1101101 and 0Xbabe1055)
 * fixed a bug in which ~1% of compiles would segfault on Macs
 * fixed a bug relating to nested records and default constructors

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,7 +12,6 @@ Ben Albrecht, Cray Inc.
 Ian Bertolacci, Cray Inc./Colorado State University
 Kyle Brady, Cray Inc.
 Brad Chamberlain, Cray Inc.
-Cory McCartan, Cray Inc.
 Sung-Eun Choi, Cray Inc.
 Lydia Duncan, Cray Inc.
 Michael Ferguson, Cray Inc.
@@ -21,6 +20,7 @@ Tom Hildebrandt, Cray Inc.
 David Iten, Cray Inc.
 Vassily Litvinov, Cray Inc.
 Tom MacDonald, Cray Inc.
+Cory McCartan, Cray Inc.
 Damian McGuckin, Pacific Engineering Systems International
 Phil Nelson, Western Washington University/Cray Inc.
 Michael Noakes, Cray Inc.


### PR DESCRIPTION
* Fixing spelling of hexadecimal.
* Fixing alphabetization of Cory's name.

Dur.
