### PR TITLE
Add ability to limit how many tests will execute concurrently

### DIFF
--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -40,9 +40,9 @@ class FileLock():
 
     # simple backoff sleep, so that we have relatively fast latency for a bunch
     # of quick running tests, but don't poll the machine continuously if a test
-    # is taking a while to run.
-    sleep_time = .1
-    def _backoff_sleep(self, max_sleep=.5, backoff_factor=1.1):
+    # is taking a while to run. see #3928 for why the times/backoff were chosen
+    sleep_time = .02
+    def _backoff_sleep(self, max_sleep=.5, backoff_factor=1.3):
 	time.sleep(self.sleep_time)
 	if self.sleep_time < max_sleep:
 	    self.sleep_time *= backoff_factor

--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -1,0 +1,107 @@
+from __future__ import with_statement
+
+import getpass
+import os
+import sys
+import tempfile
+import time
+
+def log_info(msg):
+    if os.getenv('CHPL_TEST_DEBUG_RUNNING_EXECUTABLE_LOCK') is not None:
+        sys.stdout.write('[Exec-lock Info: {0}]\n'.format(msg))
+        sys.stdout.flush()
+
+# Empty class that can be used with a context manager. Does not
+# limit how many executables can run at once.
+class NoLock():
+    def __enter__(self):
+        pass
+    def __exit__(self, type, value, traceback):
+        pass
+
+# Class that uses a file as a mutex so that only one executable can
+# run per user, per machine. This is useful when you want to
+# oversubscribe paratest, but don't want to cause too many
+# executables to run at once since some tests can consume the whole
+# machine which can starve other executables, causing timeouts.
+#
+# This works by using a file as a lock/mutex. It's race-y so it's
+# possible (though relatively unlikely) that two or more executables
+# could run at the same time. That's a little unfortunate, but not a
+# huge deal as it's pretty unlikely we'll get multiple resource
+# heavy tests running simultaneously
+#
+# The constructor takes the name of the executable and its timeout
+# value.
+class FileLock():
+    exec_name = ''
+    exec_timeout = ''
+    lock_file = ''
+
+    # simple backoff sleep, so that we have relatively fast latency for a bunch
+    # of quick running tests, but don't poll the machine continuously if a test
+    # is taking a while to run.
+    sleep_time = .1
+    def _backoff_sleep(self, max_sleep=.5, backoff_factor=1.1):
+	time.sleep(self.sleep_time)
+	if self.sleep_time < max_sleep:
+	    self.sleep_time *= backoff_factor
+   
+    def __init__(self, exec_name, exec_timeout):
+	lock_name = '{0}-chpl_program_executing'.format(getpass.getuser())
+        self.lock_file = os.path.join(tempfile.gettempdir(), lock_name)
+        self.exec_name = exec_name
+        self.exec_timeout = exec_timeout
+
+    def __enter__(self):
+        self._lock()
+
+    def __exit__(self, type, value, traceback):
+        self._unlock()
+
+    # parse the lock_file and return how long ago the lock_file was
+    # modified, the name of the test that has the lock, and the
+    # test's timeout value. If there's issues opening or parsing the
+    # file, return a default of: (1, "corrupted_lock_file", 0), so
+    # that the waiting test can continue.
+    def _parse_lock_file(self):
+        default_lock_file = (1, "corrupted_lock_file", 0)
+        try:
+            with open(self.lock_file, 'r') as f:
+                lines = f.read().splitlines()
+                other_filename = lines[0]
+                other_timeout = int(lines[1])
+
+                modified = time.time() - os.path.getmtime(self.lock_file)
+                return (modified, other_filename, other_timeout)
+        except:
+            log_info('Failed to parse lock file, using default one')
+            return default_lock_file
+
+    # Grab the execution "lock", spin waiting while some other test
+    # has the lock. If for some reason the other test didn't clean
+    # up the locking file, we'll continue if the lock hasn't been
+    # modified in the other test's timeout value.
+    def _lock(self):
+	modified = 0
+	other_timeout = 1
+	while os.path.exists(self.lock_file) and modified < other_timeout:
+            modified, other_filename, other_timeout = self._parse_lock_file()
+            log_info('"{0}" is waiting at most {1}s for "{2}" (started {3:.1f}s '
+                     'ago) to finish executing'.format(
+                     self.exec_name, other_timeout, other_filename, modified))
+            self._backoff_sleep()
+
+	# actually grab the "lock" by creating the file
+        log_info('Grabbing exec-lock for "{0}"'.format(self.exec_name))
+	with open(self.lock_file, 'w') as f:
+	    f.write('{0}\n{1}\n'.format(self.exec_name, self.exec_timeout))
+
+
+    def _unlock(self):
+	try:
+	    # release the "lock" by removing the file
+            log_info('Releasing exec-lock for "{0}"'.format(self.exec_name))
+	    os.remove(self.lock_file)
+	except:
+	    pass

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -128,6 +128,7 @@
 
 from __future__ import with_statement
 
