### PR TITLE
Change the LLVM name of complex types from complex(128) to _complex128

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -515,7 +515,7 @@ llvm::Value* codegenImmediateLLVM(Immediate* i)
               llvm::Type::getFloatTy(info->module->getContext()),
               i->v_complex64.i);
           ret = llvm::ConstantStruct::get(
-              llvm::cast<llvm::StructType>(getTypeLLVM("complex(64)")),
+              llvm::cast<llvm::StructType>(getTypeLLVM("_complex64")),
               elements);
           break;
         }
@@ -528,7 +528,7 @@ llvm::Value* codegenImmediateLLVM(Immediate* i)
               llvm::Type::getDoubleTy(info->module->getContext()),
               i->v_complex128.i);
           ret = llvm::ConstantStruct::get(
-              llvm::cast<llvm::StructType>(getTypeLLVM("complex(128)")),
+              llvm::cast<llvm::StructType>(getTypeLLVM("_complex128")),
               elements);
           break;
         }


### PR DESCRIPTION
This fixes the LLVM regression for release/examples/primers/genericClasses.
In codegen for a complex immediate it was failing to find the type
"complex(128)". The name used in the runtime is "_complex128".  Same for
"complex(64)".

Tested over release/examples with --llvm.  release/examples/benchmarks/hpcc/fft
is still failing for --llvm, but it is another issue.