### PR TITLE
Fix issues encountered with jemalloc+hugepages

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -83,21 +83,24 @@ size_t chpl_getHeapPageSize(void) {
     if ((ev = getenv("HUGETLB_DEFAULT_PAGE_SIZE")) == NULL)
       pageSize = chpl_getSysPageSize();
     else {
-      int scanCnt;
+
       size_t tmpPageSize;
+      int  num_scanned;
       char units;
 
-      if ((scanCnt = sscanf(ev, "%zd%1[kKmMgG]", &tmpPageSize, &units)) > 0) {
-        if (scanCnt == 2) {
+      if ((num_scanned = sscanf(ev, "%zi%c", &tmpPageSize, &units)) != 1) {
+        if (num_scanned == 2 && strchr("kKmMgG", units) != NULL) {
           switch (units) {
           case 'k': case 'K': tmpPageSize <<= 10; break;
           case 'm': case 'M': tmpPageSize <<= 20; break;
           case 'g': case 'G': tmpPageSize <<= 30; break;
           }
         }
+        else {
+          chpl_internal_error("unexpected HUGETLB_DEFAULT_PAGE_SIZE syntax");
+        }
       }
-      else
-        chpl_internal_error("unexpected HUGETLB_DEFAULT_PAGE_SIZE syntax");
+
       pageSize = tmpPageSize;
     }
 #else


### PR DESCRIPTION
I've been running into what I thought were OOMs when I was using jemalloc with a
hugepage module loaded. It turns out that we were calling je_posix_memalign
with an alignment of 0, but "alignment must be a power of 2 at least as large
as sizeof(void *)" Because of this, we were getting an EINVAL back and halting
in some IO code.

This was a really obscure issue that only occurred when a hugepage module was
loaded. However, if I built with CHPL_TARGET_COMPILER=cray-prgenv-intel, things
seemed to just work.

The issue turned out to be that the code that processes
HUGETLB_DEFAULT_PAGE_SIZE to determine what the pagesize is was buggy.

chpl_getHeapPageSize() processes the value of HUGETLB_DEFAULT_PAGE_SIZE to
determine how big our heap page size is. However, its processing was wrong and
we ended up overriding our pagesize, causing it to be set to 0.

Then in chpl_valloc() we call `chpl_memalign(chpl_getHeapPageSize(), size);`
Since chpl_getHeapPageSize() was returning 0, this caused us to call memalign
with an alignment of 0 leading to these issues.

If HUGETLB_DEFAULT_PAGE_SIZE isn't set, chpl_getHeapPageSize() just returns the
system pagesize, which explains why this only caused issues when a hugepage
module was loaded. As far as why things worked with intel, it's likely that the
stack layout was slightly different (or something was aligned differently) such
that we didn't override our pagesize value.

To fix this issue, I copied the processing code that we use for
CHPL_RT_MAX_HEAP_SIZE. Longer term, we should create common env var processing
functions. We already have a start of that in chpl-env.c, but some more
functions are needed.