### PR TITLE
Stencil - add `proc main()` again and correct fluff update for 'pretty' version

### DIFF
--- a/test/studies/prk/stencil/stencil-fast.chpl
+++ b/test/studies/prk/stencil/stencil-fast.chpl
@@ -121,6 +121,9 @@ proc main() {
   /* Initialize Input matrix */
   [(i, j) in Dom] input[i,j] = coefx*i+coefy*j;
 
+  /* Update ghost cells with initial values */
+  if useStencilDist then input.updateFluff();
+
   //
   // Print information before main loop
   //
@@ -140,7 +143,6 @@ proc main() {
     else                        writeln("Distribution         = None");
   }
 
-  if useStencilDist then input.updateFluff();
   //
   // Main loop of Stencil
   //

--- a/test/studies/prk/stencil/stencil-fast.chpl
+++ b/test/studies/prk/stencil/stencil-fast.chpl
@@ -99,13 +99,20 @@ proc main() {
                 else if useStencilDist then stencilDist
                 else noDist;
 
+  const outputDist =  if useBlockDist then blockDist
+                      else if useStencilDist then blockDist
+                      else noDist;
+
   /* Map domains to selected distribution */
   const Dom = localDom dmapped new dmap(Dist),
    innerDom = innerLocalDom dmapped new dmap(Dist),
    tiledDom = tiledLocalDom dmapped new dmap(Dist);
 
+  const outputDom = localDom dmapped new dmap(outputDist);
+
   /* Input and Output matrices represented as arrays over a 2D domain */
-  var input, output:  [Dom] dtype = 0.0;
+  var input: [Dom] dtype = 0.0,
+      output: [outputDom] dtype = 0.0;
 
   /* Weight matrix represented as tuple of tuples*/
   var weight: Wsize*(Wsize*(dtype));
@@ -200,7 +207,7 @@ proc main() {
     /* Update ghost cells for each locales, for StencilDist */
     if useStencilDist then {
       if debug then diagnostics('output.updateFluff()');
-      output.updateFluff();
+      //output.updateFluff();
       input.updateFluff();
     }
 

--- a/test/studies/prk/stencil/stencil-fast.chpl
+++ b/test/studies/prk/stencil/stencil-fast.chpl
@@ -57,187 +57,189 @@ const activePoints = (order-2*R)*(order-2*R),
 var timer: Timer;
 
 /* Parallel Research Kernel - Stencil */
+proc main() {
 
-//
-// Process and test input configs
-//
-if (iterations < 1) {
-  writeln("ERROR: iterations must be >= 1: ", iterations);
-  exit(1);
-}
-if (order < 1) {
-  writeln("ERROR: Matrix Order must be greater than 0 : ", order);
-  exit(1);
-}
-if (R < 1) {
-  writeln("ERROR: Stencil radius ", R, " should be positive");
-  exit(1);
-}
-if (2*R + 1 > order) {
-  writeln("ERROR: Stencil radius ", R, " exceeds grid size ", order);
-  exit(1);
-}
-
-/* If tiling is disabled, ensure tiledDom can still be created */
-if (!tiling) then tileSize = 1;
-
-/* Domain over entire Input/Output matrices */
-const localDom = {0.. # order, 0.. # order},
-/* Domain over entire 'active' region, where Output will be updated */
- innerLocalDom = localDom.expand(-R),
-/* Strided domain over 'active' region - possibly a cleaner way to write...*/
-tiledLocalDom = {R.. # order-2*R by tileSize, R.. # order-2*R by tileSize};
-
-/* Flavors of parallelism, by distribution */
-const blockDist = new Block(localDom),
-    stencilDist = new Stencil(innerLocalDom, fluff=(R,R)),
-         noDist = new DefaultDist();
-
-/* Set distribution based on configs */
-const Dist =  if useBlockDist then blockDist
-              else if useStencilDist then stencilDist
-              else noDist;
-
-/* Map domains to selected distribution */
-const Dom = localDom dmapped new dmap(Dist),
- innerDom = innerLocalDom dmapped new dmap(Dist),
- tiledDom = tiledLocalDom dmapped new dmap(Dist);
-
-/* Input and Output matrices represented as arrays over a 2D domain */
-var input, output:  [Dom] dtype = 0.0;
-
-/* Weight matrix represented as tuple of tuples*/
-var weight: Wsize*(Wsize*(dtype));
-
-for i in 1..R {
-  const element : dtype = 1 / (2*i*R) : dtype;
-  weight[R1][R1+i]  =  element;
-  weight[R1+i][R1]  =  element;
-  weight[R1-i][R1] = -element;
-  weight[R1][R1-i] = -element;
-}
-
-/* Initialize Input matrix */
-[(i, j) in Dom] input[i,j] = coefx*i+coefy*j;
-
-//
-// Print information before main loop
-//
-if (!validate) {
-  writeln("Parallel Research Kernels Version ", PRKVERSION);
-  writeln("Serial stencil execution on 2D grid");
-  writeln("Grid size            = ", order);
-  writeln("Radius of stencil    = ", R);
-  if compact then writeln("Type of stencil      = compact");
-  else            writeln("Type of stencil      = star");
-  writeln("Data type            = ", dtype:string);
-  if tiling then writeln("Tile size             = ", tileSize);
-  else           writeln("Untiled");
-  writeln("Number of iterations = ", iterations);
-  if useBlockDist then        writeln("Distribution         = Block");
-  else if useStencilDist then writeln("Distribution         = Stencil");
-  else                        writeln("Distribution         = None");
-}
-
-if useStencilDist then input.updateFluff();
-//
-// Main loop of Stencil
-//
-if debug then startVdebug("stencil-fast-vis");
-for iteration in 0..iterations {
-
-  /* Start timer after warmup iteration */
-  if (iteration == 1) {
-    timer.start();
+  //
+  // Process and test input configs
+  //
+  if (iterations < 1) {
+    writeln("ERROR: iterations must be >= 1: ", iterations);
+    exit(1);
+  }
+  if (order < 1) {
+    writeln("ERROR: Matrix Order must be greater than 0 : ", order);
+    exit(1);
+  }
+  if (R < 1) {
+    writeln("ERROR: Stencil radius ", R, " should be positive");
+    exit(1);
+  }
+  if (2*R + 1 > order) {
+    writeln("ERROR: Stencil radius ", R, " exceeds grid size ", order);
+    exit(1);
   }
 
-  if debug then diagnostics('stencil');
-  if (!tiling) {
-    forall (i,j) in innerDom with (in weight) {
-      var tmpout: dtype = 0.0;
-      if (!compact) {
-        for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input[i, j+jj];
-        for param jj in 1..R   do tmpout += weight[R1][R1+jj] * input[i, j+jj];
-        for param ii in -R..-1 do tmpout += weight[R1+ii][R1] * input[i+ii, j];
-        for param ii in 1..R   do tmpout += weight[R1+ii][R1] * input[i+ii, j];
-      } else {
-        for ii in -R..R do
-          for jj in -R..R do
-            tmpout += weight[R1+ii][R1+jj] * input[i+ii, j+jj];
-      }
-      output[i, j] += tmpout;
+  /* If tiling is disabled, ensure tiledDom can still be created */
+  if (!tiling) then tileSize = 1;
+
+  /* Domain over entire Input/Output matrices */
+  const localDom = {0.. # order, 0.. # order},
+  /* Domain over entire 'active' region, where Output will be updated */
+   innerLocalDom = localDom.expand(-R),
+  /* Strided domain over 'active' region - possibly a cleaner way to write...*/
+  tiledLocalDom = {R.. # order-2*R by tileSize, R.. # order-2*R by tileSize};
+
+  /* Flavors of parallelism, by distribution */
+  const blockDist = new Block(localDom),
+      stencilDist = new Stencil(innerLocalDom, fluff=(R,R)),
+           noDist = new DefaultDist();
+
+  /* Set distribution based on configs */
+  const Dist =  if useBlockDist then blockDist
+                else if useStencilDist then stencilDist
+                else noDist;
+
+  /* Map domains to selected distribution */
+  const Dom = localDom dmapped new dmap(Dist),
+   innerDom = innerLocalDom dmapped new dmap(Dist),
+   tiledDom = tiledLocalDom dmapped new dmap(Dist);
+
+  /* Input and Output matrices represented as arrays over a 2D domain */
+  var input, output:  [Dom] dtype = 0.0;
+
+  /* Weight matrix represented as tuple of tuples*/
+  var weight: Wsize*(Wsize*(dtype));
+
+  for i in 1..R {
+    const element : dtype = 1 / (2*i*R) : dtype;
+    weight[R1][R1+i]  =  element;
+    weight[R1+i][R1]  =  element;
+    weight[R1-i][R1] = -element;
+    weight[R1][R1-i] = -element;
+  }
+
+  /* Initialize Input matrix */
+  [(i, j) in Dom] input[i,j] = coefx*i+coefy*j;
+
+  //
+  // Print information before main loop
+  //
+  if (!validate) {
+    writeln("Parallel Research Kernels Version ", PRKVERSION);
+    writeln("Serial stencil execution on 2D grid");
+    writeln("Grid size            = ", order);
+    writeln("Radius of stencil    = ", R);
+    if compact then writeln("Type of stencil      = compact");
+    else            writeln("Type of stencil      = star");
+    writeln("Data type            = ", dtype:string);
+    if tiling then writeln("Tile size             = ", tileSize);
+    else           writeln("Untiled");
+    writeln("Number of iterations = ", iterations);
+    if useBlockDist then        writeln("Distribution         = Block");
+    else if useStencilDist then writeln("Distribution         = Stencil");
+    else                        writeln("Distribution         = None");
+  }
+
+  if useStencilDist then input.updateFluff();
+  //
+  // Main loop of Stencil
+  //
+  if debug then startVdebug("stencil-fast-vis");
+  for iteration in 0..iterations {
+
+    /* Start timer after warmup iteration */
+    if (iteration == 1) {
+      timer.start();
     }
-  } else {
-    forall (it,jt) in tiledDom {
-      for i in it .. # min(order - R - it, tileSize) {
-        for j in jt .. # min(order - R - jt, tileSize) {
-          var tmpout: dtype = 0.0;
-          if (!compact) {
-            for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input[i, j+jj];
-            for param jj in 1..R   do tmpout += weight[R1][R1+jj] * input[i, j+jj];
-            for param ii in -R..-1 do tmpout += weight[R1+ii][R1] * input[i+ii, j];
-            for param ii in 1..R   do tmpout += weight[R1+ii][R1] * input[i+ii, j];
-          } else {
-            for ii in -R..R do
-              for jj in -R..R do
-                tmpout += weight[R1+ii][R1+jj] * input[i+ii, j+jj];
+
+    if debug then diagnostics('stencil');
+    if (!tiling) {
+      forall (i,j) in innerDom with (in weight) {
+        var tmpout: dtype = 0.0;
+        if (!compact) {
+          for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input[i, j+jj];
+          for param jj in 1..R   do tmpout += weight[R1][R1+jj] * input[i, j+jj];
+          for param ii in -R..-1 do tmpout += weight[R1+ii][R1] * input[i+ii, j];
+          for param ii in 1..R   do tmpout += weight[R1+ii][R1] * input[i+ii, j];
+        } else {
+          for ii in -R..R do
+            for jj in -R..R do
+              tmpout += weight[R1+ii][R1+jj] * input[i+ii, j+jj];
+        }
+        output[i, j] += tmpout;
+      }
+    } else {
+      forall (it,jt) in tiledDom {
+        for i in it .. # min(order - R - it, tileSize) {
+          for j in jt .. # min(order - R - jt, tileSize) {
+            var tmpout: dtype = 0.0;
+            if (!compact) {
+              for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input[i, j+jj];
+              for param jj in 1..R   do tmpout += weight[R1][R1+jj] * input[i, j+jj];
+              for param ii in -R..-1 do tmpout += weight[R1+ii][R1] * input[i+ii, j];
+              for param ii in 1..R   do tmpout += weight[R1+ii][R1] * input[i+ii, j];
+            } else {
+              for ii in -R..R do
+                for jj in -R..R do
+                  tmpout += weight[R1+ii][R1+jj] * input[i+ii, j+jj];
+            }
+            output[i, j] += tmpout;
           }
-          output[i, j] += tmpout;
         }
       }
     }
-  }
 
-  /* Add constant to solution to force refresh of neighbor data */
-  if debug then diagnostics('input += 1');
-  forall (i,j) in Dom {
-    input[i, j] += 1.0;
-  }
+    /* Add constant to solution to force refresh of neighbor data */
+    if debug then diagnostics('input += 1');
+    forall (i,j) in Dom {
+      input[i, j] += 1.0;
+    }
 
-  /* Update ghost cells for each locales, for StencilDist */
-  if useStencilDist then {
-    if debug then diagnostics('output.updateFluff()');
-    output.updateFluff();
-    input.updateFluff();
-  }
+    /* Update ghost cells for each locales, for StencilDist */
+    if useStencilDist then {
+      if debug then diagnostics('output.updateFluff()');
+      output.updateFluff();
+      input.updateFluff();
+    }
 
 
-} /* end of main loop */
+  } /* end of main loop */
 
-timer.stop();
-if debug then stopVdebug();
+  timer.stop();
+  if debug then stopVdebug();
 
-//
-// Analyze and output results
-//
+  //
+  // Analyze and output results
+  //
 
-/* Timings */
-var stencilTime = timer.elapsed(),
-    flops = (2*stencilSize + 1) * activePoints,
-    avgTime = stencilTime / iterations;
+  /* Timings */
+  var stencilTime = timer.elapsed(),
+      flops = (2*stencilSize + 1) * activePoints,
+      avgTime = stencilTime / iterations;
 
-/* Compute L1 norm */
-var referenceNorm = (iterations + 1) * (coefx + coefy),
-    norm = + reduce abs(output);
-norm /= activePoints;
+  /* Compute L1 norm */
+  var referenceNorm = (iterations + 1) * (coefx + coefy),
+      norm = + reduce abs(output);
+  norm /= activePoints;
 
-/* Error threshold */
-const epsilon = 1.e-8;
+  /* Error threshold */
+  const epsilon = 1.e-8;
 
-/* Verify correctness */
-if abs(norm-referenceNorm) > epsilon then {
-  writeln("ERROR: L1 norm = ", norm, ", Reference L1 norm = ", referenceNorm);
-  exit(1);
-} else {
-  writeln("Solution validates");
+  /* Verify correctness */
+  if abs(norm-referenceNorm) > epsilon then {
+    writeln("ERROR: L1 norm = ", norm, ", Reference L1 norm = ", referenceNorm);
+    exit(1);
+  } else {
+    writeln("Solution validates");
 
-  if debug {
-    writeln("L1 norm = ", norm, ", Reference L1 norm = ", referenceNorm);
-  }
+    if debug {
+      writeln("L1 norm = ", norm, ", Reference L1 norm = ", referenceNorm);
+    }
 
-  if (!validate) {
-    writeln("Rate (MFlops/s): ", 1.0E-06 * flops/avgTime, "  Avg time (s): ",
-            avgTime);
+    if (!validate) {
+      writeln("Rate (MFlops/s): ", 1.0E-06 * flops/avgTime, "  Avg time (s): ",
+              avgTime);
+    }
   }
 }
 

--- a/test/studies/prk/stencil/stencil-fast.chpl
+++ b/test/studies/prk/stencil/stencil-fast.chpl
@@ -206,8 +206,7 @@ proc main() {
 
     /* Update ghost cells for each locales, for StencilDist */
     if useStencilDist then {
-      if debug then diagnostics('output.updateFluff()');
-      //output.updateFluff();
+      if debug then diagnostics('input.updateFluff()');
       input.updateFluff();
     }
 

--- a/test/studies/prk/stencil/stencil-pretty.chpl
+++ b/test/studies/prk/stencil/stencil-pretty.chpl
@@ -201,6 +201,7 @@ proc main() {
     if useStencilDist then {
       if debug then diagnostics('output.updateFluff()');
       output.updateFluff();
+      input.updateFluff();
     }
 
 

--- a/test/studies/prk/stencil/stencil-pretty.chpl
+++ b/test/studies/prk/stencil/stencil-pretty.chpl
@@ -202,8 +202,7 @@ proc main() {
 
     /* Update ghost cells for each locales, for StencilDist */
     if useStencilDist then {
-      if debug then diagnostics('output.updateFluff()');
-      output.updateFluff();
+      if debug then diagnostics('input.updateFluff()');
       input.updateFluff();
     }
 

--- a/test/studies/prk/stencil/stencil-pretty.chpl
+++ b/test/studies/prk/stencil/stencil-pretty.chpl
@@ -101,6 +101,9 @@ proc main() {
   const Dist = if useBlockDist then blockDist
                else if useStencilDist then stencilDist
                else noDist,
+  outputDist =  if useBlockDist then blockDist
+                      else if useStencilDist then blockDist
+                      else noDist,
   /* Replicated distribution ensures a full local copy on each locale */
   weightDist = if (useBlockDist || useStencilDist) then replDist
                else noDist;

--- a/test/studies/prk/stencil/stencil-pretty.chpl
+++ b/test/studies/prk/stencil/stencil-pretty.chpl
@@ -111,9 +111,12 @@ proc main() {
    tiledDom = tiledLocalDom dmapped new dmap(Dist),
   weightDom = weightLocalDom dmapped new dmap(weightDist);
 
+  const outputDom = localDom dmapped new dmap(outputDist);
+
   /* Input and Output matrices represented as arrays over a 2D domain */
-  var input, output:  [Dom] dtype = 0.0,
-        weight: [weightDom] dtype = 0.0;
+  var input: [Dom] dtype = 0.0,
+      output: [outputDom] dtype = 0.0,
+      weight: [weightDom] dtype = 0.0;
 
   /* Creating weight matrix on each locale */
   for L in Locales do on L {

--- a/test/studies/prk/stencil/stencil-pretty.chpl
+++ b/test/studies/prk/stencil/stencil-pretty.chpl
@@ -129,6 +129,9 @@ proc main() {
   /* Initialize Input matrix */
   [(i, j) in Dom] input[i,j] = coefx*i+coefy*j;
 
+  /* Update ghost cells with initial values */
+  if useStencilDist then input.updateFluff();
+
 
   //
   // Print information before main loop


### PR DESCRIPTION
* `proc main()` was removed due to a (now) known bug with `pragma "locale private"`. Since we switched to task intents, we can now add `proc main()` back in.
* Corrected error in which 'pretty-fast' version was not updating input matrix fluff cells before first iteration
* We now update fluff cells every iteration to remain true to the original implementations
* We now use `blockDist` for output matrix, when `useStencilDist` is activated.
    * This should result in significant performance bump for `stencilDist` implementations


* [x] Correctness tested on Tiger w/ GASNet
* [x] Performance tested on Tiger w/ GASNet