### PR TITLE
Basics of initialization chip

### DIFF
--- a/doc/chips/10.rst
+++ b/doc/chips/10.rst
@@ -1,3 +1,5 @@
+.. _initializers:
+
 Initializers
 ============
 

--- a/doc/chips/12.rst
+++ b/doc/chips/12.rst
@@ -1,0 +1,169 @@
+.. _initialization:
+
+Basics of Initialization
+========================
+
+Status:
+  Draft
+
+Authors:
+  Michael Ferguson
+
+Abstract
+--------
+
+A description of what constitutes initialization and the different kinds
+of initialization in Chapel programs for non-generic records and
+non-generic classes.
+
+Rationale
+---------
+
+This document provides common language for describing initialization
+and some basic understanding of when initialization occurs. While the
+current language specification covers these topics, this document was
+created as part of a group of CHIPs to do with improvements to
+initializaters and initialization. Thus, this document focuses on
+behaviors specific to the new design.
+
+This document provides background for :ref:`Initializers` and
+:ref:`record-copies`.
+
+Description
+-----------
+
+When a new Chapel variable is created, it is initialized. In other words,
+it is set to some initial state.
+
+In the discussion below, we will assume that `R` is a non-generic record
+and `C` is a non-generic class.
+
+
+Record Initialization
++++++++++++++++++++++
+
+This section applies to generic records.  Also, these examples are meant
+to be introductory. While these examples should be correct with respect
+to all planned ways to reduce unnecessary record copies, the details of
+these are discussed in other documents.
+
+
+.. code-block:: chapel
+
+  var x:R;
+
+`x` is automatically initialized by a call to `x.init()`.
+
+.. code-block:: chapel
+
+  var x:R = noinit;
+
+`x` is automatically initialized by a call to `x.init(noinit=true)`.
+
+.. code-block:: chapel
+
+  var x:R = new R(<args>);
+  // or, equivalently
+  var x = new R(<args>);
+
+`x` is initialized by a call to `x.init(<args>)`.
+
+.. code-block:: chapel
+
+  var x:R = ...;
+  var y:R = x;
+  ... uses of both x and y ...
+
+We say that `y` is `copy initialized` from `x`. Since `x` and `y` both
+exist after `y` is initialized and they are different record variables,
+they must not be observed to alias. That is, modifications to a field in
+`x` should not cause the corresponding field in `y` to change.
+
+Note that at the time of this writing, specific syntax for specifying how
+a record should be `copy initialized` is still under discussion.
+
+.. code-block:: chapel
+
+  record MyRecord {
+    var field:R;
+
+    proc init(const ref arg:R) {
+      field = arg;   // Note Here
+      super.init();
+    }
+  }
+
+This example shows field initialization. The statement `field = arg`
+causes `field` to be `copy initialized` from `arg`.
+
+.. code-block:: chapel
+
+  proc returnR() {
+    var ret = new R(<args>);
+    return ret;
+  }
+  var x:R = returnR();
+
+`x` is initialized to have the same value as `ret`. There are several
+possible mechanisms for how this can be accomplished, but `x` does not
+necessarily need to be `copy initialized` from `ret`. This case is
+discussed in more detail in :ref:`record-copies`.
+
+There are many other situations beyond the examples above in which `copy
+initialization` occurs. The document :ref:`record-copies` describes these
+in detail.
+
+.. code-block:: chapel
+
+  var x:R;
+  var y:R;
+  ...;
+  x = y;
+
+The statement `x = y` here is called assignment. It is different from
+initialization. It will be translated to a call to the `=` operator with
+the arguments `x` and `y`. Assignment is different from initialization
+because in assignment, the left-hand-side variable has already been
+initialized and is being set again.
+
+
+
+Class Initialization
+++++++++++++++++++++
+
+This section is a about non-generic classes.
+
+.. code-block:: chapel
+
+  var x:C;
+
+`x` is automatically initialized to `nil`.
+
+.. code-block:: chapel
+
+  var x:C = new C(<args>);
+  // or, equivalently
+  var x = new C(<args>);
+
+`x` is automatically initialized to the result of:
+
+ 1) allocating memory for a class instance of type `C`
+ 2) invoking `x.init(<args>)` to initialize that instance
+
+.. code-block:: chapel
+
+  var x:C = ...;
+  var y:C = x;
+
+`y` and `x` point to the same class instance. We can say that the
+variable `y` is initialized from the variable `x`. That initialization
+just amounts to copying a pointer value and no user-defined initializer
+is invoked.
+
+Related Documents
++++++++++++++++++
+
+ * :ref:`Initializers` describes how initializers can be specified
+ * :ref:`record-copies` describes exactly when copy or move
+   initialization occur.
+

--- a/doc/chips/13.rst
+++ b/doc/chips/13.rst
@@ -1,0 +1,26 @@
+.. _record-copies:
+
+Record Copying in Chapel
+========================
+
+Status:
+  Draft
+
+Authors:
+  Michael Ferguson
+
+Abstract
+--------
+
+A proposal for when Chapel will introduce record copy and move
+initialization.
+
+Rationale
+---------
+
+
+Description
+-----------
+
+Content forthcoming.
+

--- a/doc/chips/README.md
+++ b/doc/chips/README.md
@@ -3,6 +3,9 @@ Chapel Improvement Proposals (CHIPs)
 See the first CHIP for an overview.
 
 * [Chapel Improvement Proposals](1.rst)
+* [Initializers](10.rst)
+* [Basics of Initialization](12.rst)
+* [Record Copying in Chapel](13.rst)
 * [Constrained Generics](2.rst)
 * [ZeroMQ Integration](3.rst)
 * [Constructor Syntax and Semantics](4.rst)
@@ -11,5 +14,4 @@ See the first CHIP for an overview.
 * [Rules for inserting autoCopy](7.rst)
 * [Error Handling in Chapel](8.rst)
 * [Chapel Package Manager](9.rst)
-* [Initializers](10.rst)
 

--- a/util/devel/chips/update-readme.bash
+++ b/util/devel/chips/update-readme.bash
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 cat README.md.in > README.md
+
 for name in `ls -v [0-9]*.rst`
 do
   echo $name
-  title=`head -n 1 $name`
+  title=`head -n 10 $name | grep -e '^[A-Za-z]' | head -n 1`
   echo "* [$title]($name)" >> README.md
 done
 


### PR DESCRIPTION
Adds a basics of initialization chip. Content of that has been discussed
with @vasslitvinov @noakesmichael and @lydia-duncan.

Also adds a placeholder for the record copies CHIP, so that
cross-references to it can work.

Lastly, adjusts the readme-generation script to skip over a cross
reference target before the document title.
