### PR TITLE
Back out use of -Wa,-q

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -73,13 +73,8 @@ IEEE_FLOAT_GEN_CFLAGS = -fno-fast-math
 ifeq ($(CHPL_MAKE_PLATFORM), darwin)
 # build 64-bit binaries when on a 64-bit capable PowerPC
 ARCH := $(shell test -x /usr/bin/machine -a `/usr/bin/machine` = ppc970 && echo -arch ppc64)
-# -Wa,-q passes control over from the horribly outdated version of as to clang's
-#  as this is needed to set things like -march=native or else gcc will generate
-#  instructions as can't actually assemble.
-RUNTIME_CFLAGS += $(ARCH) -Wa,-q
-RUNTIME_CXXFLAGS += $(ARCH) -Wa,-q
 # the -D_POSIX_C_SOURCE flag prevents nonstandard functions from polluting the global name space
-GEN_CFLAGS += -D_POSIX_C_SOURCE $(ARCH) -Wa,-q
+GEN_CFLAGS += -D_POSIX_C_SOURCE $(ARCH)
 GEN_LFLAGS += $(ARCH)
 endif
 


### PR DESCRIPTION
In 1c3bf118717110672d4965ee0eb5ec9fc28a7c90, Kyle added -Wa,-q in
order to get -march= flags to work on versions of gcc provided by
OS X.  On newer versions of OS X, this flag no longer seems to be
needed and, worse, generates errors:

    mbp-bradc$ gcc -Wa,-q chapel/testit.c
    clang: error: unsupported argument '-q' to option 'Wa,'

    mbp-bradc$ which gcc
    /usr/bin/gcc

    mbp-bradc$ gcc --version
    Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
    Apple LLVM version 7.0.2 (clang-700.1.81)
    Target: x86_64-apple-darwin15.2.0
    Thread model: posix

Kyle did his own analysis and agreed that it didn't seem like it
was necessary on key gcc's that we care about anymore.  A spot-check
on our Mac used for testing suggests to me that this shouldn't
break testing.