### PR TITLE
Minor fixes for distributions

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1194,6 +1194,7 @@ proc BlockArr.dsiSerialWrite(f) {
 }
 
 proc BlockArr.dsiSlice(d: BlockDom) {
+  // MPF: should this use sparseLayoutType = d.sparseLayoutType ?
   var alias = new BlockArr(eltType=eltType, rank=rank, idxType=idxType,
       stridable=d.stridable, dom=d, sparseLayoutType=DefaultDist);
   var thisid = this.locale.id;
@@ -1459,8 +1460,18 @@ proc BlockArr.dsiPrivatize(privatizeData) {
   return c;
 }
 
-proc BlockArr.dsiSupportsBulkTransfer() param return true;
-proc BlockArr.dsiSupportsBulkTransferInterface() param return true;
+proc BlockArr.dsiSupportsBulkTransfer() param {
+  if sparseLayoutType != DefaultDist then
+    return false;
+  else
+    return true;
+}
+proc BlockArr.dsiSupportsBulkTransferInterface() param {
+   if sparseLayoutType != DefaultDist then
+    return false;
+  else
+    return true;
+}
 
 proc BlockArr.doiCanBulkTransfer() {
   if debugBlockDistBulkTransfer then

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -454,7 +454,10 @@ proc Block.dsiEqualDMaps(that) param {
 proc Block.dsiClone() {
   return new Block(boundingBox, targetLocales,
                    dataParTasksPerLocale, dataParIgnoreRunningTasks,
-                   dataParMinGranularity);
+                   dataParMinGranularity,
+                   rank,
+                   idxType,
+                   sparseLayoutType);
 }
 
 proc Block.dsiDestroyDistClass() {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -886,8 +886,8 @@ proc CyclicArr.dsiPrivatize(privatizeData) {
 
 
 inline proc _remoteAccessData.getDataIndex(
-    param stridable, myStr:
-    rank*chpl__signedType(idxType),
+    param stridable,
+    myStr: rank*chpl__signedType(idxType),
     ind: rank*idxType,
     startIdx,
     dimLen) {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -885,7 +885,12 @@ proc CyclicArr.dsiPrivatize(privatizeData) {
 }
 
 
-inline proc _remoteAccessData.getDataIndex(param stridable, myStr: rank*idxType, ind: rank*idxType, startIdx, dimLen) {
+inline proc _remoteAccessData.getDataIndex(
+    param stridable, myStr:
+    rank*chpl__signedType(idxType),
+    ind: rank*idxType,
+    startIdx,
+    dimLen) {
   // modified from DefaultRectangularArr
   var sum = origin;
   if stridable {
@@ -935,7 +940,8 @@ proc CyclicArr.dsiAccess(i:rank*idxType) ref {
       if radata(rlocIdx).data != nil {
         const startIdx = myLocArr.locCyclicRAD.startIdx;
         const dimLength = myLocArr.locCyclicRAD.targetLocDomDimLength;
-        var str: rank*idxType;
+        type strType = chpl__signedType(idxType);
+        var str: rank*strType;
         for param i in 1..rank {
           pragma "no copy" pragma "no auto destroy" var whole = dom.whole;
           str(i) = whole.dim(i).stride;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1666,9 +1666,10 @@ module DefaultRectangular {
     compilerAssert(Aarr.rank == Barr.rank);
     const b = chpl__tuplify(bArg);
     param rank = Aarr.rank;
+    type idxType = Aarr.idxType;
     const AD = Aarr.dom.dsiDims();
     const BD = Barr.dom.dsiDims();
-    var result: rank * int;
+    var result: rank * idxType;
     for param i in 1..rank {
       const ar = AD(i), br = BD(i);
       if boundsChecking then assert(br.member(b(i)));


### PR DESCRIPTION
These fixes solve compilation problems that occur on my arrays branch. The arrays branch instantiates chpl__initCopy for each array type and that seems to reveal some simple problems with type mismatches.

The main non-trivial change here is to adjust BlockArr.dsiSupportsBulkTransfer and BlockArr.dsiSupportsBulkTransferInterface to return false when a sparseLayoutType has been set to something other than DefaultDist. This avoids compilation errors on the arrays branch when such an array's initCopy is resolved (and the initCopy in turn tries to use dsiSlice which is probably wrong - see the comment added there).

Note that sparse arrays don't currently support slicing at all.

Passed quickstart testing, local testing, and GASNet testing of distributions/ and release/examples/.
Reviewed by @benharsh - thanks!
