### PR TITLE
Print function return types using nicer formatting for chpldoc

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2450,8 +2450,10 @@ void FnSymbol::printDocs(std::ostream *file, unsigned int tabs) {
 
   // Print return type.
   if (this->retExprType != NULL) {
+    AstToText info;
+    info.appendExpr(this->retExprType->body.tail, true);
     *file << ": ";
-    this->retExprType->body.tail->prettyPrint(file);
+    *file << info.text();
   }
   *file << std::endl;
 

--- a/compiler/include/AstToText.h
+++ b/compiler/include/AstToText.h
@@ -90,6 +90,8 @@ public:
   void                   appendEnumDecl(EnumType* et);
   void                   appendVarDef(VarSymbol* var);
 
+  void                   appendExpr(Expr* expr, bool printingType);
+
 private:
 
   //
@@ -130,9 +132,6 @@ private:
   //
   // Formatting the expressions found in formals (skeleton)
   //
-  void                   appendExpr(Expr*              expr,
-                                    bool               printingType);
-
   void                   appendExpr(UnresolvedSymExpr* expr);
 
   void                   appendExpr(SymExpr*           expr,

--- a/test/chpldoc/returnTypeExpression.doc.catfiles
+++ b/test/chpldoc/returnTypeExpression.doc.catfiles
@@ -1,0 +1,1 @@
+docs/returnTypeExpression.doc.txt

--- a/test/chpldoc/returnTypeExpression.doc.chpl
+++ b/test/chpldoc/returnTypeExpression.doc.chpl
@@ -1,0 +1,3 @@
+proc foo(a: complex(?w), b: real(w/2)): real(w/2) {
+  return a.im + b;
+}

--- a/test/chpldoc/returnTypeExpression.doc.good
+++ b/test/chpldoc/returnTypeExpression.doc.good
@@ -1,0 +1,6 @@
+returnTypeExpression.doc
+
+Usage:
+   use returnTypeExpression.doc;
+
+   proc foo(a: complex(?w), b: real(w/2)): real(w/2)


### PR DESCRIPTION
For a function like:
proc f(a: complex(?w), b: real(w/2)): real(w/2)

chpldoc printed the second argument type like it appears above, but the return
type as:

real(/(w,2))

Use the same class/method that pretty prints formal argument types to print
the return type.  Changed the method
  AstToText::appendExpr(Expr* expr, bool printingType)
from private to public, so it could be used for return types.

Added a test to lock in the new style.