### PR TITLE
Fix readline(array)'s use of "amount"

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4078,7 +4078,7 @@ proc channel.read(ref args ...?k,
 
 // documented in the error= version
 pragma "no doc"
-proc channel.readline(arg: [] uint(8), out numRead : int, start = arg.domain.low, amount = arg.domain.high - start) : bool
+proc channel.readline(arg: [] uint(8), out numRead : int, start = arg.domain.low, amount = arg.domain.high - start + 1) : bool
 where arg.rank == 1 && isRectangularArr(arg)
 {
   var e:syserr = ENOERR;
@@ -4104,20 +4104,20 @@ where arg.rank == 1 && isRectangularArr(arg)
               will halt with an error message.
   :returns: true if the bytes were read without error.
 */
-proc channel.readline(arg: [] uint(8), out numRead : int, start = arg.domain.low, amount = arg.domain.high - start, out error:syserr) : bool
+proc channel.readline(arg: [] uint(8), out numRead : int, start = arg.domain.low, amount = arg.domain.high - start + 1, out error:syserr) : bool
 where arg.rank == 1 && isRectangularArr(arg)
 {
   error = ENOERR;
 
   // Make sure the arguments are valid
-  if arg.size == 0 || !arg.domain.member(start) || amount <= 0 || (start + amount > arg.domain.high)  then return false;
+  if arg.size == 0 || !arg.domain.member(start) || amount <= 0 || (start + amount - 1 > arg.domain.high)  then return false;
 
   on this.home {
     this.lock();
     param newLineChar = 0x0A;
     var got : int;
     var i = start;
-    const maxIdx = start + amount;
+    const maxIdx = start + amount - 1;
     while i <= maxIdx {
       got = qio_channel_read_byte(false, this._channel_internal);
       arg[i] = got:uint(8);

--- a/test/io/cassella/readline.chpl
+++ b/test/io/cassella/readline.chpl
@@ -1,0 +1,71 @@
+/*
+ * Tests that readline(array, amount=) returns the number of bytes we
+ * asked for, and that readline(array) will read the right number of
+ * bytes.
+ */
+
+
+// I can't figure out how to get from uint(8) to a string.
+// So do the comparison the other way around.
+proc check_expected(data, expected:string, len) {
+  for i in 1..min(len, expected.length) {
+    var n = data[i];
+    var c = expected[i];
+    if n != ascii(c) {
+      writeln("miscompare at ", i, ": expected ", c, " (", ascii(c), "), got ", n);
+    }
+  }
+
+  if len < expected.length {
+    writeln("Short read -- expected ", expected.length, " bytes, got ", len);
+  } else if len > expected.length {
+    writeln("Got extra ", len - expected.length, " bytes: ");
+    writeln(data[expected.length+1..len]);
+  }
+}
+
+/*
+ * Read amount bytes from input into an array[1..10], and check that
+ * the result is expected.  If amount is -1, allow readline() to use
+ * its default values for start and amount, but the result should
+ * still match expected.
+ */
+proc test_readline(amount: int, input: string, expected: string) {
+  /* Write input string to f, so we can readline() it out */
+  var f = openmem();
+  var w = f.writer();
+
+  w.writeln(input);
+
+  var r = f.reader();
+  var ret: bool;
+  var numRead: int;
+
+
+  var data: [1..10] uint(8);
+  if amount >= 0 {
+    ret = r.readline(data, numRead, start=1, amount=amount);
+  } else {
+    ret = r.readline(data, numRead);
+  }
+
+  var invoke_string = if amount >= 0 then "readline(amount="+amount+")" else
+					    "readline()";
+
+  if (!ret) {
+    writeln(invoke_string, " failed");
+  } else {
+    writeln(invoke_string," returned ", numRead, " bytes");
+    if numRead != expected.length then
+      writeln("but we expected ", expected.length, " bytes");
+    check_expected(data, expected, numRead);
+  }
+}
+
+test_readline(9, "foop", "foop\n");
+test_readline(9,  "We apologize for the inconvenience", "We apolog");
+test_readline(10, "Share and Enjoy", "Share and ");
+
+// Test that readline's formal's defaults fill the array.
+// This should give us 10 bytes.
+test_readline(-1, "Your Plastic Pal Who's Fun To Be With", "Your Plast");

--- a/test/io/cassella/readline.good
+++ b/test/io/cassella/readline.good
@@ -1,0 +1,4 @@
+readline(amount=9) returned 5 bytes
+readline(amount=9) returned 9 bytes
+readline(amount=10) returned 10 bytes
+readline() returned 10 bytes


### PR DESCRIPTION
readline(array, amount=1)

should read 1 byte, not 2.  And it shouldn't fail if array has exactly
1 element.

Add a few test cases.