### PR TITLE
Hacky fix for jemalloc w/ hugepage issues

### DIFF
--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -41,11 +41,10 @@ static inline void* chpl_malloc(size_t size) {
 }
 
 static inline void* chpl_memalign(size_t boundary, size_t size) {
-  void* ret = NULL;
-  int rc;
-  rc = je_posix_memalign(&ret, boundary, size);
-  if( rc == 0 ) return ret;
-  else return NULL;
+  if (boundary == 0) {
+    return je_malloc(size);
+  }
+  return je_aligned_alloc(boundary, size);
 }
 
 static inline void* chpl_realloc(void* ptr, size_t size) {


### PR DESCRIPTION
I've been getting OOM issues when using jemalloc with hugepages loaded. It
turns out the reason is because we're generating some bogus code that's calling
chpl_memalign with an alignment of 0, but alignment must be a power of 2 at
least as large as sizeof(void*).

It's a bug that we're calling it like this, but for now I'm working around this
by just calling malloc if alignment is zero. Note that our other allocators
seem to work, so presumably they handle an alignment of zero, but jemalloc
chooses not to.