### PR TITLE
Update for trivial leaks to capture uses of variations on random stream

### DIFF
--- a/test/distributions/robust/arithmetic/modules/test_module_Norm.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Norm.chpl
@@ -132,3 +132,5 @@ writeln("\trcR1D:");
 doNorm(rcR1D, 1);
 writeln("\trcR2D:");
 doNorm(rcR2D, 2);
+
+delete rng;

--- a/test/distributions/robust/arithmetic/modules/test_module_Random.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Random.chpl
@@ -5,7 +5,7 @@ use Random;
 
 config const printRefArrays = true;
 
-var rng = makeRandomStream(314159265, eltType=real(64), algorithm=RNG.NPB);
+var rng  = makeRandomStream(314159265, eltType=real(64), algorithm=RNG.NPB);
 var trng = makeRandomStream(314159265, eltType=real(64), algorithm=RNG.NPB);
 
 proc fillRefArrays() {
@@ -123,3 +123,6 @@ writeln("\trcR3D: ", checkRNG(rcR3D, rcT3D), " errors");
 
 if printRefArrays then
   outputRealArrays();
+
+delete trng;
+delete rng;

--- a/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
@@ -98,3 +98,5 @@ rng.fillRandom(rc4DR1D);
 QuickSort(rc4DR1D, doublecheck=true);
 rng.fillRandom(rc4DR1D);
 HeapSort(rc4DR1D, doublecheck=true);
+
+delete rng;

--- a/test/domains/ferguson/build-associative.chpl
+++ b/test/domains/ferguson/build-associative.chpl
@@ -24,9 +24,12 @@ var configs = [
 if table {
   for (cfg,i) in zip(configs, 1..) {
     var (iters, size, num_domains) = cfg;
+
     if correctness then iters = 1;
-    writeln(i, ": iters=", iters, " size=", size, " num_domains=", num_domains); 
+
+    writeln(i, ": iters=", iters, " size=", size, " num_domains=", num_domains);
   }
+
   writeln();
 
   for (cfg,idx) in zip(configs, 1..) {
@@ -43,20 +46,25 @@ for (cfg,idx) in zip(configs, 1..) {
   if correctness then iters = 1;
 
   var t1 = new Timer();
+
   t1.start();
+
   for it in 1..iters {
     var D1:[1..num_domains] domain(int, parSafe=false);
+
     // Doesn't work with tuple?
     for i in 1..size {
       var j = rng.getNext(1, num_domains);
       D1(j) += i;
     }
+
     for j in 1..num_domains {
       D1(j).clear();
     }
   }
+
   t1.stop();
-  
+
   if timing {
     if perf {
       writef("%i: % 6.3r\n", idx, t1.elapsed());
@@ -76,3 +84,4 @@ if perf || correctness {
   writeln("SUCCESS");
 }
 
+delete rng;

--- a/test/domains/johnk/capacityAssoc.chpl
+++ b/test/domains/johnk/capacityAssoc.chpl
@@ -10,18 +10,22 @@ arr["foo"] = 4;
 arr["bar"] = 5;
 
 //Pick a random initial capacity for the associative domain
-var rs = new RandomStream();
-var min = 5;
-var max = 3500;
+var rs       = new RandomStream();
+
+var min      = 5;
+var max      = 3500;
 var capacity = (rs.getNext() * (max - min) + min): int;
+
 D.requestCapacity(capacity);
 
 
 if (D._value.tableSize > 2 * (capacity + 1)) &&
-   arr["foo"] == 4 && 
-   arr["bar"] == 5 
+   arr["foo"] == 4 &&
+   arr["bar"] == 5
 {
     writeln("SUCCESS");
 } else {
     writeln("FAILURE");
 }
+
+delete rs;

--- a/test/exercises/life.chpl
+++ b/test/exercises/life.chpl
@@ -26,6 +26,7 @@ var Grid:     [BigD] bool, // grid of life
 
 // initialize grid
 var rs = makeRandomStream(seed, eltType=real(64), algorithm=RNG.NPB);
+
 for i in D do
   Grid(i) = if rs.getNext() <= p:real / 100 then true else false;
 
@@ -44,14 +45,20 @@ for i in 1..k {
       Grid(i+1,j-1) + Grid(i+1,j) + Grid(i+1,j+1);
     NextGrid(i,j) = neighbors == 3 || neighbors == 2 && Grid(i,j);
   }
+
   if !(|| reduce (NextGrid != Grid(D))) {
     writeln("Stable Grid");
     break;
   }
+
   Grid(D) = NextGrid;
+
   writeln("Iteration ", i);
+
   printGrid();
 }
+
+delete rs;
 
 // print a generation
 proc printGrid() {

--- a/test/functions/deitz/iterators/leader_follower/test_strided_leader2.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_strided_leader2.chpl
@@ -35,6 +35,8 @@ use Random;
     B(i) = r;
 
   writeln(B);
+
+  delete rs;
 }
 
 {
@@ -46,4 +48,6 @@ use Random;
     B(f) = r;
 
   writeln(B);
+
+  delete rs;
 }

--- a/test/modules/standard/Random/bradc/writeRandomStream.chpl
+++ b/test/modules/standard/Random/bradc/writeRandomStream.chpl
@@ -2,10 +2,13 @@ module A2 {
   use Random;
 
   config param useNPB = true;
-  config param rtype = if useNPB then RNG.NPB else RNG.PCG;
+  config param rtype  = if useNPB then RNG.NPB else RNG.PCG;
 
   proc main() {
     var rnd  = makeRandomStream(seed=314159265, algorithm=rtype);
+
     writeln(rnd);
+
+    delete rnd;
   }
 }

--- a/test/modules/standard/Random/ferguson/pcg-rand-check.chpl
+++ b/test/modules/standard/Random/ferguson/pcg-rand-check.chpl
@@ -21,18 +21,25 @@ writeln("Checking 32-bit RNG seq 1");
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] );
   }
+
   rs.skipToNth(1);
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] );
   }
- for i in 1..6 {
+
+  for i in 1..6 {
     var got = rs.getNth(i);
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] );
   }
+
+  delete rs;
 }
 
 {
@@ -44,18 +51,23 @@ writeln("Checking 32-bit RNG seq 1");
     if verbose then writef("%xu\n", got);
     assert( got:uint(32) == expect32_1[i] );
   }
+
   rs.skipToNth(1);
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
     if verbose then writef("%xu\n", got);
     assert( got:uint(32) == expect32_1[i] );
   }
- for i in 1..6 {
+
+  for i in 1..6 {
     var got = rs.getNth(i);
     if verbose then writef("%xu\n", got);
     assert( got:uint(32) == expect32_1[i] );
   }
+
+  delete rs;
 }
 
 
@@ -66,48 +78,66 @@ writeln("Checking 32-bit RNG seq 1");
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] >> 24 );
   }
+
   rs.skipToNth(1);
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] >> 24 );
   }
- for i in 1..6 {
+
+  for i in 1..6 {
     var got = rs.getNth(i);
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] >> 24 );
   }
+
+  delete rs;
 }
 
 // check 16 bit version
 {
   var rs = makeRandomStream(seed = seed, parSafe=false,
                             eltType = uint(16), algorithm=RNG.PCG);
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] >> 16 );
   }
+
   rs.skipToNth(1);
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] >> 16 );
   }
- for i in 1..6 {
+
+  for i in 1..6 {
     var got = rs.getNth(i);
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] >> 16 );
   }
+
+  delete rs;
 }
 
 writeln("Checking 2x 32-bit RNG seq 1 seq 2");
+
 // check 64 bit version
 {
   var rs = makeRandomStream(seed = seed, parSafe=false,
@@ -115,21 +145,29 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%xu\n", got);
     assert( got == (expect32_1[i]:uint(64) << 32) | expect32_2[i]:uint(64) );
   }
+
   rs.skipToNth(1);
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%xu\n", got);
     assert( got == (expect32_1[i]:uint(64) << 32) | expect32_2[i]:uint(64) );
   }
- for i in 1..6 {
+
+  for i in 1..6 {
     var got = rs.getNth(i);
+
     if verbose then writef("%xu\n", got);
     assert( got == (expect32_1[i]:uint(64) << 32) | expect32_2[i]:uint(64) );
   }
+
+  delete rs;
 }
 
 //writeln("Checking real(32)");
@@ -137,64 +175,89 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
 // TODO - bug in resolution?
 /*{
   var expect:[1..6] real(32);
+
   fillRandom(expect, seed=seed, algorithm=RNG.PCG);
+
   var rs = makeRandomStream(seed = seed, eltType = real(32), algorithm=RNG.PCG);
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%n\n", got);
     assert( got == expect[i] );
   }
+
   rs.skipToNth(1);
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%n\n", got);
     assert( got == expect[i] );
   }
- for i in 1..6 {
+
+  for i in 1..6 {
     var got = rs.getNth(i);
+
     if verbose then writef("%n\n", got);
     assert( got == expect[i] );
   }
+
+  delete rs;
 }*/
 
 writeln("Checking real(64)");
 // check that real(64) reproduces
 {
   var expect:[1..6] real(64);
+
   fillRandom(expect, seed=seed, algorithm=RNG.PCG);
+
   var rs = new RandomStream(seed = seed, eltType = real(64));
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%n\n", got);
     assert( got == expect[i] );
   }
+
   rs.skipToNth(1);
+
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
+
     if verbose then writef("%n\n", got);
     assert( got == expect[i] );
   }
- for i in 1..6 {
+
+  for i in 1..6 {
     var got = rs.getNth(i);
+
     if verbose then writef("%n\n", got);
     assert( got == expect[i] );
   }
+
+  delete rs;
 }
 
-writeln("Checking random shuffle and permutation"); 
+writeln("Checking random shuffle and permutation");
 // try a random permutation
 {
   for i in 1..10 {
     var arr = [10,20,30,40];
+
     shuffle(arr, seed=i, algorithm=RNG.PCG);
     writeln(arr);
   }
+
   for i in 1..10 {
     var arr:[1..4] int;
+
     permutation(arr, seed=i, algorithm=RNG.PCG);
     writeln(arr);
   }
@@ -204,20 +267,25 @@ writeln("Checking random shuffle and permutation");
 writeln("Checking 8-bit once-only RNG");
 {
     var two_n = 256;
+
     for seed in 0..10 {
       for stream in 1..10 {
         var inc = pcg_getvalid_inc(stream:uint):uint(8);
         var hits:[0..#two_n] int;
         var rng = new pcg_setseq_8_rxs_m_xs_8_rng();
+
         rng.srandom(seed:uint(8), inc);
+
         for i in 0..#two_n {
           var got = rng.random(inc);
           if verbose then
             writeln(got, " i=", i, " n=", 8, " seed=", seed, " stream=", stream);
           hits[got] += 1;
         }
+
         if verbose then
           writeln();
+
         for i in 0..#two_n {
           assert(hits[i] == 1);
         }
@@ -229,20 +297,27 @@ writeln("Checking generalized once-only RNG");
 {
   for n in 1..20 {
     var two_n:uint = 1:uint << n;
+
     for seed in 0..2 {
       for stream in 1..2 {
         var inc = pcg_getvalid_inc(stream:uint);
         var hits:[0:uint..#two_n] int;
         var rng = new pcg_setseq_N_rxs_m_xs_N_rng(n);
+
         rng.srandom(seed:uint, inc);
+
         for i in 0..#two_n {
           var got = rng.random(inc);
-          if verbose then 
+
+          if verbose then
             writeln(got, " i=", i, " n=", n, " seed=", seed, " stream=", stream);
+
           hits[got] += 1;
         }
+
         if verbose then
           writeln();
+
         for i in 0:uint..#two_n {
           assert(hits[i] == 1);
         }

--- a/test/modules/standard/Random/ferguson/pcg-rand-range-check.chpl
+++ b/test/modules/standard/Random/ferguson/pcg-rand-range-check.chpl
@@ -18,13 +18,16 @@ var expect32_1_2_31_30_1 = [ 0x4df1ccf9, 0x25838751, 0x58ed9e10,
 {
   if verbose then
     writeln("Checking 32-bit RNG seq 1 bound 2**31+1");
+
   var bound:uint(32) = 2147483649;
   var tmprng:pcg_setseq_64_xsh_rr_32_rng;
   var tmpinc = pcg_getvalid_inc(1);
+
   tmprng.srandom(seed:uint, tmpinc);
 
   for i in 1..6 {
     var got = tmprng.bounded_random(tmpinc, bound);
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1_2_31_1[i] );
   }
@@ -34,13 +37,16 @@ var expect32_1_2_31_30_1 = [ 0x4df1ccf9, 0x25838751, 0x58ed9e10,
 {
   if verbose then
     writeln("Checking 32-bit RNG seq 1 bound 2**31+2**30+1");
+
   var bound:uint(32) = 3221225473;
   var tmprng:pcg_setseq_64_xsh_rr_32_rng;
   var tmpinc = pcg_getvalid_inc(1);
+
   tmprng.srandom(seed:uint, tmpinc);
 
   for i in 1..6 {
     var got = tmprng.bounded_random(tmpinc, bound);
+
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1_2_31_30_1[i] );
   }
@@ -56,13 +62,17 @@ var histo:[0..255] int;
 
   for i in 1..1000000 {
     var got = rs.getNext();
+
     histo[got] += 1;
   }
 
   for (h,i) in zip(histo,0..) {
     assert(h > 0);
+
     if verbose then writef("% 3i: %i\n", i, h);
   }
+
+  delete rs;
 }
 
 
@@ -81,8 +91,11 @@ histo = 0;
   for (h,i) in zip(histo,0..) {
     if 5 <= i && i <= 20 then assert(h > 0);
     else assert(h == 0);
+
     if verbose then writef("% 3i: %i\n", i, h);
   }
+
+  delete rs;
 }
 
 histo = 0;
@@ -94,14 +107,18 @@ histo = 0;
 
   for i in 1..1000000 {
     var got = rs.getNext(5, 20):int;
+
     histo[got] += 1;
   }
 
   for (h,i) in zip(histo,0..) {
     if 5 <= i && i <= 20 then assert(h > 0);
     else assert(h == 0);
+
     if verbose then writef("% 3i: %i\n", i, h);
   }
+
+  delete rs;
 }
 
 

--- a/test/modules/standard/Random/ferguson/pcg-rand-range-check2.chpl
+++ b/test/modules/standard/Random/ferguson/pcg-rand-range-check2.chpl
@@ -54,6 +54,8 @@ for i in 0..#n {
   assert(got[i] == num);
 }
 
+delete rs;
+
 var rs2 = makeRandomStream(seed=seed, parSafe=false, eltType=uint(64), algorithm=RNG.PCG);
 
 var max2:uint = (2**32 + max):uint;
@@ -91,3 +93,4 @@ rs2.skipToNth(n + 3);
 num = rs2.getNext();
 assert(got2[n+2] == num);
 
+delete rs2;

--- a/test/modules/standard/Random/ferguson/pcg-real32-bug.chpl
+++ b/test/modules/standard/Random/ferguson/pcg-real32-bug.chpl
@@ -11,3 +11,5 @@ if verbose then
   writeln(displace);
 
 
+delete rng;
+

--- a/test/modules/standard/Random/ferguson/rmixed.chpl
+++ b/test/modules/standard/Random/ferguson/rmixed.chpl
@@ -6,11 +6,16 @@ use Random;
 
   var v1 = rng.getNext();
   writeln(v1.type:string);
+
   var v2 = rng.getNext(uint(8));
   writeln(v2.type:string);
+
   var v3 = rng.getNext(uint(64));
   writeln(v3.type:string);
+
+  delete rng;
 }
+
 // Test stepping for uint
 {
   var v2: uint(64);
@@ -19,17 +24,23 @@ use Random;
     var rng = makeRandomStream(seed=17, parSafe=false,
                                eltType=uint(64), algorithm=RNG.PCG);
 
-    var v1 = rng.getNext();
+    var v1  = rng.getNext();
+
     v2 = rng.getNext();
+
+    delete rng;
   }
 
   {
     var rng = makeRandomStream(seed=17, parSafe=false,
                                eltType=uint(64), algorithm=RNG.PCG);
 
-    var v1 = rng.getNext(uint(8));
+    var v1     = rng.getNext(uint(8));
     var got_v2 = rng.getNext();
+
     assert(v2 == got_v2);
+
+    delete rng;
   }
 }
 
@@ -42,7 +53,10 @@ use Random;
                                eltType=real(64), algorithm=RNG.PCG);
 
     var v1 = rng.getNext();
+
     v2 = rng.getNext();
+
+    delete rng;
   }
 
   {
@@ -51,7 +65,10 @@ use Random;
 
     var v1 = rng.getNext(uint(8));
     var got_v2 = rng.getNext();
+
     assert(v2 == got_v2);
+
+    delete rng;
   }
 }
 
