### PR TITLE
Extend comparator.key return-type support

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -217,20 +217,19 @@ private proc chpl_check_comparator(comparator, type eltType) {
   const data: eltType;
 
   if comparator.type == DefaultComparator {}
-  // Check for valid comaparator methods
+  // Check for valid comparator methods
   else if canResolveMethod(comparator, "compare", data, data) {
     // Check return type of compare
     type comparetype = comparator.compare(data, data).type;
-    if !(isNumericType(comparetype)) {
+    if !(isNumericType(comparetype)) then
       compilerError("The compare method must return a numeric type");
-    }
   }
   else if canResolveMethod(comparator, "key", data) {
     // Check return type of key
-    type keytype = comparator.key(data).type;
-    if !(isNumericType(keytype) || isStringType(keytype)) {
-      compilerError("The key method must return a numeric or string type");
-    }
+    const keydata = comparator.key(data);
+    type keytype = keydata.type;
+    if !(canResolve("<", keydata, keydata)) then
+      compilerError("The key method must return an object that supports the '<' function");
   }
   else {
     // If we make it this far, the passed comparator was defined incorrectly
@@ -338,7 +337,7 @@ proc bubbleSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) where 
   while (swapped) {
     swapped = false;
     for i in lo..hi-1 {
-      if chpl_compare(Data(i), Data(i+1), comparator) >= 0 {
+      if chpl_compare(Data(i), Data(i+1), comparator) > 0 {
         Data(i) <=> Data(i+1);
         swapped = true;
       }
@@ -590,7 +589,7 @@ record DefaultComparator {
    :returns: -1 if ``a < b``
 
    */
-  proc compare(a:?t, b) {
+  proc compare(a, b) {
     if a < b { return -1; }
     else if b < a { return 1; }
     else return 0;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -42,8 +42,8 @@ Key Comparator
 ~~~~~~~~~~~~~~
 
 The ``key(a)`` method accepts 1 argument, which will be an element from the
-array being sorted. The value returned should support numeric operations or be
-a string.
+array being sorted. The return type should support the ``<`` operator, since
+that is what the base ``compare`` method of all sort algorithms uses by default.
 
 The default key method would look like this:
 

--- a/test/modules/standard/Sort/comparator.chpl
+++ b/test/modules/standard/Sort/comparator.chpl
@@ -26,16 +26,25 @@ proc main() {
         compare = new compcomparator(),
         keycompare = new keycompcomparator(),
         revkey = new ReverseComparator(key),
-        revcompare = new ReverseComparator(compare);
+        revcompare = new ReverseComparator(compare),
+        tuplekey = new tuplecomparator();
 
 
   /* Test data types */
+
+  // Integers
+  sort(Arr);
+  checkSort(Arr, ArrSorted, 'sort');
 
   // Strings
   sort(StrArr);
   checkSort(StrArr, StrArrSorted, 'sort');
 
-  /* Default behavior */
+  // Integers sorted as tuples
+  sort(Arr, comparator=tuplekey);
+  checkSort(Arr, ArrSorted, 'sort');
+
+  /* Key + Compare */
 
   // key method sorts by abs(a), while compare is normal sort
   sort(Arr, comparator=keycompare);
@@ -185,3 +194,7 @@ proc keycompcomparator.key(a) { return abs(a); }
 proc keycompcomparator.compare(a, b) {
   return a - b;
 }
+
+/* Key method can return a non-numerical/string type, such as tuple */
+record tuplecomparator { }
+proc tuplecomparator.key(a) { return (a, a); }

--- a/test/modules/standard/Sort/errors-comparator.chpl
+++ b/test/modules/standard/Sort/errors-comparator.chpl
@@ -14,7 +14,7 @@ proc main() {
   var comp = new comparator();
 
   // Test fails if this compiles
-  bubbleSort(Arr, comparator=comp);
+  sort(Arr, comparator=comp);
 
 }
 

--- a/test/modules/standard/Sort/errors-comparator.good
+++ b/test/modules/standard/Sort/errors-comparator.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'bubbleSort':
+$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
 $CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The comparator record requires a 'key(a)' or 'compare(a, b)' method

--- a/test/modules/standard/Sort/errors-compare.chpl
+++ b/test/modules/standard/Sort/errors-compare.chpl
@@ -14,7 +14,7 @@ proc main() {
   var comp = new comparator();
 
   // Test fails if this compiles
-  bubbleSort(Arr, comparator=comp);
+  sort(Arr, comparator=comp);
 
 }
 

--- a/test/modules/standard/Sort/errors-compare.good
+++ b/test/modules/standard/Sort/errors-compare.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'bubbleSort':
+$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
 $CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The compare method must return a numeric type

--- a/test/modules/standard/Sort/errors-key.chpl
+++ b/test/modules/standard/Sort/errors-key.chpl
@@ -14,18 +14,11 @@ proc main() {
   var comp = new comparator();
 
   // Test fails if this compiles
-  bubbleSort(Arr, comparator=comp);
+  sort(Arr, comparator=comp);
 
 }
 
 /* Broken keys */
-
-// Returns bool
-record boolean { }
-
-proc boolean.key(a) {
-  return true;
-}
 
 // Return record 'foobar'
 record rec { }

--- a/test/modules/standard/Sort/errors-key.compopts
+++ b/test/modules/standard/Sort/errors-key.compopts
@@ -1,2 +1,1 @@
--scomparator=boolean
 -scomparator=rec

--- a/test/modules/standard/Sort/errors-key.good
+++ b/test/modules/standard/Sort/errors-key.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'bubbleSort':
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The key method must return a numeric or string type
+$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
+$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The key method must return an object that supports the '<' function


### PR DESCRIPTION
Before, `comparator.key(a)` could only return a numeric type or string, without getting a compile error. With this PR, we now support any return type that can resolve with the `<` operation, since that is all that is used in the base compare method of all sort algorithms.