### PR TITLE
Retire Sung's c_string intents future

### DIFF
--- a/test/types/string/sungeun/c_string/intents-error.good
+++ b/test/types/string/sungeun/c_string/intents-error.good
@@ -1,0 +1,6 @@
+intents.chpl:14: error: non-lvalue actual is passed to 'out' formal 's' of fo()
+intents.chpl:15: error: non-lvalue actual is passed to 'inout' formal 's' of fio()
+intents.chpl:16: error: non-lvalue actual is passed to 'ref' formal 's' of fr()
+intents.chpl:28: error: non-lvalue actual is passed to 'out' formal 's' of go()
+intents.chpl:29: error: non-lvalue actual is passed to 'inout' formal 's' of gio()
+intents.chpl:30: error: non-lvalue actual is passed to 'ref' formal 's' of gr()

--- a/test/types/string/sungeun/c_string/intents-error2.good
+++ b/test/types/string/sungeun/c_string/intents-error2.good
@@ -1,0 +1,2 @@
+intents.chpl:38: error: unresolved call 'fo(c_string)'
+intents.chpl:7: note: candidates are: fo(out s: string)

--- a/test/types/string/sungeun/c_string/intents-error3.good
+++ b/test/types/string/sungeun/c_string/intents-error3.good
@@ -1,0 +1,2 @@
+intents.chpl:41: error: unresolved call 'fio(c_string)'
+intents.chpl:8: note: candidates are: fio(inout s: string)

--- a/test/types/string/sungeun/c_string/intents-error4.good
+++ b/test/types/string/sungeun/c_string/intents-error4.good
@@ -1,0 +1,2 @@
+intents.chpl:44: error: unresolved call 'fr(c_string)'
+intents.chpl:9: note: candidates are: fr(ref s: string)

--- a/test/types/string/sungeun/c_string/intents.bad
+++ b/test/types/string/sungeun/c_string/intents.bad
@@ -1,2 +1,0 @@
-intents.chpl:11: error: unresolved call 'fo("hi")'
-intents.chpl:5: note: candidates are: fo(out s: string)

--- a/test/types/string/sungeun/c_string/intents.chpl
+++ b/test/types/string/sungeun/c_string/intents.chpl
@@ -1,5 +1,7 @@
 use checkType;
 
+config param errorCase = 0;
+
 proc f(s: string) {  checkType(s.type); }
 proc fi(in s: string) { checkType(s.type); }
 proc fo(out s: string) { checkType(s.type); }
@@ -8,17 +10,11 @@ proc fr(ref s: string) { checkType(s.type); }
 
 f("hi");
 fi("hi");
-fo("hi");
-fio("hi");
-fr("hi");
-
-var s: c_string = "hi";
-s += s;
-f(s);
-fi(s);
-fo(s);
-fio(s);
-fr(s);
+if errorCase == 1 {
+  fo("hi"); 
+  fio("hi");
+  fr("hi");
+}
 
 proc g(s) {  checkType(s.type); }
 proc gi(in s) { checkType(s.type); }
@@ -28,6 +24,21 @@ proc gr(ref s) { checkType(s.type); }
 
 g("hi");
 gi("hi");
-go("hi");
-gio("hi");
-gr("hi");
+if errorCase == 1 {
+  go("hi");
+  gio("hi");
+  gr("hi");
+}
+
+var s: c_string = "hi";
+s += s;
+f(s);
+fi(s);
+if errorCase == 2 then
+   fo(s);
+
+if errorCase == 3 then
+   fio(s);
+
+if errorCase == 4 then
+   fr(s);

--- a/test/types/string/sungeun/c_string/intents.compopts
+++ b/test/types/string/sungeun/c_string/intents.compopts
@@ -1,0 +1,5 @@
+-serrorCase=0
+-serrorCase=1 # intents-error.good
+-serrorCase=2 # intents-error2.good
+-serrorCase=3 # intents-error3.good
+-serrorCase=4 # intents-error4.good

--- a/test/types/string/sungeun/c_string/intents.future
+++ b/test/types/string/sungeun/c_string/intents.future
@@ -1,2 +1,0 @@
-bug: Implicit conversion of c_string to string does not work for ref, out, or inout intents.
-


### PR DESCRIPTION
With the strings changes, this test seems to be working as we'd like
to me, though it's different than the .good predicted.  Specifically,
the test was trying to pass non-lvalue strings into routines with
'in', 'inout', and 'ref' intent, which should not be legal.  What
I've done here is to add a config param to look at different compile-time
failure modes while letting the cases that work as expected through.

Removed the .bad and .future and added .good files for the various
error cases.