### PR TITLE
Revise memleaks stats for no-local after c_string -> string casts

### DIFF
--- a/test/memory/shannon/printFinalMemStat.no-local.good
+++ b/test/memory/shannon/printFinalMemStat.no-local.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  505
-Total Allocated Memory                 2281
-Total Freed Memory                     2025
+Total Allocated Memory                 2137
+Total Freed Memory                     1881
 ==============================================================


### PR DESCRIPTION
Replace an implicit cast from c_string to string in the compiler with an explicit cast in the module
code resulted in a minor change to memLeaks stats for memory/shannon/printFinalMemStat
under no-local.  The leakage is unchanged but the memory use is slightly reduced.  Tweaked
the .good file for no-local.

Tested but not reviewed
