### PR TITLE
Turn cpp #line directives / beautify on when debugging

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -277,7 +277,16 @@ void openCFile(fileinfo* fi, const char* name, const char* ext) {
 
 void closeCFile(fileinfo* fi, bool beautifyIt) {
   fclose(fi->fptr);
-  if (beautifyIt && saveCDir[0])
+  //
+  // We should beautify if (1) we were asked to and (2) either (a) we
+  // were asked to save the C code or (b) we're debugging and were
+  // asked to codegen cpp #line information.
+  //
+  // TODO: With some refactoring, we could simply do the #line part of
+  // beautify without also improving indentation and such which could
+  // save some time.
+  //
+  if (beautifyIt && (saveCDir[0] || (debugCCode && printCppLineno)))
     beautify(fi);
 }
 


### PR DESCRIPTION
When debugging with Chris today, we noticed that we weren't getting .chpl
line numbers in our debugger session as expected.  It turns out that when
we turned off beautify unless the generated C was being saved in 6e9a77d16c2bee720a5a4f9eddb92b4d780b3c14 (to save compile
time) we also inadvertently disabled the insertion of C preprocessor
#line directives into the generated code).  In this pull request, I'm re-enabling
the beautify pass in the event that we're debugging the C code and the
--cpp-lines flag is on (explicitly or by default).

As future work, we could potentially permit separate control of inserting #line 
directives and doing the other aspects of tabbing/formatting that beautify does
to get the former without the latter.  Here I just took the simple approach of
both or neither (figuring that it wouldn't add much time to our nightly testing
since most configurations aren't tested with -g on and that when you're
debugging, you probably won't mind the minor extra overhead).