### PR TITLE
Bump lcals perftimeout again

### DIFF
--- a/test/studies/lcals/LCALSMain.perftimeout
+++ b/test/studies/lcals/LCALSMain.perftimeout
@@ -1,1 +1,2 @@
-600
+# --no-local perf testing takes a while
+900


### PR DESCRIPTION
lcals --no-local perf testing is timing out since a few more kernels were
added with #3303. This isn't indicative of any real problem, there's just a lot
of kernels being run as part of one test.