### PR TITLE
Major refactoring of bradc version of chameneos

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -1,400 +1,294 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 
-   contributed by Hannah Hemmaplardh
-   modified by Lydia Duncan and Brad Chamberlain
+   contributed by Hannah Hemmaplardh, Lydia Duncan, and Brad Chamberlain
 */
 
+config const n = 600,              // number of meetings (must be >= 0)
+             popSize1 = 3,         // size of population 1 (must be > 1)
+             popSize2 = 10;        // size of population 2 (must be > 1)
 
-//
-// the following params indicate the number of bits to use when storing
-// IDs in a meeting place's 'state' and the corresponding bitmask
-// to use when extracting chameneos IDs, respectively.
-//
-config param NUM_CHAMENEOS_ID_BITS = 8;
-param CHAMENEOS_ID_MASK = (0x1 << NUM_CHAMENEOS_ID_BITS) - 1;
-
-
-config const n = 100,                // number of meetings to take place
-             numChameneos1 = 3,      // size of population 1
-             numChameneos2 = 10;     // size of population 2
-
-if (numChameneos1 < 2 || numChameneos2 < 2) then
-  halt("There must be at least 2 chameneos");
-
-if (n < 0) then
-  halt("the number of meetings must be non-negative");
-
-//
-// TODO: We should arguably also check that the number of bits
-// devoted to chameneos IDs and meeting IDs are enough to store
-// numChameneos1/2 and n, respectively.
-//
+enum Color {blue=0, red, yellow};  // the chameneos colors
+use Color;                         // permit unqualified references to them
 
 
 //
-// the colors the chameneos can take on
+// Print the color equations and simulate the two population sizes.
 //
-param numColors = 3;
-enum Color {blue=0, red, yellow};
-//
-// TODO: Would be cool to support a param .size query for enums to
-// avoid the whole C "declare one extra enum for the number" hack and
-// then we could do param numColors = Color.size; (or, if not size,
-// some other query function).
-//
-
-
 proc main() {
-  //
-  // print out the equations that govern chameneos color changes
-  //
   printColorEquations();
 
-  //
-  // run two simulations for the two different population sizes
-  //
-  simulate(numChameneos1);
-  simulate(numChameneos2);
+  simulate(popSize1);
+  simulate(popSize2);
 }
 
 
 //
-// simulate() takes a number of chameneos as input and creates as
-// population of that size, then allows them to meet in parallel.
+// Print the results of getNewColor() for all color pairs.
+//
+proc printColorEquations() {
+  const colors = (blue, red, yellow);
+
+  for c1 in colors do
+    for c2 in colors do
+      writeln(c1, " + ", c2, " -> ", getNewColor(c1, c2));
+  writeln();
+}
+
+
+//
+// Given a number of chameneos as input, create a population of that
+// size, have it print its colors, host 'n' meetings, and print notes
+// about the meetings.
 //
 proc simulate(numChameneos) {
-  //
-  // create the population of chameneos
-  //
-  const chameneos = createChameneos(numChameneos);
+  const group = new Population(numChameneos);
 
-  //
-  // print the chameneos's initial colors
-  //
-  for c in chameneos do
-    write(" ", c.color);
-  writeln();
-
-  //
-  // create a meeting place and simulate the interactions
-  //
-  const meetingPlace = new MeetingPlace(n);
-  meetingPlace.hostMeetings(chameneos);
-
-  //
-  // print information about the population once we're done
-  //
-  printInfo(chameneos);
-
-  //
-  // Clean up after ourselves
-  //
-  destroyChameneos(chameneos);
-  delete meetingPlace;
+  group.printColors();
+  group.holdMeetings(n);
+  group.printNotes();
 }
 
 
 //
