### PR TITLE
Use maxTaskPar, not numPUs, in reductions-perf.chpl.

### DIFF
--- a/test/reductions/vass/reductions-perf.chpl
+++ b/test/reductions/vass/reductions-perf.chpl
@@ -31,7 +31,7 @@ config const n00 = numLocales * n00perLocale;
 
 // small arrays for multipe reductions
 config const elemsPerCore = 1024; // or 65536
-config const numCores = if perf then here.numPUs() else 4;
+config const numCores = if perf then here.maxTaskPar else 4;
 
 proc myRound(arg) return (arg+0.5):int;
 


### PR DESCRIPTION
numPUs is not compatible with earlier Chapel releases,
which makes it more difficult to gether release-over-release
performance numbers.

At Elliot's suggestion, I am using maxTaskPar instead.
