### PR TITLE
Provide an updated version of the chpl.lang file for Andre Simon's highlighter

### DIFF
--- a/highlight/highlight/README
+++ b/highlight/highlight/README
@@ -1,13 +1,13 @@
 This file goes with 
- highlight version 2.16
- Copyright (C) 2002-2010 Andre Simon <andre.simon1 at gmx.de>
+ highlight version 3.28
+ Copyright (C) 2002-2016 Andre Simon <andre.simon1 at gmx.de>
 
 which you can find at highlight http://www.andre-simon.de/
 
 This is the highlighter used by the Computer Languages Benchmark Game.
 
 For example, run from this directory:
-  highlight -M --add-config-dir=. --add-data-dir=. your_file.chpl
+  highlight --config-file=./langDefs/chpl.lang your_file.chpl
 
 For more options, try:
   highlight --help

--- a/highlight/highlight/langDefs/chpl.lang
+++ b/highlight/highlight/langDefs/chpl.lang
@@ -1,38 +1,52 @@
-# Chapel language definition file for highlight http://www.andre-simon.de/
-#
-# Author: Michael Ferguson
-#   Mail: 
-#   Date:
-# ------------------------------------------
-# The file is used to describe keywords and special symbols of programming languages.
-# See README in the highlight directory for details.
+-- Chapel language definition file for highlight http://www.andre-simon.de/
+-- This file is written in Lua
+--
+-- Author: Lydia Duncan
+-- Date  : April 28, 2016
+--
+-- The file is used to describe keywords and special symbols of programming languages.
+-- See README in the highlight directory for details.
 
-$DESCRIPTION=CHPL
+Description="Chapel"
 
-# Putting reserved identifiers here from spec section 6.4.2 Keywords
-$KEYWORDS(kwa)=as atomic begin break by class cobegin coforall config const continue proc iter delete dmapped do domain else enum except false for forall if in index inout label lambda let local module new nil noinit on only otherwise out param private public record reduce ref require return scan select serial single sparse subdomain sync then true type union use var when where while with yield zip
+Keywords={
+  { Id=1,
+   List={"as", "align", "atomic", "begin", "break", "by", "class", "cobegin",
+         "coforall", "config", "const", "continue", "proc", "iter", "delete",
+         "dmapped", "do", "domain", "else", "enum", "except", "export",
+         "extern", "false", "for", "forall", "if", "in", "index", "inline",
+         "inout", "label", "lambda", "let", "local", "module", "new", "nil",
+         "noinit", "on", "only", "otherwise", "out", "param", "private",
+         "public", "record", "reduce", "ref", "require", "return", "scan",
+         "select", "serial", "single", "sparse", "subdomain", "sync", "then",
+         "true", "type", "union", "use", "var", "when", "where", "while",
+         "with", "yield", "zip"
+        }
+  },
+  { Id=2,
+    List= { "bool", "complex", "imag", "int", "opaque", "range", "real",
+            "string", "uint"
+          }
+  }
+}
 
-# Putting built-in things that are not types things here
-$KEYWORDS(kwb)=bool complex int opaque range real string uint
+Strings = {
+  Delimiter=[["|']]
+}
 
-#$KEYWORDS(kwc)=regex((\w+)\s*\()
-#$KEYWORDS(kwb)=regex((\w+)\s*\()
+Comments = {
+   { Block=true,
+     Nested=false,
+     Delimiter = { [[\/\*]], [[\*\/]] }
+   },
+   {
+     Block=false,
+     Delimiter = { [[//]] }
+   }
+}
 
-$STRINGDELIMITERS=" '
+IgnoreCase=false
 
-$SL_COMMENT=//
-$ML_COMMENT=/* */
+Operators=[[\(|\)|\[|\]|\{|\}|\,|\;|\.|\:|\/|\*|\%|\+|\-|=|\&|\?|<|>|\!|\~|\||\^|!|#]]
 
-$ALLOWNESTEDCOMMENTS=false
-
-$IGNORECASE=false
-
-$ESCCHAR=regex(\\u\p{XDigit}{4}|\\\d{3}|\\x\p{XDigit}{2}|\\[ntvbrfa\\\?'"])
-
-$SYMBOLS= ( ) [ ] { } , ; . : & | < > !  = / * %  + - ~ \#
-
-$DIGIT=regex((?:0x|0X)[0-9a-fA-F]+|\d*[\.\_]?\d+(?:[eE][\-\+]\d+)?[lLuUbfdm]*)
-
-#
-# end of [chpl.lang]
-#
+EnableIndentation=true


### PR DESCRIPTION
The version we had was compatible with the 2.x release of the highlighter, but
not 3.x when it switched to using Lua for the backend scripts.  I took a look
at the c.lang file in the most up-to-date version of highlight (3.28) and
modified it to utilize the information in the old chpl.lang file.  Also updated
the README to mention the latest version and the new syntax to highlight a file