### PR TITLE
Have whitebox testing set oversubscription vars

### DIFF
--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -3,7 +3,9 @@
 # Configure environment for GASNet testing. This should be sourced by other
 # scripts that wish to make use of the variables set here.
 
-source $(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)/common.bash
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+
+source $CWD/common.bash
 
 export CHPL_COMM=gasnet
 export GASNET_SPAWNFN=L
@@ -15,9 +17,8 @@ export CHPL_TEST_TIMEOUT=500
 
 tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
 if [ "${tasks}" == "qthreads" ] ; then
-    # Set these to use oversubscription to help with timeouts
-    export QT_AFFINITY=no
-    export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
+
+    source $CWD/common-oversubscribed.bash
 
     # Even with oversubscription we still have some timeouts with
     # qtheads+gasnet on "low" core count machines. The main issue is

--- a/util/cron/common-oversubscribed.bash
+++ b/util/cron/common-oversubscribed.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Configure environment for testing in an oversubscribed manner (help multiple
+# chapel programs run nicer side by side)
+
+tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
+if [ "${tasks}" == "qthreads" ] ; then
+    export QT_AFFINITY=no
+    export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
+fi

--- a/util/cron/common-qthreads.bash
+++ b/util/cron/common-qthreads.bash
@@ -3,11 +3,11 @@
 # Configure environment for qthreads testing. This should be sourced by other
 # scripts that wish to make use of the variables set here.
 
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+
 comm=$($CHPL_HOME/util/chplenv/chpl_comm.py)
 if [ "${comm}" != "none" ] ; then
-    # Set these to use oversubscription to help with timeouts
-    export QT_AFFINITY=no
-    export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
+    source $CWD/common-oversubscribed.bash
 fi
 
 export CHPL_TASKS=qthreads

--- a/util/cron/common-valgrind.bash
+++ b/util/cron/common-valgrind.bash
@@ -11,8 +11,7 @@ export CHPL_RT_NUM_THREADS_PER_LOCALE=100
 # with debugging
 tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
 if [ "${tasks}" == "qthreads" ] ; then
-    export QT_AFFINITY=no
-    export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
+    source $CWD/common-oversubscribed.bash
     export CHPL_QTHREAD_MORE_CFG_OPTIONS=--enable-valgrind
 fi
 

--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -6,6 +6,7 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/functions.bash
 source $CWD/common-whitebox.bash
+source $CWD/common-oversubscribed.bash
 
 # Run the tests!
 nightly_args="-cron"


### PR DESCRIPTION
Whitebox testing runs heavily oversubscribed, so try to configure it with the
same oversubscription settings we use for gasnet testing to hopefully allow us
to finish testing faster.
