### PR TITLE
Adding module name to the end of generated symbols

### DIFF
--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -791,8 +791,14 @@ static void codegen_header() {
   // mangle type names if they clash with other types
   //
   forv_Vec(TypeSymbol, ts, types) {
-    if (ts->isRenameable())
-      ts->cname = uniquifyName(ts->cname, &cnames);
+    if (ts->isRenameable()){
+      if(ts->getModule()->modTag != MOD_INTERNAL) {
+        legalizeName(ts->getModule());
+        ts->cname = uniquifyName(astr(ts->cname, "_", ts->getModule()->cname), &cnames);
+      }
+      else
+        ts->cname = uniquifyName(ts->cname, &cnames);
+   }
   }
   uniquifyNameCounts.clear();
 
@@ -805,8 +811,9 @@ static void codegen_header() {
       for_enums(constant, enumType) {
         Symbol* sym = constant->sym;
         legalizeName(sym);
+        legalizeName(sym->getModule());
         sym->cname = astr(enumType->symbol->cname, "_", sym->cname);
-        sym->cname = uniquifyName(sym->cname, &cnames);
+        sym->cname = uniquifyName(astr(sym->cname, "_", sym->getModule()->cname), &cnames);
       }
     }
   }
@@ -822,7 +829,43 @@ static void codegen_header() {
         Vec<const char*> fieldNameSet;
         for_fields(field, ct) {
           legalizeName(field);
-          field->cname = uniquifyName(field->cname, &fieldNameSet);
+
+          //
+          // Here, we try to append module name to the end of a field name.
+          // However, simply appending the module name breaks things in a way
+          // similar to suggested previously in protectNameFromC (Pending TODO)
+          // Hence, the fix used there has been implemented here to rename only
+          // the specific parts which can be renamed currently. A more
+          // detailed explanation of the issue and the fix can be found in
+          // the comments of protectNameFromC function.
+          //
+          bool canModifyName = true;
+
+          ModuleSymbol* fieldMod = field->getModule();
+          if (fieldMod->modTag == MOD_INTERNAL) {
+            canModifyName = false;
+          }
+
+          //
+          // Walk from the symbol up to its enclosing module.  If the symbol
+          // is declared within an extern declaration, name should be preserved.
+          //
+          if (field != fieldMod) {
+            Symbol* parentSym = field->defPoint->parentSymbol;
+            while (parentSym != fieldMod) {
+              if (parentSym->hasFlag(FLAG_EXTERN)) {
+                canModifyName = false;
+              }
+              parentSym = parentSym->defPoint->parentSymbol;
+            }
+          }
+
+          if(canModifyName){
+            legalizeName(field->getModule());
+            field->cname = uniquifyName(astr(field->cname, "_", field->getModule()->cname), &fieldNameSet);
+          }
+          else
+            field->cname = uniquifyName(field->cname, &fieldNameSet);
         }
         uniquifyNameCounts.clear();
       }
@@ -834,8 +877,10 @@ static void codegen_header() {
   // constants, or other global variables
   //
   forv_Vec(VarSymbol, var, globals) {
-    if (var->isRenameable())
-      var->cname = uniquifyName(var->cname, &cnames);
+    if (var->isRenameable()){
+      legalizeName(var->getModule());
+      var->cname = uniquifyName(astr(var->cname, "_", var->getModule()->cname), &cnames);
+    }
   }
   uniquifyNameCounts.clear();
 
@@ -844,8 +889,25 @@ static void codegen_header() {
   // global variables, or other functions
   //
   for_vector(FnSymbol, fn, functions) {
-    if (fn->isRenameable())
-      fn->cname = uniquifyName(fn->cname, &cnames);
+    if (fn->isRenameable()){
+      legalizeName(fn->getModule());
+      bool canModifyName = true;
+
+      ModuleSymbol* fnMod = fn->getModule();
+      if (fnMod->modTag == MOD_INTERNAL) {
+        canModifyName = false;
+      }
+
+      //
+      // Avoiding strange looking name "chpl__init_ModuleName_ModuleName"
+      // for the init function where the name of the function has the module
+      // name already appended to it.
+      //
+      if(canModifyName && strncmp("chpl__init", fn->cname, strlen("chpl__init")))
+        fn->cname = uniquifyName(astr(fn->cname, "_", fn->getModule()->cname), &cnames);
+      else
+        fn->cname = uniquifyName(fn->cname, &cnames);
+    }
   }
   uniquifyNameCounts.clear();
 
@@ -858,7 +920,8 @@ static void codegen_header() {
     Vec<const char*> formalNameSet;
     for_formals(formal, fn) {
       legalizeName(formal);
-      formal->cname = uniquifyName(formal->cname, &formalNameSet, &cnames);
+      legalizeName(formal->getModule());
+      formal->cname = uniquifyName(astr(formal->cname, "_", formal->getModule()->cname), &formalNameSet, &cnames);
     }
     uniquifyNameCounts.clear();
   }
@@ -891,7 +954,11 @@ static void codegen_header() {
             def->sym->cname = astr("T");
         }
       }
-      def->sym->cname = uniquifyName(def->sym->cname, &local, &cnames);
+
+      if(def->sym->isRenameable())
+        def->sym->cname = uniquifyName(astr(def->sym->cname, "_", def->sym->getModule()->cname), &local, &cnames);
+      else
+        def->sym->cname = uniquifyName(def->sym->cname, &local, &cnames);
     }
     uniquifyNameCounts.clear();
   }

