### PR TITLE
Realized how to put the factorial initializer into an iterator

### DIFF
--- a/test/studies/shootout/fannkuch-redux/bradc/fannkuch-redux-blc.chpl
+++ b/test/studies/shootout/fannkuch-redux/bradc/fannkuch-redux-blc.chpl
@@ -10,14 +10,7 @@ use DynamicIters;
 config const n = 7,          // the array size over which to compute perms
              nchunks = 720;  // the number of chunks of parallelism
 
-//
-// memoize n! (n factorial)
-//
-var fact: [0..n] int;
-fact[0] = 1;
-for i in 1..n do
-  fact[i] = i*fact[i-1];
-
+const fact = computeFact(n);  // memoize n! (n-factorial)
 
 proc main() {
   var checkSum = 0,
@@ -115,5 +108,13 @@ iter fannkuch(inds) {
       
       count[i] += 1;
     }
+  }
+}
+
+iter computeFact(n) {
+  var f = 1;
+  for i in 1..n {
+    f *= i;
+    yield f;
   }
 }


### PR DESCRIPTION
This is a simple refactoring that permits me to initialize the fact[] array in-place using
an iterator.  Yesterday, I was getting a warning using the various approaches that I
was trying.  Today I realized that the warning goes away if we use an inferred array
size rather than a declared one (and we can get away with this since we never
look up fact(0).
