### PR TITLE
Fix bug generating real(32) from PCG

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -839,7 +839,7 @@ module Random {
     private inline
     proc randToReal64(x: uint(64)):real(64)
     {
-      return ldexp(x, -64);
+      return ldexp(x:real(64), -64);
     }
     // returns a random number in [min, max]
     // by scaling a multiple of 2**-64 by (max-min)
@@ -855,7 +855,7 @@ module Random {
     private inline
     proc randToReal32(x: uint(32))
     {
-      return ldexp(x, -32);
+      return ldexp(x:real(32), -32);
     }
 
     // returns a random number in [min, max)

--- a/test/modules/standard/Random/ferguson/pcg-real32-bug.chpl
+++ b/test/modules/standard/Random/ferguson/pcg-real32-bug.chpl
@@ -1,0 +1,13 @@
+use Random;
+
+config const verbose = false;
+
+var rng = makeRandomStream(eltType=real(32), algorithm=RNG.PCG);
+
+
+var displace = (rng.getNext(), rng.getNext(), rng.getNext());
+
+if verbose then
+  writeln(displace);
+
+


### PR DESCRIPTION
Includes test case that was failing.
Bug reported by @npadmana - thanks!

Adds casts to the appropriate real type in calls to ldexp to make sure we are calling the correct ldexp function.

Trivial and not reviewed.
Passed test/modules/standard/Random on OS X and linux.
Passed full local testing.