### PR TITLE
Add a makefile rule to always build chpldoc if CHPL_ALWAYS_BUILD_CHPLDOC is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ comprt: FORCE
 	@$(MAKE) compiler
 	@$(MAKE) third-party-try-opt
 	@$(MAKE) always-build-test-venv
+	@$(MAKE) always-build-chpldoc
 	@$(MAKE) runtime
 	@$(MAKE) modules
 
@@ -114,6 +115,11 @@ chpldoc: compiler third-party-chpldoc-venv
 always-build-test-venv: FORCE
 	-@if [ -n "$$CHPL_ALWAYS_BUILD_TEST_VENV" ]; then \
 	$(MAKE) test-venv; \
+	fi
+
+always-build-chpldoc: FORCE
+	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHPLDOC" ]; then \
+	$(MAKE) chpldoc; \
 	fi
 
 clean-module-docs:


### PR DESCRIPTION
Add a top-level makefile rule to always build chpldoc if
CHPL_ALWAYS_BUILD_CHPLDOC is set. CHPL_ALWAYS_BUILD_CHPLDOC is a sibling to
CHPL_ALWAYS_BUILD_TEST_VENV, which was added with #2263

The rationale is that chpldoc is required for a full test run or you get an
error along the lines of "[Error matching man page(s) with compiler
environment]" and a bunch of tests are skipped.

I (and I believe a few other developers) never remember to build chpldoc so I
just mentally filter out that error. This is just for testing convenience.