### PR TITLE
De-futurized two tests that #4378 fixed.

### DIFF
--- a/test/associative/ferguson/plus-reduce-intent-assoc.future
+++ b/test/associative/ferguson/plus-reduce-intent-assoc.future
@@ -1,6 +1,0 @@
-bug: reduce intent on assoc array ref counting
-
-There appears to be a problem maintaining the domain
-reference count in this example.
-
-Compiling with -snoRefCount=true lets the program run.

--- a/test/trivial/sidelnik/array_init.bad
+++ b/test/trivial/sidelnik/array_init.bad
@@ -1,0 +1,1 @@
+array_init.chpl:1: error: cannot iterate over values of type real(64)

--- a/test/trivial/sidelnik/reduction.future
+++ b/test/trivial/sidelnik/reduction.future
@@ -1,4 +1,0 @@
-bug: reduction over the arrays in an arrays of arrays does not work
-
-This test fails in different ways for different compilers (?), so for
-now, only it run it for CHPL_HOST_COMPILER=gnu.


### PR DESCRIPTION
I verified that plus-reduce-intent-assoc passes valgrind also.

While there, added a .bad for another test.