### PR TITLE
Update LICENSE file WRT what packages are used by default

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -80,8 +80,10 @@ The Chapel implementation is composed of two categories of code:
      re2              only used when CHPL_REGEXP is 're2'
      utf8-decoder     bundled into the Chapel runtime to decode UTF-8 strings
 
-   For packages that are only used based on a CHPL_* setting, note that
-   this setting may either be explicitly or implicitly set. Also note
-   that some packages are speculatively built, and will only be used if
-   they were built successfully. To check your CHPL_* settings, run
+   For packages that are used based on a CHPL_* setting, note that this
+   setting may either be explicitly or implicitly set. Additionally,
+   some packages are only used if a speculative build was successful.
+   See http://chapel.cray.com/docs/latest/usingchapel/chplenv.html to
+   see which packages are used by default and which ones are built
+   speculatively. You can also check your CHPL_* settings by running
    $CHPL_HOME/util/printchplenv after Chapel has been built

--- a/LICENSE
+++ b/LICENSE
@@ -58,24 +58,9 @@ The Chapel implementation is composed of two categories of code:
    licensing terms, refer to highlight/README.md, third-party/README, and the
    README and license files in the subdirectories listed above.
 
-   Note that most of these packages are not used by Chapel unless specifically
-   requested.  There are some exceptions to this rule, as of the 1.10 release:
-
-      - Outside of quickstart mode, we attempt to build and include re2 and gmp,
-        leaving their respective environment variables set if building them
-        completed successfully.  This can be disabled by setting the relevant
-        environment variable to 'none'.  Details about quickstart mode can be
-        found in the top-level README.rst.
-
-      - For all platforms, with the exception of 'cygwin' and 'knc', our default
-        tasking layer is 'qthreads', with hwloc included.  On the other
-        platforms our default is 'fifo'.  Unless the relevant environment
-        variable was set for hwloc, settings CHPL_TASKS to a tasking layer other
-        than 'qthreads' will turn off the use of hwloc.  For a description of
-        other tasking options, please see tasks.rst
-
-   The following table summarizes the conditions under which each package is
-   used (see chplenv.rst for details on CHPL_* settings):
+   Note that not all of these packages are used by Chapel by default. The
+   following table summarizes the conditions under which each package is used
+   (see chplenv.rst for details on CHPL_* settings):
 
    directory/package  when used
    -----------------  ----------------------------------------------------
@@ -86,18 +71,17 @@ The Chapel implementation is composed of two categories of code:
    third-party/
      chpl-venv        only used when running 'chpldoc' or 'start_test'
      gasnet           only used when CHPL_COMM is 'gasnet'
-     gmp              where possible, used by default or when CHPL_GMP is 'gmp'
-     hwloc            used by default on most platforms, or when CHPL_HWLOC is
-                      'hwloc'
+     gmp              only used when CHPL_GMP is 'gmp'
+     hwloc            only used when CHPL_HWLOC is 'hwloc'
      jemalloc         only used when CHPL_MEM is 'jemalloc'
      llvm             only used when CHPL_LLVM is 'llvm'
      massivethreads   only used when CHPL_TASKS is 'massivethreads'
-     qthread          used by default on most platforms, or when CHPL_TASKS is
-                      'qthreads'
-     re2              where possible, used by default or when CHPL_REGEXP is
-                      're2'
+     qthread          only used when CHPL_TASKS is 'qthreads'
+     re2              only used when CHPL_REGEXP is 're2'
      utf8-decoder     bundled into the Chapel runtime to decode UTF-8 strings
 
-   For packages that are only used based on a CHPL_* setting, note
-   that this setting may either be explicitly or implicitly set.  To
-   verify your settings, run $CHPL_HOME/util/printchplenv.
+   For packages that are only used based on a CHPL_* setting, note that
+   this setting may either be explicitly or implicitly set. Also note
+   that some packages are speculatively built, and will only be used if
+   they were built successfully. To check your CHPL_* settings, run
+   $CHPL_HOME/util/printchplenv after Chapel has been built


### PR DESCRIPTION
The LICENSE tries to express when certain third-party packages are used.
Previously it tried to give a sense of when we default to using certain
packages (i.e. it said that we used qthreads most places except on cygwin/knc.)
However, this information is out of date for this release and there are new
third-party packages for this release.

Instead of updating it and trying to maintain yet another list of when certain
third-party packages are used I updated the file to basically say check
[chplenv.rst] (http://chapel.cray.com/docs/latest/usingchapel/chplenv.html) or the output of printchplenv to determine which packages are being used
