### PR TITLE
Add test filenames to users guide code samples

### DIFF
--- a/doc/sphinx/source/users-guide/base/.gitignore
+++ b/doc/sphinx/source/users-guide/base/.gitignore
@@ -1,0 +1,1 @@
+examples

--- a/doc/sphinx/source/users-guide/base/simpleConsoleOutput.rst
+++ b/doc/sphinx/source/users-guide/base/simpleConsoleOutput.rst
@@ -13,7 +13,8 @@ arguments to the console, one after the other without spaces, followed
 by a newline.  Thus, the following statement will print a greeting to
 the console:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/hello.chpl
+.. literalinclude:: examples/users-guide/base/hello.chpl
+  :caption:
   :language: chapel
   :lines: 1-1
 
@@ -38,7 +39,7 @@ the program using::
 
 The program should then print the greeting to your console as follows:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/hello.good
+.. literalinclude:: examples/users-guide/base/hello.good
   :language: text
 
 And with that, you've executed your first Chapel program!

--- a/doc/sphinx/source/users-guide/base/variableDeclarations.rst
+++ b/doc/sphinx/source/users-guide/base/variableDeclarations.rst
@@ -7,19 +7,20 @@ Chapel variables are declared using the **var** keyword.  As an
 example, the following statement declares a variable named *x* of
 integer type (``int``) and initializes it to 42:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/intVarTypeInit.chpl
+.. literalinclude:: examples/users-guide/base/intVarTypeInit.chpl
+  :caption:
   :language: chapel
   :lines: 1
 
 We can verify its value by printing it out using ``writeln()``:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/intVarTypeInit.chpl
+.. literalinclude:: examples/users-guide/base/intVarTypeInit.chpl
   :language: chapel
   :lines: 2
 
 Compiling and running this program results in:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/intVarTypeInit.good
+.. literalinclude:: examples/users-guide/base/intVarTypeInit.good
   :language: text
 
 As we will see in the following sections, a variable declaration may
@@ -34,13 +35,14 @@ compiler will initialize the variable to a default value based on its
 type.  For example, the default value for integers is zero, so if we
 had instead declared *x* as:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/intVarDefaultInit.chpl
+.. literalinclude:: examples/users-guide/base/intVarDefaultInit.chpl
+  :caption:
   :language: chapel
   :lines: 1-2
 
 We would get:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/intVarDefaultInit.good
+.. literalinclude:: examples/users-guide/base/intVarDefaultInit.good
   :language: text
 
 
@@ -52,7 +54,8 @@ type specification.  In this case, the compiler will infer the
 variable's type to be the same as its initialization expression's.
 Thus, we could have written the original program simply as:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/intVarInferType.chpl
+.. literalinclude:: examples/users-guide/base/intVarInferType.chpl
+  :caption: 
   :language: chapel
   :lines: 1-2
 
@@ -60,7 +63,7 @@ In this case, the compiler knows that 42 is a value of integer type
 (``int``), therefore it infers that the type of *x* is also ``int``.
 Running this program, once again produces:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/intVarInferType.good
+.. literalinclude:: examples/users-guide/base/intVarInferType.good
   :language: text
 
 In practice, this style of coding is often used for brevity, resulting
@@ -78,7 +81,8 @@ The **var** keyword can also be used to create more than one variable
 at a time.  For example, the following statement will create three
 integer variables, *a*, *b*, and *c*, all initialized to 42:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/compoundVarDecls.chpl
+.. literalinclude:: examples/users-guide/base/compoundVarDecls.chpl
+  :caption: 
   :language: chapel
   :lines: 1
 
@@ -86,7 +90,7 @@ As before, initialization and type information may be omitted.  For
 example, the following statement creates three integer variables, *i*,
 *j*, and *k*, all default-initialized to zero:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/compoundVarDecls.chpl
+.. literalinclude:: examples/users-guide/base/compoundVarDecls.chpl
   :language: chapel
   :lines: 2
 
@@ -94,7 +98,7 @@ Similarly, the following declaration creates three variables, *x*,
 *y*, and *z*, all inferred to be of type ``int`` due to being
 initialized with the integer 42:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/compoundVarDecls.chpl
