### PR TITLE
Fix CCE support for jemalloc

### DIFF
--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -15,7 +15,7 @@ endif
 # Can't build under cce with `-hgnu` or anything above `-O1`. Additionally,
 # CCE doesn't support the dependency flags that jemalloc expects (-MM -MT)
 ifeq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)
-CFLAGS += "-hnognu -O1'
+CFLAGS += -hnognu -O1
 CHPL_JEMALLOC_MAKE_OPTIONS += CC_MM=''
 endif
 


### PR DESCRIPTION
I messed up the quotes for throwing `-hnognu -O1` so CCE couldn't actually
build jemalloc. Not quite sure how I did this. Maybe I tried changing from
double to single quotes and didn't think to test again?