### PR TITLE
Correct line number with domain queries.

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1405,8 +1405,10 @@ static void fixup_array_formals(FnSymbol* fn) {
         // "arg.eltType", so we use the instantiated element type.
         if (queryEltType) {
           for_vector(SymExpr, se, symExprs) {
-            if (se->var == queryEltType->sym)
+            if (se->var == queryEltType->sym) {
+              SET_LINENO(se);
               se->replace(new CallExpr(".", arg, new_CStringSymbol("eltType")));
+            }
           }
         } else if (!noEltType) {
           // The element type is supplied, but it is null.
@@ -1429,8 +1431,10 @@ static void fixup_array_formals(FnSymbol* fn) {
           // Array type is built using a domain.
           // If we match the domain symbol, replace it with arg._dom.
           for_vector(SymExpr, se, symExprs) {
-            if (se->var == queryDomain->sym)
+            if (se->var == queryDomain->sym) {
+              SET_LINENO(se);
               se->replace(new CallExpr(".", arg, new_CStringSymbol("_dom")));
+            }
           }
         } else if (!noDomain) {
           // The domain argument is supplied but NULL.

--- a/test/domains/bradc/modDomQuery.future
+++ b/test/domains/bradc/modDomQuery.future
@@ -1,1 +1,0 @@
-bug: The return value of a non-var domain accessor should be treated as const (read-only).


### PR DESCRIPTION
We used to generate an incorrect line number in this case:

    proc foo(X: [?D]?T) {
      ... D ...
    }

The SymExprs for the uses of D within foo() referred to
the line number with "proc foo" instead of the line number
where those uses actually occurred.

Fixed by adding SET_LINENO() appropriately.

I verified that I also fixed the line number for the uses of T
within foo(). I have not added a test for this because
I do not know how - contributions are welcome here.

I am de-futurizing this test, which produces the expected outcome now:

  test/domains/bradc/modDomQuery.chpl

It was really fixed in #3548. The error message had an incorrect
line number there, which is fixed in this change.

Thank you Lydia for bringing this to my attention.