### PR TITLE
Revert "Have whitebox testing set oversubscription vars"

### DIFF
--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -6,7 +6,6 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/functions.bash
 source $CWD/common-whitebox.bash
-source $CWD/common-oversubscribed.bash
 
 # Run the tests!
 nightly_args="-cron"


### PR DESCRIPTION
This reverts commit c28f096e6a1ca78474cdcbc319f5df90711ebed6.

Stop oversubscribing whitebox testing. It ended up increasing total testing
time and led to a few timeouts, so just revert it.