### PR TITLE
Split general case of BlockArr.dsiAccess into its own function.

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1340,6 +1340,8 @@ proc BlockArr.setRADOpt(val=true) {
 //
 // the accessor for the local array -- assumes the index is local
 //
+// TODO: Should this be inlined?
+//
 proc LocBlockArr.this(i) ref {
   return myElems(i);
 }

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1001,15 +1001,18 @@ inline proc BlockArr.dsiLocalAccess(i: rank*idxType) ref {
 //
 // TODO: Do we need a global bounds check here or in targetLocsIdx?
 //
-proc BlockArr.dsiAccess(i: rank*idxType) ref {
+// By splitting the non-local case into its own function, we can inline the
+// fast/local path and get better performance.
+//
+inline proc BlockArr.dsiAccess(i: rank*idxType) ref {
   local {
     if myLocArr != nil && myLocArr.locDom.member(i) then
       return myLocArr.this(i);
   }
-  return generalAccess(i);
+  return nonLocalAccess(i);
 }
 
-proc BlockArr.generalAccess(i: rank*idxType) ref {
+proc BlockArr.nonLocalAccess(i: rank*idxType) ref {
   if doRADOpt {
     if myLocArr {
       if boundsChecking then

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1006,6 +1006,10 @@ proc BlockArr.dsiAccess(i: rank*idxType) ref {
     if myLocArr != nil && myLocArr.locDom.member(i) then
       return myLocArr.this(i);
   }
+  return generalAccess(i);
+}
+
+proc BlockArr.generalAccess(i: rank*idxType) ref {
   if doRADOpt {
     if myLocArr {
       if boundsChecking then


### PR DESCRIPTION
By splitting the remote case of dsiAccess into its own function, we can inline the fast/local path and get better performance. This change should resolve the performance regression seen for studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl as a result of #2838 