### PR TITLE
Resolve HPL perf regression and memory leaks

### DIFF
--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -1004,8 +1004,10 @@ proc DimensionalDom.dsiBuildArray(type eltType)
 //== dsiAccess
 
 proc DimensionalArr.dsiAccess(indexx: dom.indexT) ref: eltType {
-  _traceddc(traceDimensionalDist || traceDimensionalDistDsiAccess,
-            this, ".dsiAccess", indexx);
+  if traceDimensionalDist || traceDimensionalDistDsiAccess {
+    _traceddc(traceDimensionalDist || traceDimensionalDistDsiAccess,
+              this, ".dsiAccess", indexx);
+  }
 
   if !isTuple(indexx) || indexx.size != 2 then
     compilerError("DimensionalDist2D presently supports only indexing with",


### PR DESCRIPTION
Fully param protect a call to _traceddc in DimensionalArr.dsiAccess. Previously
the param protection occurred inside the function, however this still resulted
in strings being copied to make the function call. This sort of param
protection inside a function isn't really a great idea and is the same issue we
had with #1200. There may be other places where the tracedd calls are leaking
memory, but this is by far the biggest one since it's in dsiAccess

This brings the "string copy data" memory leaks from 1,003,296 bytes down to
93,440 bytes. Prior to the string-as-rec merge we were at 229,402 bytes leaked,
so we're now doing even better than before..

This also resolves the performance regressions seen with HPL and HPL (max
logical)