### PR TITLE
Fix chpldoc output for dmapped variables

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -875,6 +875,13 @@ void AstToText::appendExpr(CallExpr* expr, bool printingType)
         appendExpr(expr->get(1), printingType);
       }
 
+      else if (strcmp(fnName, "chpl__distributed")             == 0)
+      {
+        appendExpr(expr->get(2), printingType);
+        mText += " dmapped ";
+        appendExpr(expr->get(1), printingType);
+      }
+
       else if (strcmp(fnName, "chpl__buildDomainExpr")        == 0)
       {
         mText += "{";
@@ -1182,6 +1189,11 @@ void AstToText::appendExpr(CallExpr* expr, bool printingType)
     {
       appendExpr(expr->get(1), printingType);
       mText += ".type ";
+    }
+    else if (expr->isPrimitive(PRIM_NEW))
+    {
+      mText += "new ";
+      appendExpr(expr->get(1), printingType);
     }
     else
     {

--- a/test/chpldoc/globals/dmappedArr.doc.catfiles
+++ b/test/chpldoc/globals/dmappedArr.doc.catfiles
@@ -1,0 +1,1 @@
+docs/dmappedArr.doc.txt

--- a/test/chpldoc/globals/dmappedArr.doc.chpl
+++ b/test/chpldoc/globals/dmappedArr.doc.chpl
@@ -1,0 +1,7 @@
+use BlockDist;
+
+var domBase = {1..10};
+var domMap = new Block(domBase);
+
+var dom1 = domBase dmapped new dmap(domMap);
+var dom2: domain(1) dmapped new dmap(domMap);

--- a/test/chpldoc/globals/dmappedArr.doc.good
+++ b/test/chpldoc/globals/dmappedArr.doc.good
@@ -1,0 +1,9 @@
+dmappedArr.doc
+
+Usage:
+   use dmappedArr.doc;
+
+   var domBase = {1..10}
+   var domMap = new Block(domBase)
+   var dom1 = domBase dmapped new dmap(domMap)
+   var dom2: domain(1) dmapped new dmap(domMap)


### PR DESCRIPTION
UtilReplicatedVar was experiencing output of the form:

``const rcDomain = AppendExpr.Call09chpl__distributedrcDomainBase``

for a declaration like this:

``const rcDomain = rcDomainBase dmapped new dmap(rcDomainMap);``

Turns out there were a couple of issues.  One was the new call, the other
was a failure to recognize chpl__distributed.  Added a new branch to the
if/else statement in AstToText for each of these cases.

Added a test of the problem.

Verified that the standard module UtilReplicatedVar has the correct output
now.  Testing over std/