### PR TITLE
Add complex math functions wrapping C99 functions

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -149,11 +149,31 @@ module Math {
     return fabsf(_i2r(im));
   }
 
-  /* Returns the real magnitude of the complex argument `x`.
+  /* Returns the real magnitude of the complex argument `z`.
 
      :rtype: The type of the real component of the argument (== `w`/2).
   */
-  inline proc abs(x : complex(?w)) return sqrt(x.re*x.re + x.im*x.im);
+  inline proc abs(z : complex(?w)) {
+    extern proc cabsf(z: complex(64)): real(32);
+    extern proc cabs(z: complex(128)): real(64);
+    if w == 64 then
+      return cabsf(z);
+    else
+      return cabs(z);
+  }
+
+
+  /* Returns the real phase angle of complex argument `z`. */
+  inline proc arg(z: complex(64)): real(32) {
+    extern proc cargf(z: complex(64)): real(32);
+    return cargf(z);
+  }
+
+  /* Returns the real phase angle of complex argument `z`. */
+  inline proc arg(z: complex(128)): real(64) {
+    extern proc carg(z: complex(128)): real(64);
+    return carg(z);
+  }
 
 
   /* Returns the arc cosine of the argument `x`.
@@ -169,6 +189,18 @@ module Math {
   inline proc acos(x : real(32)): real(32) {
     extern proc acosf(x: real(32)): real(32);
     return acosf(x);
+  }
+
+  /* Returns the arc cosine of the argument `z`. */
+  inline proc acos(z: complex(64)): complex(64) {
+    extern proc cacosf(z: complex(64)): complex(64);
+    return cacosf(z);
+  }
+
+  /* Returns the arc cosine of the argument `z`. */
+  inline proc acos(z: complex(128)): complex(128) {
+    extern proc cacos(z: complex(128)): complex(128);
+    return cacos(z);
   }
 
 
@@ -187,6 +219,18 @@ module Math {
     return acoshf(x);
   }
 
+  /* Returns the inverse hyperbolic cosine of the argument `z`. */
+  inline proc acosh(z: complex(64)): complex(64) {
+    extern proc cacoshf(z: complex(64)): complex(64);
+    return cacoshf(z);
+  }
+
+  /* Returns the inverse hyperbolic cosine of the argument `z`. */
+  inline proc acosh(z: complex(128)): complex(128) {
+    extern proc cacosh(z: complex(128)): complex(128);
+    return cacosh(z);
+  }
+
 
   /* Returns the arc sine of the argument `x`.
 
@@ -203,6 +247,18 @@ module Math {
     return asinf(x);
   }
 
+  /* Returns the arc sine of the argument `z`. */
+  inline proc asin(z: complex(64)): complex(64) {
+    extern proc casinf(z: complex(64)): complex(64);
+    return casinf(z);
+  }
+
+  /* Returns the arc sine of the argument `z`. */
+  inline proc asin(z: complex(128)): complex(128) {
+    extern proc casin(z: complex(128)): complex(128);
+    return casin(z);
+  }
+
 
   /* Returns the inverse hyperbolic sine of the argument `x`. */
   extern proc asinh(x: real(64)): real(64);
@@ -213,6 +269,19 @@ module Math {
     return asinhf(x);
   }
 
+  /* Returns the inverse hyperbolic sine of the argument `z`. */
+  inline proc asinh(z: complex(64)): complex(64) {
+    extern proc casinhf(z: complex(64)): complex(64);
+    return casinhf(z);
+  }
+
+  /* Returns the inverse hyperbolic sine of the argument `z`. */
+  inline proc asinh(z: complex(128)): complex(128) {
+    extern proc casinh(z: complex(128)): complex(128);
+    return casinh(z);
+  }
+
+
 
   /* Returns the arc tangent of the argument `x`. */
   extern proc atan(x: real(64)): real(64);
