### PR TITLE
Skip pointer-cast-to-string test if CHPL_REGEXP==none

### DIFF
--- a/test/types/cptr/ptr_cast_to_string.skipif
+++ b/test/types/cptr/ptr_cast_to_string.skipif
@@ -1,0 +1,1 @@
+CHPL_REGEXP == none


### PR DESCRIPTION
Skip `ptr_cast_to_string.chpl` from #4371 if `CHPL_REGEXP == none`