### PR TITLE
Remove untested and broken _stack class from ChapelUtil

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -656,22 +656,7 @@ module ChapelBase {
   pragma "no default functions"
   class _ddata {
     type eltType;
-    /*
-       If we had a way to do 'static' routines, this
-       could stay here, but since we don't at the moment,
-       we've wired the modules to call _ddata_free().
 
-    proc ~_ddata() {
-      __primitive("array_free", this);
-    }
-
-     If we had a way to do 'static' routines, this
-       could stay here, but since we don't at the moment,
-       we've wired the modules to call _ddata_allocate().
-    inline proc init(size: integral) {
-      __primitive("array_alloc", this, eltType, size);
-      init_elts(this, size, eltType);
-    }*/
     inline proc this(i: integral) ref {
       return __primitive("array_get", this, i);
     }

--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -22,58 +22,7 @@
 // Internal data structures module
 //
 module ChapelUtil {
-  
-  param _INIT_STACK_SIZE = 8;
-  
-  class _stack {
-    type eltType;
-    var  size: int;
-    var  top: int;
-    var  data: _ddata(eltType);
-    
-    proc initialize() {
-      top = 0;
-      size = _INIT_STACK_SIZE;
-      data = new _ddata(eltType);
-      data.init(8);
-    }
-  
-    proc push( e: eltType) {
-      if (top == size-1) {  // supersize as necessary
-        size *= 2;
-        var supersize = new _ddata(eltType);
-        supersize.init(size);
-        [i in 0..(size/2)-1] supersize[i] = data[i];
-        data = supersize;
-      }
-      data[top] = e;
-      top += 1;
-    }
-  
-    proc pop() {
-      var e: eltType;
-      if top>0 then {
-        top -= 1;
-        e = data[top];
-      } else {
-        halt( "pop() on empty stack");
-      }
-      return e;
-    }
-  
-    proc empty() {
-      top = 0;
-    }
-  
-    proc length {
-      return top;
-    }
-  
-    proc writeThis(f) {
-      for i in 0..top-1 do f.write(" ", data[i]);
-    }
-  }
-  
+
   //
   // safeAdd: If a and b are of type t, return true iff no
   //  overflow/underflow would occur for a + b


### PR DESCRIPTION
The _stack class defined in ChapelUtil relied on a ddata method that was
commented out 4 years ago.  Since we didn't notice before, it seems likely that
resurrecting the code will be more trouble than it's worth, so remove it.  Also
remove the commented out methods.

Passed std/ testing.  No objections via email.