### PR TITLE
Add suppressif to studies versions of revcomp/knucleotide

### DIFF
--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.suppressif
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.suppressif
@@ -1,0 +1,2 @@
+CHPL_LAUNCHER <= slurm
+CHPL_LAUNCHER <= aprun

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.suppressif
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.suppressif
@@ -1,0 +1,2 @@
+CHPL_LAUNCHER <= slurm
+CHPL_LAUNCHER <= aprun

--- a/test/studies/shootout/k-nucleotide/bradc/knucleotide-blc.suppressif
+++ b/test/studies/shootout/k-nucleotide/bradc/knucleotide-blc.suppressif
@@ -1,0 +1,2 @@
+CHPL_LAUNCHER <= slurm
+CHPL_LAUNCHER <= aprun

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.suppressif
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.suppressif
@@ -1,0 +1,2 @@
+CHPL_LAUNCHER <= slurm
+CHPL_LAUNCHER <= aprun

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.suppressif
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.suppressif
@@ -1,0 +1,2 @@
+CHPL_LAUNCHER <= slurm
+CHPL_LAUNCHER <= aprun


### PR DESCRIPTION
Though I realized these study versions could fail on a Cray, I didn't
bother to mark them as suppressif yesterday, thinking we didn't test
non-release tests on Crays, and forgetting about performance testing.
The failures last night suggest that historical data for these tests
is suspect...
