### PR TITLE
Fixes for requestCapacity

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -396,8 +396,11 @@ module DefaultAssociative {
           var copyDom = tableDom;
           var copyTable: [copyDom] chpl_TableEntry(idxType) = table;
 
-          tableSizeNum=primeLoc;
-          tableSize=prime;
+          // Do not preserve entries
+          tableDom = {0..-1};
+
+          tableSizeNum = primeLoc;
+          tableSize = prime;
           tableDom = {0..tableSize-1};
 
           //numEntries will be reconstructed as keys are readded

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -335,10 +335,10 @@ module DefaultAssociative {
       } else {
         if (slotNum < 0) {
           halt("couldn't add ", idx, " -- ", numEntries.read(), " / ", tableSize, " taken");
-          return (-1,0);
+          return (-1, 0);
         }
         // otherwise, re-adding an index that's already in there
-        return (-1,0);
+        return (slotNum, 0);
       }
       return (slotNum, 1);
     }

--- a/test/domains/johnk/capacityAssoc.chpl
+++ b/test/domains/johnk/capacityAssoc.chpl
@@ -1,31 +1,47 @@
-use Random;
 
-var D : domain(string);
-var arr : [D] int;
+config const pow = 14;
 
-D += "foo";
-D += "bar";
+proc main() {
+  var D : domain(string);
+  var A : [D] int;
 
-arr["foo"] = 4;
-arr["bar"] = 5;
+  D += "foo";
+  D += "bar";
 
-//Pick a random initial capacity for the associative domain
-var rs       = new RandomStream();
+  A["foo"] = 4;
+  A["bar"] = 5;
 
-var min      = 5;
-var max      = 3500;
-var capacity = (rs.getNext() * (max - min) + min): int;
+  for i in 3..pow {
+    const cap = 2**i;
 
-D.requestCapacity(capacity);
+    test(cap);
 
-
-if (D._value.tableSize > 2 * (capacity + 1)) &&
-   arr["foo"] == 4 &&
-   arr["bar"] == 5
-{
-    writeln("SUCCESS");
-} else {
-    writeln("FAILURE");
+    D.requestCapacity(cap);
+    verify(A, cap);
+  }
 }
 
-delete rs;
+proc test(cap : int) {
+  var D : domain(string);
+  var A : [D] int;
+
+  D += "foo";
+  D += "bar";
+
+  A["foo"] = 4;
+  A["bar"] = 5;
+
+  D.requestCapacity(cap);
+  verify(A, cap);
+}
+
+proc verify(A : [], cap : int) {
+
+  const minSize = 2 * (cap + 1);
+  const correct = A.domain._value.tableSize > cap &&
+                  A.size == 2 &&
+                  A["foo"] == 4 &&
+                  A["bar"] == 5;
+
+  if !correct then halt("FAILURE for capacity ", cap);
+}

--- a/test/domains/johnk/capacityAssoc.good
+++ b/test/domains/johnk/capacityAssoc.good
@@ -1,1 +1,0 @@
-SUCCESS


### PR DESCRIPTION
The test "domains/johnk/capacityAssoc.chpl" would fail about 4/1000 runs with an array OOB error for the index "-1". The RandomStream used to generate a capacity is the source of this low failure rate. Once I printed out the failing capacities, I could re-use those numbers to reliably reproduce the issue.

I tracked down the source of this "-1" value to the "_add" function in DefaultAssociative. I concluded that it would make more sense to return the found slot instead of a sentinel value, and instead rely on the second element of the tuple to determine if an index was truly added.

I then discovered the real source of the problem: that the domain's 'table' variable was not being cleared, such that old entries still existed. I copied the approach of the "_resize" function and simply set the table's domain to a zero-length domain prior to resizing which will result in a 'clean' table when we begin to add the original indices back in.

The original test has also been changed to be more deterministic and thorough by:
- requesting capacity for an associative domain/array multiple times
- requesting capacity a recently-initialized and small associative array to increasingly larger sizes

I ran the new test 5000 times and observed no failures.