### PR TITLE
Fix regression for plusEquals.chpl

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1147,7 +1147,7 @@ module String {
       // Care is required if lhs.buff == rhs.buff
       if lhs._size <= newLength {
         const newSize0 = (lhsLen * chpl_stringGrowthFactor) : int;
-	const newSize1 = max(newLength + 1, newSize0);
+        const newSize1 = max(newLength + 1, newSize0);
         const newSize2 = newSize1.safeCast(size_t);
         const newSize  = chpl_mem_goodAllocSize(newSize2);
 
@@ -1182,7 +1182,7 @@ module String {
       if lhs._size <= newLength {
         if lhs.owned && !rhsRemote && lhs.buff == rhs.buff {
           chpl_mem_free(lhs.buff);
-	}
+        }
 
         lhs.buff  = lhsBuff;
         lhs._size = lhsSize;

--- a/test/types/string/StringImpl/stress/plusEquals.suppressif
+++ b/test/types/string/StringImpl/stress/plusEquals.suppressif
@@ -1,3 +1,0 @@
-COMPOPTS <= --no-local
-CHPL_COMM!=none
-CHPL_LOCALE_MODEL == numa


### PR DESCRIPTION
The test  types/string/StringImpl/stress/plusEquals.chpl has been failing on a subset of
the gasnet configurations since we merged Kyle's record based implementation.  This turned
out to be due to a module error in string.+=.  The original implementation attempts to exploit
the potential benefit of using realloc vs malloc/memcpy but was doing so for the case of

myStr += myStr

i.e. self-assignment.  After the realloc rhs.buff was no longer valid.  In some ways the
most intriguing thing about this error was that it was so subtle.

I have chosen to retain the realloc but take more care in falling back on malloc/memcpy.

This PR has passed both linux64 and gasnet.
