### PR TITLE
Bug fix for bulkAdd where inds is not 0-based

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1490,15 +1490,17 @@ module ChapelArray {
   }  // record _domain
 
   // this is a helper function for bulkAdd functions in sparse subdomains.
+  // NOTE:it assumes that nnz array of the sparse domain has non-negative 
+  // indices. If, for some reason it changes, this function and bulkAdds have to
+  // be refactored. (I think it is a safe assumption at this point and keeps the
+  // function a bit cleaner than some other approach. -Engin)
   proc __getActualInsertPts(d, inds, 
       isSorted, isUnique) /* where isSparseDom(d) */ {
 
-    var numAdded = inds.size; //maybe remove this var
-
     //find individual insert points
     //and eliminate duplicates between inds and dom
-    var indivInsertPts: [{0..#numAdded}] int;
-    var actualInsertPts: [{0..#numAdded}] int; //where to put in newdom
+    var indivInsertPts: [inds.domain] int;
+    var actualInsertPts: [inds.domain] int; //where to put in newdom
 
     if !isSorted then QuickSort(inds);
 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -255,7 +255,8 @@ module DefaultSparse {
       }
     }
 
-    proc bulkAdd_help(inds: [] index(rank, idxType), isSorted=false, isUnique=false){
+    proc bulkAdd_help(inds: [?indsDom] index(rank, idxType), isSorted=false, 
+        isUnique=false){
 
       const (actualInsertPts, actualAddCnt) =
         __getActualInsertPts(this, inds, isSorted, isUnique);
@@ -271,12 +272,12 @@ module DefaultSparse {
       }
 
       //linearly fill the new colIdx from backwards
-      var newIndIdx = actualInsertPts.size-1; //index into new indices
+      var newIndIdx = indsDom.high; //index into new indices
       var oldIndIdx = oldnnz; //index into old indices
       var newLoc = actualInsertPts[newIndIdx]; //its position-to-be in new dom
       while newLoc == -1 {
         newIndIdx -= 1;
-        if newIndIdx == -1 then break; //there were duplicates -- now done
+        if newIndIdx == indsDom.low-1 then break; //there were duplicates -- now done
         newLoc = actualInsertPts[newIndIdx];
       }
 
@@ -289,17 +290,17 @@ module DefaultSparse {
           arrShiftMap[oldIndIdx] = i;
           oldIndIdx -= 1;
         }
-        else if newIndIdx >= 0 && i == newLoc {
+        else if newIndIdx >= indsDom.low && i == newLoc {
           //put the new guy in
           indices[i] = inds[newIndIdx];
           newIndIdx -= 1;
-          if newIndIdx >= 0 then 
+          if newIndIdx >= indsDom.low then 
             newLoc = actualInsertPts[newIndIdx];
           else
             newLoc = -2; //finished new set
           while newLoc == -1 {
             newIndIdx -= 1;
-            if newIndIdx == -1 then break; //there were duplicates -- now done
+            if newIndIdx == indsDom.low-1 then break; //there were duplicates -- now done
             newLoc = actualInsertPts[newIndIdx];
           }
         }

--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -303,7 +303,8 @@ class CSRDom: BaseSparseDom {
     }
   }
 
-  proc bulkAdd_help(inds: [] rank*idxType, isSorted=false, isUnique=false){
+  proc bulkAdd_help(inds: [?indsDom] rank*idxType, isSorted=false, 
+      isUnique=false){
 
     const (actualInsertPts, actualAddCnt) =
       __getActualInsertPts(this, inds, isSorted, isUnique);
@@ -319,12 +320,12 @@ class CSRDom: BaseSparseDom {
     }
 
     //linearly fill the new colIdx from backwards
-    var newIndIdx = actualInsertPts.size-1; //index into new indices
+    var newIndIdx = indsDom.high; //index into new indices
     var oldIndIdx = oldnnz; //index into old indices
     var newLoc = actualInsertPts[newIndIdx]; //its position-to-be in new dom
     while newLoc == -1 {
       newIndIdx -= 1;
-      if newIndIdx == -1 then break; //there were duplicates -- now done
+      if newIndIdx == indsDom.low-1 then break; //there were duplicates -- now done
       newLoc = actualInsertPts[newIndIdx];
     }
 
@@ -337,17 +338,17 @@ class CSRDom: BaseSparseDom {
         arrShiftMap[oldIndIdx] = i;
         oldIndIdx -= 1;
       }
-      else if newIndIdx >= 0 && i == newLoc {
+      else if newIndIdx >= indsDom.low && i == newLoc {
         //put the new guy in
         colIdx[i] = inds[newIndIdx][2];
         newIndIdx -= 1;
-        if newIndIdx >= 0 then 
+        if newIndIdx >= indsDom.low then 
           newLoc = actualInsertPts[newIndIdx];
         else
           newLoc = -2; //finished new set
         while newLoc == -1 {
           newIndIdx -= 1;
-          if newIndIdx == -1 then break; //there were duplicates -- now done
+          if newIndIdx == indsDom.low-1 then break; //there were duplicates -- now done
           newLoc = actualInsertPts[newIndIdx];
         }
       }

--- a/test/users/engin/sparse_bulk/sparseBulk2D.chpl
+++ b/test/users/engin/sparse_bulk/sparseBulk2D.chpl
@@ -41,10 +41,10 @@ for i in ParentDom.dim(1) {
 }
 
 //create diagonal indices
-var diagIndArr : [{0..#2*N}] 2*int;
+var diagIndArr : [{17..#2*N }] 2*int;
 for i in ParentDom.dim(1) {
-  diagIndArr[i*2] = (i, i);
-  diagIndArr[i*2+1] = (i, N-1-i);
+  diagIndArr[diagIndArr.domain.low+i*2] = (i, i);
+  diagIndArr[diagIndArr.domain.low+i*2+1] = (i, N-1-i);
 }
 
 SparseDom += diagIndArr;


### PR DESCRIPTION
I noticed this while working on += for SparseBulkDist. This version creates
helper arrays in a way they have the same domain as inds.

There is still room for refactoring out another helper method for shifting indices.