### PR TITLE
add .good files for comm-none.lm-numa

### DIFF
--- a/test/distributions/robust/arithmetic/optimizations/optimizeOnClauses_basic.comm-none.lm-numa.good
+++ b/test/distributions/robust/arithmetic/optimizations/optimizeOnClauses_basic.comm-none.lm-numa.good
@@ -1,0 +1,6 @@
+Optimized on clause (wrapon_fn) in module optimizeOnClauses_basic (optimizeOnClauses_basic.chpl:3)
+100
+20
+5
+3
+8

--- a/test/distributions/robust/arithmetic/optimizations/optimizeOnClauses_basic_record.comm-none.lm-numa.good
+++ b/test/distributions/robust/arithmetic/optimizations/optimizeOnClauses_basic_record.comm-none.lm-numa.good
@@ -1,0 +1,6 @@
+Optimized on clause (wrapon_fn) in module optimizeOnClauses_basic_record (optimizeOnClauses_basic_record.chpl:13)
+(r = 100)
+(r = 20)
+(r = 5)
+(r = 3)
+(r = 8)

--- a/test/distributions/robust/arithmetic/optimizations/optimizeOnClauses_basic_tuple.comm-none.lm-numa.good
+++ b/test/distributions/robust/arithmetic/optimizations/optimizeOnClauses_basic_tuple.comm-none.lm-numa.good
@@ -1,0 +1,6 @@
+Optimized on clause (wrapon_fn) in module optimizeOnClauses_basic_tuple (optimizeOnClauses_basic_tuple.chpl:9)
+(100, 100)
+(20, 20)
+(5, 5)
+(3, 3)
+(8, 8)


### PR DESCRIPTION
Now that local blocks are working for comm-none.lm-numa, these on-statements will be optimized and the .good files need to be updated.