### PR TITLE
Enable an override of the default intent for a formal

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1052,13 +1052,30 @@ bool ArgSymbol::requiresCPtr(void) {
 
 
 bool ArgSymbol::isConstant() const {
-  if (intent == INTENT_CONST_IN || intent == INTENT_CONST_REF) {
-    return true;
+  bool retval = false;
+
+  switch (intent) {
+  case INTENT_BLANK:
+    retval = type->isDefaultIntentConst();
+    break;
+
+  case INTENT_CONST_IN:
+  case INTENT_CONST_REF:
+    retval = true;
+    break;
+
+  // Noakes: 2016/06/14
+  // It seems odd to me that this case depends on the type
+  case INTENT_CONST:
+    retval = type->isDefaultIntentConst();
+    break;
+
+  default:
+    retval = false;
+    break;
   }
-  return (intent == INTENT_BLANK || intent == INTENT_CONST) &&
-    !isReferenceType(type) &&
-    !isSyncType(type) &&
-    !isRecordWrappedType(type) /* array, domain, distribution */;
+
+  return retval;
 }
 
 bool ArgSymbol::isConstValWillNotChange() const {

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -79,6 +79,18 @@ Type* Type::typeInfo() {
   return this;
 }
 
+// Are actuals of this type passed with const intent by default?
+bool Type::isDefaultIntentConst() const {
+  bool retval = true;
+
+  if (symbol->hasFlag(FLAG_DEFAULT_INTENT_IS_REF) == true ||
+      isReferenceType(this)                       == true ||
+      isSyncType(this)                            == true ||
+      isRecordWrappedType(this)                   == true)
+    retval = false;
+
+  return retval;
+}
 
 GenRet Type::codegen() {
   if (this == dtUnknown) {
@@ -1846,7 +1858,7 @@ bool isUnion(Type* t) {
   return false;
 }
 
-bool isReferenceType(Type* t) {
+bool isReferenceType(const Type* t) {
   return t->symbol->hasFlag(FLAG_REF);
 }
 
@@ -1860,7 +1872,7 @@ bool isRefCountedType(Type* t) {
   return getRecordWrappedFlags(t->symbol).any();
 }
 
-bool isRecordWrappedType(Type* t) {
+bool isRecordWrappedType(const Type* t) {
   return getRecordWrappedFlags(t->symbol).any();
 }
 
@@ -1904,11 +1916,11 @@ static bool isDerivedType(Type* type, Flag flag)
   return retval;
 }
 
-bool isSyncType(Type* t) {
+bool isSyncType(const Type* t) {
   return getSyncFlags(t->symbol).any();
 }
 
-bool isAtomicType(Type* t) {
+bool isAtomicType(const Type* t) {
   return t->symbol->hasFlag(FLAG_ATOMIC_TYPE);
 }
 

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -82,6 +82,10 @@ symbolFlag( FLAG_CONST , npr, "const" , "constant" )
 symbolFlag( FLAG_C_PTR_CLASS , ypr, "c_ptr class" , "marks c_ptr class" )
 symbolFlag( FLAG_CONSTRUCTOR , npr, "constructor" , "constructor (but not type constructor); loosely defined to include constructor wrappers" )
 symbolFlag( FLAG_DATA_CLASS , ypr, "data class" , ncm )
+
+// Enable override for default-intent for types defined in terms of record/class
+symbolFlag( FLAG_DEFAULT_INTENT_IS_REF, ypr, "default intent is ref", "The default intent for this type is ref")
+
 symbolFlag( FLAG_DEFAULT_CONSTRUCTOR , npr, "default constructor" , ncm )
 symbolFlag( FLAG_DESTRUCTOR , npr, "destructor" , "applied to functions that are destructors" )
 symbolFlag( FLAG_DISTRIBUTION , ypr, "distribution" , ncm )

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -73,6 +73,8 @@ public:
 
   void             addSymbol(TypeSymbol* newSymbol);
 
+  bool             isDefaultIntentConst()                                const;
+
   TypeSymbol*      symbol;
   AggregateType*   refType;  // pointer to references for non-reference types
   Vec<FnSymbol*>   methods;
@@ -287,15 +289,15 @@ bool isClass(Type* t);
 bool isRecord(Type* t);
 bool isUnion(Type* t);
 
-bool isReferenceType(Type* t);
+bool isReferenceType(const Type* t);
 
 bool isRefCountedType(Type* t);
-bool isRecordWrappedType(Type* t);
+bool isRecordWrappedType(const Type* t);
 bool isDomImplType(Type* t);
 bool isArrayImplType(Type* t);
 bool isDistImplType(Type* t);
-bool isSyncType(Type* t);
-bool isAtomicType(Type* t);
+bool isSyncType(const Type* t);
+bool isAtomicType(const Type* t);
 bool isRefIterType(Type* t);
 
 bool isSubClass(Type* type, Type* baseType);

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,8 +17,9 @@
  * limitations under the License.
  */
 
-#include "passes.h"
 #include "resolveIntents.h"
+
+#include "passes.h"
 
 bool intentsResolved = false;
 
@@ -53,35 +54,42 @@ static IntentTag constIntentForType(Type* t) {
 }
 
 IntentTag blankIntentForType(Type* t) {
-  if (isSyncType(t) ||
-      isAtomicType(t) ||
+  IntentTag retval = INTENT_BLANK;
+
+  if (isSyncType(t)                                  ||
+      isAtomicType(t)                                ||
+      t->symbol->hasFlag(FLAG_DEFAULT_INTENT_IS_REF) ||
       t->symbol->hasFlag(FLAG_ARRAY)) {
-    return INTENT_REF;
-  } else if (is_bool_type(t) ||
-             is_int_type(t) ||
-             is_uint_type(t) ||
-             is_real_type(t) ||
-             is_imag_type(t) ||
-             is_complex_type(t) ||
-             is_enum_type(t) ||
-             t == dtStringC ||
-             t == dtStringCopy ||
-             t == dtCVoidPtr ||
-             t == dtCFnPtr ||
-             isClass(t) ||
-             isRecord(t) ||
-             isUnion(t) ||
-             t == dtTaskID ||
-             t == dtFile ||
-             t == dtNil ||
-             t == dtOpaque ||
-             t->symbol->hasFlag(FLAG_DOMAIN) ||
-             t->symbol->hasFlag(FLAG_DISTRIBUTION) ||
+    retval = INTENT_REF;
+
+  } else if (is_bool_type(t)                         ||
+             is_int_type(t)                          ||
+             is_uint_type(t)                         ||
+             is_real_type(t)                         ||
+             is_imag_type(t)                         ||
+             is_complex_type(t)                      ||
+             is_enum_type(t)                         ||
+             t == dtStringC                          ||
+             t == dtStringCopy                       ||
+             t == dtCVoidPtr                         ||
+             t == dtCFnPtr                           ||
+             isClass(t)                              ||
+             isRecord(t)                             ||
+             isUnion(t)                              ||
+             t == dtTaskID                           ||
+             t == dtFile                             ||
+             t == dtNil                              ||
+             t == dtOpaque                           ||
+             t->symbol->hasFlag(FLAG_DOMAIN)         ||
+             t->symbol->hasFlag(FLAG_DISTRIBUTION)   ||
              t->symbol->hasFlag(FLAG_EXTERN)) {
-    return constIntentForType(t);
+    retval = constIntentForType(t);
+
+  } else {
+    INT_FATAL(t, "Unhandled type in blankIntentForType()");
   }
-  INT_FATAL(t, "Unhandled type in blankIntentForType()");
-  return INTENT_BLANK;
+
+  return retval;
 }
 
 IntentTag concreteIntent(IntentTag existingIntent, Type* t) {
@@ -100,15 +108,16 @@ static IntentTag blankIntentForThisArg(Type* t) {
 }
 
 void resolveArgIntent(ArgSymbol* arg) {
-  arg->intent = 
-    arg->hasFlag(FLAG_ARG_THIS) && arg->intent == INTENT_BLANK ?
-    blankIntentForThisArg(arg->type) :
-    concreteIntent(arg->intent, arg->type);
+  if (arg->hasFlag(FLAG_ARG_THIS) && arg->intent == INTENT_BLANK)
+    arg->intent = blankIntentForThisArg(arg->type);
+  else
+    arg->intent = concreteIntent(arg->intent, arg->type);
 }
 
 void resolveIntents() {
   forv_Vec(ArgSymbol, arg, gArgSymbols) {
     resolveArgIntent(arg);
   }
+
   intentsResolved = true;
 }


### PR DESCRIPTION
Today the default intent for a formal of type record is "const" and the default intent for a
formal of type sync/single is "ref".  This is an obstacle to a naive effort to re-implement
sync/single in terms of a record and may also be an obstacle to an overhaul of Michael's
effort to reimplement array.

This PR introduces a pragma "default intent is ref" that can be attached to a type declaration to
force a type that would otherwise default to const (primarily record and class) to be treated as
ref.

I had intended to merge this with my update to ChapelSyncvar, which would also lock in this
behavior, but am electing to merge it prematurely in case it could be useful to Michael.

Compiles on clang/darwin and gcc/linux64 with/without CHPL_DEVELOPER.
No unexpected errors on standard-linux64 and gasnet-linux64.

