### PR TITLE
Recursively chmod sphinx-built doc dir after making it

### DIFF
--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -59,6 +59,7 @@ check-sphinxbuild:
 
 html: symlink-docs check-sphinxbuild clean-build
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	chmod -R ugo+rX $(BUILDDIR)
 	@echo
 	@echo "Build finished. The HTML pages are in "'$(BUILDPATH)'"/html."
 


### PR DESCRIPTION
This commit recursively chmod's ugo+rX after building the
Chapel sphinx docs so that web shares that are pointing to
the resulting directory can read the generated html files
by default.