### PR TITLE
Tweak .bad file to convert c_string to string to respond to explicit casts

### DIFF
--- a/test/classes/hannah/configSyncsNotSupported.bad
+++ b/test/classes/hannah/configSyncsNotSupported.bad
@@ -1,1 +1,1 @@
-configSyncsNotSupported.chpl:1: error: illegal cast from c_string to _syncvar(int(64))
+configSyncsNotSupported.chpl:1: error: illegal cast from string to _syncvar(int(64))


### PR DESCRIPTION
Brad removed implicit casts from c_string to string and then inserted explicit casts.
This resulted in a trivial change to the error message.

Tested but no review
