### PR TITLE
(fast) meteor cleanup 2

### DIFF
--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -72,22 +72,23 @@ proc initialize() {
 
   /* The puzzle pieces are defined with hexagonal cell coordinates
      starting from the origin cell (0, 0).
-     (1, 0) corresponds to 1 cell to the right of the the origin cell.
-     (0, 1) corresponds to 1 cell diagonally down/right from the origin cell.
 
-    Piece 0      Piece 1       Piece 2      Piece 3      Piece 4
+     The hexagonal cell coordinates map to cardinal directions as follows:
+     (1, 0) = East | (-1, 0) = West | (0, 1) = SouthEast | (-1, 1) = South
 
-    0 1 2 3         0           0 1 2        0 1 2        0
-           4         1         3                3          1 2
-                  2 3           4                4        3   4
-                 4
+     Piece 0      Piece 1       Piece 2      Piece 3      Piece 4
 
-    Piece 5      Piece 6       Piece 7      Piece 8      Piece 9
+     0 1 2 3         0           0 1 2        0 1 2        0
+            4         1         3                3          1 2
+                   2 3           4                4        3   4
+                  4
 
-       0 1        0 1           0   1        0            0
-    2 3 4          2           2 3 4          1            1
-                  3                            2 3          2
-                   4                              4        3 4
+     Piece 5      Piece 6       Piece 7      Piece 8      Piece 9
+
+        0 1        0 1           0   1        0            0
+     2 3 4          2           2 3 4          1            1
+                   3                            2 3          2
+                    4                              4        3 4
 
   */
   const pieces: [piecesDom][0..#pieceCells] 2*int =
@@ -234,8 +235,6 @@ proc initialize() {
 }
 
 
-
-
 //
 // Add initial piece to board, then fire off remaining searches in parallel
 //
@@ -348,8 +347,6 @@ proc searchLinearHelper(in board, in pos, in used, in placed,
 // DIY sync variable functionality that outperforms native sync variables.
 // Access controlled by functions lock() and unlock()
 var l: atomic bool;
-
-
 
 
 //

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -70,25 +70,33 @@ proc initialize() {
   var totalCount = 0,
       coords: [0..#pieceCells] 2*int;
 
-  /* The puzzle pieces are defined with hexagonal cell coordinates
-     starting from the origin cell (0, 0).
+  /* The puzzle pieces are defined with hexagonal cell coordinates, where the
+     first piece cell always begins at the origin cell, (0, 0).
+     This coordinate system is best conveyed through a diagram:
 
-     The hexagonal cell coordinates map to cardinal directions as follows:
-     (1, 0) = East | (-1, 0) = West | (0, 1) = SouthEast | (-1, 1) = South
+                         (0, -1)       (1, -1)
 
-     Piece 0      Piece 1       Piece 2      Piece 3      Piece 4
+                  (-1, 0)       (0 , 0)       (1 , 0)
 
-     0 1 2 3         0           0 1 2        0 1 2        0
-            4         1         3                3          1 2
-                   2 3           4                4        3   4
+                         (-1, 1)       (0 , 1)
+
+     Therefore, (-1, 2) corresponds to the South, and (1, -2) to the North.
+
+     The following illustrates the piece shapes and their cell indices:
+
+     Piece 0      Piece 1      Piece 2      Piece 3      Piece 4
+
+     0 1 2 3         0          0 1 2        0 1 2        0
+            4         1        3                3          1 2
+                   2 3          4                4        3   4
                   4
 
-     Piece 5      Piece 6       Piece 7      Piece 8      Piece 9
+     Piece 5      Piece 6      Piece 7      Piece 8      Piece 9
 
-        0 1        0 1           0   1        0            0
-     2 3 4          2           2 3 4          1            1
-                   3                            2 3          2
-                    4                              4        3 4
+        0 1        0 1          0   1        0            0
+     2 3 4          2          2 3 4          1            1
+                   3                           2 3          2
+                    4                             4        3 4
 
   */
   const pieces: [piecesDom][0..#pieceCells] 2*int =

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -70,8 +70,8 @@ proc initialize() {
   var totalCount = 0,
       coords: [0..#pieceCells] 2*int;
 
-  /* The puzzle pieces are defined with hexagonal cell coordinates, where the
-     first piece cell always begins at the origin cell, (0, 0).
+  /* The 10 puzzle pieces are defined with hexagonal cell coordinates, where
+     the first cell of a piece always begins at the origin cell, (0, 0).
      This coordinate system is best conveyed through a diagram:
 
                          (0, -1)       (1, -1)
@@ -80,23 +80,26 @@ proc initialize() {
 
                          (-1, 1)       (0 , 1)
 
-     Therefore, (-1, 2) corresponds to the South, and (1, -2) to the North.
+     Therefore, the cell to the South of the origin can be computed as follows:
+
+        S =    SW   +   SE
+        S = (-1, 1) + (0, 1) = (-1, 2)
 
      The following illustrates the piece shapes and their cell indices:
 
-     Piece 0      Piece 1      Piece 2      Piece 3      Piece 4
+        Piece 0      Piece 1      Piece 2      Piece 3      Piece 4
 
-     0 1 2 3         0          0 1 2        0 1 2        0
-            4         1        3                3          1 2
-                   2 3          4                4        3   4
-                  4
+        0 1 2 3         0          0 1 2        0 1 2        0
+               4         1        3                3          1 2
+                      2 3          4                4        3   4
+                     4
 
-     Piece 5      Piece 6      Piece 7      Piece 8      Piece 9
+        Piece 5      Piece 6      Piece 7      Piece 8      Piece 9
 
-        0 1        0 1          0   1        0            0
-     2 3 4          2          2 3 4          1            1
-                   3                           2 3          2
-                    4                             4        3 4
+           0 1        0 1          0   1        0            0
+        2 3 4          2          2 3 4          1            1
+                      3                           2 3          2
+                       4                             4        3 4
 
   */
   const pieces: [piecesDom][0..#pieceCells] 2*int =

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -23,7 +23,7 @@ const boardDom = {0..#boardCells},
 var allMasks: [0..#permutations] int,
     maskStart: [boardDom][0..#numPieces-2] int;
 
-// Arrays of min, max, and integer storing number of solutions
+// Arrays of min and max, and an integer storing the number of solutions
 var minSolution, maxSolution: [boardDom] int,
     solutions: int;
 


### PR DESCRIPTION
After feedback on the (slow) meteor cleanup (#4124) during @chapel-lang/perf-team  meeting, I followed up and made some similar changes to the (fast) version.

Changes include:

* Named anonymous ranges: `0..#boardCells` instead of `0..49`
* Corrected piece descriptions (thanks @Ldelaney)
    * Heavily improved description with a helper diagram and sample calculation of South cell

TODO:

* [x] Check to see if reductions can be utilized anywhere
    * Found 1 opportunity to use an overloaded `min` reduction.