### PR TITLE
Make no-op functions produce an error

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2219,8 +2219,26 @@ buildFunctionDecl(FnSymbol*   fn,
   }
   else
   {
-    // Looks like this flag is redundant with FLAG_EXTERN. <hilde>
-    fn->addFlag(FLAG_FUNCTION_PROTOTYPE);
+    if (!fn->hasFlag(FLAG_EXTERN)) {
+      //
+      // Chapel doesn't really support procedures with no-op bodies (a
+      // semicolon only).  Doing so is likely to cause confusion for C
+      // programmers who will think of it as a prototype, but we don't
+      // support prototypes, so require such programmers to type the
+      // empty body instead.  This is consistent with the current draft
+      // of the spec as well.
+      //
+      USR_FATAL(fn, "no-op procedures are only legal for extern functions");
+      //
+      // this is a way to make this branch robust to downstream passes
+      // if we got past this USR_FATAL for any reason or decide we
+      // want to support this case -- it changes the NULL pointer that
+      // is the body the parser created into a no-op body.
+      //
+      //
+      fn->insertAtTail(buildChapelStmt(new BlockStmt()));
+    }
+
   }
 
   fn->doc = docs;

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2596,8 +2596,7 @@ void ModuleSymbol::codegenDef() {
     if (DefExpr* def = toDefExpr(expr))
       if (FnSymbol* fn = toFnSymbol(def->sym)) {
         // Ignore external and prototype functions.
-        if (fn->hasFlag(FLAG_EXTERN) ||
-            fn->hasFlag(FLAG_FUNCTION_PROTOTYPE))
+        if (fn->hasFlag(FLAG_EXTERN))
           continue;
 
         fns.push_back(fn);
@@ -2796,8 +2795,7 @@ Vec<FnSymbol*> ModuleSymbol::getTopLevelFunctions(bool includeExterns) {
       if (FnSymbol* fn = toFnSymbol(def->sym)) {
         // Ignore external and prototype functions.
         if (includeExterns == false &&
-            (fn->hasFlag(FLAG_EXTERN) ||
-             fn->hasFlag(FLAG_FUNCTION_PROTOTYPE))) {
+            fn->hasFlag(FLAG_EXTERN)) {
           continue;
         }
 
@@ -2814,8 +2812,7 @@ Vec<FnSymbol*> ModuleSymbol::getTopLevelFunctions(bool includeExterns) {
             if (DefExpr* def2 = toDefExpr(expr2)) {
               if (FnSymbol* fn2 = toFnSymbol(def2->sym)) {
                 if (includeExterns == false &&
-                    (fn2->hasFlag(FLAG_EXTERN) ||
-                     fn2->hasFlag(FLAG_FUNCTION_PROTOTYPE))) {
+                    fn2->hasFlag(FLAG_EXTERN)) {
                   continue;
                 }
 

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -101,7 +101,6 @@ symbolFlag( FLAG_FIELD_ACCESSOR , npr, "field accessor" , "field setter/getter f
 symbolFlag( FLAG_FIRST_CLASS_FUNCTION_INVOCATION, npr, "first class function invocation" , "proxy for first-class function invocation" )
 symbolFlag( FLAG_FORMAL_TEMP,     npr, "formal temp", "a formal temp to back an in, out, or inout argument" )
 symbolFlag( FLAG_FUNCTION_CLASS , npr, "function class" , "first-class function class representation" )
-symbolFlag( FLAG_FUNCTION_PROTOTYPE , npr, "function prototype" , "signature for function prototypes" )
 // When applied to an argument, this flag means that the arg accepts a value
 // but has unspecified type.
 symbolFlag( FLAG_GENERIC , npr, "generic" , "generic types, functions and arguments" )

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -213,7 +213,6 @@ checkReturnPaths(FnSymbol* fn) {
       fn->retType == dtVoid ||
       fn->retTag == RET_TYPE ||
       fn->hasFlag(FLAG_EXTERN) ||
-      fn->hasFlag(FLAG_FUNCTION_PROTOTYPE) ||
       fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR) ||
       fn->hasFlag(FLAG_TYPE_CONSTRUCTOR) ||
       fn->hasFlag(FLAG_AUTO_II))

--- a/compiler/passes/expandExternArrayCalls.cpp
+++ b/compiler/passes/expandExternArrayCalls.cpp
@@ -98,7 +98,6 @@ void expandExternArrayCalls() {
       SET_LINENO(fn);
       fn->defPoint->insertAfter(new DefExpr(fcopy));
       fcopy->removeFlag(FLAG_EXTERN);
-      fcopy->removeFlag(FLAG_FUNCTION_PROTOTYPE);
       fcopy->addFlag(FLAG_INLINE);
       fcopy->cname = astr("chpl__extern_array_wrapper_", fcopy->cname);
       fn->name = astr("chpl__extern_array_", fn->name);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7187,9 +7187,6 @@ resolveFns(FnSymbol* fn) {
     return;
   }
 
-  if (fn->hasFlag(FLAG_FUNCTION_PROTOTYPE))
-    return;
-
   //
   // Mark serial loops that yield inside of follower, standalone, and
   // explicitly vectorized iterators as order independent. By using a forall

--- a/test/functions/noOpBody.chpl
+++ b/test/functions/noOpBody.chpl
@@ -1,0 +1,3 @@
+proc testit(a);
+
+testit("hello");

--- a/test/functions/noOpBody.good
+++ b/test/functions/noOpBody.good
@@ -1,0 +1,1 @@
+noOpBody.chpl:1: error: no-op procedures are only legal for extern functions

--- a/test/release/examples/benchmarks/miniMD/explicit/helpers/forces.chpl
+++ b/test/release/examples/benchmarks/miniMD/explicit/helpers/forces.chpl
@@ -10,7 +10,6 @@ class Force {
 
   var wipetime, maintime: real;
 
-  proc Force();
   proc compute(store : bool) : void {}
 }
 

--- a/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
@@ -10,7 +10,6 @@ class Force {
 
   var wipetime, maintime: real;
 
-  proc Force();
   proc compute(store : bool) : void {}
 }
 

--- a/test/users/thom/topLevelCode.good
+++ b/test/users/thom/topLevelCode.good
@@ -1,0 +1,1 @@
+topLevelCode.chpl:11: error: no-op procedures are only legal for extern functions


### PR DESCRIPTION
A mail from a user/developer this morning showed that calling a function defined as a no-op:

    proc foo();
    foo();

resulted in an internal error.  It turns out that this syntax is accepted by the parser primarily to support the case of external function prototypes and, notably, the specification suggests that this should not be a legal Chapel function.  It seems appropriate to make this case an error and require the user who wants a no-op function to instead write:

    proc foo() { }

in order to avoid confusion w.r.t. C prototypes (which don't have a Chapel equivalent).

While here, I found that FLAG_FUNCTION_PROTOTYPE is not doing anything interesting/important above and beyond what FLAG_EXTERN is doing (as Tom had noted earlier), so I pulled it as a related code cleanup.

Filed a new test against no-op functions and updated some old tests that were declaring such functions but not calling them (and therefore not running into the internal error).

[note: Like a gitiot, I biffed the commit message for this due to some confusion on my part.  This merge commit message specifies things that should've been in the original multiple commits if I hadn't messed up].