### PR TITLE
Remove missed warning for serialized array assignment

### DIFF
--- a/test/multilocale/diten/localBlock/needMultiLocales/localBlock3.good
+++ b/test/multilocale/diten/localBlock/needMultiLocales/localBlock3.good
@@ -1,3 +1,1 @@
-localBlock3.chpl:6: In function 'main':
-localBlock3.chpl:14: warning: whole array assignment has been serialized (see note in $CHPL_HOME/STATUS)
 localBlock3.chpl:26: error: cannot access remote data in local block


### PR DESCRIPTION
I missed this file because of the (poor) technique I used for scanning
for gasnet-specific tests that might give this warning.