### PR TITLE
Fixing bugs in test_glob

### DIFF
--- a/test/studies/glob/Glob.chpl
+++ b/test/studies/glob/Glob.chpl
@@ -39,7 +39,10 @@ iter my_wordexp(pattern:string, recursive:bool = false, flags:int = 0, directory
 
   err = chpl_wordexp((directory + pattern).c_str(), flags:c_int, glb);
 
-  for i in 0..wordexp_num(glb) -1 {
+  const wordexpNum = wordexp_num(glb);
+
+  if wordexpNum then
+  for i in 0..wordexpNum -1 {
     tx = wordexp_index(glb, i);
     if recursive && chpl_isdir(tx) == 1 {
       const pth = toString(tx) + "/";

--- a/test/studies/glob/Glob.chpl
+++ b/test/studies/glob/Glob.chpl
@@ -59,15 +59,21 @@ iter my_wordexp(param tag:iterKind, pattern:string, recursive:bool = false,
 
   dirBuff += directory;
 
-  do {
+  while (true) {
 
     // No more work left to accomplish
     if (dirBuff.numIndices == 0) then
       break;
 
+    //
+    // make a copy of the directory buffer to avoid modifying a
+    // collection while iterating over it.
+    //
+    const dirBuffCopy = dirBuff;
+    dirBuff.clear();
+
     // Now spawn off tasks for each dir
-    coforall dir in dirBuff {
-      dirBuff -= dir;
+    coforall dir in dirBuffCopy {
       for flConst in my_wordexp(pattern, false, flags, dir) {
         var fl = flConst;
         if recursive && chpl_isdir(fl.c_str()) == 1 {
@@ -77,7 +83,7 @@ iter my_wordexp(param tag:iterKind, pattern:string, recursive:bool = false,
         yield fl;
       }
     }
-  } while (true);
+  }
 }
 
 iter my_wordexp(param tag:iterKind, pattern:string, recursive:bool = false,
@@ -113,15 +119,21 @@ iter my_glob(param tag:iterKind, pattern:string, recursive:bool = false,
   // We start out with the current directory
   dirBuff += directory;
 
-  do {
+  while (true) {
 
     // No more work left to accomplish
     if (dirBuff.numIndices == 0) then
       break;
 
+    //
+    // make a copy of the directory buffer to avoid modifying a
+    // collection while iterating over it.
+    //
+    const dirBuffCopy = dirBuff;
+    dirBuff.clear();
+
     // Now spawn off tasks for each dir
-    coforall dir in dirBuff {
-      dirBuff -= dir;
+    coforall dir in dirBuffCopy {
       for flConst in my_glob(pattern, false, flags, dir) {
         var fl = flConst;
         if recursive && chpl_isdir(fl.c_str()) == 1 {
@@ -131,7 +143,7 @@ iter my_glob(param tag:iterKind, pattern:string, recursive:bool = false,
         yield fl;
       }
     }
-  } while (true);
+  }
 }
 
 iter my_glob(param tag:iterKind, pattern:string, recursive:bool = false,

--- a/test/studies/glob/Glob.chpl
+++ b/test/studies/glob/Glob.chpl
@@ -98,7 +98,10 @@ iter my_glob(pattern:string, recursive:bool = false, flags:int = 0, directory:st
 
   err = chpl_study_glob((directory + pattern).c_str(), flags:c_int, glb);
 
-  for i in 0..glob_num(glb) - 1 {
+  const globNum = glob_num(glb);
+
+  if globNum then
+  for i in 0..globNum - 1 {
     tx = glob_index(glb, i);
     if recursive && chpl_isdir(tx) == 1 {
       const pth = toString(tx) + "/";

--- a/test/studies/glob/test_glob.good
+++ b/test/studies/glob/test_glob.good
@@ -1,7 +1,7 @@
-./Glob.chpl:116: In iterator 'my_glob':
-./Glob.chpl:135: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
-./Glob.chpl:54: In iterator 'my_wordexp':
-./Glob.chpl:72: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+./Glob.chpl:119: In iterator 'my_glob':
+./Glob.chpl:138: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+./Glob.chpl:57: In iterator 'my_wordexp':
+./Glob.chpl:75: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 ======== SERIAL ITERATORS (recursive) ==========
 -------- GLOB ----------
 a/a.c

--- a/test/studies/glob/test_glob.good
+++ b/test/studies/glob/test_glob.good
@@ -1,3 +1,7 @@
+./Glob.chpl:113: In iterator 'my_glob':
+./Glob.chpl:132: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+./Glob.chpl:54: In iterator 'my_wordexp':
+./Glob.chpl:72: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 ======== SERIAL ITERATORS (recursive) ==========
 -------- GLOB ----------
 a/a.c

--- a/test/studies/glob/test_glob.good
+++ b/test/studies/glob/test_glob.good
@@ -1,5 +1,5 @@
-./Glob.chpl:113: In iterator 'my_glob':
-./Glob.chpl:132: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+./Glob.chpl:116: In iterator 'my_glob':
+./Glob.chpl:135: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 ./Glob.chpl:54: In iterator 'my_wordexp':
 ./Glob.chpl:72: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 ======== SERIAL ITERATORS (recursive) ==========


### PR DESCRIPTION
In testing, @Kyle-B ran into a few bugs in the test_glob test:

1) Tim was simultaneously iterating over an associative domain and
modifying it which is a race (and one that we can't detect).
We've somehow avoided this becoming a problem, though in Kyle's
testing it revealed itself.

Here, I fix this by making a copy of the associative domain
before iterating over it, which should be equivalent since
the whole thing is in an infinite loop until the domain is empty.
This domain copy results in a warning, so I updated the .good
to acknowledge the warning.

While, here, I changed do...while(true)'s into while(true)'s
which seems more readable to me.

2) In another pair of cases, loops were iterating from 0..<#size_t>-1 which
ran into warnings when size_t was zero because of maximal
range issues.  I guarded these loops by a conditional to protect against
this case.
