### PR TITLE
Update a few tests dealing with multilocale c_strings

### DIFF
--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.chpl
@@ -1,4 +1,4 @@
 var s = "0123456789";
 on Locales[numLocales-1] {
-  writeln(s.c_str());
+  writeln(s.c_str():string);
 }

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.future
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.future
@@ -1,4 +1,0 @@
-bug: c_string variables should not be copied to other locales
-
-See remote_assign_c_string.future for more info.
-

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.good
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.good
@@ -1,1 +1,1 @@
-0123456789
+c_str_on_remote_global_string.chpl:3: error: halt reached - Cannot call .c_str() on a remote string

--- a/test/types/string/sungeun/c_string/multilocale/remote_assign_c_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/remote_assign_c_string.chpl
@@ -3,5 +3,5 @@
   on Locales[numLocales-1] {
     cs = "0123456789".c_str(); // this should result in a runtime error
   }
-  writeln(cs);
+  writeln(cs:string);
 }

--- a/test/types/string/sungeun/c_string/multilocale/remote_assign_global_c_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/remote_assign_global_c_string.chpl
@@ -2,4 +2,4 @@ var cs: c_string;
 on Locales[numLocales-1] {
   cs = "0123456789".c_str(); // this should result in a runtime error
 }
-writeln(cs);
+writeln(cs:string);

--- a/test/types/string/sungeun/c_string/multilocale/write_c_string.future
+++ b/test/types/string/sungeun/c_string/multilocale/write_c_string.future
@@ -1,6 +1,0 @@
-bug: c_string variables should not be used with write
-
-c_strings are only valid in the locale they were created on. Trying to write
-one from a locale other than the channel's home will cause a the use of a bad
-pointer. We should disallow the use of c_string in our IO system. If users
-really want to print one they can cast to string.

--- a/test/types/string/sungeun/c_string/multilocale/write_c_string.good
+++ b/test/types/string/sungeun/c_string/multilocale/write_c_string.good
@@ -1,1 +1,1 @@
-write_c_string.chpl:4: error: Cannot write out a c_string, cast to string for multi-locale IO.
+$CHPL_HOME/modules/standard/IO.chpl:3685: error: Cannot write a c_string, cast to a string first.


### PR DESCRIPTION
I've gone through and updated the futures in

    test/types/string/sungeun/c_string/multilocale/

They now all compile with the new c_string IO changes.

Two of them have been retired:

    c_str_on_remote_global_string.future
    write_c_string.future