### PR TITLE
Update Random.chpl's chpldoc comments to build without errors

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -20,15 +20,16 @@
 /*
    Support for pseudorandom number generation
 
-   This module defines an abstraction for a stream of pseudorandom
-   numbers, :class:`RandomStreamInterface`, supporting methods to get the next
-   random number in the stream (:proc:`.getNext`), to fast-forward to
-   a specific value in the stream (:proc:`.skipToNth` and
-   :proc:`.getNth`), or to fill an array with random numbers in
-   parallel (:proc:`~Random.RandomStream.fillRandom`).  The module
-   also provides a standalone convenience function, :proc:`fillRandom`
-   that can be used to fill an array with random numbers in parallel
-   without manually creating a :class:`RandomStream` object.
+   This module defines an abstraction for a stream of pseudorandom numbers,
+   :class:`~Random.RandomStreamInterface`, supporting methods to get the next random
+   number in the stream (:proc:`~Random.RandomStreamInterface.getNext`), to
+   fast-forward to a specific value in the stream
+   (:proc:`~Random.RandomStreamInterface.skipToNth` and
+   :proc:`~Random.RandomStreamInterface.getNth`), or to fill an array with random
+   numbers in parallel (:proc:`~Random.RandomStream.fillRandom`).  The module
+   also provides a standalone convenience function, :proc:`fillRandom` that can
+   be used to fill an array with random numbers in parallel without manually
+   creating a :class:`RandomStream` object.
 
    Use :proc:`makeRandomStream` or the constructor for a specific RNG
    implementation to get a RandomStream.


### PR DESCRIPTION
Previously, we were getting:

    Random.rst:11: WARNING: more than one target found for cross-reference u'getNext':
        Random.NPBRandom.RandomStream.getNext,
        Random.PCGRandom.PCGRandomStream.getNext,
        Random.PCGRandom.RandomStreamInterface.getNext

I've corrected this, but an error in chpldoc prevents the links from showing up.