### PR TITLE
Begin to integrate string-as-rec changes to master

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -231,6 +231,9 @@ bool Symbol::isImmediate() const {
   return false;
 }
 
+bool isString(Symbol* symbol) {
+  return isString(symbol->type);
+}
 
 /******************************** | *********************************
 *                                                                   *

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1938,34 +1938,46 @@ bool isSubClass(Type* type, Type* baseType)
   return false;
 }
 
-bool
-isDistClass(Type* type) {
+bool isDistClass(Type* type) {
   if (type->symbol->hasFlag(FLAG_BASE_DIST))
     return true;
+
   forv_Vec(Type, pt, type->dispatchParents)
     if (isDistClass(pt))
       return true;
+
   return false;
 }
 
-bool
-isDomainClass(Type* type) {
+bool isDomainClass(Type* type) {
   if (type->symbol->hasFlag(FLAG_BASE_DOMAIN))
     return true;
+
   forv_Vec(Type, pt, type->dispatchParents)
     if (isDomainClass(pt))
       return true;
+
   return false;
 }
 
-bool
-isArrayClass(Type* type) {
+bool isArrayClass(Type* type) {
   if (type->symbol->hasFlag(FLAG_BASE_ARRAY))
     return true;
+
   forv_Vec(Type, t, type->dispatchParents)
     if (isArrayClass(t))
       return true;
+
   return false;
+}
+
+bool isString(Type* type) {
+  bool retval = false;
+
+  if (AggregateType* aggr = toAggregateType(type))
+    retval = strcmp(aggr->symbol->name, "string") == 0;
+
+  return retval;
 }
 
 static Vec<TypeSymbol*> typesToStructurallyCodegen;

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -106,6 +106,7 @@ symbolFlag( FLAG_FUNCTION_PROTOTYPE , npr, "function prototype" , "signature for
 symbolFlag( FLAG_GENERIC , npr, "generic" , "generic types, functions and arguments" )
 symbolFlag( FLAG_GLOBAL_TYPE_SYMBOL, npr, "global type symbol", "is accessible through a global type variable")
 symbolFlag( FLAG_HAS_RUNTIME_TYPE , ypr, "has runtime type" , "type that has an associated runtime type" )
+symbolFlag( FLAG_RVV, npr, "RVV", "variable is the return value variable" )
 symbolFlag( FLAG_HEAP , npr, "heap" , ncm )
 symbolFlag( FLAG_IMPLICIT_ALIAS_FIELD , npr, "implicit alias field" , ncm )
 symbolFlag( FLAG_INDEX_VAR , npr, "index var" , ncm )

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -152,6 +152,8 @@ private:
 
 #define forv_Symbol(_p, _v) forv_Vec(Symbol, _p, _v)
 
+bool isString(Symbol* symbol);
+
 /******************************** | *********************************
 *                                                                   *
 * This class has two roles:                                         *

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -308,6 +308,8 @@ bool isDistClass(Type* type);
 bool isDomainClass(Type* type);
 bool isArrayClass(Type* type);
 
+bool isString(Type* type);
+
 void registerTypeToStructurallyCodegen(TypeSymbol* type);
 GenRet genTypeStructureIndex(TypeSymbol* typesym);
 void codegenTypeStructures(FILE* hdrfile);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -648,6 +648,8 @@ static void normalize_returns(FnSymbol* fn) {
     // Handle declared return type.
     retval = newTemp("ret", fn->retType);
 
+    retval->addFlag(FLAG_RVV);
+
     if (fn->retTag == RET_PARAM)
       retval->addFlag(FLAG_PARAM);
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -575,7 +575,7 @@ returnTypeIsArray(BlockStmt* retExprType)
 
 
 // Following normalization, each function contains only one return statement
-// preceded by a label.  The first half of the function counts the 
+// preceded by a label.  The first half of the function counts the
 // total number of returns and the number of void returns.
 // The big IF beginning with if (rets.n == 1) determines if the function
 // is already normal.
@@ -589,11 +589,15 @@ static void normalize_returns(FnSymbol* fn) {
   int numVoidReturns = 0;
   int numYields = 0;
   bool isIterator = fn->isIterator();
-  collectMyCallExprs(fn, calls, fn); // ones not in a nested function
+
+  collectMyCallExprs(fn, calls, fn); // calls not in a nested function
+
   for_vector(CallExpr, call, calls) {
     if (call->isPrimitive(PRIM_RETURN)) {
       rets.add(call);
+
       theRet = call;
+
       if (is_void_return(call))
           numVoidReturns++;
     }
@@ -604,7 +608,7 @@ static void normalize_returns(FnSymbol* fn) {
   }
 
   // If an iterator, then there is at least one nonvoid return-or-yield.
-  INT_ASSERT(!isIterator || rets.n > numVoidReturns); // done in semanticChecks
+  INT_ASSERT(!isIterator || rets.n > numVoidReturns);
 
   // Check if this function's returns are already normal.
   if (rets.n - numYields == 1) {
@@ -616,25 +620,25 @@ static void normalize_returns(FnSymbol* fn) {
             !strcmp("=", fn->name) ||
             !strcmp("_init", fn->name) ||
             !strcmp("_ret", se->var->name)) {
-          return;   // Yup.
+          return;
         }
       }
     }
   }
 
   // Add a void return if needed.
-  if (rets.n == 0)
-  {
-    if (fn->retExprType == NULL)
-    {
+  if (rets.n == 0) {
+    if (fn->retExprType == NULL) {
       fn->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));
       return;
     }
   }
 
-  LabelSymbol* label = new LabelSymbol(astr("_end_", fn->name));
+  LabelSymbol* label  = new LabelSymbol(astr("_end_", fn->name));
+  VarSymbol*   retval = NULL;
+
   fn->insertAtTail(new DefExpr(label));
-  VarSymbol* retval = NULL;
+
   // If a proc has a void return, do not return any values ever.
   // (Types are not resolved yet, so we judge by presence of "void returns"
   // i.e. returns with no expr. See also a related check in semanticChecks.)
@@ -643,38 +647,51 @@ static void normalize_returns(FnSymbol* fn) {
   } else {
     // Handle declared return type.
     retval = newTemp("ret", fn->retType);
+
     if (fn->retTag == RET_PARAM)
       retval->addFlag(FLAG_PARAM);
+
     if (fn->retTag == RET_TYPE)
       retval->addFlag(FLAG_TYPE_VARIABLE);
+
     if (fn->hasFlag(FLAG_MAYBE_TYPE))
       retval->addFlag(FLAG_MAYBE_TYPE);
+
     // If the function has a specified return type (and is not a var function),
     // declare and initialize the return value up front,
     // and set the specified_return_type flag.
     if (fn->retExprType && fn->retTag != RET_REF) {
       BlockStmt* retExprType = fn->retExprType->copy();
+
       if (isIterator)
         if (SymExpr* lastRTE = toSymExpr(retExprType->body.tail))
           if (TypeSymbol* retSym = toTypeSymbol(lastRTE->var))
             if (retSym->type == dtVoid)
-              USR_FATAL_CONT(fn, "an iterator's return type cannot be 'void'; if specified, it must be the type of the expressions the iterator yields");
+              USR_FATAL_CONT(fn,
+                             "an iterator's return type cannot be 'void'; "
+                             "if specified, it must be the type of the "
+                             "expressions the iterator yields");
+
       fn->addFlag(FLAG_SPECIFIED_RETURN_TYPE);
-// I recommend a rework of function representation in the AST.
-// Because we strip type information off of variable declarations and use 
-// the type of the initializer instead, initialization is obligatory.
-// I think we should definitely heed the declared type.  
-// Then at least these two lines can go away, and other simplifications may
-// follow.
+
+      // I recommend a rework of function representation in the AST.
+      // Because we strip type information off of variable declarations and
+      // use the type of the initializer instead, initialization is obligatory.
+      // I think we should heed the declared type.
+      // Then at least these two lines can go away, and other simplifications
+      // may follow.
+
       // We do not need to do this for iterators returning arrays
-      // because it adds initialization code that is later removed.  
+      // because it adds initialization code that is later removed.
       // Also, we want arrays returned from iterators to behave like
       // references, so we add the 'var' return intent here.
       if (fn->isIterator() &&
           returnTypeIsArray(retExprType))
-        // Treat iterators returning arrays as if they are always returned by ref.
+        // Treat iterators returning arrays as if they are always returned
+        // by ref.
         fn->retTag = RET_REF;
     }
+
     fn->insertAtHead(new DefExpr(retval));
     fn->insertAtTail(new CallExpr(PRIM_RETURN, retval));
   }
@@ -682,12 +699,14 @@ static void normalize_returns(FnSymbol* fn) {
   // Now, for each return statement appearing in the function body,
   // move the value of its body into the declared return value.
   bool label_is_used = false;
+
   forv_Vec(CallExpr, ret, rets) {
     SET_LINENO(ret);
+
     if (isIterator) {
       INT_ASSERT(!!retval);
 
-      // Three cases: 
+      // Three cases:
       // (1) yield expr; => mov _ret expr; yield _ret;
       // (2) return; => goto end_label;
       // (3) return expr; -> mov _ret expr; yield _ret; goto end_label;
@@ -695,9 +714,11 @@ static void normalize_returns(FnSymbol* fn) {
       if (!is_void_return(ret)) { // Cases 1 and 3
         // insert MOVE(retval,ret_expr)
         insertRetMove(fn, retval, ret);
+
         // insert YIELD(retval)
         ret->insertBefore(new CallExpr(PRIM_YIELD, retval));
       }
+
       if (ret->isPrimitive(PRIM_YIELD)) // Case 1 only.
           // it's a yield => no goto; need to remove the original node
           ret->remove();
@@ -715,6 +736,7 @@ static void normalize_returns(FnSymbol* fn) {
         // insert MOVE(retval,ret_expr)
         insertRetMove(fn, retval, ret);
       }
+
       // replace with GOTO(label)
       if (ret->next != label->defPoint) {
         ret->replace(new GotoStmt(GOTO_RETURN, label));
@@ -724,6 +746,7 @@ static void normalize_returns(FnSymbol* fn) {
       }
     }
   }
+
   if (!label_is_used)
     label->defPoint->remove();
 }

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2015 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -110,8 +110,10 @@ void cullOverReferences() {
             VarSymbol* tmp = newTemp(copy->retType);
             move->insertBefore(new DefExpr(tmp));
             if (requiresImplicitDestroy(call)) {
-              tmp->addFlag(FLAG_INSERT_AUTO_COPY);
-              tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
+              if (isString(copy->retType) == false) {
+                tmp->addFlag(FLAG_INSERT_AUTO_COPY);
+                tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
+              }
             }
             if (useMap.get(se->var) && useMap.get(se->var)->n > 0) {
               move->insertAfter(new CallExpr(PRIM_MOVE, se->var,


### PR DESCRIPTION
A set of minor changes to support integration of the new "string as record" changes to master

1) Add a simple predicate, isString(), that is only true for the new "string as record" type.   This allows
business logic for this type to be injected incrementally in to master.  It is assumed that this predicate
will be deprecated as records mature further.

2) Do not add autoCopy/autoDestroy flags to strings in an inner loop of cullReferences

3) Add a flag to simplify the detection of the "return value variable" (RVV) in certain inner loops


These are all minor changes.  All of this code has been tested extensively on a newer string-as-rec
branch and this merge has passed a full linux64 test.
