### PR TITLE
(fast) meteor cleanup

### DIFF
--- a/test/release/examples/benchmarks/shootout/meteor-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/meteor-fast.chpl
@@ -1,45 +1,46 @@
 /* The Computer Language Benchmarks Game
  * http://benchmarksgame.alioth.debian.org/
  *
- * contributed by Kyle Brady and Ben Albrecht
- * derived from the C++ implementation by Stefan Westen which states it was
+ * contributed by Kyle Brady
+ * based upon the C++ implementation by Stefan Westen which states it was
  * loosely based on Ben St. John's and Kevin Barnes' implementation
  */
 
 use BitOps;
 
-// Arrays of masks to store all pieces and their possible configurations
-var allMasks: [0..8191] uint(32),
-    maskStart: [0..49][0..7] uint(32);
+const pieceCount: int(32) = 10;
+const pieces: [0..9][0..4][0..1] int(32) = [
+  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [2:int(32), 0:int(32)], [3:int(32), 0:int(32)], [3:int(32), 1:int(32)]],
+  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [-2:int(32), 2:int(32)], [-1:int(32), 2:int(32)], [-3:int(32), 3:int(32)]],
+  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [2:int(32), 0:int(32)], [-1:int(32), 1:int(32)], [-1:int(32), 2:int(32)]],
+  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [2:int(32), 0:int(32)], [1:int(32), 1:int(32)], [1:int(32), 2:int(32)]],
+  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [1:int(32), 1:int(32)], [-1:int(32), 2:int(32)], [1:int(32), 2:int(32)]],
+  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [-2:int(32), 1:int(32)], [-1:int(32), 1:int(32)], [0:int(32), 1:int(32)]],
+  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [0:int(32), 1:int(32)], [-1:int(32), 2:int(32)], [-1:int(32), 3:int(32)]],
+  [[0:int(32), 0:int(32)], [2:int(32), 0:int(32)], [-1:int(32), 1:int(32)], [0:int(32), 1:int(32)], [1:int(32), 1:int(32)]],
+  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [0:int(32), 2:int(32)], [1:int(32), 2:int(32)], [1:int(32), 3:int(32)]],
+  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [0:int(32), 2:int(32)], [-1:int(32), 3:int(32)], [0:int(32), 3:int(32)]]
+];
 
-// Arrays of solutions
-var minSolution: [0..49] uint(8),
-    maxSolution: [0..49] uint(8),
-    solutions: uint(32);
+var allMasks: [0..8191] uint(32);
+var maskStart: [0..49][0..7] uint(32);
 
-// Masks for evens and left border
-var evenRowsLookup: [0..49] uint(32),
-    leftBorderLookup: [0..49] uint(32);
+var minSolution: [0..49] uint(8);
+var maxSolution: [0..49] uint(8);
+var solutions: uint(32);
 
-// Predefined masks commonly used throughout program
-param maskEven = 0xf07c1f07c1f07c1f,    // Even rows of board (rows 0, 2, 4,..)
-      maskBorder = 0x1084210842108421,  // Right border of board
-      maskBoard = 0xFFFC000000000000,   // bits of board within 64-bit int
-      maskBottom = 0x003FFFFF,          // Bottom 22 elements of boards
-      maskUsed = 0xFFC00000;            // Board + 4 additional bits
+var evenRowsLookup: [0..49] uint(32);
+var leftBorderLookup: [0..49] uint(32);
 
