### PR TITLE
NOTEST the coforall-mod future

### DIFF
--- a/test/types/records/ferguson/parallel/coforall-mod/NOTEST
+++ b/test/types/records/ferguson/parallel/coforall-mod/NOTEST
@@ -1,0 +1,3 @@
+This test was sporadically passing.
+It probably still represents a compiler bug, but the noise
+it was adding to our testing system was not worthwhile.


### PR DESCRIPTION
This future was going between passing and failing and causing
a lot of test system noise. So I just turned off testing
for it for now.