### PR TITLE
Avoid creating a tuple for varargs in some cases

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -39,6 +39,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "type.h"
+#include "resolution.h"
 
 #include "AstToText.h"
 #include "AstVisitor.h"

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1466,6 +1466,7 @@ FnSymbol::FnSymbol(const char* initName) :
   codegenUniqueNum(1),
   doc(NULL),
   partialCopySource(NULL),
+  varargOldFormal(NULL),
   retSymbol(NULL)
 {
   substitutions.clear();
@@ -1694,6 +1695,7 @@ void FnSymbol::finalizeCopy(void) {
       /*
        * Iterate over the statements that have been added to the function body
        * and add them to the new body.
+       * (Added only if needTupleInBody - see handleSymExprInExpandVarArgs().)
        */
       for_alist_backward(node, varArgNodes->body) {
         this->body->insertAtHead(node->remove());
@@ -1767,6 +1769,15 @@ void FnSymbol::finalizeCopy(void) {
      * replacements.
      */
     update_symbols(this, map);
+
+    // Replace vararg formal if appropriate.
+    if (this->varargOldFormal) {
+      substituteVarargTupleRefs(this->body, this->varargNewFormals.size(),
+                                this->varargOldFormal, this->varargNewFormals);
+      // Done, clean up.
+      this->varargOldFormal = NULL;
+      this->varargNewFormals.clear(); // unless we want to keep these around?
+    }
 
     // Clean up book keeping information.
     this->partialCopyMap.clear();

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1695,7 +1695,6 @@ void FnSymbol::finalizeCopy(void) {
       /*
        * Iterate over the statements that have been added to the function body
        * and add them to the new body.
-       * (Added only if needTupleInBody - see handleSymExprInExpandVarArgs().)
        */
       for_alist_backward(node, varArgNodes->body) {
         this->body->insertAtHead(node->remove());
@@ -1776,7 +1775,7 @@ void FnSymbol::finalizeCopy(void) {
                                 this->varargOldFormal, this->varargNewFormals);
       // Done, clean up.
       this->varargOldFormal = NULL;
-      this->varargNewFormals.clear(); // unless we want to keep these around?
+      this->varargNewFormals.clear();
     }
 
     // Clean up book keeping information.

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -21,6 +21,7 @@
 #define _RESOLUTION_H_
 
 #include "baseAST.h"
+#include <vector>
 #include <map>
 
 class CallInfo;
@@ -47,6 +48,7 @@ const char* toString(CallInfo* info);
 const char* toString(FnSymbol* fn);
 
 void parseExplainFlag(char* flag, int* line, ModuleSymbol** module);
+void substituteVarargTupleRefs(BlockStmt* ast, int numArgs, ArgSymbol* formal, std::vector<ArgSymbol*>& varargFormals);
 
 FnSymbol* getTheIteratorFn(Symbol* ic);
 FnSymbol* getTheIteratorFn(CallExpr* call);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -591,9 +591,6 @@ const char* intentDescrString(IntentTag intent);
 // pass-by-reference intents are used.
 bool argMustUseCPtr(Type* t);
 
-void substituteVarargTupleRefs(BlockStmt* ast, int numArgs, ArgSymbol* formal,
-                               std::vector<ArgSymbol*>& varargFormals);
-
 extern bool localTempNames;
 
 extern HashMap<Immediate *, ImmHashFns, VarSymbol *> uniqueConstantsHash;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -355,7 +355,6 @@ class FnSymbol : public Symbol {
 
   // The following fields are used only when hasFlag(FLAG_PARTIAL_COPY)
   // to pass information from partialCopy() to finalizeCopy().
-  // This localized use suggests that they should be moved to a hashtable.
   /// Used to keep track of symbol substitutions during partial copying.
   SymbolMap partialCopyMap;
   /// Source of a partially copied function.

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -354,6 +354,8 @@ class FnSymbol : public Symbol {
   const char *doc;
 
   // The following fields are used only when hasFlag(FLAG_PARTIAL_COPY)
+  // to pass information from partialCopy() to finalizeCopy().
+  // This localized use suggests that they should be moved to a hashtable.
   /// Used to keep track of symbol substitutions during partial copying.
   SymbolMap partialCopyMap;
   /// Source of a partially copied function.

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -353,10 +353,16 @@ class FnSymbol : public Symbol {
   int codegenUniqueNum;
   const char *doc;
 
+  // The following fields are used only when hasFlag(FLAG_PARTIAL_COPY)
   /// Used to keep track of symbol substitutions during partial copying.
   SymbolMap partialCopyMap;
   /// Source of a partially copied function.
   FnSymbol* partialCopySource;
+  /// Vararg formal to be replaced with individual formals, or NULL.
+  ArgSymbol* varargOldFormal;
+  /// Individual formals to replace varargOldFormal.
+  std::vector<ArgSymbol*> varargNewFormals;
+
   /// Used to store the return symbol during partial copying.
   Symbol* retSymbol;
   /// Number of formals before tuple type constructor formals are added.
@@ -582,6 +588,9 @@ const char* intentDescrString(IntentTag intent);
 // Return true if the arg must use a C pointer whether or not
 // pass-by-reference intents are used.
 bool argMustUseCPtr(Type* t);
+
+void substituteVarargTupleRefs(BlockStmt* ast, int numArgs, ArgSymbol* formal,
+                               std::vector<ArgSymbol*>& varargFormals);
 
 extern bool localTempNames;
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1686,7 +1686,8 @@ static void replaceVarargAccess(CallExpr* parent, SymExpr* se,
 //
 // Is 'parent' the call 'se'.size?
 //
-static bool isVarargSizeExpr(SymExpr* se, CallExpr* parent) {
+static bool isVarargSizeExpr(SymExpr* se, CallExpr* parent)
+{
   if (parent->isNamed("size"))
     // Is 'parent' a method call?
     if (parent->numActuals() == 2)
@@ -1895,77 +1896,76 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
         }
       }
 
-     // odd indentation to avoid revision diffs on the body of this 'if'
-     if (needTupleInBody) {
+      if (needTupleInBody) {
 
-      // MDN 2016/02/01. Enable special handling for strings with blank intent
+        // MDN 2016/02/01. Enable special handling for strings with blank intent
 
-      // If the original formal is a string with blank intent then the
-      // new formals appear to be strings with blank intent.  However
-      // the resolver is about to update these to be const ref intent.
-      //
-      // Currently this will cause the tuple to appear to be a tuple
-      // ref(String) which is not supported.
-      //
-      // Insert local copies that can be used for the tuple
+        // If the original formal is a string with blank intent then the
+        // new formals appear to be strings with blank intent.  However
+        // the resolver is about to update these to be const ref intent.
+        //
+        // Currently this will cause the tuple to appear to be a tuple
+        // ref(String) which is not supported.
+        //
+        // Insert local copies that can be used for the tuple
 
-      if (isString(formal->type) && formal->intent == INTENT_BLANK) {
-        DefExpr* varDefn = new DefExpr(var);
-        Expr*    tail    = NULL;
+        if (isString(formal->type) && formal->intent == INTENT_BLANK) {
+          DefExpr* varDefn = new DefExpr(var);
+          Expr*    tail    = NULL;
 
-        // Insert the new locals
-        for (int i = 0; i < n; i++) {
-          const char* localName = astr("_e", istr(i + n), "_", formal->name);
-          VarSymbol*  local     = newTemp(localName, formal->type);
-          DefExpr*    defn      = new DefExpr(local);
+          // Insert the new locals
+          for (int i = 0; i < n; i++) {
+            const char* localName = astr("_e", istr(i + n), "_", formal->name);
+            VarSymbol*  local     = newTemp(localName, formal->type);
+            DefExpr*    defn      = new DefExpr(local);
 
-          if (tail == NULL)
-            workingFn->insertAtHead(defn);
-          else
-            tail->insertAfter(defn);
+            if (tail == NULL)
+              workingFn->insertAtHead(defn);
+            else
+              tail->insertAfter(defn);
 
-          tail = defn;
+            tail = defn;
+          }
+
+          // Insert the definition for the tuple
+          tail->insertAfter(varDefn);
+          tail = varDefn;
+
+          // Insert the copies from the blank-intent strings to the locals
+          // Update the arguments to the tuple call
+          for (int i = 1; i <= n; i++) {
+            DefExpr*  localDefn = toDefExpr(workingFn->body->body.get(i));
+            Symbol*   local     = localDefn->sym;
+            SymExpr*  localExpr = new SymExpr(local);
+
+            SymExpr*  tupleArg  = toSymExpr(tupleCall->get(i + 1));
+            SymExpr*  copyArg   = tupleArg->copy();
+
+            CallExpr* moveExpr  = new CallExpr(PRIM_MOVE, localExpr, copyArg);
+
+            tupleArg->var = local;
+
+            tail->insertAfter(moveExpr);
+            tail = moveExpr;
+          }
+
+          tail->insertAfter(new CallExpr(PRIM_MOVE, var, tupleCall));
+        } else {
+          workingFn->insertAtHead(new CallExpr(PRIM_MOVE, var, tupleCall));
+          workingFn->insertAtHead(new DefExpr(var));
         }
 
-        // Insert the definition for the tuple
-        tail->insertAfter(varDefn);
-        tail = varDefn;
-
-        // Insert the copies from the blank-intent strings to the locals
-        // Update the arguments to the tuple call
-        for (int i = 1; i <= n; i++) {
-          DefExpr*  localDefn = toDefExpr(workingFn->body->body.get(i));
-          Symbol*   local     = localDefn->sym;
-          SymExpr*  localExpr = new SymExpr(local);
-
-          SymExpr*  tupleArg  = toSymExpr(tupleCall->get(i + 1));
-          SymExpr*  copyArg   = tupleArg->copy();
-
-          CallExpr* moveExpr  = new CallExpr(PRIM_MOVE, localExpr, copyArg);
-
-          tupleArg->var = local;
-
-          tail->insertAfter(moveExpr);
-          tail = moveExpr;
+        if (workingFn->hasFlag(FLAG_PARTIAL_COPY)) {
+          // If this is a partial copy, store the mapping for substitution later.
+          workingFn->partialCopyMap.put(formal, var);
+        } else {
+          // Otherwise, do the substitution now.
+          subSymbol(workingFn->body, formal, var);
         }
-
-        tail->insertAfter(new CallExpr(PRIM_MOVE, var, tupleCall));
       } else {
-        workingFn->insertAtHead(new CallExpr(PRIM_MOVE, var, tupleCall));
-        workingFn->insertAtHead(new DefExpr(var));
+        // !needTupleInBody
+        substituteVarargTupleRefs(workingFn->body, n, formal, varargFormals);
       }
-
-      if (workingFn->hasFlag(FLAG_PARTIAL_COPY)) {
-        // If this is a partial copy, store the mapping for substitution later.
-        workingFn->partialCopyMap.put(formal, var);
-      } else {
-        // Otherwise, do the substitution now.
-        subSymbol(workingFn->body, formal, var);
-      }
-     } else {
-      // !needTupleInBody
-      substituteVarargTupleRefs(workingFn->body, n, formal, varargFormals);
-     }
 
       if (workingFn->where) {
         if (needVarArgTupleAsWhole(workingFn->where, n, formal)) {

--- a/test/functions/vass/resolution/param-detuple.chpl
+++ b/test/functions/vass/resolution/param-detuple.chpl
@@ -11,3 +11,4 @@ proc p2(param args...) {
 
 p2("a");
 p2("a","b");
+compilerAssert(false, "done", 2); // exercise stack-not-deep-enough warning

--- a/test/functions/vass/resolution/param-detuple.future
+++ b/test/functions/vass/resolution/param-detuple.future
@@ -1,5 +1,0 @@
-feature request: detuple of a param tuple to be a sequence of param values
-
-Right now it's a sequence of non-param values.
-This, e.g., does not let me pass param varargs through to other
-param varargs functions.

--- a/test/functions/vass/resolution/param-detuple.good
+++ b/test/functions/vass/resolution/param-detuple.good
@@ -2,3 +2,6 @@ param-detuple.chpl:8: In function 'p2':
 param-detuple.chpl:9: warning: param proc
 param-detuple.chpl:8: In function 'p2':
 param-detuple.chpl:9: warning: param proc
+$CHPL_HOME/modules/internal/ChapelBase.chpl:49: In function 'compilerError':
+$CHPL_HOME/modules/internal/ChapelBase.chpl:50: warning: compiler diagnostic depth value exceeds call stack depth
+param-detuple.chpl:14: error: assert failed - done

--- a/test/functions/vass/varargs-1.chpl
+++ b/test/functions/vass/varargs-1.chpl
@@ -1,0 +1,95 @@
+
+var A111: [1..2] int = 101, i222 = 102;
+
+proc show(tag, var11, var22) {
+  writeln(tag, " :  ", var11, "  ", var22);
+}
+
+proc main {
+  test_param("arg1 ", "arg2 ");
+  test_param_typed("arg1 ", "arg2 ");
+  test_param_queried("arg1 ", "arg2 ");
+  show(1000, A111, i222);
+  test_default(A111, 71);
+  test_const(A111, 72);
+  test_in(A111, i222);
+  test_const_in(A111, 73);
+  test_out(A111, i222);
+  test_inout(A111, i222);
+  test_ref(A111, i222);
+  test_const_ref(A111, i222);
+  show(9999, A111, i222);
+}
+
+proc test_param(param xxx...) {
+  compilerWarning(xxx(1));
+  compilerWarning(xxx(2));
+  compilerWarning((...xxx));
+  compilerWarning(xxx.size:string);
+  show(81, xxx(1), xxx(2));
+}
+
+proc test_param_typed(param xxx:string...) {
+  compilerWarning(xxx(1));
+  compilerWarning(xxx(2));
+  compilerWarning((...xxx));
+  compilerWarning(xxx.size:string);
+  show(82, xxx(1), xxx(2));
+}
+
+proc test_param_queried(param xxx...?nnn) {
+  compilerWarning(xxx(1));
+  compilerWarning(xxx(2));
+  compilerWarning((...xxx));
+  if nnn == xxx.size then
+    compilerWarning("YES!!!");
+  else
+    compilerWarning("noooo");
+  show(83, xxx(1), xxx(2));
+}
+
+proc test_default(xxx...) {
+  show(1001, xxx(1), xxx(2));
+  xxx(1) = 105;
+  show(1009, xxx(1), xxx(2));
+}
+
+proc test_const(const xxx...) {
+  show(2001, xxx(1), xxx(2));
+}
+
+proc test_in(in xxx...) {
+  show(3001, xxx(1), xxx(2));
+  xxx(1) = 301;
+  xxx(2) = 302;
+  show(3009, xxx(1), xxx(2));
+}
+
+proc test_const_in(const in xxx...) {
+  show(4001, xxx(1), xxx(2));
+}
+
+proc test_out(out xxx...) {
+  show(5001, xxx(1), xxx(2));
+  xxx(1) = 501;
+  xxx(2) = 502;
+  show(5009, xxx(1), xxx(2));
+}
+
+proc test_inout(inout xxx...) {
+  show(6001, xxx(1), xxx(2));
+  xxx(1) = 601;
+  xxx(2) = 602;
+  show(6009, xxx(1), xxx(2));
+}
+
+proc test_ref(ref xxx...) {
+  show(7001, xxx(1), xxx(2));
+  xxx(1) = 701;
+  xxx(2) = 702;
+  show(7009, xxx(1), xxx(2));
+}
+
+proc test_const_ref(const ref xxx...) {
+  show(8001, xxx(1), xxx(2));
+}

--- a/test/functions/vass/varargs-1.good
+++ b/test/functions/vass/varargs-1.good
@@ -1,0 +1,31 @@
+varargs-1.chpl:8: In function 'main':
+varargs-1.chpl:9: warning: arg1 
+varargs-1.chpl:9: warning: arg2 
+varargs-1.chpl:9: warning: arg1 arg2 
+varargs-1.chpl:9: warning: 2
+varargs-1.chpl:10: warning: arg1 
+varargs-1.chpl:10: warning: arg2 
+varargs-1.chpl:10: warning: arg1 arg2 
+varargs-1.chpl:10: warning: 2
+varargs-1.chpl:11: warning: arg1 
+varargs-1.chpl:11: warning: arg2 
+varargs-1.chpl:11: warning: arg1 arg2 
+varargs-1.chpl:11: warning: YES!!!
+81 :  arg1   arg2 
+82 :  arg1   arg2 
+83 :  arg1   arg2 
+1000 :  101 101  102
+1001 :  101 101  71
+1009 :  105 105  71
+2001 :  105 105  72
+3001 :  105 105  102
+3009 :  301 301  302
+4001 :  105 105  73
+5001 :  0 0  0
+5009 :  501 501  502
+6001 :  501 501  502
+6009 :  601 601  602
+7001 :  601 601  602
+7009 :  701 701  702
+8001 :  701 701  702
+9999 :  701 701  702

--- a/test/functions/vass/varargs-2.chpl
+++ b/test/functions/vass/varargs-2.chpl
@@ -1,0 +1,73 @@
+// Note there is a TODO in this test.
+// When it is done, update the .good.
+
+
+var A111: [1..2] int, i222 = 2222;
+
+proc showit(tag, var11, var22) {
+  writeln(tag, " :  ", var11, "  ", var22);
+}
+
+
+// these invoke showit()
+
+proc show_default(xxx...) {
+  xxx(1) = 4444;  // OK for an array
+  xxx(2) = 5555;  // error: can't assign to 'const'
+  showit(11, xxx(2), xxx(1));
+}
+
+proc show_const(const xxx...) {
+  xxx(1) = 4444;  // TODO: error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+  showit(12, xxx(2), xxx(1));
+}
+
+proc show_const_in(const in xxx...) {
+  xxx(1) = 4444;  // error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+  showit(13, xxx(2), xxx(1));
+}
+
+proc show_const_ref(const ref xxx...) {
+  xxx(1) = 4444;  // error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+  showit(14, xxx(2), xxx(1));
+}
+
+
+// these do not call showit()
+
+proc test_default(xxx...) {
+  xxx(1) = 4444;  // OK for an array
+  xxx(2) = 5555;  // error: can't assign to 'const'
+}
+
+proc test_const(const xxx...) {
+  xxx(1) = 4444;  // TODO: error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+}
+
+proc test_const_in(const in xxx...) {
+  xxx(1) = 4444;  // error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+}
+
+proc test_const_ref(const ref xxx...) {
+  xxx(1) = 4444;  // error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+}
+
+
+
+proc main {
+  show_default(A111, i222);
+  show_const(A111, i222);
+  show_const_in(A111, i222);
+  show_const_ref(A111, i222);
+
+  test_default(A111, i222);
+  test_const(A111, i222);
+  test_const_in(A111, i222);
+  test_const_ref(A111, i222);
+}

--- a/test/functions/vass/varargs-2.good
+++ b/test/functions/vass/varargs-2.good
@@ -1,0 +1,20 @@
+varargs-2.chpl:14: In function 'show_default':
+varargs-2.chpl:16: error: illegal lvalue in assignment
+varargs-2.chpl:20: In function 'show_const':
+varargs-2.chpl:22: error: illegal lvalue in assignment
+varargs-2.chpl:26: In function 'show_const_in':
+varargs-2.chpl:27: error: illegal lvalue in assignment
+varargs-2.chpl:28: error: illegal lvalue in assignment
+varargs-2.chpl:32: In function 'show_const_ref':
+varargs-2.chpl:33: error: illegal lvalue in assignment
+varargs-2.chpl:34: error: illegal lvalue in assignment
+varargs-2.chpl:41: In function 'test_default':
+varargs-2.chpl:43: error: illegal lvalue in assignment
+varargs-2.chpl:46: In function 'test_const':
+varargs-2.chpl:48: error: illegal lvalue in assignment
+varargs-2.chpl:51: In function 'test_const_in':
+varargs-2.chpl:52: error: illegal lvalue in assignment
+varargs-2.chpl:53: error: illegal lvalue in assignment
+varargs-2.chpl:56: In function 'test_const_ref':
+varargs-2.chpl:57: error: illegal lvalue in assignment
+varargs-2.chpl:58: error: illegal lvalue in assignment


### PR DESCRIPTION
WE USED TO

combine varargs into a tuple the first thing in a function.
E.g when this function:

  proc test(args...) {
    BODY;
  }

is invoked with two formals, the compiler instantiates it into:

  proc test(_e0_args, _e1_args) {
    var args = _build_tuple(2, _e0_args, _e1_args);
    BODY;
  }

Indeed the vararg tuple is created in the callee, not the caller.

WITH THIS COMMIT,

the compiler no longer inserts the _build_tuple() call or creates
the local 'args' tuple when:

(A) BODY does not need 'args' as a whole tuple (see below), and
(B) the "args..." formal's intent is not 'out' or 'inout'.

This results in simpler generated code. Also, as the primary motivation
for this change, if the args formal has a param or type intent, then
(...args) consists of params or types, resp. This latter was not the case
prior to this change.

(A) details: the compiler considers (A) to hold when the only uses
of 'args' in the body, if any, are these:

  (A1) (...args)           --> replaced with _e0_args, _e1_args
  (A2) args(i) for param i --> replaced with _e0_args or _e1_args
  (A3) args.size           --> replaced with 2

The replacements shown are for the test() example above.

(B) details: supporting out/inout intent is left as future work.
These intents require formal temps. So instead of the 'args' tuple
we'd have to create individual temps. Maybe this wouldn't be
much savings to begin with?

IMPLEMENTATION NOTES

When the function whose varargs are being instantiated
had FLAG_PARTIAL_COPY, the replacements needed to be done
separately. The necessary information is passed through
the fields I added on FnSymbol.

While there, I added a missing SET_LINENO and in a different
spot set a node's astloc manually, which is more lightweight
than SET_LINENO.

ALSO ADDED TESTS

that exercise varargs in various ways.