### PR TITLE
Minor vararg-related fixes in compiler

### DIFF
--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -270,7 +270,12 @@ public:
   IntentTag       intent;
   BlockStmt*      typeExpr;    // Type expr for arg type, or NULL.
   BlockStmt*      defaultExpr;
+
+  // Stores the expression specified after an ellipsis in vararg formal.
+  // This must resolve during function resolution to a parameter expression.
+  // It can be omitted for variadic arguments or a query identifier.
   BlockStmt*      variableExpr;
+
   Type*           instantiatedFrom;
 
 };

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1641,6 +1641,7 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
   workingFn->addFlag(FLAG_EXPANDED_VARARGS);
 
   // Handle specified number of variable arguments.
+  // sym->var is not a VarSymbol e.g. in: proc f(param n, v...n)
   if (VarSymbol* nVar = toVarSymbol(sym->var)) {
     if (nVar->type == dtInt[INT_SIZE_DEFAULT] && nVar->immediate) {
       VarSymbol* var       = new VarSymbol(formal->name);
@@ -1785,6 +1786,9 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
       }
 
       formal->defPoint->remove();
+    } else {
+      // Just documenting the current status.
+      INT_FATAL(formal, "unexpected non-VarSymbol");
     }
   }
 }


### PR DESCRIPTION
* Replace explicit calls to 'delete' etc. on AST nodes
(inserted by a collaborator)
with the standard node->replace().

* Added a comment on FnSymbol::variableExpr field.
Taken from compilerOverview.pdf.

* All code in handleSymExprInExpandVarArgs() is gated by two conditionals.
I verified and documented, using INT_FATAL, that the inner conditional
always fires.
Also documented when the outer condition may be false.
This was illustrated by this one test in our suite:

  test/functions/deitz/varargs/test_varargs3.chpl

* Moved "newFn->partialCopySource = this;"
from copyInnerCore() to partialCopy() - for clarity:
do not do it where it is not needed.

Passes full linux64 test suite.