### PR TITLE
'make check' for Sphinx Documentation

### DIFF
--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -63,6 +63,13 @@ html: symlink-docs check-sphinxbuild clean-build
 	@echo
 	@echo "Build finished. The HTML pages are in "'$(BUILDPATH)'"/html."
 
+check: symlink-docs check-sphinxbuild clean-build
+	@echo "Checking for dead links and cross-references"
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	chmod -R ugo+rX $(BUILDDIR)
+	@echo
+	@echo "Build finished. The HTML pages are in "'$(BUILDPATH)'"/html."
+
 dirhtml:  symlink-docs check-sphinxbuild clean-build
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo

--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -65,7 +65,7 @@ html: symlink-docs check-sphinxbuild clean-build
 
 check: symlink-docs check-sphinxbuild clean-build
 	@echo "Checking for dead links and cross-references"
-	$(SPHINXBUILD) -n -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -n -b linkcheck -d $(BUILDDIR)/doctrees source $(BUILDDIR)/html
 	chmod -R ugo+rX $(BUILDDIR)
 	@echo
 	@echo "Build finished. The HTML pages are in "'$(BUILDPATH)'"/html."

--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -65,7 +65,7 @@ html: symlink-docs check-sphinxbuild clean-build
 
 check: symlink-docs check-sphinxbuild clean-build
 	@echo "Checking for dead links and cross-references"
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -n -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	chmod -R ugo+rX $(BUILDDIR)
 	@echo
 	@echo "Build finished. The HTML pages are in "'$(BUILDPATH)'"/html."

--- a/doc/sphinx/source/tools/chpldoc/chpldoc.rst
+++ b/doc/sphinx/source/tools/chpldoc/chpldoc.rst
@@ -618,7 +618,7 @@ developed by the docutils_ projects and is amended by custom directives to
 support documenting Chapel code. Sphinx_ is used by ``chpldoc`` to render
 reStructuredText as HTML.
 
-.. _reStructuredText: http://docutils.sf.net/rst.html
+.. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _docutils: http://docutils.sourceforge.net/
 .. _Sphinx: http://www.sphinx-doc.org/en/stable/
 

--- a/doc/sphinx/source/tools/chpldoc/chpldoc.rst
+++ b/doc/sphinx/source/tools/chpldoc/chpldoc.rst
@@ -216,7 +216,7 @@ primers (some of the text is copied verbatim).
 
 The authoritative `reStructuredText User Guide`_ is also helpful.
 
-.. _Sphinx reST Primer: http://sphinx-doc.org/rest.html
+.. _Sphinx reST Primer: http://www.sphinx-doc.org/en/stable/rest.html
 .. _Python reST Primer: https://docs.python.org/devguide/documenting.html#restructuredtext-primer
 .. _reStructuredText User Guide: http://docutils.sourceforge.net/rst.html
 
@@ -620,7 +620,7 @@ reStructuredText as HTML.
 
 .. _reStructuredText: http://docutils.sf.net/rst.html
 .. _docutils: http://docutils.sourceforge.net/
-.. _Sphinx: http://sphinx-doc.org/
+.. _Sphinx: http://www.sphinx-doc.org/en/stable/
 
 
 .. _Future directions:

--- a/modules/standard/Curl.chpl
+++ b/modules/standard/Curl.chpl
@@ -488,10 +488,10 @@ extern const curlopt_low_speed_time             : c_int ;
 extern const curlopt_resume_from                : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_COOKIE.html */
 extern const curlopt_cookie                     : c_int ;
-/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsHEADER.html */
-extern const curlopt_httpsheader                 : c_int ;
-/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsPOST.html */
-extern const curlopt_httpspost                   : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HTTPHEADER.html */
+extern const curlopt_httpheader                 : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HTTPPOST.html */
+extern const curlopt_httppost                   : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_SSLCERT.html */
 extern const curlopt_sslcert                    : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_KEYPASSWD.html */
@@ -554,8 +554,8 @@ extern const curlopt_autoreferer                : c_int ;
 extern const curlopt_proxyport                  : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_POSTFIELDSIZE.html */
 extern const curlopt_postfieldsize              : c_int ;
-/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsPROXYTUNNEL.html */
-extern const curlopt_httpsproxytunnel            : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HTTPPROXYTUNNEL.html */
+extern const curlopt_httpproxytunnel            : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_INTERFACE.html */
 extern const curlopt_interface                  : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_KRBLEVEL.html */
@@ -586,16 +586,16 @@ extern const curlopt_egdsocket                  : c_int ;
 extern const curlopt_connecttimeout             : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html */
 extern const curlopt_headerfunction             : c_int ;
-/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsGET.html */
-extern const curlopt_httpsget                    : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HTTPGET.html */
+extern const curlopt_httpget                    : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html */
 extern const curlopt_ssl_verifyhost             : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_COOKIEJAR.html */
 extern const curlopt_cookiejar                  : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CIPHER_LIST.html */
 extern const curlopt_ssl_cipher_list            : c_int ;
-/* See https://curl.haxx.se/libcurl/c/CURLOPT_https_VERSION.html */
-extern const curlopt_https_version               : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HTTP_VERSION.html */
+extern const curlopt_http_version               : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_USE_EPSV.html */
 extern const curlopt_ftp_use_epsv               : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_SSLCERTTYPE.html */
