### PR TITLE
Check for mpi-gnu explicitly in chpl_arch and chpl_atomics

### DIFF
--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -113,7 +113,7 @@ class argument_map(object):
         if arch == 'unknown':
             return arch
 
-        if compiler == 'gnu':
+        if compiler in ['gnu', 'mpi-gnu']:
             if version >= CompVersion('4.9'):
                 return cls.gcc49.get(arch, '')
             elif version >= CompVersion('4.7'):

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -31,7 +31,7 @@ def get(flag='target'):
             # support 64 bit atomics on 32 bit platforms and the cray compiler
             # will never run on a 32 bit machine. For pgi or 32 bit platforms
             # with an older gcc, we fall back to locks
-            if compiler_val == 'gnu' or compiler_val == 'cray-prgenv-gnu':
+            if compiler_val in ['gnu', 'cray-prgenv-gnu', 'mpi-gnu']:
                 version = utils.get_compiler_version('gnu')
                 if version >= CompVersion('4.8'):
                     atomics_val = 'intrinsics'

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -36,6 +36,8 @@ def using_chapel_module():
 def get_compiler_version(compiler):
     version_string = '0'
     if 'gnu' in compiler:
+        # Asssuming the 'compiler' version matches the gcc version
+        # e.g., `mpicc -dumpversion == gcc -dumpversion`
         version_string = run_command(['gcc', '-dumpversion'])
     elif 'cray-prgenv-cray' == compiler:
         version_string = os.environ.get('CRAY_CC_VERSION', '0')


### PR DESCRIPTION
Previously, `CHPL_TARGET_ARCH=native` and `CHPL_ATOMICS=intrinsics` did not play nicely* with `CHPL_TARGET_COMPILER=mpi-gnu`,  even though the `make/compilers/Makefile.mpi-gnu` makefile supported this. This PR adds explicit checks for `mpi-gnu` in `chpl_arch.py` and `chpl_atomics.py`, to mitigate this issue.

*sample of the warnings when compiling with  `CHPL_TARGET_ARCH=native` and  `CHPL_TARGET_COMPILER=mpi-gnu`:


```
Warning: Unknown compiler: "mpi-gnu"
Warning: No valid option found: arch="native" compiler="mpi-gnu" version="CompVersion(major=4, minor=8, revision=0, build=0)"
Warning: Unknown compiler: "mpi-gnu"
Warning: No valid option found: arch="native" compiler="mpi-gnu" version="CompVersion(major=4, minor=8, revision=0, build=0)"
```

Special thanks to @npadmana for bringing this issue to our attention during MPI module testing.