### PR TITLE
GCC 5.10 workaround

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5851,6 +5851,7 @@ preFold(Expr* expr) {
         fieldcount++;
         if (fieldcount == fieldnum) {
           name = field->name;
+          // break could be here, but might have issues with GCC 5.10
         }
       }
       if (!name) {
@@ -5882,7 +5883,7 @@ preFold(Expr* expr) {
         fieldcount++;
         if (fieldcount == fieldnum) {
           name = field->name;
-          break;
+          // break could be here, but seems to cause issues with GCC 5.10
         }
       }
       if (!name) {
@@ -5916,7 +5917,7 @@ preFold(Expr* expr) {
         fieldcount++;
         if ( 0 == strcmp(field->name,  fieldname) ) {
           num = fieldcount;
-          break;
+          // break could be here, but might have issues with GCC 5.10
         }
       }
       result = new SymExpr(new_IntSymbol(num));


### PR DESCRIPTION
We've been having problems with GCC 5.10 with errors along the lines of:

      error: '<field>' is not a valid field number for <class/record>

e.g. with the test.

      test/release/examples/primers/classes.chpl

I tried to create a small C++ reproducer, but it didn't reproduce. I was
observing (in adding prints) that the for_fields iteration would normally
go over 3 fields but would stop early if the break statement is there...
E.g. if the fields are super, a, b - the loop containing the break
statement would only consider super, a (even if the break statement
should be dynamically executed after considering b).

Removing the break statements lets it work again and only has a minor
compile performance cost. It should have the same functionality.

Ubuntu Wily with GCC 5.2.1 also has this problem.  The GCC issues only
occur with optimizations (OPTIMIZE=1).  Turning on debug does not seem to
matter (DEBUG=1).

This patch removes the break statements that seem to be misbehaving in
order to prevent these errors with the affected versions of GCC.  I did
not figure out if the problem is a GCC bug or a problem in the Chapel
compiler source code. It is certainly a strange problem.

Passed full local testing.
Not reviewed.