### PR TITLE
Default to ugni when using the module and CCE is the target compiler

### DIFF
--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -23,9 +23,10 @@ def get():
         # happens for X* systems using the Cray programming environment, so it
         # is safe to assume the relevant craype module will be used that sets
         # CRAY_CPU_TARGET.
+        ugni_comp = ('cray-prgenv-gnu', 'cray-prgenv-intel', 'cray-prgenv-cray')
         if (platform_val.startswith('cray-x') and
                 utils.using_chapel_module() and
-                compiler_val in ('cray-prgenv-gnu', 'cray-prgenv-intel') and
+                compiler_val in ugni_comp and
                 os.getenv('CRAY_CPU_TARGET', '') != 'knc'):
             comm_val = 'ugni'
         # automatically uses gasnet when on a cray-x* or cray-cs machine


### PR DESCRIPTION
We used to default to gasnet for CCE because we couldn't build ugni. Well,
technically we couldn't build tcmalloc, but ugni required tcmalloc. With the
switch to jemalloc, we can now build ugni support under CCE. We're already
building the module with ugni+cce support, this just changes the default.

We can now use ugni with all the target compilers we currently build the module
with. We could remove the compiler check in chpl_comm.py all together, but I
decided to leave it in on the off chance we ever add pgi support back into the
module build.