### PR TITLE
Add warnings/errors when identifiers are repeated in 'except' or 'only' lists

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -445,7 +445,7 @@ BlockStmt* buildUseStmt(Expr* mod, std::vector<OnlyRename*>* names, bool except)
           if (renameMap.count(new_name->unresolved) == 0) {
             renameMap[new_name->unresolved] = old_name->unresolved;
           } else {
-            USR_FATAL_CONT(elem->first, "already renamed '%s' to '%s'", renameMap[new_name->unresolved], new_name->unresolved);
+            USR_FATAL_CONT(elem->first, "already renamed '%s' to '%s', renaming '%s' would conflict", renameMap[new_name->unresolved], new_name->unresolved, old_name->unresolved);
           }
         } else {
           useListError(elem->first, except);

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -102,6 +102,8 @@ class UseStmt : public Stmt {
 
   bool matchedNameOrConstructor(const char* name);
   bool inRelatedNames(const char* name);
+
+  void noRepeats();
 };
 
 /************************************ | *************************************

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -501,7 +501,7 @@ void UseStmt::noRepeats() {
   for (std::vector<const char*>::iterator it = named.begin();
        it != named.end(); ++it) {
     std::vector<const char*>::iterator next = it;
-    for (std::advance(next, 1); next != named.end(); ++next) {
+    for (++next; next != named.end(); ++next) {
       // Check rest of named for the same name
       if (!strcmp(*it, *next)) {
         USR_WARN(this, "identifier '%s' is repeated", *it);
@@ -524,7 +524,7 @@ void UseStmt::noRepeats() {
   for (std::map<const char*, const char*>::iterator it = renamed.begin();
        it != renamed.end(); ++it) {
     std::map<const char*, const char*>::iterator next = it;
-    for (std::advance(next, 1); next != renamed.end(); ++next) {
+    for (++next; next != renamed.end(); ++next) {
       if (!strcmp(it->second, next->second)) {
         // Renamed this variable twice.  Probably a mistake on the user's part,
         // but not a catastrophic one

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -488,7 +488,7 @@ void UseStmt::validateList() {
     Symbol* sym = lookup(module->block, it->second);
 
     if (!sym) {
-      USR_FATAL_CONT(this, "Bad identifier in rename, no known '%s'", it->second);
+      USR_FATAL_CONT(this, "Bad identifier in rename, no known '%s' in module '%s'", it->second, module->name);
     } else if (!sym->isVisible(this)) {
       USR_FATAL_CONT(this, "Bad identifier in rename, '%s' is private", it->second);
     }
@@ -534,18 +534,18 @@ void UseStmt::noRepeats() {
         // This name is the old_name in one rename and the new_name in another
         // Did the user actually want to cut out the middle man?
         USR_WARN(this, "identifier '%s' is repeated", it->second);
-        USR_PRINT("Did you mean '%s' as '%s'?", next->second, it->first);
+        USR_PRINT("Did you mean to rename '%s' to '%s'?", next->second, it->first);
       }
       if (!strcmp(it->first, next->second)) {
         // This name is the old_name in one rename and the new_name in another
         // Did the user actually want to cut out the middle man?
         USR_WARN(this, "identifier '%s' is repeated", it->first);
-        USR_PRINT("Did you mean '%s' as '%s'?", it->second, next->first);
+        USR_PRINT("Did you mean to rename '%s' to '%s'?", it->second, next->first);
       }
-      if (!strcmp(it->first, next->first)) {
-        // Two symbols were renamed to the same name.  Naming conflict!
-        USR_FATAL_CONT(this, "symbol '%s' multiply defined", it->first);
-      }
+      // Two symbols can't be renamed to the same name because the map can only
+      // store one entry with a given key.  We catch this case in build.cpp
+      // when creating the UseStmt.  No need to check it->first matching
+      // next->first.
     }
   }
 }

--- a/test/visibility/except/repeatInList.chpl
+++ b/test/visibility/except/repeatInList.chpl
@@ -1,0 +1,23 @@
+module Foo {
+  var a = 14.2;
+
+  const b: bool;
+
+  proc c() {
+    writeln("wheeeee");
+  }
+
+  proc d(x: int) {
+    return x * 2 + 4;
+  }
+}
+
+module M {
+  use Foo except a, a;
+  // Verifies that the user is informed when they repeat an identifier in an
+  // only list.
+
+  proc main() {
+    writeln(b);
+  }
+}

--- a/test/visibility/except/repeatInList.chpl
+++ b/test/visibility/except/repeatInList.chpl
@@ -15,7 +15,7 @@ module Foo {
 module M {
   use Foo except a, a;
   // Verifies that the user is informed when they repeat an identifier in an
-  // only list.
+  // except list.
 
   proc main() {
     writeln(b);

--- a/test/visibility/except/repeatInList.good
+++ b/test/visibility/except/repeatInList.good
@@ -1,0 +1,2 @@
+repeatInList.chpl:16: warning: identifier 'a' is repeated
+false

--- a/test/visibility/only/repeatInList.chpl
+++ b/test/visibility/only/repeatInList.chpl
@@ -1,0 +1,23 @@
+module Foo {
+  var a = 14.2;
+
+  const b: bool;
+
+  proc c() {
+    writeln("wheeeee");
+  }
+
+  proc d(x: int) {
+    return x * 2 + 4;
+  }
+}
+
+module M {
+  use Foo only a, a;
+  // Verifies that the user is informed when they repeat an identifier in an
+  // only list.
+
+  proc main() {
+    writeln(a);
+  }
+}

--- a/test/visibility/only/repeatInList.good
+++ b/test/visibility/only/repeatInList.good
@@ -1,0 +1,2 @@
+repeatInList.chpl:16: warning: identifier 'a' is repeated
+14.2

--- a/test/visibility/rename/badOldName.good
+++ b/test/visibility/rename/badOldName.good
@@ -1,1 +1,1 @@
-badOldName.chpl:8: error: Bad identifier in rename, no known 'br'
+badOldName.chpl:8: error: Bad identifier in rename, no known 'br' in module 'Foo'

--- a/test/visibility/rename/chainInSameUse.chpl
+++ b/test/visibility/rename/chainInSameUse.chpl
@@ -1,0 +1,17 @@
+module Foo {
+  var a = -12;
+
+  var b = "fie";
+}
+
+module M {
+  use Foo only a as bleep, bleep as bloop;
+  // In this test, the user has attempted to create a rename chain within a
+  // single use.  Compile as if the use of "bleep" as an old name was intended
+  // to refer to a bleep within Foo itself, and warn the user in case they
+  // really wanted to rename a to bloop.
+
+  proc main() {
+    writeln(bloop);
+  }
+}

--- a/test/visibility/rename/chainInSameUse.good
+++ b/test/visibility/rename/chainInSameUse.good
@@ -1,0 +1,3 @@
+chainInSameUse.chpl:8: warning: identifier 'bleep' is repeated
+note: Did you mean to rename 'a' to 'bloop'?
+chainInSameUse.chpl:8: error: Bad identifier in rename, no known 'bleep' in module 'Foo'

--- a/test/visibility/rename/chainInSameUse2.chpl
+++ b/test/visibility/rename/chainInSameUse2.chpl
@@ -1,0 +1,20 @@
+module Foo {
+  var a = -12;
+
+  var b = "fie";
+
+  var bleep = false;
+}
+
+module M {
+  use Foo only a as bleep, bleep as bloop;
+  // In this test, for some reason the user wants to use bleep to refer to
+  // a symbol that isn't Foo.bleep, but they still want to access Foo.bleep.
+  // We'll warn them about the multiple mentions of the same name (and
+  // hopefully they'll come to their senses), but otherwise leave it.
+
+  proc main() {
+    writeln(bloop);
+    writeln(bleep);
+  }
+}

--- a/test/visibility/rename/chainInSameUse2.good
+++ b/test/visibility/rename/chainInSameUse2.good
@@ -1,0 +1,4 @@
+chainInSameUse2.chpl:10: warning: identifier 'bleep' is repeated
+note: Did you mean to rename 'a' to 'bloop'?
+false
+-12

--- a/test/visibility/rename/innerExcept.good
+++ b/test/visibility/rename/innerExcept.good
@@ -1,1 +1,1 @@
-innerExcept.chpl:14: error: Bad identifier in rename, no known 'bar'
+innerExcept.chpl:14: error: Bad identifier in rename, no known 'bar' in module 'A'

--- a/test/visibility/rename/renameConflictInList.chpl
+++ b/test/visibility/rename/renameConflictInList.chpl
@@ -1,0 +1,15 @@
+module Foo {
+  var bar = 42;
+
+  var baz = 19.6;
+}
+
+module M {
+  use Foo only bar as baz, baz;
+  // Should cause a naming conflict on the use statement.  Arbitrarily choosing
+  // one of them would be confusing.
+
+  proc main() {
+    writeln(baz);
+  }
+}

--- a/test/visibility/rename/renameConflictInList.good
+++ b/test/visibility/rename/renameConflictInList.good
@@ -1,2 +1,1 @@
 renameConflictInList.chpl:8: error: symbol 'baz' multiply defined
-renameConflictInList.chpl:8: error: symbol 'baz' multiply defined

--- a/test/visibility/rename/renameConflictInList.good
+++ b/test/visibility/rename/renameConflictInList.good
@@ -1,0 +1,2 @@
+renameConflictInList.chpl:8: error: symbol 'baz' multiply defined
+renameConflictInList.chpl:8: error: symbol 'baz' multiply defined

--- a/test/visibility/rename/repeatNewNames.chpl
+++ b/test/visibility/rename/repeatNewNames.chpl
@@ -1,0 +1,13 @@
+module Foo {
+  var a = -12;
+
+  var b = "fie";
+}
+
+module M {
+  use Foo only a as bleep, b as bleep;
+
+  proc main() {
+    writeln(bleep);
+  }
+}

--- a/test/visibility/rename/repeatNewNames.good
+++ b/test/visibility/rename/repeatNewNames.good
@@ -1,0 +1,1 @@
+repeatNewNames.chpl:8: error: already renamed 'a' to 'bleep', renaming 'b' would conflict

--- a/test/visibility/rename/repeatOldName.chpl
+++ b/test/visibility/rename/repeatOldName.chpl
@@ -1,0 +1,14 @@
+module Foo {
+  var a = -12;
+
+  var b = "fie";
+}
+
+module M {
+  use Foo only a as bleep, a;
+
+  proc main() {
+    writeln(a);
+    writeln(bleep);
+  }
+}

--- a/test/visibility/rename/repeatOldName.good
+++ b/test/visibility/rename/repeatOldName.good
@@ -1,0 +1,3 @@
+repeatOldName.chpl:8: warning: identifier 'a' is repeated
+-12
+-12

--- a/test/visibility/rename/repeatRename.chpl
+++ b/test/visibility/rename/repeatRename.chpl
@@ -1,0 +1,14 @@
+module Foo {
+  var a = -12;
+
+  var b = "fie";
+}
+
+module M {
+  use Foo only a as bleep, a as bloop;
+
+  proc main() {
+    writeln(bloop);
+    writeln(bleep);
+  }
+}

--- a/test/visibility/rename/repeatRename.good
+++ b/test/visibility/rename/repeatRename.good
@@ -1,0 +1,3 @@
+repeatRename.chpl:8: warning: identifier 'a' is repeated
+-12
+-12


### PR DESCRIPTION
Catch when the user accidentally mentions the same symbol multiple times in an
'except' or 'only' list.  There are some cases where this isn't a catastrophe,
such as when the same symbol is renamed twice - in such a case, one could access
the symbol from either new name, but no conflicts are created so no harm is
done.  There are other cases where repeating a name is problematic, such as
when you've renamed a symbol to a name that you were already including.

Verified over std/