### PR TITLE
Revert "Use cstdlib for valgrind testing"

### DIFF
--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -9,8 +9,4 @@ source $CWD/common-valgrind.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrind"
 
-# EJR (02/22/16): use cstdlib until the valgrind header files are installed on
-# our test systems (header files required for jemalloc to support valgrind.)
-export CHPL_MEM=cstdlib
-
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
This reverts commit 55fcb8303f7d150c79ba556b384e41ce15095c7e.

Valgrind headers were installed on our test machines, so we can use jemalloc
for valgrind testing now. I did a full paratest (including a new test that
verifies valgrind is working)