### PR TITLE
Rewording to be less ambiguous about auto-use'd modules

### DIFF
--- a/doc/sphinx/source/modules/modules.rst
+++ b/doc/sphinx/source/modules/modules.rst
@@ -6,8 +6,8 @@ Standard Modules
 Standard modules are those which describe features that are considered
 part of the Chapel Standard Library.
 
-The modules :chpl:mod:`Assert` , :chpl:mod:`Math` , and :chpl:mod:`Types`
-are included by default.
+All Chapel programs automatically ``use`` the modules :chpl:mod:`Assert` ,
+:chpl:mod:`Math` , and :chpl:mod:`Types` by default.
 
 
 .. toctree::

--- a/modules/standard/Assert.chpl
+++ b/modules/standard/Assert.chpl
@@ -24,7 +24,8 @@
   In the current implementation, these asserts never become no-ops.  That is,
   using them will always incur execution-time checks.
 
-  .. note:: This module is included by default.
+  .. note:: All Chapel programs automatically ``use`` this module by default.
+            An explicit ``use`` statement is not necessary.
 
 */
 module Assert {

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -19,8 +19,7 @@
 
 /*
 This module provides wrappers for <cmath> (math.h) numerical constants and
-routines.  Its symbols are provided by default; an explicit 'use' statement
-is not necessary.
+routines.
 
 The C Math library is part of the C Language Standard (ISO/IEC 9899), as
 described in Section 7.12.  Please consult that standard for an
@@ -43,7 +42,8 @@ handling in the Math module.  The default behavior is as if the macro
 all math functions will return an implementation-defined value; no
 exception will be generated.
 
-.. note:: This module is included by default.
+.. note:: All Chapel programs automatically ``use`` this module by default.
+          An explicit ``use`` statement is not necessary.
 
 */
 module Math {

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -20,10 +20,8 @@
 /*
 Functions related to predefined types.
 
-These functions are provided by default;
-an explicit 'use' statement is not necessary.
-
-.. note:: This module is included by default.
+.. note:: All Chapel programs automatically ``use`` this module by default.
+          An explicit ``use`` statement is not necessary.
 
 */
 module Types {


### PR DESCRIPTION
Reworded to reduce ambiguity and please Chapel's BDFL.

Also removed some redundancy in some of the module docs w.r.t. being use'd by default.