### PR TITLE
Ensure args[] is destroyed when passed to main()

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -535,6 +535,8 @@ static void build_chpl_entry_points() {
     if (mainHasArgs) {
       VarSymbol* converted_args = newTemp("_main_args");
 
+      converted_args->addFlag(FLAG_INSERT_AUTO_DESTROY);
+
       chpl_gen_main->insertAtTail(new DefExpr(converted_args));
       chpl_gen_main->insertAtTail(new CallExpr(PRIM_MOVE,
                                                converted_args,


### PR DESCRIPTION
If a chapel program defines main as

proc main(args : [] string) {
..
}

then args[] would be leaked.  The setup procedure to main failed to autoDestroy the array that
it created.


Trivial.

Tested for correctness and impact on a few programs on darwin/clang.
Tested for correctness and impact on linux64 on linux64/gcc

No review
