### PR TITLE
Filter out apsys errors

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1812,6 +1812,8 @@ for testname in testsrc:
                         launcher_error = 'Jira 18 -- Expired slurm credential for'
                     elif re.search('output file from job .* does not exist', output, re.IGNORECASE) != None:
                         launcher_error = 'Jira 17 -- Missing output file for'
+                    elif re.search('aprun: Unexpected close of the apsys control connection', output, re.IGNORECASE) != None:
+                        launcher_error = 'Jira 193 -- Unexpected close of apsys for'
                     elif (re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None or
                           re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None):
                         exectimeout = True


### PR DESCRIPTION
We've been getting some sporadic XE failures along the lines of:

    aprun: Unexpected close of the apsys control connection
    aprun: Exiting due to errors. Application aborted

This adds filtering to sub_test to pick out these errors and report them with a
reference to the JIRA issue so they're easier to pick out in the regression
mails without having to go dig through the nightly logs.

Errors will now show up as:

    [Error: Jira 193 -- Unexpected close of apsys for release/examples/hello]

instead of a generic:

    [Error matching program output for release/examples/hello]