### PR TITLE
One-init binary trees versions

### DIFF
--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -50,17 +50,7 @@ implementations that would benefit the codes:
 
 binarytrees
 -----------
-o it'd be nice if Chapel provided a means to retain the default /
-  compiler-provided initializer even when the user specifies one.  In
-  this case, it essentially needs to be rewritten by the user
-  unnecessarily.
-
-o should we change 'nil' be of type 'Object' rather than 'nilType'?
-  This would permit the type declarations on the left/right arguments
-  to be left off.  Brad recalls a very distinct decision to have 'nil'
-  be its own type in the early years of Chapel but can't recall the
-  rationale or whether it still holds in today's Chapel.
-
+o no current TODOs
 
 chameneosredux
 --------------

--- a/test/release/examples/benchmarks/shootout/binarytrees.chpl
+++ b/test/release/examples/benchmarks/shootout/binarytrees.chpl
@@ -71,19 +71,14 @@ class Tree {
   const left, right: Tree;
 
   //
-  // Two initializers (constructors) for a Tree object
+  // A Tree-building initializer
   //
-  proc init(item, left: Tree=nil, right: Tree=nil) {
-    this.item = item;
-    this.left = left;
-    this.right = right;
-  }
-  
   proc init(item, depth) {
-    if depth <= 0 then
-      init(item);
-    else
-      init(item, new Tree(2*item-1, depth-1), new Tree(2*item, depth-1));
+    this.item = item;
+    if depth > 1 {
+      left = new Tree(2*item-1, depth-1);
+      right = new Tree(2*item, depth-1);
+    }
   }
 
   //

--- a/test/studies/shootout/binary-trees/binarytrees-blc.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-blc.chpl
@@ -73,18 +73,14 @@ class Tree {
   //
   // Two initializers (constructors) for a Tree object
   //
-  proc init(item, left: Tree=nil, right: Tree=nil) {
-    this.item = item;
-    this.left = left;
-    this.right = right;
-    super.init();
-  }
-  
   proc init(item, depth) {
-    if depth <= 0 then
-      init(item);
-    else
-      init(item, new Tree(2*item-1, depth-1), new Tree(2*item, depth-1));
+    this.item = item;
+    super.init();
+    if depth > 1 {
+      left = new Tree(2*item-1, depth-1);
+      right = new Tree(2*item, depth-1);
+    }
+    // TODO: want this here    super.init();
   }
 
   //


### PR DESCRIPTION
[viewed by @lydia-duncan ]

Last night while thinking about my annoyance at having to write the default compiler-provided initializer by hand, I realized that in this case, there's no need for it.  Rather than calling the default initializer, we can just assign the fields in the custom initializer that we've provided.  I feel stupid to not have thought of this before -- I think I was still being led too much by the old two-routine factory-based approach.
