### PR TITLE
Fix performance regression for Block and Cyclic

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1127,9 +1127,9 @@ iter BlockArr.these(param tag: iterKind, followThis, param fast: bool = false) r
     // live on a different locale and require communication for reference
     // counting. Simply put: don't slice inside a local block.
     //
+    var chunk => arrSection.myElems(myFollowThisDom);
     local {
-      const follow = arrSection.locDom.myBlock(myFollowThisDom);
-      for i in follow do yield arrSection.this(i);
+      for i in chunk do yield i;
     }
   } else {
     //

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -992,7 +992,6 @@ iter CyclicArr.these(param tag: iterKind, followThis, param fast: bool = false) 
     //
     // TODO: Can myLocArr be used here to simplify things?
     //
-    const follow = arrSection.locDom.myBlock(myFollowThis);
     var chunk => arrSection.myElems(myFollowThis);
     if arrSection.locale.id == here.id then local {
       for i in chunk do yield i;

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -993,10 +993,11 @@ iter CyclicArr.these(param tag: iterKind, followThis, param fast: bool = false) 
     // TODO: Can myLocArr be used here to simplify things?
     //
     const follow = arrSection.locDom.myBlock(myFollowThis);
+    var chunk => arrSection.myElems(myFollowThis);
     if arrSection.locale.id == here.id then local {
-      for i in follow do yield arrSection.myElems.this(i);
+      for i in chunk do yield i;
     } else {
-      for i in follow do yield arrSection.myElems.this(i);
+      for i in chunk do yield i;
     }
   } else {
     proc accessHelper(i) ref {

--- a/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
+++ b/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
@@ -43,9 +43,9 @@ Return domain map:
 Create domain:
 	1520 bytes leaked
 Create domain and array:
-	3624 bytes leaked
+	3632 bytes leaked
 total:
-	6294 bytes leaked
+	6302 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:

--- a/test/memory/sungeun/refCount/domainMaps.lm-numa.good
+++ b/test/memory/sungeun/refCount/domainMaps.lm-numa.good
@@ -43,9 +43,9 @@ Return domain map:
 Create domain:
 	592 bytes leaked
 Create domain and array:
-	2384 bytes leaked
+	2392 bytes leaked
 total:
-	3502 bytes leaked
+	3510 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:

--- a/test/memory/sungeun/refCount/domainMaps.no-local.good
+++ b/test/memory/sungeun/refCount/domainMaps.no-local.good
@@ -43,9 +43,9 @@ Return domain map:
 Create domain:
 	1520 bytes leaked
 Create domain and array:
-	3624 bytes leaked
+	3632 bytes leaked
 total:
-	6294 bytes leaked
+	6302 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:


### PR DESCRIPTION
We saw a small performance regression as a result of #2939 for global stream. It seems that iterating over a domain is a bit slower than iterating over a sliced array. This patch reverts to the previous approach which sliced an array. Some memory leaks for domainMaps.chpl must also be updated.