### PR TITLE
Fix isx problem size

### DIFF
--- a/test/studies/isx/COMPOPTS
+++ b/test/studies/isx/COMPOPTS
@@ -1,1 +1,1 @@
---no-warnings
+--no-warnings -sperBucketMultiply=1

--- a/test/studies/isx/COMPOPTS
+++ b/test/studies/isx/COMPOPTS
@@ -1,1 +1,1 @@
---no-warnings -sperBucketMultiply=1
+--no-warnings

--- a/test/studies/isx/PERFEXECOPTS
+++ b/test/studies/isx/PERFEXECOPTS
@@ -1,1 +1,1 @@
---mode=weakISO --useSubTimers=true --n 8388608
+--mode=weakISO --useSubTimers=true --perBucketMultiply=1

--- a/test/studies/isx/PERFEXECOPTS
+++ b/test/studies/isx/PERFEXECOPTS
@@ -1,1 +1,1 @@
---mode=weakISO --useSubTimers=true --n 16777216
+--mode=weakISO --useSubTimers=true --n 8388608

--- a/test/studies/isx/PERFEXECOPTS
+++ b/test/studies/isx/PERFEXECOPTS
@@ -1,1 +1,1 @@
---mode=weakISO --useSubTimers=true
+--mode=weakISO --useSubTimers=true --n 16777216

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -61,6 +61,7 @@ config const mode = scaling.weak;
 //
 config const n = if testrun then 32 else 2**27;
 
+const tasksPerLocale = here.maxTaskPar;
 //
 // The number of buckets per locale and total number of buckets.
 //
@@ -71,14 +72,14 @@ const numBuckets = numLocales * bucketsPerLocale;
 // The total number of keys
 //
 config const totalKeys = if mode == scaling.strong then n
-                                                   else n * numBuckets;
+                                                   else n * numBuckets * tasksPerLocale;
 
 //
 // The number of keys per bucket -- this is approximate for strong
 // scaling if the number of buckets doesn't divide 'n' evenly.
 //
 config const keysPerBucket = if mode == scaling.strong then n/numBuckets
-                                                       else n;
+                                                       else n * tasksPerLocale;
 
 
 //
@@ -97,7 +98,7 @@ if !quiet && mode != scaling.weakISO && isoBucketWidth != 0 then
 // The maximum key value to use.  When debugging, use a small size.
 //
 config const maxKeyVal = (if mode == scaling.weakISO 
-                            then (numBuckets * isoBucketWidth)
+                            then (numBuckets * tasksPerLocale * isoBucketWidth)
                             else (if testrun then 32 else 2**28)): keyType;
 
 //
