### PR TITLE
IO.chpl: two small fixes

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3770,7 +3770,7 @@ inline proc channel.readwrite(ref x) where !this.writing {
   // these are overridden to not be inout
   // since they don't change when read anyway
   // and it's much more convenient to be able to do e.g.
-  //   reader & new ioLiteral("=")
+  //   reader <~> new ioLiteral("=")
 
   /* Overload to support reading an :type:`IO.ioLiteral` without
      passing ioLiterals by reference, so that
@@ -3793,7 +3793,7 @@ inline proc channel.readwrite(ref x) where !this.writing {
 
      .. code-block:: chapel
 
-       reader <~> new ioNewline("=")
+       reader <~> new ioNewline()
 
      works without requiring an explicit temporary value to store
      the ioNewline.


### PR DESCRIPTION
reader & new ioLiteral("=") seems to have been the notation prior to
the introduction of <~>.

reader <~> new ioNewline("=") seems to have been copy and pasted from
the ioLiteral("=") example without removing the argument that
ioNewline() doesn't accept.