### PR TITLE
Patch codegen of strided primitives for --denormalize

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -5395,14 +5395,12 @@ GenRet CallExpr::codegenPrimitive() {
 
     // source data array
     GenRet   remoteAddr = get(4);
-    SymExpr* sym        = toSymExpr(get(4));
+    TypeSymbol* remoteAddrType = get(4)->typeInfo()->symbol;
 
-    INT_ASSERT(sym);
-
-    if (sym->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) == true) {
+    if (remoteAddrType->hasFlag(FLAG_WIDE_REF) == true) {
       remoteAddr = codegenRaddr(remoteAddr);
-    } else if (sym->typeInfo()->symbol->hasFlag(FLAG_REF) == false) {
-        remoteAddr = codegenAddrOf(remoteAddr);
+    } else if (remoteAddrType->hasFlag(FLAG_REF) == false) {
+      remoteAddr = codegenAddrOf(remoteAddr);
     }
 
     // source strides local array


### PR DESCRIPTION
@benharsh reported a bug with --denormalize flag and strided 
communication primitives. This is a small fix to avoid assertions 
at codegen time for those primitives.

He also tested this patch with several configs.

@mppf might be interested in taking a quick look before merged.