### PR TITLE
Revert fix for Kushal's inter-dmap assignment case

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1036,24 +1036,13 @@ module DefaultRectangular {
     }
 
     proc dsiReallocate(d: domain) {
-      on this {
-      //
-      // If both d and dom are default rectangular, this is pretty
-      // easy...
-      //
       if (d._value.type == dom.type) {
+        on this {
         var copy = new DefaultRectangularArr(eltType=eltType, rank=rank,
-                                             idxType=idxType,
-                                             stridable=d._value.stridable,
-                                             dom=d._value);
-        //
-        // TODO: Making this for into a forall ought to accelerate
-        // dsiReallocate() calls, yet doing so breaks due to uint/int
-        // interaction issues today.  Deserves more of a look...
-        // Does our standalone parallel iterator not have the same
-        // type flexibility as the serial iterator?
-        //
-        for i in d[(...dom.ranges)] do
+                                            idxType=idxType,
+                                            stridable=d._value.stridable,
+                                            dom=d._value);
+        for i in d((...dom.ranges)) do
           copy.dsiAccess(i) = dsiAccess(i);
         off = copy.off;
         blk = copy.blk;
@@ -1075,16 +1064,9 @@ module DefaultRectangular {
             shiftedData = copy.shiftedData;
         //numelm = copy.numelm;
         delete copy;
+        }
       } else {
-        //
-        // In this case, dom is DefaultRectangular, but d is not.  We
-        // permit assignments between distributed domains and non-,
-        // interpreting it as just the assignment of the index sets.
-        // So for the purposes of this reallocation, just create a
-        // temporary DefaultRectangular domain and use it above.
-        //
-        dsiReallocate({(...d.getIndices())});
-      }
+        halt("illegal reallocation");
       }
     }
   

--- a/test/distributions/kushal/assignDomain.bad
+++ b/test/distributions/kushal/assignDomain.bad
@@ -1,0 +1,7 @@
+arrA is: 0 0 0
+arrB is: 0 0 0
+
+arrA is: 0 0 0
+arrB is: 0 0 0
+
+assignDomain.chpl:20: error: halt reached - illegal reallocation

--- a/test/distributions/kushal/assignDomain.future
+++ b/test/distributions/kushal/assignDomain.future
@@ -1,0 +1,7 @@
+bug: unable to assign between non-distributed and distributed domains
+
+This bug limits the types of operations that can be currently done 
+using domains. For instance choosing a subset of an array A[low..hi]
+should be independent of the fact that it is distributed or not.
+However, this bug points out that such a thing would currently not
+be possible.


### PR DESCRIPTION
This fix from PR #3423 caused our compiler to generate a (never
called) infinitely recursive routine which results in a clang warning
(treated as error for developers and in the test system) for clang
7.3.0 or later.  I've been trying to put a quick fix together (e.g.,
PR #3698 and my fix-clang-inf-loop-warning-wander branch), but
have been thwarted in each attempt so far by dynamic dispatch
resolution and entanglements in the domain map framework.  It still
seems as though a fairly simple solution should not be difficult, but
with the limited cycles I've had to put into it, I haven't been able
to crack it, and it seems like reverting this is the better thing to
do for now given the impacts of the warnings on clang developers.

For future reference, fixes to this future should be tested with clang
7.3.0 on test/release/examples/hello4-datapar-dist.chpl before
committing to make sure that they haven't run afoul of this issue
again.