### PR TITLE
String escape error msg

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -539,7 +539,7 @@ llvm::Value* codegenImmediateLLVM(Immediate* i)
       // with C escapes - that is newline is 2 chars \ n
       // so we have to convert to a sequence of bytes
       // for LLVM (the C backend can just print it out).
-      std::string newString = unescapeString(i->v_string);
+      std::string newString = unescapeString(i->v_string, NULL);
       ret = info->builder->CreateGlobalString(newString);
       break;
   }
@@ -2976,7 +2976,7 @@ void LabelSymbol::accept(AstVisitor* visitor) {
 *                                                                   *
 ********************************* | ********************************/
 
-std::string unescapeString(const char* const str) {
+std::string unescapeString(const char* const str, BaseAST *astForError) {
   std::string newString = "";
   char nextChar;
   int pos = 0;
@@ -3029,7 +3029,7 @@ std::string unescapeString(const char* const str) {
         }
         break;
       default:
-        INT_FATAL("Unknown C string escape");
+        USR_FATAL(astForError, "Unexpected string escape: '\\%c'",  nextChar);
         break;
     }
   }
@@ -3079,7 +3079,7 @@ VarSymbol *new_StringSymbol(const char *str) {
       castTemp,
       new CallExpr("_cast", cptrTemp, new_CStringSymbol(str)));
 
-  int strLength = unescapeString(str).length();
+  int strLength = unescapeString(str, castCall).length();
 
   CallExpr *ctor = new CallExpr("_construct_string",
       castTemp,

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -520,7 +520,7 @@ class LabelSymbol : public Symbol {
 ********************************* | ********************************/
 
 // Processes a char* to replace any escape sequences with the actual bytes
-std::string unescapeString(const char* const str);
+std::string unescapeString(const char* const str, BaseAST* astForError);
 
 // Creates a new string literal with the given value.
 VarSymbol *new_StringSymbol(const char *s);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2712,15 +2712,16 @@ static void issueCompilerError(CallExpr* call) {
   }
 
   const char* str = "";
+  VarSymbol* var = NULL;
   for_formals(arg, fn) {
     if (foundDepthVal && arg->defPoint == fn->formals.tail)
       continue;
-    VarSymbol* var = toVarSymbol(paramMap.get(arg));
+    var = toVarSymbol(paramMap.get(arg));
     INT_ASSERT(var && var->immediate && var->immediate->const_kind == CONST_KIND_STRING);
     str = astr(str, var->immediate->v_string);
   }
   // collapse newlines and other escape sequences before printing
-  str = astr(unescapeString(str).c_str());
+  str = astr(unescapeString(str, var).c_str());
   if (call->isPrimitive(PRIM_ERROR)) {
     USR_FATAL(from, "%s", str);
   } else {
@@ -6281,7 +6282,7 @@ postFold(Expr* expr) {
       INT_ASSERT(se);
       if (se->var->isParameter()) {
         const char* str = get_string(se);
-        int length = unescapeString(str).length();
+        int length = unescapeString(str, se).length();
         result = new SymExpr(new_IntSymbol(length, INT_SIZE_DEFAULT));
         call->replace(result);
       }
@@ -6290,7 +6291,7 @@ postFold(Expr* expr) {
       INT_ASSERT(se);
       if (se->var->isParameter()) {
         const char* str = get_string(se);
-        const std::string unescaped = unescapeString(str);
+        const std::string unescaped = unescapeString(str, se);
         result = new SymExpr(new_IntSymbol((int)unescaped[0], INT_SIZE_DEFAULT));
         call->replace(result);
       }

--- a/test/types/string/bradc/badEscape.future
+++ b/test/types/string/bradc/badEscape.future
@@ -1,5 +1,0 @@
-bug: internal error on unexpected escape sequence
-
-The compiler currently prints an internal error for cases like this
-with no pointer for the user as to what line# is the issue, what the
-bad escape sequence is, etc.  This seems bad and easily correctable.

--- a/test/types/string/bradc/badEscape.good
+++ b/test/types/string/bradc/badEscape.good
@@ -1,1 +1,1 @@
-badEscape.chpl:1: Unexpected string escape: '\ '
+badEscape.chpl:1: error: Unexpected string escape: '\ '


### PR DESCRIPTION
@bradcray requested a better error message in PR #3234. This PR improves the
error message for bad string backslash escapes.

* Adds BaseAST* argument to unescapeString for error reporting position
* Changes INT_FATAL to a USR_FATAL with Brad's suggested wording
* Very minor update to Brad's test (adds error: ) and un-future it.

TODO:

We might want to change the string escape rules. Writing regular
expressions is currently awkward.

Passed full local fifo testing.