### PR TITLE
Fix broken 3d domain in spec

### DIFF
--- a/spec/Domains.tex
+++ b/spec/Domains.tex
@@ -147,7 +147,13 @@ The following declarations both create an uninitialized rectangular domain with 
 var D1 : domain(rank=3, idxType=int, stridable=false);
 var D2 : domain(3);
 \end{chapel}
+\begin{chapelpost}
+writeln(D1);
+writeln(D2);
+\end{chapelpost}
 \begin{chapeloutput}
+{1..0, 1..0, 1..0}
+{1..0, 1..0, 1..0}
 \end{chapeloutput}
 \end{chapelexample}
 

--- a/spec/Domains.tex
+++ b/spec/Domains.tex
@@ -145,7 +145,7 @@ using standard type signature.
 The following declarations both create an uninitialized rectangular domain with three dimensions, with \chpl{int} indices:
 \begin{chapel}
 var D1 : domain(rank=3, idxType=int, stridable=false);
-var D2 : domain(3*int);
+var D2 : domain(3);
 \end{chapel}
 \begin{chapeloutput}
 \end{chapeloutput}


### PR DESCRIPTION
@cassella pointed out an issue in the spec where it claims that 'domain(3*int)' creates a 3D rectangular domain, but it actually creates an associative domain over 3*int indices. Here, I took a very simple, localized approach for fixing it by changing it to 'domain(3)' which is equivalent to 'domain(rank=3)' which is perhaps what was originally intended...  I also added some output to the test to lock in the behavior.

