### PR TITLE
Completely revert walkTreeUsingBegins.chpl

### DIFF
--- a/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl
+++ b/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl
@@ -2,11 +2,6 @@ class Node {
   var data: int;
   var left, right: Node;
 
-  proc ~Node() {
-    if left  then delete left;
-    if right then delete right;
-  }
-
   proc processNode() {
     writeln(data);
   }
@@ -19,22 +14,18 @@ const tree = new Node(5,
                    new Node(3, nil, nil),
                    nil)),
                new Node(8,
-                 new Node(6,
-                   nil,
+                 new Node(6, 
+                   nil, 
                    new Node(7, nil, nil)),
                    new Node(9, nil, nil)));
 
-
-begin {
-  walkTree(tree);
-}
+                      
+begin walkTree(tree);                      
 
 proc walkTree(node) {
   node.processNode();
-
   if node.left != nil then
     begin walkTree(node.left);
-
   if node.right != nil then
     begin walkTree(node.right);
 }


### PR DESCRIPTION
While working on "trivial" memory leaks I made the mistake of trying to fix the slightly subtle
leak in 

release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl

Not only did I fail to resolve this leak but I broke the online user-guide due to shifting text
around.

This trivial commit completely restores this file to the version before I munged things.
