### PR TITLE
Add perf annotations for the regexdna mem-leak/perf fix

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -274,12 +274,18 @@ memleaks:
     - Nikhil's k-d tests added to repository
   12/11/15:
     - Fixed string leak in DimensionalDist2D (#3013)
+  12/13/15:
+    - Fixed string memory leak resulting from redundant autoCopies (#3023)
 
 memleaksfull:
   07/08/14:
     - Conversion of knucleotide-forall and -coforall to read input line-by-line (23733).
   07/10/14:
     - Included tests that leak only string data in the Number of Tests with Leaks (r23785).
+  12/11/15:
+    - Fixed string leak in DimensionalDist2D (#3013)
+  12/13/15:
+    - Fixed string memory leak resulting from redundant autoCopies (#3023)
 
 meteor:
   12/18/13:
@@ -314,6 +320,8 @@ regexdna:
     - Add c_string_copy type
   11/29/15:
     - started building re2 with optimizations (#2930)
+  12/13/15:
+    - Fixed string memory leak resulting from redundant autoCopies (#3023)
 
 revcomp:
   05/11/15:


### PR DESCRIPTION
#3023 resolved the regexdna memory leaks that resulted from the string-as-rec
merge. It was the last leak that was introduced, so we're now leaking less than
we were before the string-as-rec merge.

It also partially resolved the regexdna performance regression from the
string-as-rec merge, though there is still some work to be done.