### PR TITLE
Deprecate class BIgInt in favor of record bigint

### DIFF
--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -1152,14 +1152,20 @@ module GMP {
 
     // initializing integers (constructors)
     proc BigInt(init2: bool, nbits: uint) {
+      compilerWarning("The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead");
+
       mpz_init2(this.mpz, nbits.safeCast(c_ulong));
     }
 
     proc BigInt(num: int) {
+      compilerWarning("The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead");
+
       mpz_init_set_si(this.mpz, num.safeCast(c_long));
     }
 
     proc BigInt(str: string, base: int = 0) {
+      compilerWarning("The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead");
+
       var e: c_int;
 
       e = mpz_init_set_str(this.mpz,
@@ -1174,6 +1180,8 @@ module GMP {
     }
 
     proc BigInt(str: string, base: int = 0, out error: syserr) {
+      compilerWarning("The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead");
+
       var e: c_int;
 
       error = ENOERR;
@@ -1190,6 +1198,8 @@ module GMP {
     }
 
     proc BigInt(num: BigInt) {
+      compilerWarning("The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead");
+
       if num.locale == here {
         mpz_init_set(this.mpz, num.mpz);
       } else {
@@ -1202,6 +1212,8 @@ module GMP {
     }
 
     proc BigInt() {
+      compilerWarning("The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead");
+
       mpz_init(this.mpz);
     }
 

--- a/test/deprecated/bigint.chpl
+++ b/test/deprecated/bigint.chpl
@@ -1,0 +1,26 @@
+/*
+  Noakes 2016/09/12
+
+  The class  GMP.BigInt is being deprecated in favor of
+  the record BigInteger.Bigint
+*/
+
+use GMP;
+
+proc main() {
+  var   a = new BigInt(234958444);
+  const b = new BigInt("4847382292989382987395534934347");
+  var   c = new BigInt();
+
+  c.mul(a, b);
+  writeln(c);
+
+  var   d = new BigInt();
+  d.fac_ui(100 : uint);
+  writeln(d);
+
+  delete d;
+  delete c;
+  delete b;
+  delete a;
+}

--- a/test/deprecated/bigint.good
+++ b/test/deprecated/bigint.good
@@ -1,0 +1,10 @@
+bigint.chpl:10: In function 'main':
+bigint.chpl:11: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
+bigint.chpl:12: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
+bigint.chpl:13: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
+$CHPL_HOME/modules/standard/GMP.chpl:1244: In function 'maybeCopy':
+$CHPL_HOME/modules/standard/GMP.chpl:1249: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
+bigint.chpl:10: In function 'main':
+bigint.chpl:18: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
+1138933401033937535238526500721813276068
+93326215443944152681699238856266700490715968264381621468592963895217599993229915608941463976156518286253697920827223758251185210916864000000000000000000000000

--- a/test/deprecated/bigint.skipif
+++ b/test/deprecated/bigint.skipif
@@ -1,0 +1,2 @@
+# This test assumes we can use GMP
+CHPL_GMP == none


### PR DESCRIPTION
1) Add a compiler warning to the constructors for the class BigInt

2) Add a new test to test/deprecated

3) Avoid egg-on-face by including a .skipif

Verified that no existing tests trigger the warning with and without gasnet
Verified that the deprecated test triggers the warning with GMP enabled.
Verified that the test does not run if GMP is disabled.
