### PR TITLE
Updating the warning to be used along with --incremental with optimisations enabled

### DIFF
--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -1489,9 +1489,12 @@ void codegen(void) {
       USR_WARN("C code generation for packed pointers not supported");
   }
 
-  if(fIncrementalCompilation && fFastFlag)
-    USR_WARN("Compiling with --incremental and --fast together can lead to "
-             "slower execution time than compiling with --fast only");
+  std::size_t optimizationsEnabled = ccflags.find("-O");
+  if(fIncrementalCompilation && ( fFastFlag||
+      optimizationsEnabled!=std::string::npos ))
+    USR_WARN("Compiling with --incremental along with optimizations enabled"
+              " may lead to a slower execution time compared to --fast or"
+              " using -O optimizations directly.");
 
   if( llvmCodegen ) {
 #ifndef HAVE_LLVM

--- a/test/compflags/kushal/fastAndIncremental.compopts
+++ b/test/compflags/kushal/fastAndIncremental.compopts
@@ -1,1 +1,3 @@
 --fast --incremental
+--ccflags=-O3 --incremental
+--incremental --ccflags=-O0

--- a/test/compflags/kushal/fastAndIncremental.good
+++ b/test/compflags/kushal/fastAndIncremental.good
@@ -1,3 +1,3 @@
-warning: Compiling with --incremental and --fast together can lead to slower execution time than compiling with --fast only
+warning: Compiling with --incremental along with optimizations enabled may lead to a slower execution time compared to --fast or using -O optimizations directly.
 Computing...
 2

--- a/util/test/prediff-for-incremental-warning
+++ b/util/test/prediff-for-incremental-warning
@@ -26,13 +26,13 @@ if(sys.argv[1] not in incrementalTests):
 try:
   goodFile = open(sys.argv[1]+".good", "r")
   for line in goodFile:
-      if(line == "warning: Compiling with --incremental and --fast together can lead to slower execution time than compiling with --fast only\n"):
+      if(line == "warning: Compiling with --incremental along with optimizations enabled may lead to a slower execution time compared to --fast or using -O optimizations directly.\n"):
         sys.exit(0)
 except IOError:
     print "Can't find "+sys.argv[1]+".good"
 
 # Matches the warning we are looking for
-pattern = re.compile("warning: Compiling with --incremental and --fast together can lead to slower execution time than compiling with --fast only")
+pattern = re.compile("warning: Compiling with --incremental along with optimizations enabled may lead to a slower execution time compared to --fast or using -O optimizations directly.")
 
 outfile = open(sys.argv[2], "r")
 realOut = open(sys.argv[2]+".tmp" , "w")


### PR DESCRIPTION
* Updating the USR_WARN displayed while using optimisations like --fast or --ccflags=-O3 etc.
* Updating the tests to reflect the new warning and changes.