### PR TITLE
Recognize and permit super.init() and this.init() calls (but don't act on them)

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -307,8 +307,18 @@ Expr* buildDotExpr(BaseAST* base, const char* member) {
     // chpl_localeID_to_locale(_wide_get_node(x)).
     return new CallExpr("chpl_localeID_to_locale",
                         new CallExpr(PRIM_WIDE_GET_LOCALE, base));
-  else
-    return new CallExpr(".", base, new_CStringSymbol(member));
+  else if (!strcmp("init", member)) {
+    // MAGIC: detect this.init and super.init calls
+    if (UnresolvedSymExpr* expr = toUnresolvedSymExpr(base)) {
+      if (!strcmp("super", expr->unresolved)) {
+        return new CallExpr(PRIM_SUPER_INIT);
+      } else if (!strcmp("this", expr->unresolved)) {
+        return new CallExpr(PRIM_THIS_INIT);
+      }
+    }
+  }
+  // fall through case
+  return new CallExpr(".", base, new_CStringSymbol(member));
 }
 
 

--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -87,6 +87,8 @@ void checkPrimitives()
 
       // These do not survive past resolution.
      case PRIM_INIT:
+     case PRIM_SUPER_INIT:
+     case PRIM_THIS_INIT:
      case PRIM_TYPE_TO_STRING:
      case PRIM_TO_LEADER:
      case PRIM_TO_FOLLOWER:

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -396,6 +396,8 @@ initPrimitive() {
   prim_def(PRIM_MOVE, "move", returnInfoVoid, false, true);
   prim_def(PRIM_INIT, "init", returnInfoFirstDeref);
   prim_def(PRIM_NO_INIT, "no init", returnInfoFirstDeref);
+  prim_def(PRIM_SUPER_INIT, "super init", returnInfoVoid);
+  prim_def(PRIM_THIS_INIT, "this init", returnInfoVoid);
   prim_def(PRIM_TYPE_INIT, "type init", returnInfoFirstDeref);
   prim_def(PRIM_REF_TO_STRING, "ref to string", returnInfoStringC);
   prim_def(PRIM_RETURN, "return", returnInfoFirst, true);

--- a/compiler/include/primitive.h
+++ b/compiler/include/primitive.h
@@ -34,6 +34,8 @@ enum PrimitiveTag {
   PRIM_MOVE,
   PRIM_INIT,
   PRIM_NO_INIT,
+  PRIM_SUPER_INIT,
+  PRIM_THIS_INIT,
   PRIM_TYPE_INIT,       // Used in a context where only a type is needed.
                         // Establishes the type of the result without
                         // generating code.

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -231,6 +231,8 @@ isFastPrimitive(CallExpr *call, bool isLocal) {
   case PRIM_NEW:
   case PRIM_INIT:
   case PRIM_NO_INIT:
+  case PRIM_SUPER_INIT:
+  case PRIM_THIS_INIT:
   case PRIM_TYPE_INIT:
   case PRIM_LOGICAL_FOLDER:
   case PRIM_TYPEOF:

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6015,6 +6015,14 @@ preFold(Expr* expr) {
         }
       }
 
+    } else if (call->isPrimitive(PRIM_SUPER_INIT)) {
+      result = new CallExpr(PRIM_NOOP);
+      call->replace(result);
+
+    } else if (call->isPrimitive(PRIM_THIS_INIT)) {
+      result = new CallExpr(PRIM_NOOP);
+      call->replace(result);
+
     } else if (call->isPrimitive(PRIM_TYPEOF)) {
       Type* type = call->get(1)->getValType();
       if (type->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE)) {

--- a/test/classes/initializers/brad-dispatch.future
+++ b/test/classes/initializers/brad-dispatch.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/parentCall/ifExplicitImplicit.future
+++ b/test/classes/initializers/parentCall/ifExplicitImplicit.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/parentCall/inIf.future
+++ b/test/classes/initializers/parentCall/inIf.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/accessThisGood.future
+++ b/test/classes/initializers/phase1/accessThisGood.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/hasIf.future
+++ b/test/classes/initializers/phase1/hasIf.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/hasIfImplicit.future
+++ b/test/classes/initializers/phase1/hasIfImplicit.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/hasLoopGood.future
+++ b/test/classes/initializers/phase1/hasLoopGood.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/localHelpers.future
+++ b/test/classes/initializers/phase1/localHelpers.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/omit.future
+++ b/test/classes/initializers/phase1/omit.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/orderedFields.future
+++ b/test/classes/initializers/phase1/orderedFields.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase2/methods.future
+++ b/test/classes/initializers/phase2/methods.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase2/thisUse.future
+++ b/test/classes/initializers/phase2/thisUse.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/user_def_default_initializer_const.future
+++ b/test/classes/initializers/user_def_default_initializer_const.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/user_def_unique_initializer_const.future
+++ b/test/classes/initializers/user_def_unique_initializer_const.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.


### PR DESCRIPTION
Prior to this change, calls to super.init() and this.init() would resolve
weirdly.  With this change, they will not cause compiler errors, but will
basically be treated as no-ops, allowing many of my tests with no-op
super.init() calls in them to function properly.  My next step is to cause
these calls to function - allow super.init() when the type has a parent class
to call the parent's initializer, and allow this.init() calls to call another
initializer on the type.

IMPLEMENTATION DETAILS:

We wouldn't be able to trace the init() portion to the appropriate
_construct_type function.  The AST was transformed sufficiently that the "super"
or "this" portion was separated from the init call, so resolving the call in
function resolution on its own would've relied on a large amount of strange AST
knowledge that could easily break at any time.

With that in mind, I decided to add a couple of primitives to the compiler,
PRIM_SUPER_INIT and PRIM_THIS_INIT.  Doing this allowed me to keep the
"super"/"this" portion associated with the "init" portion of the call.
Recognizing when to insert these primitives was a bit unfortunate - I had to
do a strcmp against all the names involved to be sure we were entering the right
case.  I decided to do this instead of causing the compiler to flag these
names as keywords, which in the case of "this" and "super" would've meant
updating a lot of our rules and logic associated with those names to use the
keywords instead.  As that seemed unfortunate and costly, adding new primitives
felt more reasonable.

I decided to add these primitives during build.cpp instead of later in the
compiler (say, scope resolution or normalize).  This seemed the most reasonable
place, since later places in the compiler will involve more work to
backtranslate the changes that have happened to the AST, and would just end up
removing the nodes that were placed there to start.

Because these calls are created through the parser's dot_expr rule, however,
some AST shuffling was required - dot_exprs are inserted into the AST as
a call, stored in the baseExpr field on a call with the arguments (i.e.
``call ( call base . modifier) args`` ).  This meant that we needed to
transform the whole expression so that the arguments would be applied to the
super.init or this.init call, instead of having normalize move the call away
from the arguments because it and function resolution thought it needed to
return an object to work with.  To fix this, I had normalize recognize the
primitives and squash the call into a single level
( i.e. `` call super.init args `` )

Then, to allow this change to work without leaving junk in the compiler with
my stub implementation, I had functionResolution change the primitives into
PRIM_NOOP.  This was able to be done at precisely the point where I want to
have function resolution determine what to do about those calls, thankfully.

I also removed .future files from the tests that now pass with this change.
With the exception of a couple, it seems unlikely these tests will need to
become futures again, in case you were curious.

Tested over std/