### PR TITLE
Turn off qthreads affinity (cpu pinning) for whitebox testing

### DIFF
--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -7,6 +7,11 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 
+# Turn off CPU pinning since we run so oversubscribed. Note that we don't just
+# use common-oversubscribed.bash, because CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION
+# hurt overall testing time and led to timeouts.
+export QT_AFFINITY=no
+
 # Run the tests!
 nightly_args="-cron"
 log_info "Calling nightly with args: ${nightly_args}"


### PR DESCRIPTION
Whitebox testing runs heavily oversubscribed, so try to configure it with some
of the same oversubscription settings we use for gasnet testing. Hopefully this
will allow us to finish testing faster and avoid some timeouts.

I tried something like this with #3684, but I had to back that out because
CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION led to some timeouts.

This particular change is motivated by two concurrent instances of
npb/is/mcahir/intsort.mtml running. On its own, the test only takes ~10
seconds, but if two instances are running concurrently they take ~8 minutes to
finish. We know that separate qthreads instances don't play well together, but
this is a pretty extreme case. I did a little digging into this test to figure
out why it's so bad WRT qthreads oversubscription. I didn't discover anything
too insightful, but turning off qthreads affinity drastically improved the
running time (8 min -> 30 sec.)