### PR TITLE
Sync as record

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -87,7 +87,6 @@ bool Type::isDefaultIntentConst() const {
 
   if (symbol->hasFlag(FLAG_DEFAULT_INTENT_IS_REF) == true ||
       isReferenceType(this)                       == true ||
-      isSyncType(this)                            == true ||
       isSingleType(this)                          == true ||
       isRecordWrappedType(this)                   == true)
     retval = false;

--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -332,7 +332,19 @@ static void updateTaskArg(Map<Symbol*, Vec<SymExpr*>*>& useMap,
 
 
 static bool isSyncSingleMethod(FnSymbol* fn) {
-  return fn->_this && (isSyncType(fn->_this->type) || isSingleType(fn->_this->type));
+
+  bool retval = false;
+
+  if (fn->_this != NULL) {
+    Type* valType = fn->_this->getValType();
+
+    if  (isSyncType(valType)   == true ||
+         isSingleType(valType) == true) {
+      retval = true;
+    }
+  }
+
+  return retval;
 }
 
 /************************************* | **************************************

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1000,7 +1000,7 @@ static void build_type_constructor(AggregateType* ct) {
 // which is also called by user-defined constructors to pre-initialize all
 // fields to their declared or type-specific initial values.
 static void build_constructor(AggregateType* ct) {
-  if (isSyncType(ct) || isSingleType(ct)) {
+  if (isSingleType(ct)) {
     ct->defaultValue = NULL;
   }
 
@@ -1059,9 +1059,7 @@ static void build_constructor(AggregateType* ct) {
   CallExpr*  superCall = NULL;
   CallExpr*  allocCall = NULL;
 
-  if (ct->symbol->hasFlag(FLAG_REF) ||
-      isSyncType(ct)                ||
-      isSingleType(ct)) {
+  if (ct->symbol->hasFlag(FLAG_REF) || isSingleType(ct)) {
     // For ref, sync and single classes, just allocate space.
     allocCall = callChplHereAlloc(fn->_this);
 

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -545,7 +545,14 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
               (rhsFn->hasFlag(FLAG_AUTO_COPY_FN) == true ||
                rhsFn->hasFlag(FLAG_INIT_COPY_FN) == true))
           {
-            copyExpr = rhsCall;
+            ArgSymbol* formalArg  = rhsFn->getFormal(1);
+            Type*      formalType = formalArg->type;
+
+            // Cannot reduce initCopy/autoCopy for sync variables
+            if (isSyncType(formalType) == false)
+            {
+              copyExpr = rhsCall;
+            }
           }
         }
       }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1393,7 +1393,8 @@ bool canCoerce(Type*     actualType,
   }
 
   if (isSyncType(actualType) || isSingleType(actualType)) {
-    Type* baseType = actualType->getField("base_type")->type;
+    Type* baseType = actualType->getField("valType")->type;
+
     return canDispatch(baseType, NULL, formalType, fn, promotes);
   }
 
@@ -2524,13 +2525,13 @@ static bool considerParamMatches(Type* actualType,
     }
 
     if (isSyncType(actualType)) {
-      return considerParamMatches(actualType->getField("base_type")->type,
+      return considerParamMatches(actualType->getField("valType")->type,
                                   arg1Type,
                                   arg2Type);
     }
 
     if (isSingleType(actualType)) {
-      return considerParamMatches(actualType->getField("base_type")->type,
+      return considerParamMatches(actualType->getField("valType")->type,
                                   arg1Type,
                                   arg2Type);
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4798,8 +4798,7 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
     if (concreteIntent(formal->intent, formalType) & INTENT_FLAG_CONST) {
       tmp->addFlag(FLAG_CONST);
 
-      if (!isSyncType(formalType)   &&
-          !isSingleType(formalType) &&
+      if (!isSingleType(formalType) &&
           !isRefCountedType(formalType))
         tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
     }
@@ -4888,7 +4887,6 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
        if (!getRecordWrappedFlags(ts).any()   &&
            !ts->hasFlag(FLAG_ITERATOR_CLASS)  &&
            !ts->hasFlag(FLAG_ITERATOR_RECORD) &&
-           !isSyncType(ts->type)              &&
            !isSingleType(ts->type)) {
          if (fn->hasFlag(FLAG_BEGIN)) {
            // autoCopy/autoDestroy will be added later, in parallel pass
@@ -8650,7 +8648,6 @@ static void resolveAutoCopies() {
       continue; // Skip the "dmapped" pseudo-type.
 
     if (isRecord(ts->type)   ||
-        isSyncType(ts->type) ||
         isSingleType(ts->type)) {
       resolveAutoCopy(ts->type);
       resolveAutoDestroy(ts->type);

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -234,8 +234,7 @@ static void createShadowVars(DefExpr* defChplIter, SymbolMap& uses,
         // See e.g. parallel/taskPar/figueroa/taskParallel.chpl
         pruneit = true;
 
-      } else if (isSyncType(ovar->type)   ||
-                 isSingleType(ovar->type) ||
+      } else if (isSingleType(ovar->type) ||
                  isAtomicType(ovar->type)) {
         // Currently we need it because sync variables do not get tupled
         // and detupled properly when threading through the leader iterator.

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -174,7 +174,6 @@ buildDefaultWrapper(FnSymbol* fn,
 
   bool specializeDefaultConstructor =
     fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR) &&
-    !isSyncType(fn->_this->type)          &&
     !isSingleType(fn->_this->type)        &&
     !fn->_this->type->symbol->hasFlag(FLAG_REF);
   if (specializeDefaultConstructor) {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3285,7 +3285,12 @@ module ChapelArray {
     chpl__tupleInit(j, a.rank, b);
   }
 
-  proc _desync(type t) where t: _syncvar || t: _singlevar {
+  proc _desync(type t) where t: _syncvar {
+    var x: t;
+    return x.syncVar.value;
+  }
+
+  proc _desync(type t) where t: _singlevar {
     var x: t;
     return x.value;
   }

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -64,10 +64,6 @@ module ChapelReduce {
     proc unlock() {
       lock$.readFE();
     }
-
-    proc ~ReduceScanOp() {
-
-    }
   }
   
   class SumReduceScanOp: ReduceScanOp {

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -66,7 +66,7 @@ module ChapelReduce {
     }
 
     proc ~ReduceScanOp() {
-      delete lock$;
+
     }
   }
   

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -111,89 +111,110 @@ module ChapelSyncvar {
         delete syncVar;
     }
 
-    /*
-      Resets the value of this sync variable to the default value of
-      its type. This method is non-blocking and the state of the sync
-      variable is set to empty when this method completes.
-    */
-    proc reset() {
-      syncVar.reset();
-    }
-
-    /*
-       Determine if the sync variable is full without blocking.
-       Does not alter the state of the sync variable
-
-       :returns: true if the state of the sync variable is full.
-    */
-    proc isFull {
-      return syncVar.isFull;
-    }
-
-    /*
-      1) Block until the sync variable is full.
-      2) Read the value of the sync variable and set the variable to empty.
-
-      :returns: The value of the sync variable.
-    */
-    proc readFE() {
-      return syncVar.readFE();
-    }
-
-    /*
-      1) Block until the sync variable is full.
-      2) Read the value of the sync variable and leave the variable full
-
-      :returns: The value of the sync variable.
-    */
-    proc readFF() {
-      return syncVar.readFF();
-    }
-
-    /*
-      1) Read the value of the sync variable
-      2) Do not inspect or change the full/empty state
-
-      :returns: The value of the sync variable.
-    */
-    proc readXX() {
-      return syncVar.readXX();
-    }
-
-    /*
-      1) Block until the sync variable is empty.
-      2) Write the value of the sync variable and leave the variable full
-    */
-    proc writeEF(x : valType) {
-      syncVar.writeEF(x);
-    }
-
-    /*
-      1) Block until the sync variable is full.
-      2) Write the value of the sync variable and leave the variable full
-    */
-    proc writeFF(x : valType) {
-      syncVar.writeFF(x);
-    }
-
-    /*
-      1) Write the value of the sync variable and leave the variable full
-    */
-    proc writeXF(x : valType) {
-      syncVar.writeXF(x);
-    }
-
-    // Do not allow implicit reads of sync/single vars.
-    pragma "no doc"
+    // Do not allow implicit reads of sync vars.
     proc readThis(x) {
       compilerError("sync variables cannot currently be read - use writeEF/writeFF instead");
     }
 
-    // Do not allow implicit writes of sync/single vars.
-    pragma "no doc"
+    // Do not allow implicit writes of sync vars.
     proc writeThis(x) {
       compilerError("sync variables cannot currently be written - apply readFE/readFF() to those variables first");
-    }
+     }
+  }
+
+  /*
+     Noakes 2016/08/10
+
+     These are defined as secondary methods so that chpldoc can render the
+     documentation
+  */
+
+  pragma "no doc"
+  proc isSyncType(type t) param where t : _syncvar {
+    return true;
+  }
+
+  /* Returns true if `t` is a sync type, false otherwise. */
+  proc isSyncType(type t) param {
+    return false;
+  }
+
+  /*
+    1) Block until the sync variable is full.
+    2) Read the value of the sync variable and set the variable to empty.
+
+    :returns: The value of the sync variable.
+  */
+  proc _syncvar.readFE() {
+    return syncVar.readFE();
+  }
+
+  /*
+    1) Block until the sync variable is full.
+    2) Read the value of the sync variable and leave the variable full
+
+    :returns: The value of the sync variable.
+  */
+  proc _syncvar.readFF() {
+    return syncVar.readFF();
+  }
+
+  /*
+    1) Read the value of the sync variable
+    2) Do not inspect or change the full/empty state
+
+    :returns: The value of the sync variable.
+  */
+  proc _syncvar.readXX() {
+    return syncVar.readXX();
+  }
+
+  /*
+    1) Block until the sync variable is empty.
+    2) Write the value of the sync variable and leave the variable full
+
+    :arg val: New value of the sync variable.
+  */
+  proc _syncvar.writeEF(x : valType) {
+    syncVar.writeEF(x);
+  }
+
+  /*
+    1) Block until the sync variable is full.
+    2) Write the value of the sync variable and leave the variable full
+
+    :arg val: New value of the sync variable.
+  */
+  proc _syncvar.writeFF(x : valType) {
+    syncVar.writeFF(x);
+  }
+
+  /*
+    1) Write the value of the sync variable and leave the variable full
+
+    :arg val: New value of the sync variable.
+  */
+  proc _syncvar.writeXF(x : valType) {
+    syncVar.writeXF(x);
+  }
+
+  /*
+    Resets the value of this sync variable to the default value of
+    its type. This method is non-blocking and the state of the sync
+    variable is set to empty when this method completes.
+  */
+  proc _syncvar.reset() {
+    syncVar.reset();
+  }
+
+  /*
+     Determine if the sync variable is full without blocking.
+     Does not alter the state of the sync variable
+
+     :returns: true if the state of the sync variable is full.
+  */
+  proc _syncvar.isFull {
+    return syncVar.isFull;
   }
 
   proc   = (ref lhs : _syncvar(?t), rhs : t) {
@@ -269,14 +290,6 @@ module ChapelSyncvar {
   pragma "no doc"
   proc chpl__readXX(x : _syncvar(?)) return x.readXX();
 
-  proc isSyncType(type t) param where t : _syncvar {
-    return true;
-  }
-
-  proc isSyncType(type t) param {
-    return false;
-  }
-
   proc <=>(lhs: _syncvar, ref rhs) {
     const tmp = lhs;
 
@@ -308,6 +321,7 @@ module ChapelSyncvar {
   ************************************* | ************************************/
 
   // Implementation is target dependent and opaque to Chapel code
+  pragma "no doc"
   extern record chpl_sync_aux_t { };
 
   extern proc   chpl_sync_initAux(ref aux : chpl_sync_aux_t);
@@ -614,16 +628,16 @@ module ChapelSyncvar {
   }
 
 
-  // Do not allow implicit reads of sync/single vars.
+  // Do not allow implicit reads of single vars.
   pragma "no doc"
   proc _singlevar.readThis(x) {
-    compilerError("single/sync variables cannot currently be read - use writeEF/writeFF instead");
+    compilerError("single variables cannot currently be read - use writeEF/writeFF instead");
   }
 
-  // Do not allow implicit writes of sync/single vars.
+  // Do not allow implicit writes of single vars.
   pragma "no doc"
   proc _singlevar.writeThis(x) {
-    compilerError("single/sync variables cannot currently be written - apply readFF/readFE() to those variables first");
+    compilerError("single variables cannot currently be written - apply readFF/readFE() to those variables first");
   }
 
   pragma "dont disable remote value forwarding"

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -37,257 +37,480 @@ for the state transition, one is non-deterministically selected to proceed and
 the others continue to wait if it is a sync variable; all tasks are selected to
 proceed if it is a single variable.
 */
+
 module ChapelSyncvar {
   use MemConsistency;
 
-  pragma "no doc"
-  inline proc chpl__readXX(x: sync) return x.readXX();
-  pragma "no doc"
-  inline proc chpl__readXX(x: single) return x.readXX();
-  pragma "no doc"
-  inline proc chpl__readXX(x) return x;
+  /************************************ | *************************************
+  *                                                                           *
+  * The implementation of the user-facing sync/single types are exposed to    *
+  * the compiler as a pair of record-wrapped classes.                         *
+  *                                                                           *
+  * The record implements the compiler facing API and manages the memory      *
+  * associated with the underlying class while the class provides the         *
+  * identity behavior required for the semantics of sync/single.              *
+  *                                                                           *
+  ************************************* | ************************************/
 
-  proc chpl_ensureFEType(type t) {
-    //
-    // The following types are OK for full empty types (sync/single)
-    // because they represent a single logical value.  (Note that for
-    // the class it's the reference to the object that has full/empty
-    // semantics.  Note that this includes the internal type
-    // chpl_taskID_t in order to keep parallel/taskPar/sungeun/private.chpl
-    // working, but this does not seem to be more broadly necessary.
-    //
-    if !(isVoidType(t) || isBoolType(t) || isIntegralType(t) || 
-         isEnumType(t) || isFloatType(t) || isStringType(t) || 
-         isClassType(t) || t == chpl_taskID_t) {
-      //
-      // TODO: compilerError() does not seem to be propagating up to
-      // the user-level modules... it should, shouldn't it?
-      //
-      compilerError("sync/single types cannot be of type '", t:string, "'");
+  //
+  // The following types are OK for full empty types (sync/single)
+  // because they represent a single logical value.  (Note that for
+  // the class it's the referenece to the object that has full/empty
+  // semantics.  Note that this includes the internal type
+  // chpl_taskID_t in order to keep parallel/taskPar/sungeun/private.chpl
+  // working, but this does not seem to be more broadly necessary.
+  //
+
+  private proc isSupported(type t) param
+    return isVoidType(t)          ||
+           isBoolType(t)          ||
+           isIntegralType(t)      ||
+           isRealType(t)          ||
+           isImagType(t)          ||
+           isEnumType(t)          ||
+           isClassType(t)         ||
+           isStringType(t)        ||    // Should this be allowed?
+           t == chpl_taskID_t;
+
+  private proc ensureFEType(type t) {
+    if isSupported(t) == false then
+      compilerError("sync/single types cannot be of type '", t : string, "'");
+  }
+
+  /************************************ | *************************************
+  *                                                                           *
+  * The record wrapper to implement sync                                      *
+  *                                                                           *
+  ************************************* | ************************************/
+
+  pragma "sync"
+  pragma "default intent is ref"
+  pragma "no doc"
+  record _syncvar {
+    type valType;                              // The compiler knows this name
+
+    var  syncVar : _synccls(valType) = nil;
+    var  isOwned : bool              = true;
+
+    proc _syncvar(type valType) {
+      ensureFEType(valType);
+
+      syncVar = new _synccls(valType);
+      isOwned = true;
+    }
+
+    proc _syncvar(type valType, other : _syncvar(valType)) {
+      ensureFEType(valType);
+
+      syncVar = other.syncVar;
+      isOwned = false;
+    }
+
+    proc ~_syncvar() {
+      if isOwned == true then
+        delete syncVar;
+    }
+
+    /*
+      Resets the value of this sync variable to the default value of
+      its type. This method is non-blocking and the state of the sync
+      variable is set to empty when this method completes.
+    */
+    proc reset() {
+      syncVar.reset();
+    }
+
+    /*
+       Determine if the sync variable is full without blocking.
+       Does not alter the state of the sync variable
+
+       :returns: true if the state of the sync variable is full.
+    */
+    proc isFull {
+      return syncVar.isFull;
+    }
+
+    /*
+      1) Block until the sync variable is full.
+      2) Read the value of the sync variable and set the variable to empty.
+
+      :returns: The value of the sync variable.
+    */
+    proc readFE() {
+      return syncVar.readFE();
+    }
+
+    /*
+      1) Block until the sync variable is full.
+      2) Read the value of the sync variable and leave the variable full
+
+      :returns: The value of the sync variable.
+    */
+    proc readFF() {
+      return syncVar.readFF();
+    }
+
+    /*
+      1) Read the value of the sync variable
+      2) Do not inspect or change the full/empty state
+
+      :returns: The value of the sync variable.
+    */
+    proc readXX() {
+      return syncVar.readXX();
+    }
+
+    /*
+      1) Block until the sync variable is empty.
+      2) Write the value of the sync variable and leave the variable full
+    */
+    proc writeEF(x : valType) {
+      syncVar.writeEF(x);
+    }
+
+    /*
+      1) Block until the sync variable is full.
+      2) Write the value of the sync variable and leave the variable full
+    */
+    proc writeFF(x : valType) {
+      syncVar.writeFF(x);
+    }
+
+    /*
+      1) Write the value of the sync variable and leave the variable full
+    */
+    proc writeXF(x : valType) {
+      syncVar.writeXF(x);
+    }
+
+    // Do not allow implicit reads of sync/single vars.
+    pragma "no doc"
+    proc readThis(x) {
+      compilerError("sync variables cannot currently be read - use writeEF/writeFF instead");
+    }
+
+    // Do not allow implicit writes of sync/single vars.
+    pragma "no doc"
+    proc writeThis(x) {
+      compilerError("sync variables cannot currently be written - apply readFE/readFF() to those variables first");
     }
   }
 
-  pragma "sync"
-    pragma "no object" // Optimize out the object base pointer.
-    pragma "no default functions"
-    pragma "ignore noinit"
-    pragma "not plain old data"
-    pragma "no doc"
-    class _syncvar {
-      type base_type;
-      var  value: base_type;       // actual data - may need to be declared specially on some targets!
-      pragma "omit from constructor" var sync_aux: _sync_aux_t; // data structure for locking, signaling, etc.
-      // Ideally, the definition of this class should be target and base_type dependent,
-      // since not all targets need to have a sync_aux field if base_type is sufficiently simple.
+  proc   = (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(rhs);
+  }
 
-      proc ~_syncvar() { __primitive("sync_destroy", this); }
+  proc  += (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() +  rhs);
+  }
 
-      proc initialize() {
-        chpl_ensureFEType(base_type);
-        __primitive("sync_init", this);
+  proc  -= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() -  rhs);
+  }
+
+  proc  *= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() *  rhs);
+  }
+
+  proc  /= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() /  rhs);
+  }
+
+  proc  %= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() %  rhs);
+  }
+
+  proc **= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() ** rhs);
+  }
+
+  proc  &= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() &  rhs);
+  }
+
+  proc  |= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() |  rhs);
+  }
+
+  proc  ^= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() ^  rhs);
+  }
+
+  proc >>= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() >> rhs);
+  }
+
+  proc <<= (ref lhs : _syncvar(?t), rhs : t) {
+    lhs.syncVar.writeEF(lhs.syncVar.readFE() << rhs);
+  }
+
+  pragma "init copy fn"
+  proc chpl__initCopy(sv : _syncvar(?t)) {
+    return sv.readFE();
+  }
+
+  pragma "donor fn"
+  pragma "auto copy fn"
+  pragma "no doc"
+  proc chpl__autoCopy(const ref rhs : _syncvar(?t)) {
+    return new _syncvar(t, rhs);
+  }
+
+  // Be explicit about whether syncs are auto-destroyed.
+  inline proc chpl__maybeAutoDestroyed(x : _syncvar(?t)) param return true;
+
+  // This version has to be available to take precedence
+  pragma "auto destroy fn sync"
+    inline proc chpl__autoDestroy(x : _syncvar(?)) {
+    if x.isOwned == true then
+      delete x.syncVar;
+  }
+
+  pragma "no doc"
+  proc chpl__readXX(x : _syncvar(?)) return x.readXX();
+
+  proc isSyncType(type t) param where t : _syncvar {
+    return true;
+  }
+
+  proc isSyncType(type t) param {
+    return false;
+  }
+
+  proc <=>(lhs: _syncvar, ref rhs) {
+    const tmp = lhs;
+
+    lhs = rhs;
+    rhs = tmp;
+  }
+
+  proc <=>(ref lhs, rhs: _syncvar) {
+    const tmp = lhs;
+
+    lhs = rhs;
+    rhs = tmp;
+  }
+
+  proc <=>(lhs: _syncvar, rhs: _syncvar) {
+    const tmp = lhs;
+
+    lhs = rhs;
+    rhs = tmp;
+  }
+
+  /************************************ | *************************************
+  *                                                                           *
+  * Use of a class instance establishes the required identity property.       *
+  *                                                                           *
+  * Potential future optimization: Some targets could rely on a class that    *
+  * omits the syncAux variable for sufficiently simple valType.               *
+  *                                                                           *
+  ************************************* | ************************************/
+
+  // Implementation is target dependent and opaque to Chapel code
+  extern record chpl_sync_aux_t { };
+
+  extern proc   chpl_sync_initAux(ref aux : chpl_sync_aux_t);
+  extern proc   chpl_sync_destroyAux(ref aux : chpl_sync_aux_t);
+
+  pragma "insert line file info"
+  extern proc   chpl_sync_waitEmptyAndLock(ref aux : chpl_sync_aux_t);
+
+  pragma "insert line file info"
+  extern proc   chpl_sync_waitFullAndLock (ref aux : chpl_sync_aux_t);
+
+  extern proc   chpl_sync_lock  (ref aux : chpl_sync_aux_t);
+  extern proc   chpl_sync_unlock(ref aux : chpl_sync_aux_t);
+
+  extern proc   chpl_sync_markAndSignalEmpty(ref aux : chpl_sync_aux_t);
+  extern proc   chpl_sync_markAndSignalFull (ref aux : chpl_sync_aux_t);
+
+  extern proc   chpl_sync_isFull(value : c_void_ptr,
+                                 ref aux   : chpl_sync_aux_t) : bool;
+
+  pragma "no doc"
+  class _synccls {
+    type valType;
+
+    var  value   : valType;
+    var  syncAux : chpl_sync_aux_t;      // Locking, signalling, ...
+
+    proc _synccls(type valType) {
+      chpl_sync_initAux(syncAux);
+    }
+
+    proc ~_synccls() {
+      chpl_sync_destroyAux(syncAux);
+    }
+
+    proc readFE() {
+      var ret: valType;
+
+      on this {
+        var localRet: valType;
+
+        chpl_rmem_consist_release();
+        chpl_sync_waitFullAndLock(syncAux);
+
+        localRet = value;
+
+        chpl_sync_markAndSignalEmpty(syncAux);
+        chpl_rmem_consist_acquire();
+
+        ret      = localRet;
+      }
+
+      return ret;
+    }
+
+    proc readFF() {
+      var ret: valType;
+
+      on this {
+        var localRet: valType;
+
+        chpl_rmem_consist_release();
+        chpl_sync_waitFullAndLock(syncAux);
+
+        localRet = value;
+
+        chpl_sync_markAndSignalFull(syncAux);
+        chpl_rmem_consist_acquire();
+
+        ret = localRet;
+      }
+
+      return ret;
+    }
+
+    proc readXX() {
+      var ret: valType;
+
+      on this {
+        var localRet: valType;
+
+        chpl_rmem_consist_release();
+        chpl_sync_lock(syncAux);
+
+        localRet = value;
+
+        chpl_sync_unlock(syncAux);
+        chpl_rmem_consist_acquire();
+
+        ret      = localRet;
+      }
+
+      return ret;
+    }
+
+    proc writeEF(val : valType) {
+      on this {
+        chpl_rmem_consist_release();
+        chpl_sync_waitEmptyAndLock(syncAux);
+
+        value = val;
+
+        chpl_sync_markAndSignalFull(syncAux);
+        chpl_rmem_consist_acquire();
       }
     }
 
-  /* Returns true if `t` is a sync type, false otherwise. */
-  proc isSyncType(type t) param
-    return __primitive("is sync type", t);
+    proc writeFF(val:valType) {
+      on this {
+        chpl_rmem_consist_release();
+        chpl_sync_waitFullAndLock(syncAux);
+
+        value = val;
+
+        chpl_sync_markAndSignalFull(syncAux);
+        chpl_rmem_consist_acquire();
+      }
+    }
+
+    proc writeXF(val:valType) {
+      on this {
+        chpl_rmem_consist_release();
+        chpl_sync_lock(syncAux);
+
+        value = val;
+
+        chpl_sync_markAndSignalFull(syncAux);
+        chpl_rmem_consist_acquire();
+      }
+    }
+
+    proc reset() {
+      on this {
+        const default_value: valType;
+
+        chpl_rmem_consist_release();
+        chpl_sync_lock(syncAux);
+
+        value = default_value;
+
+        chpl_sync_markAndSignalEmpty(syncAux);
+        chpl_rmem_consist_acquire();
+      }
+    }
+
+    proc isFull {
+      var b : bool;
+
+      on this {
+        chpl_rmem_consist_release();
+        b = chpl_sync_isFull(c_ptrTo(value), syncAux);
+        chpl_rmem_consist_acquire();
+      }
+
+      return b;
+    }
+  }
 
   pragma "no doc"
   proc isSyncValue(x: sync) param  return true;
