### PR TITLE
Added archive for languages specifications

### DIFF
--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -31,6 +31,7 @@ Chapel Documentation
    :maxdepth: 1
 
    Chapel Evolution <language/evolution>
+   Archived Language Specifications <language/archivedSpecs>
 
 Index
 -----

--- a/doc/sphinx/source/language/archivedSpecs.rst
+++ b/doc/sphinx/source/language/archivedSpecs.rst
@@ -3,27 +3,32 @@
 Archived Language Specifications
 ================================
 
-This page contains language specifications prior to `Chapel 1.13.0 - Spec 0.981`_.
+This page contains language specifications prior to `Spec 0.981 - Chapel 1.13.0`_.
+
+Each spec version is appended with the associated Chapel release version.
+Spec versions associated with a Chapel release that is no longer available for
+public download do not list the Chapel release version.
+
 
 .. note::
     To access language specifications for 1.13.0 and beyond, visit the
     documentation page at the url ``chapel.cray.docs/<X>.<YY>/language/spec.html``,
     where ``<X>`` and ``<YY>`` are the major and minor versions, respectively.
 
-* `Chapel 1.12.0 - Spec 0.98`_
-* `Chapel 1.11.0 - Spec 0.97`_
-* `Chapel 1.10.0 - Spec 0.96`_
-* `Chapel 1.9.0  - Spec 0.95`_
-* `Chapel 1.8.0  - Spec 0.94`_
-* `Chapel 1.7.0  - Spec 0.93`_
-* `Chapel 1.6.0  - Spec 0.92`_
-* `Chapel 1.5.0  - Spec 0.91`_
-* `Chapel 1.4.0  - Spec 0.82`_
-* `Chapel 1.3.0  - Spec 0.8`_
-* `Chapel 1.2.0  - Spec 0.796`_
-* `Chapel 1.1.0  - Spec 0.795`_
-* `Chapel 1.0.0  - Spec 0.785`_
-* `Chapel 0.9.0  - Spec 0.782`_
+* `Spec 0.98  - Chapel 1.12.0`_
+* `Spec 0.97  - Chapel 1.11.0`_
+* `Spec 0.96  - Chapel 1.10.0`_
+* `Spec 0.95  - Chapel 1.9.0`_
+* `Spec 0.94  - Chapel 1.8.0`_
+* `Spec 0.93  - Chapel 1.7.0`_
+* `Spec 0.92  - Chapel 1.6.0`_
+* `Spec 0.91  - Chapel 1.5.0`_
+* `Spec 0.82  - Chapel 1.4.0`_
+* `Spec 0.8   - Chapel 1.3.0`_
+* `Spec 0.796 - Chapel 1.2.0`_
+* `Spec 0.795 - Chapel 1.1.0`_
+* `Spec 0.785 - Chapel 1.0.0`_
+* `Spec 0.782 - Chapel 0.9.0`_
 * `Spec 0.780`_
 * `Spec 0.775`_
 * `Spec 0.760`_
@@ -31,21 +36,21 @@ This page contains language specifications prior to `Chapel 1.13.0 - Spec 0.981`
 * `Spec 0.702`_
 * `Spec 0.4`_
 
