### PR TITLE
Enable Qthreads tasking shim in runtime

### DIFF
--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -27,15 +27,15 @@
 #ifndef _tasks_qthreads_h_
 #define _tasks_qthreads_h_
 
-#include <stdint.h>
+#include "chpl-tasks-prvdata.h"
+#include "chpltypes.h"
+
+#include "qthread.h"
 
 #include <assert.h>
-#include <qthread.h>
-#include <stdio.h>
 #include <pthread.h>
-
-#include "chpltypes.h"
-#include "chpl-tasks-prvdata.h"
+#include <stdint.h>
+#include <stdio.h>
 
 #define CHPL_COMM_YIELD_TASK_WHILE_POLLING
 void chpl_task_yield(void);

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -31,6 +31,7 @@
 #include "chpltypes.h"
 
 #include "qthread.h"
+#include "qthread-chapel.h"
 
 #include <assert.h>
 #include <pthread.h>
@@ -435,10 +436,9 @@ c_sublocid_t chpl_task_getRequestedSubloc(void)
 #else
 #define CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL 1
 #endif
-extern int chpl_qthread_supports_remote_cache;
 static inline
 int chpl_task_supportsRemoteCache(void) {
-  return chpl_qthread_supports_remote_cache;
+  return CHPL_QTHREAD_SUPPORTS_REMOTE_CACHE;
 }
 
 #endif // ifndef _tasks_qthreads_h_

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -41,55 +41,6 @@
 #define CHPL_COMM_YIELD_TASK_WHILE_POLLING
 void chpl_task_yield(void);
 
-// For mutexes
-//   type(s)
-//     threadlayer_mutex_t
-//     threadlayer_mutex_p
-//   functions
-//     threadlayer_mutex_init()
-//     threadlayer_mutex_new()
-//     threadlayer_mutex_lock()
-//     threadlayer_mutex_unlock()
-//
-// For thread management
-//   type(s)
-//     <none>
-//   functions
-//     threadlayer_thread_id()
-//     threadlayer_thread_cancel()
-//     threadlayer_thread_join()
-//
-// For sync variables
-//   type(s)
-//     threadlayer_sync_aux_t
-//   functions
-//     threadlayer_sync_suspend()
-//     threadlayer_sync_awaken()
-//     threadlayer_sync_init()
-//     threadlayer_sync_destroy()
-//
-// For task management
-//   type(s)
-//     <none>
-//   functions
-//     threadlayer_init()
-//     threadlayer_thread_create()
-//     threadlayer_pool_suspend()
-//     threadlayer_pool_awaken()
-//     threadlayer_get_thread_private_data()
-//     threadlayer_set_thread_private_data()
-//
-// The types are declared in the threads-*.h file for each specific
-// threading layer, and the callback functions are declared here.  The
-// interfaces and requirements for these other types and callback
-// functions are described elsewhere in this file.
-//
-// Although the above list may seem long, in practice many of the
-// functions are quite simple, and with luck also easily extrapolated
-// from what is done for other threading layers.  For an example of an
-// implementation, see "pthreads" threading.
-//
-
 //
 // Type (and default value) used to communicate task identifiers
 // between C code and Chapel code in the runtime.
@@ -98,17 +49,7 @@ typedef unsigned int chpl_taskID_t;
 #define chpl_nullTaskID QTHREAD_NULL_TASK_ID
 
 //
-// Mutexes
-//
-typedef syncvar_t chpl_mutex_t;
-
-//
 // Sync variables
