### PR TITLE
Quiet regexp tests

### DIFF
--- a/test/regexp/ferguson/ctests/sub_test
+++ b/test/regexp/ferguson/ctests/sub_test
@@ -43,8 +43,8 @@ fi
 
 # If we had an easy way to get the names of the C/C++ compilers
 # we could support non-gnu
-COMP=`$CHPL_HOME/util/chplenv/chpl_compiler.py`
-PLAT=`$CHPL_HOME/util/chplenv/chpl_platform.py`
+COMP=`$CHPL_HOME/util/chplenv/chpl_compiler.py --target`
+PLAT=`$CHPL_HOME/util/chplenv/chpl_platform.py --target`
 if [ "$COMP" = "gnu" ]
 then
   echo C tests will run using gnu compiler


### PR DESCRIPTION
Properly skip regexp/ferguson/ctests/regexp_* tests. They are meant to be
skipped for compilers other than gnu or clang but they were checking the host
compiler instead of the target compiler so they weren't getting properly
skipped for some configurations.