### PR TITLE
Repair some tests broken in #4503

### DIFF
--- a/test/distributions/bradc/assoc/userAssoc-array-noelt.prediff
+++ b/test/distributions/bradc/assoc/userAssoc-array-noelt.prediff
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Ignores line numbers printed upon error, to lessen the burden of updating
+# every time we modify the WIP UserMapAssoc.chpl
+#
+
+tmpfile=$2
+
+tmptmp=`mktemp "tmp.XXXXXX"`
+
+regex='\|UserMapAssoc.chpl|s/:[0-9:]*:/:nnnn:/'
+
+sed -e "$regex" $tmpfile > $tmptmp
+
+mv $tmptmp $tmpfile

--- a/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
+++ b/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
@@ -2,6 +2,7 @@ use utilities;
 use BlockDist;
 use CyclicDist;
 use BlockCycDist;
+use Search;
 
 //
 // DefaultRectangular support


### PR DESCRIPTION
* `.prediff` to ignore line number of errors accidentally not added to commit
* `use Search` in a test that was added after the dev branch was forked

Thanks @ronawho for pointing these failures out.