### PR TITLE
Mandelbrot edits for shootout

### DIFF
--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -41,8 +41,9 @@ Future work / TODO
 The following are a list of planned improvements to Chapel and/or our
 implementations that would benefit the codes:
 
-mandelbrot.chpl:
-----------------
+
+mandelbrot.chpl
+---------------
 o extend the dynamic() iterators for ranges to support domains and
   collapse the two nested loops into a single loop over a 2D domain.
 
@@ -53,3 +54,9 @@ o add an 'unroll' capability to loops and use it to unroll the 'for
 o have the compiler automatically optimize writes to 'stdout' in
   serial code segments to avoid the need to manually get a lock-free
   channel to it.
+
+
+threadring.chpl
+---------------
+o map Chapel's sync vars more directly down to Qthreads' sync vars
+  to avoid space and time overheads

--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -34,3 +34,22 @@ be run in correctness or performance modes using the Chapel testing
 system (see $CHPL_HOME/util/sub_test).
 
 Note that chameneosredux.chpl has non-deterministic output.
+
+
+Future work / TODO
+==================
+The following are a list of planned improvements to Chapel and/or our
+implementations that would benefit the codes:
+
+mandelbrot.chpl:
+----------------
+o extend the dynamic() iterators for ranges to support domains and
+  collapse the two nested loops into a single loop over a 2D domain.
+
+o add an 'unroll' capability to loops and use it to unroll the 'for
+  off ...' loop which is about twice as fast with manual unrolling.
+  (we weren't willing to unroll it manually in this version)
+
+o have the compiler automatically optimize writes to 'stdout' in
+  serial code segments to avoid the need to manually get a lock-free
+  channel to it.

--- a/test/release/examples/benchmarks/shootout/mandelbrot.chpl
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.chpl
@@ -22,10 +22,10 @@ proc main() {
 
   var image : [ydim, xdim] eltType;            // the bitmap image
 
-  forall y in dynamic(ydim, chunkSize) {       // forall rows...
-    for xelt in xdim {                         //   forall column elements
+  forall y in dynamic(ydim, chunkSize) {       // for all rows...
+    for xelt in xdim {                         //   for each column element...
 
-      var mask = 0: eltType;                   // zero out the mask
+      var mask: eltType = 0;                   // zero out the mask
 
       for off in 0..#bitsPerElt {              // for each bit in the element
         const x = xelt*bitsPerElt + off;       // compute its logical location
@@ -34,7 +34,7 @@ proc main() {
         const Ci = 2.0*y/n - 1.0;              //   to compute with
         var Zr, Zi, Tr, Ti = 0.0;
 
-        for i in 1..maxIter {                  // for the max # of iterations
+        for 1..maxIter {                       // for the max # of iterations
           if (Tr + Ti > limit) then            // if we haven't converged
             break;
           
@@ -53,8 +53,10 @@ proc main() {
     }
   }
 
-  var f = openfd(1);                           // open a stdout file descriptor
-  var w = f.writer(iokind.native, locking=false);  // get a lock-free writer
+  //
+  // get a lock-free writer channel on 'stdout'
+  //
+  var w = openfd(1).writer(iokind.native, locking=false);
 
   w.writef("P4\n");                            // write the file header
   w.writef("%i %i\n", n, n);

--- a/test/release/examples/benchmarks/shootout/mandelbrot.chpl
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.chpl
@@ -1,8 +1,8 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 
-   contributed by Jacob Nelson
-   modified by Lydia Duncan, Brad Chamberlain, and Ben Harshbarger
+   contributed by Jacob Nelson, Lydia Duncan, Brad Chamberlain, and 
+   Ben Harshbarger
 */
 
 use DynamicIters;
@@ -18,9 +18,7 @@ type eltType = uint(bitsPerElt);   // the element type to store
 
 proc main() {
   const ydim = 0..#n,                          // the y dimension
-        xdim = 0..#divceilpos(n, bitsPerElt),  // the compacted x dimension
-        bitRange = 0..#bitsPerElt,             // the degree of compactness
-        iters = 1..maxIter;                    // the max # of iterations
+        xdim = 0..#divceilpos(n, bitsPerElt);  // the compacted x dimension
 
   var image : [ydim, xdim] eltType;            // the bitmap image
 
@@ -29,17 +27,16 @@ proc main() {
 
       var mask = 0: eltType;                   // zero out the mask
 
-      for off in bitRange {                    // for each bit in the element
+      for off in 0..#bitsPerElt {              // for each bit in the element
         const x = xelt*bitsPerElt + off;       // compute its logical location
 
         const Cr = 2.0*x/n - 1.5;              // floating point values
         const Ci = 2.0*y/n - 1.0;              //   to compute with
         var Zr, Zi, Tr, Ti = 0.0;
 
-        for i in iters {                       // for the max # of iterations
-          if (Tr + Ti > limit) {               // if we haven't converged
+        for i in 1..maxIter {                  // for the max # of iterations
+          if (Tr + Ti > limit) then            // if we haven't converged
             break;
-          }
           
           Zi = 2.0*Zr*Zi + Ci;                 // update floating point values
           Zr = Tr - Ti + Cr;
@@ -48,9 +45,8 @@ proc main() {
         }
 
         mask <<= 1;                            // shift the mask
-        if (Tr + Ti <= limit) {                // if below the limit,
+        if (Tr + Ti <= limit) then             // if below the limit,
           mask |= 0x1;                         // set the low bit to 1
-        }
       }
 
       image[y, xelt] = mask;                   // store the computed element

--- a/test/release/examples/benchmarks/shootout/mandelbrot.chpl
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.chpl
@@ -1,65 +1,66 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 
-   contributed by Jacob Nelson, Lydia Duncan, Brad Chamberlain, and 
-   Ben Harshbarger
+   contributed by Jacob Nelson, Lydia Duncan, Brad Chamberlain,
+   and Ben Harshbarger
+   derived from the GNU C version by Greg Buchholz
 */
 
 use DynamicIters;
 
-config const n = 200,              // the problem size
-             maxIter = 50,         // the maximum # of iterations
-             limit = 4.0,          // the limit before quitting
-             chunkSize = 1;        // the chunk size of the dynamic iterator
+config const n = 200,              // image size in pixels (n x n)
+             maxIter = 50,         // max # of iterations per pixel
+             limit = 4.0,          // per-pixel convergence limit
+             chunkSize = 1;        // dynamic iterator's chunk size
 
-param bitsPerElt = 8;              // the # of bits to store per element
-type eltType = uint(bitsPerElt);   // the element type to store
+param bitsPerElt = 8;              // # of bits to store per array element
+type eltType = uint(bitsPerElt);   // element type used to store the image
 
 
 proc main() {
-  const ydim = 0..#n,                          // the y dimension
+  const ydim = 0..#n,                          // the image's y dimension
         xdim = 0..#divceilpos(n, bitsPerElt);  // the compacted x dimension
 
-  var image : [ydim, xdim] eltType;            // the bitmap image
+  var image : [ydim, xdim] eltType;            // the compacted bitmap image
 
   forall y in dynamic(ydim, chunkSize) {       // for all rows...
     for xelt in xdim {                         //   for each column element...
 
-      var mask: eltType = 0;                   // zero out the mask
+      var buff: eltType;                       // a single-element pixel buffer
 
-      for off in 0..#bitsPerElt {              // for each bit in the element
-        const x = xelt*bitsPerElt + off;       // compute its logical location
+      for off in 0..#bitsPerElt {              // for each bit in the buffer
+        const x = xelt*bitsPerElt + off;       // compute its logical column
 
-        const Cr = 2.0*x/n - 1.5;              // floating point values
-        const Ci = 2.0*y/n - 1.0;              //   to compute with
-        var Zr, Zi, Tr, Ti = 0.0;
+        const Cr = 2.0*x/n - 1.5;              // the (x,y) pixel as a complex
+        const Ci = 2.0*y/n - 1.0;              //   (real, imag) value 'C'
+        var Zr, Zi, Tr, Ti = 0.0;              // 'complex' helper values
 
         for 1..maxIter {                       // for the max # of iterations
           if (Tr + Ti > limit) then            // if we haven't converged
             break;
           
-          Zi = 2.0*Zr*Zi + Ci;                 // update floating point values
+          Zi = 2.0*Zr*Zi + Ci;                 // update Z and T
           Zr = Tr - Ti + Cr;
           Tr = Zr**2;
           Ti = Zi**2;
         }
 
-        mask <<= 1;                            // shift the mask
-        if (Tr + Ti <= limit) then             // if below the limit,
-          mask |= 0x1;                         // set the low bit to 1
+        buff <<= 1;                            // shift the pixel buffer
+        if (Tr + Ti <= limit) then             // if 'C' is within the limit,
+          buff |= 0x1;                         //   turn the low pixel on
       }
 
-      image[y, xelt] = mask;                   // store the computed element
+      image[y, xelt] = buff;                   // store the pixel buffer
     }
   }
 
   //
-  // get a lock-free writer channel on 'stdout'
+  // Get a lock-free writer channel on 'stdout', write the file header,
+  // and the image array.
   //
   var w = openfd(1).writer(iokind.native, locking=false);
 
-  w.writef("P4\n");                            // write the file header
+  w.writef("P4\n");
   w.writef("%i %i\n", n, n);
-
-  w.write(image);                              // write out the image
+  w.write(image);
 }


### PR DESCRIPTION
[co-developed by and reviewed by members of the performance team]

Edits to mandelbrot to prep for the shootout.  Also added a "Next steps / TODOs" list to the README as a means of tracking other improvements to these benchmarks that we've discussed but haven't done yet.

Changes to mandelbrot include:

* eliminating use-once ranges, which should no longer hurt performance
* renamed 'mask' to 'buff' to better reflect its role
* tightened up file I/O slightly
* squashed out curly brackets for trivial single-line control flow elements
* updated comments to try and improve clarity, remove obvious statements
