### PR TITLE
Enable jemalloc's decay-based purging

### DIFF
--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -31,6 +31,11 @@ endif
 CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \
 			     --with-jemalloc-prefix=je_
 
+# As an optimization, use jemalloc's decay-based purging instead of the
+# default ratio-based purging
+CHPL_JEMALLOC_CFG_OPTIONS += --with-malloc-conf=purge:decay
+
+
 # jemalloc wants you to set EXTRA_CFLAGS instead of CFLAGS:
 #  """
 #  EXTRA_CFLAGS="?"


### PR DESCRIPTION
Use jemalloc's decay-based purging instead of the default ratio-based purging.
Decay-based purging was a major optimization added with jemalloc 4.1.0, but it
won't be the default until at least 5.0. I've seen some pretty nice performance
speedups from using decay-based purging, so make it our default.

For binary trees (a benchmark that really measures allocator speed) this
results in a ~10% speedup on the shootout-like machine.

From the 4.1.0 release notes:

    Implement decay-based unused dirty page purging, a major optimization with
    mallctl API impact. This is an alternative to the existing ratio-based
    unused dirty page purging, and is intended to eventually become the sole
    purging mechanism.

See https://github.com/jemalloc/jemalloc/issues/325 for more info on
decay-based purging