### PR TITLE
Pass all CHPL_vars to chpl_compilation_config.c

### DIFF
--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -591,7 +591,7 @@ static void codegen_header_compilation_config() {
     genGlobalInt("CHPL_CACHE_REMOTE", fCacheRemote);
 
     for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
-      if (env->first != "CHPL_HOME" && !useDefaultEnv(env->first)) {
+      if (env->first != "CHPL_HOME") {
         genGlobalString(env->first.c_str(), env->second);
       }
     }


### PR DESCRIPTION
An effort to fix the XE module failures

The aprun launcher on checks for values of `CHPL_TARGET_ARCH` to decide what flags to throw - however, compiler/passes/codegen.cpp was not writing `CHPL_TARGET_ARCH` to `chpl_compilation_config.c`. 

This PR removes the `!useDefaultEnv` check in `codegen.cpp` so that `CHPL_TARGET_ARCH` is written with the other CHPL_vars and is ultimately accessible by aprun launcher.



**[ √ Paratested ]**