### PR TITLE
Add chpldoc dependency to `make docs`

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -19,7 +19,7 @@
 develall: STATUS
 	@$(MAKE) always-build-man
 
-docs:
+docs: chpldoc
 	cd doc/sphinx && $(MAKE) docs
 
 checkdocs: FORCE


### PR DESCRIPTION
By removing `module-docs` dependency, the `chpldoc` dependency was inadvertently lost in #4416. This resulted in build failures.