### PR TITLE
Fix negative stride issue with strided transfers

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -978,7 +978,7 @@ module DefaultRectangular {
         } else { // unsigned type, signed stride
           assert((dom.dsiDim(i).stride<0 && str(i)<0) ||
                  (dom.dsiDim(i).stride>0 && str(i)>0));
-          s = dom.dsiDim(i).stride / str(i) : d.idxType;
+          s = (dom.dsiDim(i).stride / str(i)) : d.idxType;
         }
         alias.off(i) = d.dsiDim(i).low;
         alias.blk(i) = blk(i) * s;
@@ -1455,11 +1455,11 @@ module DefaultRectangular {
     // align'd.
     const Adims = A.dom.dsiDims();
     var AFirst : rank*idxType;
-    for i in 1..rank do AFirst(i) = Adims(i).first;
+    for i in 1..rank do AFirst(i) = if Adims(i).stride < 0 then Adims(i).last else Adims(i).first;
 
     const Bdims = B.dom.dsiDims();
     var BFirst : rank*idxType;
-    for i in 1..rank do BFirst(i) = Bdims(i).first;
+    for i in 1..rank do BFirst(i) = if Bdims(i).stride < 0 then Bdims(i).last else Bdims(i).first;
 
     if debugDefaultDistBulkTransfer {
       writeln("In DefaultRectangularArr.doiBulkTransferStride");

--- a/test/optimizations/bulkcomm/bharshbarg/misc.chpl
+++ b/test/optimizations/bulkcomm/bharshbarg/misc.chpl
@@ -75,4 +75,9 @@ proc main() {
     const right = 1..3 by 2 align 0;
     stridedAssign(A[left], B[right]);
   }
+
+  {
+    var A, B : [2..6 by -2] int;
+    stridedAssign(A, B);
+  }
 }


### PR DESCRIPTION
After #4327 the adjustBlkOffStrForNewDomain function needs to be updated to correctly handle unsigned idxType, because this function is called
in a new way after the strided transfer optimization was enabled.

This also exposed an issue with negative strides and the strided
transfer optimization, where we need to ask for the 'last' index instead
of the 'first' when the stride for a dimension is negative.