### PR TITLE
Work-around for StringImpl/stress/plusEquals.chpl

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1033,6 +1033,11 @@ makeHeapAllocations() {
       }
     }
 
+    if (isString(var) && var->isImmediate()) {
+      // String immediates are privatized; do not widen them
+      continue;
+    }
+
     SET_LINENO(var);
 
     if (ArgSymbol* arg = toArgSymbol(var)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1151,12 +1151,15 @@ isLegalLvalueActualArg(ArgSymbol* formal, Expr* actual) {
 // At present, params cannot be passed to 'const ref'.
 static bool
 isLegalConstRefActualArg(ArgSymbol* formal, Expr* actual) {
+  bool retval = true;
+
   if (SymExpr* se = toSymExpr(actual))
-    if (se->var->isParameter())
-      if (okToConvertFormalToRefType(formal->type))
-        return false;
-  // Perhaps more checks are needed.
-  return true;
+    if (se->var->isParameter()                   ==  true &&
+        okToConvertFormalToRefType(formal->type) ==  true &&
+        isString(se->var)                        == false)
+      retval = false;
+
+  return retval;
 }
 
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1131,7 +1131,7 @@ module String {
   //
   // Append
   //
-  proc +=(ref lhs: string, rhs: string) : void {
+  proc +=(ref lhs: string, const ref rhs: string) : void {
     // if rhs is empty, nothing to do
     if rhs.len == 0 then return;
 

--- a/test/types/string/StringImpl/stress/plusEquals.suppressif
+++ b/test/types/string/StringImpl/stress/plusEquals.suppressif
@@ -1,3 +1,0 @@
-COMPOPTS <= --no-local
-CHPL_COMM!=none
-CHPL_LOCALE_MODEL == numa


### PR DESCRIPTION
This multi-locale test has been failing on 4/6 gasnet tests but passed on the two remain
configurations and on all of the non-gasnet configurations.  Drilling down on the failure
cases revealed that this was an instance of the errors that will tend to occur if strings
are passed as if by value for functions that expect a ref.

In particular the string.+= procedure has the signature

proc +=(ref lhs: string, rhs: string) : void;

where rhs is then implicitly const ref.  When this function is called from an
on-statment, for example, the compiler inserts a temporary string value at
the call-site and then passes a reference to that value in to the operator.

A slightly subtle detail of the memory management that occurs within this
procedure can lead to a seg-fault when the compiler makes this mistake.


1) Altering the signature to be 

proc +=(ref lhs: string, const ref rhs: string) : void;

causes the compiler to correctly pass a reference for both formals and
allows this function to perform as intended.  This is the first commit.


2) Unfortunately this apparently simple change caused all programs to
stop compiling due to some I/O code that was calling += with a string
literal; the compiler has logic to prevent passing an immediate value
for a formal that is declared const ref.  The second commit makes a
minor change to function resolution to allow string literals as a const-ref
formal.

More work would be required to relax this constraint for immediate
primitive types.



3) This then surfaced a problem with reference widening.  String
literals are privatized and the initialization code for these privatized
literals was attempting to generate wide-references.  The third commit
contains a minor adjustment that excludes string-literals from this
step; this follows a precedent for some other edge cases.


4) Removed the suppression for gasnet.

This branch was created from an up to date master and has passed
the regression suite for linux64 and gasnet-everything.



The next step is to revise the compiler to treat blank intent for string
formals in the same manner as if the user had explicitly stated
"const ref" for all procedures.  Once that has been done I intend to
remove the work-around in String.chpl.
