### PR TITLE
Adding missing directories to clean to Makefile

### DIFF
--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -32,7 +32,10 @@ clean-symlink-docs: FORCE
 	rm -f language/spec.pdf
 
 clean-module-docs: FORCE
-	rm -rf source/modules/standard
+	rm -rf source/modules/dists
 	rm -rf source/modules/internal
+	rm -rf source/modules/layouts
+	rm -rf source/modules/packages
+	rm -rf source/modules/standard
 
 FORCE:


### PR DESCRIPTION
Lydia and I just noticed that when I added modules/packages/ to the
things to be documented yesterday, I failed to add that directory
to the list of things to be cleaned up.  Turns out that previous
additions of dists and layouts were never added either.  Add all
these and re-alphabetize.