### PR TITLE
Make compare_exchange failure memory order conform to requirements.

### DIFF
--- a/runtime/include/atomics/cstdlib/chpl-atomics.h
+++ b/runtime/include/atomics/cstdlib/chpl-atomics.h
@@ -105,13 +105,13 @@ static inline basetype atomic_exchange_ ## type(atomic_ ## type * obj, basetype 
   return atomic_exchange(obj, value); \
 } \
 static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(atomic_ ## type * obj, basetype expected, basetype desired, memory_order order) { \
-  return atomic_compare_exchange_strong_explicit(obj, &expected, desired, order, order); \
+  return atomic_compare_exchange_strong_explicit(obj, &expected, desired, order, memory_order_relaxed); \
 } \
 static inline chpl_bool atomic_compare_exchange_strong_ ## type(atomic_ ## type * obj, basetype expected, basetype desired) { \
   return atomic_compare_exchange_strong(obj, &expected, desired); \
 } \
 static inline chpl_bool atomic_compare_exchange_weak_explicit_ ## type(atomic_ ## type * obj, basetype expected, basetype desired, memory_order order) { \
-  return atomic_compare_exchange_weak_explicit(obj, &expected, desired, order, order); \
+  return atomic_compare_exchange_weak_explicit(obj, &expected, desired, order, memory_order_relaxed); \
 } \
 static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * obj, basetype expected, basetype desired) { \
   return atomic_compare_exchange_weak(obj, &expected, desired); \
@@ -163,7 +163,7 @@ static inline type atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, typ
   type new_val; \
   do { \
     new_val = old_val + operand; \
-  } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, order)); \
+  } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, memory_order_relaxed)); \
   return old_val; \
 } \
 static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
@@ -174,7 +174,7 @@ static inline type atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, typ
   type new_val; \
   do { \
     new_val = old_val - operand; \
-  } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, order)); \
+  } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, memory_order_relaxed)); \
   return old_val; \
 } \
 static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \

--- a/runtime/include/atomics/cstdlib/chpl-atomics.h
+++ b/runtime/include/atomics/cstdlib/chpl-atomics.h
@@ -83,8 +83,8 @@ static inline memory_order _defaultOfMemoryOrder(void) {
 // that satisifes those requirements.
 //
 #define GET_READABLE_ORDER(order) (order != memory_order_release && \
-				   order != memory_order_acq_rel ? \
-				   order : memory_order_acquire)
+                                   order != memory_order_acq_rel ? \
+                                   order : memory_order_acquire)
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/runtime/include/atomics/cstdlib/chpl-atomics.h
+++ b/runtime/include/atomics/cstdlib/chpl-atomics.h
@@ -69,7 +69,7 @@ static inline memory_order _defaultOfMemoryOrder(void) {
 
 
 ///////////////////////////////////////////////////////////////////////////////
-////                      START OF INTEGER ATOMICS BASE                   ////
+////                      START OF ATOMICS BASE                           ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_ATOMICS_BASE(type, basetype) \
 static inline chpl_bool atomic_is_lock_free_ ## type(atomic_ ## type * obj) { \
@@ -95,7 +95,7 @@ static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
 
 
 ///////////////////////////////////////////////////////////////////////////////
-////                 START OF INTEGER ATOMIC EXCHANGE OPS                 ////
+////                 START OF ATOMIC EXCHANGE OPS                         ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_ATOMICS_EXCHANGE_OPS(type, basetype) \
 static inline basetype atomic_exchange_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
@@ -163,7 +163,7 @@ static inline type atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, typ
   type new_val; \
   do { \
     new_val = old_val + operand; \
-  } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, memory_order_relaxed)); \
+  } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, order == memory_order_seq_cst ? order : memory_order_relaxed)); \
   return old_val; \
 } \
 static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
@@ -174,7 +174,7 @@ static inline type atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, typ
   type new_val; \
   do { \
     new_val = old_val - operand; \
-  } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, memory_order_relaxed)); \
+  } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, order == memory_order_seq_cst ? order : memory_order_relaxed)); \
   return old_val; \
 } \
 static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \


### PR DESCRIPTION
The C standard atomic API updates the "expected" parameter of an atomic_compare_exchange with the actual value in case of failure.   This change makes the failure path use either the same order as the success path, if that order is allowed for the failure path, or memory_order_acquire if not.

The result is that the failure order will never be stronger than the success order, and will never be memory_order_release or memory_order_acq_rel.  These are requirements of the C standard.

Also, comments indicating that general macros were only for integers were corrected.