### PR TITLE
Add dead string literal elimination

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -3092,6 +3092,7 @@ VarSymbol *new_StringSymbol(const char *str) {
   s->addFlag(FLAG_NO_AUTO_DESTROY);
   s->addFlag(FLAG_CONST);
   s->addFlag(FLAG_LOCALE_PRIVATE);
+  s->addFlag(FLAG_CHAPEL_STRING_LITERAL);
 
   DefExpr* stringLitDef = new DefExpr(s);
   // DefExpr(s) always goes into the module scope to make it a global

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -55,11 +55,11 @@ symbolFlag( FLAG_BEGIN , npr, "begin" , ncm )
 symbolFlag( FLAG_BEGIN_BLOCK , npr, "begin block" , ncm )
 symbolFlag( FLAG_BUILD_TUPLE , ypr, "build tuple" , "used to mark the build_tuple functions")
 
+symbolFlag( FLAG_CHAPEL_STRING_LITERAL, npr, "chapel string literal id" , "mark Chapel strings created from literals")
 // When resolution encounters the def of the variable 'chpl__iter',
 // as indicated by this flag, it launches into enacting forall intents
 // for the forall loop that this variable was created for.
 symbolFlag( FLAG_CHPL__ITER , npr, "chpl__iter", "used as a marker to implement forall intents" )
-symbolFlag( FLAG_VECTORIZE_YIELDING_LOOPS, ypr, "vectorize yielding loops", "used to explicitly vectorize yielding loops in iterators" )
 symbolFlag( FLAG_COBEGIN_OR_COFORALL , npr, "cobegin or coforall" , ncm )
 symbolFlag( FLAG_COBEGIN_OR_COFORALL_BLOCK , npr, "cobegin or coforall block" , ncm )
 symbolFlag( FLAG_COERCE_TEMP , npr, "coerce temp" , "a temporary that was stores the result of a coercion" )
@@ -246,6 +246,7 @@ symbolFlag( FLAG_REF_TEMP , npr, "ref temp" , "compiler-inserted reference tempo
 symbolFlag( FLAG_TUPLE , ypr, "tuple" , ncm )
 symbolFlag( FLAG_TYPE_CONSTRUCTOR , npr, "type constructor" , ncm )
 symbolFlag( FLAG_TYPE_VARIABLE , npr, "type variable" , "contains a type instead of a value" )
+symbolFlag( FLAG_VECTORIZE_YIELDING_LOOPS, ypr, "vectorize yielding loops", "used to explicitly vectorize yielding loops in iterators" )
 symbolFlag( FLAG_VIRTUAL , npr, "virtual" , ncm )
 // Used to mark where a compiler generated flag was removed (but is desired
 // elsewhere).

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -281,6 +281,77 @@ void deadCodeElimination(FnSymbol* fn) {
   freeDefUseChains(DU, UD);
 }
 
+// Eliminate dead string literals. Any string literals that are introduced get
+// created by the `new_StringSymbol()` function. This includes strings used
+// internally by the compiler (such as "boundedNone" for BoundedRangeType) and
+// param string used for things like compiler error messages as well as strings
+// that may actually be used at runtime. `new_StringSymbol()` adds all strings
+// to the stringLiteralModule, but strings that are only used for compilation
+// or whose runtime path was param folded away are never removed because the
+// code paths that are removed don't include the string literal initialization.
+// This code removes dead string literals and all the support code that turns
+// them into Chapel level strings.
+//
+// Essentially we're looking for code of the form:
+//
+//     var _str_literal_id:string;                                         // string
+//
+//     var call_tmp:c_ptr(uint(8));                                        // call_tmp 
+//     call_tmp = (c_ptr_uint8_t)"string literal";                         // call_tmp_assign
+//     var ret_to_arg_ref_tmp: _ref(string);                               // ret_to_arg
+//     ret_to_arg_ref_tmp = &_str_literal_id                               // ret_to_arg_assign
+//     string(call_tmp, len, size, false, false, ret_to_arg_ref_tmp);      // stringCtor
+//
+//  where there is only one use of the global "str_literal_id" (the rhs of
+//  ret_to_arg_ref_tmp = &str_literal_id) and just removing all the code to
+//  init the Chapel string from the string literal.
+//
+// TODO See if this can be made into a more general dead record elimination.
+// (EJR 01/12/15)
+static void deadStringLiteralElimination() {
+
+  // build up global defUse maps
+  Map<Symbol*,Vec<SymExpr*>*> defMap;
+  Map<Symbol*,Vec<SymExpr*>*> useMap;
+  buildDefUseMaps(defMap, useMap);
+
+  // find all the symExprs in the string literal module
+  std::vector<SymExpr*> symExprs;
+  collectSymExprs(stringLiteralModule, symExprs);
+
+  for_vector(SymExpr, stringUse, symExprs) {
+    // if we're looking at a Chapel string created from a string literal
+    if (stringUse->var->hasFlag(FLAG_CHAPEL_STRING_LITERAL)) {
+      // and there's only a single use of it
+      Vec<SymExpr*>* stringUses = useMap.get(stringUse->var);
+      if (stringUses && stringUses->n == 1) {
+        // then that use is the RHS of `ret_to_arg_ref_tmp = &str_literal_id`,
+        // which is only used in the string constructor so the string is dead. 
+        assert(stringUses->v[0] == stringUse);
+
+        // gather the AST used to create a Chapel string from the literal,
+        // using variable names that mimic the current generated code
+        CallExpr*      ret_to_arg_assign = toCallExpr(stringUse->getStmtExpr());
+        SymExpr*       ret_to_arg        = toSymExpr(ret_to_arg_assign->get(1));
+        Vec<SymExpr*>* ret_to_arg_uses   = useMap.get(ret_to_arg->var);
+        CallExpr*      stringCtor        = toCallExpr(ret_to_arg_uses->v[0]->parentExpr);
+        SymExpr*       call_tmp          = toSymExpr(stringCtor->get(1));
+        Vec<SymExpr*>* call_tmp_defs     = defMap.get(call_tmp->var);
+        CallExpr*      call_tmp_assign   = toCallExpr(call_tmp_defs->v[0]->parentExpr);
+
+        // remove all the AST, in the order listed in the function comment
+        stringUse->var->defPoint->remove();
+        call_tmp->var->defPoint->remove();
+        call_tmp_assign->remove();
+        ret_to_arg->remove();
+        ret_to_arg_assign->remove();
+        stringCtor->remove();
+      }
+    }
+  }
+  freeDefUseMaps(defMap, useMap);
+}
+
 
 // Determines if a module is dead. A module is dead if the module's init
 // function can only be called from module code, and the init function
@@ -316,6 +387,7 @@ static bool isDeadModule(ModuleSymbol* mod) {
 
 // Eliminates all dead modules
 static void deadModuleElimination() {
+  deadModuleCount = 0;
   forv_Vec(ModuleSymbol, mod, allModules) {
     if (isDeadModule(mod) == true) {
       deadModuleCount++;
@@ -334,12 +406,12 @@ static void deadModuleElimination() {
   }
 }
 
-
 void deadCodeElimination() {
   if (!fNoDeadCodeElimination) {
     deadBlockElimination();
 
-    deadModuleCount = 0;
+    deadStringLiteralElimination();
+
 
     forv_Vec(FnSymbol, fn, gFnSymbols) {
 


### PR DESCRIPTION
When string-as-rec was committed (#2884) we saw a large increase in the
generated code size and thus compilation time. This is mostly because dead
string literals were being left in "ChapelStringLiterals". They were left there
because string literals are turned into Chapel records, and we don't currently
have any dead record elimination.

In order to resolve this, I initially tried to implement a general dead record
elimination. I ran into some issues with this so I opted to just do dead string
literal elimination for now. Dead string literal elimination is implemented as
follows:

String literals are all created with the `new_StringSymbol()` function. We now
mark the global variable that represents the Chapel string (the record) with a
flag. Then in dead code elimination we look for all these variables. If there
is only a single use of the string, we know that use is in the string
constructor, so we can safely DCE all the code used to construct the string
from the literal, as well as the literal itself. Note that we don't have to
worry about multiple Chapel strings using the same literal since we
hash/uniqify all string literals.

The implementation is a little fragile because it expects the AST to be in
certain order and if the AST for string literal initialization ever changes
it'll break pretty spectacularly. Unfortunately there's not great/easy way
around this for now, but that might change once our new constructor story comes
online.  Fair warning: this isn't code I'm terribly proud of, but it is
effective.

For jacobi, this takes us from 16,000 emitted statements down to 13,500 (was
12,000 before string-as-rec merge.)

Looking at just the number of emitted SLOC from `wc -l` (basically the number
we report, plus variable declarations) this takes us from 30,661 SLOC down to
25,500 (was 22,300 before string-as-rec merge.)

The remaining ~2,200 lines are coming from

| Module               | SLOC |
| -------------------- | ---- |
| ChapelDistribution   |  250 |
| ChapelStringLiterals |  300 |
| chpl__header         |   50 |
| Error                |  200 |
| IO                   |  700 |
| MemTracking          |  100 |
| String               |  900 |
| StringCasts          |  125 |
|                      |      |
| NewString (removed)  | -500 |

I'm not sure if there's too much we can do about them for now since most of the
code is for the new string implementation. At least a few hundred lines seems be
coming from dynamic dispatch branches being created instead of calls that index
into the chpl_vmtable. I still have to investigate that further as I'm not sure
what in the string-as-rec merge would have caused this.