### PR TITLE
bug in Makefile for Ubuntu : source not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ modules: FORCE
 runtime: FORCE
 	cd runtime && $(MAKE)
 	-@if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
-	source ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
+	. ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
 	cd runtime && $(MAKE) ; \
 	fi
 
@@ -86,7 +86,7 @@ third-party-try-re2: FORCE
 	-@if [ -z "$$CHPL_REGEXP" ]; then \
 	cd third-party && $(MAKE) try-re2; \
 	if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
-	source ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
+	. ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
 	$(MAKE) try-re2; \
 	fi \
 	fi
@@ -95,7 +95,7 @@ third-party-try-gmp: FORCE
 	-@if [ -z "$$CHPL_GMP" ]; then \
 	cd third-party && $(MAKE) try-gmp; \
 	if [ "llvm" = `${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py` ]; then \
-	source ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
+	. ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
 	$(MAKE) try-gmp; \
 	fi \
 	fi


### PR DESCRIPTION
/bin/sh in Ubuntu points to dash, which does not support "source", causing the Makefile to fail with a "source not found" error. I'll note that this looks like it only gets tickled when CHPL_LLVM is set.

Replacing source with . should fix this in all cases. 

Just for completeness :
```
$ ls -l `which sh`; uname -a
lrwxrwxrwx 1 root root 4 Feb 19  2014 /bin/sh -> dash
Linux andromeda0 3.19.0-56-generic #62~14.04.1-Ubuntu SMP Fri Mar 11 11:03:15 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
```
