### PR TITLE
Only run coforall-mod future under valgrind

### DIFF
--- a/test/types/records/ferguson/parallel/coforall-mod.skipif
+++ b/test/types/records/ferguson/parallel/coforall-mod.skipif
@@ -1,0 +1,3 @@
+# For some reason compopts: 1 passes with CHPL_MEM=jemalloc, CHPL_COMM=none.
+# Only run under valgrind so we can get a reliable failure mode.
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
For some reason types/records/ferguson/parallel/coforall-mod (compopts: 1)
started passing under comm=none with the switch to jemalloc as the default
allocator.

I haven't had much luck figuring out why it started passing. It fails reliably
under valgrind, so I'm just turning it into a valgrind only test.