### PR TITLE
Compflags test skip crays

### DIFF
--- a/test/compflags/albrecht/chplenv/chplenv.skipif
+++ b/test/compflags/albrecht/chplenv/chplenv.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER==cray-prgenv-*

--- a/test/compflags/albrecht/chplenv/chplenv.skipif
+++ b/test/compflags/albrecht/chplenv/chplenv.skipif
@@ -1,1 +1,4 @@
-CHPL_TARGET_COMPILER==cray-prgenv-*
+CHPL_TARGET_COMPILER==cray-prgenv-gnu
+CHPL_TARGET_COMPILER==cray-prgenv-cray
+CHPL_TARGET_COMPILER==cray-prgenv-intel
+CHPL_TARGET_COMPILER==cray-prgenv-pgi


### PR DESCRIPTION
This patch adds a skipif for the `compflags/albrecht/chplenv` test on Cray PrgEnv's because the test sets `CHPL_TARGET_ARCH` explicitly, which is disallowed by `printchplenv` (`chplenv/chpl_arch.py` specifically) when using Cray PrgEnvs.