### PR TITLE
Do not make standard atomics the default for clang due to broken system headers.

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -7,7 +7,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_comm, chpl_compiler, chpl_platform, overrides
-from compiler_utils import CompVersion, get_compiler_version, has_std_atomics
+from compiler_utils import CompVersion, get_compiler_version
 from utils import memoize
 
 

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -45,10 +45,7 @@ def get(flag='target'):
             elif compiler_val == 'cray-prgenv-cray':
                 atomics_val = 'intrinsics'
             elif compiler_val == 'clang':
-                if has_std_atomics(compiler_val):
-                    atomics_val = 'cstdlib'
-                else:
-                    atomics_val = 'intrinsics'
+                atomics_val = 'intrinsics'
             elif compiler_val == 'clang-included':
                 atomics_val = 'intrinsics'
 


### PR DESCRIPTION
There are just too many types of broken system headers used by clang to make standard atomics the default right now.  Each obsolete operating system has its own.  Will try to find a way to detect them all after the release.