### PR TITLE
Halving/Doubling style array vector operations

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2004,10 +2004,6 @@ module ChapelArray {
 
        These are currently not parallel safe, and cannot safely be called by
        multiple tasks simultaneously on the same array.
-
-       The current implementation reallocates the array every time the domain
-       is modified.  This could be improved with a size doubling/halving
-       strategy.
      */
 
     /* Return true if the array has no elements */
@@ -2030,8 +2026,12 @@ module ChapelArray {
     proc tail(): this._value.eltType {
       return this[this.domain.high];
     }
+
+    /* Return a range that is grown or shrunk from r to accomodate 'd2' */
     pragma "no doc"
-    proc resizeAllocRange(r: range, d2: domain, factor=arrayAsVecGrowthFactor, direction=1, grow=1) {
+    inline proc resizeAllocRange(r: range, d2: domain, factor=arrayAsVecGrowthFactor, param direction=1, param grow=1) {
+      // This should only be called for 1-dimensional arrays
+      compilerAssert(d2.rank == 1);
       const lo = r.low,
             hi = r.high,
             size = hi - lo + 1;
@@ -2052,8 +2052,12 @@ module ChapelArray {
         }
       }
     }
+
     /* Add element ``val`` to the back of the array, extending the array's
        domain by one. If the domain was ``{1..5}`` it will become ``{1..6}``.
+
+       The array must be a rectangular 1-D array; its domain must be
+       non-stridable and not shared with other arrays.
      */
     proc push_back(val: this.eltType) where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("push_back");
@@ -2081,6 +2085,9 @@ module ChapelArray {
 
     /* Remove the last element from the array, reducing the size of the
        domain by one. If the domain was ``{1..5}`` it will become ``{1..4}``
+
+       The array must be a rectangular 1-D array; its domain must be
+       non-stridable and not shared with other arrays.
      */
     proc pop_back() where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("pop_back");
@@ -2102,6 +2109,9 @@ module ChapelArray {
 
     /* Add element ``val`` to the front of the array, extending the array's
        domain by one. If the domain was ``{1..5}`` it will become ``{0..5}``.
+
+       The array must be a rectangular 1-D array; its domain must be
+       non-stridable and not shared with other arrays.
      */
     proc push_front(val: this.eltType) where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("push_front");
@@ -2124,6 +2134,9 @@ module ChapelArray {
 
     /* Remove the first element of the array reducing the size of the
        domain by one.  If the domain was ``{1..5}`` it will become ``{2..5}``.
+
+       The array must be a rectangular 1-D array; its domain must be
+       non-stridable and not shared with other arrays.
      */
     proc pop_front() where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("pop_front");
@@ -2146,6 +2159,9 @@ module ChapelArray {
     /* Insert element ``val`` into the array at index ``pos``. Shift the array
        elements above ``pos`` up one index. If the domain was ``{1..5}`` it will
        become ``{1..6}``.
+
+       The array must be a rectangular 1-D array; its domain must be
+       non-stridable and not shared with other arrays.
      */
     proc insert(pos: this.idxType, val: this.eltType) where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("insert");
@@ -2170,6 +2186,9 @@ module ChapelArray {
     /* Remove the element at index ``pos`` from the array and shift the array
        elements above ``pos`` down one index. If the domain was ``{1..5}``
        it will become ``{1..4}``.
+
+       The array must be a rectangular 1-D array; its domain must be
+       non-stridable and not shared with other arrays.
      */
     proc remove(pos: this.idxType) where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("remove");
@@ -2194,6 +2213,9 @@ module ChapelArray {
 
     /* Remove ``count`` elements from the array starting at index ``pos`` and
        shift elements above ``pos+count`` down by ``count`` indices.
+
+       The array must be a rectangular 1-D array; its domain must be
+       non-stridable and not shared with other arrays.
      */
     proc remove(pos: this.idxType, count: this.idxType) where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("remove count");
@@ -2223,6 +2245,9 @@ module ChapelArray {
        ``{1..5}`` and this is called with ``2..3`` as an argument, the new
        domain would be ``{1..3}`` and the array would contain the elements
        formerly at positions 1, 4, and 5.
+
+       The array must be a rectangular 1-D array; its domain must be
+       non-stridable and not shared with other arrays.
      */
     proc remove(pos: range(this.idxType, stridable=false)) where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("remove range");
@@ -2241,6 +2266,9 @@ module ChapelArray {
 
     /* Remove all elements from the array leaving the domain empty. If the
        domain was ``{5..10}`` it will become ``{5..4}``.
+
+       The array must be a rectangular 1-D array; its domain must be
+       non-stridable and not shared with other arrays.
      */
     proc clear() where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("clear");

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2031,9 +2031,9 @@ module ChapelArray {
       return this[this.domain.high];
     }
     pragma "no doc"
-    proc resizeAllocDomain(d: domain, d2: domain, factor=arrayAsVecGrowthFactor, direction=1, grow=1) {
-      const lo = d.low,
-            hi = d.high,
+    proc resizeAllocRange(r: range, d2: domain, factor=arrayAsVecGrowthFactor, direction=1, grow=1) {
+      const lo = r.low,
+            hi = r.high,
             size = hi - lo + 1;
       var newSize: int;
       if grow > 0 {
@@ -2061,17 +2061,17 @@ module ChapelArray {
             hi = this.domain.high+1;
       const newDom = {lo..hi};
       on this._value {
-        if !this._value.dataAllocDom.member(hi) {
+        if !this._value.dataAllocRange.member(hi) {
           /* The new index is not in the allocated space.  We'll need to
              realloc it. */
-          if this._value.dataAllocDom.numIndices < this.domain.numIndices {
-            /* if dataAllocDom has fewer indices than this.domain it must not
+          if this._value.dataAllocRange.length < this.domain.numIndices {
+            /* if dataAllocRange has fewer indices than this.domain it must not
                be set correctly.  Set it to match this.domain to start.
              */ 
-            this._value.dataAllocDom = this.domain;
+            this._value.dataAllocRange = this.domain.low..this.domain.high;
           }
-          this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom);
-          this._value.dsiReallocate(this._value.dataAllocDom);
+          this._value.dataAllocRange = resizeAllocRange(this._value.dataAllocRange, newDom);
+          this._value.dsiReallocate({this._value.dataAllocRange});
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();
@@ -2088,12 +2088,12 @@ module ChapelArray {
             hi = this.domain.high-1;
       const newDom = {lo..hi};
       on this._value {
-        if this._value.dataAllocDom.numIndices < this.domain.numIndices {
-          this._value.dataAllocDom = this.domain;
+        if this._value.dataAllocRange.length < this.domain.numIndices {
+          this._value.dataAllocRange = this.domain.low..this.domain.high;
         }
-        if newDom.numIndices < (this._value.dataAllocDom.numIndices / arrayAsVecGrowthFactor):int {
-          this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom, grow=-1);
-          this._value.dsiReallocate(this._value.dataAllocDom);
+        if newDom.numIndices < (this._value.dataAllocRange.length / arrayAsVecGrowthFactor):int {
+          this._value.dataAllocRange = resizeAllocRange(this._value.dataAllocRange, newDom, grow=-1);
+          this._value.dsiReallocate({this._value.dataAllocRange});
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();
@@ -2109,12 +2109,12 @@ module ChapelArray {
             hi = this.domain.high;
       const newDom = {lo..hi};
       on this._value {
-        if !this._value.dataAllocDom.member(lo) {
-          if this._value.dataAllocDom.numIndices < this.domain.numIndices {
-            this._value.dataAllocDom = this.domain;
+        if !this._value.dataAllocRange.member(lo) {
+          if this._value.dataAllocRange.length < this.domain.numIndices {
+            this._value.dataAllocRange = this.domain.low..this.domain.high;
           }
-          this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom, direction=-1);
-          this._value.dsiReallocate(this._value.dataAllocDom);
+          this._value.dataAllocRange = resizeAllocRange(this._value.dataAllocRange, newDom, direction=-1);
+          this._value.dsiReallocate({this._value.dataAllocRange});
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();
@@ -2131,12 +2131,12 @@ module ChapelArray {
             hi = this.domain.high;
       const newDom = {lo..hi};
       on this._value {
-        if this._value.dataAllocDom.numIndices < this.domain.numIndices {
-          this._value.dataAllocDom = this.domain;
+        if this._value.dataAllocRange.length < this.domain.numIndices {
+          this._value.dataAllocRange = this.domain.low..this.domain.high;
         }
-        if newDom.numIndices < (this._value.dataAllocDom.numIndices / arrayAsVecGrowthFactor):int {
-          this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom, direction=-1, grow=-1);
-          this._value.dsiReallocate(this._value.dataAllocDom);
+        if newDom.numIndices < (this._value.dataAllocRange.length / arrayAsVecGrowthFactor):int {
+          this._value.dataAllocRange = resizeAllocRange(this._value.dataAllocRange, newDom, direction=-1, grow=-1);
+          this._value.dsiReallocate({this._value.dataAllocRange});
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();
@@ -2153,12 +2153,12 @@ module ChapelArray {
             hi = this.domain.high+1;
       const newDom = {lo..hi};
       on this._value {
-        if !this._value.dataAllocDom.member(hi) {
-          if this._value.dataAllocDom.numIndices < this.domain.numIndices {
-            this._value.dataAllocDom = this.domain;
+        if !this._value.dataAllocRange.member(hi) {
+          if this._value.dataAllocRange.length < this.domain.numIndices {
+            this._value.dataAllocRange = this.domain.low..this.domain.high;
           }
-          this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom);
-          this._value.dsiReallocate(this._value.dataAllocDom);
+          this._value.dataAllocRange = resizeAllocRange(this._value.dataAllocRange, newDom);
+          this._value.dsiReallocate({this._value.dataAllocRange});
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();
@@ -2180,12 +2180,12 @@ module ChapelArray {
         this[i] = this[i+1];
       }
       on this._value {
-        if this._value.dataAllocDom.numIndices < this.domain.numIndices {
-          this._value.dataAllocDom = this.domain;
+        if this._value.dataAllocRange.length < this.domain.numIndices {
+          this._value.dataAllocRange = this.domain.low..this.domain.high;
         }
-        if newDom.numIndices < (this._value.dataAllocDom.numIndices / arrayAsVecGrowthFactor):int {
-          this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom, grow=-1);
-          this._value.dsiReallocate(this._value.dataAllocDom);
+        if newDom.numIndices < (this._value.dataAllocRange.length / arrayAsVecGrowthFactor):int {
+          this._value.dataAllocRange = resizeAllocRange(this._value.dataAllocRange, newDom, grow=-1);
+          this._value.dsiReallocate({this._value.dataAllocRange});
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();
@@ -2206,12 +2206,12 @@ module ChapelArray {
         this[i] = this[i+count];
       }
       on this._value {
-        if this._value.dataAllocDom.numIndices < this.domain.numIndices {
-          this._value.dataAllocDom = this.domain;
+        if this._value.dataAllocRange.length < this.domain.numIndices {
+          this._value.dataAllocRange = this.domain;
         }
-        if newDom.numIndices < (this._value.dataAllocDom.numIndices / arrayAsVecGrowthFactor):int {
-          this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom, grow=-1);
-          this._value.dsiReallocate(this._value.dataAllocDom);
+        if newDom.numIndices < (this._value.dataAllocRange.length / arrayAsVecGrowthFactor):int {
+          this._value.dataAllocRange = resizeAllocRange(this._value.dataAllocRange, newDom, grow=-1);
+          this._value.dsiReallocate({this._value.dataAllocRange});
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -151,8 +151,6 @@ module ChapelArray {
 
   pragma "no doc" // no doc unless we decide to expose this
   config param arrayAsVecGrowthFactor = 1.5;
-  pragma "no doc"
-  config param debugArrayAsVec = false;
 
   pragma "privatized class"
   proc _isPrivatized(value) param
@@ -2062,8 +2060,6 @@ module ChapelArray {
       const lo = this.domain.low,
             hi = this.domain.high+1;
       const newDom = {lo..hi};
-      if debugArrayAsVec then
-        writeln("Adding index ", hi, " to ", this.domain, " dataAllocDom = ", this._value.dataAllocDom);
       on this._value {
         if !this._value.dataAllocDom.member(hi) {
           /* The new index is not in the allocated space.  We'll need to
@@ -2072,19 +2068,10 @@ module ChapelArray {
             /* if dataAllocDom has fewer indices than this.domain it must not
                be set correctly.  Set it to match this.domain to start.
              */ 
-            if debugArrayAsVec then
-              writeln("setting dataAllocDom to this.domain: ", this.domain);
             this._value.dataAllocDom = this.domain;
           }
           this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom);
-          extern proc printf(fmt: c_string, args...);
-          if debugArrayAsVec {
-            writeln("dataAllocDom resized to: ", this._value.dataAllocDom);
-            printf("%p %p\n", this._value.data, this._value.shiftedData);
-          }
           this._value.dsiReallocate(this._value.dataAllocDom);
-          if debugArrayAsVec then
-            printf("%p %p\n", this._value.data, this._value.shiftedData);
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();
@@ -2100,22 +2087,13 @@ module ChapelArray {
       const lo = this.domain.low,
             hi = this.domain.high-1;
       const newDom = {lo..hi};
-      if debugArrayAsVec then
-        writeln("Removing index ", hi+1, " from ", this.domain, " dataAllocDom = ", this._value.dataAllocDom);
       on this._value {
         if this._value.dataAllocDom.numIndices < this.domain.numIndices {
           this._value.dataAllocDom = this.domain;
         }
         if newDom.numIndices < (this._value.dataAllocDom.numIndices / arrayAsVecGrowthFactor):int {
           this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom, grow=-1);
-          extern proc printf(fmt: c_string, args...);
-          if debugArrayAsVec {
-            writeln("dataAllocDom resized to ", this._value.dataAllocDom);
-            printf("%p %p\n", this._value.data, this._value.shiftedData);
-          }
           this._value.dsiReallocate(this._value.dataAllocDom);
-          if debugArrayAsVec then
-            printf("%p %p\n", this._value.data, this._value.shiftedData);
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();
@@ -2130,25 +2108,13 @@ module ChapelArray {
       const lo = this.domain.low-1,
             hi = this.domain.high;
       const newDom = {lo..hi};
-      if debugArrayAsVec then
-        writeln("Adding index ", lo, " to ", this.domain, " dataAllocDom = ", this._value.dataAllocDom);
       on this._value {
         if !this._value.dataAllocDom.member(lo) {
           if this._value.dataAllocDom.numIndices < this.domain.numIndices {
             this._value.dataAllocDom = this.domain;
           }
           this._value.dataAllocDom = resizeAllocDomain(this._value.dataAllocDom, newDom, direction=-1);
-          extern proc printf(fmt: c_string, args...);
-          if debugArrayAsVec {
-            writeln("dataAllocDom resized to: ", this._value.dataAllocDom);
-            printf("%p %p\n", this._value.data, this._value.shiftedData);
-          }
-
           this._value.dsiReallocate(this._value.dataAllocDom);
-
-          if debugArrayAsVec then
-            printf("%p %p\n", this._value.data, this._value.shiftedData);
-
         }
         this.domain.setIndices(newDom.getIndices());
         this._value.dsiPostReallocate();

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2207,7 +2207,7 @@ module ChapelArray {
       }
       on this._value {
         if this._value.dataAllocRange.length < this.domain.numIndices {
-          this._value.dataAllocRange = this.domain;
+          this._value.dataAllocRange = this.domain.low..this.domain.high;
         }
         if newDom.numIndices < (this._value.dataAllocRange.length / arrayAsVecGrowthFactor):int {
           this._value.dataAllocRange = resizeAllocRange(this._value.dataAllocRange, newDom, grow=-1);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -645,12 +645,12 @@ module DefaultRectangular {
     var shiftedData : _ddata(eltType);
     var noinit_data: bool = false;
 
-    // 'dataAllocDom' is used by the array-vector operations (e.g. push_back,
+    // 'dataAllocRange' is used by the array-vector operations (e.g. push_back,
     // pop_back, insert, remove) to allow growing or shrinking the data
     // buffer in a doubling/halving style.  If it is used, it will be the
     // actual size of the data buffer, while 'dom' represents the size of the
     // user-level array.
-    var dataAllocDom: domain(1);
+    var dataAllocRange: range(int);
     //var numelm: int = -1; // for correctness checking
   
     // end class definition here, then defined secondary methods below

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -644,6 +644,13 @@ module DefaultRectangular {
     pragma "local field"
     var shiftedData : _ddata(eltType);
     var noinit_data: bool = false;
+
+    // 'dataAllocDom' is used by the array-vector operations (e.g. push_back,
+    // pop_back, insert, remove) to allow growing or shrinking the data
+    // buffer in a doubling/halving style.  If it is used, it will be the
+    // actual size of the data buffer, while 'dom' represents the size of the
+    // user-level array.
+    var dataAllocDom: domain(1);
     //var numelm: int = -1; // for correctness checking
   
     // end class definition here, then defined secondary methods below
@@ -1027,7 +1034,7 @@ module DefaultRectangular {
       }
       return alias;
     }
-  
+
     proc dsiReallocate(d: domain) {
       if (d._value.type == dom.type) {
         on this {

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -648,8 +648,8 @@ module DefaultRectangular {
     // 'dataAllocRange' is used by the array-vector operations (e.g. push_back,
     // pop_back, insert, remove) to allow growing or shrinking the data
     // buffer in a doubling/halving style.  If it is used, it will be the
-    // actual size of the data buffer, while 'dom' represents the size of the
-    // user-level array.
+    // actual size of the 'data' buffer, while 'dom' represents the size of
+    // the user-level array.
     var dataAllocRange: range(int);
     //var numelm: int = -1; // for correctness checking
   

--- a/test/arrays/diten/timeVectorArray.chpl
+++ b/test/arrays/diten/timeVectorArray.chpl
@@ -82,6 +82,24 @@ class InsertSorted: Runner {
   }
 }
 
+class Remove: Runner {
+  const n: int;
+  const front: bool;
+  proc run(A: [] int) {
+    if front {
+      for i in 1..n {
+        A.remove(1);
+      }
+    } else {
+      var numElements = A.numElements;
+      for i in 1..n {
+        A.remove(numElements);
+        numElements -= 1;
+      }
+    }
+  }
+}
+
 // try a few similar operation on a list to compare
 class ListAppend: Runner {
   const n: int;
@@ -164,6 +182,10 @@ proc main {
   r = new PopBack(); r.run(A); delete r; // clean up
   r = new InsertSorted(n, false); output("InsertSL", timeRun(r,A)); delete r;
   assert(isSorted(A,n));
+
+  r = new Remove(n, true); output("RemoveFront", timeRun(r, A)); delete r;
+  r = new PushBack(n); r.run(A); delete r;
+  r = new Remove(n, false); output("RemoveBack", timeRun(r, A)); delete r;
 
   var l = new list(int);
   r = new ListAppend(n); output("ListAppend", timeRunList(r,l)); delete r;

--- a/test/arrays/diten/timeVectorArray.good
+++ b/test/arrays/diten/timeVectorArray.good
@@ -6,6 +6,8 @@ PopFront
 InsertR
 InsertSB
 InsertSL
+RemoveFront
+RemoveBack
 ListAppend
 ListReduce
 ListDest

--- a/test/arrays/diten/timeVectorArray.graph
+++ b/test/arrays/diten/timeVectorArray.graph
@@ -1,4 +1,4 @@
-perfkeys: PushBack, SumElements, PopBack, PushFront, PopFront, InsertR, InsertSB, InsertSL, ListAppend, ListReduce, ListDest
+perfkeys: PushBack, SumElements, PopBack, PushFront, PopFront, InsertR, InsertSB, InsertSL, RemoveFront, RemoveBack, ListAppend, ListReduce, ListDest
 files: timeVectorArray.dat
 ylabel: Time (seconds)
 graphname: timeVectorArray

--- a/test/arrays/diten/timeVectorArray.perfkeys
+++ b/test/arrays/diten/timeVectorArray.perfkeys
@@ -6,6 +6,8 @@ PopFront
 InsertR
 InsertSB
 InsertSL
+RemoveFront
+RemoveBack
 ListAppend
 ListReduce
 ListDest

--- a/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
+++ b/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
@@ -13,27 +13,27 @@ total:
 Block Dist
 ==========
 Copy of domain map:
-	912 bytes leaked
+	1184 bytes leaked
 Return domain map:
-	1824 bytes leaked
+	2368 bytes leaked
 Create domain:
-	1216 bytes leaked
+	1488 bytes leaked
 Create domain and array:
-	2392 bytes leaked
+	2936 bytes leaked
 total:
-	8168 bytes leaked
+	10344 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
-	640 bytes leaked
+	912 bytes leaked
 Return domain map:
-	1424 bytes leaked
+	1968 bytes leaked
 Create domain:
-	1216 bytes leaked
+	1488 bytes leaked
 Create domain and array:
-	2400 bytes leaked
+	2944 bytes leaked
 total:
-	7104 bytes leaked
+	9280 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -41,20 +41,20 @@ Copy of domain map:
 Return domain map:
 	96 bytes leaked
 Create domain:
-	1520 bytes leaked
+	1792 bytes leaked
 Create domain and array:
-	3632 bytes leaked
+	4584 bytes leaked
 total:
-	6016 bytes leaked
+	7512 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
-	272 bytes leaked
+	408 bytes leaked
 Return domain map:
-	544 bytes leaked
+	816 bytes leaked
 Create domain:
-	1216 bytes leaked
+	1488 bytes leaked
 Create domain and array:
-	2344 bytes leaked
+	2888 bytes leaked
 total:
-	4920 bytes leaked
+	6416 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
+++ b/test/memory/sungeun/refCount/domainMaps.comm-gasnet.good
@@ -13,27 +13,27 @@ total:
 Block Dist
 ==========
 Copy of domain map:
-	1184 bytes leaked
+	992 bytes leaked
 Return domain map:
-	2368 bytes leaked
+	1984 bytes leaked
 Create domain:
-	1488 bytes leaked
+	1296 bytes leaked
 Create domain and array:
-	2936 bytes leaked
+	2552 bytes leaked
 total:
-	10344 bytes leaked
+	8808 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
-	912 bytes leaked
+	720 bytes leaked
 Return domain map:
-	1968 bytes leaked
+	1584 bytes leaked
 Create domain:
-	1488 bytes leaked
+	1296 bytes leaked
 Create domain and array:
-	2944 bytes leaked
+	2560 bytes leaked
 total:
-	9280 bytes leaked
+	7744 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -41,20 +41,20 @@ Copy of domain map:
 Return domain map:
 	96 bytes leaked
 Create domain:
-	1792 bytes leaked
+	1600 bytes leaked
 Create domain and array:
-	4584 bytes leaked
+	3912 bytes leaked
 total:
-	7512 bytes leaked
+	6456 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
-	408 bytes leaked
+	312 bytes leaked
 Return domain map:
-	816 bytes leaked
+	624 bytes leaked
 Create domain:
-	1488 bytes leaked
+	1296 bytes leaked
 Create domain and array:
-	2888 bytes leaked
+	2504 bytes leaked
 total:
-	6416 bytes leaked
+	5360 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.cygwin32.good
+++ b/test/memory/sungeun/refCount/domainMaps.cygwin32.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	192 bytes leaked
 Create domain and array:
-	1016 bytes leaked
+	968 bytes leaked
 total:
-	1208 bytes leaked
+	1160 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	192 bytes leaked
 Create domain and array:
-	1020 bytes leaked
+	972 bytes leaked
 total:
-	1404 bytes leaked
+	1356 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,18 +43,18 @@ Return domain map:
 Create domain:
 	384 bytes leaked
 Create domain and array:
-	2096 bytes leaked
+	1904 bytes leaked
 total:
-	2720 bytes leaked
+	2528 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
 	0 bytes leaked
 Return domain map:
-	192 bytes leaked
+	144 bytes leaked
 Create domain:
 	192 bytes leaked
 Create domain and array:
-	1012 bytes leaked
+	964 bytes leaked
 total:
-	1780 bytes leaked
+	1588 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.cygwin32.good
+++ b/test/memory/sungeun/refCount/domainMaps.cygwin32.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	192 bytes leaked
 Create domain and array:
-	928 bytes leaked
+	1016 bytes leaked
 total:
-	1120 bytes leaked
+	1208 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	192 bytes leaked
 Create domain and array:
-	932 bytes leaked
+	1020 bytes leaked
 total:
-	1316 bytes leaked
+	1404 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,18 +43,18 @@ Return domain map:
 Create domain:
 	384 bytes leaked
 Create domain and array:
-	1744 bytes leaked
+	2096 bytes leaked
 total:
-	2368 bytes leaked
+	2720 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
 	0 bytes leaked
 Return domain map:
-	104 bytes leaked
+	192 bytes leaked
 Create domain:
 	192 bytes leaked
 Create domain and array:
-	924 bytes leaked
+	1012 bytes leaked
 total:
-	1428 bytes leaked
+	1780 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.good
+++ b/test/memory/sungeun/refCount/domainMaps.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	224 bytes leaked
 Create domain and array:
-	1000 bytes leaked
+	1104 bytes leaked
 total:
-	1224 bytes leaked
+	1328 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	224 bytes leaked
 Create domain and array:
-	1008 bytes leaked
+	1112 bytes leaked
 total:
-	1456 bytes leaked
+	1560 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,18 +43,18 @@ Return domain map:
 Create domain:
 	448 bytes leaked
 Create domain and array:
-	1936 bytes leaked
+	2352 bytes leaked
 total:
-	2624 bytes leaked
+	3040 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
 	0 bytes leaked
 Return domain map:
-	128 bytes leaked
+	232 bytes leaked
 Create domain:
 	224 bytes leaked
 Create domain and array:
-	992 bytes leaked
+	1096 bytes leaked
 total:
-	1600 bytes leaked
+	2016 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.good
+++ b/test/memory/sungeun/refCount/domainMaps.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	224 bytes leaked
 Create domain and array:
-	1104 bytes leaked
+	1040 bytes leaked
 total:
-	1328 bytes leaked
+	1264 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	224 bytes leaked
 Create domain and array:
-	1112 bytes leaked
+	1048 bytes leaked
 total:
-	1560 bytes leaked
+	1496 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,18 +43,18 @@ Return domain map:
 Create domain:
 	448 bytes leaked
 Create domain and array:
-	2352 bytes leaked
+	2096 bytes leaked
 total:
-	3040 bytes leaked
+	2784 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
 	0 bytes leaked
 Return domain map:
-	232 bytes leaked
+	168 bytes leaked
 Create domain:
 	224 bytes leaked
 Create domain and array:
-	1096 bytes leaked
+	1032 bytes leaked
 total:
-	2016 bytes leaked
+	1760 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.linux32.good
+++ b/test/memory/sungeun/refCount/domainMaps.linux32.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	160 bytes leaked
 Create domain and array:
-	956 bytes leaked
+	916 bytes leaked
 total:
-	1116 bytes leaked
+	1076 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	160 bytes leaked
 Create domain and array:
-	960 bytes leaked
+	920 bytes leaked
 total:
-	1280 bytes leaked
+	1240 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,18 +43,18 @@ Return domain map:
 Create domain:
 	320 bytes leaked
 Create domain and array:
-	1864 bytes leaked
+	1704 bytes leaked
 total:
-	2384 bytes leaked
+	2224 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
 	0 bytes leaked
 Return domain map:
-	164 bytes leaked
+	124 bytes leaked
 Create domain:
 	160 bytes leaked
 Create domain and array:
-	952 bytes leaked
+	912 bytes leaked
 total:
-	1604 bytes leaked
+	1444 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.linux32.good
+++ b/test/memory/sungeun/refCount/domainMaps.linux32.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	160 bytes leaked
 Create domain and array:
-	880 bytes leaked
+	956 bytes leaked
 total:
-	1040 bytes leaked
+	1116 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	160 bytes leaked
 Create domain and array:
-	884 bytes leaked
+	960 bytes leaked
 total:
-	1204 bytes leaked
+	1280 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,18 +43,18 @@ Return domain map:
 Create domain:
 	320 bytes leaked
 Create domain and array:
-	1560 bytes leaked
+	1864 bytes leaked
 total:
-	2080 bytes leaked
+	2384 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
 	0 bytes leaked
 Return domain map:
-	88 bytes leaked
+	164 bytes leaked
 Create domain:
 	160 bytes leaked
 Create domain and array:
-	876 bytes leaked
+	952 bytes leaked
 total:
-	1300 bytes leaked
+	1604 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.lm-numa.good
+++ b/test/memory/sungeun/refCount/domainMaps.lm-numa.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	288 bytes leaked
 Create domain and array:
-	1136 bytes leaked
+	1272 bytes leaked
 total:
-	1424 bytes leaked
+	1560 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	288 bytes leaked
 Create domain and array:
-	1144 bytes leaked
+	1280 bytes leaked
 total:
-	1720 bytes leaked
+	1856 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,18 +43,18 @@ Return domain map:
 Create domain:
 	592 bytes leaked
 Create domain and array:
-	2392 bytes leaked
+	2936 bytes leaked
 total:
-	3224 bytes leaked
+	3768 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
 	0 bytes leaked
 Return domain map:
-	184 bytes leaked
+	320 bytes leaked
 Create domain:
 	288 bytes leaked
 Create domain and array:
-	1120 bytes leaked
+	1256 bytes leaked
 total:
-	1960 bytes leaked
+	2504 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.lm-numa.good
+++ b/test/memory/sungeun/refCount/domainMaps.lm-numa.good
@@ -19,9 +19,9 @@ Return domain map:
 Create domain:
 	288 bytes leaked
 Create domain and array:
-	1272 bytes leaked
+	1176 bytes leaked
 total:
-	1560 bytes leaked
+	1464 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
@@ -31,9 +31,9 @@ Return domain map:
 Create domain:
 	288 bytes leaked
 Create domain and array:
-	1280 bytes leaked
+	1184 bytes leaked
 total:
-	1856 bytes leaked
+	1760 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -43,18 +43,18 @@ Return domain map:
 Create domain:
 	592 bytes leaked
 Create domain and array:
-	2936 bytes leaked
+	2552 bytes leaked
 total:
-	3768 bytes leaked
+	3384 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
 	0 bytes leaked
 Return domain map:
-	320 bytes leaked
+	224 bytes leaked
 Create domain:
 	288 bytes leaked
 Create domain and array:
-	1256 bytes leaked
+	1160 bytes leaked
 total:
-	2504 bytes leaked
+	2120 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.no-local.good
+++ b/test/memory/sungeun/refCount/domainMaps.no-local.good
@@ -13,27 +13,27 @@ total:
 Block Dist
 ==========
 Copy of domain map:
-	912 bytes leaked
+	1184 bytes leaked
 Return domain map:
-	1824 bytes leaked
+	2368 bytes leaked
 Create domain:
-	1216 bytes leaked
+	1488 bytes leaked
 Create domain and array:
-	2392 bytes leaked
+	2936 bytes leaked
 total:
-	8168 bytes leaked
+	10344 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
-	640 bytes leaked
+	912 bytes leaked
 Return domain map:
-	1424 bytes leaked
+	1968 bytes leaked
 Create domain:
-	1216 bytes leaked
+	1488 bytes leaked
 Create domain and array:
-	2400 bytes leaked
+	2944 bytes leaked
 total:
-	7104 bytes leaked
+	9280 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -41,20 +41,20 @@ Copy of domain map:
 Return domain map:
 	96 bytes leaked
 Create domain:
-	1520 bytes leaked
+	1792 bytes leaked
 Create domain and array:
-	3632 bytes leaked
+	4584 bytes leaked
 total:
-	6016 bytes leaked
+	7512 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
-	272 bytes leaked
+	408 bytes leaked
 Return domain map:
-	544 bytes leaked
+	816 bytes leaked
 Create domain:
-	1216 bytes leaked
+	1488 bytes leaked
 Create domain and array:
-	2344 bytes leaked
+	2888 bytes leaked
 total:
-	4920 bytes leaked
+	6416 bytes leaked

--- a/test/memory/sungeun/refCount/domainMaps.no-local.good
+++ b/test/memory/sungeun/refCount/domainMaps.no-local.good
@@ -13,27 +13,27 @@ total:
 Block Dist
 ==========
 Copy of domain map:
-	1184 bytes leaked
+	992 bytes leaked
 Return domain map:
-	2368 bytes leaked
+	1984 bytes leaked
 Create domain:
-	1488 bytes leaked
+	1296 bytes leaked
 Create domain and array:
-	2936 bytes leaked
+	2552 bytes leaked
 total:
-	10344 bytes leaked
+	8808 bytes leaked
 Cyclic Dist
 ===========
 Copy of domain map:
-	912 bytes leaked
+	720 bytes leaked
 Return domain map:
-	1968 bytes leaked
+	1584 bytes leaked
 Create domain:
-	1488 bytes leaked
+	1296 bytes leaked
 Create domain and array:
-	2944 bytes leaked
+	2560 bytes leaked
 total:
-	9280 bytes leaked
+	7744 bytes leaked
 Block-Cyclic Dist
 =================
 Copy of domain map:
@@ -41,20 +41,20 @@ Copy of domain map:
 Return domain map:
 	96 bytes leaked
 Create domain:
-	1792 bytes leaked
+	1600 bytes leaked
 Create domain and array:
-	4584 bytes leaked
+	3912 bytes leaked
 total:
-	7512 bytes leaked
+	6456 bytes leaked
 Replicated Dist
 ===============
 Copy of domain map:
-	408 bytes leaked
+	312 bytes leaked
 Return domain map:
-	816 bytes leaked
+	624 bytes leaked
 Create domain:
-	1488 bytes leaked
+	1296 bytes leaked
 Create domain and array:
-	2888 bytes leaked
+	2504 bytes leaked
 total:
-	6416 bytes leaked
+	5360 bytes leaked


### PR DESCRIPTION
Implement the array vector operations using a buffer that grows and shrinks
by a factor of its current size instead of one element at a time.  Currently,
the growth factor defaults to 1.5, but it can be changed with a config
param.

Updated timeVectorArray.chpl test to include testing the remove() function.

Update domainMaps.chpl memory tracking test .goods.  The array-as-vec work
added a new domain member to DefaultRectangular arrays.  This test tracks
leaked memory from operations on different domain maps, and in some cases
DefaultRectangular arrays are leaked in it.  Since the leaked arrays have
a new domain field, the amount leaked for each leaked array went up.