### PR TITLE
Change make_sys_basic_types to be compatible with Python 3

### DIFF
--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -102,7 +102,7 @@ def get_sys_c_types(docs=False):
     compileline_env.pop('CHPL_MAKE_SETTINGS_NO_NEWLINES', None)
     compileline_proc = subprocess.Popen([compileline_cmd, '--compile'],
         stdout=subprocess.PIPE, env=compileline_env)
-    compileline = compileline_proc.communicate()[0].strip();
+    compileline = compileline_proc.communicate()[0].decode().strip();
     logging.debug('Compile line: {0}'.format(compileline))
 
     # Create temp header file with *_MAX macros, then run it through the C


### PR DESCRIPTION
communicate() returns a tuple of byte strings in python 3. Decode to a
string so the rest of the code is happy.