### PR TITLE
Revert "Cleanup our "don't use malloc" macros"

### DIFF
--- a/runtime/include/chpl-mem-warning-macros.h
+++ b/runtime/include/chpl-mem-warning-macros.h
@@ -33,7 +33,7 @@
 static inline void sys_free(void *ptr) { free(ptr); }
 #endif
 
-#define malloc(size)       dont_use_malloc_use_chpl_mem_allocMany_instead
-#define calloc(num, size)  dont_use_calloc_use_chpl_mem_allocMany_instead
-#define free(ptr)          dont_use_free_use_chpl_mem_free_instead
-#define realloc(ptr, size) dont_use_realloc_use_chpl_mem_realloc_instead
+#define malloc  dont_use_malloc_use_chpl_mem_allocMany_instead
+#define calloc  dont_use_calloc_use_chpl_mem_allocMany_instead
+#define free    dont_use_free_use_chpl_mem_free_instead
+#define realloc dont_use_realloc_use_chpl_mem_realloc_instead

--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -21,7 +21,11 @@
 #ifndef _chpl_mem_impl_H_
 #define _chpl_mem_impl_H_
 
+// jemalloc.h references the token "malloc" (but not the actual function) and
+// our warning macros mess up jemalloc's use of it.
+#include "chpl-mem-no-warning-macros.h"
 #include "jemalloc.h"
+#include "chpl-mem-warning-macros.h"
 
 static inline void* chpl_calloc(size_t n, size_t size) {
   return je_calloc(n,size);


### PR DESCRIPTION
This reverts commit f2b9982c47371fe8cf39c55da63c6c21bcbf905c.

For some reason (that makes no sense to me) this caused cygwin64 builds to
fail, but not cygwin32