### PR TITLE
Optimize iteration over anonymous low-bounded counted ranges

### DIFF
--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -39,21 +39,22 @@
  * time, provide a more optimized iterator that uses "<, <=, >, or >=" as the
  * relational operator.
  *
- * This is only meant to replace anonymous range iteration for "simple" bounded
- * ranges. Simple means it's a range of the form "low..high" or "low..high by
- * stride". Anything more complex is ignored with the thinking that this should
- * optimize the most common range iterators, but it could be expanded to handle
- * more cases.
+ * This is only meant to replace anonymous range iteration for "simple" ranges.
+ * Simple means it's a range of the form "low..high", "low..high by stride", or
+ * "low..#count". Anything more complex is ignored with the thinking that this
+ * should optimize the most common range iterators, but it could be expanded to
+ * handle more cases.
  *
  * An alternative is to update scalar replacement of aggregates to work on
  * ranges, which should be able to achieve similar results as this optimization
  * while handling all ranges, including non-anonymous ranges.
  *
- * Will optimize things like:
+ * This function will optimize things like:
  * - "for i in 1..10"
  * - "for i in 1..10+1"
  * - "var lo=1, hi=10;for i in lo..hi"
  * - "for i in 1..10 by 2"
+ * - "for i in 1..#10"
  * - "for (i, j) in zip(1..10 by 2, 1..10 by -2)"
  * - "for (i, j) in zip(A, 1..10 by 2)" // will optimize range iter still
  * - "coforall i in 1..10 by 2"         // works for coforalls as well
@@ -62,9 +63,10 @@
  * - "for in in (1..)"             // doesn't handle unbounded ranges
  * - "for i in 1..10 by 2 by 2"    // doesn't handle more than one by operator
  * - "for i in 1..10 align 2"      // doesn't handle align operator
- * - "for i in 1..#10"             // doesn't handle # operator
+ * - "for i in (1..10)#2"          // doesn't handle bounded counted ranges
+ * - "for i in 1..#10 by 2"        // doesn't handle strided and counted ranges
  * - "var r = 1..10"; for i in r"  // not an anonymous range
- * - "forall i in 1..10"           // does not get applied to foralls
+ * - "forall i in 1..10"           // doesn't get applied to foralls
  *
  * Note that this function is pretty fragile because it relies on names of
  * functions/iterators as well as the arguments and order of those
