### PR TITLE
Add an OpenMP variant of the task spawning perf tests

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfcompopts
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfcompopts
@@ -1,0 +1,1 @@
+-fopenmp -O3

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfexecopts
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfexecopts
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+numCores=`./getNumPhysicalCores.sh`
+echo "--numThreads=$numCores"

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfkeys
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfkeys
@@ -1,0 +1,1 @@
+Elapsed time:

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.skipif
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.skipif
@@ -1,0 +1,6 @@
+# skip configs where -fopenmp or /proc/cpuinfo aren't supported
+CHPL_TARGET_COMPILER==clang
+CHPL_TARGET_COMPILER<=pgi
+CHPL_TARGET_COMPILER<=cray
+CHPL_TARGET_PLATFORM>=linux
+CHPL_TEST_PERF!=on

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.test.c
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.test.c
@@ -1,0 +1,62 @@
+#include <omp.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+static int numTrials = 100;
+static int printTimings = 0;
+static int numThreads = -1;
+
+// Helper routine to parse Chapel config vars of the form `--var=value` where
+// var is an int or a bool. For bools, a value of `true` returns 1, and
+// everything else returns false
+static int parseConfigInt(char* arg) {
+  char* configVal = NULL;
+
+  configVal = strchr(arg, '=');
+  if (configVal == NULL) {
+    printf("Error, config var '%s', must be of the form `--var=value`\n", arg);
+  }
+  configVal = configVal+sizeof(char);
+
+  if (strcmp(configVal, "true") == 0) {
+    return 1;
+  }
+  return (int) strtol(configVal, NULL, 10);
+}
+
+static void parseArgs(int argc, char** argv) {
+  if (argc < 4) {
+    printf("Usage is ./prog --numTrials=<trials> --printTimings=<timings> --numThreads=<threads>\n");
+    exit(-1);
+  }
+
+  numTrials = parseConfigInt(argv[1]);
+  printTimings = parseConfigInt(argv[2]);
+  numThreads = parseConfigInt(argv[3]);
+}
+
+int main (int argc, char** argv) {
+  double start, elapsed;
+  int i, j;
+
+  parseArgs(argc, argv);
+
+  if (numThreads) {
+    omp_set_num_threads(numThreads);
+  }
+
+  start = omp_get_wtime();
+  for (i=0; i<numTrials; i++) {
+    #pragma omp parallel for
+    for (j=0; j<numThreads; j++) {
+    }
+  }
+  elapsed = omp_get_wtime() - start;
+
+  if (printTimings) {
+    printf("Elapsed time: %f\n", elapsed);
+  }
+
+  return 0;
+}

--- a/test/parallel/taskCompare/elliot/getNumPhysicalCores.sh
+++ b/test/parallel/taskCompare/elliot/getNumPhysicalCores.sh
@@ -1,0 +1,14 @@
+#! /bin/bash -norc
+numPUs=$( grep -c '^processor[[:space:]]\+: ' /proc/cpuinfo )
+numCores1=$( grep -m 1 '^cpu cores[[:space:]]\+: ' /proc/cpuinfo |
+             sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
+numSibs1=$( grep -m 1 '^siblings[[:space:]]\+: ' /proc/cpuinfo |
+            sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
+if [[ -z $numCores1 || -z $numSibs1 ]] ; then
+  numCores=$numPUs
+else
+  sibsPerCore=$(( $numSibs1 / $numCores1 ))
+  numCores=$(( $numPUs / $sibsPerCore ))
+fi
+
+echo "$numCores"

--- a/test/parallel/taskCompare/elliot/taskSpawn.graph
+++ b/test/parallel/taskCompare/elliot/taskSpawn.graph
@@ -1,5 +1,5 @@
-perfkeys: Elapsed time:, Elapsed time:, Elapsed time:
-graphkeys: forall, coforall, for+begin
-files: empty-forall.dat, empty-coforall.dat, empty-for+begin.dat
+perfkeys: Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:
+graphkeys: forall, coforall, for+begin, omp parallel-for
+files: empty-forall.dat, empty-coforall.dat, empty-for+begin.dat, empty-omp-parallel-for.dat
 graphtitle: Empty Task Spawn Timings (500,000 x maxTaskPar)
 ylabel: Time (seconds)


### PR DESCRIPTION
Add an OpenMP comparison to the task spawning suite. This is the OpenMP
equivalent of our forall version. It's careful to only use the number of
physical cores so that we compare the same number of tasks being created. The
code to determine the number of physical cores was grabbed from
test/runtime/gbt/numThreadsSymbolicPhysical.prediff