### PR TITLE
Readme, quickstart, bugs fixup

### DIFF
--- a/QUICKSTART.rst
+++ b/QUICKSTART.rst
@@ -3,31 +3,27 @@
 Chapel Quickstart Instructions
 ==============================
 
-The following instructions are designed to get you get a Chapel
-installation up and running with a minimum of fuss.  Note that
-building and using Chapel as described in steps 1-7 disables advanced
-runtime options and optional language capabilities in the interest of
-a simple and clean build.  Steps 8-9 give instructions for enabling
-additional capabilities.
+The following instructions are designed to help you build Chapel from
+source.  If you haven't already downloaded Chapel, head over to
+http://chapel.cray.com/download.html to obtain the latest release, or
+see http://chapel.cray.com/install.html for other installation
+options.
+
+In the following instructions, note that building and using Chapel as
+described in steps 1-7 disables optional and advanced features in the
+interest of getting you a clean build as quickly as possible.  Steps
+8-9 explain how to re-build the preferred configuration that has these
+additional features enabled.
 
 
 0) See `prereqs.rst`_ for more information about system tools and
    packages you may need to have installed in support of Chapel.
-   Download a Chapel source release from `download.html`_ if you
-   haven't already or refer to `install.html`_ to learn about other
-   installation options.
-
-.. _prereqs.rst: http://chapel.cray.com/docs/1.13/usingchapel/prereqs.html
-.. _download.html: http://chapel.cray.com/download.html
-.. _install.html: http://chapel.cray.com/install.html
 
 
 1) Make sure that your shell is in the directory containing this
    ``QUICKSTART.rst`` file.  For example:
 
-    .. code-block:: sh
-
-        cd ~/chapel-1.13.0
+        ``cd ~/chapel-1.13.0``
 
 
 2) Set up your environment to use Chapel in "Quick Start" mode:
@@ -128,7 +124,6 @@ What's next?
     implementation status                       ``STATUS``
     performance status                          ``PERFORMANCE.md``
     Chapel's file and directory structure       ``README.files``
-    prerequisites for using this release        `prereqs.rst`_
     setting Chapel environment variables        `chplenv.rst`_
     building the compiler                       `building.rst`_
     using the compiler                          `compiling.rst`_

--- a/QUICKSTART.rst
+++ b/QUICKSTART.rst
@@ -117,44 +117,29 @@ the Bourne shell (sh)                    ``. util/quickstart/setchplenv.sh``
 
 What's next?
 ------------
-=============================================== =====================================
+=============================================== =========================
 **For more detailed information about:**        **refer to:**
------------------------------------------------ -------------------------------------
-    changes since the last release              ``CHANGES.md``
-    implementation status                       ``STATUS``
-    performance status                          ``PERFORMANCE.md``
-    Chapel's file and directory structure       ``README.files``
+----------------------------------------------- -------------------------
+    platform-specific notes                     `platforms`_
+    online Chapel Documentation                 `chapel.cray.com/docs`_
+    example Chapel programs                     ``examples/README``
     setting Chapel environment variables        `chplenv.rst`_
     building the compiler                       `building.rst`_
-    using the compiler                          `compiling.rst`_
+    compiling Chapel programs                   `compiling.rst`_
     executing Chapel programs                   `executing.rst`_
     debugging Chapel programs                   `debugging.rst`_
     reporting bugs                              `bugs.rst`_
+    implementation status                       ``STATUS``
+    performance status                          ``PERFORMANCE.md``
     Chapel modes for emacs and vim              ``highlight/README.md``
-    example Chapel programs                     ``examples/README``
-    a quick reference for Chapel syntax         `doc/quickReference.pdf`_
-    the Chapel language specification           `doc/chapelLanguageSpec.pdf`_
-    other Chapel Documentation                  `chapel.cray.com/docs`_
-    third-party software that we use            ``third-party/README``
-=============================================== =====================================
+    Chapel's file and directory structure       ``README.files``
+    changes since the last release              ``CHANGES.md``
+=============================================== =========================
 
