### PR TITLE
Fixed reduce-intents bug on darwin from #4565

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -346,8 +346,9 @@ static void lowerReduceAssign() {
         else if (Symbol* globalOp = reduceIntentOp(enclosingForall, lhsVar))
           {
             SET_LINENO(call);
+            Expr* rhs = call->get(2)->remove(); // do it before lhsSE->remove()
             Expr* repl = new_Expr(".(%S, 'accumulateOntoState')(%E,%E)",
-                           globalOp, lhsSE->remove(), call->get(2)->remove());
+                           globalOp, lhsSE->remove(), rhs);
             call->replace(repl);
           }
         else


### PR DESCRIPTION
We observed these tests fail with a compiler assert on darwin and
other configurations:

  parallel/forall/vass/3types-1-wrapped-plus
  parallel/forall/vass/3types-3-sum-of-booleans
  parallel/forall/vass/reduce-assign-1

The failure was apparently caused by this code, added in #4565:

   SymExpr* lhsSE = toSymExpr(call->get(1)) ...
   ... new_Expr(".(%S, 'accumulateOntoState')(%E,%E)",
                globalOp, lhsSE->remove(), call->get(2)->remove())

I.e. new_Expr has two arguments, among others:
  call->get(1)->remove()
  call->get(2)->remove()

which are intended to refer to call's first and second arguments.
Here, 'call' has two arguments total.

If call->get(2)->remove() is executed first, then everything is fine.
Which is what we observe under gcc. On other platforms apparently
call->get(1)->remove() is executed first, leaving only a single arg
with 'call', so call->get(2) fails.

I am correcting this by moving call->get(2)->remove() ahead of
the new_Expr call, so it is guaranteed to be executed first.

Tested on the problematic tests under darwin/comm=none.
Tested on parallel/forall/vass under linux64.
