### PR TITLE
Add clang correctness and performance jobs

### DIFF
--- a/util/cron/test-linux64-clang38.bash
+++ b/util/cron/test-linux64-clang38.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Test linux64 + clang 3.8 on examples only
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+source /data/cf/chapel/setup_clang38.bash     # host-specific setup for target compiler
+export CHPL_HOST_COMPILER=clang
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-clang38"
+
+$CWD/nightly -cron -examples ${nightly_args}

--- a/util/cron/test-perf.chapcs.clang.bash
+++ b/util/cron/test-perf.chapcs.clang.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
+
+source $CWD/common-perf.bash
+
+source /data/cf/chapel/setup_clang38.bash
+export CHPL_HOST_COMPILER=clang
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.clang"
+
+SHORT_NAME=clang
+START_DATE=09/10/16
+
+perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
+perf_args="${perf_args} -performance -numtrials 5 -startdate $START_DATE"
+
+$CWD/nightly -cron ${nightly_args} ${perf_args}


### PR DESCRIPTION
DavidK installed clang 3.8 on chap and chapcs boxes. Use it to do some
correctness and performance testing. This is primarily motived by wanting to
see the performance impact of using cstdlib atomics with clang, but it'll also
be interesting to compare clang's performance to gcc.