### PR TITLE
Update which repos the perf playgrounds are using

### DIFF
--- a/util/cron/test-perf.chapcs.arr-playground.bash
+++ b/util/cron/test-perf.chapcs.arr-playground.bash
@@ -11,7 +11,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.arr-playground"
 
 # Test performance the array as record branch
 GITHUB_USER=mppf
-GITHUB_BRANCH=distribution-no-rc2
+GITHUB_BRANCH=distribution-no-rc3
 SHORT_NAME=arrays
 START_DATE=08/30/16
 

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -28,7 +28,7 @@ $CWD/nightly -cron ${nightly_args} ${perf_args}
 
 
 GITHUB_USER=ronawho
-GITHUB_BRANCH=optimize-1dim-array-access-2
+GITHUB_BRANCH=optimize-away-inner-array-mult
 
 git checkout .
 git clean -fdx .


### PR DESCRIPTION
"distribution-no-rc2" => "distribution-no-rc3"

"optimize-1dim-array-access-2" => "optimize-away-inner-array-mult"

Still testing the same things (array-as-rec and remove-inner-mult), just
different/newer branches