### PR TITLE
Add a PREDIFF to handle message introduced by #3558.

### DIFF
--- a/test/studies/madness/aniruddha/madchap/PREDIFF
+++ b/test/studies/madness/aniruddha/madchap/PREDIFF
@@ -1,0 +1,2 @@
+#! /bin/sh
+grep -v 'Reduced numThreadsPerLocale' < $2 > $2.prediff.tmp && mv $2.prediff.tmp $2


### PR DESCRIPTION
Yesterday's #3558 caused a number of the madchap tests to emit
the message about reducing numThreadsPerLocale, whenever
they were run on systems with fewer PUs than the specified 5
threads in the EXECENV file.  Add a PREDIFF to remove this
new message from the test output.