### PR TITLE
Apply gasnet amudp spawn patch.

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -28,11 +28,12 @@ as follows:
   third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
   which is the only ARM change beneath gasnet-src in the tree.
 
-* Fixed a use-after-free bug in amudp_spawn command line argument
-  handling.  We'll get this with the next GASNet release we pick up, but
-  we're applying it early because it fixes a problem reported against
-  Chapel on stackoverflow:
-    http://stackoverflow.com/questions/39195929/chapel-gasnet-unexpected-eof-while-looking-for-matching
+* Applied an upstream path to fix a use-after-free bug in amudp_spawn
+  command line argument handling:
+    https://bitbucket.org/berkeleylab/gasnet/commits/a6a6534
+
+  This fixes a problem reported against Chapel on stackoverflow:
+    https://stackoverflow.com/questions/39195929/chapel-gasnet-unexpected-eof-while-looking-for-matching
 
 Upgrading GASNet versions
 =========================

--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -28,6 +28,12 @@ as follows:
   third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
   which is the only ARM change beneath gasnet-src in the tree.
 
+* Fixed a use-after-free bug in amudp_spawn command line argument
+  handling.  We'll get this with the next GASNet release we pick up, but
+  we're applying it early because it fixes a problem reported against
+  Chapel on stackoverflow:
+    http://stackoverflow.com/questions/39195929/chapel-gasnet-unexpected-eof-while-looking-for-matching
+
 Upgrading GASNet versions
 =========================
 

--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -28,7 +28,7 @@ as follows:
   third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
   which is the only ARM change beneath gasnet-src in the tree.
 
-* Applied an upstream path to fix a use-after-free bug in amudp_spawn
+* Applied an upstream patch to fix a use-after-free bug in amudp_spawn
   command line argument handling:
     https://bitbucket.org/berkeleylab/gasnet/commits/a6a6534
 

--- a/third-party/gasnet/gasnet-src/other/amudp/amudp_spawn.cpp
+++ b/third-party/gasnet/gasnet-src/other/amudp/amudp_spawn.cpp
@@ -91,23 +91,19 @@ char *quote_for_local(const char *arg) {
   char *result = (char *)AMUDP_malloc(1 + new_len);
   char *end = result;
 
-  if (c) {
-    char *q, *dup = (char *)AMUDP_malloc(1 + old_len);
-    p = strcpy(dup, tmp);
-    while (NULL != (q = strpbrk((char *)p, specials))) {
-      size_t len = q-p;
-      strncpy(end, p, len);   end += len;
-      end[0] = '\\';          end += 1;
-      if (q[0] != '\\' || strchr(specials, q[1])) {
-        end[0] = q[0];        end += 1;
-      }
-      p = q + 1;
+  char *q, *dup = (char *)AMUDP_malloc(1 + old_len);
+  p = strcpy(dup, tmp);
+  while (NULL != (q = strpbrk((char *)p, specials))) {
+    size_t len = q-p;
+    strncpy(end, p, len);   end += len;
+    end[0] = '\\';          end += 1;
+    if (q[0] != '\\' || strchr(specials, q[1])) {
+      end[0] = q[0];        end += 1;
     }
-    AMUDP_free(dup);
-  } else {
-    p = tmp;
+    p = q + 1;
   }
   strcpy(end, p);
+  AMUDP_free(dup);
   AMUDP_free(tmp);
 
   AMUDP_assert(strlen(result) <= new_len);


### PR DESCRIPTION
Fix an amudp_spawn bug in which we reference memory that has
already been freed, potentially corrupting the command line to be
used to launch the target executable.  The patch itself was originally
contributed from Chapel to GASNet, so here we're pulling their copy
back into our repo.