### PR TITLE
Documentation Build System Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,17 +122,6 @@ always-build-chpldoc: FORCE
 	$(MAKE) chpldoc; \
 	fi
 
-clean-module-docs:
-	cd modules && $(MAKE) clean-documentation
-
-module-docs-only:
-	cd modules && $(MAKE) documentation
-
-module-docs: chpldoc
-# Call `make module-docs-only` as part of the recipe instead of as a
-# dependency so parallel make executions correctly build chpldoc first.
-	$(MAKE) module-docs-only
-
 chplvis: compiler third-party-fltk FORCE
 	cd tools/chplvis && $(MAKE)
 	cd tools/chplvis && $(MAKE) install

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -19,7 +19,7 @@
 develall: STATUS
 	@$(MAKE) always-build-man
 
-docs: module-docs
+docs:
 	cd doc/sphinx && $(MAKE) docs
 
 checkdocs: FORCE

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Chapel documentation
 
-# Sphinx-generated Makefile with minor modification
+# Makefile.sphinx interfaces with sphinx build commands
 include Makefile.sphinx
 
 help: help-sphinx help-source
@@ -15,20 +15,31 @@ help-source:
 	@echo "  clobber        to remove all generated files in source/ and build/"
 	@echo ""
 
+
 docs: FORCE
 	./run-in-venv.bash $(MAKE) html
 
 man-chapel: FORCE
 	./run-in-venv.bash $(MAKE) man
 
+
+module-docs: clean-module-docs
+	@echo "Generating module docs from \$CHPL_HOME/modules/ to doc/sphinx/source"
+	(cd ../../modules && make documentation)
+
 symlink-docs: clean-symlink-docs
-	@echo "Setting up symlinks from /doc/release to /doc/sphinx/source"
+	@echo "Symbolically linking docs from from doc/release to doc/sphinx/source"
 	./symlinks.py
+
+copy-docs: clean-copy-docs
+	@echo "Copying files from doc/release to doc/sphinx/source/"
 	cp  ../release/quickReference.pdf     source/language/quickReference.pdf
 	cp  ../release/chapelLanguageSpec.pdf source/language/chapelLanguageSpec.pdf
 
+
 checkdocs: FORCE
 	./run-in-venv.bash $(MAKE) check
+
 
 clean: clean-source
 
@@ -36,19 +47,26 @@ cleanall: clean-source
 
 clobber: clean-source clean-build
 
-clean-source: clean-symlink-docs clean-module-docs
+clean-source: clean-symlink-docs clean-module-docs clean-copy-docs
+	@echo "Cleaning all source files"
+
 
 clean-symlink-docs: FORCE
-	@echo "Removing all symbolic links contained in source/"
+	@echo "Removing all symbolic links created in source/"
 	find source -type l -delete
-	rm -f language/quickReference.pdf
-	rm -f language/chapelLanguageSpec.pdf
+
+clean-copy-docs: FORCE
+	@echo "Removing files that were copied into source/"
+	rm -f source/language/quickReference.pdf
+	rm -f source/language/chapelLanguageSpec.pdf
 
 clean-module-docs: FORCE
+	@echo "Removing module docs that were generated into source/"
 	rm -rf source/modules/dists
 	rm -rf source/modules/internal
 	rm -rf source/modules/layouts
 	rm -rf source/modules/packages
 	rm -rf source/modules/standard
+
 
 FORCE:

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -16,27 +16,28 @@ help-source:
 	@echo ""
 
 
-docs: FORCE source
+docs: FORCE
 	./run-in-venv.bash $(MAKE) html
 
-man-chapel: FORCE source
+man-chapel: FORCE
 	./run-in-venv.bash $(MAKE) man
 
 
 source: symlink-docs module-docs copy-docs
-	@echo "Dynamically creating files in source/"
-
 
 symlink-docs: clean-symlink-docs
-	@echo "Symbolically linking docs from from doc/release to doc/sphinx/source"
+	@echo
+	@echo "Symbolically linking docs from '$$CHPL_HOME/doc/release' to $$CHPL_HOME/doc/sphinx/source"
 	./symlinks.py
 
 module-docs: clean-module-docs
-	@echo "Generating module docs from \$CHPL_HOME/modules/ to doc/sphinx/source"
+	@echo
+	@echo "Generating module docs from $$CHPL_HOME/modules/ into $$CHPL_HOME/doc/sphinx/source"
 	(cd ../../modules && make documentation)
 
 copy-docs: clean-copy-docs
