### PR TITLE
minor fixes to test scripts

### DIFF
--- a/test/reductions/vass/reductions-perf.graph
+++ b/test/reductions/vass/reductions-perf.graph
@@ -1,5 +1,5 @@
 perfkeys: success  single reduction 1d:, success  multiple reductions 1d:, success  multiple reductions 2d:, success  multiple reductions 3d:
-files: reductions-perf.dat, reductions-perf.dat, reductions-perf.dat, reductions-perf.dat
+repeat-files: reductions-perf.dat
 graphkeys: single reduction 1d, M reductions 1d, M reductions 2d, M reductions 3d
 ylabel: Time (seconds)
 graphtitle: Reductions Time (sec)

--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -104,7 +104,7 @@ def validate_output(verify_keys, output_file):
         # match verify keys
         m = re.match("(verify|reject):(?:(-?[1-9][0-9]*):)? ?(.+)", key)
         if not m:
-            print("[Error: invalid verify/reject line '{}']".format(key))
+            print("[Error: invalid verify/reject line '{0}']".format(key))
             exit(1)
         # set parts of match to variables
         type = m.group(1)
@@ -208,13 +208,16 @@ def verify_data_file(keys_exp, keys_file):
                 # ignore comments and empty lines
                 if parsed[0] == "" or "#" in parsed[0]:
                     continue
-                if len(parsed) != columns:
-                    print("[Error: {} entry for {} doesn't match header length.]"
-                            .format(data_file, parsed[0]))
+                else:
+                    print("[Error: data entry prior to header or missing header in {0}]".format(data_file))
                     exit(2)
+            if len(parsed) != columns:
+                print("[Error: {0} entry for {1} doesn't match header length.]"
+                      .format(data_file, parsed[0]))
+                exit(2)
 
         if header == None: # not found
-            print("[Error: {} has no header.]".format(data_file))
+            print("[Error: {0} has no header.]".format(data_file))
             exit(2)
 
     
@@ -226,7 +229,7 @@ def verify_data_file(keys_exp, keys_file):
 
     # the two aren't equal
     if len(diff) > 1 or (len(diff) == 1 and diff[0][0] != "equal"):        
-        print("[Error: key mismatch between {} and {}]"
+        print("[Error: key mismatch between {0} and {1}]"
                 .format(keys_file, data_file))
         print("Changes since creation of .dat file:")
         for d in diff:
@@ -235,16 +238,16 @@ def verify_data_file(keys_exp, keys_file):
                 continue
             elif type == "delete":
                 for i in range(d[1], d[2]):
-                    print("\t'{}' has been removed.".format(keys_actual[i]))
+                    print("\t'{0}' has been removed.".format(keys_actual[i]))
             elif type == "insert":
                 for i in range(d[3], d[4]):
-                    print("\t'{}' has been added.".format(keys_exp[i]))
+                    print("\t'{0}' has been added.".format(keys_exp[i]))
             elif type == "replace":
                 if d[2] - d[1] == 1: # singlular
-                    print("\t'{}' has been replaced with '{}'.".format(
+                    print("\t'{0}' has been replaced with '{1}'.".format(
                             keys_actual[d[1]], ", ".join(keys_exp[d[3]:d[4]])))
                 else: # plural
-                    print("\t'{}' have been replaced with '{}'.".format(
+                    print("\t'{0}' have been replaced with '{1}'.".format(
                         ", ".join(keys_actual[d[1]:d[2]]), 
                         ", ".join(keys_exp[d[3]:d[4]])))
 

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -260,6 +260,9 @@ def strip_series(csvFile, numseries):
 
 ############
 
+class CouldNotReadGraphFile(Exception):
+    pass
+
 # Global info about generating graphs
 class GraphStuff:
     def __init__(self, _name, _testdir, _perfdir, _outdir, _startdate, _enddate,
@@ -409,15 +412,18 @@ class GraphStuff:
 
 
     def genGraphStuff(self, fname, suites):
-        fullFname = self.testdir+'/'+fname
-        if not os.path.exists(fullFname):
-            fullFname = './'+fname
+        if os.path.isabs(fname):
+            fullFname = fname
+        else:
+            fullFname = self.testdir+'/'+fname
+            if not os.path.exists(fullFname):
+                fullFname = './'+fname
         if verbose:
             sys.stdout.write('Reading %s...\n'%(fullFname))
         lines=fileReadHelp.ReadFileWithComments(fullFname)
         if lines==None:
             sys.stdout.write('WARNING: Could not read graph description from %s.  Ignoring.\n'%(fullFname))
-            return
+            raise CouldNotReadGraphFile
 
         basename = os.path.splitext(os.path.basename(fname))[0]
 
@@ -524,7 +530,10 @@ class GraphClass:
     def __str__(self):
         l  = 'Graph: '+str(self.name)+' (id='+str(self.id)+')\n'
         l += '\ttitle: '+self.title+'\n'
-        l += '\tsuites: ['+','.join(suites)+']\n'
+        if self.suites == None or self.suites == [] or self.suites == [None]:
+            l += '\tsuites: none\n'
+        else:
+            l += '\tsuites: ['+','.join(self.suites)+']\n'
         l += '\tgraphname: '+self.graphname+'\n'
         l += '\tylabel: '+self.ylabel+'\n'
         if self.startdate != None:
@@ -1017,6 +1026,8 @@ def main():
         try:
             graphInfo.genGraphStuff(graph[0], graph[1])
             numGraphfiles += 1
+        except (CouldNotReadGraphFile):
+            pass  # do not increment numGraphfiles
         except (ValueError, IOError, OSError):
             return -1
 


### PR DESCRIPTION
computePerfStats
----------------

* It had {} in format strings, which is unsupported by Python 2.6,
  which we still use sometimes.  Replaced with {0} and {1}.

* Corrected the logic to handle the case of data lines before the header.
  Not that we expect that to happen, I just did not want to leave misleading
  code sitting around.

genGraphs
---------

* Handle correctly the case where a/the .graph file has an absolute path.

* Do not include a .graph file in the final count when it was not
  actually read.

while there
-----------

* reductions-perf.graph: replaced "files" with "repeat-files".

* GraphClass.__str__(): handle the case of empty self.suites.
  I test for [None] because I have observed that in one of the runs.