### PR TITLE
Cleaner local blocks

### DIFF
--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -426,8 +426,14 @@ GenRet BlockStmt::codegen() {
   codegenStmt(this);
 
   if (outfile) {
-    if (this != getFunction()->body)
+    if (this != getFunction()->body) {
+      if (this->blockInfoGet()) {
+        if (this->blockInfoGet()->isPrimitive(PRIM_BLOCK_LOCAL)) {
+          info->cStatements.push_back("/* local block */\n");
+        }
+      }
       info->cStatements.push_back("{\n");
+    }
 
     body.codegen("");
 

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -252,6 +252,15 @@ static void moveAddressSourcesToTemp();
 static void fixAST();
 static void handleIsWidePointer();
 
+static bool isLocalBlock(Expr* stmt) {
+  BlockStmt* block = toBlockStmt(stmt);
+  return block &&
+         block->parentSymbol &&
+         block->isLoopStmt() == false &&
+         block->blockInfoGet() &&
+         block->blockInfoGet()->isPrimitive(PRIM_BLOCK_LOCAL);
+}
+
 // Top-level wrapper
 static bool isCausedByArgs(FnSymbol* fn,
                            Symbol* sym,
@@ -2406,15 +2415,6 @@ void handleIsWidePointer() {
       call->replace(new SymExpr(isWide));
     }
   }
-}
-
-bool isLocalBlock(Expr* stmt) {
-  BlockStmt* block = toBlockStmt(stmt);
-  return block &&
-         block->parentSymbol &&
-         block->isLoopStmt() == false &&
-         block->blockInfoGet() &&
-         block->blockInfoGet()->isPrimitive(PRIM_BLOCK_LOCAL);
 }
 
 //


### PR DESCRIPTION
This commit attempts to improve the quality of the generated code for
local blocks. First, we will now emit a comment "/* local block */" to
make it clear when a local block begins. Second, we remove empty local
blocks at the beginning and towards the end of insertWideReferences.
These two changes should have the most positive impact on the generated
code.

The final transformation is to merge consecutive local blocks together.
Local blocks can be split up by the function 'fragmentLocalBlocks' in
lowerIterators. By the time we get to insertWideReferences, we find that
some of these local blocks are consecutive. One can also observe that
these local blocks are sometimes only separated by DefExprs. In that
case, we move those DefExprs before the earlier block when merging. This
transformation will not touch local blocks that were split across loops
or if-statements. For example, this AST:

```
{
  ...
  ('local block');
}
var len:int(64)
var call_tmp:int(64)
{
  ...
  ('local block');
}
```

Becomes this AST:
```
var len:int(64)
var call_tmp:int(64)
{
  ...
  ...
  ('local block')
}
```