### PR TITLE
Contains Fix for bool literal size being reported incorrectly issue

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -568,7 +568,27 @@ GenRet VarSymbol::codegen() {
         ret.c += immediate->v_string;
         ret.c += '"';
       } else if (immediate->const_kind == NUM_KIND_BOOL) {
-        ret.c =  immediate->bool_value() ? "true" : "false";
+        std::string bstring = (immediate->bool_value())?"true":"false";
+        const char* castString = "(";
+        switch (immediate->num_index) {
+        case BOOL_SIZE_1:
+        case BOOL_SIZE_SYS:
+        case BOOL_SIZE_8:
+          castString = "UINT8(";
+          break;
+        case BOOL_SIZE_16:
+          castString = "UINT16(";
+          break;
+        case BOOL_SIZE_32:
+          castString = "UINT32(";
+          break;
+        case BOOL_SIZE_64:
+          castString = "UINT64(";
+          break;
+        default:
+          INT_FATAL("Unexpected immediate->num_index: %d\n", immediate->num_index);
+        }
+        ret.c = castString + bstring + ")";
       } else if (immediate->const_kind == NUM_KIND_INT) {
         int64_t iconst = immediate->int_value();
         if (iconst == (1ll<<63)) {

--- a/test/types/bool/kushal/reportLiteralSize.chpl
+++ b/test/types/bool/kushal/reportLiteralSize.chpl
@@ -1,0 +1,14 @@
+extern proc sizeof(e): size_t;
+
+/* Testing that the size reported is correct */
+writeln(sizeof(true:bool(8)));
+writeln(sizeof(false:bool(16)));
+writeln(sizeof(true:bool(32)));
+writeln(sizeof(false:bool(64)));
+
+writeln();
+/* Testing the that output shown is still the correct one */
+writeln(true:bool(8));
+writeln(false:bool(16));
+writeln(true:bool(32));
+writeln(false:bool(64));

--- a/test/types/bool/kushal/reportLiteralSize.good
+++ b/test/types/bool/kushal/reportLiteralSize.good
@@ -1,0 +1,9 @@
+1
+2
+4
+8
+
+true
+false
+true
+false


### PR DESCRIPTION
- Added changes to make sure that the boolean literal gets correctly casted as needed in the generated code.
- Separate tests have been added to verify the correctness
- Tested the changes locally for the added test-cases. 