### PR TITLE
Removing the previous workaround for non-default size bools in no-local

### DIFF
--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -103,18 +103,6 @@ static bool canRemoveRefTemps(FnSymbol* fn) {
   if (!fn) // primitive
     return true;
 
-  // Work around for a bug with non-default size bools in no-local. I believe
-  // they dont work in no-local due to not preserving thier size during
-  // codegen.
-  // TODO: Check if this can be removed onces bool sizes are preserved
-  //       ( test/types/scalar/bradc/bools[2].chpl )
-  if (!fLocal) {
-    for_formals(formal, fn) {
-      if (is_bool_type(formal->typeInfo()))
-        return false;
-    }
-  }
-
   std::vector<CallExpr*> callExprs;
   collectCallExprs(fn, callExprs);
 


### PR DESCRIPTION
 - Remove the stopgap fix from cd4bce6
 - PR #3475 fixes the issue, so the workaround is not needed anymore.