### PR TITLE
Test out perf of jemalloc's decay-based purging

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,8 +9,9 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of jemalloc 4.1.0
-#
+# Test performance of jemalloc 4.1.0 w/ decay-based purging
+
+export CHPL_JEMALLOC_MORE_CFG_OPTIONS="--with-malloc-conf=purge:decay"
 GITHUB_USER=ronawho
 GITHUB_BRANCH=upgrade-jemalloc
 SHORT_NAME=jemalloc


### PR DESCRIPTION
This is an opt-in feature for 4.1.0, but will probably become the default for
5.0. Test out the performance to see if we want to enable it now (it's supposed
to have pretty drastic performance impact.)

From the 4.1.0 release notes:

    Implement decay-based unused dirty page purging, a major optimization with
    mallctl API impact. This is an alternative to the existing ratio-based
    unused dirty page purging, and is intended to eventually become the sole
    purging mechanism.