### PR TITLE
Correctness and performance improvements to miniMD

### DIFF
--- a/test/release/examples/benchmarks/miniMD/helpers/StencilDist.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/StencilDist.chpl
@@ -1240,15 +1240,15 @@ iter _array.boundaries(param tag : iterKind) where tag == iterKind.standalone {
 
 iter StencilArr.dsiBoundaries() {
   for i in dom.dist.targetLocDom {
-    var loc = locArr[i];
-    for (D, N, L) in zip(loc.Dest, loc.Neighs, loc.NeighDom) {
+    var LSA = locArr[i];
+    for (D, N, L) in zip(LSA.Dest, LSA.Neighs, LSA.NeighDom) {
       const target = i + L;
       const low = dom.dist.targetLocDom.low;
       const high = dom.dist.targetLocDom.high;
 
       if (!dom.dist.targetLocDom.member(target)) {
         var translated : target.type;
-        for param r in 1..loc.rank {
+        for param r in 1..LSA.rank {
           if target(r) < low(r) {
             translated(r) = target(r);
           } else if target(r) > high(r) {
@@ -1258,7 +1258,7 @@ iter StencilArr.dsiBoundaries() {
           }
         }
 
-        for el in loc.myElems[D] do yield (el, translated);
+        for el in LSA.myElems[D] do yield (el, translated);
       }
     }
   }
@@ -1271,13 +1271,13 @@ iter StencilArr.dsiBoundaries() {
 iter StencilArr.dsiBoundaries(param tag : iterKind) where tag == iterKind.standalone {
   coforall i in dom.dist.targetLocDom {
     on dom.dist.targetLocales(i) {
-      var loc = locArr[i];
-      forall (D, N, L) in zip(loc.Dest, loc.Neighs, loc.NeighDom) {
+      var LSA = locArr[i];
+      forall (D, N, L) in zip(LSA.Dest, LSA.Neighs, LSA.NeighDom) {
         const target = i + L;
         const low = dom.dist.targetLocDom.low;
         const high = dom.dist.targetLocDom.high;
         //
-        // if `loc` has a cache section of the outermost fluff/boundary,
+        // if `LSA` has a cache section of the outermost fluff/boundary,
         // then we should yield that so it is updated correctly. To do
         // so, we need to translate the local offset to the global offset.
         // A 2D example:
@@ -1297,7 +1297,7 @@ iter StencilArr.dsiBoundaries(param tag : iterKind) where tag == iterKind.standa
         // If the target locale is outside the grid, it's a boundary chunk
         if (!dom.dist.targetLocDom.member(target)) {
           var translated : target.type;
-          for param r in 1..loc.rank {
+          for param r in 1..LSA.rank {
             if target(r) < low(r) {
               translated(r) = target(r);
             } else if target(r) > high(r) {
@@ -1308,7 +1308,7 @@ iter StencilArr.dsiBoundaries(param tag : iterKind) where tag == iterKind.standa
           }
 
           // TODO: should we 'forall' over this instead?
-          for el in loc.myElems[D] do yield (el, translated);
+          for el in LSA.myElems[D] do yield (el, translated);
         }
       }
     }

--- a/test/release/examples/benchmarks/miniMD/helpers/StencilDist.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/StencilDist.chpl
@@ -1269,7 +1269,7 @@ iter StencilArr.dsiBoundaries() {
 iter StencilArr.dsiBoundaries(param tag : iterKind) where tag == iterKind.leader {
   coforall i in dom.dist.targetLocDom {
     on dom.dist.targetLocales(i) {
-      for (D, N, L) in zip(locArr[i].Dest, locArr[i].Neighs, locArr[i].NeighDom) {
+      forall (D, N, L) in zip(locArr[i].Dest, locArr[i].Neighs, locArr[i].NeighDom) {
         if (i + L != N) {
           for el in locArr[i].myElems[D] do yield (el, L);
         }
@@ -1292,7 +1292,7 @@ proc StencilArr.dsiUpdateFluff() {
   if zeroTuple(dom.fluff) then return;
   coforall i in dom.dist.targetLocDom {
     on dom.dist.targetLocales(i) {
-      for (S, D, N, L) in zip(locArr[i].Src, locArr[i].Dest, 
+      forall (S, D, N, L) in zip(locArr[i].Src, locArr[i].Dest, 
           locArr[i].Neighs, locArr[i].NeighDom) {
         if !zeroTuple(L) {
           if !dom.dist.targetLocDom.member(i+L) && dom.periodic then

--- a/test/release/examples/benchmarks/miniMD/helpers/StencilDist.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/StencilDist.chpl
@@ -928,20 +928,6 @@ inline proc StencilArr.dsiLocalAccess(i: rank*idxType) ref {
   return myLocArr.this(i);
 }
 
-proc _array.readRemote(i: _value.rank*_value.idxType) {
-  return _value.dsiReadRemote(i);
-}
-
-proc StencilArr.dsiReadRemote(i: rank*idxType) {
-  local {
-    if myLocArr != nil {
-
-      // return from actual if it's a write or there's no fluff
-      if myLocArr.locDom.member(i) then return myLocArr.this(i);
-    }
-  } 
-  return locArr(dom.dist.targetLocsIdx(i))(i);
-}
 //
 // the global accessor for the array
 //

--- a/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
@@ -334,14 +334,19 @@ class ForceLJ : Force {
     // for each atom, compute force between itself and its neighbors
     fTimer.start();
     var eng, vir : atomic real;
-    forall (b,p,c,r) in zip(Bins, RealPos, RealCount, binSpace) {
+
+    // Get a const copy of 'cutforcesq' and use the 'in' intent to get a copy on each
+    // locale to reduce communication
+    const cfsq = cutforcesq;
+
+    forall (b,p,c,r) in zip(Bins, RealPos, RealCount, binSpace) with (in cfsq) {
       var t_eng, t_vir : real;
       for (a, x, j) in zip(b[1..c],p[1..c],1..c) {
         for(n,i) in a.neighs[1..a.ncount] {
           const del = x - Pos[n][i];
           const rsq = dot(del,del);
           
-          if rsq < cutforcesq {
+          if rsq < cfsq {
             const sr2: real = 1.0 / rsq;
             const sr6 : real = sr2 * sr2 * sr2;
             const force : real = 48.0 * sr6 * (sr6 - .5) * sr2;

--- a/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
@@ -12,9 +12,7 @@ proc updateFluff() {
     // boundaries() yields a periodic array element, and the 
     // neighbor panel value
     forall (pos, N) in Pos.boundaries() {
-      //forall p in pos do
-       // p += PosOffset[N];
-      pos += PosOffset[N];
+      for p in pos do p += PosOffset[N];
     }
   } else {
     forall (P, D, S) in zip(PosOffset, Dest, Src) {

--- a/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
@@ -121,8 +121,9 @@ proc buildNeighbors() {
 // See test/types/records/bharshbarger/remote*Record.chpl for more.
 inline proc addatom(ref a : atom, x : v3, b : v3int) {
   // increment bin's # of atoms
-  Count[b] += 1;
-  const end = if useStencilDist then Count.readRemote(b) else Count[b];
+  var end = RealCount[b];
+  end += 1;
+  RealCount[b] = end;
   
   // resize bin storage if needed
   if end >= perBinSpace.high {
@@ -134,7 +135,7 @@ inline proc addatom(ref a : atom, x : v3, b : v3int) {
   // add to the end of the bin
   Bins[b][end].v = a.v;
   Bins[b][end].f = a.f;
-  Pos[b][end] = x;
+  RealPos[b][end] = x;
 }
 
 proc binAtoms() {

--- a/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
@@ -119,8 +119,7 @@ proc buildNeighbors() {
 // See test/types/records/bharshbarger/remote*Record.chpl for more.
 inline proc addatom(ref a : atom, x : v3, b : v3int) {
   // increment bin's # of atoms
-  var end = RealCount[b];
-  end += 1;
+  const end = RealCount[b] + 1;
   RealCount[b] = end;
   
   // resize bin storage if needed


### PR DESCRIPTION
Correctness improvements:
- StencilArr.dsiBoundaries() now yields all outer boundary chunks with the correct global offset coordinates
- StencilArr.dsiBoundaries() is now a standalone parallel iterator
- The readRemote() function has been retired in favor of reading from a slice into the non-boundary regions of the array

Performance improvements:
- More parallelism in dsiUpdateFluff and dsiBoundaries
- reduced communication in force computation step