### PR TITLE
In build.cpp, move iterableExpr to call to parloopexpr()

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -990,8 +990,12 @@ buildForallLoopExpr(Expr* indices, Expr* iteratorExpr, Expr* expr, Expr* cond, b
   BlockStmt* block = fn->body;
 
   if (maybeArrayType) {
-    // Is this part necessary?
-    // See test/arrays/deitz/part4/test_array_type_alias.chpl
+    // handle e.g.
+    //
+    //   type t = [1..3] int;
+    //
+    // as in test/arrays/deitz/part4/test_array_type_alias.chpl
+    // As of 2016-08-10, about 42 tests fail without this special case.
     INT_ASSERT(!cond);
     block = handleArrayTypeCase(fn, indices, iteratorExprArg, expr);
   }

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -861,14 +861,15 @@ CallExpr*
 buildForLoopExpr(Expr* indices, Expr* iteratorExpr, Expr* expr, Expr* cond, bool maybeArrayType, bool zippered) {
   FnSymbol* fn = new FnSymbol(astr("_seqloopexpr", istr(loopexpr_uid++)));
   fn->addFlag(FLAG_COMPILER_NESTED_FUNCTION);
+
+  // See comment in buildForallLoopExpr()
   ArgSymbol* iteratorExprArg = new ArgSymbol(INTENT_BLANK, "iterExpr", dtAny);
   fn->insertFormalAtTail(iteratorExprArg);
   BlockStmt* block = fn->body;
 
   if (maybeArrayType) {
-    // MPF: I would think this is only necessary for the
-    // [ ] syntax. This would allow something like
-    // type t = for 1..100 int
+    // MPF: I suspect this case is not necessary here since array type
+    // expressions are be handled by buildForallLoopExpr()
     INT_ASSERT(!cond);
     block = handleArrayTypeCase(fn, indices, iteratorExprArg, expr);
   }
@@ -990,12 +991,9 @@ buildForallLoopExpr(Expr* indices, Expr* iteratorExpr, Expr* expr, Expr* cond, b
   BlockStmt* block = fn->body;
 
   if (maybeArrayType) {
-    // handle e.g.
-    //
-    //   type t = [1..3] int;
-    //
+    // handle e.g. type t = [1..3] int;
     // as in test/arrays/deitz/part4/test_array_type_alias.chpl
-    // As of 2016-08-10, about 42 tests fail without this special case.
+    // where "[1..3] int" is syntactically a "forall loop expression"
     INT_ASSERT(!cond);
     block = handleArrayTypeCase(fn, indices, iteratorExprArg, expr);
   }

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -767,7 +767,7 @@ destructureIndices(BlockStmt* block,
 
 
 static BlockStmt*
-handleArrayTypeCase(FnSymbol* fn, Expr* indices, Expr* iteratorExpr, Expr* expr) {
+handleArrayTypeCase(FnSymbol* fn, Expr* indices, ArgSymbol* iteratorExprArg, Expr* expr) {
   BlockStmt* block = new BlockStmt();
   fn->addFlag(FLAG_MAYBE_TYPE);
   bool hasSpecifiedIndices = !!indices;
@@ -800,7 +800,7 @@ handleArrayTypeCase(FnSymbol* fn, Expr* indices, Expr* iteratorExpr, Expr* expr)
   VarSymbol* iteratorSym = newTemp("_iterator");
   isArrayTypeFn->insertAtTail(new DefExpr(iteratorSym));
   isArrayTypeFn->insertAtTail(new CallExpr(PRIM_MOVE, iteratorSym,
-                                new CallExpr("_getIterator", iteratorExpr->copy())));
+                                new CallExpr("_getIterator", iteratorExprArg)));
   VarSymbol* index = newTemp("_indexOfInterest");
   index->addFlag(FLAG_INDEX_OF_INTEREST);
   isArrayTypeFn->insertAtTail(new DefExpr(index));
@@ -833,7 +833,7 @@ handleArrayTypeCase(FnSymbol* fn, Expr* indices, Expr* iteratorExpr, Expr* expr)
   thenStmt->insertAtTail(new CallExpr(PRIM_MOVE, domain,
                            new CallExpr("chpl__autoCopy",
                              new CallExpr("chpl__ensureDomainExpr",
-                                          iteratorExpr->copy()))));
+                                          iteratorExprArg))));
   if (hasSpecifiedIndices) {
     // we want to swap something like the below commented-out
     // statement with the compiler error statement but skyline
@@ -861,24 +861,29 @@ CallExpr*
 buildForLoopExpr(Expr* indices, Expr* iteratorExpr, Expr* expr, Expr* cond, bool maybeArrayType, bool zippered) {
   FnSymbol* fn = new FnSymbol(astr("_seqloopexpr", istr(loopexpr_uid++)));
   fn->addFlag(FLAG_COMPILER_NESTED_FUNCTION);
+  ArgSymbol* iteratorExprArg = new ArgSymbol(INTENT_BLANK, "iterExpr", dtAny);
+  fn->insertFormalAtTail(iteratorExprArg);
   BlockStmt* block = fn->body;
 
   if (maybeArrayType) {
+    // MPF: I would think this is only necessary for the
+    // [ ] syntax. This would allow something like
+    // type t = for 1..100 int
     INT_ASSERT(!cond);
-    block = handleArrayTypeCase(fn, indices, iteratorExpr, expr);
+    block = handleArrayTypeCase(fn, indices, iteratorExprArg, expr);
   }
 
   VarSymbol* iterator = newTemp("_iterator");
   iterator->addFlag(FLAG_EXPR_TEMP);
   block->insertAtTail(new DefExpr(iterator));
-  block->insertAtTail(new CallExpr(PRIM_MOVE, iterator, new CallExpr("_checkIterator", iteratorExpr)));
+  block->insertAtTail(new CallExpr(PRIM_MOVE, iterator, new CallExpr("_checkIterator", iteratorExprArg)));
   const char* iteratorName = astr("_iterator_for_loopexpr", istr(loopexpr_uid-1));
   block->insertAtTail(new CallExpr(PRIM_RETURN, new CallExpr(iteratorName, iterator)));
 
   Expr* stmt = NULL; // Initialized by buildSerialIteratorFn
   buildSerialIteratorFn(fn, iteratorName, expr, cond, indices, zippered, stmt);
 
-  return new CallExpr(new DefExpr(fn));
+  return new CallExpr(new DefExpr(fn), iteratorExpr);
 }
 
 
@@ -973,17 +978,28 @@ CallExpr*
 buildForallLoopExpr(Expr* indices, Expr* iteratorExpr, Expr* expr, Expr* cond, bool maybeArrayType, bool zippered) {
   FnSymbol* fn = new FnSymbol(astr("_parloopexpr", istr(loopexpr_uid++)));
   fn->addFlag(FLAG_COMPILER_NESTED_FUNCTION);
+
+  // MPF: We'll add the iteratorExpr to the call, so we need an
+  // argument to accept it in the new function. This way,
+  // the responsibility for managing the memory of whatever
+  // is being iterated over (e.g. a domain literal) is in the
+  // caller, where the iteration most likely occurs. That way,
+  // the iterator can capture such a domain by reference.
+  ArgSymbol* iteratorExprArg = new ArgSymbol(INTENT_BLANK, "iterExpr", dtAny);
+  fn->insertFormalAtTail(iteratorExprArg);
   BlockStmt* block = fn->body;
 
   if (maybeArrayType) {
+    // Is this part necessary?
+    // See test/arrays/deitz/part4/test_array_type_alias.chpl
     INT_ASSERT(!cond);
-    block = handleArrayTypeCase(fn, indices, iteratorExpr, expr);
+    block = handleArrayTypeCase(fn, indices, iteratorExprArg, expr);
   }
 
   VarSymbol* iterator = newTemp("_iterator");
   iterator->addFlag(FLAG_EXPR_TEMP);
   block->insertAtTail(new DefExpr(iterator));
-  block->insertAtTail(new CallExpr(PRIM_MOVE, iterator, new CallExpr("_checkIterator", iteratorExpr)));
+  block->insertAtTail(new CallExpr(PRIM_MOVE, iterator, new CallExpr("_checkIterator", iteratorExprArg)));
   const char* iteratorName = astr("_iterator_for_loopexpr", istr(loopexpr_uid-1));
   block->insertAtTail(new CallExpr(PRIM_RETURN, new CallExpr(iteratorName, iterator)));
 
@@ -999,7 +1015,7 @@ buildForallLoopExpr(Expr* indices, Expr* iteratorExpr, Expr* expr, Expr* cond, b
   Expr* bodyCopy = stmt->copy(&map);
   fifn->insertAtTail(ForLoop::buildForLoop(indicesCopy, new SymExpr(followerIterator), new BlockStmt(bodyCopy), false, zippered));
 
-  return new CallExpr(new DefExpr(fn));
+  return new CallExpr(new DefExpr(fn), iteratorExpr);
 }
 
 


### PR DESCRIPTION
This provides a solution to a problem I ran into while working on array
improvements. With my array improvements, iterator records capture array
and domain arguments by ref (since autoCopy now does a deep copy and
iterator records are copied a number of times in normal use). That change
causes problems for cases like the below:

    const a3 : [1..6,1..3] int = [(i,j) in {1..6,1..3}] i+j;

    (from test/users/shetag/unboundslice2.chpl ).

in which the expression {1..6,1..3} is a domain that is created in a
"parloopexpr" function (created in build.cpp).  But the "parloopexpr"
function returns an iterator record, which the caller iterates over. The
problem is that - if iterator records capture arrays and domain arguments
by ref - by the time "parloopexpr" returns, the anonymous domain has
already been freed (and the iterator record now refers to garbage
memory).

This change adjusts build.cpp to generate the iterable expression such as
{1..6,1..3} in this case in the call site for parloopexpr and for the
body of parloopexpr to use it as an argument.

Note: While here, I investigated if it was possible to remove
entirely handleArrayTypeCase. Doing so causes 42 test failures.

Passes quickstart testing.
Passed full local testing.
Reviewed by @vasslitvinov - thanks!