### PR TITLE
Fix baseline errors

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -673,7 +673,8 @@ module ChapelBase {
     return __primitive("cast", t, x);
   }
 
-  inline proc _ddata_shift(data: _ddata(?eltType), shift: integral) {
+  // Removing the 'eltType' arg results in errors for --baseline
+  inline proc _ddata_shift(type eltType, data: _ddata(eltType), shift: integral) {
     var ret: _ddata(eltType);
      __primitive("shift_base_pointer", ret, data, shift);
     return ret;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -787,10 +787,10 @@ module DefaultRectangular {
         // work for something with no immediate reward.
         if dom.dsiNumIndices > 0 {
           if isIntType(idxType) then
-            shiftedData = _ddata_shift(data, origin-factoredOffs);
+            shiftedData = _ddata_shift(eltType, data, origin-factoredOffs);
           else
             // Not bothering to check for over/underflow
-            shiftedData = _ddata_shift(data,
+            shiftedData = _ddata_shift(eltType, data,
                                        origin:chpl__signedType(idxType)-
                                        factoredOffs:chpl__signedType(idxType));
         }
@@ -1289,7 +1289,7 @@ module DefaultRectangular {
                "length of array to write is greater than ssize_t can hold");
       const src = this.theData;
       const idx = getDataIndex(this.dom.dsiLow);
-      f.writeBytes(_ddata_shift(src, idx), len:ssize_t*elemSize:ssize_t);
+      f.writeBytes(_ddata_shift(eltType, src, idx), len:ssize_t*elemSize:ssize_t);
     } else {
       this.dsiSerialReadWrite(f);
     }
@@ -1379,8 +1379,8 @@ module DefaultRectangular {
               ", len=", len, ", elemSize=", elemSize);
     }
 
-    const Adata = _ddata_shift(this.theData, getDataIndex(Alo));
-    const Bdata = _ddata_shift(B._value.theData, B._value.getDataIndex(Blo));
+    const Adata = _ddata_shift(eltType, this.theData, getDataIndex(Alo));
+    const Bdata = _ddata_shift(eltType, B._value.theData, B._value.getDataIndex(Blo));
 
     if Adata == Bdata then return;
   


### PR DESCRIPTION
Add an eltType argument back to _ddata_shift to resolve --baseline errors, caused by #3328 