### PR TITLE
Link to IO.string.format and Regexp from string docs

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -42,13 +42,13 @@ private module BaseStringType {
 
 /*
   The following documentation shows functions and methods used to
-  manipulate and process Chapel strings. See the :mod:`IO` documentation for
-  more information on reading, writing, and formatting strings.
+  manipulate and process Chapel strings.
 
   Besides the functions below, some other modules proved routines that are
   useful for working with strings. The :mod:`IO` module provides
   :proc:`IO.string.format` which creates a string that is the result of
-  formatting. The :mod:`Regexp` module also provides some routines for searching
+  formatting. It also includes functions for reading and writing strings.
+  The :mod:`Regexp` module also provides some routines for searching
   within strings.
 
   .. warning::

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -41,9 +41,15 @@ private module BaseStringType {
 // It might be worth moving them here for documentation - KB Feb 2016
 
 /*
-  The following documentation consists of functions and methods used to
+  The following documentation shows functions and methods used to
   manipulate and process Chapel strings. See the :mod:`IO` documentation for
   more information on reading, writing, and formatting strings.
+
+  Besides the functions below, some other modules proved routines that are
+  useful for working with strings. The :mod:`IO` module provides
+  :proc:`IO.string.format` which creates a string that is the result of
+  formatting. The :mod:`Regexp` module also provides some routines for searching
+  within strings.
 
   .. warning::
 


### PR DESCRIPTION
It seems to me it would be useful to note the existence of these other routines.
In particular, I remember somebody asking if it's possible to go from an
integer storing an ASCII character code to a 1-character string. The answer
is yes, the format routine can do that. But that might be difficult to discover
with the current version of the documentation.

Whether format is an *efficient* way to do this is another question.

Reviewed by @benharsh - thanks!