### PR TITLE
Fix bulk transfer between aliases of same array

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -673,7 +673,7 @@ module ChapelBase {
     return __primitive("cast", t, x);
   }
 
-  inline proc _ddata_shift(type eltType, data: _ddata(eltType), shift: integral) {
+  inline proc _ddata_shift(data: _ddata(?eltType), shift: integral) {
     var ret: _ddata(eltType);
      __primitive("shift_base_pointer", ret, data, shift);
     return ret;

--- a/test/performance/ferguson/array-assign-get.good
+++ b/test/performance/ferguson/array-assign-get.good
@@ -1,3 +1,3 @@
 1
 100000
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 10, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 2, execute_on_fast = 0, execute_on_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 9, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 2, execute_on_fast = 0, execute_on_nb = 0)


### PR DESCRIPTION
Adds a check to confirm that the destination and source pointers are not
identical. If they are the same, do nothing.

Previously we would compare the 'data' or 'shiftedData' pointers,
instead of the offset pointers. This is especially bad for aliases, and
would prevent bulk transfers from non-overlapping slices of the same
array.

Also changes the _ddata_shift function to no longer require an explicit
type argument, and instead relies on a query expression to infer the
element type.

These changes allow for a nice cleanup of the doiBulkTransfer function as well, and reduce the number of primitives explicitly invoked.