### PR TITLE
Update fft test to avoid printing error value when under threshold

### DIFF
--- a/test/studies/hpcc/FFT/bradc/fft.chpl
+++ b/test/studies/hpcc/FFT/bradc/fft.chpl
@@ -147,7 +147,7 @@ proc verifyResults(z, Z, execTime, Twiddles) {
   maxerr = maxerr / logN / epsilon;
 
   write(if (maxerr < threshold) then "SUCCESS" else "FAILURE");
-  writeln(", error = ", maxerr);
+  writeln(if (maxerr < threshold) then "" else ", error = " + maxerr);
   writeln();
   writeln("N      = ", N);
   if (printTiming) {

--- a/test/studies/hpcc/FFT/bradc/fft.good
+++ b/test/studies/hpcc/FFT/bradc/fft.good
@@ -1,3 +1,3 @@
-SUCCESS, error = 0.05
+SUCCESS
 
 N      = 32


### PR DESCRIPTION
For 32 bit platforms, the reported error value changed slightly when C99 complex
started being generated. It is still well under the threshold for success, so don't
report the error value unless it is above the threshold.  The error went from 0.05 to
0.111803, but the threshold for reporting success is 16.

I also tried adding a complex multiply operator overload to the test that does the
transformation:
c1 * c2 -> (c1.re*c2.re - c1.im*c2.im, c1.re*c2.im + c1.im*c2.re):complex.

Adding this overload to the test reduced the error back down to the previous expected
error value, but I decided to just not print the error value instead.

Tested on linux32, but expected to also fix cygwin32.