### PR TITLE
Fix hwloc /proc/mounts overflow

### DIFF
--- a/third-party/hwloc/README
+++ b/third-party/hwloc/README
@@ -10,3 +10,7 @@ convenience and was obtained from:
 Any Chapel issues that seem to be related to hwloc should be directed
 to the Chapel team at chapel-bugs@lists.sourceforge.net.
 
+In addition to the base 1.11.2 version, we have applied a patch taken from
+master in order fix an issue encountered with long /proc/mount entries:
+
+  https://github.com/open-mpi/hwloc/commit/d2d07b9

--- a/third-party/hwloc/hwloc-src/NEWS
+++ b/third-party/hwloc/hwloc-src/NEWS
@@ -1,5 +1,5 @@
 Copyright © 2009 CNRS
-Copyright © 2009-2015 Inria.  All rights reserved.
+Copyright © 2009-2016 Inria.  All rights reserved.
 Copyright © 2009-2013 Université Bordeaux
 Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
 
@@ -15,6 +15,12 @@ This file contains the main features as well as overviews of specific
 bug fixes (and other actions) for each version of hwloc since version
 0.9 (as initially released as "libtopology", then re-branded to "hwloc"
 in v0.9.1).
+
+
+Version 1.11.3
+--------------
+* Fix /proc/mounts parsing on Linux by using mntent.h.
+  Thanks to Nathan Hjelm for reporting the issue.
 
 
 Version 1.11.2


### PR DESCRIPTION
On some newer versions of CLE we were encountering an issue where long
/proc/mounts entries were overflowing a 512 byte buffer. It turns out this
issue was already reported and fixed on hwloc/master, but it won't make it into
an official version before our release:

  https://github.com/open-mpi/hwloc/issues/142

This just cherry-picks that commit and updates our hwloc README to mention it.