### PR TITLE
Futurizing new test that's failing: return-array-promoted

### DIFF
--- a/test/functions/ferguson/return-array-promoted.bad
+++ b/test/functions/ferguson/return-array-promoted.bad
@@ -1,0 +1,2 @@
+return-array-promoted.chpl:4: In function 'retit':
+return-array-promoted.chpl:5: error: type mismatch in return from int(64) to [domain(1,int(64),false)] int(64)

--- a/test/functions/ferguson/return-array-promoted.future
+++ b/test/functions/ferguson/return-array-promoted.future
@@ -1,0 +1,4 @@
+semantic: promotion of scalar value for declared array return type
+
+This test was checked in broken.  I'm futurizing it to prevent noise
+in tonight's testing.


### PR DESCRIPTION
[failure verified by @benharsh]

This test seems to have been failing since being checked in today, so futurizing
it to avoid noise in tonight's testing.  [Attn: @mppf]