### PR TITLE
Update .good files after reduction in mem used

### DIFF
--- a/test/memory/shannon/printFinalMemStat.lm-numa.good
+++ b/test/memory/shannon/printFinalMemStat.lm-numa.good
@@ -3,7 +3,7 @@
 Memory Statistics
 ==============================================================
 Current Allocated Memory               256
-Maximum Simultaneous Allocated Memory  368
-Total Allocated Memory                 880
-Total Freed Memory                     624
+Maximum Simultaneous Allocated Memory  256
+Total Allocated Memory                 256
+Total Freed Memory                     0
 ==============================================================

--- a/test/memory/shannon/printFinalMemStat.no-local.good
+++ b/test/memory/shannon/printFinalMemStat.no-local.good
@@ -3,7 +3,7 @@
 Memory Statistics
 ==============================================================
 Current Allocated Memory               256
-Maximum Simultaneous Allocated Memory  505
-Total Allocated Memory                 2137
-Total Freed Memory                     1881
+Maximum Simultaneous Allocated Memory  448
+Total Allocated Memory                 729
+Total Freed Memory                     473
 ==============================================================


### PR DESCRIPTION
PR #3890 reduced the memory used in this test, so the .good files needed
updating.
