### PR TITLE
Separate initializers and constructors, and make initializers take in the memory to initialize

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -575,6 +575,7 @@ std::string EnumType::docsDirective() {
 AggregateType::AggregateType(AggregateTag initTag) :
   Type(E_AggregateType, NULL),
   aggregateTag(initTag),
+  instantiationStyle(DEFINES_NONE_USE_DEFAULT),
   fields(),
   inherits(),
   outer(NULL),

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -575,7 +575,7 @@ std::string EnumType::docsDirective() {
 AggregateType::AggregateType(AggregateTag initTag) :
   Type(E_AggregateType, NULL),
   aggregateTag(initTag),
-  instantiationStyle(DEFINES_NONE_USE_DEFAULT),
+  initializerStyle(DEFINES_NONE_USE_DEFAULT),
   fields(),
   inherits(),
   outer(NULL),

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -152,7 +152,7 @@ enum AggregateTag {
   AGGREGATE_UNION
 };
 
-enum InstantiationStyle {
+enum InitializerStyle {
   DEFINES_CONSTRUCTOR,
   DEFINES_INITIALIZER,
   DEFINES_NONE_USE_DEFAULT
@@ -161,7 +161,7 @@ enum InstantiationStyle {
 class AggregateType : public Type {
  public:
   AggregateTag aggregateTag;
-  InstantiationStyle instantiationStyle;
+  InitializerStyle initializerStyle;
   AList fields;
   AList inherits; // used from parsing, sets dispatchParents
   Symbol* outer;  // pointer to an outer class if this is an inner class

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -152,9 +152,16 @@ enum AggregateTag {
   AGGREGATE_UNION
 };
 
+enum InstantiationStyle {
+  DEFINES_CONSTRUCTOR,
+  DEFINES_INITIALIZER,
+  DEFINES_NONE_USE_DEFAULT
+};
+
 class AggregateType : public Type {
  public:
   AggregateTag aggregateTag;
+  InstantiationStyle instantiationStyle;
   AList fields;
   AList inherits; // used from parsing, sets dispatchParents
   Symbol* outer;  // pointer to an outer class if this is an inner class

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1028,6 +1028,12 @@ static void build_record_copy_function(AggregateType* ct) {
       INT_FATAL(arg, "Extern type's constructor call didn't create expected # of actuals");
     }
   }
+  if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+    // We want the initializer to take in the memory it will initialize
+    VarSymbol* meme = newTemp(ct);
+    fn->insertAtHead(new DefExpr(meme));
+    call->insertAtTail(new NamedExpr("meme", new SymExpr(meme)));
+  }
   fn->insertAtTail(new CallExpr(PRIM_RETURN, call));
   DefExpr* def = new DefExpr(fn);
   ct->symbol->defPoint->insertBefore(def);
@@ -1200,6 +1206,13 @@ static void build_record_init_function(AggregateType* ct) {
         }
       }
     }
+    if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+      // We want the initializer to take in the memory it will initialize
+      VarSymbol* meme = newTemp(ct);
+      fn->insertAtHead(new DefExpr(meme));
+      call->insertAtTail(new NamedExpr("meme", new SymExpr(meme)));
+    }
+
     fn->insertAtTail(new CallExpr(PRIM_RETURN, call));
   }
 

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1028,9 +1028,9 @@ static void build_record_copy_function(AggregateType* ct) {
       INT_FATAL(arg, "Extern type's constructor call didn't create expected # of actuals");
     }
   }
-  if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+  if (ct->initializerStyle == DEFINES_INITIALIZER) {
     // We want the initializer to take in the memory it will initialize
-    VarSymbol* meme = newTemp(ct);
+    VarSymbol* meme = newTemp("meme_tmp", ct);
     fn->insertAtHead(new DefExpr(meme));
     call->insertAtTail(new NamedExpr("meme", new SymExpr(meme)));
   }
@@ -1118,7 +1118,7 @@ static void build_record_init_function(AggregateType* ct) {
     // To default initialize, call the type specified default constructor (by
     // name), passing in all generic arguments.
     CallExpr* call = NULL;
-    if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+    if (ct->initializerStyle == DEFINES_INITIALIZER) {
       call = new CallExpr("init");
     } else {
       call = new CallExpr(ct->defaultInitializer->name);
@@ -1206,9 +1206,9 @@ static void build_record_init_function(AggregateType* ct) {
         }
       }
     }
