### PR TITLE
Add chpl-domain and reference labels to primers

### DIFF
--- a/doc/sphinx/chpl2rst.py
+++ b/doc/sphinx/chpl2rst.py
@@ -70,12 +70,19 @@ def gen_preamble(chapelfile, link=None):
 
     # Strip path and extension from chapelfile
     filename = os.path.split(chapelfile)[1]
-    #basename, _ = os.path.splitext(filename)
-    output = []
+    basename, _ = os.path.splitext(filename)
 
-    # Generate title
-    output.append(filename)
-    output.append('='*len(filename))
+    domain = '.. default-domain:: chpl'
+    reference = '.. _primers-{0}:'.format(basename)
+    title = filename
+
+    output = []
+    output.append(domain)
+    output.append('')
+    output.append(reference)
+    output.append('')
+    output.append(title)
+    output.append('='*len(title))
     output.append('')
 
     # Generate dynamic links below title


### PR DESCRIPTION
* Add domain so that primers can use stuff like `:mod:`, `:proc:`, etc.
* Add reference labels to primers, so that they can refer to each other like so:
    *  ``For more information, see the :ref:`variables primer <primers-variables>` ``
    * or simply:  ``For more information, see the :ref:`primers-variables` ``
