### PR TITLE
Fix UserMapAssoc standalone iterator

### DIFF
--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -734,7 +734,7 @@ class UserMapAssocArr: BaseArr {
       yield i;
   }
 
-  iter these(param tag: iterKind, followThis) ref where tag == iterKind.standalone {
+  iter these(param tag: iterKind) ref where tag == iterKind.standalone {
     coforall locArr in locArrs do on locArr {
       // Forward to associative array standalone iterator
       for i in locArr.myElems._value.these(tag) {


### PR DESCRIPTION
I noticed an error that was preventing it from being called (extra arg).
Checked it is called with a writeln.

Trivial and not reviewed.
Tested with test/distributions/bradc/assoc and test/studies/labelprob with and without GASNet.