### PR TITLE
Fix playgrounds checkout path

### DIFF
--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -17,7 +17,7 @@ SHORT_NAME=ref-rvalue
 START_DATE=12/22/15
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
-git checkout -b $GITHUB_USER-$GITHUB_BRANCH master
+git checkout -b $GITHUB_USER-$GITHUB_BRANCH
 git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"

--- a/util/cron/test-perf.chapcs.numa-playground.bash
+++ b/util/cron/test-perf.chapcs.numa-playground.bash
@@ -24,7 +24,7 @@ SHORT_NAME=numa-no-steal
 START_DATE=01/20/16
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
-git checkout -b $GITHUB_USER-$GITHUB_BRANCH master
+git checkout -b $GITHUB_USER-$GITHUB_BRANCH
 git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,numa:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"


### PR DESCRIPTION
chap04.playground and chapcs.numa-playground check out from personal github
repos. They were trying to create a new branch based off of master, but jenkins
checks out a specific SHA, not master. For the new chapcs playground the master
branch doesn't exist, which caused issues. For some reason it happened to exist
for the chap04 playground, but this was probably just a leftover branch from
previous things.

Jenkins will always check out the right SHA so we don't have to worry about
what branch we're coming from, so just delete the "from" branch in the checkout
line.