### PR TITLE
Update cullOverReferences to track return-by-ref for strings

### DIFF
--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -24,6 +24,23 @@
 #include "stmt.h"
 #include "symbol.h"
 
+//
+// MDN: 2016/01/07
+//
+// Update the sense of "a reference is necessary", i.e. the call-site
+// being examined should preserve the reference, to include the case
+// in which the ref-return function is returning a _ref(string).
+//
+// The goal is to avoid inserting a string value for the result of
+// the library functions that return strings as this will then drive
+// the insertion of an autoCopy/autoDestory pair.  This is particularly
+// problematic when accessing an array of strings.
+//
+// This update is acceptable for the current string libraries but may
+// have problems in the not-too-distant future.  Trying to handle the
+// general case of user-defined records as well as handling return with
+// ref-intent more thoughtfully is likely to require additional work.
+
 static bool
 refNecessary(SymExpr*                      se,
              Map<Symbol*, Vec<SymExpr*>*>& defMap,
@@ -96,6 +113,11 @@ refNecessary(SymExpr*                      se,
                 return true;
             }
           }
+
+        // Hueristic: if we are deferencing a string reference,
+        // that reference may still be needed.
+        } else if (isString(se->var->type->getValType())) {
+          return true;
         }
       }
     }

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -25,99 +25,160 @@
 #include "symbol.h"
 
 static bool