-    if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+    if (ct->initializerStyle == DEFINES_INITIALIZER) {
       // We want the initializer to take in the memory it will initialize
-      VarSymbol* meme = newTemp(ct);
+      VarSymbol* meme = newTemp("meme_tmp", ct);
       fn->insertAtHead(new DefExpr(meme));
       call->insertAtTail(new NamedExpr("meme", new SymExpr(meme)));
     }

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1111,7 +1111,12 @@ static void build_record_init_function(AggregateType* ct) {
   } else {
     // To default initialize, call the type specified default constructor (by
     // name), passing in all generic arguments.
-    CallExpr* call = new CallExpr(ct->defaultInitializer->name);
+    CallExpr* call = NULL;
+    if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+      call = new CallExpr("init");
+    } else {
+      call = new CallExpr(ct->defaultInitializer->name);
+    }
     // Need to insert all required arguments into this call
     for_formals(formal, ct->defaultInitializer) {
       if (formal->hasFlag(FLAG_IS_MEME))

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1764,6 +1764,14 @@ static void change_method_into_constructor(FnSymbol* fn) {
     }
   }
 
+  if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+    ArgSymbol* meme = new ArgSymbol(INTENT_BLANK, "meme", ct, NULL,
+                                    new SymExpr(gTypeDefaultToken));
+    meme->addFlag(FLAG_IS_MEME);
+    fn->insertFormalAtTail(meme);
+    call->insertAtTail(new NamedExpr ("meme", new SymExpr(meme)));
+  }
+
   fn->_this = new VarSymbol("this");
   fn->_this->addFlag(FLAG_ARG_THIS);
   fn->insertAtHead(new CallExpr(PRIM_MOVE, fn->_this, call));

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1776,7 +1776,11 @@ static void change_method_into_constructor(FnSymbol* fn) {
   fn->formals.get(1)->remove();
   update_symbols(fn, &map);
 
-  fn->name = ct->defaultInitializer->name;
+  if (!notCtor) {
+    // The constructor's name is the name of the type.  Replace it with
+    // _construct_typename
+    fn->name = ct->defaultInitializer->name;
+  }
   fn->addFlag(FLAG_CONSTRUCTOR);
 }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4675,6 +4675,9 @@ resolveNew(CallExpr* call)
       // argument if we're making a call to an initializer
       Type* typeToNew = toReplace->var->typeInfo();
       VarSymbol* new_temp = newTemp(typeToNew);
+      if (typeToNew->symbol->hasFlag(FLAG_GENERIC)) {
+        USR_FATAL(call, "Sorry, new style initializers don't work with generics yet.  Stay tuned!");
+      }
       DefExpr* def = new DefExpr(new_temp);
       Expr* insertBeforeMe = ((!isBlockStmt(call->parentExpr)) ?
                               call->parentExpr : call);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7639,17 +7639,6 @@ static void instantiate_default_constructor(FnSymbol* fn) {
         }
       }
     }
