### PR TITLE
Use low-level PCG interface for ISx

### DIFF
--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -349,32 +349,19 @@ proc makeInput(taskID, myKeys) {
   if (debug) then
     writeln(taskID, ": Initializing random stream with seed = ", taskID);
 
-  var MyRandStream = new RandomStream(seed = taskID,
-                                      parSafe=false,
-                                      eltType = keyType);
-
+  var pcg : pcg_setseq_64_xsh_rr_32_rng;
+  const tid = taskID:uint(64);
+  const inc = pcg_getvalid_inc(tid);
+  pcg.srandom(tid, inc);
   //
   // Fill local array
   //
 
-  //
-  // The following code ensures that the value we get from the stream
-  // is in [0, maKeyVal) before storing it to key.  This is tricky when
-  // maxKeyVal isn't a power of two and so we take some care to keep the
-  // value distributed evenly.
-  //
-  const maxModdableKeyVal = max(keyType) - max(keyType)%maxKeyVal;
-  for key in myKeys do
-    do {
-      key = MyRandStream.getNext();
-      if key <= maxModdableKeyVal
-        then key %= maxKeyVal;
-    } while (key >= maxKeyVal || key < 0);
+  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):int(32);
     
   if (debug) then
     writeln(taskID, ": myKeys: ", myKeys);
 
-  delete MyRandStream;
 }
 
 

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -351,33 +351,19 @@ proc makeInput(bucketID) {
   if (debug) then
     writeln(here.id, ": Initializing random stream with seed = ", here.id);
 
-  var MyRandStream = makeRandomStream(seed = here.id,
-                                      parSafe = false,
-                                      eltType = keyType,
-                                      algorithm = RNG.PCG);
+  var pcg : pcg_setseq_64_xsh_rr_32_rng;
+  const tid = bucketID:uint(64);
+  const inc = pcg_getvalid_inc(tid);
+  pcg.srandom(tid, inc);
 
   //
   // Fill local array
   //
 
-  //
-  // The following code ensures that the value we get from the stream
-  // is in [0, maKeyVal) before storing it to key.  This is tricky when
-  // maxKeyVal isn't a power of two and so we take some care to keep the
-  // value distributed evenly.
-  //
-  const maxModdableKeyVal = max(keyType) - max(keyType)%maxKeyVal;
-  for key in myKeys do
-    do {
-      key = MyRandStream.getNext();
-      if key <= maxModdableKeyVal
-        then key %= maxKeyVal;
-    } while (key >= maxKeyVal || key < 0);
-    
+  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):int(32);
+
   if (debug) then
     writeln(bucketID, ": myKeys: ", myKeys);
-
-  delete MyRandStream;
 
   return myKeys;
 }


### PR DESCRIPTION
In order to match the random numbers from the reference version, we need to be able to set the increment value used by the PCG generator. Our current RandomStream interface does not support this, so we will use the low-level interface. Testing suggests that there wasn't a significant difference in the transfer sizes due to the generated numbers, but it's nice to be as close to the reference as we can.

The existing logic to find a random number in [0, maxKeyVal) was slower than the low-level bounded_random implementation, so I expect to see a modest performance boost for the input section.

The name of the low-level pcg record is a bit ugly. Future work may involve using a type function to hide the record name, where users can request a generator with a certain number of bits for state and output.