### PR TITLE
Communication layer callbacks

### DIFF
--- a/runtime/include/chpl-comm-callbacks-internal.h
+++ b/runtime/include/chpl-comm-callbacks-internal.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef _chpl_tasks_callbacks_internal_h_
-#define _chpl_tasks_callbacks_internal_h_
+#ifndef _chpl_comm_callbacks_internal_h_
+#define _chpl_comm_callbacks_internal_h_
 
 
 #include <stdint.h>

--- a/runtime/include/chpl-comm-callbacks-internal.h
+++ b/runtime/include/chpl-comm-callbacks-internal.h
@@ -32,8 +32,8 @@
 // determine if the code needs to call any callbacks:
 // Typical code:
 //
-//    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put) {
-//       struct chpl_comm_cb_info_t cb_data = {.... actual data ....}
+//    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put)) {
+//       chpl_comm_cb_info_t cb_data = {.... actual data ....};
 //       chpl_comm_do_callbacks (&cb_data);
 //    }
 //

--- a/runtime/include/chpl-comm-callbacks-internal.h
+++ b/runtime/include/chpl-comm-callbacks-internal.h
@@ -1,0 +1,51 @@
+
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_tasks_callbacks_internal_h_
+#define _chpl_tasks_callbacks_internal_h_
+
+
+#include <stdint.h>
+#include <assert.h>
+
+#include "chpl-comm-callbacks.h"
+
+//
+// This is here for use in the runtime comm code to quickly
+// determine if the code needs to call any callbacks:
+// Typical code:
+//
+//    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put) {
+//       struct chpl_comm_cb_info_t cb_data = {.... actual data ....}
+//       chpl_comm_do_callbacks (&cb_data);
+//    }
+//
+
+int chpl_comm_callback_counts[chpl_comm_cb_num_event_kinds];
+
+static inline
+int chpl_comm_have_callbacks(chpl_comm_cb_event_kind_t event_kind) {
+  assert(event_kind < chpl_comm_cb_num_event_kinds);
+  return (chpl_comm_callback_counts[event_kind] > 0);
+}
+
+void chpl_comm_do_callbacks (const chpl_comm_cb_info_t *cb_data);
+
+#endif

--- a/runtime/include/chpl-comm-callbacks-internal.h
+++ b/runtime/include/chpl-comm-callbacks-internal.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.

--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -64,9 +64,9 @@ extern "C" {
 //     typedef void (*chpl_comm_cb_fn_t)(chpl_comm_cb_info_t* info);
 //
 //   The single argument passed to it is a pointer to information of
-//   type chpl_comm_cb_info_t, describing the task and/or event.  This
+//   type chpl_comm_cb_info_t, describing the communication operation.  This
 //   type is also defined below.  It contains a union of three different
-//   information sets dependinf only on the chpl_comm_cb_devent_kind_t
+//   information sets depending only on the chpl_comm_cb_devent_kind_t
 //   value.   
 //
 //
@@ -119,9 +119,9 @@ typedef enum {
   chpl_comm_cb_event_kind_get,       // Simple get
   chpl_comm_cb_event_kind_get_nb,    // Non-blocking get
   chpl_comm_cb_event_kind_get_strd,  // Strided get
-  chpl_comm_cb_event_kind_fork,      // regular fork
-  chpl_comm_cb_event_kind_fork_nb,   // Non-blocking fork
-  chpl_comm_cb_event_kind_fork_fast, // Fast fork
+  chpl_comm_cb_event_kind_exeOn,     // regular executeOn
+  chpl_comm_cb_event_kind_exeOn_nb,   // Non-blocking executeOn
+  chpl_comm_cb_event_kind_exeOn_fast, // Fast executeOn
   chpl_comm_cb_num_event_kinds
 } chpl_comm_cb_event_kind_t;
 
@@ -136,7 +136,7 @@ typedef struct {
       void *addr;                // Source address
       void *raddr;               // Destination address
       size_t size;               // Size of communication
-      int32_t typeIndex;         // type of the communcation
+      int32_t typeIndex;         // type of the communication
       int lineno;                // source line of communication
       int32_t filename;          // source file of communication
     } comm;
@@ -147,20 +147,20 @@ typedef struct {
 
       void* dstaddr;            // Destination Address
       void* dststrides;         // Destination strides
-      void* count;
+      size_t *count;            // Counts for the above
       int32_t stridelevels;
-      int32_t elemSize;
+      size_t elemSize;
       int32_t typeIndex;
       int lineno;               // source line of communication
       int32_t filename;         // source file of communication
     } comm_strd;
 
-    struct chpl_comm_info_comm_fork { //
+    struct chpl_comm_info_comm_exeOn { //
       c_sublocid_t subloc;      //  Sub-location
       chpl_fn_int_t fid;        //  Function ID
       void *arg;                //  Function arg pointer
-      int32_t arg_size;         //  Function arg size
-    } fork;
+      size_t arg_size;          //  Function arg size
+    } exeOn;
 
   } iu;
 } chpl_comm_cb_info_t;

