### PR TITLE
Just limit the IPA level instead of throwing -O1 for CCE builds of jemalloc

### DIFF
--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -12,10 +12,19 @@ ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_JEMALLOC_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
 endif
 
-# Can't build under cce with `-hgnu` or anything above `-O1`. Additionally,
-# CCE doesn't support the dependency flags that jemalloc expects (-MM -MT)
+# Can't build under CCE with gcc extensions enabled or with high levels of
+# interprocedural analysis on. The build fails with -hipa3 (the default) or
+# higher so we limit to a max of -hipa2. Additionally, CCE doesn't have the
+# dependency flags that jemalloc expects (-MM -MT)
 ifeq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)
-CFLAGS += -hnognu -O1
+CFLAGS += -hnognu
+
+ifeq ($(OPTIMIZE), 1)
+CFLAGS += -hipa2
+else
+CFLAGS += -hipa0
+endif
+
 CHPL_JEMALLOC_MAKE_OPTIONS += CC_MM=''
 endif
 


### PR DESCRIPTION
IPA is the specific optimization that prevents jemalloc from building under
CCE. Instead of disabling most optimizations by throwing `-O1` just throw
`-hipa2`. The default is `-hipa3`  and that or anything higher results in a
build failure.

This allows us to build with a pretty high level of IPA and all other
optimizations enabled.