### PR TITLE
Clarify business logic for CallExpr::isResolved()

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -117,7 +117,7 @@ bool AstDump::enterCallExpr(CallExpr* node) {
     newline();
   }
 
-  if (FnSymbol* fn = node->isResolved()) {
+  if (FnSymbol* fn = node->theFnSymbol()) {
     if (fn->hasFlag(FLAG_BEGIN_BLOCK))
       write("begin");
     else if (fn->hasFlag(FLAG_ON_BLOCK))

--- a/compiler/AST/AstDumpToHtml.cpp
+++ b/compiler/AST/AstDumpToHtml.cpp
@@ -166,7 +166,7 @@ bool AstDumpToHtml::enterCallExpr(CallExpr* node) {
 
   fprintf(mFP, " ");
 
-  if (FnSymbol* fn = node->isResolved()) {
+  if (FnSymbol* fn = node->theFnSymbol()) {
     if (fn->hasFlag(FLAG_BEGIN_BLOCK))
       fprintf(mFP, "begin ");
     else if (fn->hasFlag(FLAG_ON_BLOCK))

--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -861,7 +861,7 @@ bool AstDumpToNode::enterCallExpr(CallExpr* node)
   else
     newline();
 
-  if (FnSymbol* fn = node->isResolved())
+  if (FnSymbol* fn = node->theFnSymbol())
   {
     if (fn->hasFlag(FLAG_BEGIN_BLOCK))
       write("begin");

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -244,7 +244,6 @@ void reset_ast_loc(BaseAST* destNode, astlocT astlocArg) {
   AST_CHILDREN_CALL(destNode, reset_ast_loc, astlocArg);
 }
 
-
 void compute_call_sites() {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     if (fn->calledBy)
@@ -252,16 +251,23 @@ void compute_call_sites() {
     else
       fn->calledBy = new Vec<CallExpr*>();
   }
+
   forv_Vec(CallExpr, call, gCallExprs) {
-    if (FnSymbol* fn = call->isResolved()) {
+    if (call->isEmpty() == true) {
+
+    } else if (FnSymbol* fn = call->isResolved()) {
       fn->calledBy->add(call);
+
     } else if (call->isPrimitive(PRIM_FTABLE_CALL)) {
       // sjd: do we have to do anything special here?
       //      should this call be added to some function's calledBy list?
+
     } else if (call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
-      FnSymbol* fn = toFnSymbol(toSymExpr(call->get(1))->var);
+      FnSymbol*       fn       = toFnSymbol(toSymExpr(call->get(1))->var);
       Vec<FnSymbol*>* children = virtualChildrenMap.get(fn);
+
       fn->calledBy->add(call);
+
       forv_Vec(FnSymbol, child, *children)
         child->calledBy->add(call);
     }

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3722,6 +3722,10 @@ CallExpr::insertAtTail(BaseAST* ast) {
 }
 
 
+bool CallExpr::isEmpty() const {
+  return primitive == NULL && baseExpr == NULL;
+}
+
 FnSymbol* CallExpr::isResolved() const {
   return resolvedFunction();
 }

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3788,14 +3788,16 @@ Type* CallExpr::typeInfo(void) {
 }
 
 void CallExpr::prettyPrint(std::ostream *o) {
-  if (isResolved()) {
-    if (isResolved()->hasFlag(FLAG_BEGIN_BLOCK))
+  if (FnSymbol* fn = theFnSymbol()) {
+    if      (fn->hasFlag(FLAG_BEGIN_BLOCK))
       *o << "begin";
-    else if (isResolved()->hasFlag(FLAG_ON_BLOCK))
+    else if (fn->hasFlag(FLAG_ON_BLOCK))
       *o << "on";
   }
-  bool array = false;
+
+  bool array   = false;
   bool unusual = false;
+
   if (baseExpr != NULL) {
     if (UnresolvedSymExpr *expr = toUnresolvedSymExpr(baseExpr)) {
       if (strcmp(expr->unresolved, "*") == 0){

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3726,6 +3726,7 @@ bool CallExpr::isEmpty() const {
   return primitive == NULL && baseExpr == NULL;
 }
 
+// MDN 2016/01/29: This will become a predicate
 FnSymbol* CallExpr::isResolved() const {
   return resolvedFunction();
 }
@@ -3734,8 +3735,43 @@ FnSymbol* CallExpr::isResolved() const {
 FnSymbol* CallExpr::resolvedFunction() const {
   FnSymbol* retval = NULL;
 
-  if (SymExpr* base = toSymExpr(baseExpr))
-    retval = toFnSymbol(base->var);
+  // A PRIM-OP
+  if (primitive != NULL) {
+    INT_ASSERT(baseExpr  == NULL);
+
+  // A Chapel call
+  } else if (baseExpr != NULL) {
+    INT_ASSERT(primitive == NULL);
+
+    if (isUnresolvedSymExpr(baseExpr) == true) {
+
+    } else if (SymExpr* base = toSymExpr(baseExpr)) {
+      if (FnSymbol* fn = toFnSymbol(base->var)) {
+        retval = toFnSymbol(base->var);
+
+      // Probably an array index
+      } else if (isArgSymbol(base->var)  == true ||
+                 isVarSymbol(base->var)  == true) {
+
+      // A type specifier
+      } else if (isTypeSymbol(base->var) == true) {
+
+      } else {
+        INT_ASSERT(false);
+      }
+
+    } else if (CallExpr* subCall = toCallExpr(baseExpr)) {
+      // Confirm that this is a partial call
+      INT_ASSERT(subCall->partialTag == true);
+
+    } else {
+      INT_ASSERT(false);
+    }
+
+  // The CallExpr has been purged during resolve
+  } else {
+    INT_ASSERT(false);
+  }
 
   return retval;
 }

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3722,9 +3722,28 @@ CallExpr::insertAtTail(BaseAST* ast) {
 }
 
 
-FnSymbol* CallExpr::isResolved(void) {
-  SymExpr* base = toSymExpr(baseExpr);
-  return base ? toFnSymbol(base->var) : NULL;
+FnSymbol* CallExpr::isResolved() const {
+  return resolvedFunction();
+}
+
+
+FnSymbol* CallExpr::resolvedFunction() const {
+  FnSymbol* retval = NULL;
+
+  if (SymExpr* base = toSymExpr(baseExpr))
+    retval = toFnSymbol(base->var);
+
+  return retval;
+}
+
+
+FnSymbol* CallExpr::theFnSymbol() const {
+  FnSymbol* retval = NULL;
+
+  if (SymExpr* base = toSymExpr(baseExpr))
+    retval = toFnSymbol(base->var);
+
+  return retval;
 }
 
 

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3726,6 +3726,7 @@ bool CallExpr::isEmpty() const {
   return primitive == NULL && baseExpr == NULL;
 }
 
+
 // MDN 2016/01/29: This will become a predicate
 FnSymbol* CallExpr::isResolved() const {
   return resolvedFunction();
@@ -3741,13 +3742,11 @@ FnSymbol* CallExpr::resolvedFunction() const {
 
   // A Chapel call
   } else if (baseExpr != NULL) {
-    INT_ASSERT(primitive == NULL);
-
     if (isUnresolvedSymExpr(baseExpr) == true) {
 
     } else if (SymExpr* base = toSymExpr(baseExpr)) {
       if (FnSymbol* fn = toFnSymbol(base->var)) {
-        retval = toFnSymbol(base->var);
+        retval = fn;
 
       // Probably an array index
       } else if (isArgSymbol(base->var)  == true ||

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -203,6 +203,9 @@ class CallExpr : public Expr {
   void            insertAtHead(BaseAST* ast);
   void            insertAtTail(BaseAST* ast);
 
+  // True if the callExpr has been emptied (aka dead)
+  bool            isEmpty()                                              const;
+
   FnSymbol*       isResolved()                                           const;
   FnSymbol*       resolvedFunction()                                     const;
 

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -203,7 +203,11 @@ class CallExpr : public Expr {
   void            insertAtHead(BaseAST* ast);
   void            insertAtTail(BaseAST* ast);
 
-  FnSymbol*       isResolved();
+  FnSymbol*       isResolved()                                           const;
+  FnSymbol*       resolvedFunction()                                     const;
+
+  FnSymbol*       theFnSymbol()                                          const;
+
   bool            isNamed(const char*);
 
   int             numActuals();


### PR DESCRIPTION
CallExpr:isResolved() currently returns an FnSymbol in one specific situation and NULL in all
other cases.  In practice this function is used as a predicate, a simple accessor to the FnSymbol,
and to obtain the FnSymbol while executing the business logic associated with resolution.  In the
latter case it is not immediately obvious what cases are left to handle when it returns NULL.

This PR

a) splits isResolved in to several different functions that are better aligned with their intended
purpose

b) takes a first step towards converting isResolved to a simple predicate

c) clarifies/verifies the cases in which isResolved() is currently returning NULL during resolution.

There is no change in behavior for the existing compiler but this version would halt() for malformed
AST in cases where the previous implementation would return NULL.

Tested on linux64 and gasnet.
