### PR TITLE
chplconfig tests: Use full path to `printchplenv`

### DIFF
--- a/test/chplenv/chplconfig/correctness/.gitignore
+++ b/test/chplenv/chplconfig/correctness/.gitignore
@@ -1,0 +1,1 @@
+correctness.good

--- a/test/chplenv/chplconfig/correctness/correctness.precomp
+++ b/test/chplenv/chplconfig/correctness/correctness.precomp
@@ -8,4 +8,5 @@ export CHPL_CONFIG=${PWD}
 # Unset any current overrides to prevent interference with test overrides
 source ../unset_overrides.sh
 
-$CHPL_HOME/util/printchplenv --anonymize > correctness.good
+${PRINTCHPLENV} --anonymize > correctness.good
+

--- a/test/chplenv/chplconfig/unset_overrides.sh
+++ b/test/chplenv/chplconfig/unset_overrides.sh
@@ -1,5 +1,9 @@
-# Unset any env vars currently set
-CHPL_OVERRIDES=$(printchplenv --overrides | awk -F'=' '{print $1}')
+# Modify environment, removing any non-home CHPL_* vars and add $PRINTCHPLENV
+
+export PRINTCHPLENV=$CHPL_HOME/util/printchplenv
+
+CHPL_OVERRIDES=$(${PRINTCHPLENV} --overrides | awk -F'=' '{print $1}')
+
 for CHPL_VAR in ${CHPL_OVERRIDES}; do
     if [ ${CHPL_VAR} != "CHPL_HOME" ]; then
         unset ${CHPL_VAR}

--- a/test/chplenv/chplconfig/warnings/.gitignore
+++ b/test/chplenv/chplconfig/warnings/.gitignore
@@ -1,0 +1,2 @@
+warnings.good
+notfound.good


### PR DESCRIPTION
PR to fix failed `chplconfig` tests.

Not using the full path in the sourced file `unset_overrides.sh` caused numerous configurations to fail for these tests, since they did not find the file `printchplenv` in their path. Unfortunately, this was not surfaced in the OS X / linux64 testing done before merging.

Also added `.gitignore` for those pesky generated `.good` files.