### PR TITLE
Annotate performance impact from restoring static to normal compilation C code

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -144,7 +144,7 @@ all:
     - Disable jemalloc's stat gathering by default (#4180)
   07/20/16:
     - Generated code changes in preparation for incremental compilation (#4177)
-  08/01/16:
+  08/02/16:
     - Restore static to normal compilation generated code (#4233)
 
 AllCompTime:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -144,6 +144,8 @@ all:
     - Disable jemalloc's stat gathering by default (#4180)
   07/20/16:
     - Generated code changes in preparation for incremental compilation (#4177)
+  08/01/16:
+    - Restore static to normal compilation generated code (#4233)
 
 AllCompTime:
   11/09/14:


### PR DESCRIPTION
Results are still coming in, but it looks like this change restored performance
to previous numbers, as expected.