### PR TITLE
Disable libnuma in hwloc builds

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -16,6 +16,7 @@ CHPL_HWLOC_CFG_OPTIONS += --enable-static \
                           --disable-shared \
                           --disable-cairo \
                           --disable-libxml2 \
+                          --disable-libnuma \
                           --disable-opencl \
                           --disable-pci
 


### PR DESCRIPTION
We don't currently need the libnuma support in hwloc and it's causing the
module build to fail, so we're disabling it.

A few more details:

Our module build starting failing in the hwloc make step while trying to do
-lnuma. On 11/12/15 the configure step started detecting that libnuma was
available, so during the make step it unsuccessfully tried to include libnuma.
However, only the .so was available, so we think that since we force static linking
it couldn't actually find libnuma. That said removing "--disable-shared" and
"--enable-static" didn't make the issue go away, so it's not clear what's going
wrong.

Also we're still not sure what caused hwloc to start detecting that libnuma is
available in the configure step, but since we don't currently need the libnuma
support, we're not going to worry about it for now.