### PR TITLE
Replace 'uint' with 'unsigned int'

### DIFF
--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright 2004-2016 Cray Inc.  Other additional copyright holders
- * may be indicated within.
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright 2004-2016 Cray Inc.
- * Other additional copyright holders may be indicated within.
+ * Copyright 2004-2016 Cray Inc.  Other additional copyright holders
+ * may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -241,11 +241,11 @@ bool UseStmt::skipSymbolSearch(const char* name) {
 
 bool UseStmt::matchedNameOrConstructor(const char* name) {
   for_vector(const char, toCheck, named) {
-    uint constructorLen = strlen(toCheck) + strlen("_construct_");
+    unsigned int constructorLen = strlen(toCheck) + strlen("_construct_");
     char constructorName[constructorLen];
     strcpy(constructorName, "_construct_");
     strcat(constructorName, toCheck);
-    uint typeConstLen = constructorLen + strlen("_type");
+    unsigned int typeConstLen = constructorLen + strlen("_type");
     char typeConstructorName[typeConstLen];
     strcpy(typeConstructorName, "_type_construct_");
     strcat(typeConstructorName, toCheck);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2380,7 +2380,7 @@ bool UseStmt::providesNewSymbols(UseStmt* other) {
       // Other also has an 'except' list.
       if (other->named.size() <= named.size()) {
         // We are excluding more symbols than other, or the same number
-        uint numSame = 0;
+        unsigned int numSame = 0;
         for_vector(const char, exclude, other->named) {
           if (std::find(named.begin(), named.end(), exclude) != named.end())
             numSame++;
@@ -2422,7 +2422,7 @@ bool UseStmt::providesNewSymbols(UseStmt* other) {
       // providing symbols not available in other.
       return true;
     } else {
-      uint numSame = 0;
+      unsigned int numSame = 0;
       for_vector(const char, include, named) {
         if (std::find(other->named.begin(), other->named.end(), include) != other->named.end()) {
           numSame++;


### PR DESCRIPTION
uint is not standard C and can't be relied on to be portable.  It
isn't supported by gnu on darwin, e.g.