### PR TITLE
Simplify 'select' statement grammar in spec

### DIFF
--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -373,16 +373,11 @@ select-statement:
 
 when-statements:
   when-statement
-  when-statement otherwise-statement
-  otherwise-statement when-statement
   when-statement when-statements
-  when-statements when-statement
 
 when-statement:
   `when' expression-list `do' statement
   `when' expression-list block-statement
-
-otherwise-statement:
   `otherwise' statement
   `otherwise' `do' statement
 


### PR DESCRIPTION
Previously the grammar for when statements was:

    when-statements:
      when-statement
      when-statement otherwise-statement
      otherwise-statement when-statement
      when-statement when-statements
      when-statements when-statement

It said that it is a sequence of when/otherwise-statement(s),
and expressed two additional properties of such a sequence.

Since these two additional properties are not clearly conveyed
by the grammar, this change simplifies the grammar to:

    when-statements:
      when-statement
      when-statement when-statements

The two additional properties are no longer conveyed by the grammar.
Instead they are conveyed in plain English in the last sentence
of the immediately-following paragraph.