### PR TITLE
 Fix incorrect .bad and .good files

### DIFF
--- a/test/users/rohanbadlani/bugs/bug1.bad
+++ b/test/users/rohanbadlani/bugs/bug1.bad
@@ -1,1 +1,1 @@
-bug2.chpl:9: syntax error
+bug1.chpl:9: syntax error

--- a/test/users/rohanbadlani/bugs/bug1.good
+++ b/test/users/rohanbadlani/bugs/bug1.good
@@ -1,1 +1,1 @@
-bug2.chpl:1: syntax error: no matching parenthesis found for '{'
+bug1.chpl:1: syntax error: no matching parenthesis found for '{'

--- a/test/users/rohanbadlani/bugs/bug2.bad
+++ b/test/users/rohanbadlani/bugs/bug2.bad
@@ -1,1 +1,1 @@
-bug8.chpl:8: error: unresolved access of 'list(int(64))' by '(2)'
+bug2.chpl:8: error: unresolved access of 'list(int(64))' by '(2)'

--- a/test/users/rohanbadlani/bugs/bug3.bad
+++ b/test/users/rohanbadlani/bugs/bug3.bad
@@ -1,4 +1,4 @@
-bug9.chpl:15: internal error: FUN3849 chpl Version 1.12.0.df10fc5
+bug3.chpl:16: internal error: FUN3849 chpl Version 1.12.0.df10fc5
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/users/rohanbadlani/bugs/bug3.good
+++ b/test/users/rohanbadlani/bugs/bug3.good
@@ -1,1 +1,1 @@
-bug9.chpl:15: Accessing elements of list 'mylist' is not allowed using these iterator
+bug3.chpl:16: Accessing elements of list 'mylist' is not allowed using these iterator


### PR DESCRIPTION
Fix some incorrect file names and line numbers. Likely missed during review due to shuffling/refactoring of tests.