### PR TITLE
Def use workaround

### DIFF
--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -111,6 +111,7 @@ void insertReferenceTemps(CallExpr* call);
 // parallel.cpp
 Type* getOrMakeRefTypeDuringCodegen(Type* type);
 Type* getOrMakeWideTypeDuringCodegen(Type* refType);
+bool  variableWillBePrivateBroadcast(Symbol* var);
 
 // type.cpp
 void initForTaskIntents();

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1095,6 +1095,91 @@ createClonedFnWithRetArg(FnSymbol* fn, FnSymbol* useFn)
 }
 
 
+/************************************* | **************************************
+*                                                                             *
+* The following functions implement a transformation that is intended to      *
+* reduce the number of calls to autoCopy/autoDestroy pairs by focussing on    *
+* a common cliche in the current AST.                                         *
+*                                                                             *
+* The transformation attempts to identify pairs of calls such that            *
+*   the first  call generates a value that requires an autoDestroy            *
+*   the second call is an assignment/initCopy/autoCopy                        *
+*                                                                             *
+* When this pattern occurs, the compiler creates a new function based on      *
+*   the function used for the first call                                      *
+*   the operation performed by the second call                                *
+*                                                                             *
+* that accepts an extra argument that is passed by reference.                 *
+*                                                                             *
+* For example assume we have                                                  *
+*                                                                             *
+*   tmp0 = foo(a, b, c);                                                      *
+*   tmp1 = autoCopy(tmp0);                                                    *
+*                                                                             *
+* A new function will be generated based on foo() that                        *
+*   does not return a value                                                   *
+*   accepts a reference to any tmp1.type as an extra argument                 *
+*   replaces the return statement with the second call, e.g. the autoCopy()   *
+*                                                                             *
+* The original call sequence becomes                                          *
+*                                                                             *
+*   fooPrime(a, b, c, &tmp1);                                                 *
+*                                                                             *
+* This transformation may enable optimizations within fooPrime() that would   *
+* be challenging to find otherwise.                                           *
+*                                                                             *
+* Unfortunately this transformation can disrupt flow analysis in later        *
+* passes due to a weakness in the existing def-use infrastructure. The        *
+* current implementation recognizes that the original form of the code        *
+* is a definition for tmp0 and then tmp1.  However it does not recognize      *
+* the indirect definition of tmp1 in the transformed version.                 *
+*                                                                             *
+* In general this might lead to a failure to implement a desired optimization *
+* but it can also lead to a incorrect behavior.  In particular it can         *
+* interfere with the code to generate private-broadcasts during the           *
+* the initialization of module level variables.  Hence we have to detect if   *
+* tmp1 would be broadcast and then disable this transformation.               *
+*                                                                             *
+************************************** | *************************************/
+
+static void changeRetToArgAndClone(CallExpr*                     move,
+                                   Symbol*                       lhs,
+                                   CallExpr*                     call,
+                                   FnSymbol*                     fn,
+                                   Map<Symbol*, Vec<SymExpr*>*>& defMap,
+                                   Map<Symbol*, Vec<SymExpr*>*>& useMap);
+
+static void replaceRemainingUses(Vec<SymExpr*>& use,
+                                 SymExpr*       firstUse,
+                                 Symbol*        actual);
+
+static void replaceUsesOfFnResultInCaller(CallExpr*      move,
+                                          CallExpr*      call,
+                                          Vec<SymExpr*>& use,
+                                          FnSymbol*      fn);
+
+static void
+returnRecordsByReferenceArguments() {
+  Map<Symbol*,Vec<SymExpr*>*> defMap;
+  Map<Symbol*,Vec<SymExpr*>*> useMap;
+  buildDefUseMaps(defMap, useMap);
+
+  forv_Vec(CallExpr, call, gCallExprs) {
+    if (call->parentSymbol) {
+      if (FnSymbol* fn = requiresImplicitDestroy(call)) {
+        if (fn->hasFlag(FLAG_EXTERN))
+          continue;
+        CallExpr* move = toCallExpr(call->parentExpr);
+        INT_ASSERT(move->isPrimitive(PRIM_MOVE));
+        SymExpr* lhs = toSymExpr(move->get(1));
+        INT_ASSERT(!lhs->var->hasFlag(FLAG_TYPE_VARIABLE));
+        changeRetToArgAndClone(move, lhs->var, call, fn, defMap, useMap);
+      }
+    }
+  }
+  freeDefUseMaps(defMap, useMap);
+}
+
 static void replaceRemainingUses(Vec<SymExpr*>& use, SymExpr* firstUse,
                                  Symbol* actual)
 {
@@ -1263,28 +1348,11 @@ changeRetToArgAndClone(CallExpr* move, Symbol* lhs,
   }
 }
 
