### PR TITLE
Update STATUS.devel

### DIFF
--- a/STATUS.devel
+++ b/STATUS.devel
@@ -37,6 +37,9 @@ run into.
 # OMITTED: users/vass/crash1callDestructorsMain.future
 #  b/c not investigated
 #
+# OMITTED: distributions/vass/negative-ref-count-dmap.future
+#  b/c it is a low-level implementation detail
+#
 # OMITTED: users/csep524/userDefReduceSlim.future
 #  b/c multiple errors in the user code and hard to quantify what is wrong
 #
@@ -52,6 +55,7 @@ General (see also portability section at the bottom of this file)
   # sparse/bradc/accumInds-forexpr.future
   # functions/vass/resolution/need-missing-return-error-2.future
   # types/scalar/bradc/index-int.future
+  # users/rohanbadlani/bugs/bug1.future
 - Compiler and runtime and errors may report incorrect line numbers,
   may not be formatted correctly, or may be garbled.  If needed,
   please ask us for help finding the line in question.
@@ -67,9 +71,11 @@ General (see also portability section at the bottom of this file)
     distributions) are leaked
   - Non-default domain maps may be leaked
   - Data associated with iterators may be leaked
+  - Records with generic fields may be leaked
   # types/records/ferguson/leak-futures/iterate-loop-break.future
   # types/records/ferguson/leak-futures/iterate-loop-break2.future
   # types/records/ferguson/leak-futures/iterate-twice-break.future
+  # types/records/ferguson/leak-futures/record-in-record-generic.future
 - Separate compilation of Chapel files is not supported.
   # separate_compilation/jturner/array.future
   # separate_compilation/jturner/use_array.future
@@ -116,13 +122,19 @@ Types, Params, Variables, and Consts
 - When setting a boolean config variable on the command line, using a
   space as the delimiter results in an "Unexpected flag" error.
   # execflags/thomasvandoren/configVarBooleanSpaceAfter.future
+- When setting an integral config variable on the command line, only
+  base 10 values are supported.
+  # execflags/tmacd/config_num.future
 - Some assignments to ref variables can cause an internal compiler error.
   # variables/sungeun/refvar-assign-with-cast.future
   # variables/vass/ref-to-const-domain.future
+- Taking a reference of an array formal argument causes a const checking error.
+  # arrays/bradc/refArray2.future
 - Variables that rely on each other for initialization
   and/or type inference may result in an internal compiler error.
   # functions/deitz/test_outoforder.future
 - Constant checking is incomplete.
+  # arrays/bradc/refArray3.future
   # domains/bradc/assignConstDom2.future
   # domains/bradc/assignConstDom.future
   # types/records/const-checking/todo-multiple-asgn-errors.future
@@ -156,7 +168,8 @@ Conversions
   # expressions/vass/cast-to-non-type-2.future
 - Integer to c_string cast promotes from int to real before cast is performed
   # types/string/thomasvandoren/int-to-c_string.future
-
+- Casting from string to uint(32) clips result to 31 bits on 32 bit platforms
+  # types/string/cassella/cast-biggish-uint32-through-string.future
 
 Statements and Expressions
 --------------------------
@@ -229,10 +242,14 @@ Functions and Iterators
   compiler error or compile and run.
   # functions/deitz/test_arg_type_is_value_error.future
   # functions/vass/return-type-function-failure.future
+- Formal arguments that depend on preceeding vararg arguments fail to compile
+  # functions/nspark/generic-varargs2.future
 - Array-of-array formal argument declarations do not work.
   # arrays/bradc/arrayOfArrayArg.future
 - Arrays returned from a ref function result in memory corruption.
   # arrays/vass/setter-assigned-to-a-var.future
+- Returning arrays from getter/setter functions always uses the setter version
+  # functions/bharshbarg/arr-ref-return.future
 - Function argument with type tuple of generic class results in a
   compiler assertion.
   # functions/diten/fnGenericTupleArg.future
@@ -260,6 +277,12 @@ Functions and Iterators
   # functions/diten/varFnRetClasses2.future
 - Ref functions that return local data may not result in an error.
   # functions/deitz/test_var_function_returns_local_via_var_function.future
+- Ref functions that return fields from a record argument passed by
+  blank intent may produce incorrect results.
+  # optimizations/copyPropagation/cp-problem1.future
+- Blank argument intent should be const ref for records, not make a copy
+  # functions/ferguson/record-const-ref-default.future
+  # functions/ferguson/record-const-ref-default-inline.future
 - Type functions with unambiguous return paths may result in "illegal
   cast" errors.
   # users/weili/typefnbug.future
