### PR TITLE
Unset CONFIG_SITE, so as to have dependable third-party install paths.

### DIFF
--- a/make/Makefile.base
+++ b/make/Makefile.base
@@ -28,6 +28,11 @@ isTrue = $(filter yes Yes YES y Y true True TRUE t T, $(1))
 MAKEFLAGS = --no-print-directory
 
 
+#
+# Don't let CONFIG_SITE mess up our third-party/ builds.
+#
+unexport CONFIG_SITE
+
 ifndef CHPL_MAKE_HOST_TARGET
 CHPL_MAKE_HOST_TARGET = --host
 endif


### PR DESCRIPTION
CONFIG_SITE is an environment variable used to specify site-specific
autoconf defaults.  Unfortunately, use of it can interfere with our
assumptions about third-party builds and installs, including where we
think the installed libraries are placed.  To work around this, for now
prevent it being passed along to the environment of any subprocess of
our make.

See https://sourceforge.net/p/chapel/mailman/message/33852491/ for a
conversation about this.