### PR TITLE
Fix bug in open when path is remote

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2366,7 +2366,7 @@ proc open(out error:syserr, path:string="", mode:iomode, hints:iohints=IOHINT_NO
        the above two lines. (2015-02-04, lydia)
 
     */
-    error = qio_file_open_access(ret._file_internal, path.c_str(), _modestring(mode).c_str(), hints, local_style);
+    error = qio_file_open_access(ret._file_internal, path.localize().c_str(), _modestring(mode).c_str(), hints, local_style);
   }
 
   return ret;

--- a/test/io/ferguson/open-remote-string.chpl
+++ b/test/io/ferguson/open-remote-string.chpl
@@ -1,0 +1,49 @@
+use FileSystem;
+use Path;
+use BlockDist;
+
+config const verbose = false;
+
+var files = ["open-remote-string-bar", "open-remote-string-baz"];
+
+var Space = files.domain dmapped Block(files.domain);
+var DistFiles:[Space] string = files;
+
+for f in files {
+  var openf = open(f, iomode.cw);
+  openf.close();
+}
+
+for f in DistFiles {
+  on f {
+    var from = f;
+    var base = basename(f);
+    var uname:c_string;
+    sys_getenv(c"USER", uname);
+    var to = "/tmp/" + uname + base;
+    if verbose then writeln("on ", here.id, " copying from ", from, " to ", to);
+    copy(from, to);
+    f = to;
+  }
+}
+
+for f in DistFiles {
+  on f {
+    if verbose then writeln("on ", here.id, " opening ", f);
+    var openf = open(f, iomode.r);
+    if verbose then writeln("on ", here.id, " done opening ", f);
+  }
+}
+
+for f in DistFiles {
+  on f {
+    if verbose then writeln("on ", here.id, " removing ", f);
+    remove(f);
+  }
+}
+
+for f in files {
+  remove(f);
+}
+
+


### PR DESCRIPTION
In open, path needed a .localize().c_str(). Includes a test that failed before.

Trivial and not reviewed.
Passed full fifo+GASNet testing.
Passed full local testing.