### PR TITLE
Change make_sys_basic_types.py to not require third-party libs

### DIFF
--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -19,6 +19,7 @@ import optparse
 import os
 import os.path
 import re
+import subprocess
 import sys
 
 
@@ -91,8 +92,17 @@ def get_sys_c_types(docs=False):
 
     # Get the C compile line.
     compileline_cmd = os.path.join(util_cfg_dir, 'compileline')
-    cmd = '{compileline_cmd} --compile'.format(**locals())
-    compileline = os.popen(cmd).read().strip()
+
+    compileline_env = os.environ.copy()
+    # Make CHPL_COMM=none for the compile line command, we dont want any of the
+    # stuff from gasnet (we dont want to require gasnet to be built)
+    compileline_env['CHPL_COMM'] = 'none'
+    # We need to clear CHPL_MAKE_SETTINGS_NO_NEWLINES for our change to
+    # CHPL_COMM to actually work
+    compileline_env.pop('CHPL_MAKE_SETTINGS_NO_NEWLINES', None)
+    compileline_proc = subprocess.Popen([compileline_cmd, '--compile'],
+        stdout=subprocess.PIPE, env=compileline_env)
+    compileline = compileline_proc.communicate()[0].strip();
     logging.debug('Compile line: {0}'.format(compileline))
 
     # Create temp header file with *_MAX macros, then run it through the C


### PR DESCRIPTION
When using CHPL_COMM=gasnet, make_sys_basic_types would require Gasnet
to be built before it could run. Having CHPL_COMM set will not change
the output, so now it is set to none inside the command. This lets us
run make_sys_basic_types without having Gasnet built.