### PR TITLE
Use .decode() instead of str() in run_command

### DIFF
--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -74,7 +74,7 @@ def run_command(command, stdout=True, stderr=False):
             "command `{0}` failed - output was \n{1}".format(command,
                                                              output[1]))
     else:
-        output = (str(output[0]), str(output[1]))
+        output = (output[0].decode(), output[1].decode())
         if stdout and stderr:
             return output
         elif stdout:


### PR DESCRIPTION
Fixes #3923

Whoops, just converting a byte string to a string leaves you with something
like " b'string\n' " instead of just "string". Need to decode the byte string
to unicode instead of just casting.

Note that for python 3 we could use `str(byteString, 'utf-8'), but that's not
supported by python 2, so use decode instead:
https://docs.python.org/3/library/stdtypes.html#str
