### PR TITLE
MCM-related and other minor spec edits

### DIFF
--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -297,7 +297,7 @@ can hold a reference to an object of any class type.
 
 A derived class contains data associated with the fields in its base
 classes.  The fields can be accessed in the same way that they are
-accessed in their base class unless the getter or setter method is
+accessed in their base class unless a getter method is
 overridden in the derived class, as discussed
 in~\rsec{Overriding_Base_Class_Methods}.
 

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -20,6 +20,12 @@ are handled within forall statements and expressions.
 controlling default data parallelism.
 \end{itemize}       
 
+Data-parallel constructs may result in accesses to the same variable
+from different tasks, possibly due to aliasing using
+\chpl{ref} argument intents or forall intents, among others.
+Such accesses are subject to Memory Consistency Model
+(\rsec{Memory_Consistency_Model}).
+
 \section{The Forall Statement}
 \label{Forall}
 \index{forall@\chpl{forall} (see also statements, forall)}

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -23,7 +23,7 @@ controlling default data parallelism.
 Data-parallel constructs may result in accesses to the same variable
 from different tasks, possibly due to aliasing using
 \chpl{ref} argument intents or forall intents, among others.
-Such accesses are subject to Memory Consistency Model
+Such accesses are subject to the Memory Consistency Model
 (\rsec{Memory_Consistency_Model}).
 
 \section{The Forall Statement}

--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -816,8 +816,7 @@ used.
 
 \begin{chapelexample}{ref-return-intent-pair.chpl}
 
-\index{setter}
-\index{functions!setter argument}
+\index{functions!ref-pair}
 A ref-pair can be used to ensure, for
 example, that the second element in the pseudo-array is only assigned
 a value if the first argument is positive.  The following is an

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -804,14 +804,6 @@ program from which the function containing the call is called.
 Compilation halts if a \chpl{compilerError} is encountered whereas it
 will continue after encountering a \chpl{compilerWarning}.
 
-\begin{craychapel}
-Note that when a function with a \chpl{ref} return intent is called in a
-context where the implicit \chpl{setter} argument is true or false, both
-versions of the function are resolved by the compiler.  Consequently, the
-\chpl{setter} argument cannot be effectively used to guard a compiler
-diagnostic statements.
-\end{craychapel}
-
 \begin{chapelexample}{compilerDiagnostics.chpl}
 The following code shows an example of using user-defined compiler
 diagnostics to generate warnings and errors:

--- a/spec/Memory_Consistency.tex
+++ b/spec/Memory_Consistency.tex
@@ -10,9 +10,16 @@ Sequential consistency (SC) means that all Chapel tasks agree on the
 interleaving of memory operations and this interleaving results in an
 order is consistent with the order of operations in the program source
 code.  \emph{Conflicting memory operations}, i.e., operations to the
-same location and one of which is a write, form a data race if they
-are from different Chapel tasks and can be executed concurrently.  Any
-Chapel program with a data race is not a valid program, and an
+same variable, or memory location, and one of which is a write, form a data race if they
+are from different Chapel tasks and can be executed concurrently.
+Accesses to the same variable from different tasks can result from
+the tasks referencing the same variable directly -- or indirectly
+via aliases. Aliases arise, for example, when using \chpl{ref} variables,
+argument intents, return intents, task intents and forall intents.
+% TODO: add to the above: 'const ref' variables/intents and
+% 'ref'/'const ref' fields, once we settle on their semantics.
+
+Any Chapel program with a data race is not a valid program, and an
 implementation cannot be relied upon to produce consistent behavior.
 Valid Chapel programs will use synchronization constructs such
 as \emph{sync}, \emph{single}, or \emph{atomic} variables or

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -63,6 +63,11 @@ scopes are considered to be passed into a task function by default intent,
 unless a different \emph{task intent} is specified explicitly
 by a \sntx{task-intent-clause}.
 
+% Should this be placed more prominently right before this section?
+Accesses to the same variable from different tasks are subject
+to Memory Consistency Model (\rsec{Memory_Consistency_Model}).
+Such accesses can result from aliasing due to \chpl{ref} argument intents
+or task intents, among others.
 
 \section{The Begin Statement}
 \label{Begin}

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -65,7 +65,7 @@ by a \sntx{task-intent-clause}.
 
 % Should this be placed more prominently right before this section?
 Accesses to the same variable from different tasks are subject
-to Memory Consistency Model (\rsec{Memory_Consistency_Model}).
+to the Memory Consistency Model (\rsec{Memory_Consistency_Model}).
 Such accesses can result from aliasing due to \chpl{ref} argument intents
 or task intents, among others.
 


### PR DESCRIPTION
MCM-RELATED

* Added forward references to MCM to the chapters on Task and Data parallelism.

* Not done - perhaps consider in the future - doing the same for:
 - ref variables, fields
 - ref argument/return intents
 - ref task and forall intents

* In the other direction, have the MCM chapter point to ref variables
and intents of all kinds as possible sources of concurrent accesses
to the same location.

MISCELLANEA

* In MCM, replaced "location" with "variable, or memory location" once.

* Removed a "setter" method reference and an index entry.
That's because fields are accessed via "getter" methods as per Classes.tex.
More cleanup is needed in this area, which I am not taking on at the moment.

* Removed a \craychapel note relating to the implicit 'setter' argument.
We may want to reinstate this note w.r.t. ref-pairs instead.
