### PR TITLE
Modify use of the new ChapelStringLiterals module, attempt 2

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2840,7 +2840,9 @@ void ModuleSymbol::addDefaultUses() {
     SET_LINENO(this);
 
     block->moduleUseAdd(rootModule);
-    block->moduleUseAdd(stringLiteralModule);
+
+    UnresolvedSymExpr* modRef = new UnresolvedSymExpr("ChapelStringLiterals");
+    block->insertAtHead(new CallExpr(PRIM_USE, modRef));
   }
 }
 

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -1,6 +1,7 @@
 Initializing Modules:
    ChapelStandard
     ChapelBase
+     ChapelStringLiterals
     CPtr
     CString
     String


### PR DESCRIPTION
When I merged the string changes into my branch for adding the except keyword,
this line in symbol.cpp was causing me problems.  Kyle's preference was to
continue to insert the use of this module in the compiler instead of creating
a reference to a file that the reader cannot find in module space.  This change
will avoid unnecessary fragility in my current branch to otherwise fix the
problem.

Modified the output of test/modules/sungeun/init/printModuleInitOrder,
as the additional use statement changed its output.

Tested over std/