### PR TITLE
Function resolution cleanups

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6539,6 +6539,12 @@ resolveFns(FnSymbol* fn) {
   if (fn->isResolved())
     return;
 
+  if (fn->id == breakOnResolveID) {
+    printf("breaking on resolve fn:\n");
+    print_view(fn);
+    gdbShouldBreakHere();
+  }
+
   fn->addFlag(FLAG_RESOLVED);
 
   if (fn->hasFlag(FLAG_EXTERN)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5794,7 +5794,7 @@ postFold(Expr* expr) {
           if (paramMap.get(lhs->var))
             INT_FATAL(call, "parameter set multiple times");
           VarSymbol* lhsVar = toVarSymbol(lhs->var);
-          // We are expecting the LHS to be a var (what else could it be?
+          // We are expecting the LHS to be a var (what else could it be? )
           if (lhsVar->immediate) {
             // The value of the LHS of this move has already been
             // established, most likely through a construct like

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -754,12 +754,16 @@ protoIteratorClass(FnSymbol* fn) {
   ii->iclass = new AggregateType(AGGREGATE_CLASS);
   TypeSymbol* cts = new TypeSymbol(astr("_ic_", className), ii->iclass);
   cts->addFlag(FLAG_ITERATOR_CLASS);
+  cts->addFlag(FLAG_POD);
   add_root_type(ii->iclass);    // Add super : dtObject.
   fn->defPoint->insertBefore(new DefExpr(cts));
 
   ii->irecord = new AggregateType(AGGREGATE_RECORD);
   TypeSymbol* rts = new TypeSymbol(astr("_ir_", className), ii->irecord);
   rts->addFlag(FLAG_ITERATOR_RECORD);
+  // TODO -- do a better job of deciding if an iterator record is
+  // POD or not POD.
+  rts->addFlag(FLAG_NOT_POD);
   if (fn->retTag == RET_REF)
     rts->addFlag(FLAG_REF_ITERATOR_CLASS);
   fn->defPoint->insertBefore(new DefExpr(rts));

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2133,7 +2133,7 @@ proc file.getPath(out error:syserr) : string {
       ret = "unknown";
     }
   }
- return ret; 
+  return ret;
 }
 
 /*


### PR DESCRIPTION
* Tidy up resolution's handling of declared return types
* Trivial comment and spacing changes
* Make iterator classes and records POD and NOT_POD respectively.
* Allow --break-on-resolve-id to work with a FnSymbol ID to stop when
  that function is resolved.

For more detail on the first of these changes, see the individual commit
messages.

These changes to how declared return types are handled are required for
my upcoming PR changing returns for declared return types to not always
use the = operator.

Passes full local testing.
Reviewed by @noakesmichael.
