### PR TITLE
Checkout the master version of util/cron for the 1.13 shootout job

### DIFF
--- a/util/cron/test-perf.chapel-shootout-release.bash
+++ b/util/cron/test-perf.chapel-shootout-release.bash
@@ -12,6 +12,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout-release"
 currentSha=`git rev-parse HEAD`
 git checkout 1.13.0
 git checkout $currentSha -- $CHPL_HOME/test/
+git checkout $currentSha -- $CHPL_HOME/util/cron/
 
 export CHPL_NIGHTLY_TEST_DIRS="studies/shootout/submitted/"
 


### PR DESCRIPTION
In addition to checking out the master test/ dir, we also need to checkout the
util/cron dir so that we can actually find the right script to run.

Note that a better solution would probably be to update nightly to either use
the 1.13 tarball directly, or to use a version of chapel installed on the
machine, but that's more work than I want to do right now.