### PR TITLE
Bugfix : CHPL_COMM_WORLD should be set even if numLocales==1

### DIFF
--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -215,8 +215,13 @@ module MPI {
         C_MPI.MPI_Comm_split(MPI_COMM_WORLD, 0, here.id : c_int,
           CHPL_COMM_WORLD_REPLICATED(1));
       }
-      _mpi.freeChplComm = true;
+    } else {
+      // For a single locale, just duplicate MPI_COMM_WORLD
+      C_MPI.MPI_Comm_dup(MPI_COMM_WORLD, CHPL_COMM_WORLD_REPLICATED(1));
     }
+
+    // Set flag to free
+    _mpi.freeChplComm = true;
   }
 
   /* commRank(comm)

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -216,7 +216,9 @@ module MPI {
           CHPL_COMM_WORLD_REPLICATED(1));
       }
     } else {
-      // For a single locale, just duplicate MPI_COMM_WORLD
+      // For a single Chapel locale, just duplicate MPI_COMM_WORLD
+      // NOTE : This split in logic is necessary, especially if Chapel is running
+      // in single-locale mode, but we want to continue to use MPI.
       C_MPI.MPI_Comm_dup(MPI_COMM_WORLD, CHPL_COMM_WORLD_REPLICATED(1));
     }
 

--- a/test/users/npadmana/mpi-bugfix-single-rank-comm/test.chpl
+++ b/test/users/npadmana/mpi-bugfix-single-rank-comm/test.chpl
@@ -1,0 +1,13 @@
+use MPI;
+use C_MPI;
+
+writeln("Test...");
+
+writeln("numLocales = ",numLocales);
+writeln("MPI size = ", commSize(MPI_COMM_WORLD));
+
+coforall loc in Locales do on loc {
+  MPI_Barrier(CHPL_COMM_WORLD);
+}
+
+writeln("All done");

--- a/test/users/npadmana/mpi-bugfix-single-rank-comm/testit.good
+++ b/test/users/npadmana/mpi-bugfix-single-rank-comm/testit.good
@@ -1,0 +1,28 @@
+Test...
+numLocales = 1
+MPI size = 1
+All done
+Test...
+numLocales = 1
+MPI size = 4
+Test...
+numLocales = 1
+MPI size = 4
+Test...
+numLocales = 1
+MPI size = 4
+Test...
+numLocales = 1
+MPI size = 4
+All done
+All done
+All done
+All done
+Test...
+numLocales = 1
+MPI size = 1
+All done
+Test...
+numLocales = 4
+MPI size = 4
+All done

--- a/test/users/npadmana/mpi-bugfix-single-rank-comm/testit.sh
+++ b/test/users/npadmana/mpi-bugfix-single-rank-comm/testit.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+export AMMPI_MPI_THREAD=multiple
+# This is for Cray systems, at least the ones I use!
+export MPICH_MAX_THREAD_SAFETY=multiple
+
+export CHPL_TARGET_COMPILER=mpi-gnu
+
+# Chapel (single-locale) + MPI
+export CHPL_COMM=none
+rm -f a.out
+chpl test.chpl
+mpirun -np 1 ./a.out
+mpirun -np 4 ./a.out
+
+# Chapel + MPI
+export CHPL_COMM=gasnet
+export CHPL_COMM_SUBSTRATE=mpi
+export CHPL_TASKS=fifo
+rm -f a.out a.out_real
+chpl test.chpl
+./a.out -nl 1
+./a.out -nl 4
+


### PR DESCRIPTION
We were previously only setting CHPL_COMM_WORLD if the number of locales > 1, which would cause the program to crash if the user attempted to use it when the number of locales==1.

This bugfix now sets CHPL_COMM_WORLD to MPI_COMM_WORLD when numLocales==1, which is (happily) the desired behavior even when running single-locale Chapel + MPI.

@mppf -- could you review this? Thanks!