### PR TITLE
Extend AstDumpToNode to support new-ish node ContextCallExpr

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -45,12 +45,15 @@ void AstDumpToNode::view(const char* passName, int passNum)
   {
     if (log_module[0] == '\0' || strcmp(log_module, module->name) == 0)
     {
-      view(passName, passNum, module);
+      if (strcmp(module->name, "_root") != 0)
+        view(passName, passNum, module);
     }
   }
 }
 
-void AstDumpToNode::view(const char* passName, int passNum, ModuleSymbol* module)
+void AstDumpToNode::view(const char*   passName,
+                         int           passNum,
+                         ModuleSymbol* module)
 {
   AstDumpToNode logger;
 
@@ -128,25 +131,25 @@ bool AstDumpToNode::close()
   return retval;
 }
 
-/******************************** | *********************************
-*                                                                   *
-* The visit functions for each concrete class                       *
-*                                                                   *
-* Note that there are default implementations in AstLogger          *
-*                                                                   *
-********************************* | ********************************/
+/************************************* | **************************************
+*                                                                             *
+* The visit functions for each concrete class                                 *
+*                                                                             *
+* Note that there are default implementations in AstLogger                    *
+*                                                                             *
+************************************** | *************************************/
 
 // pad right to longStringLength unless compact
 void AstDumpToNode::writeLongString(const char* msg, const char* arg) const
 {
-  static const size_t longStringLength = 36;
+  static const size_t longStringLength = 38;
 
   fputs(msg, mFP);
 
   if (compact || strlen(arg) >= longStringLength)
     fputs(arg, mFP);
   else
-    fprintf(mFP, "%-36s", arg);
+    fprintf(mFP, "%-28s", arg);
 }
 
 // Print the node ID, only if desired i.e. if showNodeIDs.
@@ -163,7 +166,7 @@ void AstDumpToNode::writeNodeID(BaseAST* node,
     if (compact)
       fprintf(mFP, "%s%d%s",   sb, node->id, sa);
     else
-      fprintf(mFP, "%s%12d%s", sb, node->id, sa);
+      fprintf(mFP, "%s%7d%s", sb, node->id, sa);
   }
 }
 
@@ -172,12 +175,25 @@ void AstDumpToNode::enterNode(BaseAST* node) const
   if (compact)
   {
     fprintf(mFP, "%s%s", delimitEnter, node->astTagAsString());
-    writeNodeID(node, 1, 0);
+    writeNodeID(node, true, false);
   }
   else
   {
-    fprintf(mFP, "%s%-18s", delimitEnter, node->astTagAsString());
-    writeNodeID(node, 0, 0);
+    if (FnSymbol* fn = toFnSymbol(node))
+    {
+      fprintf(mFP, "%s%-10s", delimitEnter, node->astTagAsString());
+      writeNodeID(node, true, false);
+
+      if (fn->hasFlag(FLAG_GENERIC) == true)
+      {
+        fprintf(mFP, " (Generic)");
+      }
+    }
+    else
+    {
+      fprintf(mFP, "%s%-10s", delimitEnter, node->astTagAsString());
+      writeNodeID(node, true, false);
+    }
   }
 }
 
@@ -271,13 +287,12 @@ bool AstDumpToNode::enterBlockStmt(BlockStmt* node)
 
     newline();
     write(false, "BlockInfo: ", false);
-    mOffset = mOffset + 2;
+    mOffset = mOffset + 11;
     node->blockInfoGet()->accept(this);
-    mOffset = mOffset - 2;
+    mOffset = mOffset - 11;
 
     mOffset = mOffset - 2;
-
-    newline();
+    fprintf(mFP, "\n");
   }
 
   // Show blockTag bits.
