### PR TITLE
Adding rpath to glibc (includes glibcxx) for Crays

### DIFF
--- a/make/platform/Makefile.cray-x-series
+++ b/make/platform/Makefile.cray-x-series
@@ -20,4 +20,8 @@ ifeq ($(CHPL_COMM), gasnet)
   GEN_LFLAGS += -L/usr/lib64/nptl
 endif
 
+# This ensures that the Chapel binary can find and link against the latest
+# gcc-lib versions. This addition was motivated by an error where chapel
+# could not find a version of GLIBCXX when compiling with intel/cray compilers
+# Note: This is assuming gcc-libs maintain forward compatibility
 LDFLAGS += -Wl,-rpath,/opt/cray/gcc-libs

--- a/make/platform/Makefile.cray-x-series
+++ b/make/platform/Makefile.cray-x-series
@@ -23,5 +23,6 @@ endif
 # This ensures that the Chapel binary can find and link against the latest
 # gcc-lib versions. This addition was motivated by an error where chapel
 # could not find a version of GLIBCXX when compiling with intel/cray compilers
+# This particular approach was suggested by CCE build/integration staff.
 # Note: This is assuming gcc-libs maintain forward compatibility
 LDFLAGS += -Wl,-rpath,/opt/cray/gcc-libs

--- a/make/platform/Makefile.cray-x-series
+++ b/make/platform/Makefile.cray-x-series
@@ -19,3 +19,5 @@ ifeq ($(CHPL_COMM), gasnet)
   GEN_CFLAGS += -I$(GASNET_INSTALL_DIR)/patched_headers
   GEN_LFLAGS += -L/usr/lib64/nptl
 endif
+
+LDFLAGS += -Wl,-rpath,/opt/cray/gcc-libs


### PR DESCRIPTION
## Bug-fix to `GLIBCXX_3.4.18 not found` error on Cray XC/XEs

### The problem
The Chapel compiler binary is built with gcc, and has dependencies on glibcxx/glibc. On Cray machines, when the gnu programming environment and gcc are not loaded (such as when using intel gen compiler), some glibcxx dependencies are not available, resulting in a nasty error on every call to the binary (hence every test failing).

### The solution
This patch adds an rpath into the chpl binary that points to the latest gcc-libs, so that chpl can find the glibcxx dependency regardless of what modules are loaded (loading a specific version of gcc will override this rpath however). This is assuming the gcc-lib versions remain forwards compatible.

The change is made to `Makefile.cray-x-series`, which will affect all Cray X* builds.

### Testing

Confirmed that the rpath works on a Cray-XC machine. Going to test the module build / smoke test via Jenkins with this patch merged.