### PR TITLE
Fix logic for re-making version.cpp

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -115,8 +115,9 @@ CHPL_CONFIG_CHECK = $(CHPL_CONFIG_CHECK_PREFIX)-$(CHPL_MAKE_COMPILER_SUBDIR)
 UPDATE_BUILD_VERSION = $(CHPL_MAKE_HOME)/util/devel/updateBuildVersion
 
 $(BUILD_VERSION_FILE): FORCE
-	@({ test -x $(CHPL_MAKE_HOME)/.git || test -x $(CHPL_MAKE_HOME)/.svn ; } && \
-	test -x $(UPDATE_BUILD_VERSION) && $(UPDATE_BUILD_VERSION) $@) || (echo '"0"' > $@);
+	@({ test -x $(CHPL_MAKE_HOME)/.git ; } && \
+	test -x $(UPDATE_BUILD_VERSION) && $(UPDATE_BUILD_VERSION) $@) || \
+	test -r $(BUILD_VERSION_FILE) || (echo '"0"' > $@);
 
 $(CHPL_CONFIG_CHECK): | $(CHPL_BIN_DIR)
 	rm -f $(CHPL_CONFIG_CHECK_PREFIX)-*


### PR DESCRIPTION
For quite some time now, if building the Chapel compiler outside
of a .git setting, we would rebuild version.cpp on every compile
because the logic that avoids creating a new compiler/main/BUILD_VERSION
file if nothing has changed version-wise is only intelligent when
git is involved.  When git is not involved -- or when we don't
have the util/devel/updateBuildVersion script available (as in a
release build setting), we would just echo "0" out to
compiler/main/BUILD_VERSION on *every* compile, forcing a rebuild.

This commit fixes that issue by only dropping a "0" into that file
in the event that the file does not exist.  The reviewer should
double-check my shell syntax, as I'm not an expert (specifically,
while this works on bash, will it work on sh?  If we care...)

While here, I also removed the check for .svn, which I believe
predates our move to git and was probably preserved for the
period of time when we were sitting on both svn and git before
disconnecting from svn.