### PR TITLE
Document our ability to use enums in the spec

### DIFF
--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -315,116 +315,15 @@ compiler error.
 If a module is visible to the scope in which accessing its symbols is desirable,
 then a use statement on that module may be employed.  Use statements
 make a module's visible symbols available without requiring them to be
-prefixed by the module's name.  The syntax of the use statement is
-given by:
+prefixed by the module's name.  For information about use statements in general,
+see~\rsec{The_Use_Statement}.
 
-\begin{syntax}
-use-statement:
-  `use' module-name-list ;
-
-module-name-list:
-  module-name limitation-clause[OPT]
-  module-name , module-name-list
-
-module-name:
-  identifier
-  module-name . module-name
-
-limitation-clause:
-  `except' identifier-list
-  `only' rename-list
-
-rename-list:
-  rename-base
-  rename-base , rename-list
-
-rename-base:
-  identifier `as' identifier
-  identifier
-\end{syntax}
-
-Symbols made available by a use statement are at an outer scope from those
-defined directly in the scope where the use statement occurs, but at a
-nearer scope than symbols defined in the scope containing the scope where
-the use statement occurs.
-
-An optional \sntx{limitation-clause} may be provided to limit the symbols made
-available by the use statement.  If an \chpl{except} list is provided, then all
-the visible but unlisted symbols in the module will be made available without
-prefix.  If an \chpl{only} list is provided, then just the listed visible
-symbols in the module will be made available without prefix.  All visible
-symbols not provided via these limited use statements are still accessible with
-the module name prefix.  If a type is specified in the \sntx{limitation-clause},
-then the type's fields and methods are treated similarly to the type name.
-These fields and methods cannot be specified in a \sntx{limitation-clause} on
-their own.  It is an error to provide a name in a \sntx{limitation-clause} that
-does not exist or is not visible in the respective module.
-
-Within an \chpl{only} list, a visible symbol from that module may optionally be
-given a new name using the \chpl{as} keyword.  This new name will be usable from
-the scope of the use in place of the old name unless the old name is
-additionally specified in the \chpl{only} list.  If a use which renames a symbol
-is present at module scope, uses of that module will also be able to reference
-that symbol using the new name instead of the old name.  Renaming does not
-affect accesses to that symbol via the source module's prefix, nor does it
-affect uses of that module from other contexts.  It is an error to attempt to
-rename a symbol that does not exist or is not visible in the respective module,
-or to rename a symbol to a name that is already present in the same \chpl{only}
-list.  It is, however, perfectly acceptable to rename a symbol to a name present
-in the respective module which was not specified via that \chpl{only} list.
+If a type is specified in the \sntx{limitation-clause}, then the type's fields
+and methods are treated similarly to the type name.  These fields and methods
+cannot be specified in a \sntx{limitation-clause} on their own.
 
 % We need to figure out what to do about functions that return types which due
 % to the limitation-clause are not visible without prefix.
-
-If a use statement mentions multiple modules, only the last module can have a
-\sntx{limitation-clause}.
-
-Use statements are transitive by default: if a module A used by
-another module B also contains a use of a further module C, C's
-symbols will also be considered visible within B, at a further scope
-than the symbols of other modules immediately used by B.  Limitation clauses
-are applied transitively as well - if module B's use of module A contains an
-\chpl{except} or \chpl{only} list, that list will also limit which of C's
-symbols are visible to B.
-
-% We would like to provide a way to specify that a use should not be
-% transitive
-
-It is an error for two public variables, types, or modules with the same
-name to be defined at the same depth.
-
-\begin{chapelexample}{use.chpl}
-  The following example illustrates how the use statement makes
-  symbols declared in \chpl{M1}'s scope (like procedure
-  \chpl{foo()}) visible within the scope of \chpl{M2}'s \chpl{main}
-  function.  Without the \chpl{use} statement, the procedure call to
-  \chpl{foo} could not be resolved since \chpl{M2} would not have
-  access to symbols in \chpl{M1}.
-
-  When executed, the program
-\begin{chapel}
-module M1 {
-  proc foo() {
-    writeln("In M1's foo.");
-  }
-}
-
-module M2 {
-  proc main() {
-    use M1;
-
-    writeln("In M2's main.");
-    foo();
-  }
-}
-\end{chapel}
-prints out
-\begin{chapelprintoutput}{}
-In M2's main.
-In M1's foo.
-\end{chapelprintoutput}
-\end{chapelexample}
-
 
 
 \subsection{Module Initialization}

