### PR TITLE
Fix ~ in Lexical Structure/Tokens/Operators and Punctiation

### DIFF
--- a/spec/spec.tex
+++ b/spec/spec.tex
@@ -1,4 +1,5 @@
 \documentclass[10pt,oneside,titlepage]{spec}
+\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{color}


### PR DESCRIPTION
I see many online Tex sites encouraging the use of

\usepackage[T1]{fontenc}

While I have relatively little understanding of what that actually does,
it seems enable cut/paste from the operators table to a terminal (for me
at least). My reading indicates it should solve the problem generally.

I poked around in the spec and do not see any other visual changes from
making this change.

Vass and I checked that it solved the problem on Linux and Mac OS X and
that the spec still looked OK.
