### PR TITLE
Attempt to quiet recent Coverity issues

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -201,6 +201,8 @@ static void getCpuInfo(int* p_numPhysCpus, int* p_numLogCpus) {
   if ((f = fopen("/proc/cpuinfo", "r")) == NULL)
     chpl_internal_error("Cannot open /proc/cpuinfo");
 
+  assert(f != NULL);
+
   while (!feof(f) && fgets(buf, sizeof(buf), f) != NULL) {
     size_t buf_len = strlen(buf);
     int procTmp;

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -201,6 +201,11 @@ static void getCpuInfo(int* p_numPhysCpus, int* p_numLogCpus) {
   if ((f = fopen("/proc/cpuinfo", "r")) == NULL)
     chpl_internal_error("Cannot open /proc/cpuinfo");
 
+  //
+  // If f is NULL, we should have exited by now, but Coverity doesn't
+  // seem to be catching this (anymore), so I'm adding an assertion
+  // to try and help it out.
+  //
   assert(f != NULL);
 
   while (!feof(f) && fgets(buf, sizeof(buf), f) != NULL) {

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1758,6 +1758,7 @@ qioerr qio_shortest_path(qio_file_t* file, const char** path_out, const char* pa
   qio_free((void*) cwd); cwd = NULL;
 
   if( ! err ) {
+    assert(relpath != NULL);
     // Use relpath or path_in, whichever is shorter.
     if( strlen(relpath) < strlen(path_in) ) {
       *path_out = relpath; relpath = NULL;

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1758,6 +1758,11 @@ qioerr qio_shortest_path(qio_file_t* file, const char** path_out, const char* pa
   qio_free((void*) cwd); cwd = NULL;
 
   if( ! err ) {
+    //
+    // If relpath is NULL, err should have been non-zero, but Coverity
+    // doesn't feel safe about this, so I'm adding this assertion to
+    // be double-sure.
+    //
     assert(relpath != NULL);
     // Use relpath or path_in, whichever is shorter.
     if( strlen(relpath) < strlen(path_in) ) {


### PR DESCRIPTION
Coverity flagged five new issues due to two root issues this weekend,
though it seems unlikely to have been due to our code changes and
more likely to be due to changes in Coverity -- either it got much
smarter (than I am) or more conservative.

In one case (qio.c), it seems to be a case that Coverity would
understandably not be able to trace through to understand that the
non-NULL-ness of a pointer is related to whether or not the error
code is zero.

In the other case, it seems surprising that it isn't treating
chpl_internal_error() as an exit() when (it seems to me) it
unambiguously is.

In both cases, I'm guessing/hoping that adding an assertion that a
pointer is non-NULL will quiet it down.
