### PR TITLE
Trivial updates to a few futures for the SyncAsRecord migration

### DIFF
--- a/test/classes/hannah/configSyncsNotSupported.bad
+++ b/test/classes/hannah/configSyncsNotSupported.bad
@@ -1,1 +1,1 @@
-configSyncsNotSupported.chpl:1: error: illegal cast from string to _syncvar(int(64))
+configSyncsNotSupported.chpl:1: error: type mismatch in assignment from string to _syncvar(int(64))

--- a/test/functions/vass/sync-to-this-of-underlying-type.bad
+++ b/test/functions/vass/sync-to-this-of-underlying-type.bad
@@ -1,2 +1,0 @@
-showme 0
-showme 0

--- a/test/parallel/sync/diten/returnSync.future
+++ b/test/parallel/sync/diten/returnSync.future
@@ -1,8 +1,0 @@
-semantic: Should we be able to return a sync variable?
-
-The change to destroy sync variables when they leave scope makes returning
-syncs problematic, especially since copying syncs is not recommended.  Should
-it be possible to return a sync which would otherwise be cleaned up?
-
-When resolving this future, please remove the skipif and test with
-TASKS=qthreads, as well as fifo+valgrind

--- a/test/parallel/sync/diten/returnSync.good
+++ b/test/parallel/sync/diten/returnSync.good
@@ -1,1 +1,1 @@
-(int(64), _syncvar(int(64)))
+int(64), _syncvar(int(64))

--- a/test/types/sync/vass/int-method-on-sync-int.bad
+++ b/test/types/sync/vass/int-method-on-sync-int.bad
@@ -1,1 +1,0 @@
-in methodOnInt: 55


### PR DESCRIPTION
I overlooked a run with --futures when preparing the migration to a record-wrapped
implementation of sync.  One future was resolved and several others need to be tweaked.

Trivial.

Tested with --futures