--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -665,12 +665,11 @@ label outer for i in 1..n {
 \index{modules!using}
 \index{types!enumerated!using}
 
-The use statement makes constants in each listed enumerated type or symbols in
-each listed module's scope available without prefix from the scope where the use
-statement occurs.  Note that this is the only way to reference an enumeration
-constant without the enumeration type name as a prefix
-(see~\rsec{Enumerated_Types}).  For rules which are only applicable to modules,
-please see~\rsec{Using_Modules}.  The syntax of the use statement is given by:
+The use statement provides access to the constants in an enumerated type or
+the public symbols of a module within the scope in which it appears without
+the need to provide a full qualified path.
+
+The syntax of the use statement is given by:
 
 \begin{syntax}
 use-statement:
@@ -697,14 +696,82 @@ rename-base:
   identifier
 \end{syntax}
 
-Symbols made available by a use statement are at an outer scope from those
-defined directly in the scope where the use statement occurs, but at a nearer
-scope than symbols defined in the scope containing the scope where the use
-statement occurs.  The placement of a use statement relative to other statements
-within a scope does not affect the availability of the used module's symbols or
-the used enumerated type's constants - a use statement at the end or middle of a
-scope will impact the same symbol accesses it would have impacted if it had been
-placed at the beginning of that scope.
+For example, the program
+\begin{chapelexample}{use1.chpl}
+\begin{chapel}
+module M1 {
+  proc foo() {
+    writeln("In M1's foo.");
+  }
+}
+
+module M2 {
+  proc main() {
+    writeln("In M2's main.");
+    M1.foo();
+  }
+}
+\end{chapel}
+prints out
+\begin{chapelprintoutput}{}
+In M2's main.
+In M1's foo.
+\end{chapelprintoutput}
+\end{chapelexample}
+
+This program is equivalent to:
+\begin{chapelexample}{use2.chpl}
+\begin{chapel}
+module M1 {
+  proc foo() {
+    writeln("In M1's foo.");
+  }
+}
+
+module M2 {
+  proc main() {
+    use M1;
+
+    writeln("In M2's main.");
+    foo();
+  }
+}
+\end{chapel}
+which also prints out
+\begin{chapelprintoutput}{}
+In M2's main.
+In M1's foo.
+\end{chapelprintoutput}
+\end{chapelexample}
+
+The names that are imported by a use statement are inserted in to a
+new scope that immediately encloses the scope within which the
+statement appears.  This implies that the position of the use
+statement within a scope has no effect on its behavior.  If a scope
+includes multiple use statements then the imported names are inserted
+in to a common enclosing scope.
+
+An error is signaled if multiple enumeration constants or public module-level
+symbols would be inserted into this enclosing scope with the same name, and
+that name is referenced by other statements in the same scope as the use.
+
+
+Use statements are transitive by default: if a module A uses a module
+B, and module B contains a use of a module or enumerated type C, then
+C's public symbols may also be visible within A.  The exception to
+this occurs when B has public symbols that shadow symbols with the
+same name in C.
+
+This notion of transitivity extends to the case in which a scope
+imports symbols from multiple modules or constants from multiple
+enumeration types.  For example if a module A uses modules B1, B2, B3
+and modules B1, B2, B3 use modules C1, C2, C3 respectively, then all
+of the public symbols in B1, B2, B3 have the potential to shadow the
+public symbols of C1, C2, and C3.  However an error is signaled if
+C1, C2, C3 have public module level definitions of the same symbol.
+
+% We would like to provide a way to specify that a use should not be
+% transitive
 
 An optional \sntx{limitation-clause} may be provided to limit the symbols made
 available by the use statement.  If an \chpl{except} list is provided, then all
@@ -733,54 +800,15 @@ that \chpl{only} list.
 
 If a use statement mentions multiple modules or enumerated types or a mix of
 these symbols, only the last module or enumerated type can have a
-\sntx{limitation-clause}.  All use statements in a scope are considered at the
-same depth relative to the symbols within the scope - the ordering of use
-statements or modules/enumerated types within a use statement will not affect
-that depth.  It is an error for two public variables, types, enumeration
-constants, or modules with the same name to be defined at the same depth.
+\sntx{limitation-clause}.  Limitation clauses are applied transitively as well
+- in the first example, if module A's use of module B contains an \chpl{except}
+or \chpl{only} list, that list will also limit which of C's symbols are visible
+to A.
 
-Use statements are transitive by default: if a module A used by another module B
-also contains a use of a further module or enumerated type C, C's symbols will
-also be considered visible within B, at a further scope than the symbols of
-other modules immediately used by B.  Limitation clauses are applied
-transitively as well - if module B's use of module A contains an
-\chpl{except} or \chpl{only} list, that list will also limit which of C's
-symbols are visible to B.
-
-% We would like to provide a way to specify that a use should not be
-% transitive
-
-\begin{chapelexample}{use.chpl}
-  The following example illustrates how the use statement makes
-  symbols declared in \chpl{M1}'s scope (like procedure
-  \chpl{foo()}) visible within the scope of \chpl{M2}'s \chpl{main}
-  function.  Without the \chpl{use} statement, the procedure call to
-  \chpl{foo} could not be resolved since \chpl{M2} would not have
-  access to symbols in \chpl{M1}.
-
-  When executed, the program
-\begin{chapel}
-module M1 {
-  proc foo() {
-    writeln("In M1's foo.");
-  }
-}
-
-module M2 {
-  proc main() {
-    use M1;
-
-    writeln("In M2's main.");
-    foo();
-  }
-}
-\end{chapel}
-prints out
-\begin{chapelprintoutput}{}
-In M2's main.
-In M1's foo.
-\end{chapelprintoutput}
-\end{chapelexample}
+For more information on enumerated types, please see~\rsec{Enumerated_Types}.
+For use statement rules which are only applicable to modules, please
+see~\rsec{Using_Modules}.  For more information on modules in general, please
+see~\rsec{Modules}.
 
 
 \section{The Empty Statement}

