### PR TITLE
Allow casts to string for C pointers

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -90,12 +90,12 @@ module CPtr {
     return __primitive("cast", t, x);
   }
   pragma "no doc"
-  inline proc _cast(type t, x) where t:uint(64) && x.type:c_void_ptr {
-    return __primitive("cast", t, x);
+  inline proc _cast(type t, x) where t:string && x.type:c_void_ptr {
+    return __primitive("ref to string", x):string;
   }
   pragma "no doc"
-  inline proc _cast(type t, x) where t:uint(64) && x.type:c_ptr {
-    return __primitive("cast", t, x);
+  inline proc _cast(type t, x) where t:string && x.type:c_ptr {
+    return __primitive("ref to string", x):string;
   }
 
 

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -199,16 +199,6 @@ module CPtr {
   pragma "no doc"
   extern proc c_pointer_return(ref x:?t):c_ptr(t);
 
-  pragma "no doc"
-  proc c_void_ptr.writeThis(x) {
-    writef("0x%016xu", this:uint(64));
-  }
-
-  pragma "no doc"
-  proc c_ptr.writeThis(x) {
-    writef("0x%016xu", this:uint(64));
-  }
-
 
   /* Returns a :type:`c_ptr` to a Chapel rectangular array.
     Note that the existence of this c_ptr has no impact on the lifetime of the

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -199,6 +199,16 @@ module CPtr {
   pragma "no doc"
   extern proc c_pointer_return(ref x:?t):c_ptr(t);
 
+  pragma "no doc"
+  proc c_void_ptr.writeThis(x) {
+    writef("0x%016xu", this:uint(64));
+  }
+
+  pragma "no doc"
+  proc c_ptr.writeThis(x) {
+    writef("0x%016xu", this:uint(64));
+  }
+
 
   /* Returns a :type:`c_ptr` to a Chapel rectangular array.
     Note that the existence of this c_ptr has no impact on the lifetime of the

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -89,6 +89,14 @@ module CPtr {
   inline proc _cast(type t, x) where t:c_ptr && x.type:c_void_ptr {
     return __primitive("cast", t, x);
   }
+  pragma "no doc"
+  inline proc _cast(type t, x) where t:uint(64) && x.type:c_void_ptr {
+    return __primitive("cast", t, x);
+  }
+  pragma "no doc"
+  inline proc _cast(type t, x) where t:uint(64) && x.type:c_ptr {
+    return __primitive("cast", t, x);
+  }
 
 
   pragma "compiler generated"

--- a/test/types/cptr/ptr_cast_to_string.chpl
+++ b/test/types/cptr/ptr_cast_to_string.chpl
@@ -1,0 +1,9 @@
+use Regexp;
+
+var mem = c_calloc(uint(8), 4096);
+if mem != c_nil then
+  assert((mem:string).match(compile("0x[0-9a-f]+")).matched);
+var ptr = mem:c_void_ptr;
+assert((mem:string) == (ptr:string));
+assert((c_nil:string) == "(nil)");
+c_free(mem);

--- a/test/types/cptr/ptr_cast_to_string.chpl
+++ b/test/types/cptr/ptr_cast_to_string.chpl
@@ -5,5 +5,4 @@ if mem != c_nil then
   assert((mem:string).match(compile("0x[0-9a-f]+")).matched);
 var ptr = mem:c_void_ptr;
 assert((mem:string) == (ptr:string));
-assert((c_nil:string) == "(nil)");
 c_free(mem);


### PR DESCRIPTION
Allow casts to `string` for both `c_void_ptr` and `c_ptr` objects.
