### PR TITLE
Simplify and speed up chpl_executeOn().

### DIFF
--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -68,6 +68,7 @@
   m(LOCALE_NAME_BUF,      "locale name buffer",                       true ), \
   m(TASK_DESC,            "task descriptor",                          false), \
   m(TASK_DESC_LINK,       "task descriptor link",                     false), \
+  m(TASK_ARG,             "task body argument",                       false), \
   m(TASK_STACK,           "task stack",                               false), \
   m(MUTEX,                "mutex",                                    false), \
   m(LOCK_REPORT_DATA,     "lock report data",                         false), \

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -23,6 +23,7 @@
 #ifndef LAUNCHER
 
 #include <stdint.h>
+#include "chplcgfns.h"
 #include "chpltypes.h"
 #include "chpl-tasks-prvdata.h"
 
@@ -144,8 +145,35 @@ void chpl_task_addToTaskList(
          c_nodeid_t,         // locale (node) where task list resides
          chpl_bool,          // is begin{} stmt?  (vs. cobegin or coforall)
          int,                // line at which function begins
-         int32_t);          // name of file containing functions
+         int32_t);           // name of file containing function
 void chpl_task_executeTasksInList(void**);
+
+//
+// Call a function in a task.
+//
+void chpl_task_taskCall(chpl_fn_p,          // function to call
+                        void*,              // function arg
+                        size_t,             // length of arg
+                        c_sublocid_t,       // desired sublocale
+                        int,                // line at which function begins
+                        int32_t);           // name of file containing function
+
+//
+// Call a chpl_ftable[] function in a task.
+//
+// This is a convenience function for use by the module code, in which
+// we have function table indices rather than function pointers.
+//
+static inline
+void chpl_task_taskCallFTable(chpl_fn_int_t fid,      // ftable[] entry to call
+                              void* arg,              // function arg
+                              size_t arg_size,        // length of arg
+                              c_sublocid_t subloc,    // desired sublocale
+                              int lineno,             // source line
+                              int32_t filename) {     // source filename
+    chpl_task_taskCall(chpl_ftable[fid], arg, arg_size, subloc,
+                       lineno, filename);
+}
 
 //
 // Launch a task that is the logical continuation of some other task,

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -134,13 +134,6 @@ typedef struct {
           .requestedSubloc = _subloc, \
           .prvdata = { .serial_state = _serial } }
 
