### PR TITLE
Filter out JIRA-154 errors

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -299,6 +299,15 @@ def DiffFiles(f1, f2):
         sys.stdout.write(trim_output(myoutput))
     return p.returncode
 
+def DiffBinaryFiles(f1, f2):
+    sys.stdout.write('[Executing binary diff %s %s]\n'%(f1, f2))
+    p = subprocess.Popen(['diff', '-a', f1,f2],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
+    if p.returncode != 0:
+        sys.stdout.write(trim_output(myoutput))
+    return p.returncode
+
 # diff output vs. .bad file, filtering line numbers out of error messages that arise
 # in module files.
 def DiffBadFiles(f1, f2):
@@ -2029,7 +2038,22 @@ for testname in testsrc:
                             os.unlink(execlog)
                             sys.stdout.write('%s[Success '%(futuretest))
                         else:
-                            sys.stdout.write('%s[Error '%(futuretest))
+                            # If the output contains messages consistent with JIRA 154, add a
+                            # hint to the error summary and force a text base diff since
+                            # sometimes the output contains a null character
+                            extra_msg = ''
+                            err_strings = ['got exn while reading exit code: connection closed',
+                                           'slave got an unknown command on coord socket:',
+                                           'Slave got an xSocket: connection closed on recv',
+                                           'recursive failure in AMUDP_SPMDShutdown']
+                            for s in err_strings:
+                                if re.search(s, output, re.IGNORECASE) != None:
+                                    extra_msg = '(possible JIRA 154) '
+                                    DiffBinaryFiles(execgoodfile, execlog)
+                                    break
+
+                            sys.stdout.write('%s[Error %s'%(futuretest, extra_msg))
+
                         sys.stdout.write('matching program output for %s/%s'%
                                         (localdir, test_filename))
                         if result!=0:


### PR DESCRIPTION
We've been getting some sporadic gasnet failures along the lines of

    recursive failure in AMUDP_SPMDShutdown

There are several different error messages and sometimes it just shows up as
"binary files diff" because one of the errors has a null character in it.

These errors are ultimately caused by a halt (which leads to a gasnet_exit)
being called on a non-zero locale, leading to recursive shutdown calls, which
gasnet complains about. Greg and I are brainstorming solutions, but in the
meantime we need an easier way to identify the regression (previously there
were ~10 duplicate jira entires.)

This adds filtering for a handful of error messages, and adds some routines to
diff a binary file so we can see the error message for the error with a null
character.

Errors will now show up as

    [Error (possible JIRA 154) matching program output for <test>]