### PR TITLE
Use an atomic instead of a sync in coforallon_maxThreads

### DIFF
--- a/test/multilocale/diten/needMultiLocales/coforallon_maxThreads.chpl
+++ b/test/multilocale/diten/needMultiLocales/coforallon_maxThreads.chpl
@@ -1,12 +1,12 @@
 use Time;
 
 proc main {
-  var a: sync int = 0;
+  var a: atomic int;
   coforall loc in Locales {
     on loc {
       sleep(2);
-      a += 1;
+      a.add(1);
     }
   }
-  writeln(a.readFF());
+  writeln(a);
 }


### PR DESCRIPTION
This test sporadically deadlocks under gasnet-fifo. I haven't tracked down
exactly what's causing the deadlock, but changing the sync to atomic appears to
avoid the deadlock, at least for my test of ~1000 trials.

This isn't a very satisfying "fix", but we're not too concerned about
investigating further since it only impacts gasnet-fifo when
CHPL_RT_NUM_THREADS_PER_LOCALE is explicitly limited.

See JIRA issue 87 for more info (https://chapel.atlassian.net/browse/CHAPEL-87)