### PR TITLE
Replace filenames in arg bundles with an index to a table

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -5614,7 +5614,7 @@ GenRet CallExpr::codegen() {
 
     std::vector<GenRet> args(7);
     args[0] = new_IntSymbol(-2 /* c_sublocid_any */, INT_SIZE_32);
-    args[1] = new_IntSymbol(ftableMap.get(fn), INT_SIZE_64);
+    args[1] = new_IntSymbol(ftableMap[fn], INT_SIZE_64);
     args[2] = codegenCastToVoidStar(taskBundle);
     args[3] = taskList;
     args[4] = codegenValue(taskListNode);
@@ -5642,7 +5642,7 @@ GenRet CallExpr::codegen() {
 
     std::vector<GenRet> args(6);
     args[0] = codegenLocalAddrOf(locale_id);
-    args[1] = new_IntSymbol(ftableMap.get(fn), INT_SIZE_32);
+    args[1] = new_IntSymbol(ftableMap[fn], INT_SIZE_32);
     args[2] = get(2);
     args[3] = get(3);
     args[4] = fn->linenum();

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -5560,6 +5560,10 @@ GenRet CallExpr::codegen() {
       ret = codegenCallExpr(fngen, args, fn, true);
       break;
     }
+    case PRIM_FIND_FILENAME_IDX:
+    case PRIM_LOOKUP_FILENAME:
+      ret = codegenBasicPrimitiveExpr(this);
+      break;
     case NUM_KNOWN_PRIMS:
       INT_FATAL(this, "impossible");
       break;

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -644,6 +644,9 @@ initPrimitive() {
 
   prim_def(PRIM_START_RMEM_FENCE, "chpl_rmem_consist_acquire", returnInfoVoid, true, true);
   prim_def(PRIM_FINISH_RMEM_FENCE, "chpl_rmem_consist_release", returnInfoVoid, true, true);
+
+  prim_def(PRIM_FIND_FILENAME_IDX, "chpl_findFilenameIdx", returnInfoUInt64, false, false);
+  prim_def(PRIM_LOOKUP_FILENAME, "chpl_lookupFilename", returnInfoStringC, false, false);
 }
 
 Map<const char*, VarSymbol*> memDescsMap;

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -96,7 +96,7 @@ FnSymbol* gChplHereFree = NULL;
 Symbol *gCLine = NULL;
 Symbol *gCFile = NULL;
 
-Map<FnSymbol*,int> ftableMap;
+std::map<FnSymbol*,int> ftableMap;
 Vec<FnSymbol*> ftableVec;
 
 Map<Type*,Vec<FnSymbol*>*> virtualMethodTable;

--- a/compiler/include/insertLineNumbers.h
+++ b/compiler/include/insertLineNumbers.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _INSERT_LINE_NUMBERS_H_
+#define _INSERT_LINE_NUMBERS_H_
+
+#include <set>
+#include <string>
+
+// used to generate chpl_filenameTable
+extern std::set<std::string> gFilenameLookup;
+
+#endif //_INSERT_LINE_NUMBERS_H

--- a/compiler/include/primitive.h
+++ b/compiler/include/primitive.h
@@ -263,6 +263,11 @@ enum PrimitiveTag {
   PRIM_START_RMEM_FENCE,
   PRIM_FINISH_RMEM_FENCE,
 
+  PRIM_FIND_FILENAME_IDX, // search for a filename's index in a lookup table
+                          // used when converting line/file info into a form
+                          // that can be passed into argument bundles
+  PRIM_LOOKUP_FILENAME,   // Given an index, get a given filename (c_string)
+
   NUM_KNOWN_PRIMS
 };
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -28,6 +28,7 @@
 #include <bitset>
 #include <iostream>
 #include <vector>
+#include <map>
 
 //
 // The function that represents the compiler-generated entry point
@@ -619,7 +620,7 @@ extern Symbol *gSingleVarAuxFields;
 
 extern Symbol *gTaskList;
 
-extern Map<FnSymbol*,int> ftableMap;
+extern std::map<FnSymbol*,int> ftableMap;
 extern Vec<FnSymbol*> ftableVec;
 
 //

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -26,6 +26,7 @@
 #include "flex-chapel.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "insertLineNumbers.h"
 
 #include <cstdlib>
 
@@ -127,6 +128,8 @@ ModuleSymbol* parseFile(const char* filename,
   ModuleSymbol* retval = NULL;
 
   if (FILE* fp = openInputFile(filename)) {
+    gFilenameLookup.insert(filename);
+
     // State for the lexer
     int             lexerStatus  = 100;
 

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -34,6 +34,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "insertLineNumbers.h"
 
 #include <inttypes.h>
 
@@ -181,6 +182,23 @@ genGlobalInt(const char* cname, int value) {
 #endif
   }
 }
+
+static void genGlobalInt64(const char *cname, int value) {
+  GenInfo *info = gGenInfo;
+  if (info->cfile) {
+    fprintf(info->cfile, "const int64_t %s = %d;\n", cname, value);
+  } else {
+#ifdef HAVE_LLVM
+    llvm::GlobalVariable *globalInt =
+        llvm::cast<llvm::GlobalVariable>(info->module->getOrInsertGlobal(
+            cname, llvm::IntegerType::getInt64Ty(info->module->getContext())));
+    globalInt->setInitializer(info->builder->getInt64(value));
+    globalInt->setConstant(true);
+    info->lvt->addGlobalValue(cname, globalInt, GEN_PTR, false);
+#endif
+  }
+}
+
 static void
 genClassIDs(Vec<TypeSymbol*> & typeSymbols) {
   genComment("Class Type Identification Numbers");
@@ -336,6 +354,59 @@ genVirtualMethodTable(Vec<TypeSymbol*>& types) {
     info->lvt->addGlobalValue(vmt, vmtElmPtr, GEN_VAL, true);
 #endif
   }
+}
+
+static void genFilenameTable() {
+  GenInfo *info = gGenInfo;
+  const char *tableName = "chpl_filenameTable";
+  const char *sizeName = "chpl_filenameTableSize";
+  // make sure the internal filename is added to the table
+  gFilenameLookup.insert("<internal>");
+  if (info->cfile) {
+    FILE *hdrfile = info->cfile;
+
+    fprintf(hdrfile, "c_string %s[] = {\n", tableName);
+
+    bool first = true;
+    for (std::set<std::string>::iterator it = gFilenameLookup.begin();
+         it != gFilenameLookup.end(); it++) {
+      if (!first)
+        fprintf(hdrfile, ",\n");
+      fprintf(hdrfile, "    \"%s\"", (*it).c_str());
+      first = false;
+    }
+
+    fprintf(hdrfile, "\n};\n");
+  } else {
+#ifdef HAVE_LLVM
+    std::vector<llvm::Constant *> table(gFilenameLookup.size());
+
+    llvm::Type *c_stringType = info->lvt->getType("c_string");
+
+    int idx = 0;
+    for (std::set<std::string>::iterator it = gFilenameLookup.begin();
+         it != gFilenameLookup.end(); it++) {
+      table[idx++] = llvm::cast<llvm::Constant>(
+          new_CStringSymbol((*it).c_str())->codegen().val);
+    }
+
+    llvm::ArrayType *filenameTableType =
+        llvm::ArrayType::get(c_stringType, table.size());
+
+    if (llvm::GlobalVariable *filenameTable =
+            info->module->getNamedGlobal(tableName)) {
+      filenameTable->eraseFromParent();
+    }
+
+    llvm::GlobalVariable *filenameTable = llvm::cast<llvm::GlobalVariable>(
+        info->module->getOrInsertGlobal(tableName, filenameTableType));
+    filenameTable->setInitializer(
+        llvm::ConstantArray::get(filenameTableType, table));
+    filenameTable->setConstant(true);
+    info->lvt->addGlobalValue(tableName, filenameTable, GEN_PTR, true);
+#endif
+  }
+  genGlobalInt64(sizeName, gFilenameLookup.size());
 }
 
 static int
@@ -934,6 +1005,9 @@ static void codegen_header() {
 
   genComment("Virtual Method Table");
   genVirtualMethodTable(types);
+
+  genComment("Filename Lookup Table");
+  genFilenameTable();
 
   genComment("Global Variables");
   forv_Vec(VarSymbol, varSymbol, globals) {

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -997,7 +997,7 @@ static void codegen_header() {
         fn2->hasFlag(FLAG_COBEGIN_OR_COFORALL_BLOCK) ||
         fn2->hasFlag(FLAG_ON_BLOCK)) {
     ftableVec.add(fn2);
-    ftableMap.put(fn2, ftableVec.n-1);
+    ftableMap[fn2] = ftableVec.n-1;
     }
   }
 

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "insertLineNumbers.h"
+
 #include "passes.h"
 
 #include "astutil.h"
@@ -35,6 +37,7 @@
 // number and a filename.
 //
 
+std::set<std::string> gFilenameLookup;
 static void moveLinenoInsideArgBundle();
 
 //
@@ -129,9 +132,10 @@ insertLineNumber(CallExpr* call) {
       INT_ASSERT(var);
       INT_ASSERT(var->immediate);
       INT_ASSERT(var->immediate->const_kind == CONST_KIND_STRING);
-      call->insertAtTail(new_CStringSymbol(astr("<command line setting of '",
-                                               var->immediate->v_string,
-                                               "'>")));
+      const char *cmdLineSetting =
+          astr("<command line setting of '", var->immediate->v_string, "'>");
+      call->insertAtTail(new_CStringSymbol(cmdLineSetting));
+      gFilenameLookup.insert(cmdLineSetting);
     } else {
       if (fCLineNumbers) {
         if (!gCLine) {
@@ -284,20 +288,46 @@ static void moveLinenoInsideArgBundle()
       DefExpr* lineArg = toDefExpr(fn->formals.tail);
       lineArg->remove();
 
-      // In the body of the wrapper, create local lineno and fname variables 
-      // initialized from the corresponding fields in the argument bundle.
+      // In the body of the wrapper, create a local lineno variable initialized
+      // from the new corresponding field in the argument bundle.
       DefExpr* bundleArg = toDefExpr(fn->formals.tail);
       AggregateType* bundleType = toAggregateType(bundleArg->sym->typeInfo());
+
       VarSymbol* lineField = newTemp("_ln", lineArg->sym->typeInfo());
       bundleType->fields.insertAtTail(new DefExpr(lineField));
-      VarSymbol* fileField = newTemp("_fn", fileArg->sym->typeInfo());
-      bundleType->fields.insertAtTail(new DefExpr(fileField));
-      VarSymbol* fileLocal = newTemp("_fn", fileArg->sym->typeInfo());
+
       VarSymbol* lineLocal = newTemp("_ln", lineArg->sym->typeInfo());
-      fn->insertAtHead("'move'(%S, '.v'(%S, %S))", fileLocal, bundleArg->sym, fileField);
-      fn->insertAtHead(new DefExpr(fileLocal));
+
       fn->insertAtHead("'move'(%S, '.v'(%S, %S))", lineLocal, bundleArg->sym, lineField);
       fn->insertAtHead(new DefExpr(lineLocal));
+
+      // Now perform a similar operation for filenames
+      // filenames can not be passed directly via argument bundles since they
+      // are (local only) c_strings. Instead we need to map them from integers
+      // via a lookup table.
+      // We only do this if we are using chapel line numbers, when using C line
+      // numbers we will just use __FILE__ and we dont have to put anything in
+      // the bundle
+      VarSymbol* fileLocal = NULL;
+      VarSymbol* fileIdxField = NULL;
+      if (!fCLineNumbers) {
+        fileIdxField = newTemp("_fnIdx", dtUInt[INT_SIZE_64]);
+        bundleType->fields.insertAtTail(new DefExpr(fileIdxField));
+
+        VarSymbol* fileIdxLocal = newTemp("_fnIdx", dtUInt[INT_SIZE_64]);
+        fileLocal = newTemp("_fn", fileArg->sym->typeInfo());
+
+        fn->insertAtHead(
+            new CallExpr(PRIM_MOVE, fileLocal,
+                        new CallExpr(PRIM_LOOKUP_FILENAME,
+                                      new SymExpr(fileIdxLocal))));
+
+        fn->insertAtHead("'move'(%S, '.v'(%S, %S))", fileIdxLocal, bundleArg->sym, fileIdxField);
+        fn->insertAtHead(new DefExpr(fileLocal));
+        fn->insertAtHead(new DefExpr(fileIdxLocal));
+      } else {
+        fileLocal = toVarSymbol(gCFile); // __FILE__
+      }
 
       // Replace references to the (removed) arguments with
       // references to these local variables.
@@ -314,8 +344,21 @@ static void moveLinenoInsideArgBundle()
         Expr* fileActual = call->argList.tail->remove();
         Expr* lineActual = call->argList.tail->remove();
         Expr* bundleActual = call->argList.tail;
-        call->insertBefore(new CallExpr(PRIM_SET_MEMBER, bundleActual->copy(), lineField, lineActual));
-        call->insertBefore(new CallExpr(PRIM_SET_MEMBER, bundleActual->copy(), fileField, fileActual));
+        call->insertBefore(new CallExpr(PRIM_SET_MEMBER,
+              bundleActual->copy(), lineField, lineActual));
+
+        // As above, we cant use the file directly with the bundle
+        // Instead we will perform a lookup to find it's index in the table and
+        // pass that along instead. If we are using C line numbers we dont need
+        // to pass anything.
+        if (!fCLineNumbers) {
+          VarSymbol* fileIdxTemp = newTemp("fnIdx_tmp", dtUInt[INT_SIZE_64]);
+          call->insertBefore(new DefExpr(fileIdxTemp));
+          call->insertBefore(new CallExpr(PRIM_MOVE, fileIdxTemp,
+                new CallExpr(PRIM_FIND_FILENAME_IDX, fileActual)));
+          call->insertBefore(new CallExpr(PRIM_SET_MEMBER,
+              bundleActual->copy(), fileIdxField, new SymExpr(fileIdxTemp)));
+        }
       }
     }
   }

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -112,9 +112,11 @@ insertLineNumber(CallExpr* call) {
       call->replace(new SymExpr(line));
     }
   } else if (fn->hasFlag(FLAG_EXTERN) ||
+             (fn->hasFlag(FLAG_EXPORT) && !fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO)) ||
              !strcmp(fn->name, "chpl__heapAllocateGlobals") ||
              !strcmp(fn->name, "chpl__initModuleGuards") ||
              !strcmp(fn->name, "chpl_gen_main") ||
+             ftableMap.count(fn) ||
              (mod->modTag == MOD_USER && 
               !fn->hasFlag(FLAG_COMPILER_GENERATED) && !fn->hasFlag(FLAG_INLINE)) ||
              (developer && strcmp(fn->name, "halt"))) {
@@ -122,6 +124,7 @@ insertLineNumber(CallExpr* call) {
 
     // call is in user code; insert AST line number and filename
     // or developer flag is on and the call is not the halt() call
+    // or the call is via the ftable
     if (call->isResolved() &&
         call->isResolved()->hasFlag(FLAG_COMMAND_LINE_SETTING)) {
       call->insertAtTail(new_IntSymbol(0));

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -542,7 +542,7 @@ createArgBundleFreeFn(AggregateType* ct, FnSymbol* loopBodyFnWrapper) {
   if (addedRecursiveCall) {
     Symbol* cond = newTemp("cond", dtBool);
     argBundleFreeFn->insertAtHead(new CondStmt(new SymExpr(cond), block));
-    argBundleFreeFn->insertAtHead(new CallExpr(PRIM_MOVE, cond, new CallExpr(PRIM_EQUAL, loopBodyFnIDArg, new_IntSymbol(ftableMap.get(loopBodyFnWrapper)))));
+    argBundleFreeFn->insertAtHead(new CallExpr(PRIM_MOVE, cond, new CallExpr(PRIM_EQUAL, loopBodyFnIDArg, new_IntSymbol(ftableMap[loopBodyFnWrapper]))));
     argBundleFreeFn->insertAtHead(new DefExpr(cond));
   }
 }
@@ -642,7 +642,7 @@ createArgBundleCopyFn(AggregateType* ct, FnSymbol* loopBodyFnWrapper) {
   //  { <body_as_defined_above> }
   Symbol* cond = newTemp(dtBool);
   argBundleCopyFn->insertBeforeReturn(new DefExpr(cond));
-  argBundleCopyFn->insertBeforeReturn(new CallExpr(PRIM_MOVE, cond, new CallExpr(PRIM_EQUAL, loopBodyFnIDArg, new_IntSymbol(ftableMap.get(loopBodyFnWrapper)))));
+  argBundleCopyFn->insertBeforeReturn(new CallExpr(PRIM_MOVE, cond, new CallExpr(PRIM_EQUAL, loopBodyFnIDArg, new_IntSymbol(ftableMap[loopBodyFnWrapper]))));
   argBundleCopyFn->insertBeforeReturn(new CondStmt(new SymExpr(cond), block));
 }
 
@@ -1050,7 +1050,7 @@ expandRecursiveIteratorInline(ForLoop* forLoop)
   parent->defPoint->insertBefore(new DefExpr(loopBodyFnWrapper));
 
   ftableVec.add(loopBodyFnWrapper);
-  ftableMap.put(loopBodyFnWrapper, ftableVec.n-1);
+  ftableMap[loopBodyFnWrapper] = ftableVec.n-1;
 
   //
   // insert a call to the iterator function (using iterator as a
@@ -1061,7 +1061,7 @@ expandRecursiveIteratorInline(ForLoop* forLoop)
   //
   Symbol*    ic             = forLoop->iteratorGet()->var;
   FnSymbol*  iterator       = getTheIteratorFn(ic);
-  CallExpr*  iteratorFnCall = new CallExpr(iterator, ic, new_IntSymbol(ftableMap.get(loopBodyFnWrapper)));
+  CallExpr*  iteratorFnCall = new CallExpr(iterator, ic, new_IntSymbol(ftableMap[loopBodyFnWrapper]));
 
   // replace function in iteratorFnCall with iterator function once that is created
   CallExpr*  loopBodyFnCall = new CallExpr(loopBodyFn, gVoid);

--- a/runtime/include/chpl-linefile-support.h
+++ b/runtime/include/chpl-linefile-support.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_linefile_support_h_
+#define _chpl_linefile_support_h_
+
+#include "chpltypes.h"
+
+uint64_t chpl_findFilenameIdx(const c_string name);
+c_string chpl_lookupFilename(const uint64_t idx);
+
+#endif // _chpl_linefile_support_h_

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -72,6 +72,11 @@ extern char* chpl_executionCommand;
 /* generated */
 extern chpl_fn_p chpl_ftable[];
 
+// Sorted lookup table of filenames used with insertLineNumbers for error
+// messages and logging
+extern c_string chpl_filenameTable[];
+extern const int64_t chpl_filenameTableSize;
+
 void chpl__init_preInit(int64_t _ln, c_string _fn);
 void chpl__init_PrintModuleInitOrder(int64_t _ln, c_string _fn);
 void chpl__init_ChapelStandard(int64_t _ln, c_string _fn);

--- a/runtime/include/stdchpl.h
+++ b/runtime/include/stdchpl.h
@@ -50,6 +50,7 @@
 #include "chplio.h"
 #include "chplmath.h"
 #include "chpl-init.h"
+#include "chpl-linefile-support.h"
 #include "chpl-mem.h"
 #include "chplmemtrack.h"
 #include "chpl-prefetch.h"

--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -34,6 +34,7 @@ COMMON_NOGEN_SRCS = \
 	chpl-file-utils.c \
 	chplgmp.c \
 	chplio.c \
+	chpl-linefile-support.c \
 	chpl-mem.c \
 	chpl-mem-desc.c \
 	chpl-mem-hook.c \

--- a/runtime/src/chpl-linefile-support.c
+++ b/runtime/src/chpl-linefile-support.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "chplrt.h"
+#include "chplcgfns.h"
+
+#include "chpl-linefile-support.h"
+
+// chpl_filenameTable is defined in chplcgfns.h
+
+static int compare(const void *a, const void *b) {
+  return strcmp((c_string)a, *(c_string *)b);
+}
+
+uint64_t chpl_findFilenameIdx(c_string name) {
+  c_string *result;
+
+  if (name == NULL) {
+    // We will occasionally get a NULL passed in as the filename, just use
+    // <internal> instead in that case
+    name = "<internal>";
+  }
+
+  // binary search chpl_filenameTable for our answer, we will output this table
+  // in sorted order with all possible values so result will never be NULL
+  result = (c_string *)bsearch(name, chpl_filenameTable,
+                               (size_t)chpl_filenameTableSize, sizeof(c_string),
+                               compare);
+  assert(result != NULL);
+  return (uint64_t)(result - chpl_filenameTable);
+}
+
+c_string chpl_lookupFilename(const uint64_t idx) {
+  assert(idx < chpl_filenameTableSize);
+
+  return chpl_filenameTable[idx];
+}
+


### PR DESCRIPTION
Filenames (added by insertLineNumbers) in arg bundles were being added
straight to the bundle, even though they are c_strings. Since c_strings
are only good on their original locales, use of the filenames passed into
the arg bundles would lead to segfaults. After this patch we now use the
string to find an index into a lookup table of filenames, pass the index
in the arg bundle, and use that index to get a valid c_string on the
other side.

This error would not show up on linux due to its weak ASLR, but would
cause major problems on OSX.

Another bug was surfaced while working on this patch - function calls via 
the ftable were having line/file arguments added to them by insert line
numbers, but we wouldn't actually pass the extra args to the
PRIM_FTABLE_CALL. This would cause us to use whatever garbage was
 in our registers as line numbers and filenames, which causes all sorts of
 problems when we are trying to use these filenames in a lookup table.
After this patch we now get new line and file info inside of functions called
via the ftable rather than have it passed in.

I've also change the type of the `ftableMap` from our homegrown `Map`
to `std::map`. When using `Map<X, int>` there is no way to check if a key
is in the map as we return 0 when the key is not found.

[Tested full standard + gasnet linux64, spot checked llvm]