### PR TITLE
Simple test of sparse arrays and, implicitly, return by ref-intent

### DIFF
--- a/test/arrays/sparse/sparse.chpl
+++ b/test/arrays/sparse/sparse.chpl
@@ -1,0 +1,21 @@
+/*
+  Jan 12, 2016: Michael Noakes
+
+  Cray's internal implementation of sparse arrays currently relies on
+  the use of the setter param in a procedure with return by ref-intent.
+
+  This simple test provides some confidence that this continues to
+  work correctly while
+     a) we stabilize strings
+     b) we refine the definition of return-by-ref and the setter param
+*/
+
+var D                        = { 1 .. 10 };
+var SD : sparse subdomain(D) = { 3 };
+
+var A  : [SD] string;
+
+A[3] = "hi";
+
+for i in D do
+  writeln(A[i]);

--- a/test/arrays/sparse/sparse.good
+++ b/test/arrays/sparse/sparse.good
@@ -1,0 +1,11 @@
+sparse.chpl:14: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+
+
+hi
+
+
+
+
+
+
+


### PR DESCRIPTION
Recent work to improve autoCopy/autoDestroy for arrays of strings failed to honor the setter param
for return by ref-intent but no test failed.  This simple test, contributed by Brad, provides a first
check for this.
