### PR TITLE
Reduce numa timeout from 20 minutes to 10 and bump to 3 trials

### DIFF
--- a/util/cron/test-perf.chapcs.numa-playground.bash
+++ b/util/cron/test-perf.chapcs.numa-playground.bash
@@ -10,7 +10,7 @@ source $CWD/common-numa.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.numa-playground"
 
-export CHPL_TEST_TIMEOUT=1200
+export CHPL_TEST_TIMEOUT=600
 
 
 # Test performance of numa with work stealing turned off
@@ -28,5 +28,5 @@ git checkout -b $GITHUB_USER-$GITHUB_BRANCH
 git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,numa:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
-perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"
+perf_args="${perf_args} -numtrials 3 -startdate $START_DATE"
 $CWD/nightly -cron ${perf_args} ${nightly_args}

--- a/util/cron/test-perf.chapcs.numa.bash
+++ b/util/cron/test-perf.chapcs.numa.bash
@@ -10,9 +10,9 @@ source $CWD/common-numa.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.numa"
 
-export CHPL_TEST_TIMEOUT=1200
+export CHPL_TEST_TIMEOUT=600
 
 perf_args="-performance-description numa -performance-configs default:v,numa:v -sync-dir-suffix numa"
-perf_args="${perf_args} -performance -numtrials 1 -startdate 01/15/16"
+perf_args="${perf_args} -performance -numtrials 3 -startdate 01/15/16"
 
 $CWD/nightly -cron ${nightly_args} ${perf_args}


### PR DESCRIPTION
Reduce numa timeout from 20 minutes to 10 and bump to 3 trials

With #3146, numa performance testing finishes much faster. Looking at the log,
there's only a few tests that take more than 5 minutes:

| test                                             | time (min) |
| ------------------------------------------------ | ---------- |
| studies/shootout/nbody/bradc/nbody-blc-slice:    | ~9.5       |
| studies/shootout/nbody/sidelnik/nbody_forloop_3: | ~9.0       |
| release/examples/benchmarks/hpcc/ptrans:         | ~6.0       |
| release/examples/benchmarks/hpcc/ra-atomics      | ~5.1       |
