### PR TITLE
More consistent indentation rules for primer docs

### DIFF
--- a/doc/sphinx/chpl2rst.py
+++ b/doc/sphinx/chpl2rst.py
@@ -187,21 +187,25 @@ def gen_rst(handle):
                 rstline = rstline.replace('//', '  ')
                 rstline = rstline.strip()
             else:
-                # Preserve white space for block comments
+                # Preserve white space for block comments, for indent purposes
                 if commentstarts:
                     rstline = rstline.replace('/*', '  ')
                 if commentends > 0:
                     rstline = rstline.replace('*/', '  ')
-                if '.. code-block::' in rstline or len(rstline.strip()) == 0:
-                    rstline = rstline.strip()
+                # No need for trailing white space... ever
+                rstline = rstline.rstrip(' ')
 
-            # Strip indentation
+            # Handle indentation
             if indentation == -1:
-                lineindentation = len(rstline) - len(rstline.lstrip(' '))
-                if lineindentation > 0:
-                    indentation = lineindentation
+                # Detect level of indentation (number of leading whitespaces)
+                baseline = len(rstline) - len(rstline.lstrip(' '))
+                if baseline > 0:
+                    # Set indentation for the proceeding block
+                    indentation = baseline
+                    # Set indentation for baseline to 0
                     rstline = rstline.lstrip(' ')
             else:
+                # Remove the amount of indent that was removed from baseline
                 if rstline.startswith(' '*indentation):
                     rstline = rstline[indentation:]
                 else:
@@ -209,7 +213,7 @@ def gen_rst(handle):
 
             output.append(rstline)
         else:
-            # Reset indentation
+            # Reset indentation as we enter codeblock state
             indentation = -1
 
             # Write code block


### PR DESCRIPTION
Before this script had indentation logic, it just stripped any line with `.. code-block` in it.

This is problematic when combined with the new indentation logic, as the code-block's indentation will not be detected since it was stripped. 

Basically the following comment would be converted incorrectly:

```chapel

/*
.. code-block:: chapel

    writeln('this line's indentation gets stripped away')
*/
```

This PR removes the old 'strip all code-block lines' approach, to resolve the bug.

It also right-strips all trailing white space from lines with `/*` and `*/` to avoid mis-identifying the replaced spaces as indentation.

I've also added some better comments

*Note:* One remaining known issue is that there is currently no way to display the characters `/*` or `*/` in a primer. This is problematic for primers that try to demonstrate the commenting syntax