### PR TITLE
Lcals memory leaks cleanup

### DIFF
--- a/test/studies/lcals/LCALSDataTypes.chpl
+++ b/test/studies/lcals/LCALSDataTypes.chpl
@@ -70,23 +70,31 @@ module LCALSDataTypes {
       if ref_loop_stat != nil then delete ref_loop_stat;
       if loop_weights != nil then delete loop_weights;
       if num_loops_run != nil {
-        // TODO: delete the sub-vectors
+        for nlr in num_loops_run do
+          if nlr != nil then delete nlr;
         delete num_loops_run;
       }
       if tot_time != nil {
-        // TODO: delete the sub-vectors
+        for tt in tot_time do
+          if tt != nil then delete tt;
         delete tot_time;
       }
       if fom_rel != nil {
-        // TODO: delete the sub-vectors
+        for fr in fom_rel do
+          if fr != nil then delete fr;
         delete fom_rel;
       }
       if fom_rate != nil {
-        // TODO: delete the sub-vectors
+        for fr in fom_rate do
+          if fr != nil then delete fr;
         delete fom_rate;
       }
       for idx in loop_test_stats_dom {
-        if loop_test_stats[idx] != nil then delete loop_test_stats[idx];
+        if loop_test_stats[idx] != nil {
+          for stat in loop_test_stats[idx] do
+            if stat != nil then delete stat;
+          delete loop_test_stats[idx];
+        }
       }
     }
   }
@@ -131,7 +139,8 @@ module LCALSDataTypes {
     }
     proc ~LoopStat() {
       if loop_run_time != nil {
-        // TODO: delete the sub-vectors
+        for lrt in loop_run_time do
+          if lrt != nil then delete lrt;
         delete loop_run_time;
       }
       if loop_run_count != nil then delete loop_run_count;

--- a/test/studies/lcals/LCALSDataTypes.chpl
+++ b/test/studies/lcals/LCALSDataTypes.chpl
@@ -63,6 +63,32 @@ module LCALSDataTypes {
       loop_test_stats_dom += name;
       loop_test_stats[name] = new vector(LoopStat);
     }
+    proc ~LoopSuiteRunInfo() {
+      if loop_names != nil then delete loop_names;
+      if run_loop_length != nil then delete run_loop_length;
+      if loop_length_names != nil then delete loop_length_names;
+      if ref_loop_stat != nil then delete ref_loop_stat;
+      if loop_weights != nil then delete loop_weights;
+      if num_loops_run != nil {
+        // TODO: delete the sub-vectors
+        delete num_loops_run;
+      }
+      if tot_time != nil {
+        // TODO: delete the sub-vectors
+        delete tot_time;
+      }
+      if fom_rel != nil {
+        // TODO: delete the sub-vectors
+        delete fom_rel;
+      }
+      if fom_rate != nil {
+        // TODO: delete the sub-vectors
+        delete fom_rate;
+      }
+      for idx in loop_test_stats_dom {
+        if loop_test_stats[idx] != nil then delete loop_test_stats[idx];
+      }
+    }
   }
 
   class LoopStat {
@@ -102,6 +128,22 @@ module LCALSDataTypes {
       samples_per_pass.resize(num_loop_lengths);
 
       loop_chksum.resize(num_loop_lengths);
+    }
+    proc ~LoopStat() {
+      if loop_run_time != nil {
+        // TODO: delete the sub-vectors
+        delete loop_run_time;
+      }
+      if loop_run_count != nil then delete loop_run_count;
+      if mean != nil then delete mean;
+      if std_dev != nil then delete std_dev;
+      if min != nil then delete min;
+      if max != nil then delete max;
+      if harm_mean != nil then delete harm_mean;
+      if meanrel2ref != nil then delete meanrel2ref;
+      if loop_length != nil then delete loop_length;
+      if samples_per_pass != nil then delete samples_per_pass;
+      if loop_chksum != nil then delete loop_chksum;
     }
   }
 

--- a/test/studies/lcals/LCALSMain.chpl
+++ b/test/studies/lcals/LCALSMain.chpl
@@ -160,6 +160,7 @@ module main {
     writeln("\n freeLoopSuiteRunInfo...");
     freeLoopSuiteRunInfo();
     writeln("\n DONE!!! ");
+    delete run_variants;
   }
 
   proc computeStats(ilv: int, loop_stats: vector(LoopStat), do_fom: bool) {
@@ -431,9 +432,11 @@ module main {
           }
         }
       }
+      delete ref_mean;
     }
     outchannel.write(dash_line);
     outchannel.write("\n\n\n");
+    delete len_id;
   }
 
   proc buildVersionInfo() {
@@ -539,9 +542,11 @@ module main {
           }
         }
       }
+      delete ref_chksum;
     }
     outchannel.write(dash_line);
     outchannel.write("\n\n\n");
