### PR TITLE
Generate links to GitHub-hosted code in primers

### DIFF
--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -3,6 +3,9 @@
 # Makefile.sphinx interfaces with sphinx build commands
 include Makefile.sphinx
 
+CHPL2RST     = ./run-in-venv.bash ./chpl2rst.py
+CHPL2RSTOPTS = --output=rst --prefix=source/primers --link=master
+
 help: help-sphinx help-source
 
 help-source:
@@ -48,9 +51,9 @@ primers: clean-primers
 	@echo
 	@echo "Generating primers from "'$$CHPL_HOME'"/test/release/examples to "'$$CHPL_HOME'"/doc/sphinx/source/primers"
 	@#Note - this assumes that we are not in a release tar ball
-	./run-in-venv.bash ./chpl2rst.py ../../test/release/examples/primers/*.chpl --output=rst --prefix=source/primers
-	./run-in-venv.bash ./chpl2rst.py ../../test/release/examples/primers/*doc.chpl --output=rst --codeblock --prefix=source/primers
-	./run-in-venv.bash ./chpl2rst.py ../../test/release/examples/primers/chplvis/*.chpl --output=rst --prefix=source/primers
+	$(CHPL2RST) $(CHPL2RSTOPTS) ../../test/release/examples/primers/*.chpl
+	$(CHPL2RST) $(CHPL2RSTOPTS) ../../test/release/examples/primers/*doc.chpl --codeblock
+	$(CHPL2RST) $(CHPL2RSTOPTS) ../../test/release/examples/primers/chplvis/*.chpl
 
 
 checkdocs: FORCE

--- a/doc/sphinx/chpl2rst.py
+++ b/doc/sphinx/chpl2rst.py
@@ -90,14 +90,18 @@ def gen_preamble(chapelfile, link=None):
         # Note - this makes the assumption that the file lives in the test dir
         abspath = os.path.abspath(chapelfile)
 
-        if 'chapel/test/' not in abspath:
-            print('Error: --link flag only works for files in chapel/test/')
+
+        chpl_home = os.getenv('CHPL_HOME')
+        if not chpl_home:
+            print('Error: --link flag only works when $CHPL_HOME is defined')
+            sys.exit(1)
+        elif not chpl_home in abspath:
+            print('Error: --link flag only work for files within $CHPL_HOME')
             sys.exit(1)
 
         # Get path from CHPL_HOME directory
-        chplpath = abspath[abspath.find('chapel/test/'):]
-        testpath = chplpath.lstrip('chapel/')
-        hyperlink = 'https://github.com/chapel-lang/chapel/blob/{0}/{1}'.format(link, testpath)
+        chplpath = abspath.replace(chpl_home, '').lstrip('/')
+        hyperlink = 'https://github.com/chapel-lang/chapel/blob/{0}/{1}'.format(link, chplpath)
         rstlink = '`View {0} on GitHub <{1}>`_'.format(filename, hyperlink)
         output.append(rstlink)
         output.append('')


### PR DESCRIPTION
* Updated `doc/sphinx/Makefile` to use the `--link=master` flag
   * Also cleaned up the flags / script invocation by wrapping them in variables
* Improved `chpl2rst.py` implementation to depend on `$CHPL_HOME`, rather than search for `chapel/test` in the absolute path.
