### PR TITLE
Update steps to build Chapel with newer HDFS sources

### DIFF
--- a/doc/release/technotes/auxIO.rst
+++ b/doc/release/technotes/auxIO.rst
@@ -129,6 +129,7 @@ work on "standard" file systems as well).
    Since, Apache Hadoop's libhdfs spins up a jvm, each compute node will need 
    access to the Apache Hadoop HDFS jar files and correct Java classpath 
    configurations. Set ``CHPL_AUX_FILESYS=hdfs`` to use libhdfs.
+   Review ``$CHPL_HOME/modules/packages/HDFS.chpl`` for configuration.
 
  - Pivotal libhdfs3 is a pure C/C++ alternative implementation of the libhdfs. 
    To use libhdfs3: install the libhdfs3 using source code from the PivotalHD 

--- a/doc/release/technotes/auxIO.rst
+++ b/doc/release/technotes/auxIO.rst
@@ -128,7 +128,7 @@ work on "standard" file systems as well).
    libhdfs, make sure the jvm installation includes a static version of libjvm.
    Since, Apache Hadoop's libhdfs spins up a jvm, each compute node will need 
    access to the Apache Hadoop HDFS jar files and correct Java classpath 
-   configurations.
+   configurations. Set ``CHPL_AUX_FILESYS=hdfs`` to use libhdfs.
 
  - Pivotal libhdfs3 is a pure C/C++ alternative implementation of the libhdfs. 
    To use libhdfs3: install the libhdfs3 using source code from the PivotalHD 

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -49,7 +49,7 @@ CHPL_AUX_FILESYS to 'hdfs' to enable HDFS support:
 
   export CHPL_AUX_FILESYS=hdfs
 
-The HDFS C API on some platforms freezes using the default qthreads. Use fifo instead.
+Hdfslib on some platforms freezes using the default qthreads. Use fifo instead.
 
   export CHPL_TASKS=fifo
 
@@ -64,8 +64,6 @@ Then, rebuild Chapel by executing 'make' from $CHPL_HOME.
   If HDFS support is not enabled (which is the default), all
   features described below will compile successfully but will result in
   an error at runtime such as: "No HDFS Support".
-  
-  Currently, the HDFS C API is NOT supported on Macintosh OS X platforms.
 
 
 Using HDFS Support in Chapel

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -49,6 +49,10 @@ CHPL_AUX_FILESYS to 'hdfs' to enable HDFS support:
 
   export CHPL_AUX_FILESYS=hdfs
 
+The HDFS C API on some platforms freezes using the default q-threads. Use fifo instead.
+
+  export CHPL_TASKS=fifo
+
 Then, rebuild Chapel by executing 'make' from $CHPL_HOME.
 
 .. code-block:: sh
@@ -60,6 +64,8 @@ Then, rebuild Chapel by executing 'make' from $CHPL_HOME.
   If HDFS support is not enabled (which is the default), all
   features described below will compile successfully but will result in
   an error at runtime such as: "No HDFS Support".
+  
+  Currently, the HDFS C API is NOT supported on Macintosh OS X platforms.
 
 
 Using HDFS Support in Chapel
@@ -295,8 +301,8 @@ Here is a sample .bashrc for using Hadoop within Chapel:
   # those listed below if you have more than one IO system enabled. These are all
   # that you will need in order to use HDFS (only)
   #
-  export CHPL_AUXIO_INCLUDE="-I$JAVA_INSTALL/include -I$JAVA_INSTALL/include/linux  -I$HADOOP_INSTALL/src/c++/libhdfs"
-  export CHPL_AUXIO_LIBS="-L$JAVA_INSTALL/jre/lib/amd64/server -L$HADOOP_INSTALL/c++/Linux-amd64-64/lib"
+  export CHPL_AUXIO_INCLUDE="-I$JAVA_INSTALL/include -I$JAVA_INSTALL/include/linux  -I$HADOOP_INSTALL/include"
+  export CHPL_AUXIO_LIBS="-L$JAVA_INSTALL/jre/lib/amd64/server -L$HADOOP_INSTALL/lib/native"
 
   #
   # So we can run things such as start-all.sh etc. from anywhere and
