### PR TITLE
Add a future about domain assignment that changes stridedness

### DIFF
--- a/test/domains/diten/domainReassignChangeStridedness.chpl
+++ b/test/domains/diten/domainReassignChangeStridedness.chpl
@@ -1,0 +1,10 @@
+var D1 = {1..10};
+var A: [D1] int;
+
+const D2 = {1..20 by 2};
+//const D3 = {1:uint..10:uint};
+//const D4 = {1..2, 1..5};
+
+D1 = D2; // can domain reassign change stridedness?
+//D1 = D3; // can domain reassign change idxType? Currently a compiler error
+//D1 = D4; // can domain reassign change rank? Currently a compiler error

--- a/test/domains/diten/domainReassignChangeStridedness.future
+++ b/test/domains/diten/domainReassignChangeStridedness.future
@@ -1,0 +1,5 @@
+bug: domain assignment that changes stridedness causes runtime crash
+
+I think this should be a compiler error similar to domain assignments that
+change rank or idxType. Assignments that change rank and idxType are commented
+out in this test as an example.

--- a/test/domains/diten/domainReassignChangeStridedness.good
+++ b/test/domains/diten/domainReassignChangeStridedness.good
@@ -1,0 +1,1 @@
+domainReassignChangeStridedness.chpl:8: error: stridable mismatch in domain assignment


### PR DESCRIPTION
This test currently crashes at runtime due to an infinite recursion.  Brad
has a change in progress that should fix that crash, but it gets a runtime
halt.  I think we should catch this case at compile time and report an error
then instead, similar to what we do for a rank mismatch or idxType mismatch.