### PR TITLE
Further clean up of the elegant Meteor

### DIFF
--- a/test/studies/shootout/meteor/kbrady/meteor-parallel.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel.chpl
@@ -553,12 +553,15 @@ module meteor {
 
   /* pretty print a board in the specified hexagonal format */
   proc pretty(s) {
-    for i in 0..#boardCells by 10 {
-      // '0' -> 48 in ascii: shifting the numbers up into valid range
-      writef("%c %c %c %c %c \n %c %c %c %c %c \n", s[i]+48, s[i+1]+48,
-        s[i+2]+48, s[i+3]+48, s[i+4]+48, s[i+5]+48, s[i+6]+48,
-        s[i+7]+48, s[i+8]+48, s[i+9]+48);
+    param boardWidth = 5;
+    for i in 0..#boardCells {
+      writef("%i ", s[i]);
+      if (i % boardWidth == 4) {
+        writeln();
+        if (i & 1 == 0) then
+          write(" ");
+      }
     }
-    writeln("");
+    writeln();
   }
 }

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel.chpl
@@ -101,7 +101,7 @@ module meteor {
     forall piece in 0..#numPieces {
       for indx in 0..#boardCells {
         calcSixRotations(piece, indx, cells[piece]);
-        flipPiece(piece);
+        serial do pieceDef[piece] = flip(pieceDef[piece]);
         calcSixRotations(piece, indx, cells[piece]);
       }
     }
@@ -127,7 +127,7 @@ module meteor {
           recordPiece(piece, minimum, firstEmpty, pieceMask);
         }
       }
-      rotatePiece(piece);
+      serial do pieceDef[piece] = rotate(pieceDef[piece]);
     }
   }
 
@@ -312,26 +312,14 @@ module meteor {
     pieceCounts[piece][minimum] += 1;
   }
 
-  /* Rotate a piece 60 degrees clockwise */
-  proc rotatePiece(piece) {
-    for i in 0..3 do
-      pieceDef[piece][i] = rotate(pieceDef[piece][i]);
-  }
-
   /* Returns the direction rotated 60 degrees clockwise */
   proc rotate(dir) {
-    return ((dir + 2) % PIVOT): direction;
-  }
-
-  /* Flip a piece along the horizontal axis */
-  proc flipPiece(piece) {
-    for i in 0..3 do
-      pieceDef[piece][i] = flip(pieceDef[piece][i]);
+    return ((dir + 2) % PIVOT:int): direction;
   }
 
   /* Returns the direction flipped on the horizontal axis */
   proc flip(dir) {
-    return ((PIVOT - dir) % PIVOT): direction;
+    return ((PIVOT - dir:int) % PIVOT:int): direction;
   }
 
   /* Calculate all 32 possible states for a 5-bit row and all rows that will


### PR DESCRIPTION
Based on feedback from the @chapel-lang/perf-team yesterday

- Remove extra enum numbers
- Remove unnecessary magic numbers comment
- Change args.domain.size to args.size
- Replace domains with const numPieces and boardCells, for use in 0..# ranges
- Replace 2099 with #maxSolutions
- move use statement
- remove firstEmptyCell's local variable and replace with in intent on argument
- replace some for loops with &&, min, and | reductions
- move some of those new reductions into the function which called them
- rename lastIdx to pieceCount
- replace some functions with for loops over an entire array with promotion
   Unfortunately this meant I needed to add some int casts to avoid errors about
   ambiguous calls to the % and - operators.
- Change index calculation in calcRows to reuse the value computed
- remove == false, == true comparisons
- make result1 and result2 loop local variables, and change the use of them to
  even/odd, corresponding to which array is referenced
- remove bool cast
- replace hex literals in tripleIsOkay with binary literals
- comment magic hex number in solveHelper
- replace printing function with more appealing version
- also added my name as a contributor