### PR TITLE
Add perf annotation for using an atomic spin-lock with reductions

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -166,7 +166,9 @@ all:
     - remove volatile on real atomics, make atomic_load atomic (#4491)
     - use "distrib" scheduler for numa instead of "sherwood" (#4505)
   09/14/16:
-    - enable native qthreds sync vars (#4506)
+    - enable native qthreads sync vars (#4506)
+  09/15/16:
+    - use atomic spin-lock instead of sync for reductions (#4532)
 
 AllCompTime:
   11/09/14:


### PR DESCRIPTION
- use an atomic spin-lock instead of a sync var for reductions (#4532)
  - resolved [single locale] (http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/10&enddate=2016/09/16&graphs=luleshbradcstudyversion,nasparallelbenchmarkscgtimingssizea,serialreductionstyles,reductionstimesec,timetobuildtrees) reduction regressions caused by native qthread sync
    vars. In most cases reduction performance is actually better than it was
    before, particularly for [multi-locale](http://chapel.sourceforge.net/perf/16-node-xc/?startdate=2016/09/09&enddate=2016/09/16&graphs=reductionstimesec)