### PR TITLE
Update a few more tests for the new strings

### DIFF
--- a/test/classes/constructors/assign-param-segfault.bad
+++ b/test/classes/constructors/assign-param-segfault.bad
@@ -1,4 +1,5 @@
-internal error: MIS0453 chpl Version 1.11.0.e5a07fc
+assign-param-segfault.chpl:6: In constructor 'Bar':
+assign-param-segfault.chpl:11: internal error: EXP0492 chpl Version 1.12.0.223383c
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/types/string/StringImpl/memLeaks/relational.suppressif
+++ b/test/types/string/StringImpl/memLeaks/relational.suppressif
@@ -1,1 +1,0 @@
-CHPL_COMM!=none


### PR DESCRIPTION
Trivial .bad update for test/classes/constructors/assign-param-segfault

Removed suppression for test/types/string/StringImpl/memLeaks/relational
since the test passes now