### PR TITLE
Fix broken links in users guide

### DIFF
--- a/doc/sphinx/source/users-guide/index.rst
+++ b/doc/sphinx/source/users-guide/index.rst
@@ -42,6 +42,8 @@ support of parallelism and locality are removed.
 
 (more to come...)
 
+.. _index-task-parallelism:
+
 Task Parallelism
 ----------------
 
@@ -57,6 +59,7 @@ explicitly and synchronizing between them.
 
 (more to come...)
 
+.. _index-data-parallelism:
 
 Data Parallelism
 ----------------

--- a/doc/sphinx/source/users-guide/taskpar/taskParallelismOverview.rst
+++ b/doc/sphinx/source/users-guide/taskpar/taskParallelismOverview.rst
@@ -15,9 +15,9 @@ runs, additional tasks can be created to introduce parallel
 computation.  Chapel does not automatically parallelize programs,
 which is to say, tasks are not automatically created on the
 programmer's behalf.  Rather, the programmer must create all tasks,
-either directly (using the constructs described in this `Task
-Parallelism <index.html#task-parallelism>`_ section), or indirectly
-(through the use of `Data Parallelism <index.html#data-parallelism>`_
+either directly (using the constructs described in this
+:ref:`index-task-parallelism` section), or indirectly
+(through the use of :ref:`index-data-parallelism`
 abstractions that create the tasks).
 
 A Chapel task may be short-lived, or it may run for the program's


### PR DESCRIPTION
Fixed some broken links in the users guide and switched cross-reference style to `:ref: foobar`. This is considered the best practice in our Sphinx documentation.