### PR TITLE
chpl-mode.el: Support nested block /* comments */

### DIFF
--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -43,6 +43,8 @@
   (if (and (= emacs-major-version 24) (<= emacs-minor-version 5))
       (require 'cl)))
 
+;; Need to exclude xemacs from some behavior
+(defvar running-xemacs (string-match "XEmacs\\|Lucid" emacs-version))
 
 ;; These are only required at compile time to get the sources for the
 ;; language constants.  (The cc-fonts require and the font-lock
@@ -344,6 +346,11 @@ need for `chpl-font-lock-extra-types'.")
 (or chpl-mode-syntax-table
     (setq chpl-mode-syntax-table
 	  (funcall (c-lang-const c-make-mode-syntax-table chpl))))
+
+;; Nested block comments -- add "n" to the syntax table entry for "*"
+;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-Flags.html#Syntax-Flags
+(if (not running-xemacs)
+    (modify-syntax-entry ?* ". 23n" chpl-mode-syntax-table))
 
 (defvar chpl-mode-abbrev-table nil
   "Abbreviation table used in chpl-mode buffers.")


### PR DESCRIPTION
Not for xemacs though -- it doesn't support this syntax-table syntax.

C-h s gives the following description of the effects of
(modify-syntax-entry ?* ". 23n") on the syntax-table entry for *

*           . 23n   which means: punctuation,
      is the second character of a comment-start sequence,
      is the first character of a comment-end sequence (nestable)

Tested on emacs 24.5.1, and doesn't break chpl-mode on xemacs 21.4.

This change is already present in github.com:russel/Emacs-Chapel-Mode