### PR TITLE
Minor touches on util/ scripts

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -34,9 +34,9 @@
 #
 
 function testReleasePerformance {
-    pushd $CHPL_HOME > /dev/null
+    pushd $CHPL_HOME
     . util/setchplenv.bash
-    popd > /dev/null
+    popd
     $CHPL_TEST_UTIL_DIR/start_test -performance -num-trials 3
 }
 
@@ -48,10 +48,10 @@ export CHPL_HOME_ORIG=$CHPL_HOME
 export CHPL_TEST_UTIL_DIR=$CHPL_HOME_ORIG/util
 
 if [[ -z $CHPL_TEST_VENV_DIR && ! -z $CHPL_HOST_PLATFORM ]]; then
-    export CHPL_TEST_VENV_DIR=$CHPL_HOME/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/chpl-virtualenv
+    export CHPL_TEST_VENV_DIR=$CHPL_HOME_ORIG/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/chpl-virtualenv
 fi
 if [[ ! -d $CHPL_TEST_VENV_DIR ]]; then
-    echo "ERROR: incorrect or missing CHPL_TEST_VENV_DIR or CHPL_HOST_PLATFORM"
+    echo "ERROR: incorrect or missing CHPL_TEST_VENV_DIR=$CHPL_TEST_VENV_DIR or CHPL_HOST_PLATFORM"
     exit 1
 fi
 

--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -17,8 +17,8 @@
 #   you want to make the results comparable to the ones we gather
 #   nightly) and up-to-date with the master.
 #
-# * set CHPL_TEST_VENV_DIR=\
-#     $CHPL_HOME/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/chpl-virtualenv
+# * optionally, set CHPL_TEST_VENV_DIR if you want it to differ
+#   from the default below.
 #
 # * optionally, set CHPL_TEST_PERF_DIR to indicate where you want
 #   the output .dat and html/ files to be placed.  By default, it
@@ -34,10 +34,10 @@
 #
 
 function testReleasePerformance {
-    pushd $CHPL_HOME
+    pushd $CHPL_HOME > /dev/null
     . util/setchplenv.bash
-    popd
-    $CHPL_HOME_ORIG/util/start_test -performance -num-trials 3
+    popd > /dev/null
+    $CHPL_TEST_UTIL_DIR/start_test -performance -num-trials 3
 }
 
 if [[ -z $CHPL_HOME ]]; then
@@ -46,6 +46,14 @@ fi
 
 export CHPL_HOME_ORIG=$CHPL_HOME
 export CHPL_TEST_UTIL_DIR=$CHPL_HOME_ORIG/util
+
+if [[ -z $CHPL_TEST_VENV_DIR && ! -z $CHPL_HOST_PLATFORM ]]; then
+    export CHPL_TEST_VENV_DIR=$CHPL_HOME/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/chpl-virtualenv
+fi
+if [[ ! -d $CHPL_TEST_VENV_DIR ]]; then
+    echo "ERROR: incorrect or missing CHPL_TEST_VENV_DIR or CHPL_HOST_PLATFORM"
+    exit 1
+fi
 
 #
 # This is a place where all releases will be unpacked and built with
@@ -95,9 +103,9 @@ export CHPL_TEST_PERF_DATE="03/29/16"
 export CHPL_HOME=$chpl_release_home/chapel-1.13.0
 testReleasePerformance
 
-export -n CHPL_TEST_PERF_DATE
+unset CHPL_TEST_PERF_DATE
 export CHPL_HOME=$CHPL_HOME_ORIG
-start_test --gen-graphs
+$CHPL_TEST_UTIL_DIR/start_test --gen-graphs
 
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.

--- a/util/start_test
+++ b/util/start_test
@@ -568,11 +568,13 @@ def check_environment():
             sys.exit(1)
 
     # find test dir and check for access
-    global test_dir
+    global test_dir, auto_gen_spec_tests
     test_dir = os.path.join(home, "test")
+    auto_gen_spec_tests = os.access(os.path.join(home, "spec"), os.F_OK)
     if (not os.access(test_dir, os.F_OK) or not os.access(test_dir, os.W_OK)
         or not os.access(test_dir, os.X_OK)):
         test_dir = os.path.join(home, "examples")
+        auto_gen_spec_tests = False
         if (not os.access(test_dir, os.F_OK) or not os.access(test_dir, os.W_OK)
             or not os.access(test_dir, os.X_OK)):
             test_dir = os.getcwd()
@@ -999,6 +1001,8 @@ def set_up_executables():
 
 
 def auto_generate_tests():
+    if not auto_gen_spec_tests:
+        return
     path = os.getcwd()
     with cd(home):
         if path == home or path == test_dir and not args.clean_only:
@@ -1086,7 +1090,7 @@ def check_for_duplicates():
     # check for .graph files, and GRAPHFILES
     if args.gen_graphs or args.comp_performance:
         logger.write("[Checking for duplicate .graph files and that all .graph"
-                " files appear in {0}/.*GRAPHFILES]".format(test_dir))
+                " files appear in {0}/*GRAPHFILES]".format(test_dir))
 
         # find GRAPHFILES
         graph_files = [f for f in os.listdir(test_dir) if


### PR DESCRIPTION
testReleasesPerformance
-----------------------

* Set CHPL_TEST_VENV_DIR automatically when needed and possible.
  Relieve the user from the need to do so.

* Hide the output of pushd/popd - I find it not helpful in
  the console output.

* Change "export -n" to "unset" for CHPL_TEST_PERF_DATE.
  That way the variable is clearly gone.

start_test
----------

* Avoid generating spec tests when it does not make sense, e.g.:
 - CHPL_HOME/spec does not exist
 - CHPL_HOME/test is read-only and I am invoking start_test
   from a directory that's outside CHPL_HOME.

* Change an informational message from .../.*GRAPHFILES to .../*GRAPHFILES.
  The former is a RegExp and the latter is a path wildcard.
  I prefer the latter, so it matches e.g. the style of our READMEs.
  Elliot condones this change.
