### PR TITLE
Change the comm interface to take a size instead of elemSize+len

### DIFF
--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -206,6 +206,8 @@ void checkPrimitives()
      case PRIM_TUPLE_AND_EXPAND:
      case PRIM_CHPL_COMM_GET:           // Direct calls to the Chapel comm layer
      case PRIM_CHPL_COMM_PUT:           // may eventually add others (e.g.: non-blocking)
+     case PRIM_CHPL_COMM_ARRAY_GET:
+     case PRIM_CHPL_COMM_ARRAY_PUT:
      case PRIM_CHPL_COMM_REMOTE_PREFETCH:
      case PRIM_CHPL_COMM_GET_STRD:      // Direct calls to the Chapel comm layer for strided comm
      case PRIM_CHPL_COMM_PUT_STRD:      //  may eventually add others (e.g.: non-blocking)

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -97,7 +97,7 @@ static void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3, Gen
 static void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3, GenRet a4, GenRet a5);
 
 static GenRet codegenZero();
-static GenRet codegenOne();
+//static GenRet codegenOne();
 static GenRet codegenNullPointer();
 
 static GenRet codegenFieldPtr(GenRet base, const char* field);
@@ -2835,6 +2835,7 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   codegenCall(fnName, args);
 }
 
+/*
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7, GenRet a8)
@@ -2851,7 +2852,6 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   codegenCall(fnName, args);
 }
 
-/*
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7, GenRet a8,
@@ -2939,11 +2939,13 @@ GenRet codegenZero()
   return new_IntSymbol(0, INT_SIZE_64)->codegen();
 }
 
+/*
 static
 GenRet codegenOne()
 {
   return new_IntSymbol(1, INT_SIZE_64)->codegen();
 }
+*/
 
 static
 GenRet codegenNullPointer()
@@ -3383,7 +3385,6 @@ void codegenAssign(GenRet to_ptr, GenRet from)
                     codegenRaddr(from),
                     codegenSizeof(type),
                     genTypeStructureIndex(type->symbol),
-                    codegenOne(),
                     info->lineno, info->filename );
       } else {
         if (forceWidePtrsForLocal()) {
@@ -3402,7 +3403,6 @@ void codegenAssign(GenRet to_ptr, GenRet from)
                         codegenRaddr(from),
                         codegenSizeof(type),
                         genTypeStructureIndex(type->symbol),
-                        codegenOne(),
                         info->lineno, info->filename );
           }
         }
@@ -3426,7 +3426,6 @@ void codegenAssign(GenRet to_ptr, GenRet from)
                       codegenRaddr(to_ptr),
                       codegenSizeof(type),
                       genTypeStructureIndex(type->symbol),
-                      codegenOne(),
                       info->lineno, info->filename);
         }
       }
