### PR TITLE
Improve isDataContiguous by removing check against the origin.

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1312,12 +1312,10 @@ module DefaultRectangular {
     }
   }
 
-  // This is very conservative.  For example, it will return false for
-  // 1-d array aliases that are shifted from the aliased array.
+  // This is very conservative.
   proc DefaultRectangularArr.isDataContiguous() {
     if debugDefaultDistBulkTransfer then
       writeln("isDataContiguous(): origin=", origin, " off=", off, " blk=", blk);
-    if origin != 0 then return false;
   
     for param dim in 1..rank do
       if off(dim)!= dom.dsiDim(dim).first then return false;


### PR DESCRIPTION
Removes a check that prevents bulk transfer from firing for shifted aliases, or if an array's indices are 0-based. Neither imply anything fundamental about contiguous storage. This check has existed since it was added in 769c0ac. I have tested the following directories without failure:

- distributions/
- release/
- multilocale/
- optimizations/bulkcomm/