### PR TITLE
Yet another update to PREDIFF for hplx.chpl

### DIFF
--- a/test/distributions/dm/PREDIFF
+++ b/test/distributions/dm/PREDIFF
@@ -29,6 +29,8 @@ case $testname in
      #
      egrep -ai '^start...finish$|error|warning' $outputfile.orig \
        | grep -av 'error: attempt to dereference nil' \
+       | grep -av 'error for object' \
+       | grep -av 'set a breakpoint' \
        | grep -av 'FATAL ERROR:' \
        | grep -avi 'AMUDP.*error' \
        > $outputfile


### PR DESCRIPTION
Now that I am used to handling new failure modes for this test,
I prefer to update PREDIFF to deal with them.
That way, we can keep hplx.bad around, which has the advantage
of guarding against unexpected failures.

This commit continues the tradition, see e.g. 007eac5:

This test has been failing in more and more diverse ways.
I keep relaxing PREDIFF to accept these failures,
so we can have .bad and match clean against it.