### PR TITLE
Update AstTraverse classes to account for renamed symbols in uses

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -296,7 +296,8 @@ void AstDump::visitUseStmt(UseStmt* node) {
 
   if (!node->isPlainUse()) {
     node->writeListPredicate(mFP);
-    outputVector(mFP, node->named);
+    bool first = outputVector(mFP, node->named);
+    outputRenames(mFP, node->renamed, first);
   }
 
   write(false, ")", true);

--- a/compiler/AST/AstDumpToHtml.cpp
+++ b/compiler/AST/AstDumpToHtml.cpp
@@ -396,7 +396,8 @@ void AstDumpToHtml::visitUseStmt(UseStmt* node) {
 
   if (!node->isPlainUse()) {
     node->writeListPredicate(mFP);
-    outputVector(mFP, node->named);
+    bool first = outputVector(mFP, node->named);
+    outputRenames(mFP, node->renamed, first);
   }
 
   fprintf(mFP, ")");

--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -989,6 +989,11 @@ void AstDumpToNode::visitUseStmt(UseStmt* node)
       newline();
       fprintf(mFP, "%s", str);
     }
+    for (std::map<const char*, const char*>::iterator it = node->renamed.begin();
+         it != node->renamed.end(); ++it) {
+      newline();
+      fprintf(mFP, "%s as %s", it->second, it->first);
+    }
   }
 
   mOffset = mOffset - 2;

--- a/compiler/AST/AstLogger.cpp
+++ b/compiler/AST/AstLogger.cpp
@@ -172,7 +172,7 @@ bool AstLogger::enterGotoStmt(GotoStmt* node) {
 void AstLogger::exitGotoStmt(GotoStmt* node) {
 }
 
-void AstLogger::outputVector(FILE* mFP, std::vector<const char *> vec) {
+bool AstLogger::outputVector(FILE* mFP, std::vector<const char *> vec) {
   bool first = true;
   for_vector(const char, str, vec) {
     if (first) {
@@ -181,5 +181,20 @@ void AstLogger::outputVector(FILE* mFP, std::vector<const char *> vec) {
       fprintf(mFP, ", ");
     }
     fprintf(mFP, "%s", str);
+  }
+  return first;
+}
+
+void AstLogger::outputRenames(FILE* mFP,
+                              std::map<const char*, const char*> renames,
+                              bool first) {
+  for (std::map<const char*, const char*>::iterator it = renames.begin();
+       it != renames.end(); ++it) {
+    if (first) {
+      first = false;
+    } else {
+      fprintf(mFP, ", ");
+    }
+    fprintf(mFP, "%s 'as' %s", it->second, it->first);
   }
 }

--- a/compiler/include/AstLogger.h
+++ b/compiler/include/AstLogger.h
@@ -21,6 +21,7 @@
 #define _AST_LOGGER_H_
 
 #include <cstdio>
+#include <map>
 #include <vector>
 
 #include "AstVisitor.h"
@@ -110,7 +111,9 @@ public:
   virtual void   exitGotoStmt     (GotoStmt*          node);
 
  protected:
-  void outputVector (FILE* mFP, std::vector<const char *> vec);
+  bool outputVector (FILE* mFP, std::vector<const char *> vec);
+  void outputRenames(FILE* mFP, std::map<const char*, const char*> renames,
+                     bool first);
 };
 
 #endif

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -58,8 +58,8 @@ class UseStmt : public Stmt {
   Expr* mod; // Can be either an UnresolvedSymExpr, SymExpr, or CallExpr to
   // specify an explicit module name.
 
-  // Lydia note: This field is only public because our AstTraversal classes
-  // need to see it.  No one else should touch it.  I mean it!
+  // Lydia note: These fields are only public because our AstTraversal classes
+  // need to see them.  No one else should touch it.  I mean it!
   std::vector<const char *> named; // The names of symbols from an 'except' or
   // 'only' list
   std::map<const char*, const char*> renamed; // Map of newName: oldName
@@ -91,7 +91,7 @@ class UseStmt : public Stmt {
 
  private:
   bool except; // Used to determine if the use contains an 'except' or 'only'
-  // list (but only if 'named' has any contents)
+  // list (but only if 'named' or 'renamed' has any contents)
   std::vector<const char *> relatedNames; // The names of fields or methods
   // related to a type specified in an 'except' or 'only' list.
 


### PR DESCRIPTION
I forgot to do this when I was adding the renaming capability.  Update is
similar to that of the 'only' and 'except' update - add a helper function for
the two AST traversal options that share code, and make sure that we respond
correctly to whether or not there are other names before the renamed symbols
in the use statement.

Also updated some comments so that the rename data structure is also referred
to, instead of just the normal 'only' or 'except' data structure