### PR TITLE
Add suppressif file for sparse bulk addition test

### DIFF
--- a/test/arrays/bradc/slices/outOfBoundsSlice.suppressif
+++ b/test/arrays/bradc/slices/outOfBoundsSlice.suppressif
@@ -5,7 +5,7 @@
 # whether tests like this should be suppressed or skipped. For now we
 # suppress with the argument that we're testing that --fast actually
 # turns our checks off. Note that we don't just turn checks on in the
-# comopts since we wouldn't be testing the default behavior, and
+# compopts since we wouldn't be testing the default behavior, and
 # wouldn't be able to verify that checks are enabled by default. 
 
 COMPOPTS <= --fast

--- a/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.suppressif
+++ b/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.suppressif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast

--- a/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.suppressif
+++ b/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.suppressif
@@ -1,1 +1,11 @@
+# --fast sets --no-checks
+#
+# --fast sets --no-checks and this test is explicitly checking that one
+# of our runtime checks is working correctly. There's been debate as to
+# whether tests like this should be suppressed or skipped. For now we
+# suppress with the argument that we're testing that --fast actually
+# turns our checks off. Note that we don't just turn checks on in the
+# compopts since we wouldn't be testing the default behavior, and
+# wouldn't be able to verify that checks are enabled by default. 
+
 COMPOPTS <= --fast


### PR DESCRIPTION
This change was necessary to avoid failures with --fast testing.