@@ -634,14 +634,14 @@ extern const curlopt_proxytype                  : c_int ;
 extern const curlopt_encoding                   : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_PRIVATE.html */
 extern const curlopt_private                    : c_int ;
-/* See https://curl.haxx.se/libcurl/c/CURLOPT_https200ALIASES.html */
-extern const curlopt_https200aliases             : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HTTP200ALIASES.html */
+extern const curlopt_http200aliases             : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_UNRESTRICTED_AUTH.html */
 extern const curlopt_unrestricted_auth          : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_USE_EPRT.html */
 extern const curlopt_ftp_use_eprt               : c_int ;
-/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsAUTH.html */
-extern const curlopt_httpsauth                   : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HTTPAUTH.html */
+extern const curlopt_httpauth                   : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_FUNCTION.html */
 extern const curlopt_ssl_ctx_function           : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_DATA.html */
@@ -722,10 +722,10 @@ extern const curlopt_ftp_ssl_ccc                : c_int ;
 extern const curlopt_timeout_ms                 : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html */
 extern const curlopt_connecttimeout_ms          : c_int ;
-/* See https://curl.haxx.se/libcurl/c/CURLOPT_https_TRANSFER_DECODING.html */
-extern const curlopt_https_transfer_decoding     : c_int ;
-/* See https://curl.haxx.se/libcurl/c/CURLOPT_https_CONTENT_DECODING.html */
-extern const curlopt_https_content_decoding      : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HTTP_TRANSFER_DECODING.html */
+extern const curlopt_http_transfer_decoding     : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HTTP_CONTENT_DECODING.html */
+extern const curlopt_http_content_decoding      : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_NEW_FILE_PERMS.html */
 extern const curlopt_new_file_perms             : c_int ;
 /* See https://curl.haxx.se/libcurl/c/CURLOPT_NEW_DIRECTORY_PERMS.html */

--- a/modules/standard/Curl.chpl
+++ b/modules/standard/Curl.chpl
@@ -29,9 +29,9 @@ The `curl homepage <https://curl.haxx.se/libcurl/>`_ describes libcurl thus::
  libcurl is a free and easy-to-use client-side URL transfer library, supporting
  DICT, FILE, FTP, FTPS, Gopher, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS, POP3,
  POP3S, RTMP, RTSP, SCP, SFTP, SMTP, SMTPS, Telnet and TFTP.  libcurl supports
- SSL certificates, https POST, https PUT, FTP uploading, https form based upload,
+ SSL certificates, HTTP POST, HTTP PUT, FTP uploading, HTTP form based upload,
  proxies, cookies, user+password authentication (Basic, Digest, NTLM,
- Negotiate, Kerberos), file transfer resume, https proxy tunneling and more! 
+ Negotiate, Kerberos), file transfer resume, http proxy tunneling and more! 
 
 Dependencies
 ------------

--- a/modules/standard/Curl.chpl
+++ b/modules/standard/Curl.chpl
@@ -8,7 +8,7 @@
  * 
  * You may obtain a copy of the License at
  * 
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,21 +24,21 @@ Simple support for many network protocols with libcurl
 This module provides support for libcurl, enabling Chapel programs
 to work with many network protocols. 
 
-The `curl homepage <http://curl.haxx.se/libcurl/>`_ describes libcurl thus::
+The `curl homepage <https://curl.haxx.se/libcurl/>`_ describes libcurl thus::
 
  libcurl is a free and easy-to-use client-side URL transfer library, supporting
- DICT, FILE, FTP, FTPS, Gopher, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS, POP3,
+ DICT, FILE, FTP, FTPS, Gopher, https, httpsS, IMAP, IMAPS, LDAP, LDAPS, POP3,
  POP3S, RTMP, RTSP, SCP, SFTP, SMTP, SMTPS, Telnet and TFTP.  libcurl supports
- SSL certificates, HTTP POST, HTTP PUT, FTP uploading, HTTP form based upload,
+ SSL certificates, https POST, https PUT, FTP uploading, https form based upload,
  proxies, cookies, user+password authentication (Basic, Digest, NTLM,
- Negotiate, Kerberos), file transfer resume, http proxy tunneling and more! 
+ Negotiate, Kerberos), file transfer resume, https proxy tunneling and more! 
 
 Dependencies
 ------------
 
 The Curl functionality in Chapel is dependent on libcurl. For information on
 how to install libcurl, see the
-`curl installation instructions <http://curl.haxx.se/docs/install.html>`_
+`curl installation instructions <https://curl.haxx.se/docs/install.html>`_
 
 The environment variables CHPL_AUXIO_INCLUDE and CHPL_AUXIO_LIBS must be set to
 point to the include and lib directories for libcurl respectively. More
@@ -106,21 +106,21 @@ Interface 1:
 
     .. code-block:: chapel
 
-      open(url="http://example.com", iomode.r);
+      open(url="https://example.com", iomode.r);
 
     will result in a compile time error. You would, instead, need to use:
 
     .. code-block:: chapel
 
-      open(url="http://example.com", mode=iomode.r).
+      open(url="https://example.com", mode=iomode.r).
 
 
 Interface 2:
