### PR TITLE
Improve build steps of chapel man page (language documentation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ tags
 
 # Man ignores.
 /man/man1/
+/man/man3/
 
 # Modules ignores.
 /modules/docs

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -31,6 +31,11 @@ man: third-party-chpldoc-venv FORCE
 man-chpldoc: FORCE
 	cd man && $(MAKE) chpldoc
 
+man-chapel: FORCE
+	cd doc/sphinx && $(MAKE) man
+	mkdir -p man/man3
+	cp doc/sphinx/build/man/chapel.3 man/man3/chapel.3
+
 always-build-man: FORCE
 	-@if [ -n "$$CHPL_ALWAYS_BUILD_MAN" ]; then \
 	$(MAKE) man; \

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -32,7 +32,7 @@ man-chpldoc: FORCE
 	cd man && $(MAKE) chpldoc
 
 man-chapel: FORCE
-	cd doc/sphinx && $(MAKE) man
+	cd doc/sphinx && $(MAKE) man-chapel
 	mkdir -p man/man3
 	cp doc/sphinx/build/man/chapel.3 man/man3/chapel.3
 

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -34,7 +34,7 @@ man-chpldoc: FORCE
 man-chapel: FORCE
 	cd doc/sphinx && $(MAKE) man
 	mkdir -p man/man3
-	cp doc/sphinx/build/man/chapel.1 man/man3/chapel.3
+	cp doc/sphinx/build/man/chapel.3 man/man3/chapel.3
 
 always-build-man: FORCE
 	-@if [ -n "$$CHPL_ALWAYS_BUILD_MAN" ]; then \

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -34,7 +34,7 @@ man-chpldoc: FORCE
 man-chapel: FORCE
 	cd doc/sphinx && $(MAKE) man
 	mkdir -p man/man3
-	cp doc/sphinx/build/man/chapel.3 man/man3/chapel.3
+	cp doc/sphinx/build/man/chapel.1 man/man3/chapel.3
 
 always-build-man: FORCE
 	-@if [ -n "$$CHPL_ALWAYS_BUILD_MAN" ]; then \

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -18,6 +18,9 @@ help-source:
 docs: FORCE
 	./run-in-venv.bash $(MAKE) html
 
+man-chapel: FORCE
+	./run-in-venv.bash $(MAKE) man
+
 symlink-docs: clean-symlink-docs
 	@echo "Setting up symlinks from /doc/release to /doc/sphinx/source"
 	./symlinks.py

--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -133,6 +133,9 @@ text: symlink-docs check-sphinxbuild clean-build
 
 man: symlink-docs check-sphinxbuild clean-build
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	echo ".if n .pl 2000v" > $(BUILDDIR)/man/chapel.3
+	cat $(BUILDDIR)/man/chapel.1 >> $(BUILDDIR)/man/chapel.3
+	rm -f $(BUILDDIR)/man/chapel.1
 	@echo
 	@echo "Build finished. The manual pages are in "'$(BUILDPATH)'"/man."
 

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -64,7 +64,7 @@ shortversion = 1.13
 release = '1.13.1'
 
 # General information about the project.
-project = u'Chapel Documentation {0}'.format(shortversion)
+project = u'Chapel Language Documentation {0}'.format(shortversion)
 
 author_text = os.environ.get('CHPLDOC_AUTHOR', '')
 
@@ -206,7 +206,7 @@ html_show_sphinx = False
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'chpldoc'
+htmlhelp_basename = 'chapel'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -226,7 +226,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'chpldoc.tex', u'chpldoc Documentation',
+  ('index', 'chapel.tex', u'Chapel Documentation',
    author_text, 'manual'),
 ]
 
@@ -256,7 +256,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'chpldoc', u'chpldoc Documentation',
+    ('index', 'chapel', u'Chapel Documentation',
      [author_text], 1)
 ]
 
@@ -270,8 +270,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'chpldoc', u'chpldoc Documentation',
-   author_text, 'chpldoc', 'One line description of project.',
+  ('index', 'chapel', u'Chapel Documentation',
+   author_text, 'chapel',
+   'Chapel is an emerging programming language designed for productive parallel computing at scale.',
    'Miscellaneous'),
 ]
 

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -64,7 +64,7 @@ shortversion = 1.13
 release = '1.13.1'
 
 # General information about the project.
-project = u'Chapel Language Documentation {0}'.format(shortversion)
+project = u'Chapel Documentation {0}'.format(shortversion)
 
 author_text = os.environ.get('CHPLDOC_AUTHOR', '')
 


### PR DESCRIPTION
Small improvement to **chapel** man page build process I added back in #4081. This is the *language* man page that can be built as an alternative to building the [html documentation](chapel.cray.com/docs/master]. It now builds into `/man/man3/chapel.3` when invoking `make man-chapel` from the project root, or `make man` from the sphinx project (this make target does not run in the virtualenv, as per convention).

TODO:

* [x] Fix bug:
    * There is a bug in `grotty` that prints an error message when opening the man page. The solution was found in collaboration with @dmk42 and the help of this [bug report back in 2012](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=673436). The fix prepends `.if n .pl 2000v` to the man page to avoid imagined page breaks from `grotty`.
* [x] Test on OS X && a Linux distro
    * OS X looks fine.
    * Linux looks fine (if you build the man page on the linux distro)