### PR TITLE
Fix gasnet with debugger.

### DIFF
--- a/doc/developer/bestPractices/GASNetOnDesktops.txt
+++ b/doc/developer/bestPractices/GASNetOnDesktops.txt
@@ -24,7 +24,8 @@ warning messages from GASNet regarding using the Infiniband conduit.
 
 DEBUGGING
 =========
-See executing.rst regarding debugging with CHPL_COMM_USE_GDB.
+See debugging.rst regarding debugging with CHPL_COMM_USE_GDB or
+CHPL_COMM_USE_LLDB.
 
 Sometimes GASNet issues are general multi-locale issues that can be
 recreated by compiling the program with the --no-local flag and using

--- a/doc/release/debugging.rst
+++ b/doc/release/debugging.rst
@@ -17,10 +17,12 @@ Running in gdb
 The compiler-generated executable has a ``--gdb`` flag that can be used
 to launch the program within a ``gdb`` session.  For best results, make
 sure that your program has been compiled using the chpl compiler's
-``-g`` flag.  With ``CHPL_COMM=gasnet``, launching ``gdb`` is supported
-via the environment variable ``CHPL_COMM_USE_GDB``.  This will open up a
-separate xterm running ``gdb`` for each locale.  Note that we only know
-this to work for the ``amudprun`` launcher.
+``-g`` flag.  With ``CHPL_COMM=gasnet`` when using the ``amudprun``
+launcher, you can launch ``gdb`` by setting the environment variable
+``CHPL_COMM_USE_GDB`` when running the program.  This will open up a
+separate xterm for each locale, running the designated debugger.  On the
+Mac OS X (darwin) platform, you can launch ``lldb`` instead, by setting
+the ``CHPL_COMM_USE_LLDB`` environment variable.
 
 The utility of this feature depends greatly on your familiarity with
 the Chapel generated code.  However, if your program is crashing or

