### PR TITLE
Turn off guard pages for lulesh and MiniMD for KNL

### DIFF
--- a/test/release/examples/benchmarks/lulesh/lulesh.execenv
+++ b/test/release/examples/benchmarks/lulesh/lulesh.execenv
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Guard pages are expensive on KNC. See JIRA issue 160
+# Guard pages are expensive on Xeon Phi. See JIRA issue 160
 
 import os
-if os.getenv('CHPL_TARGET_ARCH', '') == 'knc':
+if os.getenv('CHPL_TARGET_ARCH', '') in ['knc', 'mic-knl']:
     print('QT_GUARD_PAGES=false')

--- a/test/release/examples/benchmarks/miniMD/explicit/miniMD.execenv
+++ b/test/release/examples/benchmarks/miniMD/explicit/miniMD.execenv
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Guard pages are expensive on KNC. See JIRA issue 160
+# Guard pages are expensive on Xeon Phi. See JIRA issue 160
 
 import os
-if os.getenv('CHPL_TARGET_ARCH', '') == 'knc':
+if os.getenv('CHPL_TARGET_ARCH', '') in ['knc', 'mic-knl']:
     print('QT_GUARD_PAGES=false')

--- a/test/release/examples/benchmarks/miniMD/miniMD.execenv
+++ b/test/release/examples/benchmarks/miniMD/miniMD.execenv
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Guard pages are expensive on KNC. See JIRA issue 160
+# Guard pages are expensive on Xeon Phi. See JIRA issue 160
 
 import os
-if os.getenv('CHPL_TARGET_ARCH', '') == 'knc':
+if os.getenv('CHPL_TARGET_ARCH', '') in ['knc', 'mic-knl']:
     print('QT_GUARD_PAGES=false')


### PR DESCRIPTION
Looks like guard pages are expensive on KNL just like there are for KNC so
update the execenvs to disable guard pages for KNL too.