+import execution_limiter
 import sys, os, subprocess, string, signal
 import operator
 import select, fcntl
@@ -1785,107 +1786,115 @@ for testname in testsrc:
             # Run program (with timeout)
             #
             for count in xrange(numTrials):
-                exectimeout = False  # 'exectimeout' is specific to one trial of one execopt setting
-                launcher_error = ''  # used to suppress output/timeout errors whose root cause is a launcher error
-                sys.stdout.write('[Executing program %s %s'%(cmd, ' '.join(args)))
-                if redirectin:
-                    sys.stdout.write(' < %s'%(redirectin))
-                sys.stdout.write(']\n')
-                sys.stdout.flush()
+                exec_limiter = execution_limiter.NoLock()
+                if os.getenv("CHPL_TEST_LIMIT_RUNNING_EXECUTABLES") is not None:
+                    exec_name = os.path.join(localdir, test_filename)
+                    exec_limiter = execution_limiter.FileLock(exec_name, timeout)
 
-                execStart = time.time()
-                if useLauncherTimeout:
-                    if redirectin == None:
-                        my_stdin = None
+                with exec_limiter:
+                    exectimeout = False  # 'exectimeout' is specific to one trial of one execopt setting
+                    launcher_error = ''  # used to suppress output/timeout errors whose root cause is a launcher error
+                    sys.stdout.write('[Executing program %s %s'%(cmd, ' '.join(args)))
+                    if redirectin:
+                        sys.stdout.write(' < %s'%(redirectin))
+                    sys.stdout.write(']\n')
+                    sys.stdout.flush()
+
+                    execStart = time.time()
+                    if useLauncherTimeout:
+                        if redirectin == None:
+                            my_stdin = None
+                        else:
+                            my_stdin=file(redirectin, 'r')
+                        test_command = [cmd] + args + LauncherTimeoutArgs(timeout)
+                        p = subprocess.Popen(test_command,
+                                            env=dict(os.environ.items() + testenv.items()),
+                                            stdin=my_stdin,
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.STDOUT)
+                        output = p.communicate()[0]
+                        status = p.returncode
+
+                        if re.search('slurmstepd: Munge decode failed: Expired credential', output, re.IGNORECASE) != None:
+                            launcher_error = 'Jira 18 -- Expired slurm credential for'
+                        elif re.search('output file from job .* does not exist', output, re.IGNORECASE) != None:
+                            launcher_error = 'Jira 17 -- Missing output file for'
+                        elif re.search('aprun: Unexpected close of the apsys control connection', output, re.IGNORECASE) != None:
+                            launcher_error = 'Jira 193 -- Unexpected close of apsys for'
+                        elif (re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None or
+                              re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None):
+                            exectimeout = True
+                            launcher_error = 'Timed out executing program'
+
+                        if launcher_error:
+                            sys.stdout.write('%s[Error: %s %s/%s'%
+                                            (futuretest, launcher_error, localdir, test_filename))
+                            printTestVariation(compoptsnum, compoptslist,
+                                               execoptsnum, execoptslist);
+                            sys.stdout.write(']\n')
+                            sys.stdout.write('[Execution output was as follows:]\n')
+                            sys.stdout.write(trim_output(output))
+
+                    elif useTimedExec:
+                        wholecmd = cmd+' '+' '.join(map(ShellEscape, args))
+
+                        if redirectin == None:
+                            my_stdin = sys.stdin
+                        else:
+                            my_stdin = file(redirectin, 'r')
+                        p = subprocess.Popen([timedexec, str(timeout), wholecmd],
+                                            env=dict(os.environ.items() + testenv.items()),
+                                            stdin=my_stdin,
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.STDOUT)
+                        output = p.communicate()[0]
+                        status = p.returncode
+
+                        if status == 222:
+                            exectimeout = True
+                            sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
+                                            (futuretest, localdir, test_filename))
+                            printTestVariation(compoptsnum, compoptslist,
+                                               execoptsnum, execoptslist);
+                            sys.stdout.write(']\n')
+                            sys.stdout.write('[Execution output was as follows:]\n')
+                            sys.stdout.write(trim_output(output))
+                        else:
+                            # for perf runs print out the 5 processes with the
+                            # highest cpu usage. This should help identify if other
+                            # processes might have interfered with a test.
+                            if perftest:
+                                print('[Reporting processes with top 5 highest cpu usages]')
+                                sys.stdout.flush()
+                                psCom = 'ps ax -o user,pid,pcpu,command '
+                                subprocess.call(psCom + '| head -n 1', shell=True)
+                                subprocess.call(psCom + '| tail -n +2 | sort -r -k 3 | head -n 5', shell=True)
+
+
                     else:
