### PR TITLE
Retire a passing future for first-class-functions.  Thanks Nick.

### DIFF
--- a/test/functions/sungeun/retType.future
+++ b/test/functions/sungeun/retType.future
@@ -1,3 +1,0 @@
-feature request: A way to query the return type of a function without calling the function.
-
-


### PR DESCRIPTION
Nick's work on first-class-functions, PR 3887, resolved a long standing future.
Remove the future.