### PR TITLE
Add a pretty hacky (but effective) version of dead string literal elimination

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -3082,6 +3082,7 @@ VarSymbol *new_StringSymbol(const char *str) {
   s->addFlag(FLAG_NO_AUTO_DESTROY);
   s->addFlag(FLAG_CONST);
   s->addFlag(FLAG_LOCALE_PRIVATE);
+  s->addFlag(FLAG_STRING_LITERAL_ID);
 
   DefExpr* stringLitDef = new DefExpr(s);
   // DefExpr(s) always goes into the module scope to make it a global

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -253,6 +253,7 @@ symbolFlag( FLAG_WIDE_REF , npr, "wide" , ncm )
 symbolFlag( FLAG_WIDE_CLASS , npr, "wide class" , ncm )
 symbolFlag( FLAG_WRAPPER , npr, "wrapper" , "wrapper function" )
 symbolFlag( FLAG_WRAP_WRITTEN_FORMAL , npr, "wrap written formal" , "formal argument for wrapper for out/inout intent" )
+symbolFlag( FLAG_STRING_LITERAL_ID, npr, "string literal id" , "used to mark the global Chapel string resulting from a string literal")
 
 #undef ypr
 #undef npr


### PR DESCRIPTION
This is an initial draft of dead string literal elimination. This does
effectively remove all dead string literals, but the way it does so is a little
hacky.

Basically it looks for all of the global strings that were created from string
literals. If there is only 1 use of it, we know that use is in the code that
constructs the Chapel string from the literal. The reason it's hacky is because
I basically find that use of the string, remove the 3 statementExprs before it
as well as the 1 after it and then remove it and it's defExpr. i.e. I'm just
removing 5 lines that are currently in a particular order, but that ordering
could easily change over tine. If the code that creates this order is ever
altered, this code will break pretty spectacularly.

I'm still working on a better way to write this code, but I wanted to test this
out in the meantime since it's accomplishing the same end goal.

For jacobi, this takes us from 16,000 emitted statements down to 13,500 (was
12,000 before string-as-rec merge.)

Looking at just the number of emitted SLOC from `wc -l` (basically the number
we report, plus variable declarations) this takes us from 30,600 SLOC down to
25,500 (was 22,300 before string-as-rec merge.)

The remaining ~2,200 lines are coming from

 - ChapelDistribution   (250)
 - ChapelStringLiterals (300)
 - chpl__header         (50)
 - Error                (200)
 - IO                   (700)
 - MemTracking          (100)
 - String               (900)
 - StringCasts          (125)
 - NewString           -(500)

I'm not sure if there's too much we can do about them for now since most of the
code is for the new string implementaion. At least a few hundred lines seems be
coming from dynamic dispatch branches being created instead of calls that index
into the chpl_vmtable. I still have to investigate that further as I'm not sure
what in the string-as-rec merge would have caused this.