### PR TITLE
Adjust qio_shortest_path to soothe Coverity

### DIFF
--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1753,17 +1753,13 @@ qioerr qio_shortest_path(qio_file_t* file, const char** path_out, const char* pa
 
   err = qio_relative_path(&relpath, cwd, path_in);
 
-  //printf("cwd %s abs %s rel %s\n", cwd, path_in, relpath);
+  // If relpath is NULL, err should have been non-zero.
+  // This line is here to quiety Coverity.
+  if( !relpath ) err = QIO_ENOMEM;
 
   qio_free((void*) cwd); cwd = NULL;
 
   if( ! err ) {
-    //
-    // If relpath is NULL, err should have been non-zero, but Coverity
-    // doesn't feel safe about this, so I'm adding this assertion to
-    // be double-sure.
-    //
-    assert(relpath != NULL);
     // Use relpath or path_in, whichever is shorter.
     if( strlen(relpath) < strlen(path_in) ) {
       *path_out = relpath; relpath = NULL;


### PR DESCRIPTION
Coverity started complaining about this code again for some reason. Here
I take away the assert I added earlier and instead add code that sets err
if relpath == NULL. I'm hoping that this will resolve issue 1350087.

Trivial and not reviewed.
Passed test/io/ on a Mac.