-// This class represents a place for chameneos to meet
+// special colors to use for a chameneos population of size 10
+//
+const colors10 = [blue, red, yellow, red, yellow, blue, red, yellow, red, blue];
+
+//
+// a chameneos population
+//
+record Population {
+  const size = 0;   // the size of the population
+
+  //
+  // an array of chameneos objects representing the population
+  //
+  var chameneos = [i in 1..size]
+                    new Chameneos(i, if size == 10 then colors10[i]
+                                                   else ((i-1)%3): Color);
+
+  //
+  // Print the colors of the current population.
+  //
+  proc printColors() {
+    for c in chameneos do
+      write(" ", c.color);
+    writeln();
+  }
+
+  //
+  // Hold meetings among the population by creating a shared meeting
+  // place, and then creating per-chameneos tasks to have meetings.
+  //
+  proc holdMeetings(numMeetings) {
+    const place = new MeetingPlace(numMeetings);
+
+    coforall c in chameneos do           // create a task per chameneos
+      c.haveMeetings(place, chameneos);
+
+    delete place;
+  }
+
+  //
+  // Print notes about the meetings by having each chameneos print the
+  // number of meetings it had and spell out the number of
+  // self-meetings it had.  Then spell out the total number of
+  // meetings for the population.
+  //
+  proc printNotes() {
+    for c in chameneos {
+      write(c.meetings);
+      spellInt(c.meetingsWithSelf);
+    }
+    
+    spellInt(+ reduce chameneos.meetings);
+    writeln();
+  }
+
+  //
+  // Delete the chameneos objects.
+  //
+  proc ~Population {
+    for c in chameneos do
+      delete c;
+  }
+}
+
+
+//
+// a class representing a single chameneos
+//
+class Chameneos {
+  const id: int;                       // its unique ID
+  var color: Color;                    // its current color
+  var meetings,                        // the number of meetings it's had
+      meetingsWithSelf: int;           // the number of meetings with itself
+  var meetingCompleted: atomic bool;   // used to coordinate meeting endings
+
+  //
+  // Have meetings in a given 'place' with other 'chameneos' as long
+  // as more meetings remain by reading the current state and then
+  // attempting to optimistically replace it with new state that would
+  // indicate that we're a participant.
+  //
+  proc haveMeetings(place, chameneos) {
+    do {
+      const (currentState, meetingsLeft, peerID) = place.getInfo();
+
+      if meetingsLeft {
+        //
+        // We are the first to arrive if the state had no peer ID
+        //
+        const firstToArrive = (peerID == 0);
+
+        //
+        // Attempt to store the values that would indicate we're a
+        // participant:
+        // - If we're the first to arrive, leave the number of
+        //   meetings unchanged and store our ID
+        // - Otherwise, we're the second to arrive, so decrement 
+        //   the number of meetings and reset the ID to zero.
+        //
+        if place.attemptToStore(currentState,
+                                meetingsLeft - !firstToArrive,
+                                if firstToArrive then id else 0) {
+          //
+          // If we were successful and the first to arrive, wait
+          // for the meeting to end; otherwise, run the meeting.
+          //
+          if firstToArrive then
+            waitForMeetingToEnd();
+          else
+            meetWith(chameneos[peerID]);
+        }
+      }
+    } while (meetingsLeft);
+  }
+
+  //
+  // Wait for our meeting to end by waiting for 'meetingCompleted'
+  // to become 'true' and then resetting it to 'false'.
+  //
+  proc waitForMeetingToEnd() {
+    meetingCompleted.waitFor(true);
+    meetingCompleted.write(false);
+  }
+
+  //
+  // Meet with a 'peer' chameneos by computing our shared new color,
+  // storing it, and incrementing the number of meetings for each
+  // chameneos.  Signal to the peer that the meeting is complete.  If
+  // the peer was us, update our 'meetingsWithSelf' count.  Set the
+  // peer free as quickly as possible so it can go on to meet with
+  // others.
+  //
+  proc meetWith(peer) {
+    const newColor = getNewColor(color, peer.color);
+
+    peer.color = newColor;
+    peer.meetings += 1;
+    peer.meetingCompleted.write(true);
+
+    color = newColor;
+    meetings += 1;
+    meetingsWithSelf += (peer == this);
+  }
+}
+
+
+//
+// Return the complement of two colors: If the colors are the same,
+// that's the result; otherwise, it's the third color.
+//
+inline proc getNewColor(myColor, otherColor) {
+  select myColor {
+    //
+    // Handle the case when the two colors are equal
+    //
+    when otherColor do
+      return myColor;
+
+    //
+    // Handle the cases when they are not:
+    //
+    when blue do
+      return (if otherColor == red then yellow else red);
+
+    when red do
+      return (if otherColor == blue then yellow else blue);
+
+    otherwise {
+      return (if otherColor == blue then red else blue);
+    }
+  }
+}
+
+
+//
+// The number of bits needed to store a chameneos ID (upper bound).
+//
+config param bitsPerChameneosID = 8;
+
+//
+// A class representing a place for chameneos to meet
 //
 class MeetingPlace {
   //
-  // the 'state' variable packs a chameneos ID in the bottom
-  // NUM_CHAMENEOS_ID_BITS bits and the number of meetings in the
-  // upper ones, permitting atomic operations to be performed on both
-  // values simultaneously.
+  // Its state packs a chameneos ID in the lower 'bitsPerChameneosID'
+  // bits and the number of meetings in the upper ones, permitting
+  // atomic operations to read/write the pair of values simultaneously.
   //
   var state: atomic int;
 
   //
-  // constructor initializes the number of meetings to take place
+  // Initialize the number of meetings that should take place
   //
   proc MeetingPlace(numMeetings) {
-    state.write(numMeetings << NUM_CHAMENEOS_ID_BITS);
+    state.write(numMeetings << bitsPerChameneosID);
   }
 
   //
-  // This method kicks off the execution of all the chameneos in
-  // parallel and has them meet with each other in the meeting place.
+  // Read the current state and return it, along with the number of
+  // meetings and chameneos ID that it encodes.
   //
-  proc hostMeetings(chameneos) {
-    //
-    // fire off a task per chameneos, and have them try to meet
-    //
-    coforall c in chameneos {
-      //
-      // each chameneos will try to have meetings with others as
-      // long as meetings remain
-      //
-      do {
-        //
-        // read the current state, atomically
-        //
-        const currentState = state.read(memory_order_acquire);
-        
-        //
-        // extract the number of meetings remaining and the index of a
-        // waiting peer (if any) from the state
-        //
-        const (meetingsLeft, peerID) = stateToVals(currentState);
+  proc getInfo() {
+    param chameneosIDMask = (0x1 << bitsPerChameneosID) - 1;
+    const currentState = state.read(),
+          meetingsRemaining = currentState >> bitsPerChameneosID,
+          chameneosID = currentState & chameneosIDMask;
 
-        //
-        // if meetings remain, let's try to get one
-        //        
-        if (meetingsLeft) {
-          //
-          // We're the first to arrive if there is no peer index in the
-          // state
-          //
-          const firstToArrive = (peerID == 0);
-
-          //
-          // We'll try to meet by optimistically building the state
-          // that would indicate we were successful in meeting.
-          // We decrement the meetingsLeft if we are the second to arrive.
-          // If we're the first to arrive, we store our ID; otherwise,
-          // we reset the ID to zero.
-          //
-          const newState = valsToState(meetingsLeft - !firstToArrive,
-                                       if firstToArrive then c.id else 0);
-          
-          //
-          // use a compare-exchange to see if the state remains the
-          // same, and to swap in the new state we've computed if it is.
-          //
-          if (state.compareExchangeStrong(currentState, newState,
-                                          memory_order_acq_rel)) {
-            //
-            // We get to meet!
-            //
-            if (firstToArrive) {
-              //
-              // We were the first chameneos in, so we wait for the
-              // other to complete the meeting
-              //
-              c.waitForMeetingToEnd();
-            } else {
-              //
-              // We were the second chameneos in, so we run the meeting
-              //
-              c.meetWith(chameneos[peerID]);
-            }
-          }
-        }
-        //
-        // continue looping as long as meetings remain
-        //
-      } while (meetingsLeft);
-    }
+    return (currentState, meetingsRemaining, chameneosID);
   }
 
-  //
-  // This method computes a state value from a number of meetings and ID
-  //
-  inline proc valsToState(numMeetings, chameneosID) {
-    return (numMeetings << NUM_CHAMENEOS_ID_BITS) | chameneosID;
-  }
 
   //
-  // This method extracts the number of meeting IDs and chameneos ID from
-  // a state value
+  // Given a previous state value, a number of meetings, and a
+  // chameneos ID, compute a new state value and attempt to
+  // replace the old one with it (using an atomic compare-exchange),
+  // returning 'true' if 'successful.
   //
-  inline proc stateToVals(state) {
-    return (state >> NUM_CHAMENEOS_ID_BITS, state & CHAMENEOS_ID_MASK);
+  proc attemptToStore(prevState, numMeetings, chameneosID) {
+    const newState = (numMeetings << bitsPerChameneosID) | chameneosID;
+    return state.compareExchangeStrong(prevState, newState);
   }
 }
 
 
 //
-// a class representing a chameneos
+// the base-10 digits as an enum to support I/O and casting trivially
 //
-class Chameneos {
-  const id: int;                       // its unique ID
-  var color: Color;                    // its color
-  var meetings,                        // the number of meetings it's had
-      meetingsWithSelf: int;           // the number of meetings with itself
-  var meetingCompleted: atomic bool;   // indicates that a meeting is over
-
-
-  //
-  // This method says how to wait for a meeting to end and is used
-  // by the first chameneos to a meeting
-  //
-  proc waitForMeetingToEnd() {
-    //
-    // wait for meeting to end
-    //
-    meetingCompleted.waitFor(true);
-    //
-    // and then reset our meetingCompleted flag for next time
-    //
-    meetingCompleted.write(false, memory_order_release);
-  }
-
-  //
-  // This method computes the meeting between 'this' chameneos and
-  // its peer and is used by the second chameneos to a meeting
-  //
-  proc meetWith(peer) {
-    //
-    // If we meet with ourself, something's wrong, so check for that
-    //
-    const metSelf = (peer == this);
-
-    //
-    // compute the new color that we'll share as a function of our
-    // current colors
-    //
-    const newColor = getNewColor(color, peer.color);
-
-    //
-    // Update our peer's state: store the new color, update its
-    // meetings, and then tell it that the meeting's over
-    //
-    //
-    // TODO: abstract the following two assignments into a method to
-    // avoid repetition?  Or is that more trouble than it's worth?
-    //
-    peer.color = newColor;
-    peer.meetings += 1;
-    peer.meetingsWithSelf += metSelf;
-    peer.meetingCompleted.write(true, memory_order_release);
-
-    //
-    // Then update ourself similarly
-    //
-    color = newColor;
-    meetings += 1;
-    meetingsWithSelf += metSelf;
-  }
-}
-
+enum digit {zero=0, one, two, three, four, five, six, seven, eight, nine};
 
 //
-// createChameneos() creates an array of chameneos of the given size.
-// If the size is 10, it uses the predefined array of colors;
-// otherwise, it deals out colors round-robin.
-//
-//
-// TODO: Currently, the compiler prints out an error if we remove the
-// return type from here; seems it would be nicer if it just put in
-// the array temp?  (unless we think we want to return unevaluated
-// iterators, which we may?  But even then, maybe in the meantime, we
-// should realize it?)
-//
-proc createChameneos(size): [1..size] Chameneos {
-  //
-  // TODO: Really want support for 'use Color' for cases like this
-  //
-  const colorsFor10 = [Color.blue, Color.red, Color.yellow, Color.red, 
-                       Color.yellow, Color.blue, Color.red, Color.yellow, 
-                       Color.red, Color.blue];
-
-  return [i in 1..size] new Chameneos(i, if (size == 10) then colorsFor10[i]
-                                                         else ((i-1)%3):Color);
-}
-
-
-//
-// Destroy the array of chameneos
-//
-proc destroyChameneos(ca: [] Chameneos) {
-  for c in ca do delete c;
-}
-
-//
-// getNewColor() returns the complement of two colors; if the two colors
-// are the same value, the color stays the same; otherwise, it becomes the
-// third color.
-//
-inline proc getNewColor(myColor, otherColor) {
-  select myColor {
-    when otherColor do return myColor;
-    when Color.blue {
-      if (otherColor == Color.red) then return Color.yellow;
-      else
-        // otherColor == Color.yellow, because first when statement
-        // eliminates Color.blue
-        return Color.red;
-    }
-    when Color.red {
-      if (otherColor == Color.blue) then return Color.yellow;
-      else
-        // otherColor == Color.yellow, because first when statement
-        // eliminates Color.red
-        return Color.blue;
-    }
-    otherwise {
-      if (otherColor == Color.blue) then return Color.red;
-      else
-        // otherColor == Color.red, because first when statement
-        // eliminates Color.yellow
-        return Color.blue;
-    }
-  }
-}
-
-
-//
-// printColorEquations() prints the result of getNewColor() for all
-// pairs of colors
-//
-proc printColorEquations() {
-  const colors = [Color.blue, Color.red, Color.yellow];
-  for color1 in colors {
-    for color2 in colors {
-      writeln(color1, " + ", color2, " -> ", getNewColor(color1, color2));
-    }
-  }
-  writeln();
-}
-
-//
-// printInfo() prints out information about the population using
-// a combination of numbers and English text
-//
-proc printInfo(chameneos) {
-  //
-  // for each chameneos, print the number of meetings and spell out
-  // the number of self-meetings for each chameneos
-  //
-  for c in chameneos {
-    write(c.meetings);
-    spellInt(c.meetingsWithSelf);
-  }
-
-  //
-  // compute the total number of meetings and spell it out
-  //
-  const totalMeetings = + reduce chameneos.meetings;
-  spellInt(totalMeetings);
-  writeln();
-}
-
-
-//
-// the base-10 digits
-//
-// TODO: Would be nice to be able to make this local to spellInt()
-//
-enum Digit {zero=0, one, two, three, four, five, six, seven, eight, nine};
-
-
-//
-// spellInt() takes out an integer value and prints its digits out
-// in English
+// Print out the digits of argument 'n' as English words by casting
+// 'n' to a string, iterating over its characters, casting those
+// characters to integers, converting those integers to 'digit's, and
+// printing those digits out.
 //
 proc spellInt(n) {
-  //
-  // Cast n to a string so that it's easier (?!) to pick out its characters
-  //
-  var s = n:string;
-  //
-  // TODO: would be nice to replace this with a character iterator?
-  //
-  for i in 1..s.length do
-    write(" ", (s[i]:int):Digit);
+  const s = n: string;
+  for c in s do
+    write(" ", (c: int): digit);
   writeln();
 }
-

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.good
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.good
@@ -12,7 +12,7 @@ yellow + yellow -> yellow
 nnn zero
 nnn zero
 nnn zero
- two zero zero
+ one two zero zero
 
  blue red yellow red yellow blue red yellow red blue
 nnn zero
@@ -25,5 +25,5 @@ nnn zero
 nnn zero
 nnn zero
 nnn zero
- two zero zero
+ one two zero zero
 


### PR DESCRIPTION
This is intended as a candidate for the release and incorporates
feedback from today's performance meeting as well as my own ideas
(mostly with respect to refactoring).  Specifically, it:

* dramatically reformats the comments and tries to normalize their
  approach.  Attempts to move away from line-by-line comments, moving
  that to procedure headers or clumps of code when things are more
  complex.

* uses the awesome new 'use enums' feature (how did I miss this when I
  looked for such cases before?  What else did I miss?)

* refactors a bunch of code:
  - introduces a 'population' record that stores all the chameneos
    and has methods that act on the group; primarily for clarity,
    though this also cleans up some memory management.
  - moved much of the top-level code in simulate() into this
    population type including the creation/destruction of the meeting
    place itself
  - moves logic relative to creating parallelism and holding meetings
    into the population
  - moves logic relating to compressing and decompressing values
    into the meeting place

* reorders code into more of a topological sort (tries to define
  things soon after their unique|last mention).

* uses a string iterator rather than a range iterator + random access

* removes the duplicate counting of meetings with self because the
  rules don't necessitate this double-counting and it seems stupid/
  unintuitive (plus should never happen, and we'll still detect that).

* leans on type inference a bit harder

* removes halts on configs and moves these into comments because
  it's not required and counts against our code size (and we don't
  think others do it)

* moves globals closer to their uses

* removes unused numColors

* tightens up the logic in the computation of the new color

* probably other stuff as well...