### PR TITLE
Move test of empty file revcomp

### DIFF
--- a/test/release/examples/benchmarks/shootout/revcomp.execopts
+++ b/test/release/examples/benchmarks/shootout/revcomp.execopts
@@ -1,2 +1,1 @@
 --n=0 < fasta-revcomp.small
---n-0 < /dev/null           # revcomp-empty.good

--- a/test/studies/shootout/reverse-complement/bradc/EXECOPTS
+++ b/test/studies/shootout/reverse-complement/bradc/EXECOPTS
@@ -1,1 +1,0 @@
---n=0 < fasta.small

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.execopts
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.execopts
@@ -1,0 +1,2 @@
+--n=0 < fasta.small
+--n=0 < /dev/null           # revcomp-empty.good


### PR DESCRIPTION
Last week, I added a conditional to protect against revcomp being sent
  an extra file, which had previously resulted in an OOB error.

Last night, I added a suppression to revcomp for XC testing in order
  to squash the file.length() issues until we have a chance to understand
  them better.

However, I failed to consider that the suppression would cause a "passing
  suppression" message for the empty file case (which works on the XC
  as expected, though for the wrong reasons)

Here, I'm moving the empty file test into my own study version of revcomp.
This isn't completely satisfactory because the release version won't be
safe when an empty file is passed in.  OTOH, it removes an extra .good
file from the release directory for a corner-case that the competition
doesn't necessarily require us to guard against, so it's probably
acceptable.

Note that our EXECOPTS files don't seem to support multiple lines (can
that be right?), so I moved it to a .execopts file.