### PR TITLE
Document which standard modules are included by default

### DIFF
--- a/doc/sphinx/source/modules/modules.rst
+++ b/doc/sphinx/source/modules/modules.rst
@@ -6,6 +6,10 @@ Standard Modules
 Standard modules are those which describe features that are considered
 part of the Chapel Standard Library.
 
+The modules :chpl:mod:`Assert` , :chpl:mod:`Math` , and :chpl:mod:`Types`
+are included by default.
+
+
 .. toctree::
    :hidden:
 

--- a/modules/standard/Assert.chpl
+++ b/modules/standard/Assert.chpl
@@ -21,10 +21,11 @@
 /*
   Support for simple assert() routines.
 
-  .. note:: 
-            In the current implementation, these asserts never become
-            no-ops.  That is, using them will always incur
-            execution-time checks.
+  In the current implementation, these asserts never become no-ops.  That is,
+  using them will always incur execution-time checks.
+
+  .. note:: This module is included by default.
+
 */
 module Assert {
 

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -43,6 +43,8 @@ handling in the Math module.  The default behavior is as if the macro
 all math functions will return an implementation-defined value; no
 exception will be generated.
 
+.. note:: This module is included by default.
+
 */
 module Math {
 

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -22,6 +22,9 @@ Functions related to predefined types.
 
 These functions are provided by default;
 an explicit 'use' statement is not necessary.
+
+.. note:: This module is included by default.
+
 */
 module Types {
 


### PR DESCRIPTION
Added documentation to `modules.rst` that states which modules are included by default, and added a `.. note:` to the end of the intro-section of each module that is included by default.

Also, removed `.. note:` formatting of some text in `Assert.chpl` because 2 back to back notes looks odd.