### PR TITLE
Annotations for complex change and gcc update

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -135,9 +135,7 @@ all:
   05/31/16:
     - Enable jemalloc's decay-based purging (#3926)
   06/06/16:
-    - Avoid allocating arg bundles for local on statements (#3890)
-  06/06/16:
-    - Upgrade target compiler versions (#218, internal)
+    - Avoid allocating arg bundles for local on statements (#3890) && Upgrade target compiler versions (#218, internal)
 
 AllCompTime:
   11/09/14:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -136,6 +136,8 @@ all:
     - Enable jemalloc's decay-based purging (#3926)
   06/06/16:
     - Avoid allocating arg bundles for local on statements (#3890)
+  06/06/16:
+    - Upgrade target compiler versions (#218, internal)
 
 AllCompTime:
   11/09/14:
@@ -340,6 +342,8 @@ mandelbrot:
     - maxTaskPar change delayed fifo->qthreads performance hit
   11/11/15:
     - Initial commit of C complexes
+  06/16/16:
+    - Change complex getter functions for .re and .im into "static inline" (#4033)
 
 mandelbrot-extras:
   01/03/14:


### PR DESCRIPTION
2 new annotations:

* Upgrade target compiler versions (#218, internal)
* Change complex getter functions for .re and .im into "static inline" (#4033)

One of which was combined with another annotation, because our scripts + dygraph don't support overlapping annotations (yet!).
