### PR TITLE
Fix ref-after-use bug in target program command line arguments.

### DIFF
--- a/third-party/gasnet/gasnet-src/other/amudp/amudp_spawn.cpp
+++ b/third-party/gasnet/gasnet-src/other/amudp/amudp_spawn.cpp
@@ -91,23 +91,19 @@ char *quote_for_local(const char *arg) {
   char *result = (char *)AMUDP_malloc(1 + new_len);
   char *end = result;
 
-  if (c) {
-    char *q, *dup = (char *)AMUDP_malloc(1 + old_len);
-    p = strcpy(dup, tmp);
-    while (NULL != (q = strpbrk((char *)p, specials))) {
-      size_t len = q-p;
-      strncpy(end, p, len);   end += len;
-      end[0] = '\\';          end += 1;
-      if (q[0] != '\\' || strchr(specials, q[1])) {
-        end[0] = q[0];        end += 1;
-      }
-      p = q + 1;
+  char *q, *dup = (char *)AMUDP_malloc(1 + old_len);
+  p = strcpy(dup, tmp);
+  while (NULL != (q = strpbrk((char *)p, specials))) {
+    size_t len = q-p;
+    strncpy(end, p, len);   end += len;
+    end[0] = '\\';          end += 1;
+    if (q[0] != '\\' || strchr(specials, q[1])) {
+      end[0] = q[0];        end += 1;
     }
-    AMUDP_free(dup);
-  } else {
-    p = tmp;
+    p = q + 1;
   }
   strcpy(end, p);
+  AMUDP_free(dup);
   AMUDP_free(tmp);
 
   AMUDP_assert(strlen(result) <= new_len);


### PR DESCRIPTION
If we take the `if(c)` true branch we do `ADMUDP_free(dup)` at the end of it
and then `strcpy(end,p)` right after the whole if-stmt, but `p` points into
`dup` so we're referencing already-freed memory.  Fix this by waiting
until after the `strcpy()` to free `dup`.

While here, remove the `if(c)` check and its else branch entirely, since
we've already done` if(!c)return` a few lines earlier in this function,
and  `c` is not modified after that.