### PR TITLE
Add the ability to reflect on type methods

### DIFF
--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -121,7 +121,7 @@ proc getFieldIndex(type t, param s:string) param : int
 proc hasField(type t, param s:string) param : bool
   return getFieldIndex(t, s) > 0;
 
-/* Returns true if a function named `fname` taking in no arguments
+/* Returns true if a function named `fname` taking no arguments
    could be called in the current scope.
    */
 proc canResolve(param fname : string) param : bool
@@ -135,7 +135,7 @@ proc canResolve(param fname : string, args ...) param : bool
 
 // TODO -- how can this work with by-name argument passing?
 
-/* Returns true if a method named `fname` taking in no arguments
+/* Returns true if a method named `fname` taking no arguments
    could be called on `obj` in the current scope.
    */
 proc canResolveMethod(obj, param fname : string) param : bool
@@ -147,16 +147,16 @@ proc canResolveMethod(obj, param fname : string) param : bool
 proc canResolveMethod(obj, param fname : string, args ...) param : bool
   return __primitive("method call resolves", obj, fname, (...args));
 
-/* Returns true if a type method named `fname` taking in no
+/* Returns true if a type method named `fname` taking no
    arguments could be called on type `t` in the current scope.
    */
-proc canResolveMethod(type t, param fname : string) param : bool
+proc canResolveTypeMethod(type t, param fname : string) param : bool
   return __primitive("method call resolves", t, fname);
  
 /* Returns true if a type method named `fname` taking the
    arguments in `args` could be called on type `t` in the current scope.
    */
-proc canResolveMethod(type t, param fname : string, args ...) param : bool
+proc canResolveTypeMethod(type t, param fname : string, args ...) param : bool
   return __primitive("method call resolves", t, fname, (...args));
 
 // TODO -- do we need a different version of can resolve with ref this?

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -135,26 +135,26 @@ proc canResolve(param fname : string, args ...) param : bool
 
 // TODO -- how can this work with by-name argument passing?
 
-/* Returns true if a method on `obj` named `fname` taking in no arguments
-   could be called in the current scope.
+/* Returns true if a method named `fname` taking in no arguments
+   could be called on `obj` in the current scope.
    */
 proc canResolveMethod(obj, param fname : string) param : bool
   return __primitive("method call resolves", obj, fname);
 
-/* Returns true if a method on `obj` named `fname` taking the arguments in `args`
-   could be called in the current scope.
+/* Returns true if a method named `fname` taking the arguments in `args`
+   could be called on `obj` in the current scope.
    */
 proc canResolveMethod(obj, param fname : string, args ...) param : bool
   return __primitive("method call resolves", obj, fname, (...args));
 
-/* Returns true if a method on type `t` named `fname` taking in no
-   arguments could be called in the current scope.
+/* Returns true if a type method named `fname` taking in no
+   arguments could be called on type `t` in the current scope.
    */
 proc canResolveMethod(type t, param fname : string) param : bool
   return __primitive("method call resolves", t, fname);
  
-/* Returns true if a method on type `t` named `fname` taking the
-   arguments in `args` could be called in the current scope.
+/* Returns true if a type method named `fname` taking the
+   arguments in `args` could be called on type `t` in the current scope.
    */
 proc canResolveMethod(type t, param fname : string, args ...) param : bool
   return __primitive("method call resolves", t, fname, (...args));

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -127,7 +127,7 @@ proc hasField(type t, param s:string) param : bool
 proc canResolve(param fname : string) param : bool
   return __primitive("call resolves", fname);
 
-/* Returns true if a function named `fname` taking the arguments in args
+/* Returns true if a function named `fname` taking the arguments in `args`
    could be called in the current scope.
    */
 proc canResolve(param fname : string, args ...) param : bool
@@ -141,11 +141,23 @@ proc canResolve(param fname : string, args ...) param : bool
 proc canResolveMethod(obj, param fname : string) param : bool
   return __primitive("method call resolves", obj, fname);
 
-/* Returns true if a method on `obj` named `fname` taking the arguments in args
+/* Returns true if a method on `obj` named `fname` taking the arguments in `args`
    could be called in the current scope.
    */
 proc canResolveMethod(obj, param fname : string, args ...) param : bool
   return __primitive("method call resolves", obj, fname, (...args));
+
+/* Returns true if a method on type `t` named `fname` taking in no
+   arguments could be called in the current scope.
+   */
+proc canResolveMethod(type t, param fname : string) param : bool
+  return __primitive("method call resolves", t, fname);
+ 
+/* Returns true if a method on type `t` named `fname` taking the
+   arguments in `args` could be called in the current scope.
+   */
+proc canResolveMethod(type t, param fname : string, args ...) param : bool
+  return __primitive("method call resolves", t, fname, (...args));
 
 // TODO -- do we need a different version of can resolve with ref this?
 

