### PR TITLE
Improved wording in iterators primer.

### DIFF
--- a/test/release/examples/primers/iterators.chpl
+++ b/test/release/examples/primers/iterators.chpl
@@ -15,28 +15,50 @@
 // fibonacci - generates the first n Fibonacci numbers
 //
 // The state of the iterator is stored in the tuple (current, next).
-// Each time the iterator runs, it returns the current Fibonacci number,
-// and then updates the state to the next one.
+// Each time the yield statement is reached, it yields, or generates,
+// the current Fibonacci number. It then updates the state to the next one.
+//
 iter fibonacci(n: int) {
-  var (current, next) = (0, 1);
+  var (current, next) = (0, 1); // same as: var current = 0, next = 1;
   for 1..n {
     yield current;
-      // The first time this iterator is run, it proceeds this far
-      // and then yields (returns) the first value of current (== 0),
-      // and its state is preserved.
-      // The next time it is called, execution resumes here.
-      // It continues until another yield is reached.
-      // If the iterator completes or encounters a return statement,
-      // execution of the enclosing loop terminates immediately.
+      // When this iterator runs, it proceeds this far
+      // and then yields (generates) the first value of current (== 0).
+      // current and next are saved, and the control and the yielded
+      // value are passed into the loop body.
+      //
+      // When the loop iteration completes, execution resumes here
+      // and continues until another yield is reached, etc.
+      //
+      // This statement updates current and next from their saved values.
     (current, next) = (next, current + next);
   }
 }
 
 //
+// An iterator is typically invoked in a loop.
+// Whenever iterator's yield statement is executed, the loop's index variable
+// is initialized with the yielded value and the loop body is executed
+// for a single iteration.
+//
+// When the iterator completes or encounters a return statement,
+// execution of the loop terminates (no more iterations occur).
+//
+write("The first few Fibonacci numbers are: ");
+for indexVar in fibonacci(10) do
+  write(indexVar, ", ");
+writeln("...");
+writeln();
+
+//
 // This example uses zipper iteration to iterate over the unbounded range 1..
 // and the fibonacci iterator with n set to ten.
 // Zipper iteration means that each iterator is advanced to the next yield
-// and the two values they return are returned as a tuple.
+// and the two values they yield are combined into a tuple.
+//
+// A zippered loop can have a single index variable, which will be a tuple,
+// or a tuple of variables like (i,j), each of which is initialized
+// with the value yielded by the corresponding iterator.
 //
 writeln("Fibonacci Numbers");
 for (i, j) in zip(1.., fibonacci(10)) {

--- a/test/release/examples/primers/iterators.chpl
+++ b/test/release/examples/primers/iterators.chpl
@@ -24,10 +24,10 @@ iter fibonacci(n: int) {
     yield current;
       // When this iterator runs, it proceeds this far
       // and then yields (generates) the first value of current (== 0).
-      // current and next are saved, and the control and the yielded
-      // value are passed into the loop body.
+      // current and next are saved. The control and the yielded value
+      // are passed into the loop body, and one loop iteration executes.
       //
-      // When the loop iteration completes, execution resumes here
+      // When the iteration completes, execution resumes here
       // and continues until another yield is reached, etc.
       //
       // This statement updates current and next from their saved values.
@@ -53,6 +53,8 @@ writeln();
 //
 // This example uses zipper iteration to iterate over the unbounded range 1..
 // and the fibonacci iterator with n set to ten.
+// Ranges, as well as arrays and domains, can be used as iterators in loops.
+//
 // Zipper iteration means that each iterator is advanced to the next yield
 // and the two values they yield are combined into a tuple.
 //

--- a/test/release/examples/primers/iterators.good
+++ b/test/release/examples/primers/iterators.good
@@ -1,3 +1,5 @@
+The first few Fibonacci numbers are: 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, ...
+
 Fibonacci Numbers
 The 1st Fibonacci number is 0
 The 2nd Fibonacci number is 1


### PR DESCRIPTION
Motivated by Tomsy Paul's feedback.

* Do not say that an iterator is invoked multiple times (for a single loop),
to avoid ambiguity.

* Use "generate" as another way of saying "yield" - instead of "return",
to avoid ambiguity.

* Introduce the concept of index variable.
Say that an index variable is "initialized"
because that's how we want it to behave w.r.t. constructors.

* Use "pass control" to explain control flow.

* Move the comment on when a loop terminates from an iterator to a loop.

While there, added a simple loop as the first example of a loop,
before getting into zippering, promotion, etc.