### PR TITLE
Fix module-level tuple leak

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1015,26 +1015,42 @@ static void fix_def_expr(VarSymbol* var) {
 
   INT_ASSERT(fn);
 
-  if (// Not explicily marked "no auto destroy"
-      !var->hasFlag(FLAG_NO_AUTO_DESTROY) &&
+  if (!var->hasFlag(FLAG_NO_AUTO_DESTROY) &&
+      !var->hasFlag(FLAG_PARAM)           && // Note 1.
+      !var->hasFlag(FLAG_REF_VAR)         &&
+      fn->_this != var                    && // Note 2.
+      !fn->hasFlag(FLAG_INIT_COPY_FN)     && // Note 3.
+      !fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
 
-      // Not a param variable.  (Note 1)
-      !var->hasFlag(FLAG_PARAM) &&
+    // Variables in a module initializer need special attention
+    if (var->defPoint->parentExpr == fn->getModule()->initFn->body) {
 
-      // The variables initialized in a module initializer are global,
-      // and therefore should not be autodestroyed.
-      // There is a special global destructor function for that.
-      var->defPoint->parentExpr != fn->getModule()->initFn->body &&
+      // MDN 2016/04/27
+      //
+      // Most variables in a module init function will become
+      // global and should not be auto destroyed.  The challenging
+      // case is injected by
+      //
+      // var (a1, a2) = fnReturnTuple();
+      //
+      // The parser expands this as
+      //
+      // var tmp = fnReturnTuple();
+      // var a1  = tmp.x1;
+      // var a2  = tmp.x2;
+      //
+      // This pseudo-tuple must be auto-destroyed to ensure the components
+      // are managed correctly. However the AST doesn't provide us with a
+      // strong/easy way to determine that we're dealing with this case.
+      // In practice is appears to be sufficient to flag any TMP
+      if (var->hasFlag(FLAG_TEMP)) {
+        var->addFlag(FLAG_INSERT_AUTO_DESTROY);
+      }
 
-      !fn->hasFlag(FLAG_INIT_COPY_FN) && // Note 3.
-
-      fn->_this != var                && // Note 2.
-
-      !fn->hasFlag(FLAG_TYPE_CONSTRUCTOR) &&
-
-      // don't add auto-destroy on reference variables
-      !var->hasFlag(FLAG_REF_VAR))
-    var->addFlag(FLAG_INSERT_AUTO_DESTROY);
+    } else {
+      var->addFlag(FLAG_INSERT_AUTO_DESTROY);
+    }
+  }
 
   //
   // handle "no copy" variables


### PR DESCRIPTION
Statements of the form

var (a1, a2, ...) = fn_returns_tuple();

may  leak the variables a1, a2, .. if this declaration appears at module level. 

a) Currently we actually create a temp tuple for this statement

b) In most contexts normalize adds a FLAG_INSERT_AUTO_DESTROY to the tuple to compensate
for the init copies that are sprinkled around.  This was being disabled for all variables in a module init function as if all initFn variables would be promoted to module level.  In practice tmp vars are not
promoted.

There are several approaches to handling this better in the long term.  In the short term I ensure
that temp variables in initFn are destroyed.  Did this is a somewhat verbose way to clarify what
is going on.


Tested for correctness and impact on a subset of tests in darwin/clang.
Tested for correctness and impact on full suite on linux64/gnu

Per BenH: Tested test/release for correctness with gasnet on linux64/gnu

This will knock off about 90 leaks.

