### PR TITLE
Remove .suppressifs for now passing tests

### DIFF
--- a/test/npb/ft/ft-serial.suppressif
+++ b/test/npb/ft/ft-serial.suppressif
@@ -1,2 +1,0 @@
-# Problem with C99 complex when optimizations with PGI are -O2 or higher.
-CHPL_TARGET_COMPILER <= pgi

--- a/test/performance/compiler/bradc/fft-timecomp.suppressif
+++ b/test/performance/compiler/bradc/fft-timecomp.suppressif
@@ -1,2 +1,0 @@
-# Problem with C99 complex when optimizations with PGI are -O2 or higher.
-CHPL_TARGET_COMPILER <= pgi


### PR DESCRIPTION
ft-serial and fft-timecomp had been failing with PGI at -O2 or higher, so they
were suppressed.  PR #4033 (e39fb104a) made some functions that were giving
PGI problems "static inline", and these tests now work with PGI and -O2.