--- a/test/modules/standard/Reflection/reflectOnTypeMethods.chpl
+++ b/test/modules/standard/Reflection/reflectOnTypeMethods.chpl
@@ -1,0 +1,54 @@
+proc type int.foo() {
+  writeln("In int foo");
+}
+
+proc type int.bar(x: int) {
+  writeln("In int bar(", x, ")");
+}
+
+proc type int.baz(x: int, y: int, z: int) {
+  writeln("In int baz", (x, y, z));
+}
+
+record R {
+  proc type foo() {
+    writeln("In R foo");
+  }
+
+  proc type bar(x: int) {
+    writeln("In R bar(", x, ")");
+  }
+
+  proc type baz(x: int, y: int, z: int) {
+    writeln("In R bar", (x, y, z));
+  }
+}
+
+checkType(int);
+checkType(R);
+
+proc checkType(type t) {
+  use Reflection;
+  
+  assert(canResolveMethod(t, "foo"));
+  assert(!canResolveMethod(t, "fog"));
+  
+  assert(canResolveMethod(t, "bar", 1));
+  assert(!canResolveMethod(t, "bar", 1.2));
+  assert(!canResolveMethod(t, "bar", 1, 2));
+  assert(!canResolveMethod(t, "bar"));
+  assert(!canResolveMethod(t, "bag", 1));
+
+  assert(canResolveMethod(t, "baz", 1, 2, 3));
+  assert(!canResolveMethod(t, "baz", 1.2, 3, 4));
+  assert(!canResolveMethod(t, "baz", 1, 2));
+  assert(!canResolveMethod(t, "baz", 1, 2, 3, 4));
+  assert(!canResolveMethod(t, "bag", 1, 2, 3));
+
+  writeln("passed all assertions for ", t:string);
+
+  t.foo();
+  t.bar(1);
+  t.baz(2,3,4);
+}
+

--- a/test/modules/standard/Reflection/reflectOnTypeMethods.chpl
+++ b/test/modules/standard/Reflection/reflectOnTypeMethods.chpl
@@ -30,20 +30,20 @@ checkType(R);
 proc checkType(type t) {
   use Reflection;
   
-  assert(canResolveMethod(t, "foo"));
-  assert(!canResolveMethod(t, "fog"));
+  assert(canResolveTypeMethod(t, "foo"));
+  assert(!canResolveTypeMethod(t, "fog"));
   
-  assert(canResolveMethod(t, "bar", 1));
-  assert(!canResolveMethod(t, "bar", 1.2));
-  assert(!canResolveMethod(t, "bar", 1, 2));
-  assert(!canResolveMethod(t, "bar"));
-  assert(!canResolveMethod(t, "bag", 1));
+  assert(canResolveTypeMethod(t, "bar", 1));
+  assert(!canResolveTypeMethod(t, "bar", 1.2));
+  assert(!canResolveTypeMethod(t, "bar", 1, 2));
+  assert(!canResolveTypeMethod(t, "bar"));
+  assert(!canResolveTypeMethod(t, "bag", 1));
 
-  assert(canResolveMethod(t, "baz", 1, 2, 3));
-  assert(!canResolveMethod(t, "baz", 1.2, 3, 4));
-  assert(!canResolveMethod(t, "baz", 1, 2));
-  assert(!canResolveMethod(t, "baz", 1, 2, 3, 4));
-  assert(!canResolveMethod(t, "bag", 1, 2, 3));
+  assert(canResolveTypeMethod(t, "baz", 1, 2, 3));
+  assert(!canResolveTypeMethod(t, "baz", 1.2, 3, 4));
+  assert(!canResolveTypeMethod(t, "baz", 1, 2));
+  assert(!canResolveTypeMethod(t, "baz", 1, 2, 3, 4));
+  assert(!canResolveTypeMethod(t, "bag", 1, 2, 3));
 
   writeln("passed all assertions for ", t:string);
 

--- a/test/modules/standard/Reflection/reflectOnTypeMethods.good
+++ b/test/modules/standard/Reflection/reflectOnTypeMethods.good
@@ -1,0 +1,8 @@
+passed all assertions for int(64)
+In int foo
+In int bar(1)
+In int baz(2, 3, 4)
+passed all assertions for R
+In R foo
+In R bar(1)
+In R bar(2, 3, 4)


### PR DESCRIPTION
I hadn't realized until trying to use it, but we don't support
reflection on type method calls.  Happily, adding the support is a
five-minute fix (TM).  Added a test exercising the new capability.

Also unified formatting of 'args' with other arguments in the chpldoc
comments.

[tested on all tests that 'use Reflection']