### PR TITLE
Reduce communications in PRK/Stencil

### DIFF
--- a/test/studies/prk/stencil/stencil-fast.chpl
+++ b/test/studies/prk/stencil/stencil-fast.chpl
@@ -191,8 +191,8 @@ proc main() {
       if debug then diagnostics('output.updateFluff()');
       output.updateFluff();
 
-      if debug then diagnostics('input.updateFluff()');
-      input.updateFluff();
+      //if debug then diagnostics('input.updateFluff()');
+      //input.updateFluff();
     }
 
 

--- a/test/studies/prk/stencil/stencil-fast.chpl
+++ b/test/studies/prk/stencil/stencil-fast.chpl
@@ -190,9 +190,6 @@ proc main() {
     if useStencilDist then {
       if debug then diagnostics('output.updateFluff()');
       output.updateFluff();
-
-      //if debug then diagnostics('input.updateFluff()');
-      //input.updateFluff();
     }
 
 

--- a/test/studies/prk/stencil/stencil-fast.chpl
+++ b/test/studies/prk/stencil/stencil-fast.chpl
@@ -5,6 +5,7 @@ use Time;
 use BlockDist;
 use ReplicatedDist;
 use StencilDist; // Included from miniMD
+use VisualDebug;
 
 param PRKVERSION = "2.15";
 
@@ -21,7 +22,7 @@ config param R = 2,
              compact = false,
              // Control of multilocale parallelism
              useStencilDist = false,
-             useBlockDist = (CHPL_COMM != "none" && !useStencilDist);
+             useBlockDist = false;
 
 // Configurable type for array elements
 config type dtype = real;
@@ -38,182 +39,204 @@ const activePoints = (order-2*R)*(order-2*R),
 
 var timer: Timer;
 
-//
-// Process and test input configs
-//
-if (iterations < 1) {
-  writeln("ERROR: iterations must be >= 1: ", iterations);
-  exit(1);
-}
-if (order < 1) {
-  writeln("ERROR: Matrix Order must be greater than 0 : ", order);
-  exit(1);
-}
-if (R < 1) {
-  writeln("ERROR: Stencil radius ", R, " should be positive");
-  exit(1);
-}
-if (2*R + 1 > order) {
-  writeln("ERROR: Stencil radius ", R, " exceeds grid size ", order);
-  exit(1);
-}
-
-// Determine tiling
-var tiling = (tileSize > 0 && tileSize < order);
-
-// Safety check for creation of tiledDom
-if (!tiling) then tileSize = 1;
-
-// Domain Map
-
-const localDom = {0.. # order, 0.. # order},
- innerLocalDom = localDom.expand(-R),
-weightLocalDom = {-R..R, -R..R};
-
-// Choice of distribution / parallelism
-const blockDist = new dmap(new Block(localDom)),
-    stencilDist = new dmap(new Stencil(innerLocalDom, fluff=(R,R))),
-         noDist = new dmap(new DefaultDist()),
-       replDist = new dmap(new ReplicatedDist());
-
-const Dist =  if useBlockDist then blockDist
-              else if useStencilDist then stencilDist
-              else noDist;
-
-//const weightDist = if (useBlockDist || useStencilDist) then replDist
-//                 else noDist;
-
-// Domains
-const Dom = localDom dmapped Dist,
- innerDom = innerLocalDom dmapped Dist,
-weightDom = {-R..R, -R..R};
-
-var tiledDom = {R.. # order-2*R by tileSize, R.. # order-2*R by tileSize};
-
-// Arrays (initialized to zeros)
-var input, output:  [Dom] dtype = 0.0;
-
-// Tuple of tuples
-var weight: Wsize*(Wsize*(dtype));
-
-// Create local copy of weight on each Locale
-for loc in Locales do on loc {
-  for i in 1..R {
-    const element : dtype = 1 / (2*i*R) : dtype;
-    weight[R1][R1+i]  =  element;
-    weight[R1+i][R1]  =  element;
-    weight[R1-i][R1] = -element;
-    weight[R1][R1-i] = -element;
+proc main() {
+  //
+  // Process and test input configs
+  //
+  if (iterations < 1) {
+    writeln("ERROR: iterations must be >= 1: ", iterations);
+    exit(1);
   }
-}
-
-// Initialize the input and output arrays
-[(i, j) in Dom] input[i,j] = coefx*i+coefy*j;
-
-if useStencilDist then input.updateFluff();
-
-//
-// Print information before main loop
-//
-if (!validate) {
-  writeln("Parallel Research Kernels Version ", PRKVERSION);
-  writeln("Serial stencil execution on 2D grid");
-  writeln("Grid size            = ", order);
-  writeln("Radius of stencil    = ", R);
-  if compact then writeln("Type of stencil      = compact");
-  else              writeln("Type of stencil      = star");
-  writeln("Data type            = ", dtype:string);
-  if tiling then writeln("Tile size             = ", tileSize);
-  else             writeln("Untiled");
-  writeln("Number of iterations = ", iterations);
-}
-
-
-//
-// Main loop
-//
-for iteration in 0..iterations {
-
-  // Start timer after warmup iteration
-  if (iteration == 1) {
-    timer.start();
+  if (order < 1) {
+    writeln("ERROR: Matrix Order must be greater than 0 : ", order);
+    exit(1);
+  }
+  if (R < 1) {
+    writeln("ERROR: Stencil radius ", R, " should be positive");
+    exit(1);
+  }
+  if (2*R + 1 > order) {
+    writeln("ERROR: Stencil radius ", R, " exceeds grid size ", order);
+    exit(1);
   }
 
-  if (!tiling) {
-    forall (i,j) in innerDom {
-      var tmpout: dtype = 0.0;
-      if (!compact) {
-        for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input[i, j+jj];
-        for param jj in 1..R   do tmpout += weight[R1][R1+jj] * input[i, j+jj];
-        for param ii in -R..-1 do tmpout += weight[R1+ii][R1] * input[i+ii, j];
-        for param ii in 1..R   do tmpout += weight[R1+ii][R1] * input[i+ii, j];
-      } else {
-        for (ii, jj) in weightDom do
-          tmpout += weight[R1+ii][R1+jj] * input[i+ii, j+jj];
-      }
-      output[i, j] += tmpout;
-    }
-  } else {
-    forall (it,jt) in tiledDom {
-      for i in it .. # min(order - R - it, tileSize) {
-        for j in jt .. # min(order - R - jt, tileSize) {
-          var tmpout: dtype = 0.0;
-          if (!compact) {
-            for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input[i, j+jj];
-            for param jj in 1..R   do tmpout += weight[R1][R1+jj] * input[i, j+jj];
-            for param ii in -R..-1 do tmpout += weight[R1+ii][R1] * input[i+ii, j];
-            for param ii in 1..R   do tmpout += weight[R1+ii][R1] * input[i+ii, j];
-          } else {
-            for (ii, jj) in weightDom do
-              tmpout += weight[R1+ii][R1+jj] * input[i+ii, j+jj];
-          }
-          output[i, j] += tmpout;
-        }
-      }
+  // Determine tiling
+  var tiling = (tileSize > 0 && tileSize < order);
+
+  // Safety check for creation of tiledDom
+  if (!tiling) then tileSize = 1;
+
+  // Domain Map
+
+  const localDom = {0.. # order, 0.. # order},
+   innerLocalDom = localDom.expand(-R),
+  weightLocalDom = {-R..R, -R..R};
+
+  // Choice of distribution / parallelism
+  const blockDist = new dmap(new Block(localDom)),
+      stencilDist = new dmap(new Stencil(innerLocalDom, fluff=(R,R))),
+           noDist = new dmap(new DefaultDist()),
+         replDist = new dmap(new ReplicatedDist());
+
+  const Dist =  if useBlockDist then blockDist
+                else if useStencilDist then stencilDist
+                else noDist;
+
+  //const weightDist = if (useBlockDist || useStencilDist) then replDist
+  //                 else noDist;
+
+  // Domains
+  const Dom = localDom dmapped new dmap(new Stencil(innerLocalDom, fluff=(R,R))),
+   innerDom = innerLocalDom dmapped new dmap(new Stencil(innerLocalDom, fluff=(R,R)));
+
+  var tiledDom = {R.. # order-2*R by tileSize, R.. # order-2*R by tileSize};
+
+  // Arrays (initialized to zeros)
+  var input, output:  [Dom] dtype = 0.0;
+
+
+  // Tuple of tuples
+  pragma "locale private"
+  var weight: Wsize*(Wsize*(dtype));
+
+  // Create local copy of weight on each Locale
+  for loc in Locales do on loc {
+    for i in 1..R {
+      const element : dtype = 1 / (2*i*R) : dtype;
+      weight[R1][R1+i]  =  element;
+      weight[R1+i][R1]  =  element;
+      weight[R1-i][R1] = -element;
+      weight[R1][R1-i] = -element;
     }
   }
+
+  // Initialize the input and output arrays
+  [(i, j) in Dom] input[i,j] = coefx*i+coefy*j;
 
   if useStencilDist then input.updateFluff();
 
-  // Add constant to solution to force refresh of neighbor data, if any
-  forall (i,j) in Dom {
-    input[i, j] += 1.0;
-  }
-
-} // end of iterations
-
-timer.stop();
-
-//
-// Analyze and output results
-//
-
-// Timings
-var stencilTime = timer.elapsed(),
-    flops = (2*stencilSize + 1) * activePoints,
-    avgTime = stencilTime / iterations;
-
-// Compute L1 norm
-var referenceNorm = (iterations + 1) * (coefx + coefy),
-    norm = + reduce abs(output);
-norm /= activePoints;
-
-// Error threshold
-const epsilon = 1.e-8;
-
-// Verify correctness
-if abs(norm-referenceNorm) > epsilon then {
-  writeln("ERROR: L1 norm = ", norm, ", Reference L1 norm = ", referenceNorm);
-  exit(1);
-} else {
-  writeln("Solution validates");
-
-  if debug {
-    writeln("L1 norm = ", norm, ", Reference L1 norm = ", referenceNorm);
-  }
-
+  //
+  // Print information before main loop
+  //
   if (!validate) {
-    writeln("Rate (MFlops/s): ", 1.0E-06 * flops/avgTime, "  Avg time (s): ", 
-            avgTime);
+    writeln("Parallel Research Kernels Version ", PRKVERSION);
+    writeln("Serial stencil execution on 2D grid");
+    writeln("Grid size            = ", order);
+    writeln("Radius of stencil    = ", R);
+    if compact then writeln("Type of stencil      = compact");
+    else            writeln("Type of stencil      = star");
+    writeln("Data type            = ", dtype:string);
+    if tiling then writeln("Tile size             = ", tileSize);
+    else           writeln("Untiled");
+    writeln("Number of iterations = ", iterations);
+    if useBlockDist then        writeln("Distribution         = Block");
+    else if useStencilDist then writeln("Distribution         = Stencil");
+    else                        writeln("Distribution         = None");
   }
+
+
+  //
+  // Main loop
+  //
+  if debug then startVdebug("stencil-fast-vis");
+  for iteration in 0..iterations {
+
+    // Start timer after warmup iteration
+    if (iteration == 1) {
+      timer.start();
+    }
+
+    if debug then tagVdebug('stencil');
+    if (!tiling) {
+      forall (i,j) in innerDom {
+        var tmpout: dtype = 0.0;
+        if (!compact) {
+          for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input[i, j+jj];
+          for param jj in 1..R   do tmpout += weight[R1][R1+jj] * input[i, j+jj];
+          for param ii in -R..-1 do tmpout += weight[R1+ii][R1] * input[i+ii, j];
+          for param ii in 1..R   do tmpout += weight[R1+ii][R1] * input[i+ii, j];
+        } else {
+          for (ii, jj) in {-R..R, -R..R} do
+            tmpout += weight[R1+ii][R1+jj] * input[i+ii, j+jj];
+        }
+        output[i, j] += tmpout;
+      }
+    } else {
+      forall (it,jt) in tiledDom {
+        for i in it .. # min(order - R - it, tileSize) {
+          for j in jt .. # min(order - R - jt, tileSize) {
+            var tmpout: dtype = 0.0;
+            if (!compact) {
+              for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input[i, j+jj];
+              for param jj in 1..R   do tmpout += weight[R1][R1+jj] * input[i, j+jj];
+              for param ii in -R..-1 do tmpout += weight[R1+ii][R1] * input[i+ii, j];
+              for param ii in 1..R   do tmpout += weight[R1+ii][R1] * input[i+ii, j];
+            } else {
+              for (ii, jj) in {-R..R, -R..R} do
+                tmpout += weight[R1+ii][R1+jj] * input[i+ii, j+jj];
+            }
+            output[i, j] += tmpout;
+          }
+        }
+      }
+    }
+
+    // Add constant to solution to force refresh of neighbor data, if any
+    if debug then diagnostics('input += 1');
+    forall (i,j) in Dom {
+      input[i, j] += 1.0;
+    }
+
+    if useStencilDist then {
+      if debug then diagnostics('output.updateFluff()');
+      output.updateFluff();
+
+      if debug then diagnostics('input.updateFluff()');
+      input.updateFluff();
+    }
+
+
+  } // end of iterations
+
+  timer.stop();
+  if debug then stopVdebug();
+
+  //
+  // Analyze and output results
+  //
+
+  // Timings
+  var stencilTime = timer.elapsed(),
+      flops = (2*stencilSize + 1) * activePoints,
+      avgTime = stencilTime / iterations;
+
+  // Compute L1 norm
+  var referenceNorm = (iterations + 1) * (coefx + coefy),
+      norm = + reduce abs(output);
+  norm /= activePoints;
+
+  // Error threshold
+  const epsilon = 1.e-8;
+
+  // Verify correctness
+  if abs(norm-referenceNorm) > epsilon then {
+    writeln("ERROR: L1 norm = ", norm, ", Reference L1 norm = ", referenceNorm);
+    exit(1);
+  } else {
+    writeln("Solution validates");
+
+    if debug {
+      writeln("L1 norm = ", norm, ", Reference L1 norm = ", referenceNorm);
+    }
+
+    if (!validate) {
+      writeln("Rate (MFlops/s): ", 1.0E-06 * flops/avgTime, "  Avg time (s): ", 
+              avgTime);
+    }
+  }
+}
+
+proc diagnostics(tag: string) {
+  tagVdebug(tag);
+  writeln('[Debug]: ', tag);
 }

--- a/test/studies/prk/stencil/stencil-pretty.chpl
+++ b/test/studies/prk/stencil/stencil-pretty.chpl
@@ -21,7 +21,7 @@ config param R = 2,
              compact = false,
              // Control of multilocale parallelism
              useStencilDist = false,
-             useBlockDist = (CHPL_COMM != "none" && !useStencilDist);
+             useBlockDist = false;
 
 // Configurable type for array elements
 config type dtype = real;
@@ -121,6 +121,9 @@ if (!validate) {
   if tiling then writeln("Tile size             = ", tileSize);
   else             writeln("Untiled");
   writeln("Number of iterations = ", iterations);
+  if useBlockDist then        writeln("Distribution         = Block");
+  else if useStencilDist then writeln("Distribution         = Stencil");
+  else                        writeln("Distribution         = None");
 }
 
 

--- a/test/studies/prk/stencil/stencil-pretty.chpl
+++ b/test/studies/prk/stencil/stencil-pretty.chpl
@@ -140,9 +140,9 @@ for iteration in 0..iterations {
   if (!tiling) {
     forall (i,j) in innerDom {
       if (!compact) {
-        for param jj in -R..R  do output[i, j] += weight[0, jj] * input[i, j+jj];
-        for param ii in -R..-1 do output[i, j] += weight[ii, 0] * input[i+ii, j];
-        for param ii in 1..R   do output[i, j] += weight[ii, 0] * input[i+ii, j];
+        for jj in -R..R  do output[i, j] += weight[0, jj] * input[i, j+jj];
+        for ii in -R..-1 do output[i, j] += weight[ii, 0] * input[i+ii, j];
+        for ii in 1..R   do output[i, j] += weight[ii, 0] * input[i+ii, j];
       } else {
         for (ii, jj) in weightDom do
           output[i, j] += weight[ii,jj] * input[i+ii, j+jj];
@@ -153,9 +153,9 @@ for iteration in 0..iterations {
       for i in it .. # min(order - R - it, tileSize) {
         for j in jt .. # min(order - R - jt, tileSize) {
           if (!compact) {
-            for param jj in -R..R  do output[i, j] += weight[0, jj] * input[i, j+jj];
-            for param ii in -R..-1 do output[i, j] += weight[ii, 0] * input[i+ii, j];
-            for param ii in 1..R   do output[i, j] += weight[ii, 0] * input[i+ii, j];
+            for jj in -R..R  do output[i, j] += weight[0, jj] * input[i, j+jj];
+            for ii in -R..-1 do output[i, j] += weight[ii, 0] * input[i+ii, j];
+            for ii in 1..R   do output[i, j] += weight[ii, 0] * input[i+ii, j];
           } else {
             for (ii, jj) in weightDom do
               output[i, j] += weight[ii,jj] * input[i+ii, j+jj];
@@ -165,12 +165,12 @@ for iteration in 0..iterations {
     }
   }
 
-  if useStencilDist then input.updateFluff();
-
   // Add constant to solution to force refresh of neighbor data, if any
   forall (i,j) in Dom {
     input[i, j] += 1.0;
   }
+
+  if useStencilDist then output.updateFluff();
 
 } // end of iterations
 


### PR DESCRIPTION
Some `chplvis` and `CommDiagnostics` work on `stencil-fast.chpl` led me to some improvements that reduce communication in PRK/Stencil. In StencilDist, communication *only* occurs during the update fluff step now, as expected.

Summary of these improvements:
*  `pragma "locale private"` on weight 'matrix'
* Updating only output fluff cells
* Looping over param ranges rather than weight domains (since domains are no longer relevant with tuple of tuples).

Also added some debug code that is executed with `--debug`, which may be removed eventually. I'd like to keep it in for now, as I continue to actively search for improvements.

[Confirmed `start_test` works in this directory with `COMM=none/gasnet`]