### PR TITLE
start_test can run examples/hello*.chpl with slurm-gasnetrun_ibv launcher

### DIFF
--- a/util/test/prediff-for-slurm-gasnet-launcher
+++ b/util/test/prediff-for-slurm-gasnet-launcher
@@ -1,0 +1,3 @@
+#!/bin/sh
+sed -e 's/\r$//' -e '/^salloc:/d' < $2 > $2.prediff.tmp
+mv $2.prediff.tmp $2


### PR DESCRIPTION
launch-slurm-gasnetrun_ibv.c handles --walltime on commandline

global PREDIFF handles examples test outputs with slurm-gasnet
    
    All test/release/examples/... tests pass start_test on chapcs with slurm-gasnet_ibv,
    except: primers/fileIO, primers/classes, shootout/mandelbrot
