### PR TITLE
Attempt to enable Jama module documentation

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -99,6 +99,7 @@ PACKAGES_TO_DOCUMENT = \
 	packages/HDFS.chpl \
 	packages/HDFSiterator.chpl \
 	packages/LAPACK.chpl \
+	packages/LinearAlgebraJama.chpl \
 	packages/Norm.chpl \
 	packages/RecordParser.chpl \
 	packages/Search.chpl \


### PR DESCRIPTION
Unfortunately, this doesn't seem to work as it chokes on special
symbols in the generated .rst...