### PR TITLE
Fix indentation levels for HTML dumps when viewed with Chrome

### DIFF
--- a/compiler/AST/AstDumpToHtml.cpp
+++ b/compiler/AST/AstDumpToHtml.cpp
@@ -42,6 +42,9 @@
 int   AstDumpToHtml::sPassIndex = 1;
 FILE* AstDumpToHtml::sIndexFP   = 0;
 
+const char* HTML_DL_open_tag = "<DL><DD>";
+const char* HTML_DL_close_tag = "</DD></DL>";
+
 AstDumpToHtml::AstDumpToHtml() {
   mFP = 0;
 }
@@ -161,7 +164,7 @@ bool AstDumpToHtml::close() {
 //
 bool AstDumpToHtml::enterCallExpr(CallExpr* node) {
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "<DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_open_tag);
   }
 
   fprintf(mFP, " ");
@@ -199,7 +202,7 @@ void AstDumpToHtml::exitCallExpr(CallExpr* node) {
   fprintf(mFP, ")");
 
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "</DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_close_tag);
   }
 }
 
@@ -211,7 +214,7 @@ bool AstDumpToHtml::enterDefExpr(DefExpr* node) {
   bool retval = true;
 
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "<DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_open_tag);
   }
 
   fprintf(mFP, " ");
@@ -281,7 +284,7 @@ bool AstDumpToHtml::enterDefExpr(DefExpr* node) {
     writeSymbol(node->sym, true);
 
   } else if (isModuleSymbol(node->sym)) {
-    fprintf(mFP, "</DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_close_tag);
     // Don't process nested modules -- they'll be handled at the top-level
     retval = false;
 
@@ -308,7 +311,7 @@ void AstDumpToHtml::exitDefExpr(DefExpr* node) {
   }
 
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "</DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_close_tag);
   }
 }
 
@@ -318,7 +321,7 @@ void AstDumpToHtml::exitDefExpr(DefExpr* node) {
 //
 bool AstDumpToHtml::enterNamedExpr(NamedExpr* node) {
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "<DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_open_tag);
   }
 
   fprintf(mFP, " (%s = ", node->name);
@@ -330,7 +333,7 @@ void AstDumpToHtml::exitNamedExpr(NamedExpr* node) {
   fprintf(mFP, ")");
 
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "</DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_close_tag);
   }
 }
 
@@ -343,7 +346,7 @@ void AstDumpToHtml::visitSymExpr(SymExpr* node) {
   VarSymbol* var = toVarSymbol(sym);
 
   if (isBlockStmt(node->parentExpr) == true) {
-    fprintf(mFP, "<DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_open_tag);
   }
 
   fprintf(mFP, " ");
@@ -361,7 +364,7 @@ void AstDumpToHtml::visitSymExpr(SymExpr* node) {
   }
 
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "</DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_close_tag);
   }
 }
 
@@ -371,13 +374,13 @@ void AstDumpToHtml::visitSymExpr(SymExpr* node) {
 //
 void AstDumpToHtml::visitUsymExpr(UnresolvedSymExpr* node) {
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "<DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_open_tag);
   }
 
   fprintf(mFP, " <FONT COLOR=\"red\">%s</FONT>", node->unresolved);
 
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "</DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_close_tag);
   }
 }
 
@@ -387,7 +390,7 @@ void AstDumpToHtml::visitUsymExpr(UnresolvedSymExpr* node) {
 //
 void AstDumpToHtml::visitUseStmt(UseStmt* node) {
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "<DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_open_tag);
   }
 
   fprintf(mFP, " (%d 'use' ", node->id);
@@ -403,7 +406,7 @@ void AstDumpToHtml::visitUseStmt(UseStmt* node) {
   fprintf(mFP, ")");
 
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "</DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_close_tag);
   }
 }
 
