### PR TITLE
Automatically use ChapelStandard in outer user modules only

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2899,12 +2899,21 @@ void ModuleSymbol::accept(AstVisitor* visitor) {
 
 void ModuleSymbol::addDefaultUses() {
   if (modTag != MOD_INTERNAL) {
-    UnresolvedSymExpr* modRef = 0;
+    ModuleSymbol* parentModule = toModuleSymbol(this->defPoint->parentSymbol);
+    assert (parentModule != NULL);
 
-    SET_LINENO(this);
+    //
+    // Don't insert 'use ChapelStandard' for nested user modules.
+    // They should get their ChapelStandard symbols from their parent.
+    //
+    if (parentModule->modTag != MOD_USER) {
+      //      printf("Inserting use of ChapelStandard into %s\n", name);
 
-    modRef = new UnresolvedSymExpr("ChapelStandard");
-    block->insertAtHead(new UseStmt(modRef));
+      SET_LINENO(this);
+
+      UnresolvedSymExpr* modRef = new UnresolvedSymExpr("ChapelStandard");
+      block->insertAtHead(new UseStmt(modRef));
+    }
 
   // We don't currently have a good way to fetch the root module by name.
   // Insert it directly rather than by name

--- a/test/users/ferguson/histogram/reductionex_module3.future
+++ b/test/users/ferguson/histogram/reductionex_module3.future
@@ -1,7 +1,0 @@
-semantic: initializer depending on values at module use
-
-If I can fulfill module requirements at use time,
-why can't those requirements be used in an initializer?
-
-reductionex_module3.chpl:11: error: 'max' undeclared (first use this function)
-reductionex_module3.chpl:11: error: 'min' undeclared (first use this function)


### PR DESCRIPTION
Historically, we've inserted 'use ChapelStandard' into every user
module.  However, this seems inappropriate for nested user modules
because it causes them to favor symbols in internal/standard modules
over those in their parent module which seems unintuitive/ incorrect.
As a simple example, imagine that 'foo' is a symbol defined in an
internal/standard module that ChapelStandard references.  Consider:

    module M {
      // compiler-inserted 'use ChapelStandard;'

      var foo: int = 3;

      module Inner {
        // compiler-inserted 'use ChapelStandard;'

        writeln(foo);
      }
    }

Here, the writeln() of foo in the inner module would refer to the
'foo' defined by ChapelStandard rather than the obvious one in
the outer module.  Meanwhile if we only insert the use into the
outermost module:

    module M {
      // compiler-inserted 'use ChapelStandard;'

      var foo: int = 3;

      module Inner {
        writeln(foo);
      }
    }

The code works as you'd guess and other symbols within ChapelStandard
are also be available to Inner through its parent module's use of
ChapelStandard.

Retired a future that was failing for this reason.