### PR TITLE
CHPL_TARGET_COMPILER support for mpicc with a gnu backend

### DIFF
--- a/make/compiler/Makefile.mpi-gnu
+++ b/make/compiler/Makefile.mpi-gnu
@@ -1,0 +1,23 @@
+# Copyright 2004-2016 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# put Cray PE cross-compilation gnu-specific settings here
+
+include $(CHPL_MAKE_HOME)/make/compiler/Makefile.gnu
+
+CC=mpicc
+CXX=mpicxx


### PR DESCRIPTION
First step towards an MPI module, splitting PR #3766 into a few pieces.

This adds in a new compiler Makefile "mpi-gnu" which calls mpicc/mpicxx, assuming a gnu backend. This is a trivial modification of the cray-prgenv-gnu Makefile.