### PR TITLE
Use paratest for cygwin32 testing (round 2)

### DIFF
--- a/util/cron/test-cygwin32.bat
+++ b/util/cron/test-cygwin32.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/cygdrive/c/Program Files/emacs-24.4/bin' ; export CHPL_HOME=$PWD ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron"
+c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/cygdrive/c/Program Files/emacs-24.4/bin' ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print(multiprocessing.cpu_count())-1'` ; for i in $(seq 1 $num_procs); do echo 'localhost'; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
 GOTO End
 
 :ErrExit

--- a/util/cron/test-cygwin64.bat
+++ b/util/cron/test-cygwin64.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows:/cygdrive/c/windows/System32/Wbem:/cygdrive/c/windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/usr/bin:/cygdrive/c/emacs-24.3/bin' ; num_procs=`python -c 'import multiprocessing; print(multiprocessing.cpu_count())-1'` ; for i in $(seq 1 $num_procs); do echo "localhost"; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_HOME=$PWD ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
+c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows:/cygdrive/c/windows/System32/Wbem:/cygdrive/c/windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/usr/bin:/cygdrive/c/emacs-24.3/bin' ; export CHPL_HOME=$PWD ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron"
 GOTO End
 
 :ErrExit


### PR DESCRIPTION
[I accidentally committed the wrong changes for cygwin64 instead of cygwin32.
This reverts the cygwin64 changes, and applies them correctly to cygwin32
testing.]

Cygwin32 testing takes a long time (over a day) so oversubscribe the machine
with paratest to try and finish faster. I didn't want to commit stpwchap
specific nodefiles in $CHPL_HOME/test/NODES/ so instead we create one at the
beginning of testing. It basically creates a CHPL_HOME/test/NODES/<num_cores -
1>-localhost file that nightly testing will use.

Ideally we would just say nodepara=<num_cores - 1>, but I didn't want to thread
nodepara all the way through the nightly test script.
