### PR TITLE
Make workaround similar to pull request 3466 for enum casting with gcc 5.1

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5586,7 +5586,7 @@ preFold(Expr* expr) {
                         result = new SymExpr(constant->sym);
                         call->replace(result);
                         replaced = true;
-                        break;
+                        // could break here but might have issues with gcc 5.1
                       }
                     }
                     if (!replaced) {


### PR DESCRIPTION
Something about this version of gcc is not finding the right constant while
casting if the constant desired is at the end of the list of enum constants.
Maybe there's something wrong with our for_enums that gcc 5.1 is tickling in
the right way?  This bears further investigation.