### PR TITLE
Associative performance test improvements

### DIFF
--- a/test/distributions/robust/associative/performance/array_iter.chpl
+++ b/test/distributions/robust/associative/performance/array_iter.chpl
@@ -1,68 +1,97 @@
-config const debug = false;
-config const printTiming = false;
+use Memory, Types, Time;
 
-config const n = 1024;
-const D = {1..n};
-var AD: domain(int);
+config const printTiming = false;
+config const verify = true;
+
 config const offset = 7;
-var Aref: [D] int;
-var A: [D] int;
-var success = true;
+
+config const memFraction = if verify then 10000 else 5000;
+type eltType = int;
+
+const totalMem = here.physicalMemory(unit = MemUnits.Bytes);
+const target = (totalMem / numBytes(eltType)) / memFraction;
+
+// set a max problem size
+const n = min(target, 8 * 1e9) : int;
+
+const D = {1..n};
+var AD: domain(eltType);
+
+var Aref: [D] eltType;
+var A: [D] eltType;
+var AA: [AD] eltType;
 
 for i in D {
-  Aref(i) = 2*i-offset;
-  AD += Aref(i);
+  const off = 2*i - offset;
+  Aref(i) = off;
+  AD += off;
 }
-QuickSort(Aref);
-if debug then writeln(AD);
-if debug then writeln(Aref);
 
-var AA: [AD] int;
+if verify then QuickSort(Aref);
+
 forall i in AD {
   AA(i) = i;
 }
-if debug then writeln(AA);
-for i in AD {
-  if AA(i) != i then halt("uh oh! ", i);
-}
 