+
   pragma "no doc"
   proc isSyncValue(x)       param  return false;
 
-  // The operations are:
-  //  readFE - wait for full, leave empty
-  //  readFF - wait for full, leave full
-  //  readXX - ignore F/E, leave F/E unchanged
-  //  = (i.e., write_wait_empty_leave_full)
-  //  writeEF  - wait for empty, leave full (same as =)
-  //  writeFF  - wait for full, leave full
-  //  writeXF  - ignore F/E, leave full
-  //  reset - ignore F/E, write zero, leave empty
-  //  isFull - query whether it is full
 
-  /*
-     This method blocks until the sync variable is full. The state of the sync
-     variable is set to empty when this method completes. This method
-     implements the default read of a sync variable.
 
-     :returns: The value of the sync variable.
-  */
-  proc _syncvar.readFE(): base_type {
-    var ret: base_type;
-    on this {
-      var localRet: base_type;
-      chpl_rmem_consist_release();
-      __primitive("sync_wait_full_and_lock", this);
-      localRet = value;
-      __primitive("sync_mark_and_signal_empty", this);
-      chpl_rmem_consist_acquire();
-      ret = localRet;
-    }
-    return ret;
-  }
 
-  /*
-     This method blocks until the sync variable is full. The state of the sync
-     variable remains full when this method completes.
 
-     :returns: The value of the sync variable.
-  */
-  proc _syncvar.readFF() {
-    var ret: base_type;
-    on this {
-      var localRet: base_type;
-      chpl_rmem_consist_release();
-      __primitive("sync_wait_full_and_lock", this);
-      localRet = value;
-      __primitive("sync_mark_and_signal_full", this); // in case others are waiting
-      chpl_rmem_consist_acquire();
-      ret = localRet;
-    }
-    return ret;
-  }
+  /************************************ | *************************************
+  *                                                                           *
+  * Class based implementation of single                                      *
+  *                                                                           *
+  ************************************* | ************************************/
 
