### PR TITLE
Use cstdlib for valgrind testing

### DIFF
--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -9,4 +9,8 @@ source $CWD/common-valgrind.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrind"
 
+# EJR (02/22/16): use cstdlib until the valgrind header files are installed on
+# our test systems (header files required for jemalloc to support valgrind.)
+export CHPL_MEM=cstdlib
+
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
Temporarily (hopefully) use cstdlib for valgrind testing. jemalloc requires
"valgrind.h" in order to be able to support running under valgrind with
prefixed names. In other words, valgrind can't natively track
allocations/deallocations through je_malloc() and friends. jemalloc can tell
valgrind which functions to track, but only if the valgrind headers are
installed.

The valgrind headers are currently missing from our testing systems, so until
we can get them installed I'm defaulting to cstdlib for valgrind testing.