### PR TITLE
Updated distributions primer for online docs

### DIFF
--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -16,11 +16,11 @@ use DimensionalDist2D, ReplicatedDim, BlockCycDim;
 // characteristics.
 //
 // All of these distributions support options to map to a different
-// virtual locale grid than the one used by default (a
-// multidimensional factoring of the built-in Locales array), as well
-// as to control the amount of parallelism used in data parallel
-// loops.  See the Standard Distributions chapter of the language spec
-// for more details.
+// virtual locale grid than the one used by default (a multidimensional
+// factoring of the built-in ``Locales`` array), as well as
+// to control the amount of parallelism used in data parallel
+// loops.  For more details, see the documentation on
+// :ref:`Standard Distributions <layouts_and_distributions>`.
 //
 
 //
@@ -29,13 +29,13 @@ use DimensionalDist2D, ReplicatedDim, BlockCycDim;
 config const n = 8;
 
 //
-// Declare a 2-dimensional domain Space that we will later use to
+// Declare a 2-dimensional domain ``Space`` that we will later use to
 // initialize the distributed domains.
 //
 const Space = {1..n, 1..n};
 
 //
-// The Block distribution distributes a bounding box from
+// The ``Block`` distribution distributes a bounding box from
 // n-dimensional space across the target locale array viewed as an
 // n-dimensional virtual locale grid.  The bounding box is blocked
 // into roughly equal portions across the locales.  Note that domains
@@ -44,7 +44,7 @@ const Space = {1..n, 1..n};
 // the blocking of space.
 //
 // In this example, we declare a 2-dimensional Block-distributed
-// domain BlockSpace and a Block-distributed array BA declared over
+// domain ``BlockSpace`` and a Block-distributed array ``BA`` declared over
 // the domain.
 //
 const BlockSpace = Space dmapped Block(boundingBox=Space);
@@ -59,7 +59,7 @@ forall ba in BA do
   ba = here.id;
 
 //
-// The 'hasSingleLocalSubdomain' method on arrays will return true if the
+// The ``hasSingleLocalSubdomain`` method on arrays will return true if the
 // index set for a locale can be represented by a single domain.
 //
 if !BA.hasSingleLocalSubdomain() then
@@ -68,11 +68,11 @@ if !BA.hasSingleLocalSubdomain() then
 
 //
 // If the distribution's subdomains can be represented as single subdomain,
-// we can use the 'localSubdomain' method to get the index set for the
+// we can use ``localSubdomain()`` to get the index set for the
 // current locale.
 //
 // Below, we'll use the index set to confirm that the array elements have the
