### PR TITLE
Convert a "c for loop" in default rectangular to use a direct range iter

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1271,10 +1271,10 @@ module ChapelRange {
 
   // cases for when stride is a uint (we know the stride is must be positive)
   iter chpl_direct_range_iter(low: int(?w), high: int(w), stride: uint(w)) {
-    for i in chpl_direct_uint_stride_range_iter(low, high, stride) do yield i;
+    for i in chpl_direct_pos_stride_range_iter(low, high, stride) do yield i;
   }
   iter chpl_direct_range_iter(low: uint(?w), high: uint(w), stride: uint(w)) {
-    for i in chpl_direct_uint_stride_range_iter(low, high, stride) do yield i;
+    for i in chpl_direct_pos_stride_range_iter(low, high, stride) do yield i;
   }
 
 
@@ -1302,10 +1302,10 @@ module ChapelRange {
 
 
   // These are the "actual" direct range iterators. Note that they do not do
-  // any checks on the arguments, and rely on the above functions to
-  // check/coerce types (assumes args are of legal types, low/high are the same
-  // same type, and stride is valid.)
-  iter chpl_direct_uint_stride_range_iter(low: ?t, high, stride) {
+  // any checks on the arguments, and rely on the above functions/expert user
+  // to check/coerce types (i.e. they assume args are of legal types, low/high
+  // are the same same type, stride is valid, etc.)
+  iter chpl_direct_pos_stride_range_iter(low: ?t, high, stride) {
     if (useOptimizedRangeIterators) {
       chpl_range_check_stride(stride, t);
 


### PR DESCRIPTION
#407 converted a loop over a range to a direct invocation of a "c for loop" in
DefaultRectangular. This was motivated by a performance regression that was
caused by the introduction of a range constructor (which was expensive in tight
loops.)

Using the "c for loop" directly was ugly, and meant that we didn't get any
overflow or legal stride checking. It also meant that the generalIterator()
wouldn't be invoked if a user compiled with `suseOptimizedRangeIterators=false`

The anonymous range iteration optimization (#1021) added some direct iterators
that take low, high, and stride as arguments and avoid range creation. There
was already one optimized for positively strided ranges, so this commit changes
the iteration over the "c for loop" to invoke that iterator.

For some reason it didn't occur to me at the time of that commit to make this
change, but some recent work on a range overflow bug (#2905) and some
improvements to the anonymous range iteration code (#3154) pointed me towards
this.