### PR TITLE
Update Cray docs for quicker quick-start instructions

### DIFF
--- a/doc/release/platforms/cray.rst
+++ b/doc/release/platforms/cray.rst
@@ -17,17 +17,34 @@ Getting Started with Chapel on Cray X-Series Systems
 
 Chapel is available as a module for Cray X-series systems.  When it is
 installed on your system, you do not need to build Chapel from the
-source release (though you can); instead, simply load the module
-using::
+source release (though you can). To use Chapel with the default settings and
+confirm it is correctly installed, do the following:
+
+1) Load the Chapel module::
 
      module load chapel
 
-Then proceed directly to `Using Chapel on a Cray System`_ below.  If instead
-you wish to build Chapel from source, continue on to `Building Chapel for a
-Cray System from Source`_ just below.
+
+2) Compile an example program using::
+
+     chpl -o hello6-taskpar-dist $CHPL_HOME/examples/hello6-taskpar-dist.chpl
+
+
+3) Execute the resulting executable (on four locales)::
+
+     ./hello6-taskpar-dist -nl 4
+
+
+This is all that is necessary for most Chapel installations on Cray X-Series
+systems.  If the installation setup by your system administratordeviates from
+the default settings, or you are interested in additional configuration
+options, see `Using Chapel on a Cray System`_ below.  If instead you wish to
+build Chapel from source, continue on to
+`Building Chapel for a Cray System from Source`_ just below.
 
 For information on obtaining and installing the Chapel module please
 contact your system administrator.
+
 
 
 ----------------------------------------------
@@ -37,8 +54,8 @@ Getting Started with Chapel on Cray CS Systems
 On Cray CS systems, Chapel is not currently available as a module due
 to the wide diversity of software packages that Cray CS customers may
 choose to install on their system.  For this reason, Chapel must be
-built from source on Cray CS systems using the instructions just
-below.
+built from source on Cray CS systems using the
+`Building Chapel for a Cray System from Source`_ instructions just below.
 
 
 ---------------------------------------------
@@ -711,7 +728,7 @@ environment variable, which can take the following values:
 Successively higher levels of overflow checking are more likely both to
 catch overflow and to catch it earlier, but they also have more overhead
 and thus a greater impact on performance.
- 
+
 Note: in some situations the check as to whether or not the task
 stacks are in hugepage memory gets the wrong answer, leading to
 internal errors when the tasking layer tries to use guard pages and

--- a/doc/release/platforms/cray.rst
+++ b/doc/release/platforms/cray.rst
@@ -35,16 +35,15 @@ confirm it is correctly installed, do the following:
      ./hello6-taskpar-dist -nl 4
 
 
-This is all that is necessary for most Chapel installations on Cray X-Series
-systems.  If the installation setup by your system administratordeviates from
-the default settings, or you are interested in additional configuration
+This may be all that is necessary to use Chapel on a Cray X-Series system.
+If the installation setup by your system administrator deviates from
+the default settings, or you are interested in other configuration
 options, see `Using Chapel on a Cray System`_ below.  If instead you wish to
 build Chapel from source, continue on to
 `Building Chapel for a Cray System from Source`_ just below.
 
 For information on obtaining and installing the Chapel module please
 contact your system administrator.
-
 
 
 ----------------------------------------------


### PR DESCRIPTION
This is coupled to the planned removal of the Cray `README.rst`. This change ensures that the contents of `cray.rst` subsumes the quick-start instructions of the Cray `README.rst`.
