### PR TITLE
Single as record

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -87,7 +87,6 @@ bool Type::isDefaultIntentConst() const {
 
   if (symbol->hasFlag(FLAG_DEFAULT_INTENT_IS_REF) == true ||
       isReferenceType(this)                       == true ||
-      isSingleType(this)                          == true ||
       isRecordWrappedType(this)                   == true)
     retval = false;
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1000,10 +1000,6 @@ static void build_type_constructor(AggregateType* ct) {
 // which is also called by user-defined constructors to pre-initialize all
 // fields to their declared or type-specific initial values.
 static void build_constructor(AggregateType* ct) {
-  if (isSingleType(ct)) {
-    ct->defaultValue = NULL;
-  }
-
   // Create the default constructor function symbol,
   FnSymbol* fn = new FnSymbol(astr("_construct_", ct->symbol->name));
 
@@ -1059,7 +1055,7 @@ static void build_constructor(AggregateType* ct) {
   CallExpr*  superCall = NULL;
   CallExpr*  allocCall = NULL;
 
-  if (ct->symbol->hasFlag(FLAG_REF) || isSingleType(ct)) {
+  if (ct->symbol->hasFlag(FLAG_REF)) {
     // For ref, sync and single classes, just allocate space.
     allocCall = callChplHereAlloc(fn->_this);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4828,8 +4828,7 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
     if (concreteIntent(formal->intent, formalType) & INTENT_FLAG_CONST) {
       tmp->addFlag(FLAG_CONST);
 
-      if (!isSingleType(formalType) &&
-          !isRefCountedType(formalType))
+      if (!isRefCountedType(formalType))
         tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
     }
 
@@ -4916,8 +4915,7 @@ static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars)
 
        if (!getRecordWrappedFlags(ts).any()   &&
            !ts->hasFlag(FLAG_ITERATOR_CLASS)  &&
-           !ts->hasFlag(FLAG_ITERATOR_RECORD) &&
-           !isSingleType(ts->type)) {
+           !ts->hasFlag(FLAG_ITERATOR_RECORD)) {
          if (fn->hasFlag(FLAG_BEGIN)) {
            // autoCopy/autoDestroy will be added later, in parallel pass
            // by insertAutoCopyDestroyForTaskArg()
@@ -8677,8 +8675,7 @@ static void resolveAutoCopies() {
     if (ts->hasFlag(FLAG_SYNTACTIC_DISTRIBUTION))
       continue; // Skip the "dmapped" pseudo-type.
 
-    if (isRecord(ts->type)   ||
-        isSingleType(ts->type)) {
+    if (isRecord(ts->type)) {
       resolveAutoCopy(ts->type);
       resolveAutoDestroy(ts->type);
     }

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -234,8 +234,7 @@ static void createShadowVars(DefExpr* defChplIter, SymbolMap& uses,
         // See e.g. parallel/taskPar/figueroa/taskParallel.chpl
         pruneit = true;
 
-      } else if (isSingleType(ovar->type) ||
-                 isAtomicType(ovar->type)) {
+      } else if (isAtomicType(ovar->type)) {
         // Currently we need it because sync variables do not get tupled
         // and detupled properly when threading through the leader iterator.
         // See e.g. test/distributions/dm/s7.chpl

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -174,7 +174,6 @@ buildDefaultWrapper(FnSymbol* fn,
 
   bool specializeDefaultConstructor =
     fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR) &&
-    !isSingleType(fn->_this->type)        &&
     !fn->_this->type->symbol->hasFlag(FLAG_REF);
   if (specializeDefaultConstructor) {
     wrapper->removeFlag(FLAG_COMPILER_GENERATED);

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -576,12 +576,6 @@ static void addArgCoercion(FnSymbol*  fn,
       // Don't insert a readFE or readFF when deleting a sync/single.
       castCall = NULL;
 
-    else if (fn->numFormals() >= 2 &&
-             fn->getFormal(1)->type == dtMethodToken &&
-             formal == fn->_this)
-      // NB if this case is removed, reduce the checksLeft number below.
-      castCall = new CallExpr("value",  gMethodToken, prevActual);
-
     else if (ats->hasFlag(FLAG_SYNC))
       castCall = new CallExpr("readFE", gMethodToken, prevActual);
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3193,7 +3193,7 @@ module ChapelArray {
 
   proc _desync(type t) where t: _syncvar {
     var x: t;
-    return x.syncVar.value;
+    return x.wrapped.value;
   }
 
   proc _desync(type t) where t: _singlevar {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3198,7 +3198,7 @@ module ChapelArray {
 
   proc _desync(type t) where t: _singlevar {
     var x: t;
-    return x.value;
+    return x.wrapped.value;
   }
 
   proc _desync(type t) {

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -89,26 +89,26 @@ module ChapelSyncvar {
   record _syncvar {
     type valType;                              // The compiler knows this name
 
-    var  syncVar : _synccls(valType) = nil;
+    var  wrapped : _synccls(valType) = nil;
     var  isOwned : bool              = true;
 
     proc _syncvar(type valType) {
       ensureFEType(valType);
 
-      syncVar = new _synccls(valType);
+      wrapped = new _synccls(valType);
       isOwned = true;
     }
 
     proc _syncvar(type valType, other : _syncvar(valType)) {
       ensureFEType(valType);
 
-      syncVar = other.syncVar;
+      wrapped = other.wrapped;
       isOwned = false;
     }
 
     proc ~_syncvar() {
       if isOwned == true then
-        delete syncVar;
+        delete wrapped;
     }
 
     // Do not allow implicit reads of sync vars.
@@ -146,7 +146,7 @@ module ChapelSyncvar {
     :returns: The value of the sync variable.
   */
   proc _syncvar.readFE() {
-    return syncVar.readFE();
+    return wrapped.readFE();
   }
 
   /*
@@ -156,7 +156,7 @@ module ChapelSyncvar {
     :returns: The value of the sync variable.
   */
   proc _syncvar.readFF() {
-    return syncVar.readFF();
+    return wrapped.readFF();
   }
 
   /*
@@ -166,7 +166,7 @@ module ChapelSyncvar {
     :returns: The value of the sync variable.
   */
   proc _syncvar.readXX() {
-    return syncVar.readXX();
+    return wrapped.readXX();
   }
 
   /*
@@ -176,7 +176,7 @@ module ChapelSyncvar {
     :arg val: New value of the sync variable.
   */
   proc _syncvar.writeEF(x : valType) {
-    syncVar.writeEF(x);
+    wrapped.writeEF(x);
   }
 
   /*
@@ -186,7 +186,7 @@ module ChapelSyncvar {
     :arg val: New value of the sync variable.
   */
   proc _syncvar.writeFF(x : valType) {
-    syncVar.writeFF(x);
+    wrapped.writeFF(x);
   }
 
   /*
@@ -195,7 +195,7 @@ module ChapelSyncvar {
     :arg val: New value of the sync variable.
   */
   proc _syncvar.writeXF(x : valType) {
-    syncVar.writeXF(x);
+    wrapped.writeXF(x);
   }
 
   /*
@@ -204,7 +204,7 @@ module ChapelSyncvar {
     variable is set to empty when this method completes.
   */
   proc _syncvar.reset() {
-    syncVar.reset();
+    wrapped.reset();
   }
 
   /*
@@ -214,55 +214,55 @@ module ChapelSyncvar {
      :returns: true if the state of the sync variable is full.
   */
   proc _syncvar.isFull {
-    return syncVar.isFull;
+    return wrapped.isFull;
   }
 
   proc   = (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(rhs);
+    lhs.wrapped.writeEF(rhs);
   }
 
   proc  += (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() +  rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() +  rhs);
   }
 
   proc  -= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() -  rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() -  rhs);
   }
 
   proc  *= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() *  rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() *  rhs);
   }
 
   proc  /= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() /  rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() /  rhs);
   }
 
   proc  %= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() %  rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() %  rhs);
   }
 
   proc **= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() ** rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() ** rhs);
   }
 
   proc  &= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() &  rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() &  rhs);
   }
 
   proc  |= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() |  rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() |  rhs);
   }
 
   proc  ^= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() ^  rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() ^  rhs);
   }
 
   proc >>= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() >> rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() >> rhs);
   }
 
   proc <<= (ref lhs : _syncvar(?t), rhs : t) {
-    lhs.syncVar.writeEF(lhs.syncVar.readFE() << rhs);
+    lhs.wrapped.writeEF(lhs.wrapped.readFE() << rhs);
   }
 
   pragma "init copy fn"
