### PR TITLE
Add a 'spec' rule to the top level of Makefile.devel

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -36,6 +36,9 @@ always-build-man: FORCE
 	$(MAKE) man; \
 	fi
 
+spec: FORCE
+	cd spec && $(MAKE)
+
 test: FORCE
 	cd test && start_test
 


### PR DESCRIPTION
I keep feeling surprised that we don't support a 'make spec' rule
at the top-level directory for developers and couldn't come up
with any reason that we don't, so added one.