### PR TITLE
Allow parallel iterators with param formals

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5564,6 +5564,13 @@ static CallExpr* toPrimToLeaderCall(Expr* expr) {
   return NULL;
 }
 
+static SymExpr* symOrParamExpr(Symbol* arg) {
+  Symbol* result = arg;
+  if (Symbol* paramVal = paramMap.get(arg))
+    result = paramVal;
+  return new SymExpr(result);
+}
+
 // Recursively resolve typedefs
 static Type* resolveTypeAlias(SymExpr* se)
 {
@@ -6337,7 +6344,8 @@ preFold(Expr* expr) {
       FnSymbol* iterator = getTheIteratorFn(call);
       CallExpr* standaloneCall = new CallExpr(iterator->name);
       for_formals(formal, iterator) {
-        standaloneCall->insertAtTail(new NamedExpr(formal->name, new SymExpr(formal)));
+        standaloneCall->insertAtTail(new NamedExpr(formal->name,
+                                                   symOrParamExpr(formal)));
       }
       // "tag" should be placed at the end of the formals in the source code as
       // well, to avoid insertion of an order wrapper.
@@ -6352,7 +6360,8 @@ preFold(Expr* expr) {
       else
         leaderCall = new CallExpr(iterator->name);
       for_formals(formal, iterator) {
-        leaderCall->insertAtTail(new NamedExpr(formal->name, new SymExpr(formal)));
+        leaderCall->insertAtTail(new NamedExpr(formal->name,
+                                               symOrParamExpr(formal)));
       }
       // "tag" should be placed at the end of the formals in the source code as
       // well, to avoid insertion of an order wrapper.
@@ -6367,7 +6376,8 @@ preFold(Expr* expr) {
       else
         followerCall = new CallExpr(iterator->name);
       for_formals(formal, iterator) {
-        followerCall->insertAtTail(new NamedExpr(formal->name, new SymExpr(formal)));
+        followerCall->insertAtTail(new NamedExpr(formal->name,
+                                                 symOrParamExpr(formal)));
       }
       // "tag", "followThis" and optionally "fast" should be placed at the end
       // of the formals in the source code as well, to avoid insertion of an

--- a/test/functions/iterators/engin/paramArgIterator.chpl
+++ b/test/functions/iterators/engin/paramArgIterator.chpl
@@ -1,0 +1,31 @@
+config param useLF = false;
+config param useSA = false;
+
+iter myParallelIter(param x, type y, z) {
+  for i in min(y):int .. x do yield i;
+}
+
+iter myParallelIter(param x, type y, z, param tag)
+  where tag==iterKind.leader && useLF
+{
+  yield (min(y):int .. x, );
+}
+
+iter myParallelIter(param x, type y, z, param tag, followThis)
+  where tag==iterKind.follower
+{
+
+  for i in followThis[1] do yield i * z;
+}
+
+iter myParallelIter(param x, type y, z, param tag) 
+  where tag==iterKind.standalone && useSA
+{
+  for i in min(y):int .. x do yield i * z;
+}
+
+for i in myParallelIter(3,uint,10) do
+  writeln("ser: ", i);
+
+forall i in myParallelIter(3,uint,10) do
+  writeln("par: ", i);

--- a/test/functions/iterators/engin/paramArgIterator.compopts
+++ b/test/functions/iterators/engin/paramArgIterator.compopts
@@ -1,0 +1,2 @@
+-s useLF=true
+-s useSA=true

--- a/test/functions/iterators/engin/paramArgIterator.good
+++ b/test/functions/iterators/engin/paramArgIterator.good
@@ -1,8 +1,8 @@
-par: 0
-par: 10
-par: 20
-par: 30
 ser: 0
 ser: 1
 ser: 2
 ser: 3
+par: 0
+par: 10
+par: 20
+par: 30

--- a/test/functions/iterators/engin/paramArgIterator.good
+++ b/test/functions/iterators/engin/paramArgIterator.good
@@ -1,0 +1,8 @@
+par: 0
+par: 10
+par: 20
+par: 30
+ser: 0
+ser: 1
+ser: 2
+ser: 3

--- a/test/functions/iterators/engin/paramArgIterator.prediff
+++ b/test/functions/iterators/engin/paramArgIterator.prediff
@@ -1,0 +1,2 @@
+#! /bin/sh
+sort < $2 > $2.prediff.tmp && mv $2.prediff.tmp $2

--- a/test/functions/iterators/engin/paramArgIterator.prediff
+++ b/test/functions/iterators/engin/paramArgIterator.prediff
@@ -1,2 +1,0 @@
-#! /bin/sh
-sort < $2 > $2.prediff.tmp && mv $2.prediff.tmp $2


### PR DESCRIPTION
This newly-added test, mostly written by Engin, now works:

  test/functions/iterators/engin/paramArgIterator.chpl

DETAILS

preFold() converts a PRIM_TO_LEADER, PRIM_TO_FOLLOWER, or PRIM_TO_STANDALONE
to a CallExpr that resolves to a call to the corresponding parallel iterator.
The CallExpr's actuals are formals of the corresponding serial iterator.

When the user-written serial iterator has param formals, preFold() uses its
resolved+instantiated version. In that version, param formals are replaced
with default-intent formals with FLAG_INSTANTIATED_PARAM.

Prior to this change, those formals ended up as actuals of the CallExpr.
Since they are no longer params, the CallExpr did not resolve against
the parallel iterator with param formals.

To fix that, preFold() now looks them up in paramMap.

As the test shows, type formals work already.