### PR TITLE
Allow re2 to be built with optimizations

### DIFF
--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -17,9 +17,11 @@ endif
 #
 ifeq ($(CHPL_MAKE_TARGET_ARCH),knc)
 ifeq ($(CHPL_MAKE_TARGET_COMPILER),intel)
-CHPL_RE2_CXXFLAGS=-mmic
+CHPL_RE2_CXXFLAGS += -mmic
 endif
 endif
+
+CHPL_RE2_CXXFLAGS += $(CFLAGS)
 
 default: all
 


### PR DESCRIPTION
re2's makefile defaults to setting -O3 in their CXXFLAGS. However, we override
CXXFLAGS but were not providing an optimization level of our own, which meant
we defaulted to whatever the backend does.

GCC and Clang do not have any optimizations on by default, so we were dropping
performance on the floor. To resolve this, this patch just adds CFLAGS to the
CXXFLAGS so that we get optimization/debug/profile/whatever flags passed along
for free. Note that this is what we do in most other 3rd party libs like hwloc
and qthreads.

This patch has a pretty dramatic improvement on performance for tests that use
re2. For regexdna on chap04, this reduces the runtime from 5.4 seconds down to
3.1 seconds.

For regexdna on the shootout box this takes us from 9.4 seconds down to 6.0
seconds. For the current shootout entries, this moves us from 20th place to
10th place. The current fastest entries are a rust version that takes 2.0
seconds followed by a 2.5 second C version.