### PR TITLE
Stop heap allocating for vars for on statements under fifo and muxed

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -801,9 +801,20 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
 //  fLocal == true
 // or
 //  CHPL_COMM == "ugni"
-// of
+// or
 //  CHPL_COMM == "gasnet" && CHPL_GASNET_SEGMENT == "everything";
+// or
+//  CHPL_STACK_CHECKS == 0 && CHPL_TASKS == "fifo"
+// or
+//  CHPL_STACK_CHECKS == 0 && CHPL_TASKS == "muxed"
+//
 // true otherwise.
+//
+// The tasking layer matters because fifo and muxed allocate
+// from task stacks the communication registered heap
+// (unless stack checks is on, in which case it might not
+//  be possible because of huge pages).
+// In the future, we hope that all tasking layers do this.
 static bool
 needHeapVars() {
   if (fLocal) return false;
@@ -811,6 +822,11 @@ needHeapVars() {
   if (!strcmp(CHPL_COMM, "ugni") ||
       (!strcmp(CHPL_COMM, "gasnet") &&
        !strcmp(CHPL_GASNET_SEGMENT, "everything")))
+    return false;
+
+  if (fNoStackChecks &&
+      (0 == strcmp(CHPL_TASKS, "fifo") ||
+       0 == strcmp(CHPL_TASKS, "muxed")) )
     return false;
 
   return true;


### PR DESCRIPTION
In parallel.cpp, we heap allocate some variables as a communication
optimization.  By heap allocating them, we put them on the Chapel heap,
which is registered for communication. That avoids certain trampolining
active messages in some cases.

However, for fifo and muxed tasking layers, the task stacks are already
allocated from the Chapel heap and so should represent registered memory.
The possible exception is if guard pages are on. So, this PR modifies
needHeapVars to return false for fifo and muxed if fNoStackChecks is set
(and it is set by --fast).

I verified (by inspecting the generated code) that the heap allocation was no
longer occuring for a simple program when compiled with fifo, gasnet,
segment=fast, and --fast:

    proc doit() {
      var x = 17;
      on Locales[numLocales-1] {
        x += 1;
      }
      writeln(x);
    }

    doit();

Without this change, x is heap allocated in that configuration.


- Passed full GASNet+fast+fifo testing
* Passed examples ugni+muxed perf testing
  (note LCALSMain.chpl fails under this configuration on master)

Reviewed by @gbtitus - thanks!