### PR TITLE
Include arg section for buffer in subprocess.wait

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -676,6 +676,8 @@ module Spawn {
 
     :arg error: optional argument to capture any error encountered
                 when waiting for the child process.
+    :arg buffer: if `true`, buffer input and output pipes (see above).
+
    */
   proc subprocess.wait(out error:syserr, buffer=true) {
 


### PR DESCRIPTION
Documentation already described this argument;
here we just add it to the Arguments: summary.

Trivial and not reviewed.