### PR TITLE
Fix retArg handling in insertWideReferences

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -2121,7 +2121,8 @@ static void fixAST() {
     if (call->isResolved()) {
       for_formals_actuals(formal, actual, call) {
         if (formal->hasFlag(FLAG_RETARG)) {
-          if (formal->typeInfo() != actual->typeInfo() && hasSomeWideness(formal)) {
+          if (formal->typeInfo() != actual->typeInfo() && hasSomeWideness(formal) &&
+              !(formal->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) || actual->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF))) {
             SET_LINENO(call);
 
             SymExpr* act = toSymExpr(actual);
@@ -2180,6 +2181,10 @@ static void fixAST() {
             call->insertAfter(new CallExpr(PRIM_MOVE, dest->copy(), new SymExpr(destTemp)));
             parent->remove();
             act->var->defPoint->remove();
+          } else {
+            SymExpr* act = toSymExpr(actual);
+            INT_ASSERT(act);
+            makeMatch(formal, act);
           }
         }
         else if (SymExpr* act = toSymExpr(actual)) {

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -2121,6 +2121,8 @@ static void fixAST() {
     if (call->isResolved()) {
       for_formals_actuals(formal, actual, call) {
         if (formal->hasFlag(FLAG_RETARG)) {
+          // Only looking for a mismatch where the formal is a _ref_wide_T
+          // and the actual is a _ref_T
           if (formal->typeInfo() != actual->typeInfo() && hasSomeWideness(formal) &&
               !(formal->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) || actual->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF))) {
             SET_LINENO(call);


### PR DESCRIPTION
PR #4572 exposed a case with retArgs that insertWideReferences didn't know how to handle. The solution here is to avoid that case and drop into the general handling of mismatched actuals and formals.