### PR TITLE
Fix the implementation of copyTreeHelper to correctly handle symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,6 +285,9 @@ tags
 /test/modules/standard/FileSystem/lydia/copyTree/denseDest
 /test/modules/standard/FileSystem/lydia/copyTree/cutoffDest
 /test/modules/standard/FileSystem/lydia/copyTree/existing_dir
+/test/modules/standard/FileSystem/lydia/copyTree/hasLink
+/test/modules/standard/FileSystem/lydia/copyTree/willLink
+/test/modules/standard/FileSystem/lydia/copyTree/willCopy
 /test/modules/standard/FileSystem/lydia/exists/broken_link
 /test/modules/standard/FileSystem/lydia/exists/dir
 /test/modules/standard/FileSystem/lydia/exists/dir_link

--- a/test/modules/standard/FileSystem/lydia/copyTree/links.catfiles
+++ b/test/modules/standard/FileSystem/lydia/copyTree/links.catfiles
@@ -1,0 +1,2 @@
+willCopy/amALink
+willLink/amALink

--- a/test/modules/standard/FileSystem/lydia/copyTree/links.chpl
+++ b/test/modules/standard/FileSystem/lydia/copyTree/links.chpl
@@ -3,34 +3,56 @@ use Path;
 
 // This test ensures that copyTree works as expected for copySymbolically =
 // true or false when the source directory contains a symlink.
-var linkDir = "hasLink";
-var link = "hasLink/amALink";
+var dirWithLinks = "hasLink";
+var fileLink = "hasLink/amALink";
+var dirLink = "hasLink/dirLink";
 var linkSrc = "linksSrc/linked.txt";
+var linkSrcDir = "linksSrc";
 