@@ -284,7 +284,7 @@ module ChapelSyncvar {
   pragma "auto destroy fn sync"
     inline proc chpl__autoDestroy(x : _syncvar(?)) {
     if x.isOwned == true then
-      delete x.syncVar;
+      delete x.wrapped;
   }
 
   pragma "no doc"

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -654,7 +654,7 @@ module ChapelSyncvar {
   extern proc   chpl_single_markAndSignalFull (ref aux : chpl_single_aux_t);
 
   extern proc   chpl_single_isFull(value   : c_void_ptr,
-				   ref aux : chpl_single_aux_t) : bool;
+                                   ref aux : chpl_single_aux_t) : bool;
 
 
   pragma "no doc"
@@ -680,13 +680,13 @@ module ChapelSyncvar {
 
         chpl_rmem_consist_release();
 
-	if this.isFull then
+        if this.isFull then
           localRet = value;
         else {
           chpl_single_waitFullAndLock(singleAux);   // single_wait_full
           localRet = value;
           chpl_single_markAndSignalFull(singleAux);
-	}
+        }
 
         chpl_rmem_consist_acquire();
 
@@ -710,7 +710,7 @@ module ChapelSyncvar {
           chpl_single_lock(singleAux);
           localRet = value;
           chpl_single_unlock(singleAux);
-	}
+        }
 
         chpl_rmem_consist_acquire();
         ret = localRet;

