### PR TITLE
Revert "Change the module search path when using chpldoc"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,6 @@ test-venv: third-party-test-venv
 
 chpldoc: compiler third-party-chpldoc-venv
 	cd compiler && $(MAKE) chpldoc
-	cd modules && $(MAKE) sys-ctypes-docs
 	@test -r Makefile.devel && $(MAKE) man-chpldoc || echo ""
 
 always-build-test-venv: FORCE

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -29,7 +29,6 @@
 
 #include "beautify.h"
 #include "driver.h"
-#include "docsDriver.h"
 #include "misc.h"
 #include "mysystem.h"
 #include "stringutil.h"
@@ -753,15 +752,9 @@ void setupModulePaths() {
                       CHPL_COMM));
   intModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/internal"));
 
-  if (fDocs) {
-    // We use a special sysCTypes when running with chpldoc to gloss over
-    // machine differences
-    stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/standard/gen/doc"));
-  } else {
-    stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/standard/gen/",
-                        CHPL_TARGET_PLATFORM,
-                        "-", CHPL_TARGET_COMPILER));
-  }
+  stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/standard/gen/",
+                      CHPL_TARGET_PLATFORM,
+                      "-", CHPL_TARGET_COMPILER));
 
   stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/standard"));
   stdModPath.add(astr(CHPL_HOME, "/", modulesRoot, "/layouts"));

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -64,7 +64,6 @@ $(SYS_CTYPES_MODULE_DOC): $(MAKE_SYS_BASIC_TYPES)
 	mkdir -p $(@D)
 	cd $(@D) && $(MAKE_SYS_BASIC_TYPES) --doc $(@F)
 
-sys-ctypes-docs: $(SYS_CTYPES_MODULE_DOC)
 
 MODULES_TO_DOCUMENT = \
 	standard/AdvancedIters.chpl \


### PR DESCRIPTION
With #3015 this search path change is no longer necessary, and just adds unneeded complexity.

Revert chapel-lang/chapel#2980