@@ -73,29 +75,64 @@
  */
 static void tryToReplaceWithDirectRangeIterator(Expr* iteratorExpr)
 {
-  CallExpr* range = NULL;
-  Expr* stride = NULL;
   if (CallExpr* call = toCallExpr(iteratorExpr))
   {
+    CallExpr* range = NULL;
+    Expr* stride = NULL;
+    Expr* count = NULL;
     // grab the stride if we have a strided range
     if (call->isNamed("chpl_by"))
     {
       range = toCallExpr(call->get(1)->copy());
       stride = toExpr(call->get(2)->copy());
     }
-    // assume the call is the range (checked below) and set default stride
+    // or grab the count if we have a counted range and set unit stride
+    else if (call->isNamed("#"))
+    {
+      range = toCallExpr(call->get(1)->copy());
+      count = toExpr(call->get(2)->copy());
+      stride = new SymExpr(new_IntSymbol(1));
+    }
+    // or assume the call is the range (checked below) and set unit stride
     else
     {
       range = call;
       stride = new SymExpr(new_IntSymbol(1));
     }
-    // see if we're looking at a builder for a bounded range. the builder is
-    // iteratable since range has these() iterators
+
+    //
+    // see if we're looking at a range builder. The builder is iteratable since
+    // range has these() iterators
+    //
+
+    // replace fully bounded (and possibly strided range) with a direct range
+    // iter. e.g. replace:
+    //
+    //   `low..high by stride`
+    //
+    // with:
+    //
+    // `chpl_direct_range_iter(low, high, stride)`
     if (range && range->isNamed("chpl_build_bounded_range"))
     {
       // replace the range construction with a direct range iterator
       Expr* low = range->get(1)->copy();
       Expr* high = range->get(2)->copy();
+      iteratorExpr->replace(new CallExpr("chpl_direct_range_iter", low, high, stride));
+    }
+
+    // replace a counted, low bounded range with unit stride with an equivalent
+    // direct range iter. e.g. replace:
+    //
+    //   `low..#count` (which is equivalent to `low..low+count-1`)
+    //
+    // with:
+    //
+    //   `chpl_direct_range_iter(low, low+count-1, 1)`
+    else if (count && range && range->isNamed("chpl_build_low_bounded_range"))
+    {
+      Expr* low = range->get(1)->copy();
+      Expr* high = new CallExpr("-", new CallExpr("+", low->copy(), count), new_IntSymbol(1));
       iteratorExpr->replace(new CallExpr("chpl_direct_range_iter", low, high, stride));
     }
   }

--- a/test/types/range/elliot/anonymousRangeIter.chpl
+++ b/test/types/range/elliot/anonymousRangeIter.chpl
@@ -13,6 +13,7 @@ proc main() {
   for i in 2..2+1 do write(i); writeln();
   var lo=3, hi=4; for i in lo..hi do write(i); writeln();
   for i in 4..5 by 2 do write(i); writeln();
+  for i in 2..#4 do write(i); writeln();
   for (i, j) in zip(1..10 by 3, 1..10 by -3) do write(i,j); writeln();
   var r = 1..10 by 2; for (i, j) in zip(1..10 by 2, r) do write(i, j); writeln();
   coforall i in 5..5 do write(i); writeln();

--- a/test/types/range/elliot/anonymousRangeIter.expectedGenCode
+++ b/test/types/range/elliot/anonymousRangeIter.expectedGenCode
@@ -13,29 +13,29 @@
 # loops to change.
 
 # for i in 1..2 do write(i); writeln();
-ic__F1_high_chpl = INT64(2);
-for (i_chpl = INT64(1); ((i_chpl <= _ic__F1_high_chpl)); i_chpl += INT64(1))
+ic__F#_high_chpl = INT64(2);
+for (i_chpl = INT64(1); ((i_chpl <= _ic__F#_high_chpl)); i_chpl += INT64(1))
 
 # for i in 2..2+1 do write(i); writeln();
-_ic__F1_high_chpl2 = INT64(3);
-for (i_chpl2 = INT64(2); ((i_chpl2 <= _ic__F1_high_chpl2)); i_chpl2 += INT64(1))
+_ic__F#_high_chpl# = INT64(3);
+for (i_chpl# = INT64(2); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(1))
 
 # var lo=3, hi=4; for i in lo..hi do write(i); writeln();
-_ic__F1_high_chpl3 = INT64(4);
-for (i_chpl3 = INT64(3); ((i_chpl3 <= _ic__F1_high_chpl3)); i_chpl3 += INT64(1))
+_ic__F#_high_chpl# = INT64(4);
+for (i_chpl# = INT64(3); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(1))
 
 # for i in 4..5 by 2 do write(i); writeln();
-_ic__F1_high_chpl4 = INT64(5);
-for (i_chpl4 = INT64(4); ((i_chpl4 <= _ic__F1_high_chpl4)); i_chpl4 += INT64(2)) {
+_ic__F#_high_chpl# = INT64(5);
+for (i_chpl# = INT64(4); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(2)) {
 
 # for (i, j) in zip(1..10 by 3, 1..10 by -3) do write(i,j); writeln();
-_ic__F1_high_chpl5 = INT64(10);
-for (_ic__F3_i_chpl = INT64(1),_ic__F3_i_chpl2 = INT64(10); (tmp_chpl = (_ic__F3_i_chpl <= _ic__F1_high_chpl5),tmp_chpl); tmp_chpl2 = _ic__F3_i_chpl,tmp_chpl2 += INT64(3),_ic__F3_i_chpl = tmp_chpl2,tmp_chpl3 = _ic__F3_i_chpl2,tmp_chpl3 += INT64(-3),_ic__F3_i_chpl2 = tmp_chpl3)
+_ic__F#_high_chpl# = INT64(10);
+for (_ic__F#_i_chpl = INT64(1),_ic__F3_i_chpl2 = INT64(10); (tmp_chpl = (_ic__F#_i_chpl <= _ic__F#_high_chpl#),tmp_chpl); tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += INT64(3),_ic__F3_i_chpl = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT64(-3),_ic__F3_i_chpl2 = tmp_chpl#)
 
 # var r = 1..10 by 2; for (i, j) in zip(1..10 by 2, r) do write(i, j); writeln();
-_ic__F1_high_chpl6 = INT64(10);
-for (_ic__F3_i_chpl3 = INT64(1),_ic__value_chpl = tmp_chpl5; (tmp_chpl6 = (_ic__F3_i_chpl3 <= _ic__F1_high_chpl6),tmp_chpl6); tmp_chpl7 = _ic__F3_i_chpl3,tmp_chpl7 += INT64(2),_ic__F3_i_chpl3 = tmp_chpl7,tmp_chpl8 = _ic__value_chpl,tmp_chpl8 += ret_chpl19,_ic__value_chpl = tmp_chpl8)
+_ic__F#_high_chpl# = INT64(10);
+for (_ic__F#_i_chpl# = INT64(1),_ic__value_chpl = tmp_chpl#; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT64(2),_ic__F3_i_chpl3 = tmp_chpl#,tmp_chpl# = _ic__value_chpl,tmp_chpl# += ret_chpl#,_ic__value_chpl = tmp_chpl#)
 
 # coforall i in 5..5 do write(i); writeln();
-_ic__F1_high_chpl7 = INT64(5);
-for (i_chpl5 = INT64(5); ((i_chpl5 <= _ic__F1_high_chpl7)); i_chpl5 += INT64(1))
+_ic__F#_high_chpl# = INT64(5);
+for (i_chpl# = INT64(5); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(1))

--- a/test/types/range/elliot/anonymousRangeIter.expectedGenCode
+++ b/test/types/range/elliot/anonymousRangeIter.expectedGenCode
@@ -28,6 +28,10 @@ for (i_chpl# = INT64(3); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(1))
 _ic__F#_high_chpl# = INT64(5);
 for (i_chpl# = INT64(4); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(2)) {
 
+# for i in 2..#4 do write(i); writeln();
+_ic__F#_high_chpl# = INT64(5);
+for (i_chpl# = INT64(2); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(1)) {
+
 # for (i, j) in zip(1..10 by 3, 1..10 by -3) do write(i,j); writeln();
 _ic__F#_high_chpl# = INT64(10);
 for (_ic__F#_i_chpl = INT64(1),_ic__F3_i_chpl2 = INT64(10); (tmp_chpl = (_ic__F#_i_chpl <= _ic__F#_high_chpl#),tmp_chpl); tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += INT64(3),_ic__F3_i_chpl = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT64(-3),_ic__F3_i_chpl2 = tmp_chpl#)

--- a/test/types/range/elliot/anonymousRangeIter.good
+++ b/test/types/range/elliot/anonymousRangeIter.good
@@ -2,10 +2,13 @@
 23
 34
 4
+2345
 1104774101
 1133557799
 5
 
+Found expected line
+Found expected line
 Found expected line
 Found expected line
 Found expected line


### PR DESCRIPTION
Similar to how we optimize iteration over anonymous (possibly strided) fully
bounded ranges (added with #1021), but for anonymous low-bounded counted
ranges.

This effectively replaces code like:

```chapel
for i in low..#count {}  (note that `low..#count` is equivalent to `low..low+count-1`)
```

with:

```chapel
for i in chpl_direct_range_iter(low, low+count-1, 1) {}
```

Low-bounded counted ranges are used a lot in our internal iterators (particular
leader and standalone iterators) and are pretty common in user code because
it's easier than writing `low..low+count-1`. Because of this it's worthwhile to
optimize this specific case too. This was also listed in the next steps when
the anonymous range optimization was originally added. Note that this doesn't
add support for fully bounded counted ranges or counted and strided ranges.

This optimization has a pretty nice impact on the generated code but like the
original optimization we don't expect this to have a huge impact on
performance. That said it is important for vectorization and it does eliminate
a few unnecessary function calls.

See deb9f3cf2c48dd7c150b9cf1a2bb64b7514e8c82 for a generated code example.
