### PR TITLE
Revert "Use jemalloc with pgi"

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -380,8 +380,9 @@ CHPL_MEM
         ========= =======================================================
 
    If unset, ``CHPL_MEM`` defaults to ``jemalloc`` for most configurations.
-   If the target platform is ``cygwin*``, or the target platform is
-   ``darwin`` and the target compiler is ``gnu`` it defaults to ``cstdlib``
+   If the target platform is ``cygwin*``, the target compiler is ``*pgi``,
+   or the target platform is ``darwin`` and the target compiler is ``gnu``
+   it defaults to ``cstdlib``
 
 
 .. _readme-chplenv.CHPL_LAUNCHER:

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -21,9 +21,10 @@ def get(flag='host'):
             compiler_val = chpl_compiler.get('target')
 
             cygwin = platform_val.startswith('cygwin')
+            pgi = 'pgi' in compiler_val
             gnu_darwin = platform_val == 'darwin' and compiler_val == 'gnu'
 
-            if cygwin or gnu_darwin:
+            if cygwin or pgi or gnu_darwin:
                 mem_val = 'cstdlib'
             else:
                 mem_val = 'jemalloc'


### PR DESCRIPTION
This reverts commit e732c6385b7ce1d124e2e2a73bc9a5208281f497.

There were some segfaults and timeouts with this change. Revert to using
cstdlib until I can figure out the root cause. On the plus side there were only
a half dozen or so regressions (compared to almost every test failing with
jemalloc 4.0.4)

See JIRA 188 for more info: https://chapel.atlassian.net/browse/CHAPEL-188