### PR TITLE
Pre-release prep. for Chapel 1.14.0 : increment version numbers

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -1,5 +1,5 @@
 ============================================
-Chapel Public Release Goals (version 1.13.1)
+Chapel Public Release Goals (version 1.14.0)
 ============================================
 
 The goals of this release are as follows:

--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -21,8 +21,8 @@
 #define _version_num_H_
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION "13"
-#define UPDATE_VERSION "1"
+#define MINOR_VERSION "14"
+#define UPDATE_VERSION "0"
 
 static const char* BUILD_VERSION =
 #include "BUILD_VERSION"

--- a/doc/release/README.md
+++ b/doc/release/README.md
@@ -57,7 +57,7 @@ Online Documentation
 You can navigate to the root of the documentation for this release using
 the URL:
 
-[chapel.cray.com/docs/1.13](http://chapel.cray.com/docs/1.13/)
+[chapel.cray.com/docs/1.14](http://chapel.cray.com/docs/1.14/)
 
 
 For More Information

--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -33,7 +33,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.13.1
+        export CHPL_HOME=~/chapel-1.14.0
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -53,15 +53,15 @@ master_doc = 'index'
 # built documents.
 #
 # The short X.Y version.
-# version = '1.13'
+# version = '1.14'
 
 # We use a custom version variable (shortversion) instead, because setting
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
-shortversion = 1.13
+shortversion = 1.14
 
 # The full version, including alpha/beta/rc tags.
-release = '1.13.1'
+release = '1.14.0'
 
 # General information about the project.
 project = u'Chapel Documentation {0}'.format(shortversion)

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.13.1
+:Version: 1.14.0
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.13.1
+:Version: 1.14.0
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- Version 1.13.1
+ Version 1.14.0

--- a/test/release/examples/README.testing
+++ b/test/release/examples/README.testing
@@ -67,4 +67,4 @@ For more information
 --------------------
 
 See:
-https://github.com/chapel-lang/chapel/blob/release/1.13/doc/developer/bestPractices/TestSystem.txt
+https://github.com/chapel-lang/chapel/blob/release/1.14/doc/developer/bestPractices/TestSystem.txt


### PR DESCRIPTION
THIS IS NOT CHAPEL RELEASE 1.14.0.

This commit merely increments the embedded version numbers from
1.13.1 to 1.14.0, in preparation for later release; currently
scheduled for 6 October 2016.

NOTE: util/dockerfiles/... is not included in this change