@@ -283,6 +306,8 @@ Functions and Iterators
   # statements/elliot/loops/modifyIndicesStandalone.future
 - Ref iterators yielding records may introduce uninitialized values
   # types/records/ferguson/parallel/coforall-mod/coforall-mod.future
+- Passing unexpected argument to default 'these' iterator causes internal error
+  # users/rohanbadlani/bugs/bug3.future
 - The (deprecated) implicit 'setter' argument does not work in ref iterators.
   # functions/deitz/iterators/iterator_uses_setter.future
   # functions/deitz/iterators/test_promote_var_function_and_iterate.future
@@ -411,10 +436,13 @@ Classes, Records, and Unions
   # classes/figueroa/DestructorSubclassing3.future
 - Records returned from functions are destructed incorrectly.
   # types/records/kbrady/return-record.future
-- User-defined constructors and destructors are not robust.
+- User-defined initializers/constructors and destructors are not robust.
   # users/murai/test_nested_class_constructor.future
   # classes/bradc/initialize-secondary.future
   # classes/vass/nested-class-with-user-defined-constructor-1.future
+  # classes/initializers/nested-class-with-user-defined-initializer-1.future
+  # classes/initializers/noReturnInInit.future
+  # classes/initializers/assign-param-segfault.future
 - Copy constructors are not properly implemented.
   # types/records/sungeun/constructor2.future
   # users/vass/km/array-of-records-crash-1.explicit-type.future
@@ -442,12 +470,13 @@ Classes, Records, and Unions
   compile time error.
   # classes/vass/jglewis-class-in-function.future
   # users/ferguson/record-in-iterator.future
-- Non-sync arguments to default constructors that expect sync vars are
-  not properly coerced to sync type.
+  # users/ferguson/inner-record-generic.future
+- Non-sync arguments to default initializers/constructors that expect
+  sync vars are not properly coerced to sync type.
   # classes/hannah/coercingIntToSyncIntOnConstructor.future
+  # classes/initializers/coercingIntToSyncIntOnInitializer.future
 - Assigning to param class members from constructors may fail to compile
   # classes/constructors/assign-param-segfault.future
-- Subclassing uninstantiated generic classes should be prohibited but is not.
 - Implicit casting of record parameters not implemented.
   # users/ferguson/recordEquivalence.future
 - Array alias arguments to constructors fail to compile.
@@ -465,10 +494,14 @@ Classes, Records, and Unions
   # types/records/vass/method-of-parent-record-1.future
 - Nested classes and records can result in multiple destructor calls
   # classes/constructors/nested-destructor.future
+  # classes/initializers/nested-destructor.future
 - Nested record inheritance results in a compilation error.
   # types/records/vass/nested-record-with-outer-1.future
 - Nested record constructor should not need an explicit generic outer
   # users/bguarraci/nested_record.future
+- Nested records as fields in outer classes/records is not robust
+  # types/records/engin/fieldOfOuter.future
+  # types/records/engin/nestedRecordField.future
 - Unused records defined in procedures result in an internal compiler error.
   # types/records/vass/unused-decl-in-proc-1.future
   # types/records/vass/unused-decl-in-proc-2.future
@@ -498,12 +531,17 @@ Classes, Records, and Unions
   # types/records/bharshbarger/recordArrCmp.future
   # types/records/bharshbarger/recordDomArrCmp.future
 - There's no way to determine which field of a union is "active".
+- Setting union field from constructor doesn't work
+  # classes/diten/constructUnion.future
 
 
 Domain Maps, Domains and Arrays
 -------------------------------
 - Reference counting (used for memory management of domain maps,
   domains, and arrays) may contain bugs.
+  # arrays/bradc/refArray1.future
+  # arrays/diten/replaceArrayAccess/arrayAlias.future
+  # arrays/diten/replaceArrayAccess/arrayAlias2.future
   # arrays/ferguson/choose-array/choose-array2.future
   # arrays/ferguson/choose-array/choose-array10.future
   # distributions/vass/dmap-var-decl.future
@@ -513,6 +551,9 @@ Domain Maps, Domains and Arrays
   # distributions/bradc/layoutEquality.future
 - Distributed domain maps are currently only supported for dense,
   rectangular domains.
+- Assignment from a distributed domain to a non-distributed domain causes
+  a runtime error.
+  # distributions/kushal/assignDomain.future
 - Assignment to domain maps with declared domains not supported for
   all domain map types.
   # distributions/deitz/test_distribution_syntax2.future
