### PR TITLE
Sub_test: say when diff-ignoring-module-line-numbers is being used.

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -301,7 +301,7 @@ def DiffFiles(f1, f2):
 # diff output vs. .bad file, filtering line numbers out of error messages that arise
 # in module files.
 def DiffBadFiles(f1, f2):
-    sys.stdout.write('[Executing diff %s %s]\n'%(f1, f2))
+    sys.stdout.write('[Executing diff-ignoring-module-line-numbers %s %s]\n'%(f1, f2))
     p = subprocess.Popen([utildir+'/test/diff-ignoring-module-line-numbers', f1, f2],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock


### PR DESCRIPTION
I was confused by some start_test output, not realizing that when it
said 'diff <test>.bad <test>.comp.out.tmp' it was not actually running
'diff' but rather 'diff-ignoring-module-line-numbers'.  Adjust the
output to say so.