### PR TITLE
Disable jemalloc's stats gathering by default

### DIFF
--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -15,6 +15,12 @@ endif
 CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \
 			     --with-jemalloc-prefix=je_
 
+# Unless the user explicitly asks for stats gathering, disable it since
+# there is some runtime overhead of this capability
+ifeq (, $(CHPL_JEMALLOC_ENABLE_STATS))
+CHPL_JEMALLOC_CFG_OPTIONS += --disable-stats
+endif
+
 # As an optimization, use jemalloc's decay-based purging instead of the
 # default ratio-based purging
 CHPL_JEMALLOC_CFG_OPTIONS += --with-malloc-conf=purge:decay


### PR DESCRIPTION
Jemalloc has really powerful and helpful stats gathering that can be really
helpful during development, but there is some performance cost for gathering
these statistics when they're not used. By default, disable stats gathering
unless the user explicitly opts in by setting CHPL_JEMALLOC_ENABLE_STATS

For binary trees (a benchmark that really measures allocator speed) this
results in a ~10% speedup on the shootout-like machine.