### PR TITLE
Fix function resolution unexecuted code

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7555,12 +7555,8 @@ insertCasts(BaseAST* ast, FnSymbol* fn, Vec<CallExpr*>& casts) {
                   tmp = se->var;
                 } else {
                   tmp = newTemp("_cast_tmp_", rhs->typeInfo());
-                  DefExpr* def = new DefExpr(tmp);
-                  call->insertBefore(def);
-                  resolveExpr(def);
-                  CallExpr* newMove = new CallExpr(PRIM_MOVE, tmp, rhs->copy());
-                  call->insertBefore(newMove);
-                  resolveExpr(newMove);
+                  call->insertBefore(new DefExpr(tmp));
+                  call->insertBefore(new CallExpr(PRIM_MOVE, tmp, rhs->copy()));
                 }
                 CallExpr* cast = new CallExpr("_cast", lhsType->symbol, tmp);
                 rhs->replace(cast);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7564,7 +7564,6 @@ insertCasts(BaseAST* ast, FnSymbol* fn, Vec<CallExpr*>& casts) {
                 }
                 CallExpr* cast = new CallExpr("_cast", lhsType->symbol, tmp);
                 rhs->replace(cast);
-                resolveExpr(cast);
                 casts.add(cast);
               }
             }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7555,11 +7555,16 @@ insertCasts(BaseAST* ast, FnSymbol* fn, Vec<CallExpr*>& casts) {
                   tmp = se->var;
                 } else {
                   tmp = newTemp("_cast_tmp_", rhs->typeInfo());
-                  call->insertBefore(new DefExpr(tmp));
-                  call->insertBefore(new CallExpr(PRIM_MOVE, tmp, rhs));
+                  DefExpr* def = new DefExpr(tmp);
+                  call->insertBefore(def);
+                  resolveExpr(def);
+                  CallExpr* newMove = new CallExpr(PRIM_MOVE, tmp, rhs->copy());
+                  call->insertBefore(newMove);
+                  resolveExpr(newMove);
                 }
                 CallExpr* cast = new CallExpr("_cast", lhsType->symbol, tmp);
                 rhs->replace(cast);
+                resolveExpr(cast);
                 casts.add(cast);
               }
             }


### PR DESCRIPTION
In my initializers work, I went down into this else branch in function
resolution's insertCasts() and discovered that this branch did not properly
execute on its own.  The PRIM_MOVE inserted tried to use a AST node which was
already in the AST (as was made clear by the ->replace() call which followed
the else branch) and that is an error in our compiler.

After fixing that, there was a complaint about encountering a use before
resolving the def, because  the DefExpr inserted in that else branch never
had resolve called on it (nor did any of the other Exprs inserted in this entire
branch).  This failure was likely due to a bug on my end, as Michael pointed
out he had encountered the first error (AST node already in tree) but not the
use before def error and I was able to compile equally correctly with his change
or mine + the resolveExprs.  So I removed the resolveExprs from the final PR
(but left the history in, in any someone discovers we do want to do this in the
future).

I don't think any of this is executed, but since I'm running into it now, it
seems reasonable to try to maintain it.  I'm still encountering bugs in my code
- if more of them seem to be related to this else branch being stale, I will
make further fixes.

Tested over std with no issues, and I'm no longer encountering a problem
with it in my branch.