### PR TITLE
Disable work stealing in "distrib" performance playgrounds

### DIFF
--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -11,6 +11,9 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04.playground"
 # Test perf of qthreads WIP "distrib" scheduler compared to nemesis
 export CHPL_QTHREAD_SCHEDULER=distrib
 
+# See if disabling work stealing improves performance
+export QT_STEAL_RATIO=0
+
 # hackily checkout and overlay qthreads branch that has the scheduler
 cd $CHPL_HOME/third-party/qthread/
 rm -rf qthread-1.10/

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -12,6 +12,9 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 # Test perf of qthreads WIP "distrib" scheduler with numa against sherwood
 export CHPL_QTHREAD_SCHEDULER=distrib
 
+# See if disabling work stealing improves performance
+export QT_STEAL_RATIO=0
+
 # hackily checkout and overlay qthreads branch that has the scheduler
 cd $CHPL_HOME/third-party/qthread/
 rm -rf qthread-1.10/


### PR DESCRIPTION
See if disabling work stealing for the experimental "distrib" scheduler
improves performance.