### PR TITLE
Fix test_local_int_begin to not rely on stack-heap-promotion

### DIFF
--- a/test/multilocale/deitz/needMultiLocales/test_local_int_begin.chpl
+++ b/test/multilocale/deitz/needMultiLocales/test_local_int_begin.chpl
@@ -4,20 +4,29 @@ extern proc printf(fmt: c_string, x...);
 
 proc main {
   foo();
-  sleep(5); // make sure program does not exit
 }
 
 proc foo() {
   var x: int = 17;
   printf("%s\n", (here.id + " x=" + x).c_str());
   x += 1;
+  // Now x is 18
+
   on Locales(1) {
     begin with (ref x) {
+      // wait for statement A below
       sleep(2);
+      // Now x should be 18
       printf("%s\n", (here.id + " x=" + x).c_str());
       x += 1;
+      // Now x should be 19
       printf("%s\n", (here.id + " x=" + x).c_str());
     }
   }
+
+  // statement A. x should still be 18 because of the sleep above.
   printf("%s\n", (here.id + " x=" + x).c_str());
+
+  // make sure this stack frame does not exit since x is stack allocated
+  sleep(5);
 }


### PR DESCRIPTION
PRs #2745, #2755, #2855 disabled the behavior of heap-promoting stack
variables that were used in non-blocking on blocks.  That meant that this
test was using a stack variable that had gone out of scope. I adjust the
test (by moving a sleep) so that the stack frame with the variable does
not go out of scope before the variable is used. Note that the test
already had such a sleep - I just moved it to the inner scope instead of
at the end of main().