### PR TITLE
Improve ugni Spawn halt to only fail with hugepages

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -92,7 +92,7 @@ back its input.
 
   As of Chapel v1.12, creating a subprocess that uses :const:`PIPE` to provide
   input or capture output does not work when using the ugni communications layer
-  with huge pages enabled and when using more than one locale. In this
+  with hugepages enabled and when using more than one locale. In this
   circumstance, the program will halt with an error message. These scenarios do
   work when using GASNet instead of the ugni layer.
 
@@ -438,7 +438,7 @@ module Spawn {
             env_str = env_c_str;
             if env_str.count("HUGETLB") > 0 then
               halt("spawn with more than 1 locale for CHPL_COMM=ugni ",
-                   "with huge pages currently ",
+                   "with hugepages currently ",
                    "requires stdin, stdout, stderr=FORWARD");
           }
         }

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -91,10 +91,10 @@ back its input.
 .. note::
 
   As of Chapel v1.12, creating a subprocess that uses :const:`PIPE` to provide
-  input or capture output does not work when using the ugni communications
-  layer and when using more than one locale. In this circumstance, the program
-  will halt with an error message. These scenarios do work when using GASNet
-  instead of the ugni layer.
+  input or capture output does not work when using the ugni communications layer
+  with huge pages enabled and when using more than one locale. In this
+  circumstance, the program will halt with an error message. These scenarios do
+  work when using GASNet instead of the ugni layer.
 
  */
 module Spawn {
@@ -431,9 +431,17 @@ module Spawn {
     // under those circumstances. See JIRA issue 113 for more details.
     if CHPL_COMM == "ugni" then
       if stdin != FORWARD || stdout != FORWARD || stderr != FORWARD then
-        if numLocales > 1 then
-          halt("spawn with more than 1 locale for CHPL_COMM=ugni currently ",
-               "requires stdin, stdout, stderr=FORWARD");
+        if numLocales > 1 {
+          var env_c_str:c_string;
+          var env_str:string;
+          if sys_getenv(c"PE_PRODUCT_LIST", env_c_str)==1 {
+            env_str = env_c_str;
+            if env_str.count("HUGETLB") > 0 then
+              halt("spawn with more than 1 locale for CHPL_COMM=ugni ",
+                   "with huge pages currently ",
+                   "requires stdin, stdout, stderr=FORWARD");
+          }
+        }
 
     if stdin == QIO_FD_PIPE then stdin_pipe = true;
     if stdout == QIO_FD_PIPE then stdout_pipe = true;


### PR DESCRIPTION
Greg's recent work enables CHPL_COMM=ugni to work without a hugepages module
loaded. In that configuration, Spawn seems to work correctly.

Therefore, this commit updates the halt in Spawn.chpl that checks for
CHPL_COMM=ugni to also check for a huge pages module being loaded. This check
is specific to a Cray, but so is CHPL_COMM=ugni.

Passed test/modules//standard/Spawn/.
Checked behavior with and without huge pages with CHPL_COMM=ugni using the test spawn-popen-input-output.chpl.

Reviewed by @gbtitus - thanks!