### PR TITLE
Add some error checking to jemalloc shim and do some minor cleanup

### DIFF
--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -147,12 +147,13 @@ static void initialize_arenas(void) {
   }
   narenas = (unsigned) s_narenas;
 
-  // for each arena, set the current thread to use it (this initializes each arena)
+  // for each non-zero arena, set the current thread to use it (this
+  // initializes each arena). arena 0 is automatically initialized.
   //
   //   jemalloc 4.0.4 man: "If the specified arena was not initialized
   //   beforehand, it will be automatically initialized as a side effect of
   //   calling this interface."
-  for (arena=0; arena<narenas; arena++) {
+  for (arena=1; arena<narenas; arena++) {
     if (je_mallctl("thread.arena", NULL, NULL, &arena, sizeof(arena)) != 0) {
       chpl_internal_error("could not change current thread's arena");
     }


### PR DESCRIPTION
Add error checking to all the appropriate je_* calls. Doing so caused me to
realize I was using `unsigned` for the number of arenas instead of `size_t`. I
think I was using an old man page when I did that, so I updated all references
to the man page to include the version number.

This also removes a duplicate "initialization" of arena 0
