### PR TITLE
Fix failure to build hwloc when $CHPL_HOME contains an "@"

### DIFF
--- a/third-party/hwloc/README
+++ b/third-party/hwloc/README
@@ -9,3 +9,9 @@ convenience and was obtained from:
 
 Any Chapel issues that seem to be related to hwloc should be directed
 to the Chapel team at chapel-bugs@lists.sourceforge.net.
+
+In addition to the base 1.11.3 version, we have applied a modified
+patch taken from master in order fix a build issue when $CHPL_HOME
+contains an "@" symbol:
+
+  https://github.com/open-mpi/hwloc/commit/7526599

--- a/third-party/hwloc/hwloc-src/contrib/systemd/Makefile.am
+++ b/third-party/hwloc/hwloc-src/contrib/systemd/Makefile.am
@@ -1,4 +1,5 @@
 # Copyright © 2016 Inria.  All rights reserved.
+# Copyright © 2016 Université Bordeaux
 # See COPYING in top-level directory.
 
 # We can't use autoconf because we don't want $sbindir to be replaced with ${exec_prefix}/sbin
@@ -12,9 +13,9 @@ nodist_pkgdata_DATA = hwloc-dump-hwdata.service
 hwloc-dump-hwdata.service: hwloc-dump-hwdata.service.in Makefile
 	@echo Creating $@...
 	@ $(SED) \
-	  -e 's@#SBINDIR#@'$(sbindir)'@g' \
-	  -e 's@#RUNSTATEDIR#@'$(HWLOC_runstatedir)'@g' \
-	  -e 's@#RMPATH#@'$(RMPATH)'@g' \
+	  -e 's/#SBINDIR#/$(subst /,\/,$(sbindir))/g' \
+	  -e 's/#RUNSTATEDIR#/$(subst /,\/,$(HWLOC_runstatedir))/g' \
+	  -e 's/#RMPATH#/$(subst /,\/,$(RMPATH))/g' \
 	  > $@ < $<
 
 distclean-local:

--- a/third-party/hwloc/hwloc-src/contrib/systemd/Makefile.in
+++ b/third-party/hwloc/hwloc-src/contrib/systemd/Makefile.in
@@ -579,9 +579,9 @@ uninstall-am: uninstall-nodist_pkgdataDATA
 @HWLOC_HAVE_LINUX_TRUE@hwloc-dump-hwdata.service: hwloc-dump-hwdata.service.in Makefile
 @HWLOC_HAVE_LINUX_TRUE@	@echo Creating $@...
 @HWLOC_HAVE_LINUX_TRUE@	@ $(SED) \
-@HWLOC_HAVE_LINUX_TRUE@	  -e 's@#SBINDIR#@'$(sbindir)'@g' \
-@HWLOC_HAVE_LINUX_TRUE@	  -e 's@#RUNSTATEDIR#@'$(HWLOC_runstatedir)'@g' \
-@HWLOC_HAVE_LINUX_TRUE@	  -e 's@#RMPATH#@'$(RMPATH)'@g' \
+@HWLOC_HAVE_LINUX_TRUE@	  -e 's/#SBINDIR#/$(subst /,\/,$(sbindir))/g' \
+@HWLOC_HAVE_LINUX_TRUE@	  -e 's/#RUNSTATEDIR#/$(subst /,\/,$(HWLOC_runstatedir))/g' \
+@HWLOC_HAVE_LINUX_TRUE@	  -e 's/#RMPATH#/$(subst /,\/,$(RMPATH))/g' \
 @HWLOC_HAVE_LINUX_TRUE@	  > $@ < $<
 
 @HWLOC_HAVE_LINUX_TRUE@distclean-local:

--- a/third-party/hwloc/hwloc-src/utils/hwloc/Makefile.am
+++ b/third-party/hwloc/hwloc-src/utils/hwloc/Makefile.am
@@ -1,5 +1,5 @@
 # Copyright © 2009-2016 Inria.  All rights reserved.
-# Copyright © 2009-2012, 2014 Université Bordeaux
+# Copyright © 2009-2012, 2014, 2016 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 #
 # See COPYING in top-level directory.
@@ -125,7 +125,7 @@ endif HWLOC_HAVE_LINUX
 	@ $(SED) -e 's/#PACKAGE_NAME#/@PACKAGE_NAME@/g' \
 	  -e 's/#PACKAGE_VERSION#/@PACKAGE_VERSION@/g' \
 	  -e 's/#HWLOC_DATE#/@HWLOC_RELEASE_DATE@/g' \
-	  -e 's@#RUNSTATEDIR#@'$(HWLOC_runstatedir)'@g' \
+	  -e 's/#RUNSTATEDIR#/$(subst /,\/,$(HWLOC_runstatedir))/g' \
 	  > $@ < $<
 
 .3in.3:

--- a/third-party/hwloc/hwloc-src/utils/hwloc/Makefile.in
+++ b/third-party/hwloc/hwloc-src/utils/hwloc/Makefile.in
@@ -1581,7 +1581,7 @@ uninstall-man: uninstall-man1 uninstall-man7
 	@ $(SED) -e 's/#PACKAGE_NAME#/@PACKAGE_NAME@/g' \
 	  -e 's/#PACKAGE_VERSION#/@PACKAGE_VERSION@/g' \
 	  -e 's/#HWLOC_DATE#/@HWLOC_RELEASE_DATE@/g' \
-	  -e 's@#RUNSTATEDIR#@'$(HWLOC_runstatedir)'@g' \
+	  -e 's/#RUNSTATEDIR#/$(subst /,\/,$(HWLOC_runstatedir))/g' \
 	  > $@ < $<
 
 .3in.3:


### PR DESCRIPTION
A commit in hwloc 1.11.3 prevented the docs from installing correctly if the
installation directory included an "@". This is because a sed command used "@"
as a delimiter. See https://github.com/open-mpi/hwloc/issues/187 for more info.

This caused occasional build failures for our smoke tests because Jenkins uses
"@{num}" to give concurrent builds unique build directories.

This bug was fixed in hwloc master, so this pulls in a slightly modified
version of that patch and applies it to the generated Makefile.in files as
well.
