### PR TITLE
Remove 'use' now that we have 'require' (and a release full of warnings)

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -413,22 +413,7 @@ BlockStmt* buildUseStmt(CallExpr* args) {
   //
   for_actuals(expr, args) {
     Expr* useArg = expr->remove();
-    //
-    // 'use' statements no longer accept string literals, but let's
-    // let it slide for one release to ease transition to the
-    // 'require' statement.  Generate a warning and process it as
-    // though the user had typed 'require'.  This check can be removed
-    // after the 1.12 release.
-    //
-    if (const char* str = toImmediateString(useArg)) {
-      USR_WARN(useArg, "'use' no longer accepts string literals == use 'require' instead");
-      processStringInRequireStmt(str);
-    } else {
-      //
-      // Otherwise, handle it in the traditional way
-      //
-      list = buildUseList(useArg, list);
-    }
+    list = buildUseList(useArg, list);
   }
 
   //

--- a/test/extern/bradc/use-nonmodules/useModAsString-deprecate.bad
+++ b/test/extern/bradc/use-nonmodules/useModAsString-deprecate.bad
@@ -1,0 +1,1 @@
+useModAsString-deprecate.chpl:6: error: Illegal use of non-module _str_literal_1662

--- a/test/extern/bradc/use-nonmodules/useModAsString-deprecate.future
+++ b/test/extern/bradc/use-nonmodules/useModAsString-deprecate.future
@@ -1,0 +1,8 @@
+error message: 'use' of literal string prints temp name rather than string
+
+In deprecating the support for 'use "foo.c"' in favor of 'require "foo.c"'
+I noticed that this error message isn't as clear as it should be.  I'm
+not sure whether it's always been this way or whether it requires some
+updates as a result of the recent string changes.
+
+

--- a/test/extern/bradc/use-nonmodules/useModAsString-deprecate.good
+++ b/test/extern/bradc/use-nonmodules/useModAsString-deprecate.good
@@ -1,2 +1,1 @@
-useModAsString-deprecate.chpl:6: warning: 'use' no longer accepts string literals == use 'require' instead
-In useModAsString.chpl's foo
+useModAsString-deprecate.chpl:6: error: Illegal use of non-module "Foo.chpl"


### PR DESCRIPTION
This commit removes the ability to do:

    use "foo.c";

now that we have switched it to:

    require "foo.c";

and had a release worth of "this feature is deprecated" warnings.

It also converts a test that used to warn about the deprecation into an 'error message' future because the message isn't particularly good.  If I had a bit more time, I suspect @Kyle-B or someone could suggest a simple fix for this.
