### PR TITLE
Updates to Search module

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -153,8 +153,8 @@ class SparseBlockDom: BaseSparseDom {
         const _first = locDoms[l].mySparseBlock._value.parentDom.first;
         const _last = locDoms[l].mySparseBlock._value.parentDom.last;
 
-        var (foundFirst, locFirst) = search(inds, _first, comp);
-        var (foundLast, locLast) = search(inds, _last, comp);
+        var (foundFirst, locFirst) = binarySearch(inds, _first, comp);
+        var (foundLast, locLast) = binarySearch(inds, _last, comp);
 
         if !foundLast then locLast -= 1;
 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -138,9 +138,9 @@ module DefaultSparse {
       // sjd: unfortunate specialization for rank == 1
       //
       if rank == 1 && isTuple(ind) && ind.size == 1 then
-        return BinarySearch(indices, ind(1), 1, nnz);
+        return binarySearch(indices, ind(1), 1, nnz);
       else
-        return BinarySearch(indices, ind, 1, nnz);
+        return binarySearch(indices, ind, 1, nnz);
     }
 
     proc dsiMember(ind) { // ind should be verified to be index type

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -138,9 +138,9 @@ module DefaultSparse {
       // sjd: unfortunate specialization for rank == 1
       //
       if rank == 1 && isTuple(ind) && ind.size == 1 then
-        return binarySearch(indices, ind(1), 1, nnz);
+        return binarySearch(indices[1..nnz], ind(1));
       else
-        return binarySearch(indices, ind, 1, nnz);
+        return binarySearch(indices[1..nnz], ind);
     }
 
     proc dsiMember(ind) { // ind should be verified to be index type

--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -234,7 +234,7 @@ class CSRDom: BaseSparseDom {
 
     const (row, col) = ind;
 
-    return binarySearch(colIdx, col, rowStart(row), rowStop(row));
+    return binarySearch(colIdx[rowStart(row)..rowStop(row)], col);
   }
 
   proc dsiMember(ind: rank*idxType) {

--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -187,7 +187,7 @@ class CSRDom: BaseSparseDom {
   proc _private_findStartRow(startIx, low, high) {
     var approx = 2; // Indicates when to switch to linear search.
                     // This number could be tuned for performance.
-    // simple binary search (should be fewer comparisons than BinarySearch())
+    // simple binary search (should be fewer comparisons than binarySearch())
     var l = low, h = high;
     while h > l + approx {
       var m = (h + l) / 2;
@@ -234,7 +234,7 @@ class CSRDom: BaseSparseDom {
 
     const (row, col) = ind;
 
-    return BinarySearch(colIdx, col, rowStart(row), rowStop(row));
+    return binarySearch(colIdx, col, rowStart(row), rowStop(row));
   }
 
   proc dsiMember(ind: rank*idxType) {

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -47,7 +47,7 @@ proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, sorted=false) w
   if sorted then
     return binarySearch(Data, val, comparator);
   else
-    return linearSearch(Data, val);
+    return linearSearch(Data, val, comparator);
 }
 
 

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -18,63 +18,65 @@
  */
 
 /*
-   The `Search` module is designed to support standard search routines. The
-   current interface is minimal and should be expected to grow and evolve
-   over time.
+   The `Search` module is designed to support standard search routines.
  */
 module Search {
   use Sort;
 
 /*
-   General purpose searching interface for searching through a pre-sorted array.
+   General purpose searching interface for searching through a 1-D array.
+   For pre-sorted arrays, denoted by passing ``sorted=true`` as an argument,
+   this function wraps :proc:`binarySearch`, otherwise it wraps
+   :proc`linearSearch`.
 
-   .. note:: Currently this method calls a sequential :proc:`binarySearch`, but
-             this may change the future as other algorithms are implemented.
-
-   :arg Data: The array to be sorted
+   :arg Data: The array to be searched
    :type Data: [] `eltType`
    :arg val: The value to find in the array
    :type val: `eltType`
    :arg comparator: :ref:`Comparator <comparators>` record that defines how the
       data is sorted.
+   :arg sorted: Indicate if the array is pre-sorted
+   :type sorted: `bool`
 
    :returns: A tuple indicating (1) if the value was found and (2) the location
       of the value if it was found or the location where the value should have
       been if it was not found.
    :rtype: (`bool`, `Data.domain.type`)
  */
-proc search(Data:[?Dom], val, comparator:?rec=defaultComparator) where Dom.rank == 1 {
-  return binarySearch(Data, val, comparator);
+proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, sorted=false) where Dom.rank == 1 {
+  if sorted then
+    return binarySearch(Data, val, comparator);
+  else
+    return linearSearch(Data, val);
 }
 
 
 /*
-   Searches through the pre-sorted array `Data` looking for the value `val` using
+   Searches through the array `Data` looking for the value `val` using
    a sequential linear search.  Returns a tuple indicating (1) whether or not
-   the value was found and (2) the location of the value if it was found, or
-   the location where the value should have been if it was not found.
+   the value was found and (2) the location of the first occurrence of the
+   value if it was found, or ``Data.domain.high+1`` if it was not found.
 
-   :arg Data: The sorted array to search
+   :arg Data: The array to search
    :type Data: [] `eltType`
    :arg val: The value to find in the array
    :type val: `eltType`
-   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
-      data is sorted.
+   :arg comparator: :ref:`Comparator <comparators>` record that defines the
+       quality operation for the array data.
 
    :returns: A tuple indicating (1) if the value was found and (2) the location
-      of the value if it was found or the location where the value should have
-      been if it was not found.
+      of the value if it was found or ``Data.domain.high+1`` if it was not
+      found.
    :rtype: (`bool`, `Data.domain.type`)
 
  */
 proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator) where Dom.rank == 1 {
   chpl_check_comparator(comparator, Data.eltType);
-  for i in Dom {
+
+  for i in Dom do
     if chpl_compare(Data[i], val, comparator=comparator) == 0 then
       return (true, i);
-    else if chpl_compare(Data[i], val, comparator=comparator) > 0 then
-      return (false, i);
-  }
+
   return (false, Dom.high+1);
 }
 
@@ -131,6 +133,7 @@ pragma "no doc"
 
  */
 proc LinearSearch(Data:[?Dom], val) {
+  compilerWarning("LinearSearch() has been deprecated.  Please use linearSearch() instead");
   for i in Dom {
     if (Data(i) == val) {
       return (true, i);
@@ -165,6 +168,7 @@ pragma "no doc"
 
  */
 proc BinarySearch(Data:[?Dom], val, in lo = Dom.low, in hi = Dom.high) {
+  compilerWarning("BinarySearch() has been deprecated.  Please use binarySearch() instead");
   while (lo <= hi) {
     const mid = (hi - lo)/2 + lo;
     if (Data(mid) == val) {

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -118,8 +118,14 @@ proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator) where Dom
   return (false, lo);
 }
 
+
+/*
+    Deprecated Functions
+    TODO -- deprecate in 1.15
+ */
+
+
 pragma "no doc"
-// TODO -- deprecate
 /*
    Searches through the pre-sorted array `Data` looking for the value `val` using
    a sequential linear search.  Returns a tuple indicating (1) whether or not
@@ -146,9 +152,6 @@ proc LinearSearch(Data:[?Dom], val) {
 
 
 pragma "no doc"
-// would really like to drop the lo/hi arguments here, but right now
-// that causes too big of a memory leak
-// TODO -- deprecate
 /*
    Searches through the pre-sorted array `Data` looking for the value `val`
    using a sequential binary search.  If provided, only the indices `lo`

--- a/test/arrays/diten/timeVectorArray.chpl
+++ b/test/arrays/diten/timeVectorArray.chpl
@@ -70,14 +70,13 @@ class InsertRandom: Runner {
 // generate random numbers and put them in order in the array
 class InsertSorted: Runner {
   const n: int;
-  const linear: bool = false;
   proc run(A: [] int) {
     extern proc srand(int);
     extern proc rand(): int;
     srand(randSeed);
     for i in 1..linearN {
       const val = rand();
-      const (_, loc) = if linear then LinearSearch(A, val) else BinarySearch(A, val);
+      const (_, loc) = binarySearch(A, val);
       A.insert(loc, val);
     }
   }
@@ -181,7 +180,7 @@ proc main {
   assert(isSorted(A,linearN));
 
   r = new PopBack(); r.run(A); delete r; // clean up
-  r = new InsertSorted(n, false); output("InsertSL", timeRun(r,A)); delete r;
+  r = new InsertSorted(n); output("InsertSL", timeRun(r,A)); delete r;
   assert(isSorted(A,linearN));
 
   r = new Remove(n, true); output("RemoveFront", timeRun(r, A)); delete r;

--- a/test/distributions/robust/arithmetic/modules/test_module_Search.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Search.chpl
@@ -28,64 +28,64 @@ proc checkSearch(found, foundIdx, A, searchType) {
 
 writeln("Search array");
 reset(R1D);
-(found, foundIdx) = LinearSearch(R1D, elem);
-checkSearch(found, foundIdx, R1D, "LinearSearch");
+(found, foundIdx) = linearSearch(R1D, elem);
+checkSearch(found, foundIdx, R1D, "linearSearch");
 reset(R1D);
-(found, foundIdx) = BinarySearch(R1D, elem);
-checkSearch(found, foundIdx, R1D, "BinarySearch");
+(found, foundIdx) = binarySearch(R1D, elem);
+checkSearch(found, foundIdx, R1D, "binarySearch");
 
 writeln("Search aliased array");
 var aR1D => R1D;
 reset(R1D);
-(found, foundIdx) = LinearSearch(aR1D, elem);
-checkSearch(found, foundIdx, R1D, "LinearSearch");
+(found, foundIdx) = linearSearch(aR1D, elem);
+checkSearch(found, foundIdx, R1D, "linearSearch");
 reset(R1D);
-(found, foundIdx) = BinarySearch(aR1D, elem);
-checkSearch(found, foundIdx, R1D, "BinarySearch");
+(found, foundIdx) = binarySearch(aR1D, elem);
+checkSearch(found, foundIdx, R1D, "binarySearch");
 
 writeln("Search reindexed array");
 proc foo(D: domain, A: [D], useLinear=true) {
   if useLinear then
-    return LinearSearch(A, elem);
+    return linearSearch(A, elem);
   else
-    return BinarySearch(A, elem);
+    return binarySearch(A, elem);
 }
 const TD1D: domain(1) = Space1.translate(-o5);
 reset(R1D);
 (found, foundIdx) = foo(TD1D, R1D.reindex(TD1D));
-checkSearch(found, foundIdx+o5, R1D, "LinearSearch");
+checkSearch(found, foundIdx+o5, R1D, "linearSearch");
 reset(R1D);
 (found, foundIdx) = foo(TD1D, R1D.reindex(TD1D), false);
-checkSearch(found, foundIdx+o5, R1D, "BinarySearch");
+checkSearch(found, foundIdx+o5, R1D, "binarySearch");
 
 
 writeln("Search rank changed array (2D->1D)");
 var rc2DR1D =>  R2D(Dom2D.dim(1), n2-1);
 idx = Dom2D.dim(1).length/2+1;
 reset(rc2DR1D);
-(found, foundIdx) = LinearSearch(rc2DR1D, elem);
-checkSearch(found, foundIdx, rc2DR1D, "LinearSearch");
+(found, foundIdx) = linearSearch(rc2DR1D, elem);
+checkSearch(found, foundIdx, rc2DR1D, "linearSearch");
 reset(rc2DR1D);
-(found, foundIdx) = BinarySearch(rc2DR1D, elem);
-checkSearch(found, foundIdx, rc2DR1D, "BinarySearch");
+(found, foundIdx) = binarySearch(rc2DR1D, elem);
+checkSearch(found, foundIdx, rc2DR1D, "binarySearch");
 
 writeln("Search rank changed array (3D->1D)");
 var rc3DR1D =>  R3D(Dom3D.dim(1), n3-1, n3-1);
 idx = Dom3D.dim(1).length/2+1;
 reset(rc3DR1D);
-(found, foundIdx) = LinearSearch(rc3DR1D, elem);
-checkSearch(found, foundIdx, rc3DR1D, "LinearSearch");
+(found, foundIdx) = linearSearch(rc3DR1D, elem);
+checkSearch(found, foundIdx, rc3DR1D, "linearSearch");
 reset(rc3DR1D);
-(found, foundIdx) = BinarySearch(rc3DR1D, elem);
-checkSearch(found, foundIdx, rc3DR1D, "BinarySearch");
+(found, foundIdx) = binarySearch(rc3DR1D, elem);
+checkSearch(found, foundIdx, rc3DR1D, "binarySearch");
 
 writeln("Search rank changed array (4D->1D)");
 var rc4DR1D =>  R4D(Dom4D.dim(1), n4-1, n4-1, n4-1);
 idx = Dom4D.dim(1).length/2+1;
 reset(rc4DR1D);
-(found, foundIdx) = LinearSearch(rc4DR1D, elem);
-checkSearch(found, foundIdx, rc4DR1D, "LinearSearch");
+(found, foundIdx) = linearSearch(rc4DR1D, elem);
+checkSearch(found, foundIdx, rc4DR1D, "linearSearch");
 reset(rc4DR1D);
-(found, foundIdx) = BinarySearch(rc4DR1D, elem);
-checkSearch(found, foundIdx, rc4DR1D, "BinarySearch");
+(found, foundIdx) = binarySearch(rc4DR1D, elem);
+checkSearch(found, foundIdx, rc4DR1D, "binarySearch");
 

--- a/test/distributions/robust/arithmetic/modules/test_module_Search.good
+++ b/test/distributions/robust/arithmetic/modules/test_module_Search.good
@@ -1,18 +1,18 @@
 Search array
-	LinearSearch: SUCCESS
-	BinarySearch: SUCCESS
+	linearSearch: SUCCESS
+	binarySearch: SUCCESS
 Search aliased array
-	LinearSearch: SUCCESS
-	BinarySearch: SUCCESS
+	linearSearch: SUCCESS
+	binarySearch: SUCCESS
 Search reindexed array
-	LinearSearch: SUCCESS
-	BinarySearch: SUCCESS
+	linearSearch: SUCCESS
+	binarySearch: SUCCESS
 Search rank changed array (2D->1D)
-	LinearSearch: SUCCESS
-	BinarySearch: SUCCESS
+	linearSearch: SUCCESS
+	binarySearch: SUCCESS
 Search rank changed array (3D->1D)
-	LinearSearch: SUCCESS
-	BinarySearch: SUCCESS
+	linearSearch: SUCCESS
+	binarySearch: SUCCESS
 Search rank changed array (4D->1D)
-	LinearSearch: SUCCESS
-	BinarySearch: SUCCESS
+	linearSearch: SUCCESS
+	binarySearch: SUCCESS

--- a/test/modules/engin/pkg_module_res.chpl
+++ b/test/modules/engin/pkg_module_res.chpl
@@ -16,8 +16,8 @@ writeln(isSorted(arr));
 writeln(Sort.isSorted(arr));
 
 use Search;
-writeln(LinearSearch(arr,1));
+writeln(linearSearch(arr,1));
 
 //compilation doesn't come to this point but following line also fails when run
 //standalone
-writeln(Search.LinearSearch(arr,1));
+writeln(Search.linearSearch(arr,1));

--- a/test/modules/packages/Search/correctness.chpl
+++ b/test/modules/packages/Search/correctness.chpl
@@ -32,31 +32,31 @@ proc main() {
   checkSearch(result, (true, 3), StrArr, 'search');
 
   // Integers sorted as tuples
-  result = search(Arr, 2, comparator=tuplekey);
+  result = search(Arr, 2, comparator=tuplekey, sorted=true);
   checkSearch(result, (true, 3), Arr, 'search', 'tuplekey');
 
   /* Reverse */
 
   // Default reversecomparator
-  result = search(ArrRev, 2, comparator=reverseComparator);
+  result = search(ArrRev, 2, comparator=reverseComparator, sorted=true);
   checkSearch(result, (true, 2), ArrRev, 'search');
 
   /* Comparator basics */
-  result = search(ArrAbs, 2, comparator=key);
+  result = search(ArrAbs, 2, comparator=key, sorted=true);
   checkSearch(result, (true, 2), ArrAbs, 'search', 'key');
 
-  result = search(ArrAbs, 2, comparator=compare);
+  result = search(ArrAbs, 2, comparator=compare, sorted=true);
   checkSearch(result, (true, 2), ArrAbs, 'search', 'compare');
 
   /* Not Found */
 
-  result = search(Arr, 5);
+  result = search(Arr, 5, sorted=true);
   checkSearch(result, (false, Arr.domain.high+1), Arr, 'search');
 
-  result = search(Arr, -5);
+  result = search(Arr, -5, sorted=true);
   checkSearch(result, (false, Arr.domain.low), Arr, 'search');
 
-  result = search(Arr, 0);
+  result = search(Arr, 0, sorted=true);
   checkSearch(result, (false, 3), Arr, 'search');
 
   /* Test Searches */


### PR DESCRIPTION
Making finishing touches to Search module in preparation for 1.14 release.

Non-testing related changes are best viewed in this [commit](https://github.com/chapel-lang/chapel/commit/f03ced4b68381b9a6da82b56068be829acec778b).

### Changes include:

* **Interface changes**
  * `linearSearch()` now assumes the array is unsorted. If users are searching a pre-sorted array, they should use `binarySearch()`.
    * comparator support was left in for `linearSearch()` so that users can redefine how they want to check equality of array data without overloading `op==()` for their data type. This also keeps the `*Search()` interface consistent.
  * `search()` now supports a `sorted: bool` argument, which determines if it wraps `binarySearch()` (`sorted=true`), or `linearSearch()` (sorted=false, default value).
     * This affects all `search()` calls, since the new default behavior is to assume that the array is not pre-sorted, and thus it calls `linearSearch()` by default now instead of `binarySearch()`
  * The old `BinarySearch()` &&  `LinearSearch()` routines print a deprecation warning, and can be officially removed in 1.15.
* Documentation fixes that referred to Sort module instead of Search module
* Updated all the tests that use these interfaces.
   * Notably, removed an unused call to `linearSearch()` from `timeVectorArray.chpl`.

[*paratest sanity check completed*]

* 153 errors found - fixed [here](https://github.com/chapel-lang/chapel/pull/4273/commits/b63e309a731169e7d6d05187d19e48a00e97e670) and [here](https://github.com/chapel-lang/chapel/pull/4273/commits/fd17cb7c92cec64322d7c6ff4cc514a3e8865455)

[*second paratest  complete*]

* 0 errors