### PR TITLE
Remove recursive * from builtins/packages.rst

### DIFF
--- a/doc/sphinx/source/modules/builtins.rst
+++ b/doc/sphinx/source/modules/builtins.rst
@@ -13,7 +13,7 @@ amenable to being documented using **chpldoc**:
    :maxdepth: 1
    :glob:
 
-   internal/**
+   internal/*
 
 
 Index

--- a/doc/sphinx/source/modules/packages.rst
+++ b/doc/sphinx/source/modules/packages.rst
@@ -16,7 +16,7 @@ inclusion there.
    :maxdepth: 1
    :glob:
 
-   packages/**
+   packages/*
 
 
 Index


### PR DESCRIPTION
This change fixes a bug in which submodules under `builtins` or `packages` were listed as siblings as opposed to parent-child. This surfaced when I tried to add the new `BLAS` module documentation to `packages`, which includes a submodule, `C_BLAS`.

This bug was caused by a recursive include in the toctree, e.g. `packages/**`, which would add all modules found recursively as siblings. Changing this to `packages/*` yields the correct behavior.

I've left `layoutdist.rst` untouched since distributions has non-submodule subdirectories.