### PR TITLE
Fix problem with using an enum in a library module

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -321,8 +321,14 @@ void parseDependentModules(ModTag modtype) {
         // if we haven't found the standard version of the module then we
         // need to parse it
         if (!foundInt) {
-          ModuleSymbol* mod = parseFile(stdModNameToFilename(modName),
-                                        MOD_STANDARD);
+
+          const char* filename = stdModNameToFilename(modName);
+          if (filename == NULL) {
+            // The use statement could be of an enum.  Continue and if that
+            // doesn't resolve later then we'll notice during scopeResolve
+            continue;
+          }
+          ModuleSymbol* mod = parseFile(filename, MOD_STANDARD);
 
           // if we also found a user module by the same name, we need to
           // rename the standard module and the use of it

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -813,16 +813,10 @@ const char* modNameToFilename(const char* modName,
   return  fullfilename;
 }
 
+// Returns either a file name or NULL if no such file was found
+// (which could happen if there's a use of an enum within the library files)
 const char* stdModNameToFilename(const char* modName) {
-  const char* fullfilename = searchPath(stdModPath,
-                                        astr(modName, ".chpl"),
-                                        NULL);
-
-  if (fullfilename == NULL) {
-    USR_FATAL("Can't find standard module '%s'\n", modName);
-  }
-
-  return fullfilename;
+  return searchPath(stdModPath, astr(modName, ".chpl"), NULL);
 }
 
 const char* filenameToModulename(const char* filename) {


### PR DESCRIPTION
Preston discovered that if you used an enum in a library module, you would get
the error "Can't find standard module 'nameOfEnum'" instead of handling the enum
use like we do in user code.  This is because standard modules are searched in a
different manner from user modules.  Since it seems reasonable to want to use an
enum in the library modules, I removed the error case from stdModNameToFilename
and returned the NULL when the name doesn't work.  I then had the parser's
parseDependentModules function continue through the loop if the filename wasn't
found, letting the potential error when neither an enum nor a standard module
was named wait until scopeResolve handles unresolved names.  This allowed his
case to work, and I verified that I still got an error when the name didn't
match.

Passed full std/ testing