### PR TITLE
Tweaks to fa* shootouts

### DIFF
--- a/test/studies/shootout/fannkuch-redux/bradc/fannkuch-redux-blc.chpl
+++ b/test/studies/shootout/fannkuch-redux/bradc/fannkuch-redux-blc.chpl
@@ -7,10 +7,11 @@
 
 use DynamicIters;
 
-config const n = 7,          // the array size over which to compute perms
-             nchunks = 720;  // the number of chunks of parallelism
+config const n = 7,           // the array size over which to compute perms
+             nchunks = 720;   // the number of chunks of parallelism to use
 
 const fact = computeFact(n);  // memoize n! (n-factorial)
+
 
 proc main() {
   var checkSum = 0,
@@ -20,11 +21,11 @@ proc main() {
   chunksz += chunksz%2;
   const work = 0..(fact(n) - chunksz) by chunksz;
 
-  forall lo in dynamic(work, 1) with (+ reduce checkSum, 
-                                      max reduce maxFlips) {
-    for (i, flips) in fannkuch(lo..#chunksz) {
+  forall i in dynamic(work, 1) with (+ reduce checkSum, 
+                                     max reduce maxFlips) {
+    for (j, flips) in fannkuch(i..#chunksz) {
       maxFlips = max(maxFlips, flips);
-      checkSum += if i % 2 == 0 then flips else -flips;
+      checkSum += if j % 2 == 0 then flips else -flips;
     }
   }
   
@@ -35,7 +36,8 @@ proc main() {
 
 iter fannkuch(inds) {
   var p, pp, count: [0..#n] int;
-  p = 0..#n;
+  for i in 0..#n do
+    p[i] = i;
 
   firstPerm();
 
@@ -51,13 +53,11 @@ iter fannkuch(inds) {
   proc firstPerm() {
     var idx = inds.low;
     for i in 1..n-1 by -1 {
-      const fact_i = fact(i),
-            d = idx / fact_i;
+      const d = idx / fact(i);;
       count[i] = d;
       idx %= fact(i);
 
-      for i in 0..i do
-        pp[i] = p[i];
+      pp[0..i] = p[0..i];
 
       for j in 0..i {
         if j + d <= i then

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -1,19 +1,19 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 
-   contributed by Casey, Battaglino, Kyle Brady, Preston Sahabu, 
+   contributed by Casey Battaglino, Kyle Brady, Preston Sahabu,
                and Brad Chamberlain
+   derived from the GNU C version by Petr Prokhorenkov
 */
-use IO;
 
-config const n = 1000;   // controls the length of the generated strings
+config const n = 1000,   // controls the length of the generated strings
 
-config const lineLength = 60,
-             lookupSize = 4*1024,
+             lineLength = 60,
+             lookupSize = 4096,
              lookupScale = lookupSize - 1.0;
 
 //
-// TODO: Could we eliminate these ascii initializers somehow?
+// Nucleotide definitions
 //
 enum nucleotide {
   A = ascii("A"), C = ascii("C"), G = ascii("G"), T = ascii("T"),
@@ -24,7 +24,9 @@ enum nucleotide {
 }
 use nucleotide;
 
+//
 // Sequence to be repeated
+//
 const ALU: [0..286] int(8) = [
   G, G, C, C, G, G, G, C, G, C, G, G, T, G, G, C, T, C, A, C,
   G, C, C, T, G, T, A, A, T, C, C, C, A, G, C, A, C, T, T, T,
@@ -44,13 +46,14 @@ const ALU: [0..286] int(8) = [
 ];
 
 //
-// index aliases for use with (nucleotide, probability) tuples
+// Index aliases for use with (nucleotide, probability) tuples
 //
 param nucl = 1,
       prob = 2;
 
-// Sequences to be randomly generated (probability table)
-
+//
+// Probability tables for equences to be randomly generated
+//
 const IUB = [(a, 0.27), (c, 0.12), (g, 0.12), (t, 0.27),
              (B, 0.02), (D, 0.02), (H, 0.02), (K, 0.02),
              (M, 0.02), (N, 0.02), (R, 0.02), (S, 0.02),
@@ -61,6 +64,7 @@ const HomoSapiens = [(a, 0.3029549426680),
                      (g, 0.1975473066391),
                      (t, 0.3015094502008)];
 
+
 proc main() {
   sumAndScale(IUB);
   sumAndScale(HomoSapiens);
@@ -69,7 +73,9 @@ proc main() {
   randomMake(">THREE Homo sapiens frequency\n", HomoSapiens, n * 5);
 }
 
-// Scan operation
+//
+// Scan the alphabets' probabilities to compute cut-offs
+//
 proc sumAndScale(alphabet: [?D]) {
   var p = 0.0;
   for letter in alphabet {
@@ -79,10 +85,15 @@ proc sumAndScale(alphabet: [?D]) {
   alphabet[D.high](prob) = lookupScale;
 }
 
+//
+// Redefine stdout to use lock-free binary I/O and capture a newline
+//
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newLine = ascii("\n"): int(8);
+param newline = ascii("\n"): int(8);
 
+//
 // Repeat sequence "alu" for n characters
+//
 proc repeatMake(desc, alu, n) {
   stdout.writef("%s", desc); // TODO: Why can't this be a write()?
   const r = alu.size;
@@ -95,11 +106,13 @@ proc repeatMake(desc, alu, n) {
     const lo = i % r + 1,
           len = min(lineLength, n-i);
     // TODO: Can we avoid this slice?
-    stdout.write(s[lo..#len], newLine);
+    stdout.write(s[lo..#len], newline);
   }
 }
 
-// Output a random sequence of length 'len' using distribution a
+//
+// Output a random sequence of length 'n' using distribution a
+//
 proc randomMake(desc, a, n) {
   var lookup = initLookup();
   var line_buff: [0..lineLength] int(8);  // TODO: This wants to be static
@@ -119,7 +132,9 @@ proc randomMake(desc, a, n) {
     }
   }
 
+  //
   // Add a line of random sequence
+  //
   proc addLine(bytes) {
     for (r, i) in zip(getRands(bytes), 0..) {
       var ai = r: int + 1;
@@ -128,15 +143,16 @@ proc randomMake(desc, a, n) {
       
       line_buff[i] = lookup[ai](nucl);
     }
-    line_buff[bytes] = newLine;
+    line_buff[bytes] = newline;
 
     stdout.write(line_buff[0..bytes]); // TODO: avoid slicing?
   }
 }
 
 
-// Deterministic random number generator as specified
-
+//
+// Deterministic random number generator
+//
 var lastRand = 42;  // TODO: wants to be static local to getRands()
 
 iter getRands(n) {

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -95,17 +95,14 @@ param newline = ascii("\n"): int(8);
 // Repeat sequence "alu" for n characters
 //
 proc repeatMake(desc, alu, n) {
-  stdout.writef("%s", desc); // TODO: Why can't this be a write()?
-  const r = alu.size;
-  //
-  // TODO; Can we reduce reliance on % below?
-  //
-  const s = [i in 0..(r+lineLength)] alu[i % r];
+  stdout.writef("%s", desc);
+
+  const r = alu.size,
+        s = [i in 0..(r+lineLength)] alu[i % r];
 
   for i in 0..n by lineLength {
     const lo = i % r + 1,
           len = min(lineLength, n-i);
-    // TODO: Can we avoid this slice?
     stdout.write(s[lo..#len], newline);
   }
 }
@@ -115,10 +112,9 @@ proc repeatMake(desc, alu, n) {
 //
 proc randomMake(desc, a, n) {
   var lookup = initLookup();
-  var line_buff: [0..lineLength] int(8);  // TODO: This wants to be static
+  var line_buff: [0..lineLength] int(8);
     
   stdout.writef("%s", desc);
-  //  stdout.write(desc);
   for i in 1..n by lineLength do
     addLine(min(lineLength, n-i+1));
 
@@ -145,7 +141,7 @@ proc randomMake(desc, a, n) {
     }
     line_buff[bytes] = newline;
 
-    stdout.write(line_buff[0..bytes]); // TODO: avoid slicing?
+    stdout.write(line_buff[0..bytes]);
   }
 }
 
@@ -153,7 +149,7 @@ proc randomMake(desc, a, n) {
 //
 // Deterministic random number generator
 //
-var lastRand = 42;  // TODO: wants to be static local to getRands()
+var lastRand = 42;
 
 iter getRands(n) {
   param IA = 3877,


### PR DESCRIPTION
Minor tweaks to the shootouts for a mix of clarity and not throwing performance away.  Primarily comments and formatting cleanups.

Perhaps most intriguingly, changing the integer config consts in fasta to config params seemed to hurt, not help, performance (?!), so I left them as-is.
