### PR TITLE
Add annotation to performance graphs for incremental comp codegen changes

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -142,6 +142,8 @@ all:
       config: 16 node XC
   07/19/16:
     - Disable jemalloc's stat gathering by default (#4180)
+  07/20/16:
+    - Generated code changes in preparation for incremental compilation (#4177)
 
 AllCompTime:
   11/09/14:


### PR DESCRIPTION
Some of the changes made in preparation for --incremental resulted in slower
code during performance testing.  This is due to no longer applying the static
keyword to functions within the chpl__header.h file.  We are planning on
reapplying that keyword during normal compilation, but will not restore it for
incremental compilation because otherwise it will not work at all.