### PR TITLE
Change the module search path when using chpldoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ test-venv: third-party-test-venv
 
 chpldoc: compiler third-party-chpldoc-venv
 	cd compiler && $(MAKE) chpldoc
+	cd modules && $(MAKE) sys-ctypes-docs
 	@test -r Makefile.devel && $(MAKE) man-chpldoc || echo ""
 
 always-build-test-venv: FORCE

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -29,6 +29,7 @@
 
 #include "beautify.h"
 #include "driver.h"
+#include "docsDriver.h"
 #include "misc.h"
 #include "mysystem.h"
 #include "stringutil.h"
@@ -752,9 +753,15 @@ void setupModulePaths() {
                       CHPL_COMM));
   intModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/internal"));
 
-  stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/standard/gen/",
-                      CHPL_TARGET_PLATFORM,
-                      "-", CHPL_TARGET_COMPILER));
+  if (fDocs) {
+    // We use a special sysCTypes when running with chpldoc to gloss over
+    // machine differences
+    stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/standard/gen/doc"));
+  } else {
+    stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/standard/gen/",
+                        CHPL_TARGET_PLATFORM,
+                        "-", CHPL_TARGET_COMPILER));
+  }
 
   stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/standard"));
   stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/layouts"));

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -64,6 +64,7 @@ $(SYS_CTYPES_MODULE_DOC): $(MAKE_SYS_BASIC_TYPES)
 	mkdir -p $(@D)
 	cd $(@D) && $(MAKE_SYS_BASIC_TYPES) --doc $(@F)
 
+sys-ctypes-docs: $(SYS_CTYPES_MODULE_DOC)
 
 MODULES_TO_DOCUMENT = \
 	standard/AdvancedIters.chpl \


### PR DESCRIPTION
Switch the module search path for SysCTypes.chpl from
`moduleRoot/standard/gen/TARGET-HOST` to `moduleRoot/standard/gen/doc`. We
create two different versions of SysCTypes, the normal one in
`gen/TARGET-HOST` and a version for chpldoc in `gen/doc`. Since the parser
still follows 'use' clauses when running inside chpldoc, errors would
occur if the normal version of SysCTypes had not been created.

We started running into this error since the new String module has a use
of SysCTypes.