### PR TITLE
Remove validation of ISx problem size

### DIFF
--- a/test/release/examples/benchmarks/isx/goods-1/isx-probsize-strong.good
+++ b/test/release/examples/benchmarks/isx/goods-1/isx-probsize-strong.good
@@ -1,7 +1,0 @@
-scaling mode = strong
-total keys = 134217728 (2**27)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 268435456 (2**28)
-bucketWidth = 268435456 (2**28)
-numTrials = 0
-numLocales = 1

--- a/test/release/examples/benchmarks/isx/goods-1/isx-probsize-weak.good
+++ b/test/release/examples/benchmarks/isx/goods-1/isx-probsize-weak.good
@@ -1,7 +1,0 @@
-scaling mode = weak
-total keys = 134217728 (2**27)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 268435456 (2**28)
-bucketWidth = 268435456 (2**28)
-numTrials = 0
-numLocales = 1

--- a/test/release/examples/benchmarks/isx/goods-1/isx-probsize-weakISO.good
+++ b/test/release/examples/benchmarks/isx/goods-1/isx-probsize-weakISO.good
@@ -1,7 +1,0 @@
-scaling mode = weakISO
-total keys = 134217728 (2**27)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 8192 (2**13)
-bucketWidth = 8192 (2**13)
-numTrials = 0
-numLocales = 1

--- a/test/release/examples/benchmarks/isx/goods-4/isx-probsize-strong.good
+++ b/test/release/examples/benchmarks/isx/goods-4/isx-probsize-strong.good
@@ -1,7 +1,0 @@
-scaling mode = strong
-total keys = 134217728 (2**27)
-keys per locale = 33554432 (2**25)
-maxKeyVal = 268435456 (2**28)
-bucketWidth = 67108864 (2**26)
-numTrials = 0
-numLocales = 4

--- a/test/release/examples/benchmarks/isx/goods-4/isx-probsize-weak.good
+++ b/test/release/examples/benchmarks/isx/goods-4/isx-probsize-weak.good
@@ -1,7 +1,0 @@
-scaling mode = weak
-total keys = 536870912 (2**29)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 268435456 (2**28)
-bucketWidth = 67108864 (2**26)
-numTrials = 0
-numLocales = 4

--- a/test/release/examples/benchmarks/isx/goods-4/isx-probsize-weakISO.good
+++ b/test/release/examples/benchmarks/isx/goods-4/isx-probsize-weakISO.good
@@ -1,7 +1,0 @@
-scaling mode = weakISO
-total keys = 536870912 (2**29)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 32768 (2**15)
-bucketWidth = 8192 (2**13)
-numTrials = 0
-numLocales = 4

--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -151,29 +151,27 @@ var barrier = new Barrier(numTasks);
 
 // should result in one loop iteration per task
 proc main() {
-  if numTrials != 0 {
-    coforall loc in Locales do on loc {
-      coforall tid in 0..#perBucketMultiply {
-        //
-        // The non-positive iterations represent burn-in runs, so don't
-        // time those.  To reduce time spent in verification, verify only
-        // the final timed run.
-        //
-        const taskID = (loc.id * perBucketMultiply) + tid;
-        for i in 1-numBurnInRuns..numTrials do
-          bucketSort(taskID, trial=i, time=printTimings && (i>0), verify=(i==numTrials));
-      }
+  coforall loc in Locales do on loc {
+    coforall tid in 0..#perBucketMultiply {
+      //
+      // The non-positive iterations represent burn-in runs, so don't
+      // time those.  To reduce time spent in verification, verify only
+      // the final timed run.
+      //
+      const taskID = (loc.id * perBucketMultiply) + tid;
+      for i in 1-numBurnInRuns..numTrials do
+        bucketSort(taskID, trial=i, time=printTimings && (i>0), verify=(i==numTrials));
     }
-
-    if debug {
-      writeln("final buckets =\n");
-      for (i,b) in zip(LocTaskSpace, allBucketKeys) do
-        writeln("Bucket ", i, " (owned by ", b.locale.id, "): ", b);
-    }
-
-    if printTimings then
-      printTimingData("locales");
   }
+
+  if debug {
+    writeln("final buckets =\n");
+    for (i,b) in zip(LocTaskSpace, allBucketKeys) do
+      writeln("Bucket ", i, " (owned by ", b.locale.id, "): ", b);
+  }
+
+  if printTimings then
+    printTimingData("locales");
 
   delete barrier;
 }

