### PR TITLE
Minor clean up for miniMD

### DIFF
--- a/test/release/examples/benchmarks/miniMD/Makefile
+++ b/test/release/examples/benchmarks/miniMD/Makefile
@@ -18,7 +18,7 @@ clean: FORCE
 	cd explicit && $(MAKE) clean
 
 stencil: FORCE
-stencil: CHPL_FLAGS += -suseStencilDist=true -sdefaultDoRADOpt=false
+stencil: CHPL_FLAGS += -suseStencilDist=true
 stencil: $(TARGETS)
 
 miniMD: miniMD.chpl helpers/*.chpl

--- a/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
@@ -79,7 +79,6 @@ proc buildNeighbors() {
                                  binSpace, RealCount) {
     const existing = 1..c;
     for (a, p, i) in zip(bin[existing], pos[existing], existing) {
-  //    writeln("comparing to ", r, " at ", i, " with count ", c);
       a.ncount = 0;
 
       for s in stencil {
@@ -88,13 +87,11 @@ proc buildNeighbors() {
 
         for (n, x) in zip(Pos[o][existing], existing) {
           if r == o && x == i then continue; 
-    //      writeln("\t", o, " at ", x, " with pos ", n);
 
           // are we within range?
           const del = p - n;
           const rsq = dot(del,del);
           if rsq <= cutneighsq {
-      //      writeln("\t\tadded");
             a.ncount += 1;
 
             // resize neighbor list if necessary

--- a/test/release/examples/benchmarks/miniMD/miniMD.chpl
+++ b/test/release/examples/benchmarks/miniMD/miniMD.chpl
@@ -54,7 +54,7 @@ proc main() {
 proc initialIntegrate() {
   // On each Locale in parallel, and for each bin in parallel, 
   // update the velocity and position of the bin's atoms
-  forall (b,p,c) in zip(Bins, Pos[binSpace], Count[binSpace]) {
+  forall (b,p,c) in zip(Bins, RealPos, RealCount) {
     for (a,x) in zip(b[1..c], p[1..c]) {
       a.v += dtforce * a.f;
       x += dt * a.v;
@@ -67,7 +67,7 @@ proc finalIntegrate() {
   // On each Locale in parallel, and for each bin in parallel, 
   // update the velocity of the bin's atoms. We do this again so that 
   // the thermo computation has up-to-date values to work with.
-  forall (b,c) in zip(Bins, Count[binSpace]) {
+  forall (b,c) in zip(Bins, RealCount) {
     for a in b[1..c] {
       a.v += dtforce * a.f;
     }

--- a/test/studies/stencil9/stencil9-stencildist.compopts
+++ b/test/studies/stencil9/stencil9-stencildist.compopts
@@ -1,1 +1,1 @@
--sdefaultDoRADOpt=false -M../../release/examples/benchmarks/miniMD/helpers
+-M../../release/examples/benchmarks/miniMD/helpers


### PR DESCRIPTION
This PR cleans up a few things I noticed while doing some performance work on miniMD. None of these changes should impact performance.

I don't recall why I ever disabled the RAD optimization, but we have been testing miniMD successfully on 16-node-xc for a while without problems.