### PR TITLE
Add const ref return intent to spec

### DIFF
--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -728,9 +728,6 @@ an iterator).
 The \chpl{ref} return intent is specified by following the argument list with
 the \chpl{ref} keyword.  The function must return or yield an lvalue.
 
-It is a program error to return a variable with the \chpl{ref} return
-intent if that variable is used after it is destroyed.
-
 \begin{chapelexample}{ref-return-intent.chpl}
 The following code defines a procedure that can be interpreted as a
 simple two-element array where the elements are actually module
@@ -777,10 +774,6 @@ mechanism but the function call cannot be assigned to. The \chpl{const ref}
 return intent should be viewed as a performance optimization. It
 indicates that the returned value does not need to be copied because the
 returned value will not be destroyed when the function returns.
-
-As with the \chpl{ref} return intent, it is a program error to return a
-variable with the \chpl{const ref} return intent if that variable is used
-after it is destroyed.
 
 \subsection{Choosing a Ref Return Intent Function Based on Calling Context}
 \label{Ref_Pair}

--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -776,8 +776,8 @@ This code outputs the number \chpl{3}.
 \index{intents!const ref return@\chpl{const ref} return}
 
 The \chpl{const ref} return intent is also available. It is a restricted
-form of the \chpl{ref} return intent. Functions marked with the
-\chpl{const ref} return intent cannot be used as an lvalue.
+form of the \chpl{ref} return intent. Calls to functions marked with
+the \chpl{const ref} return intent are not lvalue expressions.
 
 \subsection{Choosing a Ref Return Intent Function Based on Calling Context}
 \label{Ref_Pair}

--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -169,8 +169,12 @@ formal-intent:
   `param'
   `type'
 
-return-intent: one of
-  `ref' $ $ $ $ `const' $ $ $ $ `param' $ $ $ $ `type'
+return-intent:
+  `const'
+  `const ref'
+  `ref'
+  `param'
+  `type'
 
 return-type:
   : type-specifier
@@ -713,6 +717,8 @@ cannot be used as an lvalue.
 \subsection{The Ref Return Intent}
 \label{Ref_Return_Intent}
 \index{functions!ref keyword and@\chpl{ref} keyword and}
+\index{ref (return intent)@\chpl{ref} (return intent)}
+\index{intents!ref return@\chpl{ref} return}
 \index{functions!lvalues}
 
 When using a \chpl{ref} return intent, the function call is an lvalue
@@ -722,17 +728,8 @@ an iterator).
 The \chpl{ref} return intent is specified by following the argument list with
 the \chpl{ref} keyword.  The function must return or yield an lvalue.
 
-During function resolution, if a procedure with a \chpl{ref} return
-intent and a procedure without a \chpl{ref} return intent are both
-possible candidates for a call, and either both use promotion or neither do,
-then this pair of procedures is called a ref-pair.
-
-When the call to a ref-pair is on the left-hand side of an
-assignment statement or appears in a call and corresponds to a formal argument
-with \chpl{out}, \chpl{inout}, or \chpl{ref} intent, the \chpl{ref} return
-intent procedure is used. Otherwise, the other candidate is used.  Thus,
-a ref-pair can be useful for adjusting the behavior depending on the
-calling context.
+It is a program error to return a variable with the \chpl{ref} return
+intent if that variable is used after it is destroyed.
 
 \begin{chapelexample}{ref-return-intent.chpl}
 The following code defines a procedure that can be interpreted as a
@@ -766,6 +763,43 @@ This code outputs the number \chpl{3}.
 3
 \end{chapeloutput}
 \end{chapelexample}
