### PR TITLE
Straight forward refactoring of CallExpr::codegen()

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -5961,7 +5961,7 @@ GenRet CallExpr::codegenPrimitive() {
 
       // call GLOBAL_FN_GLOBAL_TO_WIDE dummy function
       llvm::Function* fn = getGlobalToWideFn(gGenInfo->module,
-                                             &info->globalToWideInfo,
+                                             &gGenInfo->globalToWideInfo,
                                              ptr_wide_ptr_ty);
 
       INT_ASSERT(fn);

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -4352,400 +4352,9 @@ GenRet CallExpr::codegenPrimitive() {
   case PRIM_NOOP:
     break;
 
-  case PRIM_MOVE: {
-    if (get(1)->typeInfo() == dtVoid) {
-      ret = get(2)->codegen();
-      break;
-    }
-
-    if (CallExpr* call = toCallExpr(get(2))) {
-      if (call->primitive) {
-        // Assume that the RHS is a primitive we wish to handle specially
-        // until proven otherwise.
-        // If the RHS is not handled specially, we fall through and handle it
-        // generally.
-        bool handled = true;
-        switch (call->primitive->tag) {
-        case PRIM_GET_REAL:
-        case PRIM_GET_IMAG: {
-          bool isReal = call->primitive->tag == PRIM_GET_REAL;
-
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
-            // move(wide_real, prim_get_real(wide_complex));
-            // turns into: wide_real.locale = wide_complex.locale;
-            //             wide_real.addr = prim_get_real(wide_complex.addr);
-            Type*  cplxType = call->get(1)->typeInfo()->getRefType();
-
-            GenRet t1       = createTempVar(cplxType);
-            codegenAssign(t1, codegenRaddr(call->get(1)));
-
-            GenRet t2       = createTempVar(get(1)->typeInfo()->getRefType());
-            codegenAssign(t2, codegen_prim_get_real(t1, cplxType, isReal));
-
-            GenRet to_ptr   = get(1);
-            GenRet from     = codegenWideAddr(codegenRlocale(call->get(1)),
-                                              codegenDeref(t2));
-
-            if (gGenInfo->cfile) {
-              std::string stmt = codegenValue(to_ptr).c + " = ";
-
-              stmt += from.c;
-              stmt += ";\n";
-
-              gGenInfo->cStatements.push_back(stmt);
-            } else {
-#ifdef HAVE_LLVM
-              codegenStoreLLVM(from, to_ptr);
-#endif
-            }
-
-          } else {
-            codegenAssign(get(1), codegen_prim_get_real(call->get(1), call->get(1)->typeInfo(), isReal));
-          }
-
-          break;
-        }
-
-        case PRIM_DEREF: {
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
-              call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-            Type* valueType;
-
-            if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF))
-              valueType = call->get(1)->getValType();
-            else
-              valueType = call->get(1)->typeInfo()->getField("addr")->type;
-
-            INT_ASSERT(valueType == get(1)->typeInfo());
-
-            // set get(1) = *(call->get(1));
-            codegenAssign(get(1),codegenDeref(call->get(1)));
-
-          } else if (get(1)->typeInfo()->symbol->hasFlag(FLAG_STAR_TUPLE)) {
-            // star tuple handled in codegenAssign
-            // set get(1) = *(call->get(1));
-            codegenAssign(get(1),codegenDeref(call->get(1)));
-
-          } else {
-            // set get(1) = *(call->get(1));
-            codegenAssign(get(1),codegenDeref(call->get(1)));
-          }
-
-          break;
-        }
-
-        case PRIM_GET_MEMBER_VALUE: {
-          SymExpr* se = toSymExpr(call->get(2));
-
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-            INT_ASSERT(se);
-
-            if (se->var->hasFlag(FLAG_SUPER_CLASS)) {
-              // We're getting the super class pointer.
-              GenRet srcwide = call->get(1);
-              GenRet addr    = codegenCast(get(1)->typeInfo()->getField("addr")->type,
-                                           codegenRaddr(srcwide));
-              GenRet ref     =  codegenAddrOf(codegenWideAddrWithAddr(srcwide, addr));
-
-              codegenAssign(get(1), ref);
-            } else {
-              codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
-            }
-
-          } else if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
-            INT_ASSERT(se);
-
-            // codegenAssign will dereference.
-            codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
-
-          } else if (get(2)->typeInfo()->symbol->hasFlag(FLAG_STAR_TUPLE)) {
-            INT_ASSERT(se);
-
-            // codegenAssign will handle star tuple
-            codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
-
-          } else {
-            INT_ASSERT(se);
-
-            if (se->var->hasFlag(FLAG_SUPER_CLASS)) {
-              // We're getting the super class pointer.
-              GenRet ref = codegenFieldPtr(call->get(1), se);
-              // Now we have a field pointer to object->super, but
-              // the pointer to super *is* actually the value of
-              // the super class. So we just set isPtr to Value.
-              ref.isLVPtr = GEN_VAL;
-
-              codegenAssign(get(1), ref);
-
-            } else {
-              codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
-            }
-          }
-
-          break;
-        }
-
-        case PRIM_GET_MEMBER: {
-          /* Get a pointer to a member */
-          SymExpr* se = toSymExpr(call->get(2));
-
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-              call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)   ||
-              get(2)->typeInfo()->symbol->hasFlag(FLAG_STAR_TUPLE)) {
-
-            codegenAssign(get(1), codegenAddrOf(codegenFieldPtr(call->get(1), se)));
-
-          }  else if (get(1)->getValType() != call->get(2)->typeInfo()) {
-            // get a narrow reference to the actual 'addr' field of the wide pointer
-            GenRet getField = codegenFieldPtr(call->get(1), se);
-
-            codegenAssign(get(1), codegenAddrOf(codegenWideThingField(getField, WIDE_GEP_ADDR)));
-
-          } else {
-            handled = false;
-          }
-
-          break;
-        }
-
-        case PRIM_GET_SVEC_MEMBER: {
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
-            /* Get a pointer to the i'th element of a homogeneous tuple */
-            GenRet elemPtr = codegenElementPtr(call->get(1),codegenExprMinusOne(call->get(2)));
-
-            INT_ASSERT( elemPtr.isLVPtr == GEN_WIDE_PTR );
-
-            elemPtr = codegenAddrOf(elemPtr);
-
-            codegenAssign(get(1), elemPtr);
-
-          } else if (get(1)->getValType() != call->getValType()) {
-            GenRet getElem = codegenElementPtr(call->get(1), codegenExprMinusOne(call->get(2)));
-
-            codegenAssign(get(1), codegenAddrOf(codegenWideThingField(getElem, WIDE_GEP_ADDR)));
-
-          } else {
-            handled = false;
-          }
-
-          break;
-        }
-
-        case PRIM_GET_SVEC_MEMBER_VALUE: {
-          /* Get the i'th value from a homogeneous tuple */
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
-            // codegenElementPtr/codegenAssign handle wide pointers
-            codegenAssign(get(1),
-                          codegenElementPtr(call->get(1),
-                                            codegenExprMinusOne(call->get(2))));
-
-          } else {
-            codegenAssign(get(1),
-                          codegenElementPtr(call->get(1),
-                                            codegenExprMinusOne(call->get(2))));
-          }
-
-          break;
-        }
-
-        case PRIM_ARRAY_GET: {
-          /* Get a pointer to the i'th array element */
-          // ('_array_get' array idx)
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-            codegenAssign(get(1),
-                          codegenAddrOf(codegenElementPtr(call->get(1), call->get(2))));
-
-          } else if( get(1)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS)) {
-            // resulting reference is wide, but the array is local.
-            // This can happen with c_ptr for extern integration...
-            codegenAssign(get(1),
-                          codegenAddrOf(codegenWideHere(codegenAddrOf(codegenElementPtr(call->get(1), call->get(2))))));
-
-          } else {
-            codegenAssign(get(1),
-                          codegenAddrOf(codegenElementPtr(call->get(1), call->get(2))));
-          }
-
-          break;
-        }
-
-        case PRIM_ARRAY_GET_VALUE: {
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-            codegenAssign(get(1),
-                          codegenElementPtr(call->get(1), call->get(2)));
-          } else {
-            codegenAssign(get(1),
-                          codegenElementPtr(call->get(1), call->get(2)));
-          }
-
-          break;
-        }
-
-        case PRIM_GET_UNION_ID: {
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
-            codegenAssign(get(1), codegenFieldUidPtr(call->get(1)));
-
-          } else {
-            handled = false;
-          }
-
-          break;
-        }
-
-        case PRIM_TESTCID: {
-          // set get(1) to
-          //   call->get(1)->chpl_class_id == chpl__cid_"call->get(2)"
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-            GenRet tmp = codegenFieldCidPtr(call->get(1));
-            codegenAssign(
-                          get(1),
-                          codegenEquals(tmp, codegenUseCid(call->get(2)->typeInfo())));
-
-          } else {
-            handled = false;
-          }
-
-          break;
-        }
-
-        case PRIM_GETCID: {
-          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-            GenRet tmp = codegenFieldCidPtr(call->get(1));
-
-            codegenAssign(get(1), tmp);
-
-          } else {
-            handled = false;
-          }
-
-          break;
-        }
-
-        case PRIM_CAST: {
-          if (call->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
-              call->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
-            GenRet tmp = call->get(2);
-
-            tmp = codegenWideAddrWithAddr(tmp,
-                                          codegenCast(call->get(1)->typeInfo(),
-                                                      codegenRaddr(tmp)));
-            codegenAssign(get(1), codegenAddrOf(tmp));
-
-          } else {
-            handled = false;
-          }
-
-          break;
-        }
-
-        case PRIM_DYNAMIC_CAST: {
-          if (call->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-            Type*  type         = call->typeInfo()->getField("addr")->type;
-            GenRet wideFrom     = codegenValue(call->get(2));
-            GenRet wideFromAddr = codegenRaddr(wideFrom);
-            GenRet value        = codegenValue(codegenFieldCidPtr(wideFrom));
-            GenRet ok           = codegenDynamicCastCheck(value, type);
-            GenRet cast         = codegenCast(type, wideFromAddr);
-            GenRet nul          = codegenCast(type, codegenNullPointer());
-            GenRet addr         = codegenTernary(ok, cast, nul);
-            GenRet wide         = codegenAddrOf(codegenWideAddrWithAddr(wideFrom, addr, call->typeInfo()));
-
-            codegenAssign(get(1), wide);
-
-          } else {
-            handled = false;
-          }
-
-          break;
-        }
-
-        case PRIM_GET_PRIV_CLASS: {
-          GenRet r = codegenCallExpr("chpl_getPrivatizedClass", call->get(2));
-
-          if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-            r = codegenAddrOf(codegenWideHere(r, get(1)->typeInfo()));
-          }
-
-          codegenAssign(get(1), r);
-          break;
-        }
-
-        case PRIM_ON_LOCALE_NUM: {
-          // This primitive expects an argument of type chpl_localeID_t.
-          INT_ASSERT(call->get(1)->typeInfo() == dtLocaleID);
-          codegenAssign(get(1), call->get(1));
-          break;
-        }
-
-        default:
-          // OK, we did not handle the RHS as a special case.
-          handled = false;
-          break;
-        }
-        // If the RHS was handled as a special case above, the entire PRIM_MOVE has
-        // been codegenned, so we can skip the general cases appearing below.
-        if (handled)
-          break;
-      }
-    } // End of special-case handling for primitives in the RHS of MOVE.
-
-    // Handle general cases of PRIM_MOVE.
-    if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) == true &&
-        get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) == false) {
-      codegenAssign(get(1), codegenAddrOf(codegenWideHere(get(2))));
-
-      break;
-    }
-
-    if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) == true &&
-        get(2)->typeInfo()->symbol->hasFlag(FLAG_REF)      == true) {
-      codegenAssign(get(1), codegenAddrOf(codegenWideHere(get(2))));
-      break;
-    }
-
-    if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) == true  &&
-        get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) == false &&
-        get(2)->typeInfo()->symbol->hasFlag(FLAG_REF)      == false) {
-      GenRet to_ptr = codegenDeref(get(1));
-
-      codegenAssign(to_ptr, get(2));
-
-      break;
-    }
-
-    if (get(1)->typeInfo()->symbol->hasFlag(FLAG_REF) &&
-        get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
-      if (get(1)->getValType() != get(2)->getValType()) {
-        // ref_T = wide_ref_wide_T
-        GenRet narrowRef   = codegenRaddr(get(2));
-        GenRet wideThing   = codegenDeref(narrowRef);
-        GenRet narrowThing = codegenWideThingField(wideThing, WIDE_GEP_ADDR);
-
-        codegenAssign(get(1), codegenAddrOf(narrowThing));
-      } else {
-        // get(1) = Raddr(get(2));
-        codegenAssign(get(1), codegenRaddr(get(2)));
-      }
-      break;
-    }
-
-    if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) == false &&
-        get(1)->typeInfo()->symbol->hasFlag(FLAG_REF)        == false &&
-        get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) == true) {
-      // get(1) = Raddr(get(2));
-      codegenAssign(get(1), codegenRaddr(get(2)));
-      break;
-    }
-
-    if (get(1)->typeInfo()->symbol->hasFlag(FLAG_REF) &&
-        !get(2)->typeInfo()->symbol->hasFlag(FLAG_REF))
-      codegenAssign(codegenDeref(get(1)), get(2));
-
-    else
-      codegenAssign(get(1), get(2));
-
+  case PRIM_MOVE:
+    ret = codegenPrimMove();
     break;
