### PR TITLE
Basic support for folding when using 'foldmethod=syntax'

### DIFF
--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -259,6 +259,9 @@ syn keyword chplConstant	nil
 syn keyword chplRepeat		while for do coforall forall in serial
 syn keyword chplLabel	        when otherwise label
 
+" Folding
+syn region scopeFold start="{" end="}" fold transparent
+
 " The minimum and maximum operators in GNU C++
 syn match chplMinMax "[<>]?"
 


### PR DESCRIPTION
I'm vim user and from time to time I like to use folding (zc, zo keystrokes).
The basic method I use is 'syntax', which isn't currently supported by chpl. Note that setting foldmethod to 'indent' makes it work, but it's inconvenient when using vim for multiple languages,
so the easiest solution is simply to add some lines for folding in syntax/chpl.vim.
Note that this could be expanded in future.