### PR TITLE
Fix memory leak in genericStack example

### DIFF
--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -890,8 +890,10 @@ record Stack {
     if isEmpty then
       halt("attempt to pop an item off an empty stack");
     var oldTop = top;
+    var oldItem = top.item;
     top = top.next;
-    return oldTop.item;
+    delete oldTop;
+    return oldItem;
   }
 
   proc isEmpty return top == nil;

--- a/test/release/examples/programs/genericStack.chpl
+++ b/test/release/examples/programs/genericStack.chpl
@@ -35,8 +35,10 @@ record ListStack {
     if isEmpty then
       halt("attempt to pop an item off an empty stack");
     var oldTop = top;
+    var oldItem = top.item;
     top = top.next;
-    return oldTop.item;
+    delete oldTop;
+    return oldItem;
   }
 
   // isEmpty method: true if the stack is empty; otherwise false


### PR DESCRIPTION
The genericStack example in spec/Generics.tex is replicated in
test/release/examples/programs/genericStack.chpl.  Both leak the Node
object on pop().

Before:

```
$ ./genericStack -nl 1 --memLeaksByType
...
Number of leaked allocations
           Total leaked memory (bytes)
                      Description of allocation
==============================================================
16         640        MyNode(ListStack(2*int(64)),2*int(64))
2          240        DefaultRectangularDom(1,int(64),false)
3          168        MyNode(ListStack(string),string)

```
After:

`2          240        DefaultRectangularDom(1,int(64),false)`

Fix both of them.  Both examples/programs/genericStack.chpl and
the generated spec/Generics/genericStack.chpl pass start_test.