### PR TITLE
move alignment functions to own header

### DIFF
--- a/runtime/include/chpl-align.h
+++ b/runtime/include/chpl-align.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_align_h_
+#define _chpl_align_h_
+
+#include <inttypes.h>
+#include <string.h>
+#include <assert.h>
+#include <stdint.h>
+#include <limits.h>
+
+// If we have a mask representing 2^n - 1,
+// round an offset down to a multiple of 2^n.
+static inline
+uintptr_t round_down_to_mask(uintptr_t p, uintptr_t mask)
+{
+ return p - (p & mask);
+}
+static inline
+unsigned char* round_down_to_mask_ptr(unsigned char* p, uintptr_t mask)
+{
+  return (unsigned char*) round_down_to_mask((uintptr_t)p, mask);
+}
+
+// If we have a mask representing 2^n - 1,
+// round an offset up to a multiple of 2^n.
+static inline
+uintptr_t round_up_to_mask(uintptr_t p, uintptr_t mask)
+{
+  uintptr_t offset = p & mask;
+  return (offset==0)?(p):(p + (mask+1) - offset);
+}
+static inline
+unsigned char* round_up_to_mask_ptr(unsigned char* p, uintptr_t mask)
+{
+  return (unsigned char*) round_up_to_mask((uintptr_t)p, mask);
+}
+
+
+#endif // _chpl_align_h_

--- a/runtime/include/chpl-align.h
+++ b/runtime/include/chpl-align.h
@@ -31,7 +31,7 @@
 static inline
 uintptr_t round_down_to_mask(uintptr_t p, uintptr_t mask)
 {
- return p - (p & mask);
+  return p - (p & mask);
 }
 static inline
 unsigned char* round_down_to_mask_ptr(unsigned char* p, uintptr_t mask)
@@ -44,8 +44,7 @@ unsigned char* round_down_to_mask_ptr(unsigned char* p, uintptr_t mask)
 static inline
 uintptr_t round_up_to_mask(uintptr_t p, uintptr_t mask)
 {
-  uintptr_t offset = p & mask;
-  return (offset==0)?(p):(p + (mask+1) - offset);
+  return (p + mask) & ~mask;
 }
 static inline
 unsigned char* round_up_to_mask_ptr(unsigned char* p, uintptr_t mask)

--- a/runtime/src/chpl-cache-support.c
+++ b/runtime/src/chpl-cache-support.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <assert.h>
 #include "chpl-bitops.h"
+#include "chpl-align.h"
 
 // ----------  SUPPORT FUNCTIONS 
 typedef int64_t cache_seqn_t;
@@ -56,33 +57,6 @@ static inline void saturating_add(saturating_count_t *x, unsigned int num) {
   *x = v;
 }
 */
-// If we have a mask representing 2^n - 1,
-// round an offset down to a multiple of 2^n.
-static inline
-uintptr_t round_down_to_mask(uintptr_t p, uintptr_t mask)
-{
- return p - (p & mask);
-}
-static inline
-unsigned char* round_down_to_mask_ptr(unsigned char* p, uintptr_t mask)
-{
-  return (unsigned char*) round_down_to_mask((uintptr_t)p, mask);
-}
-
-// If we have a mask representing 2^n - 1,
-// round an offset up to a multiple of 2^n.
-static inline
-uintptr_t round_up_to_mask(uintptr_t p, uintptr_t mask)
-{
-  uintptr_t offset = p & mask;
-  return (offset==0)?(p):(p + (mask+1) - offset);
-}
-static inline
-unsigned char* round_up_to_mask_ptr(unsigned char* p, uintptr_t mask)
-{
-  return (unsigned char*) round_up_to_mask((uintptr_t)p, mask);
-}
-
 
 // Single linked list/stack
 #define SINGLE_POP_HEAD(tree, NAME) { \

--- a/test/optimizations/cache-remote/ferguson/c_tests/chpl-cache-support-test.test.c
+++ b/test/optimizations/cache-remote/ferguson/c_tests/chpl-cache-support-test.test.c
@@ -316,6 +316,7 @@ static void chpl_cache_support_test(void)
   assert(round_down_to_mask(16, 15) == 16);
   assert(round_down_to_mask(17, 15) == 16);
   assert(round_up_to_mask(0, 15) == 0);
+  assert(round_up_to_mask(1, 15) == 16);
   assert(round_up_to_mask(10, 15) == 16);
   assert(round_up_to_mask(15, 15) == 16);
   assert(round_up_to_mask(16, 15) == 16);


### PR DESCRIPTION
Earlier versions of PR #4074 needed these alignment functions originally created for chpl-cache.c. So I moved them out of chpl-cache-support.h to their own header.

Passed test/optimizations/cache-remote with gasnet+fifo
Passed full local testing.
Reviewed by @gbtitus - thanks!