### PR TITLE
Move UDP conduit documentation to own file

### DIFF
--- a/doc/release/launcher.rst
+++ b/doc/release/launcher.rst
@@ -102,153 +102,7 @@ forwarded to worker processes. However, this strategy is not always
 reliable. The remote system may override some environment variables, and
 some launchers might not correctly forward all environment variables.
 
-
-.. _using-udp:
-
-Using the Portable UDP Conduit
-++++++++++++++++++++++++++++++
-
-GASNet includes a portable UDP conduit. While this conduit can help get
-multilocale Chapel programs running in a variety of environments, it is
-not expected to achieve the best performance.
-
-To build Chapel with the UDP conduit, run these commands from ``$CHPL_HOME``:
-
-.. code-block:: bash
-
-   export CHPL_COMM=gasnet
-   export CHPL_COMM_SUBSTRATE=udp
-   make
-
-Now you should be able to compile a program:
-
-.. code-block:: bash
-
-   chpl -o hello6-taskpar-dist $CHPL_HOME/examples/hello6-taskpar-dist.chpl
-
-But, in order to run this program, you'll need to indicate where the
-multi-locale program should run.
-
-First, try running it locally:
-
-.. code-block:: bash
-
-   # Run over-subscribed on this machine
-   export GASNET_SPAWNFN=L
-   ./hello6-taskpar-dist -nl 2
-
-You should see output from 2 locales that both report the same hostname. This
-configuration simulates multiple Chapel locales with one workstation. This
-configuration is useful for testing but is not expected to perform well.
-
-Next, try running it across several machines.
-
-.. code-block:: bash
-
-   # Use SSH to spawn jobs
-   export GASNET_SPAWNFN=S
-   # Which ssh command should be used? ssh is the default.
-   export GASNET_SSH_CMD=ssh
-   # Disable X11 forwarding
-   export GASNET_SSH_OPTIONS=-x
-   # Specify which hosts to spawn on.
-   export GASNET_SSH_SERVERS="host1 host2 host3 ..."
-
-where host1, host2, host3, ... are the names of the
-workstations that will serve as your Chapel locales.  In
-order to run your Chapel program on k locales, you must
-have k entries in the ``GASNET_SSH_SERVERS`` variable.  To avoid
-typing in passwords for each node, you will probably want
-to use normal ssh-agent/ssh-add capabilities to support
-password-less ssh-ing.
-
-Now running
-
-.. code-block:: bash
-
-  ./hello6-taskpar-dist -nl 2
-
-should display 2 different hostnames that you specified in GASNET_SSH_SERVERS.
-
-GASNet's UDP conduit can be configured with many other options. Please refer
-to:
-
-   ``$CHPL_HOME/third-party/gasnet/gasnet-src/udp-conduit/README``
-   or
-   http://gasnet.lbl.gov/dist/udp-conduit/README
-
-
-.. _using-udp-slurm:
-
-Using the UDP Conduit with Slurm
-********************************
-
-It is also possible to configure GASNet/UDP to launch jobs with
-Slurm using the following commands:
-
-.. code-block:: bash
-
-   export GASNET_SPAWNFN=C
-   export GASNET_CSPAWN_CMD="srun -N%N %C"
-
-Note that this configuration will not work for other conduits, as
-``GASNET_SPAWNFN=C`` is specific to the UDP conduit.
-
-See ssh-launchers-with-slurm_ for other possibilities.
-
-Troubleshooting the UDP Conduit
-*******************************
-
-I need to type a password when running my program
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Configure your machines for password-less ssh. Try searching for "how to set up
-passwordless ssh". You'll know you have succeeded when you can `ssh` directly to
-the compute nodes without needing to type in a password each time.
-
-I'm seeing login banners mixed with my program's output
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you are using SSH to launch jobs, you might get a
-login banner printed out along with your program's output. We have
-found the following setting useful to disable such printing:
-
-.. code-block:: bash
-
-   export GASNET_SSH_OPTIONS="-o LogLevel=Error"
-
-
-I'm seeing warnings from GASNet about using a higher-performance network
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-  WARNING: Using GASNet's udp-conduit, which exists for portability convenience.
-  WARNING: Support was detected for native GASNet conduits: ibv
-  WARNING: You should *really* use the high-performance native GASNet conduit
-  WARNING: if communication performance is at all important in this program run.
-
-Using a high-performance network, when available, is going to give much better
-performance with Chapel than the UDP conduit. However, in some cases (e.g. when
-comparing conduits) you might like to use the UDP conduit without these
-warnings. To turn them off, use:
-
-.. code-block:: bash
-
-  export GASNET_QUIET=yes
-
-I get xSocket errors when using a system with multiple IP addresses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
- *** FATAL ERROR: Got an xSocket while spawning slave process: connect()
- failed while creating a connect socket (111:Connection refused)
-
-You need to set ``GASNET_MASTERIP`` and possibly ``GASNET_WORKERIP``. See
-``$CHPL_HOME/third-party/gasnet/gasnet-src/udp-conduit/README`` or
-http://gasnet.lbl.gov/dist/udp-conduit/README .
-
+.. _using-slurm:
 
 Using Slurm
 +++++++++++
