### PR TITLE
Correct a redefine for CHPL_UNWIND

### DIFF
--- a/runtime/make/Makefile.runtime.unwind-libunwind
+++ b/runtime/make/Makefile.runtime.unwind-libunwind
@@ -15,5 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-RUNTIME_DEFS += -DCHPL_UNWIND_LIBUNWIND
+RUNTIME_DEFS += -DCHPL_DO_UNWIND
 RUNTIME_INCLS += -I$(LIBUNWIND_INCLUDE_DIR)

--- a/runtime/make/Makefile.runtime.unwind-system
+++ b/runtime/make/Makefile.runtime.unwind-system
@@ -15,5 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-RUNTIME_DEFS += -DCHPL_UNWIND_LIBUNWIND
+RUNTIME_DEFS += -DCHPL_DO_UNWIND
 

--- a/runtime/src/error.c
+++ b/runtime/src/error.c
@@ -35,7 +35,7 @@
 #include "chpl-atomics.h"
 #endif
 
-#ifdef CHPL_UNWIND_LIBUNWIND
+#ifdef CHPL_DO_UNWIND
 // Necessary for instruct libunwind to use only the local unwind
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
@@ -140,7 +140,7 @@ void chpl_error_explicit(const char *message, int32_t lineno,
     fprintf(stderr, "error: %s", message);
   fprintf(stderr, "\n");
 
-#ifdef CHPL_UNWIND_LIBUNWIND
+#ifdef CHPL_DO_UNWIND
   chpl_stack_unwind();
 #endif
 


### PR DESCRIPTION
This PR solves a redefinition of CHPL_UNWIND_LIBUNWIND. On some occasions, if CHPL_UNWIND=libunwind, there was a redefinition of CHPL_UNWIND_LIBUNWIND in both the command line and chpl-env-gen.h (an example is showed by test/runtime/sungeun/chpl-env-gen). 

Passed, with $CHPL_HOME/util/test/prediff-for-stacktrace as a system prediff, test/runtime and test/release on linux64 and darwin