-
-static void
-returnRecordsByReferenceArguments() {
-  Map<Symbol*,Vec<SymExpr*>*> defMap;
-  Map<Symbol*,Vec<SymExpr*>*> useMap;
-  buildDefUseMaps(defMap, useMap);
-
-  forv_Vec(CallExpr, call, gCallExprs) {
-    if (call->parentSymbol) {
-      if (FnSymbol* fn = requiresImplicitDestroy(call)) {
-        if (fn->hasFlag(FLAG_EXTERN))
-          continue;
-        CallExpr* move = toCallExpr(call->parentExpr);
-        INT_ASSERT(move->isPrimitive(PRIM_MOVE));
-        SymExpr* lhs = toSymExpr(move->get(1));
-        INT_ASSERT(!lhs->var->hasFlag(FLAG_TYPE_VARIABLE));
-        changeRetToArgAndClone(move, lhs->var, call, fn, defMap, useMap);
-      }
-    }
-  }
-  freeDefUseMaps(defMap, useMap);
-}
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 static void
 fixupDestructors() {

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1147,7 +1147,6 @@ static void replaceRemainingUses(Vec<SymExpr*>& use,
                                  Symbol*        actual);
 
 static void replaceUsesOfFnResultInCaller(CallExpr*      move,
-                                          CallExpr*      call,
                                           Vec<SymExpr*>& use,
                                           FnSymbol*      fn);
 
@@ -1193,7 +1192,7 @@ static void returnRecordsByReferenceArguments() {
           // of the call which uses the result of the above call to that
           // function.
           if (use.n > 0) {
-            replaceUsesOfFnResultInCaller(move, call, use, fn);
+            replaceUsesOfFnResultInCaller(move, use, fn);
           }
         }
       }
@@ -1219,10 +1218,10 @@ static void returnRecordsByReferenceArguments() {
 // newFn.  The use function is expected to be assignment, initCopy or
 // autoCopy.  All other cases are ignored.
 static void replaceUsesOfFnResultInCaller(CallExpr*      move,
-                                          CallExpr*      call,
                                           Vec<SymExpr*>& use,
                                           FnSymbol*      fn) {
-  SymExpr* firstUse = use.v[0];
+  CallExpr* call     = toCallExpr(move->get(2));
+  SymExpr*  firstUse = use.v[0];
 
   // If this isn't a call expression, we've got problems.
   if (CallExpr* useCall = toCallExpr(firstUse->parentExpr)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -339,7 +339,6 @@ static Expr* preFold(Expr* expr);
 static void foldEnumOp(int op, EnumSymbol *e1, EnumSymbol *e2, Immediate *imm);
 static bool isSubType(Type* sub, Type* super);
 static void insertValueTemp(Expr* insertPoint, Expr* actual);
-FnSymbol* requiresImplicitDestroy(CallExpr* call);
 static Expr* postFold(Expr* expr);
 static Expr* resolveExpr(Expr* expr);
 static void


### PR DESCRIPTION
I was trying to remove an unnecessary tmp that is generated while normalizing many VarDecls
and was surprised when the gasnet configuration failed.  I learned that our def-use analysis does
not track variables involved in "addr-of" and this in turn caused one of the "private broadcast"
transformations in parallel.cpp to fail in some cases.

Fortunately the failure case is focussed on the module level variables during module initialization
and then when the variable has been subjected to the returnRecordsByReferenceArguments()
transformation.

This PR

1) Exposes the business logic that parallel.cpp uses to determine one of the cases in which
it inserts a private-broadcast primitive

2) Does some house-cleaning for returnRecordsByReferenceArguments() in callDestructors

3) Adds a guard to prevent the transformation if the target variable will require a private broadcast.

Note that this only impacts single-locale programs that are compiled with --no-local and multi-locale
programs and then it only affects a subset of variables during module initialization.

Discussed with BenH and Elliot.  Created JIRA 179 for the def-use problem.

Passes linux64-verify, linux64-baseline-verify, and gasnet.
