### PR TITLE
Fix two autological-compare warnings in c_ptr tests

### DIFF
--- a/test/types/cptr/ptr_eq.chpl
+++ b/test/types/cptr/ptr_eq.chpl
@@ -1,2 +1,6 @@
-writeln(c_nil == nil);
-writeln(nil == c_nil);
+proc test(x) {
+  writeln(x == nil);
+  writeln(nil == x);
+}
+var y: c_void_ptr = c_nil;
+test(y);

--- a/test/types/cptr/ptr_neq.chpl
+++ b/test/types/cptr/ptr_neq.chpl
@@ -1,2 +1,6 @@
-writeln(c_nil != nil);
-writeln(nil != c_nil);
+proc test(x) {
+  writeln(x != nil);
+  writeln(nil != x);
+}
+var y: c_void_ptr = c_nil;
+test(y);


### PR DESCRIPTION
These tests would end up generating C code like:

  c_nil == c_nil

causing warnings at C compilation time. This fix wraps these comparisons
with a function and passes in one of the values.