### PR TITLE
Change this link so that 'make checkdocs' won't complain about it

### DIFF
--- a/doc/release/bugs.rst
+++ b/doc/release/bugs.rst
@@ -41,7 +41,7 @@ If you are a Chapel contributor and familiar with the `Chapel Testing
 System`_, you can file bugs by submitting `Future tests`_.
 
 .. _Chapel testing system: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst
-.. _Future tests: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst#futures-a-mechanism-for-tracking-bugs-feature-requests-etc
+.. _Future tests: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst#user-content-futures-a-mechanism-for-tracking-bugs-feature-requests-etc
 
 
 JIRA Issues


### PR DESCRIPTION
I'm not entirely sure why, but even though this anchor seems to work, our docs checks don't seem to be happy about it.  Examining the way GitHub renders .rst as html, it seems to insert a "user-content" string in the "<a name =" tag and putting that in makes the link checker happy.  Who am I to question...?