### PR TITLE
Update perf testing of jemalloc's decay-based purging

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,17 +9,11 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of jemalloc 4.1.0 w/ decay-based purging
-
+# Test performance of jemalloc's decay-based purging
 export CHPL_JEMALLOC_MORE_CFG_OPTIONS="--with-malloc-conf=purge:decay"
-GITHUB_USER=ronawho
-GITHUB_BRANCH=upgrade-jemalloc
-SHORT_NAME=jemalloc
-START_DATE=03/07/16
+SHORT_NAME=decay-purge
+START_DATE=03/12/16
 
-git branch -D $GITHUB_USER-$GITHUB_BRANCH
-git checkout -b $GITHUB_USER-$GITHUB_BRANCH
-git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"


### PR DESCRIPTION
jemalloc 4.1.0 has been committed to master, so just use master instead of
checking out my jemalloc 4.1.0 branch