### PR TITLE
Updated HDFS modules w.r.t. string/c_string and task intent changes

### DIFF
--- a/modules/standard/HDFSiterator.chpl
+++ b/modules/standard/HDFSiterator.chpl
@@ -100,7 +100,7 @@ iter HDFSiter(param tag: iterKind, path: string, type rec, regex: string)
     coforall loc in Locales {
       on loc {
         // Rip though the work in parallel on that locale
-        forall byteRange in workQueue[loc.id] {
+        forall byteRange in workQueue[loc.id] with (ref globalFile) {
           var rr = globalFile.hdfsReader(start=byteRange(1));
           var N  = new RecordReader(rec, rr, regex);
           // Dont have a L/F for this so we yield serially. 


### PR DESCRIPTION
A user pointed out that these no longer compiled on master.  Sadly,
these escaped us due to ongoing lack of HDFS testing support...

The changes involved updates based on string/c_string changes and
differences and task intents to forall loops.  Hopefully, this will get
things working again, though my coverage was only as good as our
tests -- specifically, I checked if things compiled, but was not able
to run them.