### PR TITLE
Attempt to quiet chameneosredux-race (round 4)

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-race.skipif
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-race.skipif
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+# skip this test for numa perf testing, it takes too long in that config
+import os
+
+numa = os.getenv('CHPL_LOCALE_MODEL', '') == 'numa'
+perf_test = os.getenv('CHPL_TEST_PERF', '') == 'on'
+
+print(numa and perf_test)


### PR DESCRIPTION
Skip chameneosredux-race for numa performance testing, it's just too slow in
that configuration.