### PR TITLE
Add check for refering to local/arg in another fn

### DIFF
--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -62,8 +62,7 @@ void checkArgsAndLocals()
     Symbol* useInSym = se->parentSymbol;
 
     if (isFnSymbol(defInSym) && isFnSymbol(useInSym)) {
-      if (defInSym->hasFlag(FLAG_MODULE_INIT) /*||
-          defInSym->hasFlag(FLAG_ITERATOR_FN) */ ) {
+      if (defInSym->hasFlag(FLAG_MODULE_INIT)) {
         // OK, module init functions can define globals
       } else {
         if (defInSym != useInSym) {

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -84,6 +84,7 @@ void checkPostResolution();
 void checkNoUnresolveds();
 // These checks can be applied after any pass.
 void checkForDuplicateUses();
+void checkArgsAndLocals();
 void checkReturnTypesHaveRefTypes();
 
 //

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -449,6 +449,8 @@ static void check_afterCallDestructors()
 static void check_afterLowerIterators()
 {
   checkLowerIteratorsRemovedPrims();
+  if (fVerify)
+    checkArgsAndLocals();
 }
 
 


### PR DESCRIPTION
As part of my work on the arrays branch, I found myself confused by a case where a local variable referred to a local variable in another function. This amounts to incorrect compiler code, but we didn't have a check for --verify for this case.

This PR adds such a check. Note that the representation of iterators in the AST will refer to ArgSymbol/VarSymbols in other functions before the iterators are lowered.

Passed full local testing with and without --verify.
Reviewed by @daviditen - thanks!