### PR TITLE
Update domainMaps.*.good to reflect recent reduction in leaks

### DIFF
--- a/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
+++ b/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
@@ -53,8 +53,8 @@ Copy of domain map:
 Return domain map:
 	608 bytes leaked
 Create domain:
-	2064 bytes leaked
+	1216 bytes leaked
 Create domain and array:
-	3376 bytes leaked
+	2344 bytes leaked
 total:
-	7246 bytes leaked
+	5366 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.cygwin32.good
+++ b/test/memory/sungeun/refCount/domainMaps.cygwin32.good
@@ -53,8 +53,8 @@ Copy of domain map:
 Return domain map:
 	168 bytes leaked
 Create domain:
-	280 bytes leaked
+	192 bytes leaked
 Create domain and array:
-	1012 bytes leaked
+	924 bytes leaked
 total:
-	1907 bytes leaked
+	1731 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.lm-numa.good
+++ b/test/memory/sungeun/refCount/domainMaps.lm-numa.good
@@ -53,8 +53,8 @@ Copy of domain map:
 Return domain map:
 	248 bytes leaked
 Create domain:
-	408 bytes leaked
+	288 bytes leaked
 Create domain and array:
-	1240 bytes leaked
+	1120 bytes leaked
 total:
-	2646 bytes leaked
+	2406 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.no-local.good
+++ b/test/memory/sungeun/refCount/domainMaps.no-local.good
@@ -53,8 +53,8 @@ Copy of domain map:
 Return domain map:
 	608 bytes leaked
 Create domain:
-	2184 bytes leaked
+	1216 bytes leaked
 Create domain and array:
-	3496 bytes leaked
+	2344 bytes leaked
 total:
-	7486 bytes leaked
+	5366 bytes leaked


### PR DESCRIPTION
A recent patch to address leaks in Michael's record stress tests resulted in a reduction in leaks for
memory/sungeun/refCount/domainMaps.chpl.  Update the leak counts for several configurations.

Ben and Michael have both sanity checked this change; Ben explicitly and Michael implicitly.

