### PR TITLE
Test out the performance of the "distrib" qthreads scheduler

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,11 +9,17 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of jemalloc's decay-based purging
-export CHPL_JEMALLOC_MORE_CFG_OPTIONS="--with-malloc-conf=purge:decay"
-SHORT_NAME=decay-purge
-START_DATE=03/12/16
+# Test performance of qthread "distrib" scheduler
+export CHPL_QTHREAD_SCHEDULER=distrib
 
+GITHUB_USER=ronawho
+GITHUB_BRANCH=qthreads-test-disrib
+SHORT_NAME=distrib
+START_DATE=03/15/16
+
+git branch -D $GITHUB_USER-$GITHUB_BRANCH
+git checkout -b $GITHUB_USER-$GITHUB_BRANCH
+git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"


### PR DESCRIPTION
Test out the perf of the distrib scheduler compared to nemesis w/ flat to see
its overall performance characters. It's technically a sherwood competitor,
but ideally we only want to use a single scheduler for flat and numa.

For chameneos on chapcs07 I'm seeing pretty competitive performance

~ 4.0 seconds for nemesis
~ 5.0 seconds for distrib
~30.0 seconds for sherwood

From the qthreads team:

"
It is basically just a simplified sherwood that is a bit faster. There is an
exponential backoff that starts with spinloop and switches to a
pthread_cond_wait. You can control the maximum exponent of both with
QT_SPINLOOP_BACKOFF and QT_MAX_BACKOFF, which controls the exponent for the
number of spinloops and the number of nanoseconds, respectively. They default
to 16 and 23, respectively, which seemed like good defaults from my testing.

There is also the STEAL_RATIO, which now does something fairly different: for
each loop checking for work, separated by a wait determined by the above
backoff, it will do a local check for work, but for every STEAL_RATIO loop, it
will check remotely as well. This has a default of 8. In other words, for every
8 times it checks locally, it will check remotely once. It is different from
sherwood in that it doesn't steal multiple. This actually seems to help with
performance.
"