### PR TITLE
Update how remoteValueForwarding finds functions with sync var operations

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -331,6 +331,11 @@ static void updateTaskArg(Map<Symbol*, Vec<SymExpr*>*>& useMap,
   }
 }
 
+
+static bool isSyncSingleMethod(FnSymbol* fn) {
+  return fn->_this && (isSyncType(fn->_this->type) || isSingleType(fn->_this->type));
+}
+
 /************************************* | **************************************
 *                                                                             *
 * Compute set of functions that access sync variables.                        *
@@ -341,50 +346,29 @@ static void buildSyncAccessFunctionSet(Vec<FnSymbol*>& syncAccessFunctionSet) {
   Vec<FnSymbol*> syncAccessFunctionVec;
 
   //
-  // Find all functions that directly call sync access primitives.
+  // Find all methods on sync/single vars
   //
-  forv_Vec(CallExpr, call, gCallExprs) {
-    if (FnSymbol* parent = toFnSymbol(call->parentSymbol)) {
-      if (call->isPrimitive(PRIM_SYNC_INIT) ||
-          call->isPrimitive(PRIM_SYNC_LOCK) ||
-          call->isPrimitive(PRIM_SYNC_UNLOCK) ||
-          call->isPrimitive(PRIM_SYNC_WAIT_FULL) ||
-          call->isPrimitive(PRIM_SYNC_WAIT_EMPTY) ||
-          call->isPrimitive(PRIM_SYNC_SIGNAL_FULL) ||
-          call->isPrimitive(PRIM_SYNC_SIGNAL_EMPTY) ||
-          call->isPrimitive(PRIM_SINGLE_INIT) ||
-          call->isPrimitive(PRIM_SINGLE_LOCK) ||
-          call->isPrimitive(PRIM_SINGLE_UNLOCK) ||
-          call->isPrimitive(PRIM_SINGLE_WAIT_FULL) ||
-          call->isPrimitive(PRIM_SINGLE_SIGNAL_FULL) ||
-          call->isPrimitive(PRIM_WRITEEF) ||
-          call->isPrimitive(PRIM_WRITEFF) ||
-          call->isPrimitive(PRIM_WRITEXF) ||
-          call->isPrimitive(PRIM_READFE) ||
-          call->isPrimitive(PRIM_READFF) ||
-          call->isPrimitive(PRIM_READXX) ||
-          call->isPrimitive(PRIM_SYNC_IS_FULL) ||
-          call->isPrimitive(PRIM_SINGLE_WRITEEF) ||
-          call->isPrimitive(PRIM_SINGLE_READFF) ||
-          call->isPrimitive(PRIM_SINGLE_READXX) ||
-          call->isPrimitive(PRIM_SINGLE_IS_FULL)) {
-        if (!parent->hasFlag(FLAG_DONT_DISABLE_REMOTE_VALUE_FORWARDING) &&
-            !syncAccessFunctionSet.set_in(parent)) {
-          syncAccessFunctionSet.set_add(parent);
-          syncAccessFunctionVec.add(parent);
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (isSyncSingleMethod(fn)) {
+      if (!fn->hasFlag(FLAG_DONT_DISABLE_REMOTE_VALUE_FORWARDING) &&
+          !syncAccessFunctionSet.set_in(fn)) {
+        syncAccessFunctionSet.set_add(fn);
+        syncAccessFunctionVec.add(fn);
 #ifdef DEBUG_SYNC_ACCESS_FUNCTION_SET
-          printf("%s:%d %s\n",
-                 parent->getModule()->name,
-                 parent->linenum(),
-                 parent->name);
+        printf("%s:%d %s\n",
+               fn->getModule()->name,
+               fn->linenum(),
+               fn->name);
 #endif
-        }
       }
     }
   }
 
   //
-  // Find all functions that indirectly call sync access primitives.
+  // Find all functions that indirectly call methods on sync/single vars. Note
+  // that syncAccessFunctionSet is just used for fast membership check, while
+  // syncAccessFunctionVec is trickily appended to while iterating over it so
+  // that we look at callsites of newly discovered functions.
   //
   forv_Vec(FnSymbol, fn, syncAccessFunctionVec) {
     forv_Vec(CallExpr, caller, *fn->calledBy) {


### PR DESCRIPTION
remoteValueForwarding previously found sync var operations by looking for the
sync var primitives and then finding functions that called the primitives.
However, we're working towards removing the primitives and just calling extern
functions directly.

Instead of looking for functions with sync var primitives in them, we now just
look for functions whose "this" argument is a sync var (i.e. we're finding
methods on sync vars)

Looking at the compiler output for release/examples/primers/syncsingle when
DEBUG_SYNC_ACCESS_FUNCTION_SET is defined shows that we're finding the same set
of functions that we were before this patch. In addition, we're also finding
the destructors on sync vars now, but I don't think that's a bid deal. In other
words, this just updates how we're finding functions with sync var operations,
it's not really changing the end behavior.
