### PR TITLE
Enable ldflags to stack like ccflags

### DIFF
--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -28,8 +28,8 @@
 
 extern char executableFilename[FILENAME_MAX+1];
 extern char saveCDir[FILENAME_MAX+1];
-extern char ccflags[256];
-extern char ldflags[256];
+extern std::string ccflags;
+extern std::string ldflags;
 extern bool ccwarnings;
 extern Vec<const char*> incDirs;
 extern int numLibFlags;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -695,7 +695,7 @@ static ArgumentDescription arg_desc[] = {
  {"savec", ' ', "<directory>", "Save generated C code in directory", "P", saveCDir, "CHPL_SAVEC_DIR", verifySaveCDir},
 
  {"", ' ', NULL, "C Code Compilation Options", NULL, NULL, NULL, NULL},
- {"ccflags", ' ', "<flags>", "Back-end C compiler flags (can be specified multiplee times)", "S", NULL, "CHPL_CC_FLAGS", setCCFlags},
+ {"ccflags", ' ', "<flags>", "Back-end C compiler flags (can be specified multiple times)", "S", NULL, "CHPL_CC_FLAGS", setCCFlags},
  {"debug", 'g', NULL, "[Don't] Support debugging of generated C code", "N", &debugCCode, "CHPL_DEBUG", setChapelDebug},
  {"dynamic", ' ', NULL, "Generate a dynamically linked binary", "F", &fLinkStyle, NULL, setDynamicLink},
  {"hdr-search-path", 'I', "<directory>", "C header search path", "P", incFilename, NULL, handleIncDir},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -376,17 +376,25 @@ static void setChapelDebug(const ArgumentDescription* desc, const char* arg_unus
 // being passed to the backend C compiler).
 static void setCCFlags(const ArgumentDescription* desc, const char* arg) {
   // Append arg to the end of ccflags.
-  int curlen = strlen(ccflags);
-  int space = sizeof(ccflags) - curlen - 1 - 1; // room for ' ' and \0
-  int arglen = strlen(arg);
-  if( arglen <= space ) {
-    // add a space if there are already arguments here
-    if( curlen != 0 ) ccflags[curlen++] = ' ';
-    memcpy(&ccflags[curlen], arg, arglen);
-  } else {
-    USR_FATAL("ccflags argument too long");
-  }
+
+  // add a space if there are already arguments here
+  if( ccflags.length() > 0 )
+    ccflags += ' ';
+
+  ccflags += arg;
 }
+
+// similar to setCCFlags
+static void setLDFlags(const ArgumentDescription* desc, const char* arg) {
+  // Append arg to the end of ldflags.
+
+  // add a space if there are already arguments here
+  if( ldflags.length() > 0 )
+    ldflags += ' ';
+
+  ldflags += arg;
+}
+
 
 static void handleLibrary(const ArgumentDescription* desc, const char* arg_unused) {
   addLibInfo(astr("-l", libraryFilename));
@@ -691,7 +699,7 @@ static ArgumentDescription arg_desc[] = {
  {"debug", 'g', NULL, "[Don't] Support debugging of generated C code", "N", &debugCCode, "CHPL_DEBUG", setChapelDebug},
  {"dynamic", ' ', NULL, "Generate a dynamically linked binary", "F", &fLinkStyle, NULL, setDynamicLink},
  {"hdr-search-path", 'I', "<directory>", "C header search path", "P", incFilename, NULL, handleIncDir},
- {"ldflags", ' ', "<flags>", "Back-end C linker flags", "S256", ldflags, "CHPL_LD_FLAGS", NULL},
+ {"ldflags", ' ', "<flags>", "Back-end C linker flags", "S", NULL, "CHPL_LD_FLAGS", setLDFlags},
  {"lib-linkage", 'l', "<library>", "C library linkage", "P", libraryFilename, "CHPL_LIB_NAME", handleLibrary},
  {"lib-search-path", 'L', "<directory>", "C library search path", "P", libraryFilename, "CHPL_LIB_PATH", handleLibPath},
  {"optimize", 'O', NULL, "[Don't] Optimize generated C code", "N", &optimizeCCode, "CHPL_OPTIMIZE", NULL},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -695,11 +695,11 @@ static ArgumentDescription arg_desc[] = {
  {"savec", ' ', "<directory>", "Save generated C code in directory", "P", saveCDir, "CHPL_SAVEC_DIR", verifySaveCDir},
 
  {"", ' ', NULL, "C Code Compilation Options", NULL, NULL, NULL, NULL},
- {"ccflags", ' ', "<flags>", "Back-end C compiler flags", "S", NULL, "CHPL_CC_FLAGS", setCCFlags},
+ {"ccflags", ' ', "<flags>", "Back-end C compiler flags (can be specified multiplee times)", "S", NULL, "CHPL_CC_FLAGS", setCCFlags},
  {"debug", 'g', NULL, "[Don't] Support debugging of generated C code", "N", &debugCCode, "CHPL_DEBUG", setChapelDebug},
  {"dynamic", ' ', NULL, "Generate a dynamically linked binary", "F", &fLinkStyle, NULL, setDynamicLink},
  {"hdr-search-path", 'I', "<directory>", "C header search path", "P", incFilename, NULL, handleIncDir},
- {"ldflags", ' ', "<flags>", "Back-end C linker flags", "S", NULL, "CHPL_LD_FLAGS", setLDFlags},
+ {"ldflags", ' ', "<flags>", "Back-end C linker flags (can be specified multiple times)", "S", NULL, "CHPL_LD_FLAGS", setLDFlags},
  {"lib-linkage", 'l', "<library>", "C library linkage", "P", libraryFilename, "CHPL_LIB_NAME", handleLibrary},
  {"lib-search-path", 'L', "<directory>", "C library search path", "P", libraryFilename, "CHPL_LIB_PATH", handleLibPath},
  {"optimize", 'O', NULL, "[Don't] Optimize generated C code", "N", &optimizeCCode, "CHPL_OPTIMIZE", NULL},

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -49,8 +49,8 @@
 char               executableFilename[FILENAME_MAX + 1] = "a.out";
 char               saveCDir[FILENAME_MAX + 1]           = "";
 
-char               ccflags[256]                         = "";
-char               ldflags[256]                         = "";
+std::string ccflags;
+std::string ldflags;
 
 int                numLibFlags                          = 0;
 const char**       libFlag                              = NULL;
@@ -602,7 +602,7 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname, bool skip_com
   forv_Vec(const char*, dirName, incDirs) {
     fprintf(makefile.fptr, " -I%s", dirName);
   }
-  fprintf(makefile.fptr, " %s\n", ccflags);
+  fprintf(makefile.fptr, " %s\n", ccflags.c_str());
 
   fprintf(makefile.fptr, "COMP_GEN_LFLAGS =");
   if (!fLibraryCompile) {
@@ -616,7 +616,7 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname, bool skip_com
     else
       fprintf(makefile.fptr, " $(LIB_STATIC_FLAG)" );
   }
-  fprintf(makefile.fptr, " %s\n", ldflags);
+  fprintf(makefile.fptr, " %s\n", ldflags.c_str());
 
   fprintf(makefile.fptr, "TAGS_COMMAND = ");
   if (developer && saveCDir[0] && !printCppLineno) {

--- a/man/chpl.txt
+++ b/man/chpl.txt
@@ -248,7 +248,10 @@ OPTIONS
   C Code Compilation Options
 
   --ccflags <flags>   Add the specified flags to the C compiler command line
-                     when compiling the generated code.
+                     when compiling the generated code. Multiple
+                     --ccflags options can be provided and in that case the
+                     combination of the flags will be forwarded to the C
+                     compiler.
 
   -g, --[no-]debug  Causes the generated C code to be compiled with debugging
                     turned on. If you are trying to debug a Chapel program,
@@ -264,7 +267,9 @@ OPTIONS
                      path for header files.
 
   --ldflags <flags>  Add the specified flags to the C compiler link line
-                     when linking the generated code.
+                     when linking the generated code. Multiple --ldflags
+                     options can be provided and in that case the combination
+                     of the flags will be forwarded to the C compiler.
 
   -l, --lib-linkage <library>   Specify a C library to link in on the C
                      compiler command line.

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -97,12 +97,14 @@ C Code Generation Options:
       --savec <directory>             Save generated C code in directory
 
 C Code Compilation Options:
-      --ccflags <flags>               Back-end C compiler flags
+      --ccflags <flags>               Back-end C compiler flags (can be
+                                      specified multiple times)
   -g, --[no-]debug                    [Don't] Support debugging of generated C
                                       code
       --dynamic                       Generate a dynamically linked binary
   -I, --hdr-search-path <directory>   C header search path
-      --ldflags <flags>               Back-end C linker flags
+      --ldflags <flags>               Back-end C linker flags (can be
+                                      specified multiple times)
   -l, --lib-linkage <library>         C library linkage
   -L, --lib-search-path <directory>   C library search path
   -O, --[no-]optimize                 [Don't] Optimize generated C code

--- a/test/compflags/ferguson/ldflags-order.chpl
+++ b/test/compflags/ferguson/ldflags-order.chpl
@@ -1,0 +1,1 @@
+writeln("Hi");

--- a/test/compflags/ferguson/ldflags-order.compopts
+++ b/test/compflags/ferguson/ldflags-order.compopts
@@ -1,0 +1,1 @@
+--print-commands --ldflags -Ltest-a --ldflags -Ltest-b --ldflags -Ltest-a

--- a/test/compflags/ferguson/ldflags-order.good
+++ b/test/compflags/ferguson/ldflags-order.good
@@ -1,0 +1,1 @@
+-Ltest-a -Ltest-b -Ltest-a

--- a/test/compflags/ferguson/ldflags-order.prediff
+++ b/test/compflags/ferguson/ldflags-order.prediff
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+TEST=$1
+LOG=$2
+# PREDIFF: Script to execute before diff'ing output (arguments: <test
+#    executable>, <log>, <compiler executable>)
+
+MYLOG=""
+
+LAST=""
+
+for word in `cat $LOG`
+  do
+    if [[ $word == -Ltest-* ]]
+      then
+        if [[ $word != $LAST ]]
+          then
+            MYLOG+=" $word"
+            LAST=$word
+          fi
+      fi
+done
+
+echo $MYLOG > $LOG

--- a/test/compflags/ferguson/ldflags-order.skipif
+++ b/test/compflags/ferguson/ldflags-order.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER != gnu

--- a/test/compflags/ferguson/test-a/README
+++ b/test/compflags/ferguson/test-a/README
@@ -1,0 +1,1 @@
+Empty directory for -Ltest-a for ldflags test

--- a/test/compflags/ferguson/test-b/README
+++ b/test/compflags/ferguson/test-b/README
@@ -1,0 +1,1 @@
+Empty directory for -Ltest-b for ldflags test


### PR DESCRIPTION
If you specify multiple --ccflags options, e.g.

    --ccflags -O1 --ccflags -O3

the C compiler will get the combination of the flags, e.g.

    -O1 -O3

This feature is useful when some compiler arguments come from
a package (or a script giving arguments needed to use a library e.g.).
This pattern happens a lot with 3rd party software. llvm-config
is an example that comes to mind. Since the arguments stack, a
user of a library can also add flags, e.g.

    chpl `library-get-compflags.sh` --ccflags -fPIC

will append to - but not replace - any ccflags from the script.

Generally speaking, we expect that a C compiler will handle several
options for the same thing, where the last takes precedence, e.g.

     -O1 -O3

is really the same as

     -O3

This PR updates --ldflags to receive the same treatment, and cleans up
--ccflags and --ldflags support so that they use a std::string instead of
a fixed length C string. It adds a test to verify this behavior of
ldflags.

Passed full local testing.
Reviewed by @ben-albrecht.