### PR TITLE
Turn off chpl-mem warnings before including windows.h on cygwin

### DIFF
--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -84,7 +84,9 @@
 //#include <ntddk.h>
 //#include <winternl.h>
 //#include <ntifs.h>
+#include "chpl-mem-no-warning-macros.h"
 #include <windows.h>
+#include "chpl-mem-warning-macros.h"
 #include <sys/cygwin.h> // for cygwin_internal
 
 #define REPLACE_CYGWIN_PREADWRITE 1


### PR DESCRIPTION
On cygwin with newer versions of gcc (I'm using 5.3) windows.h ends up
including mm_malloc.h, which includes calls to a function named "_mm_malloc"
that our chpl-mem warnings mess up.

This just disables the warnings before including windows.h and re-enables them
afterwards.

I'm starting to think that our current chpl-mem warnings scheme isn't really a
great one since we have no control over what some of our includes might use
themselves. Maybe it'd be better to check for malloc and friends in some sort
of smoke test instead?