### PR TITLE
Use cstdlib for valgrind testing

### DIFF
--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -7,6 +7,8 @@ source $CWD/common.bash
 source $CWD/common-fifo.bash
 source $CWD/common-valgrind.bash
 
+export CHPL_MEM=cstdlib
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrind"
 
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
The recent upgrade to jemalloc 4.2.0 (#3919) introduced some valgrind errors.
There's at least two issues going on. One is that je_calloc() is no longer
detected as zeroing memory, so valgrind reports uninitialized memory errors.
This is likely a jemalloc bug.

Using the extended API version of je_calloc() is detecting as zeroing, but even
using that, some tests are getting errors about invalid writes.

Until I can get to the bottom of this, use cstdlib for valgrind testing.