### PR TITLE
Tidy up union in ifa, use in ParamForLoop

### DIFF
--- a/compiler/AST/ParamForLoop.cpp
+++ b/compiler/AST/ParamForLoop.cpp
@@ -431,7 +431,7 @@ CallExpr* ParamForLoop::foldForResolve()
 
     uint64_t low    = lvar->immediate->to_uint();
     uint64_t high   = hvar->immediate->to_uint();
-    int64_t  stride = svar->immediate->to_uint();
+    int64_t  stride = svar->immediate->to_int();
 
     if (stride <= 0)
     {

--- a/compiler/AST/ParamForLoop.cpp
+++ b/compiler/AST/ParamForLoop.cpp
@@ -399,9 +399,9 @@ CallExpr* ParamForLoop::foldForResolve()
 
   if (is_int_type(idxType))
   {
-    int64_t low    = lvar->immediate->int_value();
-    int64_t high   = hvar->immediate->int_value();
-    int64_t stride = svar->immediate->int_value();
+    int64_t low    = lvar->immediate->to_int();
+    int64_t high   = hvar->immediate->to_int();
+    int64_t stride = svar->immediate->to_int();
 
     if (stride <= 0)
     {
@@ -429,9 +429,9 @@ CallExpr* ParamForLoop::foldForResolve()
   {
     INT_ASSERT(is_uint_type(idxType) || is_bool_type(idxType));
 
-    uint64_t low    = lvar->immediate->uint_value();
-    uint64_t high   = hvar->immediate->uint_value();
-    int64_t  stride = svar->immediate->int_value();
+    uint64_t low    = lvar->immediate->to_uint();
+    uint64_t high   = hvar->immediate->to_uint();
+    int64_t  stride = svar->immediate->to_uint();
 
     if (stride <= 0)
     {

--- a/compiler/ifa/num.h
+++ b/compiler/ifa/num.h
@@ -120,6 +120,9 @@ class Immediate { public:
   int64_t  int_value( void);
   uint64_t uint_value( void);
   uint64_t bool_value( void);
+  // calls int_value, uint_value, or bool_value as appropriate.
+  int64_t  to_int( void);
+  uint64_t to_uint( void);
 
   Immediate& operator=(const Immediate&);
   Immediate& operator=(bool b) {
@@ -156,12 +159,14 @@ class Immediate { public:
 
 inline uint64_t
 Immediate::bool_value( void) {
+  INT_ASSERT(const_kind == NUM_KIND_BOOL);
   return v_bool;
 }
 
 inline int64_t
 Immediate::int_value( void) {
   int64_t val = 0;
+  INT_ASSERT(const_kind == NUM_KIND_INT);
   switch (num_index) {
   case INT_SIZE_8 : val = v_int8;  break;
   case INT_SIZE_16: val = v_int16; break;
@@ -177,6 +182,7 @@ Immediate::int_value( void) {
 inline uint64_t
 Immediate::uint_value( void) {
   uint64_t val = 0;
+  INT_ASSERT(const_kind == NUM_KIND_UINT);
   switch (num_index) {
   case INT_SIZE_8 : val = v_uint8;  break;
   case INT_SIZE_16: val = v_uint16; break;
@@ -188,6 +194,32 @@ Immediate::uint_value( void) {
   return val;
 }
 
+inline int64_t
+Immediate::to_int( void) {
+  int64_t val = 0;
+  switch (const_kind) {
+    case NUM_KIND_INT : val = int_value();  break;
+    case NUM_KIND_UINT: val = uint_value(); break;
+    case NUM_KIND_BOOL: val = bool_value(); break;
+  default:
+    INT_FATAL("kind not handled in to_int");
+  }
+  return val;
+}
+
+
+inline uint64_t
+Immediate::to_uint( void) {
+  uint64_t val = 0;
+  switch (const_kind) {
+    case NUM_KIND_INT : val = int_value();  break;
+    case NUM_KIND_UINT: val = uint_value(); break;
+    case NUM_KIND_BOOL: val = bool_value(); break;
+  default:
+    INT_FATAL("kind not handled in to_uint");
+  }
+  return val;
+}
 
 class ImmHashFns { public:
   static unsigned int hash(Immediate *);


### PR DESCRIPTION
Union elements should (for portability/C standard compliance)
technically only be read if they were the one set. Add asserts
to check that. Since ParamForLoop really wants to convert
to an integer/uint, I also added to_int and to_uint methods
for Immediate that do so in a way that only uses the
union element previously stored.

The test test/param/diten/paramForBool.chpl otherwise fails
with the assertions added.

Passed full local quickstart testing, Hello with GASNet.
Not reviewed.