### PR TITLE
Python-version-specific install path for chpl-venv (chpldoc works)

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+PYTHON_VERSION_DIR = py$(shell $(CHPL_MAKE_HOME)/util/chplenv/chpl_python_version.py)
 
 develall: STATUS
 	@$(MAKE) always-build-man
@@ -81,4 +82,4 @@ future_stats: FUTURES
 # Makefile...
 #
 %.docs: FORCE
-	third-party/chpl-venv/install/linux64/chpl-virtualenv/bin/sphinx-build -c doc/sphinx/source doc/sphinx/source/ doc/sphinx/build/html/$* && chmod -R ugo+rX doc/sphinx/build
+	third-party/chpl-venv/install/linux64/$(PYTHON_VERSION_DIR)/chpl-virtualenv/bin/sphinx-build -c doc/sphinx/source doc/sphinx/source/ doc/sphinx/build/html/$* && chmod -R ugo+rX doc/sphinx/build

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -77,6 +77,7 @@ void genIncludeCommandLineHeaders(FILE* outfile);
 const char* createDebuggerFile(const char* debugger, int argc, char* argv[]);
 
 std::string runPrintChplEnv(std::map<std::string, const char*> varMap);
+std::string getChplPythonVersion(void);
 std::string runCommand(std::string& command);
 
 void setupModulePaths(void);

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -306,8 +306,8 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir) {
   // based on the install path in the third-party/chpl-venv/ dir.
 
   const char * venvDir = astr(
-    CHPL_HOME, "/third-party/chpl-venv/install/",
-    CHPL_HOST_PLATFORM, "/chpl-virtualenv");
+    CHPL_HOME, "/third-party/chpl-venv/install/", CHPL_HOST_PLATFORM,
+    "/py", getChplPythonVersion().c_str(), "/chpl-virtualenv");
   const char * venvBinDir = astr(venvDir, "/bin");
   const char * sphinxBuild = astr(venvBinDir, "/sphinx-build");
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -440,6 +440,18 @@ std::string runPrintChplEnv(std::map<std::string, const char*> varMap) {
   return runCommand(command);
 }
 
