### PR TITLE
Denormalize patches

### DIFF
--- a/test/expressions/bradc/uminusVsTimesPrec.skipif
+++ b/test/expressions/bradc/uminusVsTimesPrec.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast

--- a/test/studies/parboil/SAD/sadSerial.perfcompopts
+++ b/test/studies/parboil/SAD/sadSerial.perfcompopts
@@ -1,1 +1,1 @@
--sprintTimers=1
+-sprintTimers=1 --no-denormalize


### PR DESCRIPTION
This PR contains fixes for the latest regressions(hopefully last)

- compflags/bradc/html/testit

This test tests `--html` flag and fails with `--baseline`. Here is what
happens:

`_construct_object` function looks something like this with `--baseline`

```
proc _construct_object(meme) {
  var this;
  this = meme;
  return this;
}
```

after denormalization it becomes:

```
proc _construct_object(meme) {
  return meme;
}
```

And this is what it looks like without `--baseline`

```
proc _construct_object(meme) {
  var this;
  return meme;
}
```

which stays untouched after denormalize pass.

Denormalized baseline version with `--html`, causes 
`AstDumpToHtml::writeFnSymbol` to segfault. This is as far as I could
explain the issue. Since I am unable to explain the root cause of the
issue, this patch avoids denormalizing variables named 'this'
altogether. Since `this` is a keyword anyways, I expect the effect to be
minimal.

- expressions/bradc/uminusVsTimesPrec

An issue with the signed integer wraparound as explained in the test. We
are skipping it with `--fast`. As suggested by @ronawho and 
@benharsh 
