### PR TITLE
Add a semicolon after 'q' command for a 'sed' command

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -284,7 +284,7 @@ sub feed_nodes {
                     # print Error lines; terminate when we reach Test Summary
                     ? '/^\\[Error/p; /^\\[Test Summary/q'
                     # once an Error line is seen, print it and terminate
-                    : '/^\\[Error/{p;q}';
+                    : '/^\\[Error/{p;q;}';
                   $partial_errors = `sed -n '$pe_command' $logfile`;
                   if ($partial_errors) {
                       print "\n:( $partial_errors";


### PR DESCRIPTION
The 'sed' command on Mac expects a semicolon after the 'q' command here.
Without the semicolon, it complains:

`sed: 1: "/^\[Error/{p;q}": extra characters at the end of q command`

Tested on Mac and Linux64