### PR TITLE
Temporarily remove --link flag from primers build

### DIFF
--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -48,9 +48,9 @@ primers: clean-primers
 	@echo
 	@echo "Generating primers from "'$$CHPL_HOME'"/test/release/examples to "'$$CHPL_HOME'"/doc/sphinx/source/primers"
 	@#Note - this assumes that we are not in a release tar ball
-	./run-in-venv.bash ./chpl2rst.py ../../test/release/examples/primers/*.chpl --output=rst --prefix=source/primers --link=master
-	./run-in-venv.bash ./chpl2rst.py ../../test/release/examples/primers/*doc.chpl --output=rst --codeblock --prefix=source/primers --link=master
-	./run-in-venv.bash ./chpl2rst.py ../../test/release/examples/primers/chplvis/*.chpl --output=rst --prefix=source/primers --link=master
+	./run-in-venv.bash ./chpl2rst.py ../../test/release/examples/primers/*.chpl --output=rst --prefix=source/primers
+	./run-in-venv.bash ./chpl2rst.py ../../test/release/examples/primers/*doc.chpl --output=rst --codeblock --prefix=source/primers
+	./run-in-venv.bash ./chpl2rst.py ../../test/release/examples/primers/chplvis/*.chpl --output=rst --prefix=source/primers
 
 
 checkdocs: FORCE


### PR DESCRIPTION
The testing environment doesn't follow the directory hierarchy that `--link` expects. Removing the flag from the build step for now.