-
-    if (AggregateType* ct = toAggregateType(fn->_this->type)) {
-      if (ct->initializerStyle == DEFINES_INITIALIZER &&
-          !ct->symbol->hasFlag(FLAG_REF) &&
-          !isSyncType(ct) && !isSingleType(ct)) {
-        call->insertAtTail(new NamedExpr("meme", new SymExpr(fn->_this)));
-        // The "meme" argument isn't an argument to the type constructor, so
-        // wouldn't be inserted for major types otherwise.
-      }
-    }
-
     fn->insertBeforeReturn(call);
     resolveCall(call);
     fn->retType->defaultInitializer = call->isResolved();

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4653,7 +4653,7 @@ resolveNew(CallExpr* call)
     // 1: replace the type with the constructor call name
     if (Type* ty = resolveTypeAlias(toReplace)) {
       if (AggregateType* ct = toAggregateType(ty)) {
-        if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+        if (ct->initializerStyle == DEFINES_INITIALIZER) {
           toReplace->replace(new UnresolvedSymExpr("init"));
           initCall = true;
         } else {
@@ -4674,7 +4674,7 @@ resolveNew(CallExpr* call)
       // 4: insert the allocation for the instance and pass that in as an
       // argument if we're making a call to an initializer
       Type* typeToNew = toReplace->var->typeInfo();
-      VarSymbol* new_temp = newTemp(typeToNew);
+      VarSymbol* new_temp = newTemp("new_temp", typeToNew);
       if (typeToNew->symbol->hasFlag(FLAG_GENERIC)) {
         USR_FATAL(call, "Sorry, new style initializers don't work with generics yet.  Stay tuned!");
       }
@@ -4687,7 +4687,7 @@ resolveNew(CallExpr* call)
       if (!isRecord(typeToNew) && !isUnion(typeToNew)) {
         BlockStmt* allocCallBlock = new BlockStmt();
 
-        CallExpr* innerCall = callChplHereAlloc((new_temp->typeInfo())->symbol);
+        CallExpr* innerCall = callChplHereAlloc(typeToNew->symbol);
         CallExpr* allocCall = new CallExpr(PRIM_MOVE, new_temp,
                                            innerCall);
         insertBeforeMe->insertBefore(allocCallBlock);
@@ -7641,7 +7641,7 @@ static void instantiate_default_constructor(FnSymbol* fn) {
     }
 
     if (AggregateType* ct = toAggregateType(fn->_this->type)) {
-      if (ct->instantiationStyle == DEFINES_INITIALIZER &&
+      if (ct->initializerStyle == DEFINES_INITIALIZER &&
           !ct->symbol->hasFlag(FLAG_REF) &&
           !isSyncType(ct) && !isSingleType(ct)) {
         call->insertAtTail(new NamedExpr("meme", new SymExpr(fn->_this)));

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4651,7 +4651,11 @@ resolveNew(CallExpr* call)
     // 1: replace the type with the constructor call name
     if (Type* ty = resolveTypeAlias(toReplace)) {
       if (AggregateType* ct = toAggregateType(ty)) {
+        if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+          toReplace->replace(new UnresolvedSymExpr("init"));
+        } else {
           toReplace->replace(new UnresolvedSymExpr(ct->defaultInitializer->name));
+        }
       }
     }
 

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -187,7 +187,7 @@ buildDefaultWrapper(FnSymbol* fn,
 
     if (defaults->v[defaults->n-1]->hasFlag(FLAG_IS_MEME) &&
         (!isAggregateType(wrapper->_this->type) ||
-         toAggregateType(wrapper->_this->type)->instantiationStyle !=
+         toAggregateType(wrapper->_this->type)->initializerStyle !=
          DEFINES_INITIALIZER)) {
       if (!isRecord(fn->_this->type) && !isUnion(fn->_this->type)) {
         wrapper->insertAtTail(new CallExpr(PRIM_MOVE,
@@ -314,7 +314,7 @@ buildDefaultWrapper(FnSymbol* fn,
       formal->type = wrapper->_this->type;
 
       if (AggregateType* ct = toAggregateType(formal->type)) {
-        if (ct->instantiationStyle == DEFINES_INITIALIZER) {
+        if (ct->initializerStyle == DEFINES_INITIALIZER) {
           ArgSymbol* wrapper_formal = copyFormalForWrapper(formal);
           wrapper->insertAtHead(new CallExpr(PRIM_MOVE, wrapper->_this,
                                              wrapper_formal));

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -201,6 +201,8 @@ printErrorHeader(BaseAST* ast) {
                   cleanFilename(err_fn), err_fn->linenum());
           if (!strncmp(err_fn->name, "_construct_", 11)) {
             fprintf(stderr, "initializer '%s':\n", err_fn->name+11);
+          } else if (!strcmp(err_fn->name, "init")) {
+            fprintf(stderr, "initializer:\n");
           } else {
             fprintf(stderr, "%s '%s':\n",
                     (err_fn->isIterator() ? "iterator" : "function"),

--- a/test/classes/initializers/constAndParamInHeader.good
+++ b/test/classes/initializers/constAndParamInHeader.good
@@ -1,4 +1,4 @@
-constAndParamInHeader.chpl:6: In initializer 'Foo':
+constAndParamInHeader.chpl:6: In initializer:
 constAndParamInHeader.chpl:6: error: invalid access of class member in initializer argument list
-constAndParamInHeader.chpl:14: In initializer 'Bar':
+constAndParamInHeader.chpl:14: In initializer:
 constAndParamInHeader.chpl:14: error: invalid access of class member in initializer argument list

--- a/test/classes/initializers/generic-uninit-field-initializers.future
+++ b/test/classes/initializers/generic-uninit-field-initializers.future
@@ -1,0 +1,5 @@
+feature request: new initializer story
+
+This test is not expected to pass until at least part of the initializers story
+is on master.  Make it a future so that Lydia can stay in step with master
+without disrupting testing overly much.

--- a/test/classes/initializers/oldAndNew.chpl
+++ b/test/classes/initializers/oldAndNew.chpl
@@ -1,0 +1,15 @@
+class badClass {
+  var i = 10;
+
+  proc init() {
+    writeln("in new initializer");
+  }
+
+  proc badClass() {
+    writeln("in old constructor");
+  }
+}
+
+var c: badClass = new badClass(); // Should fail
+// Can't distinguish between the two initializer styles.
+writeln(c);

--- a/test/classes/initializers/oldAndNew.good
+++ b/test/classes/initializers/oldAndNew.good
@@ -1,0 +1,1 @@
+oldAndNew.chpl:8: error: Definition of both constructor 'badClass' and initializer 'init'.  Please choose one.

--- a/test/classes/initializers/oldAndNew2.chpl
+++ b/test/classes/initializers/oldAndNew2.chpl
@@ -1,0 +1,18 @@
+class badClass {
+  var i = 10;
+
+  proc init() {
+    writeln("in new initializer");
+  }
+
+  proc badClass(x) {
+    i = x;
+    writeln("in old constructor");
+  }
+}
+
+var c: badClass = new badClass(); // Should fail
+// Can't distinguish between the two initializer styles.
+writeln(c);
+// Variation on oldAndNew.chpl with constructor taking a different argument list
+// than the initializer

--- a/test/classes/initializers/oldAndNew2.good
+++ b/test/classes/initializers/oldAndNew2.good
@@ -1,0 +1,1 @@
+oldAndNew2.chpl:8: error: Definition of both constructor 'badClass' and initializer 'init'.  Please choose one.

--- a/test/classes/initializers/oldAndNew3.chpl
+++ b/test/classes/initializers/oldAndNew3.chpl
@@ -1,0 +1,18 @@
+class badClass {
+  var i = 10;
+
+  proc badClass(x) {
+    i = x;
+    writeln("in old constructor");
+  }
+
+  proc init() {
+    writeln("in new initializer");
+  }
+}
+
+var c: badClass = new badClass(); // Should fail
+// Can't distinguish between the two initializer styles.
+writeln(c);
+// Variation on oldAndNew2.chpl with the constructor occurring before the
+// initializer in code.

--- a/test/classes/initializers/oldAndNew3.good
+++ b/test/classes/initializers/oldAndNew3.good
@@ -1,0 +1,1 @@
+oldAndNew3.chpl:9: error: Definition of both constructor 'badClass' and initializer 'init'.  Please choose one.


### PR DESCRIPTION
In trying to convert constructors to take in their memory as an
argument instead of having that happen in the defaultWrapper
of the (often inserted) call to the default constructor, I ran into a
hiccup with generic types.  Basically, I couldn't know the type to
use to allocate the memory and send it to the constructor call
until we'd resolved to a particular generic instantiation of the
constructor.  Chicken and egg.  This may be solved by some
code movement, but since we haven't finalized our semantics
for generics and the new initializers story, it seemed reasonable
to use this as an excuse to split their semantics from that of
old constructors (which I was going to need to do anyways very
soon).  With that split, I could make progress on having initializers
take in their memory, and added an error for trying to call the
initializer on a generic type (since it would fail compilation with
an obscure error anyways).  Also added a check that the type
designer did not define both initializers and constructors on their
type.

Details:
I added an enum field to AggregateTypes to differentiate based 
on the style used to instantiate an instance.  This enum has three
states: an old style constructor was defined, a new style initializer
was defined, or neither was defined so just go with the compiler
defined one.  Once the first user defined constructor/initializer was
encountered, this field would be updated on the AggregateType,
allowing us to verify upon the next encountered constructor or
initializer (if any) that the style was consistently followed and error
if not.  These actions occur in normalize's
change_method_into_constructor().

Then, I changed the internal name of the init definitions to "init", and
in all the places where constructor calls are inserted if the type
being instantiated had an initializer defined I would call that instead.
This included buildDefaultFunctions' creation of the _defaultOf function
for records, the calls inserted by functionResolution's resolveNew, and
printErrorHeader's output for failures in the init functions.

Then I made the memory change described above.  Moves alloc calls
to the site of the "new" call on types that define our new initializers.
Insert the meme argument into calls from record _defaultOf and initCopy
functions, as well as the compiler-inserted user initializer calls to the parent
initializer and calls from the type constructor.  In buildDefaultWrapper, skip
the alloc call insertion if we define initializers, avoid dereferences of NULL
when handling the meme argument, and pass the meme argument on
straight.

Testing:
Added three tests of the "no type can have both an initializer and a
constructor defined on it" error case, and made one of the "passing"
generic tests into a future again.  Updated the .good for
constAndParamInHeader, which expected to know the type of the
initializer (which is no longer possible at normalize where the failure is
detected.  But we know the line number of the init function, so it's okay).

Tested over std/