### PR TITLE
Revcomp cleanup

### DIFF
--- a/test/release/examples/benchmarks/shootout/revcomp.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp.chpl
@@ -68,12 +68,11 @@ proc process(data, start, end) {
 proc initTable(pairs) {
   var table: [1..128] uint(8);
 
-  for i in 1..pairs.length do
-    if i%2 {
-      table[ascii(pairs[i])] = ascii(pairs[i+1]):uint(8);
-      if pairs[i] != "\n" then
-        table[ascii(pairs[i].toLower())] = ascii(pairs[i+1]):uint(8);
-    }
+  for i in 1..pairs.length by 2 {
+    table[ascii(pairs[i])] = ascii(pairs[i+1]):uint(8);
+    if pairs[i] != "\n" then
+      table[ascii(pairs[i].toLower())] = ascii(pairs[i+1]):uint(8);
+  }
 
   return table;
 }

--- a/test/release/examples/benchmarks/shootout/revcomp.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp.chpl
@@ -23,18 +23,18 @@ proc main(args: [] string) {
     while stdinNoLock.readline(data, numRead, idx) {
       if data[idx] == ascii(">") {       // is this the start of a section?
 
-        // spawn a task to process the previous section, if there was one
+        // spawn a task to process the previous sequence, if there was one
         if start then
           begin process(data, start, idx-2);     // -2 == rewind past "\n>"
 
-        // capture the start of this section
+        // capture the start of this sequence
         start = idx + numRead;
       }
 
       idx += numRead; 
     }
 
-    // process the final section
+    // process the final sequence
     if start then
       process(data, start, idx-2);
   }

--- a/test/release/examples/benchmarks/shootout/revcomp.execopts
+++ b/test/release/examples/benchmarks/shootout/revcomp.execopts
@@ -1,1 +1,2 @@
 --n=0 < fasta-revcomp.small
+--n-0 < /dev/null           # revcomp-empty.good

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -21,19 +21,22 @@ proc main(args: [] string) {
     var numRead: int;
 
     while stdinNoLock.readline(data, numRead, idx) {
-      // Look for the start of a section
-      if data[idx] == ascii(">") {
-        if start then 
-          // Spawn a task to work on the previous section
-          begin process(data, start, idx-2);
-        
-        start = idx;
+      if data[idx] == ascii(">") {       // is this the start of a section?
+
+        // spawn a task to process the previous sequence, if there was one
+        if start then
+          begin process(data, start, idx-2);     // -2 == rewind past "\n>"
+
+        // capture the start of this sequence
+        start = idx + numRead;
       }
+
       idx += numRead; 
     }
 
-    // work on the final section
-    process(data, start, idx-2);
+    // process the final sequence
+    if start then
+      process(data, start, idx-2);
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
@@ -42,12 +45,7 @@ proc main(args: [] string) {
 }
 
 
-proc process(data, in start, end) {
-  // Skip the header information
-  while data[start] != ascii("\n") do 
-    start += 1;
-  start += 1;
-
+proc process(data, start, end) {
   const extra = (end - start) % columns,
         off = columns - extra - 1;
 


### PR DESCRIPTION
These are primarily cosmetic changes, though there is also a change to guard against an array OOB error if the input file is empty or has no sections.

The cosmetic changes are oriented towards trying to clarify the logic related to finding sections / sequences within the file and skipping past the section header proactively rather than having the process() routine simply skip past the first line.

I added an execopts line to test the case when the input file is empty.  We don't expect this to happen in practice, but it could if the input file was badly formatted.

These changes were motivated by debugging testing failures last night, but do not address them.  Those failures were due to consoleIn.length() returning 0 and the solution is still TBD pending further discussion.