### PR TITLE
Add initial support for using a shared heap with jemalloc

### DIFF
--- a/third-party/README
+++ b/third-party/README
@@ -70,6 +70,7 @@ hwloc/
 jemalloc/
   Summary: Jason Evan's memory allocator (jemalloc) which "emphasizes
            fragmentation avoidance and scalable concurrency support."
+           and can be used when a shared heap is required.
 
   License: jemalloc is released under a BSD-derived License (see
            jemalloc/jemalloc-*/COPYING)


### PR DESCRIPTION
This adds initial support for using jemalloc when we require a shared heap
(such as with gasnet segment fast/large and ugni.)

I used our tcmalloc support and what HPX-5 does as building blocks for this
code. For more info see:

 - $CHPL_HOME/runtime/src/mem/tcmalloc/tcmalloc-interface.*
 - http://jemalloc-discuss.canonware.narkive.com/FzSQ4Qv4/need-help-in-porting-jemalloc
 - https://gitlab.crest.iu.edu/extreme/hpx/blob/develop/libhpx/gas/pgas/jemalloc_global.c

Here's the jist of how this works. jemalloc allows you to specify custom chunk
hooks:

http://www.canonware.com/download/jemalloc/jemalloc-latest/doc/jemalloc.html#arena.i.chunk_hooks

These hooks allow us to specify functions for allocation, deallocation, etc.
i.e. instead of calling into mmap() or sbrk() or whatever, jemalloc calls our
custom hooks. For allocation we just grab memory out of the shared heap that
the comm layer gave us (this is the same thing we do for tcmalloc.)

Then all we have to do is tell each of jemaloc's arenas to use our custom
hooks. To do this we have to first initialize the arenas, and then we set the
hooks. After that we just have to use up any memory jemalloc grabbed from the
system before we were able to provide our custom hooks.

We opt out of the rest of the chunk hook functions. Most of them aren't
important for unix-like machines, the only one that's interesting is that we
opt-out of the dalloc function. All this really means is that we don't ever get
memory back from jemalloc. Once it asks for it, it can re-use it indefinitely.
This is what we do with tcmalloc and is the behavior we want for shared heaps.

This isn't quite ready for prime time because. I'm getting ~4 regressions for a
full gasnet-fast run. Only 1 of these is a real regression (sporadic segfault
for knucleotide), but I haven't gotten to the bottom of it yet. Additionally
there's some cleanup that needs to be done before this goes live. In
particular, I need to check for errors on on calls to je_* functions. That
said, this is a pretty good initial implementation and I think it's worth
committing.