### PR TITLE
Zip sans tuples improves comm counts

### DIFF
--- a/test/performance/ferguson/remote-two-array-read.good
+++ b/test/performance/ferguson/remote-two-array-read.good
@@ -1,4 +1,5 @@
+warning: --specialize was set, but CHPL_TARGET_ARCH is 'unknown'. If you want any specialization to occur please set CHPL_TARGET_ARCH to a proper value.
 0
 1 -1
 1 -1
-(get = 9, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 200020, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 3, execute_on_fast = 2, execute_on_nb = 0)
+(get = 9, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 200020, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-two-array-read.good
+++ b/test/performance/ferguson/remote-two-array-read.good
@@ -1,4 +1,3 @@
-warning: --specialize was set, but CHPL_TARGET_ARCH is 'unknown'. If you want any specialization to occur please set CHPL_TARGET_ARCH to a proper value.
 0
 1 -1
 1 -1


### PR DESCRIPTION
Yesterday's zip-without-tuples improved the comm counts for this
test -- something that hadn't even occurred to me could be possible.
Sorry not to have thought to have tested gasnet before merging...

Apparently, the lack of using tuples during iteration removes 4
on's (two fast, two not) for zippered serial iteration over remote
arrays.  To bad we don't do more of that in real benchmarks... :)