### PR TITLE
Revert the timer changes made to RA in #4076

### DIFF
--- a/test/release/examples/benchmarks/hpcc/ra.chpl
+++ b/test/release/examples/benchmarks/hpcc/ra.chpl
@@ -131,8 +131,7 @@ proc main() {
   //
   [i in TableSpace] T[i] = i;
 
-  var kernel: Timer;
-  kernel.start();
+  const startTime = getCurrentTime();              // capture the start time
 
   //
   // The main computation: Iterate over the set of updates and the
@@ -158,9 +157,7 @@ proc main() {
     forall (_, r) in zip(Updates, RAStream()) do
       T[r & indexMask] ^= r;
 
-  kernel.stop();
-
-  const execTime = kernel.elapsed(); // capture the elapsed time
+  const execTime = getCurrentTime() - startTime;   // capture the elapsed time
 
   const validAnswer = verifyResults(T);            // verify the updates
   printResults(validAnswer, execTime);             // print the results


### PR DESCRIPTION
#4076 updated RA to use a Timer instead of getCurrentTime() since
getCurrentTime() resets at midnight. Unfortunately the RA comm count test uses
getCurrentTime() as a sentinel to figure out where to insert comm count code.

The right solution is probably to verify that the HPCC benchmarks aren't
required to use getCurrentTime(), update all of them to use a timer, and
finally update the  script that inserts the comm counting code. However, I
don't have a lot of time to look at that right now, so in order to quiet the
regression this just reverts the timer changes.