### PR TITLE
Allow initializers to recursively call themselves

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7802,6 +7802,19 @@ resolveFns(FnSymbol* fn) {
 
   insertFormalTemps(fn);
 
+  if (fn->hasFlag(FLAG_CONSTRUCTOR) && !strcmp(fn->name, "init")) {
+    // Lydia NOTE: Quick fix to allow our new initializers to recursively call
+    // themselves.  We know their return type already, pretending we don't just
+    // leads to errors.  Ideally, we'll remove this code when we fix our
+    // compiler's handling of recursive calls when the function doesn't declare
+    // its return type.
+    for_formals(formal, fn) {
+      if (formal->hasFlag(FLAG_IS_MEME)) {
+        fn->retType = formal->type;
+      }
+    }
+  }
+
   resolveBlockStmt(fn->body);
 
   if (tryFailure) {

--- a/test/classes/initializers/recursiveCall.chpl
+++ b/test/classes/initializers/recursiveCall.chpl
@@ -1,0 +1,104 @@
+// Copy of binary trees which uses our new initializers story, to validate
+// that initializers can be called recursively (since you already know their
+// return type)
+
+/* The Computer Language Benchmarks Game
+   http://benchmarksgame.alioth.debian.org/
+
+   contributed by Casey Battaglino, Ben Harshbarger, and Brad Chamberlain
+   derived from the GNU C version by Jeremy Zerfas
+*/
+
+
+use DynamicIters;
+
+config const n = 10;         // the maximum tree depth
+
+proc main() {
+  const minDepth = 4,                      // the shallowest tree
+        maxDepth = max(minDepth + 2, n),   // the deepest normal tree
+        strDepth = maxDepth + 1,           // the depth of the "stretch" tree
+        depths = minDepth..maxDepth by 2;  // the range of depths to create
+  var stats: [depths] (int,int);           // stores statistics for the trees
+
+  //
+  // Create the "stretch" tree, checksum it, print its stats, and free it.
+  //
+  const strTree = new Tree(0, strDepth);
+  writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
+  delete strTree;
+
+  //
+  // Build the long-lived tree.
+  //
+  const llTree = new Tree(0, maxDepth);
+
+  //
+  // Iterate over the depths in parallel, dynamically assigning them
+  // to tasks.  At each depth, create the required trees, compute
+  // their sums, and free them.
+  //
+  forall depth in dynamic(depths, chunkSize=1) {
+    const iterations = 1 << (maxDepth - depth + minDepth);
+    var sum = 0;
+			
+    for i in 1..iterations {
+      const posT = new Tree( i, depth), 
+            negT = new Tree(-i, depth);
+      sum += posT.sum() + negT.sum();
+      delete posT;
+      delete negT;
+    }
+    stats[depth] = (2*iterations, sum);
+  }
+
+  //
+  // Print out the stats for the trees of varying depths.
+  //
+  for depth in depths do
+    writeln(stats[depth](1), "\t trees of depth ", depth, "\t check: ",
+            stats[depth](2));
+
+  //
+  // Checksum the long-lived tree, print its stats, and free it.
+  //
+  writeln("long lived tree of depth ", maxDepth, "\t check: ", llTree.sum());
+  delete llTree;
+}
+
+
+//
+// A simple balanced tree node class
+//
+class Tree {
+  const item: int;
+  const left, right: Tree;
+
+  proc init(item, left, right) { // Leaves the type of left and right ambiguous
+    this.item = item;
+    this.left = left;
+    this.right = right;
+    super.init();
+  }
+
+  proc init(item, depth) {
+    if depth <= 0 then
+      this.init(item, nil, nil);
+    else
+      this.init(item, new Tree(2*item-1, depth-1),
+                new Tree(2*item  , depth-1));
+  }
+
+  //
+  // Add up tree node, freeing as we go
+  //
+  proc sum(): int {
+    var sum = item;
+    if left {
+      sum += left.sum() - right.sum();
+      delete left;
+      delete right;
+    }
+    return sum;
+  }
+}

--- a/test/classes/initializers/recursiveCall.good
+++ b/test/classes/initializers/recursiveCall.good
@@ -1,0 +1,6 @@
+stretch tree of depth 11	 check: -1
+2048	 trees of depth 4	 check: -2048
+512	 trees of depth 6	 check: -512
+128	 trees of depth 8	 check: -128
+32	 trees of depth 10	 check: -32
+long lived tree of depth 10	 check: -1

--- a/test/classes/initializers/recursiveCall2.chpl
+++ b/test/classes/initializers/recursiveCall2.chpl
@@ -1,0 +1,106 @@
+// Copy of binary trees which uses our new initializers story, to validate
+// that initializers can be called recursively (since you already know their
+// return type)
+
+/* The Computer Language Benchmarks Game
+   http://benchmarksgame.alioth.debian.org/
+
+   contributed by Casey Battaglino, Ben Harshbarger, and Brad Chamberlain
+   derived from the GNU C version by Jeremy Zerfas
+*/
+
+
+use DynamicIters;
+
+config const n = 10;         // the maximum tree depth
+
+proc main() {
+  const minDepth = 4,                      // the shallowest tree
+        maxDepth = max(minDepth + 2, n),   // the deepest normal tree
+        strDepth = maxDepth + 1,           // the depth of the "stretch" tree
+        depths = minDepth..maxDepth by 2;  // the range of depths to create
+  var stats: [depths] (int,int);           // stores statistics for the trees
+
+  //
+  // Create the "stretch" tree, checksum it, print its stats, and free it.
+  //
+  const strTree = new Tree(0, strDepth);
+  writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
+  delete strTree;
+
+  //
+  // Build the long-lived tree.
+  //
+  const llTree = new Tree(0, maxDepth);
+
+  //
+  // Iterate over the depths in parallel, dynamically assigning them
+  // to tasks.  At each depth, create the required trees, compute
+  // their sums, and free them.
+  //
+  forall depth in dynamic(depths, chunkSize=1) {
+    const iterations = 1 << (maxDepth - depth + minDepth);
+    var sum = 0;
+			
+    for i in 1..iterations {
+      const posT = new Tree( i, depth), 
+            negT = new Tree(-i, depth);
+      sum += posT.sum() + negT.sum();
+      delete posT;
+      delete negT;
+    }
+    stats[depth] = (2*iterations, sum);
+  }
+
+  //
+  // Print out the stats for the trees of varying depths.
+  //
+  for depth in depths do
+    writeln(stats[depth](1), "\t trees of depth ", depth, "\t check: ",
+            stats[depth](2));
+
+  //
+  // Checksum the long-lived tree, print its stats, and free it.
+  //
+  writeln("long lived tree of depth ", maxDepth, "\t check: ", llTree.sum());
+  delete llTree;
+}
+
+
+//
+// A simple balanced tree node class
+//
+class Tree {
+  const item: int;
+  const left, right: Tree;
+
+  proc init(item, left: Tree = nil, right: Tree = nil) {
+    // Gives left and right a default value, but also declares their type
+    // (note that currently only giving their default value fails to compile
+    this.item = item;
+    this.left = left;
+    this.right = right;
+    super.init();
+  }
+
+  proc init(item, depth) {
+    if depth <= 0 then
+      this.init(item);
+    else
+      this.init(item, new Tree(2*item-1, depth-1),
+                new Tree(2*item  , depth-1));
+  }
+
+  //
+  // Add up tree node, freeing as we go
+  //
+  proc sum(): int {
+    var sum = item;
+    if left {
+      sum += left.sum() - right.sum();
+      delete left;
+      delete right;
+    }
+    return sum;
+  }
+}

--- a/test/classes/initializers/recursiveCall2.good
+++ b/test/classes/initializers/recursiveCall2.good
@@ -1,0 +1,6 @@
+stretch tree of depth 11	 check: -1
+2048	 trees of depth 4	 check: -2048
+512	 trees of depth 6	 check: -512
+128	 trees of depth 8	 check: -128
+32	 trees of depth 10	 check: -32
+long lived tree of depth 10	 check: -1


### PR DESCRIPTION
Currently, we have an issue where recursive functions must declare
their return type or the compiler will fail to determine the return type
and give the user an error.  Constructors (and initializers) are not
allowed to declare their return type so users that wish to write
these functions as recursive are up a creek without a paddle.  This
change allows our new initializers to recursively call themselves.

Due to the presence of the meme argument in initializers, we can give the
initializers a return type before trying to resolve its body.  Old style
constructors do not have this argument and so cannot as simply benefit
from this change (as their _this field does not know its type until resolution
of part of the body).

Ideally, this code will be removed when our compiler's handling of recursive
calls improves.

Also add two tests that this works (unsimplified from the case Brad ran into).
One leaves the last two arguments to the initializer generic, the other gives
them a default value and also a declared type (since only giving them a default
value results in a failure to match between nil type and object, which is a
separate issue)