### PR TITLE
Statically link in libstdc++ on crays for the compiler and llvm

### DIFF
--- a/make/platform/Makefile.cray-x-series
+++ b/make/platform/Makefile.cray-x-series
@@ -20,9 +20,11 @@ ifeq ($(CHPL_COMM), gasnet)
   GEN_LFLAGS += -L/usr/lib64/nptl
 endif
 
-# This ensures that the Chapel binary can find and link against the latest
-# gcc-lib versions. This addition was motivated by an error where chapel
-# could not find a version of GLIBCXX when compiling with intel/cray compilers
-# This particular approach was suggested by CCE build/integration staff.
-# Note: This is assuming gcc-libs maintain forward compatibility
-LDFLAGS += -Wl,-rpath,/opt/cray/gcc-libs,-rpath,/opt/cray/pe/gcc-libs
+# Statically link in libstdc++ so that it doesn't matter what compiler a user
+# has loaded at `chpl` invocation time. We build the compiler (and llvm) with a
+# specific version of gcc, but we don't want to force users to have that gcc
+# version loaded. Ideally we would just set an rpath to /opt/cray/gcc-libs and
+# /opt/cray/pe/gcc-libs, but this only works for non PrgEnv-gnu compilers.
+# PrgEnv-gnu sets a LD_LIBRARY_PATH to include a set of libs that could be
+# older than the versions we build the compiler and llvm with.
+LDFLAGS += -static-libstdc++

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -36,7 +36,7 @@ $(LLVM_FILE):
 	if [ ! -d llvm ]; then ./unpack-llvm.sh; fi
 	mkdir -p $(LLVM_BUILD_DIR)
 	cd $(LLVM_BUILD_DIR) && $(LLVM_SRC_DIR)/configure CC='$(CC)' CXX='$(CXX)' \
-	--prefix=$(LLVM_INSTALL_DIR) \
+	LDFLAGS='$(LDFLAGS)' --prefix=$(LLVM_INSTALL_DIR) \
 	--enable-optimized --disable-clang-arcmt --disable-clang-static-analyzer \
 	--disable-clang-rewriter --disable-docs \
 	--disable-zlib \


### PR DESCRIPTION
For crays, and particularly the module release, the compiler (and llvm) could
have been built with a newer version of gcc than is being used when a user
invokes `chpl`. In the past we set an rpath to /opt/cray/gcc-libs and
/opt/cray/pe/gcc-libs, but that only works for non-gnu PrgEnv's. PrgEnv gnu sets an
LD_LIBRARY_PATH that takes precedence over our rpath, so if a user is using an
older version of gcc than the one the compiler was built with they'll get
undefined references to GLIBCXX because the libstdc++ that the compiler was
built with won't be found at dynamic load time.

To work around this, we now statically link in libstdc++ for the compiler and
llvm so that it doesn't matter what libstdc++ is around at `chpl` invocation
time. Note that longer term we might want to consider making the chpl binary
totally static to avoid similar issues with any other libs. Currently that
leads to some issues because we do use some routines in libnss such as
geteuid() (libnss can't really be statically linked in)