### PR TITLE
Cherry pick html doc title fixup for 1.13 web docs

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -138,8 +138,8 @@ if not on_rtd:
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
+# We set this because the default title is repetitive
 html_title = 'Chapel Documentation {0}'.format(shortversion)
-#html_short_title = ''
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -138,7 +138,8 @@ if not on_rtd:
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = version
+html_title = 'Chapel Documentation {0}'.format(shortversion)
+#html_short_title = ''
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None


### PR DESCRIPTION
I forgot about this one which makes our HTML titles far less ridiculous.  Also seems like a no-brainer for the www release docs.
