### PR TITLE
Replace chpl_mem_* with chpl_here_* functions in the string module

### DIFF
--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -289,34 +289,34 @@ module LocaleModel {
   // The allocator pragma is used by scalar replacement.
   pragma "allocator"
   pragma "locale model alloc"
-  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t) {
+  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "insert line file info"
       extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t) {
+  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "insert line file info"
       extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t) {
+  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "insert line file info"
       extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
-  proc chpl_here_good_alloc_size(min_size:int) {
+  proc chpl_here_good_alloc_size(min_size:int): int {
     pragma "insert line file info"
       extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
     return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(int);
   }
 
   pragma "locale model free"
-  proc chpl_here_free(ptr:c_void_ptr) {
+  proc chpl_here_free(ptr:c_void_ptr): void {
     pragma "insert line file info"
       extern proc chpl_mem_free(ptr:c_void_ptr) : void;
     chpl_mem_free(ptr);

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -365,45 +365,44 @@ module LocaleModel {
   //
   // support for memory management
   //
-  
+
   private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
 
   // The allocator pragma is used by scalar replacement.
   pragma "allocator"
   pragma "locale model alloc"
-  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t) {
+  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "insert line file info"
       extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t) {
+  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "insert line file info"
       extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
-  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t) {
+  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "insert line file info"
       extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
   }
 
-  proc chpl_here_good_alloc_size(min_size:int) {
+  proc chpl_here_good_alloc_size(min_size:int): int {
     pragma "insert line file info"
       extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
     return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(int);
   }
 
   pragma "locale model free"
-  proc chpl_here_free(ptr:c_void_ptr) {
+  proc chpl_here_free(ptr:c_void_ptr): void {
     pragma "insert line file info"
       extern proc chpl_mem_free(ptr:c_void_ptr) : void;
     chpl_mem_free(ptr);
   }
-
 
   //////////////////////////////////////////
   //


### PR DESCRIPTION
The string module externed out to the chpl_mem_* functions to support alloc,
dealloc, etc. This was because the chpl_here_* variants weren't trivially
usable because of type mismatches. Some previous updates have improved the
signature of the chpl_here_* functions and to allow implicit coercions between
c_ptr's and c_void_ptr's. This simply converts all chpl_mem_* calls in the
string module to use the chpl_here_* variants.

This allows some really nice cleanup as it removes the extern declarations and
removes a ton of safeCasts that are now handled in the chpl_here_* functions.

Using chpl_here_* in the string module did require me to explicitly declare the
return types of the chpl_here_* functions to avoid some recursive resolution. I
think I only really needed it for alloc and realloc, but I decided to add it to
all of them to be consistent.