### PR TITLE
Replace 'substring' calls with string index operator '[]' in LCALS

### DIFF
--- a/test/studies/lcals/LCALSMain.chpl
+++ b/test/studies/lcals/LCALSMain.chpl
@@ -325,7 +325,7 @@ module main {
     var len_id = new vector(string);
     len_id.resize(suite_run_info.loop_length_names.size());
     for ilen in 0..#len_id.size() {
-      len_id[ilen] = suite_run_info.loop_length_names[ilen].substring(1);
+      len_id[ilen] = suite_run_info.loop_length_names[ilen][1];
     }
 
     var ver_info = buildVersionInfo();
@@ -469,7 +469,7 @@ module main {
 
     len_id.resize(suite_run_info.loop_length_names.size());
     for ilen in 0..#len_id.size() {
-      len_id[ilen] = suite_run_info.loop_length_names[ilen].substring(1);
+      len_id[ilen] = suite_run_info.loop_length_names[ilen][1];
     }
 
 


### PR DESCRIPTION
Replace '.substring(i)' with '[i]' in two places in LCALS to make it work with
the new string implementation.

Passed 'start_test LCALS_main.chpl -performance' on Mac.