### PR TITLE
Testing and messaging improvements for #4549

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4300,7 +4300,7 @@ static void lvalueCheck(CallExpr* call)
               constructName = "begin";
             } else {
               marker = enclTaskFn->defPoint->parentExpr;
-              constructName = "cobegin or coforall";
+              constructName = "parallel";
             }
             USR_PRINT(marker, "The shadow variable '%s' is constant due to task intents in this %s statement", varname, constructName);
           } else {

--- a/test/parallel/forall/vass/const-errors-due-to-intents.chpl
+++ b/test/parallel/forall/vass/const-errors-due-to-intents.chpl
@@ -1,0 +1,18 @@
+// Test of error reporting for const errors due to forall intents.
+
+var i1, i2, i3, i4: int;
+
+var A = [1,2,3];
+
+proc useit(ref arg: int) {}
+
+forall a in A with (const i2, const in i3, const ref i4) {
+  i1 = 1;
+  i2 = 2;
+  i3 = 3;
+  i4 = 4;
+  useit(i1);
+  useit(i2);
+  useit(i3);
+  useit(i4);
+}

--- a/test/parallel/forall/vass/const-errors-due-to-intents.good
+++ b/test/parallel/forall/vass/const-errors-due-to-intents.good
@@ -1,0 +1,16 @@
+const-errors-due-to-intents.chpl:10: error: illegal lvalue in assignment
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:11: error: illegal lvalue in assignment
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:12: error: illegal lvalue in assignment
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:13: error: illegal lvalue in assignment
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:14: error: non-lvalue actual is passed to 'ref' formal 'arg' of useit()
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:15: error: non-lvalue actual is passed to 'ref' formal 'arg' of useit()
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:16: error: non-lvalue actual is passed to 'ref' formal 'arg' of useit()
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:17: error: non-lvalue actual is passed to 'ref' formal 'arg' of useit()
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to forall intents in this loop

--- a/test/parallel/taskPar/taskIntents/01-error-global.good
+++ b/test/parallel/taskPar/taskIntents/01-error-global.good
@@ -41,86 +41,86 @@
 01-error-global.chpl:93: error: illegal lvalue in assignment
 01-error-global.chpl:68: note: The shadow variable 'cls' is constant due to task intents in this begin statement
 01-error-global.chpl:102: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 01-error-global.chpl:103: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 01-error-global.chpl:104: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 01-error-global.chpl:105: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 01-error-global.chpl:106: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 01-error-global.chpl:107: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 01-error-global.chpl:108: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 01-error-global.chpl:109: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 01-error-global.chpl:110: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 01-error-global.chpl:111: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 01-error-global.chpl:112: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 01-error-global.chpl:113: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 01-error-global.chpl:114: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 01-error-global.chpl:115: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 01-error-global.chpl:116: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 01-error-global.chpl:117: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 01-error-global.chpl:118: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 01-error-global.chpl:119: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 01-error-global.chpl:120: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 01-error-global.chpl:122: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 01-error-global.chpl:125: error: illegal lvalue in assignment
-01-error-global.chpl:100: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:100: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 01-error-global.chpl:134: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 01-error-global.chpl:135: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 01-error-global.chpl:136: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 01-error-global.chpl:137: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 01-error-global.chpl:138: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 01-error-global.chpl:139: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 01-error-global.chpl:140: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 01-error-global.chpl:141: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 01-error-global.chpl:142: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 01-error-global.chpl:143: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 01-error-global.chpl:144: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 01-error-global.chpl:145: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 01-error-global.chpl:146: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 01-error-global.chpl:147: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 01-error-global.chpl:148: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 01-error-global.chpl:149: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 01-error-global.chpl:150: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 01-error-global.chpl:151: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 01-error-global.chpl:152: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 01-error-global.chpl:154: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 01-error-global.chpl:157: error: illegal lvalue in assignment
-01-error-global.chpl:132: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+01-error-global.chpl:132: note: The shadow variable 'cls' is constant due to task intents in this parallel statement

--- a/test/parallel/taskPar/taskIntents/02-error-local.good
+++ b/test/parallel/taskPar/taskIntents/02-error-local.good
@@ -42,86 +42,86 @@
 02-error-local.chpl:94: error: illegal lvalue in assignment
 02-error-local.chpl:69: note: The shadow variable 'cls' is constant due to task intents in this begin statement
 02-error-local.chpl:103: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 02-error-local.chpl:104: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 02-error-local.chpl:105: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 02-error-local.chpl:106: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 02-error-local.chpl:107: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 02-error-local.chpl:108: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 02-error-local.chpl:109: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 02-error-local.chpl:110: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 02-error-local.chpl:111: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 02-error-local.chpl:112: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 02-error-local.chpl:113: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 02-error-local.chpl:114: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 02-error-local.chpl:115: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 02-error-local.chpl:116: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 02-error-local.chpl:117: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 02-error-local.chpl:118: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 02-error-local.chpl:119: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 02-error-local.chpl:120: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 02-error-local.chpl:121: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 02-error-local.chpl:123: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 02-error-local.chpl:126: error: illegal lvalue in assignment
-02-error-local.chpl:101: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:101: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 02-error-local.chpl:135: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 02-error-local.chpl:136: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 02-error-local.chpl:137: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 02-error-local.chpl:138: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 02-error-local.chpl:139: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 02-error-local.chpl:140: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 02-error-local.chpl:141: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 02-error-local.chpl:142: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 02-error-local.chpl:143: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 02-error-local.chpl:144: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 02-error-local.chpl:145: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 02-error-local.chpl:146: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 02-error-local.chpl:147: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 02-error-local.chpl:148: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 02-error-local.chpl:149: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 02-error-local.chpl:150: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 02-error-local.chpl:151: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 02-error-local.chpl:152: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 02-error-local.chpl:153: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 02-error-local.chpl:155: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 02-error-local.chpl:158: error: illegal lvalue in assignment
-02-error-local.chpl:133: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+02-error-local.chpl:133: note: The shadow variable 'cls' is constant due to task intents in this parallel statement

--- a/test/parallel/taskPar/taskIntents/03-error-in-fun.good
+++ b/test/parallel/taskPar/taskIntents/03-error-in-fun.good
@@ -234,89 +234,89 @@
 03-error-in-fun.chpl:640: error: illegal lvalue in assignment
 03-error-in-fun.chpl:615: note: The shadow variable 'cls' is constant due to task intents in this begin statement
 03-error-in-fun.chpl:649: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:650: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:651: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:652: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:653: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:654: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:655: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:656: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:657: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:658: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:659: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:660: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:661: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:662: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:663: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:664: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:665: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:666: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:667: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:669: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:672: error: illegal lvalue in assignment
-03-error-in-fun.chpl:647: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:647: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:681: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:682: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:683: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:684: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:685: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:686: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:687: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:688: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:689: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:690: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:691: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:692: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:693: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:694: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:695: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:696: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:697: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:698: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:699: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:701: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:704: error: illegal lvalue in assignment
-03-error-in-fun.chpl:679: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:679: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:751: In function 'funInOut':
 03-error-in-fun.chpl:787: error: illegal lvalue in assignment
 03-error-in-fun.chpl:785: note: The shadow variable 'b0' is constant due to task intents in this begin statement
@@ -361,89 +361,89 @@
 03-error-in-fun.chpl:810: error: illegal lvalue in assignment
 03-error-in-fun.chpl:785: note: The shadow variable 'cls' is constant due to task intents in this begin statement
 03-error-in-fun.chpl:819: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:820: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:821: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:822: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:823: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:824: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:825: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:826: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:827: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:828: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:829: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:830: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:831: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:832: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:833: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:834: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:835: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:836: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:837: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:839: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:842: error: illegal lvalue in assignment
-03-error-in-fun.chpl:817: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:817: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:851: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:852: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:853: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:854: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:855: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:856: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:857: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:858: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:859: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:860: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:861: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:862: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:863: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:864: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:865: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:866: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:867: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:868: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:869: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:871: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:874: error: illegal lvalue in assignment
-03-error-in-fun.chpl:849: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:849: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:921: In function 'funOut':
 03-error-in-fun.chpl:957: error: illegal lvalue in assignment
 03-error-in-fun.chpl:955: note: The shadow variable 'b0' is constant due to task intents in this begin statement
@@ -488,89 +488,89 @@
 03-error-in-fun.chpl:980: error: illegal lvalue in assignment
 03-error-in-fun.chpl:955: note: The shadow variable 'cls' is constant due to task intents in this begin statement
 03-error-in-fun.chpl:989: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:990: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:991: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:992: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:993: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:994: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:995: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:996: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:997: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:998: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:999: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1000: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1001: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1002: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1003: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1004: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1005: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1006: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1007: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1009: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1012: error: illegal lvalue in assignment
-03-error-in-fun.chpl:987: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:987: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1021: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1022: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1023: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1024: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1025: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1026: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1027: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1028: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1029: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1030: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1031: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1032: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1033: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1034: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1035: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1036: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1037: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1038: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1039: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1041: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1044: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1019: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1019: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1091: In function 'funRef':
 03-error-in-fun.chpl:1127: error: illegal lvalue in assignment
 03-error-in-fun.chpl:1125: note: The shadow variable 'b0' is constant due to task intents in this begin statement
@@ -615,89 +615,89 @@
 03-error-in-fun.chpl:1150: error: illegal lvalue in assignment
 03-error-in-fun.chpl:1125: note: The shadow variable 'cls' is constant due to task intents in this begin statement
 03-error-in-fun.chpl:1159: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1160: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1161: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1162: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1163: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1164: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1165: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1166: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1167: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1168: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1169: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1170: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1171: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1172: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1173: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1174: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1175: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1176: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1177: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1179: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1182: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1157: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1157: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1191: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'b0' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'b0' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1192: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'b8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'b8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1193: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'b16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'b16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1194: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'b32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'b32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1195: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'b64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'b64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1196: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'u8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'u8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1197: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'u16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'u16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1198: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'u32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'u32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1199: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'u64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'u64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1200: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'i8' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'i8' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1201: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'i16' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'i16' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1202: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'i32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'i32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1203: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'i64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'i64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1204: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'r32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'r32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1205: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'r64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'r64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1206: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'm32' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'm32' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1207: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'm64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'm64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1208: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'z64' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'z64' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1209: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'z128' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'z128' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1211: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'enm' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'enm' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1214: error: illegal lvalue in assignment
-03-error-in-fun.chpl:1189: note: The shadow variable 'cls' is constant due to task intents in this cobegin or coforall statement
+03-error-in-fun.chpl:1189: note: The shadow variable 'cls' is constant due to task intents in this parallel statement
 03-error-in-fun.chpl:1261: In function 'funConstRef':
 03-error-in-fun.chpl:1297: error: illegal lvalue in assignment
 03-error-in-fun.chpl:1298: error: illegal lvalue in assignment

--- a/test/parallel/taskPar/taskIntents/04-error-in-var-iter.good
+++ b/test/parallel/taskPar/taskIntents/04-error-in-var-iter.good
@@ -1,16 +1,16 @@
 04-error-in-var-iter.chpl:6: error: illegal lvalue in assignment
 04-error-in-var-iter.chpl:5: note: The shadow variable 'aaaaa' is constant due to task intents in this begin statement
 04-error-in-var-iter.chpl:9: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl:8: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:8: note: The shadow variable 'aaaaa' is constant due to task intents in this parallel statement
 04-error-in-var-iter.chpl:10: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl:8: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:8: note: The shadow variable 'aaaaa' is constant due to task intents in this parallel statement
 04-error-in-var-iter.chpl:13: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl:12: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:12: note: The shadow variable 'aaaaa' is constant due to task intents in this parallel statement
 04-error-in-var-iter.chpl:18: error: illegal lvalue in assignment
 04-error-in-var-iter.chpl:17: note: The shadow variable 'aaaaa' is constant due to task intents in this begin statement
 04-error-in-var-iter.chpl:21: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl:20: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:20: note: The shadow variable 'aaaaa' is constant due to task intents in this parallel statement
 04-error-in-var-iter.chpl:22: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl:20: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:20: note: The shadow variable 'aaaaa' is constant due to task intents in this parallel statement
 04-error-in-var-iter.chpl:25: error: illegal lvalue in assignment
-04-error-in-var-iter.chpl:24: note: The shadow variable 'aaaaa' is constant due to task intents in this cobegin or coforall statement
+04-error-in-var-iter.chpl:24: note: The shadow variable 'aaaaa' is constant due to task intents in this parallel statement

--- a/test/parallel/taskPar/vass/const-in-intent-arrays-domains.good
+++ b/test/parallel/taskPar/vass/const-in-intent-arrays-domains.good
@@ -7,10 +7,10 @@ const-in-intent-arrays-domains.chpl:14: note: The shadow variable 'DOM' is const
 const-in-intent-arrays-domains.chpl:16: error: illegal lvalue in assignment
 const-in-intent-arrays-domains.chpl:14: note: The shadow variable 'ARR' is constant due to task intents in this begin statement
 const-in-intent-arrays-domains.chpl:20: error: illegal lvalue in assignment
-const-in-intent-arrays-domains.chpl:19: note: The shadow variable 'DOM' is constant due to task intents in this cobegin or coforall statement
+const-in-intent-arrays-domains.chpl:19: note: The shadow variable 'DOM' is constant due to task intents in this parallel statement
 const-in-intent-arrays-domains.chpl:21: error: illegal lvalue in assignment
-const-in-intent-arrays-domains.chpl:19: note: The shadow variable 'ARR' is constant due to task intents in this cobegin or coforall statement
+const-in-intent-arrays-domains.chpl:19: note: The shadow variable 'ARR' is constant due to task intents in this parallel statement
 const-in-intent-arrays-domains.chpl:25: error: illegal lvalue in assignment
-const-in-intent-arrays-domains.chpl:24: note: The shadow variable 'DOM' is constant due to task intents in this cobegin or coforall statement
+const-in-intent-arrays-domains.chpl:24: note: The shadow variable 'DOM' is constant due to task intents in this parallel statement
 const-in-intent-arrays-domains.chpl:26: error: illegal lvalue in assignment
-const-in-intent-arrays-domains.chpl:24: note: The shadow variable 'ARR' is constant due to task intents in this cobegin or coforall statement
+const-in-intent-arrays-domains.chpl:24: note: The shadow variable 'ARR' is constant due to task intents in this parallel statement

--- a/test/parallel/taskPar/vass/taskintents-errors.good
+++ b/test/parallel/taskPar/vass/taskintents-errors.good
@@ -1,6 +1,6 @@
 taskintents-errors.chpl:22: error: illegal lvalue in assignment
-taskintents-errors.chpl:20: note: The shadow variable 'i' is constant due to task intents in this cobegin or coforall statement
+taskintents-errors.chpl:20: note: The shadow variable 'i' is constant due to task intents in this parallel statement
 taskintents-errors.chpl:46: error: illegal lvalue in assignment
-taskintents-errors.chpl:44: note: The shadow variable 'i' is constant due to task intents in this cobegin or coforall statement
+taskintents-errors.chpl:44: note: The shadow variable 'i' is constant due to task intents in this parallel statement
 taskintents-errors.chpl:58: error: illegal lvalue in assignment
-taskintents-errors.chpl:56: note: The shadow variable 'i' is constant due to task intents in this cobegin or coforall statement
+taskintents-errors.chpl:56: note: The shadow variable 'i' is constant due to task intents in this parallel statement


### PR DESCRIPTION
#4549 added explanations upon const errors due to task/forall intents.

In this PR:

* Replaced "... due to task intents in this cobegin or coforall statement"
with "... due to task intents in this parallel statement"
for brevity and to avoid the suggestion that we don't know which it is.

* Added a test for the explanation introduced in #4549
for the case of forall intents.
