### PR TITLE
Fix Makefile cross-dependency and document 'man' dependency: docutils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ comprt: FORCE
 	@$(MAKE) third-party-try-opt
 	@$(MAKE) always-build-test-venv
 	@$(MAKE) always-build-chpldoc
-	@$(MAKE) always-build-man
 	@$(MAKE) runtime
 	@$(MAKE) modules
 

--- a/third-party/README
+++ b/third-party/README
@@ -9,7 +9,8 @@ Chapel itself.  Current subdirectories include:
 
 chpl-venv/
   Summary: Directory where several python packages are downloaded and
-           installed. Used for chpldoc and the testing system. See
+           installed. Used for chpldoc, generating standard module
+           documentation, testing system, and man page generation. See
            chpldoc-requirements.txt, test-requirements.txt, and
            virtualenv.txt files for a complete list of packages that are
            installed.

--- a/third-party/README
+++ b/third-party/README
@@ -9,9 +9,9 @@ Chapel itself.  Current subdirectories include:
 
 chpl-venv/
   Summary: Directory where several python packages are downloaded and
-           installed. Used for chpldoc, generating standard module
-           documentation, testing system, and man page generation. See
-           chpldoc-requirements.txt, test-requirements.txt, and
+           installed. Used by chpldoc and the testing system, and to generate
+           the man page and standard module documentation.
+           See chpldoc-requirements.txt, test-requirements.txt, and
            virtualenv.txt files for a complete list of packages that are
            installed.
 

--- a/third-party/chpl-venv/README.md
+++ b/third-party/chpl-venv/README.md
@@ -129,7 +129,7 @@ Required by Sphinx.
 
 Python Documentation Utilities
 
-Required by Sphinx.
+Required by Sphinx, and man page generation.
 
 **License**: public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt, also found at http://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/COPYING.txt)
 


### PR DESCRIPTION
* Putting all of 'make man' references into Makefile.devel
    * This was causing an unknown Make target for the release tarball, where Makefile.devel is omitted.
* Documenting the man page dependency on docutils (rst2man.py)
    * grepped for other mentions of docutils / test-venv, to check if other documentation needed updates


[ **paratested** ]
[ **release-tarball tested** ]