### PR TITLE
Turn off sleepTimeUnits for darwin.

### DIFF
--- a/test/modules/standard/Time/sleepTimeUnits.skipif
+++ b/test/modules/standard/Time/sleepTimeUnits.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM == darwin


### PR DESCRIPTION
We're having trouble with this test reporting under-sleeps that seem to
be spurious, apparently because of a slight disagreement between the
mach-based times that Qthreads sleep uses and the gettimeofday(2) times
upon which our modules/standard/Time sleep is based.  This is creating
noise in nightly testing.  We'd like to get rid of the noise, but the
right way to do that is to rewrite the standard/Time sleep stuff (since
gettimeofday() is inherently problematic) and nobody has jumped at the
opportunity to do that.  So for now, just disable this test on darwin.