+.. literalinclude:: examples/users-guide/base/compoundVarDecls.chpl
   :language: chapel
   :lines: 3
 
@@ -106,7 +110,8 @@ default-initialized to zero; *s* and *t* to be string variables
 initialized to "hi"; and *x*, *y*, and *z* to be inferred integer
 variables initialized to 42:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/base/compoundVarDecls2.chpl
+.. literalinclude:: examples/users-guide/base/compoundVarDecls2.chpl
+  :caption:
   :language: chapel
   :lines: 1-4
 

--- a/doc/sphinx/source/users-guide/locality/.gitignore
+++ b/doc/sphinx/source/users-guide/locality/.gitignore
@@ -1,0 +1,1 @@
+examples

--- a/doc/sphinx/source/users-guide/locality/localeTypeAndVariables.rst
+++ b/doc/sphinx/source/users-guide/locality/localeTypeAndVariables.rst
@@ -37,12 +37,13 @@ The variable *numLocales* is a built-in integer constant indicating
 the number of locales on which the program is running.  For example,
 when run on four locales, the following program:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/numLocalesVar.chpl
+.. literalinclude:: examples/users-guide/locality/numLocalesVar.chpl
+  :caption:
   :language: chapel
 
 would generate:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/numLocalesVar.good
+.. literalinclude:: examples/users-guide/locality/numLocalesVar.good
   :language: text
 
 
@@ -60,12 +61,13 @@ array.  This is demonstrated by the following program which first
 prints the *LocaleSpace* domain and then iterates over it, showing
 that the ID of each value in *Locales* corresponds to its index:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/localesDomArr.chpl
+.. literalinclude:: examples/users-guide/locality/localesDomArr.chpl
+  :caption:
   :language: chapel
 
 Running on four locales, its output is:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/localesDomArr.good
+.. literalinclude:: examples/users-guide/locality/localesDomArr.good
   :language: text
 
 
@@ -82,10 +84,11 @@ As an example, the following program demonstrates that Chapel programs
 begin their execution on locale 0:
 
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/here-id.chpl
+.. literalinclude:: examples/users-guide/locality/here-id.chpl
+  :caption:
   :language: chapel
 
 Running it on any number of locales generates:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/here-id.good
+.. literalinclude:: examples/users-guide/locality/here-id.good
   :language: text

--- a/doc/sphinx/source/users-guide/locality/onClauses.rst
+++ b/doc/sphinx/source/users-guide/locality/onClauses.rst
@@ -22,23 +22,25 @@ of the Locales on which the program is running, conceptually migrating
 the main task to that locale, where it writes out a message indicating
 the locale's ID:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/onClause.chpl
+.. literalinclude:: examples/users-guide/locality/onClause.chpl
+  :caption:
   :language: chapel
 
 Running this program on four locales generates:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/onClause.good
+.. literalinclude:: examples/users-guide/locality/onClause.good
   :language: text
 
 Here's a minor change to this example which demonstrates that the
 original task starts and ends on locale #0:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/onClausePlusOrig.chpl
+.. literalinclude:: examples/users-guide/locality/onClausePlusOrig.chpl
+  :caption:
   :language: chapel
 
 When run on three locales, this program generates:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/onClausePlusOrig.good
+.. literalinclude:: examples/users-guide/locality/onClausePlusOrig.good
   :language: text
   :lines: 1-12
 
@@ -64,14 +66,15 @@ simple example, the following program uses a coforall loop to create a
 task per locale in combination with an on-clause to execute each task
 on its corresponding locale:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/coforallPlusOn.chpl
+.. literalinclude:: examples/users-guide/locality/coforallPlusOn.chpl
+  :caption:
   :language: chapel
 
 In effect, this creates an SPMD (Single Program, Multiple Data) style
 of parallelism.  When running on four locales, the output will be a
 nondeterministic permutation of the following four lines:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/coforallPlusOn.good
+.. literalinclude:: examples/users-guide/locality/coforallPlusOn.good
   :language: text
 
 
@@ -88,14 +91,15 @@ the variable or expression is stored.  These are referred to as
 As a simple example of a data-driven on-clause, the following program
 moves its task to the locale on which *x* is stored:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/dataDrivenOnClause-trivial.chpl
