### PR TITLE
Fix misnamed .dat file in LCALSMain.graph

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.graph
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.graph
@@ -1,53 +1,53 @@
 perfkeys: raw_pressure_calc_short, raw_energy_calc_short, raw_vol3d_calc_short, raw_del_dot_vec_2d_short, raw_couple_short, raw_fir_short, raw_init3_short, raw_muladdsub_short, raw_if_quad_short, raw_trap_int_short, raw_hydro_1d_short, raw_iccg_short, raw_inner_prod_short, raw_band_lin_eq_short, raw_tridiag_elim_short, raw_eos_short, raw_adi_short, raw_int_predict_short, raw_diff_predict_short, raw_first_sum_short, raw_first_diff_short, raw_pic_2d_short, raw_pic_1d_short, raw_hydro_2d_short, raw_gen_lin_recur_short, raw_disc_ord_short, raw_mat_x_mat_short, raw_planckian_short, raw_imp_hydro_2d_short, raw_find_first_min_short
 graphkeys: pressure_calc, energy_calc, vol3d_calc, del_dot_vec_2d, couple, fir, init3, muladdsub, if_quad, trap_int, hydro_1d, iccg, inner_prod, band_lin_eq, tridiag_elim, eos, adi, int_predict, diff_predict, first_sum, first_diff, pic_2d, pic_1d, hydro_2d, gen_lin_recur, disc_ord, mat_x_mat, planckian, imp_hydro_2d, find_first_min
-repeat-files: LCALS.dat
+repeat-files: LCALSMain.dat
 graphtitle: LCALS (raw, short)
 ylabel: Time (seconds)
 
 perfkeys: raw_pressure_calc_medium, raw_energy_calc_medium, raw_vol3d_calc_medium, raw_del_dot_vec_2d_medium, raw_couple_medium, raw_fir_medium, raw_init3_medium, raw_muladdsub_medium, raw_if_quad_medium, raw_trap_int_medium, raw_hydro_1d_medium, raw_iccg_medium, raw_inner_prod_medium, raw_band_lin_eq_medium, raw_tridiag_elim_medium, raw_eos_medium, raw_adi_medium, raw_int_predict_medium, raw_diff_predict_medium, raw_first_sum_medium, raw_first_diff_medium, raw_pic_2d_medium, raw_pic_1d_medium, raw_hydro_2d_medium, raw_gen_lin_recur_medium, raw_disc_ord_medium, raw_mat_x_mat_medium, raw_planckian_medium, raw_imp_hydro_2d_medium, raw_find_first_min_medium
 graphkeys: pressure_calc, energy_calc, vol3d_calc, del_dot_vec_2d, couple, fir, init3, muladdsub, if_quad, trap_int, hydro_1d, iccg, inner_prod, band_lin_eq, tridiag_elim, eos, adi, int_predict, diff_predict, first_sum, first_diff, pic_2d, pic_1d, hydro_2d, gen_lin_recur, disc_ord, mat_x_mat, planckian, imp_hydro_2d, find_first_min
-repeat-files: LCALS.dat
+repeat-files: LCALSMain.dat
 graphtitle: LCALS (raw, medium)
 ylabel: Time (seconds)
 
 perfkeys: raw_pressure_calc_long, raw_energy_calc_long, raw_vol3d_calc_long, raw_del_dot_vec_2d_long, raw_couple_long, raw_fir_long, raw_init3_long, raw_muladdsub_long, raw_if_quad_long, raw_trap_int_long, raw_hydro_1d_long, raw_iccg_long, raw_inner_prod_long, raw_band_lin_eq_long, raw_tridiag_elim_long, raw_eos_long, raw_adi_long, raw_int_predict_long, raw_diff_predict_long, raw_first_sum_long, raw_first_diff_long, raw_pic_2d_long, raw_pic_1d_long, raw_hydro_2d_long, raw_gen_lin_recur_long, raw_disc_ord_long, raw_mat_x_mat_long, raw_planckian_long, raw_imp_hydro_2d_long, raw_find_first_min_long
 graphkeys: pressure_calc, energy_calc, vol3d_calc, del_dot_vec_2d, couple, fir, init3, muladdsub, if_quad, trap_int, hydro_1d, iccg, inner_prod, band_lin_eq, tridiag_elim, eos, adi, int_predict, diff_predict, first_sum, first_diff, pic_2d, pic_1d, hydro_2d, gen_lin_recur, disc_ord, mat_x_mat, planckian, imp_hydro_2d, find_first_min
