### PR TITLE
Add note to Math docs about sign of mod

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -614,7 +614,7 @@ module Math {
 
 
   /* Computes the mod operator on the two arguments, defined as
-     ``mod(x,y) = x - y * floor(x / y)``.
+     ``mod(m,n) = m - n * floor(m / n)``.
 
      The result is always >= 0 if `n` > 0.
      It is an error if `n` == 0.
@@ -634,10 +634,10 @@ module Math {
   }
 
   /* Computes the mod operator on the two arguments, defined as
-     ``mod(x,y) = x - y * floor(x / y)``.
+     ``mod(m,n) = m - n * floor(m / n)``.
 
      If the arguments are of unsigned type, then
-     fewer condititionals will be evaluated at run time.
+     fewer conditionals will be evaluated at run time.
 
      The result is always >= 0 if `n` > 0.
      It is an error if `n` == 0.

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -615,6 +615,9 @@ module Math {
 
   /* Computes the mod operator on the two arguments, defined as
      ``mod(x,y) = x - y * floor(x / y)``.
+
+     The result is always >= 0 if `n` > 0.
+     It is an error if `n` == 0.
   */
   proc mod(param m: integral, param n: integral) param {
     param temp = m % n;
@@ -634,7 +637,10 @@ module Math {
      ``mod(x,y) = x - y * floor(x / y)``.
 
      If the arguments are of unsigned type, then
-     fewer condititionals will be evaluated at run time. 
+     fewer condititionals will be evaluated at run time.
+
+     The result is always >= 0 if `n` > 0.
+     It is an error if `n` == 0.
   */
   proc mod(m: integral, n: integral) {
     const temp = m % n;


### PR DESCRIPTION
The main reason we have proc mod and % is that the % operator can return
a negative value when one of its arguments is negative. In this regard,
proc mod might be more useful, but it wasn't clear from the documentation
why.