### PR TITLE
Revert "Make standard atomics the default for clang when appropriate"

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -7,7 +7,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_comm, chpl_compiler, chpl_platform, overrides
-from compiler_utils import CompVersion, get_compiler_version, has_std_atomics
+from compiler_utils import CompVersion, get_compiler_version
 from utils import memoize
 
 
@@ -45,10 +45,7 @@ def get(flag='target'):
             elif compiler_val == 'cray-prgenv-cray':
                 atomics_val = 'intrinsics'
             elif compiler_val == 'clang':
-                if has_std_atomics(compiler_val):
-                    atomics_val = 'cstdlib'
-                else:
-                    atomics_val = 'intrinsics'
+                atomics_val = 'intrinsics'
             elif compiler_val == 'clang-included':
                 atomics_val = 'intrinsics'
 

--- a/util/chplenv/compiler_utils.py
+++ b/util/chplenv/compiler_utils.py
@@ -12,29 +12,14 @@ from utils import memoize, run_command
 
 
 @memoize
-def get_compiler_name(compiler):
-    if compiler_is_prgenv(compiler):
-        return 'cc'
-    elif compiler == 'aarch64-gnu':
-        return 'aarch64-unknown-linux-gnu-gcc'
-    elif 'gnu' in compiler:
-        return 'gcc'
-    elif compiler == 'clang':
-        return 'clang'
-    elif compiler == 'intel':
-        return 'icc'
-    elif compiler == 'pgi':
-        return 'pgcc'
-    return 'other'
-
-
-@memoize
 def get_compiler_version(compiler):
     version_string = '0'
-    if 'gnu' in compiler:
+    if compiler == 'aarch64-gnu':
+        version_string = run_command(['aarch64-unknown-linux-gnu-gcc', '-dumpversion'])
+    elif 'gnu' in compiler:
         # Asssuming the 'compiler' version matches the gcc version
         # e.g., `mpicc -dumpversion == gcc -dumpversion`
-        version_string = run_command([get_compiler_name(compiler), '-dumpversion'])
+        version_string = run_command(['gcc', '-dumpversion'])
     elif 'cray-prgenv-cray' == compiler:
         version_string = os.environ.get('CRAY_CC_VERSION', '0')
     return CompVersion(version_string)
@@ -61,53 +46,6 @@ def CompVersion(version_string):
                          "a tuple".format(version_string))
 
 
-@memoize
 def compiler_is_prgenv(compiler_val):
   return (compiler_val.startswith('cray-prgenv') or
      os.environ.get('CHPL_ORIG_TARGET_COMPILER','').startswith('cray-prgenv'))
-
-
-def strip_preprocessor_lines(lines):
-    lines = [line for line in lines if len(line.split('#')[0].strip()) > 0]
-    return lines
-
-#
-# Determine whether a given compiler's default compilation mode
-# supports standard atomics by running the compiler and checking
-# how it expands key feature-test macros.
-#
-# The assumption is that if standard atomics make it into the
-# compiler's default compilation mode, then they actually work.
-# If they are not available in the default mode, they probably
-# have problems and we don't want to use them.
-#
-# Due to the command-line options required, this works for GCC,
-# Clang, and the Intel compiler, but probably not others.
-#
-@memoize
-def has_std_atomics(compiler_val):
-    try:
-        compiler_name = get_compiler_name(compiler_val)
-        if compiler_name == 'other':
-            return False
-
-        version_key='version'
-        atomics_key='atomics'
-
-        cmd_input = '{0}=__STDC_VERSION__\n{1}=__STDC_NO_ATOMICS__'.format(version_key, atomics_key)
-        cmd = [compiler_name, '-E', '-x', 'c', '-']
-        output = run_command(cmd, cmd_input=cmd_input)
-        output = strip_preprocessor_lines(output.splitlines())
-
-        output_dict = dict(line.split('=') for line in output)
-        version = output_dict[version_key].rstrip("L")
-        atomics = output_dict[atomics_key]
-
-        if version == "__STDC_VERSION__" or int(version) < 201112:
-            return False
-        # If the atomics macro was expanded, then we do not have support.
-        if atomics != "__STDC_NO_ATOMICS__":
-            return False
-        return True
-    except:
-        return False

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -20,13 +20,11 @@ class CommandError(Exception):
 
 # This could be replaced by subprocess.check_output, but that isn't available
 # until python 2.7 and we only have 2.6 on most machines :(
-def run_command(command, stdout=True, stderr=False, cmd_input=None):
+def run_command(command, stdout=True, stderr=False):
     process = subprocess.Popen(command,
                                stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE,
-                               stdin=subprocess.PIPE)
-    byte_cmd_input = str.encode(cmd_input) if cmd_input else None
-    output = process.communicate(input=byte_cmd_input)
+                               stderr=subprocess.PIPE)
+    output = process.communicate()
     if process.returncode != 0:
         raise CommandError(
             "command `{0}` failed - output was \n{1}".format(command,


### PR DESCRIPTION
Reverts chapel-lang/chapel#4480

There are just too many combinations of clang and broken types of \<atomic\> headers to make this work right now.  Will try again after the upcoming release by detecting broken headers in the chplenv scripts.