### PR TITLE
Fix dynamic linking with cray PrgEnvs

### DIFF
--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -50,3 +50,17 @@ LIB_DYNAMIC_FLAG = -shared
 # will take care of that Since we want to be able to get other flags from e.g.
 # Makefile.intel, here we replace SPECIALIZE_CFLAGS with nothing.
 SPECIALIZE_CFLAGS =
+
+
+#
+# The CC and cc drivers use pkg-config to determine several things including
+# which libraries to link in. Set the appropriate libs based on our config:
+#
+
+# ugni and gasnet-{aries, gemini} require pmi and ugni
+ifeq ($(CHPL_MAKE_COMM), ugni)
+PE_PKGCONFIG_LIBS += :cray-pmi:cray-ugni
+endif
+ifneq (,$(filter $(CHPL_MAKE_COMM_SUBSTRATE),gemini aries))
+PE_PKGCONFIG_LIBS += :cray-pmi:cray-ugni
+endif

--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -57,10 +57,17 @@ SPECIALIZE_CFLAGS =
 # which libraries to link in. Set the appropriate libs based on our config:
 #
 
+export PE_PKGCONFIG_PRODUCTS := PE_CHAPEL:$(PE_PKGCONFIG_PRODUCTS)
+export PE_CHAPEL_MODULE_NAME := chapel
+
 # ugni and gasnet-{aries, gemini} require pmi and ugni
 ifeq ($(CHPL_MAKE_COMM), ugni)
-PE_PKGCONFIG_LIBS += :cray-pmi:cray-ugni
+PE_CHAPEL_PKGCONFIG_LIBS := cray-pmi:cray-ugni:$(PE_CHAPEL_PKGCONFIG_LIBS)
 endif
+ifeq ($(CHPL_MAKE_COMM), gasnet)
 ifneq (,$(filter $(CHPL_MAKE_COMM_SUBSTRATE),gemini aries))
-PE_PKGCONFIG_LIBS += :cray-pmi:cray-ugni
+PE_CHAPEL_PKGCONFIG_LIBS := cray-pmi:cray-ugni:$(PE_CHAPEL_PKGCONFIG_LIBS)
 endif
+endif
+
+export PE_CHAPEL_PKGCONFIG_LIBS


### PR DESCRIPTION
On crays we had issues with dynamic linking (i.e. CRAYPE_LINK_TYPE=dynamic)
that resulted in undefined references to PMI and GNI routines. CrayPE/2.X
requires that dynamic libraries know their dependencies, but we weren't
specifying that Chapel requires pmi and ugni.

With static linking, libraries must specify the link args that they provide and
the ones that they require. We happened to get lucky because cray-mpich
satisfied our pmi and ugni dependencies.

If you tried to compile any chapel program with CRAYPE_LINK_TYPE=dynamic or
with cray-mpich unloaded, you'd get link time errors about undefined references
to PMI and GNI functions.

To resolve this, we now specify the PKGCONFIG_LIBS that are required by ugni
and gasnet-{gemini, aries} in our cray-prgenv makefile