+std::string getChplPythonVersion() {
+  // Runs util/chplenv/chpl_python_version.py and removes the newline
+
+  std::string command = "";
+  command += std::string(CHPL_HOME) + "/util/chplenv/chpl_python_version.py 2> /dev/null";
+
+  std::string pyVer = runCommand(command);
+  pyVer.erase(pyVer.find_last_not_of("\n\r")+1);
+
+  return pyVer;
+}
+
 std::string runCommand(std::string& command) {
   // Run arbitrary command and return result
   char buffer[256];

--- a/doc/sphinx/run-in-venv.bash
+++ b/doc/sphinx/run-in-venv.bash
@@ -8,7 +8,8 @@ if [ -z "$CHPL_HOME" ]; then
 fi
 
 platform=$("$CHPL_HOME/util/chplenv/chpl_platform.py" --host)
-venv_path="$CHPL_HOME/third-party/chpl-venv/install/$platform/chpl-virtualenv/"
+python_version_dir=py$("$CHPL_HOME/util/chplenv/chpl_python_version.py")
+venv_path="$CHPL_HOME/third-party/chpl-venv/install/$platform/$python_version_dir/chpl-virtualenv/"
 
 if [ ! -d "$venv_path" ]; then
   echo "Error: virtualenv '$venv_path' does not exist"

--- a/make/Makefile.base
+++ b/make/Makefile.base
@@ -156,7 +156,6 @@ include $(THIRD_PARTY_DIR)/gmp/Makefile.include
 include $(THIRD_PARTY_DIR)/hwloc/Makefile.include
 include $(THIRD_PARTY_DIR)/re2/Makefile.include
 include $(THIRD_PARTY_DIR)/llvm/Makefile.include-$(CHPL_MAKE_LLVM)
-include $(THIRD_PARTY_DIR)/chpl-venv/Makefile.include
 include $(THIRD_PARTY_DIR)/fltk/Makefile.include
 include $(THIRD_PARTY_DIR)/libunwind/Makefile.include
 

--- a/man/Makefile
+++ b/man/Makefile
@@ -9,7 +9,9 @@ MANPAGE = man1/$(PROGRAM).1
 CHPLDOC_MANPAGE = man1/$(CHPLDOC).1
 TARGETS = $(MANPAGE) $(PROGRAM).pdf $(CHPLDOC).pdf
 
-RST2MAN = $(CHPL_MAKE_HOME)/third-party/chpl-venv/install/*/chpl-virtualenv/bin/rst2man.py
+PYTHON_VERSION_DIR = py$(shell $(CHPL_MAKE_HOME)/util/chplenv/chpl_python_version.py)
+
+RST2MAN = $(CHPL_MAKE_HOME)/third-party/chpl-venv/install/*/$(PYTHON_VERSION_DIR)/chpl-virtualenv/bin/rst2man.py
 
 STARS = \*\*\*\*\*
 

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -2,6 +2,7 @@ ifndef CHPL_MAKE_HOME
 export CHPL_MAKE_HOME=$(shell pwd)/..
 endif
 include $(CHPL_MAKE_HOME)/make/Makefile.base
+include $(THIRD_PARTY_DIR)/chpl-venv/Makefile.include
 
 ifdef CHPL_DEVELOPER
 DEBUG=1

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -4,16 +4,12 @@ endif
 
 CHPL_MAKE_HOST_TARGET = --host
 include $(CHPL_MAKE_HOME)/make/Makefile.base
+include $(THIRD_PARTY_DIR)/chpl-venv/Makefile.include
 
-PYTHON = $(shell which python)
 ifneq (,$(findstring cygwin, $(CHPL_MAKE_TARGET_PLATFORM)))
 # easy_install from cygwin's setuptools is `easy_install-<MAJOR>.<MINOR>`
 # instead of `easy_install`. If we can't find easy_install, look for the
-# versioned one. Version is grabbed from python's `sys.version_info`
-PYTHON_VERSION = $(shell $(PYTHON) -c "from __future__ import print_function; \
-                                       import sys; \
-                                       ver=sys.version_info; \
-                                       print('{0}.{1}'.format(ver[0], ver[1]))")
+# versioned one.
 EASY_INSTALL = $(shell which easy_install 2>/dev/null || which easy_install-$(PYTHON_VERSION))
 else
 EASY_INSTALL = $(shell which easy_install)

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -2,9 +2,28 @@
 # recorded all the way down to the hash bangs in scripts. Removing them here
 # avoids any potential issues when paths are compared (e.g. some things
 # consider a/b/../../a/b/ equal to a/b/, while string matching does not).
+
 CHPL_VENV_DIR=$(shell cd $(THIRD_PARTY_DIR)/chpl-venv && pwd)
 
-CHPL_VENV_UNIQUE_SUBDIR=$(CHPL_MAKE_HOST_PLATFORM)
+CHPL_VENV_TEST_REQUIREMENTS_FILE=$(CHPL_VENV_DIR)/test-requirements.txt
+CHPL_VENV_CHPLDOC_REQUIREMENTS_FILE=$(CHPL_VENV_DIR)/chpldoc-requirements.txt
+
+# Do not include this file from $(CHPL_MAKE_HOME)/make/Makefile.base.
+# Makefile.base gets run by the chpl compiler, but the third-party/chpl-venv stuff
+# is not used by the chpl compiler.
+# The following Python version processing would needlessly add to chpl's run times.
+
+# Python version
+PYTHON = $(shell which python)
+ifeq ($(wildcard $(PYTHON)),)
+PYTHON_VERSION = _not_found
+else
+# Python version has 2 digits, like "2.6" or "2.7"
+PYTHON_VERSION = $(shell $(CHPL_MAKE_HOME)/util/chplenv/chpl_python_version.py)
+endif
+
+# chpl-venv installation path depends on Python version
+CHPL_VENV_UNIQUE_SUBDIR=$(CHPL_MAKE_HOST_PLATFORM)/py$(PYTHON_VERSION)
 CHPL_VENV_INSTALL_SUBDIR=install/$(CHPL_VENV_UNIQUE_SUBDIR)
 CHPL_VENV_INSTALL_DIR=$(CHPL_VENV_DIR)/$(CHPL_VENV_INSTALL_SUBDIR)
 CHPL_VENV_VIRTUALENV=$(CHPL_VENV_INSTALL_SUBDIR)/virtualenv
@@ -14,5 +33,3 @@ CHPL_VENV_VIRTUALENV_DIR=$(CHPL_VENV_DIR)/$(CHPL_VENV_VIRTUALENV_SUBDIR)
 CHPL_VENV_VIRTUALENV_BIN=$(CHPL_VENV_VIRTUALENV_DIR)/bin
 CHPL_VENV_SPHINX_BUILD=$(CHPL_VENV_VIRTUALENV_BIN)/sphinx-build
 CHPL_VENV_TEST_REQS=$(CHPL_VENV_VIRTUALENV_DIR)/chpl-test-reqs
-CHPL_VENV_TEST_REQUIREMENTS_FILE=$(CHPL_VENV_DIR)/test-requirements.txt
-CHPL_VENV_CHPLDOC_REQUIREMENTS_FILE=$(CHPL_VENV_DIR)/chpldoc-requirements.txt

--- a/util/chplenv/__init__.py
+++ b/util/chplenv/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     'chpl_3p_re2_configs',
     # General purpose helpers
     'chpl_home_utils',
+    'chpl_python_version',
     'compiler_utils',
     'overrides',
     'utils',

--- a/util/chplenv/chpl_python_version.py
+++ b/util/chplenv/chpl_python_version.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import sys
+
+from utils import memoize
+
+
+@memoize
+def get():
+    ver = sys.version_info
+    return '{0}.{1}'.format(ver[0], ver[1])
+
+
+def _main():
+    python_version_val = get()
+    sys.stdout.write("{0}\n".format(python_version_val))
+
+
+if __name__ == '__main__':
+    _main()

--- a/util/devel/chips/render.bash
+++ b/util/devel/chips/render.bash
@@ -6,13 +6,15 @@ if [ -z "$CHPL_HOME" ] ; then
 fi
 
 PLATFORM=`$CHPL_HOME/util/chplenv/chpl_platform.py`
+python_version_dir=py`$CHPL_HOME/util/chplenv/chpl_python_version.py`
+
 mkdir -p tmp
 cp -r $CHPL_HOME/third-party/chpl-venv/chpldoc-sphinx-project/* tmp
 
 rm tmp/source/modules/*.rst
 cp *.rst tmp/source/modules
 
-export PATH=$CHPL_HOME/third-party/chpl-venv/install/$PLATFORM/chpl-virtualenv/bin:$PATH && export VIRTUAL_ENV=$CHPL_HOME/third-party/chpl-venv/install/$PLATFORM/chpl-virtualenv && export CHPLDOC_AUTHOR='' && $CHPL_HOME/third-party/chpl-venv/install/$PLATFORM/chpl-virtualenv/bin/sphinx-build -b html -d tmp/build/doctrees -W tmp/source ./html
+export PATH=$CHPL_HOME/third-party/chpl-venv/install/$PLATFORM/$python_version_dir/chpl-virtualenv/bin:$PATH && export VIRTUAL_ENV=$CHPL_HOME/third-party/chpl-venv/install/$PLATFORM/$python_version_dir/chpl-virtualenv && export CHPLDOC_AUTHOR='' && $CHPL_HOME/third-party/chpl-venv/install/$PLATFORM/$python_version_dir/chpl-virtualenv/bin/sphinx-build -b html -d tmp/build/doctrees -W tmp/source ./html
 
 echo point your web browser to html/index.html
 echo open html/index.html \# on a mac

--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -48,10 +48,11 @@ export CHPL_HOME_ORIG=$CHPL_HOME
 export CHPL_TEST_UTIL_DIR=$CHPL_HOME_ORIG/util
 
 if [[ -z $CHPL_TEST_VENV_DIR ]]; then
+    python_version_dir=py`$CHPL_TEST_UTIL_DIR/chplenv/chpl_python_version.py`
     if [[ -z $CHPL_HOST_PLATFORM ]]; then
-        export CHPL_TEST_VENV_DIR=$CHPL_HOME_ORIG/third-party/chpl-venv/install/`$CHPL_TEST_UTIL_DIR/chplenv/chpl_platform.py --host`/chpl-virtualenv
+        export CHPL_TEST_VENV_DIR=$CHPL_HOME_ORIG/third-party/chpl-venv/install/`$CHPL_TEST_UTIL_DIR/chplenv/chpl_platform.py --host`/$python_version_dir/chpl-virtualenv
     else
-        export CHPL_TEST_VENV_DIR=$CHPL_HOME_ORIG/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/chpl-virtualenv
+        export CHPL_TEST_VENV_DIR=$CHPL_HOME_ORIG/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/$python_version_dir/chpl-virtualenv
     fi
 fi
 if [[ ! -d $CHPL_TEST_VENV_DIR ]]; then

--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -15,7 +15,7 @@ from chplenv import chpl_make
 # Activate a virtualenv that has testing infrastructure requirements installed
 #
 # By default, we will try to use
-#   $CHPL_HOME/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/chpl-virtualenv
+#   $CHPL_HOME/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/$python_version_dir/chpl-virtualenv
 # as our virtualenv. We then check for a sentinel file that test-venv
 # creates when it's been successfully installed and finally activate
 # the virtualenv.
@@ -59,9 +59,10 @@ def activate_venv():
             chpl_home = os.path.join(chpl_home_utils.get_chpl_home(), '')
             third_party = os.path.join(chpl_home, 'third-party')
             host_platform = chpl_platform.get('host')
+            python_version_dir  = 'py{0}.{1}'.format(sys.version_info[0], sys.version_info[1])
 
             venv_dir = os.path.join(third_party, 'chpl-venv', 'install',
-                                    host_platform, 'chpl-virtualenv')
+                                    host_platform, python_version_dir, 'chpl-virtualenv')
             sentinel_file = os.path.join(venv_dir, 'chpl-test-reqs')
             if not os.path.isfile(sentinel_file):
                 error('Chapel test virtualenv is not available, run `{0} '


### PR DESCRIPTION
Python-version-specific install path for chpl-venv

Same as PR #4369 except now getChplPythonVersion() (in files.cpp) strips the newline 