### PR TITLE
Add recent jemalloc perf annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -152,6 +152,10 @@ binary-trees:
     - introduce "library mode"
   01/25/16:
     - Optimize iteration over anonymous low-bounded counted ranges (#3154)
+  03/14/16:
+    - upgrade jemalloc to 4.1.0 (#3447)
+  03/16/16:
+    - revert jemalloc to 4.0.4 (#3477)
 
 chameneos-redux:
   07/08/13:
@@ -195,6 +199,8 @@ fasta:
     - Add c_string_copy type
   01/14/16:
     - optimize certain functions that return with ref-intent (#3101)
+  03/12/16:
+    - implemented good_alloc_size for jemalloc(#3446)
 
 forall-dom-range:
   01/21/15:
@@ -367,6 +373,10 @@ nbody:
     - chap04 Subtest random glitch
   01/17/16:
     - add dead string literal elimination (#3120)
+  03/14/16:
+    - upgrade jemalloc to 4.1.0 (#3447)
+  03/16/16:
+    - revert jemalloc to 4.0.4 (#3477)
 
 parOpEquals:
   09/06/13:
@@ -387,6 +397,8 @@ regexdna:
     - started building re2 with optimizations (#2930)
   12/13/15:
     - Fixed string memory leak resulting from redundant autoCopies (#3023)
+  03/12/16:
+    - implemented good_alloc_size for jemalloc(#3446)
 
 revcomp:
   05/11/15:


### PR DESCRIPTION
10% speedup for fasta-lines and regex-dna with good_alloc_size implementation
10% speedup for binary-trees and nbody with jemalloc 4.1.0 upgrade
10% slowdown for binary-tress and nbody with jemalloc 4.0.4 reversion