-.. _Chapel 1.13.0 - Spec 0.981: http://chapel.cray.com/docs/1.13/language/spec.html
-.. _Chapel 1.12.0 - Spec 0.98:  http://chapel.cray.com/spec/spec-0.98.pdf
-.. _Chapel 1.11.0 - Spec 0.97:  http://chapel.cray.com/spec/spec-0.97.pdf
-.. _Chapel 1.10.0 - Spec 0.96:  http://chapel.cray.com/spec/spec-0.96.pdf
-.. _Chapel 1.9.0  - Spec 0.95:  http://chapel.cray.com/spec/spec-0.95.pdf
-.. _Chapel 1.8.0  - Spec 0.94:  http://chapel.cray.com/spec/spec-0.94.pdf
-.. _Chapel 1.7.0  - Spec 0.93:  http://chapel.cray.com/spec/spec-0.93.pdf
-.. _Chapel 1.6.0  - Spec 0.92:  http://chapel.cray.com/spec/spec-0.92.pdf
-.. _Chapel 1.5.0  - Spec 0.91:  http://chapel.cray.com/spec/spec-0.91.pdf
-.. _Chapel 1.4.0  - Spec 0.82:  http://chapel.cray.com/spec/spec-0.82.pdf
-.. _Chapel 1.3.0  - Spec 0.8:   http://chapel.cray.com/spec/spec-0.8.pdf
-.. _Chapel 1.2.0  - Spec 0.796: http://chapel.cray.com/spec/spec-0.796.pdf
-.. _Chapel 1.1.0  - Spec 0.795: http://chapel.cray.com/spec/spec-0.795.pdf
-.. _Chapel 1.0.0  - Spec 0.785: http://chapel.cray.com/spec/spec-0.785.pdf
-.. _Chapel 0.9.0  - Spec 0.782: http://chapel.cray.com/spec/spec-0.782.pdf
+.. _Spec 0.981 - Chapel 1.13.0: http://chapel.cray.com/docs/1.13/language/spec.html
+.. _Spec 0.98  - Chapel 1.12.0: http://chapel.cray.com/spec/spec-0.98.pdf
+.. _Spec 0.97  - Chapel 1.11.0: http://chapel.cray.com/spec/spec-0.97.pdf
+.. _Spec 0.96  - Chapel 1.10.0: http://chapel.cray.com/spec/spec-0.96.pdf
+.. _Spec 0.95  - Chapel 1.9.0:  http://chapel.cray.com/spec/spec-0.95.pdf
+.. _Spec 0.94  - Chapel 1.8.0:  http://chapel.cray.com/spec/spec-0.94.pdf
+.. _Spec 0.93  - Chapel 1.7.0:  http://chapel.cray.com/spec/spec-0.93.pdf
+.. _Spec 0.92  - Chapel 1.6.0:  http://chapel.cray.com/spec/spec-0.92.pdf
+.. _Spec 0.91  - Chapel 1.5.0:  http://chapel.cray.com/spec/spec-0.91.pdf
+.. _Spec 0.82  - Chapel 1.4.0:  http://chapel.cray.com/spec/spec-0.82.pdf
+.. _Spec 0.8   - Chapel 1.3.0:  http://chapel.cray.com/spec/spec-0.8.pdf
+.. _Spec 0.796 - Chapel 1.2.0:  http://chapel.cray.com/spec/spec-0.796.pdf
+.. _Spec 0.795 - Chapel 1.1.0:  http://chapel.cray.com/spec/spec-0.795.pdf
+.. _Spec 0.785 - Chapel 1.0.0:  http://chapel.cray.com/spec/spec-0.785.pdf
+.. _Spec 0.782 - Chapel 0.9.0:  http://chapel.cray.com/spec/spec-0.782.pdf
 .. _Spec 0.780:                 http://chapel.cray.com/spec/spec-0.780.pdf
 .. _Spec 0.775:                 http://chapel.cray.com/spec/spec-0.775.pdf
 .. _Spec 0.760:                 http://chapel.cray.com/spec/spec-0.760.pdf

--- a/doc/sphinx/source/language/archivedSpecs.rst
+++ b/doc/sphinx/source/language/archivedSpecs.rst
@@ -3,31 +3,18 @@
 Archived Language Specifications
 ================================
 
-This page contains language specifications prior to `Spec 0.981 (Chapel 1.13.0)`_.
-
-
-Latest Spec Version
--------------------
+**Latest Spec Version**
 
 * `Language Specification`_
 
-Spec Version >= 0.981
----------------------
+**Spec Version >= 0.981**
 
 * Visit ``chapel.cray.com/docs/<X.YY>/language/spec.html``, where ``X.YY`` is
   their associated Chapel release version
 
-Spec Version < 0.981
---------------------
+**Spec Version < 0.981**
 
-**Format:**
-
-* Spec *<version>* (Chapel *<release in which specification was made available>*)
-
-.. note::
-
-    Chapel releases that are no longer available for public download are
-    not listed after their associated language specification versions.
+Spec *<version>* (Chapel *<release in which specification was made available>*)
 
 * `Spec 0.98  (Chapel 1.12.0)`_
 * `Spec 0.97  (Chapel 1.11.0)`_
@@ -49,6 +36,11 @@ Spec Version < 0.981
 * `Spec 0.750`_
 * `Spec 0.702`_
 * `Spec 0.4`_
