### PR TITLE
Fix lustre support on non-esl crays

### DIFF
--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -70,4 +70,13 @@ PE_CHAPEL_PKGCONFIG_LIBS := cray-pmi:cray-ugni:$(PE_CHAPEL_PKGCONFIG_LIBS)
 endif
 endif
 
+# on login/compute nodes, lustre requires the devel api to make
+# lustre/lustreapi.h available (it's implicitly available on esl nodes)
+ifneq (,$(findstring lustre,$(CHPL_MAKE_AUXFS)))
+HAVE_LUSTRE_API_DEVEL_STATUS=$(shell pkg-config --libs cray-lustre-api-devel &>/dev/null; echo $$?)
+ifeq ($(HAVE_LUSTRE_API_DEVEL_STATUS), 0)
+PE_CHAPEL_PKGCONFIG_LIBS := cray-lustre-api-devel:$(PE_CHAPEL_PKGCONFIG_LIBS)
+endif
+endif
+
 export PE_CHAPEL_PKGCONFIG_LIBS


### PR DESCRIPTION
Our lustre support requires lustre/lustreapi.h, but this header wasn't
implicitly available on login nodes. It is on esl nodes (where we happen to be
building our modules) but if you try to build lustre support on a non-esl node
you'll get errors about the missing header.

In order to resolve this we need bring in the devel api when we're on login
nodes. The devel api isn't available on all machines (it's not on esls) so we
first check if a pkg-config call to it will be successful before trying to
include it. There might be a more principled way to check esl vs non-esl, but
this also handles cases where the devel api might not have been installed.