### PR TITLE
Removing broken chpldoc links

### DIFF
--- a/doc/release/technotes/extern.rst
+++ b/doc/release/technotes/extern.rst
@@ -177,7 +177,7 @@ c_string
 
 The c_string type maps to a constant C string (that is, const char*)
 that is intended for use locally. A c_string can be obtained from a
-Chapel string using the method string.c_str(). A Chapel string can be
+Chapel string using the method :proc:`~String.string.c_str`. A Chapel string can be
 constructed from a C string using the cast operator. Note however that
 because c_string is a local-only type, the .c_str() method can only be
 called on Chapel strings that are stored on the same locale; calling
@@ -846,7 +846,7 @@ Working with strings
 If you need to call a C function and provide a Chapel string, you may need to
 convert the Chapel string to a C string first.  Chapel string literals will
 automatically convert to C strings.  A Chapel string variable can be converted
-using the :proc:`string.c_str` method.
+using the :proc:`~String.string.c_str` method.
 
 myprint.h:
 

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -119,12 +119,12 @@ module ChapelLocale {
       :arg logical: Count logical PUs (hyperthreads and the like),
                     or physical ones (cores)?  Defaults to `false`,
                     for cores.
-      :type logical: :type:`bool`
+      :type logical: `bool`
       :arg accessible: Count only PUs that can be reached, or all of
                        them?  Defaults to `true`, for accessible PUs.
-      :type accessible: :type:`bool`
+      :type accessible: `bool`
       :returns: number of PUs
-      :rtype: :type:`int`
+      :rtype: `int`
 
       There are several things that can cause the OS to limit the
       processor resources available to a Chapel program.  On plain

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -260,7 +260,7 @@ module String {
     }
 
     /*
-      Get a :type:`c_string` from a :record:`string`.
+      Get a `c_string` from a :record:`string`.
 
       .. warning::
 
@@ -278,8 +278,8 @@ module String {
           }
 
       :returns:
-          A :type:`c_string` that points to the underlying buffer used by this
-          :record:`string`.  The returned :type:`c_string` is only valid while
+          A `c_string` that points to the underlying buffer used by this
+          :record:`string`.  The returned `c_string` is only valid while
           on the current locale and while the :record:`string` is.
      */
     inline proc c_str(): c_string {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -258,7 +258,7 @@ In addition, there are several convenient synonyms for :proc:`channel.write` and
 :proc:`channel.read`:
 
  * :proc:`channel.readwrite`
- * :proc:`<~>`
+ * the `<~> operator`_
 
 Sometimes it's important to flush the buffer in a channel - to do that, use the
 .flush() method. Flushing the buffer will make all writes available to other
@@ -1199,12 +1199,12 @@ The :type:`iomode` type is an enum.
 When used as arguments when opening files,
 its constants have the following meaning:
 
-* :enum:`iomode.r` - open an existing file for reading.
-* :enum:`iomode.rw` - open an existing file for reading and writing.
-* :enum:`iomode.cw` - create a new file for writing.
+* ``iomode.r`` - open an existing file for reading.
+* ``iomode.rw`` - open an existing file for reading and writing.
+* ``iomode.cw`` - create a new file for writing.
   If the file already exists, its contents are removed
   when the file is opened in this mode.
-* :enum:`iomode.cwr` - as with :enum:`iomode.cw` but reading from the
+* ``iomode.cwr`` - as with ``iomode.cw`` but reading from the
   file is also allowed.
 
 */
@@ -1220,29 +1220,29 @@ enum iomode {
 The :type:`iokind` type is an enum. When used as arguments to the
 :record:`channel` type, its constants have the following meaning:
 
-* :enum:`iokind.big` means binary I/O with big-endian byte order is performed
+* ``iokind.big`` means binary I/O with big-endian byte order is performed
   when writing/reading basic types from the channel.
 
-* :enum:`iokind.little` means binary I/O with little-endian byte order
-  (similar to :enum:`iokind.big` but with little-endian byte order).
+* ``iokind.little`` means binary I/O with little-endian byte order
+  (similar to ``iokind.big`` but with little-endian byte order).
 
-* :enum:`iokind.native` means binary I/O in native byte order
-  (similar to :enum:`iokind.big` but with the byte order that is native
+* ``iokind.native`` means binary I/O in native byte order
+  (similar to ``iokind.big`` but with the byte order that is native
   to the target platform).
 
-* :enum:`iokind.dynamic` means that the applicable I/O style has full effect
+* ``iokind.dynamic`` means that the applicable I/O style has full effect
   and as a result the kind varies at runtime.
 
-In the case of :enum:`iokind.big`, :enum:`iokind.little`, and
-:enum:`iokind.native` the applicable :record:`iostyle` is consulted when
+In the case of ``iokind.big``, ``iokind.little``, and
+``iokind.native`` the applicable :record:`iostyle` is consulted when
 writing/reading strings, but not for other basic types.
 
 There are synonyms available for these values:
 
-* ``iodynamic`` = :enum:`iokind.dynamic`
-* ``ionative`` = :enum:`iokind.native`
-* ``iobig`` = :enum:`iokind.big`
-* ``iolittle`` = :enum:`iokind.little`
+* :proc:`iodynamic` = ``iokind.dynamic``
+* :proc:`ionative` = ``iokind.native``
+* :proc:`iobig` = ``iokind.big``
+* :proc:`iolittle` = ``iokind.little``
 
 */
 enum iokind {
@@ -1256,13 +1256,13 @@ enum iokind {
   little = 3
 }
 
-/* A synonym for :enum:`iokind.dynamic`; see :type:`iokind` */
+/* A synonym for ``iokind.dynamic``; see :type:`iokind` */
 param iodynamic = iokind.dynamic;
-/* A synonym for :enum:`iokind.native`; see :type:`iokind` */
+/* A synonym for ``iokind.native``; see :type:`iokind` */
 param ionative = iokind.native;
-/* A synonym for :enum:`iokind.big`; see :type:`iokind` */
+/* A synonym for ``iokind.big``; see :type:`iokind` */
 param iobig = iokind.big;
-/* A synonym for :enum:`iokind.little`; see :type:`iokind` */
+/* A synonym for ``iokind.little``; see :type:`iokind` */
 param iolittle = iokind.little;
 
 /*
@@ -1270,23 +1270,23 @@ param iolittle = iokind.little;
 This enum contains values used to control binary I/O with strings
 via the ``str_style`` field in :record:`iostyle`.
 
-* :enum:`iostringstyle.len1b_data` indicates a string format of 1 byte of
+* ``iostringstyle.len1b_data`` indicates a string format of 1 byte of
   length followed by length bytes of string data.
-* :enum:`iostringstyle.len2b_data` indicates a string format of 2 bytes of
+* ``iostringstyle.len2b_data`` indicates a string format of 2 bytes of
   length followed by length bytes of string data.
-* :enum:`iostringstyle.len4b_data` indicates a string format of 4 bytes of
+* ``iostringstyle.len4b_data`` indicates a string format of 4 bytes of
   length followed by length bytes of string data.
-* :enum:`iostringstyle.len8b_data` indicates a string format of 8 bytes of
+* ``iostringstyle.len8b_data`` indicates a string format of 8 bytes of
   length followed by length bytes of string data.
-* :enum:`iostringstyle.lenVb_data` indicates a string format of a variable
+* ``iostringstyle.lenVb_data`` indicates a string format of a variable
   number of bytes of length, encoded with high-bit meaning more bytes
   of length follow, and where the 7-bits of length from each byte store
   the 7-bit portions of the length in order from least-significant to
   most-significant. This way of encoding a variable-byte length  matches
   `Google Protocol Buffers <https://github.com/google/protobuf/>`_.
-* :enum:`iostringstyle.data_toeof` indicates a string format that contains
+* ``iostringstyle.data_toeof`` indicates a string format that contains
   string data until the end of the file
-* :enum:`iostringstyle.data_null` indicates a string that is terminated
+* ``iostringstyle.data_null`` indicates a string that is terminated
   by a zero byte. It can be combined with other numeric
   values to indicate a string terminated by a particular byte. For example,
   to indicate a string terminated by ``$`` (which in ASCII has byte value 0x24),
@@ -2504,7 +2504,7 @@ The temporary file will be created in an OS-dependent temporary directory,
 for example "/tmp" is the typical location. The temporary file will be
 deleted upon closing.
 
-Temporary files are always opened with :type:`iomode` :enum:`iomode.cwr`;
+Temporary files are always opened with :type:`iomode` ``iomode.cwr``;
 that is, a new file is created that supports both writing and reading.
 
 :arg error: optional argument to capture an error code. If this argument
@@ -3028,7 +3028,7 @@ This function is equivalent to calling :proc:`open` and then
            is required unless the ``url=`` argument is used.
 :arg kind: :type:`iokind` compile-time argument to determine the
             corresponding parameter of the :record:`channel` type. Defaults
-            to :enum:`iokind.dynamic`, meaning that the associated
+            to ``iokind.dynamic``, meaning that the associated
             :record:`iostyle` controls the formatting choices.
 :arg locking: compile-time argument to determine whether or not the
               channel should use locking; sets the 
@@ -3097,7 +3097,7 @@ This function is equivalent to calling :proc:`open` with ``iomode.cwr`` and then
            is required unless the ``url=`` argument is used.
 :arg kind: :type:`iokind` compile-time argument to determine the
            corresponding parameter of the :record:`channel` type. Defaults
-           to :enum:`iokind.dynamic`, meaning that the associated
+           to ``iokind.dynamic``, meaning that the associated
            :record:`iostyle` controls the formatting choices.
 :arg locking: compile-time argument to determine whether or not the
               channel should use locking; sets the 
@@ -3168,7 +3168,7 @@ proc openwriter(path:string="", param kind=iokind.dynamic, param locking=true,
                will halt with an error message.
    :arg kind: :type:`iokind` compile-time argument to determine the
               corresponding parameter of the :record:`channel` type. Defaults
-              to :enum:`iokind.dynamic`, meaning that the associated
+              to ``iokind.dynamic``, meaning that the associated
               :record:`iostyle` controls the formatting choices.
    :arg locking: compile-time argument to determine whether or not the
                  channel should use locking; sets the 
@@ -3267,7 +3267,7 @@ proc file.lines(param locking:bool = true, start:int(64) = 0, end:int(64) = max(
                will halt with an error message.
    :arg kind: :type:`iokind` compile-time argument to determine the
               corresponding parameter of the :record:`channel` type. Defaults
-              to :enum:`iokind.dynamic`, meaning that the associated
+              to ``iokind.dynamic``, meaning that the associated
               :record:`iostyle` controls the formatting choices.
    :arg locking: compile-time argument to determine whether or not the
                  channel should use locking; sets the 
@@ -3729,6 +3729,7 @@ proc channel.writeIt(x) {
    For a writing channel, writes as with :proc:`channel.write`.
    For a reading channel, reads as with :proc:`channel.read`.
    Stores any error encountered in the channel. Does not return anything.
+
  */
 inline proc channel.readwrite(x) where this.writing {
   this.writeIt(x);
@@ -3741,7 +3742,9 @@ inline proc channel.readwrite(ref x) where !this.writing {
 
   /*
 
-     The `<~>` operator is the same as calling :proc:`channel.readwrite`,
+     The _`<~> operator`
+
+     This `<~>` operator is the same as calling :proc:`channel.readwrite`,
      except that it returns the channel so that multiple operator
      calls can be chained together.
 

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -905,7 +905,7 @@ record regexp {
 
      :arg repl: replace matches with this string
      :arg text: the text to search and replace within
-     :type text: string
+     :type text: `string`
      :arg global: if true, replace multiple matches
      :returns: a tuple containing (new string, number of substitutions made)
    */
@@ -938,7 +938,7 @@ record regexp {
 
      :arg repl: replace matches with this string
      :arg text: the text to search and replace within
-     :type text: string
+     :type text: `string`
      :arg global: if true, replace multiple matches
      :returns: the new string
    */

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -26,7 +26,7 @@
    This module also defines the error types :type:`syserr` and :type:`err_t`.
 
    When should one use :type:`syserr` and when should one use :type:`err_t`?
-   :type:`err_t` is a system error code (a :type:`c_int` by a nicer name to
+   :type:`err_t` is a system error code (a `c_int` by a nicer name to
    indicate its purpose). :type:`syserr` is an enhanced error that might also
    include an error message. All user-facing Chapel library code, or user
    Chapel code, should generally use :type:`syserr`. When wrapping functions
@@ -91,13 +91,13 @@ extern proc chpl_cnullfile():_file;
  */
 extern type syserr; // = c_int, opaque so we can manually override ==,!=,etc
 
-/* An integral error code. This is really just a :type:`c_int`, but code is
+/* An integral error code. This is really just a `c_int`, but code is
    clearer if you use err_t to indicate arguments, variables, and return types
    that are system error codes. 
  */
 extern type err_t = c_int;
 
-/* A system file descriptior. This is really just a :type:`c_int`, but code is
+/* A system file descriptior. This is really just a `c_int`, but code is
    clearer if you use fd_t to indicate arguments, variables, and return types
    that are system file descriptors.
  */


### PR DESCRIPTION
This commit removes all broken links reported by sphinx make check in
these files:

 * technotes/extern.rst
 * ChapelLocale.chpl
 * String.chpl
 * IO.chpl
 * Regexp.chpl
 * SysBasic.chpl

I used the commands

     cd doc/sphinx
     ./run-in-venv.bash  make check

to verify that the broken links in these files were no longer
reported.

Sometimes I used one quote and sometimes two: e.g. `int` but
``iomode.cwr``. Right now, the first of these renders as italics but the
second as red monospace in a box.

chpldoc TODOs:

* Our current chpldoc output has e.g. ``c_int`` rendering
   in red. That seems a bit jarring to me and I would prefer
   it look like :type:`channel` e.g. - just be monospaced.

* I think Chapel primitive types should work if you say
   e.g. :type:`int`.

* :rtype: renders very differently from :type:

* It does not seem to be possible to cross-reference directly
   to an enum field (without making a broken link).

* I had some trouble referencing a proc named <~>. This might
   be an issue because it conflicts with the RST
   syntax for specifying a url (like `Cray <http://cray.com>`).
   Perhaps such procedures need to have their name escaped
   in the RST. I wonder if there is a similar issue for
   procedures named < for example.