### PR TITLE
Move direct on optimization to parallel

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -94,6 +94,7 @@ VarSymbol *gModuleInitIndentLevel = NULL;
 FnSymbol *gPrintModuleInitFn = NULL;
 FnSymbol* gChplHereAlloc = NULL;
 FnSymbol* gChplHereFree = NULL;
+FnSymbol* gChplDoDirectExecuteOn = NULL;
 
 std::map<FnSymbol*,int> ftableMap;
 Vec<FnSymbol*> ftableVec;

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -89,7 +89,6 @@ symbolFlag( FLAG_DEFAULT_INTENT_IS_REF, ypr, "default intent is ref", "The defau
 symbolFlag( FLAG_DEFAULT_CONSTRUCTOR , npr, "default constructor" , ncm )
 symbolFlag( FLAG_DESTRUCTOR , npr, "destructor" , "applied to functions that are destructors" )
 symbolFlag( FLAG_DISTRIBUTION , ypr, "distribution" , ncm )
-symbolFlag( FLAG_DIRECT_ON_ARGUMENT , npr, "direct on argument" , ncm )
 symbolFlag( FLAG_DOMAIN , ypr, "domain" , ncm )
 symbolFlag( FLAG_DONOR_FN, ypr, "donor fn" , "function donates ownership of the returned object to the calling function" )
 symbolFlag( FLAG_DONT_DISABLE_REMOTE_VALUE_FORWARDING , ypr, "dont disable remote value forwarding" , ncm )

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -634,6 +634,7 @@ extern VarSymbol *gModuleInitIndentLevel;
 extern FnSymbol *gPrintModuleInitFn;
 extern FnSymbol *gChplHereAlloc;
 extern FnSymbol *gChplHereFree;
+extern FnSymbol *gChplDoDirectExecuteOn;
 
 extern Symbol *gSyncVarAuxFields;
 extern Symbol *gSingleVarAuxFields;

--- a/compiler/passes/filesToAST.cpp
+++ b/compiler/passes/filesToAST.cpp
@@ -36,6 +36,7 @@ bool parsed = false;
 static void countTokensInCmdLineFiles();
 static void setIteratorTags();
 static void gatherWellKnownTypes();
+static void gatherWellKnownFns();
 
 // This structure and the following array provide a list of types that must be
 // defined in module code.  At this point, they are all classes.
@@ -59,6 +60,23 @@ static WellKnownType sWellKnownTypes[] = {
   {"chpl_main_argument", &dtMainArgument, false}
 };
 
+
+struct WellKnownFn
+{
+  const char* name;
+  FnSymbol**  fn;
+  Flag        flag;
+  FnSymbol*   lastNameMatchedFn;
+};
+
+// These functions are a required part of the compiler/module interface.
+// They should generally be marked export so that they are always
+// resolved.
+static WellKnownFn sWellKnownFns[] = {
+  {"chpl_here_alloc",         &gChplHereAlloc, FLAG_LOCALE_MODEL_ALLOC},
+  {"chpl_here_free",          &gChplHereFree,  FLAG_LOCALE_MODEL_FREE},
+  {"chpl_doDirectExecuteOn",  &gChplDoDirectExecuteOn, FLAG_UNKNOWN}
+};
 
 void parse() {
   yydebug = debugParserLevel;
@@ -86,6 +104,7 @@ void parse() {
     parseDependentModules(MOD_INTERNAL);
 
     gatherWellKnownTypes();
+    gatherWellKnownFns();
   }
 
   {
@@ -218,5 +237,51 @@ static void gatherWellKnownTypes() {
       delete dtString;
       dtString = NULL;
     }
+  }
+}
+
+static void gatherWellKnownFns() {
+  int nEntries = sizeof(sWellKnownFns) / sizeof(sWellKnownFns[0]);
+  static const char* mult_def_message   = "'%s' defined more than once in Chapel internal modules.";
+  static const char* flag_reqd_message = "The '%s' function is missing a required flag.";
+  static const char* wkfn_reqd_message   = "Function '%s' must be defined in the Chapel internal modules.";
+
+  // Harvest well-known functions from among the global fn definitions.
+  // We check before assigning to the well-known type dt<typename>, to ensure that it
+  // is null.  In that way we can flag duplicate definitions.
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    for (int i = 0; i < nEntries; ++i) {
+      WellKnownFn& wkfn = sWellKnownFns[i];
+
+      if (strcmp(fn->name, wkfn.name) == 0) {
+        wkfn.lastNameMatchedFn = fn;
+        if (wkfn.flag == FLAG_UNKNOWN || fn->hasFlag(wkfn.flag)) {
+          if (*wkfn.fn != NULL)
+            USR_WARN(fn, mult_def_message, wkfn.name);
+
+          *wkfn.fn = fn;
+        }
+      }
+    }
+  }
+
+  //
+  // When compiling for minimal modules, we don't require any specific
+  // well-known functions to be defined.
+  //
+  if (fMinimalModules == false) {
+    // Make sure all well-known functions are defined.
+    for (int i = 0; i < nEntries; ++i) {
+      WellKnownFn& wkfn = sWellKnownFns[i];
+      FnSymbol* lastMatched = wkfn.lastNameMatchedFn;
+      FnSymbol* fn = *wkfn.fn;
+
+      if (lastMatched == NULL)
+        USR_FATAL_CONT(wkfn_reqd_message, wkfn.name);
+      else if(! fn)
+        USR_FATAL_CONT(fn, flag_reqd_message, wkfn.name);
+    }
+
+    USR_STOP();
   }
 }

