### PR TITLE
Clean *.pyc files in util/chplenv upon 'make clobber'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ clobber: FORCE
 	-@[ -d doc/sphinx ] && cd doc/sphinx && $(MAKE) clobber
 	rm -rf bin
 	rm -rf lib
+	rm -f util/chplenv/*.pyc
 
 depend:
 	@echo "make depend has been deprecated for the time being"


### PR DESCRIPTION
I encountered an issue with persistent *pyc files during Debian packaging - this removes all *pyc files when 'make clobber' is called.