### PR TITLE
Add pragma "compiler generated" to the object chpl__autoDestroy function

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1136,6 +1136,7 @@ module ChapelBase {
   inline proc chpl__maybeAutoDestroyed(x: object) param return false;
   inline proc chpl__maybeAutoDestroyed(x) param return true;
 
+  pragma "compiler generated"
   inline proc chpl__autoDestroy(x: object) { }
 
   pragma "compiler generated"


### PR DESCRIPTION
This change was made on string-as-rec and to several other auto/init*
functions.  Most of those functions have now been labeled as such on master,
via PR #2752, let's have this change join them.

Tested over std/