### PR TITLE
Fix typo added with 446933c

### DIFF
--- a/third-party/jemalloc/jemalloc-src/configure
+++ b/third-party/jemalloc/jemalloc-src/configure
@@ -6981,7 +6981,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $je_cv_gcc_builtin_unreachable" >&5
 $as_echo "$je_cv_gcc_builtin_unreachable" >&6; }
 
-if test "x${je_cv_gcc_builtin_ffsl}" = "xyes" ; then
+if test "x${je_cv_gcc_builtin_unreachable}" = "xyes" ; then
   $as_echo "#define JEMALLOC_INTERNAL_UNREACHABLE __builtin_unreachable" >>confdefs.h
 
 else

--- a/third-party/jemalloc/jemalloc-src/configure.ac
+++ b/third-party/jemalloc/jemalloc-src/configure.ac
@@ -1061,7 +1061,7 @@ void foo (void) {
 		foo();
 	}
 ], [je_cv_gcc_builtin_unreachable])
-if test "x${je_cv_gcc_builtin_ffsl}" = "xyes" ; then
+if test "x${je_cv_gcc_builtin_unreachable}" = "xyes" ; then
   AC_DEFINE([JEMALLOC_INTERNAL_UNREACHABLE], [__builtin_unreachable])
 else
   AC_DEFINE([JEMALLOC_INTERNAL_UNREACHABLE], [abort])


### PR DESCRIPTION
I accidentally checked for je_cv_gcc_builtin_ffsl instead of
je_cv_gcc_builtin_unreachable, which meant that JEMALLOC_INTERNAL_UNREACHABLE
was always being defined as abort instead of __builtin_unreachable when it was
available.