### PR TITLE
Phase 2 to integrate recent string-as-rec work to master

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -422,12 +422,12 @@ void ReturnByRef::transform()
       }
       else
       {
-        assert(false);
+        INT_ASSERT(false);
       }
     }
     else
     {
-      assert(false);
+      INT_ASSERT(false);
     }
   }
 }


### PR DESCRIPTION
Update callDestructors with a few trivial changes and then three functional changes

Trivial:

Michael initiated some work that demonstrated there was some dead code for managing
certain flags.  Complete that effort and do a small amount of whitespace cleanup.


Functional:

1) The compiler includes a transformation that updates some calls to functions that return a
record-like type by value with a call to a clone that provides a by-ref formal for the value.
We've agreed to extend that to be used more uniformly.

Provide a first implementation for this.  This version is intended to be generally applicable
but it is currently only applied to the new string-as-record type.  This has been tested
extensively on a string-as-rec branch.  It has been tested on master but currently does
not trigger on that branch.



2) There is logic to cull the autoDestroy flag for variables that are assigned to the
"return value variable" (RVV).  Extend that to apply transitively.  This can be triggered
on master.


3) There is logic to insert autoDestroys to formals vs. block variables.  The latter is
 a little complex when there are multiple returns.  The compiler is trying to manage
an informal sense of a function epilogue but doesn't do a very good job of this.

Extend this code in a manner that is consistent with the current implementation.
Longer term we may want to revise this to be less fragile.  This can be triggered
on master.



All of this code has been tested extensively on Kyle's newer string-as-rec branch
and has passed a standard regression on master.


