### PR TITLE
Optimize anonymous 1-D domain iteration

### DIFF
--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -80,14 +80,22 @@ static void tryToReplaceWithDirectRangeIterator(Expr* iteratorExpr)
     CallExpr* range = NULL;
     Expr* stride = NULL;
     Expr* count = NULL;
+
+    // if we have a 1D domain constructor, just grab the inner range and see if
+    // that can be optimized away
+    if (call->isNamed("chpl__buildDomainExpr") and call->numActuals() == 1)
+    {
+      call = toCallExpr(call->get(1)->copy());
+    }
+
     // grab the stride if we have a strided range
-    if (call->isNamed("chpl_by"))
+    if (call && call->isNamed("chpl_by"))
     {
       range = toCallExpr(call->get(1)->copy());
       stride = toExpr(call->get(2)->copy());
     }
     // or grab the count if we have a counted range and set unit stride
-    else if (call->isNamed("#"))
+    else if (call && call->isNamed("#"))
     {
       range = toCallExpr(call->get(1)->copy());
       count = toExpr(call->get(2)->copy());


### PR DESCRIPTION
Optimize anonymous domain iteration much like we do anonymous range iteration.

#1021 added an optimization to remove range constructor for iteration of
anonymous ranges. This adds the optimization for anonymous domains as well. The
anonymous range part looks for code of the form:

    chpl_build_bounded_range(start, end, [stride])

This just updates that code to also look for

    chpl__buildDomainExpr(chpl_build_bounded_range(start, end, [stride]))

and applies the optimization to the inner range, discarding the domain
constructor.

Previously code like:

```chapel
  for i in {1..10} do writeln(i);
```

would generate:

```c
  ret_to_arg_ref_tmp__chpl = &call_tmp_chpl;
  chpl_build_bounded_range(INT64(1), INT64(10), ret_to_arg_ref_tmp__chpl);
  ret_to_arg_ref_tmp__chpl2 = &call_tmp_chpl2;
  chpl__buildDomainExpr(&call_tmp_chpl, ret_to_arg_ref_tmp__chpl2);
  ret_chpl = call_tmp_chpl2;
  ret_to_arg_ref_tmp__chpl3 = &default_argoffset_chpl;
  createTuple_chpl(INT64(0), ret_to_arg_ref_tmp__chpl3);
  this_chpl = ret_chpl;
  ret__chpl = &((this_chpl)->ranges);
  ret_x1_chpl = *(*(ret__chpl) + INT64(0));
  _ic__F0_this_chpl = ret_x1_chpl;
  ret_chpl2 = (&_ic__F0_this_chpl)->_low;
  ret_chpl3 = (&_ic__F0_this_chpl)->_high;
  end_chpl = ret_chpl3;
  for (i_chpl = ret_chpl2; ((i_chpl <= end_chpl)); i_chpl += INT64(1)) {
    writeln_chpl2(i_chpl);
  }
```

and now it will generate:

```c
  _ic__F1_high_chpl = INT64(10);
  for (i_chpl = INT64(1); ((i_chpl <= _ic__F1_high_chpl)); i_chpl += INT64(1)) {
    writeln_chpl2(i_chpl);
  }
```