### PR TITLE
Check performance of jemalloc's decay-based purging in chapcs playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,11 +9,11 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of using native qthread sync vars
+# Test performance of jemalloc's decay-based purging
 GITHUB_USER=ronawho
-GITHUB_BRANCH=fast-syncvars
-SHORT_NAME=syncvar
-START_DATE=05/21/16
+GITHUB_BRANCH=jemalloc-decay-based-purging
+SHORT_NAME=decay-purge
+START_DATE=05/28/16
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
Same as #3455, but test out the perf w/ jemalloc 4.2.0 to make sure it still
has the same performance benefits.