### PR TITLE
Fix performance graphs with multiple annotations on the same day

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -135,7 +135,8 @@ all:
   05/31/16:
     - Enable jemalloc's decay-based purging (#3926)
   06/06/16:
-    - Avoid allocating arg bundles for local on statements (#3890) && Upgrade target compiler versions (#218, internal)
+    - Avoid allocating arg bundles for local on statements (#3890)
+    - Upgrade target compiler versions (#218, internal)
 
 AllCompTime:
   11/09/14:

--- a/util/test/annotate.py
+++ b/util/test/annotate.py
@@ -53,7 +53,7 @@ def get(data, graph, series, start, end, config_name):
   for i, date in enumerate(sorted(matches.keys()), start=1):
     date_string = time.strftime(_csv_date_format, date)
     ann_text = json.dumps('{0}: {1}'.format(date_string,
-      r'\n'.join(matches[date])))
+      '\n'.join(matches[date])))
     formatted.append(_annotation_format.format(
         series = series,
         x = date_string,


### PR DESCRIPTION
Previously we were generating `\\n` to split up multiple annotations on the same
day, but instead we just need to generate `\n` to actually render newlines

e.g.:

    06/06/16:
      - Avoid ... (#3890)
      - Upgrade ... (#218, internal)

rendered as

    2016-06-20: Avoid ... (#3890)\\nUpgrade ... (#218, internal)

instead of

    2016-06-20: Avoid ... (#3890)
    Upgrade ... (#218, internal)