### PR TITLE
Default to qthreads+hwloc for KNC instead of fifo

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -319,7 +319,6 @@ CHPL_TASKS
      * target platform is ``cygwin*``
      * target platform is ``netbsd*``
      * target compiler is ``cray-prgenv-cray``
-     * target architecture is ``knc``
 
    The latter two apply independent of whether you are building Chapel
    yourself or using the pre-built module on a Cray XC or XE\ |trade|
@@ -476,13 +475,11 @@ CHPL_HWLOC
        ======= ==============================================================
 
    If unset, ``CHPL_HWLOC`` defaults to ``hwloc`` if :ref:`CHPL_TASKS` is
-   ``qthreads``, unless the target platform is knc.  In all other cases it
-   defaults to ``none``.  In the unlikely event the bundled hwloc distribution
-   does not build successfully, it should still be possible to use qthreads.
-   Manually set ``CHPL_HWLOC`` to ``none`` and rebuild in this case (and please
-   file a bug with the Chapel team.)  Building without hwloc should not have a
-   large performance impact when :ref:`CHPL_LOCALE_MODEL` is ``flat`` but will
-   drastically hurt performance for ``numa``.
+   ``qthreads``.  In all other cases it defaults to ``none``.  In the unlikely
+   event the bundled hwloc distribution does not build successfully, it should
+   still be possible to use qthreads.  To do this, manually set ``CHPL_HWLOC``
+   to ``none`` and rebuild (and please file a bug with the Chapel team.) Note
+   that building without hwloc will have a negative impact on performance.
 
 
 CHPL_REGEXP

--- a/doc/release/platforms/knc.rst
+++ b/doc/release/platforms/knc.rst
@@ -33,7 +33,6 @@ There are currently a number of limitations for KNC builds:
   =================  ================================
   CHPL_MEM=tcmalloc  lfence not supported
   CHPL_REGEXP=re2    sfence not supported
-  CHPL_HWLOC=hwloc   undiagnosed build issues
   CHPL_GMP=system    system version not built for KNC
   =================  ================================
 
@@ -57,14 +56,14 @@ For vanilla Intel compiler:
     CHPL_TARGET_ARCH: knc
     CHPL_LOCALE_MODEL: flat
     CHPL_COMM: none
-    CHPL_TASKS: fifo
+    CHPL_TASKS: qthreads
     CHPL_LAUNCHER: none
     CHPL_TIMERS: generic
     CHPL_MEM: cstdlib
     CHPL_MAKE: gmake
     CHPL_ATOMICS: intrinsics
     CHPL_GMP: none
-    CHPL_HWLOC: none
+    CHPL_HWLOC: hwloc
     CHPL_REGEXP: none
     CHPL_WIDE_POINTERS: struct
     CHPL_LLVM: none
@@ -112,7 +111,7 @@ For Cray machines, only the ``aprun`` launcher is supported.  In addition,
     CHPL_COMM: gasnet
       CHPL_COMM_SUBSTRATE: mpi
       CHPL_GASNET_SEGMENT: everything
-    CHPL_TASKS: fifo
+    CHPL_TASKS: qthreads
     CHPL_LAUNCHER: aprun
     CHPL_TIMERS: generic
     CHPL_MEM: cstdlib
@@ -120,7 +119,7 @@ For Cray machines, only the ``aprun`` launcher is supported.  In addition,
     CHPL_ATOMICS: intrinsics
       CHPL_NETWORK_ATOMICS: none
     CHPL_GMP: gmp
-    CHPL_HWLOC: none
+    CHPL_HWLOC: hwloc
     CHPL_REGEXP: none
     CHPL_WIDE_POINTERS: struct
     CHPL_LLVM: none

--- a/doc/release/tasks.rst
+++ b/doc/release/tasks.rst
@@ -51,8 +51,8 @@ environment variable to one of the following values:
   best performance; default for most targets
 
 :fifo:
-  most portable, but heavyweight; default for Intel KNC, NetBSD, Cygwin,
-  or when Cray is the target compiler
+  most portable, but heavyweight; default for NetBSD, Cygwin, or when
+  Cray is the target compiler
 
 :massivethreads:
   based on U Tokyo's MassiveThreads library
@@ -213,8 +213,8 @@ CHPL_TASKS == fifo
 ------------------
 
 FIFO tasking over POSIX threads (or pthreads) works on all platforms
