### PR TITLE
Add a test to ensure that valgrind is working

### DIFF
--- a/test/memory/elliot/valgrind/I-fail-without-working-valgrind.chpl
+++ b/test/memory/elliot/valgrind/I-fail-without-working-valgrind.chpl
@@ -1,0 +1,7 @@
+// This test is intended to verify that valgrind is working by explicitly
+// accessing memory that hasn't been allocated
+
+proc main() {
+  var c = c_malloc(int, 1);
+  writeln(c[1]);            // invalid read
+}

--- a/test/memory/elliot/valgrind/I-fail-without-working-valgrind.good
+++ b/test/memory/elliot/valgrind/I-fail-without-working-valgrind.good
@@ -1,0 +1,2 @@
+Invalid read of size 8
+Address xxx is 0 bytes after a block of size 8 alloc'd

--- a/test/memory/elliot/valgrind/I-fail-without-working-valgrind.prediff
+++ b/test/memory/elliot/valgrind/I-fail-without-working-valgrind.prediff
@@ -1,0 +1,12 @@
+#!/bin/bash
+outfile=$2
+
+mv $outfile $outfile.tmp
+
+# grep for specific items in valgrind output
+# 'head -2' is to ignore the process ID
+grep -E 'Invalid read|Address 0x.* is' $outfile.tmp | head -2 \
+| sed 's@^.*Invalid read@Invalid read@; s@^.*Address .* is@Address xxx is@' \
+> $outfile
+
+rm $outfile.tmp

--- a/test/memory/elliot/valgrind/I-fail-without-working-valgrind.skipif
+++ b/test/memory/elliot/valgrind/I-fail-without-working-valgrind.skipif
@@ -1,0 +1,1 @@
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
Add a simple test to verify that valgrind is working by explicitly accessing
memory that hasn't been allocated and expecting an error from valgrind.

We recently discovered that because our test systems don't have the valgrind
header files installed, jemalloc valgrind support wasn't working. As a result,
valgrind couldn't track allocations/deallocations. There was no big indication
that valgrind support was missing, but luckily there was a single future that
was expecting a leak in the .bad file, which allowed us to discovered the
issue.

This test is intended to always run under valgrind so that have some more
assurance that our valgrind results can be trusted.