### PR TITLE
Make all non-'flat' locale models outline on-clauses

### DIFF
--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -74,13 +74,13 @@ bool requireWideReferences() {
 }
 
 //
-// If the --no-local flag is used or the locale model is not 'flat'
-// (i.e., has sub-locales that on-clauses might target), we should
-// not drop on-clauses on the floor.  I.e., we should require them
-// to be "outlined."
+// If the --no-local flag is used, or the locale model is not 'flat'
+// (i.e., has sub-locales that an on-clause might target), we should
+// require on-clauses to be "outlined" (i.e., we should not assume the
+// on-clause is a no-op and execute the associated statement locally.
 //
 bool requireOutlinedOn() {
-  return !fLocal || strcmp(CHPL_LOCALE_MODEL, "flat");
+  return !fLocal || strcmp(CHPL_LOCALE_MODEL, "flat") != 0;
 }
 
 const char* cleanFilename(const char* name) {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -73,8 +73,14 @@ bool requireWideReferences() {
   return !fLocal || forceWidePtrs();
 }
 
+//
+// If the --no-local flag is used or the locale model is not 'flat'
+// (i.e., has sub-locales that on-clauses might target), we should
+// not drop on-clauses on the floor.  I.e., we should require them
+// to be "outlined."
+//
 bool requireOutlinedOn() {
-  return !fLocal || forceWidePtrs();
+  return !fLocal || strcmp(CHPL_LOCALE_MODEL, "flat");
 }
 
 const char* cleanFilename(const char* name) {


### PR DESCRIPTION
[discussed with @ronawho and @gbtitus, reviewed by @gbtitus ]

When compiling --local, if a locale model is not 'flat', chances are it should not drop on-clauses on the floor.  Previously, we were checking that the locale model was 'numa' when making this call (our only non-'flat' locale model currently).  Here, I changed it to check that it was not 'flat' instead.  In doing so, I also decoupled this decision from the one about whether or not wide pointers should be used as the two decisions seem arguably independent (even though most locale models will probably answer the questions in a way that keeps them linked).

Longer-term, we talked about turning these into param fields/methods on locale models themselves, but that's a pretty big refactoring of how the compiler works.  Specifically, these on-clauses are dropped on the floor very early now, but we don't resolve params until later.

This was undertaken in support of external developers who are investigating their own locale model and found the current default surprising.

Tested this by looking at generated code for [--local | --no-local] x [flat | numa] to see that the on_fn was in the generated code as expected, or not.  Also ran full linux64 testing and examples on numa and --no-local.