### PR TITLE
Raise error with CHPL_UNWIND=libunwind on darwin

### DIFF
--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -22,7 +22,8 @@ def get():
             return 'system'
     if osx:
         if val == 'libunwind':
-            raise ValueError("Invalid flag "+val)
+            raise ValueError("Using CHPL_UNWIND=libunwind is not supported"+
+                            " on Mac OS X. Use CHPL_UNWIND=system instead.")
         elif val == 'system':
             return 'system'
     return 'none'

--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -14,12 +14,18 @@ def get():
     linux = platform_val.startswith('linux64')
     osx = platform_val.startswith('darwin')
     val = os.environ.get('CHPL_UNWIND')
-    if val == 'libunwind' and linux:
-        return 'libunwind'
-    if val == 'system' and (osx or linux):
-        return 'system'
-    return 'none'
 
+    if linux:
+        if val == 'libunwind':
+            return 'libunwind'
+        elif val == 'system':
+            return 'system'
+    if osx:
+        if val == 'libunwind':
+            raise ValueError("Invalid flag "+val)
+        elif val == 'system':
+            return 'system'
+    return 'none'
 
 def _main():
     unwind_val = get()


### PR DESCRIPTION
This PR raises an error if CHPL_UNWIND is set to ‘libunwind’ on darwin.

Passed test/runtime/panzone with CHPL_UNWIND = none/libunwind/system on linux64.