### PR TITLE
Allow c_ptr's to be implicitly coerced to c_void_ptr

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -79,6 +79,7 @@ symbolFlag( FLAG_COMPILER_NESTED_FUNCTION , npr, "compiler nested function" , nc
 symbolFlag( FLAG_CONCURRENTLY_ACCESSED , npr, "concurrently accessed" , "local variables accessed by multiple threads" )
 symbolFlag( FLAG_CONFIG , npr, "config" , "config variable, constant, or parameter" )
 symbolFlag( FLAG_CONST , npr, "const" , "constant" )
+symbolFlag( FLAG_C_PTR_CLASS , ypr, "c_ptr class" , "marks c_ptr class" )
 symbolFlag( FLAG_CONSTRUCTOR , npr, "constructor" , "constructor (but not type constructor); loosely defined to include constructor wrappers" )
 symbolFlag( FLAG_DATA_CLASS , ypr, "data class" , ncm )
 symbolFlag( FLAG_DEFAULT_CONSTRUCTOR , npr, "default constructor" , ncm )

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1379,6 +1379,9 @@ canCoerce(Type* actualType, Symbol* actualSym, Type* formalType, FnSymbol* fn, b
     return true;
   if (formalType == dtStringC && actualType == dtStringCopy)
     return true;
+  if (actualType->symbol->hasFlag(FLAG_C_PTR_CLASS) &&
+      (formalType == dtCVoidPtr))
+    return true;
 
   return false;
 }

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -48,6 +48,7 @@ module CPtr {
   pragma "no object"
   pragma "no default functions"
   pragma "no wide class"
+  pragma "c_ptr class"
   class c_ptr {
     /* The type that this pointer points to */
     type eltType;

--- a/test/types/cptr/ptr_coerce_to_void_ptr.chpl
+++ b/test/types/cptr/ptr_coerce_to_void_ptr.chpl
@@ -1,0 +1,8 @@
+proc test(x: c_void_ptr) {
+  writeln(x == nil);
+}
+
+var y: c_ptr(uint(8));
+test(y);
+
+test(c_malloc(int, 1));

--- a/test/types/cptr/ptr_coerce_to_void_ptr.good
+++ b/test/types/cptr/ptr_coerce_to_void_ptr.good
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
This is to support using the chpl_here_* routines instead of externing to the
chpl_mem_* functions in the string module. Currently the string module defines
the chpl_mem_* routines as taking/return a c_ptr instead of a c_void_ptr,
because we didn't coerce c_ptr's to c_void_ptr's.

This should also allow us to get rid of a lot of code in CPtr module, but
that's cleanup for another day