+    delete len_id;
   }
 
   proc generateFOMReport(run_loop_variants: vector(string),
@@ -549,9 +554,11 @@ module main {
   }
 
   proc freeLoopData() {
+    delete s_loop_data;
   }
 
   proc freeLoopSuiteRunInfo() {
+    delete s_loop_suite_run_info;
   }
 
   proc runLoopVariant(lvid: LoopVariantID, run_loop:[] bool, ilength: LoopLength) {
@@ -660,18 +667,18 @@ module main {
     var suite_info = getLoopSuiteRunInfo();
     var ref_loop_stat = suite_info.ref_loop_stat;
 
-    var lstat0 = new LoopStat(suite_info.num_loop_lengths);
+    var lstat0: LoopStat;
 
     writeln("\n computeReferenceLoopTimes...");
 
-    lstat0 = ref_loop_stat; // ???
+    lstat0 = ref_loop_stat;
 
     for ilen in 0..#LoopLength.NUM_LENGTHS {
       runReferenceLoop0(lstat0, ilen);
     }
 
-    var lstat1 = new LoopStat(suite_info.num_loop_lengths);
-    lstat1 = ref_loop_stat; // ???
+    var lstat1: LoopStat;
+    lstat1 = ref_loop_stat;
 
     for ilen in 0..#LoopLength.NUM_LENGTHS {
       runReferenceLoop1(lstat1, ilen);

--- a/test/studies/lcals/LCALSMain.chpl
+++ b/test/studies/lcals/LCALSMain.chpl
@@ -160,6 +160,7 @@ module main {
     writeln("\n freeLoopSuiteRunInfo...");
     freeLoopSuiteRunInfo();
     writeln("\n DONE!!! ");
+    delete run_variant_names;
     delete run_variants;
   }
 
@@ -558,7 +559,7 @@ module main {
   }
 
   proc freeLoopSuiteRunInfo() {
-    delete s_loop_suite_run_info;
+    delete getLoopSuiteRunInfo();
   }
 
   proc runLoopVariant(lvid: LoopVariantID, run_loop:[] bool, ilength: LoopLength) {
@@ -751,8 +752,7 @@ module main {
       suite_info.fom_rate[ilv].resize(LoopLength.NUM_LENGTHS);
     }
 
-    var shared_loop_length = new vector(int);
-    shared_loop_length.resize(LoopLength.NUM_LENGTHS);
+    var shared_loop_length: [0..#LoopLength.NUM_LENGTHS] int;
     shared_loop_length[LoopLength.LONG]   = (44217 * loop_length_factor):int;
     shared_loop_length[LoopLength.MEDIUM] = (5001 * loop_length_factor):int;
     shared_loop_length[LoopLength.SHORT]  = (171 * loop_length_factor):int;
@@ -1188,8 +1188,9 @@ module main {
         suite_info.getLoopStats(run_variant_names[ilv]).push_back(loop_stat);
       }
     }
-
     defineReferenceLoopRunInfo();
     s_loop_data = new LoopData(max(max_loop_length, suite_info.ref_loop_stat.loop_length[LoopLength.LONG]));
+
+    delete run_variant_names;
   }
 }

--- a/test/studies/lcals/RunARawLoops.chpl
+++ b/test/studies/lcals/RunARawLoops.chpl
@@ -389,6 +389,7 @@ module RunARawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
+        delete ltimer;
       }
     }
   }

--- a/test/studies/lcals/RunBRawLoops.chpl
+++ b/test/studies/lcals/RunBRawLoops.chpl
@@ -112,6 +112,7 @@ module RunBRawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
+        delete ltimer;
       }
     }
   }

--- a/test/studies/lcals/RunCRawLoops.chpl
+++ b/test/studies/lcals/RunCRawLoops.chpl
@@ -340,6 +340,7 @@ module RunCRawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
+        delete ltimer;
       }
     }
   }

--- a/test/studies/lcals/RunParallelRawLoops.chpl
+++ b/test/studies/lcals/RunParallelRawLoops.chpl
@@ -492,6 +492,7 @@ module RunParallelRawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
+        delete ltimer;
       }
     }
   }

--- a/test/studies/lcals/RunVectorizeOnlyRawLoops.chpl
+++ b/test/studies/lcals/RunVectorizeOnlyRawLoops.chpl
@@ -495,6 +495,7 @@ module RunVectorizeOnlyRawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
+        delete ltimer;
       }
     }
   }


### PR DESCRIPTION
Clean up leaked memory in LCALS.  Improve destructors to free class
fields.  Call 'delete' on class variables before they leave scope.

Compiling and running LCALS as:
chpl --fast LCALSMain.chpl
./a.out --memLeaks=true

Now reports instances of "string copy data" and "string concat data" as the
only detected leaks.
