### PR TITLE
Turn off parallel build for docs

### DIFF
--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -6,9 +6,6 @@ include Makefile.sphinx
 CHPL2RST     = ./run-in-venv.bash ./chpl2rst.py
 CHPL2RSTOPTS = --output=rst --prefix=source/primers/primers --link=master
 
-# Disable parallel builds to prevent race conditions
-.NOTPARALLEL:
-
 help: help-sphinx help-source
 
 help-source:
@@ -99,3 +96,7 @@ clean-primers: FORCE
 
 
 FORCE:
+
+# Disable parallel builds to prevent race conditions
+.NOTPARALLEL:
+

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -6,6 +6,9 @@ include Makefile.sphinx
 CHPL2RST     = ./run-in-venv.bash ./chpl2rst.py
 CHPL2RSTOPTS = --output=rst --prefix=source/primers/primers --link=master
 
+# Disable parallel builds to prevent race conditions
+.NOTPARALLEL:
+
 help: help-sphinx help-source
 
 help-source:


### PR DESCRIPTION
It turns out the docs Makefile has a race condition when built in parallel, which was encountered in testing sporadically. I managed to reproduce the error, and confirm that adding `.NOTPARALLEL` to `doc/sphinx/Makefile` eliminates the issue.

On my local machine, the difference before and after this change for `make docs` was <1 second .