### PR TITLE
Update the documentation on atomics to reflect the cstdlib implementation.

### DIFF
--- a/doc/release/chplenv.rst
+++ b/doc/release/chplenv.rst
@@ -403,6 +403,8 @@ CHPL_ATOMICS
         ===========  =====================================================
         Value        Description
         ===========  =====================================================
+        cstdlib      implement Chapel atomics as a wrapper around C
+                     standard atomics (from C11)
         intrinsics   implement atomics using target compiler intrinsics
                      (which typically map down to hardware capabilities)
         locks        implement atomics by using Chapel sync variables to
@@ -411,7 +413,10 @@ CHPL_ATOMICS
 
    If unset, CHPL_ATOMICS defaults to ``intrinsics`` for most configurations.
    On some 32 bit platforms, or if the target compiler is ``pgi`` or
-   ``cray-prgenv-pgi`` it defaults to ``locks``.
+   ``cray-prgenv-pgi`` it defaults to ``locks``.  In a future release,
+   ``cstdlib`` will become the default whenever possible.  At this
+   time, though, most C compilers either do not support standard
+   atomics or have bugs in their implementation.
 
    .. note::
      gcc 4.8.1 added support for 64 bit atomics on 32 bit platforms.  We

--- a/doc/release/technotes/atomics.rst
+++ b/doc/release/technotes/atomics.rst
@@ -31,16 +31,16 @@ network-based atomics are available for your platform
 
 The choice of supported atomic variable types as well as the atomic
 operations were strongly influenced by the C11 standard. A notable
-exception is that Chapel supports atomics for ``real`` types as
-well.
+exception is that Chapel supports atomic
+fetch-and-add/fetch-and-subtract operations on ``real`` types as well.
 
 The specific implementation of atomics can be selected via the
 environment variable ``CHPL_ATOMICS``.  Similar to the other Chapel
 environment variables, an appropriate default is chosen when not
 specified, and not all implementations are available for all
-settings.  Chapel currently supports two atomics implementations:
-``intrinsics`` and ``locks``. This environment variable also
-specifies the atomic implementation used by the Chapel runtime.
+settings.  Chapel currently supports three atomics implementations:
+``cstdlib``, ``intrinsics`` and ``locks``. This environment variable
+also specifies the atomic implementation used by the Chapel runtime.
 
 If compiler support for atomics is available, the atomic operations
 will be mapped down the appropriate compiler intrinsics which often
@@ -48,9 +48,10 @@ map directly to processor atomics.  If intrinsics are not available,
 the atomic implementation defaults to using locks in the form of
 Chapel's sync vars. As a result the locks implementation will be
 slower than the intrinsic implementation. Since Chapel's atomics
-were modeled after the C11 standard, as C11 support becomes more
-prevalent, we will support an implementation that maps to the C11
-atomics.
+were modeled after the C11 edition of the C standard, the cstdlib
+implementation is just a wrapper around C standard atomics.  As C11
+support becomes more prevalent and reliable, cstdlib will become the
+default in some configurations.
 
 Currently, unless using network atomics, all remote atomic
 operations will result in the calling task effectively migrating to
@@ -76,36 +77,34 @@ Memory Order Notes
 ------------------
 
 As mentioned in the spec, most atomic operations optionally take a
-memory order. However for all current implementations, this argument
-is ignored. The resulting effect is that all atomic operations are
-performed with memory_order_seq_cst (sequentially consistent)
-regardless of the actual order specified. The reason for this is
-because the compiler intrinsics used in the runtime have no way to
-specify memory order.
+memory order. However, for the intrinsics and locks implementations,
+this argument is ignored. The resulting effect is that all atomic
+operations are performed with memory_order_seq_cst (sequentially
+consistent) regardless of the actual order specified. The reason for
+this is because the compiler intrinsics used in the runtime have no
+way to specify memory order.
 
-We expect to begin using the specified memory order with a C11
-implementation of the atomics.
+The cstdlib implementation uses the specified memory order.
 
 
--------------------------------
-Variances from the C11 standard
--------------------------------
+-----------------------------
+Variances from the C standard
+-----------------------------
 
-While Chapel atomics are modeled after the C11 standard there are some
-notable differences. The primary one is that Chapel supports atomics for
-``real`` types. It should be noted that since there is virtually no
-hardware support for floating point atomics, our implementation is
-not very efficient.
+While Chapel atomics are modeled after the C standard there are some
+notable differences. The primary one is that Chapel supports
+fetch-and-add/fetch-and-subtract operations for ``real`` types. It
+should be noted that since there is virtually no hardware support for
+floating point atomics, our implementation is not very efficient.
 
 As noted in the spec there a few additional methods in Chapel that
 are not in C11. They are ``peek``, ``poke``, and ``waitFor``.
 ``peek`` and ``poke`` are supposed to be relaxed versions of read
 and write that allow users to perform reads and writes with more
 relaxed memory constraints.  Currently they are implemented as reads
-and writes with memory_order_relaxed but current implementations
-ignore memory_order. ``waitFor`` is method that waits until an
-atomic value has a specific value.  It can yield to other tasks
-while waiting.
+and writes with memory_order_relaxed. ``waitFor`` is a method that
+waits until an atomic object has a specific value.  It can yield to
+other tasks while waiting.
 
 Chapel currently does not support the memory fences or the
 ``isLockFree`` method from the C11 spec. They are defined in the
@@ -115,10 +114,12 @@ the intrinsics. Without examining each intrinsic operation for each
 compiler it is hard to know if they actually map down to lock free
 operations. ``threadFence`` and ``signalFence`` are also in the
 runtime but not in the modules. The primary reason for this is that
-there is no need for them with the current implementation.  All our
-operations use memory_order_seq_cst. The fences are used with other
-memory_orders to allow you to create safe programs when atomic
-operations are using non sequential memory orders.
+there is no need for them with the intrinsics or locks
+implementations, where all our operations use
+memory_order_seq_cst. They will be added for use with the cstdlib
+implementation. The fences are used with other memory_orders to allow
+you to create safe programs when atomic operations are using non
+sequential memory orders.
 
 
 -----------
@@ -128,7 +129,11 @@ Open issues
 - Atomic bools are only supported for the default size and not
   implemented for all sizes of bools.
 
-- The memory_order is currently ignored by all implementations.
+- The memory_order is currently ignored by the intrinsics and locks
+  implementations.
+
+- The threadFence and signalFence methods need to be made available
+  for use with nonsequential memory orders.
 
 
 ---------------------

--- a/runtime/include/atomics/README
+++ b/runtime/include/atomics/README
@@ -6,10 +6,12 @@ implementation. The cstdlib implementation is basically a wrapper for
 C11 atomics. The intrinsics implementation uses compiler atomic
 intrinsics to implement atomics and the locks version uses Chapel
 locks. The cstdlib implementation is expected to have the best
-performance (depending on the compiler's native handling of C11
-atomics), and the intrinsic version has better performance than locks,
-but neither the standard atomics nor the intrinsics are available on
-all systems.
+performance in the long run, depending on the compiler's native
+handling of C11 atomics, and the intrinsic version has better
+performance than locks, but neither the standard atomics nor the
+intrinsics are available on all systems.  (For gcc up to at least
+6.2.0, though, there is a performance bug that inhibits more
+optimization than necessary with standard atomics.)
 
 We require the C11 standard atomic functions for the types:
    atomic_uint_least8_t


### PR DESCRIPTION
Since C standard atomics were added, several places in the documentation needed to be updated to reflect them.