### PR TITLE
Fix one last under-sleep possibility and re-enable sleepTimeUnits.

### DIFF
--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -745,7 +745,7 @@ void chpl_task_sleep(double secs) {
   // yielding.
   //
   gettimeofday(&deadline, NULL);
-  deadline.tv_usec += (suseconds_t) ((secs - trunc(secs)) * 1.0e6);
+  deadline.tv_usec += (suseconds_t) lround((secs - trunc(secs)) * 1.0e6);
   if (deadline.tv_usec > 1000000) {
     deadline.tv_sec++;
     deadline.tv_usec -= 1000000;

--- a/test/modules/standard/Time/sleepTimeUnits.chpl
+++ b/test/modules/standard/Time/sleepTimeUnits.chpl
@@ -17,8 +17,8 @@ sleep(100, TimeUnits.microseconds);
 timer.stop();
 if printTime then
   stderr.writeln(timer.elapsed());
-if abs((1e-6 * 100) - timer.elapsed()) > (tolerance*(1e-6*100)) then
-  halt("Exceeded tolerance on TimeUnits.microseconds");
+if timer.elapsed() < 1e-6*100 then
+  halt("Slept short on TimeUnits.microseconds", ": ", timer.elapsed());
 timer.clear();
 
 timer.start();
@@ -26,8 +26,8 @@ sleep(100, TimeUnits.milliseconds);
 timer.stop();
 if printTime then
   stderr.writeln(timer.elapsed());
-if abs((1e-3 * 100) - timer.elapsed()) > (tolerance*(1e-3*100)) then
-  halt("Exceeded tolerance on TimeUnits.milliseconds");
+if timer.elapsed() < 1e-3*100 then
+  halt("Slept short on TimeUnits.milliseconds");
 timer.clear();
 
 timer.start();
@@ -35,8 +35,8 @@ sleep(3);
 timer.stop();
 if printTime then
   stderr.writeln(timer.elapsed());
-if abs(3 - timer.elapsed()) > (tolerance*3) then
-  halt("Exceeded tolerance on TimeUnits.seconds");
+if timer.elapsed() < 3 then
+  halt("Slept short on TimeUnits.seconds");
 timer.clear();
 
 writeln("Done");


### PR DESCRIPTION
The tasking layers would under-sleep by 1 microsecond if, when computing
the (integer) microsecond part of the struct timeval for the deadline to
awaken, they truncated instead of rounding.  Here, fix this by rounding
explicitly.

In addition, re-enable the sleepTimeUnits test that we disabled due to
intermittent failures when it was new.  However, make it complain only
when we under-sleep (with zero tolerance).  Checking for over-sleep
isn't worthwhile, because that can happen for reasons that are beyond
our control.