### PR TITLE
Remove backslashes from UserIDs before creating output temp directories

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -87,14 +87,14 @@ void ensureDirExists(const char* dirname, const char* explanation) {
 }
 
 
-static void removeSpacesFromString(char* str)
+static void removeSpacesBackslashesFromString(char* str)
 {
   char* src = str;
   char* dst = str;
   while (*src != '\0')
   {
     *dst = *src++;
-    if (*dst != ' ')
+    if (*dst != ' ' && *dst != '\\')
         dst++;
   }
   *dst = '\0';
@@ -141,7 +141,7 @@ const char* makeTempDir(const char* dirPrefix) {
     userid = passwdinfo->pw_name;
   }
   char* myuserid = strdup(userid);
-  removeSpacesFromString(myuserid);
+  removeSpacesBackslashesFromString(myuserid);
 
   const char* tmpDir = astr(tmpdirprefix, myuserid, mypidstr, tmpdirsuffix);
   ensureDirExists(tmpDir, "making temporary directory");


### PR DESCRIPTION
It seems that if a user ID contains a backslash that the compiler fails to create the /tmp directory properly and then fails to be able to write codegenerated files to it.  This was reported by a user whose userID had such a backslash, and I was able to reproduce it by hardcoding the userID string in files.cpp to contain a backslash.  Previously, we ran into a similar issue for userIDs containing spaces, so I extended that logic to handle backslashes as well and confirmed that it worked.  Then backed out the hardcoding of the userID.

This seems hard to file a test against without adding logic to the compiler to permit a userID to be manually specified, and I wasn't sure it was worth that level of trouble to lock in, but if others feel differently...