### PR TITLE
Proposed improvements to spectral-norm

### DIFF
--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -48,6 +48,20 @@ binarytrees.chpl
 o What would it take to make Chapel better at inferring the type of
   recursive functions, at least in simple cases?
 
+o Related: the type function Tree.build() could be made into a
+  constructor except that the compiler can't resolve the return type
+  of the constructor because it's recursive (which is silly since it's
+  a constructor) yet we can't declare the return type because it's a
+  constructor.  I.e., wouldn't it be nice to write:
+
+    proc Tree(item, depth) {
+      this.item = item;
+      if depth {
+        left = new Tree(2*item-1, depth-1);
+        right = new Tree(2*item-1, depth-1);
+      }
+    }
+
 
 chameneosredux.chpl
 -------------------
@@ -114,6 +128,27 @@ o promote mpz_t types to a record-based implementation with:
   - automatic memory reclamation when it leaves scope
   - support for native Chapel types rather than exposing C types
     (using safecasts at any downward-facing interfaces)
+
+
+spectralnorm.chpl
+-----------------
+o spectral norm really wants partial reductions... :(
+
+o open question: What would it take to efficiently have the helper
+  routines return the result they're computing rather than taking it
+  in as an input argument?
+
+o similarly, what could we do to not pass 'tmp' in as an input
+  argument?  Static variables?
+
+o do we have an opportunity to take advantage of vectorization?
+  (could it be as simple as 'vectorizeOnly-ing' the reduction loops?
+
+o are our reductions overly heavyweight in the serial case?  (e.g., do
+  we still use synchronized values?)  What could we do to improve
+  them?
+
+o are the domain queries costing us more than we'd like?
 
 
 threadring.chpl

--- a/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
+++ b/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
@@ -1,66 +1,51 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 
-   Contributed by Lydia Duncan & Albert Sidelnik, based on Sebastien
-   Loisel's C version
+   contributed by Lydia Duncan, Albert Sidelnik, and Brad Chamberlain
+   derived from the C version by Sebastien Loisel
 */
 
-config const n = 500;
-
-// Note:
-// Matrix A is never actually stored, its contents are computed on the fly
-// through calls to the method A.  This is part of the benchmark's
-// required implementation.  For ease of reference, it will be referred to as
-// simply "A" when used.  Similarly, At is A transposed.
+config const n = 500;           // the size of A (n x n), u and v (n-vectors)
 
 proc main() {
-  var tmp, u, v: [0..#n] real;  // Declare three vectors
+  var tmp, u, v: [0..#n] real;
 
-  u = 1.0;                      // Initialize u to 1.0
+  u = 1.0;
 
   for 1..10 {                   // For 10 iterations...
-    multiplyAtAv(u, tmp, v);    // ...compute v = A*u*At
-    multiplyAtAv(v, tmp, u);    // ...and     u = A*v*At
+    multiplyAtAv(u, tmp, v);    // ...compute     v = A^T*A*u
+    multiplyAtAv(v, tmp, u);    // ...followed by u = A^T*A*v
   }
 
   writef("%.9dr\n", sqrt(+ reduce (u*v) / + reduce (v*v)));
 }
 
 //
-// Multiply vector v by matrix A and then by matrix A transposed
+// Compute A-transpose * A * v ('AtAv').
 //
 proc multiplyAtAv(v, tmp, AtAv) {
   multiplyAv(v, tmp);
   multiplyAtv(tmp, AtAv);
 }
 
-
 //
-// Multiply vector v by matrix A
+// Compute A * v ('Av').
 //
 proc multiplyAv(v: [?Dv], Av: [?DAv]) {
   forall i in DAv do
-    // The use of a serial statement here and in multiplyAtv is to avoid
-    // creating additional tasks for the reduction.  Traversing the outer
-    // loop in parallel is more efficient than dividing the smaller
-    // computations up between parallel tasks.
-    serial do
-      Av[i] = + reduce [j in Dv] (A[i,j] * v[j]);
+    Av[i] = + reduce (for j in Dv do A[i,j] * v[j]);
 }
 
-
 //
-// Multiply vector V by matrix A transposed
+// Compute A-tranpose * v ('Atv').
 //
 proc multiplyAtv(v: [?Dv], Atv: [?DAtv]) {
   forall i in DAtv do
-    serial do
-      Atv[i] = + reduce [j in Dv] (A[j,i] * v[j]);
+    Atv[i] = + reduce (for j in Dv do A[j,i] * v[j]);
 }
 
-
 //
-// return element i,j of infinite matrix A
+// Compute element i,j of the conceptually infinite matrix A.
 //
 inline proc A(i, j) {
   return 1.0 / ((((i + j) * (i + j + 1)) / 2) + i + 1);

--- a/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
+++ b/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
@@ -48,5 +48,5 @@ proc multiplyAtv(v: [?Dv], Atv: [?DAtv]) {
 // Compute element i,j of the conceptually infinite matrix A.
 //
 inline proc A(i, j) {
-  return 1.0 / ((((i + j) * (i + j + 1)) / 2) + i + 1);
+  return 1.0 / ((((i+j) * (i+j+1)) / 2) + i + 1);
 }

--- a/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
+++ b/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
@@ -13,8 +13,8 @@ proc main() {
   u = 1.0;
 
   for 1..10 {                   // For 10 iterations...
-    multiplyAtAv(u, tmp, v);    // ...compute     v = A^T*A*u
-    multiplyAtAv(v, tmp, u);    // ...followed by u = A^T*A*v
+    multiplyAtAv(u, tmp, v);    // ...compute:     v = A^T*A*u
+    multiplyAtAv(v, tmp, u);    // ...followed by: u = A^T*A*v
   }
 
   writef("%.9dr\n", sqrt(+ reduce (u*v) / + reduce (v*v)));

--- a/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
+++ b/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
@@ -2,7 +2,8 @@
    http://benchmarksgame.alioth.debian.org/
 
    contributed by Lydia Duncan, Albert Sidelnik, and Brad Chamberlain
-   derived from the C version by Sebastien Loisel
+   derived from the GNU C version by Sebastien Loisel and the C# version
+   by Isaac Gouy
 */
 
 config const n = 500;           // the size of A (n x n), u and v (n-vectors)


### PR DESCRIPTION
This is a proposed set of improvements to spectral-norm for submission to the CLBG.  Mostly it's simplification of comments, attempting to follow what we've done for others.  The main code change
was to change a serial statement into a for loop (i.e., now that we have no warnings for serial reductions, why ask to compute something in parallel and then serializing it rather than just asking for it to be serial to begin with?)
