### PR TITLE
Binary literal syntax highlighting

### DIFF
--- a/doc/sphinx/source/_static/empty
+++ b/doc/sphinx/source/_static/empty
@@ -1,1 +1,0 @@
-This directory is empty.

--- a/doc/sphinx/source/_static/style.css
+++ b/doc/sphinx/source/_static/style.css
@@ -7,3 +7,7 @@
 .rst-content .section ol.lowerroman, .rst-content .section ol.lowerroman li {
   list-style: lower-roman;
 }
+
+/* Add color for .mb class that is undefined in Sphinx RTD theme */
+.highlight .mb{ color: #099}
+

--- a/doc/sphinx/source/_templates/empty
+++ b/doc/sphinx/source/_templates/empty
@@ -1,1 +1,0 @@
-This directory is empty.

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -101,7 +101,7 @@ exclude_patterns = []
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+#pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
Sphinx read-the-docs theme does not define this particular css class by default and it ignores the `pygments_style` variable in `conf.py`, so I definite it in `style.css`.

Also removed unnecessary place-holder files and commented out the `pygments_style` line to reduce further confusion in the future.