### PR TITLE
ISx ref to array

### DIFF
--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -295,8 +295,9 @@ proc countLocalKeys(bucketID, myBucketSize) {
   const myMinKeyVal = bucketID * bucketWidth;
   var myLocalKeyCounts: [myMinKeyVal..#bucketWidth] atomic int;
 
+  ref myBucket = allBucketKeys[bucketID];
   forall i in 0..#myBucketSize do
-    myLocalKeyCounts[allBucketKeys[bucketID][i]].add(1);
+    myLocalKeyCounts[myBucket[i]].add(1);
 
   if debug then
     writeln(bucketID, ": myLocalKeyCounts[", myMinKeyVal, "..] = ", 

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -289,8 +289,9 @@ proc exchangeKeys(bucketID, sendOffsets, bucketSizes, myBucketedKeys) {
 
 
 proc countLocalKeys(myLocalKeyCounts, bucketID, myBucketSize, myMinKeyVal) {
+  ref myBucket = allBucketKeys[bucketID];
   forall i in 0..#myBucketSize do
-    myLocalKeyCounts[allBucketKeys[bucketID][i]].add(1);
+    myLocalKeyCounts[myBucket[i]].add(1);
 
   if debug then
     writeln(bucketID, ": myLocalKeyCounts[", myMinKeyVal, "..] = ", 

--- a/test/studies/isx/isx-spmd.chpl
+++ b/test/studies/isx/isx-spmd.chpl
@@ -294,8 +294,9 @@ proc countLocalKeys(myBucketSize) {
   const myMinKeyVal = here.id * bucketWidth;
   var myLocalKeyCounts: [myMinKeyVal..#bucketWidth] atomic int;
 
+  ref myBucket = allBucketKeys[here.id];
   forall i in 0..#myBucketSize do
-    myLocalKeyCounts[allBucketKeys[here.id][i]].add(1);
+    myLocalKeyCounts[myBucket[i]].add(1);
 
   if debug then
     writeln(here.id, ": myLocalKeyCounts[", myMinKeyVal, "..] = ", 


### PR DESCRIPTION
Avoid redundant array access by using a ref to an array. Possible after 2c6daea4