### PR TITLE
Grab-bag of compiler debugging improvements

### DIFF
--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -106,6 +106,55 @@ void checkPrimitives()
         INT_FATAL("Primitive should not appear after resolution is complete.");
       break;
 
+     case PRIM_ADDR_OF:             // set a reference to a value
+      if (resolved) {
+        // Check that the argument is not already a reference.
+        // references can only go 1 level
+        if (isReferenceType(call->get(1)->typeInfo()))
+          INT_FATAL("Invalid PRIM_ADDR_OF of a reference");
+      }
+      break;
+
+     case PRIM_DEREF:               // dereference a reference
+      if (resolved) {
+        // Check that the argument is a reference.
+        if (!isReferenceType(call->get(1)->typeInfo()))
+          INT_FATAL("Invalid PRIM_DEREF of a non-reference");
+      }
+      break;
+
+     case PRIM_MOVE:
+      if (resolved) {
+        // Check that the LHS has the same type as the RHS.
+        if (call->get(1)->typeInfo() != call->get(2)->typeInfo())
+          INT_FATAL("PRIM_MOVE types do not match");
+      }
+      break;
+
+     case PRIM_GET_MEMBER:
+     case PRIM_GET_MEMBER_VALUE:
+     case PRIM_SET_MEMBER:
+      if (resolved) {
+        // For expr.field, check that field is a VarSymbol
+        // in the class expr.type.
+        AggregateType* ct = toAggregateType(call->get(1)->typeInfo());
+        SymExpr* getFieldSe = toSymExpr(call->get(2));
+        Symbol* getField = getFieldSe->var;
+        INT_ASSERT(ct);
+        INT_ASSERT(getField);
+        Symbol* name_match = NULL;
+        for_fields(field, ct) {
+          if (0 == strcmp(field->name, getField->name))
+            name_match = field;
+        }
+        if (name_match != getField) {
+          // Note: name_match contains the field that was
+          // probably meant...
+          INT_FATAL("Field access for field not in type");
+        }
+      }
+      break;
+
      case PRIM_UNKNOWN:
      case PRIM_NOOP:
      case PRIM_MOVE:
@@ -151,9 +200,6 @@ void checkPrimitives()
      case PRIM_GETCID:
      case PRIM_SET_UNION_ID:
      case PRIM_GET_UNION_ID:
-     case PRIM_GET_MEMBER:
-     case PRIM_GET_MEMBER_VALUE:
-     case PRIM_SET_MEMBER:
      case PRIM_CHECK_NIL:
      case PRIM_GET_REAL:            // get complex real component
      case PRIM_GET_IMAG:            // get complex imag component

--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -157,7 +157,6 @@ void checkPrimitives()
 
      case PRIM_UNKNOWN:
      case PRIM_NOOP:
-     case PRIM_MOVE:
      case PRIM_REF_TO_STRING:
      case PRIM_RETURN:
      case PRIM_YIELD:
@@ -204,8 +203,6 @@ void checkPrimitives()
      case PRIM_GET_REAL:            // get complex real component
      case PRIM_GET_IMAG:            // get complex imag component
      case PRIM_QUERY:               // query expression primitive
-     case PRIM_ADDR_OF:             // set a reference to a value
-     case PRIM_DEREF:               // dereference a reference
      case PRIM_LOCAL_CHECK:         // assert that a wide ref is on this locale
      case PRIM_SYNC_INIT:
      case PRIM_SYNC_DESTROY:

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1144,7 +1144,7 @@ Type* getRefTypesForWideThing(GenRet wide, Type** wideRefTypeOut)
         ret = wide.chplType->getField("addr")->typeInfo();
         wideRefType = wide.chplType;
       } else {
-        INT_ASSERT(0);
+        INT_ASSERT(0); // Not a wide thing.
       }
     }
   }

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -671,9 +671,14 @@ GenRet VarSymbol::codegen() {
           immediate &&
           ret.chplType == dtString &&
           immediate->const_kind == CONST_KIND_STRING) {
-        ret.c += " /* \"";
-        ret.c += immediate->v_string;
-        ret.c += "\" */";
+        if (strstr(immediate->v_string, "/*") ||
+            strstr(immediate->v_string, "*/")) {
+          // Don't emit comment b/c string contained comment character.
+        } else {
+          ret.c += " /* \"";
+          ret.c += immediate->v_string;
+          ret.c += "\" */";
+        }
       }
     }
     return ret;

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -664,6 +664,17 @@ GenRet VarSymbol::codegen() {
         ret.c += cname;
         ret.isLVPtr = GEN_PTR;
       }
