### PR TITLE
Fix an error handling bug in start_test

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -281,7 +281,7 @@ def test_directory(test, test_type):
                         # error that would have already reported.
                         if not error == 0 and not error == 173:
                             logger.write("[Error running sub_test in {0} {1}]"
-                                    .format(root, e.returncode))
+                                    .format(root, error))
                                 
             # let user know no tests were found
             else:


### PR DESCRIPTION
I was testing on a system that did not have csh installed, and testing
ended in the directory test/compflags/bradc/copyright/ because it has a
PREDIFF written in csh, and start_test did not correctly handle the
error.  The fix looks clear to me at least, and solved the problem.

Trivial and not reviewed.