### PR TITLE
Fix a typo "1 node XC" -> "Single node XC"

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -123,7 +123,7 @@ all:
     - implemented doubling/halving for array-as-vec (#3380)
   03/17/16:
     - text: Switched gen compiler to gcc 5.1.0
-      config: 16 node XC, 1 node XC
+      config: 16 node XC, Single node XC
 
 AllCompTime:
   11/09/14:


### PR DESCRIPTION
Who the heck named this thing?!?  :)