### PR TITLE
Stop printing "Unresolved Future Tests" in nightly mails

### DIFF
--- a/util/cron/nightly_email.pl
+++ b/util/cron/nightly_email.pl
@@ -150,10 +150,6 @@ if ($status == 0) {
     print MAIL "--- New Failing Future tests -----------------\n";
     print MAIL `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Error"`;
     print MAIL "\n";
-
-    print MAIL "--- Unresolved Future tests ------------------\n";
-    print MAIL `LC_ALL=C comm -12 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Error"`;
-    print MAIL "\n";    
 }
 
 print MAIL endMailChplenv();


### PR DESCRIPTION
For our nightly regression testing we send out summary mails that include a
list of futures that haven't been resolved. This list doesn't change much, and
is typically just ignored. For configurations where we do full future testing,
this adds ~800 lines of test names without adding much useful information.