### PR TITLE
Bug Fix: String and CString casting bug (whitespaces not being ignored)

### DIFF
--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -193,7 +193,7 @@ module CString {
   {
     pragma "insert line file info"
     extern proc c_string_to_chpl_bool(x:c_string) : bool;
-    return c_string_to_chpl_bool(x) : t;
+    return c_string_to_chpl_bool((x:string).strip().c_str()) : t;
   }
 
   //
@@ -217,21 +217,21 @@ module CString {
   extern proc c_string_to_uint64_t(x:c_string) : uint(64);
 
   inline proc _cast(type t, x:c_string) where t == int(8)
-    return c_string_to_int8_t(x);
+    return c_string_to_int8_t((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == int(16)
-    return c_string_to_int16_t(x);
+    return c_string_to_int16_t((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == int(32)
-    return c_string_to_int32_t(x);
+    return c_string_to_int32_t((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == int(64)
-    return c_string_to_int64_t(x);
+    return c_string_to_int64_t((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == uint(8)
-    return c_string_to_uint8_t(x);
+    return c_string_to_uint8_t((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == uint(16)
-    return c_string_to_uint16_t(x);
+    return c_string_to_uint16_t((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == uint(32)
-    return c_string_to_uint32_t(x);
+    return c_string_to_uint32_t((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == uint(64)
-    return c_string_to_uint64_t(x);
+    return c_string_to_uint64_t((x:string).strip().c_str());
 
   //
   // casts from c_string to real/imag types
@@ -246,13 +246,13 @@ module CString {
   extern proc c_string_to_imag64(x:c_string) : imag(64);
 
   inline proc _cast(type t, x:c_string) where t == real(32)
-    return c_string_to_real32(x);
+    return c_string_to_real32((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == real(64)
-    return c_string_to_real64(x);
+    return c_string_to_real64((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == imag(32)
-    return c_string_to_imag32(x);
+    return c_string_to_imag32((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == imag(64)
-    return c_string_to_imag64(x);
+    return c_string_to_imag64((x:string).strip().c_str());
 
   //
   // casts from c_string to complex types
@@ -263,9 +263,9 @@ module CString {
   extern proc c_string_to_complex128(x:c_string) : complex(128);
 
   inline proc _cast(type t, x:c_string) where t == complex(64)
-    return c_string_to_complex64(x);
+    return c_string_to_complex64((x:string).strip().c_str());
   inline proc _cast(type t, x:c_string) where t == complex(128)
-    return c_string_to_complex128(x);
+    return c_string_to_complex128((x:string).strip().c_str());
 
   //
   // casts from complex

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -41,10 +41,11 @@ module StringCasts {
     }
   }
 
-  proc _cast(type t, x: string) where t == bool {
-    if (x == "true") {
+  proc _cast(type t, x: string) where isBoolType(t) {
+    var str = x.strip();
+    if (str == "true") {
       return true;
-    } else if (x == "false") {
+    } else if (str == "false") {
       return false;
     } else {
       halt("Unexpected value when converting from string to bool: '"+x+"'");
@@ -88,7 +89,7 @@ module StringCasts {
     pragma "insert line file info"
     extern proc c_string_to_uint64_t(x:c_string) : uint(64);
 
-    const localX = x.localize();
+    const localX = x.strip().localize();
     if isIntType(t) {
       select numBits(t) {
         when 8  do return c_string_to_int8_t(localX.c_str());
@@ -144,7 +145,7 @@ module StringCasts {
     pragma "insert line file info"
     extern proc c_string_to_real64(x: c_string) : real(64);
 
-    const localX = x.localize();
+    const localX = x.strip().localize();
     select numBits(t) {
       when 32 do return c_string_to_real32(localX.c_str());
       when 64 do return c_string_to_real64(localX.c_str());
@@ -158,7 +159,7 @@ module StringCasts {
     pragma "insert line file info"
     extern proc c_string_to_imag64(x: c_string) : imag(64);
 
-    const localX = x.localize();
+    const localX = x.strip().localize();
     select numBits(t) {
       when 32 do return c_string_to_imag32(localX.c_str());
       when 64 do return c_string_to_imag64(localX.c_str());
@@ -199,7 +200,7 @@ module StringCasts {
     pragma "insert line file info"
     extern proc c_string_to_complex128(x:c_string) : complex(128);
 
-    const localX = x.localize();
+    const localX = x.strip().localize();
     select numBits(t) {
       when 64 do return c_string_to_complex64(localX.c_str());
       when 128 do return c_string_to_complex128(localX.c_str());

--- a/test/users/ferguson/cast_to_int_ignore_whitespace.bad
+++ b/test/users/ferguson/cast_to_int_ignore_whitespace.bad
@@ -1,1 +1,0 @@
-cast_to_int_ignore_whitespace.chpl:3: error: Unexpected character when converting from string to int(64): ' '

--- a/test/users/ferguson/cast_to_int_ignore_whitespace.future
+++ b/test/users/ferguson/cast_to_int_ignore_whitespace.future
@@ -1,1 +1,0 @@
-bug: cast from string to int does not ignore whitespace


### PR DESCRIPTION
- Modified the String and Cstring module to take care of casting errors for
  all the major types like int, uint, real, complex and imaginary.
- Also throws appropriate errors in case of invalid input.
- Also removing .bad and .future files for
 test/users/ferguson/cast_to_int_ignore_whitespace.chpl