### PR TITLE
Support building re2 with the cray compiler

### DIFF
--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -21,6 +21,27 @@ CHPL_RE2_CXXFLAGS=-mmic
 endif
 endif
 
+
+# re2's makefile throws gcc specific flags that are not supported by the cray
+# compiler. This is intended to effectively replace the re2 makefile lines:
+#
+#     CXXFLAGS?=-Wall -O3 -g -pthread # can override
+#     RE2_CXXFLAGS?=-Wsign-compare -c -I. $(CCPCRE)  # required
+#     LDFLAGS?=-pthread
+#
+# with:
+#
+#     CXXFLAGS?= -O3
+#     RE2_CXXFLAGS?= -c -I. $(CCPCRE)
+#     LDFLAGS?=
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)
+CHPL_RE2_CXXFLAGS=-O3
+CHPL_RE2_CFG_OPTIONS += LDFLAGS=
+CHPL_RE2_CFG_OPTIONS += 'RE2_CXXFLAGS= -c -I. $$(CCPCRE)'
+endif
+
+CHPL_RE2_CFG_OPTIONS += $(CHPL_RE2_MORE_CFG_OPTIONS)
+
 default: all
 
 all: re2
@@ -40,8 +61,8 @@ $(RE2_BUILD_SUBDIR):
 $(RE2_H_FILE): $(RE2_BUILD_SUBDIR)
 	cd re2 && \
 	$(MAKE) clean && \
-	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' obj/libre2.a && \
-	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' prefix=$(RE2_INSTALL_DIR) install-static && \
+	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' $(CHPL_RE2_CFG_OPTIONS) obj/libre2.a && \
+	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' $(CHPL_RE2_CFG_OPTIONS) prefix=$(RE2_INSTALL_DIR) install-static && \
 	mkdir -p ../build/$(RE2_UNIQUE_SUBDIR) && \
 	rm -rf ../build/$(RE2_UNIQUE_SUBDIR) && \
 	mv obj ../build/$(RE2_UNIQUE_SUBDIR)


### PR DESCRIPTION
Historically we have not supported building re2 with the cray compiler. This
was primarily because re2 throws gcc specific flags that the cray compiler
doesn't support. It's also possible that before the cray compiler threw -hgnu
by default it might not have been to build re2 even if it wasn't given bogus
flags.

This patch just overrides re2's default LDFLAGS and RE2_CXXFLAGS to not include
flags that are not supported or not needed for the cray compiler.

I tested this by running a few tests that use re2 such as regexdna

This is not a particularly elegant solution, it's mostly a proof of concept and
hopefully somebody more familiar with re2 can help me clean it up.

While working on this, I was wondering why we don't use our CXXFLAGS like we do
for our other third party libraries. It seems to me that we're building without
optimizations turned on. I think we're overriding re2s CXXFLAGS (which threw
-O3) but never asking for optimizations ourselves.