### PR TITLE
Disable gmp for pgi whitebox testing

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -92,7 +92,7 @@ if [ "${COMPILER}" != "gnu" ] ; then
     module load gcc/${CHPL_GCC_TARGET_VERSION}
 fi
 
-# quiet libu warning about cpuid detection failure until it's fixed in CCE 8.4
+# quiet libu warning about cpuid detection failure
 if [ "${COMPILER}" == "cray" ] ; then
   export RFE_811452_DISABLE=true
 fi
@@ -107,7 +107,14 @@ case $COMPILER in
         log_info "Swap network module for host-only environment."
         module swap craype-network-aries craype-target-local_host
         ;;
-    intel|gnu|pgi)
+    intel|gnu)
+        ;;
+    pgi)
+        # EJR (04/07/16): Since the default pgi was upgraded from 15.10.0 to
+        # 16.3.0 on 04/02/16 the speculative gmp build gets stuck in an
+        # infinite loop during `make check` while trying to test t_scan.c. Just
+        # force disable gmp until there's more time to investigate this.
+        export CHPL_GMP=none
         ;;
     *)
         log_error "Unknown COMPILER value: ${COMPILER}. Exiting."


### PR DESCRIPTION
Since the default pgi was upgraded from 15.10.0 to 16.3.0 on 04/02/16 the
speculative gmp build gets stuck in an infinite loop during `make check` while
trying to test t_scan.c. Just force disable gmp until there's more time to
investigate this so that whitebox testing actually finishes.

I did a little bit of digging so far. This hang also occurs with pgi 16.1.0 as
well. It's pretty easy to reproduce outside of our repo. I just downloaded the
latest release of gmp (6.1.0) and did:

    ./configure CC=cc --prefix=$PWD/../gmp-install --enable-static --disable-shared
    make
    make check

I'm hoping to have some time to look into this next week, but in the meantime
this will at least let testing finish.