### PR TITLE
Fix internal typos

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2918,7 +2918,7 @@ getVisibilityBlock(Expr* expr) {
       else
         return getVisibilityBlock(s->defPoint);
   } else {
-    INT_FATAL(expr, "Expresion has no visibility block.");
+    INT_FATAL(expr, "Expression has no visibility block.");
     return NULL;
   }
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -553,7 +553,7 @@ Integral Conversions
  (That is, it is right-justified in a 17-column field.
  Padding width is ignored when reading integers)
 ``%*i``
- as with ``%17i`` but read the minimum width from the preceeding argument
+ as with ``%17i`` but read the minimum width from the preceding argument
 ``%017i``
  a decimal integer padded on the left with zeros to 17 columns
 ``%-17i``
@@ -586,13 +586,13 @@ Real Conversions
 ``%.4r``
  as with ``%r`` but with 4 significant digits
 ``%.*r``
- as with ``%.4r`` but with significant digits read from preceeding argument
+ as with ``%.4r`` but with significant digits read from preceding argument
 ``%6.4r``
  as with ``%r`` but padded on the left to 6 columns
  and with 4 significant digits
 ``%*.*r``
  as with ``%6.4r`` but read minimum width and significant digits from
- preceeding arguments
+ preceding arguments
 
 ``%dr``
  a real number in decimal notation, e.g. ``12.34``

--- a/runtime/src/qio/auxFilesys/curl/qio_plugin_curl.c
+++ b/runtime/src/qio/auxFilesys/curl/qio_plugin_curl.c
@@ -440,7 +440,7 @@ qioerr curl_seek(void* fl, off_t offset, int whence, off_t* offset_out, void* fs
       if (curl_local->length != -1)  // we have the length
         curl_local->current_offset= curl_local->length + offset;
       else
-        QIO_RETURN_CONSTANT_ERROR(ESPIPE, "Unable to SEEK_END for path with unkown length");
+        QIO_RETURN_CONSTANT_ERROR(ESPIPE, "Unable to SEEK_END for path with unknown length");
       break;
     case SEEK_SET:
       curl_local->current_offset = offset;

--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -3599,7 +3599,7 @@ qioerr qio_channel_print_complex(const int threadsafe,
     err = maybe_right_pad(ch, width);
     if( err ) goto rewind;
   } else {
-    QIO_GET_CONSTANT_ERROR(err, EINVAL, "unknow complex format");
+    QIO_GET_CONSTANT_ERROR(err, EINVAL, "unknown complex format");
     goto rewind;
   }
 


### PR DESCRIPTION
The Debian package helper tool `lintian` caught a few typos in warning/error messages, when building a Chapel Debian package. This PR corrects them.

**paratested on linux64**