### PR TITLE
Update runtime qthreads shim to match the one in third-party.

### DIFF
--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -430,5 +430,15 @@ c_sublocid_t chpl_task_getRequestedSubloc(void)
     return c_sublocid_any;
 }
 
+#ifdef CHPL_TASK_TASKS_BOUND_TO_PTHREADS_IMPL_DECL
+#error "CHPL_TASK_TASKS_BOUND_TO_PTHREADS_IMPL_DECL is already defined!"
+#else
+#define CHPL_TASK_TASKS_BOUND_TO_PTHREADS_IMPL_DECL 1
+#endif
+static inline
+int chpl_task_tasksBoundToPthreads(void) {
+  return 1;    // only correct for flat (nemesis); needs further work
+}
+
 #endif // ifndef _tasks_qthreads_h_
 /* vim:set expandtab: */

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -288,20 +288,26 @@ volatile int chpl_qthread_done_initializing;
 #endif
 
 typedef struct {
+    c_string task_filename;
+    int task_lineno;
+    chpl_taskID_t id;
+    chpl_bool is_executeOn;
     c_sublocid_t requestedSubloc;  // requested sublocal for task
     chpl_task_prvData_t prvdata;
 } chpl_task_prvDataImpl_t;
 
 // Define PRV_DATA_IMPL_VAL to set up a chpl_task_prvData_t.
-#define PRV_DATA_IMPL_VAL(subloc, serial) \
-        { .requestedSubloc = subloc, \
-          .prvdata = { .serial_state = serial } }
+#define PRV_DATA_IMPL_VAL(_fn, _ln, _id, _is_execOn, _subloc, _serial) \
+        { .task_filename = _fn, \
+          .task_lineno = _ln, \
+          .id = _id, \
+          .is_executeOn = _is_execOn, \
+          .requestedSubloc = _subloc, \
+          .prvdata = { .serial_state = _serial } }
 
 typedef struct {
     void                     *fn;
     void                     *args;
-    c_string                 task_filename;
-    int                      lineno;
     chpl_bool                countRunning;
     chpl_task_prvDataImpl_t  chpl_data;
 } chpl_qthread_wrapper_args_t;
@@ -313,8 +319,6 @@ typedef struct chpl_qthread_tls_s {
     /* Reports */
     c_string    lock_filename;
     size_t      lock_lineno;
-    const char *task_filename;
-    size_t      task_lineno;
 } chpl_qthread_tls_t;
 
 extern pthread_t chpl_qthread_process_pthread;

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -435,9 +435,10 @@ c_sublocid_t chpl_task_getRequestedSubloc(void)
 #else
 #define CHPL_TASK_TASKS_BOUND_TO_PTHREADS_IMPL_DECL 1
 #endif
+extern int chpl_qthread_tasks_bound_to_pthreads;
 static inline
 int chpl_task_tasksBoundToPthreads(void) {
-  return 1;    // only correct for flat (nemesis); needs further work
+  return chpl_qthread_tasks_bound_to_pthreads;
 }
 
 #endif // ifndef _tasks_qthreads_h_

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -430,15 +430,15 @@ c_sublocid_t chpl_task_getRequestedSubloc(void)
     return c_sublocid_any;
 }
 
-#ifdef CHPL_TASK_TASKS_BOUND_TO_PTHREADS_IMPL_DECL
-#error "CHPL_TASK_TASKS_BOUND_TO_PTHREADS_IMPL_DECL is already defined!"
+#ifdef CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL
+#error "CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL is already defined!"
 #else
-#define CHPL_TASK_TASKS_BOUND_TO_PTHREADS_IMPL_DECL 1
+#define CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL 1
 #endif
-extern int chpl_qthread_tasks_bound_to_pthreads;
+extern int chpl_qthread_supports_remote_cache;
 static inline
