### PR TITLE
Change includes so re2-interface.cc can compile with clang

### DIFF
--- a/runtime/include/chplcast.h
+++ b/runtime/include/chplcast.h
@@ -51,15 +51,19 @@ _real32 c_string_to_real32_precise(c_string str, int* invalid, char* invalidCh);
 _real64 c_string_to_real64_precise(c_string str, int* invalid, char* invalidCh);
 _imag32 c_string_to_imag32_precise(c_string str, int* invalid, char* invalidCh);
 _imag64 c_string_to_imag64_precise(c_string str, int* invalid, char* invalidCh);
+#ifndef __cplusplus
 _complex64 c_string_to_complex64_precise(c_string str, int* invalid, char* invalidCh);
 _complex128 c_string_to_complex128_precise(c_string str, int* invalid, char* invalidCh);
+#endif
 
 _real32 c_string_to_real32(c_string str, int lineno, c_string filename);
 _real64 c_string_to_real64(c_string str, int lineno, c_string filename);
 _imag32 c_string_to_imag32(c_string str, int lineno, c_string filename);
 _imag64 c_string_to_imag64(c_string str, int lineno, c_string filename);
+#ifndef __cplusplus
 _complex64 c_string_to_complex64(c_string str, int lineno, c_string filename);
 _complex128 c_string_to_complex128(c_string str, int lineno, c_string filename);
+#endif
 
 
 /* every other primitive type to string */

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -27,7 +27,9 @@
 #include <stdlib.h>
 #include <stddef.h> // for ptrdiff_t
 #include <sys/time.h> // for struct timeval
+#ifndef __cplusplus
 #include <complex.h>
+#endif
 
 // C types usable from Chapel.
 typedef char c_char;
@@ -201,8 +203,10 @@ typedef float               _real32;
 typedef double              _real64;
 typedef float               _imag32;
 typedef double              _imag64;
+#ifndef __cplusplus
 typedef float complex       _complex64;
 typedef double complex      _complex128;
+#endif
 typedef int64_t             _symbol;
 
 // macros for Chapel min/max -> C stdint.h or values.h min/max
@@ -240,6 +244,7 @@ typedef struct chpl_main_argument_s {
   int32_t return_value;
 } chpl_main_argument;
 
+#ifndef __cplusplus
 _complex128 _chpl_complex128(_real64 re, _real64 im);
 _complex64 _chpl_complex64(_real32 re, _real32 im);
 
@@ -247,6 +252,7 @@ _real64* complex128GetRealRef(_complex128* cplx);
 _real64* complex128GetImagRef(_complex128* cplx);
 _real32* complex64GetRealRef(_complex64* cplx);
 _real32* complex64GetImagRef(_complex64* cplx);
+#endif
 
 /* This should be moved somewhere else, but where is the question */
 const char* chpl_get_argument_i(chpl_main_argument* args, int32_t i);


### PR DESCRIPTION
The recent change to use C99 complex types causes re2-interface.cc to
choke when built with clang. There is an incompatibility when using
C99's complex.h and compiling C++ code with clang. Rather than try to
really figure out the root cause, or do a clean fix, I've just #ifdef'd
out the definitions in chplcast.h and chpltypes.h when compiling with
C++. A more principled approach might be to make it so re2-interface.cc
never includes these files in the first place, but that seemed to
require editing far to many include files.

Something to note is that a "convention" used in re2-interface.cc is not
actually valid code: placing imports inside of a `extern "C" {` block is
not allowed.