### PR TITLE
Suppress baseline memory leak for types/string/StringImpl/memLeaks/find

### DIFF
--- a/test/types/string/StringImpl/memLeaks/find.supressif
+++ b/test/types/string/StringImpl/memLeaks/find.supressif
@@ -1,0 +1,3 @@
+# baseline memory leak, see JIRA issue 76
+
+COMPOPTS <= --baseline


### PR DESCRIPTION
Suppress a memory leak caused by non-inlined iterator memory leaks (when the
invoking loop breaks out before the iterator is finished)

Similar to #1151, suppress a baseline memory leak (and update JIRA issue 76.)
#1151 added suppressions for leaks introduced by the original anonymous range
optimization (#1021). The leak for the "find" test was introduced with a recent
improvement to the anonymous range optimization (#3154) that optimizes cases
like `for i in low..#count`

Note that these leaks just hit a pre-existing issue, but are unrelated to the
anonymous range optimization. When I added the originally suppressions, I
really had no idea what was going on and just took Tom's word that they were
known issue that were being worked on. I dove a little deeper this time and at
least for "find" I believe this is another instance of non-inlined iterators
not being freed if the invoking loop has a break or early return. This is
basically because the `advance()` function is currently responsible for freeing
an iterator class after it's done (more == 0), but if there's a break in the
invoking loop, the advance function will never know it's done. This is a known
issue that's documented in JIRA issue 155.

The reason the anonymous range optimization triggers this is because it adds a
wrapper iterator. Previously the String.find code just called a range iterator,
which directly iterates over a c-for loop. The anonymous range optimization
replaces that with a call to a `chpl_direct_range_iter`, which invokes a
`chpl_direct_param_stride_range_iter`, which directly iterates over a c-for
loop.  This extra wrapper iterator is what's being leaked. The iterator class
invoked by the find code is still freed, but it is the iterator class that
iterator invokes that's not being freed. Normally this isn't an issue because
the wrapper iterators can be fully inlined, but iterator inlining is turned off
with `--baseline`

Note that while this fails with `--baseline` all thats required to get the
failure is `--no-inline-iterators --no-optimize-loop-iterators`. For now I'm
just adding a suppression and updating the JIRA issues with more info