### PR TITLE
Support inheriting from a generic class

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3706,19 +3706,25 @@ void CallExpr::replaceChild(Expr* old_ast, Expr* new_ast) {
 
 void
 CallExpr::insertAtHead(BaseAST* ast) {
+  Expr *toInsert;
   if (Symbol* a = toSymbol(ast))
-    argList.insertAtHead(new SymExpr(a));
+    toInsert = new SymExpr(a);
   else
-    argList.insertAtHead(toExpr(ast));
+    toInsert = toExpr(ast);
+  argList.insertAtHead(toInsert);
+  parent_insert_help(this, toInsert);
 }
 
 
 void
 CallExpr::insertAtTail(BaseAST* ast) {
+  Expr *toInsert;
   if (Symbol* a = toSymbol(ast))
-    argList.insertAtTail(new SymExpr(a));
+    toInsert = new SymExpr(a);
   else
-    argList.insertAtTail(toExpr(ast));
+    toInsert = toExpr(ast);
+  argList.insertAtTail(toInsert);
+  parent_insert_help(this, toInsert);
 }
 
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2220,23 +2220,29 @@ FnSymbol::insertBeforeDownEndCount(Expr* ast) {
 
 void
 FnSymbol::insertFormalAtHead(BaseAST* ast) {
+  Expr* toInsert = NULL;
   if (ArgSymbol* arg = toArgSymbol(ast))
-    formals.insertAtHead(new DefExpr(arg));
+    toInsert = new DefExpr(arg);
   else if (DefExpr* def = toDefExpr(ast))
-    formals.insertAtHead(def);
+    toInsert = def;
   else
     INT_FATAL(ast, "Bad argument to FnSymbol::insertFormalAtHead");
+  formals.insertAtHead(toInsert);
+  parent_insert_help(this, toInsert);
 }
 
 
 void
 FnSymbol::insertFormalAtTail(BaseAST* ast) {
+  Expr* toInsert = NULL;
   if (ArgSymbol* arg = toArgSymbol(ast))
-    formals.insertAtTail(new DefExpr(arg));
+    toInsert = new DefExpr(arg);
   else if (DefExpr* def = toDefExpr(ast))
-    formals.insertAtTail(def);
+    toInsert = def;
   else
     INT_FATAL(ast, "Bad argument to FnSymbol::insertFormalAtTail");
+  formals.insertAtTail(toInsert);
+  parent_insert_help(this, toInsert);
 }
 
 

--- a/compiler/include/alist.h
+++ b/compiler/include/alist.h
@@ -84,6 +84,7 @@ class AList {
        node = _alist_prev,                                              \
          _alist_prev = node ? toDefExpr(node->prev) : NULL)
 
+// for_formals(arg, fn) arg is ArgSymbol*, fn is FnSymbol*
 #define for_formals(formal, fn)                                         \
   for (ArgSymbol *formal = ((fn)->formals.head) ? toArgSymbol(toDefExpr((fn)->formals.head)->sym) : NULL, \
          *_alist_next = (formal && formal->defPoint->next) ? toArgSymbol(toDefExpr((formal)->defPoint->next)->sym) : NULL; \

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -196,6 +196,8 @@ symbolFlag( FLAG_ON , npr, "on" , ncm )
 symbolFlag( FLAG_ON_BLOCK , npr, "on block" , ncm )
 symbolFlag( FLAG_PARAM , npr, "param" , "parameter (compile-time constant)" )
 
+symbolFlag( FLAG_PARENT_FIELD , npr, "parent field" , "field from parent type" )
+
 symbolFlag( FLAG_PARTIAL_COPY, npr, "partial copy", ncm )
 symbolFlag( FLAG_PARTIAL_TUPLE, npr, "partial tuple", ncm)
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -814,7 +814,7 @@ static void build_type_constructor(AggregateType* ct) {
   CallExpr* superCall = NULL;
 
   // Copy arguments from superclass type constructor
-  // (supporting inheritence from generic classes)
+  // (supporting inheritance from generic classes)
   if (isClass(ct) && ct->dispatchParents.n > 0) {
 
     if(AggregateType *parentTy = toAggregateType(ct->dispatchParents.v[0])){
@@ -868,7 +868,7 @@ static void build_type_constructor(AggregateType* ct) {
 
     if (VarSymbol* field = toVarSymbol(tmp)) {
       if (field->hasFlag(FLAG_SUPER_CLASS)) {
-        // supporting inheritence from generic classes
+        // supporting inheritance from generic classes
         if (superCall) {
           CallExpr* newInit = new CallExpr(PRIM_TYPE_INIT, superCall);
           CallExpr* newSet  = new CallExpr(PRIM_SET_MEMBER,

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1519,7 +1519,7 @@ computeActualFormalAlignment(FnSymbol* fn,
 // instantiated by a given actual type
 //
 static Type*
-geBasictInstantiationType(Type* actualType, Type* formalType) {
+getBasicInstantiationType(Type* actualType, Type* formalType) {
   if (canInstantiate(actualType, formalType)) {
     return actualType;
   }
@@ -1539,7 +1539,7 @@ geBasictInstantiationType(Type* actualType, Type* formalType) {
 
 static Type*
 getInstantiationType(Type* actualType, Type* formalType) {
-  Type *ret = geBasictInstantiationType(actualType, formalType);
+  Type *ret = getBasicInstantiationType(actualType, formalType);
 
   // Now, if formalType is a generic parent type to actualType,
   // we should instantiate the parent actual type

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7403,8 +7403,8 @@ addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
 
 // Add overrides of fn to virtual maps down the inheritance heirarchy
 static void
-addAllToVirtualMaps(FnSymbol* fn, AggregateType* ct) {
-  forv_Vec(Type, t, ct->dispatchChildren) {
+addAllToVirtualMaps(FnSymbol* fn, AggregateType* pct) {
+  forv_Vec(Type, t, pct->dispatchChildren) {
     AggregateType* ct = toAggregateType(t);
     if (ct->defaultTypeConstructor &&
         (ct->defaultTypeConstructor->hasFlag(FLAG_GENERIC) ||

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -492,6 +492,62 @@ renameInstantiatedType(TypeSymbol* sym, SymbolMap& subs, FnSymbol* fn) {
   sym->name = astr(sym->name, ")");
 }
 
+/** Instantiate a type
+ *
+ * \param fn   Type constructor we are working on
+ * \param subs Type substitutions to be made during instantiation
+ * \param call The call that is being resolved (used for scope)
+ * \param type The generic type we wish to instantiate
+ */
+static Type*
+instantiateTypeForTypeConstructor(FnSymbol* fn, SymbolMap& subs,
+                                  CallExpr* call, Type* type) {
+
+  INT_ASSERT(isAggregateType(type));
+  AggregateType* ct = toAggregateType(type);
+
+  Type* newType = NULL;
+  newType = ct->symbol->copy()->type;
+
+  //
+  // mark star tuples, add star flag
+  //
+  if (!fn->hasFlag(FLAG_TUPLE) && newType->symbol->hasFlag(FLAG_TUPLE)) {
+    bool markStar = true;
+    Type* starType = NULL;
+    form_Map(SymbolMapElem, e, subs) {
+      TypeSymbol* ts = toTypeSymbol(e->value);
+      INT_ASSERT(ts && ts->type);
+      if (starType == NULL) {
+        starType = ts->type;
+      } else if (starType != ts->type) {
+        markStar = false;
+        break;
+      }
+    }
+    if (markStar)
+      newType->symbol->addFlag(FLAG_STAR_TUPLE);
+  }
+
+  renameInstantiatedType(newType->symbol, subs, fn);
+  fn->retType->symbol->defPoint->insertBefore(new DefExpr(newType->symbol));
+  newType->symbol->copyFlags(fn);
+  if (isSyncType(newType))
+    newType->defaultValue = NULL;
+  newType->substitutions.copy(fn->retType->substitutions);
+  newType->dispatchParents.copy(fn->retType->dispatchParents);
+  forv_Vec(Type, t, fn->retType->dispatchParents) {
+    bool inserted = t->dispatchChildren.add_exclusive(newType);
+    INT_ASSERT(inserted);
+  }
+  if (newType->dispatchChildren.n)
+    INT_FATAL(fn, "generic type has subtypes");
+  newType->instantiatedFrom = fn->retType;
+  newType->substitutions.map_union(subs);
+  newType->symbol->removeFlag(FLAG_GENERIC);
+
+  return newType;
+}
 
 /** Instantiate enough of the function for it to make it through the candidate
  *  filtering and disambiguation process.
@@ -555,45 +611,7 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   //
   Type* newType = NULL;
   if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
-    INT_ASSERT(isAggregateType(fn->retType));
-    newType = fn->retType->symbol->copy()->type;
-
-    //
-    // mark star tuples, add star flag
-    //
-    if (!fn->hasFlag(FLAG_TUPLE) && newType->symbol->hasFlag(FLAG_TUPLE)) {
-      bool markStar = true;
-      Type* starType = NULL;
-      form_Map(SymbolMapElem, e, subs) {
-        TypeSymbol* ts = toTypeSymbol(e->value);
-        INT_ASSERT(ts && ts->type);
-        if (starType == NULL) {
-          starType = ts->type;
-        } else if (starType != ts->type) {
-          markStar = false;
-          break;
-        }
-      }
-      if (markStar)
-        newType->symbol->addFlag(FLAG_STAR_TUPLE);
-    }
-
-    renameInstantiatedType(newType->symbol, subs, fn);
-    fn->retType->symbol->defPoint->insertBefore(new DefExpr(newType->symbol));
-    newType->symbol->copyFlags(fn);
-    if (isSyncType(newType))
-      newType->defaultValue = NULL;
-    newType->substitutions.copy(fn->retType->substitutions);
-    newType->dispatchParents.copy(fn->retType->dispatchParents);
-    forv_Vec(Type, t, fn->retType->dispatchParents) {
-      bool inserted = t->dispatchChildren.add_exclusive(newType);
-      INT_ASSERT(inserted);
-    }
-    if (newType->dispatchChildren.n)
-      INT_FATAL(fn, "generic type has subtypes");
-    newType->instantiatedFrom = fn->retType;
-    newType->substitutions.map_union(subs);
-    newType->symbol->removeFlag(FLAG_GENERIC);
+    newType = instantiateTypeForTypeConstructor(fn, subs, call, fn->retType);
   }
 
   //

--- a/test/classes/ferguson/generic-inherit-record-no-parent-methods.chpl
+++ b/test/classes/ferguson/generic-inherit-record-no-parent-methods.chpl
@@ -1,0 +1,33 @@
+record Parent {
+  type t;
+  var x:t;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+record Child : Parent {
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+// OK
+writeln("Parent(int)");
+var p = new Parent(int, 1);
+p.parent_method();
+p.overridden_method();
+
+writeln("Child(int)");
+var c = new Child(int, 1, 2);
+c.overridden_method();
+c.child_method();
+

--- a/test/classes/ferguson/generic-inherit-record-no-parent-methods.good
+++ b/test/classes/ferguson/generic-inherit-record-no-parent-methods.good
@@ -1,0 +1,6 @@
+Parent(int)
+1
+1
+Child(int)
+12
+2

--- a/test/classes/ferguson/generic-inherit-record.chpl
+++ b/test/classes/ferguson/generic-inherit-record.chpl
@@ -1,0 +1,34 @@
+record Parent {
+  type t;
+  var x:t;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+record Child : Parent {
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+// OK
+writeln("Parent(int)");
+var p = new Parent(int, 1);
+p.parent_method();
+p.overridden_method();
+
+writeln("Child(int)");
+var c = new Child(int, 1, 2);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+

--- a/test/classes/ferguson/generic-inherit-record.future
+++ b/test/classes/ferguson/generic-inherit-record.future
@@ -1,0 +1,1 @@
+feature request: calling parent methods on inherited records, generic parent

--- a/test/classes/ferguson/generic-inherit-record.good
+++ b/test/classes/ferguson/generic-inherit-record.good
@@ -1,0 +1,7 @@
+Parent(int)
+1
+1
+Child(int)
+1
+12
+2

--- a/test/classes/ferguson/generic-inherit-record3.chpl
+++ b/test/classes/ferguson/generic-inherit-record3.chpl
@@ -1,0 +1,33 @@
+record Parent {
+  var x:int;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+record Child : Parent {
+  type t;
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+writeln("Parent");
+var p = new Parent(1);
+p.parent_method();
+p.overridden_method();
+
+writeln("Child(int)");
+var c = new Child(1, int, 2);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+

--- a/test/classes/ferguson/generic-inherit-record3.future
+++ b/test/classes/ferguson/generic-inherit-record3.future
@@ -1,0 +1,1 @@
+feature request: calling parent methods on inherited records, generic child

--- a/test/classes/ferguson/generic-inherit-record3.good
+++ b/test/classes/ferguson/generic-inherit-record3.good
@@ -1,0 +1,7 @@
+Parent
+1
+1
+Child(int)
+1
+12
+2

--- a/test/classes/ferguson/generic-inherit-record4.chpl
+++ b/test/classes/ferguson/generic-inherit-record4.chpl
@@ -1,0 +1,38 @@
+record Parent {
+  type t;
+  var x:t;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+record Child : Parent {
+  type u;
+  var y:u;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+writeln("Parent(int)");
+var p = new Parent(int, 1);
+p.parent_method();
+p.overridden_method();
+
+writeln("Child(int,real)");
+var c = new Child(int, 1, real, 2.0);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+
+writeln("Dynamic Child(int,real)");
+var pc:Parent(int) = c;
+pc.parent_method();
+pc.overridden_method();

--- a/test/classes/ferguson/generic-inherit-record4.future
+++ b/test/classes/ferguson/generic-inherit-record4.future
@@ -1,0 +1,1 @@
+feature request: calling parent methods on inherited records generic parent,child

--- a/test/classes/ferguson/generic-inherit-record4.good
+++ b/test/classes/ferguson/generic-inherit-record4.good
@@ -1,0 +1,10 @@
+Parent(int)
+1
+1
+Child(int,real)
+1
+12.0
+2.0
+Dynamic Child(int,real)
+1
+1

--- a/test/classes/ferguson/generic-inherit-record5.chpl
+++ b/test/classes/ferguson/generic-inherit-record5.chpl
@@ -1,0 +1,34 @@
+record Parent {
+  type t;
+  var x:t;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+record Child : Parent {
+  type t;
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+writeln("Parent(int)");
+var p = new Parent(int, 1);
+p.parent_method();
+p.overridden_method();
+
+writeln("Child(int,real)");
+var c = new Child(int, 1, real, 2.0);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+

--- a/test/classes/ferguson/generic-inherit-record5.future
+++ b/test/classes/ferguson/generic-inherit-record5.future
@@ -1,0 +1,1 @@
+feature request: calling parent methods on inherited records generic parent,child, same name

--- a/test/classes/ferguson/generic-inherit-record5.good
+++ b/test/classes/ferguson/generic-inherit-record5.good
@@ -1,0 +1,7 @@
+Parent(int)
+1
+1
+Child(int,real)
+1
+12.0
+2.0

--- a/test/classes/ferguson/generic-inherit.chpl
+++ b/test/classes/ferguson/generic-inherit.chpl
@@ -1,0 +1,35 @@
+class Parent {
+  type t;
+  var x:t;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+class Child : Parent {
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+// OK
+writeln("Parent(int)");
+var p = new Parent(int, 1);
+p.parent_method();
+p.overridden_method();
+delete p;
+
+writeln("Child(int)");
+var c = new Child(int, 1, 2);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+delete c;

--- a/test/classes/ferguson/generic-inherit.good
+++ b/test/classes/ferguson/generic-inherit.good
@@ -1,0 +1,7 @@
+Parent(int)
+1
+1
+Child(int)
+1
+12
+2

--- a/test/classes/ferguson/generic-inherit2.chpl
+++ b/test/classes/ferguson/generic-inherit2.chpl
@@ -1,0 +1,39 @@
+class Parent {
+  type t;
+  var x:t;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+class Child : Parent {
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+writeln("Parent(int)");
+var p = new Parent(int, 1);
+p.parent_method();
+p.overridden_method();
+delete p;
+
+writeln("Child(int)");
+var c = new Child(int, 1, 2);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+
+writeln("Dynamic Child(int)");
+var pc:Parent(int) = c;
+pc.parent_method();
+pc.overridden_method();
+delete pc;

--- a/test/classes/ferguson/generic-inherit2.good
+++ b/test/classes/ferguson/generic-inherit2.good
@@ -1,0 +1,10 @@
+Parent(int)
+1
+1
+Child(int)
+1
+12
+2
+Dynamic Child(int)
+1
+12

--- a/test/classes/ferguson/generic-inherit2a.chpl
+++ b/test/classes/ferguson/generic-inherit2a.chpl
@@ -1,0 +1,26 @@
+class Parent {
+  type t;
+  var x:t;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+class Child : Parent {
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+writeln("Dynamic Child(int)");
+var pc:Parent(int) = new Child(int, 1, 2);
+pc.parent_method();
+pc.overridden_method();
+delete pc;

--- a/test/classes/ferguson/generic-inherit2a.good
+++ b/test/classes/ferguson/generic-inherit2a.good
@@ -1,0 +1,3 @@
+Dynamic Child(int)
+1
+12

--- a/test/classes/ferguson/generic-inherit3.chpl
+++ b/test/classes/ferguson/generic-inherit3.chpl
@@ -1,0 +1,39 @@
+class Parent {
+  var x:int;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+class Child : Parent {
+  type t;
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+writeln("Parent");
+var p = new Parent(1);
+p.parent_method();
+p.overridden_method();
+delete p;
+
+writeln("Child(int)");
+var c = new Child(1, int, 2);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+
+writeln("Dynamic Child(int)");
+var pc:Parent = c;
+pc.parent_method();
+pc.overridden_method();
+delete pc;

--- a/test/classes/ferguson/generic-inherit3.good
+++ b/test/classes/ferguson/generic-inherit3.good
@@ -1,0 +1,10 @@
+Parent
+1
+1
+Child(int)
+1
+12
+2
+Dynamic Child(int)
+1
+12

--- a/test/classes/ferguson/generic-inherit4.chpl
+++ b/test/classes/ferguson/generic-inherit4.chpl
@@ -1,0 +1,40 @@
+class Parent {
+  type t;
+  var x:t;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+class Child : Parent {
+  type u;
+  var y:u;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+writeln("Parent(int)");
+var p = new Parent(int, 1);
+p.parent_method();
+p.overridden_method();
+delete p;
+
+writeln("Child(int,real)");
+var c = new Child(int, 1, real, 2.0);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+
+writeln("Dynamic Child(int,real)");
+var pc:Parent(int) = c;
+pc.parent_method();
+pc.overridden_method();
+delete pc;

--- a/test/classes/ferguson/generic-inherit4.good
+++ b/test/classes/ferguson/generic-inherit4.good
@@ -1,0 +1,10 @@
+Parent(int)
+1
+1
+Child(int,real)
+1
+12.0
+2.0
+Dynamic Child(int,real)
+1
+12.0

--- a/test/classes/ferguson/generic-inherit5.chpl
+++ b/test/classes/ferguson/generic-inherit5.chpl
@@ -1,0 +1,40 @@
+class Parent {
+  type t;
+  var x:t;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+class Child : Parent {
+  type t;
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+writeln("Parent(int)");
+var p = new Parent(int, 1);
+p.parent_method();
+p.overridden_method();
+delete p;
+
+writeln("Child(int,real)");
+var c = new Child(int, 1, real, 2.0);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+
+writeln("Dynamic Child(int,real)");
+var pc:Parent(int) = c;
+pc.parent_method();
+pc.overridden_method();
+delete pc;

--- a/test/classes/ferguson/generic-inherit5.future
+++ b/test/classes/ferguson/generic-inherit5.future
@@ -1,0 +1,4 @@
+feature request: generic inheritence with same field name
+
+I'm not sure what exactly it should look like, but you should be able to
+do something like this...

--- a/test/classes/ferguson/generic-inherit5.future
+++ b/test/classes/ferguson/generic-inherit5.future
@@ -1,4 +1,4 @@
-feature request: generic inheritence with same field name
+feature request: generic inheritance with same field name
 
 I'm not sure what exactly it should look like, but you should be able to
 do something like this...

--- a/test/classes/ferguson/generic-inherit5.good
+++ b/test/classes/ferguson/generic-inherit5.good
@@ -1,0 +1,10 @@
+Parent(int)
+1
+1
+Child(int,real)
+1
+12.0
+2.0
+Dynamic Child(int,real)
+1
+12

--- a/test/classes/ferguson/generic-inherit6.chpl
+++ b/test/classes/ferguson/generic-inherit6.chpl
@@ -1,0 +1,40 @@
+class Parent {
+  type u;
+  var x:u;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+class Child : Parent(int) {
+  type t;
+  var y:t;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+writeln("Parent(int)");
+var p = new Parent(int, 1);
+p.parent_method();
+p.overridden_method();
+delete p;
+
+writeln("Child(int)");
+var c = new Child(1, int, 2);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+
+writeln("Dynamic Child(int)");
+var pc:Parent = c;
+pc.parent_method();
+pc.overridden_method();
+delete pc;

--- a/test/classes/ferguson/generic-inherit6.future
+++ b/test/classes/ferguson/generic-inherit6.future
@@ -1,0 +1,1 @@
+feature request: inherit from generic with arguments

--- a/test/classes/ferguson/generic-inherit6.good
+++ b/test/classes/ferguson/generic-inherit6.good
@@ -1,0 +1,10 @@
+Parent(int)
+1
+1
+Child(int)
+1
+12
+2
+Dynamic Child(int)
+1
+12

--- a/test/classes/ferguson/inherit-record.chpl
+++ b/test/classes/ferguson/inherit-record.chpl
@@ -1,0 +1,36 @@
+record Parent {
+  var x:int;
+  proc parent_method() {
+    writeln(x);
+  }
+  proc overridden_method() {
+    writeln(x);
+  }
+
+}
+
+record Child : Parent {
+  var y:int;
+  proc overridden_method() {
+    writeln(x,y);
+  }
+  proc child_method() {
+    writeln(y);
+  }
+}
+
+writeln("Parent(int)");
+var p = new Parent(1);
+p.parent_method();
+p.overridden_method();
+
+writeln("Child(int)");
+var c = new Child(1, 2);
+c.parent_method();
+c.overridden_method();
+c.child_method();
+
+writeln("Dynamic Child(int)");
+var pc:Parent = c;
+pc.parent_method();
+pc.overridden_method();

--- a/test/classes/ferguson/inherit-record.future
+++ b/test/classes/ferguson/inherit-record.future
@@ -1,0 +1,1 @@
+feature request: calling parent methods on inherited records

--- a/test/classes/ferguson/inherit-record.good
+++ b/test/classes/ferguson/inherit-record.good
@@ -1,0 +1,10 @@
+Parent(int)
+1
+1
+Child(int)
+1
+12
+2
+Dynamic Child(int)
+1
+1

--- a/test/classes/ferguson/override-generic-1-where.chpl
+++ b/test/classes/ferguson/override-generic-1-where.chpl
@@ -1,0 +1,22 @@
+class Parent {
+  proc foo(param x) {
+    writeln("Parent ", x);
+  }
+}
+
+class Child : Parent {
+  proc foo(param x) where x == 1 || x == 2 {
+    writeln("Child ", x);
+  }
+}
+
+class ChildSub : Child {
+  proc foo(param x) where x == 2 {
+    writeln("ChildSub ", x);
+  }
+}
+
+var x = new Parent();
+x.foo(1);
+x.foo(2);
+x.foo(3);

--- a/test/classes/ferguson/override-generic-1-where.good
+++ b/test/classes/ferguson/override-generic-1-where.good
@@ -1,0 +1,3 @@
+Parent 1
+Parent 2
+Parent 3

--- a/test/classes/ferguson/override-generic-1.chpl
+++ b/test/classes/ferguson/override-generic-1.chpl
@@ -1,0 +1,22 @@
+class Parent {
+  proc foo(param x) {
+    writeln("Parent ", x);
+  }
+}
+
+class Child : Parent {
+  proc foo(param x) {
+    writeln("Child ", x);
+  }
+}
+
+class ChildSub : Child {
+  proc foo(param x) {
+    writeln("ChildSub ", x);
+  }
+}
+
+var x = new Parent();
+x.foo(1);
+x.foo(2);
+x.foo(3);

--- a/test/classes/ferguson/override-generic-1.good
+++ b/test/classes/ferguson/override-generic-1.good
@@ -1,0 +1,3 @@
+Parent 1
+Parent 2
+Parent 3

--- a/test/classes/ferguson/override-generic-2-where.chpl
+++ b/test/classes/ferguson/override-generic-2-where.chpl
@@ -1,0 +1,22 @@
+class Parent {
+  proc foo(param x) {
+    writeln("Parent ", x);
+  }
+}
+
+class Child : Parent {
+  proc foo(param x) where x == 1 || x == 2 {
+    writeln("Child ", x);
+  }
+}
+
+class ChildSub : Child {
+  proc foo(param x) where x == 2 {
+    writeln("ChildSub ", x);
+  }
+}
+
+var x = new Child();
+x.foo(1);
+x.foo(2);
+x.foo(3);

--- a/test/classes/ferguson/override-generic-2-where.good
+++ b/test/classes/ferguson/override-generic-2-where.good
@@ -1,0 +1,3 @@
+Child 1
+Child 2
+Parent 3

--- a/test/classes/ferguson/override-generic-2.chpl
+++ b/test/classes/ferguson/override-generic-2.chpl
@@ -1,0 +1,22 @@
+class Parent {
+  proc foo(param x) {
+    writeln("Parent ", x);
+  }
+}
+
+class Child : Parent {
+  proc foo(param x) {
+    writeln("Child ", x);
+  }
+}
+
+class ChildSub : Child {
+  proc foo(param x) {
+    writeln("ChildSub ", x);
+  }
+}
+
+var x = new Child();
+x.foo(1);
+x.foo(2);
+x.foo(3);

--- a/test/classes/ferguson/override-generic-2.good
+++ b/test/classes/ferguson/override-generic-2.good
@@ -1,0 +1,3 @@
+Child 1
+Child 2
+Child 3

--- a/test/classes/ferguson/override-generic-3-where.chpl
+++ b/test/classes/ferguson/override-generic-3-where.chpl
@@ -1,0 +1,22 @@
+class Parent {
+  proc foo(param x) {
+    writeln("Parent ", x);
+  }
+}
+
+class Child : Parent {
+  proc foo(param x) where x == 1 || x == 2 {
+    writeln("Child ", x);
+  }
+}
+
+class ChildSub : Child {
+  proc foo(param x) where x == 2 {
+    writeln("ChildSub ", x);
+  }
+}
+
+var x = new ChildSub();
+x.foo(1);
+x.foo(2);
+x.foo(3);

--- a/test/classes/ferguson/override-generic-3-where.good
+++ b/test/classes/ferguson/override-generic-3-where.good
@@ -1,0 +1,3 @@
+Child 1
+ChildSub 2
+Parent 3

--- a/test/classes/ferguson/override-generic-3.chpl
+++ b/test/classes/ferguson/override-generic-3.chpl
@@ -1,0 +1,22 @@
+class Parent {
+  proc foo(param x) {
+    writeln("Parent ", x);
+  }
+}
+
+class Child : Parent {
+  proc foo(param x) {
+    writeln("Child ", x);
+  }
+}
+
+class ChildSub : Child {
+  proc foo(param x) {
+    writeln("ChildSub ", x);
+  }
+}
+
+var x = new ChildSub();
+x.foo(1);
+x.foo(2);
+x.foo(3);

--- a/test/classes/ferguson/override-generic-3.good
+++ b/test/classes/ferguson/override-generic-3.good
@@ -1,0 +1,3 @@
+ChildSub 1
+ChildSub 2
+ChildSub 3


### PR DESCRIPTION
This PR enables code patterns like the following:

    class Parent {
      type t;
      var x:t;
      proc parent_method() { }
      proc overridden_method() { }
    }

    class Child : Parent {
      var y:t;
      proc overridden_method() { }
      proc child_method() { }
    }

Before this PR, such code would not compile. This PR mostly adjusts the
compiler to do better book-keeping in this case of the various types
involved. The following table is useful when thinking about the
situation:

                                              (formal)
     Parent(int) ------ instantiatedFrom --->  Parent
         |                                      |
      dispatch child                         dispatch child
         |                                      |
         v                                      v
     Child(int)  ------ instantiatedFrom ---> Child
      (actual)



The first commits performed minor clean-up changes to prepare for this
patch:
 * Adjusted functions to add an arg/formal to the AST to immediately
   update AST parent pointers
 * Pulled some logic out of addToVirtualMaps and instantiateSignature
   into new functions
 * Renamed a shadowed variable in addAllToVirtualMaps

Commit 83481ba, "Add support for inheriting from a generic class" does
the meaningful changes:
* Adjusts scope resolve to create type constructors appropriately for
  this situation and to mark fields and type constructor arguments with
  FLAG_PARENT_FIELD as appropriate, so that resolution can easily
  construct the type constructor call for the parent type.
* Adjusts generics.cpp to compute the concrete parent type to use when
  instantiating a generic child type.
* Adjusts function resolution to support this situation. Adjusted
  canInstantiate, getInstantiationType, and addToVirtualMaps.

More detail is available in the individual commit messages.

Passed full quickstart testing.
Passed release/examples with --verify --baseline.
Passed full local testing.
Passed classes/ferguson with GASNet fast, numa
Passed Hello World with --llvm

Reviewed by @lydia-duncan - thanks!
