### PR TITLE
Stop increasing the timeout for numa perf testing

### DIFF
--- a/util/cron/test-perf.chapcs.numa.bash
+++ b/util/cron/test-perf.chapcs.numa.bash
@@ -10,9 +10,7 @@ source $CWD/common-numa.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.numa"
 
-export CHPL_TEST_TIMEOUT=600
-
 perf_args="-performance-description numa -performance-configs default:v,numa:v -sync-dir-suffix numa"
-perf_args="${perf_args} -performance -numtrials 3 -startdate 01/15/16"
+perf_args="${perf_args} -performance -numtrials 5 -startdate 01/15/16"
 
 $CWD/nightly -cron ${nightly_args} ${perf_args}


### PR DESCRIPTION
With the new scheduler (distrib), performance improved enough that we no longer
need to bump the timeout