### PR TITLE
Fix line numbers reported for standalone iterators

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1303,6 +1303,8 @@ expandBodyForIteratorInline(ForLoop*       forLoop,
         if (!fcopy) {
           // Clone the function. Just once per 'body' should suffice.
           fcopy = cfn->copy();
+          if (!preserveInlinedLineNumbers)
+            reset_ast_loc(fcopy, call);
 
           // Note that 'fcopy' will likely get a copy of 'body',
           // so we need to preserve correct scoping of its SymExprs.

--- a/test/performance/vectorization/vectorPragmas/basicIters.compgood
+++ b/test/performance/vectorization/vectorPragmas/basicIters.compgood
@@ -1,2 +1,2 @@
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeLeaderFollower:15
-Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:15
+Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23

--- a/test/performance/vectorization/vectorPragmas/cForLoopInParIter.compgood
+++ b/test/performance/vectorization/vectorPragmas/cForLoopInParIter.compgood
@@ -1,2 +1,2 @@
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeLeaderFollower:15
-Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:18
+Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23

--- a/test/performance/vectorization/vectorPragmas/doWhileInParIter.compgood
+++ b/test/performance/vectorization/vectorPragmas/doWhileInParIter.compgood
@@ -1,1 +1,1 @@
-Adding CHPL_PRAGMA_IVDEP to DoWhileStmt for InvokeStandalone:18
+Adding CHPL_PRAGMA_IVDEP to DoWhileStmt for InvokeStandalone:23

--- a/test/performance/vectorization/vectorPragmas/forallInStandalone.compgood
+++ b/test/performance/vectorization/vectorPragmas/forallInStandalone.compgood
@@ -1,3 +1,3 @@
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeLeaderFollower:15
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23
-Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:1523
+Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23

--- a/test/performance/vectorization/vectorPragmas/loopWithoutYield.compgood
+++ b/test/performance/vectorization/vectorPragmas/loopWithoutYield.compgood
@@ -1,2 +1,2 @@
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeLeaderFollower:15
-Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:19
+Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23

--- a/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
+++ b/test/performance/vectorization/vectorPragmas/loopsInForallNoVector.compgood
@@ -1,2 +1,2 @@
-Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:15
 Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:10
+Adding CHPL_PRAGMA_IVDEP to CForLoop for loopsInForallNoVector:18

--- a/test/performance/vectorization/vectorPragmas/nestedLoopsInFollower.compgood
+++ b/test/performance/vectorization/vectorPragmas/nestedLoopsInFollower.compgood
@@ -1,1 +1,1 @@
-Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:15
+Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23

--- a/test/performance/vectorization/vectorPragmas/whileDoInParIter.compgood
+++ b/test/performance/vectorization/vectorPragmas/whileDoInParIter.compgood
@@ -1,2 +1,2 @@
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeLeaderFollower:15
-Adding CHPL_PRAGMA_IVDEP to WhileDoStmt for InvokeStandalone:17
+Adding CHPL_PRAGMA_IVDEP to WhileDoStmt for InvokeStandalone:23

--- a/test/performance/vectorization/vectorPragmas/zipIterInFollower.compgood
+++ b/test/performance/vectorization/vectorPragmas/zipIterInFollower.compgood
@@ -1,2 +1,2 @@
 Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeLeaderFollower:15
-Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:14
+Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23


### PR DESCRIPTION
As originally mentioned in 189feea8f0ab5c2c94dac26b3d317a68246b14a9 we were
reporting the wrong line numbers for order independent loops that invoked a
standalone iterator. Instead of reporting the line number of the user-level
loop that was order independent, we were reporting the line number of the
yielding loop inside the standalone iterator. This was particularly annoying
for the forallInStandalone test because it meant code changes that affected
ChapelRange line numbers would cause it to fail.

This fix is peeled off of (blatantly stolen from) a larger patch that Vass
made. His patch updates when we preserve line numbers. This ignores that
question, and sticks with our current line number reporting scheme, but
corrects what we report for invocations of standalone iterators.