### PR TITLE
Fix start_test's --[no]stdinredirect features

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1275,10 +1275,10 @@ def parser_setup():
             help="set the number of locales to run on")
     # stdin redirect
     parser.add_argument("-nostdinredirect", "--nostdinredirect",
-            action="store", dest="no_stdin_redirect",
+            action="store_true", dest="no_stdin_redirect",
             help="run the tests without redirecting stdin from /dev/null")
-    parser.add_argument("-stdinredirect", "--stdinredirect", action="store",
-            dest="stdin_redirect",
+    parser.add_argument("-stdinredirect", "--stdinredirect",
+            action="store_true", dest="stdin_redirect",
             help="force stdin redirection from /dev/null")
     # launcher timeout
     parser.add_argument("-launchertimeout", "--launchertimeout", 


### PR DESCRIPTION
They were using "store" which meant they required an arg instead of just
setting a boolean. For example you'd have to say:

    start_test --nostdinredirect true

instead of just:

    start_test --nostdinredirect