### PR TITLE
Add examples testing against clang 3.8 on a 64-bit ubuntu machine

### DIFF
--- a/util/cron/test-linux64-clang.bash
+++ b/util/cron/test-linux64-clang.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with clang
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+export CHPL_HOST_COMPILER=clang
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-clang"
+
+$CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
This adds linux64 clang testing. This is a configuration that we're only
testing under travis, but it's a common enough configuration in the real world
that we should be testing it more.