### PR TITLE
Report an error for a field or function in with-clause.

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -88,6 +88,10 @@ static bool                                enableModuleUsesCache = false;
 static Vec<const char*>                         aliasFieldSet;
 
 
+// To avoid duplicate user warnings in checkIdInsideWithClause().
+// Using pair<> instead of astlocT to avoid defining operator<.
+typedef std::pair< std::pair<const char*,int>, const char* >  WFDIWmark;
+static std::set< std::pair< std::pair<const char*,int>, const char* > > warnedForDotInsideWith;
 
 
 static void     addToSymbolTable(Vec<DefExpr*>& defs); // deprecated.
@@ -212,6 +216,8 @@ void scopeResolve() {
   destroyTable();
 
   destroyModuleUsesCaches();
+
+  warnedForDotInsideWith.clear();
 
   renameDefaultTypesToReflectWidths();
 
@@ -1430,6 +1436,8 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr*       unresolvedSymExpr,
 static void resolveModuleCall(CallExpr* call, Vec<UnresolvedSymExpr*>& skipSet);
 static bool isMethodName(const char* name, Type* type);
 static bool isMethodNameLocal(const char* name, Type* type);
+static void checkIdInsideWithClause(Expr* exprInAst,
+                                    UnresolvedSymExpr* origUSE);
 
 #ifdef HAVE_LLVM
 static bool tryCResolve(ModuleSymbol* module, const char* name);
@@ -1505,6 +1513,7 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* unresolvedSymExpr,
   //
   if (FnSymbol* fn = toFnSymbol(sym)) {
     if (!fn->_this && fn->hasFlag(FLAG_NO_PARENS)) {
+      checkIdInsideWithClause(unresolvedSymExpr, unresolvedSymExpr);
       unresolvedSymExpr->replace(new CallExpr(fn));
       return;
     }
@@ -1632,6 +1641,7 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* unresolvedSymExpr,
                 }
               }
 
+              checkIdInsideWithClause(expr, unresolvedSymExpr);
               expr->replace(dot);
             }
           }
@@ -1699,7 +1709,54 @@ static bool isMethodNameLocal(const char* name, Type* type) {
   }
 
   return false;
