### PR TITLE
Updates for online Chapel docs (modules, mainly)

### DIFF
--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -26,9 +26,15 @@ Chapel Documentation
    modules/layoutdist
    users-guide/index
 
-
 .. toctree::
    :caption: Language History
    :maxdepth: 1
 
    Chapel Evolution <language/evolution>
+
+Index
+-----
+
+* :ref:`Chapel Online Documentation Index <genindex>`
+
+.. COMMENT: clean this up before exposing:: * :chpl:chplref:`chplmodindex`

--- a/doc/sphinx/source/modules/builtins.rst
+++ b/doc/sphinx/source/modules/builtins.rst
@@ -2,7 +2,9 @@
 
 Built-in Types and Functions
 ============================
-Contents:
+
+The following sections describe built-in language features which are
+amenable to being documented using **chpldoc**:
 
 .. toctree::
    :hidden:
@@ -12,3 +14,11 @@ Contents:
    :glob:
 
    internal/**
+
+
+Index
+-----
+
+* :ref:`Chapel Online Documentation Index <genindex>`
+
+.. COMMENT: clean this up before exposing:: * :chpl:chplref:`chplmodindex`

--- a/doc/sphinx/source/modules/layoutdist.rst
+++ b/doc/sphinx/source/modules/layoutdist.rst
@@ -5,17 +5,33 @@ Standard Layouts and Distributions
 
 Standard Layouts
 ----------------
+
+Standard layouts are domain maps that target a single locale and
+describe the local storage of domains and arrays.
+
 .. toctree::
    :maxdepth: 1
    :glob:
 
    layouts/**
 
+
 Standard Distributions
 ----------------------
+
+Standard distributions are domain maps that target multiple locales
+and describe how domains and arrays are stored across them.
 
 .. toctree::
    :maxdepth: 1
    :glob:
 
    dists/**
+
+
+Index
+-----
+
+* :ref:`Chapel Online Documentation Index <genindex>`
+
+.. COMMENT: clean this up before exposing:: * :chpl:chplref:`chplmodindex`

--- a/doc/sphinx/source/modules/modules.rst
+++ b/doc/sphinx/source/modules/modules.rst
@@ -2,7 +2,9 @@
 
 Standard Modules
 ================
-Contents:
+
+Standard modules are those which describe features that are considered
+part of the Chapel Standard Library.
 
 .. toctree::
    :hidden:
@@ -14,7 +16,10 @@ Contents:
 
    standard/*
 
-**Module Indices and tables**
 
-* :ref:`genindex`
-* :chpl:chplref:`chplmodindex`
+Index
+-----
+
+* :ref:`Chapel Online Documentation Index <genindex>`
+
+.. COMMENT: clean this up before exposing:: * :chpl:chplref:`chplmodindex`

--- a/doc/sphinx/source/modules/packages.rst
+++ b/doc/sphinx/source/modules/packages.rst
@@ -2,7 +2,12 @@
 
 Package Modules
 ===============
-Contents:
+
+Package modules are libraries that currently live outside of the
+Chapel Standard Library, either because they are not considered to be
+fundamental enough or because they are not yet mature enough for
+inclusion there.
+
 
 .. toctree::
    :hidden:
@@ -13,7 +18,10 @@ Contents:
 
    packages/**
 
-**Package Indices and tables**
 
-* :ref:`genindex`
-* :chpl:chplref:`chplmodindex`
+Index
+-----
+
+* :ref:`Chapel Online Documentation Index <genindex>`
+
+.. COMMENT: clean this up before exposing:: * :chpl:chplref:`chplmodindex`


### PR DESCRIPTION
* Added a short description to each of the module docs lists
  describing what was on that page and dropped the old "Contents:"
  label.

* Made a concerted effort to get the index onto the sidebar, but just
  couldn't figure out any way to do it, so added it to the bottom of
  the front page and each of the online docs pages that contributes to
  it.  If we were able to get the index onto the sidebar, I'd be
  tempted to separate the "language docs" from the "online docs" in
  the sidebar so that it was clear what the index referred to.

* Ended up dropping "the module index" because most of the
  descriptions were poor / unintended to be there, and because it
  seemed to add little value beyond the individual contents pages and
  index, and because many of these things are not what a user should
  think of as a module (again, the "language/internal" vs. "library"
  distinction in my mind).