### PR TITLE
Cleanup the intrinsics atomic implementation

### DIFF
--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -38,8 +38,8 @@ typedef uint_least32_t atomic_uint_least32_t;
 typedef uint_least64_t atomic_uint_least64_t;
 typedef uintptr_t atomic_uintptr_t;
 typedef chpl_bool atomic_bool;
-typedef _real64 atomic__real64;
-typedef _real32 atomic__real32;
+typedef uint64_t atomic__real64;
+typedef uint64_t atomic__real32;
 
 typedef enum {
  memory_order_relaxed,
@@ -108,8 +108,7 @@ static inline void atomic_store_ ## type(atomic_ ## type * obj, basetype value) 
   atomic_store_explicit_ ## type(obj, value, memory_order_seq_cst); \
 } \
 static inline basetype atomic_load_explicit_ ## type(atomic_ ## type * obj, memory_order order) { \
-  full_memory_barrier(); \
-  return *obj; \
+  return __sync_val_compare_and_swap(obj, (basetype)0, (basetype)0); \
 } \
 static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
   return atomic_load_explicit_ ## type(obj, memory_order_seq_cst); \
@@ -121,10 +120,10 @@ static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_ATOMICS_EXCHANGE_OPS(type, basetype) \
 static inline basetype atomic_exchange_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
-  basetype volatile ret; \
-  basetype volatile old_val; \
+  basetype ret = *obj; \
+  basetype old_val; \
   do { \
-    old_val = *obj; \
+    old_val = ret; \
     ret = __sync_val_compare_and_swap(obj, old_val, value); \
   } while(ret != old_val); \
   return ret; \
@@ -195,25 +194,28 @@ static inline chpl_bool atomic_is_lock_free_ ## type(atomic_ ## type * obj) { \
 } \
 static inline void atomic_init_ ## type(atomic_ ## type * obj, type value) { \
   assert(sizeof(type) == sizeof(uinttype)); \
-  *obj = value; \
+  memcpy(obj, &value, sizeof(*obj)); \
 } \
 static inline void atomic_destroy_ ## type(atomic_ ## type * obj) { \
 } \
 static inline void atomic_store_explicit_ ## type(atomic_ ## type * obj, type value, memory_order order) { \
-  uinttype ret_uint = *(uinttype *)obj; \
-  uinttype val_uint = *(uinttype *)&value; \
+  uinttype ret_uint = *obj; \
+  uinttype val_uint; \
   uinttype old_uint; \
+  memcpy(&val_uint, &value, sizeof(val_uint)); \
   do { \
     old_uint = ret_uint; \
-    ret_uint = __sync_val_compare_and_swap((uinttype *)obj, old_uint, val_uint); \
+    ret_uint = __sync_val_compare_and_swap(obj, old_uint, val_uint); \
   } while (ret_uint != old_uint); \
 } \
 static inline void atomic_store_ ## type(atomic_ ## type * obj, type value) { \
   atomic_store_explicit_ ## type(obj, value, memory_order_seq_cst); \
 } \
 static inline type atomic_load_explicit_ ## type(atomic_ ## type * obj, memory_order order) { \
-  full_memory_barrier(); \
-  return *obj; \
+  type ret; \
+  uinttype ret_uint = __sync_fetch_and_or(obj, (uinttype)0); \
+  memcpy(&ret, &ret_uint, sizeof(ret)); \
+  return ret; \
 } \
 static inline type atomic_load_ ## type(atomic_ ## type * obj) { \
   return atomic_load_explicit_ ## type(obj, memory_order_seq_cst); \
@@ -224,39 +226,28 @@ static inline type atomic_load_ ## type(atomic_ ## type * obj) { \
 ////                START OF REAL ATOMICS EXCHANGE OPS                    ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_REAL_ATOMICS_EXCHANGE_OPS(type, uinttype) \
-static inline type atomic_exchange_explicit_ ## type(atomic_ ## type * obj, type _value, memory_order order) { \
-  type volatile ret; \
-  type volatile *ret_p; \
-  type volatile value; \
-  uinttype volatile value_as_uint; \
-  uinttype volatile ret_as_uint; \
-  uinttype volatile * value_as_uint_p; \
-  uinttype volatile old_val_as_uint; \
-  value = _value; \
-  ret_p = (type volatile *) &ret_as_uint; \
-  value_as_uint_p = (uinttype volatile *) &value; \
-  value_as_uint = *value_as_uint_p; \
+static inline type atomic_exchange_explicit_ ## type(atomic_ ## type * obj, type value, memory_order order) { \
+  type ret; \
+  uinttype value_as_uint; \
+  uinttype ret_as_uint = *obj; \
+  uinttype old_val_as_uint; \
+  memcpy(&value_as_uint, &value, sizeof(value_as_uint)); \
   do { \
-    old_val_as_uint = *(uinttype*)obj; \
-    ret_as_uint = __sync_val_compare_and_swap((uinttype *)obj, old_val_as_uint, value_as_uint); \
+    old_val_as_uint = ret_as_uint; \
+    ret_as_uint = __sync_val_compare_and_swap(obj, old_val_as_uint, value_as_uint); \
   } while(ret_as_uint != old_val_as_uint); \
