### PR TITLE
Skip planDFTmismatch under pgi

### DIFF
--- a/test/modules/standard/FFTW/SKIPIF
+++ b/test/modules/standard/FFTW/SKIPIF
@@ -1,8 +1,15 @@
 #!/usr/bin/env python
 
 #
-# skip this test when FFTW_DIR is not set
+# skip this test when FFTW_DIR is not set or we're using pgi (JIRA 195).
+#
+# See JIRA 195 for more info on why we skip with pgi:
+#    https://chapel.atlassian.net/browse/CHAPEL-195
 #
 
 import os
-print('FFTW_DIR' not in os.environ)
+
+missing_fftw_dir = 'FFTW_DIR' not in os.environ
+using_pgi = 'pgi' in os.getenv('CHPL_TARGET_COMPILER')
+
+print(missing_fftw_dir or using_pgi)


### PR DESCRIPTION
This test has been noisy, and is likely regressing because of a PGI bug that's
not worth investigating.

See JIRA 195 fore more info: https://chapel.atlassian.net/browse/CHAPEL-195