### PR TITLE
Revert to using cstdlib for gnu+darwn and pgi

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -368,7 +368,9 @@ CHPL_MEM
         ========= =======================================================
 
    If unset, ``CHPL_MEM`` defaults to ``jemalloc`` for most configurations.
-   If the target platform is ``cygwin*``, it defaults to ``cstdlib``
+   If the target platform is ``cygwin*``, the target compiler is ``*pgi``,
+   or the target platform is ``darwin`` and the target compiler is ``gnu``
+   it defaults to ``cstdlib``
 
 
 CHPL_LAUNCHER

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -6,7 +6,7 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_platform
+import chpl_compiler, chpl_platform
 from utils import memoize
 
 
@@ -18,7 +18,13 @@ def get(flag='host'):
         mem_val = os.environ.get('CHPL_MEM')
         if not mem_val:
             platform_val = chpl_platform.get('target')
-            if platform_val.startswith('cygwin'):
+            compiler_val = chpl_compiler.get('target')
+
+            cygwin = platform_val.startswith('cygwin')
+            pgi = 'pgi' in compiler_val
+            gnu_darwin = platform_val == 'darwin' and compiler_val == 'gnu'
+
+            if cygwin or pgi or gnu_darwin:
                 mem_val = 'cstdlib'
             else:
                 mem_val = 'jemalloc'


### PR DESCRIPTION
We're having some portability issues with gnu+darwin (can't build because of
some linker error) and with pgi (get sporadic segfaults at runtime)

Until I have more time to dig into these issues, we're going to default to
using cstdlib for these configurations.

See JIRA issue 188: https://chapel.atlassian.net/browse/CHAPEL-188