### PR TITLE
Resolve the valgrind errors and other fixes

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -18,7 +18,7 @@
  */
 
 /*
-Support for GNU Multiple Precision Integer Arithmetic through the Bigint record
+Support for GNU Multiple Precision Integer Arithmetic through the bigint record
 
 This module implements an interface with the GMP library (the GNU Multiple
 Precision Arithmetic Library). See the `GMP homepage <https://gmplib.org/>`
@@ -26,17 +26,17 @@ for more information on this library.
 
 See the GMP Chapel module for more information on how to use GMP with Chapel.
 
-Using the Bigint record
+Using the bigint record
 -----------------------
 
-The BigInteger Chapel module provides a :record:`Bigint` record wrapping GMP
+The BigInteger Chapel module provides a :record:`bigint` record wrapping GMP
 integers. At the present time, only the functions for ``mpz`` (ie signed
-integer) GMP types are supported with :record:`Bigint`; future work will be to
+integer) GMP types are supported with :record:`bigint`; future work will be to
 extend this support to floating-point types.
 
-:record:`Bigint` methods all wrap GMP functions with obviously similar names.
-The :record:`Bigint` methods are locale aware - so Chapel programs can create
-a distributed array of GMP numbers. The method of :record:`Bigint` objects are
+:record:`bigint` methods all wrap GMP functions with obviously similar names.
+The :record:`bigint` methods are locale aware - so Chapel programs can create
+a distributed array of GMP numbers. The method of :record:`bigint` objects are
 setting the receiver, so e.g. myBigint.add(x,y) sets myBigint to ``x + y``.
 
 A code example::
@@ -44,13 +44,13 @@ A code example::
  use BigInteger;
 
  // initialize a GMP value, set it to zero
- var a = new Bigint();
+ var a = new bigint();
 
  a.fac(100);                            // set a to 100!
  writeln(a);                            // output   100!
 
  // initialize from a decimal string
- var b = new Bigint("48473822929893829847");
+ var b = new bigint("48473822929893829847");
 
  b.add(b, 1);                           // add one to b
 */
