### PR TITLE
Remove counter variable from outer for loop

### DIFF
--- a/test/studies/elegance/arrayAdd.chpl
+++ b/test/studies/elegance/arrayAdd.chpl
@@ -41,7 +41,7 @@ proc elegant(order, subOrder, iterations): real {
 
   t.start();
 
-  for i in 1..iterations {
+  for 1..iterations {
     for (i,j) in Dom {
       for k in 1..subOrder do
         Array[i, j] += i*j*subArray[k, k];
@@ -65,7 +65,7 @@ proc performant(order, subOrder, iterations): real {
 
   var tmp: real = 0;
 
-  for i in 1..iterations {
+  for 1..iterations {
     tmp = 0;
     for (i,j) in Dom {
       for k in 1..subOrder do

--- a/test/studies/elegance/promotedOp.chpl
+++ b/test/studies/elegance/promotedOp.chpl
@@ -50,7 +50,7 @@ proc performant(order, iterations): real {
 
   t.start();
 
-  for i in 1..iterations {
+  for 1..iterations {
     forall (i,j) in Dom {
       Array[i, j] += 1.0;
     }

--- a/test/studies/elegance/tuplesVSarrays.chpl
+++ b/test/studies/elegance/tuplesVSarrays.chpl
@@ -39,7 +39,7 @@ proc elegant(order, param subOrder, iterations): real {
 
   var total: real = 0;
 
-  for i in 1..iterations do
+  for 1..iterations do
     for (i,j) in Dom do
       for k in 1..subOrder do
         Array[i, j] += Array[i, j] * subArray[k, k];
@@ -65,7 +65,7 @@ proc performant(order, param subOrder, iterations): real {
 
   var total: real = 0;
 
-  for i in 1..iterations do
+  for 1..iterations do
     for (i,j) in Dom do
       for k in 1..subOrder do
         Array[i, j] += Array[i, j] * subArray[k][k];


### PR DESCRIPTION
Changed

```chapel
for i in 1..iterations { .. }
```

to

```chapel
for 1..iterations { .. }
```
to avoid redundant use of `i`
