### PR TITLE
 Change default binary string format to data_toeof

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1290,7 +1290,8 @@ via the ``str_style`` field in :record:`iostyle`.
   most-significant. This way of encoding a variable-byte length  matches
   `Google Protocol Buffers <https://github.com/google/protobuf/>`_.
 * ``iostringstyle.data_toeof`` indicates a string format that contains
-  string data until the end of the file
+  only the string data without any length or terminator. When reading,
+  this format will read a string until the end of the file is reached.
 * ``iostringstyle.data_null`` indicates a string that is terminated
   by a zero byte. It can be combined with other numeric
   values to indicate a string terminated by a particular byte. For example,
@@ -1504,7 +1505,7 @@ extern record iostyle { // aka qio_style_t
      in binary mode? See :type:`iostringstyle` for more information
      on what the values of ``str_style`` mean.
    */
-  var str_style:int(64) = -10;
+  var str_style:int(64) = iostringstyle.data_toeof;
 
   // text style choices
   /* When performing text I/O, pad out to this many columns */

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1555,7 +1555,7 @@ extern record iostyle { // aka qio_style_t
      See :type:`iostringstyle` for more information
      on what the values of ``str_style`` mean.
    */
-  var string_format:uint(8) = iostringformat.word;
+  var string_format:uint(8) = iostringformat.word:uint(8);
   // numeric scanning/printing choices
   /* When reading or writing a numeric value in a text mode channel,
      what base should be used for the number? Default of 0 means decimal.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1313,6 +1313,35 @@ enum iostringstyle {
 
 /*
 
+This enum contains values used to control text I/O with strings
+via the ``string_format`` field in :record:`iostyle`.
+
+  * ``iostringformat.word`` means string is as-is;
+    reading reads until whitespace. This is the default.
+  * ``iostringformat.basic`` means only escape *string_end* and ``\``
+    with ``\``
+  * ``iostringformat.chpl`` means  escape *string_end*
+    ``\`` ``'`` ``"`` ``\n`` with ``\`` and
+    nonprinting characters ``c = 0xXY`` with ``\xXY``
+  * ``iostringformat.json`` means  escape *string_end* ``"`` and ``\``
+    with ``\``, and nonprinting characters ``c = \uABCD``
+  * ``iostringformat.toend`` means string is as-is; reading reads until
+    *string_end*
+  * ``iostringformat.toeof`` means string is as-is; reading reads until
+    end of file
+*/
+enum iostringformat {
+  word = 0,
+  basic = 1,
+  chpl = 2,
+  json = 3,
+  toend = 4,
+  toeof = 5,
+}
+
+
+/*
+
   This method returns the appropriate :record:`iostyle` ``str_style`` value
   to indicate a string format where strings are terminated by a
   particular byte.
@@ -1517,50 +1546,68 @@ extern record iostyle { // aka qio_style_t
   /* When performing text I/O, do not use more than this many bytes */
   var max_width_bytes:uint(32) = max(uint(32));
 
-  /* What character do we start strings with, when appropriate? */
+  /* What character do we start strings with, when appropriate? Default is " */
   var string_start:style_char_t = 0x22; // "
-  /* What character do we end strings with, when appropriate? */
+  /* What character do we end strings with, when appropriate? Default is " */
   var string_end:style_char_t = 0x22; // "
 
   /* How should we format strings when performing text I/O?
-
-      * ``QIO_STRING_FORMAT_WORD`` means string is as-is;
-        reading reads until whitespace.
-      * ``QIO_STRING_FORMAT_BASIC`` means only escape *string_end* and ``\``
-        with ``\``
-      * ``QIO_STRING_FORMAT_CHPL`` means  escape *string_end*
-        ``\`` ``'`` ``"`` ``\n`` with ``\`` and
-        nonprinting characters ``c = 0xXY`` with ``\xXY``
-      * ``QIO_STRING_FORMAT_JSON`` means  escape *string_end* ``"`` and ``\``
-        with ``\``, and nonprinting characters ``c = \uABCD``
-      * ``QIO_STRING_FORMAT_TOEND`` means string is as-is; reading reads until
-        *string_end*
-      * ``QIO_STRING_FORMAT_TOEOF`` means string is as-is; reading reads until
-        end of file
+     See :type:`iostringstyle` for more information
+     on what the values of ``str_style`` mean.
    */
-  var string_format:uint(8) = 0;
+  var string_format:uint(8) = iostringformat.word;
   // numeric scanning/printing choices
+  /* When reading or writing a numeric value in a text mode channel,
+     what base should be used for the number? Default of 0 means decimal.
+     Bases 2, 8, 10, 16 are supported for integers. Bases 10 and 16
+     are supported for real values.*/
   var base:uint(8) = 0;
+  /* When reading or writing a numeric value in a text mode channel,
+     how is the integer portion separated from the fractional portion?
+     Default is '.' */
   var point_char:style_char_t = 0x2e; // .
+  /* When reading or writing a numeric value in a text mode channel,
+     how is the exponent written? Default is 'e' */
   var exponent_char:style_char_t = 0x65; // e
+  /* When reading or writing a numeric value in a text mode channel,
+     when base is > 10, how is the exponent written? Default is 'e' */
   var other_exponent_char:style_char_t = 0x70; // p
+  /* What character denotes a positive number? Default is '+' */
   var positive_char:style_char_t = 0x2b; // +;
+  /* What character denotes a negative number? Default is '-' */
   var negative_char:style_char_t = 0x2d; // -;
+  /* What character follows an the imaginary number? Default is 'i' */
   var i_char:style_char_t = 0x69; // i
+  /* When writing in a base other than 10, should the prefix be used?
+     (e.g. hexadecimal numbers are prefixed with 0x) */
   var prefix_base:uint(8) = 1;
   // numeric printing choices
+  /* When padding with spaces, which pad character to use? Default is ' ' */
   var pad_char:style_char_t = 0x20; // ' '
+  /* When printing a positive numeric value, should the + be shown? */
   var showplus:uint(8) = 0;
+  /* When printing a numeric value in hexadecimal, should it be
+     uppercase? */
   var uppercase:uint(8) = 0;
+  /* When printing a numeric value in a field of specified width, should
+     the number be on the left (that is padded on the right?). The default
+     is to right-justify the number. */
   var leftjustify:uint(8) = 0;
+  /* When printing an integral value using a real format, should a trailing
+     decimal point be included? If so, the value 0 will be writtes as '0.' */
   var showpoint:uint(8) = 0;
+  /* When printing an integral value using a real format, should a trailing
+     decimal point and zero be included? If so, the value 0 will be writtes
+     as '0.0' */
   var showpointzero:uint(8) = 1;
+  /* Specifies the precision for real format conversions. See the description
+     of realfmt below. */
   var precision:int(32) = -1;
 
   /*
      Formatting of real numbers:
 
-       * 0 means  print out 'significant_digits' number of significant digits
+       * 0 means  print out 'precision' number of significant digits
          (%g in printf)
        * 1 means  print out 'precision' number of digits after the decimal point
          (%f)

--- a/runtime/include/qio/qio_style.h
+++ b/runtime/include/qio/qio_style.h
@@ -169,7 +169,7 @@ typedef struct qio_style_s {
 
   // numeric printing and scanning choice
   int32_t precision; // for floating point, number after decimal point.
-                     // or number of significant digits in realfmt 2.
+                     // or number of significant digits in realfmt 0.
                      // for integers, this is always the number
                      // of .000 zeros to print
                      // when reading, this number has no impact on floating

--- a/runtime/include/qio/qio_style.h
+++ b/runtime/include/qio/qio_style.h
@@ -43,6 +43,7 @@ typedef uint8_t style_char_t;
 #define QIO_STYLE_ELEMENT_SKIP_UNKNOWN_FIELDS 8
 
 
+// If these values change, also change iostringformat in IO.chpl
 #define QIO_STRING_FORMAT_WORD 0
 #define QIO_STRING_FORMAT_BASIC 1
 #define QIO_STRING_FORMAT_CHPL 2

--- a/runtime/include/qio/qio_style.h
+++ b/runtime/include/qio/qio_style.h
@@ -232,7 +232,7 @@ void qio_style_init_default(qio_style_t* s)
 
   s->binary = 0;
   s->byteorder = QIO_NATIVE;
-  s->str_style = -10;
+  s->str_style = -0xff00; // to EOF
 
   s->min_width_columns = 0;
   s->max_width_columns = UINT32_MAX;

--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -984,6 +984,7 @@ qioerr qio_channel_write_string(const int threadsafe, const int byteorder, const
       break;
     case QIO_BINARY_STRING_STYLE_TOEOF:
       // Just don't worry about the length - write len bytes.
+      break;
     default:
       if( str_style >= 0 ) {
         // MPF - perhaps we should allow writing a string

--- a/test/io/bradc/badWrite.bad
+++ b/test/io/bradc/badWrite.bad
@@ -1,2 +1,0 @@
-	>foo bar
->foo bar

--- a/test/io/bradc/badWrite.future
+++ b/test/io/bradc/badWrite.future
@@ -1,6 +1,0 @@
-bug: write(:string) not equivalent to writef("%s", :string) for binary I/O
-
-This test shows that these two ways of writing strings don't
-behave equivalently as I believe they should.  I believe the
-issue is that the former is trying to write the length of
-the string as a binary character prior to the string itself.

--- a/test/io/ferguson/io_test.chpl
+++ b/test/io/ferguson/io_test.chpl
@@ -81,7 +81,7 @@ proc test_readlines()
   if noisy then writeln("Testing readlines: itemReader");
   {
     var style = defaultIOStyle();
-    style.string_format = QIO_STRING_FORMAT_TOEND;
+    style.string_format = iostringformat.toend:uint(8);
     style.string_end = 0x0a;
     var ch = f.reader(style=style);
     for (line,i) in zip(ch.itemReader(string),1..) {

--- a/test/io/ferguson/io_test.chpl
+++ b/test/io/ferguson/io_test.chpl
@@ -39,9 +39,13 @@ proc testio(x)
 
   for i in 1..styles.size {
     var style = styles[i];
+    if noisy then writeln("STYLE ", i, " iodynamic");
     testio(iodynamic, style, x);
+    if noisy then writeln("STYLE ", i, " ionative");
     testio(ionative, style, x);
+    if noisy then writeln("STYLE ", i, " iobig");
     testio(iobig, style, x);
+    if noisy then writeln("STYLE ", i, " iolittle");
     testio(iolittle, style, x);
   }
 }

--- a/test/io/ferguson/read-style.chpl
+++ b/test/io/ferguson/read-style.chpl
@@ -12,7 +12,7 @@ var reader = open( file_name, iomode.r ).reader();
 
 var line_style = new iostyle();
 var line: string;
-line_style.string_format = QIO_STRING_FORMAT_TOEND;
+line_style.string_format = iostringformat.toend:uint(8);
 line_style.string_end = 0x0a; // ascii newline.
 while( reader.read( line, style=line_style ) ) do writeln( line );
 

--- a/test/io/ferguson/recordeof.chpl
+++ b/test/io/ferguson/recordeof.chpl
@@ -17,7 +17,7 @@ proc MyRecord.readWriteThis(f) {
 {
   // create a reader but specify that we'd like to use single-quoted strings.
   // 0x27 is ascii for '
-  var reader = f.reader(style=new iostyle(string_format=QIO_STRING_FORMAT_BASIC, string_start = 0x27, string_end = 0x27));
+  var reader = f.reader(style=new iostyle(string_format=iostringformat.basic:uint(8), string_start = 0x27, string_end = 0x27));
 
   var rec:MyRecord;
   var i = 1;

--- a/test/io/ferguson/utf8/widecols.chpl
+++ b/test/io/ferguson/utf8/widecols.chpl
@@ -29,7 +29,7 @@ for s in strings {
   writeln(new ioLiteral("|"));
 }
 
-st.string_format = QIO_STRING_FORMAT_CHPL;
+st.string_format = iostringformat.chpl:uint(8);
 st.min_width_columns = 79;
 st.leftjustify = 1;
 
@@ -49,7 +49,7 @@ for s in strings {
   writeln(new ioLiteral("|"));
 }
 
-st.string_format = QIO_STRING_FORMAT_JSON;
+st.string_format = iostringformat.json:uint(8);
 st.min_width_columns = 79;
 st.leftjustify = 1;
 

--- a/test/release/examples/patterns/recordio.chpl
+++ b/test/release/examples/patterns/recordio.chpl
@@ -108,7 +108,7 @@ proc MyRecord.readWriteThis(f) {
 {
   // create a reader but specify that we'd like to use single-quoted strings.
   // 0x27 is ascii for '
-  var reader = f.reader(style=new iostyle(string_format=QIO_STRING_FORMAT_BASIC, string_start = 0x27, string_end = 0x27));
+  var reader = f.reader(style=new iostyle(string_format=iostringformat.basic:uint(8), string_start = 0x27, string_end = 0x27));
 
   var rec:MyRecord;
   var i = 1;


### PR DESCRIPTION
Previously, the default binary string format was variable-byte-length followed by data. However, that format was confusing because

     textchannel.write(mystring)

outputs only the string data, but

     binarychannel.write(mystring)

would output a length in addition to the string data.

Now that we have formatted I/O (with writef and readf), it is more reasonable to make these two writes do the same thing. Someone wanting strings that can be read back in should be setting a string style or using formatted I/O.

While there, I updated some of the IO.chpl documentation and removed the need for the documentation to name some QIO_STRING_FORMAT_.... constants.

While I was able to remove uses of these QIO_STRING_FORMAT_... constants, the compiler currently requires a cast from their value to uint(8) in the examples using them. I'm leaving fixing that as future work. It is the same enum coercion issue that @bradcray mentioned in #4525.

Passed full local testing.
Reviewed by @benharsh - thanks!