### PR TITLE
Necessary normalize change to .init calls

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -886,7 +886,17 @@ static void applyGetterTransform(CallExpr* call) {
     if (VarSymbol* var = toVarSymbol(symExpr->var)) {
       if (var->immediate->const_kind == CONST_KIND_STRING) {
         call->baseExpr->replace(new UnresolvedSymExpr(var->immediate->v_string));
-        call->insertAtHead(gMethodToken);
+        if (!strcmp(var->immediate->v_string, "init")) {
+          // If we've been passed in either "super" or "this"
+
+          // Want to explicitly make the super/this value a setting to "meme"
+          Expr* firstArg = call->get(1)->remove();
+          call->insertAtHead(new NamedExpr("meme", firstArg));
+          // initializer calls don't include the gMethodToken as an arg, so only
+          // perform that action if we aren't making a .init call
+        } else {
+          call->insertAtHead(gMethodToken);
+        }
       } else {
         INT_FATAL(call, "unexpected case");
       }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -887,13 +887,13 @@ static void applyGetterTransform(CallExpr* call) {
       if (var->immediate->const_kind == CONST_KIND_STRING) {
         call->baseExpr->replace(new UnresolvedSymExpr(var->immediate->v_string));
         if (!strcmp(var->immediate->v_string, "init")) {
-          // If we've been passed in either "super" or "this"
-
-          // Want to explicitly make the super/this value a setting to "meme"
+          // Transform:
+          //   call(call(. x "init") args)
+          // into:
+          //   call(call(init meme=x) args)
+          // because initializers are handled differently from other methods
           Expr* firstArg = call->get(1)->remove();
           call->insertAtHead(new NamedExpr("meme", firstArg));
-          // initializer calls don't include the gMethodToken as an arg, so only
-          // perform that action if we aren't making a .init call
         } else {
           call->insertAtHead(gMethodToken);
         }

--- a/test/classes/initializers/base-initializer.future
+++ b/test/classes/initializers/base-initializer.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/initializer-inheritance.future
+++ b/test/classes/initializers/initializer-inheritance.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/siblingCall/inIf.future
+++ b/test/classes/initializers/siblingCall/inIf.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.


### PR DESCRIPTION
Constructors and initializers are different from other methods - they don't take
in the _mt token.  Normally we don't have calls to instance.constructor(),
so normalize's applyGetterTransform doesn't cause problems, but with the new
initializer story we rely on the presence of this.init() and super.init() calls.
Additionally, initializers now take in their memory to initialize as the final
"meme" argument (to help distinguish between inits of records which have similar
field set up), and ordinary method calls have the instance of the type to
operate on in the first argument.  Thus two adjustments need to occur (and could
occur at the same time): 1) .init() calls should not be given the _mt actual
and 2) the first actual should be made into an actual for "meme".

With this minor modification, three of my futures now pass, and many more of
them are now only encountering problems with super.init() calls when super ==
object.  Retire the .future files on the passing tests.

- [x] std testing