### PR TITLE
Use local-on in internal module code.

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1570,7 +1570,7 @@ module ChapelRange {
         yield (0..len-1,);
       } else {
         coforall chunk in 0..#numChunks {
-          on here.getChild(chunk) {
+          local on here.getChild(chunk) {
             if debugDataParNuma {
               if chunk!=chpl_getSubloc() then
                 writeln("*** ERROR: ON WRONG SUBLOC (should be "+chunk+

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -294,7 +294,7 @@ module DefaultRectangular {
           }
         } else {
           coforall chunk in 0..#numChunks { // make sure coforall on can trigger
-            on here.getChild(chunk) {
+            local on here.getChild(chunk) {
               if debugDataParNuma {
                 if chunk!=chpl_getSubloc() then
                   writeln("*** ERROR: ON WRONG SUBLOC (should be "+chunk+


### PR DESCRIPTION
ChapelRange and DefaultRectangular were using on-statements to execute
on sublocales. The new local-on statement should allow the compiler to
avoid creating as much wide pointer overhead, and should be used
instead.