-  /*
-     This method is non-blocking and the state of the sync variable is
-     unchanged when this method completes.
-
-     :returns: The value of the sync variable.
-  */
-  proc _syncvar.readXX() {
-    var ret: base_type;
-    on this {
-      var localRet: base_type;
-      chpl_rmem_consist_release();
-      __primitive("sync_lock", this);
-      localRet = value;
-      __primitive("sync_unlock", this);
-      chpl_rmem_consist_acquire();
-      ret = localRet;
-    }
-    return ret;
-  }
-
-  /*
-     :arg val: New value of the sync variable.
-
-     This method blocks until the sync variable is empty. The state of the sync
-     variable is set to full when this method completes. This method implements
-     the default write of a sync variable.
-  */
-  proc _syncvar.writeEF(val:base_type) {
-    on this {
-      chpl_rmem_consist_release();
-      __primitive("sync_wait_empty_and_lock", this);
-      value = val;
-      __primitive("sync_mark_and_signal_full", this);
-      chpl_rmem_consist_acquire();
-    }
-  }
-
-  proc =(ref sv: sync, val:sv.base_type) {
-    sv.writeEF(val);
-  }
-
-  /*
-     :arg val: New value of the sync variable.
-
-     This method blocks until the sync variable is full. The state
-     of the sync variable remains full when this method completes.
-  */
-  proc _syncvar.writeFF(val:base_type) {
-    on this {
-      chpl_rmem_consist_release();
-      __primitive("sync_wait_full_and_lock", this);
-      value = val;
-      __primitive("sync_mark_and_signal_full", this);
-      chpl_rmem_consist_acquire();
-    }
-  }
-
-  /*
-     :arg val: New value of the sync variable.
-
-     This method is non-blocking and the state of the sync
-     variable is set to full when this method completes.
-  */
-  proc _syncvar.writeXF(val:base_type) {
-    on this {
-      chpl_rmem_consist_release();
-      __primitive("sync_lock", this);
-      value = val;
-      __primitive("sync_mark_and_signal_full", this);
-      chpl_rmem_consist_acquire();
-    }
-  }
-
-  /*
-     Resets the value of this sync variable to the default value of
-     its type. This method is non-blocking and the state of the sync
-     variable is set to empty when this method completes.
-  */
-  proc _syncvar.reset() {
-    on this {
-      const default_value: base_type;
-      chpl_rmem_consist_release();
-      __primitive("sync_lock", this);
-      value = default_value;
-      __primitive("sync_mark_and_signal_empty", this);
-      chpl_rmem_consist_acquire();
-    }
-  }
-
-  /*
-     :returns: true if the state of the sync variable is full.
-
-     This method is non-blocking and the state of the sync variable is
-     unchanged when this method completes.
-  */
-  proc _syncvar.isFull {
-    var b: bool;
-    on this {
-      chpl_rmem_consist_release();
-      b = __primitive("sync_is_full", this);
-      chpl_rmem_consist_acquire();
-    }
-    return b;
-  }
-
-  // Do not allow implicit reads of sync/single vars.
+  pragma "single"
+  pragma "no object" // Optimize out the object base pointer.
+  pragma "no default functions"
+  pragma "ignore noinit"
+  pragma "not plain old data"
   pragma "no doc"
