### PR TITLE
CSRDom.member test for recently fixed bug

### DIFF
--- a/test/sparse/engin/csrMember.chpl
+++ b/test/sparse/engin/csrMember.chpl
@@ -1,0 +1,11 @@
+use LayoutCSR;
+
+config const N = 10;
+const ParentDom = {0..#N, 0..#N};
+var SparseDom: sparse subdomain(ParentDom);
+
+const denseRow = [i in ParentDom.dim(2)] (3,i);
+SparseDom += denseRow;
+
+writeln(SparseDom.member(3, 5));
+writeln(SparseDom.member(-1,-1)); //recently resolved bug - Engin

--- a/test/sparse/engin/csrMember.good
+++ b/test/sparse/engin/csrMember.good
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
The bug was fixed by #4003. This test prevents going back to the buggy dsiMember

This was suggested by @bradcray 

PS: I will merge this next week to play safe.