### PR TITLE
Unify key types for bulk transfer optimization

### DIFF
--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -22,9 +22,9 @@
 //
 // TODO: What are the potential performance issues?
 // * put as one message?
-//   - not currently happening due to int(32)/int(64) mismatch that
-//     prevents direct copying -- will fix in future revision to
-//     see performance impact.
+//   - not currently happening due to origin check in bulk transfer
+//     optimization -- will fix in future revision to see performance
+//     impact.
 // * how do Ben's locality optimizations do?
 // * does returning arrays cost us anything?  Do we leak them?
 // * other?
@@ -158,7 +158,7 @@ const LocBucketSpace = {0..#numBuckets};
 const BucketDist = new dmap(new Block(LocBucketSpace));
 const BucketSpace = LocBucketSpace dmapped BucketDist;
 
-var allBucketKeys: [BucketSpace] [0..#recvBuffSize] int;
+var allBucketKeys: [BucketSpace] [0..#recvBuffSize] keyType;
 var recvOffset: [BucketSpace] atomic int;
 var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
     exchangeKeysTime, countKeysTime: [BucketSpace] [1..numTrials] real;

--- a/test/studies/isx/isx-spmd.chpl
+++ b/test/studies/isx/isx-spmd.chpl
@@ -26,9 +26,9 @@
 //
 // TODO: What are the potential performance issues?
 // * put as one message?
-//   - not currently happening due to int(32)/int(64) mismatch that
-//     prevents direct copying -- will fix in future revision to
-//     see performance impact.
+//   - not currently happening due to origin check in bulk transfer
+//     optimization -- will fix in future revision to see performance
+//     impact.
 // * how do Ben's locality optimizations do?
 // * does returning arrays cost us anything?  Do we leak them?
 // * other?
@@ -156,7 +156,7 @@ if numTrials == 0 then
 
 const OnePerLocale = LocaleSpace dmapped Block(LocaleSpace);
 
-var allBucketKeys: [OnePerLocale] [0..#recvBuffSize] int;
+var allBucketKeys: [OnePerLocale] [0..#recvBuffSize] keyType;
 var recvOffset: [OnePerLocale] atomic int;
 var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
     exchangeKeysTime, countKeysTime: [OnePerLocale] [1..numTrials] real;


### PR DESCRIPTION
Due to oversight, our original versions of ISx were storing keys
as 'int's in one place and 'keyType's (int(32)s) in another.
This difference prevented the bulk transfer optimization from
firing because you can't memcpy() distinct types.  Other checks
are now (incorrectly, we believe) preventing the optimization
from firing and will be fixed in subsequent commits.