### PR TITLE
Update the lview command in gdb to give all the info on the UseStmt node

### DIFF
--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -28,6 +28,7 @@
 #include "ForLoop.h"
 #include "log.h"
 #include "ParamForLoop.h"
+#include "stlUtil.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
@@ -98,8 +99,8 @@ list_line(Expr* expr, BaseAST* parentAst) {
       return false;
   }
   if (Expr* pExpr = toExpr(parentAst))
-   if (pExpr->isStmt())
-    return true;
+    if (pExpr->isStmt() && !isUseStmt(pExpr))
+      return true;
   if (isSymbol(parentAst))
     return true;
   return false;
@@ -146,6 +147,8 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
       list_sym(e->var, false);
     } else if (UnresolvedSymExpr* e = toUnresolvedSymExpr(expr)) {
       printf("%s ", e->unresolved);
+    } else if (isUseStmt(expr)) {
+      printf("use ");
     }
   }
 
@@ -182,6 +185,34 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
         printf("} ");
       else
         printf("}\n");
+    } else if (UseStmt* use = toUseStmt(expr)) {
+      if (!use->isPlainUse()) {
+        if (use->hasExceptList()) {
+          printf("except ");
+        } else {
+          printf("only ");
+        }
+        bool first = true;
+        for_vector(const char, str, use->named) {
+          if (first) {
+            first = false;
+          } else {
+            printf(", ");
+          }
+          printf("%s", str);
+        }
+
+        for (std::map<const char*, const char*>::iterator it = use->renamed.begin();
+             it != use->renamed.end(); ++it) {
+          if (first) {
+            first = false;
+          } else {
+            printf(", ");
+          }
+          printf("%s as %s", it->second, it->first);
+        }
+        printf("\n");
+      }
     } else if (CondStmt* cond = toCondStmt(parentAst)) {
       if (cond->condExpr == expr)
         printf("\n");

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -81,6 +81,9 @@ class UseStmt : public Stmt {
 
   void validateList();
   bool isPlainUse();
+  bool hasOnlyList();
+  bool hasExceptList();
+
   void writeListPredicate(FILE* mFP);
 
   bool skipSymbolSearch(const char* name);
@@ -94,9 +97,6 @@ class UseStmt : public Stmt {
   // list (but only if 'named' has any contents)
   std::vector<const char *> relatedNames; // The names of fields or methods
   // related to a type specified in an 'except' or 'only' list.
-
-  bool hasOnlyList();
-  bool hasExceptList();
 
   void createRelatedNames(Symbol* maybeType);
 


### PR DESCRIPTION
I realized that updating the AstTraversal classes wasn't sufficient to provide
this.  We should really clean up that representation.

This change required making a couple of my helper methods public rather than
leaking information through a less savory channel.