### PR TITLE
Remove Git metadata from Chapel release tarball

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -192,6 +192,9 @@ SystemOrDie("cd runtime/include && rm -r sunos_old");
 print "Removing third-party directories that are not intended for release...\n";
 SystemOrDie("cd third-party && rm *.devel*");
 
+print "Removing Git metadata files not intended for release...\n";
+SystemOrDie('find . -type f \( -name .gitignore -o -name .gitattributes \) -exec rm -f {} \; -print');
+
 chdir "$archive_dir";
 
 print "Chmodding the hierarchy\n";


### PR DESCRIPTION
The util/buildRelease/gen_release script leaves many vcs-type files (.gitignore, .gitattributes) throughout the project when it builds the tarball. These files should not be deployed with Chapel release. Consequently, the Debian package requires package metadata in the copyright file that explicitly excludes these files from the package. 