### PR TITLE
Allow param formals to remain params within forall loops.

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -58,6 +58,7 @@ static bool isCorrespIndexVar(BlockStmt* block, Symbol* sym)
 //
 static bool isOuterVar(Symbol* sym, BlockStmt* block) {
   if (sym->isParameter()               || // includes isImmediate()
+      sym->hasFlag(FLAG_INSTANTIATED_PARAM)    || // also a param
       sym->hasFlag(FLAG_TEMP)          || // exclude these
 
       // Consts need no special semantics for begin/cobegin/coforall/on.

--- a/test/functions/iterators/engin/paramFormalInForall.chpl
+++ b/test/functions/iterators/engin/paramFormalInForall.chpl
@@ -1,0 +1,17 @@
+var A: [1..10] int;  // for forall loop
+
+proc fun2(param arg2) {
+  compilerWarning(arg2: string, 0);
+  writeln("fun2 ", arg2);
+}
+
+proc fun1(param arg1) {
+  forall a in A {
+    compilerWarning(arg1: string, 0);
+    fun2(arg1);
+  }
+}
+
+proc main {
+  fun1(5);
+}

--- a/test/functions/iterators/engin/paramFormalInForall.good
+++ b/test/functions/iterators/engin/paramFormalInForall.good
@@ -1,0 +1,15 @@
+paramFormalInForall.chpl:8: In function 'fun1':
+paramFormalInForall.chpl:10: warning: 5
+paramFormalInForall.chpl:11: warning: 5
+paramFormalInForall.chpl:3: In function 'fun2':
+paramFormalInForall.chpl:4: warning: 5
+fun2 5
+fun2 5
+fun2 5
+fun2 5
+fun2 5
+fun2 5
+fun2 5
+fun2 5
+fun2 5
+fun2 5


### PR DESCRIPTION
The situation is similar to #4256 - an instantiated param formal
becomes a default-intent formal, with FLAG_INSTANTIATED_PARAM.

The solution is different, however: when implementing forall intents,
we exclude such formals from the set of "outer variables", just like
we do proper param things.

Added a test authored by Engin.