### PR TITLE
Fix gasnet-fast fifo spawn

### DIFF
--- a/runtime/src/qio/qio_popen.c
+++ b/runtime/src/qio/qio_popen.c
@@ -34,6 +34,8 @@
 #include <unistd.h>
 #include <spawn.h>
 
+#include <pthread.h>
+
 // We need to be able to call malloc, free, etc.
 #include "chpl-mem-no-warning-macros.h"
 
@@ -156,7 +158,8 @@ static qioerr setup_actions(
    executable == NULL or "" -> search the path for argv[0]
 
  */
-qioerr qio_openproc(const char** argv,
+static
+qioerr qio_do_openproc(const char** argv,
                     const char** envp,
                     const char* executable,
                     int* stdin_fd,
@@ -319,6 +322,73 @@ error:
 
   return err;
 }
+
+struct openproc_args_s {
+  const char** argv;
+  const char** envp;
+  const char* executable;
+  int* stdin_fd;
+  int* stdout_fd;
+  int* stderr_fd;
+  int64_t* pid_out;
+  qioerr err;
+};
+
+static
+void* qio_openproc_wrapper(void* arg)
+{
+  struct openproc_args_s* s = (struct openproc_args_s*) arg;
+  s->err = qio_do_openproc(s->argv, s->envp, s->executable,
+                           s->stdin_fd, s->stdout_fd, s->stderr_fd,
+                           s->pid_out);
+  return NULL;
+}
+
+qioerr qio_openproc(const char** argv,
+                    const char** envp,
+                    const char* executable,
+                    int* stdin_fd,
+                    int* stdout_fd,
+                    int* stderr_fd,
+                    int64_t *pid_out)
+{
+  // runs qio_do_openproc in a pthread in order
+  // to avoid issuse where a Chapel task is allocated
+  // from memory with MAP_SHARED.
+  //
+  // If such a thread is the thread running fork(),
+  // after the fork() occurs, there will be 2 threads
+  // sharing the same stack.
+  //
+  // If it mattered, we could do this extra step
+  // only for configurations where the Chapel heap
+  // has this problem (GASNet with SEGMENT=fast,large
+  // and possibly others).
+
+  int rc;
+  pthread_t thread;
+  struct openproc_args_s s;
+
+  s.argv = argv;
+  s.envp = envp;
+  s.executable = executable;
+  s.stdin_fd = stdin_fd;
+  s.stdout_fd = stdout_fd;
+  s.stderr_fd = stderr_fd;
+  s.pid_out = pid_out;
+  s.err = 0;
+
+  rc = pthread_create(&thread, NULL, qio_openproc_wrapper, &s);
+  if (rc)
+    QIO_RETURN_CONSTANT_ERROR(EAGAIN, "failed pthread_create in qio_openproc");
+
+  rc = pthread_join(thread, NULL);
+  if (rc)
+    QIO_RETURN_CONSTANT_ERROR(EAGAIN, "failed pthread_join in qio_openproc");
+
+  return s.err;
+}
+
 
 // waitpid
 qioerr qio_waitpid(int64_t pid,

--- a/test/extern/bradc/externSystem.skipif
+++ b/test/extern/bradc/externSystem.skipif
@@ -1,0 +1,4 @@
+# This test fails for GASNet fast + fifo
+# Generally the Spawn module should be used instead
+# Some registered heaps configurations will fail
+CHPL_COMM!=none

--- a/test/memory/shannon/outofmemory/mallocOutOfMemory.skipif
+++ b/test/memory/shannon/outofmemory/mallocOutOfMemory.skipif
@@ -3,3 +3,4 @@ CHPL_TEST_VGRND_EXE == on
 # Both cygwin and darwin fail to define ulimit or anything similar
 CHPL_HOST_PLATFORM == darwin
 CHPL_HOST_PLATFORM <= cygwin
+# Note, this test has a different error for GASNet fast + fifo


### PR DESCRIPTION
The configuration:

    CHPL_COMM: gasnet *
      CHPL_COMM_SUBSTRATE: udp
      CHPL_GASNET_SEGMENT: fast *
    CHPL_TASKS: fifo *

was not working with the Spawn module.

The problem is that with segment=fast, GASNet allocates the
communication-ready segment with MAP_SHARED. At the same time, PR #3729
made tasks=fifo allocate out of the Chapel heap.  The result is that task
stacks are allocated with MAP_SHARED.  That causes pretty severe problems
if fork() is called, because the new process and the old process are both
sharing the same thread stack.

This PR solves this problem by calling pthread_create before running
fork() in qio_openproc. That way, the current thread will have a stack
that is not allocated from the Chapel heap and so presumably will not
have MAP_SHARED.

Tested with test/modules/standard/Spawn on linux64 and on Mac OS X (but
only linux showed the problem described).
Tested with full GASNet segment=fast with fifo run.

Reviewed by @gbtitus - thanks!