### PR TITLE
Update `util/devel/README` to describe fnhtml.pl

### DIFF
--- a/util/devel/README
+++ b/util/devel/README
@@ -6,7 +6,8 @@ This directory contains utility scripts that are useful mostly to developers.
 For example:
 
   chpl-run         : compiles a Chapel program and runs it right away
-  fnhtml.pl        : Looks at a single function throughout compilation via html
+  fnhtml.pl        : Views a single function throughout compilation output
+                     generated from compiling with '--html' flag
   receive_patch    : two scripts useful for moving patches between trees
   send_patch
   test/

--- a/util/devel/README
+++ b/util/devel/README
@@ -6,6 +6,7 @@ This directory contains utility scripts that are useful mostly to developers.
 For example:
 
   chpl-run         : compiles a Chapel program and runs it right away
+  fnhtml.pl        : Looks at a single function throughout compilation via html
   receive_patch    : two scripts useful for moving patches between trees
   send_patch
   test/


### PR DESCRIPTION
`fnhtml.pl` was recently moved from `compiler/etc/www` to `util/devel`, so I am updating the README to reflect this.