### PR TITLE
Fix Spawn and I/O problems

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -709,7 +709,9 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
             if (CallExpr* call = toCallExpr(se->parentExpr)) {
               if (call->isPrimitive(PRIM_ADDR_OF) ||
                   call->isPrimitive(PRIM_GET_MEMBER) ||
+                  call->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
                   call->isPrimitive(PRIM_GET_SVEC_MEMBER) ||
+                  // TODO - should this handle PRIM_GET_SVEC_MEMBER_VALUE?
                   call->isPrimitive(PRIM_WIDE_GET_LOCALE) ||
                   call->isPrimitive(PRIM_WIDE_GET_NODE))
                 // Treat the use of these primitives as a use of their arguments.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1615,6 +1615,7 @@ private extern proc qio_channel_style_element(ch:qio_channel_ptr_t, element:int(
 
 private extern proc qio_channel_flush(threadsafe:c_int, ch:qio_channel_ptr_t):syserr;
 private extern proc qio_channel_close(threadsafe:c_int, ch:qio_channel_ptr_t):syserr;
+private extern proc qio_channel_isclosed(threadsafe:c_int, ch:qio_channel_ptr_t):bool;
 
 private extern proc qio_channel_read(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:ssize_t, ref amt_read:ssize_t):syserr;
 private extern proc qio_channel_read_amt(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:ssize_t):syserr;
@@ -2353,6 +2354,8 @@ proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE, style:iostyle 
 Create a Chapel file that works with a system file descriptor  Note that once
 the file is open, you will need to use a :proc:`file.reader` or
 :proc:`file.writer` to create a channel to actually perform I/O operations
+
+The system file descriptor will be closed when the Chapel file is closed.
 
 .. note::
 
@@ -4373,6 +4376,17 @@ proc channel.close() {
   var e:syserr = ENOERR;
   this.close(error=e);
   if e then this._ch_ioerror(e, "in channel.close");
+}
+
+/*
+   Return `true` if a channel is currently closed.
+ */
+proc channel.isclosed() {
+  var ret:bool;
+  on this.home {
+    ret = qio_channel_isclosed(locking, _channel_internal);
+  }
+  return ret;
 }
 
 // TODO -- we should probably have separate c_ptr ddata and ref versions

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -133,15 +133,15 @@ module Spawn {
      This record represents a subprocess.
 
      Note that the subprocess will not be waited for if this record
-     goes out of scope. Memory used by the subprocess record itself
-     to implement pipes will be freed if the record goes out of scope,
-     however.
+     goes out of scope. Channels opened to communicate with the subprocess
+     will be closed if the record goes out of scope, however.
 
      Generally, it is important to call :proc:`subprocess.wait` to wait for the
      process to complete. If the parent process is using pipes to communicate
      with the subprocess, the parent process may call :proc:`subprocess.close`
-     in order to close the pipes and free any buffers.
-
+     in order to close the pipes and free any buffers. Such calls are
+     generally not needed since the channels will be closed when the
+     subprocess record is automatically destroyed.
    */
   record subprocess {
     /* The kind of a subprocess is used to create the types

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -1015,6 +1015,7 @@ qioerr qio_channel_write_byte(const int threadsafe, qio_channel_t* restrict ch, 
 static inline
 qioerr qio_channel_lock(qio_channel_t* ch)
 {
+  assert( ch != NULL );
   return qio_lock(&ch->lock);
 }
 

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -1363,13 +1363,12 @@ qioerr qio_channel_close(const int threadsafe, qio_channel_t* ch)
 static inline
 bool qio_channel_isclosed(const int threadsafe, qio_channel_t* ch)
 {
-  qioerr err;
   bool ret;
 
   if( ch == NULL ) return true;
 
   if( threadsafe ) {
-    err = qio_lock(&ch->lock);
+    qio_lock(&ch->lock);
   }
 
   ret = false;

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -1357,6 +1357,33 @@ qioerr qio_channel_close(const int threadsafe, qio_channel_t* ch)
   return err;
 }
 
+// Returns true for ch=NULL channel if ch has been closed
+// (but not yet deallocated).
+static inline
+bool qio_channel_isclosed(const int threadsafe, qio_channel_t* ch)
+{
+  qioerr err;
+  bool ret;
+
+  if( ch == NULL ) return true;
+
+  if( threadsafe ) {
+    err = qio_lock(&ch->lock);
+  }
+
+  ret = false;
+  {
+    qio_chtype_t type = (qio_chtype_t) (ch->hints & QIO_CHTYPEMASK);
+    if( type == QIO_CHTYPE_CLOSED ) ret = true;
+  }
+
+  if( threadsafe ) {
+    qio_unlock(&ch->lock);
+  }
+
+  return ret;
+}
+
 qioerr qio_channel_mark(const int threadsafe, qio_channel_t* ch);
 qioerr qio_channel_mark_maybe_flush_bits(const int threadsafe, qio_channel_t* ch, int flushbits);
 

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -2328,6 +2328,9 @@ qioerr _buffered_read_atleast(qio_channel_t* ch, int64_t amt)
     left -= num_read;
     qbuffer_iter_advance(&ch->buf, &read_start, num_read);
 
+    // Ignore interrupted system call, just keep reading.
+    if( err && qio_err_to_int(err) == EINTR ) err = 0;
+
     if( err ) break;
   }
 
@@ -2554,6 +2557,10 @@ qioerr _qio_buffered_behind(qio_channel_t* ch, int flushall)
         // no default to get warnings when new methods are added
       }
       qbuffer_iter_advance(&ch->buf, &write_start, num_written);
+
+      // Ignore interrupted system call, just keep writing.
+      if( err && qio_err_to_int(err) == EINTR ) err = 0;
+
       if( err ) goto error;
     }
   } else {

--- a/test/io/ferguson/isclosed.chpl
+++ b/test/io/ferguson/isclosed.chpl
@@ -1,0 +1,16 @@
+config const fileName = "test.txt";
+
+var f = open(fileName, iomode.cwr);
+
+var w = f.writer();
+
+assert(!w.isclosed());
+w.close();
+assert(w.isclosed());
+
+// Try a channel that was not initialized.
+{
+  var ch:channel(writing=false, kind=iokind.dynamic, locking=true);
+  assert(ch.isclosed());
+}
+

--- a/test/modules/standard/Spawn/no-command.chpl
+++ b/test/modules/standard/Spawn/no-command.chpl
@@ -12,4 +12,4 @@ assert(sub.running == false);
 // but on Linux, exit_status != 0.
 assert(error != 0 || sub.exit_status != 0);
 
-
+sub.close();

--- a/test/modules/standard/Spawn/spawn-error.chpl
+++ b/test/modules/standard/Spawn/spawn-error.chpl
@@ -1,0 +1,8 @@
+use Spawn;
+
+{
+  var sub = spawn(["./some-command-that-does-not-exist"]);
+  sub.wait();
+}
+
+

--- a/test/modules/standard/Spawn/spawn-error.good
+++ b/test/modules/standard/Spawn/spawn-error.good
@@ -1,0 +1,1 @@
+spawn-error.chpl:5: error: No such file or directory encountered when launching subprocess

--- a/test/modules/standard/Spawn/spawn-error.skipif
+++ b/test/modules/standard/Spawn/spawn-error.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM != darwin

--- a/test/modules/standard/Spawn/spawn-error2.chpl
+++ b/test/modules/standard/Spawn/spawn-error2.chpl
@@ -1,0 +1,14 @@
+use Spawn;
+
+{
+  var sub = spawn(["./some-command-that-does-not-exist"], stdout=PIPE);
+  var line:string;
+  var count:int;
+  while sub.stdout.readline(line) {
+    count += 1;
+  }
+  sub.wait();
+  sub.close();
+}
+
+

--- a/test/modules/standard/Spawn/spawn-error2.good
+++ b/test/modules/standard/Spawn/spawn-error2.good
@@ -1,0 +1,1 @@
+spawn-error2.chpl:7: error: No such file or directory encountered when launching subprocess

--- a/test/modules/standard/Spawn/spawn-error2.skipif
+++ b/test/modules/standard/Spawn/spawn-error2.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM != darwin

--- a/test/modules/standard/Spawn/spawn-popen-input-error-long.chpl
+++ b/test/modules/standard/Spawn/spawn-popen-input-error-long.chpl
@@ -23,5 +23,7 @@ while sub.stderr.read(x) {
 assert(sub.running == false);
 assert(sub.exit_status == 0);
 
+sub.close();
+
 writeln("OK");
 

--- a/test/modules/standard/Spawn/spawn-popen-input-output-error-long.chpl
+++ b/test/modules/standard/Spawn/spawn-popen-input-output-error-long.chpl
@@ -36,6 +36,8 @@ while sub.stderr.read(x) {
 assert(sub.running == false);
 assert(sub.exit_status == 0);
 
+sub.close();
+
 writeln("OK");
 
 unlink("stdout-stderr");

--- a/test/modules/standard/Spawn/spawn-popen-input-output-error.chpl
+++ b/test/modules/standard/Spawn/spawn-popen-input-output-error.chpl
@@ -23,8 +23,9 @@ while sub.stderr.readline(line) {
   write("stderr line: ", line);
 }
 
-
 assert(sub.running == false);
 assert(sub.exit_status == 0);
+
+sub.close();
 
 unlink("stdout-stderr");

--- a/test/modules/standard/Spawn/spawn-popen-input-output-long.chpl
+++ b/test/modules/standard/Spawn/spawn-popen-input-output-long.chpl
@@ -21,5 +21,7 @@ while sub.stdout.read(x) {
 assert(sub.running == false);
 assert(sub.exit_status == 0);
 
+sub.close();
+
 writeln("OK");
 

--- a/test/modules/standard/Spawn/spawn-popen-input-output.chpl
+++ b/test/modules/standard/Spawn/spawn-popen-input-output.chpl
@@ -15,3 +15,5 @@ while sub.stdout.readline(line) {
 assert(sub.running == false);
 assert(sub.exit_status == 0);
 
+sub.close();
+

--- a/test/modules/standard/Spawn/spawn-popen-input.chpl
+++ b/test/modules/standard/Spawn/spawn-popen-input.chpl
@@ -8,4 +8,5 @@ sub.wait();
 assert(sub.running == false);
 assert(sub.exit_status == 0);
 
+sub.close();
 

--- a/test/modules/standard/Spawn/spawn-popen-wait.chpl
+++ b/test/modules/standard/Spawn/spawn-popen-wait.chpl
@@ -42,4 +42,5 @@ sub.wait();
 assert(sub.running == false);
 assert(sub.exit_status == 0);
 
+sub.close();
 

--- a/test/modules/standard/Spawn/spawn-popen.chpl
+++ b/test/modules/standard/Spawn/spawn-popen.chpl
@@ -11,4 +11,4 @@ sub.wait();
 assert(sub.running == false);
 assert(sub.exit_status == 0);
 
-
+sub.close();


### PR DESCRIPTION
I wrote a Chapel program to find which files in the test/ directory were
changed most frequently. In doing so, I discovered several bugs and
deficiencies with I/O and the Spawn module. This PR addresses the
problems I encountered.

* Adds a channel.isclosed() method a test for it. (This new method is not
  currently used in the modules).
* Improves the Spawn documentation about what to expect when a subprocess
  record goes out of scope.
* Improve error handling for several cases I was running into with
  slightly wrong programs
* Enable some QIO functions to tolerate EINTR, which I was seeing on Mac
  OS X when debugging
* Added a close function to explicitly close the channels in a
  subprocess. (these should be closed when the subprocess goes out of
  scope).

More details are available in individual commit messages.

Passed test/io/ferguson and test/modules/standard/Spawn on Mac OS X.
Passed full local linux testing.
Passed test/modules/standard/Spawn on Cygwin32.
Reviewed by @lydia-duncan.