### PR TITLE
Use qthreads master branch for testing "distrib" scheduler

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -15,7 +15,7 @@ export CHPL_QTHREAD_SCHEDULER=distrib
 # hackily checkout and overlay qthreads branch that has the scheduler
 cd $CHPL_HOME/third-party/qthread/
 rm -rf qthread-1.10/
-git clone https://github.com/Qthreads/qthreads.git --branch distrib qthread-1.10/
+git clone https://github.com/Qthreads/qthreads.git qthread-1.10/
 cd qthread-1.10/
 ./autogen.sh
 cd $CWD


### PR DESCRIPTION
The "distrib" scheduler is now on the master branch, so just use that instead
of checking out the "distrib" branch