@@ -312,12 +318,12 @@ Here is a sample .bashrc for using Hadoop within Chapel:
   #
   # Add Hadoop directories to the Java class path
   #
-  export CLASSPATH=$CLASSPATH:$HADOOP_HOME/""*:$HADOOP_HOME/lib/""*:$HADOOP_HOME/conf/""*:$(hadoop classpath):
+  export CLASSPATH=$CLASSPATH:`hadoop classpath --glob`:
 
   #
   # So we don't have to "install" these things
   #
-  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_HOME/c++/Linux-amd64-64/lib:$HADOOP_HOME/src/c++/libhdfs:$JAVA_INSTALL/jre/lib/amd64/server:$JAVA_INSTALL:$HADOOP_HOME/lib:$JAVA_INSTALL/jre/lib/amd64:$CLASSPATH
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_HOME/lib/native:$JAVA_INSTALL/jre/lib/amd64/server:$JAVA_INSTALL:$JAVA_INSTALL/jre/lib/amd64:$CLASSPATH
 
   #
   # Settings to run Chapel on multiple nodes

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -49,7 +49,7 @@ CHPL_AUX_FILESYS to 'hdfs' to enable HDFS support:
 
   export CHPL_AUX_FILESYS=hdfs
 
-The HDFS C API on some platforms freezes using the default q-threads. Use fifo instead.
+The HDFS C API on some platforms freezes using the default qthreads. Use fifo instead.
 
   export CHPL_TASKS=fifo
 
@@ -182,7 +182,7 @@ First reflect your directory structure and version numbers (etc) in the
 
 2. Install Hadoop
 
-   * Download the latest version of Hadoop and unpack it
+   * Download the latest version of Hadoop (minimum version > 2.0) and unpack it
 
    * Now in the unpacked directory, open conf/hadoop-env.sh and edit:
 
@@ -318,7 +318,7 @@ Here is a sample .bashrc for using Hadoop within Chapel:
   #
   # Add Hadoop directories to the Java class path
   #
-  export CLASSPATH=$CLASSPATH:`hadoop classpath --glob`:
+  export CLASSPATH=$CLASSPATH:`hadoop classpath --glob`
 
   #
   # So we don't have to "install" these things

--- a/runtime/make/Makefile.runtime.include
+++ b/runtime/make/Makefile.runtime.include
@@ -48,11 +48,11 @@ ifneq (,$(findstring hdfs,$(CHPL_MAKE_AUXFS)))
 	CHPL_AUXIO_INCLUDE ?= \
 		-I$(JAVA_INSTALL)/include \
 		-I$(JAVA_INSTALL)/include/linux \
-		-I$(HADOOP_INSTALL)/src/c++/libhdfs \
+		-I$(HADOOP_INSTALL)/include \
 
 	CHPL_AUXIO_LIBS ?= \
 		-L$(JAVA_INSTALL)/jre/lib/amd64/server \
-		-L$(HADOOP_INSTALL)/c++/Linux-amd64-64/lib 
+		-L$(HADOOP_INSTALL)/lib/native 
 endif 
 
 

--- a/util/chplenv/chpl_aux_filesys.py
+++ b/util/chplenv/chpl_aux_filesys.py
@@ -20,11 +20,13 @@ def get():
 
         # This will not check that all dependencies are satisfied..
         found_java = os.path.isdir(os.path.join(java_subdir, 'include'))
-        found_hdfs = os.path.exists(os.path.join(aux_fs_subdir, 'src', 'c++',
-                                                 'libhdfs', 'hdfs.h'))
+        found_hdfs = os.path.exists(os.path.join(aux_fs_subdir, 
+                                                 'include', 'hdfs.h'))
+        found_hdfs_lib = os.path.exists(os.path.join(aux_fs_subdir, 'lib',
+                                                 'native', 'libhdfs.a'))
         if not found_java:
             stderr.write("Warning: Can't find your Java installation\n")
-        if not found_hdfs:
+        if not found_hdfs or not found_hdfs_lib:
             stderr.write("Warning: Can't find your Hadoop installation\n")
 
     elif aux_fs == 'hdfs3':


### PR DESCRIPTION
The current instructions to build HDFS seem to be outdated. This patch updates the process.