--- a/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
+++ b/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
@@ -558,35 +558,57 @@ extern int AMUDP_SPMDStartup(int *argc, char ***argv,
 
     //
     // For ease-of-debugging with Chapel, hacked this so that GASNet
-    // will launch each task in an xterm running gdb if
+    // will launch each task in an xterm running a debugger if
     // CHPL_COMM_USE_GDB is set.
     //
-    if (getenv("CHPL_COMM_USE_GDB")) {
-      //
-      // Create a new argv with space for -E options for the env vars.
-      //
-      int new_argc = 4 + *argc + 1;
-      char** new_argv = (char**) AMUDP_malloc(new_argc * sizeof((*new_argv)));
+    if (getenv("CHPL_COMM_USE_GDB") != NULL
+        || getenv("CHPL_COMM_USE_LLDB") != NULL) {
+      char xtermPath[1 << 12];
+      char *pp, *ppn;
+      int new_argc = 4 + *argc;
+      char** new_argv
+             = (char**) AMUDP_malloc((new_argc + 1) * sizeof((*new_argv)));
 
-      //
-      // Instead of running the program directly, run an xterm which
-      // runs lldb on the program and its args.
-      //
-#if defined __APPLE__
-      new_argv[0] = (char *) "/opt/X11/bin/xterm";
-      new_argv[1] = (char *) "-e";
-      new_argv[2] = (char *) "lldb";
-      new_argv[3] = (char *) "--";
-#else
-      new_argv[0] = (char *) "/usr/bin/xterm";
-      new_argv[1] = (char *) "-e";
-      new_argv[2] = (char *) "gdb";
-      new_argv[3] = (char *) "--args";
-#endif
-      memcpy(&new_argv[4], *argv, (*argc + 1) * sizeof(*new_argv));
+      if ((pp = getenv("PATH")) == NULL || *pp == '\0')
+        AMUDP_FatalErr("CHPL_COMM_USE_(G|LL)DB: no PATH.  Exiting...");
+      else {
+        do {
+          ppn = strchr(pp, ':');
+          if (ppn == NULL)
+            (void) snprintf(xtermPath, sizeof(xtermPath), "%s/xterm",
+                            (*pp == '\0') ? "." : pp);
+          else if (ppn == pp)
+            (void) snprintf(xtermPath, sizeof(xtermPath), "./xterm");
+          else
+            (void) snprintf(xtermPath, sizeof(xtermPath), "%.*s/xterm",
+                            (int) (ppn - pp), pp);
+          if (access(xtermPath, X_OK) == 0)
+            break;
+          xtermPath[0] = '\0';
+          pp = ppn + 1;
+        } while (ppn != NULL);
 
-      *argc = new_argc;
-      *argv = new_argv;
+        if (xtermPath[0] == '\0')
+          AMUDP_FatalErr("CHPL_COMM_USE_(G|LL)DB: no xterm in PATH.  "
+                         "Exiting...");
+        else {
+          new_argv[0] = (char*) AMUDP_malloc(strlen(xtermPath) + 1);
+          strcpy(new_argv[0], xtermPath);
+          new_argv[1] = (char *) "-e";
+
+          if (getenv("CHPL_COMM_USE_GDB") != NULL) {
+            new_argv[2] = (char *) "gdb";
+            new_argv[3] = (char *) "--args";
+          } else {
+            new_argv[2] = (char *) "lldb";
+            new_argv[3] = (char *) "--";
+          }
+
+          memcpy(&new_argv[4], *argv, (*argc + 1) * sizeof(*new_argv));
+          *argc = new_argc;
+          *argv = new_argv;
+        }
+      }
     }
 
     // call system-specific spawning routine

--- a/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
+++ b/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
@@ -570,12 +570,19 @@ extern int AMUDP_SPMDStartup(int *argc, char ***argv,
 
       //
       // Instead of running the program directly, run an xterm which
-      // runs gdb on the program and its args.
+      // runs lldb on the program and its args.
       //
+#if defined __APPLE__
+      new_argv[0] = (char *) "/opt/X11/bin/xterm";
+      new_argv[1] = (char *) "-e";
+      new_argv[2] = (char *) "lldb";
+      new_argv[3] = (char *) "--";
+#else
       new_argv[0] = (char *) "/usr/bin/xterm";
       new_argv[1] = (char *) "-e";
       new_argv[2] = (char *) "gdb";
       new_argv[3] = (char *) "--args";
+#endif
       memcpy(&new_argv[4], *argv, *argc * sizeof(*new_argv));
 
       *argc = new_argc;

--- a/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
+++ b/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
@@ -559,7 +559,7 @@ extern int AMUDP_SPMDStartup(int *argc, char ***argv,
     //
     // For ease-of-debugging with Chapel, hacked this so that GASNet
     // will launch each task in an xterm running a debugger if
-    // CHPL_COMM_USE_GDB is set.
+    // CHPL_COMM_USE_GDB or CHPL_COMM_USE_LLDB is set.
     //
     if (getenv("CHPL_COMM_USE_GDB") != NULL
         || getenv("CHPL_COMM_USE_LLDB") != NULL) {

--- a/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
+++ b/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
@@ -583,7 +583,7 @@ extern int AMUDP_SPMDStartup(int *argc, char ***argv,
       new_argv[2] = (char *) "gdb";
       new_argv[3] = (char *) "--args";
 #endif
-      memcpy(&new_argv[4], *argv, *argc * sizeof(*new_argv));
+      memcpy(&new_argv[4], *argv, (*argc + 1) * sizeof(*new_argv));
 
       *argc = new_argc;
       *argv = new_argv;

--- a/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
+++ b/third-party/gasnet/GASNet-1.26.0/other/amudp/amudp_spmd.cpp
@@ -565,7 +565,7 @@ extern int AMUDP_SPMDStartup(int *argc, char ***argv,
       //
       // Create a new argv with space for -E options for the env vars.
       //
-      int new_argc = 4 + *argc;
+      int new_argc = 4 + *argc + 1;
       char** new_argv = (char**) AMUDP_malloc(new_argc * sizeof((*new_argv)));
 
       //

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -86,6 +86,8 @@ else
 endif
 endif
 
+CHPL_GASNET_CFG_OPTIONS += $(CHPL_GASNET_MORE_CFG_OPTIONS)
+
 MKFILES=$(shell find $(GASNET_INSTALL_DIR) -name \*.mak)
 
 default: all

--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -14,11 +14,12 @@ library itself.
 The modifications that we have made to the official GASNet release are
 as follows:
 
-* Added support for launching an xterm window running gdb in the udp
-  active messages layer if the environment variable CHPL_COMM_USE_GDB
-  is set.  Our modification is not particularly elegant, but it should
-  be innocuous for non-Chapel developers, and has been exceedingly
-  useful for the Chapel development team.
+* Added support for launching an xterm window running a debugger in the
+  udp active messages layer if either of the environment variables
+  CHPL_COMM_USE_GDB or CHPL_COMM_USE_LLDB is set.  Our modification is
+  not particularly elegant, but it should be innocuous for non-Chapel
+  developers, and has been exceedingly useful for the Chapel development
+  team.
 
 The structure of this directory is as follows:
 


### PR DESCRIPTION
Back in December I rewrote the Chapel developer feature that starts a
debugger in an xterm for each instance of a program distributed via
GASNet's amudprun launcher (for the udp substrate), because our old
patch for that feature could no longer be applied due to changes in the
underlying code.  Unfortunately my "fix" was broken in a couple of ways, 
which my limited testing didn't pick up:
- I didn't NULL-terminate the argv vectors passed to execve(2) to
  launch the xterms and indeed, those argv vectors weren't even
  allocated large enough to hold a terminating NULL.
- The code didn't work on darwin, where the xterm binary is in a
  different place and we need to use lldb instead of gdb.

Here, solve both these problems.
