### PR TITLE
Remove a .future fixed by PR #3778

### DIFF
--- a/test/types/range/vass/explicit-conversion-index-type.future
+++ b/test/types/range/vass/explicit-conversion-index-type.future
@@ -1,7 +1,0 @@
-feature request: allow explicit conversion from range(int(64)) to range(int(32))
-
-Since we are allowed to have an explicit cast from int(64) to int(32),
-it only makes sense to allow the same thing for ranges.
-
-Alas, right now I get:
-  explicit-conversion-index-type.chpl:2: error: illegal cast from range(int(64),bounded,false) to range(int(32),bounded,false)


### PR DESCRIPTION
This future requested a cast from range(int(64)) to range(int(32)).  That cast
works now and the test passes.