### PR TITLE
Fix gasnet config for recent memory leak updates

### DIFF
--- a/test/classes/lydia/overrides/remoteVersion.chpl
+++ b/test/classes/lydia/overrides/remoteVersion.chpl
@@ -27,7 +27,7 @@ on Locales(1) {
   b2.foo();
 
   delete b2;
-  deleta a2;
+  delete a2;
 }
 
 delete b;

--- a/test/extern/sungeun/classes/extern_class_nl_extern_proc.good
+++ b/test/extern/sungeun/classes/extern_class_nl_extern_proc.good
@@ -1,2 +1,2 @@
 (x = 5)
-extern_class_nl_extern_proc.chpl:12: error: cannot pass non-local extern class to extern procedure
+extern_class_nl_extern_proc.chpl:13: error: cannot pass non-local extern class to extern procedure


### PR DESCRIPTION
I recently updated a few tests to eliminate user-generated leaks but only tested on linux64.
I have learned that gasnet had 2 failures

1) I had a simple typo

2) A line number changed and so needed an update to a .good file

Trivial changes.  Tested on gasnet.

