### PR TITLE
Make reservedSymbolsName.h depend on Makefile

### DIFF
--- a/compiler/passes/Makefile
+++ b/compiler/passes/Makefile
@@ -41,7 +41,7 @@ FORCE:
 #
 include $(COMPILER_ROOT)/make/Makefile.compiler.foot
 
-reservedSymbolNames.h: reservedSymbolNames
+reservedSymbolNames.h: reservedSymbolNames Makefile
 	sed -e 's/^\([ 	]*\)\([A-Za-z_][A-Za-z0-9_]*\)/\1cnames.insert(astr("\2"));/' <$< >$@
 
 $(OBJ_SUBDIR)/codegen.o: reservedSymbolNames.h


### PR DESCRIPTION
This is a conservative Makefile change to avoid frustration/noise.

If the rule for making reservedSymbolsName.h changes, we need to
rebuild it.  Of course it may be the case that the Makefile will
change for other reasons, but the time to re-build this header is
not long (and other things will presumably be getting built if the
Makefile does change), and it seems more attractive to have things
be bulletproof than to require people to make clean and rebuild or
manually remove/rebuild the file, or the like...