### PR TITLE
Add a .future about promotion not preserving array shape

### DIFF
--- a/STATUS.devel
+++ b/STATUS.devel
@@ -673,6 +673,7 @@ Data Parallelism
   E.g., [i in D] f(i) should result in an array of type: [D] f(i).type
     but instead results in a 1D array
   # arrays/bradc/inferArrayType.future
+  # arrays/tmacd/promotionLosesArrayShape.future
   # reductions/bradc/minmaxlocscan-shape.future
   # sparse/bradc/inferSparseArrayType.future
 - Parallel zippered iteration does not perform runtime size/shape checks

--- a/test/arrays/tmacd/promotionLosesArrayShape.bad
+++ b/test/arrays/tmacd/promotionLosesArrayShape.bad
@@ -1,0 +1,7 @@
+====== N ======
+0 0
+0 0
+[domain(2,int(64),false)] int(64)
+====== NN =====
+0 0 0 0
+[domain(1,int(64),false)] int(64)

--- a/test/arrays/tmacd/promotionLosesArrayShape.chpl
+++ b/test/arrays/tmacd/promotionLosesArrayShape.chpl
@@ -1,0 +1,12 @@
+config const n = 2;
+var b: [0..n+1, 0..n+1, 0..1] int;
+
+const N = b[0..n-1, 0..n-1, 0];
+writeln("====== N ======");
+writeln(N);
+writeln(N.type:string);
+
+const NN = b[0..n-1, 0..n-1, 0] + b[0..n-1, 2..n+1, 0];
+writeln("====== NN =====");
+writeln(NN);
+writeln(NN.type:string); 

--- a/test/arrays/tmacd/promotionLosesArrayShape.future
+++ b/test/arrays/tmacd/promotionLosesArrayShape.future
@@ -1,0 +1,3 @@
+bug: array shape is not preserved in promotion
+
+Promoting '+' over two 2D arrays results in a 1D array

--- a/test/arrays/tmacd/promotionLosesArrayShape.good
+++ b/test/arrays/tmacd/promotionLosesArrayShape.good
@@ -1,0 +1,8 @@
+====== N ======
+0 0
+0 0
+[domain(2,int(64),false)] int(64)
+====== NN =====
+0 0
+0 0
+[domain(2,int(64),false)] int(64)


### PR DESCRIPTION
File a .future on behalf of @tmacd9.  Promoting the '+' operator for two 2D
arrays currently results in a 1D array.