### PR TITLE
Yield less frequently in meteor's testAndSet lock

### DIFF
--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -351,8 +351,33 @@ proc searchLinearHelper(in board, in pos, in used, in placed,
 }
 
 
-// Atomic used as mutex for recordSolution()
-var l: atomic bool;
+//
+// Exponential backoff spin-wait lock that yields every so many contested locks
+// to avoid potentially starving other tasks. This results in slightly faster
+// runtime than just using a sync var because it has lower latency.
+//
+record BackoffSpinLock {
+  var l: atomic bool;
+      lockAttempts: uint;
+      maxLockAttempts = (2**16-1): uint;
+
+  inline proc lock() {
+    while l.testAndSet() {
+      lockAttempts += 1;
+      if (lockAttempts & maxLockAttempts) == 0 {
+        maxLockAttempts >>= 1;
+        chpl_task_yield();
+      }
+    }
+  }
+
+  inline proc unlock() {
+    l.clear();
+  }
+}
+
+// Minimally contended lock that serializes calls to recordSolution()
+var recordSolutionLock: BackoffSpinLock;
 
 
 //
@@ -363,15 +388,9 @@ proc searchLinear(in board, in pos, in used, in placed, currentSolution) {
       s1, s2, s3, s4, s5, s6, s7, s8: int;
 
   if placed == numPieces {
-
-    // lock
-    while l.testAndSet() do chpl_task_yield();
-
+    recordSolutionLock.lock();
     recordSolution(currentSolution);
-
-    // unlock
-    l.clear();
-
+    recordSolutionLock.unlock();
   } else {
     evenRows = evenRowsLookup[pos];
 


### PR DESCRIPTION
In meteor-parallel-alt we use a testAndSet lock to serialize/protect calls to
recordSolution(). Normally we'd just use a syncvar as a lock, but that hurts
performance for this insanely fast benchmark. The lock has minimal contention
and sync vars are best for highly contended locks. In this case using as sync
var almost doubles the execution time.

Previously a testAndSet loop with a yield every failed lock attempt was used.
Unfortunately this isn't ideal either, because yielding will lead to
unnecessary work and cache misses. Ideally we'd just do a pure testAndSet loop
without yielding, but that's not possible. Under qthreads (a non preemptive
scheduler) if some other thing (like memory tracking) yields the qthread, then
a plain testAndSet lock will deadlock, so we need to yield at some point to
avoid starvation.

For meteor-parallel-alt on the shootout machine, we need to spin `~2**16` times
before yielding to avoid yielding under perf runs. Unfortunately, that makes
meteor take ~300 seconds with memory tracking turned on. Basically if memory
tracking yields the qthread, we have to wait for all ~1,000 tasks to spin wait
2**16 times to reschedule the task that needs to unlock the lock.

To work around these problems, this patch uses an exponential backoff lock that
decreases the number of lockAttempts until the next yield. This gives us the
best performance (.065 seconds compared to a previous .08 seconds) while still
allowing memory tracking to finish quickly (.2 seconds.) This should put us in
the top 5 for the shootout entries.