### PR TITLE
Remove curly brackets from 'otherwise'

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -219,9 +219,8 @@ inline proc getNewColor(myColor, otherColor) {
     when red do
       return (if otherColor == blue then yellow else blue);
 
-    otherwise {
+    otherwise
       return (if otherColor == blue then red else blue);
-    }
   }
 }
 


### PR DESCRIPTION
I was thinking that we should support 'otherwise do stmt' but was
misremembering that we simply support 'otherwise stmt'.  I think
we should permit the 'do' (for symmetry, because it's an obvious
thing to want to type there), but will take advantage of the do-less,
curly-bracket-less form here for its brevity and simplicity.