--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -152,7 +152,7 @@ typedef struct {
       int32_t typeIndex;        //
       int lineno;               // source line of communication
       int32_t filename;         // source file of communication
-    } strd_comm;
+    } comm_strd;
 
     struct chpl_comm_info_comm_fork { //
       c_sublocid_t subloc;      //  Sub-location

--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_comm_callbacks_h_
+#define _chpl_comm_callbacks_h_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//
+// Communication layer callback support.
+//
+// NAME
+//
+//   chpl_comm_install_callback   - install communication callback function
+//   chpl_comm_uninstall_callback - remove communication callback function
+//
+//
+// SYNOPSIS
+//
+//     #include "chpl-comm-callbacks.h"
+//
+//     int chpl_comm_install_callback(chpl_comm_cb_event_kind_t event_kind,
+//                                    chpl_comm_cb_fn_t cb_fn);
+//     int chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_t event_kind,
+//                                      chpl_comm_cb_fn_t cb_fn);
+//
+//
+// DESCRIPTION
+//
+//   These runtime functions are used to install and remove functions
+//   called when certain events occur in the runtime communication layer.
+//
+//   The 'event_kind' argument specifies the communication layer event that
+//   is of interest. The 'cb_fn' argument is a pointer to a callback
+//   function for that event.  The callback functions installed for
+//   each event will be called, in the order in which they were
+//   installed, each time the corresponding event occurs in the
+//   communication layer of the runtime.
+//
+//   The event type, chpl_comm_cb_event_kind_t is defined below.
+//
+//   The type of a communication layer callback function pointer is:
+//
+//     typedef void (*chpl_comm_cb_fn_t)(chpl_comm_cb_info_t* info);
+//
+//   The single argument passed to it is a pointer to information of
+//   type chpl_comm_cb_info_t, describing the task and/or event.  This
+//   type is also defined below.  It contains a union of three different
+//   information sets dependinf only on the chpl_comm_cb_devent_kind_t
+//   value.   
+//
+//
+// RETURN VALUE
+//
+//   The returned value is 0 if no errors occurred and some other value
+//   (with errno set) if any errors did occur.
+//
+//
+// ERRORS
+//
+//   The following errors can occur with chpl_comm_install_callback():
+//
+//     ENOMEM:  No room to install another callback function for this
+//              event.  At present there is a static limit of 10 installed
+//              callback functions for each event.
+//     ERANGE:  The specified 'kind' is too large.
+//
+//   The following errors can occur with chpl_comm_uninstall_callback():
+//
+//     ENOENT:  The given pointer was not found in the list of installed
+//              callback functions for the given event.
+//     ERANGE:  The specified 'kind' is too large.
+//
+//
+// NOTES
+//
+//   Communication callbacks are local to the top-level locale.  In 
+//   multi-locale programs, callback functions must be installed separately
+//   on each locale where they are wanted.
+//
+//   The communication callback system is not thread safe.  Calling the install
+//   and/or uninstall functions simultaneously from more than one thread
+//   on a single locale can corrupt internal data structures and lead to
+//   chaos.  The installed callback functions themselves may be called
+//   by more than one thread on the same locale simultaneously; if they
+//   need concurrency control they must provide for it themselves.
+//
+//   The callback function should not depend upon the allocation
+//   status of the pointed-to info or any member within it, past the
+//   point when it returns.  For example, it must not store a copy of
+//   the info pointer for an event call for use when any other event
+//   call occurs.
+//
+
+typedef enum {
+  chpl_comm_cb_event_kind_put,       // Simple put
+  chpl_comm_cb_event_kind_put_nb,    // Non-blocking put
+  chpl_comm_cb_event_kind_put_strd,  // Strided put
+  chpl_comm_cb_event_kind_get,       // Simple get
+  chpl_comm_cb_event_kind_get_nb,    // Non-blocking get
+  chpl_comm_cb_event_kind_get_strd,  // Strided get
+  chpl_comm_cb_event_kind_fork,      // regular fork
+  chpl_comm_cb_event_kind_fork_nb,   // Non-blocking fork
+  chpl_comm_cb_event_kind_fork_fast, // Fast fork
+  chpl_comm_cb_num_event_kinds
+} chpl_comm_cb_event_kind_t;
+
+typedef struct {
+  c_nodeid_t nodeID;              // target nodeID
+  chpl_comm_cb_event_kind_t 
+             event_kind;          // kind of event this describes
+  union {
+
+    struct chpl_comm_info_comm { // put, put_nb, get, get_nb
+      void *addr;                // Source address
+      void *raddr;               // Destination address
+      size_t size;		 // Size of communication
+      int32_t typeIndex;         // type of the communcation
+      int lineno;                // source line of communication
+      int32_t filename;          // source file of communication
+    } comm;
+
+    struct chpl_comm_info_comm_strd { // put_strd, get_strd
+      void* srcaddr;            // Source Address
+      void* srcstrides;         // Source strides
+
+      void* dstaddr;		// Destination Address
+      void* dststrides;		// Destination strides
+      void* count;		// 
+      int32_t stridelevels;     // 
+      int32_t elemSize;        //
+      int32_t typeIndex;        //
+      int lineno;               // source line of communication
+      int32_t filename;         // source file of communication
+    } strd_comm;
+
+    struct chpl_comm_info_comm_fork { //
+      c_sublocid_t subloc;      //  Sub-location
+      chpl_fn_int_t fid;        //  Function ID
+      void *arg;                //  Function arg pointer
+      int32_t arg_size;         //  Function arg size
+    } fork;
+
+  } iu;
+} chpl_comm_cb_info_t;
+
+typedef void (*chpl_comm_cb_fn_t)(const chpl_comm_cb_info_t*);
+
+int chpl_comm_install_callback(chpl_comm_cb_event_kind_t,
+                               chpl_comm_cb_fn_t);
+int chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_t,
+                                 chpl_comm_cb_fn_t);
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
+
+#endif // _chpl_comm_callbacks_h_

