### PR TITLE
Remove unused index variables from several LCALS loops

### DIFF
--- a/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
@@ -29,7 +29,7 @@ module RunARawLoops {
             const eosvmax = loop_data.RealArray_scalars[3];
 
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in 0..#len {
                 bvc[i] = cls * (compression[i] + 1.0);
               }
@@ -70,7 +70,7 @@ module RunARawLoops {
             const q_cut = loop_data.RealArray_scalars[3];
 
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in 0..#len {
                 e_new[i] = e_old[i] - 0.5 * delvc[i] *
                            (p_old[i] + q_old[i]) + 0.5 * work[i];
@@ -170,7 +170,7 @@ module RunARawLoops {
 
             const vnormq = 0.083333333333333333;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in dom.fpz..dom.lpz {
                 const x71 = x7[i] - x1[i],
                       x72 = x7[i] - x2[i],
@@ -260,7 +260,7 @@ module RunARawLoops {
             const ptiny = 1.0e-20;
             const half = 0.5;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for ii in 0..#dom.n_real_zones {
                 const i  = dom.real_zones[ii];
 
@@ -311,7 +311,7 @@ module RunARawLoops {
                   c20 = c10*r_fratio;
             const ireal = 0.0 + 1.0i;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in kmin..kmax-1 {
                 for j in jmin..jmax-1 {
                   var it0    = (k*(jmax+1) + j) * (imax+1);

--- a/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
@@ -28,7 +28,7 @@ module RunBRawLoops {
             var in1  => loop_data.RealArray_1D[3];
             var in2  => loop_data.RealArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in 0..#len {
                 const res = -in1[i] - in2[i];
                 out3[i] = res;
@@ -47,7 +47,7 @@ module RunBRawLoops {
             var in1  => loop_data.RealArray_1D[3];
             var in2  => loop_data.RealArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in 0..#len {
                 out1[i] = in1[i] * in2[i];
                 out2[i] = in1[i] + in2[i];
@@ -65,7 +65,7 @@ module RunBRawLoops {
             var x1 => loop_data.RealArray_1D[3];
             var x2 => loop_data.RealArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in 0..#len {
                 var s = b[i]*b[i] - 4.0*a[i]*c[i];
                 if s >= 0 {
@@ -96,7 +96,7 @@ module RunBRawLoops {
                               trap_int_func(xn, y, xp, yp));
             var val = 0.0;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in 0..#len {
                 var x = x0 + i*h;
                 sumx += trap_int_func(x, y, xp, yp);

--- a/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
@@ -23,7 +23,7 @@ module RunCRawLoops {
                   r = loop_data.RealArray_scalars[1],
                   t = loop_data.RealArray_scalars[2];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in 0..#len {
                 x[k] = q + y[k]*(r*z[k+10] + t*z[k+11]);
               }
@@ -37,7 +37,7 @@ module RunCRawLoops {
                 v => loop_data.RealArray_1D_Nx4[1];
             var ii, ipnt, ipntp, i: int;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               ii = len;
               ipntp = 0;
               do {
@@ -78,7 +78,7 @@ module RunCRawLoops {
             var lw = 0, temp = 0.0;
 
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               var m = (1001-7)/2;
               for k in 6..1000 by m {
                 lw = k-6;
@@ -99,7 +99,7 @@ module RunCRawLoops {
                 y => loop_data.RealArray_1D[1],
                 z => loop_data.RealArray_1D[2];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in 1..len-1 {
                 x[i] = z[i]*(y[i] - x[i-1]);
               }
@@ -118,7 +118,7 @@ module RunCRawLoops {
                   r = loop_data.RealArray_scalars[1],
                   t = loop_data.RealArray_scalars[2];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in 0..#len {
                 x[k] = u[k] + r*(z[k] + r*y[k]) +
                        t*(u[k+3] + r*(u[k+2] + r*u[k+1]) +
@@ -152,7 +152,7 @@ module RunCRawLoops {
             const nl1 = 0, nl2 = 1;
 
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for kx in 1..3-1 {
                 for ky in 1..len-1 {
                   du1[ky] = u1[nl1, ky+1, kx] - u1[nl1, ky-1, kx];
@@ -187,7 +187,7 @@ module RunCRawLoops {
                   dm28 = loop_data.RealArray_scalars[6],
                   c0 = loop_data.RealArray_scalars[7];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in 0..#len {
                 px[i,0] = dm28*px[i,12] + dm27*px[i,11] + dm26*px[i,10] +
                           dm25*px[i,9]  + dm24*px[i,8]  + dm23*px[i,7]  +
@@ -202,7 +202,7 @@ module RunCRawLoops {
             var px => loop_data.RealArray_2D_Nx25[0];
             var cx => loop_data.RealArray_2D_Nx25[1];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in 0..#len {
                 var ar, br, cr: real;
                 ar       =      cx[i,4];
@@ -234,7 +234,7 @@ module RunCRawLoops {
             var x => loop_data.RealArray_1D[0],
                 y => loop_data.RealArray_1D[1];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               x[0] = y[0];
               for k in 1..len-1 {
                 x[k] = x[k-1] + y[k];
@@ -248,7 +248,7 @@ module RunCRawLoops {
             var x => loop_data.RealArray_1D[0],
                 y => loop_data.RealArray_1D[1];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in 0..#len {
                 x[k] = y[k+1] - y[k];
               }
@@ -277,7 +277,7 @@ module RunCRawLoops {
                  Convert the over-indexed pairs into in-bounds pairs */
               return (i+j/25, j%25);
             }
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for ip in 0..#len {
                 var i1, j1, i2, j2: int;
                 // These casts to int(32) overflow and behave differently
@@ -323,7 +323,7 @@ module RunCRawLoops {
                 ir => loop_data.IndxArray_1D[3],
                 grd => loop_data.IndxArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in 0..#len {
                 vx[k] = 0.0;
                 xx[k] = 0.0;
@@ -369,7 +369,7 @@ module RunCRawLoops {
             var kn = 6, jn = len;
 
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in 1..kn-1 {
                 for j in 1..jn-1 {
                   za[k,j] = ( zp[k+1,j-1] +zq[k+1,j-1] -zp[k,j-1] -zq[k,j-1] )*
@@ -410,7 +410,7 @@ module RunCRawLoops {
             var stb5 = loop_data.RealArray_scalars[0];
             var kb5i = 0;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in 0..#len {
                 b5[k+kb5i] = sa[k] + stb5*sb[k];
                 stb5 = b5[k+kb5i] - stb5;
@@ -439,7 +439,7 @@ module RunCRawLoops {
                   t = loop_data.RealArray_scalars[1],
                   dk = loop_data.RealArray_scalars[2];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in 0..#len {
                 var di = y[k] - g[k] / (xx[k] + dk);
                 var dn = 0.2;
@@ -461,7 +461,7 @@ module RunCRawLoops {
                 cx => loop_data.RealArray_2D_Nx25[1],
                 vy => loop_data.RealArray_2D_64x64[0];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in 0..#25 {
                 for i in 0..#25 {
                   for j in 0..#len {
@@ -483,7 +483,7 @@ module RunCRawLoops {
             var expmax = 20.0;
             u[len-1] = 0.99 * expmax*v[len-1];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in 0..#len {
                 y[k] = u[k] / v[k];
                 w[k] = x[k] / (exp(y[k]) - 1.0);
@@ -502,7 +502,7 @@ module RunCRawLoops {
                 zz => loop_data.RealArray_2D_7xN[5];
 
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for j in 1..6-1 {
                 for k in 1..len-1 {
                   var qa = za[j+1,k]*zr[j,k] + za[j-1,k]*zb[j,k] +

--- a/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
@@ -27,7 +27,7 @@ module RunParallelRawLoops {
             const pmin = loop_data.RealArray_scalars[2];
             const eosvmax = loop_data.RealArray_scalars[3];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall i in 0..#len {
                 bvc[i] = cls * (compression[i] + 1.0);
               }
@@ -71,7 +71,7 @@ module RunParallelRawLoops {
             const q_cut = loop_data.RealArray_scalars[3];
 
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall i in 0..#len {
                 e_new[i] = e_old[i] - 0.5 * delvc[i] *
                            (p_old[i] + q_old[i]) + 0.5 * work[i];
@@ -174,7 +174,7 @@ module RunParallelRawLoops {
 
             const vnormq = 0.083333333333333333;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall i in dom.fpz..dom.lpz {
                 const x71 = x7[i] - x1[i],
                       x72 = x7[i] - x2[i],
@@ -264,7 +264,7 @@ module RunParallelRawLoops {
             const ptiny = 1.0e-20;
             const half = 0.5;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall ii in 0..#dom.n_real_zones with (ref dom) {
                 const i  = dom.real_zones[ii];
 
@@ -315,7 +315,7 @@ module RunParallelRawLoops {
                   c20 = c10*r_fratio;
             const ireal = 0.0 + 1.0i;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall k in kmin..kmax-1 {
                 for j in jmin..jmax-1 {
                   var it0    = (k*(jmax+1) + j) * (imax+1);
@@ -399,7 +399,7 @@ module RunParallelRawLoops {
             var in1  => loop_data.RealArray_1D[3];
             var in2  => loop_data.RealArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall i in 0..#len {
                 const res = -in1[i] - in2[i];
                 out3[i] = res;
@@ -418,7 +418,7 @@ module RunParallelRawLoops {
             var in1  => loop_data.RealArray_1D[3];
             var in2  => loop_data.RealArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall i in 0..#len {
                 out1[i] = in1[i] * in2[i];
                 out2[i] = in1[i] + in2[i];
@@ -436,7 +436,7 @@ module RunParallelRawLoops {
             var x1 => loop_data.RealArray_1D[3];
             var x2 => loop_data.RealArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall i in 0..#len {
                 var s = b[i]*b[i] - 4.0*a[i]*c[i];
                 if s >= 0 {
@@ -468,7 +468,7 @@ module RunParallelRawLoops {
             var sumx = 0.0;
             var val = 0.0;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall i in 0..#len with (+ reduce sumx) {
                 var x = x0 + i*h;
                 sumx += trap_int_func(x, y, xp, yp);
@@ -507,7 +507,7 @@ module RunParallelRawLoops {
                  Convert the over-indexed pairs into in-bounds pairs */
               return (i+j/25, j%25);
             }
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall ip in 0..#len {
                 var i1, j1, i2, j2: int;
                 // These casts to int(32) overflow and behave differently

--- a/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
@@ -27,7 +27,7 @@ module RunVectorizeOnlyRawLoops {
             const pmin = loop_data.RealArray_scalars[2];
             const eosvmax = loop_data.RealArray_scalars[3];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in vectorizeOnly(0..#len) {
                 bvc[i] = cls * (compression[i] + 1.0);
               }
@@ -71,7 +71,7 @@ module RunVectorizeOnlyRawLoops {
             const q_cut = loop_data.RealArray_scalars[3];
 
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in vectorizeOnly(0..#len) {
                 e_new[i] = e_old[i] - 0.5 * delvc[i] *
                            (p_old[i] + q_old[i]) + 0.5 * work[i];
@@ -174,7 +174,7 @@ module RunVectorizeOnlyRawLoops {
 
             const vnormq = 0.083333333333333333;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in vectorizeOnly(dom.fpz..dom.lpz) {
                 const x71 = x7[i] - x1[i],
                       x72 = x7[i] - x2[i],
@@ -264,7 +264,7 @@ module RunVectorizeOnlyRawLoops {
             const ptiny = 1.0e-20;
             const half = 0.5;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for ii in vectorizeOnly(0..#dom.n_real_zones) {
                 const i  = dom.real_zones[ii];
 
@@ -315,7 +315,7 @@ module RunVectorizeOnlyRawLoops {
                   c20 = c10*r_fratio;
             const ireal = 0.0 + 1.0i;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for k in vectorizeOnly(kmin..kmax-1) {
                 for j in jmin..jmax-1 {
                   var it0    = (k*(jmax+1) + j) * (imax+1);
@@ -399,7 +399,7 @@ module RunVectorizeOnlyRawLoops {
             var in1  => loop_data.RealArray_1D[3];
             var in2  => loop_data.RealArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in vectorizeOnly(0..#len) {
                 const res = -in1[i] - in2[i];
                 out3[i] = res;
@@ -418,7 +418,7 @@ module RunVectorizeOnlyRawLoops {
             var in1  => loop_data.RealArray_1D[3];
             var in2  => loop_data.RealArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in vectorizeOnly(0..#len) {
                 out1[i] = in1[i] * in2[i];
                 out2[i] = in1[i] + in2[i];
@@ -436,7 +436,7 @@ module RunVectorizeOnlyRawLoops {
             var x1 => loop_data.RealArray_1D[3];
             var x2 => loop_data.RealArray_1D[4];
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               for i in vectorizeOnly(0..#len) {
                 var s = b[i]*b[i] - 4.0*a[i]*c[i];
                 if s >= 0 {
@@ -468,7 +468,7 @@ module RunVectorizeOnlyRawLoops {
             var sumx = 0.0;
             var val = 0.0;
             ltimer.start();
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall i in vectorizeOnly(0..#len) with (+ reduce sumx) {
                 var x = x0 + i*h;
                 sumx += trap_int_func(x, y, xp, yp);
@@ -508,7 +508,7 @@ module RunVectorizeOnlyRawLoops {
                  Convert the over-indexed pairs into in-bounds pairs */
               return (i+j/25, j%25);
             }
-            for isamp in 0..#num_samples {
+            for 0..#num_samples {
               forall ip in vectorizeOnly(0..#len) {
                 var i1, j1, i2, j2: int;
                 // These casts to int(32) overflow and behave differently


### PR DESCRIPTION
The loop kernels in LCALS all do:

```
for isamp in 0..#num_samples {
  for i in someRange {
    <kernel using i>
  }
}
```

Almost none of the kernels use 'isamp', so change the outer loop to not use an
index variable.  The only kernels that do use 'isamp' are FIR, INNER_PROD,
and FIND_FIRST_MIN.