### PR TITLE
Get an interactive shell before deleting old SF files

### DIFF
--- a/util/cron/syncPerfGraphs.py
+++ b/util/cron/syncPerfGraphs.py
@@ -60,6 +60,12 @@ def syncToSourceForge(dirToSync, destDir, logFile):
     sfPerfBaseDir = '/home/project-web/chapel/htdocs/perf/'
     sfPerfDir = posixpath.join(sfPerfBaseDir, destDir)
 
+    # create an interactive shell on sourceforge and immediately exit, which
+    # allows us to do regular ssh commands (SF security thing)
+    getShellCommand = 'ssh chapeladmin,chapel@{0} create '.format(sfShellHost)
+    getShellDesc = 'create interactive sourceforge shell'
+    executeCommand(getShellCommand, getShellDesc, logFile)
+
     # Delete files older than 10 days. Don't just use `rsync --del` because
     # there might be subdirectories we don't want to delete, ignore errors
     delOldCommand = 'ssh {0} "find {1} -ctime +10 | xargs rm -rf "'.format(sfShellHost, sfPerfDir)


### PR DESCRIPTION
You can't just run arbitrary ssh commands on SF, you have to first create an
interactive shell using `ssh USER,PROJECT@shell.sourceforge.net create` before
executing ssh commands. When I was testing, I had already done this outside of
running the tests so I didn't realize I needed to do it in the script as well.