### PR TITLE
After much turmoil and angst, fix bug with internal documentation clean up

### DIFF
--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -31,6 +31,9 @@ function removePattern() {
     echo "Bad call to removePattern."
     exit 1
   fi
+  # remove the line that contains the pattern (assumed to be part of a
+  # symbol declaration) and any documentation comments associated with
+  # it until the next symbol declaration in the file.
   awk "/$1/{flag=0;next}/\.\. .*:: /{flag=1}flag" $2 > $2.tmp
   mv $2.tmp $2
 }

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -31,7 +31,7 @@ function removePattern() {
     echo "Bad call to removePattern."
     exit 1
   fi
-  sed "/$1/ { N; d; }" $2 > $2.tmp
+  awk "/$1/{flag=0;next}/\.\. .*:: /{flag=1}flag" $2 > $2.tmp
   mv $2.tmp $2
 }
 


### PR DESCRIPTION
Prior to this change, our fixInternalDocs script would remove functions and
variables with "chpl_", "_" and non-alphabet character starts, but it would fail
to remove any associated documentation comments, thus making it appear that the
symbol listed before the removed symbols had longer (and inaccurate)
documentation than was actually the case.  This change extends the removal to
also encompass the comments that followed the removed symbol.

Many thanks to Greg for the brainstorming and Ben A. for the actual awk command
structure.

Verified that the internal modules are not modified other than those I expect to be
modified due to this change (http://chapel.cray.com/docs/master/modules/internal/ChapelArray.html#ChapelArray.isArrayValue).  The String module does not have
this script applied to it.