### PR TITLE
Repair numPUs test, broken when running on multithreaded cores.

### DIFF
--- a/test/modules/standard/machine/numPUs.chpl
+++ b/test/modules/standard/machine/numPUs.chpl
@@ -1,1 +1,4 @@
-writeln("Number of cores on locale 0 = ", Locales(0).numPUs());
+config const logical = false;
+config const accessible = true;
+writeln("Number of PUs on locale 0 = ",
+	Locales(0).numPUs(logical=logical, accessible=accessible));

--- a/test/modules/standard/machine/numPUs.execopts
+++ b/test/modules/standard/machine/numPUs.execopts
@@ -1,0 +1,1 @@
+--logical=true --accessible=false

--- a/test/modules/standard/machine/numPUs.prediff
+++ b/test/modules/standard/machine/numPUs.prediff
@@ -6,7 +6,7 @@ numCores = multiprocessing.cpu_count()
 goodfile = sys.argv[1]+".good"
 
 f = open(goodfile, 'w')
-f.write("Number of cores on locale 0 = %d\n"%(numCores))
+f.write("Number of PUs on locale 0 = %d\n"%(numCores))
 f.close()
 
 sys.exit(0)


### PR DESCRIPTION
The numCores->numPUs change (#3061) made this print the number of
physical cores, but the .good files were still expecting the number of
hardware threads.  Change the test to print the latter, at least until
I can expand this test to cover all combinations of numPUs() args.