### PR TITLE
Replace some checks against the name of the "meme" arg with flag checks

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1622,7 +1622,7 @@ computeGenericSubs(SymbolMap &subs,
       // check for field with specified generic type
       //
       if (!formal->hasFlag(FLAG_TYPE_VARIABLE) && formal->type != dtAny &&
-          strcmp(formal->name, "outer") && strcmp(formal->name, "meme") &&
+          strcmp(formal->name, "outer") && !formal->hasFlag(FLAG_IS_MEME) &&
           (fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR) || fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)))
         USR_FATAL(formal, "invalid generic type specification on class field");
 
@@ -2134,7 +2134,7 @@ resolve_type_constructor(FnSymbol* fn, CallInfo& info) {
     SET_LINENO(fn);
     CallExpr* typeConstructorCall = new CallExpr(astr("_type", fn->name));
     for_formals(formal, fn) {
-      if (strcmp(formal->name, "meme")) {
+      if (!formal->hasFlag(FLAG_IS_MEME)) {
         if (fn->_this->type->symbol->hasFlag(FLAG_TUPLE)) {
           if (formal->instantiatedFrom) {
             typeConstructorCall->insertAtTail(formal->type->symbol);

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -62,7 +62,7 @@ explainInstantiation(FnSymbol* fn) {
     form_Map(SymbolMapElem, e, fn->substitutions) {
       ArgSymbol* arg = toArgSymbol(e->key);
       if (!strcmp(formal->name, arg->name)) {
-        if (!strcmp(arg->name, "meme")) // do not show meme argument
+        if (arg->hasFlag(FLAG_IS_MEME)) // do not show meme argument
           continue;
         if (first)
           first = false;


### PR DESCRIPTION
Checking a flag that is already there is preferable to performing string
comparisons.

This patch assumes that all "meme" arguments will have the flag FLAG_IS_MEME
attached to them.  I performed a paratest over the std build with asserts to
verify this assumption and saw no failures, so I believe it is a fair
assumption.  I also observed no code paths which added the argument without the
flag.