### PR TITLE
Add as a future for gasnet only

### DIFF
--- a/test/param/ferguson/getfieldref.future
+++ b/test/param/ferguson/getfieldref.future
@@ -1,0 +1,4 @@
+bug: fielderator problem in ref return proc
+
+This seems to be the same problem as other tests
+with records passed by default intent not being widened.

--- a/test/param/ferguson/getfieldref.skipif
+++ b/test/param/ferguson/getfieldref.skipif
@@ -1,0 +1,2 @@
+# Skip for non-GASNet runs since it might pass there
+CHPL_COMM != gasnet


### PR DESCRIPTION
This test passes on linux64 but demonstrates a bug with gasnet/--no-local.
Adjust it to be a .future with a .skipif.