### PR TITLE
Add cast operations to bigint

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -257,66 +257,6 @@ module BigInteger {
       return ret;
     }
 
-    proc get_si() : int {
-      var ret: c_long;
-
-      if _local {
-        ret = mpz_get_si(this.mpz);
-
-      } else if this.localeId == chpl_nodeID {
-        ret = mpz_get_si(this.mpz);
-
-      } else {
-        const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
-
-        on __primitive("chpl_on_locale_num", thisLoc) {
-          ret = mpz_get_si(this.mpz);
-        }
-      }
-
-      return ret.safeCast(int);
-    }
-
-    proc get_ui() : uint {
-      var ret: c_ulong;
-
-      if _local {
-        ret = mpz_get_ui(this.mpz);
-
-      } else if this.localeId == chpl_nodeID {
-        ret = mpz_get_ui(this.mpz);
-
-      } else {
-        const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
-
-        on __primitive("chpl_on_locale_num", thisLoc) {
-          ret = mpz_get_ui(this.mpz);
-        }
-      }
-
-      return ret.safeCast(uint);
-    }
-
-    proc get_d() : real {
-      var ret: c_double;
-
-      if _local {
-        ret = mpz_get_d(this.mpz);
-
-      } else if this.localeId == chpl_nodeID {
-        ret = mpz_get_d(this.mpz);
-
-      } else {
-        const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
-
-        on __primitive("chpl_on_locale_num", thisLoc) {
-          ret = mpz_get_d(this.mpz);
-        }
-      }
-
-      return ret : real;
-    }
-
     proc get_d_2exp() : (uint(32), real) {
       var exp: c_long;
       var dbl: c_double;
@@ -433,6 +373,75 @@ module BigInteger {
     }
 
     return ret;
+  }
+
+  //
+  // Cast operators
+  //
+
+  inline proc _cast(type t, const ref x: bigint) where isIntType(t) {
+    var ret: c_long;
+
+    if _local {
+      ret = mpz_get_si(x.mpz);
+
+    } else if x.localeId == chpl_nodeID {
+        ret = mpz_get_si(x.mpz);
+
+    } else {
+      const xLoc = chpl_buildLocaleID(x.localeId, c_sublocid_any);
+
+      on __primitive("chpl_on_locale_num", xLoc) {
+        ret = mpz_get_si(x.mpz);
+      }
+    }
+
+    return ret.safeCast(int);
+  }
+
+  inline proc _cast(type t, const ref x: bigint) where isUintType(t) {
+    var ret: c_ulong;
+
+    if (mpz_cmp_ui(x.mpz, 0) >= 0) {
+      if _local {
+        ret = mpz_get_ui(x.mpz);
+
+      } else if x.localeId == chpl_nodeID {
+        ret = mpz_get_ui(x.mpz);
+
+      } else {
+        const xLoc = chpl_buildLocaleID(x.localeId, c_sublocid_any);
+
+        on __primitive("chpl_on_locale_num", xLoc) {
+          ret = mpz_get_ui(x.mpz);
+        }
+      }
+
+    } else {
+      halt("unable to convert a negative bigint to a uint(?w)");
+    }
+
+    return ret.safeCast(uint);
+  }
+
+  inline proc _cast(type t, const ref x: bigint) where isRealType(t) {
+    var ret: c_double;
+
+    if _local {
+      ret = mpz_get_d(x.mpz);
+
+    } else if x.localeId == chpl_nodeID {
+      ret = mpz_get_d(x.mpz);
+
+    } else {
+      const xLoc = chpl_buildLocaleID(x.localeId, c_sublocid_any);
+
+      on __primitive("chpl_on_locale_num", xLoc) {
+        ret = mpz_get_d(x.mpz);
+      }
+    }
+
+    return ret : real;
   }
 
   //

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_assignment.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_assignment.chpl
@@ -1,10 +1,10 @@
 use BigInteger;
 
-// tests the assignment functions
-var a = new bigint(0);    // a = 0
-var b = new bigint(2);    // b = 2
+var a = new bigint(0);
+var b = new bigint(2);
 
 writeln(a, " ", b);
+
 a.set(b);
 writeln(a, " ", b);
 
@@ -29,14 +29,12 @@ writeln(a);
 a.swap(b);
 writeln(a, " ", b);
 
-var x = a.get_ui();
+var x = a : uint;
+var y = b : int;
+var z = a : real;
 
 if isUint(x) then writeln("uint ", x);
-
-var y = b.get_si();
-if isInt(y) then writeln("int ", y);
-
-var z = a.get_d();
+if isInt(y)  then writeln("int ",  y);
 if isReal(z) then writeln("real ", z);
 
 a.set(101);

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
@@ -69,7 +69,7 @@ iter genDigits(numDigits) {
     } while tmp2.cmp(denom) >= 0; // tmp2 >= denom
 
     // Compute and yield the digit.
-    const digit = tmp1.get_ui();
+    const digit = tmp1 : uint;
 
     yield digit;
 

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
@@ -76,6 +76,6 @@ iter genDigits(numDigits) {
     tmp2.add(tmp1, accum);
     tmp1.div_q(Round.ZERO, tmp2, denom);
 
-    return tmp1.get_ui();
+    return tmp1 : uint;
   }
 }


### PR DESCRIPTION
The first pass of bigint followed the GMP convention of defining get_ui(), get_si(), get_d().
Brad made the observation that we could replace there with Chapel cast operators.

The PR makes this change and tweaks some tests to match.

Focussed tested: clang/darwin with and without gasnet, gcc/linux64 with and without gasnet,
and finally gcc/linux32 without gasnet