-  ret = *ret_p; \
+  memcpy(&ret, &ret_as_uint, sizeof(ret)); \
   return ret; \
 } \
 static inline type atomic_exchange_ ## type(atomic_ ## type * obj, type value) { \
   return atomic_exchange_explicit_ ## type(obj, value, memory_order_seq_cst); \
 } \
 static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(atomic_ ## type * obj, type expected, type desired, memory_order order) { \
-  uinttype volatile expected_as_uint; \
-  uinttype volatile desired_as_uint; \
-  uinttype volatile * expected_as_uint_p; \
-  uinttype volatile * desired_as_uint_p; \
-  full_memory_barrier(); \
-  expected_as_uint_p = (uinttype volatile *) &expected; \
-  desired_as_uint_p = (uinttype volatile *) &desired; \
-  expected_as_uint = *expected_as_uint_p; \
-  desired_as_uint = *desired_as_uint_p; \
-  return my__sync_bool_compare_and_swap((uinttype *) obj, expected_as_uint, desired_as_uint); \
+  uinttype expected_as_uint; \
+  uinttype desired_as_uint; \
+  memcpy(&expected_as_uint, &expected, sizeof(expected_as_uint)); \
+  memcpy(&desired_as_uint, &desired, sizeof(desired_as_uint)); \
+  return my__sync_bool_compare_and_swap(obj, expected_as_uint, desired_as_uint); \
 } \
 static inline chpl_bool atomic_compare_exchange_strong_ ## type(atomic_ ## type * obj, type expected, type desired) { \
   return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, memory_order_seq_cst); \
@@ -274,49 +265,41 @@ static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * 
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_REAL_ATOMICS_FETCH_OPS(type, uinttype) \
 static inline type atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
-  int success; \
-  type volatile cur; \
-  type volatile desired; \
-  uinttype volatile cur_as_uint; \
-  uinttype volatile desired_as_uint; \
-  uinttype volatile * cur_as_uint_p; \
-  uinttype volatile * desired_as_uint_p; \
-  cur_as_uint_p = (uinttype volatile *) &cur; \
-  desired_as_uint_p = (uinttype volatile *) &desired; \
-  success = false; \
-  while(!success) { \
-    full_memory_barrier(); \
-    cur = *obj; \
-    desired = cur + operand; \
-    cur_as_uint = *cur_as_uint_p; \
-    desired_as_uint = *desired_as_uint_p; \
-    success = my__sync_bool_compare_and_swap((uinttype *) obj, cur_as_uint, desired_as_uint); \
-  } \
-  return cur; \
+  type ret; \
+  type old; \
+  type desired; \
+  uinttype ret_as_uint = *obj; \
+  uinttype old_as_uint; \
+  uinttype desired_as_uint; \
+  do { \
+    old_as_uint = ret_as_uint; \
+    memcpy(&old, &old_as_uint, sizeof(old)); \
+    desired = old + operand; \
+    memcpy(&desired_as_uint, &desired, sizeof(desired_as_uint)); \
+    ret_as_uint = __sync_val_compare_and_swap(obj, old_as_uint, desired_as_uint); \
+  } while (ret_as_uint != old_as_uint); \
+  memcpy(&ret, &ret_as_uint, sizeof(ret)); \
+  return ret; \
 } \
 static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
   return atomic_fetch_add_explicit_ ## type(obj, operand, memory_order_seq_cst); \
 } \
 static inline type atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
-  int success; \
-  type volatile cur; \
-  type volatile desired; \
-  uinttype volatile cur_as_uint; \
-  uinttype volatile desired_as_uint; \
-  uinttype volatile * cur_as_uint_p; \
-  uinttype volatile * desired_as_uint_p; \
-  cur_as_uint_p = (uinttype volatile *) &cur; \
-  desired_as_uint_p = (uinttype volatile *) &desired; \
-  success = false; \
-  while(!success) { \
-    full_memory_barrier(); \
-    cur = *obj; \
-    desired = cur - operand; \
-    cur_as_uint = *cur_as_uint_p; \
-    desired_as_uint = *desired_as_uint_p; \
-    success =  my__sync_bool_compare_and_swap((uinttype *) obj, cur_as_uint, desired_as_uint); \
-  } \
-  return cur; \
+  type ret; \
+  type old; \
+  type desired; \
+  uinttype ret_as_uint = *obj; \
+  uinttype old_as_uint; \
+  uinttype desired_as_uint; \
+  do { \
+    old_as_uint = ret_as_uint; \
+    memcpy(&old, &old_as_uint, sizeof(old)); \
+    desired = old - operand; \
+    memcpy(&desired_as_uint, &desired, sizeof(desired_as_uint)); \
+    ret_as_uint = __sync_val_compare_and_swap(obj, old_as_uint, desired_as_uint); \
+  } while (ret_as_uint != old_as_uint); \
+  memcpy(&ret, &ret_as_uint, sizeof(ret)); \
+  return ret; \
 } \
 static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \
   return atomic_fetch_sub_explicit_ ## type(obj, operand, memory_order_seq_cst); \

--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -39,7 +39,7 @@ typedef uint_least64_t atomic_uint_least64_t;
 typedef uintptr_t atomic_uintptr_t;
 typedef chpl_bool atomic_bool;
 typedef uint64_t atomic__real64;
-typedef uint64_t atomic__real32;
+typedef uint32_t atomic__real32;
 
 typedef enum {
  memory_order_relaxed,


### PR DESCRIPTION
In the intrinsics implementation of atomics, this change:
* Makes atomic_load always atomic.  Before, 64-bit atomic_load on a 32-bit machine was not atomic.
* Eliminates all type punning, by making atomic__real* into integer types and using memcpy to switch back and forth with the _real* types.
* Eliminates all use of volatile.  With this cleanup, volatile is no longer needed.
