### PR TITLE
Minimising the use of Vec and Map

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -97,7 +97,7 @@ FnSymbol* gChplHereFree = NULL;
 FnSymbol* gChplDoDirectExecuteOn = NULL;
 
 std::map<FnSymbol*,int> ftableMap;
-Vec<FnSymbol*> ftableVec;
+std::vector<FnSymbol*> ftableVec;
 
 Map<Type*,Vec<FnSymbol*>*> virtualMethodTable;
 Map<FnSymbol*,int> virtualMethodMap;

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -807,9 +807,9 @@ void whocalls(int id) {
     }
   }
 
-  int ftMatch = 0, ftAll = ftableVec.n;
+  int ftMatch = 0, ftAll = ftableVec.size();
   for (int i = 0; i < ftAll; i++) {
-    if (ftableVec.v[i]->id == id) {
+    if (ftableVec.begin()[i]->id == id) {
       ftMatch++;
       printf("  ftableVec[%d]\n", i);
     }

--- a/compiler/include/map.h
+++ b/compiler/include/map.h
@@ -169,6 +169,7 @@ template <class C, class AHashFns, int N> class NBlockHash {
 
   C* end() { return last(); }
   int length() { return N * n; }
+  int size() {return n;}
   C *first();
   C *last();
   C put(C c);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -640,7 +640,7 @@ extern Symbol *gSyncVarAuxFields;
 extern Symbol *gSingleVarAuxFields;
 
 extern std::map<FnSymbol*,int> ftableMap;
-extern Vec<FnSymbol*> ftableVec;
+extern std::vector<FnSymbol*> ftableVec;
 
 //
 // The virtualMethodTable maps types to their arrays of methods.  The

--- a/compiler/include/vec.h
+++ b/compiler/include/vec.h
@@ -77,6 +77,7 @@ class Vec {
   ~Vec() { if (v && v != e) free(v); }
 
   void add(C a);
+  void push_back(C a) { add(a);}
   int add_exclusive(C a);
   C& add();
   C head() { return n>0 ? *v : 0; }
@@ -104,9 +105,11 @@ class Vec {
   void remove(int index);
   void insert(int index, C a);
   void reverse();
+  C* begin() { return v; }
   C* end() { return v + n; }
   Vec<C,S>& operator=(Vec<C,S> &v) { this->copy(v); return *this; }
   int length () { return n; }
+  int size() { return n; }
   
  private:
   void move_internal(Vec<C,S> &v);
@@ -121,8 +124,8 @@ class Vec {
 // _p -- loop variable to be declared by the macro
 // _v -- vector to be iterated over
 //
-#define forv_Vec(_c, _p, _v) if ((_v).n) for (_c *qq__##_p = (_c*)0, *_p = (_v).v[0]; \
-                    ((intptr_t)(qq__##_p) < (_v).length()) && ((_p = (_v).v[(intptr_t)qq__##_p]) || 1); qq__##_p = (_c*)(((intptr_t)qq__##_p) + 1))
+#define forv_Vec(_c, _p, _v) if ((_v).size()) for (_c *qq__##_p = (_c*)0, *_p = (_v).begin()[0]; \
+                    ((intptr_t)(qq__##_p) < (int)(_v).size()) && ((_p = (_v).begin()[(intptr_t)qq__##_p]) || 1); qq__##_p = (_c*)(((intptr_t)qq__##_p) + 1))
 
 template <class C, int S = VEC_INTEGRAL_SIZE> class Accum { public:
   Vec<C,S> asset;

--- a/compiler/passes/Makefile
+++ b/compiler/passes/Makefile
@@ -42,7 +42,7 @@ FORCE:
 include $(COMPILER_ROOT)/make/Makefile.compiler.foot
 
 reservedSymbolNames.h: reservedSymbolNames
-	sed -e 's/^\([ 	]*\)\([A-Za-z_][A-Za-z0-9_]*\)/\1cnames.set_add(astr("\2"));/' <$< >$@
+	sed -e 's/^\([ 	]*\)\([A-Za-z_][A-Za-z0-9_]*\)/\1cnames.insert(astr("\2"));/' <$< >$@
 
 $(OBJ_SUBDIR)/codegen.o: reservedSymbolNames.h
 

--- a/compiler/passes/codegen.cpp
+++ b/compiler/passes/codegen.cpp
@@ -227,11 +227,11 @@ static void genGlobalInt32(const char *cname, int value) {
 }
 
 static void
-genClassIDs(Vec<TypeSymbol*> & typeSymbols, bool isHeader) {
+genClassIDs(std::vector<TypeSymbol*> & typeSymbol, bool isHeader) {
   genComment("Class Type Identification Numbers");
 
   int count=0;
-  forv_Vec(TypeSymbol, ts, typeSymbols) {
+  forv_Vec(TypeSymbol, ts, typeSymbol) {
     if (AggregateType* ct = toAggregateType(ts->type)) {
       if (!isReferenceType(ct) && isClass(ct)) {
         genGlobalDefClassId(ts->cname, count, isHeader);
@@ -242,7 +242,7 @@ genClassIDs(Vec<TypeSymbol*> & typeSymbols, bool isHeader) {
 }
 
 static void
-genFtable(Vec<FnSymbol*> & fSymbols, bool isHeader) {
+genFtable(std::vector<FnSymbol*> & fSymbols, bool isHeader) {
   GenInfo* info = gGenInfo;
   const char* ftable_name = "chpl_ftable";
   if( info->cfile ) {
@@ -260,7 +260,7 @@ genFtable(Vec<FnSymbol*> & fSymbols, bool isHeader) {
       first = false;
     }
 
-    if (fSymbols.n == 0)
+    if (fSymbols.size() == 0)
       fprintf(hdrfile, "(chpl_fn_p)0");
     fprintf(hdrfile, "\n};\n");
   } else {
@@ -268,7 +268,7 @@ genFtable(Vec<FnSymbol*> & fSymbols, bool isHeader) {
     if (!isHeader)
       return;
 
-    std::vector<llvm::Constant *> table ((fSymbols.n == 0) ? 1 : fSymbols.n);
+    std::vector<llvm::Constant *> table ((fSymbols.size() == 0) ? 1 : fSymbols.size());
 
     llvm::Type *funcPtrType = info->lvt->getType("chpl_fn_p");
 
@@ -278,7 +278,7 @@ genFtable(Vec<FnSymbol*> & fSymbols, bool isHeader) {
       table[fID++] = llvm::cast<llvm::Constant>(
           info->builder->CreatePointerCast(func, funcPtrType));
     }
-    if (fSymbols.n == 0) {
+    if (fSymbols.size() == 0) {
       table[0] = llvm::Constant::getNullValue(funcPtrType);
     }
 
@@ -300,7 +300,7 @@ genFtable(Vec<FnSymbol*> & fSymbols, bool isHeader) {
 }
 
 static void
-genFinfo(Vec<FnSymbol*> & fSymbols, bool isHeader) {
+genFinfo(std::vector<FnSymbol*> & fSymbols, bool isHeader) {
   GenInfo* info = gGenInfo;
   const char* finfo_name = "chpl_finfo";
   if( info->cfile ) {
@@ -333,7 +333,7 @@ genFinfo(Vec<FnSymbol*> & fSymbols, bool isHeader) {
 }
 
 static void
-genVirtualMethodTable(Vec<TypeSymbol*>& types, bool isHeader) {
+genVirtualMethodTable(std::vector<TypeSymbol*>& types, bool isHeader) {
   GenInfo* info = gGenInfo;
   const char* vmt = "chpl_vmtable";
   if(info->cfile && isHeader) {
@@ -341,9 +341,9 @@ genVirtualMethodTable(Vec<TypeSymbol*>& types, bool isHeader) {
     return;
   }
   int maxVMT = 0;
-  for (int i = 0; i < virtualMethodTable.n; i++)
-    if(virtualMethodTable.v[i].key && virtualMethodTable.v[i].value->n > maxVMT)
-      maxVMT = virtualMethodTable.v[i].value->n;
+  for (int i = 0; i < virtualMethodTable.size(); i++)
+    if(virtualMethodTable.begin()[i].key && virtualMethodTable.begin()[i].value->n > maxVMT)
+      maxVMT = virtualMethodTable.begin()[i].value->n;
 
   gMaxVMT = maxVMT;
 
@@ -379,7 +379,7 @@ genVirtualMethodTable(Vec<TypeSymbol*>& types, bool isHeader) {
         }
       }
     }
-    if (types.n == 0 || maxVMT == 0)
+    if (types.size() == 0 || maxVMT == 0)
       fprintf(hdrfile, "(chpl_fn_p)0");
     fprintf(hdrfile, "\n};\n");
   } else {
@@ -497,14 +497,14 @@ static void genFilenameTable() {
 //
 static void genUnwindSymbolTable(){
   GenInfo *info = gGenInfo;
-  Vec<FnSymbol*> symbols;
+  std::vector<FnSymbol*> symbols;
 
   //If CHPL_UNWIND is none we don't want any symbols in our tables
   if(strcmp(CHPL_UNWIND, "none") != 0){
     // Gets only user symbols
     forv_Vec(FnSymbol, fn, gFnSymbols) {
       if(strncmp(fn->cname, "chpl_", 5)) {
-        symbols.add(fn);
+        symbols.push_back(fn);
       }
     }
   }
@@ -529,34 +529,11 @@ static void genUnwindSymbolTable(){
     fprintf(hdrfile," 0, 0};\n");
   }
 
-  genGlobalInt32("chpl_sizeSymTable", symbols.n * 2);
-}
-
-static int
-compareSymbol(const void* v1, const void* v2) {
-  Symbol* s1 = *(Symbol* const *)v1;
-  Symbol* s2 = *(Symbol* const *)v2;
-  ModuleSymbol* m1 = s1->getModule();
-  ModuleSymbol* m2 = s2->getModule();
-  if (m1 != m2) {
-    if (m1->modTag < m2->modTag)
-      return -1;
-    if (m1->modTag > m2->modTag)
-      return 1;
-    return strcmp(m1->cname, m2->cname);
-  }
-
-  if (s1->linenum() != s2->linenum())
-    return (s1->linenum() < s2->linenum()) ? -1 : 1;
-
-  int result = strcmp(s1->type->symbol->cname, s2->type->symbol->cname);
-  if (!result)
-    result = strcmp(s1->cname, s2->cname);
-  return result;
+  genGlobalInt32("chpl_sizeSymTable", symbols.size() * 2);
 }
 
 static bool
-compareSymbol2(void* v1, void* v2) {
+compareSymbol(void* v1, void* v2) {
   Symbol* s1 = (Symbol*)v1;
   Symbol* s2 = (Symbol*)v2;
   ModuleSymbol* m1 = s1->getModule();
@@ -579,6 +556,29 @@ compareSymbol2(void* v1, void* v2) {
   return result < 0;
 }
 
+static int
+compareSymbol2(const void* v1, const void* v2) {
+  Symbol* s1 = *(Symbol* const *)v1;
+  Symbol* s2 = *(Symbol* const *)v2;
+  ModuleSymbol* m1 = s1->getModule();
+  ModuleSymbol* m2 = s2->getModule();
+  if (m1 != m2) {
+    if (m1->modTag < m2->modTag)
+      return -1;
+    if (m1->modTag > m2->modTag)
+      return 1;
+    return strcmp(m1->cname, m2->cname);
+  }
+
+  if (s1->linenum() != s2->linenum())
+    return (s1->linenum() < s2->linenum()) ? -1 : 1;
+
+  int result = strcmp(s1->type->symbol->cname, s2->type->symbol->cname);
+  if (!result)
+    result = strcmp(s1->cname, s2->cname);
+  return result;
+}
+
 //
 // given a name and up to two sets of names, return a name that is in
 // neither set and add the name to the first set; the second set may
@@ -595,8 +595,8 @@ static const int maxCNameAddedChars = 20;
 static char* longCNameReplacementBuffer = NULL;
 static Map<const char*, int> uniquifyNameCounts;
 static const char* uniquifyName(const char* name,
-                                Vec<const char*>* set1,
-                                Vec<const char*>* set2 = NULL) {
+                                std::set<const char*>* set1,
+                                std::set<const char*>* set2 = NULL) {
   const char* newName = name;
   if (fMaxCIdentLen > 0 &&
       (int)(strlen(newName) + maxCNameAddedChars) > fMaxCIdentLen)
@@ -612,14 +612,14 @@ static const char* uniquifyName(const char* name,
     longCNameReplacementBuffer[prefixLen-1] = 'X'; //fyi truncation marker
     name = newName = astr(longCNameReplacementBuffer);
   }
-  while (set1->set_in(newName) || (set2 && set2->set_in(newName))) {
+  while ((set1->find(newName)!=set1->end()) || (set2 && (set2->find(newName)!=set2->end()))) {
     char numberTmp[64];
     int count = uniquifyNameCounts.get(name);
     uniquifyNameCounts.put(name, count+1);
     snprintf(numberTmp, 64, "%d", count+2);
     newName = astr(name, numberTmp);
   }
-  set1->set_add(newName);
+  set1->insert(newName);
   return newName;
 }
 
@@ -840,8 +840,8 @@ static void protectNameFromC(Symbol* sym) {
 
 
 // TODO: Split this into a number of smaller routines.<hilde>
-static void codegen_defn(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
-  std::vector<FnSymbol*> & functions, Vec<VarSymbol*> & globals) {
+static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*> & types,
+  std::vector<FnSymbol*> & functions, std::vector<VarSymbol*> & globals) {
   GenInfo* info = gGenInfo;
   FILE* hdrfile = info->cfile;
 
@@ -915,8 +915,8 @@ static void codegen_defn(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
   }
 }
 
-static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
-  std::vector<FnSymbol*> & functions, Vec<VarSymbol*> & globals) {
+static void codegen_header(std::set<const char*> & cnames, std::vector<TypeSymbol*> & types,
+  std::vector<FnSymbol*> & functions, std::vector<VarSymbol*> & globals) {
   GenInfo* info = gGenInfo;
 
   // reserved symbol names that require renaming to compile
@@ -928,10 +928,10 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
   forv_Vec(TypeSymbol, ts, gTypeSymbols) {
     if (ts->defPoint->parentExpr != rootModule->block) {
       legalizeName(ts);
-      types.add(ts);
+      types.push_back(ts);
     }
   }
-  qsort(types.v, types.n, sizeof(types.v[0]), compareSymbol);
+  std::sort(types.begin(), types.end(), compareSymbol);
 
   //
   // collect globals and apply canonical sort
@@ -940,11 +940,10 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
     if (var->defPoint->parentExpr != rootModule->block &&
         toModuleSymbol(var->defPoint->parentSymbol)) {
       legalizeName(var);
-      globals.add(var);
+      globals.push_back(var);
     }
   }
-  qsort(globals.v, globals.n, sizeof(globals.v[0]), compareSymbol);
-
+  std::sort(globals.begin(), globals.end(), compareSymbol);
   //
   // collect functions and apply canonical sort
   //
@@ -952,7 +951,7 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
     legalizeName(fn);
     functions.push_back(fn);
   }
-  std::sort(functions.begin(), functions.end(), compareSymbol2);
+  std::sort(functions.begin(), functions.end(), compareSymbol);
 
 
   //
@@ -1017,7 +1016,7 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
   forv_Vec(TypeSymbol, ts, types) {
     if (ts->defPoint->parentExpr != rootModule->block) {
       if (AggregateType* ct = toAggregateType(ts->type)) {
-        Vec<const char*> fieldNameSet;
+        std::set<const char*> fieldNameSet;
         for_fields(field, ct) {
           legalizeName(field);
           field->cname = uniquifyName(field->cname, &fieldNameSet);
@@ -1053,7 +1052,7 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
   // arguments in the same function
   //
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-    Vec<const char*> formalNameSet;
+    std::set<const char*> formalNameSet;
     for_formals(formal, fn) {
       legalizeName(formal);
       formal->cname = uniquifyName(formal->cname, &formalNameSet, &cnames);
@@ -1067,10 +1066,10 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
   // other local variables in the same function
   //
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-    Vec<const char*> local;
+    std::set<const char*> local;
 
     for_formals(formal, fn) {
-      local.set_add(formal->cname);
+      local.insert(formal->cname);
     }
 
     std::vector<DefExpr*> defs;
@@ -1159,6 +1158,7 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
   // codegen class definitions in breadth first order starting with
   // "object" and following its dispatch children
   //
+
   Vec<TypeSymbol*> next, current;
   current.add(dtObject->symbol);
   while (current.n) {
@@ -1172,7 +1172,7 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
     current.clear();
     current.move(next);
     current.set_to_vec();
-    qsort(current.v, current.n, sizeof(current.v[0]), compareSymbol);
+    qsort(current.v, current.n, sizeof(current.v[0]), compareSymbol2);
     next.clear();
   }
 
@@ -1193,8 +1193,8 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
     if (fn2->hasFlag(FLAG_BEGIN_BLOCK) ||
         fn2->hasFlag(FLAG_COBEGIN_OR_COFORALL_BLOCK) ||
         fn2->hasFlag(FLAG_ON_BLOCK)) {
-    ftableVec.add(fn2);
-    ftableMap[fn2] = ftableVec.n-1;
+    ftableVec.push_back(fn2);
+    ftableMap[fn2] = ftableVec.size()-1;
     }
   }
 
@@ -1265,7 +1265,7 @@ static void codegen_header(Vec<const char*> & cnames, Vec<TypeSymbol*> & types,
 #endif
   }
 
-  genGlobalInt("chpl_mem_numDescs", memDescsVec.n, true);
+  genGlobalInt("chpl_mem_numDescs", memDescsVec.size(), true);
 
   //
   // add table of private-broadcast constants
@@ -1598,10 +1598,10 @@ void codegen(void) {
   }
 
   // Vectors to store different symbol names to be used while generating header
-  Vec<const char*> cnames;
-  Vec<TypeSymbol*> types;
+  std::set<const char*> cnames;
+  std::vector<TypeSymbol*> types;
   std::vector<FnSymbol*> functions;
-  Vec<VarSymbol*> globals;
+  std::vector<VarSymbol*> globals;
 
   // This dumps the generated sources into the build directory.
   info->cfile = hdrfile.fptr;

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1064,8 +1064,8 @@ expandRecursiveIteratorInline(ForLoop* forLoop)
 
   parent->defPoint->insertBefore(new DefExpr(loopBodyFnWrapper));
 
-  ftableVec.add(loopBodyFnWrapper);
-  ftableMap[loopBodyFnWrapper] = ftableVec.n-1;
+  ftableVec.push_back(loopBodyFnWrapper);
+  ftableMap[loopBodyFnWrapper] = ftableVec.size()-1;
 
   //
   // insert a call to the iterator function (using iterator as a


### PR DESCRIPTION
* Replacing Vec with std::vector in codegen.cpp and modifying the files
  for that accordingly.
* Also includes minor cleanup and use of std::set in certain places.
* Slight modification in Makefile for the generated file
  reservedSymbolNames.h
* Adding new function with naming scheme closer to std::vector and
  std::map making it easier to switch later on.