### PR TITLE
Add a .bad for a future on constructors for types with sync variables

### DIFF
--- a/test/classes/hannah/coercingIntToSyncIntOnConstructor.bad
+++ b/test/classes/hannah/coercingIntToSyncIntOnConstructor.bad
@@ -1,0 +1,3 @@
+coercingIntToSyncIntOnConstructor.chpl:6: In function 'main':
+coercingIntToSyncIntOnConstructor.chpl:7: error: unresolved call 'Foo(1)'
+coercingIntToSyncIntOnConstructor.chpl:1: note: candidates are: Foo(x$: _syncvar(int(64)))


### PR DESCRIPTION
Output seems stable, adding a .bad file.