### PR TITLE
Update Search interface to include args: lo, hi

### DIFF
--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -138,9 +138,9 @@ module DefaultSparse {
       // sjd: unfortunate specialization for rank == 1
       //
       if rank == 1 && isTuple(ind) && ind.size == 1 then
-        return binarySearch(indices[1..nnz], ind(1));
+        return binarySearch(indices, ind(1), lo=1, hi=nnz);
       else
-        return binarySearch(indices[1..nnz], ind);
+        return binarySearch(indices, ind, lo=1, hi=nnz);
     }
 
     proc dsiMember(ind) { // ind should be verified to be index type

--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -234,7 +234,7 @@ class CSRDom: BaseSparseDom {
 
     const (row, col) = ind;
 
-    return binarySearch(colIdx[rowStart(row)..rowStop(row)], col);
+    return binarySearch(colIdx, col, lo=rowStart(row), hi=rowStop(row));
   }
 
   proc dsiMember(ind: rank*idxType) {

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -96,6 +96,7 @@ proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=
 proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=Dom.high) where Dom.rank == 1 {
   chpl_check_comparator(comparator, Data.eltType);
 
+  // Domain slicing is cheap, but avoiding it when possible helps performance
   if lo == Dom.low && hi == Dom.high {
     for i in Dom do
       if chpl_compare(Data[i], val, comparator=comparator) == 0 then

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -70,12 +70,18 @@ proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, sorted=false) w
    :rtype: (`bool`, `Data.domain.type`)
 
  */
-proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator) where Dom.rank == 1 {
+proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo = Dom.low, hi = Dom.high) where Dom.rank == 1 {
   chpl_check_comparator(comparator, Data.eltType);
 
-  for i in Dom do
-    if chpl_compare(Data[i], val, comparator=comparator) == 0 then
-      return (true, i);
+  if lo == Dom.low && hi == Dom.high {
+    for i in Dom do
+      if chpl_compare(Data[i], val, comparator=comparator) == 0 then
+        return (true, i);
+  else {
+    for i in Dom[lo..hi] do
+      if chpl_compare(Data[i], val, comparator=comparator) == 0 then
+        return (true, i);
+  }
 
   return (false, Dom.high+1);
 }
@@ -102,9 +108,7 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator) where Dom
    :rtype: (`bool`, `Data.domain.type`)
 
  */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator) where Dom.rank == 1 {
-  var lo = Dom.low,
-      hi = Dom.high;
+proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo = Dom.low, in hi = Dom.high) where Dom.rank == 1 {
 
   while (lo <= hi) {
     const mid = (hi - lo)/2 + lo;

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -64,9 +64,9 @@ module Search {
  */
 proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=Dom.high, sorted=false) where Dom.rank == 1 {
   if sorted then
-    return binarySearch(Data, val, comparator);
+    return binarySearch(Data, val, comparator, lo, hi);
   else
-    return linearSearch(Data, val, comparator);
+    return linearSearch(Data, val, comparator, lo, hi);
 }
 
 

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -18,13 +18,27 @@
  */
 
 /*
-   The `Search` module is designed to support standard search routines.
+   The `Search` module is designed to support standard search routines on 1D
+   arrays
  */
 module Search {
   use Sort;
 
+
 /*
-   General purpose searching interface for searching through a 1-D array.
+  A note about lo/hi arguments:
+
+  These args were kept in the interface since passing sliced arrays is
+  (currently) very expensive, and many fundamental module codes depend on
+  passing sliced arrays to binarySearch. For interface consistency, other
+  search algorithms also support lo/hi arguments.
+
+  TODO -- add performance testing for Search algorithms, and compare
+          passing sliced arrays vs. unsliced arrays with lo/hi args
+*/
+
+/*
+   General purpose searching interface for searching through a 1D array.
    For pre-sorted arrays, denoted by passing ``sorted=true`` as an argument,
    this function wraps :proc:`binarySearch`, otherwise it wraps
    :proc`linearSearch`.
@@ -34,16 +48,21 @@ module Search {
    :arg val: The value to find in the array
    :type val: `eltType`
    :arg comparator: :ref:`Comparator <comparators>` record that defines how the
-      data is sorted.
-   :arg sorted: Indicate if the array is pre-sorted
+      data is sorted, and the equality operation for the array data.
+   :arg lo: The lowest index to consider while searching
+   :type lo: `Dom.idxType`
+   :arg hi: The highest index to consider while searching
+   :type hi: `Dom.idxType`
+   :arg sorted: Indicate if the array is pre-sorted, determining which search
+      algorithm to call
    :type sorted: `bool`
 
    :returns: A tuple indicating (1) if the value was found and (2) the location
       of the value if it was found or the location where the value should have
       been if it was not found.
-   :rtype: (`bool`, `Data.domain.type`)
+   :rtype: (`bool`, `Dom.idxType`)
  */
-proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, sorted=false) where Dom.rank == 1 {
+proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=Dom.high, sorted=false) where Dom.rank == 1 {
   if sorted then
     return binarySearch(Data, val, comparator);
   else
@@ -62,22 +81,26 @@ proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, sorted=false) w
    :arg val: The value to find in the array
    :type val: `eltType`
    :arg comparator: :ref:`Comparator <comparators>` record that defines the
-       quality operation for the array data.
+       equality operation for the array data.
+   :arg lo: The lowest index to consider while searching
+   :type lo: `Dom.idxType`
+   :arg hi: The highest index to consider while searching
+   :type hi: `Dom.idxType`
 
    :returns: A tuple indicating (1) if the value was found and (2) the location
       of the value if it was found or ``Data.domain.high+1`` if it was not
       found.
-   :rtype: (`bool`, `Data.domain.type`)
+   :rtype: (`bool`, `Dom.idxType`)
 
  */
-proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo = Dom.low, hi = Dom.high) where Dom.rank == 1 {
+proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=Dom.high) where Dom.rank == 1 {
   chpl_check_comparator(comparator, Data.eltType);
 
   if lo == Dom.low && hi == Dom.high {
     for i in Dom do
       if chpl_compare(Data[i], val, comparator=comparator) == 0 then
         return (true, i);
-  else {
+  } else {
     for i in Dom[lo..hi] do
       if chpl_compare(Data[i], val, comparator=comparator) == 0 then
         return (true, i);
@@ -101,23 +124,28 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo = Dom.
    :type val: `eltType`
    :arg comparator: :ref:`Comparator <comparators>` record that defines how the
       data is sorted.
+   :arg lo: The lowest index to consider while searching
+   :type lo: `Dom.idxType`
+   :arg hi: The highest index to consider while searching
+   :type hi: `Dom.idxType`
 
    :returns: A tuple indicating (1) if the value was found and (2) the location
       of the value if it was found or the location where the value should have
       been if it was not found.
-   :rtype: (`bool`, `Data.domain.type`)
+   :rtype: (`bool`, `Dom.idxType`)
 
  */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo = Dom.low, in hi = Dom.high) where Dom.rank == 1 {
+proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high) where Dom.rank == 1 {
+  chpl_check_comparator(comparator, Data.eltType);
 
   while (lo <= hi) {
     const mid = (hi - lo)/2 + lo;
     if chpl_compare(Data[mid], val, comparator=comparator) == 0 then
       return (true, mid);
     else if chpl_compare(val, Data[mid], comparator=comparator) > 0 then
-      lo = mid+1;
+      lo = mid + 1;
     else
-      hi = mid-1;
+      hi = mid - 1;
   }
   return (false, lo);
 }

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -149,6 +149,8 @@ all:
   08/03/16:
     - text: Hardware upgrade
       config: 16 node XC, Single node XC
+  08/04/16:
+    - Updates to Search module, required array slicing (partially reverted) (#4273)
 
 AllCompTime:
   11/09/14:


### PR DESCRIPTION
Dropping the `lo` and `hi` args from `binarySearch`  back in #4273 added a requirement for some performance critical module code to pass sliced arrays into `binarySearch`. This caused a surprisingly large performance hit across a surprisingly wide range of tests.

This PR re-implements the `lo` / `hi` arguments, and adds the functionality to all search routines for interface consistency. The performance critical module code no longer passes sliced arrays, the performance regression has been annotated, and new comments describe why we now support these arguments.

*[paratest passed]*