### PR TITLE
Fix cce link/sungeun/static_dynamic regression

### DIFF
--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -5,7 +5,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_compiler, chpl_llvm, chpl_locale_model, third_party_utils, utils
-from utils import memoize
+from utils import memoize, compiler_is_prgenv
 
 
 @memoize
@@ -21,7 +21,8 @@ def get_link_args():
                                                 libs=['libqthread_chpl.la',
                                                       '-lchpl',
                                                       'libqthread.la'])
-    if ( chpl_compiler.get('target').startswith('cray-prgenv') and
-         chpl_llvm.get() != 'none' ):
+    compiler_val = chpl_compiler.get('target')
+    if ( compiler_val == 'cray-prgenv-cray' or
+         (compiler_is_prgenv(compiler_val) and chpl_llvm.get() != 'none' )):
         link_args.append('-lrt')
     return link_args


### PR DESCRIPTION
The --dynamic versions of this test started failing with cce when qthreads was
made the default. To fix this, I'm adding -lrt as a link arg to qthreads when
cce is the target compiler.

Looking at `cc -craype-verbose -static` and `cc -craype-verbose -dynamic` we
can see that the `-static` versions automatically adds a `-lrt`, but the
dynamic version does not. `-static` is the default so I think during qthreads
build time it detects that it does not need to link librt itself. Then when a
chapel executable is being dynamically linked librt is missing.

I believe this is a similar issue that we ran into with #1466 and the follow-up
#1470. I'm not sure why this isn't an issue for gnu, intel, or pgi.