### PR TITLE
Make standard atomics the default for appropriate gcc versions.

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -34,7 +34,9 @@ def get(flag='target'):
             # with an older gcc, we fall back to locks
             if compiler_val in ['gnu', 'cray-prgenv-gnu', 'mpi-gnu']:
                 version = get_compiler_version('gnu')
-                if version >= CompVersion('4.8'):
+                if version >= CompVersion('5.0'):
+                    atomics_val = 'cstdlib'
+                elif version >= CompVersion('4.8'):
                     atomics_val = 'intrinsics'
                 elif version >= CompVersion('4.1') and not platform_val.endswith('32'):
                     atomics_val = 'intrinsics'

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -26,6 +26,10 @@ def get(flag='target'):
             compiler_val = chpl_compiler.get('target')
             platform_val = chpl_platform.get('target')
 
+            # We default to C standard atomics (cstdlib) for gcc 5 and newer.
+            # Some prior versions of gcc look like they support standard
+            # atomics, but have buggy or missing parts of the implementation,
+            # so we do not try to use cstdlib with gcc < 5.
             # we currently support intrinsics for gcc, intel, cray and clang.
             # gcc added initial support in 4.1, and added support for 64 bit
             # atomics on 32 bit platforms with 4.8. clang and intel also


### PR DESCRIPTION
This change makes the C standard library atomics the default for gcc versions &ge; 5.  Some gcc versions earlier than this claim to support standard atomics, but have missing or buggy implementations.