--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -126,9 +126,10 @@ typedef enum {
 } chpl_comm_cb_event_kind_t;
 
 typedef struct {
-  c_nodeid_t nodeID;              // target nodeID
   chpl_comm_cb_event_kind_t 
              event_kind;          // kind of event this describes
+  c_nodeid_t localNodeID;         // The node doing the communication
+  c_nodeid_t remoteNodeID;        // The node to which the communication is going
   union {
 
     struct chpl_comm_info_comm { // put, put_nb, get, get_nb

--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -135,7 +135,7 @@ typedef struct {
     struct chpl_comm_info_comm { // put, put_nb, get, get_nb
       void *addr;                // Source address
       void *raddr;               // Destination address
-      size_t size;		 // Size of communication
+      size_t size;               // Size of communication
       int32_t typeIndex;         // type of the communcation
       int lineno;                // source line of communication
       int32_t filename;          // source file of communication
@@ -145,12 +145,12 @@ typedef struct {
       void* srcaddr;            // Source Address
       void* srcstrides;         // Source strides
 
-      void* dstaddr;		// Destination Address
-      void* dststrides;		// Destination strides
-      void* count;		// 
-      int32_t stridelevels;     // 
-      int32_t elemSize;        //
-      int32_t typeIndex;        //
+      void* dstaddr;            // Destination Address
+      void* dststrides;         // Destination strides
+      void* count;
+      int32_t stridelevels;
+      int32_t elemSize;
+      int32_t typeIndex;
       int lineno;               // source line of communication
       int32_t filename;         // source file of communication
     } comm_strd;

--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -119,9 +119,9 @@ typedef enum {
   chpl_comm_cb_event_kind_get,       // Simple get
   chpl_comm_cb_event_kind_get_nb,    // Non-blocking get
   chpl_comm_cb_event_kind_get_strd,  // Strided get
-  chpl_comm_cb_event_kind_exeOn,     // regular executeOn
-  chpl_comm_cb_event_kind_exeOn_nb,   // Non-blocking executeOn
-  chpl_comm_cb_event_kind_exeOn_fast, // Fast executeOn
+  chpl_comm_cb_event_kind_executeOn,      // regular executeOn
+  chpl_comm_cb_event_kind_executeOn_nb,   // Non-blocking executeOn
+  chpl_comm_cb_event_kind_executeOn_fast, // Fast executeOn
   chpl_comm_cb_num_event_kinds
 } chpl_comm_cb_event_kind_t;
 
@@ -155,12 +155,12 @@ typedef struct {
       int32_t filename;         // source file of communication
     } comm_strd;
 
-    struct chpl_comm_info_comm_exeOn { //
+    struct chpl_comm_info_comm_executeOn {
       c_sublocid_t subloc;      //  Sub-location
       chpl_fn_int_t fid;        //  Function ID
       void *arg;                //  Function arg pointer
       size_t arg_size;          //  Function arg size
-    } exeOn;
+    } executeOn;
 
   } iu;
 } chpl_comm_cb_info_t;

--- a/runtime/include/chpl-visual-debug.h
+++ b/runtime/include/chpl-visual-debug.h
@@ -41,37 +41,21 @@ extern int chpl_dprintf(int fd, const char * format, ...)
 
 //  start and open file if not NULL
 extern void chpl_vdebug_start(const char *, double now); 
+
 //  stop collecting data
 extern void chpl_vdebug_stop(void);
+
 //  Tag the data with a character tag, and possibly resume
 extern void chpl_vdebug_tag(int);
-//  resume from a tag point
+
+//  Stop logging events 
 extern void chpl_vdebug_pause(int);
-//  mark the current task as a xxxVdebug() task and all children
-extern void chpl_vdebug_mark(void);
 
-
-//  communication logging routines
+//  Identify a tagname with a tag number
 void chpl_vdebug_tagname(const char* tagname, int tagno);
 
-void chpl_vdebug_log_put_nb(const chpl_comm_cb_info_t *info);
-
-void chpl_vdebug_log_get_nb(const chpl_comm_cb_info_t *info);
-
-void chpl_vdebug_log_put(const chpl_comm_cb_info_t *info);
-
-void chpl_vdebug_log_get(const chpl_comm_cb_info_t *info);
-
-void  chpl_vdebug_log_put_strd(const chpl_comm_cb_info_t *info);
-
-void chpl_vdebug_log_get_strd(const chpl_comm_cb_info_t *info);
-
-void chpl_vdebug_log_fork(const chpl_comm_cb_info_t *info);
-
-void  chpl_vdebug_log_fork_nb(const chpl_comm_cb_info_t *info);
-
-void chpl_vdebug_log_fork_fast(const chpl_comm_cb_info_t *info);
-
+//  mark the current task as a xxxVdebug() task and all children
+extern void chpl_vdebug_mark(void);
 
 #endif
 

--- a/runtime/include/chpl-visual-debug.h
+++ b/runtime/include/chpl-visual-debug.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 #include "chpl-tasks.h"
+#include "chpl-comm-callbacks.h"
 
 extern int chpl_vdebug_fd;    // fd of output file, 0 => not gathering data
 extern int chpl_vdebug;       // Should we generate debug data
@@ -53,40 +54,24 @@ extern void chpl_vdebug_mark(void);
 //  communication logging routines
 void chpl_vdebug_tagname(const char* tagname, int tagno);
 
-void chpl_vdebug_log_put_nb(void *addr, c_nodeid_t node, void* raddr,
-                            size_t size, int32_t typeIndex,
-                            int ln, int32_t fname);
+void chpl_vdebug_log_put_nb(const chpl_comm_cb_info_t *info);
 
-void chpl_vdebug_log_get_nb(void* addr, c_nodeid_t node, void* raddr,
-                            size_t size, int32_t typeIndex,
-                            int ln, int32_t fname);
+void chpl_vdebug_log_get_nb(const chpl_comm_cb_info_t *info);
 
-void chpl_vdebug_log_put(void* addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t typeIndex,
-                         int ln, int32_t fname);
+void chpl_vdebug_log_put(const chpl_comm_cb_info_t *info);
 
-void chpl_vdebug_log_get(void* addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t typeIndex,
-                         int ln, int32_t fname);
+void chpl_vdebug_log_get(const chpl_comm_cb_info_t *info);
 
-void  chpl_vdebug_log_put_strd(void* dstaddr, void* dststrides, c_nodeid_t dstnode_id,
-                               void* srcaddr, void* srcstrides, void* count,
-                               int32_t stridelevels, int32_t elemSize, int32_t typeIndex,
-                               int ln, int32_t fname);
+void  chpl_vdebug_log_put_strd(const chpl_comm_cb_info_t *info);
 
-void chpl_vdebug_log_get_strd(void* dstaddr, void* dststrides, c_nodeid_t srcnode_id,
-                              void* srcaddr, void* srcstrides, void* count,
-                              int32_t stridelevels, int32_t elemSize, int32_t typeIndex,
-                              int ln, int32_t fname);
+void chpl_vdebug_log_get_strd(const chpl_comm_cb_info_t *info);
 
-void chpl_vdebug_log_fork(c_nodeid_t node, c_sublocid_t subloc,
-                          chpl_fn_int_t fid, void *arg, int32_t arg_size);
+void chpl_vdebug_log_fork(const chpl_comm_cb_info_t *info);
 
-void  chpl_vdebug_log_fork_nb(c_nodeid_t node, c_sublocid_t subloc,
-                              chpl_fn_int_t fid, void *arg, int32_t arg_size);
+void  chpl_vdebug_log_fork_nb(const chpl_comm_cb_info_t *info);
 
-void chpl_vdebug_log_fast_fork(c_nodeid_t node, c_sublocid_t subloc,
-                               chpl_fn_int_t fid, void *arg, int32_t arg_size);
+void chpl_vdebug_log_fork_fast(const chpl_comm_cb_info_t *info);
+
 
 #endif
 

--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -30,6 +30,7 @@ COMMON_NOGEN_SRCS = \
 	chpl-bitops.c \
 	chpl-cache.c \
 	chpl-comm.c \
+        chpl-comm-callbacks.c \
 	chpl-env.c \
 	chpl-init.c \
 	chplexit.c \

--- a/runtime/src/chpl-comm-callbacks.c
+++ b/runtime/src/chpl-comm-callbacks.c
@@ -103,6 +103,7 @@ void chpl_comm_do_callbacks(const chpl_comm_cb_info_t *info)
 {
   int i;
 
+
   // Don't do anything if the event kind is bad
   if (info->event_kind >= chpl_comm_cb_num_event_kinds)
     return;

--- a/runtime/src/chpl-comm-callbacks.c
+++ b/runtime/src/chpl-comm-callbacks.c
@@ -102,14 +102,14 @@ int chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_t event_kind,
 void chpl_comm_do_callbacks(const chpl_comm_cb_info_t *info)
 {
   int i;
-
+  struct cb_info *cb;
 
   // Don't do anything if the event kind is bad
   if (info->event_kind >= chpl_comm_cb_num_event_kinds)
     return;
 
   // Call the callbacks
-  struct cb_info *cb = &cb_info[info->event_kind];
+  cb = &cb_info[info->event_kind];
   for (i = 0; i < chpl_comm_callback_counts[info->event_kind]; i++) {
     (cb->fns[i])(info);
   }

--- a/runtime/src/chpl-comm-callbacks.c
+++ b/runtime/src/chpl-comm-callbacks.c
@@ -43,7 +43,7 @@ int chpl_comm_callback_counts[chpl_comm_cb_num_event_kinds] = {0};
 
 
 //
-// Comming callback support.
+// Communication callback support.
 //
 int chpl_comm_install_callback(chpl_comm_cb_event_kind_t event_kind,
                                chpl_comm_cb_fn_t cb_fn) {

--- a/runtime/src/chpl-comm-callbacks.c
+++ b/runtime/src/chpl-comm-callbacks.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+
+#include "chplrt.h"
+
+#include "chpl-comm.h"
+#include "error.h"
+#include "chpl-comm-callbacks.h"
+#include "chpl-comm-callbacks-internal.h"
+
+//
+// Communication callback support
+//
+#define MAX_CBS_PER_EVENT 10
+
+
+//
+// Storage for call back information
+//
+static struct cb_info {
+  chpl_comm_cb_fn_t fns[MAX_CBS_PER_EVENT];
+} cb_info[chpl_comm_cb_num_event_kinds];
+
+int chpl_comm_callback_counts[chpl_comm_cb_num_event_kinds] = {0};
+
+
+//
+// Comming callback support.
+//
+int chpl_comm_install_callback(chpl_comm_cb_event_kind_t event_kind,
+                               chpl_comm_cb_fn_t cb_fn) {
+  int i;
+
+  if (event_kind >= chpl_comm_cb_num_event_kinds) {
+    errno = ERANGE;
+    return -1;
+  }
+
+  i = chpl_comm_callback_counts[event_kind];
+
+  if (i >= MAX_CBS_PER_EVENT) {
+    errno = ENOMEM;
+    return -1;
+  }
+
+  chpl_comm_callback_counts[event_kind]++;
+  cb_info[event_kind].fns[i]= cb_fn;
+
+  return 0;
+}
+
+
+int chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_t event_kind,
+                                 chpl_comm_cb_fn_t cb_fn) {
+  int i;
+  int found_i;
+
+  if (event_kind >= chpl_comm_cb_num_event_kinds) {
+    errno = ERANGE;
+    return -1;
+  }
+
+  for (i = 0, found_i = -1; i < chpl_comm_callback_counts[event_kind]; i++) {
+    if (cb_info[event_kind].fns[i] == cb_fn) {
+      found_i = i;
+      break;
+    }
+  }
+
+  if (found_i < 0) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  for (i = found_i + 1; i < chpl_comm_callback_counts[event_kind]; i++) {
+    cb_info[event_kind].fns[i - 1] = cb_info[event_kind].fns[i];
+  }
+
+  chpl_comm_callback_counts[event_kind]--;
+
+  return 0;
+}
+
+void chpl_comm_do_callbacks(const chpl_comm_cb_info_t *info)
+{
+  int i;
+
+  // Don't do anything if the event kind is bad
+  if (info->event_kind >= chpl_comm_cb_num_event_kinds)
+    return;
+
+  // Call the callbacks
+  struct cb_info *cb = &cb_info[info->event_kind];
+  for (i = 0; i < chpl_comm_callback_counts[info->event_kind]; i++) {
+    (cb->fns[i])(info);
+  }
+}

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -57,9 +57,9 @@ static void cb_comm_put(const chpl_comm_cb_info_t *info);
 static void cb_comm_get(const chpl_comm_cb_info_t *info);
 static void cb_comm_put_strd(const chpl_comm_cb_info_t *info);
 static void cb_comm_get_strd(const chpl_comm_cb_info_t *info);
-static void cb_comm_exeOn(const chpl_comm_cb_info_t *info);
-static void cb_comm_exeOn_nb(const chpl_comm_cb_info_t *info);
-static void cb_comm_exeOn_fast(const chpl_comm_cb_info_t *info);
+static void cb_comm_executeOn(const chpl_comm_cb_info_t *info);
+static void cb_comm_executeOn_nb(const chpl_comm_cb_info_t *info);
+static void cb_comm_executeOn_fast(const chpl_comm_cb_info_t *info);
 
 int chpl_vdebug_fd = -1;
 int chpl_vdebug = 0;
@@ -211,7 +211,7 @@ void chpl_vdebug_stop (void) {
 
 // Record>  VdbMark: time.sec nodeId taskId
 //
-// This marks taskID as being a xxxVdebug() call.   Any exeOns or tasks
+// This marks taskID as being a xxxVdebug() call.   Any executeOns or tasks
 // started by this task and descendants of this task are related to
 // the xxxVdebug() call and chplvis should ignore them.
 
@@ -403,51 +403,51 @@ void cb_comm_get_strd (const chpl_comm_cb_info_t *info) {
 
 // Record>  fork: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
 
-void cb_comm_exeOn (const chpl_comm_cb_info_t *info) {
+void cb_comm_executeOn (const chpl_comm_cb_info_t *info) {
 
   // Visual Debug Support
   if (chpl_vdebug) {
-    const struct chpl_comm_info_comm_exeOn *cm = &info->iu.exeOn;
-    chpl_taskID_t exeOnTask = chpl_task_getId();
+    const struct chpl_comm_info_comm_executeOn *cm = &info->iu.executeOn;
+    chpl_taskID_t executeOnTask = chpl_task_getId();
     struct timeval tv;
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
                   "fork: %lld.%06ld %d %d %d %d %#lx %zd %lu \n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, cm->subloc, cm->fid, (unsigned long) cm->arg,
-                  cm->arg_size, (unsigned long) exeOnTask);
+                  cm->arg_size, (unsigned long) executeOnTask);
   }
 }
 
 // Record>  fork_nb: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
 
 
-void  cb_comm_exeOn_nb (const chpl_comm_cb_info_t *info) {
+void  cb_comm_executeOn_nb (const chpl_comm_cb_info_t *info) {
   if (chpl_vdebug) {
-    const struct chpl_comm_info_comm_exeOn *cm = &info->iu.exeOn;
-    chpl_taskID_t exeOnTask = chpl_task_getId();
+    const struct chpl_comm_info_comm_executeOn *cm = &info->iu.executeOn;
+    chpl_taskID_t executeOnTask = chpl_task_getId();
     struct timeval tv;
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd, "fork_nb: %lld.%06ld %d %d %d %d %#lx %zd %lu\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, cm->subloc, cm->fid, (unsigned long) cm->arg, 
-                  cm->arg_size, (unsigned long)exeOnTask);
+                  cm->arg_size, (unsigned long)executeOnTask);
   }
 }
 
 // Record>  f_fork: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
 
-void cb_comm_exeOn_fast (const chpl_comm_cb_info_t *info) {
+void cb_comm_executeOn_fast (const chpl_comm_cb_info_t *info) {
   if (chpl_vdebug) {
-    const struct chpl_comm_info_comm_exeOn *cm = &info->iu.exeOn;
-    chpl_taskID_t exeOnTask = chpl_task_getId();
+    const struct chpl_comm_info_comm_executeOn *cm = &info->iu.executeOn;
+    chpl_taskID_t executeOnTask = chpl_task_getId();
     struct timeval tv;
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  "f_exeOn: %lld.%06ld %d %d %d %d %#lx %zd %ld\n",
+                  "f_executeOn: %lld.%06ld %d %d %d %d %#lx %zd %ld\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, cm->subloc, cm->fid, (unsigned long)cm->arg, 
-                  cm->arg_size, (unsigned long)exeOnTask);
+                  cm->arg_size, (unsigned long)executeOnTask);
   }
 }
 
@@ -498,18 +498,18 @@ int install_callbacks (void) {
     (void) uninstall_callbacks();
     return 1;
   }
-  if (chpl_comm_install_callback(chpl_comm_cb_event_kind_exeOn,
-                                 cb_comm_exeOn)) {
+  if (chpl_comm_install_callback(chpl_comm_cb_event_kind_executeOn,
+                                 cb_comm_executeOn)) {
     (void) uninstall_callbacks();
     return 1;
   }
-  if (chpl_comm_install_callback(chpl_comm_cb_event_kind_exeOn_nb,
-                                 cb_comm_exeOn_nb)) {
+  if (chpl_comm_install_callback(chpl_comm_cb_event_kind_executeOn_nb,
+                                 cb_comm_executeOn_nb)) {
     (void) uninstall_callbacks();
     return 1;
   }
-  if (chpl_comm_install_callback(chpl_comm_cb_event_kind_exeOn_fast,
-                                 cb_comm_exeOn_fast)) {
+  if (chpl_comm_install_callback(chpl_comm_cb_event_kind_executeOn_fast,
+                                 cb_comm_executeOn_fast)) {
     (void) uninstall_callbacks();
     return 1;
   }
@@ -538,12 +538,12 @@ int uninstall_callbacks (void) {
                                      cb_comm_put_strd);
   rv += chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_get_strd,
                                      cb_comm_get_strd);
-  rv += chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_exeOn,
-                                     cb_comm_exeOn);
-  rv += chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_exeOn_nb,
-                                     cb_comm_exeOn_nb);
-  rv += chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_exeOn_fast,
-                                     cb_comm_exeOn_fast);
+  rv += chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_executeOn,
+                                     cb_comm_executeOn);
+  rv += chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_executeOn_nb,
+                                     cb_comm_executeOn_nb);
+  rv += chpl_comm_uninstall_callback(chpl_comm_cb_event_kind_executeOn_fast,
+                                     cb_comm_executeOn_fast);
   return rv;
 }
 

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -24,6 +24,8 @@
 #include "gasnet_coll.h"
 #include "gasnet_tools.h"
 #include "chpl-comm.h"
