### PR TITLE
Fix a record test bug, improve debugging, remove ignore noinit

### DIFF
--- a/test/types/records/ferguson/assert-locale-record/myrecord.chpl
+++ b/test/types/records/ferguson/assert-locale-record/myrecord.chpl
@@ -4,7 +4,6 @@
 
 config const debug = false;
 
-pragma "ignore noinit"
 record R {
   var x:int;
   var home:locale = here;

--- a/test/types/records/ferguson/must-init-record/myrecord.chpl
+++ b/test/types/records/ferguson/must-init-record/myrecord.chpl
@@ -4,7 +4,6 @@
 
 config const debug = false;
 
-pragma "ignore noinit"
 record R {
   var x: int = 0;
   var canary: int = 42;
@@ -91,7 +90,8 @@ proc chpl__initCopy(arg: R) {
 
   var ret: R;
 
-  ret.init(x = arg.x);
+  // allow copies of a default-initialized record.
+  ret.init(x = arg.x, true);
 
   if debug {
     writeln("leaving init copy");

--- a/test/types/records/ferguson/tracking-record/myrecord.chpl
+++ b/test/types/records/ferguson/tracking-record/myrecord.chpl
@@ -24,6 +24,11 @@ record R {
 proc ref R.init(x:int, allow_zero:bool=false) {
   if !allow_zero then assert(x != 0);
 
+  if debug {
+    printf("in init deallocating c=%p ", c);
+    writeln(c);
+  }
+
   if this.c then trackFree(this.c, this.c.id, this.x);
   delete this.c;
   this.c = nil;
@@ -58,7 +63,7 @@ proc R.~R() {
   extern proc printf(fmt:c_string, arg:C);
   if debug {
     printf("in destructor for c=%p ", c);
-    writeln(c);
+    writeln("x=", x, " ", c);
   }
 
   if c then trackFree(c, c.id, this.x);
@@ -93,7 +98,7 @@ proc chpl__autoCopy(arg: R) {
   extern proc printf(fmt:c_string, arg:C, arg2:C);
   if debug {
     printf("in auto copy from arg.c=%p ", arg.c);
-    writeln(arg.c);
+    writeln("x=", arg.x, " ", arg.c);
   }
 
   // TODO - is no auto destroy necessary here?


### PR DESCRIPTION
* removes pragma "ignore noinit" from the records being tested
  since after the POD change it is no longer necessary
* allows initCopy to be called from a default-initialized record
  (the must-init-record/myrecord already allowed that for autoCopy
   and not doing so for initCopy was an oversight).
* improve debugging for memory leak test

Thanks to Mike for pointing out the initCopy problem.