### PR TITLE
Fix LLVM builds after C99 complex merge

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4072,7 +4072,7 @@ GenRet CallExpr::codegen() {
                info->cStatements.push_back(stmt);
              } else {
 #ifdef HAVE_LLVM
-               codegenStoreLLVM(from, to_ptr, type);
+               codegenStoreLLVM(from, to_ptr);
 #endif
              }
            } else {


### PR DESCRIPTION
The C99 complex merge broke LLVM builds with an undefined variable.  Stop
using that undefined variable.

Tested on test/types/complex with CHPL_LLVM=llvm and CHPL_COMM=[none, gasnet].