### PR TITLE
Fix a clang warning in generated code

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -203,6 +203,7 @@ module ChapelDistribution {
 
     proc dsiSupportsPrivatization() param return false;
     proc dsiRequiresPrivatization() param return false;
+    proc isDefaultRectangular() param return false;
   
     // false for default distribution so that we don't increment the
     // default distribution's reference count and add domains to the

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1037,7 +1037,21 @@ module DefaultRectangular {
     }
 
     proc dsiReallocate(d: domain) {
-      on this {
+      //
+      // The following test seems like it should be unnecessary; this
+      // routine should only be called with domains of matching rank,
+      // and we are reasonably sure that this always happens in
+      // practice.  Yet dynamic method resolution is somehow invoking
+      // this in a way where they do not match, making other things
+      // blow up (which is also why the halt() can't be turned into
+      // a compilerError()... it always triggers).  This deserves a
+      // deeper look, but the lack of this is breaking newer clang
+      // builds with c warnings on, so I'm adding this for the time
+      // being.
+      //
+      if (d.rank != dom.rank) then
+        halt("internal error: dsiReallocate() rank mismatch");
+      else on this {
       //
       // If d is default rectangular, like dom, this is pretty easy...
       //

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1038,19 +1038,21 @@ module DefaultRectangular {
 
     proc dsiReallocate(d: domain) {
       //
-      // The following test seems like it should be unnecessary; this
-      // routine should only be called with domains of matching rank,
-      // and we are reasonably sure that this always happens in
-      // practice.  Yet dynamic method resolution is somehow invoking
-      // this in a way where they do not match, making other things
-      // blow up (which is also why the halt() can't be turned into
-      // a compilerError()... it always triggers).  This deserves a
-      // deeper look, but the lack of this is breaking newer clang
-      // builds with c warnings on, so I'm adding this for the time
-      // being.
+      // The following two tests seem like they should be unnecessary;
+      // this routine should only be called with domains of matching
+      // rank and idxType and we are reasonably sure that this always
+      // happens in practice.  Yet dynamic method resolution is
+      // somehow invoking this in a way where they do not match,
+      // making other things blow up (which is also why the halt()s
+      // can't be turned into compilerError()s... it always triggers).
+      // This deserves a deeper look, but the lack of this is breaking
+      // newer clang builds with c warnings on, so I'm adding this for
+      // the time being.
       //
       if (d.rank != dom.rank) then
         halt("internal error: dsiReallocate() rank mismatch");
+      else if (d.idxType != dom.idxType) then
+        halt("internal error: dsiReallocate() idxType mismatch");
       else on this {
       //
       // If d is default rectangular, like dom, this is pretty easy...

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -95,6 +95,7 @@ module DefaultRectangular {
   
     proc linksDistribution() param return false;
     proc dsiLinksDistribution()     return false;
+    proc isDefaultRectangular() param return true;
   
     proc DefaultRectangularDom(param rank, type idxType, param stridable, dist) {
       this.dist = dist;
@@ -1038,10 +1039,9 @@ module DefaultRectangular {
     proc dsiReallocate(d: domain) {
       on this {
       //
-      // If both d and dom are default rectangular, this is pretty
-      // easy...
+      // If d is default rectangular, like dom, this is pretty easy...
       //
-      if (d._value.type == dom.type) {
+      if (d._value.isDefaultRectangular()) {
         var copy = new DefaultRectangularArr(eltType=eltType, rank=rank,
                                              idxType=idxType,
                                              stridable=d._value.stridable,


### PR DESCRIPTION
David pointed out that commit 88e5b21d00124aa236c908c224348b532e232d74
introduced a warning in Chapel-generated code for programs as simple
as test/release/examples/hello4-datapar-dist.chpl.  Specifically,
'chpl' generated a version of dsiReallocate() that would call itself
unconditionally for the 'else' branch of dsiReallocate() in
DefaultRectangular.chpl.  This seems to have been due to the way I
was testing to see whether the 'd' argument was defaultrectangular
or not, by comparing its type to 'dom's type.

In this commit, I take a different approach that I thought about but
didn't pursue originally, which is to query more directly whether the
domain was a default rectangular.  We haven't supported such a query
in the past (and I don't think it can be done via a simple type
comparison since DefaultRectangular is generic), so here, I add the
same type of query that we already support on the
DefaultRectangularArr class by adding a param method to BaseDom and
DefaultRectangularDom indicating whether or not it's a default
rectangular.  While this is somewhat of a special case (i.e., we
wouldn't want to do it for all layouts and distributions), default
rectangulars are pretty special semantically, so it seems justifiable
(and I've found myself wanting it in other cases where I was
disappointed to find that only the arrays support such a query).