### PR TITLE
Unfuturize test unusedEnumDeclInFn

### DIFF
--- a/test/types/enum/diten/unusedEnumDeclInFn.future
+++ b/test/types/enum/diten/unusedEnumDeclInFn.future
@@ -1,1 +1,0 @@
-bug: unused enum declaration in function body causes bad mem access in compiler

--- a/test/types/enum/diten/unusedEnumDeclInFn.skipif
+++ b/test/types/enum/diten/unusedEnumDeclInFn.skipif
@@ -1,1 +1,0 @@
-CHPL_TEST_VGRND_COMP != on


### PR DESCRIPTION
This .future has been passing since record strings were merged (bb0f6cf).  The invalid
reads and writes valgrind reported have gone away. bb0f6cf seems to have fixed the bug
this test was running into.

Also removed the .skipif file to allow this test to run in all configurations instead of
restricting it to valgrind runs only.