### PR TITLE
Add a chapcs performance playground

### DIFF
--- a/util/cron/common-fast.bash
+++ b/util/cron/common-fast.bash
@@ -5,4 +5,4 @@
 
 unset CHPL_TARGET_ARCH
 
-nightly_args="-fast"
+nightly_args="${nightly_args} -fast"

--- a/util/cron/common-llvm.bash
+++ b/util/cron/common-llvm.bash
@@ -26,4 +26,4 @@ fi
 # Run examples and test/extern/ferguson/.
 export CHPL_NIGHTLY_TEST_DIRS="extern/ferguson"
 
-nightly_args="-llvm"
+nightly_args="${nightly_args} -llvm"

--- a/util/cron/common-valgrind.bash
+++ b/util/cron/common-valgrind.bash
@@ -16,4 +16,4 @@ if [ "${tasks}" == "qthreads" ] ; then
     export CHPL_QTHREAD_MORE_CFG_OPTIONS=--enable-valgrind
 fi
 
-nightly_args="-valgrind -parnodefile $CWD/../../test/Nodes/valgrind-localhost"
+nightly_args="${nightly_args} -valgrind -parnodefile $CWD/../../test/Nodes/valgrind-localhost"

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Run performance tests on a chapcs machine with default configuration.
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs-playground'
+
+source $CWD/common-perf.bash
+source $CWD/common-llvm.bash
+
+# common-llvm restricts us to extern/fergeson, we want all the perf tests
+unset CHPL_NIGHTLY_TEST_DIRS
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
+
+perf_args="-performance-description llvm -performance-configs default:v,llvm:v -sync-dir-suffix llvm"
+perf_args="${perf_args} -performance -numtrials 5 -startdate 11/24/15"
+
+$CWD/nightly -cron ${nightly_args} ${perf_args}


### PR DESCRIPTION
Adds a new test configuration available for performance testing on
different settings as needed, using a chapcs node.

Also made a few common-*.bash scripts composable with respect to
$nightly_args.