### PR TITLE
Switch studies versions of pidigits to use the high-precision timer

### DIFF
--- a/test/studies/shootout/pidigits/bradc/PERFTIMEEXEC
+++ b/test/studies/shootout/pidigits/bradc/PERFTIMEEXEC
@@ -1,2 +1,1 @@
 highPrecisionTimer
-

--- a/test/studies/shootout/pidigits/bradc/PERFTIMEEXEC
+++ b/test/studies/shootout/pidigits/bradc/PERFTIMEEXEC
@@ -1,1 +1,2 @@
-defaultTimer
+highPrecisionTimer
+

--- a/test/studies/shootout/pidigits/thomasvandoren/PERFTIMEEXEC
+++ b/test/studies/shootout/pidigits/thomasvandoren/PERFTIMEEXEC
@@ -1,1 +1,1 @@
-defaultTimer
+highPrecisionTimer


### PR DESCRIPTION
Without this, it looked like the studies versions were unnaturally
stable and faster than the release versions.