### PR TITLE
Make fixes as suggested by Paul Casella via email

### DIFF
--- a/spec/Lexical_Structure.tex
+++ b/spec/Lexical_Structure.tex
@@ -357,7 +357,7 @@ string-character:
   hexadecimal-escape-character
 
 simple-escape-character: one of
-  `$\backslash\mbox{\bf '}\hspace{5pt}$' `$\backslash$"$\hspace{5pt}$' `$\backslash$?$\hspace{5pt}$' `$\backslash$a$\hspace{5pt}$' `$\backslash$b$\hspace{5pt}$' `$\backslash$f$\hspace{5pt}$' `$\backslash$n$\hspace{5pt}$' `$\backslash$r$\hspace{5pt}$' `$\backslash$t$\hspace{5pt}$' `$\backslash$v$\hspace{5pt}$'
+  `$\backslash\mbox{\bf '}\hspace{5pt}$' `$\backslash$"$\hspace{5pt}$' `$\backslash$?$\hspace{5pt}$' `$\backslash$\$\hspace{5pt}$' `$\backslash$a$\hspace{5pt}$' `$\backslash$b$\hspace{5pt}$' `$\backslash$f$\hspace{5pt}$' `$\backslash$n$\hspace{5pt}$' `$\backslash$r$\hspace{5pt}$' `$\backslash$t$\hspace{5pt}$' `$\backslash$v$\hspace{5pt}$'
 
 hexadecimal-escape-character:
   `$\backslash$x' hexadecimal-digits

--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -91,8 +91,8 @@ specified filename.  If the resulting name is not a legal Chapel
 identifier, it cannot be referenced in a use statement.
 
 \begin{chapelexample}{implicit.chpl}
-The following file, named myModule.chpl, defines an implicitly named
-module called myModule.
+The following file, named implicit.chpl, defines an implicitly named
+module called implicit.
 \begin{chapel}
 var x: int = 0;
 var y: int = 1;
@@ -112,7 +112,7 @@ printY();
 0
 1
 \end{chapeloutput}
-Module myModule defines the top-level module symbols x, y, printX, and
+Module implicit defines the top-level module symbols x, y, printX, and
 printY.
 \end{chapelexample}
 
@@ -155,8 +155,8 @@ Files with both module declarations and top-level statements result in
 nested modules.
 
 \begin{chapelexample}{nested.chpl}
-The following file, named myModule.chpl, defines an
-implicitly named module called myModule, with nested modules
+The following file, named nested.chpl, defines an
+implicitly named module called nested, with nested modules
 MX and MY.
 \begin{chapel}
 module MX {

--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -351,7 +351,6 @@ Parameter expressions are restricted to the following constructs:
 \item
  Applications of the binary operators \verb@+@, \verb@-@, \verb@*@, \verb@/@, \verb@%@, \verb@**@, \verb@&&@, \verb@||@, \verb@&@, \verb@|@, \verb@^@, \verb@<<@, \verb@>>@, \verb@==@, \verb@!=@, \verb@<=@, \verb@>=@, \verb@<@, and \verb@>@ on operands that are bool or integral parameter expressions.
 \item
-\item
  Applications of the binary
  operators \verb@+@, \verb@-@, \verb@*@, \verb@/@, \verb@**@, \verb@==@, \verb@!=@, \verb@<=@, \verb@>=@, \verb@<@,
  and \verb@>@ on operands that are real, imaginary or complex parameter expressions.


### PR DESCRIPTION
Include \ on the list of simple-escape-characters in section 6.4.3 Literals.
Fix the names of the example files in 12.2 Files and Implicit Modules, and
12.3 Nested Modules.  Remove an empty bullet in the list on 8.4.1 Compile-Time
Constants.

Thanks Paul!