### PR TITLE
Limit remote-value-forwarding

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -184,8 +184,7 @@ static void updateTaskFunctions(Map<Symbol*, Vec<SymExpr*>*>& defMap,
   buildSyncAccessFunctionSet(syncSet);
 
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-
-    if (isTaskFun(fn)) {
+    if (fn->hasFlag(FLAG_ON) == true) {
       // Would need to flatten them if they are not already.
       INT_ASSERT(isGlobal(fn));
 


### PR DESCRIPTION
RVF has been applied to both on-functions and task-functions.  It appears inconsistent that
it applies to task-functions.  There shouldn't be any performance benefit and it might
interact negatively with the more modern task intents.  This PR limits RVF to blocking and
non-blocking on-functions.

Tested on linux64 std and gasnet.

Reviewed by Elliot


