### PR TITLE
Bump SSCA2 timeouts to quiet XE compilation timeouts

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_main.timeout
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_main.timeout
@@ -1,4 +1,3 @@
-# This timeout is currently required because the cray compiler takes roughly 7
-# minutes to compile the generated code for this test. If compilation speed for
-# this test gets better, this timeout can be removed.
-600
+# This timeout is currently required because the cray and intel compilers takes
+# a while to compile the generated code.
+900


### PR DESCRIPTION
Since we moved our XE testing to a different machine, compilation has been
taking longer. Until we figure out the root cause, just bump the timeout