### PR TITLE
Fix a minor whitespace bug in AstDumpToNode

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -1401,7 +1401,6 @@ void AstDumpToNode::writeSymbol(Symbol* sym) const
 
     if (sym->type != 0)
     {
-      writeLongString("      ", "");
       writeType(sym->type);
     }
 


### PR DESCRIPTION
Writing out uses of an FnSymbol has extra space for subfields.  Quash.

Trivial.
