### PR TITLE
Support linux_ppc64 as a platform if machine = ppc64.

### DIFF
--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -51,6 +51,8 @@ def get(flag='host'):
                     platform_val = "linux64_32"
                 else:
                     platform_val = "linux64"
+            elif machine == 'ppc64':
+                platform_val = "linux_ppc64"
             else:
                 platform_val = "linux32"
         elif platform_val.startswith("cygwin"):


### PR DESCRIPTION
This change was authored by Matt Baker.