### PR TITLE
Add perf annotation for recent improvements to optimizeOnClauses

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -137,6 +137,9 @@ all:
   06/06/16:
     - Avoid allocating arg bundles for local on statements (#3890)
     - Upgrade target compiler versions (#218, internal)
+  06/24/16:
+    - text: Improve optimizeOnClauses optimization (#4008)
+      config: 16 node XC
 
 AllCompTime:
   11/09/14:


### PR DESCRIPTION
This had nice perf improvements for reductions, ISx, ra-atomics, and HPCC HPL:

  http://chapel.sourceforge.net/perf/16-node-xc/?startdate=2016/05/03&enddate=2016/07/07&configs=gnugasnetaries,gnugasnetmpi&graphs=hpcchplhpccversionperfgflopsn22knb200,hpccraatomicsperfgupsn233nu10m,isxvariations,reductionstimesec

There was a slight regression for ra-atomics w/ gn-mpi, but gn-aries improved.
See JIRA 229 for more info: https://chapel.atlassian.net/browse/CHAPEL-229