### PR TITLE
Fix resolveDynamicDispatches for override_overload

### DIFF
--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -321,7 +321,7 @@ class TypeSymbol : public Symbol {
 
 class FnSymbol : public Symbol {
  public:
-  AList formals;
+  AList formals; // each formal is an ArgSymbol
   DefExpr* setter; // implicit setter argument to var functions
   Type* retType; // The return type of the function.  This field is not
                  // fully established until resolution, and could be NULL

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7645,8 +7645,32 @@ static void resolveDynamicDispatches() {
       if (Type* t = virtualMethodTable.v[i].key) {
         printf("  %s\n", toString(t));
         for (int j = 0; j < virtualMethodTable.v[i].value->n; j++) {
-          printf("    %s\n", toString(virtualMethodTable.v[i].value->v[j]));
+          FnSymbol* fn = virtualMethodTable.v[i].value->v[j];
+          printf("    %s", toString(fn));
+          if (developer) {
+            int index = virtualMethodMap.get(fn);
+            printf(" index %i", index);
+            if ( fn->getFormal(2)->typeInfo() == t ) {
+              // print dispatch children if the function is
+              // the method in type t (and not, say, the version in
+              // some parent class e.g. object).
+              Vec<FnSymbol*>* childFns = virtualChildrenMap.get(fn);
+              if (childFns) {
+                printf(" %i children:\n", childFns->n);
+                for (int k = 0; k < childFns->n; k++) {
+                  FnSymbol* childFn = childFns->v[k];
+                  printf("      %s\n", toString(childFn));
+                }
+              }
+              if( childFns == NULL || childFns->n == 0 ) printf("\n");
+            } else {
+              printf(" inherited\n");
+            }
+          }
+          printf("\n");
         }
+        if (developer)
+          printf("\n");
       }
     }
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7568,7 +7568,7 @@ static void resolveEnumTypes() {
 
 // removes entries in virtualChildrenMap that are not in virtualMethodTable.
 // such entries could not be called and should be dead-code eliminated.
-void filterVirtualChildren()
+static void filterVirtualChildren()
 {
   std::set<FnSymbol*> fns_in_vmt;
   typedef MapElem<Type*,Vec<FnSymbol*>*> VmtMapElem;


### PR DESCRIPTION
This PR is a bug fix. I was observing that virtualChildrenMap
sometimes contained functions that were not in the virtualMethodTable.
That meant that there was an inconsistency - some of these methods
would never be called and would be deleted (in some situations),
possibly causing the compiler to core dump.

This fixes a problem with

     test/users/ferguson/override_overload.chpl

which did not always cause the compiler to core dump, but in which the
virtualChildrenMap was always inconsistent (BaseWriter had
2 writeIt overrides for SubWriterTwo).

I fixed it in a straightforward but somewhat cumbersome manner because I
found it hard to understand and modify the existing virtual method table
generation code. My initial attempts at a simpler solution caused other
problems. I'll also note that this section of function resolution is
unnecessarily inefficient and that better data structures could almost
certainly give it much better performance.

This PR consists of 3 patches:
 * first, update comments based upon what I learned in investigating the problem
 * second, update --print-dispatch to print information from virtualChildrenMap
 * third, adjust resolveDynamicDispatches as described above.

Passed full local testing.
Reviewed by @vasslitvinov - thanks!