### PR TITLE
Update spec section on record inheritance

### DIFF
--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -176,22 +176,30 @@ means of an \chpl{outer} reference.
 \index{records!inheritance}
 \index{inheritance!records}
 
-A \emph{derived} record type is a type that inherits from other record types.  For each named
-base record type, inheritance effectively inserts all of its fields and methods
-into the new record type.
+A \emph{derived} record type is a type that inherits from another record
+type. Inheritance effectively inserts
+all of the field in the base record type into the new record type.
 
-Since record types are resolved statically, there is no type hierarchy implied
+\begin{openissue}
+Inheritance of methods in records has not been defined. Inheritance of
+fields in records may change.
+\end{openissue}
+
+\begin{openissue}
+It has not been decided whether or not multiple inheritance for records
+will be allowed.
+\end{openissue}
+
+There is no type hierarchy implied
 by record inheritance.  It is merely a shorthand for including a list of fields
 in the record (or class) type being defined.  Record inheritance can be useful
 for grouping data common to several or class or record types.
 
 \begin{future}
-From the definition of record inheritance, it is apparent that a record of a
-derived type can be cast legally to any of its base record types.  But given
-their semantics, records can also be legally cast to types with which they have
-no inheritance relationship.  Thus, records do not induce a well-defined type
-hierarchy.
+Depending on how interitance of record methods is defined, record
+inheritance might possibly define a type heirarchy.
 \end{future}
+
 
 \begin{chapelexample}{recordInheritance.chpl}
 \begin{chapel}
@@ -212,10 +220,6 @@ three \chpl{real} fields named \chpl{x}, \chpl{y} and \chpl{radius}.  The
 \chpl{major} and \chpl{minor}.
 \end{chapelexample}
 
-The syntax and semantics for accessing methods (including getter methods and
-hence fields) in a base
-record type is the same as for accessing fields in a base class (\rsec{Accessing_Base_Class_Fields}).
-
 \subsection{Shadowing Base Record Fields}
 \label{Shadowing_Base_Record_Fields}
 \index{records!fields!shadowing}
@@ -228,24 +232,6 @@ directly accessible.
 \begin{openissue}
 A syntax for accessing shadowed fields has not yet been specified.
 \end{openissue}
-
-\subsection{Overriding Base Record Methods}
-\label{Overriding_Base_Record_Methods}
-\index{records!base method!overriding}
-
-\begin{future}
-If a method in a derived record is declared with a signature identical to that
-of a method in a base record, then it is said to override the
-base record's method.  Since records do not support dynamic dispatch, method
-overriding is the same as method shadowing: When referenced via the derived
-record type, the derived type's version of the method is called; when referenced
-via the base record type, the base record type's version of the method is called.
-
-The identical signature requires that the names, types, and order of
-the formal arguments be identical. The return type of the overriding
-method must be the same as the return type of the base record's method,
-or must be a subrecord of the base record method's return type.
-\end{future}
 
 \section{Record Variable Declarations}
 \label{Record_Variable_Declarations}


### PR DESCRIPTION
Explicitly uses open issues to describe the areas in which I at least am
uncertain of the language design around record inheritance.

Narrowed the specification to only describe what is currently
implemented. Removed some speculative sections about record type
heirarchy and method inheritance.

Reviewed by @vasslitvinov - thanks!