### PR TITLE
Tweaks enabling FreeBSD functionality

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,0 +1,5 @@
+default:
+	@gmake ${MAKEFLAGS}
+
+${.TARGETS}:
+	@gmake ${.TARGETS} ${MAKEFLAGS}

--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,5 +1,0 @@
-default:
-	@gmake ${MAKEFLAGS}
-
-${.TARGETS}:
-	@gmake ${.TARGETS} ${MAKEFLAGS}

--- a/doc/release/prereqs.rst
+++ b/doc/release/prereqs.rst
@@ -52,3 +52,7 @@ We have used the following commands to install the above prerequisites:
   * Debian, Ubuntu::
 
       sudo apt-get install gcc g++ perl python python-dev python-setuptools bash make mawk
+
+  * FreeBSD::
+
+     sudo pkg install bash python py27-setuptools gmake gawk

--- a/make/platform/Makefile.freebsd
+++ b/make/platform/Makefile.freebsd
@@ -1,0 +1,31 @@
+# Copyright 2004-2016 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 
+# seemingly necessary to get dependencies, e.g. curl.h
+#
+RUNTIME_CFLAGS += -I/usr/local/include
+ 
+#
+# seemingly necessary to get dependencies, e.g. curl.h
+#
+GEN_CFLAGS +=  -I/usr/local/include
+
+#
+# seemingly necessary to get dependencies, e.g. libcurl.a
+#
+GEN_LFLAGS +=  -L/usr/local/lib

--- a/runtime/include/qio/qio_error.h
+++ b/runtime/include/qio/qio_error.h
@@ -133,7 +133,9 @@ qioerr qio_mkerror_errno(void);
   return qio_err_local_ptr_to_err(&qio_macro_tmp_err__); \
 }
 
-// EEOF 
+// custom errors
+// if you update these, alse update the extended_errors array.
+
 #ifndef EEOF
 #define EEOF (EXTEND_ERROR_OFFSET+0)
 #endif
@@ -146,17 +148,18 @@ qioerr qio_mkerror_errno(void);
 #define EFORMAT (EXTEND_ERROR_OFFSET+2)
 #endif
 
-// Make sure we have an EILSEQ
+// These are errors not available on every platform.
 #ifndef EILSEQ
 #define EILSEQ (EXTEND_ERROR_OFFSET+3)
 #endif
-
-// Make sure we have EOVERFLOW
 #ifndef EOVERFLOW
 #define EOVERFLOW (EXTEND_ERROR_OFFSET+4)
 #endif
+#ifndef ENODATA
+#define ENODATA (EXTEND_ERROR_OFFSET+5)
+#endif
 
-#define EXTEND_ERROR_NUM 5
+#define EXTEND_ERROR_NUM 6
 
 
 #define QIO_ENOMEM (qio_int_to_err(ENOMEM))

--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -328,11 +328,13 @@ static const char* error_string_no_error = "No error";
 
 static
 const char* extended_errors[] = {
-  "end of file",
-  "short read or write",
-  "bad format",
-  "illegal multibyte sequence", // most systems already have EILSEQ but not all
-  "overflow", // most systems already have EOVERFLOW but not all
+  /* EEOF */     "end of file",
+  /* ESHORT */   "short read or write",
+  /* EFORMAT */  "bad format",
+  // most systems already have the following but not all
+  /* EILSEQ */    "illegal multibyte sequence",
+  /* EOVERFLOW */ "overflow",
+  /* ENODATA */   "no data",
   NULL
 };
 

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -54,7 +54,7 @@ def get(flag='host'):
             compiler_val = 'ibm'
         elif platform_val == 'marenostrum':
             compiler_val = 'ibm'
-        elif platform_val == 'darwin':
+        elif platform_val == 'darwin' or platform_val == 'freebsd':
             if find_executable('clang'):
                 compiler_val = 'clang'
             else:


### PR DESCRIPTION
A user appeared on irc was trying to use Chapel on GhostBSD. I helped them solve a problem with curl support. Then, to follow up, I wanted to check myself. I don't have easy access to GhostBSD but I do have a FreeBSD VM so I went through the exercise of quickstart make & make check on FreeBSD.


* prereqs.rst: Added the command to get the dependencies installed, since I had to figure it out anyway.

* make/platform/Makefile.freebsd : add a new file and include /usr/local/include and /usr/local/lib. These are necessary for libcurl to work (since FreeBSD adds libcurl to /usr/local) and that's what the user on irc was trying to do.

* qio/qio_error.h: define ENODATA if it's not defined by the OS. It wasn't defined on FreeBSD, but something in QIO's curl support uses it. 

* qio/sys.c: make the corresponding change to support our own definition of ENODATA.

* chplenv/chpl_compiler.py : on FreeBSD, check first for clang, and then for GCC. The version of FreeBSD I tested on didn't come with GCC but did come with clang. Without this change, printchplenv wouldn't even work.

Passed full local testing.
Reviewed by @lydia-duncan - thanks!