### PR TITLE
Make ascii() return uint(8) rather than int(32)

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -70,6 +70,11 @@ returnInfoNodeID(CallExpr* call) {
 }
 
 static QualifiedType
+returnInfoUInt8(CallExpr* call) {
+  return QualifiedType(dtUInt[INT_SIZE_8], QUAL_VAL);
+}
+
+static QualifiedType
 returnInfoInt32(CallExpr* call) {
   return QualifiedType(dtInt[INT_SIZE_32], QUAL_VAL);
 }
@@ -568,7 +573,7 @@ initPrimitive() {
   prim_def("string_contains", returnInfoBool, true);
   prim_def("string_concat", returnInfoStringCopy, true, true);
   prim_def("string_length", returnInfoDefaultInt);
-  prim_def("ascii", returnInfoInt32);
+  prim_def("ascii", returnInfoUInt8);
   prim_def("string_index", returnInfoStringCopy, true, true);
   prim_def(PRIM_STRING_COPY, "string_copy", returnInfoStringCopy, false, true);
   prim_def(PRIM_CAST_TO_VOID_STAR, "cast_to_void_star", returnInfoCVoidPtr, true, false);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7094,7 +7094,7 @@ postFold(Expr* expr) {
       if (se->var->isParameter()) {
         const char* str = get_string(se);
         const std::string unescaped = unescapeString(str, se);
-        result = new SymExpr(new_IntSymbol((int)unescaped[0], INT_SIZE_DEFAULT));
+        result = new SymExpr(new_UIntSymbol((int)unescaped[0], INT_SIZE_8));
         call->replace(result);
       }
     } else if (call->isPrimitive("string_contains")) {

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1690,16 +1690,16 @@ module String {
   //
   // Helper routines
   //
-  private const uint_A: uint(8) = ascii('A');
-  private const uint_Z: uint(8) = ascii('Z');
-  private const uint_a: uint(8) = ascii('a');
-  private const uint_z: uint(8) = ascii('z');
-  private const uint_0: uint(8) = ascii('0');
-  private const uint_9: uint(8) = ascii('9');
-  private const uint_space   : uint(8) = ascii(' ');
-  private const uint_tab     : uint(8) = ascii('\t');
-  private const uint_newline : uint(8) = ascii('\n');
-  private const uint_return  : uint(8) = ascii ('\r');
+  private const uint_A = ascii('A');
+  private const uint_Z = ascii('Z');
+  private const uint_a = ascii('a');
+  private const uint_z = ascii('z');
+  private const uint_0 = ascii('0');
+  private const uint_9 = ascii('9');
+  private const uint_space    = ascii(' ');
+  private const uint_tab      = ascii('\t');
+  private const uint_newline  = ascii('\n');
+  private const uint_return   = ascii('\r');
 
   private inline proc byte_isUpper(b: uint(8)) : bool {
     return b >= uint_A && b <= uint_Z;
@@ -1730,15 +1730,15 @@ module String {
   /*
      :returns: The byte value of the first character in `a` as an integer.
   */
-  inline proc ascii(a: string) : int(32) {
+  inline proc ascii(a: string) : uint(8) {
     if a.isEmptyString() then return 0;
 
     if _local || a.locale_id == chpl_nodeID {
       // the string must be local so we can index into buff
-      return a.buff[0]:int(32);
+      return a.buff[0];
     } else {
       // a[1] grabs the first character as a string (making it local)
-      return a[1].buff[0]:int(32);
+      return a[1].buff[0];
     }
   }
 

--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -134,21 +134,18 @@ o remove warning for serial whole-array assignment when RHS is serial
 o should globals be allowed to be declared below main()?  If so, move
   fact[] to the bottom of the file?
 
-fasta.chpl
-----------
-o no notes to provide
 
-
-fastaredux.chpl
----------------
-o Shouldn't ascii() return an int(8)/uint(8) by default?
-
+fasta.chpl / fastaredux.chpl
+----------------------------
 o We should introduce local "static" variables (using some other
   keyword) and use it to define some of the variables that are
   currently at global or outer scopes unnecessarily
 
 o Should writef("%s", str) and write(str) be equivalent?  If so,
   it looks like we have a bug.
+
+o It seems like a param uint(8) whose value is known to fit in an
+  int(8) should be assignable without a cast, but currently it isn't.
 
 
 k-nucleotide
@@ -173,8 +170,6 @@ o Good motivation for optimizing 1D array reallocations with a common
   low bound?
 
 o Why does '(data:[] uint(8)) op= 0x20' not work?
-
-o Shouldn't ascii() return an int(8)/uint(8) by default?
 
 o Should readline() support an overload that takes an array of int(8)?
 
@@ -255,8 +250,6 @@ o promote mpz_t types to a record-based implementation with:
 
 revcomp.chpl
 ------------
-o Shouldn't ascii() return an int(8)/uint(8) by default?
-
 o The pattern ascii(mystring[i]) seems like it ought to be very
   optimizable compared to what we do now, and to support param
   versions in the event that mystring and 'i' are both params.  As a

--- a/test/release/examples/benchmarks/shootout/fasta.chpl
+++ b/test/release/examples/benchmarks/shootout/fasta.chpl
@@ -85,7 +85,7 @@ proc sumProbs(alphabet: []) {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = ascii("\n"): int(8);
+param newline = ascii("\n");
 
 //
 // Repeat sequence "alu" for n characters
@@ -133,7 +133,7 @@ proc randomMake(desc, a, n) {
         line_buff[i] = a[hi](nucl);
       }
     }
-    line_buff[bytes] = newline;
+    line_buff[bytes] = newline:int(8);
 
     stdout.write(line_buff[0..bytes]);
   }

--- a/test/release/examples/benchmarks/shootout/fastaredux.chpl
+++ b/test/release/examples/benchmarks/shootout/fastaredux.chpl
@@ -89,7 +89,7 @@ proc sumAndScale(alphabet: [?D]) {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = ascii("\n"): int(8);
+param newline = ascii("\n");
 
 //
 // Repeat sequence "alu" for n characters
@@ -139,7 +139,7 @@ proc randomMake(desc, a, n) {
       
       line_buff[i] = lookup[ai](nucl);
     }
-    line_buff[bytes] = newline;
+    line_buff[bytes] = newline: int(8);
 
     stdout.write(line_buff[0..bytes]);
   }

--- a/test/release/examples/benchmarks/shootout/knucleotide.chpl
+++ b/test/release/examples/benchmarks/shootout/knucleotide.chpl
@@ -128,7 +128,7 @@ inline proc hash(str, beg, param size) {
 proc string.toBytes() {
   var bytes: [1..this.length] uint(8);
   for (b, i) in zip(bytes, 1..) do
-    b = ascii(this[i]):uint(8);
+    b = ascii(this[i]);
   return bytes;
 }
 

--- a/test/release/examples/benchmarks/shootout/revcomp.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp.chpl
@@ -69,9 +69,9 @@ proc initTable(pairs) {
   var table: [1..128] uint(8);
 
   for i in 1..pairs.length by 2 {
-    table[ascii(pairs[i])] = ascii(pairs[i+1]):uint(8);
+    table[ascii(pairs[i])] = ascii(pairs[i+1]);
     if pairs[i] != "\n" then
-      table[ascii(pairs[i].toLower())] = ascii(pairs[i+1]):uint(8);
+      table[ascii(pairs[i].toLower())] = ascii(pairs[i+1]);
   }
 
   return table;

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -89,7 +89,7 @@ proc sumAndScale(alphabet: [?D]) {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = ascii("\n"): int(8);
+param newline = ascii("\n");
 
 //
 // Repeat sequence "alu" for n characters
@@ -139,7 +139,7 @@ proc randomMake(desc, a, n) {
       
       line_buff[i] = lookup[ai](nucl);
     }
-    line_buff[bytes] = newline;
+    line_buff[bytes] = newline: int(8);
 
     stdout.write(line_buff[0..bytes]);
   }

--- a/test/studies/shootout/fasta/kbrady/fasta-enum.chpl
+++ b/test/studies/shootout/fasta/kbrady/fasta-enum.chpl
@@ -13,7 +13,7 @@ config const LOOKUP_SCALE : real = LOOKUP_SIZE - 1;
 config const n = 1000;
 
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newLine: int(8) = ascii("\n");
+param newLine = ascii("\n");
 
 enum Ntide {
   A = ascii("A"), C = ascii("C"), G = ascii("G"), T = ascii("T"),

--- a/test/studies/shootout/k-nucleotide/bradc/knucleotide-blc.chpl
+++ b/test/studies/shootout/k-nucleotide/bradc/knucleotide-blc.chpl
@@ -145,7 +145,7 @@ inline proc hash(str, beg, param size) {
 proc string.toBytes() {
   var bytes: [1..this.length] uint(8);
   for (b, i) in zip(bytes, 1..) do
-    b = ascii(this[i]):uint(8);
+    b = ascii(this[i]);
   return bytes;
 }
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
@@ -16,7 +16,7 @@ proc main(args: [] string) {
   var data : [1..fileLen] uint(8);
   var r = inFile.reader(locking=false);
 
-  const pairs = [c in "ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n"] ascii(c):uint(8);
+  const pairs = [c in "ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n"] ascii(c);
 
   // initialize complement table
   for i in 1..pairs.size by 2 {

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -70,9 +70,9 @@ proc initTable(param pairs) {
 
   for param i in 1..pairs.length do
     if i%2 {
-      table[ascii(pairs[i])] = ascii(pairs[i+1]):uint(8);
+      table[ascii(pairs[i])] = ascii(pairs[i+1]);
       if pairs[i] != "\n" then
-        table[ascii(pairs[i].toLower())] = ascii(pairs[i+1]):uint(8);
+        table[ascii(pairs[i].toLower())] = ascii(pairs[i+1]);
     }
 
   return table;


### PR DESCRIPTION
This PR makes our (unpopular) ascii() routine return uint(8) values rather than int(32)s/int(64)s (inconsistently) as it did before.  Previously, the param version returned int(64)s while the non-param version returned int(32)s.

While this is a trivial change, and many better thoughts are in the works about string representations and queries like this, it also removes a strange smell from the library and implementation (why does ascii() return such a large int?  why 32 bits sometimes?  why inconsistently?) while removing some ridiculous casts from the shootout benchmarks.  And it's an easy fix.