### PR TITLE
Add a new perf job that tests 1.13.0 perf on the shootout-like machine

### DIFF
--- a/util/cron/test-perf.chapel-shootout-release.bash
+++ b/util/cron/test-perf.chapel-shootout-release.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Run submitted shootout performance benchmark tests on chapel-shootout with
+# default configuration against the 1.13 release (but with the current tests)
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-perf.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout-release"
+
+# check out 1.13.0, but then grab the current tests
+currentSha=`git rev-parse HEAD`
+git checkout 1.13.0
+git checkout $currentSha -- $CHPL_HOME/test/
+
+export CHPL_NIGHTLY_TEST_DIRS="studies/shootout/submitted/"
+
+perf_args="-performance -numtrials 5 -startdate 06/28/16 -sync-dir-suffix release"
+$CWD/nightly -cron ${perf_args}


### PR DESCRIPTION
This job will test the performance of the submitted shootout entries
(studies/shootout/submitted/) against 1.13.0. This will allow us to check
performance against what's actually running for the shootout competition and
help check that we're not using any features that aren't actually in 1.13 prior
to submitting them.