### PR TITLE
An optimization for certain functions that return with ref-intent

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -97,6 +97,7 @@ symbolFlag( FLAG_EXTERN , npr, "extern" , "extern variables, types, and function
 symbolFlag( FLAG_FAST_ON , npr, "fast on" , "with FLAG_ON/FLAG_ON_BLOCK, \"on block\" , use fast spawning option (if available)" )
 symbolFlag( FLAG_FIELD_ACCESSOR , npr, "field accessor" , "field setter/getter function, user-declared or compiler-generated" )
 symbolFlag( FLAG_FIRST_CLASS_FUNCTION_INVOCATION, npr, "first class function invocation" , "proxy for first-class function invocation" )
+symbolFlag( FLAG_FN_REF_USES_SETTER, npr, "fn ref uses setter", "A function that returns by ref AND relies on the setter param" )
 symbolFlag( FLAG_FORMAL_TEMP,     npr, "formal temp", "a formal temp to back an in, out, or inout argument" )
 symbolFlag( FLAG_FUNCTION_CLASS , npr, "function class" , "first-class function class representation" )
 symbolFlag( FLAG_FUNCTION_PROTOTYPE , npr, "function prototype" , "signature for function prototypes" )

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -17,51 +17,65 @@
  * limitations under the License.
  */
 
+#include "passes.h"
+
 #include "astutil.h"
 #include "expr.h"
-#include "passes.h"
 #include "resolution.h"
 #include "stmt.h"
 #include "symbol.h"
 
 static bool
-refNecessary(SymExpr* se,
-             Map<Symbol*,Vec<SymExpr*>*>& defMap,
-             Map<Symbol*,Vec<SymExpr*>*>& useMap) {
+refNecessary(SymExpr*                      se,
+             Map<Symbol*, Vec<SymExpr*>*>& defMap,
+             Map<Symbol*, Vec<SymExpr*>*>& useMap) {
   Vec<SymExpr*>* defs = defMap.get(se->var);
+
   if (defs && defs->n > 1)
     return true;
+
   for_uses(use, useMap, se->var) {
     if (CallExpr* call = toCallExpr(use->parentExpr)) {
       if (FnSymbol* fn = call->isResolved()) {
         ArgSymbol* formal = actual_to_formal(use);
+
         if (formal->defPoint->getFunction()->_this == formal)
           return true;
+
         if (formal->intent == INTENT_INOUT || formal->intent == INTENT_OUT)
           return true;
+
         if (formal->type->symbol->hasFlag(FLAG_REF) &&
             (fn->hasFlag(FLAG_ALLOW_REF) ||
              formal->hasFlag(FLAG_WRAP_WRITTEN_FORMAL)))
           return true;
+
       } else if (call->isPrimitive(PRIM_MOVE)) {
         if (refNecessary(toSymExpr(call->get(1)), defMap, useMap))
           return true;
+
       } else if (call->isPrimitive(PRIM_GET_MEMBER) ||
                  call->isPrimitive(PRIM_GET_SVEC_MEMBER)) {
         CallExpr* move = toCallExpr(call->parentExpr);
+
         INT_ASSERT(move);
         INT_ASSERT(move->isPrimitive(PRIM_MOVE));
+
         if (refNecessary(toSymExpr(move->get(1)), defMap, useMap))
           return true;
+
       } else if (call->isPrimitive(PRIM_SET_MEMBER)) {
         if (!call->get(2)->typeInfo()->refType)
+
           return true;
       } else if (call->isPrimitive(PRIM_RETURN) ||
                  call->isPrimitive(PRIM_YIELD)) {
         return true;
+
       } else if (call->isPrimitive(PRIM_WIDE_GET_LOCALE) ||
                  call->isPrimitive(PRIM_WIDE_GET_NODE)) {
-        // If we are extracting a field from the wide pointer, we need to keep it as a pointer.
+        // If we are extracting a field from the wide pointer,
+        // we need to keep it as a pointer.
         // Dereferencing would be premature.
         return true;
       } else if (call->isPrimitive(PRIM_DEREF) &&
@@ -69,12 +83,17 @@ refNecessary(SymExpr* se,
         // Heuristic: if we are dereferencing an array reference,
         // that reference may still be needed.
         Expr* callParent = call->parentExpr;
+
         INT_ASSERT(callParent);
+
         if (CallExpr* callParentCall = toCallExpr(callParent)) {
           if (callParentCall->isPrimitive(PRIM_MOVE)) {
             INT_ASSERT(call == callParentCall->get(2));
+
             SymExpr* dest = toSymExpr(callParentCall->get(1));
+
             INT_ASSERT(dest);
+
             if (dest->var->hasFlag(FLAG_COERCE_TEMP))
               return true;
           }
@@ -82,42 +101,84 @@ refNecessary(SymExpr* se,
       }
     }
   }
+
   return false;
 }
 
 
 //
-// removes references that are not necessary
+// Michael Noakes: 2016/01/07
+// Currently every function that is declared as return-by-ref
+// is implemented as a pair of functions.
 //
+//   1) A function that returns a ref
+//   2) A function that returns a value
+//
+// Additionally the "by-ref" version includes a pointer to the "by-value"
+// version.
+//
+// This is done independently of whether the setter param is used in the
+// the function body and without careful attention to whether the function
+// actually returns a value or a ref.
+//
+// The early phases of resolution have bound the call-site for every
+// return-by-ref function to the "by-ref" version of the function.
+//
+// This pass studies all of these call-sites and determines if the
+// "by-reference" version is "necessary".  If it is not, then the
+// compiler attempts to switch in the "by-value" version. This requires
+// the insertion of a temporary value near the call site.
+//
+// The compiler must also determine whether the "by value" implementation
+// will have inserted an autoCopy.   If so then the compiler attaches
+// the AUTO_COPY/AUTO_DESTROY flags as necessary to enable the
+// callDestructors pass to operate correctly.
+//
+// As far as I can tell this switch is, at best, only lossely coupled to
+// the the setter param.   Most functions that return with ref-intent do
+// not inspect the setter param but I think that some portions of the
+// compiler assume that setter = true for the by-ref version and
+// setter = false for the by-value version.  If this is correct then there
+// could be programs in which the function replacement does not track the
+// setter paramc orrectly.
+//
+// Careful separation of "by-ref" behavior and the management of the
+// setter param will require additional effort.
+//
+
 void cullOverReferences() {
-  //
-  // change call of reference function to value function
-  //
-  Map<Symbol*,Vec<SymExpr*>*> defMap;
-  Map<Symbol*,Vec<SymExpr*>*> useMap;
+  Map<Symbol*, Vec<SymExpr*>*> defMap;
+  Map<Symbol*, Vec<SymExpr*>*> useMap;
 
   buildDefUseMaps(defMap, useMap);
 
   forv_Vec(CallExpr, call, gCallExprs) {
+    // Is this call to a non-primitive function?
     if (FnSymbol* fn = call->isResolved()) {
-      if (FnSymbol* copy = fn->valueFunction) {
+      // Does that function have a "value" counter part?
+      if (FnSymbol* valueFn = fn->valueFunction) {
         if (CallExpr* move = toCallExpr(call->parentExpr)) {
           INT_ASSERT(move->isPrimitive(PRIM_MOVE));
+
           SymExpr* se = toSymExpr(move->get(1));
 
           INT_ASSERT(se);
-          SET_LINENO(move);
 
+          // Should we switch to the by-value form?
           if (!refNecessary(se, defMap, useMap)) {
+            SET_LINENO(move);
+
             SymExpr*   base = toSymExpr(call->baseExpr);
-            VarSymbol* tmp  = newTemp(copy->retType);
+            VarSymbol* tmp  = newTemp(valueFn->retType);
 
-            base->var = copy;
+            // Swap in the by-value implementation
+            base->var = valueFn;
 
+            // Generate a value temp to receive the value
             move->insertBefore(new DefExpr(tmp));
 
             if (requiresImplicitDestroy(call)) {
-              if (isString(copy->retType) == false) {
+              if (isString(valueFn->retType) == false) {
                 tmp->addFlag(FLAG_INSERT_AUTO_COPY);
                 tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
               } else {
@@ -135,8 +196,9 @@ void cullOverReferences() {
 
             se->var = tmp;
           }
-        } else
+        } else {
           INT_FATAL(call, "unexpected case");
+        }
       }
     }
   }
@@ -155,38 +217,48 @@ void cullOverReferences() {
           def->sym->type = vt;
         }
       }
+
       if (FnSymbol* fn = toFnSymbol(def->sym)) {
         if (Type* vt = fn->retType->getValType()) {
           if (isRecordWrappedType(vt)) {
             fn->retType = vt;
-            fn->retTag = RET_VALUE;
+            fn->retTag  = RET_VALUE;
           }
         }
       }
     }
   }
+
   forv_Vec(CallExpr, call, gCallExprs) {
     if (call->isPrimitive(PRIM_DEREF) ||
         call->isPrimitive(PRIM_ADDR_OF)) {
       Type* vt = call->get(1)->typeInfo();
+
       if (isReferenceType(vt))
         vt = vt->getValType();
+
       if (isRecordWrappedType(vt))
         call->replace(call->get(1)->remove());
     }
+
     if (call->isPrimitive(PRIM_GET_MEMBER)) {
       Type* vt = call->get(2)->getValType();
+
       if (isRecordWrappedType(vt))
         call->primitive = primitives[PRIM_GET_MEMBER_VALUE];
     }
+
     if (call->isPrimitive(PRIM_GET_SVEC_MEMBER)) {
       Type* tupleType = call->get(1)->getValType();
-      Type* vt = tupleType->getField("x1")->getValType();
+      Type* vt        = tupleType->getField("x1")->getValType();
+
       if (isRecordWrappedType(vt))
         call->primitive = primitives[PRIM_GET_SVEC_MEMBER_VALUE];
     }
+
     if (call->isPrimitive(PRIM_ARRAY_GET)) {
       Type* vt = call->getValType();
+
       if (isRecordWrappedType(vt))
         call->primitive = primitives[PRIM_ARRAY_GET_VALUE];
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -404,6 +404,7 @@ static void removeMootFields();
 static void expandInitFieldPrims();
 static void fixTypeNames(AggregateType* ct);
 static void setScalarPromotionType(AggregateType* ct);
+static bool functionUsesSetter(FnSymbol* fn);
 
 bool ResolutionCandidate::computeAlignment(CallInfo& info) {
   if (alignedActuals.n != 0) alignedActuals.clear();
@@ -6545,10 +6546,15 @@ replaceSetterArgWithTrue(BaseAST* ast, FnSymbol* fn) {
   if (SymExpr* se = toSymExpr(ast)) {
     if (se->var == fn->setter->sym) {
       se->var = gTrue;
+
+      // This variation relies on the setter param directly
+      fn->addFlag(FLAG_FN_REF_USES_SETTER);
+
       if (fn->isIterator())
         USR_WARN(fn, "setter argument is not supported in iterators");
     }
   }
+
   AST_CHILDREN_CALL(ast, replaceSetterArgWithTrue, fn);
 }
 
@@ -6873,6 +6879,7 @@ resolveFns(FnSymbol* fn) {
     stashPristineCopyOfLeaderIter(fn, /*ignore_isResolved:*/ true);
   }
 
+  // Does this function return by ref-intent?
   if (fn->retTag == RET_REF) {
     buildValueFunction(fn);
   }
@@ -6880,6 +6887,15 @@ resolveFns(FnSymbol* fn) {
   insertFormalTemps(fn);
 
   resolveBlockStmt(fn->body);
+
+  // Does this function return by ref-intent?
+  if (fn->retTag == RET_REF) {
+    // Determine if it might rely on the setter param recursively
+    if (fn->hasFlag(FLAG_FN_REF_USES_SETTER) == false &&
+        functionUsesSetter(fn)               == true) {
+      fn->addFlag(FLAG_FN_REF_USES_SETTER);
+    }
+  }
 
   if (tryFailure) {
     fn->removeFlag(FLAG_RESOLVED);
@@ -8882,4 +8898,26 @@ setScalarPromotionType(AggregateType* ct) {
     if (!strcmp(field->name, "_promotionType"))
       ct->scalarPromotionType = field->type;
   }
+}
+
+//
+// Does this function call a ref-return function that relies on the
+// setter param?  By induction this handles the general recursive case.
+//
+static bool functionUsesSetter(FnSymbol* fn) {
+  std::vector<CallExpr*> calls;
+  bool                   retval = false;
+
+  collectCallExprs(fn, calls);
+
+  for (size_t i = 0; i < calls.size() && retval == false; i++) {
+    CallExpr* call = calls[i];
+
+    if (FnSymbol* calledFn = call->isResolved()) {
+      if (calledFn->hasFlag(FLAG_FN_REF_USES_SETTER))
+        retval = true;
+    }
+  }
+
+  return retval;
 }

--- a/test/functions/byref/string-setter.chpl
+++ b/test/functions/byref/string-setter.chpl
@@ -1,0 +1,87 @@
+// Michael Noakes
+// 2016/01/13
+//
+// The new implementation of strings as records relies on the use of
+// "copy-constructors" and associated destructors to manage string-buffer
+// memory.  In some cases the use of these copy/destroy pairs results in
+// observable performance regressions.
+//
+// One response to this is to optimize the use of functions that return
+// strings with a ref-return intent.
+//
+// This test is designed to demonstrate that we do not introduce
+// correctness regressions while doing so.
+
+
+var getterString = "getter";
+var setterString = "setter";
+
+
+//
+// Verify behavior when there is no use of the setter param
+//
+proc refReturnString() ref
+{
+  return getterString;
+}
+
+writeln(refReturnString());
+writeln("");
+writeln("");
+
+
+
+//
+// A simple use of the setter param
+//
+
+proc refWithSetter() ref
+{
+  if setter then
+    return setterString;
+  else
+    return getterString;
+}
+
+writeln(refWithSetter());
+writeln(setterString);
+refWithSetter1() = "SetterNew";
+writeln(setterString);
+writeln("");
+writeln("");
+
+
+
+//
+// Ensure that setter is honored through a chain of by-ref calls
+//
+
+proc refWithSetter3() ref
+{
+  return refWithSetter2();
+}
+
+proc refWithSetter4() ref
+{
+  return refWithSetter3();
+}
+
+proc refWithSetter2() ref
+{
+  return refWithSetter1();
+}
+
+proc refWithSetter1()   ref
+{
+  if setter then
+    return setterString;
+  else
+    return getterString;
+}
+
+setterString = "setter";
+
+writeln(refWithSetter4());
+writeln(setterString);
+refWithSetter4() = "SetterNew";
+writeln(setterString);

--- a/test/functions/byref/string-setter.good
+++ b/test/functions/byref/string-setter.good
@@ -1,0 +1,11 @@
+getter
+
+
+getter
+setter
+SetterNew
+
+
+getter
+setter
+SetterNew


### PR DESCRIPTION
The compiler creates two implementations of functions that return with ref-intent.  One
implementation returns a reference to the value and the other returns the actual value.
If the procedure definition references the setter param, then it is assigned to true for
by-ref implementation and to false for the by-value implementation.

Traditionally the by-ref implementation is selected when the lvalue is required and the
by-value implementation is selected for non lvalues regardless of whether the setter
param has been used to specialize the implementations.

This PR allows calls that expect a string to rely on the by-ref implementation for the
common case in which the function has not been specialized on the setter param.  The
PR is partitioned in to a small number of commits to clarify the changes.


1) A simple test to help "bake in" the expected behavior for by-ref functions that return a
string.  This test includes a check for a chain of by-ref calls that ultimately relies on the
setter param.


2) A commit to introduce a flag that can be attached to the by-ref implementation to
indicate that it relies, directly or indirectly, on the setter param


3) A commit to function resolution to apply the flag when required


4) A non-functional commit to cullOverReferences to help to clarify the central
business logic for this pass


5) A commit to cullOverReferences that determines when it is valid to rely on
the by-ref implementation of a function that returns a string.


This PR passes the standard linux64 test suite while providing a performance
improvement when accessing arrays of strings.