### PR TITLE
Convert --no-warnings into --[no-]warnings

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -731,7 +731,7 @@ static ArgumentDescription arg_desc[] = {
  {"warn-special", ' ', NULL, "Enable [disable] special warnings", "n", &fNoWarnSpecial, "CHPL_WARN_SPECIAL", setWarnSpecial},
  {"warn-domain-literal", ' ', NULL, "Enable [disable] old domain literal syntax warnings", "n", &fNoWarnDomainLiteral, "CHPL_WARN_DOMAIN_LITERAL", setWarnDomainLiteral},
  {"warn-tuple-iteration", ' ', NULL, "Enable [disable] warnings for tuple iteration", "n", &fNoWarnTupleIteration, "CHPL_WARN_TUPLE_ITERATION", setWarnTupleIteration},
- {"warnings", ' ', NULL, "Disable output of warnings", "n", &ignore_warnings, "CHPL_DISABLE_WARNINGS", NULL},
+ {"warnings", ' ', NULL, "Enable [disable] output of warnings", "n", &ignore_warnings, "CHPL_DISABLE_WARNINGS", NULL},
 
  {"", ' ', NULL, "Compiler Information Options", NULL, NULL, NULL, NULL},
  DRIVER_ARG_COPYRIGHT,

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -731,7 +731,7 @@ static ArgumentDescription arg_desc[] = {
  {"warn-special", ' ', NULL, "Enable [disable] special warnings", "n", &fNoWarnSpecial, "CHPL_WARN_SPECIAL", setWarnSpecial},
  {"warn-domain-literal", ' ', NULL, "Enable [disable] old domain literal syntax warnings", "n", &fNoWarnDomainLiteral, "CHPL_WARN_DOMAIN_LITERAL", setWarnDomainLiteral},
  {"warn-tuple-iteration", ' ', NULL, "Enable [disable] warnings for tuple iteration", "n", &fNoWarnTupleIteration, "CHPL_WARN_TUPLE_ITERATION", setWarnTupleIteration},
- {"no-warnings", ' ', NULL, "Disable output of warnings", "F", &ignore_warnings, "CHPL_DISABLE_WARNINGS", NULL},
+ {"warnings", ' ', NULL, "Disable output of warnings", "n", &ignore_warnings, "CHPL_DISABLE_WARNINGS", NULL},
 
  {"", ' ', NULL, "Compiler Information Options", NULL, NULL, NULL, NULL},
  DRIVER_ARG_COPYRIGHT,

--- a/man/chpl.txt
+++ b/man/chpl.txt
@@ -408,7 +408,8 @@ OPTIONS
                      zippering syntax. All uses of tuple iteration
                      will produce warnings.
 
-  --no-warnings      Turns off compiler warnings.
+  --[no-]warnings    Enable [disable] the printing of compiler warnings.
+                     Defaults to printing warnings.
 
   Compiler Information Options
 

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -143,7 +143,7 @@ Miscellaneous Options:
                                       syntax warnings
       --[no-]warn-tuple-iteration     Enable [disable] warnings for tuple
                                       iteration
-      --no-warnings                   Disable output of warnings
+      --[no-]warnings                 Disable output of warnings
 
 Compiler Information Options:
       --copyright                     Show copyright

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -143,7 +143,7 @@ Miscellaneous Options:
                                       syntax warnings
       --[no-]warn-tuple-iteration     Enable [disable] warnings for tuple
                                       iteration
-      --[no-]warnings                 Disable output of warnings
+      --[no-]warnings                 Enable [disable] output of warnings
 
 Compiler Information Options:
       --copyright                     Show copyright

--- a/test/compflags/bradc/warnings-no.good
+++ b/test/compflags/bradc/warnings-no.good
@@ -1,0 +1,1 @@
+Hello there!

--- a/test/compflags/bradc/warnings.chpl
+++ b/test/compflags/bradc/warnings.chpl
@@ -1,0 +1,2 @@
+compilerWarning("Will Robinson!");
+writeln("Hello there!");

--- a/test/compflags/bradc/warnings.compopts
+++ b/test/compflags/bradc/warnings.compopts
@@ -1,0 +1,5 @@
+                         # warnings.good
+--no-warnings            # warnings-no.good
+--no-warnings --warnings # warnings.good
+--warnings               # warnings.good
+--warnings --no-warnings # warnings-no.good

--- a/test/compflags/bradc/warnings.good
+++ b/test/compflags/bradc/warnings.good
@@ -1,0 +1,2 @@
+warnings.chpl:1: warning: Will Robinson!
+Hello there!


### PR DESCRIPTION
This mod converts the --no-warnings flag into a --[no-]warnings flag such that if you're appending flags to an existing command line that contains --no-warnings, you can override it.  This would be useful, for example, to run the test system with --warnings to see which tests that are throwing --no-warnings are doing so needlessly (if the test system appended rather than prepending compopts... d'oh!)

I'm not sure why we've never done this in the past.  It may be that, as a result of it being a meta-flag, we were concerned that undoing all the changes that it made.  But given the way it's implemented, it's actually quite simple.