### PR TITLE
Removing no longer necessary prediff

### DIFF
--- a/test/studies/labelprop/labelprop-tweets.prediff
+++ b/test/studies/labelprop/labelprop-tweets.prediff
@@ -1,5 +1,0 @@
-#! /bin/bash -norc
-#
-# Ignore whole array assignment has been serialized warnings
-#
-grep 'twitter user' < $2 > $2.tmp && mv $2.tmp $2


### PR DESCRIPTION
@cassella pointed out that this prediff isn't necessary anymore now
that serial array assignment warnings have been removed.  I didn't
catch this one as I was only considering tests that threw --no-warnings.