### PR TITLE
Fix setter-assigned-to-a-var valgrind .bad mismatch

### DIFF
--- a/test/arrays/vass/setter-assigned-to-a-var.bad
+++ b/test/arrays/vass/setter-assigned-to-a-var.bad
@@ -1,2 +1,2 @@
 Invalid read of size 8
-Address xxx is 24 bytes inside a block of size 160 free'd
+Address xxx is 24 bytes inside a block of size xxx free'd

--- a/test/arrays/vass/setter-assigned-to-a-var.prediff
+++ b/test/arrays/vass/setter-assigned-to-a-var.prediff
@@ -8,6 +8,8 @@ mv $outfile $outfile.save
 # 'head -2' is to keep only what comes from the first anticipated error
 # this should increase the determinism of the output, for .bad
 #
-grep -E 'Invalid read|Address 0x.* is' $outfile.save | head -2 \
-| sed 's@^.*Invalid read@Invalid read@; s@^.*Address .* is@Address xxx is@' \
+grep -E 'Invalid read|Address 0x.* is' $outfile.save | head -2 | \
+sed 's@^.*Invalid read@Invalid read@' | \
+sed 's@^.*Address .* is@Address xxx is@' | \
+sed 's@size .* free@size xxx free@' \
 > $outfile


### PR DESCRIPTION
setter-assigned-to-a-var started failing when I reverted to using cstdlib for
valgrind testing. This is because valgrind prints out the size of the memory
block a leak is in, and that can differ across allocators. Update the prediff
to make the .bad block size agnostic.