### PR TITLE
Fix llvm perf testing

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 #
-# Run performance tests on a chapcs machine with default configuration.
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-export CHPL_TEST_PERF_CONFIG_NAME='chapcs-playground'
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 
 source $CWD/common-perf.bash
 source $CWD/common-llvm.bash


### PR DESCRIPTION
We wanted this to be able to compare against the regular chapcs numbers, so it
needs to pretend to be chapcs as well. That way all the .dats wil be stored in
a subdirectory of chapcs which the perf compare scripts will then find.

Currently the llvm .dat files are going into:

    /data/sea/chapel/NightlyPerformance/chapcs-playground/llvm/

but we really just want them in:

    /data/sea/chapel/NightPerformance/chapcs/llvm/