### PR TITLE
Allow setting CHPL_QTHREAD_SCHEDULER=distrib

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -125,7 +125,7 @@ qthread-build: FORCE
 ifeq ($(SCHEDULER),$(findstring $(SCHEDULER),lifo mtsfifo mutexfifo nemesis))
 SUPPORTS_REMOTE_CACHE = 1
 ONE_WORKER_PER_SHEPHERD = 1
-else ifeq ($(SCHEDULER),$(findstring $(SCHEDULER),nottingham sherwood))
+else ifeq ($(SCHEDULER),$(findstring $(SCHEDULER),distrib nottingham sherwood))
 SUPPORTS_REMOTE_CACHE = 0
 ONE_WORKER_PER_SHEPHERD = 0
 else


### PR DESCRIPTION
distrib is an upcoming/WIP scheduler. Add support for it to the code that
determines the number of workers per shepherd and whether remote cache is
supported in our qthreads Makefile.