### PR TITLE
Restoring a dropped space

### DIFF
--- a/compiler/resolution/callInfo.cpp
+++ b/compiler/resolution/callInfo.cpp
@@ -58,7 +58,7 @@ CallInfo::CallInfo(CallExpr* icall, bool checkonly) :
     Type* t = se->var->type;
     if (t == dtUnknown && ! se->var->hasFlag(FLAG_TYPE_VARIABLE) ) {
       if (checkonly) badcall = true;
-      else USR_FATAL(call, "use of '%s' before encountering its definition,"
+      else USR_FATAL(call, "use of '%s' before encountering its definition, "
                            "type unknown", se->var->name);
     }
     if (t->symbol->hasFlag(FLAG_GENERIC)) {


### PR DESCRIPTION
In refactoring this code (PR #3072), Michael dropped a space from a string literal making five futures no longer match their .bads.  This restores the space.
