### PR TITLE
Add initial support for using native qthread sync variables

### DIFF
--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -39,5 +39,6 @@ Initializing Modules:
     ChapelDynDispHack
     Assert
     CommDiagnostics
+    AlignedTSupport
    printModuleInitOrder
     moduleInitTest


### PR DESCRIPTION
Add support to map int/uint/bool sync vars down to native qthreads aligned_t
sync vars. It's not enabled by default yet, because the current qthreads
release is missing some FEB operations. I contributed them upstream, and they
will be in the next release, at which point these sync vars can be enabled by
default.

For "simple" sync var types, we can directly use the aligned_t qthreads FEB
routines instead of using the heavyweight routines that we've traditionally
used. This support is loosely modeled after the fast syncvars that we used for
MTA. That code was added with 8503f6e removed with d7707439.

#3192 has more details on the history of sync vars and why the implementation
has traditionally been so heavyweight. Short version is that we used to allow
arbitrary types to be sync, but we're moving towards just primitives being
allowed.

Native sync vars should drastically improve the performance of highly contended
sync variables. e.g. threadring is over 6 times faster with native qthread
sync vars. The main reason for this is because qthreads will actually
de-schedule tasks that are blocked on a native sync var. Our other
implementation has to lock before any operation, and that lock is implemented
with a spin-wait. This often led to thrashing and bogging down the scheduler.

Future work:
 - extend support to single vars
 - extend support for more base types
   - currently integral and bool only, expand to all primitives <= 64-bit
 - better yielding policy for readXX
 - use native sync vars on 32-bit platforms for <= 32-bit base types
   - currently all aligned_t sync vars are broken on 32-bit platforms (qthreads bug)

See JIRA 249 for more info: https://chapel.atlassian.net/browse/CHAPEL-249
