### PR TITLE
Fix ISx sed portability issue

### DIFF
--- a/test/studies/isx/isx-bucket-spmd.precomp
+++ b/test/studies/isx/isx-bucket-spmd.precomp
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 rm -f *.good
 if [ "gasnet" = `$CHPL_HOME/util/chplenv/chpl_comm.py` ]; then cp goods-4/*.good .; else cp goods-1/*.good .; fi
-sed -i .bak s/locale/bucket/ *.good
-sed -i .bak s/Locale/Bucket/ *.good
-rm *.bak
+
+for f in *.good; do
+  ftmp="$f.tmp"
+  sed s/locale/bucket/g "$f" > "$ftmp"
+  mv "$ftmp" "$f"
+  sed s/Locale/Bucket/g "$f" > "$ftmp"
+  mv "$ftmp" "$f"
+done


### PR DESCRIPTION
Replace ISx `sed -i`, which isn't portable across the platforms we test on
with a more generic and portable method.  Traditionally, we just do a regular
sed, send the output to a temp file, and then replace the original with the
temp file. Do that here in a loop over the .good files.