### PR TITLE
Add SKIPIF to check for available memory > 8GB

### DIFF
--- a/test/studies/prk/stencil/SKIPIF
+++ b/test/studies/prk/stencil/SKIPIF
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+# PRK stencil uses more memory than some testing machines have available.
+
+# We want to keep the problem size constant across single and multi-locale
+# runs, meaning there are strict memory restrictions for running single locale.
+
+
+$memRequiredInGB = 8;
+$memInGB = $memRequiredInGB;
+
+if ($ENV{CHPL_TEST_PERF} eq "on") {
+    $memfile = "/proc/meminfo";
+    if (-r $memfile) {
+      open MEMFILE, "$memfile" or die "can't open $memfile $!";
+      my @memLines = <MEMFILE>;
+      close (MEMFILE);
+
+      foreach my $line (@memLines) {
+        if ($line =~ m/MemTotal: (\s*)(\S*)/) {
+          $memInKB = "$2";
+          $memInGB = $memInKB / (1024 * 1024);
+        }
+      }
+    } else {
+        $platform = `$ENV{CHPL_HOME}/util/chplenv/chpl_platform.py --target`; chomp($platform);
+        if ($platform eq "darwin") {
+            $memInBytes = `sysctl -n hw.memsize`; chomp($memInBytes);
+            $memInGB = $memInBytes / (1024 * 1024 * 1024);
+        }
+    }
+}
+
+if ($memInGB < $memRequiredInGB) {
+    print("True\n");
+} else {
+    print("False\n");
+}
+


### PR DESCRIPTION
PRK stencil problem size is too great for older test machines with limited memory available. We want to keep the problem size constant across single/multi-locale testing, so rather than decrease the problem size, we are adding a `SKIPIF` script that was borrowed from the fasta-lines test (#2990) to ensure only machines with 8GB+ memory run the test.