### PR TITLE
Compiler error for fields named 'outer'

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -153,7 +153,7 @@ void scopeResolve() {
   forv_Vec(AggregateType, ct, gAggregateTypes) {
     for_fields(field, ct) {
       if (strcmp(field->name, "outer") == 0) {
-        USR_FATAL(field, "Cannot have a field named 'outer'. 'outer' is used to refer to an outer class from within a nested class.");
+        USR_FATAL_CONT(field, "Cannot have a field named 'outer'. 'outer' is used to refer to an outer class from within a nested class.");
       }
       if (aliasFieldSet.set_in(field->name)) {
         SET_LINENO(field);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -152,6 +152,9 @@ void scopeResolve() {
   //
   forv_Vec(AggregateType, ct, gAggregateTypes) {
     for_fields(field, ct) {
+      if (strcmp(field->name, "outer") == 0) {
+        USR_FATAL(field, "Cannot have a field named 'outer'. 'outer' is used to refer to an outer class from within a nested class.");
+      }
       if (aliasFieldSet.set_in(field->name)) {
         SET_LINENO(field);
 

--- a/test/classes/bharshbarg/field-outer.chpl
+++ b/test/classes/bharshbarg/field-outer.chpl
@@ -1,0 +1,6 @@
+record Bar {
+  var outer : int;
+}
+
+var b : Bar;
+writeln(b);

--- a/test/classes/bharshbarg/field-outer.good
+++ b/test/classes/bharshbarg/field-outer.good
@@ -1,0 +1,1 @@
+field-outer.chpl:2: error: Cannot have a field named 'outer'. 'outer' is used to refer to an outer class from within a nested class.


### PR DESCRIPTION
This change adds a fatal compiler error to scopeResolve to catch user fields named 'outer'.

Prior to this change, a user would encounter odd compiler or runtime errors if they had a field in a class or record named 'outer'. It was rather difficult to track down the cause of a runtime error, as no one in their right mind would assume the field name would have anything to do with the problem.