### PR TITLE
Set dataParMinGranularity for LCALS

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
@@ -1,1 +1,1 @@
--sperfTesting=true
+-sperfTesting=true -sassertNoSlicing=true

--- a/test/release/examples/benchmarks/lcals/LCALSMain.perfexecopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.perfexecopts
@@ -1,0 +1,1 @@
+--dataParMinGranularity=1000


### PR DESCRIPTION
The parallel variant of LCALS was using way too many tasks for the Medium and
Small loop sizes in LCALS on systems with larger numbers of cores, making the
tasking overhead swamp the actual computation, causing perf testing timeouts.

By setting the dataParMinGranularity to 1000, a system with 24 cores that was
going past 3000 seconds to time out is now under 400 seconds.

While there, also set -sassertNoSlicing to improve the serial variant.