### PR TITLE
add 'checkdocs' make targets

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -22,6 +22,9 @@ develall: STATUS
 docs: module-docs
 	cd doc/sphinx && ./run-in-venv.bash ${MAKE} docs
 
+checkdocs: FORCE
+	cd doc/sphinx && ./run-in-venv.bash ${MAKE} check
+
 man: third-party-chpldoc-venv FORCE
 	cd man && $(MAKE)
 

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -20,10 +20,10 @@ develall: STATUS
 	@$(MAKE) always-build-man
 
 docs: module-docs
-	cd doc/sphinx && ./run-in-venv.bash ${MAKE} docs
+	cd doc/sphinx && $(MAKE) docs
 
 checkdocs: FORCE
-	cd doc/sphinx && ./run-in-venv.bash ${MAKE} check
+	cd doc/sphinx && $(MAKE) checkdocs
 
 man: third-party-chpldoc-venv FORCE
 	cd man && $(MAKE)

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -9,13 +9,17 @@ help-source:
 	@echo "Source Help:"
 	@echo "  symlinks-docs to symlink doc/release contents to source"
 
-docs: html
+docs: FORCE
+	./run-in-venv.bash $(MAKE) html
 
 symlink-docs: clean-symlink-docs
 	@echo "Setting up symlinks from /doc/release to /doc/sphinx/source"
 	./symlinks.py
 	cp  ../release/quickReference.pdf     source/language/quickReference.pdf
 	cp  ../release/chapelLanguageSpec.pdf source/language/chapelLanguageSpec.pdf
+
+checkdocs: FORCE
+	./run-in-venv.bash $(MAKE) check
 
 clean: clean-source
 


### PR DESCRIPTION
Prior to this commit, it was necessary to run 'make check' on the
sphinx-generated docs from within the docs/sphinx/ directory, and
to have sphinx available in your environment.  This commit adds a
top-level 'checkdocs' target for developers that is symmetrical to
the 'docs' target in that it uses run-in-venv to ensure that sphinx is
loaded.

On BenA's request, this change also pushes the 'run-in-venv'
invocations down to the doc/sphinx/Makefile so that 'make docs'
can be run there without having sphinx in your environment, and
introduces a 'checkdocs' target to that Makefile for symmetry with
the top-level Makefile targets.