### PR TITLE
Adding missing standard modules to the chpldoc documentation

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -73,6 +73,7 @@ MODULES_TO_DOCUMENT = \
 	standard/Buffers.chpl \
 	standard/CommDiagnostics.chpl \
 	standard/Curl.chpl \
+	standard/Error.chpl \
 	standard/FFTW.chpl \
 	standard/FFTW_MT.chpl \
 	standard/FileSystem.chpl \
@@ -81,19 +82,22 @@ MODULES_TO_DOCUMENT = \
 	standard/HDFSiterator.chpl \
 	standard/Help.chpl \
 	standard/IO.chpl \
-	standard/List.chpl \
 	standard/LAPACK.chpl \
+	standard/List.chpl \
 	standard/Math.chpl \
 	standard/Memory.chpl \
 	standard/Norm.chpl \
 	standard/Path.chpl \
 	standard/Random.chpl \
+	standard/RecordParser.chpl \
 	standard/Reflection.chpl \
 	standard/Regexp.chpl \
 	standard/Search.chpl \
 	standard/Sort.chpl \
 	standard/Spawn.chpl \
 	standard/Sys.chpl \
+	standard/SysBasic.chpl \
+	standard/Time.chpl \
 	standard/Types.chpl \
 	standard/UtilReplicatedVar.chpl \
 	standard/VisualDebug.chpl \


### PR DESCRIPTION
In version 1.12, 'chpldoc', automatically crawled all transitively
'use'd modules as it documented something.  This meant that we
didn't have to list all modules/standard/*.chpl modules in our list of
files to chpldoc and so, apparently, we didn't.  Since then, we
changed this behavior of chpldoc (in PR #3015) to only process a
single file at a time.  While looking up some documentation today,
I realized that doc/master/ didn't have the Time.chpl module documented
and @lydia-duncan and @Kyle-B  correctly determined that this change
was the reason.

Here, I'm adding modules from modules/standard that were included in
1.12 but missing in doc/master.  Also, re-alphabetized while here.

In passing, I'll note that virtually all of the modules/standard files
are now documented (Prefetch was a notable outlier) and that it would
be easier to maintain this variable if we could just chpldoc
modules/standard/*.chpl rather than explicitly listing modules files.
We're currently having a chat about the reasons for neglecting that module.