-  proc _syncvar.readThis(x) {
-    compilerError("sync/single variables cannot currently be read - use writeEF/writeFF instead");
-  }
+  class _singlevar {
+    type valType;                              // The compiler knows this name
 
-  // Do not allow implicit writes of sync/single vars.
-  pragma "no doc"
-  proc _syncvar.writeThis(x) {
-    compilerError("sync/single variables cannot currently be written - apply readFE/readFF() to those variables first");
-  }
+    // actual data - may need to be declared specially on some targets!
+    var  value: valType;
 
+    // data structure for locking, signaling, etc.
+    pragma "omit from constructor"
+    var single_aux: _single_aux_t;
 
-  // single variable support
-    pragma "single"
-    pragma "no object" // Optimize out the object base pointer.
-    pragma "no default functions"
-    pragma "ignore noinit"
-    pragma "not plain old data"
-    pragma "no doc"
-    class _singlevar {
-      type base_type;
-      var  value: base_type;     // actual data - may need to be declared specially on some targets!
-      pragma "omit from constructor" var single_aux: _single_aux_t; // data structure for locking, signaling, etc.
-      // Ideally, the definition of this class should be target and base_type dependent,
-      // since not all targets need to have a single_aux field if base_type is sufficiently simple.
+    // Ideally, the definition of this class should be target and valType
+    // dependent, since not all targets need to have a single_aux field if
+    // valType is sufficiently simple.
 
-      proc ~_singlevar() { __primitive("single_destroy", this); }
-
-      proc initialize() {
-        chpl_ensureFEType(base_type);
-        __primitive("single_init", this);
-      }
+    proc ~_singlevar() {
+      __primitive("single_destroy", this);
     }
+
+    proc initialize() {
+      ensureFEType(valType);
+      __primitive("single_init", this);
+    }
+  }
 
   /* Returns true if `t` is a single type, false otherwise. */
   proc isSingleType(type t) param
@@ -295,27 +518,29 @@ module ChapelSyncvar {
 
   pragma "no doc"
   proc isSingleValue(x: single) param  return true;
+
   pragma "no doc"
   proc isSingleValue(x)         param  return false;
 
   /*
-     This method blocks until the single variable is full. The state of the single
-     variable remains full when this method completes. This method implements
-     the default read of a single variable.
+     This method blocks until the single variable is full.
+     The state of the single variable remains full when this method completes.
+     This method implements the default read of a single variable.
 
      :returns: The value of the single variable.
   */
   proc _singlevar.readFF() {
-    var ret: base_type;
+    var ret: valType;
     on this {
-      var localRet: base_type;
+      var localRet: valType;
       chpl_rmem_consist_release();
       if this.isFull then
         localRet = value;
       else {
         __primitive("single_wait_full", this);
         localRet = value;
-        __primitive("single_mark_and_signal_full", this); // in case others are waiting
+        // in case others are waiting
+        __primitive("single_mark_and_signal_full", this);
       }
       chpl_rmem_consist_acquire();
       ret = localRet;
@@ -331,10 +556,10 @@ module ChapelSyncvar {
      :returns: The value of the single variable.
   */
   proc _singlevar.readXX() {
-    var ret: base_type;
+    var ret: valType;
     on this {
       chpl_rmem_consist_release();
-      var localRet: base_type;
+      var localRet: valType;
       if this.isFull then
         localRet = value;
       else {
@@ -356,7 +581,7 @@ module ChapelSyncvar {
      variable is set to full when this method completes. This method implements
      the default write of a single variable.
   */
-  proc _singlevar.writeEF(val:base_type) {
+  proc _singlevar.writeEF(val:valType) {
     on this {
       chpl_rmem_consist_release();
       __primitive("single_lock", this);
@@ -368,7 +593,7 @@ module ChapelSyncvar {
     }
   }
 
-  proc =(ref sv: single, value:sv.base_type) {
+  proc =(ref sv: single, value:sv.valType) {
     sv.writeEF(value);
   }
 
@@ -402,20 +627,10 @@ module ChapelSyncvar {
   }
 
   pragma "dont disable remote value forwarding"
-  inline proc _createFieldDefault(type t, init: sync) {
-    return init;
-  }
-  
-  pragma "dont disable remote value forwarding"
   inline proc _createFieldDefault(type t, init: single) {
     return init;
   }
-  
-  pragma "init copy fn"
-  inline proc chpl__initCopy(sv: sync) {
-    return sv.readFE();
-  }
-  
+
   pragma "init copy fn"
   inline proc chpl__initCopy(sv: single) {
     return sv.readFF();
@@ -424,21 +639,11 @@ module ChapelSyncvar {
   pragma "dont disable remote value forwarding"
   pragma "donor fn"
   pragma "auto copy fn"
-  inline proc chpl__autoCopy(x: sync) return x;
-
-  pragma "dont disable remote value forwarding"
-  pragma "donor fn"
-  pragma "auto copy fn"
   inline proc chpl__autoCopy(x: single) return x;
 
-  // Be explicit about whether syncs and singles are auto-destroyed.
-  inline proc chpl__maybeAutoDestroyed(x: _syncvar) param return true;
+  // Be explicit about whether singles are auto-destroyed.
   inline proc chpl__maybeAutoDestroyed(x: _singlevar) param return true;
 
-  pragma "auto destroy fn sync"
-  inline proc chpl__autoDestroy(x: _syncvar) {
-    delete x;
-  }
   pragma "auto destroy fn sync"
   inline proc chpl__autoDestroy(x: _singlevar) {
     delete x;
@@ -449,35 +654,9 @@ module ChapelSyncvar {
     return x.type;
   }
 
-  // op= for sync variables
-  inline proc  +=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs  + rhs; }
-  inline proc  -=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs  - rhs; }
-  inline proc  *=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs  * rhs; }
-  inline proc  /=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs  / rhs; }
-  inline proc  %=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs  % rhs; }
-  inline proc **=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs ** rhs; }
-  inline proc  &=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs  & rhs; }
-  inline proc  |=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs  | rhs; }
-  inline proc  ^=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs  ^ rhs; }
-  inline proc >>=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs >> rhs; }
-  inline proc <<=(ref lhs:sync, rhs:chpl__syncBaseType(lhs)) { lhs = lhs << rhs; }
-  
-  inline proc <=>(lhs: sync, ref rhs) {
-    const tmp = lhs;
-    lhs = rhs;
-    rhs = tmp;
-  }
-  
-  inline proc <=>(ref lhs, rhs: sync) {
-    const tmp = lhs;
-    lhs = rhs;
-    rhs = tmp;
-  }
-  
-  inline proc <=>(lhs: sync, rhs: sync) {
-    const tmp = lhs;
-    lhs = rhs;
-    rhs = tmp;
-  }
-  
+  pragma "no doc"
+  inline proc chpl__readXX(x: single) return x.readXX();
+
+  pragma "no doc"
+  inline proc chpl__readXX(x) return x;
 }

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -582,18 +582,9 @@ module Random {
         PCGRandomStreamPrivate_count = 1;
       }
 
-      //
-      // NOAKES: 2016/04/21
-      //
-      // syncs are currently implemented as bare classes and so require a delete to be reclaimed
-      //
-      // We do not want to update application code but have agreed to update the randomStream
-      // classes to reduce leak noise until the implementation can be revised
-      //
-
       pragma "no doc"
       proc ~RandomStream() {
-        delete PCGRandomStreamPrivate_lock$;
+
       }
 
       pragma "no doc"
@@ -2066,17 +2057,9 @@ module Random {
         }
       }
 
-      //
-      // NOAKES: 2016/04/21
-      //
-      // syncs are currently implemented as bare classes and so require a delete to be reclaimed
-      //
-      // We do not want to update application code but have agreed to update the randomStream
-      // classes to reduce leak noise until the implementation can be revised
-      //
       pragma "no doc"
       proc ~NPBRandomStream() {
-        delete NPBRandomStreamPrivate_lock$;
+
       }
 
       pragma "no doc"

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -583,11 +583,6 @@ module Random {
       }
 
       pragma "no doc"
-      proc ~RandomStream() {
-
-      }
-
-      pragma "no doc"
       proc PCGRandomStreamPrivate_getNext_noLock(type resultType=eltType) {
         PCGRandomStreamPrivate_count += 1;
         return randlc(resultType, PCGRandomStreamPrivate_rngs);
@@ -2055,11 +2050,6 @@ module Random {
         } else {
           compilerError("NPBRandomStream only supports eltType=real(64), imag(64), or complex(128)");
         }
-      }
-
-      pragma "no doc"
-      proc ~NPBRandomStream() {
-
       }
 
       pragma "no doc"

--- a/test/parallel/sync/waynew/class3.bad
+++ b/test/parallel/sync/waynew/class3.bad
@@ -1,0 +1,14 @@
+class3.chpl:12: error: unresolved call '_syncvar(C).value()'
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:75: note: candidates are: SumReduceScanOp.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:94: note:                 ProductReduceScanOp.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:109: note:                 MaxReduceScanOp.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:124: note:                 MinReduceScanOp.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:139: note:                 LogicalAndReduceScanOp.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:154: note:                 LogicalOrReduceScanOp.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:169: note:                 BitwiseAndReduceScanOp.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:184: note:                 BitwiseOrReduceScanOp.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:199: note:                 BitwiseXorReduceScanOp.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:214: note:                 maxloc.value
+$CHPL_HOME/modules/internal/ChapelReduce.chpl:239: note:                 minloc.value
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:330: note:                 _synccls.value
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:490: note:                 _singlevar.value

--- a/test/parallel/sync/waynew/class3.future
+++ b/test/parallel/sync/waynew/class3.future
@@ -1,0 +1,13 @@
+bug: Compiler is attempting to bypass sync API
+
+This program executed to completion when ChapelSyncvar was implemented
+as a class.  Conversion to a record-wrapped class revealed that this
+test, and only this test, caused the compiler to generate AST that
+fetched fields of the class directly.
+
+This in turn lead to a recognition that the semantics of sync class is
+not as clear as it should be and so it was not clear how to support
+this test for the new implementation.
+
+A decision was made to define this as a future until the use cases for
+sync class are better understood

--- a/test/types/single/vass/readThis.good
+++ b/test/types/single/vass/readThis.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/IO.chpl:: error: single/sync variables cannot currently be read - use writeEF/writeFF instead
+$CHPL_HOME/modules/standard/IO.chpl:: error: single variables cannot currently be read - use writeEF/writeFF instead

--- a/test/types/single/vass/writeThis.good
+++ b/test/types/single/vass/writeThis.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/IO.chpl:: error: single/sync variables cannot currently be written - apply readFF/readFE() to those variables first
+$CHPL_HOME/modules/standard/IO.chpl:: error: single variables cannot currently be written - apply readFF/readFE() to those variables first

--- a/test/types/sync/vass/readThis.good
+++ b/test/types/sync/vass/readThis.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/IO.chpl:: error: sync/single variables cannot currently be read - use writeEF/writeFF instead
+$CHPL_HOME/modules/standard/IO.chpl:: error: sync variables cannot currently be read - use writeEF/writeFF instead

--- a/test/types/sync/vass/writeThis.good
+++ b/test/types/sync/vass/writeThis.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/IO.chpl:: error: sync/single variables cannot currently be written - apply readFE/readFF() to those variables first
+$CHPL_HOME/modules/standard/IO.chpl:: error: sync variables cannot currently be written - apply readFE/readFF() to those variables first

--- a/test/users/vass/isX/isX.byBlankArgs-compWarns.good
+++ b/test/users/vass/isX/isX.byBlankArgs-compWarns.good
@@ -308,11 +308,17 @@ isArrayValue
 isArrayType
 
 _syncvar(int(64))
+isRecord
+isRecordValue
+isRecordType
 isSync
 isSyncValue
 isSyncType
 
 _syncvar(real(64))
+isRecord
+isRecordValue
+isRecordType
 isSync
 isSyncValue
 isSyncType

--- a/test/users/vass/isX/isX.module-writeln.good
+++ b/test/users/vass/isX/isX.module-writeln.good
@@ -32,8 +32,8 @@ DomType1 (dom1)  isDomain  isDomainValue  isDomainType  .
 DomType2 (dom2)  isDomain  isDomainValue  isDomainType  .
 ArrType1 (arr1)  isArray  isArrayValue  isArrayType  .
 ArrType2 (arr2)  isArray  isArrayValue  isArrayType  .
-sync int (syInt)  isSync  isSyncValue  isSyncType  .
-sync real (syReal)  isSync  isSyncValue  isSyncType  .
+sync int (syInt)  isRecord  isRecordValue  isRecordType  isSync  isSyncValue  isSyncType  .
+sync real (syReal)  isRecord  isRecordValue  isRecordType  isSync  isSyncValue  isSyncType  .
 single int (siInt)  isSingle  isSingleValue  isSingleType  .
 single real (siReal)  isSingle  isSingleValue  isSingleType  .
 atomic int (aInt)  isAtomic  isAtomicValue  isAtomicType  .

--- a/test/users/vass/type-tests.good
+++ b/test/users/vass/type-tests.good
@@ -64,7 +64,7 @@ type-tests.chpl:27: warning: atomic is a record: false
 type-tests.chpl:27: warning: atomic is a union:  false
 type-tests.chpl:27: warning: atomic is an atomic
 type-tests.chpl:28: warning: sync is a class:  false
-type-tests.chpl:28: warning: sync is a record: false
+type-tests.chpl:28: warning: sync is a record: true
 type-tests.chpl:28: warning: sync is a union:  false
 type-tests.chpl:28: warning: sync is a sync
 type-tests.chpl:29: warning: single is a class:  false


### PR DESCRIPTION
Historically sync has been implemented as a class in internal/ChapelSyncvar.chpl plus a moderate
number of special cases in the compiler.  This provided the necessary "identity" but tended to
cause syncs to leak.

The primary change in this PR is to rename the old class to be an internal class and
then wrap this in a record-wrapped class.  

This allowed a fraction of the compiler-based specializations to be removed.  Finally it was necessary
to make trivial changes to a few tests and to convert a fragile test in to a future.


Compiled with/without CHPL_DEVELOPER on darwin/clang and linux/gcc.

Tested on

std-single-locale with --verify
--baseline with --verify
--gasnet

Verified that this branch has slightly fewer leaks than master.



