### PR TITLE
Skip tests running into sporadic cygwin32 problem

### DIFF
--- a/test/modules/standard/Spawn/spawn-checkmutate.skipif
+++ b/test/modules/standard/Spawn/spawn-checkmutate.skipif
@@ -1,4 +1,4 @@
 # This test runs gcc
 CHPL_TARGET_COMPILER != gnu
 # This test unlinks an executable (see unlink-exe-cygwin.sh)
-CHPL_TARGET_PLATFORM <= cygwin
+CHPL_TARGET_PLATFORM == cygwin32

--- a/test/modules/standard/Spawn/spawn-popen-input-output-error.skipif
+++ b/test/modules/standard/Spawn/spawn-popen-input-output-error.skipif
@@ -1,4 +1,2 @@
-# This test runs gcc
-CHPL_TARGET_COMPILER != gnu
 # This test unlinks an executable (see unlink-exe-cygwin.sh)
 CHPL_TARGET_PLATFORM <= cygwin

--- a/test/modules/standard/Spawn/spawn-popen-input-output-error.skipif
+++ b/test/modules/standard/Spawn/spawn-popen-input-output-error.skipif
@@ -1,2 +1,2 @@
 # This test unlinks an executable (see unlink-exe-cygwin.sh)
-CHPL_TARGET_PLATFORM <= cygwin
+CHPL_TARGET_PLATFORM == cygwin32

--- a/test/modules/standard/Spawn/unlink-exe-cygwin.sh
+++ b/test/modules/standard/Spawn/unlink-exe-cygwin.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script shows a problem with Cygwin where
+# unlinking/removing an executable that used stdout
+# will occasionally result in a Device or resource busy
+# error.
+
+# This error occurs about 10/1000 times on cygwin32.
+
+# When run, this script will only print out the error cases.
+
+# It appears that the executable must use stdout to cause the problem.
+
+echo '
+#include <stdio.h>
+int main(int argc, char** argv) {
+  printf("Hello\n");
+  return 0;
+}' > return0.c
+gcc return0.c -o return0
+
+for i in `seq 1 1000`
+do
+cp return0 a.out && ./a.out > /dev/null && rm a.out
+done


### PR DESCRIPTION
This PR is related to JIRA issue 164. It seems to be a cygwin32 problem
(or a problem specific to our cygwin32 installation). The issue comes up
when unlinking an executable that has just finished running, when that
executable uses stdout. I created a script (included in this PR) that can
easily check for this particular problem. It prints about 10 errors on
cygwin32, but prints no errors on cygwin64, linux, or Mac OS X.

Since the failure is sporadic and connected to Cygwin (vs our code), I
have added .skipif files for the tests that have this behavior. They skip
cygwin32 now.

Not reviewed (testing change only).