-  } // End of PRIM_MOVE
 
   // We list the special cases handled in the PRIM_MOVE switch above, so we don't
   // trigger the "should these still be in the AST?" error.
@@ -6220,6 +5829,391 @@ GenRet CallExpr::codegenPrimitive() {
       getStmtExpr() == this &&
       ret.c.length() > 0)
     gGenInfo->cStatements.push_back(ret.c + ";\n");
+
+  return ret;
+}
+
+GenRet CallExpr::codegenPrimMove() {
+  GenRet ret;
+
+  if (get(1)->typeInfo() == dtVoid) {
+    ret = get(2)->codegen();
+
+  } else {
+    if (CallExpr* call = toCallExpr(get(2))) {
+      if (call->primitive) {
+        // Assume that the RHS is a primitive we wish to handle specially
+        // until proven otherwise.
+        // If the RHS is not handled specially, we fall through and handle it
+        // generally.
+        bool handled = true;
+
+        switch (call->primitive->tag) {
+        case PRIM_GET_REAL:
+        case PRIM_GET_IMAG: {
+          bool isReal = call->primitive->tag == PRIM_GET_REAL;
+
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
+            // move(wide_real, prim_get_real(wide_complex));
+            // turns into: wide_real.locale = wide_complex.locale;
+            //             wide_real.addr = prim_get_real(wide_complex.addr);
+            Type*  cplxType = call->get(1)->typeInfo()->getRefType();
+
+            GenRet t1       = createTempVar(cplxType);
+            codegenAssign(t1, codegenRaddr(call->get(1)));
+
+            GenRet t2       = createTempVar(get(1)->typeInfo()->getRefType());
+            codegenAssign(t2, codegen_prim_get_real(t1, cplxType, isReal));
+
+            GenRet to_ptr   = get(1);
+            GenRet from     = codegenWideAddr(codegenRlocale(call->get(1)),
+                                              codegenDeref(t2));
+
+            if (gGenInfo->cfile) {
+              std::string stmt = codegenValue(to_ptr).c + " = ";
+
+              stmt += from.c;
+              stmt += ";\n";
+
+              gGenInfo->cStatements.push_back(stmt);
+            } else {
+#ifdef HAVE_LLVM
+              codegenStoreLLVM(from, to_ptr);
+#endif
+            }
+
+          } else {
+            codegenAssign(get(1), codegen_prim_get_real(call->get(1), call->get(1)->typeInfo(), isReal));
+          }
+
+          break;
+        }
+
+        case PRIM_DEREF: {
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) ||
+              call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+            Type* valueType;
+
+            if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF))
+              valueType = call->get(1)->getValType();
+            else
+              valueType = call->get(1)->typeInfo()->getField("addr")->type;
+
+            INT_ASSERT(valueType == get(1)->typeInfo());
+
+            // set get(1) = *(call->get(1));
+            codegenAssign(get(1),codegenDeref(call->get(1)));
+
+          } else if (get(1)->typeInfo()->symbol->hasFlag(FLAG_STAR_TUPLE)) {
+            // star tuple handled in codegenAssign
+            // set get(1) = *(call->get(1));
+            codegenAssign(get(1),codegenDeref(call->get(1)));
+
+          } else {
+            // set get(1) = *(call->get(1));
+            codegenAssign(get(1),codegenDeref(call->get(1)));
+          }
+
+          break;
+        }
+
+        case PRIM_GET_MEMBER_VALUE: {
+          SymExpr* se = toSymExpr(call->get(2));
+
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+            INT_ASSERT(se);
+
+            if (se->var->hasFlag(FLAG_SUPER_CLASS)) {
+              // We're getting the super class pointer.
+              GenRet srcwide = call->get(1);
+              GenRet addr    = codegenCast(get(1)->typeInfo()->getField("addr")->type,
+                                           codegenRaddr(srcwide));
+              GenRet ref     =  codegenAddrOf(codegenWideAddrWithAddr(srcwide, addr));
+
+              codegenAssign(get(1), ref);
+            } else {
+              codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
+            }
+
+          } else if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
+            INT_ASSERT(se);
+
+            // codegenAssign will dereference.
+            codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
+
+          } else if (get(2)->typeInfo()->symbol->hasFlag(FLAG_STAR_TUPLE)) {
+            INT_ASSERT(se);
+
+            // codegenAssign will handle star tuple
+            codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
+
+          } else {
+            INT_ASSERT(se);
+
+            if (se->var->hasFlag(FLAG_SUPER_CLASS)) {
+              // We're getting the super class pointer.
+              GenRet ref = codegenFieldPtr(call->get(1), se);
+              // Now we have a field pointer to object->super, but
+              // the pointer to super *is* actually the value of
+              // the super class. So we just set isPtr to Value.
+              ref.isLVPtr = GEN_VAL;
+
+              codegenAssign(get(1), ref);
+
+            } else {
+              codegenAssign(get(1), codegenFieldPtr(call->get(1), se));
+            }
+          }
+
+          break;
+        }
+
+        case PRIM_GET_MEMBER: {
+          /* Get a pointer to a member */
+          SymExpr* se = toSymExpr(call->get(2));
+
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
+              call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)   ||
+              get(2)->typeInfo()->symbol->hasFlag(FLAG_STAR_TUPLE)) {
+
+            codegenAssign(get(1), codegenAddrOf(codegenFieldPtr(call->get(1), se)));
+
+          }  else if (get(1)->getValType() != call->get(2)->typeInfo()) {
+            // get a narrow reference to the actual 'addr' field of the wide pointer
+            GenRet getField = codegenFieldPtr(call->get(1), se);
+
+            codegenAssign(get(1), codegenAddrOf(codegenWideThingField(getField, WIDE_GEP_ADDR)));
+
+          } else {
+            handled = false;
+          }
+
+          break;
+        }
+
+        case PRIM_GET_SVEC_MEMBER: {
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
+            /* Get a pointer to the i'th element of a homogeneous tuple */
+            GenRet elemPtr = codegenElementPtr(call->get(1),codegenExprMinusOne(call->get(2)));
+
+            INT_ASSERT( elemPtr.isLVPtr == GEN_WIDE_PTR );
+
+            elemPtr = codegenAddrOf(elemPtr);
+
+            codegenAssign(get(1), elemPtr);
+
+          } else if (get(1)->getValType() != call->getValType()) {
+            GenRet getElem = codegenElementPtr(call->get(1), codegenExprMinusOne(call->get(2)));
+
+            codegenAssign(get(1), codegenAddrOf(codegenWideThingField(getElem, WIDE_GEP_ADDR)));
+
+          } else {
+            handled = false;
+          }
+
+          break;
+        }
+
+        case PRIM_GET_SVEC_MEMBER_VALUE: {
+          /* Get the i'th value from a homogeneous tuple */
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
+            // codegenElementPtr/codegenAssign handle wide pointers
+            codegenAssign(get(1),
+                          codegenElementPtr(call->get(1),
+                                            codegenExprMinusOne(call->get(2))));
+
+          } else {
+            codegenAssign(get(1),
+                          codegenElementPtr(call->get(1),
+                                            codegenExprMinusOne(call->get(2))));
+          }
+
+          break;
+        }
+
+        case PRIM_ARRAY_GET: {
+          /* Get a pointer to the i'th array element */
+          // ('_array_get' array idx)
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+            codegenAssign(get(1),
+                          codegenAddrOf(codegenElementPtr(call->get(1), call->get(2))));
+
+          } else if( get(1)->typeInfo()->symbol->hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS)) {
+            // resulting reference is wide, but the array is local.
+            // This can happen with c_ptr for extern integration...
+            codegenAssign(get(1),
+                          codegenAddrOf(codegenWideHere(codegenAddrOf(codegenElementPtr(call->get(1), call->get(2))))));
+
+          } else {
+            codegenAssign(get(1),
+                          codegenAddrOf(codegenElementPtr(call->get(1), call->get(2))));
+          }
+
+          break;
+        }
+
+        case PRIM_ARRAY_GET_VALUE: {
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+            codegenAssign(get(1),
+                          codegenElementPtr(call->get(1), call->get(2)));
+          } else {
+            codegenAssign(get(1),
+                          codegenElementPtr(call->get(1), call->get(2)));
+          }
+
+          break;
+        }
+
+        case PRIM_GET_UNION_ID: {
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
+            codegenAssign(get(1), codegenFieldUidPtr(call->get(1)));
+
+          } else {
+            handled = false;
+          }
+
+          break;
+        }
+
+        case PRIM_TESTCID: {
+          // set get(1) to
+          //   call->get(1)->chpl_class_id == chpl__cid_"call->get(2)"
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+            GenRet tmp = codegenFieldCidPtr(call->get(1));
+            codegenAssign(
+                          get(1),
+                          codegenEquals(tmp, codegenUseCid(call->get(2)->typeInfo())));
+
+          } else {
+            handled = false;
+          }
+
+          break;
+        }
+
+        case PRIM_GETCID: {
+          if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+            GenRet tmp = codegenFieldCidPtr(call->get(1));
+
+            codegenAssign(get(1), tmp);
+
+          } else {
+            handled = false;
+          }
+
+          break;
+        }
+
+        case PRIM_CAST: {
+          if (call->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
+              call->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
+            GenRet tmp = call->get(2);
+
+            tmp = codegenWideAddrWithAddr(tmp,
+                                          codegenCast(call->get(1)->typeInfo(),
+                                                      codegenRaddr(tmp)));
+            codegenAssign(get(1), codegenAddrOf(tmp));
+
+          } else {
+            handled = false;
+          }
+
+          break;
+        }
+
+        case PRIM_DYNAMIC_CAST: {
+          if (call->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+            Type*  type         = call->typeInfo()->getField("addr")->type;
+            GenRet wideFrom     = codegenValue(call->get(2));
+            GenRet wideFromAddr = codegenRaddr(wideFrom);
+            GenRet value        = codegenValue(codegenFieldCidPtr(wideFrom));
+            GenRet ok           = codegenDynamicCastCheck(value, type);
+            GenRet cast         = codegenCast(type, wideFromAddr);
+            GenRet nul          = codegenCast(type, codegenNullPointer());
+            GenRet addr         = codegenTernary(ok, cast, nul);
+            GenRet wide         = codegenAddrOf(codegenWideAddrWithAddr(wideFrom, addr, call->typeInfo()));
+
+            codegenAssign(get(1), wide);
+
+          } else {
+            handled = false;
+          }
+
+          break;
+        }
+
+        case PRIM_GET_PRIV_CLASS: {
+          GenRet r = codegenCallExpr("chpl_getPrivatizedClass", call->get(2));
+
+          if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+            r = codegenAddrOf(codegenWideHere(r, get(1)->typeInfo()));
+          }
+
+          codegenAssign(get(1), r);
+          break;
+        }
+
+        case PRIM_ON_LOCALE_NUM: {
+          // This primitive expects an argument of type chpl_localeID_t.
+          INT_ASSERT(call->get(1)->typeInfo() == dtLocaleID);
+          codegenAssign(get(1), call->get(1));
+          break;
+        }
+
+        default:
+          // OK, we did not handle the RHS as a special case.
+          handled = false;
+          break;
+        }
+
+        // If the RHS was handled as a special case above, the entire PRIM_MOVE has
+        // been codegenned, so we can skip the general cases appearing below.
+        if (handled)
+          return ret;
+      }
+    } // End of special-case handling for primitives in the RHS of MOVE.
+
+    // Handle general cases of PRIM_MOVE.
+    if (       get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) == true  &&
+               get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) == false) {
+      codegenAssign(get(1), codegenAddrOf(codegenWideHere(get(2))));
+
+    } else if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)   == true  &&
+               get(2)->typeInfo()->symbol->hasFlag(FLAG_REF)        == true) {
+      codegenAssign(get(1), codegenAddrOf(codegenWideHere(get(2))));
+
+    } else if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)   == true  &&
+               get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)   == false &&
+               get(2)->typeInfo()->symbol->hasFlag(FLAG_REF)        == false) {
+      GenRet to_ptr = codegenDeref(get(1));
+
+      codegenAssign(to_ptr, get(2));
+
+    } else if (get(1)->typeInfo()->symbol->hasFlag(FLAG_REF)        == true  &&
+               get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)   == true)  {
+      if (get(1)->getValType() != get(2)->getValType()) {
+        GenRet narrowRef   = codegenRaddr(get(2));
+        GenRet wideThing   = codegenDeref(narrowRef);
+        GenRet narrowThing = codegenWideThingField(wideThing, WIDE_GEP_ADDR);
+
+        codegenAssign(get(1), codegenAddrOf(narrowThing));
+      } else {
+        codegenAssign(get(1), codegenRaddr(get(2)));
+      }
+
+    } else if (get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) == false &&
+               get(1)->typeInfo()->symbol->hasFlag(FLAG_REF)        == false &&
+               get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) == true)  {
+      codegenAssign(get(1), codegenRaddr(get(2)));
+
+    } else if (get(1)->typeInfo()->symbol->hasFlag(FLAG_REF)        == true  &&
+               get(2)->typeInfo()->symbol->hasFlag(FLAG_REF)        == false) {
+      codegenAssign(codegenDeref(get(1)), get(2));
+
+    } else {
+      codegenAssign(get(1), get(2));
+    }
+  }
 
   return ret;
 }

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -248,6 +248,8 @@ public:
 private:
   GenRet          codegenPrimitive();
   GenRet          codegenPrimMove();
