### PR TITLE
Drop unused code from flattenFunctions

### DIFF
--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -101,21 +101,6 @@ passByRef(Symbol* sym) {
     return false;
   }
 
-  if (sym->hasFlag(FLAG_DISTRIBUTION) ||
-      sym->hasFlag(FLAG_DOMAIN) ||
-      sym->hasFlag(FLAG_ARRAY)
-  ) {
-    printf("Surprise suppression\n");
-
-    // These values *are* constant. E.g the symbol with FLAG_ARRAY
-    // stores a pointer to the corresponding array descriptor.  Since
-    // each Chapel variable corresponds to a single Chapel array
-    // throughout the variable's lifetime, the descriptor object stays
-    // the same, and so does a pointer to it. The contents of that
-    // object *can* change, however.
-    return false;
-  }
-
   Type* type = sym->type;
 
   if (sym->hasFlag(FLAG_ARG_THIS))

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -105,6 +105,8 @@ passByRef(Symbol* sym) {
       sym->hasFlag(FLAG_DOMAIN) ||
       sym->hasFlag(FLAG_ARRAY)
   ) {
+    printf("Surprise suppression\n");
+
     // These values *are* constant. E.g the symbol with FLAG_ARRAY
     // stores a pointer to the corresponding array descriptor.  Since
     // each Chapel variable corresponds to a single Chapel array


### PR DESCRIPTION
I happened to notice that a small portion of the implementation of passByRef()
in flattenFunctions never triggers.  A casual reader might believe that there is
special handling for distribution/domain/array but there is not.

Compiled on clang/darwin and gcc/linux.

Tested full suite with

1) --verify
2) --verify --no-local

