### PR TITLE
Investigate shifted data

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -828,7 +828,7 @@ proc chpl__autoDestroy(x: DefaultDist) {
 
     inline proc initShiftedData() {
       if earlyShiftData && !stridable {
-//        if dom.dsiNumIndices > 0 { // This is not an optimization
+        if dom.dsiNumIndices > 0 {
           if isIntType(idxType) then
             shiftedData = _ddata_shift(eltType, data, origin-factoredOffs);
           else
@@ -836,7 +836,7 @@ proc chpl__autoDestroy(x: DefaultDist) {
             shiftedData = _ddata_shift(eltType, data,
                                        origin:chpl__signedType(idxType)-
                                        factoredOffs:chpl__signedType(idxType));
-//        }
+        }
       }
     }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1050,7 +1050,7 @@ proc chpl__autoDestroy(x: DefaultDist) {
         // has not yet been updated (this is called from within the
         // = function for domains.
         if earlyShiftData && !d._value.stridable then
-//          if d.numIndices > 0 then
+          if d.numIndices > 0 then
             shiftedData = copy.shiftedData;
         //numelm = copy.numelm;
 // This breaks some routines.  We will leak the copies for now, and

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1075,7 +1075,7 @@ proc chpl__autoDestroy(x: DefaultDist) {
       rad.factoredOffs = factoredOffs;
       rad.data = data;
       if earlyShiftData && !stridable then
-//        if dom.dsiNumIndices > 0 then
+        if dom.dsiNumIndices > 0 then
           rad.shiftedData = shiftedData;
       return rad;
     }


### PR DESCRIPTION
These three checks were removed from string-as-rec back in June,
with the claim that because the checks occurred at runtime, they
were not an optimization and so provided no value.  I have done a
broad analysis of the performance impact of implementing this removal
on master and of undoing it on string-as-rec and the results were fairly
inconclusive.  The tests which seemed to indicate a trend either positively
or negatively as a result of this change are tests with a history of fluctuation
between the two values (i.e. they are sensitive to cache effects or page
boundaries).  There were also tests which reacted on one branch but were
unaffected on the other; of the two branches, master's changes had a
more negative impact in this regard.  With this in mind (and a lack of
correctness failures for standard linux in either circumstance), the
correct course of action seems to be to undo this change on string as rec.