### PR TITLE
Support empty .compopts files in the testing infrastructure

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1207,6 +1207,9 @@ for testname in testsrc:
             # cf. for execoptslist no warning is issued
             sys.stdout.write('[Warning: ignoring an empty compopts file %s]\n'%(test_filename+compoptssuffix))
 
+    compoptslist = compoptslist or list(' ')
+    directoryCompopts = directoryCompopts or list(' ')
+
     # Merge global compopts list with local compopts.
     # Use the "product" of the two if they are both provided.
     usecompoptslist = [ ]


### PR DESCRIPTION
The testing system didn't support empty COMPOPTS or .compopts files. If an
empty one did exist, we mistakenly skipped compilation, because there is a loop
over the compopts lists and it expected at least one value to be in there. i.e.
we do something like:

```python
compoptslist = [' ']
if compoptsfile:
    compoptslist = ReadFile(compoptsfile)
for compopts in compoptslist:
   compile (compopts)
```

and ReadFile would return an empty list if comoptsfile was empty.

It kind-of makes sense to assume that plain .compopts files shouldn't be empty,
but since we also support executable compopts, it's reasonable to expect that
the .comopts might output some compiler options under some circumstances, but
none in other cases.

This just makes sure that the compopts lists have at least one element before
iterating over them.