### PR TITLE
Squash CCE-specific warnings generated by 'c_fn_ptr' tests

### DIFF
--- a/make/compiler/Makefile.cray-prgenv-cray
+++ b/make/compiler/Makefile.cray-prgenv-cray
@@ -15,8 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Suppress warning about variables used before defined
-CRAYPE_GEN_CFLAGS = -hnomessage=7212
+# Suppress warnings:
+# 7212: Suppress warning about variables used before defined
+# 167:  Suppress warning about pointer mismatches (required by 'c_fn_ptr')
+CRAYPE_GEN_CFLAGS = -hnomessage=7212:167
 
 FAST_FLOAT_GEN_CFLAGS = -hfp2
 IEEE_FLOAT_GEN_CFLAGS = -hfp0


### PR DESCRIPTION
My new 'c_fn_ptr' tests cause warnings due to assigning a 'void*'
pointer to a C function pointer.  This PR squashes the warning for
CCE.  The following simple C test demonstrates the same warning:

        #include <stdio.h>

        void bar(void (*f)(void)) {
          f();
        }

        void foo(void) {
          printf("Hi!\n");
        }

        int main() {
          void* fptr = foo;
          bar(fptr);
        }

Note that the warning is CCE-specific and doesn't show up with gnu,
intel, or pgi.

Tests that generated the warning were:

* extern/fnPtrs/passFnsToC2x2.chpl
* extern/fnPtrs/passFnsToC2x.chpl
* extern/fnPtrs/passFnsToCChapel2.chpl
* extern/fnPtrs/passFnsToCChapel2x.chpl
* extern/fnPtrs/passFnsToCChapel.chpl
* extern/fnPtrs/storeFnsThenPass2x.chpl
* extern/fnPtrs/storeFnsThenPass.chpl

This is something we can't work around in the generated code until
such time as users can declare the argument and return types of their
external C function pointer types (and even then, we may still wish to
preserve the ability to specify a generic C function pointer like
'c_fn_ptr' for the sake of productivity).

Note that Nikhil ran into similar warnings with gnu in a different
context in PR#3992.