### PR TITLE
Limit travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
   exclude:
     - os: osx
       compiler: gcc
+    - os: linux
+      compiler: clang
 
 
 script:
@@ -19,7 +21,6 @@ script:
 # have access to. This seems to be an artifact caused by the interaction
 # between docker and hwloc on Travis's docker images.
 env:
-  - CHPL_DEVELOPER=true QTHREAD_AFFINITY=no
   - NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no
 
 sudo: false

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -106,16 +106,14 @@ num_procs=$(python -c "import multiprocessing; print(multiprocessing.cpu_count()
 # in $CHPL_HOME where the hello*.chpl tests are copied and run.
 export CHPL_CHECK_INSTALL_DIR=$CHPL_HOME
 
-if [ "${TRAVIS}" = "true" ] ; then
-    export CHPL_CHECK_INSTALL_PRINT_ERROR="true"
-fi
-
-# Compile chapel and make sure the hello world examples run. Compile first with
-# parallel execution, but call `make check` without it.
+# Compile chapel and make sure `make check` works. Compile first with parallel
+# execution, but call `make check` without it.
 make -j${num_procs} $chpl_make_args && \
     make $chpl_make_args check || exit 2
 
-# Build chpldoc and make sure the chpldoc primer runs. Build chpldoc with
-# parallel execution, but call `make check-chpldoc` without it.
-make -j${num_procs} $chpl_make_args chpldoc && \
-    make $chpl_make_args check-chpldoc || exit 2
+if [ "${TRAVIS}" != "true" ] ; then
+    # Build chpldoc and make sure the chpldoc primer runs. Build chpldoc with
+    # parallel execution, but call `make check-chpldoc` without it.
+    make -j${num_procs} $chpl_make_args chpldoc && \
+        make $chpl_make_args check-chpldoc || exit 2
+fi


### PR DESCRIPTION
Speed up the travis smoke test by eliminating some configurations
 - remove linux+clang testing, this has been subsumed by internal jobs
 - remove CHPL_DEVELOPER=true (WARNINGS=1, OPTIMIZE=0, DEBUG=1) testing and
   only do NIGHTLY_TEST_SETTINGS (WARNINGS=1, OPTIMIZE=1, DEBUG=0) since
   NIGHTLY_TEST_SETTINGS should catch the same build issues as CHPL_DEVELOPER
 - remove chpldoc testing under travis. It will still be tested by the internal
   smoke test, but chpldoc doesn't change enough to merit travis testing it