### PR TITLE
New blc study version of pidigits

### DIFF
--- a/test/studies/shootout/pidigits/bradc/pidigits-blc.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-blc.chpl
@@ -1,105 +1,85 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org
 
-   contributed by Tom Hildebrandt, Brad Chamberlain, Lydia Duncan
-   derived from the GNU C version by Bonzini, Bartlett, and Mellor
+   contributed by Tom Hildebrandt, Brad Chamberlain, and Lydia Duncan
+   derived from the GNU C version by Mr Ledrug
 */
 
-use GMP;
+use BigInteger;
 
-config const n = 50;                // Compute n digits of Pi, 50 by default
-
-var numer, accum, denom, tmp1, tmp2: mpz_t;
-//
-// TODO: would be nice to support initialization rules for external types
-// and then to implement overloads to support these cases more directly
-//
-mpz_init_set_ui(numer, 1);                 // numer = 1
-mpz_init_set_ui(accum, 0);                 // accum = 0
-mpz_init_set_ui(denom, 1);                 // denom = 1
-mpz_init(tmp1);                            // init tmp1
-mpz_init(tmp2);                            // init tmp2
-
+config const n = 50;         // Compute n digits of pi, 50 by default
 
 proc main() {
-  var k: c_ulong;
-  // This needs to be a c_ulong for portability to 32 bit systems.
-  // TODO: make our GMP methods accept uints, ints, etc. of various sizes so
-  // that the user doesn't need to know C types?
-
   param digitsPerLine = 10;
 
   //
-  // extract and print n digits
+  // Generate n digits, printing them in groups of digitsPerLine
   //
-  for i in 1..n {
-    const d = next_digit(k);
+  for (d,i) in zip(gen_digits(n), 1..) {
     write(d);
-    eliminate_digit(d);
-
-    if i % 10 == 0 then
+    if i % digitsPerLine == 0 then
       writeln("\t:", i);
   }
 
   //
   // Pad out any trailing digits for the final line
   //
-  const leftover = n%digitsPerLine;
+  const leftover = n % digitsPerLine;
   if (leftover) {
     for leftover..digitsPerLine do
       write(" ");
     writeln("\t:", n);
   }
-
-  //
-  // Free memory associated with multi-precision values
-  //
-  mpz_clear(tmp2);
-  mpz_clear(tmp1);
-  mpz_clear(denom);
-  mpz_clear(accum);
-  mpz_clear(numer);
 }
 
 
-proc next_digit(inout k) {
-  do {
+iter gen_digits(numDigits) {
+  var numer, denom: bigint = 1,
+      accum: bigint;
+
+  var d, k = 0;
+  for i in 1..numDigits {
     do {
-      k += 1;
-      const y2 = 2 * k + 1;
+      do {
+        k += 1;
+        const k2 = 2 * k + 1;
 
-      mpz_mul_2exp(tmp1, numer, 1);        // tmp1  = numer * 2
-      mpz_add(accum, accum, tmp1);         // accum += numer * 2
-      mpz_mul_ui(accum, accum, y2);        // accum *= (2k+1)
-      mpz_mul_ui(numer, numer, k);         // numer *= k
-      mpz_mul_ui(denom, denom, y2);        // denom *= (2k+1)
-    } while (mpz_cmp(numer, accum) > 0);   // while numer > accum
+        //
+        // Compute the next term
+        //
+        accum.addmul(numer, 2);
+        accum *= k2;
+        denom *= k2;
+        numer *= k;
+
+        //
+        // Continue looping until the digit is ready
+        //
+      } while (numer > accum);
+
+      d = extract_digit(3);
+    } while (d != extract_digit(4));       // while the 3rd digit != the 4th
+
+    yield d;                               // once it differs, yield it
 
     //
-    // Compute (numer * 3 + accum)
+    // eliminate digit d
     //
-    mpz_mul_2exp(tmp1, numer, 1);          // tmp1 = numer * 2
-    mpz_add(tmp1, tmp1, numer);            // tmp1 += numer
-    mpz_add(tmp1, tmp1, accum);            // tmp1 += accum
+    accum.submul(denom, d);
+    accum *= 10;
+    numer *= 10;
+  }
 
-    //
-    // tmp1 = tmp1 / denom; tmp2 = tmp1 % denom
-    //
-    mpz_fdiv_qr(tmp1, tmp2, tmp1, denom);
+  //
+  // Helper function to extract the nth digit
+  //
+  proc extract_digit(nth) {
+    var tmp: bigint;
 
-    //
-    // Now, if (numer * 3 + accum) % denom + numer
-    // == (numer * 4 + accum) % denom
-    //
-    mpz_add(tmp2, tmp2, numer);
-  } while (mpz_cmp(tmp2, denom) >= 0);     // while tmp2 >= denom
+    tmp.mul(numer, nth);
+    tmp += accum;
+    tmp /= denom;
 
-  return mpz_get_ui(tmp1);                 // return least significant digit
-}
-
-
-proc eliminate_digit(d) {
-  mpz_submul_ui(accum, denom, d);           // accum = (accum - denom) * d
-  mpz_mul_ui(accum, accum, 10);             // accum *= 10
-  mpz_mul_ui(numer, numer, 10);             // numer *= 10
+    return tmp: int;
+  }
 }


### PR DESCRIPTION
This is a version of pidigits based on the fast release version that moves the
two temps down into the routine that uses them and combines them into one
based on guidance in the GMP documentation that this is preferred.  In spite
of that, and it being more elegant, it seems slower (due to both changes, I
think).  Support for static locals could help with the one issue.  The other
suggests that two temps really might be better for GMP.
