### PR TITLE
Change use of atomic_flag to atomic_bool.

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -357,7 +357,7 @@ class LocBlockArr {
   const locDom: LocBlockDom(rank, idxType, stridable);
   var locRAD: LocRADCache(eltType, rank, idxType); // non-nil if doRADOpt=true
   var myElems: [locDom.myBlock] eltType;
-  var locRADLock: atomicflag; // This will only be accessed locally
+  var locRADLock: atomicbool; // This will only be accessed locally
                               // force the use of processor atomics
 
   // These function will always be called on this.locale, and so we do

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -1069,7 +1069,7 @@ class LocCyclicArr {
   var locRAD: LocRADCache(eltType, rank, idxType); // non-nil if doRADOpt=true
   var locCyclicRAD: LocCyclicRADCache(rank, idxType); // see below for why
   var myElems: [locDom.myBlock] eltType;
-  var locRADLock: atomicflag; // This will only be accessed locally, so
+  var locRADLock: atomicbool; // This will only be accessed locally, so
                               // force the use of processor atomics
 
   // These function will always be called on this.locale, and so we do

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -307,7 +307,7 @@ class LocStencilArr {
   const locDom: LocStencilDom(rank, idxType, stridable);
   var locRAD: LocRADCache(eltType, rank, idxType); // non-nil if doRADOpt=true
   var myElems: [locDom.myFluff] eltType;
-  var locRADLock: atomicflag; // This will only be accessed locally
+  var locRADLock: atomicbool; // This will only be accessed locally
                               // force the use of processor atomics
 
   // These function will always be called on this.locale, and so we do

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -85,23 +85,19 @@ module Atomics {
   extern type atomic__real64;
   extern type atomic__real32;
 
-  extern type atomic_flag;
+  extern type atomic_bool;
 
   extern proc atomic_thread_fence(order:memory_order);
   extern proc atomic_signal_thread_fence(order:memory_order);
 
-  extern proc atomic_is_lock_free_flag(ref obj:atomic_flag):bool;
-  extern proc atomic_init_flag(ref obj:atomic_flag, value:bool);
-  extern proc atomic_destroy_flag(ref obj:atomic_flag);
-  extern proc atomic_store_explicit_flag(ref obj:atomic_flag, value:bool, order:memory_order);
-  extern proc atomic_load_explicit_flag(ref obj:atomic_flag, order:memory_order):bool;
-  extern proc atomic_exchange_explicit_flag(ref obj:atomic_flag, value:bool, order:memory_order):bool;
-  extern proc atomic_compare_exchange_strong_explicit_flag(ref obj:atomic_flag, expected:bool, desired:bool, order:memory_order):bool;
-  extern proc atomic_compare_exchange_weak_explicit_flag(ref obj:atomic_flag, expected:bool, desired:bool, order:memory_order):bool;
-  extern proc atomic_flag_test_and_set_explicit(ref obj:atomic_flag, order:memory_order):bool;
-  extern proc atomic_flag_test_and_set(ref obj:atomic_flag):bool;
-  extern proc atomic_flag_clear_explicit(ref obj:atomic_flag, order:memory_order);
-  extern proc atomic_flag_clear(ref obj:atomic_flag);
+  extern proc atomic_is_lock_free_bool(ref obj:atomic_bool):bool;
+  extern proc atomic_init_bool(ref obj:atomic_bool, value:bool);
+  extern proc atomic_destroy_bool(ref obj:atomic_bool);
+  extern proc atomic_store_explicit_bool(ref obj:atomic_bool, value:bool, order:memory_order);
+  extern proc atomic_load_explicit_bool(ref obj:atomic_bool, order:memory_order):bool;
+  extern proc atomic_exchange_explicit_bool(ref obj:atomic_bool, value:bool, order:memory_order):bool;
+  extern proc atomic_compare_exchange_strong_explicit_bool(ref obj:atomic_bool, expected:bool, desired:bool, order:memory_order):bool;
+  extern proc atomic_compare_exchange_weak_explicit_bool(ref obj:atomic_bool, expected:bool, desired:bool, order:memory_order):bool;
 
   extern proc atomic_is_lock_free_uint_least8_t(ref obj:atomic_uint_least8_t):bool;
   extern proc atomic_init_uint_least8_t(ref obj:atomic_uint_least8_t, value:uint(8));
@@ -271,7 +267,7 @@ module Atomics {
 
   pragma "no doc"
   proc chpl__processorAtomicType(type base_type) type {
-    if base_type==bool then return atomicflag;
+    if base_type==bool then return atomicbool;
     else if base_type==uint(8) then return atomic_uint8;
     else if base_type==uint(16) then return atomic_uint16;
     else if base_type==uint(32) then return atomic_uint32;
@@ -296,9 +292,9 @@ module Atomics {
 
 
   pragma "no doc"
-  inline proc create_atomic_flag():atomic_flag {
-    var ret:atomic_flag;
-    atomic_init_flag(ret, false);
+  inline proc create_atomic_bool():atomic_bool {
+    var ret:atomic_bool;
+    atomic_init_bool(ret, false);
     return ret;
   }
 
@@ -307,13 +303,13 @@ module Atomics {
   /*
      The boolean atomic type.
   */
-  record atomicflag {
+  record atomicbool {
     pragma "no doc"
-    var _v:atomic_flag = create_atomic_flag();
+    var _v:atomic_bool = create_atomic_bool();
 
     pragma "no doc"
-    inline proc ~atomicflag() {
-      atomic_destroy_flag(_v);
+    inline proc ~atomicbool() {
+      atomic_destroy_bool(_v);
     }
 
     /*
@@ -321,7 +317,7 @@ module Atomics {
     */
     inline proc read(order:memory_order = memory_order_seq_cst):bool {
       var ret:bool;
-      on this do ret = atomic_load_explicit_flag(_v, order);
+      on this do ret = atomic_load_explicit_bool(_v, order);
       return ret;
     }
 
@@ -329,7 +325,7 @@ module Atomics {
        Stores `value` as the new value.
     */
     inline proc write(value:bool, order:memory_order = memory_order_seq_cst) {
-      on this do atomic_store_explicit_flag(_v, value, order);
+      on this do atomic_store_explicit_bool(_v, value, order);
     }
 
     /*
@@ -337,7 +333,7 @@ module Atomics {
     */
     inline proc exchange(value:bool, order:memory_order = memory_order_seq_cst):bool {
       var ret:bool;
-      on this do ret = atomic_exchange_explicit_flag(_v, value, order);
+      on this do ret = atomic_exchange_explicit_bool(_v, value, order);
       return ret;
     }
 
@@ -353,7 +349,7 @@ module Atomics {
     */
     inline proc compareExchangeWeak(expected:bool, desired:bool, order:memory_order = memory_order_seq_cst):bool {
       var ret:bool;
-      on this do ret = atomic_compare_exchange_weak_explicit_flag(_v, expected, desired, order);
+      on this do ret = atomic_compare_exchange_weak_explicit_bool(_v, expected, desired, order);
       return ret;
     }
 
@@ -363,7 +359,7 @@ module Atomics {
     */
     inline proc compareExchangeStrong(expected:bool, desired:bool, order:memory_order = memory_order_seq_cst):bool {
       var ret:bool;
-      on this do ret = atomic_compare_exchange_strong_explicit_flag(_v, expected, desired, order);
+      on this do ret = atomic_compare_exchange_strong_explicit_bool(_v, expected, desired, order);
       return ret;
     }
 
@@ -372,7 +368,7 @@ module Atomics {
     */
     inline proc testAndSet(order:memory_order = memory_order_seq_cst) {
       var ret:bool;
-      on this do ret = atomic_flag_test_and_set_explicit(_v, order);
+      on this do ret = atomic_exchange_explicit_bool(_v, true, order);
       return ret;
     }
 
@@ -380,7 +376,7 @@ module Atomics {
        Stores `false` as the new value.
     */
     inline proc clear(order:memory_order = memory_order_seq_cst) {
-      on this do atomic_flag_clear_explicit(_v, order);
+      on this do atomic_store_explicit_bool(_v, false, order);
     }
 
     /*
@@ -391,7 +387,7 @@ module Atomics {
     */
     inline proc waitFor(val:bool, order:memory_order = memory_order_seq_cst) {
       on this {
-        while (atomic_load_explicit_flag(_v, memory_order_relaxed) != val) {
+        while (atomic_load_explicit_bool(_v, memory_order_relaxed) != val) {
           chpl_task_yield();
         }
         // After waiting for the value, do a thread fence
@@ -1524,10 +1520,10 @@ module Atomics {
   // We need to explicitly define these for all types because the atomic
   //  types are records and unless explicitly defined, it will resolve
   //  to the normal record version of the function.  Sigh.
-  inline proc =(ref a:atomicflag, b:atomicflag) {
+  inline proc =(ref a:atomicbool, b:atomicbool) {
     a.write(b.read());
   }
-  inline proc =(ref a:atomicflag, b) {
+  inline proc =(ref a:atomicbool, b) {
     compilerError("Cannot directly assign atomic variables");
   }
   inline proc =(ref a:atomic_uint8, b:atomic_uint8) {

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -33,7 +33,7 @@ module ChapelDistribution {
     // atomics are available
     var _distCnt: atomic_refcnt; // distribution reference count
     var _doms: list(BaseDom);   // domains declared over this distribution
-    var _domsLock: atomicflag;  //   and lock for concurrent access
+    var _domsLock: atomicbool;  //   and lock for concurrent access
   
     pragma "dont disable remote value forwarding"
     proc destroyDist(): int {
@@ -121,7 +121,7 @@ module ChapelDistribution {
     // atomics are available
     var _domCnt: atomic_refcnt; // domain reference count
     var _arrs: list(BaseArr);  // arrays declared over this domain
-    var _arrsLock: atomicflag; //   and lock for concurrent access
+    var _arrsLock: atomicbool; //   and lock for concurrent access
   
     proc dsiMyDist(): BaseDist {
       halt("internal error: dsiMyDist is not implemented");

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -64,7 +64,7 @@ module DefaultAssociative {
     // We explicitly use processor atomics here since this is not
     // by design a distributed data structure
     var numEntries: atomic_int64;
-    var tableLock: atomicflag; // do not access directly, use function below
+    var tableLock: atomicbool; // do not access directly, use function below
     var tableSizeNum = 1;
     var tableSize = chpl__primes(tableSizeNum);
     var tableDom = {0..tableSize-1};

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -789,7 +789,7 @@ module NetworkAtomics {
 
   // bool, implemented with int(64)
   pragma "atomic type"
-  record ratomicflag {
+  record ratomicbool {
     var _v: int(64);
     inline proc read(order:memory_order = memory_order_seq_cst):bool {
       var ret: int(64);
@@ -850,29 +850,29 @@ inline proc compareExchangeWeak(expected:bool, desired:bool,
     }
   }
 
-  inline proc =(ref a:ratomicflag, b:ratomicflag) {
+  inline proc =(ref a:ratomicbool, b:ratomicbool) {
     a.write(b.read());
   }
-  inline proc =(ref a:ratomicflag, b) {
+  inline proc =(ref a:ratomicbool, b) {
     compilerError("Cannot directly assign network atomic variables");
   }
-  inline proc +(a:ratomicflag, b) {
+  inline proc +(a:ratomicbool, b) {
     compilerError("Cannot directly add network atomic variables");
     return a;
   }
-  inline proc -(a:ratomicflag, b) {
+  inline proc -(a:ratomicbool, b) {
     compilerError("Cannot directly subtract network atomic variables");
     return a;
   }
-  inline proc *(a:ratomicflag, b) {
+  inline proc *(a:ratomicbool, b) {
     compilerError("Cannot directly multiply network atomic variables");
     return a;
   }
-  inline proc /(a:ratomicflag, b) {
+  inline proc /(a:ratomicbool, b) {
     compilerError("Cannot directly divide network atomic variables");
     return a;
   }
-  inline proc %(a:ratomicflag, b) {
+  inline proc %(a:ratomicbool, b) {
     compilerError("Cannot directly divide network atomic variables");
     return a;
   }

--- a/modules/internal/comm/ugni/NetworkAtomicTypes.chpl
+++ b/modules/internal/comm/ugni/NetworkAtomicTypes.chpl
@@ -20,7 +20,7 @@
 module NetworkAtomicTypes {
 
   proc chpl__networkAtomicType(type base_type) type {
-    if base_type==bool then return ratomicflag;
+    if base_type==bool then return ratomicbool;
     else if base_type==uint(32) then return ratomic_uint32;
     else if base_type==uint(64) then return ratomic_uint64;
     else if base_type==int(32) then return ratomic_int32;

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -189,7 +189,7 @@ removePrefixFunctions $file
 
 replace "record" "type" $file
 
-replace "atomicflag" "atomic \(bool\)" $file
+replace "atomicbool" "atomic \(bool\)" $file
 replace "atomic_int64" "atomic \(T\)" $file
 replace "int(64)" "T" $file
 

--- a/runtime/include/atomics/README
+++ b/runtime/include/atomics/README
@@ -18,7 +18,7 @@ We require the C11 standard atomic functions for the types:
    atomic_int_least16_t
    atomic_int_least32_t
    atomic_int_least64_t
-   atomic_flag
+   atomic_bool
 and we require that the generic routines have the type appended
 to them, so that (for example), atomic_fetch_add( (uint_least64_t*) ptr, 100 )
 will be written atomic_fetch_add_uint_least64_t( (uint_least64_t*) ptr, 100 )
@@ -62,22 +62,6 @@ Memory Fences:
    void atomic_signal_thread_fence(memory_order order);
 
 
-/////////////////
-For Atomic Bools:
-/////////////////
-
-   // an atomic flag; set or not; must be lock-free according to the standard.
-   atomic_flag type
- 
-   // sets an atomic flag to true and returns the old value 
-   bool atomic_flag_test_and_set(volatile atomic_flag *object);
-   bool atomic_flag_test_and_set_explicit(volatile atomic_flag *object, memory_order order);
-
-   // sets atomic flag to false 
-   void atomic_flag_clear(volatile atomic_flag *object);
-   void atomic_flag_clear_explicit(volatile atomic_flag *object, memory_order order);
-
-
 ////////////////////
 For Atomic Integers:
 ////////////////////
@@ -92,7 +76,7 @@ For Atomic Integers:
    atomic_int_least16_t
    atomic_int_least32_t
    atomic_int_least64_t
-   atomic_flag
+   atomic_bool
 
    // All the following functions are generic - the Chapel runtime will assume
    // that we have implementations with e.g. _uint_least64_t appended to the function
@@ -132,6 +116,7 @@ For Atomic Integers:
 
    // atomic fetch and op, for op in add, sub, or, and:
    // (atomic xor only supported on some platforms)
+   // for non-bool integers
    C atomic_fetch_op(volatile A *object, M operand);
    C atomic_fetch_op_explicit(volatile A *object, M operand, memory_order order);
 

--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -37,7 +37,7 @@ typedef uint_least16_t atomic_uint_least16_t;
 typedef uint_least32_t atomic_uint_least32_t;
 typedef uint_least64_t atomic_uint_least64_t;
 typedef uintptr_t atomic_uintptr_t;
-typedef chpl_bool atomic_flag;
+typedef chpl_bool atomic_bool;
 typedef _real64 atomic__real64;
 typedef _real32 atomic__real32;
 
@@ -81,26 +81,12 @@ static inline void atomic_signal_thread_fence(memory_order order)
 
 
 ///////////////////////////////////////////////////////////////////////////////
-////               Test & Set and Clear for flag(boolean)                 ////
-//////////////////////////////////////////////////////////////////////////////
-static inline chpl_bool atomic_flag_test_and_set_explicit(atomic_flag *obj, memory_order order) {
-  return (chpl_bool)__sync_fetch_and_or((int_fast8_t*)obj, true); 
-}
-static inline chpl_bool atomic_flag_test_and_set(atomic_flag *obj) {
-  return atomic_flag_test_and_set_explicit(obj, memory_order_seq_cst);
-}
-
-static inline void atomic_flag_clear_explicit(atomic_flag *obj, memory_order order) {
-  __sync_fetch_and_and((int_fast8_t*)obj, false);
-}
-static inline void atomic_flag_clear(atomic_flag *obj) {
-  atomic_flag_clear_explicit(obj, memory_order_seq_cst);
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
 ////                      START OF INTEGER ATOMICS BASE                   ////
 //////////////////////////////////////////////////////////////////////////////
+
+// The obvious implementation of atomic stores is insufficient.
+// They must be implemented with atomic primitives to ensure consistent
+// visibility of the results.
 #define DECLARE_ATOMICS_BASE(type, basetype) \
 static inline chpl_bool atomic_is_lock_free_ ## type(atomic_ ## type * obj) { \
   return true; \
@@ -111,8 +97,12 @@ static inline void atomic_init_ ## type(atomic_ ## type * obj, basetype value) {
 static inline void atomic_destroy_ ## type(atomic_ ## type * obj) { \
 } \
 static inline void atomic_store_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
-  *obj = value; \
-  full_memory_barrier(); \
+  basetype ret = *obj; \
+  basetype old_val; \
+  do { \
+    old_val = ret; \
+    ret = __sync_val_compare_and_swap(obj, old_val, value); \
+  } while (ret != old_val); \
 } \
 static inline void atomic_store_ ## type(atomic_ ## type * obj, basetype value) { \
   atomic_store_explicit_ ## type(obj, value, memory_order_seq_cst); \
@@ -195,6 +185,10 @@ static inline type atomic_fetch_xor_ ## type(atomic_ ## type * obj, type operand
 ///////////////////////////////////////////////////////////////////////////////
 ////                       START OF REAL ATOMICS BASE                     ////
 //////////////////////////////////////////////////////////////////////////////
+
+// The obvious implementation of atomic stores is insufficient.
+// They must be implemented with atomic primitives to ensure consistent
+// visibility of the results.
 #define DECLARE_REAL_ATOMICS_BASE(type, uinttype) \
 static inline chpl_bool atomic_is_lock_free_ ## type(atomic_ ## type * obj) { \
   return true; \
@@ -206,8 +200,13 @@ static inline void atomic_init_ ## type(atomic_ ## type * obj, type value) { \
 static inline void atomic_destroy_ ## type(atomic_ ## type * obj) { \
 } \
 static inline void atomic_store_explicit_ ## type(atomic_ ## type * obj, type value, memory_order order) { \
-  *obj = value; \
-  full_memory_barrier(); \
+  uinttype ret_uint = *(uinttype *)obj; \
+  uinttype val_uint = *(uinttype *)&value; \
+  uinttype old_uint; \
+  do { \
+    old_uint = ret_uint; \
+    ret_uint = __sync_val_compare_and_swap((uinttype *)obj, old_uint, val_uint); \
+  } while (ret_uint != old_uint); \
 } \
 static inline void atomic_store_ ## type(atomic_ ## type * obj, type value) { \
   atomic_store_explicit_ ## type(obj, value, memory_order_seq_cst); \
@@ -325,8 +324,8 @@ static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand
 
 
 // Actually declare the atomics for integer and real types using the above macros 
-DECLARE_ATOMICS_BASE(flag, chpl_bool);
-DECLARE_ATOMICS_EXCHANGE_OPS(flag, chpl_bool);
+DECLARE_ATOMICS_BASE(bool, chpl_bool);
+DECLARE_ATOMICS_EXCHANGE_OPS(bool, chpl_bool);
 
 
 #define DECLARE_ATOMICS(type) \

--- a/runtime/include/atomics/intrinsics/testatomics.c
+++ b/runtime/include/atomics/intrinsics/testatomics.c
@@ -71,11 +71,11 @@
 
 int main(int argc, char** argv)
 {
-  atomic_flag flag;
+  atomic_bool flag;
 
-  atomic_flag_clear(&flag);
-  assert( false == atomic_flag_test_and_set(&flag) );
-  assert( true == atomic_flag_test_and_set(&flag) );
+  atomic_store_bool(&flag, false);
+  assert( false == atomic_exchange_bool(&flag, true) );
+  assert( true == atomic_exchange_bool(&flag, true) );
 
   atomic_thread_fence(memory_order_seq_cst);
   atomic_signal_thread_fence(memory_order_seq_cst);

--- a/runtime/include/atomics/locks/chpl-atomics.h
+++ b/runtime/include/atomics/locks/chpl-atomics.h
@@ -76,10 +76,10 @@ typedef struct atomic_uintptr_s {
   uintptr_t v;
 } atomic_uintptr_t;
 
-typedef struct atomic_flag_s {
+typedef struct atomic_bool_s {
   chpl_sync_aux_t sv;
   chpl_bool v;
-} atomic_flag;
+} atomic_bool;
 
 typedef struct atomic__real32_s {
   chpl_sync_aux_t sv;
@@ -109,28 +109,6 @@ static inline
 void atomic_signal_thread_fence(memory_order order)
 {
   // No idea!
-}
-
-static MAYBE_INLINE chpl_bool
-atomic_flag_test_and_set_explicit(atomic_flag *obj, memory_order order) {
-  chpl_bool ret;
-  chpl_sync_lock(&obj->sv);
-  ret = obj->v;
-  obj->v = true;
-  chpl_sync_unlock(&obj->sv);
-  return ret;
-}
-static inline chpl_bool atomic_flag_test_and_set(atomic_flag *obj) {
-  return atomic_flag_test_and_set_explicit(obj, memory_order_seq_cst);
-}
-static MAYBE_INLINE void
-atomic_flag_clear_explicit(atomic_flag *obj, memory_order order) {
-  chpl_sync_lock(&obj->sv);
-  obj->v = false;
-  chpl_sync_unlock(&obj->sv);
-}
-static inline void atomic_flag_clear(atomic_flag *obj) {
-  atomic_flag_clear_explicit(obj, memory_order_seq_cst);
 }
 
 #define DECLARE_ATOMICS_BASE(type, basetype) \
@@ -287,7 +265,7 @@ static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand
   return atomic_fetch_sub_explicit_ ## type(obj, operand, memory_order_seq_cst); \
 }
 
-DECLARE_ATOMICS_BASE(flag, chpl_bool);
+DECLARE_ATOMICS_BASE(bool, chpl_bool);
 
 #define DECLARE_ATOMICS(type) \
   DECLARE_ATOMICS_BASE(type, type) \

--- a/runtime/src/error.c
+++ b/runtime/src/error.c
@@ -111,16 +111,16 @@ void chpl_warning_explicit(const char *message, int32_t lineno,
 }
 
 #ifndef LAUNCHER
-static atomic_flag thisLocaleAlreadyExiting;
+static atomic_bool thisLocaleAlreadyExiting;
 void chpl_error_init(void) {
-  atomic_init_flag(&thisLocaleAlreadyExiting, false);
+  atomic_init_bool(&thisLocaleAlreadyExiting, false);
 }
 #endif
 
 static void spinhaltIfAlreadyExiting(void) {
 #ifndef LAUNCHER
   volatile int temp;
-  if (atomic_flag_test_and_set(&thisLocaleAlreadyExiting)) {
+  if (atomic_exchange_bool(&thisLocaleAlreadyExiting, true)) {
     // spin forever if somebody else already set it to 1
     temp = 1;
     while (temp);

--- a/test/users/aroonsharma/CyclicZipOpt.chpl
+++ b/test/users/aroonsharma/CyclicZipOpt.chpl
@@ -1016,7 +1016,7 @@ class LocCyclicZipOptArr {
   var locRAD: LocRADCache(eltType, rank, idxType); // non-nil if doRADOpt=true
   var locCyclicZipOptRAD: LocCyclicZipOptRADCache(rank, idxType); // see below for why
   var myElems: [locDom.myBlock] eltType;
-  var locRADLock: atomicflag; // This will only be accessed locally, so
+  var locRADLock: atomicbool; // This will only be accessed locally, so
                               // force the use of processor atomics
 
   // These function will always be called on this.locale, and so we do


### PR DESCRIPTION
This changes atomic_flag to atomic_bool, because Chapel's previous use of atomic_flag did not match the C11 atomics API and was really closer to atomic_bool.

This change causes atomic_store to be exercised more heavily, which made it apparent that a more robust version of atomic_store was needed, so it is included in this change.

The previous atomic_flag_test_and_set and atomic_flag_clear were optimized for bistate variables by using __sync_fetch_and_or and __sync_fetch_and_and respectively.  The old references to the atomic flag functions are being replaced with atomic_exchange_bool and atomic_store_bool respectively.  Consequently, there may be a performance regression due to the use of more generic routines and the new CAS version of atomic_store.  This possible performance issue does not affect the upcoming change to add support for C11 atomics.