### PR TITLE
add to expiring value test, add cross language comparison

### DIFF
--- a/test/types/records/ferguson/expiring-value-alias.chpl
+++ b/test/types/records/ferguson/expiring-value-alias.chpl
@@ -4,6 +4,12 @@ class C {
   var x:int;
 }
 
+proc getNum(c:C)
+{
+  if c == nil then return -1;
+  else return c.x;
+}
+
 record R {
   var c:C;
 }
@@ -13,29 +19,125 @@ proc addOne(r:R) {
   r.c.x += 1;
 }
 
-proc makeR(x:int) {
+proc makeAlias(c:C)
+{
+  if debug then writeln("in makeAlias");
+  return new R(c = c);
+}
+
+proc returnsR(x:int) {
+  if debug then writeln("in returnsR");
   var ret: R;
   ret.c = new C(x);
   return ret;
 }
 
-proc identity(arg:R) {
+proc transformR(arg:R) {
+  if debug then writeln("in transformR");
+  arg.c.x += 1;
   return arg;
 }
 
-proc test1() {
-  writeln("test1");
-  var r1 = makeR(1);
-  var r2 = makeR(2);
-  r2 = r1;
-  addOne(r2);
-  writeln(r1);
-  writeln(r2);
+var globalR = returnsR(100);
+
+proc test0()
+{
+  writeln("test0");
+  if debug then writeln("R r = returnsR(100)");
+  {
+    // 2016-01 Chapel calls a copy, but neither C++11 nor D do
+    var r = returnsR(100);
+    writeln("r.x is ", r.c.x);
+  }
+  if debug then writeln("R r = transformR(returnsR(100))");
+  {
+    // 2016-01 Chapel makes 2 copies, D makes 1, C++11 makes 0
+    var r = transformR(returnsR(100));
+    writeln("r.x is ", r.c.x);
+  }
+  if debug then writeln("R r = transformR(transformR(returnsR(100)))");
+  {
+    // 2016-01 Chapel makes 3 copies, D makes 2, C++11 makes 0
+    var r = transformR(transformR(returnsR(100)));
+    writeln("r.x is ", r.c.x);
+  }
 }
 
-test1();
+proc pass(r:R) {
+  if debug then writeln("in pass");
+}
 
-var globalR = makeR(100);
+proc passpass(r:R) {
+  pass(r);
+}
+
+proc ret() {
+  var r:R;
+  r.c = new C(5);
+  return r;
+}
+
+proc retret() {
+  return ret();
+}
+
+proc passret(r:R)
+{
+  return r;
+}
+
+proc passpassretret(r:R)
+{
+  return passret(r);
+}
+
+
+proc test1() {
+  writeln("test1");
+  var r:R;
+  r.c = new C(3);
+
+  if debug then writeln("created r");
+  writeln(getNum(r.c));
+
+  if debug then writeln("calling pass");
+  // 2016-01 D and C++11 each make a copy here, Chapel makes 0
+  // (because of pass by ref, you could do that in C++/D too)
+  pass(r);
+
+  if debug then writeln("calling passpass");
+  // 2016-01 D and C++11 each make 2 copies here, Chapel makes 0
+  // (because of pass by ref, you could do that in C++/D too)
+  passpass(r);
+
+  if debug then writeln("calling ret()");
+  // 2016-01 Chapel calls a copy, but neither C++11 nor D do
+  var r2 = ret();
+
+  if debug then writeln("calling retret()");
+  // 2016-01 Chapel makes 2 copies, but D and C++11 make 0
+  var r3 = retret();
+
+  if debug then writeln("calling pass(ret)");
+  // 2016-01 Chapel makes 1 copies, but D and C++11 make 0
+  pass(ret());
+
+  if debug then writeln("calling passret");
+  // 2016-01 Chapel makes 1 copy, D makes 2, C++11 makes 1
+  var r4 = passret(r);
+
+  if debug then writeln("calling passpassretret");
+  // 2016-01 Chapel makes 2 copies, D makes 3, C++11 makes 2
+  var r5 = passpassretret(r);
+
+  writeln("r.x=", getNum(r.c));
+  writeln("r2.x=", getNum(r2.c));
+  writeln("r3.x=", getNum(r3.c));
+  writeln("r4.x=", getNum(r4.c));
+  writeln("r5.x=", getNum(r5.c));
+}
+
+
 proc getGlobalR() ref {
   return globalR;
 }
@@ -44,44 +146,188 @@ proc getAliasGlobalR() {
 }
 
 proc test2() {
+  globalR.c.x = 100;
   writeln("test2");
   var local_dom = getAliasGlobalR();
   var curr_dom = local_dom;
-  var next_dom = makeR(3);
+  var next_dom = returnsR(3);
   curr_dom = next_dom;
   writeln(globalR);
 }
 
-test2();
-
 
 proc test3() {
+  globalR.c.x = 100;
   writeln("test3");
   var local_dom:R;
   local_dom.c = globalR.c;
   var curr_dom = local_dom;
-  var next_dom = makeR(3);
+  var next_dom = returnsR(3);
   curr_dom = next_dom;
-  writeln(globalR);
+  writeln(globalR); // Chapel, C++11, D print 100
 }
-
-test3();
-
 proc test4() {
+  globalR.c.x = 100;
   writeln("test4");
   var local_dom:R;
   local_dom.c = globalR.c;
   var curr_dom = local_dom;
-  var next_dom = makeR(3);
+  var next_dom = returnsR(3);
   curr_dom.c.x = next_dom.c.x;
-  writeln(globalR);
+  writeln(globalR); // Chapel, C++11, D print 100
 }
 
+proc test5_part2(curr_dom: R)
+{
+  if debug then writeln("var next_dom = make");
+  var next_dom = returnsR(3);
+  if debug then writeln("curr_dom = next_dom");
+  curr_dom.c.x = next_dom.c.x;
+  writeln(globalR.c.x);
+}
+
+proc test5()
+{
+  globalR.c.x = 100;
+  writeln("test5");
+  var local_dom:R;
+  local_dom.c = globalR.c;
+  if debug then writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test5_part2(local_dom); // does argument passing create a copy?
+  // Because records pass by const ref (default intent),
+  // the answer is no (prints 3)
+  // It would be yes for D and C++11, since these are pass-by-value
+  // (prints 100) - but a better comparison is test5in
+}
+
+proc test5ref_part2(ref curr_dom: R)
+{
+  if debug then writeln("var next_dom = make");
+  var next_dom = returnsR(3);
+  if debug then writeln("curr_dom = next_dom");
+  curr_dom.c.x = next_dom.c.x;
+  writeln(globalR.c.x);
+}
+
+proc test5ref()
+{
+  globalR.c.x = 100;
+  writeln("test5ref");
+  var local_dom:R;
+  local_dom.c = globalR.c;
+  if debug then writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test5ref_part2(local_dom); // does argument passing create a copy?
+  // C++11 and Chapel both do not make a copy (prints 3)
+  // This pattern is not possible to write in D
+}
+
+proc test5in_part2(in curr_dom: R)
+{
+  if debug then writeln("var next_dom = make");
+  var next_dom = returnsR(3);
+  if debug then writeln("curr_dom = next_dom");
+  curr_dom.c.x = next_dom.c.x;
+  writeln(globalR.c.x);
+}
+
+proc test5in()
+{
+  globalR.c.x = 100;
+  writeln("test5in");
+  var local_dom:R;
+  local_dom.c = globalR.c;
+  if debug then writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test5in_part2(local_dom); // does argument passing create a copy?
+  // The answer for Chapel is yes with in intent (prints 100).
+  // It is also yes for D and C++11 with the default of pass-by-value.
+}
+
+
+proc test6_part2(curr_dom:R)
+{
+  if debug then writeln("var next_dom = make");
+  var next_dom = returnsR(3);
+  if debug then writeln("curr_dom = next_dom");
+  curr_dom.c.x = next_dom.c.x;
+  writeln(globalR.c.x);
+}
+
+proc test6()
+{
+  globalR.c.x = 100;
+  writeln("test6");
+  var local_dom:R;
+  local_dom.c = globalR.c;
+  if debug then writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test6_part2(makeAlias(globalR.c)); // does argument passing create a copy?
+  // 2016-01 - Chapel creates a copy here, but C++11 does not,
+  // although the default argument passing in Chapel corresponds
+  // to 'const ref' in C++.
+}
+
+proc test6ref_part2(const ref curr_dom:R)
+{
+  if debug then writeln("var next_dom = make");
+  var next_dom = returnsR(3);
+  if debug then writeln("curr_dom = next_dom");
+  curr_dom.c.x = next_dom.c.x;
+  writeln(globalR.c.x);
+}
+
+proc test6ref()
+{
+  globalR.c.x = 100;
+  writeln("test6ref");
+  var local_dom:R;
+  local_dom.c = globalR.c;
+  if debug then writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test6ref_part2(makeAlias(globalR.c)); // does argument passing create a copy?
+  // 2016-01 - Chapel creates a copy here, but C++11 does not
+  // (when both are using a const ref argument).
+}
+
+proc test6in_part2(in curr_dom:R)
+{
+  if debug then writeln("var next_dom = make");
+  var next_dom = returnsR(3);
+  if debug then writeln("curr_dom = next_dom");
+  curr_dom = next_dom;
+  writeln(globalR.c.x);
+}
+
+proc test6in()
+{
+  globalR.c.x = 100;
+  writeln("test6in");
+  var local_dom:R;
+  local_dom.c = globalR.c;
+  if debug then writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test6in_part2(makeAlias(globalR.c)); // does argument passing create a copy?
+  // 2016-01 - Chapel creates a copy here, but D and C++11 do not.
+  // The default argument passing for D and C++11 corresponds to in.
+}
+
+test0();
+test1();
+test2();
+test3();
 test4();
+test5();
+test5ref();
+test5in();
+test6();
+test6ref();
+test6in();
 
 
 proc R.~R() {
-  if debug then writeln("In record destructor");
+  if debug then writeln("  delete ", getNum(c));
 }
 
 // We'd like this to be by ref, but doing so leads to an internal
@@ -90,15 +336,16 @@ proc R.~R() {
 pragma "donor fn"
 pragma "auto copy fn"
 proc chpl__autoCopy(arg: R) {
+  if debug then writeln("  auto copy from ", getNum(arg.c));
+  // Note -- this auto copy could be the same as
+  // init copy and it wouldn't affect the test.
+
   // TODO - is no auto destroy necessary here?
   pragma "no auto destroy"
   var ret: R;
 
-  ret.c = arg.c;
-
-  if debug {
-    writeln("leaving auto copy");
-  }
+  //ret.c = arg.c;
+  ret.c = new C(arg.c.x);
 
   return ret;
 }
@@ -107,23 +354,19 @@ proc chpl__autoCopy(arg: R) {
 //    var outerX: R; begin { var x = outerX; }
 pragma "init copy fn"
 proc chpl__initCopy(arg: R) {
+  if debug then writeln("  init copy from ", getNum(arg.c));
+
   var ret: R;
 
   ret.c = new C(arg.c.x);
-
-  if debug {
-    writeln("leaving init copy");
-  }
 
   return ret;
 }
 
 proc =(ref lhs: R, rhs: R) {
-  lhs.c.x = rhs.c.x;
+  if debug then writeln("  assign lhs = rhs ", getNum(rhs.c));
 
-  if debug {
-    writeln("leaving assign");
-  }
+  lhs.c.x = rhs.c.x;
 }
 
 

--- a/test/types/records/ferguson/expiring-value-alias.cpp
+++ b/test/types/records/ferguson/expiring-value-alias.cpp
@@ -1,0 +1,276 @@
+// compile with e.g. g++ --std=c++11
+
+#include <stdio.h>
+
+struct C {
+  int x;
+  C(int x_) : x(x_) { }  
+};
+
+int getNum(C* c)
+{
+  if( c == NULL ) return -1;
+  else return c->x;
+}
+
+struct R {
+  C* c;
+  R() : c(NULL) { }
+  R(int x) {
+    this->c = new C(x);
+  }
+  R(const R& o) {
+    printf("  copy from %i\n", getNum(o.c));
+    this->c = new C(getNum(o.c));
+  }
+  R(R&& o) noexcept {
+    printf("  move from %i\n", getNum(o.c));
+    this->c = o.c;
+    o.c = NULL;
+  }
+  ~R() {
+    printf("  delete %i\n", getNum(this->c));
+    //delete c;
+  }
+  R& operator=(const R& arg)
+  {
+    printf("  assign lhs = rhs %i\n", getNum(arg.c));
+    this->c->x = arg.c->x;
+    return *this;
+  }
+};
+
+R makeAlias(C* c)
+{
+  printf("in makeAlias\n");
+  R ret;
+  ret.c = c;
+  return ret;
+}
+
+
+R returnsR(int x)
+{
+  printf("in returnsR\n");
+  R ret;
+  ret.c = new C(x);
+  return ret;
+}
+
+R transformR(R arg) {
+  printf("in transformR\n");
+  arg.c->x += 1;
+  return arg;
+}
+
+
+R globalR;
+
+void test0()
+{
+  printf("test0\n");
+  printf("R r = returnsR(100)\n");
+  {
+    R r = returnsR(100);
+    printf("r.x is %i\n", r.c->x);
+  }
+  printf("R r = transformR(returnsR(100))\n");
+  {
+    R r = transformR(returnsR(100));
+    printf("r.x is %i\n", r.c->x);
+  }
+  printf("R r = transformR(transformR(returnsR(100)))\n");
+  {
+    R r = transformR(transformR(returnsR(100)));
+    printf("r.x is %i\n", r.c->x);
+  }
+}
+
+void pass(R r)
+{
+  printf("in pass\n");
+}
+
+void passpass(R r)
+{
+  pass(r);
+}
+
+
+R ret()
+{
+  R r;
+  r.c = new C(5);
+  return r;
+}
+
+R retret()
+{
+  return ret();
+}
+
+R passret(R r)
+{
+  return r;
+}
+
+R passpassretret(R r)
+{
+  return passret(r);
+}
+
+void test1()
+{
+  printf("test1\n");
+  R r;
+  r.c = new C(3);
+
+  printf("created r\n");
+  printf("%i\n", getNum(r.c));
+
+  printf("calling pass\n");
+  pass(r);
+
+  printf("calling passpass\n");
+  passpass(r);
+
+  printf("calling ret\n");
+  R r2 = ret();
+
+  printf("calling retret\n");
+  R r3 = retret();
+
+  printf("calling pass(ret)\n");
+  pass(ret());
+
+  printf("calling passret\n");
+  R r4 = passret(r);
+
+  printf("calling passpassretret\n");
+  R r5 = passpassretret(r);
+
+  printf("r.x=%i\n", getNum(r.c));
+  printf("r2.x=%i\n", getNum(r2.c));
+  printf("r3.x=%i\n", getNum(r3.c));
+  printf("r4.x=%i\n", getNum(r4.c));
+  printf("r5.x=%i\n", getNum(r5.c));
+
+}
+
+
+void test4()
+{
+  globalR.c->x = 100;
+  printf("test4\n");
+  R local_dom;
+  local_dom.c = globalR.c;
+  printf("R curr_dom = local_dom\n");
+  // now local_dom "aliases" globalR
+  R curr_dom = local_dom;
+  printf("R next_dom = make\n");
+  R next_dom = returnsR(3);
+  //curr_dom.c->x = next_dom.c->x; // could be = overload
+  printf("curr_dom = next_dom\n");
+  curr_dom = next_dom;
+  printf("%i\n", globalR.c->x);
+}
+
+void test5_part2(R curr_dom)
+{
+  printf("R next_dom = make\n");
+  R next_dom = returnsR(3);
+  printf("curr_dom = next_dom\n");
+  curr_dom = next_dom;
+  printf("%i\n", globalR.c->x);
+}
+
+void test5()
+{
+  globalR.c->x = 100;
+  printf("test5\n");
+  R local_dom;
+  local_dom.c = globalR.c;
+  printf("R curr_dom = local_dom\n");
+  // now local_dom "aliases" globalR
+  test5_part2(local_dom); // does argument passing create a copy?
+}
+
+void test5ref_part2(const R& curr_dom)
+{
+  printf("R next_dom = make\n");
+  R next_dom = returnsR(3);
+  printf("curr_dom = next_dom\n");
+  curr_dom.c->x = next_dom.c->x;
+  printf("%i\n", globalR.c->x);
+}
+
+void test5ref()
+{
+  globalR.c->x = 100;
+  printf("test5ref\n");
+  R local_dom;
+  local_dom.c = globalR.c;
+  printf("R curr_dom = local_dom\n");
+  // now local_dom "aliases" globalR
+  test5ref_part2(local_dom); // does argument passing create a copy?
+}
+
+
+void test6_part2(R curr_dom)
+{
+  printf("R next_dom = make\n");
+  R next_dom = returnsR(3);
+  printf("curr_dom = next_dom\n");
+  curr_dom = next_dom;
+  printf("%i\n", globalR.c->x);
+}
+
+void test6()
+{
+  globalR.c->x = 100;
+  printf("test6\n");
+  R local_dom;
+  local_dom.c = globalR.c;
+  printf("R curr_dom = local_dom\n");
+  // now local_dom "aliases" globalR
+  test6_part2(makeAlias(globalR.c)); // does argument passing create a copy?
+}
+
+void test6ref_part2(const R& curr_dom)
+{
+  printf("R next_dom = make\n");
+  R next_dom = returnsR(3);
+  printf("curr_dom = next_dom\n");
+  curr_dom.c->x = next_dom.c->x;
+  printf("%i\n", globalR.c->x);
+}
+
+void test6ref()
+{
+  globalR.c->x = 100;
+  printf("test6ref\n");
+  R local_dom;
+  local_dom.c = globalR.c;
+  printf("R curr_dom = local_dom\n");
+  // now local_dom "aliases" globalR
+  test6ref_part2(makeAlias(globalR.c)); // does argument passing create a copy?
+}
+
+
+
+int main(int argc, char** argv)
+{
+  globalR.c = new C(100);
+
+  test0();
+  test1();
+  test4();
+  test5();
+  test5ref();
+  test6();
+  test6ref();
+
+  return 0;
+}
+
+

--- a/test/types/records/ferguson/expiring-value-alias.d
+++ b/test/types/records/ferguson/expiring-value-alias.d
@@ -1,0 +1,273 @@
+/* compile with ldc2 expiring.d */
+
+module test;
+
+import std.stdio;
+
+
+class C {
+  int x;
+  this(int x_) { x = x_; }
+};
+
+int getNum(const C c)
+{
+  if( c is null ) return -1;
+  else return c.x;
+}
+
+struct R {
+  C c;
+  this(int x) {
+    c = new C(x);
+  }
+  this(this) {
+    writeln("  copy from ", getNum(c));
+    int num = getNum(c);
+    c = new C(num);
+  }
+  ~this() {
+    writeln("  delete ", getNum(c));
+    //delete c;
+  }
+  ref R opAssign(ref const R arg)
+  {
+    writeln("  assign lhs = rhs ", getNum(arg.c));
+    c.x = arg.c.x;
+    return this;
+  }
+};
+
+R makeAlias(C c)
+{
+  writeln("in makeAlias");
+  R ret;
+  ret.c = c;
+  return ret;
+}
+
+R returnsR(int x)
+{
+  //writeln("in returnsR");
+  R ret;
+  ret.c = new C(x);
+  return ret;
+}
+
+R transformR(R arg) {
+  writeln("in transformR");
+  arg.c.x += 1;
+  return arg;
+}
+
+
+R globalR;
+
+void test0()
+{
+  writeln("test0");
+  writeln("R r = returnsR(100)");
+  {
+    R r = returnsR(100);
+    writeln("r.x is ", r.c.x);
+  }
+  writeln("R r = transformR(returnsR(100))");
+  {
+    R r = transformR(returnsR(100));
+    writeln("r.x is ", r.c.x);
+  }
+  writeln("R r = transformR(transformR(returnsR(100)))");
+  {
+    R r = transformR(transformR(returnsR(100)));
+    writeln("r.x is ", r.c.x);
+  }
+}
+
+void pass(R r)
+{
+  writeln("in pass");
+}
+
+void passpass(R r)
+{
+  pass(r);
+}
+
+
+R ret()
+{
+  R r;
+  r.c = new C(5);
+  return r;
+}
+
+R retret()
+{
+  return ret();
+}
+
+R passret(R r)
+{
+  return r;
+}
+
+R passpassretret(R r)
+{
+  return passret(r);
+}
+
+void test1()
+{
+  writeln("test1");
+
+  R r;
+  r.c = new C(3);
+
+  writeln("created r");
+  writeln(getNum(r.c));
+
+  writeln("calling pass");
+  pass(r);
+
+  writeln("calling passpass");
+  passpass(r);
+
+  writeln("calling ret");
+  R r2 = ret();
+
+  writeln("calling retret");
+  R r3 = retret();
+
+  writeln("calling pass(ret)");
+  pass(ret());
+
+  writeln("calling passret");
+  R r4 = passret(r);
+
+  writeln("calling passpassretret");
+  R r5 = passpassretret(r);
+
+  writeln("r.x=", getNum(r.c));
+  writeln("r2.x=", getNum(r2.c));
+  writeln("r3.x=", getNum(r3.c));
+  writeln("r4.x=", getNum(r4.c));
+  writeln("r5.x=", getNum(r5.c));
+}
+
+void test4()
+{
+  globalR.c.x = 100;
+  writeln("test4");
+  R local_dom;
+  local_dom.c = globalR.c;
+  writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  R curr_dom = local_dom;
+  writeln("R next_dom = make");
+  R next_dom = returnsR(3);
+  //curr_dom.c.x = next_dom.c.x; // could be = overload
+  writeln("curr_dom = next_dom");
+  curr_dom = next_dom;
+  writeln(globalR.c.x);
+}
+
+
+void test5_part2(R curr_dom)
+{
+  writeln("R next_dom = make");
+  R next_dom = returnsR(3);
+  writeln("curr_dom = next_dom");
+  curr_dom = next_dom;
+  writeln(globalR.c.x);
+}
+
+void test5()
+{
+  globalR.c.x = 100;
+  writeln("test5");
+  R local_dom;
+  local_dom.c = globalR.c;
+  writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test5_part2(local_dom); // does argument passing create a copy?
+}
+
+void test6_part2(R curr_dom)
+{
+  writeln("R next_dom = make");
+  R next_dom = returnsR(3);
+  writeln("curr_dom = next_dom");
+  curr_dom = next_dom;
+  writeln(globalR.c.x);
+}
+
+void test6()
+{
+  globalR.c.x = 100;
+  writeln("test6");
+  R local_dom;
+  local_dom.c = globalR.c;
+  writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test6_part2(makeAlias(globalR.c)); // does argument passing create a copy?
+}
+
+/* compilation error b/c can't pass fn return to ref arg 
+void test6ref_part2(ref R curr_dom)
+{
+  writeln("R next_dom = make");
+  R next_dom = returnsR(3);
+  writeln("curr_dom = next_dom");
+  curr_dom.c.x = next_dom.c.x;
+  writeln(globalR.c.x);
+}
+
+void test6ref()
+{
+  globalR.c.x = 100;
+  writeln("test6ref");
+  R local_dom;
+  local_dom.c = globalR.c;
+  writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test6ref_part2(makeAlias(globalR.c)); // does argument passing create a copy?
+}
+*/
+
+/* compilation error b/c immutable const
+void test6in_part2(in R curr_dom)
+{
+  writeln("R next_dom = make");
+  R next_dom = returnsR(3);
+  writeln("curr_dom = next_dom");
+  curr_dom.c.x = next_dom.c.x;
+  writeln(globalR.c.x);
+}
+
+void test6in()
+{
+  globalR.c.x = 100;
+  writeln("test6in");
+  R local_dom;
+  local_dom.c = globalR.c;
+  writeln("R curr_dom = local_dom");
+  // now local_dom "aliases" globalR
+  test6in_part2(makeAlias(globalR.c)); // does argument passing create a copy?
+}
+*/
+
+
+
+int main()
+{
+  globalR.c = new C(100);
+
+  test0();
+  test1();
+  test4();
+  test5();
+  test6();
+
+  return 0;
+}
+

--- a/test/types/records/ferguson/expiring-value-alias.good
+++ b/test/types/records/ferguson/expiring-value-alias.good
@@ -1,9 +1,29 @@
+test0
+r.x is 100
+r.x is 101
+r.x is 102
 test1
-(c = {x = 1})
-(c = {x = 2})
+3
+r.x=3
+r2.x=5
+r3.x=5
+r4.x=3
+r5.x=3
 test2
 (c = {x = 100})
 test3
 (c = {x = 100})
 test4
 (c = {x = 100})
+test5
+3
+test5ref
+3
+test5in
+100
+test6
+100
+test6ref
+100
+test6in
+100


### PR DESCRIPTION
Merged a few examples I have been using to compare record semantics in
C++11 and in D into one test.  Here I commit also the D and C++11
versions for future reference (although they will not be tested).

Both C++11 and D can remove a copy-construction call in a user-visible
way (the issue is more than just side effects in the copy constructor).
test6 shows this case.