### PR TITLE
UtilReplicatedVar.chpl: Kill unused rcCollectDomaim

### DIFF
--- a/modules/standard/UtilReplicatedVar.chpl
+++ b/modules/standard/UtilReplicatedVar.chpl
@@ -112,8 +112,6 @@ private const rcDomainMap  = new ReplicatedDist(rcLocales);
 /* Use this domain to declare a user-level replicated variable,
    as shown :ref:`above <basic-usage>` . */
 const rcDomain     = rcDomainBase dmapped new dmap(rcDomainMap);
-// todo - remove private from rcCollectDomaim?  our examples use LocaleSpace instead
-private const rcCollectDomaim = rcLocales.domain;
 private param _rcErr1 = " must be 'rcDomain' or 'rcDomainBase dmapped ReplicatedDist(an array of locales)'";
 
 private proc _rcTargetLocalesHelper(replicatedVar: [?D])


### PR DESCRIPTION
The variable name got my attention first, but since it's private to the module and also unreferenced in the whole tree, it seems safe to remove. 

Lightly tested, but I don't know how to target the module.