### PR TITLE
Cleanup string helper functions

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
+/* A Chapel version of a C pointer. */
 module CPtr {
-  /* A Chapel version of a C NULL pointer.
-  */
+  /* A Chapel version of a C NULL pointer. */
   extern const c_nil:c_void_ptr;
 
   // To generate legal C prototypes, we have to manually instantiate this
@@ -85,6 +85,7 @@ module CPtr {
   inline proc _cast(type t, x) where t:c_void_ptr && x.type:c_ptr {
     return __primitive("cast", t, x);
   }
+  pragma "no doc"
   inline proc _cast(type t, x) where t:c_ptr && x.type:c_void_ptr {
     return __primitive("cast", t, x);
   }
@@ -245,7 +246,8 @@ module CPtr {
   }
 
 
-  /* Free memory that was allocated with :proc:`c_free`.
+  /* Free memory that was allocated with :proc:`c_calloc` or :proc:`c_malloc`.
+
     :arg data: the c_ptr to memory that was allocated
     */
   inline proc c_free(data: c_ptr) {

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -267,4 +267,19 @@ module CPtr {
     extern proc memmove(dest: c_void_ptr, const src: c_void_ptr, n: size_t);
     memmove(dest, src, n.safeCast(size_t));
   }
+
+  /*
+    Copies n (non-overlapping) bytes from memory area src to memory
+    area dest. Use :proc:`c_memmove` if memory areas do overlap.
+
+    This is a simple wrapper over the C memcpy() function.
+
+    :arg dest: the destination memory area to copy to
+    :arg src: the source memory area to copy from
+    :arg n: the number of bytes from src to copy to dest
+   */
+  inline proc c_memcpy(dest: c_ptr, const src: c_ptr, n: integral) {
+    extern proc memcpy (dest: c_void_ptr, const src: c_void_ptr, n: size_t);
+    memcpy(dest, src, n.safeCast(size_t));
+  }
 }

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -282,4 +282,18 @@ module CPtr {
     extern proc memcpy (dest: c_void_ptr, const src: c_void_ptr, n: size_t);
     memcpy(dest, src, n.safeCast(size_t));
   }
+
+  /*
+    Compares the first n bytes of memory areas s1 and s2
+
+    This is a simple wrapper over the C memcmp() function.
+
+    :returns: returns an integer less than, equal to, or greater than zero if
+              the first n bytes of s1 are found, respectively, to be less than,
+              to match, or be greater than the first n bytes of s2.
+   */
+  inline proc c_memcmp(const s1: c_ptr, const s2: c_ptr, n: integral) {
+    extern proc memcmp(const s1: c_void_ptr, const s2: c_ptr, n: size_t) : c_int;
+    return memcmp(s1, s2, n.safeCast(size_t)).safeCast(int);
+  }
 }

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -213,7 +213,6 @@ module CPtr {
     return c_pointer_return(x);
   }
 
-
   /*
     Allocate memory that is filled with zeros. This memory should eventually be
     freed with c_free.
@@ -245,12 +244,27 @@ module CPtr {
     return ret;
   }
 
-
   /* Free memory that was allocated with :proc:`c_calloc` or :proc:`c_malloc`.
 
     :arg data: the c_ptr to memory that was allocated
     */
   inline proc c_free(data: c_ptr) {
     __primitive("array_free", data);
+  }
+
+
+  /*
+    Copies n (potentially overlapping) bytes from memory area src to memory
+    area dest.
+
+    This is a simple wrapper over the C memmove() function.
+
+    :arg dest: the destination memory area to copy to
+    :arg src: the source memory area to copy from
+    :arg n: the number of bytes from src to copy to dest
+   */
+  inline proc c_memmove(dest: c_ptr, const src: c_ptr, n: integral) {
+    extern proc memmove(dest: c_void_ptr, const src: c_void_ptr, n: size_t);
+    memmove(dest, src, n.safeCast(size_t));
   }
 }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -98,7 +98,6 @@ module String {
       return dest;
   }
 
-  private extern proc memmove(destination: c_ptr, const source: c_ptr, num: size_t);
   private extern proc memcpy(destination: c_ptr, const source: c_ptr, num: size_t);
   private extern proc memcmp(s1: c_ptr, s2: c_ptr, n: size_t) : c_int;
 
@@ -229,7 +228,7 @@ module String {
             // We just allocated a buffer, make sure to free it later
             this.owned = true;
           }
