### PR TITLE
"make check" should always clean up its tmp directories

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -96,6 +96,30 @@ else
     CHPL_DIR_REMOVE=0
 fi
 
+# Tmp directory for compile output
+TMP_TEST_DIR="$(mktemp -d ${CHPL_DIR}/chapel-test-XXXXX)"
+log_info "Temporary test job directory: ${TMP_TEST_DIR}"
+
+# Cleanup the tmp directory whenever exit is invoked
+function cleanup_tmp_dir()
+{
+    local i
+    log_debug "Removing ${TMP_TEST_DIR}"
+    for i in 1 2 3 4 5
+    do
+        rm -rf ${TMP_TEST_DIR} && break
+        # sometimes rm needs to wait for the TEST_JOB exe file to close
+        log_debug "wait and try again"
+        sleep 1
+    done
+    if [ "${CHPL_DIR_REMOVE}" == "1" ]; then
+        log_debug "Removing ${CHPL_DIR}"
+        # rmdir should fail if some other process started using CHPL_DIR after we created it
+        rmdir ${CHPL_DIR} || log_debug "error ignored"
+    fi
+}
+trap cleanup_tmp_dir EXIT
+
 # Location of test job
 if [ -d ${CHPL_HOME}/test/release/examples ] ; then
     # Install from source repo.
@@ -109,9 +133,6 @@ else
     log_error "Could not find test cases in CHPL_HOME: ${CHPL_HOME}."
     exit 1
 fi
-
-TMP_TEST_DIR="$(mktemp -d ${CHPL_DIR}/chapel-test-XXXXX)"
-log_info "Temporary test job directory: ${TMP_TEST_DIR}"
 
 TEST_JOB=${TEST_JOB_BASENAME}
 
@@ -144,18 +165,6 @@ elif [ -s ${TMP_TEST_DIR}/${TEST_COMP_OUT} ]; then
 else
     log_info "Test job compiled into ${TMP_TEST_DIR}/${TEST_JOB}"
 fi
-
-# Cleanup the tmp directory whenever exit is invoked
-function cleanup_tmp_dir()
-{
-    log_debug "Removing ${TMP_TEST_DIR}"
-    rm -rf ${TMP_TEST_DIR}
-    if [ "${CHPL_DIR_REMOVE}" == "1" ]; then
-        log_debug "Removing ${CHPL_DIR}"
-        rm -rf ${CHPL_DIR}
-    fi
-}
-trap cleanup_tmp_dir EXIT
 
 # Find number of locales and .good file
 if [ ${chpl_comm} == "none" ]; then

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -103,19 +103,15 @@ log_info "Temporary test job directory: ${TMP_TEST_DIR}"
 # Cleanup the tmp directory whenever exit is invoked
 function cleanup_tmp_dir()
 {
-    local i
     log_debug "Removing ${TMP_TEST_DIR}"
-    for i in 1 2 3 4 5
-    do
-        rm -rf ${TMP_TEST_DIR} && break
-        # sometimes rm needs to wait for the TEST_JOB exe file to close
-        log_debug "wait and try again"
-        sleep 1
-    done
+    rm -rf ${TMP_TEST_DIR} || (
+        log_warning "failed rm -rf ${TMP_TEST_DIR}, ignore the error"
+        set -x; ls -la ${TMP_TEST_DIR}
+    ) || : ok
     if [ "${CHPL_DIR_REMOVE}" == "1" ]; then
         log_debug "Removing ${CHPL_DIR}"
         # rmdir should fail if some other process started using CHPL_DIR after we created it
-        rmdir ${CHPL_DIR} || log_debug "error ignored"
+        rmdir ${CHPL_DIR} || log_debug "rmdir error ignored"
     fi
 }
 trap cleanup_tmp_dir EXIT


### PR DESCRIPTION
Saving this change until I have an opportunity to test it.