### PR TITLE
Add a cast from type to string

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4349,13 +4349,17 @@ static Expr* dropUnnecessaryCast(CallExpr* call) {
 
   if (SymExpr* sym = toSymExpr(call->get(2))) {
     if (LcnSymbol* var = toLcnSymbol(sym->var)) {
-      if (SymExpr* sym = toSymExpr(call->get(1))) {
-        Type* oldType = var->type->getValType();
-        Type* newType = sym->var->type->getValType();
+      // Casts of type variables are always required
+      // eg. foo.type:string
+      if (!var->hasFlag(FLAG_TYPE_VARIABLE)) {
+        if (SymExpr* sym = toSymExpr(call->get(1))) {
+          Type* oldType = var->type->getValType();
+          Type* newType = sym->var->type->getValType();
 
-        if (newType == oldType) {
-          result = new SymExpr(var);
-          call->replace(result);
+          if (newType == oldType) {
+            result = new SymExpr(var);
+            call->replace(result);
+          }
         }
       }
     } else if (EnumSymbol* e = toEnumSymbol(sym->var)) {

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -23,6 +23,13 @@ module StringCasts {
   // would use a tagged union return val as well.
 
   //
+  // Type -- Foo.type:string
+  //
+  proc _cast(type t, type x)  param : string where t == string {
+    return typeToString(x);
+  }
+
+  //
   // Bool
   //
   const _true_s: string = "true";

--- a/test/types/string/kbrady/type-cast.chpl
+++ b/test/types/string/kbrady/type-cast.chpl
@@ -1,0 +1,16 @@
+record R {
+  var q = 1;
+}
+
+var x = 10;
+var y = 1.0;
+var z = new R();
+var s = "a string";
+type t = int(32);
+
+writeln(x.type:string);
+writeln(y.type:string);
+writeln(z.type:string);
+writeln(s.type:string);
+writeln(t:string);
+writeln(uint(8):string);

--- a/test/types/string/kbrady/type-cast.good
+++ b/test/types/string/kbrady/type-cast.good
@@ -1,0 +1,6 @@
+int(64)
+real(64)
+R
+string
+int(32)
+uint(8)


### PR DESCRIPTION
This cast lets us write code like:

    writeln(foo.type:string);

instead of:

    writeln(typeToString(foo.type));