-                        my_stdin=file(redirectin, 'r')
-                    test_command = [cmd] + args + LauncherTimeoutArgs(timeout)
-                    p = subprocess.Popen(test_command,
-                                        env=dict(os.environ.items() + testenv.items()),
-                                        stdin=my_stdin,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.STDOUT)
-                    output = p.communicate()[0]
-                    status = p.returncode
+                        if redirectin == None:
+                            my_stdin = None
+                        else:
+                            my_stdin=file(redirectin, 'r')
+                        p = subprocess.Popen([cmd]+args,
+                                            env=dict(os.environ.items() + testenv.items()),
+                                            stdin=my_stdin,
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.STDOUT)
+                        try:
+                            output = SuckOutputWithTimeout(p.stdout, timeout)
+                        except ReadTimeoutException:
+                            exectimeout = True
+                            sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
+                                            (futuretest, localdir, test_filename))
+                            printTestVariation(compoptsnum, compoptslist,
+                                               execoptsnum, execoptslist);
+                            sys.stdout.write(']\n')
+                            KillProc(p, killtimeout)
 
-                    if re.search('slurmstepd: Munge decode failed: Expired credential', output, re.IGNORECASE) != None:
-                        launcher_error = 'Jira 18 -- Expired slurm credential for'
-                    elif re.search('output file from job .* does not exist', output, re.IGNORECASE) != None:
-                        launcher_error = 'Jira 17 -- Missing output file for'
-                    elif re.search('aprun: Unexpected close of the apsys control connection', output, re.IGNORECASE) != None:
-                        launcher_error = 'Jira 193 -- Unexpected close of apsys for'
-                    elif (re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None or
-                          re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None):
-                        exectimeout = True
-                        launcher_error = 'Timed out executing program'
+                        status = p.returncode
 
