### PR TITLE
Fix GCC error when compiling with CHPL_LLVM=llvm

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -5830,7 +5830,7 @@ ContextCallExpr::copyInner(SymbolMap* map) {
   return _this;
 }
 
-CallExpr* getDesignatedCall(ContextCallExpr* a) {
+CallExpr* getDesignatedCall(const ContextCallExpr* a) {
   return toCallExpr(a->options.tail);
 }
 

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -398,7 +398,7 @@ static inline const LcnSymbol* toConstLcnSymbol(const BaseAST* a)
   return isLcnSymbol(a) ? (const LcnSymbol*) a : NULL;
 }
 
-CallExpr* getDesignatedCall(ContextCallExpr* a);
+CallExpr* getDesignatedCall(const ContextCallExpr* a);
 
 static inline CallExpr* toCallExpr(BaseAST* a)
 {
@@ -412,7 +412,7 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
 {
   if (!a) return NULL;
   if (a->astTag == E_CallExpr) return (const CallExpr*) a;
-  if (a->astTag == E_ContextCallExpr) return getDesignatedCall((ContextCallExpr*)a);
+  if (a->astTag == E_ContextCallExpr) return getDesignatedCall((const ContextCallExpr*)a);
   return NULL;
 }
 


### PR DESCRIPTION
The error was about casting away const; here I just
add appropriate const qualifiers.

Fixes build error for LLVM after #3232.
Verified that --llvm hello.chpl works.