-int chpl_task_tasksBoundToPthreads(void) {
-  return chpl_qthread_tasks_bound_to_pthreads;
+int chpl_task_supportsRemoteCache(void) {
+  return chpl_qthread_supports_remote_cache;
 }
 
 #endif // ifndef _tasks_qthreads_h_

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -158,10 +158,10 @@ chpl_qthread_tls_t chpl_qthread_comm_task_tls = {
     NULL, 0 };
 
 //
-// TASKS_BOUND_TO_PTHREADS is set in the Chapel Qthreads Makefile,
-// based on the Qthreads scheduler configuration.
+// QTHREADS_SUPPORTS_REMOTE_CACHE is set in the Chapel Qthreads
+// Makefile, based on the Qthreads scheduler configuration.
 //
-int chpl_qthread_tasks_bound_to_pthreads = TASKS_BOUND_TO_PTHREADS;
+int chpl_qthread_supports_remote_cache = QTHREADS_SUPPORTS_REMOTE_CACHE;
 
 //
 // structs chpl_task_prvDataImpl_t, chpl_qthread_wrapper_args_t and

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -722,7 +722,14 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
 
     PROFILE_INCR(profile_task_addToTaskList,1);
 
-    if (serial_state) {
+    // Visual Debug -- should be protected by an #ifdef VISUALDEBUG?
+    if (chpl_vdebug) {
+       dprintf (chpl_vdebug_fd, "addToTaskList: %d %d %s %d %s\n"
+                chpl_nodeID, task_list_locale, (is_begin_stmt ? "begin" : "nb"),
+                lineno, filename);
+    }
+
+  if (serial_state) {
         // call the function directly.
         (chpl_ftable[fid])(arg);
     } else if (subloc == c_sublocid_any) {

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -40,7 +40,6 @@
 #include "chpl-comm.h"
 #include "chpl-locale-model.h"
 #include "chpl-tasks.h"
-#include "chpl-visual-debug.h"
 #include "config.h"
 #include "error.h"
 #include "arg.h"

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -158,6 +158,12 @@ chpl_qthread_tls_t chpl_qthread_comm_task_tls = {
     NULL, 0 };
 
 //
+// TASKS_BOUND_TO_PTHREADS is set in the Chapel Qthreads Makefile,
+// based on the Qthreads scheduler configuration.
+//
+int chpl_qthread_tasks_bound_to_pthreads = TASKS_BOUND_TO_PTHREADS;
+
+//
 // structs chpl_task_prvDataImpl_t, chpl_qthread_wrapper_args_t and
 // chpl_qthread_tls_t have been moved to tasks-qthreads.h
 //

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -849,10 +849,6 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
 
     PROFILE_INCR(profile_task_addToTaskList,1);
 
-    // Visual Debug
-    chpl_vdebug_log_task_queue(fid, arg, subloc, task_list, task_list_locale,
-                               is_begin_stmt, lineno, filename);
-
     if (serial_state) {
         // call the function directly.
         (chpl_ftable[fid])(arg);

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -40,6 +40,7 @@
 #include "chpl-comm.h"
 #include "chpl-locale-model.h"
 #include "chpl-tasks.h"
+#include "chpl-tasks-callbacks-internal.h"
 #include "config.h"
 #include "error.h"
 #include "arg.h"
@@ -642,117 +643,16 @@ void chpl_task_exit(void)
 #endif /* QTHREAD_MULTINODE */
 }
 
-//
-// Tasking callback support.
-//
-#define MAX_CBS_PER_EVENT 10
-
-static struct cb_info {
-    chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
-    chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
-    int count;
-} cb_info[chpl_task_cb_num_event_kinds];
-
-int chpl_task_install_callback(chpl_task_cb_event_kind_t event_kind,
-                               chpl_task_cb_info_kind_t info_kind,
-                               chpl_task_cb_fn_t cb_fn) {
-    int i;
-
-    if (event_kind >= chpl_task_cb_num_event_kinds) {
-        errno = ERANGE;
-        return -1;
-    }
-
-    i = cb_info[event_kind].count;
-
-    if (i >= MAX_CBS_PER_EVENT) {
-        errno = ENOMEM;
-        return -1;
-    }
-
-    cb_info[event_kind].count++;
-    cb_info[event_kind].fns[i]= cb_fn;
-    cb_info[event_kind].info_kinds[i] = info_kind;
-
-    return 0;
-}
-
-int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
-                                 chpl_task_cb_fn_t cb_fn) {
-    int i;
-    int found_i;
-
-    if (event_kind >= chpl_task_cb_num_event_kinds) {
-        errno = ERANGE;
-        return -1;
-    }
-
-    for (i = 0, found_i = -1; i < cb_info[event_kind].count; i++) {
-        if (cb_info[event_kind].fns[i] == cb_fn) {
-            found_i = i;
-            break;
-        }
-    }
-
-    if (found_i < 0) {
-        errno = ENOENT;
-        return -1;
-    }
-
-    for (i = found_i + 1; i < cb_info[event_kind].count; i++) {
-        cb_info[event_kind].fns[i - 1] =
-            cb_info[event_kind].fns[i];
-        cb_info[event_kind].info_kinds[i - 1] =
-            cb_info[event_kind].info_kinds[i];
-    }
-
-    cb_info[event_kind].count--;
-
-    return 0;
-}
-
-static inline void do_callbacks(chpl_task_cb_event_kind_t event_kind,
-                                chpl_task_prvDataImpl_t *chpl_data) {
-    struct cb_info *cbp;
-
-    assert(event_kind < chpl_task_cb_num_event_kinds);
-
-    cbp = &cb_info[event_kind];
-
-    if (cbp->count > 0) {
-        chpl_task_cb_info_t info;
-        int i;
-
-        info.nodeID = chpl_nodeID;
-        info.event_kind = event_kind;
-
+static inline void wrap_callbacks(chpl_task_cb_event_kind_t event_kind,
+                                  chpl_task_prvDataImpl_t *chpl_data) {
+    if (chpl_task_have_callbacks(event_kind)) {
         if (chpl_data->id == chpl_nullTaskID)
             chpl_data->id = qthread_incr(&next_task_id, 1);
-
-        for (i = 0; i < cbp->count; i++) {
-            info.info_kind = cbp->info_kinds[i];
-
-            switch (cbp->info_kinds[i]) {
-            case chpl_task_cb_info_kind_full:
-                info.iu.full = (struct chpl_task_info_full)
-                               { .filename = chpl_data->task_filename,
-                                 .lineno = chpl_data->task_lineno,
-                                 .id = chpl_data->id,
-                                 .is_executeOn = chpl_data->is_executeOn
-                               };
-              break;
-
-            case chpl_task_cb_info_kind_id_only:
-                info.iu.id_only.id = chpl_data->id;
-                break;
-
-            default:
-                assert(false);
-                break;
-            }
-
-            (*cbp->fns[i])((const chpl_task_cb_info_t*) &info);
-        }
+        chpl_task_do_callbacks(event_kind,
+                               chpl_data->task_filename,
+                               chpl_data->task_lineno,
+                               chpl_data->id,
+                               chpl_data->is_executeOn);
     }
 }
 
@@ -769,11 +669,11 @@ static aligned_t chapel_wrapper(void *arg)
         chpl_taskRunningCntInc(0, NULL);
     }
 
-    do_callbacks(chpl_task_cb_event_kind_begin, &data->chpl_data);
+    wrap_callbacks(chpl_task_cb_event_kind_begin, &data->chpl_data);
 
     (*(chpl_fn_p)(rarg->fn))(rarg->args);
 
-    do_callbacks(chpl_task_cb_event_kind_end, &data->chpl_data);
+    wrap_callbacks(chpl_task_cb_event_kind_end, &data->chpl_data);
 
     if (rarg->countRunning) {
         chpl_taskRunningCntDec(0, NULL);
@@ -802,7 +702,7 @@ void chpl_task_callMain(void (*chpl_main)(void))
     assert(SPR_OK == rc);
 #endif /* QTHREAD_MULTINODE */
 
-    do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
+    wrap_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
 
     qthread_fork_syncvar(chapel_wrapper, &wrapper_args, &exit_ret);
     qthread_syncvar_readFF(NULL, &exit_ret);
@@ -857,7 +757,9 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
              PRV_DATA_IMPL_VAL(filename, lineno, chpl_nullTaskID, false,
                                subloc, serial_state) };
 
-        do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
+        wrap_callbacks(chpl_task_cb_event_kind_create,
+                       &wrapper_args.chpl_data);
+
         if (subloc == c_sublocid_any) {
             qthread_fork_copyargs(chapel_wrapper, &wrapper_args,
                                   sizeof(chpl_qthread_wrapper_args_t), NULL);
@@ -900,7 +802,7 @@ void chpl_task_startMovedTask(chpl_fn_p      fp,
 
     PROFILE_INCR(profile_task_startMovedTask,1);
 
-    do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
+    wrap_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
 
     if (subloc == c_sublocid_any) {
         qthread_fork_copyargs(chapel_wrapper, &wrapper_args,

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -40,6 +40,7 @@
 #include "chpl-comm.h"
 #include "chpl-locale-model.h"
 #include "chpl-tasks.h"
+#include "chpl-visual-debug.h"
 #include "config.h"
 #include "error.h"
 #include "arg.h"

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -142,19 +142,21 @@ struct chpl_task_list {
     chpl_task_list_p next;
 };
 
+static aligned_t next_task_id = 1;
+
 pthread_t chpl_qthread_process_pthread;
 pthread_t chpl_qthread_comm_pthread;
 
 chpl_qthread_tls_t chpl_qthread_process_tls = {
-    PRV_DATA_IMPL_VAL(c_sublocid_any_val, false),
-    NULL, 0, NULL, 0 };
+    PRV_DATA_IMPL_VAL("<main task>", 0, chpl_nullTaskID, false,
+                      c_sublocid_any_val, false),
+    NULL, 0 };
 
 chpl_qthread_tls_t chpl_qthread_comm_task_tls = {
-    PRV_DATA_IMPL_VAL(c_sublocid_any_val, false),
-    NULL, 0, NULL, 0 };
- 
- //
- 
+    PRV_DATA_IMPL_VAL("<comm thread>", 0, chpl_nullTaskID, false,
+                      c_sublocid_any_val, false),
+    NULL, 0 };
+
 //
 // structs chpl_task_prvDataImpl_t, chpl_qthread_wrapper_args_t and
 // chpl_qthread_tls_t have been moved to tasks-qthreads.h
@@ -313,11 +315,11 @@ static void chapel_display_thread(qt_key_t     addr,
 
     if (rep) {
         if ((rep->lock_lineno > 0) && rep->lock_filename) {
-            fprintf(stderr, "Waiting at: %s:%zu (task %s:%zu)\n", rep->lock_filename, rep->lock_lineno, rep->task_filename, rep->task_lineno);
+            fprintf(stderr, "Waiting at: %s:%zu (task %s:%zu)\n", rep->lock_filename, rep->lock_lineno, rep->chpl_data.task_filename, rep->chpl_data.task_lineno);
         } else if (rep->lock_lineno == 0 && rep->lock_filename) {
-            fprintf(stderr, "Waiting for more work (line 0? file:%s) (task %s:%zu)\n", rep->lock_filename, rep->task_filename, rep->task_lineno);
+            fprintf(stderr, "Waiting for more work (line 0? file:%s) (task %s:%zu)\n", rep->lock_filename, rep->chpl_data.task_filename, rep->chpl_data.task_lineno);
         } else if (rep->lock_lineno == 0) {
-            fprintf(stderr, "Waiting for dependencies (uninitialized task %s:%zu)\n", rep->task_filename, rep->task_lineno);
+            fprintf(stderr, "Waiting for dependencies (uninitialized task %s:%zu)\n", rep->chpl_data.task_filename, rep->chpl_data.task_lineno);
         }
         fflush(stderr);
     }
@@ -586,6 +588,7 @@ void chpl_task_init(void)
     pthread_t initer;
 
     chpl_qthread_process_pthread = pthread_self();
+    chpl_qthread_process_tls.chpl_data.id = qthread_incr(&next_task_id, 1);
 
     commMaxThreads = chpl_comm_getMaxThreads();
 
@@ -634,13 +637,123 @@ void chpl_task_exit(void)
 #endif /* QTHREAD_MULTINODE */
 }
 
+//
+// Tasking callback support.
+//
+#define MAX_CBS_PER_EVENT 10
+
+static struct cb_info {
+  chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
+  chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
+  int count;
+} cb_info[chpl_task_cb_num_event_kinds];
+
+int chpl_task_install_callback(chpl_task_cb_event_kind_t event_kind,
+                               chpl_task_cb_info_kind_t info_kind,
+                               chpl_task_cb_fn_t cb_fn) {
+  int i;
+
+  if (event_kind >= chpl_task_cb_num_event_kinds) {
+    errno = ERANGE;
+    return -1;
+  }
+
+  i = cb_info[event_kind].count;
+
+  if (i >= MAX_CBS_PER_EVENT) {
+    errno = ENOMEM;
+    return -1;
+  }
+
+  cb_info[event_kind].count++;
+  cb_info[event_kind].fns[i]= cb_fn;
+  cb_info[event_kind].info_kinds[i] = info_kind;
+
+  return 0;
+}
+
+int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
+                                 chpl_task_cb_fn_t cb_fn) {
+  int i;
+  int found_i;
+
+  if (event_kind >= chpl_task_cb_num_event_kinds) {
+    errno = ERANGE;
+    return -1;
+  }
+
+  for (i = 0, found_i = -1; i < cb_info[event_kind].count; i++) {
+    if (cb_info[event_kind].fns[i] == cb_fn) {
+      found_i = i;
+      break;
+    }
+  }
+
+  if (found_i < 0) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  for (i = found_i + 1; i < cb_info[event_kind].count; i++) {
+    cb_info[event_kind].fns[i - 1] = cb_info[event_kind].fns[i];
+    cb_info[event_kind].info_kinds[i - 1] = cb_info[event_kind].info_kinds[i];
+  }
+
+  cb_info[event_kind].count--;
+
+  return 0;
+}
+
+static inline void do_callbacks(chpl_task_cb_event_kind_t event_kind,
+                                chpl_task_prvDataImpl_t *chpl_data) {
+    struct cb_info *cbp;
+
+    assert(event_kind < chpl_task_cb_num_event_kinds);
+
+    cbp = &cb_info[event_kind];
+
+    if (cbp->count > 0) {
+        chpl_task_cb_info_t info;
+        int i;
+
+        info.nodeID = chpl_nodeID;
+        info.event_kind = event_kind;
+
+        if (chpl_data->id == chpl_nullTaskID)
+            chpl_data->id = qthread_incr(&next_task_id, 1);
+
+        for (i = 0; i < cbp->count; i++) {
+            info.info_kind = cbp->info_kinds[i];
+
+            switch (cbp->info_kinds[i]) {
+            case chpl_task_cb_info_kind_full:
+                info.iu.full = (struct chpl_task_info_full)
+                               { .filename = chpl_data->task_filename,
+                                 .lineno = chpl_data->task_lineno,
+                                 .id = chpl_data->id,
+                                 .is_executeOn = chpl_data->is_executeOn
+                               };
+              break;
+
+            case chpl_task_cb_info_kind_id_only:
+                info.iu.id_only.id = chpl_data->id;
+                break;
+
+            default:
+                assert(false);
+                break;
+            }
+
+            (*cbp->fns[i])((const chpl_task_cb_info_t*) &info);
+        }
+    }
+}
+
 static aligned_t chapel_wrapper(void *arg)
 {
     chpl_qthread_wrapper_args_t *rarg = arg;
     chpl_qthread_tls_t * data = chpl_qthread_get_tasklocal();
 
-    data->task_filename = rarg->task_filename;
-    data->task_lineno = rarg->lineno;
     data->chpl_data = rarg->chpl_data;
     data->lock_filename = NULL;
     data->lock_lineno = 0;
@@ -649,7 +762,11 @@ static aligned_t chapel_wrapper(void *arg)
         chpl_taskRunningCntInc(0, NULL);
     }
 
+    do_callbacks(chpl_task_cb_event_kind_begin, &data->chpl_data);
+
     (*(chpl_fn_p)(rarg->fn))(rarg->args);
+
+    do_callbacks(chpl_task_cb_event_kind_end, &data->chpl_data);
 
     if (rarg->countRunning) {
         chpl_taskRunningCntDec(0, NULL);
@@ -664,9 +781,11 @@ static aligned_t chapel_wrapper(void *arg)
 // not use methods that require task context (e.g., task-local storage).
 void chpl_task_callMain(void (*chpl_main)(void))
 {
-    const chpl_qthread_wrapper_args_t wrapper_args = 
-        {chpl_main, NULL, NULL, 0, false,
-         PRV_DATA_IMPL_VAL(c_sublocid_any_val, false) };
+    chpl_qthread_wrapper_args_t wrapper_args =
+        {chpl_main, NULL, false,
+         PRV_DATA_IMPL_VAL("<main task>", 0,
+                           chpl_qthread_process_tls.chpl_data.id, false,
+                           c_sublocid_any_val, false) };
 
     qthread_debug(CHAPEL_CALLS, "[%d] begin chpl_task_callMain()\n", chpl_nodeID);
 
@@ -675,6 +794,8 @@ void chpl_task_callMain(void (*chpl_main)(void))
     int const rc = spr_unify();
     assert(SPR_OK == rc);
 #endif /* QTHREAD_MULTINODE */
+
+    do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
 
     qthread_fork_syncvar(chapel_wrapper, &wrapper_args, &exit_ret);
     qthread_syncvar_readFF(NULL, &exit_ret);
@@ -715,9 +836,6 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
                              c_string          filename)
 {
     chpl_bool serial_state = chpl_task_getSerial();
-    chpl_qthread_wrapper_args_t wrapper_args =
-        {chpl_ftable[fid], arg, filename, lineno, false,
-         PRV_DATA_IMPL_VAL(subloc, serial_state) };
 
     assert(subloc != c_sublocid_none);
 
@@ -730,13 +848,21 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
     if (serial_state) {
         // call the function directly.
         (chpl_ftable[fid])(arg);
-    } else if (subloc == c_sublocid_any) {
-        qthread_fork_copyargs(chapel_wrapper, &wrapper_args,
-                              sizeof(chpl_qthread_wrapper_args_t), NULL);
     } else {
-        qthread_fork_copyargs_to(chapel_wrapper, &wrapper_args,
-                                 sizeof(chpl_qthread_wrapper_args_t), NULL,
-                                 (qthread_shepherd_id_t) subloc);
+        chpl_qthread_wrapper_args_t wrapper_args =
+            {chpl_ftable[fid], arg, false,
+             PRV_DATA_IMPL_VAL(filename, lineno, chpl_nullTaskID, false,
+                               subloc, serial_state) };
+
+        do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
+        if (subloc == c_sublocid_any) {
+            qthread_fork_copyargs(chapel_wrapper, &wrapper_args,
+                                  sizeof(chpl_qthread_wrapper_args_t), NULL);
+        } else {
+            qthread_fork_copyargs_to(chapel_wrapper, &wrapper_args,
+                                     sizeof(chpl_qthread_wrapper_args_t), NULL,
+                                     (qthread_shepherd_id_t) subloc);
+        }
     }
 }
 
@@ -764,12 +890,14 @@ void chpl_task_startMovedTask(chpl_fn_p      fp,
     assert(subloc != c_sublocid_none);
     assert(id == chpl_nullTaskID);
 
-    chpl_qthread_wrapper_args_t wrapper_args = 
-        {fp, arg, NULL, 0, canCountRunningTasks,
-         PRV_DATA_IMPL_VAL(subloc, serial_state) };
-
+    chpl_qthread_wrapper_args_t wrapper_args =
+        {fp, arg, canCountRunningTasks,
+         PRV_DATA_IMPL_VAL("<unknown>", 0, chpl_nullTaskID, true,
+                           subloc, serial_state) };
 
     PROFILE_INCR(profile_task_startMovedTask,1);
+
+    do_callbacks(chpl_task_cb_event_kind_create, &wrapper_args.chpl_data);
 
     if (subloc == c_sublocid_any) {
         qthread_fork_copyargs(chapel_wrapper, &wrapper_args,
@@ -797,9 +925,17 @@ void chpl_task_startMovedTask(chpl_fn_p      fp,
 // Returns '(unsigned int)-1' if called outside of the tasking layer.
 chpl_taskID_t chpl_task_getId(void)
 {
+    chpl_qthread_tls_t * tls = chpl_qthread_get_tasklocal();
+
     PROFILE_INCR(profile_task_getId,1);
 
-    return (chpl_taskID_t)qthread_id();
+    if (tls == NULL)
+        return (chpl_taskID_t) -1;
+
+    if (tls->chpl_data.id == chpl_nullTaskID)
+        tls->chpl_data.id = qthread_incr(&next_task_id, 1);
+
+    return tls->chpl_data.id;
 }
 
 void chpl_task_sleep(int secs)

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -727,7 +727,7 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
       struct timeval tv;
       struct timezone tz = {0,0};
       (void)gettimeofday(&tv, &tz);
-      dprintf (chpl_vdebug_fd, "task: %lld.%06d %d %d %s %d %s\n",
+      chpl_dprintf (chpl_vdebug_fd, "task: %lld.%06d %d %d %s %d %s\n",
                (long long) tv.tv_sec, tv.tv_usec,
                chpl_nodeID, task_list_locale, (is_begin_stmt ? "begin" : "nb"),
                lineno, filename);

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -643,65 +643,67 @@ void chpl_task_exit(void)
 #define MAX_CBS_PER_EVENT 10
 
 static struct cb_info {
-  chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
-  chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
-  int count;
+    chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
+    chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
+    int count;
 } cb_info[chpl_task_cb_num_event_kinds];
 
 int chpl_task_install_callback(chpl_task_cb_event_kind_t event_kind,
                                chpl_task_cb_info_kind_t info_kind,
                                chpl_task_cb_fn_t cb_fn) {
-  int i;
+    int i;
 
-  if (event_kind >= chpl_task_cb_num_event_kinds) {
-    errno = ERANGE;
-    return -1;
-  }
+    if (event_kind >= chpl_task_cb_num_event_kinds) {
+        errno = ERANGE;
+        return -1;
+    }
 
-  i = cb_info[event_kind].count;
+    i = cb_info[event_kind].count;
 
-  if (i >= MAX_CBS_PER_EVENT) {
-    errno = ENOMEM;
-    return -1;
-  }
+    if (i >= MAX_CBS_PER_EVENT) {
+        errno = ENOMEM;
+        return -1;
+    }
 
-  cb_info[event_kind].count++;
-  cb_info[event_kind].fns[i]= cb_fn;
-  cb_info[event_kind].info_kinds[i] = info_kind;
+    cb_info[event_kind].count++;
+    cb_info[event_kind].fns[i]= cb_fn;
+    cb_info[event_kind].info_kinds[i] = info_kind;
 
-  return 0;
+    return 0;
 }
 
 int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
                                  chpl_task_cb_fn_t cb_fn) {
-  int i;
-  int found_i;
+    int i;
+    int found_i;
 
-  if (event_kind >= chpl_task_cb_num_event_kinds) {
-    errno = ERANGE;
-    return -1;
-  }
-
-  for (i = 0, found_i = -1; i < cb_info[event_kind].count; i++) {
-    if (cb_info[event_kind].fns[i] == cb_fn) {
-      found_i = i;
-      break;
+    if (event_kind >= chpl_task_cb_num_event_kinds) {
+        errno = ERANGE;
+        return -1;
     }
-  }
 
-  if (found_i < 0) {
-    errno = ENOENT;
-    return -1;
-  }
+    for (i = 0, found_i = -1; i < cb_info[event_kind].count; i++) {
+        if (cb_info[event_kind].fns[i] == cb_fn) {
+            found_i = i;
+            break;
+        }
+    }
 
-  for (i = found_i + 1; i < cb_info[event_kind].count; i++) {
-    cb_info[event_kind].fns[i - 1] = cb_info[event_kind].fns[i];
-    cb_info[event_kind].info_kinds[i - 1] = cb_info[event_kind].info_kinds[i];
-  }
+    if (found_i < 0) {
+        errno = ENOENT;
+        return -1;
+    }
 
-  cb_info[event_kind].count--;
+    for (i = found_i + 1; i < cb_info[event_kind].count; i++) {
+        cb_info[event_kind].fns[i - 1] =
+            cb_info[event_kind].fns[i];
+        cb_info[event_kind].info_kinds[i - 1] =
+            cb_info[event_kind].info_kinds[i];
+    }
 
-  return 0;
+    cb_info[event_kind].count--;
+
+    return 0;
 }
 
 static inline void do_callbacks(chpl_task_cb_event_kind_t event_kind,

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -682,11 +682,16 @@ static aligned_t chapel_wrapper(void *arg)
     return 0;
 }
 
+typedef struct {
+    chpl_fn_p fn;
+    void *arg;
+} comm_task_wrapper_info_t;
+
 static void *comm_task_wrapper(void *arg)
 {
-    chpl_qthread_wrapper_args_t *rarg = arg;
+    comm_task_wrapper_info_t *rarg = arg;
     chpl_moveToLastCPU();
-    (*(chpl_fn_p)(rarg->fn))(rarg->args);
+    (*(chpl_fn_p)(rarg->fn))(rarg->arg);
     return 0;
 }
 
@@ -734,9 +739,18 @@ int chpl_task_createCommTask(chpl_fn_p fn,
                              void     *arg)
 {
 #ifndef QTHREAD_MULTINODE
-    chpl_qthread_wrapper_args_t wrapper_args = {fn, arg, false, {0}};
+    //
+    // The wrapper info must be static because it won't be referred to
+    // until the new pthread calls comm_task_wrapper().  And, it is
+    // safe for it to be static because we will be called at most once
+    // on each node.
+    //
+    static
+        comm_task_wrapper_info_t wrapper_info;
+    wrapper_info.fn = fn;
+    wrapper_info.arg = arg;
     return pthread_create(&chpl_qthread_comm_pthread,
-                          NULL, comm_task_wrapper, &wrapper_args);
+                          NULL, comm_task_wrapper, &wrapper_info);
 #else
     return 0;
 #endif

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -723,18 +723,11 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
 
     PROFILE_INCR(profile_task_addToTaskList,1);
 
-    // Visual Debug -- should be protected by an #ifdef VISUALDEBUG?
-    if (chpl_vdebug) {
-      struct timeval tv;
-      struct timezone tz = {0,0};
-      (void)gettimeofday(&tv, &tz);
-      chpl_dprintf (chpl_vdebug_fd, "task: %lld.%06d %d %d %s %d %s\n",
-               (long long) tv.tv_sec, tv.tv_usec,
-               chpl_nodeID, task_list_locale, (is_begin_stmt ? "begin" : "nb"),
-               lineno, filename);
-    }
+    // Visual Debug
+    chpl_vdebug_log_task_queue(fid, arg, subloc, task_list, task_list_locale,
+                               is_begin_stmt, lineno, filename);
 
-  if (serial_state) {
+    if (serial_state) {
         // call the function directly.
         (chpl_ftable[fid])(arg);
     } else if (subloc == c_sublocid_any) {

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -682,6 +682,14 @@ static aligned_t chapel_wrapper(void *arg)
     return 0;
 }
 
+static void *comm_task_wrapper(void *arg)
+{
+    chpl_qthread_wrapper_args_t *rarg = arg;
+    chpl_moveToLastCPU();
+    (*(chpl_fn_p)(rarg->fn))(rarg->args);
+    return 0;
+}
+
 // Start the main task.
 //
 // Warning: this method is not called within a Qthread task context. Do
@@ -726,8 +734,9 @@ int chpl_task_createCommTask(chpl_fn_p fn,
                              void     *arg)
 {
 #ifndef QTHREAD_MULTINODE
+    chpl_qthread_wrapper_args_t wrapper_args = {fn, arg, false, {0}};
     return pthread_create(&chpl_qthread_comm_pthread,
-                          NULL, (void *(*)(void *))fn, arg);
+                          NULL, comm_task_wrapper, &wrapper_args);
 #else
     return 0;
 #endif

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -724,9 +724,13 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
 
     // Visual Debug -- should be protected by an #ifdef VISUALDEBUG?
     if (chpl_vdebug) {
-       dprintf (chpl_vdebug_fd, "addToTaskList: %d %d %s %d %s\n"
-                chpl_nodeID, task_list_locale, (is_begin_stmt ? "begin" : "nb"),
-                lineno, filename);
+      struct timeval tv;
+      struct timezone tz = {0,0};
+      (void)gettimeofday(&tv, &tz);
+      dprintf (chpl_vdebug_fd, "task: %lld.%06d %d %d %s %d %s\n",
+               (long long) tv.tv_sec, tv.tv_usec,
+               chpl_nodeID, task_list_locale, (is_begin_stmt ? "begin" : "nb"),
+               lineno, filename);
     }
 
   if (serial_state) {


### PR DESCRIPTION
We last arranged to update the Chapel tasking shim in the Qthreads repo
back in the summer, and the copy of the shim we just dropped into the
runtime therefore doesn't have any changes Cray has made to its copy of
the shim in third-party since then.  Here we update the runtime copy of the
shim with all these changes.

As this point the runtime copy of the shim matches the Chapel third-party
one except for the addition of the Cray copyright in the former.  The runtime
copy is still not referenced by builds, however, and I feel fairly certain it will
not build due to references to some Qthreads functions which are not in the
public interface. Getting that all fixed up is next.

Note:
I made the changes by duplicating each commit individually.  I applied
them using 'git show --patch <sha>' and 'git apply', and committed them
using 'git commit -C <sha>' (in both cases there were other, secondary
options).  This results in each new commit having the same author and
Iimestamp as the original, but the Committer and CommitDate are for the
duplication.  I could have used 'git format-patch' and 'git am' for the
cases in which only the .h or .c file was changed, but the couldn't work
when both files changed because in third-party the .h and .c are in the
same directory and in the runtime they are in different ones, and the
git options to manipulate the directory paths couldn't get both files
right at the same time.  So to make everything work the same every time
I just separated the apply and commit.