### PR TITLE
Avoid LLVM problem with header rearrangement

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -813,7 +813,7 @@ void VarSymbol::codegenGlobalDef(bool isHeader) {
     codegenDefC(/*global=*/true, isHeader);
   } else {
 #ifdef HAVE_LLVM
-    if(type == dtVoid) {
+    if(type == dtVoid || !isHeader) {
       return;
     }
 

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -143,6 +143,8 @@ genGlobalDefClassId(const char* cname, int id, bool isHeader) {
                       id_type_name, name.c_str(), id);
   } else {
 #ifdef HAVE_LLVM
+    if (!isHeader)
+      return;
     GenRet id_type_g = CLASS_ID_TYPE->codegen();
     llvm::Type *id_type = id_type_g.type;
     llvm::GlobalVariable * gv = llvm::cast<llvm::GlobalVariable>(
@@ -244,6 +246,9 @@ genFtable(Vec<FnSymbol*> & fSymbols, bool isHeader) {
     fprintf(hdrfile, "\n};\n");
   } else {
 #ifdef HAVE_LLVM
+    if (!isHeader)
+      return;
+
     std::vector<llvm::Constant *> table ((fSymbols.n == 0) ? 1 : fSymbols.n);
     
     llvm::Type *funcPtrType = info->lvt->getType("chpl_fn_p");
@@ -327,6 +332,9 @@ genVirtualMethodTable(Vec<TypeSymbol*>& types, bool isHeader) {
     fprintf(hdrfile, "\n};\n");
   } else {
 #ifdef HAVE_LLVM
+    if (!isHeader)
+      return;
+
     const char* vmtData = "chpl_vmtable_data";
     std::vector<llvm::Constant *> table;
     llvm::Type *funcPtrType = getTypeLLVM("chpl_fn_p");
@@ -1073,7 +1081,11 @@ static void codegen_header(bool isHeader) {
   }
 
   genComment("Function Pointer Table");
+#ifndef HAVE_LLVM
   if(!isHeader) {
+#else
+    if (isHeader) {
+#endif
     for_vector(FnSymbol, fn2, functions) {
       if (fn2->hasFlag(FLAG_BEGIN_BLOCK) ||
           fn2->hasFlag(FLAG_COBEGIN_OR_COFORALL_BLOCK) ||
@@ -1105,6 +1117,9 @@ static void codegen_header(bool isHeader) {
                       globals_registry_static_size);
   } else {
 #ifdef HAVE_LLVM
+    if (!isHeader)
+      return; // Nothing in remainder of function should be done twice for LLVM
+
     llvm::Type* ptr_wide_ptr_t = info->lvt->getType("ptr_wide_ptr_t");
     INT_ASSERT(ptr_wide_ptr_t);
 


### PR DESCRIPTION
The entrance into the codegen_header function multiple times with
variation depending on the isHeader boolean value (PR #4177) caused
the code paths for LLVM generation to be unintentionally entered
multiple times.  This is a quick fix for that problem to avoid reverting
the change - the proper fix would either be a broader rearrangement
that understands LLVM will not respond to these changes (and so
doesn't perform the same check multiple times), or to determine the
equivalent changes necessary for LLVM and perform them.  The latter
is beyond the scope of the incremental compilation prototype at this
time, and the former seems to build on a follow-up comment for the
aforementioned PR and so is perhaps best handled when that comment
is addressed.

Verified that this change works with the failing LLVM tests, and over std
and std + --incremental.  Verifying that the LLVM future we made
still behaves as expected.