### PR TITLE
Homogeneous homogeneity

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3355,7 +3355,7 @@ void codegenAssign(GenRet to_ptr, GenRet from)
   if( (to_ptr.isLVPtr != GEN_WIDE_PTR && from.isLVPtr != GEN_WIDE_PTR )) {
     // Neither is wide.
     if( isStarTuple ) {
-      // Homogenous tuples are pointers even when GEN_VAL is set.
+      // Homogeneous tuples are pointers even when GEN_VAL is set.
       // Homogeneous tuples are copied specially
       if ( !fNoTupleCopyOpt &&
            starTupleLength <= tuple_copy_limit &&
@@ -4259,7 +4259,7 @@ GenRet CallExpr::codegen() {
          case PRIM_GET_SVEC_MEMBER:
          {
           if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
-            /* Get a pointer to the i'th element of a homogenous tuple */
+            /* Get a pointer to the i'th element of a homogeneous tuple */
             GenRet elemPtr =
               codegenElementPtr(call->get(1),codegenExprMinusOne(call->get(2)));
             INT_ASSERT( elemPtr.isLVPtr == GEN_WIDE_PTR );

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6185,7 +6185,7 @@ preFold(Expr* expr) {
       call->replace(result);
     } else if (call->isPrimitive(PRIM_IS_STAR_TUPLE_TYPE)) {
       Type* tupleType = call->get(1)->typeInfo();
-      // If the type isn't a tuple, it definitely isn't a homogenous tuple!
+      // If the type isn't a tuple, it definitely isn't a homogeneous tuple!
       if (tupleType->symbol->hasFlag(FLAG_TUPLE) &&
           tupleType->symbol->hasFlag(FLAG_STAR_TUPLE))
         result = new SymExpr(gTrue);

--- a/modules/dists/DSIUtil.chpl
+++ b/modules/dists/DSIUtil.chpl
@@ -363,7 +363,7 @@ proc _densiIdxCheck(type subIdxType, type wholeIdxType, type argtypes) {
 }
 
 proc _densiCheck(param cond, type argtypes, param errlevel = 2) {
-  if !cond then compilerError("densify() is defined only on matching domains, ranges, and quasi-homogenous tuples of ranges (except stridability and range boundedness do not need to match), but is invoked on ", argtypes:string, errlevel);
+  if !cond then compilerError("densify() is defined only on matching domains, ranges, and quasi-homogeneous tuples of ranges (except stridability and range boundedness do not need to match), but is invoked on ", argtypes:string, errlevel);
 }
 
 //
@@ -444,7 +444,7 @@ proc _undensEnsureBounded(arg) {
 }
 
 proc _undensCheck(param cond, type argtypes, param errlevel = 2) {
-  if !cond then compilerError("unDensify() is defined only on matching domains, ranges, and quasi-homogenous tuples of ranges, but is invoked on ", argtypes:string, errlevel);
+  if !cond then compilerError("unDensify() is defined only on matching domains, ranges, and quasi-homogeneous tuples of ranges, but is invoked on ", argtypes:string, errlevel);
 }
 
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -799,7 +799,7 @@ module String {
     }
 
     /*
-      Same as the varargs version, but with a homogenous tuple of strings.
+      Same as the varargs version, but with a homogeneous tuple of strings.
 
       .. code-block:: chapel
 

--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -3,7 +3,7 @@
 \index{arrays}
 
 An \emph{array} is a map from a domain's indices to a collection of
-variables of homogenous type.  Since Chapel domains support a rich
+variables of homogeneous type.  Since Chapel domains support a rich
 variety of index sets, Chapel arrays are also richer than the
 traditional linear or rectilinear array types in conventional
 languages.  Like domains, arrays may be distributed across multiple

--- a/spec/Domains.tex
+++ b/spec/Domains.tex
@@ -121,7 +121,7 @@ any of the domain's dimensions will be characterized by a strided
 range.
 \end{itemize}
 If \chpl{rank} is $1$, the index type represented by a rectangular
-domain is \chpl{idxType}.  Otherwise, the index type is the homogenous
+domain is \chpl{idxType}.  Otherwise, the index type is the homogeneous
 tuple type \chpl{rank*idxType}.
 If unspecified, \chpl{idxType} defaults
 to \chpl{int} and \chpl{stridable} defaults to \chpl{false}.

--- a/spec/Interoperation.tex
+++ b/spec/Interoperation.tex
@@ -209,7 +209,7 @@ it treats the named type as an opaque type.  The definition for an external type
 must be supplied by a C header file named on the \chpl{chpl} command line.
 
 Fixed-size C array types can be described within Chapel using its
-homogenous tuple type.  For example, the C typedef
+homogeneous tuple type.  For example, the C typedef
 \begin{chapel}
 typedef double vec[3];
 \end{chapel}

--- a/spec/Tuples.tex
+++ b/spec/Tuples.tex
@@ -52,7 +52,7 @@ tuple.  If a programmer requires a non-parameter value to define a
 data structure, an array may be a better choice.
 \end{rationale}
 
-\begin{chapelexample}{homogenous.chpl}
+\begin{chapelexample}{homogeneous.chpl}
 The statement
 \begin{chapel}
 var x1: (string, real),
@@ -226,7 +226,7 @@ since the type of an expression must be statically known.
 
 % FYI: Similar to text regarding array iteration.  Slightly less
 % similar for domain iteration.
-Only homogenous tuples support iteration via
+Only homogeneous tuples support iteration via
 standard \chpl{for}, \chpl{forall} and \chpl{coforall} loops.  These loops
 iterate over all of the tuple's elements.  A loop of the form:
 
@@ -236,7 +236,7 @@ iterate over all of the tuple's elements.  A loop of the form:
   ...e...
 \end{chapel}
 
-where t is a homogenous tuple of size \chpl{n}, is semantically
+where t is a homogeneous tuple of size \chpl{n}, is semantically
 equivalent to:
 
 % This is difficult to capture in a test program
@@ -667,7 +667,7 @@ The binary operators \chpl{\+}, \chpl{\-}, \chpl{\*}, \chpl{\/}, \chpl{\%},
 are overloaded on tuples by applying them to pairs of the respective
 argument components and returning the results as a new tuple.  The
 sizes of the two argument tuples must be the same.  These operators
-are also defined for homogenous tuples and scalar values of matching
+are also defined for homogeneous tuples and scalar values of matching
 type.
 
 The size of the result tuple is the same as the argument tuple(s).


### PR DESCRIPTION
Fix a few places that said "homogenous" instead of "homogeneous".  (The latter is more prevalent in the spec and in the rest of the repo.)

Re: the spec chplexample change: I ran make spectests, and then start_test of the resulting
release/examples/spec/Tuples/homogeneous.chpl
which passed.

The error messages in DSIUtil.chpl do not appear in any .good or .bad file.