### PR TITLE
Three trivial patches to resolve the final linux64 regressions for strings

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2015 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -482,13 +482,16 @@ static void addArgCoercion(FnSymbol* fn, CallExpr* call, ArgSymbol* formal,
   TypeSymbol* fts = formal->type->symbol;
   CallExpr* castCall;
   VarSymbol* castTemp = newTemp("coerce_tmp"); // ..., formal->type ?
+
   castTemp->addFlag(FLAG_COERCE_TEMP);
+
   // gotta preserve this-ness, so can write to this's fields in constructors
   if (actualSym->hasFlag(FLAG_ARG_THIS) &&
       isDispatchParent(actualSym->type, formal->type))
     castTemp->addFlag(FLAG_ARG_THIS);
 
   Expr* newActual = new SymExpr(castTemp);
+
   if (NamedExpr* namedActual = toNamedExpr(prevActual)) {
     // preserve the named portion
     Expr* newCurrActual = namedActual->actual;
@@ -573,9 +576,13 @@ static void addArgCoercion(FnSymbol* fn, CallExpr* call, ArgSymbol* formal,
     castCall = NULL;
   }
 
-  if (castCall == NULL)
+  if (castCall == NULL) {
     // the common case
     castCall = new CallExpr("_cast", fts, prevActual);
+
+    if (isString(fts))
+      castTemp->addFlag(FLAG_INSERT_AUTO_DESTROY);
+  }
 
   // move the result to the temp
   CallExpr* castMove = new CallExpr(PRIM_MOVE, castTemp, castCall);


### PR DESCRIPTION
1) Several tests, esp test_glob.chpl, were failing when accessing freed memory.   This turns out to be
caused when forall statements reference strings in the body.  The iterator for the forall is copying the
string by value [NB: this is a bug that needs to be fixed] in to the arg bundle and then destroying the
parent task's copy.

I was able to extend the existing logic for copy/destroy to support begin statements.


2) There were two trivial leaks caused by different ways in which a string was being copied, to a
compiler temp, and then not being destroyed.  Added the AUTO_DESTROY flag to each case.


Triivial changes.
Passed a full linux64 regression.
