### PR TITLE
Disable bulk transfer support for SparseBlockDist

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -855,7 +855,7 @@ proc SparseBlockArr.dsiPrivatize(privatizeData) {
   return c;
 }
 
-proc SparseBlockArr.dsiSupportsBulkTransfer() param return true;
+proc SparseBlockArr.dsiSupportsBulkTransfer() param return false;
 
 proc SparseBlockArr.doiCanBulkTransfer() {
   if dom.stridable then
@@ -869,6 +869,8 @@ proc SparseBlockArr.doiCanBulkTransfer() {
   return true;
 }
 
+// TODO This function needs to be fixed. For now, explicitly returning false
+// from dsiSupportsBulkTransfer, so this function should never be compiled
 proc SparseBlockArr.doiBulkTransfer(B) {
   if debugSparseBlockDistBulkTransfer then resetCommDiagnostics();
   var sameDomain: bool;

--- a/test/distributions/engin/SparseBlock/spsblkAssignment.chpl
+++ b/test/distributions/engin/SparseBlock/spsblkAssignment.chpl
@@ -1,0 +1,13 @@
+use BlockDist;
+
+const space = {1..10};
+const par1 = space dmapped Block(space);
+const par2 = space dmapped Block(space);
+
+var sps1: sparse subdomain(par1);
+var sps2: sparse subdomain(par2);
+
+var arr1: [sps1] int;
+var arr2: [sps2] int;
+
+arr1 = arr2;


### PR DESCRIPTION
SparseBulkArr.doiBulkTransfer does not compile and needs some work.
This PR disables bulk transfer support for now, so that sparse block array
assignments can compile correctly.

Also adds a test that wouldn't compile before.

Passed full correctness with standard and GASNet configs. Will be merged on Monday.