### PR TITLE
Refactor RemoveValueForwarding

### DIFF
--- a/compiler/include/optimizations.h
+++ b/compiler/include/optimizations.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -61,17 +61,14 @@ void liveVariableAnalysis(FnSymbol* fn,
                           Vec<SymExpr*>& defSet,
                           std::vector<BitVec*>& OUT);
 
-void
-buildDefUseChains(FnSymbol* fn,
-                  std::map<SymExpr*,Vec<SymExpr*>*>& DU,
-                  std::map<SymExpr*,Vec<SymExpr*>*>& UD);
+void buildDefUseChains(FnSymbol*                           fn,
+                       std::map<SymExpr*, Vec<SymExpr*>*>& DU,
+                       std::map<SymExpr*, Vec<SymExpr*>*>& UD);
 
-void
-freeDefUseChains(std::map<SymExpr*,Vec<SymExpr*>*>& DU,
-                 std::map<SymExpr*,Vec<SymExpr*>*>& UD);
+void freeDefUseChains(std::map<SymExpr*, Vec<SymExpr*>*>& DU,
+                      std::map<SymExpr*, Vec<SymExpr*>*>& UD);
 
-void
-remoteValueForwarding(Vec<FnSymbol*>& fns);
+void remoteValueForwarding();
 
 
 #endif


### PR DESCRIPTION
RemoveValueForwarding (RVF) is an important optimization that is becoming a blocker to some
intended changes for sync/single and atomics.  Additionally (a) it was a surprise to several people
that it triggers even for single-locale programs (b) there is some early evidence that it has been a
factor in some of the problems with multi-locale string-as-record programs.

The existing implementation consists of a few reasonably large and slightly opaque functions.  This
PR attempts to break the business logic out in to smaller more digestible components as a pre-requisite
to revising the business logic to enable work on sync/single/atomic and possibly fix some bugs.

The refactoring was performed in reasonably well-defined steps with commits at each stage.
This version passes the full suite for std-linux64 and gasnet-linux64
