### PR TITLE
Support emacs/24 as we do emacs/22 and emacs/23

### DIFF
--- a/highlight/emacs/24/chpl-mode.el
+++ b/highlight/emacs/24/chpl-mode.el
@@ -1,0 +1,1 @@
+../chpl-mode.el


### PR DESCRIPTION
I have a local edit that does this, but can't recall why I never committed it.  Maybe because we updated the emacs/README to stop including the major version number in the path it searched?