### PR TITLE
Fail when building examples directory with 'make' fails

### DIFF
--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -100,6 +100,11 @@ endif
 #
 cd examples
 $mymake -j$num_procs
+set tmpstatus = $status
+if ($tmpstatus!= 0) then
+    echo "ERROR: compiling examples with 'make' failed"
+    exit($tmpstatus)
+endif
 cd ..
 
 


### PR DESCRIPTION
Check the status of 'make' in the `test/release/examples/` directory for the `testReleaseHelp` script, which is invoked down the chain from the release-tarball smoke/nightly tests.