@@ -263,8 +117,10 @@ On Cray systems, this will happen automatically if srun is found in your path,
 but not when both srun and aprun are found in your path. Native Slurm is the
 best option where it works, but at the time of this writing, there are problems with it when combined with UDP or InfiniBand conduits. So, for these configurations please see:
 
-  * :ref:`readme-infiniband` for information about using Slurm with InfiniBand.
-  * using-udp-slurm_ for information about using Slurm with the UDP conduit
+  * :ref:`readme-infiniband` for information about using Slurm with
+    InfiniBand.
+  * :ref:`using-udp-slurm` for information about using Slurm with the UDP
+    conduit
 
 Common Slurm Settings
 *********************

--- a/doc/release/multilocale.rst
+++ b/doc/release/multilocale.rst
@@ -73,12 +73,10 @@ hello6-taskpar-dist_real).  The first binary contains code to
 launch the Chapel program onto the compute nodes. The second contains
 the program code itself.
 
+.. _what-is-gasnet:
 
 What is GASNet?
 +++++++++++++++
-
-.. _what-is-gasnet:
-
 
 GASNet is a one-sided communication and active message library being
 developed by Lawrence Berkeley National Lab and UC Berkeley.  For details,

--- a/doc/release/platforms/infiniband.rst
+++ b/doc/release/platforms/infiniband.rst
@@ -4,6 +4,10 @@
 Using Chapel with InfiniBand
 ============================
 
+This document describes how to run Chapel across multiple machines in an
+InfiniBand cluster. The :ref:`readme-multilocale` describes general
+information about running Chapel in a multilocale configuration.
+
 Avoiding Slow Job Launch
 ++++++++++++++++++++++++
 
@@ -50,7 +54,7 @@ a. In the future, we expect that ``CHPL_LAUNCHER=slurm-srun`` will be the best
      # Compile a sample program
      chpl -o hello6-taskpar-dist examples/hello6-taskpar-dist.chpl
 
-   See :ref:`readme-launcher` for other options available, such
+   See :ref:`using-slurm` for other options available, such
    as setting the time limit or selecting the type of node.
    Some settings might be required by your Slurm configuration.
    Setting these variables are typically necessary:

--- a/doc/release/platforms/macosx.rst
+++ b/doc/release/platforms/macosx.rst
@@ -17,6 +17,10 @@ following command::
 
     brew install chapel
 
+When using a Homebrew install of Chapel, the ``CHPL_HOME`` directory is
+here::
+
+    /usr/local/Cellar/chapel/<chapel-version>/libexec/
 
 .. note::
 

--- a/doc/release/platforms/macosx.rst
+++ b/doc/release/platforms/macosx.rst
@@ -17,6 +17,12 @@ following command::
 
     brew install chapel
 
+The above command installs a release version of Chapel. It is also
+possible to use Homebrew_ to build and install a development version
+based on the master branch on GitHub::
+
+    brew install chapel --HEAD
+
 When using a Homebrew install of Chapel, the ``CHPL_HOME`` directory is
 here::
 

--- a/doc/release/platforms/udp.rst
+++ b/doc/release/platforms/udp.rst
@@ -153,9 +153,11 @@ I get xSocket errors when using a system with multiple IP addresses
  *** FATAL ERROR: Got an xSocket while spawning slave process: connect()
  failed while creating a connect socket (111:Connection refused)
 
-You need to set ``GASNET_MASTERIP`` and possibly ``GASNET_WORKERIP``. See
-``$CHPL_HOME/third-party/gasnet/gasnet-src/udp-conduit/README`` or
-http://gasnet.lbl.gov/dist/udp-conduit/README .
+You need to set ``GASNET_MASTERIP`` and possibly ``GASNET_WORKERIP``.
+Please refer to:
+
+  * ``$CHPL_HOME/third-party/gasnet/gasnet-src/udp-conduit/README``
+  * http://gasnet.lbl.gov/dist/udp-conduit/README .
 
 
 

