### PR TITLE
Update NPB random seed adjustment to use mask

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1975,12 +1975,13 @@ module Random {
         // See test/portability/bigmod.test.c
         var one:uint(64) = 1;
         var two_46:uint(64) = one << 46;
+        var two_46_mask:uint(64) = two_46 - 1;
         var useed = seed:uint(64);
         var mod:uint(64);
         if useed % 2 == 0 then
           halt("NPBRandomStream seed must be an odd integer");
         // Adjust seed to be between 0 and 2**46.
-        mod = useed % two_46;
+        mod = useed & two_46_mask;
         this.seed = mod:int(64);
 
         if this.seed % 2 == 0 || this.seed < 1 || this.seed > two_46:int(64) then


### PR DESCRIPTION
This is a second attempt to work around a PGI issue.  The first attempt
was in PR #3545.

Here we mask instead of using mod in an attempt to avoid the apparent C
compiler bug.

Verified that these tests pass in an environment where some were failing:
 * test/npb/cg/bradc/cg-printa.chpl
 * test/exercises
 * test/modules/standard/Random

Verified also that test/modules/standard/Random passes with clang/OSX.
Trivial and not reviewed.