+  bool            codegenPrimMoveSpecial();
+
   GenRet          codegenBasicPrimitiveExpr()                            const;
 };
 

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -246,6 +246,7 @@ public:
 
 
 private:
+  GenRet          codegenPrimitive();
   GenRet          codegenBasicPrimitiveExpr()                            const;
 };
 

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -165,31 +165,50 @@ class UnresolvedSymExpr : public Expr {
 // ContextCallExpr. Therefore, it is important to use toCallExpr()
 // instead of casting to CallExpr* directly.
 class CallExpr : public Expr {
- public:
-  Expr* baseExpr;         // function expression
-  AList argList;          // function actuals
-  PrimitiveOp* primitive; // primitive expression (baseExpr == NULL)
+public:
+  PrimitiveOp* primitive;        // primitive expression (baseExpr == NULL)
+  Expr*        baseExpr;         // function expression
 
-  bool partialTag;
-  bool methodTag; ///< Set to true if the call is a method call.
-  // It is used in gatherCandidates to filter out method field extraction
-  // (partials).
-  // TODO: Maybe use a new primitive to represent partials, and get rid of this tag.
-  bool square; // true if call made with square brackets
+  AList        argList;          // function actuals
 
-  CallExpr(BaseAST* base, BaseAST* arg1 = NULL, BaseAST* arg2 = NULL,
-           BaseAST* arg3 = NULL, BaseAST* arg4 = NULL, BaseAST* arg5 = NULL);
-  CallExpr(PrimitiveOp *prim, BaseAST* arg1 = NULL, BaseAST* arg2 = NULL,
-           BaseAST* arg3 = NULL, BaseAST* arg4 = NULL, BaseAST* arg5 = NULL);
-  CallExpr(PrimitiveTag prim, BaseAST* arg1 = NULL, BaseAST* arg2 = NULL,
-           BaseAST* arg3 = NULL, BaseAST* arg4 = NULL, BaseAST* arg5 = NULL);
-  CallExpr(const char* name, BaseAST* arg1 = NULL, BaseAST* arg2 = NULL,
-           BaseAST* arg3 = NULL, BaseAST* arg4 = NULL, BaseAST* arg5 = NULL);
+  bool         partialTag;
+  bool         methodTag;        // Set to true if the call is a method call.
+  bool         square;           // true if call made with square brackets
+
+  CallExpr(BaseAST*     base,
+           BaseAST*     arg1 = NULL,
+           BaseAST*     arg2 = NULL,
+           BaseAST*     arg3 = NULL,
+           BaseAST*     arg4 = NULL,
+           BaseAST*     arg5 = NULL);
+
+  CallExpr(PrimitiveOp* prim,
+           BaseAST*     arg1 = NULL,
+           BaseAST*     arg2 = NULL,
+           BaseAST*     arg3 = NULL,
+           BaseAST*     arg4 = NULL,
+           BaseAST*     arg5 = NULL);
+
+  CallExpr(PrimitiveTag prim,
+           BaseAST*     arg1 = NULL,
+           BaseAST*     arg2 = NULL,
+           BaseAST*     arg3 = NULL,
+           BaseAST*     arg4 = NULL,
+           BaseAST*     arg5 = NULL);
+
+  CallExpr(const char*  name,
+           BaseAST*     arg1 = NULL,
+           BaseAST*     arg2 = NULL,
+           BaseAST*     arg3 = NULL,
+           BaseAST*     arg4 = NULL,
+           BaseAST*     arg5 = NULL);
+
   ~CallExpr();
 
   virtual void    verify();
 
   DECLARE_COPY(CallExpr);
+
 
   virtual void    accept(AstVisitor* visitor);
 
@@ -210,6 +229,10 @@ class CallExpr : public Expr {
   // True if the callExpr has been emptied (aka dead)
   bool            isEmpty()                                              const;
 
+  bool            isPrimitive()                                          const;
+  bool            isPrimitive(PrimitiveTag primitiveTag)                 const;
+  bool            isPrimitive(const char*  primitiveName)                const;
+
   FnSymbol*       isResolved()                                           const;
   FnSymbol*       resolvedFunction()                                     const;
 
@@ -220,10 +243,6 @@ class CallExpr : public Expr {
   int             numActuals()                                           const;
   Expr*           get(int index)                                         const;
   FnSymbol*       findFnSymbol();
-
-  bool            isPrimitive()                                          const;
-  bool            isPrimitive(PrimitiveTag primitiveTag)                 const;
-  bool            isPrimitive(const char*  primitiveName)                const;
 };
 
 // For storing several call expressions, where

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -250,6 +250,9 @@ private:
   GenRet          codegenPrimMove();
   bool            codegenPrimMoveSpecial();
 
+  void            codegenInvokeOnFun();
+  void            codegenInvokeTaskFun(const char* name);
+
   GenRet          codegenBasicPrimitiveExpr()                            const;
 };
 

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -254,6 +254,8 @@ private:
   void            codegenInvokeTaskFun(const char* name);
 
   GenRet          codegenBasicPrimitiveExpr()                            const;
+
+  bool            isExternStarTuple(Symbol* formal, Expr* actual)        const;
 };
 
 // For storing several call expressions, where

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -248,14 +248,14 @@ public:
 private:
   GenRet          codegenPrimitive();
   GenRet          codegenPrimMove();
-  bool            codegenPrimMoveSpecial();
+  bool            codegenPrimMoveRhsIsSpecialPrimop();
 
   void            codegenInvokeOnFun();
   void            codegenInvokeTaskFun(const char* name);
 
   GenRet          codegenBasicPrimitiveExpr()                            const;
 
-  bool            isExternStarTuple(Symbol* formal, Expr* actual)        const;
+  bool            isRefExternStarTuple(Symbol* formal, Expr* actual)     const;
 };
 
 // For storing several call expressions, where

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -243,6 +243,10 @@ public:
   int             numActuals()                                           const;
   Expr*           get(int index)                                         const;
   FnSymbol*       findFnSymbol();
