### PR TITLE
Support building jemalloc with CCE

### DIFF
--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -12,6 +12,13 @@ ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_JEMALLOC_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 endif
 
+# Can't build under cce with `-hgnu` or anything above `-O1`. Additionally,
+# CCE doesn't support the dependency flags that jemalloc expects (-MM -MT)
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)
+CFLAGS += "-hnognu -O1'
+CHPL_JEMALLOC_MAKE_OPTIONS += CC_MM=''
+endif
+
 CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \
 			     --with-jemalloc-prefix=je_
 
@@ -51,7 +58,7 @@ configure-jemalloc: FORCE
 	cd $(JEMALLOC_BUILD_DIR) && $(JEMALLOC_SUBDIR)/configure CC='$(CC)' EXTRA_CFLAGS='$(CHPL_JEMALLOC_EXTRA_CFLAGS)' $(CHPL_JEMALLOC_CFG_OPTIONS)
 
 build-jemalloc: FORCE
-	cd $(JEMALLOC_BUILD_DIR) && $(MAKE) build_lib_static
+	cd $(JEMALLOC_BUILD_DIR) && $(MAKE) $(CHPL_JEMALLOC_MAKE_OPTIONS) build_lib_static
 
 install-jemalloc: FORCE
 	cd $(JEMALLOC_BUILD_DIR) && $(MAKE) install_lib_static install_bin install_include


### PR DESCRIPTION
Support building jemalloc with CCE

When compiling jemalloc with CCE throw `-hnognu -O1` and turn off automatic
dependency tracking since CCE doesn't support it.

CCE >= 8.4.0 currently fails to build jemalloc. It fails while compiling
jemalloc-4.0.4/src/prof.c with an LLVM error message along the lines of:

    Store operand must be a pointer.
      store i64 %r97, i64 %r90, !dbg !62
    LLVM ERROR: Broken function found, compilation aborted!

There's no associated line number, so it's not easy for me to see if there's a
simple workaround or not. I'm working with CCE to figure out what's going on,
but in the meantime `-hnognu -O1` will allow us to build jemalloc with cce.

Beyond taht jemalloc also expects some dependency flags (`-MM` and `-MT`) to
work, but CCE doesn't support them. jemalloc already has a work-around for
other compilers (MSVC) that don't support these flags:

https://github.com/jemalloc/jemalloc/commit/79c4bca7d10e967ff524f17a6990e5c630116198

I'm slightly abusing this work-around because I'm telling the `make` step that
these flags aren't supported instead of having that be auto-detected at
configure time. Ideally, I want to try to commit a fix upstream so jemalloc
will detect that CCE is being used and that it doesn't support these dependency
flags, but this commit will get us building jemalloc in the meantime.
