### PR TITLE
Have release and submitted shootouts use the highPrecisionTimer

### DIFF
--- a/test/release/examples/benchmarks/shootout/PERFTIMEEXEC
+++ b/test/release/examples/benchmarks/shootout/PERFTIMEEXEC
@@ -1,1 +1,1 @@
-defaultTimer
+highPrecisionTimer

--- a/test/studies/shootout/submitted/PERFTIMEEXEC
+++ b/test/studies/shootout/submitted/PERFTIMEEXEC
@@ -1,1 +1,1 @@
-defaultTimer
+highPrecisionTimer


### PR DESCRIPTION
Use the highPrecisionTimer (timeit.default_timer) instead of the defaultTimer
(time -p) for the release and submitted shootout entries.

This is important for meteor which finishes insanely fast and wants a high
precision timer. The release versions using the  defaultTimer is the reason why
the release and parallel-alt meteors appeared to have different times even
though the code was identical.

The highPrecisionTimer also mimics how the official CLBG timings are done:

  http://benchmarksgame.alioth.debian.org/how-programs-are-measured.html