### PR TITLE
Document Chapel Configuration File

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -630,5 +630,9 @@ variables that support each option, run the compiler with the ``--help-env``
 flag.  For boolean flags and toggles, setting the environment variable to any
 value selects that flag.
 
+Chapel Configuration File
+-------------------------
+
+
 
 .. |trade|  unicode:: U+02122 .. TRADE MARK SIGN

--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -649,61 +649,64 @@ Users can define variables with the following format:
 
 .. code-block:: python
 
-    CHPL_ENV = value
+    CHPL_ENV=value
 
 
 Above, the default value of ``CHPL_ENV`` will be overridden to be ``value``.
+All white space is stripped away from definitions.
 
-**White Space**
+**Ignored Lines**
 
-All white space is stripped away from definitions. Any lines containing nothing
-or only white space will be ignored.
-
-**Comments**
-
-Comments are denoted by the ``#`` character, similar to ``bash`` or ``python``.
+Any lines containing nothing or only white space will be ignored.  Comments,
+which are denoted by the ``#`` character, similar to ``bash`` or ``python``,
+are also ignored.
 
 
 Example
 ~~~~~~~
 
-An example of a Chapel configuration file with comments:
+Below is an example of a Chapel configuration file with comments:
 
 .. code-block:: python
 
     # ~/.chplconfig
 
     # Default to multi-locale
-    CHPL_COMM = gasnet
+    CHPL_COMM=gasnet
 
-    # Always use qthreads
-    CHPL_TASKS = qthreads
+    CHPL_TASKS=qthreads # Use Qthreads
 
     # System GMP is available on these machines
-    CHPL_GMP = system
+    CHPL_GMP=system
 
 
 
 Generating Configuration Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The syntax has been chosen in such a way that a user can dump their current
-configuration into a ``chplconfig`` file with ``printchplenv --simple``:
+The format of the ``printchplenv --overrides`` and ``printchplenv --simple``
+commands is compatible with Chapel configuration files.
+
+The ``printchplenv --overrides`` flag can be used to print the variables
+currently overridden by either environment variables or Chapel
+configuration file.
+
+A user can dump their current overrides into a Chapel configuration file:
+
+.. code-block:: sh
+
+    printchplenv --overrides > ~/.chplconfig
+
+The ``printchplenv --simple`` flag can be used to print all the variables
+of the current configuration.
+
+A user can dump their current configuration into a Chapel configuration file as
+well:
 
 .. code-block:: sh
 
     printchplenv --simple > ~/.chplconfig
 
-The flag ``printchplenv --overrides`` can be used to print the variables
-currently overridden by either environment variables or Chapel
-configuration file.
-
-A user can dump their current overrides into a Chapel configuration file as
-well:
-
-.. code-block:: sh
-
-    printchplenv --overrides > ~/.chplconfig
 
 
 Search Paths and File Names

--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -635,7 +635,7 @@ Chapel Configuration File
 
 The Chapel configuration file is a file named either ``chplconfig`` or
 ``.chplconfig`` that can store overrides of the inferred environment variables
-that are determined by ``printchplenv``.
+listed as a result of executing ``printchplenv``.
 
 Syntax
 ~~~~~~
@@ -711,6 +711,11 @@ well:
 
 Search Paths and File Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Though you can put your Chapel configuration file anywhere by setting the
+``$CHPL_CONFIG`` environment variable to its enclosing directory, you can also
+place it in your ``$HOME`` or ``$CHPL_HOME`` directory and Chapel will be able to
+find it.
+
 The search priority for Chapel configuration files is as follows:
 
 1. ``$CHPL_CONFIG``
@@ -723,8 +728,10 @@ When both a ``chplconfig`` and ``.chplconfig`` are present, the visible
 Only a single ``chplconfig`` file will be used. That is, as soon as a valid
 Chapel configuration file is found, the definitions of that file are used.
 