-          memmove(this.buff, buf, s_len.safeCast(size_t));
+          c_memmove(this.buff, buf, s_len);
         } else {
           if this.owned && !this.isEmptyString() then
             chpl_here_free(this.buff);

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -98,7 +98,6 @@ module String {
       return dest;
   }
 
-  private extern proc memcpy(destination: c_ptr, const source: c_ptr, num: size_t);
   private extern proc memcmp(s1: c_ptr, s2: c_ptr, n: size_t) : c_int;
 
   private config param debugStrings = false;
@@ -150,7 +149,7 @@ module String {
             const allocSize = chpl_here_good_alloc_size(sLen+1);
             this.buff = chpl_here_alloc(allocSize,
                                        CHPL_RT_MD_STR_COPY_DATA): bufferType;
-            memcpy(this.buff, s.buff, s.len.safeCast(size_t));
+            c_memcpy(this.buff, s.buff, s.len);
             this.buff[sLen] = 0;
             this._size = allocSize;
           } else {
@@ -851,7 +850,7 @@ module String {
           if first {
             first = false;
           } else if this.len != 0 {
-            memcpy(joined.buff + offset, this.buff, this.len.safeCast(size_t));
+            c_memcpy(joined.buff + offset, this.buff, this.len);
             offset += this.len;
           }
 
@@ -860,7 +859,7 @@ module String {
             var cpyStart = joined.buff + offset;
             var sSize = sLen.safeCast(size_t);
             if _local || s.locale_id == chpl_nodeID {
-              memcpy(cpyStart, s.buff, sSize);
+              c_memcpy(cpyStart, s.buff, sSize);
             } else {
               chpl_string_comm_get(cpyStart, s.locale_id, s.buff, sSize);
             }
@@ -1255,7 +1254,7 @@ module String {
         if s.owned {
           ret.buff = chpl_here_alloc(s._size,
                                     CHPL_RT_MD_STR_COPY_DATA): bufferType;
-          memcpy(ret.buff, s.buff, s.len.safeCast(size_t));
+          c_memcpy(ret.buff, s.buff, s.len);
           ret.buff[s.len] = 0;
         } else {
           ret.buff = s.buff;
@@ -1295,7 +1294,7 @@ module String {
         if s.owned {
           ret.buff = chpl_here_alloc(s._size,
                                     CHPL_RT_MD_STR_COPY_DATA): bufferType;
-          memcpy(ret.buff, s.buff, s.len.safeCast(size_t));
+          c_memcpy(ret.buff, s.buff, s.len);
           ret.buff[s.len] = 0;
         } else {
           ret.buff = s.buff;
@@ -1382,7 +1381,7 @@ module String {
       chpl_string_comm_get(ret.buff, s0.locale_id,
                            s0.buff, s0len.safeCast(size_t));
     } else {
-      memcpy(ret.buff, s0.buff, s0len.safeCast(size_t));
+      c_memcpy(ret.buff, s0.buff, s0len);
     }
 
     const s1remote = s1.locale_id != chpl_nodeID;
@@ -1390,7 +1389,7 @@ module String {
       chpl_string_comm_get(ret.buff+s0len, s1.locale_id,
                            s1.buff, s1len.safeCast(size_t));
     } else {
-      memcpy(ret.buff+s0len, s1.buff, s1len.safeCast(size_t));
+      c_memcpy(ret.buff+s0len, s1.buff, s1len);
     }
     ret.buff[ret.len] = 0;
 
@@ -1430,13 +1429,13 @@ module String {
       chpl_string_comm_get(ret.buff, s.locale_id,
                            s.buff, sLen.safeCast(size_t));
     } else {
-      memcpy(ret.buff, s.buff, sLen.safeCast(size_t));
+      c_memcpy(ret.buff, s.buff, sLen);
     }
 
     var iterations = n-1;
     var offset = sLen;
     for i in 1..iterations {
-      memcpy(ret.buff+offset, ret.buff, sLen.safeCast(size_t));
+      c_memcpy(ret.buff+offset, ret.buff, sLen);
       offset += sLen;
     }
     ret.buff[ret.len] = 0;
@@ -1578,7 +1577,7 @@ module String {
         } else {
           var newBuff = chpl_here_alloc(newSize,
                                        CHPL_RT_MD_STR_COPY_DATA):bufferType;
-          memcpy(newBuff, lhs.buff, lhs.len.safeCast(size_t));
+          c_memcpy(newBuff, lhs.buff, lhs.len);
           lhs.buff = newBuff;
           lhs.owned = true;
         }
@@ -1590,7 +1589,7 @@ module String {
         chpl_string_comm_get(lhs.buff+lhs.len, rhs.locale_id,
                               rhs.buff, rhsLen.safeCast(size_t));
       } else {
-        memcpy(lhs.buff+lhs.len, rhs.buff, rhsLen.safeCast(size_t));
+        c_memcpy(lhs.buff+lhs.len, rhs.buff, rhsLen);
       }
       lhs.len = newLength;
       lhs.buff[newLength] = 0;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -98,8 +98,6 @@ module String {
       return dest;
   }
 
-  private extern proc memcmp(s1: c_ptr, s2: c_ptr, n: size_t) : c_int;
-
   private config param debugStrings = false;
 
   //
@@ -483,13 +481,13 @@ module String {
 
           const needleR = 0:int..#localNeedle.len;
           if fromLeft {
-            const result = memcmp(this.buff, localNeedle.buff,
-                                  localNeedle.len.safeCast(size_t));
+            const result = c_memcmp(this.buff, localNeedle.buff,
+                                    localNeedle.len);
             ret = result == 0;
           } else {
             var offset = this.len-localNeedle.len;
-            const result = memcmp(this.buff+offset, localNeedle.buff,
-                                  localNeedle.len.safeCast(size_t));
+            const result = c_memcmp(this.buff+offset, localNeedle.buff,
+                                    localNeedle.len);
             ret = result == 0;
           }
           if ret == true then break;
@@ -1615,7 +1613,7 @@ module String {
   private inline proc _strcmp(a: string, b:string) : int {
     // Assumes a and b are on same locale and not empty.
     const size = min(a.len, b.len);
-    const result =  memcmp(a.buff, b.buff, size.safeCast(size_t));
+    const result =  c_memcmp(a.buff, b.buff, size);
 
     if (result == 0) {
       // Handle cases where one string is the beginning of the other


### PR DESCRIPTION
Add wrappers for memmove, memcpy, and memcmp in CPtr.chpl and use them in
String.chpl (instead of using private externs that required safeCast'ing.) The
mem* functions seem like generally useful routines, so it makes sense to move
them from private externs in String.chpl to wrappers in CPtr.chpl.

This adds wrappers that take integral instead of size_t and takes care of
safeCast'ing internally so that you don't have to cast at the callsites.

It also changes chpl_string_comm_get to take an integral instead of a size_t
and does the safeCast to a size_t internally.

Combined these changes allow us to get rid of all of the safeCasts in
String.chpl.