-repeat-files: LCALS.dat
+repeat-files: LCALSMain.dat
 graphtitle: LCALS (raw, long)
 ylabel: Time (seconds)
 
 perfkeys: raw_omp_pressure_calc_short, raw_omp_energy_calc_short, raw_omp_vol3d_calc_short, raw_omp_del_dot_vec_2d_short, raw_omp_couple_short, raw_omp_fir_short, raw_omp_init3_short, raw_omp_muladdsub_short, raw_omp_if_quad_short, raw_omp_trap_int_short, raw_omp_pic_2d_short
 graphkeys: pressure_calc, energy_calc, vol3d_calc, del_dot_vec_2d, couple, fir, init3, muladdsub, if_quad, trap_int, pic_2d
-repeat-files: LCALS.dat
+repeat-files: LCALSMain.dat
 graphtitle: LCALS (raw_omp, short)
 ylabel: Time (seconds)
 
 perfkeys: raw_omp_pressure_calc_medium, raw_omp_energy_calc_medium, raw_omp_vol3d_calc_medium, raw_omp_del_dot_vec_2d_medium, raw_omp_couple_medium, raw_omp_fir_medium, raw_omp_init3_medium, raw_omp_muladdsub_medium, raw_omp_if_quad_medium, raw_omp_trap_int_medium, raw_omp_pic_2d_medium
 graphkeys: pressure_calc, energy_calc, vol3d_calc, del_dot_vec_2d, couple, fir, init3, muladdsub, if_quad, trap_int, pic_2d
-repeat-files: LCALS.dat
+repeat-files: LCALSMain.dat
 graphtitle: LCALS (raw_omp, medium)
 ylabel: Time (seconds)
 
 perfkeys: raw_omp_pressure_calc_long, raw_omp_energy_calc_long, raw_omp_vol3d_calc_long, raw_omp_del_dot_vec_2d_long, raw_omp_couple_long, raw_omp_fir_long, raw_omp_init3_long, raw_omp_muladdsub_long, raw_omp_if_quad_long, raw_omp_trap_int_long, raw_omp_pic_2d_long
 graphkeys: pressure_calc, energy_calc, vol3d_calc, del_dot_vec_2d, couple, fir, init3, muladdsub, if_quad, trap_int, pic_2d
-repeat-files: LCALS.dat
+repeat-files: LCALSMain.dat
 graphtitle: LCALS (raw_omp, long)
 ylabel: Time (seconds)
 
 perfkeys: raw_vector_only_pressure_calc_short, raw_vector_only_energy_calc_short, raw_vector_only_vol3d_calc_short, raw_vector_only_del_dot_vec_2d_short, raw_vector_only_couple_short, raw_vector_only_fir_short, raw_vector_only_init3_short, raw_vector_only_muladdsub_short, raw_vector_only_if_quad_short, raw_vector_only_trap_int_short, raw_vector_only_pic_2d_short
 graphkeys: pressure_calc, energy_calc, vol3d_calc, del_dot_vec_2d, couple, fir, init3, muladdsub, if_quad, trap_int, pic_2d
-repeat-files: LCALS.dat
+repeat-files: LCALSMain.dat
 graphtitle: LCALS (raw_vector_only, short)
 ylabel: Time (seconds)
 
 perfkeys: raw_vector_only_pressure_calc_medium, raw_vector_only_energy_calc_medium, raw_vector_only_vol3d_calc_medium, raw_vector_only_del_dot_vec_2d_medium, raw_vector_only_couple_medium, raw_vector_only_fir_medium, raw_vector_only_init3_medium, raw_vector_only_muladdsub_medium, raw_vector_only_if_quad_medium, raw_vector_only_trap_int_medium, raw_vector_only_pic_2d_medium
 graphkeys: pressure_calc, energy_calc, vol3d_calc, del_dot_vec_2d, couple, fir, init3, muladdsub, if_quad, trap_int, pic_2d
-repeat-files: LCALS.dat
+repeat-files: LCALSMain.dat
 graphtitle: LCALS (raw_vector_only, medium)
 ylabel: Time (seconds)
 
 perfkeys: raw_vector_only_pressure_calc_long, raw_vector_only_energy_calc_long, raw_vector_only_vol3d_calc_long, raw_vector_only_del_dot_vec_2d_long, raw_vector_only_couple_long, raw_vector_only_fir_long, raw_vector_only_init3_long, raw_vector_only_muladdsub_long, raw_vector_only_if_quad_long, raw_vector_only_trap_int_long, raw_vector_only_pic_2d_long
 graphkeys: pressure_calc, energy_calc, vol3d_calc, del_dot_vec_2d, couple, fir, init3, muladdsub, if_quad, trap_int, pic_2d
-repeat-files: LCALS.dat
+repeat-files: LCALSMain.dat
 graphtitle: LCALS (raw_vector_only, long)
 ylabel: Time (seconds)


### PR DESCRIPTION
The name of the .dat file should have been LCALSMain.dat, not LCALS.dat.