-use Time;
-var t2: Timer;
-t2.start();
-for aa in AA {
-  var ai = aa;
-  A((ai+offset)/2) = ai;
-}
-t2.stop();
-if debug then writeln(A);
-success = true;
-QuickSort(A);
-for i in D {
-  if A(i) != Aref(i) {
-    success = false;
-    break;
+if verify {
+  for i in AD {
+    if AA(i) != i then halt("uh oh! ", i);
   }
 }
-writeln("Serial array iteration: ", if success then "SUCCESS" else "FAILED");
-if printTiming then writeln("Serial: ", t2.elapsed(TimeUnits.milliseconds));
 
+//
+// SERIAL
+//
 
-var t3: Timer;
-t3.start();
-forall aa in AA {
-  var ai = aa;
-  A((ai+offset)/2) = ai;
-}
-t3.stop();
-if debug then writeln(A);
-success = true;
-QuickSort(A);
-for i in D {
-  if A(i) != Aref(i) {
-    success = false;
-    break;
+{
+  var timer: Timer;
+  timer.start();
+  for aa in AA {
+    var ai = aa;
+    A((ai+offset)/2) = ai;
   }
-}
-writeln("Parallel array iteration: ", if success then "SUCCESS" else "FAILED");
-if printTiming then writeln("Parallel: ", t3.elapsed(TimeUnits.milliseconds));
+  timer.stop();
 
+  var success = true;
+
+  if verify {
+    QuickSort(A);
+    for i in D {
+      if A(i) != Aref(i) {
+        success = false;
+        break;
+      }
+    }
+  }
+
+  writeln("Serial array iteration: ", if success then "SUCCESS" else "FAILED");
+  if printTiming then writeln("Serial: ", timer.elapsed());
+}
+
+//
+// PARALLEL
+//
+
+{
+  var paraTimer: Timer;
+  paraTimer.start();
+  forall aa in AA {
+    var ai = aa;
+    A((ai+offset)/2) = ai;
+  }
+  paraTimer.stop();
+
+  var success = true;
+
+  if verify {
+    QuickSort(A);
+    for i in D {
+      if A(i) != Aref(i) {
+        success = false;
+        break;
+      }
+    }
+  }
+  writeln("Parallel array iteration: ", if success then "SUCCESS" else "FAILED");
+  if printTiming then writeln("Parallel: ", paraTimer.elapsed());
+}

--- a/test/distributions/robust/associative/performance/array_iter.chpl
+++ b/test/distributions/robust/associative/performance/array_iter.chpl
@@ -26,7 +26,6 @@ for i in D {
   Aref(i) = off;
   AD += off;
 }
-
 if verify then QuickSort(Aref);
 
 forall i in AD {

--- a/test/distributions/robust/associative/performance/array_iter.graph
+++ b/test/distributions/robust/associative/performance/array_iter.graph
@@ -1,4 +1,4 @@
 perfkeys: Serial:, Parallel:
 graphkeys: Serial (for), Parallel (forall)
 graphtitle: Associative Array Iteration
-ylabel: Time (milliseconds)
+ylabel: Time (seconds)

--- a/test/distributions/robust/associative/performance/array_iter.perfcompopts
+++ b/test/distributions/robust/associative/performance/array_iter.perfcompopts
@@ -1,1 +1,0 @@
--sprintTiming=true

--- a/test/distributions/robust/associative/performance/array_iter.perfexecopts
+++ b/test/distributions/robust/associative/performance/array_iter.perfexecopts
@@ -1,0 +1,1 @@
+--verify=false --printTiming=true

--- a/test/distributions/robust/associative/performance/domain_iter.chpl
+++ b/test/distributions/robust/associative/performance/domain_iter.chpl
@@ -1,58 +1,84 @@
-config const debug = false;
+use Memory, Types, Time;
+
 config const printTiming = false;
+config const verify = true;
 
-config const n = 1024;
-const D = {1..n};
-var AD: domain(int);
 config const offset = 7;
-var Aref: [D] int;
-var A: [D] int;
-var success = true;
+
+config const memFraction = if verify then 10000 else 5000;
+type eltType = int;
+
+const totalMem = here.physicalMemory(unit = MemUnits.Bytes);
+const target = (totalMem / numBytes(eltType)) / memFraction;
+
+// set a max problem size
+const n = min(target, 8 * 1e9) : int;
+
+const D = {1..n};
+var AD: domain(eltType);
+
+var Aref: [D] eltType;
+var A: [D] eltType;
+
 
 for i in D {
-  Aref(i) = 2*i-offset;
-  AD += Aref(i);
+  const off = 2*i-offset;
+  Aref(i) = off;
+  AD += off;
 }
-QuickSort(Aref);
-if debug then writeln(AD);
-if debug then writeln(Aref);
+if verify then QuickSort(Aref);
 
-use Time;
-var t0: Timer;
+//
+// SERIAL
+//
 
-t0.start();
-for ai in AD {
-  A((ai+offset)/2) = ai;
-}
-t0.stop();
-if debug then writeln(A);
-success = true;
-QuickSort(A);
-for i in D {
-  if A(i) != Aref(i) {
-    success = false;
-    break;
+{
+  var timer: Timer;
+  timer.start();
+  for ai in AD {
+    A((ai+offset)/2) = ai;
   }
-}
-writeln("Serial domain iteration: ", if success then "SUCCESS" else "FAILED");
-if printTiming then writeln("Serial: ", t0.elapsed(TimeUnits.milliseconds));
+  timer.stop();
 
+  var success = true;
 
-var t1: Timer;
-t1.start();
-forall ai in AD {
-  A((ai+offset)/2) = ai;
-}
-t1.stop();
-if debug then writeln(A);
-success = true;
-QuickSort(A);
-for i in D {
-  if A(i) != Aref(i) {
-    success = false;
-    break;
+  if verify {
+    QuickSort(A);
+    for i in D {
+      if A(i) != Aref(i) {
+        success = false;
+        break;
+      }
+    }
   }
-}
-writeln("Parallel domain iteration: ", if success then "SUCCESS" else "FAILED");
-if printTiming then writeln("Parallel: ", t1.elapsed(TimeUnits.milliseconds));
 
+  writeln("Serial domain iteration: ", if success then "SUCCESS" else "FAILED");
+  if printTiming then writeln("Serial: ", timer.elapsed());
+}
+
+//
+// PARALLEL
+//
+
+{
+  var timer: Timer;
+  timer.start();
+  forall ai in AD {
+    A((ai+offset)/2) = ai;
+  }
+  timer.stop();
+
+  var success = true;
+
+  if verify {
+    QuickSort(A);
+    for i in D {
+      if A(i) != Aref(i) {
+        success = false;
+        break;
+      }
+    }
+  }
+  writeln("Parallel domain iteration: ", if success then "SUCCESS" else "FAILED");
+  if printTiming then writeln("Parallel: ", timer.elapsed());
+}

--- a/test/distributions/robust/associative/performance/domain_iter.chpl
+++ b/test/distributions/robust/associative/performance/domain_iter.chpl
@@ -5,7 +5,7 @@ config const verify = true;
 
 config const offset = 7;
 
-config const memFraction = if verify then 10000 else 5000;
+config const memFraction = if verify then 5000 else 1000;
 type eltType = int;
 
 const totalMem = here.physicalMemory(unit = MemUnits.Bytes);

--- a/test/distributions/robust/associative/performance/domain_iter.graph
+++ b/test/distributions/robust/associative/performance/domain_iter.graph
@@ -1,4 +1,4 @@
 perfkeys: Serial:, Parallel:
 graphkeys: Serial (for), Parallel (forall)
 graphtitle: Associative Domain Iteration
-ylabel: Time (milliseconds)
+ylabel: Time (seconds)

--- a/test/distributions/robust/associative/performance/domain_iter.perfcompopts
+++ b/test/distributions/robust/associative/performance/domain_iter.perfcompopts
@@ -1,1 +1,0 @@
--sprintTiming=true

--- a/test/distributions/robust/associative/performance/domain_iter.perfexecopts
+++ b/test/distributions/robust/associative/performance/domain_iter.perfexecopts
@@ -1,0 +1,1 @@
+--verify=false --printTiming


### PR DESCRIPTION
The array_iter and domain_iter tests ran way to quickly to be useful, having to be measured in milliseconds. This changes the tests to use a fraction of physical memory and to skip verification during performance testing.