### PR TITLE
Fix seg fault due to failing fopen()

### DIFF
--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -53,7 +53,6 @@ const char* objectFileForCFile(const char* cfile);
 const char* genIntermediateFilename(const char* filename);
 
 void openCFile(fileinfo* fi, const char* name, const char* ext = NULL);
-void appendCFile(fileinfo* fi, const char* name, const char* ext = NULL);
 void closeCFile(fileinfo* fi, bool beautifyIt=true);
 
 fileinfo* openTmpFile(const char* tmpfilename, const char* mode = "w");

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -272,17 +272,7 @@ void openCFile(fileinfo* fi, const char* name, const char* ext) {
     fi->filename = astr(name);
 
   fi->pathname = genIntermediateFilename(fi->filename);
-  fi->fptr = fopen(fi->pathname, "w");
-}
-
-void appendCFile(fileinfo* fi, const char* name, const char* ext) {
-  if (ext)
-    fi->filename = astr(name, ".", ext);
-  else
-    fi->filename = astr(name);
-
-  fi->pathname = genIntermediateFilename(fi->filename);
-  fi->fptr     = fopen(fi->pathname, "a+");
+  openfile(fi, "w");
 }
 
 void closeCFile(fileinfo* fi, bool beautifyIt) {

--- a/test/trivial/bradc/.gitignore
+++ b/test/trivial/bradc/.gitignore
@@ -1,0 +1,1 @@
+nonWriteableDir

--- a/test/trivial/bradc/nonWriteableDir/README
+++ b/test/trivial/bradc/nonWriteableDir/README
@@ -1,0 +1,2 @@
+This directory is designed to be non-writeable in order to lock in
+a test that used result in a segfault.

--- a/test/trivial/bradc/nonWriteableDir/README
+++ b/test/trivial/bradc/nonWriteableDir/README
@@ -1,2 +1,0 @@
-This directory is designed to be non-writeable in order to lock in
-a test that used result in a segfault.

--- a/test/trivial/bradc/savecInNonWriteableDir.chpl
+++ b/test/trivial/bradc/savecInNonWriteableDir.chpl
@@ -1,0 +1,1 @@
+writeln("Hello!");

--- a/test/trivial/bradc/savecInNonWriteableDir.compopts
+++ b/test/trivial/bradc/savecInNonWriteableDir.compopts
@@ -1,0 +1,1 @@
+--savec nonWriteableDir

--- a/test/trivial/bradc/savecInNonWriteableDir.good
+++ b/test/trivial/bradc/savecInNonWriteableDir.good
@@ -1,0 +1,1 @@
+error: opening nonWriteableDir/chpl__header.h: Permission denied

--- a/test/trivial/bradc/savecInNonWriteableDir.precomp
+++ b/test/trivial/bradc/savecInNonWriteableDir.precomp
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir nonWriteableDir
+chmod ugo-w nonWriteableDir


### PR DESCRIPTION
It turns out that we never check to see if our fopen()s to write
out generated C code succeed or not (what?!) so if they do
fail, we get segfaults in codegen.  This doesn't happen much
in practice because typically the generation of the temp
directory fails first, and it does generate a useful error message.
But we seemingly had a user run into a seg fault of this form
this week, seemingly for this reason (final confirmation still
pending).  However, it's easy to create such a case yourself
by trying to --savec into a directory that is non-writeable.

This commit fixes this by replacing the fopen() call to a call
to openfile() (a utility that we have which already checks for
the NULL case and generates a user error message).  It
also includes a new test that creates a non-writeable directory,
tries to --savec into it, and generates an error message.

It also removes another call appendToCFile() which had another
unguarded fopen().  However, in wondering why we would need
such a routine, it turns out that we don't currently, so I just removed
it instead.

Editorializing slightly, this was a case that made me think "Oh, I
bet this is part of our Coverity backlog, and maybe an indication
that we should work through that backlog.  Yet checking Coverity,
I don't see any sign that it picked up on this case and that frustrates
me given the number of false negatives (or at least, inconsequential
negatives) that we seem to get from it -- since it seems like an
unchecked fopen() would be an obvious case to check against.
