### PR TITLE
Follow-on fix to PR #4327

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -978,7 +978,7 @@ module DefaultRectangular {
         } else { // unsigned type, signed stride
           assert((dom.dsiDim(i).stride<0 && str(i)<0) ||
                  (dom.dsiDim(i).stride>0 && str(i)>0));
-          s = dom.dsiDim(i).stride / str(i) : d.idxType;
+          s = (dom.dsiDim(i).stride / str(i)) : d.idxType;
         }
         alias.off(i) = d.dsiDim(i).low;
         alias.blk(i) = blk(i) * s;


### PR DESCRIPTION
My testing for PR #4327 didn't show any failures but after it was merged, the new test I added was failing.  The function adjustBlkOffStrForNewDomain needed to be updated to correctly handle unsigned idxType. It appears that this function was not previously called when compiling the test program but that it now is.

- [x] test/arrays/ferguson/idxTypesStridedAssign.chpl now compiles
- [ ] test/arrays/ferguson/idxTypesStridedAssign.chpl passes
- [ ] full local testing