-	@echo "Copying files from doc/release to doc/sphinx/source/"
+	@echo
+	@echo "Copying files from $$CHPL_HOME/doc/release to $$CHPL_HOME/doc/sphinx/source/"
 	cp  ../release/quickReference.pdf     source/language/quickReference.pdf
 	cp  ../release/chapelLanguageSpec.pdf source/language/chapelLanguageSpec.pdf
 
@@ -52,19 +53,21 @@ cleanall: clean-source
 clobber: clean-source clean-build
 
 clean-source: clean-symlink-docs clean-module-docs clean-copy-docs
-	@echo "Cleaning all dynamically created files in source/"
 
 
 clean-symlink-docs: FORCE
+	@echo
 	@echo "Removing all symbolic links created in source/"
 	find source -type l -delete
 
 clean-copy-docs: FORCE
+	@echo
 	@echo "Removing files that were copied into source/"
 	rm -f source/language/quickReference.pdf
 	rm -f source/language/chapelLanguageSpec.pdf
 
 clean-module-docs: FORCE
+	@echo
 	@echo "Removing module docs that were generated into source/"
 	rm -rf source/modules/dists
 	rm -rf source/modules/internal

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -16,20 +16,24 @@ help-source:
 	@echo ""
 
 
-docs: FORCE
+docs: FORCE source
 	./run-in-venv.bash $(MAKE) html
 
-man-chapel: FORCE
+man-chapel: FORCE source
 	./run-in-venv.bash $(MAKE) man
 
 
-module-docs: clean-module-docs
-	@echo "Generating module docs from \$CHPL_HOME/modules/ to doc/sphinx/source"
-	(cd ../../modules && make documentation)
+source: symlink-docs module-docs copy-docs
+	@echo "Dynamically creating files in source/"
+
 
 symlink-docs: clean-symlink-docs
 	@echo "Symbolically linking docs from from doc/release to doc/sphinx/source"
 	./symlinks.py
+
+module-docs: clean-module-docs
+	@echo "Generating module docs from \$CHPL_HOME/modules/ to doc/sphinx/source"
+	(cd ../../modules && make documentation)
 
 copy-docs: clean-copy-docs
 	@echo "Copying files from doc/release to doc/sphinx/source/"
@@ -48,7 +52,7 @@ cleanall: clean-source
 clobber: clean-source clean-build
 
 clean-source: clean-symlink-docs clean-module-docs clean-copy-docs
-	@echo "Cleaning all source files"
+	@echo "Cleaning all dynamically created files in source/"
 
 
 clean-symlink-docs: FORCE

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -41,8 +41,8 @@ clean-source: clean-symlink-docs clean-module-docs
 clean-symlink-docs: FORCE
 	@echo "Removing all symbolic links contained in source/"
 	find source -type l -delete
-	rm -f language/reference.pdf
-	rm -f language/spec.pdf
+	rm -f language/quickReference.pdf
+	rm -f language/chapelLanguageSpec.pdf
 
 clean-module-docs: FORCE
 	rm -rf source/modules/dists

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -27,17 +27,17 @@ source: symlink-docs module-docs copy-docs
 
 symlink-docs: clean-symlink-docs
 	@echo
-	@echo "Symbolically linking docs from '$$CHPL_HOME/doc/release' to $$CHPL_HOME/doc/sphinx/source"
+	@echo "Symbolically linking docs from "'$$CHPL_HOME'"/doc/release to "'$$CHPL_HOME'"/doc/sphinx/source"
 	./symlinks.py
 
 module-docs: clean-module-docs
 	@echo
-	@echo "Generating module docs from $$CHPL_HOME/modules/ into $$CHPL_HOME/doc/sphinx/source"
+	@echo "Generating module docs from "'$$CHPL_HOME'"/modules/ into "'$$CHPL_HOME'"/doc/sphinx/source"
 	(cd ../../modules && make documentation)
 
 copy-docs: clean-copy-docs
 	@echo
-	@echo "Copying files from $$CHPL_HOME/doc/release to $$CHPL_HOME/doc/sphinx/source/"
+	@echo "Copying files from "'$$CHPL_HOME'"/doc/release to "'$$CHPL_HOME'"/doc/sphinx/source/"
 	cp  ../release/quickReference.pdf     source/language/quickReference.pdf
 	cp  ../release/chapelLanguageSpec.pdf source/language/chapelLanguageSpec.pdf
 

