### PR TITLE
Add cross-references in Literal Expressions section

### DIFF
--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -110,6 +110,7 @@ array-literal:
 \end{syntax}
 
 \subsection{Rectangular Array Literals}
+\label{Rectangular_Array_Literals}
 \index{rectangular array literals}
 \index{arrays!rectangular!literals}
 
@@ -175,6 +176,7 @@ An rectangular array's default value is for each array element to be initialized
 the default value of the element type.
 
 \subsection{Associative Array Literals}
+\label{Associative_Array_Literals}
 \index{associative array literals}
 \index{arrays!associative!literals}
 

--- a/spec/Expressions.tex
+++ b/spec/Expressions.tex
@@ -52,8 +52,8 @@ and additionally as follows:
 \index{literal expressions}
 \index{expressions!literal}
 
-A literal value for any of the predefined
-types~(\rsec{Primitive_Type_Literals}) is a literal expression.
+A literal value for any of the predefined types is a literal expression.
+
 Literal expressions are given by the following syntax:
 \begin{syntax}
 literal-expression:
@@ -66,6 +66,15 @@ literal-expression:
   domain-literal
   array-literal
 \end{syntax}
+
+Literal values for primitive types are described in
+\rsec{Primitive_Type_Literals}.
+Literal range values are described in \rsec{Range_Literals}.
+Literal values for domains are described in \rsec{Rectangular_Domain_Values}
+and \rsec{Associative_Domain_Values}.
+Literal values for arrays are described in  \rsec{Rectangular_Array_Literals}
+and \rsec{Associative_Array_Literals}.
+
 
 \section{Variable Expressions}
 \label{Variable_Expressions}


### PR DESCRIPTION
In looking at the spec, I had trouble finding the description of associative array literal syntax since I looked in the Literal Expressions section which merely mentions that an array-literal is a kind of literal. This PR updates that section to include cross references to the sections that describe each literal in more detail.

Reviewed by @vasslitvinov - thanks!