### PR TITLE
Denormalization should consider the LHS of MOVEs

### DIFF
--- a/compiler/include/exprAnalysis.h
+++ b/compiler/include/exprAnalysis.h
@@ -57,7 +57,7 @@ class SafeExprAnalysis {
   public:
     bool isNonEssentialPrimitive(CallExpr* ce);
 
-    bool exprHasNoSideEffects(Expr* e);
+    bool exprHasNoSideEffects(Expr* e, Expr* exprToMove);
     bool fnHasNoSideEffects(FnSymbol* fn);
 
     bool isSafePrimitive(CallExpr* ce);

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -35,7 +35,7 @@ typedef std::map<SymExpr*, DefCastPair> UseDefCastMap;
 
 //prototypes
 bool primMoveGeneratesCommCall(CallExpr* ce);
-inline bool unsafeExprInBetween(Expr* e1, Expr* e2,
+inline bool unsafeExprInBetween(Expr* e1, Expr* e2, Expr* exprToMove,
     SafeExprAnalysis& analysisData);
 inline bool requiresCast(Type* t);
 inline bool isIntegerPromotionPrimitive(PrimitiveTag tag);
@@ -218,8 +218,8 @@ void findCandidatesInFuncOnlySym(FnSymbol* fn, Vec<Symbol*> symVec,
 
       //denormalize if the def is safe to move and there is no unsafe
       //function between use and def
-      if(analysisData.exprHasNoSideEffects(def)) {
-        if(!unsafeExprInBetween(def, use, analysisData)) {
+      if(analysisData.exprHasNoSideEffects(def, NULL)) {
+        if(!unsafeExprInBetween(def, use, def, analysisData)) {
           DefCastPair defCastPair(def, castTo);
           udcMap.insert(std::pair<SymExpr*, DefCastPair>
               (use, defCastPair));
@@ -489,11 +489,11 @@ bool primMoveGeneratesCommCall(CallExpr* ce) {
 }
 
 
-inline bool unsafeExprInBetween(Expr* e1, Expr* e2,
+inline bool unsafeExprInBetween(Expr* e1, Expr* e2, Expr* exprToMove,
     SafeExprAnalysis& analysisData){
   int counter = 0;
   for(Expr* e = e1; e != e2 ; e = getNextExpr(e)) {
-    if(! analysisData.exprHasNoSideEffects(e)) {
+    if(! analysisData.exprHasNoSideEffects(e, exprToMove)) {
       return true;
     }
     

--- a/compiler/util/exprAnalysis.cpp
+++ b/compiler/util/exprAnalysis.cpp
@@ -28,6 +28,7 @@
  *  - Read/write to a global
  *  - Is/contains essential primitive
  *  - If it's a call to functions with ref arguments
+ *  - If the LHS of a PRIM_MOVE appears in the exprToMove
  *
  * For now, this is a very conservative analysis. A more precise analysis
  * could distinguish between reads and writes to memory and to take into


### PR DESCRIPTION
While working on another branch I observed that denormalization could
transform the following AST:

(move T (+ A B))
(move A B)
(move B T)

into this incorrect pattern:

(move A B)
(move B (+ A B))

It turned out that denormalization wasn't recognizing the 'move A B'
call inbetween the first and last expressions.

This does not appear to have a significant impact on denormalization's
effectiveness at this time.

Based on patch received from @e-kayrakli 

Successfully passed the following testing configs:
- [x] --local
- [x] --no-local
- [x] gasnet