### PR TITLE
Skip the distributions primer for KNC if we don't have enough KNC nodes

### DIFF
--- a/test/release/examples/primers/distributions.skipif
+++ b/test/release/examples/primers/distributions.skipif
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+# Our KNC test machines with don't have enough nodes to run this test, so just
+# skip if cnselect says we have less than 6 KNC nodes. This isn't a particular
+# elegant solution, but oh well.
+
+import subprocess
+import os
+
+try:
+    if os.getenv('CHPL_TARGET_ARCH') == 'knc':
+        p = subprocess.Popen(["cnselect", "type.eq.MIC", "-c"], stdout=subprocess.PIPE)
+        out = p.communicate()[0]
+
+        num_kncs = int(out.strip())
+
+        print(num_kncs < 6)
+    else:
+        print("False")
+
+
+# if there's any errors (e.g. cnselect isn't availble, don't skip the test)
+except:
+    print("False")


### PR DESCRIPTION
We only test release/examples on KNC and distributions is the only test that
uses more than 4 locales. Unfortunately our current KNC testing machine only
has 4 KNC nodes now. Just skip this test if we're running KNC and cnselect
tells us there's not enough nodes.

This isn't a very elegant solution, but it will let testing work again.