### PR TITLE
Update old comment in slurm launcher

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -61,28 +61,10 @@ typedef enum {
   unknown
 } sbatchVersion;
 
-// Find the default tmp directory. Try getting the tmp dir from the
-// ISO/IEC 9945 env var options first, then P_tmpdir, then "/tmp"
+// /tmp is always available on cray compute nodes (it's a memory mounted dir.)
+// If we ever need this to run on non-cray machines, we should update this to
+// look for the ISO/IEC 9945 env var options first, then P_tmpdir, then "/tmp"
 static const char* getTmpDir(void) {
-// TODO Elliot (02/15/15): I'm temporarily disabling this logic and just using
-// '/tmp' to see if it resolves the single local xc perf testing failures. We
-// set TMPDIR in one of our common scripts. We then make that dir on the login
-// node, but not on the compute nodes, so the program can't actually put it's
-// output anywhere. If this resolves the issues, I'll update the launcher to
-// do something smarter like create the temp dir before running and remove it
-// afterwards.
-//
-//  int i;
-//  const char* possibleDirsInEnv[] = {"TMPDIR", "TMP", "TEMP", "TEMPDIR"};
-//  for (i = 0; i < (sizeof(possibleDirsInEnv) / sizeof(char*)); i++) {
-//    const char* curDir = getenv(possibleDirsInEnv[i]);
-//    if (curDir != NULL) {
-//      return curDir;
-//    }
-//  }
-//#ifdef P_tmpdir
-//  return P_tmpdir;
-//#endif
   return "/tmp";
 }
 


### PR DESCRIPTION
Update a comment about how/why we get the /tmp dir for buffering stdout on
cray machines