### PR TITLE
Updated UtilMisc_forDocs.chpl for compilerAssert,

### DIFF
--- a/modules/internal/UtilMisc_forDocs.chpl
+++ b/modules/internal/UtilMisc_forDocs.chpl
@@ -49,8 +49,7 @@ module UtilMisc_forDocs {
      Generate a compile-time error.
      The error text is a concatenation of the arguments.
   */
-  proc compilerError(param x:c_string ...?n) {
-    __primitive("error", (...x));
+  proc compilerError(param msg: string ...?n) {
   }
 
   /*
@@ -59,8 +58,7 @@ module UtilMisc_forDocs {
 
      :arg errorDepth: controls the depth of the error stack trace
   */
-  proc compilerError(param x:c_string ...?n, param errorDepth:int) {
-    __primitive("error", (...x));
+  proc compilerError(param msg: string ...?n, param errorDepth: int) {
   }
 
 
@@ -68,8 +66,7 @@ module UtilMisc_forDocs {
      Generate a compile-time warning.
      The warning text is a concatenation of the arguments.
   */
-  proc compilerWarning(param x:c_string ...?n) {
-    __primitive("warning", (...x));
+  proc compilerWarning(param msg: string ...?n) {
   }
 
   /*
@@ -78,114 +75,40 @@ module UtilMisc_forDocs {
 
      :arg errorDepth: controls the depth of the error stack trace
   */
-  proc compilerWarning(param x:c_string ...?n, param errorDepth:int) {
-    __primitive("warning", (...x));
+  proc compilerWarning(param msg: string ...?n, param errorDepth: int) {
   }
 
 
-
-  //
-  // chpldoc note: I wanted to aggregate compilerAssert into just a couple
-  // of nice-looking prototypes and call the int argument 'errorDepth'
-  // - in this file - so that the online docs look pretty.
-  //
-  // I chose against it - to avoid situations where the user invokes
-  // compilerAssert() according to one of these prototypes and gets
-  // an "unresolved call" error.  -vass 3'2016
   //
   // TODO: improve the compilerAssert() functions in ChapelBase.chpl:
-  //  * either require the formals to be 'string' or cast them
-  //    to 'string' when passing to compilerError
-  //  * name the 'int' formal 'errorDepth'
   //  * do we want to +1 when passing errorDepth to compilerError() ?
-  //  * switch to nice-looking prototypes by allowing varargs;
-  //    one option for that is to invoke __primitive("error") directly
   //
 
-  /*
-     This function is used primarily within system modules to test a compile
-     time property. An error message is generated if the property is false
-
-     :arg test: the param value to be tested
+  /* Generate a compile-time error if the `test` argument is false.
   */
   proc compilerAssert(param test: bool)
-  { if !test then compilerError("assert failed"); }
+  { }
 
+  /* Generate a compile-time error if the `test` argument is false.
 
-  /*
-     This function is used primarily within system modules to test a compile
-     time property. An error message is generated if the property is false.
-     The second parameter, which must be integral, is used to control the
-     depth of the error stack traceback.
-
-     :arg test: the param value to be tested
+     :arg errorDepth: controls the depth of the error stack trace
   */
-  proc compilerAssert(param test: bool, param arg1:integral)
-  { if !test then compilerError("assert failed", arg1:int); }
+  proc compilerAssert(param test: bool, param errorDepth: int)
+  { }
 
-  /*
-     This function of two arguments will be used if the second parameter is not
-     integral.  If the first parameter is false, then the second parameter is
-     included in the error message that is generated
-
-     :arg test: the param value to be tested
+  /* Generate a compile-time error if the `test` argument is false.
+     The warning text is a concatenation of the string arguments.
   */
+  proc compilerAssert(param test: bool, param msg: string ...?n)
+  { }
 
-  proc compilerAssert(param test: bool, param arg1) where !isIntegralType(arg1.type)
-  { if !test then compilerError("assert failed - ", arg1); }
+  /* Generate a compile-time error if the `test` argument is false.
+     The warning text is a concatenation of the string arguments.
 
-  /* Generate a compile-time error if `test` is false.
-     The error message includes `arg1` and `arg2`. */
-  proc compilerAssert(param test: bool, param arg1, param arg2)
-  { if !test then compilerError("assert failed - ", arg1, arg2); }
-
-  /* Generate a compile-time error if `test` is false.
-     The error message includes `arg1`, `arg2`, `arg3`. */
-  proc compilerAssert(param test: bool, param arg1, param arg2, param arg3)
-  { if !test then compilerError("assert failed - ", arg1, arg2, arg3); }
-
-  /* Generate a compile-time error if `test` is false.
-     The error message includes `arg1` through `arg4`. */
-  proc compilerAssert(param test: bool, param arg1, param arg2, param arg3, param arg4)
-  { if !test then compilerError("assert failed - ", arg1, arg2, arg3, arg4); }
-
-  /* Generate a compile-time error if `test` is false.
-     The error message includes `arg1` through `arg5`. */
-  proc compilerAssert(param test: bool, param arg1, param arg2, param arg3, param arg4, param arg5)
-  { if !test then compilerError("assert failed - ", arg1, arg2, arg3, arg4, arg5); }
-
-  /*
-     This variation accepts any number of arguments.  The first five additional parameters are
-     included if an error message is generated and then there is an indication that there are
-     additional parameters.
-
-     :arg test: the param value to be tested
+     :arg errorDepth: controls the depth of the error stack trace
   */
-
-  proc compilerAssert(param test: bool, param arg1, param arg2, param arg3, param arg4, param arg5, argrest...)
-  { if !test then compilerError("assert failed - ", arg1, arg2, arg3, arg4, arg5, " [...]"); }
-
-
-  /*
-     This variation accepts the value to be tested, precisely 5 values to be included in the
-     error message, and finally an integral value that controls the depth of the error stack.
-
-     :arg test: the param value to be tested
-  */
-
-  proc compilerAssert(param test: bool, param arg1, param arg2, param arg3, param arg4, param arg5, param arg6: integral)
-  { if !test then compilerError("assert failed - ", arg1, arg2, arg3, arg4, arg5, arg6:int); }
-
-  /*
-     This variation accepts any number of arguments but detects that the final argument is integral.
-     In this version the final argument is treated as an errorDepth as for compilerWarning() and
-     compilerError()
-
-     :arg test: the param value to be tested
-  */
-  proc compilerAssert(param test: bool, param arg1, param arg2, param arg3, param arg4, param arg5, argrest..., param arglast: integral)
-  { if !test then compilerError("assert failed - ", arg1, arg2, arg3, arg4, arg5, " [...]", arglast:int); }
-
+  proc compilerAssert(param test: bool, param msg: string ...?n, param errorDepth: int)
+  { }
 
 
   /* Compute the minimum value of 2 or more arguments


### PR DESCRIPTION
... compilerWarning, compilerError changes.

#4508 switched to nicer signatures for these functions.
I am updating chpldocs to match.

The signatures in UtilMisc_forDocs.chpl are exactly
the same as in ChapelBase.chpl. So once the doc-generating
infrastructure is in place, we could generate the docs
straight from ChapelBase.chpl. For these three functions,
that is.

While there: Many of these functions also changed their bodies.
I do not see the point of updating these functions' bodies
in UtilMisc_forDocs.chpl, so I uniformly made all their bodies
empty in UtilMisc_forDocs.chpl.