### PR TITLE
Don't re-enable chpl-mem warnings after including windows.h on cygwin

### DIFF
--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -86,7 +86,6 @@
 //#include <ntifs.h>
 #include "chpl-mem-no-warning-macros.h"
 #include <windows.h>
-#include "chpl-mem-warning-macros.h"
 #include <sys/cygwin.h> // for cygwin_internal
 
 #define REPLACE_CYGWIN_PREADWRITE 1


### PR DESCRIPTION
Enabling them led to some testing regressions.