### PR TITLE
Quiet mallocOutOfMemory for jemalloc with a shared heap

### DIFF
--- a/test/memory/shannon/outofmemory/sub_test
+++ b/test/memory/shannon/outofmemory/sub_test
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set virtual memory limit
-ulimit -v 400000
-export CHPL_RT_MAX_HEAP_SIZE=4M
+ulimit -v 4000000
+export CHPL_RT_MAX_HEAP_SIZE=10M
 
 ../../../../util/test/sub_test $1


### PR DESCRIPTION
mallocOutOfMemory sets a virtual memory limit in order to test that we get a
sane error message on OOM. However, the limit it's setting is too low for
jemalloc when there's a shared heap. With a shared heap, we have to waste
whatever memory jemalloc got from the system before it was given our heap. This
is more than the current ulimit, so I'm just bumping it and the max heap size.

I just arbitrarily chose numbers that worked, and tested them out for a few
other configurations (gasnet-fast+dlmalloc, gasnet-everything, std,
--baseline, --fast) to make sure I didn't break them.