### PR TITLE
Update extern decls of chpl_mem_* functions to match the runtime signatures

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -6092,7 +6092,7 @@ void insertChplHereAlloc(Expr *call, bool insertAfter, Symbol *sym,
                                                  (ct != NULL) ?
                                                  ct->symbol : t->symbol));
   VarSymbol* mdExpr = (md != NULL) ? md : newMemDesc(t->symbol->name);
-  Symbol *allocTmp = newTemp("chpl_here_alloc_tmp", dtOpaque);
+  Symbol *allocTmp = newTemp("chpl_here_alloc_tmp", dtCVoidPtr);
   CallExpr* allocExpr = new CallExpr(PRIM_MOVE, allocTmp,
                                      new CallExpr(gChplHereAlloc,
                                                   sizeTmp, mdExpr));

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -35,8 +35,8 @@ returnInfoVoid(CallExpr* call) {
 }
 
 static Type*
-returnInfoOpaque(CallExpr* call) {
-  return dtOpaque;
+returnInfoCVoidPtr(CallExpr* call) {
+  return dtCVoidPtr;
 }
 
 static Type*
@@ -589,7 +589,7 @@ initPrimitive() {
   prim_def("ascii", returnInfoInt32);
   prim_def("string_index", returnInfoStringCopy, true, true);
   prim_def(PRIM_STRING_COPY, "string_copy", returnInfoStringCopy, false, true);
-  prim_def(PRIM_CAST_TO_VOID_STAR, "cast_to_void_star", returnInfoOpaque, true, false);
+  prim_def(PRIM_CAST_TO_VOID_STAR, "cast_to_void_star", returnInfoCVoidPtr, true, false);
   prim_def("string_select", returnInfoStringCopy, true, true);
   prim_def("sleep", returnInfoVoid, true);
   prim_def("real2int", returnInfoDefaultInt);

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -396,21 +396,6 @@ module ChapelLocale {
       return dummyLocale;
   }
 
-
-  pragma "insert line file info"
-  extern proc chpl_memhook_malloc_pre(number:int, size:int, md:int(16)): void;
-  pragma "insert line file info"
-  extern proc chpl_memhook_malloc_post(ptr:opaque, number:int,
-                                       size:int, md:int(16)): void;
-  pragma "insert line file info"
-  extern proc chpl_memhook_realloc_pre(ptr:object, size:int, md:int(16)): void;
-  pragma "insert line file info"
-  extern proc chpl_memhook_realloc_post(newPtr:opaque, ptr:object,
-                                        size:int, md:int(16)): void;
-  pragma "insert line file info"
-  extern proc chpl_memhook_free_pre(ptr:opaque): void;
-  extern proc chpl_memhook_md_num(): int(16);
-
   proc chpl_getPrivatizedCopy(type objectType, objectPid:int): objectType
     return __primitive("chpl_getPrivatizedClass", nil:objectType, objectPid);
   

--- a/modules/internal/ChapelLocale_forDocs.chpl
+++ b/modules/internal/ChapelLocale_forDocs.chpl
@@ -561,29 +561,6 @@ module ChapelLocale {
   const Locales: [LocaleSpace] locale;
 
   pragma "no doc"
-  pragma "insert line file info"
-  extern proc chpl_memhook_malloc_pre(number:int, size:int, md:int(16)): void;
-
-  pragma "no doc"
-  pragma "insert line file info"
-  extern proc chpl_memhook_malloc_post(ptr:opaque, number:int,
-                                       size:int, md:int(16)): void;
-  pragma "no doc"
-  pragma "insert line file info"
-  extern proc chpl_memhook_realloc_pre(ptr:object, size:int, md:int(16)): void;
-
-  pragma "no doc"
-  pragma "insert line file info"
-  extern proc chpl_memhook_realloc_post(newPtr:opaque, ptr:object,
-                                        size:int, md:int(16)): void;
-  pragma "no doc"
-  pragma "insert line file info"
-  extern proc chpl_memhook_free_pre(ptr:opaque): void;
-
-  pragma "no doc"
-  extern proc chpl_memhook_md_num(): int(16);
-
-  pragma "no doc"
   proc chpl_getPrivatizedCopy(type objectType, objectPid:int): objectType
     return __primitive("chpl_getPrivatizedClass", nil:objectType, objectPid);
   

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -53,6 +53,10 @@ module String {
   config param chpl_stringGrowthFactor = 1.5;
   extern proc chpl_mem_goodAllocSize(minSize: size_t) : size_t;
 
+  // TODO (EJR: 02/25/16): see if we can remove this explicit type declaration.
+  // chpl_mem_descInt_t is really a well known compiler type since the compiler
+  // emits calls for the chpl_mem_descs table. Maybe the compiler should just
+  // create the type and export it to the runtime?
   extern type chpl_mem_descInt_t = int(16);
 
   // We use this as a shortcut to get at here.id without actually constructing

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -53,7 +53,7 @@ module String {
   config param chpl_stringGrowthFactor = 1.5;
   extern proc chpl_mem_goodAllocSize(minSize: size_t) : size_t;
 
-  extern type chpl_mem_descInt_t;
+  extern type chpl_mem_descInt_t = int(16);
 
   // We use this as a shortcut to get at here.id without actually constructing
   // a locale object. Used when determining if we should make a remote transfer.

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -287,26 +287,26 @@ module LocaleModel {
   // The allocator pragma is used by scalar replacement.
   pragma "allocator"
   pragma "locale model alloc"
-  proc chpl_here_alloc(size:int, md:int(16)) {
-    extern proc chpl_memhook_md_num(): int(16);
+  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t) {
+    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:size_t, md:int(16)) : c_void_ptr;
+      extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_calloc(size:int, number:int, md:int(16)) {
-    extern proc chpl_memhook_md_num(): int(16);
+  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t) {
+    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:int(16)) : c_void_ptr;
+      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:int(16)) {
-    extern proc chpl_memhook_md_num(): int(16);
+  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t) {
+    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:int(16)) : c_void_ptr;
+      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -288,6 +288,7 @@ module LocaleModel {
   pragma "allocator"
   pragma "locale model alloc"
   proc chpl_here_alloc(size:int, md:int(16)) {
+    extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
       extern proc chpl_mem_alloc(size:int, md:int(16)) : opaque;
     return chpl_mem_alloc(size, md + chpl_memhook_md_num());
@@ -295,6 +296,7 @@ module LocaleModel {
 
   pragma "allocator"
   proc chpl_here_calloc(size:int, number:int, md:int(16)) {
+    extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
       extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : opaque;
     return chpl_mem_calloc(number, size, md + chpl_memhook_md_num());
@@ -302,6 +304,7 @@ module LocaleModel {
 
   pragma "allocator"
   proc chpl_here_realloc(ptr:opaque, size:int, md:int(16)) {
+    extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
       extern proc chpl_mem_realloc(ptr:opaque, size:int, md:int(16)) : opaque;
     return chpl_mem_realloc(ptr, size, md + chpl_memhook_md_num());

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -284,11 +284,12 @@ module LocaleModel {
   // support for memory management
   //
 
+  private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
+
   // The allocator pragma is used by scalar replacement.
   pragma "allocator"
   pragma "locale model alloc"
   proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t) {
-    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
       extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
@@ -296,7 +297,6 @@ module LocaleModel {
 
   pragma "allocator"
   proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t) {
-    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
       extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
@@ -304,7 +304,6 @@ module LocaleModel {
 
   pragma "allocator"
   proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t) {
-    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
       extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -290,30 +290,30 @@ module LocaleModel {
   proc chpl_here_alloc(size:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:int, md:int(16)) : c_void_ptr;
-    return chpl_mem_alloc(size, md + chpl_memhook_md_num());
+      extern proc chpl_mem_alloc(size:size_t, md:int(16)) : c_void_ptr;
+    return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
   proc chpl_here_calloc(size:int, number:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : c_void_ptr;
-    return chpl_mem_calloc(number, size, md + chpl_memhook_md_num());
+      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:int(16)) : c_void_ptr;
+    return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
   proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:int, md:int(16)) : c_void_ptr;
-    return chpl_mem_realloc(ptr, size, md + chpl_memhook_md_num());
+      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:int(16)) : c_void_ptr;
+    return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "locale model free"
   proc chpl_here_free(ptr:c_void_ptr) {
     pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:c_void_ptr): void;
+      extern proc chpl_mem_free(ptr:c_void_ptr) : void;
     chpl_mem_free(ptr);
   }
 

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -290,7 +290,7 @@ module LocaleModel {
   proc chpl_here_alloc(size:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:int, md:int(16)) : opaque;
+      extern proc chpl_mem_alloc(size:int, md:int(16)) : c_void_ptr;
     return chpl_mem_alloc(size, md + chpl_memhook_md_num());
   }
 
@@ -298,22 +298,22 @@ module LocaleModel {
   proc chpl_here_calloc(size:int, number:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : opaque;
+      extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : c_void_ptr;
     return chpl_mem_calloc(number, size, md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_realloc(ptr:opaque, size:int, md:int(16)) {
+  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:opaque, size:int, md:int(16)) : opaque;
+      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:int, md:int(16)) : c_void_ptr;
     return chpl_mem_realloc(ptr, size, md + chpl_memhook_md_num());
   }
 
   pragma "locale model free"
-  proc chpl_here_free(ptr:opaque) {
+  proc chpl_here_free(ptr:c_void_ptr) {
     pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:opaque): void;
+      extern proc chpl_mem_free(ptr:c_void_ptr): void;
     chpl_mem_free(ptr);
   }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -372,30 +372,30 @@ module LocaleModel {
   proc chpl_here_alloc(size:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:int, md:int(16)) : c_void_ptr;
-    return chpl_mem_alloc(size, md + chpl_memhook_md_num());
+      extern proc chpl_mem_alloc(size:size_t, md:int(16)) : c_void_ptr;
+    return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
   proc chpl_here_calloc(size:int, number:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : c_void_ptr;
-    return chpl_mem_calloc(number, size, md + chpl_memhook_md_num());
+      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:int(16)) : c_void_ptr;
+    return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
   proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:int, md:int(16)) : c_void_ptr;
-    return chpl_mem_realloc(ptr, size, md + chpl_memhook_md_num());
+      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:int(16)) : c_void_ptr;
+    return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "locale model free"
   proc chpl_here_free(ptr:c_void_ptr) {
     pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:c_void_ptr): void;
+      extern proc chpl_mem_free(ptr:c_void_ptr) : void;
     chpl_mem_free(ptr);
   }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -370,6 +370,7 @@ module LocaleModel {
   pragma "allocator"
   pragma "locale model alloc"
   proc chpl_here_alloc(size:int, md:int(16)) {
+    extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
       extern proc chpl_mem_alloc(size:int, md:int(16)) : opaque;
     return chpl_mem_alloc(size, md + chpl_memhook_md_num());
@@ -377,6 +378,7 @@ module LocaleModel {
 
   pragma "allocator"
   proc chpl_here_calloc(size:int, number:int, md:int(16)) {
+    extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
       extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : opaque;
     return chpl_mem_calloc(number, size, md + chpl_memhook_md_num());
@@ -384,6 +386,7 @@ module LocaleModel {
 
   pragma "allocator"
   proc chpl_here_realloc(ptr:opaque, size:int, md:int(16)) {
+    extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
       extern proc chpl_mem_realloc(ptr:opaque, size:int, md:int(16)) : opaque;
     return chpl_mem_realloc(ptr, size, md + chpl_memhook_md_num());

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -365,12 +365,13 @@ module LocaleModel {
   //
   // support for memory management
   //
+  
+  private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
 
   // The allocator pragma is used by scalar replacement.
   pragma "allocator"
   pragma "locale model alloc"
   proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t) {
-    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
       extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
@@ -378,7 +379,6 @@ module LocaleModel {
 
   pragma "allocator"
   proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t) {
-    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
       extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
@@ -386,7 +386,6 @@ module LocaleModel {
 
   pragma "allocator"
   proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t) {
-    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
       extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -369,26 +369,26 @@ module LocaleModel {
   // The allocator pragma is used by scalar replacement.
   pragma "allocator"
   pragma "locale model alloc"
-  proc chpl_here_alloc(size:int, md:int(16)) {
-    extern proc chpl_memhook_md_num(): int(16);
+  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t) {
+    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:size_t, md:int(16)) : c_void_ptr;
+      extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_calloc(size:int, number:int, md:int(16)) {
-    extern proc chpl_memhook_md_num(): int(16);
+  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t) {
+    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:int(16)) : c_void_ptr;
+      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:int(16)) {
-    extern proc chpl_memhook_md_num(): int(16);
+  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t) {
+    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
     pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:int(16)) : c_void_ptr;
+      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -372,7 +372,7 @@ module LocaleModel {
   proc chpl_here_alloc(size:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:int, md:int(16)) : opaque;
+      extern proc chpl_mem_alloc(size:int, md:int(16)) : c_void_ptr;
     return chpl_mem_alloc(size, md + chpl_memhook_md_num());
   }
 
@@ -380,22 +380,22 @@ module LocaleModel {
   proc chpl_here_calloc(size:int, number:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : opaque;
+      extern proc chpl_mem_calloc(number:int, size:int, md:int(16)) : c_void_ptr;
     return chpl_mem_calloc(number, size, md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_realloc(ptr:opaque, size:int, md:int(16)) {
+  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:int(16)) {
     extern proc chpl_memhook_md_num(): int(16);
     pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:opaque, size:int, md:int(16)) : opaque;
+      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:int, md:int(16)) : c_void_ptr;
     return chpl_mem_realloc(ptr, size, md + chpl_memhook_md_num());
   }
 
   pragma "locale model free"
-  proc chpl_here_free(ptr:opaque) {
+  proc chpl_here_free(ptr:c_void_ptr) {
     pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:opaque): void;
+      extern proc chpl_mem_free(ptr:c_void_ptr): void;
     chpl_mem_free(ptr);
   }
 


### PR DESCRIPTION
The extern declarations of the chpl_mem_* functions in ChapelLocale were using
opaque instead of c_void_ptr, int instead of size_t, and int(16) instead of
chpl_mem_descInt_t.  This fixes the extern declarations so they match the
runtime signatures and adds safeCasts where appropriate.

The patch makes sense on its own, but the real goal is to work towards the
removal of the additional extern decls and uses of the chpl_mem_* functions in
the string module. The string module has its own externs instead of using the
chpl_here_* routines because the signatures were off.

Individual commits have more details on the specific changes.
