### PR TITLE
Reductions op equals

### DIFF
--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -80,10 +80,10 @@ module ChapelReduce {
       var x: chpl__sumType(eltType); return x;
     }
     proc accumulate(x) {
-      value = value + x;
+      value += x;
     }
     proc combine(x) {
-      value = value + x.value;
+      value += x.value;
     }
     proc generate() return value;
     proc clone() return new SumReduceScanOp(eltType=eltType);
@@ -95,10 +95,10 @@ module ChapelReduce {
   
     proc identity return _prod_id(eltType);
     proc accumulate(x) {
-      value = value * x;
+      value *= x;
     }
     proc combine(x) {
-      value = value * x.value;
+      value *= x.value;
     }
     proc generate() return value;
     proc clone() return new ProductReduceScanOp(eltType=eltType);
@@ -140,10 +140,10 @@ module ChapelReduce {
   
     proc identity return _land_id(eltType);
     proc accumulate(x) {
-      value = value && x;
+      value &&= x;
     }
     proc combine(x) {
-      value = value && x.value;
+      value &&= x.value;
     }
     proc generate() return value;
     proc clone() return new LogicalAndReduceScanOp(eltType=eltType);
@@ -155,10 +155,10 @@ module ChapelReduce {
   
     proc identity return _lor_id(eltType);
     proc accumulate(x) {
-      value = value || x;
+      value ||= x;
     }
     proc combine(x) {
-      value = value || x.value;
+      value ||= x.value;
     }
     proc generate() return value;
     proc clone() return new LogicalOrReduceScanOp(eltType=eltType);
@@ -170,10 +170,10 @@ module ChapelReduce {
   
     proc identity return _band_id(eltType);
     proc accumulate(x) {
-      value = value & x;
+      value &= x;
     }
     proc combine(x) {
-      value = value & x.value;
+      value &= x.value;
     }
     proc generate() return value;
     proc clone() return new BitwiseAndReduceScanOp(eltType=eltType);
@@ -185,10 +185,10 @@ module ChapelReduce {
   
     proc identity return _bor_id(eltType);
     proc accumulate(x) {
-      value = value | x;
+      value |= x;
     }
     proc combine(x) {
-      value = value | x.value;
+      value |= x.value;
     }
     proc generate() return value;
     proc clone() return new BitwiseOrReduceScanOp(eltType=eltType);
@@ -200,10 +200,10 @@ module ChapelReduce {
   
     proc identity return _bxor_id(eltType);
     proc accumulate(x) {
-      value = value ^ x;
+      value ^= x;
     }
     proc combine(x) {
-      value = value ^ x.value;
+      value ^= x.value;
     }
     proc generate() return value;
     proc clone() return new BitwiseXorReduceScanOp(eltType=eltType);

--- a/test/associative/bharshbarg/domains/reduceArrOfAssocDom.good
+++ b/test/associative/bharshbarg/domains/reduceArrOfAssocDom.good
@@ -2,6 +2,4 @@ reduceArrOfAssocDom.chpl:5: warning: whole-domain assignment has been serialized
 reduceArrOfAssocDom.chpl:7: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 reduceArrOfAssocDom.chpl:7: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 reduceArrOfAssocDom.chpl:7: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
-reduceArrOfAssocDom.chpl:7: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
-reduceArrOfAssocDom.chpl:7: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 55


### PR DESCRIPTION
Adjusts ChapelReduce.chpl to use op= when possible.

E.g.

       value = value + x;

becomes

       value += x;


It looks like this code is very old in the project's history and might
have predated better code generation support for op=.

Passed full local testing.
Reviewed by @bradcray - thanks!