### PR TITLE
Avoid creating a tuple for varargs in some cases

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -39,6 +39,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "type.h"
+#include "resolution.h"
 
 #include "AstToText.h"
 #include "AstVisitor.h"
@@ -1466,6 +1467,7 @@ FnSymbol::FnSymbol(const char* initName) :
   codegenUniqueNum(1),
   doc(NULL),
   partialCopySource(NULL),
+  varargOldFormal(NULL),
   retSymbol(NULL)
 {
   substitutions.clear();
@@ -1767,6 +1769,15 @@ void FnSymbol::finalizeCopy(void) {
      * replacements.
      */
     update_symbols(this, map);
+
+    // Replace vararg formal if appropriate.
+    if (this->varargOldFormal) {
+      substituteVarargTupleRefs(this->body, this->varargNewFormals.size(),
+                                this->varargOldFormal, this->varargNewFormals);
+      // Done, clean up.
+      this->varargOldFormal = NULL;
+      this->varargNewFormals.clear();
+    }
 
     // Clean up book keeping information.
     this->partialCopyMap.clear();

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -353,10 +353,17 @@ class FnSymbol : public Symbol {
   int codegenUniqueNum;
   const char *doc;
 
+  // The following fields are used only when hasFlag(FLAG_PARTIAL_COPY)
+  // to pass information from partialCopy() to finalizeCopy().
   /// Used to keep track of symbol substitutions during partial copying.
   SymbolMap partialCopyMap;
   /// Source of a partially copied function.
   FnSymbol* partialCopySource;
+  /// Vararg formal to be replaced with individual formals, or NULL.
+  ArgSymbol* varargOldFormal;
+  /// Individual formals to replace varargOldFormal.
+  std::vector<ArgSymbol*> varargNewFormals;
+
   /// Used to store the return symbol during partial copying.
   Symbol* retSymbol;
   /// Number of formals before tuple type constructor formals are added.
@@ -584,6 +591,9 @@ const char* intentDescrString(IntentTag intent);
 // Return true if the arg must use a C pointer whether or not
 // pass-by-reference intents are used.
 bool argMustUseCPtr(Type* t);
+
+void substituteVarargTupleRefs(BlockStmt* ast, int numArgs, ArgSymbol* formal,
+                               std::vector<ArgSymbol*>& varargFormals);
 
 extern bool localTempNames;
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1647,6 +1647,167 @@ computeGenericSubs(SymbolMap &subs,
 }
 
 
+//
+// Assuming 'parent' is an indexing expression into the tuple 'se',
+// return the index, between 1 and numArgs. Otherwise return 0.
+//
+static int varargAccessIndex(SymExpr* se, CallExpr* parent, int numArgs) {
+  if (se == parent->baseExpr) {
+    if(parent->numActuals() == 1) {
+      VarSymbol* idxVar = toVarSymbol(toSymExpr(parent->get(1))->var);
+      if (idxVar && idxVar->immediate &&
+          idxVar->immediate->const_kind == NUM_KIND_INT) {
+        int idxNum = idxVar->immediate->int_value();
+        if (1 <= idxNum && idxNum <= numArgs)
+          return idxNum;
+        // report an "index out of bounds" error otherwise?
+      }
+    }
+  }
+  return 0;
+}
+
+//
+// 'parent' corresponds to tuple(i); replace it with 'replFormal'.
+//
+// If 'parent' is the source of a prim_move into a temp 'dest',
+// then eliminate 'dest' altogether, replacing its uses with 'replFormal'.
+//
+// Q: Why not just keep move(dest,replFormal), which is simpler?
+// A: because 'move' does not preserv replFormal's ref-ness and const-ness,
+// so we will get errors when using dest on the l.h.s. and miss errors
+// when dest or deref(dest) is modified and it shouldn't.
+// Note that we are here before the code is resolved, so we do not
+// necessarily know whether 'replFormal' is a const and/or a ref.
+// To keep 'dest' around, instead of move we probably need to add
+// the AST equivalent of Chapel's "ref dest = replFormal;".
+//
+static void replaceVarargAccess(CallExpr* parent, SymExpr* se,
+                                ArgSymbol* replFormal, SymbolMap& tempReps)
+{
+  if (CallExpr* move = toCallExpr(parent->parentExpr))
+    if (move->isPrimitive(PRIM_MOVE)) {
+      Symbol* dest = toSymExpr(move->get(1))->var;
+      if (dest->hasFlag(FLAG_TEMP)) {
+        // Remove the def of 'dest'.
+        dest->defPoint->remove();
+        move->remove();
+        // Uses of 'dest' will come later. We replace them with 'replFormal'
+        // in substituteVarargTupleRefs() using 'tempReps'.
+        tempReps.put(dest, replFormal);
+        return;
+      }
+    }
+  // Otherwise, just replace 'parent'.
+  parent->replace(new SymExpr(replFormal));
+}
+
+//
+// Is 'parent' the call 'se'.size?
+//
+static bool isVarargSizeExpr(SymExpr* se, CallExpr* parent)
+{
+  if (parent->isNamed("size"))
+    // Is 'parent' a method call?
+    if (parent->numActuals() == 2)
+      if (SymExpr* firstArg = toSymExpr(parent->get(1)))
+        if (firstArg->var->type == dtMethodToken) {
+          // If this fails, ensure that isVarargSizeExpr still works correctly.
+          INT_ASSERT(parent->get(2) == se);
+          return true;
+        }
+  return false;
+}
+
+//
+// Does 'ast' contain use(s) of the vararg tuple 'formal'
+// that require 'formal' as a whole tuple?
+//
+// needVarArgTupleAsWhole() and substituteVarargTupleRefs() should handle
+// the exact same set of SymExprs.
+//
+static bool needVarArgTupleAsWhole(BlockStmt* ast, int numArgs,
+                                   ArgSymbol* formal)
+{
+  std::vector<SymExpr*> symExprs;
+  collectSymExprs(ast, symExprs);
+
+  for_vector(SymExpr, se, symExprs) {
+    if (se->var == formal) {
+      if (CallExpr* parent = toCallExpr(se->parentExpr)) {
+        if (parent->isPrimitive(PRIM_TUPLE_EXPAND)) {
+          // (...formal) -- does not require
+          continue;
+        }
+        if (varargAccessIndex(se, parent, numArgs) > 0) {
+          // formal(i) -- does not require
+          continue;
+        }
+        if (isVarargSizeExpr(se, parent)) {
+          // formal.size -- does not require
+          continue;
+        }
+      }
+      // Something else ==> may require.
+      return true;
+    }
+  }
+
+  // The 'formal' is used only in "does not require" cases.
+  return false;
+}
+
+//
+// Replace, in 'ast', uses of the vararg tuple 'formal'
+// with references to individual formals.
+//
+// needVarArgTupleAsWhole() and substituteVarargTupleRefs() should handle
+// the exact same set of SymExprs.
+//
+void substituteVarargTupleRefs(BlockStmt* ast, int numArgs, ArgSymbol* formal,
+                               std::vector<ArgSymbol*>& varargFormals)
+{
+  std::vector<SymExpr*> symExprs;
+  collectSymExprs(ast, symExprs);
+  SymbolMap tempReps;
+
+  for_vector(SymExpr, se, symExprs) {
+    if (se->var == formal) {
+      if (CallExpr* parent = toCallExpr(se->parentExpr)) {
+        SET_LINENO(parent);
+
+        if (parent->isPrimitive(PRIM_TUPLE_EXPAND)) {
+          // Replace 'parent' with a sequence of individual args.
+          for_vector(ArgSymbol, arg, varargFormals)
+            parent->insertBefore(new SymExpr(arg));
+          parent->remove();
+          continue;
+        }
+
+        if (int idxNum = varargAccessIndex(se, parent, numArgs)) {
+          INT_ASSERT(1 <= idxNum && idxNum <= numArgs);
+          ArgSymbol* replFormal = varargFormals[idxNum-1];
+          replaceVarargAccess(parent, se, replFormal, tempReps);
+          continue;
+        }
+
+        if (isVarargSizeExpr(se, parent)) {
+          parent->replace(new SymExpr(new_IntSymbol(numArgs)));
+          continue;
+        }
+
+      }
+      // Cases not "continue"-ed above should have been ruled out
+      // by needVarArgTupleAsWhole().
+      INT_ASSERT(false);
+    } else if (Symbol* replmt = tempReps.get(se->var)) {
+      SET_LINENO(se);
+      se->replace(new SymExpr(replmt));
+    }
+  }
+}
+
+
 /** Common code for multiple paths through expandVarArgs.
  *
  * This code handles the case where the number of varargs are known at compile
@@ -1657,16 +1818,17 @@ static void
 handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
                              ArgSymbol* formal,
                              SymExpr*   sym) {
-  workingFn->addFlag(FLAG_EXPANDED_VARARGS);
-
   // Handle specified number of variable arguments.
   // sym->var is not a VarSymbol e.g. in: proc f(param n, v...n)
   if (VarSymbol* nVar = toVarSymbol(sym->var)) {
     if (nVar->type == dtInt[INT_SIZE_DEFAULT] && nVar->immediate) {
+      workingFn->addFlag(FLAG_EXPANDED_VARARGS);
+
+      SET_LINENO(formal);
       VarSymbol* var       = new VarSymbol(formal->name);
       int        n         = nVar->immediate->int_value();
       CallExpr*  tupleCall = NULL;
-
+      std::vector<ArgSymbol*> varargFormals(n);
       if (formal->hasFlag(FLAG_TYPE_VARIABLE) == true)
         tupleCall = new CallExpr("_type_construct__tuple");
       else
@@ -1683,27 +1845,55 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
         newFormal->cname        = astr("_e", istr(i), "_", formal->cname);
 
         tupleCall->insertAtTail(new SymExpr(newFormal));
-
         formal->defPoint->insertBefore(newArgDef);
+        varargFormals[i] = newFormal;
       }
+
+      bool needTupleInBody = true; //avoid "may be used uninitialized" warning
 
       // Replace mappings to the old formal with mappings to the new variable.
       if (workingFn->hasFlag(FLAG_PARTIAL_COPY)) {
+        bool gotFormal = false; // for assertion only
         for (int index = workingFn->partialCopyMap.n; --index >= 0;) {
           SymbolMapElem& mapElem = workingFn->partialCopyMap.v[index];
 
           if (mapElem.value == formal) {
-            mapElem.value = var;
+            gotFormal = true;
+            needTupleInBody =
+              needVarArgTupleAsWhole(workingFn->partialCopySource->body, n,
+                                     toArgSymbol(mapElem.key));
+
+            if (needTupleInBody) {
+              mapElem.value = var;
+            } else {
+              // We will rely on mapElem.value==formal to replace it away
+              // in finalizeCopy().  This assumes a single set of varargs.
+              workingFn->varargOldFormal = formal;
+              workingFn->varargNewFormals = varargFormals;
+            }
+
             break;
           }
         }
+        // If !gotFormal, still need to compute needTupleInBody.
+        // What to pass for 'formal' argument? Or maybe doesn't matter?
+        INT_ASSERT(gotFormal);
+      } else {
+        needTupleInBody = needVarArgTupleAsWhole(workingFn->body, n, formal);
       }
 
       if (formal->hasFlag(FLAG_TYPE_VARIABLE)) {
         var->addFlag(FLAG_TYPE_VARIABLE);
       }
 
+      // This is needed regardless of needTupleInBody...
       if (formal->intent == INTENT_OUT || formal->intent == INTENT_INOUT) {
+        // ... however, we need temporaries even if !needTupleInBody.
+        // Creating one temporary per formal is left as future work.
+        // A challenge is whether varargFormals should contain these
+        // per-formal temporaries instead of the formals, in this case.
+        needTupleInBody = true;
+
         int i = 0;
 
         for_actuals(actual, tupleCall) {
@@ -1725,83 +1915,94 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
         }
       }
 
-      // MDN 2016/02/01. Enable special handling for strings with blank intent
+      if (needTupleInBody) {
 
-      // If the original formal is a string with blank intent then the
-      // new formals appear to be strings with blank intent.  However
-      // the resolver is about to update these to be const ref intent.
-      //
-      // Currently this will cause the tuple to appear to be a tuple
-      // ref(String) which is not supported.
-      //
-      // Insert local copies that can be used for the tuple
+        // MDN 2016/02/01. Enable special handling for strings with blank intent
 
-      if (isString(formal->type) && formal->intent == INTENT_BLANK) {
-        DefExpr* varDefn = new DefExpr(var);
-        Expr*    tail    = NULL;
+        // If the original formal is a string with blank intent then the
+        // new formals appear to be strings with blank intent.  However
+        // the resolver is about to update these to be const ref intent.
+        //
+        // Currently this will cause the tuple to appear to be a tuple
+        // ref(String) which is not supported.
+        //
+        // Insert local copies that can be used for the tuple
 
-        // Insert the new locals
-        for (int i = 0; i < n; i++) {
-          const char* localName = astr("_e", istr(i + n), "_", formal->name);
-          VarSymbol*  local     = newTemp(localName, formal->type);
-          DefExpr*    defn      = new DefExpr(local);
+        if (isString(formal->type) && formal->intent == INTENT_BLANK) {
+          DefExpr* varDefn = new DefExpr(var);
+          Expr*    tail    = NULL;
 
-          if (tail == NULL)
-            workingFn->insertAtHead(defn);
-          else
-            tail->insertAfter(defn);
+          // Insert the new locals
+          for (int i = 0; i < n; i++) {
+            const char* localName = astr("_e", istr(i + n), "_", formal->name);
+            VarSymbol*  local     = newTemp(localName, formal->type);
+            DefExpr*    defn      = new DefExpr(local);
 
-          tail = defn;
+            if (tail == NULL)
+              workingFn->insertAtHead(defn);
+            else
+              tail->insertAfter(defn);
+
+            tail = defn;
+          }
+
+          // Insert the definition for the tuple
+          tail->insertAfter(varDefn);
+          tail = varDefn;
+
+          // Insert the copies from the blank-intent strings to the locals
+          // Update the arguments to the tuple call
+          for (int i = 1; i <= n; i++) {
+            DefExpr*  localDefn = toDefExpr(workingFn->body->body.get(i));
+            Symbol*   local     = localDefn->sym;
+            SymExpr*  localExpr = new SymExpr(local);
+
+            SymExpr*  tupleArg  = toSymExpr(tupleCall->get(i + 1));
+            SymExpr*  copyArg   = tupleArg->copy();
+
+            CallExpr* moveExpr  = new CallExpr(PRIM_MOVE, localExpr, copyArg);
+
+            tupleArg->var = local;
+
+            tail->insertAfter(moveExpr);
+            tail = moveExpr;
+          }
+
+          tail->insertAfter(new CallExpr(PRIM_MOVE, var, tupleCall));
+        } else {
+          workingFn->insertAtHead(new CallExpr(PRIM_MOVE, var, tupleCall));
+          workingFn->insertAtHead(new DefExpr(var));
         }
 
-        // Insert the definition for the tuple
-        tail->insertAfter(varDefn);
-        tail = varDefn;
-
-        // Insert the copies from the blank-intent strings to the locals
-        // Update the arguments to the tuple call
-        for (int i = 1; i <= n; i++) {
-          DefExpr*  localDefn = toDefExpr(workingFn->body->body.get(i));
-          Symbol*   local     = localDefn->sym;
-          SymExpr*  localExpr = new SymExpr(local);
-
-          SymExpr*  tupleArg  = toSymExpr(tupleCall->get(i + 1));
-          SymExpr*  copyArg   = tupleArg->copy();
-
-          CallExpr* moveExpr  = new CallExpr(PRIM_MOVE, localExpr, copyArg);
-
-          tupleArg->var = local;
-
-          tail->insertAfter(moveExpr);
-          tail = moveExpr;
+        if (workingFn->hasFlag(FLAG_PARTIAL_COPY)) {
+          // If this is a partial copy, store the mapping for substitution later.
+          workingFn->partialCopyMap.put(formal, var);
+        } else {
+          // Otherwise, do the substitution now.
+          subSymbol(workingFn->body, formal, var);
         }
-
-        tail->insertAfter(new CallExpr(PRIM_MOVE, var, tupleCall));
       } else {
-        workingFn->insertAtHead(new CallExpr(PRIM_MOVE, var, tupleCall));
-        workingFn->insertAtHead(new DefExpr(var));
-      }
-
-      if (workingFn->hasFlag(FLAG_PARTIAL_COPY)) {
-        // If this is a partial copy, store the mapping for substitution later.
-        workingFn->partialCopyMap.put(formal, var);
-      } else {
-        // Otherwise, do the substitution now.
-        subSymbol(workingFn->body, formal, var);
+        // !needTupleInBody
+        substituteVarargTupleRefs(workingFn->body, n, formal, varargFormals);
       }
 
       if (workingFn->where) {
-        VarSymbol* var  = new VarSymbol(formal->name);
-        CallExpr*  move = new CallExpr(PRIM_MOVE, var, tupleCall->copy());
+        if (needVarArgTupleAsWhole(workingFn->where, n, formal)) {
+          VarSymbol* var  = new VarSymbol(formal->name);
+          CallExpr*  move = new CallExpr(PRIM_MOVE, var, tupleCall->copy());
 
-        if (formal->hasFlag(FLAG_TYPE_VARIABLE)) {
-          var->addFlag(FLAG_TYPE_VARIABLE);
+          if (formal->hasFlag(FLAG_TYPE_VARIABLE)) {
+            var->addFlag(FLAG_TYPE_VARIABLE);
+          }
+
+          workingFn->where->insertAtHead(move);
+          workingFn->where->insertAtHead(new DefExpr(var));
+
+          subSymbol(workingFn->where, formal, var);
+        } else {
+          // !needVarArgTupleAsWhole()
+          substituteVarargTupleRefs(workingFn->where, n, formal, varargFormals);
         }
-
-        workingFn->where->insertAtHead(move);
-        workingFn->where->insertAtHead(new DefExpr(var));
-
-        subSymbol(workingFn->where, formal, var);
       }
 
       formal->defPoint->remove();
@@ -1863,6 +2064,7 @@ expandVarArgs(FnSymbol* origFn, int numActuals) {
 
     // Handle unspecified variable number of arguments.
     if (DefExpr* def = toDefExpr(formal->variableExpr->body.tail)) {
+      // This assumes a single set of varargs.
       int numCopies = numActuals - workingFn->numFormals() + 1;
       if (numCopies <= 0) {
         if (workingFn != origFn) delete workingFn;
@@ -1879,8 +2081,10 @@ expandVarArgs(FnSymbol* origFn, int numActuals) {
         formal = static_cast<ArgSymbol*>(substitutions.get(formal));
       }
 
+      // newSym queries the number of varargs. Replace it with int literal.
       Symbol*  newSym     = substitutions.get(def->sym);
       SymExpr* newSymExpr = new SymExpr(new_IntSymbol(numCopies));
+      newSymExpr->astloc = newSym->astloc;
       newSym->defPoint->replace(newSymExpr);
 
       subSymbol(workingFn, newSym, new_IntSymbol(numCopies));

--- a/test/compflags/bradc/minimalModules/minModVarArgs.chpl
+++ b/test/compflags/bradc/minimalModules/minModVarArgs.chpl
@@ -1,0 +1,10 @@
+// Varargs work out of the box in limited cases.
+
+extern proc printf(f:c_string, args...);
+
+proc hello(args...) {
+  printf(c"Hello %s #%d with %d varargs and #%d\n",
+         (...args), args.size:int(8), args(2));
+}
+
+hello(c"World", 32:int(8));

--- a/test/compflags/bradc/minimalModules/minModVarArgs.good
+++ b/test/compflags/bradc/minimalModules/minModVarArgs.good
@@ -1,0 +1,1 @@
+Hello World #32 with 2 varargs and #32

--- a/test/functions/vass/resolution/param-detuple.chpl
+++ b/test/functions/vass/resolution/param-detuple.chpl
@@ -11,3 +11,4 @@ proc p2(param args...) {
 
 p2("a");
 p2("a","b");
+compilerAssert(false, "done", 2); // exercise stack-not-deep-enough warning

--- a/test/functions/vass/resolution/param-detuple.future
+++ b/test/functions/vass/resolution/param-detuple.future
@@ -1,5 +1,0 @@
-feature request: detuple of a param tuple to be a sequence of param values
-
-Right now it's a sequence of non-param values.
-This, e.g., does not let me pass param varargs through to other
-param varargs functions.

--- a/test/functions/vass/resolution/param-detuple.good
+++ b/test/functions/vass/resolution/param-detuple.good
@@ -2,3 +2,6 @@ param-detuple.chpl:8: In function 'p2':
 param-detuple.chpl:9: warning: param proc
 param-detuple.chpl:8: In function 'p2':
 param-detuple.chpl:9: warning: param proc
+$CHPL_HOME/modules/internal/ChapelBase.chpl: In function 'compilerError':
+$CHPL_HOME/modules/internal/ChapelBase.chpl: warning: compiler diagnostic depth value exceeds call stack depth
+param-detuple.chpl:14: error: assert failed - done

--- a/test/functions/vass/resolution/param-detuple.prediff
+++ b/test/functions/vass/resolution/param-detuple.prediff
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat $2 | sed s@ChapelBase.chpl:..:@ChapelBase.chpl:@ > $2.tmp
+mv $2.tmp $2

--- a/test/functions/vass/varargs-1.chpl
+++ b/test/functions/vass/varargs-1.chpl
@@ -1,0 +1,95 @@
+
+var A111: [1..2] int = 101, i222 = 102;
+
+proc show(tag, var11, var22) {
+  writeln(tag, " :  ", var11, "  ", var22);
+}
+
+proc main {
+  test_param("arg1 ", "arg2 ");
+  test_param_typed("arg1 ", "arg2 ");
+  test_param_queried("arg1 ", "arg2 ");
+  show(1000, A111, i222);
+  test_default(A111, 71);
+  test_const(A111, 72);
+  test_in(A111, i222);
+  test_const_in(A111, 73);
+  test_out(A111, i222);
+  test_inout(A111, i222);
+  test_ref(A111, i222);
+  test_const_ref(A111, i222);
+  show(9999, A111, i222);
+}
+
+proc test_param(param xxx...) {
+  compilerWarning(xxx(1));
+  compilerWarning(xxx(2));
+  compilerWarning((...xxx));
+  compilerWarning(xxx.size:string);
+  show(81, xxx(1), xxx(2));
+}
+
+proc test_param_typed(param xxx:string...) {
+  compilerWarning(xxx(1));
+  compilerWarning(xxx(2));
+  compilerWarning((...xxx));
+  compilerWarning(xxx.size:string);
+  show(82, xxx(1), xxx(2));
+}
+
+proc test_param_queried(param xxx...?nnn) {
+  compilerWarning(xxx(1));
+  compilerWarning(xxx(2));
+  compilerWarning((...xxx));
+  if nnn == xxx.size then
+    compilerWarning("YES!!!");
+  else
+    compilerWarning("noooo");
+  show(83, xxx(1), xxx(2));
+}
+
+proc test_default(xxx...) {
+  show(1001, xxx(1), xxx(2));
+  xxx(1) = 105;
+  show(1009, xxx(1), xxx(2));
+}
+
+proc test_const(const xxx...) {
+  show(2001, xxx(1), xxx(2));
+}
+
+proc test_in(in xxx...) {
+  show(3001, xxx(1), xxx(2));
+  xxx(1) = 301;
+  xxx(2) = 302;
+  show(3009, xxx(1), xxx(2));
+}
+
+proc test_const_in(const in xxx...) {
+  show(4001, xxx(1), xxx(2));
+}
+
+proc test_out(out xxx...) {
+  show(5001, xxx(1), xxx(2));
+  xxx(1) = 501;
+  xxx(2) = 502;
+  show(5009, xxx(1), xxx(2));
+}
+
+proc test_inout(inout xxx...) {
+  show(6001, xxx(1), xxx(2));
+  xxx(1) = 601;
+  xxx(2) = 602;
+  show(6009, xxx(1), xxx(2));
+}
+
+proc test_ref(ref xxx...) {
+  show(7001, xxx(1), xxx(2));
+  xxx(1) = 701;
+  xxx(2) = 702;
+  show(7009, xxx(1), xxx(2));
+}
+
+proc test_const_ref(const ref xxx...) {
+  show(8001, xxx(1), xxx(2));
+}

--- a/test/functions/vass/varargs-1.good
+++ b/test/functions/vass/varargs-1.good
@@ -1,0 +1,31 @@
+varargs-1.chpl:8: In function 'main':
+varargs-1.chpl:9: warning: arg1 
+varargs-1.chpl:9: warning: arg2 
+varargs-1.chpl:9: warning: arg1 arg2 
+varargs-1.chpl:9: warning: 2
+varargs-1.chpl:10: warning: arg1 
+varargs-1.chpl:10: warning: arg2 
+varargs-1.chpl:10: warning: arg1 arg2 
+varargs-1.chpl:10: warning: 2
+varargs-1.chpl:11: warning: arg1 
+varargs-1.chpl:11: warning: arg2 
+varargs-1.chpl:11: warning: arg1 arg2 
+varargs-1.chpl:11: warning: YES!!!
+81 :  arg1   arg2 
+82 :  arg1   arg2 
+83 :  arg1   arg2 
+1000 :  101 101  102
+1001 :  101 101  71
+1009 :  105 105  71
+2001 :  105 105  72
+3001 :  105 105  102
+3009 :  301 301  302
+4001 :  105 105  73
+5001 :  0 0  0
+5009 :  501 501  502
+6001 :  501 501  502
+6009 :  601 601  602
+7001 :  601 601  602
+7009 :  701 701  702
+8001 :  701 701  702
+9999 :  701 701  702

--- a/test/functions/vass/varargs-2.chpl
+++ b/test/functions/vass/varargs-2.chpl
@@ -1,0 +1,73 @@
+// Note there is a TODO in this test.
+// When it is done, update the .good.
+
+
+var A111: [1..2] int, i222 = 2222;
+
+proc showit(tag, var11, var22) {
+  writeln(tag, " :  ", var11, "  ", var22);
+}
+
+
+// these invoke showit()
+
+proc show_default(xxx...) {
+  xxx(1) = 4444;  // OK for an array
+  xxx(2) = 5555;  // error: can't assign to 'const'
+  showit(11, xxx(2), xxx(1));
+}
+
+proc show_const(const xxx...) {
+  xxx(1) = 4444;  // TODO: error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+  showit(12, xxx(2), xxx(1));
+}
+
+proc show_const_in(const in xxx...) {
+  xxx(1) = 4444;  // error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+  showit(13, xxx(2), xxx(1));
+}
+
+proc show_const_ref(const ref xxx...) {
+  xxx(1) = 4444;  // error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+  showit(14, xxx(2), xxx(1));
+}
+
+
+// these do not call showit()
+
+proc test_default(xxx...) {
+  xxx(1) = 4444;  // OK for an array
+  xxx(2) = 5555;  // error: can't assign to 'const'
+}
+
+proc test_const(const xxx...) {
+  xxx(1) = 4444;  // TODO: error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+}
+
+proc test_const_in(const in xxx...) {
+  xxx(1) = 4444;  // error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+}
+
+proc test_const_ref(const ref xxx...) {
+  xxx(1) = 4444;  // error: can't assign to 'const'
+  xxx(2) = 5555;  // error: can't assign to 'const'
+}
+
+
+
+proc main {
+  show_default(A111, i222);
+  show_const(A111, i222);
+  show_const_in(A111, i222);
+  show_const_ref(A111, i222);
+
+  test_default(A111, i222);
+  test_const(A111, i222);
+  test_const_in(A111, i222);
+  test_const_ref(A111, i222);
+}

--- a/test/functions/vass/varargs-2.good
+++ b/test/functions/vass/varargs-2.good
@@ -1,0 +1,20 @@
+varargs-2.chpl:14: In function 'show_default':
+varargs-2.chpl:16: error: illegal lvalue in assignment
+varargs-2.chpl:20: In function 'show_const':
+varargs-2.chpl:22: error: illegal lvalue in assignment
+varargs-2.chpl:26: In function 'show_const_in':
+varargs-2.chpl:27: error: illegal lvalue in assignment
+varargs-2.chpl:28: error: illegal lvalue in assignment
+varargs-2.chpl:32: In function 'show_const_ref':
+varargs-2.chpl:33: error: illegal lvalue in assignment
+varargs-2.chpl:34: error: illegal lvalue in assignment
+varargs-2.chpl:41: In function 'test_default':
+varargs-2.chpl:43: error: illegal lvalue in assignment
+varargs-2.chpl:46: In function 'test_const':
+varargs-2.chpl:48: error: illegal lvalue in assignment
+varargs-2.chpl:51: In function 'test_const_in':
+varargs-2.chpl:52: error: illegal lvalue in assignment
+varargs-2.chpl:53: error: illegal lvalue in assignment
+varargs-2.chpl:56: In function 'test_const_ref':
+varargs-2.chpl:57: error: illegal lvalue in assignment
+varargs-2.chpl:58: error: illegal lvalue in assignment


### PR DESCRIPTION
WE USED TO

combine varargs into a tuple the first thing in a function.
E.g when this function:

  proc test(args...) {
    BODY;
  }

is invoked with two formals, the compiler instantiates it into:

  proc test(_e0_args, _e1_args) {
    var args = _build_tuple(2, _e0_args, _e1_args);
    BODY;
  }

Indeed the vararg tuple is created in the callee, not the caller.

WITH THIS COMMIT,

the compiler no longer inserts the _build_tuple() call or creates
the local 'args' tuple when:

(A) BODY does not need 'args' as a whole tuple (see below), and
(B) the "args..." formal's intent is not 'out' or 'inout'.

This results in simpler generated code. Also, as the primary motivation
for this change, if the args formal has a param or type intent, then
(...args) consists of params or types, resp. This latter was not the case
prior to this change.

(A) details: the compiler considers (A) to hold when the only uses
of 'args' in the body, if any, are these:

  (A1) (...args)           --> replaced with _e0_args, _e1_args
  (A2) args(i) for param i --> replaced with _e0_args or _e1_args
  (A3) args.size           --> replaced with 2

The replacements shown are for the test() example above.

(B) details: supporting out/inout intent is left as future work.
These intents require formal temps. So instead of the 'args' tuple
we'd have to create individual temps. Maybe this wouldn't be
much savings to begin with?

IMPLEMENTATION NOTES

When the function whose varargs are being instantiated
had FLAG_PARTIAL_COPY, the replacements needed to be done
separately. The necessary information is passed through
the fields I added on FnSymbol.

While there, I added a missing SET_LINENO and in a different
spot set a node's astloc manually, which is more lightweight
than SET_LINENO.

MULTIPLE VARARGS

are not supported by my changes. This is because FnSymbol
has only a single pair of varargOldFormal and varargNewFormals
fields. One way to support multiple sets of varargs is to
convert the two fields to a map old-formals to their respective
new-formals vectors. Another way is to fall back on the current
create-a-tuple implementation.

Note that the compiler already does not support multiple sets of
varargs. This is mainly because the number of vararg actuals is
computed like so:

  int numCopies = numActuals - workingFn->numFormals() + 1;

If we were, for example, to distinguish different sets of varargs
by their types, we would need to run the entire instantiation
machinery before computing numCopies and instantiating again.

ALSO ADDED TESTS

that exercise varargs in various ways.

Varargs now work with --minimal-modules, too, as long
as (A) and (B) above are satisfied - see minModVarArgs.chpl

This replaces #3838 
