### PR TITLE
Add a mutex to our jemalloc chunk alloc hook

### DIFF
--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -51,7 +51,7 @@
 static void*  heap_base = NULL;
 static size_t heap_size = 0;
 static size_t cur_heap_offset = 0;
-static pthread_mutex_t chunk_alloc_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t chunk_alloc_lock;
 
 // *** Chunk hook replacements *** //
 // See http://www.canonware.com/download/jemalloc/jemalloc-latest/doc/jemalloc.html#arena.i.chunk_hooks
@@ -253,6 +253,9 @@ void chpl_mem_layerInit(void) {
     heap_base = heap_base_;
     heap_size = heap_size_;
     cur_heap_offset = 0;
+    if (pthread_mutex_init(&chunk_alloc_lock, NULL) != 0) {
+      chpl_internal_error("cannot init chunk_alloc lock");
+    }
     initializeSharedHeap();
   } else {
     void* p;
@@ -265,5 +268,8 @@ void chpl_mem_layerInit(void) {
 
 
 void chpl_mem_layerExit(void) {
-  pthread_mutex_destroy(&chunk_alloc_lock);
+  if (heap_base != NULL) {
+    // ignore errors, we're exiting anyways
+    pthread_mutex_destroy(&chunk_alloc_lock);
+  }
 }


### PR DESCRIPTION
It looks like our chunk_alloc might not be called inside a lock like I thought
it was. This adds a simple mutex to protect getting the current pointer into
the shared heap. Note that the critical section (computing our current index
into the shared heap) will be very fast, so we shouldn't have much contention
on this lock (uncontended locks/unlocks happen in user-space and are fast)

This resolves the knucleotide regressions for gasnet-fast mentioned in #3252

BenH provided the following reduced knucleotide-like test case that allowed me
to track this down:

```chapel
proc calculate() {
  var freqDom : domain(uint);
  var freqs : [freqDom] int;
  for i in 1..100000 do freqs[i:uint] += i;
  return freqs;
}

proc main() {
  var ret = calculate();
  writeln(ret.size);
}
```

Without the lock this failed every ~3 runs, and with the lock it passed 10,000 trials