+
+.. note::
+
+    Chapel releases that are no longer available for public download are
+    not listed after their associated language specification versions.
 
 
 

--- a/doc/sphinx/source/language/archivedSpecs.rst
+++ b/doc/sphinx/source/language/archivedSpecs.rst
@@ -3,32 +3,46 @@
 Archived Language Specifications
 ================================
 
-This page contains language specifications prior to `Spec 0.981 - Chapel 1.13.0`_.
+This page contains language specifications prior to `Spec 0.981 (Chapel 1.13.0)`_.
 
-Each spec version is appended with the associated Chapel release version.
-Spec versions associated with a Chapel release that is no longer available for
-public download do not list the Chapel release version.
 
+Latest Spec Version
+-------------------
+
+* `Language Specification`_
+
+Spec Version >= 0.981
+---------------------
+
+* Visit ``chapel.cray.com/docs/<X.YY>/language/spec.html``, where ``X.YY`` is
+  their associated Chapel release version
+
+Spec Version < 0.981
+--------------------
+
+**Format:**
+
+* Spec *<version>* (Chapel *<release in which specification was made available>*)
 
 .. note::
-    To access language specifications for 1.13.0 and beyond, visit the
-    documentation page at the url ``chapel.cray.docs/<X>.<YY>/language/spec.html``,
-    where ``<X>`` and ``<YY>`` are the major and minor versions, respectively.
 
-* `Spec 0.98  - Chapel 1.12.0`_
-* `Spec 0.97  - Chapel 1.11.0`_
-* `Spec 0.96  - Chapel 1.10.0`_
-* `Spec 0.95  - Chapel 1.9.0`_
-* `Spec 0.94  - Chapel 1.8.0`_
-* `Spec 0.93  - Chapel 1.7.0`_
-* `Spec 0.92  - Chapel 1.6.0`_
-* `Spec 0.91  - Chapel 1.5.0`_
-* `Spec 0.82  - Chapel 1.4.0`_
-* `Spec 0.8   - Chapel 1.3.0`_
-* `Spec 0.796 - Chapel 1.2.0`_
-* `Spec 0.795 - Chapel 1.1.0`_
-* `Spec 0.785 - Chapel 1.0.0`_
-* `Spec 0.782 - Chapel 0.9.0`_
+    Chapel releases that are no longer available for public download are
+    not listed after their associated language specification versions.
+
+* `Spec 0.98  (Chapel 1.12.0)`_
+* `Spec 0.97  (Chapel 1.11.0)`_
+* `Spec 0.96  (Chapel 1.10.0)`_
+* `Spec 0.95  (Chapel 1.9.0)`_
+* `Spec 0.94  (Chapel 1.8.0)`_
+* `Spec 0.93  (Chapel 1.7.0)`_
+* `Spec 0.92  (Chapel 1.6.0)`_
+* `Spec 0.91  (Chapel 1.5.0)`_
+* `Spec 0.82  (Chapel 1.4.0)`_
+* `Spec 0.8   (Chapel 1.3.0)`_
+* `Spec 0.796 (Chapel 1.2.0)`_
+* `Spec 0.795 (Chapel 1.1.0)`_
+* `Spec 0.785 (Chapel 1.0.0)`_
+* `Spec 0.782 (Chapel 0.9.0)`_
 * `Spec 0.780`_
 * `Spec 0.775`_
 * `Spec 0.760`_
@@ -36,21 +50,24 @@ public download do not list the Chapel release version.
 * `Spec 0.702`_
 * `Spec 0.4`_
 
