### PR TITLE
Revert "Make standard atomics the default for appropriate gcc versions"

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -26,10 +26,6 @@ def get(flag='target'):
             compiler_val = chpl_compiler.get('target')
             platform_val = chpl_platform.get('target')
 
-            # We default to C standard atomics (cstdlib) for gcc 5 and newer.
-            # Some prior versions of gcc look like they support standard
-            # atomics, but have buggy or missing parts of the implementation,
-            # so we do not try to use cstdlib with gcc < 5.
             # we currently support intrinsics for gcc, intel, cray and clang.
             # gcc added initial support in 4.1, and added support for 64 bit
             # atomics on 32 bit platforms with 4.8. clang and intel also
@@ -38,9 +34,7 @@ def get(flag='target'):
             # with an older gcc, we fall back to locks
             if compiler_val in ['gnu', 'cray-prgenv-gnu', 'mpi-gnu']:
                 version = get_compiler_version('gnu')
-                if version >= CompVersion('5.0'):
-                    atomics_val = 'cstdlib'
-                elif version >= CompVersion('4.8'):
+                if version >= CompVersion('4.8'):
                     atomics_val = 'intrinsics'
                 elif version >= CompVersion('4.1') and not platform_val.endswith('32'):
                     atomics_val = 'intrinsics'


### PR DESCRIPTION
This reverts commit 554240af460452f5c1afff886fe97f945e573ae4. 

Revert "make standard atomics the default for appropriate gcc versions." There were some correctness and performance regressions :(

The correctness regressions are just because some chameneos versions are inappropriately using `memory_order_acq_rel` for a compareAndSwap, but according to c11 docs the memory order for compareAndSwap "Cannot be memory_order_release or memory_order_acq_rel and cannot specify stronger ordering than succ"
