### PR TITLE
Remove a passing .future

### DIFF
--- a/test/types/records/ferguson/array/iterate-array-break.future
+++ b/test/types/records/ferguson/array/iterate-array-break.future
@@ -1,1 +1,0 @@
-bug: iterator leaks memory if caller breaks out of loop


### PR DESCRIPTION
There is still a bug to do with breaking out of an iterator, but it seems
it is not triggered with this program presently. So I have removed
the .future file.