### PR TITLE
 Fix prediff for OSX

### DIFF
--- a/test/optimizations/sungeun/optimized-on/test_OptimizedOn_RA.prediff
+++ b/test/optimizations/sungeun/optimized-on/test_OptimizedOn_RA.prediff
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
 # $1 = testname
 # $2 = outfile
-sed 's/\.chpl:[0-9]\+)$/.chpl:LINE)/' < $2 > $2.prediff.tmp \
+sed 's/\.chpl:[0-9][0-9]*)$/.chpl:LINE)/' < $2 > $2.prediff.tmp \
 && mv $2.prediff.tmp $2


### PR DESCRIPTION
The + operator doesn't work on OSX's sed by default, so simply use * instead within the prediff for test_OptimizedOn_RA. One could use -E, but this seemed to be the simplest way to get things working across platforms.