@@ -551,6 +592,11 @@ Domain Maps, Domains and Arrays
 - Sparse domain/array slicing is not supported.
   # arrays/stonea/sliceSparseSubdomain.future
   # sparse/bradc/sliceWithDense.future
+- Sparse arrays of arrays can halt when reading values that were not added
+  # functions/bharshbarg/sparse-ref-return.future
+- Associative arrays of arrays can add new array elements by reading
+  empty positions
+  # functions/bharshbarg/assoc-ref-return.future
 - Associative domain/array slicing is not supported.
   # users/ferguson/assoc-slice.future
 - Associative domain clear() does not reset values of arrays declared
@@ -576,6 +622,9 @@ Domain Maps, Domains and Arrays
 Task Parallelism and Synchronization
 ------------------------------------
 - Atomic statements are not implemented.
+- Remove value forwarding does not respect the memory order imposed by
+  atomic variables.
+  # parallel/begin/deitz/test_begin_cobegin1_atomic.future
 - Deadlock may occur due to an insufficient number of threads.
   # multilocale/deitz/needMultiLocales/test_big_recursive_on.future
   # multilocale/deitz/needMultiLocales/test_big_recursive_on_begin.future
@@ -584,6 +633,8 @@ Task Parallelism and Synchronization
   # memory/deitz/test_tricky_heap_case.future
 - Sync variables cannot be used in conditional expressions
   # types/sync/vass/if-sync-int.future
+- Semantics of sync class types are not clearly defined
+  # parallel/sync/waynew/class3.future
 - Default 'const ref' task intent for record does not prevent updates to sync
   variable field in the record from within task.
   # parallel/sync/waynew/record2.future
@@ -646,6 +697,8 @@ Data Parallelism
   # parallel/forall/in-intents/both-arr-dom-const-var.future
   # parallel/forall/in-intents/both-arr-dom-var-const.future
   # parallel/forall/in-intents/domain-var-var.future
+- Default forall intent for records results in extra record copies
+  # parallel/forall/vass/default-intent-record-with-int-field.future
 - Iterating over a range where bound+stride overflows the index type
   results in runtime halt
   # users/bguarraci/for_byte.future
@@ -705,6 +758,10 @@ Optimizations
 -------------
 # OMITTED: optimizations/rafa/rankChange.future
 #  b/c workaround put in place
+# OMITTED: arrays/diten/replaceArrayAccess/aliasThroughArgs2.future
+# OMITTED: arrays/diten/replaceArrayAccess/modifyInAnotherTask2.future
+# OMITTED: arrays/diten/replaceArrayAccess/wholeArrayAssignInLoop.future
+#  b/c this optimization is still in "experimental" phase
 - Disabling inlining may cause incorrect code to be generated.
   # SEE NIGHTLY BASELINE TESTING NOTES
   # functions/deitz/nested/test_nested_var_iterator3.future
@@ -813,9 +870,19 @@ Developer
 LLVM (experimental)
 -------------------
 
+
 Multi-locale/GASNet executions
 ------------------------------
 - stdin does not work for multi-locale/GASNet executions
+
+
+Incremental compilation (experimental)
+--------------------------------------
+- Incremental compilation support is not enabled for LLVM
+  # compflags/kushal/llvm-incremental.future
+- Cannot include C header files that define symbols with
+  incremental compilation enabled
+  # extern/kushal/extern-includes.future
 
 
 Portability

--- a/STATUS.devel
+++ b/STATUS.devel
@@ -45,6 +45,11 @@ run into.
 #
 # OMITTED: users/npadmana/fftw/testFFTWsegfault.future
 # b/c not investigated or diagnosed
+#
+# OMITTED: functions/deitz/iterators/iterator_uses_setter.future
+# b/c 'setter' has been removed from the language and it's unclear if this test
+# can be updated
+#
 
 General (see also portability section at the bottom of this file)
 -----------------------------------------------------------------
@@ -308,12 +313,10 @@ Functions and Iterators
   # types/records/ferguson/parallel/coforall-mod/coforall-mod.future
 - Passing unexpected argument to default 'these' iterator causes internal error
   # users/rohanbadlani/bugs/bug3.future
-- The (deprecated) implicit 'setter' argument does not work in ref iterators.
-  # functions/deitz/iterators/iterator_uses_setter.future
-  # functions/deitz/iterators/test_promote_var_function_and_iterate.future
-- The (deprecated) implicit 'setter' argument passed to other functions may
-  be incorrect.
+- The ref version of a ref/val function pair is sometimes chosen when the val
+  version would be better.
   # functions/vass/setter-passed-to-another-fun.future