-  Many times when we are connecting to a URL (FTP, IMAP, SMTP, HTTP) we have to
+  Many times when we are connecting to a URL (FTP, IMAP, SMTP, https) we have to
   give extra information to the Curl handle. This is done via the setopt()
   interface.  Documentation on the various options, as well as the functions
   that are referenced below can be found `here
-  <http://curl.haxx.se/libcurl/c/libcurl-easy.html>`_
+  <https://curl.haxx.se/libcurl/c/libcurl-easy.html>`_
 
   Types:
     * :record:`slist`
@@ -145,7 +145,7 @@ Example 1
 
   var writer = openwriter("out.txt");
   // Open a URL and get a reader on a section of the site
-  var reader = openreader(url="http://example.com");
+  var reader = openreader(url="https://example.com");
 
   var str:string;
 
@@ -160,12 +160,12 @@ Example 2
 
   // This example uses the first interface
   var str:string;
-  var reader = openreader(url="http://example.com");
+  var reader = openreader(url="https://example.com");
   reader.readstring(str);
   reader.close();
 
   // Write out to a URL via Curl
-  var writer = openwriter("http://127.0.0.1:1080");
+  var writer = openwriter("https://127.0.0.1:1080");
   writer.write(str);
   writer.close();
 
@@ -177,7 +177,7 @@ Example 3
   // Open a file on our local file system
   var f = openwriter("out.txt");
   // Now get a curl handle
-  var c = openreader(url="http://example.com");
+  var c = openreader(url="https://example.com");
   var str:string;
 
   // Read from example.com and write it out to out.txt
@@ -198,7 +198,7 @@ Example 4
   // This example uses the second interface
 
   // Open a file with a curl handle as the internal file
-  var c = open(url="http://example.com", mode=iomode.r);
+  var c = open(url="https://example.com", mode=iomode.r);
   // do a standard perform operation on the underlying curl handle
   c.perform(); // This will print to stdout
   // disconnect and free the curl handle
@@ -212,7 +212,7 @@ Example 5
 
   // This example uses the second interface + the first interface
 
-  var c = open(url="http://example.com", mode=iomode.r);
+  var c = open(url="https://example.com", mode=iomode.r);
   var str:string;
   // Set verbose output from curl
   c.setopt(curlopt_verbose, true);
@@ -329,7 +329,7 @@ private extern proc chpl_curl_slist_free(list:chpl_slist);
 private extern const CHPL_CURL_SLIST_NULL:chpl_slist;
 
 /* This function is the equivalent to the 
-   `curl_easy_setopt <http://curl.haxx.se/libcurl/c/curl_easy_setopt.html>`_
+   `curl_easy_setopt <https://curl.haxx.se/libcurl/c/curl_easy_setopt.html>`_
    function in libcurl. It sets information on the curl file handle
    that can change libcurl's behavior.
 
@@ -375,10 +375,10 @@ proc file.setopt(args ...?k) {
 
 /* Perform any blocking file transfer operations on the curl file.
    This function calls
-   `curl_easy_perform <http://curl.haxx.se/libcurl/c/curl_easy_perform.html>`_.
+   `curl_easy_perform <https://curl.haxx.se/libcurl/c/curl_easy_perform.html>`_.
  
    Corresponds to
-   `curl_easy_perform <http://curl.haxx.se/libcurl/c/curl_easy_perform.html>`_
+   `curl_easy_perform <https://curl.haxx.se/libcurl/c/curl_easy_perform.html>`_
    where the file has been opened up by specifying that `url=<some url>`.
 
    :returns: true on success. This version halts if an error is encountered,
@@ -417,7 +417,7 @@ record slist {
 
 /* Append the string argument to an slist. This function is the same
    as calling
-   `curl_slist_append <http://curl.haxx.se/libcurl/c/curl_slist_append.html>`_
+   `curl_slist_append <https://curl.haxx.se/libcurl/c/curl_slist_append.html>`_
    
    This function halts if an error is encountered. Future versions will
    support returning an error code instead of halting.
@@ -446,341 +446,341 @@ proc slist.free() {
 // has access to the easy interface.
 
 
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_WRITEDATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_WRITEDATA.html */
 extern const curlopt_file                       : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_URL.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_URL.html */
 extern const curlopt_url                        : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PORT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PORT.html */
 extern const curlopt_port                       : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html */
 extern const curlopt_proxy                      : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_USERPWD.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_USERPWD.html */
 extern const curlopt_userpwd                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROXYUSERPWD.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROXYUSERPWD.html */
 extern const curlopt_proxyuserpwd               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_RANGE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_RANGE.html */
 extern const curlopt_range                      : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_READDATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_READDATA.html */
 extern const curlopt_infile                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_ERRORBUFFER.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_ERRORBUFFER.html */
 extern const curlopt_errorbuffer                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html */
 extern const curlopt_writefunction              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_READFUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_READFUNCTION.html */
 extern const curlopt_readfunction               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT.html */
 extern const curlopt_timeout                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_INFILESIZE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_INFILESIZE.html */
 extern const curlopt_infilesize                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_POSTFIELDS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_POSTFIELDS.html */
 extern const curlopt_postfields                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_REFERER.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_REFERER.html */
 extern const curlopt_referer                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTPPORT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTPPORT.html */
 extern const curlopt_ftpport                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_USERAGENT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_USERAGENT.html */
 extern const curlopt_useragent                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_LOW_SPEED_LIMIT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_LOW_SPEED_LIMIT.html */
 extern const curlopt_low_speed_limit            : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_LOW_SPEED_TIME.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_LOW_SPEED_TIME.html */
 extern const curlopt_low_speed_time             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_RESUME_FROM.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_RESUME_FROM.html */
 extern const curlopt_resume_from                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_COOKIE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_COOKIE.html */
 extern const curlopt_cookie                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HTTPHEADER.html */
