### PR TITLE
Add the renaming keyword "as" to our syntax highlighters

### DIFF
--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -71,7 +71,8 @@
 but they don't build a type of themselves.  Unlike the keywords on
 `c-primitive-type-kwds', they are fontified with the keyword face and
 not the type face."
-  chpl '("const" "config"
+  chpl '("as"
+         "const" "config"
          "except" "export" "extern"
          "inline" "iter"
          "module"
@@ -138,7 +139,7 @@ be mutually exclusive with `c-type-list-kwds'.
 
 Note: Use `c-typeless-decl-kwds' for keywords followed by a function
 or variable identifier (that's being defined)."
-  chpl '("except" "only" "use"))
+  chpl '("as" "except" "only" "use"))
 
 (c-lang-defconst c-block-stmt-1-kwds
   "Statement keywords followed directly by a substatement."

--- a/highlight/highlight/langDefs/chpl.lang
+++ b/highlight/highlight/langDefs/chpl.lang
@@ -10,7 +10,7 @@
 $DESCRIPTION=CHPL
 
 # Putting reserved identifiers here from spec section 6.4.2 Keywords
-$KEYWORDS(kwa)=atomic begin break by class cobegin coforall config const continue proc iter delete dmapped do domain else enum except false for forall if in index inout label lambda let local module new nil noinit on only otherwise out param private public record reduce ref require return scan select serial single sparse subdomain sync then true type union use var when where while with yield zip
+$KEYWORDS(kwa)=as atomic begin break by class cobegin coforall config const continue proc iter delete dmapped do domain else enum except false for forall if in index inout label lambda let local module new nil noinit on only otherwise out param private public record reduce ref require return scan select serial single sparse subdomain sync then true type union use var when where while with yield zip
 
 # Putting built-in things that are not types things here
 $KEYWORDS(kwb)=bool complex int opaque range real string uint

--- a/highlight/source-highlight/chpl.lang
+++ b/highlight/source-highlight/chpl.lang
@@ -12,7 +12,7 @@ number =
 string delim "\"" "\"" escape "\\"
 
 # double-quotes mean that parens are interpreted literally
-keyword = "atomic|begin|break|by|class|cobegin|coforall|config|const|continue|proc|iter|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|in|index|inline|inout|label|lambda|let|local|module|new|nil|noinit|on|only|otherwise|out|param|private|public|record|reduce|ref|require|return|scan|select|serial|single|sparse|subdomain|sync|then|true|type|union|use|var|when|where|while|with|yield|zip"
+keyword = "as|atomic|begin|break|by|class|cobegin|coforall|config|const|continue|proc|iter|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|in|index|inline|inout|label|lambda|let|local|module|new|nil|noinit|on|only|otherwise|out|param|private|public|record|reduce|ref|require|return|scan|select|serial|single|sparse|subdomain|sync|then|true|type|union|use|var|when|where|while|with|yield|zip"
 
 
 # double-quotes mean that parens are interpreted literally

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -243,7 +243,7 @@ endif
 " Chapel extentions
 syn keyword chplStatement	goto break return continue compilerWarning delete
 syn keyword chplStatement	noinit new delete this these use except only require
-syn keyword chplStatement module yield compilerError zip
+syn keyword chplStatement	as module yield compilerError zip
 syn keyword chplIntent		param type in out inout ref
 syn keyword chplStorageClass    const config export extern var
 syn keyword chplType            domain sparse subdomain range index imag complex int uint real bool


### PR DESCRIPTION
Update emacs and vim. Update highlight and source-highlight.  Still need to
update pygments and tmbundle.  Still need to update the spec with this new
keyword.