### PR TITLE
Fix pychapel testing by removing duplicate chpl-linefile-support.c src

### DIFF
--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -36,7 +36,6 @@ COMMON_NOGEN_SRCS = \
 	chpl-file-utils.c \
 	chplgmp.c \
 	chplio.c \
-	chpl-linefile-support.c \
 	chpl-mem.c \
 	chpl-mem-desc.c \
 	chpl-mem-hook.c \


### PR DESCRIPTION
chpl-linefile-support.c was added to `COMMON_LAUNCHER_SRCS` with #3049.
However, it was already in `COMMON_NOGEN_SRCS` and `COMMON_NOGEN_SRCS` includes
`COMMON_LAUNCHER_SRCS` so we were grabbing chpl-linefile-support.c twice. This
caused multiple definitions of the functions in chpl-linefile-support.c to be
seen.