### PR TITLE
Decrease problem size for ri-4arrdom for CHPL_COMM!=none

### DIFF
--- a/test/parallel/forall/vass/ri-4-arrdom.chpl
+++ b/test/parallel/forall/vass/ri-4-arrdom.chpl
@@ -2,9 +2,11 @@
 
 use BlockDist, CyclicDist, BlockCycDist, ReplicatedDist;
 
+const defR = if CHPL_COMM=="none" then 3000 else 1500;
+
 config var
   n2 = 100,   // for compatibility with distributions/robust/arithmetic suite
-  r = 3000,   // how many times to repeat
+  r = defR,   // how many times to repeat
   d = n2,     // each dimension of the domain and array
   f = 500;    // frequency of reports, 0 if none
 

--- a/test/parallel/forall/vass/ri-4-arrdom.comm-none.good
+++ b/test/parallel/forall/vass/ri-4-arrdom.comm-none.good
@@ -1,0 +1,8 @@
+starting  3000 tests  100 size
+500 tests
+1000 tests
+1500 tests
+2000 tests
+2500 tests
+3000 tests
+done  3000 tests  100 size   all good

--- a/test/parallel/forall/vass/ri-4-arrdom.good
+++ b/test/parallel/forall/vass/ri-4-arrdom.good
@@ -1,8 +1,5 @@
-starting  3000 tests  100 size
+starting  1500 tests  100 size
 500 tests
 1000 tests
 1500 tests
-2000 tests
-2500 tests
-3000 tests
-done  3000 tests  100 size   all good
+done  1500 tests  100 size   all good

--- a/test/parallel/forall/vass/ri-4-arrdom.replicated.comm-none.good
+++ b/test/parallel/forall/vass/ri-4-arrdom.replicated.comm-none.good
@@ -1,0 +1,1 @@
+ri-4-arrdom.comm-none.good


### PR DESCRIPTION
This test was timing out for me during my gasnet-fast jemalloc tests. Here's
some number I collected to make sure there wasn't something wrong with our
jemalloc shim.

config               | time (sec)
-------------------- | ----------
comm=none            | ~1
gasnet-everything    | ~200
gasnet-fast+dlmalloc | ~300
gasnet-fast+tcmalloc | ~495
gasnet-fast+jemalloc | ~505

After talking with Vass, we opted to just decrease the problem size for
CHPL_COMM!=none.

Here's the after numbers:

config               | time (sec)
-------------------- | ----------
comm=none            | ~1
gasnet-everything    | ~85
gasnet-fast+dlmalloc | ~150
gasnet-fast+tcmalloc | ~245
gasnet-fast+jemalloc | ~250