### PR TITLE
Isx cleanups

### DIFF
--- a/test/studies/isx/TODO
+++ b/test/studies/isx/TODO
@@ -1,0 +1,88 @@
+Performance issues
+------------------
+* atomics:
+  - all atomics are used locally, but utilize on-clauses and result
+    in on-clauses and their overhead related to bundling arguments
+    and the like.  A case for locality optimizations and/or user
+    hints/tags
+  - On systems with network atomics, like Crays, we're using the
+    network atomics path even though processor atomics are sufficient
+    and would be preferable.  Can we automatically optimize this based
+    on efforts similar to the above bullet?  And/or have the user mark
+    them as such.
+
+* returning arrays:
+  - we're currently returning arrays from procedures which causes
+    us to have two arrays live simultaneously and a copy between
+    them.  The copy doesn't seem to have a significant overall
+    performance impact (see isx-no-return.chpl), but can strain the
+    memory system of smaller-memory provisions (see bradc-lnx
+    performance results)
+
+Variants we might want to write
+-------------------------------
+* a global-view version (already in-progress on a branch of Brad's)
+
+* a version in which we explicitly do SPMD-style parallelism across
+  cores as well as locales in order to avoid using atomics at all
+  - and/or could a single version automatically switch between using
+    atomics and not based on number of buckets per locale?
+
+* a verion in which histogramming (countLocalKeys) is done in parallel
+  with exchange keys (using a cobegin, say); the exchange keys task
+  would write a "done"-style sync variable when a 'put' was complete
+  and the next task could begin aggressively histogramming the next
+  buffer's worth of data.
+
+* a version in which countLocalKeys() used a global histogram rather
+  than a local one.  Doing this and moving it outside of the coforall
+  would permit us to remove the barrier from within the coforall (?)
+
+
+Other TODOs
+-----------
+* Unify PCG usage with reference version
+  - reference version uses pcg32_srandom_r() which takes a second stream
+    ID argument
+  - PCG supports an ability to safely clamp values to a [0, maxKeyVal)
+    range.  The PCG interface we're using doesn't currently, so I did
+    it manually in the code.  Switch to a lower-level interface that
+    does the clamping and/or make sure that I don't have bugs in my
+    clamping logic.
+
+* It'd be interesting to look at this code in chplvis
+
+* Make bucketsPerLocale and numBuckets configurable in the bucket-based
+  versions?
+
+* Come up with a better name for the barrier variable?
+
+* Introduce a main() procedure?
+
+* What would it take to use a forall over BucketSpace in the
+  bucket-based versions?  It seems attractive, but also seems like
+  it'd break the barrier synchronization.
+
+* Consider using nested procedures within bucketSort() for the helper
+  routines to avoid passing so much state around?  Or is that crazy?
+
+* Related: should we avoid the use of globals and/or pass them into
+  and out of routines?
+
+* In countLocalKeys, can we use a ref/array alias to
+  myBucketKeys[bucketID] to avoid redundant reindexing in
+  countLocalKeys()?
+  
+
+Language TODOs
+--------------
+* The stats would be much more complete (while remaining elegant/
+  efficient) if we had min/max task reduction intents...
+  
+* Should we be able to support scans on arrays of atomics without a
+  .read()?
+
+* We really want an exclusive scan, but Chapel's is inclusive.  Wasn't
+  the original plan to support both?  Does code exist for this that
+  simply isn't accessible currently?
+  

--- a/test/studies/isx/isx-bucket-spmd.graph
+++ b/test/studies/isx/isx-bucket-spmd.graph
@@ -1,5 +1,5 @@
 perfkeys: total =, bucket count =, bucket offset =, bucketize =, exchange =, count keys =
-files: isx-bucket-spmd.dat
+repeat-files: isx-bucket-spmd.dat
 graphkeys: total time, bucket count time, bucket offset time, bucketize time, exchange time, count keys time
 ylabel: Time (seconds)
 graphtitle: ISx (SPMD over Buckets)

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -11,28 +11,6 @@
 //
 
 //
-// Top priorities:
-// - performance analysis / chplvis
-
-// TODO:
-// * variants that we should try
-//   - multiple buckets per locale w/out any atomic ints
-//   - some sort of hybrid between the current 1 bucket per locale scheme
-//     and the previous?
-
-//
-// TODO: What are the potential performance issues?
-// * put as one message?
-//   - not currently happening due to origin check in bulk transfer
-//     optimization -- will fix in future revision to see performance
-//     impact.
-// * how do Ben's locality optimizations do?
-// * does returning arrays cost us anything?  Do we leak them?
-// * other?
-// * (this would be a good chplvis demo)
-//
-
-//
 // We want to use block-distributed arrays (BlockDist), barrier
 // synchronization (Barrier), and timers (Time).
 //
@@ -85,10 +63,10 @@ config const mode = scaling.weak;
 config const n = if testrun then 32 else 2**27;
 
 //
-// TODO: permit these to be configurable
+// The number of buckets per locale and total number of buckets.
 //
 const bucketsPerLocale = 1;
-const numBuckets = numLocales;
+const numBuckets = numLocales * bucketsPerLocale;
 
 //
 // The total number of keys
@@ -165,26 +143,13 @@ var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
     exchangeKeysTime, countKeysTime: [BucketSpace] [1..numTrials] real;
 var verifyKeyCount: atomic int;
 
-//
-// TODO: better name?
-//
 var barrier = new Barrier(numBuckets);
 
-//
-// TODO: introduce a main()
-//
-
-// TODO: This seems attractive, but also like it will break the barrier:
-// forall bucketID in BucketSpace {
 coforall bucketID in BucketSpace do
   on BucketDist.idxToLocale(bucketID) {
     //
     // Execution is SPMD-style across buckets here
     //
-    // TODO: remove this once we feel confident it's working
-    //
-    if allBucketKeys[bucketID][0].locale != here then
-      warning("Need to distribute allBucketKeys");
 
     //
     // The non-positive iterations represent burn-in runs, so don't
@@ -192,11 +157,6 @@ coforall bucketID in BucketSpace do
     // the final timed run.
     //
     for i in 1-numBurnInRuns..numTrials do
-      //
-      // TODO: Could make all other procedures nested in this loop
-      // to let them refer to bucketID non-locally?  Or is that
-      // crazy?
-      //
       bucketSort(bucketID, trial=i, time=printTimings && (i>0),
                  verify=(i==numTrials));
   }
@@ -239,13 +199,6 @@ proc bucketSort(bucketID, trial: int, time = false, verify = false) {
     subTimer.clear();
   }
 
-  //
-  // TODO: Should we be able to support scans on arrays of atomics without a
-  // .read()?
-  //
-  // TODO: We really want an exclusive scan, but Chapel's is inclusive... :(
-  // Weren't we planning on supporting both?
-  //
   var sendOffsets: [LocBucketSpace] int = + scan bucketSizes.read();
   sendOffsets -= bucketSizes.read();
   if debug then writeln(bucketID, ": sendOffsets = ", sendOffsets);
@@ -255,9 +208,6 @@ proc bucketSort(bucketID, trial: int, time = false, verify = false) {
     subTimer.clear();
   }
 
-  //
-  // TODO: should we pass our globals into/out of these routines?
-  //
   var myBucketedKeys: [0..#keysPerBucket] keyType;
   bucketizeLocalKeys(myBucketedKeys, bucketID, myKeys, sendOffsets);
 
@@ -274,21 +224,6 @@ proc bucketSort(bucketID, trial: int, time = false, verify = false) {
     subTimer.clear();
   }
 
-  //
-  // TODO: discussed with Jake a version in which the histogramming
-  // (countLocalKeys) was done in parallel with the exchangeKeys;
-  // the exchange keys task would write a "done"-style sync variable
-  // when a put was complete and the task could begin aggressively
-  // histogramming the next buffer's worth of data.  Use a cobegin
-  // to kick off both of these tasks in parallel and know when they're
-  // both done.
-  //
-
-  //
-  // TODO: what if we used a global histogram here instead?
-  // Note that if we did so and moved this outside of the coforall,
-  // we could also remove the barrier from within the coforall
-  //
   const myMinKeyVal = bucketID * bucketWidth;
   var myLocalKeyCounts: [myMinKeyVal..#bucketWidth] atomic int;
   const keysInMyBucket = recvOffset[bucketID].read();
@@ -328,8 +263,6 @@ proc bucketizeLocalKeys(myBucketedKeys, bucketID, myKeys, sendOffsets) {
 
 
 proc countLocalBucketSizes(bucketSizes, myKeys) {
-  // TODO: if adding numBuckets, change to that here
-
   forall key in myKeys {
     const bucketIndex = key / bucketWidth;
     bucketSizes[bucketIndex].add(1);
@@ -346,12 +279,7 @@ proc exchangeKeys(bucketID, sendOffsets, bucketSizes, myBucketedKeys) {
     const transferSize = bucketSizes[dstBucketID].read();
     const dstOffset = recvOffset[dstBucketID].fetchAdd(transferSize);
     const srcOffset = sendOffsets[dstBucketID];
-    //
-    // TODO: are we implementing this with one communication?
-    // Answer (BenH): No, due to int(32)/int(64) mismatch.  Leaving
-    // it as is now in order to measure the perf difference in the
-    // test system.
-    //
+
     allBucketKeys[dstBucketID][dstOffset..#transferSize] = 
              myBucketedKeys[srcOffset..#transferSize];
   }
@@ -360,10 +288,6 @@ proc exchangeKeys(bucketID, sendOffsets, bucketSizes, myBucketedKeys) {
 
 
 proc countLocalKeys(myLocalKeyCounts, bucketID, myBucketSize, myMinKeyVal) {
-  //
-  // TODO: Can we use a ref/array alias to myBucketKeys[bucketID] to avoid
-  // redundant indexing?
-  //
   forall i in 0..#myBucketSize do
     myLocalKeyCounts[allBucketKeys[bucketID][i]].add(1);
 
@@ -414,11 +338,6 @@ proc makeInput(myKeys, bucketID) {
   if (debug) then
     writeln(bucketID, ": Calling pcg32_srandom_r with ", bucketID);
 
-  //
-  // TODO: The reference version of ISx uses pcg32_srandom_r(), which
-  // takes a second argument in addition to the seed to specify a stream
-  // ID.  Should/can our PCG interface do that as well?
-  //
   var MyRandStream = new PCGRandomStream(seed = here.id,
                                          parSafe=false,
                                          eltType = keyType);
@@ -432,14 +351,6 @@ proc makeInput(myKeys, bucketID) {
   // is in [0, maKeyVal) before storing it to key.  This is tricky when
   // maxKeyVal isn't a power of two and so we take some care to keep the
   // value distributed evenly.
-  //
-  // TODO: Double-check that I don't have an off-by-one error here.
-  // Having one would not make the code break, but would imply
-  // that we're not evenly distributing the random numbers.
-  //
-  // TODO: The C PCG takes care of this bounding automatically.  Should
-  // our PCG interface do so as well?  (Can it if it's being called
-  // in parallel?  Seems unlikely...)
   //
   const maxModdableKeyVal = max(keyType) - max(keyType)%maxKeyVal;
   for key in myKeys do

--- a/test/studies/isx/isx-no-return.graph
+++ b/test/studies/isx/isx-no-return.graph
@@ -1,5 +1,5 @@
 perfkeys: total =, bucket count =, bucket offset =, bucketize =, exchange =, count keys =
-files: isx-no-return.dat
+repeat-files: isx-no-return.dat
 graphkeys: total time, bucket count time, bucket offset time, bucketize time, exchange time, count keys time
 ylabel: Time (seconds)
 graphtitle: ISx (Avoids array returns)

--- a/test/studies/isx/isx-spmd.graph
+++ b/test/studies/isx/isx-spmd.graph
@@ -1,5 +1,5 @@
 perfkeys: total =, bucket count =, bucket offset =, bucketize =, exchange =, count keys =
-files: isx-spmd.dat
+repeat-files: isx-spmd.dat
 graphkeys: total time, bucket count time, bucket offset time, bucketize time, exchange time, count keys time
 ylabel: Time (seconds)
 graphtitle: ISx (SPMD over Locales)


### PR DESCRIPTION
This PR has a few simple cleanups to the ISx directory:

[trivial, not reviewed]

* refactors all TODO-related comments into a file named TODO.  Keeping these up-to-date as they're addressed and across multiple versions was getting ridiculous and the code is cleaner as a result.

* changes the 'files' labels in my graph files to 'repeat-files' which @ronawho tells me is the right thing to do in cases like this where all keys are from a single file.  While the old approach seems to work for our single-locale testing, it doesn't in other configurations apparently (?).
