### PR TITLE
Updating tuple-of-string test for new strings

### DIFF
--- a/test/types/tuple/bradc/tupleOfNonIterableTypes.chpl
+++ b/test/types/tuple/bradc/tupleOfNonIterableTypes.chpl
@@ -1,0 +1,12 @@
+var A = (new R(), new R(), new R());
+
+for a in zip((...A)) {
+  writeln("a is: ", a);
+}
+
+//
+// This record intentionally supports no iterators
+//
+record R {
+  var x: int;
+}

--- a/test/types/tuple/bradc/tupleOfNonIterableTypes.good
+++ b/test/types/tuple/bradc/tupleOfNonIterableTypes.good
@@ -1,0 +1,1 @@
+tupleOfNonIterableTypes.chpl:3: error: cannot iterate over values of type R

--- a/test/types/tuple/bradc/tupleOfStrings.chpl
+++ b/test/types/tuple/bradc/tupleOfStrings.chpl
@@ -1,4 +1,4 @@
-var A = ("brad", "steve", "marybeth", "david", "samuel");
+var A = ("brad", "stev", "mary", "dave", "saml");
 
 for a in zip((...A)) {
   writeln("a is: ", a);

--- a/test/types/tuple/bradc/tupleOfStrings.good
+++ b/test/types/tuple/bradc/tupleOfStrings.good
@@ -1,5 +1,4 @@
 a is: (b, s, m, d, s)
 a is: (r, t, a, a, a)
 a is: (a, e, r, v, m)
-a is: (d, v, y, i, u)
-tupleOfStrings.chpl:3: error: zippered iterations have non-equal lengths
+a is: (d, v, y, e, l)


### PR DESCRIPTION
This test was originally written to improve and lock in an error
message indicating that iteration over strings was not permitted.
Now that it is permitted, the test "works", but generates an error
because the strings are of different lengths.  Yet, when running
--fast, such errors are disabled, so this test failed on fast
testing last night.

To make the test stable, I made the strings the same length
(sorry to my ex-colleagues for abbreviating your names to match
the four characters of 'brad').

Meanwhile, I introduced a new test (tupleOfNonIterableTypes.chpl)
to lock in the behavior that the tupleOfStrings test was originally
designed to test -- iterating over a tuple of types that did not
support iteration.