@@ -669,18 +684,18 @@ bool AstDumpToNode::enterDefExpr(DefExpr* node)
       isFnSymbol(node->sym)     == false &&
       isArgSymbol(node->sym)    == false)
   {
-    fputs(compact ? " sym: " : " sym:      ", mFP);
+    fputs(compact ? " sym:  " : " sym:  ", mFP);
 
     if (compact == false)
-      mOffset = mOffset + 43;
+      mOffset = mOffset + 39;
 
     node->sym->accept(this);
 
     if (compact == false)
-      mOffset = mOffset - 43;
+      mOffset = mOffset - 39;
 
     // NOAKES 2015/02/16 Need better logic for this
-    isSimple = false;
+    //    isSimple = false;
   }
   else
   {
@@ -741,17 +756,53 @@ bool AstDumpToNode::enterFnSym(FnSymbol* node)
 
   mOffset = mOffset + 2;
 
-  if (node->_this && node->_this->defPoint)
-  {
+  if (node->hasFlag(FLAG_BEGIN)               == true ||
+      node->hasFlag(FLAG_ON)                  == true ||
+      node->hasFlag(FLAG_COBEGIN_OR_COFORALL) == true) {
+    int count = 0;
+
     newline();
-    fprintf(mFP, "DefPoint:    ");
-    mOffset = mOffset + 13;
-    ast_symbol(node->_this->type->symbol, false);
-    mOffset = mOffset - 13;
+    fprintf(mFP, "Flags:    ");
+
+    if (node->hasFlag(FLAG_BEGIN)) {
+      fprintf(mFP, "FLAG_BEGIN");
+      count = count + 1;
+    }
+
+    if (node->hasFlag(FLAG_ON)) {
+      if (count > 0)
+        fprintf(mFP, ", ");
+
+      fprintf(mFP, "FLAG_ON");
+      count = count + 1;
+    }
+
+    if (node->hasFlag(FLAG_COBEGIN_OR_COFORALL)) {
+      if (count > 0)
+        fprintf(mFP, ", ");
+
+      fprintf(mFP, "FLAG_COBEGIN_OR_COFORALL");
+      count = count + 1;
+    }
   }
 
   newline();
-  fprintf(mFP, "Name:        %s", node->name);
+  fprintf(mFP, "FileName: %s", node->astloc.filename);
+
+  newline();
+  fprintf(mFP, "LineNum:  %5d", node->astloc.lineno);
+
+  if (node->_this && node->_this->defPoint)
+  {
+    newline();
+    fprintf(mFP, "DefPoint: ");
+    mOffset = mOffset + 10;
+    ast_symbol(node->_this->type->symbol, false);
+    mOffset = mOffset - 10;
+  }
+
+  newline();
+  fprintf(mFP, "Name:     %s", node->name);
 
   // Now the return type info
   switch (node->retTag)
@@ -761,33 +812,33 @@ bool AstDumpToNode::enterFnSym(FnSymbol* node)
 
     case RET_REF:
       newline();
-      write("RetTag:      ref");
+      write("RetTag:   ref");
       break;
 
     case RET_CONST_REF:
       newline();
-      write("RetTag:      const ref");
+      write("RetTag:   const ref");
       break;
 
 
     case RET_PARAM:
       newline();
-      write("RetTag:      param");
+      write("RetTag:   param");
       break;
 
     case RET_TYPE:
       newline();
-      write("RetTag:      type");
+      write("RetTag:   type");
       break;
   }
 
   if (node->retType && node->retType->symbol)
   {
     newline();
-    fprintf(mFP, "RetType:     ");
-    mOffset = mOffset + 13;
+    fprintf(mFP, "RetType:  ");
+    mOffset = mOffset + 10;
     node->retType->symbol->accept(this);
-    mOffset = mOffset - 13;
+    mOffset = mOffset - 10;
   }
 
   newline();
@@ -795,9 +846,9 @@ bool AstDumpToNode::enterFnSym(FnSymbol* node)
 
   if (node->formals.length > 0)
   {
-    fprintf(mFP, "     ");
+    fprintf(mFP, "  ");
 
-    mOffset = mOffset + 13;
+    mOffset = mOffset + 10;
 
     for_alist(next_ast, node->formals)
     {
@@ -809,29 +860,29 @@ bool AstDumpToNode::enterFnSym(FnSymbol* node)
       next_ast->accept(this);
     }
 
-    mOffset = mOffset - 13;
+    mOffset = mOffset - 10;
   }
 
   if (node->body)
   {
     newline();
-    writeField("Body:        ", 13, node->body);
+    writeField("Body:     ", 10, node->body);
   }
 
   if (node->where)
   {
     newline();
-    writeField("Where:       ", 13, node->where);
+    writeField("Where:    ", 10, node->where);
   }
 
   if (node->retExprType)
   {
     newline();
-    write(false, "RetExprType: ", false);
+    write(false, "RetExprType:  ", false);
 
-    mOffset = mOffset + 13;
+    mOffset = mOffset + 10;
     node->retExprType->accept(this);
-    mOffset = mOffset - 13;
+    mOffset = mOffset - 10;
   }
 
   mOffset = mOffset - 2;
@@ -848,14 +899,26 @@ bool AstDumpToNode::enterFnSym(FnSymbol* node)
 
 bool AstDumpToNode::enterCallExpr(CallExpr* node)
 {
-  enterNode(node);
+  if (node->primitive == 0)
+    fprintf(mFP, "#<%-12s", "Call");
+
+  else if (node->isPrimitive(PRIM_RETURN))
+    fprintf(mFP, "#<%-12s", "Return");
+
+  else
+  {
+    char name[128];
+
+    sprintf(name, "PrimOp %s", node->primitive->name);
+    fprintf(mFP, "#<%-12s", name);
+  }
+
+  writeNodeID(node, false, false);
 
   mOffset = mOffset + 2;
 
   if (compact)
     mNeedSpace = true;
-  else
-    newline();
 
   if (FnSymbol* fn = node->theFnSymbol())
   {
@@ -873,25 +936,6 @@ bool AstDumpToNode::enterCallExpr(CallExpr* node)
       fprintf(mFP, " '%s'", primitive->name);
     }
   }
-
-  else if (node->primitive == 0)
-    write("call");
-
-  else if (node->isPrimitive(PRIM_RETURN))
-    write("return");
-
-  else if (node->isPrimitive(PRIM_YIELD))
-    write("yield ");
-
-  else
-  {
-    fprintf(mFP, "PrimOp: \"");
-    write(node->primitive->name);
-    fprintf(mFP, "\"");
-  }
-
-  if (node->partialTag)
-    write("(partial)");
 
   if (node->baseExpr)
   {
@@ -1007,10 +1051,12 @@ void AstDumpToNode::visitUseStmt(UseStmt* node)
 
   if (!node->isPlainUse()) {
     node->writeListPredicate(mFP);
+
     for_vector(const char, str, node->named) {
       newline();
       fprintf(mFP, "%s", str);
     }
+
     for (std::map<const char*, const char*>::iterator it = node->renamed.begin();
          it != node->renamed.end(); ++it) {
       newline();
@@ -1328,12 +1374,11 @@ void AstDumpToNode::visitVarSym(VarSymbol* node)
   writeSymbol(node);
 }
 
-/******************************** | *********************************
-*                                                                   *
-* Helper routines                                                   *
-*                                                                   *
-********************************* | ********************************/
-
+/************************************* | **************************************
+*                                                                             *
+* Helper routines                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 // "module." or "class::" is applicable, "" otherwise
 // beware it may return a static buffer
@@ -1373,6 +1418,7 @@ void AstDumpToNode::writeSymbol(Symbol* sym) const
   }
   else if (mod != 0)
   {
+#if 0
     if (false)
       ;
 
@@ -1390,6 +1436,11 @@ void AstDumpToNode::writeSymbol(Symbol* sym) const
 
     else
       sprintf(name, "%s.%s", mod->name, sym->name);
+#else
+
+      sprintf(name, "%s", sym->name);
+
+#endif
   }
   else
   {
@@ -1599,19 +1650,19 @@ void AstDumpToNode::writeSymbolCompact(Symbol* sym) const
     }
     else
     {
-      writeNodeID(sym, 0, 1);
+      writeNodeID(sym, false, true);
       fprintf(mFP, "%s%s", symPrefixString(sym), sym->name);
     }
   }
   else if (ArgSymbol* arg = toArgSymbol(sym))
   {
-    writeNodeID(sym, 0, 1);
+    writeNodeID(sym, false, true);
     fprintf(mFP, "arg %s", arg->name);
 
   }
   else
   {
-    writeNodeID(sym, 0, 1);
+    writeNodeID(sym, false, true);
     fprintf(mFP, "%s", sym->astTagAsString());
 
   }
@@ -1709,8 +1760,10 @@ void AstDumpToNode::ast_symbol(Symbol* sym, bool def)
     writeType(sym->type, false);
   }
 
+#if 0
   if (sym->hasFlag(FLAG_GENERIC))
-    write(false, " \"generic\" ", false);
+    write(false, " \"generic\"", false);
+#endif
 
   mNeedSpace = true;
 }
@@ -1721,9 +1774,9 @@ int AstDumpToNode::writeType(Type* type, bool announce) const
 
   if (announce)
   {
-    fputs(compact ? " type: " : " type:   ", mFP);
+    fputs(compact ? " type: " : " type: ", mFP);
 
-    len = (compact == true) ? 7 : 9;
+    len = (compact == true) ? 7 : 7;
   }
 
   if (false)
@@ -1738,7 +1791,7 @@ int AstDumpToNode::writeType(Type* type, bool announce) const
     {
       // ad-hoc suppress "PrimitiveType"
       fputs(delimitEnter, mFP);
-      writeNodeID(t, 0, 1);
+      writeNodeID(t, false, true);
       fputs(t->symbol->name, mFP);
       fputs(delimitExit, mFP);
     }

--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -916,6 +916,28 @@ bool AstDumpToNode::enterCallExpr(CallExpr* node)
 //
 //
 
+bool AstDumpToNode::enterContextCallExpr(ContextCallExpr* node)
+{
+  enterNode(node);
+
+  mOffset = mOffset + 2;
+
+  for_alist(expr, node->options) {
+    newline();
+    expr->accept(this);
+  }
+
+  mOffset = mOffset - 2;
+  newline();
+  exitNode(node);
+
+  return false;
+}
+
+//
+//
+//
+
 bool AstDumpToNode::enterNamedExpr(NamedExpr* node)
 {
   enterNode(node);

--- a/compiler/AST/AstLogger.cpp
+++ b/compiler/AST/AstLogger.cpp
@@ -90,6 +90,13 @@ bool AstLogger::enterCallExpr(CallExpr* node) {
 void AstLogger::exitCallExpr(CallExpr* node) {
 }
 
+bool AstLogger::enterContextCallExpr(ContextCallExpr* node) {
+  return true;
+}
+
+void AstLogger::exitContextCallExpr(ContextCallExpr* node) {
+}
+
 bool AstLogger::enterDefExpr(DefExpr* node) {
   return true;
 }

--- a/compiler/AST/AstVisitorTraverse.cpp
+++ b/compiler/AST/AstVisitorTraverse.cpp
@@ -119,6 +119,16 @@ void AstVisitorTraverse::exitCallExpr(CallExpr* node)
 
 }
 
+bool AstVisitorTraverse::enterContextCallExpr(ContextCallExpr* node)
+{
+  return true;
+}
+
+void AstVisitorTraverse::exitContextCallExpr(ContextCallExpr* node)
+{
+
+}
+
 bool AstVisitorTraverse::enterDefExpr(DefExpr* node)
 {
   return true;

--- a/compiler/AST/CollapseBlocks.cpp
+++ b/compiler/AST/CollapseBlocks.cpp
@@ -281,6 +281,15 @@ void CollapseBlocks::exitCallExpr(CallExpr* node)
 {
 }
 
+bool CollapseBlocks::enterContextCallExpr(ContextCallExpr* node)
+{
+  return false;
+}
+
+void CollapseBlocks::exitContextCallExpr(ContextCallExpr* node)
+{
+}
+
 bool CollapseBlocks::enterDefExpr(DefExpr* node)
 {
   return false;

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3900,13 +3900,13 @@ void CallExpr::prettyPrint(std::ostream *o) {
         if (array && expr == argList.last()) {
           *o << "] ";
         } else {
-          *o << ", "; 
-        }     
+          *o << ", ";
+        }
       }
-      expr->prettyPrint(o);         
+      expr->prettyPrint(o);
     }
     if (array && argList.first() == argList.last())
-      *o << "]"; 
+      *o << "]";
   }
   if (!array && !unusual) {
     *o << ")";
@@ -5866,8 +5866,14 @@ ContextCallExpr::verify() {
 }
 
 void ContextCallExpr::accept(AstVisitor* visitor) {
-  for_alist(expr, options)
-    expr->accept(visitor);
+  if (visitor->enterContextCallExpr(this) == true) {
+
+    for_alist(expr, options) {
+      expr->accept(visitor);
+    }
+
+    visitor->exitContextCallExpr(this);
+  }
 }
 
 Type* ContextCallExpr::typeInfo() {

--- a/compiler/include/AstDumpToNode.h
+++ b/compiler/include/AstDumpToNode.h
@@ -77,60 +77,61 @@ public:
   // themselves
   //
 
-  virtual bool     enterAggrType    (AggregateType*     node);
-  virtual void     exitAggrType     (AggregateType*     node);
+  virtual bool     enterAggrType       (AggregateType*     node);
+  virtual void     exitAggrType        (AggregateType*     node);
 
-  virtual bool     enterEnumType    (EnumType*          node);
-  virtual void     exitEnumType     (EnumType*          node);
+  virtual bool     enterEnumType       (EnumType*          node);
+  virtual void     exitEnumType        (EnumType*          node);
 
-  virtual void     visitPrimType    (PrimitiveType*     node);
+  virtual void     visitPrimType       (PrimitiveType*     node);
 
-  virtual bool     enterArgSym      (ArgSymbol*         node);
+  virtual bool     enterArgSym         (ArgSymbol*         node);
 
-  virtual void     visitEnumSym     (EnumSymbol*        node);
+  virtual void     visitEnumSym        (EnumSymbol*        node);
 
-  virtual bool     enterFnSym       (FnSymbol*          node);
+  virtual bool     enterFnSym          (FnSymbol*          node);
 
-  virtual void     visitLabelSym    (LabelSymbol*       node);
+  virtual void     visitLabelSym       (LabelSymbol*       node);
 
-  virtual bool     enterModSym      (ModuleSymbol*      node);
-  virtual void     exitModSym       (ModuleSymbol*      node);
+  virtual bool     enterModSym         (ModuleSymbol*      node);
+  virtual void     exitModSym          (ModuleSymbol*      node);
 
-  virtual bool     enterTypeSym     (TypeSymbol*        node);
+  virtual bool     enterTypeSym        (TypeSymbol*        node);
 
-  virtual void     visitVarSym      (VarSymbol*         node);
+  virtual void     visitVarSym         (VarSymbol*         node);
 
-  virtual bool     enterCallExpr    (CallExpr*          node);
+  virtual bool     enterCallExpr       (CallExpr*          node);
+  virtual bool     enterContextCallExpr(ContextCallExpr*   node);
 
-  virtual bool     enterDefExpr     (DefExpr*           node);
+  virtual bool     enterDefExpr        (DefExpr*           node);
 
-  virtual bool     enterNamedExpr   (NamedExpr*         node);
-  virtual void     exitNamedExpr    (NamedExpr*         node);
+  virtual bool     enterNamedExpr      (NamedExpr*         node);
+  virtual void     exitNamedExpr       (NamedExpr*         node);
 
-  virtual void     visitSymExpr     (SymExpr*           node);
+  virtual void     visitSymExpr        (SymExpr*           node);
 
-  virtual void     visitUsymExpr    (UnresolvedSymExpr* node);
+  virtual void     visitUsymExpr       (UnresolvedSymExpr* node);
 
-  virtual void     visitUseStmt     (UseStmt*           node);
+  virtual void     visitUseStmt        (UseStmt*           node);
 
-  virtual bool     enterBlockStmt   (BlockStmt*         node);
+  virtual bool     enterBlockStmt      (BlockStmt*         node);
 
-  virtual bool     enterWhileDoStmt (WhileDoStmt*       node);
+  virtual bool     enterWhileDoStmt    (WhileDoStmt*       node);
 
-  virtual bool     enterDoWhileStmt (DoWhileStmt*       node);
+  virtual bool     enterDoWhileStmt    (DoWhileStmt*       node);
 
-  virtual bool     enterCForLoop    (CForLoop*          node);
+  virtual bool     enterCForLoop       (CForLoop*          node);
 
-  virtual bool     enterForLoop     (ForLoop*           node);
+  virtual bool     enterForLoop        (ForLoop*           node);
 
-  virtual bool     enterParamForLoop(ParamForLoop*      node);
+  virtual bool     enterParamForLoop   (ParamForLoop*      node);
 
-  virtual bool     enterCondStmt    (CondStmt*          node);
+  virtual bool     enterCondStmt       (CondStmt*          node);
 
-  virtual void     visitEblockStmt  (ExternBlockStmt*   node);
+  virtual void     visitEblockStmt     (ExternBlockStmt*   node);
 
-  virtual bool     enterGotoStmt    (GotoStmt*          node);
-  virtual void     exitGotoStmt     (GotoStmt*          node);
+  virtual bool     enterGotoStmt       (GotoStmt*          node);
+  virtual void     exitGotoStmt        (GotoStmt*          node);
 
 private:
                    AstDumpToNode();

--- a/compiler/include/AstLogger.h
+++ b/compiler/include/AstLogger.h
@@ -28,92 +28,97 @@
 
 class AstLogger : public AstVisitor {
 public:
-                   AstLogger();
-  virtual         ~AstLogger();
+                 AstLogger();
+  virtual       ~AstLogger();
 
   //
   // The sub-classes of Type
   //
-  virtual bool   enterAggrType    (AggregateType*     node);
-  virtual void   exitAggrType     (AggregateType*     node);
+  virtual bool   enterAggrType       (AggregateType*     node);
+  virtual void   exitAggrType        (AggregateType*     node);
 
-  virtual bool   enterEnumType    (EnumType*          node);
-  virtual void   exitEnumType     (EnumType*          node);
+  virtual bool   enterEnumType       (EnumType*          node);
+  virtual void   exitEnumType        (EnumType*          node);
 
-  virtual void   visitPrimType    (PrimitiveType*     node);
+  virtual void   visitPrimType       (PrimitiveType*     node);
 
   //
   // The sub-classes of Symbol
   //
-  virtual bool   enterArgSym      (ArgSymbol*         node);
-  virtual void   exitArgSym       (ArgSymbol*         node);
+  virtual bool   enterArgSym         (ArgSymbol*         node);
+  virtual void   exitArgSym          (ArgSymbol*         node);
 
-  virtual void   visitEnumSym     (EnumSymbol*        node);
+  virtual void   visitEnumSym        (EnumSymbol*        node);
 
-  virtual bool   enterFnSym       (FnSymbol*          node);
-  virtual void   exitFnSym        (FnSymbol*          node);
+  virtual bool   enterFnSym          (FnSymbol*          node);
+  virtual void   exitFnSym           (FnSymbol*          node);
 
-  virtual void   visitLabelSym    (LabelSymbol*       node);
+  virtual void   visitLabelSym       (LabelSymbol*       node);
 
-  virtual bool   enterModSym      (ModuleSymbol*      node);
-  virtual void   exitModSym       (ModuleSymbol*      node);
+  virtual bool   enterModSym         (ModuleSymbol*      node);
+  virtual void   exitModSym          (ModuleSymbol*      node);
 
-  virtual bool   enterTypeSym     (TypeSymbol*        node);
-  virtual void   exitTypeSym      (TypeSymbol*        node);
+  virtual bool   enterTypeSym        (TypeSymbol*        node);
+  virtual void   exitTypeSym         (TypeSymbol*        node);
 
-  virtual void   visitVarSym      (VarSymbol*         node);
+  virtual void   visitVarSym         (VarSymbol*         node);
 
   //
   // The sub-classes of Expr
   //
-  virtual bool   enterCallExpr    (CallExpr*          node);
-  virtual void   exitCallExpr     (CallExpr*          node);
+  virtual bool   enterCallExpr       (CallExpr*          node);
+  virtual void   exitCallExpr        (CallExpr*          node);
 
-  virtual bool   enterDefExpr     (DefExpr*           node);
-  virtual void   exitDefExpr      (DefExpr*           node);
+  virtual bool   enterContextCallExpr(ContextCallExpr*   node);
+  virtual void   exitContextCallExpr (ContextCallExpr*   node);
 
-  virtual bool   enterNamedExpr   (NamedExpr*         node);
-  virtual void   exitNamedExpr    (NamedExpr*         node);
+  virtual bool   enterDefExpr        (DefExpr*           node);
+  virtual void   exitDefExpr         (DefExpr*           node);
 
-  virtual void   visitSymExpr     (SymExpr*           node);
+  virtual bool   enterNamedExpr      (NamedExpr*         node);
+  virtual void   exitNamedExpr       (NamedExpr*         node);
 
-  virtual void   visitUsymExpr    (UnresolvedSymExpr* node);
+  virtual void   visitSymExpr        (SymExpr*           node);
+
+  virtual void   visitUsymExpr       (UnresolvedSymExpr* node);
 
   //
   // The sub-classes of Stmt
   //
-  virtual void   visitUseStmt     (UseStmt*           node);
+  virtual void   visitUseStmt        (UseStmt*           node);
 
-  virtual bool   enterBlockStmt   (BlockStmt*         node);
-  virtual void   exitBlockStmt    (BlockStmt*         node);
+  virtual bool   enterBlockStmt      (BlockStmt*         node);
+  virtual void   exitBlockStmt       (BlockStmt*         node);
 
-  virtual bool   enterWhileDoStmt (WhileDoStmt*       node);
-  virtual void   exitWhileDoStmt  (WhileDoStmt*       node);
+  virtual bool   enterWhileDoStmt    (WhileDoStmt*       node);
+  virtual void   exitWhileDoStmt     (WhileDoStmt*       node);
 
-  virtual bool   enterDoWhileStmt (DoWhileStmt*       node);
-  virtual void   exitDoWhileStmt  (DoWhileStmt*       node);
+  virtual bool   enterDoWhileStmt    (DoWhileStmt*       node);
+  virtual void   exitDoWhileStmt     (DoWhileStmt*       node);
 
-  virtual bool   enterCForLoop    (CForLoop*          node);
-  virtual void   exitCForLoop     (CForLoop*          node);
+  virtual bool   enterCForLoop       (CForLoop*          node);
+  virtual void   exitCForLoop        (CForLoop*          node);
 
-  virtual bool   enterForLoop     (ForLoop*           node);
-  virtual void   exitForLoop      (ForLoop*           node);
+  virtual bool   enterForLoop        (ForLoop*           node);
+  virtual void   exitForLoop         (ForLoop*           node);
 
-  virtual bool   enterParamForLoop(ParamForLoop*      node);
-  virtual void   exitParamForLoop (ParamForLoop*      node);
+  virtual bool   enterParamForLoop   (ParamForLoop*      node);
+  virtual void   exitParamForLoop    (ParamForLoop*      node);
 
-  virtual bool   enterCondStmt    (CondStmt*          node);
-  virtual void   exitCondStmt     (CondStmt*          node);
+  virtual bool   enterCondStmt       (CondStmt*          node);
+  virtual void   exitCondStmt        (CondStmt*          node);
 
-  virtual void   visitEblockStmt  (ExternBlockStmt*   node);
+  virtual void   visitEblockStmt     (ExternBlockStmt*   node);
 
-  virtual bool   enterGotoStmt    (GotoStmt*          node);
-  virtual void   exitGotoStmt     (GotoStmt*          node);
+  virtual bool   enterGotoStmt       (GotoStmt*          node);
+  virtual void   exitGotoStmt        (GotoStmt*          node);
 
- protected:
-  bool outputVector (FILE* mFP, std::vector<const char *> vec);
-  void outputRenames(FILE* mFP, std::map<const char*, const char*> renames,
-                     bool first);
+protected:
+  bool outputVector (FILE* fp, std::vector<const char*> vec);
+
+  void outputRenames(FILE*                              fp,
+                     std::map<const char*, const char*> renames,
+                     bool                               first);
 };
 
 #endif

--- a/compiler/include/AstVisitor.h
+++ b/compiler/include/AstVisitor.h
@@ -33,6 +33,7 @@ class TypeSymbol;
 class VarSymbol;
 
 class CallExpr;
+class ContextCallExpr;
 class DefExpr;
 class NamedExpr;
 class SymExpr;
@@ -67,81 +68,84 @@ public:
   //
   // The sub-classes of Type
   //
-  virtual bool   enterAggrType    (AggregateType*     node) = 0;
-  virtual void   exitAggrType     (AggregateType*     node) = 0;
+  virtual bool   enterAggrType       (AggregateType*     node) = 0;
+  virtual void   exitAggrType        (AggregateType*     node) = 0;
 
-  virtual bool   enterEnumType    (EnumType*          node) = 0;
-  virtual void   exitEnumType     (EnumType*          node) = 0;
+  virtual bool   enterEnumType       (EnumType*          node) = 0;
+  virtual void   exitEnumType        (EnumType*          node) = 0;
 
-  virtual void   visitPrimType    (PrimitiveType*     node) = 0;
+  virtual void   visitPrimType       (PrimitiveType*     node) = 0;
 
   //
   // The sub-classes of Symbol
   //
-  virtual bool   enterArgSym      (ArgSymbol*         node) = 0;
-  virtual void   exitArgSym       (ArgSymbol*         node) = 0;
+  virtual bool   enterArgSym         (ArgSymbol*         node) = 0;
+  virtual void   exitArgSym          (ArgSymbol*         node) = 0;
 
-  virtual void   visitEnumSym     (EnumSymbol*        node) = 0;
+  virtual void   visitEnumSym        (EnumSymbol*        node) = 0;
 
-  virtual bool   enterFnSym       (FnSymbol*          node) = 0;
-  virtual void   exitFnSym        (FnSymbol*          node) = 0;
+  virtual bool   enterFnSym          (FnSymbol*          node) = 0;
+  virtual void   exitFnSym           (FnSymbol*          node) = 0;
 
-  virtual void   visitLabelSym    (LabelSymbol*       node) = 0;
+  virtual void   visitLabelSym       (LabelSymbol*       node) = 0;
 
-  virtual bool   enterModSym      (ModuleSymbol*      node) = 0;
-  virtual void   exitModSym       (ModuleSymbol*      node) = 0;
+  virtual bool   enterModSym         (ModuleSymbol*      node) = 0;
+  virtual void   exitModSym          (ModuleSymbol*      node) = 0;
 
-  virtual bool   enterTypeSym     (TypeSymbol*        node) = 0;
-  virtual void   exitTypeSym      (TypeSymbol*        node) = 0;
+  virtual bool   enterTypeSym        (TypeSymbol*        node) = 0;
+  virtual void   exitTypeSym         (TypeSymbol*        node) = 0;
 
-  virtual void   visitVarSym      (VarSymbol*         node) = 0;
+  virtual void   visitVarSym         (VarSymbol*         node) = 0;
 
   //
   // The sub-classes of Expr
   //
-  virtual bool   enterCallExpr    (CallExpr*          node) = 0;
-  virtual void   exitCallExpr     (CallExpr*          node) = 0;
+  virtual bool   enterCallExpr       (CallExpr*          node) = 0;
+  virtual void   exitCallExpr        (CallExpr*          node) = 0;
 
-  virtual bool   enterDefExpr     (DefExpr*           node) = 0;
-  virtual void   exitDefExpr      (DefExpr*           node) = 0;
+  virtual bool   enterContextCallExpr(ContextCallExpr*   node) = 0;
+  virtual void   exitContextCallExpr (ContextCallExpr*   node) = 0;
 
-  virtual bool   enterNamedExpr   (NamedExpr*         node) = 0;
-  virtual void   exitNamedExpr    (NamedExpr*         node) = 0;
+  virtual bool   enterDefExpr        (DefExpr*           node) = 0;
+  virtual void   exitDefExpr         (DefExpr*           node) = 0;
 
-  virtual void   visitSymExpr     (SymExpr*           node) = 0;
+  virtual bool   enterNamedExpr      (NamedExpr*         node) = 0;
+  virtual void   exitNamedExpr       (NamedExpr*         node) = 0;
 
-  virtual void   visitUsymExpr    (UnresolvedSymExpr* node) = 0;
+  virtual void   visitSymExpr        (SymExpr*           node) = 0;
+
+  virtual void   visitUsymExpr       (UnresolvedSymExpr* node) = 0;
 
   //
   // The sub-classes of Stmt
   //
-  virtual void   visitUseStmt     (UseStmt*           node) = 0;
+  virtual void   visitUseStmt        (UseStmt*           node) = 0;
 
-  virtual bool   enterBlockStmt   (BlockStmt*         node) = 0;
-  virtual void   exitBlockStmt    (BlockStmt*         node) = 0;
+  virtual bool   enterBlockStmt      (BlockStmt*         node) = 0;
+  virtual void   exitBlockStmt       (BlockStmt*         node) = 0;
 
-  virtual bool   enterWhileDoStmt (WhileDoStmt*       node) = 0;
-  virtual void   exitWhileDoStmt  (WhileDoStmt*       node) = 0;
+  virtual bool   enterWhileDoStmt    (WhileDoStmt*       node) = 0;
+  virtual void   exitWhileDoStmt     (WhileDoStmt*       node) = 0;
 
-  virtual bool   enterDoWhileStmt (DoWhileStmt*       node) = 0;
-  virtual void   exitDoWhileStmt  (DoWhileStmt*       node) = 0;
+  virtual bool   enterDoWhileStmt    (DoWhileStmt*       node) = 0;
+  virtual void   exitDoWhileStmt     (DoWhileStmt*       node) = 0;
 
-  virtual bool   enterCForLoop    (CForLoop*          node) = 0;
-  virtual void   exitCForLoop     (CForLoop*          node) = 0;
+  virtual bool   enterCForLoop       (CForLoop*          node) = 0;
+  virtual void   exitCForLoop        (CForLoop*          node) = 0;
 
-  virtual bool   enterForLoop     (ForLoop*           node) = 0;
-  virtual void   exitForLoop      (ForLoop*           node) = 0;
+  virtual bool   enterForLoop        (ForLoop*           node) = 0;
+  virtual void   exitForLoop         (ForLoop*           node) = 0;
 
-  virtual bool   enterParamForLoop(ParamForLoop*      node) = 0;
-  virtual void   exitParamForLoop (ParamForLoop*      node) = 0;
+  virtual bool   enterParamForLoop   (ParamForLoop*      node) = 0;
+  virtual void   exitParamForLoop    (ParamForLoop*      node) = 0;
 
-  virtual bool   enterCondStmt    (CondStmt*          node) = 0;
-  virtual void   exitCondStmt     (CondStmt*          node) = 0;
+  virtual bool   enterCondStmt       (CondStmt*          node) = 0;
+  virtual void   exitCondStmt        (CondStmt*          node) = 0;
 
-  virtual void   visitEblockStmt  (ExternBlockStmt*   node) = 0;
+  virtual void   visitEblockStmt     (ExternBlockStmt*   node) = 0;
 
-  virtual bool   enterGotoStmt    (GotoStmt*          node) = 0;
-  virtual void   exitGotoStmt     (GotoStmt*          node) = 0;
+  virtual bool   enterGotoStmt       (GotoStmt*          node) = 0;
+  virtual void   exitGotoStmt        (GotoStmt*          node) = 0;
 };
 
 #endif

--- a/compiler/include/AstVisitorTraverse.h
+++ b/compiler/include/AstVisitorTraverse.h
@@ -36,87 +36,90 @@
 class AstVisitorTraverse : public AstVisitor
 {
 public:
-                   AstVisitorTraverse();
-  virtual         ~AstVisitorTraverse();
+                 AstVisitorTraverse();
+  virtual       ~AstVisitorTraverse();
 
   //
   // The sub-classes of Type
   //
-  virtual bool   enterAggrType    (AggregateType*     node);
-  virtual void   exitAggrType     (AggregateType*     node);
+  virtual bool   enterAggrType       (AggregateType*     node);
+  virtual void   exitAggrType        (AggregateType*     node);
 
-  virtual bool   enterEnumType    (EnumType*          node);
-  virtual void   exitEnumType     (EnumType*          node);
+  virtual bool   enterEnumType       (EnumType*          node);
+  virtual void   exitEnumType        (EnumType*          node);
 
-  virtual void   visitPrimType    (PrimitiveType*     node);
+  virtual void   visitPrimType       (PrimitiveType*     node);
 
   //
   // The sub-classes of Symbol
   //
-  virtual bool   enterArgSym      (ArgSymbol*         node);
-  virtual void   exitArgSym       (ArgSymbol*         node);
+  virtual bool   enterArgSym         (ArgSymbol*         node);
+  virtual void   exitArgSym          (ArgSymbol*         node);
 
-  virtual void   visitEnumSym     (EnumSymbol*        node);
+  virtual void   visitEnumSym        (EnumSymbol*        node);
 
-  virtual bool   enterFnSym       (FnSymbol*          node);
-  virtual void   exitFnSym        (FnSymbol*          node);
+  virtual bool   enterFnSym          (FnSymbol*          node);
+  virtual void   exitFnSym           (FnSymbol*          node);
 
-  virtual void   visitLabelSym    (LabelSymbol*       node);
+  virtual void   visitLabelSym       (LabelSymbol*       node);
 
-  virtual bool   enterModSym      (ModuleSymbol*      node);
-  virtual void   exitModSym       (ModuleSymbol*      node);
+  virtual bool   enterModSym         (ModuleSymbol*      node);
+  virtual void   exitModSym          (ModuleSymbol*      node);
 
-  virtual bool   enterTypeSym     (TypeSymbol*        node);
-  virtual void   exitTypeSym      (TypeSymbol*        node);
+  virtual bool   enterTypeSym        (TypeSymbol*        node);
+  virtual void   exitTypeSym         (TypeSymbol*        node);
 
-  virtual void   visitVarSym      (VarSymbol*         node);
+  virtual void   visitVarSym         (VarSymbol*         node);
 
   //
   // The sub-classes of Expr
   //
-  virtual bool   enterCallExpr    (CallExpr*          node);
-  virtual void   exitCallExpr     (CallExpr*          node);
+  virtual bool   enterCallExpr       (CallExpr*          node);
+  virtual void   exitCallExpr        (CallExpr*          node);
 
-  virtual bool   enterDefExpr     (DefExpr*           node);
-  virtual void   exitDefExpr      (DefExpr*           node);
+  virtual bool   enterContextCallExpr(ContextCallExpr*   node);
+  virtual void   exitContextCallExpr (ContextCallExpr*   node);
 
-  virtual bool   enterNamedExpr   (NamedExpr*         node);
-  virtual void   exitNamedExpr    (NamedExpr*         node);
+  virtual bool   enterDefExpr        (DefExpr*           node);
+  virtual void   exitDefExpr         (DefExpr*           node);
 
-  virtual void   visitSymExpr     (SymExpr*           node);
+  virtual bool   enterNamedExpr      (NamedExpr*         node);
+  virtual void   exitNamedExpr       (NamedExpr*         node);
 
-  virtual void   visitUsymExpr    (UnresolvedSymExpr* node);
+  virtual void   visitSymExpr        (SymExpr*           node);
+
+  virtual void   visitUsymExpr       (UnresolvedSymExpr* node);
 
   //
   // The sub-classes of Stmt
   //
-  virtual void   visitUseStmt     (UseStmt*           node);
+  virtual void   visitUseStmt        (UseStmt*           node);
 
-  virtual bool   enterBlockStmt   (BlockStmt*         node);
-  virtual void   exitBlockStmt    (BlockStmt*         node);
+  virtual bool   enterBlockStmt      (BlockStmt*         node);
+  virtual void   exitBlockStmt       (BlockStmt*         node);
 
-  virtual bool   enterWhileDoStmt (WhileDoStmt*       node);
-  virtual void   exitWhileDoStmt  (WhileDoStmt*       node);
+  virtual bool   enterWhileDoStmt    (WhileDoStmt*       node);
+  virtual void   exitWhileDoStmt     (WhileDoStmt*       node);
 
-  virtual bool   enterDoWhileStmt (DoWhileStmt*       node);
-  virtual void   exitDoWhileStmt  (DoWhileStmt*       node);
+  virtual bool   enterDoWhileStmt    (DoWhileStmt*       node);
+  virtual void   exitDoWhileStmt     (DoWhileStmt*       node);
 
-  virtual bool   enterCForLoop    (CForLoop*          node);
-  virtual void   exitCForLoop     (CForLoop*          node);
+  virtual bool   enterCForLoop       (CForLoop*          node);
+  virtual void   exitCForLoop        (CForLoop*          node);
 
-  virtual bool   enterForLoop     (ForLoop*           node);
-  virtual void   exitForLoop      (ForLoop*           node);
+  virtual bool   enterForLoop        (ForLoop*           node);
+  virtual void   exitForLoop         (ForLoop*           node);
 
-  virtual bool   enterParamForLoop(ParamForLoop*      node);
-  virtual void   exitParamForLoop (ParamForLoop*      node);
+  virtual bool   enterParamForLoop   (ParamForLoop*      node);
+  virtual void   exitParamForLoop    (ParamForLoop*      node);
 
-  virtual bool   enterCondStmt    (CondStmt*          node);
-  virtual void   exitCondStmt     (CondStmt*          node);
+  virtual bool   enterCondStmt       (CondStmt*          node);
+  virtual void   exitCondStmt        (CondStmt*          node);
 
-  virtual void   visitEblockStmt  (ExternBlockStmt*   node);
+  virtual void   visitEblockStmt     (ExternBlockStmt*   node);
 
-  virtual bool   enterGotoStmt    (GotoStmt*          node);
-  virtual void   exitGotoStmt     (GotoStmt*          node);
+  virtual bool   enterGotoStmt       (GotoStmt*          node);
+  virtual void   exitGotoStmt        (GotoStmt*          node);
 };
 
 #endif

--- a/compiler/include/CollapseBlocks.h
+++ b/compiler/include/CollapseBlocks.h
@@ -30,81 +30,84 @@ public:
   //
   // The sub-classes of Type
   //
-  virtual bool   enterAggrType    (AggregateType*     node);
-  virtual void   exitAggrType     (AggregateType*     node);
+  virtual bool   enterAggrType       (AggregateType*     node);
+  virtual void   exitAggrType        (AggregateType*     node);
 
-  virtual bool   enterEnumType    (EnumType*          node);
-  virtual void   exitEnumType     (EnumType*          node);
+  virtual bool   enterEnumType       (EnumType*          node);
+  virtual void   exitEnumType        (EnumType*          node);
 
-  virtual void   visitPrimType    (PrimitiveType*     node);
+  virtual void   visitPrimType       (PrimitiveType*     node);
 
   //
   // The sub-classes of Symbol
   //
-  virtual bool   enterArgSym      (ArgSymbol*         node);
-  virtual void   exitArgSym       (ArgSymbol*         node);
+  virtual bool   enterArgSym         (ArgSymbol*         node);
+  virtual void   exitArgSym          (ArgSymbol*         node);
 
-  virtual void   visitEnumSym     (EnumSymbol*        node);
+  virtual void   visitEnumSym        (EnumSymbol*        node);
 
-  virtual bool   enterFnSym       (FnSymbol*          node);
-  virtual void   exitFnSym        (FnSymbol*          node);
+  virtual bool   enterFnSym          (FnSymbol*          node);
+  virtual void   exitFnSym           (FnSymbol*          node);
 
-  virtual void   visitLabelSym    (LabelSymbol*       node);
+  virtual void   visitLabelSym       (LabelSymbol*       node);
 
-  virtual bool   enterModSym      (ModuleSymbol*      node);
-  virtual void   exitModSym       (ModuleSymbol*      node);
+  virtual bool   enterModSym         (ModuleSymbol*      node);
+  virtual void   exitModSym          (ModuleSymbol*      node);
 
-  virtual bool   enterTypeSym     (TypeSymbol*        node);
-  virtual void   exitTypeSym      (TypeSymbol*        node);
+  virtual bool   enterTypeSym        (TypeSymbol*        node);
+  virtual void   exitTypeSym         (TypeSymbol*        node);
 
-  virtual void   visitVarSym      (VarSymbol*         node);
+  virtual void   visitVarSym         (VarSymbol*         node);
 
   //
   // The sub-classes of Expr
   //
-  virtual bool   enterCallExpr    (CallExpr*          node);
-  virtual void   exitCallExpr     (CallExpr*          node);
+  virtual bool   enterCallExpr       (CallExpr*          node);
+  virtual void   exitCallExpr        (CallExpr*          node);
 
-  virtual bool   enterDefExpr     (DefExpr*           node);
-  virtual void   exitDefExpr      (DefExpr*           node);
+  virtual bool   enterContextCallExpr(ContextCallExpr*   node);
+  virtual void   exitContextCallExpr (ContextCallExpr*   node);
 
-  virtual bool   enterNamedExpr   (NamedExpr*         node);
-  virtual void   exitNamedExpr    (NamedExpr*         node);
+  virtual bool   enterDefExpr        (DefExpr*           node);
+  virtual void   exitDefExpr         (DefExpr*           node);
 
-  virtual void   visitSymExpr     (SymExpr*           node);
+  virtual bool   enterNamedExpr      (NamedExpr*         node);
+  virtual void   exitNamedExpr       (NamedExpr*         node);
 
-  virtual void   visitUsymExpr    (UnresolvedSymExpr* node);
+  virtual void   visitSymExpr        (SymExpr*           node);
+
+  virtual void   visitUsymExpr       (UnresolvedSymExpr* node);
 
   //
   // The sub-classes of Stmt
   //
-  virtual void   visitUseStmt     (UseStmt*           node);
+  virtual void   visitUseStmt        (UseStmt*           node);
 
-  virtual bool   enterBlockStmt   (BlockStmt*         node);
-  virtual void   exitBlockStmt    (BlockStmt*         node);
+  virtual bool   enterBlockStmt      (BlockStmt*         node);
+  virtual void   exitBlockStmt       (BlockStmt*         node);
 
-  virtual bool   enterWhileDoStmt (WhileDoStmt*       node);
-  virtual void   exitWhileDoStmt  (WhileDoStmt*       node);
+  virtual bool   enterWhileDoStmt    (WhileDoStmt*       node);
+  virtual void   exitWhileDoStmt     (WhileDoStmt*       node);
 
-  virtual bool   enterDoWhileStmt (DoWhileStmt*       node);
-  virtual void   exitDoWhileStmt  (DoWhileStmt*       node);
+  virtual bool   enterDoWhileStmt    (DoWhileStmt*       node);
+  virtual void   exitDoWhileStmt     (DoWhileStmt*       node);
 
-  virtual bool   enterCForLoop    (CForLoop*          node);
-  virtual void   exitCForLoop     (CForLoop*          node);
+  virtual bool   enterCForLoop       (CForLoop*          node);
+  virtual void   exitCForLoop        (CForLoop*          node);
 
-  virtual bool   enterForLoop     (ForLoop*           node);
-  virtual void   exitForLoop      (ForLoop*           node);
+  virtual bool   enterForLoop        (ForLoop*           node);
+  virtual void   exitForLoop         (ForLoop*           node);
 
-  virtual bool   enterParamForLoop(ParamForLoop*      node);
-  virtual void   exitParamForLoop (ParamForLoop*      node);
+  virtual bool   enterParamForLoop   (ParamForLoop*      node);
+  virtual void   exitParamForLoop    (ParamForLoop*      node);
 
-  virtual bool   enterCondStmt    (CondStmt*          node);
-  virtual void   exitCondStmt     (CondStmt*          node);
+  virtual bool   enterCondStmt       (CondStmt*          node);
+  virtual void   exitCondStmt        (CondStmt*          node);
 
-  virtual void   visitEblockStmt  (ExternBlockStmt*   node);
+  virtual void   visitEblockStmt     (ExternBlockStmt*   node);
 
-  virtual bool   enterGotoStmt    (GotoStmt*          node);
-  virtual void   exitGotoStmt     (GotoStmt*          node);
+  virtual bool   enterGotoStmt       (GotoStmt*          node);
+  virtual void   exitGotoStmt        (GotoStmt*          node);
 };
 
 #endif


### PR DESCRIPTION
1) Extend the AstVisitor APIs to recognize the new-ish ContextCallExpr node.  This is trivial work.

2) Extend AstDumpToNode to provide formatted output for ContextCallExpr.  Also trivial

3) Integrate a handful of minor changes to the formatted output of AstDumpToNode.  Not entirely
trivial but no impact on compiler or tests.

Compiled on clang/darwin and gcc/linux64.
Tested on full suite for std-linux64
