### PR TITLE
Modify assertion in captureTaskIntentValues()

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3394,16 +3394,7 @@ static void captureTaskIntentValues(int argNum, ArgSymbol* formal,
   }
   if (varActual->defPoint->parentExpr == parent) {
     // Index variable of the coforall loop? Do not capture it!
-    if (fVerify) {
-      // This is what currently happens.
-      CallExpr* move = toCallExpr(varActual->defPoint->next);
-      INT_ASSERT(move);
-      INT_ASSERT(move->isPrimitive(PRIM_MOVE));
-      SymExpr* src = toSymExpr(move->get(2));
-      INT_ASSERT(src);
-      INT_ASSERT(!strcmp(src->var->name, "_indexOfInterest"));
-    }
-    // do nothing
+    INT_ASSERT(varActual->hasFlag(FLAG_COFORALL_INDEX_VAR));
     return;
   }
   SymbolMap*& symap = capturedValues[parent->id];


### PR DESCRIPTION
captureTaskIntentValues() contained assertions
one of which was failing under gasnet with --verify.
This change replaces them with another assertion
which passes under linux64 and gasnet.

The previous assertions examined the structure of the AST,
verifying that varActual is a loop induction variable.
I replaced that with a direct check of FLAG_COFORALL_INDEX_VAR.
Verifying the particular structure of the AST does not seem useful
in this case.

The reason the failure had gone unnoticed for a while, perhaps since
that code was added, is because the code is run only upon --verify,
and we do not require that compiler executes successfully with
--verify under gasnet.