### PR TITLE
Link parent indiv links2

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2700,11 +2700,7 @@ void ModuleSymbol::printDocs(std::ostream *file, unsigned int tabs) {
   this->printTabs(file, tabs + 1);
   *file << "use ";
 
-  *file << this->getUsage() << ";" << std::endl;
-
-  if (!fDocsTextOnly) {
-    *file << std::endl;
-  }
+  *file << this->getUsage() << ";" << std::endl << std::endl;
 
   // If we had submodules, be sure to link to them
   if (hasTopLevelModule()) {

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2691,6 +2691,21 @@ void ModuleSymbol::printDocs(std::ostream *file, unsigned int tabs) {
     *file << std::endl;
   }
 
+  if (!fDocsTextOnly) {
+    *file << "**Usage**" << std::endl << std::endl;
+  } else {
+    *file << std::endl;
+    *file << "Usage:" << std::endl;
+  }
+  this->printTabs(file, tabs + 1);
+  *file << "use ";
+
+  *file << this->getUsage() << ";" << std::endl;
+
+  if (!fDocsTextOnly) {
+    *file << std::endl;
+  }
+
   // If we had submodules, be sure to link to them
   if (hasTopLevelModule()) {
     this->printTableOfContents(file);
@@ -2873,6 +2888,32 @@ bool ModuleSymbol::hasTopLevelModule() {
   }
   return false;
 }
+
+std::string ModuleSymbol::getUsage() {
+  std::string parent;
+
+  if (!this->defPoint || !this->defPoint->parentSymbol ||
+      !toModuleSymbol(this->defPoint->parentSymbol) ||
+      this->defPoint->parentSymbol == theProgram ||
+      this->defPoint->parentSymbol == rootModule) {
+    // We're a top level module
+    parent = "";
+  } else {
+    // We have a parent module
+    parent = toModuleSymbol(this->defPoint->parentSymbol)->getUsage() + ".";
+  }
+
+  if (!fDocsTextOnly) {
+    if (parent != "") {
+      parent = parent + " ";
+      // Space separator necessary for link to later modules to work
+    }
+    return parent + ":mod:`" + name + "`";
+  } else {
+    return parent + name;
+  }
+}
+
 
 void ModuleSymbol::replaceChild(BaseAST* old_ast, BaseAST* new_ast) {
   if (old_ast == block) {

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -496,6 +496,7 @@ public:
 private:
   void                 getTopLevelConfigOrVariables(Vec<VarSymbol *> *contain, Expr *expr, bool config);
   bool                 hasTopLevelModule();
+  std::string          getUsage();
 };
 
 /******************************** | *********************************

--- a/modules/dists/fixDistDocs.perl
+++ b/modules/dists/fixDistDocs.perl
@@ -57,6 +57,19 @@ sub process {
          my $next = <RST>;
          $next =~ /^=+$/ or die "Expected an underline after module name, got $next";
          print MOD $next;
+
+         my $usageFirstLine = <RST>;
+         $usageFirstLine =~ /^\*\*Usage\*\*/ or die "Expected usage information, got $usageFirstLine";
+         print MOD $usageFirstLine;
+         # the next three lines are anticipated to be a continuation of the
+         # usage output.  We don't really need to validate that, that's what our
+         # testing system is for.
+         my $usageNextLine = <RST>;
+         print MOD $usageNextLine;
+         $usageNextLine = <RST>;
+         print MOD $usageNextLine;
+         $usageNextLine = <RST>;
+         print MOD $usageNextLine;
          last;
       }
    }

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -95,7 +95,16 @@ function removePrefixVariables() {
   removePattern "var chpl_" $1
 }
 
+# remove Usage information
+function removeUsage() {
+  if [ $# -ne 1 ] || [ ! -f $1 ]; then
+    echo "Bad call to removeUsage."
+    exit 1;
+  fi
 
+  sed -e '/\*\*Usage\*\*/,+3d' $1 > $1.tmp
+  mv $1.tmp $1
+}
 
 #############################################################
 ## Modules to fixup listed in INTERNAL_MODULES_TO_DOCUMENT ##
@@ -108,12 +117,13 @@ removePrefixFunctions $file
 removePattern "param size" $file
 removePattern "record:: _tuple" $file
 fixTitle "Tuples" $file
-
+removeUsage $file
 
 ## ChapelIO ##
 
 file="./ChapelIO.rst"
 fixTitle "IO Support" $file
+removeUsage $file
 
 ## End ChapelIO ##
 
@@ -123,6 +133,7 @@ fixTitle "IO Support" $file
 file="./ChapelIteratorSupport.rst"
 removePrefixFunctions $file
 fixTitle "Vectorizing Iterator" $file
+removeUsage $file
 
 
 ## End ChapelIteratorSupport ##
@@ -134,6 +145,7 @@ file="./ChapelLocale.rst"
 fixTitle "Locales" $file
 replace "LocaleSpace = chpl__buildDomainExpr(0..numLocales-1)" \
         "LocaleSpace = {0..numLocales-1}" $file
+removeUsage $file
 
 
 ## End ChapelLocale ##
@@ -146,6 +158,7 @@ replace "_syncvar" "sync" $file
 replace "_singlevar" "single" $file
 removePrefixFunctions $file
 fixTitle "Synchronization Variables" $file
+removeUsage $file
 
 ## End ChapelSyncvar ##
 
@@ -160,6 +173,7 @@ removePrefixFunctions $file
 removePrefixVariables $file
 
 fixTitle "Domain and Array Operations" $file
+removeUsage $file
 
 ## End ChapelArray ##
 
@@ -180,6 +194,7 @@ replace "atomic_int64" "atomic \(T\)" $file
 replace "int(64)" "T" $file
 
 fixTitle "Atomics" $file
+removeUsage $file
 
 ## End Atomics ##
 
@@ -189,6 +204,7 @@ file="./ChapelRange.rst"
 
 removePrefixFunctions $file
 fixTitle "Ranges" $file
+removeUsage $file
 
 # End ChapelRange ##
 
@@ -198,6 +214,7 @@ file="./ChapelComplex_forDocs.rst"
 
 removePrefixFunctions $file
 fixTitle "Complex" $file
+removeUsage $file
 
 # End ChapelComplex_forDocs ##
 
@@ -205,6 +222,7 @@ fixTitle "Complex" $file
 
 file="./String.rst"
 fixTitle "Strings" $file
+removeUsage $file
 
 ## End of String ##
 
@@ -214,6 +232,7 @@ file="./UtilMisc_forDocs.rst"
 
 removePrefixFunctions $file
 fixTitle "Misc Functions" $file
+removeUsage $file
 
 # End UtilMisc_forDocs ##
 
@@ -222,5 +241,6 @@ fixTitle "Misc Functions" $file
 file="./ChapelEnv.rst"
 fixTitle "Chapel Environment Variables" $file
 replace " = AppendExpr.Call09" "" $file
+removeUsage $file
 
 ## End of ChapelEnv##

--- a/modules/standard/Assert.chpl
+++ b/modules/standard/Assert.chpl
@@ -21,11 +21,11 @@
 /*
   Support for simple assert() routines.
 
-  In the current implementation, these asserts never become no-ops.  That is,
-  using them will always incur execution-time checks.
-
   .. note:: All Chapel programs automatically ``use`` this module by default.
             An explicit ``use`` statement is not necessary.
+
+  In the current implementation, these asserts never become no-ops.  That is,
+  using them will always incur execution-time checks.
 
 */
 module Assert {

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -20,6 +20,9 @@
 /*
 This module provides mathematical constants and functions.
 
+.. note:: All Chapel programs automatically ``use`` this module by default.
+          An explicit ``use`` statement is not necessary.
+
 It includes wrappers for many of the constants in functions in
 the C Math library, which is part of the C Language Standard (ISO/IEC 9899)
 as described in Section 7.12.  Please consult that standard for an
@@ -41,9 +44,6 @@ handling in the Math module.  The default behavior is as if the macro
 ``math_errhandling`` is set to 0: Given erroneous input at run-time,
 all math functions will return an implementation-defined value; no
 exception will be generated.
-
-.. note:: All Chapel programs automatically ``use`` this module by default.
-          An explicit ``use`` statement is not necessary.
 
 */
 module Math {

--- a/test/chpldoc/basics/disconnectedComment.doc.good
+++ b/test/chpldoc/basics/disconnectedComment.doc.good
@@ -1,4 +1,8 @@
 unattached
+
+Usage:
+   use unattached;
+
    This comment should be attached to unattached but not reallyCommentless, 
    even when before the defined module 
    proc reallyCommentless()

--- a/test/chpldoc/basics/empty.doc.good
+++ b/test/chpldoc/basics/empty.doc.good
@@ -1,4 +1,8 @@
 empty.doc
+
+Usage:
+   use empty.doc;
+
    proc noComment()
    proc noBody()
    proc noBodyButArgs(num: int, bleah: bool)

--- a/test/chpldoc/basics/fullyCommented.doc.good
+++ b/test/chpldoc/basics/fullyCommented.doc.good
@@ -1,4 +1,8 @@
 fullyCommented.doc
+
+Usage:
+   use fullyCommented.doc;
+
 Submodules for this module are located in the fullyCommented.doc/ directory
 
    proc method1()
@@ -14,6 +18,10 @@ Submodules for this module are located in the fullyCommented.doc/ directory
       Comment for method with argument and body 
 
 Other
+
+Usage:
+   use fullyCommented.doc.Other;
+
    proc inside
       Comment for method inside module 
 

--- a/test/chpldoc/basics/hello.doc.good
+++ b/test/chpldoc/basics/hello.doc.good
@@ -1,4 +1,8 @@
 hello.doc
+
+Usage:
+   use hello.doc;
+
    proc hello()
       This method prints out a greeting.
 

--- a/test/chpldoc/basics/interruptingComment.doc.good
+++ b/test/chpldoc/basics/interruptingComment.doc.good
@@ -1,4 +1,8 @@
 interruptingComment.doc
+
+Usage:
+   use interruptingComment.doc;
+
    Record: R
       proc write()
       proc otherFunc()

--- a/test/chpldoc/basics/longerComments.doc.good
+++ b/test/chpldoc/basics/longerComments.doc.good
@@ -1,4 +1,8 @@
 longerComments.doc
+
+Usage:
+   use longerComments.doc;
+
 Submodules for this module are located in the longerComments.doc/ directory
 
    proc method1()
@@ -20,6 +24,10 @@ Submodules for this module are located in the longerComments.doc/ directory
       defined module 
 
 Other
+
+Usage:
+   use longerComments.doc.Other;
+
    proc inside
       This is a comment for a method inside of
       a module 

--- a/test/chpldoc/basics/main.doc.good
+++ b/test/chpldoc/basics/main.doc.good
@@ -1,4 +1,8 @@
 main
+
+Usage:
+   use main;
+
    This is the only valid doc string in this modules. 
 
    proc foo()

--- a/test/chpldoc/basics/nestFunctions.doc.good
+++ b/test/chpldoc/basics/nestFunctions.doc.good
@@ -1,4 +1,8 @@
 nestFunctions.doc
+
+Usage:
+   use nestFunctions.doc;
+
    proc outer()
       This the comment for the outer function 
 

--- a/test/chpldoc/basics/parenthesesLess.doc.good
+++ b/test/chpldoc/basics/parenthesesLess.doc.good
@@ -1,4 +1,8 @@
 parenthesesLess.doc
+
+Usage:
+   use parenthesesLess.doc;
+
    proc foo
    proc bar: bool
    proc foo2

--- a/test/chpldoc/basics/sparselyCommented.doc.good
+++ b/test/chpldoc/basics/sparselyCommented.doc.good
@@ -1,4 +1,8 @@
 sparselyCommented.doc
+
+Usage:
+   use sparselyCommented.doc;
+
 Submodules for this module are located in the sparselyCommented.doc/ directory
 
    proc method1()
@@ -18,6 +22,10 @@ Submodules for this module are located in the sparselyCommented.doc/ directory
 
    proc argAndBodyCommentless(val: int)
 Other
+
+Usage:
+   use sparselyCommented.doc.Other;
+
    proc inside()
       Comment for method inside module 
 

--- a/test/chpldoc/classes/basic.doc.good
+++ b/test/chpldoc/classes/basic.doc.good
@@ -1,4 +1,8 @@
 basic
+
+Usage:
+   use basic;
+
 Submodules for this module are located in the basic/ directory
 
    This is the module that Lydia built 
@@ -6,6 +10,10 @@ Submodules for this module are located in the basic/ directory
       This is the proc that lies in the module that Lydia built 
 
 sadAndAlone
+
+Usage:
+   use basic.sadAndAlone;
+
 Submodules for this module are located in the sadAndAlone/ directory
 
    This is the module all sad and alone, listed behind the proc
@@ -16,6 +24,10 @@ Submodules for this module are located in the sadAndAlone/ directory
       that Lydia built 
 
 classesAreGrown
+
+Usage:
+   use basic.sadAndAlone.classesAreGrown;
+
    This is the module whose classes are grown, sister of the
    class with nary a tone, declared in the module all sad and
    alone, listed behind the proc that lies in the module that

--- a/test/chpldoc/classes/fieldInheritance.doc.good
+++ b/test/chpldoc/classes/fieldInheritance.doc.good
@@ -1,4 +1,8 @@
 fieldInheritance.doc
+
+Usage:
+   use fieldInheritance.doc;
+
    Class: Elder
       This class has two fields 
 

--- a/test/chpldoc/classes/fields.doc.good
+++ b/test/chpldoc/classes/fields.doc.good
@@ -1,4 +1,8 @@
 fields.doc
+
+Usage:
+   use fields.doc;
+
    Class: fullOfFields
       type eltType
          This is a generic type. 

--- a/test/chpldoc/classes/inheritance.doc.good
+++ b/test/chpldoc/classes/inheritance.doc.good
@@ -1,4 +1,8 @@
 inheritance.doc
+
+Usage:
+   use inheritance.doc;
+
    Class: Grandparent
       The eldest 
 

--- a/test/chpldoc/classes/methodOutsideClassDef.doc.good
+++ b/test/chpldoc/classes/methodOutsideClassDef.doc.good
@@ -1,4 +1,8 @@
 methodOutsideClassDef.doc
+
+Usage:
+   use methodOutsideClassDef.doc;
+
    Class: Foo
       This class will declare a method inside itself, but will have a
       method declared outside it as well 

--- a/test/chpldoc/classes/methods.doc.good
+++ b/test/chpldoc/classes/methods.doc.good
@@ -1,4 +1,8 @@
 methods.doc
+
+Usage:
+   use methods.doc;
+
    Class: fullOfMethods
       proc commented()
          This is just a normal method with a comment.  I shouldn't

--- a/test/chpldoc/classes/multipleInheritance.doc.good
+++ b/test/chpldoc/classes/multipleInheritance.doc.good
@@ -1,4 +1,8 @@
 multipleInheritance.doc
+
+Usage:
+   use multipleInheritance.doc;
+
    Class: Mother
       proc eyes()
          One of Mother's methods 

--- a/test/chpldoc/classes/paramFields.doc.good
+++ b/test/chpldoc/classes/paramFields.doc.good
@@ -1,4 +1,8 @@
 paramFields.doc
+
+Usage:
+   use paramFields.doc;
+
    Class: hasParams
       param typeless
       param docTyped: int

--- a/test/chpldoc/classes/typeMethods.doc.good
+++ b/test/chpldoc/classes/typeMethods.doc.good
@@ -1,4 +1,8 @@
 typeMethods.doc
+
+Usage:
+   use typeMethods.doc;
+
    Class: Foo
       proc type biff()
          A type method declared inside the class Foo 

--- a/test/chpldoc/compflags/alphabetical/paramVars.doc.good
+++ b/test/chpldoc/compflags/alphabetical/paramVars.doc.good
@@ -1,4 +1,8 @@
 hasGlobalParams.doc
+
+Usage:
+   use hasGlobalParams.doc;
+
    This module has some global scoped params. 
    param first
    param fourth: bool

--- a/test/chpldoc/compflags/alphabetical/typeVars.doc.good
+++ b/test/chpldoc/compflags/alphabetical/typeVars.doc.good
@@ -1,4 +1,8 @@
 hasGlobalTypes.doc
+
+Usage:
+   use hasGlobalTypes.doc;
+
    This module has some global scoped types. 
    type first
    type second

--- a/test/chpldoc/compflags/alphabetical/variables.doc.good
+++ b/test/chpldoc/compflags/alphabetical/variables.doc.good
@@ -1,4 +1,8 @@
 hasGlobalVariables.doc
+
+Usage:
+   use hasGlobalVariables.doc;
+
    This module has some global scoped variables. 
    var fifth
       This variable has an associated comment and a value 

--- a/test/chpldoc/compflags/comment/basic.doc.good
+++ b/test/chpldoc/compflags/comment/basic.doc.good
@@ -1,4 +1,8 @@
 basic.doc
+
+Usage:
+   use basic.doc;
+
    proc commented()
       This is one way to make your own comment 
 

--- a/test/chpldoc/compflags/comment/loseComments.doc.good
+++ b/test/chpldoc/compflags/comment/loseComments.doc.good
@@ -1,2 +1,6 @@
 loseComments.doc
+
+Usage:
+   use loseComments.doc;
+
    proc found()

--- a/test/chpldoc/compflags/comment/specifiedDefault.doc.good
+++ b/test/chpldoc/compflags/comment/specifiedDefault.doc.good
@@ -1,4 +1,8 @@
 specifiedDefault.doc
+
+Usage:
+   use specifiedDefault.doc;
+
    proc found()
       This comment should be seen 
 

--- a/test/chpldoc/compflags/folder/oneWord.doc.good
+++ b/test/chpldoc/compflags/folder/oneWord.doc.good
@@ -1,4 +1,8 @@
 oneWord.doc
+
+Usage:
+   use oneWord.doc;
+
    proc dummy()
       Should be located in myDocs/unspecified.txt 
 

--- a/test/chpldoc/compflags/folder/save-sphinx/deepNestModules.doc.good
+++ b/test/chpldoc/compflags/folder/save-sphinx/deepNestModules.doc.good
@@ -4,6 +4,10 @@
 
 Foo
 ===
+**Usage**
+
+   use :mod:`Foo`;
+
 **Submodules**
 
 .. toctree::
@@ -20,5 +24,9 @@ Foo
 
 Bar
 ===
+**Usage**
+
+   use :mod:`Foo`. :mod:`Bar`;
+
 .. function:: proc baz()
 

--- a/test/chpldoc/compflags/folder/withHyphen.doc.good
+++ b/test/chpldoc/compflags/folder/withHyphen.doc.good
@@ -1,4 +1,8 @@
 withHyphen.doc
+
+Usage:
+   use withHyphen.doc;
+
    proc example()
       This should end up in my-docs/withHyphen.txt 
 

--- a/test/chpldoc/compflags/folder/withUnderscore.doc.good
+++ b/test/chpldoc/compflags/folder/withUnderscore.doc.good
@@ -1,4 +1,8 @@
 withUnderscore.doc
+
+Usage:
+   use withUnderscore.doc;
+
    proc example()
       This should end up in my_docs/withUnderscore.txt 
 

--- a/test/chpldoc/devel/classMethods.doc.good
+++ b/test/chpldoc/devel/classMethods.doc.good
@@ -1,4 +1,8 @@
 classMethods.doc
+
+Usage:
+   use classMethods.doc;
+
    proc method(_mt: _MT, this: named)
        This method has a comment 
 

--- a/test/chpldoc/devel/hello.doc.good
+++ b/test/chpldoc/devel/hello.doc.good
@@ -1,4 +1,8 @@
 hello.doc
+
+Usage:
+   use hello.doc;
+
    proc hello()
       This method prints out a greeting.
 

--- a/test/chpldoc/enum.doc.good
+++ b/test/chpldoc/enum.doc.good
@@ -1,4 +1,8 @@
 enum.doc
+
+Usage:
+   use enum.doc;
+
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/enum/docConstants.doc.good
+++ b/test/chpldoc/enum/docConstants.doc.good
@@ -1,4 +1,8 @@
 docConstants.doc
-   enum Color { Red, Yellow }
+ 
+Usage:
+   use docConstants.doc;
+
+  enum Color { Red, Yellow }
       enum documentation 
 

--- a/test/chpldoc/globals/constants.doc.good
+++ b/test/chpldoc/globals/constants.doc.good
@@ -1,4 +1,8 @@
 hasGlobalConstants
+
+Usage:
+   use hasGlobalConstants;
+
    This module has some global scoped constants. 
    const first: int
    const second = 16

--- a/test/chpldoc/globals/enums.doc.good
+++ b/test/chpldoc/globals/enums.doc.good
@@ -1,4 +1,8 @@
 enums.doc
+
+Usage:
+   use enums.doc;
+
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/globals/globalOrdering.doc.good
+++ b/test/chpldoc/globals/globalOrdering.doc.good
@@ -1,4 +1,8 @@
 globalOrdering.doc
+
+Usage:
+   use globalOrdering.doc;
+
    config var goop: bool
       hello 
    param after = 35

--- a/test/chpldoc/globals/paramVars.doc.good
+++ b/test/chpldoc/globals/paramVars.doc.good
@@ -1,4 +1,8 @@
 hasGlobalParams
+
+Usage:
+   use hasGlobalParams;
+
    This module has some global scoped params. 
    param first = 16
    param second: bool = false

--- a/test/chpldoc/globals/typeVars.doc.good
+++ b/test/chpldoc/globals/typeVars.doc.good
@@ -1,4 +1,8 @@
 hasGlobalTypes
+
+Usage:
+   use hasGlobalTypes;
+
    This module has some global scoped types. 
    type first = bool
    type second = int(64)

--- a/test/chpldoc/globals/variables.doc.good
+++ b/test/chpldoc/globals/variables.doc.good
@@ -1,4 +1,8 @@
 hasGlobalVariables
+
+Usage:
+   use hasGlobalVariables;
+
    This module has some global scoped variables. 
    var first: int
    var second = 16

--- a/test/chpldoc/intents.doc.good
+++ b/test/chpldoc/intents.doc.good
@@ -1,4 +1,8 @@
 intents.doc
+
+Usage:
+   use intents.doc;
+
 Submodules for this module are located in the intents.doc/ directory
 
    proc one(in val)
@@ -47,6 +51,10 @@ Submodules for this module are located in the intents.doc/ directory
       This function has a return intent (other than ref) and a body 
 
 Inner
+
+Usage:
+   use intents.doc.Inner;
+
    proc one(in val)
       This function has an argument with the in intent 
 

--- a/test/chpldoc/iterators.doc.good
+++ b/test/chpldoc/iterators.doc.good
@@ -1,4 +1,8 @@
 iterators.doc
+
+Usage:
+   use iterators.doc;
+
    iter body()
       This iterator should output its comment 
 

--- a/test/chpldoc/linkage-spec/exportTest.doc.good
+++ b/test/chpldoc/linkage-spec/exportTest.doc.good
@@ -1,4 +1,8 @@
 exportTest.doc
+
+Usage:
+   use exportTest.doc;
+
 Submodules for this module are located in the exportTest.doc/ directory
 
    export proc method1()
@@ -39,6 +43,10 @@ Submodules for this module are located in the exportTest.doc/ directory
 
    export proc allThreeCommentless2(val: int): int
 Other
+
+Usage:
+   use exportTest.doc.Other;
+
    export proc inside()
       Comment for method inside module 
 

--- a/test/chpldoc/linkage-spec/externTest.doc.good
+++ b/test/chpldoc/linkage-spec/externTest.doc.good
@@ -1,4 +1,8 @@
 externTest.doc
+
+Usage:
+   use externTest.doc;
+
 Submodules for this module are located in the externTest.doc/ directory
 
    proc method1()
@@ -23,6 +27,10 @@ Submodules for this module are located in the externTest.doc/ directory
 
    proc hasReturnTypeAndArgCommentless(val: int): int
 Other
+
+Usage:
+   use externTest.doc.Other;
+
    proc inside
       Comment for method inside module 
 

--- a/test/chpldoc/linkage-spec/inlineTest.doc.good
+++ b/test/chpldoc/linkage-spec/inlineTest.doc.good
@@ -1,4 +1,8 @@
 inlineTest.doc
+
+Usage:
+   use inlineTest.doc;
+
 Submodules for this module are located in the inlineTest.doc/ directory
 
    proc method1()
@@ -39,6 +43,10 @@ Submodules for this module are located in the inlineTest.doc/ directory
 
    proc allThreeCommentless(val: int): int
 Other
+
+Usage:
+   use inlineTest.doc.Other;
+
    proc inside
       Comment for inline method inside module 
 

--- a/test/chpldoc/module/config.doc.good
+++ b/test/chpldoc/module/config.doc.good
@@ -1,4 +1,8 @@
 config.doc
+
+Usage:
+   use config.doc;
+
    config var normal = "hello"
       This is a normal config var 
    config param other = 1

--- a/test/chpldoc/module/defaultModule.doc.good
+++ b/test/chpldoc/module/defaultModule.doc.good
@@ -1,4 +1,8 @@
 defaultModule.doc
+
+Usage:
+   use defaultModule.doc;
+
    proc foo()
       This proc doesn't matter very much 
 

--- a/test/chpldoc/module/module.doc.good
+++ b/test/chpldoc/module/module.doc.good
@@ -1,21 +1,45 @@
 M
+
+Usage:
+   use M;
+
    This module has a comment 
    proc commentless()
 N
+
+Usage:
+   use N;
+
    So does this module 
    proc hasArgCommentless(val: int)
 O
+
+Usage:
+   use O;
+
    And this one 
    proc hasBodyCommentless()
 P
+
+Usage:
+   use P;
+
    What?  Even this one! 
    proc hasBodyAndArgCommentless(val: int)
    proc useless()
 Q
+
+Usage:
+   use Q;
+
    proc main()
       Sadly, this method's module does not 
 
 R
+
+Usage:
+   use R;
+
    proc furthermore()
       Nor this method's module 
 

--- a/test/chpldoc/module/nestModules.doc.good
+++ b/test/chpldoc/module/nestModules.doc.good
@@ -1,10 +1,22 @@
 outer
+
+Usage:
+   use outer;
+
 Submodules for this module are located in the outer/ directory
 
    This is the outer module's comment 
 inner
+
+Usage:
+   use outer.inner;
+
 Submodules for this module are located in the inner/ directory
 
    This is the inner module's comment 
 innermost
+
+Usage:
+   use outer.inner.innermost;
+
    This is the innermost module's comment 

--- a/test/chpldoc/module/nestWithFns.doc.good
+++ b/test/chpldoc/module/nestWithFns.doc.good
@@ -1,4 +1,8 @@
 OuterMod
+
+Usage:
+   use OuterMod;
+
 Submodules for this module are located in the OuterMod/ directory
 
    This module has a comment, but uncommented first method 
@@ -7,6 +11,10 @@ Submodules for this module are located in the OuterMod/ directory
       The second method is commented 
 
 Inner
+
+Usage:
+   use OuterMod.Inner;
+
    proc innerFn()
       This module has no comment, but it's inner function does! 
 

--- a/test/chpldoc/module/ordering.doc.good
+++ b/test/chpldoc/module/ordering.doc.good
@@ -1,4 +1,8 @@
 ordering.doc
+
+Usage:
+   use ordering.doc;
+
    proc second()
       This is a proc... 
 

--- a/test/chpldoc/module/ordering.logical.doc.good
+++ b/test/chpldoc/module/ordering.logical.doc.good
@@ -1,4 +1,8 @@
 ordering
+
+Usage:
+   use ordering;
+
    config var first: string
       This config var should be printed first 
    proc second()

--- a/test/chpldoc/module/sameName.doc.good
+++ b/test/chpldoc/module/sameName.doc.good
@@ -1,10 +1,18 @@
 sameName.doc
+
+Usage:
+   use sameName.doc;
+
 Submodules for this module are located in the sameName.doc/ directory
 
    proc outerFn()
       This function is outside the defined module 
 
 sameName
+
+Usage:
+   use sameName.doc.sameName;
+
    This module has the same name as its file but doesn't
    contain all the code within the file 
    proc innerFn()

--- a/test/chpldoc/module/sameName2.doc.good
+++ b/test/chpldoc/module/sameName2.doc.good
@@ -1,4 +1,8 @@
 sameName2
+
+Usage:
+   use sameName2;
+
    This module with the same name actually contains all 
    the code in the file 
    proc inner()

--- a/test/chpldoc/module/surroundingModule.doc.good
+++ b/test/chpldoc/module/surroundingModule.doc.good
@@ -1,4 +1,8 @@
 surroundingModule.doc
+
+Usage:
+   use surroundingModule.doc;
+
 Submodules for this module are located in the surroundingModule.doc/ directory
 
    proc before()
@@ -8,6 +12,10 @@ Submodules for this module are located in the surroundingModule.doc/ directory
       This comment and its proc lies after the defined module 
 
 Middle
+
+Usage:
+   use surroundingModule.doc.Middle;
+
    proc inside()
       This comment and its proc lies inside the defined module 
 

--- a/test/chpldoc/multifile.doc.good
+++ b/test/chpldoc/multifile.doc.good
@@ -1,9 +1,17 @@
 first
+
+Usage:
+   use first;
+
    This module uses another module in a separate file 
    proc main()
       This function calls the other module's function 
 
 second
+
+Usage:
+   use second;
+
    proc method()
       This method is called by a method in another file 
 

--- a/test/chpldoc/nodoc/noDocPlease.doc.good
+++ b/test/chpldoc/nodoc/noDocPlease.doc.good
@@ -1,4 +1,8 @@
 Foo
+
+Usage:
+   use Foo;
+
    config var blah4: int
    proc d()
    Class: bar

--- a/test/chpldoc/nodoc/privateClasses.doc.good
+++ b/test/chpldoc/nodoc/privateClasses.doc.good
@@ -1,3 +1,7 @@
 privateClasses
+
+Usage:
+   use privateClasses;
+
    Class: bar
       var showMe: bool

--- a/test/chpldoc/nodoc/privatePlease.doc.good
+++ b/test/chpldoc/nodoc/privatePlease.doc.good
@@ -1,4 +1,8 @@
 Bar
+
+Usage:
+   use Bar;
+
    config var blah3: int
    proc c()
 cat: docs/toBeIgnored.txt: No such file or directory

--- a/test/chpldoc/nodoc/privateTypeAlias.doc.good
+++ b/test/chpldoc/nodoc/privateTypeAlias.doc.good
@@ -1,1 +1,5 @@
 privateTypeAlias
+
+Usage:
+   use privateTypeAlias;
+

--- a/test/chpldoc/types/arguments/arrays.doc.good
+++ b/test/chpldoc/types/arguments/arrays.doc.good
@@ -1,4 +1,8 @@
 arrays.doc
+
+Usage:
+   use arrays.doc;
+
    proc smallArray(val: [1..4] bool)
       This method takes an array of bools as an argument 
 

--- a/test/chpldoc/types/arguments/domains.doc.good
+++ b/test/chpldoc/types/arguments/domains.doc.good
@@ -1,4 +1,8 @@
 domains.doc
+
+Usage:
+   use domains.doc;
+
    proc baseCase(dom: domain(1))
       This proc takes in a one dimensional array 
 

--- a/test/chpldoc/types/arguments/enums.doc.good
+++ b/test/chpldoc/types/arguments/enums.doc.good
@@ -1,4 +1,8 @@
 enums.doc
+
+Usage:
+   use enums.doc;
+
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/types/arguments/explicitImplicit.doc.good
+++ b/test/chpldoc/types/arguments/explicitImplicit.doc.good
@@ -1,4 +1,8 @@
 explicitImplicit.doc
+
+Usage:
+   use explicitImplicit.doc;
+
    proc foo(bar: int)
       This proc has an explicit type argument of type int 
 

--- a/test/chpldoc/types/arguments/methodCall.doc.good
+++ b/test/chpldoc/types/arguments/methodCall.doc.good
@@ -1,4 +1,8 @@
 methodCall.doc
+
+Usage:
+   use methodCall.doc;
+
    proc nada() type
       This proc specifies the type of the next method's argument 
 

--- a/test/chpldoc/types/arguments/queried.doc.good
+++ b/test/chpldoc/types/arguments/queried.doc.good
@@ -1,4 +1,8 @@
 queried.doc
+
+Usage:
+   use queried.doc;
+
    proc queried(x: ?t)
       This proc queries the type of its argument 
 

--- a/test/chpldoc/types/arguments/recordsAndClasses.doc.good
+++ b/test/chpldoc/types/arguments/recordsAndClasses.doc.good
@@ -1,4 +1,8 @@
 recordsAndClasses.doc
+
+Usage:
+   use recordsAndClasses.doc;
+
    Record: thingy
    proc takesAThingy(val: thingy)
       This method takes a record as its argument 

--- a/test/chpldoc/types/arguments/tuples.doc.good
+++ b/test/chpldoc/types/arguments/tuples.doc.good
@@ -1,4 +1,8 @@
 tuples.doc
+
+Usage:
+   use tuples.doc;
+
    proc smallTuple(val: (bool, bool))
       This method takes a tuple of bools as an argument 
 

--- a/test/chpldoc/types/config/basic.doc.good
+++ b/test/chpldoc/types/config/basic.doc.good
@@ -1,4 +1,8 @@
 basic.doc
+
+Usage:
+   use basic.doc;
+
    config var isInt: int
       Comment for config var that is an int 
    config var isIntCommentless: int

--- a/test/chpldoc/types/fields/arrays.doc.good
+++ b/test/chpldoc/types/fields/arrays.doc.good
@@ -1,4 +1,8 @@
 arrays.doc
+
+Usage:
+   use arrays.doc;
+
    Class: fullOfArrays
       var smallArray: [1..4] bool
          This field contains an array of bools 

--- a/test/chpldoc/types/fields/basic.doc.good
+++ b/test/chpldoc/types/fields/basic.doc.good
@@ -1,4 +1,8 @@
 basic.doc
+
+Usage:
+   use basic.doc;
+
    Class: Other
       var isInt: int
          Comment for field that is an int 

--- a/test/chpldoc/types/fields/complexes.doc.good
+++ b/test/chpldoc/types/fields/complexes.doc.good
@@ -1,4 +1,8 @@
 complexes.doc
+
+Usage:
+   use complexes.doc;
+
    Record: Foo
       var aComplex: complex = 1.0+2.0i
       const bar = 0.0+1.0i

--- a/test/chpldoc/types/fields/domains.doc.good
+++ b/test/chpldoc/types/fields/domains.doc.good
@@ -1,4 +1,8 @@
 domains.doc
+
+Usage:
+   use domains.doc;
+
    Class: fullOfDomains
       var baseCase: domain(1)
          This field contains a one dimensional array 

--- a/test/chpldoc/types/fields/enums.doc.good
+++ b/test/chpldoc/types/fields/enums.doc.good
@@ -1,4 +1,8 @@
 enums.doc
+
+Usage:
+   use enums.doc;
+
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/types/fields/imags.doc.good
+++ b/test/chpldoc/types/fields/imags.doc.good
@@ -1,4 +1,8 @@
 imags.doc
+
+Usage:
+   use imags.doc;
+
    Record: Foo
       var anImag: imag = 2.0i
       const bar = 1.0i

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.good
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.good
@@ -1,4 +1,8 @@
 rangesAndDomains.doc
+
+Usage:
+   use rangesAndDomains.doc;
+
    Record: R
       var isRange: range
       var boundedRange = 1..10

--- a/test/chpldoc/types/fields/reals.doc.good
+++ b/test/chpldoc/types/fields/reals.doc.good
@@ -1,4 +1,8 @@
 reals.doc
+
+Usage:
+   use reals.doc;
+
    Record: Foo
       var aReal: real = 2.0
       const bar = 1.0

--- a/test/chpldoc/types/fields/recordsAndClasses.doc.good
+++ b/test/chpldoc/types/fields/recordsAndClasses.doc.good
@@ -1,4 +1,8 @@
 recordsAndClasses.doc
+
+Usage:
+   use recordsAndClasses.doc;
+
    Record: thingy
    Class: whatchamacallit
       var aThingy: thingy

--- a/test/chpldoc/types/fields/tuples.doc.good
+++ b/test/chpldoc/types/fields/tuples.doc.good
@@ -1,4 +1,8 @@
 tuples.doc
+
+Usage:
+   use tuples.doc;
+
    Class: fullOfTuples
       var smallTuple: (bool, bool)
          This field contains a tuple of bools 

--- a/test/chpldoc/types/fields/typevar.doc.good
+++ b/test/chpldoc/types/fields/typevar.doc.good
@@ -1,4 +1,8 @@
 typevar.doc
+
+Usage:
+   use typevar.doc;
+
    Class: Foo
       This class has type fields 
 

--- a/test/chpldoc/types/fields/usesTypeVar.doc.good
+++ b/test/chpldoc/types/fields/usesTypeVar.doc.good
@@ -1,4 +1,8 @@
 usesTypeVar.doc
+
+Usage:
+   use usesTypeVar.doc;
+
    Class: Bar
       This class uses the type field as the type of another field 
 

--- a/test/chpldoc/types/paramMethod.doc.good
+++ b/test/chpldoc/types/paramMethod.doc.good
@@ -1,4 +1,8 @@
 paramMethod.doc
+
+Usage:
+   use paramMethod.doc;
+
    proc param int.foo()
       I can only be called on param versions of the type `int` 
 

--- a/test/chpldoc/types/returns/arrays.doc.good
+++ b/test/chpldoc/types/returns/arrays.doc.good
@@ -1,4 +1,8 @@
 arrays.doc
+
+Usage:
+   use arrays.doc;
+
    proc smallArray(): [1..4] bool
       This method returns an array of bools as an argument 
 

--- a/test/chpldoc/types/returns/basic.doc.good
+++ b/test/chpldoc/types/returns/basic.doc.good
@@ -1,4 +1,8 @@
 basic.doc
+
+Usage:
+   use basic.doc;
+
 Submodules for this module are located in the basic.doc/ directory
 
    proc method1(): string
@@ -31,6 +35,10 @@ Submodules for this module are located in the basic.doc/ directory
 
    proc returnCommentless()
 Other
+
+Usage:
+   use basic.doc.Other;
+
    proc inside(): int
       Comment for method inside module 
 

--- a/test/chpldoc/types/returns/domains.doc.good
+++ b/test/chpldoc/types/returns/domains.doc.good
@@ -1,4 +1,8 @@
 domains.doc
+
+Usage:
+   use domains.doc;
+
    proc baseCase(): domain(1)
       This proc returns a one dimensional array 
 

--- a/test/chpldoc/types/returns/enums.doc.good
+++ b/test/chpldoc/types/returns/enums.doc.good
@@ -1,4 +1,8 @@
 enums.doc
+
+Usage:
+   use enums.doc;
+
    enum Color { Red, Yellow, Blue }
       This is a color enum. 
 

--- a/test/chpldoc/types/returns/recordsAndClasses.doc.good
+++ b/test/chpldoc/types/returns/recordsAndClasses.doc.good
@@ -1,4 +1,8 @@
 recordsAndClasses.doc
+
+Usage:
+   use recordsAndClasses.doc;
+
    Record: thingy
    proc takesAThingy(): thingy
       This method returns a record 

--- a/test/chpldoc/types/returns/recordsAndClasses.logical.doc.good
+++ b/test/chpldoc/types/returns/recordsAndClasses.logical.doc.good
@@ -1,4 +1,8 @@
 recordsAndClasses
+
+Usage:
+   use recordsAndClasses;
+
    proc takesAThingy(): thingy
       This method returns a record 
 

--- a/test/chpldoc/types/returns/tuples.doc.good
+++ b/test/chpldoc/types/returns/tuples.doc.good
@@ -1,4 +1,8 @@
 tuples.doc
+
+Usage:
+   use tuples.doc;
+
    proc smallTuple(): (bool, bool)
       This method returns a tuple of bools as an argument 
 

--- a/test/chpldoc/variableArguments.doc.good
+++ b/test/chpldoc/variableArguments.doc.good
@@ -1,4 +1,8 @@
 variableArguments.doc
+
+Usage:
+   use variableArguments.doc;
+
 Submodules for this module are located in the variableArguments.doc/ directory
 
    proc variable(x ...)
@@ -15,6 +19,10 @@ Submodules for this module are located in the variableArguments.doc/ directory
 
    proc specifyMeCommentless(q ...?p)
 Other
+
+Usage:
+   use variableArguments.doc.Other;
+
    proc variable(x ...)
       This method has a variable number of arguments 
 

--- a/test/compflags/thomasvandoren/chpldoc/copyright.doc.goodend
+++ b/test/compflags/thomasvandoren/chpldoc/copyright.doc.goodend
@@ -1,4 +1,8 @@
 copyright.doc
+
+Usage:
+   use copyright.doc;
+
    proc foo()
       this is a proc 
 

--- a/test/release/examples/primers/chpldoc.doc.good
+++ b/test/release/examples/primers/chpldoc.doc.good
@@ -1,4 +1,8 @@
 chpldoc.doc
+
+Usage:
+   use chpldoc.doc;
+
 Submodules for this module are located in the chpldoc.doc/ directory
 
    proc commented(val: int): string
@@ -12,6 +16,10 @@ Submodules for this module are located in the chpldoc.doc/ directory
 
    proc uncommented()
 Defined
+
+Usage:
+   use chpldoc.doc.Defined;
+
    
    If the source code defines a module, it can also have a comment associated
    with it


### PR DESCRIPTION
In html/rst mode, will create a "Usage" title, and a separate line with a
description of the use statement required to access this module, with links to
all modules in the chain. In txt mode, prints "Usage:" with a buffer from the
module name, following by the unaltered use statement.

Also modified the fixInternalDocs script to remove this information from the
internal modules, since we don't want the casual user calling
"use ChapelLocale_forDocs", for instance. Because chpldoc is called on
the internal modules instead of having them be discovered through ordinary
means, we can't key off of MOD_INTERNAL when determining whether to export this
information in the first place.

Update the chpldoc tests for this new expected output.

Replaces #3650 