### PR TITLE
Revise release/examples/user-guide/taskpar/walkTreeUsingBegins.chpl

### DIFF
--- a/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl
+++ b/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl
@@ -27,7 +27,6 @@ const tree = new Node(5,
 
 begin {
   walkTree(tree);
-  delete tree;
 }
 
 proc walkTree(node) {


### PR DESCRIPTION
Revert this program back to its original, leaking, state. There is not a good place
to insert a delete without significant changes.