+      // Print string contents in a comment if developer mode
+      // and savec is set.
+      if (developer &&
+          0 != strcmp(saveCDir, "") &&
+          immediate &&
+          ret.chplType == dtString &&
+          immediate->const_kind == CONST_KIND_STRING) {
+        ret.c += " /* \"";
+        ret.c += immediate->v_string;
+        ret.c += "\" */";
+      }
     }
     return ret;
   } else {

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -57,8 +57,8 @@ list_sym(Symbol* sym, bool type = true) {
   }
   if (toFnSymbol(sym)) {
     printf("fn ");
-  } else if (ArgSymbol* arg = toArgSymbol(sym)) {
-    printf("arg intent %s", arg->intentDescrString());
+  } else if (toArgSymbol(sym)) {
+    printf("arg ");
   } else if (toTypeSymbol(sym)) {
     printf("type ");
   }

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -57,8 +57,8 @@ list_sym(Symbol* sym, bool type = true) {
   }
   if (toFnSymbol(sym)) {
     printf("fn ");
-  } else if (toArgSymbol(sym)) {
-    printf("arg ");
+  } else if (ArgSymbol* arg = toArgSymbol(sym)) {
+    printf("arg intent %s", arg->intentDescrString());
   } else if (toTypeSymbol(sym)) {
     printf("type ");
   }
@@ -371,6 +371,8 @@ view_ast(BaseAST* ast, bool number = false, int mark = -1, int indent = 0) {
 
   if (DefExpr* def = toDefExpr(ast)) {
     printf(" ");
+    if (ArgSymbol* arg = toArgSymbol(def->sym))
+      printf("intent %s ", arg->intentDescrString());
     writeFlags(stdout, def->sym);
   }
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -328,7 +328,8 @@ class TypeSymbol : public Symbol {
 
 class FnSymbol : public Symbol {
  public:
-  AList formals; // each formal is an ArgSymbol
+  AList formals; // each formal is an ArgSymbol, but the
+                 // elements of this list are DefExprs
   Type* retType; // The return type of the function.  This field is not
                  // fully established until resolution, and could be NULL
                  // before then.  Up to that point, return type information is

--- a/compiler/optimizations/localizeGlobals.cpp
+++ b/compiler/optimizations/localizeGlobals.cpp
@@ -69,6 +69,14 @@ void localizeGlobals() {
             fn->insertAtHead(new CallExpr(PRIM_MOVE, local_global, var));
             fn->insertAtHead(new DefExpr(local_global));
 
+            // Copy string immediates to localized strings so that
+            // we can show the string value in comments next to uses.
+            if (VarSymbol* localVarSym = toVarSymbol(var))
+              if (Immediate* immediate = localVarSym->immediate)
+                if (immediate->const_kind == CONST_KIND_STRING)
+                  local_global->immediate =
+                    new Immediate(immediate->v_string, immediate->string_kind);
+
             globals.put(var, local_global);
           }
           se->replace(new SymExpr(toSymbol(local_global)));

--- a/compiler/optimizations/scalarReplace.cpp
+++ b/compiler/optimizations/scalarReplace.cpp
@@ -453,6 +453,7 @@ scalarReplaceRecord(AggregateType* ct, Symbol* sym) {
       SET_LINENO(sym);
       // Do we need to add a case for PRIM_ASSIGN?
       if (call->isPrimitive(PRIM_MOVE)) {
+        INT_ASSERT(call->get(1)->getValType() == call->get(2)->getValType());
         SymExpr* lhs = toSymExpr(call->get(1));
         for_fields(field, ct) {
           SymExpr* lhsCopy = lhs->copy();

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3903,7 +3903,7 @@ FnSymbol* tryResolveCall(CallExpr* call) {
 FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
 
   if( call->id == breakOnResolveID ) {
-    printf("breaking on call:\n");
+    printf("breaking on resolve call:\n");
     print_view(call);
     gdbShouldBreakHere();
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4495,8 +4495,12 @@ static void resolveMove(CallExpr* call) {
     }
   }
 
-  if (lhs->type == dtUnknown || lhs->type == dtNil)
+  if (lhs->type == dtUnknown || lhs->type == dtNil) {
+    if (lhs->id == breakOnResolveID )
+      gdbShouldBreakHere();
+
     lhs->type = rhsType;
+  }
 
   Type* lhsType = lhs->type;
 


### PR DESCRIPTION
* Adds more checks to --verify for cases I encountered
* Adds an assertion to scalar replace for erroneous AST that would otherwise cause problems later
* Adds comments in generated code showing the C string contents, but only in developer mode when the C source code is saved.
* Prints argument intent in AST dumps

Passed quickstart testing with --verify.
Passed full local testing with --verify.
Reviewed by @vasslitvinov - thanks!