### PR TITLE
Add cast from c_string to c_void_ptr

### DIFF
--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -161,7 +161,6 @@ module CString {
     __primitive("=", a, b);
   }
 
-
   // A c_string_copy can always be used as a c_string.
   inline proc _cast(type t, x: c_string_copy) where t == c_string {
     return __primitive("cast", t, x);
@@ -184,6 +183,13 @@ module CString {
   inline proc _cast(type t, x:integral) where t == c_string_copy {
     extern proc integral_to_c_string_copy(x:int(64), size:size_t, isSigned: bool) : c_string_copy ;
     return integral_to_c_string_copy(x:int(64), numBytes(x.type), isIntType(x.type));
+  }
+
+  //
+  // casts from c_string to c_void_ptr
+  //
+  inline proc _cast(type t, x: c_string) where t == c_void_ptr {
+    return __primitive("cast", t, x);
   }
 
   //

--- a/test/types/string/nspark/cast-cstring-to-cvoidptr.c
+++ b/test/types/string/nspark/cast-cstring-to-cvoidptr.c
@@ -1,0 +1,6 @@
+#include "cast-cstring-to-cvoidptr.h"
+
+size_t strlen_voidptr(const void *s)
+{
+  return strlen((const char*)s);
+}

--- a/test/types/string/nspark/cast-cstring-to-cvoidptr.chpl
+++ b/test/types/string/nspark/cast-cstring-to-cvoidptr.chpl
@@ -1,0 +1,7 @@
+require 'cast-cstring-to-cvoidptr.h', 'cast-cstring-to-cvoidptr.c';
+
+extern proc strlen(const s: c_string): size_t;
+extern proc strlen_voidptr(const s: c_void_ptr): size_t;
+
+config const buf = "Hello, World";
+assert(strlen(buf.c_str()) == strlen_voidptr(buf.c_str():c_void_ptr));

--- a/test/types/string/nspark/cast-cstring-to-cvoidptr.execopts
+++ b/test/types/string/nspark/cast-cstring-to-cvoidptr.execopts
@@ -1,0 +1,1 @@
+--buf="Hello, CString!"

--- a/test/types/string/nspark/cast-cstring-to-cvoidptr.h
+++ b/test/types/string/nspark/cast-cstring-to-cvoidptr.h
@@ -1,0 +1,4 @@
+#include <stdlib.h>
+#include <string.h>
+
+size_t strlen_voidptr(const void *s);


### PR DESCRIPTION
Currently, casting an object of type `c_string` to `c_void_ptr` is not allowed. This PR adds this cast and a simple test.

Such a cast is intended to help facilitate interoperability with C libraries; e.g., ZeroMQ.