### PR TITLE
Resolve new passing boolean size future (thanks Kushal!)

### DIFF
--- a/test/portability/boolLiteralSizes.future
+++ b/test/portability/boolLiteralSizes.future
@@ -1,6 +1,0 @@
-bug: boolean literals don't preserve their sizes
-
-Our generated code calls sizeof(true), which is a C constant value.  This will
-always return the same size, no matter what boolean size we cast it to.  In
-order to display correctly, we need to define and use separate values for each
-boolean size.


### PR DESCRIPTION
Since the merge of @kushalsingh007 's #3475 to fix boolean literal sizes in our code
generation, this test now passes where futures are run.  Remove the .future
file so it can get run everywhere.