### PR TITLE
Condense similar branches in scopeResolve check

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -277,16 +277,10 @@ static void addOneToSymbolTable(DefExpr* def)
                     def->sym->stringLoc());
         }
 
-        if (!oldFn && (newFn && !newFn->_this)) {
+        if ((!oldFn && (newFn && !newFn->_this)) ||
+            (!newFn && (oldFn && !oldFn->_this))) {
           // A function definition is conflicting with another named symbol
           // that isn't a function (could be a variable, a module name, etc.)
-          USR_FATAL(sym,
-                    "'%s' has multiple definitions, redefined at:\n  %s",
-                    sym->name,
-                    def->sym->stringLoc());
-        } else if (!newFn && (oldFn && !oldFn->_this)) {
-          // Another named symbol that isn't a function is conflicting with
-          // a function definition name.
           USR_FATAL(sym,
                     "'%s' has multiple definitions, redefined at:\n  %s",
                     sym->name,


### PR DESCRIPTION
I realized that the behavior within the if statement branches was identical and
that the only difference between the checks was the order - we're verifying
that a function doesn't conflict with a named symbol of another type (like a
variable, or a module, etc) and the difference between the two checks was
whether the function was the new symbol, or the old one.  Since they accomplish
the same thing, make them one check in the if statement and drop the else if
branch.

I added the duplicate branches about a year ago - my bad.

Passes full std run.