### PR TITLE
Fix DefaultRectangularArr.dsiSerialWrite's use of channel.writeBytes

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1287,7 +1287,9 @@ module DefaultRectangular {
       if boundsChecking then
         assert((len:uint*elemSize:uint) <= max(ssize_t):uint,
                "length of array to write is greater than ssize_t can hold");
-      f.writeBytes(data, len:ssize_t*elemSize:ssize_t);
+      const src = this.theData;
+      const idx = getDataIndex(this.dom.dsiLow);
+      f.writeBytes(_ddata_shift(src.eltType, src, idx), len:ssize_t*elemSize:ssize_t);
     } else {
       this.dsiSerialReadWrite(f);
     }


### PR DESCRIPTION
The dsiSerialWrite function was passing in the base data pointer to
the writeBytes function. This would result in incorrect output if the
array was a sliced offset. The solution is to pass in a ddata shifted
based on the domain's lowest index.

This was exposed by 7021419c, which changed the result of the function
"isDataContiguous".