### PR TITLE
Fixes for denormalize

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -113,6 +113,14 @@ SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized
 SQUASH_WARN_GEN_CFLAGS += -Wno-pointer-sign
 
 #
+# Don't warn for unsigned pointer comparisons
+#
+# uint32_t i = foo();
+# bool = i < 0; // always false
+#
+SQUASH_WARN_GEN_CFLAGS += -Wno-tautological-compare
+
+#
 # compiler warnings settings
 #
 ifeq ($(WARNINGS), 1)

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -163,6 +163,13 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-pointer-sign
 endif
 
 #
+# Don't warn/error for tautological compares (ex. x == x)
+#
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -lt 6; echo "$$?"),1)
+SQUASH_WARN_GEN_CFLAGS += -Wno-tautological-compare
+endif
+
+#
 # 2016/03/28: Help to protect the Chapel compiler from a partially
 # characterized GCC optimizer regression when the compiler is being
 # compiled with gcc 5.X.  Issue will be pursued after the release


### PR DESCRIPTION
This PR fixes two issues that came up in nightlies with denormalize on by default:

- Generated LLVM IR with bool functions was causing an issue with return instruction type(1-bit) not matching function type(8-bit). This PR adds a cast to PRIM_RETURN for LLVM. Connected to this issue, special treatment("!= 0") on boolean casts are avoided for LLVM.

- clang complains when you do something like `x < 0` where x is unsigned, since it always evaluates to false. IMHO, compiler can get rid of such statements in earlier passes than denormalize, but for now this PR throws in `-Wno-tautological-compare` for clang to supress warnings.

PS. Even with this merged in --denormalize can still cause some tests to fail, most likely due to floating point precision. @ronawho is aware of the issue and those test will need to be adjusted before we turn denormalize on-by-default

PPS. I'd feel better if this goes in next Monday and not today.