### PR TITLE
Fix documentation broken link warnings in Sort and AdvancedIters modules

### DIFF
--- a/modules/standard/AdvancedIters.chpl
+++ b/modules/standard/AdvancedIters.chpl
@@ -53,16 +53,16 @@ config param debugAdvancedIters:bool=false;
 
   :arg c: The range to iterate over. The length of the range must be greater
           than zero.
-  :type c: range(?)
+  :type c: `range(?)`
 
   :arg chunkSize: The size of chunks to be yielded to each thread. Must be
                   greater than zero.
-  :type chunkSize: int
+  :type chunkSize: `int`
 
   :arg numTasks: The number of tasks to use. Must be >= zero. If this argument
                  has the value 0, it will use the value indicated by
                  ``dataParTasksPerLocale``.
-  :type numTasks: int
+  :type numTasks: `int`
 
   :yields: Indices in the range ``c``.
 
@@ -160,12 +160,12 @@ where tag == iterKind.follower
 /*
 
   :arg c: The range to iterate over. Must have a length greater than zero.
-  :type c: range(?)
+  :type c: `range(?)`
 
   :arg numTasks: The number of tasks to use. Must be >= zero. If this argument
                  has the value 0, it will use the value indicated by
                  ``dataParTasksPerLocale``.
-  :type numTasks: int
+  :type numTasks: `int`
 
   :yields: Indices in the range ``c``.
 
@@ -241,12 +241,12 @@ where tag == iterKind.follower
 /*
 
   :arg c: The range to iterate over. Must have a length greater than zero.
-  :type c: range(?)
+  :type c: `range(?)`
 
   :arg numTasks: The number of tasks to use. Must be >= zero. If this argument
                  has the value 0, it will use the value indicated by
                  ``dataParTasksPerLocale``.
-  :type numTasks: int
+  :type numTasks: `int`
 
   :yields: Indices in the range ``c``.
 

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -42,11 +42,11 @@ private inline proc chpl_sort_cmp(a, b, param reverse=false, param eq=false) {
    Sort the 1D array `Data` in-place using a sequential bubble sort algorithm.
 
    :arg Data: The array to be sorted
-   :type Data: [] eltType
+   :type Data: [] `eltType`
    :arg doublecheck: Verify the array is correctly sorted before returning
-   :type doublecheck: bool
+   :type doublecheck: `bool`
    :arg reverse: Sort in reverse numerical order
-   :type reverse: bool
+   :type reverse: `bool`
 
  */
 proc BubbleSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) where Dom.rank == 1 {
@@ -72,11 +72,11 @@ proc BubbleSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) wh
    Sort the 1D array `Data` in-place using a sequential heap sort algorithm.
 
    :arg Data: The array to be sorted
-   :type Data: [] elType
+   :type Data: [] `eltType`
    :arg doublecheck: Verify the array is correctly sorted before returning
-   :type doublecheck: bool
+   :type doublecheck: `bool`
    :arg reverse: Sort in reverse numerical order
-   :type reverse: bool
+   :type reverse: `bool`
 
  */
 proc HeapSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) where Dom.rank == 1 {
@@ -122,11 +122,11 @@ proc HeapSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) wher
    Sort the 1D array `Data` in-place using a sequential insertion sort algorithm.
 
    :arg Data: The array to be sorted
-   :type Data: [] eltType
+   :type Data: [] `eltType`
    :arg doublecheck: Verify the array is correctly sorted before returning
-   :type doublecheck: bool
+   :type doublecheck: `bool`
    :arg reverse: Sort in reverse numerical order
-   :type reverse: bool
+   :type reverse: `bool`
 
  */
 proc InsertionSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) where Dom.rank == 1 {
@@ -156,13 +156,13 @@ proc InsertionSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false)
    Sort the 1D array `Data` in-place using a parallel merge sort algorithm.
 
    :arg Data: The array to be sorted
-   :type Data: [] eltType
+   :type Data: [] `eltType`
    :arg minlen: When the array size is less than `minlen` use insertion sort algorithm
-   :type minlen: integral
+   :type minlen: `integral`
    :arg doublecheck: Verify the array is correctly sorted before returning
-   :type doublecheck: bool
+   :type doublecheck: `bool`
    :arg reverse: Sort in reverse numerical order
