### PR TITLE
Update types/atomic/ferguson/atomictest to test all atomics types

### DIFF
--- a/test/types/atomic/ferguson/atomictest.chpl
+++ b/test/types/atomic/ferguson/atomictest.chpl
@@ -1,38 +1,46 @@
-config const n = 100000;
+config const n = 1000000;
 config const showRace = false;
 
-proc test(param width, n_max:int ) {
-  var n:uint(width) = max(uint(width));
-  n -= 1; // don't go to max(type) since that will overflow the range iterator
-  if n_max:uint(64) < n:uint(64) then n = n_max:uint(width);
+proc test(type base_type, n_max:int) {
+  const mult = 10: base_type;
+  const one  =  1: base_type;
+  const zero =  0: base_type;
 
-  const mult:uint(width) = 10;
-  const one:uint(width) = 1;
-  const zero:uint(width) = 0;
+  var n:uint = max(base_type):uint;
+  if isRealType(base_type) then n = max(uint);
+  n = min(n, n_max:uint);
 
-  writeln("Testing " + width:string + " - bit atomics");
+  // single precision floats have 24 bits of precision (i.e. can only
+  // represent integers up to 2**24 exactly)
+  if base_type == real(32) then n = min(n, (2**24)/mult:uint);
+
+  // need to avoid signed integer overflow, since it's undefined behavior
+  if isIntType(base_type) then
+    if n > (max(base_type)/mult):uint then  n = n/mult:uint;
+
+
+  writeln("Testing atomic " + base_type:string);
 
   if showRace {
-    var x:uint(width);
+    var x:base_type;
     x = zero;
-    forall i in one..n with (ref x) { // race is intentional
+    forall i in 1..n with (ref x) { // race is intentional
       x += one;
     }
     writeln("X is ", x," (vs. ", n, ")");
   }
 
-  var aint:atomic uint(width);
+  var aint:atomic base_type;
 
-  //aint.init(0);
-
-  forall i in one..n {
+  forall i in 1..n {
     aint.fetchAdd(one);
   }
 
-  assert(aint.read() == n);
+  assert(aint.read() == n:base_type);
   writeln("Increment OK");
 
-  forall i in one..n {
+
+  forall i in 1..n {
     aint.fetchSub(one);
   }
 
@@ -40,14 +48,14 @@ proc test(param width, n_max:int ) {
 
   writeln("Decrement OK");
 
-  forall i in one..n {
+  forall i in 1..n {
     aint.fetchAdd(mult);
   }
 
-  assert(aint.read() == (mult*n):uint(width));
+  assert(aint.read() == (mult*n:base_type));
   writeln("Add OK");
 
-  forall i in one..n {
+  forall i in 1..n {
     aint.fetchSub(mult);
   }
 
@@ -59,11 +67,18 @@ proc test(param width, n_max:int ) {
   assert(aint.read() == mult);
 
   writeln("Compare and Swap OK");
-
-  //aint.destroy();
+  writeln();
 }
 
-test(8,  n);
-test(16, n);
-test(32, n);
-//test(64, n);
+test(uint(8),  n);
+test(uint(16), n);
+test(uint(32), n);
+test(uint(64), n);
+
+test(int(8),  n);
+test(int(16), n);
+test(int(32), n);
+test(int(64), n);
+
+test(real(32), n);
+test(real(64), n);

--- a/test/types/atomic/ferguson/atomictest.good
+++ b/test/types/atomic/ferguson/atomictest.good
@@ -1,18 +1,70 @@
-Testing 8 - bit atomics
+Testing atomic uint(8)
 Increment OK
 Decrement OK
 Add OK
 Subtract OK
 Compare and Swap OK
-Testing 16 - bit atomics
+
+Testing atomic uint(16)
 Increment OK
 Decrement OK
 Add OK
 Subtract OK
 Compare and Swap OK
-Testing 32 - bit atomics
+
+Testing atomic uint(32)
 Increment OK
 Decrement OK
 Add OK
 Subtract OK
 Compare and Swap OK
+
+Testing atomic uint(64)
+Increment OK
+Decrement OK
+Add OK
+Subtract OK
+Compare and Swap OK
+
+Testing atomic int(8)
+Increment OK
+Decrement OK
+Add OK
+Subtract OK
+Compare and Swap OK
+
+Testing atomic int(16)
+Increment OK
+Decrement OK
+Add OK
+Subtract OK
+Compare and Swap OK
+
+Testing atomic int(32)
+Increment OK
+Decrement OK
+Add OK
+Subtract OK
+Compare and Swap OK
+
+Testing atomic int(64)
+Increment OK
+Decrement OK
+Add OK
+Subtract OK
+Compare and Swap OK
+
+Testing atomic real(32)
+Increment OK
+Decrement OK
+Add OK
+Subtract OK
+Compare and Swap OK
+
+Testing atomic real(64)
+Increment OK
+Decrement OK
+Add OK
+Subtract OK
+Compare and Swap OK
+


### PR DESCRIPTION
Previously types/atomic/ferguson/atomictest only tested uint(8), uint(16), and
uint(32) atomics, this updates it to test all uint, int, and real types.

The only slightly interesting change is that we need to be careful not to
overflow the int atomics since int overflow is undefined, and we need to make
sure we don't exceed floating point precision for real(32). real(32) can only
exactly represent integers up to 2**24, and larger value results in rounding,
which makes aint.fetch(1.0) effectively a no-op and will cause the test to
fail.

This is motivated by a recent change to how intrinsic atomic reals are
implemented (#4491). While testing that I realized that we didn't have any
great tests that exercise floating point atomics. When I started writing my
own test, it ended up looking a lot like types/atomic/ferguson/atomictest, so I
just updated that instead.