### PR TITLE
Don't under-sleep.

### DIFF
--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -737,10 +737,27 @@ void chpl_task_yield(void) {
 
 
 void chpl_task_sleep(double secs) {
-  struct timespec delay;
-  delay.tv_sec = (time_t)(secs);
-  delay.tv_nsec = (long)(1e9*(secs - floor(secs)));
-  nanosleep(&delay, NULL);
+  struct timeval deadline;
+  struct timeval now;
+
+  //
+  // Figure out when this task can proceed again, and until then, keep
+  // yielding.
+  //
+  gettimeofday(&deadline, NULL);
+  deadline.tv_usec += (suseconds_t) ((secs - trunc(secs)) * 1.0e6);
+  if (deadline.tv_usec > 1000000) {
+    deadline.tv_sec++;
+    deadline.tv_usec -= 1000000;
+  }
+  deadline.tv_sec += (time_t) trunc(secs);
+
+  do {
+    chpl_task_yield();
+    gettimeofday(&now, NULL);
+  } while (now.tv_sec < deadline.tv_sec
+           || (now.tv_sec == deadline.tv_sec
+               && now.tv_usec < deadline.tv_usec));
 }
 
 chpl_bool chpl_task_getSerial(void) {

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -914,10 +914,27 @@ chpl_taskID_t chpl_task_getId(void)
 void chpl_task_sleep(double secs)
 {
     if (qthread_shep() == NO_SHEPHERD) {
-        struct timespec delay;
-        delay.tv_sec = (time_t)(secs);
-        delay.tv_nsec = (long)(1e9*(secs - floor(secs)));
-        nanosleep(&delay, NULL);
+        struct timeval deadline;
+        struct timeval now;
+
+        //
+        // Figure out when this task can proceed again, and until then, keep
+        // yielding.
+        //
+        gettimeofday(&deadline, NULL);
+        deadline.tv_usec += (suseconds_t) ((secs - trunc(secs)) * 1.0e6);
+        if (deadline.tv_usec > 1000000) {
+            deadline.tv_sec++;
+            deadline.tv_usec -= 1000000;
+        }
+        deadline.tv_sec += (time_t) trunc(secs);
+
+        do {
+            chpl_task_yield();
+            gettimeofday(&now, NULL);
+        } while (now.tv_sec < deadline.tv_sec
+                 || (now.tv_sec == deadline.tv_sec
+                     && now.tv_usec < deadline.tv_usec));
     } else {
         qtimer_t t = qtimer_create();
         qtimer_start(t);


### PR DESCRIPTION
The qthreads and fifo versions of chpl_task_sleep() could sleep the
calling task for less than the desired amount of time, because they
were implemented in terms of nanosleep(2), which can return early
if a signal arrives.  Qthreads could only do this in a task not bound
to a shepherd, meaning early during runtime initialization, so that
was a fairly minor failing.  But fifo could do it any time.  Adjust both
of these so that they sleep the calling task at least as long as
requested, yielding while doing so.