--- a/compiler/passes/filesToAST.cpp
+++ b/compiler/passes/filesToAST.cpp
@@ -247,7 +247,7 @@ static void gatherWellKnownFns() {
   static const char* wkfn_reqd_message   = "Function '%s' must be defined in the Chapel internal modules.";
 
   // Harvest well-known functions from among the global fn definitions.
-  // We check before assigning to the well-known type dt<typename>, to ensure that it
+  // We check before assigning to the associated global to ensure that it
   // is null.  In that way we can flag duplicate definitions.
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     for (int i = 0; i < nEntries; ++i) {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -109,14 +109,6 @@ void normalize() {
     if (!fn->hasFlag(FLAG_TYPE_CONSTRUCTOR) &&
         !fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR))
       fixup_array_formals(fn);
-    if (fn->hasFlag(FLAG_LOCALE_MODEL_ALLOC)) {
-      INT_ASSERT(gChplHereAlloc==NULL);
-      gChplHereAlloc = fn;
-    }
-    if (fn->hasFlag(FLAG_LOCALE_MODEL_FREE)) {
-      INT_ASSERT(gChplHereFree==NULL);
-      gChplHereFree = fn;
-    }
     clone_parameterized_primitive_methods(fn);
     fixup_query_formals(fn);
     change_method_into_constructor(fn);

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1473,6 +1473,7 @@ static void insertEndCounts()
 //
 // Returns the call in the 'else' block (which will need
 // argument bundling as usual).
+static
 CallExpr* createConditionalForDirectOn(CallExpr* call, FnSymbol* fn)
 {
 


### PR DESCRIPTION
PR #3890 adjusted the compiler to generate a conditional for direct local
on statements. This conditional was added in createTaskFunctions, but
@noakesmichael pointed out that it would be better to add it in
parallel.cpp. This PR moves that code to parallel.cpp.

In order to do so, it was necessary to make  it possible for the compiler
to add calls to chpl_doDirectExecuteOn after resolution.  So, it adds a
global gChplDoDirectExecuteOn.  In order to associate the correct AST
symbol with that global, it adds a function gatherWellKnownFns as a
sibling to gatherWellKnownTypes in filesToAST.cpp. It moves the task of
finding two other functions I was able to quickly identify
("chpl_here_alloc" and "chpl_here_free") to this section (out of
normalize). I think that identifying these functions in this way is more
straightforward and maintainable than the previous strategy (in which
each such function has a unique flag and then the global FnSymbol*
variable is set in some arbitrary place in the compiler).

Reviewed by @noakesmichael - thanks!

Passed quickstart+gasnet testing.
Passed full local testing.
Passed qthreads+gasnet testing.