### PR TITLE
spec: add more promotion examples, cross references

### DIFF
--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -680,6 +680,8 @@ that is equal to the domain of the first argument to the function that
 enables promotion.  If the first argument is an iterator or a range,
 the result is a one-based one-dimensional array.
 
+See also~\rsec{Promotion}.
+
 \begin{chapelexample}{whole-array-ops.chpl}
 Whole array operations is a special case of array promotion of scalar
 functions.  In the code

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -280,8 +280,10 @@ ranges, or the yielded types of the iterators can be resolved to the
 type of the argument.  The rules of when an overloaded function can be
 promoted are discussed in~\rsec{Function_Resolution}.
 
-In addition to scalar functions, operators and casts are also
-promoted.
+Functions that can be promoted include procedures, operators, casts,
+and methods. Also note that since class and record field access
+is performed with getter methods~(\rsec{Getter_Methods}), field
+access can also be promoted.
 
 \begin{chapelexample}{promotion.chpl}
 Given the array
@@ -307,6 +309,37 @@ for s in square(A) do writeln(s);
 25
 \end{chapeloutput}
 \end{chapelexample}
+
+\begin{chapelexample}{field-promotion.chpl}
+Given an array of points, such as \chpl{A} defined below:
+\begin{chapel}
+record Point {
+  var x: real;
+  var y: real;
+}
+var A: [1..5] Point = [i in 1..5] new Point(x=i, y=i);
+\end{chapel}
+the following statement will create a new array consisting of
+the \chpl{x} field value for each value in A:
+\begin{chapel}
+var X = A.x;
+\end{chapel}
+and the following call will set the \chpl{y} field values for each
+element in A to 1.0:
+\begin{chapel}
+A.y = 1.0;
+\end{chapel}
+
+\begin{chapelnoprint}
+writeln(X);
+writeln(A);
+\end{chapelnoprint}
+\begin{chapeloutput}
+1.0 2.0 3.0 4.0 5.0
+(x = 1.0, y = 1.0) (x = 2.0, y = 1.0) (x = 3.0, y = 1.0) (x = 4.0, y = 1.0) (x = 5.0, y = 1.0)
+\end{chapeloutput}
+\end{chapelexample}
+
 
 %%
 %% sungeun: 10/2011

--- a/spec/Iterators.tex
+++ b/spec/Iterators.tex
@@ -189,6 +189,50 @@ b d e c a
 \end{chapeloutput}
 \end{chapelexample}
 
+\subsection{Iterator Promotion of Scalar Functions}
+\label{Iterator_Promotion_of_Scalar_Functions}
+\index{iterators!promotion}
+\index{promotion!iterator}
+
+Iterator calls may be passed to a scalar function argument whose type
+matches the iterator's yielded type.  This results in a promotion of the
+scalar function as described in~\rsec{Promotion}.
+
+\begin{chapelexample}{iteratorPromotion.chpl}
+Given a function \chpl{addOne(x:int)} that accepts \chpl{int} values
+and an iterator \chpl{firstN()} that yields \chpl{int} values,
+\chpl{addOne()} can be called with \chpl{firstN()} as its actual argument.
+This pattern creates a new iterator that yields the result of appling
+\chpl{addOne()} to each value yielded by \chpl{firstN()}.
+
+\begin{chapel}
+proc addOne(x:int) {
+  return x + 1;
+}
+iter firstN(n:int) {
+  for i in 1..n {
+    yield i;
+  }
+}
+for number in addOne(firstN(10)) {
+  writeln(number);
+}
+\end{chapel}
+\begin{chapeloutput}
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+\end{chapeloutput}
+
+\end{chapelexample}
+
 \section{Parallel Iterators}
 \label{Parallel_Iterators}
 \index{parallel iterators}

--- a/spec/Ranges.tex
+++ b/spec/Ranges.tex
@@ -536,6 +536,45 @@ produces the output
 \end{chapelprintoutput}
 \end{chapelexample}
 
+\subsection{Range Promotion of Scalar Functions}
+\label{Range_Promotion_of_Scalar_Functions}
+\index{ranges!promotion}
+\index{promotion!range}
+
+Range values may be passed to a scalar function argument whose type
+matches the range's index type.  This results in a promotion of the
+scalar function as described in~\rsec{Promotion}.
+
+\begin{chapelexample}{rangePromotion.chpl}
+Given a function \chpl{addOne(x:int)} that accepts \chpl{int} values and
+a range \chpl{1..10}, the function \chpl{addOne()} can be called with
+\chpl{1..10} as its actual argument which will result in the function
+being invoked for each value in the range.
+
+\begin{chapel}
+proc addOne(x:int) {
+  return x + 1;
+}
+var A:[1..10] int;
+A = addOne(1..10);
+\end{chapel}
+\begin{chapelpost}
+writeln(A);
+\end{chapelpost}
+\begin{chapeloutput}
+2 3 4 5 6 7 8 9 10 11
+\end{chapeloutput}
+
+\end{chapelexample}
+
+The last statement is equivalent to:
+\begin{chapel}
+forall (a,i) in zip(A,1..10) do
+  a = addOne(i);
+\end{chapel}
+
+
+
 %REVIEW: perhaps define implicit/explicit conversions as well
 % under "Common Operations"?
 


### PR DESCRIPTION
Trying to understand a strange example in our test directory got me looking at how promotion is described in the specification. I found a section that did not describe it very well only to later discover another section that describes it more fully.

This PR:

 * adds cross-references linking the description of promotion in sections about certain types (ranges, iterators, arrays, domains) to the main section on promotion.
 * adds sections on promotion for ranges and iterators.
 * adds an example of promoting field access to the main section on promotion.

Tested against test/release/examples/spec.
Reviewed by @vasslitvinov - thanks!