-extern const curlopt_httpheader                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HTTPPOST.html */
-extern const curlopt_httppost                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSLCERT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsHEADER.html */
+extern const curlopt_httpsheader                 : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsPOST.html */
+extern const curlopt_httpspost                   : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSLCERT.html */
 extern const curlopt_sslcert                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_KEYPASSWD.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_KEYPASSWD.html */
 extern const curlopt_keypasswd                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CRLF.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CRLF.html */
 extern const curlopt_crlf                       : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_QUOTE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_QUOTE.html */
 extern const curlopt_quote                      : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HEADERDATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HEADERDATA.html */
 extern const curlopt_writeheader                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_COOKIEFILE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_COOKIEFILE.html */
 extern const curlopt_cookiefile                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSLVERSION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSLVERSION.html */
 extern const curlopt_sslversion                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_TIMECONDITION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_TIMECONDITION.html */
 extern const curlopt_timecondition              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_TIMEVALUE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_TIMEVALUE.html */
 extern const curlopt_timevalue                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CUSTOMREQUEST.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CUSTOMREQUEST.html */
 extern const curlopt_customrequest              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_STDERR.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_STDERR.html */
 extern const curlopt_stderr                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_POSTQUOTE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_POSTQUOTE.html */
 extern const curlopt_postquote                  : c_int ;
 /* This curlopt setting is deprecated */
 extern const curlopt_writeinfo                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_VERBOSE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_VERBOSE.html */
 extern const curlopt_verbose                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HEADER.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HEADER.html */
 extern const curlopt_header                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_NOPROGRESS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_NOPROGRESS.html */
 extern const curlopt_noprogress                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_NOBODY.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_NOBODY.html */
 extern const curlopt_nobody                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FAILONERROR.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FAILONERROR.html */
 extern const curlopt_failonerror                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_UPLOAD.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_UPLOAD.html */
 extern const curlopt_upload                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_POST.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_POST.html */
 extern const curlopt_post                       : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_DIRLISTONLY.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_DIRLISTONLY.html */
 extern const curlopt_dirlistonly                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_APPEND.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_APPEND.html */
 extern const curlopt_append                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_NETRC.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_NETRC.html */
 extern const curlopt_netrc                      : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html */
 extern const curlopt_followlocation             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_TRANSFERTEXT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_TRANSFERTEXT.html */
 extern const curlopt_transfertext               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PUT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PUT.html */
 extern const curlopt_put                        : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html */
 extern const curlopt_progressfunction           : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROGRESSDATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROGRESSDATA.html */
 extern const curlopt_progressdata               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_AUTOREFERER.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_AUTOREFERER.html */
 extern const curlopt_autoreferer                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROXYPORT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROXYPORT.html */
 extern const curlopt_proxyport                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_POSTFIELDSIZE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_POSTFIELDSIZE.html */
 extern const curlopt_postfieldsize              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HTTPPROXYTUNNEL.html */
-extern const curlopt_httpproxytunnel            : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_INTERFACE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsPROXYTUNNEL.html */
+extern const curlopt_httpsproxytunnel            : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_INTERFACE.html */
 extern const curlopt_interface                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_KRBLEVEL.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_KRBLEVEL.html */
 extern const curlopt_krblevel                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html */
 extern const curlopt_ssl_verifypeer             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html */
 extern const curlopt_cainfo                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_MAXREDIRS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_MAXREDIRS.html */
 extern const curlopt_maxredirs                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FILETIME.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FILETIME.html */
 extern const curlopt_filetime                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_TELNETOPTIONS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_TELNETOPTIONS.html */
 extern const curlopt_telnetoptions              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_MAXCONNECTS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_MAXCONNECTS.html */
 extern const curlopt_maxconnects                : c_int ;
 /* This option is deprecated */
 extern const curlopt_closepolicy                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FRESH_CONNECT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FRESH_CONNECT.html */
 extern const curlopt_fresh_connect              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FORBID_REUSE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FORBID_REUSE.html */
 extern const curlopt_forbid_reuse               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_RANDOM_FILE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_RANDOM_FILE.html */
 extern const curlopt_random_file                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_EGDSOCKET.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_EGDSOCKET.html */
 extern const curlopt_egdsocket                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html */
 extern const curlopt_connecttimeout             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html */
 extern const curlopt_headerfunction             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HTTPGET.html */
-extern const curlopt_httpget                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsGET.html */
+extern const curlopt_httpsget                    : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html */
 extern const curlopt_ssl_verifyhost             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_COOKIEJAR.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_COOKIEJAR.html */
 extern const curlopt_cookiejar                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSL_CIPHER_LIST.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CIPHER_LIST.html */
 extern const curlopt_ssl_cipher_list            : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HTTP_VERSION.html */
