### PR TITLE
Change complex getter functions for .re and .im into "static inline"

### DIFF
--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -249,10 +249,18 @@ typedef struct chpl_main_argument_s {
 _complex128 _chpl_complex128(_real64 re, _real64 im);
 _complex64 _chpl_complex64(_real32 re, _real32 im);
 
-_real64* complex128GetRealRef(_complex128* cplx);
-_real64* complex128GetImagRef(_complex128* cplx);
-_real32* complex64GetRealRef(_complex64* cplx);
-_real32* complex64GetImagRef(_complex64* cplx);
+static inline _real64* complex128GetRealRef(_complex128* cplx) {
+  return ((_real64*)cplx) + 0;
+}
+static inline _real64* complex128GetImagRef(_complex128* cplx) {
+  return ((_real64*)cplx) + 1;
+}
+static inline _real32* complex64GetRealRef(_complex64* cplx) {
+  return ((_real32*)cplx) + 0;
+}
+static inline _real32* complex64GetImagRef(_complex64* cplx) {
+  return ((_real32*)cplx) + 1;
+}
 
 /* 128 bit complex operators for LLVM use */
 static inline _complex128 complexMultiply128(_complex128 c1, _complex128 c2) {

--- a/runtime/src/chpltypes.c
+++ b/runtime/src/chpltypes.c
@@ -44,23 +44,6 @@ _complex64 _chpl_complex64(_real32 re, _real32 im) {
   return re + im*_Complex_I;
 }
 
-_real64* complex128GetRealRef(_complex128* cplx) {
-  return ((_real64*)cplx) + 0;
-}
-
-_real64* complex128GetImagRef(_complex128* cplx) {
-  return ((_real64*)cplx) + 1;
-}
-
-_real32* complex64GetRealRef(_complex64* cplx) {
-  return ((_real32*)cplx) + 0;
-}
-
-_real32* complex64GetImagRef(_complex64* cplx) {
-  return ((_real32*)cplx) + 1;
-}
-
-
 int64_t real2int( _real64 f) {
   // need to use a union here rather than a pointer cast to avoid gcc
   // warnings when compiling -O3


### PR DESCRIPTION
Calls to the runtime functions to get references to the real or imaginary
parts of complex numbers appear to be causing significant overhead vs.
inlining the code in them.

Moved the bodies of these functions into the header file that declares them
and mark them "static inline".