### PR TITLE
Simplify structured parallelism interface with modules and runtime.

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1387,7 +1387,6 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
     BlockStmt* block = ForLoop::buildForLoop(indices, iterator, beginBlk, true, zippered);
     block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc", /* forceLocalTypes= */gTrue)));
     block->insertAtHead(new DefExpr(coforallCount));
-    block->insertAtTail(new CallExpr(PRIM_PROCESS_TASK_LIST, coforallCount));
     beginBlk->insertBefore(new CallExpr("_upEndCount", coforallCount));
     block->insertAtTail(new CallExpr("_waitEndCount", coforallCount));
     block->insertAtTail(new CallExpr("_endCountFree", coforallCount));
@@ -2174,7 +2173,6 @@ buildCobeginStmt(CallExpr* byref_vars, BlockStmt* block) {
 
   block->insertAtHead(new CallExpr(PRIM_MOVE, cobeginCount, new CallExpr("_endCountAlloc", /* forceLocalTypes= */gTrue)));
   block->insertAtHead(new DefExpr(cobeginCount));
-  block->insertAtTail(new CallExpr(PRIM_PROCESS_TASK_LIST, cobeginCount));
   block->insertAtTail(new CallExpr("_waitEndCount", cobeginCount));
   block->insertAtTail(new CallExpr("_endCountFree", cobeginCount));
 

--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -187,9 +187,6 @@ void checkPrimitives()
      case PRIM_SINGLE_IS_FULL:
      case PRIM_GET_END_COUNT:
      case PRIM_SET_END_COUNT:
-     case PRIM_PROCESS_TASK_LIST:
-     case PRIM_EXECUTE_TASKS_IN_LIST:
-     case PRIM_FREE_TASK_LIST:
      case PRIM_GET_SERIAL:              // get serial state
      case PRIM_SET_SERIAL:              // set serial state to true or false
      case PRIM_SIZEOF:

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -5059,21 +5059,6 @@ GenRet CallExpr::codegen() {
                             val_ptr, aux);
       break; 
     }
