### PR TITLE
Memory_Consistency.tex: fix typo in dangling, commented-out \ref

### DIFF
--- a/spec/Memory_Consistency.tex
+++ b/spec/Memory_Consistency.tex
@@ -728,7 +728,7 @@ for i in 1..n {
 %% \begin{itemize}
 
 %%  \item The load and store operations cannot be reordered across SC atomic
-%%  operations (see \ref{loads_stores_ordererd_with_atomics}).
+%%  operations (see \ref{loads_stores_ordered_with_atomics}).
 
 %%  \item Concurrent access by at least two tasks to the same memory location,
 %%  when at least one of the accesses is a store, is a race condition. In order to


### PR DESCRIPTION
I can't find the target (or attempted target) in the spec, commented out or not.