### PR TITLE
Fix tests for ChapelEnv Module

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -29,6 +29,7 @@
 
 class Timer;
 
+bool useDefaultEnv(std::string key);
 
 extern int  instantiation_limit;
 

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -29,8 +29,6 @@
 
 class Timer;
 
-bool useDefaultEnv(std::string key);
-
 extern int  instantiation_limit;
 
 // optimization control flags
@@ -72,6 +70,8 @@ extern int  tuple_copy_limit;
 extern bool report_inlining;
 
 // Chapel Envs
+bool useDefaultEnv(std::string key);
+
 extern std::map<std::string, const char*> envMap;
 
 extern char CHPL_HOME[FILENAME_MAX+1];

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -344,7 +344,7 @@ static void setHome(const ArgumentDescription* desc, const char* arg) {
 
   // Copy arg into CHPL_HOME
   size_t arglen = strlen(arg) + 1; // room for \0
-  if( arglen <= sizeof(CHPL_HOME) ) {
+  if (arglen <= sizeof(CHPL_HOME)) {
     memcpy(CHPL_HOME, arg, arglen);
     // Update envMap
     envMap["CHPL_HOME"] = CHPL_HOME;
@@ -571,7 +571,7 @@ static void setWarnSpecial(const ArgumentDescription* desc, const char* unused) 
 static void setPrintPassesFile(const ArgumentDescription* desc, const char* fileName) {
   printPassesFile = fopen(fileName, "w");
 
-  if(printPassesFile == NULL) {
+  if (printPassesFile == NULL) {
     USR_WARN("Error opening printPassesFile: %s.", fileName);
   }
 }
@@ -859,13 +859,13 @@ bool useDefaultEnv(std::string key) {
   // For Cray programming environments, we must infer CHPL_TARGET_ARCH
   // Note: When CHPL_TARGET_ARCH is processed, CHPL_HOST_COMPILER is already
   // set in envMap, due to the order of printchplenv output
-  if(key == "CHPL_TARGET_ARCH") {
-    if(strstr(envMap["CHPL_TARGET_COMPILER"], "cray-prgenv") != NULL) {
+  if (key == "CHPL_TARGET_ARCH") {
+    if (strstr(envMap["CHPL_TARGET_COMPILER"], "cray-prgenv") != NULL) {
       return true;
     }
   }
   // CHPL_THREADS should always be inferred
-  else if(key == "CHPL_THREADS") {
+  else if (key == "CHPL_THREADS") {
     return true;
   }
 
@@ -909,9 +909,9 @@ static void populateEnvMap() {
     value = line.substr(valuePos);
 
     // If key does not have a value in envMap, map it to the parsed value
-    if(envMap.find(key) == envMap.end()) {
+    if (envMap.find(key) == envMap.end()) {
       envMap[key] = strdup(value.c_str());
-    } else if(useDefaultEnv(key)) {
+    } else if (useDefaultEnv(key)) {
       envMap.erase(key);
       envMap[key] = strdup(value.c_str());
     }
@@ -952,7 +952,7 @@ static void setupChplGlobals(const char* argv0) {
   // Set CHPL_HOME, populate envMap with defaults, and set global CHPL_vars
 
   // Set CHPL_HOME the traditional way if it was not passed as an argument
-  if( envMap.find("CHPL_HOME") == envMap.end() )
+  if (envMap.find("CHPL_HOME") == envMap.end())
   {
     setupChplHome(argv0);
 
@@ -1004,7 +1004,7 @@ static void setMaxCIndentLen() {
 }
 
 static void setWidePointersStruct() {
-  if( 0 == strcmp(CHPL_WIDE_POINTERS, "struct") ) {
+  if (0 == strcmp(CHPL_WIDE_POINTERS, "struct")) {
     widePointersStruct = true;
   } else {
     widePointersStruct = false;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -853,15 +853,20 @@ static void printStuff(const char* argv0) {
   }
 }
 
-static bool useDefaultEnv(std::string key) {
+bool useDefaultEnv(std::string key) {
   // Check conditions for which default value should override argument provided
 
-  // For Cray programming environments, we must infer target_arch from default
-  // Note: When CHPL_TARGET_ARCH is processed, CHPL_HOST_COMPILER is already set in envMap, due to the order of printchplenv output 
+  // For Cray programming environments, we must infer CHPL_TARGET_ARCH
+  // Note: When CHPL_TARGET_ARCH is processed, CHPL_HOST_COMPILER is already
+  // set in envMap, due to the order of printchplenv output
   if(key == "CHPL_TARGET_ARCH") {
-    if(strstr(envMap["CHPL_HOST_COMPILER"], "cray-prgenv") != NULL) {
+    if(strstr(envMap["CHPL_TARGET_COMPILER"], "cray-prgenv") != NULL) {
       return true;
     }
+  }
+  // CHPL_THREADS should always be inferred
+  else if(key == "CHPL_THREADS") {
+    return true;
   }
 
   return false;

--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -321,6 +321,7 @@ int processNewline(yyscan_t scanner) {
 void stringBufferInit() {
   if (stringBuffer == NULL) {
     stringBuffer  = (char*) malloc(1024);
+    stringBuffer[0] = "\0";
   }
 }
 

--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -321,7 +321,7 @@ int processNewline(yyscan_t scanner) {
 void stringBufferInit() {
   if (stringBuffer == NULL) {
     stringBuffer  = (char*) malloc(1024);
-    stringBuffer[0] = "\0";
+    stringBuffer[0] = '\0';
   }
 }
 

--- a/compiler/parser/flex-chapel.cpp
+++ b/compiler/parser/flex-chapel.cpp
@@ -3009,6 +3009,7 @@ int processNewline(yyscan_t scanner) {
 void stringBufferInit() {
   if (stringBuffer == NULL) {
     stringBuffer  = (char*) malloc(1024);
+    stringBuffer[0] = "\0";
   }
 }
 

--- a/compiler/parser/flex-chapel.cpp
+++ b/compiler/parser/flex-chapel.cpp
@@ -3009,7 +3009,7 @@ int processNewline(yyscan_t scanner) {
 void stringBufferInit() {
   if (stringBuffer == NULL) {
     stringBuffer  = (char*) malloc(1024);
-    stringBuffer[0] = "\0";
+    stringBuffer[0] = '\0';
   }
 }
 

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -585,6 +585,7 @@ static void codegen_header_compilation_config() {
 
     genGlobalString("chpl_compileCommand", compileCommand);
     genGlobalString("chpl_compileVersion", compileVersion);
+    genGlobalString("CHPL_HOME",           CHPL_HOME);
 
     genGlobalInt("CHPL_STACK_CHECKS", !fNoStackChecks);
     genGlobalInt("CHPL_CACHE_REMOTE", fCacheRemote);
@@ -605,6 +606,7 @@ static void codegen_header_compilation_config() {
             CHPL_HOME);
     for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
       if (env->first != "CHPL_HOME") {
+        genGlobalString(env->first.c_str(), env->second);
         fprintf(cfgfile.fptr,
           "printf(\"%%s\", \"  %s: %s\\n\");\n",
           env->first.c_str(),

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -590,6 +590,12 @@ static void codegen_header_compilation_config() {
     genGlobalInt("CHPL_STACK_CHECKS", !fNoStackChecks);
     genGlobalInt("CHPL_CACHE_REMOTE", fCacheRemote);
 
+    for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
+      if (env->first != "CHPL_HOME" && !useDefaultEnv(env->first)) {
+        genGlobalString(env->first.c_str(), env->second);
+      }
+    }
+
     // generate the "about" function
     fprintf(cfgfile.fptr, "\nvoid chpl_program_about(void);\n");
     fprintf(cfgfile.fptr, "\nvoid chpl_program_about() {\n");
@@ -606,7 +612,6 @@ static void codegen_header_compilation_config() {
             CHPL_HOME);
     for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
       if (env->first != "CHPL_HOME") {
-        genGlobalString(env->first.c_str(), env->second);
         fprintf(cfgfile.fptr,
           "printf(\"%%s\", \"  %s: %s\\n\");\n",
           env->first.c_str(),

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -435,7 +435,8 @@ std::string runPrintChplEnv(std::map<std::string, const char*> varMap) {
     command += ii->first + "=" + std::string(ii->second) + " ";
   }
 
-  command += std::string(CHPL_HOME) + "/util/printchplenv --simple";
+  // We don't want stderr until printchplenv supports a --suppresswarnings flag
+  command += std::string(CHPL_HOME) + "/util/printchplenv --simple 2> /dev/null";
 
   return runCommand(command);
 }

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -555,11 +555,10 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname, bool skip_com
   fprintf(makefile.fptr, "TMPDIRNAME = %s\n\n", tmpDirName);
 
   // Generate one variable containing all envMap information to pass to printchplenv
-  for( std::map<std::string, const char*>::iterator ii=envMap.begin(); ii!=envMap.end(); ++ii)
+  for( std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env)
   {
-    // Avoid passing CHPL_THREADS because printchplenv will throw warning
-    if (ii->first != "CHPL_THREADS") {
-      chplmakeallvars += ii->first + "=" + std::string(ii->second) + " ";
+    if(!useDefaultEnv(env->first)) {
+      chplmakeallvars += env->first + "=" + std::string(env->second) + " ";
     }
   }
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -430,12 +430,12 @@ std::string runPrintChplEnv(std::map<std::string, const char*> varMap) {
   std::string command = "";
 
   // Pass known variables in varMap into printchplenv by appending to command
-  for( std::map<std::string, const char*>::iterator ii=varMap.begin(); ii!=varMap.end(); ++ii)
+  for (std::map<std::string, const char*>::iterator ii=varMap.begin(); ii!=varMap.end(); ++ii)
   {
     command += ii->first + "=" + std::string(ii->second) + " ";
   }
 
-  // We don't want stderr until printchplenv supports a --suppresswarnings flag
+  // Toss stderr away until printchplenv supports a '--suppresswarnings' flag
   command += std::string(CHPL_HOME) + "/util/printchplenv --simple 2> /dev/null";
 
   return runCommand(command);
@@ -449,19 +449,19 @@ std::string runCommand(std::string& command) {
 
   // Call command
   FILE* pipe = popen(command.c_str(), "r");
-  if(!pipe) {
+  if (!pipe) {
     error = "running " + command;
     USR_FATAL(error.c_str());
   }
 
   // Read output of command into result via buffer
-  while(!feof(pipe)) {
-    if(fgets(buffer, 256, pipe) != NULL) {
+  while (!feof(pipe)) {
+    if (fgets(buffer, 256, pipe) != NULL) {
       result += buffer;
     }
   }
 
-  if(pclose(pipe)) {
+  if (pclose(pipe)) {
     error = command + " did not run successfully";
     USR_FATAL(error.c_str());
   }
@@ -555,7 +555,7 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname, bool skip_com
   fprintf(makefile.fptr, "TMPDIRNAME = %s\n\n", tmpDirName);
 
   // Generate one variable containing all envMap information to pass to printchplenv
-  for( std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env)
+  for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env)
   {
     if(!useDefaultEnv(env->first)) {
       chplmakeallvars += env->first + "=" + std::string(env->second) + " ";

--- a/test/compflags/albrecht/chplenv/generateChplEnvFiles
+++ b/test/compflags/albrecht/chplenv/generateChplEnvFiles
@@ -4,7 +4,7 @@
 # Called by chplenv.good and chplenv.compopts to dynamically create contents
 
 
-function generateGood {
+generateGood() {
     # Generate Good file from printchplenv variables
 
     printchplenv=$(../../../../util/printchplenv --simple)
@@ -21,7 +21,7 @@ function generateGood {
 }
 
 
-function generateCompopts {
+generateCompopts() {
     # Generate Compopts file from printchplenv variables
 
     printchplenv=$(../../../../util/printchplenv --simple)


### PR DESCRIPTION
This patch sets out to fix the tests that broke in nightly testing:

* No longer passing `CHPL_TARGET_ARCH` to `printchplenv` when using Cray programming environment
* Initialize first element of `stringBuffer` in `stringBufferInit()` to please the valgrind god (Odin?)
* Calling `genGlobalString` for CHPL_vars in `codegen.cpp` so that CHPL_vars are initialized in `chpl_compilation_config.c`
* Bash functions are now POSIX-compliant to please our linux32 test box.

**[ √ paratested]**