### PR TITLE
Varargs for blank string

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1617,8 +1617,6 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
       workingFn->insertAtHead(new CallExpr(PRIM_MOVE, var, tupleCall));
       workingFn->insertAtHead(new DefExpr(var));
 
-      formal->defPoint->remove();
-
       if (workingFn->hasFlag(FLAG_PARTIAL_COPY)) {
         // If this is a partial copy, store the mapping for substitution later.
         workingFn->partialCopyMap.put(formal, var);
@@ -1640,6 +1638,8 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
 
         subSymbol(workingFn->where, formal, var);
       }
+
+      formal->defPoint->remove();
     }
   }
 }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1617,8 +1617,62 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
         }
       }
 
-      workingFn->insertAtHead(new CallExpr(PRIM_MOVE, var, tupleCall));
-      workingFn->insertAtHead(new DefExpr(var));
+      // MDN 2016/02/01. Enable special handling for strings with blank intent
+
+      // If the original formal is a string with blank intent then the
+      // new formals appear to be strings with blank intent.  However
+      // the resolver is about to update these to be const ref intent.
+      //
+      // Currently this will cause the tuple to appear to be a tuple
+      // ref(String) which is not supported.
+      //
+      // Insert local copies that can be used for the tuple
+
+      if (isString(formal->type) && formal->intent == INTENT_BLANK) {
+        DefExpr* varDefn = new DefExpr(var);
+        Expr*    tail    = NULL;
+
+        // Insert the new locals
+        for (int i = 0; i < n; i++) {
+          const char* localName = astr("_e", istr(i + n), "_", formal->name);
+          VarSymbol*  local     = newTemp(localName, formal->type);
+          DefExpr*    defn      = new DefExpr(local);
+
+          if (tail == NULL)
+            workingFn->insertAtHead(defn);
+          else
+            tail->insertAfter(defn);
+
+          tail = defn;
+        }
+
+        // Insert the definition for the tuple
+        tail->insertAfter(varDefn);
+        tail = varDefn;
+
+        // Insert the copies from the blank-intent strings to the locals
+        // Update the arguments to the tuple call
+        for (int i = 1; i <= n; i++) {
+          DefExpr*  localDefn = toDefExpr(workingFn->body->body.get(i));
+          Symbol*   local     = localDefn->sym;
+          SymExpr*  localExpr = new SymExpr(local);
+
+          SymExpr*  tupleArg  = toSymExpr(tupleCall->get(i + 1));
+          SymExpr*  copyArg   = tupleArg->copy();
+
+          CallExpr* moveExpr  = new CallExpr(PRIM_MOVE, localExpr, copyArg);
+
+          tupleArg->var = local;
+
+          tail->insertAfter(moveExpr);
+          tail = moveExpr;
+        }
+
+        tail->insertAfter(new CallExpr(PRIM_MOVE, var, tupleCall));
+      } else {
+        workingFn->insertAtHead(new CallExpr(PRIM_MOVE, var, tupleCall));
+        workingFn->insertAtHead(new DefExpr(var));
+      }
 
       if (workingFn->hasFlag(FLAG_PARTIAL_COPY)) {
         // If this is a partial copy, store the mapping for substitution later.


### PR DESCRIPTION
The work to convert string args with blank intent to be consistent with strings with const ref
lead to a problem with varargs expansion.  Before this PR, the tuple that is constructed for
the varargs would expect to be of type n * ref(String) which is not currently supported.

This PR revises the implementation of the helper function for varargs expansion to provide
special handling for strings with blank intent.  In that case we introduce local variables within
the function that will receive a copy of each formal and use these locals for the required tuple.

Later in resolution the formals will be revised to be flagged as const-ref but the underying
tuple will be unaffected.

The first 3 commits are simple cleanup to prepare the way for the new code.  There should be
no observable impact from these commits.  The final commit is reasonably straight forward and
is focused on generating the required temps and then passing them in to the required tuple.

Local testing on darwin/clang for release.
Full paratest for linux64 and gasnet.
