### PR TITLE
Fix labelprop-tweets baseline regression

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -224,8 +224,8 @@ static void replaceLocalWithFieldTemp(SymExpr*       se,
   if (call && call->isPrimitive(PRIM_GET_MEMBER)) {
     // Get member returns the address of the member, so we convert the
     // type of the corresponding temp to a reference type.
-    INT_ASSERT(tmp->type->refType);
-    tmp->type = tmp->type->refType;
+    INT_ASSERT(tmp->type->getRefType());
+    tmp->type = tmp->type->getRefType();
   }
 
   // OK, insert the declaration.

--- a/test/studies/labelprop/labelprop-tweets.suppressif
+++ b/test/studies/labelprop/labelprop-tweets.suppressif
@@ -1,4 +1,0 @@
-# compilation error ITE0227 with baseline
-# This is almost certainly a bug. Suppresing it for now
-# in order to avoid the testing noise.
-COMPOPTS <= --baseline


### PR DESCRIPTION
The recently add labelprop-tweets tests was regressing with baseline because
the refType wasn't set for a tmp in `replaceLocalWithFieldTemp()`, leading to a
failed INT_ASSERT(). This just replaces a use of `<type>.retType` with
`<type>.getRefType()`. getRefType() includes logic to check if the current type
is a ref or wide ref, before checking `<type>.retType`