### PR TITLE
Print an explanation upon const error due to task/forall intents

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2606,6 +2606,7 @@ buildCobeginStmt(CallExpr* byref_vars, BlockStmt* block) {
   block->insertAtTail(new CallExpr("_waitEndCount", cobeginCount));
   block->insertAtTail(new CallExpr("_endCountFree", cobeginCount));
 
+  block->astloc = cobeginCount->astloc; // grab the location of 'cobegin' kw
   return block;
 }
 

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -78,6 +78,8 @@ symbolFlag( FLAG_COMPILER_NESTED_FUNCTION , npr, "compiler nested function" , nc
 symbolFlag( FLAG_CONCURRENTLY_ACCESSED , npr, "concurrently accessed" , "local variables accessed by multiple threads" )
 symbolFlag( FLAG_CONFIG , npr, "config" , "config variable, constant, or parameter" )
 symbolFlag( FLAG_CONST , npr, "const" , "constant" )
+// this shadow variable is constant, whereas the outer variable is not
+symbolFlag( FLAG_CONST_DUE_TO_TASK_FORALL_INTENT , npr, "const due to task or forall intent", ncm )
 symbolFlag( FLAG_C_PTR_CLASS , ypr, "c_ptr class" , "marks c_ptr class" )
 symbolFlag( FLAG_CONSTRUCTOR , npr, "constructor" , "constructor (but not type constructor); loosely defined to include constructor wrappers" )
 symbolFlag( FLAG_DATA_CLASS , ypr, "data class" , ncm )

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -431,6 +431,8 @@ addVarsToFormalsActuals(FnSymbol* fn, SymbolMap& vars,
               newFormal->addFlag(FLAG_MARKED_GENERIC);
           newActual = e->key;
           symReplace = newFormal;
+          if (!newActual->isConstant() && newFormal->isConstant())
+            newFormal->addFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
         }
 
         call->insertAtTail(newActual);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4284,6 +4284,31 @@ static void lvalueCheck(CallExpr* call)
                          calleeFn->name, calleeParens);
         }
       }
+      if (SymExpr* aSE = toSymExpr(actual)) {
+        Symbol* aVar = aSE->var;
+        if (aVar->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT)) {
+          const char* varname = aVar->name;
+          if (!strncmp(varname, "_formal_tmp_", 12))
+            varname += 12;
+          if (isArgSymbol(aVar) || aVar->hasFlag(FLAG_TEMP)) {
+            Symbol* enclTaskFn = aVar->defPoint->parentSymbol;
+            BaseAST* marker;
+            const char* constructName;
+            if (enclTaskFn->hasFlag(FLAG_BEGIN)) {
+              // enclTaskFn points to a good line number
+              marker = enclTaskFn;
+              constructName = "begin";
+            } else {
+              marker = enclTaskFn->defPoint->parentExpr;
+              constructName = "cobegin or coforall";
+            }
+            USR_PRINT(marker, "The shadow variable '%s' is constant due to task intents in this %s statement", varname, constructName);
+          } else {
+            Expr* enclLoop = aVar->defPoint->parentExpr;
+            USR_PRINT(enclLoop, "The shadow variable '%s' is constant due to forall intents in this loop", varname);
+          }
+        }
+      }
     }
   }
 }
@@ -4823,6 +4848,8 @@ insertFormalTemps(FnSymbol* fn) {
     if (formalRequiresTemp(formal)) {
       SET_LINENO(formal);
       VarSymbol* tmp = newTemp(astr("_formal_tmp_", formal->name));
+      if (formal->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT))
+        tmp->addFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
       formals2vars.put(formal, tmp);
     }
   }

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -128,9 +128,12 @@ static void findOuterVars(BlockStmt* block, SymbolMap& uses) {
 }
 
 // Not to be invoked upon a reduce intent.
