### PR TITLE
Extern block c_fn_ptr

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -919,11 +919,13 @@ void setupClang(GenInfo* info, std::string mainFile)
     // Make sure we include clang's internal header dir
 #if HAVE_LLVM_VER >= 34
     SmallString<128> P;
+    SmallString<128> P2; // avoids a valgrind overlapping memcpy
+
     P = clangexe;
     // Remove /clang from foo/bin/clang
-    P = sys::path::parent_path(P);
+    P2 = sys::path::parent_path(P);
     // Remove /bin   from foo/bin
-    P = sys::path::parent_path(P);
+    P = sys::path::parent_path(P2);
 
     if( ! P.equals("") ) {
       // Get foo/lib/clang/<version>/

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -103,6 +103,19 @@ module CPtr {
       return __primitive("cast", t, nil);
   }
 
+  pragma "compiler generated"
+  pragma "no doc"
+  inline proc _defaultOf(type t) where t == c_fn_ptr {
+      return __primitive("cast", t, nil);
+  }
+
+  pragma "no doc"
+  inline proc =(ref a:c_fn_ptr, b:_nilType) { __primitive("=", a, c_nil); }
+
+  pragma "no doc"
+  inline proc =(ref a:c_fn_ptr, b:c_fn_ptr) { __primitive("=", a, b); }
+
+
 
   pragma "no doc"
   inline proc ==(a: c_ptr, b: c_ptr) where a.eltType == b.eltType {

--- a/test/extern/ferguson/externblock/fptr2.chpl
+++ b/test/extern/ferguson/externblock/fptr2.chpl
@@ -1,0 +1,19 @@
+extern {
+  static void runit(double (*f)(double)) {
+     double result;
+     printf("in runit, calling f(1.0)\n");
+     result = f(1.0);
+     printf("in runit, result is %lf\n", result);
+  }
+}
+
+proc f(x:real):real {
+  writeln("in f(", x, ")");
+  return x + 1.1;
+}
+
+runit(c_ptrTo(f));
+
+var x = c_ptrTo(f);
+
+runit(x);

--- a/test/extern/ferguson/externblock/fptr2.good
+++ b/test/extern/ferguson/externblock/fptr2.good
@@ -1,0 +1,6 @@
+in runit, calling f(1.0)
+in f(1.0)
+in runit, result is 2.100000
+in runit, calling f(1.0)
+in f(1.0)
+in runit, result is 2.100000

--- a/test/extern/ferguson/externblock/fptr3.chpl
+++ b/test/extern/ferguson/externblock/fptr3.chpl
@@ -1,0 +1,22 @@
+extern {
+  typedef double (*function_ptr_type)(double x);
+  static void runit(function_ptr_type f) {
+     double result;
+     printf("in runit, calling f(1.0)\n");
+     result = f(1.0);
+     printf("in runit, result is %lf\n", result);
+  }
+}
+
+proc f(x:real):real {
+  writeln("in f(", x, ")");
+  return x + 1.1;
+}
+
+runit(c_ptrTo(f));
+
+var x : function_ptr_type;
+x = nil;
+x = c_ptrTo(f);
+
+runit(x);

--- a/test/extern/ferguson/externblock/fptr3.good
+++ b/test/extern/ferguson/externblock/fptr3.good
@@ -1,0 +1,6 @@
+in runit, calling f(1.0)
+in f(1.0)
+in runit, result is 2.100000
+in runit, calling f(1.0)
+in f(1.0)
+in runit, result is 2.100000


### PR DESCRIPTION
Improves C function pointer support especially with extern blocks.

* Adds _defaultOf and basic = overloads for c_fn_ptr
* Adjusts externCResolve to use c_fn_ptr instead of treating C function
  pointers as opaque
* Adds test cases for the new functionality
* While working in this area, noticed and resolved a valgrind overlapping
  memcpy.

Note: c_fn_ptr does not distinguish between pointers to C functions with
different argument types. That should probably be improved at some point.

Passed test/extern/ferguson and test/extern/jjueckstock with
CHPL_LLVM=llvm.
Passed full local testing with CHPL_LLVM=llvm.

Valgrind run for the test fptr2.chpl is now clean.

Reviewed by @lydia-duncan - thanks!