### PR TITLE
Make sure Qthreads knows how much per-task private storage we need.

### DIFF
--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -654,6 +654,16 @@ void chpl_task_init(void)
     hwpar = setupAvailableParallelism(commMaxThreads);
     setupCallStacks(hwpar);
 
+    // Make sure Qthreads supplies enough space for our task-local needs.
+    {
+        unsigned long int tasklocal_size = chpl_qt_getenv_num("TASKLOCAL_SIZE", 0);
+        if (tasklocal_size < sizeof(chpl_qthread_tls_t)) {
+            char newenv[QT_ENV_S];
+            snprintf(newenv, sizeof(newenv), "%zu", sizeof(chpl_qthread_tls_t));
+            chpl_qt_setenv("TASKLOCAL_SIZE", newenv, 1);
+        }
+    }
+
     if (verbosity >= 2) { chpl_qt_setenv("INFO", "1", 0); }
 
     // Initialize qthreads


### PR DESCRIPTION
WHile researching a different problem (fixed in PR #3323) I happened to
check the size of Qthreads tasklocal storage and found that it was only
8 bytes, much less than the 30 or so bytes we actually use, depending on
configuration.  Here, before initializing Qthreads, set the environment
variable that tells it how much space per task to reserve for tasklocal
storage.

As far as I know we we haven't seen problems due to failure to set this
properly, and don't know what the symptoms might be of failing to set
it, but certainly it doesn't seem wise to leave things as they are.