### PR TITLE
Fix extern block tests under llvm+jemalloc

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -1094,11 +1094,11 @@ void runClang(const char* just_parse_filename) {
 
   std::string readargsfrom;
 
-  if( just_parse_filename ) {
+  if( !llvmCodegen && just_parse_filename ) {
     // We're handling an extern block and not using the LLVM backend.
-    // Don't change CHPL_TARGET_COMPILER or ask for any compiler-specific
-    // C flags. Just get the neccesary includes and defines.
-    readargsfrom = compileline + " --llvm-install-dir"
+    // Don't ask for any compiler-specific C flags.
+    readargsfrom = compileline + " --llvm"
+                                 " --llvm-install-dir"
                                  " --clang-sysroot-arguments"
                                  " --includes-and-defines";
   } else {


### PR DESCRIPTION
When jemalloc was made the default allocator for gasnet, the extern block tests
started failing. The reason for this is because we were trying to compile with
the gnu build of jemalloc instead of the clang-included version. This was due
to a call to `compileline` not knowing to use the clang-included builds.

This patch fixes a bug where we would use a code path intended for extern
blocks with the C backend even when `--llvm` was thrown. This was enough to fix
the extern block tests when `--llvm` is thrown, but didn't fix the case where
you had extern blocks, but were using the C backend. To fix that, we also need
to add `--llvm` to the compileline for extern blocks so we pull in the right
headers then.

This fix was suggested by Michael. I was mostly just the testing guinea pig