### PR TITLE
Fix a sporadic failure to build jemalloc

### DIFF
--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -70,7 +70,9 @@ build-jemalloc: FORCE
 	cd $(JEMALLOC_BUILD_DIR) && $(MAKE) $(CHPL_JEMALLOC_MAKE_OPTIONS) build_lib_static
 
 install-jemalloc: FORCE
-	cd $(JEMALLOC_BUILD_DIR) && $(MAKE) install_lib_static install_bin install_include
+	cd $(JEMALLOC_BUILD_DIR) && $(MAKE) install_lib_static
+	cd $(JEMALLOC_BUILD_DIR) && $(MAKE) install_bin
+	cd $(JEMALLOC_BUILD_DIR) && $(MAKE) install_include
 
 
 FORCE:


### PR DESCRIPTION
We've been getting sporadic failures to build jemalloc with our OSX testng. We
got an error along the lines that the install directory already existed and it
couldn't be created again.

I believe what was happening is that the `install_lib_static`, `install_bin`,
and `install_include` targets were getting called simultaneously. Each one of
those targets was trying to create the install dir if it didn't exist, which is
racey.

To fix this I split out the install steps so that they are serialized.