### PR TITLE
Fix unintentional naming conflict bug related to the 'except' list

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2025,30 +2025,32 @@ static bool lookupThisScopeAndUses(BaseAST* scope, const char * name,
         }
 
         forv_Vec(UseStmt, use, *moduleUses) {
-          if (use && !use->skipSymbolSearch(name)) {
-            SymExpr* se = toSymExpr(use->mod);
-            INT_ASSERT(se);
-            ModuleSymbol* mod = toModuleSymbol(se->var);
-            INT_ASSERT(mod);
-            if (Symbol* sym = inSymbolTable(mod->block, name)) {
-              if (sym->hasFlag(FLAG_PRIVATE)) {
-                if (rejectedPrivateIds.find(sym->id) ==
-                    rejectedPrivateIds.end()) {
-                  // The symbol found was not one of the already rejected
-                  // private symbols
-                  if (!sym->isVisible(callingContext)) {
-                    rejectedPrivateIds.insert(sym->id);
-                  } else {
-                    if (!isRepeat(symbols, sym)) {
-                      symbols.push_back(sym);
+          if (use) {
+            if (!use->skipSymbolSearch(name)) {
+              SymExpr* se = toSymExpr(use->mod);
+              INT_ASSERT(se);
+              ModuleSymbol* mod = toModuleSymbol(se->var);
+              INT_ASSERT(mod);
+              if (Symbol* sym = inSymbolTable(mod->block, name)) {
+                if (sym->hasFlag(FLAG_PRIVATE)) {
+                  if (rejectedPrivateIds.find(sym->id) ==
+                      rejectedPrivateIds.end()) {
+                    // The symbol found was not one of the already rejected
+                    // private symbols
+                    if (!sym->isVisible(callingContext)) {
+                      rejectedPrivateIds.insert(sym->id);
+                    } else {
+                      if (!isRepeat(symbols, sym)) {
+                        symbols.push_back(sym);
+                      }
                     }
                   }
-                }
-                // If it was already rejected, we don't want to add it.
+                  // If it was already rejected, we don't want to add it.
 
-              } else if (!isRepeat(symbols, sym)) {
-                // Don't want to add if the symbol itself was already present.
-                symbols.push_back(sym);
+                } else if (!isRepeat(symbols, sym)) {
+                  // Don't want to add if the symbol itself was already present.
+                  symbols.push_back(sym);
+                }
               }
             }
           } else {

--- a/test/visibility/except/noResolveConflict.chpl
+++ b/test/visibility/except/noResolveConflict.chpl
@@ -1,0 +1,24 @@
+module A {
+  var foo = 13;
+}
+
+module B {
+  var bar = -2;
+  var foo = 34.2;
+}
+
+module C {
+  var foo = true;
+}
+
+module M {
+  use A;
+  use B except foo;
+  use C;
+  // Verifies the behavior when more than two uses cause a naming conflict and
+  // there is only an 'except' list on one of them.
+
+  proc main() {
+    writeln(foo);
+  }
+}

--- a/test/visibility/except/noResolveConflict.good
+++ b/test/visibility/except/noResolveConflict.good
@@ -1,0 +1,2 @@
+noResolveConflict.chpl:2: error: Symbol foo multiply defined
+noResolveConflict.chpl:11: error: Symbol foo multiply defined


### PR DESCRIPTION
In doing my renaming work, I realized that I accidentally caused a situation where
three or more modules that were in conflict would stop reporting a conflict
if the second one avoided it via an 'except' list but the third one
was unmodified - e.g. if A, B and C all define a symbol 'foo', then

use A;
use B;
use C;

would cause a naming conflict, but

use A;
use B except foo;
use C;

wouldn't, when really A.foo and C.foo should still conflict.

The fix is really straight forward, just move the check for the 'only' or
'except' list into an inner scope so that we don't fall to the "are we done
searching for this name" check too early.