### PR TITLE
Fix .bad file for setter-assigned-to-a-var test

### DIFF
--- a/test/arrays/vass/setter-assigned-to-a-var.bad
+++ b/test/arrays/vass/setter-assigned-to-a-var.bad
@@ -1,2 +1,2 @@
 Invalid read of size 8
-Address xxx is 24 bytes inside a block of size 96 free'd
+Address xxx is 24 bytes inside a block of size 160 free'd


### PR DESCRIPTION
The amount of memory allocated/freed in an error in this test changed after
the array-as-vec halving/doubling feature was merged.