### PR TITLE
Modify use of the new ChapelStringLiterals module

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2840,7 +2840,6 @@ void ModuleSymbol::addDefaultUses() {
     SET_LINENO(this);
 
     block->moduleUseAdd(rootModule);
-    block->moduleUseAdd(stringLiteralModule);
   }
 }
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -21,6 +21,7 @@
 //
 
 module ChapelBase {
+  use ChapelStringLiterals;
 
   // These two are called by compiler-generated code.
   extern proc chpl_config_has_value(name:c_string, module_name:c_string): bool;

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -1,6 +1,7 @@
 Initializing Modules:
    ChapelStandard
     ChapelBase
+     ChapelStringLiterals
     CPtr
     CString
     String


### PR DESCRIPTION
When I merged the string changes into my branch for adding the except keyword,
this line in symbol.cpp was causing me problems.  I determined that having
the compiler insert this use was unnecessary, so I removed its addition there
and added a use statement to ChapelBase (which was where it was getting
inserted).  This will avoid unnecessary fragility in my current branch to
otherwise fix the problem.

Modified the output of test/modules/sungeun/init/printModuleInitOrder,
as the additional use statement changed its output.

Tested over std/
(verified that the chpldoc failures I initially encountered were unrelated)