### PR TITLE
Math module chpldoc touchup

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -18,11 +18,11 @@
  */
 
 /*
-This module provides wrappers for <cmath> (math.h) numerical constants and
-routines.
+This module provides mathematical constants and functions.
 
-The C Math library is part of the C Language Standard (ISO/IEC 9899), as
-described in Section 7.12.  Please consult that standard for an
+It includes wrappers for many of the constants in functions in
+the C Math library, which is part of the C Language Standard (ISO/IEC 9899)
+as described in Section 7.12.  Please consult that standard for an
 authoritative description of the expected properties of those constants and
 routines.
 


### PR DESCRIPTION
As we discussed in today's group meeting, position the Math module as providing math functions, rather than wrappers to math.h.

Turns out there are several paragraphs providing a strong connection to math.h which I did not take on eliminating. So I just removed the mention of math.h from the first paragraph.

While there, replaced "numeric routines" with "math functions".