### PR TITLE
Move submodule documentation to top of file

### DIFF
--- a/compiler/AST/AstPrintDocs.cpp
+++ b/compiler/AST/AstPrintDocs.cpp
@@ -35,8 +35,7 @@ AstPrintDocs::AstPrintDocs(std::string moduleName, std::string path) :
   file(NULL),
   tabs(0),
   moduleName(moduleName),
-  pathWithoutPostfix(""),
-  tableOfContentsNeeded(false)
+  pathWithoutPostfix("")
 {
   pathWithoutPostfix = path + "/" + moduleName;
 
@@ -127,10 +126,10 @@ bool AstPrintDocs::enterModSym(ModuleSymbol* node) {
     node->accept(docsVisitor);
     delete docsVisitor;
 
-    this->tableOfContentsNeeded = true;
     return false;
   }
 
+  // Then print our documentation
   node->printDocs(this->file, this->tabs);
 
   if (fDocsTextOnly) {
@@ -151,10 +150,6 @@ void AstPrintDocs::exitModSym(ModuleSymbol* node) {
   if (fDocsTextOnly) {
     this->tabs--;
   }
-
-  // If we had submodules, be sure to link to them
-  if (tableOfContentsNeeded)
-    node->printTableOfContents(this->file);
 }
 
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2691,6 +2691,11 @@ void ModuleSymbol::printDocs(std::ostream *file, unsigned int tabs) {
     *file << std::endl;
   }
 
+  // If we had submodules, be sure to link to them
+  if (hasTopLevelModule()) {
+    this->printTableOfContents(file);
+  }
+
   if (this->doc != NULL) {
     // Only print tabs for text only mode. The .rst prefers not to have the
     // tabs for module level comments and leading whitespace removed.
@@ -2721,10 +2726,10 @@ void ModuleSymbol::printTableOfContents(std::ostream *file) {
     this->printTabs(file, tabs);
     *file << ":glob:" << std::endl << std::endl;
     this->printTabs(file, tabs);
-    *file << name << "/*" << std::endl;
+    *file << name << "/*" << std::endl << std::endl;
   } else {
     *file << "Submodules for this module are located in the " << name;
-    *file << "/ directory" << std::endl;
+    *file << "/ directory" << std::endl << std::endl;
   }
 }
 
@@ -2853,6 +2858,20 @@ Vec<ModuleSymbol*> ModuleSymbol::getTopLevelModules() {
   }
 
   return mods;
+}
+
+// Intended for documentation purposes only, please don't use otherwise.
+bool ModuleSymbol::hasTopLevelModule() {
+  for_alist(expr, block->body) {
+    if (DefExpr* def = toDefExpr(expr)) {
+      if (ModuleSymbol* mod = toModuleSymbol(def->sym)) {
+        if (mod->defPoint->parentExpr == block && !mod->noDocGen()) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }
 
 void ModuleSymbol::replaceChild(BaseAST* old_ast, BaseAST* new_ast) {

--- a/compiler/include/AstPrintDocs.h
+++ b/compiler/include/AstPrintDocs.h
@@ -55,7 +55,6 @@ private:
   unsigned int    tabs;
   std::string     moduleName;
   std::string     pathWithoutPostfix;
-  bool            tableOfContentsNeeded;
 };
 
 #endif

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -495,6 +495,7 @@ public:
 
 private:
   void                 getTopLevelConfigOrVariables(Vec<VarSymbol *> *contain, Expr *expr, bool config);
+  bool                 hasTopLevelModule();
 };
 
 /******************************** | *********************************

--- a/test/chpldoc/basics/fullyCommented.doc.good
+++ b/test/chpldoc/basics/fullyCommented.doc.good
@@ -1,4 +1,6 @@
 fullyCommented.doc
+Submodules for this module are located in the fullyCommented.doc/ directory
+
    proc method1()
       Comment for method1 
 
@@ -11,7 +13,6 @@ fullyCommented.doc
    proc argAndBody(val: int)
       Comment for method with argument and body 
 
-Submodules for this module are located in the fullyCommented.doc/ directory
 Other
    proc inside
       Comment for method inside module 

--- a/test/chpldoc/basics/longerComments.doc.good
+++ b/test/chpldoc/basics/longerComments.doc.good
@@ -1,4 +1,6 @@
 longerComments.doc
+Submodules for this module are located in the longerComments.doc/ directory
+
    proc method1()
       This is a comment for method1, which lies
       outside of a defined module 
@@ -17,7 +19,6 @@ longerComments.doc
       argument and body which lies outside of a
       defined module 
 
-Submodules for this module are located in the longerComments.doc/ directory
 Other
    proc inside
       This is a comment for a method inside of

--- a/test/chpldoc/basics/sparselyCommented.doc.good
+++ b/test/chpldoc/basics/sparselyCommented.doc.good
@@ -1,4 +1,6 @@
 sparselyCommented.doc
+Submodules for this module are located in the sparselyCommented.doc/ directory
+
    proc method1()
       Comment for method1 
 
@@ -15,7 +17,6 @@ sparselyCommented.doc
       Comment for method with argument and body 
 
    proc argAndBodyCommentless(val: int)
-Submodules for this module are located in the sparselyCommented.doc/ directory
 Other
    proc inside()
       Comment for method inside module 

--- a/test/chpldoc/classes/basic.doc.good
+++ b/test/chpldoc/classes/basic.doc.good
@@ -1,10 +1,13 @@
 basic
+Submodules for this module are located in the basic/ directory
+
    This is the module that Lydia built 
    proc inner()
       This is the proc that lies in the module that Lydia built 
 
-Submodules for this module are located in the basic/ directory
 sadAndAlone
+Submodules for this module are located in the sadAndAlone/ directory
+
    This is the module all sad and alone, listed behind the proc
    that lies in the module that Lydia built 
    Class: naryATone
@@ -12,7 +15,6 @@ sadAndAlone
       sad and alone, listed behind the proc that lies in the module
       that Lydia built 
 
-Submodules for this module are located in the sadAndAlone/ directory
 classesAreGrown
    This is the module whose classes are grown, sister of the
    class with nary a tone, declared in the module all sad and

--- a/test/chpldoc/compflags/folder/save-sphinx/deepNestModules.doc.good
+++ b/test/chpldoc/compflags/folder/save-sphinx/deepNestModules.doc.good
@@ -4,8 +4,6 @@
 
 Foo
 ===
-.. function:: proc gob()
-
 **Submodules**
 
 .. toctree::
@@ -13,6 +11,9 @@ Foo
    :glob:
 
    Foo/*
+
+.. function:: proc gob()
+
 .. default-domain:: chpl
 
 .. module:: Bar

--- a/test/chpldoc/intents.doc.good
+++ b/test/chpldoc/intents.doc.good
@@ -1,4 +1,6 @@
 intents.doc
+Submodules for this module are located in the intents.doc/ directory
+
    proc one(in val)
       This function has an argument with the in intent 
 
@@ -44,7 +46,6 @@ intents.doc
    proc fourteen()
       This function has a return intent (other than ref) and a body 
 
-Submodules for this module are located in the intents.doc/ directory
 Inner
    proc one(in val)
       This function has an argument with the in intent 

--- a/test/chpldoc/linkage-spec/exportTest.doc.good
+++ b/test/chpldoc/linkage-spec/exportTest.doc.good
@@ -1,4 +1,6 @@
 exportTest.doc
+Submodules for this module are located in the exportTest.doc/ directory
+
    export proc method1()
       Comment for method1 
 
@@ -36,7 +38,6 @@ exportTest.doc
       This method has a return type, an argument, and a function body 
 
    export proc allThreeCommentless2(val: int): int
-Submodules for this module are located in the exportTest.doc/ directory
 Other
    export proc inside()
       Comment for method inside module 

--- a/test/chpldoc/linkage-spec/externTest.doc.good
+++ b/test/chpldoc/linkage-spec/externTest.doc.good
@@ -1,4 +1,6 @@
 externTest.doc
+Submodules for this module are located in the externTest.doc/ directory
+
    proc method1()
       Comment for method1 
 
@@ -20,7 +22,6 @@ externTest.doc
       This method has a return type and an argument 
 
    proc hasReturnTypeAndArgCommentless(val: int): int
-Submodules for this module are located in the externTest.doc/ directory
 Other
    proc inside
       Comment for method inside module 

--- a/test/chpldoc/linkage-spec/inlineTest.doc.good
+++ b/test/chpldoc/linkage-spec/inlineTest.doc.good
@@ -1,4 +1,6 @@
 inlineTest.doc
+Submodules for this module are located in the inlineTest.doc/ directory
+
    proc method1()
       Comment for method1 
 
@@ -36,7 +38,6 @@ inlineTest.doc
       This method has a return type, an argument, and a function body 
 
    proc allThreeCommentless(val: int): int
-Submodules for this module are located in the inlineTest.doc/ directory
 Other
    proc inside
       Comment for inline method inside module 

--- a/test/chpldoc/module/nestModules.doc.good
+++ b/test/chpldoc/module/nestModules.doc.good
@@ -1,8 +1,10 @@
 outer
-   This is the outer module's comment 
 Submodules for this module are located in the outer/ directory
+
+   This is the outer module's comment 
 inner
-   This is the inner module's comment 
 Submodules for this module are located in the inner/ directory
+
+   This is the inner module's comment 
 innermost
    This is the innermost module's comment 

--- a/test/chpldoc/module/nestWithFns.doc.good
+++ b/test/chpldoc/module/nestWithFns.doc.good
@@ -1,10 +1,11 @@
 OuterMod
+Submodules for this module are located in the OuterMod/ directory
+
    This module has a comment, but uncommented first method 
    proc outerFn()
    proc outerCommented()
       The second method is commented 
 
-Submodules for this module are located in the OuterMod/ directory
 Inner
    proc innerFn()
       This module has no comment, but it's inner function does! 

--- a/test/chpldoc/module/sameName.doc.good
+++ b/test/chpldoc/module/sameName.doc.good
@@ -1,8 +1,9 @@
 sameName.doc
+Submodules for this module are located in the sameName.doc/ directory
+
    proc outerFn()
       This function is outside the defined module 
 
-Submodules for this module are located in the sameName.doc/ directory
 sameName
    This module has the same name as its file but doesn't
    contain all the code within the file 

--- a/test/chpldoc/module/surroundingModule.doc.good
+++ b/test/chpldoc/module/surroundingModule.doc.good
@@ -1,11 +1,12 @@
 surroundingModule.doc
+Submodules for this module are located in the surroundingModule.doc/ directory
+
    proc before()
       This comment and its proc lies before the defined module 
 
    proc after()
       This comment and its proc lies after the defined module 
 
-Submodules for this module are located in the surroundingModule.doc/ directory
 Middle
    proc inside()
       This comment and its proc lies inside the defined module 

--- a/test/chpldoc/types/returns/basic.doc.good
+++ b/test/chpldoc/types/returns/basic.doc.good
@@ -1,4 +1,6 @@
 basic.doc
+Submodules for this module are located in the basic.doc/ directory
+
    proc method1(): string
       Comment for method1 
 
@@ -28,7 +30,6 @@ basic.doc
       This proc has an implicit return type and a return statement 
 
    proc returnCommentless()
-Submodules for this module are located in the basic.doc/ directory
 Other
    proc inside(): int
       Comment for method inside module 

--- a/test/chpldoc/variableArguments.doc.good
+++ b/test/chpldoc/variableArguments.doc.good
@@ -1,4 +1,6 @@
 variableArguments.doc
+Submodules for this module are located in the variableArguments.doc/ directory
+
    proc variable(x ...)
       This method has a variable number of arguments 
 
@@ -12,7 +14,6 @@ variableArguments.doc
       be specified by the caller 
 
    proc specifyMeCommentless(q ...?p)
-Submodules for this module are located in the variableArguments.doc/ directory
 Other
    proc variable(x ...)
       This method has a variable number of arguments 

--- a/test/release/examples/primers/chpldoc.doc.good
+++ b/test/release/examples/primers/chpldoc.doc.good
@@ -1,4 +1,6 @@
 chpldoc.doc
+Submodules for this module are located in the chpldoc.doc/ directory
+
    proc commented(val: int): string
       
       Multiline comments found before a function are associated with that function
@@ -9,7 +11,6 @@ chpldoc.doc
       The function can be a stub and still output its comment
 
    proc uncommented()
-Submodules for this module are located in the chpldoc.doc/ directory
 Defined
    
    If the source code defines a module, it can also have a comment associated


### PR DESCRIPTION
Brad pointed out it was nicer to have the submodules listed at the top of the
file if they exist rather than have them listed at the bottom of the file.  This
means an extra pass through the module's contents to look for submodules, but
since we only need to know of one, we don't have to pay this entire cost all
the time.  Move the table of contents generation to occur between the module
name output and that of its documentation comment, to avoid the submodules
getting lost in the middle.

Ran over all the chpldoc tests and verified that the documentation output for
the Random module was pretty.