### PR TITLE
Fixing a bug in non-periodic uses of StencilDist

### DIFF
--- a/test/release/examples/benchmarks/miniMD/helpers/StencilDist.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/StencilDist.chpl
@@ -1288,7 +1288,7 @@ proc StencilArr.dsiUpdateFluff() {
         if !zeroTuple(L) {
           if !dom.dist.targetLocDom.member(i+L) && dom.periodic then
             locArr[i].myElems[D] = locArr[N].myElems[S];
-          else 
+          else if dom.dist.targetLocDom.member(N) then
             locArr[i].myElems[D] = locArr[N].myElems[D];
         }
       }


### PR DESCRIPTION
In MiniMD, we use Ben's Stencil distribution in periodic mode -- if
a locale on the edge indexes towards the edge, it wraps around to the
other side.  In trying to write a non-periodic use of Stencil today,
I ran into a problem where the locale at coordinate (0,0) in the
virtual locale grid (say) tries to access data stored by locales
(-1,-1), (-1,0), and (0,-1).  But of course, these locales don't
exist, so we get out of bounds errors.

The fix was simple: Check to make sure that the locale index isn't
out of bounds and skip the copy if it is (in this case, the data
must already be local to your locale so no copy is required -- i.e.,
a no-op is appropriate).

Normally in reviewing a commit like this, I'd say "where's the test?"
but I'm working on a bigger PR that introduces tests of it, so will
save the test for that merge.