### PR TITLE
Fix cleanup iterator defaultinitializer uses

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1495,8 +1495,14 @@ FnSymbol::FnSymbol(const char* initName) :
 
 
 FnSymbol::~FnSymbol() {
-  if (iteratorInfo)
+  if (iteratorInfo) {
+    // Also set iterator class and iterator record iteratorInfo = NULL.
+    if (iteratorInfo->iclass)
+      iteratorInfo->iclass->iteratorInfo = NULL;
+    if (iteratorInfo->irecord)
+      iteratorInfo->irecord->iteratorInfo = NULL;
     delete iteratorInfo;
+  }
   BasicBlock::clear(this);
   delete basicBlocks; basicBlocks = 0;
   if (calledBy)

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -35,6 +35,7 @@
 #include "WhileStmt.h"
 #include "AstDump.h"
 #include "AstDumpToNode.h"
+#include "iterator.h"
 
 #include <inttypes.h>
 
@@ -779,11 +780,11 @@ void whocalls(int id) {
       // check each step, just in case
       if (SymExpr* act2 = toSymExpr(call->get(2)))
         if (Symbol* ic = act2->var)
-          if (Type* ty = ic->type)
-            if (FnSymbol* init = ty->defaultInitializer)
+          if (AggregateType* ty = toAggregateType(ic->type))
+            if (FnSymbol* init = ty->iteratorInfo->getIterator)
               if (ArgSymbol* form1 = init->getFormal(1))
-                if (Type* fty = form1->type)
-                  if (FnSymbol* iterator = fty->defaultInitializer)
+                if (AggregateType* fty = toAggregateType(form1->type))
+                  if (FnSymbol* iterator = fty->iteratorInfo->iterator)
                     if (iterator->id == id)
                       printf("  for-loop blockInfo %d  %s  %s\n",
                              call->id, parentMsg(call, &forMatch,

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -51,6 +51,7 @@ class FnSymbol;
 class Symbol;
 class TypeSymbol;
 class VarSymbol;
+class IteratorInfo;
 
 class Type : public BaseAST {
 public:
@@ -157,6 +158,9 @@ class AggregateType : public Type {
   AList fields;
   AList inherits; // used from parsing, sets dispatchParents
   Symbol* outer;  // pointer to an outer class if this is an inner class
+
+  IteratorInfo* iteratorInfo; // Attached only to iterator class/records
+
   const char *doc;
 
   AggregateType(AggregateTag initTag);

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -27,6 +27,8 @@
 #include "stmt.h"
 #include "stlUtil.h"
 
+#include "iterator.h"
+
 #include <set>
 
 // We use RefVector to store a list of symbols that are aliases for the return
@@ -56,10 +58,11 @@ checkResolved() {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     checkReturnPaths(fn);
     if (fn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
-        !fn->isIterator() &&
-        fn->retType->defaultInitializer &&
-        fn->retType->defaultInitializer->defPoint->parentSymbol == fn)
-      USR_FATAL_CONT(fn, "functions cannot return nested iterators or loop expressions");
+        !fn->isIterator()) {
+      IteratorInfo* ii = toAggregateType(fn->retType)->iteratorInfo;
+      if (ii && ii->iterator && ii->iterator->defPoint->parentSymbol == fn)
+        USR_FATAL_CONT(fn, "functions cannot return nested iterators or loop expressions");
+    }
     if (fn->hasFlag(FLAG_ASSIGNOP) && fn->retType != dtVoid)
       USR_FATAL(fn, "The return value of an assignment operator must be 'void'.");
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -646,7 +646,7 @@ const char* toString(CallInfo* info) {
       str = astr(str, info->actualNames.v[i], "=");
     VarSymbol* var = toVarSymbol(info->actuals.v[i]);
     if (info->actuals.v[i]->type->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
-        info->actuals.v[i]->type->defaultInitializer->hasFlag(FLAG_PROMOTION_WRAPPER))
+        toAggregateType(info->actuals.v[i]->type)->iteratorInfo->iterator->hasFlag(FLAG_PROMOTION_WRAPPER))
       str = astr(str, "promoted expression");
     else if (info->actuals.v[i] && info->actuals.v[i]->hasFlag(FLAG_TYPE_VARIABLE))
       str = astr(str, "type ", toString(info->actuals.v[i]->type));
@@ -820,11 +820,9 @@ protoIteratorClass(FnSymbol* fn) {
   ii->init = protoIteratorMethod(ii, "init", dtVoid);
   ii->incr = protoIteratorMethod(ii, "incr", dtVoid);
 
-  // The original iterator function is stashed in the defaultInitializer field
-  // of the iterator record type.  Since we are only creating shell functions
-  // here, we still need a way to obtain the original iterator function, so we
-  // can fill in the bodies of the above 9 methods in the lowerIterators pass.
-  ii->irecord->defaultInitializer = fn;
+  // Save the iterator info in the iterator record.
+  // The iterator info is still owned by the iterator function.
+  ii->irecord->iteratorInfo = ii;
   ii->irecord->scalarPromotionType = fn->retType;
   fn->retType = ii->irecord;
   fn->retTag = RET_VALUE;
@@ -843,11 +841,11 @@ protoIteratorClass(FnSymbol* fn) {
   ii->getIterator->insertAtTail(new CallExpr(PRIM_SETCID, ret));
   ii->getIterator->insertAtTail(new CallExpr(PRIM_RETURN, ret));
   fn->defPoint->insertBefore(new DefExpr(ii->getIterator));
-  // The _getIterator function is stashed in the defaultInitializer field of
-  // the iterator class type.  This makes it easy to obtain the iterator given
+  // Save the iterator info in the iterator class also.
+  // This makes it easy to obtain the iterator given
   // just a symbol of the iterator class type.  This may include _getIterator
   // and _getIteratorZip functions in the module code.
-  ii->iclass->defaultInitializer = ii->getIterator;
+  ii->iclass->iteratorInfo = ii;
   normalize(ii->getIterator);
   resolveFns(ii->getIterator);  // No shortcuts.
 }
@@ -7572,6 +7570,11 @@ static void instantiate_default_constructor(FnSymbol* fn) {
     while (instantiatedFrom->instantiatedFrom)
       instantiatedFrom = instantiatedFrom->instantiatedFrom;
     CallExpr* call = new CallExpr(instantiatedFrom->retType->defaultInitializer);
+
+    // This should not be happening for iterators.
+    TypeSymbol* ts = instantiatedFrom->retType->symbol;
+    INT_ASSERT(!ts->hasEitherFlag(FLAG_ITERATOR_RECORD, FLAG_ITERATOR_CLASS));
+
     for_formals(formal, fn) {
       if (formal->type == dtMethodToken || formal == fn->_this) {
         call->insertAtTail(formal);
@@ -8006,18 +8009,22 @@ addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
             resolveFns(fn);
             if (fn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
                 pfn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
-              if (!isSubType(fn->retType->defaultInitializer->iteratorInfo->getValue->retType,
-                  pfn->retType->defaultInitializer->iteratorInfo->getValue->retType)) {
+              AggregateType* fnRetType = toAggregateType(fn->retType);
+              IteratorInfo* fnInfo = fnRetType->iteratorInfo;
+              AggregateType* pfnRetType = toAggregateType(pfn->retType);
+              IteratorInfo* pfnInfo = pfnRetType->iteratorInfo;
+              if (!isSubType(fnInfo->getValue->retType,
+                             pfnInfo->getValue->retType)) {
                 USR_FATAL_CONT(pfn, "conflicting return type specified for '%s: %s'", toString(pfn),
-                               pfn->retType->defaultInitializer->iteratorInfo->getValue->retType->symbol->name);
+                               pfnInfo->getValue->retType->symbol->name);
                 USR_FATAL_CONT(fn, "  overridden by '%s: %s'", toString(fn),
-                               fn->retType->defaultInitializer->iteratorInfo->getValue->retType->symbol->name);
+                               fnInfo->getValue->retType->symbol->name);
                 USR_STOP();
               } else {
                 pfn->retType->dispatchChildren.add_exclusive(fn->retType);
                 fn->retType->dispatchParents.add_exclusive(pfn->retType);
-                Type* pic = pfn->retType->defaultInitializer->iteratorInfo->iclass;
-                Type* ic = fn->retType->defaultInitializer->iteratorInfo->iclass;
+                Type* pic = pfnInfo->iclass;
+                Type* ic = fnInfo->iclass;
                 INT_ASSERT(ic->symbol->hasFlag(FLAG_ITERATOR_CLASS));
 
                 // Iterator classes are created as normal top-level classes (inheriting
@@ -9166,6 +9173,20 @@ static void clearDefaultInitFns(FnSymbol* unusedFn) {
   if (unusedFn->retType->defaultInitializer == unusedFn) {
     unusedFn->retType->defaultInitializer = NULL;
   }
+  // Also remove unused fns from iterator infos.
+  // Ditto for iterator fn in iterator info.
+  AggregateType* at = toAggregateType(unusedFn->retType);
+  if (at && at->iteratorInfo) {
+    IteratorInfo* ii = at->iteratorInfo;
+    INT_ASSERT(at->symbol->hasEitherFlag(FLAG_ITERATOR_RECORD,
+                                         FLAG_ITERATOR_CLASS));
+    if (ii) {
+      if (ii->iterator == unusedFn)
+        ii->iterator = NULL;
+      if (ii->getIterator == unusedFn)
+        ii->getIterator = NULL;
+    }
+  }
 }
 
 static void removeUnusedFunctions() {
@@ -9195,6 +9216,12 @@ isUnusedClass(AggregateType *ct) {
 
   // Uses of iterator records get inserted in lowerIterators
   if (ct->symbol->hasFlag(FLAG_ITERATOR_RECORD))
+    return false;
+
+  // FALSE if iterator class's getIterator is used
+  // (this case may not be necessary)
+  if (ct->symbol->hasFlag(FLAG_ITERATOR_CLASS) &&
+      ct->iteratorInfo->getIterator->isResolved())
     return false;
 
   // FALSE if initializers are used

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -32,13 +32,11 @@
 #include "stringutil.h"
 #include "symbol.h"
 
-
+#include "view.h"
 //
 // getTheIteratorFn(): get the original (user-written) iterator function
 // that corresponds to an _iteratorClass type or symbol
-// or a CallExpr therewith. Its uses were simply:
-//
-//   ... ->defaultInitializer->getFormal(1)->type->defaultInitializer
+// or a CallExpr therewith.
 //
 
 // 'ic' must be an instance of _iteratorClass
@@ -50,26 +48,43 @@ FnSymbol* getTheIteratorFn(CallExpr* call) {
   return getTheIteratorFn(call->get(1)->typeInfo());
 }
 
-// either an _iteratorClass type or a tuple thereof
+// icType is either an _iteratorClass type or a tuple thereof
+// When icType is a tuple, this function returns
+//  the getIterator function for the first tuple element.
+// When icType is an _iteratorClass, this function returns
+//  the original iterator function.
 FnSymbol* getTheIteratorFn(Type* icType)
 {
   // the asserts document the current state
-  bool gotTuple = icType->symbol->hasFlag(FLAG_TUPLE);
-  INT_ASSERT(gotTuple || icType->symbol->hasFlag(FLAG_ITERATOR_CLASS));
 
-  // The _getIterator function is in _iteratorClass's defaultInitializer.
-  FnSymbol* getIterFn = icType->defaultInitializer;
+  if (icType->symbol->hasFlag(FLAG_TUPLE)) {
+    FnSymbol* getIterFn = icType->defaultInitializer;
+    // A tuple of iterator classes -> first argument to
+    // tuple constructor is the iterator class type.
+    Type* firstIcType = getIterFn->getFormal(1)->type;
+    INT_ASSERT(firstIcType->symbol->hasFlag(FLAG_ITERATOR_CLASS));
+    AggregateType* firstIcTypeAgg = toAggregateType(firstIcType);
+    FnSymbol* result = firstIcTypeAgg->iteratorInfo->getIterator;
 
-  // The type of _getIterator's first formal arg is _iteratorRecord.
-  Type* irType = getIterFn->getFormal(1)->type;
-  INT_ASSERT(irType->symbol->hasFlag(FLAG_ITERATOR_RECORD) ||
-             (gotTuple && irType->symbol->hasFlag(FLAG_ITERATOR_CLASS)));
+    return result;
+  } else {
+    INT_ASSERT(icType->symbol->hasFlag(FLAG_ITERATOR_CLASS));
+    AggregateType* icTypeAgg = toAggregateType(icType);
+    INT_ASSERT(icTypeAgg->iteratorInfo);
+    FnSymbol* getIterFn = icTypeAgg->iteratorInfo->getIterator;
+    // The type of _getIterator's first formal arg is _iteratorRecord.
+    Type* irType = getIterFn->getFormal(1)->type;
+    INT_ASSERT(irType->symbol->hasFlag(FLAG_ITERATOR_RECORD));
 
-  // The original iterator function is in _iteratorRecord's defaultInitializer.
-  FnSymbol* result = irType->defaultInitializer;
-  INT_ASSERT(gotTuple || result->hasFlag(FLAG_ITERATOR_FN));
+    AggregateType* irTypeAgg = toAggregateType(irType);
+    INT_ASSERT(irTypeAgg->iteratorInfo);
 
-  return result;
+    // Return the original iterator function
+    FnSymbol* result = irTypeAgg->iteratorInfo->iterator;
+    INT_ASSERT(result->hasFlag(FLAG_ITERATOR_FN));
+
+    return result;
+  }
 }
 
 
@@ -2127,11 +2142,12 @@ static void handlePolymorphicIterators()
         getIterator->insertBeforeReturn(new DefExpr(label));
         Symbol* ret = getIterator->getReturnSymbol();
         forv_Vec(Type, type, irecord->dispatchChildren) {
+          AggregateType* subTypeAgg = toAggregateType(type);
           VarSymbol* tmp = newTemp(irecord->getField(1)->type);
           VarSymbol* cid = newTemp(dtBool);
           BlockStmt* thenStmt = new BlockStmt();
           VarSymbol* recordTmp = newTemp("recordTmp", type);
-          VarSymbol* classTmp = newTemp("classTmp", type->defaultInitializer->iteratorInfo->getIterator->retType);
+          VarSymbol* classTmp = newTemp("classTmp", subTypeAgg->iteratorInfo->getIterator->retType);
           thenStmt->insertAtTail(new DefExpr(recordTmp));
           thenStmt->insertAtTail(new DefExpr(classTmp));
 
@@ -2150,11 +2166,11 @@ static void handlePolymorphicIterators()
               thenStmt->insertAtTail(new CallExpr(PRIM_SET_MEMBER, recordTmp, field, ftmp2));
             }
           }
-          thenStmt->insertAtTail(new CallExpr(PRIM_MOVE, classTmp, new CallExpr(type->defaultInitializer->iteratorInfo->getIterator, recordTmp)));
+          thenStmt->insertAtTail(new CallExpr(PRIM_MOVE, classTmp, new CallExpr(subTypeAgg->iteratorInfo->getIterator, recordTmp)));
           thenStmt->insertAtTail(new CallExpr(PRIM_MOVE, ret, new CallExpr(PRIM_CAST, ret->type->symbol, classTmp)));
           thenStmt->insertAtTail(new GotoStmt(GOTO_GETITER_END, label));
           ret->defPoint->insertAfter(new CondStmt(new SymExpr(cid), thenStmt));
-          ret->defPoint->insertAfter(new CallExpr(PRIM_MOVE, cid, new CallExpr(PRIM_TESTCID, tmp, type->defaultInitializer->iteratorInfo->irecord->getField(1)->type->symbol)));
+          ret->defPoint->insertAfter(new CallExpr(PRIM_MOVE, cid, new CallExpr(PRIM_TESTCID, tmp, subTypeAgg->iteratorInfo->irecord->getField(1)->type->symbol)));
           ret->defPoint->insertAfter(new DefExpr(cid));
           ret->defPoint->insertAfter(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_GET_MEMBER_VALUE, getIterator->getFormal(1), irecord->getField(1))));
           ret->defPoint->insertAfter(new DefExpr(tmp));

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3927,12 +3927,11 @@ inline proc channel.read(ref args ...?k,
   */
 proc stringify(args ...?k):string {
   proc isStringOrPrimitiveTypes(type t) param : bool {
-    var x: t;
     for param i in 1..k {
-      if !(x[i].type == string ||
-          x[i].type == c_string ||
-          x[i].type == c_string_copy) {
-        if !isPrimitiveType(x[i].type) then
+      if !(t[i] == string ||
+           t[i] == c_string ||
+           t[i] == c_string_copy) {
+        if !isPrimitiveType(t[i]) then
           return false;
       }
     }

--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -317,7 +317,7 @@ proc verifyResults(taskID, myBucketSize, myLocalKeyCounts) {
   for i in 0..#myBucketSize {
     const key = myBucket[i];
     if !myKeys.member(key) then
-      halt("got key value outside my range: "+key + " not in " + myKeys);
+      halt("got key value outside my range: "+key + " not in " + myKeys:string);
   }
 
   //

--- a/test/release/examples/primers/atomics.chpl
+++ b/test/release/examples/primers/atomics.chpl
@@ -107,7 +107,7 @@ coforall id in R do a.add(id*id);
 //
 var expected = n*(n+1)*(2*n+1)/6; 
 if a.read() != expected then
-  halt("Error: a=", a, " (should be ", expected, ")");
+  halt("Error: a=", a.read(), " (should be ", expected, ")");
 
 // In the following example, we create n tasks to atomically increment
 // the atomic variable a with the square of the task's given id.  The

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -317,7 +317,7 @@ proc verifyResults(bucketID, myBucketSize, myLocalKeyCounts) {
   forall i in 0..#myBucketSize {
     const key = allBucketKeys[bucketID][i];
     if !myKeys.member(key) then
-      halt("got key value outside my range: "+key + " not in " + myKeys);
+      halt("got key value outside my range: "+key + " not in " + myKeys:string);
   }
 
   //

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -309,7 +309,7 @@ proc verifyResults(bucketID, myBucketSize, myLocalKeyCounts) {
   forall i in 0..#myBucketSize {
     const key = allBucketKeys[bucketID][i];
     if !myKeys.member(key) then
-      halt("got key value outside my range: "+key + " not in " + myKeys);
+      halt("got key value outside my range: "+key + " not in " + myKeys:string);
   }
 
   //

--- a/test/studies/isx/isx-per-task.chpl
+++ b/test/studies/isx/isx-per-task.chpl
@@ -323,7 +323,7 @@ proc verifyResults(taskID, myBucketSize, myLocalKeyCounts) {
   for i in 0..#myBucketSize {
     const key = myBucket[i];
     if !myKeys.member(key) then
-      halt("got key value outside my range: "+key + " not in " + myKeys);
+      halt("got key value outside my range: "+key + " not in " + myKeys:string);
   }
 
   //


### PR DESCRIPTION
(Take 2; this was originally PR #4192)

The Type->defaultInitializer field was used in very different
ways depending on the type:
 * for an iterator record, the getIterator function
 * for an iterator class, the original user iterator function
 * for everything else, the compiler-generated default initializer

This overloading of the defaultInitializer field is confusing.

This PR adds an IteratorInfo field to AggregateType from which the
relevant functions can be found. The defaultInitiailzer field can now be
the compiler-generated initializer even for iterator records and iterator
classes.

This change supports my work on reworking tuple support functions, which
in turn supports my work on arrays. Nonetheless it might not turn out to
be necessary for those efforts.

No program behavior changes are expected from this patch. It can be
viewed as renaming:

      iteratorRecord->defaultInitializer to iteratorRecord->iteratorInfo->iterator

and

      iteratorClass->defaultInitializer to iteratorClass->iteratorInfo->getIterator

It also adjusts uses of type->defaultInitializer that could have applied
to handle these cases.

The trickiest part about this change was correctly handling
removeUnusedFunctions.  This change removes an unused function from
IteratorInfo and adjusts the FnSymbol destructor to set the related
iteratorInfo in AggregateType to NULL before deleting the IteratorInfo.

Passed quickstart testing.
Passed full local testing.

Reviewed by @daviditen - thanks!

Update for Take 2:

A few tests were failing to compile when calling halt with unusual
arguments (iterator or atomic).  I've fixed that since I'm pretty sure it
was not intended. After this PR, passing an iterator to halt works
(but isn't done in standard tests) and passing an atomic to halt
causes a compilation error (but also isn't done in standard tests).

Passed full local testing.
Passed full --no-local testing.
