### PR TITLE
Upgrade to the official qthreads 1.11 release

### DIFF
--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -2,7 +2,7 @@
 Qthreads README for Chapel
 ==========================
 
-This copy of Qthreads 1.11 RC is being released with Chapel for
+This copy of Qthreads 1.11 is being released with Chapel for
 convenience and was obtained from:
 
   https://github.com/qthreads/qthreads

--- a/third-party/qthread/qthread-src/NEWS
+++ b/third-party/qthread/qthread-src/NEWS
@@ -2,7 +2,8 @@
 New Features:
  - Distib scheduler: lower contention numa-aware scheduling
  - Binders affinity layer: more control over affinity
- - Portals4 support
+ - Updated Portals4 runtime support
+ - Added missing XMT FEB operations
 --- 1.10 ---
 New Features:
  - Task queue subsystem

--- a/third-party/qthread/qthread-src/README.multinode
+++ b/third-party/qthread/qthread-src/README.multinode
@@ -7,7 +7,6 @@ Configuring and Building
 ------------------------
 
     ./configure --enable-multinode \
-                --with-multinode-runtime={mpi,pmi,shmemrt}
                 --with-portals4[=DIR]
                 [...]
     make
@@ -33,9 +32,9 @@ Launching with SLURM and `pmi`:
     Hello from locale 004!
     Hello from locale 002!
 
-Launching with YOD (provided with Portals4) and `shmemrt`:
+Launching with YOD (provided with Portals4):
 
-    env VERBOSE=1 yod -c 4 hello_world
+    env VERBOSE=1 yod.hydra -c 4 hello_world
     Hello from locale 003!
     Hello from locale 001!
     Hello from locale 004!


### PR DESCRIPTION
Upgrade to the official (non release-candidate) qthreads 1.11 release!

Only differences between 1.11 RC and 1.11 are some minor doc changes