### PR TITLE
Another Sync/Single clean up

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -191,11 +191,12 @@ bool AstDump::enterDefExpr(DefExpr* node) {
       writeSymbol("type", sym, true);
 
     } else if (VarSymbol* vs = toVarSymbol(sym)) {
-      if (isSyncType(vs->type))
+      if (isSyncType(vs->type)) {
         write("sync");
 
-      if (isSingleType(vs->type))
+      } else if (isSingleType(vs->type)) {
         write("single");
+      }
 
       writeSymbol("var", sym, true);
       writeFlags(mFP, sym);

--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -180,7 +180,7 @@ bool AstDump::enterDefExpr(DefExpr* node) {
       writeFnSymbol(fn);
 
     } else if (isTypeSymbol(sym)) {
-      if (toAggregateType(sym->type)) {
+      if (isAggregateType(sym->type)) {
         if (sym->hasFlag(FLAG_SYNC))
           write("sync");
 
@@ -191,10 +191,10 @@ bool AstDump::enterDefExpr(DefExpr* node) {
       writeSymbol("type", sym, true);
 
     } else if (VarSymbol* vs = toVarSymbol(sym)) {
-      if (vs->type->symbol->hasFlag(FLAG_SYNC))
+      if (isSyncType(vs->type))
         write("sync");
 
-      if (vs->type->symbol->hasFlag(FLAG_SINGLE))
+      if (isSingleType(vs->type))
         write("single");
 
       writeSymbol("var", sym, true);

--- a/compiler/AST/AstDumpToHtml.cpp
+++ b/compiler/AST/AstDumpToHtml.cpp
@@ -232,7 +232,7 @@ bool AstDumpToHtml::enterDefExpr(DefExpr* node) {
     fprintf(mFP, "</B><UL>\n");
 
   } else if (isTypeSymbol(node->sym)) {
-    if (toAggregateType(node->sym->type)) {
+    if (isAggregateType(node->sym->type)) {
       fprintf(mFP, "<UL CLASS =\"mktree\">\n");
       fprintf(mFP, "<LI>");
 
@@ -252,10 +252,10 @@ bool AstDumpToHtml::enterDefExpr(DefExpr* node) {
     }
 
   } else if (VarSymbol* vs = toVarSymbol(node->sym)) {
-    if (vs->type->symbol->hasFlag(FLAG_SYNC))
+    if (isSyncType(vs->type))
       fprintf(mFP, "<B>sync </B>");
 
-    if (vs->type->symbol->hasFlag(FLAG_SINGLE))
+    if (isSingleType(vs->type))
       fprintf(mFP, "<B>single </B>");
 
     fprintf(mFP, "<B>var </B> ");

--- a/compiler/AST/AstDumpToHtml.cpp
+++ b/compiler/AST/AstDumpToHtml.cpp
@@ -252,11 +252,12 @@ bool AstDumpToHtml::enterDefExpr(DefExpr* node) {
     }
 
   } else if (VarSymbol* vs = toVarSymbol(node->sym)) {
-    if (isSyncType(vs->type))
+    if (isSyncType(vs->type)) {
       fprintf(mFP, "<B>sync </B>");
 
-    if (isSingleType(vs->type))
+    } else if (isSingleType(vs->type)) {
       fprintf(mFP, "<B>single </B>");
+    }
 
     fprintf(mFP, "<B>var </B> ");
     writeSymbol(node->sym, true);

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,11 +24,12 @@
 // transformations that would be difficult to do while parsing.
 //
 
+#include "passes.h"
+
 #include "astutil.h"
-#include "stlUtil.h"
 #include "build.h"
 #include "expr.h"
-#include "passes.h"
+#include "stlUtil.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
@@ -148,31 +149,34 @@ destructureTupleAssignment(CallExpr* call) {
   }
 }
 
-
 static void flatten_primary_methods(FnSymbol* fn) {
   if (TypeSymbol* ts = toTypeSymbol(fn->defPoint->parentSymbol)) {
     Expr* insertPoint = ts->defPoint;
+
     while (toTypeSymbol(insertPoint->parentSymbol))
       insertPoint = insertPoint->parentSymbol->defPoint;
+
     DefExpr* def = fn->defPoint;
+
     def->remove();
+
     insertPoint->insertBefore(def);
+
     if (fn->userString && fn->name != ts->name) {
       if (strncmp(fn->userString, "ref ", 4) == 0) {
         // fn->userString of "ref foo()"
         // Move "ref " before the type name so we end up with "ref Type.foo()"
         // instead of "Type.ref foo()"
-        fn->userString = astr("ref ", ts->name, ".", fn->userString+4);
+        fn->userString = astr("ref ", ts->name, ".", fn->userString + 4);
       } else {
         fn->userString = astr(ts->name, ".", fn->userString);
       }
     }
-    if (ts->hasFlag(FLAG_SYNC))
-      fn->addFlag(FLAG_SYNC);
-    if (ts->hasFlag(FLAG_SINGLE))
-      fn->addFlag(FLAG_SINGLE);
-    if (ts->hasFlag(FLAG_ATOMIC_TYPE))
+
+
+    if (ts->hasFlag(FLAG_ATOMIC_TYPE)) {
       fn->addFlag(FLAG_ATOMIC_TYPE);
+    }
   }
 }
 

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1062,7 +1062,6 @@ static void findHeapVarsAndRefs(Map<Symbol*, Vec<SymExpr*>*>& defMap,
            is_complex_type(def->sym->type) ||
            (isRecord(def->sym->type)             &&
             !isRecordWrappedType(def->sym->type) &&
-            // sync/single are currently classes, so this shouldn't matter
             !isSyncType(def->sym->type)          &&
             !isSingleType(def->sym->type)        &&
             // Dont try to broadcast string literals, they'll get fixed in

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -549,7 +549,8 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
             Type*      formalType = formalArg->type;
 
             // Cannot reduce initCopy/autoCopy for sync variables
-            if (isSyncType(formalType) == false)
+            if (isSyncType(formalType)   == false &&
+                isSingleType(formalType) == false)
             {
               copyExpr = rhsCall;
             }


### PR DESCRIPTION
Elliot prompted me to do another pass to

1) Drop unnecessary uses of FLAG_SYNC/FLAG_SINGLE

2) Use isSyncType() / isSingleType() consistently in preference to use of the flags

3) Fix an obsolete comment

4) Ensure isSingleType() is applied consistently with isSyncType()

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Tested on suite with "--verify" for both single locale and gasnet
