### PR TITLE
Reduce elegance-test problem size to prevent timeouts

### DIFF
--- a/test/studies/elegance/promotedOp.perfcompopts
+++ b/test/studies/elegance/promotedOp.perfcompopts
@@ -1,1 +1,1 @@
---set order=20000 --set iterations=5 --set correctness=false
+--set order=10000 --set iterations=3 --set correctness=false


### PR DESCRIPTION
For `promotedOp.chpl` which was timing out on `perf.brac.lnx`: 
* Reduced iterations 5->3 and order 20000->10000, reduce timeouts.

It puzzles me how this was timing out (runtime > 300 seconds) on performance runs. Locally, the performance test ran in 19 seconds. 

After these changes, the performance test runs locally in 7.5 seconds. Hopefully this is fast enough.