### PR TITLE
Add top level categorization for new FileSystem links

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -39,7 +39,9 @@
    :proc:`copyFile`
    :proc:`copyTree`
    :proc:`mkdir`
+   :proc:`moveDir`
    :proc:`remove`
+   :proc:`rmTree`
    :proc:`symlink`
    :proc:`chmod`
    :proc:`chown`


### PR DESCRIPTION
Though moveDir and rmTree had chpldoc comments on them, the FileSystem module
documentation comment had not been updated to include them in the list of
File/Directory Manipulations.  Fix that oversight.

(verified that the output was correct and the links valid)