### PR TITLE
modules/internal/DefaultAssociative.chpl: fix typo

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -346,11 +346,11 @@ module DefaultAssociative {
       if entries < numKeys {
 
         //Find the first suitable prime
-        var threshhold = (numKeys + 1) * 2;
+        var threshold = (numKeys + 1) * 2;
         var prime = 0;
         var primeLoc = 0;
         for i in 1..chpl__primes.size {
-            if chpl__primes(i) > threshhold {
+            if chpl__primes(i) > threshold {
               prime = chpl__primes(i);
               primeLoc = i;
               break;


### PR DESCRIPTION
Threshold is an interesting word.  It refered to a piece of wood added
to the base of the door jamb for the purpose of "holding" in the
"thresh".  Thresh being the leftover bits from threshing wheat.  Why
was there thresh that needed to be held back from a doorway?  It turns
out that back before carpets, it was used as a floor covering.  But doors
swinging open and closed would knock it about or damage it.  The added
piece of wood lets the door close tightly while swinging a distance
above the floor so as not to disturb the thresh.  Hence, "threshold".

Also, it has only two h's, hence this PR.
