### PR TITLE
Destroy qtimer_t used in qthreads chpl_task_sleep()

### DIFF
--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -982,6 +982,7 @@ void chpl_task_sleep(double secs)
             qthread_yield();
             qtimer_stop(t);
         } while (qtimer_secs(t) < secs);
+        qtimer_destroy(t);
     }
 }
 


### PR DESCRIPTION
It was being leaked previously. Note that we copied our sleep implementation
from qthreads version of sleep() and they were missing the destroy previously.

That was fixed in qthreads with https://github.com/Qthreads/qthreads/pull/30,
so I'm applying the fix to our use of it too.