### PR TITLE
Use jemalloc-config to determine the link args for jemalloc

### DIFF
--- a/util/chplenv/chpl_3p_jemalloc_configs.py
+++ b/util/chplenv/chpl_3p_jemalloc_configs.py
@@ -12,9 +12,19 @@ from utils import memoize
 def get_uniq_cfg_path():
     return third_party_utils.default_uniq_cfg_path()
 
+# Instead of libtool or pkg-config, jemalloc uses a jemalloc-config script to
+# determine dependencies/link args . It's located in the bin directory
+@memoize
+def get_jemalloc_config_file():
+    install_path = third_party_utils.get_cfg_install_path('jemalloc')
+    config_file = os.path.join(install_path, 'bin', 'jemalloc-config')
+    return config_file
+
 @memoize
 def get_link_args():
-    # We have to manually link libpthread since we build statically and .a's
-    # don't have a way to specify dependencies.
-    return third_party_utils.default_get_link_args('jemalloc',
-                                                   libs=['-ljemalloc', '-lpthread'])
+    jemalloc_config = get_jemalloc_config_file()
+    libs = ['-ljemalloc']
+    if os.access(jemalloc_config, os.X_OK):
+        jemalloc_libs = utils.run_command([jemalloc_config, '--libs'])
+        libs += jemalloc_libs.split()
+    return libs

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -20,6 +20,13 @@ def default_uniq_cfg_path():
                                               get_lcd=utils.using_chapel_module()))
 
 #
+# Returns the path to the packages install directory
+#
+@memoize
+def get_cfg_install_path(pkg, ucp=default_uniq_cfg_path()):
+    return os.path.join(utils.get_chpl_home(), 'third-party', pkg, 'install', ucp)
+
+#
 # Return libraries and other options mentioned in the old_library and
 # dependency_libs entries in a libtool .la file, recursively searching
 # other .la files encountered there.
@@ -61,13 +68,8 @@ def default_get_link_args(pkg, ucp='', libs=[]):
     all_args = []
     for lib_arg in libs:
         if lib_arg.endswith('.la'):
-            all_args.extend(handle_la(os.path.join(utils.get_chpl_home(),
-                                                   'third-party',
-                                                   pkg,
-                                                   'install',
-                                                   ucp,
-                                                   'lib',
-                                                   lib_arg)))
+            la = os.path.join(get_cfg_install_path(pkg, ucp), 'lib', lib_arg)
+            all_args.extend(handle_la(la))
         else:
             all_args.append(lib_arg)
     return all_args


### PR DESCRIPTION
Instead of pkg-config or libtool, jemalloc uses a custom jemalloc-config script
to help figure out the required dependencies. I didn't realize this originally,
so I ended up manually trying to guess the link args like `-lpthread`. Now we
just call `jemalloc-config --libs` to get the link args that we need.

This will allow us to automatically bring in librt when we upgrade to jemalloc
4.2.0. Newer versions of jemalloc require librt to be linked in for glibc <
2.17, but we had no sane way of detecting this ourselves without doing a
configure like test.