### PR TITLE
Makes checkSufficientBitsAndAdvanceOthers private

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -940,6 +940,7 @@ module Random {
       }
     }
 
+    private
     proc checkSufficientBitsAndAdvanceOthers(type resultType, ref states) {
       // Note - this error could be eliminated if we used
       // the same strategy as bounded_rand_vary_inc and


### PR DESCRIPTION
This routine is not meant to be user-facing.

Passed test/modules/standard/Random