+
+
+\subsection{The Const Ref Return Intent}
+\label{Const_Ref_Return_Intent}
+\index{functions!const ref keyword and@\chpl{const ref} keyword and}
+\index{const ref (return intent)@\chpl{const ref} (return intent)}
+\index{intents!const ref return@\chpl{const ref} return}
+
+The \chpl{const ref} return intent is also available. It is a restricted
+form of the \chpl{ref} return intent. In particular, it uses a similar
+mechanism but the function call cannot be assigned to. The \chpl{const ref}
+return intent should be viewed as a performance optimization. It
+indicates that the returned value does not need to be copied because the
+returned value will not be destroyed when the function returns.
+
+As with the \chpl{ref} return intent, it is a program error to return a
+variable with the \chpl{const ref} return intent if that variable is used
+after it is destroyed.
+
+\subsection{Choosing a Ref Return Intent Function Based on Calling Context}
+\label{Ref_Pair}
+\index{functions!ref-pair}
+
+During function resolution, if a procedure with a \chpl{ref} return
+intent and a procedure without a \chpl{ref} return intent are both
+possible candidates for a call, and either both use promotion or neither
+do, then this pair of procedures is called a ref-pair. Note that the
+procedure without \chpl{ref} return intent in a ref-pair could have no
+specified return intent, it could have the \chpl{const} return intent,
+or it could have the \chpl{const ref} return intent.
+
+When the call to a ref-pair is on the left-hand side of an
+assignment statement or appears in a call and corresponds to a formal argument
+with \chpl{out}, \chpl{inout}, or \chpl{ref} intent, the \chpl{ref} return
+intent procedure is used. Otherwise, the other candidate is used.  Thus,
+a ref-pair can be useful for adjusting the behavior depending on the
+calling context.
 
 \begin{chapelexample}{ref-return-intent-pair.chpl}
 

--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -714,6 +714,13 @@ and in what contexts that function is allowed to be used.  By default, or if
 the \sntx{return-intent} is \chpl{const}, the function returns a value that
 cannot be used as an lvalue.
 
+% TODO: it's a little jarring that the above talks about returning
+% a value when e.g. a type function does not return a value at all
+% (since it returns a type).
+% It would probably be better to consider type and param return
+% functions "type functions" or "param functions" and leave this
+% section to only discuss const/ref/const ref return intents.
+
 \subsection{The Ref Return Intent}
 \label{Ref_Return_Intent}
 \index{functions!ref keyword and@\chpl{ref} keyword and}
@@ -769,30 +776,43 @@ This code outputs the number \chpl{3}.
 \index{intents!const ref return@\chpl{const ref} return}
 
 The \chpl{const ref} return intent is also available. It is a restricted
-form of the \chpl{ref} return intent. In particular, it uses a similar
-mechanism but the function call cannot be assigned to. The \chpl{const ref}
-return intent should be viewed as a performance optimization. It
-indicates that the returned value does not need to be copied because the
-returned value will not be destroyed when the function returns.
+form of the \chpl{ref} return intent. Functions marked with the
+\chpl{const ref} return intent cannot be used as an lvalue.
 
 \subsection{Choosing a Ref Return Intent Function Based on Calling Context}
 \label{Ref_Pair}
 \index{functions!ref-pair}
 
-During function resolution, if a procedure with a \chpl{ref} return
-intent and a procedure without a \chpl{ref} return intent are both
-possible candidates for a call, and either both use promotion or neither
-do, then this pair of procedures is called a ref-pair. Note that the
-procedure without \chpl{ref} return intent in a ref-pair could have no
-specified return intent, it could have the \chpl{const} return intent,
-or it could have the \chpl{const ref} return intent.
+In some situations, it is useful to distinguish between calls that are
+used in an lvalue setting and those that are not. In particular, suppose
+that there are two functions that have the same formal arguments and
+differ only in their return intent. Normally, such a situation will cause
+an error since it is ambiguous which function is called. However, the
+Chapel language includes a special rule for determining which function to
+call when one of the calls is an lvalue and the other is not.  This rule
+enables data structures such as sparse arrays.
 
