### PR TITLE
Jenkins smoketest build should fail if make fails.

### DIFF
--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -113,9 +113,9 @@ fi
 # Compile chapel and make sure the hello world examples run. Compile first with
 # parallel execution, but call `make check` without it.
 make -j${num_procs} $chpl_make_args && \
-    make $chpl_make_args check
+    make $chpl_make_args check || exit 2
 
 # Build chpldoc and make sure the chpldoc primer runs. Build chpldoc with
 # parallel execution, but call `make check-chpldoc` without it.
 make -j${num_procs} $chpl_make_args chpldoc && \
-    make $chpl_make_args check-chpldoc
+    make $chpl_make_args check-chpldoc || exit 2


### PR DESCRIPTION
Fix Jenkins "smoketest" builds: if "make <something>" fails (exit status > 0), the bash script that called make should fail also.  Otherwise Jenkins will think the smoketest build was successful.  