### PR TITLE
Add jemalloc correctness jobs for linux64, gasnet-everything, and gasnet-fast

### DIFF
--- a/util/cron/test-jemalloc-gasnet-everything.bash
+++ b/util/cron/test-jemalloc-gasnet-everything.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Test gasnet (segment everything) w/ jemalloc against full suite on linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-gasnet.bash
+source $CWD/common-jemalloc.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="jemalloc-gasnet-everything"
+
+export GASNET_QUIET=Y
+
+# Test a GASNet compile using the default segment (everything for linux64)
+export CHPL_GASNET_SEGMENT=everything
+
+$CWD/nightly -cron

--- a/util/cron/test-jemalloc-gasnet-fast.bash
+++ b/util/cron/test-jemalloc-gasnet-fast.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Test gasnet (segment fast) w/ jemalloc against full suite on linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-gasnet.bash
+source $CWD/common-jemalloc.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="jemalloc-gasnet-fast"
+
+export GASNET_QUIET=Y
+
+# Test a GASNet compile using the fast segment
+export CHPL_GASNET_SEGMENT=fast
+
+$CWD/nightly -cron

--- a/util/cron/test-jemalloc-linux64.bash
+++ b/util/cron/test-jemalloc-linux64.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on full suite with jemalloc on linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+source $CWD/common-jemalloc.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="jemalloc-linux64"
+
+$CWD/nightly -cron


### PR DESCRIPTION
Get in some early nightly testing of jemalloc so we have more confidence before
we consider making it the default.

I might also add some valgrind testing in the near future

I just copied the non-jemalloc versions of these jobs, changed the
CHPL_NIGHTLY_TEST_CONFIG_NAME to include jemalloc, updated some comments,
sourced common-jemalloc, and removed things like compiler performance, and
futures since we don't need to test those for jemalloc.