### PR TITLE
Use jemalloc with PGI

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -380,9 +380,8 @@ CHPL_MEM
         ========= =======================================================
 
    If unset, ``CHPL_MEM`` defaults to ``jemalloc`` for most configurations.
-   If the target platform is ``cygwin*``, the target compiler is ``*pgi``,
-   or the target platform is ``darwin`` and the target compiler is ``gnu``
-   it defaults to ``cstdlib``
+   If the target platform is ``cygwin*``, or the target platform is
+   ``darwin`` and the target compiler is ``gnu`` it defaults to ``cstdlib``
 
 
 .. _readme-chplenv.CHPL_LAUNCHER:

--- a/third-party/jemalloc/README
+++ b/third-party/jemalloc/README
@@ -10,6 +10,11 @@ convenience and was obtained from:
 Any Chapel issues that seem to be related to jemalloc should be
 directed to the Chapel team at chapel-bugs@lists.sourceforge.net.
 
+In addition to the base 4.2.1 version, we have applied upstream
+patches in order to support using jemalloc with the PGI compiler.
+
+  https://github.com/jemalloc/jemalloc/commit/fbd7956
+  https://github.com/jemalloc/jemalloc/commit/8a1a794
 
 Upgrading jemalloc versions
 ===========================
@@ -18,16 +23,17 @@ The directory $CHPL_HOME/third-party/jemalloc/jemalloc-src contains the
 un-tarballed jemalloc package contents. Version updates should be done as
 follows, assuming the CWD is $CHPL_HOME/third-party/jemalloc/:
 
-1. download and untar the latest jemalloc version: e.g. jemalloc-4.2.1
-2. `rm -rf jemalloc-src`
-3. `mv jemalloc-4.2.1 jemalloc-src`
-4. `git add --force jemalloc-src` (--force to ignore our .gitignore)
-5. update the version number mentioned above
-6. verify the references to jemalloc's man page in the runtime shim are
-   accurate and update the version number referenced.
-7. make sure these instructions are up to date :)
-8. test (std config, and at least one that requires a shared-heap)
-9. commit, PR, merge, etc
+1.  download and untar the latest jemalloc version: e.g. jemalloc-4.2.1
+2.  `rm -rf jemalloc-src`
+3.  `mv jemalloc-4.2.1 jemalloc-src`
+4.  `git add --force jemalloc-src` (--force to ignore our .gitignore)
+5.  update the version number mentioned above
+6.  apply patches mentioned above, assuming they aren't in the new version
+7.  verify the references to jemalloc's man page in the runtime shim are
+    accurate and update the version number referenced.
+8.  make sure these instructions are up to date :)
+9.  test (std config, and at least one that requires a shared-heap)
+10. commit, PR, merge, etc
 
 Note that these instructions are for a simple API compatible updates. If the
 jemalloc API changes, or the references to the man page in the runtime shim are

--- a/third-party/jemalloc/jemalloc-src/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/third-party/jemalloc/jemalloc-src/include/jemalloc/internal/jemalloc_internal.h.in
@@ -162,7 +162,9 @@ static const bool config_cache_oblivious =
 #endif
 
 #include "jemalloc/internal/ph.h"
+#ifndef __PGI
 #define	RB_COMPACT
+#endif
 #include "jemalloc/internal/rb.h"
 #include "jemalloc/internal/qr.h"
 #include "jemalloc/internal/ql.h"

--- a/third-party/jemalloc/jemalloc-src/test/unit/math.c
+++ b/third-party/jemalloc/jemalloc-src/test/unit/math.c
@@ -5,6 +5,10 @@
 
 #include <float.h>
 
+#ifdef __PGI
+#undef INFINITY
+#endif
+
 #ifndef INFINITY
 #define	INFINITY (DBL_MAX + DBL_MAX)
 #endif

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -21,10 +21,9 @@ def get(flag='host'):
             compiler_val = chpl_compiler.get('target')
 
             cygwin = platform_val.startswith('cygwin')
-            pgi = 'pgi' in compiler_val
             gnu_darwin = platform_val == 'darwin' and compiler_val == 'gnu'
 
-            if cygwin or pgi or gnu_darwin:
+            if cygwin or gnu_darwin:
                 mem_val = 'cstdlib'
             else:
                 mem_val = 'jemalloc'


### PR DESCRIPTION
Try using jemalloc with pgi (round 3? maybe round 4?)

#3944 was the latest attempt to use jemalloc with pgi, but we ran into some
segfaults and timeouts as a result a result of a jemalloc bug when TLS wasn't
available (such as under pgi.) That bug was fixed with 4.2.1 and the previous
red-black tree segfaults we saw have been fixed with 5e22f84. With those two
fixes, I think we can finally use jemalloc with pgi.

This updates our chplenv scripts to default to jemalloc for pgi and
cherry-picks two commits that I committed upstream to fix PGI support:
 - https://github.com/jemalloc/jemalloc/commit/fbd7956
 - https://github.com/jemalloc/jemalloc/commit/8a1a794
