### PR TITLE
Contents looks out of place on these pages

### DIFF
--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -3,8 +3,6 @@
 Chapel Documentation
 ====================
 
-Contents:
-
 .. toctree::
    :caption: Compiling and Running Chapel
    :maxdepth: 1

--- a/doc/sphinx/source/language/spec.rst
+++ b/doc/sphinx/source/language/spec.rst
@@ -3,6 +3,4 @@
 Chapel Language Specification
 =============================
 
-Contents:
-
 * :download:`View Language Specification [pdf] <spec.pdf>`


### PR DESCRIPTION
`Contents:` looks out of place on the mainpage TOC and the spec download page.