### PR TITLE
Substring timeout

### DIFF
--- a/test/types/string/psahabu/perf/substring.chpl
+++ b/test/types/string/psahabu/perf/substring.chpl
@@ -23,7 +23,7 @@ if timing then tCount.stop();
 // replace
 var tReplace: Timer;
 if timing then tReplace.start();
-search.replace("ear", "hear");
+search.replace("searchsearchsearchsearch", "sea");
 if timing then tReplace.stop();
 
 if timing {


### PR DESCRIPTION
@bradcray, @benharsh:

substring was timing out on chap03 due to the length of the replace test. Shrunk that down by expanding the size of the search string.