### PR TITLE
Dial back the amount of oversubscription we do for cygwin testing

### DIFF
--- a/util/cron/test-cygwin32.bat
+++ b/util/cron/test-cygwin32.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/cygdrive/c/Program Files/emacs-24.4/bin' ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print(multiprocessing.cpu_count())-1'` ; for i in $(seq 1 $num_procs); do echo 'localhost'; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
+c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/cygdrive/c/Program Files/emacs-24.4/bin' ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print(multiprocessing.cpu_count())/2'` ; for i in $(seq 1 $num_procs); do echo 'localhost'; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
 GOTO End
 
 :ErrExit

--- a/util/cron/test-cygwin64.bat
+++ b/util/cron/test-cygwin64.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows:/cygdrive/c/windows/System32/Wbem:/cygdrive/c/windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/usr/bin:/cygdrive/c/emacs-24.3/bin' ; export CHPL_HOME=$PWD ;num_procs=`python -c 'import multiprocessing; print(multiprocessing.cpu_count())-1'` ; for i in $(seq 1 $num_procs); do echo 'localhost'; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
+c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows:/cygdrive/c/windows/System32/Wbem:/cygdrive/c/windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/usr/bin:/cygdrive/c/emacs-24.3/bin' ; export CHPL_HOME=$PWD ;num_procs=`python -c 'import multiprocessing; print(multiprocessing.cpu_count())/2'` ; for i in $(seq 1 $num_procs); do echo 'localhost'; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
 GOTO End
 
 :ErrExit


### PR DESCRIPTION
We use paratest for cygwin testing since it was taking ~24 hours. Previously we
were using `numCores-1` (7) instances, but we've seen some sporadic timeouts so
I'm dropping back to `numCores/2` (4) instances. I think testing should finish
in under 8 hours now (was 4 hours with 7 instances.)

See JIRA 202 for more info: https://chapel.atlassian.net/browse/CHAPEL-202