### PR TITLE
Adjust test prediff for downEndCount in fast_executeOn

### DIFF
--- a/test/performance/sungeun/multilocale/syncsingle.chpl
+++ b/test/performance/sungeun/multilocale/syncsingle.chpl
@@ -1,5 +1,7 @@
 use CommDiagnostics;
+use Time;
 config param doVerboseComm = false;
+config const dosleep = false;
 
 var si: single bool;
 resetCommDiagnostics();
@@ -7,7 +9,10 @@ startCommDiagnostics();
 if doVerboseComm then startVerboseComm();
 coforall l in Locales do on l {
   if l.id == numLocales-1 then
-    begin si.writeEF(true);
+    begin {
+      si.writeEF(true);
+      if dosleep then sleep(3);
+    }
   si.readFF();
 }
 if doVerboseComm then stopVerboseComm();
@@ -20,7 +25,10 @@ startCommDiagnostics();
 if doVerboseComm then startVerboseComm();
 coforall l in Locales do on l {
   if l.id == numLocales-1 then
-    begin sy.writeEF(true);
+    begin {
+      sy.writeEF(true);
+      if dosleep then sleep(3);
+    }
   sy.readFF();
 }
 if doVerboseComm then stopVerboseComm();

--- a/test/performance/sungeun/multilocale/syncsingle.prediff
+++ b/test/performance/sungeun/multilocale/syncsingle.prediff
@@ -14,15 +14,15 @@ def fixForkCounts(fn, orig):
     counts = orig.split(')')
     l4 = counts[-2].split()
     if l4[0]=='(get':
-        forks = l4[23]
-        if forks >= '4,' and forks <= '5,':
-            forks = '5,'
+        forks = l4[26]
+        if forks >= '1,' and forks <= '2,':
+            forks = '2,'
         for c in counts[0:-2]:
             fn.write(c+')')
-        for e in l4[0:23]:
+        for e in l4[0:26]:
             fn.write(' '+e)
         fn.write(' '+forks)
-        for c in l4[24:]:
+        for c in l4[27:]:
             fn.write(' '+c)
         fn.write(')\n')
     else:

--- a/test/performance/sungeun/multilocale/syncsingle.skipif
+++ b/test/performance/sungeun/multilocale/syncsingle.skipif
@@ -1,0 +1,2 @@
+# prediff uses execute_on_fast numbers
+COMPOPTS <= --baseline


### PR DESCRIPTION
Also added a dosleep config var to the test that can easily
show the unusual behavior.

Also added a .skipif since the test won't use fast executeOn
in --baseline.