### PR TITLE
Remove cast from c_string to c_string

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1301,13 +1301,6 @@ module String {
   // Casts (casts to & from other primitive types are in StringCasts)
   //
 
-  // TODO: remove this and fix the folding out of string casts
-  // Yes this is invoked sometimes. In the long run, however,
-  // we'd like the compiler to eliminate casts to the same type instead.
-  inline proc _cast(type t, x: c_string) where t == c_string {
-    return x;
-  }
-
   inline proc _cast(type t, cs: c_string) where t == bufferType {
     return __primitive("cast", t, cs);
   }


### PR DESCRIPTION
It seems that PR #3089 removed the need for this cast.
Change suggested by @Kyle-B.

Passed full local testing.
Passed release/examples with GASNet.