### PR TITLE
Fix a typo in a comment

### DIFF
--- a/runtime/etc/Makefile.include
+++ b/runtime/etc/Makefile.include
@@ -41,7 +41,7 @@ endif
 ifeq ($(COMP_GEN_FLOAT_OPT), -1)
   MAKE_COMP_GEN_CFLAGS += $(IEEE_FLOAT_GEN_CFLAGS)
 endif
-# COMP_GEN_FLOAT_OPT = -1 -> IEEE lax, optimize please
+# COMP_GEN_FLOAT_OPT = 1 -> IEEE lax, optimize please
 ifeq ($(COMP_GEN_FLOAT_OPT), 1)
   MAKE_COMP_GEN_CFLAGS += $(FAST_FLOAT_GEN_CFLAGS)
 endif


### PR DESCRIPTION
This comment is about the +1 case, not -1.