+#include "chpl-comm-callbacks.h"
+#include "chpl-comm-callbacks-internal.h"
 #include "chpl-mem.h"
 #include "chplsys.h"
 #include "chpl-tasks.h"
@@ -34,7 +36,6 @@
 #include "error.h"
 #include "chpl-mem-desc.h"
 #include "chpl-cache.h" // to call chpl_cache_init()
-#include "chpl-visual-debug.h"
 
 // Don't get warning macros for chpl_comm_get etc
 #include "chpl-comm-no-warning-macros.h"
@@ -453,9 +454,14 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
   gasnet_handle_t ret;
   int remote_in_segment;
 
-  // Should be in the compiler macros file?
-  chpl_vdebug_log_put_nb(addr, node, raddr, size, typeIndex, ln, fn);
-
+  // Communication callbacks
+  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put_nb)) {
+    chpl_comm_cb_info_t cb_data = 
+      {chpl_comm_cb_event_kind_put_nb, chpl_nodeID, node,
+       .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+    chpl_comm_do_callbacks (&cb_data);
+  }
+    
 #ifdef GASNET_SEGMENT_EVERYTHING
     remote_in_segment = 1;
 #else
@@ -486,8 +492,13 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
   gasnet_handle_t ret;
   int remote_in_segment;
 
-  // Visual Debug Support
-  chpl_vdebug_log_get_nb(addr, node, raddr, size, typeIndex, ln, fn);
+  // Communications callback support
+  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get_nb)) {
+    chpl_comm_cb_info_t cb_data = 
+      {chpl_comm_cb_event_kind_get_nb, chpl_nodeID, node,
+       .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+    chpl_comm_do_callbacks (&cb_data);
+  }
 
 #ifdef GASNET_SEGMENT_EVERYTHING
     remote_in_segment = 1;
@@ -928,8 +939,13 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
   if (chpl_nodeID == node) {
     memmove(raddr, addr, size);
   } else {
-    // Visual Debug support
-    chpl_vdebug_log_put(addr, node, raddr, size, typeIndex, ln, fn);
+    // Communications callback support
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put)) {
+      chpl_comm_cb_info_t cb_data =
+        {chpl_comm_cb_event_kind_put, chpl_nodeID, node,
+         .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+      chpl_comm_do_callbacks (&cb_data);
+    }
 
     if (chpl_verbose_comm && !chpl_comm_no_debug_private)
       printf("%d: %s:%d: remote put to %d\n", chpl_nodeID,
@@ -1005,9 +1021,14 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
   if (chpl_nodeID == node) {
     memmove(addr, raddr, size);
   } else {
-    // Visual Debug support
-    chpl_vdebug_log_get(addr, node, raddr, size, typeIndex, ln, fn);
-    
+    // Communications callback support
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get)) {
+      chpl_comm_cb_info_t cb_data = 
+        {chpl_comm_cb_event_kind_get, chpl_nodeID, node,
+         .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+      chpl_comm_do_callbacks (&cb_data);
+    }
+
     if (chpl_verbose_comm && !chpl_comm_no_debug_private)
       printf("%d: %s:%d: remote get from %d\n", chpl_nodeID,
              chpl_lookupFilename(fn), ln, node);
@@ -1164,10 +1185,15 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
     printf("\n");
   }
 
-  // Visual Debug Support
-  chpl_vdebug_log_get_strd(dstaddr, dststrides, srcnode_id, srcaddr, srcstrides, count,
-                           stridelevels, elemSize, typeIndex, ln, fn);
-
+  // Communications callback support
+  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get_strd)) {
+    chpl_comm_cb_info_t cb_data =
+      {chpl_comm_cb_event_kind_get_strd, chpl_nodeID, srcnode_id,
+       .iu.comm_strd={srcaddr, srcstrides, dstaddr, dststrides, count,
+                      stridelevels, elemSize, typeIndex, ln, fn}};
+    chpl_comm_do_callbacks (&cb_data);
+  }
+  
   // the case (chpl_nodeID == srcnode) is internally managed inside gasnet
   if (chpl_verbose_comm && !chpl_comm_no_debug_private)
     printf("%d: %s:%d: remote get from %d\n", chpl_nodeID,
@@ -1224,9 +1250,14 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
     printf("\n");
   }
 
