### PR TITLE
Remove some non-vanilla-POSIX signals from Spawn

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -890,18 +890,25 @@ module Spawn {
   /*
     Send a signal to a child process.
 
-    Values for `signal` are system-specific and can be declared as:
-
-    .. code-block:: chapel
-
-       extern const SIG*: c_int;
-
     Declarations for POSIX.1.2008 signals are provided in this module.
+    These include `SIGABRT`, `SIGALRM`, `SIGBUS`, `SIGCHLD`, `SIGCONT`,
+    `SIGFPE`, `SIGHUP`, `SIGILL`, `SIGINT`, `SIGKILL`, `SIGPIPE`, `SIGQUIT`,
+    `SIGSEGV`, `SIGSTOP`, `SIGTERM`, `SIGTRAP`, `SIGTSTP`, `SIGTTIN`,
+    `SIGTTOU`, `SIGURG`, `SIGUSR1`, `SIGUSR2`, `SIGXCPU`, `SIGXFSZ`.
+
     See your system's documentation for their meaning:
 
     ::
 
       man signal
+
+    Other values for `signal` are system-specific and can be declared in this
+    way, for example:
+
+    .. code-block:: chapel
+
+       extern const SIGPOLL: c_int;
+
 
     :arg signal: the signal to send
 

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -393,7 +393,7 @@ module Spawn {
      :arg kind: What kind of channels should be created when
                 :const:`PIPE` is used. This argument is used to set
                 :attr:`subprocess.kind` in the resulting subprocess.
-                Defaults to :enum:`IO.iokind.dynamic`.
+                Defaults to :type:`IO.iokind` ``iokind.dynamic``.
                  
      :arg locking: Should channels created use locking?
                    This argument is used to set :attr:`subprocess.locking`
@@ -598,7 +598,7 @@ module Spawn {
      :arg kind: What kind of channels should be created when
                 :const:`PIPE` is used. This argument is used to set
                 :attr:`subprocess.kind` in the resulting subprocess.
-                Defaults to :enum:`IO.iokind.dynamic`.
+                Defaults to :type:`IO.iokind` ``iokind.dynamic``.
                  
      :arg locking: Should channels created use locking?
                    This argument is used to set :attr:`subprocess.locking`
@@ -824,8 +824,8 @@ module Spawn {
     if err then ioerror(err, "in subprocess.close");
   }
 
-  // Signals as required by POSIX-2013, less the deprecated SIGPOLL
-  // for sake of portability on OS X
+  // Signals as required by POSIX.1-2008, 2013 edition
+  // See note below about signals intentionally not included.
   pragma "no doc"
   extern const SIGABRT: c_int;
   pragma "no doc"
@@ -848,8 +848,6 @@ module Spawn {
   extern const SIGKILL: c_int;
   pragma "no doc"
   extern const SIGPIPE: c_int;
-  pragma "no doc"
-  extern const SIGPROF: c_int;
   pragma "no doc"
   extern const SIGQUIT: c_int;
   pragma "no doc"
@@ -875,26 +873,35 @@ module Spawn {
   pragma "no doc"
   extern const SIGUSR2: c_int;
   pragma "no doc"
-  extern const SIGVTALRM: c_int;
-  pragma "no doc"
   extern const SIGXCPU: c_int;
   pragma "no doc"
   extern const SIGXFSZ: c_int;
+
+  // These signals are not strictly required by POSIX.1.2008 2013 edition
+  // and so should not be included here:
+
+  // SIGPOLL is Obsolescent and optional as part of XSI STREAMS
+  // SIGPROF is Obsolescent and optional as part of XSI STREAMS
+  // SIGSYS is optional as part of X/Open Systems Interface
+  // SIGVTALRM is optional as part of X/Open Systems Interface
 
   private extern proc qio_send_signal(pid: int(64), sig: c_int): syserr;
 
   /*
     Send a signal to a child process.
 
-    Values for :const:`signal` are system-specific and should be declared as:
+    Values for `signal` are system-specific and can be declared as:
 
     .. code-block:: chapel
 
-       const SIG*: c_int;
+       extern const SIG*: c_int;
 
-    Declarations for common signals are provided in this module:
-    :const:`SIGKILL`, :const:`SIGTERM`,
-    :const:`SIGSTOP`, :const:`SIGTSTP`, :const:`SIGCONT`
+    Declarations for POSIX.1.2008 signals are provided in this module.
+    See your system's documentation for their meaning:
+
+    ::
+
+      man signal
 
     :arg signal: the signal to send
 
@@ -920,7 +927,9 @@ module Spawn {
 
   /*
     Unconditionally kill the child process.  The associated signal,
-    :const:`SIGKILL`, cannot be caught by the child process.
+    `SIGKILL`, cannot be caught by the child process. See
+    :proc:`subprocess.send_signal`.
+
 
     :arg error: optional argument to capture any error encountered
                 when killing the child process
@@ -942,7 +951,8 @@ module Spawn {
 
   /*
     Request termination of the child process.  The associated signal,
-    :const:`SIGTERM`, may be caught and handled by the child process.
+    `SIGTERM`, may be caught and handled by the child process. See
+    :proc:`subprocess.send_signal`.
 
     :arg error: optional argument to capture any error encountered
                 when terminating the child process

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -855,8 +855,6 @@ module Spawn {
   pragma "no doc"
   extern const SIGSTOP: c_int;
   pragma "no doc"
-  extern const SIGSYS: c_int;
-  pragma "no doc"
   extern const SIGTERM: c_int;
   pragma "no doc"
   extern const SIGTRAP: c_int;


### PR DESCRIPTION
The Spawn module provides extern const declarations for POSIX 2008.1
signals, except previously sometimes included optional or deprecated
POSIX 2008.1 signals. This PR adjusts it to only include the signals
required by the base POSIX 2008.1.

That meant removing
 * SIGPROF
 * SIGSYS
 * SIGVTALRM
 * (SIGPOLL was already removed - it caused portability problems with OS X)

I used http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html
as my reference for what exactly is in POSIX 2008.1 2013-edition.

While there, I updated the documentation to not have broken links and to
list exactly the set of signals included to be absolutely clear. The
documentation includes an example of getting a platform-specific signal
after describing these that are already included. I also included a
comment about these signals indicating why they are not included.

Passed modules/standard/Spawn testing on linux and OS X.
