### PR TITLE
Adjust chpl_memcpy to allow src==dst if len==0

### DIFF
--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -129,7 +129,7 @@ void chpl_mem_free(void* memAlloc, int32_t lineno, c_string filename) {
 static inline
 void* chpl_memcpy(void* dest, const void* src, size_t num)
 {
-  assert(dest != src);
+  assert(dest != src || num == 0);
   return memcpy(dest, src, num);
 }
 


### PR DESCRIPTION
I was seeing failures in

      test/expressions/lydia/noinit/enumCheckUninit.chpl

in debug builds due to chpl_memcpy call like this

      chpl_memcpy(NULL, NULL, 0);
      
This is partly due to QIO and partly due to the new string
implementation. The QIO code is simpler/faster if memcpy can be relied
upon to handle the 0-length case.

I updated chpl_memcpy to allow dst==src if len==0.

- [x] verified that the test in question passes with valgrind after this change.
- [x] test/release/examples pass

Trivial and not reviewed.