+  # functions/deitz/iterators/test_promote_var_function_and_iterate.future
 - A forall loop with an iteratable expression that does not provide
   leader/follower iterators cause an internal compiler error.
   # functions/iterators/vass/forall-without-leaderfollower.future
@@ -549,8 +552,6 @@ Domain Maps, Domains and Arrays
   # studies/hpcc/HPL/vass/bug.future
 - The default domain map is currently a single type for all default domains
   # distributions/bradc/layoutEquality.future
-- Distributed domain maps are currently only supported for dense,
-  rectangular domains.
 - Assignment from a distributed domain to a non-distributed domain causes
   a runtime error.
   # distributions/kushal/assignDomain.future

--- a/STATUS.devel
+++ b/STATUS.devel
@@ -156,8 +156,6 @@ Conversions
   # expressions/vass/cast-to-non-type-2.future
 - Integer to c_string cast promotes from int to real before cast is performed
   # types/string/thomasvandoren/int-to-c_string.future
-- Cast from string to scalar type does not ignore leading white space
-  # users/ferguson/cast_to_int_ignore_whitespace.future
 
 
 Statements and Expressions
@@ -178,8 +176,6 @@ Statements and Expressions
   # users/jglewis/locClassSegFault.future
 - Nested for expressions can cause runtime failure
   # expressions/diten/forExprs.future
-- Index variable in for expression can interfere with outer var by same name
-  # users/bguarraci/comprehension.future
 - Using domain extraction syntax inside a variable declaration causes
   compiler failure instead of a clean error
   # users/bguarraci/domain_extraction.future
@@ -439,9 +435,6 @@ Classes, Records, and Unions
   # arrays/deitz/part5/test_array_type_field_type.future 
   # classes/diten/type_order_problem.future
   # types/records/bharshbarger/nestedRecordInClass2.future
-- Cannot call 'new' on type variables for classes and records
-  # types/typedefs/tzakian/classConstructorsFromTypes.future
-  # types/typedefs/lydia/new-on-returned-type-alias.future
 - Ambiguous definitions of class methods that are overridden in a
   subclass result in an internal compiler error.
   # classes/vass/duplicate-virtual-method-error-2.future
@@ -483,11 +476,6 @@ Classes, Records, and Unions
   compiler error.
   # types/records/sungeun/recursiveRecord.future
   # arrays/dinan/array_of_records.future
-- Remote records have wide members shallow-copied.  Array members may
-  not share the same locale as the containing record violating the
-  intended semantics of array copying.
-  # types/records/bharshbarger/remoteBlankRecord.future
-  # types/records/bharshbarger/remoteInRecord.future
 - Classes arguments passed to out, inout, and ref intent formals
   result in a compiler internal error.
   # classes/vass/ref-like-intents/inout-subclass.future
@@ -636,7 +624,6 @@ Data Parallelism
   # arrays/sungeun/array_of_arrays/bxor_reduce.future
   # arrays/sungeun/array_of_arrays/max_reduce.future
   # arrays/sungeun/array_of_arrays/sum_reduce.future
-  # trivial/sidelnik/reduction.future
   # studies/shootout/nbody/sidelnik/nbody_fullreduction.future
 - Reduction type definitions nested in classes or records cannot be
   used directly outside of enclosing class or record's scope.
@@ -779,10 +766,6 @@ Miscellaneous
   # types/tuple/stonea/returnArrayTuple.future
 - Indexing string literals results in a parse error
   # types/string/sungeun/c_string/substr.future
-- The --minimal-modules feature has been disabled because strings are
-  required, but are records in the standard modules.
-  # compflags/bradc/minimalModules/minModDeclPrint.future
-  # compflags/bradc/minimalModules/minModFnRefArg.future
 - Getting the locale-id of variable in local-on statement can be incorrect.
   # optimizations/localon/bad-id.future
 
@@ -805,9 +788,6 @@ chpldoc
 - chpldoc comments that are not closed with using the specified
   comment style are not detected.
   # chpldoc/compflags/comment/badClose.doc.future
-- chpldoc generates documentation for some symbols that should not be
-  documented
-  # chpldoc/basics/main.doc.future
 - chpldoc is incorrect or incomplete for some types
   # chpldoc/enum/docConstants.doc.future
 

--- a/test/classes/initializers/assign-param-segfault.future
+++ b/test/classes/initializers/assign-param-segfault.future
@@ -1,3 +1,8 @@
+unimplemented feature: new initializers on generic classes not supported
+
+Once they are supported, it is likely this will turn back into:
+
+---
 bug: assigning param member causes segfault
 
 For some reason, assigning the param 'foo' member in its initializer

