### PR TITLE
Remove second explainInstantiation test

### DIFF
--- a/test/classes/hilde/explainInstantiation.chpl
+++ b/test/classes/hilde/explainInstantiation.chpl
@@ -1,6 +1,0 @@
-var maxint = max(int(64));
-
-var r = new range(int(64), _low = maxint - 10, _high = maxint);
-
-writeln(r);
-

--- a/test/classes/hilde/explainInstantiation.compopts
+++ b/test/classes/hilde/explainInstantiation.compopts
@@ -1,1 +1,0 @@
---explain-instantiation=range

--- a/test/classes/hilde/explainInstantiation.good
+++ b/test/classes/hilde/explainInstantiation.good
@@ -1,5 +1,0 @@
-$CHPL_HOME/modules/internal/DefaultRectangular.chpl:: note: instantiated range(idxType = int(64), boundedType = bounded, stridable = false)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:: note: instantiated _unknown(idxType = int(64), boundedType = bounded, stridable = false)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:: note: instantiated _unknown(idxType = int(64), boundedType = boundedLow, stridable = false)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:: note: instantiated range(idxType = int(64), boundedType = boundedLow, stridable = false)
-9223372036854775797..9223372036854775807

--- a/test/classes/hilde/explainInstantiation.prediff
+++ b/test/classes/hilde/explainInstantiation.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-outfile=$2
-
-sed -e "s/:[0-9]*:/::/g" $outfile > $outfile.tmp
-mv $outfile.tmp $outfile


### PR DESCRIPTION
This test has been updated many times indicating that it is fragile. The
--explain-instantiation option is already covered in a less fragile way
by
 test/functions/deitz/test_explain_instantiation.chpl

Therefore I'm removing this test instead of updating the .good
file for the 24th time.