### PR TITLE
Add ==/!= comparisons for c_void_ptr types and nil

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -122,6 +122,14 @@ module CPtr {
   inline proc ==(a: _nilType, b: c_ptr) {
     return __primitive("ptr_eq", c_nil, b);
   }
+  pragma "no doc"
+  inline proc ==(a: c_void_ptr, b: _nilType) {
+    return __primitive("ptr_eq", a, c_nil);
+  }
+  pragma "no doc"
+  inline proc ==(a: _nilType, b: c_void_ptr) {
+    return __primitive("ptr_eq", c_nil, b);
+  }
 
   pragma "no doc"
   inline proc !=(a: c_ptr, b: c_ptr) where a.eltType == b.eltType {
@@ -141,6 +149,14 @@ module CPtr {
   }
   pragma "no doc"
   inline proc !=(a: _nilType, b: c_ptr) {
+    return __primitive("ptr_neq", c_nil, b);
+  }
+  pragma "no doc"
+  inline proc !=(a: c_void_ptr, b: _nilType) {
+    return __primitive("ptr_neq", a, c_nil);
+  }
+  pragma "no doc"
+  inline proc !=(a: _nilType, b: c_void_ptr) {
     return __primitive("ptr_neq", c_nil, b);
   }
 

--- a/test/types/cptr/ptr_eq.chpl
+++ b/test/types/cptr/ptr_eq.chpl
@@ -1,0 +1,2 @@
+writeln(c_nil == nil);
+writeln(nil == c_nil);

--- a/test/types/cptr/ptr_eq.good
+++ b/test/types/cptr/ptr_eq.good
@@ -1,0 +1,2 @@
+true
+true

--- a/test/types/cptr/ptr_neq.chpl
+++ b/test/types/cptr/ptr_neq.chpl
@@ -1,0 +1,2 @@
+writeln(c_nil != nil);
+writeln(nil != c_nil);

--- a/test/types/cptr/ptr_neq.good
+++ b/test/types/cptr/ptr_neq.good
@@ -1,0 +1,2 @@
+false
+false


### PR DESCRIPTION
This is a simple change that adds ==/!= comparisons for `c_void_ptr` types and `nil`. This includes some basic tests.

(This is an incremental commit I needed for ZMQ support. It seemed standalone enough to submit on its own.)