### PR TITLE
Handle new case in buildDefaultWrapper

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9059,6 +9059,10 @@ static void insertReturnTemps() {
               }
             }
 
+            if (isTypeExpr(contextCallOrCall)) {
+              tmp->addFlag(FLAG_MAYBE_TYPE);
+              tmp->addFlag(FLAG_MAYBE_PARAM);
+            }
             def->insertAfter(new CallExpr(PRIM_MOVE,
                                           tmp,
                                           contextCallOrCall->remove()));

--- a/test/arrays/diten/distArrInRecord.compopts
+++ b/test/arrays/diten/distArrInRecord.compopts
@@ -1,0 +1,5 @@
+# -suseBulkTransferStride was resulting in a function resolution bug.
+# PR 4210 attempts to fix this bug.
+
+-suseBulkTransferStride=false
+-suseBulkTransferStride=true


### PR DESCRIPTION
The following test, when compiled with -suseBulkTransferStride, was encountering an error ("illegal assignment of type to value") in function resolution:

test/arrays/diten/distArrInRecord.chpl

Part of the error was that the buildDefaultWrapper function was creating
invalid AST like this:

```
(move
  SymExpr call_tmp
  (CallExpr init
    (move
      SymExpr _return_tmp_
      (call chpl__buildArrayRuntimeType ...))))
```

I believe this occurred because we attempted to build a default wrapper
after inserting return temps. The buildDefaultWrapper function seemed to
expect a normal call or a variable, but not a PRIM_MOVE.

My solution was to use the LHS of this existing move as the argument to
the PRIM_INIT call that buildDefaultWrapper wants to insert. I also
needed to add FLAG_MAYBE_TYPE and FLAG_MAYBE_PARAM to the '_return_tmp_'
variable in order to avoid error messages about assigning types to
values.

I'm not sure why this wasn't handled before, but I'm guessing that the
-suseBulkTransferStride config param opened up some path that hadn't
been tested much before and introduced a new order to function
resolution.