### PR TITLE
spec/Ranges.tex: change an Iff to If

### DIFF
--- a/spec/Ranges.tex
+++ b/spec/Ranges.tex
@@ -799,7 +799,7 @@ away.  Specifically:
 \item If the count times the stride is positive, the low bound is preserved
 and the high bound is adjusted to be one less than the low bound plus that
 product.
-\item Iff the count times the stride is negative, the high bound is preserved
+\item If the count times the stride is negative, the high bound is preserved
 and the low bound is adjusted to be one greater than the high bound plus that
 product.
 \end{itemize}


### PR DESCRIPTION
I don't think there's any reason for it to be "iff": There doesn't
seem to be any "and only if" involved here; the previous
parallelly-constructed \item has "if", and "iff" does not appear
elsewhere in the text of the spec.
