### PR TITLE
Removed `CHPL_NETWORK_ATOMICS` from name of lib/runtime dir

### DIFF
--- a/util/printchplenv
+++ b/util/printchplenv
@@ -90,7 +90,7 @@ def print_mode(mode='list'):
 
     atomics = chpl_atomics.get()
     print_var('CHPL_ATOMICS', atomics, mode, 'atomics', ('runtime', 'launcher'))
-    if comm != 'none' or mode == 'simple':
+    if (mode != 'runtime' and mode != 'make') and comm != 'none' or mode == 'simple':
         net_atomics = chpl_atomics.get('network')
         print_var('  CHPL_NETWORK_ATOMICS', net_atomics, mode, filters=('runtime', 'launcher'))
 


### PR DESCRIPTION
Removed the `CHPL_NETWORK_ATOMICS` variable from the name of the lib/runtime directory. This fixes a bug where setting `$CHPL_NETWORK_ATOMICS` explicitly would cause a runtime error complaining that the runtime directory with that specific network atomic configuration does not exist.

e.g. 

`darwin.clang.arch-native.loc-flat.comm-none.tasks-qthreads.tmr-generic.mem-cstdlib.atomics-intrinsics.none.gmp-none.hwloc.re-none.wide-struct.fs-none`

 ->

 `darwin.clang.arch-native.loc-flat.comm-none.tasks-qthreads.tmr-generic.mem-cstdlib.atomics-intrinsics.gmp-none.hwloc.re-none.wide-struct.fs-none`

**[√ Paratested]**