### PR TITLE
Cleanup the code used to add perf graph buttons

### DIFF
--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -163,37 +163,20 @@ function getNextDivs(afterDiv, afterLDiv) {
   lspacer.className = 'lspacer';
   legend.insertBefore(lspacer, beforeLDiv);
 
-  // create a log button and put it in the gspacer
-  var logToggle = document.createElement('input');
-  logToggle.type = 'button';
-  logToggle.className = 'toggle';
-  logToggle.value = 'log';
-  logToggle.style.visibility = 'hidden';
-  gspacer.appendChild(logToggle);
+  function addButtonHelper(buttonText) {
+    var button = document.createElement('input');
+    button.type = 'button';
+    button.className = 'toggle';
+    button.value = buttonText;
+    button.style.visibility = 'hidden';
+    gspacer.appendChild(button);
+    return button;
+  }
 
-  // create an annotation button and put it next to the log button in gspacer
-  var annToggle = document.createElement('input');
-  annToggle.type = 'button';
-  annToggle.className = 'toggle';
-  annToggle.value = 'annotations';
-  annToggle.style.visibility = 'hidden';
-  gspacer.appendChild(annToggle);
-
-  // create a screenshot button and put it next to the annotation button
-  var screenshotToggle = document.createElement('input');
-  screenshotToggle.type = 'button';
-  screenshotToggle.className = 'toggle';
-  screenshotToggle.value = 'screenshot';
-  screenshotToggle.style.visibility = 'hidden';
-  gspacer.appendChild(screenshotToggle);
-
-  // create a close graph button and put it next to the screnshot button
-  var closeGraphToggle = document.createElement('input');
-  closeGraphToggle.type = 'button';
-  closeGraphToggle.className = 'toggle';
-  closeGraphToggle.value = 'close';
-  closeGraphToggle.style.visibility = 'hidden';
-  gspacer.appendChild(closeGraphToggle);
+  var logToggle = addButtonHelper('log');
+  var annToggle = addButtonHelper('annotations');
+  var screenshotToggle = addButtonHelper('screenshot');
+  var closeGraphToggle = addButtonHelper('close');
 
   return {
     div: div,
@@ -209,13 +192,6 @@ function getNextDivs(afterDiv, afterLDiv) {
 // Gen a new dygraph, if an existing graph is being expanded then expandInfo
 // will contain the expansion information, else it is null
 function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
-
-  var div = graphDivs.div;
-  var ldiv = graphDivs.ldiv;
-  var logToggle = graphDivs.logToggle;
-  var annToggle = graphDivs.annToggle;
-  var screenshotToggle = graphDivs.screenshotToggle;
-  var closeGraphToggle = graphDivs.closeGraphToggle;
 
   var startdate = getDateFromURL(OptionsEnum.STARTDATE, graphInfo.startdate);
   var enddate = getDateFromURL(OptionsEnum.ENDDATE, graphInfo.enddate);
@@ -253,7 +229,7 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
     // So it's easier to zoom in on the right side
     rightGap: 15,
     labels: graphLabels,
-    labelsDiv: ldiv,
+    labelsDiv: graphDivs.ldiv,
     labelsSeparateLines: true,
     dateWindow: [startdate, enddate],
     // sync graphs anytime we pan, zoom, or at initial draw
@@ -283,7 +259,7 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
   }
 
   // actually create the dygraph
-  var g = new Dygraph(div, graphData, graphOptions);
+  var g = new Dygraph(graphDivs.div, graphData, graphOptions);
   g.isReady = false;
   setupSeriesLocking(g);
 
@@ -297,10 +273,10 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
     g.divs = graphDivs;
     g.graphInfo = graphInfo;
 
-    setupLogToggle(g, graphInfo, logToggle);
-    setupAnnToggle(g, graphInfo, annToggle);
-    setupScreenshotToggle(g, graphInfo, screenshotToggle);
-    setupCloseGraphToggle(g, graphInfo, closeGraphToggle);
+    setupLogToggle(g, graphInfo, graphDivs.logToggle);
+    setupAnnToggle(g, graphInfo, graphDivs.annToggle);
+    setupScreenshotToggle(g, graphInfo, graphDivs.screenshotToggle);
+    setupCloseGraphToggle(g, graphInfo, graphDivs.closeGraphToggle);
 
     g.isReady = true;
 


### PR DESCRIPTION
Add a helper function to remove some duplicate code that was used to create the
"log", "annotations", "screenshot", and "close" buttons. This also removes
"temp" variables that were used to store the divs, since they variables were
only used once.