### PR TITLE
Update some sleepy tests to use syncs

### DIFF
--- a/test/parallel/begin/deitz/test_begin7.chpl
+++ b/test/parallel/begin/deitz/test_begin7.chpl
@@ -1,13 +1,9 @@
-use Time;
-
 var s, t: sync bool;
 
 begin {
   s = true;
 }
 s;
-
-sleep(1);
 
 begin {
   s = true;

--- a/test/parallel/begin/deitz/test_begin8.chpl
+++ b/test/parallel/begin/deitz/test_begin8.chpl
@@ -1,13 +1,9 @@
-use Time;
-
 var s, t: sync bool;
 
 begin {
   s = true;
 }
 s;
-
-sleep(1);
 
 begin {
   s;

--- a/test/parallel/begin/deitz/test_begin9.chpl
+++ b/test/parallel/begin/deitz/test_begin9.chpl
@@ -1,13 +1,9 @@
-use Time;
-
 var s, t, u, v: sync bool;
 
 begin {
   s = true;
 }
 s;
-
-sleep(1);
 
 begin {
   u;

--- a/test/parallel/begin/deitz/test_begin_cobegin1.chpl
+++ b/test/parallel/begin/deitz/test_begin_cobegin1.chpl
@@ -1,5 +1,3 @@
-use Time;
-
 proc main {
   var x: int;
   var z: int;

--- a/test/parallel/begin/deitz/test_begin_cobegin2.chpl
+++ b/test/parallel/begin/deitz/test_begin_cobegin2.chpl
@@ -1,17 +1,16 @@
-use Time;
-
 proc main {
-  var x: int;
-  var z: int;
-  begin with (ref x, ref z) {
-    x = 2;
-    var y: int;
-    cobegin with (ref y, ref z) {
-      y = x + 1;
-      z = x + 1;
+  var x, z: int;
+  sync {
+    begin with (ref x, ref z) {
+      x = 2;
+      var y: int;
+      cobegin with (ref y, ref z) {
+        y = x + 1;
+        z = x + 1;
+      }
+      writeln((x, y, z));
     }
-    writeln((x, y, z));
   }
-  sleep(2);
   writeln((x, z));
 }
+

--- a/test/parallel/begin/deitz/test_begin_error_lineno.chpl
+++ b/test/parallel/begin/deitz/test_begin_error_lineno.chpl
@@ -1,4 +1,4 @@
-use Time;
+
 
 var s: sync int;
 var x: int = 0;
@@ -10,4 +10,4 @@ begin with (ref x) {
   }
 }
 
-sleep(1); halt("a thread is out of control");
+halt("a thread is out of control");

--- a/test/parallel/begin/deitz/test_begin_sync.chpl
+++ b/test/parallel/begin/deitz/test_begin_sync.chpl
@@ -1,4 +1,5 @@
 use Time;
+
 proc main {
   var s: sync int;
   begin {


### PR DESCRIPTION
Some old tests use `Time.sleep`, where they should be using `sync` vars instead to avoid race conditions.

This fix was motivated by the recent nightly testing failure of `test_begin_cobegin2.chpl`, where some variables were freed from memory too early in some runs, causing output of nonsense values. This sporadic failure became possible back in the 1.12.0 changes to [lexical scoping](http://chapel.cray.com/docs/latest/language/evolution.html#lexical-scoping) (see #2739 && #3628).

Other tests have been updated in the past for this same reason:  #2744

I am only changing tests that I consider *no-brainers*. There are more sleepy tests in this directory that I am leaving alone for now.

`start_test test/parallel/begin/deitz passed all tests` *passed all tests*