### PR TITLE
Find easy_install for chpl-venv on cygwin

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -6,7 +6,18 @@ CHPL_MAKE_HOST_TARGET = --host
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 PYTHON = $(shell which python)
+ifneq (,$(findstring cygwin, $(CHPL_MAKE_TARGET_PLATFORM)))
+# easy_install from cygwin's setuptools is `easy_install-<MAJOR>.<MINOR>`
+# instead of `easy_install`. If we can't find easy_install, look for the
+# versioned one. Version is grabbed from python's `sys.version_info`
+PYTHON_VERSION = $(shell $(PYTHON) -c "from __future__ import print_function; \
+                                       import sys; \
+                                       ver=sys.version_info; \
+                                       print('{0}.{1}'.format(ver[0], ver[1]))")
+EASY_INSTALL = $(shell which easy_install 2>/dev/null || which easy_install-$(PYTHON_VERSION))
+else
 EASY_INSTALL = $(shell which easy_install)
+endif
 
 default: all
 


### PR DESCRIPTION
The easy_install that comes from setuptools on cygwin is named
`easy_install-<MAJOR>.<MINOR>` (e.g. easy_install-2.7) instead of just being
`easy_install`. This adds support to our makefile to look for
`easy_install-<MAJOR>.<MINOR>` if the plain `easy_install` wasn't found under
cygwin.

For our test machines, we typically just symlinked easy_install to
easy_install-2.7, but this seems like a cleaner solution, especially for users
who might want to use our testing system on their cygwin machines.