### PR TITLE
Close out numa, no-local, and linux32 regressions introduced last night

### DIFF
--- a/test/memory/shannon/printFinalMemStat.lm-numa.good
+++ b/test/memory/shannon/printFinalMemStat.lm-numa.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  368
-Total Allocated Memory                 880
-Total Freed Memory                     624
+Total Allocated Memory                 960
+Total Freed Memory                     704
 ==============================================================

--- a/test/memory/shannon/printFinalMemStat.no-local.good
+++ b/test/memory/shannon/printFinalMemStat.no-local.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  505
-Total Allocated Memory                 2097
-Total Freed Memory                     1841
+Total Allocated Memory                 2281
+Total Freed Memory                     2025
 ==============================================================

--- a/test/memory/sungeun/refCount/domainMaps.linux32.good
+++ b/test/memory/sungeun/refCount/domainMaps.linux32.good
@@ -9,7 +9,7 @@ Create domain:
 Create domain and array:
 	0 bytes leaked
 total:
-	143 bytes leaked
+	0 bytes leaked
 Block Dist
 ==========
 Copy of domain map:
@@ -21,7 +21,7 @@ Create domain:
 Create domain and array:
 	880 bytes leaked
 total:
-	1183 bytes leaked
+	1040 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -33,7 +33,7 @@ Create domain:
 Create domain and array:
 	884 bytes leaked
 total:
-	1347 bytes leaked
+	1204 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -45,16 +45,16 @@ Create domain:
 Create domain and array:
 	1560 bytes leaked
 total:
-	2223 bytes leaked
+	2080 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
-	32 bytes leaked
+	0 bytes leaked
 Return domain map:
-	152 bytes leaked
+	88 bytes leaked
 Create domain:
 	160 bytes leaked
 Create domain and array:
 	876 bytes leaked
 total:
-	1603 bytes leaked
+	1300 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.lm-numa.good
+++ b/test/memory/sungeun/refCount/domainMaps.lm-numa.good
@@ -9,7 +9,7 @@ Create domain:
 Create domain and array:
 	0 bytes leaked
 total:
-	286 bytes leaked
+	0 bytes leaked
 Block Dist
 ==========
 Copy of domain map:
@@ -21,7 +21,7 @@ Create domain:
 Create domain and array:
 	1136 bytes leaked
 total:
-	1710 bytes leaked
+	1424 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -33,7 +33,7 @@ Create domain:
 Create domain and array:
 	1144 bytes leaked
 total:
-	2006 bytes leaked
+	1720 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -45,16 +45,16 @@ Create domain:
 Create domain and array:
 	2392 bytes leaked
 total:
-	3510 bytes leaked
+	3224 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
-	32 bytes leaked
+	0 bytes leaked
 Return domain map:
-	248 bytes leaked
+	184 bytes leaked
 Create domain:
 	288 bytes leaked
 Create domain and array:
 	1120 bytes leaked
 total:
-	2406 bytes leaked
+	1960 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.no-local.good
+++ b/test/memory/sungeun/refCount/domainMaps.no-local.good
@@ -9,7 +9,7 @@ Create domain:
 Create domain and array:
 	0 bytes leaked
 total:
-	286 bytes leaked
+	0 bytes leaked
 Block Dist
 ==========
 Copy of domain map:
@@ -21,7 +21,7 @@ Create domain:
 Create domain and array:
 	2392 bytes leaked
 total:
-	8454 bytes leaked
+	8168 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -33,7 +33,7 @@ Create domain:
 Create domain and array:
 	2400 bytes leaked
 total:
-	7390 bytes leaked
+	7104 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -45,16 +45,16 @@ Create domain:
 Create domain and array:
 	3632 bytes leaked
 total:
-	6302 bytes leaked
+	6016 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
-	304 bytes leaked
+	272 bytes leaked
 Return domain map:
-	608 bytes leaked
+	544 bytes leaked
 Create domain:
 	1216 bytes leaked
 Create domain and array:
 	2344 bytes leaked
 total:
-	5366 bytes leaked
+	4920 bytes leaked

--- a/test/types/string/StringImpl/stress/plusEquals.suppressif
+++ b/test/types/string/StringImpl/stress/plusEquals.suppressif
@@ -1,1 +1,3 @@
+COMPOPTS <= --no-local
 CHPL_COMM!=none
+CHPL_LOCALE_MODEL == numa


### PR DESCRIPTION
This commit updates .good files and suppressions for numa, no-local, and
linux32 as needed by yesterday's string commit to quiet them.  Interestingly,
while memory stats are better overall for Sung's domainMap test (as with
the standard configurations that had already been updated), Shannon's
printFinalMemStat test got slightly worse.  But as with other changes, given
the net positives (and intent to make things more positive in short order),
this backslide seems worth it.

The .suppressif changes are motivated by the failures last night yet and
not surprising (one was anticipated but did not get implemented).
Unfortunately, they are problematic when testing on Macs because this
test does not fail there (e.g., plusEquals passed on gasnet.darwin
last night and reported a passing suppression as a result).  Here, I'm
relying on the fact that we don't do nightly no-local/numa testing on
Mac to rationalize this change.  If Mike didn't have his short-term
sights set on this test, I'd be more reluctant to add these lines
(alternatively, if we had boolean and we could suppress for linux as
well, but survey says we don't; and doing an executable skipif seemed
like overkill given the previous caveats).