### PR TITLE
Make jemalloc our default allocator for comm=none (except under cygwin)

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -367,8 +367,8 @@ CHPL_MEM
         tcmalloc  use the tcmalloc package from Google Performance Tools
         ========= =======================================================
 
-   If unset, ``CHPL_MEM`` defaults to ``cstdlib`` if comm is ``none``,
-   otherwise it defaults to ``jemalloc``.
+   If unset, ``CHPL_MEM`` defaults to ``jemalloc`` for most configurations.
+   If the target platform is ``cygwin*``, it defaults to ``cstdlib``
 
 
 CHPL_LAUNCHER

--- a/doc/release/platforms/knc.rst
+++ b/doc/release/platforms/knc.rst
@@ -59,7 +59,7 @@ For vanilla Intel compiler:
     CHPL_TASKS: qthreads
     CHPL_LAUNCHER: none
     CHPL_TIMERS: generic
-    CHPL_MEM: cstdlib
+    CHPL_MEM: jemalloc
     CHPL_MAKE: gmake
     CHPL_ATOMICS: intrinsics
     CHPL_GMP: none
@@ -114,7 +114,7 @@ For Cray machines, only the ``aprun`` launcher is supported.  In addition,
     CHPL_TASKS: qthreads
     CHPL_LAUNCHER: aprun
     CHPL_TIMERS: generic
-    CHPL_MEM: cstdlib
+    CHPL_MEM: jemalloc
     CHPL_MAKE: gmake
     CHPL_ATOMICS: intrinsics
       CHPL_NETWORK_ATOMICS: none

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -6,7 +6,7 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_comm
+import chpl_platform
 from utils import memoize
 
 
@@ -17,11 +17,11 @@ def get(flag='host'):
     elif flag == 'target':
         mem_val = os.environ.get('CHPL_MEM')
         if not mem_val:
-            comm_val = chpl_comm.get()
-            if comm_val != 'none':
-                mem_val='jemalloc'
-            else:
+            platform_val = chpl_platform.get('target')
+            if platform_val.startswith('cygwin'):
                 mem_val = 'cstdlib'
+            else:
+                mem_val = 'jemalloc'
     else:
         raise ValueError("Invalid flag: '{0}'".format(flag))
     return mem_val

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -12,7 +12,7 @@ from utils import memoize, CompVersion
 def get():
     tasks_val = os.environ.get('CHPL_TASKS')
     if not tasks_val:
-        platform_val = chpl_platform.get()
+        platform_val = chpl_platform.get('target')
         compiler_val = chpl_compiler.get('target')
 
         # CCE >= 8.4 is required to build qthreads (for gnu style inline asm.)


### PR DESCRIPTION
This is the last stage of making jemalloc our default allocator. jemalloc is
now our default allocator everywhere except on cygwin, which has some build
issues. jemalloc 4 (the version we use) added initial support for cywgin, so
hopefully these issues will be resolved in future releases. Unfortunately I
don't know enough about autoconf to try to add a work-around or commit anything
upstream. More details about problems we run into on cygwin can be found in
#3055's commit message.

We've been doing full nightly linux64 correctness and performance testing for a
while now, so I don't expect any major problems. Additionally, I have done some
spot checks with valgrind and a few other configurations.

Overall we expect a pretty big win in terms of performance. There might be a
few benchmarks that will take a hit, but the overall trend is overwhelmingly
positive.