### PR TITLE
Remove typeToString

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1464,17 +1464,6 @@ module String {
   //
   // Param procs
   //
-  pragma "no doc"
-  proc typeToString(type t) param {
-    compilerWarning("typeToString() has been deprecated.  Please use a cast instead: '(type-expression):string'");
-    return __primitive("typeToString", t);
-  }
-
-  pragma "no doc"
-  proc typeToString(x) param {
-    compilerWarning("typeToString() has been deprecated.  Please use a cast instead: '(type-expression):string'");
-    compilerError("typeToString()'s argument must be a type, not a value");
-  }
 
   pragma "no doc"
   inline proc ==(param s0: string, param s1: string) param  {

--- a/test/deprecated/typeToString.chpl
+++ b/test/deprecated/typeToString.chpl
@@ -1,1 +1,0 @@
-writeln(typeToString(real));

--- a/test/deprecated/typeToString.good
+++ b/test/deprecated/typeToString.good
@@ -1,2 +1,0 @@
-typeToString.chpl:1: warning: typeToString() has been deprecated.  Please use a cast instead: '(type-expression):string'
-real(64)


### PR DESCRIPTION
In version 1.13.0, typeToString() was replaced with a cast from types
to strings and marked as deprecated.  This removes the feature for
1.14.0.