### PR TITLE
Bug fix: Remove C_BLAS_INDEX type value in BLAS module

### DIFF
--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -715,15 +715,7 @@ module BLAS {
 
   */
   module C_BLAS {
-    extern type CBLAS_INDEX = size_t;
-
-    // Do a size test.
-    {
-      pragma "no doc"
-      pragma "no prototype"
-      extern proc sizeof(type t): size_t;
-      assert(sizeof(CBLAS_INDEX) == sizeof(size_t), "size of CBLAS_INDEX is not the same as size_t");
-    }
+    extern type CBLAS_INDEX;
 
     // Define the external types
     // These are C enums, so we define these as c_ints;


### PR DESCRIPTION
Different versions of BLAS might have varying types for `C_BLAS_INDEX`. Notably, the LAPACK bundled BLAS defines `C_BLAS_INDEX` as a `int` or `long`, rather than a `size_t`.

This allows the Chapel BLAS module's `C_BLAS_INDEX` to be implicitly defined. I also removed the check for this type that followed it's definition.

* Tested BLAS tests