### PR TITLE
New "free-while-adding (summing)" version of binary-trees

### DIFF
--- a/test/studies/shootout/binary-trees/binarytrees-freeWhileAdding.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-freeWhileAdding.chpl
@@ -1,102 +1,92 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 
-   contributed by Casey Battaglino
-   modified by Ben Harshbarger
-   modified by Brad Chamberlain
+   contributed by Casey Battaglino, Ben Harshbarger, and Brad Chamberlain
 */
 
-//
-// Use this helper module to get the dynamic iterator
-//
-use DynamicIters;
+
+use DynamicIters;            // get access to the dynamic() iterator
+
+config const n = 10;         // the maximum tree depth (if > 5)
+
+proc main() {
+  const minDepth = 4,                      // the shallowest tree
+        maxDepth = max(minDepth + 2, n),   // the deepest normal tree
+        strDepth = maxDepth + 1,           // the depth of the "stretch" tree
+        depths = minDepth..maxDepth by 2;  // the range of depths to create
+  var stats: [depths] (int,int);         // stores statistics for the trees
+
+  //
+  // Create the "stretch" tree, checksum it, print its stats, and free it.
+  //
+  const strTree = Tree.build(0, strDepth);
+  writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
+  delete strTree;
+
+  //
+  // Build the long-lived tree.
+  //
+  const llTree = Tree.build(0, maxDepth);
+
+  //
+  // Iterate over the depths in parallel, dynamically assigning them
+  // to tasks.  At each depth, create the required trees, compute
+  // their sums, and free them.
+  //
+  forall depth in dynamic(depths, chunkSize=1) {
+    const iterations = 1 << (maxDepth - depth + minDepth);
+    var sum = 0;
+			
+    for i in 1..iterations {
+      const posT = Tree.build( i, depth), 
+            negT = Tree.build(-i, depth);
+      sum += posT.sum() + negT.sum();
+      delete posT;
+      delete negT;
+    }
+    stats[depth] = (2*iterations, sum);
+  }
+
+  //
+  // Print out the stats for the trees of varying depths.
+  //
+  for depth in depths do
+    writeln(stats[depth](1), "\t trees of depth ", depth, "\t check: ",
+            stats[depth](2));
+
+  //
+  // Checksum the long-lived tree, print its stats, and free it.
+  //
+  writeln("long lived tree of depth ", maxDepth, "\t check: ", llTree.sum());
+  delete llTree;
+}
+
 
 //
-// The problem size determines the maximum depth of the trees created
-//
-config const n = 10;
-
-//
-// A simple tree class
+// A simple balanced tree node class
 //
 class Tree {
   const item: int;
   const left, right: Tree;
-}
 
-
-proc main() {
-  const minDepth = 4,                      // the shallowest tree
-        maxDepth = max(minDepth + 2, n),   // the deepest tree
-        depths = minDepth..maxDepth by 2;  // the range of depths to create
-
-  //
-  // Create the "stretch" tree, checksum it, print its stats, and free it
-  //
-  const stretchDepth = maxDepth + 1;
-  const stretchTree = buildTree(0, stretchDepth);
-  writeln("stretch tree of depth ", stretchDepth, "\t check: ", 
-          checksumAndFree(stretchTree));
-
-  //
-  // Build our long-lived tree
-  //
-  const longLivedTree = buildTree(0, maxDepth);
-
-  //
-  // Declare an array for storing stats for the trees
-  //
-  var results: [depths] 2*int;
-
-  //
-  // Iterate over the depths we're exploring, dynamically mapping out a
-  // single iteration per task at a time
-  //
-  forall depth in dynamic(depths, chunkSize=1) {
-    const iterations = 1 << (maxDepth - depth + minDepth);
-    var check = 0;
-			
-    for i in 1..iterations {
-      const posT = buildTree( i, depth), 
-            negT = buildTree(-i, depth);
-      check += checksumAndFree(posT) + checksumAndFree(negT);
-    }
-    results[depth] = (2*iterations, check);
+  proc type build(item, depth): Tree {
+    if depth <= 0 then
+      return new Tree(item);
+    else
+      return new Tree(item, Tree.build(2*item-1, depth-1),
+                            Tree.build(2*item  , depth-1));
   }
 
   //
-  // Print out the results for the trees of varying depths
+  // Add up tree node, freeing as we go
   //
-  for depth in depths do
-    writeln(results[depth](1), "\t trees of depth ", depth, "\t check: ", 
-            results[depth](2));
-
-  //
-  // Checksum the long-lived tree, print its results, and free it
-  //
-  writeln("long lived tree of depth ", maxDepth, "\t check: ",
-          checksumAndFree(longLivedTree));
-}
-
-//
-// Build a tree
-//
-proc buildTree(item, depth): Tree {
-  if depth <= 0 then
-    return new Tree(item);
-  else 
-    return new Tree(item, buildTree(2*item-1, depth-1), 
-                          buildTree(2*item  , depth-1));
-}
-
-//
-// Compute a simple checksum on a tree
-//
-proc checksumAndFree(T): int {
-  const sum = if (T.left == nil) then
-                T.item
-              else 
-                (T.item + checksumAndFree(T.left) - checksumAndFree(T.right));
-  delete T;
-  return sum;
+  proc sum(): int {
+    var sum = item;
+    if (left) {
+      sum += left.sum() - right.sum();
+      delete left;
+      delete right;
+    }
+    return sum;
+  }
 }


### PR DESCRIPTION
This version of binary trees frees while computing the sum of
the tree, but is more in-line with the binarytrees-blc version
that I submitted yesterday in terms of comments, code organization,
etc.  Put another way, diffing it against binarytrees-blc would
probably be more instructive than diffing it against the previous
version of binarytrees-freeWhileAdding.chpl...
