### PR TITLE
Document ~ in format strings

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -880,15 +880,15 @@ Going through each section for text conversions:
    (a space) leaves a blank before a positive number
    (in order to help line up with negative numbers)
   ``-``
-   left-justify the converted value instead of right-justifying
+   left-justify the converted value instead of right-justifying.
+   Note, if both ``0`` and ``-`` are given, the effect is as if only ``-``
+   were given.
   ``~``
    when reading a record or class instance, skip over fields in the input not
    present in the Chapel type. This flag currently only works in combination
    with the JSON format.  This flag allows a Chapel program to describe only the
    relevant fields in a record when the input might contain many more fields.
   
-  Note, if both ``0`` and ``-`` are given, the effect is as if only ``-`` were
-  given.
 
 [optional field width]
    When printing numeric or string values, the field width specifies the number

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -881,6 +881,11 @@ Going through each section for text conversions:
    (in order to help line up with negative numbers)
   ``-``
    left-justify the converted value instead of right-justifying
+  ``~``
+   when reading a record or class instance, skip over fields in the input not
+   present in the Chapel type. This flag currently only works in combination
+   with the JSON format.  This flag allows a Chapel program to describe only the
+   relevant fields in a record when the input might contain many more fields.
   
   Note, if both ``0`` and ``-`` are given, the effect is as if only ``-`` were
   given.


### PR DESCRIPTION
Added it only to the detailed specification section.
Noted that it only does anything useful for JSON format at the moment.

Reviewed by @lydia-duncan - thanks!