### PR TITLE
Fixed some fallouts from #3375 "reductions as foralls"

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1643,7 +1643,9 @@ buildReduceViaForall(FnSymbol* fn, Expr* opExpr, Expr* dataExpr,
   }
 
   UnresolvedSymExpr* opUnr = toUnresolvedSymExpr(opExpr);
-  INT_ASSERT(opUnr);
+  // Some future tests have expressions here. We do not handle them.
+  if (!opUnr)
+    return NULL;
 
   const char* opFun;
   if (!strcmp(opUnr->unresolved, "SumReduceScanOp")) {

--- a/test/arrays/deitz/parallelism/test_reduction_is_parallel.lm-numa.good
+++ b/test/arrays/deitz/parallelism/test_reduction_is_parallel.lm-numa.good
@@ -1,0 +1,4 @@
+1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 15.0 16.0 17.0 18.0 19.0 20.0
+CHPL TEST PAR (test_reduction_is_parallel.chpl:15): default rectangular domain follower invoked on (0..9)
+CHPL TEST PAR (test_reduction_is_parallel.chpl:15): default rectangular domain follower invoked on (10..19)
+210.0

--- a/test/reductions/vass/reductions-wanted-SA-not-LF.future
+++ b/test/reductions/vass/reductions-wanted-SA-not-LF.future
@@ -1,1 +1,14 @@
-feature request: not LF
+feature request: invoke standalone iterator, not leader-follower
+
+Since #3375 aka eefbfe1, certain reductions are represented in the
+compiler using forall loops. Some reductions, however, are represented
+as before. That previous representation does not know about
+standalone iterators and so invokes only either leader/follower
+if they exist or serial iterator otherwise. While we can fix that
+representation to allow for standalone iterators too, our path
+forward is to use the new representation for all reductions.
+This future commemorates our intention to do so.
+
+This future exercises the case where both a standalone iterator and
+leader/follower are available. If so, we would like the standalone
+iterator to be invoked, whereas currently leader/follower are.

--- a/test/reductions/vass/reductions-wanted-SA-not-ser.future
+++ b/test/reductions/vass/reductions-wanted-SA-not-ser.future
@@ -1,1 +1,15 @@
-feature request: not serial
+feature request: invoke standalone iterator, not serial
+
+Since #3375 aka eefbfe1, certain reductions are represented in the
+compiler using forall loops. Some reductions, however, are represented
+as before. That previous representation does not know about
+standalone iterators and so invokes only either leader/follower
+if they exist or serial iterator otherwise. While we can fix that
+representation to allow for standalone iterators too, our path
+forward is to use the new representation for all reductions.
+This future commemorates our intention to do so.
+
+This future exercises the case where both a standalone iterator is
+available, as well as the serial iterator but not leader/follower.
+If so, we would like the standalone iterator to be invoked, whereas
+currently the serial iterator is.


### PR DESCRIPTION
* This test now invokes the standlone iterator rather than
leader-follower, so I updated its .good:

    arrays/deitz/parallelism/test_reduction_is_parallel

However, the standalone iterator is not available under numa,
so there leader-follower are still invoked.

I am adding .lm-numa.good to match that behavior.
It is identical to the pre-#3375 .good.

* These futures:

    reductions/thomasvandoren/test/TestMinkWithArg
    users/ferguson/histogram/reductionex_class
    users/ferguson/histogram/reductionex_record

pass expressions, not just class names, to reductions,
making the compiler trip over one of my assertions.
I am removing an assertion in:

    compiler/AST/build.cpp

 so that the compiler can generate at least some error message and
these tests' .bad files can be left unchanged.

* I also filled in the .future files for these tests,
which I forgot to do in #3375:

    reductions/vass/reductions-wanted-SA-not-LF.future
    reductions/vass/reductions-wanted-SA-not-ser.future