### PR TITLE
Fix two more typos

### DIFF
--- a/doc/chips/5.rst
+++ b/doc/chips/5.rst
@@ -375,7 +375,7 @@ allow the postblit function to repair a narrow pointer because it
 would know the original locale.
 
 Along with that, any copying across locales needs to call either
-postblit the assignment overlead. If a record:
+postblit or the assignment overload. If a record:
 
  * has a nontrivial postblit constructor, and
  * has any narrow pointers in fields

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -160,7 +160,7 @@ int chpl_comm_run_in_gdb(int argc, char* argv[], int gdbArgnum, int* status);
 void chpl_comm_post_task_init(void);
 
 //
-// a final comm layer stub before barrier synching and calling into
+// a final comm layer stub before barrier syncing and calling into
 // the user code.  It is recommended that a debugging message be
 // printed here indicating that each locale has started using
 // chpl_msg() and a verbosity level of 2 (which will cause it to be


### PR DESCRIPTION
Fix a typo in runtime/include/chpl-comm.h and one in doc/chips/5.rst.