### PR TITLE
Add CHPL_COMM to runtime launcher path

### DIFF
--- a/util/printchplenv
+++ b/util/printchplenv
@@ -59,7 +59,7 @@ def print_mode(mode='list'):
         print_var('CHPL_LOCALE_MODEL', locale_model, mode, 'loc')
 
     comm = chpl_comm.get()
-    print_var('CHPL_COMM', comm, mode, 'comm', ('runtime',))
+    print_var('CHPL_COMM', comm, mode, 'comm', ('runtime', 'launcher'))
     if m == 'make' or (comm != 'none' and comm != 'ugni'):
         comm_substrate = chpl_comm_substrate.get()
         print_var('  CHPL_COMM_SUBSTRATE', comm_substrate, mode, filters=('runtime',))


### PR DESCRIPTION
This keeps the `chpl-<CHPL_COMM>-locale.c` distinguishable across varying `CHPL_COMM`.

This should resolve a bug in gasnet-mpi / slurm-srun, where `chpl-none-locale.c` was being invoked and complaining about the number of locales requested, despite `CHPL_COMM=gasnet` being set.


**[ √ Paratested ]**

**Testing with a handful of jobs on Tiger to confirm test-failures will resolve:**

* √ `test/npb/ep/mcahir`
* √ `release/examples/benchmarks/hpcc/fft`
*  √  `studies/nbody/md`

**Confirmed that building with `CHPL_COMM=none` and `CHPL_COMM=gasnet` on an XC system produces two separate unique runtime launcher paths**