### PR TITLE
New optional env for `testReleaseHelp` to run only hello-worlds

### DIFF
--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -112,7 +112,15 @@ if ($tmpstatus != 0) then
     echo "ERROR: cd into examples failed"
     exit($tmpstatus)
 endif
-./start_test -logfile Logs/testReleaseHelp.log
+
+set start_test_flags = ''
+if ($?CHPL_TEST_NORECURSE) then
+    set start_test_flags = ${start_test_flags}' --norecurse'
+endif
+
+./start_test ${start_test_flags} -logfile Logs/testReleaseHelp.log
+
+endif
 set tmpstatus = $status
 if ($tmpstatus != 0) then
     echo "ERROR: testing of examples failed"

--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -114,7 +114,7 @@ if ($tmpstatus != 0) then
 endif
 
 set start_test_flags = ''
-if ($?CHPL_TEST_NORECURSE) then
+if ($?CHPL_TEST_RELEASE_NORECURSE) then
     set start_test_flags = ${start_test_flags}' --norecurse'
 endif
 


### PR DESCRIPTION
The script, `testReleaseHelp` fires off `start_test` with `--no-recurse` if `CHPL_TEST_RELEASE_NORECURSE` is set. This script is called down the chain from `/util/cron/test-release.bash`.

I am adding this option for a new Jenkins job that will fire off `test-release.bash` each time a PR is merged. This option will provide the ability to perform a minimal test case with the Jenkins job.


[ Tested  `testRelease` locally with `CHPL_TEST_RELEASE_NORECURSE` set and unset ]