### PR TITLE
Update README and Makefile in release shootout directory for new versions

### DIFF
--- a/test/release/examples/benchmarks/shootout/Makefile
+++ b/test/release/examples/benchmarks/shootout/Makefile
@@ -6,12 +6,14 @@ TARGETS = \
 	binarytrees \
 	chameneosredux \
 	fannkuchredux \
+	knucleotide \
 	mandelbrot \
 	meteor \
 	meteor-fast \
 	nbody \
 	pidigits \
 	regexdna \
+	revcomp \
 	spectralnorm \
 	threadring
 
@@ -36,6 +38,9 @@ chameneosredux: chameneosredux.chpl
 
 fannkuchredux: fannkuchredux.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) $<
+
+knucleotide: knucleotide.chpl
+	$(CHPL) -o $@ $(CHPL_FLAGS) --no-warnings $<
 
 mandelbrot: mandelbrot.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) $<
@@ -69,6 +74,9 @@ regexdna: regexdna.chpl
 	echo "http://chapel.cray.com/docs/latest/usingchapel/chplenv.html#chpl-regexp"; \
 	echo ""; \
 	fi
+
+revcomp: revcomp.chpl
+	$(CHPL) -o $@ $(CHPL_FLAGS) $<
 
 spectralnorm: spectralnorm.chpl
 	$(CHPL) -o $@ $(CHPL_FLAGS) $<

--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -14,6 +14,7 @@ At present, this directory contains the following codes:
     binarytrees.chpl    : Allocates and deallocates many, many binary trees
     chameneosredux.chpl : Simulates meetings between color-changing Chameneos
     fannkuchredux.chpl  : Performs many operations on small arrays
+    knucleotide.chpl    : Count the frequencies of specific nucleotide sequences
     mandelbrot.chpl     : Plots the mandelbrot set [-1.5-i,0.5+i] on a bitmap
     meteor.chpl         : Performs a parallel search for all solutions to a
                           puzzle
@@ -21,6 +22,7 @@ At present, this directory contains the following codes:
     nbody.chpl          : Performs an n-body simulation of the Jovian planets
     pidigits.chpl       : Computes digits of pi using GMP, if available
     regexdna.chpl       : Performs DNA matching
+    revcomp.chpl        : Calculate the strand to bind with a given DNA strand
     spectralnorm.chpl   : Calculates the spectral norm of an infinite matrix
     threadring.chpl     : Passes a token between a large number of threads
 


### PR DESCRIPTION
We recently promoted versions of k-nucleotide and revcomp but did not add them
to the Makefile or the short benchmark summary at the top of the README.  Fix
that oversight.

Verified that the Makefile changes allowed those tests to build and run as expected.