-Note that the ``$CHPL_CONFIG`` variable is the path to the *enclosing*
-directory - not the full path including ``chplconfig`` itself.
+.. note::
+
+    The ``$CHPL_CONFIG`` variable is the path to the *enclosing*
+    directory - not the full path including ``chplconfig`` itself.
 
 Variable Priority
 ~~~~~~~~~~~~~~~~~

--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -633,6 +633,105 @@ value selects that flag.
 Chapel Configuration File
 -------------------------
 
+The Chapel configuration file is a file named either ``chplconfig`` or
+``.chplconfig`` that can store overrides of the inferred environment variables
+that are determined by ``printchplenv``.
+
+Syntax
+~~~~~~
+
+Below are the valid forms of syntax for Chapel configuration files. All other
+usages will result in a syntax error.
+
+**Definitions**
+
+Users can define variables with the following format:
+
+.. code-block:: python
+
+    CHPL_ENV = value
+
+
+Above, the default value of ``CHPL_ENV`` will be overridden to be ``value``.
+
+**White Space**
+
+All white space is stripped away from definitions. Any lines containing nothing
+or only white space will be ignored.
+
+**Comments**
+
+Comments are denoted by the ``#`` character, similar to ``bash`` or ``python``.
+
+
+Example
+~~~~~~~
+
+An example of a Chapel configuration file with comments:
+
+.. code-block:: python
+
+    # ~/.chplconfig
+
+    # Default to multi-locale
+    CHPL_COMM = gasnet
+
+    # Always use qthreads
+    CHPL_TASKS = qthreads
+
+    # System GMP is available on these machines
+    CHPL_GMP = system
+
+
+
+Generating Configuration Files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The syntax has been chosen in such a way that a user can dump their current
+configuration into a ``chplconfig`` file with ``printchplenv --simple``:
+
+.. code-block:: sh
+
+    printchplenv --simple > ~/.chplconfig
+
+The flag ``printchplenv --overrides`` can be used to print the variables
+currently overridden by either environment variables or Chapel
+configuration file.
+
+A user can dump their current overrides into a Chapel configuration file as
+well:
+
+.. code-block:: sh
+
+    printchplenv --overrides > ~/.chplconfig
+
+
+Search Paths and File Names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The search priority for Chapel configuration files is as follows:
+
+1. ``$CHPL_CONFIG``
+2. ``$HOME`` (``~/``)
+3. ``$CHPL_HOME``
+
+When both a ``chplconfig`` and ``.chplconfig`` are present, the visible
+``chplconfig`` will be prioritized.
+
+Only a single ``chplconfig`` file will be used. That is, as soon as a valid
+Chapel configuration file is found, the definitions of that file are used.
+
+Note that the ``$CHPL_CONFIG`` variable is the path to the *enclosing*
+directory - not the full path including ``chplconfig`` itself.
+
+Variable Priority
+~~~~~~~~~~~~~~~~~
+
+Variable precedence goes in the following order:
+
+1. Explicit compiler flags: ``chpl --env=value``
+2. Environment variables: ``CHPL_ENV=value``
+3. Chapel configuration file: ``~/.chplconfig``
+4. Inferred environment variables: ``printchplenv``
 
 
 .. |trade|  unicode:: U+02122 .. TRADE MARK SIGN

--- a/test/chplenv/chplconfig/correctness/chplconfig
+++ b/test/chplenv/chplconfig/correctness/chplconfig
@@ -1,6 +1,6 @@
 # Comment test (followed by blank line test)
 
-CHPL_HOST_PLATFORM=darwin
+CHPL_HOST_PLATFORM=darwin       # inline comment test
 CHPL_HOST_COMPILER=clang
 CHPL_TARGET_PLATFORM=darwin
 CHPL_TARGET_COMPILER=clang

--- a/test/chplenv/chplconfig/correctness/correctness.precomp
+++ b/test/chplenv/chplconfig/correctness/correctness.precomp
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
+# Unset any current overrides to prevent interference with test overrides
+source ../unset_overrides.sh
+
 # This finds the .chplconfig file in this directory
 # Note that this is run in a subprocess, so it does not actually modify the
 # compilation environment for this test
 export CHPL_CONFIG=${PWD}
