### PR TITLE
Default to qthreads+hwloc with CCE

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -318,11 +318,6 @@ CHPL_TASKS
 
      * target platform is ``cygwin*``
      * target platform is ``netbsd*``
-     * target compiler is ``cray-prgenv-cray``
-
-   The latter two apply independent of whether you are building Chapel
-   yourself or using the pre-built module on a Cray XC or XE\ |trade|
-   system.
 
    .. note::
      Note that the Chapel ``util/quickstart/setchplenv.*`` source scripts set

--- a/doc/release/platforms/cray.rst
+++ b/doc/release/platforms/cray.rst
@@ -124,6 +124,9 @@ Building Chapel for a Cray System from Source
        PrgEnv-intel
        PrgEnv-pgi
 
+   For PrgEnv-cray we recommend using CCE 8.4 or newer for best performance.
+   This allows us to build our recommended third-party packages (i.e. allows
+   us to default to CHPL_TASKS=qthreads instead of CHPL_TASKS=fifo)
 
 4) By default, ``g++`` will be used to compile code that runs on the login
    node, such as the Chapel compiler and launcher code.  Optionally, you can
@@ -139,9 +142,7 @@ Building Chapel for a Cray System from Source
    configure the Chapel build.  These are described in greater detail in
    :ref:`readme-chplenv`.
 
-     :``CHPL_TASKS``: tasking implementation, default ``fifo`` when using
-                      target compiler ``cray-prgenv-cray``, otherwise
-                      ``qthreads``
+     :``CHPL_TASKS``: tasking implementation, default ``qthreads``
      :``CHPL_COMM``: communication implementation, default ``gasnet``
 
    Other configuration environment variables such as ``CHPL_MEM`` can also
@@ -197,9 +198,7 @@ Using Chapel on a Cray System
    select a Chapel configuration.  These are described in greater detail
    in :ref:`readme-chplenv`.
 
-     :``CHPL_TASKS``: tasking implementation, default ``fifo`` with target
-                      compiler ``cray-prgenv-cray``, ``muxed`` on Cray
-                      XC/XE with pre-built module, otherwise ``qthreads``
+     :``CHPL_TASKS``: tasking implementation, default ``qthreads``
      :``CHPL_COMM``: communication implementation, default ``ugni`` on Cray
                      XC/XE with pre-built module, else ``gasnet``
 

--- a/doc/release/tasks.rst
+++ b/doc/release/tasks.rst
@@ -51,8 +51,7 @@ environment variable to one of the following values:
   best performance; default for most targets
 
 :fifo:
-  most portable, but heavyweight; default for NetBSD, Cygwin, or when
-  Cray is the target compiler
+  most portable, but heavyweight; default for NetBSD and Cygwin
 
 :massivethreads:
   based on U Tokyo's MassiveThreads library
@@ -212,13 +211,13 @@ For more information on Qthreads, see $CHPL_HOME/third-party/README.
 CHPL_TASKS == fifo
 ------------------
 
-FIFO tasking over POSIX threads (or pthreads) works on all platforms
-and is the default for Cygwin, NetBSD, or when Cray is the target
-compiler.  It is attractive in its portability, though on most
-platforms it will tend to be heavier weight than Chapel strictly
-requires.  FIFO tasking is also used when Chapel is configured in
-'Quick Start' mode (see :ref:`chapelhome-quickstart`).  To use FIFO
-tasking, please take the following steps:
+FIFO tasking over POSIX threads (or pthreads) works on all
+platforms and is the default for Cygwin and NetBSD. It is
+attractive in its portability, though on most platforms it will
+tend to be heavier weight than Chapel strictly requires.  FIFO
+tasking is also used when Chapel is configured in 'Quick Start'
+mode (see :ref:`chapelhome-quickstart`).  To use FIFO tasking,
+please take the following steps:
 
 1) Ensure that the environment variable ``CHPL_HOME`` points to the
    top-level Chapel directory.

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -18,6 +18,14 @@ CFLAGS += -mmic
 endif
 endif
 
+#
+# Something with ffsl is broken with cce >= 8.4.0 (and older
+# versions with -hgnu thrown.)
+#
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)
+CFLAGS += -DHWLOC_HAVE_BROKEN_FFS
+endif
+
 CHPL_HWLOC_CFG_OPTIONS += --enable-static \
                           --disable-shared \
                           --disable-cairo \

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -5,9 +5,8 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_comm, chpl_compiler, chpl_platform, utils
-from utils import memoize
-
+import chpl_compiler, chpl_platform, utils
+from utils import memoize, CompVersion
 
 @memoize
 def get():
@@ -15,11 +14,19 @@ def get():
     if not tasks_val:
         platform_val = chpl_platform.get()
         compiler_val = chpl_compiler.get('target')
-        comm_val = chpl_comm.get()
+
+        # CCE >= 8.4 is required to build qthreads (for gnu style inline asm.)
+        # We build the module with a new enough version so we know the we can
+        # use the qthreads it provides even if the user has an older CCE loaded
+        using_qthreads_incompatible_cce = False
+        if compiler_val == 'cray-prgenv-cray':
+            if (utils.get_compiler_version(compiler_val) < CompVersion('8.4') and
+                    not using_chapel_module()):
+                using_qthreads_incompatible_cce = True
 
         if (platform_val.startswith('cygwin') or
                 platform_val.startswith('netbsd') or
-                compiler_val == 'cray-prgenv-cray'):
+                using_qthreads_incompatible_cce):
             tasks_val = 'fifo'
         else:
             tasks_val = 'qthreads'

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -37,7 +37,7 @@ def get_compiler_version(compiler):
     version_string = '0'
     if 'gnu' in compiler:
         version_string = run_command(['gcc', '-dumpversion'])
-    elif 'cray' in compiler:
+    elif 'cray-prgenv-cray' == compiler:
         version_string = os.environ.get('CRAY_CC_VERSION', '0')
     return CompVersion(version_string)
 


### PR DESCRIPTION
CCE 8.4 added support for gnu style inline assembly, which means we can now
build qthreads with it. This patch updates chplenv to default to qthreads if
we're using a new enough CCE (or if the module is being used since we know the
module is built with a new enough version of CCE.)

#2496 was an attempt to default to qthreads w/o hwloc for cce since hwloc
didn't build. However, hwloc is needed to get the best performance out of
qthreads. 792d4b37663ae5016075dab8f1b3ab0b5529a60c allows us to build hwloc
with CCE so we can now enable qthreads+hwloc and get better performance. For
stream-ep on a CRAY-XC this takes us from 65 GB/s with fifo to 74 GB/s.
