### PR TITLE
Test out the performance of jemalloc configured with --disable-cache-oblivious

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,9 +9,9 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-export JE_MALLOC_CONF="narenas:24"
+export CHPL_JEMALLOC_MORE_CFG_OPTIONS="--disable-cache-oblivious"
 
-perf_args="-performance-description narneas -performance-configs default:v,narneas:v -sync-dir-suffix narneas"
-perf_args="${perf_args} -performance -numtrials 5 -startdate 03/02/16"
+perf_args="-performance-description cache-oblivious -performance-configs default:v,cache-oblivious:v -sync-dir-suffix cache-oblivious"
+perf_args="${perf_args} -performance -numtrials 5 -startdate 03/03/16"
 
 $CWD/nightly -cron ${nightly_args} ${perf_args}


### PR DESCRIPTION
Some other jemalloc users have experience performance regressions do to
cache-oblivious large allocations. Out of curiosity, I want to see if it
impacts our performance at all.

See JIRA 186 for more info: https://chapel.atlassian.net/browse/CHAPEL-186