@@ -5124,11 +5123,15 @@ GenRet CallExpr::codegen() {
       codegenCall("chpl_task_setSerial", codegenValue(get(1)));
       break;
     case PRIM_CHPL_COMM_GET:
-    case PRIM_CHPL_COMM_PUT: {
+    case PRIM_CHPL_COMM_PUT:
+    case PRIM_CHPL_COMM_ARRAY_GET:
+    case PRIM_CHPL_COMM_ARRAY_PUT: {
       // args are:
-      //   localvar, locale, remote addr, (eltSize), get(4)==length, line, file
+      //   localvar, locale, remote addr, get(4)==size, line, file
+      //                                  get(4)==len  for array_get/put
       const char* fn;
-      if (primitive->tag == PRIM_CHPL_COMM_GET) {
+      if (primitive->tag == PRIM_CHPL_COMM_GET ||
+          primitive->tag == PRIM_CHPL_COMM_ARRAY_GET) {
         fn = "chpl_gen_comm_get";
       } else {
         fn = "chpl_gen_comm_put";
@@ -5168,22 +5171,25 @@ GenRet CallExpr::codegen() {
           remoteAddr = codegenAddrOf(remoteAddr);
         }
       }
-      /*if( remoteAddrArg.isLVPtr == GEN_WIDE_PTR ) {
-        remoteAddr = codegenRaddr(remoteAddrArg);
-      } else {
-        remoteAddr = codegenValuePtr(remoteAddrArg);
-      }*/
-      GenRet eltSize = codegenSizeof(dt->typeInfo());
+
       GenRet len;
-      if( get(4)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_REF) ) {
+      GenRet size;
+      if (get(4)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_REF)) {
         len = codegenValue(codegenDeref(get(4)));
       } else {
         len = codegenValue(get(4));
       }
+      if (primitive->tag == PRIM_CHPL_COMM_ARRAY_PUT ||
+          primitive->tag == PRIM_CHPL_COMM_ARRAY_GET) {
+        GenRet eltSize = codegenSizeof(dt->typeInfo());
+        size = codegenMul(eltSize, len);
+      } else {
+        size = len;
+      }
+
       if (!fLLVMWideOpt ){
-        codegenCall(fn, codegenCastToVoidStar(localAddr), locale, remoteAddr, 
-            eltSize,genTypeStructureIndex(dt), len,
-            get(5), get(6));
+        codegenCall(fn, codegenCastToVoidStar(localAddr), locale, remoteAddr,
+                    size, genTypeStructureIndex(dt), get(5), get(6));
       } else {
         // Figure out the locale-struct value to put into the wide address
         // (instead of just using the node number)
@@ -5194,30 +5200,19 @@ GenRet CallExpr::codegen() {
           localAddr = codegenRaddr( localAddr );
 
         if (primitive->tag == PRIM_CHPL_COMM_GET) {
-          codegenCallMemcpy(localAddr, 
+          codegenCallMemcpy(localAddr,
                             codegenAddrOf(codegenWideAddr(lc, remoteAddr)),
-                            codegenMul(eltSize, len), NULL);
+                            size, NULL);
         } else {
           codegenCallMemcpy(codegenAddrOf(codegenWideAddr(lc, remoteAddr)),
-                            localAddr, 
-                            codegenMul(eltSize, len), NULL);
+                            localAddr, size, NULL);
         }
       }
       break;
     }
     case PRIM_CHPL_COMM_REMOTE_PREFETCH: {
       // args are:
-      //   locale, remote addr, (eltSize), get(3)==length, line, file
-
-      TypeSymbol *dt;
-      // Get the element type.
-      if (get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
-        Symbol *sym = get(2)->typeInfo()->getField("addr", true);
-        INT_ASSERT(sym);
-        dt = sym->typeInfo()->getValType()->symbol;
-      } else {
-        dt = get(2)->typeInfo()->getValType()->symbol;
-      }
+      //   locale, remote addr, get(3)==size, line, file
 
       // Get the locale
       GenRet locale;
@@ -5238,15 +5233,14 @@ GenRet CallExpr::codegen() {
           remoteAddr = codegenAddrOf(remoteAddr);
         }
       }
-      GenRet eltSize = codegenSizeof(dt->typeInfo());
       GenRet len;
       if( get(3)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_REF) ) {
         len = codegenValue(codegenDeref(get(3)));
       } else {
         len = codegenValue(get(3));
       }
-      codegenCall("chpl_gen_comm_prefetch", locale, remoteAddr, 
-          eltSize, genTypeStructureIndex(dt), len, get(4), get(5));
+      codegenCall("chpl_gen_comm_prefetch", locale, remoteAddr, len, -1, get(4),
+                  get(5));
       break;
     }
       //Strided versions of get and put

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -520,6 +520,8 @@ initPrimitive() {
 
   prim_def(PRIM_CHPL_COMM_GET, "chpl_comm_get", returnInfoVoid, true, true);
   prim_def(PRIM_CHPL_COMM_PUT, "chpl_comm_put", returnInfoVoid, true, true);
+  prim_def(PRIM_CHPL_COMM_ARRAY_GET, "chpl_comm_array_get", returnInfoVoid, true, true);
+  prim_def(PRIM_CHPL_COMM_ARRAY_PUT, "chpl_comm_array_put", returnInfoVoid, true, true);
   prim_def(PRIM_CHPL_COMM_REMOTE_PREFETCH, "chpl_comm_remote_prefetch", returnInfoVoid, true, true);
   prim_def(PRIM_CHPL_COMM_GET_STRD, "chpl_comm_get_strd", returnInfoVoid, true, true);
   prim_def(PRIM_CHPL_COMM_PUT_STRD, "chpl_comm_put_strd", returnInfoVoid, true, true);

--- a/compiler/include/primitive.h
+++ b/compiler/include/primitive.h
@@ -151,6 +151,8 @@ enum PrimitiveTag {
 
   PRIM_CHPL_COMM_GET,           // Direct calls to the Chapel comm layer
   PRIM_CHPL_COMM_PUT,           // may eventually add others (e.g., non-blocking)
+  PRIM_CHPL_COMM_ARRAY_GET,
+  PRIM_CHPL_COMM_ARRAY_PUT,
   PRIM_CHPL_COMM_REMOTE_PREFETCH,
   PRIM_CHPL_COMM_GET_STRD,      // Direct calls to the Chapel comm layer for strided comm
   PRIM_CHPL_COMM_PUT_STRD,      //  may eventually add others (e.g., non-blocking)

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -398,6 +398,8 @@ static bool isUse(SymExpr* se)
       return false;
      case PRIM_CHPL_COMM_GET:
      case PRIM_CHPL_COMM_PUT:
+     case PRIM_CHPL_COMM_ARRAY_GET:
+     case PRIM_CHPL_COMM_ARRAY_PUT:
      case PRIM_CHPL_COMM_GET_STRD:
      case PRIM_CHPL_COMM_PUT_STRD:
       // ('comm_get/put' locAddr locale widePtr len)

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -192,6 +192,8 @@ isFastPrimitive(CallExpr *call, bool isLocal) {
 
   case PRIM_CHPL_COMM_GET:
   case PRIM_CHPL_COMM_PUT:
+  case PRIM_CHPL_COMM_ARRAY_GET:
+  case PRIM_CHPL_COMM_ARRAY_PUT:
   case PRIM_CHPL_COMM_REMOTE_PREFETCH:
   case PRIM_CHPL_COMM_GET_STRD:
   case PRIM_CHPL_COMM_PUT_STRD:

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -766,6 +766,7 @@ static void addKnownWides() {
       }
     }
     else if (call->isPrimitive(PRIM_HEAP_REGISTER_GLOBAL_VAR) ||
+             call->isPrimitive(PRIM_CHPL_COMM_ARRAY_GET) ||
              call->isPrimitive(PRIM_CHPL_COMM_GET)) { // TODO: Is this necessary?
       for_actuals(actual, call) {
         if (SymExpr* se = toSymExpr(actual)) {

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1495,7 +1495,7 @@ proc BlockArr.doiBulkTransfer(B) {
           // once that is fixed.
           var dest = myLocArr.myElems._value.theData;
           const src = B._value.locArr[rid].myElems._value.theData;
-          __primitive("chpl_comm_get",
+          __primitive("chpl_comm_array_get",
                       __primitive("array_get", dest,
                                   myLocArr.myElems._value.getDataIndex(lo)),
                       rid,
@@ -1518,7 +1518,7 @@ proc BlockArr.doiBulkTransfer(B) {
                                         );
           var dest = myLocArr.myElems._value.theData;
           const src = B._value.locArr[rid].myElems._value.theData;
-          __primitive("chpl_comm_get",
+          __primitive("chpl_comm_array_get",
                       __primitive("array_get", dest,
                                   myLocArr.myElems._value.getDataIndex(lo)),
                       dom.dist.targetLocales(rid).id,

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -331,11 +331,11 @@ module ChapelLocale {
       // We must directly implement a bulk copy here, as the mechanisms
       // for doing so via a whole array assignment are not initialized
       // yet and copying element-by-element via a for loop is is costly.
-      __primitive("chpl_comm_get",
+      __primitive("chpl_comm_array_get",
                   __primitive("array_get", newRL, 0),
                   0 /* locale 0 */,
                   __primitive("array_get", origRL, 0), 
-                  numLocales.safeCast(size_t));
+                  numLocales:size_t);
       // Set the rootLocale to the local copy
       rootLocale = newRootLocale;
     }

--- a/modules/internal/ChapelLocale_forDocs.chpl
+++ b/modules/internal/ChapelLocale_forDocs.chpl
@@ -433,7 +433,7 @@ module ChapelLocale {
       // We must directly implement a bulk copy here, as the mechanisms
       // for doing so via a whole array assignment are not initialized
       // yet and copying element-by-element via a for loop is is costly.
-      __primitive("chpl_comm_get",
+      __primitive("chpl_comm_array_get",
                   __primitive("array_get", newRL, 0),
                   0 /* locale 0 */,
                   __primitive("array_get", origRL, 0), 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1254,7 +1254,7 @@ module DefaultRectangular {
       const dest = this.theData;
       const src = B._value.theData;
       if dest != src {
-        __primitive("chpl_comm_get",
+        __primitive("chpl_comm_array_get",
                   __primitive("array_get", dest, getDataIndex(Alo)),
                   B._value.data.locale.id,
                   __primitive("array_get", src, B._value.getDataIndex(Blo)),
@@ -1265,7 +1265,7 @@ module DefaultRectangular {
         writeln("\tlocal put() to ", this.locale.id);
       const dest = this.theData;
       const src = B._value.theData;
-      __primitive("chpl_comm_put",
+      __primitive("chpl_comm_array_put",
                   __primitive("array_get", src, B._value.getDataIndex(Blo)),
                   this.data.locale.id,
                   __primitive("array_get", dest, getDataIndex(Alo)),
@@ -1275,7 +1275,7 @@ module DefaultRectangular {
         writeln("\tremote get() on ", here.id, " from ", B.locale.id);
       const dest = this.theData;
       const src = B._value.theData;
-      __primitive("chpl_comm_get",
+      __primitive("chpl_comm_array_get",
                   __primitive("array_get", dest, getDataIndex(Alo)),
                   B._value.data.locale.id,
                   __primitive("array_get", src, B._value.getDataIndex(Blo)),

--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -64,13 +64,13 @@ void chpl_cache_release(int ln, c_string fn)
 // These are the functions that the generated code should be eventually
 // calling on a put or a get.
 void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                         size_t elemSize, int32_t typeIndex, size_t len,
+                         size_t size, int32_t typeIndex,
                          int ln, c_string fn);
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                         size_t elemSize, int32_t typeIndex, size_t len,
+                         size_t size, int32_t typeIndex,
                          int ln, c_string fn);
 void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
-                              size_t elemSize, int32_t typeIndex, size_t len,
+                              size_t size, int32_t typeIndex,
                               int ln, c_string fn);
 void  chpl_cache_comm_get_strd(
                    void *addr, void *dststr, c_nodeid_t node, void *raddr,

--- a/runtime/include/chpl-comm-compiler-llvm-support.h
+++ b/runtime/include/chpl-comm-compiler-llvm-support.h
@@ -40,7 +40,7 @@ void chpl_gen_comm_get_ctl(void *dst_addr, wide_ptr_t src, int64_t n, int64_t ct
 {
   c_nodeid_t src_node = chpl_wide_ptr_get_node(src);
   void* src_addr = chpl_wide_ptr_get_address(src);
-  chpl_gen_comm_get(dst_addr, src_node, src_addr, sizeof(uint8_t), CHPL_TYPE_uint8_t, n, -1, "");
+  chpl_gen_comm_get(dst_addr, src_node, src_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, -1, "");
 }
 
 static inline
@@ -48,7 +48,7 @@ void chpl_gen_comm_put_ctl(wide_ptr_t dst, void *src_addr, int64_t n, int64_t ct
 {
   c_nodeid_t dst_node = chpl_wide_ptr_get_node(dst);
   void* dst_addr = chpl_wide_ptr_get_address(dst);
-  chpl_gen_comm_put(src_addr, dst_node, dst_addr, sizeof(uint8_t), CHPL_TYPE_uint8_t, n, -1, "");
+  chpl_gen_comm_put(src_addr, dst_node, dst_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, -1, "");
 }
 
 // This function implements memcpy/memmove when both the source and destination

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -42,32 +42,31 @@
 
 static inline
 void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                       size_t elemSize, int32_t typeIndex, size_t len,
+                       size_t size, int32_t typeIndex,
                        int ln, c_string fn)
 {
   if (chpl_nodeID == node) {
-    chpl_memcpy(addr, raddr, elemSize*len);
+    chpl_memcpy(addr, raddr, size);
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_get(addr, node, raddr, elemSize, typeIndex, len, ln, fn);
+    chpl_cache_comm_get(addr, node, raddr, size, typeIndex, ln, fn);
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_GET
-    chpl_task_comm_get(addr, node, raddr, elemSize, typeIndex, len, ln, fn);
+    chpl_task_comm_get(addr, node, raddr, size, typeIndex, ln, fn);
 #else
-    chpl_comm_get(addr, node, raddr, elemSize, typeIndex, len, ln, fn);
+    chpl_comm_get(addr, node, raddr, size, typeIndex, ln, fn);
 #endif
   }
 }
 
 static inline
 void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
-                            size_t elemSize, int32_t typeIndex, size_t len,
+                            size_t size, int32_t typeIndex,
                             int ln, c_string fn)
 {
   const size_t MAX_BYTES_LOCAL_PREFETCH = 1024;
   size_t offset;
-  size_t size = elemSize*len;
 
   if (chpl_nodeID == node) {
     // Prefetch only the first part since we don't want to blow
@@ -79,7 +78,7 @@ void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
     }
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_prefetch(node, raddr, elemSize, typeIndex, len, ln, fn);
+    chpl_cache_comm_prefetch(node, raddr, size, typeIndex, ln, fn);
 #endif
   } else {
     // Can't do anything if we don't have a remote data cache
@@ -90,20 +89,20 @@ void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
 
 static inline
 void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                       size_t elemSize, int32_t typeIndex, size_t len,
+                       size_t size, int32_t typeIndex,
                        int ln, c_string fn)
 {
   if (chpl_nodeID == node) {
-    chpl_memcpy(raddr, addr, elemSize*len);
+    chpl_memcpy(raddr, addr, size);
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_put(addr, node, raddr, elemSize, typeIndex, len, ln, fn);
+    chpl_cache_comm_put(addr, node, raddr, size, typeIndex, ln, fn);
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_PUT
-    chpl_task_comm_put(addr, node, raddr, elemSize, typeIndex, len, ln, fn);
+    chpl_task_comm_put(addr, node, raddr, size, typeIndex, ln, fn);
 #else
-    chpl_comm_put(addr, node, raddr, elemSize, typeIndex, len, ln, fn);
+    chpl_comm_put(addr, node, raddr, size, typeIndex, ln, fn);
 #endif
   }
 }

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -81,17 +81,15 @@ extern const int chpl_heterogeneous;
 // wait for the GET to complete. The destination buffer must not be modified
 // before the request completes (after waiting on the returned handle)
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
-                                     size_t elemSize, int32_t typeIndex,
-                                     size_t len,
-                                     int ln, c_string fn);
+                                       size_t size, int32_t typeIndex,
+                                       int ln, c_string fn);
 
 // Do a PUT in a nonblocking fashion, returning a handle which can be used to
 // wait for the PUT to complete. The source buffer must not be modified before
 // the request completes (after waiting on the returned handle)
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
-                                    size_t elemSize, int32_t typeIndex,
-                                    size_t len,
-                                    int ln, c_string fn);
+                                       size_t size, int32_t typeIndex,
+                                       int ln, c_string fn);
 
 // Returns nonzero iff the handle has already been waited for and has
 // been cleared out in a call to chpl_comm_{wait,try}_some.
@@ -261,7 +259,7 @@ void chpl_comm_exit(int all, int status);
 //   size and locale are part of p
 //
 void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                    size_t elemSize, int32_t typeIndex, size_t len,
+                    size_t size, int32_t typeIndex,
                     int ln, c_string fn);
 
 //
@@ -272,7 +270,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 //   size and locale are part of p
 //
 void  chpl_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                    size_t elemSize, int32_t typeIndex, size_t len,
+                    size_t size, int32_t typeIndex,
                     int ln, c_string fn);
 
 //
@@ -307,8 +305,8 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, int32_t srclocale,
 // a locally-allocated char[] and the locale field is set to "here".
 // The local char[] buffer is leaked. :(
 //
-void chpl_gen_comm_wide_string_get(void* addr,
-  c_nodeid_t node, void* raddr, size_t elemSize, int32_t typeIndex, size_t len,
+void chpl_gen_comm_wide_string_get(void *addr, c_nodeid_t node, void *raddr,
+                                   size_t size, int32_t typeIndex,
                                    int ln, c_string fn);
 
 //

--- a/runtime/include/chpl-visual-debug.h
+++ b/runtime/include/chpl-visual-debug.h
@@ -52,19 +52,19 @@ extern void chpl_vdebug_mark(void);
 
 //  communication logging routines 
 void chpl_vdebug_log_put_nb(void *addr, c_nodeid_t node, void* raddr,
-                            int32_t elemSize, int32_t typeIndex,
-                            int32_t len, int ln, c_string fn);
+                            size_t size, int32_t typeIndex,
+                            int ln, c_string fn);
 
 void chpl_vdebug_log_get_nb(void* addr, c_nodeid_t node, void* raddr,
-                            int32_t elemSize, int32_t typeIndex,
-                            int32_t len, int ln, c_string fn);
+                            size_t size, int32_t typeIndex,
+                            int ln, c_string fn);
 
 void chpl_vdebug_log_put(void* addr, c_nodeid_t node, void* raddr,
-                         int32_t elemSize, int32_t typeIndex, int32_t len,
+                         size_t size, int32_t typeIndex,
                          int ln, c_string fn);
 
 void chpl_vdebug_log_get(void* addr, c_nodeid_t node, void* raddr,
-                         int32_t elemSize, int32_t typeIndex, int32_t len,
+                         size_t size, int32_t typeIndex,
                          int ln, c_string fn);
 
 void  chpl_vdebug_log_put_strd(void* dstaddr, void* dststrides, c_nodeid_t dstnode_id,

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -1727,12 +1727,11 @@ void flush_entry(struct rdcache_s* cache, struct cache_entry_s* entry, int op,
                  page+start, entry->base.node, (void*) (entry->raddr+start),
                  (int) got_len));
 
-          handle = 
+          handle =
             chpl_comm_put_nb(page+start, /*local addr*/
                              entry->base.node,
                              (void*)(entry->raddr+start),
-                             1 /*elmsize*/, -1/*typei*/,
-                             got_len /*len*/,
+                             got_len /*size*/, -1/*typei*/,
                              -1, NULL);
 
           // Save the handle in the list of pending requests.
@@ -2475,8 +2474,8 @@ void cache_get(struct rdcache_s* cache,
 #endif
     handle = 
       chpl_comm_get_nb(page+(ra_line-ra_page), /*local addr*/
-                       node, (void*) ra_line, 1 /*elmsize*/, -1/*typei*/,
-                       ra_line_end - ra_line /*len*/,
+                       node, (void*) ra_line,
+                       ra_line_end - ra_line /*size*/, -1/*typei*/,
                        ln, fn);
 #ifdef TIME
     clock_gettime(CLOCK_REALTIME, &start_get2);
@@ -2789,13 +2788,12 @@ void chpl_cache_fence(int acquire, int release, int ln, c_string fn)
 }
 
 void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                         size_t elemSize, int32_t typeIndex, size_t len,
+                         size_t size, int32_t typeIndex,
                          int ln, c_string fn)
 {
   //printf("put len %d node %d raddr %p\n", (int) len * elemSize, node, raddr);
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
-  size_t size = elemSize*len;
   TRACE_PRINT(("%d: task %d in chpl_cache_comm_put %s:%d put %d bytes to %d:%p from %p\n", chpl_nodeID, (int) chpl_task_getId(), fn?fn:"", ln, (int) size, node, raddr, addr));
   if (chpl_verbose_comm)
     printf("%d: %s:%d: remote get from %d\n", chpl_nodeID, fn?fn:"", ln, node);
@@ -2811,13 +2809,12 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
 }
 
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                         size_t elemSize, int32_t typeIndex, size_t len,
+                         size_t size, int32_t typeIndex,
                          int ln, c_string fn)
 {
   //printf("get len %d node %d raddr %p\n", (int) len * elemSize, node, raddr);
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
-  size_t size = elemSize*len;
   TRACE_PRINT(("%d: task %d in chpl_cache_comm_get %s:%d get %d bytes from %d:%p to %p\n", chpl_nodeID, (int) chpl_task_getId(), fn?fn:"", ln, (int) size, node, raddr, addr));
   if (chpl_verbose_comm)
     printf("%d: %s:%d: remote put to %d\n", chpl_nodeID, fn?fn:"", ln, node);
@@ -2832,12 +2829,11 @@ void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
 }
 
 void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
-                              size_t elemSize, int32_t typeIndex, size_t len,
+                              size_t size, int32_t typeIndex,
                               int ln, c_string fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
-  size_t size = elemSize*len;
   TRACE_PRINT(("%d: in chpl_cache_comm_prefetch\n", chpl_nodeID));
   if (chpl_verbose_comm)
     printf("%d: %s:%d: remote prefetch from %d\n", chpl_nodeID, fn?fn:"", ln, node);

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -51,15 +51,14 @@ chpl_wide_string_copy(chpl____wide_chpl_string* x, int32_t lineno, chpl_string f
 // In chpl_comm_wide_get_string() a buffer of the right size is allocated 
 // to receive the bytes copied from the remote node.  This buffer will be leaked,
 // since no corresponding free is added to the generated code.
-void chpl_gen_comm_wide_string_get(void* addr,
-  c_nodeid_t node, void* raddr, size_t elemSize, int32_t typeIndex, size_t len,
-  int ln, chpl_string fn)
-{
+void chpl_gen_comm_wide_string_get(void *addr, c_nodeid_t node, void *raddr,
+                                   size_t size, int32_t typeIndex,
+                                   int ln, chpl_string fn) {
   // This part just copies the descriptor.
   if (chpl_nodeID == node) {
-    chpl_memcpy(addr, raddr, elemSize*len);
+    chpl_memcpy(addr, raddr, size);
   } else {
-    chpl_gen_comm_get(addr, node, raddr, elemSize, typeIndex, len, ln, fn);
+    chpl_gen_comm_get(addr, node, raddr, size, typeIndex, ln, fn);
   }
 
   // And now we copy the bytes in the string itself.
@@ -113,10 +112,10 @@ chpl_comm_wide_get_string(chpl_string* local, struct chpl_chpl____wide_chpl_stri
   if (chpl_nodeID == chpl_rt_nodeFromLocaleID(x->locale))
     chpl_memcpy(chpl_macro_tmp, x->addr, x->size);
   else
-    chpl_gen_comm_get((void*) &(*chpl_macro_tmp),
-                  chpl_rt_nodeFromLocaleID(x->locale),
-                  (void*)(x->addr),
-                  sizeof(char), tid, x->size, lineno, filename);
+    chpl_gen_comm_get((void *)&(*chpl_macro_tmp),
+                      chpl_rt_nodeFromLocaleID(x->locale), (void *)(x->addr),
+                      sizeof(char) * x->size, tid,
+                      lineno, filename);
   *local = chpl_macro_tmp;
 }
 
@@ -234,7 +233,7 @@ c_string_copy remoteStringCopy(c_nodeid_t src_locale,
   if (src_addr == NULL) return NULL;
   ret = chpl_mem_alloc(src_len+1, CHPL_RT_MD_STR_COPY_REMOTE,
                        lineno, filename);
-  chpl_gen_comm_get((void*)ret, src_locale, (void*)src_addr, sizeof(char),
-                    CHPL_TYPE_uint8_t, src_len+1, lineno, filename);
+  chpl_gen_comm_get((void*)ret, src_locale, (void*)src_addr, sizeof(char)*(src_len+1),
+                    CHPL_TYPE_uint8_t, lineno, filename);
   return (c_string)ret;
 }

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -237,21 +237,24 @@ void chpl_vdebug_pause (void) {
 
 // Routines to log data ... put here so other places can
 // just call this code to get things logged.
+// FIXME: the size argument (size_t) is being cast to int here. chplvis needs
+//        to be updated to take in size_t. The elemsize field is no longer
+//        relevant as well.
 
 // Record>  nb_put: time.sec srcNodeId dstNodeId commTaskId addr raddr elemsize 
 //                  typeIndex length lineNumber fileName
 //
 
 void chpl_vdebug_log_put_nb(void *addr, c_nodeid_t node, void* raddr,
-                            int32_t elemSize, int32_t typeIndex,
-                            int32_t len, int ln, c_string fn) {
+                            size_t size, int32_t typeIndex,
+                            int ln, c_string fn) {
   if (chpl_vdebug) {
     struct timeval tv;
     chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd, "nb_put: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  (unsigned long) commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  (unsigned long) commTask, (long) addr, (long) raddr, 1, typeIndex, (int)size,
                   ln, fn);
   }
 }
@@ -262,15 +265,15 @@ void chpl_vdebug_log_put_nb(void *addr, c_nodeid_t node, void* raddr,
 // Note: dstNodeId is node requesting Get
 
 void chpl_vdebug_log_get_nb(void* addr, c_nodeid_t node, void* raddr,
-                            int32_t elemSize, int32_t typeIndex,
-                            int32_t len, int ln, c_string fn) {
+                            size_t size, int32_t typeIndex,
+                            int ln, c_string fn) {
   if (chpl_vdebug) {
     struct timeval tv;
     chpl_taskID_t commTask = chpl_task_getId();
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd, "nb_get: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-                  (unsigned long)commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  (unsigned long)commTask, (long) addr, (long) raddr, 1, typeIndex, (int)size,
                   ln, fn);
   }
 }
@@ -280,7 +283,7 @@ void chpl_vdebug_log_get_nb(void* addr, c_nodeid_t node, void* raddr,
 
 
 void chpl_vdebug_log_put(void* addr, c_nodeid_t node, void* raddr,
-                         int32_t elemSize, int32_t typeIndex, int32_t len,
+                         size_t size, int32_t typeIndex,
                          int ln, c_string fn) {
   if (chpl_vdebug) {
     struct timeval tv;
@@ -288,7 +291,7 @@ void chpl_vdebug_log_put(void* addr, c_nodeid_t node, void* raddr,
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd, "put: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, chpl_nodeID, node,
-                  (unsigned long) commTask, (long) addr, (long) raddr, elemSize, typeIndex, len,
+                  (unsigned long) commTask, (long) addr, (long) raddr, 1, typeIndex, (int)size,
                   ln, fn);
   }
 }
@@ -299,7 +302,7 @@ void chpl_vdebug_log_put(void* addr, c_nodeid_t node, void* raddr,
 // Note:  dstNodeId is for the node makeing the request
 
 void chpl_vdebug_log_get(void* addr, c_nodeid_t node, void* raddr,
-                         int32_t elemSize, int32_t typeIndex, int32_t len,
+                         size_t size, int32_t typeIndex,
                          int ln, c_string fn) {
   if (chpl_vdebug) {
     struct timeval tv;
@@ -308,8 +311,8 @@ void chpl_vdebug_log_get(void* addr, c_nodeid_t node, void* raddr,
     chpl_dprintf (chpl_vdebug_fd,
              "get: %lld.%06ld %d %d %lu 0x%lx 0x%lx %d %d %d %d %s\n",
              (long long) tv.tv_sec, (long) tv.tv_usec,  chpl_nodeID, node,
-             (unsigned long) commTask, (long) addr, (long) raddr, elemSize,
-             typeIndex, len, ln, fn); 
+             (unsigned long) commTask, (long) addr, (long) raddr, 1,
+             typeIndex, (int)size, ln, fn); 
   }
 }
 

--- a/runtime/src/chplgmp.c
+++ b/runtime/src/chplgmp.c
@@ -57,7 +57,9 @@ void chpl_gmp_get_mpz(mpz_t ret, int64_t src_locale, __mpz_struct from)
   ret[0]._mp_size = from._mp_size;
 
   // Next, use GASNET to move the pointer data.
-  chpl_gen_comm_get( ret[0]._mp_d, src_locale, from._mp_d, sizeof(mp_limb_t), CHPL_TYPE_uint64_t, ret[0]._mp_alloc, __LINE__, __FILE__);
+  chpl_gen_comm_get(ret[0]._mp_d, src_locale, from._mp_d,
+                    sizeof(mp_limb_t) * ret[0]._mp_alloc, CHPL_TYPE_uint64_t,
+                    __LINE__, __FILE__);
 
   //gmp_printf("got %Zd\n", ret);
 }

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -320,10 +320,10 @@ void chpl_printMemAllocStats(int32_t lineno, c_string filename) {
     fprintf(memLogFile, "==============================================================\n");
     for (i = 0; i < chpl_numNodes; i++) {
       static size_t m1, m2, m3, m4;
-      chpl_gen_comm_get(&m1, i, &totalMem, sizeof(size_t), -1 /* broke for hetero */, 1, lineno, filename);
-      chpl_gen_comm_get(&m2, i, &maxMem, sizeof(size_t), -1 /* broke for hetero */, 1, lineno, filename);
-      chpl_gen_comm_get(&m3, i, &totalAllocated,  sizeof(size_t), -1 /* broke for hetero */, 1, lineno, filename);
-      chpl_gen_comm_get(&m4, i, &totalFreed, sizeof(size_t), -1 /*broke for hetero */, 1, lineno, filename);
+      chpl_gen_comm_get(&m1, i, &totalMem, sizeof(size_t), -1 /* broke for hetero */, lineno, filename);
+      chpl_gen_comm_get(&m2, i, &maxMem, sizeof(size_t), -1 /* broke for hetero */, lineno, filename);
+      chpl_gen_comm_get(&m3, i, &totalAllocated,  sizeof(size_t), -1 /* broke for hetero */, lineno, filename);
+      chpl_gen_comm_get(&m4, i, &totalFreed, sizeof(size_t), -1 /*broke for hetero */, lineno, filename);
       fprintf(memLogFile, "%-9d  %-9zu  %-9zu  %-9zu  %-9zu\n", i, m1, m2, m3, m4);
     }
     fprintf(memLogFile, "==============================================================\n");

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -55,22 +55,20 @@ static int mysystem(const char* command, const char* description,
 
 // Chapel interface
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
-                                       size_t elemSize, int32_t typeIndex,
-                                       size_t len,
+                                       size_t size, int32_t typeIndex,
                                        int ln, c_string fn)
 {
   assert(node == 0);
-  chpl_memcpy(raddr, addr, len*elemSize);
+  chpl_memcpy(raddr, addr, size);
   return NULL;
 }
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
-                                       size_t elemSize, int32_t typeIndex,
-                                       size_t len,
+                                       size_t size, int32_t typeIndex,
                                        int ln, c_string fn)
 {
   assert(node == 0);
-  chpl_memcpy(addr, raddr, len*elemSize);
+  chpl_memcpy(addr, raddr, size);
   return NULL;
 }
 
@@ -148,19 +146,19 @@ void chpl_comm_pre_task_exit(int all) { }
 void chpl_comm_exit(int all, int status) { }
 
 void  chpl_comm_put(void* addr, int32_t locale, void* raddr,
-                    size_t size, int32_t typeIndex, size_t len,
+                    size_t size, int32_t typeIndex,
                     int ln, c_string fn) {
   assert(locale==0);
 
-  memmove(raddr, addr, size*len);
+  memmove(raddr, addr, size);
 }
 
 void  chpl_comm_get(void* addr, int32_t locale, void* raddr,
-                    size_t size, int32_t typeIndex, size_t len,
+                    size_t size, int32_t typeIndex,
                     int ln, c_string fn) {
   assert(locale==0);
 
-  memmove(addr, raddr, size*len);
+  memmove(addr, raddr, size);
 }
 
 void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,

--- a/runtime/src/qio/bulkget.c
+++ b/runtime/src/qio/bulkget.c
@@ -37,7 +37,7 @@ qbytes_t* bulk_get_bytes(int64_t src_locale, qbytes_t* src_addr)
   memset(&tmp, 0, sizeof(qbytes_t));
 
   // First, get the length and local pointer to the bytes.
-  chpl_gen_comm_get( &tmp, src_locale, src_addr, sizeof(qbytes_t), CHPL_TYPE_int64_t, 1, -1, "<internal>");
+  chpl_gen_comm_get( &tmp, src_locale, src_addr, sizeof(qbytes_t), CHPL_TYPE_int64_t, -1, "<internal>");
   src_len = tmp.len;
   src_data = tmp.data;
 
@@ -50,7 +50,7 @@ qbytes_t* bulk_get_bytes(int64_t src_locale, qbytes_t* src_addr)
 
   // Next, get the data itself.
   if( src_data ) {
-    chpl_gen_comm_get( ret->data, src_locale, src_data, sizeof(uint8_t), CHPL_TYPE_uint8_t, src_len, -1, "<internal>");
+    chpl_gen_comm_get( ret->data, src_locale, src_data, sizeof(uint8_t)*src_len, CHPL_TYPE_uint8_t, -1, "<internal>");
   }
 
   // Great! All done.
@@ -86,8 +86,7 @@ qioerr bulk_put_buffer(int64_t dst_locale, void* dst_addr, int64_t dst_len,
     chpl_gen_comm_put( iov[i].iov_base,
                        dst_locale,
                        PTR_ADDBYTES(dst_addr, j),
-                       sizeof(uint8_t), CHPL_TYPE_uint8_t,
-                       iov[i].iov_len,
+                       sizeof(uint8_t)*iov[i].iov_len, CHPL_TYPE_uint8_t,
                        -1, "<internal>" );
 
     j += iov[i].iov_len;

--- a/test/optimizations/sungeun/bulk_transfer/chpl_comm_get.chpl
+++ b/test/optimizations/sungeun/bulk_transfer/chpl_comm_get.chpl
@@ -5,7 +5,7 @@ var A: [1..n] int = 777;
 var B: [1..n] int = -1;
 var Ad = A._value.theData;
 var Bd = B._value.theData;
-__primitive("chpl_comm_get",
+__primitive("chpl_comm_array_get",
             __primitive("array_get", Bd, B._value.getDataIndex(1)),
             0,
             __primitive("array_get", Ad, A._value.getDataIndex(1)),
@@ -18,7 +18,7 @@ for i in B.domain do
 on Locales(numLocales-1) {
   var C: [1..n] int = -1;
   var Cd = C._value.theData;
-  __primitive("chpl_comm_get",
+  __primitive("chpl_comm_array_get",
               __primitive("array_get", Cd, C._value.getDataIndex(1)),
               0,
               __primitive("array_get", Ad, A._value.getDataIndex(1)),
@@ -36,7 +36,7 @@ on Locales(numLocales-1) {
   on Locales(0) {
     var E: [1..n] int = -1;
     var Ed = E._value.theData;
-    __primitive("chpl_comm_get",
+    __primitive("chpl_comm_array_get",
                 __primitive("array_get", Ed, E._value.getDataIndex(1)),
                 numLocales-1,
                 __primitive("array_get", Dd, D._value.getDataIndex(1)),

--- a/test/optimizations/sungeun/bulk_transfer/chpl_comm_put.chpl
+++ b/test/optimizations/sungeun/bulk_transfer/chpl_comm_put.chpl
@@ -5,7 +5,7 @@ var A: [1..n] int = 777;
 var B: [1..n] int = -1;
 var Ad = A._value.theData;
 var Bd = B._value.theData;
-__primitive("chpl_comm_put",
+__primitive("chpl_comm_array_put",
             __primitive("array_get", Ad, A._value.getDataIndex(1)),
             0,
             __primitive("array_get", Bd, B._value.getDataIndex(1)),
@@ -19,7 +19,7 @@ on Locales(numLocales-1) {
   var C: [1..n] int = -1;
   var Cd = C._value.theData;
   on Locales(0) {
-    __primitive("chpl_comm_put",
+    __primitive("chpl_comm_array_put",
                 __primitive("array_get", Ad, A._value.getDataIndex(1)),
                 numLocales-1,
                 __primitive("array_get", Cd, C._value.getDataIndex(1)),
@@ -39,7 +39,7 @@ on Locales(numLocales-1) {
     var E: [1..n] int = -1;
     var Ed = E._value.theData;
     on Locales(numLocales-1) {
-      __primitive("chpl_comm_put",
+      __primitive("chpl_comm_array_put",
                   __primitive("array_get", Dd, D._value.getDataIndex(1)),
                   0,
                   __primitive("array_get", Ed, E._value.getDataIndex(1)),


### PR DESCRIPTION
This change was motivated by my work on strings, PRIM_CHPL_COMM_GET/PUT
would perform a sizeof behind the scenes that was causing me to request
8x the amount of memory I thought I was. After this patch
chpl_comm_get, chpl_comm_put, and similar functions just take in the
number of bytes to use rather than an element size and count.

PRIM_CHPL_COMM_GET/PUT no longer performs a sizeof, if the old behavior
is needed use the new PRIM_CHPL_COMM_ARRAY_GET/PUT. These new primitives
work just like the old ones used to and are suited for use in bulk array
transfer.