### PR TITLE
Stop skipping gmp-chudnovsky for non-GNU compilers

### DIFF
--- a/test/modules/standard/gmp/studies/gmp-chudnovsky.skipif
+++ b/test/modules/standard/gmp/studies/gmp-chudnovsky.skipif
@@ -1,1 +1,0 @@
-CHPL_TARGET_COMPILER != gnu


### PR DESCRIPTION
As best I can tell, this skipif predates general support for GMP
and we should really be skipping based on gmp support being
available or not (which is already handled by the gmp.skipif a
few directories up).  So retiring this.

The presence of this .skipif is why we saw failures for gnu-over-clang
on Mac testing last night when we've never seen them for clang testing.
The test simply wasn't being run for clang testing.