### PR TITLE
Update cray rpath for CLE6

### DIFF
--- a/make/platform/Makefile.cray-x-series
+++ b/make/platform/Makefile.cray-x-series
@@ -25,4 +25,4 @@ endif
 # could not find a version of GLIBCXX when compiling with intel/cray compilers
 # This particular approach was suggested by CCE build/integration staff.
 # Note: This is assuming gcc-libs maintain forward compatibility
-LDFLAGS += -Wl,-rpath,/opt/cray/gcc-libs
+LDFLAGS += -Wl,-rpath,/opt/cray/gcc-libs,-rpath,/opt/cray/pe/gcc-libs


### PR DESCRIPTION
gcc-libs are stored at /opt/cray/gcc-libs/ for for CLE <= 5.2, but are stored at
/opt/cray/pe/gcc-libs/ for CLE >= 6.0.

Add /opt/cray/pe/gcc-libs to our rpath for cray so both locations are checked.

This should fix the CLE 6 errors we saw along the lines of:

    /opt/cray/gcc-libs/libstdc++.so.6: version `GLIBCXX_3.4.21' not found