### PR TITLE
Add an explicit cast to quiet a Coverity complaint.

### DIFF
--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -477,9 +477,9 @@ static int32_t chpl_qt_getenv_num_workers(void) {
     int32_t  num_wps;
     int32_t  num_sheps;
 
-    hwpar = chpl_qt_getenv_num("HWPAR", 0);
-    num_wps = chpl_qt_getenv_num("NUM_WORKERS_PER_SHEPHERD", 0);
-    num_sheps = chpl_qt_getenv_num("NUM_SHEPHERDS", 0);
+    hwpar = (int32_t) chpl_qt_getenv_num("HWPAR", 0);
+    num_wps = (int32_t) chpl_qt_getenv_num("NUM_WORKERS_PER_SHEPHERD", 0);
+    num_sheps = (int32_t) chpl_qt_getenv_num("NUM_SHEPHERDS", 0);
 
     if (hwpar) {
         return hwpar;


### PR DESCRIPTION
Coverity complained about returning the 'overflowed or truncated' value
of hwpar.  To quiet this, explicitly cast the unsigned long int value of
chpl_qt_getenv_num() to the int32_t type of hwpar when assigning the
former to the latter.  And to make the resulting code look less funny,
do the same for the num_wps and num_sheps assignments that follow, even
though Coverity didn't mention either of those.

(The Coverity complaint was new because the Qthreads tasking shim is new
in the runtime.  We don't have Coverity scan the third-party packages,
where this code used to reside.)