-.. _Spec 0.981 - Chapel 1.13.0: http://chapel.cray.com/docs/1.13/language/spec.html
-.. _Spec 0.98  - Chapel 1.12.0: http://chapel.cray.com/spec/spec-0.98.pdf
-.. _Spec 0.97  - Chapel 1.11.0: http://chapel.cray.com/spec/spec-0.97.pdf
-.. _Spec 0.96  - Chapel 1.10.0: http://chapel.cray.com/spec/spec-0.96.pdf
-.. _Spec 0.95  - Chapel 1.9.0:  http://chapel.cray.com/spec/spec-0.95.pdf
-.. _Spec 0.94  - Chapel 1.8.0:  http://chapel.cray.com/spec/spec-0.94.pdf
-.. _Spec 0.93  - Chapel 1.7.0:  http://chapel.cray.com/spec/spec-0.93.pdf
-.. _Spec 0.92  - Chapel 1.6.0:  http://chapel.cray.com/spec/spec-0.92.pdf
-.. _Spec 0.91  - Chapel 1.5.0:  http://chapel.cray.com/spec/spec-0.91.pdf
-.. _Spec 0.82  - Chapel 1.4.0:  http://chapel.cray.com/spec/spec-0.82.pdf
-.. _Spec 0.8   - Chapel 1.3.0:  http://chapel.cray.com/spec/spec-0.8.pdf
-.. _Spec 0.796 - Chapel 1.2.0:  http://chapel.cray.com/spec/spec-0.796.pdf
-.. _Spec 0.795 - Chapel 1.1.0:  http://chapel.cray.com/spec/spec-0.795.pdf
-.. _Spec 0.785 - Chapel 1.0.0:  http://chapel.cray.com/spec/spec-0.785.pdf
-.. _Spec 0.782 - Chapel 0.9.0:  http://chapel.cray.com/spec/spec-0.782.pdf
+
+
+.. _Language Specification:     http://chapel.cray.com/docs/latest/language/spec.html
+.. _Spec 0.981 (Chapel 1.13.0): http://chapel.cray.com/docs/1.13/language/spec.html
+.. _Spec 0.98  (Chapel 1.12.0): http://chapel.cray.com/spec/spec-0.98.pdf
+.. _Spec 0.97  (Chapel 1.11.0): http://chapel.cray.com/spec/spec-0.97.pdf
+.. _Spec 0.96  (Chapel 1.10.0): http://chapel.cray.com/spec/spec-0.96.pdf
+.. _Spec 0.95  (Chapel 1.9.0):  http://chapel.cray.com/spec/spec-0.95.pdf
+.. _Spec 0.94  (Chapel 1.8.0):  http://chapel.cray.com/spec/spec-0.94.pdf
+.. _Spec 0.93  (Chapel 1.7.0):  http://chapel.cray.com/spec/spec-0.93.pdf
+.. _Spec 0.92  (Chapel 1.6.0):  http://chapel.cray.com/spec/spec-0.92.pdf
+.. _Spec 0.91  (Chapel 1.5.0):  http://chapel.cray.com/spec/spec-0.91.pdf
+.. _Spec 0.82  (Chapel 1.4.0):  http://chapel.cray.com/spec/spec-0.82.pdf
+.. _Spec 0.8   (Chapel 1.3.0):  http://chapel.cray.com/spec/spec-0.8.pdf
+.. _Spec 0.796 (Chapel 1.2.0):  http://chapel.cray.com/spec/spec-0.796.pdf
+.. _Spec 0.795 (Chapel 1.1.0):  http://chapel.cray.com/spec/spec-0.795.pdf
+.. _Spec 0.785 (Chapel 1.0.0):  http://chapel.cray.com/spec/spec-0.785.pdf
+.. _Spec 0.782 (Chapel 0.9.0):  http://chapel.cray.com/spec/spec-0.782.pdf
 .. _Spec 0.780:                 http://chapel.cray.com/spec/spec-0.780.pdf
 .. _Spec 0.775:                 http://chapel.cray.com/spec/spec-0.775.pdf
 .. _Spec 0.760:                 http://chapel.cray.com/spec/spec-0.760.pdf

