### PR TITLE
Avoid a copy when returning the result of a call

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -94,6 +94,7 @@ symbolFlag( FLAG_EXPAND_TUPLES_WITH_VALUES , ypr, "expand tuples with values" , 
 symbolFlag( FLAG_EXPORT , npr, "export" , ncm )
 symbolFlag( FLAG_EXPORT_INIT, ypr, "export init", "indicate that the module's initialization function should be exported" )
 symbolFlag( FLAG_EXPR_TEMP , npr, "expr temp" , "temporary that stores the result of an expression" )
+symbolFlag( FLAG_RET_EXPR_TEMP , npr, "ret expr temp" , "temporary that stores the result of a returned expression" )
 symbolFlag( FLAG_EXTERN , npr, "extern" , "extern variables, types, and functions" )
 symbolFlag( FLAG_FAST_ON , npr, "fast on" , "with FLAG_ON/FLAG_ON_BLOCK, \"on block\" , use fast spawning option (if available)" )
 symbolFlag( FLAG_FIELD_ACCESSOR , npr, "field accessor" , "field setter/getter function, user-declared or compiler-generated" )

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5923,8 +5923,13 @@ postFold(Expr* expr) {
               !lhs->var->hasFlag(FLAG_TYPE_VARIABLE)) {
             if (CallExpr* rhsCall = toCallExpr(call->get(2))) {
               if (requiresImplicitDestroy(rhsCall)) {
-                lhs->var->addFlag(FLAG_INSERT_AUTO_COPY);
-                lhs->var->addFlag(FLAG_INSERT_AUTO_DESTROY);
+                if (lhs->var->hasFlag(FLAG_RET_EXPR_TEMP) &&
+                    !isRecordWrappedType(lhs->typeInfo()) ) {
+                  // do nothing
+                } else {
+                  lhs->var->addFlag(FLAG_INSERT_AUTO_COPY);
+                  lhs->var->addFlag(FLAG_INSERT_AUTO_DESTROY);
+                }
               }
             }
           }


### PR DESCRIPTION
For code like this:

    proc return2() {
      return return1();
    }

the compiler was adding a temporary to store the result of return1()
and an autoCopy/autoDestroy pair. Since the return value of a function
is the caller's responsibility to free, we can just directly move
a the result from one call into the return value variable for another.

This patch adds a flag, FLAG_RET_EXPR_TEMP, that is set in normalize for
temporaries created in this situation (storing the result of a call that
is then returned). It modifies postFold in functionResolution to avoid
adding FLAG_INSERT_AUTO_COPY and FLAG_INSERT_AUTO_DESTROY for such
variables - except that we leave the old behavior for record wrapped
types, since there seems to be some kind of issue with enabling this
change for them (Hello World seems to enter an infinite loop).

The return-return.chpl test is useful for investigating this case.  This
change does not help with the extra auto-copies for uses of ref functions
as in:

    var x = A[i];

where A is an array of records. That case is discussed in PR #2867.

