### PR TITLE
Additional clean up to a first class functions future

### DIFF
--- a/test/functions/jturner/first-class-generic-function.bad
+++ b/test/functions/jturner/first-class-generic-function.bad
@@ -1,0 +1,8 @@
+first-class-generic-function.chpl:72: In function 'scalar_outer_product_cholesky':
+first-class-generic-function.chpl:90: internal error: CAL0066 chpl Version 1.13.0.c914f67
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/jturner/first-class-generic-function.chpl
+++ b/test/functions/jturner/first-class-generic-function.chpl
@@ -330,7 +330,7 @@ module cholesky_scalar_algorithms {
 
     var Rand = new RandomStream ( seed = 314159) ;
 
-    const MatIdx = [ index_base .. #n, index_base .. #n ];
+    const MatIdx = { index_base .. #n, index_base .. #n };
 
     const mat_dom : domain (2) dmapped Cyclic ( startIdx = MatIdx.low )
       = MatIdx; // CYCLIC VERSION


### PR DESCRIPTION
It turns out the reason we were getting a different error message than the one
expected by the future was because we were using an old syntax for declaring
a domain.  With this change, the message generated now matches the old expected
internal error.  Add that internal error message as a .bad file for the future,
so it doesn't slip again. (suggested by @bradcray)