### PR TITLE
Fix QIO problems exposed on linux32 with recordReader

### DIFF
--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -2432,6 +2432,7 @@ void _qio_buffered_advance_cached(qio_channel_t* ch)
     // before a read or a write, we'll recompute it in a jiffy.
     ch->cached_cur = NULL;
     ch->cached_end = NULL;
+    ch->cached_start = NULL;
   }
 
   _qio_channel_set_error_unlocked(ch, err);

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -79,8 +79,13 @@
 #endif
 #endif
 
+// A few global variables that control which I/O strategy is used.
+// See choose_io_method.
+
+// We don't want to use mmap to work with files that are too small
+// because operating on such files would use a lot of extra memory
+// when rounding up to 4k pages.
 ssize_t qio_too_small_for_default_mmap = 16*1024;
-ssize_t qio_too_large_for_default_mmap = 64*1024*((size_t)1024*1024);
 ssize_t qio_mmap_chunk_iobufs = 128; // mmap 128 iobufs at a time (8M)
 
 // Future - possibly set this based on ulimit?
@@ -567,8 +572,6 @@ qio_hint_t choose_io_method(qio_file_t* file, qio_hint_t hints, qio_hint_t defau
             // default case
             if( qio_allow_default_mmap && (!writing) &&
                 qio_too_small_for_default_mmap <= file_size &&
-                file_size < SSIZE_MAX &&
-                file_size < qio_too_large_for_default_mmap &&
                 (qbytes_iobuf_size & 4095) == 0) {
               // not writing, not too small, not too big, iobuf size multiple of 4k.
               method = QIO_METHOD_MMAP;

--- a/test/io/tzakian/recordReader/test.chpl
+++ b/test/io/tzakian/recordReader/test.chpl
@@ -1,6 +1,15 @@
 use RecordParser;
+
+// Allow test to run with mmap or without since this test has exposed
+// QIO errors in the past for one of these configurations.
+config const no_mmap=false;
+var hints=IOHINT_NONE;
+if no_mmap {
+  hints = QIO_METHOD_PREADPWRITE;
+}
+
 var f = open("input1.txt", iomode.rw);
-var ff = open("input2_beer.txt", iomode.rw);
+var ff = open("input2_beer.txt", iomode.rw, hints=hints);
 var fr = f.reader();
 var ffr = ff.reader();
 

--- a/test/io/tzakian/recordReader/test.execopts
+++ b/test/io/tzakian/recordReader/test.execopts
@@ -1,0 +1,2 @@
+--no_mmap=false
+--no_mmap=true


### PR DESCRIPTION
This PR fixes two problems with QIO:
1) linux32 and linux64 had very different behavior for whether or not
   mmap was used for reading
2) if mmap was not used for reading, the test

      test/io/tzakian/recordReader/test.chpl

was failing due to a pattern of calls in which channel->cached_start was
not set to NULL when it should have been. This behavior was only exposed
when mmap was not used for reading, and so the error appeared only on
linux32 because of the first bug.

In addition, this PR adjusts that test to test both mmap and non-mmap
reading for the future.

The individual commit messages have a little bit more detail.

- [x] recordReader test passes on linux32
- [x] recordReader test passes on cygwin32
- [x] full local testing

Trivial bug fix, not reviewed.