### PR TITLE
Fix a minor error in Types.chpl docs

### DIFF
--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -546,7 +546,7 @@ proc min(type t) where isComplexType(t) {
 
 // joint documentation, for user convenience
 /*
-Returns the minimum value the type `t` can store.
+Returns the maximum value the type `t` can store.
 `t` can be one of the following types, of any width:
 `bool`, `int`, `uint`, `real`, `imag`, `complex`.
 When `t` is a `bool` type, it returns `false`.


### PR DESCRIPTION
max functions were described to find "minimum"