### PR TITLE
support for SPMD MPI mode in the mpirun launcher

### DIFF
--- a/runtime/src/launch/mpirun/launch-mpirun.c
+++ b/runtime/src/launch/mpirun/launch-mpirun.c
@@ -23,53 +23,64 @@
 #include "chpl-mem.h"
 #include "error.h"
 
+#define CHPL_MPI_NUM_RANKS "--mpi-num-ranks"
 
-static char* chpl_launch_create_command(int argc, char* argv[], 
-                                        int32_t numLocales) {
-  int i;
-  int size;
-  char baseCommand[256];
-  char* command;
+static char* mpi_num_ranks=NULL;
 
-  chpl_compute_real_binary_name(argv[0]);
+static char _nlbuf[16];
+static char** chpl_launch_create_argv(const char *launch_cmd,
+                                      int argc, char* argv[],
+                                      int32_t numLocales) {
+  const int largc = 3;
+  char *largv[largc];
 
-  sprintf(baseCommand, "mpirun -np %d %s %s", numLocales, MPIRUN_XTRA_OPTS, 
-          chpl_get_real_binary_name());
-
-  size = strlen(MPIRUN_PATH) + 1 + strlen(baseCommand) + 1;
-
-  for (i=1; i<argc; i++) {
-    size += strlen(argv[i]) + 3;
-  }
-
-  command = chpl_mem_allocMany(size, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+  int numranks;
   
-  sprintf(command, "%s/%s", MPIRUN_PATH, baseCommand);
-  for (i=1; i<argc; i++) {
-    strcat(command, " '");
-    strcat(command, argv[i]);
-    strcat(command, "'");
+  // Get the number of ranks
+  // TODO -- if we want, we can also use an environment variable, although
+  // that's probably overkill for this.
+  if (mpi_num_ranks==NULL) {
+    numranks = numLocales;
+  } else {
+    numranks = atoi(mpi_num_ranks);
   }
 
-  if (strlen(command)+1 > size) {
-    chpl_internal_error("buffer overflow");
-  }
+  largv[0] = (char *) launch_cmd;
+  largv[1] = (char *) "-np";
+  sprintf(_nlbuf, "%d", numranks);
+  largv[2] = _nlbuf;
 
-  return command;
+  return chpl_bundle_exec_args(argc, argv, largc, largv);
 }
-
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  return chpl_launch_using_system(chpl_launch_create_command(argc, argv, numLocales),
-                                  argv[0]);
+  char *cmd = "mpirun";
+
+  return chpl_launch_using_exec(cmd,
+                                chpl_launch_create_argv(cmd, argc, argv,
+                                                        numLocales),
+                                argv[0]);
 }
+
 
 
 int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
                            int32_t lineno, int32_t filename) {
+  // handle --mpi-num-ranks <nrank> or --mpi-num-ranks=<nrank>
+  if (!strcmp(argv[argNum], CHPL_MPI_NUM_RANKS)) {
+    mpi_num_ranks = argv[argNum+1];
+    return 2;
+  } else if (!strncmp(argv[argNum], CHPL_MPI_NUM_RANKS"=", strlen(CHPL_MPI_NUM_RANKS))) {
+    mpi_num_ranks = &(argv[argNum][strlen(CHPL_MPI_NUM_RANKS)+1]);
+    return 1;
+  }
+
   return 0;
 }
 
 
 void chpl_launch_print_help(void) {
+  fprintf(stdout, "LAUNCHER FLAGS:\n");
+  fprintf(stdout, "===============\n");
+  fprintf(stdout, "  %s : specify number of MPI ranks (default : numLocales)\n", CHPL_MPI_NUM_RANKS);
 }


### PR DESCRIPTION
Add an --mpi-num-ranks option to the mpirun launcher to allow for SPMD Chapel programs over MPI.

Note that we switch from using system() to exec*() for the call to avoid a hang in start_test with Ubuntu.

This is part of the effort to set up testing for the MPI module; separating this out for simplicity...