### PR TITLE
Fix Coverity complaint about passing a null pointer

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -346,7 +346,8 @@ void insertOmittedField(Expr* next, const char* nextField,
   CallExpr* thisAccess = new CallExpr(".", _this,
                                       new_CStringSymbol(nextField));
   CallExpr* newInit = NULL;
-  if (!(isSymExpr(initExpr.first) &&
+  if (initExpr.first != NULL &&
+      !(isSymExpr(initExpr.first) &&
         toSymExpr(initExpr.first)->var == gTypeDefaultToken)) {
     Expr* init = initExpr.first->copy();
 


### PR DESCRIPTION
In the case where the initExpr is NULL, we want to use the default of the type.
It probably will never be NULL because even when there isn't an init we give it
the type default token as its init, but just to be safe.