### PR TITLE
Improved #line directives in generated C code.

### DIFF
--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -48,16 +48,10 @@ void codegenStmt(Expr* stmt) {
   info->filename = stmt->fname();
 
   if( outfile ) {
-    if (stmt->linenum() > 0) {
-      if (printCppLineno) {
-        info->cStatements.push_back(
-            "/* ZLINE: " + numToString(stmt->linenum())
-            + " " + stmt->fname() + " */\n");
-      }
-    }
-
+    if (printCppLineno && stmt->linenum() > 0)
+        info->cStatements.push_back(zlineToString(stmt));
     if (fGenIDS)
-      info->cStatements.push_back("/* " + numToString(stmt->id) + " */ ");
+      info->cStatements.push_back(idCommentTemp(stmt));
   }
 
   ++gStmtCount;

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -804,6 +804,12 @@ void VarSymbol::codegenDefC(bool global, bool isHeader) {
       }
     }
   }
+
+  if (fGenIDS)
+    str = idCommentTemp(this) + str;
+  if (printCppLineno && !isHeader && !isTypeSymbol(defPoint->parentSymbol))
+    str = zlineToString(this) + str;
+
   info->cLocalDecls.push_back(str);
 }
 
@@ -1900,7 +1906,8 @@ GenRet FnSymbol::codegenFunctionType(bool forHeader) {
 void FnSymbol::codegenHeaderC(void) {
   FILE* outfile = gGenInfo->cfile;
   if (fGenIDS)
-    fprintf(outfile, "/* %7d */ ", id);
+    fprintf(outfile, "%s", idCommentTemp(this));
+
     // Prepend function header with necessary __global__ declaration
 
     //
@@ -2040,6 +2047,7 @@ void FnSymbol::codegenDef() {
   if( outfile ) {
     if (strcmp(saveCDir, "")) {
      if (const char* rawname = fname()) {
+      zlineToFileIfNeeded(this, outfile);
       const char* name = strrchr(rawname, '/');
       name = name ? name + 1 : rawname;
       fprintf(outfile, "/* %s:%d */\n", name, linenum());
@@ -2089,8 +2097,6 @@ void FnSymbol::codegenDef() {
     for_vector(BaseAST, ast, asts) {
       if (DefExpr* def = toDefExpr(ast))
         if (!toTypeSymbol(def->sym)) {
-          if (fGenIDS && isVarSymbol(def->sym))
-            genIdComment(def->sym->id);
           def->sym->codegenDef();
           flushStatements();
         }

--- a/compiler/backend/beautify.cpp
+++ b/compiler/backend/beautify.cpp
@@ -232,6 +232,8 @@ void beautify(fileinfo* origfile) {
     if (cp[0] != '\0') {
       if (zline >= 0 && new_line == TRUE) {
         fprintf(outputfile, ZLINEFORMAT, zline, zname);
+        if (zline == 0 && !strcmp(zname, "<internal>"))
+          zline = -1;
       }
     }
 

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -157,8 +157,10 @@ bool isBuiltinExternCFunction(const char* cname);
 std::string numToString(int64_t num);
 std::string int64_to_string(int64_t i);
 std::string uint64_to_string(uint64_t i);
+std::string zlineToString(BaseAST* ast);
+void zlineToFileIfNeeded(BaseAST* ast, FILE* outfile);
+const char* idCommentTemp(BaseAST* ast);
 void genComment(const char* comment, bool push=false);
-void genIdComment(int id);
 void flushStatements(void);
 
 

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -51,6 +51,24 @@ int      gMaxVMT    = -1;
 int      gStmtCount =  0;
 
 
+// ensure these two produce consistent output
+std::string zlineToString(BaseAST* ast) {
+  return "/* ZLINE: " + numToString(ast->linenum())
+         + " " + ast->fname() + " */\n";
+}
+void zlineToFileIfNeeded(BaseAST* ast, FILE* outfile) {
+  if (printCppLineno)
+    fprintf(outfile, "%s", zlineToString(ast).c_str());
+}
+
+static char idCommentBuffer[32];
+
+const char* idCommentTemp(BaseAST* ast) {
+  sprintf(idCommentBuffer, "/* %7d */ ", ast->id);
+  return idCommentBuffer;
+}
+
+
 static const char*
 subChar(Symbol* sym, const char* ch, const char* x) {
   char* tmp = (char*)malloc(ch-sym->cname+1);
@@ -1107,6 +1125,8 @@ static void codegen_header(bool isHeader) {
     }
   }
   flushStatements();
+  if (!isHeader)
+    zlineToFileIfNeeded(rootModule, info->cfile);
 
   genGlobalInt("chpl_numGlobalsOnHeap", numGlobalsOnHeap, isHeader);
   int globals_registry_static_size = (numGlobalsOnHeap ? numGlobalsOnHeap : 1);
@@ -1513,6 +1533,7 @@ void codegen(void) {
     openCFile(&defnfile, "chpl__defn",    "c");
     openCFile(&strconfig,  "chpl_str_config", "c");
 
+    zlineToFileIfNeeded(rootModule, mainfile.fptr);
     fprintf(mainfile.fptr, "#include \"chpl_str_config.c\"\n");
     fprintf(mainfile.fptr, "#include \"chpl__header.h\"\n");
     fprintf(mainfile.fptr, "#include \"%s.c\"\n", sCfgFname);
@@ -1724,10 +1745,6 @@ void genComment(const char* comment, bool push) {
       fprintf(info->cfile, "/*** %s ***/\n\n", comment);
     }
   }
-}
-void genIdComment(int id) {
-  GenInfo* info = gGenInfo;
-  if( info->cfile ) fprintf(info->cfile, "/* %7d */ ", id);
 }
 
 void flushStatements(void)


### PR DESCRIPTION
CHANGES IN GENERATED CODE

This PR results in the following changes in the generated C code,
when applicable due to --cpp-lines and --gen-ids compiler options:

* All "id comments", i.e. /* NNN */ where NNN is an AST node's ID,
are generated uniformly by idCommentTemp() using %7d format.
idCommentTemp() returns a static buffer for simplicity, hence "Temp".

* In chpl__header.h, each field of a struct type has an id comment.
I preferred not to generate a #line per field for brevity
and to avoid inadequate #line diagnostics for adjacent things.

* In chpl__defn.c, each global variable declaration corresponding
to a user variable has an id comment and a #line.

* In per-module .c files, the #line directive for each function and local
variable declaration reflect the astloc from the corresponding ast node.

* There is a #line 0 "<internal>" directive at the top of _main.c,
to reduce user exposure to the generated code upon --cpp-lines.

* There is also a #line 0 "<internal>" directive after the declarations
of global user variables in chpl__defn.c. Avoids pointing, for internal
things like chpl_mem_descs, into whatever file the last user variable
was in.

As an aside, my preference is to improve things further so chpl__header.h:

* contains an id comment and a #line for each struct type,

* does not contain an id comment for things that are defined in .c files,
especially function prototypes;

* separately, force no-#line mode when CHPL_CG_CPP_LINES=n is set
and no #line-related options are given on the command line,
even when CHPL_DEBUG=y.

I suggest - and include a related change to beautify.cpp - that we do not
necessarily emit #line 0 "<internal>" for consecutive lines.
The benefit is slightly smaller generated code. For example,
chpl__defn.c contains #lines only for global-user-variable decls.
The cost is that the C compiler may report "<internal>:nn" for nn>0,
besides just "<internal>:0".

Minor - we get a slight duplication right before a function header:

#line 22 "DefaultRectangular.chpl"
/* DefaultRectangular.chpl:22 */
#line 22 "DefaultRectangular.chpl"
void chpl__init_DefaultRectangular(int64_t _ln, int32_t _fn) {

DETAILS

#line directives are added by beautify(fileinfo* origfile), replacing
the comments /* ZLINE: lineno filename */ generated by codegen.

I think that when beautify() sees a ZLINE line, it records (lineno, filename).
When it sees any other line, it outputs a #line with the currently-recorded
(lineno, filename), if any, prior to printing the line itself.

Prior to this change, ZLINE comments were added before each statement
within a function and were not added before the function header.
Therefore the first function in a generated .c file had no #line
directives - until the first statement in its body. Each subsequent
function started out with #line directives that duplicated the last
#line in the preceding function.

Now we are generating a ZLINE before the header of each function
and before each local variable declaration. That way their #line
directives are meaningful, not just cloned from the previous line.

There are still some ZLINE comments left unhandled by beautify().
This was the case prior to this change as well.
This is independent of --gen-ids.

These unhandled comments can be found at least at "then" and "else"
branches of conditional statements. I think this happens whenever
we start codegen-ing a BlockStmt not at start of the line
of the generated C code. This is because beautify() recognizes ZLINE
comments only at the beginning of the line - see

  if (!strncmp(cp, ZLINEINPUT, ZLINEINPUTLEN))

Probably related to those cases where we generate to node-ID comments
at the beginning of a line.

I did not attempt to fix these cases.

BTW "ZLINE" is a cute historical artifact. I think it's short for "ZPL line"
i.e. line number in the code written in ZPL. This exposes code lineage,
see the comment near the top of beautify.cpp.

This is a replacement for #4260 to resolve merge conflicts.
