### PR TITLE
Squash pointer warnings for CCE on c_fn_ptr tests

### DIFF
--- a/test/extern/fnPtrs/COMPOPTS
+++ b/test/extern/fnPtrs/COMPOPTS
@@ -1,5 +1,15 @@
 #!/usr/bin/env python
 
+#
+# CCE is pretty strict about pointers and so complains about our
+# passing of c_fn_ptr types (which are void*'s) to C functions
+# expecting a true function pointer.  This flag squashes the warnings
+# in question for the tests in this directory.  The more robust
+# solution would be to give the programmer the ability to specify the
+# argument and return types of their c_fn_ptr()s (though we may want
+# to always preserve the current ability to be non-specific for the
+# sake of putting code together quickly/generically.
+#
 import os
 if os.getenv('CHPL_TARGET_COMPILER', '') == 'cray-prgenv-cray':
     print('--ccflags -hnomessage=167')

--- a/test/extern/fnPtrs/COMPOPTS
+++ b/test/extern/fnPtrs/COMPOPTS
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+import os
+if os.getenv('CHPL_TARGET_COMPILER', '') == 'cray-prgenv-cray':
+    print('--ccflags -hnomessage=167')


### PR DESCRIPTION
[spoon-fed to me by@ronawho]

My new 'c_fn_ptr' tests cause warnings due to assigning a 'void*'
pointer to a C function pointer.  This PR squashes the warning for
these tests for CCE.  The following simple C test demonstrates the
same warning:

        #include <stdio.h>

        void bar(void (*f)(void)) {
          f();
        }

        void foo(void) {
          printf("Hi!\n");
        }

        int main() {
          void* fptr = foo;
          bar(fptr);
        }

Note that the warning is CCE-specific and doesn't show up with gnu,
intel, or pgi.

Tests that generated the warning were:

* extern/fnPtrs/passFnsToC2x2.chpl
* extern/fnPtrs/passFnsToC2x.chpl
* extern/fnPtrs/passFnsToCChapel2.chpl
* extern/fnPtrs/passFnsToCChapel2x.chpl
* extern/fnPtrs/passFnsToCChapel.chpl
* extern/fnPtrs/storeFnsThenPass2x.chpl
* extern/fnPtrs/storeFnsThenPass.chpl

so I'm putting a COMPOPTS file into this directory to squash this
warning for these tests.

This is something we can't work around in the generated code until
such time as users can declare the argument and return types of their
external C function pointer types (and even then, we may still wish to
preserve the ability to specify a generic C function pointer like
'c_fn_ptr' for the sake of productivity).

Note that Nikhil ran into similar warnings with gnu in a different
context in PR#3992.