### PR TITLE
Fixes error obtained on using exit() without args

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -560,7 +560,7 @@ module ChapelBase {
   //
   // More primitive funs
   //
-  inline proc exit(status: int) {
+  inline proc exit(status: int=0) {
     __primitive("chpl_exit_any", status);
   }
 

--- a/test/exits/kushal/exitWithNoArgs.chpl
+++ b/test/exits/kushal/exitWithNoArgs.chpl
@@ -1,0 +1,2 @@
+writeln("Hello, World");
+exit();

--- a/test/exits/kushal/exitWithNoArgs.good
+++ b/test/exits/kushal/exitWithNoArgs.good
@@ -1,0 +1,1 @@
+Hello, World


### PR DESCRIPTION
- Default argument set as zero to avoid the issue
- Fixes a part of https://chapel.atlassian.net/projects/CHAPEL/issues/CHAPEL-168
- Tested by grepping  exit() in tests/
- Tested with full test_start after making the changes 