### PR TITLE
Replace manual define/undef of our malloc warning macros with header includes

### DIFF
--- a/runtime/include/chpl-mem-no-warning-macros.h
+++ b/runtime/include/chpl-mem-no-warning-macros.h
@@ -17,8 +17,10 @@
  * limitations under the License.
  */
 
-#ifndef _chpl_mem_no_warning_macros_h_
-#define _chpl_mem_no_warning_macros_h_
+// NOTE: there is no include guard. This is so that the mem-warning and
+// mem-no-warning headers can be included an arbitrary number of times to
+// disable and then re-enable the macros
+
 
 // Leave malloc/free/etc to use the system allocator.
 // malloc/free may not return memory that can be
@@ -28,5 +30,3 @@
 #undef calloc
 #undef free
 #undef realloc
-
-#endif

--- a/runtime/include/chpl-mem-warning-macros.h
+++ b/runtime/include/chpl-mem-warning-macros.h
@@ -17,11 +17,13 @@
  * limitations under the License.
  */
 
-#ifndef _chpl_mem_warning_macros_h_
-#define _chpl_mem_warning_macros_h_
 
-// this function gets its own ifdef in case
-// we want to disable and then re-enable the warning macros.
+// NOTE: there is no include guard. This is so that the mem-warning and
+// mem-no-warning headers can be included an arbitrary number of times to
+// disable and then re-enable the macros
+
+
+// this function gets its own ifdef so that it's not redefined
 #ifndef _chpl_mem_warning_macros_really_h_
 #define _chpl_mem_warning_macros_really_h_
 // MPF - I needed to call the system free to pair with system valloc
@@ -35,5 +37,3 @@ static inline void sys_free(void *ptr) { free(ptr); }
 #define calloc  dont_use_calloc_use_chpl_mem_allocMany_instead
 #define free    dont_use_free_use_chpl_mem_free_instead
 #define realloc dont_use_realloc_use_chpl_mem_realloc_instead
-
-#endif

--- a/runtime/include/mem/cstdlib/chpl-mem-impl.h
+++ b/runtime/include/mem/cstdlib/chpl-mem-impl.h
@@ -28,11 +28,8 @@
 #include <malloc/malloc.h>
 #endif
 
-#undef malloc
-#undef calloc
-#undef realloc
-#undef free
-#undef _chpl_mem_warning_macros_h_
+// disable mem warnings since cstdlib uses the system allocator
+#include "chpl-mem-no-warning-macros.h"
 
 #include <stdlib.h>
 

--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -21,16 +21,11 @@
 #ifndef _chpl_mem_impl_H_
 #define _chpl_mem_impl_H_
 
-// jemalloc references malloc and friends internally so we need to quiet our
-// warnings before including jemalloc.h
-#undef malloc
-#undef calloc
-#undef realloc
-#undef free
-#undef _chpl_mem_warning_macros_h_
-
-
+// jemalloc.h references the token "malloc" (but not the actual function) and
+// our warning macros mess up jemalloc's use of it.
+#include "chpl-mem-no-warning-macros.h"
 #include "jemalloc.h"
+#include "chpl-mem-warning-macros.h"
 
 static inline void* chpl_calloc(size_t n, size_t size) {
   return je_calloc(n,size);
@@ -69,9 +64,5 @@ static inline size_t chpl_good_alloc_size(size_t minSize) {
 // TODO (EJR 12/17/15): if we end up using the extended API should we consider
 // adding something like `chpl_sized_free()` sized deallocations that maps down
 // to `sdallocx()`
-
-
-// Now that we've defined our functions, turn the warnings back on.
-#include "chpl-mem-warning-macros.h"
 
 #endif

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -81,14 +81,6 @@ int _runInGDB(void) {
 }
 
 
-//
-// defineEnvVar() needs to be able to call malloc(), because it runs
-// before the memory layer is initialized but needs to allocate memory
-// (for a copy of the var=value string).  So, we turn off the magic
-// warning macro here, and turn it back on after defineEnvVar().
-//
-#undef malloc
-
 static void defineEnvVar(const char* currentArg,
                          int32_t lineno, int32_t filename) {
   char* eqp;
@@ -120,8 +112,6 @@ static void defineEnvVar(const char* currentArg,
   }
   *eqp = '=';
 }
-
-#define malloc dont_use_malloc_use_chpl_mem_allocMany_instead
 
 
 static void parseDashEArgs(int* argc, char* argv[]) {

--- a/runtime/src/chpl-mem-replace-malloc.c
+++ b/runtime/src/chpl-mem-replace-malloc.c
@@ -27,10 +27,7 @@
 #include "error.h"
 
 // This file needs to be able to use real allocator names
-#undef malloc
-#undef calloc
-#undef realloc
-#undef free
+#include "chpl-mem-no-warning-macros.h"
 
 // This file always declares this function at least.
 void chpl_mem_replace_malloc_if_needed(void);

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -60,9 +60,8 @@ extern void chpl_memTracking_returnConfigVals(chpl_bool* memTrack,
 
 chpl_bool chpl_memTrack = false;
 
-#undef malloc
-#undef calloc
-#undef free
+// memory layer hasn't been initialized, need to use the system allocator
+#include "chpl-mem-no-warning-macros.h"
 
 typedef struct memTableEntry_struct { /* table entry */
   size_t number;

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -604,7 +604,10 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
                             sizeof(ftable)/sizeof(gasnet_handlerentry_t),
                             gasnet_getMaxLocalSegmentSize(),
                             0));
-#undef malloc
+  // memory layer hasn't been initialized, need to use the system allocator
+#include "chpl-mem-no-warning-macros.h"
+  // TODO (EJR: 03/03/16): we currently "leak" seginfo_table. We should
+  // probably free it on exit (but only for "clean" exits.)
   seginfo_table = (gasnet_seginfo_t*)malloc(chpl_numNodes*sizeof(gasnet_seginfo_t));
   //
   // The following call has no real effect on the .addr and .size
@@ -667,7 +670,7 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   GASNET_BLOCKUNTIL(bcast_seginfo_done);
   chpl_comm_barrier("making sure everyone's done with the broadcast");
 #endif
-#define malloc dont_use_malloc_use_chpl_mem_allocMany_instead
+#include "chpl-mem-warning-macros.h"
 
   gasnet_set_waitmode(GASNET_WAIT_BLOCK);
 


### PR DESCRIPTION
We have malloc macros to prevent us from mistakenly using the system allocator.
However, there are some places where we must use the system allocator because
the memory layer isn't initialized or because our allocator is a thin wrapper
over the system allocator (cstdlib). Previously we got at the system allocator
by undef'ing the macros then redefining them. This was fragile because it
hard-coded the macros in a bunch of places instead of limiting their definition
to a single place.

This patch replaces all those defines and undefs to just include the
no-mem-warning.h file to disable the warnings and mem-warnings.h to re-enable
them.

In order to allow the arbitrarily inclusion of the warning and no-warning
header files, I had to remove their include guards. Greg and Michael supported
removing the include guards. There's probably other things we could have done,
but this is pretty clean, and you should only be including these files if you
really know what you're doing anyways.