-.. _doc/quickReference.pdf: http://chapel.cray.com/spec/quickReference.pdf
-.. _doc/chapelLanguageSpec.pdf: http://chapel.cray.com/spec/spec-0.98.pdf
+.. _platforms: http://chapel.cray.com/docs/1.13/platforms/index.html
 .. _chapel.cray.com/docs: http://chapel.cray.com/docs/1.13/
 .. _building.rst: http://chapel.cray.com/docs/1.13/usingchapel/building.html
 .. _compiling.rst: http://chapel.cray.com/docs/1.13/usingchapel/compiling.html
 .. _executing.rst: http://chapel.cray.com/docs/1.13/usingchapel/executing.html
 .. _debugging.rst: http://chapel.cray.com/docs/1.13/usingchapel/debugging.html
 .. _bugs.rst: http://chapel.cray.com/docs/1.13/usingchapel/bugs.html
-
-
-=============================================== =====================================
-**To use Chapel on a specific platform:**       **refer to:**
------------------------------------------------ -------------------------------------
-       a Cray system                            `cray.rst`_
-       Cygwin over Windows                      `cygwin.rst`_
-=============================================== =====================================
-
-
-.. _cray.rst: http://chapel.cray.com/docs/1.13/platforms/cray.html
-.. _cygwin.rst: http://chapel.cray.com/docs/1.13/platforms/cygwin.html

--- a/QUICKSTART.rst
+++ b/QUICKSTART.rst
@@ -4,20 +4,22 @@ Chapel Quickstart Instructions
 ==============================
 
 The following instructions are designed to help you build Chapel from
-source.  If you haven't already downloaded Chapel, head over to
-http://chapel.cray.com/download.html to obtain the latest release, or
-see http://chapel.cray.com/install.html for other installation
-options.
+source.  If you haven't already downloaded Chapel, obtain the latest
+release from http://chapel.cray.com/download.html, or refer to
+http://chapel.cray.com/install.html for other installation options.
 
 In the following instructions, note that building and using Chapel as
 described in steps 1-7 disables optional and advanced features in the
-interest of getting you a clean build as quickly as possible.  Steps
-8-9 explain how to re-build the preferred configuration that has these
-additional features enabled.
+interest of getting you a clean build as quickly as possible.  Step 8
+explains how to re-build in the preferred configuration with these
+additional features enabled.  Step 9 explains how to build Chapel for
+distributed memory execution.
 
 
 0) See `prereqs.rst`_ for more information about system tools and
-   packages you may need to have installed in support of Chapel.
+   packages you may need to have installed to build and run Chapel.
+
+.. _prereqs.rst: http://chapel.cray.com/docs/1.13/usingchapel/prereqs.html
 
 
 1) Make sure that your shell is in the directory containing this
@@ -40,9 +42,9 @@ the Bourne shell (sh)                    ``. util/quickstart/setchplenv.sh``
    Note that there is no requirement to use these scripts long-term,
    they are merely designed to help new users get their environment
    variables and paths set up quickly.  Long-term, users may want to
-   make these settings in their dotfiles or via other means.  See
-   `chplenv.rst`_ for a complete description of Chapel's environment
-   variables and their values.
+   copy and paste these settings into their dotfiles or set them in
+   other ways.  See `chplenv.rst`_ for a complete description of
+   Chapel's environment variables and their expected values.
 
 .. _chplenv.rst: http://chapel.cray.com/docs/1.13/usingchapel/chplenv.html
 
@@ -59,7 +61,7 @@ the Bourne shell (sh)                    ``. util/quickstart/setchplenv.sh``
    Parallel builds (e.g. ``gmake -j``) are also supported.
 
 
-4) ``csh``/``tcsh`` users only: Update your shell's path cache using:
+4) ``csh``/``tcsh`` users only: Update your shell's path hash table using:
 
         ``rehash``
 
@@ -73,33 +75,31 @@ the Bourne shell (sh)                    ``. util/quickstart/setchplenv.sh``
         ``make check``
 
 
-6) Compile an example program using:
+6) Compile an example program:
 
         ``chpl -o hello examples/hello.chpl``
 
 
-7) Execute the resulting executable:
+7) Run the resulting executable:
 
        ``./hello``
 
 
-8) Experiment with Chapel in this Quick-Start mode to your heart's
-   content.
-
-   Once you are comfortable with Chapel and interested in using a
-   full-featured version in the preferred configuration:
+8) Experiment with Chapel in this Quickstart mode to your heart's
+   content.  Once you are comfortable with Chapel and interested in
+   using a full-featured version in the preferred configuration:
 
    a) Open up a new shell to avoid inheriting the previous environment
       settings.
 
