### PR TITLE
Add perf annotations for defaulting to jemalloc for gasnet configurations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -108,6 +108,9 @@ all:
     - Enable the Qthreads tasking shim (#3040)
   01/06/16:
     - Replace filenames with indices into a lookup table (#3049)
+  02/14/16:
+    - text: Default to jemalloc for gasnet configurations
+      config: 16 node XC
 
 AllCompTime:
   11/09/14:


### PR DESCRIPTION
Some nice (and some pretty substantial performance improvements from this):

http://chapel.sourceforge.net/perf/16-node-xc/?startdate=2015/12/28&enddate=2016/02/14&configs=gnugasnetaries&graphs=hpccfftperfgflopsn220,hpcchplreleaseperfgflopsn255nb32,hpcchplhpccversionperfgflopsn22knb200,hpccraatomicsperfgupsn233nu10m,hpccraonperfgupsn233nu10m,sscassca2kernel4secsize1624vertices,doeluleshdensetimesecsedov15oct,doeminimdtimesecsize20