### PR TITLE
Fix python 3 incompatibilities introduced with #3917

### DIFF
--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -48,7 +48,7 @@ def get_compiler_version(compiler):
 @memoize
 def CompVersion(version_string):
     CompVersionT = namedtuple('CompVersion', ['major', 'minor', 'revision', 'build'])
-    match = re.search(u'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', str(version_string))
+    match = re.search(u'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', version_string)
     if match:
         major    = int(match.group(1))
         minor    = int(match.group(3) or 0)
@@ -74,6 +74,7 @@ def run_command(command, stdout=True, stderr=False):
             "command `{0}` failed - output was \n{1}".format(command,
                                                              output[1]))
     else:
+        output = (str(output[0]), str(output[1]))
         if stdout and stderr:
             return output
         elif stdout:


### PR DESCRIPTION
#3917 switched from manually specifying jemalloc link args to using
jemalloc-config. It used utils.run_command() in order to run jemalloc-config,
but run_command() returns a byte string in python3. This led to errors because
the consumer of the link args was expecting a string. A simple fix would have
been to just wrap the jemalloc run_command with str(), but I wanted to see if
we could just push that into run_command() itself.

It turns out the other places that use run_command also want a string instead
of a byte string. The uses in chpl_arch aren't hit with our nightly testing so
we never noticed that they were wrong. And the use in utils put the string
conversion in CompVersion instead of in get_compiler_version() where the actual
run_command() is. This just converts the output of run_command to a string
before returning and removes a now unnecessary conversion in CompVersion

To repro the jemalloc failure (must have jemalloc built), you can run:
  `python3 util/printchplenv --make`

To repro the chpl_arch failure (must be on a mac), you can run:
  `CHPL_HOST_ARCH=native python3 util/chplenv/chpl_arch.py --host`