### PR TITLE
Add a space to testReleaseHelp

### DIFF
--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -101,7 +101,7 @@ endif
 cd examples
 $mymake -j$num_procs
 set tmpstatus = $status
-if ($tmpstatus!= 0) then
+if ($tmpstatus != 0) then
     echo "ERROR: compiling examples with 'make' failed"
     exit($tmpstatus)
 endif


### PR DESCRIPTION
There needs to be a space around operators in csh, this was causing the release-tarball builds to fail.