### PR TITLE
Add some recent perf annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -417,6 +417,8 @@ memleaksfull:
 meteor:
   12/18/13:
     - Chapel level improvement by using implicit domains
+  08/10/16:
+    - Updated meteor's lock to yield less frequently (#4300)
 
 miniMD:
   12/21/13:
@@ -537,6 +539,10 @@ stream:
   05/13/16:
     - text: stridable ranges and domains safeCasts, compiler error, etc. (#3778)
       config: Single node XC
+
+taskSpawn:
+  07/24/16:
+    - Stopped performing remote value forwarding on task functions (#4240)
 
 testSerialReductions:
   08/16/14:


### PR DESCRIPTION
Add an annotation for a meteor-parallel-alt improvement due to yielding less
frequently in the testAndSet lock (#4300)

Add an annotation for a taskSpawn regression due to no longer performing remote
value forwarding on task functions (#4240)