### PR TITLE
Adjust prints in DefaultRectangular to not depend on IO.chpl

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3124,9 +3124,13 @@ module ChapelArray {
       chpl__bulkTransferHelper(a, b);
     }
     else {
-      if debugBulkTransfer then
-        // just writeln() clashes with writeln.chpl
-        stdout.writeln("proc =(a:[],b): bulk transfer did not happen");
+      if debugBulkTransfer {
+        // uses printf b/c this function can be called before
+        // stdout exists (order of resolution issues)
+        // note that just writeln() would clash with writeln.chpl
+        extern proc printf(fmt:c_string);
+        printf(c"proc =(a:[],b): bulk transfer did not happen");
+      }
       chpl__transferArray(a, b);
     }
   }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3125,11 +3125,7 @@ module ChapelArray {
     }
     else {
       if debugBulkTransfer {
-        // uses printf b/c this function can be called before
-        // stdout exists (order of resolution issues)
-        // note that just writeln() would clash with writeln.chpl
-        extern proc printf(fmt:c_string);
-        printf(c"proc =(a:[],b): bulk transfer did not happen");
+        chpl_debug_writeln("proc =(a:[],b): bulk transfer did not happen");
       }
       chpl__transferArray(a, b);
     }

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Debug printing for internal modules.
+
+   In order to work around problems with resolution order
+   (commonly, stdout not defined in methods in DefaultRectangular),
+   this module implements a debug printing facility that can
+   be used before IO.chpl is resolved (or initialized).
+ */
+
+module ChapelDebugPrint {
+
+  // This routine is called in DefaultRectangular in order
+  // to report an out of bounds access for a halt. A normal
+  // call to halt with a tuple can't be made because of module
+  // order issues.
+  pragma "no doc"
+  proc _stringify_index(tup:?t) where isTuple(t)
+  {
+    var str = "(";
+
+    for param i in 1..tup.size {
+      if i != 1 then str += ", ";
+      str += tup[i]:string;
+    }
+
+   str += ")";
+
+    return str;
+
+  }
+
+  proc chpl_debug_stringify(args...) : string {
+    var str = "";
+    for param i in 1..args.size {
+      var tmp = args(i);
+      if isNumericType(tmp.type) || isBoolType(tmp.type) {
+	str += tmp:string;
+      } else if isRangeType(tmp.type) {
+	str += tmp.lo:string;
+	str += "..";
+	str += tmp.hi:string;
+      } else if isTupleType(tmp.type) {
+	str += _stringify_index(tmp);
+      } else if isStringType(tmp.type) {
+	str += tmp;
+      } else {
+	str += "?";
+      }
+    }
+    return str;
+  }
+
+  // this function allows DefaultRectangular to perform
+  // debug output without using stdout/writeln. It is a
+  // work around for module ordering issues in resolution.
+  proc chpl_debug_writeln(args...) {
+    extern proc printf(fmt:c_string, f:c_string);
+    var str = chpl_debug_stringify((...args));
+    printf("%s\n", str.c_str());
+  }
+
+  //
+  // When this flag is used during compilation, calls to chpl__testPar
+  // will output a message to indicate that a portion of the code has been
+  // parallelized.
+  //
+  // (chpl__testParFlag and related code is here to avoid order
+  //  of resolution issues.)
+
+  pragma "no doc"
+  config param chpl__testParFlag = false;
+  pragma "no doc"
+  var chpl__testParOn = false;
+
+  pragma "no doc"
+  proc chpl__testParStart() {
+    chpl__testParOn = true;
+  }
+
+  pragma "no doc"
+  proc chpl__testParStop() {
+    chpl__testParOn = false;
+  }
+
+  pragma "no doc"
+  proc chpl__testPar(args...) {
+    if chpl__testParFlag && chpl__testParOn {
+      // This function is written this way because it is called
+      // from DefaultRectangular. This way of writing it works
+      // around resolution ordering issues (such as stdout not
+      // yet defined).
+      const file_cs : c_string = __primitive("chpl_lookupFilename",
+                                        __primitive("_get_user_file"));
+      const file = file_cs:string;
+      const line = __primitive("_get_user_line");
+      var str = chpl_debug_stringify((...args));
+      extern proc printf(fmt:c_string, f:c_string, ln:c_int, s:c_string);
+      printf("CHPL TEST PAR (%s:%i): %s\n", file_cs, line:c_int, str.c_str());
+    }
+  }
+}
+

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -52,17 +52,17 @@ module ChapelDebugPrint {
     for param i in 1..args.size {
       var tmp = args(i);
       if isNumericType(tmp.type) || isBoolType(tmp.type) {
-	str += tmp:string;
+        str += tmp:string;
       } else if isRangeType(tmp.type) {
-	str += tmp.lo:string;
-	str += "..";
-	str += tmp.hi:string;
+        str += tmp.lo:string;
+        str += "..";
+        str += tmp.hi:string;
       } else if isTupleType(tmp.type) {
-	str += _stringify_index(tmp);
+        str += _stringify_index(tmp);
       } else if isStringType(tmp.type) {
-	str += tmp;
+        str += tmp;
       } else {
-	str += "?";
+        str += "?";
       }
     }
     return str;

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -35,7 +35,7 @@ module ChapelDebugPrint {
         // Call stringify from IO.chpl. Note that stringify
         // is also called on halt, and so needs to handle
         // being resolved before IO.chpl is completely resolved.
-	str += stringify(tmp);
+        str += stringify(tmp);
       } else {
         str += "?";
       }

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -27,40 +27,15 @@
 
 module ChapelDebugPrint {
 
-  // This routine is called in DefaultRectangular in order
-  // to report an out of bounds access for a halt. A normal
-  // call to halt with a tuple can't be made because of module
-  // order issues.
-  pragma "no doc"
-  proc _stringify_index(tup:?t) where isTuple(t)
-  {
-    var str = "(";
-
-    for param i in 1..tup.size {
-      if i != 1 then str += ", ";
-      str += tup[i]:string;
-    }
-
-   str += ")";
-
-    return str;
-
-  }
-
   proc chpl_debug_stringify(args...) : string {
     var str = "";
     for param i in 1..args.size {
       var tmp = args(i);
-      if isNumericType(tmp.type) || isBoolType(tmp.type) {
-        str += tmp:string;
-      } else if isRangeType(tmp.type) {
-        str += tmp.lo:string;
-        str += "..";
-        str += tmp.hi:string;
-      } else if isTupleType(tmp.type) {
-        str += _stringify_index(tmp);
-      } else if isStringType(tmp.type) {
-        str += tmp;
+      if _can_stringify_direct(tmp) {
+        // Call stringify from IO.chpl. Note that stringify
+        // is also called on halt, and so needs to handle
+        // being resolved before IO.chpl is completely resolved.
+	str += stringify(tmp);
       } else {
         str += "?";
       }

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -207,26 +207,6 @@ module ChapelIO {
     param dummy = readerDeprecated();
   }
 
-  // This routine is called in DefaultRectangular in order
-  // to report an out of bounds access for a halt. A normal
-  // call to halt with a tuple can't be made because of module
-  // order issues.
-  pragma "no doc"
-  proc _stringify_index(tup:?t) where isTuple(t)
-  {
-    var str = "(";
-
-    for param i in 1..tup.size {
-      if i != 1 then str += ", ";
-      str += tup[i]:string;
-    }
-
-   str += ")";
-
-    return str;
-
-  }
-
   use IO;
 
     private
@@ -767,36 +747,4 @@ module ChapelIO {
   proc ref string.write(args ...?n) {
     compilerError("string.write deprecated: use string.format or stringify");
   }
-
-  //
-  // When this flag is used during compilation, calls to chpl__testPar
-  // will output a message to indicate that a portion of the code has been
-  // parallelized.
-  //
-  pragma "no doc"
-  config param chpl__testParFlag = false;
-  pragma "no doc"
-  var chpl__testParOn = false;
-  
-  pragma "no doc"
-  proc chpl__testParStart() {
-    chpl__testParOn = true;
-  }
-  
-  pragma "no doc"
-  proc chpl__testParStop() {
-    chpl__testParOn = false;
-  }
-  
-  pragma "no doc"
-  proc chpl__testPar(args...) {
-    if chpl__testParFlag && chpl__testParOn {
-      const file_cs : c_string = __primitive("chpl_lookupFilename",
-                                        __primitive("_get_user_file"));
-      const file = file_cs:string;
-      const line = __primitive("_get_user_line");
-      writeln("CHPL TEST PAR (", file, ":", line, "): ", (...args));
-    }
-  }
-
 }

--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -27,6 +27,7 @@ module ChapelStandard {
   use CPtr;
   use CString;
   use String;
+  use ChapelDebugPrint;
   use ChapelEnv;
   use ChapelBase;
   use MemConsistency;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -907,7 +907,7 @@ module DefaultRectangular {
           // the multiple-arguments implementation of halt cannot
           // be called at this point. So we call a special routine
           // that does the right thing here.
-          halt("array index out of bounds: " + _stringify_index(ind));
+          halt("array index out of bounds: " + _stringify_tuple(ind));
         }
       var dataInd = getDataIndex(ind);
       return theData(dataInd);
@@ -917,7 +917,7 @@ module DefaultRectangular {
     where !shouldReturnRvalueByConstRef(eltType) {
       if boundsChecking then
         if !dom.dsiMember(ind) {
-          halt("array index out of bounds: " + _stringify_index(ind));
+          halt("array index out of bounds: " + _stringify_tuple(ind));
         }
       var dataInd = getDataIndex(ind);
       return theData(dataInd);
@@ -927,7 +927,7 @@ module DefaultRectangular {
     where shouldReturnRvalueByConstRef(eltType) {
       if boundsChecking then
         if !dom.dsiMember(ind) {
-          halt("array index out of bounds: " + _stringify_index(ind));
+          halt("array index out of bounds: " + _stringify_tuple(ind));
         }
       var dataInd = getDataIndex(ind);
       return theData(dataInd);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -169,12 +169,12 @@ module DefaultRectangular {
       if chpl__testParFlag then
         chpl__testPar("default rectangular domain standalone invoked on ", ranges);
       if debugDefaultDist then
-        writeln("*** In domain standalone code:");
+        chpl_debug_writeln("*** In domain standalone code:");
 
       const numTasks = if tasksPerLocale == 0 then here.maxTaskPar
                        else tasksPerLocale;
       if debugDefaultDist {
-        writeln("    numTasks=", numTasks, " (", ignoreRunning,
+        chpl_debug_writeln("    numTasks=", numTasks, " (", ignoreRunning,
                 "), minIndicesPerTask=", minIndicesPerTask);
       }
       const (numChunks, parDim) = if __primitive("task_get_serial") then
@@ -184,12 +184,12 @@ module DefaultRectangular {
                                                      minIndicesPerTask,
                                                      ranges);
       if debugDefaultDist {
-        writeln("    numChunks=", numChunks, " parDim=", parDim,
+        chpl_debug_writeln("    numChunks=", numChunks, " parDim=", parDim,
                 " ranges(", parDim, ").length=", ranges(parDim).length);
       }
 
       if debugDataPar {
-        writeln("### numTasksPerLoc = ", numTasks, "\n" +
+        chpl_debug_writeln("### numTasksPerLoc = ", numTasks, "\n" +
                 "### ignoreRunning = ", ignoreRunning, "\n" +
                 "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
                 "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n" +
@@ -206,7 +206,7 @@ module DefaultRectangular {
           locBlock(i) = offset(i)..#(ranges(i).length);
         }
         if debugDefaultDist {
-          writeln("*** DI: locBlock = ", locBlock);
+          chpl_debug_writeln("*** DI: locBlock = ", locBlock);
         }
         coforall chunk in 0..#numChunks {
           var followMe: rank*range(idxType) = locBlock;
@@ -217,7 +217,7 @@ module DefaultRectangular {
                                         locBlock(parDim).low);
           followMe(parDim) = lo..hi;
           if debugDefaultDist {
-            writeln("*** DI[", chunk, "]: followMe = ", followMe);
+            chpl_debug_writeln("*** DI[", chunk, "]: followMe = ", followMe);
           }
           var block: rank*range(idxType=idxType, stridable=stridable);
           if stridable {
@@ -278,7 +278,7 @@ module DefaultRectangular {
                                                        minIndicesPerTask,
                                                        ranges);
         if debugDataParNuma {
-          writeln("### numSublocs = ", numSublocs, "\n" +
+          chpl_debug_writeln("### numSublocs = ", numSublocs, "\n" +
                   "### numTasksPerSubloc = ", numSublocTasks, "\n" +
                   "### ignoreRunning = ", ignoreRunning, "\n" +
                   "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
@@ -300,7 +300,7 @@ module DefaultRectangular {
             local on here.getChild(chunk) {
               if debugDataParNuma {
                 if chunk!=chpl_getSubloc() then
-                  writeln("*** ERROR: ON WRONG SUBLOC (should be "+chunk+
+                  chpl_debug_writeln("*** ERROR: ON WRONG SUBLOC (should be "+chunk+
                           ", on "+chpl_getSubloc()+") ***");
               }
               // Divide the locale's tasks approximately evenly
@@ -333,7 +333,7 @@ module DefaultRectangular {
                                               high, low, low);
                 followMe2(parDim2) = lo..hi;
                 if debugDataParNuma {
-                  writeln("### chunk = ", chunk, "  chunk2 = ", chunk2, "  " +
+                  chpl_debug_writeln("### chunk = ", chunk, "  chunk2 = ", chunk2, "  " +
                           "followMe = ", followMe, "  followMe2 = ", followMe2);
                 }
                 yield followMe2;
@@ -344,12 +344,12 @@ module DefaultRectangular {
       } else {
 
         if debugDefaultDist then
-          writeln("*** In domain/array leader code:"); // this = ", this);
+          chpl_debug_writeln("*** In domain/array leader code:"); // this = ", this);
         const numTasks = if tasksPerLocale==0 then here.maxTaskPar
                          else tasksPerLocale;
 
         if debugDefaultDist then
-          writeln("    numTasks=", numTasks, " (", ignoreRunning,
+          chpl_debug_writeln("    numTasks=", numTasks, " (", ignoreRunning,
                   "), minIndicesPerTask=", minIndicesPerTask);
 
         const (numChunks, parDim) = if __primitive("task_get_serial") then
@@ -359,11 +359,11 @@ module DefaultRectangular {
                                                        minIndicesPerTask,
                                                        ranges);
         if debugDefaultDist then
-          writeln("    numChunks=", numChunks, " parDim=", parDim,
+          chpl_debug_writeln("    numChunks=", numChunks, " parDim=", parDim,
                   " ranges(", parDim, ").length=", ranges(parDim).length);
 
         if debugDataPar {
-          writeln("### numTasksPerLoc = ", numTasks, "\n" +
+          chpl_debug_writeln("### numTasksPerLoc = ", numTasks, "\n" +
                   "### ignoreRunning = ", ignoreRunning, "\n" +
                   "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
                   "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n" +
@@ -384,7 +384,7 @@ module DefaultRectangular {
           for param i in 1..rank do
             locBlock(i) = offset(i)..#(ranges(i).length);
           if debugDefaultDist then
-            writeln("*** DI: locBlock = ", locBlock);
+            chpl_debug_writeln("*** DI: locBlock = ", locBlock);
           coforall chunk in 0..#numChunks {
             var followMe: rank*range(idxType) = locBlock;
             const (lo,hi) = _computeBlock(locBlock(parDim).length,
@@ -394,7 +394,7 @@ module DefaultRectangular {
                                           locBlock(parDim).low);
             followMe(parDim) = lo..hi;
             if debugDefaultDist then
-              writeln("*** DI[", chunk, "]: followMe = ", followMe);
+              chpl_debug_writeln("*** DI[", chunk, "]: followMe = ", followMe);
             yield followMe;
           }
         }
@@ -415,7 +415,7 @@ module DefaultRectangular {
       if chpl__testParFlag then
         chpl__testPar("default rectangular domain follower invoked on ", followThis);
       if debugDefaultDist then
-        writeln("In domain follower code: Following ", followThis);
+        chpl_debug_writeln("In domain follower code: Following ", followThis);
 
       param stridable = this.stridable || anyStridable(followThis);
       var block: rank*range(idxType=idxType, stridable=stridable);
@@ -752,7 +752,7 @@ module DefaultRectangular {
                minIndicesPerTask = dataParMinGranularity)
       ref where tag == iterKind.standalone && !localeModelHasSublocales {
       if debugDefaultDist {
-        writeln("*** In array standalone code");
+        chpl_debug_writeln("*** In array standalone code");
       }
       for i in dom.these(tag, tasksPerLocale,
                          ignoreRunning, minIndicesPerTask) {
@@ -778,7 +778,7 @@ module DefaultRectangular {
                minIndicesPerTask = dataParMinGranularity)
       ref where tag == iterKind.follower {
       if debugDefaultDist then
-        writeln("*** In array follower code:"); // [\n", this, "]");
+        chpl_debug_writeln("*** In array follower code:"); // [\n", this, "]");
       for i in dom.these(tag=iterKind.follower, followThis,
                          tasksPerLocale,
                          ignoreRunning,
@@ -958,7 +958,7 @@ module DefaultRectangular {
                                            blk=blk);
       alias.data = data;
       //alias.numelm = numelm;
-      //writeln("DR.dsiReindex blk: ", blk, " stride: ",dom.dsiDim(1).stride," str:",str(1));
+      //chpl_debug_writeln("DR.dsiReindex blk: ", blk, " stride: ",dom.dsiDim(1).stride," str:",str(1));
       adjustBlkOffStrForNewDomain(d, alias);
       alias.origin = origin:d.idxType;
       alias.computeFactoredOffs();
@@ -1335,7 +1335,7 @@ module DefaultRectangular {
   // This is very conservative.
   proc DefaultRectangularArr.isDataContiguous() {
     if debugDefaultDistBulkTransfer then
-      writeln("isDataContiguous(): origin=", origin, " off=", off, " blk=", blk);
+      chpl_debug_writeln("isDataContiguous(): origin=", origin, " off=", off, " blk=", blk);
 
     for param dim in 1..rank do
       if off(dim)!= dom.dsiDim(dim).first then return false;
@@ -1346,7 +1346,7 @@ module DefaultRectangular {
       if blk(dim) != blk(dim+1)*dom.dsiDim(dim+1).length then return false;
 
     if debugDefaultDistBulkTransfer then
-      writeln("\tYES!");
+      chpl_debug_writeln("\tYES!");
 
     return true;
   }
@@ -1355,20 +1355,20 @@ module DefaultRectangular {
   proc DefaultRectangularArr.dsiSupportsBulkTransferInterface() param return true;
 
   proc DefaultRectangularArr.doiCanBulkTransfer() {
-    if debugDefaultDistBulkTransfer then writeln("In DefaultRectangularArr.doiCanBulkTransfer()");
+    if debugDefaultDistBulkTransfer then chpl_debug_writeln("In DefaultRectangularArr.doiCanBulkTransfer()");
     if dom.stridable then
       for param i in 1..rank do
         if dom.ranges(i).stride != 1 then return false;
     if !isDataContiguous(){
       if debugDefaultDistBulkTransfer then
-        writeln("isDataContiguous return False");
+        chpl_debug_writeln("isDataContiguous return False");
       return false;
     }
     return true;
   }
 
   proc DefaultRectangularArr.doiCanBulkTransferStride() param {
-    if debugDefaultDistBulkTransfer then writeln("In DefaultRectangularArr.doiCanBulkTransferStride()");
+    if debugDefaultDistBulkTransfer then chpl_debug_writeln("In DefaultRectangularArr.doiCanBulkTransferStride()");
     // A DefaultRectangular array is always regular, so bulk should be possible.
     return true;
   }
@@ -1392,7 +1392,7 @@ module DefaultRectangular {
       pragma "no prototype"
       extern proc sizeof(type x): int;
       const elemSize =sizeof(B._value.eltType);
-      writeln("In DefaultRectangularArr.doiBulkTransfer():",
+      chpl_debug_writeln("In DefaultRectangularArr.doiBulkTransfer():",
               " Alo=", Alo, ", Blo=", Blo,
               ", len=", len, ", elemSize=", elemSize);
     }
@@ -1407,15 +1407,15 @@ module DefaultRectangular {
     // and chpl_comm_put should be changed once that is fixed.
     if Adata.locale.id==here.id {
       if debugDefaultDistBulkTransfer then //See bug in test/optimizations/bulkcomm/alberto/rafatest2.chpl
-        writeln("\tlocal get() from ", B._value.locale.id);
+        chpl_debug_writeln("\tlocal get() from ", B._value.locale.id);
       __primitive("chpl_comm_array_get", Adata[0], Bdata.locale.id, Bdata[0], len);
     } else if Bdata.locale.id==here.id {
       if debugDefaultDistBulkTransfer then
-        writeln("\tlocal put() to ", this.locale.id);
+        chpl_debug_writeln("\tlocal put() to ", this.locale.id);
       __primitive("chpl_comm_array_put", Bdata[0], Adata.locale.id, Adata[0], len);
     } else on Adata.locale {
       if debugDefaultDistBulkTransfer then
-        writeln("\tremote get() on ", here.id, " from ", B.locale.id);
+        chpl_debug_writeln("\tremote get() on ", here.id, " from ", B.locale.id);
       __primitive("chpl_comm_array_get", Adata[0], Bdata.locale.id, Bdata[0], len);
     }
   }
@@ -1440,7 +1440,7 @@ module DefaultRectangular {
   proc DefaultRectangularArr.doiBulkTransferStride(Barg) {
     if this.data.locale != here && Barg.data.locale != here {
       if debugDefaultDistBulkTransfer {
-        writeln("BulkTransferStride: Both arrays on different locale, moving to locale of destination: ", this.data.locale);
+        chpl_debug_writeln("BulkTransferStride: Both arrays on different locale, moving to locale of destination: ", this.data.locale);
       }
       on this.data do stridedTransferFrom(Barg);
     } else {
@@ -1462,9 +1462,9 @@ module DefaultRectangular {
     for i in 1..rank do BFirst(i) = if Bdims(i).stride < 0 then Bdims(i).last else Bdims(i).first;
 
     if debugDefaultDistBulkTransfer {
-      writeln("In DefaultRectangularArr.doiBulkTransferStride");
-      writeln("Dest = ", Adims);
-      writeln("Src  = ", Bdims);
+      chpl_debug_writeln("In DefaultRectangularArr.doiBulkTransferStride");
+      chpl_debug_writeln("Dest = ", Adims);
+      chpl_debug_writeln("Src  = ", Bdims);
     }
 
     // The number of values needed to express the strided region.
@@ -1541,14 +1541,14 @@ module DefaultRectangular {
   //
   proc DefaultRectangularArr.doiBulkTransferStrideComm(B, stridelevels:int(32), dstStride, srcStride, count, AFirst, BFirst) {
     if debugDefaultDistBulkTransfer {
-      writeln("BulkTransferStride with values:");
-      writeln("\tLocale        = ", here.id);
-      writeln("\tStride levels = ", stridelevels);
-      writeln("\tdstStride     = ", dstStride);
-      writeln("\tsrcStride     = ", srcStride);
-      writeln("\tcount         = ", count);
-      writeln("\tdstBlk        = ", blk);
-      writeln("\tsrcBlk        = ", B.blk);
+      chpl_debug_writeln("BulkTransferStride with values:");
+      chpl_debug_writeln("\tLocale        = ", here.id);
+      chpl_debug_writeln("\tStride levels = ", stridelevels);
+      chpl_debug_writeln("\tdstStride     = ", dstStride);
+      chpl_debug_writeln("\tsrcStride     = ", srcStride);
+      chpl_debug_writeln("\tcount         = ", count);
+      chpl_debug_writeln("\tdstBlk        = ", blk);
+      chpl_debug_writeln("\tsrcBlk        = ", B.blk);
     }
 
     const A = this;
@@ -1565,7 +1565,7 @@ module DefaultRectangular {
       var srclocale = src.locale.id : int(32);
 
       if debugBulkTransfer {
-        writeln("BulkTransferStride: On LHS - GET from ", srclocale);
+        chpl_debug_writeln("BulkTransferStride: On LHS - GET from ", srclocale);
       }
 
       __primitive("chpl_comm_get_strd",
@@ -1585,7 +1585,7 @@ module DefaultRectangular {
       }
 
       if debugBulkTransfer {
-        writeln("BulkTransferStride: On RHS - PUT to ", destlocale);
+        chpl_debug_writeln("BulkTransferStride: On RHS - PUT to ", destlocale);
       }
 
       __primitive("chpl_comm_put_strd",

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -310,20 +310,6 @@ pragma "no doc"
 proc isRefIter(type t)   param  return isRefIterType(t);
 pragma "no doc"
 proc isPOD(type t)       param  return isPODType(t);
-pragma "no doc"
-proc isTupleOfPrimitiveTypes(e) param
-{
-  if !isTuple(e) then return false;
-
-  // compute && reduce isPrimitiveValue over the tuple
-  proc help(x) param
-    return isPrimitiveValue(x);
-
-  proc help(x, args ...) param
-    return isPrimitiveValue(x) && help((...args));
-
-  return help((...e));
-}
 
 // Set 2 - values.
 /*

--- a/test/distributions/sungeun/dataPar2.prediff
+++ b/test/distributions/sungeun/dataPar2.prediff
@@ -2,7 +2,7 @@
 # sort the output to handle the numa case where iterator debug output is in a
 # non-deterministic order. Don't sort for non-numa 
 
-if [ $CHPL_LOCALE_MODEL == "numa" ]
+if [ $CHPL_LOCALE_MODEL = "numa" ]
 then 
   sort $2 > $2.prediff.tmp
   mv $2.prediff.tmp $2

--- a/test/functions/iterators/sungeun/forwarding/PREDIFF
+++ b/test/functions/iterators/sungeun/forwarding/PREDIFF
@@ -3,7 +3,7 @@
 # non-deterministic order. Don't sort for non-numa 
 
 lm=`$CHPL_HOME/util/chplenv/chpl_locale_model.py`
-if [ "$lm" == "numa" ]
+if [ "$lm" = "numa" ]
 then
   sort $2 > $2.prediff.tmp
   mv $2.prediff.tmp $2

--- a/test/functions/iterators/sungeun/localDataPar.prediff
+++ b/test/functions/iterators/sungeun/localDataPar.prediff
@@ -3,7 +3,7 @@
 # non-deterministic order. Don't sort for non-numa 
 
 lm=`$CHPL_HOME/util/chplenv/chpl_locale_model.py`
-if [ "$lm" == "numa" ]
+if [ "$lm" = "numa" ]
 then
     sort $2 > $2.prediff.tmp
     mv $2.prediff.tmp $2

--- a/test/modules/standard/Types/tup-primitive.chpl
+++ b/test/modules/standard/Types/tup-primitive.chpl
@@ -1,6 +1,6 @@
 proc test(param expect, args ...)
 {
-  param isPrim = isTupleOfPrimitiveTypes(args);
+  param isPrim = _can_stringify_direct(args);
   writeln("expect ", expect, " for ", args.type:string, " isPrim=", isPrim);
 }
 

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -6,6 +6,7 @@ Initializing Modules:
      BaseStringType
      SysCTypes
      StringCasts
+    ChapelDebugPrint
     ChapelBase
      ChapelStringLiterals
     MemConsistency


### PR DESCRIPTION
In my work on arrays, arrays return by value. As a result, the array auto copy calls something equivalent to array assignment. The result of that is that array copy is now sensitive to resolution order. In particular, there are problems with using IO.chpl from within DefaultRectangular if it could be called in the process of performing an array copy. Since the IO calls in this situation are all for debug output, I created a module that does not use IO.chpl to perform the debug output. This resolves the problem on my arrays branch with tests that check for this debug output.

Passed full local testing.
Reviewed by @daviditen - thanks!