-
-# Unset any current overrides to prevent interference with test overrides
-source ../unset_overrides.sh
 
 ${PRINTCHPLENV} --anonymize > correctness.good
 

--- a/test/chplenv/chplconfig/warnings/warnings.chpl
+++ b/test/chplenv/chplconfig/warnings/warnings.chpl
@@ -9,9 +9,9 @@
 
 
 writeln("\
-Warning: $CHPL_CONFIG/chplconfig:line 8: Received incorrect format:\
-         > CHPL_TASKS == fifo\
-         Expected format is:\
-         > CHPL_VAR = VALUE\
+Syntax Error: $CHPL_CONFIG/chplconfig:line 8\
+              > CHPL_TASKS == fifo\
+              Expected format is:\
+              > CHPL_VAR = VALUE\
 Warning: $CHPL_CONFIG/chplconfig:line 11: \"CHPL_COMMS\" is not an acceptable variable\
 Warning: $CHPL_CONFIG/chplconfig:line 15: Duplicate entry of \"CHPL_COMM\"\n");

--- a/test/chplenv/chplconfig/warnings/warnings.precomp
+++ b/test/chplenv/chplconfig/warnings/warnings.precomp
@@ -1,12 +1,12 @@
 #! /usr/bin/env bash
 
+# Unset any current overrides to prevent interference with test overrides
+source ../unset_overrides.sh
+
 # This finds the .chplconfig file in this directory
 # Note that this is run in a subprocess, so it does not actually modify the
 # compilation environment for this test
 export CHPL_CONFIG=${PWD}
-
-# Unset any current overrides to prevent interference with test overrides
-source ../unset_overrides.sh
 
 # Note that this is the actual test:
 $CHPL_HOME/util/printchplenv --simple 1> /dev/null 2> warnings.good

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -127,16 +127,18 @@ class ChapelConfig(object):
             for linenum, line in enumerate(ccfile.readlines()):
 
                 # Strip comments and trailing white space from line
-                line = line.split('#')[0].lstrip()
+                line = line.split('#')[0].strip()
 
-                if self.skip(line, linenum):
+                if self.skip_line(line, linenum):
                     continue
 
                 var, val = [f.strip() for f in line.split('=')]
                 self.chplconfig[var] = val
 
-    def skip(self, line, linenum):
-        """ Various conditions for skipping a line """
+    def skip_line(self, line, linenum):
+        """
+        Check the various conditions for skipping a line, accumulate warnings.
+        """
 
         # Check if line is comment, by taking length of stripped line
         if len(line) == 0:

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -139,11 +139,11 @@ class ChapelConfig(object):
         """ Check if the assignment is correctly formatted, e.g. ENV = VAR """
         valid = True
 
-        # Check if line is a comment (blank)
-        if len(line.lstrip()) == 0:
-            valid = False
-        # Check if line is a comment (starts with '#')
-        elif line.lstrip()[0] == '#':
+        # Strip comments and trailing whitespace
+        newline = line.strip('#')[0].lstrip()
+
+        # Check if line is a comment or blank
+        if len(newline) == 0:
             valid = False
         else:
             # Check if line is incorrectly formatted

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -148,7 +148,7 @@ class ChapelConfig(object):
         else:
             # Check if line is incorrectly formatted
             try:
-                var, val = [f.strip() for f in line.split('=')]
+                var, val = [f.strip() for f in newline.split('=')]
             except ValueError:
                 valid = False
                 self.warnings.append(


### PR DESCRIPTION
Essentially copying the contents of the initial PR description from #4349 with a few edits over to the [Chapel env page](http://chapel.cray.com/docs/master/usingchapel/chplenv.html)

Also, added support for inline comments in Chapel configuration files, so that the following is possible:

```
CHPL_ENV = value   # This is a comment
```

Testing has been added for this.

Did some additional refactoring of `overrides.py` as well.

Local testing passes for `chplenv` tests.