### PR TITLE
Add perf annotation for disabling jemalloc's stats gathering (#4180)

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -140,6 +140,8 @@ all:
   06/24/16:
     - text: Improve optimizeOnClauses optimization (#4008)
       config: 16 node XC
+  07/19/16:
+    - Disable jemalloc's stat gatherting by default (#4180)
 
 AllCompTime:
   11/09/14:


### PR DESCRIPTION
This improved perf for array-vec-ops, binary-trees, nbody, k-nucleotide:

http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/05/13&enddate=2016/07/19&graphs=arrayvectoroperations,binarytreesshootoutbenchmarkn20,nbodyvariations,knucleotideshootoutbenchmark