### PR TITLE
Docs Updates

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -198,9 +198,9 @@ CHPL_TARGET_ARCH
         none      No specialization will be performed (will not warn)
         ========  =============================================================
 
+        **Architecture-specific values**
+
         =========== ================
-        Architecture-specific values
-        ----------------------------
         intel       amd
         =========== ================
         core2           k8

--- a/doc/release/platforms/macosx.rst
+++ b/doc/release/platforms/macosx.rst
@@ -28,6 +28,6 @@ following command::
    language's rich features should clone the repository_ or
    download a release_, and :ref:`build Chapel from source <readme-building>`.
 
-.. _Homebrew: https://github.com/Homebrew/homebrew
+.. _Homebrew: https://github.com/Homebrew/brew
 .. _repository: https://github.com/chapel-lang/chapel
 .. _release: https://github.com/chapel-lang/chapel/releases

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -7,7 +7,13 @@ help: help-sphinx help-source
 
 help-source:
 	@echo "Source Help:"
-	@echo "  symlinks-docs to symlink doc/release contents to source"
+	@echo "  docs           to invoke 'make html' in the virtualenv"
+	@echo "  checkdocs      to invoke 'make check' in the virtualenv"
+	@echo "  symlinks-docs  to symlink doc/release contents to source"
+	@echo "  clean          to remove all generated files in source/"
+	@echo "  clean-build    to remove all generated files in build/"
+	@echo "  clobber        to remove all generated files in source/ and build/"
+	@echo ""
 
 docs: FORCE
 	./run-in-venv.bash $(MAKE) html

--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -25,18 +25,21 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sou
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
-.PHONY: help check-sphinxbuild clean-build html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: help check-sphinxbuild clean-build html dirhtml singlehtml pickle json htmlhelp qthelp latex latexpdf text man changes linkcheck gettext
 
 help-sphinx:
-# Currently unsupported:
-# @echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
-# @echo "  devhelp    to make HTML files and a Devhelp project"
-# @echo "  epub       to make an epub"
 	@echo "Sphinx Help:"
-	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "Please use \`make <target>' where <target> is one of the following:"
+	@echo ""
+	@echo "Supported targets:"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
+	@echo "  text       to make text files"
+	@echo "  man        to make manual pages"
+	@echo "  check      to check all internal and external links for integrity"
+	@echo ""
+	@echo "Unsupported targets:"
 	@echo "  pickle     to make pickle files"
 	@echo "  json       to make JSON files"
 	@echo "  htmlhelp   to make HTML files and a HTML help project"
@@ -44,15 +47,13 @@ help-sphinx:
 	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
 	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
 	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
-	@echo "  text       to make text files"
-	@echo "  man        to make manual pages"
 	@echo "  texinfo    to make Texinfo files"
 	@echo "  info       to make Texinfo files and run them through makeinfo"
 	@echo "  gettext    to make PO message catalogs"
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  xml        to make Docutils-native XML files"
 	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
-	@echo "  linkcheck  to check all external links for integrity"
+	@echo ""
 
 check-sphinxbuild:
 	@if [ $(SPHINXTEST) -eq 1 ]; then echo $(SPHINXERROR); fi
@@ -64,11 +65,12 @@ html: symlink-docs check-sphinxbuild clean-build
 	@echo "Build finished. The HTML pages are in "'$(BUILDPATH)'"/html."
 
 check: symlink-docs check-sphinxbuild clean-build
-	@echo "Checking for dead links and cross-references"
-	$(SPHINXBUILD) -n -b linkcheck -d $(BUILDDIR)/doctrees source $(BUILDDIR)/html
+	@echo "Checking for broken links or cross-references"
+	$(SPHINXBUILD) -n -b linkcheck -d $(BUILDDIR)/doctrees source $(BUILDDIR)/linkcheck
 	chmod -R ugo+rX $(BUILDDIR)
 	@echo
-	@echo "Build finished. The HTML pages are in "'$(BUILDPATH)'"/html."
+	@echo "Link check complete; look for any errors in the above output " \
+	      "or in "'$(BUILDPATH)'"/linkcheck/output.txt."
 
 dirhtml:  symlink-docs check-sphinxbuild clean-build
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
@@ -104,22 +106,6 @@ qthelp: symlink-docs check-sphinxbuild clean-build
 	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/chpldoc.qhcp"
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/chpldoc.qhc"
-
-# Currently unsupported
-#devhelp:
-#	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
-#	@echo
-#	@echo "Build finished."
-#	@echo "To view the help file:"
-#	@echo "# mkdir -p $$HOME/.local/share/devhelp/chpldoc"
-#	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/chpldoc"
-#	@echo "# devhelp"
-
-# Currently unsupported
-#epub:
-#	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
-#	@echo
-#	@echo "Build finished. The epub file is in "'$(BUILDPATH)'"/epub."
 
 latex: symlink-docs check-sphinxbuild clean-build
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
@@ -178,12 +164,6 @@ linkcheck: symlink-docs check-sphinxbuild clean-build
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in "'$(BUILDPATH)'"/linkcheck/output.txt."
-
-# Currently unsupported
-#doctest:
-#	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
-#	@echo "Testing of doctests in the sources finished, look at the " \
-#	      "results in "'$(BUILDPATH)'"/doctest/output.txt."
 
 xml: symlink-docs check-sphinxbuild clean-build
 	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml


### PR DESCRIPTION
A while ago, user @nspark requested the ability to view the docs more easily in the terminal. This PR initially set out to fix a table in `doc/release/chplenv.rst` so that we can build the Chapel documentation man pages without warnings, and it succeeded in doing that. They certainly aren't the prettiest option for viewing the docs, but they are functional...  Along the way, I cleaned up some other things as well:

* More realistic `make help` output for docs build options
    * Separate what targets are and are not officially supported
* Removed redundant `linkcheck` target
* Fixed a redirected link
* Removed some broken / unsupported targets (previously commented out)

