### PR TITLE
Make standard atomics the default for clang when appropriate

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -7,7 +7,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_comm, chpl_compiler, chpl_platform, overrides
-from compiler_utils import CompVersion, get_compiler_version
+from compiler_utils import CompVersion, get_compiler_version, has_std_atomics
 from utils import memoize
 
 
@@ -45,7 +45,10 @@ def get(flag='target'):
             elif compiler_val == 'cray-prgenv-cray':
                 atomics_val = 'intrinsics'
             elif compiler_val == 'clang':
-                atomics_val = 'intrinsics'
+                if has_std_atomics(compiler_val):
+                    atomics_val = 'cstdlib'
+                else:
+                    atomics_val = 'intrinsics'
             elif compiler_val == 'clang-included':
                 atomics_val = 'intrinsics'
 

--- a/util/chplenv/compiler_utils.py
+++ b/util/chplenv/compiler_utils.py
@@ -12,14 +12,29 @@ from utils import memoize, run_command
 
 
 @memoize
+def get_compiler_name(compiler):
+    if compiler == 'aarch64-gnu':
+        return 'aarch64-unknown-linux-gnu-gcc'
+    elif 'gnu' in compiler:
+        return 'gcc'
+    elif compiler.startswith('cray-prgenv-'):
+        return 'cc'
+    elif compiler == 'clang':
+        return 'clang'
+    elif compiler == 'intel':
+        return 'icc'
+    elif compiler == 'pgi':
+        return 'pgcc'
+    return 'other'
+
+
+@memoize
 def get_compiler_version(compiler):
     version_string = '0'
-    if compiler == 'aarch64-gnu':
-        version_string = run_command(['aarch64-unknown-linux-gnu-gcc', '-dumpversion'])
-    elif 'gnu' in compiler:
+    if 'gnu' in compiler:
         # Asssuming the 'compiler' version matches the gcc version
         # e.g., `mpicc -dumpversion == gcc -dumpversion`
-        version_string = run_command(['gcc', '-dumpversion'])
+        version_string = run_command([get_compiler_name(compiler), '-dumpversion'])
     elif 'cray-prgenv-cray' == compiler:
         version_string = os.environ.get('CRAY_CC_VERSION', '0')
     return CompVersion(version_string)
@@ -49,3 +64,36 @@ def CompVersion(version_string):
 def compiler_is_prgenv(compiler_val):
   return (compiler_val.startswith('cray-prgenv') or
      os.environ.get('CHPL_ORIG_TARGET_COMPILER','').startswith('cray-prgenv'))
+
+
+#
+# Determine whether a given compiler's default compilation mode
+# supports standard atomics by running the compiler and checking
+# how it expands key feature-test macros.
+#
+# The assumption is that if standard atomics make it into the
+# compiler's default compilation mode, then they actually work.
+# If they are not available in the default mode, they probably
+# have problems and we don't want to use them.
+#
+# Due to the command-line options required, this works for GCC,
+# Clang, and the Intel compiler, but probably not others.
+#
+def has_std_atomics(compiler_val):
+    try:
+        compiler_name = get_compiler_name(compiler_val)
+        if compiler_name == 'other':
+            return False
+        cmd = "echo __STDC_VERSION__ __STDC_NO_ATOMICS__ | "
+        cmd += compiler_name + " -E -x c - | sed -e '/^\#/d'"
+        out = run_command(['sh', '-c', cmd]).split()
+        version = out[0].rstrip("L")
+        atomics = out[1]
+        if version == "__STDC_VERSION__" or int(version) < 201112:
+            return False
+        # If the atomics macro was expanded, then we do not have support.
+        if atomics != "__STDC_NO_ATOMICS__":
+            return False
+        return True
+    except:
+        return False

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -20,11 +20,13 @@ class CommandError(Exception):
 
 # This could be replaced by subprocess.check_output, but that isn't available
 # until python 2.7 and we only have 2.6 on most machines :(
-def run_command(command, stdout=True, stderr=False):
+def run_command(command, stdout=True, stderr=False, cmd_input=None):
     process = subprocess.Popen(command,
                                stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
-    output = process.communicate()
+                               stderr=subprocess.PIPE,
+                               stdin=subprocess.PIPE)
+    byte_cmd_input = str.encode(cmd_input) if cmd_input else None
+    output = process.communicate(input=byte_cmd_input)
     if process.returncode != 0:
         raise CommandError(
             "command `{0}` failed - output was \n{1}".format(command,


### PR DESCRIPTION
Make standard atomics the default for clang when they are supported in the default compilation mode (meaning whenever they are supported without a \-\-std=c11 command-line option).