--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -667,8 +667,10 @@ label outer for i in 1..n {
 
 The use statement makes constants in each listed enumerated type or symbols in
 each listed module's scope available without prefix from the scope where the use
-statement occurs.  For rules which are only applicable to modules, please
-see~\rsec{Using_Modules}.  The syntax of the use statement is given by:
+statement occurs.  Note that this is the only way to reference an enumeration
+constant without the enumeration type name as a prefix
+(see~\rsec{Enumerated_Types}).  For rules which are only applicable to modules,
+please see~\rsec{Using_Modules}.  The syntax of the use statement is given by:
 
 \begin{syntax}
 use-statement:
@@ -680,7 +682,7 @@ module-or-enum-name-list:
 
 module-or-enum-name:
   identifier
-  module-or-enum-name . module-or-enum-name
+  identifier . module-or-enum-name
 
 limitation-clause:
   `except' identifier-list
@@ -696,9 +698,13 @@ rename-base:
 \end{syntax}
 
 Symbols made available by a use statement are at an outer scope from those
-defined directly in the scope where the use statement occurs, but at a
-nearer scope than symbols defined in the scope containing the scope where
-the use statement occurs.
+defined directly in the scope where the use statement occurs, but at a nearer
+scope than symbols defined in the scope containing the scope where the use
+statement occurs.  The placement of a use statement relative to other statements
+within a scope does not affect the availability of the used module's symbols or
+the used enumerated type's constants - a use statement at the end or middle of a
+scope will impact the same symbol accesses it would have impacted if it had been
+placed at the beginning of that scope.
 
 An optional \sntx{limitation-clause} may be provided to limit the symbols made
 available by the use statement.  If an \chpl{except} list is provided, then all
@@ -727,7 +733,11 @@ that \chpl{only} list.
 
 If a use statement mentions multiple modules or enumerated types or a mix of
 these symbols, only the last module or enumerated type can have a
-\sntx{limitation-clause}.
+\sntx{limitation-clause}.  All use statements in a scope are considered at the
+same depth relative to the symbols within the scope - the ordering of use
+statements or modules/enumerated types within a use statement will not affect
+that depth.  It is an error for two public variables, types, enumeration
+constants, or modules with the same name to be defined at the same depth.
 
 Use statements are transitive by default: if a module A used by another module B
 also contains a use of a further module or enumerated type C, C's symbols will
@@ -739,9 +749,6 @@ symbols are visible to B.
 
 % We would like to provide a way to specify that a use should not be
 % transitive
-
-It is an error for two public variables, types, enumeration constants, or
-modules with the same name to be defined at the same depth.
 
 \begin{chapelexample}{use.chpl}
   The following example illustrates how the use statement makes

--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -663,10 +663,118 @@ label outer for i in 1..n {
 \index{use@\chpl{use}}
 \index{statements!use@\chpl{use}}
 \index{modules!using}
+\index{types!enumerated!using}
 
-The use statement makes symbols in each listed module's scope
-available from the scope where the use statement occurs.  For more
-information on use statements, see~\rsec{Using_Modules}.
+The use statement makes constants in each listed enumerated type or symbols in
+each listed module's scope available without prefix from the scope where the use
+statement occurs.  For rules which are only applicable to modules, please
+see~\rsec{Using_Modules}.  The syntax of the use statement is given by:
+
+\begin{syntax}
+use-statement:
+  `use' module-or-enum-name-list ;
+
+module-or-enum-name-list:
+  module-or-enum-name limitation-clause[OPT]
+  module-or-enum-name , module-or-enum-name-list
+
+module-or-enum-name:
+  identifier
+  module-or-enum-name . module-or-enum-name
+
+limitation-clause:
+  `except' identifier-list
+  `only' rename-list
+
+rename-list:
+  rename-base
+  rename-base , rename-list
+
+rename-base:
+  identifier `as' identifier
+  identifier
+\end{syntax}
+
+Symbols made available by a use statement are at an outer scope from those
+defined directly in the scope where the use statement occurs, but at a
+nearer scope than symbols defined in the scope containing the scope where
+the use statement occurs.
+
+An optional \sntx{limitation-clause} may be provided to limit the symbols made
+available by the use statement.  If an \chpl{except} list is provided, then all
+the visible but unlisted symbols in the module or enumerated type will be made
+available without prefix.  If an \chpl{only} list is provided, then just the
+listed visible symbols in the module or enumerated type will be made available
+without prefix.  All visible symbols not provided via these limited use
+statements are still accessible with the module or enumerated type name prefix.
+It is an error to provide a name in a \sntx{limitation-clause} that does not
+exist or is not visible in the respective module or enumerated type.
+
+Within an \chpl{only} list, a visible symbol from that module may optionally be
+given a new name using the \chpl{as} keyword.  This new name will be usable from
+the scope of the use in place of the old name unless the old name is
+additionally specified in the \chpl{only} list.  If a use which renames a symbol
+is present at module scope, uses of that module will also be able to reference
+that symbol using the new name instead of the old name.  Renaming does not
+affect accesses to that symbol via the source module's or enumerated type's
+prefix, nor does it affect uses of that module or enumerated type from other
+contexts.  It is an error to attempt to rename a symbol that does not exist or
+is not visible in the respective module or enumerated type, or to rename a
+symbol to a name that is already present in the same \chpl{only} list.  It is,
+however, perfectly acceptable to rename a symbol to a name present in the
+respective module or enumerated type which was not specified via
+that \chpl{only} list.
+
+If a use statement mentions multiple modules or enumerated types or a mix of
+these symbols, only the last module or enumerated type can have a
+\sntx{limitation-clause}.
+
+Use statements are transitive by default: if a module A used by another module B
+also contains a use of a further module or enumerated type C, C's symbols will
+also be considered visible within B, at a further scope than the symbols of
+other modules immediately used by B.  Limitation clauses are applied
+transitively as well - if module B's use of module A contains an
+\chpl{except} or \chpl{only} list, that list will also limit which of C's
+symbols are visible to B.
+
+% We would like to provide a way to specify that a use should not be
+% transitive
+
+It is an error for two public variables, types, enumeration constants, or
+modules with the same name to be defined at the same depth.
+
+\begin{chapelexample}{use.chpl}
+  The following example illustrates how the use statement makes
+  symbols declared in \chpl{M1}'s scope (like procedure
+  \chpl{foo()}) visible within the scope of \chpl{M2}'s \chpl{main}
+  function.  Without the \chpl{use} statement, the procedure call to
+  \chpl{foo} could not be resolved since \chpl{M2} would not have
+  access to symbols in \chpl{M1}.
+
+  When executed, the program
+\begin{chapel}
+module M1 {
+  proc foo() {
+    writeln("In M1's foo.");
+  }
+}
+
+module M2 {
+  proc main() {
+    use M1;
+
+    writeln("In M2's main.");
+    foo();
+  }
+}
+\end{chapel}
+prints out
+\begin{chapelprintoutput}{}
+In M2's main.
+In M1's foo.
+\end{chapelprintoutput}
+\end{chapelexample}
+
 
 \section{The Empty Statement}
 \label{The_Empty_Statement}

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -292,7 +292,8 @@ A joke is a very serious thing.
 No one will ever win the battle of the sexes; there's too much fraternizing with the enemy.
 \end{chapeloutput}
 outputs a quote from the given statesman.  Note that enumerated
-constants must be prefixed by the enumerated type and a dot.
+constants must be prefixed by the enumerated type name and a dot unless a
+use statement is employed (see~\rsec{The_Use_Statement}).
 \end{chapelexample}
 
 


### PR DESCRIPTION
Basically, moved the description of the use of modules from "Using Modules" to
"The Use Statement", in the process alterring much of the phrasing to refer to
modules or enumerated types instead of just modules.  I left one or two bits
which were only relevant to modules in "Using Modules" and gave "The Use
Statement" a reference to that section so the information wouldn't get lost due
to the shuffle.  Also, reference the ability to use enums from the enum
description section, "Enumerated Types".