### PR TITLE
Highlight the deadlock that can occur between qthreads and MPI

### DIFF
--- a/test/users/npadmana/mpi-ring-test-deadlock/README
+++ b/test/users/npadmana/mpi-ring-test-deadlock/README
@@ -1,0 +1,52 @@
+This code tests the MPI module to make sure we
+don't deadlock (or expose the cases where we do 
+deadlock) when making MPI calls in multiple threads.
+
+To best expose possible deadlocks, I'm running this
+on a single core, but with multiple locales...
+
+Common settings :
+  export CHPL_TARGET_COMPILER=mpi-gnu
+  export AMMPI_MPI_THREAD=multiple
+
+  All of this run on MPICH
+
+1. single locale + fifo :
+  CHPL_COMM=none
+  CHPL_TASKS=fifo
+
+  chpl ring.chpl 
+  mpirun -np 3 ./a.out
+
+  No deadlock
+
+2. single locale + qthreads
+  CHPL_COMM=none
+  CHPL_TASKS=qthreads
+
+  chpl ring.chpl
+  mpirun -np 3 ./a.out
+
+  DEADLOCK!
+
+3. multi-locale + qthreads
+  CHPL_COMM=gasnet
+  CHPL_COMM_SUBSTRATE=mpi
+  CHPL_TASKS=qthreads
+
+  chpl ring.chpl
+  ./a.out -nl 3 
+
+  DEADLOCK!
+
+4. multi-locale + fifo
+  CHPL_COMM=gasnet
+  CHPL_COMM_SUBSTRATE=mpi
+  CHPL_TASKS=fifo
+
+  chpl ring.chpl
+  ./a.out -nl 3 
+
+  No deadlock
+
+

--- a/test/users/npadmana/mpi-ring-test-deadlock/ring.chpl
+++ b/test/users/npadmana/mpi-ring-test-deadlock/ring.chpl
@@ -1,0 +1,46 @@
+use MPI;
+use C_MPI;
+use Time;
+
+config const sendSleep=2;
+config const recvSleep=0;
+
+proc main() {
+  writeln("This is the main program");
+  cobegin {
+    send();
+    recv();
+  }
+  writeln("The main program ends here...");
+}
+
+proc send() {
+  // Does the right thing, even when running single-locale
+  coforall loc in Locales do on loc {
+    var rank = commRank(CHPL_COMM_WORLD) : c_int,
+        size = commSize(CHPL_COMM_WORLD) : c_int;
+    var dest : c_int;
+    dest = (rank + 1)%size;
+
+    writef("Rank %i sending to %i \n",rank, dest);
+    sleep(sendSleep);
+    MPI_Send(rank, 1, MPI_INT, dest, 0, CHPL_COMM_WORLD);
+    writef("Rank %i done sending...\n",rank);
+  }
+}
+
+proc recv() {
+  // Does the right thing, even when running single-locale
+  coforall loc in Locales do on loc {
+    var rank = commRank(CHPL_COMM_WORLD) : c_int,
+        size = commSize(CHPL_COMM_WORLD) : c_int;
+    var src, val : c_int;
+    src = mod(rank-1,size);
+
+    writef("Rank %i receiving from %i \n",rank, src);
+    sleep(recvSleep);
+    var status : MPI_Status;
+    MPI_Recv(val, 1, MPI_INT, src, 0, CHPL_COMM_WORLD, status);
+    writef("Rank %i received %i from the left.\n", rank, val);
+  }
+}


### PR DESCRIPTION
Motivated by an email exchange with @bradcray, here is a simple standalone case that exposes the deadlock when running MPI and Qthreads. 

Note that this occurs even if Chapel is running single locale, but with the qthreads tasking layer. 

The README file lists the different cases I've considered...