### PR TITLE
Extern-in-generic2 bugfix

### DIFF
--- a/test/extern/bradc/extern-in-generic2.chpl
+++ b/test/extern/bradc/extern-in-generic2.chpl
@@ -6,7 +6,9 @@ proc makeInput(bucketID) {
   require "foo.h";
   extern type foo;
   extern proc printfoo(x: foo);
+  extern proc zerofoo(ref x: foo);
 
    var x: foo;
+   zerofoo(x);
    printfoo(x);
 }

--- a/test/extern/bradc/foo.h
+++ b/test/extern/bradc/foo.h
@@ -3,5 +3,6 @@ typedef int foo;
 void printfoo(foo x);
 
 void printfoo(foo x) {
+  x = 0;
   printf("%d\n", x);
 }

--- a/test/extern/bradc/foo.h
+++ b/test/extern/bradc/foo.h
@@ -1,8 +1,12 @@
 typedef int foo;
 
 void printfoo(foo x);
+void zerofoo(foo* x);
+
+void zerofoo(foo* x) {
+  *x = 0;
+}
 
 void printfoo(foo x) {
-  x = 0;
   printf("%d\n", x);
 }


### PR DESCRIPTION
I naively wrote this test thinking that variables of extern generic types
would be automatically initialized, when of course that's naive and I
was just getting lucky on linux.  Here, I add another extern routine
to zero out the routine and guarantee the results.
