### PR TITLE
Skip new test in Cygwin

### DIFF
--- a/test/trivial/bradc/savecInNonWriteableDir.skipif
+++ b/test/trivial/bradc/savecInNonWriteableDir.skipif
@@ -1,0 +1,3 @@
+# this test doesn't work on cygwin, probably due to the precomp file...
+CHPL_TARGET_PLATFORM==cygwin64
+CHPL_TARGET_PLATFORM==cygwin32


### PR DESCRIPTION
It doesn't work/fail as expected, probably due to some non-portability
in the .precomp file...