### PR TITLE
Fix a new race condition

### DIFF
--- a/test/parallel/single/waynew/class1.chpl
+++ b/test/parallel/single/waynew/class1.chpl
@@ -7,24 +7,31 @@ class D {
 }
 
 var d: D = new D();
-var i: int;
 
-begin writeln( "got ", d.s.readFF());
-begin writeln( "got ", d.s.readFF());
-begin writeln( "got ", d.s.readFF());
-begin writeln( "got ", d.s.readFF());
+// Do not delete d until every begin has executed
+sync {
+  var i: int;
 
-i = 4;
-writeln( "1: going to sleep with ", i);
-sleep( 3);
+  begin writeln( "got ", d.s.readFF());
+  begin writeln( "got ", d.s.readFF());
+  begin writeln( "got ", d.s.readFF());
+  begin writeln( "got ", d.s.readFF());
 
-writeln( "1: woke up. writing ", i);
-d.s = i;
-sleep( 1);
+  i = 4;
+  writeln( "1: going to sleep with ", i);
 
-begin writeln( "got ", d.s.readFF());
-sleep( 1);
+  sleep( 3);
 
-begin writeln( "got ", d.s.readFF());
+  writeln( "1: woke up. writing ", i);
+  d.s = i;
+
+  sleep( 1);
+
+  begin writeln( "got ", d.s.readFF());
+
+  sleep( 1);
+
+  begin writeln( "got ", d.s.readFF());
+}
 
 delete d;


### PR DESCRIPTION
I introduced a race condition in an existing test when I added a "delete" for a class
variable.  Race was particularly obvious on CHPL_TASK = fifo.
Add a sync statement to remove the race.

Tested with quickstart and standard.

Discussed with Elliot.
