### PR TITLE
Retire future showing different ascii() return widths

### DIFF
--- a/test/types/string/diten/asciiSizes.bad
+++ b/test/types/string/diten/asciiSizes.bad
@@ -1,4 +1,0 @@
-(104, 104)
-param/var types don't match
-param: int(64)
-  var: int(32)

--- a/test/types/string/diten/asciiSizes.future
+++ b/test/types/string/diten/asciiSizes.future
@@ -1,4 +1,0 @@
-bug: return type of param 'ascii' doesn't match return type of var 'ascii'
-
-When the string argument to ascii is a param, it returns an int(64), but when
-it is a var or const, ascii returns an int(32).


### PR DESCRIPTION
My original PR for ascii()->uint(8) test run included
futures, but hadn't yet fixed the param return type
yet, so didn't catch that a future exercised it.  The
second run I didn't bother running futures, thinking
that there weren't any that would benefit.  But there
was one!  Retire it now that things are working better.