@@ -65,16 +82,22 @@ use Random;
                                eltType=complex(64), algorithm=RNG.PCG);
 
     var v1 = rng.getNext();
+
     v2 = rng.getNext();
+
+    delete rng;
   }
 
   {
     var rng = makeRandomStream(seed=17, parSafe=false,
                                eltType=complex(64), algorithm=RNG.PCG);
 
-    var v1 = rng.getNext(uint(8));
+    var v1     = rng.getNext(uint(8));
     var got_v2 = rng.getNext();
+
     assert(v2 == got_v2);
+
+    delete rng;
   }
 }
 

--- a/test/performance/thomasvandoren/matrix-multiply-chapelerific.chpl
+++ b/test/performance/thomasvandoren/matrix-multiply-chapelerific.chpl
@@ -11,6 +11,8 @@ proc main() {
 
   timer.stop();
   printResults();
+
+  delete randStream;
 }
 
 proc dotProduct(ref C: [?DC] int, ref A: [?DA] int, ref B: [?DB] int)

--- a/test/performance/thomasvandoren/matrix-multiply-foralls.chpl
+++ b/test/performance/thomasvandoren/matrix-multiply-foralls.chpl
@@ -12,6 +12,8 @@ proc main() {
 
   timer.stop();
   printResults();
+
+  delete randStream;
 }
 
 proc dotProduct(ref C: [?DC] int, ref A: [?DA] int, ref B: [?DB] int)

--- a/test/performance/thomasvandoren/matrix-multiply-reduce.chpl
+++ b/test/performance/thomasvandoren/matrix-multiply-reduce.chpl
@@ -12,6 +12,8 @@ proc main() {
 
   timer.stop();
   printResults();
+
+  delete randStream;
 }
 
 proc dotProduct(ref C: [?DC] int, ref A: [?DA] int, ref B: [?DB] int)

--- a/test/performance/thomasvandoren/matrix-multiply-slice-promotion.chpl
+++ b/test/performance/thomasvandoren/matrix-multiply-slice-promotion.chpl
@@ -11,6 +11,8 @@ proc main() {
 
   timer.stop();
   printResults();
+
+  delete randStream;
 }
 
 proc dotProduct(ref C: [?DC] int, ref A: [?DA] int, ref B: [?DB] int)

--- a/test/reductions/thomasvandoren/test/TestMink.chpl
+++ b/test/reductions/thomasvandoren/test/TestMink.chpl
@@ -14,9 +14,12 @@ writeln("mink real result: ", realResult);
 // Verify calling reduction on array of less than k elements returns those
 // elements, in sorted order, with the other values filled in with max(real).
 var smallA: [1..5] real;
+
 randStream.fillRandom(smallA);
 writeln("mink int small result: ", mink reduce smallA);
 
 // Verify calling reduction on empty array returns array of max(eltType)
 // values.
 writeln("mink int empty result: ", mink reduce emptyArray);
+
+delete randStream;

--- a/test/reductions/thomasvandoren/test/TestSorted.chpl
+++ b/test/reductions/thomasvandoren/test/TestSorted.chpl
@@ -17,3 +17,5 @@ writeln("sorted? ", isSorted reduce A);
 QuickSort(A);
 writeln("A: ", A);
 writeln("sorted? ", isSorted reduce A);
+
+delete randStream;

--- a/test/release/examples/primers/randomNumbers.chpl
+++ b/test/release/examples/primers/randomNumbers.chpl
@@ -38,7 +38,7 @@ writeln();
 // a RandomStream class instance.  If one is desired, the seed must be
 // specified upon creation of this instance.
 //
-var randStream: RandomStream(real) = new RandomStream();
+var randStream:       RandomStream(real) = new RandomStream();
 var randStreamSeeded: RandomStream(real) = new RandomStream(seed);
 
 //
@@ -97,8 +97,14 @@ for i in randStreamSeeded.iterate({5..10}, real) {
 // class creation.  As a result, two parallel accesses or updates to the
 // position from which reading is intended may conflict.
 //
-var parallelUnsafe = new RandomStream(parSafe=false);
+var parallelUnsafe       = new RandomStream(parSafe=false);
 var parallelSeededUnsafe = new RandomStream(seed, false);
+
 // Commented out for deterministic testing output.
 //writeln(parallelUnsafe.getNext());
 //writeln(parallelSeededUnsafe.getNext());
+
+delete parallelSeededUnsafe;
+delete parallelUnsafe;
+delete randStreamSeeded;
+delete randStream;

--- a/test/studies/IMSuite/vertexColor/vertexColoring-serial.chpl
+++ b/test/studies/IMSuite/vertexColor/vertexColoring-serial.chpl
@@ -239,6 +239,8 @@ module vertexColoring {
 
             if(loadValue != 0) then nval[i] = loadweight(nval[i]+i);
             }
+
+            delete randStream;
         }
 
     }

