### PR TITLE
Switch to pgc++ from pgCC as pgi's C++ compiler

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -149,7 +149,7 @@ CHPL_*_COMPILER
         gnu                The GNU compiler suite -- gcc and g++
         ibm                The IBM compiler suite -- xlc and xlC
         intel              The Intel compiler suite -- icc and icpc
-        pgi                The PGI compiler suite -- pgcc and pgCC
+        pgi                The PGI compiler suite -- pgcc and pgc++
         =================  ===================================================
 
    The default for ``CHPL_*_COMPILER`` depends on the value of the corresponding

--- a/doc/release/platforms/cray.rst
+++ b/doc/release/platforms/cray.rst
@@ -132,7 +132,7 @@ Building Chapel for a Cray System from Source
 
      :``gnu``: the GNU compiler suite -- ``gcc`` and ``g++``
      :``intel``: the Intel compiler suite -- ``icc`` and ``icpc``
-     :``pgi``: the PGI compiler suite -- ``pgcc`` and ``pgCC``
+     :``pgi``: the PGI compiler suite -- ``pgcc`` and ``pgc++``
 
 
 5) Optionally, set one or more of the following environment variables to

--- a/make/compiler/Makefile.pgi
+++ b/make/compiler/Makefile.pgi
@@ -22,7 +22,7 @@
 #
 # Tools
 #
-CXX = pgCC
+CXX = pgc++
 CC = pgcc
 
 RANLIB = ranlib


### PR DESCRIPTION
pgc++ is the "newer" version that has ABI compatibility with gnu, which allows
it to use the system STL. This should allow us to build re2 with pgi (it
currently fails because unordered_set is missing from the standard library pgCC
is limited to.)

Note that cray-prgenv-pgi already uses pgc++ behind the scenes instead of pgCC,
so we'll be in good company making the switch as well.

For more info on the difference between pgCC and pgc++ see:
https://www.pgroup.com/lit/articles/insider/v4n1a2.htm