### PR TITLE
Fix countMemory prediff for cygwin32

### DIFF
--- a/test/modules/standard/memory/countMemory/countMemory.makegood
+++ b/test/modules/standard/memory/countMemory/countMemory.makegood
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
-$memoryInKBytes = @ARGV[0];
-$memoryInBytes = $memoryInKBytes * 1024;
+$memoryInBytes  = int(@ARGV[0]);
+$memoryInKBytes = int($memoryInBytes  / 1024);
 $memoryInMBytes = int($memoryInKBytes / 1024);
 $memoryInGBytes = int($memoryInMBytes / 1024);
 
@@ -23,13 +23,13 @@ print "    in kb: $memoryInKBytes\n";
 print "    in mb: $memoryInMBytes\n";
 print "    in gb: $memoryInGBytes\n";
 
-$realMemInKBytesVal = $memoryInKBytes;
-$realMemInBytesVal  = $realMemInKBytesVal * 1024;
+$realMemInBytesVal  = $memoryInBytes;
+$realMemInKBytesVal = $realMemInBytesVal  / 1024;
 $realMemInMBytesVal = $realMemInKBytesVal / 1024;
 $realMemInGBytesVal = $realMemInMBytesVal / 1024;
 
-$realMemInKBytes = sprintf("%g", $realMemInKBytesVal);
 $realMemInBytes  = sprintf("%g", $realMemInBytesVal);
+$realMemInKBytes = sprintf("%g", $realMemInKBytesVal);
 $realMemInMBytes = sprintf("%g", $realMemInMBytesVal);
 $realMemInGBytes = sprintf("%g", $realMemInGBytesVal);
 			   
@@ -38,11 +38,11 @@ $realMemInGBytes = sprintf("%g", $realMemInGBytesVal);
 # if a string is all digits, add a trailing .0 to match
 # Chapel's default formatting of reals
 #
-if ($realMemInKBytes =~ m/^\d+$/) {
-    $realMemInKBytes .= ".0";
-}
 if ($realMemInBytes =~ m/^\d+$/) {
     $realMemInBytes .= ".0";
+}
+if ($realMemInKBytes =~ m/^\d+$/) {
+    $realMemInKBytes .= ".0";
 }
 if ($realMemInMBytes =~ m/^\d+$/) {
     $realMemInMBytes .= ".0";

--- a/test/modules/standard/memory/countMemory/countMemory.prediff
+++ b/test/modules/standard/memory/countMemory/countMemory.prediff
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 $memfile = "/proc/meminfo";
-$memFreeInKB = "unknown";
+$memFreeInBytes = "unknown";
 
 if (-r $memfile) {
   open MEMFILE, "$memfile" or die "can't open $memfile $!";
@@ -10,18 +10,17 @@ if (-r $memfile) {
 
   foreach my $line (@memLines) {
     if ($line =~ m/MemTotal: (\s*)(\S*)/) {
-      $memFreeInKB = "$2";
+      $memFreeInBytes = "$2" * 1024;
     }
   }
 } else {
     $platform = `$ENV{CHPL_HOME}/util/chplenv/chpl_platform.py --target`; chomp($platform);
     if ($platform eq "darwin") {
-	$memInBytes = `sysctl -n hw.memsize`; chomp($memInBytes);
-	$memFreeInKB = $memInBytes / 1024;
+        $memFreeInBytes = `sysctl -n hw.memsize`; chomp($memFreeInBytes);
     }
 }
 
-if ($memFreeInKB ne "unknown") {
+if ($memFreeInBytes ne "unknown") {
     $hostname = `hostname -s`; chomp($hostname);
-    system("./countMemory.makegood $memFreeInKB > countMemory.$hostname.good");
+    system("./countMemory.makegood $memFreeInBytes > countMemory.$hostname.good");
 }

--- a/test/modules/standard/memory/countMemory/countMemory.prediff
+++ b/test/modules/standard/memory/countMemory/countMemory.prediff
@@ -2,6 +2,7 @@
 
 $memfile = "/proc/meminfo";
 $memFreeInBytes = "unknown";
+$platform = `$ENV{CHPL_HOME}/util/chplenv/chpl_platform.py --target`; chomp($platform);
 
 if (-r $memfile) {
   open MEMFILE, "$memfile" or die "can't open $memfile $!";
@@ -14,9 +15,17 @@ if (-r $memfile) {
     }
   }
 } else {
-    $platform = `$ENV{CHPL_HOME}/util/chplenv/chpl_platform.py --target`; chomp($platform);
     if ($platform eq "darwin") {
         $memFreeInBytes = `sysctl -n hw.memsize`; chomp($memFreeInBytes);
+    }
+}
+
+# cygwin32 running on a 64 bit windows can have more than 4GB reported by
+# /proc/meminfo, but only ~4GB is actually accessible
+if ($platform eq "cygwin32") {
+    $maxMemInBytes = 0xffffffff;
+    if ($memFreeInBytes > $maxMemInBytes) {
+        $memFreeInBytes = $maxMemInBytes;
     }
 }
 


### PR DESCRIPTION
Limit countMemory to 4GB on cygwin32

If cygwin32 is running on a 64-bit windows with more than 4GB of ram
/proc/meminfo will report the true amount of ram the system has, but only 4GB
will be accessible and that value is what our runtime (correctly) reports.

Our cygwin32 box was upgraded from 4GB to 8GB of ram which caused countMemory
to start getting the wrong value. JIRA issue 83 has more details from the last
time we ran into this: https://chapel.atlassian.net/browse/CHAPEL-83. Last time
we just had IT re-limit the machine to 4GB of ram, but this takes a cleaner
approach and limits the amount of ram the countMemory prediff reports to
`min($memFreeInBytes, 0xffffffff)` for cygwin32.
.