@@ -412,7 +415,7 @@ void AstDumpToHtml::visitUseStmt(UseStmt* node) {
 // BlockStmt
 //
 bool AstDumpToHtml::enterBlockStmt(BlockStmt* node) {
-  fprintf(mFP, "<DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_open_tag);
 
   if (FnSymbol* fn = toFnSymbol(node->parentSymbol))
     if (node == fn->where)
@@ -428,7 +431,7 @@ bool AstDumpToHtml::enterBlockStmt(BlockStmt* node) {
 void AstDumpToHtml::exitBlockStmt(BlockStmt* node) {
   fprintf(mFP, "}");
   printBlockID(node);
-  fprintf(mFP, "</DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_close_tag);
 }
 
 
@@ -436,7 +439,7 @@ void AstDumpToHtml::exitBlockStmt(BlockStmt* node) {
 // WhileDoStmt
 //
 bool AstDumpToHtml::enterWhileDoStmt(WhileDoStmt* node) {
-  fprintf(mFP, "<DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_open_tag);
 
   if (FnSymbol* fn = toFnSymbol(node->parentSymbol))
     if (node == fn->where)
@@ -452,7 +455,7 @@ bool AstDumpToHtml::enterWhileDoStmt(WhileDoStmt* node) {
 void AstDumpToHtml::exitWhileDoStmt(WhileDoStmt* node) {
   fprintf(mFP, "}");
   printBlockID(node);
-  fprintf(mFP, "</DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_close_tag);
 }
 
 
@@ -460,7 +463,7 @@ void AstDumpToHtml::exitWhileDoStmt(WhileDoStmt* node) {
 // DoWhileStmt
 //
 bool AstDumpToHtml::enterDoWhileStmt(DoWhileStmt* node) {
-  fprintf(mFP, "<DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_open_tag);
 
   if (FnSymbol* fn = toFnSymbol(node->parentSymbol))
     if (node == fn->where)
@@ -476,7 +479,7 @@ bool AstDumpToHtml::enterDoWhileStmt(DoWhileStmt* node) {
 void AstDumpToHtml::exitDoWhileStmt(DoWhileStmt* node) {
   fprintf(mFP, "}");
   printBlockID(node);
-  fprintf(mFP, "</DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_close_tag);
 }
 
 
@@ -484,7 +487,7 @@ void AstDumpToHtml::exitDoWhileStmt(DoWhileStmt* node) {
 // ForLoop
 //
 bool AstDumpToHtml::enterForLoop(ForLoop* node) {
-  fprintf(mFP, "<DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_open_tag);
 
   if (FnSymbol* fn = toFnSymbol(node->parentSymbol))
     if (node == fn->where)
@@ -500,7 +503,7 @@ bool AstDumpToHtml::enterForLoop(ForLoop* node) {
 void AstDumpToHtml::exitForLoop(ForLoop* node) {
   fprintf(mFP, "}");
   printBlockID(node);
-  fprintf(mFP, "</DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_close_tag);
 }
 
 
@@ -508,7 +511,7 @@ void AstDumpToHtml::exitForLoop(ForLoop* node) {
 // CForLoop
 //
 bool AstDumpToHtml::enterCForLoop(CForLoop* node) {
-  fprintf(mFP, "<DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_open_tag);
 
   if (FnSymbol* fn = toFnSymbol(node->parentSymbol))
     if (node == fn->where)
@@ -524,7 +527,7 @@ bool AstDumpToHtml::enterCForLoop(CForLoop* node) {
 void AstDumpToHtml::exitCForLoop(CForLoop* node) {
   fprintf(mFP, "}");
   printBlockID(node);
-  fprintf(mFP, "</DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_close_tag);
 }
 
 
@@ -532,7 +535,7 @@ void AstDumpToHtml::exitCForLoop(CForLoop* node) {
 // ParamForLoop
 //
 bool AstDumpToHtml::enterParamForLoop(ParamForLoop* node) {
-  fprintf(mFP, "<DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_open_tag);
 
   if (FnSymbol* fn = toFnSymbol(node->parentSymbol))
     if (node == fn->where)
@@ -548,7 +551,7 @@ bool AstDumpToHtml::enterParamForLoop(ParamForLoop* node) {
 void AstDumpToHtml::exitParamForLoop(ParamForLoop* node) {
   fprintf(mFP, "}");
   printBlockID(node);
-  fprintf(mFP, "</DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_close_tag);
 }
 
 
@@ -556,14 +559,14 @@ void AstDumpToHtml::exitParamForLoop(ParamForLoop* node) {
 // CondStmt
 //
 bool AstDumpToHtml::enterCondStmt(CondStmt* node) {
-  fprintf(mFP, "<DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_open_tag);
   fprintf(mFP, "<B>if</B> ");
 
   return true;
 }
 
 void AstDumpToHtml::exitCondStmt(CondStmt* node) {
-  fprintf(mFP, "</DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_close_tag);
 }
 
 //
@@ -573,7 +576,7 @@ void AstDumpToHtml::visitEblockStmt(ExternBlockStmt* node) {
   fprintf(mFP, "(%s", node->astTagAsString());
 
   if (isBlockStmt(node->parentExpr)) {
-    fprintf(mFP, "</DL>\n");
+    fprintf(mFP, "%s\n", HTML_DL_close_tag);
   }
 }
 
@@ -582,7 +585,7 @@ void AstDumpToHtml::visitEblockStmt(ExternBlockStmt* node) {
 // GotoStmt
 //
 bool AstDumpToHtml::enterGotoStmt(GotoStmt* node) {
-  fprintf(mFP, "<DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_open_tag);
 
   switch (node->gotoTag) {
     case GOTO_NORMAL:      fprintf(mFP, "<B>goto</B> ");           break;
@@ -602,7 +605,7 @@ bool AstDumpToHtml::enterGotoStmt(GotoStmt* node) {
 }
 
 void AstDumpToHtml::exitGotoStmt(GotoStmt* node) {
-  fprintf(mFP, "</DL>\n");
+  fprintf(mFP, "%s\n", HTML_DL_close_tag);
 }
 
 //


### PR DESCRIPTION
The HTML dumps used the Definition List tag `<DL>` to increase the indentation
level, but Chrome only seems to pay attention to the first couple of these.

If the Definition Description tag `<DD>` is also used, Chrome pays better
attention to it.  So replace `<DL>` with `<DL><DD>` and replace `</DL>` with
`</DD></DL>`.

This dramatically improves how these logs render in Chrome on Windows and Mac,
and I verified that it doesn't negatively impact Firefox or Safari on Mac, and
Firefox or Internet Explorer on Windows.