### PR TITLE
Insert an autoCopy for moves to value from class wrapped ref type

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -215,7 +215,7 @@ private:
   static ArgSymbol*       addFormal(FnSymbol* fn);
   static void             insertAssignmentToFormal(FnSymbol*  fn,
                                                    ArgSymbol* formal);
-  static void             updateAssignmentsFromRefToValue(FnSymbol* fn);
+  static void             updateAssignmentsFromRefArgToValue(FnSymbol* fn);
   static void             updateAssignmentsFromModuleLevelValue(FnSymbol* fn);
   static void             updateReturnStatement(FnSymbol* fn);
   static void             updateReturnType(FnSymbol* fn);
@@ -350,7 +350,7 @@ void ReturnByRef::transformFunction(FnSymbol* fn)
   ArgSymbol* formal = addFormal(fn);
 
   insertAssignmentToFormal(fn, formal);
-  updateAssignmentsFromRefToValue(fn);
+  updateAssignmentsFromRefArgToValue(fn);
   updateAssignmentsFromModuleLevelValue(fn);
   updateReturnStatement(fn);
   updateReturnType(fn);
@@ -390,7 +390,7 @@ void ReturnByRef::insertAssignmentToFormal(FnSymbol* fn, ArgSymbol* formal)
 //
 // This work-around inserts an autoCopy to compensate
 //
-void ReturnByRef::updateAssignmentsFromRefToValue(FnSymbol* fn)
+void ReturnByRef::updateAssignmentsFromRefArgToValue(FnSymbol* fn)
 {
   std::vector<CallExpr*> callExprs;
 


### PR DESCRIPTION
The compiler failed to insert a required autoCopy when copying from a class wrapped _ref type to
a value of that type; an example occurs when fetching the field of a record.

This patch fixes two tests that were double-freeing but may have introduced leaks in some
other tests.

This patch has no effect on master
