### PR TITLE
Detect/Generate Titles for Primers + symlink bug fix

### DIFF
--- a/doc/sphinx/chpl2rst.py
+++ b/doc/sphinx/chpl2rst.py
@@ -143,7 +143,12 @@ def gen_rst(handle):
     indentation = -1
 
     # Each line is rst or code-block
-    for line in [l.strip('\n') for l in handle.readlines()]:
+    for (i, line) in enumerate([l.strip('\n') for l in handle.readlines()]):
+
+        # Skip title comment if present
+        if i == 0:
+            if titlecomment(line):
+                continue
 
         # Skip empty lines
         if len(line.strip()) == 0:
@@ -225,7 +230,11 @@ def gen_codeblock(handle):
     output.append('.. code-block:: chapel')
     output.append('')
 
-    for line in [l.strip('\n') for l in handle.readlines()]:
+    for (i, line) in enumerate([l.strip('\n') for l in handle.readlines()]):
+        if i == 0:
+            if titlecomment(line):
+                continue
+
         output.append('  ' + line)
 
     return '\n'.join(output)
@@ -283,8 +292,7 @@ def main(**kwargs):
         fname = getfname(chapelfile, output, prefix)
 
         if not os.path.exists(prefix) and output != 'stdout':
-            print('--prefix=', prefix, ' does not exist')
-            print('Creating directories:', prefix)
+            print('Creating directory: ', prefix)
             os.makedirs(prefix)
 
         if verbose:

--- a/doc/sphinx/chpl2rst.py
+++ b/doc/sphinx/chpl2rst.py
@@ -68,15 +68,17 @@ def get_arguments():
 def gen_link(link, chapelfile):
     """Generate hyperlink to GitHub URL based on chapelfile path"""
     # Note - this makes the assumption that the file lives in the github repo
-    abspath = os.path.abspath(chapelfile)
+    abspath = os.path.realpath(chapelfile)
     filename = os.path.split(chapelfile)[1]
 
-    chpl_home = os.getenv('CHPL_HOME')
+    chpl_home = os.path.realpath(os.getenv('CHPL_HOME'))
     if not chpl_home:
         print('Error: --link flag only works when $CHPL_HOME is defined')
         sys.exit(1)
     elif not chpl_home in abspath:
         print('Error: --link flag only work for files within $CHPL_HOME')
+        print('CHPL_HOME: {0}'.format(chpl_home))
+        print('file path: {0}'.format(abspath))
         sys.exit(1)
 
     # Get path from CHPL_HOME directory

--- a/test/release/examples/primers/FFTWlib.chpl
+++ b/test/release/examples/primers/FFTWlib.chpl
@@ -1,3 +1,5 @@
+// FFTW
+
 /*
   Example usage of the FFTW module in Chapel. This particular file
   demonstrates the single-threaded version of the code.  In order to

--- a/test/release/examples/primers/LAPACKlib.chpl
+++ b/test/release/examples/primers/LAPACKlib.chpl
@@ -1,3 +1,5 @@
+// LAPACK
+
 /*
   Example usage of the LAPACK module in Chapel.
 

--- a/test/release/examples/primers/arrayVectorOps.chpl
+++ b/test/release/examples/primers/arrayVectorOps.chpl
@@ -1,6 +1,8 @@
-/*
-   Vector Operations on 1D Arrays Primer
-*/
+// Array Vector Operations
+
+//
+// This primer is about vector operations on 1D arrays
+//
 
 //
 // 1D rectangular arrays support several list-like or vector-like capabilities.

--- a/test/release/examples/primers/arrays.chpl
+++ b/test/release/examples/primers/arrays.chpl
@@ -1,9 +1,8 @@
-/*
-  Arrays Primer
+// Arrays
 
-  This primer is a tutorial on Chapel rectangular arrays.
-
-*/
+//
+//  This primer is a tutorial on Chapel rectangular arrays.
+//
 
 //
 // Arrays in Chapel are specified using a square-bracketed expression

