### PR TITLE
Update shootout Makefile to check for CHPL_REGEXP and CHPL_GMP

### DIFF
--- a/test/release/examples/benchmarks/shootout/Makefile
+++ b/test/release/examples/benchmarks/shootout/Makefile
@@ -47,10 +47,10 @@ nbody: nbody.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) --no-warnings $<
 
 pidigits: pidigits.chpl
-	$(CHPL) -o $@ $(CHPL_FLAGS) $<
+	@if [ -z "$$CHPL_GMP" ]; then $(CHPL) -o $@ $(CHPL_FLAGS) $<; fi
 
 regexdna: regexdna.chpl
-	$(CHPL) -o $@ $(CHPL_FLAGS) $<
+	@if [ -z "$$CHPL_REGEXP" ]; then $(CHPL) -o $@ $(CHPL_FLAGS) $<; fi
 
 spectralnorm: spectralnorm.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) $<

--- a/test/release/examples/benchmarks/shootout/Makefile
+++ b/test/release/examples/benchmarks/shootout/Makefile
@@ -50,10 +50,23 @@ nbody: nbody.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) --no-warnings $<
 
 pidigits: pidigits.chpl
-	@if [ "$(CHPL_MAKE_GMP)" != "none" ]; then $(CHPL) -o $@ $(CHPL_FLAGS) $<; fi
+	@if [ "$(CHPL_MAKE_GMP)" != "none" ]; then \
+	$(CHPL) -o $@ $(CHPL_FLAGS) $<; \
+	else \
+	echo "Can't build pidigits without CHPL_GMP being enabled. See for details:"; \
+	echo "http://chapel.cray.com/docs/latest/usingchapel/chplenv.html#chpl-gmp"; \
+	echo ""; \
+	fi
+
 
 regexdna: regexdna.chpl
-	@if [ "$(CHPL_REGEXP)" != "none" ]; then $(CHPL) -o $@ $(CHPL_FLAGS) $<; fi
+	@if [ "$(CHPL_REGEXP)" != "none" ]; then \
+	$(CHPL) -o $@ $(CHPL_FLAGS) $<; \
+	else \
+	echo "Can't build regexdna without CHPL_REGEXP being enabled. See for details:"; \
+	echo "http://chapel.cray.com/docs/master/usingchapel/chplenv.html#chpl-regexp"; \
+	echo ""; \
+	fi
 
 spectralnorm: spectralnorm.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) $<

--- a/test/release/examples/benchmarks/shootout/Makefile
+++ b/test/release/examples/benchmarks/shootout/Makefile
@@ -15,6 +15,9 @@ TARGETS = \
 	spectralnorm \
 	threadring
 
+CHPL_MAKE_REGEXP=$(shell python $(CHPL_HOME)/util/chplenv/chpl_regexp.py)
+CHPL_MAKE_GMP=$(shell python $(CHPL_HOME)/util/chplenv/chpl_gmp.py)
+
 REALS = $(TARGETS:%=%_real)
 
 default: all
@@ -47,10 +50,10 @@ nbody: nbody.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) --no-warnings $<
 
 pidigits: pidigits.chpl
-	@if [ -z "$$CHPL_GMP" ]; then $(CHPL) -o $@ $(CHPL_FLAGS) $<; fi
+	@if [ "$(CHPL_MAKE_GMP)" != "none" ]; then $(CHPL) -o $@ $(CHPL_FLAGS) $<; fi
 
 regexdna: regexdna.chpl
-	@if [ -z "$$CHPL_REGEXP" ]; then $(CHPL) -o $@ $(CHPL_FLAGS) $<; fi
+	@if [ "$(CHPL_REGEXP)" != "none" ]; then $(CHPL) -o $@ $(CHPL_FLAGS) $<; fi
 
 spectralnorm: spectralnorm.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) $<

--- a/test/release/examples/benchmarks/shootout/Makefile
+++ b/test/release/examples/benchmarks/shootout/Makefile
@@ -53,6 +53,7 @@ pidigits: pidigits.chpl
 	@if [ "$(CHPL_MAKE_GMP)" != "none" ]; then \
 	$(CHPL) -o $@ $(CHPL_FLAGS) $<; \
 	else \
+	echo "";\
 	echo "Can't build pidigits without CHPL_GMP being enabled. See for details:"; \
 	echo "http://chapel.cray.com/docs/latest/usingchapel/chplenv.html#chpl-gmp"; \
 	echo ""; \
@@ -63,8 +64,9 @@ regexdna: regexdna.chpl
 	@if [ "$(CHPL_REGEXP)" != "none" ]; then \
 	$(CHPL) -o $@ $(CHPL_FLAGS) $<; \
 	else \
+	echo "";\
 	echo "Can't build regexdna without CHPL_REGEXP being enabled. See for details:"; \
-	echo "http://chapel.cray.com/docs/master/usingchapel/chplenv.html#chpl-regexp"; \
+	echo "http://chapel.cray.com/docs/latest/usingchapel/chplenv.html#chpl-regexp"; \
 	echo ""; \
 	fi
 


### PR DESCRIPTION
Adding checks to `release/examples/benchmarks/shootout/Makefile` so that users calling `make` from the `release/examples` directory do not encounter a few pages of errors, due to not having `CHPL_GMP` or `CHPL_REGEXP` enabled. 

With the changes, the makefile skips `pidgits.chpl` if `CHPL_GMP` is not set, and skips `regexdna.chpl` if `CHPL_REGEXP` is not set. When a target is skipped, a warning message is provided with a URL link to the relevant web documentation.

This modification should also yield a cleaner test output for the release tarball tests (smoke & nightly), which call this makefile.