### PR TITLE
Add some tests for casting c_ptr(T) to/from c_void_ptr

### DIFF
--- a/test/extern/ferguson/c_void_pointer_cast.chpl
+++ b/test/extern/ferguson/c_void_pointer_cast.chpl
@@ -1,0 +1,25 @@
+extern proc mytest(x: c_void_ptr):c_void_ptr;
+
+/*
+static void* mytest(void* x) {
+  unsigned char* xp = (unsigned char*) x;
+  xp += 2;
+  return xp;
+}
+*/
+
+extern proc printf(fmt:c_string, ptr:c_void_ptr);
+extern proc printf(fmt:c_string, ptr:c_ptr(uint(8)));
+
+var x:c_void_ptr;
+x = mytest(x); // now it's 2.
+printf("x = %p\n", x);
+
+var y:c_ptr(uint(8));
+y = x:c_ptr(uint(8));
+printf("cast to c_ptr(uint(8)) = %p\n", y);
+
+var z:c_void_ptr;
+z = y:c_void_ptr;
+printf("cast back to c_void_ptr = %p\n", z);
+

--- a/test/extern/ferguson/c_void_pointer_cast.compopts
+++ b/test/extern/ferguson/c_void_pointer_cast.compopts
@@ -1,0 +1,1 @@
+c_void_pointer.h

--- a/test/extern/ferguson/c_void_pointer_cast.good
+++ b/test/extern/ferguson/c_void_pointer_cast.good
@@ -1,0 +1,3 @@
+x = 0x2
+cast to c_ptr(uint(8)) = 0x2
+cast back to c_void_ptr = 0x2

--- a/test/extern/ferguson/c_void_pointer_cast_record.chpl
+++ b/test/extern/ferguson/c_void_pointer_cast_record.chpl
@@ -1,0 +1,29 @@
+extern proc mytest(x: c_void_ptr):c_void_ptr;
+
+/*
+static void* mytest(void* x) {
+  unsigned char* xp = (unsigned char*) x;
+  xp += 2;
+  return xp;
+}
+*/
+
+record R {
+  var field:int;
+}
+
+extern proc printf(fmt:c_string, ptr:c_void_ptr);
+extern proc printf(fmt:c_string, ptr:c_ptr(R));
+
+var x:c_void_ptr;
+x = mytest(x); // now it's 2.
+printf("x = %p\n", x);
+
+var y:c_ptr(R);
+y = x:c_ptr(R);
+printf("cast to c_ptr(R) = %p\n", y);
+
+var z:c_void_ptr;
+z = y:c_void_ptr;
+printf("cast back to c_void_ptr = %p\n", z);
+

--- a/test/extern/ferguson/c_void_pointer_cast_record.compopts
+++ b/test/extern/ferguson/c_void_pointer_cast_record.compopts
@@ -1,0 +1,1 @@
+c_void_pointer.h

--- a/test/extern/ferguson/c_void_pointer_cast_record.good
+++ b/test/extern/ferguson/c_void_pointer_cast_record.good
@@ -1,0 +1,3 @@
+x = 0x2
+cast to c_ptr(R) = 0x2
+cast back to c_void_ptr = 0x2


### PR DESCRIPTION
Kyle added support for these (in order to implement new strings)
in 21b548ae but I didn't see a test of the functionality.

New test passes on linux with LLVM or quickstart builds.