### PR TITLE
Add future for 'return' statements in initializers

### DIFF
--- a/test/classes/initializers/noReturnInInit.bad
+++ b/test/classes/initializers/noReturnInInit.bad
@@ -1,0 +1,6 @@
+stretch tree of depth 11	 check: -1
+2048	 trees of depth 4	 check: -2048
+512	 trees of depth 6	 check: -512
+128	 trees of depth 8	 check: -128
+32	 trees of depth 10	 check: -32
+long lived tree of depth 10	 check: -1

--- a/test/classes/initializers/noReturnInInit.chpl
+++ b/test/classes/initializers/noReturnInInit.chpl
@@ -1,0 +1,102 @@
+/* The Computer Language Benchmarks Game
+   http://benchmarksgame.alioth.debian.org/
+
+   contributed by Casey Battaglino, Ben Harshbarger, and Brad Chamberlain
+   derived from the GNU C version by Jeremy Zerfas
+*/
+
+
+use DynamicIters;
+
+config const n = 10;         // the maximum tree depth
+
+proc main() {
+  const minDepth = 4,                      // the shallowest tree
+        maxDepth = max(minDepth + 2, n),   // the deepest normal tree
+        strDepth = maxDepth + 1,           // the depth of the "stretch" tree
+        depths = minDepth..maxDepth by 2;  // the range of depths to create
+  var stats: [depths] (int,int);           // stores statistics for the trees
+
+  //
+  // Create the "stretch" tree, checksum it, print its stats, and free it.
+  //
+  const strTree = new Tree(0, strDepth);
+  writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
+  delete strTree;
+
+  //
+  // Build the long-lived tree.
+  //
+  const llTree = new Tree(0, maxDepth);
+
+  //
+  // Iterate over the depths in parallel, dynamically assigning them
+  // to tasks.  At each depth, create the required trees, compute
+  // their sums, and free them.
+  //
+  forall depth in dynamic(depths, chunkSize=1) {
+    const iterations = 2**(maxDepth - depth + minDepth);
+    var sum = 0;
+			
+    for i in 1..iterations {
+      const posT = new Tree( i, depth), 
+            negT = new Tree(-i, depth);
+      sum += posT.sum() + negT.sum();
+      delete posT;
+      delete negT;
+    }
+    stats[depth] = (2*iterations, sum);
+  }
+
+  //
+  // Print out the stats for the trees of varying depths.
+  //
+  for depth in depths do
+    writeln(stats[depth](1), "\t trees of depth ", depth, "\t check: ",
+            stats[depth](2));
+
+  //
+  // Checksum the long-lived tree, print its stats, and free it.
+  //
+  writeln("long lived tree of depth ", maxDepth, "\t check: ", llTree.sum());
+  delete llTree;
+}
+
+
+//
+// A simple balanced tree node class
+//
+class Tree {
+  const item: int;
+  const left, right: Tree;
+
+  //
+  // Two initializers (constructors) for a Tree object
+  //
+  proc init(item, left: Tree=nil, right: Tree=nil) {
+    this.item = item;
+    this.left = left;
+    this.right = right;
+  }
+  
+  proc init(item, depth) {
+    if depth <= 0 then
+      return new Tree(item);
+    else
+      return new Tree(item, new Tree(2*item-1, depth-1),
+                            new Tree(2*item,   depth-1));
+  }
+
+  //
+  // Add up tree node, freeing as we go
+  //
+  proc sum(): int {
+    var sum = item;
+    if left {
+      sum += left.sum() - right.sum();
+      delete left;
+      delete right;
+    }
+    return sum;
+  }
+}

--- a/test/classes/initializers/noReturnInInit.future
+++ b/test/classes/initializers/noReturnInInit.future
@@ -1,0 +1,6 @@
+bug: returns should not be allowed in inits (right?)
+
+This test shows that while you can return from within an init(), we
+probably shouldn't allow it.  The error messages in the .good are just
+a proposed placeholder.  I'm open to other wordings and only printing
+out the first such occurrence if the developer has other ideas.

--- a/test/classes/initializers/noReturnInInit.good
+++ b/test/classes/initializers/noReturnInInit.good
@@ -1,0 +1,2 @@
+noReturnInInit.chpl:84: error: 'return' not permitted from 'init' routines
+noReturnInInit.chpl:86: error: 'return' not permitted from 'init' routines


### PR DESCRIPTION
While playing around with the binarytrees shootout, I made a
thinko in which I was doing 'return new C()' within an init()
routine for 'class C'.  This worked, but probably shouldn't
(an initializer shouldn't explicitly return anything, but
should initialize its 'this').  This future is designed to
capture this issue so that we can generate an error message
in the future.