@@ -221,6 +290,18 @@ module Math {
   inline proc atan(x : real(32)): real(32) {
     extern proc atanf(x: real(32)): real(32);
     return atanf(x);
+  }
+
+  /* Returns the arc tangent of the argument `z`. */
+  inline proc atan(z: complex(64)): complex(64) {
+    extern proc catanf(z: complex(64)): complex(64);
+    return catanf(z);
+  }
+
+  /* Returns the arc tangent of the argument `z`. */
+  inline proc atan(z: complex(128)): complex(128) {
+    extern proc catan(z: complex(128)): complex(128);
+    return catan(z);
   }
 
 
@@ -255,6 +336,18 @@ module Math {
     return atanhf(x);
   }
 
+  /* Returns the inverse hyperbolic tangent of the argument `z`. */
+  inline proc atanh(z: complex(64)): complex(64) {
+    extern proc catanhf(z: complex(64)): complex(64);
+    return catanhf(z);
+  }
+
+  /* Returns the inverse hyperbolic tangent of the argument `z`. */
+  inline proc atanh(z: complex(128)): complex(128) {
+    extern proc catanh(z: complex(128)): complex(128);
+    return catanh(z);
+  }
+
 
   /* Returns the cube root of the argument `x`. */
   extern proc cbrt(x: real(64)): real(64);
@@ -276,11 +369,29 @@ module Math {
   }
 
 
-  /* Returns the complex conjugate of the argument `a`.
+  /* Returns the complex conjugate of the argument `z`.
    
-     :rtype: The type of `a`.
+     :rtype: The type of `z`.
   */
-  inline proc conjg(a: complex(?w)) : complex(w) return (a.re, -a.im):complex(w);
+  inline proc conjg(z: complex(?w)): complex(w) {
+    extern proc conjf(z: complex(64)): complex(64);
+    extern proc conj(z: complex(128)): complex(128);
+    if w == 64 then
+      return conjf(z);
+    else
+      return conj(z);
+  }
+
+
+  /* Returns the projection of `z` on a Riemann sphere. */
+  inline proc proj(z: complex(?w)): real(w/2) {
+    extern proc cprojf(z: complex(64)): real(32);
+    extern proc cproj(z: complex(128)): real(64);
+    if w == 64 then
+      return cprojf(z);
+    else
+      return cproj(z);
+  }
 
 
   /* Returns the cosine of the argument `x`. */
@@ -292,6 +403,18 @@ module Math {
     return cosf(x);
   }
 
+  /* Returns the cosine of the argument `z`. */
+  inline proc cos(z : complex(64)): complex(64) {
+    extern proc ccosf(z: complex(64)): complex(64);
+    return ccosf(z);
+  }
+
+  /* Returns the cosine of the argument `z`. */
+  inline proc cos(z : complex(128)): complex(128) {
+    extern proc ccos(z: complex(128)): complex(128);
+    return ccos(z);
+  }
+
 
   /* Returns the hyperbolic cosine of the argument `x`. */
   extern proc cosh(x: real(64)): real(64);
@@ -300,6 +423,18 @@ module Math {
   inline proc cosh(x : real(32)): real(32) {
     extern proc coshf(x: real(32)): real(32);
     return coshf(x);
+  }
+
+  /* Returns the hyperbolic cosine of the argument `z`. */
+  inline proc cosh(z: complex(64)): complex(64) {
+    extern proc ccoshf(z: complex(64)): complex(64);
+    return ccoshf(z);
+  }
+
+  /* Returns the hyperbolic cosine of the argument `z`. */
+  inline proc cosh(z: complex(128)): complex(128) {
+    extern proc ccosh(z: complex(128)): complex(128);
+    return ccosh(z);
   }
 
 
@@ -416,6 +551,18 @@ module Math {
     return expf(x);
   }
 
+  /* Returns the value of the Napierien `e` raised to the power of the argument. */
+  inline proc exp(z: complex(64)): complex(64) {
+    extern proc cexpf(z: complex(64)): complex(64);
+    return cexpf(z);
+  }
+
+  /* Returns the value of the Napierien `e` raised to the power of the argument. */
+  inline proc exp(z: complex(128)): complex(128) {
+    extern proc cexp(z: complex(128)): complex(128);
+    return cexp(z);
+  }
+
 
   /* Returns the value of `2` raised to the power of the argument `x`. */
   extern proc exp2(x: real(64)): real(64);
@@ -515,6 +662,18 @@ module Math {
   inline proc log(x : real(32)): real(32) {
     extern proc logf(x: real(32)): real(32);
     return logf(x);
+  }
+
+  /* Returns the natural logarithm of the argument `z`. */
+  inline proc log(z: complex(64)): complex(64) {
+    extern proc clogf(z: complex(64)): complex(64);
+    return clogf(z);
+  }
+
+  /* Returns the natural logarithm of the argument `z`. */
+  inline proc log(z: complex(128)): complex(128) {
+    extern proc clog(z: complex(128)): complex(128);
+    return clog(z);
   }
 
 
@@ -748,6 +907,18 @@ module Math {
     return sinf(x);
   }
 
+  /* Returns the sine of the argument `z`. */
+  inline proc sin(z: complex(64)): complex(64) {
+    extern proc csinf(z: complex(64)): complex(64);
+    return csinf(z);
+  }
+
+  /* Returns the sine of the argument `z`. */
+  inline proc sin(z: complex(128)): complex(128) {
+    extern proc csin(z: complex(128)): complex(128);
+    return csin(z);
+  }
+
 
   /* Returns the hyperbolic sine of the argument `x`. */
   extern proc sinh(x: real(64)): real(64);
@@ -756,6 +927,18 @@ module Math {
   inline proc sinh(x : real(32)): real(32) {
     extern proc sinhf(x: real(32)): real(32);
     return sinhf(x);
+  }
+
+  /* Returns the hyperbolic sine of the argument `z`. */
+  inline proc sinh(z: complex(64)): complex(64) {
+    extern proc csinhf(z: complex(64)): complex(64);
+    return csinhf(z);
+  }
+
+  /* Returns the hyperbolic sine of the argument `z`. */
+  inline proc sinh(z: complex(128)): complex(128) {
+    extern proc csinh(z: complex(128)): complex(128);
+    return csinh(z);
   }
 
 
@@ -774,6 +957,18 @@ module Math {
     return sqrtf(x);
   }
 
+  /* Returns the square root of the argument `z`. */
+  inline proc sqrt(z: complex(64)): complex(64) {
+    extern proc csqrtf(z: complex(64)): complex(64);
+    return csqrtf(z);
+  }
+
+  /* Returns the square root of the argument `z`. */
+  inline proc sqrt(z: complex(128)): complex(128) {
+    extern proc csqrt(z: complex(128)): complex(128);
+    return csqrt(z);
+  }
+
 
   /* Returns the tangent of the argument `x`. */
   extern proc tan(x: real(64)): real(64);
@@ -782,6 +977,18 @@ module Math {
   inline proc tan(x : real(32)): real(32) {
     extern proc tanf(x: real(32)): real(32);
     return tanf(x);
+  }
+
+  /* Returns the tangent of the argument `z`. */
+  inline proc tan(z: complex(64)): complex(64) {
+    extern proc ctanf(z: complex(64)): complex(64);
+    return ctanf(z);
+  }
+
+  /* Returns the tangent of the argument `z`. */
+  inline proc tan(z: complex(128)): complex(128) {
+    extern proc ctan(z: complex(128)): complex(128);
+    return ctan(z);
   }
 
 
@@ -793,6 +1000,19 @@ module Math {
     extern proc tanhf(x: real(32)): real(32);
     return tanhf(x);
   }
+
+  /* Returns the hyperbolic tangent of the argument `z`. */
+  inline proc tanh(z: complex(64)): complex(64) {
+    extern proc ctanhf(z: complex(64)): complex(64);
+    return ctanhf(z);
+  }
+
+  /* Returns the hyperbolic tangent of the argument `z`. */
+  inline proc tanh(z: complex(128)): complex(128) {
+    extern proc ctanh(z: complex(128)): complex(128);
+    return ctanh(z);
+  }
+
 
 
   /* Returns the absolute value of the gamma function of the argument `x`. */

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -153,7 +153,7 @@ module Math {
 
      :rtype: The type of the real component of the argument (== `w`/2).
   */
-  inline proc abs(z : complex(?w)) {
+  inline proc abs(z : complex(?w)): real(w/2) {
     extern proc cabsf(z: complex(64)): real(32);
     extern proc cabs(z: complex(128)): real(64);
     if w == 64 then
@@ -164,15 +164,13 @@ module Math {
 
 
   /* Returns the real phase angle of complex argument `z`. */
-  inline proc arg(z: complex(64)): real(32) {
+  inline proc carg(z: complex(?w)): real(w/2) {
     extern proc cargf(z: complex(64)): real(32);
-    return cargf(z);
-  }
-
-  /* Returns the real phase angle of complex argument `z`. */
-  inline proc arg(z: complex(128)): real(64) {
     extern proc carg(z: complex(128)): real(64);
-    return carg(z);
+    if w == 64 then
+      return cargf(z);
+    else
+      return carg(z);
   }
 
 
@@ -370,8 +368,8 @@ module Math {
 
 
   /* Returns the complex conjugate of the argument `z`.
-   
-     :rtype: The type of `z`.
+
+     :rtype: A complex number of the same type as `z`.
   */
   inline proc conjg(z: complex(?w)): complex(w) {
     extern proc conjf(z: complex(64)): complex(64);
@@ -384,7 +382,7 @@ module Math {
 
 
   /* Returns the projection of `z` on a Riemann sphere. */
-  inline proc proj(z: complex(?w)): real(w/2) {
+  inline proc cproj(z: complex(?w)): real(w/2) {
     extern proc cprojf(z: complex(64)): real(32);
     extern proc cproj(z: complex(128)): real(64);
     if w == 64 then

--- a/test/functions/diten/imagAbsFn.good
+++ b/test/functions/diten/imagAbsFn.good
@@ -2,9 +2,9 @@
  abs(im): 1.34078e+154
  abs(im).type: real(64)
 fabs(_i2r(im)): 1.34078e+154
- abs(im:complex): inf
+ abs(im:complex): 1.34078e+154
       im32: 1.84467e+19i
  abs(im32): 1.84467e+19
  abs(im32).type: real(32)
 fabsf(_i2r(im32)): 1.84467e+19
- abs(im32:complex(64)): inf
+ abs(im32:complex(64)): 1.84467e+19

--- a/test/functions/diten/realAbsFn.good
+++ b/test/functions/diten/realAbsFn.good
@@ -1,4 +1,4 @@
       x: 1.34078e+154
  abs(x): 1.34078e+154
 fabs(x): 1.34078e+154
- abs(x:complex): inf
+ abs(x:complex): 1.34078e+154

--- a/test/types/complex/diten/cplxMathFnTypes.chpl
+++ b/test/types/complex/diten/cplxMathFnTypes.chpl
@@ -1,0 +1,64 @@
+proc testTypes(x: complex(?w)) {
+  const res1 = abs(x);
+  assert(res1.type == real(w/2));
+
+  const res2 = arg(x);
+  assert(res2.type == real(w/2));
+
+  const res3 = conjg(x);
+  assert(res3.type == complex(w));
+
+  const res4 = proj(x);
+  assert(res4.type == real(w/2));
+
+  const res5 = exp(x);
+  assert(res5.type == complex(w));
+
+  const res6 = log(x);
+  assert(res6.type == complex(w));
+
+  const res7 = sqrt(x);
+  assert(res7.type == complex(w));
+
+  const res8 = sin(x);
+  assert(res8.type == complex(w));
+
+  const res9 = cos(x);
+  assert(res9.type == complex(w));
+
+  const res10 = tan(x);
+  assert(res10.type == complex(w));
+
+  const res11 = asin(x);
+  assert(res11.type == complex(w));
+
+  const res12 = acos(x);
+  assert(res12.type == complex(w));
+
+  const res13 = atan(x);
+  assert(res13.type == complex(w));
+
+  const res14 = sinh(x);
+  assert(res14.type == complex(w));
+
+  const res15 = cosh(x);
+  assert(res15.type == complex(w));
+
+  const res16 = tanh(x);
+  assert(res16.type == complex(w));
+
+  const res17 = asinh(x);
+  assert(res17.type == complex(w));
+
+  const res18 = acosh(x);
+  assert(res18.type == complex(w));
+
+  const res19 = atanh(x);
+  assert(res19.type == complex(w));
+}
+
+var c64 = 1.0:real(32) + 2.0i:imag(32); 
+var c128 = 1.0: real(64) + 2.0i: imag(64);
+
+testTypes(c64);
+testTypes(c128);

--- a/test/types/complex/diten/cplxMathFnTypes.chpl
+++ b/test/types/complex/diten/cplxMathFnTypes.chpl
@@ -2,13 +2,13 @@ proc testTypes(x: complex(?w)) {
   const res1 = abs(x);
   assert(res1.type == real(w/2));
 
-  const res2 = arg(x);
+  const res2 = carg(x);
   assert(res2.type == real(w/2));
 
   const res3 = conjg(x);
   assert(res3.type == complex(w));
 
-  const res4 = proj(x);
+  const res4 = cproj(x);
   assert(res4.type == real(w/2));
 
   const res5 = exp(x);


### PR DESCRIPTION
Added/modified functions for complex(64) and complex(128) versions of:

abs - absolute value
arg - phase angle
conjg - conjugate
proj - projection onto Riemann sphere
exp - base-e exponent
log - natural logarithm
sqrt - square root

sin, cos, tan - trig functions
asin, acos, atan - arc trig functions
sinh, cosh, tanh - hyperbolic trig functions
asinh, acosh, atanh - arc hyperbolic trig functions

All of these are calls to extern functions defined in C99.  'conjg' already
existed and is the only one of these that is named differently from its C
counterpart, 'conj'.

Added a test to help make sure I got all of the return types right.