### PR TITLE
Fix typo that in code that only fails on gasnet

### DIFF
--- a/test/classes/lydia/overrides/remoteVersion.chpl
+++ b/test/classes/lydia/overrides/remoteVersion.chpl
@@ -27,7 +27,7 @@ on Locales(1) {
   b2.foo();
 
   delete b2;
-  deleta a2;
+  delete a2;
 }
 
 delete b;


### PR DESCRIPTION
Introduced a typo that in code that isn't exercised on single-locale.  Fixed.

Thanks Laura!