-//
-// The threading layer's threadlayer_sync_aux_t may include any
-// additional members the layer needs to support the suspend/awaken
-// callbacks efficiently.  The FIFO tasking code itself does not
-// refer to this type or the tl_aux member at all.
 //
 typedef struct {
     aligned_t lockers_in;
@@ -164,129 +105,16 @@ typedef struct {
 
 #define chpl_single_read_XX(x) ((x)->single_aux.signal_full.u.s.data)
 
-// Tasks
-
 //
-// Handy services for threading layer callback functions.
-//
-// The FIFO tasking implementation also provides the following service
-// routines that can be used by threading layer callback functions.
+// Task private data
 //
 
-//
-// The remaining declarations are all for callback functions to be
-// provided by the threading layer.
-//
-
-//
-// These are called once each, from CHPL_TASKING_INIT() and
-// CHPL_TASKING_EXIT().
-//
-void threadlayer_init(void);
-void threadlayer_exit(void);
-
-//
-// Mutexes
-//
-/*void qthread_mutex_init(qthread_mutex_p);
- * qthread_mutex_p qthread_mutex_new(void);
- * void qthread_mutex_lock(qthread_mutex_p);
- * void qthread_mutex_unlock(qthread_mutex_p);*/
-
-//
-// Sync variables
-//
-// The CHPL_SYNC_WAIT_{FULL,EMPTY}_AND_LOCK() functions should call
-// threadlayer_sync_suspend() when a sync variable is not in the desired
-// full/empty state.  The call will be made with the sync variable's
-// mutex held.  (Thus, threadlayer_sync_suspend() can dependably tell
-// that the desired state must be the opposite of the state it initially
-// sees the variable in.)  It should return (with the mutex again held)
-// as soon as it can once either the sync variable changes to the
-// desired state, or (if the given deadline pointer is non-NULL) the
-// deadline passes.  It can return also early, before either of these
-// things occur, with no ill effects.  If a deadline is given and it
-// does pass, then threadlayer_sync_suspend() must return true;
-// otherwise false.
-//
-// The less the function can execute while waiting for the sync variable
-// to change state, and the quicker it can un-suspend when the variable
-// does change state, the better overall performance will be.  Obviously
-// the sync variable's mutex must be unlocked while the routine waits
-// for the variable to change state or the deadline to pass, or livelock
-// may result.
-//
-// The CHPL_SYNC_MARK_AND_SIGNAL_{FULL,EMPTY}() functions will call
-// threadlayer_sync_awaken() every time they are called, not just when
-// they change the state of the sync variable.
-//
-// Threadlayer_sync_{init,destroy}() are called to initialize or
-// destroy, respectively, the contents of the tl_aux member of the
-// chpl_sync_aux_t for the specific threading layer.
-//
-/*chpl_bool threadlayer_sync_suspend(chpl_sync_aux_t *s,
- *                                 struct timeval *deadline);
- * void threadlayer_sync_awaken(chpl_sync_aux_t *s);
- * void threadlayer_sync_init(chpl_sync_aux_t *s);
- * void threadlayer_sync_destroy(chpl_sync_aux_t *s);*/
-
-//
-// Task management
-//
-
-//
-// The interface for thread creation may need to be extended eventually
-// to allow for specifying such things as stack sizes and/or locations.
-//
-/*int threadlayer_thread_create(threadlayer_threadID_t*, void*(*)(void*), void*);*/
-
-//
-// Threadlayer_pool_suspend() is called when a thread finds nothing in
-// the pool of unclaimed tasks, and so has no work to do.  The call will
-// be made with the pointed-to mutex held.  It should return (with the
-// mutex again held) as soon as it can once either the task pool is no
-// longer empty or (if the given deadline pointer is non-NULL) the
-// deadline passes.  It can return also early, before either of these
-// things occur, with no ill effects.  If a deadline is given and it
-// does pass, then threadlayer_pool_suspend() must return true;
-// otherwise false.
-//
-// The less the function can execute while waiting for the pool to
-// become nonempty, and the quicker it can un-suspend when that happens,
-// the better overall performance will be.
-//
-// The mutex passed to threadlayer_pool_suspend() is the one that
-// provides mutual exclusion for changes to the task pool.  Allowing
-// access to this mutex simplifies the implementation for certain
-// threading layers, such as those based on pthreads condition
-// variables.  However, it also introduces a complication in that it
-// allows a threading layer to create deadlock or livelock situations if
-// it is not careful.  Certainly the mutex must be unlocked while the
-// routine waits for the task pool to fill or the deadline to pass, or
-// livelock may result.
-//
-/*chpl_bool threadlayer_pool_suspend(chpl_mutex_t*, struct timeval*);
- * void threadlayer_pool_awaken(void);*/
-
-//
-// Thread private data
-//
-// These set and get a pointer to thread private data associated with
-// each thread.  This is for the use of the FIFO tasking implementation
-// itself.  If the threading layer also needs to store some data private
-// to each thread, it must make other arrangements to do so.
-//
-/*void  threadlayer_set_thread_private_data(void*);
- * void* threadlayer_get_thread_private_data(void);*/
-
-
-#ifndef QTHREAD_MULTINODE
 extern
 #ifdef __cplusplus
 "C"
 #endif
+
 volatile int chpl_qthread_done_initializing;
-#endif
 
 typedef struct {
     c_string task_filename;
@@ -369,6 +197,9 @@ static inline chpl_task_prvData_t* chpl_task_getPrvData(void)
     return NULL;
 }
 
+//
+// Sublocale support
+//
 #ifdef CHPL_TASK_GETSUBLOC_IMPL_DECL
 #error "CHPL_TASK_GETSUBLOC_IMPL_DECL is already defined!"
 #else
@@ -431,6 +262,9 @@ c_sublocid_t chpl_task_getRequestedSubloc(void)
     return c_sublocid_any;
 }
 
+//
+// Can we support remote caching?
+//
 #ifdef CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL
 #error "CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL is already defined!"
 #else

--- a/runtime/src/tasks/qthreads/Makefile
+++ b/runtime/src/tasks/qthreads/Makefile
@@ -22,6 +22,9 @@ ifndef CHPL_MAKE_HOME
 export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
 endif
 
+#
+# standard header
+#
 include $(RUNTIME_ROOT)/make/Makefile.runtime.head
 
 TASKS_OBJDIR = $(RUNTIME_OBJDIR)

--- a/runtime/src/tasks/qthreads/Makefile.include
+++ b/runtime/src/tasks/qthreads/Makefile.include
@@ -19,11 +19,7 @@ TASKS_SUBDIR = src/tasks/$(CHPL_MAKE_TASKS)
 
 TASKS_OBJDIR = $(RUNTIME_ROOT)/$(TASKS_SUBDIR)/$(RUNTIME_OBJDIR)
 
-#
-# point to sources under third-party, at least until they're
-# contributed back to the usual local directory
-#
-ALL_SRCS += $(QTHREAD_SUBDIR)/src/interfaces/chapel/*.c \
-	$(QTHREAD_SUBDIR)/src/interfaces/chapel/*.h
+ALL_SRCS += $(CURDIR)/$(TASKS_SUBDIR)/*.c \
+	$(RUNTIME_INCLUDE_ROOT)/tasks/$(CHPL_MAKE_TASKS)/*.h
 
 include $(RUNTIME_ROOT)/$(TASKS_SUBDIR)/Makefile.share

--- a/runtime/src/tasks/qthreads/Makefile.share
+++ b/runtime/src/tasks/qthreads/Makefile.share
@@ -15,11 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TASKS_SRCS = 
+TASKS_SRCS = tasks-$(CHPL_MAKE_TASKS).c
 
 SVN_SRCS = $(TASKS_SRCS)
 SRCS = $(SVN_SRCS)
 
 TASKS_OBJS = $(TASKS_SRCS:%.c=$(TASKS_OBJDIR)/%.o)
 
-RUNTIME_CFLAGS += -I$(QTHREAD_INCLUDE)
+RUNTIME_CFLAGS += -I$(QTHREAD_INCLUDE_DIR)

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -48,6 +48,7 @@
 
 #include "qthread.h"
 #include "qthread/qtimer.h"
+#include "qthread-chapel.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -147,12 +148,6 @@ chpl_qthread_tls_t chpl_qthread_comm_task_tls = {
     PRV_DATA_IMPL_VAL("<comm thread>", 0, chpl_nullTaskID, false,
                       c_sublocid_any_val, false),
     NULL, 0 };
-
-//
-// QTHREADS_SUPPORTS_REMOTE_CACHE is set in the Chapel Qthreads
-// Makefile, based on the Qthreads scheduler configuration.
-//
-int chpl_qthread_supports_remote_cache = QTHREADS_SUPPORTS_REMOTE_CACHE;
 
 //
 // structs chpl_task_prvDataImpl_t, chpl_qthread_wrapper_args_t and
@@ -558,7 +553,7 @@ static int32_t setupAvailableParallelism(int32_t maxThreads) {
         chpl_qt_unsetenv("NUM_WORKERS_PER_SHEPHERD");
 
         snprintf(newenv_workers, sizeof(newenv_workers), "%i", (int)hwpar);
-        if (THREADQUEUE_POLICY_TRUE == qt_threadqueue_policy(SINGLE_WORKER)) {
+        if (CHPL_QTHREAD_SCHEDULER_ONE_WORKER_PER_SHEPHERD) {
             chpl_qt_setenv("NUM_SHEPHERDS", newenv_workers, 1);
             chpl_qt_setenv("NUM_WORKERS_PER_SHEPHERD", "1", 1);
         } else {

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -836,13 +836,13 @@ void chpl_task_startMovedTask(chpl_fn_p      fp,
                               chpl_taskID_t  id,
                               chpl_bool      serial_state)
 {
-    assert(subloc != c_sublocid_none);
-    assert(id == chpl_nullTaskID);
-
     chpl_qthread_wrapper_args_t wrapper_args =
         {fp, arg, canCountRunningTasks,
          PRV_DATA_IMPL_VAL("<unknown>", 0, chpl_nullTaskID, true,
                            subloc, serial_state) };
+
+    assert(subloc != c_sublocid_none);
+    assert(id == chpl_nullTaskID);
 
     PROFILE_INCR(profile_task_startMovedTask,1);
 

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -120,25 +120,24 @@ qthread-build: FORCE
 	cd $(QTHREAD_BUILD_DIR) && $(MAKE) install
 
 #
-# The if-checks on the scheduler value look the same here, but they're
-# actually asking different questions.  In the first, it's "Will remote
+# The two variables here answer different questions even though they're
+# set using the same logic.  For the first, the question is "Will remote
 # caching work with this Qthreads build?", which is true iff qthreads do
-# not move from one worker to another (thus invalidating TLS).  In the
+# not move from one worker to another (thus invalidating TLS).  For the
 # second, it's "Is there only one worker per shepherd?", which changes
 # how the shim sets certain QT_* environment variables to parameterize
-# Qthreads behavior.  These have the same answer now, but in a future
-# scheduler they could differ.
+# Qthreads behavior.  These two questions have the same scheduler-based
+# answer now, but that may not always be true.  If and when it's not,
+# we'll need separate checks to set them.
 #
-ifeq (,$(findstring $(SCHEDULER),lifo mtsfifo mutexfifo nemesis))
-SUPPORTS_REMOTE_CACHE = 0
-else
+ifeq ($(SCHEDULER),$(findstring $(SCHEDULER),lifo mtsfifo mutexfifo nemesis))
 SUPPORTS_REMOTE_CACHE = 1
-endif
-
-ifeq (,$(findstring $(SCHEDULER),lifo mtsfifo mutexfifo nemesis))
+ONE_WORKER_PER_SHEPHERD = 1
+else ifeq ($(SCHEDULER),$(findstring $(SCHEDULER),nottingham sherwood))
+SUPPORTS_REMOTE_CACHE = 0
 ONE_WORKER_PER_SHEPHERD = 0
 else
-ONE_WORKER_PER_SHEPHERD = 1
+$(error Unrecognized Qthreads scheduler '$(SCHEDULER)')
 endif
 
 qthread-chapel-h: FORCE

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -63,12 +63,6 @@ SCHEDULER = $(CHPL_QTHREAD_SCHEDULER)
 endif
 CHPL_QTHREAD_CFG_OPTIONS += --with-scheduler=$(SCHEDULER)
 
-ifeq (nemesis,$(SCHEDULER))
-CFLAGS += -DQTHREADS_SUPPORTS_REMOTE_CACHE=1
-else
-CFLAGS += -DQTHREADS_SUPPORTS_REMOTE_CACHE=0
-endif
-
 # spawn-caching has a semantic mismatch with chapel (and leads to deadlock with
 # some applications.) Qthreads team tends to build with spawn cache off too
 CHPL_QTHREAD_CFG_OPTIONS += --disable-spawn-cache
@@ -115,13 +109,47 @@ qthread-config: FORCE
 # Then configure
 #
 	mkdir -p $(QTHREAD_BUILD_DIR)
-	cd $(QTHREAD_BUILD_DIR) && $(QTHREAD_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS)' CXX='$(CXX)'  CXXFLAGS='$(CFLAGS)' --prefix=$(QTHREAD_INSTALL_DIR) --enable-interfaces=chapel CHPL_HOME=$(CHPL_MAKE_HOME) $(CHPL_QTHREAD_CFG_OPTIONS) 
+	cd $(QTHREAD_BUILD_DIR) \
+	&& $(QTHREAD_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS)' \
+	       CXX='$(CXX)'  CXXFLAGS='$(CFLAGS)' \
+	       --prefix=$(QTHREAD_INSTALL_DIR) CHPL_HOME=$(CHPL_MAKE_HOME) \
+	       $(CHPL_QTHREAD_CFG_OPTIONS) 
 
 qthread-build: FORCE
 	cd $(QTHREAD_BUILD_DIR) && $(MAKE)
 	cd $(QTHREAD_BUILD_DIR) && $(MAKE) install
 
-qthread: qthread-config qthread-build
+#
+# The if-checks on the scheduler value look the same here, but they're
+# actually asking different questions.  In the first, it's "Will remote
+# caching work with this Qthreads build?", which is true iff qthreads do
+# not move from one worker to another (thus invalidating TLS).  In the
+# second, it's "Is there only one worker per shepherd?", which changes
+# how the shim sets certain QT_* environment variables to parameterize
+# Qthreads behavior.  These have the same answer now, but in a future
+# scheduler they could differ.
+#
+ifeq (,$(findstring $(SCHEDULER),lifo mtsfifo mutexfifo nemesis))
+SUPPORTS_REMOTE_CACHE = 0
+else
+SUPPORTS_REMOTE_CACHE = 1
+endif
+
+ifeq (,$(findstring $(SCHEDULER),lifo mtsfifo mutexfifo nemesis))
+ONE_WORKER_PER_SHEPHERD = 0
+else
+ONE_WORKER_PER_SHEPHERD = 1
+endif
+
+qthread-chapel-h: FORCE
+	echo "#define CHPL_QTHREAD_SUPPORTS_REMOTE_CACHE" \
+	     $(SUPPORTS_REMOTE_CACHE) \
+	     > $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
+	echo "#define CHPL_QTHREAD_SCHEDULER_ONE_WORKER_PER_SHEPHERD" \
+	     $(ONE_WORKER_PER_SHEPHERD) \
+	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
+
+qthread: qthread-config qthread-build qthread-chapel-h
 
 qthread-reconfig:
 	cd $(QTHREAD_SUBDIR) && autoreconf -f -i


### PR DESCRIPTION
With this change we complete the work necessary to bring the Qthreads tasking shim into the Chapel runtime.  Mostly this involved rewriting or working around the places where the shim called internal (non-API) Qthreads functions.