### PR TITLE
Added future for internal error when compiling `exit;`

### DIFF
--- a/test/exits/albrecht/exitWithNoCall.chpl
+++ b/test/exits/albrecht/exitWithNoCall.chpl
@@ -1,0 +1,4 @@
+proc main() {
+  writeln("Compiling this shouldn't give an internal error");
+  exit;
+}

--- a/test/exits/albrecht/exitWithNoCall.future
+++ b/test/exits/albrecht/exitWithNoCall.future
@@ -1,0 +1,12 @@
+bug: Compiling 'exit' without parens or args results in an internal error
+
+The desirable compiler error would let the user know they probably meant
+to call the exit function like 'exit()'.
+
+Alternatively, we could consider interpreting the standalone 'exit' as 'exit()'
+
+
+The current compiler output:
+
+exitWithNoCall.chpl:1: In function 'main':
+exitWithNoCall.chpl:1: internal error: Cannot call insertBefore on Expr not in a list [expr.cpp:384]

--- a/test/exits/albrecht/exitWithNoCall.good
+++ b/test/exits/albrecht/exitWithNoCall.good
@@ -1,0 +1,1 @@
+Compiling this shouldn't give an internal error

--- a/test/types/atomic/albrecht/arrayatomics.future
+++ b/test/types/atomic/albrecht/arrayatomics.future
@@ -1,6 +1,4 @@
-bug: compiler unable to compile atomic operations on arrays that should behave
-as the short hand notation of  looping through the array and performing an
-atomic operation one by one.
+bug: compiler unable to compile promoted atomic operation, fetchAdd()
 
 The example used in this test is fetchAdd(). The desired behavior is
 demonstrated as the first part of the test. Consequently the .good output


### PR DESCRIPTION
Added a future for an internal error that occurred when a user compiled code trying to call `exit;` without any parentheses or arguments (not really calling the `exit`, but they meant to)

.future text:

    bug: Compiling 'exit' without parens or args results in an internal error

    The desirable compiler error would let the user know they probably meant
    to call the exit function like 'exit()'.

    Alternatively, we could consider interpreting the standalone 'exit' as 'exit()'

    The current compiler output:

    exitWithNoCall.chpl:1: In function 'main':
    exitWithNoCall.chpl:1: internal error: Cannot call insertBefore on Expr not in a list [expr.cpp:384]




Also reducing the characters to `<= 80` for a previously added future, `arrayatomics.future`

