### PR TITLE
Added 'ref' variables and 'ref' fields to spec.

### DIFF
--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -156,8 +156,10 @@ referenced anywhere. It could be reclaimed by the garbage collector.
 \index{fields!class}
 
 Variable declarations within a class declaration define
-fields within that class.  Parameter fields make a class generic.
-Variable fields define the storage associated with a class instance.
+fields within that class.
+% When a class is generic is defined in \section{Class Declarations}.
+\chpl{var} fields define the storage associated with a class instance.
+A \chpl{ref} field provides an alias to another variable.
 
 \begin{chapelexample}{defineActor.chpl}
 The code
@@ -177,6 +179,10 @@ string field \chpl{name} and the unsigned integer field \chpl{age}.
 \end{chapelexample}
 
 Field access is described in \rsec{Class_Field_Accesses}.
+
+\begin{craychapel}
+\chpl{ref} fields are presently not available.
+\end{craychapel}
 
 \subsection{Class Methods}
 \label{Class_Methods}

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -155,11 +155,10 @@ referenced anywhere. It could be reclaimed by the garbage collector.
 \index{classes!fields}
 \index{fields!class}
 
-Variable declarations within a class declaration define
-fields within that class.
-% When a class is generic is defined in \section{Class Declarations}.
-\chpl{var} fields define the storage associated with a class instance.
-A \chpl{ref} field provides an alias to another variable.
+A variable declaration within a class declaration defines
+a \emph{field} within that class.
+Each class instance consists of one variable per each
+\chpl{var} or \chpl{const} field in the class.
 
 \begin{chapelexample}{defineActor.chpl}
 The code
@@ -180,9 +179,10 @@ string field \chpl{name} and the unsigned integer field \chpl{age}.
 
 Field access is described in \rsec{Class_Field_Accesses}.
 
-\begin{craychapel}
-\chpl{ref} fields are presently not available.
-\end{craychapel}
+\begin{future}
+\chpl{ref} fields, which are fields corresponding to variable declarations
+with \chpl{ref} or \chpl{const ref} keywords, are an area of future work.
+\end{future}
 
 \subsection{Class Methods}
 \label{Class_Methods}

--- a/spec/Interoperation.tex
+++ b/spec/Interoperation.tex
@@ -383,7 +383,7 @@ constants.
 
 \begin{craychapel}
 Note that since params must be known to Chapel at compile-time and
-the Chapel compiler does not parse external C code,
+the Chapel compiler does not necessarily parse C code,
 external params are not supported.
 \end{craychapel}
 

--- a/spec/Interoperation.tex
+++ b/spec/Interoperation.tex
@@ -382,8 +382,8 @@ definitions for \#defines and enum symbols in addition to traditional C
 constants.
 
 \begin{craychapel}
