### PR TITLE
Fix an "undefined font" warning when building spec

### DIFF
--- a/spec/Lexical_Structure.tex
+++ b/spec/Lexical_Structure.tex
@@ -357,7 +357,7 @@ string-character:
   hexadecimal-escape-character
 
 simple-escape-character: one of
-  `$\backslash\mbox{\bf '}\hspace{5pt}$' `$\backslash$"$\hspace{5pt}$' `$\backslash$?$\hspace{5pt}$' `$\backslash$\$\hspace{5pt}$' `$\backslash$a$\hspace{5pt}$' `$\backslash$b$\hspace{5pt}$' `$\backslash$f$\hspace{5pt}$' `$\backslash$n$\hspace{5pt}$' `$\backslash$r$\hspace{5pt}$' `$\backslash$t$\hspace{5pt}$' `$\backslash$v$\hspace{5pt}$'
+  `$\backslash\mbox{\bf '}\hspace{5pt}$' `$\backslash$"$\hspace{5pt}$' `$\backslash$?$\hspace{5pt}$' `$\backslash$$\backslash$$\hspace{5pt}$' `$\backslash$a$\hspace{5pt}$' `$\backslash$b$\hspace{5pt}$' `$\backslash$f$\hspace{5pt}$' `$\backslash$n$\hspace{5pt}$' `$\backslash$r$\hspace{5pt}$' `$\backslash$t$\hspace{5pt}$' `$\backslash$v$\hspace{5pt}$'
 
 hexadecimal-escape-character:
   `$\backslash$x' hexadecimal-digits


### PR DESCRIPTION
Recently I started getting this warning when building the spec on my
Linux desktop:

  LaTeX Font Warning: Font shape `OMS/ptm/bx/n' undefined

It is due to the following piece:

  $\backslash$\$\hspace{5pt}$

that got added to Lexical_Structure.tex in 125b7fb in #3081.

I replaced that piece with:

  $\backslash$$\backslash$$\hspace{5pt}$

and the warning went away.

I could probably get rid of the internal $$.
I put them in to keep the structure of that line more uniform.