### PR TITLE
Add some tests of the FileSystem function sameFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,6 +299,8 @@ tags
 /test/modules/standard/FileSystem/lydia/isLink/my_link_file
 /test/modules/standard/FileSystem/lydia/isMount/symlinkToRoot
 /test/modules/standard/FileSystem/lydia/isMount/notAMonkey/symlinkToRoot
+/test/modules/standard/FileSystem/lydia/sameFile/linkToIt
+/test/modules/standard/FileSystem/lydia/sameFile/moveMe.txt
 /test/modules/standard/FileSystem/lydia/symlink/bar.txt
 /test/modules/standard/Path/lydia/realpath/blahblahblah.txt
 /test/modules/standard/Time/stonea/getCurrentDayOfWeek.good

--- a/test/modules/standard/FileSystem/lydia/sameFile/brokenSymlink.chpl
+++ b/test/modules/standard/FileSystem/lydia/sameFile/brokenSymlink.chpl
@@ -1,0 +1,28 @@
+use FileSystem;
+
+// Tests behavior of sameFile when provided a broken link.
+var filename = "moveMe.txt";
+var newName = "moved.txt";
+var linkname = "linkToIt";
+
+// moved.txt will be saved in the repository.  If something happens that
+// interrupts the execution of this test, this check should enable the test
+// to work correctly next time (by not needing to move newName over).
+if (!exists(filename) && exists(newName)) {
+  copy(newName, filename);
+  remove(newName);
+}
+// If we've already run this test once, linkname will still be around, so
+// we need to remove it.
+if (exists(linkname)) {
+  remove(linkname);
+}
+
+symlink(filename, linkname);
+copy(filename, newName);
+remove(filename);
+
+writeln(sameFile(newName, linkname));
+// Expected to throw "no such file" error, as python does.
+
+remove(linkname); // Don't expect to reach this line.

--- a/test/modules/standard/FileSystem/lydia/sameFile/brokenSymlink.good
+++ b/test/modules/standard/FileSystem/lydia/sameFile/brokenSymlink.good
@@ -1,0 +1,1 @@
+brokenSymlink.chpl:25: error: No such file or directory in sameFile(moved.txt, linkToIt)

--- a/test/modules/standard/FileSystem/lydia/sameFile/givenNull.chpl
+++ b/test/modules/standard/FileSystem/lydia/sameFile/givenNull.chpl
@@ -1,0 +1,8 @@
+use FileSystem;
+
+// Tests the case where a file record that points to null is provided as the
+// first argument to sameFile.
+var hasStuff: file = open("blah.txt", iomode.r);
+var nullFile: file;
+writeln(sameFile(nullFile, hasStuff));
+hasStuff.close();

--- a/test/modules/standard/FileSystem/lydia/sameFile/givenNull.good
+++ b/test/modules/standard/FileSystem/lydia/sameFile/givenNull.good
@@ -1,0 +1,1 @@
+givenNull.chpl:7: error: halt reached - Operation attempted on an invalid file

--- a/test/modules/standard/FileSystem/lydia/sameFile/givenNull2.chpl
+++ b/test/modules/standard/FileSystem/lydia/sameFile/givenNull2.chpl
@@ -1,0 +1,8 @@
+use FileSystem;
+
+// Tests the case where a file record that points to null is provided as the
+// second argument to sameFile.
+var hasStuff: file = open("blah.txt", iomode.r);
+var nullFile: file;
+writeln(sameFile(hasStuff, nullFile));
+hasStuff.close();

--- a/test/modules/standard/FileSystem/lydia/sameFile/givenNull2.good
+++ b/test/modules/standard/FileSystem/lydia/sameFile/givenNull2.good
@@ -1,0 +1,1 @@
+givenNull2.chpl:7: error: halt reached - Operation attempted on an invalid file

--- a/test/modules/standard/FileSystem/lydia/sameFile/givenNull3.chpl
+++ b/test/modules/standard/FileSystem/lydia/sameFile/givenNull3.chpl
@@ -1,0 +1,6 @@
+use FileSystem;
+
+// Tests the case where a file record that points to null is provided as the
+// only arguments to sameFile.
+var nullFile: file;
+writeln(sameFile(nullFile, nullFile));

--- a/test/modules/standard/FileSystem/lydia/sameFile/givenNull3.good
+++ b/test/modules/standard/FileSystem/lydia/sameFile/givenNull3.good
@@ -1,0 +1,1 @@
+givenNull3.chpl:6: error: halt reached - Operation attempted on an invalid file

--- a/test/modules/standard/FileSystem/lydia/sameFile/moved.txt
+++ b/test/modules/standard/FileSystem/lydia/sameFile/moved.txt
@@ -1,0 +1,1 @@
+here are some contents

--- a/test/modules/standard/FileSystem/lydia/sameFile/symlinkOfSame.chpl
+++ b/test/modules/standard/FileSystem/lydia/sameFile/symlinkOfSame.chpl
@@ -13,3 +13,11 @@ writeln(sameFile(f1, f2));
 f1.close();
 f2.close();
 remove(symlinkName);
+
+// This section tests sameFile over directories where one is a symlink of the
+// other.
+var origDir = "../";
+var sym2 = "foo3";
+symlink(origDir, sym2); // Creates foo3 as a symlink of ../
+writeln(sameFile(origDir, sym2));
+remove(sym2);

--- a/test/modules/standard/FileSystem/lydia/sameFile/symlinkOfSame.good
+++ b/test/modules/standard/FileSystem/lydia/sameFile/symlinkOfSame.good
@@ -1,2 +1,3 @@
 true
 true
+true


### PR DESCRIPTION
Part of an on-going effort (as I am motivated) to add more tests of the
FileSystem module.  These tests verify some edge cases for the sameFile
function: that file objects which point to null generate the correct error
message, that broken symlinks generate the correct error message (matching
Python's behavior), and that symlinks of the same directory correctly match
against the original.

Tested modules/standard/FileSystem directory on linux, darwin, and
cygwin