### PR TITLE
Remove a use of FLAG_FUNCTION_PROTOTYPE that was missed in #3512

### DIFF
--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -283,7 +283,6 @@ void convertDeclToChpl(ModuleSymbol* module, const char* name, Vec<Expr*> & resu
     FnSymbol* f = new FnSymbol(name);
     f->addFlag(FLAG_EXTERN);
     f->addFlag(FLAG_LOCAL_ARGS);
-    f->addFlag(FLAG_FUNCTION_PROTOTYPE);
     Expr* chpl_type = convertToChplType(module, resultType.getTypePtr(), results);
     BlockStmt* result = buildFunctionDecl(
        f, RET_VALUE, chpl_type, NULL, NULL, NULL);


### PR DESCRIPTION
#3512 removed FLAG_FUNCTION_PROTOTYPE, but missed a use in externCResolve.cpp
in a code path that's only used when CHPL_LLVM=llvm (i.e. easy to miss if
you're not testing with llvm built.)