-and is the default for Intel KNC, Cygwin, NetBSD, or when Cray is the
-target compiler.  It is attractive in its portability, though on most
+and is the default for Cygwin, NetBSD, or when Cray is the target
+compiler.  It is attractive in its portability, though on most
 platforms it will tend to be heavier weight than Chapel strictly
 requires.  FIFO tasking is also used when Chapel is configured in
 'Quick Start' mode (see :ref:`chapelhome-quickstart`).  To use FIFO

--- a/test/release/examples/benchmarks/lulesh/lulesh.execenv
+++ b/test/release/examples/benchmarks/lulesh/lulesh.execenv
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Guard pages are expensive on KNC. See JIRA issue 160
+
+import os
+if os.getenv('CHPL_TARGET_ARCH', '') == 'knc':
+    print('QT_GUARD_PAGES=false')

--- a/test/release/examples/benchmarks/miniMD/explicit/miniMD.execenv
+++ b/test/release/examples/benchmarks/miniMD/explicit/miniMD.execenv
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Guard pages are expensive on KNC. See JIRA issue 160
+
+import os
+if os.getenv('CHPL_TARGET_ARCH', '') == 'knc':
+    print('QT_GUARD_PAGES=false')

--- a/test/release/examples/benchmarks/miniMD/miniMD.execenv
+++ b/test/release/examples/benchmarks/miniMD/miniMD.execenv
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Guard pages are expensive on KNC. See JIRA issue 160
+
+import os
+if os.getenv('CHPL_TARGET_ARCH', '') == 'knc':
+    print('QT_GUARD_PAGES=false')

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -12,6 +12,12 @@ ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_HWLOC_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 endif
 
+ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),intel)
+CFLAGS += -mmic
+endif
+endif
+
 CHPL_HWLOC_CFG_OPTIONS += --enable-static \
                           --disable-shared \
                           --disable-cairo \

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -5,7 +5,7 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_arch, chpl_tasks
+import chpl_tasks
 from utils import memoize
 
 
@@ -15,8 +15,7 @@ def get():
     hwloc_val = os.environ.get('CHPL_HWLOC')
     if not hwloc_val:
         tasks_val = chpl_tasks.get()
-        arch_val = chpl_arch.get('target', get_lcd=True)
-        if tasks_val == 'qthreads' and arch_val != 'knc':
+        if tasks_val == 'qthreads':
             hwloc_val = 'hwloc'
         else:
             hwloc_val = 'none'

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -5,7 +5,7 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_arch, chpl_comm, chpl_compiler, chpl_platform, utils
+import chpl_comm, chpl_compiler, chpl_platform, utils
 from utils import memoize
 
 
@@ -13,13 +13,11 @@ from utils import memoize
 def get():
     tasks_val = os.environ.get('CHPL_TASKS')
     if not tasks_val:
-        arch_val = chpl_arch.get('target', get_lcd=True)
         platform_val = chpl_platform.get()
         compiler_val = chpl_compiler.get('target')
         comm_val = chpl_comm.get()
 
-        if (arch_val == 'knc' or
-                platform_val.startswith('cygwin') or
+        if (platform_val.startswith('cygwin') or
                 platform_val.startswith('netbsd') or
                 compiler_val == 'cray-prgenv-cray'):
             tasks_val = 'fifo'


### PR DESCRIPTION
When we originally added support for KNC we saw poor performance with qthreads.
However, this was before we did any performance tuning with qthreads. In
particular we were using a work stealing scheduler, which did not perform well
especially as more cores were added.

Motivated by some recent work with stream and hwloc I decided to see if the
performance with qthreads is better now. The short summary is that
qthreads+hwloc performance is better, at least for stream (121 vs 115 GB/s.) As
a next step I'd like to add some nightly performance testing for KNC.

In the past hwloc didn't build on stream, but it appears to build just fine
now. This patch adds code to throw `-mmic` for KNC builds in the hwloc Makefile
just like we do for our other third-party libraries.

Testing did reveal a few timeouts for miniMD and lulesh. These were because
guard pages appear to be more expensive on KNC. For now I just turned off guard
pages for these tests, but we'll keep looking at other solutions and will check
if we see this same issue on KNL as well. For details on why guard pages are
more expensive on KNC and possible solutions see JIRA issue 160
(https://chapel.atlassian.net/browse/CHAPEL-160)

The specific changes in this patch are:
 - make qthreads and hwloc the defaults in the chplenv scripts
 - throw `-mmic` for KNC builds in hwloc Makefile
 - update documentation that mentioned fifo as the tasking layer for KNC
 - turn off guard pages for miniMD and lulesh under KNC
