### PR TITLE
Use portable sed command.

### DIFF
--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -102,7 +102,7 @@ function removeUsage() {
     exit 1;
   fi
 
-  sed -e '/\*\*Usage\*\*/,+6d' $1 > $1.tmp
+  sed -e '/\*\*Usage\*\*/ { N; N; N; N; N; N; d; }' $1 > $1.tmp
   mv $1.tmp $1
 }
 


### PR DESCRIPTION
When making this update, before, I tried to use a command that is apparently
only present on GNU versions of sed.  The replacement should be more
portable.