--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -60,6 +60,8 @@ check-sphinxbuild:
 	if [ $(SPHINXTEST) -eq 1 ]; then echo $(SPHINXERROR); fi
 
 html: check-sphinxbuild source clean-build
+	@echo
+	@echo "Building HTML documentation"
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@chmod -R ugo+rX $(BUILDDIR)
 	@echo
@@ -133,6 +135,8 @@ text: check-sphinxbuild source clean-build
 	@echo "Build finished. The text files are in "'$(BUILDPATH)'"/text."
 
 man: check-sphinxbuild source clean-build
+	@echo
+	@echo "Building man page documentation"
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	echo ".if n .pl 2000v" > $(BUILDDIR)/man/chapel.3
 	cat $(BUILDDIR)/man/chapel.1 >> $(BUILDDIR)/man/chapel.3

--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -56,8 +56,9 @@ help-sphinx:
 	@echo ""
 
 check-sphinxbuild:
-	@echo "Confirming that sphinx-build is available"
-	if [ $(SPHINXTEST) -eq 1 ]; then echo $(SPHINXERROR); fi
+	@echo
+	@echo "Confirming that sphinx-build is available..."
+	@if [ $(SPHINXTEST) -eq 1 ]; then echo $(SPHINXERROR); fi
 
 html: check-sphinxbuild source clean-build
 	@echo
@@ -186,5 +187,6 @@ pseudoxml: check-sphinxbuild source clean-build
 # Clean build
 
 clean-build:
+	@echo
 	@echo "Cleaning all build files"
 	rm -rf $(BUILDDIR)

--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -56,49 +56,50 @@ help-sphinx:
 	@echo ""
 
 check-sphinxbuild:
-	@if [ $(SPHINXTEST) -eq 1 ]; then echo $(SPHINXERROR); fi
+	@echo "Confirming that sphinx-build is available"
+	if [ $(SPHINXTEST) -eq 1 ]; then echo $(SPHINXERROR); fi
 
-html: symlink-docs module-docs copy-docs check-sphinxbuild clean-build
+html: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	chmod -R ugo+rX $(BUILDDIR)
+	@chmod -R ugo+rX $(BUILDDIR)
 	@echo
 	@echo "Build finished. The HTML pages are in "'$(BUILDPATH)'"/html."
 
-check: symlink-docs check-sphinxbuild clean-build
+check: check-sphinxbuild source clean-build
 	@echo "Checking for broken links or cross-references"
 	$(SPHINXBUILD) -n -b linkcheck -d $(BUILDDIR)/doctrees source $(BUILDDIR)/linkcheck
-	chmod -R ugo+rX $(BUILDDIR)
+	@chmod -R ugo+rX $(BUILDDIR)
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in "'$(BUILDPATH)'"/linkcheck/output.txt."
 
-dirhtml:  symlink-docs check-sphinxbuild clean-build
+dirhtml: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in "'$(BUILDPATH)'"/dirhtml."
 
-singlehtml: symlink-docs check-sphinxbuild clean-build
+singlehtml: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in "'$(BUILDPATH)'"/singlehtml."
 
-pickle: symlink-docs check-sphinxbuild clean-build
+pickle: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
-json: symlink-docs check-sphinxbuild clean-build
+json: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
-htmlhelp: symlink-docs check-sphinxbuild clean-build
+htmlhelp: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in "'$(BUILDPATH)'"/htmlhelp."
 
-qthelp: symlink-docs check-sphinxbuild clean-build
+qthelp: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -107,31 +108,31 @@ qthelp: symlink-docs check-sphinxbuild clean-build
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/chpldoc.qhc"
 
-latex: symlink-docs check-sphinxbuild clean-build
+latex: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in "'$(BUILDPATH)'"/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
-latexpdf: symlink-docs check-sphinxbuild clean-build
+latexpdf: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in "'$(BUILDPATH)'"/latex."
 
-latexpdfja: symlink-docs check-sphinxbuild clean-build
+latexpdfja: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in "'$(BUILDPATH)'"/latex."
 
-text: symlink-docs check-sphinxbuild clean-build
+text: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in "'$(BUILDPATH)'"/text."
 
-man: symlink-docs check-sphinxbuild clean-build
+man: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	echo ".if n .pl 2000v" > $(BUILDDIR)/man/chapel.3
 	cat $(BUILDDIR)/man/chapel.1 >> $(BUILDDIR)/man/chapel.3
@@ -139,41 +140,41 @@ man: symlink-docs check-sphinxbuild clean-build
 	@echo
 	@echo "Build finished. The manual pages are in "'$(BUILDPATH)'"/man."
 
