### PR TITLE
Initial Chapel Dockerfile(s)

### DIFF
--- a/util/dockerfiles/1.13.1/Dockerfile
+++ b/util/dockerfiles/1.13.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:testing
+FROM debian:jessie
 
 ENV CHPL_VERSION 1.13.1
 
@@ -11,15 +11,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python \
     python-dev \
     python-setuptools \
+    libgmp10 \
+    libgmp-dev \
     bash \
     make \
     mawk \
     && rm -rf /var/lib/apt/lists/*
 
+ENV CHPL_HOME /opt/chapel/$CHPL_VERSION
+ENV CHPL_GMP  system
+
 RUN mkdir -p /opt/chapel \
     && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
     && make -C /opt/chapel/$CHPL_VERSION
-
-ENV CHPL_HOME /opt/chapel/$CHPL_VERSION
 
 ENV PATH $PATH:$CHPL_HOME/bin/linux64:$CHPL_HOME/util

--- a/util/dockerfiles/1.13.1/Dockerfile
+++ b/util/dockerfiles/1.13.1/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:testing
+
+ENV CHPL_VERSION 1.13.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    ca-certificates \
+    gcc \
+    g++ \
+    perl \
+    python \
+    python-dev \
+    python-setuptools \
+    bash \
+    make \
+    mawk \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/chapel \
+    && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
+    && make -C /opt/chapel/$CHPL_VERSION
+
+ENV CHPL_HOME /opt/chapel/$CHPL_VERSION
+
+ENV PATH $PATH:$CHPL_HOME/bin/linux64:$CHPL_HOME/util

--- a/util/dockerfiles/1.13.1/Dockerfile
+++ b/util/dockerfiles/1.13.1/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:jessie
 
-ENV CHPL_VERSION 1.13.1
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     ca-certificates \
@@ -18,11 +16,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mawk \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CHPL_HOME /opt/chapel/$CHPL_VERSION
-ENV CHPL_GMP  system
+ENV CHPL_VERSION 1.13.1
+ENV CHPL_HOME    /opt/chapel/$CHPL_VERSION
+ENV CHPL_GMP     system
 
 RUN mkdir -p /opt/chapel \
     && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
-    && make -C /opt/chapel/$CHPL_VERSION
+    && make -C $CHPL_HOME
 
 ENV PATH $PATH:$CHPL_HOME/bin/linux64:$CHPL_HOME/util


### PR DESCRIPTION
This PR adds a single `Dockerfile` for the 1.13.1 release and sets up a directory structure for future `Dockerfiles`. The Docker image for 1.13.1 is already on [Docker Hub](https://hub.docker.com/r/chapel/chapel/) but is subject to update (for the time being).

Requesting review by @ben-albrecht 