### PR TITLE
Drop the pragma "auto destroy fn sync" and the related flag

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -46,7 +46,6 @@ symbolFlag( FLAG_ATOMIC_MODULE , ypr, "atomic module" , "module containing imple
 symbolFlag( FLAG_ATOMIC_TYPE , ypr, "atomic type" , "type that implements an atomic" )
 symbolFlag( FLAG_AUTO_COPY_FN,  ypr, "auto copy fn" , "auto copy function" )
 symbolFlag( FLAG_AUTO_DESTROY_FN,  npr, "auto destroy fn" , "auto destroy function" )
-symbolFlag( FLAG_AUTO_DESTROY_FN_SYNC, ypr, "auto destroy fn sync", "auto destroy function for sync/single" )
 symbolFlag( FLAG_AUTO_II , npr, "auto ii" , ncm )
 symbolFlag( FLAG_BASE_ARRAY , ypr, "base array" , ncm )
 symbolFlag( FLAG_BASE_DOMAIN , ypr, "base domain" , ncm )

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1301,24 +1301,9 @@ makeHeapAllocations() {
             call->replace(new CallExpr(PRIM_GET_MEMBER, use->var, heapType->getField(1)));
           }
         } else if (call->isResolved()) {
-          if (call->isResolved()->hasFlag(FLAG_AUTO_DESTROY_FN_SYNC)) {
-            //
-            // We don't move sync vars to the heap and don't do the
-            // analysis to determine whether or not they outlive a
-            // task that refers to them, so conservatively remove
-            // their autodestroy calls to avoid freeing them before
-            // all tasks are done with them.  While this is
-            // unfortunate and needs to be fixed in the future to
-            // avoid leaks (TODO), it is better than the previous
-            // version of this code that would remove all autodestroy
-            // calls in this conditional.  See the commit message for
-            // this comment for more detail.
-            //
-            call->remove();
-          } else if (actual_to_formal(use)->type == heapType) {
-            // do nothing
-          } else {
+          if (actual_to_formal(use)->type != heapType) {
             VarSymbol* tmp = newTemp(var->type);
+
             call->getStmtExpr()->insertBefore(new DefExpr(tmp));
             call->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_GET_MEMBER_VALUE, use->var, heapType->getField(1))));
             use->replace(new SymExpr(tmp));

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -285,8 +285,7 @@ module ChapelSyncvar {
   inline proc chpl__maybeAutoDestroyed(x : _syncvar(?t)) param return true;
 
   // This version has to be available to take precedence
-  pragma "auto destroy fn sync"
-    inline proc chpl__autoDestroy(x : _syncvar(?)) {
+  inline proc chpl__autoDestroy(x : _syncvar(?)) {
     if x.isOwned == true then
       delete x.wrapped;
   }
@@ -594,8 +593,7 @@ module ChapelSyncvar {
   inline proc chpl__maybeAutoDestroyed(x : _singlevar(?t)) param return true;
 
   // This version has to be available to take precedence
-  pragma "auto destroy fn sync"
-    inline proc chpl__autoDestroy(x : _singlevar(?)) {
+  inline proc chpl__autoDestroy(x : _singlevar(?)) {
     if x.isOwned == true then
       delete x.wrapped;
   }


### PR DESCRIPTION
The original implementation of sync/single as classes relied on the pragma
"auto destroy fn sync" to identify the special code required for memory management.

This pragma can be dropped now that these are types are record-wrapped classes.
This allows the underlying FLAG to be dropped a long with a minor utility function.



Compiled on clang/darwin and gcc/linux64 with/without CHPL_DEVELOPER


Testing:

examples/ on darwin

full suite on linux64 with "--verify" and "--baseline --verify"
full suite on gasnet with "--verify".
