### PR TITLE
Add recent jemalloc annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -132,6 +132,8 @@ all:
       config: shootout
   05/12/16:
     - KACE removed from systems.  Should see less noise after this day.
+  05/31/16:
+    - Enable jemalloc's decay-based purging (#3926)
 
 AllCompTime:
   11/09/14:
@@ -171,6 +173,8 @@ binary-trees:
     - upgrade jemalloc to 4.1.0 (#3447)
   03/16/16:
     - revert jemalloc to 4.0.4 (#3477)
+  05/28/16:
+    - upgrade jemalloc to 4.2.0 (#3919)
 
 chameneos-redux:
   07/08/13:
@@ -410,6 +414,8 @@ nbody:
     - upgrade jemalloc to 4.1.0 (#3447)
   03/16/16:
     - revert jemalloc to 4.0.4 (#3477)
+  05/28/16:
+    - upgrade jemalloc to 4.2.0 (#3919)
 
 parOpEquals:
   09/06/13:
@@ -539,3 +545,5 @@ timeVectorArray:
     - implemented doubling/halving for array-as-vec (#3380) (no timing from 4th)
   03/09/16:
     - increased array-as-vec problem size (#3422)
+  05/28/16:
+    - upgrade jemalloc to 4.2.0 (#3919)


### PR DESCRIPTION
Add annotation for upgrade from 4.0.4 to 4.2.0
 - improved nbody, array-as-vec, binary-trees

Add annotation for enabling decay-based purging
 - improved binary-tress, regex-dna, and a few others