### PR TITLE
Add an error if a constructor or initializer is declared without parentheses

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1726,6 +1726,10 @@ static void change_method_into_constructor(FnSymbol* fn) {
   if (!ct)
     INT_FATAL(fn, "initializer on non-class type");
 
+  if (fn->hasFlag(FLAG_NO_PARENS)) {
+    USR_FATAL(fn, "a%s cannot be declared without parentheses", isCtor ? " constructor" : "n initializer");
+  }
+
   if (ct->initializerStyle == DEFINES_NONE_USE_DEFAULT) {
     // We hadn't previously seen a constructor or initializer definition.
     // Update the field on the type appropriately.

--- a/test/classes/constructors/error-parenthesless-constructor.bad
+++ b/test/classes/constructors/error-parenthesless-constructor.bad
@@ -1,1 +1,0 @@
-x constructor

--- a/test/classes/constructors/error-parenthesless-constructor.future
+++ b/test/classes/constructors/error-parenthesless-constructor.future
@@ -1,8 +1,0 @@
-semantic: disallow parenthesis-less constructors
-
-Brad and Vass feel that Chapel should not allow constructor methods to
-be declared without parentheses.
-
-Note: in the current implementation one can write both constructors
-(both with no arguments) at the same time. Then when invoking
-new classname(), the compiler finds that call ambiguous.

--- a/test/classes/initializers/error-parenthesless-initializer.future
+++ b/test/classes/initializers/error-parenthesless-initializer.future
@@ -1,8 +1,0 @@
-semantic: disallow parenthesis-less initializers
-
-Brad and Vass feel that Chapel should not allow initializer methods to
-be declared without parentheses.
-
-Note: in the current implementation one can write both initializers
-(both with no arguments) at the same time. Then when invoking
-new classname(), the compiler finds that call ambiguous.

--- a/test/classes/initializers/error-parenthesless-initializer.good
+++ b/test/classes/initializers/error-parenthesless-initializer.good
@@ -1,1 +1,1 @@
-error-parenthesless-initializer.chpl:3: error: an initializer cannot be declared without parentheses
+error-parenthesless-initializer.chpl:5: error: an initializer cannot be declared without parentheses


### PR DESCRIPTION
(Depends on #4319)

A future from 2011 indicated that at least Brad and Vass thought this error
was a reasonable idea.  Polling the group, folks seem to be in favor of this error,
at least for now.

The fix was really simple - when we're converting a method into a constructor,
just check if it was declared with parentheses.

Had to update the line number in the initializer version of the future.  Removed
the .bad and .future files.

Passed std/ testing