### PR TITLE
Return const ref from value version of ref return-intent functions

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -523,6 +523,7 @@ void AstDump::writeFnSymbol(FnSymbol* fn) {
   switch (fn->retTag) {
     case RET_VALUE:                 break;
     case RET_REF:   write("ref");   break;
+    case RET_CONST_REF:   write("const ref");   break;
     case RET_PARAM: write("param"); break;
     case RET_TYPE:  write("type");  break;
   }

--- a/compiler/AST/AstDumpToHtml.cpp
+++ b/compiler/AST/AstDumpToHtml.cpp
@@ -610,6 +610,7 @@ void AstDumpToHtml::writeFnSymbol(FnSymbol* fn) {
   switch (fn->retTag) {
     case RET_VALUE:                                break;
     case RET_REF:   fprintf(mFP, "<b>ref</b> ");   break;
+    case RET_CONST_REF:   fprintf(mFP, "<b>const ref</b> ");   break;
     case RET_PARAM: fprintf(mFP, "<b>param</b> "); break;
     case RET_TYPE:  fprintf(mFP, "<b>type</b> ");  break;
   }

--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -763,6 +763,12 @@ bool AstDumpToNode::enterFnSym(FnSymbol* node)
       write("RetTag:      ref");
       break;
 
+    case RET_CONST_REF:
+      newline();
+      write("RetTag:      const ref");
+      break;
+
+
     case RET_PARAM:
       newline();
       write("RetTag:      param");

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4370,6 +4370,8 @@ GenRet CallExpr::codegen() {
     case PRIM_ARRAY_GET:
     case PRIM_ARRAY_GET_VALUE:
     case PRIM_ON_LOCALE_NUM:
+    case PRIM_GET_REAL:
+    case PRIM_GET_IMAG:
       // generated during generation of PRIM_MOVE
       break;
     case PRIM_WIDE_GET_LOCALE:

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1050,6 +1050,7 @@ const char* retTagDescrString(RetTag retTag) {
   switch (retTag) {
     case RET_VALUE: return "value";
     case RET_REF:   return "ref";
+    case RET_CONST_REF:   return "const ref";
     case RET_PARAM: return "param";
     case RET_TYPE:  return "type";
     default:        return "<unknown RetTag>";
@@ -2357,6 +2358,10 @@ bool FnSymbol::isIterator() const {
   return hasFlag(FLAG_ITERATOR_FN);
 }
 
+// This function returns by ref or const ref
+bool FnSymbol::returnsRefOrConstRef() const {
+  return (retTag == RET_REF || retTag == RET_CONST_REF);
+}
 
 std::string FnSymbol::docsDirective() {
   if (fDocsTextOnly) {
@@ -2408,6 +2413,9 @@ void FnSymbol::printDocs(std::ostream *file, unsigned int tabs) {
   switch (this->retTag) {
   case RET_REF:
     *file << " ref";
+    break;
+  case RET_CONST_REF:
+    *file << " const ref";
     break;
   case RET_PARAM:
     *file << " param";

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -47,6 +47,7 @@ class SymExpr;
 enum RetTag {
   RET_VALUE,
   RET_REF,
+  RET_CONST_REF,
   RET_PARAM,
   RET_TYPE
 };
@@ -409,6 +410,7 @@ class FnSymbol : public Symbol {
   bool            isPrimaryMethod()                            const;
   bool            isSecondaryMethod()                          const;
   bool            isIterator()                                 const;
+  bool            returnsRefOrConstRef()                       const;
 
   virtual void printDocs(std::ostream *file, unsigned int tabs);
 

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -751,7 +751,7 @@ lambda_decl_expr:
   opt_ret_tag opt_type opt_where_part function_body_stmt
     {
       $3->retTag = $5;
-      if ($5 == RET_REF)
+      if ($5 == RET_REF || $5 == RET_CONST_REF)
         USR_FATAL("'ref' return types are not allowed in lambdas");
       if ($5 == RET_PARAM)
         USR_FATAL("'param' return types are not allowed in lambdas");
@@ -953,7 +953,7 @@ proc_or_iter:
 opt_ret_tag:
             { $$ = RET_VALUE; }
 | TCONST    { $$ = RET_VALUE; }
-| TREF      { $$ = RET_REF; }
+| TREF      { $$ = RET_REF; } // TODO -- handle const ref
 | TPARAM    { $$ = RET_PARAM; }
 | TTYPE     { $$ = RET_TYPE; }
 ;

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -272,6 +272,7 @@ static void build_getter(AggregateType* ct, Symbol *field) {
   else if (field->hasFlag(FLAG_SUPER_CLASS)) {
     fn->retTag = RET_VALUE;
   } else {
+    // TODO -- handle const ref
     fn->retTag = RET_REF;
     fn->setter = new DefExpr(new ArgSymbol(INTENT_BLANK, "setter", dtBool));
   }

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -248,7 +248,7 @@ checkFunction(FnSymbol* fn) {
   if (isIterator && numYields == 0)
     USR_FATAL_CONT(fn, "iterator does not yield a value");
   if (!isIterator &&
-      fn->retTag == RET_REF &&
+      fn->retTag == RET_REF && // TODO -- handle RET_CONST_REF
       numNonVoidReturns == 0) {
     USR_FATAL_CONT(fn, "function declared 'var' but does not return anything");
   }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -539,7 +539,7 @@ static bool is_void_return(CallExpr* call) {
 static void insertRetMove(FnSymbol* fn, VarSymbol* retval, CallExpr* ret) {
   Expr* ret_expr = ret->get(1);
   ret_expr->remove();
-  if (fn->retTag == RET_REF)
+  if (fn->returnsRefOrConstRef())
     ret->insertBefore(new CallExpr(PRIM_MOVE, retval, new CallExpr(PRIM_ADDR_OF, ret_expr)));
   else if (fn->retExprType)
   {

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -857,7 +857,7 @@ static void findHeapVarsAndRefs(Map<Symbol*,Vec<SymExpr*>*>& defMap,
         refSet.set_add(def->sym);
         refVec.add(def->sym);
       } else if (!isPrimitiveType(def->sym->type) ||
-                 toFnSymbol(def->parentSymbol)->retTag==RET_REF) {
+                 toFnSymbol(def->parentSymbol)->returnsRefOrConstRef()) {
         varSet.set_add(def->sym);
         varVec.add(def->sym);
       }

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -654,6 +654,8 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
   Symbol*   useLhs   = toSymExpr(lhs)->var;
   Symbol*   refVar   = newTemp("ret_to_arg_ref_tmp_", useLhs->type->refType);
 
+  // Make sure that we created a temp with a type
+  INT_ASSERT(useLhs->type->refType);
 
   // Determine if
   //   a) current call is not a PRIMOP

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -58,7 +58,11 @@ refNecessary(SymExpr* se,
           return true;
       } else if (call->isPrimitive(PRIM_RETURN) ||
                  call->isPrimitive(PRIM_YIELD)) {
-        return true;
+        FnSymbol* inFn = toFnSymbol(call->parentSymbol);
+        // Return true only for ref-return functions
+        // but not const-ref-return functions (which are
+        // the "value" versions).
+        if (inFn->retTag == RET_REF) return true;
       } else if (call->isPrimitive(PRIM_WIDE_GET_LOCALE) ||
                  call->isPrimitive(PRIM_WIDE_GET_NODE)) {
         // If we are extracting a field from the wide pointer, we need to keep it as a pointer.

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -109,31 +109,9 @@ void cullOverReferences() {
           SET_LINENO(move);
 
           if (!refNecessary(se, defMap, useMap)) {
+            // Change the call to the const ref version with (setter=false)
             SymExpr*   base = toSymExpr(call->baseExpr);
-            VarSymbol* tmp  = newTemp(copy->retType);
-
             base->var = copy;
-
-            move->insertBefore(new DefExpr(tmp));
-
-            if (requiresImplicitDestroy(call)) {
-              if (isString(copy->retType) == false) {
-                tmp->addFlag(FLAG_INSERT_AUTO_COPY);
-                tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
-              } else {
-                tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
-              }
-            }
-
-            if (useMap.get(se->var) && useMap.get(se->var)->n > 0) {
-              move->insertAfter(new CallExpr(PRIM_MOVE,
-                                             se->var,
-                                             new CallExpr(PRIM_ADDR_OF, tmp)));
-            } else {
-              se->var->defPoint->remove();
-            }
-
-            se->var = tmp;
           }
         } else
           INT_FATAL(call, "unexpected case");

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5368,8 +5368,9 @@ preFold(Expr* expr) {
                     !ret->var->type->symbol->hasFlag(FLAG_ARRAY))
                   // Should this conditional include domains, distributions, sync and/or single?
                   USR_FATAL(ret, "illegal expression to return by ref");
-                if (ret->var->isConstant() || ret->var->isParameter())
-                  USR_FATAL(ret, "function cannot return constant by ref");
+                if (fn->retTag == RET_REF)
+                  if (ret->var->isConstant() || ret->var->isParameter())
+                    USR_FATAL(ret, "function cannot return constant by ref");
               }
             }
           }
@@ -5386,12 +5387,20 @@ preFold(Expr* expr) {
                     INT_FATAL(call, "Cannot set a non-const reference to a const variable.");
                   }
                 } else {
-                  // This probably indicates that an invalid 'addr of' primitive
-                  // was inserted, which would be the compiler's fault, not the
-                  // user's.
-                  // At least, we might perform the check at or before the 'addr
-                  // of' primitive is inserted.
-                  INT_FATAL(call, "A non-lvalue appears where an lvalue is expected.");
+                  // It is not a problem to return a const value
+                  if (fn->retTag == RET_CONST_REF &&
+                      lhs && lhs->var == fn->getReturnSymbol() ) {
+                    // It's OK
+                    // TODO -- this should be handled differently
+                    // by including the idea of 'const ref' types
+                    // throughout resolution
+                  } else {
+                    // This probably indicates that an invalid 'addr of'
+                    // primitive was inserted, which would be the compiler's
+                    // fault, not the user's.  At least, we might perform the
+                    // check at or before the 'addr of' primitive is inserted.
+                    INT_FATAL(call, "A non-lvalue appears where an lvalue is expected.");
+                  }
                 }
               }
             }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -766,7 +766,7 @@ protoIteratorClass(FnSymbol* fn) {
   // TODO -- do a better job of deciding if an iterator record is
   // POD or not POD.
   rts->addFlag(FLAG_NOT_POD);
-  if (fn->retTag == RET_REF)
+  if (fn->retTag == RET_REF) // TODO -- handle RET_CONST_REF
     rts->addFlag(FLAG_REF_ITERATOR_CLASS);
   fn->defPoint->insertBefore(new DefExpr(rts));
 
@@ -901,7 +901,7 @@ resolveSpecifiedReturnType(FnSymbol* fn) {
   fn->retType = retType;
 
   if (retType != dtUnknown) {
-    if (fn->retTag == RET_REF) {
+    if (fn->returnsRefOrConstRef()) {
       makeRefType(retType);
       retType = fn->retType->refType;
       fn->retType = retType;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -513,30 +513,18 @@ module ChapelBase {
   // complex component methods re and im
   //
   inline proc ref chpl_anycomplex.re ref {
-    if setter {
-      return __primitive("complex_get_real", this);
-    } else {
-      if this.type == complex(128) {
-        extern proc creal(x:complex(128)): real(64);
-        return creal(this);
-      } else {
-        extern proc crealf(x:complex(64)): real(32);
-        return crealf(this);
-      }
-    }
+    // MPF note:
+    // This function used to use complex_get_real only
+    // for the setter version, and creal/crealf for the
+    // !setter version, but that doesn't work with
+    // the language change that ref intent functions
+    // always return ref or const ref ("value" version).
+    // David tells me that complex_get_real does not
+    // show reduced performance in benchmarks.
+    return __primitive("complex_get_real", this);
   }
   inline proc ref chpl_anycomplex.im ref {
-    if setter {
-      return __primitive("complex_get_imag", this);
-    } else {
-      if this.type == complex(128) {
-        extern proc cimag(x:complex(128)): real(64);
-        return cimag(this);
-      } else {
-        extern proc cimagf(x:complex(64)): real(32);
-        return cimagf(this);
-      }
-    }
+    return __primitive("complex_get_imag", this);
   }
   
   //


### PR DESCRIPTION
### Overview

There is a known performance issue with array element access when the
array stores  strings or other records. The array implementation uses
several 'this' or other access methods that are marked with the 'ref'
return intent. At the same time, the compiler changes rvalue-only uses of
ref-return-intent functions into value functions.
(Note - the performance issue has not been quantified, it's just
 that the generated code is obviously slow).

The compiler generates the "value" version of ref-intent functions
in order to support the implicit 'setter' variable.

The resulting problem is that code like this:

    var A:[1..10] R;
    ...
    test(A[i])

generates something like this:

    test(A[i]);
    ->
    a = *(tmp);
    b = autoCopy(&a);
    c = autoCopy(&b);
    autoDestroy(&b);
    d = autoCopy(&c);
    autoDestroy(&c);
    e = autoCopy(&d);
    autoDestroy(&d);
    test(&e);
    autoDestroy(&e);

I believe that the most reasonable way to solve this issue is for the
compiler to generate the "value" version of a ref-intent function as
returning const ref instead of returning a value.  This PR makes that
change.

After this PR, the example above will code generate to this:

    test(A[i]);
    ->
    a = *(tmp);
    test(&a);


### History

Why did the compiler create "value" versions of *ref return intent*
functions in the first place?

If I understand correctly, the current behavior stemmed from 3
historical factors.

 1) Ref return intent functions support a *setter* implicit parameter
    in order to support returning a default value. For example, a sparse
    array might return 0 for all elements that have not been set yet,
    but allocate memory/create a slot when setting an element. So the
    behaviour of the *this* method for the sparse array needs to
    differ depending on whether or not the value accessed is written.

 2) At the time the feature was introduced, there weren't *ref return intent*
    functions, there were *var return intent* functions. As far as I
    know, the language and implementation didn't have any concept of
    *const ref* at the time.

 3) Based on my commit log investigations, it appears that
    autoCopy/autoDestroy were added *after* the *setter* behavior existed
    for *var return intent* functions. Meaning that the design of the
    *var return intent* feature did not take into account how
    it should minimize extra auto copy calls.

### Commits

The individual commits have more detail, but the outline is:

 * adds RET_CONST_REF RetTag
 * adjusts code that used to work with RET_REF to work with RET_CONST_REF
   also, or adds a comment indicating that is future work (for when const
   ref return intents are fully supported from parsing)
 * adjusts function resolution to create a RET_CONST_REF "value version"
   of RET_REF functions
 * adjusts cullOverReferences to change calls from the RET_REF version to
   the RET_CONST_REF version when appropriate (instead of changing calls
   to a version that returns by value)
 * several other minor workarounds to get specific tests passing

### Testing

Passes full local quickstart testing.

### Future work:

 * fully support const ref return intent for user functions,
   possibly removing some of the workarounds in this patch.
   
