### PR TITLE
Fix various stencil slicing issues

### DIFF
--- a/test/distributions/bharshbarg/stencil/rankChange.chpl
+++ b/test/distributions/bharshbarg/stencil/rankChange.chpl
@@ -1,0 +1,22 @@
+use StencilDist;
+
+config const n = 5;
+
+var Dom = {1..n,1..n};
+var Space = Dom dmapped Stencil(Dom, fluff=(2,3));
+
+for (a, b) in zip(Dom[1,..], Space[1,..]) {
+  assert(a == b);
+}
+var A : [Space] int;
+A = 9;
+A.updateFluff();
+
+ref first = A[1,..];
+writeln("Fluff = ", first._value.dom.dist.fluff);
+first = 0;
+A.updateFluff();
+
+for a in A[1,..] do assert(a == 0);
+for a in A[n,..] do assert(a == 9);
+writeln("SUCCESS!");

--- a/test/distributions/bharshbarg/stencil/rankChange.good
+++ b/test/distributions/bharshbarg/stencil/rankChange.good
@@ -1,0 +1,2 @@
+Fluff = (3)
+SUCCESS!

--- a/test/distributions/bharshbarg/stencil/slice.chpl
+++ b/test/distributions/bharshbarg/stencil/slice.chpl
@@ -1,0 +1,90 @@
+use StencilDist;
+use util;
+
+proc test(dom : domain) {
+  param rank = dom.rank;
+  var fluff : rank * int;
+  for i in 1..rank do fluff(i) = 2;
+
+  const max = dom.expand(fluff*dom.stride);
+
+  var Space = dom dmapped Stencil(dom, fluff=fluff, periodic=true);
+
+  {
+    var rs : rank*range;
+    rs(1) = 1..dom.dim(1).size/2;
+    for param i in 2..rank do rs(i) = Space.dim(i);
+    var HalfOne = Space[(...rs)];
+    assert(HalfOne._value.fluff == fluff);
+
+    var Data : [Space] int;
+    ref Same = Data[Space];
+    // Make sure the fluff is still there
+    assert(Data._value.dom.fluff == Same._value.dom.fluff);
+    ref Half = Data[HalfOne];
+    assert(Data._value.dom.fluff == Half._value.dom.fluff);
+
+    forall idx in Space {
+      var temp = if isTuple(idx) then idx else (idx,);
+      var m = 1;
+      for i in temp do m *= i;
+      assert(m != 0);
+      Data[idx] = m;
+    }
+    Data.updateFluff();
+
+    // Make sure the slice can see changes
+    const sub = Half.localSubdomain();
+    const max = sub.expand(fluff*dom.stride);
+    for m in max {
+      var idx = if isTuple(m) then m else (m,);
+      if !Space.member(idx) {
+        for param i in 1..rank {
+          if idx(i) < Space.dim(i).low then idx(i) += Space.dim(i).size*Space.dim(i).stride;
+          else if idx(i) > Space.dim(i).high then idx(i) -= Space.dim(i).size * Space.dim(i).stride;
+        }
+      }
+      assert(Half(m) == Data[idx]);
+    }
+  }
+
+  {
+    var Data : [Space] int;
+    ref Actual = Data.noFluffView();
+    assert(Actual._value.dom.whole == Actual._value.dom.wholeFluff);
+
+    Data[Space.low] = 42;
+    // Ensure that we didn't somehow create a new array with noFluffView
+    assert(Actual[Space.low] == Data[Space.low]);
+
+    forall idx in Space {
+      var temp = if isTuple(idx) then idx else (idx,);
+      var m = 1;
+      for i in temp do m *= i;
+      assert(m != 0);
+      Data[idx] = m;
+    }
+
+    // Assert that we can read remote values without having to call updateFluff
+    on Locales[numLocales-1] {
+      const sub = Data.localSubdomain();
+      const max = sub.expand(fluff*dom.stride);
+      for idx in max {
+        var temp = if isTuple(idx) then idx else (idx,);
+        // Only look at indices in 'Space' since no updateFluff call has
+        // occurred.
+        if Space.member(idx) {
+          var m = 1;
+          for i in temp do m *= i;
+          assert(Actual[idx] == m);
+        }
+      }
+    }
+  }
+}
+
+test({1..40});
+test({1..10, 1..10});
+test({10..50, 10..50});
+test({1..10, 1..10, 1..10});
+writeln("SUCCESS");

--- a/test/distributions/bharshbarg/stencil/slice.good
+++ b/test/distributions/bharshbarg/stencil/slice.good
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test/distributions/bharshbarg/stencil/util.chpl
+++ b/test/distributions/bharshbarg/stencil/util.chpl
@@ -3,6 +3,7 @@ proc verifyStencil(A : [?dom], debug = false) {
   // Domain where each dim is "-1..1"
   param rank = dom.rank;
   const halo = dom._value.fluff;
+  assert(dom._value.periodic);
   var Neighs : domain(rank);
   {
     var n : rank*range;
@@ -12,7 +13,8 @@ proc verifyStencil(A : [?dom], debug = false) {
 
   // Build each ghost domain and check it against the actual data to confirm
   // the update occurred correctly
-  for neigh in Neighs {
+  for n in Neighs {
+    const neigh = if isTuple(n) then n else (n,);
     const base : rank*int;
     if neigh == base then continue; // skip when neigh is all 0s
 
@@ -36,7 +38,7 @@ proc verifyStencil(A : [?dom], debug = false) {
     if debug then writeln("\tComparing ", gdom, " vs. ", adom);
     for (g, a) in zip(gdom, adom) {
       if A[g] != A[a] {
-        writeln("Failed when domain is: ", dom);
+        writeln("Failed when domain is: ", dom, ". Ghost = ", gdom, "; actual = ", adom);
         halt();
       }
     }

--- a/test/release/examples/benchmarks/miniMD/helpers/initMD.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/initMD.chpl
@@ -222,14 +222,16 @@ const NeighDom = {-1..1, -1..1, -1..1};
 
 // atom positions
 var Pos: [DistSpace] [perBinSpace] v3;
-var RealPos => Pos[binSpace];
+var RealPos => if useStencilDist then Pos.noFluffView()
+               else Pos[binSpace];
 
 // atom velocity, force, and neighbor lists
 var Bins: [Space] [perBinSpace] atom;
 
 // bin counts
 var Count: [DistSpace] int(32);
-var RealCount => Count[binSpace];
+var RealCount => if useStencilDist then Count.noFluffView()
+                 else Count[binSpace];
 
 // offsets used to wrap ghosts
 var PosOffset: [NeighDom] v3;


### PR DESCRIPTION
As an intern, I made an incorrect decision that slicing a StencilDist should drop all fluff for the resulting array. At the time this allowed me to get a view of the stencil-distributed array without any cached data. This allows the user to read from the remote/actual/uncached data without having to call updateFluff, as if it were a Block-distributed array.

For general usage though, this is the entirely wrong decision. This PR fixes StencilDist slicing to preserve fluff and adds a new function on arrays called 'noFluffView'. Also fixes some obvious bugs with rank changing and 1D stencils. Two new tests are added to lock in this behavior.