### PR TITLE
Forgot to set the lineno when making these copies.

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2524,6 +2524,7 @@ UseStmt* UseStmt::applyOuterUse(UseStmt* outer) {
       // Handles case where inner use has an 'except' list, or is
       // just a plain use.  The use returned will have a (longer) 'except'
       // list.
+      SET_LINENO(this);
       UseStmt* newUse = copy();
       for_vector(const char, toExclude, outer->named) {
         newUse->named.push_back(toExclude);
@@ -2618,6 +2619,7 @@ UseStmt* UseStmt::applyOuterUse(UseStmt* outer) {
     } else {
       // The inner use did not specify an 'except' or 'only' list,
       // so propagate our 'only' list and/or renamed list to it.
+      SET_LINENO(this);
       UseStmt* newUse = copy();
       for_vector(const char, toInclude, outer->named) {
         newUse->named.push_back(toInclude);


### PR DESCRIPTION
Led to a "missing line number" error when BenA tried to allow DefaultAssociative
to limit its use of the Sort module.  This changes allows hello.chpl to pass,
and I verified that it worked in the testing directory without the DefaultAssociative
change.