### PR TITLE
Revise memleaks stats for no-local/numa after c_string -> string casts

### DIFF
--- a/test/memory/shannon/printFinalMemStat.lm-numa.good
+++ b/test/memory/shannon/printFinalMemStat.lm-numa.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  368
-Total Allocated Memory                 960
-Total Freed Memory                     704
+Total Allocated Memory                 880
+Total Freed Memory                     624
 ==============================================================

--- a/test/memory/shannon/printFinalMemStat.no-local.good
+++ b/test/memory/shannon/printFinalMemStat.no-local.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  505
-Total Allocated Memory                 2281
-Total Freed Memory                     2025
+Total Allocated Memory                 2137
+Total Freed Memory                     1881
 ==============================================================


### PR DESCRIPTION
The amount of memory leaked in memory/shannon/printFinalMemStat is the 
same as before but the total memory used is slightly lower both configurations

Tested but not reviewed