-} 
+}
+
+
+static void errorDotInsideWithClause(UnresolvedSymExpr* origUSE,
+                                     const char* construct)
+{
+  // As of this writing, a with-clause can be duplicated in the AST.
+  // This code avoids multiple error messages for the same symbol.
+
+  std::pair<const char*,int> markLoc(origUSE->astloc.filename,
+                                     origUSE->astloc.lineno);
+  WFDIWmark mark(markLoc, origUSE->unresolved);
+
+  if (!warnedForDotInsideWith.count(mark)) {
+    USR_FATAL_CONT(origUSE, "%s: cannot reference a field or function in a 'with' clause of a %s", origUSE->unresolved, construct);
+    warnedForDotInsideWith.insert(mark);
+  }
+}
+
+//
+// 'expr' ended up being a field reference (or perhaps a method call).
+// If we are inside a 'with' clause, report an error.
+//
+static void checkIdInsideWithClause(Expr* exprInAst,
+                                    UnresolvedSymExpr* origUSE)
+{
+  // A 'with' clause for a forall loop.
+  if (CallExpr* call = toCallExpr(exprInAst->parentExpr)) {
+    if (call->isPrimitive(PRIM_FORALL_LOOP)) {
+      errorDotInsideWithClause(origUSE, "forall loop");
+      return;
+    }
+  }
+
+  // A 'with' clause for a task construct.
+  if (Expr* parent1 = exprInAst->parentExpr)
+    if (BlockStmt* parent2 = toBlockStmt(parent1->parentExpr))
+      if (parent1 == parent2->byrefVars) {
+        CallExpr* blockInfo = parent2->blockInfoGet();
+        // Ensure that an issue, indeed, occurred a task construct.
+        INT_ASSERT(blockInfo->isPrimitive(PRIM_BLOCK_COBEGIN) ||
+                   blockInfo->isPrimitive(PRIM_BLOCK_COFORALL) ||
+                   blockInfo->isPrimitive(PRIM_BLOCK_BEGIN));
+        errorDotInsideWithClause(origUSE, blockInfo->primitive->name);
+        return;
+      }
+}
+
 
 static void resolveModuleCall(CallExpr* call, Vec<UnresolvedSymExpr*>& skipSet) {
   if (call->isNamed(".")) {

--- a/test/parallel/forall/forall.SEE_ALSO.txt
+++ b/test/parallel/forall/forall.SEE_ALSO.txt
@@ -1,0 +1,3 @@
+The following test also exercises forall:
+
+  test/parallel/taskPar/vass/errorFieldMethodInWithClause.chpl

--- a/test/parallel/taskPar/vass/errorFieldMethodInWithClause.chpl
+++ b/test/parallel/taskPar/vass/errorFieldMethodInWithClause.chpl
@@ -1,0 +1,55 @@
+
+const ITER = 1..3;
+
+class myClass {
+  var myField = 5;
+  proc myProcc return 6;
+}
+
+proc ourProc { return 7; }
+iter ourIter { yield 8; }
+
+proc something {}
+
+proc myClass.test {
+  forall ITER with (in myField) do
+    something();
+  forall ITER with (in myProcc) do
+    something;
+  forall ITER with (ref ourProc, ref ourIter) do
+    something;
+
+  cobegin with (in myField) {
+    something;
+    something;
+  }
+  cobegin with (in myProcc) {
+    something;
+    something;
+  }
+  cobegin with (ref ourProc, ref ourIter) {
+    something;
+    something;
+  }
+
+  coforall ITER with (in myField) do
+    something;
+  coforall ITER with (in myProcc) do
+    something;
+  coforall ITER with (ref ourProc, ref ourIter) do
+    something;
+
+ sync {
+  begin with (in myField)
+    { something;  }
+  begin with (in myProcc)
+    { something;  }
+  begin with (ref ourProc, ref ourIter)
+    { something;  }
+ }
+}
+
+proc main {
+  const mc = new myClass();
+  mc.test;
+}

--- a/test/parallel/taskPar/vass/errorFieldMethodInWithClause.good
+++ b/test/parallel/taskPar/vass/errorFieldMethodInWithClause.good
@@ -1,0 +1,17 @@
+errorFieldMethodInWithClause.chpl:15: error: myField: cannot reference a field or function in a 'with' clause of a forall loop
+errorFieldMethodInWithClause.chpl:14: In function 'test':
+errorFieldMethodInWithClause.chpl:17: error: myProcc: cannot reference a field or function in a 'with' clause of a forall loop
+errorFieldMethodInWithClause.chpl:19: error: ourProc: cannot reference a field or function in a 'with' clause of a forall loop
+errorFieldMethodInWithClause.chpl:19: error: ourIter: cannot reference a field or function in a 'with' clause of a forall loop
+errorFieldMethodInWithClause.chpl:22: error: myField: cannot reference a field or function in a 'with' clause of a cobegin block
+errorFieldMethodInWithClause.chpl:26: error: myProcc: cannot reference a field or function in a 'with' clause of a cobegin block
+errorFieldMethodInWithClause.chpl:30: error: ourProc: cannot reference a field or function in a 'with' clause of a cobegin block
+errorFieldMethodInWithClause.chpl:30: error: ourIter: cannot reference a field or function in a 'with' clause of a cobegin block
+errorFieldMethodInWithClause.chpl:35: error: myField: cannot reference a field or function in a 'with' clause of a coforall loop
+errorFieldMethodInWithClause.chpl:37: error: myProcc: cannot reference a field or function in a 'with' clause of a coforall loop
+errorFieldMethodInWithClause.chpl:39: error: ourProc: cannot reference a field or function in a 'with' clause of a coforall loop
+errorFieldMethodInWithClause.chpl:39: error: ourIter: cannot reference a field or function in a 'with' clause of a coforall loop
+errorFieldMethodInWithClause.chpl:43: error: myField: cannot reference a field or function in a 'with' clause of a begin block
+errorFieldMethodInWithClause.chpl:45: error: myProcc: cannot reference a field or function in a 'with' clause of a begin block
+errorFieldMethodInWithClause.chpl:47: error: ourProc: cannot reference a field or function in a 'with' clause of a begin block
+errorFieldMethodInWithClause.chpl:47: error: ourIter: cannot reference a field or function in a 'with' clause of a begin block


### PR DESCRIPTION
Syntactically, a with-clause consists of identifiers. Semantically,
those identifiers must refer to variables - global or local. If an
identifier in a with-clause instead references a field or paren-less
method of the current object or a paren-less function, we now generate
an error.

I put this check in this particular spot in scopeResolve. That's where
the compiler realizes that an UnresolvedSymExpr refers to a field or
function rather than a variable. So it's perfect to check whether it's
a with-clause, right there.

Alternatively we could iterate, separately, over all blocks or loops
that could have with clause. For each with clause, we could check
whether each element is a SymExpr or something else, and report an error
if it is the latter.