### PR TITLE
Fix associative iteration problem size for valgrind testing

### DIFF
--- a/test/distributions/robust/associative/performance/array_iter.chpl
+++ b/test/distributions/robust/associative/performance/array_iter.chpl
@@ -5,7 +5,7 @@ config const verify = true;
 
 config const offset = 7;
 
-config const memFraction = if verify then 10000 else 5000;
+config const memFraction = if verify then 100000 else 5000;
 type eltType = int;
 
 const totalMem = here.physicalMemory(unit = MemUnits.Bytes);

--- a/test/distributions/robust/associative/performance/domain_iter.chpl
+++ b/test/distributions/robust/associative/performance/domain_iter.chpl
@@ -5,7 +5,7 @@ config const verify = true;
 
 config const offset = 7;
 
-config const memFraction = if verify then 5000 else 1000;
+config const memFraction = if verify then 100000 else 1000;
 type eltType = int;
 
 const totalMem = here.physicalMemory(unit = MemUnits.Bytes);


### PR DESCRIPTION
Reduce the problem size for array_iter and domain_iter during --verify (correctness) testing. This is motivated by valgrind testing timing out after moving to a machine with more memory.