-extern const curlopt_http_version               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTP_USE_EPSV.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_https_VERSION.html */
+extern const curlopt_https_version               : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_USE_EPSV.html */
 extern const curlopt_ftp_use_epsv               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSLCERTTYPE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSLCERTTYPE.html */
 extern const curlopt_sslcerttype                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSLKEY.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSLKEY.html */
 extern const curlopt_sslkey                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSLKEYTYPE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSLKEYTYPE.html */
 extern const curlopt_sslkeytype                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSLENGINE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSLENGINE.html */
 extern const curlopt_sslengine                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSLENGINE_DEFAULT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSLENGINE_DEFAULT.html */
 extern const curlopt_sslengine_default          : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_DNS_USE_GLOBAL_CACHE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_DNS_USE_GLOBAL_CACHE.html */
 extern const curlopt_dns_use_global_cache       : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_DNS_CACHE_TIMEOUT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_DNS_CACHE_TIMEOUT.html */
 extern const curlopt_dns_cache_timeout          : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PREQUOTE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PREQUOTE.html */
 extern const curlopt_prequote                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_DEBUGFUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_DEBUGFUNCTION.html */
 extern const curlopt_debugfunction              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_DEBUGDATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_DEBUGDATA.html */
 extern const curlopt_debugdata                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_COOKIESESSION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_COOKIESESSION.html */
 extern const curlopt_cookiesession              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CAPATH.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CAPATH.html */
 extern const curlopt_capath                     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_BUFFERSIZE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_BUFFERSIZE.html */
 extern const curlopt_buffersize                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_NOSIGNAL.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_NOSIGNAL.html */
 extern const curlopt_nosignal                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SHARE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SHARE.html */
 extern const curlopt_share                      : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROXYTYPE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROXYTYPE.html */
 extern const curlopt_proxytype                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html */
 extern const curlopt_encoding                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PRIVATE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PRIVATE.html */
 extern const curlopt_private                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HTTP200ALIASES.html */
-extern const curlopt_http200aliases             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_UNRESTRICTED_AUTH.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_https200ALIASES.html */
+extern const curlopt_https200aliases             : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_UNRESTRICTED_AUTH.html */
 extern const curlopt_unrestricted_auth          : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTP_USE_EPRT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_USE_EPRT.html */
 extern const curlopt_ftp_use_eprt               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HTTPAUTH.html */
-extern const curlopt_httpauth                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_FUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_httpsAUTH.html */
+extern const curlopt_httpsauth                   : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_FUNCTION.html */
 extern const curlopt_ssl_ctx_function           : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_DATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_DATA.html */
 extern const curlopt_ssl_ctx_data               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTP_CREATE_MISSING_DIRS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_CREATE_MISSING_DIRS.html */
 extern const curlopt_ftp_create_missing_dirs    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROXYAUTH.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROXYAUTH.html */
 extern const curlopt_proxyauth                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTP_RESPONSE_TIMEOUT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_RESPONSE_TIMEOUT.html */
 extern const curlopt_ftp_response_timeout       : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_IPRESOLVE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_IPRESOLVE.html */
 extern const curlopt_ipresolve                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_MAXFILESIZE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_MAXFILESIZE.html */
 extern const curlopt_maxfilesize                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_INFILESIZE_LARGE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_INFILESIZE_LARGE.html */
 extern const curlopt_infilesize_large           : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_RESUME_FROM_LARGE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_RESUME_FROM_LARGE.html */
 extern const curlopt_resume_from_large          : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_MAXFILESIZE_LARGE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_MAXFILESIZE_LARGE.html */
 extern const curlopt_maxfilesize_large          : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_NETRC_FILE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_NETRC_FILE.html */
 extern const curlopt_netrc_file                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_USE_SSL.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_USE_SSL.html */
 extern const curlopt_use_ssl                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_POSTFIELDSIZE_LARGE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_POSTFIELDSIZE_LARGE.html */
 extern const curlopt_postfieldsize_large        : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_TCP_NODELAY.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_TCP_NODELAY.html */
 extern const curlopt_tcp_nodelay                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTPSSLAUTH.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTPSSLAUTH.html */
 extern const curlopt_ftpsslauth                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_IOCTLFUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_IOCTLFUNCTION.html */
 extern const curlopt_ioctlfunction              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_IOCTLDATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_IOCTLDATA.html */
 extern const curlopt_ioctldata                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTP_ACCOUNT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_ACCOUNT.html */
 extern const curlopt_ftp_account                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_COOKIELIST.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_COOKIELIST.html */
 extern const curlopt_cookielist                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_IGNORE_CONTENT_LENGTH.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_IGNORE_CONTENT_LENGTH.html */
 extern const curlopt_ignore_content_length      : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTP_SKIP_PASV_IP.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_SKIP_PASV_IP.html */
 extern const curlopt_ftp_skip_pasv_ip           : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTP_FILEMETHOD.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_FILEMETHOD.html */
 extern const curlopt_ftp_filemethod             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_LOCALPORT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_LOCALPORT.html */
 extern const curlopt_localport                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_LOCALPORTRANGE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_LOCALPORTRANGE.html */
 extern const curlopt_localportrange             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CONNECT_ONLY.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CONNECT_ONLY.html */
 extern const curlopt_connect_only               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CONV_FROM_NETWORK_FUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CONV_FROM_NETWORK_FUNCTION.html */
 extern const curlopt_conv_from_network_function : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CONV_TO_NETWORK_FUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CONV_TO_NETWORK_FUNCTION.html */
 extern const curlopt_conv_to_network_function   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CONV_FROM_UTF8_FUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CONV_FROM_UTF8_FUNCTION.html */
 extern const curlopt_conv_from_utf8_function    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_MAX_SEND_SPEED_LARGE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_MAX_SEND_SPEED_LARGE.html */
 extern const curlopt_max_send_speed_large       : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_MAX_RECV_SPEED_LARGE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_MAX_RECV_SPEED_LARGE.html */
 extern const curlopt_max_recv_speed_large       : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTP_ALTERNATIVE_TO_USER.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_ALTERNATIVE_TO_USER.html */
 extern const curlopt_ftp_alternative_to_user    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SOCKOPTFUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SOCKOPTFUNCTION.html */
 extern const curlopt_sockoptfunction            : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SOCKOPTDATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SOCKOPTDATA.html */
 extern const curlopt_sockoptdata                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSL_SESSIONID_CACHE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSL_SESSIONID_CACHE.html */
 extern const curlopt_ssl_sessionid_cache        : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSH_AUTH_TYPES.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSH_AUTH_TYPES.html */
 extern const curlopt_ssh_auth_types             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSH_PUBLIC_KEYFILE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSH_PUBLIC_KEYFILE.html */
 extern const curlopt_ssh_public_keyfile         : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSH_PRIVATE_KEYFILE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSH_PRIVATE_KEYFILE.html */
 extern const curlopt_ssh_private_keyfile        : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_FTP_SSL_CCC.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_FTP_SSL_CCC.html */
 extern const curlopt_ftp_ssl_ccc                : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT_MS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT_MS.html */
 extern const curlopt_timeout_ms                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html */
 extern const curlopt_connecttimeout_ms          : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HTTP_TRANSFER_DECODING.html */
