### PR TITLE
Support for comparators in Search module

### DIFF
--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,103 @@
    over time.
  */
 module Search {
+  use Sort;
 
+/*
+   General purpose searching interface for searching through a pre-sorted array.
+
+   .. note:
+
+      This method calls a sequential binarySearch but it will call faster
+      algorithms once they are implemented.
+
+   :arg Data: The array to be sorted
+   :type Data: [] `eltType`
+   :arg val: The value to find in the array
+   :type val: `eltType`
+   :arg comparator: :ref: Comparator <comparators> record that defines how the
+      data is sorted.
+
+   :returns: A tuple indicating (1) if the value was found and (2) the location
+      of the value if it was found or the location where the value should have
+      been if it was not found.
+   :rtype: (`bool`, `Data.domain.type`)
+ */
+proc search(Data:[?Dom], val, comparator:?rec=defaultComparator) {
+  return binarySearch(Data, val, comparator);
+}
+
+
+/*
+   Searches through the pre-sorted array `Data` looking for the value `val` using
+   a sequential linear search.  Returns a tuple indicating (1) whether or not
+   the value was found and (2) the location of the value if it was found, or
+   the location where the value should have been if it was not found.
+
+   :arg Data: The sorted array to search
+   :type Data: [] `eltType`
+   :arg val: The value to find in the array
+   :type val: `eltType`
+   :arg comparator: :ref: Comparator <comparators> record that defines how the
+      data is sorted.
+
+   :returns: A tuple indicating (1) if the value was found and (2) the location
+      of the value if it was found or the location where the value should have
+      been if it was not found.
+   :rtype: (`bool`, `Data.domain.type`)
+
+ */
+proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator) {
+  chpl_check_comparator(comparator, Data.eltType);
+  for i in Dom {
+    if chpl_compare(Data[i], val, comparator=comparator) == 0 then
+      return (true, i);
+    else if chpl_compare(Data[i], val, comparator=comparator) > 0 then
+      return (false, i);
+  }
+  return (false, Dom.high+1);
+}
+
+
+/*
+   Searches through the pre-sorted array `Data` looking for the value `val`
+   using a sequential binary search.  If provided, only the indices `lo`
+   through `hi` will be considered, otherwise the whole array will be
+   searched. Returns a tuple indicating (1) whether or not the value was
+   found and (2) the location of the value if it was found, or the location
+   where the value should have been if it was not found.
+
+   :arg Data: The sorted array to search
+   :type Data: [] `eltType`
+   :arg val: The value to find in the array
+   :type val: `eltType`
+   :arg comparator: :ref: Comparator <comparators> record that defines how the
+      data is sorted.
+
+   :returns: A tuple indicating (1) if the value was found and (2) the location
+      of the value if it was found or the location where the value should have
+      been if it was not found.
+   :rtype: (`bool`, `Data.domain.type`)
+
+ */
+proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator) {
+  var lo = Dom.low,
+      hi = Dom.high;
+
+  while (lo <= hi) {
+    const mid = (hi - lo)/2 + lo;
+    if chpl_compare(Data[mid], val, comparator=comparator) == 0 then
+      return (true, mid);
+    else if chpl_compare(val, Data[mid], comparator=comparator) > 0 then
+      lo = mid+1;
+    else
+      hi = mid-1;
+  }
+  return (false, lo);
+}
+
+pragma "no doc"
+// TODO -- deprecate
 /*
    Searches through the pre-sorted array `Data` looking for the value `val` using
    a sequential linear search.  Returns a tuple indicating (1) whether or not
@@ -48,8 +144,10 @@ proc LinearSearch(Data:[?Dom], val) {
 }
 
 
+pragma "no doc"
 // would really like to drop the lo/hi arguments here, but right now
 // that causes too big of a memory leak
+// TODO -- deprecate
 /*
    Searches through the pre-sorted array `Data` looking for the value `val`
    using a sequential binary search.  If provided, only the indices `lo`

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -28,16 +28,14 @@ module Search {
 /*
    General purpose searching interface for searching through a pre-sorted array.
 
-   .. note:
-
-      This method calls a sequential binarySearch but it will call faster
-      algorithms once they are implemented.
+   .. note:: Currently this method calls a sequential :proc:`binarySearch`, but
+             this may change the future as other algorithms are implemented.
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
    :arg val: The value to find in the array
    :type val: `eltType`
-   :arg comparator: :ref: Comparator <comparators> record that defines how the
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
       data is sorted.
 
    :returns: A tuple indicating (1) if the value was found and (2) the location
@@ -60,7 +58,7 @@ proc search(Data:[?Dom], val, comparator:?rec=defaultComparator) {
    :type Data: [] `eltType`
    :arg val: The value to find in the array
    :type val: `eltType`
-   :arg comparator: :ref: Comparator <comparators> record that defines how the
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
       data is sorted.
 
    :returns: A tuple indicating (1) if the value was found and (2) the location
@@ -93,7 +91,7 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator) {
    :type Data: [] `eltType`
    :arg val: The value to find in the array
    :type val: `eltType`
-   :arg comparator: :ref: Comparator <comparators> record that defines how the
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
       data is sorted.
 
    :returns: A tuple indicating (1) if the value was found and (2) the location

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -43,7 +43,7 @@ module Search {
       been if it was not found.
    :rtype: (`bool`, `Data.domain.type`)
  */
