### PR TITLE
Test case and fix for an issue with closing a spawn chanel before wait

### DIFF
--- a/test/modules/standard/Spawn/spawn-popen2.chpl
+++ b/test/modules/standard/Spawn/spawn-popen2.chpl
@@ -1,0 +1,16 @@
+use Spawn;
+
+var sub = spawn(["cat", "test.txt"], stdout=PIPE);
+
+var line:string;
+while sub.stdout.readline(line) {
+  write("Got line: ", line);
+}
+
+sub.stdout.close();
+
+sub.wait();
+assert(sub.running == false);
+assert(sub.exit_status == 0);
+
+sub.close();

--- a/test/modules/standard/Spawn/spawn-popen2.good
+++ b/test/modules/standard/Spawn/spawn-popen2.good
@@ -1,0 +1,3 @@
+Got line: this is
+Got line: a test
+Got line: file.


### PR DESCRIPTION
Work on labelprob-twitter revealed an issues with one way of using the
Spawn module - which led to a core dump if the stdout channel was closed
before the subprocess.wait call.

This PR fixes the issue by ignoring closed channels in qio_proc_communicate.

Passed full local testing.
Reviewed by @lydia-duncan - thanks!