### PR TITLE
Retire chap04 release-over-release testing

### DIFF
--- a/util/cron/test-perf.chap04.bash
+++ b/util/cron/test-perf.chap04.bash
@@ -7,4 +7,4 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04"
 
-$CWD/nightly -cron -performance -releasePerformance -numtrials 5 -startdate 07/28/12
+$CWD/nightly -cron -performance -numtrials 5 -startdate 07/28/12


### PR DESCRIPTION
We're only going to do this for chapcs now since that's our main
linux perf testing platform.