-proc search(Data:[?Dom], val, comparator:?rec=defaultComparator) {
+proc search(Data:[?Dom], val, comparator:?rec=defaultComparator) where Dom.rank == 1 {
   return binarySearch(Data, val, comparator);
 }
 
@@ -67,7 +67,7 @@ proc search(Data:[?Dom], val, comparator:?rec=defaultComparator) {
    :rtype: (`bool`, `Data.domain.type`)
 
  */
-proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator) {
+proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator) where Dom.rank == 1 {
   chpl_check_comparator(comparator, Data.eltType);
   for i in Dom {
     if chpl_compare(Data[i], val, comparator=comparator) == 0 then
@@ -100,7 +100,7 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator) {
    :rtype: (`bool`, `Data.domain.type`)
 
  */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator) {
+proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator) where Dom.rank == 1 {
   var lo = Dom.low,
       hi = Dom.high;
 

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -203,13 +203,14 @@ inline proc chpl_compare(a, b, comparator:?rec=defaultComparator) {
 }
 
 
+pragma "no doc"
 /*
     Check if a comparator was passed and confirm that it will work, otherwise
     throw a compile-time error.
 
     :arg a: Sample data passed to confirm that comparator methods can resolve
-    :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
 
  */
 proc chpl_check_comparator(comparator, type eltType) {
@@ -246,15 +247,13 @@ proc chpl_check_comparator(comparator, type eltType) {
 /*
    General purpose sorting interface.
 
-   .. note:
-
-      This method calls a sequential quickSort but it will call faster algorithms
-      once they are implemented.
+   .. note:: Currently this method calls a sequential :proc:`quickSort`, but
+             this may change the future as other algorithms are implemented.
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
-   :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
 
  */
 proc sort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) where Dom.rank == 1 {
@@ -267,8 +266,8 @@ proc sort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) where Dom.ra
 
    :arg Data: The array to verify
    :type Data: [] `eltType`
-   :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
    :returns: ``true`` if array is sorted
    :rtype: `bool`
  */
@@ -305,8 +304,8 @@ proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator): bool {
 
    :arg x: An iterable value to be sorted and yielded element by element
    :type x: `iterable`
-   :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
 
    :yields: The elements of x in sorted order
    :ytype: x's element type
@@ -327,8 +326,8 @@ iter sorted(x, comparator:?rec=defaultComparator) {
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
-   :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
 
  */
 proc bubbleSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) where Dom.rank == 1 {
@@ -354,8 +353,8 @@ proc bubbleSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) where 
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
-   :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
 
  */
 proc heapSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) where Dom.rank == 1 {
@@ -402,8 +401,8 @@ proc heapSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) where Do
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
-   :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
 
  */
 proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) where Dom.rank == 1 {
@@ -433,10 +432,10 @@ proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) whe
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
-   :arg minlen: When the array size is less than `minlen` use insertion sort algorithm
+   :arg minlen: When the array size is less than `minlen` use :proc:`insertionSort` algorithm
    :type minlen: `integral`
-   :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
 
  */
 proc mergeSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparator) where Dom.rank == 1 {
@@ -494,10 +493,10 @@ private iter _MergeIterator(A1: [] ?eltType, A2: [] eltType, comparator:?rec=def
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
-   :arg minlen: When the array size is less than `minlen` use insertion sort algorithm
+   :arg minlen: When the array size is less than `minlen` use :proc:`insertionSort` algorithm
    :type minlen: `integral`
-   :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
 
  */
 proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparator) where Dom.rank == 1 {
@@ -609,8 +608,8 @@ record ReverseComparator {
    Constructor - builds a comparator with a compare method that reverses the sort order of
    the argument-provided comparator.
 
-   :arg comparator: Record that redefines the comparison mechanism with one of
-      the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
 
    */
   proc ReverseComparator(comparator:?rec=defaultComparator) {}
@@ -690,7 +689,7 @@ pragma "no doc"
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
-   :arg minlen: When the array size is less than `minlen` use insertion sort algorithm
+   :arg minlen: When the array size is less than `minlen` use :proc:`insertionSort` algorithm
    :type minlen: `integral`
    :arg doublecheck: Verify the array is correctly sorted before returning
    :type doublecheck: `bool`

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -24,6 +24,8 @@ This module supports a variety of standard sorting routines on 1D arrays.
 The current interface is minimal and should be expected to
 grow and evolve over time.
 
+.. _comparators:
+
 Comparators
 -----------
 
@@ -131,7 +133,7 @@ reverse the default sorting order.
   var Array = [-1, -4, 2, 3];
 
   // Using module-defined 'reverseComparator'
-  sort(Array, comparator=reverseComparator)
+  sort(Array, comprator=reverseComparator)
 
   // This will output: 3, 2, -1, -4
   writeln(Array);
@@ -182,8 +184,9 @@ const reverseComparator: ReverseComparator(DefaultComparator);
 
 /* Private methods */
 
+pragma "no doc"
 /* Base compare method of all sort functions */
-private inline proc chpl_compare(a, b, comparator:?rec=defaultComparator) {
+inline proc chpl_compare(a, b, comparator:?rec=defaultComparator) {
   use Reflection;
 
   // TODO -- In cases where values are larger than keys, it may be faster to
@@ -209,7 +212,7 @@ private inline proc chpl_compare(a, b, comparator:?rec=defaultComparator) {
       the methods: ``comparator.key(a)`` or ``comparator.compare(a,b)``
 
  */
-private proc chpl_check_comparator(comparator, type eltType) {
+proc chpl_check_comparator(comparator, type eltType) {
   use Reflection;
 
   // Dummy data for checking method resolution

--- a/test/modules/packages/Search/correctness.chpl
+++ b/test/modules/packages/Search/correctness.chpl
@@ -1,0 +1,102 @@
+/*
+ *  Check correctness of search functions
+ */
+
+use Search;
+
+proc main() {
+
+  var result: (bool, int);
+
+  // Sorted arrays
+  const    Arr = [-4, -1, 2, 3],
+        ArrAbs = [-1, 2, 3, -4],
+        ArrRev = [ 3, 2, -1, -4],
+     ArrAbsRev = [ -4, 3, 2, -1],
+        StrArr = ['Brad', 'anthony', 'ben', 'david'];
+
+  // Comparators
+  const key = new keycomparator(),
+        compare = new compcomparator(),
+        tuplekey = new tuplecomparator();
+
+
+  /* Test data types */
+
+  // Integers
+  result = search(Arr, 2);
+  checkSearch(result, (true, 3), Arr, 'search');
+
+  // Strings
+  result = search(StrArr, 'ben');
+  checkSearch(result, (true, 3), StrArr, 'search');
+
+  // Integers sorted as tuples
+  result = search(Arr, 2, comparator=tuplekey);
+  checkSearch(result, (true, 3), Arr, 'search', 'tuplekey');
+
+  /* Reverse */
+
+  // Default reversecomparator
+  result = search(ArrRev, 2, comparator=reverseComparator);
+  checkSearch(result, (true, 2), ArrRev, 'search');
+
+  /* Comparator basics */
+  result = search(ArrAbs, 2, comparator=key);
+  checkSearch(result, (true, 2), ArrAbs, 'search', 'key');
+
+  result = search(ArrAbs, 2, comparator=compare);
+  checkSearch(result, (true, 2), ArrAbs, 'search', 'compare');
+
+  /* Not Found */
+
+  result = search(Arr, 5);
+  checkSearch(result, (false, Arr.domain.high+1), Arr, 'search');
+
+  result = search(Arr, -5);
+  checkSearch(result, (false, Arr.domain.low), Arr, 'search');
+
+  result = search(Arr, 0);
+  checkSearch(result, (false, 3), Arr, 'search');
+
+  /* Test Searches */
+
+  // linearSearch
+  result = linearSearch(Arr, 2);
+  checkSearch(result, (true, 3), Arr, 'linearSearch');
+
+  // binarySearch
+  result = binarySearch(Arr, 2);
+  checkSearch(result, (true, 3), Arr, 'binarySearch');
+
+}
+
+
+/* Checks array and resets values -- any output results in failure */
+proc checkSearch(result, expected, array, searchProc:string, comparator:string='none') {
+  if result != expected {
+    writeln(searchProc, ' with comparator=', comparator, ' failed');
+    writeln('For array:');
+    writeln(array);
+    writeln('Incorrect result:');
+    writeln(result);
+    writeln('Expected result:');
+    writeln(expected);
+  }
+}
+
+
+/* Defines manipulation of value that should be used for comparison */
+record keycomparator { }
+proc keycomparator.key(a) { return abs(a); }
+
+
+/* Defines compare behavior, return 1, 0, or -1 */
+record compcomparator { }
+proc compcomparator.compare(a, b) {
+  return abs(a) - abs(b);
+}
+
+/* Key method can return a non-numerical/string type, such as tuple */
+record tuplecomparator { }
+proc tuplecomparator.key(a) { return (a, a); }


### PR DESCRIPTION
@e-kayrakli pointed out that the Search module methods assert that the array being searched is pre-sorted. This PR adds support for comparators in the Search module routines, so that a user can specify _how_ the data is sorted.

Other changes include:

* Making Search module dependent on Sort module
* Making some private functions in Sort public, so they may be utilized by Search module (still `pragma "no doc"` because they are not meant for users)
* Added a test for Search module (minimal testing coverage existed prior to this PR)
* Polished some documentation in both Search and Sort modules

`[Summary: #Successes = 6281 | #Failures = 0 | #Futures = 0]`