### PR TITLE
buildDefaultFunctions.cpp: fix enum typo

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -168,14 +168,14 @@ typedef enum {
   FIND_EITHER = 0,
   FIND_REF,
   FIND_NOT_REF
-} fuction_exists_kind_t;
+} function_exists_kind_t;
 
 static FnSymbol* function_exists(const char* name,
                                  int numFormals,
                                  Type* formalType1 = NULL,
                                  Type* formalType2 = NULL,
                                  Type* formalType3 = NULL,
-                                 fuction_exists_kind_t kind=FIND_EITHER)
+                                 function_exists_kind_t kind=FIND_EITHER)
 {
   switch(numFormals)
   {


### PR DESCRIPTION
Separate from the rest as this one changes code.

This changes the name of a (C++) enum.  The enum is defined and referenced only in this one .cpp file, so it seems safe to change.  Lightly tested.