### PR TITLE
Add .suppressif for baseline

### DIFF
--- a/test/studies/labelprop/labelprop-tweets.suppressif
+++ b/test/studies/labelprop/labelprop-tweets.suppressif
@@ -1,0 +1,2 @@
+# compilation error ITE0227 with baseline
+COMPOPTS <= --baseline

--- a/test/studies/labelprop/labelprop-tweets.suppressif
+++ b/test/studies/labelprop/labelprop-tweets.suppressif
@@ -1,2 +1,4 @@
 # compilation error ITE0227 with baseline
+# This is almost certainly a bug. Suppresing it for now
+# in order to avoid the testing noise.
 COMPOPTS <= --baseline


### PR DESCRIPTION
Adds a suppression for this test, which fails to compile with --baseline.

This failure is almost certainly a bug and needs to be investigated. This
PR will quiet testing in the meantime.
