### PR TITLE
Allow some test system files to be executable

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -240,11 +240,30 @@ def PerfDirFile(s):
 def PerfTFile(test_filename, sfx):
     return test_filename + '.' + perflabel + sfx
 
-# read file with comments
+# Read a file or if the file is executable read its output. If the file is
+# executable, the current chplenv is copied into the env before executing.
+# Expands shell variables and strip out comments/whitespace. Returns a list of
+# string, one per line in the file.
 def ReadFileWithComments(f, ignoreLeadingSpace=True):
-    # sys.stdout.write('Opening: %s\n'%(f))
-    with open(f, 'r') as myfile:
-      mylines = myfile.readlines()
+    mylines = ""
+    # if the file is executable, run it and grab the output
+    if os.access(f, os.X_OK):
+        # grab the chplenv so it can be stuffed into the subprocess env
+        env_cmd = [os.path.join(utildir, 'printchplenv'), '--simple']
+        chpl_env = subprocess.Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0]
+        chpl_env = dict(map(lambda l: l.split('='), chpl_env.splitlines()))
+        file_env = os.environ.copy()
+        file_env.update(chpl_env)
+
+        # execute the file and grab its output
+        cmd = subprocess.Popen([os.path.abspath(f)], stdout=subprocess.PIPE, env=file_env)
+        mylines = cmd.communicate()[0].splitlines()
+
+    # otherwise, just read the file
+    else:
+        with open(f, 'r') as myfile:
+            mylines = myfile.readlines()
+
     mylist=list()
     for line in mylines:
         line = line.rstrip()


### PR DESCRIPTION
Ordinarily test files such as .compopts, .execopts, or .execenv files are just
read in, which doesn't allow them to differ across configurations. Most of our
test systems files are read in with ReadFileWithComments() function. This adds
code to that function to read the output of a file if its executable instead of
just reading in the file.

This patch is motivated by wanting to turn off guard pages with an execenv, but
only for KNC.

Looking through sub_test I think this allows the following files to be
executable:

```
COMPOPTS    and .compopts
EXECOPTS    and .execopts
TIMEEXEC    and .timeexec
EXECENV     and .execenv
CHPLDOCOPTS and .chpldocopts
TIMEOUT     and .timeout
NUMLOCALES  and .numlocales
NUMTRIALS   and .numtrials
```

But it does not allow the following files to be executable yet:

```
.good        or .bad          (`diff` is called on the actual files)
LASTCOMPOPTS or .lastcompopts (`cat` is used to read in for some reason)
LASTEXECOPTS or .lastexecopts (`cat` is used to read in for some reason)
STDIN        or .stdin        (simply piped in with '<')
CATFILES     or .catfiles     (`cat` is used here)
```