### PR TITLE
Limit numa perf playground to 1 trial

### DIFF
--- a/util/cron/test-perf.chapcs.numa-playground.bash
+++ b/util/cron/test-perf.chapcs.numa-playground.bash
@@ -28,5 +28,5 @@ git checkout -b $GITHUB_USER-$GITHUB_BRANCH
 git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,numa:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
-perf_args="${perf_args} -numtrials 3 -startdate $START_DATE"
+perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"
 $CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
We don't need very accurate results, and testing is taking a little longer now
that we're limiting which machines we run chapcs perf testing on.