### PR TITLE
Improve perf-test compilation error output clarity

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1504,7 +1504,10 @@ for testname in testsrc:
             # sys.stdout.write('default goodfile=%s\n'%(goodfile))
 
             if not os.path.isfile(goodfile) or not os.access(goodfile, os.R_OK):
-                sys.stdout.write('[Error cannot locate compiler output comparison file %s/%s]\n'%(localdir, goodfile))
+                if perftest:
+                    sys.stdout.write('[Error compilation failed for %s/%s]\n'%(localdir, test_filename))
+                else:
+                    sys.stdout.write('[Error cannot locate compiler output comparison file %s/%s]\n'%(localdir, goodfile))
                 sys.stdout.write('[Compiler output was as follows:]\n')
                 sys.stdout.write(origoutput)
                 cleanup(execname)


### PR DESCRIPTION
When a performance test failed, the output would include something like:

```
[Error cannot locate compiler output comparison file studies/prk/stencil/stencil-stencildist.good]
```

However, a performance test should never be looking for a good file in the first place, so this error can be quite confusing. 

This PR improves the clarity of this message. The new output for the same performance test above is:

```
[Error compilation failed for studies/prk/stencil/stencil]
```

Tested locally by adding a compilation error (classic *missing semi-colon*) to the test used as an example above. 