### PR TITLE
Revert "Turn off qthreads affinity (cpu pinning) for whitebox testing"

### DIFF
--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -7,11 +7,6 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 
-# Turn off CPU pinning since we run so oversubscribed. Note that we don't just
-# use common-oversubscribed.bash, because CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION
-# hurt overall testing time and led to timeouts.
-export QT_AFFINITY=no
-
 # Run the tests!
 nightly_args="-cron"
 log_info "Calling nightly with args: ${nightly_args}"


### PR DESCRIPTION
This reverts commit bda4fd7ccd5ab7e7d5d50907ab66962f339edcb2.

Setting QT_AFFINITY=no for whitebox testing resulted in some timeouts
(particularly for pgi) so I'm reverting it.