### PR TITLE
Add a .future showing a memory leak

### DIFF
--- a/test/types/records/ferguson/leak-futures/record-in-record-generic.chpl
+++ b/test/types/records/ferguson/leak-futures/record-in-record-generic.chpl
@@ -1,0 +1,16 @@
+use myrecord;
+
+record OtherRecord {
+  var r;
+}
+
+proc run() {
+  var r = new R(1);
+  var myR = new OtherRecord(r);
+  myR.r.verify();
+  assert(myR.r.x == 1);
+}
+
+run();
+verify();
+

--- a/test/types/records/ferguson/leak-futures/record-in-record-generic.future
+++ b/test/types/records/ferguson/leak-futures/record-in-record-generic.future
@@ -1,0 +1,1 @@
+bug: record with generic field leaks memory


### PR DESCRIPTION
Totally generic fields in records/classes leak memory.

I believe an erroneous autoCopy is being added in buildDefaultWrapper (around line 297, in setting the variable copyTemp). Adding FLAG_INSERT_AUTO_DESTROY to this variable does not help because that flag is removed in cullForDefaultConstructor.

The problem is that scopeResolve creates a default constructor that already calls initCopy when setting the fields.

Simply removing the auto copy (on my arrays branch) led to core dumps.