### PR TITLE
Bug fix for dsiMember in CSRDom

### DIFF
--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -238,8 +238,11 @@ class CSRDom: BaseSparseDom {
   }
 
   proc dsiMember(ind: rank*idxType) {
-    const (found, loc) = find(ind);
-    return found;
+    if parentDom.member(ind) {
+      const (found, loc) = find(ind);
+      return found;
+    }
+    return false;
   }
 
   proc dsiAdd(ind: rank*idxType) {


### PR DESCRIPTION
Previously the function wasn't checking if the index in parentDom, which was
causing out-of-bounds errors, instead of returning false.

Passed tests that have `use LayoutCSR;` on GASNet and default configs.