-extern const curlopt_http_transfer_decoding     : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_HTTP_CONTENT_DECODING.html */
-extern const curlopt_http_content_decoding      : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_NEW_FILE_PERMS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_https_TRANSFER_DECODING.html */
+extern const curlopt_https_transfer_decoding     : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_https_CONTENT_DECODING.html */
+extern const curlopt_https_content_decoding      : c_int ;
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_NEW_FILE_PERMS.html */
 extern const curlopt_new_file_perms             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_NEW_DIRECTORY_PERMS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_NEW_DIRECTORY_PERMS.html */
 extern const curlopt_new_directory_perms        : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_POSTREDIR.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_POSTREDIR.html */
 extern const curlopt_postredir                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.html */
 extern const curlopt_ssh_host_public_key_md5    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_OPENSOCKETFUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_OPENSOCKETFUNCTION.html */
 extern const curlopt_opensocketfunction         : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_OPENSOCKETDATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_OPENSOCKETDATA.html */
 extern const curlopt_opensocketdata             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_COPYPOSTFIELDS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_COPYPOSTFIELDS.html */
 extern const curlopt_copypostfields             : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROXY_TRANSFER_MODE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROXY_TRANSFER_MODE.html */
 extern const curlopt_proxy_transfer_mode        : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SEEKFUNCTION.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SEEKFUNCTION.html */
 extern const curlopt_seekfunction               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SEEKDATA.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SEEKDATA.html */
 extern const curlopt_seekdata                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CRLFILE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CRLFILE.html */
 extern const curlopt_crlfile                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_ISSUERCERT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_ISSUERCERT.html */
 extern const curlopt_issuercert                 : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_ADDRESS_SCOPE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_ADDRESS_SCOPE.html */
 extern const curlopt_address_scope              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_CERTINFO.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_CERTINFO.html */
 extern const curlopt_certinfo                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_USERNAME.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_USERNAME.html */
 extern const curlopt_username                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PASSWORD.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PASSWORD.html */
 extern const curlopt_password                   : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROXYUSERNAME.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROXYUSERNAME.html */
 extern const curlopt_proxyusername              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROXYPASSWORD.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROXYPASSWORD.html */
 extern const curlopt_proxypassword              : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_NOPROXY.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_NOPROXY.html */
 extern const curlopt_noproxy                    : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_TFTP_BLKSIZE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_TFTP_BLKSIZE.html */
 extern const curlopt_tftp_blksize               : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SOCKS5_GSSAPI_SERVICE.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SOCKS5_GSSAPI_SERVICE.html */
 extern const curlopt_socks5_gssapi_service      : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_SOCKS5_GSSAPI_NEC.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_SOCKS5_GSSAPI_NEC.html */
 extern const curlopt_socks5_gssapi_nec          : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_PROTOCOLS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_PROTOCOLS.html */
 extern const curlopt_protocols                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_REDIR_PROTOCOLS.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_REDIR_PROTOCOLS.html */
 extern const curlopt_redir_protocols            : c_int ;
 /* All other curlopt values will be less than this one */
 extern const curlopt_lastentry                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_MAIL_FROM.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_MAIL_FROM.html */
 extern const curlopt_mail_from                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_MAIL_RCPT.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_MAIL_RCPT.html */
 extern const curlopt_mail_rcpt                  : c_int ;
