### PR TITLE
Fix graph title in array-vs-ref perf test

### DIFF
--- a/test/arrays/diten/time_array_vs_ref_forall.graph
+++ b/test/arrays/diten/time_array_vs_ref_forall.graph
@@ -2,4 +2,4 @@ perfkeys: Array access:, Ref access:
 files: time_array_vs_ref_forall.dat, time_array_vs_ref_forall.dat
 ylabel: Time (seconds)
 graphname: time_array_vs_ref_forall
-graphtitle: Serial Array Access vs. Reference Access in forall loop
+graphtitle: Array Access vs. Reference Access in forall loop


### PR DESCRIPTION
The title accidentally included the word "serial" even though it was testing
a forall loop that was not serial.