### PR TITLE
Add recent perf annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -151,17 +151,32 @@ all:
       config: 16 node XC, Single node XC
   08/04/16:
     - Updates to Search module, required array slicing (partially reverted) (#4273)
+  08/19/16:
+    - Turn denormalization on by default (reverted the next night) (#4360)
   08/28/16:
     - text: Upgraded chap* (except chap03) and chapcs* machines from gcc 4.7 to gcc 6.2
       config: chap04, chapcs
+  09/01/16:
+    - Turn denormalization on by default (#4434)
   09/04/16:
     - use standard atomics rather than intrinsics for gcc (reverted the next night) (#4443)
+  09/09/16:
+    - convert more reductions to use reduce intents (#4396)
+  09/13/16:
+    - remove volatile on real atomics, make atomic_load atomic (#4491)
+    - use "distrib" scheduler for numa instead of "sherwood" (#4505)
+  09/14/16:
+    - enable native qthreds sync vars (#4506)
 
 AllCompTime:
   11/09/14:
     - disable the task table by default
   01/17/16:
     - add dead string literal elimination (#3120)
+  09/09/16:
+    - disable function resolution optimization (#4476)
+  09/14/16:
+    - re-enable function resolution optimization (#4517)
 
 arrayPerformance-1d:
   03/19/15:
@@ -203,6 +218,18 @@ binary-trees:
 chameneos-redux:
   07/08/13:
     - altered output order for chameneos data, old data incompatible
+
+compSampler-timecomp:
+  09/09/16:
+    - disable function resolution optimization (#4476)
+  09/14/16:
+    - re-enable function resolution optimization (#4517)
+
+cg-sparse-timecomp:
+  09/09/16:
+    - disable function resolution optimization (#4476)
+  09/14/16:
+    - re-enable function resolution optimization (#4517)
 
 dgemm.128:
   09/06/13:
@@ -246,6 +273,12 @@ fasta:
     - optimize certain functions that return with ref-intent (#3101)
   03/12/16:
     - implemented good_alloc_size for jemalloc(#3446)
+
+fft-timecomp:
+  09/09/16:
+    - disable function resolution optimization (#4476)
+  09/14/16:
+    - re-enable function resolution optimization (#4517)
 
 forall-dom-range:
   01/21/15:
@@ -343,10 +376,6 @@ jacobi:
     - Improve and enable strided bulk transfer optimization as default (#4318)
   08/13/16:
     - Fix bulk transfer stride failure, cast to size_t for 32-bit support (#4329)
-  08/19/16:
-    - Turn denormalization on by default (reverted the next night) (#4360)
-  09/01/16:
-    - Turn denormalization on by default (#4434)
 
 
 
@@ -588,6 +617,18 @@ time_array_vs_ddata:
     - Optimize iteration over anonymous low-bounded counted ranges (#3154)
   03/01/16:
     - Extend early string-as-rec work to cover more sub-types of record (#3386)
+
+time_array_vs_ref:
+  09/13/16:
+    - stop converting "ref" variables to values in cullOverReferences (#4485)
+
+time_array_vs_ref_forall:
+  09/13/16:
+    - stop converting "ref" variables to values in cullOverReferences (#4485)
+
+time_array_vs_ref_multidim:
+  09/13/16:
+    - stop converting "ref" variables to values in cullOverReferences (#4485)
 
 time_array_vs_tuple:
   08/19/14:


### PR DESCRIPTION
- convert more reductions to use reduce intents (#4396):
  - improved perf for: [cg, 2D Matrix Multiply](http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/07&enddate=2016/09/10&graphs=nasparallelbenchmarkscgtimingssizea,2dmatrixmultiply), and [16 node lulesh] (http://chapel.sourceforge.net/perf/16-node-xc/?startdate=2016/09/03&enddate=2016/09/14&graphs=doeluleshdensetimesecsedov15oct)

<p>

- remove volatile on real atomics, make atomic_load atomic (#4491):
  - improved perf for [lcals pic_2d, atomic real fetchAdd, tree paircount] (http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/10&enddate=2016/09/14&graphs=lcalsrawomplong,buildingupassociativedomains,parallelatomicfetchaddtimesec,timetotreepaircount)  
  - hurt perf for [meteor (non-fast version)](http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/08/29&enddate=2016/09/14&graphs=meteorshootoutbenchmarkn2098), and [16 node RA] (http://chapel.sourceforge.net/perf/16-node-xc/?startdate=2016/09/07&enddate=2016/09/14&configs=gnuugnimuxed,gnuugniqthreads&graphs=hpccraatomicsperfgupsn233nu10m,hpccrarmoperfgupsn233nu10m)

<p>

- use "distrib" scheduler for numa instead of "sherwood" (#4505)
  - improved perf of [numa](http://chapel.sourceforge.net/perf/chapcs/numa/?startdate=2016/09/04&enddate=2016/09/14&suite=performancetracking) across the board

<p>

- enable native qthreds sync vars (#4506)
  - improved perf of [threadring](http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/10&enddate=2016/09/15&graphs=threadringshootoutbenchmarkn50000000)
  - hurt performance of [reductions] (http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/09&enddate=2016/09/14&graphs=luleshbradcstudyversion,nasparallelbenchmarkscgtimingssizea,serialreductionstyles,reductionstimesec,timetobuildtrees)

<p>

- Disabled and re-enabled function resolution optimization (#4476/#4517)
  - [hurt and restored compiler performance] (http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/06&enddate=2016/09/14&suite=compilerperformance)

<p>

- stop converting "ref" variables to values in cullOverReferences (#4485)
  - hurt perf of [array vs array ref access] (http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/07&enddate=2016/09/15&graphs=serialarrayaccessvsreferenceaccess,serialarrayaccessvsreferenceaccessinforallloop,serialarrayaccessvsreferenceaccessmultidimensional)