### PR TITLE
Encapsulate internal module uses of Sort & Search

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -134,12 +134,14 @@ class SparseBlockDom: BaseSparseDomImpl {
   }
 
   proc bulkAdd_help(inds: [] index(rank,idxType),
-      isSorted=false, isUnique=false) {
+      dataSorted=false, isUnique=false) {
+    use Sort;
+    use Search;
 
     // without _new_, record functions throw null deref
     var comp = new TargetLocaleComparator();
 
-    if !isSorted then sort(inds, comparator=comp);
+    if !dataSorted then sort(inds, comparator=comp);
 
     var localeRanges: [dist.targetLocDom] range;
     on inds {
@@ -167,7 +169,7 @@ class SparseBlockDom: BaseSparseDomImpl {
     var _totalAdded: atomic int;
     coforall l in dist.targetLocDom do on dist.targetLocales[l] {
       const _retval = locDoms[l].mySparseBlock.bulkAdd(inds[localeRanges[l]],
-          isSorted=true, isUnique=false);
+          dataSorted=true, isUnique=false);
       _totalAdded.add(_retval);
     }
     const _retval = _totalAdded.read();

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1044,20 +1044,20 @@ module ChapelArray {
       return _value.dsiAdd(i);
     }
 
-    proc bulkAdd(inds: [] _value.idxType, isSorted=false,
+    proc bulkAdd(inds: [] _value.idxType, dataSorted=false,
         isUnique=false, preserveInds=true) where isSparseDom(this) && _value.rank==1 {
 
       if inds.size == 0 then return 0;
 
-      return _value.dsiBulkAdd(inds, isSorted, isUnique, preserveInds);
+      return _value.dsiBulkAdd(inds, dataSorted, isUnique, preserveInds);
     }
 
-    proc bulkAdd(inds: [] _value.rank*_value.idxType, isSorted=false,
+    proc bulkAdd(inds: [] _value.rank*_value.idxType, dataSorted=false,
         isUnique=false, preserveInds=true) where isSparseDom(this) && _value.rank>1 {
 
       if inds.size == 0 then return 0;
 
-      return _value.dsiBulkAdd(inds, isSorted, isUnique, preserveInds);
+      return _value.dsiBulkAdd(inds, dataSorted, isUnique, preserveInds);
     }
 
     /* Remove index ``i`` from this domain */

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -236,19 +236,19 @@ module ChapelDistribution {
     var nnzDom = {1..nnz};
 
     proc dsiBulkAdd(inds: [] index(rank, idxType),
-        isSorted=false, isUnique=false, preserveInds=true){
+        dataSorted=false, isUnique=false, preserveInds=true){
 
-      if !isSorted && preserveInds {
+      if !dataSorted && preserveInds {
         var _inds = inds;
-        return bulkAdd_help(_inds, isSorted, isUnique); 
+        return bulkAdd_help(_inds, dataSorted, isUnique); 
       }
       else {
-        return bulkAdd_help(inds, isSorted, isUnique);
+        return bulkAdd_help(inds, dataSorted, isUnique);
       }
     }
 
     proc bulkAdd_help(inds: [?indsDom] index(rank, idxType), 
-        isSorted=false, isUnique=false){
+        dataSorted=false, isUnique=false){
       halt("Helper function called on the BaseSparseDomImpl");
 
       return -1;
@@ -276,14 +276,16 @@ module ChapelDistribution {
     // be refactored. (I think it is a safe assumption at this point and keeps the
     // function a bit cleaner than some other approach. -Engin)
     proc __getActualInsertPts(d, inds, 
-        isIndsSorted, isUnique) /* where isSparseDom(d) */ {
+        dataSorted, isUnique) /* where isSparseDom(d) */ {
+
+      use Sort;
 
       //find individual insert points
       //and eliminate duplicates between inds and dom
       var indivInsertPts: [inds.domain] int;
       var actualInsertPts: [inds.domain] int; //where to put in newdom
 
-      if !isIndsSorted then sort(inds);
+      if !dataSorted then sort(inds);
 
       //eliminate duplicates --assumes sorted
       if !isUnique {
@@ -297,11 +299,8 @@ module ChapelDistribution {
 
       //verify sorted and no duplicates if not --fast
       if boundsChecking {
-        // TODO there seems to be a bug while resolving Sort.isSorted, therefore
-        // for this function the argument is still isIndsSorted, instead of
-        // isSorted. This should be changed when Sort.isSorted is working.
         if !isSorted(inds) then
-          halt("bulkAdd: Data not sorted, call the function with isSorted=false");
+          halt("bulkAdd: Data not sorted, call the function with dataSorted=false");
 
         //check duplicates assuming sorted
         const indsStart = inds.domain.low;
@@ -362,7 +361,7 @@ module ChapelDistribution {
     }
   
     proc dsiBulkAdd(inds: [] index(rank, idxType),
-        isSorted=false, isUnique=false, preserveInds=true){
+        dataSorted=false, isUnique=false, preserveInds=true){
 
       halt("Bulk addition is not supported by this sparse domain");
     }

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -179,7 +179,6 @@ read in the output of the default ``write`` method.
 module ChapelIO {
   use ChapelBase; // for uint().
   use SysBasic;
-  // use IO; happens below once we need it.
   
   // TODO -- this should probably be private
   pragma "no doc"

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -84,9 +84,7 @@
 
  */
 module ChapelRange {
-  
-  use Math; // for abs().
-  
+
   // Turns on range iterator debugging.
   pragma "no doc"
   config param debugChapelRange = false;

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -85,6 +85,8 @@
  */
 module ChapelRange {
 
+  use Math;
+
   // Turns on range iterator debugging.
   pragma "no doc"
   config param debugChapelRange = false;

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -20,27 +20,25 @@
 // DefaultAssociative.chpl
 //
 module DefaultAssociative {
-  
+
   use DSIUtil;
   config param debugDefaultAssoc = false;
   config param debugAssocDataPar = false;
-  
-  use Sort; /* only sort */;
-  
+
   // TODO: make the domain parameterized by this?
   type chpl_table_index_type = int;
-  
-  
+
+
   /* These declarations could/should both be nested within
      DefaultAssociativeDom? */
   enum chpl__hash_status { empty, full, deleted };
-  
+
   record chpl_TableEntry {
     type idxType;
     var status: chpl__hash_status = chpl__hash_status.empty;
     var idx: idxType;
   }
-  
+
   proc chpl__primes return
   (23, 53, 89, 191, 383, 761, 1531, 3067, 6143, 12281, 24571, 49139, 98299,
    196597, 393209, 786431, 1572853, 3145721, 6291449, 12582893, 25165813,
@@ -429,6 +427,7 @@ module DefaultAssociative {
     }
   
     iter dsiSorted() {
+      use Sort;
       var tableCopy: [0..#numEntries.read()] idxType;
   
       for (tmp, slot) in zip(tableCopy.domain, _fullSlots()) do
@@ -699,6 +698,7 @@ module DefaultAssociative {
     //
   
     iter dsiSorted() {
+      use Sort;
       var tableCopy: [0..dom.dsiNumIndices-1] eltType;
       for (copy, slot) in zip(tableCopy.domain, dom._fullSlots()) do
         tableCopy(copy) = data(slot);

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -236,11 +236,11 @@ module DefaultSparse {
       }
     }
 
-    proc bulkAdd_help(inds: [?indsDom] index(rank, idxType), isSorted=false, 
+    proc bulkAdd_help(inds: [?indsDom] index(rank, idxType), dataSorted=false,
         isUnique=false){
 
       const (actualInsertPts, actualAddCnt) =
-        __getActualInsertPts(this, inds, isSorted, isUnique);
+        __getActualInsertPts(this, inds, dataSorted, isUnique);
 
       const oldnnz = nnz;
       nnz += actualAddCnt;

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -21,7 +21,6 @@
 //
 module DefaultSparse {
 
-  use Search;
   config param debugDefaultSparse = false;
 
   class DefaultSparseDom: BaseSparseDomImpl {
@@ -115,6 +114,7 @@ module DefaultSparse {
 
     // private
     proc find(ind) {
+      use Search;
       //
       // sjd: unfortunate specialization for rank == 1
       //

--- a/modules/internal/startInitCommDiags.chpl
+++ b/modules/internal/startInitCommDiags.chpl
@@ -23,14 +23,13 @@
 // and teardown.  See that module (or its chpldocs) for details.
 //
 module startInitCommDiags {
+  use CommDiagnostics;
 
   if printInitVerboseComm {
-    use CommDiagnostics;
     startVerboseComm();
   }
 
   if printInitCommCounts {
-    use CommDiagnostics;
     startCommDiagnostics();
   }
 }

--- a/modules/internal/startInitCommDiags.chpl
+++ b/modules/internal/startInitCommDiags.chpl
@@ -23,13 +23,14 @@
 // and teardown.  See that module (or its chpldocs) for details.
 //
 module startInitCommDiags {
-  use CommDiagnostics;
 
   if printInitVerboseComm {
+    use CommDiagnostics;
     startVerboseComm();
   }
 
   if printInitCommCounts {
+    use CommDiagnostics;
     startCommDiagnostics();
   }
 }

--- a/modules/internal/stopInitCommDiags.chpl
+++ b/modules/internal/stopInitCommDiags.chpl
@@ -23,14 +23,13 @@
 // and teardown.  See that module (or its chpldocs) for details.
 //
 module stopInitCommDiags {
+  use CommDiagnostics;
 
   if printInitVerboseComm {
-    use CommDiagnostics;
     stopVerboseComm();
   }
 
   if printInitCommCounts {
-    use CommDiagnostics;
     stopCommDiagnostics();
     writeln(getCommDiagnostics());
     resetCommDiagnostics();

--- a/modules/internal/stopInitCommDiags.chpl
+++ b/modules/internal/stopInitCommDiags.chpl
@@ -23,13 +23,14 @@
 // and teardown.  See that module (or its chpldocs) for details.
 //
 module stopInitCommDiags {
-  use CommDiagnostics;
 
   if printInitVerboseComm {
+    use CommDiagnostics;
     stopVerboseComm();
   }
 
   if printInitCommCounts {
+    use CommDiagnostics;
     stopCommDiagnostics();
     writeln(getCommDiagnostics());
     resetCommDiagnostics();

--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -18,7 +18,6 @@
  */
 
 config param debugCSR = false;
-use Sort;
 
 // In the following, I insist on SUBdomains because
 // I have not seen us test a non-"sub" CSR domain
@@ -284,11 +283,11 @@ class CSRDom: BaseSparseDomImpl {
     return 1;
   }
 
-  proc bulkAdd_help(inds: [?indsDom] rank*idxType, isSorted=false, 
+  proc bulkAdd_help(inds: [?indsDom] rank*idxType, dataSorted=false,
       isUnique=false){
 
     const (actualInsertPts, actualAddCnt) =
-      __getActualInsertPts(this, inds, isSorted, isUnique);
+      __getActualInsertPts(this, inds, dataSorted, isUnique);
 
     const oldnnz = nnz;
     nnz += actualAddCnt;

--- a/test/arrays/diten/timeVectorArray.chpl
+++ b/test/arrays/diten/timeVectorArray.chpl
@@ -1,4 +1,4 @@
-use Random, Time;
+use Random, Time, Search, Sort;
 
 config const n: int = 30000;
 const linearN: int = n/1000; // problem size for slow "linear" opeations

--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -321,6 +321,7 @@ class UserMapAssocDom: BaseAssociativeDom {
   }
 
   iter dsiSorted() {
+    use Sort;
     // This function creates a local copy of an entire distributed
     // data structure, which is probably a bad idea.
     // Alternatives include:

--- a/test/distributions/bradc/assoc/userAssoc-array-noelt.good
+++ b/test/distributions/bradc/assoc/userAssoc-array-noelt.good
@@ -1,1 +1,1 @@
-./UserMapAssoc.chpl:827: error: halt reached - array index out of bounds: 22.0
+./UserMapAssoc.chpl:nnnn: error: halt reached - array index out of bounds: 22.0

--- a/test/distributions/robust/associative/performance/array_iter.chpl
+++ b/test/distributions/robust/associative/performance/array_iter.chpl
@@ -1,4 +1,4 @@
-use Memory, Types, Time;
+use Memory, Types, Time, Sort;
 
 config const printTiming = false;
 config const verify = true;

--- a/test/distributions/robust/associative/performance/domain_iter.chpl
+++ b/test/distributions/robust/associative/performance/domain_iter.chpl
@@ -1,4 +1,4 @@
-use Memory, Types, Time;
+use Memory, Types, Time, Sort;
 
 config const printTiming = false;
 config const verify = true;

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -29,13 +29,13 @@ Parsing module files:
   $CHPL_HOME/modules/standard/Sys.chpl
   $CHPL_HOME/modules/dists/DSIUtil.chpl
   $CHPL_HOME/modules/standard/List.chpl
+  $CHPL_HOME/modules/packages/Sort.chpl
   $CHPL_HOME/modules/standard/SysBasic.chpl
   $CHPL_HOME/modules/standard/IO.chpl
-  $CHPL_HOME/modules/packages/Sort.chpl
   $CHPL_HOME/modules/packages/Search.chpl
+  $CHPL_HOME/modules/standard/Reflection.chpl
   $CHPL_HOME/modules/standard/Error.chpl
   $CHPL_HOME/modules/standard/Regexp.chpl
-  $CHPL_HOME/modules/standard/Reflection.chpl
 In bar
 In baz
 In bak

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -26,13 +26,13 @@ Initializing Modules:
     LocalesArray
     ChapelDistribution
      List
+     Sort
     ChapelIO
      IO
       Error
       Regexp
     LocaleTree
     DefaultAssociative
-     Sort
     ChapelTaskTable
     MemTracking
     ChapelUtil

--- a/test/reductions/thomasvandoren/sorted.chpl
+++ b/test/reductions/thomasvandoren/sorted.chpl
@@ -3,6 +3,7 @@
  * or not.
  */
 
+use Sort;
 //
 // BLC: For some of the reasons noted below in comments, I don't
 // believe this test behaves as expected (nor do I think it could,

--- a/test/release/examples/benchmarks/shootout/knucleotide.chpl
+++ b/test/release/examples/benchmarks/shootout/knucleotide.chpl
@@ -5,6 +5,8 @@
    derived from the GNU C++ version by Branimir Maksimovic
 */
 
+use Sort;
+
 config param tableSize = 1 << 16,
              columns = 61;
 
@@ -54,7 +56,7 @@ proc writeFreqs(data, param nclSize) {
   // sort by frequencies
   var arr = for (k,v) in zip(freqs.domain, freqs) do (v,k);
 
-  QuickSort(arr, reverse=true);
+  quickSort(arr, comparator=reverseComparator);
 
   for (f, s) in arr do
    writef("%s %.3dr\n", decode(s, nclSize), 

--- a/test/studies/madness/aniruddha/madchap/test_showboxes.chpl
+++ b/test/studies/madness/aniruddha/madchap/test_showboxes.chpl
@@ -1,5 +1,6 @@
 use MRA;
 use MadAnalytics;
+use Sort;
 
 config const k      = 5;
 config const thresh = 1e-5;

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
@@ -1,4 +1,5 @@
 use IO;
+use Sort;
 
 extern proc memcpy(x : [], b:c_string , len:int);
 
@@ -65,7 +66,7 @@ proc write_frequencies(data : [] uint(8), size : int) {
   var arr : [1..freqs.size] (int, uint);
   for (a, k, v) in zip(arr, freqs.domain, freqs) do
     a = (v,k);
-  QuickSort(arr, reverse=true);
+  quickSort(arr, comparator=reverseComparator);
 
   for (f, s) in arr do
     writef("%s %.3dr\n", decode(s, size), (100.0 * f) / sum);

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
@@ -1,4 +1,5 @@
 use IO;
+use Sort;
 
 extern proc memcpy(x : [], b:c_string, len:int);
 
@@ -117,7 +118,7 @@ proc write_frequencies(data : [] uint(8), size : int) {
   var arr : [1..freqs.size] (int, uint);
   for (a, (k,v)) in zip(arr, freqs) do
     a = (v,k);
-  QuickSort(arr, reverse=true);
+  quickSort(arr, comparator=reverseComparator);
 
   for (f, s) in arr do
     writef("%s %.3dr\n", decode(s, size), (100.0 * f) / sum);

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-strings.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-strings.chpl
@@ -4,6 +4,7 @@
    contributed by Ben Harshbarger
    derived from the GNU C++ version by Branimir Maksimovic
 */
+use Sort;
 
 // Used to encode a string into a uint
 var tonum : [0..127] int;
@@ -85,7 +86,7 @@ proc write_frequencies(data : string, size : int) {
     s = (f, e);
 
   // QuickSort will sort starting at the tuple's first element.
-  QuickSort(sorted, reverse=true);
+  quickSort(sorted, comparator=reverseComparator);
 
   const sum = data.length - size;
   for (f, e) in sorted do

--- a/test/studies/shootout/k-nucleotide/bradc/knucleotide-blc.chpl
+++ b/test/studies/shootout/k-nucleotide/bradc/knucleotide-blc.chpl
@@ -5,6 +5,8 @@
    derived from the GNU C++ version by Branimir Maksimovic
 */
 
+use Sort;
+
 config param tableSize = 1 << 16,
              columns = 61;
 
@@ -61,7 +63,7 @@ proc writeFreqs(data, param nclSize) {
   //  var arr: [1..freqs.size] 2*int;
   //  for (a, k, v) in zip(arr, freqs.domain, freqs) do
   //    a = (v, k);
-  QuickSort(arr, reverse=true);
+  quickSort(arr, comparator=reverseComparator);
 
   for (f, s) in arr do
    writef("%s %.3dr\n", decode(s, nclSize), 

--- a/test/studies/shootout/submitted/knucleotide.suppressif
+++ b/test/studies/shootout/submitted/knucleotide.suppressif
@@ -1,2 +1,12 @@
-CHPL_LAUNCHER <= slurm
-CHPL_LAUNCHER <= aprun
+#!/bin/bash
+
+echo "True"
+
+#
+# knucleotide depended on Sort being available by default, which was an
+# unintentional behavior up through 1.13.1.
+#
+# Once updated and resubmitted, this suppressif return to being the following:
+#
+# CHPL_LAUNCHER <= slurm
+# CHPL_LAUNCHER <= aprun


### PR DESCRIPTION
This prevents leaking the Sort and Search module into the default user namespace, which happened to surface the bug described in #4476 (to be reverted).

After this PR, the following qualified accesses are no longer compilation errors:

```chapel
use Sort;
var A = [3, 1, 4, 5, 9];
Sort.sort(A);

use Search;
var results = Search.search(A, 3);
```

Due to the function-level use of the Sort module, the conflicting commonly used variable/argument `isSorted` had to be renamed to `dataSorted`. This is a large, but non-user facing internal interface change.

Many tests relied on the fact that the Search and Sort modules were unintentionally provided by default. These tests were corrected in this PR as well.

`[Summary: #Successes = 6454 | #Failures = 4 | #Futures = 0]`

* [x] Fix the 4 failures
    * [1](https://github.com/chapel-lang/chapel/pull/4503/commits/fe3ebacbba7c9078bdab82773e32f464c658c18b) - line number in good file (now removed with prediff)
    * [2](https://github.com/chapel-lang/chapel/pull/4503/commits/a49aaf682358389259e3763ed4e75d6f3d01008e) - order of modules printed
    * [3](https://github.com/chapel-lang/chapel/pull/4503/commits/506b63da2fcd47d8b0ff1dbec75e6dd1faaf7de2) - order of modules initialized
    * [4](https://github.com/chapel-lang/chapel/pull/4503/commits/c528286dbecc5b46e0b4a107de445a4259eaf869) - suppressif on submitted `knucleotide` implementation, which relies on the sort module being available by default.

`[Summary: #Successes = 6457 | #Failures = 0 | #Futures = 0]`