### PR TITLE
Pre-release prep. for Chapel 1.13.1 : increment version numbers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Release Changes List
 ====================
 
 ==============
-version 1.13.0
+version 1.13.1 (PRE-RELEASE)
 ==============
 
 Sixteenth public release of Chapel, April 7, 2016

--- a/GOALS.md
+++ b/GOALS.md
@@ -1,5 +1,5 @@
 ============================================
-Chapel Public Release Goals (version 1.13.0)
+Chapel Public Release Goals (version 1.13.1)
 ============================================
 
 The goals of this release are as follows:

--- a/QUICKSTART.rst
+++ b/QUICKSTART.rst
@@ -25,7 +25,7 @@ distributed memory execution.
 1) Make sure that your shell is in the directory containing this
    ``QUICKSTART.rst`` file.  For example:
 
-        ``cd ~/chapel-1.13.0``
+        ``cd ~/chapel-1.13.1``
 
 
 2) Set up your environment to use Chapel in "Quick Start" mode:

--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -22,7 +22,7 @@
 
 #define MAJOR_VERSION 1
 #define MINOR_VERSION "13"
-#define UPDATE_VERSION "0"
+#define UPDATE_VERSION "1"
 
 static const char* BUILD_VERSION =
 #include "BUILD_VERSION"

--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -33,7 +33,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.13.0
+        export CHPL_HOME=~/chapel-1.13.1
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -61,7 +61,7 @@ master_doc = 'index'
 shortversion = 1.13
 
 # The full version, including alpha/beta/rc tags.
-release = '1.13.0'
+release = '1.13.1'
 
 # General information about the project.
 project = u'Chapel Documentation {0}'.format(shortversion)

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.13.0
+:Version: 1.13.1
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.13.0
+:Version: 1.13.1
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- Version 1.13.0
+ Version 1.13.1


### PR DESCRIPTION
THIS IS NOT CHAPEL RELEASE 1.13.1.

This commit merely increments the embedded version numbers from
1.13.0 to 1.13.1, in preparation for later release.