### PR TITLE
Allow our venv to use the system python

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -105,6 +105,9 @@ rm-sphinx-build: FORCE
 	@rm -f $(CHPL_VENV_SPHINX_BUILD)
 
 
+use-system-python: FORCE
+	@./venv-use-sys-python.py $(CHPL_VENV_VIRTUALENV_BIN)
+
 FORCE:
 
 .PHONY: install-requirements create-virtualenv virtualenv check-exes rm-sphinx-build check-easy-install check-python

--- a/third-party/chpl-venv/venv-use-sys-python.py
+++ b/third-party/chpl-venv/venv-use-sys-python.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import sys
+
+# Remove the virtualenv pythons as well as references to them in
+# scripts. This effectively forces the virtualenv scripts to use the
+# system python.
+def remove_venv_python_references(venv_bin_dir):
+    for f in os.listdir(venv_bin_dir):
+        abs_f = os.path.join(venv_bin_dir, f)
+        if f.startswith("python"):
+            print('Removing {0}'.format(abs_f))
+            os.remove(abs_f)
+        else:
+            with open(abs_f) as fin:
+                lines = fin.readlines()
+
+            python_shebang = '#!/usr/bin/env python'
+            if len(lines) > 0  and lines[0].startswith (python_shebang):
+                print('Updating shebang for {0}'.format(abs_f))
+                lines[0] = '{0}\n'.format(python_shebang)
+
+            with open (abs_f, 'w') as fout:
+               for line in lines:
+                   fout.write(line)
+
+def main():
+    venv_bin_dir = sys.argv[1]
+    remove_venv_python_references(venv_bin_dir)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add a helper script and makefile target to force our virtualenv scripts to use
the system python. For the binary release of the cray module we need to be able
to support multiple pythons. In particular, the same module will be used on a
system with 2.6 and another with 2.7.

However, scripts installed in the virtualenv bin/ dir specify which python
version they were built with and the virtualenv includes a python that kind-of
symlinks to the system python used to initialize it. This means that the python
the virtualenv was built with needs to be available to use it. We build the
virtualenv with 2.6, but some machines only have 2.7, so we need some way to
remove the dependency on the system python version.

This adds a somewhat lame version of making the scripts in bin/ python
agnostic. It replaces `#!/usr/bin/env python<version>` with `#!/usr/bin/env
python` and removes the python* bins in the virtualenv.

I think all we'll need to do for the module build is build the venv with 2.7,
then force re-build it for 2.6 and then run this script and things *should*
work. It's not a particularly elegant solution. I don't know anything about
distributing python code in binaries so somebody else can come up with a better
solution later. In the meantime this should allow the module start_test and
chpldoc to work on CLE 5.X and 6.X