### PR TITLE
string-as-rec compiler cleanup

### DIFF
--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -202,13 +202,7 @@ static bool isClassMethodCall(CallExpr* call) {
       if (fn->numFormals() > 0 &&
           fn->getFormal(1)->typeInfo() == fn->_this->typeInfo()) {
         if (isClass(ct) || ct->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-          // TODO: When strings are records, remove this protective if.
-          // isClassMethodCall is only used in insertNilChecks() and widened
-          // strings gain FLAG_WIDE_CLASS, but it doesn't make sense to check
-          // strings against nil.
-          if (strcmp(ct->symbol->name, "__wide_chpl_string")) {
-            return true;
-          }
+          return true;
         }
       }
     }


### PR DESCRIPTION
@lydia-duncan:

Lydia found a wide-pointer change that was left as a TODO in a string-as-rec world, which we now have. Gasnet testing came back clean.