### PR TITLE
Adjusted my future on negative reference count

### DIFF
--- a/test/distributions/vass/negative-ref-count-dmap.bad
+++ b/test/distributions/vass/negative-ref-count-dmap.bad
@@ -1,4 +1,3 @@
-77777777
-0
-88888888
-negative-ref-count-dmap.chpl:10: error: halt reached - domain reference count is negative!
+Invalid read of size 8
+Address xxx is 104 bytes inside a block of size 112 free'd
+test: bd1 dereference OK

--- a/test/distributions/vass/negative-ref-count-dmap.chpl
+++ b/test/distributions/vass/negative-ref-count-dmap.chpl
@@ -6,7 +6,11 @@ const d1 = {1..4};
 proc main() {
   var bd1 = new Block(d1);
   var dm1 = new dmap(bd1);
-  writeln(77777777);
-  writeln(for tl in bd1.targetLocales do tl.id);
-  writeln(88888888);
+
+  if bd1.pid >= -1 then  // dereference bd1, doesn't matter how
+    writeln("test: bd1 dereference OK");
+
+  // we want 'dm1' to wrap 'bd1' directoy
+  if bd1 == dm1._value then
+    writeln("test: bd1 wrap OK");
 }

--- a/test/distributions/vass/negative-ref-count-dmap.future
+++ b/test/distributions/vass/negative-ref-count-dmap.future
@@ -1,13 +1,17 @@
-bug: program crashes upon dmap() and for-expression
+bug: dmap(DMobject) duplicates+deallocates DMobject
 
-It is an uncommon pattern: dmap() followed by a 'for' expression
-on one of the fields.
+In this code:
 
-The test runs clean under valgrind, still producing the same
-negative-reference-count error.
+  var bd = new Block(...);
+  var dm = new dmap(bd);
 
-The error should be resolved once we eliminate reference counts.
-After that the test will still be useful IMO because it will still
-exercise proper allocation/deallocation of all objects involved.
+* We want dm to wrap bd directly.
 
-Once the test runs cleanly, we should remove the .skipif.
+* We want bd to remain live afterwards.
+
+Neither is hapenning now. Instead, new dmap(bd):
+
+* clones bd i.e. using .clone() and .dsiClone(), and
+
+* invokes autoDestroy on the original, which decrements
+its reference count; Since the ref cnt reaches 0, bd is deleted.

--- a/test/distributions/vass/negative-ref-count-dmap.good
+++ b/test/distributions/vass/negative-ref-count-dmap.good
@@ -1,3 +1,2 @@
-77777777
-0
-88888888
+test: bd1 dereference OK
+test: bd1 wrap OK

--- a/test/distributions/vass/negative-ref-count-dmap.prediff
+++ b/test/distributions/vass/negative-ref-count-dmap.prediff
@@ -1,0 +1,17 @@
+#!/bin/bash
+outfile=$2
+
+# preserve the full output
+mv $outfile $outfile.tmp
+
+# grep for specific items in valgrind output
+# 'head -2' is to keep only what comes from the first anticipated error
+# this should increase the determinism of the output, for .bad
+#
+grep -E 'Invalid read|Address 0x.* is' $outfile.tmp | head -2 \
+| sed 's@^.*Invalid read@Invalid read@; s@^.*Address .* is@Address xxx is@' \
+> $outfile
+
+grep ^test: $outfile.tmp >> $outfile
+
+rm $outfile.tmp

--- a/test/distributions/vass/negative-ref-count-dmap.skipif
+++ b/test/distributions/vass/negative-ref-count-dmap.skipif
@@ -1,12 +1,4 @@
-# This test may behaves differently under various configurations,
-# so test it under the default configuration only.
-# Should be OK with valgrind.
-#
-# Remove this .skipif once the test passes.
-#
-CHPL_COMM != none
-COMPOPTS <= --baseline
-COMPOPTS <= --no-local
-CHPL_TEST_PERF == on
-#CHPL_TEST_VGRND_EXE == on
-CHPL_TARGET_PLATFORM != linux64
+# run only under valgrind
+# otherwise the outcome will probably fluctuate
+# Remove this .skipif once the test works correctly.
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
Turns out that valgrind DOES report an error on my previous test.

Clarification: valgrind does not report error if CHPL_MEM is jemalloc and
there are no valgrind headers installed on the system. So need to run it
with CHPL_MEM=cstdlib or install the valgrind-devel package.

I adjusted the test accordingly, and simplified it too.

From the adjusted .future:

In this code:

  var bd = new Block(...);
  var dm = new dmap(bd);

* We want dm to wrap bd directly.

* We want bd to remain live afterwards.

Neither is hapenning now. Instead, new dmap(bd):

* clones bd i.e. using .clone() and .dsiClone(), and

* invokes autoDestroy on the original, which decrements
its reference count; Since the ref cnt reaches 0, bd is deleted.