### PR TITLE
Do not require $CHPL_HOST_PLATFORM for testReleasesPerformance

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -47,13 +47,18 @@ fi
 export CHPL_HOME_ORIG=$CHPL_HOME
 export CHPL_TEST_UTIL_DIR=$CHPL_HOME_ORIG/util
 
-if [[ -z $CHPL_TEST_VENV_DIR && ! -z $CHPL_HOST_PLATFORM ]]; then
-    export CHPL_TEST_VENV_DIR=$CHPL_HOME_ORIG/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/chpl-virtualenv
+if [[ -z $CHPL_TEST_VENV_DIR ]]; then
+    if [[ -z $CHPL_HOST_PLATFORM ]]; then
+        export CHPL_TEST_VENV_DIR=$CHPL_HOME_ORIG/third-party/chpl-venv/install/`$CHPL_TEST_UTIL_DIR/chplenv/chpl_platform.py --host`/chpl-virtualenv
+    else
+        export CHPL_TEST_VENV_DIR=$CHPL_HOME_ORIG/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/chpl-virtualenv
+    fi
 fi
 if [[ ! -d $CHPL_TEST_VENV_DIR ]]; then
-    echo "ERROR: incorrect or missing CHPL_TEST_VENV_DIR=$CHPL_TEST_VENV_DIR or CHPL_HOST_PLATFORM"
+    echo "ERROR: incorrect or missing CHPL_TEST_VENV_DIR='$CHPL_TEST_VENV_DIR'"
     exit 1
 fi
+echo VASS SUCCESS; exit
 
 #
 # This is a place where all releases will be unpacked and built with

--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -58,7 +58,6 @@ if [[ ! -d $CHPL_TEST_VENV_DIR ]]; then
     echo "ERROR: incorrect or missing CHPL_TEST_VENV_DIR='$CHPL_TEST_VENV_DIR'"
     exit 1
 fi
-echo VASS SUCCESS; exit
 
 #
 # This is a place where all releases will be unpacked and built with


### PR DESCRIPTION
In ab16e10 I removed the requirement that $CHPL_TEST_VENV_DIR
be set for testReleasesPerformance. Instead, it relied on
$CHPL_HOST_PLATFORM to compute $CHPL_TEST_VENV_DIR.

At Brad's request, testReleasesPerformance now gets $CHPL_HOST_PLATFORM
from printchplenv scripts when needed for setting CHPL_TEST_VENV_DIR.
It does NOT "export" CHPL_HOST_PLATFORM as to not interfere
with user settings, if any.