-    case PRIM_PROCESS_TASK_LIST: {
-      GenRet taskListPtr = codegenFieldPtr(get(1), "taskList");
-      codegenCall("chpl_taskListProcess", codegenValue(taskListPtr), get(2), get(3));
-      break;
-    }
-    case PRIM_EXECUTE_TASKS_IN_LIST:
-      codegenCall("chpl_taskListExecute", get(1), get(2), get(3));
-      break;
-    case PRIM_FREE_TASK_LIST:
-    {
-      if (fNoMemoryFrees)
-        break;
-      codegenCall("chpl_taskListFree", get(1), get(2), get(3));
-      break;
-    }
     case PRIM_GET_SERIAL:
       ret = codegenCallExpr("chpl_task_getSerial");
       break;

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -491,10 +491,6 @@ initPrimitive() {
   prim_def(PRIM_GET_END_COUNT, "get end count", returnInfoEndCount);
   prim_def(PRIM_SET_END_COUNT, "set end count", returnInfoVoid, true);
 
-  prim_def(PRIM_PROCESS_TASK_LIST, "process task list", returnInfoVoid, true, true);
-  prim_def(PRIM_EXECUTE_TASKS_IN_LIST, "execute tasks in list", returnInfoVoid, true, true);
-  prim_def(PRIM_FREE_TASK_LIST, "free task list", returnInfoVoid, true, true);
-
   // task primitives
   prim_def(PRIM_GET_SERIAL, "task_get_serial", returnInfoBool);
   prim_def(PRIM_SET_SERIAL, "task_set_serial", returnInfoVoid, true);

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -80,7 +80,6 @@ Symbol *gTimer = NULL;
 Symbol *gTaskID = NULL;
 Symbol *gSyncVarAuxFields = NULL;
 Symbol *gSingleVarAuxFields = NULL;
-Symbol *gTaskList = NULL;
 
 VarSymbol *gTrue = NULL;
 VarSymbol *gFalse = NULL;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1553,12 +1553,6 @@ void initPrimitiveTypes() {
   CREATE_DEFAULT_SYMBOL (dtSingleVarAuxFields, gSingleVarAuxFields, "_nullSingleVarAuxFields");
   gSingleVarAuxFields->cname = "NULL";
 
-  dtTaskList = createPrimitiveType( "_task_list", "chpl_task_list_p");
-  dtTaskList->symbol->addFlag(FLAG_EXTERN);
-
-  CREATE_DEFAULT_SYMBOL (dtTaskList, gTaskList, "_nullTaskList");
-  gTaskList->cname = "NULL";
-
   dtAny = createInternalType ("_any", "_any");
   dtAny->symbol->addFlag(FLAG_GENERIC);
 
@@ -2134,7 +2128,6 @@ bool needsCapture(Type* t) {
       isUnion(t) ||
       t == dtTaskID || // false?
       t == dtFile ||
-      t == dtTaskList ||
       // TODO: Move these down to the "no" section.
       t == dtNil ||
       t == dtOpaque ||

--- a/compiler/include/primitive.h
+++ b/compiler/include/primitive.h
@@ -128,10 +128,6 @@ enum PrimitiveTag {
   PRIM_GET_END_COUNT,
   PRIM_SET_END_COUNT,
 
-  PRIM_PROCESS_TASK_LIST,
-  PRIM_EXECUTE_TASKS_IN_LIST,
-  PRIM_FREE_TASK_LIST,
-
   PRIM_GET_SERIAL,              // get serial state
   PRIM_SET_SERIAL,              // set serial state to true or false
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -622,8 +622,6 @@ extern FnSymbol *gChplHereFree;
 extern Symbol *gSyncVarAuxFields;
 extern Symbol *gSingleVarAuxFields;
 
-extern Symbol *gTaskList;
-
 extern std::map<FnSymbol*,int> ftableMap;
 extern Vec<FnSymbol*> ftableVec;
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -242,7 +242,6 @@ TYPE_EXTERN PrimitiveType* dtOpaque;
 TYPE_EXTERN PrimitiveType* dtTaskID;
 TYPE_EXTERN PrimitiveType* dtSyncVarAuxFields;
 TYPE_EXTERN PrimitiveType* dtSingleVarAuxFields;
-TYPE_EXTERN PrimitiveType* dtTaskList;
 
 // Well-known types
 TYPE_EXTERN AggregateType* dtString;

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -292,7 +292,6 @@ isFastPrimitive(CallExpr *call, bool isLocal) {
    // These don't block in the Chapel sense, but they may require a system
     // call so we don't consider them eligible.
     //
-  case PRIM_FREE_TASK_LIST:
   case PRIM_ARRAY_ALLOC:
   case PRIM_ARRAY_FREE:
   case PRIM_ARRAY_FREE_ELTS:
@@ -303,8 +302,6 @@ isFastPrimitive(CallExpr *call, bool isLocal) {
     // here until they are proven fast.
   case PRIM_GET_END_COUNT:
   case PRIM_SET_END_COUNT:
-  case PRIM_PROCESS_TASK_LIST:
-  case PRIM_EXECUTE_TASKS_IN_LIST:
   case PRIM_TO_LEADER:
   case PRIM_TO_FOLLOWER:
   case PRIM_DELETE:

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -375,7 +375,7 @@ bundleArgs(CallExpr* fcall, BundleArgsFnData &baData) {
 
     // Now get the taskList field out of the end count.
 
-    taskList = newTemp(astr("_taskList", fn->name), dtTaskList->refType);
+    taskList = newTemp(astr("_taskList", fn->name), dtCVoidPtr);
 
     // If the end count is a reference, dereference it.
     // EndCount is a class.
@@ -457,7 +457,7 @@ static void create_block_fn_wrapper(FnSymbol* fn, CallExpr* fcall, BundleArgsFnD
   } else {
     // create a task list argument.
     ArgSymbol *taskListArg = new ArgSymbol( INTENT_IN, "dummy_taskList", 
-                                            dtTaskList->refType );
+                                            dtCVoidPtr );
     taskListArg->addFlag(FLAG_NO_CODEGEN);
     wrap_fn->insertFormalAtTail(taskListArg);
     ArgSymbol *taskListNode = new ArgSymbol( INTENT_IN, "dummy_taskListNode", 

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -40,7 +40,6 @@ static IntentTag constIntentForType(Type* t) {
              t == dtOpaque ||
              t == dtTaskID ||
              t == dtFile ||
-             t == dtTaskList ||
              t == dtNil ||
              t == dtStringC ||
              t == dtStringCopy ||
@@ -72,7 +71,6 @@ IntentTag blankIntentForType(Type* t) {
              isUnion(t) ||
              t == dtTaskID ||
              t == dtFile ||
-             t == dtTaskList ||
              t == dtNil ||
              t == dtOpaque ||
              t->symbol->hasFlag(FLAG_DOMAIN) ||

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6267,8 +6267,6 @@ postFold(Expr* expr) {
                call->isPrimitive(PRIM_SINGLE_READFF) ||
                call->isPrimitive(PRIM_SINGLE_READXX) ||
                call->isPrimitive(PRIM_SINGLE_IS_FULL) ||
-               call->isPrimitive(PRIM_EXECUTE_TASKS_IN_LIST) ||
-               call->isPrimitive(PRIM_FREE_TASK_LIST) ||
                (call->primitive &&
                 (!strncmp("_fscan", call->primitive->name, 6) ||
                  !strcmp("_readToEndOfLine", call->primitive->name) ||

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1529,7 +1529,6 @@ module ChapelBase {
   pragma "no doc"
   inline proc _defaultOf(type t) where t: _sync_aux_t return _nullSyncVarAuxFields;
   pragma "no doc"
-  inline proc _defaultOf(type t) where t == c_void_ptr return _nullVoidPtr;
 
   pragma "no doc"
   inline proc _defaultOf(type t) where t: _ddata

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -811,7 +811,7 @@ module ChapelBase {
   pragma "dont disable remote value forwarding"
   proc _waitEndCount(e: _EndCount, param countRunningTasks=true) {
     // See if we can help with any of the started tasks
-    __primitive("execute tasks in list", e.taskList);
+    chpl_taskListExecute(e.taskList);
 
     // Remove the task that will just be waiting/yielding in the following
     // waitFor() from the running task count to let others do real work. It is

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -740,7 +740,7 @@ module ChapelBase {
     type taskType;
     var i: iType,
         taskCnt: taskType,
-        taskList: _task_list = _defaultOf(_task_list);
+        taskList: c_void_ptr = _defaultOf(c_void_ptr);
   }
 
   // This function is called once by the initiating task.  No on
@@ -829,16 +829,6 @@ module ChapelBase {
       // re-add the task that was waiting for others to finish
       here.runningTaskCntAdd(1);
     }
-
-    // It is now safe to free the task list, because we know that all the
-    // tasks have been completed.  We could free this list when all the
-    // tasks have been started, but this seems cleaner.  The alternative
-    // would be for the tasking layer to free the elements of the list
-    // when when they are no longer needed, but then every tasking layer
-    // would have to implement the free, and it's not clear that it
-    // would be of any benefit.  Another option would be for the
-    // starting task to free its own list element.
-    __primitive("free task list", e.taskList);
   }
 
   proc _upEndCount(param countRunningTasks=true) {
@@ -1539,7 +1529,7 @@ module ChapelBase {
   pragma "no doc"
   inline proc _defaultOf(type t) where t: _sync_aux_t return _nullSyncVarAuxFields;
   pragma "no doc"
-  inline proc _defaultOf(type t) where t == _task_list return _nullTaskList;
+  inline proc _defaultOf(type t) where t == c_void_ptr return _nullVoidPtr;
 
   pragma "no doc"
   inline proc _defaultOf(type t) where t: _ddata

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -404,11 +404,9 @@ module LocaleModel {
   //
   pragma "insert line file info"
   extern proc chpl_task_addToTaskList(fn: int, args: c_void_ptr, subloc_id: int,
-                                      ref tlist: _task_list, tlist_node_id: int,
+                                      ref tlist: c_void_ptr, tlist_node_id: int,
                                       is_begin: bool);
-  extern proc chpl_task_processTaskList(tlist: _task_list);
-  extern proc chpl_task_executeTasksInList(ref tlist: _task_list);
-  extern proc chpl_task_freeTaskList(tlist: _task_list);
+  extern proc chpl_task_executeTasksInList(ref tlist: c_void_ptr);
 
   //
   // add a task to a list of tasks being built for a begin statement
@@ -417,8 +415,8 @@ module LocaleModel {
   export
   proc chpl_taskListAddBegin(subloc_id: int,        // target sublocale
                              fn: int,               // task body function idx
-                             args: c_void_ptr,           // function args
-                             ref tlist: _task_list, // task list
+                             args: c_void_ptr,      // function args
+                             ref tlist: c_void_ptr, // task list
                              tlist_node_id: int     // task list owner node
                             ) {
     chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, true);
@@ -432,20 +430,11 @@ module LocaleModel {
   export
   proc chpl_taskListAddCoStmt(subloc_id: int,        // target sublocale
                               fn: int,               // task body function idx
-                              args: c_void_ptr,           // function args
-                              ref tlist: _task_list, // task list
+                              args: c_void_ptr,      // function args
+                              ref tlist: c_void_ptr, // task list
                               tlist_node_id: int     // task list owner node
                              ) {
     chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, false);
-  }
-
-  //
-  // make sure all tasks in a list are known to the tasking layer
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListProcess(task_list: _task_list) {
-    chpl_task_processTaskList(task_list);
   }
 
   //
@@ -453,16 +442,7 @@ module LocaleModel {
   //
   pragma "insert line file info"
   export
-  proc chpl_taskListExecute(ref task_list: _task_list) {
+  proc chpl_taskListExecute(ref task_list: c_void_ptr) {
     chpl_task_executeTasksInList(task_list);
-  }
-
-  //
-  // do final cleanup for a task list
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListFree(task_list: _task_list) {
-    chpl_task_freeTaskList(task_list);
   }
 }

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -407,7 +407,7 @@ module LocaleModel {
                                       ref tlist: _task_list, tlist_node_id: int,
                                       is_begin: bool);
   extern proc chpl_task_processTaskList(tlist: _task_list);
-  extern proc chpl_task_executeTasksInList(tlist: _task_list);
+  extern proc chpl_task_executeTasksInList(ref tlist: _task_list);
   extern proc chpl_task_freeTaskList(tlist: _task_list);
 
   //
@@ -453,7 +453,7 @@ module LocaleModel {
   //
   pragma "insert line file info"
   export
-  proc chpl_taskListExecute(task_list: _task_list) {
+  proc chpl_taskListExecute(ref task_list: _task_list) {
     chpl_task_executeTasksInList(task_list);
   }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -528,7 +528,7 @@ module LocaleModel {
                                       ref tlist: _task_list, tlist_node_id: int,
                                       is_begin: bool);
   extern proc chpl_task_processTaskList(tlist: _task_list);
-  extern proc chpl_task_executeTasksInList(tlist: _task_list);
+  extern proc chpl_task_executeTasksInList(ref tlist: _task_list);
   extern proc chpl_task_freeTaskList(tlist: _task_list);
 
   //
@@ -574,7 +574,7 @@ module LocaleModel {
   //
   pragma "insert line file info"
   export
-  proc chpl_taskListExecute(task_list: _task_list) {
+  proc chpl_taskListExecute(ref task_list: _task_list) {
     chpl_task_executeTasksInList(task_list);
   }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -525,11 +525,9 @@ module LocaleModel {
   //
   pragma "insert line file info"
   extern proc chpl_task_addToTaskList(fn: int, args: c_void_ptr, subloc_id: int,
-                                      ref tlist: _task_list, tlist_node_id: int,
+                                      ref tlist: c_void_ptr, tlist_node_id: int,
                                       is_begin: bool);
-  extern proc chpl_task_processTaskList(tlist: _task_list);
-  extern proc chpl_task_executeTasksInList(ref tlist: _task_list);
-  extern proc chpl_task_freeTaskList(tlist: _task_list);
+  extern proc chpl_task_executeTasksInList(ref tlist: c_void_ptr);
 
   //
   // add a task to a list of tasks being built for a begin statement
@@ -539,7 +537,7 @@ module LocaleModel {
   proc chpl_taskListAddBegin(subloc_id: int,        // target sublocale
                              fn: int,               // task body function idx
                              args: c_void_ptr,      // function args
-                             ref tlist: _task_list, // task list
+                             ref tlist: c_void_ptr, // task list
                              tlist_node_id: int     // task list owner node
                             ) {
     chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, true);
@@ -554,19 +552,10 @@ module LocaleModel {
   proc chpl_taskListAddCoStmt(subloc_id: int,        // target sublocale
                               fn: int,               // task body function idx
                               args: c_void_ptr,      // function args
-                              ref tlist: _task_list, // task list
+                              ref tlist: c_void_ptr, // task list
                               tlist_node_id: int     // task list owner node
                              ) {
     chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, false);
-  }
-
-  //
-  // make sure all tasks in a list are known to the tasking layer
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListProcess(task_list: _task_list) {
-    chpl_task_processTaskList(task_list);
   }
 
   //
@@ -574,16 +563,7 @@ module LocaleModel {
   //
   pragma "insert line file info"
   export
-  proc chpl_taskListExecute(ref task_list: _task_list) {
+  proc chpl_taskListExecute(ref task_list: c_void_ptr) {
     chpl_task_executeTasksInList(task_list);
-  }
-
-  //
-  // do final cleanup for a task list
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListFree(task_list: _task_list) {
-    chpl_task_freeTaskList(task_list);
   }
 }

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -140,14 +140,12 @@ void chpl_task_addToTaskList(
          chpl_fn_int_t,      // function to call for task
          void*,              // argument to the function
          c_sublocid_t,       // desired sublocale
-         chpl_task_list_p*,  // task list
+         void**,             // task list
          c_nodeid_t,         // locale (node) where task list resides
          chpl_bool,          // is begin{} stmt?  (vs. cobegin or coforall)
          int,                // line at which function begins
          int32_t);          // name of file containing functions
-void chpl_task_processTaskList(chpl_task_list_p);
-void chpl_task_executeTasksInList(chpl_task_list_p*);
-void chpl_task_freeTaskList(chpl_task_list_p);
+void chpl_task_executeTasksInList(void**);
 
 //
 // Launch a task that is the logical continuation of some other task,

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -146,7 +146,7 @@ void chpl_task_addToTaskList(
          int,                // line at which function begins
          int32_t);          // name of file containing functions
 void chpl_task_processTaskList(chpl_task_list_p);
-void chpl_task_executeTasksInList(chpl_task_list_p);
+void chpl_task_executeTasksInList(chpl_task_list_p*);
 void chpl_task_freeTaskList(chpl_task_list_p);
 
 //

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -540,7 +540,7 @@ void dequeue_task(task_pool_p ptask) {
 
 void chpl_task_addToTaskList(chpl_fn_int_t fid, void* arg,
                              c_sublocid_t subloc,
-                             chpl_task_list_p* p_task_list,
+                             void** p_task_list_void,
                              int32_t task_list_locale,
                              chpl_bool is_begin_stmt,
                              int lineno,
@@ -562,7 +562,7 @@ void chpl_task_addToTaskList(chpl_fn_int_t fid, void* arg,
 
   if (task_list_locale == chpl_nodeID) {
     (void) add_to_task_pool(chpl_ftable[fid], arg, false, chpl_data,
-                            (task_pool_p*) p_task_list, is_begin_stmt,
+                            (task_pool_p*) p_task_list_void, is_begin_stmt,
                             lineno, filename);
 
   }
@@ -582,12 +582,8 @@ void chpl_task_addToTaskList(chpl_fn_int_t fid, void* arg,
 }
 
 
-void chpl_task_processTaskList(chpl_task_list_p task_list) {
-}
-
-
-void chpl_task_executeTasksInList(chpl_task_list_p* p_task_list) {
-  task_pool_p* p_task_list_head = (task_pool_p*) p_task_list;
+void chpl_task_executeTasksInList(void** p_task_list_void) {
+  task_pool_p* p_task_list_head = (task_pool_p*) p_task_list_void;
   task_pool_p curr_ptask;
   task_pool_p child_ptask;
 
@@ -669,10 +665,6 @@ void chpl_task_executeTasksInList(chpl_task_list_p* p_task_list) {
     chpl_mem_free(child_ptask, 0, 0);
 
   }
-}
-
-
-void chpl_task_freeTaskList(chpl_task_list_p task_list) {
 }
 
 

--- a/runtime/src/tasks/massivethreads/tasks-massivethreads.c
+++ b/runtime/src/tasks/massivethreads/tasks-massivethreads.c
@@ -384,7 +384,7 @@ void chpl_task_stdModulesInitialized(void) {
 }
 
 void chpl_task_addToTaskList(chpl_fn_int_t fid, void* arg, c_sublocid_t subLoc,
-    chpl_task_list_p *task_list, int32_t task_list_locale,
+    void **task_list, int32_t task_list_locale,
     chpl_bool is_begin_stmt, int lineno, c_string filename) {
   //Create a new task directly
   myth_thread_option opt;
@@ -409,15 +409,7 @@ void chpl_task_addToTaskList(chpl_fn_int_t fid, void* arg, c_sublocid_t subLoc,
   myth_detach(th);
 }
 
-void chpl_task_processTaskList(chpl_task_list_p task_list) {
-  //Nothing to do because chpl_task_list is actually not used.
-}
-
-void chpl_task_executeTasksInList(chpl_task_list_p task_list) {
-  //Nothing to do because chpl_task_list is actually not used.
-}
-
-void chpl_task_freeTaskList(chpl_task_list_p task_list) {
+void chpl_task_executeTasksInList(void** task_list) {
   //Nothing to do because chpl_task_list is actually not used.
 }
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -72,9 +72,7 @@
 /* Tasks */
 static aligned_t profile_task_yield = 0;
 static aligned_t profile_task_addToTaskList = 0;
-static aligned_t profile_task_processTaskList = 0;
 static aligned_t profile_task_executeTasksInList = 0;
-static aligned_t profile_task_freeTaskList = 0;
 static aligned_t profile_task_startMovedTask = 0;
 static aligned_t profile_task_getId = 0;
 static aligned_t profile_task_sleep = 0;
@@ -97,9 +95,7 @@ static void profile_print(void)
     /* Tasks */
     fprintf(stderr, "task yield: %lu\n", (unsigned long)profile_task_yield);
     fprintf(stderr, "task addToTaskList: %lu\n", (unsigned long)profile_task_addToTaskList);
-    fprintf(stderr, "task processTaskList: %lu\n", (unsigned long)profile_task_processTaskList);
     fprintf(stderr, "task executeTasksInList: %lu\n", (unsigned long)profile_task_executeTasksInList);
-    fprintf(stderr, "task freeTaskList: %lu\n", (unsigned long)profile_task_freeTaskList);
     fprintf(stderr, "task startMovedTask: %lu\n", (unsigned long)profile_task_startMovedTask);
     fprintf(stderr, "task getId: %lu\n", (unsigned long)profile_task_getId);
     fprintf(stderr, "task sleep: %lu\n", (unsigned long)profile_task_sleep);
@@ -798,11 +794,11 @@ int chpl_task_createCommTask(chpl_fn_p fn,
 void chpl_task_addToTaskList(chpl_fn_int_t     fid,
                              void             *arg,
                              c_sublocid_t      subloc,
-                             chpl_task_list_p *task_list,
+                             void            **task_list,
                              int32_t           task_list_locale,
                              chpl_bool         is_begin_stmt,
                              int               lineno,
-                             int32_t          filename)
+                             int32_t           filename)
 {
     chpl_bool serial_state = chpl_task_getSerial();
 
@@ -833,19 +829,9 @@ void chpl_task_addToTaskList(chpl_fn_int_t     fid,
     }
 }
 
-void chpl_task_processTaskList(chpl_task_list_p task_list)
-{
-    PROFILE_INCR(profile_task_processTaskList,1);
-}
-
-void chpl_task_executeTasksInList(chpl_task_list_p task_list)
+void chpl_task_executeTasksInList(void **task_list)
 {
     PROFILE_INCR(profile_task_executeTasksInList,1);
-}
-
-void chpl_task_freeTaskList(chpl_task_list_p task_list)
-{
-    PROFILE_INCR(profile_task_freeTaskList,1);
 }
 
 void chpl_task_startMovedTask(chpl_fn_p      fp,

--- a/test/parallel/cobegin/stonea/reports.good
+++ b/test/parallel/cobegin/stonea/reports.good
@@ -1,15 +1,15 @@
 
 - main program:0 is suspended
-- reports.chpl:6 is active
-- reports.chpl:7 is active
-- reports.chpl:8
-- reports.chpl:8 is pending
-- reports.chpl:9
-- reports.chpl:9 is pending
+- reports.chpl:N
+- reports.chpl:N
+- reports.chpl:N is active
+- reports.chpl:N is active
+- reports.chpl:N is pending
+- reports.chpl:N is pending
 --------------------------------
 Known tasks:
 Pending tasks:
 Program is deadlocked!
 Task report
-Waiting at: reports.chpl:6
-Waiting at: reports.chpl:7
+Waiting at: reports.chpl:N
+Waiting at: reports.chpl:N

--- a/test/parallel/cobegin/stonea/reports.prediff
+++ b/test/parallel/cobegin/stonea/reports.prediff
@@ -1,2 +1,3 @@
 #! /bin/sh
-sort < $2 > $2.prediff.tmp && mv $2.prediff.tmp $2
+( sed 's/\.chpl:[0-9]/.chpl:N/' < $2 | sort ) > $2.prediff.tmp \
+&& mv $2.prediff.tmp $2

--- a/test/parallel/taskPool/figueroa/QueuedTasks.chpl
+++ b/test/parallel/taskPool/figueroa/QueuedTasks.chpl
@@ -2,7 +2,7 @@ var b1, b2, b3: single bool;
 
 begin b2 = b1;
 
-begin b3 = b2;
+begin b3 = b1;
 
 writeln(here.queuedTasks(), " tasks are queued up at the moment.");
 b1 = true;


### PR DESCRIPTION
Simplify the interfaces for managing structured parallelism in the
module code and runtime.  Specifically, remove the "process task list"
and "free task list" steps, leaving us with just "add to task list" and
"execute tasks in list".  In doing so, also change the task list data
object manipulated and used by the latter two from a type known to the
compiler to just an opaque pointer.

The major functional work here is to change fifo tasking to so that it
maintains its needed task list within the task descriptors in the pool
rather than as a separate data structure.  (Side note: it needs this
task list because it cannot multiplex tasks on threads.  None of the
other tasking layer implementations need or use such a list.)

This removes three primitives, one each type and var pre-declared by the
compiler, and two procs from each locale model and runtime tasking layer
implementation.