### PR TITLE
Bump the Pygments version used by chpldoc

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -1,6 +1,6 @@
 Jinja2==2.8
 MarkupSafe==0.23
-Pygments==2.0.2
+Pygments>=2,<3
 Sphinx==1.3.3
 docutils==0.12
 sphinx-rtd-theme==0.1.9


### PR DESCRIPTION
I've made the requirements line for Pygments:

    Pygments>=2,<3

This will pull the latest version of Pygments >=2 but less than 3,
which should ensure we always have the latest grammar updates without
breaking compatibility.