+
+
+private:
+  GenRet          codegenBasicPrimitiveExpr()                            const;
 };
 
 // For storing several call expressions, where

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -247,6 +247,7 @@ public:
 
 private:
   GenRet          codegenPrimitive();
+  GenRet          codegenPrimMove();
   GenRet          codegenBasicPrimitiveExpr()                            const;
 };
 


### PR DESCRIPTION
CallExpr::codegen() is nearly 1800 lines of code.  Although this code is
dominated by 2 large switch statements (a large one inside a very large
one) it also includes some slightly convoluted control flow.  This control
flow is hard to recognize in the context of the switch statements.

This refactoring extracts this code in to a small number of functions each
of which has very simple control flow.  There is no change in functionality.
Also made some trivial "whitespace" changes to fit in 80 columns etc.

This work is captured in 8 passes with a commit per pass.  It is likely
unreasonably to follow each commit in detail but it is hoped that this
will expose the essence of each transformation.

Compiled with/without CHPL_DEVELOPER on clang/darwin,
gnu/linux64, and gnu/linux64 with CHPL_LLVM=llvm.

Passes
1) std-linux64
2) gasnet-linux64
3) baseline-linux64
4) llvm-linux64

The latter test has 7 failures but it is my understanding that this is
true for master.  I believe the first 6 are "trivial" and that this last
one is a known issue.

chap01> more Logs/mnoakes.linux64.log.summary 
[Test Summary - 160612.173815]
[Error matching compiler output for compflags/albrecht/chplenv/chplenv]
[Error matching compiler output for compflags/ferguson/ccflags-order]
[Error matching compiler output for link/sungeun/static_dynamic (compopts: 1)]
[Error matching compiler output for link/sungeun/static_dynamic (compopts: 2)]
[Error matching compiler output for link/sungeun/static_dynamic (compopts: 3)]
[Error matching compiler output for runtime/sungeun/chpl-env-gen]
[Error matching compiler output for trivial/bradc/savecInNonWriteableDir]
[Summary: #Successes = 6298 | #Failures = 7 | #Futures = 0]