-// correct locale id.
+// correct locale ID.
 //
 
 for L in Locales {
@@ -96,24 +96,23 @@ writeln();
 
 //
 // Most of Chapel's standard distributions support an optional
-// targetLocales argument that permits you to pass in your own
+// ``targetLocales`` argument that permits you to pass in your own
 // array of locales to be targeted.  In general, the targetLocales
 // argument should match the rank of the distribution.  So for
-// example, to map a Block to a [numLocales x 1] view of the
-// locale set, one could do something like this:
+// example, to ``Block``-distribute a domain over a 2D ``numLocales * 1``
+// view of the locale set, one could do something like the following.
 
 //
-// We start by creating our own array of the locale values.  Here
-// we use the standard array reshape function for convenience,
-// but more generally, this array could be accessed/assigned like any
-// other.
+// We start by creating our own ``MyLocales`` array of the locale values.
+// Here we use the standard array reshape function for convenience.
+// Generally, this array could be accessed/assigned like any other.
 //
 
 var MyLocaleView = {0..#numLocales, 1..1};
 var MyLocales: [MyLocaleView] locale = reshape(Locales, MyLocaleView);
 
 //
-// Then we'll declare a distributed domain/array that targets
+// Then we declare a distributed domain/array that targets
 // this view of the locales:
 //
 
@@ -122,8 +121,8 @@ const BlockSpace2 = Space dmapped Block(boundingBox=Space,
 var BA2: [BlockSpace2] int;
 
 //
-// Then we'll do a similar computation as before to verify where
-// everything ended up:
+// Now we can do a similar computation as before to verify where
+// each array element ended up:
 //
 forall ba in BA2 do
   ba = here.id;
@@ -133,8 +132,8 @@ writeln(BA2);
 writeln();
 
 //
-// We can use the 'targetLocales' method available on an array to get the
-// locales array used as targets.
+// We can use the ``targetLocales`` method available on an array to get
+// the locales array used as targets:
 //
 for (L, ML) in zip(BA2.targetLocales(), MyLocales) do
   if L != ML then
@@ -143,14 +142,14 @@ for (L, ML) in zip(BA2.targetLocales(), MyLocales) do
 
 
 //
-// Next, we'll perform a similar computation for the Cyclic distribution.
+// Next, we'll perform a similar computation for the ``Cyclic`` distribution.
 // Cyclic distributions start at a designated n-dimensional index and
 // distribute the n-dimensional space across an n-dimensional array
 // of locales in a round-robin fashion (in each dimension).  As with
-// the Block distribution, domains may be declared using the
-// distribution who have lower indices that the starting index; that
-// value should just be considered a parameterization of how the
-// distribution is defined.
+// the ``Block`` distribution, domains declared using the Cyclic distribution
+// may have lower indices than the distribution's starting index.
+// The starting index should just be considered a parameterization of
+// how the distribution is defined.
 //
 const CyclicSpace = Space dmapped Cyclic(startIdx=Space.low);
 var CA: [CyclicSpace] int;
@@ -163,8 +162,8 @@ writeln(CA);
 writeln();
 
 //
-// The domain returned by 'localSubdomain' need not be a dense block, as is
-// the case for the Cyclic Distribution.
+// The domain returned by ``localSubdomain`` need not be a dense block, as is
+// the case for the ``Cyclic`` distribution.
 //
 on Locales[0] {
   const indices = CA.localSubdomain();
@@ -176,11 +175,11 @@ on Locales[0] {
 
 
 //
-// Next, we'll declare a Block-Cyclic distribution.  These
+// Next, we'll use a ``BlockCyclic`` distribution.  Block-Cyclic
 // distributions also deal out indices in a round-robin fashion,
 // but rather than dealing out singleton indices, they deal out blocks
-// of indices.  Thus, the BlockCyclic distribution is parameterized
-// by a starting index (as with Cyclic) and a block size (per
+// of indices.  Thus, the ``BlockCyclic`` distribution is parameterized
+// by a starting index (as with ``Cyclic``) and a block size (per
 // dimension) specifying how large the chunks to be dealt out are.
 //
 const BlkCycSpace = Space dmapped BlockCyclic(startIdx=Space.low,
@@ -203,10 +202,10 @@ if BCA.hasSingleLocalSubdomain() then
 
 //
 // If the local index set cannot be represented by a single subdomain,
-// we can use the 'localSubdomains' iterator to yield a number of domains
+// we can use the ``localSubdomains`` iterator to yield a number of domains
 // that represent the whole index set.
 //
-// Let's write a function that will use 'localSubdomains' to verify the
+// Let's write a function that uses ``localSubdomains`` to verify the
 // correctness of the array values.
 //
 
@@ -225,7 +224,7 @@ proc verifyID(Data: []) {
 verifyID(BCA);
 
 //
-// The 'localSubdomains' iterator is also available on distributions that
+// The ``localSubdomains`` iterator is also available on distributions that
 // can represent a locale's index set with a single domain. This allows us to
 // write more general code that will work for all distributions.
 //
@@ -236,7 +235,7 @@ verifyID(BA);
 
 
 //
-// The ReplicatedDist distribution is different: each of the
+// The ``ReplicatedDist`` distribution is different: each of the
 // original domain's indices - and the corresponding array elements -
 // is replicated onto each locale. (Note: consistency among these
 // array replicands is NOT maintained automatically.)
@@ -257,8 +256,8 @@ writeln();
 
 //
 // The replication is observable when the replicated array is
-// on the left-hand side. If the right-hand side is not replicated,
-// it is copied into each replicand.
+// on the left-hand side of an assignment. If the right-hand side is not
+// replicated, it is copied into each replicand.
 // We illustrate this using a non-distributed array.
 //
 var A: [Space] int = [(i,j) in Space] i*100 + j;
@@ -269,24 +268,29 @@ writeln();
 
 //
 // Analogously, each replicand will be visited and
-// other participated expressions will be computed on each locale
-// (a) when the replicated array is assigned a scalar:
-//       RA = 5;
-// (b) when it appears first in a zippered forall loop:
-//       forall (ra, a) in zip(RA, A) do ...;
-// (c) when it appears in a for loop:
-//       for ra in RA do ...;
+// other participated expressions will be computed on each locale when:
 //
-// Zippering (RA,A) or (A,RA) in a 'for' loop will generate
+// (a) the replicated array is assigned a scalar:
+//       ``RA = 5;``
+//
+// (b) it appears first in a zippered forall loop:
+//       ``forall (ra, a) in zip(RA, A) do ...;``
+//
+// (c) it appears in a for loop:
+//       ``for ra in RA do ...;``
+//
+// Zippering ``(RA,A)`` or ``(A,RA)`` in a ``for`` loop will generate
 // an error due to their different number of elements.
+//
 
-// Let RA store the Index Map again, for the examples below.
+// Let ``RA`` store the Index Map again, for the examples below.
 forall ra in RA do
   ra = here.id;
 
 //
 // Only the local replicand is accessed - replication is NOT observable
 // and consistency is NOT maintained - when:
+//
 // (a) the replicated array is indexed - an individual element is read...
 //
 on Locales(0) do
@@ -317,12 +321,12 @@ writeln();
 //     in a zippered forall loop, but not in the first position.
 //     The loop could look like:
 //
-//       forall (a, (i,j), ra) in (A, ReplicatedSpace, RA) do ...;
+//     ``forall (a, (i,j), ra) in (A, ReplicatedSpace, RA) do ...;``
 //
 
 
 //
-// The DimensionalDist2D distribution lets us build a 2D distribution
+// The ``DimensionalDist2D`` distribution lets us build a 2D distribution
 // as a composition of specifiers for individual dimensions.
 // Under such a "dimensional" distribution each dimension is handled
 // independently of the other.
@@ -333,24 +337,26 @@ writeln();
 // accepts just the number of locales that the indices in the corresponding
 // dimension will be distributed across.
 //
-// The DimensionalDist2D constructor requires:
-//   an [0..nl1-1, 0..nl2-1] array of locales, where
-//   nl1 and nl2 are the number of locales in each dimension, and
-//   two dimension specifiers, created for nl1 and nl2 locale counts, resp.
+// The ``DimensionalDist2D`` constructor requires:
+//   an ``[0..nl1-1, 0..nl2-1]`` array of locales, where
+//   ``nl1`` and ``nl2`` are the number of locales in each dimension, and
+//   two dimension specifiers, created for ``nl1`` and ``nl2`` locale counts,
+//   resp.
 //
 // Presently, the following dimension specifiers are available
 // (shown here with their constructor arguments):
 //
-//   * ReplicatedDim(numLocales)
-//   * BlockDim(numLocales, boundingBoxLow, boundingBoxHigh)
-//   * BlockCyclicDim(lowIdx, blockSize, numLocales)
+//   * ``ReplicatedDim(numLocales)``
+//   * ``BlockDim(numLocales, boundingBoxLow, boundingBoxHigh)``
+//   * ``BlockCyclicDim(lowIdx, blockSize, numLocales)``
 //
 
 //
 // The following example creates a dimensional distribution that
 // replicates over 2 locales (when available) in the first dimension
 // and distributes using block-cyclic distribution in the second dimension.
-// The example computes nl1 and nl2 and reshapes MyLocales correspondingly.
+// The example computes ``nl1`` and ``nl2`` and reshapes ``MyLocales``
+// correspondingly.
 //
 
 var (nl1, nl2) = if numLocales == 1 then (1, 1) else (2, numLocales/2);
@@ -365,11 +371,11 @@ const DimReplicatedBlockcyclicSpace = Space
 
 var DRBA: [DimReplicatedBlockcyclicSpace] int;
 
-// The ReplicatedDim specifier always accesses the local replicand.
-// (This differs from how the ReplicatedDist distribution works.)
+// The ``ReplicatedDim`` specifier always accesses the local replicand.
+// (This differs from how the ``ReplicatedDist`` distribution works.)
 //
 // This example visits each replicand. The behavior is the same
-// regardless of the second index into MyLocales below.
+// regardless of the second index into ``MyLocales`` below.
 
 for locId1 in 0..#nl1 do on MyLocales[locId1, 0] {
 


### PR DESCRIPTION
* Markup.

* Some wordsmithing.

I backtick-ified only the first (one or a couple of) occurrence(s)
of each distribution name, treating the subsequent occurrences
as English names. My intention is to reduce the number of things
that stand out in the generated HTML and the amount of markup
for those reading the .chpl file directly.