-   b) Repeat steps 1-7 above, but in Step 2, use ``util/setchplenv.*``
+   b) Repeat steps 1-7 above, but in Step 2, source ``util/setchplenv.*``
       instead of ``util/quickstart/setchplenv.*``
 
    This will set up your environment to use Chapel in the preferred
-   configuration.  Building this configuration will involve compiling
-   one or more third-party packages which will increase the overall
-   build time.  If you run into any portability issues, please let us
-   know at chapel_info@cray.com.
+   configuration.  Building this configuration involves compiling
+   third-party packages, which will increase the overall build time.
+   If you run into any portability issues, please let us know via
+   http://chapel.cray.com/bugs.html.
 
 
 9) All of the instructions above describe how to run Chapel programs
@@ -110,8 +110,8 @@ the Bourne shell (sh)                    ``. util/quickstart/setchplenv.sh``
 
 
 10) If you plan to do performance studies of Chapel programs, be sure
-    to (a) use the full-featured version and (b) read the ``PERFORMANCE.md``
-    file in this directory to avoid common pitfalls.
+    to (a) use the full-featured version from steps 8-9 and (b) read
+    ``$CHPL_HOME/PERFORMANCE.md`` to avoid common pitfalls.
 
 
 

--- a/QUICKSTART.rst
+++ b/QUICKSTART.rst
@@ -16,10 +16,10 @@ additional features enabled.  Step 9 explains how to build Chapel for
 distributed memory execution.
 
 
-0) See `prereqs.rst`_ for more information about system tools and
+0) See `doc/prereqs.rst`_ for more information about system tools and
    packages you may need to have installed to build and run Chapel.
 
-.. _prereqs.rst: http://chapel.cray.com/docs/1.13/usingchapel/prereqs.html
+.. _doc/prereqs.rst: http://chapel.cray.com/docs/1.13/usingchapel/prereqs.html
 
 
 1) Make sure that your shell is in the directory containing this
@@ -43,10 +43,10 @@ the Bourne shell (sh)                    ``. util/quickstart/setchplenv.sh``
    they are merely designed to help new users get their environment
    variables and paths set up quickly.  Long-term, users may want to
    copy and paste these settings into their dotfiles or set them in
-   other ways.  See `chplenv.rst`_ for a complete description of
+   other ways.  See `doc/chplenv.rst`_ for a complete description of
    Chapel's environment variables and their expected values.
 
-.. _chplenv.rst: http://chapel.cray.com/docs/1.13/usingchapel/chplenv.html
+.. _doc/chplenv.rst: http://chapel.cray.com/docs/1.13/usingchapel/chplenv.html
 
 
 3) Build the compiler and runtime libraries using:
@@ -104,9 +104,9 @@ the Bourne shell (sh)                    ``. util/quickstart/setchplenv.sh``
 
 9) All of the instructions above describe how to run Chapel programs
    in a single-locale (shared-memory) mode. To run using multiple
-   locales (distributed memory), please refer to `multilocale.rst`_.
+   locales (distributed memory), please refer to `doc/multilocale.rst`_.
 
-.. _multilocale.rst: http://chapel.cray.com/docs/1.13/usingchapel/multilocale.html
+.. _doc/multilocale.rst: http://chapel.cray.com/docs/1.13/usingchapel/multilocale.html
 
 
 10) If you plan to do performance studies of Chapel programs, be sure
@@ -123,12 +123,12 @@ What's next?
     platform-specific notes                     `platforms`_
     online Chapel Documentation                 `chapel.cray.com/docs`_
     example Chapel programs                     ``examples/README``
-    setting Chapel environment variables        `chplenv.rst`_
-    building the compiler                       `building.rst`_
-    compiling Chapel programs                   `compiling.rst`_
-    executing Chapel programs                   `executing.rst`_
-    debugging Chapel programs                   `debugging.rst`_
-    reporting bugs                              `bugs.rst`_
+    setting Chapel environment variables        `doc/chplenv.rst`_
+    building the compiler                       `doc/building.rst`_
+    compiling Chapel programs                   `doc/compiling.rst`_
+    executing Chapel programs                   `doc/executing.rst`_
+    debugging Chapel programs                   `doc/debugging.rst`_
+    reporting bugs                              `doc/bugs.rst`_
     implementation status                       ``STATUS``
     performance status                          ``PERFORMANCE.md``
     Chapel modes for emacs and vim              ``highlight/README.md``
