### PR TITLE
Move distrib testing to chap04 and increase distrib-numa trials

### DIFF
--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+source $CWD/common-perf.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04.playground"
+
+
+# Test perf of qthreads WIP "distrib" scheduler compared to nemesis
+export CHPL_QTHREAD_SCHEDULER=distrib
+
+# hackily checkout and overlay qthreads branch that has the scheduler
+cd $CHPL_HOME/third-party/qthread/
+rm -rf qthread-1.10/
+git clone https://github.com/Qthreads/qthreads.git qthread-1.10/
+cd qthread-1.10/
+./autogen.sh
+cd $CWD
+
+SHORT_NAME=distrib
+START_DATE=08/10/16
+
+perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
+perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"
+$CWD/nightly -cron ${perf_args} ${nightly_args}

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,7 +9,7 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test perf of qthreads WIP "distrib" scheduler compared to nemesis
+# Test perf of qthreads WIP "distrib" scheduler with numa against sherwood
 export CHPL_QTHREAD_SCHEDULER=distrib
 
 # hackily checkout and overlay qthreads branch that has the scheduler
@@ -20,19 +20,12 @@ cd qthread-1.10/
 ./autogen.sh
 cd $CWD
 
-SHORT_NAME=distrib
-START_DATE=08/08/16
-
-perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
-perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"
-$CWD/nightly -cron ${perf_args} ${nightly_args}
-
-
-# Test perf of qthreads WIP "distrib" scheduler with numa against sherwood
-source $CWD/common-numa.bash
 SHORT_NAME=numa-distrib
+START_DATE=08/10/16
+
+source $CWD/common-numa.bash
 export CHPL_TEST_TIMEOUT=600
 
 perf_args="-performance-description $SHORT_NAME -performance-configs numa:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
-perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"
+perf_args="${perf_args} -numtrials 3 -startdate $START_DATE"
 $CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
We're having trouble running distrib and nemesis testing on the same machine,
so it's hard to do a direct comparison between the schedulers. Move it to
chap04 so we can do a direct comparison on the same machine and increase the
number of trials we do for distrib-numa testing.