### PR TITLE
Fixes for Solaris/illumos/OmniOS

### DIFF
--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -637,7 +637,7 @@ const char* shortLoc(BaseAST* ast) {
     return "<no node provided>";
 
   const char* longLoc = stringLoc(ast);
-  const char* slash = (const char*) rindex(longLoc, '/');
+  const char* slash = (const char*) strrchr(longLoc, '/');
   return slash ? slash+1 : longLoc;
 }
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -18,11 +18,13 @@
  */
 
 // Get realpath on linux
+#ifdef __linux__
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
 #endif
 #ifndef _XOPEN_SOURCE_EXTENDED
 #define _XOPEN_SOURCE_EXTENDED 1
+#endif
 #endif
 
 #include "files.h"

--- a/make/platform/Makefile.sunos
+++ b/make/platform/Makefile.sunos
@@ -35,3 +35,4 @@ GEN_CFLAGS +=  -U__STRICT_ANSI__
 #
 ARMCI_PLATFORM_SPECIFIC_LIBS = -lsocket
 PVM_PLATFORM_LIBS = -lrt
+GEN_LFLAGS = -lsocket -lnsl

--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -1449,10 +1449,22 @@ err_t sys_getnameinfo(const sys_sockaddr_t* addr, char** host_out, char** serv_o
   char* new_host_buf;
   char* serv_buf=0;
   char* new_serv_buf;
-  int host_buf_sz = NI_MAXHOST;
-  int serv_buf_sz = NI_MAXSERV;
+  int host_buf_sz;
+  int serv_buf_sz;
   int got;
   err_t err_out;
+
+#ifdef NI_MAXHOST
+  host_buf_sz = NI_MAXHOST;
+#else
+  host_buf_sz = 1025;
+#endif
+
+#ifdef NI_MAXSERV
+  serv_buf_sz = NI_MAXSERV;
+#else
+  serv_buf_sz = 32;
+#endif
 
   STARTING_SLOW_SYSCALL;
 


### PR DESCRIPTION
With these changes, I'm able to get a quickstart build and Hello World working.

In view.cpp, replaced rindex with strrchr. rindex is a deprecated function and strrchr is the current name for it.

In files.cpp, in setting up #defines to get realpath, only do that on linux. The BSD platforms just have a realpath that already works without further effort.

In Makefile.sunos, include -lsocket and -lnsl to avoid link errors (from functions called in sys.c) when building a Chapel program.

In qio/sys.c, tolerate NI_MAXHOST and NI_MAXSERV not being defined. This code should function with any starting value for these (since it resizes the buffer). These were not defined in OmniOS and aren't actually standard.

Passed full local testing.
Reviewed by @lydia-duncan - thanks!