### PR TITLE
Updating RNG to new interface

### DIFF
--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -346,11 +346,11 @@ proc makeInput(taskID, myKeys) {
   // Seed RNG
   //
   if (debug) then
-    writeln(taskID, ": Calling pcg32_srandom_r with ", taskID);
+    writeln(taskID, ": Initializing random stream with seed = ", taskID);
 
-  var MyRandStream = new PCGRandomStream(seed = taskID,
-                                         parSafe=false,
-                                         eltType = keyType);
+  var MyRandStream = new RandomStream(seed = taskID,
+                                      parSafe=false,
+                                      eltType = keyType);
 
   //
   // Fill local array


### PR DESCRIPTION
I think that somehow Michael's merge/test must not have included
the addition of this test in the examples directory...  While
here, I also updated the debug message to reflect the fact that
we're not calling down to the low-level PCG interface.