### PR TITLE
Quiet "unsigned int being compared to 0" warnings for CCE

### DIFF
--- a/make/compiler/Makefile.cray-prgenv-cray
+++ b/make/compiler/Makefile.cray-prgenv-cray
@@ -18,6 +18,10 @@
 # Suppress warning about variables used before defined
 CRAYPE_GEN_CFLAGS = -hnomessage=7212
 
+# Suppress warnings about unsigned ints being compared to 0
+CRAYPE_GEN_CFLAGS += -hnomessage=186
+
+
 FAST_FLOAT_GEN_CFLAGS = -hfp2
 IEEE_FLOAT_GEN_CFLAGS = -hfp0
 


### PR DESCRIPTION
Quiet a warning from the cray compiler about unsigned ints being compared to
0. These warnings stem from denormalization, but whitebox testing wasn't
running when denormalization was turned on by default.

This is a follow on to #4368, which quieted similar warnings for clang/gcc.