### PR TITLE
Test out the performance of qthreads "distrib" scheduler in the playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,15 +9,19 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of not ref coutning slices and reindexing
-GITHUB_USER=bradcray
-GITHUB_BRANCH=noRefCountArrViews
-SHORT_NAME=noRefCountArrViews
-START_DATE=07/18/16
+# Test performance qthreads WIP "distrib" scheduler
+export CHPL_QTHREAD_SCHEDULER=distrib
 
-git branch -D $GITHUB_USER-$GITHUB_BRANCH
-git checkout -b $GITHUB_USER-$GITHUB_BRANCH
-git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
+# hackily checkout and overlay qthreads branch that has the scheduler
+cd $CHPL_HOME/third-party/qthread/
+rm -rf qthread-1.10/
+git clone https://github.com/Qthreads/qthreads.git --branch distrib qthread-1.10/
+cd qthread-1.10/
+./autogen.sh
+cd $CWD
+
+SHORT_NAME=distrib
+START_DATE=08/03/16
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"


### PR DESCRIPTION
Test out the performance of the WIP "distrib" scheduler, which will hopefully
replace the sherwood scheduler. Start doing performance testing on it so we can
find performance issues sooner rather than later.