### PR TITLE
Enable histograms using arrays with reduce intents

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1133,8 +1133,8 @@ static void setupOneReduceIntent(VarSymbol* iterRec, BlockStmt* parLoop,
   // reduceVar = globalOp.generate(); delete globalOp;
   parLoop->insertAfter("'delete'(%S)",
                        globalOp);
-  parLoop->insertAfter("'='(%E,.(%S, 'generate')())",
-                       reduceVar->copy(), globalOp);
+  parLoop->insertAfter(new CallExpr("=", reduceVar->copy(),
+                         new_Expr(".(%S, 'generate')()", globalOp)));
 }
 
 // Setup for forall intents

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -52,7 +52,16 @@ module ChapelReduce {
   
   proc chpl__sumType(type eltType) type {
     var x: eltType;
-    return (x + x).type;
+    if isArray(x) {
+      type xET = x.eltType;
+      type xST = chpl__sumType(xET);
+      if xET == xST then
+        return eltType;
+      else
+        return [x.domain] xST;
+    } else {
+      return (x + x).type;
+    }
   }
   
   pragma "ReduceScanOp"

--- a/test/reductions/vass/histogram-1.chpl
+++ b/test/reductions/vass/histogram-1.chpl
@@ -1,0 +1,47 @@
+
+config const b = 3;
+config const n = 99;
+config const nr=11;
+
+var data: [1..n] int = [i in 1..n] i % b + 1;
+
+type HistT = [1..b] int;
+var histo: HistT;
+
+writeln("computing the histogram over ", data.domain, " with ", b, " buckets");
+
+forall d in data with (+ reduce histo) {
+  histo[d] += 1;
+}
+
+writeln("histogram = ", histo);
+
+// just for kicks - reduce on domains
+
+var dosto: domain(int);
+writeln("playing with an associative domain");
+forall d in data with (+ reduce dosto) {
+  dosto.add(d);
+}
+forall d in data {
+  if !dosto.member(d) then
+    halt("dosto does not include ", d);
+}
+writeln("dosto is fine");
+
+// more kicks - ensure it works for simple records
+
+record RR {
+  var xx: int;
+}
+proc +(a1:RR, a2:RR) {
+  return new RR(xx=a1.xx+a2.xx);
+}
+
+var rtotal: RR;
+writeln("playing with a record");
+
+forall i in 1..nr with (+ reduce rtotal) {
+  rtotal.xx += 10**i;
+}
+writeln("rtotal = ", rtotal);

--- a/test/reductions/vass/histogram-1.good
+++ b/test/reductions/vass/histogram-1.good
@@ -1,0 +1,7 @@
+histogram-1.chpl:23: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+computing the histogram over {1..99} with 3 buckets
+histogram = 33 33 33
+playing with an associative domain
+dosto is fine
+playing with a record
+rtotal = (xx = 111111111110)

--- a/test/reductions/vass/histogram-2.chpl
+++ b/test/reductions/vass/histogram-2.chpl
@@ -1,0 +1,52 @@
+// This is a copy of histogram-1.chpl with main{} around the code.
+
+config const b = 3;
+config const n = 99;
+config const nr=11;
+
+proc main {
+
+var data: [1..n] int = [i in 1..n] i % b + 1;
+
+type HistT = [1..b] int;
+var histo: HistT;
+
+writeln("computing the histogram over ", data.domain, " with ", b, " buckets");
+
+forall d in data with (+ reduce histo) {
+  histo[d] += 1;
+}
+
+writeln("histogram = ", histo);
+
+// just for kicks - reduce on domains
+
+var dosto: domain(int);
+writeln("playing with an associative domain");
+forall d in data with (+ reduce dosto) {
+  dosto.add(d);
+}
+forall d in data {
+  if !dosto.member(d) then
+    halt("dosto does not include ", d);
+}
+writeln("dosto is fine");
+
+// more kicks - ensure it works for simple records
+
+record RR {
+  var xx: int;
+}
+proc +(a1:RR, a2:RR) {
+  return new RR(xx=a1.xx+a2.xx);
+}
+
+var rtotal: RR;
+writeln("playing with a record");
+
+forall i in 1..nr with (+ reduce rtotal) {
+  rtotal.xx += 10**i;
+}
+writeln("rtotal = ", rtotal);
+
+}

--- a/test/reductions/vass/histogram-2.good
+++ b/test/reductions/vass/histogram-2.good
@@ -1,0 +1,8 @@
+histogram-2.chpl:7: In function 'main':
+histogram-2.chpl:26: warning: whole-domain assignment has been serialized (see note in $CHPL_HOME/STATUS)
+computing the histogram over {1..99} with 3 buckets
+histogram = 33 33 33
+playing with an associative domain
+dosto is fine
+playing with a record
+rtotal = (xx = 111111111110)


### PR DESCRIPTION
This change allows the user to write forall loops
with array variable(s) passed by + reduce intent:

    // A is an array
    forall .... with (+ reduce A) { .... }

Furthermore, this code will manage memory properly.

This enables a natural way to compute a histogram in parallel like this:

    var histo: [1..nBuckets] int;

    forall datum in <data to plot> with (+ reduce histo) {
      ....
      histo[the appropriate bucket] += 1;
    }


MODULE CHANGE

I modified chpl__sumType() to support the case
where the argument is an array.

Having a special case in chpl__sumType() is dissatisfying
in that ideally it would not be needed. However I did not see
worthy alternatives.  Indeed:

* (x+x).type produces an iterator record type - because here the + operator
is promoted. An iterator record type is not suitable.

* Another alternative due to Michael is:

    proc chpl__sumType(type eltType) type
    { var x: eltType;  var y = x+x; return y.type; }

  This downside of this more elegant code is that it will actually
perform the array addition at run time, incurring extra overhead.
BTW both my version and this version create the 'x' array at run time,
under the current compiler.

One issue is how this code will support skyline arrays.
Seems like if 'eltType' is the type of a skyline array,
then it should be possible to return the type of their sum as well.

Future work: we may want chpl__sumType() to report an explicit error when
two eltType-typed things cannot be added. Without that, the compiler would
generate an "unresolved call" error, which would be less clear to the user.

Note: chpl__sumType() does not have a counterpart for the other reduction
operations. This is because it allows reduction of wider variety of things
than, say, built-in multiplication.


COMPILER CHANGE

Some changes in the compiler are necessary to insert additional autoCopy
calls to prevent premature deletion, and also additional autoDestroy calls
to prevent memory leaks. Here are details.

Turns out that when I generate an AST that MOVEs the result of an
array-returning function without autoCopy-ing it, then
returnRecordsByReferenceArguments() on this function does not fire
and things go off rail. Namely, the function itself and I think other
array-returning functions that it invokes get an extra autoDestroy
on the return value. This was the case for two 'svar's,
named shadowVar and shadowVarReduc, that stored the result of identity():

// before this change:

  redRef1->insertBefore("'move'(%S, identity(%S,%S))", // init
                        svar, gMethodToken, parentOp);

Adding autoCopy on the result resolves the issue.

As well as I replaced a PRIM_ASSIGN with a call to "=" on the result
of generate(). Since the reduction var already exists, we really want
assign into it, not bitcopy. To call "=", I had to put in "new CallExpr"
explicitly. Before I relied on insertAfter() to invoke new_Expr,
alas the latter does not handle calls to functions with operator names
like "=".


NEW TESTS

The two new tests are identical, except histogram-1 has everything
at the global level and histogram-2 has all except config consts
as local code within a function (main()).

Each of these still leaks memory. This is independent
of this change and is due to this statement that leaks
even on its own:

    type HistT = [1..1] int;



This PR is a replacement for #3956 to
* update to the current master
* eliminate memory leaks