--- a/test/types/single/vass/readThis.good
+++ b/test/types/single/vass/readThis.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/IO.chpl:: error: single variables cannot currently be read - use writeEF/writeFF instead
+$CHPL_HOME/modules/standard/IO.chpl:: error: single variables cannot currently be read - use writeEF instead

--- a/test/types/single/vass/writeThis.good
+++ b/test/types/single/vass/writeThis.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/IO.chpl:: error: single variables cannot currently be written - apply readFF/readFE() to those variables first
+$CHPL_HOME/modules/standard/IO.chpl:: error: single variables cannot currently be written - apply readFF() to those variables first

--- a/test/users/vass/isX/isX.byBlankArgs-compWarns.good
+++ b/test/users/vass/isX/isX.byBlankArgs-compWarns.good
@@ -324,11 +324,17 @@ isSyncValue
 isSyncType
 
 _singlevar(int(64))
+isRecord
+isRecordValue
+isRecordType
 isSingle
 isSingleValue
 isSingleType
 
 _singlevar(real(64))
+isRecord
+isRecordValue
+isRecordType
 isSingle
 isSingleValue
 isSingleType

--- a/test/users/vass/isX/isX.module-writeln.good
+++ b/test/users/vass/isX/isX.module-writeln.good
@@ -34,8 +34,8 @@ ArrType1 (arr1)  isArray  isArrayValue  isArrayType  .
 ArrType2 (arr2)  isArray  isArrayValue  isArrayType  .
 sync int (syInt)  isRecord  isRecordValue  isRecordType  isSync  isSyncValue  isSyncType  .
 sync real (syReal)  isRecord  isRecordValue  isRecordType  isSync  isSyncValue  isSyncType  .
-single int (siInt)  isSingle  isSingleValue  isSingleType  .
-single real (siReal)  isSingle  isSingleValue  isSingleType  .
+single int (siInt)  isRecord  isRecordValue  isRecordType  isSingle  isSingleValue  isSingleType  .
+single real (siReal)  isRecord  isRecordValue  isRecordType  isSingle  isSingleValue  isSingleType  .
 atomic int (aInt)  isAtomic  isAtomicValue  isAtomicType  .
 atomic real (aReal)  isAtomic  isAtomicValue  isAtomicType  .
 

--- a/test/users/vass/type-tests.good
+++ b/test/users/vass/type-tests.good
@@ -68,7 +68,7 @@ type-tests.chpl:28: warning: sync is a record: true
 type-tests.chpl:28: warning: sync is a union:  false
 type-tests.chpl:28: warning: sync is a sync
 type-tests.chpl:29: warning: single is a class:  false
-type-tests.chpl:29: warning: single is a record: false
+type-tests.chpl:29: warning: single is a record: true
 type-tests.chpl:29: warning: single is a union:  false
 type-tests.chpl:29: warning: single is a single
 type-tests.chpl:30: error: done


### PR DESCRIPTION
This PR applies the process used to convert Sync from a class to a record wrapped class.

The record/class is largely a clone of the work for Sync but with the appropriate changes to
the simpler API and the relevant functional changes.

After that there was a trivial level of C++ tweaks and a few .good files to modify.

Compiled on darwin/clang and gcc/linux with/without CHPL_DEVELOPER.
Tested on --verify, --baseline --verify, --gasnet, and -futures

Also checked the chpl-docs
