### PR TITLE
Add a performance test for array of strings

### DIFF
--- a/test/types/string/ferguson/array-of-strings-read.chpl
+++ b/test/types/string/ferguson/array-of-strings-read.chpl
@@ -1,0 +1,94 @@
+use Time;
+
+// test array of string reading performance
+
+config const numTrials = 1;
+config const n = 100000;
+config const expect = 279922;
+config const timing = false;
+
+var A:[1..n] string;
+
+for i in 1..n {
+  var x = 123456789123 * i + i*i*i + i*i + i;
+  A[i] = x:string + x:string;
+}
+
+var nines1: int;
+var t1: Timer;
+
+t1.start();
+nines1 = 0;
+for i in 1..numTrials {
+  for j in 1..n {
+    nines1 += A[j].count("9");
+  }
+}
+t1.stop();
+
+proc count9s(s: string): int {
+  return s.count("9");
+}
+
+var nines2: int;
+var t2: Timer;
+t2.start();
+nines2 = 0;
+for i in 1..numTrials {
+  for j in 1..n {
+    nines2 += count9s(A[j]);
+  }
+}
+t2.stop();
+
+proc count9sConstRef(const ref s: string): int {
+  return s.count("9");
+}
+
+var nines3: int;
+var t3: Timer;
+t3.start();
+nines3 = 0;
+for i in 1..numTrials {
+  for j in 1..n {
+    nines3 += count9sConstRef(A[j]);
+  }
+}
+t3.stop();
+
+proc count9sRef(ref s: string): int {
+  return s.count("9");
+}
+
+var nines4: int;
+var t4: Timer;
+t4.start();
+nines4 = 0;
+for i in 1..numTrials {
+  for j in 1..n {
+    nines4 += count9sRef(A[j]);
+  }
+}
+t4.stop();
+
+if (nines1/numTrials == expect &&
+    nines2/numTrials == expect &&
+    nines3/numTrials == expect &&
+    nines4/numTrials == expect ) {
+  writeln("Success");
+} else {
+  writeln("Did not get expected output ", expect, " but got:");
+  writeln(nines1);
+  writeln(nines2);
+  writeln(nines3);
+  writeln(nines4);
+}
+
+if timing {
+  writeln("numTrials=", numTrials, " n=", n);
+  writeln("time in seconds for array access by argument intent:");
+  writeln ("1 this      ", t1.elapsed());
+  writeln ("2 default   ", t2.elapsed());
+  writeln ("3 const ref ", t3.elapsed());
+  writeln ("4 ref       ", t4.elapsed());
+}

--- a/test/types/string/ferguson/array-of-strings-read.good
+++ b/test/types/string/ferguson/array-of-strings-read.good
@@ -1,0 +1,1 @@
+Success

--- a/test/types/string/ferguson/array-of-strings-read.graph
+++ b/test/types/string/ferguson/array-of-strings-read.graph
@@ -1,0 +1,4 @@
+perfkeys: 1 this, 2 default, 3 const ref, 4 ref
+graphkeys: this, default, const ref, ref
+graphtitle: Array of string element access
+ylabel: Time (seconds)

--- a/test/types/string/ferguson/array-of-strings-read.perfexecopts
+++ b/test/types/string/ferguson/array-of-strings-read.perfexecopts
@@ -1,0 +1,1 @@
+--timing --numTrials=100

--- a/test/types/string/ferguson/array-of-strings-read.perfkeys
+++ b/test/types/string/ferguson/array-of-strings-read.perfkeys
@@ -1,0 +1,5 @@
+verify: Success
+1 this
+2 default
+3 const ref
+4 ref


### PR DESCRIPTION
This test measures the performance of various ways to use A[i] when A is
an array containing strings.

PR #3054 is one approach to improving the performance here and that PR
contains a description of the problematic generated code.
