### PR TITLE
Fix the memleaks/substring bug for gasket

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -251,7 +251,7 @@ module String {
 
       const remoteThis = this.locale_id != chpl_nodeID;
       if remoteThis {
-        chpl_string_comm_get(ret.buff, this.locale_id, this.buff, 1);
+        chpl_string_comm_get(ret.buff, this.locale_id, this.buff + i - 1, 1);
       } else {
         ret.buff[0] = this.buff[i-1];
       }


### PR DESCRIPTION
The remote path for string.this(i) had a trivial bug; the code failed to add "i" to the base point to compute
the element to fetch.

No review


