### PR TITLE
Add a better error message if the CHPL_HOME env var not set

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -550,6 +550,9 @@ def check_environment():
         if not os.path.isdir(home):
             print("Error: CHPL_HOME must be a legal directory.")
             sys.exit(1)
+    else:
+        print("Error: CHPL_HOME is not set.")
+        sys.exit(1)
 
     # Allow for utility directory override.
     # Useful when running more recent testing system on an older version of


### PR DESCRIPTION
I found the error message confusing when I ran start_test before setting CHPL_HOME.

* verified new error is printed if CHPL_HOME is not set on Linux, Mac OS X
* verified start_test still runs if CHPL_HOME is set on Linux, Mac OS X

Reviewed by @ben-albrecht.