### PR TITLE
Nested mutual use ordering issue, part 2

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2273,11 +2273,10 @@ static void buildBreadthFirstModuleList(Vec<UseStmt*>* modules,
             // if applyOuterUse returned NULL, the number of symbols that
             // could be provided from this use was 0, so it didn't need to be
             // added to the alreadySeen map.
+            if (useToAdd != NULL) {
+              (*alreadySeen)[useMod].push_back(useToAdd);
+            }
 
-          }
-
-          if (useToAdd != NULL) {
-            (*alreadySeen)[useMod].push_back(useToAdd);
           } else {
             (*alreadySeen)[useMod].push_back(use);
           }

--- a/test/visibility/only/notExclusive.chpl
+++ b/test/visibility/only/notExclusive.chpl
@@ -1,0 +1,24 @@
+// The only thing that varies between these versions is the order of the
+// only/except pairs
+module Order {
+  var roy = "o";
+  var haley = "r";
+  var elan = "d";
+  var durkon = "e";
+  var vaar = "r";
+  var belkar = "'s";
+}
+
+module Godsmoot {
+  use Order only durkon;
+  use Order except durkon;
+}
+
+module Future {
+  use Godsmoot only durkon;
+  use Godsmoot except durkon;
+
+  proc main() {
+    writeln("hail hail, the ", roy, haley, elan, durkon, vaar, belkar, " all here");
+  }
+}

--- a/test/visibility/only/notExclusive.good
+++ b/test/visibility/only/notExclusive.good
@@ -1,0 +1,1 @@
+hail hail, the order's all here

--- a/test/visibility/only/notExclusive2.chpl
+++ b/test/visibility/only/notExclusive2.chpl
@@ -1,0 +1,24 @@
+// The only thing that varies between these versions is the order of the
+// only/except pairs
+module Order {
+  var roy = "o";
+  var haley = "r";
+  var elan = "d";
+  var durkon = "e";
+  var vaar = "r";
+  var belkar = "'s";
+}
+
+module Godsmoot {
+  use Order except durkon;
+  use Order only durkon;
+}
+
+module Future {
+  use Godsmoot only durkon;
+  use Godsmoot except durkon;
+
+  proc main() {
+    writeln("hail hail, the ", roy, haley, elan, durkon, vaar, belkar, " all here");
+  }
+}

--- a/test/visibility/only/notExclusive2.good
+++ b/test/visibility/only/notExclusive2.good
@@ -1,0 +1,1 @@
+hail hail, the order's all here

--- a/test/visibility/only/notExclusive3.chpl
+++ b/test/visibility/only/notExclusive3.chpl
@@ -1,0 +1,24 @@
+// The only thing that varies between these versions is the order of the
+// only/except pairs
+module Order {
+  var roy = "o";
+  var haley = "r";
+  var elan = "d";
+  var durkon = "e";
+  var vaar = "r";
+  var belkar = "'s";
+}
+
+module Godsmoot {
+  use Order except durkon;
+  use Order only durkon;
+}
+
+module Future {
+  use Godsmoot except durkon;
+  use Godsmoot only durkon;
+
+  proc main() {
+    writeln("hail hail, the ", roy, haley, elan, durkon, vaar, belkar, " all here");
+  }
+}

--- a/test/visibility/only/notExclusive3.good
+++ b/test/visibility/only/notExclusive3.good
@@ -1,0 +1,1 @@
+hail hail, the order's all here

--- a/test/visibility/only/notExclusive4.chpl
+++ b/test/visibility/only/notExclusive4.chpl
@@ -1,0 +1,24 @@
+// The only thing that varies between these versions is the order of the
+// only/except pairs
+module Order {
+  var roy = "o";
+  var haley = "r";
+  var elan = "d";
+  var durkon = "e";
+  var vaar = "r";
+  var belkar = "'s";
+}
+
+module Godsmoot {
+  use Order only durkon;
+  use Order except durkon;
+}
+
+module Future {
+  use Godsmoot except durkon;
+  use Godsmoot only durkon;
+
+  proc main() {
+    writeln("hail hail, the ", roy, haley, elan, durkon, vaar, belkar, " all here");
+  }
+}

--- a/test/visibility/only/notExclusive4.good
+++ b/test/visibility/only/notExclusive4.good
@@ -1,0 +1,1 @@
+hail hail, the order's all here


### PR DESCRIPTION
A user discovered an issue with nested mutually exclusive uses of the same
module, where not all of the symbols in the module would be found and which
symbols were found varied depending on the order of these uses.  These tests
exercise all four possible orderings of the use statements.

This error occurred as a result of adding a use to the alreadySeen map when the
outer use had caused it to not include any symbols at all (for example, when the
outer use excluded the only symbol included by that particular use, and vice
versa), which meant that a later nested look at the same use would fail to be
added to the uses to search for that particular symbol.  I made that choice
while under the impression that failing to add these uses would cause us to
repeatedly encounter them over and over again, greatly slowing down
compilation to the point where it was unreasonable.  Testing does not show that
to be the case now, though, so I'm not sure where that idea came from.

(Thanks for finding this, @cassella!)

passed std/ testing