### PR TITLE
test/release/examples/primers: fix typos

### DIFF
--- a/test/release/examples/primers/README
+++ b/test/release/examples/primers/README
@@ -35,4 +35,4 @@ demonstrate Chapel feature areas in detail.
      varargs.chpl                : Variable argument procedures
      variables.chpl              : Variables, constants, and parameters
 
-     chplvis                     : A directory contaning a primer on the chplvis tool
+     chplvis                     : A directory containing a primer on the chplvis tool

--- a/test/release/examples/primers/arrays.chpl
+++ b/test/release/examples/primers/arrays.chpl
@@ -135,7 +135,7 @@ writeln("After calling printArr, B is:\n", B, "\n");
 // of storing distributed arrays across multiple similar array
 // variables.
 //
-// The following domain declaration defines a 2D arithemetic domain
+// The following domain declaration defines a 2D arithmetic domain
 // called ProbSpace which is the same size and shape as B was above.
 //
 

--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -348,7 +348,7 @@ writeln();
 
 //
 // The following example creates a dimensional distribution that
-// replicates over 2 locales (when available) in the first dimemsion
+// replicates over 2 locales (when available) in the first dimension
 // and distributes using block-cyclic distribution in the second dimension.
 // The example computes nl1 and nl2 and reshapes MyLocales correspondingly.
 //

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -178,7 +178,7 @@ if example == 0 || example == 3 {
   // First, open up a file and write to it.
   {
     var f = open(testfile, iomode.cwr);
-    /* When we create the writer, suppling locking=false will do unlocked I/O.
+    /* When we create the writer, supplying locking=false will do unlocked I/O.
        That's fine as long as the channel is not shared between tasks.
       */
     var w = f.writer(kind=ionative, locking=false);
@@ -202,7 +202,7 @@ if example == 0 || example == 3 {
 
     // Note -- this could be a forall loop to do I/O in parallel!
     forall i in 0..#num by -1 {
-      /* When we create the reader, suppling locking=false will do unlocked I/O.
+      /* When we create the reader, supplying locking=false will do unlocked I/O.
          That's fine as long as the channel is not shared between tasks;
          here it's just used as a local variable, so we are O.K. 
         */
@@ -280,7 +280,7 @@ if example == 0 || example == 5 {
   unlink(testfile, error=err);
   assert(err == ENOENT);
   
-  // What happens if we try to open a non-existant file?
+  // What happens if we try to open a non-existent file?
   var f = open(testfile, iomode.r, error=err);
   assert(err == ENOENT);
 

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -236,7 +236,7 @@ for x in 1..10 {
 // They are first-class citizen types, and can be assigned into variables
 var range1to10: range = 1..10;  // 1, 2, 3, ..., 10
 var range2to11 = 2..11; // 2, 3, 4, ..., 11
-var rangeThistoThat: range = thisInt..thatInt; // using variables
+var rangeThisToThat: range = thisInt..thatInt; // using variables
 var rangeEmpty: range = 100..-100 ; // this is valid but contains no indices 
 
 // Ranges can be unbounded 
@@ -245,7 +245,7 @@ var range1toInf: range(boundedType=BoundedRangeType.boundedLow) = 1.. ;
 // Note: the range(boundedType= ... ) is only 
 // necessary if we explicitly type the variable
 
-var rangeNegInfto1 = ..1; // ..., -4, -3, -2, -1, 0, 1
+var rangeNegInfTo1 = ..1; // ..., -4, -3, -2, -1, 0, 1
 
 // Ranges can be strided using the 'by' operator.
 var range2to10by2: range(stridable=true) = 2..10 by 2; // 2, 4, 6, 8, 10
@@ -617,7 +617,7 @@ for (i, j) in zip( toThisArray.domain, -100..#5 ){
 }
 writeln( toThisArray );
 
-// This is all very important in undestanding why the statement 
+// This is all very important in understanding why the statement
 // var iterArray : [1..10] int = [ i in 1..10 ] if ( i % 2 == 1 ) then j;
 // exhibits a runtime error.
 // Even though the domain of the array and the loop-expression are 
@@ -760,7 +760,7 @@ writeln( );
 // Modules are Chapel's way of managing name spaces.
 // The files containing these modules do not need to be named after the modules
 // (as in Java), but files implicitly name modules.
-// In this case, this file implicitly names the 'learnchapel' module
+// In this case, this file implicitly names the 'learnChapelInYMinutes' module
 
 module OurModule {
   // We can use modules inside of other modules.
@@ -902,7 +902,7 @@ proc main(){
   [ val in myBigArray ] val = 1 / val; // Parallel operation
 
   // Atomic variables, common to many languages, are ones whose operations
-  // occur uninterupted. Multiple threads can both modify atomic variables
+  // occur uninterrupted. Multiple threads can both modify atomic variables
   // and can know that their values are safe.
   // Chapel atomic variables can be of type bool, int, uint, and real.
   var uranium: atomic int;

--- a/test/release/examples/primers/locales.chpl
+++ b/test/release/examples/primers/locales.chpl
@@ -2,7 +2,7 @@
  * Locales primer
  *
  * This example showcases Chapel's locale types.  To run this example
- * using multiple locales set up your envionment as described in
+ * using multiple locales set up your environment as described in
  * multilocale.rst and execute it using the "-nl #" flag to specify
  * the number of locales.  For example, to run on 2 locales, run
  * "./a.out -nl 2".

--- a/test/release/examples/primers/opaque.chpl
+++ b/test/release/examples/primers/opaque.chpl
@@ -21,7 +21,7 @@ var People: domain(opaque);
 
 //
 // Since opaque domains don't support logical index values, new
-// indices are created by requesting them from the dommain directly.
+// indices are created by requesting them from the domain directly.
 // So, to add our first three people to the People domain, we could
 // do the following declarations/assignments:
 //

--- a/test/release/examples/primers/procedures.chpl
+++ b/test/release/examples/primers/procedures.chpl
@@ -14,7 +14,7 @@
 //
 // Formal arguments are supplied with values when the procedure is called.
 // The arguments supplied at the call site are the "actual" arguments.
-// If a name and '=' preceed an actual argument, the actual is assigned
+// If a name and '=' precede an actual argument, the actual is assigned
 // to the formal argument with that name.  Any remaining (unnamed) actual
 // arguments are assigned to the remaining formal arguments in lexical order.
 //

--- a/test/release/examples/primers/taskParallel.chpl
+++ b/test/release/examples/primers/taskParallel.chpl
@@ -46,7 +46,7 @@ cobegin {
 }
 
 // The order of the output is again undefined because the begin
-// statements in the above cobegin statment are not guaranteed to
+// statements in the above cobegin statement are not guaranteed to
 // have been executed before control reaches the following statement.
 writeln("3: output from main task");
 


### PR DESCRIPTION
start_test test/release/examples/primers all pass

(Except that it couldn't find chpldoc)