### PR TITLE
Replaced cp+rm with mv.

### DIFF
--- a/runtime/etc/Makefile.exe
+++ b/runtime/etc/Makefile.exe
@@ -35,8 +35,7 @@ ifneq ($(CHPL_MAKE_LAUNCHER),none)
 endif
 ifneq ($(TMPBINNAME),$(BINNAME))
 	rm -f $(BINNAME)
-	cp -p $(TMPBINNAME) $(BINNAME)
-	rm $(TMPBINNAME)
+	mv $(TMPBINNAME) $(BINNAME)
 endif
 
 FORCE:

--- a/runtime/etc/Makefile.launcher
+++ b/runtime/etc/Makefile.launcher
@@ -35,8 +35,7 @@ REAL_BINARY_NAME = $(BINNAME:%$(EXE_SUFFIX)=%)$(REAL_SUFFIX)
 
 all: FORCE
 	rm -f $(REAL_BINARY_NAME)
-	cp $(TMPBINNAME) $(REAL_BINARY_NAME)
-	rm $(TMPBINNAME)
+	mv $(TMPBINNAME) $(REAL_BINARY_NAME)
 	echo "#include \"chplcgfns.h\"" > $(LAUNCHER_SRC_NAME)
 	echo "#include \"config.h\"" >> $(LAUNCHER_SRC_NAME)
 	echo "#include \"_config.c\"" >> $(LAUNCHER_SRC_NAME)


### PR DESCRIPTION
Before this change, the last step in compiling the generated program was:

	cp -p $(TMPBINNAME) $(BINNAME)
	rm $(TMPBINNAME)

With this change, it is simply

	mv $(TMPBINNAME) $(BINNAME)

We are unclear why this wasn't done this way originally.
Our best guess is that we may have been observing file system issues
e.g. moving a file from /tmp to an NFS-mounted location.
If so, these issues are probably long gone.
So we want to give "mv" a try.

The 'cp' above was added, justifiably, in a2f68af2 aka r2110.
The 'rm' was added separately in 39b4e2d5 aka r6788.
At that time the makefile was called:  runtime/etc/Makefile.include

For the launcher, the cp+rm pair was added in 01eff56 aka r14292,
in that same makefile:  runtime/etc/Makefile.include
Note that 'cp' did not have the '-p' option.

Future work: an almost-last line in the current Makefile.launcher
does this:

	cp $(TMPBINNAME)_launcher $(TMPBINNAME)

Then the current Makefile.exe picks it up and (with this change)
does this:

	mv $(TMPBINNAME) $(BINNAME)

We could streamline these two into a single "mv".