### PR TITLE
Allow umask test to generate reliable output

### DIFF
--- a/test/modules/standard/FileSystem/lydia/umask/multiTask.chpl
+++ b/test/modules/standard/FileSystem/lydia/umask/multiTask.chpl
@@ -5,9 +5,13 @@ var masks: [1..3] int = [0o777, 0o744, 0o755];
 var startingMask = 0o700;
 var oldMask = here.umask(startingMask);
 
-forall i in masks.domain {
-  var prevMask = here.umask(masks[i]);
-  if (prevMask != startingMask) {
-    writeln("Not task safe!");
+serial {
+  forall i in masks.domain {
+    var prevMask = here.umask(masks[i]);
+    // For every task after the first one, umask will be updated
+    if (prevMask != startingMask) {
+      // We should see this output twice.
+      writeln("Not task safe!");
+    }
   }
 }


### PR DESCRIPTION
This test verifies that updates to the umask in one task affect other tasks on
that same locale.  On cygwin, we witnessed a case where multiple tasks saw the
same original value, leading to a failure with this test.  That is because umask
is not guaranteed to be thread-safe.  To get around that, force the independent
tasks to operate serially.  This accomplishes the original purpose of the test
without leading to non-deterministic output.

Added some comments while I was here.