### PR TITLE
highlight/highlight: highlight nested block comments

### DIFF
--- a/highlight/highlight/langDefs/chpl.lang
+++ b/highlight/highlight/langDefs/chpl.lang
@@ -39,7 +39,7 @@ Strings = {
 
 Comments = {
    { Block=true,
-     Nested=false,
+     Nested=true,
      Delimiter = { [[\/\*]], [[\*\/]] }
    },
    {


### PR DESCRIPTION
Update highlight/highlight/langDefs/chpl.lang to support Chapel's nested block comments.

Tested on test/users/ferguson/nestedcomments.chpl, and on a more convoluted case.
