### PR TITLE
Update the HDFS tests w.r.t. string/c_string changes and 'as' keyword

### DIFF
--- a/test/io/tzakian/hdfs/regex_hdfs/regex_hdfs.chpl
+++ b/test/io/tzakian/hdfs/regex_hdfs/regex_hdfs.chpl
@@ -194,12 +194,12 @@ writeln("+matches: All words capturing first letter");
     writeln("offset ", r.offset());
     writeln("match ", m);
     var s:string;
-    var as:string;
+    var my_as:string;
     r.extractMatch(m, s);
     writeln("string ", s);
     writeln("cap match", a);
     r.extractMatch(m, a);
-    writeln("cap string ", as);
+    writeln("cap string ", my_as);
 
   }
   writeln("offset ", r.offset());

--- a/test/studies/HDFS/tzakian/HDFSiterator.chpl
+++ b/test/studies/HDFS/tzakian/HDFSiterator.chpl
@@ -45,11 +45,11 @@ iter HDFSmap(dataFile: string, namenode: string = "default", port: int(32) = 0) 
 
 
   // use const instead of var -- better optimizations this way
-  const hdfsFS: c_void_ptr = HDFS.hdfsConnect(namenode, port);
-  const fileInfo = HDFS.chadoopGetFileInfo(hdfsFS, dataFile);
-  const blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile, 0, fileInfo.mSize); // incr 0?
+  const hdfsFS: c_void_ptr = HDFS.hdfsConnect(namenode.localize().c_str(), port);
+  const fileInfo = HDFS.chadoopGetFileInfo(hdfsFS, dataFile.localize().c_str());
+  const blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile.localize().c_str(), 0, fileInfo.mSize); // incr 0?
   const blockCount = HDFS.chadoopGetBlockCount(blockHosts);
-  const dataFileLocal = HDFS.hdfsOpenFile(hdfsFS, dataFile, O_RDONLY, 0, 0, 0);
+  const dataFileLocal = HDFS.hdfsOpenFile(hdfsFS, dataFile.localize().c_str(), O_RDONLY, 0, 0, 0);
   assert(HDFS.IS_NULL(dataFileLocal) == HDFS.IS_NULL_FALSE, "Failed to open dataFileLocal");
   var length = (fileInfo.mBlockSize): int(32); // LOOK
 
@@ -58,7 +58,7 @@ iter HDFSmap(dataFile: string, namenode: string = "default", port: int(32) = 0) 
 
   for i in 0..#blockCount {
 
-    var owner_tmp = HDFS.chadoopGetHost(blockHosts, i: int(32), (i % fileInfo.mReplication): int(32));
+    var owner_tmp = HDFS.chadoopGetHost(blockHosts, i: int(32), (i % fileInfo.mReplication): int(32)):string;
     var IDX = indexOf(".", owner_tmp, 1);
     var owner = owner_tmp[1..IDX-1];
 
@@ -112,11 +112,11 @@ iter HDFSmap(param tag: iterKind, dataFile: string, namenode: string = "default"
       on loc {
 
         //======================== File connection =========================
-        var hdfsFS: c_void_ptr = HDFS.hdfsConnect(namenode, port);
+        var hdfsFS: c_void_ptr = HDFS.hdfsConnect(namenode.localize().c_str(), port);
         assert(HDFS.IS_NULL(hdfsFS) == HDFS.IS_NULL_FALSE, "Failed to connect to HDFS");
 
-        var fileInfo      = HDFS.chadoopGetFileInfo(hdfsFS, dataFile);
-        var dataFileLocal = HDFS.hdfsOpenFile(hdfsFS, dataFile, O_RDONLY, 0, 0, 0);
+        var fileInfo      = HDFS.chadoopGetFileInfo(hdfsFS, dataFile.localize().c_str());
+        var dataFileLocal = HDFS.hdfsOpenFile(hdfsFS, dataFile.localize().c_str(), O_RDONLY, 0, 0, 0);
         assert(HDFS.IS_NULL(dataFileLocal) == HDFS.IS_NULL_FALSE, "Failed to open dataFileLocal on loc ", here.id);
         // =================================== END =========================
 
@@ -143,7 +143,7 @@ iter HDFSmap(param tag: iterKind, dataFile: string, namenode: string = "default"
       // Setup a mapping loc --> {block1, block2, ...}
       var fileInfo = rcLocal(fileInfo_PL);
       var hdfsFS   = rcLocal(hdfsFS_PL);
-      var blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile, 0, fileInfo.mSize); // Investigate
+      var blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile.localize().c_str(), 0, fileInfo.mSize); // Investigate
       var blockCount: int = HDFS.chadoopGetBlockCount(blockHosts);
 
       const Space = {0..blockCount-1};
@@ -153,10 +153,10 @@ iter HDFSmap(param tag: iterKind, dataFile: string, namenode: string = "default"
       forall (j, i) in zip (Biter, 0..) {
         var fileInfo = rcLocal(fileInfo_PL);
         var hdfsFS   = rcLocal(hdfsFS_PL);
-        var blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile, 0, fileInfo.mSize); // Investigate
+        var blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile.localize().c_str(), 0, fileInfo.mSize); // Investigate
 
         //var owner_tmp = HDFS.chadoopGetHost(blockHosts, i: int(32), here.name + domainSuffix, (i % fileInfo.mReplication): int(32));
-        var owner_tmp = HDFS.chadoopGetHost(blockHosts, i: int(32), (i % fileInfo.mReplication): int(32));
+        var owner_tmp = HDFS.chadoopGetHost(blockHosts, i: int(32), (i % fileInfo.mReplication): int(32)):string;
         var IDX = indexOf(".", owner_tmp, 1);
         var owner = owner_tmp[1..IDX-1];
         Blockies(owner) += i;

--- a/test/studies/HDFS/tzakian/chadoop.chpl
+++ b/test/studies/HDFS/tzakian/chadoop.chpl
@@ -93,12 +93,13 @@ sync coforall loc in Locales { // look at this more
     // 2) Find all the hosts/blocks for the file, from byte 0 to length
     // 3) On each locale, find the blocks you own and process them
     write("Connecting to HDFS on host " + here.name + "...");
-    var hdfsFS: c_void_ptr = HDFS.hdfsConnect(namenode, connectNumber);
+    var hdfsFS: c_void_ptr = HDFS.hdfsConnect(namenode.localize().c_str(), 
+                                              connectNumber);
     writeln("done");
-    var fileInfo = HDFS.chadoopGetFileInfo(hdfsFS, dataFile);
+    var fileInfo = HDFS.chadoopGetFileInfo(hdfsFS, dataFile.localize().c_str());
     //      writeln("Info for file " + dataFile + ":");
     //      writeln(fileInfo);
-    var blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile, 0, fileInfo.mSize);
+    var blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile.localize().c_str(), 0, fileInfo.mSize);
     // ==== Get the blocks
     var blockCount = HDFS.chadoopGetBlockCount(blockHosts);
     // END
