### PR TITLE
Set CHPL_MEM=cstdlib in quickstart scripts

### DIFF
--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -54,8 +54,8 @@ export CHPL_COMM=none
 echo "Setting CHPL_TASKS to fifo"
 export CHPL_TASKS=fifo
 
-#echo "Setting CHPL_MEM to cstdlib"
-#export CHPL_MEM=cstdlib
+echo "Setting CHPL_MEM to cstdlib"
+export CHPL_MEM=cstdlib
 
 echo "Setting CHPL_GMP to none"
 export CHPL_GMP=none

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -44,8 +44,8 @@ setenv CHPL_COMM none
 echo "Setting CHPL_TASKS to fifo"
 setenv CHPL_TASKS fifo
 
-#echo "Setting CHPL_MEM to cstdlib"
-#setenv CHPL_MEM cstdlib
+echo "Setting CHPL_MEM to cstdlib"
+setenv CHPL_MEM cstdlib
 
 echo "Setting CHPL_GMP to none"
 setenv CHPL_GMP none

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -48,8 +48,8 @@ set -x CHPL_COMM none
 echo "Setting CHPL_TASKS to fifo"
 set -x CHPL_TASKS fifo
 
-#echo "Setting CHPL_MEM to cstdlib"
-#set -x CHPL_MEM cstdlib
+echo "Setting CHPL_MEM to cstdlib"
+set -x CHPL_MEM cstdlib
 
 echo "Setting CHPL_GMP to none"
 set -x CHPL_GMP none

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -58,11 +58,11 @@ export CHPL_TASKS
 echo "                           ...fifo"
 echo " "
 
-#echo "Setting CHPL_MEM to..."
-#CHPL_MEM=cstdlib
-#export CHPL_MEM
-#echo "                           ...cstdlib"
-#echo " "
+echo "Setting CHPL_MEM to..."
+CHPL_MEM=cstdlib
+export CHPL_MEM
+echo "                           ...cstdlib"
+echo " "
 
 echo "Setting CHPL_GMP to..."
 CHPL_GMP=none


### PR DESCRIPTION
This is in preparation for the (hopefully soon) switch to jemalloc as the
default and I'm worried I won't remember to do this if I don't do it now.