### PR TITLE
Minor fix in SparseBlockDist, add suppressifs

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -140,10 +140,14 @@ class SparseBlockDom: BaseSparseDom {
 
     if !isSorted {
 
-      // without _new_ record functions throw null deref. It doesn't seem to be 
+      // there are two issues with the following line
+      // 1 without _new_ record functions throw null deref. It doesn't seem to be 
       // able to deref _outer_ ? I think it has something to do with memory
       // allocation for classes vs records, but I cannot explain
-      var comp = new TargetLocaleComparator;
+      // 2 this line seems to be completely hacky -- explicit parantheses were
+      // necessary for the compiler not to complain when --verify flag is
+      // present. 
+      var comp = new TargetLocaleComparator();
       sort(inds, comparator=comp);
     }
 

--- a/test/users/engin/sparse_bulk_dist/diags.suppressif
+++ b/test/users/engin/sparse_bulk_dist/diags.suppressif
@@ -1,0 +1,1 @@
+CHPL_COMM==none

--- a/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.suppressif
+++ b/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.suppressif
@@ -1,0 +1,11 @@
+# --fast sets --no-checks
+#
+# --fast sets --no-checks and this test is explicitly checking that one
+# of our runtime checks is working correctly. There's been debate as to
+# whether tests like this should be suppressed or skipped. For now we
+# suppress with the argument that we're testing that --fast actually
+# turns our checks off. Note that we don't just turn checks on in the
+# compopts since we wouldn't be testing the default behavior, and
+# wouldn't be able to verify that checks are enabled by default. 
+
+COMPOPTS <= --fast


### PR DESCRIPTION
This PR fixes a "workaround" code in SparseBlockDist which caused
compiler to crash when --verify is enabled. Also adds suppressif files
for two tests.

Passed standard and GASNet full suite.