### PR TITLE
Test the performance of jemalloc with #cores arenas

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
+
+source $CWD/common-perf.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
+
+export JE_MALLOC_CONF="narenas:24"
+
+perf_args="-performance-description narneas -performance-configs default:v,narneas:v -sync-dir-suffix narneas"
+perf_args="${perf_args} -performance -numtrials 5 -startdate 03/02/16"
+
+$CWD/nightly -cron ${nightly_args} ${perf_args}


### PR DESCRIPTION
jemalloc typically uses 4*#logicalCores, but for qthreads we only create #cores
pthreads, so we don't need the extra arenas. See if there is a performance
benefit to limiting the arenas to determine if it's worth spending the time to
implement a more structured way of doing this.