### PR TITLE
(fast) meteor cleanup 3

### DIFF
--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -11,6 +11,7 @@ use BitOps;
 param boardCells = 50,          // Number of cells on board
       boardWidth = 5,           // Number of cells along x-axis
       boardHeight = 10,         // Number of cells along y-axis
+      //TODO
       permutations = 8192,      // Number of permutations stored as masks
       piecePermutations = 12,   // Number of permutations for a single piece
       numPieces = 10,           // Number of puzzle pieces
@@ -41,10 +42,6 @@ param maskEven   = 0xf07c1f07c1f07c1f: int, // Even rows of board (0, 2, 4, ..)
 // Find and print the minimum and maximum solutions to meteor puzzle
 //
 proc main(args: [] string) {
-
-  // Support dummy arguments for shootout execution scripts
-  if args.size > 2 then
-    return;
 
   initialize();
 
@@ -357,6 +354,7 @@ proc searchLinearHelper(in board, in pos, in used, in placed,
 
 // DIY sync variable functionality that outperforms native sync variables.
 // Access controlled by functions lock() and unlock()
+// TODO
 var l: atomic bool;
 
 

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -351,11 +351,7 @@ proc searchLinearHelper(in board, in pos, in used, in placed,
 }
 
 
-//
-// Atomic lock that prevents multiple tasks recording their
-// solution at once (also known as a race condition)
-// 'false' is the unlocked state, and 'true' is the locked state
-//
+// Atomic used as mutex for recordSolution()
 var l: atomic bool;
 
 
@@ -366,16 +362,14 @@ proc searchLinear(in board, in pos, in used, in placed, currentSolution) {
   var count, evenRows, oddRows, leftBorder, rightBorder,
       s1, s2, s3, s4, s5, s6, s7, s8: int;
 
-
-
   if placed == numPieces {
 
-    // Wait (yield) until unlocked state, then lock it by setting it to true
+    // lock
     while l.testAndSet() do chpl_task_yield();
 
     recordSolution(currentSolution);
 
-    // Set to unlocked state after solution has been recorded
+    // unlock
     l.clear();
 
   } else {

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -353,14 +353,14 @@ proc searchLinearHelper(in board, in pos, in used, in placed,
 
 //
 // Atomic lock that prevents multiple tasks recording their
-// solution at once (also known as a race condition).
+// solution at once (also known as a race condition)
 // 'false' is the unlocked state, and 'true' is the locked state
 //
 var l: atomic bool;
 
 
 //
-// Recursively add pieces to the board, and check solution when filled.
+// Recursively add pieces to the board, and check solution when filled
 //
 proc searchLinear(in board, in pos, in used, in placed, currentSolution) {
   var count, evenRows, oddRows, leftBorder, rightBorder,
@@ -370,12 +370,13 @@ proc searchLinear(in board, in pos, in used, in placed, currentSolution) {
 
   if placed == numPieces {
 
-    // Wait for unlocked state, then lock it, while this task records solution
-    l.waitFor(false);
+    // Wait (yield) until unlocked state, then lock it by setting it to true
+    while l.testAndSet() != false
+      do chpl_task_yield();
 
     recordSolution(currentSolution);
 
-    // Set to unlocked state
+    // Set to unlocked state after solution has been recorded
     l.write(false);
 
   } else {


### PR DESCRIPTION
PR in response to some changes suggested by @bradcray.

* Dropped args checks, as it had no purpose
* Updated the  `totalMasks` variable name and comment
* Stopped passing global variables through functions as if they were local...
* Dropped DIY sync var `lock` and `unlock` functions, since they were each called once, and were 1-liners. Sufficiently described them in comments.


* [x] Correctness test
* [x] Performance test - 
    * 50 perf runs on cs:
        * This PR: `0.112339 sec`
        * real sync variable: `0.124873 sec`
    * 10 perf runs on shootout box:
        * This PR: `0.087879 sec`
        * drop chpl_task_yield(): `0.070332 sec`
    * for reference, actual shootout machine timings are closer to 0.08 seconds (see nightly perf graphs), and  the [top 8 performing submissions](http://benchmarksgame.alioth.debian.org/u64q/performance.php?test=meteor) run in 0.04 - 0.09 seconds. This change could make a difference of 3rd and 9th place in performance rankings...

The discrepancy between the different 'lock' implementations is believed to be due to the highly uncontested nature of the lock in this benchmark. `sync` variable will generally wait more cycle in between `chpl_task_yield()`s, making it unfavorable for the uncontested lock scenario. Taking this a step further, removing the `chpl_task_yield()` altogether minimizes the wait time between lock checks, which proves to be favorable for this benchmark. In a near future PR, we will drop the `chpl_task_yield()` for even further improved performance, but only after getting nightly performance tests for the changes in this PR.