### PR TITLE
Fix a bug in the test timeVectorArray.chpl

### DIFF
--- a/test/arrays/diten/timeVectorArray.chpl
+++ b/test/arrays/diten/timeVectorArray.chpl
@@ -61,7 +61,7 @@ class InsertRandom: Runner {
     extern proc rand(): int;
     srand(randSeed);
     for i in 1..n {
-      A.insert(i, (rand() % i) + 1);
+      A.insert((rand() % i) + 1, i);
     }
   }
 }


### PR DESCRIPTION
The test meant to time inserting new elements into random positions in an
Array-as-Vector.  Instead it was always inserting the new elements at the end.
Update it to insert into random positions as was intended.

This doesn't appear to have changed the performance times significantly.