-  // Visual Debug Support
-  chpl_vdebug_log_put_strd(dstaddr, dststrides, dstnode_id, srcaddr, srcstrides,
-                           count, stridelevels, elemSize, typeIndex, ln, fn);
+  // Communications callback support
+  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put_strd)) {
+      chpl_comm_cb_info_t cb_data =
+        {chpl_comm_cb_event_kind_put_strd, chpl_nodeID, dstnode_id,
+         .iu.comm_strd={srcaddr, srcstrides, dstaddr, dststrides, count,
+                        stridelevels, elemSize, typeIndex, ln, fn}};
+      chpl_comm_do_callbacks (&cb_data);
+  }
 
   // the case (chpl_nodeID == dstnode) is internally managed inside gasnet
   if (chpl_verbose_comm && !chpl_comm_no_debug_private)
@@ -1255,8 +1286,13 @@ void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
   if (chpl_nodeID == node) {
     chpl_ftable_call(fid, arg);
   } else {
-    // Visual Debug Support
-    chpl_vdebug_log_fork(node, subloc, fid, arg, arg_size);
+    // Communications callback support
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_fork)) {
+      chpl_comm_cb_info_t cb_data = 
+        {chpl_comm_cb_event_kind_fork, chpl_nodeID, node,
+         .iu.fork={subloc, fid, arg, arg_size}};
+      chpl_comm_do_callbacks (&cb_data);
+    }
 
     if (chpl_verbose_comm && !chpl_comm_no_debug_private)
       printf("%d: remote task created on %d\n", chpl_nodeID, node);
