### PR TITLE
Refactor extern "C" declarations to not cross include boundaries.

### DIFF
--- a/runtime/include/chpl-mem-hook.h
+++ b/runtime/include/chpl-mem-hook.h
@@ -32,6 +32,10 @@
 // Need memory tracking prototypes for inlined memory routines
 #include "chplmemtrack.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // CHPL_MEMHOOKS_ACTIVE=1 will enable the memory hooks;
 // CHPL_MEMHOOKS_ACTIVE will be set to 1 if CHPL_DEBUG is defined;
 // or if CHPL_OPTIMIZE is not defined.
@@ -122,6 +126,10 @@ void chpl_memhook_realloc_post(void* moreMemAlloc, void* memAlloc,
     chpl_track_realloc_post(moreMemAlloc, memAlloc, size, description,
                        lineno, filename);
 }
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
 
 #endif // LAUNCHER
 

--- a/runtime/include/chplmemtrack.h
+++ b/runtime/include/chplmemtrack.h
@@ -28,6 +28,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 // Memory tracking activated?
 extern chpl_bool chpl_memTrack;
@@ -74,5 +78,9 @@ void chpl_track_realloc_post(void* moreMemAlloc,
 #define chpl_setMemtrack()
 
 #endif // LAUNCHER
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
 
 #endif

--- a/runtime/include/qio/deque.h
+++ b/runtime/include/qio/deque.h
@@ -31,10 +31,6 @@
 #ifndef _DEQUE_H_
 #define _DEQUE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "sys_basic.h"
 #include "qio_error.h"
 
@@ -52,6 +48,10 @@ extern "C" {
 #define deque_calloc(nmemb, size) calloc(nmemb,size)
 #define deque_free(ptr) free(ptr)
 #define deque_memcpy(dest, src, num) memcpy(dest, src, num)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 typedef struct deque_node_s {

--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -20,10 +20,6 @@
 #ifndef _QBUFFER_H_
 #define _QBUFFER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // This macro set to obtain the portable format macro PRIu64 for debug output.
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS 1
@@ -96,6 +92,10 @@ typedef atomic_uint_least64_t qbytes_refcnt_t;
 }
 
 #define DO_DESTROY_REFCNT(ptr) atomic_destroy_uint_least64_t (&ptr->ref_cnt)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // how large is an iobuf?
 extern size_t qbytes_iobuf_size;
@@ -456,6 +456,10 @@ qioerr qbuffer_copyin_buffer(qbuffer_t* dst, qbuffer_iter_t dst_start, qbuffer_i
  * */
 qioerr qbuffer_memset(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end, unsigned char byte);
 
+#ifdef __cplusplus
+} // end extern "C"
+#endif
+
 // How many bytes to try to store on stack in some functions that don't
 // really want to call malloc
 #define MAX_ON_STACK 128
@@ -470,12 +474,20 @@ qioerr qbuffer_memset(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end, 
 #define qio_free(ptr) chpl_mem_free(ptr, 0, 0)
 #define qio_memcpy(dest, src, num) chpl_memcpy(dest, src, num)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline char* qio_strdup(const char* ptr)
 {
   char* ret = (char*) qio_malloc(strlen(ptr)+1);
   if( ret ) strcpy(ret, ptr);
   return ret;
 }
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
 
 typedef chpl_bool qio_bool;
 
@@ -523,6 +535,10 @@ typedef bool qio_bool;
     qio_free(ptr); \
   } \
 }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Returns the difference between two pointers,
    but returns 0 if either pointer is NULL.

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -20,10 +20,6 @@
 #ifndef _QIO_H_
 #define _QIO_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "sys_basic.h"
 #include "bswap.h"
 #include "qbuffer.h"
