### PR TITLE
Retire a future

### DIFF
--- a/test/users/bguarraci/comprehension.future
+++ b/test/users/bguarraci/comprehension.future
@@ -1,4 +1,0 @@
-bug: i is ambiguous.  The i used to address arr intuitively should be the outer i, while the comprehension uses an inner i.
-
-comprehension.chpl:3: In function '_parloopexpr3':
-comprehension.chpl:3: error: 'i' used before defined (first used here)


### PR DESCRIPTION
I think I heard this is due to work by Michael

Trivial change.  Tested that the test passes with future gone.
