### PR TITLE
spec/Memory_Consistency.tex: correct some authors' names

### DIFF
--- a/spec/Memory_Consistency.tex
+++ b/spec/Memory_Consistency.tex
@@ -754,7 +754,7 @@ for i in 1..n {
 % - use of SC atomics causes cache flush/invalidate)
 
 %Adve phd thesis
-%Scheurich and Dubios ScD87 and Sch89 - sufficient condition for sequential consistency.
+%Scheurich and Dubois ScD87 and Sch89 - sufficient condition for sequential consistency.
 %Collier proved .... writes in same order equivalent to atomically... thus system ... is sequential consistenc. Col84-92 and DuS90.
 %LHH91 also do it. All writes are seen in the same order by all processors -> sequentially consistent.
 %\url{http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.217.8176&rep=rep1&type=pdf}: An execution is consistent with respect to a consistency model... and these 3 invariants are sufficient to guarantee memory consistency defined in this way: Uniprocessor Ordering, Allowable Reordering, and Cache Coherence.
@@ -764,7 +764,7 @@ for i in 1..n {
 %  - Every processor issues memory ops in program order
 %  - Processor must wait for store to complete before issuing next memory operation
 %  - After load, issuing proc waits for load to complete, and store that produced value to complete before issuing next op
-%Scheurich Dubois and Brgiss 1988 Synchronization, Coherence, and Event Ordering in Multiprocessors.
+%Scheurich Dubois and Briggs 1988 Synchronization, Coherence, and Event Ordering in Multiprocessors.
 %\url{ftp://ftp.cs.wisc.edu/markhill/Papers/icpp90_seqcon.pdf} sufficient conditions for SC including the above.
 %\url{http://www.cs.berkeley.edu/~kubitron/cs252/lectures/lec20-sharedmemory3.pdf} has a picture of "exclusion zone" and argument for why processor atomics -> sequential consistency.
 


### PR DESCRIPTION
I looked up the papers and verified these spellings.