--- a/doc/release/platforms/udp.rst
+++ b/doc/release/platforms/udp.rst
@@ -1,0 +1,161 @@
+.. _using-udp:
+
+==============================
+Using the Portable UDP Conduit
+==============================
+
+This document describes how to run Chapel across multiple machines in a
+portable manner using UDP for communication. This strategy is appropriate
+for machines only connected by Ethernet, for example. See also
+:ref:`readme-multilocale` which describes general information about
+running Chapel in a multilocale configuration. 
+
+The *UDP conduit* is a portion of the GASNet networking library. See
+:ref:`what-is-gasnet` for more information about GASNet.
+
+.. note::
+
+  While the UDP conduit can help get multilocale Chapel programs running
+  in a variety of environments, it is not expected to achieve the best
+  performance. It is implemented for portability rather than for maximum
+  performance.
+
+To build Chapel with the UDP conduit, run these commands from ``$CHPL_HOME``:
+
+.. code-block:: bash
+
+   export CHPL_COMM=gasnet
+   export CHPL_COMM_SUBSTRATE=udp
+   make
+
+Now you should be able to compile a program:
+
+.. code-block:: bash
+
+   chpl -o hello6-taskpar-dist $CHPL_HOME/examples/hello6-taskpar-dist.chpl
+
+But, in order to run this program, you'll need to indicate where the
+multi-locale program should run.
+
+First, try running it locally:
+
+.. code-block:: bash
+
+   # Run over-subscribed on this machine
+   export GASNET_SPAWNFN=L
+   ./hello6-taskpar-dist -nl 2
+
+You should see output from 2 locales that both report the same hostname. This
+configuration simulates multiple Chapel locales with one workstation. This
+configuration is useful for testing but is not expected to perform well.
+
+Next, try running it across several machines.
+
+.. code-block:: bash
+
+   # Use SSH to spawn jobs
+   export GASNET_SPAWNFN=S
+   # Which ssh command should be used? ssh is the default.
+   export GASNET_SSH_CMD=ssh
+   # Disable X11 forwarding
+   export GASNET_SSH_OPTIONS=-x
+   # Specify which hosts to spawn on.
+   export GASNET_SSH_SERVERS="host1 host2 host3 ..."
+
+where host1, host2, host3, ... are the names of the
+workstations that will serve as your Chapel locales.  In
+order to run your Chapel program on k locales, you must
+have k entries in the ``GASNET_SSH_SERVERS`` variable.  To avoid
+typing in passwords for each node, you will probably want
+to use normal ssh-agent/ssh-add capabilities to support
+password-less ssh-ing.
+
+Now running
+
+.. code-block:: bash
+
+  ./hello6-taskpar-dist -nl 2
+
+should display 2 different hostnames that you specified in GASNET_SSH_SERVERS.
+
+GASNet's UDP conduit can be configured with many other options. Please refer
+to:
+
+   * ``$CHPL_HOME/third-party/gasnet/gasnet-src/udp-conduit/README``
+   * http://gasnet.lbl.gov/dist/udp-conduit/README
+
+
+.. _using-udp-slurm:
+
+Using the UDP Conduit with Slurm
+********************************
+
+It is also possible to configure GASNet/UDP to launch jobs with
+Slurm using the following commands:
+
+.. code-block:: bash
+
+   export GASNET_SPAWNFN=C
+   export GASNET_CSPAWN_CMD="srun -N%N %C"
+
+Note that this configuration will not work for other conduits, as
+``GASNET_SPAWNFN=C`` is specific to the UDP conduit.
+
+See :ref:`using-slurm` for more general information about using Chapel
+with Slurm and :ref:`ssh-launchers-with-slurm` for another strategy.
+
+Troubleshooting the UDP Conduit
+*******************************
+
+I need to type a password when running my program
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Configure your machines for password-less ssh. Try searching for "how to set up
+passwordless ssh". You'll know you have succeeded when you can `ssh` directly to
+the compute nodes without needing to type in a password each time.
+
+I'm seeing login banners mixed with my program's output
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are using SSH to launch jobs, you might get a
+login banner printed out along with your program's output. We have
+found the following setting useful to disable such printing:
+
+.. code-block:: bash
+
+   export GASNET_SSH_OPTIONS="-o LogLevel=Error"
+
+
+I'm seeing warnings from GASNet about using a higher-performance network
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+  WARNING: Using GASNet's udp-conduit, which exists for portability convenience.
+  WARNING: Support was detected for native GASNet conduits: ibv
+  WARNING: You should *really* use the high-performance native GASNet conduit
+  WARNING: if communication performance is at all important in this program run.
+
+Using a high-performance network, when available, is going to give much better
+performance with Chapel than the UDP conduit. However, in some cases (e.g. when
+comparing conduits) you might like to use the UDP conduit without these
+warnings. To turn them off, use:
+
+.. code-block:: bash
+
+  export GASNET_QUIET=yes
+
+I get xSocket errors when using a system with multiple IP addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+ *** FATAL ERROR: Got an xSocket while spawning slave process: connect()
+ failed while creating a connect socket (111:Connection refused)
+
+You need to set ``GASNET_MASTERIP`` and possibly ``GASNET_WORKERIP``. See
+``$CHPL_HOME/third-party/gasnet/gasnet-src/udp-conduit/README`` or
+http://gasnet.lbl.gov/dist/udp-conduit/README .
+
+
+


### PR DESCRIPTION
In discussions with Brad and BenA, we think it would be best to have the UDP conduit documentation in its own file instead of having it inside of launchers.rst. For now, we're putting this file into platforms/ but it's not quite accurate to call the UDP conduit a platform. Nonetheless it is the closest thing to reasonable right now.

Also makes a minor update to the Mac OS X docs for home brew users, and adds introductory paragraphs for UDP and Infiniband documentation files.

Discussed with @bradcray. Reviewed by @ben-albrecht.