### PR TITLE
Fix type-o in NUMA LocaleModel

### DIFF
--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -332,7 +332,7 @@ module LocaleModel {
 
     proc getChild(idx:int) return this.myLocales[idx];
 
-    iter getChlidren() : locale  {
+    iter getChildren() : locale  {
       for loc in this.myLocales do
         yield loc;
     }


### PR DESCRIPTION
This was in the original commit, but we never noticed because the function is never called.
