### PR TITLE
Follow up filename replace c_string w/ index lookup

### DIFF
--- a/runtime/src/launch/dummy/launch-dummy.c
+++ b/runtime/src/launch/dummy/launch-dummy.c
@@ -68,7 +68,7 @@ int chpl_launch(int argc, char* argv[], int32_t numLocales) {
 
 
 int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
-                           int32_t lineno, c_string filename) {
+                           int32_t lineno, int32_t filename) {
   if (strcmp(argv[argNum], "--dummy") == 0) {
     printf("the dummy launcher is handling an extra argument: %s\n", 
            argv[argNum]);

--- a/runtime/src/launch/loadleveler/launch-loadleveler.c
+++ b/runtime/src/launch/loadleveler/launch-loadleveler.c
@@ -121,7 +121,7 @@ int chpl_launch(int argc, char* argv[], int32_t numLocales) {
 
 
 int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
-                           int32_t lineno, c_string filename) {
+                           int32_t lineno, int32_t filename) {
   return 0;
 }
 

--- a/runtime/src/launch/marenostrum/launch-marenostrum.c
+++ b/runtime/src/launch/marenostrum/launch-marenostrum.c
@@ -170,7 +170,7 @@ int chpl_launch(int argc, char* argv[], int32_t numLocales) {
 #define CHPL_QUEUE_FLAG "--queue"
 
 int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
-                           int32_t lineno, c_string filename) {
+                           int32_t lineno, int32_t filename) {
   if (!strcmp(argv[argNum], CHPL_WALLTIME_FLAG)) {
     walltime = argv[argNum+1];
     return 2;

--- a/runtime/src/launch/mpirun/launch-mpirun.c
+++ b/runtime/src/launch/mpirun/launch-mpirun.c
@@ -60,7 +60,6 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  // if chpl_comm == none, the numLocales = 1
   return chpl_launch_using_system(chpl_launch_create_command(argc, argv, numLocales),
                                   argv[0]);
 }

--- a/runtime/src/launch/mpirun/launch-mpirun.c
+++ b/runtime/src/launch/mpirun/launch-mpirun.c
@@ -60,13 +60,14 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+  // if chpl_comm == none, the numLocales = 1
   return chpl_launch_using_system(chpl_launch_create_command(argc, argv, numLocales),
                                   argv[0]);
 }
 
 
 int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
-                           int32_t lineno, c_string filename) {
+                           int32_t lineno, int32_t filename) {
   return 0;
 }
 


### PR DESCRIPTION
As a followup to #3049, this PR catches some filename arguments that were left as `c_string` instead of `int32_t`s. 

Discovered during exploratory testing of @npadmana's MPI module.