### PR TITLE
Update perf playground to test a less "minimal" jemalloc

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,9 +9,9 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of jemalloc's decay-based purging
+# Test performance of jemalloc with some features we don't use disabled
 
-export CHPL_JEMALLOC_MORE_CFG_OPTIONS="--disable-stats --disable-fill --disable-valgrind"
+export CHPL_JEMALLOC_MORE_CFG_OPTIONS="--disable-stats"
 SHORT_NAME=minimal-jemalloc
 START_DATE=06/03/16
 


### PR DESCRIPTION
Currently the perf playground is testing jemalloc configured with:

    --disable-stats --disable-fill --disable-valgrind

but the `fill` and `valgrind` options are required to use jemalloc under
valgrind, so we wouldn't want to outright disable them for production builds.
Just test the performance of

    --disable-stats

to see if it still results in a performance improvement because that's a
feature we don't currently use and could consider disabling.