-/* See http://curl.haxx.se/libcurl/c/CURLOPT_MAIL_AUTH.html */
+/* See https://curl.haxx.se/libcurl/c/CURLOPT_MAIL_AUTH.html */
 extern const curlopt_mail_auth                  : c_int ;
 
 } /* end of module */

--- a/modules/standard/Curl.chpl
+++ b/modules/standard/Curl.chpl
@@ -116,7 +116,7 @@ Interface 1:
 
 
 Interface 2:
-  Many times when we are connecting to a URL (FTP, IMAP, SMTP, https) we have to
+  Many times when we are connecting to a URL (FTP, IMAP, SMTP, HTTP) we have to
   give extra information to the Curl handle. This is done via the setopt()
   interface.  Documentation on the various options, as well as the functions
   that are referenced below can be found `here

--- a/modules/standard/Curl.chpl
+++ b/modules/standard/Curl.chpl
@@ -27,7 +27,7 @@ to work with many network protocols.
 The `curl homepage <https://curl.haxx.se/libcurl/>`_ describes libcurl thus::
 
  libcurl is a free and easy-to-use client-side URL transfer library, supporting
- DICT, FILE, FTP, FTPS, Gopher, https, httpsS, IMAP, IMAPS, LDAP, LDAPS, POP3,
+ DICT, FILE, FTP, FTPS, Gopher, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS, POP3,
  POP3S, RTMP, RTSP, SCP, SFTP, SMTP, SMTPS, Telnet and TFTP.  libcurl supports
  SSL certificates, https POST, https PUT, FTP uploading, https form based upload,
  proxies, cookies, user+password authentication (Basic, Digest, NTLM,

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -105,7 +105,7 @@ Calling GMP functions directly
 
 The second option for Chapel programs using this module is to call the GMP
 functions directly. For a full reference to GMP capabilities, please refer to
-the `GMP website <http://gmplib.org>`_ and the
+the `GMP website <https://gmplib.org>`_ and the
 `GMP documentation <https://gmplib.org/manual/>`_.
 
 

--- a/modules/standard/HDFS.chpl
+++ b/modules/standard/HDFS.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,8 +21,8 @@
 
 Support for Hadoop Distributed Filesystem
 
-This module implements support for the 
-`Hadoop <http://hadoop.apache.org/>`_ 
+This module implements support for the
+`Hadoop <http://hadoop.apache.org/>`_
 `Distributed Filesystem <http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html>`_ (HDFS).
 
 Dependencies
@@ -34,7 +34,7 @@ environment variables must be set as described below in
 :ref:`setting-up-hadoop`.  Without this it will not compile with HDFS, even if
 the flags are set. As well, the HDFS functionality is also dependent upon the
 ``CHPL_AUXIO_INCLUDE`` and ``CHPL_AUXIO_LIBS`` environment variables being set
-properly. For more information on how to set these properly, see 
+properly. For more information on how to set these properly, see
 doc/technotes/auxIO.rst in a Chapel release.
 
 
@@ -143,7 +143,7 @@ modes that are supported, due to HDFS limitations).
 
 .. _setting-up-hadoop:
 
-Setting up Hadoop 
+Setting up Hadoop
 -----------------
 
 If you have a working installation of Hadoop already, you can skip
@@ -202,9 +202,9 @@ First reflect your directory structure and version numbers (etc) in the
 .. _setup-hadoop-3:
 
 3. Set up Hadoop
-   
+
    a. For the local host - See the
-      `Hadoop website <http://hadoop.apache.org/docs/stable/single_node_setup.html>`_
+      `Hadoop website <http://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html>`_
       for good documentation on how to do this.
 
    b. For a cluster of hosts. If you want to run Hadoop over a cluster, there
@@ -225,7 +225,7 @@ First reflect your directory structure and version numbers (etc) in the
       datanode.
 
       A good online tutorial for this as well can be found here:
-      http://hadoop.apache.org/docs/stable/cluster_setup.html
+      http://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/ClusterSetup.html
 
 .. _setup-hadoop-4:
 
@@ -250,8 +250,8 @@ First reflect your directory structure and version numbers (etc) in the
    * You can check the status of Hadoop via http, for example on a local
      host (e.g., for :ref:`3a above <setup-hadoop-3>`), using:
 
-       *  http://localhost:50070/
-       *  http://localhost:50030/
+       *  ``http://localhost:50070/``
+       *  ``http://localhost:50030/``
 
      For cluster mode (:ref:`3b <setup-hadoop-3>`), you'll use the name of the
      master host in the URL and its port (see the web for details).
@@ -275,7 +275,7 @@ First reflect your directory structure and version numbers (etc) in the
 
    * After this you should be able to run Chapel code with HDFS over
      a cluster of computers the same way as you normally would.
-    
+
 
 .. _setup-hadoop-bashrc:
 
