### PR TITLE
(fast) meteor cleanup 4

### DIFF
--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -365,7 +365,7 @@ proc searchLinear(in board, in pos, in used, in placed, currentSolution) {
   if placed == numPieces {
 
     // lock
-    while l.testAndSet() do chpl_task_yield();
+    while l.testAndSet() do;
 
     recordSolution(currentSolution);
 


### PR DESCRIPTION
Removing `chpl_task_yield()` from lock-checking-loop, optimizing for the highly uncontested lock case (which is the case for this benchmark).

As pointed out in #4201 , this should improve meteor execution time by nearly `0.02 seconds`, putting it in 3rd place in the CBLG performance rankings (maybe?).