### PR TITLE
Fix "typo" in remoteValueForwarding

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -466,7 +466,7 @@ static bool isSafeToDeref(Map<Symbol*, Vec<SymExpr*>*>& defMap,
                           Vec<Symbol*>&                 visited) {
   bool retval = true;
 
-  if (visited.set_in(ref) == false) {
+  if (visited.set_in(ref) == NULL) {
     int numDefs = (defMap.get(ref)) ? defMap.get(ref)->n : 0;
 
     visited.set_add(ref);


### PR DESCRIPTION
I introduced a minor type-checking error (field == false should have been field == NULL).
This was missed by my local compilation and the system default compilers but has been
surfaced by a newer clang++.

Revised the predicate, compiled on clang/darwin and gcc/linux64, and passed /release on
both darwin and std-linux64
