### PR TITLE
Prevent initialization of fields from the parent type during phase 1 of child

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -232,7 +232,7 @@ DefExpr* handleField(AggregateType* t, DefExpr* lastSeen, const char* fieldname,
     }
   }
   if (isParentField(t, fieldname)) {
-    USR_FATAL_CONT(call, "can't set value of parent fields in phase 1");
+    USR_FATAL_CONT(call, "can't set value of field \"%s\" from parent type during phase 1", fieldname);
   } else {
     // We didn't find the field match, even on our parent type.  It is a method.
     USR_FATAL_CONT(call, "attempted method call too early during initialization");

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -128,6 +128,9 @@ DefExpr* handleField(AggregateType* t, DefExpr* curField, const char* fieldname,
                      bool seenField[], CallExpr* call);
 
 static
+bool isParentField(AggregateType* t, const char* name);
+
+static
 void phase1Analysis(BlockStmt* body, AggregateType* t, Expr* initCall) {
   DefExpr* curField = toDefExpr(t->fields.head);
   bool *seenField = (bool*)calloc(t->fields.length, sizeof(bool));
@@ -228,7 +231,32 @@ DefExpr* handleField(AggregateType* t, DefExpr* lastSeen, const char* fieldname,
       }
     }
   }
-  // We didn't find the field match.  It is likely a method.
-  USR_FATAL_CONT(call, "attempted method call too early during initialization");
+  if (isParentField(t, fieldname)) {
+    USR_FATAL_CONT(call, "can't set value of parent fields in phase 1");
+  } else {
+    // We didn't find the field match, even on our parent type.  It is a method.
+    USR_FATAL_CONT(call, "attempted method call too early during initialization");
+  }
   return lastSeen;
+}
+
+static
+bool isParentField(AggregateType* t, const char *name) {
+  if (t->dispatchParents.n > 0) {
+    forv_Vec(Type, pt, t->dispatchParents) {
+      if (AggregateType* cpt = toAggregateType(pt)) {
+        for_fields(field, cpt) {
+          if (!strcmp(field->name, name)) {
+            return true;
+          }
+        }
+        if (isParentField(cpt, name)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  } else {
+    return false;
+  }
 }

--- a/test/classes/initializers/phase1/setParentField.chpl
+++ b/test/classes/initializers/phase1/setParentField.chpl
@@ -1,0 +1,20 @@
+class Parent {
+  var f1 = 4.27;
+}
+
+class Child : Parent {
+  var f2: real;
+
+  proc init(parentFieldVal: real) {
+    f1 = parentFieldVal; // Error, can't set the parentField in the Child's body
+    super.init(parentFieldVal);
+    // The proper way to do this is to assume the parent initializer will handle
+    // it or to update the field in Phase 2
+  }
+}
+
+proc main() {
+  var c: Child = new Child(1.25);
+  writeln(c);
+  delete c;
+}

--- a/test/classes/initializers/phase1/setParentField.good
+++ b/test/classes/initializers/phase1/setParentField.good
@@ -1,0 +1,2 @@
+setParentField.chpl:8: In initializer:
+setParentField.chpl:9: error: can't set value of parent fields in phase 1

--- a/test/classes/initializers/phase1/setParentField.good
+++ b/test/classes/initializers/phase1/setParentField.good
@@ -1,2 +1,2 @@
 setParentField.chpl:8: In initializer:
-setParentField.chpl:9: error: can't set value of parent fields in phase 1
+setParentField.chpl:9: error: can't set value of field "f1" from parent type during phase 1


### PR DESCRIPTION
During phase 1, fields from parent types are not initialized.  These fields should
only be initialized within the parent initializer.  It is perfectly valid for the
child type to want a specific value place in a field defined by a parent type.
However, if they wish to ensure this value is there, they should set the
field to this value during Phase 2 of the initializer.

Added a test of this functionality (which I verified failed before and passes
after this change).

Tested over std/