### PR TITLE
Remove special meaning for defaultInitializer for iterators

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1495,8 +1495,14 @@ FnSymbol::FnSymbol(const char* initName) :
 
 
 FnSymbol::~FnSymbol() {
-  if (iteratorInfo)
+  if (iteratorInfo) {
+    // Also set iterator class and iterator record iteratorInfo = NULL.
+    if (iteratorInfo->iclass)
+      iteratorInfo->iclass->iteratorInfo = NULL;
+    if (iteratorInfo->irecord)
+      iteratorInfo->irecord->iteratorInfo = NULL;
     delete iteratorInfo;
+  }
   BasicBlock::clear(this);
   delete basicBlocks; basicBlocks = 0;
   if (calledBy)

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -592,7 +592,15 @@ AggregateType::AggregateType(AggregateTag initTag) :
 }
 
 
-AggregateType::~AggregateType() { }
+AggregateType::~AggregateType() {
+  // Delete references to this in iteratorInfo when destroyed.
+  if (iteratorInfo) {
+    if (iteratorInfo->iclass == this)
+      iteratorInfo->iclass = NULL;
+    if (iteratorInfo->irecord == this)
+      iteratorInfo->irecord = NULL;
+  }
+}
 
 
 void AggregateType::verify() {

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -576,6 +576,7 @@ AggregateType::AggregateType(AggregateTag initTag) :
   fields(),
   inherits(),
   outer(NULL),
+  iteratorInfo(NULL),
   doc(NULL)
 {
   if (aggregateTag == AGGREGATE_CLASS) { // set defaultValue to nil to keep it

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -36,6 +36,8 @@
 #include "symbol.h"
 #include "vec.h"
 
+#include "iterator.h"
+
 #include "AstVisitor.h"
 
 static bool isDerivedType(Type* type, Flag flag);
@@ -1933,9 +1935,11 @@ bool isAtomicType(const Type* t) {
 bool isRefIterType(Type* t) {
   Symbol* iteratorRecord = NULL;
 
-  if (t->symbol->hasFlag(FLAG_ITERATOR_CLASS))
-    iteratorRecord = t->defaultInitializer->getFormal(1)->type->symbol;
-  else if (t->symbol->hasFlag(FLAG_ITERATOR_RECORD))
+  if (t->symbol->hasFlag(FLAG_ITERATOR_CLASS)) {
+    AggregateType* at = toAggregateType(t);
+    FnSymbol* getIterator = at->iteratorInfo->getIterator;
+    iteratorRecord = getIterator->getFormal(1)->type->symbol;
+  } else if (t->symbol->hasFlag(FLAG_ITERATOR_RECORD))
     iteratorRecord = t->symbol;
 
   if (iteratorRecord)

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -35,6 +35,7 @@
 #include "WhileStmt.h"
 #include "AstDump.h"
 #include "AstDumpToNode.h"
+#include "iterator.h"
 
 #include <inttypes.h>
 

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -779,11 +779,11 @@ void whocalls(int id) {
       // check each step, just in case
       if (SymExpr* act2 = toSymExpr(call->get(2)))
         if (Symbol* ic = act2->var)
-          if (Type* ty = ic->type)
-            if (FnSymbol* init = ty->defaultInitializer)
+          if (AggregateType* ty = toAggregateType(ic->type))
+            if (FnSymbol* init = ty->iteratorInfo->getIterator)
               if (ArgSymbol* form1 = init->getFormal(1))
-                if (Type* fty = form1->type)
-                  if (FnSymbol* iterator = fty->defaultInitializer)
+                if (AggregateType* fty = toAggregateType(form1->type))
+                  if (FnSymbol* iterator = fty->iteratorInfo->iterator)
                     if (iterator->id == id)
                       printf("  for-loop blockInfo %d  %s  %s\n",
                              call->id, parentMsg(call, &forMatch,

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -51,6 +51,7 @@ class FnSymbol;
 class Symbol;
 class TypeSymbol;
 class VarSymbol;
+class IteratorInfo;
 
 class Type : public BaseAST {
 public:
@@ -157,6 +158,9 @@ class AggregateType : public Type {
   AList fields;
   AList inherits; // used from parsing, sets dispatchParents
   Symbol* outer;  // pointer to an outer class if this is an inner class
+
+  IteratorInfo* iteratorInfo; // Attached only to iterator class/records
+
   const char *doc;
 
   AggregateType(AggregateTag initTag);

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -27,6 +27,8 @@
 #include "stmt.h"
 #include "stlUtil.h"
 
+#include "iterator.h"
+
 #include <set>
 
 // We use RefVector to store a list of symbols that are aliases for the return
@@ -56,10 +58,11 @@ checkResolved() {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     checkReturnPaths(fn);
     if (fn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
-        !fn->isIterator() &&
-        fn->retType->defaultInitializer &&
-        fn->retType->defaultInitializer->defPoint->parentSymbol == fn)
-      USR_FATAL_CONT(fn, "functions cannot return nested iterators or loop expressions");
+        !fn->isIterator()) {
+      IteratorInfo* ii = toAggregateType(fn->retType)->iteratorInfo;
+      if (ii->iterator && ii->iterator->defPoint->parentSymbol == fn)
+        USR_FATAL_CONT(fn, "functions cannot return nested iterators or loop expressions");
+    }
     if (fn->hasFlag(FLAG_ASSIGNOP) && fn->retType != dtVoid)
       USR_FATAL(fn, "The return value of an assignment operator must be 'void'.");
   }

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -60,7 +60,7 @@ checkResolved() {
     if (fn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
         !fn->isIterator()) {
       IteratorInfo* ii = toAggregateType(fn->retType)->iteratorInfo;
-      if (ii->iterator && ii->iterator->defPoint->parentSymbol == fn)
+      if (ii && ii->iterator && ii->iterator->defPoint->parentSymbol == fn)
         USR_FATAL_CONT(fn, "functions cannot return nested iterators or loop expressions");
     }
     if (fn->hasFlag(FLAG_ASSIGNOP) && fn->retType != dtVoid)

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7573,7 +7573,7 @@ static void instantiate_default_constructor(FnSymbol* fn) {
 
     // This should not be happening for iterators.
     TypeSymbol* ts = instantiatedFrom->retType->symbol;
-    INT_ASSERT(!ts->hasEitherFlag(FLAG_ITERATOR_RECORD, FLAG_ITERATOR_CLASS))
+    INT_ASSERT(!ts->hasEitherFlag(FLAG_ITERATOR_RECORD, FLAG_ITERATOR_CLASS));
 
     for_formals(formal, fn) {
       if (formal->type == dtMethodToken || formal == fn->_this) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9196,8 +9196,7 @@ static void removeUnusedFunctions() {
     if (fn->defPoint && fn->defPoint->parentSymbol) {
       if (fn->defPoint->parentSymbol == stringLiteralModule) continue;
 
-      if (! fn->isResolved() ||
-          fn->retTag == RET_PARAM ){
+      if (! fn->isResolved() || fn->retTag == RET_PARAM) {
         clearDefaultInitFns(fn);
         fn->defPoint->remove();
       }
@@ -9217,7 +9216,6 @@ isUnusedClass(AggregateType *ct) {
 
   // Uses of iterator records get inserted in lowerIterators
   if (ct->symbol->hasFlag(FLAG_ITERATOR_RECORD))
-    //|| ct->symbol->hasFlag(FLAG_ITERATOR_CLASS))
     return false;
 
   // FALSE if iterator class's getIterator is used

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -646,7 +646,7 @@ const char* toString(CallInfo* info) {
       str = astr(str, info->actualNames.v[i], "=");
     VarSymbol* var = toVarSymbol(info->actuals.v[i]);
     if (info->actuals.v[i]->type->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
-        info->actuals.v[i]->type->defaultInitializer->hasFlag(FLAG_PROMOTION_WRAPPER))
+        toAggregateType(info->actuals.v[i]->type)->iteratorInfo->iterator->hasFlag(FLAG_PROMOTION_WRAPPER))
       str = astr(str, "promoted expression");
     else if (info->actuals.v[i] && info->actuals.v[i]->hasFlag(FLAG_TYPE_VARIABLE))
       str = astr(str, "type ", toString(info->actuals.v[i]->type));

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9172,6 +9172,12 @@ static void clearDefaultInitFns(FnSymbol* unusedFn) {
   if (unusedFn->retType->defaultInitializer == unusedFn) {
     unusedFn->retType->defaultInitializer = NULL;
   }
+  // Ditto for iterator fn in iterator info.
+  if (unusedFn->retType->symbol->hasEitherFlag(FLAG_ITERATOR_RECORD,
+                                               FLAG_ITERATOR_CLASS)) {
+    AggregateType* it = toAggregateType(unusedFn->retType);
+    it->iteratorInfo = NULL;
+  }
 }
 
 static void removeUnusedFunctions() {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8008,18 +8008,22 @@ addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
             resolveFns(fn);
             if (fn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
                 pfn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
-              if (!isSubType(fn->retType->defaultInitializer->iteratorInfo->getValue->retType,
-                  pfn->retType->defaultInitializer->iteratorInfo->getValue->retType)) {
+              AggregateType* fnRetType = toAggregateType(fn->retType);
+              IteratorInfo* fnInfo = fnRetType->iteratorInfo;
+              AggregateType* pfnRetType = toAggregateType(pfn->retType);
+              IteratorInfo* pfnInfo = pfnRetType->iteratorInfo;
+              if (!isSubType(fnInfo->getValue->retType,
+                             pfnInfo->getValue->retType)) {
                 USR_FATAL_CONT(pfn, "conflicting return type specified for '%s: %s'", toString(pfn),
-                               pfn->retType->defaultInitializer->iteratorInfo->getValue->retType->symbol->name);
+                               pfnInfo->getValue->retType->symbol->name);
                 USR_FATAL_CONT(fn, "  overridden by '%s: %s'", toString(fn),
-                               fn->retType->defaultInitializer->iteratorInfo->getValue->retType->symbol->name);
+                               fnInfo->getValue->retType->symbol->name);
                 USR_STOP();
               } else {
                 pfn->retType->dispatchChildren.add_exclusive(fn->retType);
                 fn->retType->dispatchParents.add_exclusive(pfn->retType);
-                Type* pic = pfn->retType->defaultInitializer->iteratorInfo->iclass;
-                Type* ic = fn->retType->defaultInitializer->iteratorInfo->iclass;
+                Type* pic = pfnInfo->iclass;
+                Type* ic = fnInfo->iclass;
                 INT_ASSERT(ic->symbol->hasFlag(FLAG_ITERATOR_CLASS));
 
                 // Iterator classes are created as normal top-level classes (inheriting

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -824,7 +824,8 @@ protoIteratorClass(FnSymbol* fn) {
   // of the iterator record type.  Since we are only creating shell functions
   // here, we still need a way to obtain the original iterator function, so we
   // can fill in the bodies of the above 9 methods in the lowerIterators pass.
-  ii->irecord->defaultInitializer = fn;
+  //ii->irecord->defaultInitializer = fn; // TODO remove
+  ii->irecord->iteratorInfo = ii;
   ii->irecord->scalarPromotionType = fn->retType;
   fn->retType = ii->irecord;
   fn->retTag = RET_VALUE;
@@ -847,7 +848,8 @@ protoIteratorClass(FnSymbol* fn) {
   // the iterator class type.  This makes it easy to obtain the iterator given
   // just a symbol of the iterator class type.  This may include _getIterator
   // and _getIteratorZip functions in the module code.
-  ii->iclass->defaultInitializer = ii->getIterator;
+  //ii->iclass->defaultInitializer = ii->getIterator; // TODO remove
+  ii->iclass->iteratorInfo = ii;
   normalize(ii->getIterator);
   resolveFns(ii->getIterator);  // No shortcuts.
 }
@@ -9193,8 +9195,9 @@ isUnusedClass(AggregateType *ct) {
   if (ct->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE))
     return false;
 
-  // Uses of iterator records get inserted in lowerIterators
-  if (ct->symbol->hasFlag(FLAG_ITERATOR_RECORD))
+  // Uses of iterator records/classes get inserted in lowerIterators
+  if (ct->symbol->hasFlag(FLAG_ITERATOR_RECORD) ||
+      ct->symbol->hasFlag(FLAG_ITERATOR_CLASS))
     return false;
 
   // FALSE if initializers are used

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -32,7 +32,7 @@
 #include "stringutil.h"
 #include "symbol.h"
 
-
+#include "view.h"
 //
 // getTheIteratorFn(): get the original (user-written) iterator function
 // that corresponds to an _iteratorClass type or symbol
@@ -88,6 +88,16 @@ FnSymbol* getTheIteratorFn(Type* icType)
     AggregateType* firstIcTypeAgg = toAggregateType(firstIcType);
     FnSymbol* result = firstIcTypeAgg->iteratorInfo->getIterator;
 //INT_ASSERT(result == oldGetTheIteratorFn(icType));
+
+
+  if( 0 == strcmp(icType->symbol->name, "_ic_foo") ) {
+    printf("getTheIteratorFn for type\n");
+    nprint_view(icType);
+    printf("returning\n");
+    if ( result )
+      nprint_view(result);
+  }
+
     return result;
   } else {
     INT_ASSERT(icType->symbol->hasFlag(FLAG_ITERATOR_CLASS));
@@ -105,6 +115,15 @@ FnSymbol* getTheIteratorFn(Type* icType)
     FnSymbol* result = irTypeAgg->iteratorInfo->iterator;
     INT_ASSERT(result->hasFlag(FLAG_ITERATOR_FN));
 //INT_ASSERT(result == oldGetTheIteratorFn(icType));
+
+  if( 0 == strcmp(icType->symbol->name, "_ic_foo") ) {
+    printf("getTheIteratorFn for type\n");
+    nprint_view(icType);
+    printf("returning\n");
+    if ( result )
+      nprint_view(result);
+  }
+
     return result;
   }
 }

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -47,28 +47,6 @@ FnSymbol* getTheIteratorFn(Symbol* ic) {
 FnSymbol* getTheIteratorFn(CallExpr* call) {
   return getTheIteratorFn(call->get(1)->typeInfo());
 }
-/*
-FnSymbol* oldGetTheIteratorFn(Type* icType)
-{
-  // the asserts document the current state
-  bool gotTuple = icType->symbol->hasFlag(FLAG_TUPLE);
-  INT_ASSERT(gotTuple || icType->symbol->hasFlag(FLAG_ITERATOR_CLASS));
-
-  // The _getIterator function is in _iteratorClass's defaultInitializer.
-  FnSymbol* getIterFn = icType->defaultInitializer;
-
-  // The type of _getIterator's first formal arg is _iteratorRecord.
-  Type* irType = getIterFn->getFormal(1)->type;
-  INT_ASSERT(irType->symbol->hasFlag(FLAG_ITERATOR_RECORD) ||
-             (gotTuple && irType->symbol->hasFlag(FLAG_ITERATOR_CLASS)));
-
-  // The original iterator function is in _iteratorRecord's defaultInitializer.
-  FnSymbol* result = irType->defaultInitializer;
-  INT_ASSERT(gotTuple || result->hasFlag(FLAG_ITERATOR_FN));
-
-  return result;
-}
-*/
 
 // icType is either an _iteratorClass type or a tuple thereof
 // When icType is a tuple, this function returns
@@ -87,16 +65,6 @@ FnSymbol* getTheIteratorFn(Type* icType)
     INT_ASSERT(firstIcType->symbol->hasFlag(FLAG_ITERATOR_CLASS));
     AggregateType* firstIcTypeAgg = toAggregateType(firstIcType);
     FnSymbol* result = firstIcTypeAgg->iteratorInfo->getIterator;
-//INT_ASSERT(result == oldGetTheIteratorFn(icType));
-
-
-  if( 0 == strcmp(icType->symbol->name, "_ic_foo") ) {
-    printf("getTheIteratorFn for type\n");
-    nprint_view(icType);
-    printf("returning\n");
-    if ( result )
-      nprint_view(result);
-  }
 
     return result;
   } else {
@@ -114,15 +82,6 @@ FnSymbol* getTheIteratorFn(Type* icType)
     // Return the original iterator function
     FnSymbol* result = irTypeAgg->iteratorInfo->iterator;
     INT_ASSERT(result->hasFlag(FLAG_ITERATOR_FN));
-//INT_ASSERT(result == oldGetTheIteratorFn(icType));
-
-  if( 0 == strcmp(icType->symbol->name, "_ic_foo") ) {
-    printf("getTheIteratorFn for type\n");
-    nprint_view(icType);
-    printf("returning\n");
-    if ( result )
-      nprint_view(result);
-  }
 
     return result;
   }

--- a/test/functions/deitz/iterators/leader_follower/test_recursive_leader.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_recursive_leader.chpl
@@ -3,7 +3,9 @@ iter foo(n: int) {
     yield i;
 }
 
+extern proc printf(fmt:c_string);
 iter foo(param tag: iterKind, n: int):range where tag == iterKind.leader {
+  printf(c"In leader\n");
   if n == 1 then
     yield 1..1;
   else {
@@ -14,6 +16,7 @@ iter foo(param tag: iterKind, n: int):range where tag == iterKind.leader {
 }
 
 iter foo(param tag: iterKind, followThis, n: int) where tag == iterKind.follower {
+  printf(c"In follower\n");
   for i in followThis do
     yield i;
 }

--- a/test/functions/deitz/iterators/leader_follower/test_recursive_leader.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_recursive_leader.chpl
@@ -3,9 +3,7 @@ iter foo(n: int) {
     yield i;
 }
 
-extern proc printf(fmt:c_string);
 iter foo(param tag: iterKind, n: int):range where tag == iterKind.leader {
-  printf(c"In leader\n");
   if n == 1 then
     yield 1..1;
   else {
@@ -16,7 +14,6 @@ iter foo(param tag: iterKind, n: int):range where tag == iterKind.leader {
 }
 
 iter foo(param tag: iterKind, followThis, n: int) where tag == iterKind.follower {
-  printf(c"In follower\n");
   for i in followThis do
     yield i;
 }


### PR DESCRIPTION
The Type->defaultInitializer field was used in very different
ways depending on the type:
 * for an iterator record, the getIterator function
 * for an iterator class, the original user iterator function
 * for everything else, the compiler-generated default initializer

This overloading of the defaultInitializer field is confusing.

This PR adds an IteratorInfo field to AggregateType from which the
relevant functions can be found. The defaultInitiailzer field can now be
the compiler-generated initializer even for iterator records and iterator
classes.

This change supports my work on reworking tuple support functions, which
in turn supports my work on arrays. Nonetheless it might not turn out to
be necessary for those efforts.

No program behavior changes are expected from this patch. It can be
viewed as renaming:

      iteratorRecord->defaultInitializer to iteratorRecord->iteratorInfo->iterator

and

      iteratorClass->defaultInitializer to iteratorClass->iteratorInfo->getIterator

It also adjusts uses of type->defaultInitializer that could have applied
to handle these cases.

The trickiest part about this change was correctly handling
removeUnusedFunctions.  This change removes an unused function from
IteratorInfo and adjusts the FnSymbol destructor to set the related
iteratorInfo in AggregateType to NULL before deleting the IteratorInfo.

Passed quickstart testing.
Passed full local testing.

Reviewed by @daviditen - thanks!