### PR TITLE
Locales interface cleanups

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -168,7 +168,7 @@ module ChapelLocale {
       stack for any task on the current locale, including the
       caller.
     */
-    const callStackSize: size_t;
+    var callStackSize: size_t;
 
     /*
       Get the integer identifier for the top-level locale the

--- a/modules/internal/LocaleModelHelp.chpl
+++ b/modules/internal/LocaleModelHelp.chpl
@@ -164,50 +164,24 @@ module LocaleModelHelp {
     dst.maxTaskPar = chpl_task_getMaxPar();
   }
 
-
-
   //////////////////////////////////////////
   //
-  // support for memory management
+  // support for "on" statements
   //
 
-  private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
+  //
+  // runtime interface
+  //
+  extern proc chpl_comm_execute_on(loc_id: int, subloc_id: int, fn: int,
+                                   args: c_void_ptr, arg_size: size_t);
+  extern proc chpl_comm_execute_on_fast(loc_id: int, subloc_id: int, fn: int,
+                                        args: c_void_ptr, args_size: size_t);
+  extern proc chpl_comm_execute_on_nb(loc_id: int, subloc_id: int, fn: int,
+                                      args: c_void_ptr, args_size: size_t);
+  extern proc chpl_ftable_call(fn: int, args: c_void_ptr): void;
+  extern proc chpl_task_setSubloc(subloc: int(32));
 
-  // The allocator pragma is used by scalar replacement.
-  pragma "allocator"
-  pragma "locale model alloc"
-  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t): c_void_ptr {
-    pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
-  }
 
-  pragma "allocator"
-  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t): c_void_ptr {
-    pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
-  }
-
-  pragma "allocator"
-  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t): c_void_ptr {
-    pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
-  }
-
-  proc chpl_here_good_alloc_size(min_size:int): int {
-    pragma "insert line file info"
-      extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
-    return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(int);
-  }
-
-  pragma "locale model free"
-  proc chpl_here_free(ptr:c_void_ptr): void {
-    pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:c_void_ptr) : void;
-    chpl_mem_free(ptr);
-  }
 
   //////////////////////////////////////////
   //

--- a/modules/internal/LocaleModelHelp.chpl
+++ b/modules/internal/LocaleModelHelp.chpl
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// LocaleModelHelp.chpl
+//
+// Provides for declarations common to locale models
+// but that do not have to be the same in order to meet the
+// interface.
+
+// They are in this file as a practical matter to avoid code
+// duplication. If necessary, a locale model using this file
+// should feel free to reimplement them in some other way.
+module LocaleModelHelp {
+
+
+  use ChapelLocale;
+  use DefaultRectangular;
+  use ChapelNumLocales;
+  use Sys;
+
+  config param debugLocaleModel = false;
+
+  // We would really like a class-static storage class.(C++ nomenclature)
+  var doneCreatingLocales: bool = false;
+
+  // The chpl_localeID_t type is used internally.  It should not be exposed to
+  // the user.  The runtime defines the actual type, as well as a functional
+  // interface for assembling and disassembling chpl_localeID_t values.  This
+  // module then provides the interface the compiler-emitted code uses to do
+  // the same.
+
+  extern record chpl_localeID_t {
+    // We need to know that this is a record type in order to pass it to and
+    // return it from runtime functions properly, but we don't need or want
+    // to see its contents.
+  };
+
+  // We need an explicit copy constructor because the compiler cannot create
+  // a correct one for a record type whose members are not known to it.
+  pragma "init copy fn"
+  extern chpl__initCopy_chpl_rt_localeID_t
+  proc chpl__initCopy(initial: chpl_localeID_t): chpl_localeID_t;
+
+  extern var chpl_nodeID: chpl_nodeID_t;
+
+  // Runtime interface for manipulating global locale IDs.
+  extern
+    proc chpl_rt_buildLocaleID(node: chpl_nodeID_t,
+                               subloc: chpl_sublocID_t): chpl_localeID_t;
+  extern
+    proc chpl_rt_nodeFromLocaleID(loc: chpl_localeID_t): chpl_nodeID_t;
+
+  extern
+    proc chpl_rt_sublocFromLocaleID(loc: chpl_localeID_t): chpl_sublocID_t;
+
+  // Compiler (and module code) interface for manipulating global locale IDs..
+  pragma "insert line file info"
+  proc chpl_buildLocaleID(node: chpl_nodeID_t, subloc: chpl_sublocID_t)
+    return chpl_rt_buildLocaleID(node, subloc);
+
+  pragma "insert line file info"
+  proc chpl_nodeFromLocaleID(loc: chpl_localeID_t)
+    return chpl_rt_nodeFromLocaleID(loc);
+
+  pragma "insert line file info"
+  proc chpl_sublocFromLocaleID(loc: chpl_localeID_t)
+    return chpl_rt_sublocFromLocaleID(loc);
+
+  proc helpSetupRootLocaleFlat(dst:RootLocale) {
+    //  todo -- use atomics instead of +=
+    // var tmp_nPUsPhysAcc : atomic int;
+    // tmp_nPUsPhysAcc.add(node.nPUsPhysAcc);
+    // nPUsPhysAcc = tmp_nPUsPhysAcc.read();
+
+    forall locIdx in dst.chpl_initOnLocales() {
+      const node = new LocaleModel(dst);
+      dst.myLocales[locIdx] = node;
+      dst.nPUsPhysAcc += node.nPUsPhysAcc;
+      dst.nPUsPhysAll += node.nPUsPhysAll;
+      dst.nPUsLogAcc += node.nPUsLogAcc;
+      dst.nPUsLogAll += node.nPUsLogAll;
+      dst.maxTaskPar += node.maxTaskPar;
+    }
+
+    here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
+  }
+
+  proc helpSetupRootLocaleNUMA(dst:RootLocale) {
+    //  todo -- use atomics instead of +=
+    // var tmp_nPUsPhysAcc : atomic int;
+    // tmp_nPUsPhysAcc.add(node.nPUsPhysAcc);
+    // nPUsPhysAcc = tmp_nPUsPhysAcc.read();
+
+    forall locIdx in dst.chpl_initOnLocales() {
+      chpl_task_setSubloc(c_sublocid_any);
+      const node = new LocaleModel(dst);
+      dst.myLocales[locIdx] = node;
+      dst.nPUsPhysAcc += node.nPUsPhysAcc;
+      dst.nPUsPhysAll += node.nPUsPhysAll;
+      dst.nPUsLogAcc += node.nPUsLogAcc;
+      dst.nPUsLogAll += node.nPUsLogAll;
+      dst.maxTaskPar += node.maxTaskPar;
+    }
+
+    here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
+  }
+
+
+  proc helpSetupLocaleFlat(dst:LocaleModel, out local_name:string) {
+    const _node_id = chpl_nodeID: int;
+
+    // chpl_nodeName is defined in chplsys.c.
+    // It supplies a node name obtained by running uname(3) on the
+    // current node.  For this reason (as well), the constructor (or
+    // at least this init method) must be run on the node it is
+    // intended to describe.
+    var comm, spawnfn : c_string;
+    extern proc chpl_nodeName() : c_string;
+    // sys_getenv returns zero on success.
+    if sys_getenv(c"CHPL_COMM", comm) == 0 && comm == c"gasnet" &&
+      sys_getenv(c"GASNET_SPAWNFN", spawnfn) == 0 && spawnfn == c"L"
+    then local_name = chpl_nodeName() + "-" + _node_id : string;
+    else local_name = chpl_nodeName():string;
+
+    extern proc chpl_task_getCallStackSize(): size_t;
+    dst.callStackSize = chpl_task_getCallStackSize();
+
+    extern proc chpl_getNumPhysicalCpus(accessible_only: bool): c_int;
+    dst.nPUsPhysAcc = chpl_getNumPhysicalCpus(true);
+    dst.nPUsPhysAll = chpl_getNumPhysicalCpus(false);
+
+    extern proc chpl_getNumLogicalCpus(accessible_only: bool): c_int;
+    dst.nPUsLogAcc = chpl_getNumLogicalCpus(true);
+    dst.nPUsLogAll = chpl_getNumLogicalCpus(false);
+
+    extern proc chpl_task_getMaxPar(): uint(32);
+    dst.maxTaskPar = chpl_task_getMaxPar();
+  }
+
+
+
+  //////////////////////////////////////////
+  //
+  // support for memory management
+  //
+
+  private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
+
+  // The allocator pragma is used by scalar replacement.
+  pragma "allocator"
+  pragma "locale model alloc"
+  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t): c_void_ptr {
+    pragma "insert line file info"
+      extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
+  }
+
+  pragma "allocator"
+  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t): c_void_ptr {
+    pragma "insert line file info"
+      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
+  }
+
+  pragma "allocator"
+  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t): c_void_ptr {
+    pragma "insert line file info"
+      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
+  }
+
+  proc chpl_here_good_alloc_size(min_size:int): int {
+    pragma "insert line file info"
+      extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
+    return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(int);
+  }
+
+  pragma "locale model free"
+  proc chpl_here_free(ptr:c_void_ptr): void {
+    pragma "insert line file info"
+      extern proc chpl_mem_free(ptr:c_void_ptr) : void;
+    chpl_mem_free(ptr);
+  }
+
+  //////////////////////////////////////////
+  //
+  // support for tasking statements: begin, cobegin, coforall
+  //
+
+  //
+  // runtime interface
+  //
+  pragma "insert line file info"
+  extern proc chpl_task_addToTaskList(fn: int, args: c_void_ptr, subloc_id: int,
+                                      ref tlist: c_void_ptr, tlist_node_id: int,
+                                      is_begin: bool);
+  extern proc chpl_task_executeTasksInList(ref tlist: c_void_ptr);
+
+  //
+  // add a task to a list of tasks being built for a begin statement
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_taskListAddBegin(subloc_id: int,        // target sublocale
+                             fn: int,               // task body function idx
+                             args: c_void_ptr,      // function args
+                             ref tlist: c_void_ptr, // task list
+                             tlist_node_id: int     // task list owner node
+                            ) {
+    chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, true);
+  }
+
+  //
+  // add a task to a list of tasks being built for a cobegin or coforall
+  // statement
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_taskListAddCoStmt(subloc_id: int,        // target sublocale
+                              fn: int,               // task body function idx
+                              args: c_void_ptr,      // function args
+                              ref tlist: c_void_ptr, // task list
+                              tlist_node_id: int     // task list owner node
+                             ) {
+    chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, false);
+  }
+
+  //
+  // make sure all tasks in a list have an opportunity to run
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_taskListExecute(ref task_list: c_void_ptr) {
+    chpl_task_executeTasksInList(task_list);
+  }
+
+}

--- a/modules/internal/LocaleModelHelpFlat.chpl
+++ b/modules/internal/LocaleModelHelpFlat.chpl
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module LocaleModelHelpFlat {
+
+  param localeModelHasSublocales = false;
+
+  use LocaleModelHelp;
+
+  //////////////////////////////////////////
+  //
+  // support for "on" statements
+  //
+
+  //
+  // runtime interface
+  //
+  extern proc chpl_comm_execute_on(loc_id: int, subloc_id: int, fn: int,
+                                   args: c_void_ptr, arg_size: size_t);
+  extern proc chpl_comm_execute_on_fast(loc_id: int, subloc_id: int, fn: int,
+                                        args: c_void_ptr, args_size: size_t);
+  extern proc chpl_comm_execute_on_nb(loc_id: int, subloc_id: int, fn: int,
+                                      args: c_void_ptr, args_size: size_t);
+  extern proc chpl_ftable_call(fn: int, args: c_void_ptr): void;
+  //
+  // regular "on"
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOn(loc: chpl_localeID_t, // target locale
+                      fn: int,              // on-body function idx
+                      args: c_void_ptr,     // function args
+                      args_size: size_t     // args size
+                     ) {
+    const node = chpl_nodeFromLocaleID(loc);
+    if (node == chpl_nodeID) {
+      // don't call the runtime execute_on function if we can stay local
+      chpl_ftable_call(fn, args);
+    } else {
+      chpl_comm_execute_on(node, chpl_sublocFromLocaleID(loc),
+                     fn, args, args_size);
+    }
+  }
+
+  //
+  // fast "on" (doesn't do anything that could deadlock a comm layer,
+  // in the Active Messages sense)
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOnFast(loc: chpl_localeID_t, // target locale
+                          fn: int,              // on-body function idx
+                          args: c_void_ptr,     // function args
+                          args_size: size_t     // args size
+                         ) {
+    const node = chpl_nodeFromLocaleID(loc);
+    if (node == chpl_nodeID) {
+      // don't call the runtime fast execute_on function if we can stay local
+      chpl_ftable_call(fn, args);
+    } else {
+      chpl_comm_execute_on_fast(node, chpl_sublocFromLocaleID(loc),
+                          fn, args, args_size);
+    }
+  }
+
+  //
+  // nonblocking "on" (doesn't wait for completion)
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOnNB(loc: chpl_localeID_t, // target locale
+                        fn: int,              // on-body function idx
+                        args: c_void_ptr,     // function args
+                        args_size: size_t     // args size
+                       ) {
+    //
+    // If we're in serial mode, we should use blocking rather than
+    // non-blocking "on" in order to serialize the execute_ons.
+    //
+    const node = chpl_nodeFromLocaleID(loc);
+    if (node == chpl_nodeID) {
+      if __primitive("task_get_serial") then
+        // don't call the runtime nb execute_on function if we can stay local
+        chpl_ftable_call(fn, args);
+      else
+        // We'd like to use a begin, but unfortunately doing so as
+        // follows does not compile for --no-local:
+        // begin chpl_ftable_call(fn, args);
+        chpl_comm_execute_on_nb(node, chpl_sublocFromLocaleID(loc),
+                          fn, args, args_size);
+    } else {
+      const subloc = chpl_sublocFromLocaleID(loc);
+      if __primitive("task_get_serial") then
+        chpl_comm_execute_on(node, subloc, fn, args, args_size);
+      else
+        chpl_comm_execute_on_nb(node, subloc, fn, args, args_size);
+    }
+  }
+
+}
+

--- a/modules/internal/LocaleModelHelpMem.chpl
+++ b/modules/internal/LocaleModelHelpMem.chpl
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// LocaleModelHelp.chpl
+//
+// Provides for declarations common to locale models
+// but that do not have to be the same in order to meet the
+// interface.
+
+// They are in this file as a practical matter to avoid code
+// duplication. If necessary, a locale model using this file
+// should feel free to reimplement them in some other way.
+module LocaleModelHelpMem {
+
+  use LocaleModelHelp;
+
+
+  //////////////////////////////////////////
+  //
+  // support for memory management
+  //
+
+  private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
+
+  // The allocator pragma is used by scalar replacement.
+  pragma "allocator"
+  pragma "locale model alloc"
+  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t): c_void_ptr {
+    pragma "insert line file info"
+      extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
+  }
+
+  pragma "allocator"
+  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t): c_void_ptr {
+    pragma "insert line file info"
+      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
+  }
+
+  pragma "allocator"
+  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t): c_void_ptr {
+    pragma "insert line file info"
+      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
+  }
+
+  proc chpl_here_good_alloc_size(min_size:int): int {
+    pragma "insert line file info"
+      extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
+    return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(int);
+  }
+
+  pragma "locale model free"
+  proc chpl_here_free(ptr:c_void_ptr): void {
+    pragma "insert line file info"
+      extern proc chpl_mem_free(ptr:c_void_ptr) : void;
+    chpl_mem_free(ptr);
+  }
+}

--- a/modules/internal/LocaleModelHelpNUMA.chpl
+++ b/modules/internal/LocaleModelHelpNUMA.chpl
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module LocaleModelHelpNUMA {
+
+  param localeModelHasSublocales = true;
+
+  use LocaleModelHelp;
+
+  proc helpSetupLocaleNUMA(dst:LocaleModel, out local_name:string, out numSublocales) {
+    helpSetupLocaleFlat(dst, local_name);
+
+    extern proc chpl_task_getNumSublocales(): int(32);
+    numSublocales = chpl_task_getNumSublocales();
+
+    extern proc chpl_task_getMaxPar(): uint(32);
+
+    if numSublocales >= 1 {
+      dst.childSpace = {0..#numSublocales};
+      // These nPUs* values are estimates only; better values await
+      // full hwloc support. In particular it assumes a homogeneous node
+      const nPUsPhysAccPerSubloc = dst.nPUsPhysAcc/numSublocales;
+      const nPUsPhysAllPerSubloc = dst.nPUsPhysAll/numSublocales;
+      const nPUsLogAccPerSubloc = dst.nPUsLogAcc/numSublocales;
+      const nPUsLogAllPerSubloc = dst.nPUsLogAll/numSublocales;
+      const maxTaskParPerSubloc = chpl_task_getMaxPar()/numSublocales;
+      const origSubloc = chpl_task_getRequestedSubloc(); // this should be any
+      for i in dst.childSpace {
+        // allocate the structure on the proper sublocale
+        chpl_task_setSubloc(i:chpl_sublocID_t);
+        dst.childLocales[i] = new NumaDomain(i:chpl_sublocID_t, dst);
+        dst.childLocales[i].nPUsPhysAcc = nPUsPhysAccPerSubloc;
+        dst.childLocales[i].nPUsPhysAll = nPUsPhysAllPerSubloc;
+        dst.childLocales[i].nPUsLogAcc = nPUsLogAccPerSubloc;
+        dst.childLocales[i].nPUsLogAll = nPUsLogAllPerSubloc;
+        dst.childLocales[i].maxTaskPar = maxTaskParPerSubloc;
+      }
+      chpl_task_setSubloc(origSubloc);
+    }
+  }
+
+  inline
+  proc chpl_getSubloc() {
+    extern proc chpl_task_getSubloc(): chpl_sublocID_t;
+    return chpl_task_getSubloc();
+  }
+
+
+  //////////////////////////////////////////
+  //
+  // support for "on" statements
+  //
+
+  //
+  // runtime interface
+  //
+  extern proc chpl_comm_execute_on(loc_id: int, subloc_id: int, fn: int,
+                                   args: c_void_ptr, arg_size: size_t);
+  extern proc chpl_comm_execute_on_fast(loc_id: int, subloc_id: int, fn: int,
+                                        args: c_void_ptr, args_size: size_t);
+  extern proc chpl_comm_execute_on_nb(loc_id: int, subloc_id: int, fn: int,
+                                      args: c_void_ptr, args_size: size_t);
+  extern proc chpl_ftable_call(fn: int, args: c_void_ptr): void;
+  extern proc chpl_task_setSubloc(subloc: int(32));
+
+  //
+  // regular "on"
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOn(loc: chpl_localeID_t, // target locale
+                      fn: int,              // on-body function idx
+                      args: c_void_ptr,     // function args
+                      args_size: size_t     // args size
+                     ) {
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+    if dnode != chpl_nodeID {
+      chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
+    } else {
+      // run directly on this node
+      var origSubloc = chpl_task_getRequestedSubloc();
+      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
+        chpl_ftable_call(fn, args);
+      } else {
+        // move to a different sublocale
+        chpl_task_setSubloc(dsubloc);
+        chpl_ftable_call(fn, args);
+        chpl_task_setSubloc(origSubloc);
+      }
+    }
+  }
+
+  //
+  // fast "on" (doesn't do anything that could deadlock a comm layer,
+  // in the Active Messages sense)
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOnFast(loc: chpl_localeID_t, // target locale
+                          fn: int,              // on-body function idx
+                          args: c_void_ptr,     // function args
+                          args_size: size_t     // args size
+                         ) {
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+    if dnode != chpl_nodeID {
+      chpl_comm_execute_on_fast(dnode, dsubloc, fn, args, args_size);
+    } else {
+      var origSubloc = chpl_task_getRequestedSubloc();
+      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
+        chpl_ftable_call(fn, args);
+      } else {
+        // move to a different sublocale
+        chpl_task_setSubloc(dsubloc);
+        chpl_ftable_call(fn, args);
+        chpl_task_setSubloc(origSubloc);
+      }
+    }
+  }
+
+  // Unused for now due to bug when using 'begin'
+  inline proc chpl_executeOnNBAux(fn: int,         // on-body function idx
+                                  args: c_void_ptr // function args
+                                  ) {
+    if __primitive("task_get_serial") then
+      chpl_ftable_call(fn, args);
+    else
+      begin chpl_ftable_call(fn, args);
+  }
+  //
+  // nonblocking "on" (doesn't wait for completion)
+  //
+  param useBegin = false;
+  pragma "insert line file info"
+  export
+  proc chpl_executeOnNB(loc: chpl_localeID_t, // target locale
+                        fn: int,              // on-body function idx
+                        args: c_void_ptr,     // function args
+                        args_size: size_t     // args size
+                       ) {
+    //
+    // If we're in serial mode, we should use blocking rather than
+    // non-blocking "on" in order to serialize the execute_ons.
+    //
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+    if dnode != chpl_nodeID {
+      if __primitive("task_get_serial") then
+        chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
+      else
+        chpl_comm_execute_on_nb(dnode, dsubloc, fn, args, args_size);
+    } else {
+      var origSubloc = chpl_task_getRequestedSubloc();
+      // We'd like to call chpl_executeOnNBaux() here, but the begin
+      //  statement seems to cause a problem
+      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
+        // run on this sublocale
+        if useBegin {
+          chpl_executeOnNBAux(fn, args);
+        } else {
+          if __primitive("task_get_serial") then
+            chpl_ftable_call(fn, args);
+          else
+            // begin chpl_ftable_call(fn, args);
+            chpl_comm_execute_on_nb(dnode, dsubloc, fn, args, args_size);
+        }
+      } else {
+        // move to a different sublocale
+        chpl_task_setSubloc(dsubloc);
+        if useBegin {
+          chpl_executeOnNBAux(fn, args);
+        } else {
+          if __primitive("task_get_serial") then
+            chpl_ftable_call(fn, args);
+          else
+            // begin chpl_ftable_call(fn, args);
+            chpl_comm_execute_on_nb(dnode, dsubloc, fn, args, args_size);
+        }
+        chpl_task_setSubloc(origSubloc);
+      }
+    }
+  }
+}

--- a/modules/internal/LocaleModelHelpNUMA.chpl
+++ b/modules/internal/LocaleModelHelpNUMA.chpl
@@ -23,10 +23,11 @@ module LocaleModelHelpNUMA {
 
   use LocaleModelHelp;
 
+  extern proc chpl_task_getNumSublocales(): int(32);
+
   proc helpSetupLocaleNUMA(dst:LocaleModel, out local_name:string, out numSublocales) {
     helpSetupLocaleFlat(dst, local_name);
 
-    extern proc chpl_task_getNumSublocales(): int(32);
     numSublocales = chpl_task_getNumSublocales();
 
     extern proc chpl_task_getMaxPar(): uint(32);

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -126,28 +126,12 @@ module LocaleModel {
       f <~> new ioLiteral("LOCALE") <~> _node_id;
     }
 
-    proc getChildSpace() return chpl_emptyLocaleSpace;
-
     proc getChildCount() return 0;
-
-    iter getChildIndices() : int {
-      for idx in chpl_emptyLocaleSpace do
-        yield idx;
-    }
 
     proc getChild(idx:int) : locale {
       if boundsChecking then
-        halt("requesting a child from a LocaleModel locale");
+        halt("requesting a child from a flat LocaleModel locale");
       return nil;
-    }
-
-    iter getChildren() : locale  {
-      for loc in chpl_emptyLocales do
-        yield loc;
-    }
-
-    proc getChildArray() {
-      return chpl_emptyLocales;
     }
 
     //------------------------------------------------------------------------{
@@ -241,19 +225,7 @@ module LocaleModel {
 
     proc getChildCount() return this.myLocaleSpace.numIndices;
 
-    proc getChildSpace() return this.myLocaleSpace;
-
-    iter getChildIndices() : int {
-      for idx in this.myLocaleSpace do
-        yield idx;
-    }
-
     proc getChild(idx:int) return this.myLocales[idx];
-
-    iter getChildren() : locale  {
-      for loc in this.myLocales do
-        yield loc;
-    }
 
     proc getDefaultLocaleSpace() return this.myLocaleSpace;
     proc getDefaultLocaleArray() return myLocales;

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -32,6 +32,7 @@ module LocaleModel {
   // moved to LocaleModelHelpFlat.chpl
 
   use LocaleModelHelpFlat;
+  use LocaleModelHelpMem;
 
   // debugLocaleModel
   // doneCreatingLocales
@@ -187,7 +188,7 @@ module LocaleModel {
   // chpl_here_good_alloc_size
   // chpl_here_free
 
-  // moved to LocaleModelHelp.chpl
+  // moved to LocaleModelHelpMem.chpl
 
 
   //////////////////////////////////////////

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -28,63 +28,24 @@
 //
 module LocaleModel {
 
-  param localeModelHasSublocales = false;
+  // localeModelHasSublocales
+  // moved to LocaleModelHelpFlat.chpl
 
-  use ChapelLocale;
-  use DefaultRectangular;
-  use ChapelNumLocales;
-  use Sys;
+  use LocaleModelHelpFlat;
 
-  config param debugLocaleModel = false;
+  // debugLocaleModel
+  // doneCreatingLocales
+  // chpl_localeID_t
+  // chpl__initCopy for chpl_localeID_t
+  // chpl_nodeID
+  // chpl_rt_buildLocaleID
+  // chpl_rt_nodeFromLocaleID
+  // chpl_rt_sublocFromLocaleID
+  // chpl_buildLocaleID
+  // chpl_nodeFromLocaleID
+  // chpl_sublocFromLocaleID
+  // moved to LocaleModelHelp.chpl
 
-  // We would really like a class-static storage class.(C++ nomenclature)
-  var doneCreatingLocales: bool = false;
-
-  // The chpl_localeID_t type is used internally.  It should not be exposed to
-  // the user.  The runtime defines the actual type, as well as a functional
-  // interface for assembling and disassembling chpl_localeID_t values.  This
-  // module then provides the interface the compiler-emitted code uses to do
-  // the same.
-
-  extern record chpl_localeID_t {
-    // We need to know that this is a record type in order to pass it to and
-    // return it from runtime functions properly, but we don't need or want
-    // to see its contents.
-  };
-
-  // We need an explicit copy constructor because the compiler cannot create
-  // a correct one for a record type whose members are not known to it.
-  pragma "init copy fn"
-  extern chpl__initCopy_chpl_rt_localeID_t
-  proc chpl__initCopy(initial: chpl_localeID_t): chpl_localeID_t;
-
-  extern var chpl_nodeID: chpl_nodeID_t;
-
-  // Runtime interface for manipulating global locale IDs.
-  extern
-    proc chpl_rt_buildLocaleID(node: chpl_nodeID_t,
-                               subloc: chpl_sublocID_t): chpl_localeID_t;
-  extern
-    proc chpl_rt_nodeFromLocaleID(loc: chpl_localeID_t): chpl_nodeID_t;
-
-  extern
-    proc chpl_rt_sublocFromLocaleID(loc: chpl_localeID_t): chpl_sublocID_t;
-
-  // Compiler (and module code) interface for manipulating global locale IDs..
-  pragma "insert line file info"
-  proc chpl_buildLocaleID(node: chpl_nodeID_t, subloc: chpl_sublocID_t)
-    return chpl_rt_buildLocaleID(node, subloc);
-
-  pragma "insert line file info"
-  proc chpl_nodeFromLocaleID(loc: chpl_localeID_t)
-    return chpl_rt_nodeFromLocaleID(loc);
-
-  pragma "insert line file info"
-  proc chpl_sublocFromLocaleID(loc: chpl_localeID_t)
-    return chpl_rt_sublocFromLocaleID(loc);
-
-  const chpl_emptyLocaleSpace: domain(1) = {1..0};
-  const chpl_emptyLocales: [chpl_emptyLocaleSpace] locale;
 
   //
   // A concrete class representing the nodes in this architecture.
@@ -140,32 +101,7 @@ module LocaleModel {
     proc init() {
       _node_id = chpl_nodeID: int;
 
-      // chpl_nodeName is defined in chplsys.c.
-      // It supplies a node name obtained by running uname(3) on the
-      // current node.  For this reason (as well), the constructor (or
-      // at least this init method) must be run on the node it is
-      // intended to describe.
-      var comm, spawnfn : c_string;
-      extern proc chpl_nodeName() : c_string;
-      // sys_getenv returns zero on success.
-      if sys_getenv(c"CHPL_COMM", comm) == 0 && comm == c"gasnet" &&
-        sys_getenv(c"GASNET_SPAWNFN", spawnfn) == 0 && spawnfn == c"L"
-      then local_name = chpl_nodeName() + "-" + _node_id : string;
-      else local_name = chpl_nodeName():string;
-
-      extern proc chpl_task_getCallStackSize(): size_t;
-      callStackSize = chpl_task_getCallStackSize();
-
-      extern proc chpl_getNumPhysicalCpus(accessible_only: bool): c_int;
-      nPUsPhysAcc = chpl_getNumPhysicalCpus(true);
-      nPUsPhysAll = chpl_getNumPhysicalCpus(false);
-
-      extern proc chpl_getNumLogicalCpus(accessible_only: bool): c_int;
-      nPUsLogAcc = chpl_getNumLogicalCpus(true);
-      nPUsLogAll = chpl_getNumLogicalCpus(false);
-
-      extern proc chpl_task_getMaxPar(): uint(32);
-      maxTaskPar = chpl_task_getMaxPar();
+      helpSetupLocaleFlat(this, local_name);
     }
     //------------------------------------------------------------------------}
   }
@@ -195,17 +131,7 @@ module LocaleModel {
     // parallel) over the locales to set up the LocaleModel object.
     // In addition, the initial 'here' must be set.
     proc init() {
-      forall locIdx in chpl_initOnLocales() {
-        const node = new LocaleModel(this);
-        myLocales[locIdx] = node;
-        nPUsPhysAcc += node.nPUsPhysAcc;
-        nPUsPhysAll += node.nPUsPhysAll;
-        nPUsLogAcc += node.nPUsLogAcc;
-        nPUsLogAll += node.nPUsLogAll;
-        maxTaskPar += node.maxTaskPar;
-      }
-
-      here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
+      helpSetupRootLocaleFlat(this);
     }
 
     // Has to be globally unique and not equal to a node ID.
@@ -255,43 +181,13 @@ module LocaleModel {
   // support for memory management
   //
 
-  private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
+  // chpl_here_alloc
+  // chpl_here_calloc
+  // chpl_here_realloc
+  // chpl_here_good_alloc_size
+  // chpl_here_free
 
-  // The allocator pragma is used by scalar replacement.
-  pragma "allocator"
-  pragma "locale model alloc"
-  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t): c_void_ptr {
-    pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
-  }
-
-  pragma "allocator"
-  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t): c_void_ptr {
-    pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
-  }
-
-  pragma "allocator"
-  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t): c_void_ptr {
-    pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
-  }
-
-  proc chpl_here_good_alloc_size(min_size:int): int {
-    pragma "insert line file info"
-      extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
-    return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(int);
-  }
-
-  pragma "locale model free"
-  proc chpl_here_free(ptr:c_void_ptr): void {
-    pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:c_void_ptr) : void;
-    chpl_mem_free(ptr);
-  }
+  // moved to LocaleModelHelp.chpl
 
 
   //////////////////////////////////////////
@@ -299,140 +195,22 @@ module LocaleModel {
   // support for "on" statements
   //
 
-  //
-  // runtime interface
-  //
-  extern proc chpl_comm_execute_on(loc_id: int, subloc_id: int, fn: int,
-                                   args: c_void_ptr, arg_size: size_t);
-  extern proc chpl_comm_execute_on_fast(loc_id: int, subloc_id: int, fn: int,
-                                        args: c_void_ptr, args_size: size_t);
-  extern proc chpl_comm_execute_on_nb(loc_id: int, subloc_id: int, fn: int,
-                                      args: c_void_ptr, args_size: size_t);
-  extern proc chpl_ftable_call(fn: int, args: c_void_ptr): void;
-  //
-  // regular "on"
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_executeOn(loc: chpl_localeID_t, // target locale
-                      fn: int,              // on-body function idx
-                      args: c_void_ptr,     // function args
-                      args_size: size_t     // args size
-                     ) {
-    const node = chpl_nodeFromLocaleID(loc);
-    if (node == chpl_nodeID) {
-      // don't call the runtime execute_on function if we can stay local
-      chpl_ftable_call(fn, args);
-    } else {
-      chpl_comm_execute_on(node, chpl_sublocFromLocaleID(loc),
-                     fn, args, args_size);
-    }
-  }
+  // chpl_executeOn
+  // chpl_executeOnFast
+  // chpl_executeOnNB
 
-  //
-  // fast "on" (doesn't do anything that could deadlock a comm layer,
-  // in the Active Messages sense)
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_executeOnFast(loc: chpl_localeID_t, // target locale
-                          fn: int,              // on-body function idx
-                          args: c_void_ptr,     // function args
-                          args_size: size_t     // args size
-                         ) {
-    const node = chpl_nodeFromLocaleID(loc);
-    if (node == chpl_nodeID) {
-      // don't call the runtime fast execute_on function if we can stay local
-      chpl_ftable_call(fn, args);
-    } else {
-      chpl_comm_execute_on_fast(node, chpl_sublocFromLocaleID(loc),
-                          fn, args, args_size);
-    }
-  }
+  // moved to LocaleModelHelpFlat.chpl
 
-  //
-  // nonblocking "on" (doesn't wait for completion)
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_executeOnNB(loc: chpl_localeID_t, // target locale
-                        fn: int,              // on-body function idx
-                        args: c_void_ptr,     // function args
-                        args_size: size_t     // args size
-                       ) {
-    //
-    // If we're in serial mode, we should use blocking rather than
-    // non-blocking "on" in order to serialize the execute_ons.
-    //
-    const node = chpl_nodeFromLocaleID(loc);
-    if (node == chpl_nodeID) {
-      if __primitive("task_get_serial") then
-        // don't call the runtime nb execute_on function if we can stay local
-        chpl_ftable_call(fn, args);
-      else
-        // We'd like to use a begin, but unfortunately doing so as
-        // follows does not compile for --no-local:
-        // begin chpl_ftable_call(fn, args);
-        chpl_comm_execute_on_nb(node, chpl_sublocFromLocaleID(loc),
-                          fn, args, args_size);
-    } else {
-      const subloc = chpl_sublocFromLocaleID(loc);
-      if __primitive("task_get_serial") then
-        chpl_comm_execute_on(node, subloc, fn, args, args_size);
-      else
-        chpl_comm_execute_on_nb(node, subloc, fn, args, args_size);
-    }
-  }
 
   //////////////////////////////////////////
   //
   // support for tasking statements: begin, cobegin, coforall
   //
 
-  //
-  // runtime interface
-  //
-  pragma "insert line file info"
-  extern proc chpl_task_addToTaskList(fn: int, args: c_void_ptr, subloc_id: int,
-                                      ref tlist: c_void_ptr, tlist_node_id: int,
-                                      is_begin: bool);
-  extern proc chpl_task_executeTasksInList(ref tlist: c_void_ptr);
+  // chpl_taskListAddBegin
+  // chpl_taskListAddCoStmt
+  // chpl_taskListExecute
 
-  //
-  // add a task to a list of tasks being built for a begin statement
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListAddBegin(subloc_id: int,        // target sublocale
-                             fn: int,               // task body function idx
-                             args: c_void_ptr,      // function args
-                             ref tlist: c_void_ptr, // task list
-                             tlist_node_id: int     // task list owner node
-                            ) {
-    chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, true);
-  }
+  // moved to LocaleModelHelp.chpl
 
-  //
-  // add a task to a list of tasks being built for a cobegin or coforall
-  // statement
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListAddCoStmt(subloc_id: int,        // target sublocale
-                              fn: int,               // task body function idx
-                              args: c_void_ptr,      // function args
-                              ref tlist: c_void_ptr, // task list
-                              tlist_node_id: int     // task list owner node
-                             ) {
-    chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, false);
-  }
-
-  //
-  // make sure all tasks in a list have an opportunity to run
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListExecute(ref task_list: c_void_ptr) {
-    chpl_task_executeTasksInList(task_list);
-  }
 }

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -28,63 +28,25 @@
 //
 module LocaleModel {
 
-  param localeModelHasSublocales = true;
+  // localeModelHasSublocales
+  // chpl_task_getRequestedSubloc
 
-  use ChapelLocale;
-  use DefaultRectangular;
-  use ChapelNumLocales;
-  use Sys;
+  // moved to LocaleModelHelpNUMA.chpl
 
-  extern proc chpl_task_getRequestedSubloc(): int(32);
+  use LocaleModelHelpNUMA;
 
-  config param debugLocaleModel = false;
-
-  // We would really like a class-static storage class.(C++ nomenclature)
-  var doneCreatingLocales: bool = false;
-
-  // The chpl_localeID_t type is used internally.  It should not be exposed to
-  // the user.  The runtime defines the actual type, as well as a functional
-  // interface for assembling and disassembling chpl_localeID_t values.  This
-  // module then provides the interface the compiler-emitted code uses to do
-  // the same.
-
-  extern record chpl_localeID_t {
-    // We need to know that this is a record type in order to pass it to and
-    // return it from runtime functions properly, but we don't need or want
-    // to see its contents.
-  };
-
-  // We need an explicit copy constructor because the compiler cannot create
-  // a correct one for a record type whose members are not known to it.
-  pragma "init copy fn"
-  extern chpl__initCopy_chpl_rt_localeID_t
-  proc chpl__initCopy(initial: chpl_localeID_t): chpl_localeID_t;
-
-  extern var chpl_nodeID: chpl_nodeID_t;
-
-  // Runtime interface for manipulating global locale IDs.
-  extern
-    proc chpl_rt_buildLocaleID(node: chpl_nodeID_t,
-                               subloc: chpl_sublocID_t): chpl_localeID_t;
-
-  extern
-    proc chpl_rt_nodeFromLocaleID(loc: chpl_localeID_t): chpl_nodeID_t;
-
-  extern
-    proc chpl_rt_sublocFromLocaleID(loc: chpl_localeID_t): chpl_sublocID_t;
-
-  // Compiler (and module code) interface for manipulating global locale IDs..
-  pragma "insert line file info"
-  proc chpl_buildLocaleID(node: chpl_nodeID_t, subloc: chpl_sublocID_t)
-    return chpl_rt_buildLocaleID(node, subloc);
-
-  pragma "insert line file info"
-  proc chpl_nodeFromLocaleID(loc: chpl_localeID_t)
-    return chpl_rt_nodeFromLocaleID(loc);
-
-  pragma "insert line file info"
-  proc chpl_sublocFromLocaleID(loc: chpl_localeID_t)
-    return chpl_rt_sublocFromLocaleID(loc);
+  // debugLocaleModel
+  // doneCreatingLocales
+  // chpl_localeID_t
+  // chpl__initCopy for chpl_localeID_t
+  // chpl_nodeID
+  // chpl_rt_buildLocaleID
+  // chpl_rt_nodeFromLocaleID
+  // chpl_rt_sublocFromLocaleID
+  // chpl_buildLocaleID
+  // chpl_nodeFromLocaleID
+  // chpl_sublocFromLocaleID
+  // moved to LocaleModelHelp.chpl
 
 
   //
@@ -178,58 +140,7 @@ module LocaleModel {
     proc init() {
       _node_id = chpl_nodeID: int;
 
-      // chpl_nodeName is defined in chplsys.c.
-      // It supplies a node name obtained by running uname(3) on the
-      // current node.  For this reason (as well), the constructor (or
-      // at least this init method) must be run on the node it is
-      // intended to describe.
-      var comm, spawnfn : c_string;
-      extern proc chpl_nodeName() : c_string;
-      // sys_getenv returns zero on success.
-      if sys_getenv(c"CHPL_COMM", comm) == 0 && comm == c"gasnet" &&
-        sys_getenv(c"GASNET_SPAWNFN", spawnfn) == 0 && spawnfn == c"L"
-      then local_name = chpl_nodeName() + "-" + _node_id : string;
-      else local_name = chpl_nodeName():string;
-
-      extern proc chpl_task_getCallStackSize(): size_t;
-      callStackSize = chpl_task_getCallStackSize();
-
-      extern proc chpl_getNumPhysicalCpus(accessible_only: bool): c_int;
-      nPUsPhysAcc = chpl_getNumPhysicalCpus(true);
-      nPUsPhysAll = chpl_getNumPhysicalCpus(false);
-
-      extern proc chpl_getNumLogicalCpus(accessible_only: bool): c_int;
-      nPUsLogAcc = chpl_getNumLogicalCpus(true);
-      nPUsLogAll = chpl_getNumLogicalCpus(false);
-
-      extern proc chpl_task_getNumSublocales(): int(32);
-      numSublocales = chpl_task_getNumSublocales();
-
-      extern proc chpl_task_getMaxPar(): uint(32);
-      maxTaskPar = chpl_task_getMaxPar();
-
-      if numSublocales >= 1 {
-        childSpace = {0..#numSublocales};
-        // These nPUs* values are estimates only; better values await
-        // full hwloc support. In particular it assumes a homogeneous node
-        const nPUsPhysAccPerSubloc = nPUsPhysAcc/numSublocales;
-        const nPUsPhysAllPerSubloc = nPUsPhysAll/numSublocales;
-        const nPUsLogAccPerSubloc = nPUsLogAcc/numSublocales;
-        const nPUsLogAllPerSubloc = nPUsLogAll/numSublocales;
-        const maxTaskParPerSubloc = chpl_task_getMaxPar()/numSublocales;
-        const origSubloc = chpl_task_getRequestedSubloc(); // this should be any
-        for i in childSpace {
-          // allocate the structure on the proper sublocale
-          chpl_task_setSubloc(i:chpl_sublocID_t);
-          childLocales[i] = new NumaDomain(i:chpl_sublocID_t, this);
-          childLocales[i].nPUsPhysAcc = nPUsPhysAccPerSubloc;
-          childLocales[i].nPUsPhysAll = nPUsPhysAllPerSubloc;
-          childLocales[i].nPUsLogAcc = nPUsLogAccPerSubloc;
-          childLocales[i].nPUsLogAll = nPUsLogAllPerSubloc;
-          childLocales[i].maxTaskPar = maxTaskParPerSubloc;
-        }
-        chpl_task_setSubloc(origSubloc);
-      }
+      helpSetupLocaleNUMA(this, local_name, numSublocales);
     }
     //------------------------------------------------------------------------}
 
@@ -261,18 +172,7 @@ module LocaleModel {
     // parallel) over the locales to set up the LocaleModel object.
     // In addition, the initial 'here' must be set.
     proc init() {
-      forall locIdx in chpl_initOnLocales() {
-        chpl_task_setSubloc(c_sublocid_any);
-        const node = new LocaleModel(this);
-        myLocales[locIdx] = node;
-        nPUsPhysAcc += node.nPUsPhysAcc;
-        nPUsPhysAll += node.nPUsPhysAll;
-        nPUsLogAcc += node.nPUsLogAcc;
-        nPUsLogAll += node.nPUsLogAll;
-        maxTaskPar += node.maxTaskPar;
-      }
-
-      here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
+      helpSetupRootLocaleNUMA(this);
     }
 
     // Has to be globally unique and not equal to a node ID.
@@ -311,55 +211,21 @@ module LocaleModel {
   //
   // utilities
   //
-  inline
-  proc chpl_getSubloc() {
-    extern proc chpl_task_getSubloc(): chpl_sublocID_t;
-    return chpl_task_getSubloc();
-  }
 
+  // chpl_getSubloc
+  // moved to LocaleModelHelpNUMA.chpl
 
   //////////////////////////////////////////
   //
   // support for memory management
   //
 
-  private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
-
-  // The allocator pragma is used by scalar replacement.
-  pragma "allocator"
-  pragma "locale model alloc"
-  proc chpl_here_alloc(size:int, md:chpl_mem_descInt_t): c_void_ptr {
-    pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
-  }
-
-  pragma "allocator"
-  proc chpl_here_calloc(size:int, number:int, md:chpl_mem_descInt_t): c_void_ptr {
-    pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
-  }
-
-  pragma "allocator"
-  proc chpl_here_realloc(ptr:c_void_ptr, size:int, md:chpl_mem_descInt_t): c_void_ptr {
-    pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
-  }
-
-  proc chpl_here_good_alloc_size(min_size:int): int {
-    pragma "insert line file info"
-      extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
-    return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(int);
-  }
-
-  pragma "locale model free"
-  proc chpl_here_free(ptr:c_void_ptr): void {
-    pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:c_void_ptr) : void;
-    chpl_mem_free(ptr);
-  }
+  // chpl_here_alloc
+  // chpl_here_calloc
+  // chpl_here_realloc
+  // chpl_here_good_alloc_size
+  // chpl_here_free
+  // moved to LocaleModelHelp.chpl
 
   //////////////////////////////////////////
   //
@@ -369,183 +235,20 @@ module LocaleModel {
   //
   // runtime interface
   //
-  extern proc chpl_comm_execute_on(loc_id: int, subloc_id: int, fn: int,
-                                   args: c_void_ptr, arg_size: size_t);
-  extern proc chpl_comm_execute_on_fast(loc_id: int, subloc_id: int, fn: int,
-                                        args: c_void_ptr, args_size: size_t);
-  extern proc chpl_comm_execute_on_nb(loc_id: int, subloc_id: int, fn: int,
-                                      args: c_void_ptr, args_size: size_t);
-  extern proc chpl_ftable_call(fn: int, args: c_void_ptr): void;
-  extern proc chpl_task_setSubloc(subloc: int(32));
 
-  //
-  // regular "on"
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_executeOn(loc: chpl_localeID_t, // target locale
-                      fn: int,              // on-body function idx
-                      args: c_void_ptr,     // function args
-                      args_size: size_t     // args size
-                     ) {
-    const dnode =  chpl_nodeFromLocaleID(loc);
-    const dsubloc =  chpl_sublocFromLocaleID(loc);
-    if dnode != chpl_nodeID {
-      chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
-    } else {
-      // run directly on this node
-      var origSubloc = chpl_task_getRequestedSubloc();
-      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
-        chpl_ftable_call(fn, args);
-      } else {
-        // move to a different sublocale
-        chpl_task_setSubloc(dsubloc);
-        chpl_ftable_call(fn, args);
-        chpl_task_setSubloc(origSubloc);
-      }
-    }
-  }
-
-  //
-  // fast "on" (doesn't do anything that could deadlock a comm layer,
-  // in the Active Messages sense)
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_executeOnFast(loc: chpl_localeID_t, // target locale
-                          fn: int,              // on-body function idx
-                          args: c_void_ptr,     // function args
-                          args_size: size_t     // args size
-                         ) {
-    const dnode =  chpl_nodeFromLocaleID(loc);
-    const dsubloc =  chpl_sublocFromLocaleID(loc);
-    if dnode != chpl_nodeID {
-      chpl_comm_execute_on_fast(dnode, dsubloc, fn, args, args_size);
-    } else {
-      var origSubloc = chpl_task_getRequestedSubloc();
-      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
-        chpl_ftable_call(fn, args);
-      } else {
-        // move to a different sublocale
-        chpl_task_setSubloc(dsubloc);
-        chpl_ftable_call(fn, args);
-        chpl_task_setSubloc(origSubloc);
-      }
-    }
-  }
-
-  // Unused for now due to bug when using 'begin'
-  inline proc chpl_executeOnNBAux(fn: int,         // on-body function idx
-                                  args: c_void_ptr // function args
-                                  ) {
-    if __primitive("task_get_serial") then
-      chpl_ftable_call(fn, args);
-    else
-      begin chpl_ftable_call(fn, args);
-  }
-  //
-  // nonblocking "on" (doesn't wait for completion)
-  //
-  param useBegin = false;
-  pragma "insert line file info"
-  export
-  proc chpl_executeOnNB(loc: chpl_localeID_t, // target locale
-                        fn: int,              // on-body function idx
-                        args: c_void_ptr,     // function args
-                        args_size: size_t     // args size
-                       ) {
-    //
-    // If we're in serial mode, we should use blocking rather than
-    // non-blocking "on" in order to serialize the execute_ons.
-    //
-    const dnode =  chpl_nodeFromLocaleID(loc);
-    const dsubloc =  chpl_sublocFromLocaleID(loc);
-    if dnode != chpl_nodeID {
-      if __primitive("task_get_serial") then
-        chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
-      else
-        chpl_comm_execute_on_nb(dnode, dsubloc, fn, args, args_size);
-    } else {
-      var origSubloc = chpl_task_getRequestedSubloc();
-      // We'd like to call chpl_executeOnNBaux() here, but the begin
-      //  statement seems to cause a problem
-      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
-        // run on this sublocale
-        if useBegin {
-          chpl_executeOnNBAux(fn, args);
-        } else {
-          if __primitive("task_get_serial") then
-            chpl_ftable_call(fn, args);
-          else
-            // begin chpl_ftable_call(fn, args);
-            chpl_comm_execute_on_nb(dnode, dsubloc, fn, args, args_size);
-        }
-      } else {
-        // move to a different sublocale
-        chpl_task_setSubloc(dsubloc);
-        if useBegin {
-          chpl_executeOnNBAux(fn, args);
-        } else {
-          if __primitive("task_get_serial") then
-            chpl_ftable_call(fn, args);
-          else
-            // begin chpl_ftable_call(fn, args);
-            chpl_comm_execute_on_nb(dnode, dsubloc, fn, args, args_size);
-        }
-        chpl_task_setSubloc(origSubloc);
-      }
-    }
-  }
+  // chpl_executeOn
+  // chpl_executeOnFast
+  // chpl_executeOnNB
+  // moved to LocaleModelHelpNUMA.chpl
 
   //////////////////////////////////////////
   //
   // support for tasking statements: begin, cobegin, coforall
   //
 
-  //
-  // runtime interface
-  //
-  pragma "insert line file info"
-  extern proc chpl_task_addToTaskList(fn: int, args: c_void_ptr, subloc_id: int,
-                                      ref tlist: c_void_ptr, tlist_node_id: int,
-                                      is_begin: bool);
-  extern proc chpl_task_executeTasksInList(ref tlist: c_void_ptr);
+  // chpl_taskListAddBegin
+  // chpl_taskListAddCoStmt
+  // chpl_taskListExecute
+  // moved to LocaleModelHelp.chpl
 
-  //
-  // add a task to a list of tasks being built for a begin statement
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListAddBegin(subloc_id: int,        // target sublocale
-                             fn: int,               // task body function idx
-                             args: c_void_ptr,      // function args
-                             ref tlist: c_void_ptr, // task list
-                             tlist_node_id: int     // task list owner node
-                            ) {
-    chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, true);
-  }
-
-  //
-  // add a task to a list of tasks being built for a cobegin or coforall
-  // statement
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListAddCoStmt(subloc_id: int,        // target sublocale
-                              fn: int,               // task body function idx
-                              args: c_void_ptr,      // function args
-                              ref tlist: c_void_ptr, // task list
-                              tlist_node_id: int     // task list owner node
-                             ) {
-    chpl_task_addToTaskList(fn, args, subloc_id, tlist, tlist_node_id, false);
-  }
-
-  //
-  // make sure all tasks in a list have an opportunity to run
-  //
-  pragma "insert line file info"
-  export
-  proc chpl_taskListExecute(ref task_list: c_void_ptr) {
-    chpl_task_executeTasksInList(task_list);
-  }
 }

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -116,21 +116,7 @@ module LocaleModel {
     }
 
     proc getChildCount(): int { return 0; }
-    iter getChildIndices() : int {
-      halt("No children to iterate over.");
-      yield -1;
-    }
-    proc addChild(loc:locale) { halt("Cannot add children to this locale type."); }
     proc getChild(idx:int) : locale { return nil; }
-
-    // This is commented out b/c it leads to an internal error during
-    // the resolveIntents pass.  See
-    // test/functions/iterators/sungeun/iterInClass.future
-    //
-    // iter getChildren() : locale {
-    //  halt("No children to iterate over.");
-    //  yield nil;
-    // }
   }
 
   //
@@ -177,29 +163,13 @@ module LocaleModel {
       f <~> new ioLiteral("LOCALE") <~> _node_id;
     }
 
-    proc getChildSpace() return childSpace;
-
     proc getChildCount() return numSublocales;
-
-    iter getChildIndices() : int {
-      for idx in childSpace do
-        yield idx;
-    }
 
     proc getChild(idx:int) : locale {
       if boundsChecking then
         if (idx < 0) || (idx >= numSublocales) then
           halt("sublocale child index out of bounds (",idx,")");
       return childLocales[idx];
-    }
-
-    iter getChildren() : locale  {
-      for loc in childLocales do
-        yield loc;
-    }
-
-    proc getChildArray() {
-      return childLocales;
     }
 
     //------------------------------------------------------------------------{
@@ -322,19 +292,7 @@ module LocaleModel {
 
     proc getChildCount() return this.myLocaleSpace.numIndices;
 
-    proc getChildSpace() return this.myLocaleSpace;
-
-    iter getChildIndices() : int {
-      for idx in this.myLocaleSpace do
-        yield idx;
-    }
-
     proc getChild(idx:int) return this.myLocales[idx];
-
-    iter getChildren() : locale  {
-      for loc in this.myLocales do
-        yield loc;
-    }
 
     proc getDefaultLocaleSpace() return this.myLocaleSpace;
     proc getDefaultLocaleArray() return myLocales;

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -34,6 +34,7 @@ module LocaleModel {
   // moved to LocaleModelHelpNUMA.chpl
 
   use LocaleModelHelpNUMA;
+  use LocaleModelHelpMem;
 
   // debugLocaleModel
   // doneCreatingLocales
@@ -225,7 +226,7 @@ module LocaleModel {
   // chpl_here_realloc
   // chpl_here_good_alloc_size
   // chpl_here_free
-  // moved to LocaleModelHelp.chpl
+  // moved to LocaleModelHelpMem.chpl
 
   //////////////////////////////////////////
   //

--- a/test/localeModels/numa/dataParallel/forall.chpl
+++ b/test/localeModels/numa/dataParallel/forall.chpl
@@ -2,7 +2,7 @@ config const beNoisy = false;
 {
   writeln("Locales array iteration");
   for loc in Locales {
-    const A = (loc:LocaleModel).getChildArray();
+    const A = (loc:LocaleModel).getChildren();
     forall a in A do
       if beNoisy then writeln((a, chpl_getSubloc()));
   }


### PR DESCRIPTION
Cleaning up locale models implementations in preparation for adding new
locale models.

First, update the ChapelLocale interface for what a locale is:

* Adds numChildren as a convenient synonym for getChildCount()
  (getChildCount seems to me to be an awkward name).
* Implements getChildIndices, getChildren in locale instead of in the
  subclasses. Subclasses can override these if they want to. (I verified
  that this inheritance of iterators pattern works in a simple test).
  Removed these from flat and numa LocaleModels since the default
  implementation is just as good for them.
* Remove getChildSpace and getChildArray. These are defined but not used
  in modules or tests, except for 1 use in a test of the locale model
  itself. They do not seem to be adding any value beyond the other
  methods available.
* Clearly distinguish which methods must be overridden in
  ChapelLocales.chpl.

Next, makes callStackSize a var so helper methods can set it.  I don't
expect this field to be used frequently or use of it to be
performance-sensitive.

Next, factor most of the code in the flat/numa LocaleModel.chpl files
into new LocaleModelHelp, LocaleModelHelpFlat, and LocaleModelHelpNUMA
modules. That way, when I add another locale model that builds off of
flat or numa, this code does not need to be repeated. Most of this code
is really about how Chapel interacts with its own C runtime, rather than
about architecture-specific details. Note though that future locale
models are not obligated to use these new LocaleModelHelp modules - they
are here simply as a way to save typing/duplicate code.

Next, fix race conditions in computing the aggregate numPUs and related
variables for the rootLocale. The previous implementation did not compute
the same value for each run. The code computing this sum is somewhat
restricted since it occurs fairly early in program initialization.
Additionally, since it only occurs during program start-up, it is not
very performance sensitive. Thus, I used atomic variables to do it.

hello passes with flat/numa gasnet/none.
