### PR TITLE
Increase proc/mount path name length from 512 -> 2048

### DIFF
--- a/third-party/hwloc/README
+++ b/third-party/hwloc/README
@@ -10,3 +10,9 @@ uses a snapshot of obtained from Open MPI at:
 Any Chapel issues that seem to be related to hwloc should be directed
 to the Chapel team at chapel-bugs@lists.sourceforge.net.
 
+
+The modifications that we have made to the official hwloc 1.10.1
+release are as follows:
+
+* Increased PROC_MOUNT_LINE_LEN from 512 to 2048 to support CLE6 OS, in which
+  /proc/mount/* path name typically exceeds 512 characters.

--- a/third-party/hwloc/hwloc-1.10.1/src/topology-linux.c
+++ b/third-party/hwloc/hwloc-1.10.1/src/topology-linux.c
@@ -1674,6 +1674,7 @@ hwloc_strdup_mntpath(const char *escapedpath, size_t length)
 static void
 hwloc_find_linux_cpuset_mntpnt(char **cgroup_mntpnt, char **cpuset_mntpnt, int fsroot_fd)
 {
+// ideally, length should not be hard-coded. this is considered a hack.
 #define PROC_MOUNT_LINE_LEN 2048
   char line[PROC_MOUNT_LINE_LEN];
   FILE *fd;

--- a/third-party/hwloc/hwloc-1.10.1/src/topology-linux.c
+++ b/third-party/hwloc/hwloc-1.10.1/src/topology-linux.c
@@ -1674,7 +1674,7 @@ hwloc_strdup_mntpath(const char *escapedpath, size_t length)
 static void
 hwloc_find_linux_cpuset_mntpnt(char **cgroup_mntpnt, char **cpuset_mntpnt, int fsroot_fd)
 {
-#define PROC_MOUNT_LINE_LEN 512
+#define PROC_MOUNT_LINE_LEN 2048
   char line[PROC_MOUNT_LINE_LEN];
   FILE *fd;
 


### PR DESCRIPTION
For some cases (observed on CLE6), `proc/mount/*` path names were exceeding 512 characters, resulting in segfaults. This patch resolves this bug in hwloc, enabling Chapel 1.12 support for CLE6.

Note: this is a hack.