### PR TITLE
chpl-mode.el: require cl for emacs 24, at least up to 24.5

### DIFF
--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -36,6 +36,14 @@
 
 (require 'cc-mode)
 
+;; Work around "Symbol's function definition is void: set-difference"
+;; in emacs 24, at least through 24.5.  Per
+;; http://lists.gnu.org/archive/html/bug-gnu-emacs/2014-10/msg01175.html
+(eval-when-compile
+  (if (and (= emacs-major-version 24) (<= emacs-minor-version 5))
+      (require 'cl)))
+
+
 ;; These are only required at compile time to get the sources for the
 ;; language constants.  (The cc-fonts require and the font-lock
 ;; related constants could additionally be put inside an


### PR DESCRIPTION
Avoids the error;

  Symbol's function definition is void: set-difference

per
  http://lists.gnu.org/archive/html/bug-gnu-emacs/2014-10/msg01175.html

I tested only on emacs 24.5 and xemacs 21.4.