### PR TITLE
Filing a bug against bad escape sequences

### DIFF
--- a/test/types/string/bradc/badEscape.bad
+++ b/test/types/string/bradc/badEscape.bad
@@ -1,0 +1,7 @@
+internal error: SYM3032 chpl Version 1.12.0.feef398
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/types/string/bradc/badEscape.chpl
+++ b/test/types/string/bradc/badEscape.chpl
@@ -1,0 +1,1 @@
+writeln("Rows \ Cols");

--- a/test/types/string/bradc/badEscape.future
+++ b/test/types/string/bradc/badEscape.future
@@ -1,0 +1,5 @@
+bug: internal error on unexpected escape sequence
+
+The compiler currently prints an internal error for cases like this
+with no pointer for the user as to what line# is the issue, what the
+bad escape sequence is, etc.  This seems bad and easily correctable.

--- a/test/types/string/bradc/badEscape.good
+++ b/test/types/string/bradc/badEscape.good
@@ -1,0 +1,1 @@
+badEscape.chpl:1: Unexpected string escape: '\ '


### PR DESCRIPTION
Currently the compiler generates an internal error when
unexpected escape sequences are encountered.  This
seems heavy-handed and easily avoidable.  This future
requests a better error message (a proposal is in the
.good file, but I'm open to alternatives).
