### PR TITLE
Attempt to tighten up wording around 'this' methods

### DIFF
--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -888,10 +888,10 @@ to \chpl{4}.
 \index{this@\chpl{this}}
 \index{classes!this@\chpl{this}}
 
-A procedure method declared with the name \chpl{this} allows a class to be
-``indexed'' similarly to how an array is indexed.  Indexing into a
-class instance has the semantics of calling a method
-named \chpl{this}.  There is no other way to call a method
+Declaring a procedure method with the name \chpl{this} allows the
+class's objects to be ``called'' or ``indexed,'' similarly to how
+arrays are indexed.  Such expressions have the semantics of calling
+the method named \chpl{this}.  There is no other way to call a method
 called \chpl{this}.  The \chpl{this} method must be declared with
 parentheses even if the argument list is empty.
 

--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -513,7 +513,7 @@ method, if any, are visible outside the method.
 \index{records!indexing}
 
 As with classes, records can declare a \chpl{this} method.  Doing so
-permits record objects to be ``called''/''indexed.''
+permits record objects to be ``called''/``indexed.''
 
 \section{The {\em these} Method}
 \index{records!iterating}

--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -512,8 +512,8 @@ method, if any, are visible outside the method.
 \section{The {\em this} Method}
 \index{records!indexing}
 
-As with classes, records can be supplied with a \chpl{this} method.  This method
-defines the behavior of the indexing operator \chpl{[]}.
+As with classes, records can declare a \chpl{this} method.  Doing so
+permits record objects to be ``called''/''indexed.''
 
 \section{The {\em these} Method}
 \index{records!iterating}


### PR DESCRIPTION
This was motivated by a question from @nspark about whether using
'this' methods to "call" an object rather than indexing it was
considered an abuse.  I don't consider it to be so am trying to clarify
that in the spec.  Also did some wordsmithing while here.
