### PR TITLE
Modules typos

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -278,7 +278,7 @@ class BlockCyclic : BaseDist {
     // the number of locales in that dimension times the blocksize.
     // I think this is more akin to what cyclic does.  So the
     // current test is shallower, indicating whether they were
-    // paramterized the same, but not whether they distribute
+    // parameterized the same, but not whether they distribute
     // the same.
     //
     return (this.lowIdx == that.lowIdx &&

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -28,7 +28,7 @@
 //   LocBlockArr : local array class (per-locale instances)
 //
 // When a distribution, domain, or array class instance is created, a
-// correponding local class instance is created on each locale that is
+// corresponding local class instance is created on each locale that is
 // mapped to by the distribution.
 //
 
@@ -730,7 +730,7 @@ proc Block.dsiCreateRankChangeDist(param newRank: int, args) {
 
   for param i in 1..rank {
     if isCollapsedDimension(args(i)) {
-      // set indicies that are out of bounds to the bounding box low or high.
+      // set indices that are out of bounds to the bounding box low or high.
       collapsedBbox(i) = if args(i) < boundingBox.dim(i).low then boundingBox.dim(i).low else if args(i) > boundingBox.dim(i).high then boundingBox.dim(i).high else args(i);
       collapsedLocs(i) = collapsedLocInd(i);
     } else {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -1218,7 +1218,7 @@ proc CyclicArr.doiBulkTransferToDR(Barg)
         const sa = chpl__tuplify(B.dom.dsiStride); //return a tuple
         
         //r2 is the domain to refer the elements of A in locale j
-        //r1 is the domain to refer the correspondig elements of B
+        //r1 is the domain to refer the corresponding elements of B
         var r1,r2: rank * range(idxType = el,stridable = true);
         r2=inters.dims();
         //In the case that the number of elements in dimension t for r1 and r2

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -105,7 +105,7 @@ the mapping is obtained using the dimension specifier:
 
 The following code declares a domain ``D`` distributed
 using a 2D Dimensional distribution that
-replicates over 2 locales (when available) in the first dimemsion
+replicates over 2 locales (when available) in the first dimension
 and distributes using block-cyclic distribution in the second dimension.
 
   .. code-block:: chapel
@@ -481,7 +481,7 @@ proc DimensionalDist2D.dsiPrivatize(privatizeData) {
   _traceddd(this, ".dsiPrivatize on ", here.id);
 
   // ensure we get a local copy of targetLocales
-  // todo - provide the following as utilty functions (for domains, arrays)
+  // todo - provide the following as utility functions (for domains, arrays)
   const pdTargetLocales = privatizeData(1);
   const privTargetIds: domain(pdTargetLocales.domain.rank,
                               pdTargetLocales.domain.idxType,

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -27,7 +27,7 @@
 //   LocSparseBlockArr : local array class (per-locale instances)
 //
 // When a distribution, domain, or array class instance is created, a
-// correponding local class instance is created on each locale that is
+// corresponding local class instance is created on each locale that is
 // mapped to by the distribution.
 //
 
@@ -461,7 +461,7 @@ proc SparseBlock.dsiCreateRankChangeDist(param newRank: int, args) {
 
   for param i in 1..rank {
     if isCollapsedDimension(args(i)) {
-      // set indicies that are out of bounds to the bounding box low or high.
+      // set indices that are out of bounds to the bounding box low or high.
       collapsedBbox(i) = if args(i) < boundingBox.dim(i).low then boundingBox.dim(i).low else if args(i) > boundingBox.dim(i).high then boundingBox.dim(i).high else args(i);
       collapsedLocs(i) = collapsedLocInd(i);
     } else {

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -28,7 +28,7 @@
 //   LocStencilArr : local array class (per-locale instances)
 //
 // When a distribution, domain, or array class instance is created, a
-// correponding local class instance is created on each locale that is
+// corresponding local class instance is created on each locale that is
 // mapped to by the distribution.
 //
 
@@ -691,7 +691,7 @@ proc Stencil.dsiCreateRankChangeDist(param newRank: int, args) {
 
   for param i in 1..rank {
     if isCollapsedDimension(args(i)) {
-      // set indicies that are out of bounds to the bounding box low or high.
+      // set indices that are out of bounds to the bounding box low or high.
       collapsedBbox(i) = if args(i) < boundingBox.dim(i).low then boundingBox.dim(i).low else if args(i) > boundingBox.dim(i).high then boundingBox.dim(i).high else args(i);
       collapsedLocs(i) = collapsedLocInd(i);
     } else {

--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -387,7 +387,7 @@ on each locale, then starts over:
  // the pair (locNo(j), storageOff(j)) is unique for each integer j
  storageOff(i) = cycNo(i) * blockSize + locOff(i)
 
-Advdanced: compress the storage based on the above advanced property,
+Advanced: compress the storage based on the above advanced property,
 which implies that:
  the pair (locNo(i), storageOff(i) div |wSt|) is unique
  for each 'i' - member of 'whole'.
@@ -418,7 +418,7 @@ to stay the same throughout the life of a domain descriptor.
 (This is so that our storage indices remain consistent - which is
 useful to implement Chapel's preservation of array contents upon
 domain assignments.)
-This implies that the same cycAdj should accomodate wLo for any
+This implies that the same cycAdj should accommodate wLo for any
 domain bounds that can be assigned to our domain descriptor.
 That may not be convenient in practice.
 */

--- a/modules/internal/AtomicsCommon.chpl
+++ b/modules/internal/AtomicsCommon.chpl
@@ -32,7 +32,7 @@ module AtomicsCommon {
       // Note CHPL_CACHE_REMOTE activates more complicated behavior
       // only when the cache for remote data is enabled; it's possible
       // that the more complicated behavior would benefit single-locale
-      // situations as well but curently our atomics implementation doesn't
+      // situations as well but currently our atomics implementation doesn't
       // do anything with the order argument (except for when the cache
       // for remote data is enabled).
       if CHPL_CACHE_REMOTE then _cnt.add(cnt, order=memory_order_relaxed);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2150,7 +2150,7 @@ module ChapelArray {
       return this[this.domain.high];
     }
 
-    /* Return a range that is grown or shrunk from r to accomodate 'r2' */
+    /* Return a range that is grown or shrunk from r to accommodate 'r2' */
     pragma "no doc"
     inline proc resizeAllocRange(r: range, r2: range, factor=arrayAsVecGrowthFactor, param direction=1, param grow=1) {
       // This should only be called for 1-dimensional arrays

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -759,7 +759,7 @@ module ChapelBase {
 
   // This function is called once by the initiating task.  No on
   // statement needed, because the task should be running on the same
-  // locale as the sync/cofall/cobegin was initiated on and thus the
+  // locale as the sync/coforall/cobegin was initiated on and thus the
   // same locale on which the object is allocated.
   //
   // TODO: 'taskCnt' can sometimes be local even if 'i' has to be remote.
@@ -799,7 +799,7 @@ module ChapelBase {
       e.taskCnt.add(1, memory_order_release);
     } else {
       // note that this on statement does not have the usual
-      // remote memory fence becaues of pragma "no remote memory fence"
+      // remote memory fence because of pragma "no remote memory fence"
       // above. So we do an acquire fence before it.
       chpl_rmem_consist_fence(memory_order_release);
       on e {
@@ -1545,7 +1545,7 @@ module ChapelBase {
   inline proc _defaultOf(type t) param where t == imag return 0.0i;
   pragma "no doc"
   inline proc _defaultOf(type t) where (isImagType(t) && t != imag) return 0.0i:t;
-  // Also, complexes cannot yet be parametized
+  // Also, complexes cannot yet be parameterized
   pragma "no doc"
   inline proc _defaultOf(type t): t where (isComplexType(t)) {
     var ret:t = noinit;

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -753,7 +753,7 @@ module ChapelIO {
   // Convert 'x' to a string just the way it would be written out.
   //
   // This is marked as compiler generated so it doesn't take precedence over
-  // genereated casts for types like enums
+  // generated casts for types like enums
   //
   // This version only applies to non-primitive types
   // (primitive types should support :string directly)

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -144,7 +144,7 @@ module ChapelLocale {
 
     /*
       :proc:`numCores` is a deprecated predecessor to :proc:`numPUs`,
-      equivalant to `numPUs(logical=true, accessible=true)`.  It will
+      equivalent to `numPUs(logical=true, accessible=true)`.  It will
       be removed after Chapel 1.13 is released.
      */
     proc numCores: int {
@@ -337,7 +337,7 @@ module ChapelLocale {
   pragma "no doc"
   class AbstractRootLocale : locale {
     // These functions are used to establish values for Locales[] and
-    // LocaleSpace -- an array of locales and its correponding domain
+    // LocaleSpace -- an array of locales and its corresponding domain
     // which are used as the default set of targetLocales in many
     // distributions.
     proc getDefaultLocaleSpace() {

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -75,7 +75,7 @@ module ChapelReduce {
     var value: chpl__sumType(eltType);
 
     // Rely on the default value of the desired type.
-    // Todo: is this efficnent when that is an array?
+    // Todo: is this efficient when that is an array?
     proc identity {
       var x: chpl__sumType(eltType); return x;
     }

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -51,7 +51,7 @@ module ChapelSyncvar {
     //
     // The following types are OK for full empty types (sync/single)
     // because they represent a single logical value.  (Note that for
-    // the class it's the referenece to the object that has full/empty
+    // the class it's the reference to the object that has full/empty
     // semantics.  Note that this includes the internal type
     // chpl_taskID_t in order to keep parallel/taskPar/sungeun/private.chpl
     // working, but this does not seem to be more broadly necessary.

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -29,7 +29,7 @@ Besides the functions defined here, the Chapel Language specification
 defines other operations available on tuples: indexing, iteration,
 assignment, and unary, binary, and relational operators.
 
-The following method is also availble:
+The following method is also available:
 
   .. code-block:: chapel
 

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -362,7 +362,7 @@ module DefaultAssociative {
           halt("Requested capacity (", numKeys, ") exceeds maximum size");
         }
 
-        //Changing underlying strucure, time for locking
+        //Changing underlying structure, time for locking
         if parSafe then lockTable();
         if entries > 0 {
           // Slow path: back up required

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -263,7 +263,7 @@ module DefaultRectangular {
         // Make sure we don't use more sublocales than the numbers of
         // tasksPerLocale requested
         const numSublocTasks = min(numSublocs, dptpl);
-        // For serial tasks, we will only have a singel chunk
+        // For serial tasks, we will only have a single chunk
         const (numChunks, parDim) = if __primitive("task_get_serial") then
                                     (1, -1) else
                                     _computeChunkStuff(numSublocTasks,
@@ -471,7 +471,7 @@ module DefaultRectangular {
     proc dsiDim(d : int)
       return ranges(d);
   
-    // optional, is this necesary? probably not now that
+    // optional, is this necessary? probably not now that
     // homogeneous tuples are implemented as C vectors.
     proc dsiDim(param d : int)
       return ranges(d);
@@ -1412,8 +1412,8 @@ module DefaultRectangular {
   Data needed to use strided copy of data:
     + Stridelevels: the number of stride level (not really the number of dimensions because:
        - Stridelevels < rank if we can aggregate several dimensions due to they are consecutive 
-           -- for exameple, whole rows --
-       - Stridelevels == rank if there is a "by X" whith X>1 in the range description for 
+           -- for example, whole rows --
+       - Stridelevels == rank if there is a "by X" with X>1 in the range description for
            the rightmost dimension)
     + srcCount: slice size in each dimension for the source array. srcCount[0] should be the number of bytes of contiguous data in the rightmost dimension.
     + dstCount: slice size in each dimension for the destination array. dstCount[0] should be the number of bytes of contiguous data in the rightmost dimension.
@@ -1473,7 +1473,7 @@ module DefaultRectangular {
     //  stridelevels =1
     //  srcCount = (1,50) //In B you read 1 element 50 times
     //  (srcStride=(2) = distance between 1 element and the next one)
-    //  dstCount = (5,10) //In A you write a chunk of 5 elments 10
+    //  dstCount = (5,10) //In A you write a chunk of 5 elements 10
     //  times (dstStride=(10) distance between 1 chunk and the next one)
     
     
@@ -1503,9 +1503,9 @@ module DefaultRectangular {
     var dstStride, srcStride: [1..rank] size_t;
     /*When the source and destination arrays have different sizes 
       (example: A[1..10,1..10] and B[1..20,1..20]), the count arrays obtained are different,
-      so we have to calculate the minimun count array */
+      so we have to calculate the minimum count array */
     //Note that we use equal function equal instead of dstCount==srcCount due to the latter fails
-    //The same for the array assigment (using assing function instead of srcCount=dstCount)
+    //The same for the array assignment (using assign function instead of srcCount=dstCount)
     
     if !bulkCommEqual(dstCount, srcCount, rank+1) //For different size arrays
     {
@@ -1603,7 +1603,7 @@ module DefaultRectangular {
       const dest = A.data;
       const src = B.data;
   
-      //We are in a locale that doesn't store neither A nor B so we need to copy the auxiliarry
+      //We are in a locale that doesn't store neither A nor B so we need to copy the auxiliary
       //arrays to the locale that hosts A. This should translate into some more gets...
       const countAux=count.safeCast(size_t);
       const srcstrides=srcStride.safeCast(size_t);
@@ -1639,8 +1639,8 @@ module DefaultRectangular {
   /* This function returns stridelevels for the default rectangular array.
     + Stridelevels: the number of stride level (not really the number of dimensions because:
        - Stridelevels < rank if we can aggregate several dimensions due to they are consecutive 
-           -- for exameple, whole rows --
-       - Stridelevels == rank if there is a "by X" whith X>1 in the range description for 
+           -- for example, whole rows --
+       - Stridelevels == rank if there is a "by X" with X>1 in the range description for
            the rightmost dimension)*/
   proc DefaultRectangularArr.computeBulkStrideLevels(rankcomp):int(32) where rank == 1
   {//To understand the blk(1)==1 condition,
@@ -1653,7 +1653,7 @@ module DefaultRectangular {
   //Case 1:  
   //  var A: [1..4,1..4,1..4] real; A[1..4,3..4,1..4 by 2] 
   // --> In dimension 3 there is stride, because the elements are not
-  //     consecutives, so stridelevels +=1
+  //     consecutive, so stridelevels +=1
   //More in test/optimizations/bulkcomm/alberto/2dDRtoBDTest.chpl (example 8)
   
   //Case 2:
@@ -1728,7 +1728,7 @@ module DefaultRectangular {
   //    var A: [1..4,1..4,1..4] real; A[1..4,4..4,1..4 by 3] 
   //      --> There is only 1 element in dimension 2, so it's possible to 
   //        join to dimension 1, and the value of count[3] will be the number 
-  //        of elements in dimension 2 x number of elements in dimesion 1 (1 x 4).
+  //        of elements in dimension 2 x number of elements in dimension 1 (1 x 4).
   //More in test/optimizations/bulkcomms/alberto/3dAgTestStride.chpl (example 6 and 7)
   proc DefaultRectangularArr.computeBulkCount(stridelevels:int(32), rankcomp, aux = false):(rank+1)*size_t where rank >1
   {
@@ -1851,7 +1851,7 @@ module DefaultRectangular {
   
   /* This function checks if the stride in dimension 'x' is the same as the distance
   between the last element in dimension 'x' and  the first in dimension 'x-1'.
-  If the distances are equal, we can aggregate these two dimmensions. 
+  If the distances are equal, we can aggregate these two dimensions.
   Example: 
   array A, the domain is D=[1..6, 1..6, 1..6]
   Let's A[1..6 by 2, 1..6, 1..6 by 2], then, checkStrideDistance(3) returns true, 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -423,7 +423,7 @@ module DefaultSparse {
     }
 
     proc dsiTargetLocales() {
-      compilerError("targetLocales is unsuppported by sparse domains");
+      compilerError("targetLocales is unsupported by sparse domains");
     }
 
     proc dsiHasSingleLocalSubdomain() param return true;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1038,7 +1038,7 @@ module String {
     /*
      Checks if all the characters in the string are digits (0-9).
 
-      :returns: * `true`  -- when the characters are ditits.
+      :returns: * `true`  -- when the characters are digits.
                 * `false` -- otherwise
      */
     proc isDigit() : bool {

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -392,7 +392,7 @@ proc file.perform():bool {
     err = chpl_curl_perform(this._file_internal);
   }
 
-  if err then ioerror(err, "in file.peform()");
+  if err then ioerror(err, "in file.perform()");
   return true;
 }
 

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -112,7 +112,7 @@ module FFTW {
   // TODO: Can we have the plan_dft() routine below take in native
   // Chapel types without changing the external C constants from
   // type c_int?  Probably given that Chapel's int will be >=
-  // C's int for the forseeable future.  See also the TODO above
+  // C's int for the foreseeable future.  See also the TODO above
   // about whether we'd want to represent those constants using
   // more native Chapel types anyway.
 
@@ -382,7 +382,7 @@ module FFTW {
 
   // Direction flags
 
-  /* Request a forward transform (i.e., use a negative exponent in the tranform). */
+  /* Request a forward transform (i.e., use a negative exponent in the transform). */
   extern const FFTW_FORWARD : c_int;
   /* Request a backward transform (i.e., use a positive exponent in the transform). */
   extern const FFTW_BACKWARD : c_int;

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -411,7 +411,7 @@ proc hdfsChapelConnect(path: string, port: int): hdfsChapelFileSystem {
   return ret;
 }
 
-/* Diconnect from the configured HDFS filesystem on each locale */
+/* Disconnect from the configured HDFS filesystem on each locale */
 proc hdfsChapelFileSystem.hdfsChapelDisconnect() {
   forall loc in Locales {
     on loc {
@@ -468,7 +468,7 @@ proc hdfsChapelFile.hdfsReader(param kind=iokind.dynamic, param locking=true, st
   return rcLocal(this.files).reader(kind, locking, start, end, hints);
 }
 
-// ------------- End mulitlocale ---------------
+// ------------- End multilocale ---------------
 
 pragma "no doc"
 record hdfsChapelFile_local {

--- a/modules/packages/LinearAlgebraJama.chpl
+++ b/modules/packages/LinearAlgebraJama.chpl
@@ -1262,7 +1262,7 @@ class EigenvalueDecomposition {
    and a permutation vector piv of length m so that A(piv,:) = L*U.
    If m < n, then L is m-by-m and U is m-by-n.
 
-   The LU decompostion with pivoting always exists, even if the matrix is
+   The LU decomposition with pivoting always exists, even if the matrix is
    singular, so the constructor will never fail.  The primary use of the
    LU decomposition is in the solution of square systems of simultaneous
    linear equations.  This will fail if isNonsingular() returns false.
@@ -1487,7 +1487,7 @@ class LUDecomposition {
 
 /* Generate identity matrix
      m    Number of rows.
-     n    Number of colums.
+     n    Number of columns.
      returns An m-by-n matrix with ones on the diagonal and zeros elsewhere.
 */
 
@@ -1549,7 +1549,7 @@ class Matrix {
 
    /* Construct an m-by-n matrix of zeros. 
         m    Number of rows.
-        n    Number of colums.
+        n    Number of columns.
    */
 
    proc Matrix (m:int, n: int) {
@@ -1560,7 +1560,7 @@ class Matrix {
 
    /* Construct an m-by-n constant matrix.
         m    Number of rows.
-        n    Number of colums.
+        n    Number of columns.
         s    Fill the matrix with this scalar value.
    */
 
@@ -1606,7 +1606,7 @@ class Matrix {
    /* Construct a matrix quickly without checking arguments.
         A    Two-dimensional array of doubles.
         m    Number of rows.
-        n    Number of colums.
+        n    Number of columns.
    */
 
    proc Matrix (A:[?aDom] real, m:int, n:int) where aDom.rank == 2 {
@@ -2239,7 +2239,7 @@ class Matrix {
 
    /* Generate matrix with random elements
    m    Number of rows.
-   n    Number of colums.
+   n    Number of columns.
    return     An m-by-n matrix with uniformly distributed random elements.
    */
 
@@ -2274,7 +2274,7 @@ proc random (m, n:int) {
    orthogonal matrix Q and an n-by-n upper triangular matrix R so that
    A = Q*R.
 
-   The QR decompostion always exists, even if the matrix does not have
+   The QR decomposition always exists, even if the matrix does not have
    full rank, so the constructor will never fail.  The primary use of the
    QR decomposition is in the least squares solution of nonsquare systems
    of simultaneous linear equations.  This will fail if isFullRank()
@@ -2493,7 +2493,7 @@ class QRDecomposition {
    The singular values, sigma[k] = S[k,k], are ordered so that
    sigma[0] >= sigma[1] >= ... >= sigma[n-1].
    
-   The singular value decompostion always exists, so the constructor will
+   The singular value decomposition always exists, so the constructor will
    never fail.  The matrix condition number and the effective numerical
    rank can be computed from this decomposition.
 */

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -32,7 +32,7 @@ routines ::
 since all of these are built around user-defined handlers, that we support.
 
 .. note::
-  #. Pointer arguments are written as `ref` areguments, so no casting to a ``c_ptr``
+  #. Pointer arguments are written as `ref` arguments, so no casting to a ``c_ptr``
      is necessary.
   #. An exception to the above is if the C prototype names the argument ``array_of_*``,
      in which case we write it using an array form.

--- a/modules/packages/Norm.chpl
+++ b/modules/packages/Norm.chpl
@@ -88,7 +88,7 @@ proc norm(x: [?D], p: normType) where x.rank == 2 {
 }
 
 // this module doesn't implement norms for > 2D arrays, so generate
-// a compile-timem error if the user tries to call one
+// a compile-time error if the user tries to call one
 pragma "no doc"
 proc norm(x: [], p: normType) where x.rank > 2 {
   compilerError("Norms not implemented for array ranks > 2D");

--- a/modules/packages/RecordParser.chpl
+++ b/modules/packages/RecordParser.chpl
@@ -145,7 +145,7 @@ class RecordReader {
      this RecordReader.
 
      The created regular expression will search for
-     ``<fieldName1> <spaces> <vieldValue1> <spaces>``
+     ``<fieldName1> <spaces> <fieldValue1> <spaces>``
   */
   proc createRegexp() {
     // This is a VERY loose regex, and therefore could lead to errors unless the

--- a/modules/standard/Buffers.chpl
+++ b/modules/standard/Buffers.chpl
@@ -560,7 +560,7 @@ module Buffers {
     return new buffer_range(this.start(), this.end());
   }
 
-  /* Advance a :record:`buffer_iterator` to the next contigous
+  /* Advance a :record:`buffer_iterator` to the next contiguous
      memory region stored therein
 
      :arg it: the buffer iterator to advance
@@ -573,7 +573,7 @@ module Buffers {
     }
   }
 
-  /* Advance a :record:`buffer_iterator` to the previous contigous
+  /* Advance a :record:`buffer_iterator` to the previous contiguous
      memory region stored therein
 
      :arg it: the buffer iterator to advance

--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -199,7 +199,7 @@ where tag == iterKind.leader
   if c.length == 0 then halt("The range is empty");
   if nTasks == 1 then {
     if debugDynamicIters then
-      writeln("Guided Iterator: serial execution because there is not enoguh work");
+      writeln("Guided Iterator: serial execution because there is not enough work");
     yield (remain,); 
   }
 
@@ -383,7 +383,7 @@ where tag == iterKind.leader
         if debugDynamicIters then 
           writeln("Entering at Stealing phase in tid ", tid," with victim ", victim, " using method of Stealing ", methodStealing);
 
-        // Perform the spliting at the victim remaining range
+        // Perform the splitting at the victim remaining range
 
         if methodStealing == Method.RoundRobin {
           if moreLocalWork[victim] then {

--- a/modules/standard/Error.chpl
+++ b/modules/standard/Error.chpl
@@ -67,7 +67,7 @@ proc quote_string(s:string, len:ssize_t) {
 }
 
 /* Halt with a useful message if there was an error. Do nothing if the error
-   argument does not indicate an error occured. The error message printed
+   argument does not indicate an error occurred. The error message printed
    when halting will describe the error passed and msg will be appended to it.
 
    :arg error: the error object
@@ -85,7 +85,7 @@ proc ioerror(error:syserr, msg:string)
 }
 
 /* Halt with a useful message if there was an error. Do nothing if the error
-   argument does not indicate an error occured. The error message printed
+   argument does not indicate an error occurred. The error message printed
    when halting will describe the error passed and msg will be appended to it,
    along with the path related to the error (for example, the path to a file
    which could not be opened).
@@ -106,7 +106,7 @@ proc ioerror(error:syserr, msg:string, path:string)
 }
 
 /* Halt with a useful message if there was an error. Do nothing if the error
-   argument does not indicate an error occured. The error message printed
+   argument does not indicate an error occurred. The error message printed
    when halting will describe the error passed and msg will be appended to it,
    along with the path and file offset related to the error. For example, this
    routine might indicate a file format error at a particular location.

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -193,7 +193,7 @@ proc chmod(out error: syserr, name: string, mode: int) {
    Will halt with an error message if one is detected
 
    :arg name: The name of the file or directory whose permissions should be
-              alterred.
+              altered.
    :type name: `string`
    :arg mode: The permissions desired for the file or directory in question.
               See description of :const:`S_IRUSR`, for instance, for potential
@@ -1090,7 +1090,7 @@ proc mkdir(name: string, mode: int = 0o777, parents: bool=false) {
 pragma "no doc"
 proc moveDir(out error: syserr, src: string, dest: string) {
   var destExists = exists(error, dest);
-  // Did some error occurred in checking the existance of dest, perhaps a
+  // Did some error occur in checking the existence of dest, perhaps a
   // permissions error?  If so, return.
   if (error != ENOERR) then return;
 
@@ -1104,7 +1104,7 @@ proc moveDir(out error: syserr, src: string, dest: string) {
     if (aFile) {
       // dest is a file, we can't move src within it!
       error = ENOTDIR;
-      // Note: Python gives EEXISTS in this case, but I think ENOTDIR is
+      // Note: Python gives EEXIST in this case, but I think ENOTDIR is
       // clearer.
     } else if (aDir) {
       if (sameFile(src, dest)) {

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -30,7 +30,7 @@ Multiple Precision Arithmetic Library) module in Chapel.  It should be
 considered incomplete in that (a) only a subset of the full GMP interface is
 supported, and (b) the performance is currently lacking due to extraneous
 copies in the Chapel code that have not yet been optimized away.  If there is
-sufficient interest, this protype can be expanded to support the full GMP
+sufficient interest, this prototype can be expanded to support the full GMP
 interface and performance.
 
 This prototype GMP module has been used to implement a port of the standard GMP
@@ -173,7 +173,7 @@ module GMP {
   extern const mp_bits_per_limb: c_int;
 
   /* All these external functions are ref, which may
-     seem suprising. They are that way because identity
+     seem surprising. They are that way because identity
      matters and they may get reallocated otherwise;
      ref is currently the only way to avoid that.
    
@@ -456,9 +456,9 @@ module GMP {
     The checks are controlled by the compiler options ``--[no-]cast-checks``,
     ``--fast``, etc.
 
-    TODO: When a Chapel will not safely cast to a C type, it would be better to
-    promte the Chapel value to a BigInt, then run the operation on that
-    BigInt. This would make the BigInt interface consistent across all
+    TODO: When a Chapel type will not safely cast to a C type, it would be
+    better to promote the Chapel value to a BigInt, then run the operation on
+    that BigInt. This would make the BigInt interface consistent across all
     platforms (already true today) _and_ always work regardless of platform
     (not true today).
    */

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -219,12 +219,12 @@ more details on the situation in which this kind of data race can occur.
   conditions on channel buffers. In particular, the problem comes up for
   programs that make:
 
-   * conncurrent operations on multiple channels that operate on overlapping
+   * concurrent operations on multiple channels that operate on overlapping
      regions of a file
    * where at least one of the overlapping channels is a writing channel
    * and where data could be stored more than one of the overlapping channel's
      buffers at the same time (ie, write and read ordering are not enforced
-     through :proc:`channel.flush` and other mean such as sync variabless).
+     through :proc:`channel.flush` and other mean such as sync variables).
 
   Note that it is possible in some cases to create a :record:`file` that does
   not allow multiple channels at different offsets. Channels created on such
@@ -409,7 +409,7 @@ Overview of Format Strings
 In a manner similar to C's 'printf' and 'scanf', the IO package includes
 :proc:`channel.writef` and :proc:`channel.readf` functions. These functions take
 in a format string and some arguments. The :proc:`string.format` method is also
-available and is loosly equivalent to C's 'sprintf'. For example, one might do:
+available and is loosely equivalent to C's 'sprintf'. For example, one might do:
 
 .. code-block:: chapel
 
@@ -469,7 +469,7 @@ Generic Numeric Conversions
 
   In all cases, the output is padded on the left to the total length
   of the conversion specifier (6 in this example).  The output
-  can be longer, when needed to accomodate the number.
+  can be longer, when needed to accommodate the number.
 
 ``%{##}``
   integral value padded out to 2 digits. Also works with real, imaginary
@@ -582,7 +582,7 @@ Real Conversions
 ``%6r``
  as with ``%r`` but padded on the left to 6 columns (ie right-justified)
 ``%-6r``
- as with ``%r`` but padded on the right to 6 columns (ie left-justfied)
+ as with ``%r`` but padded on the right to 6 columns (ie left-justified)
 ``%.4r``
  as with ``%r`` but with 4 significant digits
 ``%.*r``
@@ -610,7 +610,7 @@ Real Conversions
 ``%Er``
  like %er but with the 'e' in uppercase, e.g. ``8.2E-23``
 ``%.4er``
- exponential notiation with 4 digits after the period, e.g. ``8.2000e-23``
+ exponential notation with 4 digits after the period, e.g. ``8.2000e-23``
 
 ``%xer``
  hexadecimal number using p to mark exponent e.g. ``6c.3f7p-2a``
@@ -1344,7 +1344,7 @@ proc stringStyleExactLen(len:int(64)) {
 
 /*
   This method returns the appropriate :record:`iostyle` ``str_style`` value
-  to indicate a string format where string data is preceeded by a variable-byte
+  to indicate a string format where string data is preceded by a variable-byte
   length as described in :type:`iostringstyle`.
  */
 proc stringStyleWithVariableLength() {
@@ -1353,7 +1353,7 @@ proc stringStyleWithVariableLength() {
 
 /*
   This method returns the appropriate :record:`iostyle` ``str_style`` value
-  to indicate a string format where string data is preceeded by a ``lengthBytes``
+  to indicate a string format where string data is preceded by a ``lengthBytes``
   of length. Only lengths of 1, 2, 4, or 8 are supported; if this method
   is called with any other length, it will halt with an error.
  */
@@ -2716,7 +2716,7 @@ record ioNewline {
   /*
     Normally, we will skip anything at all to get to a \n,
     but if skipWhitespaceOnly is set, it will be an error
-    if we run into non-space charcters other than \n.
+    if we run into non-space characters other than \n.
    */
   var skipWhitespaceOnly: bool = false;
   pragma "no doc"
@@ -2947,7 +2947,7 @@ inline proc channel._offset():int(64) {
       by a 'B')
     * if the speculative operation was successful,  commit the changes by
       calling :proc:`channel._commit`
-    * if the speculative operation was not succesful, go back to the *mark* by
+    * if the speculative operation was not successful, go back to the *mark* by
       calling :proc:`channel._revert`. Subsequent I/O operations will work
       as though nothing happened.
     * unlock the channel with :proc:`channel.unlock` if necessary
@@ -3586,7 +3586,7 @@ private inline proc _read_one_internal(_channel_internal:qio_channel_ptr_t, para
                                     x.val.localize().c_str(),
                                     x.val.length: ssize_t, x.ignoreWhiteSpace);
     //e = qio_channel_scan_literal(false, _channel_internal, x.val, x.val.length, x.ignoreWhiteSpace);
-    //writeln("Scanning literal ", x.val,  " yeilded error ", e);
+    //writeln("Scanning literal ", x.val,  " yielded error ", e);
     //return e;
   } else if t == ioBits {
     return qio_channel_read_bits(false, _channel_internal, x.v, x.nbits);
@@ -3995,7 +3995,7 @@ private var _arg_to_proto_names = ("a", "b", "c", "d", "e", "f");
 private proc _args_to_proto(args ...?k,
                     preArg:string) {
   // FIX ME: lot of potential leaking going on here with string concat
-  // But this is used for error handlling so maybe we don't care.
+  // But this is used for error handling so maybe we don't care.
   var err_args: string;
   for param i in 1..k {
     var name: string;
@@ -4038,7 +4038,7 @@ inline proc channel.read(ref args ...?k):bool {
    :arg error: optional argument to capture an error code. If this argument
               is not provided and an error is encountered, this function
               will halt with an error message.
-   :returns: `true` if the read succeded, and `false` on error or end of file.
+   :returns: `true` if the read succeeded, and `false` on error or end of file.
 
  */
 proc channel.read(ref args ...?k,
@@ -4372,7 +4372,7 @@ proc channel.readln(ref args ...?k,
    :arg error: optional argument to capture an error code. If this argument
               is not provided and an error is encountered, this function
               will halt with an error message.
-   :returns: `true` if the read succeded, and `false` on error or end of file.
+   :returns: `true` if the read succeeded, and `false` on error or end of file.
 
  */
 proc channel.readln(ref args ...?k,
@@ -4515,7 +4515,7 @@ inline proc channel.write(args ...?k):bool {
    :arg error: optional argument to capture an error code. If this argument
               is not provided and an error is encountered, this function
               will halt with an error message.
-   :returns: `true` if the write succeded
+   :returns: `true` if the write succeeded
 
  */
 proc channel.write(args ...?k,
@@ -4601,7 +4601,7 @@ proc channel.writeln(args ...?k,
    :arg error: optional argument to capture an error code. If this argument
               is not provided and an error is encountered, this function
               will halt with an error message.
-   :returns: `true` if the write succeded
+   :returns: `true` if the write succeeded
 
  */
 proc channel.writeln(args ...?k,
@@ -5271,7 +5271,7 @@ proc channel._match_regexp_if_needed(cur:size_t, len:size_t, ref error:syserr, r
 // Reads the next format string that will require argument handling.
 // Handles literals and regexps itself; everything else will
 // be returned in conv and with gotConv = true.
-// Assumes, for a reading channel, that we are withn a mark/revert/commit
+// Assumes, for a reading channel, that we are within a mark/revert/commit
 //  in readf. (used in the regexp handling here).
 pragma "no doc"
 proc channel._format_reader(
@@ -6127,7 +6127,7 @@ proc channel.readf(fmtStr:string, ref args ...?k, out error:syserr):bool {
                 if _format_debug then stdout.writeln("DEBUG AXI");
               } else {
                 _match_regexp_if_needed(cur, len, error, style, r);
-                // Set args(i) to the catpure at capturei.
+                // Set args(i) to the capture at capturei.
                 if r.capturei >= r.ncaptures {
                   error = qio_format_error_bad_regexp();
                   if _format_debug then stdout.writeln("DEBUG AXJ");
@@ -6408,7 +6408,7 @@ proc string.format(args ...?k):string {
 
 // ---------------------------------------------------------------
 // ---------------------------------------------------------------
-// Starting support for regular expression serach on channels
+// Starting support for regular expression search on channels
 // ---------------------------------------------------------------
 // ---------------------------------------------------------------
 

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -307,7 +307,7 @@ module Math {
      i.e., the fraction `m`/`n` rounded up to the nearest integer. 
 
      If the arguments are of unsigned type, then
-     fewer condititionals will be evaluated at run time.
+     fewer conditionals will be evaluated at run time.
   */
   proc divceil(param m: integral, param n: integral) param return
     if isNonnegative(m) then
@@ -321,7 +321,7 @@ module Math {
      i.e., the fraction `m`/`n` rounded up to the nearest integer. 
 
      If the arguments are of unsigned type, then
-     fewer condititionals will be evaluated at run time.
+     fewer conditionals will be evaluated at run time.
   */
   proc divceil(m: integral, n: integral) return
     if isNonnegative(m) then
@@ -347,7 +347,7 @@ module Math {
      i.e., the fraction `m`/`n` rounded down to the nearest integer.
 
      If the arguments are of unsigned type, then
-     fewer condititionals will be evaluated at run time.
+     fewer conditionals will be evaluated at run time.
   */
   proc divfloor(param m: integral, param n: integral) param return
     if isNonnegative(m) then
@@ -361,7 +361,7 @@ module Math {
      i.e., the fraction `m`/`n` rounded down to the nearest integer.
 
      If the arguments are of unsigned type, then
-     fewer condititionals will be evaluated at run time.
+     fewer conditionals will be evaluated at run time.
   */
   proc divfloor(m: integral, n: integral) return
     if isNonnegative(m) then

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -419,7 +419,7 @@ module Random {
 
 
   /*
-     Permuted Linear Congurential Random Number Generator
+     Permuted Linear Congruential Random Number Generator
 
      This module provides PCG random number generation routines.
      See http://www.pcg-random.org/
@@ -495,7 +495,7 @@ module Random {
       is computed will be computed with a different ganged-together RNG.
       This strategy is meant to avoid statistical bias. While we have tested
       this strategy to our satisfaction, it has not been subject to rigorous
-      analysis and may have undesireable statistical properties.
+      analysis and may have undesirable statistical properties.
 
       When generating a real, imaginary, or complex number, this implementation
       uses the strategy of generating a 64-bit unsigned integer and then
@@ -619,7 +619,7 @@ module Random {
         Returns the next value in the random stream.
 
         Generated reals are in [0,1] - both 0.0 and 1.0 are possible values.
-        Imaginary numbers are analagously in [0i, 1i]. Complex numbers will
+        Imaginary numbers are analogously in [0i, 1i]. Complex numbers will
         consist of a generated real and imaginary part, so 0.0+0.0i and 1.0+1.0i
         are possible.
 
@@ -728,8 +728,8 @@ module Random {
 
         if arr.domain.rank != 1 then
           compilerError("Shuffle requires 1-D array");
-        //if arr.domain.type.strideable then
-        //  compilerError("Shuffle requires non-strideable 1-D array");
+        //if arr.domain.type.stridable then
+        //  compilerError("Shuffle requires non-stridable 1-D array");
 
         if parSafe then
           PCGRandomStreamPrivate_lock$ = true;
@@ -757,8 +757,8 @@ module Random {
 
         if arr.domain.rank != 1 then
           compilerError("Permutation requires 1-D array");
-        //if arr.domain.dim(1).strideable then
-        //  compilerError("Permutation requires non-strideable 1-D array");
+        //if arr.domain.dim(1).stridable then
+        //  compilerError("Permutation requires non-stridable 1-D array");
 
         if parSafe then
           PCGRandomStreamPrivate_lock$ = true;
@@ -1366,7 +1366,7 @@ module Random {
         var tmpinc:uint(64);
         var r:uint(32);
 
-        // Keepy trying until we get a random number that is within the bounds.
+        // Keep trying until we get a random number that is within the bounds.
         while true {
           r = random(inc);
           if r >= threshold then

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -327,7 +327,7 @@ module Spawn {
 
   /* TODO:
      stdin stdout and stderr can be PIPE, existing file descriptor,
-     existing file opject, or None. and stderr can be STDOUT which
+     existing file object, or None. and stderr can be STDOUT which
      indicates stderr -> stdout.
 
      What about a string for a file path? To support that, use

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -59,7 +59,7 @@ extern type socklen_t = int(32);
 // C File type
 //type c_file = _file;
 
-// stdin/stdout/sterr
+// stdin/stdout/stderr
 //extern proc chpl_cstdin():_file;
 pragma "no doc"
 extern proc chpl_cstdout():_file;
@@ -97,7 +97,7 @@ extern type syserr; // = c_int, opaque so we can manually override ==,!=,etc
  */
 extern type err_t = c_int;
 
-/* A system file descriptior. This is really just a `c_int`, but code is
+/* A system file descriptor. This is really just a `c_int`, but code is
    clearer if you use fd_t to indicate arguments, variables, and return types
    that are system file descriptors.
  */
@@ -111,7 +111,7 @@ private extern proc qio_err_to_int(a:syserr):int(32);
 private extern proc qio_int_to_err(a:int(32)):syserr;
 private extern proc qio_err_iserr(a:syserr):c_int;
 
-/* The error code indicating that no error occured (Chapel specific) */
+/* The error code indicating that no error occurred (Chapel specific) */
 inline proc ENOERR return 0:err_t;
 
 // When err_t is no longer just int(32), will need to add cases for err_t too.


### PR DESCRIPTION
Fix typos in modules/{dists,internal,packages,standard}

The modified error messages do not appear in any .good or .bad files (or anywhere else in the repo).
