### PR TITLE
Remove c_string to string coercions

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1302,8 +1302,6 @@ canCoerce(Type* actualType, Symbol* actualSym, Type* formalType, FnSymbol* fn, b
   }
   if (actualType->symbol->hasFlag(FLAG_REF))
     return canDispatch(actualType->getValType(), NULL, formalType, fn, promotes);
-  if (formalType == dtString && actualType == dtStringC)
-    return true;
   if (formalType == dtString && actualType == dtStringCopy)
     return true;
   if (formalType == dtStringC && actualType == dtStringCopy)

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -847,7 +847,7 @@ module ChapelBase {
   }
 
   pragma "command line setting"
-  proc _command_line_cast(param s: c_string, type t, x) return _cast(t, x);
+  proc _command_line_cast(param s: c_string, type t, x) return _cast(t, x:string);
 
 
   //

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1340,9 +1340,9 @@ module String {
   proc chpldev_refToString(ref arg) : string {
     // print out the address of class references as well
     proc chpldev_classToString(x: object) : string
-      return " (class = " + __primitive("ref to string", x) + ")";
+      return " (class = " + __primitive("ref to string", x):string + ")";
     proc chpldev_classToString(x) : string return "";
 
-    return __primitive("ref to string", arg) + chpldev_classToString(arg);
+    return __primitive("ref to string", arg):string + chpldev_classToString(arg);
   }
 }

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -32,21 +32,19 @@ module StringCasts {
   //
   // Bool
   //
-  const _true_s: string = "true";
-  const _false_s: string = "false";
 
   inline proc _cast(type t, x: bool) where t == string {
     if (x) {
-      return _true_s;
+      return "true";
     } else {
-      return _false_s;
+      return "false";
     }
   }
 
   proc _cast(type t, x: string) where t == bool {
-    if (x == _true_s) {
+    if (x == "true") {
       return true;
-    } else if (x == _false_s) {
+    } else if (x == "false") {
       return false;
     } else {
       halt("Unexpected value when converting from string to bool: '"+x+"'");

--- a/modules/standard/Error.chpl
+++ b/modules/standard/Error.chpl
@@ -97,11 +97,9 @@ proc ioerror(error:syserr, msg:string)
 proc ioerror(error:syserr, msg:string, path:string)
 {
   if( error ) {
-    var errstr:c_string;
-    var quotedpath:c_string;
     var strerror_err:err_t = ENOERR;
-    errstr = sys_strerror_syserr_str(error, strerror_err);
-    quotedpath = quote_string(path, path.length:ssize_t);
+    const errstr = sys_strerror_syserr_str(error, strerror_err):string;
+    const quotedpath = quote_string(path, path.length:ssize_t):string;
     const err_msg: string = errstr + " " + msg + " with path " + quotedpath;
     __primitive("chpl_error", err_msg.c_str());
   }
@@ -121,11 +119,9 @@ proc ioerror(error:syserr, msg:string, path:string)
 proc ioerror(error:syserr, msg:string, path:string, offset:int(64))
 {
   if( error ) {
-    var errstr:c_string;
-    var quotedpath:c_string;
     var strerror_err:err_t = ENOERR;
-    errstr = sys_strerror_syserr_str(error, strerror_err);
-    quotedpath = quote_string(path, path.length:ssize_t);
+    const errstr = sys_strerror_syserr_str(error, strerror_err): string;
+    const quotedpath = quote_string(path, path.length:ssize_t): string;
     const err_msg: string = errstr + " " + msg + " with path " + quotedpath + " offset " + offset:string;
     __primitive("chpl_error", err_msg.c_str());
   }
@@ -147,8 +143,7 @@ proc ioerror(error:syserr, msg:string, path:string, offset:int(64))
  */
 proc ioerror(errstr:string, msg:string, path:string, offset:int(64))
 {
-  var quotedpath:c_string;
-  quotedpath = quote_string(path, path.length:ssize_t);
+  const quotedpath = quote_string(path, path.length:ssize_t): string;
   const err_msg = errstr + " " + msg + " with path " + quotedpath + " offset " + offset:string;
   __primitive("chpl_error", err_msg.c_str());
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6321,16 +6321,13 @@ proc channel.skipField() {
 }
 
 
-//
-// TODO: Should _do_format take a string rather than a c_string?
-//
-private inline proc _do_format(fmt:c_string, args ...?k, out error:syserr):string {
+private inline proc chpl_do_format(fmt:string, args ...?k, out error:syserr):string {
   // Open a memory buffer to store the result
   var f = openmem();
 
   var w = f.writer(locking=false);
 
-  w.writef(fmt:string, (...args), error=error);
+  w.writef(fmt, (...args), error=error);
 
   var offset = w.offset();
 
@@ -6373,14 +6370,14 @@ proc format(fmt:string, args ...?k):string {
 
  */
 proc string.format(args ...?k, out error:syserr):string {
-  return _do_format(this.localize().c_str(), (...args), error);
+  return chpl_do_format(this, (...args), error);
 }
 
 // documented in the error= version
 pragma "no doc"
 proc string.format(args ...?k):string {
   var err:syserr = ENOERR;
-  var ret = _do_format(this.localize().c_str(), (...args), error=err);
+  var ret = chpl_do_format(this, (...args), error=err);
   if err then ioerror(err, "in string.format");
   return ret;
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3800,13 +3800,17 @@ inline proc channel.readwrite(ref x) where !this.writing {
    */
   inline proc channel.readWriteLiteral(lit:string, ignoreWhiteSpace=true)
   {
-    this.readWriteLiteral(lit.c_str(), ignoreWhiteSpace);
+    var iolit = new ioLiteral(lit:string, ignoreWhiteSpace);
+    this.readwrite(iolit);
   }
+
+  //
+  // TODO: Do we still want this?
+  //
   pragma "no doc"
   inline proc channel.readWriteLiteral(lit:c_string, ignoreWhiteSpace=true)
   {
-    var iolit = new ioLiteral(lit, ignoreWhiteSpace);
-    this.readwrite(iolit);
+    this.readWriteLiteral(lit, ignoreWhiteSpace);
   }
 
   /* Explicit call for reading or writing a newline as an

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6321,13 +6321,16 @@ proc channel.skipField() {
 }
 
 
+//
+// TODO: Should _do_format take a string rather than a c_string?
+//
 private inline proc _do_format(fmt:c_string, args ...?k, out error:syserr):string {
   // Open a memory buffer to store the result
   var f = openmem();
 
   var w = f.writer(locking=false);
 
-  w.writef(fmt, (...args), error=error);
+  w.writef(fmt:string, (...args), error=error);
 
   var offset = w.offset();
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3804,15 +3804,6 @@ inline proc channel.readwrite(ref x) where !this.writing {
     this.readwrite(iolit);
   }
 
-  //
-  // TODO: Do we still want this?
-  //
-  pragma "no doc"
-  inline proc channel.readWriteLiteral(lit:c_string, ignoreWhiteSpace=true)
-  {
-    this.readWriteLiteral(lit, ignoreWhiteSpace);
-  }
-
   /* Explicit call for reading or writing a newline as an
      alternative to using :type:`IO.ioNewline`.
    */

--- a/test/execflags/shannon/configs/configVarInvalidBoolean.good
+++ b/test/execflags/shannon/configs/configVarInvalidBoolean.good
@@ -1,1 +1,1 @@
-<command line setting of 'x'>: error: Unexpected value when converting from string to bool: 'maybe'
+<command line setting of 'x'>: error: halt reached - Unexpected value when converting from string to bool: 'maybe'

--- a/test/types/string/StringImpl/memLeaks/concat.chpl
+++ b/test/types/string/StringImpl/memLeaks/concat.chpl
@@ -184,9 +184,9 @@ module unitTest {
       const s: t = "s";
       const cs: c_string = "0";
       if useExpr {
-        writeMe(s+cs);
+        writeMe(s+cs:string);
       } else {
-        const scs = s+cs;
+        const scs = s+cs:string;
         writeMe(scs);
       }
     }
@@ -200,9 +200,9 @@ module unitTest {
       const cs: c_string = "s";
       const s: t = "0";
       if useExpr {
-        writeMe(cs+s);
+        writeMe(cs:string+s);
       } else {
-        const css = cs+s;
+        const css = cs:string+s;
         writeMe(css);
       }
     }
@@ -217,9 +217,9 @@ module unitTest {
       on Locales[numLocales-1] {
         const cs: c_string = "r";
         if useExpr {
-          writeMe(s+cs);
+          writeMe(s+cs:string);
         } else {
-          const scs = s+cs;
+          const scs = s+cs:string;
           writeMe(scs);
         }
       }
@@ -235,9 +235,9 @@ module unitTest {
       on Locales[numLocales-1] {
         const cs: c_string = "s";
         if useExpr {
-          writeMe(cs+s);
+          writeMe(cs:string+s);
         } else {
-          const css = cs+s;
+          const css = cs:string+s;
           writeMe(css);
         }
       }

--- a/test/types/string/sungeun/c_string/casts.chpl
+++ b/test/types/string/sungeun/c_string/casts.chpl
@@ -19,8 +19,8 @@ writeln(cstri:imag(32));
 writeln(cstri:imag(64));
 writeln(cstrc:complex(64));
 writeln(cstrc:complex(128));
-writeln(cstrE:E);
-writeln(cstrB:bool);
+writeln(cstrE:string:E);
+writeln(cstrB:string:bool);
 
 for param i in 1..4 do writeln(vcstr:uint(4<<i));
 for param i in 1..4 do writeln(vcstr:int(4<<i));
@@ -30,8 +30,8 @@ writeln(vcstri:imag(32));
 writeln(vcstri:imag(64));
 writeln(vcstrc:complex(64));
 writeln(vcstrc:complex(128));
-writeln(vcstrE:E);
-writeln(vcstrB:bool);
+writeln(vcstrE:string:E);
+writeln(vcstrB:string:bool);
 
 for param i in 1..4 do writeln(str:uint(4<<i));
 for param i in 1..4 do writeln(str:int(4<<i));

--- a/test/types/string/sungeun/c_string/concat.chpl
+++ b/test/types/string/sungeun/c_string/concat.chpl
@@ -4,42 +4,42 @@ use checkType;
 checkType(c_string, (c"8"+n).type);
 checkType(string, ("8"+n).type);
 checkType(c_string, (cstr+n).type);
-checkType(string, (vcstr+n).type);
+checkType(string, (vcstr:string+n).type);
 checkType(string, ("8"+nn).type);
-checkType(string, (cstr+nn).type);
-checkType(string, (vcstr+nn).type);
+checkType(string, (cstr:string+nn).type);
+checkType(string, (vcstr:string+nn).type);
 
 checkType(string, ("8"+r).type);   // no param c_string cast from real
-checkType(string, (cstr+r).type);  // no param c_string cast from real
-checkType(string, (vcstr+r).type);
+checkType(string, (cstr:string+r).type);  // no param c_string cast from real
+checkType(string, (vcstr:string+r).type);
 checkType(string, ("8"+rr).type);
-checkType(string, (cstr+rr).type);
-checkType(string, (vcstr+rr).type);
+checkType(string, (cstr:string+rr).type);
+checkType(string, (vcstr:string+rr).type);
 
 checkType(string, ("8"+i).type);   // no param c_string cast from imag
-checkType(string, (cstr+i).type);  // no param c_string cast from imag
-checkType(string, (vcstr+i).type);
+checkType(string, (cstr:string+i).type);  // no param c_string cast from imag
+checkType(string, (vcstr:string+i).type);
 checkType(string, ("8"+ii).type);
-checkType(string, (cstr+ii).type);
-checkType(string, (vcstr+ii).type);
+checkType(string, (cstr:string+ii).type);
+checkType(string, (vcstr:string+ii).type);
 
 checkType(string, ("8"+c).type);   // no param complex
-checkType(string, (cstr+c).type);
-checkType(string, (vcstr+c).type);
+checkType(string, (cstr:string+c).type);
+checkType(string, (vcstr:string+c).type);
 
 checkType(c_string, (c"8"+e).type);
 checkType(string, ("8"+e).type);
 checkType(c_string, (cstr+e).type);
-checkType(string, (vcstr+e).type);
+checkType(string, (vcstr:string+e).type);
 checkType(string, ("8"+ee).type);
-checkType(string, (cstr+ee).type);
-checkType(string, (vcstr+ee).type);
+checkType(string, (cstr:string+ee).type);
+checkType(string, (vcstr:string+ee).type);
 
 checkType(c_string, (c"8"+b).type);
 checkType(string, ("8"+b).type);
 checkType(c_string, (cstr+b).type);
-checkType(string, (vcstr+b).type);
+checkType(string, (vcstr:string+b).type);
 checkType(string, ("8"+bb).type);
-checkType(string, (cstr+bb).type);
-checkType(string, (vcstr+bb).type);
+checkType(string, (cstr:string+bb).type);
+checkType(string, (vcstr:string+bb).type);
 

--- a/test/types/string/sungeun/c_string/intents-error2.good
+++ b/test/types/string/sungeun/c_string/intents-error2.good
@@ -1,2 +1,1 @@
-intents.chpl:38: error: unresolved call 'fo(c_string)'
-intents.chpl:7: note: candidates are: fo(out s: string)
+intents.chpl:38: error: non-lvalue actual is passed to 'out' formal 's' of fo()

--- a/test/types/string/sungeun/c_string/intents-error3.good
+++ b/test/types/string/sungeun/c_string/intents-error3.good
@@ -1,2 +1,1 @@
-intents.chpl:41: error: unresolved call 'fio(c_string)'
-intents.chpl:8: note: candidates are: fio(inout s: string)
+intents.chpl:41: error: non-lvalue actual is passed to 'inout' formal 's' of fio()

--- a/test/types/string/sungeun/c_string/intents-error4.good
+++ b/test/types/string/sungeun/c_string/intents-error4.good
@@ -1,2 +1,1 @@
-intents.chpl:44: error: unresolved call 'fr(c_string)'
-intents.chpl:9: note: candidates are: fr(ref s: string)
+intents.chpl:44: error: non-lvalue actual is passed to 'ref' formal 's' of fr()

--- a/test/types/string/sungeun/c_string/intents.chpl
+++ b/test/types/string/sungeun/c_string/intents.chpl
@@ -32,13 +32,13 @@ if errorCase == 1 {
 
 var s: c_string = "hi";
 s += s;
-f(s);
-fi(s);
+f(s:string);
+fi(s:string);
 if errorCase == 2 then
-   fo(s);
+  fo(s:string);
 
 if errorCase == 3 then
-   fio(s);
+  fio(s:string);
 
 if errorCase == 4 then
-   fr(s);
+  fr(s:string);


### PR DESCRIPTION
This PR removes coercions from c_strings to strings.  We're moving in a direction where the intention is that c_strings should not need to be used by typical Chapel programmers unless they are trying to call out to C or receive a string in from C.  To that end, lots of the old code that was put in when all string literals and param strings were necessarily c_strings is becoming stuff that we'd like to retire.  This PR takes a step in that direction by making c_strings not coerce to strings -- specifically, passing c_strings into Chapel routines that are expecting Chapel strings is something we think should happen manually (through a cast), not automatically (through a coercion).

The change here is simple -- removing one case from canCoerce() (two other related coercions remain as future work, I timed out).  The bigger effort was updating the modules and tests to fix cases that had been relying on the coercions.  These changes are as follows:

* casting c_strings received from command-line arguments setting configs into strings in order to be able to cast them to the actual config type
* making calls to the "ref to string" primitive cast their c_string results to strings before using them
* changing variables in Error.chpl from c_strings to strings (and vars to consts while here)
* removing the readWriteLiteral overload for c_strings and just keeping the string version around
* changed _do_format to take a string rather than a c_string to avoid some unnecessary string->c_string->string sloshing, some of which dated from a time when we were nervous about leaking strings apparently (while here, I also renamed the routine to chpl_do_format to reflect the current preferred way of "reserving" symbol names)
* added c_string to string casts for many of Sung's c_string tests, though in doing this, I can't help but wonder whether we should be aggressively retiring some of these tests, as they are not testing properties of c_strings anymore (and cannot, since you can do less and less with c_strings...).

A few changes were more mysterious (but got us into a more satisfying state anyway):

* replacing the named "true" and "false" constants used for string<->bool casts with literals.  For some reason, there was an order of evaluation/setup issue in which the constants were used prior to having their value established, and this caused some failures.
* added a "halt reached -" string to a .good file for a test that apparently hadn't been creating one before.  I think that this relates to the above issue, but can't explain why it hasn't always printed this.
