### PR TITLE
Wrap #define of __STDC_*_MACROS in #ifndefs

### DIFF
--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -25,9 +25,13 @@ extern "C" {
 #endif
 
 // This macro set to obtain the portable format macro PRIu64 for debug output.
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS 1
+#endif
 // This macro set to obtain SIZE_MAX
+#ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
+#endif
 
 #include "sys_basic.h"
 #include "qio_error.h"

--- a/runtime/include/sys_basic.h
+++ b/runtime/include/sys_basic.h
@@ -74,7 +74,9 @@
 //#endif
 
 // Ask a C++ compiler if it would please include e.g. INT64_MAX
+#ifndef __STDC_CONSTANT_MACROS
 #define __STDC_CONSTANT_MACROS
+#endif
 
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
The bare defines resulted in redefinition warning when using gcc 6.1.0
(__STDC_CONSTANT_MACROS and __STDC_LIMIT_MACROS are defined in stdint.h)

@ronawho 