### PR TITLE
Add bounds checks to array-as-vec functions

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2089,6 +2089,10 @@ module ChapelArray {
      */
     proc pop_back() where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("pop_back");
+
+      if boundsChecking && isEmpty() then
+        halt("pop_back called on empty array");
+
       const lo = this.domain.low,
             hi = this.domain.high-1;
       const newRange = lo..hi;
@@ -2138,6 +2142,10 @@ module ChapelArray {
      */
     proc pop_front() where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("pop_front");
+
+      if boundsChecking && isEmpty() then
+        halt("pop_front called on empty array");
+
       const lo = this.domain.low+1,
             hi = this.domain.high;
       const newRange = lo..hi;
@@ -2166,6 +2174,10 @@ module ChapelArray {
       const lo = this.domain.low,
             hi = this.domain.high+1;
       const newRange = lo..hi;
+
+      if boundsChecking && !newRange.member(pos) then
+        halt("insert at position " + pos + " out of bounds");
+
       on this._value {
         if !this._value.dataAllocRange.member(hi) {
           if this._value.dataAllocRange.length < this.domain.numIndices {
@@ -2190,6 +2202,10 @@ module ChapelArray {
      */
     proc remove(pos: this.idxType) where chpl__isDense1DArray() {
       chpl__assertSingleArrayDomain("remove");
+
+      if boundsChecking && !this.domain.member(pos) then
+        halt("remove at position " + pos + " out of bounds");
+
       const lo = this.domain.low,
             hi = this.domain.high-1;
       const newRange = lo..hi;
@@ -2219,10 +2235,10 @@ module ChapelArray {
       chpl__assertSingleArrayDomain("remove count");
       const lo = this.domain.low,
             hi = this.domain.high-count;
-      if pos+count-1 > this.domain.high then
-        halt("index ", pos+count-1, " is outside the supported range");
-      if pos < lo then
-        halt("index ", pos, " is outside the supported range");
+      if boundsChecking && pos+count-1 > this.domain.high then
+        halt("remove at position ", pos+count-1, " out of bounds");
+      if boundsChecking && pos < lo then
+        halt("remove at position ", pos, " out of bounds");
 
       const newRange = lo..hi;
       for i in pos..hi {

--- a/test/arrays/diten/array-as-vec-bounds-checking.0-1.good
+++ b/test/arrays/diten/array-as-vec-bounds-checking.0-1.good
@@ -1,0 +1,1 @@
+array-as-vec-bounds-checking.chpl:10: error: halt reached - pop_back called on empty array

--- a/test/arrays/diten/array-as-vec-bounds-checking.0-2.good
+++ b/test/arrays/diten/array-as-vec-bounds-checking.0-2.good
@@ -1,0 +1,1 @@
+array-as-vec-bounds-checking.chpl:14: error: halt reached - pop_front called on empty array

--- a/test/arrays/diten/array-as-vec-bounds-checking.0-3.good
+++ b/test/arrays/diten/array-as-vec-bounds-checking.0-3.good
@@ -1,0 +1,1 @@
+array-as-vec-bounds-checking.chpl:18: error: halt reached - insert at position 7 out of bounds

--- a/test/arrays/diten/array-as-vec-bounds-checking.0-4.good
+++ b/test/arrays/diten/array-as-vec-bounds-checking.0-4.good
@@ -1,0 +1,1 @@
+array-as-vec-bounds-checking.chpl:22: error: halt reached - remove at position 7 out of bounds

--- a/test/arrays/diten/array-as-vec-bounds-checking.0-5.good
+++ b/test/arrays/diten/array-as-vec-bounds-checking.0-5.good
@@ -1,0 +1,1 @@
+array-as-vec-bounds-checking.chpl:26: error: halt reached - remove at position 7 out of bounds

--- a/test/arrays/diten/array-as-vec-bounds-checking.0-6.good
+++ b/test/arrays/diten/array-as-vec-bounds-checking.0-6.good
@@ -1,0 +1,1 @@
+array-as-vec-bounds-checking.chpl:30: error: halt reached - remove at position 8 out of bounds

--- a/test/arrays/diten/array-as-vec-bounds-checking.chpl
+++ b/test/arrays/diten/array-as-vec-bounds-checking.chpl
@@ -1,0 +1,31 @@
+config const testPopBackEmpty = false,
+             testPopFrontEmpty = false,
+             testInsertBadPos = false,
+             testRemoveBadPos = false,
+             testRemoveBadPosCount = false,
+             testRemoveBadRange = false;
+
+if testPopBackEmpty {
+  var A: [1..0] int;
+  A.pop_back();
+}
+if testPopFrontEmpty {
+  var A: [1..0] int;
+  A.pop_front();
+}
+if testInsertBadPos {
+  var A: [1..5] int;
+  A.insert(7, 3);
+}
+if testRemoveBadPos {
+  var A: [1..5] int;
+  A.remove(7);
+}
+if testRemoveBadPosCount {
+  var A: [1..5] int;
+  A.remove(4, 4);
+}
+if testRemoveBadRange {
+  var A: [1..5] int;
+  A.remove(4..8);
+}

--- a/test/arrays/diten/array-as-vec-bounds-checking.execopts
+++ b/test/arrays/diten/array-as-vec-bounds-checking.execopts
@@ -1,0 +1,6 @@
+--testPopBackEmpty=true
+--testPopFrontEmpty=true
+--testInsertBadPos=true
+--testRemoveBadPos=true
+--testRemoveBadPosCount=true
+--testRemoveBadRange=true

--- a/test/arrays/diten/array-as-vec-bounds-checking.skipif
+++ b/test/arrays/diten/array-as-vec-bounds-checking.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast

--- a/test/arrays/diten/array-as-vec-bounds-checking.skipif
+++ b/test/arrays/diten/array-as-vec-bounds-checking.skipif
@@ -1,1 +1,3 @@
 COMPOPTS <= --fast
+COMPOPTS <= --no-bounds-checks
+COMPOPTS <= --no-checks


### PR DESCRIPTION
Most of the array-as-vec functions didn't have bounds checks, so add them
where it makes sense.  Like other bounds checks, they are disabled when bounds
checking is turned off with --no-bounds-checks or --fast.

Added a test that causes each of the new bounds checks to trip.