### PR TITLE
Bug fix: make PRIM_IS_SUBTYPE handle transitive instantiation

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5998,6 +5998,21 @@ isSubType(Type* sub, Type* super) {
   return false;
 }
 
+static bool
+isSubTypeOrInstantiation(Type* sub, Type* super) {
+  if (sub == super)
+    return true;
+  forv_Vec(Type, parent, sub->dispatchParents) {
+    if (isSubTypeOrInstantiation(parent, super))
+      return true;
+  }
+  if (sub->instantiatedFrom &&
+      isSubTypeOrInstantiation(sub->instantiatedFrom, super))
+    return true;
+  return false;
+}
+
+
 static void
 insertValueTemp(Expr* insertPoint, Expr* actual) {
   if (SymExpr* se = toSymExpr(actual)) {
@@ -6239,11 +6254,7 @@ postFold(Expr* expr) {
         Type* rt = call->get(1)->getValType();
         if (lt != dtUnknown && rt != dtUnknown && lt != dtAny &&
             rt != dtAny && !lt->symbol->hasFlag(FLAG_GENERIC)) {
-          bool is_true = false;
-          if (lt->instantiatedFrom == rt)
-            is_true = true;
-          if (isSubType(lt, rt))
-            is_true = true;
+          bool is_true = isSubTypeOrInstantiation(lt, rt);
           result = (is_true) ? new SymExpr(gTrue) : new SymExpr(gFalse);
           call->replace(result);
         }

--- a/test/users/ferguson/generic-default-record.bad
+++ b/test/users/ferguson/generic-default-record.bad
@@ -1,1 +1,0 @@
-generic-default-record.chpl:1: error: type mismatch in assignment from R(int(64),3) to R(int(64),3)

--- a/test/users/ferguson/generic-default-record.future
+++ b/test/users/ferguson/generic-default-record.future
@@ -1,1 +1,0 @@
-bug: generic record default version cannot be created


### PR DESCRIPTION
Retires test/users/ferguson/generic-default-record.future

The problem was that PRIM_IS_SUBTYPE only checked one level of
instantiation. Arguably it should have a different name, but
PRIM_IS_SUBTYPE is what a : expression maps to in a where clause. Even
before this PR, it would return true if lt is an instantiation of rt.

In this PR, I adjust it to transitively check instantiation and
sub-typing. For some reason, in the particuar generic-default-record
example, the record R had two levels of instantiation.

Passed full quickstart testing.