### PR TITLE
Allow performance graphs to be generated concurrently

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -744,7 +744,7 @@ if ($runtests == 0) {
 
     if ($performance == 1 or $compperformance == 1) {
         # sync the performance graphs over to sourceforge
-        $rsyncCommand = "$chplhomedir/util/cron/syncPerfGraphs.py $svnPerfDir/html/ $perfConfigName/$syncsuffix --logFile $logdir/syncToSourceForge.errors";
+        $rsyncCommand = "$chplhomedir/util/cron/syncPerfGraphs.py $svnPerfDir/$performancedescription/html/ $perfConfigName/$syncsuffix --logFile $logdir/syncToSourceForge.errors";
         $rsyncMessage = "syncing performance graph to sourceforge -- log file at $logdir/syncToSourceForge.errors";
         mysystem($rsyncCommand, $rsyncMessage , 0, 1, 1);
    }

--- a/util/start_test
+++ b/util/start_test
@@ -823,12 +823,11 @@ def set_up_performance_testing_B():
         else:
             perf_dir = os.environ["CHPL_TEST_PERF_DIR"]
 
-        perf_html_dir = os.path.join(perf_dir, "html")
+        perf_desc = args.performance_description
+        perf_html_dir = os.path.join(perf_dir, perf_desc, "html")
 
-        if (args.performance_description != "" 
-                and args.performance_description != "default"):
-            os.environ["CHPL_TEST_PERF_DESCRIPTION"] = (
-                args.performance_description)
+        if (perf_desc != "" and perf_desc != "default"):
+            os.environ["CHPL_TEST_PERF_DESCRIPTION"] = perf_desc
 
     global perf_keys
     perf_keys = "{0}keys".format(args.perflabel)


### PR DESCRIPTION
We used to generate performance graphs on a per machine basis so there was
never any way for genGraphs to be running concurrently on the same directory.
However, we started running multiple performance tests on chapcs boxes and they
all generated graphs in the `chapcs/html` directory instead of the machine
specific directory.

This makes us build in `chapcs/<performancedescription>/html` so we have a
unique directory now.