### PR TITLE
test/release/examples/benchmarks/shootout/README: two tweaks

### DIFF
--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -31,7 +31,8 @@ repository under the test/studies/shootout/ directory.
 
 The provided Makefile can be used to compile the programs, or they can
 be run in correctness or performance modes using the Chapel testing
-system (see $CHPL_HOME/util/start_test).
+system.  (See doc/developer/bestPractices/TestSystem.rst in the Chapel
+git repository: http://github.com/chapel-lang/chapel)
 
 Note that chameneosredux.chpl has non-deterministic output.
 

--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -20,7 +20,7 @@ At present, this directory contains the following codes:
     meteor-fast.chpl    : A less readable, but much faster version of meteor.
     nbody.chpl          : Performs an n-body simulation of the Jovian planets
     pidigits.chpl       : Computes digits of pi using GMP, if available
-    regexdna            : Performs DNA matching
+    regexdna.chpl       : Performs DNA matching
     spectralnorm.chpl   : Calculates the spectral norm of an infinite matrix
     threadring.chpl     : Passes a token between a large number of threads
 
@@ -31,7 +31,7 @@ repository under the test/studies/shootout/ directory.
 
 The provided Makefile can be used to compile the programs, or they can
 be run in correctness or performance modes using the Chapel testing
-system (see $CHPL_HOME/util/sub_test).
+system (see $CHPL_HOME/util/start_test).
 
 Note that chameneosredux.chpl has non-deterministic output.
 


### PR DESCRIPTION
List regexdna with the .chpl extension like all the others.

Reference start_test instead of sub_test.