### PR TITLE
Revise isSyncType()

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -3460,16 +3460,6 @@ FlagSet getRecordWrappedFlags(Symbol* s) {
   return s->flags & mask;
 }
 
-FlagSet getSyncFlags(Symbol* s) {
-  static FlagSet mask;
-  if (mask.none()) {
-    mask.set(FLAG_SYNC);
-    mask.set(FLAG_SINGLE);
-  }
-
-  return s->flags & mask;
-}
-
 VarSymbol* newTemp(const char* name, Type* type) {
   if (!name) {
     if (localTempNames)

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -86,6 +86,7 @@ bool Type::isDefaultIntentConst() const {
   if (symbol->hasFlag(FLAG_DEFAULT_INTENT_IS_REF) == true ||
       isReferenceType(this)                       == true ||
       isSyncType(this)                            == true ||
+      isSingleType(this)                          == true ||
       isRecordWrappedType(this)                   == true)
     retval = false;
 
@@ -1917,8 +1918,11 @@ static bool isDerivedType(Type* type, Flag flag)
 }
 
 bool isSyncType(const Type* t) {
-  return t->symbol->hasFlag(FLAG_SYNC) ||
-         t->symbol->hasFlag(FLAG_SINGLE);
+  return t->symbol->hasFlag(FLAG_SYNC);
+}
+
+bool isSingleType(const Type* t) {
+  return t->symbol->hasFlag(FLAG_SINGLE);
 }
 
 bool isAtomicType(const Type* t) {
@@ -2217,8 +2221,9 @@ bool needsCapture(Type* t) {
     return true;
   } else {
     // Ensure we have covered all types.
-    INT_ASSERT(isRecordWrappedType(t) ||  // domain, array, or distribution
-               isSyncType(t) ||
+    INT_ASSERT(isRecordWrappedType(t) ||
+               isSyncType(t)          ||
+               isSingleType(t)        ||
                isAtomicType(t));
     return false;
   }

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1917,7 +1917,8 @@ static bool isDerivedType(Type* type, Flag flag)
 }
 
 bool isSyncType(const Type* t) {
-  return getSyncFlags(t->symbol).any();
+  return t->symbol->hasFlag(FLAG_SYNC) ||
+         t->symbol->hasFlag(FLAG_SINGLE);
 }
 
 bool isAtomicType(const Type* t) {

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -578,7 +578,6 @@ VarSymbol *new_ImmediateSymbol(Immediate *imm);
 void createInitStringLiterals();
 void resetTempID();
 FlagSet getRecordWrappedFlags(Symbol* s);
-FlagSet getSyncFlags(Symbol* s);
 VarSymbol* newTemp(const char* name = NULL, Type* type = dtUnknown);
 VarSymbol* newTemp(Type* type);
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -297,6 +297,7 @@ bool isDomImplType(Type* t);
 bool isArrayImplType(Type* t);
 bool isDistImplType(Type* t);
 bool isSyncType(const Type* t);
+bool isSingleType(const Type* t);
 bool isAtomicType(const Type* t);
 bool isRefIterType(Type* t);
 

--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -1027,18 +1027,27 @@ static bool defDominatesAllExits(Loop* loop, SymExpr* def, std::vector<BitVec*>&
  */
 static bool containsSynchronizationVar(BaseAST* ast) {
   std::vector<SymExpr*> symExprs;
-  collectSymExprs(ast, symExprs);
-  for_vector(SymExpr, symExpr, symExprs) {
 
-    if(isLcnSymbol(symExpr->var)) {
+  collectSymExprs(ast, symExprs);
+
+  for_vector(SymExpr, symExpr, symExprs) {
+    if (isLcnSymbol(symExpr->var)) {
       Type* symType = symExpr->var->type;
       Type* valType = symType->getValType();
-      if (isSyncType(symType) || isAtomicType(symType) ||
-          isSyncType(valType) || isAtomicType(valType)) {
+
+      if (isSyncType(symType)    ||
+          isSingleType(symType)  ||
+          isAtomicType(symType)  ||
+
+          isSyncType(valType)    ||
+          isSingleType(valType)  ||
+          isAtomicType(valType)) {
+
         return true;
       }
     }
   }
+
   return false;
 }
 

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1031,41 +1031,51 @@ static void findBlockRefActuals(Vec<Symbol*>& refSet, Vec<Symbol*>& refVec)
 //   Otherwise, if it is a record-wrapped type, replicate it.
 //   Otherwise,
 //    Add it to varSet and varVec, so it will be put on the heap.
-static void findHeapVarsAndRefs(Map<Symbol*,Vec<SymExpr*>*>& defMap,
-                                Vec<Symbol*>& refSet, Vec<Symbol*>& refVec,
-                                Vec<Symbol*>& varSet, Vec<Symbol*>& varVec)
+static void findHeapVarsAndRefs(Map<Symbol*, Vec<SymExpr*>*>& defMap,
+
+                                Vec<Symbol*>&                 refSet,
+                                Vec<Symbol*>&                 refVec,
+
+                                Vec<Symbol*>&                 varSet,
+                                Vec<Symbol*>& varVec)
 {
   forv_Vec(DefExpr, def, gDefExprs) {
     SET_LINENO(def);
-    if (!fLocal &&
-        isModuleSymbol(def->parentSymbol) &&
-        def->parentSymbol != rootModule &&
-        isVarSymbol(def->sym) &&
+
+    if (!fLocal                                 &&
+        isModuleSymbol(def->parentSymbol)       &&
+        def->parentSymbol != rootModule         &&
+        isVarSymbol(def->sym)                   &&
         !def->sym->hasFlag(FLAG_LOCALE_PRIVATE) &&
         !def->sym->hasFlag(FLAG_EXTERN)) {
       if (def->sym->hasFlag(FLAG_CONST) &&
-          (is_bool_type(def->sym->type) ||
-           is_enum_type(def->sym->type) ||
-           is_int_type(def->sym->type) ||
-           is_uint_type(def->sym->type) ||
-           is_real_type(def->sym->type) ||
-           is_imag_type(def->sym->type) ||
+          (is_bool_type(def->sym->type)    ||
+           is_enum_type(def->sym->type)    ||
+           is_int_type(def->sym->type)     ||
+           is_uint_type(def->sym->type)    ||
+           is_real_type(def->sym->type)    ||
+           is_imag_type(def->sym->type)    ||
            is_complex_type(def->sym->type) ||
-           (isRecord(def->sym->type) &&
+           (isRecord(def->sym->type)             &&
             !isRecordWrappedType(def->sym->type) &&
             // sync/single are currently classes, so this shouldn't matter
-            !isSyncType(def->sym->type) &&
+            !isSyncType(def->sym->type)          &&
+            !isSingleType(def->sym->type)        &&
             // Dont try to broadcast string literals, they'll get fixed in
             // another manner
             (def->sym->type != dtString)))) {
         // replicate global const of primitive type
         INT_ASSERT(defMap.get(def->sym) && defMap.get(def->sym)->n == 1);
+
         for_defs(se, defMap, def->sym) {
-          se->getStmtExpr()->insertAfter(new CallExpr(PRIM_PRIVATE_BROADCAST, def->sym));
+          se->getStmtExpr()->insertAfter(new CallExpr(PRIM_PRIVATE_BROADCAST,
+                                                      def->sym));
         }
+
       } else if (isRecordWrappedType(def->sym->type)) {
         // replicate address of global arrays, domains, and distributions
         replicateGlobalRecordWrappedVars(def);
+
       } else {
         // put other global constants and all global variables on the heap
         varSet.set_add(def->sym);

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -24,7 +24,8 @@
 bool intentsResolved = false;
 
 static IntentTag constIntentForType(Type* t) {
-  if (isSyncType(t) ||
+  if (isSyncType(t)          ||
+      isSingleType(t)        ||
       isRecordWrappedType(t) ||  // domain, array, or distribution
       isRecord(t)) { // may eventually want to decide based on size
     return INTENT_CONST_REF;
@@ -57,6 +58,7 @@ IntentTag blankIntentForType(Type* t) {
   IntentTag retval = INTENT_BLANK;
 
   if (isSyncType(t)                                  ||
+      isSingleType(t)                                ||
       isAtomicType(t)                                ||
       t->symbol->hasFlag(FLAG_DEFAULT_INTENT_IS_REF) ||
       t->symbol->hasFlag(FLAG_ARRAY)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1357,10 +1357,14 @@ static bool canParamCoerce(Type* actualType, Symbol* actualSym, Type* formalType
 //
 // fn is the function being called usually but in resolveReturnType it
 // is the function we're finding return types for.
-bool
-canCoerce(Type* actualType, Symbol* actualSym, Type* formalType, FnSymbol* fn, bool* promotes) {
+bool canCoerce(Type*     actualType,
+               Symbol*   actualSym,
+               Type*     formalType,
+               FnSymbol* fn,
+               bool*     promotes) {
   if (canParamCoerce(actualType, actualSym, formalType))
     return true;
+
   if (is_real_type(formalType)) {
     if ((is_int_type(actualType) || is_uint_type(actualType))
         && get_width(formalType) >= 64)
@@ -1369,30 +1373,43 @@ canCoerce(Type* actualType, Symbol* actualSym, Type* formalType, FnSymbol* fn, b
         get_width(actualType) < get_width(formalType))
       return true;
   }
+
   if (is_complex_type(formalType)) {
     if ((is_int_type(actualType) || is_uint_type(actualType))
         && get_width(formalType) >= 128)
       return true;
+
     if (is_real_type(actualType) &&
         (get_width(actualType) <= get_width(formalType)/2))
       return true;
+
     if (is_imag_type(actualType) &&
         (get_width(actualType) <= get_width(formalType)/2))
       return true;
+
     if (is_complex_type(actualType) &&
         (get_width(actualType) < get_width(formalType)))
       return true;
   }
-  if (isSyncType(actualType)) {
+
+  if (isSyncType(actualType) || isSingleType(actualType)) {
     Type* baseType = actualType->getField("base_type")->type;
     return canDispatch(baseType, NULL, formalType, fn, promotes);
   }
+
   if (actualType->symbol->hasFlag(FLAG_REF))
-    return canDispatch(actualType->getValType(), NULL, formalType, fn, promotes);
+    return canDispatch(actualType->getValType(),
+                       NULL,
+                       formalType,
+                       fn,
+                       promotes);
+
   if (formalType == dtString && actualType == dtStringCopy)
     return true;
+
   if (formalType == dtStringC && actualType == dtStringCopy)
     return true;
+
   if (actualType->symbol->hasFlag(FLAG_C_PTR_CLASS) &&
       (formalType == dtCVoidPtr))
     return true;
@@ -2469,34 +2486,56 @@ static inline void registerParamPreference(int& paramPrefers, int preference,
 }
 
 
-static bool considerParamMatches(Type* actualtype,
-                                 Type* arg1type, Type* arg2type) {
+static bool considerParamMatches(Type* actualType,
+                                 Type* arg1Type,
+                                 Type* arg2Type) {
   /* BLC: Seems weird to have to add this; could just add it in the enum
      case if enums have to be special-cased here.  Otherwise, how are the
      int cases handled later...? */
-  if (actualtype->symbol->hasFlag(FLAG_REF)) {
-    actualtype = actualtype->getValType();
+  if (actualType->symbol->hasFlag(FLAG_REF)) {
+    actualType = actualType->getValType();
   }
-  if (actualtype == arg1type && actualtype != arg2type) {
+
+  if (actualType == arg1Type && actualType != arg2Type) {
     return true;
   }
+
   // If we don't have an exact match in the previous line, let's see if
   // we have a bool(w1) passed to bool(w2) or non-bool case;  This is
   // based on the enum case developed in r20208
-  if (is_bool_type(actualtype) && is_bool_type(arg1type) && !is_bool_type(arg2type)) {
+  if (is_bool_type(actualType) &&
+      is_bool_type(arg1Type)   &&
+      !is_bool_type(arg2Type)) {
     return true;
   }
-  // Otherwise, have bool cast to default-sized integer over a smaller size
-  if (is_bool_type(actualtype) && actualtype != arg1type && actualtype != arg2type) {
-    return considerParamMatches(dtInt[INT_SIZE_DEFAULT], arg1type, arg2type);
+
+  if (actualType != arg1Type && actualType != arg2Type) {
+    // Otherwise, have bool cast to default-sized integer over a smaller size
+    if (is_bool_type(actualType)) {
+      return considerParamMatches(dtInt[INT_SIZE_DEFAULT],
+                                  arg1Type,
+                                  arg2Type);
+    }
+
+    if (is_enum_type(actualType)) {
+      return considerParamMatches(dtInt[INT_SIZE_DEFAULT],
+                                  arg1Type,
+                                  arg2Type);
+    }
+
+    if (isSyncType(actualType)) {
+      return considerParamMatches(actualType->getField("base_type")->type,
+                                  arg1Type,
+                                  arg2Type);
+    }
+
+    if (isSingleType(actualType)) {
+      return considerParamMatches(actualType->getField("base_type")->type,
+                                  arg1Type,
+                                  arg2Type);
+    }
   }
-  if (is_enum_type(actualtype) && actualtype != arg1type && actualtype != arg2type) {
-    return considerParamMatches(dtInt[INT_SIZE_DEFAULT], arg1type, arg2type);
-  }
-  if (isSyncType(actualtype) && actualtype != arg1type && actualtype != arg2type) {
-    return considerParamMatches(actualtype->getField("base_type")->type,
-                                arg1type, arg2type);
-  }
+
   return false;
 }
 
@@ -3706,12 +3745,18 @@ static void checkForStoringIntoTuple(CallExpr* call, FnSymbol* resolvedFn)
     return;
 
   for_formals_actuals(formal, actual, call)
-    if (isSyncType(formal->type)) {
+    if (isSyncType(formal->type) || isSingleType(formal->type)) {
       const char* name = "";
+
       if (SymExpr* aSE = toSymExpr(actual))
         if (!aSE->var->hasFlag(FLAG_TEMP))
           name = aSE->var->name;
-      USR_FATAL_CONT(actual, "storing a sync or single variable %s in a tuple is not currently implemented - apply readFE() or readFF()", name);
+
+      USR_FATAL_CONT(actual,
+                     "storing a sync or single variable %s in a tuple "
+                     "is not currently implemented - "
+                     "apply readFE() or readFF()",
+                     name);
     }
 }
 
@@ -4731,7 +4776,8 @@ insertFormalTemps(FnSymbol* fn) {
 // The copy out is needed for "inout" and "out" intents.
 // Blank intent is treated like "const", and normally copies the formal through
 // chpl__autoCopy.
-// Note that autoCopy is called in this case, but not for "inout", "in" and "const in".
+// Note that autoCopy is called in this case, but not for "inout", "in" and
+// "const in".
 // Either record-wrapped types are always passed by ref, or some unexpected
 // behavior will result by applying "in" intents to them.
 static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
@@ -4751,7 +4797,9 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
     // mark CONST as needed
     if (concreteIntent(formal->intent, formalType) & INTENT_FLAG_CONST) {
       tmp->addFlag(FLAG_CONST);
-      if (!isSyncType(formalType) &&
+
+      if (!isSyncType(formalType)   &&
+          !isSingleType(formalType) &&
           !isRefCountedType(formalType))
         tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
     }
@@ -4774,21 +4822,35 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
       break;
 
      case INTENT_OUT:
-      if (formal->defaultExpr && formal->defaultExpr->body.tail->typeInfo() != dtTypeDefaultToken) {
+      if (formal->defaultExpr &&
+          formal->defaultExpr->body.tail->typeInfo() != dtTypeDefaultToken) {
         BlockStmt* defaultExpr = formal->defaultExpr->copy();
 
-        fn->insertAtHead(new CallExpr(PRIM_MOVE, tmp, defaultExpr->body.tail->remove()));
+        fn->insertAtHead(new CallExpr(PRIM_MOVE,
+                                      tmp,
+                                      defaultExpr->body.tail->remove()));
         fn->insertAtHead(defaultExpr);
+
       } else {
         VarSymbol* refTmp  = newTemp("_formal_ref_tmp_");
         VarSymbol* typeTmp = newTemp("_formal_type_tmp_");
 
         typeTmp->addFlag(FLAG_MAYBE_TYPE);
 
-        fn->insertAtHead(new CallExpr(PRIM_MOVE, tmp,     new CallExpr(PRIM_INIT, typeTmp)));
-        fn->insertAtHead(new CallExpr(PRIM_MOVE, typeTmp, new CallExpr(PRIM_TYPEOF, refTmp)));
-        fn->insertAtHead(new CallExpr(PRIM_MOVE, refTmp,  new CallExpr(PRIM_DEREF, formal)));
+        fn->insertAtHead(new CallExpr(PRIM_MOVE,
+                                      tmp,
+                                      new CallExpr(PRIM_INIT, typeTmp)));
+
+        fn->insertAtHead(new CallExpr(PRIM_MOVE,
+                                      typeTmp,
+                                      new CallExpr(PRIM_TYPEOF, refTmp)));
+
+        fn->insertAtHead(new CallExpr(PRIM_MOVE,
+                                      refTmp,
+                                      new CallExpr(PRIM_DEREF, formal)));
+
         fn->insertAtHead(new DefExpr(refTmp));
+
         fn->insertAtHead(new DefExpr(typeTmp));
       }
 
@@ -4797,9 +4859,13 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
       break;
 
      case INTENT_INOUT:
-      fn->insertAtHead(new CallExpr(PRIM_MOVE, tmp, new CallExpr("chpl__initCopy", formal)));
+      fn->insertAtHead(new CallExpr(PRIM_MOVE,
+                                    tmp,
+                                    new CallExpr("chpl__initCopy", formal)));
+
       tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
       tmp->addFlag(FLAG_FORMAL_TEMP);
+
       break;
 
      case INTENT_IN:
@@ -4807,7 +4873,10 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
       // TODO: Adding a formal temp for INTENT_CONST_IN is conservative.
       // If the compiler verifies in a separate pass that it is never written,
       // we don't have to copy it.
-      fn->insertAtHead(new CallExpr(PRIM_MOVE, tmp, new CallExpr("chpl__initCopy", formal)));
+      fn->insertAtHead(new CallExpr(PRIM_MOVE,
+                                    tmp,
+                                    new CallExpr("chpl__initCopy", formal)));
+
       tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
       break;
 
@@ -4816,23 +4885,32 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
      {
        TypeSymbol* ts = formal->type->symbol;
 
-       if (!getRecordWrappedFlags(ts).any() &&
-           !ts->hasFlag(FLAG_ITERATOR_CLASS) &&
+       if (!getRecordWrappedFlags(ts).any()   &&
+           !ts->hasFlag(FLAG_ITERATOR_CLASS)  &&
            !ts->hasFlag(FLAG_ITERATOR_RECORD) &&
-           !isSyncType(ts->type)) {
+           !isSyncType(ts->type)              &&
+           !isSingleType(ts->type)) {
          if (fn->hasFlag(FLAG_BEGIN)) {
            // autoCopy/autoDestroy will be added later, in parallel pass
            // by insertAutoCopyDestroyForTaskArg()
            fn->insertAtHead(new CallExpr(PRIM_MOVE, tmp, formal));
            tmp->removeFlag(FLAG_INSERT_AUTO_DESTROY);
+
          } else {
-           // Note that because we reject the case of record-wrapped types above,
-           // the only way we can get a formal whose call to chpl__autoCopy does
-           // anything different from calling chpl__initCopy is if the formal is a
-           // tuple containing a record-wrapped type.  This is probably not
-           // intentional: It gives tuple-wrapped record-wrapped types different
-           // behavior from bare record-wrapped types.
-           fn->insertAtHead(new CallExpr(PRIM_MOVE, tmp, new CallExpr("chpl__autoCopy", formal)));
+           // Note that because we reject the case of record-wrapped types
+           // above, the only way we can get a formal whose call to
+           // chpl__autoCopy does anything different from calling
+           // chpl__initCopy is if the formal is a tuple containing a
+           // record-wrapped type.
+
+           // This is probably not intentional: It gives tuple-wrapped
+           // record-wrapped types different behavior from bare record-wrapped
+           // types.
+           fn->insertAtHead(new CallExpr(PRIM_MOVE,
+                                         tmp,
+                                         new CallExpr("chpl__autoCopy",
+                                                      formal)));
+
            // WORKAROUND:
            // This is a temporary bug fix that results in leaked memory.
            //
@@ -4924,18 +5002,22 @@ static Expr* dropUnnecessaryCast(CallExpr* call) {
 }
 
 /*
-  Creates the parent class which will represent the function's type.  Children of the parent class will capture different functions which
-  happen to share the same function type.  By using the parent class we can assign new values onto variable that match the function type
+  Creates the parent class which will represent the function's type.
+  Children of the parent class will capture different functions which
+  happen to share the same function type.  By using the parent class
+  we can assign new values onto variable that match the function type
   but may currently be pointing at a different function.
 */
-static AggregateType* createAndInsertFunParentClass(CallExpr *call, const char *name) {
-  AggregateType *parent = new AggregateType(AGGREGATE_CLASS);
-  TypeSymbol *parent_ts = new TypeSymbol(name, parent);
+static AggregateType* createAndInsertFunParentClass(CallExpr*   call,
+                                                    const char* name) {
+  AggregateType* parent    = new AggregateType(AGGREGATE_CLASS);
+  TypeSymbol*    parent_ts = new TypeSymbol(name, parent);
 
   parent_ts->addFlag(FLAG_FUNCTION_CLASS);
 
-  // Because this function type needs to be globally visible (because we don't know the modules it will be passed to), we put
-  // it at the highest scope
+  // Because this function type needs to be globally visible (because
+  // we don't know the modules it will be passed to), we put it at the
+  // highest scope
   theProgram->block->body.insertAtTail(new DefExpr(parent_ts));
 
   parent->dispatchParents.add(dtObject);
@@ -4952,16 +5034,25 @@ static AggregateType* createAndInsertFunParentClass(CallExpr *call, const char *
 }
 
 /*
-  To mimic a function call, we create a .this method for the parent class.  This will allow the object to look and feel like a
-  first-class function, by both being an object and being invoked using parentheses syntax.  Children of the parent class will
-  override this method and wrap the function that is being used as a first-class value.
+  To mimic a function call, we create a .this method for the parent class.
+  This will allow the object to look and feel like a first-class function,
+  by both being an object and being invoked using parentheses syntax.
 
-  To focus on just the types of the arguments and not their names or default values, we use the parent method's names and types
-  as the basis for all children which override it.
+  Children of the parent class will override this method and wrap the
+  function that is being used as a first-class value.
 
-  The function is put at the highest scope so that all functions of a given type will share the same parent class.
+  To focus on just the types of the arguments and not their names or
+  default values, we use the parent method's names and types as the basis
+  for all children which override it.
+
+  The function is put at the highest scope so that all functions of a given
+  type will share the same parent class.
 */
-static FnSymbol* createAndInsertFunParentMethod(CallExpr *call, AggregateType *parent, AList &arg_list, bool isFormal, Type *retType) {
+static FnSymbol* createAndInsertFunParentMethod(CallExpr*      call,
+                                                AggregateType* parent,
+                                                AList&         arg_list,
+                                                bool           isFormal,
+                                                Type*          retType) {
   // Add a "getter" method that returns the return type of the function
   //
   //   * The return type itself is not actually stored as a member variable
@@ -4972,23 +5063,31 @@ static FnSymbol* createAndInsertFunParentMethod(CallExpr *call, AggregateType *p
   //     when "void" becomes a fully-featured type.
   {
     FnSymbol* rtGetter = new FnSymbol("retType");
+
     rtGetter->addFlag(FLAG_NO_IMPLICIT_COPY);
     rtGetter->addFlag(FLAG_INLINE);
     rtGetter->retTag = RET_TYPE;
-    rtGetter->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
+    rtGetter->insertFormalAtTail(new ArgSymbol(INTENT_BLANK,
+                                               "_mt",
+                                               dtMethodToken));
 
     ArgSymbol* _this = new ArgSymbol(INTENT_BLANK, "this", parent);
+
     _this->addFlag(FLAG_ARG_THIS);
     rtGetter->insertFormalAtTail(_this);
     rtGetter->insertAtTail(new CallExpr(PRIM_RETURN, retType->symbol));
 
     DefExpr* def = new DefExpr(rtGetter);
+
     parent->symbol->defPoint->insertBefore(def);
     normalize(rtGetter);
     parent->methods.add(rtGetter);
+
     rtGetter->addFlag(FLAG_METHOD);
     rtGetter->addFlag(FLAG_METHOD_PRIMARY);
-    rtGetter->cname = astr("chpl_get_", parent->symbol->cname, "_",
+    rtGetter->cname = astr("chpl_get_",
+                           parent->symbol->cname,
+                           "_",
                            rtGetter->cname);
     rtGetter->addFlag(FLAG_NO_PARENS);
     rtGetter->_this = _this;
@@ -4998,16 +5097,21 @@ static FnSymbol* createAndInsertFunParentMethod(CallExpr *call, AggregateType *p
   // for the function
   {
     FnSymbol* atGetter = new FnSymbol("argTypes");
+
     atGetter->addFlag(FLAG_NO_IMPLICIT_COPY);
     atGetter->addFlag(FLAG_INLINE);
     atGetter->retTag = RET_TYPE;
-    atGetter->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
+    atGetter->insertFormalAtTail(new ArgSymbol(INTENT_BLANK,
+                                               "_mt",
+                                               dtMethodToken));
 
     CallExpr* expr = new CallExpr(PRIM_ACTUALS_LIST);
+
     if (isFormal) {
       for_alist(formalExpr, arg_list) {
-        DefExpr* dExp = toDefExpr(formalExpr);
+        DefExpr*   dExp = toDefExpr(formalExpr);
         ArgSymbol* fArg = toArgSymbol(dExp->sym);
+
         expr->insertAtTail(fArg->type->symbol);
       }
     }
@@ -5015,41 +5119,54 @@ static FnSymbol* createAndInsertFunParentMethod(CallExpr *call, AggregateType *p
       for_alist(actualExpr, arg_list) {
         if (actualExpr != arg_list.tail) {
           SymExpr* sExpr = toSymExpr(actualExpr);
+
           expr->insertAtTail(sExpr->var->type->symbol);
         }
       }
     }
 
     ArgSymbol* _this = new ArgSymbol(INTENT_BLANK, "this", parent);
+
     _this->addFlag(FLAG_ARG_THIS);
+
     atGetter->insertFormalAtTail(_this);
-    atGetter->insertAtTail(
-      new CallExpr(PRIM_RETURN, new CallExpr("_build_tuple", expr)));
+    atGetter->insertAtTail(new CallExpr(PRIM_RETURN,
+                                        new CallExpr("_build_tuple", expr)));
 
     DefExpr* def = new DefExpr(atGetter);
+
     parent->symbol->defPoint->insertBefore(def);
     normalize(atGetter);
     parent->methods.add(atGetter);
+
     atGetter->addFlag(FLAG_METHOD);
     atGetter->addFlag(FLAG_METHOD_PRIMARY);
-    atGetter->cname = astr("chpl_get_", parent->symbol->cname, "_",
+    atGetter->cname = astr("chpl_get_",
+                           parent->symbol->cname, "_",
                            atGetter->cname);
     atGetter->addFlag(FLAG_NO_PARENS);
     atGetter->_this = _this;
   }
 
   FnSymbol* parent_method = new FnSymbol("this");
+
   parent_method->addFlag(FLAG_FIRST_CLASS_FUNCTION_INVOCATION);
-  parent_method->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
+  parent_method->insertFormalAtTail(new ArgSymbol(INTENT_BLANK,
+                                                  "_mt",
+                                                  dtMethodToken));
   parent_method->addFlag(FLAG_METHOD);
+
   ArgSymbol* thisParentSymbol = new ArgSymbol(INTENT_BLANK, "this", parent);
+
   thisParentSymbol->addFlag(FLAG_ARG_THIS);
+
   parent_method->insertFormalAtTail(thisParentSymbol);
   parent_method->_this = thisParentSymbol;
 
   int i = 0, alength = arg_list.length;
 
-  //We handle the arg list differently depending on if it's a list of formal args or actual args
+  // We handle the arg list differently depending on if it's a list of
+  // formal args or actual args
   if (isFormal) {
 
     for_alist(formalExpr, arg_list) {
@@ -5057,39 +5174,49 @@ static FnSymbol* createAndInsertFunParentMethod(CallExpr *call, AggregateType *p
       ArgSymbol* fArg = toArgSymbol(dExp->sym);
 
       if (fArg->type != dtVoid) {
-        ArgSymbol* newFormal = new ArgSymbol(INTENT_BLANK, fArg->name, fArg->type);
+        ArgSymbol* newFormal = new ArgSymbol(INTENT_BLANK,
+                                             fArg->name,
+                                             fArg->type);
+
         if (fArg->typeExpr)
           newFormal->typeExpr = fArg->typeExpr->copy();
 
         parent_method->insertFormalAtTail(newFormal);
       }
     }
-  }
-  else {
+
+  } else {
     char name_buffer[100];
-    int name_index = 0;
+    int  name_index = 0;
 
     for_alist(actualExpr, arg_list) {
       sprintf(name_buffer, "name%i", name_index++);
+
       if (i != (alength-1)) {
         SymExpr* sExpr = toSymExpr(actualExpr);
+
         if (sExpr->var->type != dtVoid) {
-          ArgSymbol* newFormal = new ArgSymbol(INTENT_BLANK, name_buffer, sExpr->var->type);
+          ArgSymbol* newFormal = new ArgSymbol(INTENT_BLANK,
+                                               name_buffer,
+                                               sExpr->var->type);
 
           parent_method->insertFormalAtTail(newFormal);
         }
       }
+
       ++i;
     }
   }
 
   if (retType != dtVoid) {
     VarSymbol *tmp = newTemp("_return_tmp_", retType);
+
     parent_method->insertAtTail(new DefExpr(tmp));
     parent_method->insertAtTail(new CallExpr(PRIM_RETURN, tmp));
   }
 
-  // Because this function type needs to be globally visible (because we don't know the modules it will be passed to), we put
+  // Because this function type needs to be globally visible
+  // (because we don't know the modules it will be passed to), we put
   // it at the highest scope
   theProgram->block->body.insertAtTail(new DefExpr(parent_method));
 
@@ -5101,19 +5228,22 @@ static FnSymbol* createAndInsertFunParentMethod(CallExpr *call, AggregateType *p
 }
 
 /*
-  Builds up the name of the parent for lookup by looking through the types of the arguments, either formal or actual
+  Builds up the name of the parent for lookup by looking through the types
+  of the arguments, either formal or actual
 */
-static std::string buildParentName(AList &arg_list, bool isFormal, Type *retType) {
+static std::string buildParentName(AList& arg_list,
+                                   bool   isFormal,
+                                   Type*  retType) {
   std::ostringstream oss;
-  oss << "chpl__fcf_type_";
+  bool               isFirst = true;
 
-  bool isFirst = true;
+  oss << "chpl__fcf_type_";
 
   if (isFormal) {
     if (arg_list.length == 0) {
       oss << "void";
-    }
-    else {
+
+    } else {
       for_alist(formalExpr, arg_list) {
         DefExpr* dExp = toDefExpr(formalExpr);
         ArgSymbol* fArg = toArgSymbol(dExp->sym);
@@ -5128,8 +5258,8 @@ static std::string buildParentName(AList &arg_list, bool isFormal, Type *retType
     }
     oss << "_";
     oss << retType->symbol->cname;
-  }
-  else {
+
+  } else {
     int i = 0, alength = arg_list.length;
 
     if (alength == 1) {
@@ -5154,47 +5284,62 @@ static std::string buildParentName(AList &arg_list, bool isFormal, Type *retType
 }
 
 /*
-  Helper function for creating or finding the parent class for a given function type specified
-  by the type signature.  The last type given in the signature is the return type, the remainder
-  represent arguments to the function.
+  Helper function for creating or finding the parent class for a given
+  function type specified by the type signature.  The last type given
+  in the signature is the return type, the remainder represent arguments
+  to the function.
 */
-static AggregateType* createOrFindFunTypeFromAnnotation(AList &arg_list, CallExpr *call) {
-  AggregateType *parent;
-
-  SymExpr *retTail = toSymExpr(arg_list.tail);
-  Type *retType = retTail->var->type;
-
-  std::string parent_name = buildParentName(arg_list, false, retType);
+static AggregateType* createOrFindFunTypeFromAnnotation(AList&     argList,
+                                                        CallExpr*  call) {
+  AggregateType* parent      = NULL;
+  SymExpr*       retTail     = toSymExpr(argList.tail);
+  Type*          retType     = retTail->var->type;
+  std::string    parent_name = buildParentName(argList, false, retType);
 
   if (functionTypeMap.find(parent_name) != functionTypeMap.end()) {
     parent = functionTypeMap[parent_name].first;
 
   } else {
-    parent                  = createAndInsertFunParentClass(call, parent_name.c_str());
-    FnSymbol* parent_method = createAndInsertFunParentMethod(call, parent, arg_list, false, retType);
+    FnSymbol* parentMethod = NULL;
 
-    functionTypeMap[parent_name] = std::pair<AggregateType*, FnSymbol*>(parent, parent_method);
+    parent       = createAndInsertFunParentClass(call,
+                                                 parent_name.c_str());
+    parentMethod = createAndInsertFunParentMethod(call,
+                                                  parent,
+                                                  argList,
+                                                  false,
+                                                  retType);
+
+    functionTypeMap[parent_name] = std::pair<AggregateType*,
+                                             FnSymbol*>(parent, parentMethod);
   }
 
   return parent;
 }
 
 /*
-  Captures a function as a first-class value by creating an object that will represent the function.  The class is
-  created at the same scope as the function being referenced.  Each class is unique and shared among all
-  uses of that function as a value.  Once built, the class will override the .this method of the parent and wrap
-  the call to the function being captured as a value.  Then, an instance of the class is instantiated and returned.
+  Captures a function as a first-class value by creating an object that will
+  represent the function.  The class is created at the same scope as the
+  function being referenced.  Each class is unique and shared among all
+  uses of that function as a value.  Once built, the class will override
+  the .this method of the parent and wrap the call to the function being
+  captured as a value.  Then, an instance of the class is instantiated and
+  returned.
 */
-static Expr*
-createFunctionAsValue(CallExpr *call) {
+static Expr* createFunctionAsValue(CallExpr *call) {
   static int unique_fcf_id = 0;
-  UnresolvedSymExpr* use = toUnresolvedSymExpr(call->get(1));
-  INT_ASSERT(use);
-  const char *flname = use->unresolved;
 
-  Vec<FnSymbol*> visibleFns;
-  Vec<BlockStmt*> visited;
-  getVisibleFunctions(getVisibilityBlock(call), flname, visibleFns, visited, call);
+  UnresolvedSymExpr* use    = toUnresolvedSymExpr(call->get(1));
+  const char*        flname = use->unresolved;
+
+  Vec<FnSymbol*>     visibleFns;
+  Vec<BlockStmt*>    visited;
+
+  getVisibleFunctions(getVisibilityBlock(call),
+                      flname,
+                      visibleFns,
+                      visited,
+                      call);
 
   if (visibleFns.n > 1) {
     USR_FATAL(call, "%s: can not capture overloaded functions as values",
@@ -8485,7 +8630,9 @@ static void resolveAutoCopies() {
     if (ts->hasFlag(FLAG_SYNTACTIC_DISTRIBUTION))
       continue; // Skip the "dmapped" pseudo-type.
 
-    if (isRecord(ts->type) || isSyncType(ts->type)) {
+    if (isRecord(ts->type)   ||
+        isSyncType(ts->type) ||
+        isSingleType(ts->type)) {
       resolveAutoCopy(ts->type);
       resolveAutoDestroy(ts->type);
     }
@@ -8872,14 +9019,18 @@ static void insertReturnTemps() {
       if (FnSymbol* fn = call->isResolved()) {
         if (fn->retType != dtVoid) {
           ContextCallExpr* contextCall = toContextCallExpr(call->parentExpr);
-          Expr* contextCallOrCall; // insert before, remove it
+          Expr*            contextCallOrCall; // insert before, remove it
+
           if (contextCall) {
             contextCallOrCall = contextCall;
             // Only consider the designated call; the other
             // call need not be considered by this transformation.
             if (call != getDesignatedCall(contextCall))
               continue;
-          } else contextCallOrCall = call;
+          } else {
+            contextCallOrCall = call;
+          }
+
           Expr* parent = contextCallOrCall->parentExpr;
 
           if (!isCallExpr(parent) && !isDefExpr(parent)) { // no use
@@ -8892,19 +9043,25 @@ static void insertReturnTemps() {
 
             contextCallOrCall->insertBefore(def);
 
-            if (!fMinimalModules &&
-                ((fn->retType->getValType() &&
-                  isSyncType(fn->retType->getValType())) ||
-                 isSyncType(fn->retType) ||
-                 fn->isIterator())) {
-              CallExpr* sls = new CallExpr("_statementLevelSymbol", tmp);
+            if (fMinimalModules == false) {
+              if ((fn->retType->getValType() &&
+                   (isSyncType(fn->retType->getValType()) ||
+                    isSingleType(fn->retType->getValType())))         ||
 
-              contextCallOrCall->insertBefore(sls);
-              reset_ast_loc(sls, call);
-              resolveCallAndCallee(sls);
+                  isSyncType(fn->retType)                             ||
+                  isSingleType(fn->retType)                           ||
+                  fn->isIterator()) {
+                CallExpr* sls = new CallExpr("_statementLevelSymbol", tmp);
+
+                contextCallOrCall->insertBefore(sls);
+                reset_ast_loc(sls, call);
+                resolveCallAndCallee(sls);
+              }
             }
 
-            def->insertAfter(new CallExpr(PRIM_MOVE, tmp, contextCallOrCall->remove()));
+            def->insertAfter(new CallExpr(PRIM_MOVE,
+                                          tmp,
+                                          contextCallOrCall->remove()));
           }
         }
       }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4819,7 +4819,7 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
        if (!getRecordWrappedFlags(ts).any() &&
            !ts->hasFlag(FLAG_ITERATOR_CLASS) &&
            !ts->hasFlag(FLAG_ITERATOR_RECORD) &&
-           !getSyncFlags(ts).any()) {
+           !isSyncType(ts->type)) {
          if (fn->hasFlag(FLAG_BEGIN)) {
            // autoCopy/autoDestroy will be added later, in parallel pass
            // by insertAutoCopyDestroyForTaskArg()
@@ -8478,13 +8478,14 @@ static void resolveAutoCopies() {
   forv_Vec(TypeSymbol, ts, gTypeSymbols) {
     if (!ts->defPoint->parentSymbol)
       continue; // Type is not in tree
+
     if (ts->hasFlag(FLAG_GENERIC))
       continue; // Consider only concrete types.
+
     if (ts->hasFlag(FLAG_SYNTACTIC_DISTRIBUTION))
       continue; // Skip the "dmapped" pseudo-type.
 
-    if (isRecord(ts->type) || getSyncFlags(ts).any())
-    {
+    if (isRecord(ts->type) || isSyncType(ts->type)) {
       resolveAutoCopy(ts->type);
       resolveAutoDestroy(ts->type);
     }

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -566,11 +566,14 @@ instantiateTypeForTypeConstructor(FnSymbol* fn, SymbolMap& subs, CallExpr* call,
   // mark star tuples, add star flag
   //
   if (!fn->hasFlag(FLAG_TUPLE) && newType->symbol->hasFlag(FLAG_TUPLE)) {
-    bool markStar = true;
+    bool  markStar = true;
     Type* starType = NULL;
+
     form_Map(SymbolMapElem, e, subs) {
       TypeSymbol* ts = toTypeSymbol(e->value);
+
       INT_ASSERT(ts && ts->type);
+
       if (starType == NULL) {
         starType = ts->type;
       } else if (starType != ts->type) {
@@ -578,32 +581,47 @@ instantiateTypeForTypeConstructor(FnSymbol* fn, SymbolMap& subs, CallExpr* call,
         break;
       }
     }
+
     if (markStar)
       newType->symbol->addFlag(FLAG_STAR_TUPLE);
   }
 
   renameInstantiatedType(newType->symbol, subs, fn);
+
   fn->retType->symbol->defPoint->insertBefore(new DefExpr(newType->symbol));
+
   newType->symbol->copyFlags(fn);
-  if (isSyncType(newType))
+
+  if (isSyncType(newType) || isSingleType(newType))
     newType->defaultValue = NULL;
+
   newType->substitutions.copy(fn->retType->substitutions);
+
   // Add dispatch parents, but replace parent type with
   // instantiated parent type.
   forv_Vec(Type, t, fn->retType->dispatchParents) {
     Type *useT = t;
-    if (t == oldParentTy) useT = newParentTy;
+
+    if (t == oldParentTy)
+      useT = newParentTy;
+
     newType->dispatchParents.add(useT);
   }
 
   forv_Vec(Type, t, fn->retType->dispatchParents) {
     Type *useT = t;
-    if (t == oldParentTy) useT = newParentTy;
+
+    if (t == oldParentTy)
+      useT = newParentTy;
+
     bool inserted = useT->dispatchChildren.add_exclusive(newType);
+
     INT_ASSERT(inserted);
   }
+
   if (newType->dispatchChildren.n)
     INT_FATAL(fn, "generic type has subtypes");
+
   newType->instantiatedFrom = fn->retType;
   newType->substitutions.map_union(subs);
   newType->symbol->removeFlag(FLAG_GENERIC);

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -505,7 +505,7 @@ static void addArgCoercion(FnSymbol* fn, CallExpr* call, ArgSymbol* formal,
   actualExpr = newActual;
   actualSym  = castTemp;
 
-  if (getSyncFlags(ats).any()) {
+  if (isSyncType(ats->type) == true) {
 
     // Tom notes: Ultimately, I hope to push all code related to sync
     // variable implementation into module code.  Moving the special

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -171,25 +171,35 @@ buildDefaultWrapper(FnSymbol* fn,
     wrapper->retType = fn->retType;
 
   SymbolMap copy_map;
+
   bool specializeDefaultConstructor =
     fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR) &&
-    !isSyncType(fn->_this->type) &&
+    !isSyncType(fn->_this->type)          &&
+    !isSingleType(fn->_this->type)        &&
     !fn->_this->type->symbol->hasFlag(FLAG_REF);
   if (specializeDefaultConstructor) {
     wrapper->removeFlag(FLAG_COMPILER_GENERATED);
     wrapper->_this = fn->_this->copy();
+
     copy_map.put(fn->_this, wrapper->_this);
+
     wrapper->insertAtTail(new DefExpr(wrapper->_this));
+
     if (defaults->v[defaults->n-1]->hasFlag(FLAG_IS_MEME)) {
       if (!isRecord(fn->_this->type) && !isUnion(fn->_this->type)) {
-        wrapper->insertAtTail(new CallExpr(PRIM_MOVE, wrapper->_this,
+        wrapper->insertAtTail(new CallExpr(PRIM_MOVE,
+                                           wrapper->_this,
                                            callChplHereAlloc((wrapper->_this->typeInfo())->symbol)));
+
         wrapper->insertAtTail(new CallExpr(PRIM_SETCID, wrapper->_this));
       }
     }
+
     wrapper->insertAtTail(new CallExpr(PRIM_INIT_FIELDS, wrapper->_this));
   }
+
   CallExpr* call = new CallExpr(fn);
+
   call->square = info->call->square;    // Copy square brackets call flag.
 
   // Now walk the formals list of the called function, and expand formal
@@ -470,16 +480,20 @@ static bool needToAddCoercion(Type* actualType, Symbol* actualSym,
 
 // Add a coercion; replace prevActual and actualSym - the actual to 'call' -
 // with the result of the coercion.
-static void addArgCoercion(FnSymbol* fn, CallExpr* call, ArgSymbol* formal,
-                           Expr*& actualExpr, Symbol*& actualSym,
-                           bool& checkAgain)
+static void addArgCoercion(FnSymbol*  fn,
+                           CallExpr*  call,
+                           ArgSymbol* formal,
+                           Expr*&     actualExpr,
+                           Symbol*&   actualSym,
+                           bool&      checkAgain)
 {
-  Expr* prevActual = actualExpr;
-  SET_LINENO(prevActual);
-  TypeSymbol* ats = actualSym->type->symbol;
-  TypeSymbol* fts = formal->type->symbol;
-  CallExpr* castCall;
-  VarSymbol* castTemp = newTemp("coerce_tmp"); // ..., formal->type ?
+  SET_LINENO(actualExpr);
+
+  Expr*       prevActual = actualExpr;
+  TypeSymbol* ats        = actualSym->type->symbol;
+  TypeSymbol* fts        = formal->type->symbol;
+  CallExpr*   castCall   = NULL;
+  VarSymbol*  castTemp   = newTemp("coerce_tmp"); // ..., formal->type ?
 
   castTemp->addFlag(FLAG_COERCE_TEMP);
 
@@ -499,20 +513,14 @@ static void addArgCoercion(FnSymbol* fn, CallExpr* call, ArgSymbol* formal,
   } else {
     prevActual->replace(newActual);
   }
+
   // Now 'prevActual' has been removed+replaced and is ready to be passed
   // as an actual to a cast or some such.
   // We can update addArgCoercion's caller right away.
   actualExpr = newActual;
   actualSym  = castTemp;
 
-  if (isSyncType(ats->type) == true) {
-
-    // Tom notes: Ultimately, I hope to push all code related to sync
-    // variable implementation into module code.  Moving the special
-    // handling of sync demotion (i.e. extracting the underlying value
-    // from a sync variable) into module code would render this
-    // special-case code in the compiler moot.
-
+  if (isSyncType(ats->type) == true || isSingleType(ats->type) == true) {
     // Here we will often strip the type of its sync-ness.
     // After that we may need another coercion(s), e.g.
     //   _syncvar(int) --readFE()-> _ref(int) --(dereference)-> int --> real


### PR DESCRIPTION
Currently isSyncType() really means "is a sync or single?".  Additionally some parts of the code
check for sync/single with a call to isSyncType() and some use getSyncFlags().

1) Replace uses of getSyncFlags() with isSyncType() and drop getSyncFlags()

2) Introduce isSingleType(), revise isSyncType(), and update call sites to isSyncType().

3) While updating the call sites for isSyncType(), take the opportunity to do some local
"whitespace" cleanup.  Primarily aim for 80 column goal in the enclosing functions/comments.


Compiled on clang/darwin and gcc/linux64 with/without CHPL_DEVELOPER
Tested on std-linux64 and gasnet-linux64.