--- a/test/classes/initializers/coercingIntToSyncIntOnInitializer.chpl
+++ b/test/classes/initializers/coercingIntToSyncIntOnInitializer.chpl
@@ -7,8 +7,8 @@ class Foo {
 
 proc main() {
 	var foo1 : Foo = new Foo(1);
-	writeln("a = ", foo1.x);
+	writeln("a = ", foo1.x$);
 
 	var foo2 : Foo = new Foo(x$=2);
-	writeln("b = ", foo2.x);
+	writeln("b = ", foo2.x$);
 }

--- a/test/compflags/kushal/llvm-incremental.future
+++ b/test/compflags/kushal/llvm-incremental.future
@@ -1,3 +1,3 @@
-bug : Missing support for incremental compilation for llvm
+bug: Missing support for incremental compilation for llvm
 
 Currently incremental compilation feature has not been implemented for llvm.

--- a/test/domains/diten/domainReassignChangeStridedness.future
+++ b/test/domains/diten/domainReassignChangeStridedness.future
@@ -1,5 +1,0 @@
-bug: domain assignment that changes stridedness causes runtime crash
-
-I think this should be a compiler error similar to domain assignments that
-change rank or idxType. Assignments that change rank and idxType are commented
-out in this test as an example.

--- a/test/domains/diten/domainReassignChangeStridedness.good
+++ b/test/domains/diten/domainReassignChangeStridedness.good
@@ -1,1 +1,1 @@
-domainReassignChangeStridedness.chpl:8: error: stridable mismatch in domain assignment
+domains/diten/domainReassignChangeStridedness.chpl:8: error: cannot assign from a stridable domain to an unstridable domain without an explicit cast

--- a/test/domains/diten/domainReassignChangeStridedness.good
+++ b/test/domains/diten/domainReassignChangeStridedness.good
@@ -1,1 +1,1 @@
-domains/diten/domainReassignChangeStridedness.chpl:8: error: cannot assign from a stridable domain to an unstridable domain without an explicit cast
+domainReassignChangeStridedness.chpl:8: error: cannot assign from a stridable domain to an unstridable domain without an explicit cast

--- a/test/execflags/tmacd/config_ref.future
+++ b/test/execflags/tmacd/config_ref.future
@@ -1,6 +1,4 @@
-'''
 error message: 'config ref' declarations should be a compile time error
 
 The second declaration in this test should be a compile time error, possibly
 a syntax error.
-'''

--- a/test/functions/deitz/iterators/test_promote_var_function_and_iterate.chpl
+++ b/test/functions/deitz/iterators/test_promote_var_function_and_iterate.chpl
@@ -1,9 +1,11 @@
 var A: [1..3] int;
 
 proc foo(i: int) ref {
-  if (setter) {
-    writeln("foo called in setter context");
-  }
+  writeln("foo called in setter context");
+  return A(i);
+}
+
+proc foo(i: int) {
   return A(i);
 }
 
@@ -15,31 +17,31 @@ for i in foo(1..3) {
   i = 1;
 }
 
-for t in (foo(1..3), 1..3) {
+for t in zip(foo(1..3), 1..3) {
   writeln(t);
 }
 
-for t in (foo(1..3), 1..3) {
+for t in zip(foo(1..3), 1..3) {
   t(1) = t(1) + 1;
   writeln(t);
 }
 
-proc iter() ref {
+iter iterate() ref {
   for j in foo(1..3) {
     yield j;
   }
 }
 
-for i in iter() {
+for i in iterate() {
   writeln(i);
 }
 
-for i in iter() {
+for i in iterate() {
   i = i + 1;
   writeln(i);
 }
 
-proc iter2() ref {
+iter iter2() ref {
   for i in 1..3 {
     yield foo(i);
   }

--- a/test/users/rohanbadlani/bugs/bug2.future
+++ b/test/users/rohanbadlani/bugs/bug2.future
@@ -1,4 +1,4 @@
-bug: The List Module does not support accessing elements of a list based on index. I feel that this should be supported.
+feature request: The List Module does not support accessing elements of a list based on index. I feel that this should be supported.
 
 Explainations:
 


### PR DESCRIPTION
Remove fixed .futures from STATUS, categorized and added new futures to STATUS.

Fixed some .futures that were miscategorized.  Fix up some outdated .futures.

There were:
  2 Uncategorized futures
  37 Futures missing from the STATUS file
  10 Additional futures in the STATUS file
  0 Duplicates futures in the STATUS file