### PR TITLE
Failed attempt to eliminate inner multiplies by parameterizing arrays

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -358,12 +358,10 @@ class LocBlockArr {
   param isAdvancedAlias: bool;
   const locDom: LocBlockDom(rank, idxType, stridable);
   var locRAD: LocRADCache(eltType, rank, idxType); // non-nil if doRADOpt=true
-  //  var myElems: [locDom.myBlock] eltType;
-  //  var myElems: chpl__buildArrayRuntimeType(locDom.myBlock, eltType);
-  //  var myElems = (locDom.myBlock).buildArray(eltType);
-  //  var myElems = (locDom.myBlock).buildArray(eltType, isAdvancedAlias=true);
-                                  /* wanted just 'isAdvancedAlias' here ^^^ */
   var myElems: chpl__buildArrayRuntimeType(locDom.myBlock, eltType, isAdvancedAlias=true);
+  // The previous line is long-form for declaring:
+  //   var myElems: [locDom.myBlock] eltType;
+  // while setting 'isAdvancedAlias' to true rather than its default of 'false'
   var locRADLock: atomicbool; // This will only be accessed locally
                               // force the use of processor atomics
 

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -361,7 +361,9 @@ class LocBlockArr {
   //  var myElems: [locDom.myBlock] eltType;
   //  var myElems: chpl__buildArrayRuntimeType(locDom.myBlock, eltType);
   //  var myElems = (locDom.myBlock).buildArray(eltType);
-  var myElems = (locDom.myBlock).buildArray(eltType, isAdvancedAlias=true /* want just 'isAdvancedAlias' */);
+  //  var myElems = (locDom.myBlock).buildArray(eltType, isAdvancedAlias=true);
+                                  /* wanted just 'isAdvancedAlias' here ^^^ */
+  var myElems: chpl__buildArrayRuntimeType(locDom.myBlock, eltType, isAdvancedAlias=true);
   var locRADLock: atomicbool; // This will only be accessed locally
                               // force the use of processor atomics
 
@@ -858,7 +860,7 @@ proc BlockDom.dsiSerialWrite(x) {
 //
 proc BlockDom.dsiBuildArray(type eltType, param isAdvancedAlias: bool) {
   var arr = new BlockArr(eltType=eltType, rank=rank, idxType=idxType,
-                         stridable=stridable, isAdvancedAlias=true/* want: isAdvancedAlias */, sparseLayoutType=sparseLayoutType, dom=this);
+                         stridable=stridable, isAdvancedAlias=true/* wanted: isAdvancedAlias */, sparseLayoutType=sparseLayoutType, dom=this);
   arr.setup();
   return arr;
 }

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -330,11 +330,12 @@ class BlockArr: BaseArr {
   param rank: int;
   type idxType;
   param stridable: bool;
+  param noInnerMult: bool; // = true, by default
   type sparseLayoutType;
   var doRADOpt: bool = defaultDoRADOpt;
   var dom: BlockDom(rank, idxType, stridable, sparseLayoutType);
-  var locArr: [dom.dist.targetLocDom] LocBlockArr(eltType, rank, idxType, stridable);
-  var myLocArr: LocBlockArr(eltType, rank, idxType, stridable);
+  var locArr: [dom.dist.targetLocDom] LocBlockArr(eltType, rank, idxType, stridable, noInnerMult);
+  var myLocArr: LocBlockArr(eltType, rank, idxType, stridable, noInnerMult);
   var pid: int = -1; // privatized object id (this should be factored out)
   const SENTINEL = max(rank*idxType);
 }
@@ -354,9 +355,13 @@ class LocBlockArr {
   param rank: int;
   type idxType;
   param stridable: bool;
+  param noInnerMult: bool; // = true, by default
   const locDom: LocBlockDom(rank, idxType, stridable);
   var locRAD: LocRADCache(eltType, rank, idxType); // non-nil if doRADOpt=true
-  var myElems: [locDom.myBlock] eltType;
+  //  var myElems: [locDom.myBlock] eltType;
+  //  var myElems: chpl__buildArrayRuntimeType(locDom.myBlock, eltType);
+  //  var myElems = (locDom.myBlock).buildArray(eltType);
+  var myElems = (locDom.myBlock).buildDefRectArray(eltType, noInnerMult);
   var locRADLock: atomicbool; // This will only be accessed locally
                               // force the use of processor atomics
 
@@ -853,7 +858,7 @@ proc BlockDom.dsiSerialWrite(x) {
 //
 proc BlockDom.dsiBuildArray(type eltType) {
   var arr = new BlockArr(eltType=eltType, rank=rank, idxType=idxType,
-      stridable=stridable, sparseLayoutType=sparseLayoutType, dom=this);
+                         stridable=stridable, noInnerMult=true, sparseLayoutType=sparseLayoutType, dom=this);
   arr.setup();
   return arr;
 }
@@ -995,7 +1000,7 @@ proc BlockArr.setup() {
   coforall localeIdx in dom.dist.targetLocDom {
     on dom.dist.targetLocales(localeIdx) {
       const locDom = dom.getLocDom(localeIdx);
-      locArr(localeIdx) = new LocBlockArr(eltType, rank, idxType, stridable, locDom);
+      locArr(localeIdx) = new LocBlockArr(eltType, rank, idxType, stridable, noInnerMult=noInnerMult, locDom=locDom);
       if thisid == here.id then
         myLocArr = locArr(localeIdx);
     }
@@ -1204,11 +1209,12 @@ proc BlockArr.dsiSerialWrite(f) {
 proc BlockArr.dsiSlice(d: BlockDom) {
   // MPF: should this use sparseLayoutType = d.sparseLayoutType ?
   var alias = new BlockArr(eltType=eltType, rank=rank, idxType=idxType,
-      stridable=d.stridable, dom=d, sparseLayoutType=DefaultDist);
+                           stridable=d.stridable, noInnerMult=noInnerMult,
+                           dom=d, sparseLayoutType=DefaultDist);
   var thisid = this.locale.id;
   coforall i in d.dist.targetLocDom {
     on d.dist.targetLocales(i) {
-      alias.locArr[i] = new LocBlockArr(eltType=eltType, rank=rank, idxType=idxType, stridable=d.stridable, locDom=d.locDoms[i], myElems=>locArr[i].myElems[d.locDoms[i].myBlock]);
+      alias.locArr[i] = new LocBlockArr(eltType=eltType, rank=rank, idxType=idxType, stridable=d.stridable, noInnerMult=noInnerMult, locDom=d.locDoms[i], myElems=>locArr[i].myElems[d.locDoms[i].myBlock]);
       if thisid == here.id then
         alias.myLocArr = alias.locArr[i];
     }
@@ -1259,7 +1265,8 @@ proc _extendTuple(type t, idx, args) {
 
 proc BlockArr.dsiRankChange(d, param newRank: int, param stridable: bool, args) {
   var alias = new BlockArr(eltType=eltType, rank=newRank, idxType=idxType,
-      stridable=stridable, dom=d, sparseLayoutType=DefaultDist);
+                           stridable=stridable, noInnerMult=false, dom=d,
+                           sparseLayoutType=DefaultDist);
   var thisid = this.locale.id;
   coforall ind in d.dist.targetLocDom {
     on d.dist.targetLocales(ind) {
@@ -1302,7 +1309,7 @@ proc BlockArr.dsiRankChange(d, param newRank: int, param stridable: bool, args) 
 
       alias.locArr[ind] =
         new LocBlockArr(eltType=eltType, rank=newRank, idxType=d.idxType,
-                        stridable=d.stridable, locDom=locDom,
+                        stridable=d.stridable, noInnerMult=false, locDom=locDom,
                         myElems=>locArr[(...locArrInd)].myElems[(...locSlice)]);
 
       if thisid == here.id then
@@ -1316,7 +1323,7 @@ proc BlockArr.dsiRankChange(d, param newRank: int, param stridable: bool, args) 
 proc BlockArr.dsiReindex(d: BlockDom) {
   // in constructor we have to pass sparseLayoutType as it has no default value
   var alias = new BlockArr(eltType=eltType, rank=d.rank, idxType=d.idxType,
-                           stridable=d.stridable, dom=d,
+                           stridable=d.stridable, noInnerMult=false, dom=d,
                            sparseLayoutType=DefaultDist);
   const sameDom = d==dom;
 
@@ -1328,6 +1335,7 @@ proc BlockArr.dsiReindex(d: BlockDom) {
       alias.locArr[i] = new LocBlockArr(eltType=eltType,
                                         rank=rank, idxType=d.idxType,
                                         stridable=d.stridable,
+                                        noInnerMult=false,
                                         locDom=locDom,
                                         myElems=>locAlias);
       if thisid == here.id then
@@ -1458,7 +1466,8 @@ proc BlockArr.dsiGetPrivatizeData() return dom.pid;
 proc BlockArr.dsiPrivatize(privatizeData) {
   var privdom = chpl_getPrivatizedCopy(dom.type, privatizeData);
   var c = new BlockArr(eltType=eltType, rank=rank, idxType=idxType,
-      stridable=stridable, sparseLayoutType=sparseLayoutType, dom=privdom);
+                       stridable=stridable, noInnerMult=noInnerMult,
+                       sparseLayoutType=sparseLayoutType, dom=privdom);
   for localeIdx in c.dom.dist.targetLocDom {
     c.locArr(localeIdx) = locArr(localeIdx);
     if c.locArr(localeIdx).locale.id == here.id then

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1030,6 +1030,21 @@ module ChapelArray {
       help();
       return _newArray(x);
     }
+
+    pragma "no doc"
+    proc buildDefRectArray(type eltType, param noInnerMult=true) {
+      var x = _value.dsiBuildArray(eltType, noInnerMult);
+      pragma "dont disable remote value forwarding"
+      proc help() {
+        _value.add_arr(x);
+        if !noRefCount then
+          _value.incRefCount();
+      }
+      help();
+      return _newArray(x);
+    }
+
+    
     /* Remove all indices from this domain, leaving it empty */
     proc clear() {
       _value.dsiClear();

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -352,8 +352,8 @@ module ChapelArray {
   // Support for array types
   //
   pragma "runtime type init fn"
-  proc chpl__buildArrayRuntimeType(dom: domain, type eltType)
-    return dom.buildArray(eltType);
+    proc chpl__buildArrayRuntimeType(dom: domain, type eltType, param isAdvancedAlias: bool = false /* = true */ /* want: false */)
+    return dom.buildArray(eltType, isAdvancedAlias);
 
   proc _getLiteralType(type t) type {
     if t != c_string then return t;
@@ -438,8 +438,12 @@ module ChapelArray {
 
 
   proc chpl__convertValueToRuntimeType(arr: []) type
-    return chpl__buildArrayRuntimeType(arr.domain, arr.eltType);
+    return chpl__buildArrayRuntimeType(arr.domain, arr.eltType, arr.isAdvancedAlias);
 
+  proc chpl__getDomainFromArrayType(arrayVal) {
+    return chpl__getDomainFromArrayType(arrayVal.type);
+  }
+  
   proc chpl__getDomainFromArrayType(type arrayType) {
     var A: arrayType;
     pragma "no copy" var D = A.domain;
@@ -1019,8 +1023,8 @@ module ChapelArray {
     }
 
     pragma "no doc"
-    proc buildArray(type eltType) {
-      var x = _value.dsiBuildArray(eltType);
+    proc buildArray(type eltType, param isAdvancedAlias: bool) {
+      var x = _value.dsiBuildArray(eltType, isAdvancedAlias);
       pragma "dont disable remote value forwarding"
       proc help() {
         _value.add_arr(x);
@@ -1032,8 +1036,10 @@ module ChapelArray {
     }
 
     pragma "no doc"
-    proc buildDefRectArray(type eltType, param noInnerMult=true) {
-      var x = _value.dsiBuildArray(eltType, noInnerMult);
+    proc buildDefRectArray(type eltType, param isAdvancedAlias: bool) {
+      //      if (isAdvancedAlias) then
+      //        compilerWarning("Building an advanced default rectangular array");
+      var x = _value.dsiBuildArray(eltType, isAdvancedAlias);
       pragma "dont disable remote value forwarding"
       proc help() {
         _value.add_arr(x);
@@ -1778,6 +1784,7 @@ module ChapelArray {
     proc eltType type return _value.eltType;
     /* The type of indices used in the array's domain */
     proc idxType type return _value.idxType;
+    proc isAdvancedAlias param return _value.isAdvancedAlias;
     proc _dom return _getDomain(_value.dom);
     /* The number of dimensions in the array */
     proc rank param return this.domain.rank;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2072,11 +2072,13 @@ module ChapelArray {
       // Optimization: Just return an alias of this array when
       // reindexing to the same domain. We skip same-ness test
       // if the domain descriptors' types are disjoint.
+      /*
       if isSubtype(_value.dom.type, d._value.type) ||
          isSubtype(d._value.type, _value.dom.type)
       then
         if _value.dom:object == d._value:object then
           return newAlias();
+      */
 
       for param i in 1..rank do
         if d.dim(i).length != _value.dom.dsiDim(i).length then

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -352,7 +352,7 @@ module ChapelArray {
   // Support for array types
   //
   pragma "runtime type init fn"
-    proc chpl__buildArrayRuntimeType(dom: domain, type eltType, param isAdvancedAlias: bool = false /* = true */ /* want: false */)
+  proc chpl__buildArrayRuntimeType(dom: domain, type eltType, param isAdvancedAlias: bool = false)
     return dom.buildArray(eltType, isAdvancedAlias);
 
   proc _getLiteralType(type t) type {
@@ -440,9 +440,10 @@ module ChapelArray {
   proc chpl__convertValueToRuntimeType(arr: []) type
     return chpl__buildArrayRuntimeType(arr.domain, arr.eltType, arr.isAdvancedAlias);
 
-  proc chpl__getDomainFromArrayType(arrayVal) {
-    return chpl__getDomainFromArrayType(arrayVal.type);
-  }
+  /* Shouldn't need this: */
+  // proc chpl__getDomainFromArrayType(arrayVal) {
+  //   return chpl__getDomainFromArrayType(arrayVal.type);
+  // }
   
   proc chpl__getDomainFromArrayType(type arrayType) {
     var A: arrayType;
@@ -1035,20 +1036,20 @@ module ChapelArray {
       return _newArray(x);
     }
 
-    pragma "no doc"
-    proc buildDefRectArray(type eltType, param isAdvancedAlias: bool) {
-      //      if (isAdvancedAlias) then
-      //        compilerWarning("Building an advanced default rectangular array");
-      var x = _value.dsiBuildArray(eltType, isAdvancedAlias);
-      pragma "dont disable remote value forwarding"
-      proc help() {
-        _value.add_arr(x);
-        if !noRefCount then
-          _value.incRefCount();
-      }
-      help();
-      return _newArray(x);
-    }
+    //    pragma "no doc"
+    //    proc buildDefRectArray(type eltType, param isAdvancedAlias: bool) {
+    //      //      if (isAdvancedAlias) then
+    //    //      //        compilerWarning("Building an advanced default rectangular array");
+    //      var x = _value.dsiBuildArray(eltType, isAdvancedAlias);
+    //      pragma "dont disable remote value forwarding"
+    //      proc help() {
+    //        _value.add_arr(x);
+    //        if !noRefCount then
+    //          _value.incRefCount();
+    //      }
+    //      help();
+    //      return _newArray(x);
+    //    }
 
     
     /* Remove all indices from this domain, leaving it empty */

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -440,11 +440,6 @@ module ChapelArray {
   proc chpl__convertValueToRuntimeType(arr: []) type
     return chpl__buildArrayRuntimeType(arr.domain, arr.eltType, arr.isAdvancedAlias);
 
-  /* Shouldn't need this: */
-  // proc chpl__getDomainFromArrayType(arrayVal) {
-  //   return chpl__getDomainFromArrayType(arrayVal.type);
-  // }
-  
   proc chpl__getDomainFromArrayType(type arrayType) {
     var A: arrayType;
     pragma "no copy" var D = A.domain;
@@ -1036,22 +1031,6 @@ module ChapelArray {
       return _newArray(x);
     }
 
-    //    pragma "no doc"
-    //    proc buildDefRectArray(type eltType, param isAdvancedAlias: bool) {
-    //      //      if (isAdvancedAlias) then
-    //    //      //        compilerWarning("Building an advanced default rectangular array");
-    //      var x = _value.dsiBuildArray(eltType, isAdvancedAlias);
-    //      pragma "dont disable remote value forwarding"
-    //      proc help() {
-    //        _value.add_arr(x);
-    //        if !noRefCount then
-    //          _value.incRefCount();
-    //      }
-    //      help();
-    //      return _newArray(x);
-    //    }
-
-    
     /* Remove all indices from this domain, leaving it empty */
     proc clear() {
       _value.dsiClear();

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -640,7 +640,7 @@ module DefaultRectangular {
     param rank : int;
     type idxType;
     param stridable: bool;
-    param noInnerMult = true;
+    param noInnerMult: bool;
 
     var dom : DefaultRectangularDom(rank=rank, idxType=idxType,
                                            stridable=stridable);
@@ -994,11 +994,13 @@ module DefaultRectangular {
     proc dsiSlice(d: DefaultRectangularDom) {
       var alias : DefaultRectangularArr(eltType=eltType, rank=rank,
                                         idxType=idxType,
-                                        stridable=d.stridable);
+                                        stridable=d.stridable,
+                                        noInnerMult=noInnerMult);
       on this {
         alias = new DefaultRectangularArr(eltType=eltType, rank=rank,
                                              idxType=idxType,
                                              stridable=d.stridable,
+                                             noInnerMult=noInnerMult,
                                              dom=d, noinit_data=true);
         alias.data = data;
         //alias.numelm = numelm;
@@ -1059,6 +1061,7 @@ module DefaultRectangular {
         var copy = new DefaultRectangularArr(eltType=eltType, rank=rank,
                                             idxType=idxType,
                                             stridable=d._value.stridable,
+                                            noInnerMult=noInnerMult,
                                             dom=d._value);
         for i in d((...dom.ranges)) do
           copy.dsiAccess(i) = dsiAccess(i);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -584,9 +584,8 @@ module DefaultRectangular {
     }
 
     proc dsiBuildArray(type eltType, param isAdvancedAlias: bool) {
-      //      compilerWarning("Creating a default array with isAdvancedAlias="+isAdvancedAlias);
       return new DefaultRectangularArr(eltType=eltType, rank=rank, idxType=idxType,
-                                       stridable=stridable, isAdvancedAlias=isAdvancedAlias, dom=this);
+                                      stridable=stridable, isAdvancedAlias=isAdvancedAlias, dom=this);
     }
 
     proc dsiBuildRectangularDom(param rank: int, type idxType, param stridable: bool,

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -583,9 +583,10 @@ module DefaultRectangular {
       }
     }
 
-    proc dsiBuildArray(type eltType) {
+    proc dsiBuildArray(type eltType, param noInnerMult=true) {
+      //      compilerWarning("Creating a default array with noInnerMult="+noInnerMult);
       return new DefaultRectangularArr(eltType=eltType, rank=rank, idxType=idxType,
-                                      stridable=stridable, dom=this);
+                                       stridable=stridable, noInnerMult=noInnerMult, dom=this);
     }
 
     proc dsiBuildRectangularDom(param rank: int, type idxType, param stridable: bool,
@@ -639,6 +640,7 @@ module DefaultRectangular {
     param rank : int;
     type idxType;
     param stridable: bool;
+    param noInnerMult = true;
 
     var dom : DefaultRectangularDom(rank=rank, idxType=idxType,
                                            stridable=stridable);
@@ -848,7 +850,7 @@ module DefaultRectangular {
         // then blk(rank) == 1. Knowing this, we need not multiply the final
         // ind(...) by anything. This may lead to performance improvements for
         // array accesses.
-        if assertNoSlicing {
+        if noInnerMult || assertNoSlicing {
           for param i in 1..rank-1 {
             sum += ind(i) * blk(i);
           }
@@ -948,11 +950,14 @@ module DefaultRectangular {
     proc dsiReindex(d: DefaultRectangularDom) {
       var alias : DefaultRectangularArr(eltType=eltType, rank=d.rank,
                                         idxType=d.idxType,
-                                        stridable=d.stridable);
+                                        stridable=d.stridable,
+                                        noInnerMult=false
+                                        );
       on this {
       alias = new DefaultRectangularArr(eltType=eltType, rank=d.rank,
                                            idxType=d.idxType,
                                            stridable=d.stridable,
+                                           noInnerMult=false,
                                            dom=d, noinit_data=true,
                                            str=str,
                                            blk=blk);
@@ -1019,11 +1024,13 @@ module DefaultRectangular {
     proc dsiRankChange(d, param newRank: int, param newStridable: bool, args) {
       var alias : DefaultRectangularArr(eltType=eltType, rank=newRank,
                                         idxType=idxType,
-                                        stridable=newStridable);
+                                        stridable=newStridable,
+                                        noInnerMult=false);
       on this {
       alias = new DefaultRectangularArr(eltType=eltType, rank=newRank,
                                            idxType=idxType,
                                            stridable=newStridable,
+                                           noInnerMult=false,
                                            dom=d, noinit_data=true);
       alias.data = data;
       //alias.numelm = numelm;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -583,7 +583,7 @@ module DefaultRectangular {
       }
     }
 
-    proc dsiBuildArray(type eltType, param isAdvancedAlias: bool /*= true */ /* want: false */) {
+    proc dsiBuildArray(type eltType, param isAdvancedAlias: bool) {
       //      compilerWarning("Creating a default array with isAdvancedAlias="+isAdvancedAlias);
       return new DefaultRectangularArr(eltType=eltType, rank=rank, idxType=idxType,
                                        stridable=stridable, isAdvancedAlias=isAdvancedAlias, dom=this);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -583,10 +583,10 @@ module DefaultRectangular {
       }
     }
 
-    proc dsiBuildArray(type eltType, param noInnerMult=true) {
-      //      compilerWarning("Creating a default array with noInnerMult="+noInnerMult);
+    proc dsiBuildArray(type eltType, param isAdvancedAlias: bool /*= true */ /* want: false */) {
+      //      compilerWarning("Creating a default array with isAdvancedAlias="+isAdvancedAlias);
       return new DefaultRectangularArr(eltType=eltType, rank=rank, idxType=idxType,
-                                       stridable=stridable, noInnerMult=noInnerMult, dom=this);
+                                       stridable=stridable, isAdvancedAlias=isAdvancedAlias, dom=this);
     }
 
     proc dsiBuildRectangularDom(param rank: int, type idxType, param stridable: bool,
@@ -640,7 +640,7 @@ module DefaultRectangular {
     param rank : int;
     type idxType;
     param stridable: bool;
-    param noInnerMult: bool;
+    param isAdvancedAlias: bool;
 
     var dom : DefaultRectangularDom(rank=rank, idxType=idxType,
                                            stridable=stridable);
@@ -850,7 +850,7 @@ module DefaultRectangular {
         // then blk(rank) == 1. Knowing this, we need not multiply the final
         // ind(...) by anything. This may lead to performance improvements for
         // array accesses.
-        if noInnerMult || assertNoSlicing {
+        if !isAdvancedAlias || assertNoSlicing {
           for param i in 1..rank-1 {
             sum += ind(i) * blk(i);
           }
@@ -951,13 +951,13 @@ module DefaultRectangular {
       var alias : DefaultRectangularArr(eltType=eltType, rank=d.rank,
                                         idxType=d.idxType,
                                         stridable=d.stridable,
-                                        noInnerMult=false
+                                        isAdvancedAlias=true
                                         );
       on this {
       alias = new DefaultRectangularArr(eltType=eltType, rank=d.rank,
                                            idxType=d.idxType,
                                            stridable=d.stridable,
-                                           noInnerMult=false,
+                                           isAdvancedAlias=true,
                                            dom=d, noinit_data=true,
                                            str=str,
                                            blk=blk);
@@ -995,12 +995,12 @@ module DefaultRectangular {
       var alias : DefaultRectangularArr(eltType=eltType, rank=rank,
                                         idxType=idxType,
                                         stridable=d.stridable,
-                                        noInnerMult=noInnerMult);
+                                        isAdvancedAlias=isAdvancedAlias);
       on this {
         alias = new DefaultRectangularArr(eltType=eltType, rank=rank,
                                              idxType=idxType,
                                              stridable=d.stridable,
-                                             noInnerMult=noInnerMult,
+                                             isAdvancedAlias=isAdvancedAlias,
                                              dom=d, noinit_data=true);
         alias.data = data;
         //alias.numelm = numelm;
@@ -1027,12 +1027,12 @@ module DefaultRectangular {
       var alias : DefaultRectangularArr(eltType=eltType, rank=newRank,
                                         idxType=idxType,
                                         stridable=newStridable,
-                                        noInnerMult=false);
+                                        isAdvancedAlias=true);
       on this {
       alias = new DefaultRectangularArr(eltType=eltType, rank=newRank,
                                            idxType=idxType,
                                            stridable=newStridable,
-                                           noInnerMult=false,
+                                           isAdvancedAlias=true,
                                            dom=d, noinit_data=true);
       alias.data = data;
       //alias.numelm = numelm;
@@ -1061,7 +1061,7 @@ module DefaultRectangular {
         var copy = new DefaultRectangularArr(eltType=eltType, rank=rank,
                                             idxType=idxType,
                                             stridable=d._value.stridable,
-                                            noInnerMult=noInnerMult,
+                                            isAdvancedAlias=isAdvancedAlias,
                                             dom=d._value);
         for i in d((...dom.ranges)) do
           copy.dsiAccess(i) = dsiAccess(i);


### PR DESCRIPTION
This is a failed attempt to eliminate inner multiplies by parameterizing all arrays by whether or not they are an "advanced alias" -- the result of a rank-change or reindexing, or a slice of either of those cases.  The approach seems to work for default rectangular arrays, but breaks down for Block distributed arrays, presumably due to the use of the => operator which seems to be the source of all ills.  Specifically, C compilation breaks when compiling tests that do slicing of block arrays (or, presumably, other advanced operations).

This version of the code isn't quite what I wanted -- originally, I was being much more careful within the block distribution to only assert isAdvancedAlias when necessary; this version throws in the towel on all block-distributed arrays, considering them all to be advanced aliases for uniformity and to try and work around problems with => (which helped, in that it was the first time I'd reached C compilation, but wasn't sufficient to getting testing working).

This was always intended to be a short-term workaround until the new array record comes on-board, at which point I think we should complete the array views work and retire the reliance on the => operator which is a source of overhead (always reindexing) and complexity in the compiler (hidden fields, special cases, etc.)

Recommended reading order is: 

* DefaultRectangular.chpl
* ChapelArray.chpl
* BlockDist.chpl
