### PR TITLE
Style edits to meteor-fast

### DIFF
--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -201,6 +201,17 @@ o once we have a .size query on enums, we should replace uses of PIVOT
 
 o would using 1-based arrays rather than 0-based clean anything up?
 
+o It would be nice to write:
+    var x = min reduce for x in X do x;
+  as:
+    serial var x = min reduce X;
+  or (preferably):
+    var x = serial min reduce X;
+  this suggests either adding a serial expression or permitting
+  reductions to be prefixed by 'serial'
+
+
+
 nbody.chpl
 ----------
 o explore possibility of enabling vectorization (perhaps by applying

--- a/test/release/examples/benchmarks/shootout/meteor-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/meteor-fast.chpl
@@ -1,164 +1,215 @@
 /* The Computer Language Benchmarks Game
- * http://benchmarksgame.alioth.debian.org/
- *
- * contributed by Kyle Brady
- * based upon the C++ implementation by Stefan Westen which states it was
- * loosely based on Ben St. John's and Kevin Barnes' implementation
+   http://benchmarksgame.alioth.debian.org/
+
+   contributed by Kyle Brady and Ben Albrecht
+   derived from the C++ implementation by Stefan Westen
  */
 
 use BitOps;
 
-const pieceCount: int(32) = 10;
-const pieces: [0..9][0..4][0..1] int(32) = [
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [2:int(32), 0:int(32)], [3:int(32), 0:int(32)], [3:int(32), 1:int(32)]],
-  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [-2:int(32), 2:int(32)], [-1:int(32), 2:int(32)], [-3:int(32), 3:int(32)]],
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [2:int(32), 0:int(32)], [-1:int(32), 1:int(32)], [-1:int(32), 2:int(32)]],
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [2:int(32), 0:int(32)], [1:int(32), 1:int(32)], [1:int(32), 2:int(32)]],
-  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [1:int(32), 1:int(32)], [-1:int(32), 2:int(32)], [1:int(32), 2:int(32)]],
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [-2:int(32), 1:int(32)], [-1:int(32), 1:int(32)], [0:int(32), 1:int(32)]],
-  [[0:int(32), 0:int(32)], [1:int(32), 0:int(32)], [0:int(32), 1:int(32)], [-1:int(32), 2:int(32)], [-1:int(32), 3:int(32)]],
-  [[0:int(32), 0:int(32)], [2:int(32), 0:int(32)], [-1:int(32), 1:int(32)], [0:int(32), 1:int(32)], [1:int(32), 1:int(32)]],
-  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [0:int(32), 2:int(32)], [1:int(32), 2:int(32)], [1:int(32), 3:int(32)]],
-  [[0:int(32), 0:int(32)], [0:int(32), 1:int(32)], [0:int(32), 2:int(32)], [-1:int(32), 3:int(32)], [0:int(32), 3:int(32)]]
-];
+param boardCells = 50,          // Number of cells on board
+      boardWidth = 5,           // Number of cells along x-axis
+      boardHeight = 10,         // Number of cells along y-axis
+      totalMasks = 8192,        // Upper bound for allMasks needed (power of 2)
+      piecePermutations = 12,   // Number of permutations for a single piece
+      numPieces = 10,           // Number of puzzle pieces
+      pieceCells = 5;           // Number of cells that make up a puzzle piece
 
