### PR TITLE
Quiet a remote value forwarding future

### DIFF
--- a/test/parallel/begin/deitz/test_begin_cobegin1_atomic.chpl
+++ b/test/parallel/begin/deitz/test_begin_cobegin1_atomic.chpl
@@ -2,14 +2,23 @@ proc main {
   var x: int;
   var z: int;
   var s: atomic int;
+  var onStarted: atomic bool;
   cobegin with (ref x, ref z) {
     begin with (ref x) {
+
+      // need to make sure the on-stmt's arg-bundle has been created and
+      // contains an unset `x`. Without this waitFor(), it's possible to have
+      // the x=2 complete before the argbundle has been created, which will
+      // mean we forward `2`, which would mask any rvf bugs.
+      onStarted.waitFor(true);
+
       x = 2;
       writeln((x, z));
       s.write(1);
     }
     {
       on Locales[0] {
+        onStarted.write(true);
         s.waitFor(1);
         z = x;
       }


### PR DESCRIPTION
Quiet a remote value forwarding future by making sure the on statement starts
executing before we update the scalar that is being mistakenly forwarded. The
forwarded value is put into the arg bundle for the on-stmt so we need to make
sure that the value isn't updated before the arg bundle is created, otherwise
we're forwarding the updated value, which makes it appear as though the test is
passing.