### PR TITLE
Fix clean-primers step for Linux 

### DIFF
--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -89,7 +89,7 @@ clean-module-docs: FORCE
 clean-primers: FORCE
 	@echo
 	@echo "Removing primers generated into source/primers"
-	find source/primers/ -type f -not -name 'primers*' -not -path '*/\.*' -print0 | xargs -0 rm --
+	find source/primers/ -type f -not -name 'primers*' -not -path '*/\.*' -print0 | xargs -0 rm -f
 
 
 FORCE:

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -141,7 +141,7 @@ documentation: $(SYS_CTYPES_MODULE_DOC)
 	@echo "Running post-processing scripts"
 	./internal/fixInternalDocs.sh ${MODULE_SPHINX}
 	./dists/fixDistDocs.perl      ${MODULE_SPHINX}
-	@echo "Copying generated module documentation to \$CHPL_HOME/doc/sphinx/modules"
+	@echo "Copying generated module documentation to "'$$CHPL_HOME"'/doc/sphinx/modules"
 	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/packages ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/dists    ${DOC_SPHINX}/source/modules/


### PR DESCRIPTION
Linux did not like the `--` flag, so I drop it and add a `-f` for good measure.

Also fixed a Makefile typo