### PR TITLE
Default to the "distrib" scheduler for numa

### DIFF
--- a/doc/release/technotes/localeModels.rst
+++ b/doc/release/technotes/localeModels.rst
@@ -97,7 +97,7 @@ Qthreads thread scheduling
 When qthreads tasking is used, different Qthreads thread schedulers are
 selected depending upon the ``CHPL_LOCALE_MODEL`` setting.  For the flat
 locale model the "nemesis" thread scheduler is used, and for the NUMA
-locale model the "sherwood" thread scheduler is used.  This selection is
+locale model the "distrib" thread scheduler is used.  This selection is
 done at the time the Qthreads third-party package is built, and cannot
 be adjusted later, either at user compile time or at execution time.
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -662,6 +662,15 @@ static void setupTasklocalStorage(void) {
     }
 }
 
+static void setupWorkStealing(void) {
+    // In our experience the current work stealing implementation hurts
+    // performance, so disable it. Note that we don't override, so a user could
+    // try working stealing out by setting {QT,QTHREAD}_STEAL_RATIO. Also note
+    // that not all schedulers support work stealing, but it doesn't hurt to
+    // set this env var for those configs anyways.
+    chpl_qt_setenv("STEAL_RATIO", "0", 0);
+}
+
 void chpl_task_init(void)
 {
     int32_t   commMaxThreads;
@@ -673,11 +682,12 @@ void chpl_task_init(void)
 
     commMaxThreads = chpl_comm_getMaxThreads();
 
-    // Set up hardware parallelism, the stack size and stack guards, and
-    // tasklocal storage.
+    // Set up hardware parallelism, the stack size and stack guards,
+    // tasklocal storage, and work stealing
     hwpar = setupAvailableParallelism(commMaxThreads);
     setupCallStacks(hwpar);
     setupTasklocalStorage();
+    setupWorkStealing();
 
     if (verbosity >= 2) { chpl_qt_setenv("INFO", "1", 0); }
 

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -47,10 +47,10 @@ endif
 CHPL_QTHREAD_CFG_OPTIONS += --enable-static --disable-shared
 
 # determine which scheduler to use. Default to nemesis, except for numa where
-# we want sherwood. Override with a user provided option if they requested one
+# we want distrib. Override with a user provided option if they requested one
 SCHEDULER = nemesis
 ifeq ($(CHPL_MAKE_LOCALE_MODEL),numa)
-SCHEDULER = sherwood
+SCHEDULER = distrib
 endif
 ifneq (, $(CHPL_QTHREAD_SCHEDULER))
 SCHEDULER = $(CHPL_QTHREAD_SCHEDULER)

--- a/util/cron/test-perf.chap04.playground.bash
+++ b/util/cron/test-perf.chap04.playground.bash
@@ -7,10 +7,8 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chap04.playground"
 
-
 # Test perf of qthreads "distrib" scheduler
 export CHPL_QTHREAD_SCHEDULER=distrib
-export QT_STEAL_RATIO=0
 
 SHORT_NAME=distrib
 START_DATE=08/10/16


### PR DESCRIPTION
Now that we've upgraded to qthreads 1.11 (#4499) default to distrib instead of
sherwood for numa. Sherwood had some horrible performance characteristics,
largely due to extremely aggressive work-stealing.  Distrib is a new numa-aware
scheduler that has much better performance than sherwood. Work-stealing still
hurts it's performance for us, so we disable it by default, though it can be
enabled by setting `{QT,QTHREAD}_STEAL_RATIO`

In our performance testing, distrib beats the pants off of sherwood, and it's
actually really competitive with nemesis (the default scheduler for flat)
though there are a few cases where the performance isn't quite as good yet, so
we're still defaulting to nemesis for flat.
