### PR TITLE
Fix a few new typos

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -608,7 +608,7 @@ module ChapelDistribution {
   class BaseSparseArrImpl: BaseSparseArr {
 
 
-    // currently there is no support implemneted for setting IRV for
+    // currently there is no support implemented for setting IRV for
     // SparseBlockArr, therefore I moved IRV related stuff to this class, and
     // have SparseBlockArr be a child class of BaseSparseArr directly instead
     // of this one

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -55,7 +55,7 @@ module ChapelSyncvar {
   //
   // The following types are OK for full empty types (sync/single)
   // because they represent a single logical value.  (Note that for
-  // the class it's the referenece to the object that has full/empty
+  // the class it's the reference to the object that has full/empty
   // semantics.  Note that this includes the internal type
   // chpl_taskID_t in order to keep parallel/taskPar/sungeun/private.chpl
   // working, but this does not seem to be more broadly necessary.
@@ -347,7 +347,7 @@ module ChapelSyncvar {
     type valType;
 
     var  value   : valType;
-    var  syncAux : chpl_sync_aux_t;      // Locking, signalling, ...
+    var  syncAux : chpl_sync_aux_t;      // Locking, signaling, ...
 
     proc _synccls(type valType) {
       chpl_sync_initAux(syncAux);


### PR DESCRIPTION
Fix a few new typos in ChapelDistribution.chpl and ChapelSyncvar.chpl