### PR TITLE
Revert "Add the runtime as a dependency for modules and chpldoc"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,7 @@ compiler: FORCE
 parser: FORCE
 	cd compiler && $(MAKE) parser
 
-# modules calls make_sys_basic_types.py which needs to have the subset of
-# third-party libraries the runtime builds available. The easiest way to get
-# this behavior is to just depend on runtime. Depending on third-party would
-# cause all third party libs to be built.
-modules: runtime
+modules: FORCE
 	cd modules && $(MAKE)
 
 runtime: FORCE
@@ -111,8 +107,7 @@ third-party-chpldoc-venv: FORCE
 
 test-venv: third-party-test-venv
 
-# depens on runtime for the same reasons as the module target above.
-chpldoc: compiler runtime third-party-chpldoc-venv
+chpldoc: compiler third-party-chpldoc-venv
 	cd compiler && $(MAKE) chpldoc
 	cd modules && $(MAKE) sys-ctypes-docs
 	@test -r Makefile.devel && $(MAKE) man-chpldoc || echo ""


### PR DESCRIPTION
Reverts chapel-lang/chapel#3000 which added some non-determinism to the build somehow. I'm not really sure why this change makes the builds occasionally fail on some platforms, it works 100% of the time on my laptop, and some of the time with [travis]. I only noticed this once travis's backlog finally caught up to  my build and the post commit smokeTest went through.

[travis]: https://travis-ci.org/chapel-lang/chapel/builds/95947493