### PR TITLE
Change how we touch qthreads autoconf files to match what we do for hwloc

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -94,11 +94,12 @@ qthread-config: FORCE
 # ahead in version numbers as that which was used when packaging the
 # Qthreads release
 #
-	-cd $(QTHREAD_SUBDIR) && find . -name "*.m4" | xargs touch configure.ac
-	sleep 2
+	cd $(QTHREAD_SUBDIR) && touch -c configure.ac
+	cd $(QTHREAD_SUBDIR) && find . -name "*.m4" | xargs touch
+	cd $(QTHREAD_SUBDIR) && touch -c aclocal.m4
 	cd $(QTHREAD_SUBDIR) && touch configure
-	sleep 2
 	cd $(QTHREAD_SUBDIR) && find . -name "*.in" | xargs touch
+
 #
 # Then configure
 #


### PR DESCRIPTION
While trying to upgrade qthreads versions I ran into an issue where the
configure step tried to rerun automake/autoconf steps. We try to prevent this
by touching certain configure/.m4/.in files in a certain order, but the way we
were doing it before wasn't quite right.

It turns out that this has been an issue for a while, which is why we sometimes
saw that qthreads files had been modified after a make. Beyond that we didn't
really notice the issue, because most of our systems happened to be using the
same version of automake that qthreads had been built with, but that's not the
case with the new qthreads version. This just updates the logic to match what
we do for hwloc, which seems to work.

This is similar to #69 but for qthreads instead of hwloc