### PR TITLE
Clean up $HOME/.chpl after 'make check' if it did not exist.

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -85,21 +85,15 @@ else
     log_info "Found \$CHPL_HOME directory: ${CHPL_HOME}"
 fi
 
-CHPL_DIR_REMOVE=1
-
 # Create ~/.chpl directory, if it does not already exist
 CHPL_DIR=${CHPL_CHECK_INSTALL_DIR:-${HOME}/.chpl}
 if [ ! -d ${CHPL_DIR} ] ; then
     log_info "${CHPL_DIR} does not exist. Creating it."
     mkdir -p ${CHPL_DIR} || { log_error "Failed to create ${CHPL_DIR}." && exit 1 ; }
+    CHPL_DIR_REMOVE=1
 else
     log_info "${CHPL_DIR} already exists. Using it."
-    if find "${CHPL_DIR}" -mindepth 1 -print -quit | grep -q .; then
-        log_debug "${CHPL_DIR} is not empty. Not removing it after 'make check'"
-        CHPL_DIR_REMOVE=0
-    else
-        log_debug "${CHPL_DIR} is empty. Removing it after 'make check'"
-    fi
+    CHPL_DIR_REMOVE=0
 fi
 
 # Location of test job

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -46,10 +46,12 @@ function log_error()
 function log_debug()
 {
     local msg=$@
-    if [ "${DEBUG}" == "1" ]; then
+    if [ "${CHPL_CHECK_DEBUG}" == "1" ]; then
         echo "[Debug] ${msg}" >&2
     fi
 }
+
+log_debug "Debug output is turned on, because \$CHPL_CHECK_DEBUG == 1"
 
 # Base name for test job in examples
 TEST_JOB_BASENAME=hello6-taskpar-dist

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -43,6 +43,14 @@ function log_error()
     echo "[Fail] ${msg}" >&2
 }
 
+function log_debug()
+{
+    local msg=$@
+    if [ "${DEBUG}" == "1" ]; then
+        echo "[Debug] ${msg}" >&2
+    fi
+}
+
 # Base name for test job in examples
 TEST_JOB_BASENAME=hello6-taskpar-dist
 
@@ -75,11 +83,21 @@ else
     log_info "Found \$CHPL_HOME directory: ${CHPL_HOME}"
 fi
 
+CHPL_DIR_REMOVE=1
+
 # Create ~/.chpl directory, if it does not already exist
 CHPL_DIR=${CHPL_CHECK_INSTALL_DIR:-${HOME}/.chpl}
 if [ ! -d ${CHPL_DIR} ] ; then
     log_info "${CHPL_DIR} does not exist. Creating it."
     mkdir -p ${CHPL_DIR} || { log_error "Failed to create ${CHPL_DIR}." && exit 1 ; }
+else
+    log_info "${CHPL_DIR} already exists. Using it."
+    if find "${CHPL_DIR}" -mindepth 1 -print -quit | grep -q .; then
+        log_debug "${CHPL_DIR} is not empty. Not removing it after 'make check'"
+        CHPL_DIR_REMOVE=0
+    else
+        log_debug "${CHPL_DIR} is empty. Removing it after 'make check'"
+    fi
 fi
 
 # Location of test job
@@ -134,7 +152,12 @@ fi
 # Cleanup the tmp directory whenever exit is invoked
 function cleanup_tmp_dir()
 {
+    log_debug "Removing ${TMP_TEST_DIR}"
     rm -rf ${TMP_TEST_DIR}
+    if [ "${CHPL_DIR_REMOVE}" == "1" ]; then
+        log_debug "Removing ${CHPL_DIR}"
+        rm -rf ${CHPL_DIR}
+    fi
 }
 trap cleanup_tmp_dir EXIT
 


### PR DESCRIPTION
`make check` calls `util/checkChplInstall`, which uses `$HOME/.chpl` as it's work space (see the `checkChplInstall comment header for details as to why we do this).

This PR removes `$HOME/.chpl` after `make check` if the directory did not previously exist.

Also added a `log_debug()` for additional output when calling `CHPL_CHECK_DEBUG=1 make check`. Users are notified when debug output is enabled.