### PR TITLE
Fix errors in realPath arising from the string changes on Tuesday

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -517,7 +517,7 @@ proc locale.cwd(out error: syserr): string {
       ret = "";
     } else {
       var tmp_len = tmp.length;
-      ret = new string(tmp:c_ptr(uint(8)), tmp_len, tmp_len,
+      ret = new string(tmp:c_ptr(uint(8)), tmp_len, tmp_len+1,
                        owned=true, needToCopy=false);
     }
   }

--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -332,11 +332,17 @@ qioerr chpl_fs_mkdir(const char* name, int mode, int parents) {
 
 qioerr chpl_fs_realpath(const char* path, const char **shortened) {
   qioerr err = 0;
-  *shortened = realpath(path, NULL);
-  if (*shortened == NULL) {
-    // If an error occurred, shortened will be NULL.  Otherwise, it will
-    // contain the cleaned up path.
+  size_t bufsize = MAXPATHLEN*sizeof(char);
+  char* bufptr;
+  char* pathbuf = (char *)qio_malloc(bufsize);
+
+  bufptr = realpath(path, pathbuf);
+  if (bufptr == NULL) {
+    // If an error occurred, bufptr will be NULL.  Otherwise, it will
+    // point to pathbuf anyways
     err = qio_mkerror_errno();
+  } else {
+    *shortened = pathbuf;
   }
   return err;
 }

--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -85,10 +85,12 @@ qioerr chpl_fs_cwd(const char** working_dir) {
   char* bufptr;
   char* pathbuf = (char *)qio_malloc(bufsize);
   bufptr = getcwd(pathbuf, bufsize);
-  if (bufptr == NULL)
+  if (bufptr == NULL) {
     err = qio_mkerror_errno();
-  else
+    qio_free(pathbuf);
+  } else {
     *working_dir = pathbuf;
+  }
   return err;
 }
 
@@ -341,6 +343,7 @@ qioerr chpl_fs_realpath(const char* path, const char **shortened) {
     // If an error occurred, bufptr will be NULL.  Otherwise, it will
     // point to pathbuf anyways
     err = qio_mkerror_errno();
+    qio_free(pathbuf);
   } else {
     *shortened = pathbuf;
   }


### PR DESCRIPTION
Something about the way the C function realpath creates the buffer it returns
was reacting poorly with gasnet fast and the new string set up.  Since the
locale method cwd() did not experience the same error, I surmised that it was
better to follow cwd()'s buffer creation strategy and use qio_malloc to create
a buffer to send to realpath.  This resolved the errors I was seeing.

Also added a free call to the error case for cwd, and made the string
construction in cwd identical to that in realpath

I'm not entirely certain why our string changes tickled this, others might have
a better idea.