### PR TITLE
Default to jemalloc with gnu+osx

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -376,12 +376,11 @@ CHPL_MEM
         Value     Description
         ========= =======================================================
         cstdlib   use the standard C malloc/free commands
-        jemalloc  use Jason Evan's memory allocation package
+        jemalloc  use Jason Evan's memory allocator
         ========= =======================================================
 
    If unset, ``CHPL_MEM`` defaults to ``jemalloc`` for most configurations.
-   If the target platform is ``cygwin*``, or the target platform is
-   ``darwin`` and the target compiler is ``gnu`` it defaults to ``cstdlib``
+   If the target platform is ``cygwin*`` it defaults to ``cstdlib``
 
 
 .. _readme-chplenv.CHPL_LAUNCHER:

--- a/third-party/jemalloc/jemalloc-src/configure
+++ b/third-party/jemalloc/jemalloc-src/configure
@@ -6944,6 +6944,52 @@ fi
 
 
 
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether a program using __builtin_unreachable is compilable" >&5
+$as_echo_n "checking whether a program using __builtin_unreachable is compilable... " >&6; }
+if ${je_cv_gcc_builtin_unreachable+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+void foo (void) {
+  __builtin_unreachable();
+}
+
+int
+main ()
+{
+
+	{
+		foo();
+	}
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  je_cv_gcc_builtin_unreachable=yes
+else
+  je_cv_gcc_builtin_unreachable=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $je_cv_gcc_builtin_unreachable" >&5
+$as_echo "$je_cv_gcc_builtin_unreachable" >&6; }
+
+if test "x${je_cv_gcc_builtin_ffsl}" = "xyes" ; then
+  $as_echo "#define JEMALLOC_INTERNAL_UNREACHABLE __builtin_unreachable" >>confdefs.h
+
+else
+  $as_echo "#define JEMALLOC_INTERNAL_UNREACHABLE abort" >>confdefs.h
+
+fi
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether a program using __builtin_ffsl is compilable" >&5
 $as_echo_n "checking whether a program using __builtin_ffsl is compilable... " >&6; }
 if ${je_cv_gcc_builtin_ffsl+:} false; then :

--- a/third-party/jemalloc/jemalloc-src/configure.ac
+++ b/third-party/jemalloc/jemalloc-src/configure.ac
@@ -1050,6 +1050,23 @@ if test "x$enable_cache_oblivious" = "x1" ; then
 fi
 AC_SUBST([enable_cache_oblivious])
 
+
+
+JE_COMPILABLE([a program using __builtin_unreachable], [
+void foo (void) {
+  __builtin_unreachable();
+}
+], [
+	{
+		foo();
+	}
+], [je_cv_gcc_builtin_unreachable])
+if test "x${je_cv_gcc_builtin_ffsl}" = "xyes" ; then
+  AC_DEFINE([JEMALLOC_INTERNAL_UNREACHABLE], [__builtin_unreachable])
+else
+  AC_DEFINE([JEMALLOC_INTERNAL_UNREACHABLE], [abort])
+fi
+
 dnl ============================================================================
 dnl Check for  __builtin_ffsl(), then ffsl(3), and fail if neither are found.
 dnl One of those two functions should (theoretically) exist on all platforms

--- a/third-party/jemalloc/jemalloc-src/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/third-party/jemalloc/jemalloc-src/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -189,6 +189,12 @@
 #undef JEMALLOC_TLS
 
 /*
+ * Used to mark unreachable code to quiet "end of non-void" compiler warnings.
+ * Don't use this directly; instead use unreachable() from util.h
+ */
+#undef JEMALLOC_INTERNAL_UNREACHABLE
+
+/*
  * ffs*() functions to use for bitmapping.  Don't use these directly; instead,
  * use ffs_*() from util.h.
  */

--- a/third-party/jemalloc/jemalloc-src/include/jemalloc/internal/util.h
+++ b/third-party/jemalloc/jemalloc-src/include/jemalloc/internal/util.h
@@ -61,29 +61,19 @@
 #	define JEMALLOC_CC_SILENCE_INIT(v)
 #endif
 
-#define	JEMALLOC_GNUC_PREREQ(major, minor)				\
-    (!defined(__clang__) &&						\
-    (__GNUC__ > (major) || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor))))
-#ifndef __has_builtin
-#  define __has_builtin(builtin) (0)
-#endif
-#define	JEMALLOC_CLANG_HAS_BUILTIN(builtin)				\
-    (defined(__clang__) && __has_builtin(builtin))
-
 #ifdef __GNUC__
 #	define likely(x)   __builtin_expect(!!(x), 1)
 #	define unlikely(x) __builtin_expect(!!(x), 0)
-#  if JEMALLOC_GNUC_PREREQ(4, 6) ||					\
-      JEMALLOC_CLANG_HAS_BUILTIN(__builtin_unreachable)
-#	define unreachable() __builtin_unreachable()
-#  else
-#	define unreachable() abort()
-#  endif
 #else
 #	define likely(x)   !!(x)
 #	define unlikely(x) !!(x)
-#	define unreachable() abort()
 #endif
+
+#if !defined(JEMALLOC_INTERNAL_UNREACHABLE)
+#  error JEMALLOC_INTERNAL_UNREACHABLE should have been defined by configure
+#endif
+
+#define unreachable() JEMALLOC_INTERNAL_UNREACHABLE()
 
 #include "jemalloc/internal/assert.h"
 

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -6,7 +6,7 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_compiler, chpl_platform
+import chpl_platform
 from utils import memoize
 
 
@@ -18,12 +18,9 @@ def get(flag='host'):
         mem_val = os.environ.get('CHPL_MEM')
         if not mem_val:
             platform_val = chpl_platform.get('target')
-            compiler_val = chpl_compiler.get('target')
-
             cygwin = platform_val.startswith('cygwin')
-            gnu_darwin = platform_val == 'darwin' and compiler_val == 'gnu'
 
-            if cygwin or gnu_darwin:
+            if cygwin:
                 mem_val = 'cstdlib'
             else:
                 mem_val = 'jemalloc'


### PR DESCRIPTION
Previously, we had to default to cstdlib with gnu+osx because of link time
errors. These have been resolved with 446933c, so default to jemalloc now.

This updates our chplenv scripts to default to jemalloc for gnu+osx and
cherry-picks a patch that I committed upstream to fix gnu+osx support:

 - https://github.com/jemalloc/jemalloc/commit/1167e9e
