### PR TITLE
Deprecate here.numCores.

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -59,6 +59,11 @@ module ChapelLocale {
              then if accessible then nPUsLogAcc else nPUsLogAll
              else if accessible then nPUsPhysAcc else nPUsPhysAll;
 
+    proc numCores: int {
+      compilerWarning("numCores is deprecated; please use numPUs() instead");
+      return this.numPUs(logical=true, accessible=true);
+    }
+
     var maxTaskPar: int; // max parallelism tasking layer expects to deliver
 
     proc id : int return chpl_id();  // just the node part

--- a/modules/internal/ChapelLocale_forDocs.chpl
+++ b/modules/internal/ChapelLocale_forDocs.chpl
@@ -125,6 +125,16 @@ module ChapelLocale {
              else if accessible then nPUsPhysAcc else nPUsPhysAll;
 
     /*
+      :proc:`numCores` is a deprecated predecessor to :proc:`numPUs`,
+      equivalant to `numPUs(logical=true, accessible=true)`.  It will
+      be removed after Chapel 1.13 is released.
+     */
+    proc numCores: int {
+      compilerWarning("numCores is deprecated; please use numPUs() instead");
+      return this.numPUs(logical=true, accessible=true);
+    }
+
+    /*
       This is the maximum task concurrency that one can expect to
       achieve on this locale.  The value is an estimate by the
       runtime tasking layer.  Typically it is the number of physical

--- a/test/deprecated/numCores.chpl
+++ b/test/deprecated/numCores.chpl
@@ -1,0 +1,1 @@
+if here.numCores > 0 then writeln('ok');

--- a/test/deprecated/numCores.good
+++ b/test/deprecated/numCores.good
@@ -1,0 +1,2 @@
+numCores.chpl:1: warning: numCores is deprecated; please use numPUs() instead
+ok


### PR DESCRIPTION
In #3061 I replaced here.numCores with here.numPUs(), but instead of
deprecating numCores I removed it altogether.  Here, restore it, with a
compiler warning about it being deprecated if you use it.  Also, add a
test to remind us to actually remove it after the next release.