### PR TITLE
Add annotations for Mike's optimization of functions with ref return intent

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -176,6 +176,8 @@ fasta:
     - enabled unlocked I/O on fasta and fasta-printf
   10/07/14:
     - Add c_string_copy type
+  01/14/16:
+    - optimize certain functions that return with ref-intent (#3101)
 
 forall-dom-range:
   01/21/15:
@@ -280,6 +282,8 @@ memleaks:
     - Fixed string leak in DimensionalDist2D (#3013)
   12/13/15:
     - Fixed string memory leak resulting from redundant autoCopies (#3023)
+  01/14/16:
+    - optimize certain functions that return with ref-intent (#3101)
 
 memleaksfull:
   07/08/14:
@@ -290,6 +294,8 @@ memleaksfull:
     - Fixed string leak in DimensionalDist2D (#3013)
   12/13/15:
     - Fixed string memory leak resulting from redundant autoCopies (#3023)
+  01/14/16:
+    - optimize certain functions that return with ref-intent (#3101)
 
 meteor:
   12/18/13:


### PR DESCRIPTION
#3101, which is an "optimization for certain functions that return with
ref-intent" caused a slight performance improvement for 2 versions of fasta. It
also closed a few memory leaks: 1079 => 1048 leaking tests and reduced the
total leaks by a few MB