### PR TITLE
Fix ref counting issues with StencilDist

### DIFF
--- a/test/distributions/bharshbarg/stencil/rankChange.chpl
+++ b/test/distributions/bharshbarg/stencil/rankChange.chpl
@@ -2,21 +2,23 @@ use StencilDist;
 
 config const n = 5;
 
-var Dom = {1..n,1..n};
-var Space = Dom dmapped Stencil(Dom, fluff=(2,3));
+proc main() {
+  var Dom = {1..n,1..n};
+  var Space = Dom dmapped Stencil(Dom, fluff=(2,3));
 
-for (a, b) in zip(Dom[1,..], Space[1,..]) {
-  assert(a == b);
+  for (a, b) in zip(Dom[1,..], Space[1,..]) {
+    assert(a == b);
+  }
+  var A : [Space] int;
+  A = 9;
+  A.updateFluff();
+
+  ref first = A[1,..];
+  writeln("Fluff = ", first._value.dom.dist.fluff);
+  first = 0;
+  A.updateFluff();
+
+  for a in A[1,..] do assert(a == 0);
+  for a in A[n,..] do assert(a == 9);
+  writeln("SUCCESS!");
 }
-var A : [Space] int;
-A = 9;
-A.updateFluff();
-
-ref first = A[1,..];
-writeln("Fluff = ", first._value.dom.dist.fluff);
-first = 0;
-A.updateFluff();
-
-for a in A[1,..] do assert(a == 0);
-for a in A[n,..] do assert(a == 9);
-writeln("SUCCESS!");


### PR DESCRIPTION
#4043 introduced reference counting errors for some new and old tests. This commit resolves those errors by incrementing ref counts correctly and by avoiding a known issue with ref-vars.