### PR TITLE
Add recent perf annotations:

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -169,6 +169,13 @@ all:
     - enable native qthreads sync vars (#4506)
   09/15/16:
     - use atomic spin-lock instead of sync for reductions (#4532)
+  09/16/16:
+    - Turn denormalization off by default (#4545)
+  09/18/16:
+    - Added optimization to remove inner multiply in dsiAccess (#4510)
+  09/20/16:
+    - Add promoted fast follower support (#4558)
+
 
 AllCompTime:
   11/09/14:
@@ -217,15 +224,15 @@ binary-trees:
   06/13/16:
     - polish to binary-trees versions (#4017)
   09/21/16:
-    - switch from type method factory to init()-based implementation
+    - switch from type method factory to init()-based implementation (#4598)
   09/22/16:
-    - simplify init()-based implementation
+    - simplify init()-based implementation (#4609)
 
 binarytrees-submitted:
   09/21/16:
-    - switch from type method factory to init()-based implementation
+    - switch from type method factory to init()-based implementation (#4598)
   09/22/16:
-    - simplify init()-based implementation
+    - simplify init()-based implementation (#4609)
 
 chameneos-redux:
   07/08/13:
@@ -236,6 +243,12 @@ compSampler-timecomp:
     - disable function resolution optimization (#4476)
   09/14/16:
     - re-enable function resolution optimization (#4517)
+
+cg:
+  09/20/16:
+    - Strided Array Support in Sort/Search Modules (#4569)
+  09/22/16:
+    - Added overloaded compileErrors for Sort/Search (#4621)
 
 cg-sparse-timecomp:
   09/09/16:


### PR DESCRIPTION
- Added optimization to remove inner multiply in dsiAccess (#4510):
  - improved several shootouts ([fasta, meteor, nbody, fannkuck](http://chapel.sourceforge.net/perf/shootout/?startdate=2016/09/10&enddate=2016/09/21&graphs=fastashootoutbenchmarkn25000000,meteorshootoutbenchmarkn2098,nbodyvariations,fannkuchreduxn12
))
  - improved many [array-heavy single-locale benchmarks](     http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/14&enddate=2016/09/23&graphs=hpccratime,fastashootoutbenchmarkn25000000,reversecomplementshootoutbenchmark,binarytreesshootoutbenchmarkn16,synchp2p,prkstencil,scalarmultiplication2darrayexecutiontime,arrayvstupleserialaccesses,arrayvsddataserialaccesses,serialarrayaccessvsreferenceaccess,arrayaccessvsreferenceaccessinforallloop,1darrayparalleliteration,promotedoptimelocal,elegancetuplesvsarrays)
  - maintained perf of [tests that were throwing -sassertNoSlicing before](http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/14&enddate=2016/09/23&graphs=lcalsrawlong,lcalsrawomplong,performanceofvariousjacobi1dimplementations,performanceofvariousjacobi2dimplementations,performanceofvariouscfdminiimplementations)
  - improved [miniMD and ptrans for 16-node](http://chapel.sourceforge.net/perf/16-node-xc/?startdate=2016/09/10&enddate=2016/09/21&graphs=hpccptransperfgbsecn2000nb100,doeminimdtimesecsize20)
  - made [ra-atomics and c vs. chpl serial access](http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/11&enddate=2016/09/22&graphs=hpccratime,cvschplserialaccesses) worse in chapcs
    - just an artifact of bad cache layout or something. We're now
      producing optimal 1-D array access (gen code is same as C). Also note
      that these tests we not impacted negatively for any other config.

<p>

- Add promoted fast follower support (#4558)
  - promoted stream perf now matches global for [single](http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/02&enddate=2016/09/21&graphs=globalstreamgbs) and [multi-locale](http://chapel.sourceforge.net/perf/16-node-xc/?startdate=2016/09/09&enddate=2016/09/23&configs=gnugasnetmpi&graphs=hpccpromotedstreamperfgbsn5723827200):

<p>

- Strided Array Support in Sort/Search Modules (#4569)
- Added overloaded compileErrors for Sort/Search (#4621)
  - Significantly hurt, and subsequently restored [cg-sparse performance] (http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/09/15&enddate=2016/09/23&graphs=nasparallelbenchmarkscgtimingssizes,nasparallelbenchmarkscgtimingssizew,nasparallelbenchmarkscgtimingssizea)

<p> 

- switch from type method factory to init()-based implementation (#4598)
- simplify init()-based implementation (#4609)
  - significantly improved [binary trees] ( http://chapel.sourceforge.net/perf/shootout/?startdate=2016/08/22&enddate=2016/09/24&graphs=binarytreesshootoutbenchmarkn20,submittedbinarytreesshootoutbenchmarkn20) perf:
     