--- a/test/studies/cholesky/jglewis/test_cholesky.chpl
+++ b/test/studies/cholesky/jglewis/test_cholesky.chpl
@@ -79,8 +79,8 @@ module cholesky_test {
 
   use cholesky_execution_config_consts;
 
-  use cholesky_scalar_algorithms, 
-      block_outer_product_cholesky, 
+  use cholesky_scalar_algorithms,
+      block_outer_product_cholesky,
       block_2D_outer_product_cholesky,
       block_inner_product_cholesky,
       block_2D_inner_product_cholesky,
@@ -113,14 +113,14 @@ module cholesky_test {
 
     // -------------------------------------------------------------
     // create a positive definite matrix A by setting A equal to the
-    // matrix-matrix product B B^T.  This normal equations matrix is 
+    // matrix-matrix product B B^T.  This normal equations matrix is
     // positive-definite as long as B is full rank.
     // -------------------------------------------------------------
 
     A = 0.0;
 
     forall (i,j) in mat_dom do
-      A (i,j) = + reduce (  [k in mat_dom.dim (1) ] 
+      A (i,j) = + reduce (  [k in mat_dom.dim (1) ]
     			    B (i, k) * B (j, k) );
 
     // factorization algorithms overwrite a copy of A, leaving
@@ -139,10 +139,10 @@ module cholesky_test {
     else
       writeln ("factorization failed for non-positive semi-definite matrix");
 
- 
+
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 1D outer product cholesky factorization, block size: ",
 	      block_size );
 
@@ -156,7 +156,7 @@ module cholesky_test {
 
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 2D outer product cholesky factorization, block size: ",
 	      block_size );
 
@@ -183,10 +183,10 @@ module cholesky_test {
       writeln ("factorization failed for non-positive semi-definite matrix");
 
 
-     
+
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 1D inner product cholesky factorization, block size: ",
 	      block_size );
 
@@ -202,7 +202,7 @@ module cholesky_test {
 
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 2D inner product cholesky factorization, block size: ",
 	      block_size );
 
@@ -230,7 +230,7 @@ module cholesky_test {
 
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 1D bordering cholesky factorization, block size: ",
 	      block_size );
 
@@ -246,7 +246,7 @@ module cholesky_test {
 
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 2D bordering cholesky factorization, block size: ",
 	      block_size );
 
@@ -258,6 +258,8 @@ module cholesky_test {
       check_factorization ( A, L );
     else
       writeln ("factorization failed for non-positive semi-definite matrix");
+
+    delete Rand;
   }
 
   proc check_factorization ( A : [], L : [] )
@@ -273,9 +275,9 @@ module cholesky_test {
 
     assert ( A.domain.dim (1) == A.domain.dim (2)  &&
 	     L.domain.dim (1) == A.domain.dim (1)  &&
-	     L.domain.dim (2) == A.domain.dim (2) 
+	     L.domain.dim (2) == A.domain.dim (2)
 	     );
-    
+
     const mat_dom  = A.domain,
 	  mat_rows = A.domain.dim(1),
 	  n        = A.domain.dim(1).length;
@@ -289,10 +291,10 @@ module cholesky_test {
 
     for i in mat_rows do
       d (i) = sqrt ( A (i,i) );
-    
+
     forall (i,j) in mat_dom with (ref max_ratio) do { // race
       const resid:real =
-               abs (A (i,j) - 
+               abs (A (i,j) -
 		    + reduce ( [k in mat_dom.dim(1) (..min (i,j))]
 			       L (i,k) * L (j,k) ) ) ;
       max_ratio = max ( max_ratio,
@@ -308,7 +310,7 @@ module cholesky_test {
 
 
   proc print_L ( L : [] ) {
-   
+
     const rows = L.domain.dim (1);
 
     //    for i in rows do
@@ -316,4 +318,4 @@ module cholesky_test {
   }
 
 }
-    
+

--- a/test/studies/cholesky/jglewis/test_dataflow_cholesky.chpl
+++ b/test/studies/cholesky/jglewis/test_dataflow_cholesky.chpl
@@ -79,7 +79,7 @@ module test_dataflow_cholesky {
 
   use cholesky_execution_config_consts;
 
-  use cholesky_scalar_algorithms, 
+  use cholesky_scalar_algorithms,
       dataflow_block_cholesky;
 
   proc main {
@@ -108,14 +108,14 @@ module test_dataflow_cholesky {
 
     // -------------------------------------------------------------
     // create a positive definite matrix A by setting A equal to the
-    // matrix-matrix product B B^T.  This normal equations matrix is 
+    // matrix-matrix product B B^T.  This normal equations matrix is
     // positive-definite as long as B is full rank.
     // -------------------------------------------------------------
 
     A = 0.0;
 
     forall (i,j) in mat_dom do
-      A (i,j) = + reduce (  [k in mat_dom.dim (1) ] 
+      A (i,j) = + reduce (  [k in mat_dom.dim (1) ]
     			    B (i, k) * B (j, k) );
 
     // factorization algorithms overwrite a copy of A, leaving
@@ -134,10 +134,10 @@ module test_dataflow_cholesky {
     else
       writeln ("factorization failed for non-positive semi-definite matrix");
 
- 
+
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 2D data flow cholesky factorization, block size: ",
 	      block_size );
 
@@ -150,9 +150,10 @@ module test_dataflow_cholesky {
     else
       writeln ("factorization failed for non-positive semi-definite matrix");
 
+    delete Rand;
   }
 
- 
+
   proc check_factorization ( A : [], L : [] )
 
     // -----------------------------------------------------------------------
@@ -166,9 +167,9 @@ module test_dataflow_cholesky {
 
     assert ( A.domain.dim (1) == A.domain.dim (2)  &&
 	     L.domain.dim (1) == A.domain.dim (1)  &&
-	     L.domain.dim (2) == A.domain.dim (2) 
+	     L.domain.dim (2) == A.domain.dim (2)
 	     );
-    
+
     const mat_dom  = A.domain,
 	  mat_rows = A.domain.dim(1),
 	  n        = A.domain.dim(1).length;
@@ -182,10 +183,10 @@ module test_dataflow_cholesky {
 
     for i in mat_rows do
       d (i) = sqrt ( A (i,i) );
-    
+
     forall (i,j) in mat_dom with (ref max_ratio) do { // race
       const resid: real   =
-               abs (A (i,j) - 
+               abs (A (i,j) -
 		    + reduce ( [k in mat_dom.dim(1) (..min (i,j))]
 			       L (i,k) * L (j,k) ) ) ;
       max_ratio = max ( max_ratio,
@@ -201,7 +202,7 @@ module test_dataflow_cholesky {
 
 
   proc print_L ( L : [] ) {
-   
+
     const rows = L.domain.dim (1);
 
     //for i in rows do
@@ -209,4 +210,4 @@ module test_dataflow_cholesky {
   }
 
 }
-    
+

--- a/test/studies/cholesky/jglewis/version2/performance/test_cholesky_performance.chpl
+++ b/test/studies/cholesky/jglewis/version2/performance/test_cholesky_performance.chpl
@@ -61,14 +61,14 @@ module performance_cholesky_test {
 
     // -------------------------------------------------------------
     // create a positive definite matrix A by setting A equal to the
-    // matrix-matrix product B B^T.  This normal equations matrix is 
+    // matrix-matrix product B B^T.  This normal equations matrix is
     // positive-definite as long as B is full rank.
     // -------------------------------------------------------------
 
     A = 0.0;
 
     forall (i,j) in mat_dom do
-      A (i,j) = + reduce (  [k in mat_dom.dim (1) ] 
+      A (i,j) = + reduce (  [k in mat_dom.dim (1) ]
     			    B (i, k) * B (j, k) );
 
     // factorization algorithms overwrite a copy of A, leaving
@@ -87,13 +87,13 @@ module performance_cholesky_test {
     var clock : Timer;
 
     clock.start ();
-    
+
     positive_definite = scalar_column_major_outer_product_cholesky ( L );
-    
+
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -107,7 +107,7 @@ module performance_cholesky_test {
 
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("scalar row major outer product cholesky factorization: " );
 
     clock.clear ();
@@ -118,7 +118,7 @@ module performance_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -132,10 +132,10 @@ module performance_cholesky_test {
     else
       writeln ("factorization failed for non-positive semi-definite matrix");
 
-     
+
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("scalar row major outer product cholesky factorization: " );
     writeln ( "  with explicit loops in place of vector operations: " );
 
@@ -147,7 +147,7 @@ module performance_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -161,10 +161,10 @@ module performance_cholesky_test {
     else
       writeln ("factorization failed for non-positive semi-definite matrix");
 
-     
+
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("scalar row major outer product cholesky factorization");
     writeln ( "  with explicit temporaries: " );
 
@@ -176,7 +176,7 @@ module performance_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -192,7 +192,7 @@ module performance_cholesky_test {
 
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("scalar row major outer product cholesky factorization");
     writeln ( "  with explicitly bounded iterations: " );
 
@@ -204,7 +204,7 @@ module performance_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -226,13 +226,13 @@ module performance_cholesky_test {
     L = A;
 
     clock.start ();
-    
+
     positive_definite = scalar_inner_product_cholesky ( L );
-    
+
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -250,13 +250,13 @@ module performance_cholesky_test {
     L = A;
 
     clock.start ();
-    
+
     positive_definite = scalar_bordering_cholesky ( L );
-    
+
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -267,7 +267,7 @@ module performance_cholesky_test {
     else
       writeln ("factorization failed for non-positive semi-definite matrix");
 
-
+    delete Rand;
   }
 
 
@@ -284,9 +284,9 @@ module performance_cholesky_test {
 
     assert ( A.domain.dim (1) == A.domain.dim (2)  &&
 	     L.domain.dim (1) == A.domain.dim (1)  &&
-	     L.domain.dim (2) == A.domain.dim (2) 
+	     L.domain.dim (2) == A.domain.dim (2)
 	     );
-    
+
     const mat_dom  = A.domain,
           mat_rows = A.domain.dim(1),
           n        = A.domain.dim(1).length;
@@ -300,9 +300,9 @@ module performance_cholesky_test {
 
     for i in mat_rows do
       d (i) = sqrt ( A (i,i) );
-    
+
     forall (i,j) in mat_dom with (ref max_ratio) do { // race
-      const resid : real  = abs (A (i,j) - 
+      const resid : real  = abs (A (i,j) -
 		    + reduce ( [k in mat_dom.dim(1) (..min (i,j))]
 			       L (i,k) * L (j,k) ) ) ;
       max_ratio = max ( max_ratio,
@@ -318,10 +318,10 @@ module performance_cholesky_test {
 
 
   proc print_lower_triangle ( L : [] ) {
-   
+
     if print_matrix_details then
       for (i_row, i_col) in zip( L.domain.dim(1), L.domain.dim(2) ) do
 	writeln (i_row, ":  ", L(i_row, ..i_col) );
   }
 }
-    
+

--- a/test/studies/cholesky/jglewis/version2/standard_cholesky/test_standard_cholesky.chpl
+++ b/test/studies/cholesky/jglewis/version2/standard_cholesky/test_standard_cholesky.chpl
@@ -79,10 +79,10 @@ module standard_cholesky_test {
 
   use cholesky_execution_config_consts;
 
-  use scalar_outer_product_cholesky, 
-      scalar_inner_product_cholesky, 
-      scalar_bordering_cholesky, 
-      block_1D_outer_product_cholesky, 
+  use scalar_outer_product_cholesky,
+      scalar_inner_product_cholesky,
+      scalar_bordering_cholesky,
+      block_1D_outer_product_cholesky,
       block_2D_outer_product_cholesky,
       block_1D_inner_product_cholesky,
       block_2D_inner_product_cholesky,
@@ -115,14 +115,14 @@ module standard_cholesky_test {
 
     // -------------------------------------------------------------
     // create a positive definite matrix A by setting A equal to the
-    // matrix-matrix product B B^T.  This normal equations matrix is 
+    // matrix-matrix product B B^T.  This normal equations matrix is
     // positive-definite as long as B is full rank.
     // -------------------------------------------------------------
 
     A = 0.0;
 
     forall (i,j) in mat_dom do
-      A (i,j) = + reduce (  [k in mat_dom.dim (1) ] 
+      A (i,j) = + reduce (  [k in mat_dom.dim (1) ]
     			    B (i, k) * B (j, k) );
 
     // factorization algorithms overwrite a copy of A, leaving
@@ -139,7 +139,7 @@ module standard_cholesky_test {
     writeln ("scalar outer product cholesky factorization ");
 
     var clock : Timer;
-          
+
     clock.clear ();
     clock.start ();
 
@@ -148,7 +148,7 @@ module standard_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -161,7 +161,7 @@ module standard_cholesky_test {
 
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("block 1D outer product cholesky factorization, block size: ",
 	      block_size );
 
@@ -173,7 +173,7 @@ module standard_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -186,7 +186,7 @@ module standard_cholesky_test {
 
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("block 2D outer product cholesky factorization, block size: ",
 	      block_size );
 
@@ -198,7 +198,7 @@ module standard_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -223,7 +223,7 @@ module standard_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -235,10 +235,10 @@ module standard_cholesky_test {
       writeln ("factorization failed for non-positive semi-definite matrix");
 
 
-     
+
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("block 1D inner product cholesky factorization, block size: ",
 	      block_size );
 
@@ -250,7 +250,7 @@ module standard_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -264,7 +264,7 @@ module standard_cholesky_test {
 
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("block 2D inner product cholesky factorization, block size: ",
 	      block_size );
 
@@ -276,7 +276,7 @@ module standard_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -301,7 +301,7 @@ module standard_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -314,7 +314,7 @@ module standard_cholesky_test {
 
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("block 1D bordering cholesky factorization, block size: ",
 	      block_size );
 
@@ -326,7 +326,7 @@ module standard_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -340,7 +340,7 @@ module standard_cholesky_test {
 
     L = A;
 
-    writeln ("\n\n"); 
+    writeln ("\n\n");
     writeln ("block 2D bordering cholesky factorization, block size: ",
 	      block_size );
 
@@ -352,7 +352,7 @@ module standard_cholesky_test {
     clock.stop ();
     if !reproducible_output then {
       writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-      writeln ( " collective speed in megaflops: ", 
+      writeln ( " collective speed in megaflops: ",
 		( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
     }
 
@@ -364,33 +364,33 @@ module standard_cholesky_test {
       writeln ("factorization failed for non-positive semi-definite matrix");
 
     proc run_one_cholesky_algorithm ( header : string, cholesky_fun ) {
-      
+
       // --------------------------------------------
       // Timer version assumes one process per locale
       // --------------------------------------------
       //
       // draft of a procedure to encapsulate the test process.  Unused at this
       // time because Chapel presently doesn't handle generic functions as
-      // arguments. The cholesky codes all are written generically because they 
+      // arguments. The cholesky codes all are written generically because they
       // can be.
-          
+
       var clock : Timer;
-          
+
       writeln ("\n\n");
       writeln (header);
-          
+
       clock.clear ();
       clock.start ();
-          
+
       positive_definite = cholesky_fun ( L );
-          
+
       clock.stop ();
       if !reproducible_output then {
 	writeln ( "Cholesky Factorization time:    ", clock.elapsed () );
-	writeln ( " collective speed in megaflops: ", 
+	writeln ( " collective speed in megaflops: ",
 		  ( (n**3) / 3.0 )  / (10.0**6 * clock.elapsed () ) );
       }
-          
+
       print_lower_triangle ( L );
 
       if positive_definite then
@@ -399,6 +399,7 @@ module standard_cholesky_test {
     	writeln ("factorization failed for non-positive semi-definite matrix");
     }
 
+    delete Rand;
   }
 
   proc check_factorization ( A : [], L : [] )
@@ -414,9 +415,9 @@ module standard_cholesky_test {
 
     assert ( A.domain.dim (1) == A.domain.dim (2)  &&
 	     L.domain.dim (1) == A.domain.dim (1)  &&
-	     L.domain.dim (2) == A.domain.dim (2) 
+	     L.domain.dim (2) == A.domain.dim (2)
 	     );
-    
+
     const mat_dom  = A.domain,
           mat_rows = A.domain.dim(1),
           n        = A.domain.dim(1).length;
@@ -430,10 +431,10 @@ module standard_cholesky_test {
 
     for i in mat_rows do
       d (i) = sqrt ( A (i,i) );
-    
+
     forall (i,j) in mat_dom with (ref max_ratio) do { // race
       const resid: real =
-               abs (A (i,j) - 
+               abs (A (i,j) -
 		    + reduce ( [k in mat_dom.dim(1) (..min (i,j))]
 			       L (i,k) * L (j,k) ) ) ;
       max_ratio = max ( max_ratio,
@@ -449,10 +450,10 @@ module standard_cholesky_test {
 
 
   proc print_lower_triangle ( L : [] ) {
-   
+
     if print_matrix_details then
       for (i_row, i_col) in zip( L.domain.dim(1), L.domain.dim(2) ) do
 	writeln (i_row, ":  ", L(i_row, ..i_col) );
   }
 }
-    
+

--- a/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_dyn.chpl
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_dyn.chpl
@@ -1,15 +1,15 @@
 /******************************************************************************
  * Jacobi1D benchmark
  * DiamondSlab Tiling
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~ IN PROGRESS ~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~ IN PROGRESS ~~~~~~~~~~~~~~~~~~~~~~~~~~
  * TODO:
  * <strike> 1) Figure out how to do Standalone parallel iterator</strike>
- * <strike> 1.1) Figure out if a standalone iterator will work with C code 
+ * <strike> 1.1) Figure out if a standalone iterator will work with C code
  *    Given the format, it will not. need leader follower.
  *    Means need serial.
  * </strike>
  * <strike> 2) Convert aforementioned C loop-nest code to Chapel iterator code.
- * <strike> 
+ * <strike>
  * <strike> 3) Create associated test files for this </strike>
  * 4) Wait for Standalone par. iter to take parameters, and convert to that.
  *
@@ -19,22 +19,23 @@
  * bin/Jacobi1D-DiamondSlabByHand-Chapel \
  * `cat src/Jacobi1D-DiamondSlabByHand-Chapel.perfexecopts`
  * For a run on 8 threads
- * 
+ *
  * Ian J. Bertolacci - CSU
  ******************************************************************************/
 use Time;
-use Random; 
+use Random;
 use DynamicIters;
+
 config const printTime: bool = true; // print timer
 config const globalSeed = SeedGenerator.oddCurrentTime;
-config const problemSize = 100000; 
-config const T = 1000; // number of time steps    
+config const problemSize = 100000;
+config const T = 1000; // number of time steps
 config const tau = 10;
 config const verify: bool;
 
 type Cell = real(64);
 // tile type, describes tile shape: (x_0, dx_0, x_1, dx_1, t_0, t_1)
-type Tile = (int, int, int, int, int, int); 
+type Tile = (int, int, int, int, int, int);
 
 
 // DiamondSlab Tile Iterator (serial)
@@ -43,10 +44,10 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
                           tau: int): 3*int {
   var Ui = upperBound, Li = lowerBound;
   for thyme in floord(2, tau)-2 .. floord(T*2, tau){
-    for  k1 in ((Ui*2/(tau: real)-thyme+1 )/-2): int 
+    for  k1 in ((Ui*2/(tau: real)-thyme+1 )/-2): int
             .. (( (Li*2/(tau: real))-thyme-1)/ -2): int {
       // begin inner loops over points in tile
-      for t in max(1, floord(thyme*tau - k1*tau + k1*tau + 1, 2)) 
+      for t in max(1, floord(thyme*tau - k1*tau + k1*tau + 1, 2))
                .. min(T+1, tau + floord(thyme*tau - k1*tau + k1*tau, 2)) - 1 {
         var write = t & 1;
         var read = 1-write;
@@ -56,7 +57,7 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
          // (t, i);
         } // i
       } // t
-    } // k1    
+    } // k1
   }// thyme
 }// DiamondTileIterator
 
@@ -64,15 +65,15 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
 // DiamondSlab Tile Iterator (Parallel)
 // This will produce the indicies for the loop.
 iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
-                              tau: int, 
-                              param tag: iterKind): 3*int 
+                              tau: int,
+                              param tag: iterKind): 3*int
                               where tag == iterKind.standalone {
     var Ui = upperBound, Li = lowerBound;
   for thyme in floord(2, tau)-2 .. floord(T*2, tau){
-    forall  k1 in dynamic( ((Ui*2/(tau: real)-thyme+1 )/-2): int 
+    forall  k1 in dynamic( ((Ui*2/(tau: real)-thyme+1 )/-2): int
             .. (( (Li*2/(tau: real))-thyme-1)/ -2): int, chunkSize=1) {
       // begin inner loops over points in tile
-      for t in max(1, floord(thyme*tau - k1*tau + k1*tau + 1, 2)) 
+      for t in max(1, floord(thyme*tau - k1*tau + k1*tau + 1, 2))
                .. min(T+1, tau + floord(thyme*tau - k1*tau + k1*tau, 2)) - 1 {
         var write = t & 1;
         var read = 1-write;
@@ -82,9 +83,9 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
          // (t, i);
         } // i
       } // t
-    } // k1    
+    } // k1
   }// thyme
-  
+
 }// DiamondTileIterator
 
 // main
@@ -100,14 +101,14 @@ proc main(){
   // 2 - data allocation and initialization
   const lowerBound = 1; // start of computation space
   const upperBound = lowerBound + problemSize - 1; // end of computation space
-  
+
   // create a haloed domain
   var totalSpaceRange = lowerBound - 1 .. upperBound + 1;
   var computationTimeRange = 1..T;
   var computationSpaceRange = lowerBound..upperBound;
 
   // Storage array.
-  var space: [0..1, totalSpaceRange ] Cell;  
+  var space: [0..1, totalSpaceRange ] Cell;
   var timer: Timer;
   // initialize space with values
   var generator = new RandomStream( globalSeed, parSafe = false );
@@ -123,29 +124,32 @@ proc main(){
   // 3 - jacobi 1D timed within an openmp loop
   timer.start();
 
-  forall (read, write, x) in DiamondTileIterator( lowerBound, upperBound, T, 
+  forall (read, write, x) in DiamondTileIterator( lowerBound, upperBound, T,
                                                    tau ){
-    space[write, x] = (space[read, x-1] +  
+    space[write, x] = (space[read, x-1] +
                        space[read, x] +
-                       space[read, x+1]) / 3; 
+                       space[read, x+1]) / 3;
   }
-   
+
   timer.stop();
 
   var time = timer.elapsed();;
 
   // 4 - output and optional verification
   if printTime then stdout.write( "Time: ", time );
+
   if verify {
     if verifyResult(space,lowerBound,upperBound,false ) then writeln( "SUCCESS" );
     else writeln( "FAILURE" );
   }
+
+  delete generator;
 }
 
 
-// return true if the current end state is the same as the 
+// return true if the current end state is the same as the
 // stencil applied to the original state, in serial iteration.
-proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int, 
+proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
              verbose: bool = true ): bool {
 
   var totalSpaceRange = lowerBound - 1 .. upperBound + 1;
@@ -156,25 +160,25 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
 
   for x in computationSpaceRange do
     spaceEndState[ x ] = space[ T & 1, x ];
-    
+
   var generator = new RandomStream( globalSeed, parSafe = false );
 
   for i in computationSpaceRange do
     space[0, i] = generator.getNext();
 
-  var read = 0;
+  var read  = 0;
   var write = 1;
-  
+
   for t in computationTimeRange {
     for x in computationSpaceRange do
-       space[write, x] = (space[read, x-1] + 
+       space[write, x] = (space[read, x-1] +
                     space[read, x] +
                     space[read, x+1]) / 3;
-    read <=> write;  
-  }    
-  
+    read <=> write;
+  }
+
   var passed: bool = true;
-  
+
   for x in computationSpaceRange do
     if spaceEndState[x] != space[ T & 1, x ]  {
       if verbose then
@@ -182,12 +186,13 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
       passed = false;
       break;
     }
-  
+
   if passed && verbose then
     writeln( "SUCCESS!" );
-  
+
+  delete generator;
+
   return passed;
-  
 }
 
 proc floord( x: int , y: int ): int {

--- a/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_static.chpl
@@ -1,15 +1,15 @@
 /******************************************************************************
  * Jacobi1D benchmark
  * DiamondSlab Tiling
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~ IN PROGRESS ~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~ IN PROGRESS ~~~~~~~~~~~~~~~~~~~~~~~~~~
  * TODO:
  * <strike> 1) Figure out how to do Standalone parallel iterator</strike>
- * <strike> 1.1) Figure out if a standalone iterator will work with C code 
+ * <strike> 1.1) Figure out if a standalone iterator will work with C code
  *    Given the format, it will not. need leader follower.
  *    Means need serial.
  * </strike>
  * <strike> 2) Convert aforementioned C loop-nest code to Chapel iterator code.
- * <strike> 
+ * <strike>
  * <strike> 3) Create associated test files for this </strike>
  * 4) Wait for Standalone par. iter to take parameters, and convert to that.
  *
@@ -19,22 +19,22 @@
  * bin/Jacobi1D-DiamondSlabByHand-Chapel \
  * `cat src/Jacobi1D-DiamondSlabByHand-Chapel.perfexecopts`
  * For a run on 8 threads
- * 
+ *
  * Ian J. Bertolacci - CSU
  ******************************************************************************/
 use Time;
-use Random; 
+use Random;
 
 config const printTime: bool = true; // print timer
 config const globalSeed = SeedGenerator.oddCurrentTime;
-config const problemSize = 100000; 
-config const T = 1000; // number of time steps    
+config const problemSize = 100000;
+config const T = 1000; // number of time steps
 config const tau = 10;
 config const verify: bool;
 
 type Cell = real(64);
 // tile type, describes tile shape: (x_0, dx_0, x_1, dx_1, t_0, t_1)
-type Tile = (int, int, int, int, int, int); 
+type Tile = (int, int, int, int, int, int);
 
 
 // DiamondSlab Tile Iterator (serial)
@@ -43,10 +43,10 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
                           tau: int): 3*int {
   var Ui = upperBound, Li = lowerBound;
   for thyme in floord(2, tau)-2 .. floord(T*2, tau){
-    for  k1 in ((Ui*2/(tau: real)-thyme+1 )/-2): int 
+    for  k1 in ((Ui*2/(tau: real)-thyme+1 )/-2): int
             .. (( (Li*2/(tau: real))-thyme-1)/ -2): int {
       // begin inner loops over points in tile
-      for t in max(1, floord(thyme*tau - k1*tau + k1*tau + 1, 2)) 
+      for t in max(1, floord(thyme*tau - k1*tau + k1*tau + 1, 2))
                .. min(T+1, tau + floord(thyme*tau - k1*tau + k1*tau, 2)) - 1 {
         var write = t & 1;
         var read = 1-write;
@@ -56,7 +56,7 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
          // (t, i);
         } // i
       } // t
-    } // k1    
+    } // k1
   }// thyme
 }// DiamondTileIterator
 
@@ -64,15 +64,15 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
 // DiamondSlab Tile Iterator (Parallel)
 // This will produce the indicies for the loop.
 iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
-                              tau: int, 
-                              param tag: iterKind): 3*int 
+                              tau: int,
+                              param tag: iterKind): 3*int
                               where tag == iterKind.standalone {
     var Ui = upperBound, Li = lowerBound;
   for thyme in floord(2, tau)-2 .. floord(T*2, tau){
-    forall  k1 in ((Ui*2/(tau: real)-thyme+1 )/-2): int 
+    forall  k1 in ((Ui*2/(tau: real)-thyme+1 )/-2): int
             .. (( (Li*2/(tau: real))-thyme-1)/ -2): int {
       // begin inner loops over points in tile
-      for t in max(1, floord(thyme*tau - k1*tau + k1*tau + 1, 2)) 
+      for t in max(1, floord(thyme*tau - k1*tau + k1*tau + 1, 2))
                .. min(T+1, tau + floord(thyme*tau - k1*tau + k1*tau, 2)) - 1 {
         var write = t & 1;
         var read = 1-write;
@@ -82,9 +82,9 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
          // (t, i);
         } // i
       } // t
-    } // k1    
+    } // k1
   }// thyme
-  
+
 }// DiamondTileIterator
 
 // main
@@ -100,15 +100,16 @@ proc main(){
   // 2 - data allocation and initialization
   const lowerBound = 1; // start of computation space
   const upperBound = lowerBound + problemSize - 1; // end of computation space
-  
+
   // create a haloed domain
   var totalSpaceRange = lowerBound - 1 .. upperBound + 1;
   var computationTimeRange = 1..T;
   var computationSpaceRange = lowerBound..upperBound;
 
   // Storage array.
-  var space: [0..1, totalSpaceRange ] Cell;  
+  var space: [0..1, totalSpaceRange ] Cell;
   var timer: Timer;
+
   // initialize space with values
   var generator = new RandomStream( globalSeed, parSafe = false );
 
@@ -123,29 +124,32 @@ proc main(){
   // 3 - jacobi 1D timed within an openmp loop
   timer.start();
 
-  forall (read, write, x) in DiamondTileIterator( lowerBound, upperBound, T, 
+  forall (read, write, x) in DiamondTileIterator( lowerBound, upperBound, T,
                                                    tau ){
-    space[write, x] = (space[read, x-1] +  
+    space[write, x] = (space[read, x-1] +
                        space[read, x] +
-                       space[read, x+1]) / 3; 
+                       space[read, x+1]) / 3;
   }
-   
+
   timer.stop();
 
   var time = timer.elapsed();;
 
   // 4 - output and optional verification
   if printTime then stdout.write( "Time: ", time );
+
   if verify {
     if verifyResult(space,lowerBound,upperBound,false ) then writeln( "SUCCESS" );
     else writeln( "FAILURE" );
   }
+
+  delete generator;
 }
 
 
-// return true if the current end state is the same as the 
+// return true if the current end state is the same as the
 // stencil applied to the original state, in serial iteration.
-proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int, 
+proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
              verbose: bool = true ): bool {
 
   var totalSpaceRange = lowerBound - 1 .. upperBound + 1;
@@ -156,7 +160,7 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
 
   for x in computationSpaceRange do
     spaceEndState[ x ] = space[ T & 1, x ];
-    
+
   var generator = new RandomStream( globalSeed, parSafe = false );
 
   for i in computationSpaceRange do
@@ -164,17 +168,17 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
 
   var read = 0;
   var write = 1;
-  
+
   for t in computationTimeRange {
     for x in computationSpaceRange do
-       space[write, x] = (space[read, x-1] + 
+       space[write, x] = (space[read, x-1] +
                     space[read, x] +
                     space[read, x+1]) / 3;
-    read <=> write;  
-  }    
-  
+    read <=> write;
+  }
+
   var passed: bool = true;
-  
+
   for x in computationSpaceRange do
     if spaceEndState[x] != space[ T & 1, x ]  {
       if verbose then
@@ -182,12 +186,13 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
       passed = false;
       break;
     }
-  
+
   if passed && verbose then
     writeln( "SUCCESS!" );
-  
+
+  delete generator;
+
   return passed;
-  
 }
 
 proc floord( x: int , y: int ): int {

--- a/test/studies/colostate/Jacobi1D-NaiveParallel-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi1D-NaiveParallel-Chapel_static.chpl
@@ -8,16 +8,16 @@
  * bin/Jacobi1D-NaiveParallel-Chapel \
  * `cat src/Jacobi1D-NaiveParallel-Chapel.perfexecopts`
  * For a run on 8 threads
- * 
+ *
  * Ian J. Bertolacci - CSU
  ******************************************************************************/
 use Time;
-use Random; 
+use Random;
 
 config const printTime: bool = true; // print timer
 config const globalSeed = SeedGenerator.oddCurrentTime;
-config const problemSize = 100000; 
-config const T = 1000; // number of time steps      
+config const problemSize = 100000;
+config const T = 1000; // number of time steps
 config const verify: bool;
 
 type Cell = real(64);
@@ -36,14 +36,14 @@ proc main(){
   // 2 - data allocation and initialization
   const lowerBound = 1; // start of computation space
   const upperBound = lowerBound + problemSize - 1; // end of computation space
-  
+
   // create a haloed domain
   var totalSpaceRange = lowerBound - 1 .. upperBound + 1;
   var computationTimeRange = 1..T;
   var computationSpaceRange = lowerBound..upperBound;
 
   // Storage array.
-  var space: [0..1, totalSpaceRange ] Cell;   
+  var space: [0..1, totalSpaceRange ] Cell;
   var timer: Timer;
   // initialize space with values
   var generator = new RandomStream( globalSeed, parSafe = false );
@@ -60,35 +60,37 @@ proc main(){
   // we must make our own
   var read = 0;
   var write = 1;
-   
+
   // 3 - jacobi 1D timed within an openmp loop
   timer.start();
-  
+
   for t in computationTimeRange {
       forall x in computationSpaceRange do
-          space[write, x] = (space[read, x-1] + 
+          space[write, x] = (space[read, x-1] +
                              space[read, x] +
                              space[read, x+1]) / 3;
       read <=> write;
   }
-    
+
   timer.stop();
 
   var time = timer.elapsed();
 
   // 4 - output and optional verification
   if printTime then stdout.write( "Time: ", time );
+
   if verify {
     if verifyResult(space,lowerBound,upperBound,false ) then writeln( "SUCCESS" );
     else writeln( "FAILURE" );
   }
 
+  delete generator;
 }
 
 
-// return true if the current end state is the same as the 
+// return true if the current end state is the same as the
 // stencil applied to the original state, in serial iteration.
-proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int, 
+proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
                    verbose: bool = true ): bool {
 
   var totalSpaceRange = lowerBound - 1 .. upperBound + 1;
@@ -99,7 +101,7 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
 
   for x in computationSpaceRange do
      spaceEndState[ x ] = space[ T & 1, x ];
-     
+
   var generator = new RandomStream( globalSeed, parSafe = false );
 
   for i in computationSpaceRange do
@@ -107,17 +109,17 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
 
   var read = 0;
   var write = 1;
-  
+
   for t in computationTimeRange {
      for x in computationSpaceRange do
-          space[write, x] = (space[read, x-1] + 
+          space[write, x] = (space[read, x-1] +
                              space[read, x] +
                              space[read, x+1]) / 3;
-     read <=> write;   
-  }      
-  
+     read <=> write;
+  }
+
   var passed: bool = true;
-  
+
   for x in computationSpaceRange do
      if spaceEndState[x] != space[ T & 1, x ]  {
         if verbose then
@@ -125,12 +127,13 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
         passed = false;
         break;
      }
-  
+
   if passed && verbose then
      writeln( "SUCCESS!" );
-  
+
+  delete generator;
+
   return passed;
-  
 }
 
 

--- a/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_dyn.chpl
+++ b/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_dyn.chpl
@@ -8,15 +8,16 @@
  * bin/Jacobi2D-NaiveParallel-Chapel \
  * `cat src/Jacobi2D-NaiveParallel-Chapel.perfexecopts`
  * For a run on 8 threads
- * 
+ *
  * Ian J. Bertolacci - CSU
  ******************************************************************************/
 use Time;
-use Random; 
+use Random;
 use DynamicIters;
+
 config const printTime: bool = true; // print timer
 config const globalSeed = SeedGenerator.oddCurrentTime;
-config const problemSize = 1000; 
+config const problemSize = 1000;
 config const T = 100; // number of time steps
 config const tau: int = 30;
 config const verify: bool;
@@ -25,12 +26,12 @@ type Cell = real(64);
 
 // DiamondTileIterator (serial)
 iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*int {
-  
+
   var num_tiles: int = 0;
   var tau_times_3: int = tau*3;
 
   // Set lower and upper bounds for spatial dimensions.
-  var Li: int = lowerBound, Lj: int = lowerBound, 
+  var Li: int = lowerBound, Lj: int = lowerBound,
       Ui: int = upperBound, Uj: int = upperBound;
   //var thyme: int, k1: int, k2: int, t: int, j: int;
 
@@ -46,7 +47,7 @@ iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*
     // That also turns them into a bounding box.
     var k2_lb: int = floord((2*thyme-2)*tau-3*Ui+2,tau_times_3);
     var k2_ub: int = floord((2+2*thyme)*tau-2-3*Li,tau_times_3);
-    
+
 //#pragma omp parallel for shared(start_time, Li, Lj, Ui, Uj ) private(read, write,k1,k2,t,i,j)
     //for (k1=k1_lb; k1<=k1_ub; k1++) {
     for k1 in k1_lb .. k1_ub {
@@ -60,9 +61,9 @@ iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*
 
         // Loop over time within a tile.
         /*
-        for (t=max(1,floord(thyme*tau-1,3)); 
+        for (t=max(1,floord(thyme*tau-1,3));
              t<= min(T,floord((3+thyme)*tau-3,3)); t++) { */
-        for t in max(1,floord(thyme*tau-1,3)) .. min(T,floord((3+thyme)*tau-3,3)){             
+        for t in max(1,floord(thyme*tau-1,3)) .. min(T,floord((3+thyme)*tau-3,3)){
           // if t % 2  is 1, then read=0 and write=1
           write = t & 1;
           read = 1-write;
@@ -75,7 +76,7 @@ iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*
             /*for (j=max(Lj,max(tau*k1-t,t-i-(1+k2)*tau+1));
                  j<=min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)); j++) {*/
               for j in max(Lj,max(tau*k1-t,t-i-(1+k2)*tau+1))
-                    .. min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)){       
+                    .. min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)){
                yield (read, write, i, j);
             } // for j
           } // for i
@@ -87,14 +88,14 @@ iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*
 
 
 // DiamondTileIterator (parallel)
-iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int, 
+iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
                           tau: int,
-                          param tag: iterKind): 4*int 
+                          param tag: iterKind): 4*int
                           where tag == iterKind.standalone {
   var tau_times_3: int = tau*3;
 
   // Set lower and upper bounds for spatial dimensions.
-  var Li: int = lowerBound, Lj: int = lowerBound, 
+  var Li: int = lowerBound, Lj: int = lowerBound,
       Ui: int = upperBound, Uj: int = upperBound;
   //var thyme: int, k1: int, k2: int, t: int, j: int;
 
@@ -110,7 +111,7 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
     // That also turns them into a bounding box.
     var k2_lb: int = floord((2*thyme-2)*tau-3*Ui+2,tau_times_3);
     var k2_ub: int = floord((2+2*thyme)*tau-2-3*Li,tau_times_3);
-    
+
 //#pragma omp parallel for shared(start_time, Li, Lj, Ui, Uj ) private(read, write,k1,k2,t,i,j)
     //for (k1=k1_lb; k1<=k1_ub; k1++) {
     forall k1 in dynamic(k1_lb .. k1_ub,chunkSize=1) {
@@ -123,9 +124,9 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
 
         // Loop over time within a tile.
         /*
-        for (t=max(1,floord(thyme*tau,3)); 
+        for (t=max(1,floord(thyme*tau,3));
              t<= min(T,floord((3+thyme)*tau-3,3)); t++) { */
-        for t in max(1,floord(thyme*tau,3)) .. min(T,floord((3+thyme)*tau-3,3)){             
+        for t in max(1,floord(thyme*tau,3)) .. min(T,floord((3+thyme)*tau-3,3)){
           // if t % 2  is 1, then read=0 and write=1
           write = t & 1;
           read = 1-write;
@@ -138,7 +139,7 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
             /*for (j=max(Lj,max(tau*k1-t,t-i-(1+k2)*tau+1));
                  j<=min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)); j++) {*/
               for j in max(Lj,max(tau*k1-t,t-i-(1+k2)*tau+1))
-                    .. min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)){       
+                    .. min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)){
                yield (read, write, i, j);
             } // for j
           } // for i
@@ -162,14 +163,14 @@ proc main(){
   // 2 - data allocation and initialization
   const lowerBound = 1; // start of computation space
   const upperBound = problemSize ; // end of computation space
-  
+
   // create a haloed domain
   var totalSpaceRange: domain(2) = { 0..problemSize+1, 0..problemSize+1};
   var computationTimeRange = 1..T;
   var computationDomain: domain(2) = totalSpaceRange.expand(-1);
 
   // Storage array.
-  var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;   
+  var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
   // initialize space with values
   var generator = new RandomStream( globalSeed, parSafe = false );
@@ -183,38 +184,40 @@ proc main(){
      space[0, x, y] = generator.getNext();
 
   //var read: int = 0, write: int = 1;
-  
+
   // 3 - jacobi 1D timed within an openmp loop
   timer.start();
-  
+
   //forall (x,y) in computationDomain do
   forall (read, write, x ,y) in DiamondTileIterator(lowerBound, upperBound, T, tau){
   //forall (x,y) in computationDomain {
-      space[write, x, y] = (space[read, x, y-1] + 
-                            space[read, x-1, y] + 
-                            space[read, x, y+1] + 
-                            space[read, x+1, y] + 
+      space[write, x, y] = (space[read, x, y-1] +
+                            space[read, x-1, y] +
+                            space[read, x, y+1] +
+                            space[read, x+1, y] +
                             space[read, x, y] ) / 5;
   }
   //read <=> write;
-    
+
   timer.stop();
 
   var time = timer.elapsed();
 
   // 4 - output and optional verification
   if printTime then stdout.write( "Time: ", time );
+
   if verify {
     if verifyResult(space, computationDomain, verbose=false, T ) then writeln( "SUCCESS" );
     else writeln( "FAILURE" );
   }
 
+  delete generator;
 }
 
 
-// return true if the current end state is the same as the 
+// return true if the current end state is the same as the
 // stencil applied to the original state, in serial iteration.
-proc verifyResult( space: [] Cell, computationalDomain: domain(2), 
+proc verifyResult( space: [] Cell, computationalDomain: domain(2),
                    verbose: bool = true, T: int ): bool {
 
   var computationTimeRange = 1..T;
@@ -223,7 +226,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
 
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
-     
+
   var generator = new RandomStream( globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
@@ -231,17 +234,17 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
 
   var read = 0;
   var write = 1;
-  
+
   for t in computationTimeRange {
      for (x,y) in computationalDomain do
-          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] + 
+          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] +
                                 space[read, x, y+1] + space[read, x+1, y] +
                                 space[read, x, y] ) / 5;
-     read <=> write;   
-  }      
-  
+     read <=> write;
+  }
+
   var passed: bool = true;
-  
+
   for (x, y) in computationalDomain do
      if spaceEndState[x,y] != space[ T & 1, x, y]  {
         if verbose then
@@ -249,12 +252,14 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
         passed = false;
         break;
      }
-  
+
   if passed && verbose then
      writeln( "SUCCESS!" );
-  
+
+  delete generator;
+
   return passed;
-  
+
 }
 
 proc floord( x: int , y: int ): int {

--- a/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_static.chpl
@@ -8,15 +8,15 @@
  * bin/Jacobi2D-NaiveParallel-Chapel \
  * `cat src/Jacobi2D-NaiveParallel-Chapel.perfexecopts`
  * For a run on 8 threads
- * 
+ *
  * Ian J. Bertolacci - CSU
  ******************************************************************************/
 use Time;
-use Random; 
+use Random;
 
 config const printTime: bool = true; // print timer
 config const globalSeed = SeedGenerator.oddCurrentTime;
-config const problemSize = 1000; 
+config const problemSize = 1000;
 config const T = 100; // number of time steps
 config const tau: int = 30;
 config const verify: bool;
@@ -25,12 +25,12 @@ type Cell = real(64);
 
 // DiamondTileIterator (serial)
 iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*int {
-  
+
   var num_tiles: int = 0;
   var tau_times_3: int = tau*3;
 
   // Set lower and upper bounds for spatial dimensions.
-  var Li: int = lowerBound, Lj: int = lowerBound, 
+  var Li: int = lowerBound, Lj: int = lowerBound,
       Ui: int = upperBound, Uj: int = upperBound;
   //var thyme: int, k1: int, k2: int, t: int, j: int;
 
@@ -46,7 +46,7 @@ iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*
     // That also turns them into a bounding box.
     var k2_lb: int = floord((2*thyme-2)*tau-3*Ui+2,tau_times_3);
     var k2_ub: int = floord((2+2*thyme)*tau-2-3*Li,tau_times_3);
-    
+
 //#pragma omp parallel for shared(start_time, Li, Lj, Ui, Uj ) private(read, write,k1,k2,t,i,j)
     //for (k1=k1_lb; k1<=k1_ub; k1++) {
     for k1 in k1_lb .. k1_ub {
@@ -60,9 +60,9 @@ iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*
 
         // Loop over time within a tile.
         /*
-        for (t=max(1,floord(thyme*tau-1,3)); 
+        for (t=max(1,floord(thyme*tau-1,3));
              t<= min(T,floord((3+thyme)*tau-3,3)); t++) { */
-        for t in max(1,floord(thyme*tau-1,3)) .. min(T,floord((3+thyme)*tau-3,3)){             
+        for t in max(1,floord(thyme*tau-1,3)) .. min(T,floord((3+thyme)*tau-3,3)){
           // if t % 2  is 1, then read=0 and write=1
           write = t & 1;
           read = 1-write;
@@ -75,7 +75,7 @@ iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*
             /*for (j=max(Lj,max(tau*k1-t,t-i-(1+k2)*tau+1));
                  j<=min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)); j++) {*/
               for j in max(Lj,max(tau*k1-t,t-i-(1+k2)*tau+1))
-                    .. min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)){       
+                    .. min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)){
                yield (read, write, i, j);
             } // for j
           } // for i
@@ -87,14 +87,14 @@ iter DiamondTileIterator(lowerBound: int, upperBound: int, T: int, tau: int): 4*
 
 
 // DiamondTileIterator (parallel)
-iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int, 
+iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
                           tau: int,
-                          param tag: iterKind): 4*int 
+                          param tag: iterKind): 4*int
                           where tag == iterKind.standalone {
   var tau_times_3: int = tau*3;
 
   // Set lower and upper bounds for spatial dimensions.
-  var Li: int = lowerBound, Lj: int = lowerBound, 
+  var Li: int = lowerBound, Lj: int = lowerBound,
       Ui: int = upperBound, Uj: int = upperBound;
   //var thyme: int, k1: int, k2: int, t: int, j: int;
 
@@ -110,7 +110,7 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
     // That also turns them into a bounding box.
     var k2_lb: int = floord((2*thyme-2)*tau-3*Ui+2,tau_times_3);
     var k2_ub: int = floord((2+2*thyme)*tau-2-3*Li,tau_times_3);
-    
+
 //#pragma omp parallel for shared(start_time, Li, Lj, Ui, Uj ) private(read, write,k1,k2,t,i,j)
     //for (k1=k1_lb; k1<=k1_ub; k1++) {
     forall k1 in k1_lb .. k1_ub {
@@ -123,9 +123,9 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
 
         // Loop over time within a tile.
         /*
-        for (t=max(1,floord(thyme*tau,3)); 
+        for (t=max(1,floord(thyme*tau,3));
              t<= min(T,floord((3+thyme)*tau-3,3)); t++) { */
-        for t in max(1,floord(thyme*tau,3)) .. min(T,floord((3+thyme)*tau-3,3)){             
+        for t in max(1,floord(thyme*tau,3)) .. min(T,floord((3+thyme)*tau-3,3)){
           // if t % 2  is 1, then read=0 and write=1
           write = t & 1;
           read = 1-write;
@@ -138,7 +138,7 @@ iter DiamondTileIterator( lowerBound: int, upperBound: int, T: int,
             /*for (j=max(Lj,max(tau*k1-t,t-i-(1+k2)*tau+1));
                  j<=min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)); j++) {*/
               for j in max(Lj,max(tau*k1-t,t-i-(1+k2)*tau+1))
-                    .. min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)){       
+                    .. min(Uj,min((1+k1)*tau-t-1,t-i-k2*tau)){
                yield (read, write, i, j);
             } // for j
           } // for i
@@ -162,15 +162,16 @@ proc main(){
   // 2 - data allocation and initialization
   const lowerBound = 1; // start of computation space
   const upperBound = problemSize ; // end of computation space
-  
+
   // create a haloed domain
   var totalSpaceRange: domain(2) = { 0..problemSize+1, 0..problemSize+1};
   var computationTimeRange = 1..T;
   var computationDomain: domain(2) = totalSpaceRange.expand(-1);
 
   // Storage array.
-  var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;   
+  var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
+
   // initialize space with values
   var generator = new RandomStream( globalSeed, parSafe = false );
 
@@ -183,38 +184,41 @@ proc main(){
      space[0, x, y] = generator.getNext();
 
   //var read: int = 0, write: int = 1;
-  
+
   // 3 - jacobi 1D timed within an openmp loop
   timer.start();
-  
+
   //forall (x,y) in computationDomain do
   forall (read, write, x ,y) in DiamondTileIterator(lowerBound, upperBound, T, tau){
   //forall (x,y) in computationDomain {
-      space[write, x, y] = (space[read, x, y-1] + 
-                            space[read, x-1, y] + 
-                            space[read, x, y+1] + 
-                            space[read, x+1, y] + 
+      space[write, x, y] = (space[read, x, y-1] +
+                            space[read, x-1, y] +
+                            space[read, x, y+1] +
+                            space[read, x+1, y] +
                             space[read, x, y] ) / 5;
   }
+
   //read <=> write;
-    
+
   timer.stop();
 
   var time = timer.elapsed();
 
   // 4 - output and optional verification
   if printTime then stdout.write( "Time: ", time );
+
   if verify {
     if verifyResult(space, computationDomain, verbose=false, T ) then writeln( "SUCCESS" );
     else writeln( "FAILURE" );
   }
 
+  delete generator;
 }
 
 
-// return true if the current end state is the same as the 
+// return true if the current end state is the same as the
 // stencil applied to the original state, in serial iteration.
-proc verifyResult( space: [] Cell, computationalDomain: domain(2), 
+proc verifyResult( space: [] Cell, computationalDomain: domain(2),
                    verbose: bool = true, T: int ): bool {
 
   var computationTimeRange = 1..T;
@@ -223,7 +227,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
 
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
-     
+
   var generator = new RandomStream( globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
@@ -231,17 +235,17 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
 
   var read = 0;
   var write = 1;
-  
+
   for t in computationTimeRange {
      for (x,y) in computationalDomain do
-          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] + 
+          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] +
                                 space[read, x, y+1] + space[read, x+1, y] +
                                 space[read, x, y] ) / 5;
-     read <=> write;   
-  }      
-  
+     read <=> write;
+  }
+
   var passed: bool = true;
-  
+
   for (x, y) in computationalDomain do
      if spaceEndState[x,y] != space[ T & 1, x, y]  {
         if verbose then
@@ -249,12 +253,14 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
         passed = false;
         break;
      }
-  
+
   if passed && verbose then
      writeln( "SUCCESS!" );
-  
+
+  delete generator;
+
   return passed;
-  
+
 }
 
 proc floord( x: int , y: int ): int {

--- a/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_dyn.chpl
+++ b/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_dyn.chpl
@@ -8,16 +8,16 @@
  * bin/Jacobi2D-NaiveParallel-Chapel \
  * `cat src/Jacobi2D-NaiveParallel-Chapel.perfexecopts`
  * For a run on 8 threads
- * 
+ *
  * Ian J. Bertolacci - CSU
  ******************************************************************************/
 use Time;
-use Random; 
+use Random;
 use DynamicIters;
 config const printTime: bool = true; // print timer
 config const globalSeed = SeedGenerator.oddCurrentTime;
-config const problemSize = 1000; 
-config const T = 100; // number of time steps      
+config const problemSize = 1000;
+config const T = 100; // number of time steps
 config const verify: bool;
 
 type Cell = real(64);
@@ -36,14 +36,14 @@ proc main(){
   // 2 - data allocation and initialization
   const lowerBound = 1; // start of computation space
   const upperBound = problemSize; // end of computation space
-  
+
   // create a haloed domain
   var totalSpaceRange: domain(2) = { 0..problemSize+1, 0..problemSize+1};
   var computationTimeRange = 1..T;
   var computationDomain: domain(2) = totalSpaceRange.expand(-1);
 
   // Storage array.
-  var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;   
+  var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
   // initialize space with values
   var generator = new RandomStream( globalSeed, parSafe = false );
@@ -60,7 +60,7 @@ proc main(){
   // we must make our own
   var read = 0;
   var write = 1;
-   
+
   // 3 - jacobi 1D timed within an openmp loop
   timer.start();
   const rows = computationDomain.dim(1);
@@ -70,30 +70,32 @@ proc main(){
       //forall (x,y) in computationDomain do
       forall x in dynamic(rows,1) {
         for y in cols do
-          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] + 
+          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] +
                                 space[read, x, y+1] + space[read, x+1, y] +
                                 space[read, x, y] ) / 5;
       }
       read <=> write;
   }
-    
+
   timer.stop();
 
   var time = timer.elapsed();
 
   // 4 - output and optional verification
   if printTime then stdout.write( "Time: ", time );
+
   if verify {
     if verifyResult(space, computationDomain, verbose=false, T ) then writeln( "SUCCESS" );
     else writeln( "FAILURE" );
   }
 
+  delete generator;
 }
 
 
-// return true if the current end state is the same as the 
+// return true if the current end state is the same as the
 // stencil applied to the original state, in serial iteration.
-proc verifyResult( space: [] Cell, computationalDomain: domain(2), 
+proc verifyResult( space: [] Cell, computationalDomain: domain(2),
                    verbose: bool = true, T: int ): bool {
 
   var computationTimeRange = 1..T;
@@ -102,7 +104,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
 
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
-     
+
   var generator = new RandomStream( globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
@@ -110,17 +112,17 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
 
   var read = 0;
   var write = 1;
-  
+
   for t in computationTimeRange {
      for (x,y) in computationalDomain do
-          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] + 
+          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] +
                                 space[read, x, y+1] + space[read, x+1, y] +
                                 space[read, x, y] ) / 5;
-     read <=> write;   
-  }      
-  
+     read <=> write;
+  }
+
   var passed: bool = true;
-  
+
   for (x, y) in computationalDomain do
      if spaceEndState[x,y] != space[ T & 1, x, y]  {
         if verbose then
@@ -128,12 +130,13 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
         passed = false;
         break;
      }
-  
+
   if passed && verbose then
      writeln( "SUCCESS!" );
-  
+
+  delete generator;
+
   return passed;
-  
 }
 
 

--- a/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_static.chpl
@@ -8,16 +8,16 @@
  * bin/Jacobi2D-NaiveParallel-Chapel \
  * `cat src/Jacobi2D-NaiveParallel-Chapel.perfexecopts`
  * For a run on 8 threads
- * 
+ *
  * Ian J. Bertolacci - CSU
  ******************************************************************************/
 use Time;
-use Random; 
+use Random;
 
 config const printTime: bool = true; // print timer
 config const globalSeed = SeedGenerator.oddCurrentTime;
-config const problemSize = 1000; 
-config const T = 100; // number of time steps      
+config const problemSize = 1000;
+config const T = 100; // number of time steps
 config const verify: bool;
 
 type Cell = real(64);
@@ -36,14 +36,14 @@ proc main(){
   // 2 - data allocation and initialization
   const lowerBound = 1; // start of computation space
   const upperBound = problemSize; // end of computation space
-  
+
   // create a haloed domain
   var totalSpaceRange: domain(2) = { 0..problemSize+1, 0..problemSize+1};
   var computationTimeRange = 1..T;
   var computationDomain: domain(2) = totalSpaceRange.expand(-1);
 
   // Storage array.
-  var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;   
+  var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
   // initialize space with values
   var generator = new RandomStream( globalSeed, parSafe = false );
@@ -60,10 +60,10 @@ proc main(){
   // we must make our own
   var read = 0;
   var write = 1;
-   
+
   // 3 - jacobi 1D timed within an openmp loop
   timer.start();
-  
+
   const rows = computationDomain.dim(1);
   const cols = computationDomain.dim(2);
   for t in computationTimeRange {
@@ -71,30 +71,32 @@ proc main(){
       //forall (x,y) in computationDomain do
       forall x in rows {
         for y in cols do
-          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] + 
+          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] +
                                 space[read, x, y+1] + space[read, x+1, y] +
                                 space[read, x, y] ) / 5;
       }
       read <=> write;
   }
-    
+
   timer.stop();
 
   var time = timer.elapsed();
 
   // 4 - output and optional verification
   if printTime then stdout.write( "Time: ", time );
+
   if verify {
     if verifyResult(space, computationDomain, verbose=false, T ) then writeln( "SUCCESS" );
     else writeln( "FAILURE" );
   }
 
+  delete generator;
 }
 
 
-// return true if the current end state is the same as the 
+// return true if the current end state is the same as the
 // stencil applied to the original state, in serial iteration.
-proc verifyResult( space: [] Cell, computationalDomain: domain(2), 
+proc verifyResult( space: [] Cell, computationalDomain: domain(2),
                    verbose: bool = true, T: int ): bool {
 
   var computationTimeRange = 1..T;
@@ -103,7 +105,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
 
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
-     
+
   var generator = new RandomStream( globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
@@ -111,17 +113,17 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
 
   var read = 0;
   var write = 1;
-  
+
   for t in computationTimeRange {
      for (x,y) in computationalDomain do
-          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] + 
+          space[write, x, y] = (space[read, x, y-1] + space[read, x-1, y] +
                                 space[read, x, y+1] + space[read, x+1, y] +
                                 space[read, x, y] ) / 5;
-     read <=> write;   
-  }      
-  
+     read <=> write;
+  }
+
   var passed: bool = true;
-  
+
   for (x, y) in computationalDomain do
      if spaceEndState[x,y] != space[ T & 1, x, y]  {
         if verbose then
@@ -129,12 +131,14 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
         passed = false;
         break;
      }
-  
+
   if passed && verbose then
      writeln( "SUCCESS!" );
-  
+
+  delete generator;
+
   return passed;
-  
+
 }
 
 

--- a/test/studies/graph500/v2/main.chpl
+++ b/test/studies/graph500/v2/main.chpl
@@ -4,165 +4,164 @@
 module Graph500_main
 {
   proc main () {
+    use BlockDist;
+    use Time;
+    use Random;
 
-  use BlockDist;
-  use Time;
-  use Random;
+    use Graph500_defs;
+    use Scalable_Graph_Generator;
+    use Construct_Graph;
+    use Create_Parent_Tree;
+    use Verify;
 
-  use Graph500_defs;
-  use Scalable_Graph_Generator;
-  use Construct_Graph;
-  use Create_Parent_Tree;
-  use Verify;
-
-  const A: real = 0.57;
-  const B: real = 0.19;
-  const C: real = 0.19;
-  const D: real = 0.05;
+    const A: real = 0.57;
+    const B: real = 0.19;
+    const C: real = 0.19;
+    const D: real = 0.05;
 
 
-  // extern
-  proc output_results (scale: int, NV: int, edgefactor:int,
-                const A: real, const B: real, const C: real, const D: real,
-                generation_time: real, construction_time: real,
-                nbfs: int, 
-                inout BFS_time_array: real, inout BFS_nedges_traversed: int )
-  { writeln("DONE"); }
+    // extern
+    proc output_results (scale: int, NV: int, edgefactor:int,
+                         const A: real, const B: real, const C: real, const D: real,
+                         generation_time: real, construction_time: real,
+                         nbfs: int,
+                         inout BFS_time_array: real, inout BFS_nedges_traversed: int )
+      { writeln("DONE"); }
 
-        
-  writeln ( "Problem Dimensions");
-  writeln ( "              Scale: ", SCALE );
-  writeln ( " Number of Vertices: ", N_VERTICES );
-  writeln ( "        Edge factor: ", EDGEFACTOR );
 
- if ENABLE_PRINTOUTS then
-  coforall loc in Locales do
-    {
-    on loc do
-      writeln("Locale ID: ", loc.id, " of ", numLocales);
-      writeln("Locale ID: ", loc.id, " Number of cores " , loc.numPUs());
-      writeln("Locale ID: ", loc.id, " Max task parallelism " , loc.maxTaskPar);
+    writeln ( "Problem Dimensions");
+    writeln ( "              Scale: ", SCALE );
+    writeln ( " Number of Vertices: ", N_VERTICES );
+    writeln ( "        Edge factor: ", EDGEFACTOR );
+
+    if ENABLE_PRINTOUTS then
+      coforall loc in Locales do
+        {
+          on loc do
+            writeln("Locale ID: ", loc.id, " of ", numLocales);
+
+          writeln("Locale ID: ", loc.id, " Number of cores " , loc.numPUs());
+          writeln("Locale ID: ", loc.id, " Max task parallelism " , loc.maxTaskPar);
+        }
+
+
+    const edge_range =  1..N_RAWEDGES;
+
+    var Edges:[edgelist_domain] directed_vertex_pair;
+    var Histogram:[vertex_domain] vertex_id=0;
+
+    var generation_time: Timer;
+    var construction_time: Timer;
+    var BFS_time: [1..NUMROOTS] Timer;
+    var BFS_time_array: [1..NUMROOTS] real;
+    var BFS_nedges_traversed: [1..NUMROOTS] int;
+
+    generation_time.start();
+    Scalable_Data_Generator( SCALE, N_VERTICES, N_RAWEDGES, Edges);
+    generation_time.stop();
+
+    if ENABLE_PRINTOUTS then
+      writeln("Time for Scalable Data Generator = ", generation_time.elapsed());
+
+    // Generate a histogram from the Edges to guide the distribution of the graph
+    // We will need the updates to Hist to be atomic
+    for e in Edges do {
+      var u: vertex_id = e.start;
+      var v: vertex_id = e.end;
+      Histogram[u] += 1;
+      Histogram[v] += 1;
     }
 
-
-  const edge_range =  1..N_RAWEDGES;
-
-  var Edges:[edgelist_domain] directed_vertex_pair;
-  var Histogram:[vertex_domain] vertex_id=0;
-
-  var generation_time: Timer;
-  var construction_time: Timer;
-  var BFS_time: [1..NUMROOTS] Timer;
-  var BFS_time_array: [1..NUMROOTS] real;
-  var BFS_nedges_traversed: [1..NUMROOTS] int;
-
-  generation_time.start(); 
-  Scalable_Data_Generator( SCALE, N_VERTICES, N_RAWEDGES, Edges);
-  generation_time.stop();
-
- if ENABLE_PRINTOUTS then
-  writeln("Time for Scalable Data Generator = ", generation_time.elapsed()); 
-
-// Generate a histogram from the Edges to guide the distribution of the graph
-// We will need the updates to Hist to be atomic
-  for e in Edges do {
-     var u: vertex_id = e.start;
-     var v: vertex_id = e.end;
-     Histogram[u] += 1;
-     Histogram[v] += 1;
-  }
-
-  writeln("verify count: ", + reduce Histogram);
+    writeln("verify count: ", + reduce Histogram);
 
 
-// Check min/max Node ID's
+    // Check min/max Node ID's
+    var min_vertex_ID_start = min reduce Edges.start;
+    var min_vertex_ID_end = min reduce Edges.end;
+    var max_vertex_ID_start = max reduce Edges.start;
+    var max_vertex_ID_end = max reduce Edges.end;
 
-  var min_vertex_ID_start = min reduce Edges.start;
-  var min_vertex_ID_end = min reduce Edges.end;
-  var max_vertex_ID_start = max reduce Edges.start;
-  var max_vertex_ID_end = max reduce Edges.end;
+    var min_vertex_ID = min (min_vertex_ID_start, min_vertex_ID_end);
+    var max_vertex_ID = max (max_vertex_ID_start, max_vertex_ID_end);
 
-  var min_vertex_ID = min (min_vertex_ID_start, min_vertex_ID_end);
-  var max_vertex_ID = max (max_vertex_ID_start, max_vertex_ID_end);
+    if ENABLE_PRINTOUTS {
+      writeln ("Minimum vertex ID ", min_vertex_ID);
+      writeln ("Maximum vertex ID ", max_vertex_ID);
+    }
 
- if ENABLE_PRINTOUTS {
-  writeln ("Minimum vertex ID ", min_vertex_ID);
-  writeln ("Maximum vertex ID ", max_vertex_ID);
- }
+    construction_time.start();
 
-  construction_time.start();
+    // Optimally here we would use the histogram to define a domain distribution
+    // Here we are still using a fixed Block distribution
 
-// Optimally here we would use the histogram to define a domain distribution
-// Here we are still using a fixed Block distribution
- 
-  var G = new Graph (vertex_domain, Histogram);
+    var G = new Graph (vertex_domain, Histogram);
 
-  constructGraph (Edges, G);
+    constructGraph (Edges, G);
 
-  construction_time.stop();
- if ENABLE_PRINTOUTS then
-  writeln("Kernel 1, Graph Construction Time = ", construction_time.elapsed()); 
+    construction_time.stop();
 
-  // Generate a list of valid starting roots
-  // Valid starting roots have at least one edge to another node
-  var Rand_Gen = new RandomStream (seed = 9);
-  var Unif_Random: [1..NUM_CANDIDATES] real;
-  Rand_Gen.fillRandom ( Unif_Random );
-  var runID: int = 1;
-  var candidate: int = 1;
-  var root: vertex_id;
-
-  var ParentTree:[vertex_domain] vertex_id=-1;
-  var nedges_traversed: int;
-  var nTEPs: real;
-
-  while ( (runID <= NUMROOTS) && (candidate <= NUM_CANDIDATES )) do
-  {
-     root = floor (1+ Unif_Random[candidate]* N_VERTICES): vertex_id;
     if ENABLE_PRINTOUTS then
-     writeln("Candidate root = ", root);
+      writeln("Kernel 1, Graph Construction Time = ", construction_time.elapsed());
 
-     // Verify that root is a valid candidate, ie has at least one edge
-     if ( G.Vertices[root].neighbor_count > 0 ){
+    // Generate a list of valid starting roots
+    // Valid starting roots have at least one edge to another node
+    var Rand_Gen = new RandomStream (seed = 9);
+    var Unif_Random: [1..NUM_CANDIDATES] real;
+    Rand_Gen.fillRandom ( Unif_Random );
+    var runID: int = 1;
+    var candidate: int = 1;
+    var root: vertex_id;
 
-       BFS_time[runID].start(); 
-       BFS ( root, ParentTree, G);
-       BFS_time[runID].stop(); 
+    var ParentTree:[vertex_domain] vertex_id=-1;
+    var nedges_traversed: int;
+    var nTEPs: real;
 
-       BFS_time_array[runID] = BFS_time[runID].elapsed();
-       BFS_nedges_traversed[runID] = verify_bfs_tree ( root, ParentTree, Edges);
+    while ( (runID <= NUMROOTS) && (candidate <= NUM_CANDIDATES )) do
+    {
+      root = floor (1+ Unif_Random[candidate]* N_VERTICES): vertex_id;
 
-       nTEPs = BFS_nedges_traversed[runID] / BFS_time[runID].elapsed();
+      if ENABLE_PRINTOUTS then
+        writeln("Candidate root = ", root);
 
-      if ENABLE_PRINTOUTS {
-       writeln("Root =  ", root );
-       writeln("  Number of traversed edges = ", BFS_nedges_traversed[runID]);
-       writeln("Time for BFS = ", BFS_time[runID].elapsed()); 
-       writeln("TEPS = ", nTEPs);
+      // Verify that root is a valid candidate, ie has at least one edge
+      if ( G.Vertices[root].neighbor_count > 0 ) {
+        BFS_time[runID].start();
+        BFS ( root, ParentTree, G);
+        BFS_time[runID].stop();
+
+        BFS_time_array[runID] = BFS_time[runID].elapsed();
+        BFS_nedges_traversed[runID] = verify_bfs_tree ( root, ParentTree, Edges);
+
+        nTEPs = BFS_nedges_traversed[runID] / BFS_time[runID].elapsed();
+
+        if ENABLE_PRINTOUTS {
+          writeln("Root =  ", root );
+          writeln("  Number of traversed edges = ", BFS_nedges_traversed[runID]);
+          writeln("Time for BFS = ", BFS_time[runID].elapsed());
+          writeln("TEPS = ", nTEPs);
+        }
+
+        runID += 1; candidate += 1;
+        ParentTree = -1;
       }
-
-       runID += 1; candidate += 1;
-       ParentTree = -1;
-       
-     }
-     else
-     {
+      else
+      {
         if ENABLE_PRINTOUTS then
-         writeln("Root not a valid candidate");
-        candidate += 1;
-     }
+          writeln("Root not a valid candidate");
 
+        candidate += 1;
+      }
+    }
+
+    output_results (SCALE, N_VERTICES, EDGEFACTOR, A, B, C, D,
+                    generation_time.elapsed(), construction_time.elapsed(), NUMROOTS,
+                    BFS_time_array(1), BFS_nedges_traversed(1) );
+
+    delete Rand_Gen;
   }
 
-      output_results (SCALE, N_VERTICES, EDGEFACTOR, A, B, C, D,
-           generation_time.elapsed(), construction_time.elapsed(), NUMROOTS,
-           BFS_time_array(1), BFS_nedges_traversed(1) );
-
-}
-
-// make it possible to call the above code from other files
-proc Graph500main() {
-  main();
-}
-
+  // make it possible to call the above code from other files
+  proc Graph500main() {
+    main();
+  }
 }

--- a/test/studies/graph500/v2/scalableDataGenerator.chpl
+++ b/test/studies/graph500/v2/scalableDataGenerator.chpl
@@ -5,16 +5,16 @@ module Scalable_Graph_Generator
 {
    use Graph500_defs;
 
-// A Chapel implementation of the Scalable Graph Generator 
+// A Chapel implementation of the Scalable Graph Generator
 // for the Graph500 Benchmark
 
-// The scalable data generator constructs a list of edge tuples containing 
-// vertex identifiers. Each edge is undirected with its endpoints given in 
-// the tuple as StartVertex and EndVertex. 
+// The scalable data generator constructs a list of edge tuples containing
+// vertex identifiers. Each edge is undirected with its endpoints given in
+// the tuple as StartVertex and EndVertex.
 
-// I am currently leveraging some of the code from the Chapel implementation 
-// of the RMAT Graph generator developed by John Lewis for SSCA2 but 
-// eventually will try to more closely follow the XMT implementation of the 
+// I am currently leveraging some of the code from the Chapel implementation
+// of the RMAT Graph generator developed by John Lewis for SSCA2 but
+// eventually will try to more closely follow the XMT implementation of the
 // ScalableGraphGenerator.c used for the 2010 Graph500 submission
 
 // Here I will use a similar data structure as the SSCA2 code and have Edges
@@ -35,57 +35,55 @@ module Scalable_Graph_Generator
 
   proc assign_quadrant ( u: real, a: real, b: real, c: real, d : real,
                         bit : int ) : directed_vertex_pair
-    {
-      var start_inc = 0;
-      var end_inc   = 0;
-      var edge : directed_vertex_pair;
+  {
+    var start_inc = 0;
+    var end_inc   = 0;
+    var edge : directed_vertex_pair;
 
-      if u <= a then
-        {}
-      else if u <= a + b then
-        { end_inc = 1;}
-      else if u <= a + b + c then
-        { start_inc = 1;}
-      else
-        { start_inc = 1; end_inc = 1;};
+    if u <= a then
+      {}
+    else if u <= a + b then
+      { end_inc = 1;}
+    else if u <= a + b + c then
+      { start_inc = 1;}
+    else
+      { start_inc = 1; end_inc = 1;};
 
-      edge.start = bit * start_inc;
-      edge.end   = bit * end_inc;
-      return ( edge );
-    }
+    edge.start = bit * start_inc;
+    edge.end   = bit * end_inc;
+    return ( edge );
+  }
 
 
   // ====================================
   // Main RMAT Graph Generation Procedure
   // ====================================~
 
-// Note that we include the inquiry of the domain type for edges so we can use 
+// Note that we include the inquiry of the domain type for edges so we can use
 // this to allocate additional arrays using the same distribution
 
   proc Scalable_Data_Generator ( scale :int, n_vertices : int,
                                 n_raw_edges : int, Edges:[?ArrD] )
 
-    {
-      use BlockDist;
-      use Graph500_defs;
-      use Random;
-      use Time;
+  {
+    use BlockDist;
+    use Graph500_defs;
+    use Random;
+    use Time;
 
-      // Random Numbers return in the range [0.0, 1.0)
+    // Random Numbers return in the range [0.0, 1.0)
+    var Rand_Gen = if REPRODUCIBLE_PROBLEMS then
+                      new RandomStream (seed = 0556707007)
+                   else
+                      new RandomStream ();
 
-      var Rand_Gen = if REPRODUCIBLE_PROBLEMS then
-                       new RandomStream (seed = 0556707007)
-                     else
-                       new RandomStream ();
-
-
-      const vertex_range = 1..n_vertices;
+    const vertex_range = 1..n_vertices;
 
 // Graph500 settings for RMAT parameters
-        const a: real = 0.57;
-        const b: real = 0.19;
-        const c: real = 0.19;
-        const d: real = 0.05;
+    const a: real = 0.57;
+    const b: real = 0.19;
+    const c: real = 0.19;
+    const d: real = 0.05;
 
 // SSCA2 settings for RMAT parameters
 //        const a: real = 0.55;
@@ -93,198 +91,201 @@ module Scalable_Graph_Generator
 //        const c: real = 0.10;
 //        const d: real = 0.25;
 
-        const N_SHUFFLE = scale*n_vertices;
-        const Half_N_SHUFFLE = scale*n_vertices/2;
+    const N_SHUFFLE = scale*n_vertices;
+    const Half_N_SHUFFLE = scale*n_vertices/2;
 
-//      const ab: real = a+b; 
+//      const ab: real = a+b;
 //            abc: real = a+b+c;
 
-      var   Noisy_a     : [ArrD] real,
-            Noisy_b     : [ArrD] real,
-            Noisy_c     : [ArrD] real,
-            Noisy_d     : [ArrD] real,
-            norm        : [ArrD] real;
+    var   Noisy_a     : [ArrD] real,
+          Noisy_b     : [ArrD] real,
+          Noisy_c     : [ArrD] real,
+          Noisy_d     : [ArrD] real,
+          norm        : [ArrD] real;
 
 
-      var   Unif_Random  : [ArrD] real;
-      var   Unif_Random2 : [ArrD] real;
+    var   Unif_Random  : [ArrD] real;
+    var   Unif_Random2 : [ArrD] real;
 
-      var   Edge_lock$   : [ArrD] sync bool = true;
+    var   Edge_lock$   : [ArrD] sync bool = true;
 
-      var   graph_gen_time: Timer;
+    var   graph_gen_time: Timer;
 
 
 // Initialize records in Edges
 
-   Edges.start = 1;
-   Edges.end = 1;
+    Edges.start = 1;
+    Edges.end = 1;
 
 
 // Step 0: Construct permutation array
-      graph_gen_time.clear();
-      graph_gen_time.start();
+    graph_gen_time.clear();
+    graph_gen_time.start();
 
       var permutation$ : [vertex_range] sync int = vertex_range;
 // Note: need to be very careful with sync variables as a writeln
 // invokes a read, which then sets to empty
 
-   for i in 1..scale do {
+    for i in 1..scale do {
       var   skip : real;
       Rand_Gen.fillRandom ( Unif_Random );
       skip = Rand_Gen.getNext ();
       Rand_Gen.fillRandom ( Unif_Random2 );
 
-   forall j in ArrD do
-     { 
+      forall j in ArrD do
+      {
 
 //     Choose two locations at random
-       var ndx1 = floor (1 + Unif_Random (j) * n_vertices) : int;
-       var ndx2 = floor (1 + Unif_Random2(j) * n_vertices) : int;
+        var ndx1 = floor (1 + Unif_Random (j) * n_vertices) : int;
+        var ndx2 = floor (1 + Unif_Random2(j) * n_vertices) : int;
 
 //     If the locations are not the same, then swap
-       if (ndx1 != ndx2){
+        if (ndx1 != ndx2){
 
 //       If the first location is greater than the second, swap. Insures
 //       that the locations are locked in order, preventing deadlock
-         if (ndx1 > ndx2) {ndx1 <=> ndx2;};
+          if (ndx1 > ndx2) {ndx1 <=> ndx2;};
 
 //       Lock locations in permutation array
 
-         var label1 = permutation$ (ndx1).readFE () : int;
-         var label2 = permutation$ (ndx2).readFE () : int;
+          var label1 = permutation$ (ndx1).readFE () : int;
+          var label2 = permutation$ (ndx2).readFE () : int;
 
 //       Swap labels
 
-         permutation$ (ndx1).writeEF (label2);
-         permutation$ (ndx2).writeEF (label1);
-       };
+          permutation$ (ndx1).writeEF (label2);
+          permutation$ (ndx2).writeEF (label1);
+        }
+      }
+    }
 
-     }; 
-     }; 
-      graph_gen_time.stop();
-     if ENABLE_PRINTOUTS then
+    graph_gen_time.stop();
+
+    if ENABLE_PRINTOUTS then
       writeln("Time for SDG: Construct Perm Array  = ", graph_gen_time.elapsed());
 
 // Step 1: Construct edges
-      graph_gen_time.clear();
-      graph_gen_time.start();
+    graph_gen_time.clear();
+    graph_gen_time.start();
 
-// Approach A: Leverage Lewis code using assign_quadrant, but this looks 
+// Approach A: Leverage Lewis code using assign_quadrant, but this looks
 //             to have multiple trips through the full list of edges
 
-  if RMAT_WITH_NOISE then {
+    if RMAT_WITH_NOISE then {
       var bit = 1 << scale;
 
       for depth in 1..scale do {
-          bit >>= 1;
-          var   skip : real;
+        bit >>= 1;
+        var   skip : real;
 
-          // randomize the coefficients, tweaking them by numbers in [-.05, .05)
+        // randomize the coefficients, tweaking them by numbers in [-.05, .05)
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_a = a * (0.95 + 0.1 * Unif_Random);
 
-          skip = Rand_Gen.getNext ();
-          Rand_Gen.fillRandom (Unif_Random);
-          Noisy_a = a * (0.95 + 0.1 * Unif_Random);
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_b = b * (0.95 + 0.1 * Unif_Random);
 
-          skip = Rand_Gen.getNext ();
-          Rand_Gen.fillRandom (Unif_Random);
-          Noisy_b = b * (0.95 + 0.1 * Unif_Random);
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_c = c * (0.95 + 0.1 * Unif_Random);
 
-          skip = Rand_Gen.getNext ();
-          Rand_Gen.fillRandom (Unif_Random);
-          Noisy_c = c * (0.95 + 0.1 * Unif_Random);
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_d = d * (0.95 + 0.1 * Unif_Random);
 
-          skip = Rand_Gen.getNext ();
-          Rand_Gen.fillRandom (Unif_Random);
-          Noisy_d = d * (0.95 + 0.1 * Unif_Random);
+        norm     = 1.0 / (Noisy_a + Noisy_b + Noisy_c + Noisy_d);
 
-          norm     = 1.0 / (Noisy_a + Noisy_b + Noisy_c + Noisy_d);
+        Noisy_a *= norm;
+        Noisy_b *= norm;
+        Noisy_c *= norm;
+        Noisy_d *= norm;
 
-          Noisy_a *= norm;
-          Noisy_b *= norm;
-          Noisy_c *= norm;
-          Noisy_d *= norm;
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
 
-          skip = Rand_Gen.getNext ();
-          Rand_Gen.fillRandom (Unif_Random);
-
-
-          Edges += assign_quadrant ( Unif_Random, Noisy_a, Noisy_b,
-                                     Noisy_c, Noisy_d, bit );
-
-        };
-   }
-   else
-   {
+        Edges += assign_quadrant ( Unif_Random, Noisy_a, Noisy_b,
+                                   Noisy_c, Noisy_d, bit );
+      }
+    }
+    else
+    {
 
 //    Use faster code with does not include noise
 
       var bit = 1 << scale;
 
       for depth in 1..scale do {
-          bit >>= 1;
-          var   skip : real;
+        bit >>= 1;
+        var   skip : real;
 
-          skip = Rand_Gen.getNext ();
-          Rand_Gen.fillRandom (Unif_Random);
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
 
-          forall e in ArrD do {
+        forall e in ArrD do {
+          var start_inc = 0;
+          var end_inc   = 0;
+          var u         = Unif_Random[e];
 
-            var start_inc = 0;
-            var end_inc   = 0;
-            var u = Unif_Random[e];
+          if u <= a then {
 
-            if u <= a then
-              {}
-            else if u <= a + b then
-              { end_inc = 1;}
-            else if u <= a + b + c then
-              { start_inc = 1;}
-            else
-              { start_inc = 1; end_inc = 1;};
+          } else if u <= a + b then {
+            end_inc = 1;
 
-            Edges(e).start += bit * start_inc;
-            Edges(e).end   += bit * end_inc;
+          } else if u <= a + b + c then {
+            start_inc = 1;
+
+          } else {
+            start_inc = 1; end_inc = 1;
           }
-     }
 
-   }
-      graph_gen_time.stop();
-     if ENABLE_PRINTOUTS then
+          Edges(e).start += bit * start_inc;
+          Edges(e).end   += bit * end_inc;
+        }
+      }
+    }
+
+    graph_gen_time.stop();
+
+    if ENABLE_PRINTOUTS then
       writeln("Time for SDG: Construct Edges  = ", graph_gen_time.elapsed());
 
 // Permute labels
-   graph_gen_time.clear();
-   graph_gen_time.start();
+    graph_gen_time.clear();
+    graph_gen_time.start();
 
-   forall e in ArrD do {
+    forall e in ArrD do {
       Edges(e).start = permutation$ (Edges(e).start).readFF();
       Edges(e).end   = permutation$ (Edges(e).end  ).readFF();
-   };
+    }
+
    graph_gen_time.stop();
-  if ENABLE_PRINTOUTS then
-   writeln("Time for SDG: Permute labels  = ", graph_gen_time.elapsed());
+
+   if ENABLE_PRINTOUTS then
+     writeln("Time for SDG: Permute labels  = ", graph_gen_time.elapsed());
 
 // Step 2: Shuffle edges
    if RMAT_WITH_SHUFFLE then {
-   graph_gen_time.clear();
-   graph_gen_time.start();
+     graph_gen_time.clear();
+     graph_gen_time.start();
 
 //   Sample specification only applies edgefactor*N swaps
 //   for i in 1..scale do {
-      var   skip : real;
-      Rand_Gen.fillRandom ( Unif_Random );
-      skip = Rand_Gen.getNext ();
-      Rand_Gen.fillRandom ( Unif_Random2 );
+     var   skip : real;
+     Rand_Gen.fillRandom ( Unif_Random );
+     skip = Rand_Gen.getNext ();
+     Rand_Gen.fillRandom ( Unif_Random2 );
 
      forall j in ArrD do
-     { 
+     {
 
 //     Choose two locations at random
        var ndx1 = floor (1 + Unif_Random (j) * n_vertices) : int;
        var ndx2 = floor (1 + Unif_Random2 (j) * n_vertices) : int;
 
 //     If the locations are not the same, then swap
-       if (ndx1 != ndx2){
+       if (ndx1 != ndx2) {
 
 //       If the first location is greater than the second, swap. Insures
 //       that the locations are locked in order, preventing deadlock
@@ -294,6 +295,7 @@ module Scalable_Graph_Generator
 
          Edge_lock$ (ndx1).readFE();
          Edge_lock$ (ndx2).readFE();
+
          var label1 = Edges (ndx1).start : int;
          var label2 = Edges (ndx1).end : int;
          var label3 = Edges (ndx2).start : int;
@@ -307,16 +309,18 @@ module Scalable_Graph_Generator
          Edges (ndx2).end = label2;
          Edge_lock$ (ndx1).writeEF(true);
          Edge_lock$ (ndx2).writeEF(true);
-       };
+       }
 //     };
-     };
+     }
 
      graph_gen_time.stop();
 
-    if ENABLE_PRINTOUTS then
-     writeln("Time for SDG: Shuffle Edges  = ", graph_gen_time.elapsed());
-     }
+     if ENABLE_PRINTOUTS then
+       writeln("Time for SDG: Shuffle Edges  = ", graph_gen_time.elapsed());
+   }
 
 //   writeln("Upon exit, Edges is:\n", Edges, "\n");
-}
+   delete Rand_Gen;
+
+  }
 }

--- a/test/users/jglewis/cholesky_version_1/test_cholesky.chpl
+++ b/test/users/jglewis/cholesky_version_1/test_cholesky.chpl
@@ -79,8 +79,8 @@ module cholesky_test {
 
   use cholesky_execution_config_consts;
 
-  use cholesky_scalar_algorithms, 
-      block_outer_product_cholesky, 
+  use cholesky_scalar_algorithms,
+      block_outer_product_cholesky,
       block_2D_outer_product_cholesky,
       block_inner_product_cholesky,
       block_2D_inner_product_cholesky,
@@ -113,14 +113,14 @@ module cholesky_test {
 
     // -------------------------------------------------------------
     // create a positive definite matrix A by setting A equal to the
-    // matrix-matrix product B B^T.  This normal equations matrix is 
+    // matrix-matrix product B B^T.  This normal equations matrix is
     // positive-definite as long as B is full rank.
     // -------------------------------------------------------------
 
     A = 0.0;
 
     forall (i,j) in mat_dom do
-      A (i,j) = + reduce (  [k in mat_dom.dim (1) ] 
+      A (i,j) = + reduce (  [k in mat_dom.dim (1) ]
     			    B (i, k) * B (j, k) );
 
     // factorization algorithms overwrite a copy of A, leaving
@@ -139,10 +139,10 @@ module cholesky_test {
     else
       writeln ("factorization failed for non-positive semi-definite matrix");
 
- 
+
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 1D outer product cholesky factorization, block size: ",
 	      block_size );
 
@@ -156,7 +156,7 @@ module cholesky_test {
 
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 2D outer product cholesky factorization, block size: ",
 	      block_size );
 
@@ -183,10 +183,10 @@ module cholesky_test {
       writeln ("factorization failed for non-positive semi-definite matrix");
 
 
-     
+
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 1D inner product cholesky factorization, block size: ",
 	      block_size );
 
@@ -202,7 +202,7 @@ module cholesky_test {
 
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 2D inner product cholesky factorization, block size: ",
 	      block_size );
 
@@ -230,7 +230,7 @@ module cholesky_test {
 
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 1D bordering cholesky factorization, block size: ",
 	      block_size );
 
@@ -246,7 +246,7 @@ module cholesky_test {
 
     L = A;
 
-    writeln (); 
+    writeln ();
     writeln ("block 2D bordering cholesky factorization, block size: ",
 	      block_size );
 
@@ -258,6 +258,8 @@ module cholesky_test {
       check_factorization ( A, L );
     else
       writeln ("factorization failed for non-positive semi-definite matrix");
+
+    delete Rand;
   }
 
   proc check_factorization ( A : [], L : [] )
@@ -273,9 +275,9 @@ module cholesky_test {
 
     assert ( A.domain.dim (1) == A.domain.dim (2)  &&
 	     L.domain.dim (1) == A.domain.dim (1)  &&
-	     L.domain.dim (2) == A.domain.dim (2) 
+	     L.domain.dim (2) == A.domain.dim (2)
 	     );
-    
+
     const mat_dom  = A.domain,
 	  mat_rows = A.domain.dim(1),
 	  n        = A.domain.dim(1).length;
@@ -289,10 +291,10 @@ module cholesky_test {
 
     for i in mat_rows do
       d (i) = sqrt ( A (i,i) );
-    
+
     forall (i,j) in mat_dom with (ref max_ratio) do { // race
       const resid: real =
-               abs (A (i,j) - 
+               abs (A (i,j) -
 		    + reduce ( [k in mat_dom.dim(1) (..min (i,j))]
 			       L (i,k) * L (j,k) ) ) ;
       max_ratio = max ( max_ratio,
@@ -308,7 +310,7 @@ module cholesky_test {
 
 
   proc print_L ( L : [] ) {
-   
+
     const rows = L.domain.dim (1);
 
     //    for i in rows do
@@ -316,4 +318,4 @@ module cholesky_test {
   }
 
 }
-    
+


### PR DESCRIPTION
I overlooked the opportunity to make trivial changes to delete allocations of instances of
RandomStream.  Rectify this.

Correctness confirmed on darwin/clang and linux64/gcc.
Leak status confirmed on darwin/clang.

No review
