### PR TITLE
Retire 2 passing futures after PR #3242

### DIFF
--- a/test/functions/ferguson/generic-record-assign.bad
+++ b/test/functions/ferguson/generic-record-assign.bad
@@ -1,1 +1,0 @@
-generic-record-assign.chpl:14: error: type mismatch in assignment from R_with_2_params(1,4) to R_with_2_params(1,4)

--- a/test/functions/ferguson/generic-record-assign.future
+++ b/test/functions/ferguson/generic-record-assign.future
@@ -1,1 +1,0 @@
-bug: compiler should generate working assign overloads for generic records

--- a/test/param/nelson/defaultParamValue.bad
+++ b/test/param/nelson/defaultParamValue.bad
@@ -1,1 +1,0 @@
-defaultParamValue.chpl:17: error: type mismatch in assignment from U(1,2,3,4) to U(1,2,3,4)

--- a/test/param/nelson/defaultParamValue.future
+++ b/test/param/nelson/defaultParamValue.future
@@ -1,7 +1,0 @@
-bug: compiler should generate working assign overloads for generic records
-
-After PR # 2367 or 2752, this test fails because function resolution
-tries to resolve = for all record types. That triggers the
-bug reported here:
- test/functions/ferguson/generic-record-assign.chpl
-


### PR DESCRIPTION
PR #3242 fixed a compiler bug that these futures were reporting.