--- a/test/release/examples/primers/associative.chpl
+++ b/test/release/examples/primers/associative.chpl
@@ -1,6 +1,6 @@
-/*
+// Associative Domains and Arrays
 
-  Associative Primer
+/*
 
   This is a tutorial on Chapel's associative domains and arrays.
 

--- a/test/release/examples/primers/atomics.chpl
+++ b/test/release/examples/primers/atomics.chpl
@@ -1,5 +1,6 @@
+// Atomics
+
 /*
-  Atomics primer
 
   This primer illustrates Chapel's atomic variables.  For more information
   on Chapel's atomics, see the Chapel Language Specification.

--- a/test/release/examples/primers/chpldoc.doc.chpl
+++ b/test/release/examples/primers/chpldoc.doc.chpl
@@ -1,5 +1,6 @@
+// chpldoc
+
 /*
-  chpldoc Primer
 
   This primer covers the use of chpldoc to document source code. For further
   information, please see $CHPL_HOME/doc/technotes/chpldoc.rst

--- a/test/release/examples/primers/chplvis/chplvis1.chpl
+++ b/test/release/examples/primers/chplvis/chplvis1.chpl
@@ -1,3 +1,4 @@
+// chplvis: Basic Usage
 
 //  Example 1 using visual debug
 //  Full primer is found in doc/chplvis/chplvis.rst.

--- a/test/release/examples/primers/chplvis/chplvis2.chpl
+++ b/test/release/examples/primers/chplvis/chplvis2.chpl
@@ -1,3 +1,5 @@
+// chplvis: Tags
+
 // Example 2 of use of VisualDebug module and chplvis tool.
 // Read the file doc/chplvis/chplvis.rst for full documentation
 // on chplvis.

--- a/test/release/examples/primers/chplvis/chplvis3.chpl
+++ b/test/release/examples/primers/chplvis/chplvis3.chpl
@@ -1,4 +1,6 @@
-// prog3.chpl -- A more complex chplvis example
+// chplvis: Jacobi Iterations Example
+
+// Example 3 -- A more complex chplvis example
 // A version of Jacobi Iterations written to run on multiple locales
 
 use VisualDebug;

--- a/test/release/examples/primers/chplvis/chplvis4.chpl
+++ b/test/release/examples/primers/chplvis/chplvis4.chpl
@@ -1,3 +1,5 @@
+// chplvis: Begin Tasks
+
 // Example 4, begin tasks as shown in chplvis
 // This is a contrived example to have tasks live
 // across a tagVdebug() call.

--- a/test/release/examples/primers/classes.chpl
+++ b/test/release/examples/primers/classes.chpl
@@ -1,8 +1,7 @@
+// Classes
+
 /*
-   Classes Primer
-
    This primer covers the declaration and use of classes.
-
 */
 
 //

--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -1,6 +1,6 @@
-/*
-  Distributions Primer
+// Distributions
 
+/*
   This primer demonstrates uses of some of Chapel's standard
   distributions.  To use these distributions in a Chapel program,
   the respective module must be used:

--- a/test/release/examples/primers/domains.chpl
+++ b/test/release/examples/primers/domains.chpl
@@ -1,6 +1,6 @@
-/*
-   Domains primer
+// Domains
 
+/*
    This primer showcases Chapel domains as abstract concepts, primarily
    within the context of rectangular domains.  For other uses of domains
    see the following primers:

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -1,6 +1,4 @@
-/*
-   File I/O Primer
-*/
+// File I/O
 
 /*
    First example: Textual Array I/O

--- a/test/release/examples/primers/genericClasses.chpl
+++ b/test/release/examples/primers/genericClasses.chpl
@@ -1,8 +1,7 @@
+// Generic Classes
+
 /*
-   Generic Classes Primer
-
    This primer covers generic class types.
-
 */
 
 //

--- a/test/release/examples/primers/iterators.chpl
+++ b/test/release/examples/primers/iterators.chpl
@@ -1,6 +1,6 @@
-/*
-   Iterators Primer
+// Iterators
 
+/*
    This primer contains several examples of iterators:
      an iterator to generate the Fibonacci numbers,
      an iterator defined by multiple loops

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -1,3 +1,4 @@
+// Learn Chapel in Y Minutes
 
 // Comments are C-family style
 // one line comment

--- a/test/release/examples/primers/locales.chpl
+++ b/test/release/examples/primers/locales.chpl
@@ -1,4 +1,4 @@
-// Locales primer
+// Locales
 
 /*
    This example showcases Chapel's locale types.  To run this example

--- a/test/release/examples/primers/locales.chpl
+++ b/test/release/examples/primers/locales.chpl
@@ -1,6 +1,6 @@
-/*
-   Locales primer
+// Locales primer
 
+/*
    This example showcases Chapel's locale types.  To run this example
    using multiple locales set up your environment as described in
    multilocale.rst and execute it using the "-nl #" flag to specify

--- a/test/release/examples/primers/modules.chpl
+++ b/test/release/examples/primers/modules.chpl
@@ -1,6 +1,6 @@
-/*
-   Module Primer
+// Modules
 
+/*
    This primer introduces the concept of modules, a concept for encapsulating
    code for use by other code.  It covers:
 

--- a/test/release/examples/primers/opaque.chpl
+++ b/test/release/examples/primers/opaque.chpl
@@ -1,6 +1,6 @@
-/*
-   Opaque Primer
+// Opaque Domains and Arrays
 
+/*
    This primer is designed to give a brief introduction to Chapel's
    opaque domains and arrays.  Opaque domains and arrays are those in
    which index values are opaque/anonymous, and were designed to

--- a/test/release/examples/primers/parIters.chpl
+++ b/test/release/examples/primers/parIters.chpl
@@ -1,3 +1,5 @@
+// Parallel Iterators
+
 /*
   This example shows how to use parallel iterators in Chapel.
   Leader-follower iterators are used to implement zippered

--- a/test/release/examples/primers/procedures.chpl
+++ b/test/release/examples/primers/procedures.chpl
@@ -1,9 +1,8 @@
-/*
-   Procedures Primer
+// Procedures
 
+/*
    This primer covers procedures including overloading, argument
    intents and dynamic dispatch.
-
 */
 
 //

