### PR TITLE
Skip memory/ferguson/test1 for non-cstdlib allocators

### DIFF
--- a/test/memory/ferguson/SKIPIF
+++ b/test/memory/ferguson/SKIPIF
@@ -1,3 +1,7 @@
 CHPL_TARGET_COMPILER==cray-prgenv-gnu
 CHPL_TARGET_COMPILER==cray-prgenv-intel
 CHPL_TARGET_COMPILER==cray-prgenv-pgi
+
+# this test expects the underlying chapel memory allocators be calling malloc()
+# and friends but that's not the case for non-cstdlib allocators
+CHPL_MEM != cstdlib


### PR DESCRIPTION
This test is checking that you can free c_ptr allocations made in Chapel from C
and vice versa. The C code is calling malloc() and friends, which means that in
order for this test to actually work right the Chapel calls must eventually
call down to them as well. However, for non-cstdlib allocators this isn't true.

This test started failing under darwin+gasnet when jemalloc was made the
default allocator, but I have no idea how/why it didn't blow up for any other
platform. It was essentially trying to do things like:

```c
void* ret = malloc(16);
je_free(ret);
```

which is obviously super wrong.