### PR TITLE
Remove record chpl_main_argument for --minimal-modules

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -497,10 +497,18 @@ static void build_chpl_entry_points() {
   // It invokes the user's code.
   //
   chpl_gen_main = new FnSymbol("chpl_gen_main");
-
-  ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "_arg", dtMainArgument);
-  chpl_gen_main->insertFormalAtTail(arg);
   chpl_gen_main->retType = dtInt[INT_SIZE_64];
+  ArgSymbol* arg = NULL;
+
+  if (dtMainArgument) {
+    arg = new ArgSymbol(INTENT_BLANK, "_arg", dtMainArgument);
+    chpl_gen_main->insertFormalAtTail(arg);
+  } else {
+    // Otherwise gatherWellKnownTypes() would have generated an error.
+    INT_ASSERT(fMinimalModules);
+    if (mainHasArgs)
+      USR_FATAL("main() has arguments while 'chpl_main_argument' is not declared");
+  }
 
   chpl_gen_main->cname = "chpl_gen_main";
   chpl_gen_main->addFlag(FLAG_EXPORT);  // chpl_gen_main is always exported.

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -1294,10 +1294,24 @@ codegen_config() {
   }
 }
 
+static void adjustGenMainArg() {
+  if (dtMainArgument)
+    return;
+  SET_LINENO(chpl_gen_main);
+  dtMainArgument = new AggregateType(AGGREGATE_RECORD);
+  TypeSymbol* ts = new TypeSymbol("chpl_main_argument", dtMainArgument);
+  ts->addFlag(FLAG_EXTERN);
+  chpl_gen_main->defPoint->insertBefore(new DefExpr(dtMainArgument->symbol));
+  ArgSymbol* arg = new ArgSymbol(INTENT_CONST_REF, "_arg", dtMainArgument);
+  chpl_gen_main->insertFormalAtTail(arg);
+}
+
 
 void codegen(void) {
   if (no_codegen)
     return;
+
+  adjustGenMainArg();
 
   if( fLLVMWideOpt ) {
     // --llvm-wide-opt is picky about other settings.

--- a/modules/minimal/internal/ChapelUtil.chpl
+++ b/modules/minimal/internal/ChapelUtil.chpl
@@ -22,16 +22,6 @@
 // Internal data structures module
 //
 module ChapelUtil {
-
-  pragma "no default functions"
-  extern record chpl_main_argument {
-  }
-
-  // required by resolveAutoCopies()
-  proc chpl__autoCopy(arg: chpl_main_argument) return arg;
-  proc chpl__autoDestroy(arg: chpl_main_argument) {}
-  
-
   //
   // These two are called from the emitted chpl_gen_main(), and
   // defined in the runtime.


### PR DESCRIPTION
This change makes minimal modules more minimal.

It was easy to have the compiler accomodate the absence of declaration
of chpl_main_argument - see the change in buildDefaultFunctions.cpp.

As a result, the generated C code defines chpl_gen_main() taking no arguments.
Which contradicts the prototype of chpl_gen_main() in the runtime.
To match that prototype, we create record chpl_main_argument
and add an appropriate argument to chpl_gen_main() right before codegen.