### PR TITLE
Removed .bad for crash1callDestructorsMain.chpl

### DIFF
--- a/test/users/vass/crash1callDestructorsMain.bad
+++ b/test/users/vass/crash1callDestructorsMain.bad
@@ -1,7 +1,0 @@
-internal error: CAL or MIS
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/users/vass/crash1callDestructorsMain.future
+++ b/test/users/vass/crash1callDestructorsMain.future
@@ -6,6 +6,15 @@ Once this test works for --local, enable it for --no-local and re-test.
 NOTE: crash1callDestructorsAddon.chpl replicates half of
 crash1callDestructorsMain.chpl *intentionally*.
 
+12/9/2015: the failure mode is:
+
+$CHPL_HOME/modules/internal/ChapelDistribution.chpl:132: In function 'destroyDom':
+$CHPL_HOME/modules/internal/ChapelDistribution.chpl:141: internal error: EXP0492 chpl Version 1.12.0.42c96ad
+
+or, with --devel:
+
+SymExpr::verify      1539462:  var->defPoint is not in AST [expr.cpp:492]
+
 11/19/2014: the failure mode is:
 internal error: assertion error [callDestructors.cpp:671]
 

--- a/test/users/vass/crash1callDestructorsMain.prediff
+++ b/test/users/vass/crash1callDestructorsMain.prediff
@@ -1,5 +1,0 @@
-#!/bin/bash
-repl="internal error: CAL or MIS"
-sed "s/^\(internal error: CAL\).*$/$repl/" < $2 > $2.tmp
-sed "s/^\(internal error: MIS\).*$/$repl/" < $2.tmp > $2
-rm $2.tmp


### PR DESCRIPTION
by Brad's request, as a source of undue noise in nightly testing.

While there, I removed .prediff as well,
as it was needed only to help match .bad.

Also updated the current test output mentioned in the .future.
