### PR TITLE
Remove chpldoc-venv used to build the man pages in gen_release

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -181,6 +181,7 @@ SystemOrDie("./util/devel/test/extract_tests --no-futures -o ./examples/spec spe
 print "Building the man pages...\n";
 SystemOrDie("make man");
 SystemOrDie("make man-chpldoc");
+SystemOrDie("make clobber");
 
 print "Building the STATUS file...\n";
 SystemOrDie("make STATUS");

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -160,8 +160,8 @@ if ($no_clone == 0) {
 
 chdir "$archive_dir";
 
-# Docs must be built first so we can get rid of any extra files (chpldoc) with
-# a clobber
+# Docs/man page must be built first so we can get rid of any extra files
+# (chpldoc) with a clobber
 print "Building the docs...\n";
 # Set CHPL_COMM to none to avoid issues with gasnet generated makefiles not
 # existing because we haven't built the third-party libs
@@ -169,19 +169,19 @@ $ENV{'CHPL_HOME'} = "$archive_dir";
 $ENV{'CHPL_COMM'} = "none";
 print "CHPL_HOME is set to: $ENV{'CHPL_HOME'}\n";
 
+print "Building the man module-docs...\n";
 SystemOrDie("make -j docs");
 SystemOrDie("mv doc/sphinx/build/html doc/release");
+
+print "Building the man pages...\n";
+SystemOrDie("make man");
+SystemOrDie("make man-chpldoc");
 SystemOrDie("make clobber");
 
 print "Creating the examples directory...\n";
 SystemOrDie("cp -r test/release/examples .");
 SystemOrDie("cd util && cp start_test ../examples/");
 SystemOrDie("./util/devel/test/extract_tests --no-futures -o ./examples/spec spec/*.tex");
-
-print "Building the man pages...\n";
-SystemOrDie("make man");
-SystemOrDie("make man-chpldoc");
-SystemOrDie("make clobber");
 
 print "Building the STATUS file...\n";
 SystemOrDie("make STATUS");


### PR DESCRIPTION
With #3243 we now use rst2man.py from docutils to build the man pages. We use
to docutils from the chpldoc-venv, which means we build the chpldoc-venv to
create the man page.

However, we weren't removing the chpldoc-venv after building the man page,
which meant that the venv was getting bundled with the tarball, adding ~40 MB
uncompressed (~15-20 compressed)