### PR TITLE
Bump compilation timeout

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_main.timeout
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_main.timeout
@@ -1,3 +1,4 @@
-# This timeout is currently required because the cray and intel compilers takes
-# a while to compile the generated code.
-900
+# This timeout is currently required because the cray compiler takes roughly 7
+# minutes to compile the generated code for this test. If compilation speed for
+# this test gets better, this timeout can be removed.
+600

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1357,7 +1357,7 @@ for testname in testsrc:
         #
         # Compile (with timeout)
         #
-        # compilation timeout defaults to 2 * execution timeout.
+        # compilation timeout defaults to 4 * execution timeout.
         # This is to quiet compilation timeouts in some oversubscribed test
         # configurations (since they are generating a lot of testing noise, but
         # don't represent a real issue.)

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1368,7 +1368,7 @@ for testname in testsrc:
         # testing. Hopefully this is just a temporary work around and I'll
         # remember to add the cleaner solution soon.
         #
-        comptimeout = 2*timeout
+        comptimeout = 4*timeout
         cmd=ShellEscapeCommand(cmd);
         sys.stdout.write('[Executing compiler %s'%(cmd))
         if args:


### PR DESCRIPTION
Use 4x execution timeout instead of 2x. Motivated by recent compilation timeouts in nightly testing.