### PR TITLE
Temporarily stop throwing --vectorize when --fast is thrown

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -490,7 +490,6 @@ static void setFastFlag(const ArgumentDescription* desc, const char* unused) {
   fNoInline = false;
   fNoInlineIterators = false;
   fNoOptimizeLoopIterators = false;
-  fNoVectorize = false;
   fNoLiveAnalysis = false;
   fNoRemoteValueForwarding = false;
   fNoRemoveCopyCalls = false;


### PR DESCRIPTION
We're running into some issues with the intel backend where we're attaching
pragma ivdep to loops that do actually have data dependencies. We likely need
to do more analysis to determine when ivdep is actually safe, but that will
take some time so in the meantime just stop enabling vectorization when --fast
is thrown to quiet testing.

sidebar: Really the analysis that we currently do just tells us that loops are
order independent (each iteration can be executed in any order) but we don't do
anything to check data dependencies within a single iteration. I believe we
originally misunderstood what we were asserting with ivdep so I think we need
to take a closer look at what we really want to do here.

See JIRA 221 for more info: https://chapel.atlassian.net/browse/CHAPEL-221