-When the call to a ref-pair is on the left-hand side of an
-assignment statement or appears in a call and corresponds to a formal argument
-with \chpl{out}, \chpl{inout}, or \chpl{ref} intent, the \chpl{ref} return
-intent procedure is used. Otherwise, the other candidate is used.  Thus,
-a ref-pair can be useful for adjusting the behavior depending on the
-calling context.
+This special rule is called the ref-pair rule. If, when resolving a call,
+there are two candidate functions where:
+
+\begin{itemize}
+\item
+ one of them uses the \chpl{ref} return intent and the other uses
+ \chpl{const}, \chpl{const ref}, or blank return intent
+\item
+ either both use promotion or neither do
+\end{itemize}
+
+then this pair of candidate functions is called a ref-pair.
+
+When such a call appears on the left-hand side of an assignment statement
+or appears in a call and corresponds to a formal argument with
+\chpl{out}, \chpl{inout}, or \chpl{ref} intent, the candidate with
+the \chpl{ref} return intent is used. Otherwise, the other candidate is
+used.
+
+% TODO - this section, or a significant portion of it,
+% should move to the function resolution section.
 
 \begin{chapelexample}{ref-return-intent-pair.chpl}
 

--- a/test/functions/ferguson/ref-return-intent2.chpl
+++ b/test/functions/ferguson/ref-return-intent2.chpl
@@ -1,23 +1,64 @@
-var globalInt = 0;
+record R {
+  var x;
 
-proc someFunction() {
-  return 22;
+  proc return_ref() ref
+  {
+    writeln("setter");
+    return x;
+  }
+  proc return_ref() const
+  {
+    writeln("getter");
+    return x;
+  }
+  
+  proc call_return_ref() ref
+  {
+    return return_ref();
+  }
+  proc call_return_ref() const
+  {
+    return return_ref();
+  }
+
 }
 
-proc returnRef2() ref {
-  return globalInt;
+{
+  var r = new R(1);
+
+  writeln("should be reading 1");
+  var x = r.return_ref(); // getter
+  writeln(x);
+
+  writeln("setting it to 2");
+  r.return_ref() = 2; // setter
+  writeln(r.x);
+
+  writeln("should be reading 2");
+  var y = r.call_return_ref(); // getter
+  writeln(r.x);
+
+  writeln("setting it to 3");
+  r.call_return_ref() = 3; // setter
+  writeln(r.x);
 }
 
-proc returnRef2() {
-  var x : int = someFunction();
+{
+  var r = new R("one");
 
-  return x;
+  writeln("should be reading one");
+  var x = r.return_ref(); // getter
+  writeln(x);
+
+  writeln("setting it to two");
+  r.return_ref() = "two"; // setter
+  writeln(r.x);
+
+  writeln("should be reading two");
+  var y = r.call_return_ref(); // getter
+  writeln(r.x);
+
+  writeln("setting it to three");
+  r.call_return_ref() = "three"; // setter
+  writeln(r.x);
 }
-
-
-returnRef2() = 1;      // resolves to 'ref' return intent version
-var y = returnRef2(); // resolves to default/const ref return intent
-
-writeln(globalInt);
-writeln(y);
-

--- a/test/functions/ferguson/ref-return-intent2.good
+++ b/test/functions/ferguson/ref-return-intent2.good
@@ -1,2 +1,24 @@
+should be reading 1
+getter
 1
-22
+setting it to 2
+setter
+2
+should be reading 2
+getter
+2
+setting it to 3
+setter
+3
+should be reading one
+getter
+one
+setting it to two
+setter
+two
+should be reading two
+getter
+two
+setting it to three
+setter
+three


### PR DESCRIPTION
I just realized that PR #3232 added 'const ref' return intent but didn't
update the spec. Update it here.

Also added a test of getter/setter with 'const' and 'ref' return intent
since in updating the spec I realized that should work but isn't tested.

Cleans up/rewrites the earlier spec section on ref-pair.

TODOs (for after the release):

* separate discussion of ref, const ref, const return intent from type, param which make different kinds of functions
* move most of the ref-pair discussion to the resolution part of the spec