### PR TITLE
Skip stencilSerial and mandelbrot-unrolled under --fast and 32-bit configs

### DIFF
--- a/test/studies/parboil/stencil/stencilSerial.skipif
+++ b/test/studies/parboil/stencil/stencilSerial.skipif
@@ -1,0 +1,6 @@
+# Floating point precision variations in some configs cause binary mismatch
+#
+# See JIRA 244 for more info: https://chapel.atlassian.net/browse/CHAPEL-244
+
+COMPOPTS <= --fast
+CHPL_TARGET_PLATFORM <= 32

--- a/test/studies/shootout/mandelbrot/bharshbarg/mandelbrot-unrolled.skipif
+++ b/test/studies/shootout/mandelbrot/bharshbarg/mandelbrot-unrolled.skipif
@@ -1,0 +1,6 @@
+# Floating point precision variations in some configs cause binary mismatch
+#
+# See JIRA 244 for more info: https://chapel.atlassian.net/browse/CHAPEL-244
+
+COMPOPTS <= --fast
+CHPL_TARGET_PLATFORM <= 32


### PR DESCRIPTION
Due to minor floating point variations across configurations, stencilSerial and
mandelbrot-unrolled can get slightly different binary output. A reference c
mandelbrot version also fails with the equivalent of --fast, so it seems like
it's not a bug on our end but is just a precision difference. This just skips
these tests for 32 bit platforms and when --fast is thrown.

See JIRA 244 for more info: https://chapel.atlassian.net/browse/CHAPEL-244