### PR TITLE
Stop printing "Error" when tags utility isn't found for make in modules

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -26,7 +26,7 @@ endif
 
 # Generate tags command, dependent on if Make variable, TAGS == 1
 ifeq ($(TAGS), 1)
-TAGS_COMMAND=-@($(CHPL_MAKE_HOME)/util/chpltags -r . > /dev/null 2>&1 && echo "Updating TAGS..." || true)
+TAGS_COMMAND=-@($(CHPL_MAKE_HOME)/util/chpltags -r . > /dev/null 2>&1 && echo "Updating TAGS..." || echo "Tags utility not available.  Skipping tags generation.")
 endif
 
 CHPL_MAKE_HOST_TARGET = --target

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -26,7 +26,7 @@ endif
 
 # Generate tags command, dependent on if Make variable, TAGS == 1
 ifeq ($(TAGS), 1)
-TAGS_COMMAND=-@($(CHPL_MAKE_HOME)/util/chpltags -r . > /dev/null 2>&1 && echo "Updating TAGS...")
+TAGS_COMMAND=-@($(CHPL_MAKE_HOME)/util/chpltags -r . > /dev/null 2>&1 && echo "Updating TAGS..." || true)
 endif
 
 CHPL_MAKE_HOST_TARGET = --target


### PR DESCRIPTION
If CHPL_DEVELOPER is on, then if there isn't a tags utility that our build
system knows how to use, then the last step of building from $CHPL_HOME:
"cd modules && make" prints "make[2]: [all] Error 1 (ignored)" or similar
as the last line of output from a successful build.  This is confusing.

Add " || true" to the command that causes the error, so it is silently
ignored instead of confusingly ignored.