### PR TITLE
Skip I-fail-without-re2 for the quickstart configurations.

### DIFF
--- a/test/regexp/elliot/I-fail-without-re2.skipif
+++ b/test/regexp/elliot/I-fail-without-re2.skipif
@@ -1,0 +1,1 @@
+CHPL_TEST_REGEXP==none

--- a/util/cron/common-quickstart.bash
+++ b/util/cron/common-quickstart.bash
@@ -5,3 +5,6 @@
 
 source $(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)/common.bash
 source ${CHPL_HOME}/util/quickstart/setchplenv.bash
+
+# Skip $CHPL_HOME/test/regexp/elliot/I-fail-without-re2
+export CHPL_TEST_REGEXP=none


### PR DESCRIPTION
I-fail-without-re2 is intended to lock in what configurations re2 speculatively
builds with. Since we're explicitly turning re2 off for the quickstart, we
need to skip this test.