### PR TITLE
Remove machine specifics from printchplenv with a new flag

### DIFF
--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -127,7 +127,7 @@ sub endMailChplenv {
     if (exists($ENV{"CHPL_HOME"})) {
         $ch = $ENV{"CHPL_HOME"};
     }
-    my $chplenv = `$ch/util/printchplenv --debug`;
+    my $chplenv = `$ch/util/printchplenv --debug --anonymize`;
 
     my $mystr =
         "===============================================================\n" .

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 from chplenv import *
 
-def print_mode(mode='list'):
+def print_mode(mode='list', anonymize=False):
     print_var.first_time = True
     # `m` is a 'simplified' version of `mode` that merges some cases that can
     # be treated the same by print_mode, but need to be dealt with separately
@@ -24,7 +24,7 @@ def print_mode(mode='list'):
     chpl_home = os.environ.get('CHPL_HOME', '')
     chpl_module_home = os.environ.get('CHPL_MODULE_HOME', '')
 
-    if m == 'list' or mode == 'debug':
+    if (m == 'list' or mode == 'debug') and not anonymize:
         stdout.write("machine info: {0} {1} {2} {3} {4}\n".format(*os.uname()))
         stdout.write("CHPL_HOME: {0} *\n".format(chpl_home))
         this_dir = os.path.realpath(os.path.dirname(__file__))
@@ -218,7 +218,7 @@ def print_var(env_var, value, mode, short_name='', filters=None):
 
 def _main():
     parser = optparse.OptionParser(
-        usage='usage: %prog [--list|--make|--simple|--compiler|--runtime|--launcher|--sh|--csh|--debug]')
+        usage='usage: %prog [--list|--make|--simple|--anonymize|--compiler|--runtime|--launcher|--sh|--csh|--debug]')
 
     parser.add_option('--list', action='store_const', dest='mode', default='list',
                       const='list',
@@ -230,6 +230,9 @@ def _main():
     parser.add_option('--simple', action='store_const', dest='mode', const='simple',
                       help="print out a listing of the environment that is "
                            "meant to be used in the compiler")
+    parser.add_option('--anonymize', action='store_true', dest='anonymize', default=False,
+                      help="avoid printing machine specific details such as "
+                           "host name and file paths")
     parser.add_option('--compiler', action='store_const', dest='mode', const='compiler',
                       help="print out path component for compiler objects")
     parser.add_option('--runtime', action='store_const', dest='mode', const='runtime',
@@ -246,7 +249,7 @@ def _main():
 
     (options, args) = parser.parse_args()
 
-    print_mode(options.mode)
+    print_mode(options.mode, options.anonymize)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add the option --anonymize to printchplenv.  When it is used, don't print the
lines beginning with "machine info", "CHPL_HOME", or "script location".

Add the --anonymize option to the printchplenv call that is used when
generating nightly testing emails.