@@ -106,7 +107,7 @@ config const maxKeyVal = (if mode == scaling.weakISO
 // number of buckets.
 //
 config const bucketWidth = if mode == scaling.weakISO
-                             then isoBucketWidth
+                             then isoBucketWidth * tasksPerLocale
                              else maxKeyVal/numBuckets;
 
 //

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -61,7 +61,7 @@ config const mode = scaling.weak;
 //
 config const n = if testrun then 32 else 2**27;
 
-const tasksPerLocale = here.maxTaskPar;
+config const perBucketMultiply = here.maxTaskPar;
 //
 // The number of buckets per locale and total number of buckets.
 //
@@ -72,14 +72,14 @@ const numBuckets = numLocales * bucketsPerLocale;
 // The total number of keys
 //
 config const totalKeys = if mode == scaling.strong then n
-                                                   else n * numBuckets * tasksPerLocale;
+                                                   else n * numBuckets * perBucketMultiply;
 
 //
 // The number of keys per bucket -- this is approximate for strong
 // scaling if the number of buckets doesn't divide 'n' evenly.
 //
 config const keysPerBucket = if mode == scaling.strong then n/numBuckets
-                                                       else n * tasksPerLocale;
+                                                       else n * perBucketMultiply;
 
 
 //
@@ -98,7 +98,7 @@ if !quiet && mode != scaling.weakISO && isoBucketWidth != 0 then
 // The maximum key value to use.  When debugging, use a small size.
 //
 config const maxKeyVal = (if mode == scaling.weakISO 
-                            then (numBuckets * tasksPerLocale * isoBucketWidth)
+                            then (numBuckets * perBucketMultiply * isoBucketWidth)
                             else (if testrun then 32 else 2**28)): keyType;
 
 //
@@ -107,7 +107,7 @@ config const maxKeyVal = (if mode == scaling.weakISO
 // number of buckets.
 //
 config const bucketWidth = if mode == scaling.weakISO
-                             then isoBucketWidth * tasksPerLocale
+                             then isoBucketWidth * perBucketMultiply
                              else maxKeyVal/numBuckets;
 
 //

--- a/test/studies/isx/isx-bucket-spmd.execopts
+++ b/test/studies/isx/isx-bucket-spmd.execopts
@@ -1,6 +1,6 @@
---testrun=true --mode=strong  --printTimings=false # isx-test-strong.good
---testrun=true --mode=weak    --printTimings=false # isx-test-weak.good
---testrun=true --mode=weakISO --printTimings=false # isx-test-weakISO.good
---numTrials=0 --mode=strong   --printTimings=false # isx-probsize-strong.good
---numTrials=0 --mode=weak     --printTimings=false # isx-probsize-weak.good
---numTrials=0 --mode=weakISO  --printTimings=false # isx-probsize-weakISO.good
+--testrun=true --mode=strong  --printTimings=false --perBucketMultiply=1 # isx-test-strong.good
+--testrun=true --mode=weak    --printTimings=false --perBucketMultiply=1 # isx-test-weak.good
+--testrun=true --mode=weakISO --printTimings=false --perBucketMultiply=1 # isx-test-weakISO.good
+--numTrials=0 --mode=strong   --printTimings=false --perBucketMultiply=1 # isx-probsize-strong.good
+--numTrials=0 --mode=weak     --printTimings=false --perBucketMultiply=1 # isx-probsize-weak.good
+--numTrials=0 --mode=weakISO  --printTimings=false --perBucketMultiply=1 # isx-probsize-weakISO.good

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -62,7 +62,7 @@ config const mode = scaling.weak;
 //
 config const n = if testrun then 32 else 2**27;
 
-const tasksPerLocale = here.maxTaskPar;
+config const perBucketMultiply = here.maxTaskPar;
 //
 // The number of buckets per locale and total number of buckets.
 //
@@ -73,14 +73,14 @@ const numBuckets = numLocales * bucketsPerLocale;
 // The total number of keys
 //
 config const totalKeys = if mode == scaling.strong then n
-                                                   else n * numBuckets * tasksPerLocale;
+                                                   else n * numBuckets * perBucketMultiply;
 
 //
 // The number of keys per bucket -- this is approximate for strong
 // scaling if the number of buckets doesn't divide 'n' evenly.
 //
 config const keysPerBucket = if mode == scaling.strong then n/numBuckets
-                                                       else n * tasksPerLocale;
+                                                       else n * perBucketMultiply;
 
 
 //
@@ -99,7 +99,7 @@ if !quiet && mode != scaling.weakISO && isoBucketWidth != 0 then
 // The maximum key value to use.  When debugging, use a small size.
 //
 config const maxKeyVal = (if mode == scaling.weakISO 
-                            then (numBuckets * tasksPerLocale * isoBucketWidth)
+                            then (numBuckets * perBucketMultiply * isoBucketWidth)
                             else (if testrun then 32 else 2**28)): keyType;
 
 //
@@ -108,7 +108,7 @@ config const maxKeyVal = (if mode == scaling.weakISO
 // number of buckets.
 //
 config const bucketWidth = if mode == scaling.weakISO
-                             then isoBucketWidth * tasksPerLocale
+                             then isoBucketWidth * perBucketMultiply
                              else maxKeyVal/numBuckets;
 
 //

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -62,6 +62,7 @@ config const mode = scaling.weak;
 //
 config const n = if testrun then 32 else 2**27;
 
+const tasksPerLocale = here.maxTaskPar;
 //
 // The number of buckets per locale and total number of buckets.
 //
@@ -72,14 +73,14 @@ const numBuckets = numLocales * bucketsPerLocale;
 // The total number of keys
 //
 config const totalKeys = if mode == scaling.strong then n
-                                                   else n * numBuckets;
+                                                   else n * numBuckets * tasksPerLocale;
 
 //
 // The number of keys per bucket -- this is approximate for strong
 // scaling if the number of buckets doesn't divide 'n' evenly.
 //
 config const keysPerBucket = if mode == scaling.strong then n/numBuckets
-                                                       else n;
+                                                       else n * tasksPerLocale;
 
 
 //
@@ -98,7 +99,7 @@ if !quiet && mode != scaling.weakISO && isoBucketWidth != 0 then
 // The maximum key value to use.  When debugging, use a small size.
 //
 config const maxKeyVal = (if mode == scaling.weakISO 
-                            then (numBuckets * isoBucketWidth)
+                            then (numBuckets * tasksPerLocale * isoBucketWidth)
                             else (if testrun then 32 else 2**28)): keyType;
 
 //
@@ -107,7 +108,7 @@ config const maxKeyVal = (if mode == scaling.weakISO
 // number of buckets.
 //
 config const bucketWidth = if mode == scaling.weakISO
-                             then isoBucketWidth
+                             then isoBucketWidth * tasksPerLocale
                              else maxKeyVal/numBuckets;
 
 //

--- a/test/studies/isx/isx-no-return.execopts
+++ b/test/studies/isx/isx-no-return.execopts
@@ -1,6 +1,6 @@
---testrun=true --mode=strong  --printTimings=false # isx-test-strong.good
---testrun=true --mode=weak    --printTimings=false # isx-test-weak.good
---testrun=true --mode=weakISO --printTimings=false # isx-test-weakISO.good
---numTrials=0 --mode=strong   --printTimings=false # isx-probsize-strong.good
---numTrials=0 --mode=weak     --printTimings=false # isx-probsize-weak.good
---numTrials=0 --mode=weakISO  --printTimings=false # isx-probsize-weakISO.good
+--testrun=true --mode=strong  --printTimings=false --perBucketMultiply=1 # isx-test-strong.good
+--testrun=true --mode=weak    --printTimings=false --perBucketMultiply=1 # isx-test-weak.good
+--testrun=true --mode=weakISO --printTimings=false --perBucketMultiply=1 # isx-test-weakISO.good
+--numTrials=0 --mode=strong   --printTimings=false --perBucketMultiply=1 # isx-probsize-strong.good
+--numTrials=0 --mode=weak     --printTimings=false --perBucketMultiply=1 # isx-probsize-weak.good
+--numTrials=0 --mode=weakISO  --printTimings=false --perBucketMultiply=1 # isx-probsize-weakISO.good

--- a/test/studies/isx/isx-spmd.chpl
+++ b/test/studies/isx/isx-spmd.chpl
@@ -65,18 +65,20 @@ config const mode = scaling.weak;
 //
 config const n = if testrun then 32 else 2**27;
 
+const tasksPerLocale = here.maxTaskPar;
+
 //
 // The total number of keys
 //
 config const totalKeys = if mode == scaling.strong then n
-                                                   else n * numLocales;
+                                                   else n * numLocales * tasksPerLocale;
 
 //
 // The number of keys per locale -- this is approximate for strong
 // scaling if the number of locales doesn't divide 'n' evenly.
 //
 config const keysPerLocale = if mode == scaling.strong then n/numLocales
-                                                       else n;
+                                                       else n * tasksPerLocale;
 
 
 //
@@ -95,7 +97,7 @@ if !quiet && mode != scaling.weakISO && isoBucketWidth != 0 then
 // The maximum key value to use.  When debugging, use a small size.
 //
 config const maxKeyVal = (if mode == scaling.weakISO 
-                            then (numLocales * isoBucketWidth)
+                            then (numLocales * tasksPerLocale * isoBucketWidth)
                             else (if testrun then 32 else 2**28)): keyType;
 
 //
@@ -104,7 +106,7 @@ config const maxKeyVal = (if mode == scaling.weakISO
 // number of locales.
 //
 config const bucketWidth = if mode == scaling.weakISO
-                             then isoBucketWidth
+                             then isoBucketWidth * tasksPerLocale
                              else maxKeyVal/numLocales;
 
 //

--- a/test/studies/isx/isx-spmd.chpl
+++ b/test/studies/isx/isx-spmd.chpl
@@ -65,20 +65,20 @@ config const mode = scaling.weak;
 //
 config const n = if testrun then 32 else 2**27;
 
-const tasksPerLocale = here.maxTaskPar;
+config const perBucketMultiply = here.maxTaskPar;
 
 //
 // The total number of keys
 //
 config const totalKeys = if mode == scaling.strong then n
-                                                   else n * numLocales * tasksPerLocale;
+                                                   else n * numLocales * perBucketMultiply;
 
 //
 // The number of keys per locale -- this is approximate for strong
 // scaling if the number of locales doesn't divide 'n' evenly.
 //
 config const keysPerLocale = if mode == scaling.strong then n/numLocales
-                                                       else n * tasksPerLocale;
+                                                       else n * perBucketMultiply;
 
 
 //
@@ -97,7 +97,7 @@ if !quiet && mode != scaling.weakISO && isoBucketWidth != 0 then
 // The maximum key value to use.  When debugging, use a small size.
 //
 config const maxKeyVal = (if mode == scaling.weakISO 
-                            then (numLocales * tasksPerLocale * isoBucketWidth)
+                            then (numLocales * perBucketMultiply * isoBucketWidth)
                             else (if testrun then 32 else 2**28)): keyType;
 
 //
@@ -106,7 +106,7 @@ config const maxKeyVal = (if mode == scaling.weakISO
 // number of locales.
 //
 config const bucketWidth = if mode == scaling.weakISO
-                             then isoBucketWidth * tasksPerLocale
+                             then isoBucketWidth * perBucketMultiply
                              else maxKeyVal/numLocales;
 
 //

--- a/test/studies/isx/isx-spmd.execopts
+++ b/test/studies/isx/isx-spmd.execopts
@@ -1,6 +1,6 @@
---testrun=true --mode=strong  --printTimings=false # isx-test-strong.good
---testrun=true --mode=weak    --printTimings=false # isx-test-weak.good
---testrun=true --mode=weakISO --printTimings=false # isx-test-weakISO.good
---numTrials=0 --mode=strong   --printTimings=false # isx-probsize-strong.good
---numTrials=0 --mode=weak     --printTimings=false # isx-probsize-weak.good
---numTrials=0 --mode=weakISO  --printTimings=false # isx-probsize-weakISO.good
+--testrun=true --mode=strong  --printTimings=false --perBucketMultiply=1 # isx-test-strong.good
+--testrun=true --mode=weak    --printTimings=false --perBucketMultiply=1 # isx-test-weak.good
+--testrun=true --mode=weakISO --printTimings=false --perBucketMultiply=1 # isx-test-weakISO.good
+--numTrials=0 --mode=strong   --printTimings=false --perBucketMultiply=1 # isx-probsize-strong.good
+--numTrials=0 --mode=weak     --printTimings=false --perBucketMultiply=1 # isx-probsize-weak.good
+--numTrials=0 --mode=weakISO  --printTimings=false --perBucketMultiply=1 # isx-probsize-weakISO.good


### PR DESCRIPTION
In the reference version, 'n' is the number of keys per PE. So far we have been using 'n' as the number of keys per locale/bucket, which means we have been running a significantly smaller problem size. This patch changes the code to queue off of here.maxTaskPar by default. For consistency in performance testing, we'll set perBucketMultiply to 1 to continue to measure the same problem size that we've been using.