### PR TITLE
Improved clarity of sub_test output for failed perf-compilation

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1489,7 +1489,7 @@ for testname in testsrc:
                 sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
-            
+
             # find the compiler .good file to compare against. The compiler
             # .good file can be of the form testname.<configuration>.good or
             # explicitname.<configuration>.good. It's not currently setup to
@@ -1505,7 +1505,7 @@ for testname in testsrc:
 
             if not os.path.isfile(goodfile) or not os.access(goodfile, os.R_OK):
                 if perftest:
-                    sys.stdout.write('[Error compilation failed for %s/%s]\n'%(localdir, test_filename))
+                    sys.stdout.write('[Error compilation failed for %s]\n'%(test_name))
                 else:
                     sys.stdout.write('[Error cannot locate compiler output comparison file %s/%s]\n'%(localdir, goodfile))
                 sys.stdout.write('[Compiler output was as follows:]\n')


### PR DESCRIPTION
Improve error output added in #4376 to specify the compopts index of failing test.

```
[Error compilation failed for studies/prk/stencil/stencil]
```

will now be:

```
[Error compilation failed for studies/prk/stencil/stencil (compopts: 1)
```