### PR TITLE
Add argparse to chpldoc venv reqs (for chpl2rst.py)

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -141,7 +141,7 @@ documentation: $(SYS_CTYPES_MODULE_DOC)
 	@echo "Running post-processing scripts"
 	./internal/fixInternalDocs.sh ${MODULE_SPHINX}
 	./dists/fixDistDocs.perl      ${MODULE_SPHINX}
-	@echo "Copying generated module documentation to "'$$CHPL_HOME"'/doc/sphinx/modules"
+	@echo "Copying generated module documentation to "'$$CHPL_HOME'"/doc/sphinx/modules"
 	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/packages ${DOC_SPHINX}/source/modules/
 	cp -rf ${MODULE_SPHINX}/source/modules/dists    ${DOC_SPHINX}/source/modules/

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -3,5 +3,6 @@ MarkupSafe==0.23
 Pygments>=2,<3
 Sphinx==1.3.3
 docutils==0.12
+argparse==1.3.0
 sphinx-rtd-theme==0.1.9
 sphinxcontrib-chapeldomain>=0.0.10


### PR DESCRIPTION
#4524 added a new dependency to the `make docs` step - so we add `argparse` to the `chpldoc-venv` for python 2.6 support.

Also, fixed typo ironically introduced in #4551, which attempted to correct another typo.