### PR TITLE
Link users guide to master branch

### DIFF
--- a/doc/sphinx/source/users-guide/index.rst
+++ b/doc/sphinx/source/users-guide/index.rst
@@ -15,13 +15,13 @@ defining every corner case in the language.
 
    **Pardon Our Dust**
 
-   This users guide is a work-in-progress that was kicked off in
-   Autumn 2015.  We are taking the approach of writing it in a
-   breadth-first manner in order to cover features that are most
-   unique to the language sooner without completely neglecting the
-   base language (which is expected to comprise the largest number of
-   the sections of the guide).  We welcome feedback and requests on
-   the guide as we go.
+   This users guide is a work-in-progress.  We are writing it in a
+   breadth-first manner in order to cover features that are more
+   unique to Chapel sooner.  If you're not already using the `master
+   branch <http://chapel.cray.com/docs/master/users-guide/>`_ of the
+   documentation (which tracks real-time GitHub development), you may
+   find that it contains a more complete set of sections.  We welcome
+   feedback and requests on the guide as we go.
 
 
 The Chapel Users Guide is divided into four main sections:


### PR DESCRIPTION
As I've been working on users guide edits, I realized that it's a
little regrettable that we didn't have the "work in progress" note
link to the master branch of the docs so that people could see the
latest version of the users guide easily.  This is an attempt to
remedy the situation for the next release (or maybe to back-patch
into the 1.13 docs).

I also did some wordsmithing to tighten up the note while here.