### PR TITLE
Revert "Remove .suppressif files for an Intel compiler issue"

### DIFF
--- a/test/io/ferguson/recordiobug.suppressif
+++ b/test/io/ferguson/recordiobug.suppressif
@@ -1,0 +1,31 @@
+# suppress recordiobug on intel compiler
+
+CHPL_TARGET_COMPILER == intel
+CHPL_TARGET_COMPILER == cray-prgenv-intel
+
+# test cases recordiobug writebinaryarray writebinaryclass writebinaryrecord writebinarytuple
+# started failing in job=correctness-test-whitebox-cray-xc / COMPILER=intel, on 2016-01-19
+
+# I think that these are Intel compiler bugs
+#
+# The bug seems related to the Intel failures we used to see
+# with writefbinary.chpl. TMac investigated them a little bit
+# but I'm having trouble figuring out exactly how it concluded.
+# I think that we just upgraded the Intel compiler and the error went
+# away.
+#
+# Here is the evidence that it is an Intel compiler bug:
+#
+# * other compilers run these tests correctly
+# * valgrind is clean with gcc, with intel it warns about
+#  reading beyond an allocated region in a strlen() call.
+#  (I do not think that is related to the bug)
+# * The problem goes away with -g
+# * The problem goes away with --ccflags -O0
+# * The problem goes away if I add a printf in readIt
+#  in the generated code
+# * The problem goes away if I put qio_channel_read_amt
+#  in the runtime library (where it can't be inlined)
+#  vs its current location in a header file
+# * The problem goes away if I remove restrict from the ptr
+#  argument to qio_channel_read_int64

--- a/test/io/ferguson/writebinaryarray.suppressif
+++ b/test/io/ferguson/writebinaryarray.suppressif
@@ -1,0 +1,6 @@
+# suppress writebinaryarray on intel compiler
+
+CHPL_TARGET_COMPILER == intel
+CHPL_TARGET_COMPILER == cray-prgenv-intel
+
+# see recordiobug for more info

--- a/test/io/ferguson/writebinaryclass.suppressif
+++ b/test/io/ferguson/writebinaryclass.suppressif
@@ -1,0 +1,6 @@
+# suppress writebinaryclass on intel compiler
+
+CHPL_TARGET_COMPILER == intel
+CHPL_TARGET_COMPILER == cray-prgenv-intel
+
+# see recordiobug for more info

--- a/test/io/ferguson/writebinaryrecord.suppressif
+++ b/test/io/ferguson/writebinaryrecord.suppressif
@@ -1,0 +1,6 @@
+# suppress writebinaryrecord on intel compiler
+
+CHPL_TARGET_COMPILER == intel
+CHPL_TARGET_COMPILER == cray-prgenv-intel
+
+# see recordiobug for more info

--- a/test/io/ferguson/writebinarytuple.suppressif
+++ b/test/io/ferguson/writebinarytuple.suppressif
@@ -1,0 +1,6 @@
+# suppress writebinarytuple on intel compiler
+
+CHPL_TARGET_COMPILER == intel
+CHPL_TARGET_COMPILER == cray-prgenv-intel
+
+# see recordiobug for more info


### PR DESCRIPTION
This reverts commit 7de7620c87a5809b87c82852126bfcfc95bc8732.

We rolled back to intel 15, which still has this bug so we need to suppress it
again.