### PR TITLE
Add an error message future related to naming conflicts from uses

### DIFF
--- a/test/modules/lydia/useNamingConflict.bad
+++ b/test/modules/lydia/useNamingConflict.bad
@@ -1,0 +1,2 @@
+useNamingConflict.chpl:2: error: Symbol foo multiply defined
+useNamingConflict.chpl:6: error: Symbol foo multiply defined

--- a/test/modules/lydia/useNamingConflict.chpl
+++ b/test/modules/lydia/useNamingConflict.chpl
@@ -1,0 +1,15 @@
+module A {
+  var foo = 11;
+}
+
+module B {
+  var foo = 3.7;
+}
+
+module UsesBoth {
+  use A, B;
+
+  proc main() {
+    writeln(foo);
+  }
+}

--- a/test/modules/lydia/useNamingConflict.future
+++ b/test/modules/lydia/useNamingConflict.future
@@ -1,0 +1,9 @@
+error message: Use of multiple modules which each define a symbol of same name
+
+If two modules define a symbol 'foo' and both are used by a single module, if
+that module tries to access 'foo' without specifying which 'foo' is meant, this
+will correctly cause a naming conflict.  However, the complaint in the current
+error message seems to imply that it is wrong for the same name to be used in
+multiple modules, which would be confusing to the user.  We would like the
+blame to instead be given to the use statements which caused these two symbols
+to come into conflict.

--- a/test/modules/lydia/useNamingConflict.good
+++ b/test/modules/lydia/useNamingConflict.good
@@ -1,0 +1,3 @@
+useNamingConflict.chpl:13: error: cannot resolve symbol 'foo', multiple definitions
+useNamingConflict.chpl:10: note: defined here from use of module 'A'
+useNamingConflict.chpl:10: note: defined here from use of module 'B'


### PR DESCRIPTION
If two modules define a symbol 'foo' and both are used by a single module, and
that module tries to access 'foo' without specifying which 'foo' is meant, this
will correctly cause a naming conflict.  However, the complaint in the current
error message seems to imply that it is wrong for the same name to be used in
multiple modules, which would be confusing to the user.  We would like the
blame to instead be given to the use statements which caused these two symbols
to come into conflict.

Thanks to Vass for pointing out that this was an unclear error message.