### PR TITLE
Remove the "old" perfkey from the MiniMD graph

### DIFF
--- a/test/release/examples/benchmarks/miniMD/miniMD.graph
+++ b/test/release/examples/benchmarks/miniMD/miniMD.graph
@@ -1,6 +1,6 @@
-perfkeys: Time:, Time:, Time:, Time:, Time:, Time:
-graphkeys: old, simple, simple nolocal, simple block nolocal,stencil nolocal,explicit nolocal
+perfkeys: Time:, Time:, Time:, Time:, Time:
+graphkeys:simple, simple nolocal, simple block nolocal,stencil nolocal,explicit nolocal
 ylabel: Time (seconds)
-files: miniMD.dat, miniMD.simple.dat, miniMD.simple-nolocal.dat, miniMD.simple-block.dat, miniMD.stencil.dat, miniMD.explicit.dat
+files: miniMD.simple.dat, miniMD.simple-nolocal.dat, miniMD.simple-block.dat, miniMD.stencil.dat, miniMD.explicit.dat
 graphtitle: miniMD LJ (--size=10) Time
 graphname: miniMD


### PR DESCRIPTION
We no longer run this configuration and it's not of much interest to us
anymore.

Removing this key covers up a gengraphs bug that's currently causing the "old"
key to replace an actual key for chapcs perf graphs.

For chapcs testing, the old MiniMD config was never run, so we didn't have a
.dat file for it. However, gengraphs doesn't create dummy data for the key so
it was "stealing" the actual data from another key.

Unfortunately this is a hard bug to fix with the way gengraphs currently
collates .dat files, so for now I'm just working around it and will work on
fixing gengraphs in the future. Really, I'd like to rewrite most of gengraphs
and add some actual error checking, but I probably won't get time to do that :(