### PR TITLE
Initializing 'except' field in module-only UseStmt constructor

### DIFF
--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -99,6 +99,7 @@ UseStmt::UseStmt(BaseAST* module):
   } else {
     INT_FATAL(this, "Bad mod in UseStmt constructor");
   }
+  except = false;
   gUseStmts.add(this);
 }
 


### PR DESCRIPTION
I took a quick look at the valgrind errors from last night, and it seemed that it was a case of UseStmt::except not being initialized in one of the two constructors.  This PR makes that adjustment and seems to fix the valgrind error in the one case I checked while also passing all testing on test/visibility.  I think @lydia-duncan or @noakesmichael need to review before this goes in, though, and should recommend more testing if that would be wise.

(Someone should feel free to adopt this branch as well if they like -- I'm about to time out for today).
