### PR TITLE
Ordering issue, part 1

### DIFF
--- a/test/visibility/rename/backToSame.chpl
+++ b/test/visibility/rename/backToSame.chpl
@@ -1,0 +1,24 @@
+// The only thing that varies between these versions is the order of the
+// only/except pairs
+module Order {
+  var roy = "o";
+  var haley = "r";
+  var elan = "d";
+  var durkon = "e";
+  var vaar = "r";
+  var belkar = "'s";
+}
+
+module Godsmoot {
+  use Order only durkon as durkula;
+  use Order except durkon;
+}
+
+module Future {
+  use Godsmoot only durkula as durkon;
+  use Godsmoot except durkula;
+
+  proc main() {
+    writeln("hail hail, the ", roy, haley, elan, durkon, vaar, belkar, " all here");
+  }
+}

--- a/test/visibility/rename/backToSame.good
+++ b/test/visibility/rename/backToSame.good
@@ -1,0 +1,1 @@
+hail hail, the order's all here

--- a/test/visibility/rename/backToSame2.chpl
+++ b/test/visibility/rename/backToSame2.chpl
@@ -1,0 +1,22 @@
+module Order {
+  var roy = "o";
+  var haley = "r";
+  var elan = "d";
+  var durkon = "e";
+  var vaar = "r";
+  var belkar = "'s";
+}
+
+module Godsmoot {
+  use Order except durkon;
+  use Order only durkon as durkula;
+}
+
+module Future {
+  use Godsmoot only durkula as durkon;
+  use Godsmoot except durkula;
+
+  proc main() {
+    writeln("hail hail, the ", roy, haley, elan, durkon, vaar, belkar, " all here"); 
+  }
+}

--- a/test/visibility/rename/backToSame2.good
+++ b/test/visibility/rename/backToSame2.good
@@ -1,0 +1,1 @@
+hail hail, the order's all here

--- a/test/visibility/rename/backToSame3.chpl
+++ b/test/visibility/rename/backToSame3.chpl
@@ -1,0 +1,22 @@
+module Order {
+  var roy = "o";
+  var haley = "r";
+  var elan = "d";
+  var durkon = "e";
+  var vaar = "r";
+  var belkar = "'s";
+}
+
+module Godsmoot {
+  use Order only durkon as durkula;
+  use Order except durkon;
+}
+
+module Future {
+  use Godsmoot except durkula;
+  use Godsmoot only durkula as durkon;
+
+  proc main() {
+    writeln("hail hail, the ", roy, haley, elan, durkon, vaar, belkar, " all here"); 
+  }
+}

--- a/test/visibility/rename/backToSame3.good
+++ b/test/visibility/rename/backToSame3.good
@@ -1,0 +1,1 @@
+hail hail, the order's all here

--- a/test/visibility/rename/backToSame4.chpl
+++ b/test/visibility/rename/backToSame4.chpl
@@ -1,0 +1,22 @@
+module Order {
+  var roy = "o";
+  var haley = "r";
+  var elan = "d";
+  var durkon = "e";
+  var vaar = "r";
+  var belkar = "'s";
+}
+
+module Godsmoot {
+  use Order except durkon;
+  use Order only durkon as durkula;
+}
+
+module Future {
+  use Godsmoot except durkula;
+  use Godsmoot only durkula as durkon;
+
+  proc main() {
+    writeln("hail hail, the ", roy, haley, elan, durkon, vaar, belkar, " all here"); 
+  }
+}

--- a/test/visibility/rename/backToSame4.good
+++ b/test/visibility/rename/backToSame4.good
@@ -1,0 +1,1 @@
+hail hail, the order's all here


### PR DESCRIPTION
A user discovered an issue with nested renaming uses where in some cases the
ordering of mutually exclusive uses of the same module would affect whether
certain symbols could be found.  Of the four orderings, only backToSame.chpl
would pass with the compiler as it stood.

It turns out that this error had occurred because I had forgotten to update
UseStmt::providesNewSymbols to take the renaming list into account.  Rectifying
that oversight.

The behavior should be that if one of the uses renames symbols and the other
provides an except list, we should automatically assume we provide new symbols
since even if the new name matches something that was not in the except list,
it is available in a different form than previously.  The same goes for if one
use renames a symbol and the other names the old_name or new_name in their
only list.  The only case where a renaming would potentially disqualify a use
is if the renaming is duplicated in the other use.  Checks for if the count of
duplicates should take the renaming list into account as well.

(Thanks for finding this, @cassella!)

The user also found another issue, which will be addressed in a separate PR

passed std/ testing