### PR TITLE
Add a test to lock in configs where re2 builds

### DIFF
--- a/test/regexp/elliot/I-fail-without-re2.bad
+++ b/test/regexp/elliot/I-fail-without-re2.bad
@@ -1,0 +1,1 @@
+I-fail-without-re2.chpl:6: error: Regular expression support not compiled in

--- a/test/regexp/elliot/I-fail-without-re2.chpl
+++ b/test/regexp/elliot/I-fail-without-re2.chpl
@@ -1,0 +1,6 @@
+// Simple test to lock in which configurations re2 successfully builds in.
+// Since re2 is speculatively built, we want some way to notice if it stops
+// building in configurations we expect it to.
+
+use Regexp;
+var myRegexp = compile("a+");

--- a/test/regexp/elliot/I-fail-without-re2.suppressif
+++ b/test/regexp/elliot/I-fail-without-re2.suppressif
@@ -1,0 +1,9 @@
+# Some configs don't support re2
+
+# build fails with "sfence not supported"
+CHPL_TARGET_ARCH==knc
+
+# default re2 makefile throws flags not supported by pgi/cray compilers
+CHPL_TARGET_COMPILER==cray-prgenv-cray
+CHPL_TARGET_COMPILER==cray-prgenv-pgi
+CHPL_TARGET_COMPILER==pgi


### PR DESCRIPTION
Since re2 is speculatively built, we want some way to notice if it stops
building in configurations we expect it to work in.