### PR TITLE
Support building re2 with the cray and pgi compilers

### DIFF
--- a/test/regexp/elliot/I-fail-without-re2.suppressif
+++ b/test/regexp/elliot/I-fail-without-re2.suppressif
@@ -2,8 +2,3 @@
 
 # build fails with "sfence not supported"
 CHPL_TARGET_ARCH==knc
-
-# default re2 makefile throws flags not supported by pgi/cray compilers
-CHPL_TARGET_COMPILER==cray-prgenv-cray
-CHPL_TARGET_COMPILER==cray-prgenv-pgi
-CHPL_TARGET_COMPILER==pgi

--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -21,6 +21,24 @@ CHPL_RE2_CXXFLAGS += -mmic
 endif
 endif
 
+# re2's makefile explicity throws flags that cray and pgi don't support. This
+# is intended to basically replace the re2 makefiles lines:
+#
+#     RE2_CXXFLAGS?=-Wsign-compare -c -I. $(CCPCRE)  # required
+#     LDFLAGS?=-pthread
+#
+# with:
+#
+#     RE2_CXXFLAGS?= -c -I. $(CCPCRE)
+#     LDFLAGS?=
+ifneq (, $(filter $(CHPL_MAKE_TARGET_COMPILER),pgi cray-prgenv-pgi cray-prgenv-cray))
+CHPL_RE2_CFG_OPTIONS += LDFLAGS=
+CHPL_RE2_CFG_OPTIONS += 'RE2_CXXFLAGS= -c -I. $$(CCPCRE)'
+endif
+
+CHPL_RE2_CFG_OPTIONS += $(CHPL_RE2_MORE_CFG_OPTIONS)
+
+
 CHPL_RE2_CXXFLAGS += $(CFLAGS)
 
 default: all
@@ -42,8 +60,8 @@ $(RE2_BUILD_SUBDIR):
 $(RE2_H_FILE): $(RE2_BUILD_SUBDIR)
 	cd re2 && \
 	$(MAKE) clean && \
-	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' obj/libre2.a && \
-	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' prefix=$(RE2_INSTALL_DIR) install-static && \
+	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' $(CHPL_RE2_CFG_OPTIONS) obj/libre2.a && \
+	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' $(CHPL_RE2_CFG_OPTIONS) prefix=$(RE2_INSTALL_DIR) install-static && \
 	mkdir -p ../build/$(RE2_UNIQUE_SUBDIR) && \
 	rm -rf ../build/$(RE2_UNIQUE_SUBDIR) && \
 	mv obj ../build/$(RE2_UNIQUE_SUBDIR)


### PR DESCRIPTION
Historically we have not supported building re2 with the cray or pgi compilers.
This was primarily because re2 throws gcc specific flags that these compilers
don't support.

This patch just overrides re2's default LDFLAGS and RE2_CXXFLAGS to not include
flags that are not supported or not needed for cray or pgi.