### PR TITLE
String shootout arg tolerance

### DIFF
--- a/test/release/examples/benchmarks/shootout/regexdna.chpl
+++ b/test/release/examples/benchmarks/shootout/regexdna.chpl
@@ -5,7 +5,7 @@
    derived from the GNU C++ RE2 version by Alexey Zolotov
 */
 
-proc main() {
+proc main(args: [] string) {
   var variants = [
     "agggtaaa|tttaccct",
     "[cgt]gggtaaa|tttaccc[acg]",

--- a/test/release/examples/benchmarks/shootout/regexdna.execopts
+++ b/test/release/examples/benchmarks/shootout/regexdna.execopts
@@ -1,1 +1,1 @@
-< fasta.small
+--n=0 < fasta.small

--- a/test/studies/shootout/k-nucleotide/bharshbarg/EXECOPTS
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/EXECOPTS
@@ -1,1 +1,1 @@
-< fasta.small
+--n=0 < fasta.small

--- a/test/studies/shootout/k-nucleotide/bharshbarg/PERFEXECOPTS
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/PERFEXECOPTS
@@ -1,1 +1,1 @@
-< $CHPL_TEST_TMP_DIR/fasta.big
+--n=0 < $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/k-nucleotide/bharshbarg/PREEXEC
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/PREEXEC
@@ -10,10 +10,10 @@ if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
-  ./tmpFasta --n=25000000 > $CHPL_TEST_TMP_DIR/fasta.big
+  ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big
 
   # needed by regex-dna
-  ./tmpFasta --n=5000000 > $CHPL_TEST_TMP_DIR/fasta.mid
+  ./tmpFasta --n=5000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.mid
 
   rm ./tmpFasta
 fi

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-elegant.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-elegant.chpl
@@ -78,7 +78,7 @@ proc write_count(data : string, pattern : string) {
   writeln(freqs[d], "\t", decode(d, size));
 }
 
-proc main() {
+proc main(args: [] string) {
   var data, buf : string;
 
   // Read each line until the desired section

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-strings.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-strings.chpl
@@ -99,7 +99,7 @@ proc write_count(data : string, pattern : string) {
   writeln(freqs[d], "\t", decode(d, size));
 }
 
-proc main() {
+proc main(args: [] string) {
   var data, buf : string;
 
   // Read each line until the desired section

--- a/test/studies/shootout/regex-dna/bharshbarg/EXECOPTS
+++ b/test/studies/shootout/regex-dna/bharshbarg/EXECOPTS
@@ -1,1 +1,1 @@
-< fasta.small
+--n=0 < fasta.small

--- a/test/studies/shootout/regex-dna/bharshbarg/PERFEXECOPTS
+++ b/test/studies/shootout/regex-dna/bharshbarg/PERFEXECOPTS
@@ -1,1 +1,1 @@
-< $CHPL_TEST_TMP_DIR/fasta.mid
+--n=0 < $CHPL_TEST_TMP_DIR/fasta.mid

--- a/test/studies/shootout/regex-dna/bharshbarg/PREEXEC
+++ b/test/studies/shootout/regex-dna/bharshbarg/PREEXEC
@@ -10,10 +10,10 @@ if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
-  ./tmpFasta --n=25000000 > $CHPL_TEST_TMP_DIR/fasta.big
+  ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big
 
   # needed by regex-dna
-  ./tmpFasta --n=5000000 > $CHPL_TEST_TMP_DIR/fasta.mid
+  ./tmpFasta --n=5000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.mid
 
   rm ./tmpFasta
 fi

--- a/test/studies/shootout/regex-dna/bharshbarg/regexdna.chpl
+++ b/test/studies/shootout/regex-dna/bharshbarg/regexdna.chpl
@@ -5,7 +5,7 @@
    derived from the GNU C++ RE2 version by Alexey Zolotov
 */
 
-proc main() {
+proc main(args: [] string) {
   var variants = [
     "agggtaaa|tttaccct",
     "[cgt]gggtaaa|tttaccc[acg]",

--- a/test/studies/shootout/reverse-complement/bharshbarg/EXECOPTS
+++ b/test/studies/shootout/reverse-complement/bharshbarg/EXECOPTS
@@ -1,1 +1,1 @@
-< fasta.small
+--n=0 < fasta.small

--- a/test/studies/shootout/reverse-complement/bharshbarg/PERFEXECOPTS
+++ b/test/studies/shootout/reverse-complement/bharshbarg/PERFEXECOPTS
@@ -1,1 +1,1 @@
-< $CHPL_TEST_TMP_DIR/fasta.big
+--n=0 < $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/reverse-complement/bharshbarg/PREEXEC
+++ b/test/studies/shootout/reverse-complement/bharshbarg/PREEXEC
@@ -10,10 +10,10 @@ if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
-  ./tmpFasta --n=25000000 > $CHPL_TEST_TMP_DIR/fasta.big
+  ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big
 
   # needed by regex-dna
-  ./tmpFasta --n=5000000 > $CHPL_TEST_TMP_DIR/fasta.mid
+  ./tmpFasta --n=5000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.mid
 
   rm ./tmpFasta
 fi


### PR DESCRIPTION
The official shootout Makefiles pass an unnecessary '0' (or, for
Chapel, --n=0) argument to the string benchmarks which we need to
consume and ignore.  This could be done either by adding a fake config
or by having an args argument on main().  We chose the latter because
it seems more innocuous (and is more similar to how languages like C
arguably drop such arguments on the floor).  Here, I'm adding --n=0 to
all of our EXECOPTS files in order to make sure we don't accidentally
remove this support again in the future (which is easy to forget about and
do).

While here, I also noticed that our PREEXEC scripts don't work when
we've built for GASNet because of the lack of a -nl argument on their
command lines.  While these benchmarks weren't designed for gasnet
runs, it doesn't hurt to make them work there as well, so here I add -nl 1
to these PREEXEC lines so that they're robust to comm=none or != none.