### PR TITLE
Make use of new 'enum' features (.size / enumerator) in shootouts

### DIFF
--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -77,12 +77,6 @@ o It seems like we should be able to write a strength-reduction
 
 chameneosredux.chpl
 -------------------
-o add user-level support for an enum iterator and replace array in
-  printColorEquations() with it
-
-o add support for a param enum.size query (not sure we'd actually use
-  this, though...)
-
 o once we map to C11 atomics/utilize memory order arguments, can
   performance be improved via different memory orders?
 
@@ -200,20 +194,16 @@ o explore expressing the complex values using Chapel's 'complex' type,
 
 meteor.chpl
 -----------
-o once we have a .size query on enums, we should replace uses of PIVOT
-  with this
-
 o would using 1-based arrays rather than 0-based clean anything up?
 
-o It would be nice to write:
+o It would be nice to be able to write:
     var x = min reduce for x in X do x;
   as:
     serial var x = min reduce X;
   or (preferably):
     var x = serial min reduce X;
   this suggests either adding a serial expression or permitting
-  reductions to be prefixed by 'serial'
-
+  reductions or variable declarations to be prefixed by 'serial'.
 
 
 nbody.chpl

--- a/test/release/examples/benchmarks/shootout/chameneosredux.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.chpl
@@ -28,10 +28,8 @@ proc main() {
 // Print the results of getNewColor() for all color pairs.
 //
 proc printColorEquations() {
-  const colors = (blue, red, yellow);
-
-  for c1 in colors do
-    for c2 in colors do
+  for c1 in Color do
+    for c2 in Color do
       writeln(c1, " + ", c2, " -> ", getNewColor(c1, c2));
   writeln();
 }

--- a/test/release/examples/benchmarks/shootout/meteor.chpl
+++ b/test/release/examples/benchmarks/shootout/meteor.chpl
@@ -56,8 +56,7 @@ enum direction {
   NW,
   N,
   NE,
-  ENE,
-  PIVOT
+  ENE
 }
 use direction;
 
@@ -323,12 +322,12 @@ proc recordPiece(piece, minimum, firstEmpty, pieceMask) {
 
 /* Returns the direction rotated 60 degrees clockwise */
 proc rotate(dir) {
-  return ((dir + 2) % PIVOT:int): direction;
+  return ((dir + 2) % direction.size): direction;
 }
 
 /* Returns the direction flipped on the horizontal axis */
 proc flip(dir) {
-  return ((PIVOT - dir:int) % PIVOT:int): direction;
+  return ((direction.size - dir) % direction.size): direction;
 }
 
 /* Calculate all 32 possible states for a 5-bit row and all rows that


### PR DESCRIPTION
This corresponds to commit 98f5a2a which I made a few weeks back
and makes use of the new 'enum' features in 1.14 in the release
versions of the benchmarks (thanks @Ldelaney!).  These had no
problems in the studies versions; probably I should've put them
into the release at that same time and been less cautious.