### PR TITLE
Fix failure to report ambigous value-version of a ref-pair

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3758,8 +3758,8 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
   // error.
   bool ambiguousRef = false;
   bool ambiguousValue = false;
-  if (refCandidates.n > 0 && !bestRef) ambiguousRef = true;
-  if (valueCandidates.n > 0 && !bestValue) ambiguousValue = true;
+  if (refCandidates.n > 1 && !bestRef) ambiguousRef = true;
+  if (valueCandidates.n > 1 && !bestValue) ambiguousValue = true;
   if (ambiguousRef || ambiguousValue) {
     bestValue = NULL;
     bestRef = NULL;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2617,9 +2617,9 @@ printResolutionErrorAmbiguous(
                      CallInfo* info) {
   CallExpr* call = userCall(info->call);
   if (!strcmp("this", info->name)) {
-    USR_FATAL(call, "ambiguous access of '%s' by '%s'",
-              toString(info->actuals.v[1]->type),
-              toString(info));
+    USR_FATAL_CONT(call, "ambiguous access of '%s' by '%s'",
+                   toString(info->actuals.v[1]->type),
+                   toString(info));
   } else {
     const char* entity = "call";
     if (!strncmp("_type_construct_", info->name, 16))
@@ -2631,25 +2631,26 @@ printResolutionErrorAmbiguous(
       str = astr(mod->name, ".", str);
     }
     USR_FATAL_CONT(call, "ambiguous %s '%s'", entity, str);
-    if (developer) {
-      for (int i = callStack.n-1; i>=0; i--) {
-        CallExpr* cs = callStack.v[i];
-        FnSymbol* f = cs->getFunction();
-        if (f->instantiatedFrom)
-          USR_PRINT(callStack.v[i], "  instantiated from %s", f->name);
-        else
-          break;
-      }
-    }
-    bool printed_one = false;
-    forv_Vec(FnSymbol, fn, candidates) {
-      USR_PRINT(fn, "%s %s",
-                printed_one ? "               " : "candidates are:",
-                toString(fn));
-      printed_one = true;
-    }
-    USR_STOP();
   }
+
+  if (developer) {
+    for (int i = callStack.n-1; i>=0; i--) {
+      CallExpr* cs = callStack.v[i];
+      FnSymbol* f = cs->getFunction();
+      if (f->instantiatedFrom)
+        USR_PRINT(callStack.v[i], "  instantiated from %s", f->name);
+      else
+        break;
+    }
+  }
+  bool printed_one = false;
+  forv_Vec(FnSymbol, fn, candidates) {
+    USR_PRINT(fn, "%s %s",
+              printed_one ? "               " : "candidates are:",
+              toString(fn));
+    printed_one = true;
+  }
+  USR_STOP();
 }
 
 static void

--- a/test/functions/ferguson/ref-return-intent-ambigous-ref.chpl
+++ b/test/functions/ferguson/ref-return-intent-ambigous-ref.chpl
@@ -1,0 +1,18 @@
+
+var global = 0;
+
+proc access(arg=4) ref {
+  return global;
+}
+
+
+proc access() ref {
+  return global;
+}
+
+proc access() {
+  return global;
+}
+
+var x = access();
+writeln(x);

--- a/test/functions/ferguson/ref-return-intent-ambigous-ref.good
+++ b/test/functions/ferguson/ref-return-intent-ambigous-ref.good
@@ -1,0 +1,3 @@
+ref-return-intent-ambigous-ref.chpl:17: error: ambiguous call 'access()'
+ref-return-intent-ambigous-ref.chpl:4: note: candidates are: access(arg = 4)
+ref-return-intent-ambigous-ref.chpl:9: note:                 access()

--- a/test/functions/ferguson/ref-return-intent-ambigous-value.chpl
+++ b/test/functions/ferguson/ref-return-intent-ambigous-value.chpl
@@ -1,0 +1,17 @@
+
+var global = 0;
+
+proc access() ref {
+  return global;
+}
+
+proc access() {
+  return global;
+}
+
+proc access() const ref {
+  return global;
+}
+
+var x = access();
+writeln(x);

--- a/test/functions/ferguson/ref-return-intent-ambigous-value.good
+++ b/test/functions/ferguson/ref-return-intent-ambigous-value.good
@@ -1,0 +1,3 @@
+ref-return-intent-ambigous-value.chpl:16: error: ambiguous call 'access()'
+ref-return-intent-ambigous-value.chpl:8: note: candidates are: access()
+ref-return-intent-ambigous-value.chpl:12: note:                 access()


### PR DESCRIPTION
The below code was not triggering an ambiguity error in function resolution due
to some problems with how the ref-pair support was initially implemented.

    var global = 0;
    proc access() ref { return global; }
    proc access() { return global; }
    proc access() const ref { return global; }

    var x = access();  // value version should be ambiguous
    writeln(x);

Instead, the ref version was being called (because disambiguateByMatch
was returning NULL for ambiguous but the code assumed it meant
no suitable function was found).

This PR fixes this problem. In order to do so, it separates the logic for
finding ref return and not-ref return candidates from disambiguateByMatch. The
problem with the disambiguateByMatch approach is that disambiguateByMatch
returns NULL for either

 * no matching candidates, or
 * ambiguity

Other function resolution code checks for ambiguity by inspecting the number
of candidates. So, this PR adds a function, splitCandidates, that separates the
candidates into ref and non-ref lists. Additionally, it carefully handles the
case when disambiguateByMatch returned NULL but either of these lists has > 0
elements.

Thanks to @cassella for pointing out this problem.