@@ -106,7 +107,8 @@ sync coforall loc in Locales { // look at this more
     // ==== Connect to HDFS
     // ==== Open the file 
     writeln("Opening file " + dataFile + " on " + here.name + "...");
-    var dataFileLocal = HDFS.hdfsOpenFile(hdfsFS, dataFile, O_RDONLY, 0, 0, 0);
+    var dataFileLocal = HDFS.hdfsOpenFile(hdfsFS, dataFile.localize().c_str(), 
+                                          O_RDONLY, 0, 0, 0);
     assert(HDFS.IS_NULL(dataFileLocal) == HDFS.IS_NULL_FALSE, "Failed to open dataFileLocal");
     // assert that we opened the file successfully
     writeln("done");
@@ -123,7 +125,7 @@ sync coforall loc in Locales { // look at this more
       // This might have to be changed back to the original once (if) we
       // switch to a cluster setup
       // ==== Get the host that the block resides on
-      var owner_tmp = HDFS.chadoopGetHost(blockHosts, block: int(32), (block % fileInfo.mReplication): int(32)) + domainSuffix;
+      var owner_tmp = HDFS.chadoopGetHost(blockHosts, block: int(32), (block % fileInfo.mReplication): int(32)):string + domainSuffix;
       var IDX = indexOf(".", owner_tmp, 1);
       var owner = owner_tmp[1..IDX-1];
 
@@ -145,7 +147,7 @@ sync coforall loc in Locales { // look at this more
 
         // ==== Read in characters from the file
         //writeln("Positional read with startByte=" + startByte + " length=" + length);
-        var s = HDFS.chadoopReadFilePositional(hdfsFS, dataFileLocal, startByte, length);
+        var s = HDFS.chadoopReadFilePositional(hdfsFS, dataFileLocal, startByte, length):string;
         // writeln("Read " + s.length + " characters from " + dataFile);
 
         // Read through the string and load it into the problem domain record

--- a/test/studies/HDFS/tzakian/test.chpl
+++ b/test/studies/HDFS/tzakian/test.chpl
@@ -6,16 +6,16 @@ proc bar(nm: string) {
 
   var dataFile = "/tmp/test.txt";
 
-  const hdfsFS: c_void_ptr = HDFS.hdfsConnect(nm, 0);
-  const fileInfo = HDFS.chadoopGetFileInfo(hdfsFS, dataFile);
-  const blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile, 0, fileInfo.mSize); // incr 0?
+  const hdfsFS: c_void_ptr = HDFS.hdfsConnect(nm.localize().c_str(), 0);
+  const fileInfo = HDFS.chadoopGetFileInfo(hdfsFS, dataFile.localize().c_str());
+  const blockHosts = HDFS.hdfsGetHosts(hdfsFS, dataFile.localize().c_str(), 0, fileInfo.mSize); // incr 0?
   const blockCount = HDFS.chadoopGetBlockCount(blockHosts);
-  const dataFileLocal = HDFS.hdfsOpenFile(hdfsFS, dataFile, O_RDONLY, 0, 0, 0);
+  const dataFileLocal = HDFS.hdfsOpenFile(hdfsFS, dataFile.localize().c_str(), O_RDONLY, 0, 0, 0);
   assert(HDFS.IS_NULL(dataFileLocal) == HDFS.IS_NULL_FALSE, "Failed to open dataFileLocal");
   var length = fileInfo.mBlockSize: int(32); // LOOK
 
   writeln("size of file is: ", fileInfo.mSize);
-  var s = HDFS.chadoopReadFile(hdfsFS, dataFileLocal, fileInfo.mSize: int(32));
+  var s = HDFS.chadoopReadFile(hdfsFS, dataFileLocal, fileInfo.mSize: int(32)):string;
 
   var outfile = open("foo.txt", iomode.cw);
   var writer = outfile.writer();

--- a/test/studies/HDFS/tzakian/wc.chpl
+++ b/test/studies/HDFS/tzakian/wc.chpl
@@ -16,7 +16,8 @@ forall s in HDFSmap("/tmp/test.txt") {
 HDFSreduce();
 
 // return a tuple (startWhite, wc, endWhite)
-proc wordCount((s, block)) {
+proc wordCount((s_c_string, block)) {
+  var s = s_c_string: string;
   var nl = 0; // number of lines
   var nw = 0; // number of words
   var IN = 1; // in a word


### PR DESCRIPTION
Sadly, due to our lack of regular HDFS testing, these codes suffered bitrot
caused by string/c_string changes and the introduction of the 'as' keyword.
