### PR TITLE
Ack the chameneos version from which we think we benefitted the most

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -2,6 +2,7 @@
    http://benchmarksgame.alioth.debian.org/
 
    contributed by Hannah Hemmaplardh, Lydia Duncan, and Brad Chamberlain
+   derived in part from the GNU C version by Dmitry Vyukov
 */
 
 config const n = 600,              // number of meetings (must be >= 0)


### PR DESCRIPTION
[trivial, not reviewed]

While we probably learned from several versions when we wrote this years ago, the atomic CAS from Dmitry's version is probably the most obvious ancestor of our version.
