### PR TITLE
Fix CHIP sorting in README output

### DIFF
--- a/util/devel/chips/update-readme.bash
+++ b/util/devel/chips/update-readme.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cat README.md.in > README.md
-for name in [0-9]*.rst
+for name in `ls -v [0-9]*.rst`
 do
   echo $name
   title=`head -n 1 $name`


### PR DESCRIPTION
Before this change, chip 10 would be sorted before chip 1 instead of after chip
9.  With this change, it sorts in the proper order.