### PR TITLE
Fix -b -t with FIFO+Gasnet on 1 locale

### DIFF
--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -379,7 +379,6 @@ void chpl_task_init(void) {
   if (blockreport) {
     progress_cnt = 0;
     chpl_thread_mutexInit(&block_report_lock);
-    initializeLockReportForThread();
   }
 
   if (blockreport || taskreport) {
@@ -404,6 +403,10 @@ static void* do_callMain(void* arg) {
 
   // make sure this thread has thread-private data.
   setup_main_thread_private_data();
+
+  // make sure that the lock report is set up.
+  if (blockreport)
+    initializeLockReportForThread();
 
   chpl_main();
   return NULL;


### PR DESCRIPTION
PR #3729 moved main into a new thread, so it could get
a stack allocated by the runtime. However, the support
for lock reporting was setting thread-local storage for
main, but not in the new thread running chpl_main.

This patch just moves the call to initializeLockReportForThread from
chpl_task_init to do_callMain.

This resolves errors with parallel/begin/stonea/reportsManyThreads.chpl among others.

Reviewed by @gbtitus - thanks!
passed full quickstart testing
passed full quickstart-gasnet testing