@@ -1339,7 +1375,6 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
   }
 
   if (chpl_nodeID == node) {
-    // Visual Debug?  Should we generate a task here???
     if (info->serial_state)
       fork_nb_wrapper(info);
     else
@@ -1347,8 +1382,13 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
                                (void*)info, subloc, chpl_nullTaskID,
                                info->serial_state);
   } else {
-    // Visual Debug Support
-    chpl_vdebug_log_fork_nb(node, subloc, fid, arg, arg_size);
+    // Communications callback support
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_fork_nb)) {
+      chpl_comm_cb_info_t cb_data = 
+        {chpl_comm_cb_event_kind_fork_nb, chpl_nodeID, node,
+         .iu.fork={subloc, fid, arg, arg_size}};
+      chpl_comm_do_callbacks (&cb_data);
+    }
 
     if (chpl_verbose_comm && !chpl_comm_no_debug_private)
       printf("%d: remote non-blocking task created on %d\n", chpl_nodeID, node);
@@ -1378,8 +1418,13 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
   if (chpl_nodeID == node) {
     chpl_ftable_call(fid, arg);
   } else {
-    // Visual Debug Support
-    chpl_vdebug_log_fast_fork(node, subloc, fid, arg, arg_size);
+    // Communications callback support
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_fork_fast)) {
+      chpl_comm_cb_info_t cb_data = 
+        {chpl_comm_cb_event_kind_fork_fast, chpl_nodeID, node,
+         .iu.fork={subloc, fid, arg, arg_size}};
+      chpl_comm_do_callbacks (&cb_data);
+    }
 
     if (passArg) {
       if (chpl_verbose_comm && !chpl_comm_no_debug_private)

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1287,10 +1287,10 @@ void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
     chpl_ftable_call(fid, arg);
   } else {
     // Communications callback support
-    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_fork)) {
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_exeOn)) {
       chpl_comm_cb_info_t cb_data = 
-        {chpl_comm_cb_event_kind_fork, chpl_nodeID, node,
-         .iu.fork={subloc, fid, arg, arg_size}};
+        {chpl_comm_cb_event_kind_exeOn, chpl_nodeID, node,
+         .iu.exeOn={subloc, fid, arg, arg_size}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1383,10 +1383,10 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
                                info->serial_state);
   } else {
     // Communications callback support
-    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_fork_nb)) {
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_exeOn_nb)) {
       chpl_comm_cb_info_t cb_data = 
-        {chpl_comm_cb_event_kind_fork_nb, chpl_nodeID, node,
-         .iu.fork={subloc, fid, arg, arg_size}};
+        {chpl_comm_cb_event_kind_exeOn_nb, chpl_nodeID, node,
+         .iu.exeOn={subloc, fid, arg, arg_size}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1419,10 +1419,10 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
     chpl_ftable_call(fid, arg);
   } else {
     // Communications callback support
-    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_fork_fast)) {
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_exeOn_fast)) {
       chpl_comm_cb_info_t cb_data = 
-        {chpl_comm_cb_event_kind_fork_fast, chpl_nodeID, node,
-         .iu.fork={subloc, fid, arg, arg_size}};
+        {chpl_comm_cb_event_kind_exeOn_fast, chpl_nodeID, node,
+         .iu.exeOn={subloc, fid, arg, arg_size}};
       chpl_comm_do_callbacks (&cb_data);
     }
 

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1287,10 +1287,10 @@ void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
     chpl_ftable_call(fid, arg);
   } else {
     // Communications callback support
-    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_exeOn)) {
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
       chpl_comm_cb_info_t cb_data = 
-        {chpl_comm_cb_event_kind_exeOn, chpl_nodeID, node,
-         .iu.exeOn={subloc, fid, arg, arg_size}};
+        {chpl_comm_cb_event_kind_executeOn, chpl_nodeID, node,
+         .iu.executeOn={subloc, fid, arg, arg_size}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1383,10 +1383,10 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
                                info->serial_state);
   } else {
     // Communications callback support
-    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_exeOn_nb)) {
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
       chpl_comm_cb_info_t cb_data = 
-        {chpl_comm_cb_event_kind_exeOn_nb, chpl_nodeID, node,
-         .iu.exeOn={subloc, fid, arg, arg_size}};
+        {chpl_comm_cb_event_kind_executeOn_nb, chpl_nodeID, node,
+         .iu.executeOn={subloc, fid, arg, arg_size}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1419,10 +1419,10 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
     chpl_ftable_call(fid, arg);
   } else {
     // Communications callback support
-    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_exeOn_fast)) {
+    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
       chpl_comm_cb_info_t cb_data = 
-        {chpl_comm_cb_event_kind_exeOn_fast, chpl_nodeID, node,
-         .iu.exeOn={subloc, fid, arg, arg_size}};
+        {chpl_comm_cb_event_kind_executeOn_fast, chpl_nodeID, node,
+         .iu.executeOn={subloc, fid, arg, arg_size}};
       chpl_comm_do_callbacks (&cb_data);
     }
 


### PR DESCRIPTION
Implement a callback system for the communications subsystem for get, put and fork events, all versions of those events.
Refactor chpl_visual_debug* to use the callback system.
Remove all direct calls to visual_debug routines from gasnet (comm-gasnet.c) and replace them with the upcall interface.