### PR TITLE
Cherry pick two trivial doc changes to 1.13 branch for web docs

### DIFF
--- a/doc/sphinx/source/language/evolution.rst
+++ b/doc/sphinx/source/language/evolution.rst
@@ -32,8 +32,9 @@ return an lvalue by ref. For example:
   }
 
   refToX() = 3;       // uses the setter version
+  writeln(x);         // prints 3
   var tmp = refToX(); // uses the getter version
-  writeln(tmp);       // prints 3
+  writeln(tmp);       // prints 0
 
 This functionality has changed with version 1.13. It is still possible to
 write a getter and a setter, but these must be written as pair of
@@ -54,8 +55,9 @@ related functions:
   }
 
   refToX() = 3;       // uses the setter version
+  writeln(x);         // prints 3
   var tmp = refToX(); // uses the getter version
-  writeln(tmp);       // prints 3
+  writeln(tmp);       // prints 0
 
 
 In some cases, when migrating code over to the new functionatity,

--- a/modules/internal/ChapelEnv.chpl
+++ b/modules/internal/ChapelEnv.chpl
@@ -32,71 +32,71 @@
 module ChapelEnv {
 
   /* See :ref:`readme-chplenv.CHPL_HOME` for more information. */
-  param CHPL_HOME            = __primitive("get compiler variable", "CHPL_HOME");
+  param CHPL_HOME:string            = __primitive("get compiler variable", "CHPL_HOME");
 
   /* See :ref:`readme-chplenv.CHPL_AUX_FILESYS` for more information. */
-  param CHPL_AUX_FILESYS     = __primitive("get compiler variable", "CHPL_AUX_FILESYS");
+  param CHPL_AUX_FILESYS:string     = __primitive("get compiler variable", "CHPL_AUX_FILESYS");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_PLATFORM` for more information. */
-  param CHPL_TARGET_PLATFORM = __primitive("get compiler variable", "CHPL_TARGET_PLATFORM");
+  param CHPL_TARGET_PLATFORM:string = __primitive("get compiler variable", "CHPL_TARGET_PLATFORM");
 
   /* See :ref:`readme-chplenv.CHPL_HOST_PLATFORM` for more information. */
-  param CHPL_HOST_PLATFORM   = __primitive("get compiler variable", "CHPL_HOST_PLATFORM");
+  param CHPL_HOST_PLATFORM:string   = __primitive("get compiler variable", "CHPL_HOST_PLATFORM");
 
   /* See :ref:`readme-chplenv.CHPL_COMPILER` for more information. */
-  param CHPL_HOST_COMPILER   = __primitive("get compiler variable", "CHPL_HOST_COMPILER");
+  param CHPL_HOST_COMPILER:string   = __primitive("get compiler variable", "CHPL_HOST_COMPILER");
 
   /* See :ref:`readme-chplenv.CHPL_COMPILER` for more information. */
-  param CHPL_TARGET_COMPILER = __primitive("get compiler variable", "CHPL_TARGET_COMPILER");
+  param CHPL_TARGET_COMPILER:string = __primitive("get compiler variable", "CHPL_TARGET_COMPILER");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_ARCH` for more information. */
-  param CHPL_TARGET_ARCH     = __primitive("get compiler variable", "CHPL_TARGET_ARCH");
+  param CHPL_TARGET_ARCH:string     = __primitive("get compiler variable", "CHPL_TARGET_ARCH");
 
   /* See :ref:`readme-chplenv.CHPL_LOCALE_MODEL` for more information. */
-  param CHPL_LOCALE_MODEL    = __primitive("get compiler variable", "CHPL_LOCALE_MODEL");
+  param CHPL_LOCALE_MODEL:string    = __primitive("get compiler variable", "CHPL_LOCALE_MODEL");
 
   /* See :ref:`readme-chplenv.CHPL_COMM` for more information. */
-  param CHPL_COMM            = __primitive("get compiler variable", "CHPL_COMM");
+  param CHPL_COMM:string            = __primitive("get compiler variable", "CHPL_COMM");
 
   /* See :ref:`readme-launcher` for more information. */
-  param CHPL_COMM_SUBSTRATE  = __primitive("get compiler variable", "CHPL_COMM_SUBSTRATE");
+  param CHPL_COMM_SUBSTRATE:string  = __primitive("get compiler variable", "CHPL_COMM_SUBSTRATE");
 
   /* See :ref:`readme-multilocale` for more information. */
-  param CHPL_GASNET_SEGMENT  = __primitive("get compiler variable", "CHPL_GASNET_SEGMENT");
+  param CHPL_GASNET_SEGMENT:string  = __primitive("get compiler variable", "CHPL_GASNET_SEGMENT");
 
   /* See :ref:`readme-chplenv.CHPL_TASKS` for more information. */
-  param CHPL_TASKS           = __primitive("get compiler variable", "CHPL_TASKS");
+  param CHPL_TASKS:string           = __primitive("get compiler variable", "CHPL_TASKS");
 
   /* See :ref:`readme-chplenv.CHPL_LAUNCHER` for more information. */
-  param CHPL_LAUNCHER        = __primitive("get compiler variable", "CHPL_LAUNCHER");
+  param CHPL_LAUNCHER:string        = __primitive("get compiler variable", "CHPL_LAUNCHER");
 
   /* See :ref:`readme-chplenv.CHPL_TIMERS` for more information. */
-  param CHPL_TIMERS          = __primitive("get compiler variable", "CHPL_TIMERS");
+  param CHPL_TIMERS:string          = __primitive("get compiler variable", "CHPL_TIMERS");
 
   /* See :ref:`readme-chplenv.CHPL_MEM` for more information. */
-  param CHPL_MEM             = __primitive("get compiler variable", "CHPL_MEM");
+  param CHPL_MEM:string             = __primitive("get compiler variable", "CHPL_MEM");
 
   /* See :ref:`readme-chplenv.CHPL_MAKE` for more information. */
-  param CHPL_MAKE            = __primitive("get compiler variable", "CHPL_MAKE");
+  param CHPL_MAKE:string            = __primitive("get compiler variable", "CHPL_MAKE");
 
   /* See :ref:`readme-chplenv.CHPL_ATOMICS` for more information. */
-  param CHPL_ATOMICS         = __primitive("get compiler variable", "CHPL_ATOMICS");
+  param CHPL_ATOMICS:string         = __primitive("get compiler variable", "CHPL_ATOMICS");
 
   /* See :ref:`readme-atomics` for more information. */
-  param CHPL_NETWORK_ATOMICS = __primitive("get compiler variable", "CHPL_NETWORK_ATOMICS");
+  param CHPL_NETWORK_ATOMICS:string = __primitive("get compiler variable", "CHPL_NETWORK_ATOMICS");
 
   /* See :ref:`readme-chplenv.CHPL_GMP` for more information. */
-  param CHPL_GMP             = __primitive("get compiler variable", "CHPL_GMP");
+  param CHPL_GMP:string             = __primitive("get compiler variable", "CHPL_GMP");
 
   /* See :ref:`readme-chplenv.CHPL_HWLOC` for more information. */
-  param CHPL_HWLOC           = __primitive("get compiler variable", "CHPL_HWLOC");
+  param CHPL_HWLOC:string           = __primitive("get compiler variable", "CHPL_HWLOC");
 
   /* See :ref:`readme-chplenv.CHPL_REGEXP` for more information. */
-  param CHPL_REGEXP          = __primitive("get compiler variable", "CHPL_REGEXP");
+  param CHPL_REGEXP:string          = __primitive("get compiler variable", "CHPL_REGEXP");
 
   /* See :ref:`readme-chplenv.CHPL_WIDE_POINTERS` for more information. */
-  param CHPL_WIDE_POINTERS   = __primitive("get compiler variable", "CHPL_WIDE_POINTERS");
+  param CHPL_WIDE_POINTERS:string   = __primitive("get compiler variable", "CHPL_WIDE_POINTERS");
 
   /* See :ref:`readme-chplenv.CHPL_LLVM` for more information. */
-  param CHPL_LLVM            = __primitive("get compiler variable", "CHPL_LLVM");
+  param CHPL_LLVM:string            = __primitive("get compiler variable", "CHPL_LLVM");
 }


### PR DESCRIPTION
These two simple web doc changes (772275dd02d3e532df2efbdb24d2f58c788c8c82 and  74a16f0f0ce591a32579397fea77d07410755125) were made after the 1.13 branch was cut and code/doc freeze had passed, but didn't seem worth re-spinning the release for.  Yet, they are changes we'd like to get onto the chapel.cray.com website with the 1.13 release documentation here (and in any minor releases we might make to 1.13), so I'm pushing them to this branch after some discussion among interested members of the team.