+.. literalinclude:: examples/users-guide/locality/dataDrivenOnClause-trivial.chpl
+  :caption:
   :language: chapel
 
 However, this program is trivial in that *x* is stored on locale 0,
 so the on-clause is essentially degenerate and doesn't move execution
 anywhere:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/locality/dataDrivenOnClause-trivial.good
+.. literalinclude:: examples/users-guide/locality/dataDrivenOnClause-trivial.good
   :language: text
 
 The next section will explain how variables can be declared on other

--- a/doc/sphinx/source/users-guide/taskpar/.gitignore
+++ b/doc/sphinx/source/users-guide/taskpar/.gitignore
@@ -1,0 +1,1 @@
+examples

--- a/doc/sphinx/source/users-guide/taskpar/theBeginStatement.rst
+++ b/doc/sphinx/source/users-guide/taskpar/theBeginStatement.rst
@@ -12,7 +12,8 @@ As an example, the following program creates a task to execute the
 call to ``writeln()`` in the first statement while the original task
 goes on to execute the second call to ``writeln()``.
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/taskpar/begin.chpl
+.. literalinclude:: examples/users-guide/taskpar/begin.chpl
+  :caption:
   :language: chapel
 
 Because these two tasks are not synchronized in any way, the order in
@@ -20,11 +21,11 @@ which the messages appear on the console is not guaranteed.  As a
 result, when running this program, the console could display the
 messages either like this:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/taskpar/begin-alt.good
+.. literalinclude:: examples/users-guide/taskpar/begin-alt.good
 
 or this:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/taskpar/begin.good
+.. literalinclude:: examples/users-guide/taskpar/begin.good
 
 Happily, the ``writeln()`` routine is written in a parallel-safe
 manner, so there is no danger of the characters from the two strings
@@ -42,7 +43,8 @@ prints some messages using a compound statement and a second that
 prints other messages using a function call, while the original task
 prints messages of its own.
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/taskpar/beginBiggerStatements.chpl
+.. literalinclude:: examples/users-guide/taskpar/beginBiggerStatements.chpl
+  :caption:
   :language: chapel
 
 
@@ -54,7 +56,8 @@ may itself create other tasks.  For example, the following routine
 uses recursion and **begin** statements to create a distinct task to
 process each node in a binary tree:
 
-.. literalinclude:: ../../../../../test/release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl
+.. literalinclude:: examples/users-guide/taskpar/walkTreeUsingBegins.chpl
+  :caption:
   :language: chapel
   :lines: 24-31
 

--- a/doc/sphinx/symlinks.py
+++ b/doc/sphinx/symlinks.py
@@ -56,6 +56,18 @@ def main():
     chpldocmanpage = os.path.join(chpl_home, 'man', 'chpldoc.rst')
     os.symlink(chpldocmanpage, 'source/tools/chpldoc/man.rst')
 
+    chpldocexamples = os.path.join(chpl_home, 'test', 'release', 'examples')
+    os.symlink(chpldocexamples, 'source/users-guide/base/examples')
+
+    chpldocexamples = os.path.join(chpl_home, 'test', 'release', 'examples')
+    os.symlink(chpldocexamples, 'source/users-guide/taskpar/examples')
+
+#    chpldocexamples = os.path.join(chpl_home, 'test', 'release', 'examples')
+#    os.symlink(chpldocexamples, 'source/users-guide/datapar/examples')
+
+    chpldocexamples = os.path.join(chpl_home, 'test', 'release', 'examples')
+    os.symlink(chpldocexamples, 'source/users-guide/locality/examples')
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This commit uses the :caption: option and some symbolic link
magic to make the code block examples in the user's guide
point to the file from which it originated.

One hitch is that if I use the same .chpl file twice and
use the :caption: option for both, I get an rst-level
error.  One workaround is to supply a non-default caption
for the second/subsequent cases.  Instead, here, I've
decided to not label continuations and hope that that's
clear from context.  I'm open to input / other ideas here,
though.

The formatting of these captions is somewhat funky on my
home Mac -- there's a straggling paragraph marker which
seems to be doing what the little chain link icon normally
does on our docs pages.  I'm hoping this is a personal
problem, but not optimistic.