### PR TITLE
Annotate mandelbrot perf graph about --no-ieee-float

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -347,9 +347,9 @@ mandelbrot:
     - Initial commit of C complexes
   06/16/16:
     - Change complex getter functions for .re and .im into "static inline" (#4033)
-  06/30/16:
+  07/01/16:
     - Start using C99 functions for operations such as abs() on complex numbers (#4098)
-  07/07/16:
+  07/08/16:
     - Added compiler option --no-ieee-float to mandelbrot-complex (#4134)
 
 mandelbrot-extras:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -349,6 +349,8 @@ mandelbrot:
     - Change complex getter functions for .re and .im into "static inline" (#4033)
   06/30/16:
     - Start using C99 functions for operations such as abs() on complex numbers (#4098)
+  07/07/16:
+    - Added compiler option --no-ieee-float to mandelbrot-complex (#4134)
 
 mandelbrot-extras:
   01/03/14:


### PR DESCRIPTION
Add an annotation about --no-ieee-float for mandelbrot-complex graph.