-                    if launcher_error:
-                        sys.stdout.write('%s[Error: %s %s/%s'%
-                                        (futuretest, launcher_error, localdir, test_filename))
-                        printTestVariation(compoptsnum, compoptslist,
-                                           execoptsnum, execoptslist);
-                        sys.stdout.write(']\n')
-                        sys.stdout.write('[Execution output was as follows:]\n')
-                        sys.stdout.write(trim_output(output))
-
-                elif useTimedExec:
-                    wholecmd = cmd+' '+' '.join(map(ShellEscape, args))
-
-                    if redirectin == None:
-                        my_stdin = sys.stdin
-                    else:
-                        my_stdin = file(redirectin, 'r')
-                    p = subprocess.Popen([timedexec, str(timeout), wholecmd],
-                                        env=dict(os.environ.items() + testenv.items()),
-                                        stdin=my_stdin,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.STDOUT)
-                    output = p.communicate()[0]
-                    status = p.returncode
-
-                    if status == 222:
-                        exectimeout = True
-                        sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
-                                        (futuretest, localdir, test_filename))
-                        printTestVariation(compoptsnum, compoptslist,
-                                           execoptsnum, execoptslist);
-                        sys.stdout.write(']\n')
-                        sys.stdout.write('[Execution output was as follows:]\n')
-                        sys.stdout.write(trim_output(output))
-                    else:
-                        # for perf runs print out the 5 processes with the
-                        # highest cpu usage. This should help identify if other
-                        # processes might have interfered with a test.
-                        if perftest:
-                            print('[Reporting processes with top 5 highest cpu usages]')
-                            sys.stdout.flush()
-                            psCom = 'ps ax -o user,pid,pcpu,command '
-                            subprocess.call(psCom + '| head -n 1', shell=True)
-                            subprocess.call(psCom + '| tail -n +2 | sort -r -k 3 | head -n 5', shell=True)
-
-
-                else:
-                    if redirectin == None:
-                        my_stdin = None
-                    else:
-                        my_stdin=file(redirectin, 'r')
-                    p = subprocess.Popen([cmd]+args,
-                                        env=dict(os.environ.items() + testenv.items()),
-                                        stdin=my_stdin,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.STDOUT)
-                    try:
-                        output = SuckOutputWithTimeout(p.stdout, timeout)
-                    except ReadTimeoutException:
-                        exectimeout = True
-                        sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
-                                        (futuretest, localdir, test_filename))
-                        printTestVariation(compoptsnum, compoptslist,
-                                           execoptsnum, execoptslist);
-                        sys.stdout.write(']\n')
-                        KillProc(p, killtimeout)
-
-                    status = p.returncode
+                # executable is done running
 
                 elapsedExecTime = time.time() - execStart
                 test_name = os.path.join(localdir, test_filename)


### PR DESCRIPTION
Paratest has the ability to run oversubscribed with the `-nodepara` option.
This essentially runs multiple start_tests per machine, which means multiple
compiles/executions can happen simultaneously. However, some chapel programs
(particularly when using qthreads) can use up a significant portion of the
machine, which can lead to timeouts when multiple heavy-weight tests are
running concurrently.

This adds the ability to limit our testing infrastructure so that only one
executable can run at a time. Compilation is single threaded, so this doesn't
limit how many compiles occur and it still lets compilation occur while other
tests are running.

In order to enable this just set `CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes`

In order to limit how many executables run at once, we basically use a file as
a mutex. This is race-y, which means occasionally two or more executables might
be running at the same time. It's pretty unlikely this will happen though,
since there's small window for that to happen. And note that the code is
careful to consider cases where paratest is killed and doesn't remove the lock,
or where multiple executables end up running concurrently.

The simplified version of what this code does is:

```python
  while os.path.exists('/tmp/<username>-test-running') and modified < timeout:
      time.sleep(.02)

  # race-y since other process could have created file since while loop
  open('/tmp/<username>-test-running', 'w')

  run_executable()

  os.remove('/tmp/<username>-test-running')
```

Note that arguably this is a hacky/ugly solution, and that really I should
have updated sub_test to use python's multiprocessing to get concurrent
compiles instead of just abusing paratest. However, that would have probably
taken me a few days, and this only took a few hours.
