### PR TITLE
Add LLVM generation of the function name information array.

### DIFF
--- a/test/chplvis/SKIPIF
+++ b/test/chplvis/SKIPIF
@@ -1,3 +1,0 @@
-# Tests in this directory will fail with LLVM
-CHPL_LLVM == llvm
-

--- a/test/release/examples/primers/chplvis/SKIPIF
+++ b/test/release/examples/primers/chplvis/SKIPIF
@@ -1,3 +1,0 @@
-# Tests in this directory will fail with LLVM
-CHPL_LLVM == llvm
-

--- a/test/studies/prk/stencil/SKIPIF
+++ b/test/studies/prk/stencil/SKIPIF
@@ -4,12 +4,6 @@
 # We want to keep the problem size constant across single and multi-locale
 # runs, meaning there are strict memory restrictions for running single locale.
 
-# VisualDebug doesn't work for llvm yet
-if ($ENV{CHPL_LLVM} eq "llvm") {
-    print("True\n");
-    exit(0);
-}
-
 $memRequiredInGB = 8;
 $memInGB = $memRequiredInGB;
 


### PR DESCRIPTION
Add LLVM code generation of the function name array.
Removes SKIPIF files and lines to not run tests when using LLVM and VisualDebug.