### PR TITLE
Enable computing histograms using reduce intents

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1115,8 +1115,8 @@ static void setupOneReduceIntent(VarSymbol* iterRec, BlockStmt* parLoop,
   // reduceVar = globalOp.generate(); delete globalOp;
   parLoop->insertAfter("'delete'(%S)",
                        globalOp);
-  parLoop->insertAfter("'='(%E,.(%S, 'generate')())",
-                       reduceVar->copy(), globalOp);
+  parLoop->insertAfter(new CallExpr("=", reduceVar->copy(),
+                         new_Expr(".(%S, 'generate')()", globalOp)));
 }
 
 // Setup for forall intents

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1275,9 +1275,13 @@ static void propagateThroughYield(CallExpr* rcall,
           // is going to be compiled away, e.g. if it is
           // within a param conditional on a not-taken branch.
           svar = new VarSymbol(astrArg(ix, "shadowVarReduc"));
+          VarSymbol* stemp  = newTemp("svrTmp");
           redRef1->insertBefore(new DefExpr(svar));
-          redRef1->insertBefore("'move'(%S, identity(%S,%S))", // init
-                                svar, gMethodToken, parentOp);
+          redRef1->insertBefore(new DefExpr(stemp));
+          redRef1->insertBefore("'move'(%S, identity(%S,%S))",
+                                stemp, gMethodToken, parentOp);
+          redRef1->insertBefore("'move'(%S, chpl__autoCopy(%S))",
+                                svar, stemp);
           redRef2->insertBefore("accumulate(%S,%S,%S)",
                                 gMethodToken, parentOp, svar);
           shadowVars[ix] = svar;
@@ -1374,12 +1378,16 @@ static void propagateExtraLeaderArgs(CallExpr* call, VarSymbol* retSym,
       ArgSymbol* parentOp = eFormal; // the reduceParent arg
       VarSymbol* currOp   = new VarSymbol(astrArg(ix, "reduceCurr"));
       VarSymbol* svar     = new VarSymbol(astrArg(ix, "shadowVar"));
+      VarSymbol* stemp    = newTemp("svTmp");
       redRef1->insertBefore(new DefExpr(currOp));
       redRef1->insertBefore("'move'(%S, clone(%S,%S))", // init
                             currOp, gMethodToken, parentOp);
       redRef1->insertBefore(new DefExpr(svar));
-      redRef1->insertBefore("'move'(%S, identity(%S,%S))", // init
-                            svar, gMethodToken, currOp);
+      redRef1->insertBefore(new DefExpr(stemp));
+      redRef1->insertBefore("'move'(%S, identity(%S,%S))",
+                            stemp, gMethodToken, currOp);
+      redRef1->insertBefore("'move'(%S, chpl__autoCopy(%S))",
+                            svar, stemp);
       redRef2->insertBefore("accumulate(%S,%S,%S)",
                             gMethodToken, currOp, svar);
       redRef2->insertBefore("chpl__reduceCombine(%S,%S)", parentOp, currOp);

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -52,7 +52,16 @@ module ChapelReduce {
   
   proc chpl__sumType(type eltType) type {
     var x: eltType;
-    return (x + x).type;
+    if isArray(x) {
+      type xET = x.eltType;
+      type xST = chpl__sumType(xET);
+      if xET == xST then
+        return eltType;
+      else
+        return [x.domain] xST;
+    } else {
+      return (x + x).type;
+    }
   }
   
   pragma "ReduceScanOp"

--- a/test/reductions/vass/histogram-1.chpl
+++ b/test/reductions/vass/histogram-1.chpl
@@ -1,0 +1,29 @@
+
+config const b = 3;
+config const n = 99;
+
+var data: [1..n] int = [i in 1..n] i % b + 1;
+
+type HistT = [1..b] int;
+var histo: HistT;
+
+writeln("computing the histogram over ", data.domain, " with ", b, " buckets");
+
+forall d in data with (+ reduce histo) {
+  histo[d] += 1;
+}
+
+writeln("histogram = ", histo);
+
+// just for kicks - reduce on domains
+
+var dosto: domain(int);
+writeln("playing with an associative domain");
+forall d in data with (+ reduce dosto) {
+  dosto.add(d);
+}
+forall d in data {
+  if !dosto.member(d) then
+    halt("dosto does not include ", d);
+}
+writeln("dosto is fine");

--- a/test/reductions/vass/histogram-1.good
+++ b/test/reductions/vass/histogram-1.good
@@ -1,0 +1,5 @@
+histogram-1.chpl:22: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+computing the histogram over {1..99} with 3 buckets
+histogram = 33 33 33
+playing with an associative domain
+dosto is fine


### PR DESCRIPTION
A natural way to histogram something in parallel is something like this:

    const buckets = <a range or domain with an index per bucket>;
    var histo: [buckets] int;

    forall dataElement in <data to plot> with (+ reduce histo) {
      const bucket = <compute the bucket that dataElement falls into>;
      histo[bucket] += 1;
    }

    writeln(histo);

To make this work, we first equip chpl__sumType() in ChapelReduce.chpl
to handle arrays.

Then, a simple program like the first half of
   test/reductions/vass/histogram-1.chpl

would contain/execute more autoDestroys than autoCopies, corrupting memory.
The compiler changes in this PR fix that.

DETAILS

Turns out that when I generate an AST that MOVEs the result of an
array-returning function without autoCopy-ing it, then
returnRecordsByReferenceArguments() on this function does not fire
and things go off rail. Namely, the function itself and I think other
array-returning functions that it invokes get an extra autoDestroy
on the return value. This was the case for two 'svar's,
named shadowVar and shadowVarReduc, that stored the result of identity():

// before this change:

  redRef1->insertBefore("'move'(%S, identity(%S,%S))", // init
                        svar, gMethodToken, parentOp);

Adding autoCopy on the result resolves the issue.

As well as I replaced a PRIM_ASSIGN with a call to "=" on the result
of generate(). Since the reduction var already exists, we really want
assign into it, not bitcopy. To call "=", I had to put in "new CallExpr"
explicitly. Before I relied on insertAfter() to invoke new_Expr,
alas the latter does not handle calls to functions with operator names
like "=".