### PR TITLE
Future for internal error bug reported in JIRA 184

### DIFF
--- a/test/localeModels/nspark/loc-in-locales.chpl
+++ b/test/localeModels/nspark/loc-in-locales.chpl
@@ -1,0 +1,3 @@
+forall loc in Locales do
+  on loc do
+    var c: channel;

--- a/test/localeModels/nspark/loc-in-locales.future
+++ b/test/localeModels/nspark/loc-in-locales.future
@@ -1,0 +1,17 @@
+bug: Compiling forall loc in locales, containing a channel yields internal error
+
+The desirable compiler error would be the same as the error in the case of the
+simple for loop, c.f. good file.
+
+Filed as JIRA issue #184
+
+
+The current compiler error output is the following:
+
+loc-in-locales.chpl:3: internal error: FUN0493 chpl Version 1.12.0.c3cd1e5
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.

--- a/test/localeModels/nspark/loc-in-locales.good
+++ b/test/localeModels/nspark/loc-in-locales.good
@@ -1,0 +1,2 @@
+loc-in-locales.chpl:3: error: unresolved type specifier 'channel()'
+$CHPL_HOME/modules/standard/IO.chpl:2604: note: candidates are: channel(param writing: bool, param kind: iokind, param locking: bool)


### PR DESCRIPTION
bug: Compiling forall loc in locales, containing a channel yields internal error

The desirable compiler error would be the same as the error in the case of the
simple for loop, c.f. good file.

Filed as JIRA issue #184

The current compiler error output is the following:

    loc-in-locales.chpl:3: internal error: FUN0493 chpl Version 1.12.0.c3cd1e5
    Note: This source location is a guess.

    Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
    and we're sorry for the hassle.  We would appreciate your reporting this bug --
    please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
    the filename + line number above may be useful in working around the issue.
