### PR TITLE
Fix typo in test allocBig.chpl

### DIFF
--- a/test/memory/bradc/allocBig.chpl
+++ b/test/memory/bradc/allocBig.chpl
@@ -1,3 +1,3 @@
 extern proc chpl_mem_allocMany(number, size, description, lineno, filename);
 
-chpl_mem_allocMany(max(int(32)), max(int(32)), 0, 3, __primitve("_get_user_file"));
+chpl_mem_allocMany(max(int(32)), max(int(32)), 0, 3, __primitive("_get_user_file"));


### PR DESCRIPTION
This is a follow-on to PR #3082.