### PR TITLE
Revert "Remove chpl_task_yield()"

### DIFF
--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -365,7 +365,7 @@ proc searchLinear(in board, in pos, in used, in placed, currentSolution) {
   if placed == numPieces {
 
     // lock
-    while l.testAndSet() do;
+    while l.testAndSet() do chpl_task_yield();
 
     recordSolution(currentSolution);
 


### PR DESCRIPTION
This reverts commit e22c9012f4e5bd21534113a3ad16b479918f18bb.

Re-add chpl_task_yield to meteor's atomic lock. This change was somehow
creating a deadlock for --memLeaks, which I haven't been able to track down
yet. Reverting until we can fix whatever is going wrong.