### PR TITLE
Filing a bug against extern types in generic functions

### DIFF
--- a/test/extern/bradc/extern-in-generic.bad
+++ b/test/extern/bradc/extern-in-generic.bad
@@ -1,0 +1,7 @@
+extern-in-generic.chpl:8: internal error: TYP0120 chpl Version 1.12.0.6aa346a
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/extern/bradc/extern-in-generic.chpl
+++ b/test/extern/bradc/extern-in-generic.chpl
@@ -1,0 +1,9 @@
+config param workaround = false;
+
+makeInput(1);
+
+// WORKAROUND: 
+// proc makeInput(bucketID: int) {
+proc makeInput(bucketID) {
+  extern type pgc_random_t;
+}

--- a/test/extern/bradc/extern-in-generic.future
+++ b/test/extern/bradc/extern-in-generic.future
@@ -1,0 +1,5 @@
+bug: extern types in generic => internal error
+
+Apparently, putting an extern type into a generic function causes an
+internal error because we try to make a second copy of the type and
+it's a primitive type so this triggers an error.  :(


### PR DESCRIPTION
It turns out that if we declare extern types in generic functions,
even those that are instantiated only a single time as in this
example, we hit an internal error.  From what I could tell and guess,
the cause is that we clone everything in the function, including the
extern type, but that since extern types are primitives, and
primitives throw an internal error when they are duplicated, that
causes a problem.  Workarounds include giving the type of the formal
(so the function is no longer generic) or moving the extern type
elsewhere (module level or in its own module).

It seems as though a fix for this _may_ be to not clone extern types
and just return the original type given that there's nothing about
them that's going to need to be specialized from one generic
instantiation to the other.  I'm not sure whether this would best be
done low in the callchain or higher up.  Worth a shot.