### PR TITLE
Fix documentation pertaining to PR #4471.

### DIFF
--- a/doc/release/launcher.rst
+++ b/doc/release/launcher.rst
@@ -99,9 +99,7 @@ Forwarding Environment Variables
 Chapel launchers generally arrange for environment variables to be
 forwarded to worker processes. However, this strategy is not always
 reliable. The remote system may override some environment variables, and
-some launchers might not correctly forward all environment variables.  In
-particular, the amudprun launcher will not forward environment variables
-containing backticks (`).
+some launchers might not correctly forward all environment variables.
 
 
 ---------------------------------


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/4471 we removed a
workaround that ignored environment variables whose values contained
back-tics, when forwarding the environment to the _real program started
by the GASNet amudprun launcher.  Unfortunately I missed that there was
documentation describing that behavior.  Update it now.