### PR TITLE
Cleanup some uses of je_mallctl in our jemalloc shim

### DIFF
--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -200,7 +200,7 @@ static void replaceChunkHooks(void) {
 }
 
 // helper routines to get a mallctl value
-#define DEFINE_GET_MALLCTL_VALUE(type) \
+#define DECLARE_GET_MALLCTL_VALUE(type) \
 static type get_ ## type ##_mallctl_value(const char* mallctl_string) { \
   type value; \
   size_t sz; \
@@ -212,8 +212,9 @@ static type get_ ## type ##_mallctl_value(const char* mallctl_string) { \
   } \
   return value; \
 }
-DEFINE_GET_MALLCTL_VALUE(size_t);
-DEFINE_GET_MALLCTL_VALUE(unsigned);
+DECLARE_GET_MALLCTL_VALUE(size_t);
+DECLARE_GET_MALLCTL_VALUE(unsigned);
+#undef DECLARE_GET_MALLCTL_VALUE
 
 // helper routines to get the number of size classes
 static unsigned get_num_small_classes(void) {


### PR DESCRIPTION
#3397 added a function (with a macro to define it for multiple types) to help
get information out of je_mallctl. It's a simple helper function that handles
the boilerplate code required to get a value from mallctl.

This just moves the definition of this function up (and undefs it after the
functions are declared) and uses it in get_num_arenas() instead of directly
calling the mallctl interface.