### PR TITLE
Enable native qthread sync vars by default

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -79,9 +79,8 @@ module ChapelSyncvar {
       compilerError("sync/single types cannot be of type '", t : string, "'");
   }
 
-  // Don't use native sync vars by default since the current qthreads release
-  // is missing writeFF, purge_to, and readXX.
-  config param useNativeSyncVar = false;
+  pragma "no doc"
+  config param useNativeSyncVar = true;
 
   // use native sync vars if they're enabled and supported for the valType
   private proc getSyncClassType(type valType) type {


### PR DESCRIPTION
Enable native qthread sync vars by default now that we've upgraded to qthreads
1.11 (#4499), which added some missing FEB operations. This just enables the
native sync var support that was added with #4489.