### PR TITLE
gen_release: fix broken symlinks in the Nightly "release" tarball

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -8,7 +8,9 @@ use File::Spec;
 use File::Temp qw/ tempdir /;
 
 sub SystemOrDie{
-  if (system(shift) != 0) {
+  $arg = shift;
+  print( "+ $arg \n");
+  if (system($arg) != 0) {
     die "Command failed with error code: $?";
   }
 }
@@ -21,8 +23,9 @@ while (@ARGV) {
 }
 
 if ($version eq "") {
+    $reldir = "chapel";
 } else {
-    $version = "-$version";
+    $reldir = "chapel-$version";
 }
 
 $origCwd = abs_path(cwd());
@@ -34,45 +37,35 @@ if (exists($ENV{"CHPL_HOME"})) {
 } else {
     $script_dir = dirname($0);
     $chplhome = abs_path("$script_dir/../..");
-
 }
 
+# pointers to temporary directory where chapel will be built
 
-# If CHPL_GEN_RELEASE_NO_CLONE is set in environment, do not clone the repo and
-# just use $CHPL_HOME as the work space.
-$no_clone = 0;
-$archive_dir = "";
-$resultdir = "";
-$reldir = "";
-$transform_args = "";
+$basetmpdir = File::Spec->tmpdir;
+if (exists($ENV{"CHPL_GEN_RELEASE_TMPDIR"})) {
+    $basetmpdir = $ENV{"CHPL_GEN_RELEASE_TMPDIR"};
+}
+$user = `whoami`;
+chomp($user);
+$tmpdir = tempdir("chapel-release.$user.deleteme.XXXXX", DIR => $basetmpdir, CLEANUP => 1);
+$archive_dir = "$tmpdir/$reldir";
+SystemOrDie("rm -rf $tmpdir");
+SystemOrDie("mkdir -pv $archive_dir");
+$rootdir = "$tmpdir/chpl_home";
+
+# If CHPL_GEN_RELEASE_NO_CLONE is set in environment, do not clone the repo
+# Just use whatever is found in $CHPL_HOME
+
 if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
-    $no_clone = 1;
-    $archive_dir = $chplhome;
-    $rootdir = $chplhome;
+
+    # copy the current CHPL_HOME into the directory where chapel will be built
+    print "Creating build workspace with tar...\n";
+    SystemOrDie("cd $chplhome && tar -cf - . | (cd $archive_dir && tar -xf -)");
+
     $resultdir = "$chplhome/tar";
-    $reldir = ".";
+} else {
 
-    $tar_version = `tar --version`;
-    if ( $tar_version =~ /bsd/ ) {
-        $transform_args = "-s '/./chapel$version/'";
-    } else {
-        $transform_args = "--transform 's/./chapel$version/'"
-    }
-}
-
-if ($no_clone == 0) {
-    # check out a clean copy of the sources into a temporary directory
-    $user = `whoami`;
-    chomp($user);
-
-    $basetmpdir = File::Spec->tmpdir;
-    if (exists($ENV{"CHPL_GEN_RELEASE_TMPDIR"})) {
-        $basetmpdir = $ENV{"CHPL_GEN_RELEASE_TMPDIR"};
-    }
-    $tmpdir = tempdir("chapel-release.$user.deleteme.XXXXX", DIR => $basetmpdir, CLEANUP => 1);
-
-    $reldir = "chapel$version";
-    $rootdir = "$tmpdir/$reldir";
+    # check out a clean copy of the sources into the directory where chapel will be built
     $git_url = $ENV{'CHPL_HOME_REPOSITORY'};
     if ($git_url eq "") {
         $git_url = "https://github.com/chapel-lang/chapel";
@@ -84,16 +77,10 @@ if ($no_clone == 0) {
     }
 
     print "Cloning the sources (repo: $git_url branch: $git_branch)...\n";
-    $clone_status = system("git clone --branch $git_branch $git_url $rootdir");
+    SystemOrDie("git clone --branch $git_branch $git_url $rootdir");
 
-    if ($clone_status != 0) {
-        print "Failed to clone repo.\n";
-        exit 1;
-    }
-
-    print "Creating git archive...\n";
-    $archive_dir = "$rootdir/$reldir";
-    system("cd $rootdir && git archive --format=tar HEAD | (mkdir -pv $archive_dir && cd $archive_dir && tar -xf -)");
+    print "Creating build workspace with git archive...\n";
+    SystemOrDie("cd $rootdir && git archive --format=tar HEAD | (cd $archive_dir && tar -xf -)");
 
     if (defined($ENV{"CHPL_HOME"})) {
         $resultdir = $ENV{"CHPL_HOME"};
@@ -205,36 +192,38 @@ SystemOrDie("cd runtime/include && rm -r sunos_old");
 print "Removing third-party directories that are not intended for release...\n";
 SystemOrDie("cd third-party && rm *.devel*");
 
-chdir "$rootdir";
+chdir "$archive_dir";
 
 print "Chmodding the hierarchy\n";
-SystemOrDie("chmod -R ugo+rX $reldir");
-SystemOrDie("chmod -R go-w $reldir");
+SystemOrDie("chmod -R ugo+rX .");
+SystemOrDie("chmod -R go-w .");
 
 foreach $file (@files) {
-    $dfile = "$reldir/$file";
-    if (!(-e $dfile)) {
-        print "$dfile does not exist\n";
+    if (!(-e $file)) {
+        print "$file does not exist\n";
         exit( 9);
     }
-    push @tarfiles, $dfile;
+    push @tarfiles, "$reldir/$file";
 }
 
 foreach $dir (@code_dirs) {
-    @filelist = `find $reldir/$dir`;
+    @filelist = `find $dir`;
     foreach $fullpath (@filelist) {
         chomp $fullpath;
         $file = $fullpath;
         $file =~ s/(\S+\/)+//g;
         if ($file =~ /(\.(h|cpp|c|ypp|lex)$)|Makefile|README|BUILD_VERSION/) {
             # print "$fullpath\n";
-            push @tarfiles, $fullpath;
+            push @tarfiles, "$reldir/$fullpath";
         }
     }
 }
 
 foreach $dir (@complete_dirs) {
-    push @tarfiles, "$reldir\/$dir";
+    if (!(-e $dir)) {
+        print "$dir does not exist\n";
+    }
+    push @tarfiles, "$reldir/$dir";
 }
 
 
@@ -243,10 +232,11 @@ if (! -d $resultdir) {
     mkpath($resultdir, 1);
 }
 
-$tarball_name = "$resultdir/chapel$version.tar.gz";
-$cmd = "tar -cz $transform_args -f $tarball_name @tarfiles";
+$tarball_name = "$resultdir/$reldir.tar.gz";
+$cmd = "tar -cz -f $tarball_name @tarfiles";
+chdir "..";
 print "$cmd\n";
-system ($cmd);
+SystemOrDie ($cmd);
 
 print "Left result in $tarball_name\n";
 


### PR DESCRIPTION
GNU tar --transform option resulted in broken symlinks.
Rewrite util/buildRelease/gen_release so it does not use --transform at all.