### PR TITLE
Thread good alloc size through modules

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -51,7 +51,7 @@ module String {
   param chpl_string_min_alloc_size: int = 16;
   // Growth factor to use when extending the buffer for appends
   config param chpl_stringGrowthFactor = 1.5;
-  extern proc chpl_mem_goodAllocSize(minSize: size_t) : size_t;
+  extern proc chpl_mem_good_alloc_size(minSize: size_t) : size_t;
 
   // TODO (EJR: 02/25/16): see if we can remove this explicit type declaration.
   // chpl_mem_descInt_t is really a well known compiler type since the compiler
@@ -132,7 +132,7 @@ module String {
           this._size = sLen+1;
         } else {
           if this.owned {
-            const allocSize = chpl_mem_goodAllocSize((sLen+1).safeCast(size_t));
+            const allocSize = chpl_mem_good_alloc_size((sLen+1).safeCast(size_t));
             this.buff = chpl_mem_alloc(allocSize,
                                        CHPL_RT_MD_STR_COPY_DATA): bufferType;
             memcpy(this.buff, s.buff, s.len.safeCast(size_t));
@@ -185,7 +185,7 @@ module String {
             if this.owned && !this.isEmptyString() then
               chpl_mem_free(this.buff);
             // TODO: should I just allocate 'size' bytes?
-            const allocSize = chpl_mem_goodAllocSize((s_len+1).safeCast(size_t));
+            const allocSize = chpl_mem_good_alloc_size((s_len+1).safeCast(size_t));
             this.buff = chpl_mem_alloc(allocSize,
                                        CHPL_RT_MD_STR_COPY_DATA):bufferType;
             this.buff[s_len] = 0;
@@ -255,7 +255,7 @@ module String {
       if i <= 0 || i > this.len then halt("index out of bounds of string");
 
       var ret: string;
-      const newSize = chpl_mem_goodAllocSize(2);
+      const newSize = chpl_mem_good_alloc_size(2);
       ret._size = max(chpl_string_min_alloc_size, newSize.safeCast(int));
       ret.len = 1;
       ret.buff = chpl_mem_alloc(ret._size.safeCast(size_t),
@@ -304,7 +304,7 @@ module String {
         ret = "";
       } else {
         ret.len = r2.size:int;
-        const newSize = chpl_mem_goodAllocSize((ret.len+1).safeCast(size_t));
+        const newSize = chpl_mem_good_alloc_size((ret.len+1).safeCast(size_t));
         ret._size = max(chpl_string_min_alloc_size, newSize.safeCast(int));
         // FIXME: I was dumb here, just copy the correct region over in
         // multi-locale and use that as the string buffer. No need to copy stuff
@@ -567,7 +567,7 @@ module String {
         }
         newSize += this.len*(S.size-1);
         ret.len = newSize;
-        const allocSize = chpl_mem_goodAllocSize((ret.len+1).safeCast(size_t));
+        const allocSize = chpl_mem_good_alloc_size((ret.len+1).safeCast(size_t));
         ret._size = allocSize.safeCast(int);
         ret.buff = chpl_mem_alloc(allocSize,
                                   CHPL_RT_MD_STR_COPY_DATA): bufferType;
@@ -995,7 +995,7 @@ module String {
 
     var ret: string;
     ret.len = s0len + s1len;
-    const allocSize = chpl_mem_goodAllocSize((ret.len+1).safeCast(size_t));
+    const allocSize = chpl_mem_good_alloc_size((ret.len+1).safeCast(size_t));
     ret._size = allocSize.safeCast(int);
     ret.buff = chpl_mem_alloc(allocSize,
                               CHPL_RT_MD_STR_COPY_DATA): bufferType;
@@ -1029,7 +1029,7 @@ module String {
 
     var ret: string;
     ret.len = sLen * n; // TODO: check for overflow
-    const allocSize = chpl_mem_goodAllocSize((ret.len+1).safeCast(size_t));
+    const allocSize = chpl_mem_good_alloc_size((ret.len+1).safeCast(size_t));
     ret._size = allocSize.safeCast(int);
     ret.buff = chpl_mem_alloc(allocSize,
                               CHPL_RT_MD_STR_COPY_DATA): bufferType;
@@ -1153,7 +1153,7 @@ module String {
       const rhsLen = rhs.len;
       const newLength = lhs.len+rhsLen; //TODO: check for overflow
       if lhs._size <= newLength {
-        const newSize = chpl_mem_goodAllocSize(
+        const newSize = chpl_mem_good_alloc_size(
             max(newLength+1,
                 (lhs.len * chpl_stringGrowthFactor):int).safeCast(size_t));
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -51,6 +51,7 @@ module String {
   param chpl_string_min_alloc_size: int = 16;
   // Growth factor to use when extending the buffer for appends
   config param chpl_stringGrowthFactor = 1.5;
+  pragma "insert line file info"
   extern proc chpl_mem_good_alloc_size(minSize: size_t) : size_t;
 
   // TODO (EJR: 02/25/16): see if we can remove this explicit type declaration.

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -309,6 +309,12 @@ module LocaleModel {
     return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
+  proc chpl_here_good_alloc_size(min_size:int) {
+    pragma "insert line file info"
+      extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
+    return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(int);
+  }
+
   pragma "locale model free"
   proc chpl_here_free(ptr:c_void_ptr) {
     pragma "insert line file info"

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -391,6 +391,12 @@ module LocaleModel {
     return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
+  proc chpl_here_good_alloc_size(min_size:int) {
+    pragma "insert line file info"
+      extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
+    return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(int);
+  }
+
   pragma "locale model free"
   proc chpl_here_free(ptr:c_void_ptr) {
     pragma "insert line file info"

--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -139,8 +139,8 @@ void* chpl_memcpy(void* dest, const void* src, size_t num)
 //
 // If an allocator does not have the ability to get this information, minSize
 // will be returned.
-static inline size_t chpl_mem_goodAllocSize(size_t minSize) {
-  return chpl_goodAllocSize(minSize);
+static inline size_t chpl_mem_good_alloc_size(size_t minSize) {
+  return chpl_good_alloc_size(minSize);
 }
 
 // free a c_string_copy, no error checking.

--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -139,7 +139,7 @@ void* chpl_memcpy(void* dest, const void* src, size_t num)
 //
 // If an allocator does not have the ability to get this information, minSize
 // will be returned.
-static inline size_t chpl_mem_good_alloc_size(size_t minSize) {
+static inline size_t chpl_mem_good_alloc_size(size_t minSize, int32_t lineno, int32_t filename) {
   return chpl_good_alloc_size(minSize);
 }
 

--- a/runtime/include/mem/cstdlib/chpl-mem-impl.h
+++ b/runtime/include/mem/cstdlib/chpl-mem-impl.h
@@ -71,7 +71,7 @@ static inline void chpl_free(void* ptr) {
 
 // malloc_good_size is OSX specifc unfortunately. On other platforms just
 // return minSize.
-static inline size_t chpl_goodAllocSize(size_t minSize) {
+static inline size_t chpl_good_alloc_size(size_t minSize) {
 #if defined(__APPLE__)
   return malloc_good_size(minSize);
 #else

--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -56,7 +56,7 @@ static inline void chpl_free(void* ptr) {
   je_free(ptr);
 }
 
-static inline size_t chpl_goodAllocSize(size_t minSize) {
+static inline size_t chpl_good_alloc_size(size_t minSize) {
   // TODO (EJR 12/17/15): can/should we use nallocx()? If so, this will require
   // using the extended API. Note that the extended API has undefined behavior
   // for allocations of size 0 so I think a size 0 check will have to be added

--- a/test/runtime/kbrady/goodAllocSize.chpl
+++ b/test/runtime/kbrady/goodAllocSize.chpl
@@ -1,6 +1,6 @@
-extern proc chpl_mem_goodAllocSize(minSize:size_t): size_t;
+extern proc chpl_mem_good_alloc_size(minSize:size_t): size_t;
 
-writeln(chpl_mem_goodAllocSize(1));
-writeln(chpl_mem_goodAllocSize(16));
-writeln(chpl_mem_goodAllocSize(17));
-writeln(chpl_mem_goodAllocSize(1000));
+writeln(chpl_mem_good_alloc_size(1));
+writeln(chpl_mem_good_alloc_size(16));
+writeln(chpl_mem_good_alloc_size(17));
+writeln(chpl_mem_good_alloc_size(1000));

--- a/test/runtime/kbrady/goodAllocSize.chpl
+++ b/test/runtime/kbrady/goodAllocSize.chpl
@@ -1,6 +1,4 @@
-extern proc chpl_mem_good_alloc_size(minSize:size_t): size_t;
-
-writeln(chpl_mem_good_alloc_size(1));
-writeln(chpl_mem_good_alloc_size(16));
-writeln(chpl_mem_good_alloc_size(17));
-writeln(chpl_mem_good_alloc_size(1000));
+writeln(chpl_here_good_alloc_size(1));
+writeln(chpl_here_good_alloc_size(16));
+writeln(chpl_here_good_alloc_size(17));
+writeln(chpl_here_good_alloc_size(1000));


### PR DESCRIPTION
Thread *_good_alloc_size() support through the modules. Previously it was only
declared in the runtime and externed by the string module. This cleans up the
names/interface to match the other chpl_mem_* routines and adds Chapel level
wrappers in the LocalModel modules.

This is to support removing the use of the extern in the string module, and is
a nice cleanup to make it more consistent with its sibling functions.