### PR TITLE
Have non-flat locale models force wide pointers by default

### DIFF
--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -51,7 +51,6 @@
 
 class BaseAST;
 
-bool forceWidePtrs();
 bool forceWidePtrsForLocal();
 bool requireWideReferences();
 bool requireOutlinedOn();

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -61,8 +61,16 @@ static int err_print;
 static int err_ignore;
 static FnSymbol* err_fn = NULL;
 
+//
+// Chances are that all non-flat locale models will require wide
+// pointers.  Ultimately, we'd like to make such decisions be made by
+// param fields/methods within the locale models themselves, but that
+// would require a fairly large refactoring, so for now, we
+// special-case 'flat' with the expectation that most other locale
+// models will not be.
+//
 bool forceWidePtrs() {
-  return !strcmp(CHPL_LOCALE_MODEL, "numa");
+  return strcmp(CHPL_LOCALE_MODEL, "flat");
 }
 
 bool forceWidePtrsForLocal() {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -63,14 +63,14 @@ static FnSymbol* err_fn = NULL;
 
 //
 // Chances are that all non-flat locale models will require wide
-// pointers.  Ultimately, we'd like to make such decisions be made by
+// pointers.  Ultimately, we'd like to have such decisions be made by
 // param fields/methods within the locale models themselves, but that
 // would require a fairly large refactoring, so for now, we
 // special-case 'flat' with the expectation that most other locale
-// models will not be.
+// models will not be flat.
 //
-bool forceWidePtrs() {
-  return strcmp(CHPL_LOCALE_MODEL, "flat");
+static bool forceWidePtrs() {
+  return (strcmp(CHPL_LOCALE_MODEL, "flat") != 0);
 }
 
 bool forceWidePtrsForLocal() {


### PR DESCRIPTION
Like last week's PR #3137, the compiler has long been hardcoded such that only the locale model named 'numa' needs to force wide pointers.  This PR reverses the sense of that logic, saying that locale models other than 'flat' should force wide pointers by default.  As with last week's work, the assumption is that most locale models will not be flat by default.  And, as with last week, we'd ultimately like to make this a property that the locale model can assert, but that's a larger effort than we can take on now.
