### PR TITLE
Make inline code syntax highlighted as gray instead of red

### DIFF
--- a/doc/sphinx/source/_static/style.css
+++ b/doc/sphinx/source/_static/style.css
@@ -11,3 +11,6 @@
 /* Add color for .mb class that is undefined in Sphinx RTD theme */
 .highlight .mb{ color: #099}
 
+
+.pre{ color: #515151}
+

--- a/doc/sphinx/source/_static/style.css
+++ b/doc/sphinx/source/_static/style.css
@@ -12,5 +12,6 @@
 .highlight .mb{ color: #099}
 
 
-.pre{ color: #515151}
+/* Inlined code is black (instead of default red) */
+.pre{ color: #000}
 


### PR DESCRIPTION
Some team members expressed distaste in the red highlighting of inline code on pages such as [quickstart](http://chapel.cray.com/docs/master/usingchapel/QUICKSTART.html). I agreed. This makes the text black instead.