### PR TITLE
Add/fix annotations for this week

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -119,7 +119,7 @@ all:
       config: 16 node XC
   02/22/16:
     - Default to jemalloc for comm=none (#3333)
-  03/05/16:
+  03/04/16:
     - implemented doubling/halving for array-as-vec (#3380)
 
 AllCompTime:
@@ -446,5 +446,7 @@ time-write:
     - no strings with externs update
 
 timeVectorArray:
+  03/05/16:
+    - implemented doubling/halving for array-as-vec (#3380) (no timing from 4th)
   03/09/16:
     - increased array-as-vec problem size (#3422)

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -119,6 +119,8 @@ all:
       config: 16 node XC
   02/22/16:
     - Default to jemalloc for comm=none (#3333)
+  03/05/16:
+    - implemented doubling/halving for array-as-vec (#3380)
 
 AllCompTime:
   11/09/14:
@@ -317,6 +319,8 @@ memleaks:
     - Fixed string memory leak resulting from redundant autoCopies (#3023)
   01/14/16:
     - optimize certain functions that return with ref-intent (#3101)
+  03/10/16:
+    - Cleanups to miniMD (#3436)
 
 memleaksfull:
   07/08/14:
@@ -442,7 +446,5 @@ time-write:
     - no strings with externs update
 
 timeVectorArray:
-  03/05/16:
-    - implemented doubling/halving for array-as-vec (#3380)
-  03/08/16:
+  03/09/16:
     - increased array-as-vec problem size (#3422)


### PR DESCRIPTION
The array vector annotation for David's improvements needed to be applied more
broadly, as it affected more than just the test following it.  The other
annotation on that test was listed on the date the change went in, not the date
the change was observed (we've been trying to be consistent on that).  Also,
marked the improvement to memory leaks in examples from today's run to be Ben's
fixes to miniMD that went in yesterday.