### PR TITLE
CHAPDEV-10: fixes for #4249, and more new job scripts

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -39,9 +39,12 @@
 
 #define CHPL_WALLTIME_FLAG "--walltime"
 #define CHPL_PARTITION_FLAG "--partition"
+#define CHPL_EXCLUDE_FLAG "--exclude"
 
+static char* debug = NULL;
 static char* walltime = NULL;
 static char* partition = NULL;
+static char* exclude = NULL;
 char slurmFilename[FILENAME_MAX];
 char expectFilename[FILENAME_MAX];
 char sysFilename[FILENAME_MAX];
@@ -123,10 +126,12 @@ static void genNumLocalesOptions(FILE* slurmFile, sbatchVersion sbatch,
 
   // command line partition takes precedence over env var
   if (!partition) {
-    partition = getenv("SALLOC_PARTITION");
+    partition = getenv("CHPL_LAUNCHER_PARTITION");
   }
-  if (!partition) {
-    partition = getenv("SLURM_PARTITION");
+
+  // command line exclude list takes precedence over env var
+  if (!exclude) {
+    exclude = getenv("CHPL_LAUNCHER_EXCLUDE");
   }
 
   /*
@@ -137,6 +142,8 @@ static void genNumLocalesOptions(FILE* slurmFile, sbatchVersion sbatch,
     fprintf(slurmFile, "#SBATCH --time=%s\n", walltime);
   if (partition)
     fprintf(slurmFile, "#SBATCH --partition=%s\n", partition);
+  if (exclude)
+    fprintf(slurmFile, "#SBATCH --exclude=%s\n", exclude);
   switch (sbatch) {
 /* Only slurm has been tested
   case slurmpro:
@@ -193,17 +200,19 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
   // command line partition takes precedence over env var
   if (!partition) {
-    partition = getenv("SALLOC_PARTITION");
-  }
-  if (!partition) {
-    partition = getenv("SLURM_PARTITION");
+    partition = getenv("CHPL_LAUNCHER_PARTITION");
   }
 
-#ifndef DEBUG_LAUNCH
-  mypid = getpid();
-#else
-  mypid = 0;
-#endif
+  // command line exclude list takes precedence over env var
+  if (!exclude) {
+    exclude = getenv("CHPL_LAUNCHER_EXCLUDE");
+  }
+
+  if (debug) {
+    mypid = 0;
+  } else {
+    mypid = getpid();
+  }
   sprintf(sysFilename, "%s%d", baseSysFilename, (int)mypid);
   sprintf(expectFilename, "%s%d", baseExpectFilename, (int)mypid);
   sprintf(slurmFilename, "%s%d", baseSBATCHFilename, (int)mypid);
@@ -250,6 +259,8 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   fprintf(expectFile, "--time=%s ",walltime); 
   if(partition)
     fprintf(expectFile, "--partition=%s ",partition);
+  if(exclude)
+    fprintf(expectFile, "--exclude=%s ",exclude);
   if (constraint) {
     fprintf(expectFile, " -C %s", constraint);
   }
@@ -290,27 +301,28 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 }
 
 static void chpl_launch_cleanup(void) {
-#ifndef DEBUG_LAUNCH
-  char command[1024];
-
-  if (getenv("CHPL_LAUNCHER_USE_SBATCH") == NULL) {
-    sprintf(command, "rm %s", expectFilename);
-    system(command);
-  } else {
-    sprintf(command, "rm %s", slurmFilename);
-    system(command);
-    sprintf(command, "rm %s", sysFilename);
-    system(command);
+  if (!debug) {
+    char command[1024];
+    if (getenv("CHPL_LAUNCHER_USE_SBATCH") == NULL) {
+      sprintf(command, "rm %s", expectFilename);
+      system(command);
+    } else {
+      sprintf(command, "rm %s", slurmFilename);
+      system(command);
+      sprintf(command, "rm %s", sysFilename);
+      system(command);
+    }
   }
-
-#endif
 }
 
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  int retcode =
-    chpl_launch_using_system(chpl_launch_create_command(argc, argv, numLocales),
-                             argv[0]);
+  int retcode;
+
+  debug = getenv("CHPL_LAUNCHER_DEBUG");
+
+  retcode = chpl_launch_using_system(chpl_launch_create_command(argc, argv, numLocales),
+            argv[0]);
   chpl_launch_cleanup();
   return retcode;
 }
@@ -336,6 +348,15 @@ int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
     partition = &(argv[argNum][strlen(CHPL_PARTITION_FLAG)+1]);
     return 1;
   }
+
+  // handle --exclude <nodes> or --exclude=<nodes>
+  if (!strcmp(argv[argNum], CHPL_EXCLUDE_FLAG)) {
+    exclude = argv[argNum+1];
+    return 2;
+  } else if (!strncmp(argv[argNum], CHPL_EXCLUDE_FLAG"=", strlen(CHPL_EXCLUDE_FLAG))) {
+    exclude = &(argv[argNum][strlen(CHPL_EXCLUDE_FLAG)+1]);
+    return 1;
+  }
   return 0;
 }
 
@@ -346,5 +367,7 @@ void chpl_launch_print_help(void) {
   fprintf(stdout, "  %s <HH:MM:SS> : specify a wallclock time limit\n", CHPL_WALLTIME_FLAG);
   fprintf(stdout, "                           (or use $CHPL_LAUNCHER_WALLTIME)\n");
   fprintf(stdout, "  %s <partition> : specify a partition to use\n", CHPL_PARTITION_FLAG);
-  fprintf(stdout, "                           (or use $SALLOC_PARTITION)\n");
+  fprintf(stdout, "                           (or use $CHPL_LAUNCHER_PARTITION)\n");
+  fprintf(stdout, "  %s <nodes> : specify node(s) to exclude\n", CHPL_EXCLUDE_FLAG);
+  fprintf(stdout, "                           (or use $CHPL_LAUNCHER_EXCLUDE)\n");
 }

--- a/util/cron/common-numa.bash
+++ b/util/cron/common-numa.bash
@@ -3,6 +3,6 @@
 # Configure environment for numa testing. This should be sourced by other
 # scripts that wish to make use of the variables set here.
 
-source $(cd $(dirname $0) ; pwd)/common-qthreads.bash
+source $(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)/common-qthreads.bash
 
 export CHPL_LOCALE_MODEL=numa

--- a/util/cron/common-slurm-gasnet-ibv.bash
+++ b/util/cron/common-slurm-gasnet-ibv.bash
@@ -20,8 +20,6 @@ nightly_args=-no-buildcheck
 
 # host-specific
 export CHPL_TARGET_ARCH=native
-export SALLOC_PARTITION=chapel
-export SLURM_PARTITION=chapel
+export CHPL_LAUNCHER_PARTITION=chapel
 export GASNET_PHYSMEM_MAX=16G
 export GASNET_PHYSMEM_NOPROBE=1
-

--- a/util/cron/test-slurm-gasnet-ibv.everything.bash
+++ b/util/cron/test-slurm-gasnet-ibv.everything.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Test gasnet (segment everything) against full suite on linux64.
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-slurm-gasnet-ibv.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.everything"
+
+export GASNET_QUIET=Y
+
+# Test a GASNet compile using the default segment (everything for linux64)
+export CHPL_GASNET_SEGMENT=everything
+
+$CWD/nightly -cron -no-futures ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.everything.bash
+++ b/util/cron/test-slurm-gasnet-ibv.everything.bash
@@ -13,4 +13,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron -no-futures ${nightly_args} < /dev/null
+$CWD/nightly -cron -futures ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.everything.bash
+++ b/util/cron/test-slurm-gasnet-ibv.everything.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Test gasnet (segment everything) against full suite on linux64.
+# Multi-node, multi-locale testing on a linux64 cluster with slurm-gasnetrun_ibv launcher:
+# test gasnet (segment everything) against full suite.
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-ibv.bash

--- a/util/cron/test-slurm-gasnet-ibv.fast.bash
+++ b/util/cron/test-slurm-gasnet-ibv.fast.bash
@@ -13,4 +13,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the fast segment
 export CHPL_GASNET_SEGMENT=fast
 
-$CWD/nightly -cron -no-futures ${nightly_args} < /dev/null
+$CWD/nightly -cron ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.fast.bash
+++ b/util/cron/test-slurm-gasnet-ibv.fast.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Test gasnet (segment fast) against full suite on linux64.
+# Multi-node, multi-locale testing on a linux64 cluster with slurm-gasnetrun_ibv launcher:
+# test gasnet (segment fast) against full suite.
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-ibv.bash

--- a/util/cron/test-slurm-gasnet-ibv.fast.bash
+++ b/util/cron/test-slurm-gasnet-ibv.fast.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Test gasnet (segment fast) against full suite on linux64.
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-slurm-gasnet-ibv.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.fast"
+
+export GASNET_QUIET=Y
+
+# Test a GASNet compile using the fast segment
+export CHPL_GASNET_SEGMENT=fast
+
+$CWD/nightly -cron -no-futures ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.hellos.bash
+++ b/util/cron/test-slurm-gasnet-ibv.hellos.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Multi-node, multi-locale testing on a linux64 cluster with slurm-gasnetrun_ibv launcher.
+# Multi-node, multi-locale testing on a linux64 cluster with slurm-gasnetrun_ibv launcher:
+# runs "hello" example programs, only.
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-ibv.bash

--- a/util/cron/test-slurm-gasnet-ibv.llvm.bash
+++ b/util/cron/test-slurm-gasnet-ibv.llvm.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Test gasnet configuration with CHPL_LLVM=llvm and pass --llvm flag to
-# compiler on linux64.
+# Multi-node, multi-locale testing on a linux64 cluster with slurm-gasnetrun_ibv launcher:
+# test gasnet configuration with CHPL_LLVM=llvm and pass --llvm flag to compiler.
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-ibv.bash

--- a/util/cron/test-slurm-gasnet-ibv.llvm.bash
+++ b/util/cron/test-slurm-gasnet-ibv.llvm.bash
@@ -9,4 +9,4 @@ source $CWD/common-llvm.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.llvm"
 
-$CWD/nightly -cron -no-futures -examples ${nightly_args} < /dev/null
+$CWD/nightly -cron -examples ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.llvm.bash
+++ b/util/cron/test-slurm-gasnet-ibv.llvm.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test gasnet configuration with CHPL_LLVM=llvm and pass --llvm flag to
+# compiler on linux64.
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-slurm-gasnet-ibv.bash
+source $CWD/common-llvm.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.llvm"
+
+$CWD/nightly -cron -no-futures -examples ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.numa.bash
+++ b/util/cron/test-slurm-gasnet-ibv.numa.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Test numa locale model with comm=gasnet on multilocale and examples.
+# Multi-node, multi-locale testing on a linux64 cluster with slurm-gasnetrun_ibv launcher:
+# test numa locale model with comm=gasnet on multilocale and examples.
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-ibv.bash

--- a/util/cron/test-slurm-gasnet-ibv.numa.bash
+++ b/util/cron/test-slurm-gasnet-ibv.numa.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Test numa locale model with comm=gasnet on multilocale and examples.
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-slurm-gasnet-ibv.bash
+source $CWD/common-numa.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.numa"
+
+export GASNET_QUIET=Y
+
+$CWD/nightly -cron -multilocale -no-futures ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.numa.bash
+++ b/util/cron/test-slurm-gasnet-ibv.numa.bash
@@ -11,4 +11,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.numa"
 
 export GASNET_QUIET=Y
 
-$CWD/nightly -cron -multilocale -no-futures ${nightly_args} < /dev/null
+$CWD/nightly -cron -multilocale ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.quickstart.bash
+++ b/util/cron/test-slurm-gasnet-ibv.quickstart.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Test quickstart + gasnet configuration on full suite on linux64.
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-quickstart.bash
+source $CWD/common-slurm-gasnet-ibv.bash # must come after quickstart source
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.quickstart"
+
+export GASNET_QUIET=Y
+
+$CWD/nightly -cron -no-futures -multilocale ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.quickstart.bash
+++ b/util/cron/test-slurm-gasnet-ibv.quickstart.bash
@@ -4,6 +4,11 @@
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-quickstart.bash
+
+echo "before: CHPL_MEM='$CHPL_MEM'" >&2
+unset CHPL_MEM  # avoid error: set CHPL_MEM to a more appropriate mem type (from mem-cstdlib.c)
+echo "after:  CHPL_MEM='$CHPL_MEM'" >&2
+
 source $CWD/common-slurm-gasnet-ibv.bash # must come after quickstart source
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.quickstart"

--- a/util/cron/test-slurm-gasnet-ibv.quickstart.bash
+++ b/util/cron/test-slurm-gasnet-ibv.quickstart.bash
@@ -14,4 +14,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron -no-futures -multilocale ${nightly_args} < /dev/null
+$CWD/nightly -cron -multilocale ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-ibv.quickstart.bash
+++ b/util/cron/test-slurm-gasnet-ibv.quickstart.bash
@@ -1,18 +1,17 @@
 #!/usr/bin/env bash
 #
-# Test quickstart + gasnet configuration on full suite on linux64.
+# Multi-node, multi-locale testing on a linux64 cluster with slurm-gasnetrun_ibv launcher:
+# test quickstart + gasnet configuration on full suite.
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-quickstart.bash
-
-echo "before: CHPL_MEM='$CHPL_MEM'" >&2
-unset CHPL_MEM  # avoid error: set CHPL_MEM to a more appropriate mem type (from mem-cstdlib.c)
-echo "after:  CHPL_MEM='$CHPL_MEM'" >&2
-
 source $CWD/common-slurm-gasnet-ibv.bash # must come after quickstart source
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.quickstart"
 
 export GASNET_QUIET=Y
+
+# Test a GASNet compile using the default segment (everything for linux64)
+export CHPL_GASNET_SEGMENT=everything
 
 $CWD/nightly -cron -no-futures -multilocale ${nightly_args} < /dev/null


### PR DESCRIPTION
This PR extends work begun in PR #4249 (Multi-node multi-locale chapel on linux64 cluster with slurm/gasnet), as follows:
- post-merge review comments from PR #4249 are incorporated here
- new util/cron job scripts added for slurm-gasnet-ibv.everything, .fast, .llvm, .quickstart, and .numa correctness tests.
- slurm-gasnetrun_ibv and slurm-srun launchers honor "CHPL_LAUNCHER_EXCLUDE" env variable ("\-\-exclude" cmdline parameter), by passing the value through to the generated SLURM command.  This "--exclude" pass-through is useful to prevent multi-node multi-locale Chapel tests from contending for the "login" node and possibly blocking other slurm-gasnet-ibv.\* correctness tests. 
- slurm-gasnetrun_ibv launcher honors "CHPL_LAUNCHER_DEBUG" environment variable. Easier to use than the previous \#ifdef DEBUG.