### PR TITLE
Increase default timeout for --valgrindexe like we do for --valgrind

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -652,7 +652,7 @@ timeoutsuffix  = PerfSfx('timeout')   # .timeout  or .perftimeout  or ...
 # sys.stdout.write('perftest=%d perflabel=%s\n'%(perftest,perflabel))
 
 # Get global timeout
-if os.getenv('CHPL_TEST_VGRND_COMP')=='on':
+if os.getenv('CHPL_TEST_VGRND_COMP')=='on' or os.getenv('CHPL_TEST_VGRND_EXE')=='on':
     globalTimeout=1000
 else:
     globalTimeout=300


### PR DESCRIPTION
We already increase the default timeout for --valgrind (run valgrind on the
compiler and the executable), but we didn't increase it if we were just using
valgrind on the executable.