### PR TITLE
Suppress two test failures involving complex for PGI

### DIFF
--- a/test/npb/ft/ft-serial.suppressif
+++ b/test/npb/ft/ft-serial.suppressif
@@ -1,0 +1,2 @@
+# Problem with C99 complex when optimizations with PGI are -O2 or higher.
+CHPL_TARGET_COMPILER <= pgi

--- a/test/performance/compiler/bradc/fft-timecomp.suppressif
+++ b/test/performance/compiler/bradc/fft-timecomp.suppressif
@@ -1,0 +1,2 @@
+# Problem with C99 complex when optimizations with PGI are -O2 or higher.
+CHPL_TARGET_COMPILER <= pgi


### PR DESCRIPTION
The two tests suppressed here get wrong answers when the generated code is
compiled with PGI with -O2, but are correct when compiled with -O1. They
have been failing since we started generating code using C99 complex.

Suppressing them was suggested by @bradcray.