### PR TITLE
Cleanup _desync functions

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3218,19 +3218,13 @@ module ChapelArray {
     chpl__tupleInit(j, a.rank, b);
   }
 
-  proc _desync(type t) where t: _syncvar {
+  proc _desync(type t) type where isSyncType(t) || isSingleType(t) {
     var x: t;
-    return x.wrapped.value;
+    return x.valType;
   }
 
-  proc _desync(type t) where t: _singlevar {
-    var x: t;
-    return x.wrapped.value;
-  }
-
-  proc _desync(type t) {
-    var x: t;
-    return x;
+  proc _desync(type t) type {
+    return t;
   }
 
   proc =(ref a: [], b: _desync(a.eltType)) {


### PR DESCRIPTION
The _desync functions are used to implement assignment between an array of
syncs and a non-sync base type. i.e. it's used to support:

```chapel
proc =(ref a: [], b: _desync(a.eltType)) {
  forall e in a do e = b;
}

var s$: [1..10] sync valType = 1:valType;
```

Previously _desync returned `x.wrapped.value` but `wrapped` and `value` are
private/implementation specific names. Also `value` is a variable that the
compiler then had to convert to a type anyway since _desync is only used in the
context of a type expression.

To avoid using private names, this commit changes `return x.wrapped.value` to
`return x.valType`. Note that `sync.valType` is still "private" in some sense,
but sync.valType is part of the interface that the compiler expects for sync
variables.

This commit also explicitly marks _desync as a type function and re-merges
_desync for sync and single into a single function. With df90eae (sync but not
single as record) they temporarily needed to be different functions, but no
longer.

This it motivated by an upcoming native sync patch where the wrapped sync
record won't have a `value` field.
