### PR TITLE
Filing a bug against binary string output

### DIFF
--- a/test/io/bradc/badWrite.bad
+++ b/test/io/bradc/badWrite.bad
@@ -1,0 +1,2 @@
+	>foo bar
+>foo bar

--- a/test/io/bradc/badWrite.chpl
+++ b/test/io/bradc/badWrite.chpl
@@ -1,0 +1,4 @@
+const stdout = openfd(1).writer(kind=iokind.native, locking=false);
+
+stdout.write(">foo bar\n");
+stdout.writef("%s", ">foo bar\n");

--- a/test/io/bradc/badWrite.future
+++ b/test/io/bradc/badWrite.future
@@ -1,0 +1,6 @@
+bug: write(:string) not equivalent to writef("%s", :string) for binary I/O
+
+This test shows that these two ways of writing strings don't
+behave equivalently as I believe they should.  I believe the
+issue is that the former is trying to write the length of
+the string as a binary character prior to the string itself.

--- a/test/io/bradc/badWrite.good
+++ b/test/io/bradc/badWrite.good
@@ -1,0 +1,2 @@
+>foo bar
+>foo bar


### PR DESCRIPTION
This test shows that we seem to write the length of strings to binary
output for write() calls, but not writef("%s", ...) calls.  I believe
we should not write the length in either of these two cases.