### PR TITLE
Make string bounds checking print the OOB index

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -340,7 +340,7 @@ module String {
      */
     proc this(i: int) : string {
       if boundsChecking && (i <= 0 || i > this.len)
-        then halt("index out of bounds of string");
+        then halt("index out of bounds of string: ", i);
 
       var ret: string;
       const newSize = chpl_here_good_alloc_size(2);

--- a/test/types/string/psahabu/string_bounds_checking-on.good
+++ b/test/types/string/psahabu/string_bounds_checking-on.good
@@ -1,2 +1,2 @@
 hello
-string_bounds_checking.chpl:3: error: halt reached - index out of bounds of string
+string_bounds_checking.chpl:3: error: halt reached - index out of bounds of string: 100


### PR DESCRIPTION
When doing some coding last night, I got a string OOB message that surprised me and would've been much easier to understand if it'd printed out the index that was OOB.  This PR makes that change and updates a test that was printing the message.

As extra credit, it occurs to me that if the index was <= 1 (and most notably 0), we could also print out an explanatory message saying that strings use 1-based indexing, but I'm not going to take that on now.