--- a/test/release/examples/benchmarks/isx/isx.execopts
+++ b/test/release/examples/benchmarks/isx/isx.execopts
@@ -1,6 +1,3 @@
 --testrun=true --mode=strong  --printTimings=false --perBucketMultiply=1 # isx-test-strong.good
 --testrun=true --mode=weak    --printTimings=false --perBucketMultiply=1 # isx-test-weak.good
 --testrun=true --mode=weakISO --printTimings=false --perBucketMultiply=1 # isx-test-weakISO.good
---numTrials=0 --mode=strong   --printTimings=false --perBucketMultiply=1 # isx-probsize-strong.good
---numTrials=0 --mode=weak     --printTimings=false --perBucketMultiply=1 # isx-probsize-weak.good
---numTrials=0 --mode=weakISO  --printTimings=false --perBucketMultiply=1 # isx-probsize-weakISO.good

--- a/test/studies/isx/goods-1/isx-probsize-strong.good
+++ b/test/studies/isx/goods-1/isx-probsize-strong.good
@@ -1,7 +1,0 @@
-scaling mode = strong
-total keys = 134217728 (2**27)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 268435456 (2**28)
-bucketWidth = 268435456 (2**28)
-numTrials = 0
-numLocales = 1

--- a/test/studies/isx/goods-1/isx-probsize-weak.good
+++ b/test/studies/isx/goods-1/isx-probsize-weak.good
@@ -1,7 +1,0 @@
-scaling mode = weak
-total keys = 134217728 (2**27)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 268435456 (2**28)
-bucketWidth = 268435456 (2**28)
-numTrials = 0
-numLocales = 1

--- a/test/studies/isx/goods-1/isx-probsize-weakISO.good
+++ b/test/studies/isx/goods-1/isx-probsize-weakISO.good
@@ -1,7 +1,0 @@
-scaling mode = weakISO
-total keys = 134217728 (2**27)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 8192 (2**13)
-bucketWidth = 8192 (2**13)
-numTrials = 0
-numLocales = 1

--- a/test/studies/isx/goods-4/isx-probsize-strong.good
+++ b/test/studies/isx/goods-4/isx-probsize-strong.good
@@ -1,7 +1,0 @@
-scaling mode = strong
-total keys = 134217728 (2**27)
-keys per locale = 33554432 (2**25)
-maxKeyVal = 268435456 (2**28)
-bucketWidth = 67108864 (2**26)
-numTrials = 0
-numLocales = 4

--- a/test/studies/isx/goods-4/isx-probsize-weak.good
+++ b/test/studies/isx/goods-4/isx-probsize-weak.good
@@ -1,7 +1,0 @@
-scaling mode = weak
-total keys = 536870912 (2**29)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 268435456 (2**28)
-bucketWidth = 67108864 (2**26)
-numTrials = 0
-numLocales = 4

