### PR TITLE
Have chpldoc skip nested blocks

### DIFF
--- a/compiler/AST/AstPrintDocs.cpp
+++ b/compiler/AST/AstPrintDocs.cpp
@@ -28,6 +28,7 @@
 #include "docsDriver.h"
 #include "symbol.h"
 #include "stringutil.h"
+#include "stmt.h"
 #include "type.h"
 
 
@@ -165,6 +166,14 @@ void AstPrintDocs::visitVarSym(VarSymbol* node) {
   node->printDocs(this->file, this->tabs);
 }
 
+
+bool AstPrintDocs::enterBlockStmt(BlockStmt* node) {
+  // Top level block statements have no parentExpr, only a parentSymbol.
+  // Nested block statements have a parentExpr.  We don't want to go into
+  // nested block statements, because their contents aren't accessible
+  // outside of that scope.
+  return node->parentExpr == NULL;
+}
 
 bool AstPrintDocs::enterWhileDoStmt(WhileDoStmt* node) {
   return false;

--- a/compiler/include/AstPrintDocs.h
+++ b/compiler/include/AstPrintDocs.h
@@ -42,6 +42,7 @@ public:
   virtual void   exitModSym       (ModuleSymbol*      node);
   virtual void   visitVarSym      (VarSymbol*         node);
 
+  virtual bool   enterBlockStmt   (BlockStmt*         node);
   virtual bool   enterWhileDoStmt (WhileDoStmt*       node);
   virtual bool   enterDoWhileStmt (DoWhileStmt*       node);
   virtual bool   enterCForLoop    (CForLoop*          node);

--- a/test/chpldoc/nodoc/nestedBlocks.doc.catfiles
+++ b/test/chpldoc/nodoc/nestedBlocks.doc.catfiles
@@ -1,0 +1,1 @@
+docs/looksEmpty.txt

--- a/test/chpldoc/nodoc/nestedBlocks.doc.chpl
+++ b/test/chpldoc/nodoc/nestedBlocks.doc.chpl
@@ -1,0 +1,20 @@
+/* This module should have no contents, as all of its code lives under nested
+   blocks instead of at the top level */
+module looksEmpty {
+  {
+    /* Even though this variable has a comment, it should not be visible
+       to chpldoc because it lives in a nested block and is thus inaccessible
+    */
+    var hideMe = 14;
+
+    // This constant does not have a chpldoc comment, but it still shouldn't be
+    // visible
+    const meTooPlease: bool;
+
+    /* This function should similarly be hidden */
+    proc ohAndMe() { }
+
+    // As should this record
+    record youDidNotSeeAnything { }
+  }
+}

--- a/test/chpldoc/nodoc/nestedBlocks.doc.good
+++ b/test/chpldoc/nodoc/nestedBlocks.doc.good
@@ -1,0 +1,7 @@
+looksEmpty
+
+Usage:
+   use looksEmpty;
+
+   This module should have no contents, as all of its code lives under nested
+   blocks instead of at the top level 

--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -210,7 +210,6 @@ def get_sys_c_types(docs=False):
     #
     sys_c_types.append("""
 {
-  pragma "no doc"
   pragma "no prototype"
   extern proc sizeof(type t): size_t;
 """)


### PR DESCRIPTION
Michael encountered this error while documenting SysCTypes - a symbol that lives
within a nested block should not have documentation generated for it, as it is
not accessible outside the scope in which it is defined and thus not part of
the program's API.

Add a test of this behavior, which failed before the change but now passes.
Revert the change to SysCTypes to avoid generating that output, since chpldoc
avoids the output on its own.