### PR TITLE
Fix chpldoc --text-only output of type methods

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -115,19 +115,14 @@ void AstToText::appendName(FnSymbol* fn)
 
 void AstToText::appendThisIntent(FnSymbol* fn)
 {
-  int index = indexForThis(fn);
+  if (fn->thisTag == INTENT_REF)
+    mText += "ref ";
 
-  if (index > 0)
-  {
-    DefExpr*   formal = toDefExpr(fn->formals.get(index));
-    ArgSymbol* argSym = toArgSymbol(formal->sym);
+  else if (fn->thisTag == INTENT_PARAM)
+    mText += "param ";
 
-    if (argSym->intent == INTENT_REF)
-      mText += "ref ";
-
-    else if (argSym->intent == INTENT_PARAM)
-      mText += "param ";
-  }
+  else if (fn->thisTag == INTENT_TYPE)
+    mText += "type ";
 }
 
 void AstToText::appendClassName(FnSymbol* fn)

--- a/test/chpldoc/classes/typeMethods.doc.catfiles
+++ b/test/chpldoc/classes/typeMethods.doc.catfiles
@@ -1,0 +1,1 @@
+docs/typeMethods.doc.txt

--- a/test/chpldoc/classes/typeMethods.doc.chpl
+++ b/test/chpldoc/classes/typeMethods.doc.chpl
@@ -1,0 +1,23 @@
+class Foo {
+  /* A type method declared inside the class Foo */
+  proc type biff() {
+
+  }
+}
+
+/* A type method declared outside the class Foo */
+proc type Foo.blah() {
+
+}
+
+record Bar {
+  /* A type method declared inside the record Bar */
+  proc type biff() {
+
+  }
+}
+
+/* A type method declared outside the record Bar */
+proc type Bar.blah() {
+
+}

--- a/test/chpldoc/classes/typeMethods.doc.good
+++ b/test/chpldoc/classes/typeMethods.doc.good
@@ -1,0 +1,15 @@
+typeMethods.doc
+   Class: Foo
+      proc type biff()
+         A type method declared inside the class Foo 
+
+   proc type Foo.blah()
+      A type method declared outside the class Foo 
+
+   Record: Bar
+      proc type biff()
+         A type method declared inside the record Bar 
+
+   proc type Bar.blah()
+      A type method declared outside the record Bar 
+

--- a/test/chpldoc/types/paramMethod.doc.catfiles
+++ b/test/chpldoc/types/paramMethod.doc.catfiles
@@ -1,0 +1,1 @@
+docs/paramMethod.doc.txt

--- a/test/chpldoc/types/paramMethod.doc.chpl
+++ b/test/chpldoc/types/paramMethod.doc.chpl
@@ -1,0 +1,4 @@
+/* I can only be called on param versions of the type `int` */
+proc param int.foo() {
+
+}

--- a/test/chpldoc/types/paramMethod.doc.good
+++ b/test/chpldoc/types/paramMethod.doc.good
@@ -1,0 +1,4 @@
+paramMethod.doc
+   proc param int.foo()
+      I can only be called on param versions of the type `int` 
+


### PR DESCRIPTION
Turns out that AstToText was keying off the intent of the this argument in the
function, but in the case of a type function, the intent on the this argument
was blank.  Happily, the FnSymbol has a field "thisTag" which corresponds to
whether the method is a param or type method, so I updated the appendThisIntent
method on AstToText to use that instead.  This seems much cleaner, and the
tests work now.

Add two tests, one of the generation for type methods and one of the generation
for param methods, just to lock those cases in.