### PR TITLE
Remove commented out line (and explanations) which has been skipped since 2012.

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1781,11 +1781,6 @@ static void change_method_into_constructor(FnSymbol* fn) {
 
   fn->name = ct->defaultInitializer->name;
   fn->addFlag(FLAG_CONSTRUCTOR);
-  // Hide the compiler-generated initializer
-  // which also serves as the default constructor.
-  // hilde sez: Try leaving this visible, but make it inferior in case of multiple matches
-  // (in disambiguateByMatch()).
-//  ct->defaultInitializer->addFlag(FLAG_INVISIBLE_FN);
 }
 
 // Note 1: Since param variables can only be of primitive or enumerated type,


### PR DESCRIPTION
We've lived without this line for four years, and I'm fairly certain what it was
trying to avoid is something that functionResolution handles in other ways by
now.  Also remove the comments related to it.