### PR TITLE
Correct typo of "communications"

### DIFF
--- a/tools/chplvis/ConcurrencyWin.cxx
+++ b/tools/chplvis/ConcurrencyWin.cxx
@@ -61,7 +61,7 @@ void ConcurrencyWin::updateData (long loc, long tag)
 void ConcurrencyWin::showCommBoxFor(taskData *task)
 {
   if (task->commSum.numComms == 0) {
-    fl_alert("Task has no communicastions to show.");
+    fl_alert("Task has no communications to show.");
   } else {
     scroll->hide();
 


### PR DESCRIPTION
Trivial typo correction. I tried to sweep this fix into larger PR, but @ronawho just wouldn't have it.