### PR TITLE
Add a pragma no-doc on sizeof in SysCTypes

### DIFF
--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -210,6 +210,7 @@ def get_sys_c_types(docs=False):
     #
     sys_c_types.append("""
 {
+  pragma "no doc"
   pragma "no prototype"
   extern proc sizeof(type t): size_t;
 """)


### PR DESCRIPTION
Since this function is inside of a block it shouldn't
be exported (or picked up by chpldoc) anyway.

Verified sizeof no longer appears in documentation.
Verified that make/make check work on linux, mac.