### PR TITLE
Fix several errors in testing from the filename index change

### DIFF
--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -581,6 +581,7 @@ static void codegen_header_compilation_config() {
     genComment("Compilation Info");
 
     fprintf(cfgfile.fptr, "\n#include <stdio.h>\n");
+    fprintf(cfgfile.fptr, "\n#include \"chpltypes.h\"\n");
 
     genGlobalString("chpl_compileCommand", compileCommand);
     genGlobalString("chpl_compileVersion", compileVersion);

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -1017,7 +1017,7 @@ static void report_locked_threads(void) {
       if (rep->lineno > 0 && rep->filename)
         fprintf(stderr, "Waiting at: %s:%d\n",
                 chpl_lookupFilename(rep->filename), rep->lineno);
-      else if (rep->lineno == 0 && rep->filename != CHPL_FILE_IDX_IDLE_TASK)
+      else if (rep->lineno == 0 && rep->filename == CHPL_FILE_IDX_IDLE_TASK)
         fprintf(stderr, "Waiting for more work\n");
     }
     rep = rep->next;

--- a/test/memory/bradc/allocBig.chpl
+++ b/test/memory/bradc/allocBig.chpl
@@ -1,3 +1,3 @@
 extern proc chpl_mem_allocMany(number, size, description, lineno, filename);
 
-chpl_mem_allocMany(max(int(32)), max(int(32)), 0, 3, "allocBig.chpl");
+chpl_mem_allocMany(max(int(32)), max(int(32)), 0, 3, __primitve("_get_user_file"));

--- a/test/optimizations/cache-remote/ferguson/correctness/ontest4.chpl
+++ b/test/optimizations/cache-remote/ferguson/correctness/ontest4.chpl
@@ -1,5 +1,5 @@
 extern proc chpl_cache_print();
-extern proc chpl_cache_fence(acquire:c_int, release:c_int, ln:int(32), fn:c_string);
+extern proc chpl_cache_fence(acquire:c_int, release:c_int, ln:int(32), fn:int(32));
 extern proc printf(fmt: c_string, vals...?numvals): int;
 config const verbose=false;
 
@@ -13,7 +13,7 @@ proc do_barrier(i:int, testnum:int)
   var release = ((i>>release_num) & 1):c_int;
   if verbose && acquire!=0 then printf("on %d running acquire barrier\n", here.id:c_int);
   if verbose && release!=0 then printf("on %d running release barrier\n", here.id:c_int);
-  chpl_cache_fence(acquire, release, -1, "");
+  chpl_cache_fence(acquire, release, -1, 0);
 }
 
 proc doit(a:locale, b:locale, i:int)

--- a/test/runtime/gbt/tasks/callbacks/tcb-util.h
+++ b/test/runtime/gbt/tasks/callbacks/tcb-util.h
@@ -21,15 +21,12 @@ void tcb_report(void);
 
 #include <pthread.h>
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 
 #include "chpl-tasks-callbacks.h"
 #include "chpl-linefile-support.h"
-
-
-// This seems not to come from <string.h> without effort; just declare it.
-extern char* strdup(const char*);
 
 
 static struct tcb_data {


### PR DESCRIPTION
compiler/passes/codegen.cpp:
  LLVM was failing to compile, it needed an additional header in
  chpl_compilation_config.c

runtime/src/tasks/fifo/tasks-fifo.c:
  !strcmp(a, b) is testing for equality, flip a conditional that was
  incorrect.

A few other minor test fixes.