### PR TITLE
Make llvm perf testing a real config and test assertNoSlicing in playground

### DIFF
--- a/util/cron/test-perf.chapcs.llvm.bash
+++ b/util/cron/test-perf.chapcs.llvm.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
+
+source $CWD/common-perf.bash
+source $CWD/common-llvm.bash
+
+# common-llvm restricts us to extern/fergeson, we want all the perf tests
+unset CHPL_NIGHTLY_TEST_DIRS
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.llvm"
+
+perf_args="-performance-description llvm -performance-configs default:v,llvm:v -sync-dir-suffix llvm"
+perf_args="${perf_args} -performance -numtrials 5 -startdate 11/24/15"
+
+$CWD/nightly -cron ${nightly_args} ${perf_args}

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -6,14 +6,11 @@ CWD=$(cd $(dirname $0) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 
 source $CWD/common-perf.bash
-source $CWD/common-llvm.bash
-
-# common-llvm restricts us to extern/fergeson, we want all the perf tests
-unset CHPL_NIGHTLY_TEST_DIRS
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-perf_args="-performance-description llvm -performance-configs default:v,llvm:v -sync-dir-suffix llvm"
-perf_args="${perf_args} -performance -numtrials 5 -startdate 11/24/15"
+perf_args="-performance-description noSlice -performance-configs default:v,noSlice:v -sync-dir-suffix noSlice"
+perf_args="${perf_args} -performance -numtrials 5 -startdate 01/19/16"
+perf_args="${perf_args} -compopts -sassertNoSlicing
 
 $CWD/nightly -cron ${nightly_args} ${perf_args}


### PR DESCRIPTION
Move llvm from being tested in the chapcs playground to being a real config,
and have the chapcs playground test the performance of `-sassertNoSlicing`