### PR TITLE
Update prerequisites to include python-setuptools

### DIFF
--- a/doc/release/building.rst
+++ b/doc/release/building.rst
@@ -29,10 +29,12 @@ If everything works as intended, you ought to see:
 
      ``$CHPL_HOME/lib/$CHPL_TARGET_PLATFORM.$CHPL_TARGET_COMPILER.../``
 
-If you get an error or failure during the make process, please let us
-know about it at: chapel-bugs@lists.sourceforge.net (as well as
-information about your system as described in :ref:`readme-bugs` and any
-workaround that you come up with).
+If you get an error or failure during the make process, first
+double-check that you have the required prerequisites (see
+:ref:`readme-prereqs`). If you do, please let us know about the failure
+at: chapel-bugs@lists.sourceforge.net (as well as information about your
+system as described in :ref:`readme-bugs` and any workaround that you
+come up with).
 
 Note that each make command only builds the compiler and runtime for
 the current set of ``CHPL_`` environment variables defined by (and

--- a/doc/release/prereqs.rst
+++ b/doc/release/prereqs.rst
@@ -29,23 +29,26 @@ about your environment for using Chapel:
     relatively recent versions of gcc/g++, clang, and compilers from
     Cray, Intel, and PGI.
 
-  * If you wish to use Chapel's test system, python-devel or an
-    equivalent package for your platform is required.
-
+  * If you wish to use Chapel's test system, python-setuptools and
+    python-devel (or equivalent packages for your platform) are required.
 
 Installation
 ------------
 
-We have used the following commands to install the above prerequisites
+We have used the following commands to install the above prerequisites:
 
-  * CentOS::
+  * CentOS, Fedora 21::
 
-      sudo yum install gcc gcc-c++ perl python python-devel bash make gawk
+      sudo yum install gcc gcc-c++ perl python python-devel python-setuptools bash make gawk
 
-  * SLES::
+  * Fedora 22::
 
-      sudo zypper install gcc gcc-c++ perl python python-devel bash make gawk
+      sudo dnf install gcc gcc-c++ perl python python-devel python-setuptools bash make gawk
+
+  * SLES, openSUSE::
+
+      sudo zypper install gcc gcc-c++ perl python python-devel python-setuptools bash make gawk
 
   * Debian, Ubuntu::
 
-      sudo apt-get install gcc g++ perl python python-dev bash make mawk
+      sudo apt-get install gcc g++ perl python python-dev python-setuptools bash make mawk


### PR DESCRIPTION
I started to double-check our prereqs.rst based on trouble
running start_test from a GSoC'er.

In updating these commands, I verified that:

     make
     make test
     make test-venv
     start_test test/release/examples/hello.chpl
     make docs

functions as intended after running the commands in prereqs,
installing git if necessary, and checking out Chapel from master,
on fresh VMs for following platforms:

 Fedora 22
 CentOS 7.2
 openSUSE 13.2
 Debian 8.2
 Ubuntu 15.10

The only error was that Fedora 22 did not succeed at `make docs`;
it gave an error when fixDistDocs.perl.