### PR TITLE
USR_WARN for enabling optimizations along with --incremental

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1035,6 +1035,15 @@ static void checkTargetArch() {
   }
 }
 
+static void checkIncrementalAndOptimized() {
+  std::size_t optimizationsEnabled = ccflags.find("-O");
+  if(fIncrementalCompilation && ( optimizeCCode ||
+      optimizationsEnabled!=std::string::npos ))
+    USR_WARN("Compiling with --incremental along with optimizations enabled"
+              " may lead to a slower execution time compared to --fast or"
+              " using -O optimizations directly.");
+}
+
 static void postprocess_args() {
   // Processes that depend on results of passed arguments or values of CHPL_vars
 
@@ -1055,6 +1064,8 @@ static void postprocess_args() {
   checkLLVMCodeGen();
 
   checkTargetArch();
+
+  checkIncrementalAndOptimized();
 }
 
 int main(int argc, char* argv[]) {

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -1489,13 +1489,6 @@ void codegen(void) {
       USR_WARN("C code generation for packed pointers not supported");
   }
 
-  std::size_t optimizationsEnabled = ccflags.find("-O");
-  if(fIncrementalCompilation && ( fFastFlag||
-      optimizationsEnabled!=std::string::npos ))
-    USR_WARN("Compiling with --incremental along with optimizations enabled"
-              " may lead to a slower execution time compared to --fast or"
-              " using -O optimizations directly.");
-
   if( llvmCodegen ) {
 #ifndef HAVE_LLVM
     USR_FATAL("This compiler was built without LLVM support");

--- a/test/compflags/kushal/fastAndIncremental.compopts
+++ b/test/compflags/kushal/fastAndIncremental.compopts
@@ -1,3 +1,4 @@
 --fast --incremental
 --ccflags=-O3 --incremental
 --incremental --ccflags=-O0
+--incremental -O

--- a/util/test/prediff-for-incremental-warning
+++ b/util/test/prediff-for-incremental-warning
@@ -17,7 +17,11 @@ incrementalTests = ["time_iterate", "timeVectorArray", "time_access", "optimizeO
                     "access2d", "access3d", "ri-4-arrdom", "ri-4-arrdom.replicated", "ri-3-stress", "ri-3-stress-coforall", "assign",
                     "assign_across_locales", "copy_to_local", "dgemm", "init", "reductions-stress-fast", "sparse-iter-performance",
                     "externMethodCallPerf", "forVersusWhilePerf", "test_cholesky_performance", "mandelbrot-error-works",
-                    "mandelbrot-error", "atomic_bool", "atomic_vars", "ontest"]
+                    "mandelbrot-error", "atomic_bool", "atomic_vars", "ontest","uts_deq", "uts_rec", "dequeue", "sudoku-simple",
+                    "sudoku-simpler", "sudoku-smart", "sudoku", "leadFollowOpt", "ra-cleanloop", "ra-atomics", "ra", "test_for2d",
+                    "test_cgapb", "test_cgapb_loop", "cg-sparse-timecomp", "fft-timecomp", "ManyThreads", "ft-serial", "cg-sparse",
+                    "cg-printa", "cg-makea1-sparse-sort", "enumerated-array2", "enumerated-array", "formalDomainChecks3",
+                    "formalDomainChecks4", "no_atomic_assign"]
 
 if(sys.argv[1] not in incrementalTests):
     sys.exit(0)


### PR DESCRIPTION
* Switched to enabling warning for -O instead of --fast only.