### PR TITLE
Fix test failures after PR #3099

### DIFF
--- a/modules/internal/tasktable/on/ChapelTaskTable.chpl
+++ b/modules/internal/tasktable/on/ChapelTaskTable.chpl
@@ -158,7 +158,7 @@ module ChapelTaskTable {
     if (chpldev_taskTable == nil) then return;
   
     for taskID in chpldev_taskTable.dom {
-      stderr.writeln("- ", chpl_lookupFilename(chpldev_taskTable.map[taskID].filename),
+      stderr.writeln("- ", chpl_lookupFilename(chpldev_taskTable.map[taskID].filename):string,
                      ":",  chpldev_taskTable.map[taskID].lineno,
                      " is ", chpldev_taskTable.map[taskID].state);
     }

--- a/test/extern/bradc/extern_string_test-remote.chpl
+++ b/test/extern/bradc/extern_string_test-remote.chpl
@@ -1,7 +1,7 @@
 extern proc return_string_test():c_string;
 extern proc return_string_arg_test(ref c_string);
 
-writeln("returned string ",return_string_test()); stdout.flush();
+writeln("returned string ",return_string_test():string); stdout.flush();
 var s:string;
 on Locales(1) {
   var temp_cs: c_string;

--- a/test/types/string/thomasvandoren/int-to-c_string.chpl
+++ b/test/types/string/thomasvandoren/int-to-c_string.chpl
@@ -3,6 +3,6 @@ const n = 5,
   csc = n: c_string_copy,
   s = n: string;
 writeln(n, " : ", n.type:string);
-writeln(cs, " : ", cs.type:string);
-writeln(csc, " : ", csc.type:string);
+writeln(cs:string, " : ", cs.type:string);
+writeln(csc:string, " : ", csc.type:string);
 writeln(s, " : ", s.type:string);


### PR DESCRIPTION
Minor fixes after @Kyle-B 's PR #3099 made calling writeln with a
c_string a compile error. Needed to update 2 tests and 1 line in
ChapelTaskTable.chpl with a cast to string.

Verified that the failing tests now pass.