-refNecessary(SymExpr* se,
-             Map<Symbol*,Vec<SymExpr*>*>& defMap,
-             Map<Symbol*,Vec<SymExpr*>*>& useMap) {
+refNecessary(SymExpr*                      se,
+             Map<Symbol*, Vec<SymExpr*>*>& defMap,
+             Map<Symbol*, Vec<SymExpr*>*>& useMap) {
   Vec<SymExpr*>* defs = defMap.get(se->var);
+
   if (defs && defs->n > 1)
     return true;
+
   for_uses(use, useMap, se->var) {
     if (CallExpr* call = toCallExpr(use->parentExpr)) {
       if (FnSymbol* fn = call->isResolved()) {
         ArgSymbol* formal = actual_to_formal(use);
         if (formal->defPoint->getFunction()->_this == formal)
           return true;
+
         if (formal->intent == INTENT_INOUT || formal->intent == INTENT_OUT)
           return true;
+
         if (formal->type->symbol->hasFlag(FLAG_REF) &&
             (fn->hasFlag(FLAG_ALLOW_REF) ||
              formal->hasFlag(FLAG_WRAP_WRITTEN_FORMAL)))
           return true;
+
       } else if (call->isPrimitive(PRIM_MOVE)) {
         if (refNecessary(toSymExpr(call->get(1)), defMap, useMap))
           return true;
+
       } else if (call->isPrimitive(PRIM_GET_MEMBER) ||
                  call->isPrimitive(PRIM_GET_SVEC_MEMBER)) {
         CallExpr* move = toCallExpr(call->parentExpr);
+
         INT_ASSERT(move);
         INT_ASSERT(move->isPrimitive(PRIM_MOVE));
+
         if (refNecessary(toSymExpr(move->get(1)), defMap, useMap))
           return true;
+
       } else if (call->isPrimitive(PRIM_SET_MEMBER)) {
         if (!call->get(2)->typeInfo()->refType)
           return true;
+
       } else if (call->isPrimitive(PRIM_RETURN) ||
                  call->isPrimitive(PRIM_YIELD)) {
         return true;
+
       } else if (call->isPrimitive(PRIM_WIDE_GET_LOCALE) ||
                  call->isPrimitive(PRIM_WIDE_GET_NODE)) {
-        // If we are extracting a field from the wide pointer, we need to keep it as a pointer.
-        // Dereferencing would be premature.
+        // If we are extracting a field from the wide pointer,
+        // we need to keep it as a pointer.
         return true;
-      } else if (call->isPrimitive(PRIM_DEREF) &&
-                 isRecordWrappedType(se->var->type->getValType())) {
+
+      } else if (call->isPrimitive(PRIM_DEREF)) {
         // Heuristic: if we are dereferencing an array reference,
         // that reference may still be needed.
-        Expr* callParent = call->parentExpr;
-        INT_ASSERT(callParent);
-        if (CallExpr* callParentCall = toCallExpr(callParent)) {
-          if (callParentCall->isPrimitive(PRIM_MOVE)) {
-            INT_ASSERT(call == callParentCall->get(2));
-            SymExpr* dest = toSymExpr(callParentCall->get(1));
-            INT_ASSERT(dest);
-            if (dest->var->hasFlag(FLAG_COERCE_TEMP))
-              return true;
+        if (isRecordWrappedType(se->var->type->getValType())) {
+          Expr* callParent = call->parentExpr;
+
+          INT_ASSERT(callParent);
+
+          if (CallExpr* callParentCall = toCallExpr(callParent)) {
+            if (callParentCall->isPrimitive(PRIM_MOVE)) {
+              INT_ASSERT(call == callParentCall->get(2));
+
+              SymExpr* dest = toSymExpr(callParentCall->get(1));
+
+              INT_ASSERT(dest);
+
+              if (dest->var->hasFlag(FLAG_COERCE_TEMP))
+                return true;
+            }
           }
         }
       }
     }
   }
+
   return false;
 }
 
 
 //
-// removes references that are not necessary
+// MDN: 2016/01/07
+// Currently every function that is declared as return-by-ref
+// is implemented as a pair of functions.
 //
+//   1) A function that returns a ref
+//   2) A function that returns a value
+//
+// Additionally the "by-ref" version includes a pointer to the "by-value"
+// version.
+//
+// This is done independently of whether the setter param is used in the
+// the function body and without careful attention to whether the function
+// actually returns a value or a ref.
+//
+// The early phases of resolution have bound the call-site for every
+// return-by-ref function to the "by-ref" version of the function.
+//
+// This pass studies all of these call-sites and determines if the
+// "by-reference" version is "necessary".  If it is not, then the
+// compiler attempts to switch in the "by-value" version. This requires
+// the insertion of a temporary value near the call site.
+//
+// The compiler must also determine whether the "by value" implementation
+// will have inserted an autoCopy.   If so then the compiler attaches
+// the AUTO_COPY/AUTO_DESTROY flags as necessary to enable the
+// callDestructors pass to operate correctly.
+//
+// As far as I can tell this switch, at best, only lossely coupled to the
+// the setter param.   Most functions that return with ref-intent do not
+// inspect the setter param but I think that some portions of the compiler
+// assume that setter = true for the by-ref version and setter = false for
+// the by-value version.  If this is correct then there could be programs
+// in which the function replacement does not track the setter param
+// correctly.
+//
+// Careful separation of "by-ref" behavior and the management of the
+// setter param will require additional effort.
+//
+
 void cullOverReferences() {
-  //
-  // change call of reference function to value function
-  //
-  Map<Symbol*,Vec<SymExpr*>*> defMap;
-  Map<Symbol*,Vec<SymExpr*>*> useMap;
+  Map<Symbol*, Vec<SymExpr*>*> defMap;
+  Map<Symbol*, Vec<SymExpr*>*> useMap;
 
   buildDefUseMaps(defMap, useMap);
 
   forv_Vec(CallExpr, call, gCallExprs) {
+    // Is the current call to a non-primitive?
     if (FnSymbol* fn = call->isResolved()) {
-      if (FnSymbol* copy = fn->valueFunction) {
+
+      // Does the function have a "value" counter-part?
+      if (FnSymbol* valueFn = fn->valueFunction) {
         if (CallExpr* move = toCallExpr(call->parentExpr)) {
           INT_ASSERT(move->isPrimitive(PRIM_MOVE));
+
           SymExpr* se = toSymExpr(move->get(1));
 
           INT_ASSERT(se);
-          SET_LINENO(move);
 
-          if (!refNecessary(se, defMap, useMap)) {
+          // Is it "necessary" to retain the reference?
+          if (refNecessary(se, defMap, useMap) == false) {
+            SET_LINENO(move);
+
             SymExpr*   base = toSymExpr(call->baseExpr);
-            VarSymbol* tmp  = newTemp(copy->retType);
+            VarSymbol* tmp  = newTemp(valueFn->retType);
 
-            base->var = copy;
+            // Swap in the by-value implementation
+            base->var = valueFn;
 
+            // Generate a value temp to receive the value
             move->insertBefore(new DefExpr(tmp));
 
             if (requiresImplicitDestroy(call)) {
-              if (isString(copy->retType) == false) {
+              if (isString(valueFn->retType) == false) {
                 tmp->addFlag(FLAG_INSERT_AUTO_COPY);
                 tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
               } else {
@@ -135,6 +196,7 @@ void cullOverReferences() {
 
             se->var = tmp;
           }
+
         } else
           INT_FATAL(call, "unexpected case");
       }
@@ -155,38 +217,48 @@ void cullOverReferences() {
           def->sym->type = vt;
         }
       }
+
       if (FnSymbol* fn = toFnSymbol(def->sym)) {
         if (Type* vt = fn->retType->getValType()) {
           if (isRecordWrappedType(vt)) {
             fn->retType = vt;
-            fn->retTag = RET_VALUE;
+            fn->retTag  = RET_VALUE;
           }
         }
       }
     }
   }
+
   forv_Vec(CallExpr, call, gCallExprs) {
     if (call->isPrimitive(PRIM_DEREF) ||
         call->isPrimitive(PRIM_ADDR_OF)) {
       Type* vt = call->get(1)->typeInfo();
+
       if (isReferenceType(vt))
         vt = vt->getValType();
+
       if (isRecordWrappedType(vt))
         call->replace(call->get(1)->remove());
     }
+
     if (call->isPrimitive(PRIM_GET_MEMBER)) {
       Type* vt = call->get(2)->getValType();
+
       if (isRecordWrappedType(vt))
         call->primitive = primitives[PRIM_GET_MEMBER_VALUE];
     }
+
     if (call->isPrimitive(PRIM_GET_SVEC_MEMBER)) {
       Type* tupleType = call->get(1)->getValType();
-      Type* vt = tupleType->getField("x1")->getValType();
+      Type* vt        = tupleType->getField("x1")->getValType();
+
       if (isRecordWrappedType(vt))
         call->primitive = primitives[PRIM_GET_SVEC_MEMBER_VALUE];
     }
+
     if (call->isPrimitive(PRIM_ARRAY_GET)) {
       Type* vt = call->getValType();
+
       if (isRecordWrappedType(vt))
         call->primitive = primitives[PRIM_ARRAY_GET_VALUE];
     }


### PR DESCRIPTION
Functions that return by ref-intent are currently implemented as a pair of functions; one function
returns by-ref and the other returns by-value.  These functions are generated during resolution;
the by-ref version is inserted at the call-site and it maintains a pointer to the by-value version.

The cullOverReferences pass evaluates these call-sites and attempts to replace the by-ref version
with the by-value version when practical.  If it does so, then it inserts a temporary variable that may
in turn require autoCopy/autoDestroy behavior.

There are various exceptions that prevent this substitution.  Add an exception for by-ref functions that
return_ref(string) to match the handling of those that return _ref(_array) in an effort to quash certain
obnoxious autoCopy/autoDestroy sequences.  The logic for these exceptions appears a little fragile
to me and is likely to need rework in the nearer future.

In the immediate term this adjustment removes a common pattern of autoCopy/autoDestory sequences,
especially associated with accesses of an array of strings, without any apparent negative consequences.

This PR has two commits; the first introduces white space changes and comments to help provide some clarity on the core behavior of this pass.  The second, trivial, commit extends the case for _ref(_array) to
include _ref(_string).
