### PR TITLE
Switch to jemalloc for all our gasnet configurations

### DIFF
--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -6,7 +6,7 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_comm, chpl_comm_segment
+import chpl_comm
 from utils import memoize
 
 
@@ -19,11 +19,7 @@ def get(flag='host'):
         if not mem_val:
             comm_val = chpl_comm.get()
             if comm_val == 'gasnet':
-                segment_val = chpl_comm_segment.get()
-                if segment_val == 'fast' or segment_val == 'large':
-                    mem_val = 'dlmalloc'
-                else:
-                    mem_val = 'cstdlib'
+                mem_val='jemalloc'
             elif comm_val == 'ugni':
                 mem_val = 'tcmalloc'
             else:

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -6,7 +6,7 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_arch, chpl_comm, chpl_comm_segment, chpl_compiler, chpl_platform
+import chpl_comm, chpl_comm_segment
 from utils import memoize
 
 
@@ -18,15 +18,6 @@ def get(flag='host'):
         mem_val = os.environ.get('CHPL_MEM')
         if not mem_val:
             comm_val = chpl_comm.get()
-            #platform_val = chpl_platform.get('host')
-            #arch_val = chpl_arch.get('target', get_lcd=True)
-            #tcmallocCompat = ["gnu", "clang", "clang-included", "intel"]
-
-            # true if tcmalloc is compatible with the target compiler
-            #if (not (platform_val == 'cray-xc' and arch_val == 'knc') and
-            #        (not platform_val.startswith("cygwin")) and
-            #        any(sub in chpl_compiler.get('target') for sub in tcmallocCompat)):
-            #    return 'tcmalloc'
             if comm_val == 'gasnet':
                 segment_val = chpl_comm_segment.get()
                 if segment_val == 'fast' or segment_val == 'large':


### PR DESCRIPTION
Instead of using dlmalloc for segment large/fast and cstdlib for everything
else, always use jemalloc.

This is the start of making jemalloc our default allocator. We're already
running jemalloc gasnet-everything and gasnet-fast correctness testing, so this
should go pretty smoothly. I have also done some manual performance studies
with gasnet+aries and I'm pretty confident there will be several performance
improvements.

I'm doing the switch to jemalloc in stages to limit just how many
configurations and performance characteristics will change at once, but
overtime jemalloc should become the default everywhere.

Since this is impacting everywhere we build gasnet, I did some additional spot
checks to make sure jemalloc builds on those platforms (i.e. I tested with all
our backend compilers, with KNC, and with 32 bit.)