### PR TITLE
Clean up the man page for chpldoc a little bit

### DIFF
--- a/man/chpldoc.txt
+++ b/man/chpldoc.txt
@@ -41,7 +41,7 @@ DESCRIPTION
   --[no-]html       [Don't] generate HTML-based documentation (on by default)
 
   --[no-]print-commands  Prints the system commands that chpldoc executes
-		    in order to create the documentation.
+  		    in order to create the documentation.
 
 
   Information Options
@@ -52,8 +52,7 @@ DESCRIPTION
 
   --help-env        Print the command line option help message, listing
                     the environment variable equivalent for each flag, if
-		    applicable (see ENVIRONMENT VARIABLES FOR OPTIONS), and
-		    its current value.
+		    applicable (see ENVIRONMENT), and its current value.
 
   --help-settings   Print the command line option help message, listing
                     the current setting of each option as specified by
@@ -68,7 +67,7 @@ DESCRIPTION
 ENVIRONMENT
 
   Some command-line options have an environment variable that can be used
-  to specify a default value. Use the --help-env option to list the
+  to specify a default value. Use the --help-env option to list the 
   environment variable equivalent for each option. Command-line options 
   will always override environment variable settings in the event of a 
   conflict.

--- a/man/chpldoc.txt
+++ b/man/chpldoc.txt
@@ -35,7 +35,8 @@ DESCRIPTION
 
   --save-sphinx <directory>  Save generated Sphinx project in directory.
 
-  --text-only       Generate text based documentation instead of HTML. Takes precedence over --[no-]html
+  --text-only       Generate text based documentation instead of HTML. Takes
+		     precedence over --[no-]html
 
   --[no-]html       [Don't] generate HTML based documentation (on by default)
 
@@ -49,22 +50,23 @@ DESCRIPTION
                     purpose.
 
   --help-env        Print the command line option help message, listing
-                    the environment variable equivalent for each flag (see
-                    ENVIRONMENT VARIABLES FOR OPTIONS) and its current value.
+                    the environment variable equivalent for each flag, if
+		     applicable (see ENVIRONMENT VARIABLES FOR OPTIONS), and
+		     its current value.
 
   --help-settings   Print the command line option help message, listing
                     the current setting of each option as specified by
                     environment variables and other flags on the command line.
 
-  --version         Print the version number of the compiler.
+  --version         Print chpldoc's version number.
 
-  --copyright       Print the compiler's copyright information.
+  --copyright       Print chpldoc's copyright information.
 
-  --license         Print the compiler's license information.
+  --license         Print chpldoc's license information.
 
 ENVIRONMENT VARIABLES FOR OPTIONS
 
-  Most compiler command-line options have an environment variable that can
+  Some compiler command-line options have an environment variable that can
   be used to specify a default value. Use the --help-env option to list the 
   environment variable equivalent for each option. Command-line options 
   will always override environment variable settings in the event of a 

--- a/man/chpldoc.txt
+++ b/man/chpldoc.txt
@@ -10,8 +10,8 @@ SYNOPSIS
 DESCRIPTION
 
   chpldoc is a tool for generating HTML based documentation from Chapel
-  source code and embedded comments. It does this by parsing Chapel
-  source files and associating comments with symbols, then generating
+  source code and its comments. It does this by parsing Chapel source
+  files and associating comments with symbols, then generating
   reStructuredText, and finally building the output documentation
   with Sphinx. Most users will not need to be aware of the use of
   reStructuredText as an intermediate format.
@@ -35,13 +35,14 @@ DESCRIPTION
 
   --save-sphinx <directory>  Save generated Sphinx project in directory.
 
-  --text-only       Generate text based documentation instead of HTML. Takes
+  --text-only       Generate text-based documentation instead of HTML. Takes
 		    precedence over --[no-]html
 
-  --[no-]html       [Don't] generate HTML based documentation (on by default)
+  --[no-]html       [Don't] generate HTML-based documentation (on by default)
 
-  --[no-]print-commands  Prints the system commands that the compiler
-                    executes in order to create the documentation.
+  --[no-]print-commands  Prints the system commands that chpldoc executes
+		    in order to create the documentation.
+
 
   Information Options
 
@@ -64,10 +65,10 @@ DESCRIPTION
 
   --license         Print chpldoc's license information.
 
-ENVIRONMENT VARIABLES FOR OPTIONS
+ENVIRONMENT
 
-  Some compiler command-line options have an environment variable that can
-  be used to specify a default value. Use the --help-env option to list the 
+  Some command-line options have an environment variable that can be used
+  to specify a default value. Use the --help-env option to list the
   environment variable equivalent for each option. Command-line options 
   will always override environment variable settings in the event of a 
   conflict.
@@ -89,22 +90,6 @@ ENVIRONMENT VARIABLES FOR OPTIONS
   For the other options that enable, disable or toggle some feature, any
   non-empty value of the environment variable equivalent has the same effect
   as passing that option once.
-
-
-ENVIRONMENT
-
-  See $CHPL_HOME/doc/chplenv.rst for detailed information about 
-  general environment variable settings, legal values, and default
-  settings. Run $CHPL_HOME/util/printchplenv to view your current
-  settings (as explicitly set and inferred). Some of the most
-  commonly-used environment variables are summarized here.
-
-  CHPL_HOME           Specifies the location of the Chapel installation directory.
-
-  CHPL_DEVELOPER      When set, build and compile in developer mode,
-                      which generates line numbers in internal module
-                      code and throws extra warning flags when
-                      compiling the generated C code.
 
 
 BUGS

--- a/man/chpldoc.txt
+++ b/man/chpldoc.txt
@@ -36,7 +36,7 @@ DESCRIPTION
   --save-sphinx <directory>  Save generated Sphinx project in directory.
 
   --text-only       Generate text based documentation instead of HTML. Takes
-		     precedence over --[no-]html
+		    precedence over --[no-]html
 
   --[no-]html       [Don't] generate HTML based documentation (on by default)
 
@@ -51,8 +51,8 @@ DESCRIPTION
 
   --help-env        Print the command line option help message, listing
                     the environment variable equivalent for each flag, if
-		     applicable (see ENVIRONMENT VARIABLES FOR OPTIONS), and
-		     its current value.
+		    applicable (see ENVIRONMENT VARIABLES FOR OPTIONS), and
+		    its current value.
 
   --help-settings   Print the command line option help message, listing
                     the current setting of each option as specified by


### PR DESCRIPTION
Brad noticed that a couple of the descriptions in the man page for
chpldoc were a little off.  Some were worded a little awkwardly
due to being lifted wholesale from the chpl binary man page, while
others mischaracterized the prevalence of certain settings (for
instance, very few of the flags available to chpldoc have
equivalent environment variable settings).  This commit cleans
those inconsistencies up.