### PR TITLE
Revise rounding mode for div functions

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -3927,9 +3927,9 @@ module BigInteger {
   }
 
   // 5.6 Division Functions
-  proc bigint.div_q(param     rounding: Round,
-                    const ref n:        bigint,
-                    const ref d:        bigint) {
+  proc bigint.div_q(const ref n: bigint,
+                    const ref d: bigint,
+                    param     rounding = Round.ZERO) {
     if _local {
       select rounding {
         when Round.UP   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
@@ -3962,15 +3962,16 @@ module BigInteger {
     }
   }
 
-  proc bigint.div_q(param     rounding: Round,
-                    const ref n:        bigint,
-                              d:        integral) {
-    this.div_q(rounding, n, new bigint(d));
+  proc bigint.div_q(const ref n: bigint,
+                              d: integral,
+                    param     rounding = Round.ZERO) {
+
+    this.div_q(n, new bigint(d), rounding);
   }
 
-  proc bigint.div_r(param rounding: Round,
-                    const ref n: bigint,
-                    const ref d: bigint) {
+  proc bigint.div_r(const ref n: bigint,
+                    const ref d: bigint,
+                    param     rounding = Round.ZERO) {
     if _local {
       select rounding {
         when Round.UP   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
@@ -4003,17 +4004,17 @@ module BigInteger {
     }
   }
 
-  proc bigint.div_r(param     rounding: Round,
-                    const ref n:        bigint,
-                              d:        integral) {
-    this.div_r(rounding, n, new bigint(d));
+  proc bigint.div_r(const ref n: bigint,
+                              d: integral,
+                    param     rounding = Round.ZERO) {
+    this.div_r(n, new bigint(d), rounding);
   }
 
   // this gets quotient, r gets remainder
-  proc bigint.div_qr(param     rounding: Round,
-                     ref       r:        bigint,
+  proc bigint.div_qr(ref       r:        bigint,
                      const ref n:        bigint,
-                     const ref d:        bigint) {
+                     const ref d:        bigint,
+                     param     rounding = Round.ZERO) {
     if _local {
       select rounding {
         when Round.UP   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
@@ -4050,16 +4051,16 @@ module BigInteger {
     }
   }
 
-  proc bigint.div_qr(param     rounding: Round,
-                     ref       r:        bigint,
-                     const ref n:        bigint,
-                               d:        integral) {
-    this.div_qr(rounding, r, n, new bigint(d));
+  proc bigint.div_qr(ref       r: bigint,
+                     const ref n: bigint,
+                               d: integral,
+                     param     rounding = Round.ZERO) {
+    this.div_qr(r, n, new bigint(d), rounding);
   }
 
-  proc bigint.div_q_2exp(param rounding: Round,
-                         const ref n: bigint,
-                         b: integral) {
+  proc bigint.div_q_2exp(const ref n: bigint,
+                                   b: integral,
+                         param     rounding = Round.ZERO) {
     const b_ = b.safeCast(mp_bitcnt_t);
 
     if _local {
@@ -4092,9 +4093,9 @@ module BigInteger {
     }
   }
 
-  proc bigint.div_r_2exp(param rounding: Round,
-                         const ref n: bigint,
-                         b: integral) {
+  proc bigint.div_r_2exp(const ref n: bigint,
+                                   b: integral,
+                         param     rounding = Round.ZERO) {
     const b_ = b.safeCast(mp_bitcnt_t);
 
     if _local {

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_arithmetic.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_arithmetic.chpl
@@ -32,7 +32,7 @@ writeln(a);
 a.mul_2exp(c, 3);                    // a = -1600
 writeln(a);
 
-a.div_q_2exp(Round.ZERO, a, 3);      //a =   -200
+a.div_q_2exp(a, 3);                  //a =   -200
 writeln(a);
 
 a.neg(b);                            // a =    -2

--- a/test/modules/standard/gmp/ldelaney/gmp_Bigint_division.chpl
+++ b/test/modules/standard/gmp/ldelaney/gmp_Bigint_division.chpl
@@ -6,51 +6,51 @@ var b = new bigint( 10);
 var c = new bigint(-27);
 var d = new bigint();
 
-d.div_q(Round.UP, c, a);
-b.div_r(Round.UP, c, a);
+d.div_q(c, a, Round.UP);
+b.div_r(c, a, Round.UP);
 writeln(d, " ", b);
 
-d.div_q(Round.DOWN, c, a);
-b.div_r(Round.DOWN, c, a);
+d.div_q(c, a, Round.DOWN);
+b.div_r(c, a, Round.DOWN);
 writeln(d, " ", b);
 
-d.div_q(Round.ZERO, c, a); // same as UP   for negative integers
-b.div_r(Round.ZERO, c, a); // same as DOWN for positive integers
+d.div_q(c, a, Round.ZERO); // same as UP   for negative integers
+b.div_r(c, a, Round.ZERO); // same as DOWN for positive integers
 writeln(d, " ", b);
 
 c.neg(c);
-d.div_qr(Round.UP, b, c, a);
+d.div_qr(b, c, a, Round.UP);
 writeln(d, " ", b);
 
-d.div_qr(Round.DOWN, b, c, a);
+d.div_qr(b, c, a, Round.DOWN);
 writeln(d, " ", b);
 
-d.div_qr(Round.ZERO, b, c, a); // same as DOWN for positive integers
+d.div_qr(b, c, a, Round.ZERO); // same as DOWN for positive integers
 writeln(d, " ", b);
 
 writeln();
 
 c.neg(c);
-d.div_q(Round.UP, c, 8);
-b.div_r(Round.UP, c, 8);
+d.div_q(c, 8, Round.UP);
+b.div_r(c, 8, Round.UP);
 writeln(d, " ", b);
 
-d.div_q(Round.DOWN, c, 8);
-b.div_r(Round.DOWN, c, 8);
+d.div_q(c, 8, Round.DOWN);
+b.div_r(c, 8, Round.DOWN);
 writeln(d, " ", b);
 
-d.div_q(Round.ZERO, c, 8); // same as DOWN for positive integers
-b.div_r(Round.ZERO, c, 8); // same as DOWN for positive integers
+d.div_q(c, 8, Round.ZERO); // same as DOWN for positive integers
+b.div_r(c, 8, Round.ZERO); // same as DOWN for positive integers
 writeln(d, " ", b);
 
 c.neg(c);
-d.div_qr(Round.UP, b, c, 8);
+d.div_qr(b, c, 8, Round.UP);
 writeln(d, " ", b);
 
-d.div_qr(Round.DOWN, b, c, 8);
+d.div_qr(b, c, 8, Round.DOWN);
 writeln(d, " ", b);
 
-d.div_qr(Round.ZERO, b, c, 8); // same as DOWN for positive integers
+d.div_qr(b, c, 8, Round.ZERO); // same as DOWN for positive integers
 writeln(d, " ", b);
 
 c.neg(c);
@@ -58,16 +58,16 @@ writeln();
 
 
 // q = (n / 2^d)
-d.div_q_2exp(Round.UP, c, 3);
-b.div_r_2exp(Round.UP, c, 3);
+d.div_q_2exp(c, 3, Round.UP);
+b.div_r_2exp(c, 3, Round.UP);
 writeln(d, " ", b);
 
-d.div_q_2exp(Round.DOWN, c, 3);
-b.div_r_2exp(Round.DOWN, c, 3);
+d.div_q_2exp(c, 3, Round.DOWN);
+b.div_r_2exp(c, 3, Round.DOWN);
 writeln(d, " ", b);
 
-d.div_q_2exp(Round.ZERO, c, 3);
-b.div_r_2exp(Round.ZERO, c, 3);
+d.div_q_2exp(c, 3, Round.ZERO);
+b.div_r_2exp(c, 3, Round.ZERO);
 writeln(d, " ", b);
 
 writeln();

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
@@ -61,7 +61,7 @@ iter genDigits(numDigits) {
 
       // tmp1 = tmp1 / denom; tmp2 = tmp1 % denom
       // tmp1 gets quotient, tmp2 gets remainder
-      tmp1.div_qr(Round.DOWN, tmp2, tmp1, denom);
+      tmp1.div_qr(tmp2, tmp1, denom, Round.DOWN);
 
       // Now, if:
       //   (numer * 3 + accum) % denom + numer == (numer * 4 + accum) + numer

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
@@ -74,7 +74,7 @@ iter genDigits(numDigits) {
   proc extractDigit(nth: uint) {
     tmp1.mul(numer, nth);
     tmp2.add(tmp1, accum);
-    tmp1.div_q(Round.ZERO, tmp2, denom);
+    tmp1.div_q(tmp2, denom);
 
     return tmp1 : uint;
   }


### PR DESCRIPTION
Brad observed that it would be better to define (for example)

proc bigint.div_q(param     rounding: Round,
                             const ref n:        bigint,
                             const ref d:        bigint) {
...

}

to

proc bigint.div_q(const ref n:        bigint,
                             const ref d:        bigint,
                             param     rounding = Round.Zero) {
...
}


This PR does this for every case and updates the tests accordingly.

Focussed bigint testing

clang/darwin with and without gasnet
gcc/linux64 with and without gasnet
gcc/linux32 without gasnet
