### PR TITLE
Fix use_iterator future after no-op body change

### DIFF
--- a/test/separate_compilation/jturner/use_iterator.bad
+++ b/test/separate_compilation/jturner/use_iterator.bad
@@ -1,1 +1,1 @@
-use_iterator.chpl:1: error: iterator does not yield a value
+use_iterator.chpl:1: error: 'iter' is not legal with 'extern'

--- a/test/separate_compilation/jturner/use_iterator.chpl
+++ b/test/separate_compilation/jturner/use_iterator.chpl
@@ -1,4 +1,4 @@
-iter dothis(n:int) : int;
+extern iter dothis(n:int) : int;
 
 proc main()
 {


### PR DESCRIPTION
This test tried to use a C-style prototype in order to access an
"external" iterator:

   iter foo(): int;

which started generating an error once I made no-op functions an
error.  This commit gets it "working" again by changing the
declaration into an "extern" declaration.

This test has problems in my mind -- should "separate compilation"
mean that you use extern declarations to access Chapel symbols
rather than 'use' statements?  I'm not convinced.  But in any case,
I think the original approach of using a C-style prototype is
misguided and not what we'd want in the language, so I'm just making
it an extern as the closest thing we have today.

If others have thoughts about how this test ought to be handled,
I'm all ears.