### PR TITLE
primers/modules.chpl: formatting tweak

### DIFF
--- a/test/release/examples/primers/modules.chpl
+++ b/test/release/examples/primers/modules.chpl
@@ -110,7 +110,7 @@ module MainModule {
        module name and a separating ``.`` as a prefix to the name of the symbol
        desired.
      */
-    var thriceFoo = 3 * modToUse.foo; // should be ``36``
+    var thriceFoo = 3 * modToUse.foo; // should be '36'
     writeln(thriceFoo);
 
     /* If several of the module's symbols are desired, or the same symbol is


### PR DESCRIPTION
Within a // comment in a code block, the double-backtick, instead of acting as a formatting directive,  renders as a double-backtick, which I don't think was intended here.  Replace this one with regular single-quotes as the rest of the file uses in this context.