@@ -138,8 +138,8 @@ What's next?
 
 .. _platforms: http://chapel.cray.com/docs/1.13/platforms/index.html
 .. _chapel.cray.com/docs: http://chapel.cray.com/docs/1.13/
-.. _building.rst: http://chapel.cray.com/docs/1.13/usingchapel/building.html
-.. _compiling.rst: http://chapel.cray.com/docs/1.13/usingchapel/compiling.html
-.. _executing.rst: http://chapel.cray.com/docs/1.13/usingchapel/executing.html
-.. _debugging.rst: http://chapel.cray.com/docs/1.13/usingchapel/debugging.html
-.. _bugs.rst: http://chapel.cray.com/docs/1.13/usingchapel/bugs.html
+.. _doc/building.rst: http://chapel.cray.com/docs/1.13/usingchapel/building.html
+.. _doc/compiling.rst: http://chapel.cray.com/docs/1.13/usingchapel/compiling.html
+.. _doc/executing.rst: http://chapel.cray.com/docs/1.13/usingchapel/executing.html
+.. _doc/debugging.rst: http://chapel.cray.com/docs/1.13/usingchapel/debugging.html
+.. _doc/bugs.rst: http://chapel.cray.com/docs/1.13/usingchapel/bugs.html

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ For more information about Chapel, refer to the following resources:
 =====================  ========================================
 Project homepage:      http://chapel.cray.com
 Installing Chapel:     http://chapel.cray.com/install.html
-Building from source:  `QUICKSTART.rst` (in this directory)
+Building from source:  `QUICKSTART.rst <QUICKSTART.rst>`_ (in this directory)
 Sample computations:   http://chapel.cray.com/hellos.html
 Learning Chapel:       http://chapel.cray.com/learning.html
 Filing bugs:           http://chapel.cray.com/bugs.html

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 .. image:: http://chapel.cray.com/images/cray-chapel-logo-200.png
     :align: center
 
-
-.. _chapelhome-readme:
-
 The Chapel Language
 ===================
 
@@ -13,46 +10,47 @@ Chapel is an emerging programming language designed for productive
 parallel computing at scale. Chapel's design and implementation have
 been undertaken with portability in mind, permitting Chapel to run on
 multicore desktops and laptops, commodity clusters, and the cloud, in
-addition to the high-end supercomputers for which it was designed.
-
-For a more detailed introduction to Chapel, refer to the project
-homepage at http://chapel.cray.com.
+addition to the high-end supercomputers for which it was originally
+undertaken.
 
 License
 -------
 Chapel is developed and released under the terms of the Apache 2.0
 license, though it also makes use of third-party packages under their
-own licensing terms.  See the LICENSE file for details.
+own licensing terms.  See the `LICENSE`_ file in this directory for
+details.
+
+Resources
+---------
+For more information about Chapel, refer to the following resources:
+
+* Project homepage:      http://chapel.cray.com
+* Installing Chapel:     http://chapel.cray.com/install.html
+* Building from source:  `QUICKSTART.rst`_ (in this directory)
+* Sample computations:   http://chapel.cray.com/hellos.html
+* Learning Chapel:       http://chapel.cray.com/learning.html
+* Filing bugs:           http://chapel.cray.com/bugs.html
+* Online documentation:  http://chapel.cray.com/docs/latest/
+* GitHub:                https://github.com/chapel-lang/chapel
+* Mailing lists:         https://sourceforge.net/p/chapel/mailman
+* Facebook:              https://www.facebook.com/ChapelLanguage
+* Twitter:               https://twitter.com/ChapelLanguage
 
 
-For more information
---------------------
-Here are some useful Chapel resources:
-
-* The Chapel project homepage:  http://chapel.cray.com
-
-* Installation instructions:    http://chapel.cray.com/install.html
-
-* How to build from source:     QUICKSTART.rst_ (in this directory)
-
-* Chapel sample computations:   http://chapel.cray.com/hellos.html
-
-* How to learn Chapel:          http://chapel.cray.com/learning.html
-
-* Filing bugs against Chapel:   http://chapel.cray.com/bugs.html
-
-* Online documentation:         http://chapel.cray.com/docs/latest/
-
-* Chapel's GitHub repository:   https://github.com/chapel-lang/chapel
-
-* community mailing lists:      https://sourceforge.net/p/chapel/mailman
-
-* Chapel Facebook page:         https://www.facebook.com/ChapelLanguage
-
-* Chapel Twitter feed:          https://twitter.com/ChapelLanguage
+* Building from source:  `QUICKSTART.rst <QUICKSTART.rst>`_ (in this directory)
 
 
+=====================  ========================================
+Project homepage:      http://chapel.cray.com
+Installing Chapel:     http://chapel.cray.com/install.html
+Building from source:  `QUICKSTART.rst`_ (in this directory)
+Sample computations:   http://chapel.cray.com/hellos.html
+Learning Chapel:       http://chapel.cray.com/learning.html
+Filing bugs:           http://chapel.cray.com/bugs.html
+Online documentation:  http://chapel.cray.com/docs/latest/
+GitHub:                https://github.com/chapel-lang/chapel
+Mailing lists:         https://sourceforge.net/p/chapel/mailman
+Facebook:              https://www.facebook.com/ChapelLanguage
+Twitter:               https://twitter.com/ChapelLanguage
+=====================  ========================================
 
