### PR TITLE
Add check that parentCall is not null

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -959,7 +959,7 @@ static void insert_call_temps(CallExpr* call)
   tmp->addFlag(FLAG_MAYBE_PARAM);
   tmp->addFlag(FLAG_MAYBE_TYPE);
 
-  if (call->isNamed("super") && parentCall->isNamed(".") &&
+  if (call->isNamed("super") && parentCall && parentCall->isNamed(".") &&
       parentCall->get(1) == call) {
     // We've got an access to a method or field on the super type.  This means
     // we should preserve that knowledge for when we attempt to access the


### PR DESCRIPTION
Coverity complained that we shouldn't try to call a method on a null pointer,
which is fair (though I don't think it would necessarily be null, but who knows
what code will be created?).  So insert a check that the parent call is not
null before calling the method on it.