### PR TITLE
Save spectests .dat file to the performance description subdir

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1017,9 +1017,10 @@ def auto_generate_tests():
                             "Log file: {0}]".format(tmp_file_path))
                         finish()
 
+                dat_dir = os.path.join(perf_dir, args.performance_description)
                 with cd(test_dir):
-                    if not os.path.isdir(perf_dir):
-                        os.makedirs(perf_dir)
+                    if not os.path.isdir(dat_dir):
+                        os.makedirs(dat_dir)
 
                     logger.write("[Computing stats for spec examples]")
                     temp_perf_path = os.path.join(home,
@@ -1029,7 +1030,7 @@ def auto_generate_tests():
                             cmd = os.path.join(util_dir, "test", 
                                     "computePerfStats")
                             out = subprocess.check_output([cmd, "spectests", 
-                                perf_dir, os.path.join(home, "test", 
+                                dat_dir, os.path.join(home, "test",
                                 "spectests.perfkeys"), tmp_file_path])
                             temp_perf_file.write(out)
                         except:


### PR DESCRIPTION
We've been getting sporadic failures to geneate the spectests for nightly
chapcs performance testing. This was because we were generating the file to
chapcs/spectests.dat instead of chapcs/<performancedescription>/spectests.dat.
This led to a race between all the chapcs perf runs, occasionally resulting in
one deleting the spectests.dat file, while another one was trying to use it.
This is hopefully the last instance of the perf playgrounds fighting with each
other (#3177, #3223)