### PR TITLE
Cleanup third party readme (round 2)

### DIFF
--- a/third-party/README
+++ b/third-party/README
@@ -20,9 +20,8 @@ chpl-venv/
 
 
 dlmalloc/
-  Summary: Doug Lea's memory allocator (dlmalloc) which we use to
-           support malloc/free calls when running GASNet programs
-           using segment fast.
+  Summary: Doug Lea's memory allocator (dlmalloc) is a portable
+           allocator that can be used when a shared heap is required.
 
   License: dlmalloc has been placed in the public domain as explained
            at http://creativecommons.org/publicdomain/zero/1.0/
@@ -126,9 +125,9 @@ re2/
 
 
 tcmalloc/
-  Summary: the Google perf-tools memory allocator (tcmalloc) which we
-           use to support malloc/free calls when running programs using
-           Cray's Gemini network interconnect chip
+  Summary: the Google perf-tools memory allocator (tcmalloc) is
+           optimized for high concurrency code and can be used when a
+           shared heap is required.
 
   License: Google-perftools is released under the New BSD License (see
            tcmalloc/google-perftools-<version>/COPYING)

--- a/third-party/README
+++ b/third-party/README
@@ -8,7 +8,6 @@ Chapel itself.  Current subdirectories include:
 
 
 chpl-venv/
-
   Summary: Directory where several python packages are downloaded and
            installed. Used for chpldoc and the testing system. See
            chpldoc-requirements.txt, test-requirements.txt, and
@@ -49,24 +48,24 @@ gasnet/
 gmp/
   Summary: the GNU Multiple Precision Arithmetic Library
 
-  License: L-GPL (see gmp/gmp-*/COPYING and gmp/gmp-*/COPYING.LESSERv3)
+  License: L-GPL (see gmp/gmp-<version>/COPYING and
+           gmp/gmp-<version>/COPYING.LESSERv3)
 
   Website: http://gmplib.org
 
-  See also: gmp/README and gmp/gmp-*/README
+  See also: gmp/README and gmp/gmp-<version>/README
 
 
 hwloc/
-
   Summary: The Portable Hardware Locality (hwloc) software package
            provides a portable abstraction of the hierarchical
            topology of modern architectures.
 
-  License: BSD (see hwloc/hwloc-*/COPYING)
+  License: BSD (see hwloc/hwloc-<version>/COPYING)
 
   Website: http://www.open-mpi.org/projects/hwloc
 
-  See also: hwloc/README and hwloc/hwloc-*/README
+  See also: hwloc/README and hwloc/hwloc-<version>/README
 
 
 llvm/
@@ -112,7 +111,7 @@ qthread/
     and
            http://www.cs.sandia.gov/qthreads/
 
-  See also: qthread/qthread-*/README
+  See also: qthread/qthread-<version>/README
 
 
 re2/
@@ -132,7 +131,7 @@ tcmalloc/
            Cray's Gemini network interconnect chip
 
   License: Google-perftools is released under the New BSD License (see
-           tcmalloc/google-perftools-*/COPYING)
+           tcmalloc/google-perftools-<version>/COPYING)
 
   Website: http://code.google.com/p/google-perftools/
 
@@ -148,5 +147,3 @@ utf8-decoder/
   Website: http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
 
   See also: utf8-decoder/README
-
-


### PR DESCRIPTION
#3044 updated out of date statements in third-party/README. This updates ones
that are likely to become out of date to avoid being so fragile.

It also fixes some inconsistencies with when blank lines are inserted and
changes "third-party-*" => "third-party-<version>"