### PR TITLE
Work around module ordering issue in NUMA configs

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -567,7 +567,7 @@ module ChapelBase {
   }
 
   config param parallelInitElts=true;
-  proc init_elts(x, s, type t) {
+  proc init_elts(x, s, type t) : void {
     //
     // Q: why is the declaration of 'y' in the following loops?
     //

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3922,15 +3922,13 @@ inline proc channel.read(ref args ...?k,
     to a string and returns the result.
   */
 proc stringify(args ...?k):string {
-  var all_primitive = true;
-  
-  for param i in 1..k {
-    if !isPrimitiveType(args[i].type) then all_primitive = false;
-  }
+  param all_primitive = isTupleOfPrimitiveTypes(args);
 
   if all_primitive {
     // As an optimization, use string concatenation for
     // all primitive type stringify...
+    // This helps to work around some resolution errors
+    // when internal modules use halt, which calls stringify.
 
     var str = "";
 

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -307,6 +307,20 @@ pragma "no doc"
 proc isRefIter(type t)   param  return isRefIterType(t);
 pragma "no doc"
 proc isPOD(type t)       param  return isPODType(t);
+pragma "no doc"
+proc isTupleOfPrimitiveTypes(e) param
+{
+  if !isTuple(e) then return false;
+
+  // compute && reduce isPrimitiveValue over the tuple
+  proc help(x) param
+    return isPrimitiveValue(x);
+
+  proc help(x, args ...) param
+    return isPrimitiveValue(x) && help((...args));
+
+  return help((...e));
+}
 
 // Set 2 - values.
 /*

--- a/test/modules/standard/Types/tup-primitive.chpl
+++ b/test/modules/standard/Types/tup-primitive.chpl
@@ -1,0 +1,29 @@
+proc test(param expect, args ...)
+{
+  param isPrim = isTupleOfPrimitiveTypes(args);
+  writeln("expect ", expect, " for ", args.type:string, " isPrim=", isPrim);
+}
+
+test(true, 1); // true
+test(true, 1.0); // true
+test(true, "a"); // true
+
+test(true, 1, 1); // true
+test(true, 1.0, 1.0); // true
+test(true, "a", "a"); // true
+test(true, "a", 1); // true
+
+
+record R {
+  var x:int;
+}
+class C {
+  var x:int;
+}
+
+
+test(false, new R(10)); // false
+test(false, new C(10)); // false
+
+test(false, new R(10), 1); // false
+test(false, 1, new R(10), 1); // false

--- a/test/modules/standard/Types/tup-primitive.good
+++ b/test/modules/standard/Types/tup-primitive.good
@@ -1,0 +1,11 @@
+expect true for 1*int(64) isPrim=true
+expect true for 1*real(64) isPrim=true
+expect true for 1*string isPrim=true
+expect true for 2*int(64) isPrim=true
+expect true for 2*real(64) isPrim=true
+expect true for 2*string isPrim=true
+expect true for (string,int(64)) isPrim=true
+expect false for 1*R isPrim=false
+expect false for 1*C isPrim=false
+expect false for (R,int(64)) isPrim=false
+expect false for (int(64),R,int(64)) isPrim=false


### PR DESCRIPTION
PR #2237 seems to have triggered a recursion in function resolution. The
error occurs in numa configurations and hello3-datapar fails (among many
other tests).

The problem is that:
 * iterator might use a range
 * range might call halt
 * halt might call stringify
 * stringify might call c_calloc
 * c_calloc calls init_elts
 * init_elts might call the same iterator

I resolved the problem by making a param function,
isTupleOfPrimitiveTypes. The stringify function already included a branch
to work with primitive types only that did not call c_calloc. I made the
choice of which branch to take be a param value.

In order to get isTupleOfPrimitiveType to return a param, I needed to &&
reduce isPrimitive over a tuple. The only way I could think of to do that
was with recursive functions. An alternative would be to support
isTupleOfPrimitiveTypes with a primitive in the compiler.

Another alternative to this fix is to make c_calloc not call init_elts in
some cases (such as when the array is of primitive type).

This PR also declares the return type of init_elts as void, although that
is not strictly necessary for this fix I think it is a documentation
improvement.

Passed full local quickstart testing.
Passed full local quickstart+numa testing.
Passed hellos with qthreads+numa.
Not reviewed.