--- a/test/studies/isx/goods-4/isx-probsize-weakISO.good
+++ b/test/studies/isx/goods-4/isx-probsize-weakISO.good
@@ -1,7 +1,0 @@
-scaling mode = weakISO
-total keys = 536870912 (2**29)
-keys per locale = 134217728 (2**27)
-maxKeyVal = 32768 (2**15)
-bucketWidth = 8192 (2**13)
-numTrials = 0
-numLocales = 4

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -144,32 +144,30 @@ var verifyKeyCount: atomic int;
 var barrier = new Barrier(numBuckets);
 
 proc main() {
-  if numTrials != 0 {
-    coforall bucketID in BucketSpace do
-      on BucketDist.idxToLocale(bucketID) {
-        //
-        // Execution is SPMD-style across buckets here
-        //
+  coforall bucketID in BucketSpace do
+    on BucketDist.idxToLocale(bucketID) {
+      //
+      // Execution is SPMD-style across buckets here
+      //
 
-        //
-        // The non-positive iterations represent burn-in runs, so don't
-        // time those.  To reduce time spent in verification, verify only
-        // the final timed run.
-        //
-        for i in 1-numBurnInRuns..numTrials do
-          bucketSort(bucketID, trial=i, time=printTimings && (i>0),
-                     verify=(i==numTrials));
-      }
-
-    if debug {
-      writeln("final buckets =\n");
-      for (i,b) in zip(BucketSpace, allBucketKeys) do
-        writeln("Bucket ", i, " (owned by locale ", b.locale.id, "): ", b);
+      //
+      // The non-positive iterations represent burn-in runs, so don't
+      // time those.  To reduce time spent in verification, verify only
+      // the final timed run.
+      //
+      for i in 1-numBurnInRuns..numTrials do
+        bucketSort(bucketID, trial=i, time=printTimings && (i>0),
+                   verify=(i==numTrials));
     }
 
-    if printTimings then
-      printTimingData("buckets");
+  if debug {
+    writeln("final buckets =\n");
+    for (i,b) in zip(BucketSpace, allBucketKeys) do
+      writeln("Bucket ", i, " (owned by locale ", b.locale.id, "): ", b);
   }
+
+  if printTimings then
+    printTimingData("buckets");
 
   delete barrier;
 }

--- a/test/studies/isx/isx-bucket-spmd.execopts
+++ b/test/studies/isx/isx-bucket-spmd.execopts
@@ -1,6 +1,3 @@
 --testrun=true --mode=strong  --printTimings=false --perBucketMultiply=1 # isx-test-strong.good
 --testrun=true --mode=weak    --printTimings=false --perBucketMultiply=1 # isx-test-weak.good
 --testrun=true --mode=weakISO --printTimings=false --perBucketMultiply=1 # isx-test-weakISO.good
---numTrials=0 --mode=strong   --printTimings=false --perBucketMultiply=1 # isx-probsize-strong.good
---numTrials=0 --mode=weak     --printTimings=false --perBucketMultiply=1 # isx-probsize-weak.good
---numTrials=0 --mode=weakISO  --printTimings=false --perBucketMultiply=1 # isx-probsize-weakISO.good

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -144,32 +144,30 @@ var verifyKeyCount: atomic int;
 var barrier = new Barrier(numBuckets);
 
 proc main() {
-  if numTrials != 0 {
-    coforall bucketID in BucketSpace do
-      on BucketDist.idxToLocale(bucketID) {
-        //
-        // Execution is SPMD-style across buckets here
-        //
+  coforall bucketID in BucketSpace do
+    on BucketDist.idxToLocale(bucketID) {
+      //
+      // Execution is SPMD-style across buckets here
+      //
 
-        //
-        // The non-positive iterations represent burn-in runs, so don't
-        // time those.  To reduce time spent in verification, verify only
-        // the final timed run.
-        //
-        for i in 1-numBurnInRuns..numTrials do
-          bucketSort(bucketID, trial=i, time=printTimings && (i>0),
-                     verify=(i==numTrials));
-      }
-
-    if debug {
-      writeln("final buckets =\n");
-      for (i,b) in zip(BucketSpace, allBucketKeys) do
-        writeln("Bucket ", i, " (owned by locale ", b.locale.id, "): ", b);
+      //
+      // The non-positive iterations represent burn-in runs, so don't
+      // time those.  To reduce time spent in verification, verify only
+      // the final timed run.
+      //
+      for i in 1-numBurnInRuns..numTrials do
+        bucketSort(bucketID, trial=i, time=printTimings && (i>0),
+                   verify=(i==numTrials));
     }
 
-    if printTimings then
-      printTimingData("buckets");
+  if debug {
+    writeln("final buckets =\n");
+    for (i,b) in zip(BucketSpace, allBucketKeys) do
+      writeln("Bucket ", i, " (owned by locale ", b.locale.id, "): ", b);
   }
+
+  if printTimings then
+    printTimingData("buckets");
 
   delete barrier;
 }

--- a/test/studies/isx/isx-no-return.execopts
+++ b/test/studies/isx/isx-no-return.execopts
@@ -1,6 +1,3 @@
 --testrun=true --mode=strong  --printTimings=false --perBucketMultiply=1 # isx-test-strong.good
 --testrun=true --mode=weak    --printTimings=false --perBucketMultiply=1 # isx-test-weak.good
 --testrun=true --mode=weakISO --printTimings=false --perBucketMultiply=1 # isx-test-weakISO.good
---numTrials=0 --mode=strong   --printTimings=false --perBucketMultiply=1 # isx-probsize-strong.good
---numTrials=0 --mode=weak     --printTimings=false --perBucketMultiply=1 # isx-probsize-weak.good
---numTrials=0 --mode=weakISO  --printTimings=false --perBucketMultiply=1 # isx-probsize-weakISO.good

--- a/test/studies/isx/isx-per-task.chpl
+++ b/test/studies/isx/isx-per-task.chpl
@@ -151,29 +151,27 @@ var barrier = new Barrier(numTasks);
 
 // should result in one loop iteration per task
 proc main() {
-  if numTrials != 0 {
-    coforall loc in Locales do on loc {
-      coforall tid in 0..#perBucketMultiply {
-        //
-        // The non-positive iterations represent burn-in runs, so don't
-        // time those.  To reduce time spent in verification, verify only
-        // the final timed run.
-        //
-        const taskID = (loc.id * perBucketMultiply) + tid;
-        for i in 1-numBurnInRuns..numTrials do
-          bucketSort(taskID, trial=i, time=printTimings && (i>0), verify=(i==numTrials));
-      }
+  coforall loc in Locales do on loc {
+    coforall tid in 0..#perBucketMultiply {
+      //
+      // The non-positive iterations represent burn-in runs, so don't
+      // time those.  To reduce time spent in verification, verify only
+      // the final timed run.
+      //
+      const taskID = (loc.id * perBucketMultiply) + tid;
+      for i in 1-numBurnInRuns..numTrials do
+        bucketSort(taskID, trial=i, time=printTimings && (i>0), verify=(i==numTrials));
     }
-
-    if debug {
-      writeln("final buckets =\n");
-      for (i,b) in zip(LocTaskSpace, allBucketKeys) do
-        writeln("Bucket ", i, " (owned by ", b.locale.id, "): ", b);
-    }
-
-    if printTimings then
-      printTimingData("locales");
   }
+
+  if debug {
+    writeln("final buckets =\n");
+    for (i,b) in zip(LocTaskSpace, allBucketKeys) do
+      writeln("Bucket ", i, " (owned by ", b.locale.id, "): ", b);
+  }
+
+  if printTimings then
+    printTimingData("locales");
 
   delete barrier;
 }

--- a/test/studies/isx/isx-per-task.execopts
+++ b/test/studies/isx/isx-per-task.execopts
@@ -1,6 +1,3 @@
 --testrun=true --mode=strong  --printTimings=false --perBucketMultiply=1 # isx-test-strong.good
 --testrun=true --mode=weak    --printTimings=false --perBucketMultiply=1 # isx-test-weak.good
 --testrun=true --mode=weakISO --printTimings=false --perBucketMultiply=1 # isx-test-weakISO.good
---numTrials=0 --mode=strong   --printTimings=false --perBucketMultiply=1 # isx-probsize-strong.good
---numTrials=0 --mode=weak     --printTimings=false --perBucketMultiply=1 # isx-probsize-weak.good
---numTrials=0 --mode=weakISO  --printTimings=false --perBucketMultiply=1 # isx-probsize-weakISO.good


### PR DESCRIPTION
The refactoring from #3553 resulted in massive memory leaks, as we were previously exiting before allocating distributed arrays. Instead, remove the numTrials=0 execopts and rely on performance testing to track the problem size.