--- a/test/release/examples/primers/randomNumbers.chpl
+++ b/test/release/examples/primers/randomNumbers.chpl
@@ -1,8 +1,7 @@
+// Random
+
 /*
-   Standard Module: Random primer
-
    This primer demonstrates usage of the standard module Random.chpl.
-
 */
 
 use Random;

--- a/test/release/examples/primers/ranges.chpl
+++ b/test/release/examples/primers/ranges.chpl
@@ -1,8 +1,7 @@
+// Ranges
+
 /*
-   Range Primer
-
    This primer illustrates Chapel ranges and range operations.
-
 */
 
 /*

--- a/test/release/examples/primers/reductions.chpl
+++ b/test/release/examples/primers/reductions.chpl
@@ -1,5 +1,5 @@
-//
-// Reductions Primer
+// Reductions
+
 //
 // This primer includes example reductions.
 //

--- a/test/release/examples/primers/slices.chpl
+++ b/test/release/examples/primers/slices.chpl
@@ -1,5 +1,6 @@
-/*  Slicing Primer
+// Slices
 
+/*
     This example program demonstrates the use of array slicing and
     reindexing.
 

--- a/test/release/examples/primers/sparse.chpl
+++ b/test/release/examples/primers/sparse.chpl
@@ -1,6 +1,6 @@
-/*
-   Sparse Primer
+// Sparse Domains and Arrays
 
+/*
    This primer shows off some of Chapel's support for sparse domains
    and arrays.
 

--- a/test/release/examples/primers/syncsingle.chpl
+++ b/test/release/examples/primers/syncsingle.chpl
@@ -1,5 +1,5 @@
-//
-// Sync and Single Variables Primer
+// Sync / Singles
+
 //
 // This primer illustrates Chapel's sync and single variables.
 //

--- a/test/release/examples/primers/taskParallel.chpl
+++ b/test/release/examples/primers/taskParallel.chpl
@@ -1,5 +1,5 @@
-//
-// Task Parallel Primer
+// Task Parallelism
+
 //
 // This primer illustrates Chapel's parallel tasking features,
 // namely the ``begin``, ``cobegin``, and ``coforall`` statements.

--- a/test/release/examples/primers/timers.chpl
+++ b/test/release/examples/primers/timers.chpl
@@ -1,8 +1,7 @@
+// Timers
+
 /*
-   Timers Primer
-
    This primer demonstrates the use of a Timer from the ``Time`` module.
-
 */
 
 //

--- a/test/release/examples/primers/varargs.chpl
+++ b/test/release/examples/primers/varargs.chpl
@@ -1,9 +1,9 @@
+// Variadic Arguments
+
 /*
-   Varargs Primer
-
    This primer demonstrates procedures with variable length arguments lists.
-
 */
+
 //
 // Procedures can be defined with variable length argument lists. The
 // following procedure accepts integer arguments and defines the

--- a/test/release/examples/primers/variables.chpl
+++ b/test/release/examples/primers/variables.chpl
@@ -1,8 +1,6 @@
+// Variables Primer
 /*
-   Variables Primer
-
    This primer demonstrates variable declaration syntax.
-
 */
 
 

--- a/test/release/examples/primers/variables.chpl
+++ b/test/release/examples/primers/variables.chpl
@@ -1,4 +1,5 @@
-// Variables Primer
+// Variables
+
 /*
    This primer demonstrates variable declaration syntax.
 */


### PR DESCRIPTION
## Bug Fix

* When a `$CHPL_HOME` lived in a symlink, the `--link` option would fail when confirming that the file lives in `$CHPL_HOME`. This occurred sporadically in testing, when `/ptmp` would get swapped for `/var/tmp`. 

* The use of `os.path.realpath()` should resolve this


## Titles for Primers

* Added optional title to `chpl2rst.py`.
    * If the first line is a non-empty line comment, that line-comment will be made the title

For example: 

```chapel
// The Primer
/*
  ...
*/
```

gets rendered to

```
The Primer
==========

...
```

This this is a lot prettier than the file basename titles.

This PR also adds titles to all the primers.