@@ -59,8 +59,8 @@ module BigInteger {
   use GMP;
 
   /*
-    The Bigint record provides arbitrary length integers and a set of
-    operator overloads that allow Bigints to be treated consistently
+    The bigint record provides arbitrary length integers and a set of
+    operator overloads that allow bigints to be treated consistently
     with conventional fixed width integers.
 
     The current implementation relies on the GMP library.  This is a
@@ -76,13 +76,13 @@ module BigInteger {
 
       3) Automatic memory management of GMP data structures
 
-    Wrapping an mpz_t in a Bigint record does not appear to introduce
+    Wrapping an mpz_t in a bigint record does not appear to introduce
     a measurable performance impact.  However in the fall of 2016 the
     Chapel operator-based API may introduce a measurable overhead compared
     to the GMP-native API for some applications.  Therefore this module also
     provides lower-level multi-locale aware wrappers for the GMP functions.
 
-    Methods on Bigint are defined for Chapel types e.g int(64) and uint(64)
+    Methods on bigint are defined for Chapel types e.g int(64) and uint(64)
     which must be converted to underlying C types for use by GMP.  Runtime
     checks are used to ensure the Chapel types can safely be cast to the C
     types (e.g. when casting a Chapel uint it checks that it fits in the C
@@ -93,17 +93,17 @@ module BigInteger {
    */
 
   pragma "ignore noinit"
-  record Bigint {
+  record bigint {
     var mpz      : mpz_t;              // A dynamic-vector of C integers
     var localeId : chpl_nodeID_t;      // The locale id for the GMP state
 
-    proc Bigint() {
+    proc bigint() {
       mpz_init(this.mpz);
 
       this.localeId = chpl_nodeID;
     }
 
-    proc Bigint(num: Bigint) {
+    proc bigint(num: bigint) {
       if _local || num.localeId == chpl_nodeID {
         mpz_init_set(this.mpz, num.mpz);
       } else {
@@ -117,19 +117,19 @@ module BigInteger {
       this.localeId = chpl_nodeID;
     }
 
-    proc Bigint(num: int) {
+    proc bigint(num: int) {
       mpz_init_set_si(this.mpz, num.safeCast(c_long));
 
       this.localeId = chpl_nodeID;
     }
 
-    proc Bigint(num: uint) {
+    proc bigint(num: uint) {
       mpz_init_set_ui(this.mpz, num.safeCast(c_ulong));
 
       this.localeId = chpl_nodeID;
     }
 
-    proc Bigint(str: string, base: int = 0) {
+    proc bigint(str: string, base: int = 0) {
       var e = mpz_init_set_str(this.mpz,
                                str.localize().c_str(),
                                base.safeCast(c_int));
@@ -142,7 +142,7 @@ module BigInteger {
       this.localeId = chpl_nodeID;
     }
 
-    proc Bigint(str: string, base: int = 0, out error: syserr) {
+    proc bigint(str: string, base: int = 0, out error: syserr) {
       var e = mpz_init_set_str(this.mpz,
                                str.localize().c_str(),
                                base.safeCast(c_int));
@@ -157,13 +157,13 @@ module BigInteger {
       this.localeId = chpl_nodeID;
     }
 
-    // Within a given locale, Bigint assignment creates a deep copy of the
+    // Within a given locale, bigint assignment creates a deep copy of the
     // data and so the record "owns" the GMP data.
     //
-    // If a Bigint is copied to a remote node then it will receive a shallow
+    // If a bigint is copied to a remote node then it will receive a shallow
     // copy.  The localeId points back the correct locale but the mpz field
     // is meaningless.
-    proc ~Bigint() {
+    proc ~bigint() {
       if _local || this.localeId == chpl_nodeID {
         mpz_clear(this.mpz);
       }
@@ -363,8 +363,8 @@ module BigInteger {
 
   pragma "init copy fn"
   pragma "no doc"
-  proc chpl__initCopy(bir: Bigint) {
-    var ret : Bigint;
+  proc chpl__initCopy(bir: bigint) {
+    var ret : bigint;
 
     if _local || bir.localeId == chpl_nodeID {
       mpz_set(ret.mpz, bir.mpz);
@@ -380,8 +380,8 @@ module BigInteger {
   pragma "donor fn"
   pragma "auto copy fn"
   pragma "no doc"
-  proc chpl__autoCopy(bir: Bigint) {
-    var ret : Bigint;
+  proc chpl__autoCopy(bir: bigint) {
+    var ret : bigint;
 
     if _local || bir.localeId == chpl_nodeID {
       mpz_set(ret.mpz, bir.mpz);
@@ -397,7 +397,7 @@ module BigInteger {
   // Locale-aware assignment
   //
 
-  proc =(ref lhs: Bigint, rhs: Bigint) {
+  proc =(ref lhs: bigint, rhs: bigint) {
     inline proc helper() {
       if _local || rhs.localeId == chpl_nodeID {
         mpz_set(lhs.mpz, rhs.mpz);
@@ -419,7 +419,7 @@ module BigInteger {
     }
   }
 
-  proc =(ref lhs: Bigint, rhs: int) {
+  proc =(ref lhs: bigint, rhs: int) {
     if _local || lhs.localeId == chpl_nodeID {
       mpz_set_si(lhs.mpz, rhs.safeCast(c_long));
 
@@ -432,7 +432,7 @@ module BigInteger {
     }
   }
 
-  proc =(ref lhs: Bigint, rhs: uint) {
+  proc =(ref lhs: bigint, rhs: uint) {
     if _local || lhs.localeId == chpl_nodeID {
       mpz_set_si(lhs.mpz, rhs.safeCast(c_long));
 
@@ -446,17 +446,17 @@ module BigInteger {
   }
 
   //
-  // Operations on Bigints
+  // Operations on bigints
   //
   // In general we need to think about 3 cases
   //
   //   1) This is a single-locale configuration.
   //      We can invoke the appropriate mpz operator directly.
   //
-  //   2) All Bigints are on the current locale.
+  //   2) All bigints are on the current locale.
   //      We can invoke the appropriate mpz operator directly.
   //
-  //   3) One or more Bigints are on a remote locale.
+  //   3) One or more bigints are on a remote locale.
   //      This is complicated.  It is tempting to handle all of the
   //      permutations as efficiently as possible but this introduces
   //      a lot of cases esp. for binary operations.
@@ -472,20 +472,20 @@ module BigInteger {
   //
   // Unary operators
   //
-  proc +(a: Bigint) {
-    return new Bigint(a);
+  proc +(a: bigint) {
+    return new bigint(a);
   }
 
-  proc -(a: Bigint) {
-    var c = new Bigint(a);
+  proc -(a: bigint) {
+    var c = new bigint(a);
 
     mpz_neg(c.mpz, c.mpz);
 
     return c;
   }
 
-  proc ~(a: Bigint) {
-    var c = new Bigint(a);
+  proc ~(a: bigint) {
+    var c = new bigint(a);
 
     mpz_com(c.mpz, c.mpz);
 
@@ -497,8 +497,8 @@ module BigInteger {
   //
 
   // Addition
-  proc +(a: Bigint, b: Bigint) {
-    var c = new Bigint();
+  proc +(a: bigint, b: bigint) {
+    var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_add(c.mpz, a.mpz, b.mpz);
@@ -513,8 +513,8 @@ module BigInteger {
     return c;
   }
 
-  proc +(a: Bigint, b: int) {
-    var c = new Bigint();
+  proc +(a: bigint, b: int) {
+    var c = new bigint();
 
     if b >= 0 {
       const b_ = b.safeCast(c_ulong);
@@ -545,8 +545,8 @@ module BigInteger {
     return c;
   }
 
-  proc +(a: int, b: Bigint) {
-    var c = new Bigint();
+  proc +(a: int, b: bigint) {
+    var c = new bigint();
 
     if a >= 0 {
       const a_ = a.safeCast(c_ulong);
@@ -577,9 +577,9 @@ module BigInteger {
     return c;
   }
 
-  proc +(a: Bigint, b: uint) {
+  proc +(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
       mpz_add_ui(c.mpz, a.mpz,  b_);
@@ -593,9 +593,9 @@ module BigInteger {
     return c;
   }
 
-  proc +(a: uint, b: Bigint) {
+  proc +(a: uint, b: bigint) {
     const a_ = a.safeCast(c_ulong);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || b.localeId == chpl_nodeID {
       mpz_add_ui(c.mpz, b.mpz,  a_);
@@ -612,8 +612,8 @@ module BigInteger {
 
 
   // Subtraction
-  proc -(a: Bigint, b: Bigint) {
-    var c = new Bigint();
+  proc -(a: bigint, b: bigint) {
+    var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_sub(c.mpz, a.mpz,  b.mpz);
@@ -628,8 +628,8 @@ module BigInteger {
     return c;
   }
 
-  proc -(a: Bigint, b: int) {
-    var c = new Bigint();
+  proc -(a: bigint, b: int) {
+    var c = new bigint();
 
     if b >= 0 {
       const b_ = b.safeCast(c_ulong);
@@ -660,8 +660,8 @@ module BigInteger {
     return c;
   }
 
-  proc -(a: int, b: Bigint) {
-    var c = new Bigint();
+  proc -(a: int, b: bigint) {
+    var c = new bigint();
 
     if a >= 0 {
       const a_ = a.safeCast(c_ulong);
@@ -692,9 +692,9 @@ module BigInteger {
     return c;
   }
 
-  proc -(a: Bigint, b: uint) {
+  proc -(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
       mpz_sub_ui(c.mpz, a.mpz,  b_);
@@ -708,9 +708,9 @@ module BigInteger {
     return c;
   }
 
-  proc -(a: uint, b: Bigint) {
+  proc -(a: uint, b: bigint) {
     const a_ = a.safeCast(c_ulong);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || b.localeId == chpl_nodeID {
       mpz_ui_sub(c.mpz, a_, b.mpz);
@@ -726,8 +726,8 @@ module BigInteger {
 
 
   // Multiplication
-  proc *(a: Bigint, b: Bigint) {
-    var c = new Bigint();
+  proc *(a: bigint, b: bigint) {
+    var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_mul(c.mpz, a.mpz, b.mpz);
@@ -742,9 +742,9 @@ module BigInteger {
     return c;
   }
 
-  proc *(a: Bigint, b: int) {
+  proc *(a: bigint, b: int) {
     const b_ = b.safeCast(c_long);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
       mpz_mul_si(c.mpz, a.mpz,  b_);
@@ -758,9 +758,9 @@ module BigInteger {
     return c;
   }
 
-  proc *(a: int, b: Bigint) {
+  proc *(a: int, b: bigint) {
     const a_ = a.safeCast(c_long);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || b.localeId == chpl_nodeID {
       mpz_mul_si(c.mpz, b.mpz,  a_);
@@ -774,9 +774,9 @@ module BigInteger {
     return c;
   }
 
-  proc *(a: Bigint, b: uint) {
+  proc *(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
       mpz_mul_ui(c.mpz, a.mpz,  b_);
@@ -790,9 +790,9 @@ module BigInteger {
     return c;
   }
 
-  proc *(a: uint, b: Bigint) {
+  proc *(a: uint, b: bigint) {
     const a_ = a.safeCast(c_ulong);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || b.localeId == chpl_nodeID {
       mpz_mul_ui(c.mpz, b.mpz,  a_);
@@ -809,8 +809,8 @@ module BigInteger {
 
 
   // Division
-  proc /(a: Bigint, b: Bigint) {
-    var c = new Bigint();
+  proc /(a: bigint, b: bigint) {
+    var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_tdiv_q(c.mpz, a.mpz, b.mpz);
@@ -825,9 +825,9 @@ module BigInteger {
     return c;
   }
 
-  proc /(a: Bigint, b: int) {
+  proc /(a: bigint, b: int) {
     var b_ = 0 : c_ulong;
-    var c  = new Bigint();
+    var c  = new bigint();
 
     if b >= 0 then
       b_ = b.safeCast(c_ulong);
@@ -849,9 +849,9 @@ module BigInteger {
     return c;
   }
 
-  proc /(a: Bigint, b: uint) {
+  proc /(a: bigint, b: uint) {
     var b_ = b.safeCast(c_ulong);
-    var c  = new Bigint();
+    var c  = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
       mpz_tdiv_q_ui(c.mpz, a.mpz, b_);
@@ -865,7 +865,7 @@ module BigInteger {
     return c;
   }
 
-  proc div(param rounding: Round, n: Bigint, d: uint) : uint {
+  proc div(param rounding: Round, n: bigint, d: uint) : uint {
     const d_ = d.safeCast(c_ulong);
     var   ret: c_ulong;
 
@@ -893,8 +893,8 @@ module BigInteger {
 
 
   // Exponentiation
-  proc **(a: Bigint, b: uint) {
-    var c = new Bigint();
+  proc **(a: bigint, b: uint) {
+    var c = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
       mpz_pow_ui(c.mpz, a.mpz,  b);
@@ -911,8 +911,8 @@ module BigInteger {
 
 
   // Mod
-  proc %(a: Bigint, b: Bigint) {
-    var c = new Bigint();
+  proc %(a: bigint, b: bigint) {
+    var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_mod(c.mpz, a.mpz,  b.mpz);
@@ -926,9 +926,9 @@ module BigInteger {
     return c;
   }
 
-  proc %(a: Bigint, b: int) {
+  proc %(a: bigint, b: int) {
     var b_ = 0 : c_ulong;
-    var c  = new Bigint();
+    var c  = new bigint();
 
     if b >= 0 then
       b_ = b.safeCast(c_ulong);
@@ -947,9 +947,9 @@ module BigInteger {
     return c;
   }
 
-  proc %(a: Bigint, b: uint) {
+  proc %(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
       mpz_mod_ui(c.mpz, a.mpz,  b_);
@@ -966,8 +966,8 @@ module BigInteger {
 
 
   // Bit-shift left
-  proc <<(a: Bigint, b: int) {
-    var c = new Bigint();
+  proc <<(a: bigint, b: int) {
+    var c = new bigint();
 
     if b >= 0 {
       const b_ = b.safeCast(c_ulong);
@@ -997,9 +997,9 @@ module BigInteger {
     return c;
   }
 
-  proc <<(a: Bigint, b: uint) {
+  proc <<(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
       mpz_mul_2exp(c.mpz, a.mpz,  b_);
@@ -1016,12 +1016,12 @@ module BigInteger {
 
 
   // Bit-shift right
-  proc >>(a: Bigint, b: int) {
-    var c = new Bigint();
+  proc >>(a: bigint, b: int) {
+    var c = new bigint();
 
     if b >= 0 {
       const b_ = b.safeCast(c_ulong);
-      var   c  = new Bigint();
+      var   c  = new bigint();
 
       if _local || a.localeId == chpl_nodeID {
         mpz_tdiv_q_2exp(c.mpz, a.mpz,  b_);
@@ -1048,9 +1048,9 @@ module BigInteger {
     return c;
   }
 
-  proc >>(a: Bigint, b: uint) {
+  proc >>(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
-    var   c  = new Bigint();
+    var   c  = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
       mpz_tdiv_q_2exp(c.mpz, a.mpz,  b_);
@@ -1067,8 +1067,8 @@ module BigInteger {
 
 
   // Bitwise and
-  proc &(a: Bigint, b: Bigint) {
-    var c = new Bigint();
+  proc &(a: bigint, b: bigint) {
+    var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_and(c.mpz, a.mpz, b.mpz);
@@ -1086,8 +1086,8 @@ module BigInteger {
 
 
   // Bitwise ior
-  proc |(a: Bigint, b: Bigint) {
-    var c = new Bigint();
+  proc |(a: bigint, b: bigint) {
+    var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_and(c.mpz, a.mpz, b.mpz);
@@ -1105,8 +1105,8 @@ module BigInteger {
 
 
   // Bitwise xor
-  proc ^(a: Bigint, b: Bigint) {
-    var c = new Bigint();
+  proc ^(a: bigint, b: bigint) {
+    var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_and(c.mpz, a.mpz, b.mpz);
@@ -1127,7 +1127,7 @@ module BigInteger {
   // Comparison Operations
   //
 
-  private inline proc cmp(a: Bigint, b: Bigint) {
+  private inline proc cmp(a: bigint, b: bigint) {
     var ret : c_int;
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -1143,7 +1143,7 @@ module BigInteger {
     return ret;
   }
 
-  private inline proc cmp(a: Bigint, b: int) {
+  private inline proc cmp(a: bigint, b: int) {
     const b_ = b.safeCast(c_long);
     var   ret : c_int;
 
@@ -1159,7 +1159,7 @@ module BigInteger {
     return ret;
   }
 
-  private inline proc cmp(a: int, b: Bigint) {
+  private inline proc cmp(a: int, b: bigint) {
     const a_ = a.safeCast(c_long);
     var   ret : c_int;
 
@@ -1175,7 +1175,7 @@ module BigInteger {
     return ret;
   }
 
-  private inline proc cmp(a: Bigint, b: uint) {
+  private inline proc cmp(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
     var   ret : c_int;
 
@@ -1191,7 +1191,7 @@ module BigInteger {
     return ret;
   }
 
-  private inline proc cmp(a: uint, b: Bigint) {
+  private inline proc cmp(a: uint, b: bigint) {
     const a_ = a.safeCast(c_ulong);
     var   ret : c_int;
 
@@ -1210,137 +1210,137 @@ module BigInteger {
 
 
   // Equality
-  proc ==(a: Bigint, b: Bigint) {
+  proc ==(a: bigint, b: bigint) {
     return cmp(a, b) == 0;
   }
 
-  proc ==(a: Bigint, b: int) {
+  proc ==(a: bigint, b: int) {
     return cmp(a, b) == 0;
   }
 
-  proc ==(a: int, b: Bigint) {
+  proc ==(a: int, b: bigint) {
     return cmp(a, b) == 0;
   }
 
-  proc ==(a: Bigint, b: uint) {
+  proc ==(a: bigint, b: uint) {
     return cmp(a, b) == 0;
   }
 
-  proc ==(a: uint, b: Bigint) {
+  proc ==(a: uint, b: bigint) {
     return cmp(a, b) == 0;
   }
 
 
 
   // Inequality
-  proc !=(a: Bigint, b: Bigint) {
+  proc !=(a: bigint, b: bigint) {
     return cmp(a, b) != 0;
   }
 
-  proc !=(a: Bigint, b: int) {
+  proc !=(a: bigint, b: int) {
     return cmp(a, b) != 0;
   }
 
-  proc !=(a: int, b: Bigint) {
+  proc !=(a: int, b: bigint) {
     return cmp(a, b) != 0;
   }
 
-  proc !=(a: Bigint, b: uint) {
+  proc !=(a: bigint, b: uint) {
     return cmp(a, b) != 0;
   }
 
-  proc !=(a: uint, b: Bigint) {
+  proc !=(a: uint, b: bigint) {
     return cmp(a, b) != 0;
   }
 
 
 
   // Greater than
-  proc >(a: Bigint, b: Bigint) {
+  proc >(a: bigint, b: bigint) {
     return cmp(a, b) > 0;
   }
 
-  proc >(a: Bigint, b: int) {
+  proc >(a: bigint, b: int) {
     return cmp(a, b) > 0;
   }
 
-  proc >(b: int, a: Bigint) {
+  proc >(b: int, a: bigint) {
     return cmp(a, b) > 0;
   }
 
-  proc >(a: Bigint, b: uint) {
+  proc >(a: bigint, b: uint) {
     return cmp(a, b) > 0;
   }
 
-  proc >(b: uint, a: Bigint) {
+  proc >(b: uint, a: bigint) {
     return cmp(a, b) > 0;
   }
 
 
 
   // Less than
-  proc <(a: Bigint, b: Bigint) {
+  proc <(a: bigint, b: bigint) {
     return cmp(a, b) < 0;
   }
 
-  proc <(a: Bigint, b: int) {
+  proc <(a: bigint, b: int) {
     return cmp(a, b) < 0;
   }
 
-  proc <(b: int, a: Bigint) {
+  proc <(b: int, a: bigint) {
     return cmp(a, b) < 0;
   }
 
-  proc <(a: Bigint, b: uint) {
+  proc <(a: bigint, b: uint) {
     return cmp(a, b) < 0;
   }
 
-  proc <(b: uint, a: Bigint) {
+  proc <(b: uint, a: bigint) {
     return cmp(a, b) < 0;
   }
 
 
   // Greater than or equal
-  proc >=(a: Bigint, b: Bigint) {
+  proc >=(a: bigint, b: bigint) {
     return cmp(a, b) >= 0;
   }
 
-  proc >=(a: Bigint, b: int) {
+  proc >=(a: bigint, b: int) {
     return cmp(a, b) >= 0;
   }
 
-  proc >=(b: int, a: Bigint) {
+  proc >=(b: int, a: bigint) {
     return cmp(a, b) >= 0;
   }
 
-  proc >=(a: Bigint, b: uint) {
+  proc >=(a: bigint, b: uint) {
     return cmp(a, b) >= 0;
   }
 
-  proc >=(b: uint, a: Bigint) {
+  proc >=(b: uint, a: bigint) {
     return cmp(a, b) >= 0;
   }
 
 
 
   // Less than or equal
-  proc <=(a: Bigint, b: Bigint) {
+  proc <=(a: bigint, b: bigint) {
     return cmp(a, b) <= 0;
   }
 
-  proc <=(a: Bigint, b: int) {
+  proc <=(a: bigint, b: int) {
     return cmp(a, b) <= 0;
   }
 
-  proc <=(b: int, a: Bigint) {
+  proc <=(b: int, a: bigint) {
     return cmp(a, b) <= 0;
   }
 
-  proc <=(a: Bigint, b: uint) {
+  proc <=(a: bigint, b: uint) {
     return cmp(a, b) <= 0;
   }
 
-  proc <=(b: uint, a: Bigint) {
+  proc <=(b: uint, a: bigint) {
     return cmp(a, b) <= 0;
   }
 
@@ -1352,7 +1352,7 @@ module BigInteger {
   //
 
   // +=
-  proc +=(ref a: Bigint, b: Bigint) {
+  proc +=(ref a: bigint, b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_add(a.mpz, a.mpz, b.mpz);
 
@@ -1367,7 +1367,7 @@ module BigInteger {
     }
   }
 
-  proc +=(ref a: Bigint, b: int) {
+  proc +=(ref a: bigint, b: int) {
     if (b >= 0) {
       const b_ = b.safeCast(c_ulong);
 
@@ -1398,7 +1398,7 @@ module BigInteger {
     }
   }
 
-  proc +=(ref a: Bigint, b: uint) {
+  proc +=(ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local || a.localeId == chpl_nodeID {
@@ -1416,7 +1416,7 @@ module BigInteger {
 
 
   // -=
-  proc -=(ref a: Bigint, b: Bigint) {
+  proc -=(ref a: bigint, b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_sub(a.mpz, a.mpz, b.mpz);
 
@@ -1431,7 +1431,7 @@ module BigInteger {
     }
   }
 
-  proc -=(ref a: Bigint, b: int) {
+  proc -=(ref a: bigint, b: int) {
     if (b >= 0) {
       const b_ = b.safeCast(c_ulong);
 
@@ -1462,7 +1462,7 @@ module BigInteger {
     }
   }
 
-  proc -=(ref a: Bigint, b: uint) {
+  proc -=(ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local || a.localeId == chpl_nodeID {
@@ -1480,7 +1480,7 @@ module BigInteger {
 
 
   // *=
-  proc *=(ref a: Bigint, b: Bigint) {
+  proc *=(ref a: bigint, b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_mul(a.mpz, a.mpz, b.mpz);
 
@@ -1495,7 +1495,7 @@ module BigInteger {
     }
   }
 
-  proc *=(ref a: Bigint, b: int) {
+  proc *=(ref a: bigint, b: int) {
     const b_ = b.safeCast(c_long);
 
     if _local || a.localeId == chpl_nodeID {
@@ -1510,7 +1510,7 @@ module BigInteger {
     }
   }
 
-  proc *=(ref a: Bigint, b: uint) {
+  proc *=(ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local || a.localeId == chpl_nodeID {
@@ -1528,7 +1528,7 @@ module BigInteger {
 
 
   // /=
-  proc /=(ref a: Bigint, b: Bigint) {
+  proc /=(ref a: bigint, b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_tdiv_q(a.mpz, a.mpz, b.mpz);
 
@@ -1543,7 +1543,7 @@ module BigInteger {
     }
   }
 
-  proc /=(ref a: Bigint, b: int) {
+  proc /=(ref a: bigint, b: int) {
     var b_ = 0 : c_ulong;
 
     if b >= 0 then
@@ -1569,7 +1569,7 @@ module BigInteger {
     }
   }
 
-  proc /=(ref a: Bigint, b: uint) {
+  proc /=(ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local || a.localeId == chpl_nodeID {
@@ -1586,7 +1586,7 @@ module BigInteger {
 
 
   // **=
-  proc **=(ref a: Bigint, b: uint) {
+  proc **=(ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local || a.localeId == chpl_nodeID {
@@ -1604,7 +1604,7 @@ module BigInteger {
 
 
   // %=
-  proc %=(ref a: Bigint, b: Bigint) {
+  proc %=(ref a: bigint, b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_mod(a.mpz, a.mpz, b.mpz);
 
@@ -1619,7 +1619,7 @@ module BigInteger {
     }
   }
 
-  proc %=(ref a: Bigint, b: int) {
+  proc %=(ref a: bigint, b: int) {
     var b_ = 0 : c_ulong;
 
     if b >= 0 then
@@ -1639,7 +1639,7 @@ module BigInteger {
     }
   }
 
-  proc %=(ref a: Bigint, b: uint) {
+  proc %=(ref a: bigint, b: uint) {
     var b_ = b.safeCast(c_ulong);
 
     if _local || a.localeId == chpl_nodeID {
@@ -1654,7 +1654,7 @@ module BigInteger {
     }
   }
 
-  proc &=(ref a: Bigint, b: Bigint) {
+  proc &=(ref a: bigint, b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_and(a.mpz, a.mpz, b.mpz);
 
@@ -1669,7 +1669,7 @@ module BigInteger {
     }
   }
 
-  proc |=(ref a: Bigint, b: Bigint) {
+  proc |=(ref a: bigint, b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_ior(a.mpz, a.mpz, b.mpz);
 
@@ -1684,7 +1684,7 @@ module BigInteger {
     }
   }
 
-  proc ^=(ref a: Bigint, b: Bigint) {
+  proc ^=(ref a: bigint, b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_xor(a.mpz, a.mpz, b.mpz);
 
@@ -1701,7 +1701,7 @@ module BigInteger {
 
 
   // <<=
-  proc <<=(ref a: Bigint, b: int) {
+  proc <<=(ref a: bigint, b: int) {
     if b >= 0 {
       const b_ = b.safeCast(c_ulong);
 
@@ -1732,7 +1732,7 @@ module BigInteger {
     }
   }
 
-  proc <<=(ref a: Bigint, b: uint) {
+  proc <<=(ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local || a.localeId == chpl_nodeID {
@@ -1750,7 +1750,7 @@ module BigInteger {
 
 
   // >>=
-  proc >>=(ref a: Bigint, b: int) {
+  proc >>=(ref a: bigint, b: int) {
     if b >= 0 {
       const b_ = b.safeCast(c_ulong);
 
@@ -1781,7 +1781,7 @@ module BigInteger {
     }
   }
 
-  proc >>=(ref a: Bigint, b: uint) {
+  proc >>=(ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local || a.localeId == chpl_nodeID {
@@ -1798,7 +1798,7 @@ module BigInteger {
 
 
   // Swap
-  proc <=>(ref a: Bigint, ref b: Bigint) {
+  proc <=>(ref a: bigint, ref b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       var t = a;
 
@@ -1829,7 +1829,7 @@ module BigInteger {
 
 
   // Special Operations
-  proc jacobi(a: Bigint, b: Bigint) : int {
+  proc jacobi(a: bigint, b: bigint) : int {
     var ret : c_int;
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -1847,7 +1847,7 @@ module BigInteger {
 
 
 
-  proc legendre(a: Bigint, p: Bigint) : int {
+  proc legendre(a: bigint, p: bigint) : int {
     var ret : c_int;
 
     if _local || (a.localeId == chpl_nodeID && p.localeId == chpl_nodeID) {
@@ -1866,7 +1866,7 @@ module BigInteger {
 
 
   // kronecker
-  proc kronecker(a: Bigint, b: Bigint) : int {
+  proc kronecker(a: bigint, b: bigint) : int {
     var ret : c_int;
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -1882,7 +1882,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc kronecker(a: Bigint, b: int) : int {
+  proc kronecker(a: bigint, b: int) : int {
     const b_ = b.safeCast(c_long);
     var  ret : c_int;
 
@@ -1898,7 +1898,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc kronecker(a: int, b: Bigint) : int {
+  proc kronecker(a: int, b: bigint) : int {
     const a_ = a.safeCast(c_long);
     var  ret : c_int;
 
@@ -1914,7 +1914,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc kronecker(a: Bigint, b: uint) : int {
+  proc kronecker(a: bigint, b: uint) : int {
     const b_ = b.safeCast(c_ulong);
     var  ret : c_int;
 
@@ -1930,7 +1930,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc kronecker(a: uint, b: Bigint) : int {
+  proc kronecker(a: uint, b: bigint) : int {
     const a_ = b.safeCast(c_ulong);
     var  ret : c_int;
 
@@ -1948,7 +1948,7 @@ module BigInteger {
 
 
   // divexact
-  proc Bigint.divexact(n: Bigint, d: Bigint) {
+  proc bigint.divexact(n: bigint, d: bigint) {
     if _local {
       mpz_divexact(this.mpz, n.mpz, d.mpz);
 
@@ -1969,7 +1969,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.divexact(n: Bigint, d: uint) {
+  proc bigint.divexact(n: bigint, d: uint) {
     var d_ = d.safeCast(c_ulong);
 
     if _local {
@@ -1993,7 +1993,7 @@ module BigInteger {
 
 
   // divisible_p
-  proc Bigint.divisible_p(d: Bigint) : int {
+  proc bigint.divisible_p(d: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -2013,7 +2013,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.divisible_p(d: uint) : int {
+  proc bigint.divisible_p(d: uint) : int {
     const d_ = d.safeCast(c_ulong);
     var   ret: c_int;
 
@@ -2032,7 +2032,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.divisible_2exp_p(b: uint) : int {
+  proc bigint.divisible_2exp_p(b: uint) : int {
     const b_ = b.safeCast(c_ulong);
     var   ret: c_int;
 
@@ -2053,7 +2053,7 @@ module BigInteger {
 
 
   // congruent_p
-  proc Bigint.congruent_p(d: Bigint) : int {
+  proc bigint.congruent_p(d: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -2073,7 +2073,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.congruent_p(c: Bigint, d: Bigint) : int {
+  proc bigint.congruent_p(c: bigint, d: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -2095,7 +2095,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.congruent_p(c: uint, d: uint) : int {
+  proc bigint.congruent_p(c: uint, d: uint) : int {
     const c_ = c.safeCast(c_ulong);
     const d_ = d.safeCast(c_ulong);
     var   ret: c_int;
@@ -2115,7 +2115,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.congruent_2exp_p(c: Bigint, b: uint) : int {
+  proc bigint.congruent_2exp_p(c: bigint, b: uint) : int {
     const b_ = b.safeCast(c_ulong);
     var   ret: c_int;
 
@@ -2139,9 +2139,9 @@ module BigInteger {
 
 
   // Exponentiation Functions
-  proc Bigint.powm(base: Bigint,
-                   exp:  Bigint,
-                   mod:  Bigint) {
+  proc bigint.powm(base: bigint,
+                   exp:  bigint,
+                   mod:  bigint) {
     if _local {
       mpz_powm(this.mpz, base.mpz, exp.mpz, mod.mpz);
 
@@ -2164,9 +2164,9 @@ module BigInteger {
     }
   }
 
-  proc Bigint.powm(base: Bigint,
+  proc bigint.powm(base: bigint,
                    exp: uint,
-                   mod: Bigint) {
+                   mod: bigint) {
     const exp_ = exp.safeCast(c_ulong);
 
     if _local {
@@ -2189,7 +2189,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.pow(base: Bigint, exp: uint) {
+  proc bigint.pow(base: bigint, exp: uint) {
     const exp_ = exp.safeCast(c_ulong);
 
     if _local {
@@ -2210,7 +2210,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.pow(base: uint, exp: uint) {
+  proc bigint.pow(base: uint, exp: uint) {
     const base_ = base.safeCast(c_ulong);
     const exp_  = exp.safeCast(c_ulong);
 
@@ -2230,7 +2230,7 @@ module BigInteger {
   }
 
   // Root Extraction Functions
-  proc Bigint.root(a: Bigint, n: uint) : int {
+  proc bigint.root(a: bigint, n: uint) : int {
     const n_  = n.safeCast(c_ulong);
     var   ret: c_int;
 
@@ -2254,7 +2254,7 @@ module BigInteger {
   }
 
   // this gets root, rem gets remainder.
-  proc Bigint.rootrem(ref rem: Bigint, u: Bigint, n: uint) {
+  proc bigint.rootrem(ref rem: bigint, u: bigint, n: uint) {
     const n_  = n.safeCast(c_ulong);
 
     if _local {
@@ -2279,7 +2279,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.sqrt(a: Bigint) {
+  proc bigint.sqrt(a: bigint) {
     if _local {
       mpz_sqrt(this.mpz, a.mpz);
 
@@ -2299,7 +2299,7 @@ module BigInteger {
   }
 
   // this gets root, rem gets remainder of a-root*root.
-  proc Bigint.sqrtrem(ref rem: Bigint, a: Bigint) {
+  proc bigint.sqrtrem(ref rem: bigint, a: bigint) {
     if _local {
       mpz_sqrtrem(this.mpz, rem.mpz, a.mpz);
 
@@ -2322,7 +2322,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.perfect_power_p() : int {
+  proc bigint.perfect_power_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2337,7 +2337,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.perfect_square_p() : int {
+  proc bigint.perfect_square_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2359,7 +2359,7 @@ module BigInteger {
 
   // returns 2 if definitely prime, 0 if not prime, 1 if likely prime
   // reasonable number of reps is 15-50
-  proc Bigint.probab_prime_p(reps: int) : int {
+  proc bigint.probab_prime_p(reps: int) : int {
     var reps_ = reps.safeCast(c_int);
     var ret: c_int;
 
@@ -2375,7 +2375,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.nextprime(a: Bigint) {
+  proc bigint.nextprime(a: bigint) {
     if _local {
       mpz_nextprime(this.mpz, a.mpz);
 
@@ -2397,7 +2397,7 @@ module BigInteger {
 
 
   // gcd
-  proc Bigint.gcd(a: Bigint, b: Bigint) {
+  proc bigint.gcd(a: bigint, b: bigint) {
     if _local {
       mpz_gcd(this.mpz, a.mpz, b.mpz);
 
@@ -2418,7 +2418,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.gcd(a: Bigint, b: uint) {
+  proc bigint.gcd(a: bigint, b: uint) {
     var b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -2441,10 +2441,10 @@ module BigInteger {
 
   // sets this to gcd(a,b)
   // set s and t to to coefficients satisfying a*s + b*t == g
-  proc Bigint.gcdext(ref s: Bigint,
-                     ref t: Bigint,
-                     a: Bigint,
-                     b: Bigint) {
+  proc bigint.gcdext(ref s: bigint,
+                     ref t: bigint,
+                     a: bigint,
+                     b: bigint) {
 
     if _local {
       mpz_gcdext(this.mpz, s.mpz, t.mpz, a.mpz, b.mpz);
@@ -2476,7 +2476,7 @@ module BigInteger {
 
 
   // lcm
-  proc Bigint.lcm(a: Bigint, b: Bigint) {
+  proc bigint.lcm(a: bigint, b: bigint) {
     if _local {
       mpz_lcm(this.mpz, a.mpz, b.mpz);
 
@@ -2497,7 +2497,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.lcm(a: Bigint, b: uint) {
+  proc bigint.lcm(a: bigint, b: uint) {
     var b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -2521,7 +2521,7 @@ module BigInteger {
 
 
   // invert
-  proc Bigint.invert(a: Bigint, b: Bigint) : int {
+  proc bigint.invert(a: bigint, b: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -2548,7 +2548,7 @@ module BigInteger {
 
 
   // remove
-  proc Bigint.remove(a: Bigint, f: Bigint) : uint {
+  proc bigint.remove(a: bigint, f: bigint) : uint {
     var ret: c_ulong;
 
     if _local {
@@ -2575,7 +2575,7 @@ module BigInteger {
 
 
   // Factorial
-  proc Bigint.fac(a: uint) {
+  proc bigint.fac(a: uint) {
     const a_ = a.safeCast(c_ulong);
 
     if _local || this.localeId == chpl_nodeID {
@@ -2593,7 +2593,7 @@ module BigInteger {
 
 
   // Binomial
-  proc Bigint.bin(n: Bigint, k: uint) {
+  proc bigint.bin(n: bigint, k: uint) {
     const k_ = k.safeCast(c_ulong);
 
     if _local {
@@ -2614,7 +2614,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.bin(n: uint, k: uint) {
+  proc bigint.bin(n: uint, k: uint) {
     const n_ = n.safeCast(c_ulong);
     const k_ = k.safeCast(c_ulong);
 
@@ -2633,7 +2633,7 @@ module BigInteger {
 
 
   // Fibonacci
-  proc Bigint.fib(n: uint) {
+  proc bigint.fib(n: uint) {
     const n_ = n.safeCast(c_ulong);
 
     if _local || this.localeId == chpl_nodeID {
@@ -2648,7 +2648,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.fib2(ref fnsub1: Bigint, n: uint) {
+  proc bigint.fib2(ref fnsub1: bigint, n: uint) {
     const n_ = n.safeCast(c_ulong);
 
     if _local {
@@ -2662,7 +2662,7 @@ module BigInteger {
       const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
       on __primitive("chpl_on_locale_num", thisLoc) {
-        var fnsub1_ : Bigint;
+        var fnsub1_ : bigint;
 
         mpz_fib2_ui(this.mpz, fnsub1_.mpz, n_);
 
@@ -2674,7 +2674,7 @@ module BigInteger {
 
 
   // Lucas Number
-  proc Bigint.lucnum(n: uint) {
+  proc bigint.lucnum(n: uint) {
     const n_ = n.safeCast(c_ulong);
 
     if _local || this.localeId == chpl_nodeID {
@@ -2689,7 +2689,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.lucnum2(ref fnsub1: Bigint, n: uint) {
+  proc bigint.lucnum2(ref fnsub1: bigint, n: uint) {
     const n_ = n.safeCast(c_ulong);
 
     if _local {
@@ -2703,7 +2703,7 @@ module BigInteger {
       const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
       on __primitive("chpl_on_locale_num", thisLoc) {
-        var fnsub1_ : Bigint;
+        var fnsub1_ : bigint;
 
         mpz_lucnum2_ui(this.mpz, fnsub1_.mpz, n_);
 
@@ -2715,7 +2715,7 @@ module BigInteger {
 
 
   // Bit operations
-  proc Bigint.popcount() : uint {
+  proc bigint.popcount() : uint {
     var ret: c_ulong;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2730,7 +2730,7 @@ module BigInteger {
     return ret.safeCast(uint);
   }
 
-  proc Bigint.hamdist(b: Bigint) : uint {
+  proc bigint.hamdist(b: bigint) : uint {
     var ret: c_ulong;
 
     if _local {
@@ -2750,7 +2750,7 @@ module BigInteger {
     return ret.safeCast(uint);
   }
 
-  proc Bigint.scan0(starting_bit: uint) : uint {
+  proc bigint.scan0(starting_bit: uint) : uint {
     const sb_ = starting_bit.safeCast(c_ulong);
     var   ret: c_ulong;
 
@@ -2766,7 +2766,7 @@ module BigInteger {
     return ret.safeCast(uint);
   }
 
-  proc Bigint.scan1(starting_bit: uint) : uint {
+  proc bigint.scan1(starting_bit: uint) : uint {
     const sb_ = starting_bit.safeCast(c_ulong);
     var   ret: c_ulong;
 
@@ -2785,7 +2785,7 @@ module BigInteger {
 
 
   // Set/Clr bit
-  proc Bigint.setbit(bit_index: uint) {
+  proc bigint.setbit(bit_index: uint) {
     const bi_ = bit_index.safeCast(c_ulong);
 
     if _local || this.localeId == chpl_nodeID {
@@ -2800,7 +2800,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.clrbit(bit_index: uint) {
+  proc bigint.clrbit(bit_index: uint) {
     const bi_ = bit_index.safeCast(c_ulong);
 
     if _local || this.localeId == chpl_nodeID {
@@ -2815,7 +2815,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.combit(bit_index: uint) {
+  proc bigint.combit(bit_index: uint) {
     const bi_ = bit_index.safeCast(c_ulong);
 
     if _local || this.localeId == chpl_nodeID {
@@ -2830,7 +2830,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.tstbit(bit_index: uint) : int {
+  proc bigint.tstbit(bit_index: uint) : int {
     const bi_ = bit_index.safeCast(c_ulong);
     var  ret: c_int;
 
@@ -2849,7 +2849,7 @@ module BigInteger {
 
 
   // Miscellaneous Functions
-  proc Bigint.fits_ulong_p() : int {
+  proc bigint.fits_ulong_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2864,7 +2864,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.fits_slong_p() : int {
+  proc bigint.fits_slong_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2879,7 +2879,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.fits_uint_p() : int {
+  proc bigint.fits_uint_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2894,7 +2894,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.fits_sint_p() : int {
+  proc bigint.fits_sint_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2909,7 +2909,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.fits_ushort_p() : int {
+  proc bigint.fits_ushort_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2924,7 +2924,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.fits_sshort_p() : int {
+  proc bigint.fits_sshort_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2939,7 +2939,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.even_p() : int {
+  proc bigint.even_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2954,7 +2954,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.odd_p() : int {
+  proc bigint.odd_p() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2975,7 +2975,7 @@ module BigInteger {
   // Unary arithmetic functions
   //
 
-  proc Bigint.neg(a: Bigint) {
+  proc bigint.neg(a: bigint) {
     if _local {
       mpz_neg(this.mpz, a.mpz);
 
@@ -2994,7 +2994,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.abs(a: Bigint) {
+  proc bigint.abs(a: bigint) {
     if _local {
       mpz_abs(this.mpz, a.mpz);
 
@@ -3018,7 +3018,7 @@ module BigInteger {
   //
 
   // Addition
-  proc Bigint.add(a: Bigint, b: Bigint) {
+  proc bigint.add(a: bigint, b: bigint) {
     if _local {
       mpz_add(this.mpz, a.mpz, b.mpz);
 
@@ -3039,7 +3039,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.add(a: Bigint, b: uint) {
+  proc bigint.add(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -3063,7 +3063,7 @@ module BigInteger {
 
 
   // Subtraction
-  proc Bigint.sub(a: Bigint, b: Bigint) {
+  proc bigint.sub(a: bigint, b: bigint) {
     if _local {
       mpz_sub(this.mpz, a.mpz, b.mpz);
 
@@ -3084,7 +3084,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.sub(a: Bigint, b: uint) {
+  proc bigint.sub(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -3105,7 +3105,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.sub(a: uint, b: Bigint) {
+  proc bigint.sub(a: uint, b: bigint) {
     const a_ = a.safeCast(c_ulong);
 
     if _local {
@@ -3129,7 +3129,7 @@ module BigInteger {
 
 
   // Multiplication
-  proc Bigint.mul(a: Bigint, b: Bigint) {
+  proc bigint.mul(a: bigint, b: bigint) {
     if _local {
       mpz_mul(this.mpz, a.mpz, b.mpz);
 
@@ -3150,7 +3150,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.mul(a: Bigint, b: int) {
+  proc bigint.mul(a: bigint, b: int) {
     const b_ = b.safeCast(c_long);
 
     if _local {
@@ -3171,7 +3171,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.mul(a: Bigint, b: uint) {
+  proc bigint.mul(a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -3192,7 +3192,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.mul_2exp(a: Bigint, b: uint) {
+  proc bigint.mul_2exp(a: bigint, b: uint) {
     var b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -3214,9 +3214,9 @@ module BigInteger {
   }
 
   // Division
-  proc Bigint.div_q(param rounding: Round,
-                    n: Bigint,
-                    d: Bigint) {
+  proc bigint.div_q(param rounding: Round,
+                    n: bigint,
+                    d: bigint) {
     if _local {
       select rounding {
         when Round.UP   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
@@ -3249,8 +3249,8 @@ module BigInteger {
     }
   }
 
-  proc Bigint.div_q(param rounding: Round,
-                    n: Bigint,
+  proc bigint.div_q(param rounding: Round,
+                    n: bigint,
                     d: uint) : uint {
     const d_ = d.safeCast(c_ulong);
     var   ret: c_ulong;
@@ -3287,9 +3287,9 @@ module BigInteger {
     return ret.safeCast(uint);
   }
 
-  proc Bigint.div_r(param rounding: Round,
-                    n: Bigint,
-                    d: Bigint) {
+  proc bigint.div_r(param rounding: Round,
+                    n: bigint,
+                    d: bigint) {
     if _local {
       select rounding {
         when Round.UP   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
@@ -3322,8 +3322,8 @@ module BigInteger {
     }
   }
 
-  proc Bigint.div_r(param rounding: Round,
-                    n: Bigint,
+  proc bigint.div_r(param rounding: Round,
+                    n: bigint,
                     d: uint) : uint {
     const d_ = d.safeCast(c_ulong);
     var   ret: c_ulong;
@@ -3363,10 +3363,10 @@ module BigInteger {
 
 
   // this gets quotient, r gets remainder
-  proc Bigint.div_qr(param rounding: Round,
-                     ref r: Bigint,
-                     n: Bigint,
-                     d: Bigint) {
+  proc bigint.div_qr(param rounding: Round,
+                     ref r: bigint,
+                     n: bigint,
+                     d: bigint) {
     if _local {
       select rounding {
         when Round.UP   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
@@ -3404,9 +3404,9 @@ module BigInteger {
   }
 
   // this gets quotient, r gets remainder
-  proc Bigint.div_qr(param rounding: Round,
-                     ref r: Bigint,
-                     n: Bigint,
+  proc bigint.div_qr(param rounding: Round,
+                     ref r: bigint,
+                     n: bigint,
                      d: uint) : uint {
     const d_ = d.safeCast(c_ulong);
     var   ret: c_ulong;
@@ -3452,8 +3452,8 @@ module BigInteger {
     return ret;
   }
 
-  proc Bigint.div_q_2exp(param rounding: Round,
-                         n: Bigint,
+  proc bigint.div_q_2exp(param rounding: Round,
+                         n: bigint,
                          b: uint) {
     const b_ = b.safeCast(c_ulong);
 
@@ -3487,8 +3487,8 @@ module BigInteger {
     }
   }
 
-  proc Bigint.div_r_2exp(param rounding: Round,
-                         n: Bigint,
+  proc bigint.div_r_2exp(param rounding: Round,
+                         n: bigint,
                          b: uint) {
     const b_ = b.safeCast(c_ulong);
 
@@ -3524,8 +3524,8 @@ module BigInteger {
 
 
 
-  proc Bigint.addmul(a: Bigint,
-                     b: Bigint) {
+  proc bigint.addmul(a: bigint,
+                     b: bigint) {
     if _local {
       mpz_addmul(this.mpz, a.mpz, b.mpz);
 
@@ -3546,7 +3546,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.addmul(a: Bigint,
+  proc bigint.addmul(a: bigint,
                      b: uint) {
     const b_ = b.safeCast(c_ulong);
 
@@ -3570,8 +3570,8 @@ module BigInteger {
 
 
 
-  proc Bigint.submul(a: Bigint,
-                     b: Bigint) {
+  proc bigint.submul(a: bigint,
+                     b: bigint) {
     if _local {
       mpz_submul(this.mpz, a.mpz, b.mpz);
 
@@ -3592,7 +3592,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.submul(a: Bigint,
+  proc bigint.submul(a: bigint,
                      b: uint) {
     const b_ = b.safeCast(c_ulong);
 
@@ -3616,8 +3616,8 @@ module BigInteger {
 
 
 
-  proc Bigint.mod(a: Bigint,
-                  b: Bigint) {
+  proc bigint.mod(a: bigint,
+                  b: bigint) {
     if _local {
       mpz_mod(this.mpz, a.mpz, b.mpz);
 
@@ -3638,7 +3638,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.mod(a: Bigint,
+  proc bigint.mod(a: bigint,
                   b: uint) : uint {
     const b_ = b.safeCast(c_ulong);
     var   ret: c_ulong;
@@ -3666,7 +3666,7 @@ module BigInteger {
 
 
   // Comparison Functions
-  proc Bigint.cmp(b: Bigint) : int {
+  proc bigint.cmp(b: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -3689,7 +3689,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.cmp(b: int) : int {
+  proc bigint.cmp(b: int) : int {
     const b_ = b.safeCast(c_long);
     var   ret: c_int;
 
@@ -3710,7 +3710,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.cmp(b: uint) : int {
+  proc bigint.cmp(b: uint) : int {
     const b_ = b.safeCast(c_ulong);
     var   ret: c_int;
 
@@ -3731,7 +3731,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.cmp(b: real) : int {
+  proc bigint.cmp(b: real) : int {
     const b_ = b : c_double;
     var   ret: c_int;
 
@@ -3754,7 +3754,7 @@ module BigInteger {
 
 
 
-  proc Bigint.cmpabs(b: Bigint) : int {
+  proc bigint.cmpabs(b: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -3777,7 +3777,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.cmpabs(b: uint) : int {
+  proc bigint.cmpabs(b: uint) : int {
     const b_ = b.safeCast(c_ulong);
     var   ret: c_int;
 
@@ -3798,7 +3798,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc Bigint.cmpabs(b: real) : int {
+  proc bigint.cmpabs(b: real) : int {
     const b_ = b : c_double;
     var   ret: c_int;
 
@@ -3821,7 +3821,7 @@ module BigInteger {
 
 
 
-  proc Bigint.sgn() : int {
+  proc bigint.sgn() : int {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -3847,7 +3847,7 @@ module BigInteger {
 
 
   // Logical and Bit Manipulation Functions
-  proc Bigint.and(a: Bigint, b: Bigint) {
+  proc bigint.and(a: bigint, b: bigint) {
     if _local {
       mpz_and(this.mpz, a.mpz, b.mpz);
 
@@ -3868,7 +3868,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.ior(a: Bigint, b: Bigint) {
+  proc bigint.ior(a: bigint, b: bigint) {
     if _local {
       mpz_ior(this.mpz, a.mpz, b.mpz);
 
@@ -3889,7 +3889,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.xor(a: Bigint, b: Bigint) {
+  proc bigint.xor(a: bigint, b: bigint) {
     if _local {
       mpz_xor(this.mpz, a.mpz, b.mpz);
 
@@ -3910,7 +3910,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.com(a: Bigint) {
+  proc bigint.com(a: bigint) {
     if _local {
       mpz_com(this.mpz, a.mpz);
 
@@ -3932,7 +3932,7 @@ module BigInteger {
 
 
   // Assignment functions
-  proc Bigint.set(a: Bigint) {
+  proc bigint.set(a: bigint) {
     if _local {
       mpz_set(this.mpz, a.mpz);
 
@@ -3951,7 +3951,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.set(num : int) {
+  proc bigint.set(num : int) {
     const num_ = num.safeCast(c_long);
 
     if _local {
@@ -3969,7 +3969,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.set(num : uint) {
+  proc bigint.set(num : uint) {
     const num_ = num.safeCast(c_ulong);
 
     if _local {
@@ -3987,7 +3987,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.set(num: real) {
+  proc bigint.set(num: real) {
     const num_ = num : c_double;
 
     if _local {
@@ -4005,7 +4005,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.set(str: string, base: int = 0) {
+  proc bigint.set(str: string, base: int = 0) {
     const base_ = base.safeCast(c_int);
 
     if _local {
@@ -4023,7 +4023,7 @@ module BigInteger {
     }
   }
 
-  proc Bigint.swap(ref a: Bigint) {
+  proc bigint.swap(ref a: bigint) {
     if _local {
       mpz_swap(this.mpz, a.mpz);
 
@@ -4035,7 +4035,7 @@ module BigInteger {
       const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
       on __primitive("chpl_on_locale_num", thisLoc) {
-        var tmp = new Bigint(a);
+        var tmp = new bigint(a);
 
         a.set(this);
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -58,12 +58,6 @@ A code example::
 module BigInteger {
   use GMP;
 
-  enum Round {
-    DOWN = -1,
-    ZERO =  0,
-    UP   =  1
-  }
-
   /*
     The Bigint record provides arbitrary length integers and a set of
     operator overloads that allow Bigints to be treated consistently

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -103,7 +103,7 @@ module BigInteger {
       this.localeId = chpl_nodeID;
     }
 
-    proc bigint(num: bigint) {
+    proc bigint(const ref num: bigint) {
       if _local || num.localeId == chpl_nodeID {
         mpz_init_set(this.mpz, num.mpz);
       } else {
@@ -363,7 +363,7 @@ module BigInteger {
 
   pragma "init copy fn"
   pragma "no doc"
-  proc chpl__initCopy(bir: bigint) {
+  proc chpl__initCopy(const ref bir: bigint) {
     var ret : bigint;
 
     if _local || bir.localeId == chpl_nodeID {
@@ -380,7 +380,7 @@ module BigInteger {
   pragma "donor fn"
   pragma "auto copy fn"
   pragma "no doc"
-  proc chpl__autoCopy(bir: bigint) {
+  proc chpl__autoCopy(const ref bir: bigint) {
     var ret : bigint;
 
     if _local || bir.localeId == chpl_nodeID {
@@ -397,7 +397,7 @@ module BigInteger {
   // Locale-aware assignment
   //
 
-  proc =(ref lhs: bigint, rhs: bigint) {
+  proc =(ref lhs: bigint, const ref rhs: bigint) {
     inline proc helper() {
       if _local || rhs.localeId == chpl_nodeID {
         mpz_set(lhs.mpz, rhs.mpz);
@@ -472,11 +472,11 @@ module BigInteger {
   //
   // Unary operators
   //
-  proc +(a: bigint) {
+  proc +(const ref a: bigint) {
     return new bigint(a);
   }
 
-  proc -(a: bigint) {
+  proc -(const ref a: bigint) {
     var c = new bigint(a);
 
     mpz_neg(c.mpz, c.mpz);
@@ -484,7 +484,7 @@ module BigInteger {
     return c;
   }
 
-  proc ~(a: bigint) {
+  proc ~(const ref a: bigint) {
     var c = new bigint(a);
 
     mpz_com(c.mpz, c.mpz);
@@ -497,7 +497,7 @@ module BigInteger {
   //
 
   // Addition
-  proc +(a: bigint, b: bigint) {
+  proc +(const ref a: bigint, const ref b: bigint) {
     var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -513,7 +513,7 @@ module BigInteger {
     return c;
   }
 
-  proc +(a: bigint, b: int) {
+  proc +(const ref a: bigint, b: int) {
     var c = new bigint();
 
     if b >= 0 {
@@ -545,7 +545,7 @@ module BigInteger {
     return c;
   }
 
-  proc +(a: int, b: bigint) {
+  proc +(a: int, const ref b: bigint) {
     var c = new bigint();
 
     if a >= 0 {
@@ -577,7 +577,7 @@ module BigInteger {
     return c;
   }
 
-  proc +(a: bigint, b: uint) {
+  proc +(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
     var   c  = new bigint();
 
@@ -593,7 +593,7 @@ module BigInteger {
     return c;
   }
 
-  proc +(a: uint, b: bigint) {
+  proc +(a: uint, const ref b: bigint) {
     const a_ = a.safeCast(c_ulong);
     var   c  = new bigint();
 
@@ -612,7 +612,7 @@ module BigInteger {
 
 
   // Subtraction
-  proc -(a: bigint, b: bigint) {
+  proc -(const ref a: bigint, const ref b: bigint) {
     var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -628,7 +628,7 @@ module BigInteger {
     return c;
   }
 
-  proc -(a: bigint, b: int) {
+  proc -(const ref a: bigint, const ref b: int) {
     var c = new bigint();
 
     if b >= 0 {
@@ -660,7 +660,7 @@ module BigInteger {
     return c;
   }
 
-  proc -(a: int, b: bigint) {
+  proc -(a: int, const ref b: bigint) {
     var c = new bigint();
 
     if a >= 0 {
@@ -692,7 +692,7 @@ module BigInteger {
     return c;
   }
 
-  proc -(a: bigint, b: uint) {
+  proc -(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
     var   c  = new bigint();
 
@@ -708,7 +708,7 @@ module BigInteger {
     return c;
   }
 
-  proc -(a: uint, b: bigint) {
+  proc -(a: uint, const ref b: bigint) {
     const a_ = a.safeCast(c_ulong);
     var   c  = new bigint();
 
@@ -726,7 +726,7 @@ module BigInteger {
 
 
   // Multiplication
-  proc *(a: bigint, b: bigint) {
+  proc *(const ref a: bigint, const ref b: bigint) {
     var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -742,7 +742,7 @@ module BigInteger {
     return c;
   }
 
-  proc *(a: bigint, b: int) {
+  proc *(const ref a: bigint, b: int) {
     const b_ = b.safeCast(c_long);
     var   c  = new bigint();
 
@@ -758,7 +758,7 @@ module BigInteger {
     return c;
   }
 
-  proc *(a: int, b: bigint) {
+  proc *(a: int, const ref b: bigint) {
     const a_ = a.safeCast(c_long);
     var   c  = new bigint();
 
@@ -774,7 +774,7 @@ module BigInteger {
     return c;
   }
 
-  proc *(a: bigint, b: uint) {
+  proc *(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
     var   c  = new bigint();
 
@@ -790,7 +790,7 @@ module BigInteger {
     return c;
   }
 
-  proc *(a: uint, b: bigint) {
+  proc *(a: uint, const ref b: bigint) {
     const a_ = a.safeCast(c_ulong);
     var   c  = new bigint();
 
@@ -809,7 +809,7 @@ module BigInteger {
 
 
   // Division
-  proc /(a: bigint, b: bigint) {
+  proc /(const ref a: bigint, const ref b: bigint) {
     var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -825,7 +825,7 @@ module BigInteger {
     return c;
   }
 
-  proc /(a: bigint, b: int) {
+  proc /(const ref a: bigint, b: int) {
     var b_ = 0 : c_ulong;
     var c  = new bigint();
 
@@ -849,7 +849,7 @@ module BigInteger {
     return c;
   }
 
-  proc /(a: bigint, b: uint) {
+  proc /(const ref a: bigint, b: uint) {
     var b_ = b.safeCast(c_ulong);
     var c  = new bigint();
 
@@ -865,7 +865,7 @@ module BigInteger {
     return c;
   }
 
-  proc div(param rounding: Round, n: bigint, d: uint) : uint {
+  proc div(param rounding: Round, const ref n: bigint, d: uint) : uint {
     const d_ = d.safeCast(c_ulong);
     var   ret: c_ulong;
 
@@ -893,7 +893,7 @@ module BigInteger {
 
 
   // Exponentiation
-  proc **(a: bigint, b: uint) {
+  proc **(const ref a: bigint, b: uint) {
     var c = new bigint();
 
     if _local || a.localeId == chpl_nodeID {
@@ -911,7 +911,7 @@ module BigInteger {
 
 
   // Mod
-  proc %(a: bigint, b: bigint) {
+  proc %(const ref a: bigint, const ref b: bigint) {
     var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -926,7 +926,7 @@ module BigInteger {
     return c;
   }
 
-  proc %(a: bigint, b: int) {
+  proc %(const ref a: bigint, b: int) {
     var b_ = 0 : c_ulong;
     var c  = new bigint();
 
@@ -947,7 +947,7 @@ module BigInteger {
     return c;
   }
 
-  proc %(a: bigint, b: uint) {
+  proc %(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
     var   c  = new bigint();
 
@@ -966,7 +966,7 @@ module BigInteger {
 
 
   // Bit-shift left
-  proc <<(a: bigint, b: int) {
+  proc <<(const ref a: bigint, b: int) {
     var c = new bigint();
 
     if b >= 0 {
@@ -997,7 +997,7 @@ module BigInteger {
     return c;
   }
 
-  proc <<(a: bigint, b: uint) {
+  proc <<(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
     var   c  = new bigint();
 
@@ -1016,7 +1016,7 @@ module BigInteger {
 
 
   // Bit-shift right
-  proc >>(a: bigint, b: int) {
+  proc >>(const ref a: bigint, b: int) {
     var c = new bigint();
 
     if b >= 0 {
@@ -1048,7 +1048,7 @@ module BigInteger {
     return c;
   }
 
-  proc >>(a: bigint, b: uint) {
+  proc >>(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
     var   c  = new bigint();
 
@@ -1067,7 +1067,7 @@ module BigInteger {
 
 
   // Bitwise and
-  proc &(a: bigint, b: bigint) {
+  proc &(const ref a: bigint, const ref b: bigint) {
     var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -1086,7 +1086,7 @@ module BigInteger {
 
 
   // Bitwise ior
-  proc |(a: bigint, b: bigint) {
+  proc |(const ref a: bigint, const ref b: bigint) {
     var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -1105,7 +1105,7 @@ module BigInteger {
 
 
   // Bitwise xor
-  proc ^(a: bigint, b: bigint) {
+  proc ^(const ref a: bigint, const ref b: bigint) {
     var c = new bigint();
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -1127,7 +1127,7 @@ module BigInteger {
   // Comparison Operations
   //
 
-  private inline proc cmp(a: bigint, b: bigint) {
+  private inline proc cmp(const ref a: bigint, const ref b: bigint) {
     var ret : c_int;
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -1143,7 +1143,7 @@ module BigInteger {
     return ret;
   }
 
-  private inline proc cmp(a: bigint, b: int) {
+  private inline proc cmp(const ref a: bigint, b: int) {
     const b_ = b.safeCast(c_long);
     var   ret : c_int;
 
@@ -1159,7 +1159,7 @@ module BigInteger {
     return ret;
   }
 
-  private inline proc cmp(a: int, b: bigint) {
+  private inline proc cmp(a: int, const ref b: bigint) {
     const a_ = a.safeCast(c_long);
     var   ret : c_int;
 
@@ -1175,7 +1175,7 @@ module BigInteger {
     return ret;
   }
 
-  private inline proc cmp(a: bigint, b: uint) {
+  private inline proc cmp(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
     var   ret : c_int;
 
@@ -1191,7 +1191,7 @@ module BigInteger {
     return ret;
   }
 
-  private inline proc cmp(a: uint, b: bigint) {
+  private inline proc cmp(a: uint, const ref b: bigint) {
     const a_ = a.safeCast(c_ulong);
     var   ret : c_int;
 
@@ -1210,137 +1210,137 @@ module BigInteger {
 
 
   // Equality
-  proc ==(a: bigint, b: bigint) {
+  proc ==(const ref a: bigint, const ref b: bigint) {
     return cmp(a, b) == 0;
   }
 
-  proc ==(a: bigint, b: int) {
+  proc ==(const ref a: bigint, b: int) {
     return cmp(a, b) == 0;
   }
 
-  proc ==(a: int, b: bigint) {
+  proc ==(a: int, const ref b: bigint) {
     return cmp(a, b) == 0;
   }
 
-  proc ==(a: bigint, b: uint) {
+  proc ==(const ref a: bigint, b: uint) {
     return cmp(a, b) == 0;
   }
 
-  proc ==(a: uint, b: bigint) {
+  proc ==(a: uint, const ref b: bigint) {
     return cmp(a, b) == 0;
   }
 
 
 
   // Inequality
-  proc !=(a: bigint, b: bigint) {
+  proc !=(const ref a: bigint, const ref b: bigint) {
     return cmp(a, b) != 0;
   }
 
-  proc !=(a: bigint, b: int) {
+  proc !=(const ref a: bigint, b: int) {
     return cmp(a, b) != 0;
   }
 
-  proc !=(a: int, b: bigint) {
+  proc !=(a: int, const ref b: bigint) {
     return cmp(a, b) != 0;
   }
 
-  proc !=(a: bigint, b: uint) {
+  proc !=(const ref a: bigint, b: uint) {
     return cmp(a, b) != 0;
   }
 
-  proc !=(a: uint, b: bigint) {
+  proc !=(a: uint, const ref b: bigint) {
     return cmp(a, b) != 0;
   }
 
 
 
   // Greater than
-  proc >(a: bigint, b: bigint) {
+  proc >(const ref a: bigint, const ref b: bigint) {
     return cmp(a, b) > 0;
   }
 
-  proc >(a: bigint, b: int) {
+  proc >(const ref a: bigint, b: int) {
     return cmp(a, b) > 0;
   }
 
-  proc >(b: int, a: bigint) {
+  proc >(b: int, const ref a: bigint) {
     return cmp(a, b) > 0;
   }
 
-  proc >(a: bigint, b: uint) {
+  proc >(const ref a: bigint, b: uint) {
     return cmp(a, b) > 0;
   }
 
-  proc >(b: uint, a: bigint) {
+  proc >(b: uint, const ref a: bigint) {
     return cmp(a, b) > 0;
   }
 
 
 
   // Less than
-  proc <(a: bigint, b: bigint) {
+  proc <(const ref a: bigint, const ref b: bigint) {
     return cmp(a, b) < 0;
   }
 
-  proc <(a: bigint, b: int) {
+  proc <(const ref a: bigint, b: int) {
     return cmp(a, b) < 0;
   }
 
-  proc <(b: int, a: bigint) {
+  proc <(b: int, const ref a: bigint) {
     return cmp(a, b) < 0;
   }
 
-  proc <(a: bigint, b: uint) {
+  proc <(const ref a: bigint, b: uint) {
     return cmp(a, b) < 0;
   }
 
-  proc <(b: uint, a: bigint) {
+  proc <(b: uint, const ref a: bigint) {
     return cmp(a, b) < 0;
   }
 
 
   // Greater than or equal
-  proc >=(a: bigint, b: bigint) {
+  proc >=(const ref a: bigint, const ref b: bigint) {
     return cmp(a, b) >= 0;
   }
 
-  proc >=(a: bigint, b: int) {
+  proc >=(const ref a: bigint, b: int) {
     return cmp(a, b) >= 0;
   }
 
-  proc >=(b: int, a: bigint) {
+  proc >=(b: int, const ref a: bigint) {
     return cmp(a, b) >= 0;
   }
 
-  proc >=(a: bigint, b: uint) {
+  proc >=(const ref a: bigint, b: uint) {
     return cmp(a, b) >= 0;
   }
 
-  proc >=(b: uint, a: bigint) {
+  proc >=(b: uint, const ref a: bigint) {
     return cmp(a, b) >= 0;
   }
 
 
 
   // Less than or equal
-  proc <=(a: bigint, b: bigint) {
+  proc <=(const ref a: bigint, const ref b: bigint) {
     return cmp(a, b) <= 0;
   }
 
-  proc <=(a: bigint, b: int) {
+  proc <=(const ref a: bigint, b: int) {
     return cmp(a, b) <= 0;
   }
 
-  proc <=(b: int, a: bigint) {
+  proc <=(b: int, const ref a: bigint) {
     return cmp(a, b) <= 0;
   }
 
-  proc <=(a: bigint, b: uint) {
+  proc <=(const ref a: bigint, b: uint) {
     return cmp(a, b) <= 0;
   }
 
-  proc <=(b: uint, a: bigint) {
+  proc <=(b: uint, const ref a: bigint) {
     return cmp(a, b) <= 0;
   }
 
@@ -1352,7 +1352,7 @@ module BigInteger {
   //
 
   // +=
-  proc +=(ref a: bigint, b: bigint) {
+  proc +=(ref a: bigint, const ref b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_add(a.mpz, a.mpz, b.mpz);
 
@@ -1416,7 +1416,7 @@ module BigInteger {
 
 
   // -=
-  proc -=(ref a: bigint, b: bigint) {
+  proc -=(ref a: bigint, const ref b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_sub(a.mpz, a.mpz, b.mpz);
 
@@ -1480,7 +1480,7 @@ module BigInteger {
 
 
   // *=
-  proc *=(ref a: bigint, b: bigint) {
+  proc *=(ref a: bigint, const ref b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_mul(a.mpz, a.mpz, b.mpz);
 
@@ -1528,7 +1528,7 @@ module BigInteger {
 
 
   // /=
-  proc /=(ref a: bigint, b: bigint) {
+  proc /=(ref a: bigint, const ref b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_tdiv_q(a.mpz, a.mpz, b.mpz);
 
@@ -1604,7 +1604,7 @@ module BigInteger {
 
 
   // %=
-  proc %=(ref a: bigint, b: bigint) {
+  proc %=(ref a: bigint, const ref b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_mod(a.mpz, a.mpz, b.mpz);
 
@@ -1654,7 +1654,7 @@ module BigInteger {
     }
   }
 
-  proc &=(ref a: bigint, b: bigint) {
+  proc &=(ref a: bigint, const ref b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_and(a.mpz, a.mpz, b.mpz);
 
@@ -1669,7 +1669,7 @@ module BigInteger {
     }
   }
 
-  proc |=(ref a: bigint, b: bigint) {
+  proc |=(ref a: bigint, const ref b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_ior(a.mpz, a.mpz, b.mpz);
 
@@ -1684,7 +1684,7 @@ module BigInteger {
     }
   }
 
-  proc ^=(ref a: bigint, b: bigint) {
+  proc ^=(ref a: bigint, const ref b: bigint) {
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
       mpz_xor(a.mpz, a.mpz, b.mpz);
 
@@ -1829,7 +1829,7 @@ module BigInteger {
 
 
   // Special Operations
-  proc jacobi(a: bigint, b: bigint) : int {
+  proc jacobi(const ref a: bigint, const ref b: bigint) : int {
     var ret : c_int;
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -1847,7 +1847,7 @@ module BigInteger {
 
 
 
-  proc legendre(a: bigint, p: bigint) : int {
+  proc legendre(const ref a: bigint, const ref p: bigint) : int {
     var ret : c_int;
 
     if _local || (a.localeId == chpl_nodeID && p.localeId == chpl_nodeID) {
@@ -1866,7 +1866,7 @@ module BigInteger {
 
 
   // kronecker
-  proc kronecker(a: bigint, b: bigint) : int {
+  proc kronecker(const ref a: bigint, const ref b: bigint) : int {
     var ret : c_int;
 
     if _local || (a.localeId == chpl_nodeID && b.localeId == chpl_nodeID) {
@@ -1882,7 +1882,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc kronecker(a: bigint, b: int) : int {
+  proc kronecker(const ref a: bigint, b: int) : int {
     const b_ = b.safeCast(c_long);
     var  ret : c_int;
 
@@ -1898,7 +1898,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc kronecker(a: int, b: bigint) : int {
+  proc kronecker(a: int, const ref b: bigint) : int {
     const a_ = a.safeCast(c_long);
     var  ret : c_int;
 
@@ -1914,7 +1914,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc kronecker(a: bigint, b: uint) : int {
+  proc kronecker(const ref a: bigint, b: uint) : int {
     const b_ = b.safeCast(c_ulong);
     var  ret : c_int;
 
@@ -1930,7 +1930,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc kronecker(a: uint, b: bigint) : int {
+  proc kronecker(a: uint, const ref b: bigint) : int {
     const a_ = b.safeCast(c_ulong);
     var  ret : c_int;
 
@@ -1948,7 +1948,7 @@ module BigInteger {
 
 
   // divexact
-  proc bigint.divexact(n: bigint, d: bigint) {
+  proc bigint.divexact(const ref n: bigint, const ref d: bigint) {
     if _local {
       mpz_divexact(this.mpz, n.mpz, d.mpz);
 
@@ -1969,7 +1969,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.divexact(n: bigint, d: uint) {
+  proc bigint.divexact(const ref n: bigint, d: uint) {
     var d_ = d.safeCast(c_ulong);
 
     if _local {
@@ -1993,7 +1993,7 @@ module BigInteger {
 
 
   // divisible_p
-  proc bigint.divisible_p(d: bigint) : int {
+  proc bigint.divisible_p(const ref d: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -2053,7 +2053,7 @@ module BigInteger {
 
 
   // congruent_p
-  proc bigint.congruent_p(d: bigint) : int {
+  proc bigint.congruent_p(const ref d: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -2073,7 +2073,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc bigint.congruent_p(c: bigint, d: bigint) : int {
+  proc bigint.congruent_p(const ref c: bigint, const ref d: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -2115,7 +2115,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc bigint.congruent_2exp_p(c: bigint, b: uint) : int {
+  proc bigint.congruent_2exp_p(const ref c: bigint, b: uint) : int {
     const b_ = b.safeCast(c_ulong);
     var   ret: c_int;
 
@@ -2139,9 +2139,9 @@ module BigInteger {
 
 
   // Exponentiation Functions
-  proc bigint.powm(base: bigint,
-                   exp:  bigint,
-                   mod:  bigint) {
+  proc bigint.powm(const ref base: bigint,
+                   const ref exp:  bigint,
+                   const ref mod:  bigint) {
     if _local {
       mpz_powm(this.mpz, base.mpz, exp.mpz, mod.mpz);
 
@@ -2164,9 +2164,9 @@ module BigInteger {
     }
   }
 
-  proc bigint.powm(base: bigint,
+  proc bigint.powm(const ref base: bigint,
                    exp: uint,
-                   mod: bigint) {
+                   const ref mod: bigint) {
     const exp_ = exp.safeCast(c_ulong);
 
     if _local {
@@ -2189,7 +2189,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.pow(base: bigint, exp: uint) {
+  proc bigint.pow(const ref base: bigint, exp: uint) {
     const exp_ = exp.safeCast(c_ulong);
 
     if _local {
@@ -2230,7 +2230,7 @@ module BigInteger {
   }
 
   // Root Extraction Functions
-  proc bigint.root(a: bigint, n: uint) : int {
+  proc bigint.root(const ref a: bigint, n: uint) : int {
     const n_  = n.safeCast(c_ulong);
     var   ret: c_int;
 
@@ -2254,7 +2254,7 @@ module BigInteger {
   }
 
   // this gets root, rem gets remainder.
-  proc bigint.rootrem(ref rem: bigint, u: bigint, n: uint) {
+  proc bigint.rootrem(ref rem: bigint, const ref u: bigint, n: uint) {
     const n_  = n.safeCast(c_ulong);
 
     if _local {
@@ -2279,7 +2279,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.sqrt(a: bigint) {
+  proc bigint.sqrt(const ref a: bigint) {
     if _local {
       mpz_sqrt(this.mpz, a.mpz);
 
@@ -2299,7 +2299,7 @@ module BigInteger {
   }
 
   // this gets root, rem gets remainder of a-root*root.
-  proc bigint.sqrtrem(ref rem: bigint, a: bigint) {
+  proc bigint.sqrtrem(ref rem: bigint, const ref a: bigint) {
     if _local {
       mpz_sqrtrem(this.mpz, rem.mpz, a.mpz);
 
@@ -2375,7 +2375,7 @@ module BigInteger {
     return ret.safeCast(int);
   }
 
-  proc bigint.nextprime(a: bigint) {
+  proc bigint.nextprime(const ref a: bigint) {
     if _local {
       mpz_nextprime(this.mpz, a.mpz);
 
@@ -2397,7 +2397,7 @@ module BigInteger {
 
 
   // gcd
-  proc bigint.gcd(a: bigint, b: bigint) {
+  proc bigint.gcd(const ref a: bigint, const ref b: bigint) {
     if _local {
       mpz_gcd(this.mpz, a.mpz, b.mpz);
 
@@ -2418,7 +2418,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.gcd(a: bigint, b: uint) {
+  proc bigint.gcd(const ref a: bigint, b: uint) {
     var b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -2443,8 +2443,8 @@ module BigInteger {
   // set s and t to to coefficients satisfying a*s + b*t == g
   proc bigint.gcdext(ref s: bigint,
                      ref t: bigint,
-                     a: bigint,
-                     b: bigint) {
+                     const ref a: bigint,
+                     const ref b: bigint) {
 
     if _local {
       mpz_gcdext(this.mpz, s.mpz, t.mpz, a.mpz, b.mpz);
@@ -2476,7 +2476,7 @@ module BigInteger {
 
 
   // lcm
-  proc bigint.lcm(a: bigint, b: bigint) {
+  proc bigint.lcm(const ref a: bigint, const ref b: bigint) {
     if _local {
       mpz_lcm(this.mpz, a.mpz, b.mpz);
 
@@ -2497,7 +2497,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.lcm(a: bigint, b: uint) {
+  proc bigint.lcm(const ref a: bigint, b: uint) {
     var b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -2521,7 +2521,7 @@ module BigInteger {
 
 
   // invert
-  proc bigint.invert(a: bigint, b: bigint) : int {
+  proc bigint.invert(const ref a: bigint, const ref b: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -2548,7 +2548,7 @@ module BigInteger {
 
 
   // remove
-  proc bigint.remove(a: bigint, f: bigint) : uint {
+  proc bigint.remove(const ref a: bigint, const ref f: bigint) : uint {
     var ret: c_ulong;
 
     if _local {
@@ -2593,7 +2593,7 @@ module BigInteger {
 
 
   // Binomial
-  proc bigint.bin(n: bigint, k: uint) {
+  proc bigint.bin(const ref n: bigint, k: uint) {
     const k_ = k.safeCast(c_ulong);
 
     if _local {
@@ -2730,7 +2730,7 @@ module BigInteger {
     return ret.safeCast(uint);
   }
 
-  proc bigint.hamdist(b: bigint) : uint {
+  proc bigint.hamdist(const ref b: bigint) : uint {
     var ret: c_ulong;
 
     if _local {
@@ -2975,7 +2975,7 @@ module BigInteger {
   // Unary arithmetic functions
   //
 
-  proc bigint.neg(a: bigint) {
+  proc bigint.neg(const ref a: bigint) {
     if _local {
       mpz_neg(this.mpz, a.mpz);
 
@@ -2994,7 +2994,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.abs(a: bigint) {
+  proc bigint.abs(const ref a: bigint) {
     if _local {
       mpz_abs(this.mpz, a.mpz);
 
@@ -3018,7 +3018,7 @@ module BigInteger {
   //
 
   // Addition
-  proc bigint.add(a: bigint, b: bigint) {
+  proc bigint.add(const ref a: bigint, const ref b: bigint) {
     if _local {
       mpz_add(this.mpz, a.mpz, b.mpz);
 
@@ -3039,7 +3039,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.add(a: bigint, b: uint) {
+  proc bigint.add(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -3063,7 +3063,7 @@ module BigInteger {
 
 
   // Subtraction
-  proc bigint.sub(a: bigint, b: bigint) {
+  proc bigint.sub(const ref a: bigint, const ref b: bigint) {
     if _local {
       mpz_sub(this.mpz, a.mpz, b.mpz);
 
@@ -3084,7 +3084,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.sub(a: bigint, b: uint) {
+  proc bigint.sub(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -3105,7 +3105,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.sub(a: uint, b: bigint) {
+  proc bigint.sub(a: uint, const ref b: bigint) {
     const a_ = a.safeCast(c_ulong);
 
     if _local {
@@ -3129,7 +3129,7 @@ module BigInteger {
 
 
   // Multiplication
-  proc bigint.mul(a: bigint, b: bigint) {
+  proc bigint.mul(const ref a: bigint, const ref b: bigint) {
     if _local {
       mpz_mul(this.mpz, a.mpz, b.mpz);
 
@@ -3150,7 +3150,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.mul(a: bigint, b: int) {
+  proc bigint.mul(const ref a: bigint, b: int) {
     const b_ = b.safeCast(c_long);
 
     if _local {
@@ -3171,7 +3171,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.mul(a: bigint, b: uint) {
+  proc bigint.mul(const ref a: bigint, b: uint) {
     const b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -3192,7 +3192,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.mul_2exp(a: bigint, b: uint) {
+  proc bigint.mul_2exp(const ref a: bigint, b: uint) {
     var b_ = b.safeCast(c_ulong);
 
     if _local {
@@ -3215,8 +3215,8 @@ module BigInteger {
 
   // Division
   proc bigint.div_q(param rounding: Round,
-                    n: bigint,
-                    d: bigint) {
+                    const ref n: bigint,
+                    const ref d: bigint) {
     if _local {
       select rounding {
         when Round.UP   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
@@ -3250,7 +3250,7 @@ module BigInteger {
   }
 
   proc bigint.div_q(param rounding: Round,
-                    n: bigint,
+                    const ref n: bigint,
                     d: uint) : uint {
     const d_ = d.safeCast(c_ulong);
     var   ret: c_ulong;
@@ -3288,8 +3288,8 @@ module BigInteger {
   }
 
   proc bigint.div_r(param rounding: Round,
-                    n: bigint,
-                    d: bigint) {
+                    const ref n: bigint,
+                    const ref d: bigint) {
     if _local {
       select rounding {
         when Round.UP   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
@@ -3323,7 +3323,7 @@ module BigInteger {
   }
 
   proc bigint.div_r(param rounding: Round,
-                    n: bigint,
+                    const ref n: bigint,
                     d: uint) : uint {
     const d_ = d.safeCast(c_ulong);
     var   ret: c_ulong;
@@ -3365,8 +3365,8 @@ module BigInteger {
   // this gets quotient, r gets remainder
   proc bigint.div_qr(param rounding: Round,
                      ref r: bigint,
-                     n: bigint,
-                     d: bigint) {
+                     const ref n: bigint,
+                     const ref d: bigint) {
     if _local {
       select rounding {
         when Round.UP   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
@@ -3406,7 +3406,7 @@ module BigInteger {
   // this gets quotient, r gets remainder
   proc bigint.div_qr(param rounding: Round,
                      ref r: bigint,
-                     n: bigint,
+                     const ref n: bigint,
                      d: uint) : uint {
     const d_ = d.safeCast(c_ulong);
     var   ret: c_ulong;
@@ -3453,7 +3453,7 @@ module BigInteger {
   }
 
   proc bigint.div_q_2exp(param rounding: Round,
-                         n: bigint,
+                         const ref n: bigint,
                          b: uint) {
     const b_ = b.safeCast(c_ulong);
 
@@ -3488,7 +3488,7 @@ module BigInteger {
   }
 
   proc bigint.div_r_2exp(param rounding: Round,
-                         n: bigint,
+                         const ref n: bigint,
                          b: uint) {
     const b_ = b.safeCast(c_ulong);
 
@@ -3524,8 +3524,8 @@ module BigInteger {
 
 
 
-  proc bigint.addmul(a: bigint,
-                     b: bigint) {
+  proc bigint.addmul(const ref a: bigint,
+                     const ref b: bigint) {
     if _local {
       mpz_addmul(this.mpz, a.mpz, b.mpz);
 
@@ -3546,7 +3546,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.addmul(a: bigint,
+  proc bigint.addmul(const ref a: bigint,
                      b: uint) {
     const b_ = b.safeCast(c_ulong);
 
@@ -3570,8 +3570,8 @@ module BigInteger {
 
 
 
-  proc bigint.submul(a: bigint,
-                     b: bigint) {
+  proc bigint.submul(const ref a: bigint,
+                     const ref b: bigint) {
     if _local {
       mpz_submul(this.mpz, a.mpz, b.mpz);
 
@@ -3592,7 +3592,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.submul(a: bigint,
+  proc bigint.submul(const ref a: bigint,
                      b: uint) {
     const b_ = b.safeCast(c_ulong);
 
@@ -3616,8 +3616,8 @@ module BigInteger {
 
 
 
-  proc bigint.mod(a: bigint,
-                  b: bigint) {
+  proc bigint.mod(const ref a: bigint,
+                  const ref b: bigint) {
     if _local {
       mpz_mod(this.mpz, a.mpz, b.mpz);
 
@@ -3638,7 +3638,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.mod(a: bigint,
+  proc bigint.mod(const ref a: bigint,
                   b: uint) : uint {
     const b_ = b.safeCast(c_ulong);
     var   ret: c_ulong;
@@ -3666,7 +3666,7 @@ module BigInteger {
 
 
   // Comparison Functions
-  proc bigint.cmp(b: bigint) : int {
+  proc bigint.cmp(const ref b: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -3754,7 +3754,7 @@ module BigInteger {
 
 
 
-  proc bigint.cmpabs(b: bigint) : int {
+  proc bigint.cmpabs(const ref b: bigint) : int {
     var ret: c_int;
 
     if _local {
@@ -3847,7 +3847,7 @@ module BigInteger {
 
 
   // Logical and Bit Manipulation Functions
-  proc bigint.and(a: bigint, b: bigint) {
+  proc bigint.and(const ref a: bigint, const ref b: bigint) {
     if _local {
       mpz_and(this.mpz, a.mpz, b.mpz);
 
@@ -3868,7 +3868,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.ior(a: bigint, b: bigint) {
+  proc bigint.ior(const ref a: bigint, const ref b: bigint) {
     if _local {
       mpz_ior(this.mpz, a.mpz, b.mpz);
 
@@ -3889,7 +3889,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.xor(a: bigint, b: bigint) {
+  proc bigint.xor(const ref a: bigint, const ref b: bigint) {
     if _local {
       mpz_xor(this.mpz, a.mpz, b.mpz);
 
@@ -3910,7 +3910,7 @@ module BigInteger {
     }
   }
 
-  proc bigint.com(a: bigint) {
+  proc bigint.com(const ref a: bigint) {
     if _local {
       mpz_com(this.mpz, a.mpz);
 
@@ -3932,7 +3932,7 @@ module BigInteger {
 
 
   // Assignment functions
-  proc bigint.set(a: bigint) {
+  proc bigint.set(const ref a: bigint) {
     if _local {
       mpz_set(this.mpz, a.mpz);
 

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -196,21 +196,18 @@ module GMP {
   pragma "no doc"
   extern type __mpz_struct;
 
-  /*  The GMP ``mpf_t`` type */
-  extern type mpf_t           = 1 * __mpf_struct;
-
-
-
+  /* The GMP ``mpz_t`` type */
+  extern type mpz_t           = 1 * __mpz_struct;
 
   pragma "no doc"
   extern type __mpf_struct;
 
+  /*  The GMP ``mpf_t`` type */
+  extern type mpf_t           = 1 * __mpf_struct;
+
   pragma "no doc"
   extern type __gmp_randstate_struct;
 
-
-  /* The GMP ``mpz_t`` type */
-  extern type mpz_t           = 1 * __mpz_struct;
 
   /* The GMP ``gmp_randstate_t`` type */
   extern type gmp_randstate_t = 1 * __gmp_randstate_struct;
@@ -226,7 +223,7 @@ module GMP {
      and the natural way to wrap that in Chapel is with a 1-element
      tuple. These tuples would be passed by value to the extern
      routines if not for ref.
-   */
+  */
 
 
 
@@ -259,7 +256,7 @@ module GMP {
   // 5.2 Assignment Functions
   //
 
-  extern proc mpz_set(ref rop: mpz_t, const op: mpz_t);
+  extern proc mpz_set(ref rop: mpz_t, const ref op: mpz_t);
 
   extern proc mpz_set_ui(ref rop: mpz_t, op: c_ulong);
 
@@ -1125,10 +1122,10 @@ module GMP {
   private extern proc chpl_gmp_mpz_nlimbs(from: __mpz_struct) : uint(64);
 
   /* Print out an mpz_t (for debugging) */
-  extern proc chpl_gmp_mpz_print(x: mpz_t);
+  extern proc chpl_gmp_mpz_print(const ref x: mpz_t);
 
   /* Get an mpz_t as a string */
-  extern proc chpl_gmp_mpz_get_str(base: c_int, x: mpz_t) : c_string_copy;
+  extern proc chpl_gmp_mpz_get_str(base: c_int, const ref x: mpz_t) : c_string_copy;
 
 
   enum Round {

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -2571,8 +2571,8 @@ module GMP {
       gmp_randinit_mt(this.state);
     }
 
-    proc GMPRandom(a: Bigint, c: uint, m2exp: uint) {
-      // Rely on Bigint assignment operator to obtain a local copy
+    proc GMPRandom(a: bigint, c: uint, m2exp: uint) {
+      // Rely on bigint assignment operator to obtain a local copy
       var a_ = a;
 
       gmp_randinit_lc_2exp(this.state,
@@ -2599,9 +2599,9 @@ module GMP {
       }
     }
 
-    proc seed(seed: Bigint) {
+    proc seed(seed: bigint) {
       on this {
-        // Rely on Bigint assignment operator to obtain a local copy
+        // Rely on bigint assignment operator to obtain a local copy
         var s_ = seed;
 
         gmp_randseed(this.state, s_.mpz);
@@ -2657,9 +2657,9 @@ module GMP {
       return val.safeCast(uint);
     }
 
-    proc urandomb(ref r: Bigint, nbits: uint) {
+    proc urandomb(ref r: bigint, nbits: uint) {
       on this {
-        // Rely on Bigint assignment operator to obtain a local copy
+        // Rely on bigint assignment operator to obtain a local copy
         var r_ = r;
 
         mpz_urandomb(r_.mpz, this.state, nbits.safeCast(c_ulong));
@@ -2668,9 +2668,9 @@ module GMP {
       }
     }
 
-    proc urandomm(ref r: Bigint, n: Bigint) {
+    proc urandomm(ref r: bigint, n: bigint) {
       on this {
-        // Rely on Bigint assignment operator to obtain a local copy
+        // Rely on bigint assignment operator to obtain a local copy
         var r_ = r;
         var n_ = n;
 
@@ -2680,9 +2680,9 @@ module GMP {
       }
     }
 
-    proc rrandomb(ref r: Bigint, nbits: uint) {
+    proc rrandomb(ref r: bigint, nbits: uint) {
       on this {
-        // Rely on Bigint assignment operator to obtain a local copy
+        // Rely on bigint assignment operator to obtain a local copy
         var r_ = r;
 
         mpz_rrandomb(r_.mpz, this.state, nbits.safeCast(c_ulong));

--- a/runtime/src/chplgmp.c
+++ b/runtime/src/chplgmp.c
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,9 +36,11 @@
 static void* chpl_gmp_alloc(size_t sz) {
   return chpl_mem_alloc(sz, CHPL_RT_MD_GMP, 0, 0);
 }
+
 static void* chpl_gmp_realloc(void* ptr, size_t old_size, size_t new_size) {
   return chpl_mem_realloc( ptr, new_size, CHPL_RT_MD_GMP, 0, 0);
 }
+
 static void chpl_gmp_free(void* ptr, size_t old_size) {
   chpl_mem_free( ptr, 0, 0);
 }
@@ -47,52 +49,55 @@ void chpl_gmp_init(void) {
   mp_set_memory_functions(chpl_gmp_alloc, chpl_gmp_realloc, chpl_gmp_free);
 }
 
-void chpl_gmp_get_mpz(mpz_t ret, int64_t src_locale, __mpz_struct from)
-{
+void chpl_gmp_get_mpz(mpz_t ret, int64_t src_locale, __mpz_struct from) {
   // First, resize our destination appropriately.
   mpz_realloc2(ret, from._mp_alloc * mp_bits_per_limb);
 
   // Copy the _alloc and _size fields.
   ret[0]._mp_alloc = from._mp_alloc;
-  ret[0]._mp_size = from._mp_size;
+  ret[0]._mp_size  = from._mp_size;
 
   // Next, use GASNET to move the pointer data.
-  chpl_gen_comm_get(ret[0]._mp_d, src_locale, from._mp_d,
-                    sizeof(mp_limb_t) * ret[0]._mp_alloc, CHPL_TYPE_uint64_t,
-                    0, 0);
-
-  //gmp_printf("got %Zd\n", ret);
+  chpl_gen_comm_get(ret[0]._mp_d,
+                    src_locale,
+                    from._mp_d,
+                    sizeof(mp_limb_t) * ret[0]._mp_alloc,
+                    CHPL_TYPE_uint64_t,
+                    0,
+                    0);
 }
 
-void chpl_gmp_get_randstate(gmp_randstate_t not_inited_state, int64_t src_locale, __gmp_randstate_struct from)
-{
+void chpl_gmp_get_randstate(gmp_randstate_t        not_inited_state,
+                            int64_t                src_locale,
+                            __gmp_randstate_struct from) {
   // Copy the rand state..
   not_inited_state[0] = from;
+
   // Clear the seed since it's going to be a local mpz.
   memset(& not_inited_state[0]._mp_seed, 0, sizeof(mpz_t));
   mpz_init(not_inited_state[0]._mp_seed);
+
   chpl_gmp_get_mpz(not_inited_state[0]._mp_seed, src_locale, from._mp_seed[0]);
 }
 
-
-uint64_t chpl_gmp_mpz_nlimbs(__mpz_struct from)
-{
+uint64_t chpl_gmp_mpz_nlimbs(__mpz_struct from) {
   return __GMP_ABS ( from._mp_size );
 }
 
-void chpl_gmp_mpz_print(mpz_t x)
-{
+void chpl_gmp_mpz_print(mpz_t x) {
   printf("&x=%p\n", x);
   printf("x->_mp_d=%p\n", x[0]._mp_d);
   gmp_printf("x=%Zd\n", x);
 }
 
-
-c_string_copy chpl_gmp_mpz_get_str(int base, mpz_t x)
-{
-  size_t len = mpz_sizeinbase(x, base);
-
-  char* str = (char*)chpl_mem_calloc(1, len+1, CHPL_RT_MD_GLOM_STRINGS_DATA, 0, 0);
+c_string_copy chpl_gmp_mpz_get_str(int base, mpz_t x) {
+  // The number of *digits* in abs(x);
+  size_t numDigits = mpz_sizeinbase(x, base);
+  char*  str       = (char*) chpl_mem_calloc(1,
+                                             numDigits + 2,
+                                             CHPL_RT_MD_GLOM_STRINGS_DATA,
+                                             0,
+                                             0);
 
   mpz_get_str(str, base, x);
 

--- a/test/modules/standard/gmp/congruence.chpl
+++ b/test/modules/standard/gmp/congruence.chpl
@@ -1,15 +1,15 @@
 use BigInteger;
 
-var tensandthrees = new Bigint("81000000000000000000000000000000000000000000");
+var tensandthrees = new bigint("81000000000000000000000000000000000000000000");
 
 writeln();
 writeln(tensandthrees, " _p:");
 
 for m in 1 .. 10 {
-  var mb = new Bigint(m);
+  var mb = new bigint(m);
 
   for c in 0..9 {
-    var cb = new Bigint(c);
+    var cb = new bigint(c);
 
     write(TF(tensandthrees.congruent_p(cb, mb)));
   }
@@ -31,7 +31,7 @@ writeln(tensandthrees, "_2exp_p:");
 
 for b in 1 .. 10 : uint {
   for c in 0 .. 9 {
-    var cb = new Bigint(c);
+    var cb = new bigint(c);
 
     write(TF(tensandthrees.congruent_2exp_p(cb, b)));
   }

--- a/test/modules/standard/gmp/ferguson/big_modui.chpl
+++ b/test/modules/standard/gmp/ferguson/big_modui.chpl
@@ -1,7 +1,7 @@
 use BigInteger;
 
-var x = new Bigint(20);
-var y = new Bigint(0);
+var x = new bigint(20);
+var y = new bigint(0);
 
 y.mod(x, 11);
 

--- a/test/modules/standard/gmp/ferguson/gmp_dist_array.chpl
+++ b/test/modules/standard/gmp/ferguson/gmp_dist_array.chpl
@@ -5,21 +5,21 @@ config const n     = 20;
 const        Space = { 1 .. n };
 const        D     = Space dmapped Block(boundingBox = Space);
 
-var A: [D] Bigint;
-var B: [D] Bigint;
-var C: [D] Bigint;
+var A: [D] bigint;
+var B: [D] bigint;
+var C: [D] bigint;
 
 // Fill the arrays with something easy.
 forall (x,i) in zip(A,D) {
-  x = new Bigint(i);
+  x = new bigint(i);
 }
 
 forall (x,i) in zip(B,D) {
-  x = new Bigint(i);
+  x = new bigint(i);
 }
 
 forall (x,i) in zip(C,D) {
-  x = new Bigint(i);
+  x = new bigint(i);
   x.fac((10000 * i) : uint(32));
 }
 
@@ -28,7 +28,7 @@ forall (a,b,c) in zip(A,B,C) {
   c.add(c,b);
 }
 
-var sum = new Bigint(0);
+var sum = new bigint(0);
 
 for c in C {
   writeln(c.sizeinbase(10));
@@ -38,7 +38,7 @@ for c in C {
 
 writeln(sum.sizeinbase(10));
 
-var modulus = new Bigint("10000000000000000000000000000000000000000");
+var modulus = new bigint("10000000000000000000000000000000000000000");
 
 modulus.nextprime(modulus);
 

--- a/test/modules/standard/gmp/ferguson/gmp_random.chpl
+++ b/test/modules/standard/gmp/ferguson/gmp_random.chpl
@@ -3,8 +3,8 @@ use GMP;
 config const printrandom = false;
 
 var r = new GMPRandom();
-var b = new Bigint();
-var n = new Bigint(10);
+var b = new bigint();
+var n = new bigint(10);
 var x:uint = 0;
 
 if printrandom then writeln(x);

--- a/test/modules/standard/gmp/ferguson/gmp_test.chpl
+++ b/test/modules/standard/gmp/ferguson/gmp_test.chpl
@@ -1,22 +1,22 @@
 use BigInteger;
 
-var a = new Bigint();
+var a = new bigint();
 
 a.fac(100);
 
 writeln(a);
 
-var x = new Bigint("1838348473822929893829847293847289764918276498172649817264982619487612984761928476189274698126489127649");
+var x = new bigint("1838348473822929893829847293847289764918276498172649817264982619487612984761928476189274698126489127649");
 
 writeln(x);
 
-var b = new Bigint(a);
+var b = new bigint(a);
 
 b.add(b, 1);
 
 on Locales[numLocales - 1] {
-  var c = new Bigint(a);
-  var d = new Bigint();
+  var c = new bigint(a);
+  var d = new bigint();
 
   d.add(c, b);
 

--- a/test/modules/standard/gmp/ferguson/gmp_writeln.chpl
+++ b/test/modules/standard/gmp/ferguson/gmp_writeln.chpl
@@ -1,5 +1,5 @@
 use BigInteger;
 
-var a = new Bigint(1);
+var a = new bigint(1);
 
 writeln(a);

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_arithmetic.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_arithmetic.chpl
@@ -1,8 +1,8 @@
 use BigInteger;
 
-var a = new Bigint(  0);
-var b = new Bigint(  2);
-var c = new Bigint(100);
+var a = new bigint(  0);
+var b = new bigint(  2);
+var c = new bigint(100);
 
 a.add(a, b);                         // a =     2
 a.add(a, 1000);                      // a =  1002

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_assignment.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_assignment.chpl
@@ -1,9 +1,8 @@
 use BigInteger;
 
 // tests the assignment functions
-
-var a = new Bigint(0);    // a = 0
-var b = new Bigint(2);      // b = 2
+var a = new bigint(0);    // a = 0
+var b = new bigint(2);    // b = 2
 
 writeln(a, " ", b);
 a.set(b);

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_comparison.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_comparison.chpl
@@ -2,8 +2,8 @@ use BigInteger;
 
 // Tests the comparison operators
 
-var a = new Bigint( 5);
-var b = new Bigint(-6);
+var a = new bigint( 5);
+var b = new bigint(-6);
 
 var val = a.cmp(b);
 writeln(a, " ", cmp_parse(val), " ", b);

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_division.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_division.chpl
@@ -1,10 +1,10 @@
 use BigInteger;
 
 // Tests the division functions
-var a = new Bigint(  8);
-var b = new Bigint( 10);
-var c = new Bigint(-27);
-var d = new Bigint();
+var a = new bigint(  8);
+var b = new bigint( 10);
+var c = new bigint(-27);
+var d = new bigint();
 
 d.div_q(Round.UP, c, a);
 b.div_r(Round.UP, c, a);

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_logic_bit.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_logic_bit.chpl
@@ -2,8 +2,8 @@ use BigInteger;
 
 // Tests the logical and bit manipulation functions
 
-var a = new Bigint( 8);
-var b = new Bigint(40);
+var a = new bigint( 8);
+var b = new bigint(40);
 
 a.and(a, b); // 8 & 40 = 8
 writeln(a);

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_misc.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_misc.chpl
@@ -1,8 +1,8 @@
 use BigInteger;
 
 // Tests the miscellaneous functions
-var a = new Bigint(-65536);
-var b = new Bigint(129);
+var a = new bigint(-65536);
+var b = new bigint(129);
 
 writeln(a, parse_fit(a.fits_ulong_p()), " in an unsigned long integer");
 writeln(b, parse_fit(b.fits_ulong_p()), " in an unsigned long integer");

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_multilocale.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_multilocale.chpl
@@ -1,10 +1,10 @@
 use BigInteger;
 
-var v1 = new Bigint(5);
+var v1 = new bigint(5);
 
 for l in Locales{
 	on l {
-		var v2 = new Bigint(10);
+		var v2 = new bigint(10);
 
 		v1 *= v2;
 		v1 +=  3;

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_number_theoretic.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_number_theoretic.chpl
@@ -3,11 +3,11 @@ use BigInteger;
 // Tests all of the number theoretic functions contained in the record
 // the jacobi and legendre functions will be tested elsewhere
 
-var a   = new Bigint(27);
-var b   = new Bigint(19);
-var c   = new Bigint("1302397");
-var d   = new Bigint(5);
-var e   = new Bigint(375);
+var a   = new bigint(27);
+var b   = new bigint(19);
+var c   = new bigint("1302397");
+var d   = new bigint(5);
+var e   = new bigint(375);
 
 
 

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_operators.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_operators.chpl
@@ -2,9 +2,9 @@ use BigInteger;
 
 // Tests the operator overloads
 
-var a            = new Bigint(25);
-var b            = new Bigint( 0);
-var c            = new Bigint( 5);
+var a            = new bigint(25);
+var b            = new bigint( 0);
+var c            = new bigint( 5);
 
 var ua : uint    =  12;
 var sa : int     = -13;

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_powers_roots.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_powers_roots.chpl
@@ -3,10 +3,10 @@ use BigInteger;
 // Tests the power and root functions
 
 // powers
-var a = new Bigint( 2);
-var b = new Bigint( 4);
-var c = new Bigint(10);
-var d = new Bigint();
+var a = new bigint( 2);
+var b = new bigint( 4);
+var c = new bigint(10);
+var d = new bigint();
 
 a.powm(a, b, c);          // a = a^b mod c
 writeln("2^4 mod 10 = ", a);

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_record_constructors.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_record_constructors.chpl
@@ -1,11 +1,11 @@
 use BigInteger;
 
 proc main(){
-  var x1          = new Bigint();
-  var x3          = new Bigint(100);
-  var x4          = new Bigint("1100101", 2);
-  var x5          = new Bigint(x4);
-  var x6 : Bigint = x5;
+  var x1          = new bigint();
+  var x3          = new bigint(100);
+  var x4          = new bigint("1100101", 2);
+  var x5          = new bigint(x4);
+  var x6 : bigint = x5;
   var x7          = x3;
 
   x1.writeThis(stdout);

--- a/test/modules/standard/gmp/ldelaney/gmp_random_2.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_random_2.chpl
@@ -3,8 +3,8 @@ use GMP;
 
 config const printrandom = false;
 
-var a  = new Bigint( 10);
-var b  = new Bigint(128);
+var a  = new bigint( 10);
+var b  = new bigint(128);
 
 var r1 = new GMPRandom();
 var r2 = new GMPRandom(true);

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
@@ -29,13 +29,13 @@ proc main() {
 }
 
 iter genDigits(numDigits) {
-  var numer = new Bigint(1);
-  var denom = new Bigint(1);
+  var numer = new bigint(1);
+  var denom = new bigint(1);
 
-  var accum = new Bigint(0);
+  var accum = new bigint(0);
 
-  var tmp1  = new Bigint();
-  var tmp2  = new Bigint();
+  var tmp1  = new bigint();
+  var tmp2  = new bigint();
 
   var k: uint(64);
 

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
@@ -32,13 +32,13 @@ proc main() {
 }
 
 iter genDigits(numDigits) {
-  var numer = new Bigint(1);
-  var denom = new Bigint(1);
+  var numer = new bigint(1);
+  var denom = new bigint(1);
 
-  var accum = new Bigint(0);
+  var accum = new bigint(0);
 
-  var tmp1  = new Bigint();
-  var tmp2  = new Bigint();
+  var tmp1  = new bigint();
+  var tmp2  = new bigint();
 
   var digit: uint(64);
   var k:     uint(64);


### PR DESCRIPTION
1) There were a handful of valgrind errors that had two root causes

a) a long standing error in the runtime interface for GMP that was exposed by Laura's new
tests.  We were allocating a string buffer based on the results of mpz_sizeinbase().  That
function returns the number of *digits* that will be shown if a bigint is printed.  However it
does not reflect the sign if any.  Added 1 to allow for a negative sign.

b) Added "const ref" to formals of type bigint.  Relying on the blank-intent caused bad C code
and valgrind was catching this.  I am "surprised" that the current tests weren't sufficient to see
this but I had had some indications of this earlier in recent development cycle for bigint.

2) BigInteger.chpl incorrectly redefined the enum Round that is defined in GMP.chpl.  Dropped.

3) Converted "Bigint" to "bigint".



The valgrind fixes were trivial in scope but the second fix touched a lot of lines.  Checked it by
eye a couple of times.

The other changes are also "trivial".


Tested on clang/darwin and gcc/linux64.  Tested with std, gasnet, and valgrind.
