### PR TITLE
Fix the parent locale's maxTaskPar for numa

### DIFF
--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -237,13 +237,12 @@ module LocaleModel {
       numSublocales = chpl_task_getNumSublocales();
 
       extern proc chpl_task_getMaxPar(): uint(32);
-      maxTaskPar = if numSublocales==0 then chpl_task_getMaxPar()
-                                       else numSublocales;
+      maxTaskPar = chpl_task_getMaxPar();
 
       if numSublocales >= 1 {
         childSpace = {0..#numSublocales};
         // These nPUs* values are estimates only; better values await
-        // full hwloc support.
+        // full hwloc support. In particular it assumes a homogeneous node
         const nPUsPhysAccPerSubloc = nPUsPhysAcc/numSublocales;
         const nPUsPhysAllPerSubloc = nPUsPhysAll/numSublocales;
         const nPUsLogAccPerSubloc = nPUsLogAcc/numSublocales;

--- a/test/localeModels/gbt/maxTaskPar.prediff
+++ b/test/localeModels/gbt/maxTaskPar.prediff
@@ -47,7 +47,7 @@ case $target in
         if [[ -n $hwld && -d $hwld/bin ]] ; then
           numNuma=$( $hwld/bin/lstopo --only numa | wc -l )
           numCores=$( $hwld/bin/lstopo --only cores | wc -l )
-          echo $numNuma > $1.good
+          echo $numCores > $1.good
           for (( i=0 ; $i < $numNuma ; i++ )) ; do
             echo $(( $numCores / $numNuma )) >> $1.good
           done


### PR DESCRIPTION
Previously here.maxTaskPer for numa was initialized with code like:

```chapel
maxTaskPar = if numSublocales==0 then chpl_task_getMaxPar() else numSublocales;
```

The code that does `maxTaskPar = numSublocales` was originally added with
51e2154b. I'm not quite sure why it was ever made this way, but I think the
parents maxTaskPar should be the maxTaskPar for the entire node, not the number
of sublocales.

This was causing performance issues because DefaultRectangular and ChapelRange
basically divide the parents maxTaskPar by the number of numa domains to figure
out how many tasks to create per numa domain. This resulted in something like
stream-ep on a chapcs box only using 2 cores instead of 24, which obviously
kills performance. I think a better fix for this issue involves having each
sublocale query it's maxTaskPar instead of just taking the parents/numaDomains,
but this allows us to make progress fairly quickly.

On chapcs we were getting ~15 GB/s for stream-ep and with this we get
~65-72GB/s (flat gets ~84 GB/s.) Part of this remaining performance gap will be
resolved when "local" on statements are added for numa (an extension of #3136)
and the remaining performance loss is because of the sherwood scheduler being
too aggressive with work stealing (sherwood performance issues are detailed in
#144)