### PR TITLE
Add note about potentially unnecessary checks in DefaultRectangular

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -783,6 +783,11 @@ module DefaultRectangular {
 
     inline proc initShiftedData() {
       if earlyShiftData && !stridable {
+        // Lydia note 11/04/15: a question was raised as to whether this
+        // check on dsiNumIndices added any value.  Performance results
+        // from removing this line seemed inconclusive, which may indicate
+        // that the check is not necessary, but it seemed like unnecessary
+        // work for something with no immediate reward.
         if dom.dsiNumIndices > 0 {
           if isIntType(idxType) then
             shiftedData = _ddata_shift(eltType, data, origin-factoredOffs);
@@ -1005,6 +1010,11 @@ module DefaultRectangular {
         // has not yet been updated (this is called from within the
         // = function for domains.
         if earlyShiftData && !d._value.stridable then
+          // Lydia note 11/04/15: a question was raised as to whether this
+          // check on numIndices added any value.  Performance results
+          // from removing this line seemed inconclusive, which may indicate
+          // that the check is not necessary, but it seemed like unnecessary
+          // work for something with no immediate reward.
           if d.numIndices > 0 then
             shiftedData = copy.shiftedData;
         //numelm = copy.numelm;
@@ -1028,6 +1038,11 @@ module DefaultRectangular {
       rad.factoredOffs = factoredOffs;
       rad.data = data;
       if earlyShiftData && !stridable then
+        // Lydia note 11/04/15: a question was raised as to whether this
+        // check on dsiNumIndices added any value.  Performance results
+        // from removing this check seemed inconclusive, which may indicate
+        // that the check is not necessary, but it seemed like unnecessary
+        // work for something with no immediate reward.
         if dom.dsiNumIndices > 0 then rad.shiftedData = shiftedData;
       return rad;
     }


### PR DESCRIPTION
On string-as-rec there had been a commit removing three checks to numIndices
due to a feeling that there was no runtime benefit from their presence.
Performance analysis did not report a difference between having these checks
present or absent, but there seemed a slight results bias towards leaving the lines
present, so the change was undone on string-as-rec.  There may come a time
in the future where these thoughts provide value to someone looking for
performance gains, so Michael suggested I add a comment about what I
discovered to these lines.