### PR TITLE
Fix a syntax error in this future (won't resolve it)

### DIFF
--- a/test/functions/jturner/first-class-generic-function.chpl
+++ b/test/functions/jturner/first-class-generic-function.chpl
@@ -354,7 +354,7 @@ module cholesky_scalar_algorithms {
     writeln ("");
     writeln ("Parallel Environment");
     writeln ("   Number of Locales         : ", numLocales );
-    writeln ("   Number of cores per locale: ", Locales.numPUs();
+    writeln ("   Number of cores per locale: ", Locales.numPUs());
     writeln ("   Max tasking parallelism   : ", Locales.maxTaskPar );
  
 


### PR DESCRIPTION
A user's question about first-class functions made me take a look at this
related future - it turns out the future has been failing in a different way
due to a replacement error I believe when the numPUs change went in.  The
behavior of this future still doesn't fully exercise what it intends to, but
I don't have a firm enough grasp on the Cyclic distribution to off-hand know
what to do next.  But at least the syntax error is gone!