### PR TITLE
Add an optimization that removes the inner multiply in dsiAccess

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -46,28 +46,6 @@ upcoming releases.  Both are available for use "at your own risk" in
 that they are not guaranteed to maintain program correctness (detailed
 after the flag's description).
 
-* chpl -sassertNoSlicing ...
-
-  At present, indexing into a Chapel array tends to require an extra
-  multiply compared to C/Fortran, in order to support Chapel's rich
-  array semantics.  More specifically, Chapel's support for striding,
-  reindexing, and rank-change of arrays requires a multiplication to
-  index into an array's innermost dimension in the general case; but
-  we pay this cost for every array.  In contrast, C and Fortran do not
-  require such multiplications.  For memory-bound programs, this
-  multiplication is rarely noticeable, but for programs that are
-  well-tuned for the memory hierarchy, this extra multiplication can
-  have a significant performance impact.
-
-  Work is currently underway to automatically distinguish between
-  arrays that require this multiplication and those that do not in
-  order to remove the overhead in the (common) cases where it is
-  unnecessary.  In the meantime, one can request that this
-  multiplication never be used for a given Chapel program by compiling
-  with this flag.  The flag should be safe for any program that does
-  not reindex a strided array or perform rank changes on an array to
-  remove the innermost dimension.
-
 * chpl -snoRefCount ...
 
   At present, Chapel reference counts arrays, domains, and domain maps

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -501,6 +501,7 @@ initPrimitive() {
   prim_def(PRIM_CHPL_COMM_GET_STRD, "chpl_comm_get_strd", returnInfoVoid, true, true);
   prim_def(PRIM_CHPL_COMM_PUT_STRD, "chpl_comm_put_strd", returnInfoVoid, true, true);
 
+  prim_def(PRIM_OPTIMIZE_ARRAY_BLK_MULT, "optimize_array_blk_mult", returnInfoBool);
   prim_def(PRIM_ARRAY_SHIFT_BASE_POINTER, "shift_base_pointer", returnInfoVoid, true, true);
   prim_def(PRIM_ARRAY_ALLOC, "array_alloc", returnInfoVoid, true, true);
   prim_def(PRIM_ARRAY_FREE, "array_free", returnInfoVoid, true, true);

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -56,6 +56,7 @@ extern bool fNoRemoteValueForwarding;
 extern bool fNoRemoveCopyCalls;
 extern bool fNoScalarReplacement;
 extern bool fNoTupleCopyOpt;
+extern bool fNoOptimizeArrayIndexing;
 extern bool fNoOptimizeLoopIterators;
 extern bool fNoVectorize;
 extern bool fNoPrivatization;
@@ -166,6 +167,7 @@ extern bool ignore_errors_for_pass;
 extern int  squelch_header_errors;
 extern bool fWarnConstLoops;
 
+extern bool fReportOptimizedArrayIndexing;
 extern bool fReportOptimizedLoopIterators;
 extern bool fReportOrderIndependentLoops;
 extern bool fReportOptimizedOn;

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -65,6 +65,7 @@ symbolFlag( FLAG_COERCE_TEMP , npr, "coerce temp" , "a temporary that was stores
 symbolFlag( FLAG_CODEGENNED , npr, "codegenned" , "code has been generated for this type" )
 symbolFlag( FLAG_COFORALL_INDEX_VAR , npr, "coforall index var" , ncm )
 symbolFlag( FLAG_COMMAND_LINE_SETTING , ypr, "command line setting" , ncm )
+symbolFlag( FLAG_MODIFIES_ARRAY_BLK , ypr, "modifies array blk" , "marks functions that modify the array blk field" )
 // The compiler-generated flag is already overloaded in three ways.  We may
 // want to split it if this becomes cumbersome:
 // 1. In resolution, functions marked as compiler-generated are considered only if

--- a/compiler/include/primitive.h
+++ b/compiler/include/primitive.h
@@ -126,6 +126,7 @@ enum PrimitiveTag {
   PRIM_CHPL_COMM_GET_STRD,      // Direct calls to the Chapel comm layer for strided comm
   PRIM_CHPL_COMM_PUT_STRD,      //  may eventually add others (e.g., non-blocking)
 
+  PRIM_OPTIMIZE_ARRAY_BLK_MULT,
   PRIM_ARRAY_ALLOC,
   PRIM_ARRAY_FREE,
   PRIM_ARRAY_FREE_ELTS,

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -102,6 +102,7 @@ bool fNoScalarReplacement = false;
 bool fNoTupleCopyOpt = false;
 bool fNoRemoteValueForwarding = false;
 bool fNoRemoveCopyCalls = false;
+bool fNoOptimizeArrayIndexing = false;
 bool fNoOptimizeLoopIterators = false;
 bool fNoVectorize = true;
 bool fNoGlobalConstOpt = false;
@@ -166,6 +167,7 @@ bool fPrintModuleResolution = false;
 bool fPrintEmittedCodeSize = false;
 char fPrintStatistics[256] = "";
 bool fPrintDispatch = false;
+bool fReportOptimizedArrayIndexing = false;
 bool fReportOptimizedLoopIterators = false;
 bool fReportOrderIndependentLoops = false;
 bool fReportOptimizedOn = false;
@@ -493,6 +495,7 @@ static void setFastFlag(const ArgumentDescription* desc, const char* unused) {
   fNoloopInvariantCodeMotion= false;
   fNoInline = false;
   fNoInlineIterators = false;
+  fNoOptimizeArrayIndexing = false;
   fNoOptimizeLoopIterators = false;
   fNoLiveAnalysis = false;
   fNoRemoteValueForwarding = false;
@@ -535,6 +538,7 @@ static void setBaselineFlag(const ArgumentDescription* desc, const char* unused)
   fNoInline = true;
   fNoInlineIterators = true;
   fNoLiveAnalysis = true;
+  fNoOptimizeArrayIndexing = true;
   fNoOptimizeLoopIterators = true;
   fNoVectorize = true;
   fNoRemoteValueForwarding = true;
@@ -646,6 +650,7 @@ static ArgumentDescription arg_desc[] = {
  {"inline-iterators", ' ', NULL, "Enable [disable] iterator inlining", "n", &fNoInlineIterators, "CHPL_DISABLE_INLINE_ITERATORS", NULL},
  {"live-analysis", ' ', NULL, "Enable [disable] live variable analysis", "n", &fNoLiveAnalysis, "CHPL_DISABLE_LIVE_ANALYSIS", NULL},
  {"loop-invariant-code-motion", ' ', NULL, "Enable [disable] loop invariant code motion", "n", &fNoloopInvariantCodeMotion, NULL, NULL},
+ {"optimize-array-indexing", ' ', NULL, "Enable [disable] array indexing optimization", "n", &fNoOptimizeArrayIndexing, "CHPL_DISABLE_OPTIMIZE_ARRAY_INDEXING", NULL},
  {"optimize-loop-iterators", ' ', NULL, "Enable [disable] optimization of iterators composed of a single loop", "n", &fNoOptimizeLoopIterators, "CHPL_DISABLE_OPTIMIZE_LOOP_ITERATORS", NULL},
  {"optimize-on-clauses", ' ', NULL, "Enable [disable] optimization of on clauses", "n", &fNoOptimizeOnClauses, "CHPL_DISABLE_OPTIMIZE_ON_CLAUSES", NULL},
  {"optimize-on-clause-limit", ' ', "<limit>", "Limit recursion depth of on clause optimization search", "I", &optimize_on_clause_limit, "CHPL_OPTIMIZE_ON_CLAUSE_LIMIT", NULL},
@@ -769,6 +774,7 @@ static ArgumentDescription arg_desc[] = {
  {"report-inlining", ' ', NULL, "Print inlined functions", "F", &report_inlining, NULL, NULL},
  {"report-dead-blocks", ' ', NULL, "Print dead block removal stats", "F", &fReportDeadBlocks, NULL, NULL},
  {"report-dead-modules", ' ', NULL, "Print dead module removal stats", "F", &fReportDeadModules, NULL, NULL},
+ {"report-optimized-array-indexing", ' ', NULL, "Print stats on optimized array indexing", "F", &fReportOptimizedArrayIndexing, NULL, NULL},
  {"report-optimized-loop-iterators", ' ', NULL, "Print stats on optimized single loop iterators", "F", &fReportOptimizedLoopIterators, NULL, NULL},
  {"report-order-independent-loops", ' ', NULL, "Print stats on order independent loops", "F", &fReportOrderIndependentLoops, NULL, NULL},
  {"report-optimized-on", ' ', NULL, "Print information about on clauses that have been optimized for potential fast remote fork operation", "F", &fReportOptimizedOn, NULL, NULL},

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -257,6 +257,8 @@ classifyPrimitive(CallExpr *call) {
   case PRIM_ERROR:
   case PRIM_WARNING:
 
+  case PRIM_OPTIMIZE_ARRAY_BLK_MULT:
+
   case PRIM_BLOCK_PARAM_LOOP:
   case PRIM_BLOCK_BEGIN:
   case PRIM_BLOCK_COBEGIN:

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9387,15 +9387,21 @@ static bool arrayBlkModified() {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     if (fn->isResolved() && fn->defPoint && fn->defPoint->parentSymbol) {
       if (fn->hasFlag(FLAG_MODIFIES_ARRAY_BLK)) {
+        if (fReportOptimizedArrayIndexing) {
+          printf("Unable to optimize array indexing\n");
+        }
         return true;
       }
     }
+  }
+  if (fReportOptimizedArrayIndexing) {
+    printf("Optimized array indexing\n");
   }
   return false;
 }
 
 static bool canOptimizeArrayBlk() {
-  static bool canOptimize = !arrayBlkModified();
+  static bool canOptimize = !fNoOptimizeArrayIndexing && !arrayBlkModified();
   return canOptimize;
 }
 

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -185,6 +185,11 @@ OPTIONS
     Enable [disable] live variable analysis, which is currently only used to
     optimize iterators that are not inlined.
 
+**--[no-]optimize-array-indexing**
+
+    Enable [disable] an optimization that removes an extra multiply in array
+    indexing when it's provably unnecessary. By default this is enabled.
+
 **--[no-]optimize-loop-iterators**
 
     Enable [disable] optimizations to aggressively optimize iterators that

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -38,7 +38,6 @@ module DefaultRectangular {
   config param defaultDoRADOpt = true;
   config param defaultDisableLazyRADOpt = false;
   config param earlyShiftData = true;
-  config param assertNoSlicing = false;
 
   class DefaultDist: BaseDist {
     proc dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool)

--- a/test/arrays/elliot/removeInnerMultOpt/COMPOPTS
+++ b/test/arrays/elliot/removeInnerMultOpt/COMPOPTS
@@ -1,0 +1,1 @@
+--optimize-array-indexing --report-optimized-array-indexing

--- a/test/arrays/elliot/removeInnerMultOpt/rankChangeRequiresInnerMult.chpl
+++ b/test/arrays/elliot/removeInnerMultOpt/rankChangeRequiresInnerMult.chpl
@@ -1,0 +1,7 @@
+// ensure that --optimize-array-indexing does not remove innerMult for programs
+// that rankChange
+
+var B: [1..10, 1..10] int;
+var A = B[1..10, 1];
+
+for i in 1..10 do A[i] = i;

--- a/test/arrays/elliot/removeInnerMultOpt/rankChangeRequiresInnerMult.good
+++ b/test/arrays/elliot/removeInnerMultOpt/rankChangeRequiresInnerMult.good
@@ -1,0 +1,1 @@
+Unable to optimize array indexing

--- a/test/arrays/elliot/removeInnerMultOpt/removeInnerMult.chpl
+++ b/test/arrays/elliot/removeInnerMultOpt/removeInnerMult.chpl
@@ -1,0 +1,12 @@
+var A: [1..10] int;
+var B: [1..20] int;
+
+// non-strided slicing does not prevent optimization
+A = B[11..20];
+
+// reindexing when lhs is not strided does not prevent optimization
+var C => A[2..9];
+var D => A[1..10 by 2];
+var E: [0..9] => A[1..10];
+
+for i in 1..10 do A[i] = i;

--- a/test/arrays/elliot/removeInnerMultOpt/removeInnerMult.good
+++ b/test/arrays/elliot/removeInnerMultOpt/removeInnerMult.good
@@ -1,0 +1,1 @@
+Optimized array indexing

--- a/test/arrays/elliot/removeInnerMultOpt/stridedReindexRequiresInnerMult.chpl
+++ b/test/arrays/elliot/removeInnerMultOpt/stridedReindexRequiresInnerMult.chpl
@@ -1,0 +1,7 @@
+// ensure that --optimize-array-indexing does not remove innerMult for programs
+// that use a strided reindex
+
+var A: [1..10] int;
+var B: [1..20 by 4] => A[1..10 by 2];
+
+for i in 1..20 by 4 do B[i] = i; 

--- a/test/arrays/elliot/removeInnerMultOpt/stridedReindexRequiresInnerMult.good
+++ b/test/arrays/elliot/removeInnerMultOpt/stridedReindexRequiresInnerMult.good
@@ -1,0 +1,1 @@
+Unable to optimize array indexing

--- a/test/arrays/elliot/removeInnerMultOpt/stridedSliceRequiresInnerMult.chpl
+++ b/test/arrays/elliot/removeInnerMultOpt/stridedSliceRequiresInnerMult.chpl
@@ -1,0 +1,9 @@
+// ensure that --optimize-array-indexing does not remove innerMult for programs
+// that do strided slicing
+
+var A: [1..10] int;
+var B: [1..100] int;
+
+A = B[1..100 by 10];
+
+for i in 1..10 do A[i] = i;

--- a/test/arrays/elliot/removeInnerMultOpt/stridedSliceRequiresInnerMult.good
+++ b/test/arrays/elliot/removeInnerMultOpt/stridedSliceRequiresInnerMult.good
@@ -1,0 +1,1 @@
+Unable to optimize array indexing

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -31,6 +31,8 @@ Optimization Control Options:
       --[no-]loop-invariant-code-motion
                                       Enable [disable] loop invariant code
                                       motion
+      --[no-]optimize-array-indexing  Enable [disable] array indexing
+                                      optimization
       --[no-]optimize-loop-iterators  Enable [disable] optimization of
                                       iterators composed of a single loop
       --[no-]optimize-on-clauses      Enable [disable] optimization of on

--- a/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
@@ -1,1 +1,1 @@
--sperfTesting=true -sassertNoSlicing=true
+-sperfTesting=true

--- a/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_dyn.perfcompopts
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_dyn.perfcompopts
@@ -1,1 +1,1 @@
---optimize --fast --no-checks -sassertNoSlicing
+--optimize --fast --no-checks

--- a/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_static.perfcompopts
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_static.perfcompopts
@@ -1,1 +1,1 @@
---optimize --fast --no-checks -sassertNoSlicing
+--optimize --fast --no-checks

--- a/test/studies/colostate/Jacobi1D-NaiveParallel-Chapel_static.perfcompopts
+++ b/test/studies/colostate/Jacobi1D-NaiveParallel-Chapel_static.perfcompopts
@@ -1,1 +1,1 @@
---optimize --fast --no-checks  -sassertNoSlicing
+--optimize --fast --no-checks

--- a/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_dyn.perfcompopts
+++ b/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_dyn.perfcompopts
@@ -1,1 +1,1 @@
---optimize --fast --no-checks -sassertNoSlicing
+--optimize --fast --no-checks

--- a/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_static.perfcompopts
+++ b/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_static.perfcompopts
@@ -1,1 +1,1 @@
---optimize --fast --no-checks -sassertNoSlicing
+--optimize --fast --no-checks

--- a/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_dyn.perfcompopts
+++ b/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_dyn.perfcompopts
@@ -1,1 +1,1 @@
---optimize --fast --no-checks -sassertNoSlicing
+--optimize --fast --no-checks

--- a/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_static.perfcompopts
+++ b/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_static.perfcompopts
@@ -1,1 +1,1 @@
---optimize --fast --no-checks -sassertNoSlicing
+--optimize --fast --no-checks


### PR DESCRIPTION
Add a compiler optimization (--optimize-array-indexing) that removes the inner
multiply for array indexing when possible. The basic idea of the optimization
is that if the blk field is never modified, we know that blk(rank) will always
be 1, so we can optimize away the last blk multiply in dsiAccess().

In order to determine if blk is modified, we explicitly mark all functions that
might modify it with a pragma. Then, if none of those functions are called we
know blk cannot be modified, so it's safe to remove the multiply. The functions
that modify blk are adjustBlkOffStrForNewDomain() (called for strided reindexing
and strided slicing) and rankChange().

This is kind of a lame optimization because if any array requires blk, all
arrays will suffer the performance penalty. i.e. the optimization just checks
if any function modifies block, it doesn't do any contextual or type based
analysis. Longer term we expect array views will provide a way to remove the
inner multiply in a cleaner and more principled manner, so this optimization is
really just a stopgap until that comes along.

Until then, this gets us the performance benefit for most cases, particularly
for benchmarks like the PRKs, array microbenchmarks, lcals, and some of the
shootout benchmarks. It also allows us to remove the hackier assertNoSlicing
param, because we now optimize almost all the cases where assertNoSlicing
wouldn't break things anyways.

The generated code improvement from this optimization is also pretty sweet:

```chapel
// stream like code
for i in 1..10 do A[i] = B[i] + C[i];
```

used to produce:

```c
for (i = INT64(1); i <= INT64(10); i += INT64(1)) {
  sum = INT64(0);                         // dead store
  sum += ((int64_t)((i * coerce_tmp)));   // extra mult
  call_tmp7 = (coerce_tmp2 + sum);
  sum2 = INT64(0);
  sum2 += ((int64_t)((i * coerce_tmp3)));
  call_tmp9 = (coerce_tmp4 + sum2);
  ret = *(call_tmp9);
  sum3 = INT64(0);
  sum3 += ((int64_t)((i * coerce_tmp5)));
  call_tmp11 = (coerce_tmp6 + sum3);
  *(call_tmp7) = ((int64_t)((ret + *(call_tmp11))));
}
```

and now generates: 

```c
for (i = INT64(1); i <= INT64(10); i += INT64(1)) {
  call_tmp7 = (coerce_tmp + i);
  call_tmp9 = (coerce_tmp2 + i);
  call_tmp11 = (coerce_tmp3 + i);
  *(call_tmp7) = ((int64_t)((*(call_tmp9) + *(call_tmp11))));
}
```