--- a/doc/sphinx/source/language/archivedSpecs.rst
+++ b/doc/sphinx/source/language/archivedSpecs.rst
@@ -1,0 +1,54 @@
+.. _chapel-archived-specs:
+
+Archived Language Specifications
+================================
+
+This page contains language specifications prior to `Chapel 1.13.0 - Spec 0.981`_.
+
+.. note::
+    To access language specifications for 1.13.0 and beyond, visit the
+    documentation page at the url ``chapel.cray.docs/<X>.<YY>/language/spec.html``,
+    where ``<X>`` and ``<YY>`` are the major and minor versions, respectively.
+
+* `Chapel 1.12.0 - Spec 0.98`_
+* `Chapel 1.11.0 - Spec 0.97`_
+* `Chapel 1.10.0 - Spec 0.96`_
+* `Chapel 1.9.0  - Spec 0.95`_
+* `Chapel 1.8.0  - Spec 0.94`_
+* `Chapel 1.7.0  - Spec 0.93`_
+* `Chapel 1.6.0  - Spec 0.92`_
+* `Chapel 1.5.0  - Spec 0.91`_
+* `Chapel 1.4.0  - Spec 0.82`_
+* `Chapel 1.3.0  - Spec 0.8`_
+* `Chapel 1.2.0  - Spec 0.796`_
+* `Chapel 1.1.0  - Spec 0.795`_
+* `Chapel 1.0.0  - Spec 0.785`_
+* `Chapel 0.9.0  - Spec 0.782`_
+* `Spec 0.780`_
+* `Spec 0.775`_
+* `Spec 0.760`_
+* `Spec 0.750`_
+* `Spec 0.702`_
+* `Spec 0.4`_
+
+.. _Chapel 1.13.0 - Spec 0.981: http://chapel.cray.com/docs/1.13/language/spec.html
+.. _Chapel 1.12.0 - Spec 0.98:  http://chapel.cray.com/spec/spec-0.98.pdf
+.. _Chapel 1.11.0 - Spec 0.97:  http://chapel.cray.com/spec/spec-0.97.pdf
+.. _Chapel 1.10.0 - Spec 0.96:  http://chapel.cray.com/spec/spec-0.96.pdf
+.. _Chapel 1.9.0  - Spec 0.95:  http://chapel.cray.com/spec/spec-0.95.pdf
+.. _Chapel 1.8.0  - Spec 0.94:  http://chapel.cray.com/spec/spec-0.94.pdf
+.. _Chapel 1.7.0  - Spec 0.93:  http://chapel.cray.com/spec/spec-0.93.pdf
+.. _Chapel 1.6.0  - Spec 0.92:  http://chapel.cray.com/spec/spec-0.92.pdf
+.. _Chapel 1.5.0  - Spec 0.91:  http://chapel.cray.com/spec/spec-0.91.pdf
+.. _Chapel 1.4.0  - Spec 0.82:  http://chapel.cray.com/spec/spec-0.82.pdf
+.. _Chapel 1.3.0  - Spec 0.8:   http://chapel.cray.com/spec/spec-0.8.pdf
+.. _Chapel 1.2.0  - Spec 0.796: http://chapel.cray.com/spec/spec-0.796.pdf
+.. _Chapel 1.1.0  - Spec 0.795: http://chapel.cray.com/spec/spec-0.795.pdf
+.. _Chapel 1.0.0  - Spec 0.785: http://chapel.cray.com/spec/spec-0.785.pdf
+.. _Chapel 0.9.0  - Spec 0.782: http://chapel.cray.com/spec/spec-0.782.pdf
+.. _Spec 0.780:                 http://chapel.cray.com/spec/spec-0.780.pdf
+.. _Spec 0.775:                 http://chapel.cray.com/spec/spec-0.775.pdf
+.. _Spec 0.760:                 http://chapel.cray.com/spec/spec-0.760.pdf
+.. _Spec 0.750:                 http://chapel.cray.com/spec/spec-0.750.pdf
+.. _Spec 0.702:                 http://chapel.cray.com/spec/spec-0.702.pdf
+.. _Spec 0.4:                   http://chapel.cray.com/spec/spec-0.4.pdf

--- a/doc/sphinx/source/language/spec.rst
+++ b/doc/sphinx/source/language/spec.rst
@@ -4,3 +4,5 @@ Chapel Language Specification
 =============================
 
 :download:`View Language Specification [pdf] <chapelLanguageSpec.pdf>`
+
+To see language specifications of previous versions, see :ref:`Archived Languages Specifications<chapel-archived-specs>`.


### PR DESCRIPTION
* First take visible [here](http://i.imgur.com/uKqD7sW.png).
* Second take visible [here](http://i.imgur.com/GCbTnfE.png).
    * In response to a few comments from @bradcray 
    * Note the way Sphinx renders links doesn't allow one to add white space for better alignment.
        * We could add more dashes though
        * We could alternatively pad version numbers with 0s, e.g. `0.800` vs. `0.8`, although this would not reflect the true version number accurately.