@@ -43,6 +39,10 @@ extern "C" {
 #include <sys/mman.h>
 
 #define DEBUG_QIO 0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // synonym for iovec
 typedef struct iovec qiovec_t;
@@ -196,6 +196,10 @@ typedef struct qio_file_functions_s {
 typedef qio_file_functions_t* qio_file_functions_ptr_t;
 // -- end --
 
+#ifdef __cplusplus
+} // end extern "C"
+#endif
+
 #ifdef _chplrt_H_
 // also export iohint_t and fdflag_t
 typedef qio_hint_t iohints;
@@ -211,6 +215,10 @@ typedef struct {
 
 #define NULL_OWNER chpl_nullTaskID
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 qioerr qio_lock(qio_lock_t* x);
 void qio_unlock(qio_lock_t* x);
 
@@ -225,6 +233,10 @@ static inline void qio_lock_destroy(qio_lock_t* x) {
   chpl_sync_destroyAux(&x->sv);
 }
 
+#ifdef __cplusplus
+} // end extern "C"
+#endif
+
 #else
 
 #ifndef CHPL_RT_UNIT_TEST
@@ -232,6 +244,10 @@ static inline void qio_lock_destroy(qio_lock_t* x) {
 #endif
 
 #include <pthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef pthread_mutex_t qio_lock_t;
 // these should return 0 on success; otherwise, an error number.
@@ -264,12 +280,21 @@ static inline qioerr qio_lock_init(qio_lock_t* x) {
 
 // returns void for the same reason as qio_unlock.
 static inline void qio_lock_destroy(qio_lock_t* x) { int rc = pthread_mutex_destroy(x); if( rc ) { assert(rc == 0); abort(); } }
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
+
 #endif
 
 
 extern ssize_t qio_too_small_for_default_mmap;
 extern ssize_t qio_too_large_for_default_mmap;
 extern ssize_t qio_mmap_chunk_iobufs;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Wrap system calls readv, writev, preadv, pwritev
  * to take a buffer.

--- a/runtime/include/qio/qio_error.h
+++ b/runtime/include/qio/qio_error.h
@@ -20,14 +20,14 @@
 #ifndef _QIO_ERROR_H
 #define _QIO_ERROR_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "sys_basic.h"
 #include <assert.h>
 
 #define QIO_ERROR_DOUBLE_CHECK 0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef int err_t;
 

--- a/runtime/include/qio/qio_regexp.h
+++ b/runtime/include/qio/qio_regexp.h
@@ -26,6 +26,10 @@ struct qio_channel_s;
 #include "sys_basic.h"
 #include "qio.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct qio_regexp_s {
   void* regexp;
 } qio_regexp_t;
@@ -136,5 +140,9 @@ int64_t qio_regexp_replace(qio_regexp_t* regexp, const char* repl, int64_t repl_
 //  - if there was an error, we do not adjust the channel position afterwards
 //
 qioerr qio_regexp_channel_match(const qio_regexp_t* regexp, const int threadsafe, struct qio_channel_s* ch, int64_t maxlen, int anchor, qio_bool can_discard, qio_bool keep_unmatched, qio_bool keep_whole_pattern, qio_regexp_string_piece_t* submatch, int64_t nsubmatch);
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
 
 #endif

--- a/runtime/include/qio/sys.h
+++ b/runtime/include/qio/sys.h
@@ -20,10 +20,6 @@
 #ifndef _SYS_H_
 #define _SYS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "sys_basic.h"
 #include "qio_error.h"
 
@@ -38,6 +34,10 @@ extern "C" {
 #include <netdb.h>
 #include <unistd.h>
 #include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef LUSTRE_SUPER_MAGIC
 // Magic value to be found in the statfs man page

--- a/runtime/src/qio/regexp/re2/re2-interface.cc
+++ b/runtime/src/qio/regexp/re2/re2-interface.cc
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <pthread.h>
 
-extern "C" {
   #include <stdlib.h>
   #include <stdio.h>
 #ifndef CHPL_RT_UNIT_TEST
@@ -18,7 +17,6 @@ extern "C" {
   #include "qbuffer.h" // qio_strdup, refcount functions, qio_ptr_diff, etc
   #include "qio.h" // for channel operations
   #undef printf
-}
 
 #include "re2/re2.h"
 //#include "re2/regexp.h"

--- a/test/regexp/ferguson/ctests/regexp_channel_test.cc
+++ b/test/regexp/ferguson/ctests/regexp_channel_test.cc
@@ -1,10 +1,8 @@
 
-extern "C" {
 #include "qio.h"
 #include "qio_regexp.h"
 #include <assert.h>
 #include <stdio.h>
-}
 
 
 #include "re2/re2.h"

--- a/test/regexp/ferguson/ctests/regexp_test.cc
+++ b/test/regexp/ferguson/ctests/regexp_test.cc
@@ -1,10 +1,8 @@
-extern "C" {
 //  #include "stdchplrt.h"
 #include "qio.h"
 #include "qio_regexp.h"
 #include <assert.h>
 #include <stdio.h>
-}
 
 #include "re2/re2.h"
 


### PR DESCRIPTION
This is being done in support of the upcoming atomics change.

Some system headers, notably &lt;atomic&gt;, will not work when #included inside an extern "C" declaration.  In the runtime code prior to this patch, there are multiple nested extern "C" declarations in enclosing header files that prevent &lt;atomic&gt; from working.

This patch follows a new model for extern "C" declarations.
1.  Do not #include a file inside an extern "C" declaration.
1a.  This implies that header files that expect to be included by C++ code have to place extern "C" around the declarations that need it.
2.  Do not start an extern "C" declaration outside a #if and end it inside, or vice versa.
