### PR TITLE
Don't run the LLVM tests when using VisualDebug.

### DIFF
--- a/test/studies/prk/stencil/SKIPIF
+++ b/test/studies/prk/stencil/SKIPIF
@@ -4,6 +4,11 @@
 # We want to keep the problem size constant across single and multi-locale
 # runs, meaning there are strict memory restrictions for running single locale.
 
+# VisualDebug doesn't work for llvm yet
+if ($ENV{CHPL_LLVM} eq "llvm") {
+    print("True\n");
+    exit(0);
+}
 
 $memRequiredInGB = 8;
 $memInGB = $memRequiredInGB;


### PR DESCRIPTION
Adding code to the existing SKIPIF file to skip if testing LLVM since a program uses VisualDebug.