### PR TITLE
Fix assorted typos

### DIFF
--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -360,7 +360,7 @@ module LocaleModel {
   //
   // returns true if an executeOn can be handled directly
   // by running the function in question.
-  // Applieds to execute on and execute on fast.
+  // Applies to execute on and execute on fast.
   // When performing a blocking on, the compiler will emit this sequence:
   //
   //  if (chpl_doDirectExecuteOn(targetLocale))

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -442,7 +442,7 @@ module LocaleModel {
   //
   // returns true if an executeOn can be handled directly
   // by running the function in question.
-  // Applieds to execute on and execute on fast.
+  // Applies to execute on and execute on fast.
   // When performing a blocking on, the compiler will emit this sequence:
   //
   //  if (chpl_doDirectExecuteOn(targetLocale))

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -131,7 +131,7 @@ reverse the default sorting order.
   var Array = [-1, -4, 2, 3];
 
   // Using module-defined 'reverseComparator'
-  sort(Array, comprator=reverseComparator)
+  sort(Array, comparator=reverseComparator)
 
   // This will output: 3, 2, -1, -4
   writeln(Array);

--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -475,7 +475,7 @@ where tag == iterKind.leader
             const zeroBasedIters2:rType=adaptSplit(localWork[victim], factorSteal, moreLocalWork[victim], locks[victim]);
             if zeroBasedIters2.length !=0 then {
               if debugDynamicIters then 
-                writeln("Range stealed at victim ", victim," yielded as ", zeroBasedIters2," by tid ", tid);
+                writeln("Range stolen at victim ", victim," yielded as ", zeroBasedIters2," by tid ", tid);
               yield (zeroBasedIters2,);
             }
           } else {
@@ -488,7 +488,7 @@ where tag == iterKind.leader
                                           //after splitting from a victim range
             if zeroBasedIters2.length !=0 then {
               if debugDynamicIters then 
-                writeln("Range stealed at victim ", victim," yielded as ", zeroBasedIters2," by tid ", tid);
+                writeln("Range stolen at victim ", victim," yielded as ", zeroBasedIters2," by tid ", tid);
               yield (zeroBasedIters2,);
             }
           }

--- a/runtime/include/atomics/README
+++ b/runtime/include/atomics/README
@@ -45,7 +45,7 @@ Memory Orderings:
    } memory_order;
 
    // release, acq_rel, seq_cst store performs a release on affected memory.
-   // acquire, acq_rel, seq_cst load operation performs aquire on affected memory.
+   // acquire, acq_rel, seq_cst load operation performs acquire on affected memory.
    // consume a load operation performs a consume on affected memory
    // seq_cst is 'sequentially consistent'
    // At present our implementations are really the same regardless of the memory order

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -138,7 +138,7 @@ void chpl_comm_desired_shared_heap(void** start_p, size_t* size_p) {
 
 void chpl_comm_broadcast_global_vars(int numGlobals) { }
 
-void chpl_comm_broadcast_private(int id, size_t sizee, int32_t tid) { }
+void chpl_comm_broadcast_private(int id, size_t size, int32_t tid) { }
 
 void chpl_comm_barrier(const char *msg) { }
 

--- a/runtime/src/qio/qio_popen.c
+++ b/runtime/src/qio/qio_popen.c
@@ -353,7 +353,7 @@ qioerr qio_openproc(const char** argv,
                     int64_t *pid_out)
 {
   // runs qio_do_openproc in a pthread in order
-  // to avoid issuse where a Chapel task is allocated
+  // to avoid issues where a Chapel task is allocated
   // from memory with MAP_SHARED.
   //
   // If such a thread is the thread running fork(),


### PR DESCRIPTION
The message in DynamicIters.chpl does not appear in any .good or .bad files.

chpl_comm_broadcast_private's second argument is elsewhere named "size", and nowhere else named "sizee".