### PR TITLE
Add file format documentation, correct comments, turn off VisualDebug…

### DIFF
--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -147,13 +147,20 @@ void chpl_vdebug_start (const char *fileroot, double now) {
   chpl_vdebug = 1;
 }
 
-// Record>  VdbMark: time.sec user.time system.time nodeID taskID
+// Record>  End: time.sec user.time system.time nodeID taskID
+//
+// Should be the last record in the file.
 
 void chpl_vdebug_stop (void) {
   struct rusage ru;  
   struct timeval tv;
   chpl_taskID_t stopTask = chpl_task_getId();
 
+  // First, shutdown VisualDebug
+  chpl_vdebug = 0;
+  uninstall_callbacks();
+
+  // Now log the stop
   if (chpl_vdebug_fd >= 0) {
     (void) gettimeofday (&tv, NULL);
     if ( getrusage (RUSAGE_SELF, &ru) < 0) {
@@ -170,8 +177,6 @@ void chpl_vdebug_stop (void) {
                   chpl_nodeID, (int) stopTask);
     close (chpl_vdebug_fd);
   }
-  chpl_vdebug = 0;
-  uninstall_callbacks();
 }
 
 // Record>  VdbMark: time.sec nodeId taskId
@@ -391,7 +396,7 @@ void  chpl_vdebug_log_fork_nb(c_nodeid_t node, c_sublocid_t subloc,
   }
 }
 
-// Record>  fork_nb: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
+// Record>  f_fork: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
 
 void chpl_vdebug_log_fast_fork(c_nodeid_t node, c_sublocid_t subloc,
                                chpl_fn_int_t fid, void *arg, int32_t arg_size) {

--- a/tools/chplvis/TextDataFormat
+++ b/tools/chplvis/TextDataFormat
@@ -1,0 +1,62 @@
+This file documents the text data format of the VisualDebug.chpl output files.
+
+First line of every file is:
+
+  ChplVdebug: ver x.y nodes m nid n tid t seq s t1 t2 t3
+     x.y is the version number.   The current version in 1.1.
+     m is the total locale/node count. 
+     n is the current node id
+     t is the task id for this call to ChplVdebug.
+     s is a sequence number for this run which is the time
+        at the start of the call  (chpl_now_time()) (sec.usec format)
+        ALL files from a single run must have the same s number.
+     t1, t2 and t3 are times for reference, in order, (sec.usec format)
+       timeofday, user time from rusage, system time from rusage
+
+  In the following record definitions the following will stand
+  for a number in the line:
+     nid - local node id (locale)
+     rid - remote node id
+     tid - task id
+     tv  - time of day value  (sec.usec format)
+     tu  - user time          (sec.usec format)
+     ts  - system time        (sec.usec format)
+     tnum - tag number
+     lnum - line number
+     name - name of tag or file
+
+Lines in the file:
+
+ End: tv tu ts nid tid
+    End collection of data, should be last line of file
+
+  VdbMark: tv nid tid
+    Mark a task as a VisualDebug task
+
+  Tag: tv tu ts nid tid tnum name
+    Tag in the data
+
+  Pause:  tv tu ts nid tid tnum
+    Pause the collection of data, tag number is previous tag
+
+  task: tv nid tid parent_tid [OL] lnum name
+    [OL] - on of O or L, O for an "on task", L for a "local task"
+    Task creation, On tasks don't have valid lnum and name.
+
+  nb_put: tv nid rid tid addr raddr elemsize typeIndex length lnum name
+  nb_get: tv nid rid tid addr raddr elemsize typeIndex length lnum name
+  put: tv nid rid tid addr raddr elemsize typeIndex length lnum name
+  get: tv nid rid tid addr raddr elemsize typeIndex length lnum name
+  st_put:  tv nid rid tid addr raddr elemsize typeIndex length lnum name
+  st_get:  tv nid rid tid addr raddr elemsize typeIndex length lnum name
+    communication.  Puts: data flow nid->rid, gets: data flow rid -> nid
+    nb is non-blocking, st is strided.
+
+  fork: tv nid rid subLoc funcId argPtr argSize tid
+  fork_nb: tv nid rid subLoc funcId argPtr argSize tid
+  f_fork:  tv nid rid subLoc funcId argPtr argSize tid
+     fork a task on a remote locale.   nb is non-blocking, f_fork does
+     not start a remote task.  Data is sent from nid to rid.
+
+
+    


### PR DESCRIPTION
Create a documentation for the entries in the files generated by VisualDebug.
Fix comments and turn VisualDebug off before logging to the file.