### PR TITLE
Removed `CHPL_NETWORK_ATOMICS` from name of lib/launcher dir

### DIFF
--- a/util/printchplenv
+++ b/util/printchplenv
@@ -90,7 +90,7 @@ def print_mode(mode='list'):
 
     atomics = chpl_atomics.get()
     print_var('CHPL_ATOMICS', atomics, mode, 'atomics', ('runtime', 'launcher'))
-    if (mode != 'runtime' and mode != 'make') and comm != 'none' or mode == 'simple':
+    if (mode != 'runtime' and mode != 'make' and mode != 'launcher') and comm != 'none' or mode == 'simple':
         net_atomics = chpl_atomics.get('network')
         print_var('  CHPL_NETWORK_ATOMICS', net_atomics, mode, filters=('runtime', 'launcher'))
 


### PR DESCRIPTION
This PR is an addendum to the similar PR #2962 - to prevent a compiler error when changing `CHPL_NETWORK_ATOMICS` manually.

 It was learned after an additional module performance failure that this change was necessary on top of the change from #2962.

Launcher directory changes from e.g.

 `cray-xc.gnu.loc-flat.tasks-muxed.launch-slurm-srun.tmr-generic.mem-tcmalloc.atomics-intrinsics.none.wide-struct/ `

->

`cray-xc.gnu.loc-flat.tasks-muxed.launch-slurm-srun.tmr-generic.mem-tcmalloc.atomics-intrinsics.wide-struct/`

The fix was tested on tiger (`slurm-srun`), `CHPL_COMM=ugni`, `CHPL_TASKS=muxed`, `CHPL_NETWORK_ATOMICS= none`, with gnu compiler to reproduce the environment for the failing performance test:
 `studies/hpcc/HPL/vass/hpl.hpcc2012.chpl`