-   :type reverse: bool
+   :type reverse: `bool`
 
  */
 proc MergeSort(Data: [?Dom], minlen=16, doublecheck=false, param reverse=false) where Dom.rank == 1 {
@@ -219,13 +219,13 @@ private iter _MergeIterator(A1: [] ?elType, A2: [] elType, param reverse=false) 
    Sort the 1D array `Data` in-place using a sequential quick sort algorithm.
 
    :arg Data: The array to be sorted
-   :type Data: [] eltType
+   :type Data: [] `eltType`
    :arg minlen: When the array size is less than `minlen` use insertion sort algorithm
-   :type minlen: integral
+   :type minlen: `integral`
    :arg doublecheck: Verify the array is correctly sorted before returning
-   :type doublecheck: bool
+   :type doublecheck: `bool`
    :arg reverse: Sort in reverse numerical order
-   :type reverse: bool
+   :type reverse: `bool`
 
  */
 proc QuickSort(Data: [?Dom] ?elType, minlen=16, doublecheck=false, param reverse=false) where Dom.rank == 1 {
@@ -276,11 +276,11 @@ proc QuickSort(Data: [?Dom] ?elType, minlen=16, doublecheck=false, param reverse
    algorithm.
 
    :arg Data: The array to be sorted
-   :type Data: [] eltType
+   :type Data: [] `eltType`
    :arg doublecheck: Verify the array is correctly sorted before returning
-   :type doublecheck: bool
+   :type doublecheck: `bool`
    :arg reverse: Sort in reverse numerical order
-   :type reverse: bool
+   :type reverse: `bool`
 
  */
 proc SelectionSort(Data: [?Dom], doublecheck=false, param reverse=false) where Dom.rank == 1 {
@@ -301,11 +301,11 @@ proc SelectionSort(Data: [?Dom], doublecheck=false, param reverse=false) where D
    out of order.
 
    :arg Data: The array to verify
-   :type Data: [] eltType
+   :type Data: [] `eltType`
    :arg str: string to print while halting if an element is out of order
-   :type str: string
+   :type str: `string`
    :arg reverse: if true, expect the values to be sorted in reverse.
-   :type reverse: bool
+   :type reverse: `bool`
 
  */
 inline proc VerifySort(Data: [?Dom] ?elType, str: string, param reverse=false) {
@@ -331,7 +331,7 @@ inline proc VerifySort(Data: [?Dom] ?elType, str: string, param reverse=false) {
    Yield the elements of argument `x` in sorted order.
 
    :arg x: An iterable value to be sorted and yielded element by element
-   :type x: iterable
+   :type x: `iterable`
 
    :yields: The elements of x in sorted order
    :ytype: x's element type

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -49,7 +49,7 @@ private inline proc chpl_sort_cmp(a, b, param reverse=false, param eq=false) {
    :type reverse: `bool`
 
  */
-proc BubbleSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) where Dom.rank == 1 {
+proc BubbleSort(Data: [?Dom] ?eltType, doublecheck=false, param reverse=false) where Dom.rank == 1 {
   const lo = Dom.dim(1).low;
   const hi = Dom.dim(1).high;
   var swapped = true;
@@ -79,7 +79,7 @@ proc BubbleSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) wh
    :type reverse: `bool`
 
  */
-proc HeapSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) where Dom.rank == 1 {
+proc HeapSort(Data: [?Dom] ?eltType, doublecheck=false, param reverse=false) where Dom.rank == 1 {
   const lo = Dom.dim(1).low;
   const hi = Dom.dim(1).high;
   const len = Dom.dim(1).size;
@@ -129,7 +129,7 @@ proc HeapSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) wher
    :type reverse: `bool`
 
  */
-proc InsertionSort(Data: [?Dom] ?elType, doublecheck=false, param reverse=false) where Dom.rank == 1 {
+proc InsertionSort(Data: [?Dom] ?eltType, doublecheck=false, param reverse=false) where Dom.rank == 1 {
   const lo = Dom.low;
   for i in Dom {
     const ithVal = Data(i);
@@ -190,7 +190,7 @@ private proc _MergeSort(Data: [?Dom], minlen=16, param reverse=false) where Dom.
 }
 
 
-private iter _MergeIterator(A1: [] ?elType, A2: [] elType, param reverse=false) {
+private iter _MergeIterator(A1: [] ?eltType, A2: [] eltType, param reverse=false) {
   var a1 = A1.domain.dim(1).low;
   const a1hi = A1.domain.dim(1).high;
   var a2 = A2.domain.dim(1).low;
@@ -228,7 +228,7 @@ private iter _MergeIterator(A1: [] ?elType, A2: [] elType, param reverse=false) 
    :type reverse: `bool`
 
  */
-proc QuickSort(Data: [?Dom] ?elType, minlen=16, doublecheck=false, param reverse=false) where Dom.rank == 1 {
+proc QuickSort(Data: [?Dom] ?eltType, minlen=16, doublecheck=false, param reverse=false) where Dom.rank == 1 {
   // grab obvious indices
   const lo = Dom.low, 
         hi = Dom.high,
@@ -308,7 +308,7 @@ proc SelectionSort(Data: [?Dom], doublecheck=false, param reverse=false) where D
    :type reverse: `bool`
 
  */
-inline proc VerifySort(Data: [?Dom] ?elType, str: string, param reverse=false) {
+inline proc VerifySort(Data: [?Dom] ?eltType, str: string, param reverse=false) {
   for i in Dom.low..Dom.high-1 do
     if chpl_sort_cmp(Data(i+1), Data(i), reverse) then
       halt(str, " did not sort properly (", i, "): ", Data);


### PR DESCRIPTION
These modules use the :type: role for procedure arguments with types that
are not explicitly declared within the documentation such as 'int' and
'range(?)'.  Add backquotes around the names of those types.