-//
-// Determine if piece and permutation (mask) at a given position (pos) is valid
-//
 proc goodPiece(mask: uint(32), pos: uint(32)): bool {
-   var isGood = true;
-   const evenRows: uint = maskEven,
-         oddRows: uint = ~evenRows,
-         leftBorder: uint = maskBorder,
-         rightBorder: uint = leftBorder >> 1;
+   var isGood: bool = true;
+   const evenRows: uint = 0xf07c1f07c1f07c1f;
+   const oddRows: uint = ~evenRows;
+   const leftBorder: uint = 0x1084210842108421;
+   const rightBorder: uint = leftBorder >> 1;
    var a, b, aOld, s1, s2, s3, s4, s5, s6, s7, s8: uint;
 
-   b = (mask:uint << pos) | maskBoard;
+   b = (mask:uint << pos) | 0xFFFC000000000000;
 
    b = ~b;
 
@@ -68,146 +69,93 @@ proc goodPiece(mask: uint(32), pos: uint(32)): bool {
    return isGood;
 }
 
-//
-// Setup allMasks with pre-filtered piece permutations to search
-//
-proc initialize() {
-
-  // Set up array of evens and borders masks
+proc initialise() {
   for i in 0..49 {
-    evenRowsLookup[i] = (maskEven >> i): uint(32);
-    leftBorderLookup[i] = (maskBorder >> i): uint(32);
+    evenRowsLookup[i] = (0xF07C1F07C1F07C1F >> i):uint(32);
+    leftBorderLookup[i] = (0x1084210842108421 >> i):uint(32);
   }
 
-  var totalCount: uint(32),
-      xCoords: [0..4] int,
-      yCoords: [0..4] int;
-
-  const pieceCount = 10;
-
-  /* The hexagonal puzzle pieces are defined with cell coordinates
-   * starting from the origin [0,0].
-   *
-   *   Piece 0   Piece 1   Piece 2   Piece 3   Piece 4
-   *
-   *  O O O O    O   O O   O O O     O O O     O   O
-   *         O    O O           O       O       O O
-   *                           O         O         O
-   *
-   *   Piece 5   Piece 6   Piece 7   Piece 8   Piece 9
-   *
-   *    O O O     O O       O O     O O        O O O O
-   *       O O       O O       O       O O O        O
-   *                  O       O O
-   *
-   */
-  const pieces: [0..9][0..4][0..1] int =
-  [
-    [[0, 0], [1, 0], [2, 0], [3, 0], [3, 1]],
-    [[0, 0], [0, 1], [-2, 2], [-1, 2], [-3, 3]],
-    [[0, 0], [1, 0], [2, 0], [-1, 1], [-1, 2]],
-    [[0, 0], [1, 0], [2, 0], [1, 1], [1, 2]],
-    [[0, 0], [0, 1], [1, 1], [-1, 2], [1, 2]],
-    [[0, 0], [1, 0], [-2, 1], [-1, 1], [0, 1]],
-    [[0, 0], [1, 0], [0, 1], [-1, 2], [-1, 3]],
-    [[0, 0], [2, 0], [-1, 1], [0, 1], [1, 1]],
-    [[0, 0], [0, 1], [0, 2], [1, 2], [1, 3]],
-    [[0, 0], [0, 1], [0, 2], [-1, 3], [0, 3]]
-  ];
-
-  // Generate bit mask for permutations of all pieces that fit on rows 2 & 3
-  for yBase in 2..3 {
-    for xBase in 0..4 {
-      // Compute base position for xBase, yBase coordinates
-      const pos: uint(32) = (xBase + 5 * yBase): uint(32);
-
-      // Record total number of fitted pieces at this point
+  var totalCount: uint(32);
+  var x: [0..4] int(32);
+  var y: [0..4] int(32);
+  for yBase in 2..3:int(32) {
+    for xBase in 0..4:int(32) {
+      const pos: uint(32) = (xBase+5*yBase):uint(32);
       maskStart[pos][0] = totalCount;
-
-      // Loop over piece indices
       for piece in 0..pieceCount-1 {
-
-        // Get x y coordinates of piece cells
         for j in 0..4 {
-          xCoords[j] = pieces[piece][j][0];
-          yCoords[j] = pieces[piece][j][1];
+          x[j] = pieces[piece][j][0];
+          y[j] = pieces[piece][j][1];
         }
 
-        // Loop over 12 permutations for a given piece (6 rotations * 2 flips)
-        for currentPermutation in 0..11 {
-
-          // Skip piece 3 and specific permutations
-          if piece != 3 || (currentPermutation/3) % 2 == 0 {
-
-            // Compute the xMin and yMin of coordinates for given permutation
-            var xMin = xCoords[0], yMin = yCoords[0];
-            for (x, y) in zip(xCoords, yCoords) {
-              if y < yMin || (y == yMin && x < xMin) then
-                (xMin, yMin) = (x, y);
+        for currentRotation in 0..11 {
+          if piece != 3 || (currentRotation/3) % 2 == 0 {
+            var minX: int(32) = x[0];
+            var minY: int(32) = y[0];
+            for i in 1..4 {
+              if y[i] < minY || (y[i] == minY && x[i] < minX) {
+                minX = x[i];
+                minY = y[i];
+              }
             }
 
-            var mask: uint(32), // Bit mask representing piece's permutation
-                fit = true;     // Track if piece's permutation fits board
+            var mask: uint(32);
+            var fit: bool = true;
 
-            // Offsets for piece coordinates, such that 'island' is not formed
-            const xOff = (xBase - yBase/2) - xMin,
-                  yOff= yBase - yMin;
-
-            // Set bit mask for given piece's permutation if it fits on board
-            for (x, y) in zip(xCoords, yCoords) {
-
-              var nY = y + yOff,
-                  nX = x + xOff + nY/2;
-
+            for i in 0..4 {
+              var nX: int(32) = (x[i]-minX+(xBase-yBase/2)) + (y[i]-minY+yBase)/2;
+              var nY: int(32) = y[i]-minY+yBase;
               if nX >= 0 && nX < 5 {
-                var numBits = nX - xBase + 5 * (nY - yBase);
-                mask |= (1:uint(32) << numBits);
-              } else
+                var numBits: int(32) = nX-xBase+5*(nY-yBase);
+                mask |= (1:int(32)<<numBits);
+              } else {
                 fit = false;
+              }
             }
-
-            // If it fits and is a "good piece", add it to the array of masks
-            if fit then
+            if fit {
               if goodPiece(mask, pos) {
-                allMasks[totalCount] = mask|(1:int(32) << (piece + 22));
+                allMasks[totalCount] = mask|(1:int(32)<<(piece+22));
                 totalCount += 1;
               }
+            }
           }
 
-          // Permute piece for next iteration
-          for (x, y) in zip(xCoords, yCoords) {
-            // Rotation
-            (x, y) = (x + y, -x);
-
-            // Reflection
-            if currentPermutation == 5 then
-              (x, y) = (x + y, -y);
+          for i in 0..4 {
+            const xnew: int(32) = x[i]+y[i];
+            const ynew: int(32) = -x[i];
+            x[i] = xnew;
+            y[i] = ynew;
+            if currentRotation == 5 {
+              const xnew:int(32) = x[i]+y[i];
+              const ynew:int(32) = -y[i];
+              x[i] = xnew;
+              y[i] = ynew;
+            }
           }
-        } // permutations
-      } // pieces
-
+        }
+      }
       allMasks[totalCount] = 0;
       totalCount += 1;
-    } // xBase
-  } // yBase
+    }
+  }
 
-  // Generate bit masks for translation of permutations that fit on rows 2 & 3
-  for yBase in 0..9 {
-    // Skip rows 2 & 3, since we already generated their masks
+   // copy rows 2 and 3 to other rows
+
+  for yBase in 0..9:int(32) {
     if yBase!=2 && yBase!=3 {
-      for xBase in 0..4 {
-        const pos = (xBase + 5 * yBase): uint(32),
-              origPos = xBase + 5 * (yBase%2 + 2);
+      for xBase in 0..4:int(32) {
+        const pos: uint(32) = (xBase+5*yBase):uint(32);
+        const origPos: int(32) = xBase+5*(yBase%2+2);
         maskStart[pos][0] = totalCount;
-        var pMask = maskStart[origPos][0];
-        const bottom = ((maskBoard >> pos) & maskBottom): uint(32),
-              lastRow = ((maskBoard >> (pos + 5)) & maskBottom): uint(32);
+        var pMask: uint(32) = maskStart[origPos][0];
+        const bottom: uint(32) = ((0xFFFC000000000000>>pos) & 0x003FFFFF):uint(32);
+        const lastRow: uint(32) = ((0xFFFC000000000000>>(pos+5)) & 0x003FFFFF):uint(32);
         while allMasks[pMask] {
-          var mask = allMasks[pMask];
+          var mask: uint(32) = allMasks[pMask];
           pMask += 1;
           if (mask & bottom) == 0 {
             if yBase == 0 || ((mask & lastRow) != 0) {
-              if !goodPiece(mask & maskBottom, pos) {
+              if !goodPiece(mask&0x003FFFFF, pos) {
                 continue;
               }
             }
@@ -224,11 +172,12 @@ proc initialize() {
   for filter in 1..7:uint(32) {
     for pos in 0..49:uint(32) {
       maskStart[pos][filter] = totalCount;
-      var filterMask = ((filter&1)<<1) | ((filter&6)<<(4-(evenRowsLookup[pos]&1))),
-          pMask = maskStart[pos][0];
+      var filterMask: uint(32);
+      filterMask = ((filter&1)<<1) | ((filter&6)<<(4-(evenRowsLookup[pos]&1)));
+      var pMask: uint(32) = maskStart[pos][0];
       while allMasks[pMask] {
-        const mask = allMasks[pMask];
-        if (mask & filterMask) == 0 {
+        const mask:uint(32) = allMasks[pMask];
+        if (mask&filterMask) == 0 {
           allMasks[totalCount] = mask;
           totalCount += 1;
         }
@@ -240,61 +189,60 @@ proc initialize() {
   }
 }
 
-//
-// Determine whether a solution is a min or max solution
-//
 proc compareSolution(board: [] uint(8), minSolution: [] uint(8),
                      maxSolution: [] uint(8)) {
+  var i, j: int(32);
 
   for i in 0..49 {
     if board[i] < minSolution[i] {
-      minSolution = board;
+      for j in 0..49 {
+        minSolution[j] = board[j];
+      }
       break;
-    } else if board[i] > minSolution[i] then break;
+    } else if board[i] > minSolution[i] {
+      break;
+    }
   }
   for i in 0..49 {
     if board[i] > maxSolution[i] {
-      maxSolution = board;
+      for j in 0..49 {
+        maxSolution[j] = board[j];
+      }
       break;
-    } else if board[i] < maxSolution[i] then break;
+    } else if board[i] < maxSolution[i] {
+      break;
+    }
   }
 }
 
-//
-// Pretty printed output of board
-//
 proc printBoard(board: [] uint(8)) {
   for i in 0..49 {
     writef("%i ", board[i]);
     if i%5 == 4 {
       writeln();
-      if i&1 == 0 then
+      if (i&1) == 0 {
         write(" ");
+      }
     }
   }
   writeln();
 }
 
-//
-// Check a given board as a solution and record it
-//
 proc recordSolution(currentSolution: [] uint(32)) {
-  var board: [0..49] uint(8),
-      flipBoard: [0..49] uint(8),
-      mask, pos, currentBit, b1: uint(32),
-      count: uint(32),
-      piece: uint(8);
-
+  var board: [0..49] uint(8);
+  var flipBoard: [0..49] uint(8);
+  var mask, pos, currentBit, b1 : uint(32);
+  var piece, count : uint(32);
   for i in 0..9 {
     mask = currentSolution[i];
-    piece = ctz(mask >> 22: uint(32)): uint(8);
-    mask &= maskBottom;
+    piece = ctz(mask>>22:uint(32)):uint(32);
+    mask &= 0x003FFFFF;
     b1 |= mask;
     while mask {
-      currentBit = mask & (-(mask: int(32))): uint(32);
-      count = ctz(currentBit): uint(32);
-      board[count+pos] = piece;
-      flipBoard[49-count-pos] = piece;
+      currentBit = mask&(-(mask:int(32))):uint(32);
+      count = ctz(currentBit):uint(32);
+      board[count+pos] = piece:uint(8);
+      flipBoard[49-count-pos] = piece:uint(8);
       mask ^= currentBit;
     }
     count = ctz(~b1);
@@ -302,8 +250,10 @@ proc recordSolution(currentSolution: [] uint(32)) {
     b1 >>= count;
   }
   if solutions == 0 {
-    minSolution = board;
-    maxSolution = board;
+    for i in 0..49 {
+      minSolution[i] = board[i];
+      maxSolution[i] = board[i];
+    }
   } else {
     compareSolution(board, minSolution, maxSolution);
     compareSolution(flipBoard, minSolution, maxSolution);
@@ -312,9 +262,6 @@ proc recordSolution(currentSolution: [] uint(32)) {
   solutions += 2;
 }
 
-//
-// DIY sync record that outperforms native sync vars
-//
 record Spinlock {
   var l: atomic bool;
 
@@ -329,13 +276,11 @@ record Spinlock {
 
 var recordLock: Spinlock;
 
-//
-// Recursively add pieces to the board, and check solution when filled.
-//
 proc searchLinear(in board: uint(32), in pos: uint(32), in used: uint(32),
                   in placed: uint(32), currentSolution: [] uint(32)) {
-  var count, evenRows, oddRows, leftBorder, rightBorder,
-      s1, s2, s3, s4, s5, s6, s7, s8: uint(32);
+  var count : uint(32);
+  var evenRows, oddRows, leftBorder, rightBorder: uint(32);
+  var s1, s2, s3, s4, s5, s6, s7, s8: uint(32);
   if placed == 10 {
     recordLock.lock();
     recordSolution(currentSolution);
@@ -346,50 +291,47 @@ proc searchLinear(in board: uint(32), in pos: uint(32), in used: uint(32),
     oddRows = ~evenRows;
 
     leftBorder = leftBorderLookup[pos];
-    rightBorder = leftBorder >> 1;
+    rightBorder = leftBorder>>1;
 
     s1 = (board << 1) | leftBorder;
     s2 = (board >> 1) | rightBorder;
-    s3 = (board << 4) | ((1 << 4) - 1) | rightBorder;
+    s3 = (board << 4) | ((1<<4)-1) | rightBorder;
     s4 = (board >> 4) | leftBorder;
-    s5 = (board << 5) | ((1 << 5) - 1);
+    s5 = (board << 5) | ((1<<5)-1);
     s6 = (board >> 5);
-    s7 = (board << 6) | ((1 << 6) - 1) | leftBorder;
+    s7 = (board << 6) | ((1<<6)-1) | leftBorder;
     s8 = (board >> 6) | rightBorder;
 
-    if ~board & s1 & s2 & s5 & s6 &
-       ((evenRows & s4 & s7) | (oddRows & s3 & s8)) then return;
+    if ~board&s1&s2&s5&s6 & ((evenRows&s4&s7) | (oddRows&s3&s8)) {
+      return;
+    }
 
     count = ctz(~board);
     pos += count;
     board >>= count;
 
-    const f = ((board >> 1) & 1) |
-              ((board >> (4 - (evenRowsLookup[pos] & 1))) & 6),
-          boardAndUsed = board | used;
+    const f: uint(32) = ((board>>1)&1) | ((board >> (4-(evenRowsLookup[pos] & 1)))&6);
+    const boardAndUsed = board|used;
 
-    var mask: uint(32),
-        currentMask = maskStart[pos][f];
+    var mask: uint(32);
+    var currentMask: uint(32) = maskStart[pos][f];
 
     while allMasks[currentMask] {
-
-      while allMasks[currentMask] & boardAndUsed do
+      while allMasks[currentMask] & boardAndUsed {
         currentMask += 1;
-
+      }
       if allMasks[currentMask] {
         mask = allMasks[currentMask];
         currentSolution[placed] = mask;
-        searchLinear(board | (mask & maskBottom), pos, used | (mask & maskUsed),
-                     placed+1, currentSolution);
+        searchLinear(board|(mask & 0x003FFFFF:uint(32)), pos,
+                     used|(mask & 0xFFC00000:uint(32)), placed+1,
+                     currentSolution);
         currentMask += 1;
       }
     }
   }
 }
 
-//
-// Wrapper to setup initial call to recursive searchLinear
-//
 proc searchLinearHelper(in board: uint(32), in pos: uint(32),
                         in used: uint(32), in placed: uint(32),
                         in firstPiece: uint(32), in mask: uint(32)) {
@@ -400,39 +342,37 @@ proc searchLinearHelper(in board: uint(32), in pos: uint(32),
 }
 
 
-//
-// Add initial piece to board, then fire off remaining searches in parallel
-//
 proc searchParallel(in board: uint(32), in pos: uint(32), in used: uint(32),
                     in placed: uint(32), in firstPiece: uint(32)) {
+  var count: uint(32);
 
-  var count = ctz(~board): uint(32);
+  count = ctz(~board):uint(32);
   pos += count;
   board >>= count;
 
-  const boardAndUsed = board | used;
-  var currentMask = maskStart[pos][0],
-      mask: uint(32);
+  const boardAndUsed: uint(32) = board|used;
+  var currentMask: uint(32) = maskStart[pos][0];
+  var mask: uint(32);
 
   if placed == 0 {
     while allMasks[currentMask] {
       if allMasks[currentMask] {
         mask = allMasks[currentMask];
         currentMask += 1;
-        searchParallel(board | (mask & maskBottom), pos,
-                       used | (mask & maskUsed), placed + 1, mask);
+        searchParallel(board|(mask&0x003FFFFF), pos,
+                       used|(mask&0xFFC00000:uint(32)), placed+1, mask);
       }
     }
   } else {   // placed == 1
     while allMasks[currentMask] {
-      while allMasks[currentMask] & boardAndUsed do
+      while allMasks[currentMask] & boardAndUsed {
         currentMask += 1;
-
+      }
       if allMasks[currentMask] {
         mask = allMasks[currentMask];
         currentMask += 1;
-        searchLinearHelper(board | (mask & maskBottom), pos,
-                           used | (mask & maskUsed), placed+1,
+        searchLinearHelper(board|((mask&0x003FFFFF)), pos,
+                           used|(mask&0xFFC00000:uint(32)),  placed+1,
                            firstPiece, mask);
       }
     }
@@ -440,16 +380,18 @@ proc searchParallel(in board: uint(32), in pos: uint(32), in used: uint(32),
 }
 
 
-//
-// Find and print the minimum and maximum solutions to meteor puzzle
-//
-proc main() {
+proc main(args: [] string): int
+{
+  if args.size > 2 then
+    return 1;
 
-  initialize();
+  initialise();
 
   sync searchParallel(0,0,0,0,0);
 
   writef("%i solutions found\n\n", solutions);
   printBoard(minSolution);
   printBoard(maxSolution);
+
+  return 0;
 }

--- a/test/release/examples/benchmarks/shootout/meteor-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/meteor-fast.chpl
@@ -22,7 +22,7 @@ var evenRowsLookup: [0..49] uint(32),
     leftBorderLookup: [0..49] uint(32);
 
 // Predefined masks commonly used throughout program
-param maskEven = 0xf07c1f07c1f07c1f,    // Even rows of board (starts at row 0)
+param maskEven = 0xf07c1f07c1f07c1f,    // Even rows of board (rows 0, 2, 4,..)
       maskBorder = 0x1084210842108421,  // Right border of board
       maskBoard = 0xFFFC000000000000,   // bits of board within 64-bit int
       maskBottom = 0x003FFFFF,          // Bottom 22 elements of boards
@@ -69,7 +69,7 @@ proc goodPiece(mask: uint(32), pos: uint(32)): bool {
 }
 
 //
-//
+// Setup allMasks with pre-filtered piece permutations to search
 //
 proc initialize() {
 

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -13,7 +13,6 @@ use BitOps;
 
  * More comments
  * More inferred types
- * x/yCoords -> Coords tuple (pieces)
  * Top down view -> Breadth first
 
 */
@@ -95,8 +94,7 @@ proc initialize() {
   }
 
   var totalCount = 0,
-      xCoords: [0..4] int,
-      yCoords: [0..4] int;
+      coords: [0..4] 2*int;
 
   const pieceCount = 10;
 
@@ -116,18 +114,18 @@ proc initialize() {
    *                  O       O O
    *
    */
-  const pieces: [piecesDom][0..4][0..1] int =
+  const pieces: [piecesDom][0..4] 2*int =
   [
-    [[0, 0], [1, 0], [2, 0], [3, 0], [3, 1]],
-    [[0, 0], [0, 1], [-2, 2], [-1, 2], [-3, 3]],
-    [[0, 0], [1, 0], [2, 0], [-1, 1], [-1, 2]],
-    [[0, 0], [1, 0], [2, 0], [1, 1], [1, 2]],
-    [[0, 0], [0, 1], [1, 1], [-1, 2], [1, 2]],
-    [[0, 0], [1, 0], [-2, 1], [-1, 1], [0, 1]],
-    [[0, 0], [1, 0], [0, 1], [-1, 2], [-1, 3]],
-    [[0, 0], [2, 0], [-1, 1], [0, 1], [1, 1]],
-    [[0, 0], [0, 1], [0, 2], [1, 2], [1, 3]],
-    [[0, 0], [0, 1], [0, 2], [-1, 3], [0, 3]]
+    [(0, 0), (1, 0), ( 2, 0), ( 3, 0), ( 3, 1)],
+    [(0, 0), (0, 1), (-2, 2), (-1, 2), (-3, 3)],
+    [(0, 0), (1, 0), ( 2, 0), (-1, 1), (-1, 2)],
+    [(0, 0), (1, 0), ( 2, 0), ( 1, 1), ( 1, 2)],
+    [(0, 0), (0, 1), ( 1, 1), (-1, 2), ( 1, 2)],
+    [(0, 0), (1, 0), (-2, 1), (-1, 1), ( 0, 1)],
+    [(0, 0), (1, 0), ( 0, 1), (-1, 2), (-1, 3)],
+    [(0, 0), (2, 0), (-1, 1), ( 0, 1), ( 1, 1)],
+    [(0, 0), (0, 1), ( 0, 2), ( 1, 2), ( 1, 3)],
+    [(0, 0), (0, 1), ( 0, 2), (-1, 3), ( 0, 3)]
   ];
 
   // Generate bit mask for permutations of all pieces that fit on rows 2 & 3
@@ -143,10 +141,8 @@ proc initialize() {
       for piece in 0..pieceCount-1 {
 
         // Get x y coordinates of piece cells
-        for j in 0..4 {
-          xCoords[j] = pieces[piece][j][0];
-          yCoords[j] = pieces[piece][j][1];
-        }
+        for (coord, pieceCell) in zip(coords, pieces[piece]) do
+          coord = pieceCell;
 
         // Loop over 12 permutations for a given piece (6 rotations * 2 flips)
         for currentPermutation in 0..11 {
@@ -155,8 +151,8 @@ proc initialize() {
           if piece != 3 || (currentPermutation/3) % 2 == 0 {
 
             // Compute the xMin and yMin of coordinates for given permutation
-            var xMin = xCoords[0], yMin = yCoords[0];
-            for (x, y) in zip(xCoords, yCoords) {
+            var xMin = coords[0][1], yMin = coords[0][2];
+            for (x, y) in coords {
               if y < yMin || (y == yMin && x < xMin) then
                 (xMin, yMin) = (x, y);
             }
@@ -169,7 +165,7 @@ proc initialize() {
                   yOff= yBase - yMin;
 
             // Set bit mask for given piece's permutation if it fits on board
-            for (x, y) in zip(xCoords, yCoords) {
+            for (x, y) in coords {
 
               var nY = y + yOff,
                   nX = x + xOff + nY/2;
@@ -190,7 +186,7 @@ proc initialize() {
           }
 
           // Permute piece for next iteration
-          for (x, y) in zip(xCoords, yCoords) {
+          for (x, y) in coords {
             // Rotation
             (x, y) = (x + y, -x);
 

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -18,13 +18,11 @@ var allMasks: [permutationsDom] int,
     maskStart: [boardDom][0..7] int;
 
 // Arrays of min, max, and number of solutions
-var minSolution: [boardDom] int,
-    maxSolution: [boardDom] int,
+var minSolution, maxSolution: [boardDom] int,
     solutions: int;
 
 // Masks for evens and left border
-var evenRowsLookup: [boardDom] int,
-    leftBorderLookup: [boardDom] int;
+var evenRowsLookup, leftBorderLookup: [boardDom] int;
 
 // Predefined masks commonly used throughout program
 param maskEven   = 0xf07c1f07c1f07c1f: int, // Even rows of board (0, 2, 4, ..)
@@ -33,17 +31,19 @@ param maskEven   = 0xf07c1f07c1f07c1f: int, // Even rows of board (0, 2, 4, ..)
       maskBottom = 0x00000000003FFFFF: int, // Bottom 22 elements of boards
       maskUsed   = 0x00000000FFC00000: int; // Board + 4 additional bits
 
-//
 // DIY sync variable functionality that outperforms native sync variables.
 // Access controlled by functions lock() and unlock()
-//
 var l: atomic bool;
 
 
 //
 // Find and print the minimum and maximum solutions to meteor puzzle
 //
-proc main() {
+proc main(args: [] string) {
+
+  // Support dummy arguments for shootout execution scripts
+  if args.size > 2 then
+    return;
 
   initialize();
 
@@ -413,8 +413,7 @@ proc unlock() {
 // Check a given board as a solution and record it
 //
 proc recordSolution(currentSolution) {
-  var board: [boardDom] int,
-      flipBoard: [boardDom] int,
+  var board, flipBoard: [boardDom] int,
       mask, pos, currentBit, b1, count, piece: int;
 
   for i in piecesDom {

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -1,46 +1,45 @@
 /* The Computer Language Benchmarks Game
  * http://benchmarksgame.alioth.debian.org/
  *
- * contributed by Kyle Brady
- * based upon the C++ implementation by Stefan Westen which states it was
+ * contributed by Kyle Brady and Ben Albrecht
+ * derived from the C++ implementation by Stefan Westen which states it was
  * loosely based on Ben St. John's and Kevin Barnes' implementation
  */
 
 use BitOps;
 
-const pieceCount: int(32) = 10;
-const pieces: [0..9][0..4][0..1] int(32) = [
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [2:int(32), 0:int(32)], [3:int(32), 0:int(32)], [3:int(32), 1:int(32)]],
-  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [-2:int(32), 2:int(32)], [-1:int(32), 2:int(32)], [-3:int(32), 3:int(32)]],
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [2:int(32), 0:int(32)], [-1:int(32), 1:int(32)], [-1:int(32), 2:int(32)]],
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [2:int(32), 0:int(32)], [1:int(32), 1:int(32)], [1:int(32), 2:int(32)]],
-  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [1:int(32), 1:int(32)], [-1:int(32), 2:int(32)], [1:int(32), 2:int(32)]],
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [-2:int(32), 1:int(32)], [-1:int(32), 1:int(32)], [0:int(32), 1:int(32)]],
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [0:int(32), 1:int(32)], [-1:int(32), 2:int(32)], [-1:int(32), 3:int(32)]],
-  [[0:int(32), 0:int(32)], [2:int(32), 0:int(32)], [-1:int(32), 1:int(32)], [0:int(32), 1:int(32)], [1:int(32), 1:int(32)]],
-  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [0:int(32), 2:int(32)], [1:int(32), 2:int(32)], [1:int(32), 3:int(32)]],
-  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [0:int(32), 2:int(32)], [-1:int(32), 3:int(32)], [0:int(32), 3:int(32)]]
-];
+// Arrays of masks to store all pieces and their possible configurations
+var allMasks: [0..8191] uint(32),
+    maskStart: [0..49][0..7] uint(32);
 
-var allMasks: [0..8191] uint(32);
-var maskStart: [0..49][0..7] uint(32);
+// Arrays of solutions
+var minSolution: [0..49] uint(8),
+    maxSolution: [0..49] uint(8),
+    solutions: uint(32);
 
-var minSolution: [0..49] uint(8);
-var maxSolution: [0..49] uint(8);
-var solutions: uint(32);
+// Masks for evens and left border
+var evenRowsLookup: [0..49] uint(32),
+    leftBorderLookup: [0..49] uint(32);
 
-var evenRowsLookup: [0..49] uint(32);
-var leftBorderLookup: [0..49] uint(32);
+// Predefined masks commonly used throughout program
+param maskEven = 0xf07c1f07c1f07c1f,    // Even rows of board (rows 0, 2, 4,..)
+      maskBorder = 0x1084210842108421,  // Right border of board
+      maskBoard = 0xFFFC000000000000,   // bits of board within 64-bit int
+      maskBottom = 0x003FFFFF,          // Bottom 22 elements of boards
+      maskUsed = 0xFFC00000;            // Board + 4 additional bits
 
+//
+// Determine if piece and permutation (mask) at a given position (pos) is valid
+//
 proc goodPiece(mask: uint(32), pos: uint(32)): bool {
-   var isGood: bool = true;
-   const evenRows: uint = 0xf07c1f07c1f07c1f;
-   const oddRows: uint = ~evenRows;
-   const leftBorder: uint = 0x1084210842108421;
-   const rightBorder: uint = leftBorder >> 1;
+   var isGood = true;
+   const evenRows: uint = maskEven,
+         oddRows: uint = ~evenRows,
+         leftBorder: uint = maskBorder,
+         rightBorder: uint = leftBorder >> 1;
    var a, b, aOld, s1, s2, s3, s4, s5, s6, s7, s8: uint;
 
-   b = (mask:uint << pos) | 0xFFFC000000000000;
+   b = (mask:uint << pos) | maskBoard;
 
    b = ~b;
 
@@ -69,93 +68,146 @@ proc goodPiece(mask: uint(32), pos: uint(32)): bool {
    return isGood;
 }
 
-proc initialise() {
+//
+// Setup allMasks with pre-filtered piece permutations to search
+//
+proc initialize() {
+
+  // Set up array of evens and borders masks
   for i in 0..49 {
-    evenRowsLookup[i] = (0xF07C1F07C1F07C1F >> i):uint(32);
-    leftBorderLookup[i] = (0x1084210842108421 >> i):uint(32);
+    evenRowsLookup[i] = (maskEven >> i): uint(32);
+    leftBorderLookup[i] = (maskBorder >> i): uint(32);
   }
 
-  var totalCount: uint(32);
-  var x: [0..4] int(32);
-  var y: [0..4] int(32);
-  for yBase in 2..3:int(32) {
-    for xBase in 0..4:int(32) {
-      const pos: uint(32) = (xBase+5*yBase):uint(32);
+  var totalCount: uint(32),
+      xCoords: [0..4] int,
+      yCoords: [0..4] int;
+
+  const pieceCount = 10;
+
+  /* The hexagonal puzzle pieces are defined with cell coordinates
+   * starting from the origin [0,0].
+   *
+   *   Piece 0   Piece 1   Piece 2   Piece 3   Piece 4
+   *
+   *  O O O O    O   O O   O O O     O O O     O   O
+   *         O    O O           O       O       O O
+   *                           O         O         O
+   *
+   *   Piece 5   Piece 6   Piece 7   Piece 8   Piece 9
+   *
+   *    O O O     O O       O O     O O        O O O O
+   *       O O       O O       O       O O O        O
+   *                  O       O O
+   *
+   */
+  const pieces: [0..9][0..4][0..1] int =
+  [
+    [[0, 0], [1, 0], [2, 0], [3, 0], [3, 1]],
+    [[0, 0], [0, 1], [-2, 2], [-1, 2], [-3, 3]],
+    [[0, 0], [1, 0], [2, 0], [-1, 1], [-1, 2]],
+    [[0, 0], [1, 0], [2, 0], [1, 1], [1, 2]],
+    [[0, 0], [0, 1], [1, 1], [-1, 2], [1, 2]],
+    [[0, 0], [1, 0], [-2, 1], [-1, 1], [0, 1]],
+    [[0, 0], [1, 0], [0, 1], [-1, 2], [-1, 3]],
+    [[0, 0], [2, 0], [-1, 1], [0, 1], [1, 1]],
+    [[0, 0], [0, 1], [0, 2], [1, 2], [1, 3]],
+    [[0, 0], [0, 1], [0, 2], [-1, 3], [0, 3]]
+  ];
+
+  // Generate bit mask for permutations of all pieces that fit on rows 2 & 3
+  for yBase in 2..3 {
+    for xBase in 0..4 {
+      // Compute base position for xBase, yBase coordinates
+      const pos: uint(32) = (xBase + 5 * yBase): uint(32);
+
+      // Record total number of fitted pieces at this point
       maskStart[pos][0] = totalCount;
+
+      // Loop over piece indices
       for piece in 0..pieceCount-1 {
+
+        // Get x y coordinates of piece cells
         for j in 0..4 {
-          x[j] = pieces[piece][j][0];
-          y[j] = pieces[piece][j][1];
+          xCoords[j] = pieces[piece][j][0];
+          yCoords[j] = pieces[piece][j][1];
         }
 
-        for currentRotation in 0..11 {
-          if piece != 3 || (currentRotation/3) % 2 == 0 {
-            var minX: int(32) = x[0];
-            var minY: int(32) = y[0];
-            for i in 1..4 {
-              if y[i] < minY || (y[i] == minY && x[i] < minX) {
-                minX = x[i];
-                minY = y[i];
-              }
+        // Loop over 12 permutations for a given piece (6 rotations * 2 flips)
+        for currentPermutation in 0..11 {
+
+          // Skip piece 3 and specific permutations
+          if piece != 3 || (currentPermutation/3) % 2 == 0 {
+
+            // Compute the xMin and yMin of coordinates for given permutation
+            var xMin = xCoords[0], yMin = yCoords[0];
+            for (x, y) in zip(xCoords, yCoords) {
+              if y < yMin || (y == yMin && x < xMin) then
+                (xMin, yMin) = (x, y);
             }
 
-            var mask: uint(32);
-            var fit: bool = true;
+            var mask: uint(32), // Bit mask representing piece's permutation
+                fit = true;     // Track if piece's permutation fits board
 
-            for i in 0..4 {
-              var nX: int(32) = (x[i]-minX+(xBase-yBase/2)) + (y[i]-minY+yBase)/2;
-              var nY: int(32) = y[i]-minY+yBase;
+            // Offsets for piece coordinates, such that 'island' is not formed
+            const xOff = (xBase - yBase/2) - xMin,
+                  yOff= yBase - yMin;
+
+            // Set bit mask for given piece's permutation if it fits on board
+            for (x, y) in zip(xCoords, yCoords) {
+
+              var nY = y + yOff,
+                  nX = x + xOff + nY/2;
+
               if nX >= 0 && nX < 5 {
-                var numBits: int(32) = nX-xBase+5*(nY-yBase);
-                mask |= (1:int(32)<<numBits);
-              } else {
+                var numBits = nX - xBase + 5 * (nY - yBase);
+                mask |= (1:uint(32) << numBits);
+              } else
                 fit = false;
-              }
             }
-            if fit {
+
+            // If it fits and is a "good piece", add it to the array of masks
+            if fit then
               if goodPiece(mask, pos) {
-                allMasks[totalCount] = mask|(1:int(32)<<(piece+22));
+                allMasks[totalCount] = mask|(1:int(32) << (piece + 22));
                 totalCount += 1;
               }
-            }
           }
 
-          for i in 0..4 {
-            const xnew: int(32) = x[i]+y[i];
-            const ynew: int(32) = -x[i];
-            x[i] = xnew;
-            y[i] = ynew;
-            if currentRotation == 5 {
-              const xnew:int(32) = x[i]+y[i];
-              const ynew:int(32) = -y[i];
-              x[i] = xnew;
-              y[i] = ynew;
-            }
+          // Permute piece for next iteration
+          for (x, y) in zip(xCoords, yCoords) {
+            // Rotation
+            (x, y) = (x + y, -x);
+
+            // Reflection
+            if currentPermutation == 5 then
+              (x, y) = (x + y, -y);
           }
-        }
-      }
+        } // permutations
+      } // pieces
+
       allMasks[totalCount] = 0;
       totalCount += 1;
-    }
-  }
+    } // xBase
+  } // yBase
 
-   // copy rows 2 and 3 to other rows
-
-  for yBase in 0..9:int(32) {
+  // Generate bit masks for translation of permutations that fit on rows 2 & 3
+  for yBase in 0..9 {
+    // Skip rows 2 & 3, since we already generated their masks
     if yBase!=2 && yBase!=3 {
-      for xBase in 0..4:int(32) {
-        const pos: uint(32) = (xBase+5*yBase):uint(32);
-        const origPos: int(32) = xBase+5*(yBase%2+2);
+      for xBase in 0..4 {
+        const pos = (xBase + 5 * yBase): uint(32),
+              origPos = xBase + 5 * (yBase%2 + 2);
         maskStart[pos][0] = totalCount;
-        var pMask: uint(32) = maskStart[origPos][0];
-        const bottom: uint(32) = ((0xFFFC000000000000>>pos) & 0x003FFFFF):uint(32);
-        const lastRow: uint(32) = ((0xFFFC000000000000>>(pos+5)) & 0x003FFFFF):uint(32);
+        var pMask = maskStart[origPos][0];
+        const bottom = ((maskBoard >> pos) & maskBottom): uint(32),
+              lastRow = ((maskBoard >> (pos + 5)) & maskBottom): uint(32);
         while allMasks[pMask] {
-          var mask: uint(32) = allMasks[pMask];
+          var mask = allMasks[pMask];
           pMask += 1;
           if (mask & bottom) == 0 {
             if yBase == 0 || ((mask & lastRow) != 0) {
-              if !goodPiece(mask&0x003FFFFF, pos) {
+              if !goodPiece(mask & maskBottom, pos) {
                 continue;
               }
             }
@@ -172,12 +224,11 @@ proc initialise() {
   for filter in 1..7:uint(32) {
     for pos in 0..49:uint(32) {
       maskStart[pos][filter] = totalCount;
-      var filterMask: uint(32);
-      filterMask = ((filter&1)<<1) | ((filter&6)<<(4-(evenRowsLookup[pos]&1)));
-      var pMask: uint(32) = maskStart[pos][0];
+      var filterMask = ((filter&1)<<1) | ((filter&6)<<(4-(evenRowsLookup[pos]&1))),
+          pMask = maskStart[pos][0];
       while allMasks[pMask] {
-        const mask:uint(32) = allMasks[pMask];
-        if (mask&filterMask) == 0 {
+        const mask = allMasks[pMask];
+        if (mask & filterMask) == 0 {
           allMasks[totalCount] = mask;
           totalCount += 1;
         }
@@ -189,60 +240,61 @@ proc initialise() {
   }
 }
 
+//
+// Determine whether a solution is a min or max solution
+//
 proc compareSolution(board: [] uint(8), minSolution: [] uint(8),
                      maxSolution: [] uint(8)) {
-  var i, j: int(32);
 
   for i in 0..49 {
     if board[i] < minSolution[i] {
-      for j in 0..49 {
-        minSolution[j] = board[j];
-      }
+      minSolution = board;
       break;
-    } else if board[i] > minSolution[i] {
-      break;
-    }
+    } else if board[i] > minSolution[i] then break;
   }
   for i in 0..49 {
     if board[i] > maxSolution[i] {
-      for j in 0..49 {
-        maxSolution[j] = board[j];
-      }
+      maxSolution = board;
       break;
-    } else if board[i] < maxSolution[i] {
-      break;
-    }
+    } else if board[i] < maxSolution[i] then break;
   }
 }
 
+//
+// Pretty printed output of board
+//
 proc printBoard(board: [] uint(8)) {
   for i in 0..49 {
     writef("%i ", board[i]);
     if i%5 == 4 {
       writeln();
-      if (i&1) == 0 {
+      if i&1 == 0 then
         write(" ");
-      }
     }
   }
   writeln();
 }
 
+//
+// Check a given board as a solution and record it
+//
 proc recordSolution(currentSolution: [] uint(32)) {
-  var board: [0..49] uint(8);
-  var flipBoard: [0..49] uint(8);
-  var mask, pos, currentBit, b1 : uint(32);
-  var piece, count : uint(32);
+  var board: [0..49] uint(8),
+      flipBoard: [0..49] uint(8),
+      mask, pos, currentBit, b1: uint(32),
+      count: uint(32),
+      piece: uint(8);
+
   for i in 0..9 {
     mask = currentSolution[i];
-    piece = ctz(mask>>22:uint(32)):uint(32);
-    mask &= 0x003FFFFF;
+    piece = ctz(mask >> 22: uint(32)): uint(8);
+    mask &= maskBottom;
     b1 |= mask;
     while mask {
-      currentBit = mask&(-(mask:int(32))):uint(32);
-      count = ctz(currentBit):uint(32);
-      board[count+pos] = piece:uint(8);
-      flipBoard[49-count-pos] = piece:uint(8);
+      currentBit = mask & (-(mask: int(32))): uint(32);
+      count = ctz(currentBit): uint(32);
+      board[count+pos] = piece;
+      flipBoard[49-count-pos] = piece;
       mask ^= currentBit;
     }
     count = ctz(~b1);
@@ -250,10 +302,8 @@ proc recordSolution(currentSolution: [] uint(32)) {
     b1 >>= count;
   }
   if solutions == 0 {
-    for i in 0..49 {
-      minSolution[i] = board[i];
-      maxSolution[i] = board[i];
-    }
+    minSolution = board;
+    maxSolution = board;
   } else {
     compareSolution(board, minSolution, maxSolution);
     compareSolution(flipBoard, minSolution, maxSolution);
@@ -262,6 +312,9 @@ proc recordSolution(currentSolution: [] uint(32)) {
   solutions += 2;
 }
 
+//
+// DIY sync record that outperforms native sync vars
+//
 record Spinlock {
   var l: atomic bool;
 
@@ -276,11 +329,13 @@ record Spinlock {
 
 var recordLock: Spinlock;
 
+//
+// Recursively add pieces to the board, and check solution when filled.
+//
 proc searchLinear(in board: uint(32), in pos: uint(32), in used: uint(32),
                   in placed: uint(32), currentSolution: [] uint(32)) {
-  var count : uint(32);
-  var evenRows, oddRows, leftBorder, rightBorder: uint(32);
-  var s1, s2, s3, s4, s5, s6, s7, s8: uint(32);
+  var count, evenRows, oddRows, leftBorder, rightBorder,
+      s1, s2, s3, s4, s5, s6, s7, s8: uint(32);
   if placed == 10 {
     recordLock.lock();
     recordSolution(currentSolution);
@@ -291,47 +346,50 @@ proc searchLinear(in board: uint(32), in pos: uint(32), in used: uint(32),
     oddRows = ~evenRows;
 
     leftBorder = leftBorderLookup[pos];
-    rightBorder = leftBorder>>1;
+    rightBorder = leftBorder >> 1;
 
     s1 = (board << 1) | leftBorder;
     s2 = (board >> 1) | rightBorder;
-    s3 = (board << 4) | ((1<<4)-1) | rightBorder;
+    s3 = (board << 4) | ((1 << 4) - 1) | rightBorder;
     s4 = (board >> 4) | leftBorder;
-    s5 = (board << 5) | ((1<<5)-1);
+    s5 = (board << 5) | ((1 << 5) - 1);
     s6 = (board >> 5);
-    s7 = (board << 6) | ((1<<6)-1) | leftBorder;
+    s7 = (board << 6) | ((1 << 6) - 1) | leftBorder;
     s8 = (board >> 6) | rightBorder;
 
-    if ~board&s1&s2&s5&s6 & ((evenRows&s4&s7) | (oddRows&s3&s8)) {
-      return;
-    }
+    if ~board & s1 & s2 & s5 & s6 &
+       ((evenRows & s4 & s7) | (oddRows & s3 & s8)) then return;
 
     count = ctz(~board);
     pos += count;
     board >>= count;
 
-    const f: uint(32) = ((board>>1)&1) | ((board >> (4-(evenRowsLookup[pos] & 1)))&6);
-    const boardAndUsed = board|used;
+    const f = ((board >> 1) & 1) |
+              ((board >> (4 - (evenRowsLookup[pos] & 1))) & 6),
+          boardAndUsed = board | used;
 
-    var mask: uint(32);
-    var currentMask: uint(32) = maskStart[pos][f];
+    var mask: uint(32),
+        currentMask = maskStart[pos][f];
 
     while allMasks[currentMask] {
-      while allMasks[currentMask] & boardAndUsed {
+
+      while allMasks[currentMask] & boardAndUsed do
         currentMask += 1;
-      }
+
       if allMasks[currentMask] {
         mask = allMasks[currentMask];
         currentSolution[placed] = mask;
-        searchLinear(board|(mask & 0x003FFFFF:uint(32)), pos,
-                     used|(mask & 0xFFC00000:uint(32)), placed+1,
-                     currentSolution);
+        searchLinear(board | (mask & maskBottom), pos, used | (mask & maskUsed),
+                     placed+1, currentSolution);
         currentMask += 1;
       }
     }
   }
 }
 
+//
+// Wrapper to setup initial call to recursive searchLinear
+//
 proc searchLinearHelper(in board: uint(32), in pos: uint(32),
                         in used: uint(32), in placed: uint(32),
                         in firstPiece: uint(32), in mask: uint(32)) {
@@ -342,37 +400,39 @@ proc searchLinearHelper(in board: uint(32), in pos: uint(32),
 }
 
 
+//
+// Add initial piece to board, then fire off remaining searches in parallel
+//
 proc searchParallel(in board: uint(32), in pos: uint(32), in used: uint(32),
                     in placed: uint(32), in firstPiece: uint(32)) {
-  var count: uint(32);
 
-  count = ctz(~board):uint(32);
+  var count = ctz(~board): uint(32);
   pos += count;
   board >>= count;
 
-  const boardAndUsed: uint(32) = board|used;
-  var currentMask: uint(32) = maskStart[pos][0];
-  var mask: uint(32);
+  const boardAndUsed = board | used;
+  var currentMask = maskStart[pos][0],
+      mask: uint(32);
 
   if placed == 0 {
     while allMasks[currentMask] {
       if allMasks[currentMask] {
         mask = allMasks[currentMask];
         currentMask += 1;
-        searchParallel(board|(mask&0x003FFFFF), pos,
-                       used|(mask&0xFFC00000:uint(32)), placed+1, mask);
+        searchParallel(board | (mask & maskBottom), pos,
+                       used | (mask & maskUsed), placed + 1, mask);
       }
     }
   } else {   // placed == 1
     while allMasks[currentMask] {
-      while allMasks[currentMask] & boardAndUsed {
+      while allMasks[currentMask] & boardAndUsed do
         currentMask += 1;
-      }
+
       if allMasks[currentMask] {
         mask = allMasks[currentMask];
         currentMask += 1;
-        searchLinearHelper(board|((mask&0x003FFFFF)), pos,
-                           used|(mask&0xFFC00000:uint(32)),  placed+1,
+        searchLinearHelper(board | (mask & maskBottom), pos,
+                           used | (mask & maskUsed), placed+1,
                            firstPiece, mask);
       }
     }
@@ -380,18 +440,16 @@ proc searchParallel(in board: uint(32), in pos: uint(32), in used: uint(32),
 }
 
 
-proc main(args: [] string): int
-{
-  if args.size > 2 then
-    return 1;
+//
+// Find and print the minimum and maximum solutions to meteor puzzle
+//
+proc main() {
 
-  initialise();
+  initialize();
 
   sync searchParallel(0,0,0,0,0);
 
   writef("%i solutions found\n\n", solutions);
   printBoard(minSolution);
   printBoard(maxSolution);
-
-  return 0;
 }

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -61,7 +61,7 @@ proc main(args: [] string) {
 proc initialize() {
 
   // Set up array of evens and borders masks
-  for i in boardDom {
+  for i in 0..49 {
     evenRowsLookup[i] = (maskEven >> i);
     leftBorderLookup[i] = (maskBorder >> i);
   }
@@ -176,7 +176,7 @@ proc initialize() {
   } // yBase
 
   // Generate bit masks for translation of permutations that fit on rows 2 & 3
-  for yBase in piecesDom {
+  for yBase in 0..9 {
     // Skip rows 2 & 3, since we already generated their masks
     if yBase != 2 && yBase != 3 {
       for xBase in 0..4 {
@@ -206,7 +206,7 @@ proc initialize() {
   }
 
   for filter in 1..7 {
-    for pos in boardDom {
+    for pos in 0..49 {
       maskStart[pos][filter] = totalCount;
       const filterMask = ((filter & 1) << 1) |
                          ((filter & 6) << (4 - (evenRowsLookup[pos] & 1)));
@@ -270,7 +270,7 @@ proc searchParallel(in board, in pos, in used, in placed, in firstPiece) {
 // Pretty printed output of board
 //
 proc printBoard(board) {
-  for i in boardDom {
+  for i in 0..49 {
     writef("%i ", board[i]);
     if i%5 == 4 {
       writeln();
@@ -416,7 +416,7 @@ proc recordSolution(currentSolution) {
   var board, flipBoard: [boardDom] int,
       mask, pos, currentBit, b1, count, piece: int;
 
-  for i in piecesDom {
+  for i in 0..9 {
     mask = currentSolution[i];
     piece = ctz(mask >> 22);
     mask &= maskBottom;
@@ -449,13 +449,13 @@ proc recordSolution(currentSolution) {
 //
 proc compareSolution(board, minSolution, maxSolution) {
 
-  for i in boardDom {
+  for i in 0..49 {
     if board[i] < minSolution[i] {
       minSolution = board;
       break;
     } else if board[i] > minSolution[i] then break;
   }
-  for i in boardDom {
+  for i in 0..49 {
     if board[i] > maxSolution[i] {
       maxSolution = board;
       break;


### PR DESCRIPTION
Cleaned up the fast version of meteor for our shootout entry. 

Performance shouldn't have been harmed in the making of this pull request.

**Changes include:**

* Rely upon inferred typing wherever possible
* Switched all `uint(*)` and `int(*)`'s to `int` for a simpler implementation (at the cost of memory consumption)
    * This improved my ability to remove explicit types / casting
* Switched the DIY sync record implementation to a set of a global functions
   * This may be the wrong direction, but the record is instantiated once and used in 1 function
   * Also tried using a real sync var, but observed a significant (~0.02 seconds) performance hit in doing so.
* `x`, `y` variables now represented as a `coords` tuple.
* `pieces` now represented as a 2D array of tuples, where each tuple is the `x`, `y` coordinate of the cell.
* `param`'d and named commonly used bit masks.
    * Also added comments to remove some of their magic numbery-ness
* Several other small idiomatic Chapel changes
    * Removed redundant uses of `var` and `const`
    * Removed brackets from statements that allowed it
    * More zippered iterations
    * Created domains for frequently used ranges
* Adopted Brad's top-down breadth-first approach of organizing functions
* Adopted American spelling of the function `initialize()`
* Loosely documented every function and global
    * Also improved general comment-coverage, which will continue to improve as I continue to consume the mental feast of bitwise operations

Opening up this PR now to get any opinions from @chapel-lang/perf-team before next week's performance meeting.