### PR TITLE
Tied up a loose end w.r.t. ref variable example in the spec.

### DIFF
--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -144,8 +144,6 @@ formal:
   formal-intent[OPT] tuple-grouped-identifier-list formal-type[OPT] default-expression[OPT]
   formal-intent[OPT] tuple-grouped-identifier-list formal-type[OPT] variable-argument-expression
 
-
-
 formal-type:
   : type-specifier
   : ? identifier[OPT]

--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -454,12 +454,9 @@ a \chpl{const ref} alias, making changes visible through the alias,
 and making the behavior undefined.
 \end{openissue}
 
+\begin{chapelexample}{refVariables.chpl}
 For example, the following code:
 
-% TODO: wrap the following code in "chapelexample".
-% We are not adding it to our test suite as of this writing
-% because it is too close to release cutoff.
-%
 \begin{chapel}
 var myInt = 51;
 ref refInt = myInt;                   // alias of a local or global variable
@@ -481,34 +478,13 @@ const ref myConstRef = constArr[2];   // would be an error without 'const'
 writeln("myConstRef = ", myConstRef);
 \end{chapel}
 
-%TODO: fix the bug in the following, then add to the above example:
-%
-% var myArr: [1..3] int = 51;
-% ref refArr = myArr[2];   // alias of an array element
-% myArr[2] = 62;
-% writeln("refArr = ", refArr);
-%
-% class C { var cField = 51; }
-% var myC = new C();
-% ref refField = myC.cField;   // alias of a field
-% myC.cField = 62;
-% writeln(refField);
-% delete myC;
-%
-% record R { var rField = 51; }
-% var myR = new R();
-% ref refToRecord = myR;
-% ref refToField  = myR.rField;
-% refToRecord = new R(rField = 62);  // updates 'myR', including its rField
-% writeln("refToField = ", refToField);
-
 prints out:
 
-% to be converted to {chapeloutput}
-\begin{chapel}
+\begin{chapelprintoutput}{}
 refInt = 62
 myInt = 73
 refToExpr = 62
 myArr[3] = 73
 myConstRef = 52
-\end{chapel}
+\end{chapelprintoutput}
+\end{chapelexample}

--- a/test/variables/vass/ref-bug.bad
+++ b/test/variables/vass/ref-bug.bad
@@ -1,0 +1,2 @@
+refArr1 = 51  myArr[1] = 62
+refArr2 = 62  myArr[2] = 62

--- a/test/variables/vass/ref-bug.chpl
+++ b/test/variables/vass/ref-bug.chpl
@@ -1,0 +1,12 @@
+
+var myArr: [1..3] int = 51;
+
+// alias refArr1 is not used as lvalue
+ref refArr1 = myArr[1];
+myArr[1] = 62;
+writeln("refArr1 = ", refArr1, "  myArr[1] = ", myArr[1]);
+
+// alias refArr2 IS used as lvalue
+ref refArr2 = myArr[2];
+refArr2 = 62;
+writeln("refArr2 = ", refArr2, "  myArr[2] = ", myArr[2]);

--- a/test/variables/vass/ref-bug.future
+++ b/test/variables/vass/ref-bug.future
@@ -1,0 +1,10 @@
+bug: ref variable of an array element does not alias
+
+Seems like in the following:
+
+  ref refArr = myArr[i];
+
+'refArr' works properly as an alias when it is later used as an lvalue.
+
+It does not work properly, i.e. an update to myArr[i] is not visible
+through refArr, when refArr is not used as an lvalue.

--- a/test/variables/vass/ref-bug.good
+++ b/test/variables/vass/ref-bug.good
@@ -1,0 +1,2 @@
+refArr1 = 62  myArr[1] = 62
+refArr2 = 62  myArr[2] = 62

--- a/test/variables/vass/ref-variables.chpl
+++ b/test/variables/vass/ref-variables.chpl
@@ -1,0 +1,59 @@
+// Various uses of a ref variable.
+//
+// Much of 'myInt' and 'myArr' pieces are from Variables.tex.
+// I include them here for completeness.
+
+
+////// alias of a variable //////
+
+var myInt = 51;
+ref refInt = myInt;
+myInt = 62;
+writeln("refInt = ", refInt);
+refInt = 73;
+writeln("myInt = ", myInt);
+
+
+////// alias of a ref-returning function //////
+
+proc justVariable() ref  return myInt;
+ref refExpr = justVariable();
+refExpr = 84;
+writeln("myInt = ", myInt);
+myInt = 95;
+writeln("refExpr = ", refExpr);
+
+
+////// alias of an array element //////
+
+var myArr: [1..3] int = 51;
+ref refArrElm = myArr[2];
+myArr[2] = 62;
+writeln("refArrElm = ", refArrElm);
+refArrElm = 73;
+writeln("myArr[2] = ", myArr[2]);
+
+
+////// alias of a class field //////
+
+class C { var cField = 51; }
+var myC = new C();
+ref refClassField = myC.cField;
+myC.cField = 62;
+writeln("refClassField = ", refClassField);
+refClassField = 73;
+writeln("cField = ", myC.cField);
+delete myC;
+
+
+////// alias of a record variable and a record field //////
+
+record R { var rField = 51; }
+var myR = new R();
+ref refToRecord = myR;          // alias the entire record variable
+ref refRecField  = myR.rField;   // alias just a field
+
+refToRecord = new R(rField = 62);  // updates 'myR', including its rField
+writeln("refRecField = ", refRecField);
+refRecField = 73;
+writeln("myR = ", myR);

--- a/test/variables/vass/ref-variables.good
+++ b/test/variables/vass/ref-variables.good
@@ -1,0 +1,10 @@
+refInt = 62
+myInt = 73
+myInt = 84
+refExpr = 95
+refArrElm = 62
+myArr[2] = 73
+refClassField = 62
+cField = 73
+refRecField = 62
+myR = (rField = 73)


### PR DESCRIPTION
* chapelexample-ified an example in the spec that I added as a non-
chapelexample because it was after feature freeze before the release.

* Removed the additional Chapel code that I put in comments next to that
example. I had suggested adding that code to the example proper.
I am now choosing against that because IMO that example needs not be
any bigger.

* I created a .chpl test with that removed-from-spec-comments code plus more.

* ... and added a future showing a bug: ref-bug.chpl.

* While there: removed two empty lines added in #519 without reason.