### PR TITLE
Add a config param to force returning POD values as 'const ref' from arrays

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -149,6 +149,10 @@ module ChapelArray {
   pragma "no doc"
   config param useBulkTransferStride = true;
 
+  // Return POD values from arrays as values instead of const ref?
+  pragma "no doc"
+  config param PODValAccess = true;
+
   // Toggles the functionality to perform strided bulk transfers involving
   // distributed arrays.
   //
@@ -1703,6 +1707,7 @@ module ChapelArray {
 
   pragma "no doc"
   proc shouldReturnRvalueByConstRef(type t) param {
+    if !PODValAccess then return true;
     if isPODType(t) then return false;
     return true;
   }


### PR DESCRIPTION
If the config param 'PODValAccess' is set to 'true', then POD values will be
returned from array accessors as values.  If it is 'false', POD values will
be returned as 'const ref'.

PODValAccess is true by default, so the default behavior is unchanged.

The new switch will help in evaluating the performance impact of
returning POD values by value vs. by const ref.

Tested on full default linux64, both with -sPODValAccess=true and
-sPODValAccess=false.  The only failure was for -sPODValAccess=false: distributions/bradc/assoc/userAssoc-array-noelt.chpl.  The line number
of an out of bounds index error moved because of the different choice of
array access function.