### PR TITLE
Add deprecated error for setter

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -410,9 +410,10 @@ checkUseBeforeDefs() {
                   undeclared.set_add(sym->unresolved);
                   // Also include a note about setter being deprecated if it
                   // looks like that was the problem.
-                  if (FnSymbol* inFn = toFnSymbol(call->parentSymbol))
-                    if(0 == strcmp(sym->unresolved, "setter") && inFn->retTag == RET_REF)
-                      USR_FATAL_CONT(sym, "setter is deprecated. Use a ref-pair instead.");
+                  if (call && call->parentSymbol)
+                    if (FnSymbol* inFn = toFnSymbol(call->parentSymbol))
+                      if(0 == strcmp(sym->unresolved, "setter") && inFn->retTag == RET_REF)
+                        USR_FATAL_CONT(sym, "setter is deprecated. Use a ref-pair instead.");
                 }
               }
             }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -408,6 +408,11 @@ checkUseBeforeDefs() {
                   USR_FATAL_CONT(sym, "'%s' undeclared (first use this function)",
                                  sym->unresolved);
                   undeclared.set_add(sym->unresolved);
+                  // Also include a note about setter being deprecated if it
+                  // looks like that was the problem.
+                  if (FnSymbol* inFn = toFnSymbol(call->parentSymbol))
+                    if(0 == strcmp(sym->unresolved, "setter") && inFn->retTag == RET_REF)
+                      USR_FATAL_CONT(sym, "setter is deprecated. Use a ref-pair instead.");
                 }
               }
             }

--- a/test/deprecated/setter-deprecated.chpl
+++ b/test/deprecated/setter-deprecated.chpl
@@ -1,0 +1,13 @@
+var g = 0;
+proc refReturn() ref
+{
+  if setter then
+    return g;
+  else
+    return 1;
+}
+
+writeln(refReturn());
+refReturn() = 2;
+writeln(g);
+

--- a/test/deprecated/setter-deprecated.good
+++ b/test/deprecated/setter-deprecated.good
@@ -1,0 +1,3 @@
+setter-deprecated.chpl:2: In function 'refReturn':
+setter-deprecated.chpl:4: error: 'setter' undeclared (first use this function)
+setter-deprecated.chpl:4: error: setter is deprecated. Use a ref-pair instead.


### PR DESCRIPTION
After PR #3232, setter is removed from the language. Add a deprecation
error about it and a test showing the error.

Passed full local fifo testing.
Reviewed by @lydia-duncan - thanks!
