### PR TITLE
Ensure formals' types are retained.

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9205,7 +9205,37 @@ static void clearDefaultInitFns(FnSymbol* unusedFn) {
   }
 }
 
+// Avoid pruning arg types in removeUnusedTypes() by resolving their
+// type constructor. Be sure to do so before the latter is pruned.
+// Todo: in addition to args, do the same for VarSymbols? FnSymbols?
+static void ensureResolvedArgTypeConstructors() {
+  forv_Vec(ArgSymbol, arg, gArgSymbols)
+    if (arg->inTree())
+      if (AggregateType* ct = toAggregateType(arg->type))
+        if (ct->defaultTypeConstructor &&
+            // Is there a type constructor that needs to be resolved?
+            !ct->defaultTypeConstructor->isResolved() &&
+            // Do not interfer with these. See also isUnusedClass().
+            !isReferenceType(ct) &&
+            !ct->symbol->hasFlag(FLAG_GLOBAL_TYPE_SYMBOL) &&
+            !ct->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE) &&
+            !ct->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
+            !ct->symbol->hasFlag(FLAG_ITERATOR_CLASS))
+          // Concern with args only in functions. (Can args happen elsewhere?)
+          if (FnSymbol* fn = toFnSymbol(arg->defPoint->parentSymbol))
+            // Unresolved and generic functions will be pruned.
+            if (fn->isResolved() &&
+                !fn->hasFlag(FLAG_GENERIC))
+              {
+                INT_ASSERT(!ct->symbol->hasFlag(FLAG_GENERIC));
+                SET_LINENO(ct);
+                resolveFns(ct->defaultTypeConstructor);
+              }
+}
+
 static void removeUnusedFunctions() {
+  ensureResolvedArgTypeConstructors();
+
   // Remove unused functions
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     if (fn->hasFlag(FLAG_PRINT_MODULE_INIT_FN)) continue;

--- a/test/classes/vass/no-instance-for-arg-type.chpl
+++ b/test/classes/vass/no-instance-for-arg-type.chpl
@@ -1,0 +1,32 @@
+// The class type of an argument has no instances.
+
+class Monkey1 {}
+proc proc1(arg: Monkey1) { writeln("in proc1"); }
+proc1(nil);
+
+class Monkey2 {}
+var var2: Monkey2 = nil;
+
+class Monkey3 {}
+var var3: Monkey3 = nil;
+writeln(var3);
+
+class Monkey4 {}
+class Horse4: Monkey4 {}
+proc proc4(arg: Monkey4) { writeln("in proc4"); }
+proc4(nil);
+
+class Monkey5 {}
+class Horse5: Monkey5 {}
+proc proc5(arg: Horse5) { writeln("in proc5"); }
+proc5(nil);
+
+class Monkey6 {}
+class Horse6 {
+  proc proc6(arg: Monkey6) { writeln("in proc6"); }
+}
+(new Horse6()).proc6(nil);
+
+class Monkey7 { type T7; }
+proc proc7(arg: Monkey7) { writeln("in proc7"); }
+proc7(nil: Monkey7(int));

--- a/test/classes/vass/no-instance-for-arg-type.good
+++ b/test/classes/vass/no-instance-for-arg-type.good
@@ -1,0 +1,6 @@
+in proc1
+nil
+in proc4
+in proc5
+in proc6
+in proc7


### PR DESCRIPTION
In the following code:

  class MyType {}
  proc test(arg:MyType) {}
  test(nil);

where MyType is otherwise unused, e.g. no instances or subclasses of
it are created, MyType used to get pruned during resolution by
removeUnusedTypes() because isUnusedClass() would return true for it.

This changes adds a sweep of formals to ensure that isUnusedClass()
returns false for MyType in the above example. To do so, I ensure
that ct->defaultTypeConstructor is resolved.

I also considered these alternatives:

* Add another flag like "this type is used" and have isUnusedClass()
check for this flag. ==> I was happier to find a solution that
does not require a new flag.

* Mark MyType with FLAG_GLOBAL_TYPE_SYMBOL. ==> This flag
seems to apply only to predefined types, I did not want to mess
with that.

By contrast, resolving defaultTypeConstructor seems benign
and makes sense as in "the type is used so the type constructor
may as well be usable".

I placed the sweep of formals, aka ensureResolvedArgTypeConstructors(),
earlier that removeUnusedTypes - at start of removeUnusedFunctions().
Otherwise the latter observes that the defaultTypeConstructor is
unresolved and prunes it. We could re-insert it into the AST if that
happens, however we'd need to know where, and that gets lost when the
function is removed from AST.

Doing the sweep before functions are pruned may result in
us tending to a formal of a function that will end up pruned.
I think this is OK and in practice will not be a big deal.

In writing ensureResolvedArgTypeConstructors(), I considered
the following issues:

* Its placement - see above.

* Which functions' arguments to ignore - I added the checks
until it worked. The functions must be non-generic and
have been resolved. In retrospect, the test for non-genericity
is not needed: generic functions are never resolved.

* What types not to deal with. I ignored most types that
isUnusedClass() already returns false for. The types
I would still consider are ones that have subclasses.
This should be not a big deal.

* Given that most formals will not need the adjustment,
what is the order of checks that will allow us to detect
that the fastest - to reduce the amount of time we spend
in the sweep.

The bug was reported by Vitali Baumtrok.

Passes full suite under linux64 and SSCA2 under gasnet.