### PR TITLE
Make promoted array assignments always be parallel

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3139,14 +3139,8 @@ module ChapelArray {
   }
 
   proc =(ref a: [], b: _desync(a.eltType)) {
-    if isRectangularArr(a) {
-      forall e in a do
-        e = b;
-    } else {
-      compilerWarning("whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)");
-      for e in a do
-        e = b;
-    }
+    forall e in a do
+      e = b;
   }
 
   /*

--- a/test/associative/bharshbarg/arrays/arraySetOps.good
+++ b/test/associative/bharshbarg/arrays/arraySetOps.good
@@ -1,3 +1,0 @@
-arraySetOps.chpl:12: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
-arraySetOps.chpl:13: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
-arraySetOps.chpl:14: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)

--- a/test/associative/bharshbarg/arrays/diffDomZip.good
+++ b/test/associative/bharshbarg/arrays/diffDomZip.good
@@ -1,2 +1,0 @@
-diffDomZip.chpl:44: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
-diffDomZip.chpl:45: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)

--- a/test/domains/sungeun/assoc/clear.bad
+++ b/test/domains/sungeun/assoc/clear.bad
@@ -1,4 +1,3 @@
-clear.chpl:7: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 (1, 1)(2, 1)(3, 1)(4, 1)(5, 1)(6, 1)(7, 1)(8, 1)(9, 1)(10, 1)
 (2, 1)(4, 1)(6, 1)(8, 1)(10, 1)
 (1, 1)(2, 2)(3, 1)(4, 2)(5, 1)(6, 2)(7, 1)(8, 2)(9, 1)(10, 2)

--- a/test/modules/standard/Sort/sungeun/sorty.good
+++ b/test/modules/standard/Sort/sungeun/sorty.good
@@ -1,15 +1,3 @@
-sorty.chpl:26: In function 'doSort':
-sorty.chpl:35: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
-sorty.chpl:26: In function 'doSort':
-sorty.chpl:35: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
-sorty.chpl:26: In function 'doSort':
-sorty.chpl:35: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
-sorty.chpl:26: In function 'doSort':
-sorty.chpl:35: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
-sorty.chpl:26: In function 'doSort':
-sorty.chpl:35: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
-sorty.chpl:26: In function 'doSort':
-sorty.chpl:35: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 BUBBLE Sort: SUCCESS
 BUBBLE Sort: SUCCESS
 BUBBLE Sort: SUCCESS

--- a/test/release/examples/primers/associative.good
+++ b/test/release/examples/primers/associative.good
@@ -1,6 +1,4 @@
 associative.chpl:72: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
-associative.chpl:145: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
-associative.chpl:203: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 associative.chpl:306: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 associative.chpl:307: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 associative.chpl:309: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)

--- a/test/studies/ssca2/test-rmatalt/nondet.good
+++ b/test/studies/ssca2/test-rmatalt/nondet.good
@@ -1,4 +1,3 @@
-../../../release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_execution_config_consts.chpl:42: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 ../../../release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl:97: In function 'rooted_heavy_subgraphs':
 ../../../release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl:152: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
 =========================================================

--- a/test/studies/ssca2/test-rmatalt/rmatalt.default.good
+++ b/test/studies/ssca2/test-rmatalt/rmatalt.default.good
@@ -1,4 +1,3 @@
-../../../release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_execution_config_consts.chpl:42: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 =========================================================
 Problem Dimensions
                    Scale: 6

--- a/test/studies/ssca2/test-rmatalt/rmatalt.graphIO.good
+++ b/test/studies/ssca2/test-rmatalt/rmatalt.graphIO.good
@@ -1,4 +1,3 @@
-../../../release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_execution_config_consts.chpl:42: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 =========================================================
 Problem Dimensions
                    Scale: 6

--- a/test/studies/ssca2/test-rmatalt/rmatalt.noNewEG.good
+++ b/test/studies/ssca2/test-rmatalt/rmatalt.noNewEG.good
@@ -1,4 +1,3 @@
-../../../release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_execution_config_consts.chpl:42: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 =========================================================
 Problem Dimensions
                    Scale: 6

--- a/test/studies/ssca2/test-rmatalt/rmatalt.noParEG.good
+++ b/test/studies/ssca2/test-rmatalt/rmatalt.noParEG.good
@@ -1,4 +1,3 @@
-../../../release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_execution_config_consts.chpl:42: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 =========================================================
 Problem Dimensions
                    Scale: 6

--- a/test/studies/ssca2/test-rmatalt/rmatalt.noParGC.good
+++ b/test/studies/ssca2/test-rmatalt/rmatalt.noParGC.good
@@ -1,4 +1,3 @@
-../../../release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_execution_config_consts.chpl:42: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 =========================================================
 Problem Dimensions
                    Scale: 6


### PR DESCRIPTION
Mike happened to have me look at this routine today and I couldn't see
any reason that we're (still) manually serializing non-rectangular array
assignments in the promoted assignment case, so I removed it and nothing
seemed to break or be the worse for the wear.  While it could be that some
array implementations may still not support parallel iteration, it
should be the array implementation that should warn about that (if anything
does), not a decision made at this high-level operation for all non-rectangular
arrays.