### PR TITLE
Fix bugs and python 3 incompatibilities in chpl_arch

### DIFF
--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -198,8 +198,12 @@ class feature_sets(object):
 
     @classmethod
     def find(sets, vendor, features):
+        def remove_punctuation(s):
+            exclude = set(punctuation)
+            return  ''.join(ch for ch in s if ch not in exclude)
+
         # remove all punctuation and split into a list
-        system_features = features.lower().translate(None, punctuation).split()
+        system_features = remove_punctuation(features.lower()).split()
 
         options = []
         if "genuineintel" == vendor.lower():
@@ -316,7 +320,7 @@ def get(location, map_to_compiler=False, get_lcd=False):
     if comm_val == 'none' and ('linux' in platform_val or
                                platform_val == 'darwin' or
                                platform_val.startswith('cygwin')):
-        if arch:
+        if arch and arch not in  ['none', 'unknown', 'native']:
             if location == 'host':
                 # when a user supplies an architecture, and it seems reasonable
                 # to double check their choice we do so. This will only


### PR DESCRIPTION
translate(None, punctuation) was used to removed punctuation from a string, but
that's not supported in python3. Instead create a helper remove_punctuation
routine that works for python 2 and 3. There's probably better/faster ways to
remove punctuation, but this was really simple.

I took it from:
http://stackoverflow.com/questions/265960/best-way-to-strip-punctuation-from-a-string-in-python
which has comments about py3 translate not supporting the deletechars argument.

While I was testing this I also found that setting CHPL_HOST_ARCH to "native" or
"unknown" would produce warnings about unsupported archs, so I fixed that.

To repro the unsupported arch warning run:
  `CHPL_HOST_ARCH=native python2 util/chplenv/chpl_arch.py --host`

To repro the python3 translate error run
  `CHPL_HOST_ARCH=native python3 util/chplenv/chpl_arch.py --host`