### PR TITLE
Remove a comment about operations being O(n) in array-as-vec primer

### DIFF
--- a/test/release/examples/primers/arrayVectorOps.chpl
+++ b/test/release/examples/primers/arrayVectorOps.chpl
@@ -9,10 +9,6 @@
 // array's domain, which would unexpectedly modify other arrays if they shared
 // domains.
 //
-// As currently implemented, every operation that results in a domain size
-// change results in an array reallocation and so is O(n).  This is expected
-// to improve in a future release.
-//
 
 //
 // Declare a 1D array and initialize it to the values 1..5. The anonymous


### PR DESCRIPTION
This primer mentioned that array-as-vec operations that modify the domain
were O(n), but this is no longer true, so remove that comment.