### PR TITLE
Test distrib scheduler against sherwood scheduler in playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,7 +9,7 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance qthreads WIP "distrib" scheduler
+# Test perf of qthreads WIP "distrib" scheduler compared to nemesis
 export CHPL_QTHREAD_SCHEDULER=distrib
 
 # hackily checkout and overlay qthreads branch that has the scheduler
@@ -21,8 +21,18 @@ cd qthread-1.10/
 cd $CWD
 
 SHORT_NAME=distrib
-START_DATE=08/03/16
+START_DATE=08/08/16
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"
+$CWD/nightly -cron ${perf_args} ${nightly_args}
+
+
+# Test perf of qthreads WIP "distrib" scheduler with numa against sherwood
+source $CWD/common-numa.bash
+SHORT_NAME=numa-distrib
+export CHPL_TEST_TIMEOUT=600
+
+perf_args="-performance-description $SHORT_NAME -performance-configs numa:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
+perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"
 $CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
We're already doing CHPL_LOCALE_MODEL=flat testing of distrib vs. nemesis, this
just adds CHPL_LOCALE_MODEL=numa testing of distrib vs. sherwood.