-* How to build from source:     `QUICKSTART.rst_`
-
-* How to build from source:     <QUICKSTART.rst>

--- a/README.rst
+++ b/README.rst
@@ -7,22 +7,52 @@
 The Chapel Language
 ===================
 
-Chapel is an emerging programming language designed for productive parallel
-computing at scale. Chapel's design and implementation have been undertaken
-with portability in mind, permitting Chapel to run on multicore desktops and
-laptops, commodity clusters, and the cloud, in addition to the high-end
-supercomputers for which it was designed. Chapel's design and development are
-being led by `Cray Inc.`_ in collaboration with academia, computing centers,
-and industry. See `chapel.cray.com`_ for more information.
+What is Chapel?
+---------------
+Chapel is an emerging programming language designed for productive
+parallel computing at scale. Chapel's design and implementation have
+been undertaken with portability in mind, permitting Chapel to run on
+multicore desktops and laptops, commodity clusters, and the cloud, in
+addition to the high-end supercomputers for which it was designed.
 
-.. _Cray Inc.: http://www.cray.com/
-.. _chapel.cray.com: http://chapel.cray.com/
+For a more detailed introduction to Chapel, refer to the project
+homepage at http://chapel.cray.com.
 
-This is the 1.13.0 release of the Chapel compiler, intended to give
-potential users a look at what we're doing and the opportunity to
-provide us with feedback.  See the LICENSE file for the release's
-licensing terms.
+License
+-------
+Chapel is developed and released under the terms of the Apache 2.0
+license, though it also makes use of third-party packages under their
+own licensing terms.  See the LICENSE file for details.
 
+
+For more information
+--------------------
 Here are some useful Chapel resources:
 
 * The Chapel project homepage:  http://chapel.cray.com
+
+* Installation instructions:    http://chapel.cray.com/install.html
+
+* How to build from source:     QUICKSTART.rst_ (in this directory)
+
+* Chapel sample computations:   http://chapel.cray.com/hellos.html
+
+* How to learn Chapel:          http://chapel.cray.com/learning.html
+
+* Filing bugs against Chapel:   http://chapel.cray.com/bugs.html
+
+* Online documentation:         http://chapel.cray.com/docs/latest/
+
+* Chapel's GitHub repository:   https://github.com/chapel-lang/chapel
+
+* community mailing lists:      https://sourceforge.net/p/chapel/mailman
+
+* Chapel Facebook page:         https://www.facebook.com/ChapelLanguage
+
+* Chapel Twitter feed:          https://twitter.com/ChapelLanguage
+
+
+
+* How to build from source:     `QUICKSTART.rst_`
+
+* How to build from source:     <QUICKSTART.rst>

--- a/README.rst
+++ b/README.rst
@@ -24,22 +24,6 @@ Resources
 ---------
 For more information about Chapel, refer to the following resources:
 
