### PR TITLE
Reduce problem size for PRK Stencil correctness tests

### DIFF
--- a/test/studies/prk/stencil/stencil-fast.compopts
+++ b/test/studies/prk/stencil/stencil-fast.compopts
@@ -1,6 +1,6 @@
---set validate                                      -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
---set validate                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set useBlockDist=true              -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set useStencilDist=true            -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3                                      -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3 --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3 --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3 --set useBlockDist=true              -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3 --set useStencilDist=true            -M../../../release/examples/benchmarks/miniMD/helpers

--- a/test/studies/prk/stencil/stencil-fast.compopts
+++ b/test/studies/prk/stencil/stencil-fast.compopts
@@ -1,6 +1,6 @@
---set validate --set order=100 --iterations=3                                      -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3 --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3 --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3 --set useBlockDist=true              -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3 --set useStencilDist=true            -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3                                      -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3 --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3 --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3 --set useBlockDist=true              -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3 --set useStencilDist=true            -M../../../release/examples/benchmarks/miniMD/helpers

--- a/test/studies/prk/stencil/stencil-pretty.compopts
+++ b/test/studies/prk/stencil/stencil-pretty.compopts
@@ -1,6 +1,6 @@
---set validate                                      -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
---set validate                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set useBlockDist=true              -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set useStencilDist=true            -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3                                      -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3 --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3 --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3 --set useBlockDist=true              -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3 --set useStencilDist=true            -M../../../release/examples/benchmarks/miniMD/helpers

--- a/test/studies/prk/stencil/stencil-pretty.compopts
+++ b/test/studies/prk/stencil/stencil-pretty.compopts
@@ -1,6 +1,6 @@
---set validate --set order=100 --iterations=3                                      -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3 --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3 --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3 --set useBlockDist=true              -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set order=100 --iterations=3 --set useStencilDist=true            -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3                                      -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3 --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3 --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3 --set useBlockDist=true              -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --set iterations=3 --set useStencilDist=true            -M../../../release/examples/benchmarks/miniMD/helpers

--- a/test/studies/prk/stencil/stencil-serial-fast.compopts
+++ b/test/studies/prk/stencil/stencil-serial-fast.compopts
@@ -1,4 +1,4 @@
---set validate                                      -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
---set validate                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3
+--set validate --set order=100 --iterations=3 --set tileSize=20
+--set validate --set order=100 --iterations=3                   --set compact=true
+--set validate --set order=100 --iterations=3 --set tileSize=20 --set compact=true

--- a/test/studies/prk/stencil/stencil-serial-fast.compopts
+++ b/test/studies/prk/stencil/stencil-serial-fast.compopts
@@ -1,4 +1,4 @@
---set validate --set order=100 --iterations=3
---set validate --set order=100 --iterations=3 --set tileSize=20
---set validate --set order=100 --iterations=3                   --set compact=true
---set validate --set order=100 --iterations=3 --set tileSize=20 --set compact=true
+--set validate --set order=100 --set iterations=3
+--set validate --set order=100 --set iterations=3 --set tileSize=20
+--set validate --set order=100 --set iterations=3                   --set compact=true
+--set validate --set order=100 --set iterations=3 --set tileSize=20 --set compact=true

--- a/test/studies/prk/stencil/stencil-serial-pretty.compopts
+++ b/test/studies/prk/stencil/stencil-serial-pretty.compopts
@@ -1,4 +1,4 @@
---set validate                                      -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set tileSize=20                    -M../../../release/examples/benchmarks/miniMD/helpers
---set validate                   --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
---set validate --set tileSize=20 --set compact=true -M../../../release/examples/benchmarks/miniMD/helpers
+--set validate --set order=100 --iterations=3
+--set validate --set order=100 --iterations=3 --set tileSize=20
+--set validate --set order=100 --iterations=3                   --set compact=true
+--set validate --set order=100 --iterations=3 --set tileSize=20 --set compact=true

--- a/test/studies/prk/stencil/stencil-serial-pretty.compopts
+++ b/test/studies/prk/stencil/stencil-serial-pretty.compopts
@@ -1,4 +1,4 @@
---set validate --set order=100 --iterations=3
---set validate --set order=100 --iterations=3 --set tileSize=20
---set validate --set order=100 --iterations=3                   --set compact=true
---set validate --set order=100 --iterations=3 --set tileSize=20 --set compact=true
+--set validate --set order=100 --set iterations=3
+--set validate --set order=100 --set iterations=3 --set tileSize=20
+--set validate --set order=100 --set iterations=3                   --set compact=true
+--set validate --set order=100 --set iterations=3 --set tileSize=20 --set compact=true


### PR DESCRIPTION
In my last PRK update (#3288), I resorted back to the default inputs for the correctness tests, which ended up timing out for the slow `--baseline` runs in correctness testing. This PR reduces the inputs to a minimal test, which run in less than 10 seconds, even with `--baseline`.