### PR TITLE
Better handle code generation with declared extern C types

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -748,8 +748,15 @@ void VarSymbol::codegenDefC(bool global) {
     typestr = ct->classStructName(true);
   else if (this->declaredType &&
            this->declaredType->hasFlag(FLAG_EXTERN) &&
-           this->declaredType->hasFlag(FLAG_TYPE_VARIABLE))
+           this->declaredType->hasFlag(FLAG_TYPE_VARIABLE) &&
+           this->declaredType->typeInfo() == this->typeInfo()) {
+    // If this symbol was declared with an extern type,
+    // and the declared type matches the current type,
+    // use that extern type in the generated code.
+    // (The type could change for example when promoting this
+    //  variable to the heap).
     typestr = this->declaredType->cname;
+  }
   else
     typestr = type->codegen().c;
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -747,9 +747,9 @@ void VarSymbol::codegenDefC(bool global) {
   if (this->hasFlag(FLAG_SUPER_CLASS))
     typestr = ct->classStructName(true);
   else if (this->declaredType &&
+           this->declaredType->type == this->type &&
            this->declaredType->hasFlag(FLAG_EXTERN) &&
-           this->declaredType->hasFlag(FLAG_TYPE_VARIABLE) &&
-           this->declaredType->typeInfo() == this->typeInfo()) {
+           this->declaredType->hasFlag(FLAG_TYPE_VARIABLE)) {
     // If this symbol was declared with an extern type,
     // and the declared type matches the current type,
     // use that extern type in the generated code.

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -196,6 +196,11 @@ public:
   // with C escapes - that is newline is 2 chars \ n
   Immediate   *immediate;
 
+  // This field is a workaround to allow moving a declared
+  // extern type (e.g. c_int) through compilation.
+  // An alternative design would be to stash this in the DefExpr.
+  Symbol*            declaredType;
+
   //changed isconstant flag to reflect var, const, param: 0, 1, 2
   VarSymbol(const char* init_name, Type* init_type = dtUnknown);
   virtual ~VarSymbol();

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1153,6 +1153,17 @@ static void init_config_var(VarSymbol* var,
   stmt = noop; // insert regular definition code in then block
 }
 
+static void setDeclaredType(VarSymbol* var, Expr* typeExpr)
+{
+  // For variables with a declared extern type variable type,
+  // set var->declaredType to that type.
+  // This allows code generation to use the declared extern type
+  // in many, but not all cases.
+  if (SymExpr* se = toSymExpr(typeExpr))
+    if (se->var->hasFlag(FLAG_EXTERN) &&
+        se->var->hasFlag(FLAG_TYPE_VARIABLE))
+      var->declaredType = se->var;
+}
 
 static void init_typed_var(VarSymbol* var,
                            Expr*      type,
@@ -1220,6 +1231,8 @@ static void init_typed_var(VarSymbol* var,
     // module code)
     var->defPoint->init->remove();
 
+    setDeclaredType(var, type);
+
     CallExpr* initCall = new CallExpr(PRIM_MOVE,
                                       var,
                                       new CallExpr(PRIM_NO_INIT,
@@ -1256,6 +1269,9 @@ static void init_typed_var(VarSymbol* var,
     VarSymbol* typeTemp = newTemp("type_tmp");
     DefExpr*   typeDefn = new DefExpr(typeTemp);
     CallExpr*  initCall = NULL;
+
+    setDeclaredType(typeTemp, type);
+    setDeclaredType(var, type);
 
     initCall = new CallExpr(PRIM_MOVE,
                             typeTemp,

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -331,6 +331,7 @@ static FnSymbol* createAndInsertFunParentMethod(CallExpr *call, AggregateType *p
 static std::string buildParentName(AList &arg_list, bool isFormal, Type *retType);
 static AggregateType* createOrFindFunTypeFromAnnotation(AList &arg_list, CallExpr *call);
 static Expr* createFunctionAsValue(CallExpr *call);
+static Type* resolveTypeAlias(SymExpr* se);
 static bool
 isOuterVar(Symbol* sym, FnSymbol* fn, Symbol* parent = NULL);
 static bool
@@ -3442,6 +3443,9 @@ static const char* defaultRecordAssignmentTo(FnSymbol* fn) {
 // special case cast of class w/ type variables that is not generic
 //   i.e. type variables are type definitions (have default types)
 //
+// also handles some complicated extern vars like
+//   extern var x: c_ptr(c_int)
+// which do not work in the usual order of resolution.
 static void
 resolveDefaultGenericType(CallExpr* call) {
   SET_LINENO(call);
@@ -3463,11 +3467,9 @@ resolveDefaultGenericType(CallExpr* call) {
         // Fix for complicated extern vars like
         // extern var x: c_ptr(c_int);
         if( vs->hasFlag(FLAG_EXTERN) && vs->hasFlag(FLAG_TYPE_VARIABLE) &&
-            vs->defPoint && vs->defPoint->init ) {
-          if( CallExpr* def = toCallExpr(vs->defPoint->init) ) {
-            vs->defPoint->init = resolveExpr(def);
-            te->replace(new SymExpr(vs->defPoint->init->typeInfo()->symbol));
-          }
+            vs->defPoint && vs->defPoint->init &&
+            vs->getValType() == dtUnknown ) {
+          vs->type = resolveTypeAlias(te);
         }
       }
     }
@@ -6657,6 +6659,7 @@ resolveExpr(Expr* expr) {
 
   if (DefExpr* def = toDefExpr(expr)) {
     if (def->init) {
+      // This section was added to handle type a = b
       Expr* init = preFold(def->init);
       init = resolveExpr(init);
       // expr is unchanged, so is treated as "resolved".
@@ -8905,10 +8908,37 @@ static void replaceTypeArgsWithFormalTypeTemps()
     if (! fn->defPoint->parentSymbol)
       continue;
 
-    // We do not remove type args from extern functions
-    // TODO: Find out if we really support type args in extern functions.
-    if (fn->hasFlag(FLAG_EXTERN))
+    // We do not remove type args from extern functions so that e.g.:
+    //  extern proc sizeof(type t);
+    //  sizeof(int)
+    // will function correctly.
+    // However, in such a case, we'd like to pass the type symbol
+    // to the call site rather than a type variable call_tmp
+    if (fn->hasFlag(FLAG_EXTERN)) {
+      // Replace the corresponding actual with a SymExpr TypeSymbol
+      // for all the call sites.
+      forv_Vec(CallExpr, call, *fn->calledBy)
+      {
+        for_formals_actuals(formal, actual, call)
+        {
+          if (! formal->hasFlag(FLAG_TYPE_VARIABLE))
+            continue;
+
+          if (SymExpr* se = toSymExpr(actual)) {
+            if (isTypeSymbol(se->var))
+              continue;
+            if (se->var->hasFlag(FLAG_EXTERN) &&
+                se->var->hasFlag(FLAG_TYPE_VARIABLE))
+              continue;
+          }
+
+          SET_LINENO(actual);
+          TypeSymbol* ts = formal->type->symbol;
+          actual->replace(new SymExpr(ts));
+        }
+      }
       continue;
+    }
 
     for_formals(formal, fn)
     {

--- a/test/extern/ferguson/declared-type-extern/COMPOPTS
+++ b/test/extern/ferguson/declared-type-extern/COMPOPTS
@@ -1,0 +1,1 @@
+--savec=tmp

--- a/test/extern/ferguson/declared-type-extern/PREDIFF
+++ b/test/extern/ferguson/declared-type-extern/PREDIFF
@@ -1,0 +1,8 @@
+#!/bin/bash
+grep "c_int mynum" tmp/$1.c tmp/*.h
+if [ $? = 0 ] ; then
+  echo "found c_int mynum" >> $2
+else
+  echo "missing c_int mynum" >> $2
+fi
+rm -Rf tmp

--- a/test/extern/ferguson/declared-type-extern/var_declared_type_extern-global.chpl
+++ b/test/extern/ferguson/declared-type-extern/var_declared_type_extern-global.chpl
@@ -1,0 +1,6 @@
+var x:c_int = 4;
+var mynum:c_int;
+
+mynum += x:c_int;
+
+writeln(mynum);

--- a/test/extern/ferguson/declared-type-extern/var_declared_type_extern-global.good
+++ b/test/extern/ferguson/declared-type-extern/var_declared_type_extern-global.good
@@ -1,0 +1,2 @@
+4
+found c_int mynum

--- a/test/extern/ferguson/declared-type-extern/var_declared_type_extern.chpl
+++ b/test/extern/ferguson/declared-type-extern/var_declared_type_extern.chpl
@@ -1,0 +1,10 @@
+proc doit() {
+  var x:c_int = 4;
+  var mynum:c_int;
+
+  mynum += x:c_int;
+
+  writeln(mynum);
+}
+
+doit();

--- a/test/extern/ferguson/declared-type-extern/var_declared_type_extern.good
+++ b/test/extern/ferguson/declared-type-extern/var_declared_type_extern.good
@@ -1,0 +1,2 @@
+4
+found c_int mynum

--- a/test/extern/ferguson/sizeof-extern-type/COMPOPTS
+++ b/test/extern/ferguson/sizeof-extern-type/COMPOPTS
@@ -1,0 +1,1 @@
+--savec=tmp

--- a/test/extern/ferguson/sizeof-extern-type/PREDIFF
+++ b/test/extern/ferguson/sizeof-extern-type/PREDIFF
@@ -1,0 +1,8 @@
+#!/bin/bash
+grep "sizeof(c_" tmp/$1.c
+if [ $? = 0 ] ; then
+  echo "found sizeof(c_" >> $2
+else
+  echo "missing sizeof(c_" >> $2
+fi
+rm -Rf tmp

--- a/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type.chpl
+++ b/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type.chpl
@@ -1,0 +1,14 @@
+proc doit() {
+
+  pragma "no prototype"
+  extern proc sizeof(type t): size_t;
+
+  // We just want to check that this gets code
+  // generated as sizeof(c_int) vs e.g. sizeof(int32_t);
+  var x = sizeof(c_int);
+
+  // Just using x so it's not dead code
+  assert(x>0);
+}
+
+doit();

--- a/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type.good
+++ b/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type.good
@@ -1,0 +1,1 @@
+found sizeof(c_

--- a/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type2.chpl
+++ b/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type2.chpl
@@ -1,0 +1,13 @@
+{
+
+  pragma "no prototype"
+  extern proc sizeof(type t): size_t;
+
+  // We just want to check that this gets code
+  // generated as sizeof(c_int) vs e.g. sizeof(int32_t);
+  var x = sizeof(c_uint);
+
+  // Just using x so it's not dead code
+  assert(x>0);
+}
+

--- a/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type2.good
+++ b/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type2.good
@@ -1,0 +1,1 @@
+found sizeof(c_


### PR DESCRIPTION
It has bothered me for some time that a program such as this:

     var x:c_uint;

would not generate C code that uses the type c_int (where c_int is some
extern type). Instead it would use int32_t (for example).

It also bothered me that the generated C code for SysCTypes.chpl had
several useless asserts. The Chapel code looks like this:

     assert(sizeof(c_uint) == sizeof(uint(32)));

where the intent is to fail early if there is something wrong with the
types generated in SysCTypes (e.g. we compile with c_ulong as 64-bits but
in fact it is 32-bits).

For context, note that types like c_uint are generated into
SysCTypes.chpl declarations that might look like this:

    extern type c_int= int(32);

This patch fixes both of these problems. These problems are slightly tied
together since they both have to do with how extern type type variables
work in the compiler.

## Keeping Declared Variable Extern Types

The basic problem is that the Chapel type system uses its version of
types instead of a declared type. That is a somewhat reasonable design
because then the compiler can normalize these types. However, the problem
comes up that for a variable like `x` in the example above, its type will
be `int(32)` rather than `c_int`.

This patch uses the approach of adding a field to VarSymbol that stores
the TypeSymbol for an explicitly declared type as in this case. This
connection is made in scopeResolve (which means that it will only work in
certain situations). Then, for VarSymbols with this TypeSymbol
associated, code generation uses the TypeSymbol instead of the type field
when generating the type of a variable.

## Cleaning Up sizeof(c_uint)

Initial versions of the above change caused problems with the
SysCTypes.chpl file. In particular, it turns out that something like
`sizeof(c_uint)` was code generating to `sizeof(tmp)` where `tmp` is a
local variable of type `uint(32)` in my case. That seemed obviously wrong
to me so I set about fixing it.

To fix it, I adjusted replaceTypeArgsWithFormalTypeTemps to pass a type
symbol to such calls instead of passing in a variable marked with
FLAG_TYPE_VARIABLE. In addition, I tightened up a workaround for code
like this

    extern var x: c_ptr(c_int)

that was replacing the a `c_uint` argument in a `sizeof` call with
`uint(32)` (for example). The workaround was to add code in
resolveDefaultGenericType in order to detect such cases and to replace
the argument with a new SymExpr for the TypeSymbol based on the
variable's type. This strategy had the drawback that it prevented these
sizeof calls in SysCTypes from working correctly. Instead, this patch
adjusts this workaround to call `resolveTypeAlias` and to store the
result in the VarSymbol's type. That strategy seems to fit slightly
better.

Passed local quickstart testing.
Passed test/release/examples with --verify.