-* Project homepage:      http://chapel.cray.com
-* Installing Chapel:     http://chapel.cray.com/install.html
-* Building from source:  `QUICKSTART.rst`_ (in this directory)
-* Sample computations:   http://chapel.cray.com/hellos.html
-* Learning Chapel:       http://chapel.cray.com/learning.html
-* Filing bugs:           http://chapel.cray.com/bugs.html
-* Online documentation:  http://chapel.cray.com/docs/latest/
-* GitHub:                https://github.com/chapel-lang/chapel
-* Mailing lists:         https://sourceforge.net/p/chapel/mailman
-* Facebook:              https://www.facebook.com/ChapelLanguage
-* Twitter:               https://twitter.com/ChapelLanguage
-
-
-* Building from source:  `QUICKSTART.rst <QUICKSTART.rst>`_ (in this directory)
-
-
 =====================  ========================================
 Project homepage:      http://chapel.cray.com
 Installing Chapel:     http://chapel.cray.com/install.html

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ details.
 
 Resources
 ---------
-For more information about Chapel, refer to the following resources:
+For more information about Chapel, please refer to the following resources:
 
 =====================  ========================================
 Project homepage:      http://chapel.cray.com
@@ -30,7 +30,7 @@ Installing Chapel:     http://chapel.cray.com/install.html
 Building from source:  `QUICKSTART.rst <QUICKSTART.rst>`_ (in this directory)
 Sample computations:   http://chapel.cray.com/hellos.html
 Learning Chapel:       http://chapel.cray.com/learning.html
-Filing bugs:           http://chapel.cray.com/bugs.html
+Reporting bugs:        http://chapel.cray.com/bugs.html
 Online documentation:  http://chapel.cray.com/docs/latest/
 GitHub:                https://github.com/chapel-lang/chapel
 Mailing lists:         https://sourceforge.net/p/chapel/mailman

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ For more information about Chapel, refer to the following resources:
 =====================  ========================================
 Project homepage:      http://chapel.cray.com
 Installing Chapel:     http://chapel.cray.com/install.html
-Building from source:  `QUICKSTART.rst`_ (in this directory)
+Building from source:  `QUICKSTART.rst` (in this directory)
 Sample computations:   http://chapel.cray.com/hellos.html
 Learning Chapel:       http://chapel.cray.com/learning.html
 Filing bugs:           http://chapel.cray.com/bugs.html

--- a/doc/release/bugs.rst
+++ b/doc/release/bugs.rst
@@ -29,13 +29,25 @@ Please include the following information in your email:
 
 A list of known bugs and unimplemented features can be found in
 ``$CHPL_HOME/STATUS``.  Even if you run into a known issue, we
-encourage you to email us a bug report, particularly if it is impeding
+encourage you to send us a bug report, particularly if it is impeding
 your progress.  Depending on the issue, we may be able to suggest a
-workaround or prioritize addressing the bug.
+workaround or to prioritize the development of a fix.
+
+
+Filing Futures
+--------------
+
+If you are a Chapel contributor and familiar with the `Chapel Testing
+System`_, you can file bugs by submitting `Future tests`_.
+
+.. _Chapel testing system: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst
+.. _Future tests: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst#futures-a-mechanism-for-tracking-bugs-feature-requests-etc
+
 
 JIRA Issues
 -----------
 
-The Chapel team is hard at work bringing the `JIRA issues site`_ up to date. Bugs can be viewed without a free account.
+The Chapel team is working to bring our `JIRA issues site`_ up to
+date. Bugs can be viewed without a free account.
 
 .. _JIRA issues site: https://chapel.atlassian.net/projects/CHAPEL/issues/


### PR DESCRIPTION
This PR:

* reduces the README down to a fairly minimal set of info for the release designed to cover the essentials, avoid replicating information for maintenance purposes, and working (nearly) equally well in both the GitHub "surf the repo" and download the tarball "open the README" modes, with some compromises in both cases.*  

* wordsmiths and attempts to tighten up the QuickStart instructions while making them work equally well under GitHub, the release tarball, and the online docs (not to say it didn't before -- I mostly had to avoid breaking things)

* adds a new section to the bugs file about how to file future tests for code contributors (since more and more people seem to be going down this route)


---

\* = There's an ongoing debate about how we might make the README snazzier / more like a project's landing page for the GitHub context without making it inaccessible in the tarball context (including having two READMEs -- ugh, making a feature request to GitHub (already filed and replied to), etc.).  But that'll be a discussion for another day since, once the release goes out, we can change README.md for the GitHub experience on a daily basis.