### PR TITLE
Add skipif CHPL_LLVM!=llvm since this test uses extern block

### DIFF
--- a/test/users/npadmana/bugs/extern_struct_function_pointer/SKIPIF
+++ b/test/users/npadmana/bugs/extern_struct_function_pointer/SKIPIF
@@ -1,0 +1,2 @@
+# Tests in this directory assume LLVM/Clang support
+CHPL_LLVM != llvm


### PR DESCRIPTION
Continuing #3677.