### PR TITLE
Add option --no-ieee-float to mandelbrot-complex perf test

### DIFF
--- a/test/studies/shootout/mandelbrot/jacobnelson/mandelbrot-complex.perfcompopts
+++ b/test/studies/shootout/mandelbrot/jacobnelson/mandelbrot-complex.perfcompopts
@@ -1,0 +1,1 @@
+--no-ieee-float


### PR DESCRIPTION
This test has been timing out on some of the slower performance testing
systems since PR #4098 .  Add --no-ieee-float to speed it up.