### PR TITLE
Fix a bug with the TryStack when resolving constructor calls

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6924,7 +6924,7 @@ resolveExpr(Expr* expr) {
     }
 
     if (tryFailure) {
-      if (tryStack.tail()->parentSymbol == fn) {
+      if (tryStack.n > 0 && tryStack.tail()->parentSymbol == fn) {
         // The code in the 'true' branch of a tryToken conditional has failed
         // to resolve fully. Roll the callStack back to the function where
         // the nearest tryToken conditional is and replace the entire
@@ -6944,6 +6944,8 @@ resolveExpr(Expr* expr) {
 
         if (!block->prev)
           block->insertBefore(new CallExpr(PRIM_NOOP));
+
+        tryFailure = false;
 
         return block->prev;
       } else {


### PR DESCRIPTION
My initializers work encounter a problem with the tryStack in functionResolution
when it encountered an error in a constructor call within a constructor -
basically, the tryStack would get unrolled due to the error and return further
up the resolve chain, but because it didn't reset the flag it used to determine
whether it needed to unroll the tryStack, the earlier resolveExpr would think
it still needed to do this, but the tryStack was actually empty.  This led to
a segfault instead of a useful error message.

To fix this, I took two steps (since both seemed like more appropriate
behavior): 1) Before attempting to access the tail of the tryStack, we now
first check that there is anything in the tryStack to begin with; 2) when
we unroll the tryStack, reset the tryFailure flag to true so that the other
options can be pursued without thinking there's still an error.