### PR TITLE
Couple more test updates

### DIFF
--- a/test/classes/hilde/inheritance/constructors.chpl
+++ b/test/classes/hilde/inheritance/constructors.chpl
@@ -14,7 +14,7 @@ class base {
 class sub : base {
   var _j:int;
   proc sub(i:int, j = -2) {
-    // How do we call the base class constuctor?
+    // How do we call the base class constructor?
     _i = i;
     _j = j;
   }

--- a/test/classes/vass/nested-class-with-user-defined-constructor-1.bad
+++ b/test/classes/vass/nested-class-with-user-defined-constructor-1.bad
@@ -1,0 +1,1 @@
+nested-class-with-user-defined-constructor-1.chpl:4: error: constructor for class 'inner' requires a generic argument called 'outer'

--- a/test/classes/vass/nested-class-with-user-defined-constructor-1.chpl
+++ b/test/classes/vass/nested-class-with-user-defined-constructor-1.chpl
@@ -1,10 +1,9 @@
 class enclosing {
 
   class inner {
-    proc inner(outer) {
+    proc inner() {
       writeln("in inner constructor");
     }
-    proc foo return new inner();
   } // class inner
 
   proc new_inner() {

--- a/test/classes/vass/nested-class-with-user-defined-constructor-1.future
+++ b/test/classes/vass/nested-class-with-user-defined-constructor-1.future
@@ -10,8 +10,3 @@ There are two problems with this:
 * The 'outer' formal should not be required - because there are cases
   (like in this example) where the user does not wish to pass an explicit
   outer pointer.
-
-Furthermore, if we suck it up and do add the "outer" argument,
-the compiler can't handle it (this is an internal error):
-
-nested-class-with-user-defined-constructor-1.chpl:4: error: SymExpr::var::defPoint is not in AST [expr.cpp:187]


### PR DESCRIPTION
Fix a typo in test/classes/hilde/inheritance/constructors.chpl, and fix the
future test/classes/vass/nested-class-with-user-defined-constructor-1.chpl so
that it is written the way we want it to operate and has a .bad file to lock
in the current incorrect behavior.