-// Test set up
-if (!exists(linkDir)) {
-  mkdir(linkDir);
+// Create directory to copy
+if (!exists(dirWithLinks)) {
+  mkdir(dirWithLinks);
 }
-if (!exists(link)) {
-  symlink(realPath(linkSrc), link);
+
+// Populate directory to copy with a file link
+if (!exists(fileLink)) {
+  symlink(realPath(linkSrc), fileLink);
 }
-if (!isLink(link)) {
-  writeln(link + " was not a symlink, removing and replacing");
-  remove(link);
-  symlink(realPath(linkSrc), link);
+if (!isLink(fileLink)) {
+  writeln(fileLink + " was not a symlink, removing and replacing");
+  remove(fileLink);
+  symlink(realPath(linkSrc), fileLink);
+}
+
+// Populate directory to copy with a directory link
+if (!exists(dirLink)) {
+  symlink(realPath(linkSrcDir), dirLink);
+}
+if (!isLink(dirLink)) {
+  writeln(dirLink + " was not a symlink, removing and replacing");
+  rmTree(dirLink);
+  symlink(realPath(linkSrcDir), dirLink);
 }
 
 var destLinked = "willLink";
 var destCopied = "willCopy";
 
-copyTree(linkDir, destLinked, true);
-// destLinked is expected to contain a symlink to linkSrc
-var linkInDest = "willLink/amALink";
-writeln("copying symbolically, copy exists: " + exists(linkInDest));
-writeln("and is a link: " + isLink(linkInDest));
+copyTree(dirWithLinks, destLinked, true);
+// destLinked is expected to contain symlinks to linkSrc
+var fileLinkInDest = "willLink/amALink";
+var dirLinkInDest = "willLink/dirLink";
+writeln("Copying symbolically");
+writeln("file copy exists: " + exists(fileLinkInDest));
+writeln("and is a link: " + isLink(fileLinkInDest));
+writeln("dir copy exists: " + exists(dirLinkInDest));
+writeln("and is a link: " + isLink(dirLinkInDest));
 
-copyTree(linkDir, destCopied, false);
+copyTree(dirWithLinks, destCopied, false);
 // destCopied is expected to contain a file with the exact contents of linkSrc
-var copyInDest = "willCopy/amALink";
-writeln("copying un-symbolically, copy exists: " + exists(copyInDest));
-writeln("and is a link: " + isLink(copyInDest));
+var fileCopyInDest = "willCopy/amALink";
+var dirCopyInDest = "willCopy/dirLink";
+writeln("Copying un-symbolically");
+writeln("file copy exists: " + exists(fileCopyInDest));
+writeln("and is a link: " + isLink(fileCopyInDest));
+writeln("dir copy exists: " + exists(dirCopyInDest));
+writeln("and is a link: " + isLink(dirCopyInDest));

--- a/test/modules/standard/FileSystem/lydia/copyTree/links.chpl
+++ b/test/modules/standard/FileSystem/lydia/copyTree/links.chpl
@@ -1,0 +1,36 @@
+use FileSystem;
+use Path;
+
+// This test ensures that copyTree works as expected for copySymbolically =
+// true or false when the source directory contains a symlink.
+var linkDir = "hasLink";
+var link = "hasLink/amALink";
+var linkSrc = "linksSrc/linked.txt";
+
+// Test set up
+if (!exists(linkDir)) {
+  mkdir(linkDir);
+}
+if (!exists(link)) {
+  symlink(realPath(linkSrc), link);
+}
+if (!isLink(link)) {
+  writeln(link + " was not a symlink, removing and replacing");
+  remove(link);
+  symlink(realPath(linkSrc), link);
+}
+
+var destLinked = "willLink";
+var destCopied = "willCopy";
+
+copyTree(linkDir, destLinked, true);
+// destLinked is expected to contain a symlink to linkSrc
+var linkInDest = "willLink/amALink";
+writeln("copying symbolically, copy exists: " + exists(linkInDest));
+writeln("and is a link: " + isLink(linkInDest));
+
+copyTree(linkDir, destCopied, false);
+// destCopied is expected to contain a file with the exact contents of linkSrc
+var copyInDest = "willCopy/amALink";
+writeln("copying un-symbolically, copy exists: " + exists(copyInDest));
+writeln("and is a link: " + isLink(copyInDest));

--- a/test/modules/standard/FileSystem/lydia/copyTree/links.cleanfiles
+++ b/test/modules/standard/FileSystem/lydia/copyTree/links.cleanfiles
@@ -1,0 +1,3 @@
+hasLink/amALink
+willLink
+willCopy

--- a/test/modules/standard/FileSystem/lydia/copyTree/links.good
+++ b/test/modules/standard/FileSystem/lydia/copyTree/links.good
@@ -1,6 +1,12 @@
-copying symbolically, copy exists: true
+Copying symbolically
+file copy exists: true
 and is a link: true
-copying un-symbolically, copy exists: true
+dir copy exists: true
+and is a link: true
+Copying un-symbolically
+file copy exists: true
+and is a link: false
+dir copy exists: true
 and is a link: false
 A link to me exists in another directory
 A link to me exists in another directory

--- a/test/modules/standard/FileSystem/lydia/copyTree/links.good
+++ b/test/modules/standard/FileSystem/lydia/copyTree/links.good
@@ -1,0 +1,6 @@
+copying symbolically, copy exists: true
+and is a link: true
+copying un-symbolically, copy exists: true
+and is a link: false
+A link to me exists in another directory
+A link to me exists in another directory

--- a/test/modules/standard/FileSystem/lydia/copyTree/linksSrc/linked.txt
+++ b/test/modules/standard/FileSystem/lydia/copyTree/linksSrc/linked.txt
@@ -1,0 +1,1 @@
+A link to me exists in another directory


### PR DESCRIPTION
I had a sneaking suspicion when implementing moveDir that copyTree handled this
case incorrectly.  I wrote a test to exercise that case and my suspicion proved
to be well founded.

Before, symlinks would either get ignored (if copySymbolically was false), or
have their contents copied (if copySymbolically was true).  This was not the
intended behavior: in the former case, their contents should be copied, and in
the latter symbolic links should be made.  This commit fixes that behavior.

Add test of symbolic links to files and directories in the directory that is being
copied.

Verified that the test/modules/standard/FileSystem directory works for darwin
and cygwin, and that standard testing completed without errors on linux.