### PR TITLE
Use :dedent: for forloops users-guide section

### DIFF
--- a/doc/sphinx/source/users-guide/base/forloops.rst
+++ b/doc/sphinx/source/users-guide/base/forloops.rst
@@ -55,6 +55,7 @@ the loop body:
 .. literalinclude:: examples/users-guide/base/forloops.chpl
   :language: chapel
   :lines: 14-15
+  :dedent: 2
 
 In contrast, an array's default iterator yields references to the
 array's elements.  As a result, the loop's index variable can be used

--- a/test/release/examples/users-guide/base/forloops.chpl
+++ b/test/release/examples/users-guide/base/forloops.chpl
@@ -11,8 +11,8 @@ writeln("i is: ", i);
 writeln();
 
 if tryIllegal then
-for i in 1..5 do
-  i += 1;        // Illegal: i is 'const' for ranges
+  for i in 1..5 do
+    i += 1;        // Illegal: i is 'const' for ranges
 
 var A: [1..5] real;
 for a in A do


### PR DESCRIPTION
Having learned about :dedent: as a means of removing leading whitespace
from code samples, I'm retroactively applying it to this for loops
example.