### PR TITLE
Reformat third-party/README to fit 80 columns

### DIFF
--- a/third-party/README
+++ b/third-party/README
@@ -137,10 +137,12 @@ utf8-decoder/
   See also: utf8-decoder/README
 
 libhdfs3/
-  Summary: A pure C/C++ implementation of the libhdfs client library, can be used as 
-           an alternative to the libhdfs client library provided in the Apache Hadoop 
-           distribution (Apache Hadoop's libhdfs uses the JVM). libhdfs3 is developed
-           by Pivotal and is used in HAWQ.
+
+  Summary: A pure C/C++ implementation of the libhdfs client library,
+           which can be used as an alternative to the libhdfs client
+           library provided in the Apache Hadoop distribution (Apache
+           Hadoop's libhdfs uses the JVM). libhdfs3 is developed by
+           Pivotal and is used in HAWQ.
 
   License: Apache 2.0
 


### PR DESCRIPTION
Browsing this README, I happened to notice that the libhdfs3 entry overflowed
80 columns, so just gave it a simple reformat and wordsmithed slightly while
here.