### PR TITLE
Cleanup jemalloc chunk_alloc function

### DIFF
--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -83,8 +83,6 @@ static void* chunk_alloc(void *chunk, size_t size, size_t alignment, bool *zero,
 
   cur_heap_size = (uintptr_t)cur_chunk_base - (uintptr_t)heap_base;
 
-  size = ((size + alignment - 1) / alignment) * alignment;
-
   // If there's not enough space on the heap for this allocation, return NULL
   if (size > heap_size - cur_heap_size) {
     pthread_mutex_unlock(&chunk_alloc_lock);


### PR DESCRIPTION
Some mostly readability cleanups to our jemalloc chunk_alloc function:

 - Cleanup/Improve some variables names
 - Remove an unnecessary alignment of a `size` variable
 - Cleanup the code to align our index into the shared heap

Individual commits have more details.