--- a/test/types/range/elliot/anonymousRangeIter.expectedGenCode
+++ b/test/types/range/elliot/anonymousRangeIter.expectedGenCode
@@ -13,33 +13,33 @@
 # loops to change.
 
 # for i in 1..2 do write(i); writeln();
-ic__F#_high_chpl = INT64(2);
-for (i_chpl = INT64(1); ((i_chpl <= _ic__F#_high_chpl)); i_chpl += INT64(1))
+ic__F#_high_chpl_anonymousRangeIter_chpl = INT64(2);
+for (i_chpl_anonymousRangeIter_chpl = INT64(1); ((i_chpl_anonymousRangeIter_chpl <= _ic__F#_high_chpl_anonymousRangeIter_chpl)); i_chpl_anonymousRangeIter_chpl += INT64(1))
 
 # for i in 2..2+1 do write(i); writeln();
-_ic__F#_high_chpl# = INT64(3);
-for (i_chpl# = INT64(2); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(1))
+_ic__F#_high_chpl_anonymousRangeIter_chpl# = INT64(3);
+for (i_chpl_anonymousRangeIter_chpl# = INT64(2); ((i_chpl_anonymousRangeIter_chpl# <= _ic__F#_high_chpl_anonymousRangeIter_chpl#)); i_chpl_anonymousRangeIter_chpl# += INT64(1))
 
 # var lo=3, hi=4; for i in lo..hi do write(i); writeln();
-_ic__F#_high_chpl# = INT64(4);
-for (i_chpl# = INT64(3); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(1))
+_ic__F#_high_chpl_anonymousRangeIter_chpl# = INT64(4);
+for (i_chpl_anonymousRangeIter_chpl# = INT64(3); ((i_chpl_anonymousRangeIter_chpl# <= _ic__F#_high_chpl_anonymousRangeIter_chpl#)); i_chpl_anonymousRangeIter_chpl# += INT64(1))
 
 # for i in 4..5 by 2 do write(i); writeln();
-_ic__F#_high_chpl# = INT64(5);
-for (i_chpl# = INT64(4); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(2)) {
+_ic__F#_high_chpl_anonymousRangeIter_chpl# = INT64(5);
+for (i_chpl_anonymousRangeIter_chpl# = INT64(4); ((i_chpl_anonymousRangeIter_chpl# <= _ic__F#_high_chpl_anonymousRangeIter_chpl#)); i_chpl_anonymousRangeIter_chpl# += INT64(2)) {
 
 # for i in 2..#4 do write(i); writeln();
-_ic__F#_high_chpl# = INT64(5);
-for (i_chpl# = INT64(2); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(1)) {
+_ic__F#_high_chpl_anonymousRangeIter_chpl# = INT64(5);
+for (i_chpl_anonymousRangeIter_chpl# = INT64(2); ((i_chpl_anonymousRangeIter_chpl# <= _ic__F#_high_chpl_anonymousRangeIter_chpl#)); i_chpl_anonymousRangeIter_chpl# += INT64(1)) {
 
 # for (i, j) in zip(1..10 by 3, 1..10 by -3) do write(i,j); writeln();
-_ic__F#_high_chpl# = INT64(10);
-for (_ic__F#_i_chpl = INT64(1),_ic__F3_i_chpl2 = INT64(10); (tmp_chpl = (_ic__F#_i_chpl <= _ic__F#_high_chpl#),tmp_chpl); tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += INT64(3),_ic__F3_i_chpl = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT64(-3),_ic__F3_i_chpl2 = tmp_chpl#)
+_ic__F#_high_chpl_anonymousRangeIter_chpl# = INT64(10);
+for (_ic__F#_i_chpl_anonymousRangeIter_chpl = INT64(1),_ic__F3_i_chpl_anonymousRangeIter_chpl2 = INT64(10); (tmp_chpl_anonymousRangeIter_chpl = (_ic__F#_i_chpl_anonymousRangeIter_chpl <= _ic__F#_high_chpl_anonymousRangeIter_chpl#),tmp_chpl_anonymousRangeIter_chpl); tmp_chpl_anonymousRangeIter_chpl# = _ic__F#_i_chpl_anonymousRangeIter_chpl,tmp_chpl_anonymousRangeIter_chpl# += INT64(3),_ic__F3_i_chpl_anonymousRangeIter_chpl = tmp_chpl_anonymousRangeIter_chpl#,tmp_chpl_anonymousRangeIter_chpl# = _ic__F#_i_chpl_anonymousRangeIter_chpl#,tmp_chpl_anonymousRangeIter_chpl# += INT64(-3),_ic__F3_i_chpl_anonymousRangeIter_chpl2 = tmp_chpl_anonymousRangeIter_chpl#)
 
 # var r = 1..10 by 2; for (i, j) in zip(1..10 by 2, r) do write(i, j); writeln();
-_ic__F#_high_chpl# = INT64(10);
-for (_ic__F#_i_chpl# = INT64(1),_ic__value_chpl = tmp_chpl#; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT64(2),_ic__F3_i_chpl3 = tmp_chpl#,tmp_chpl# = _ic__value_chpl,tmp_chpl# += ret_chpl#,_ic__value_chpl = tmp_chpl#)
+_ic__F#_high_chpl_anonymousRangeIter_chpl# = INT64(10);
+for (_ic__F#_i_chpl_anonymousRangeIter_chpl# = INT64(1),_ic__value_chpl_anonymousRangeIter_chpl = tmp_chpl_anonymousRangeIter_chpl#; (tmp_chpl_anonymousRangeIter_chpl# = (_ic__F#_i_chpl_anonymousRangeIter_chpl# <= _ic__F#_high_chpl_anonymousRangeIter_chpl#),tmp_chpl_anonymousRangeIter_chpl#); tmp_chpl_anonymousRangeIter_chpl# = _ic__F#_i_chpl_anonymousRangeIter_chpl#,tmp_chpl_anonymousRangeIter_chpl# += INT64(2),_ic__F3_i_chpl_anonymousRangeIter_chpl3 = tmp_chpl_anonymousRangeIter_chpl#,tmp_chpl_anonymousRangeIter_chpl# = _ic__value_chpl_anonymousRangeIter_chpl,tmp_chpl_anonymousRangeIter_chpl# += ret_chpl_anonymousRangeIter_chpl#,_ic__value_chpl_anonymousRangeIter_chpl = tmp_chpl_anonymousRangeIter_chpl#)
 
 # coforall i in 5..5 do write(i); writeln();
-_ic__F#_high_chpl# = INT64(5);
-for (i_chpl# = INT64(5); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT64(1))
+_ic__F#_high_chpl_anonymousRangeIter_chpl# = INT64(5);
+for (i_chpl_anonymousRangeIter_chpl# = INT64(5); ((i_chpl_anonymousRangeIter_chpl# <= _ic__F#_high_chpl_anonymousRangeIter_chpl#)); i_chpl_anonymousRangeIter_chpl# += INT64(1))


### PR DESCRIPTION
* Currently,in the case when two symbols have the same name, they are
distinguished by appending an integer to the end of the symbol name. However
that does make it confusing while reading the code. The changes made here also
append the module name to the end of the generated symbols which makes the
code more readable.

Some points worth making a note:
* In case the symbols are still not unique (even after appending module name,
then we append a unique integer to the end of the symbol for disambiguation.
* Currently for field names, simply appending the module name to the end of
the field name causes some errors, which were not getting easily fixed.
However, the errors were quite similar to the one's suggested in the comments
of protectFromC function in codegen.cpp. Thus, the fix for the errors obtained
is essentially along those lines.
* There were some cases in which the function name generated did not look nice,
in which cases the module name was not appended to the end of the function

Passed std+gasnet testing
