### PR TITLE
Reduce the precision of output for a complex number in a test

### DIFF
--- a/test/types/complex/bradc/resultWidths.chpl
+++ b/test/types/complex/bradc/resultWidths.chpl
@@ -109,7 +109,7 @@ proc testit(param numbits) {
   
   {
     var z = x / y;
-    writeln("z is ", z, " and requires ", numBits(z.type), " bits");
+    writef("z is %.4z and requires %i bits\n", z, numBits(z.type));
   }
   
   {

--- a/test/types/complex/bradc/resultWidths.good
+++ b/test/types/complex/bradc/resultWidths.good
@@ -18,7 +18,7 @@ z is 1.65 + 1.8i and requires 64 bits
 z is 1.65 + 1.8i and requires 64 bits
 z is -1.92 + 1.76i and requires 64 bits
 z is -1.92 + 1.76i and requires 64 bits
-z is 0.852055 + 0.00547944i and requires 64 bits
+z is 0.8521 + 0.005479i and requires 64 bits
 z is 0.622642 - 0.679245i and requires 64 bits
 z is 0.733333 + 0.8i and requires 64 bits
 z is 0.724528 + 0.664151i and requires 64 bits
@@ -43,7 +43,7 @@ z is 1.65 + 1.8i and requires 128 bits
 z is 1.65 + 1.8i and requires 128 bits
 z is -1.92 + 1.76i and requires 128 bits
 z is -1.92 + 1.76i and requires 128 bits
-z is 0.852055 + 0.00547945i and requires 128 bits
+z is 0.8521 + 0.005479i and requires 128 bits
 z is 0.622642 - 0.679245i and requires 128 bits
 z is 0.733333 + 0.8i and requires 128 bits
 z is 0.724528 + 0.664151i and requires 128 bits


### PR DESCRIPTION
The result of the complex divide in this test can be slightly different
from one configuration to the next.  Reduce the precision of the output
so the difference doesn't show up.

This fix was suggested by Brad.