### PR TITLE
Remove some .bad files, fix record.chpl

### DIFF
--- a/test/separate_compilation/jturner/record.chpl
+++ b/test/separate_compilation/jturner/record.chpl
@@ -4,7 +4,8 @@ record Foo {
 }
 
 export proc dothis(r : Foo) : Foo {
-  r.x = r.x + 1;
-  r.y = r.y + 2;
-  return r;
+  var ret:Foo;
+  ret.x = r.x + 1;
+  ret.y = r.y + 2;
+  return ret;
 }

--- a/test/separate_compilation/jturner/use_array.bad
+++ b/test/separate_compilation/jturner/use_array.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/separate_compilation/jturner/use_classextern.bad
+++ b/test/separate_compilation/jturner/use_classextern.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/separate_compilation/jturner/use_classextern2.bad
+++ b/test/separate_compilation/jturner/use_classextern2.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/separate_compilation/jturner/use_fcfunc.bad
+++ b/test/separate_compilation/jturner/use_fcfunc.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/separate_compilation/jturner/use_methodextern.bad
+++ b/test/separate_compilation/jturner/use_methodextern.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/separate_compilation/jturner/use_methodextern2.bad
+++ b/test/separate_compilation/jturner/use_methodextern2.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/separate_compilation/jturner/use_overload.bad
+++ b/test/separate_compilation/jturner/use_overload.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/separate_compilation/jturner/use_record.bad
+++ b/test/separate_compilation/jturner/use_record.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/separate_compilation/jturner/use_simplefloat.bad
+++ b/test/separate_compilation/jturner/use_simplefloat.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/separate_compilation/jturner/use_subclass.bad
+++ b/test/separate_compilation/jturner/use_subclass.bad
@@ -1,7 +1,0 @@
-internal error: CHE0497 chpl Version 1.12.0.62cd853
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-


### PR DESCRIPTION
The .bad files went from internal errors to C
compilation failures on Mac OS X and might be core
dumps in other places. I don't think these need .bad
files since they will fail in a different way.

The record.chpl function had an error since it tried
to modify an argument passed in by default intent,
which is 'const ref'.