@@ -297,28 +297,28 @@ Here is a sample .bashrc for using Hadoop within Chapel:
   #
   export CHPL_AUXIO_INCLUDE="-I$JAVA_INSTALL/include -I$JAVA_INSTALL/include/linux  -I$HADOOP_INSTALL/src/c++/libhdfs"
   export CHPL_AUXIO_LIBS="-L$JAVA_INSTALL/jre/lib/amd64/server -L$HADOOP_INSTALL/c++/Linux-amd64-64/lib"
-  
+
   #
   # So we can run things such as start-all.sh etc. from anywhere and
   # don't need to be in $HADOOP_INSTALL
   #
   export PATH=$PATH:$HADOOP_INSTALL/bin
-  
+
   #
   # Point to the JDK installation
   #
   export JAVA_INSTALL=<Place where you have the jdk installed>
-  
+
   #
   # Add Hadoop directories to the Java class path
   #
   export CLASSPATH=$CLASSPATH:$HADOOP_HOME/""*:$HADOOP_HOME/lib/""*:$HADOOP_HOME/conf/""*:$(hadoop classpath):
-  
+
   #
   # So we don't have to "install" these things
   #
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_HOME/c++/Linux-amd64-64/lib:$HADOOP_HOME/src/c++/libhdfs:$JAVA_INSTALL/jre/lib/amd64/server:$JAVA_INSTALL:$HADOOP_HOME/lib:$JAVA_INSTALL/jre/lib/amd64:$CLASSPATH
-  
+
   #
   # Settings to run Chapel on multiple nodes
   #
@@ -348,8 +348,8 @@ private extern const hdfs_function_struct_ptr:qio_file_functions_ptr_t;
 
 pragma "no doc"
 extern record hdfs_block_byte_map_t {
-  var locale_id: int; 
-  var start_byte: int(64); 
+  var locale_id: int;
+  var start_byte: int(64);
   var len: int(64);
 }
 
@@ -491,8 +491,8 @@ proc open(out error:syserr, path:string, mode:iomode, hints:iohints=IOHINT_NONE,
   ret.home = here;
   error = qio_file_open_access_usr(ret._file_internal, path.localize().c_str(),
                                    _modestring(mode).localize().c_str(),
-                                   hints, local_style, fs, 
-                                   hdfs_function_struct_ptr); 
+                                   hints, local_style, fs,
+                                   hdfs_function_struct_ptr);
   return ret;
 }
 

--- a/modules/standard/LAPACK.chpl
+++ b/modules/standard/LAPACK.chpl
@@ -25,7 +25,7 @@ Chapel idiomatic wrappers for the LAPACK library.
 
   Because of the volume of procedures provided, and because their behavior is virtually unchanged, in-depth documentation on each procedure's purpose and use is not given here.
   
-  Consult the `Netlibs LAPACK <http://www.netlib.org/lapack/>`_ site, and the `Netlibs <http://www.netlib.org/lapack/explore-html/globals_func.html>`_ and `Intel <https://software.intel.com/en-us/node/501008>`_ LAPACK documents for that information.
+  Consult the `Netlibs LAPACK <http://www.netlib.org/lapack/>`_ site, and the `Netlibs <http://www.netlib.org/lapack/explore-html/globals_func.html>`_ and `Intel <https://software.intel.com/en-us/node/520866>`_ LAPACK documents for that information.
   
   Additionally, only a small set of LAPACK procedures have been tested for correctness.
 


### PR DESCRIPTION
This PR continues the series of module/documentation changes started from #3443.


I've added dead link and dead cross-reference detection within our Sphinx project using the `-n` (nitpicky) and `-b linkcheck` flags in a `make check` rule. I considered making these flags the default behavior for `make docs`, but it requires that we disable treating warnings as errors to get all of the broken links listed at once. It also takes over ~3 times longer to build than the standard `make docs`

The `-b linkcheck` flag revealed a handful of dead links and a large amount of links that were being redirected. I've fixed all the dead links and updated redirected links (lots of `http`->`https`), so that we receive no warnings/errors from this option.

The `-n` flag revealed many cross-references utilizing the [Chapel-specific Sphinx roles](https://github.com/chapel-lang/sphinxcontrib-chapeldomain), `:chpl:`, `:proc:`, `:class:`, etc. are not actually creating cross-references, but just inline code-blocks. For example, compare the working cross-reference to `DimensionalDist2D` to the broken cross-reference to `BlockCyclic` in the beginning of [BlockCyclicDim](http://chapel.cray.com/docs/master/modules/dists/dims/BlockCycDim.html). I have only scratched the surface on identifying a fix for this behavior so far, but I suspect it will require changes to chpldoc and/or the [sphinxcontrib-chapeldomain](https://github.com/chapel-lang/sphinxcontrib-chapeldomain), which would be more fitting for a separate PR.

**Update**: Lydia and I found a way to get Chapel-specific cross-references working in their current form, by referencing the full path. For the example above, changing ``:class: `BlockCyclic` `` to ``:class: `~BlockDist.Block` `` resolves the issue. These fixes will be done during the docs-cleanup before 1.13.

For the full output of `make check` currently, see this [gist](https://gist.github.com/ben-albrecht/d2d61b26bf1f7484e02e).