### PR TITLE
Revert "Revert "Stop heap allocating because of non-blocking ons""

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -810,16 +810,15 @@ needHeapVars() {
 //   varSet, varVec - symbols that themselves need to be heap-allocated
 //
 
-// Traverses all 'on' task functions flagged as nonblocking or
-// as needing heap allocation (for its formals), as determined
-// by the comm layer and/or --local setting..
+// Traverses all 'on' task functions flagged as needing heap
+// allocation (for its formals), as determined by the comm layer
+// and/or --local setting..
 // Traverses all ref formals of these functions and adds them to the refSet and
 // refVec.
 static void findBlockRefActuals(Vec<Symbol*>& refSet, Vec<Symbol*>& refVec)
 {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->hasFlag(FLAG_ON) &&
-        (needHeapVars() || fn->hasFlag(FLAG_NON_BLOCKING))) {
+    if (fn->hasFlag(FLAG_ON) && needHeapVars()) {
       for_formals(formal, fn) {
         if (formal->type->symbol->hasFlag(FLAG_REF)) {
           refSet.set_add(formal);


### PR DESCRIPTION
This reverts #2755, which reverted #2745.

inability to handle "network" AMOs against target variables that were
not in memory registered with the NIC.  (Specifically, #2745 moved some
atomic vars to the stack, and with tasks=qthreads the stacks come from
non-Chapel-managed memory which hasn't been registered.)

Yesterday I updated comm=ugni to handle network AMOs against atomic
variables not in NIC-registered memory, so now I'm un-reverting #2745.