### PR TITLE
Work around a bug in some system <atomic> headers.

### DIFF
--- a/runtime/include/atomics/cstdlib/chpl-atomics.h
+++ b/runtime/include/atomics/cstdlib/chpl-atomics.h
@@ -42,7 +42,7 @@
     using std::atomic_uint_least32_t;
     using std::atomic_uint_least64_t;
     using std::atomic_uintptr_t;
-    using std::atomic_bool;
+    typedef std::atomic<bool> atomic_bool; // Work around broken <atomic>
     using std::memory_order_relaxed;
     using std::memory_order_consume;
     using std::memory_order_acquire;


### PR DESCRIPTION
Create our own typedef for atomic_bool.  This is identical to what valid \<atomic\> headers do, but it works around problems in systems that have broken versions of the header.