### PR TITLE
Make use of enum.size and enumerators Laura introduced in #4366

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -28,10 +28,8 @@ proc main() {
 // Print the results of getNewColor() for all color pairs.
 //
 proc printColorEquations() {
-  const colors = (blue, red, yellow);
-
-  for c1 in colors do
-    for c2 in colors do
+  for c1 in Color do
+    for c2 in Color do
       writeln(c1, " + ", c2, " -> ", getNewColor(c1, c2));
   writeln();
 }
@@ -189,7 +187,6 @@ class Chameneos {
 
     peer.color = newColor;
     peer.meetings += 1;
-    peer.meetingsWithSelf += (peer == this);
     peer.meetingCompleted.write(true);
 
     color = newColor;

--- a/test/studies/shootout/meteor/kbrady/meteor-parallel.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-parallel.chpl
@@ -56,8 +56,7 @@ enum direction {
   NW,
   N,
   NE,
-  ENE,
-  PIVOT
+  ENE
 }
 use direction;
 
@@ -323,12 +322,12 @@ proc recordPiece(piece, minimum, firstEmpty, pieceMask) {
 
 /* Returns the direction rotated 60 degrees clockwise */
 proc rotate(dir) {
-  return ((dir + 2) % PIVOT:int): direction;
+  return ((dir + 2) % direction.size): direction;
 }
 
 /* Returns the direction flipped on the horizontal axis */
 proc flip(dir) {
-  return ((PIVOT - dir:int) % PIVOT:int): direction;
+  return ((direction.size - dir) % direction.size): direction;
 }
 
 /* Calculate all 32 possible states for a 5-bit row and all rows that


### PR DESCRIPTION
These new features permit some nice cleanups to shootouts
that use enums.  For now I'm only doing this in the study versions
to make sure there's no adverse impact before propagating to the
release.