### PR TITLE
Add chpldoc future for malformed range and domain literals

### DIFF
--- a/test/chpldoc/types/fields/rangesAndDomains.doc.bad
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.bad
@@ -1,0 +1,14 @@
+rangesAndDomains.doc
+   Record: R
+      var isRange: range
+      var boundedRange = 1..10
+      var lowBoundedRange = BoundedRangeType.boundedLowchpl_build_partially_bounded_range1
+      var highBoundedRange = BoundedRangeType.boundedHighchpl_build_partially_bounded_range10
+      var unboundedRange = chpl_build_unbounded_range(BoundedRangeType.boundedNone)
+   Record: D
+      var is1DDomain: domain(1)
+      var is2DDomain: domain(2)
+      var is3DDomain: domain(3)
+      var bounded1DDomain = chpl__buildDomainExpr(1..10)
+      var bounded2DDomain = 1..10chpl__buildDomainExpr1..10
+      var bounded3DDomain = chpl__buildDomainExpr(1..10, 1..10, 1..10)

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.catfiles
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.catfiles
@@ -1,0 +1,1 @@
+docs/rangesAndDomains.doc.txt

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
@@ -1,0 +1,18 @@
+record R {
+  var isRange: range;
+
+  var boundedRange = 1..10;
+  var lowBoundedRange = 1..;
+  var highBoundedRange = ..10;
+  var unboundedRange = ..;
+}
+
+record D {
+  var is1DDomain: domain(1);
+  var is2DDomain: domain(2);
+  var is3DDomain: domain(3);
+
+  var bounded1DDomain = {1..10};
+  var bounded2DDomain = {1..10, 1..10};
+  var bounded3DDomain = {1..10, 1..10, 1..10};
+}

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.future
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.future
@@ -1,0 +1,15 @@
+bug: chpldoc generates function calls for some range and domain literals
+
+chpldoc emits the function names for some of the range builders and for
+chpl__buildDomainExpr instead of cleaning them up to look like the original
+literals.
+
+For example:
+
+```chapel
+1..10 => 1..10
+
+1.. => BoundedRangeType.boundedLowchpl_build_partially_bounded_range1
+
+{1..10} => chpl__buildDomainExpr(1..10)
+```

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.good
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.good
@@ -1,0 +1,14 @@
+rangesAndDomains.doc
+   Record: R
+      var isRange: range
+      var boundedRange = 1..10
+      var lowBoundedRange = 1..
+      var highBoundedRange = ..10
+      var unboundedRange = ..
+   Record: D
+      var is1DDomain: domain(1)
+      var is2DDomain: domain(2)
+      var is3DDomain: domain(3)
+      var bounded1DDomain = {1..10}
+      var bounded2DDomain = {1..10, 1..10}
+      var bounded3DDomain = {1..10, 1..10, 1..10}


### PR DESCRIPTION
chpldoc only cleans up fully bounded ranges, not partially bounded or unbounded
ranges. Additionally it doesn't clean up domain literals.

For example:

```chapel
  1..10 => 1..10

  1.. => BoundedRangeType.boundedLowchpl_build_partially_bounded_range1

  {1..10} => chpl__buildDomainExpr(1..10)
```