-typedef struct {
-    void                     *fn;
-    void                     *args;
-    chpl_bool                countRunning;
-    chpl_task_prvDataImpl_t  chpl_data;
-} chpl_qthread_wrapper_args_t;
-
 // Structure of task-local storage
 typedef struct chpl_qthread_tls_s {
     /* Task private data: serial state, etc. */

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -680,7 +680,7 @@ void chpl_task_taskCall(chpl_fn_p fp, void* arg, size_t arg_size,
 
   if (arg != NULL) {
     arg_copy = chpl_mem_allocMany(1, arg_size, CHPL_RT_MD_TASK_ARG, 0, 0);
-    memcpy(arg_copy, arg, arg_size);
+    chpl_memcpy(arg_copy, arg, arg_size);
   }
   taskCallBody(fp, NULL, arg_copy, subloc, false, lineno, filename);
 }

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -70,14 +70,15 @@ typedef struct task_pool_struct {
 
 
 //
-// This is a descriptor for movedTaskWrapper().
+// This is a descriptor for taskCallWrapper().
 //
 typedef struct {
   chpl_fn_p fp;
   void* arg;
+  void* arg_copy;
   chpl_bool countRunning;
   chpl_task_prvDataImpl_t chpl_data;
-} movedTaskWrapperDesc_t;
+} taskCallWrapperDesc_t;
 
 
 typedef struct lockReport {
@@ -135,7 +136,10 @@ static chpl_fn_p comm_task_fn;
 static void                    enqueue_task(task_pool_p, task_pool_p*);
 static void                    dequeue_task(task_pool_p);
 static void                    comm_task_wrapper(void*);
-static void                    movedTaskWrapper(void* a);
+static void                    taskCallBody(chpl_fn_p, void*, void*,
+                                            c_sublocid_t, chpl_bool,
+                                            int, int32_t);
+static void                    taskCallWrapper(void* a);
 static chpl_taskID_t           get_next_task_id(void);
 static thread_private_data_t*  get_thread_private_data(void);
 static task_pool_p             get_current_ptask(void);
@@ -669,45 +673,77 @@ void chpl_task_executeTasksInList(void** p_task_list_void) {
 }
 
 
-void chpl_task_startMovedTask(chpl_fn_p fp,
-                              void* a,
-                              c_sublocid_t subloc,
-                              chpl_taskID_t id,
-                              chpl_bool serial_state) {
-  movedTaskWrapperDesc_t* pmtwd;
+void chpl_task_taskCall(chpl_fn_p fp, void* arg, size_t arg_size,
+                        c_sublocid_t subloc,
+                        int lineno, int32_t filename) {
+  void *arg_copy = NULL;
+
+  if (arg != NULL) {
+    arg_copy = chpl_mem_allocMany(1, arg_size, CHPL_RT_MD_TASK_ARG, 0, 0);
+    memcpy(arg_copy, arg, arg_size);
+  }
+  taskCallBody(fp, NULL, arg_copy, subloc, false, lineno, filename);
+}
+
+
+static inline
+void taskCallBody(chpl_fn_p fp, void* arg, void* arg_copy,
+                  c_sublocid_t subloc, chpl_bool serial_state,
+                  int lineno, int32_t filename) {
+  taskCallWrapperDesc_t* ptcwd;
   chpl_task_prvDataImpl_t private = {
     .prvdata = { .serial_state = serial_state } };
 
-  assert(subloc == 0 || subloc == c_sublocid_any);
-  assert(id == chpl_nullTaskID);
-
-  pmtwd = (movedTaskWrapperDesc_t*)
-          chpl_mem_alloc(sizeof(*pmtwd),
+  ptcwd = (taskCallWrapperDesc_t*)
+          chpl_mem_alloc(sizeof(*ptcwd),
                          CHPL_RT_MD_THREAD_PRV_DATA,
                          0, 0);
-  *pmtwd = (movedTaskWrapperDesc_t)
-           { fp, a, canCountRunningTasks,
-             private };
+  *ptcwd = (taskCallWrapperDesc_t)
+    { fp, arg, arg_copy, canCountRunningTasks, private };
 
   // begin critical section
   chpl_thread_mutexLock(&threading_lock);
 
-  (void) add_to_task_pool(movedTaskWrapper, pmtwd, true, pmtwd->chpl_data,
-                          NULL, false, 0, CHPL_FILE_IDX_UNKNOWN);
+  (void) add_to_task_pool(taskCallWrapper, ptcwd, true, ptcwd->chpl_data,
+                          NULL, false, lineno, filename);
 
   // end critical section
   chpl_thread_mutexUnlock(&threading_lock);
 }
 
 
-static void movedTaskWrapper(void* a) {
-  movedTaskWrapperDesc_t* pmtwd = (movedTaskWrapperDesc_t*) a;
-  if (pmtwd->countRunning)
+static void
+taskCallWrapper(void* a) {
+  taskCallWrapperDesc_t* ptcwd = (taskCallWrapperDesc_t*) a;
+  if (ptcwd->countRunning)
     chpl_taskRunningCntInc(0, 0);
-  (pmtwd->fp)(pmtwd->arg);
-  if (pmtwd->countRunning)
+
+  if (ptcwd->arg_copy != NULL) {
+    (ptcwd->fp)(ptcwd->arg_copy);
+    chpl_mem_free(ptcwd->arg_copy, 0, 0);
+  } else
+    (ptcwd->fp)(ptcwd->arg);
+
+  if (ptcwd->countRunning)
     chpl_taskRunningCntDec(0, 0);
-  chpl_mem_free(pmtwd, 0, 0);
+  chpl_mem_free(ptcwd, 0, 0);
+}
+
+
+void chpl_task_startMovedTask(chpl_fn_p fp,
+                              void* arg,
+                              c_sublocid_t subloc,
+                              chpl_taskID_t id,
+                              chpl_bool serial_state) {
+  //
+  // For now the incoming task ID is simply dropped, though we check
+  // to make sure the caller wasn't expecting us to do otherwise.  If
+  // we someday make task IDs global we will need to be able to set
+  // the ID of this moved task.
+  //
+  assert(id == chpl_nullTaskID);
+
+  taskCallBody(fp, arg, NULL, subloc, serial_state, 0, CHPL_FILE_IDX_UNKNOWN);
 }
 
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -896,7 +896,7 @@ void chpl_task_taskCall(chpl_fn_p fp, void *arg, size_t arg_size,
 
     if (arg != NULL) {
         arg_copy = chpl_mem_allocMany(1, arg_size, CHPL_RT_MD_TASK_ARG, 0, 0);
-        memcpy(arg_copy, arg, arg_size);
+        chpl_memcpy(arg_copy, arg, arg_size);
     }
     taskCallBody(fp, NULL, arg_copy, subloc, false, lineno, filename);
 }


### PR DESCRIPTION
For chpl_executeOnNB()s that are network-local we've been (ab)using
chpl_comm_execute_on_NB() to initiate an asynchronous local task.  Here
we update the tasking layer interface to do this directly instead.

Specifically, we add chpl_task_taskCall() and chpl_task_taskCallFTable(),
which create tasks to call a pointed-to function or a function out of
chpl_ftable[], respectively.  The former is implemented in each of the
tasking layers, while the latter is just a thin shim in chpl-tasks.h.  As
part of doing this I also adjusted chpl_task_startMovedTask() so that it
and chpl_task_taskCall() share most of their code, since the two are
quite similar.  (In fact, when chpl_comm_execute_on_NB() was being used
to do asynchronous local calls chpl_task_startMovedTask() was the tool it
used to do so.)

With these available, I adjusted chpl_executeOnNB() in the flat and numa
locale models to use chpl_task_taskCallFTable() in the local, parallel
case.  While in that code I also did some cleanup, reordering an if-stmt
in numa so that it tested for local instead of nonlocal (more natural
and now matches flat), fixing white space here and there, and removing
some superfluous or incorrect comments.

I believe there is a performance improvement that could still be made in
this code.  executeOn body argument bundles are dynamically allocated by
the calling code, then freed by that code after the task creation
request is made to the runtime.  Because the bundle free() occurs right
away, in the executeOnNB case probably before the task actually runs,
the runtime has to make a copy of the bundle for the task to use.  If we
could change the compiler/runtime contract so that the emitted code
allocated the bundle and the runtime was responsible for freeing it, we
could save the extra allocate/copy/free in the executeOnNB case.