### PR TITLE
Bug Fix : cast from string to real and int does not ignore whitespace

### DIFF
--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -57,6 +57,7 @@
   m(COMM_PER_LOC_INFO,    "comm layer per-locale information",        false), \
   m(COMM_PRV_OBJ_ARRAY,   "comm layer private objects array",         false), \
   m(COMM_PRV_BCAST_DATA,  "comm layer private broadcast data",        false), \
+  m(C_STR_2_NUM_BUF,      "c_string to number conversion buffer",     true ), \
   m(GLOM_STRINGS_DATA,    "glom strings data",                        true ), \
   m(STR_COPY_DATA,        "string copy data",                         true ), \
   m(STR_COPY_REMOTE,      "remote string copy",                       true ), \

--- a/test/users/ferguson/cast_to_int_ignore_whitespace.bad
+++ b/test/users/ferguson/cast_to_int_ignore_whitespace.bad
@@ -1,1 +1,0 @@
-cast_to_int_ignore_whitespace.chpl:3: error: Unexpected character when converting from string to int(64): ' '

--- a/test/users/ferguson/cast_to_int_ignore_whitespace.future
+++ b/test/users/ferguson/cast_to_int_ignore_whitespace.future
@@ -1,1 +1,0 @@
-bug: cast from string to int does not ignore whitespace


### PR DESCRIPTION
- Modified the runtime code to take into account where whitespace are
  present after the number (int and float)
- Code also takes care of the case when some characters follow the number
  and throws an error correspondinly e.g "10 some_number" -> Gives error
- Also includes the case with the size of the int is not default 64,
  which has not been covered in the test case
  test/users/ferguson/cast_to_int_ignore_whitespace.chpl
  Since, different functions are used for bigint(int_64) and normal
  casted int's , we need to handle the two cases seperately.
- Code also takes care of float both 32 and 64
- Removing the .bad and .future file for string to int cast bug