### PR TITLE
Do not emit 0 in #line in generated C code

### DIFF
--- a/compiler/backend/beautify.cpp
+++ b/compiler/backend/beautify.cpp
@@ -231,9 +231,13 @@ void beautify(fileinfo* origfile) {
 
     if (cp[0] != '\0') {
       if (zline >= 0 && new_line == TRUE) {
-        fprintf(outputfile, ZLINEFORMAT, zline, zname);
-        if (zline == 0 && !strcmp(zname, "<internal>"))
-          zline = -1;
+        int zlineP = zline;
+        if (zline == 0) {
+          zlineP = 1;  // #line 0 ... is illegal in C11
+          if (!strcmp(zname, "<internal>")) //always internal when zline==0 ?
+            zline = -1; //do not print #line until we see ZLINEINPUT again
+        }
+        fprintf(outputfile, ZLINEFORMAT, zlineP, zname);
       }
     }
 


### PR DESCRIPTION
This is a fix to my #4265. There the compiler started to emit

#line 0 "<internal>"

in the generated code. Having 0 for the line number goes against
the C11 standard (6.10.4?). With this patch, the compiler will
emit

#line 1 ...

anywhere it used to emit #line 0 ...
Everything else is unchanged by this commit.