### PR TITLE
Unify how 'by' and 'align' are handled by the parser

### DIFF
--- a/compiler/parser/bison-chapel.cpp
+++ b/compiler/parser/bison-chapel.cpp
@@ -5313,7 +5313,7 @@ yyreduce:
 
   case 165:
 #line 882 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pch) = "align"; }
+    { (yyval.pch) = "chpl_align"; }
 #line 5318 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
@@ -6652,7 +6652,7 @@ yyreduce:
 
   case 406:
 #line 1524 "chapel.ypp" /* yacc.c:1661  */
-    { (yyval.pexpr) = new CallExpr("align", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+    { (yyval.pexpr) = new CallExpr("chpl_align", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
 #line 6657 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -879,7 +879,7 @@ fn_ident:
 | TNOT           { $$ = "!"; }
 | TBY            { $$ = "chpl_by"; }
 | THASH          { $$ = "#"; }
-| TALIGN         { $$ = "align"; }
+| TALIGN         { $$ = "chpl_align"; }
 | TSWAP          { $$ = "<=>"; }
 | TIO            { $$ = "<~>"; }
 ;
@@ -1521,7 +1521,7 @@ binary_op_expr:
 | expr TOR  expr           { $$ = new CallExpr("||", $1, $3); }
 | expr TEXP expr           { $$ = new CallExpr("**", $1, $3); }
 | expr TBY expr            { $$ = new CallExpr("chpl_by", $1, $3); }
-| expr TALIGN expr         { $$ = new CallExpr("align", $1, $3); }
+| expr TALIGN expr         { $$ = new CallExpr("chpl_align", $1, $3); }
 | expr THASH expr          { $$ = new CallExpr("#", $1, $3); }
 | expr TDMAPPED expr       { $$ = new CallExpr("chpl__distributed", $3, $1); }
 ;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2814,6 +2814,12 @@ module ChapelArray {
     }
   }
 
+  /*
+   * The following procedure is effectively equivalent to:
+   *
+  inline proc chpl_by(a:domain, b) { ... }
+   *
+   */
   proc by(a: domain, b) {
     var r: a.rank*range(a._value.idxType,
                       BoundedRangeType.bounded,

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2819,6 +2819,7 @@ module ChapelArray {
    *
   inline proc chpl_by(a:domain, b) { ... }
    *
+   * because the parser renames the routine since 'by' is a keyword.
    */
   proc by(a: domain, b) {
     var r: a.rank*range(a._value.idxType,

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -916,6 +916,12 @@ module ChapelRange {
     return new range(i, b, true,  lw, hh, st, alt, ald);
   }
 
+  /*
+   * The following procedure is effectively equivalent to:
+   *
+  inline proc chpl_by(r, step) { ... }
+   *
+   */
   inline proc by(r, step) {
     if !isRange(r) then
       compilerError("the first argument of the 'by' operator is not a range");
@@ -923,6 +929,12 @@ module ChapelRange {
     return chpl_by_help(r, step);
   }
   
+  /*
+   * The following procedure is effectively equivalent to:
+   *
+  inline proc chpl_by(r: range(?), param step) { ... }
+   *
+   */
   // We want to warn the user at compiler time if they had an invalid param
   // stride rather than waiting until runtime.
   inline proc by(r : range(?), param step) {
@@ -931,7 +943,13 @@ module ChapelRange {
   }
   
   
-  // This is the syntax processing routine for the "align" keyword.
+  /*
+   * The following procedure is effectively equivalent to:
+   *
+  inline proc chpl_align(r: range(?i, ?b, ?s), algn: i) { ... }
+   *
+   */
+  // This is the definition of the 'align' operator for ranges.
   // It produces a new range with the specified alignment.
   // By definition, alignment is relative to the low bound of the range.
   pragma "no doc"
@@ -943,6 +961,13 @@ module ChapelRange {
                      r._low, r._high, r.stride, algn, true);
   }
 
+  
+  /*
+   * The following procedure is effectively equivalent to:
+   *
+  inline proc chpl_align(r: range(?i, ?b, ?s), algn) { ... }
+   *
+   */
   pragma "no doc"
   inline proc align(r : range(?i, ?b, ?s), algn) {
     compilerError("can't align a range with idxType ", i:string, 

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -921,6 +921,7 @@ module ChapelRange {
    *
   inline proc chpl_by(r, step) { ... }
    *
+   * because the parser renames the routine since 'by' is a keyword.
    */
   inline proc by(r, step) {
     if !isRange(r) then
@@ -934,6 +935,7 @@ module ChapelRange {
    *
   inline proc chpl_by(r: range(?), param step) { ... }
    *
+   * because the parser renames the routine since 'by' is a keyword.
    */
   // We want to warn the user at compiler time if they had an invalid param
   // stride rather than waiting until runtime.
@@ -948,6 +950,7 @@ module ChapelRange {
    *
   inline proc chpl_align(r: range(?i, ?b, ?s), algn: i) { ... }
    *
+   * because the parser renames the routine since 'align' is a keyword.
    */
   // This is the definition of the 'align' operator for ranges.
   // It produces a new range with the specified alignment.
@@ -967,6 +970,7 @@ module ChapelRange {
    *
   inline proc chpl_align(r: range(?i, ?b, ?s), algn) { ... }
    *
+   * because the parser renames the routine since 'align' is a keyword.
    */
   pragma "no doc"
   inline proc align(r : range(?i, ?b, ?s), algn) {


### PR DESCRIPTION
This commit extends PR #1351 to treat the 'align' operator the same way for unity.  It also adds comments above all module-defined overloads of 'proc by' and 'proc align' to note that they are effectively defining 'proc chpl_by' and 'proc chpl_align' to help with those grepping for the definitions in the future.  This was motivated by confusion by Elliot this afternoon.

On the downside, Elliot offered free drinks to whoever could unravel this, so by adding the comments, we are arguably limiting our future free drink opportunities.