### PR TITLE
Update test_begin tests to synchronize tasks with sync variables

### DIFF
--- a/test/parallel/begin/deitz/test_begin.chpl
+++ b/test/parallel/begin/deitz/test_begin.chpl
@@ -3,17 +3,17 @@ use Time;
 const n = 5;
 
 var a: [1..n] int;
-var B: [1..n] sync bool;
+var B$: [1..n] sync bool;
 
 for i in 1..n do begin {
   a[i] = foo(i);
-  B[i] = true;
+  B$[i] = true;
 }
 
 for i in 1..n {
-  B[i];
-  while a[i] == 0 do
-    sleep(1);
+  B$[i];
+  assert(a[i] != 0);
+
   writeln(a[i]);
 }
 

--- a/test/parallel/begin/deitz/test_begin.chpl
+++ b/test/parallel/begin/deitz/test_begin.chpl
@@ -3,12 +3,15 @@ use Time;
 const n = 5;
 
 var a: [1..n] int;
+var B: [1..n] sync bool;
 
 for i in 1..n do begin {
   a[i] = foo(i);
+  B[i] = true;
 }
 
 for i in 1..n {
+  B[i];
   while a[i] == 0 do
     sleep(1);
   writeln(a[i]);

--- a/test/parallel/begin/deitz/test_begin2.chpl
+++ b/test/parallel/begin/deitz/test_begin2.chpl
@@ -4,17 +4,17 @@ proc main {
   const n = 5;
 
   var a: [1..n] int;
-  var B: [1..n] sync bool;
+  var B$: [1..n] sync bool;
 
   for i in 1..n do begin {
     a[i] = foo(i);
-    B[i] = true;
+    B$[i] = true;
   }
 
   for i in 1..n {
-    B[i];
-    while a[i] == 0 do
-      sleep(1);
+    B$[i];
+    assert(a[i] != 0);
+
     writeln(a[i]);
   }
 }

--- a/test/parallel/begin/deitz/test_begin2.chpl
+++ b/test/parallel/begin/deitz/test_begin2.chpl
@@ -4,12 +4,15 @@ proc main {
   const n = 5;
 
   var a: [1..n] int;
+  var B: [1..n] sync bool;
 
   for i in 1..n do begin {
     a[i] = foo(i);
+    B[i] = true;
   }
 
   for i in 1..n {
+    B[i];
     while a[i] == 0 do
       sleep(1);
     writeln(a[i]);


### PR DESCRIPTION
These tests violated the memory consistency model by updating an array in
one task and expecting to see the update in another task without any other
synchronization. Add synchronization to force the update to be visible.