### PR TITLE
Updating 'require "Foo.chpl";' tests

### DIFF
--- a/test/extern/bradc/require/useModAsString2.chpl
+++ b/test/extern/bradc/require/useModAsString2.chpl
@@ -1,7 +1,6 @@
 //
 // This tells Chapel to compile Foo.chpl, but does not import any
-// of its symbols.  If this feature sticks around, we've talked
-// about switching to the keyword 'require' to avoid this confusion.
+// of its symbols.
 //
 require "Foo.chpl";
 //

--- a/test/extern/bradc/require/useModAsString3.chpl
+++ b/test/extern/bradc/require/useModAsString3.chpl
@@ -4,6 +4,8 @@
 //
 require "Foo.chpl";
 
+writeln("In useModAsString3's init");
+
 proc foo() {
   writeln("In useModAsString.chpl's foo");
 }
@@ -11,4 +13,5 @@ proc foo() {
 
 proc main() {
   foo();
+  Foo.foo();  // use a fully-qualified reference to Foo's foo()
 }

--- a/test/extern/bradc/require/useModAsString3.good
+++ b/test/extern/bradc/require/useModAsString3.good
@@ -1,0 +1,4 @@
+In foo's init
+In useModAsString3's init
+In useModAsString.chpl's foo
+In Foo.chpl's foo


### PR DESCRIPTION
Lydia reminded me about these tests today, and I noticed two things:

1) There's a comment that talks about "If we rename this to require"
   even though we've long since did this, so updated those comments.

2) None of these tests actually try invoking code that lives in the
   "required" module, so I gave it a try.  My prediction was that
   we would not initialize the Foo module before invoking its function
   as we ought to, but happily/surprisingly, it seems we do!  (I wonder
   how much complexity that costs us in compiler/generated code...?)
   So added in a new test useModAsString3.chpl to lock this in.