### PR TITLE
Adjust SKIPIF to skip darwin

### DIFF
--- a/test/memory/ferguson/SKIPIF
+++ b/test/memory/ferguson/SKIPIF
@@ -2,6 +2,6 @@ CHPL_TARGET_COMPILER==cray-prgenv-gnu
 CHPL_TARGET_COMPILER==cray-prgenv-intel
 CHPL_TARGET_COMPILER==cray-prgenv-pgi
 
-# this test expects the underlying chapel memory allocators be calling malloc()
-# and friends but that's not the case for non-cstdlib allocators
-CHPL_MEM != cstdlib
+# this test uses libchplmalloc, which only works
+# on glibc systems (and is known not to work on Mac OS X)
+CHPL_TARGET_PLATFORM != linux64


### PR DESCRIPTION
Follow-on to PR #3295. This test uses libchplmalloc, which
only works on glibc platforms (and not on Mac OS X).
Adjusts the SKIPIF file to reflect that.