### PR TITLE
Add c_malloc

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4006,6 +4006,9 @@ GenRet CallExpr::codegen() {
     }
     case PRIM_ARRAY_ALLOC:
     {
+      // get(1): return symbol
+      // get(2): element type
+      // get(3): number of elements
       GenRet dst = get(1);
       GenRet alloced;
       INT_ASSERT(dst.isLVPtr);

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -196,7 +196,8 @@ module CPtr {
   }
 
 
-  /* Allocate memory that is filled with zeros. This memory should eventually be
+  /*
+    Allocate memory that is filled with zeros. This memory should eventually be
     freed with c_free.
 
     :arg eltType: the type of the elements to allocate
@@ -206,9 +207,26 @@ module CPtr {
   inline proc c_calloc(type eltType, size: integral) : c_ptr(eltType) {
     var ret:c_ptr(eltType);
     __primitive("array_alloc", ret, eltType, size);
+    // TODO - one day, this should call calloc instead of
+    // initializing the memory possibly in parallel.
     init_elts(ret, size, eltType);
     return ret;
   }
+
+  /*
+    Allocate memory that is not initialized. The memory should be written to
+    before it is read. This memory should eventually be freed with c_free.
+
+    :arg eltType: the type of the elements to allocate
+    :arg size: the number of elements to allocate
+    :returns: a c_ptr(eltType) to allocated memory
+    */
+  inline proc c_malloc(type eltType, size: integral) : c_ptr(eltType) {
+    var ret:c_ptr(eltType);
+    __primitive("array_alloc", ret, eltType, size);
+    return ret;
+  }
+
 
   /* Free memory that was allocated with :proc:`c_free`.
     :arg data: the c_ptr to memory that was allocated

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3967,7 +3967,7 @@ proc stringify(args ...?k):string {
 
     var offset = w.offset();
 
-    var buf = c_calloc(uint(8), offset+1);
+    var buf = c_malloc(uint(8), offset+1);
 
     // you might need a flush here if
     // close went away
@@ -3976,6 +3976,8 @@ proc stringify(args ...?k):string {
     var r = f.reader(locking=false);
 
     r.readBytes(buf, offset:ssize_t);
+    // Add the terminating NULL byte to make C string conversion easy.
+    buf[offset] = 0;
     r.close();
 
     f.close();
@@ -6329,7 +6331,7 @@ private inline proc _do_format(fmt:c_string, args ...?k, out error:syserr):strin
 
   var offset = w.offset();
 
-  var buf = c_calloc(uint(8), offset+1);
+  var buf = c_malloc(uint(8), offset+1);
 
   // you might need a flush here if
   // close went away
@@ -6338,6 +6340,8 @@ private inline proc _do_format(fmt:c_string, args ...?k, out error:syserr):strin
   var r = f.reader(locking=false);
 
   r.readBytes(buf, offset:ssize_t);
+  // Add the terminating NULL byte to make C string conversion easy.
+  buf[offset] = 0;
   r.close();
 
   f.close();


### PR DESCRIPTION
Adds c_malloc as a sibling to c_calloc.

Adjust the 2 calls in IO.chpl using c_calloc to instead use c_malloc,
since they immediately write to the buffer. (String.chpl already uses
chpl_mem_alloc)

Passed full local testing.

Reviewed by @ronawho - thanks!