### PR TITLE
Fix --llvm compiles after ifa has type asserts

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -2153,12 +2153,12 @@ VarSymbol* resizeImmediate(VarSymbol* s, PrimitiveType* t)
 {
   for( int i = 0; i < INT_SIZE_NUM; i++ ) {
     if( t == dtInt[i] ) {
-      return new_IntSymbol(s->immediate->int_value(), (IF1_int_type) i);
+      return new_IntSymbol(s->immediate->to_int(), (IF1_int_type) i);
     }
   }
   for( int i = 0; i < INT_SIZE_NUM; i++ ) {
     if( t == dtUInt[i] ) {
-      return new_UIntSymbol(s->immediate->uint_value(), (IF1_int_type) i);
+      return new_UIntSymbol(s->immediate->to_uint(), (IF1_int_type) i);
     }
   }
   return NULL;


### PR DESCRIPTION
PR #3088 introduced asserts to check that the read value from an
Immediate is the same as the value put in. These caused failures for
--llvm compiles because resizeImmediate, which is called only for --llvm
compiles, broke the invariant. Changed resizeImmediate to use to_int and
to_uint in order to convert the numbers appropriately.

Passed test/release/examples/ test/extern/ferguson/ test/extern/jjueckstock/ with --llvm.