### PR TITLE
Use jemalloc with pgi

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -380,9 +380,8 @@ CHPL_MEM
         ========= =======================================================
 
    If unset, ``CHPL_MEM`` defaults to ``jemalloc`` for most configurations.
-   If the target platform is ``cygwin*``, the target compiler is ``*pgi``,
-   or the target platform is ``darwin`` and the target compiler is ``gnu``
-   it defaults to ``cstdlib``
+   If the target platform is ``cygwin*``, or the target platform is
+   ``darwin`` and the target compiler is ``gnu`` it defaults to ``cstdlib``
 
 
 .. _readme-chplenv.CHPL_LAUNCHER:

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -21,10 +21,9 @@ def get(flag='host'):
             compiler_val = chpl_compiler.get('target')
 
             cygwin = platform_val.startswith('cygwin')
-            pgi = 'pgi' in compiler_val
             gnu_darwin = platform_val == 'darwin' and compiler_val == 'gnu'
 
-            if cygwin or pgi or gnu_darwin:
+            if cygwin or gnu_darwin:
                 mem_val = 'cstdlib'
             else:
                 mem_val = 'jemalloc'


### PR DESCRIPTION
#3357 reverted to using cstdlib with pgi because of undiagnosed segfaults. When
I was trying to track these down, the segfaults were deep in some internal
red-black tree manipulation. jemalloc 4.2.0 replaced a lot of red-black trees
with pairing heaps, and that seems to have resolved the segfaults, so we can
use it with pgi now.

I only tested release/examples (previously even hello4 was failing) and I'll
let nightly do the full suite.

See JIRA 188 fore more info: https://chapel.atlassian.net/browse/CHAPEL-188