-Note that since params must be known to Chapel at compile-time (and
-because the Chapel compiler doesn't have the ability to parse C code),
+Note that since params must be known to Chapel at compile-time and
+the Chapel compiler does not parse external C code,
 external params are not supported.
 \end{craychapel}
 

--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -26,7 +26,7 @@ variable-kind:
   `const'
   `var'
   `ref'
-  `const' `ref'
+  `const ref'
 
 variable-declaration-list:
   variable-declaration
@@ -430,18 +430,19 @@ configuration variable can be used to write rank-independent code.
 \index{ref@\chpl{ref}}
 
 A \emph{ref} variable is a variable declared using the \chpl{ref} keyword.
-A ref variable serves as an alias to another variable.
-% TODO: once the bug is fixed, add: another variable, field or array element.
+A ref variable serves as an alias to another variable, field or array element.
 The declaration of a ref variable must contain \sntx{initialization-part},
 which specifies what is to be aliased and can be a variable
 or any lvalue expression.
 
 Access or update to a ref variable is equivalent to access or update
-to the variable being aliased, subject to memory consistency model
-\rsec{Memory_Consistency_Model}. For example, an update to a ref variable
+to the variable being aliased. For example, an update to a ref variable
 is visible via the original variable, and visa versa.
 
-If the variable being aliased is a runtime constant, the corresponding
+If the expression being aliased is a runtime constant variable,
+a formal argument with a \chpl{const ref} concrete intent
+(\rsec{Concrete Intents}), or a call to a function with a \chpl{const ref}
+return intent (\rsec{Const_Ref_Return_Intent}), the corresponding
 ref variable must be declared as \chpl{const ref}.
 Parameter constants and expressions cannot be aliased.
 

--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -21,8 +21,12 @@ variable-declaration-statement:
 config-or-extern: one of
   `config' $ $ $ $ `extern'
 
-variable-kind: one of
-  `param' $ $ $ $ `const' $ $ $ $ `var'
+variable-kind:
+  `param'
+  `const'
+  `var'
+  `ref'
+  `const' `ref'
 
 variable-declaration-list:
   variable-declaration
@@ -68,12 +72,15 @@ Section~\rsec{Configuration_Variables}.  The optional keyword \chpl{extern}
 indicates that the variable is externally defined.  Its name and type are used
 within the Chapel program for resolution, but no space is allocated for it and
 no initialization code emitted.
+See \rsec{Shared_Data} for further details.
 
 The \sntx{variable-kind} specifies whether the variables are
-parameters (\chpl{param}), constants (\chpl{const}), or regular
+parameters (\chpl{param}), constants (\chpl{const}),
+ref variables (\chpl{ref}), or regular
 variables (\chpl{var}).  Parameters are compile-time constants whereas
 constants are runtime constants.  Both levels of constants are
 discussed in~\rsec{Constants}.
+Ref variables are discussed in \rsec{Ref_Variables}.
 
 The \sntx{type-part} of a variable declaration specifies the type of
 the variable.  It is optional if the \sntx{initialization-part} is
@@ -182,14 +189,10 @@ var v = e;
 \end{chapel}
 is equivalent to
 \begin{chapel}
-var v: e.type;
-v = e;
+var v: e.type = e;
 \end{chapel}
-for an arbitrary expression \chpl{e}.  For expressions of sync or
-single type, this translation does not hold because the evaluation
-of \chpl{e} results in a default read of this expression.  The type of
-the variable is thus equal to the base type of the sync or single
-expression.
+for an arbitrary expression \chpl{e}.  If \chpl{e} is of sync or
+single type, the type of \chpl{v} is the base type of \chpl{e}.
 
 \subsection{Multiple Variable Declarations}
 \label{Multiple_Variable_Declarations}
@@ -414,11 +417,97 @@ writeln(rank);
 \begin{chapeloutput}
 2
 \end{chapeloutput}
-sets a integer parameter \chpl{rank} to \chpl{2}.  At
-compile-time, \chpl{rank} can be set via a configuration file or compile-line
-override to \chpl{3} or \chpl{2*n}\footnote{It is assumed here that \chpl{n} is
-also a param variable.} or indeed to any other expression
-that can be evaluated at compile-time.  The value supplied at compile time
-overrides the value \chpl{2} appearing in the code.  In this example, the \chpl{rank}
+sets an integer parameter \chpl{rank} to \chpl{2}.
+At compile-time, this default value of \chpl{rank} can be overridden
+with another parameter expression, such as \chpl{3} or \chpl{2*n},
+provided \chpl{n} itself is a parameter. The \chpl{rank}
 configuration variable can be used to write rank-independent code.
 \end{chapelexample}
+
+\section{Ref Variables}
+\label{Ref_Variables}
+\index{variables!ref}
+\index{ref@\chpl{ref}}
+
+A \emph{ref} variable is a variable declared using the \chpl{ref} keyword.
+A ref variable serves as an alias to another variable.
+% TODO: once the bug is fixed, add: another variable, field or array element.
+The declaration of a ref variable must contain \sntx{initialization-part},
+which specifies what is to be aliased and can be a variable
+or any lvalue expression.
+
+Access or update to a ref variable is equivalent to access or update
+to the variable being aliased, subject to memory consistency model
+\rsec{Memory_Consistency_Model}. For example, an update to a ref variable
+is visible via the original variable, and visa versa.
+
+If the variable being aliased is a runtime constant, the corresponding
+ref variable must be declared as \chpl{const ref}.
+Parameter constants and expressions cannot be aliased.
+
+\begin{openissue}
+The behavior of a \chpl{const ref} alias to a non-\chpl{const} variable
+is an open issue. The options include disallowing such an alias,
+disallowing changes to the variable while it can be accessed via
+a \chpl{const ref} alias, making changes visible through the alias,
+and making the behavior undefined.
+\end{openissue}
+
+For example, the following code:
+
+% TODO: wrap the following code in "chapelexample".
+% We are not adding it to our test suite as of this writing
+% because it is too close to release cutoff.
+%
+\begin{chapel}
+var myInt = 51;
+ref refInt = myInt;                   // alias of a local or global variable
+myInt = 62;
+writeln("refInt = ", refInt);
+refInt = 73;
+writeln("myInt = ", myInt);
+
+var myArr: [1..3] int = 51;
+proc arrayElement(i) ref  return myArr[i];
+ref refToExpr = arrayElement(3);      // alias to lvalue returned by a function
+myArr[3] = 62;
+writeln("refToExpr = ", refToExpr);
+refToExpr = 73;
+writeln("myArr[3] = ", myArr[3]);
+
+const constArr: [1..3] int = 51..53;
+const ref myConstRef = constArr[2];   // would be an error without 'const'
+writeln("myConstRef = ", myConstRef);
+\end{chapel}
+
+%TODO: fix the bug in the following, then add to the above example:
+%
+% var myArr: [1..3] int = 51;
+% ref refArr = myArr[2];   // alias of an array element
+% myArr[2] = 62;
+% writeln("refArr = ", refArr);
+%
+% class C { var cField = 51; }
+% var myC = new C();
+% ref refField = myC.cField;   // alias of a field
+% myC.cField = 62;
+% writeln(refField);
+% delete myC;
+%
+% record R { var rField = 51; }
+% var myR = new R();
+% ref refToRecord = myR;
+% ref refToField  = myR.rField;
+% refToRecord = new R(rField = 62);  // updates 'myR', including its rField
+% writeln("refToField = ", refToField);
+
+prints out:
+
+% to be converted to {chapeloutput}
+\begin{chapel}
+refInt = 62
+myInt = 73
+refToExpr = 62
+myArr[3] = 73
+myConstRef = 52
+\end{chapel}


### PR DESCRIPTION
* Added syntax to Variables.tex.

** Converted "variable-kind: one of" to one alternative per line,
to accomodate 'const ref'

* Call them "ref variables", analogously to "configuration variables"
and "regular variables".

* Added a "Ref Variables" section to Variables.tex.

* Added a mention of 'ref' fields to Classes.tex.

** ... and a \craychapel note that ref fields "are presently not available".

WHILE THERE

* Added a reference to Interop chapter for 'extern' variables.

* Removed "Parameter fields make a class generic."
because it duplicates an earlier statement and does so incompletely.

* Removed "var v = e; is equivalent to declaration + assignment".
Streamlined the wording for the case where 'e' is sync/single.

* Streamlined the wording around the config-param.chpl example.

* Simplified the wording for not supporting extern params
in the Interop chapter.