### PR TITLE
Support "localhost" in paranode files

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -85,6 +85,11 @@ sub systemd {
     system ($cmd);
 }
 
+sub trim {
+  my $s = shift;
+  $s =~ s/^\s+|\s+$//g;
+  return $s;
+}
 
 # Collect individual logs into one final one.
 sub collect_logs {
@@ -649,6 +654,9 @@ sub main {
         while (<nodefile>) {
             next if /^$|^\#/;
             chomp;
+            if (trim($_) eq "localhost") {
+              $_ = $localnode;
+            }
             $count = $node_para;
             while ($count--) {
                 push @node_list, $_;


### PR DESCRIPTION
Add support to paratest so that you can just specify localhost in a paranode
file to use the current machine. This is to support using paratest for cygwin
testing without threading `-nodepara` support through the nightly script.