### PR TITLE
tone down "provides wrappers" in chpldoc for Math

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -18,9 +18,10 @@
  */
 
 /*
-This module provides wrappers for <cmath> (math.h) numerical constants and
-routines.  Its symbols are provided by default; an explicit 'use' statement
-is not necessary.
+This module provides numerical constants and functions,
+including those found in <cmath> (math.h) headers.
+These symbols are provided by default;
+an explicit 'use' statement is not necessary.
 
 The C Math library is part of the C Language Standard (ISO/IEC 9899), as
 described in Section 7.12.  Please consult that standard for an


### PR DESCRIPTION
The point of Math is to provide math functions. Emphasize that in its chpldoc.

Instead of "math" functions the chpldoc has historically called them "numeric".
Which one is preferred? (I did not change that; we may as well if that's desired.)
