### PR TITLE
Fix a bug in copyTreeHelper on continuing to execute after an error.

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -436,6 +436,7 @@ private proc copyTreeHelper(out error: syserr, src: string, dest: string, copySy
 
   for dirname in listdir(path=src, dirs=true, files=false, listlinks=copySymbolically) {
     copyTreeHelper(error, src+"/"+dirname, dest+"/"+dirname, copySymbolically);
+    if (error != ENOERR) then return;
   }
 }
 


### PR DESCRIPTION
In implementing rmTree and moveDir, I discovered a bug in my implementation of
copyTreeHelper.  While the function would exit if it encountered a problem
while copying a file in the current directory, this would only stop the
execution of copy in the current directory.  If the directory with an error in
it was deep in the structure being copied, we would continue copying its
sibling directories and only notice at the end of these actions if something
had gone wrong.  Now, the traversal will stop at every level if an error is
encountered.

tested on std/