### PR TITLE
spec/Array.tex: Clarify sparse arrays' domains

### DIFF
--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -784,7 +784,7 @@ equivalent to \chpl{A(3,3)}.
 \label{Sparse_Arrays}
 \index{arrays!sparse}
 
-Sparse arrays in Chapel are those whose domain is a sparse array.  A
+Sparse arrays in Chapel are those whose domain is sparse.  A
 sparse array differs from other array types in that it stores a single
 value corresponding to multiple indices.  This value is commonly
 referred to as the \emph{zero value}, but we refer to it as the


### PR DESCRIPTION
A sparse array's domain is not itself an array.