### PR TITLE
publish-chapel-module-docs build should fail if sphinx-build fails

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -19,7 +19,7 @@
 develall: man STATUS
 
 docs: module-docs
-	-cd doc/sphinx && ./run-in-venv.bash ${MAKE} docs
+	cd doc/sphinx && ./run-in-venv.bash ${MAKE} docs
 
 man: FORCE
 	cd man && $(MAKE)


### PR DESCRIPTION
Part 1 of 2 fixes to make Jenkins publish-chapel-module-docs build fail if the sphinx-build fails. May be promoted with or without Part 2 (chapel-docs.git).