### PR TITLE
Remove bigmod.suppressif as a result of PGI upgrade

### DIFF
--- a/test/portability/bigmod.suppressif
+++ b/test/portability/bigmod.suppressif
@@ -1,3 +1,0 @@
-# This looks like a PGI compiler bug
-CHPL_TARGET_COMPILER == pgi
-CHPL_TARGET_COMPILER == cray-prgenv-pgi


### PR DESCRIPTION
bigmod was suppressed for pgi because of a pgi bug. The bug appears to have
been resolved with pgi 16.5, so remove the suppression.