### PR TITLE
Quiet an uninitialized variable warning

### DIFF
--- a/runtime/src/qio/qio_popen.c
+++ b/runtime/src/qio/qio_popen.c
@@ -361,7 +361,7 @@ qioerr qio_proc_communicate(
     qio_channel_t* error) {
 
   qioerr err = 0;
-  int rc;
+  int rc = 0;
   bool do_input;
   bool do_output;
   bool do_error;


### PR DESCRIPTION
#2827 changed the control flow in some qio_popen code which resulted in a path
where `rc` could be uninitialized. This is currently breaking our nightly
(WARNINGS=1) build for all our machines that use gcc 4.7.