-var allMasks: [0..8191] uint(32);
-var maskStart: [0..49][0..7] uint(32);
+const boardDom = {0..#boardCells},
+      piecesDom = {0..#numPieces};
 
-var minSolution: [0..49] uint(8);
-var maxSolution: [0..49] uint(8);
-var solutions: uint(32);
+// Arrays of masks to store all pieces and their possible configurations
+var allMasks: [0..#totalMasks] int,
+    maskStart: [boardDom][0..#numPieces-2] int;
 
-var evenRowsLookup: [0..49] uint(32);
-var leftBorderLookup: [0..49] uint(32);
+// Arrays of min and max, and an integer storing the number of solutions
+var minSolution, maxSolution: [boardDom] int,
+    solutions = 0;
 
-proc goodPiece(mask: uint(32), pos: uint(32)): bool {
-   var isGood: bool = true;
-   const evenRows: uint = 0xf07c1f07c1f07c1f;
-   const oddRows: uint = ~evenRows;
-   const leftBorder: uint = 0x1084210842108421;
-   const rightBorder: uint = leftBorder >> 1;
-   var a, b, aOld, s1, s2, s3, s4, s5, s6, s7, s8: uint;
+// Masks for evens and left border
+var evenRowsLookup, leftBorderLookup: [boardDom] int;
 
-   b = (mask:uint << pos) | 0xFFFC000000000000;
+// Predefined masks commonly used throughout program
+param maskEven   = 0xf07c1f07c1f07c1f: int, // Even rows of board (0, 2, 4, ..)
+      maskBorder = 0x1084210842108421: int, // Right border of board
+      maskBoard  = 0xFFFC000000000000: int, // bits of board within 64-bit int
+      maskBottom = 0x00000000003FFFFF: int, // Bottom 22 elements of boards
+      maskUsed   = 0x00000000FFC00000: int; // Board + 4 additional bits
 
-   b = ~b;
+//
+// Find and print the minimum and maximum solutions to meteor puzzle
+//
+proc main(args: [] string) {
 
-   while b {
-      a = b & (-(b:int)):uint;
+  initialize();
 
-      do {
-         s1 = a << 5;
-         s2 = a >> 5;
-         s3 = (a << 1) & (~leftBorder);
-         s4 = (a >> 1) & (~rightBorder);
-         s5 = ((a & evenRows) >> 6) & (~rightBorder);
-         s6 = ((a & evenRows) << 4) & (~rightBorder);
-         s7 = ((a & oddRows) >> 4) & (~leftBorder);
-         s8 = ((a & oddRows) << 6) & (~leftBorder);
-         aOld = a;
-         a = (a|s1|s2|s3|s4|s5|s6|s7|s8) & b;
-      } while aOld != a;
+  sync searchParallel();
 
-      if popcount(a)%5 != 0 {
-         isGood = false;
-         break;
-      }
-      b ^= a;
-   }
-   return isGood;
+  writef("%i solutions found\n\n", solutions);
+  printBoard(minSolution);
+  printBoard(maxSolution);
 }
 
-proc initialise() {
-  for i in 0..49 {
-    evenRowsLookup[i] = (0xF07C1F07C1F07C1F >> i):uint(32);
-    leftBorderLookup[i] = (0x1084210842108421 >> i):uint(32);
+
+//
+// Set up allMasks with pre-filtered piece permutations to search
+//
+proc initialize() {
+
+  // Set up array of evens and borders masks
+  for i in 0..#boardCells {
+    evenRowsLookup[i] = (maskEven >> i);
+    leftBorderLookup[i] = (maskBorder >> i);
   }
 
-  var totalCount: uint(32);
-  var x: [0..4] int(32);
-  var y: [0..4] int(32);
-  for yBase in 2..3:int(32) {
-    for xBase in 0..4:int(32) {
-      const pos: uint(32) = (xBase+5*yBase):uint(32);
+  var totalCount = 0,
+      coords: [0..#pieceCells] 2*int;
+
+  /* The 10 puzzle pieces are defined with hexagonal cell coordinates, where
+     the first cell of a piece always begins at the origin cell, (0, 0).
+     This coordinate system is best conveyed through a diagram:
+
+                         (0, -1)       (1, -1)
+
+                  (-1, 0)       (0 , 0)       (1 , 0)
+
+                         (-1, 1)       (0 , 1)
+
+     Therefore, the cell to the South of the origin can be computed as follows:
+
+        S =    SW   +   SE
+        S = (-1, 1) + (0, 1) = (-1, 2)
+
+     The following illustrates the piece shapes and their cell indices:
+
+        Piece 0      Piece 1      Piece 2      Piece 3      Piece 4
+
+        0 1 2 3         0          0 1 2        0 1 2        0
+               4         1        3                3          1 2
+                      2 3          4                4        3   4
+                     4
+
+        Piece 5      Piece 6      Piece 7      Piece 8      Piece 9
+
+           0 1        0 1          0   1        0            0
+        2 3 4          2          2 3 4          1            1
+                      3                           2 3          2
+                       4                             4        3 4
+
+  */
+  const pieces: [piecesDom][0..#pieceCells] 2*int =
+  [
+    [(0, 0), (1, 0), ( 2, 0), ( 3, 0), ( 3, 1)],
+    [(0, 0), (0, 1), (-2, 2), (-1, 2), (-3, 3)],
+    [(0, 0), (1, 0), ( 2, 0), (-1, 1), (-1, 2)],
+    [(0, 0), (1, 0), ( 2, 0), ( 1, 1), ( 1, 2)],
+    [(0, 0), (0, 1), ( 1, 1), (-1, 2), ( 1, 2)],
+    [(0, 0), (1, 0), (-2, 1), (-1, 1), ( 0, 1)],
+    [(0, 0), (1, 0), ( 0, 1), (-1, 2), (-1, 3)],
+    [(0, 0), (2, 0), (-1, 1), ( 0, 1), ( 1, 1)],
+    [(0, 0), (0, 1), ( 0, 2), ( 1, 2), ( 1, 3)],
+    [(0, 0), (0, 1), ( 0, 2), (-1, 3), ( 0, 3)]
+  ];
+
+  // Generate bit mask for permutations of all pieces that fit on rows 2 & 3
+  for yBase in 2..3 {
+    for xBase in 0..#boardWidth {
+      // Compute base position for xBase, yBase coordinates
+      const pos = (xBase + boardWidth * yBase);
+
+      // Record total number of fitted pieces at this point
       maskStart[pos][0] = totalCount;
-      for piece in 0..pieceCount-1 {
-        for j in 0..4 {
-          x[j] = pieces[piece][j][0];
-          y[j] = pieces[piece][j][1];
-        }
 
-        for currentRotation in 0..11 {
-          if piece != 3 || (currentRotation/3) % 2 == 0 {
-            var minX: int(32) = x[0];
-            var minY: int(32) = y[0];
-            for i in 1..4 {
-              if y[i] < minY || (y[i] == minY && x[i] < minX) {
-                minX = x[i];
-                minY = y[i];
-              }
+      // Loop over piece indices
+      for piece in 0..#numPieces {
+
+        // Get x y coordinates of piece cells
+        for (coord, pieceCell) in zip(coords, pieces[piece]) do
+          coord = pieceCell;
+
+        // Loop over 12 permutations for a given piece (6 rotations * 2 flips)
+        for currentPermutation in 0..#piecePermutations {
+
+          // Skip piece 3 and specific permutations
+          if piece != 3 || (currentPermutation/3) % 2 == 0 {
+
+            //
+            // Overload min function to use for reduction of piece coordinates
+            //
+            proc min((x1, y1), (x2, y2)) {
+              if y1 < y2 || (y1 == y2 && x1 < x2) then
+                return (x1, y1);
+              return (x2, y2);
             }
 
-            var mask: uint(32);
-            var fit: bool = true;
+            // Serial reduction to find min coords of a given permutation
+            var (xMin, yMin) = min reduce for c in coords do c;
 
-            for i in 0..4 {
-              var nX: int(32) = (x[i]-minX+(xBase-yBase/2)) + (y[i]-minY+yBase)/2;
-              var nY: int(32) = y[i]-minY+yBase;
-              if nX >= 0 && nX < 5 {
-                var numBits: int(32) = nX-xBase+5*(nY-yBase);
-                mask |= (1:int(32)<<numBits);
-              } else {
+            var mask = 0,       // Bit mask representing piece's permutation
+                fit = true;     // Track if piece's permutation fits board
+
+            // Offsets for piece coordinates, such that 'island' is not formed
+            const xOff = (xBase - yBase/2) - xMin,
+                  yOff= yBase - yMin;
+
+            // Set bit mask for given piece's permutation if it fits on board
+            for (x, y) in coords {
+
+              var nY = y + yOff,
+                  nX = x + xOff + nY/2;
+
+              if nX >= 0 && nX < boardWidth {
+                const numBits = nX - xBase + boardWidth * (nY - yBase);
+                mask |= (1 << numBits);
+              } else
                 fit = false;
-              }
             }
+
+            // If it fits and is a "good piece", add it to the array of masks
             if fit {
               if goodPiece(mask, pos) {
-                allMasks[totalCount] = mask|(1:int(32)<<(piece+22));
+                allMasks[totalCount] = mask | (1 << (piece + 22));
                 totalCount += 1;
               }
             }
           }
 
-          for i in 0..4 {
-            const xnew: int(32) = x[i]+y[i];
-            const ynew: int(32) = -x[i];
-            x[i] = xnew;
-            y[i] = ynew;
-            if currentRotation == 5 {
-              const xnew:int(32) = x[i]+y[i];
-              const ynew:int(32) = -y[i];
-              x[i] = xnew;
-              y[i] = ynew;
-            }
+          // Permute piece for next iteration
+          for (x, y) in coords {
+            // Rotation
+            (x, y) = (x + y, -x);
+
+            // Reflection
+            if currentPermutation == 5 then
+              (x, y) = (x + y, -y);
           }
-        }
-      }
+        } // permutations
+      } // pieces
+
       allMasks[totalCount] = 0;
       totalCount += 1;
-    }
-  }
+    } // xBase
+  } // yBase
 
-   // copy rows 2 and 3 to other rows
-
-  for yBase in 0..9:int(32) {
-    if yBase!=2 && yBase!=3 {
-      for xBase in 0..4:int(32) {
-        const pos: uint(32) = (xBase+5*yBase):uint(32);
-        const origPos: int(32) = xBase+5*(yBase%2+2);
+  // Generate bit masks for translation of permutations that fit on rows 2 & 3
+  for yBase in 0..#boardHeight {
+    // Skip rows 2 & 3, since we already generated their masks
+    if yBase != 2 && yBase != 3 {
+      for xBase in 0..#boardWidth {
+        const pos = (xBase + boardWidth * yBase),
+              origPos = xBase + boardWidth * (yBase % 2 + 2);
         maskStart[pos][0] = totalCount;
-        var pMask: uint(32) = maskStart[origPos][0];
-        const bottom: uint(32) = ((0xFFFC000000000000>>pos) & 0x003FFFFF):uint(32);
-        const lastRow: uint(32) = ((0xFFFC000000000000>>(pos+5)) & 0x003FFFFF):uint(32);
+        var pMask = maskStart[origPos][0];
+        const bottom = ((maskBoard >> pos) & maskBottom),
+              lastRow = ((maskBoard >> (pos + boardWidth)) & maskBottom);
         while allMasks[pMask] {
-          var mask: uint(32) = allMasks[pMask];
+          const mask = allMasks[pMask];
           pMask += 1;
           if (mask & bottom) == 0 {
-            if yBase == 0 || ((mask & lastRow) != 0) {
-              if !goodPiece(mask&0x003FFFFF, pos) {
-                continue;
-              }
-            }
+            if (yBase == 0 || ((mask & lastRow) != 0)) &&
+               !goodPiece(mask & maskBottom, pos) then
+              continue;
+
             allMasks[totalCount] = mask;
             totalCount += 1;
           }
@@ -169,15 +220,15 @@ proc initialise() {
     }
   }
 
-  for filter in 1..7:uint(32) {
-    for pos in 0..49:uint(32) {
+  for filter in 1..7 {
+    for pos in 0..#boardCells {
       maskStart[pos][filter] = totalCount;
-      var filterMask: uint(32);
-      filterMask = ((filter&1)<<1) | ((filter&6)<<(4-(evenRowsLookup[pos]&1)));
-      var pMask: uint(32) = maskStart[pos][0];
+      const filterMask = ((filter & 1) << 1) |
+                         ((filter & 6) << (4 - (evenRowsLookup[pos] & 1)));
+      var pMask = maskStart[pos][0];
       while allMasks[pMask] {
-        const mask:uint(32) = allMasks[pMask];
-        if (mask&filterMask) == 0 {
+        const mask = allMasks[pMask];
+        if (mask & filterMask) == 0 {
           allMasks[totalCount] = mask;
           totalCount += 1;
         }
@@ -189,190 +240,39 @@ proc initialise() {
   }
 }
 
-proc compareSolution(board: [] uint(8), minSolution: [] uint(8),
-                     maxSolution: [] uint(8)) {
-  var i, j: int(32);
 
-  for i in 0..49 {
-    if board[i] < minSolution[i] {
-      for j in 0..49 {
-        minSolution[j] = board[j];
-      }
-      break;
-    } else if board[i] > minSolution[i] {
-      break;
-    }
-  }
-  for i in 0..49 {
-    if board[i] > maxSolution[i] {
-      for j in 0..49 {
-        maxSolution[j] = board[j];
-      }
-      break;
-    } else if board[i] < maxSolution[i] {
-      break;
-    }
-  }
-}
+//
+// Add initial piece to board, then fire off remaining searches in parallel
+//
+proc searchParallel(in board=0, in pos=0, used=0, placed=0, firstPiece=0) {
 
-proc printBoard(board: [] uint(8)) {
-  for i in 0..49 {
-    writef("%i ", board[i]);
-    if i%5 == 4 {
-      writeln();
-      if (i&1) == 0 {
-        write(" ");
-      }
-    }
-  }
-  writeln();
-}
-
-proc recordSolution(currentSolution: [] uint(32)) {
-  var board: [0..49] uint(8);
-  var flipBoard: [0..49] uint(8);
-  var mask, pos, currentBit, b1 : uint(32);
-  var piece, count : uint(32);
-  for i in 0..9 {
-    mask = currentSolution[i];
-    piece = ctz(mask>>22:uint(32)):uint(32);
-    mask &= 0x003FFFFF;
-    b1 |= mask;
-    while mask {
-      currentBit = mask&(-(mask:int(32))):uint(32);
-      count = ctz(currentBit):uint(32);
-      board[count+pos] = piece:uint(8);
-      flipBoard[49-count-pos] = piece:uint(8);
-      mask ^= currentBit;
-    }
-    count = ctz(~b1);
-    pos += count;
-    b1 >>= count;
-  }
-  if solutions == 0 {
-    for i in 0..49 {
-      minSolution[i] = board[i];
-      maxSolution[i] = board[i];
-    }
-  } else {
-    compareSolution(board, minSolution, maxSolution);
-    compareSolution(flipBoard, minSolution, maxSolution);
-  }
-
-  solutions += 2;
-}
-
-record Spinlock {
-  var l: atomic bool;
-
-  proc lock() {
-    while l.testAndSet() != false do chpl_task_yield();
-  }
-
-  proc unlock() {
-    l.write(false);
-  }
-}
-
-var recordLock: Spinlock;
-
-proc searchLinear(in board: uint(32), in pos: uint(32), in used: uint(32),
-                  in placed: uint(32), currentSolution: [] uint(32)) {
-  var count : uint(32);
-  var evenRows, oddRows, leftBorder, rightBorder: uint(32);
-  var s1, s2, s3, s4, s5, s6, s7, s8: uint(32);
-  if placed == 10 {
-    recordLock.lock();
-    recordSolution(currentSolution);
-    recordLock.unlock();
-  } else {
-    evenRows = evenRowsLookup[pos];
-
-    oddRows = ~evenRows;
-
-    leftBorder = leftBorderLookup[pos];
-    rightBorder = leftBorder>>1;
-
-    s1 = (board << 1) | leftBorder;
-    s2 = (board >> 1) | rightBorder;
-    s3 = (board << 4) | ((1<<4)-1) | rightBorder;
-    s4 = (board >> 4) | leftBorder;
-    s5 = (board << 5) | ((1<<5)-1);
-    s6 = (board >> 5);
-    s7 = (board << 6) | ((1<<6)-1) | leftBorder;
-    s8 = (board >> 6) | rightBorder;
-
-    if ~board&s1&s2&s5&s6 & ((evenRows&s4&s7) | (oddRows&s3&s8)) {
-      return;
-    }
-
-    count = ctz(~board);
-    pos += count;
-    board >>= count;
-
-    const f: uint(32) = ((board>>1)&1) | ((board >> (4-(evenRowsLookup[pos] & 1)))&6);
-    const boardAndUsed = board|used;
-
-    var mask: uint(32);
-    var currentMask: uint(32) = maskStart[pos][f];
-
-    while allMasks[currentMask] {
-      while allMasks[currentMask] & boardAndUsed {
-        currentMask += 1;
-      }
-      if allMasks[currentMask] {
-        mask = allMasks[currentMask];
-        currentSolution[placed] = mask;
-        searchLinear(board|(mask & 0x003FFFFF:uint(32)), pos,
-                     used|(mask & 0xFFC00000:uint(32)), placed+1,
-                     currentSolution);
-        currentMask += 1;
-      }
-    }
-  }
-}
-
-proc searchLinearHelper(in board: uint(32), in pos: uint(32),
-                        in used: uint(32), in placed: uint(32),
-                        in firstPiece: uint(32), in mask: uint(32)) {
-  var currentSolution: [0..9] uint(32);
-  currentSolution[0] = firstPiece;
-  currentSolution[1] = mask;
-  begin searchLinear(board, pos, used, placed, currentSolution);
-}
-
-
-proc searchParallel(in board: uint(32), in pos: uint(32), in used: uint(32),
-                    in placed: uint(32), in firstPiece: uint(32)) {
-  var count: uint(32);
-
-  count = ctz(~board):uint(32);
+  const count = ctz(~board);
   pos += count;
   board >>= count;
 
-  const boardAndUsed: uint(32) = board|used;
-  var currentMask: uint(32) = maskStart[pos][0];
-  var mask: uint(32);
+  const boardAndUsed = board | used;
+  var currentMask = maskStart[pos][0];
 
   if placed == 0 {
     while allMasks[currentMask] {
       if allMasks[currentMask] {
-        mask = allMasks[currentMask];
+        const mask = allMasks[currentMask];
         currentMask += 1;
-        searchParallel(board|(mask&0x003FFFFF), pos,
-                       used|(mask&0xFFC00000:uint(32)), placed+1, mask);
+        searchParallel(board | (mask & maskBottom), pos,
+                       used | (mask & maskUsed), placed + 1, mask);
       }
     }
-  } else {   // placed == 1
+  // 1 piece has been placed
+  } else {
     while allMasks[currentMask] {
-      while allMasks[currentMask] & boardAndUsed {
+      while allMasks[currentMask] & boardAndUsed do
         currentMask += 1;
-      }
+
       if allMasks[currentMask] {
-        mask = allMasks[currentMask];
+        const mask = allMasks[currentMask];
         currentMask += 1;
-        searchLinearHelper(board|((mask&0x003FFFFF)), pos,
-                           used|(mask&0xFFC00000:uint(32)),  placed+1,
+        searchLinearHelper(board | (mask & maskBottom), pos,
+                           used | (mask & maskUsed), placed+1,
                            firstPiece, mask);
       }
     }
@@ -380,18 +280,206 @@ proc searchParallel(in board: uint(32), in pos: uint(32), in used: uint(32),
 }
 
 
-proc main(args: [] string): int
-{
-  if args.size > 2 then
-    return 1;
-
-  initialise();
-
-  sync searchParallel(0,0,0,0,0);
-
-  writef("%i solutions found\n\n", solutions);
-  printBoard(minSolution);
-  printBoard(maxSolution);
-
-  return 0;
+//
+// Pretty printed output of board
+//
+proc printBoard(board) {
+  for i in 0..#boardCells {
+    writef("%i ", board[i]);
+    if i % boardWidth == 4 {
+      writeln();
+      if i & 1 == 0 then
+        write(" ");
+    }
+  }
+  writeln();
 }
+
+
+//
+// Determine if piece and permutation (mask) at a given position (pos) is valid
+//
+proc goodPiece(mask, pos) {
+   const evenRows = maskEven,
+         oddRows = ~evenRows,
+         leftBorder = maskBorder,
+         rightBorder = leftBorder >> 1;
+
+   var b = (mask << pos) | maskBoard;
+
+   b = ~b;
+
+   while b {
+      var a = b & (-b);
+
+      do {
+        const s1 = a << 5,
+              s2 = a >> 5,
+              s3 = (a << 1) & (~leftBorder),
+              s4 = (a >> 1) & (~rightBorder),
+              s5 = ((a & evenRows) >> 6) & (~rightBorder),
+              s6 = ((a & evenRows) << 4) & (~rightBorder),
+              s7 = ((a & oddRows) >> 4) & (~leftBorder),
+              s8 = ((a & oddRows) << 6) & (~leftBorder),
+              aOld = a;
+        a = (a | s1 | s2 | s3 | s4 | s5 | s6 | s7 | s8) & b;
+      } while aOld != a;
+
+      if popcount(a) % 5 != 0 then
+        return false;
+
+      b ^= a;
+   }
+   return true;
+}
+
+
+//
+// Wrapper to set up initial call to recursive searchLinear
+//
+proc searchLinearHelper(board, pos, used, placed, firstPiece, mask) {
+  var currentSolution: [piecesDom] int;
+  currentSolution[0] = firstPiece;
+  currentSolution[1] = mask;
+  begin searchLinear(board, pos, used, placed, currentSolution);
+}
+
+
+//
+// Exponential backoff spin-wait lock that yields every so many contested locks
+// to avoid potentially starving other tasks. This results in slightly faster
+// runtime than just using a sync var because it has lower latency.
+//
+record BackoffSpinLock {
+  var l: atomic bool,
+      lockAttempts = 0,
+      maxLockAttempts = (2**16-1);
+
+  inline proc lock() {
+    while l.testAndSet() {
+      lockAttempts += 1;
+      if (lockAttempts & maxLockAttempts) == 0 {
+        maxLockAttempts >>= 1;
+        chpl_task_yield();
+      }
+    }
+  }
+
+  inline proc unlock() {
+    l.clear();
+  }
+}
+
+// Minimally contended lock that serializes calls to recordSolution()
+var recordSolutionLock: BackoffSpinLock;
+
+
+//
+// Recursively add pieces to the board, and check solution when filled
+//
+proc searchLinear(in board, in pos, used, placed, currentSolution) {
+
+  if placed == numPieces {
+    recordSolutionLock.lock();
+    recordSolution(currentSolution);
+    recordSolutionLock.unlock();
+  } else {
+    const evenRows = evenRowsLookup[pos],
+          oddRows = ~evenRows,
+
+          leftBorder = leftBorderLookup[pos],
+          rightBorder = leftBorder >> 1,
+
+          s1 = (board << 1) | leftBorder,
+          s2 = (board >> 1) | rightBorder,
+          s3 = (board << 4) | ((1 << 4) - 1) | rightBorder,
+          s4 = (board >> 4) | leftBorder,
+          s5 = (board << 5) | ((1 << 5) - 1),
+          s6 = (board >> 5),
+          s7 = (board << 6) | ((1 << 6) - 1) | leftBorder,
+          s8 = (board >> 6) | rightBorder;
+
+    if ~board & s1 & s2 & s5 & s6 &
+       ((evenRows & s4 & s7) | (oddRows & s3 & s8)) then return;
+
+    const count = ctz(~board);
+    pos += count;
+    board >>= count;
+
+    const f = ((board >> 1) & 1) |
+              ((board >> (4 - (evenRowsLookup[pos] & 1))) & 6),
+          boardAndUsed = board | used;
+
+    var currentMask = maskStart[pos][f];
+
+    while allMasks[currentMask] {
+
+      while allMasks[currentMask] & boardAndUsed do
+        currentMask += 1;
+
+      if allMasks[currentMask] {
+        const mask = allMasks[currentMask];
+        currentSolution[placed] = mask;
+        searchLinear(board | (mask & maskBottom), pos,
+                     used | (mask & maskUsed), placed + 1, currentSolution);
+        currentMask += 1;
+      }
+    }
+  }
+}
+
+
+//
+// Check a given board as a solution and record it
+//
+proc recordSolution(currentSolution) {
+  var board, flipBoard: [boardDom] int,
+      pos, b1, count = 0;
+
+  for i in 0..#numPieces {
+    var mask = currentSolution[i];
+    const piece = ctz(mask >> 22);
+    mask &= maskBottom;
+    b1 |= mask;
+    while mask {
+      const currentBit = mask & (-mask);
+      count = ctz(currentBit);
+      board[count + pos] = piece;
+      flipBoard[49 - count - pos] = piece;
+      mask ^= currentBit;
+    }
+    count = ctz(~b1);
+    pos += count;
+    b1 >>= count;
+  }
+  if solutions == 0 {
+    minSolution = board;
+    maxSolution = board;
+  } else {
+    compareSolution(board);
+    compareSolution(flipBoard);
+  }
+
+  solutions += 2;
+}
+
+
+//
+// Determine whether a solution is a min or max solution
+//
+proc compareSolution(board) {
+
+  for i in 0..#boardCells {
+    if board[i] < minSolution[i] {
+      minSolution = board;
+      break;
+    } else if board[i] > minSolution[i] then break;
+  }
+  for i in 0..#boardCells {
+    if board[i] > maxSolution[i] {
+      maxSolution = board;
+      break;
+    } else if board[i] < maxSolution[i] then break;
+  }
+}
+

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel-alt.chpl
@@ -30,11 +30,11 @@ var minSolution, maxSolution: [boardDom] int,
 var evenRowsLookup, leftBorderLookup: [boardDom] int;
 
 // Predefined masks commonly used throughout program
-param maskEven   = 0xf07c1f07c1f07c1f:int,  // Even rows of board (0, 2, 4, ..)
-      maskBorder = 0x1084210842108421:int,  // Right border of board
-      maskBoard  = 0xFFFC000000000000:int,  // bits of board within 64-bit int
-      maskBottom = 0x00000000003FFFFF:int,  // Bottom 22 elements of boards
-      maskUsed   = 0x00000000FFC00000:int;  // Board + 4 additional bits
+param maskEven   = 0xf07c1f07c1f07c1f: int, // Even rows of board (0, 2, 4, ..)
+      maskBorder = 0x1084210842108421: int, // Right border of board
+      maskBoard  = 0xFFFC000000000000: int, // bits of board within 64-bit int
+      maskBottom = 0x00000000003FFFFF: int, // Bottom 22 elements of boards
+      maskUsed   = 0x00000000FFC00000: int; // Board + 4 additional bits
 
 //
 // Find and print the minimum and maximum solutions to meteor puzzle
@@ -206,11 +206,10 @@ proc initialize() {
           const mask = allMasks[pMask];
           pMask += 1;
           if (mask & bottom) == 0 {
-            if yBase == 0 || ((mask & lastRow) != 0) {
-              if !goodPiece(mask & maskBottom, pos) {
-                continue;
-              }
-            }
+            if (yBase == 0 || ((mask & lastRow) != 0)) &&
+               !goodPiece(mask & maskBottom, pos) then
+              continue;
+
             allMasks[totalCount] = mask;
             totalCount += 1;
           }
@@ -421,7 +420,7 @@ proc searchLinear(in board, in pos, used, placed, currentSolution) {
       if allMasks[currentMask] {
         const mask = allMasks[currentMask];
         currentSolution[placed] = mask;
-        searchLinear(board | (mask & maskBottom), pos, 
+        searchLinear(board | (mask & maskBottom), pos,
                      used | (mask & maskUsed), placed + 1, currentSolution);
         currentMask += 1;
       }


### PR DESCRIPTION
This is my set of proposed cleanups to the faster meteor version:

* removed multi-step history of program because previous program will
  itself embed that, we don't do this for other versions, and in the
  limit, many of our versions would result in a huge link of predecessors.
* replaced a lot of 'var x: int' with 'var x = 0' because the code
  relies on the value to be a '0', the intent seems clearer for
  someone not familiar with Chapel's auto-initialization, and it's
  just as clearly an 'int'.
* changed base-case arguments to searchParallel() into default arguments
* changed some instances of "setup" (a noun) into "set up" (an action)
* changed some vars into consts
* introduced curly brackets for single statement control flow where the
  body of that control flow is itself multi-line control flow.
* replaced unnecessary uses of 'in' intents
* pushed variable/const declarations to first point of definition.
* changed a variable + break into returns
* removed some seemingly unnecessary uint casts
* reformatted a long line
* Flattened an unnecessarily nested conditional

One change I did not make, but was tempted to, was to flatted initial blank lines out of 'proc's which look strange and too space-y to my eye (and that's as someone who's usually a big fan of vertical whitespace.

Added a TODO to the README about serial reductions.