### PR TITLE
Make jemalloc our default allocator for comm=ugni

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -368,8 +368,7 @@ CHPL_MEM
         ========= =======================================================
 
    If unset, ``CHPL_MEM`` defaults to ``cstdlib`` if comm is ``none``,
-   ``jemalloc`` if comm is ``gasnet``, and ``tcmalloc`` if comm is
-   ``ugni``.
+   otherwise it defaults to ``jemalloc``.
 
 
 CHPL_LAUNCHER

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -18,10 +18,8 @@ def get(flag='host'):
         mem_val = os.environ.get('CHPL_MEM')
         if not mem_val:
             comm_val = chpl_comm.get()
-            if comm_val == 'gasnet':
+            if comm_val != 'none':
                 mem_val='jemalloc'
-            elif comm_val == 'ugni':
-                mem_val = 'tcmalloc'
             else:
                 mem_val = 'cstdlib'
     else:


### PR DESCRIPTION
Use jemalloc instead of tcmalloc when CHPL_COMM=ugni

This is second stage of making jemalloc our default allocator. I did some
manual performance comparisons against  tcmalloc for our multi-locale
performance tests. It looks like performance is basically the same. This is
actually pretty good news, I was worried that tcmalloc might beat jemalloc for
some tests, but they look about even.

I also ran correctness testing for release/examples with gnu+ugni+qthreads.
I'll let nightly take care of the other configurations.