### PR TITLE
Future for ref-return semantics on arrays

### DIFF
--- a/test/functions/bharshbarg/arr-ref-return.bad
+++ b/test/functions/bharshbarg/arr-ref-return.bad
@@ -1,0 +1,2 @@
+Read array: access write
+0 0 0 0 0 0 0 0 0 0

--- a/test/functions/bharshbarg/arr-ref-return.chpl
+++ b/test/functions/bharshbarg/arr-ref-return.chpl
@@ -1,0 +1,16 @@
+var data : [1..10] int;
+
+proc getter() ref {
+  writeln("access write");
+  return data;
+}
+
+proc getter() {
+  writeln("access read");
+  return data;
+}
+
+// Currently enters the 'write' case, but I would expect a read
+write("Read array: ");
+var x = getter();
+writeln(x);

--- a/test/functions/bharshbarg/arr-ref-return.future
+++ b/test/functions/bharshbarg/arr-ref-return.future
@@ -1,0 +1,7 @@
+bug: ref return semantics always invoke `ref` case if returning an array, even if that array is only read.
+
+This issue was initially encountered while working on miniMD's StencilDist.
+StencilDist was initially written to rely on the `setter` param variable to
+know when a write to an element occurred. It seems that `setter` logic had been
+flawed long before Michael's ref return change (#3232). This appears to occur
+for both arrays-of-arrays and simple arrays of other types.

--- a/test/functions/bharshbarg/arr-ref-return.good
+++ b/test/functions/bharshbarg/arr-ref-return.good
@@ -1,0 +1,2 @@
+Read array: access read
+0 0 0 0 0 0 0 0 0 0


### PR DESCRIPTION
Adding future for incorrect semantics where ref-return logic always invokes 'ref' case when returning an array, even if the array is only read.