### PR TITLE
Add a test case I forgot to cover before for the 'except' and 'only' lists

### DIFF
--- a/test/visibility/only/exceptOnlySameMod.chpl
+++ b/test/visibility/only/exceptOnlySameMod.chpl
@@ -1,0 +1,27 @@
+module Foo {
+  var a = 14.2;
+
+  const b: bool;
+
+  proc c() {
+    writeln("wheeeee");
+  }
+
+  proc d(x: int) {
+    return x * 2 + 4;
+  }
+}
+
+module M {
+  use Foo except a, c;
+  use Foo only a, c;
+  // Verifies that you can cover an entire module with mutually exclusive uses
+  // at the same scope.
+
+  proc main() {
+    writeln(a);
+    writeln(b);
+    c();
+    writeln(d(3)); // Should be 10
+  }
+}

--- a/test/visibility/only/exceptOnlySameMod.good
+++ b/test/visibility/only/exceptOnlySameMod.good
@@ -1,0 +1,4 @@
+14.2
+false
+wheeeee
+10


### PR DESCRIPTION
This test ensures that you can write two uses of the same module at the same
scope with 'only' and 'except' lists.  The case provided actually includes all
the symbols in the module being used.