### PR TITLE
Repair the type of a ref to a "task list".

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -375,7 +375,7 @@ bundleArgs(CallExpr* fcall, BundleArgsFnData &baData) {
 
     // Now get the taskList field out of the end count.
 
-    taskList = newTemp(astr("_taskList", fn->name), dtCVoidPtr);
+    taskList = newTemp(astr("_taskList", fn->name), dtCVoidPtr->refType);
 
     // If the end count is a reference, dereference it.
     // EndCount is a class.
@@ -458,7 +458,7 @@ static void create_block_fn_wrapper(FnSymbol* fn, CallExpr* fcall, BundleArgsFnD
   } else {
     // create a task list argument.
     ArgSymbol *taskListArg = new ArgSymbol( INTENT_IN, "dummy_taskList", 
-                                            dtCVoidPtr );
+                                            dtCVoidPtr->refType );
     taskListArg->addFlag(FLAG_NO_CODEGEN);
     wrap_fn->insertFormalAtTail(taskListArg);
     ArgSymbol *taskListNode = new ArgSymbol( INTENT_IN, "dummy_taskListNode", 


### PR DESCRIPTION
In #3178 I changed the type of the "task list" argument to the tasking
interface functions for structured parallelism.  Unfortunately in one
spot having to do with that type, I dropped a "reference to" qualifier.
I had meant to check with someone about that code (being unfamiliar with
the compiler), but forgot to do so.  Fix that.