### PR TITLE
Normalize init expr

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -324,8 +324,8 @@ void normalize(BaseAST* base) {
 // We can't really do this before resolution, because we need to know
 // if symbols used as actual arguments are passed by ref, inout, or out
 // (all of which would be considered definitions).
-// The workaround for this has been early initialization -- 
-// which is redundant with guaranteed initialization, at least with respect 
+// The workaround for this has been early initialization --
+// which is redundant with guaranteed initialization, at least with respect
 // to class instances.
 // Given that it is not completely correct, and it forces unnecessary
 // initializations to be added to the AST, I recommend that the check be
@@ -466,7 +466,7 @@ moveGlobalDeclarationsToModuleScope() {
 
           mod->block->insertAtTail(def->remove());
         }
-        
+
         // All type and function symbols are moved out to module scope.
         if (isTypeSymbol(def->sym) || isFnSymbol(def->sym))
         {
@@ -499,9 +499,9 @@ insertUseForExplicitModuleCalls(void) {
 
 // Two cases are handled here:
 // 1. ('new' (dmap arg)) ==> (chpl__buildDistValue arg)
-// 2. (chpl__distributed (Dist args)) ==> 
+// 2. (chpl__distributed (Dist args)) ==>
 //     (chpl__distributed (chpl__buildDistValue ('new' (Dist args)))),
-//     where isDistClass(Dist). 
+//     where isDistClass(Dist).
 // In 1., the only type that has FLAG_SYNTACTIC_DISTRIBUTION on it is "dmap".
 // This is a dummy record type that must be replaced.  The call to
 // chpl__buildDistValue() performs this task, returning _newDistribution(x),
@@ -1269,7 +1269,7 @@ static void hack_resolve_types(ArgSymbol* arg) {
 // I think this prepares the function to be instantiated with various argument types.
 // That is, it reaches through one level in the type hierarchy -- treating all
 // arrays equally and then resolving using the element type.
-// But this is something of a kludge.  The expansion of arrays 
+// But this is something of a kludge.  The expansion of arrays
 // w.r.t. generic argument types should be done during expansion and resolution,
 // not up front like this. <hilde>
 static void fixup_array_formals(FnSymbol* fn) {
@@ -1327,12 +1327,12 @@ static void fixup_array_formals(FnSymbol* fn) {
         } else if (!noDomain) {
           // The domain argument is supplied but NULL.
           INT_ASSERT(queryDomain == NULL);
-          
+
           // actualArg.chpl_checkArrArgDoms(arg->typeExpr)
           fn->insertAtHead(new CallExpr(new CallExpr(".", arg,
                                                      new_CStringSymbol("chpl_checkArrArgDoms")
                                                      ),
-                                        call->get(1)->copy(), 
+                                        call->get(1)->copy(),
                                         (fNoFormalDomainChecks ? gFalse : gTrue)));
         }
       }
@@ -1464,7 +1464,7 @@ fixup_query_formals(FnSymbol* fn) {
               }
             fn->defPoint->remove();
             return;
-          } else if (callFnSym == dtInt[INT_SIZE_DEFAULT]->symbol || 
+          } else if (callFnSym == dtInt[INT_SIZE_DEFAULT]->symbol ||
                      callFnSym == dtUInt[INT_SIZE_DEFAULT]->symbol) {
             for( int i=INT_SIZE_8; i<INT_SIZE_NUM; i++)
               if (dtInt[i])
@@ -1615,7 +1615,7 @@ static void change_method_into_constructor(FnSymbol* fn) {
 
   fn->name = ct->defaultInitializer->name;
   fn->addFlag(FLAG_CONSTRUCTOR);
-  // Hide the compiler-generated initializer 
+  // Hide the compiler-generated initializer
   // which also serves as the default constructor.
   // hilde sez: Try leaving this visible, but make it inferior in case of multiple matches
   // (in disambiguateByMatch()).

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -54,11 +54,6 @@ static void call_constructor_for_class(CallExpr* call);
 static void applyGetterTransform(CallExpr* call);
 static void insert_call_temps(CallExpr* call);
 static void fix_def_expr(VarSymbol* var);
-static void init_array_alias(VarSymbol* var, Expr* type, Expr* init, Expr* stmt);
-static void init_ref_var(VarSymbol* var, Expr* init, Expr* stmt);
-static void init_config_var(VarSymbol* var, Expr*& stmt, VarSymbol* constTemp);
-static void init_typed_var(VarSymbol* var, Expr* type, Expr* init, Expr* stmt, VarSymbol* constTemp);
-static void init_untyped_var(VarSymbol* var, Expr* init, Expr* stmt, VarSymbol* constTemp);
 static void hack_resolve_types(ArgSymbol* arg);
 static void fixup_array_formals(FnSymbol* fn);
 static void clone_parameterized_primitive_methods(FnSymbol* fn);
@@ -926,6 +921,30 @@ static void insert_call_temps(CallExpr* call)
 *                                                                             *
 *                                                                             *
 ************************************** | *************************************/
+
+static void init_array_alias(VarSymbol* var,
+                             Expr*      type,
+                             Expr*      init,
+                             Expr*      stmt);
+
+static void init_ref_var(VarSymbol*     var,
+                         Expr*          init,
+                         Expr*          stmt);
+
+static void init_config_var(VarSymbol* var,
+                            Expr*&     stmt,
+                            VarSymbol* constTemp);
+
+static void init_typed_var(VarSymbol* var,
+                           Expr*      type,
+                           Expr*      init,
+                           Expr*      stmt,
+                           VarSymbol* constTemp);
+
+static void init_untyped_var(VarSymbol* var,
+                             Expr*      init,
+                             Expr*      stmt,
+                             VarSymbol* constTemp);
 
 //
 // fix_def_expr removes DefExpr::exprType and DefExpr::init from a

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -970,7 +970,7 @@ static void fix_def_expr(VarSymbol* var) {
 
   INT_ASSERT(fn);
 
-  if ( // Not explicily marked "no auto destroy"
+  if (// Not explicily marked "no auto destroy"
       !var->hasFlag(FLAG_NO_AUTO_DESTROY) &&
 
       // Not a param variable.  (Note 1)
@@ -1023,7 +1023,7 @@ static void fix_def_expr(VarSymbol* var) {
   //
   // insert temporary for constants to assist constant checking
   //
-  if (var->hasFlag(FLAG_CONST) &&
+  if ( var->hasFlag(FLAG_CONST) &&
       !var->hasEitherFlag(FLAG_EXTERN, FLAG_REF_VAR)) {
     constTemp = newTemp("const_tmp");
 
@@ -1059,8 +1059,7 @@ static void fix_def_expr(VarSymbol* var) {
 static void init_array_alias(VarSymbol* var,
                              Expr*      type,
                              Expr*      init,
-                             Expr*      stmt)
-{
+                             Expr*      stmt) {
   CallExpr* partial  = NULL;
   CallExpr* autoCopy = NULL;
 
@@ -1081,12 +1080,10 @@ static void init_array_alias(VarSymbol* var,
   autoCopy = new CallExpr("chpl__autoCopy", partial);
 
   stmt->insertAfter(new CallExpr(PRIM_MOVE, var, autoCopy));
-
 }
 
 
-static void init_ref_var(VarSymbol* var, Expr* init, Expr* stmt)
-{
+static void init_ref_var(VarSymbol* var, Expr* init, Expr* stmt) {
   if (!init) {
     USR_FATAL_CONT(var,
                    "References must be initialized when they are defined.");
@@ -1129,8 +1126,9 @@ static void init_ref_var(VarSymbol* var, Expr* init, Expr* stmt)
 }
 
 
-static void init_config_var(VarSymbol* var, Expr*& stmt, VarSymbol* constTemp)
-{
+static void init_config_var(VarSymbol* var,
+                            Expr*&     stmt,
+                            VarSymbol* constTemp) {
   Expr*   noop        = new CallExpr(PRIM_NOOP);
   Symbol* module_name = (var->getModule()->modTag != MOD_INTERNAL ?
                          new_CStringSymbol(var->getModule()->name) :
@@ -1160,8 +1158,7 @@ static void init_typed_var(VarSymbol* var,
                            Expr*      type,
                            Expr*      init,
                            Expr*      stmt,
-                           VarSymbol* constTemp)
-{
+                           VarSymbol* constTemp) {
   //
   // use cast for parameters to avoid multiple parameter assignments
   //

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -183,18 +183,18 @@ void normalize() {
   find_printModuleInit_stuff();
 }
 
-/************************************ | *************************************
-*                                                                           *
-* Insert the module initFn in to every module in allModules.  The current   *
-* implementation pulls the entire module in to the prototypical initFn and  *
-* then lets the reset of normalize sort things out.  The module looks       *
-* reasonable by the end of the pass but odd in the middle.                  *
-*                                                                           *
-* MDN 2014/07/25 At some point this transformation should be reworked to be *
-* more delicate e.g. insert an empty init function and then carefully       *
-* populate it so that the AST is well-behaved at all points.                *
-*                                                                           *
-************************************* | ************************************/
+/************************************* | **************************************
+*                                                                             *
+* Insert the module initFn in to every module in allModules.  The current     *
+* implementation pulls the entire module in to the prototypical initFn and    *
+* then lets the reset of normalize sort things out.  The module looks         *
+* reasonable by the end of the pass but odd in the middle.                    *
+*                                                                             *
+* MDN 2014/07/25 At some point this transformation should be reworked to be   *
+* more delicate e.g. insert an empty init function and then carefully         *
+* populate it so that the AST is well-behaved at all points.                  *
+*                                                                             *
+************************************** | *************************************/
 
 static void insertModuleInit() {
   // Insert an init function into every module
@@ -230,19 +230,19 @@ static void insertModuleInit() {
 
 
 
-/************************************ | *************************************
-*                                                                           *
-* Historically, parser/build converted                                      *
-*                                                                           *
-*    <expr1> && <expr2>                                                     *
-*    <expr1> || <expr2>                                                     *
-*                                                                           *
-* into an IfExpr (which itself currently has a complex implementation).     *
-*                                                                           *
-* Now we allow the parser to generate a simple unresolvable call to either  *
-* && or || and then replace it with the original IF/THEN/ELSE expansion.    *
-*                                                                           *
-************************************* | ************************************/
+/************************************* | **************************************
+*                                                                             *
+* Historically, parser/build converted                                        *
+*                                                                             *
+*    <expr1> && <expr2>                                                       *
+*    <expr1> || <expr2>                                                       *
+*                                                                             *
+* into an IfExpr (which itself currently has a complex implementation).       *
+*                                                                             *
+* Now we allow the parser to generate a simple unresolvable call to either    *
+* && or || and then replace it with the original IF/THEN/ELSE expansion.      *
+*                                                                             *
+************************************** | *************************************/
 
 static void transformLogicalShortCircuit()
 {
@@ -282,10 +282,10 @@ static void transformLogicalShortCircuit()
   }
 }
 
-/************************************ | *************************************
-*                                                                           *
-*                                                                           *
-************************************* | ************************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 // the following function is called from multiple places,
 // e.g., after generating default or wrapper functions
@@ -921,6 +921,12 @@ static void insert_call_temps(CallExpr* call)
   stmt->insertBefore(new CallExpr(PRIM_MOVE, tmp, call));
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
 //
 // fix_def_expr removes DefExpr::exprType and DefExpr::init from a
 //   variable's def expression, normalizing the AST with primitive
@@ -1220,6 +1226,11 @@ static void init_untyped_var(VarSymbol* var, Expr* init, Expr* stmt, VarSymbol* 
     }
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 static void hack_resolve_types(ArgSymbol* arg) {
   // Look only at unknown or arbitrary types.

--- a/test/types/records/hilde/newUserDefaultCtor.good
+++ b/test/types/records/hilde/newUserDefaultCtor.good
@@ -1,5 +1,5 @@
 Called R().
 Called R().
-Called ~R().
 Done.
+Called ~R().
 Called ~R().


### PR DESCRIPTION
I noticed that normalization of a statement of the form "var x : int = 10;" always wraps a scopeless
block stmt around the initialization expression.  A little investigation showed that this block stmt is
required to support one of the uncommon paths in functionResolution; the current implementation
of resolveExternVarSymbols().

This PR is focussed on fix_def_expr and the associated helper functions and consists of a handful
of relatively simple commits.

The first 7 commits are non-functional changes to address "whitespace" issues e.g. several helper
functions had extra indentation, a number of lines went well beyond the 80-column goal for no
particularly good reason, etc.

Commits 8 and 9 are the actual transformation. In the original implementation the compiler allocates
a scopeless blockStmt and then inserts the required statements in to it using insertAtTail().  The first
commit rearranges this so that most of the inserts rely on insertAfter() for the previous stmt inserted.
The second commit tweaks the logic so that the blockStmt is only created and inserted when required.

Finally the last commit fixes the one test that changed due to this update.  There is a test that writes
output when record destructors run.  This transformation delays one destructor until the end of the
scope rather than the end of the initialization.

Compiled on darwin/clang and linux/gnu with/without CHPL_DEVELOPER.
Para tested on baseline, std, and gasnet.