-static void setShadowVarFlags(VarSymbol* svar, IntentTag intent) {
-  if (intent & INTENT_FLAG_CONST)
+static void setShadowVarFlags(Symbol* ovar, VarSymbol* svar, IntentTag intent) {
+  if (intent & INTENT_FLAG_CONST) {
     svar->addFlag(FLAG_CONST);
+    if (!ovar->isConstant())
+      svar->addFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
+  }
   if (intent & INTENT_FLAG_REF) {
     INT_ASSERT(!(intent & INTENT_FLAG_IN));
     svar->addFlag(FLAG_REF_VAR);
@@ -272,7 +275,7 @@ static void createShadowVars(DefExpr* defChplIter, SymbolMap& uses,
       svar->addFlag(FLAG_REF_VAR);
       svar->type = valtype->getRefType();
     } else {
-      setShadowVarFlags(svar, tiIntent); // instead of arg intents
+      setShadowVarFlags(ovar, svar, tiIntent); // instead of arg intents
     }
 
     outerVars.push_back(ovar);

--- a/test/parallel/taskPar/taskIntents/01-error-global.good
+++ b/test/parallel/taskPar/taskIntents/01-error-global.good
@@ -1,63 +1,126 @@
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
-01-error-global.chpl: error: illegal lvalue in assignment
+01-error-global.chpl:70: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'b0' is constant due to task intents in this begin statement
+01-error-global.chpl:71: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'b8' is constant due to task intents in this begin statement
+01-error-global.chpl:72: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'b16' is constant due to task intents in this begin statement
+01-error-global.chpl:73: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'b32' is constant due to task intents in this begin statement
+01-error-global.chpl:74: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'b64' is constant due to task intents in this begin statement
+01-error-global.chpl:75: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'u8' is constant due to task intents in this begin statement
+01-error-global.chpl:76: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'u16' is constant due to task intents in this begin statement
+01-error-global.chpl:77: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'u32' is constant due to task intents in this begin statement
+01-error-global.chpl:78: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'u64' is constant due to task intents in this begin statement
+01-error-global.chpl:79: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'i8' is constant due to task intents in this begin statement
+01-error-global.chpl:80: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'i16' is constant due to task intents in this begin statement
+01-error-global.chpl:81: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'i32' is constant due to task intents in this begin statement
+01-error-global.chpl:82: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'i64' is constant due to task intents in this begin statement
+01-error-global.chpl:83: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'r32' is constant due to task intents in this begin statement
+01-error-global.chpl:84: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'r64' is constant due to task intents in this begin statement
+01-error-global.chpl:85: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'm32' is constant due to task intents in this begin statement
+01-error-global.chpl:86: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'm64' is constant due to task intents in this begin statement
+01-error-global.chpl:87: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'z64' is constant due to task intents in this begin statement
+01-error-global.chpl:88: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'z128' is constant due to task intents in this begin statement
+01-error-global.chpl:90: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'enm' is constant due to task intents in this begin statement
+01-error-global.chpl:93: error: illegal lvalue in assignment
+01-error-global.chpl:68: note: The shadow variable 'cls' is constant due to task intents in this begin statement
+01-error-global.chpl:102: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:103: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:104: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:105: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:106: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:107: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:108: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:109: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:110: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:111: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:112: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:113: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:114: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:115: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:116: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:117: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:118: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:119: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:120: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:122: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:125: error: illegal lvalue in assignment
+01-error-global.chpl:100: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:134: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:135: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:136: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:137: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:138: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:139: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:140: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:141: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:142: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:143: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:144: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:145: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:146: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:147: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:148: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:149: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:150: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:151: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:152: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:154: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:157: error: illegal lvalue in assignment
+01-error-global.chpl:132: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement

--- a/test/parallel/taskPar/taskIntents/01-error-global.prediff
+++ b/test/parallel/taskPar/taskIntents/01-error-global.prediff
@@ -1,3 +1,0 @@
-#!/bin/sh
-cut -d ':' -f 1,3- $2 > $2.prediff.tmp
-mv $2.prediff.tmp $2

--- a/test/parallel/taskPar/taskIntents/02-error-local.good
+++ b/test/parallel/taskPar/taskIntents/02-error-local.good
@@ -1,64 +1,127 @@
-02-error-local.chpl: In function 'test':
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
-02-error-local.chpl: error: illegal lvalue in assignment
+02-error-local.chpl:35: In function 'test':
+02-error-local.chpl:71: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'b0' is constant due to task intents in this begin statement
+02-error-local.chpl:72: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'b8' is constant due to task intents in this begin statement
+02-error-local.chpl:73: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'b16' is constant due to task intents in this begin statement
+02-error-local.chpl:74: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'b32' is constant due to task intents in this begin statement
+02-error-local.chpl:75: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'b64' is constant due to task intents in this begin statement
+02-error-local.chpl:76: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'u8' is constant due to task intents in this begin statement
+02-error-local.chpl:77: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'u16' is constant due to task intents in this begin statement
+02-error-local.chpl:78: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'u32' is constant due to task intents in this begin statement
+02-error-local.chpl:79: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'u64' is constant due to task intents in this begin statement
+02-error-local.chpl:80: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'i8' is constant due to task intents in this begin statement
+02-error-local.chpl:81: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'i16' is constant due to task intents in this begin statement
+02-error-local.chpl:82: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'i32' is constant due to task intents in this begin statement
+02-error-local.chpl:83: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'i64' is constant due to task intents in this begin statement
+02-error-local.chpl:84: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'r32' is constant due to task intents in this begin statement
+02-error-local.chpl:85: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'r64' is constant due to task intents in this begin statement
+02-error-local.chpl:86: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'm32' is constant due to task intents in this begin statement
+02-error-local.chpl:87: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'm64' is constant due to task intents in this begin statement
+02-error-local.chpl:88: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'z64' is constant due to task intents in this begin statement
+02-error-local.chpl:89: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'z128' is constant due to task intents in this begin statement
+02-error-local.chpl:91: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'enm' is constant due to task intents in this begin statement
+02-error-local.chpl:94: error: illegal lvalue in assignment
+02-error-local.chpl:69: note: The shadow variable 'cls' is constant due to task intents in this begin statement
+02-error-local.chpl:103: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:104: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:105: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:106: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:107: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:108: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:109: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:110: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:111: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:112: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:113: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:114: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:115: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:116: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:117: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:118: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:119: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:120: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:121: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:123: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:126: error: illegal lvalue in assignment
+02-error-local.chpl:101: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:135: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:136: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:137: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:138: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:139: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:140: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:141: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:142: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:143: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:144: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:145: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:146: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:147: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:148: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:149: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:150: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:151: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:152: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:153: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:155: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:158: error: illegal lvalue in assignment
+02-error-local.chpl:133: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement

--- a/test/parallel/taskPar/taskIntents/02-error-local.prediff
+++ b/test/parallel/taskPar/taskIntents/02-error-local.prediff
@@ -1,3 +1,0 @@
-#!/bin/sh
-cut -d ':' -f 1,3- $2 > $2.prediff.tmp
-mv $2.prediff.tmp $2

--- a/test/parallel/taskPar/taskIntents/03-error-in-fun.good
+++ b/test/parallel/taskPar/taskIntents/03-error-in-fun.good
@@ -1,512 +1,764 @@
-03-error-in-fun.chpl: In function 'funBlank':
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: In function 'funConst':
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: In function 'funConstIn':
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: In function 'funIn':
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: In function 'funInOut':
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: In function 'funOut':
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: In function 'funRef':
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: In function 'funConstRef':
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
-03-error-in-fun.chpl: error: illegal lvalue in assignment
+03-error-in-fun.chpl:71: In function 'funBlank':
+03-error-in-fun.chpl:107: error: illegal lvalue in assignment
+03-error-in-fun.chpl:108: error: illegal lvalue in assignment
+03-error-in-fun.chpl:109: error: illegal lvalue in assignment
+03-error-in-fun.chpl:110: error: illegal lvalue in assignment
+03-error-in-fun.chpl:111: error: illegal lvalue in assignment
+03-error-in-fun.chpl:112: error: illegal lvalue in assignment
+03-error-in-fun.chpl:113: error: illegal lvalue in assignment
+03-error-in-fun.chpl:114: error: illegal lvalue in assignment
+03-error-in-fun.chpl:115: error: illegal lvalue in assignment
+03-error-in-fun.chpl:116: error: illegal lvalue in assignment
+03-error-in-fun.chpl:117: error: illegal lvalue in assignment
+03-error-in-fun.chpl:118: error: illegal lvalue in assignment
+03-error-in-fun.chpl:119: error: illegal lvalue in assignment
+03-error-in-fun.chpl:120: error: illegal lvalue in assignment
+03-error-in-fun.chpl:121: error: illegal lvalue in assignment
+03-error-in-fun.chpl:122: error: illegal lvalue in assignment
+03-error-in-fun.chpl:123: error: illegal lvalue in assignment
+03-error-in-fun.chpl:124: error: illegal lvalue in assignment
+03-error-in-fun.chpl:125: error: illegal lvalue in assignment
+03-error-in-fun.chpl:127: error: illegal lvalue in assignment
+03-error-in-fun.chpl:130: error: illegal lvalue in assignment
+03-error-in-fun.chpl:139: error: illegal lvalue in assignment
+03-error-in-fun.chpl:140: error: illegal lvalue in assignment
+03-error-in-fun.chpl:141: error: illegal lvalue in assignment
+03-error-in-fun.chpl:142: error: illegal lvalue in assignment
+03-error-in-fun.chpl:143: error: illegal lvalue in assignment
+03-error-in-fun.chpl:144: error: illegal lvalue in assignment
+03-error-in-fun.chpl:145: error: illegal lvalue in assignment
+03-error-in-fun.chpl:146: error: illegal lvalue in assignment
+03-error-in-fun.chpl:147: error: illegal lvalue in assignment
+03-error-in-fun.chpl:148: error: illegal lvalue in assignment
+03-error-in-fun.chpl:149: error: illegal lvalue in assignment
+03-error-in-fun.chpl:150: error: illegal lvalue in assignment
+03-error-in-fun.chpl:151: error: illegal lvalue in assignment
+03-error-in-fun.chpl:152: error: illegal lvalue in assignment
+03-error-in-fun.chpl:153: error: illegal lvalue in assignment
+03-error-in-fun.chpl:154: error: illegal lvalue in assignment
+03-error-in-fun.chpl:155: error: illegal lvalue in assignment
+03-error-in-fun.chpl:156: error: illegal lvalue in assignment
+03-error-in-fun.chpl:157: error: illegal lvalue in assignment
+03-error-in-fun.chpl:159: error: illegal lvalue in assignment
+03-error-in-fun.chpl:162: error: illegal lvalue in assignment
+03-error-in-fun.chpl:171: error: illegal lvalue in assignment
+03-error-in-fun.chpl:172: error: illegal lvalue in assignment
+03-error-in-fun.chpl:173: error: illegal lvalue in assignment
+03-error-in-fun.chpl:174: error: illegal lvalue in assignment
+03-error-in-fun.chpl:175: error: illegal lvalue in assignment
+03-error-in-fun.chpl:176: error: illegal lvalue in assignment
+03-error-in-fun.chpl:177: error: illegal lvalue in assignment
+03-error-in-fun.chpl:178: error: illegal lvalue in assignment
+03-error-in-fun.chpl:179: error: illegal lvalue in assignment
+03-error-in-fun.chpl:180: error: illegal lvalue in assignment
+03-error-in-fun.chpl:181: error: illegal lvalue in assignment
+03-error-in-fun.chpl:182: error: illegal lvalue in assignment
+03-error-in-fun.chpl:183: error: illegal lvalue in assignment
+03-error-in-fun.chpl:184: error: illegal lvalue in assignment
+03-error-in-fun.chpl:185: error: illegal lvalue in assignment
+03-error-in-fun.chpl:186: error: illegal lvalue in assignment
+03-error-in-fun.chpl:187: error: illegal lvalue in assignment
+03-error-in-fun.chpl:188: error: illegal lvalue in assignment
+03-error-in-fun.chpl:189: error: illegal lvalue in assignment
+03-error-in-fun.chpl:191: error: illegal lvalue in assignment
+03-error-in-fun.chpl:194: error: illegal lvalue in assignment
+03-error-in-fun.chpl:241: In function 'funConst':
+03-error-in-fun.chpl:277: error: illegal lvalue in assignment
+03-error-in-fun.chpl:278: error: illegal lvalue in assignment
+03-error-in-fun.chpl:279: error: illegal lvalue in assignment
+03-error-in-fun.chpl:280: error: illegal lvalue in assignment
+03-error-in-fun.chpl:281: error: illegal lvalue in assignment
+03-error-in-fun.chpl:282: error: illegal lvalue in assignment
+03-error-in-fun.chpl:283: error: illegal lvalue in assignment
+03-error-in-fun.chpl:284: error: illegal lvalue in assignment
+03-error-in-fun.chpl:285: error: illegal lvalue in assignment
+03-error-in-fun.chpl:286: error: illegal lvalue in assignment
+03-error-in-fun.chpl:287: error: illegal lvalue in assignment
+03-error-in-fun.chpl:288: error: illegal lvalue in assignment
+03-error-in-fun.chpl:289: error: illegal lvalue in assignment
+03-error-in-fun.chpl:290: error: illegal lvalue in assignment
+03-error-in-fun.chpl:291: error: illegal lvalue in assignment
+03-error-in-fun.chpl:292: error: illegal lvalue in assignment
+03-error-in-fun.chpl:293: error: illegal lvalue in assignment
+03-error-in-fun.chpl:294: error: illegal lvalue in assignment
+03-error-in-fun.chpl:295: error: illegal lvalue in assignment
+03-error-in-fun.chpl:297: error: illegal lvalue in assignment
+03-error-in-fun.chpl:300: error: illegal lvalue in assignment
+03-error-in-fun.chpl:309: error: illegal lvalue in assignment
+03-error-in-fun.chpl:310: error: illegal lvalue in assignment
+03-error-in-fun.chpl:311: error: illegal lvalue in assignment
+03-error-in-fun.chpl:312: error: illegal lvalue in assignment
+03-error-in-fun.chpl:313: error: illegal lvalue in assignment
+03-error-in-fun.chpl:314: error: illegal lvalue in assignment
+03-error-in-fun.chpl:315: error: illegal lvalue in assignment
+03-error-in-fun.chpl:316: error: illegal lvalue in assignment
+03-error-in-fun.chpl:317: error: illegal lvalue in assignment
+03-error-in-fun.chpl:318: error: illegal lvalue in assignment
+03-error-in-fun.chpl:319: error: illegal lvalue in assignment
+03-error-in-fun.chpl:320: error: illegal lvalue in assignment
+03-error-in-fun.chpl:321: error: illegal lvalue in assignment
+03-error-in-fun.chpl:322: error: illegal lvalue in assignment
+03-error-in-fun.chpl:323: error: illegal lvalue in assignment
+03-error-in-fun.chpl:324: error: illegal lvalue in assignment
+03-error-in-fun.chpl:325: error: illegal lvalue in assignment
+03-error-in-fun.chpl:326: error: illegal lvalue in assignment
+03-error-in-fun.chpl:327: error: illegal lvalue in assignment
+03-error-in-fun.chpl:329: error: illegal lvalue in assignment
+03-error-in-fun.chpl:332: error: illegal lvalue in assignment
+03-error-in-fun.chpl:341: error: illegal lvalue in assignment
+03-error-in-fun.chpl:342: error: illegal lvalue in assignment
+03-error-in-fun.chpl:343: error: illegal lvalue in assignment
+03-error-in-fun.chpl:344: error: illegal lvalue in assignment
+03-error-in-fun.chpl:345: error: illegal lvalue in assignment
+03-error-in-fun.chpl:346: error: illegal lvalue in assignment
+03-error-in-fun.chpl:347: error: illegal lvalue in assignment
+03-error-in-fun.chpl:348: error: illegal lvalue in assignment
+03-error-in-fun.chpl:349: error: illegal lvalue in assignment
+03-error-in-fun.chpl:350: error: illegal lvalue in assignment
+03-error-in-fun.chpl:351: error: illegal lvalue in assignment
+03-error-in-fun.chpl:352: error: illegal lvalue in assignment
+03-error-in-fun.chpl:353: error: illegal lvalue in assignment
+03-error-in-fun.chpl:354: error: illegal lvalue in assignment
+03-error-in-fun.chpl:355: error: illegal lvalue in assignment
+03-error-in-fun.chpl:356: error: illegal lvalue in assignment
+03-error-in-fun.chpl:357: error: illegal lvalue in assignment
+03-error-in-fun.chpl:358: error: illegal lvalue in assignment
+03-error-in-fun.chpl:359: error: illegal lvalue in assignment
+03-error-in-fun.chpl:361: error: illegal lvalue in assignment
+03-error-in-fun.chpl:364: error: illegal lvalue in assignment
+03-error-in-fun.chpl:411: In function 'funConstIn':
+03-error-in-fun.chpl:447: error: illegal lvalue in assignment
+03-error-in-fun.chpl:448: error: illegal lvalue in assignment
+03-error-in-fun.chpl:449: error: illegal lvalue in assignment
+03-error-in-fun.chpl:450: error: illegal lvalue in assignment
+03-error-in-fun.chpl:451: error: illegal lvalue in assignment
+03-error-in-fun.chpl:452: error: illegal lvalue in assignment
+03-error-in-fun.chpl:453: error: illegal lvalue in assignment
+03-error-in-fun.chpl:454: error: illegal lvalue in assignment
+03-error-in-fun.chpl:455: error: illegal lvalue in assignment
+03-error-in-fun.chpl:456: error: illegal lvalue in assignment
+03-error-in-fun.chpl:457: error: illegal lvalue in assignment
+03-error-in-fun.chpl:458: error: illegal lvalue in assignment
+03-error-in-fun.chpl:459: error: illegal lvalue in assignment
+03-error-in-fun.chpl:460: error: illegal lvalue in assignment
+03-error-in-fun.chpl:461: error: illegal lvalue in assignment
+03-error-in-fun.chpl:462: error: illegal lvalue in assignment
+03-error-in-fun.chpl:463: error: illegal lvalue in assignment
+03-error-in-fun.chpl:464: error: illegal lvalue in assignment
+03-error-in-fun.chpl:465: error: illegal lvalue in assignment
+03-error-in-fun.chpl:467: error: illegal lvalue in assignment
+03-error-in-fun.chpl:470: error: illegal lvalue in assignment
+03-error-in-fun.chpl:479: error: illegal lvalue in assignment
+03-error-in-fun.chpl:480: error: illegal lvalue in assignment
+03-error-in-fun.chpl:481: error: illegal lvalue in assignment
+03-error-in-fun.chpl:482: error: illegal lvalue in assignment
+03-error-in-fun.chpl:483: error: illegal lvalue in assignment
+03-error-in-fun.chpl:484: error: illegal lvalue in assignment
+03-error-in-fun.chpl:485: error: illegal lvalue in assignment
+03-error-in-fun.chpl:486: error: illegal lvalue in assignment
+03-error-in-fun.chpl:487: error: illegal lvalue in assignment
+03-error-in-fun.chpl:488: error: illegal lvalue in assignment
+03-error-in-fun.chpl:489: error: illegal lvalue in assignment
+03-error-in-fun.chpl:490: error: illegal lvalue in assignment
+03-error-in-fun.chpl:491: error: illegal lvalue in assignment
+03-error-in-fun.chpl:492: error: illegal lvalue in assignment
+03-error-in-fun.chpl:493: error: illegal lvalue in assignment
+03-error-in-fun.chpl:494: error: illegal lvalue in assignment
+03-error-in-fun.chpl:495: error: illegal lvalue in assignment
+03-error-in-fun.chpl:496: error: illegal lvalue in assignment
+03-error-in-fun.chpl:497: error: illegal lvalue in assignment
+03-error-in-fun.chpl:499: error: illegal lvalue in assignment
+03-error-in-fun.chpl:502: error: illegal lvalue in assignment
+03-error-in-fun.chpl:511: error: illegal lvalue in assignment
+03-error-in-fun.chpl:512: error: illegal lvalue in assignment
+03-error-in-fun.chpl:513: error: illegal lvalue in assignment
+03-error-in-fun.chpl:514: error: illegal lvalue in assignment
+03-error-in-fun.chpl:515: error: illegal lvalue in assignment
+03-error-in-fun.chpl:516: error: illegal lvalue in assignment
+03-error-in-fun.chpl:517: error: illegal lvalue in assignment
+03-error-in-fun.chpl:518: error: illegal lvalue in assignment
+03-error-in-fun.chpl:519: error: illegal lvalue in assignment
+03-error-in-fun.chpl:520: error: illegal lvalue in assignment
+03-error-in-fun.chpl:521: error: illegal lvalue in assignment
+03-error-in-fun.chpl:522: error: illegal lvalue in assignment
+03-error-in-fun.chpl:523: error: illegal lvalue in assignment
+03-error-in-fun.chpl:524: error: illegal lvalue in assignment
+03-error-in-fun.chpl:525: error: illegal lvalue in assignment
+03-error-in-fun.chpl:526: error: illegal lvalue in assignment
+03-error-in-fun.chpl:527: error: illegal lvalue in assignment
+03-error-in-fun.chpl:528: error: illegal lvalue in assignment
+03-error-in-fun.chpl:529: error: illegal lvalue in assignment
+03-error-in-fun.chpl:531: error: illegal lvalue in assignment
+03-error-in-fun.chpl:534: error: illegal lvalue in assignment
+03-error-in-fun.chpl:581: In function 'funIn':
+03-error-in-fun.chpl:617: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'b0' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:618: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'b8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:619: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'b16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:620: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'b32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:621: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'b64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:622: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'u8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:623: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'u16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:624: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'u32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:625: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'u64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:626: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'i8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:627: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'i16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:628: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'i32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:629: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'i64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:630: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'r32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:631: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'r64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:632: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'm32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:633: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'm64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:634: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'z64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:635: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'z128' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:637: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'enm' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:640: error: illegal lvalue in assignment
+03-error-in-fun.chpl:615: note: The shadow variable 'cls' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:649: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:650: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:651: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:652: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:653: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:654: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:655: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:656: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:657: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:658: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:659: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:660: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:661: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:662: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:663: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:664: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:665: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:666: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:667: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:669: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:672: error: illegal lvalue in assignment
+03-error-in-fun.chpl:647: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:681: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:682: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:683: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:684: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:685: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:686: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:687: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:688: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:689: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:690: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:691: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:692: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:693: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:694: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:695: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:696: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:697: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:698: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:699: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:701: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:704: error: illegal lvalue in assignment
+03-error-in-fun.chpl:679: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:751: In function 'funInOut':
+03-error-in-fun.chpl:787: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'b0' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:788: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'b8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:789: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'b16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:790: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'b32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:791: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'b64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:792: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'u8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:793: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'u16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:794: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'u32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:795: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'u64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:796: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'i8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:797: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'i16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:798: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'i32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:799: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'i64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:800: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'r32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:801: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'r64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:802: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'm32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:803: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'm64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:804: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'z64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:805: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'z128' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:807: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'enm' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:810: error: illegal lvalue in assignment
+03-error-in-fun.chpl:785: note: The shadow variable 'cls' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:819: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:820: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:821: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:822: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:823: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:824: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:825: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:826: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:827: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:828: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:829: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:830: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:831: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:832: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:833: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:834: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:835: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:836: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:837: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:839: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:842: error: illegal lvalue in assignment
+03-error-in-fun.chpl:817: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:851: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:852: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:853: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:854: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:855: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:856: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:857: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:858: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:859: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:860: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:861: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:862: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:863: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:864: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:865: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:866: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:867: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:868: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:869: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:871: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:874: error: illegal lvalue in assignment
+03-error-in-fun.chpl:849: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:921: In function 'funOut':
+03-error-in-fun.chpl:957: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'b0' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:958: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'b8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:959: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'b16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:960: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'b32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:961: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'b64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:962: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'u8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:963: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'u16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:964: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'u32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:965: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'u64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:966: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'i8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:967: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'i16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:968: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'i32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:969: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'i64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:970: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'r32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:971: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'r64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:972: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'm32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:973: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'm64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:974: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'z64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:975: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'z128' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:977: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'enm' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:980: error: illegal lvalue in assignment
+03-error-in-fun.chpl:955: note: The shadow variable 'cls' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:989: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:990: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:991: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:992: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:993: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:994: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:995: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:996: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:997: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:998: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:999: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1000: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1001: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1002: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1003: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1004: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1005: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1006: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1007: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1009: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1012: error: illegal lvalue in assignment
+03-error-in-fun.chpl:987: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1021: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1022: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1023: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1024: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1025: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1026: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1027: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1028: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1029: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1030: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1031: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1032: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1033: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1034: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1035: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1036: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1037: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1038: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1039: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1041: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1044: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1019: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1091: In function 'funRef':
+03-error-in-fun.chpl:1127: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'b0' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1128: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'b8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1129: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'b16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1130: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'b32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1131: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'b64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1132: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'u8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1133: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'u16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1134: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'u32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1135: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'u64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1136: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'i8' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1137: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'i16' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1138: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'i32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1139: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'i64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1140: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'r32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1141: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'r64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1142: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'm32' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1143: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'm64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1144: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'z64' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1145: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'z128' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1147: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'enm' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1150: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1125: note: The shadow variable 'cls' is constant due to task intents in this begin statement
+03-error-in-fun.chpl:1159: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1160: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1161: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1162: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1163: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1164: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1165: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1166: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1167: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1168: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1169: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1170: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1171: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1172: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1173: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1174: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1175: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1176: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1177: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1179: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1182: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1157: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1191: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1192: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1193: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1194: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1195: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1196: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1197: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1198: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1199: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1200: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1201: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1202: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1203: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1204: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1205: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1206: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1207: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1208: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1209: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1211: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1214: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1189: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1261: In function 'funConstRef':
+03-error-in-fun.chpl:1297: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1298: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1299: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1300: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1301: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1302: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1303: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1304: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1305: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1306: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1307: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1308: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1309: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1310: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1311: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1312: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1313: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1314: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1315: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1317: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1320: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1329: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1330: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1331: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1332: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1333: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1334: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1335: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1336: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1337: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1338: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1339: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1340: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1341: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1342: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1343: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1344: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1345: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1346: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1347: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1349: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1352: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1361: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1362: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1363: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1364: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1365: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1366: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1367: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1368: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1369: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1370: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1371: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1372: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1373: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1374: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1375: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1376: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1377: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1378: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1379: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1381: error: illegal lvalue in assignment
+03-error-in-fun.chpl:1384: error: illegal lvalue in assignment

--- a/test/parallel/taskPar/taskIntents/03-error-in-fun.prediff
+++ b/test/parallel/taskPar/taskIntents/03-error-in-fun.prediff
@@ -1,3 +1,0 @@
-#!/bin/sh
-cut -d ':' -f 1,3- $2 > $2.prediff.tmp
-mv $2.prediff.tmp $2

--- a/test/parallel/taskPar/taskIntents/04-error-in-var-iter.good
+++ b/test/parallel/taskPar/taskIntents/04-error-in-var-iter.good
@@ -1,8 +1,16 @@
-04-error-in-var-iter.chpl: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl: error: illegal lvalue in assignment
+04-error-in-var-iter.chpl:6: error: illegal lvalue in assignment
+04-error-in-var-iter.chpl:5: note: The shadow variable 'aaaaa' is constant due to task intents in this begin statement
+04-error-in-var-iter.chpl:9: error: illegal lvalue in assignment
+04-error-in-var-iter.chpl:8: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:10: error: illegal lvalue in assignment
+04-error-in-var-iter.chpl:8: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:13: error: illegal lvalue in assignment
+04-error-in-var-iter.chpl:12: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:18: error: illegal lvalue in assignment
+04-error-in-var-iter.chpl:17: note: The shadow variable 'aaaaa' is constant due to task intents in this begin statement
+04-error-in-var-iter.chpl:21: error: illegal lvalue in assignment
+04-error-in-var-iter.chpl:20: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:22: error: illegal lvalue in assignment
+04-error-in-var-iter.chpl:20: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:25: error: illegal lvalue in assignment
+04-error-in-var-iter.chpl:24: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement

--- a/test/parallel/taskPar/taskIntents/04-error-in-var-iter.prediff
+++ b/test/parallel/taskPar/taskIntents/04-error-in-var-iter.prediff
@@ -1,3 +1,0 @@
-#!/bin/sh
-cut -d ':' -f 1,3- $2 > $2.prediff.tmp
-mv $2.prediff.tmp $2

--- a/test/parallel/taskPar/vass/const-in-intent-arrays-domains.good
+++ b/test/parallel/taskPar/vass/const-in-intent-arrays-domains.good
@@ -3,8 +3,14 @@ const-in-intent-arrays-domains.chpl:7: error: illegal lvalue in assignment
 const-in-intent-arrays-domains.chpl:8: error: illegal lvalue in assignment
 const-in-intent-arrays-domains.chpl:11: In function 'main':
 const-in-intent-arrays-domains.chpl:15: error: illegal lvalue in assignment
+const-in-intent-arrays-domains.chpl:14: note: The shadow variable 'DOM' is constant due to task intents in this begin statement
 const-in-intent-arrays-domains.chpl:16: error: illegal lvalue in assignment
+const-in-intent-arrays-domains.chpl:14: note: The shadow variable 'ARR' is constant due to task intents in this begin statement
 const-in-intent-arrays-domains.chpl:20: error: illegal lvalue in assignment
+const-in-intent-arrays-domains.chpl:19: note: The shadow variable 'DOM' is constant due to task intents in this cobegin or coforall statement
 const-in-intent-arrays-domains.chpl:21: error: illegal lvalue in assignment
+const-in-intent-arrays-domains.chpl:19: note: The shadow variable 'ARR' is constant due to task intents in this cobegin or coforall statement
 const-in-intent-arrays-domains.chpl:25: error: illegal lvalue in assignment
+const-in-intent-arrays-domains.chpl:24: note: The shadow variable 'DOM' is constant due to task intents in this cobegin or coforall statement
 const-in-intent-arrays-domains.chpl:26: error: illegal lvalue in assignment
+const-in-intent-arrays-domains.chpl:24: note: The shadow variable 'ARR' is constant due to task intents in this cobegin or coforall statement

--- a/test/parallel/taskPar/vass/taskintents-errors.good
+++ b/test/parallel/taskPar/vass/taskintents-errors.good
@@ -1,3 +1,6 @@
 taskintents-errors.chpl:22: error: illegal lvalue in assignment
+taskintents-errors.chpl:20: note: The shadow variable 'i' is constant due to task intents in this cobegin or coforall statement
 taskintents-errors.chpl:46: error: illegal lvalue in assignment
+taskintents-errors.chpl:44: note: The shadow variable 'i' is constant due to task intents in this cobegin or coforall statement
 taskintents-errors.chpl:58: error: illegal lvalue in assignment
+taskintents-errors.chpl:56: note: The shadow variable 'i' is constant due to task intents in this cobegin or coforall statement


### PR DESCRIPTION
In addition to printing
  file.chpl:NNN: error: illegal lvalue in assignment

or similar, also print
  file.chpl:MMM: note: The shadow variable 'XXX' is constant due to forall intents in this loop

or "... due to task intents in this cobegin or coforall statement" or
"... in this begin statement", as appropriate.

Updated several .good with these additional notes.

WHILE THERE, I removed .prediff that squashed line numbers for a couple
of tests. We added squashing in #298 and I felt OK with it back then.
Now I feel that it is somewhat important to ensure that the line numbers
are reported correctly in error messages. In particular, that the
parallel construct for the task/forall intents is pointed at correctly.
So I removed squashing and locked in the line numbers reported currently.
I spot-checked that these line numbers are correct.

IMPLEMENTATION NOTES

I added FLAG_CONST_DUE_TO_TASK_FORALL_INTENT to mark the variables
that became const due to task/forall intents.

WHILE THERE, I also ensured that the line number associated with
the BlockStmt that contains (and calls) individual task functions
for a 'coforall' is the line number for the 'cobegin' keyword (I think).
That way my "notes" can point to that line, rather than the line
where the particular task function is located.

Passes full linux64 testing.