-texinfo: symlink-docs check-sphinxbuild clean-build
+texinfo: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
 	@echo "Build finished. The Texinfo files are in "'$(BUILDPATH)'"/texinfo."
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
 
-info: symlink-docs check-sphinxbuild clean-build
+info: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in "'$(BUILDPATH)'"/texinfo."
 
-gettext: symlink-docs check-sphinxbuild clean-build
+gettext: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in "'$(BUILDPATH)'"/locale."
 
-changes: symlink-docs check-sphinxbuild clean-build
+changes: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in "'$(BUILDPATH)'"/changes."
 
-linkcheck: symlink-docs check-sphinxbuild clean-build
+linkcheck: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in "'$(BUILDPATH)'"/linkcheck/output.txt."
 
-xml: symlink-docs check-sphinxbuild clean-build
+xml: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
 	@echo
 	@echo "Build finished. The XML files are in "'$(BUILDPATH)'"/xml."
 
-pseudoxml: symlink-docs check-sphinxbuild clean-build
+pseudoxml: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in "'$(BUILDPATH)'"/pseudoxml."

--- a/doc/sphinx/Makefile.sphinx
+++ b/doc/sphinx/Makefile.sphinx
@@ -58,7 +58,7 @@ help-sphinx:
 check-sphinxbuild:
 	@if [ $(SPHINXTEST) -eq 1 ]; then echo $(SPHINXERROR); fi
 
-html: symlink-docs check-sphinxbuild clean-build
+html: symlink-docs module-docs copy-docs check-sphinxbuild clean-build
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	chmod -R ugo+rX $(BUILDDIR)
 	@echo
@@ -178,5 +178,8 @@ pseudoxml: symlink-docs check-sphinxbuild clean-build
 	@echo
 	@echo "Build finished. The pseudo-XML files are in "'$(BUILDPATH)'"/pseudoxml."
 
+# Clean build
+
 clean-build:
+	@echo "Cleaning all build files"
 	rm -rf $(BUILDDIR)

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -134,15 +134,20 @@ INTERNAL_MODULES_TO_DOCUMENT =          \
 
 
 documentation: $(SYS_CTYPES_MODULE_DOC)
+	@echo "Generating module documentation with chpldoc"
 	export CHPLDOC_AUTHOR='Cray Inc' && \
 	$(CHPLDOC) --save-sphinx ${MODULE_SPHINX} --no-html $(MODULES_TO_DOCUMENT) $(DISTS_TO_DOCUMENT) $(PACKAGES_TO_DOCUMENT) $(INTERNAL_MODULES_TO_DOCUMENT)
+	@echo "Running post-processing scripts"
 	./internal/fixInternalDocs.sh ${MODULE_SPHINX}
 	./dists/fixDistDocs.perl      ${MODULE_SPHINX}
+	@echo "Copying generated module documentation to \$CHPL_HOME/doc/sphinx/modules"
 	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/packages ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/dists    ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/layouts  ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/internal ${DOC_SPHINX}/source/modules/
+	@echo "Removing generated files and directories"
+	rm -rf ./docs
 	rm -rf ${MODULE_SPHINX}
 	rm -f ${CHPL_MAKE_HOME}/modules/$(SYS_CTYPES_MODULE_DOC)
 


### PR DESCRIPTION
## Feature Changes
* Make `make docs` in `doc/sphinx` a stand-alone build
   * Previously required a top-level `make docs`, which invoked the dependency of `make documentation` in `modules/`
   * *Potentially controversial:* This change required adding a dependency for `doc/sphinx/Makefile` to `modules/Makefile`.
       * This was previously discussed with, and approved by @bradcray 
* Remove `module-docs` and related targets in top-level and `modules/` Makefiles.
    * Due to the integration of the module docs into the full documentation build, this feature provides little value anymore
    * This Makefile target has actually been broken for a while - it would just build the module docs into the sphinx directory.

## Bug fixes
* Remove the pdf files that are copied into `source/` dynamically
    * Previously wrong name
* Make all sphinx targets depend on the dynamically generated source files
* Remove generated empty `docs/` directory for `make documentation` in `modules/`

## Refactorings
* Consolidated several common combinations of Makefile targets into single target in `doc/sphinx/Makefile*`
    * e.g. new `source` target, which depends on `symlink-docs`, `module-docs`, and `copy-docs`
* Added better user-facing documentation for what is happening during build-steps of documentation (also for being able to easily understand the Makefile)