### PR TITLE
More rel-over-rel improvements

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -21,6 +21,9 @@
 #   $CHPL_HOME from a local disk like /tmp rather than from an
 #   NFS-mounted directory (BRAD: This means you, dummy).
 #
+# * make sure that your $CHPL_HOME is set up to run testing (e.g.,
+#   can you run 'start_test'?)  If not, do a normal 'make test-venv'.
+#
 # * optionally, set CHPL_TEST_VENV_DIR if you want it to differ
 #   from the default below.
 #
@@ -41,7 +44,7 @@ function testReleasePerformance {
     pushd $CHPL_HOME
     . util/setchplenv.bash
     popd
-    $CHPL_TEST_UTIL_DIR/start_test -performance -num-trials 3
+    $CHPL_TEST_UTIL_DIR/start_test -performance --compopts --no-cc-warnings -num-trials 3
 }
 
 if [[ -z $CHPL_HOME ]]; then


### PR DESCRIPTION
Added another comment indicating that 'make test-venv' has to be run.

Threw --no-cc-warnings because 6.2 warns about lots of things that
older gcc's didn't, which breaks historical runs needlessly.
While we throw --cc-warnings during correctness testing to hold
ourselves to a high standard, for something like release-over-release
testing, it shouldn't matter.