### PR TITLE
Alignment support for Search/Sort/Random.shuffle()

### DIFF
--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -159,7 +159,7 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.lo
    :rtype: (`bool`, `Dom.idxType`)
 
  */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high) {
+proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.alignedLow, in hi=Dom.alignedHigh) {
   chpl_check_comparator(comparator, Data.eltType);
 
   const stride = if Dom.stridable then abs(Dom.stride) else 1;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -19,7 +19,6 @@
 
 
 // TODO -- performance test sort routines and optimize (see other TODO's)
-// TODO -- Try using orderToIndex rather than using alignment/stride
 /*
 
 The Sort module is designed to support standard sort routines.
@@ -757,10 +756,9 @@ proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparat
 proc selectionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
   const low = Dom.alignedLow,
         high = Dom.alignedHigh,
-        stride = abs(Dom.stride),
-        alignment = Dom.alignment;
+        stride = abs(Dom.stride);
 
-  for i in low..high-stride by stride align alignment {
+  for i in low..high-stride by stride {
     var jMin = i;
     // TODO -- should be a minloc reduction, when they can support comparators
     for j in i..high by stride {

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -378,8 +378,8 @@ iter sorted(x, comparator:?rec=defaultComparator) {
  */
 proc bubbleSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
   chpl_check_comparator(comparator, eltType);
-  const low = Dom.low,
-        high = Dom.high,
+  const low = Dom.alignedLow,
+        high = Dom.alignedHigh,
         stride = abs(Dom.stride);
 
   var swapped = true;
@@ -480,8 +480,8 @@ proc heapSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
  */
 proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
   chpl_check_comparator(comparator, eltType);
-  const low = Dom.low,
-        high = Dom.high,
+  const low = Dom.alignedLow,
+        high = Dom.alignedHigh,
         stride = abs(Dom.stride);
 
   for i in low..high by stride {
@@ -492,6 +492,32 @@ proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
         Data[j+stride] = Data[j];
       } else {
         Data[j+stride] = ithVal;
+        inserted = true;
+        break;
+      }
+    }
+    if (!inserted) {
+      Data[low] = ithVal;
+    }
+  }
+}
+
+
+/* Non-stridable insertionSort */
+proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
+  where !Dom.stridable {
+  chpl_check_comparator(comparator, eltType);
+
+  const low = Dom.alignedLow;
+
+  for i in Dom {
+    const ithVal = Data[i];
+    var inserted = false;
+    for j in low..i-1 by -1 {
+      if chpl_compare(ithVal, Data[j], comparator) < 0 {
+        Data[j+1] = Data[j];
+      } else {
+        Data[j+1] = ithVal;
         inserted = true;
         break;
       }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -593,10 +593,10 @@ proc mergeSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
  */
 proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparator) {
   chpl_check_comparator(comparator, eltType);
-  // grab obvious indices
+
   const stride = abs(Dom.stride),
-        lo = Dom.low,
-        hi = Dom.high,
+        lo = Dom.alignedLow,
+        hi = Dom.alignedHigh,
         size = Dom.size,
         mid = if hi == lo then hi
               else if size % 2 then lo + ((size - 1)/2) * stride
@@ -636,7 +636,7 @@ proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparat
 
   // TODO -- Get this cobegin working and tested
   //  cobegin {
-    quickSort(Data[..loptr-stride], minlen, comparator);  // could use unbounded ranges here
+    quickSort(Data[..loptr-stride], minlen, comparator);
     quickSort(Data[loptr+stride..], minlen, comparator);
   //  }
 }
@@ -711,11 +711,12 @@ proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparat
 
  */
 proc selectionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
-  const low = Dom.low,
-        high = Dom.high,
-        stride = abs(Dom.stride);
+  const low = Dom.alignedLow,
+        high = Dom.alignedHigh,
+        stride = abs(Dom.stride),
+        alignment = Dom.alignment;
 
-  for i in low..high-stride by stride {
+  for i in low..high-stride by stride align alignment {
     var jMin = i;
     // TODO -- should be a minloc reduction, when they can support comparators
     for j in i..high by stride {

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -712,8 +712,8 @@ module Random {
         if D.rank != 1 then
           compilerError("Shuffle requires 1-D array");
 
-        const low = D.low,
-              high = D.high,
+        const low = D.alignedLow,
+              high = D.alignedHigh,
               stride = D.stride;
 
         if parSafe then

--- a/test/modules/packages/Search/correctness.chpl
+++ b/test/modules/packages/Search/correctness.chpl
@@ -9,7 +9,8 @@ proc main() {
   var result: (bool, int);
 
   const strideD = {10..40 by 10},
-        revStrideD = {10..40 by -10};
+        revStrideD = {10..40 by -10},
+        alignD = {1..8 by -2 align 8};
 
   // Sorted arrays
   const    A = [-4, -1, 2, 3],
@@ -18,7 +19,8 @@ proc main() {
      revAbsA = [ -4, 3, 2, -1],
         strA = ['Brad', 'anthony', 'ben', 'david'],
     strideA : [strideD] int = [-4, -1, 2, 3],
-    revStrideA : [revStrideD] int = [-4, -1, 2, 3];
+    revStrideA : [revStrideD] int = [-4, -1, 2, 3],
+      alignA: [alignD] int = [-4, -1, 2, 3];
 
   // Comparators
   const absKey = new AbsKeyCmp(),
@@ -53,6 +55,12 @@ proc main() {
 
   result = binarySearch(revStrideA, 2);
   checkSearch(result, (true, 30), revStrideA, 'binarySearch');
+
+  result = linearSearch(alignA, 2);
+  checkSearch(result, (true, 6), alignA, 'linearSearch');
+
+  result = binarySearch(alignA, 2);
+  checkSearch(result, (true, 6), alignA, 'binarySearch');
 
   result = linearSearch(strideA, 5);
   checkSearch(result, (false, strideD.high+strideD.stride), strideA, 'linearSearch');

--- a/test/modules/packages/Sort/correctness/correctness.chpl
+++ b/test/modules/packages/Sort/correctness/correctness.chpl
@@ -16,12 +16,15 @@ proc main() {
         tupleKey = new TupleCmp();
 
   // Arrays and Domains
-  const largeD = {1..20}, // quickSort requires domain.size > 16
+  const largeD = {1..101}, // quickSort requires domain.size > 16
         strideD = {2..8 by 2},
-      strideRevD = {2..8 by -2};
+      strideRevD = {2..8 by -2},
+        alignD = {1..8 by -2 align 8};
   var largeA: [largeD] int,
       strideA: [strideD] int = [-3, -1, 4, 5],
-      strideRevA: [strideRevD] int = [-3, -1, 4, 5];
+      strideRevA: [strideRevD] int = [-3, -1, 4, 5],
+      alignA: [alignD] int = [-3, -1, 4, 5];
+
     [i in largeD] largeA[i] = i;
 
   // Pre-sorted arrays paired with comparators to test
@@ -34,6 +37,7 @@ proc main() {
                 (largeA, defaultComparator),
                 (strideA, defaultComparator),
                 (strideRevA, defaultComparator),
+                (alignA, defaultComparator),
 
                 // Testing comparators
                 ([-1, 2, 3, -4], absKey),


### PR DESCRIPTION
## Bug Fix

With the new strided array support for these modules, aligned arrays were failing for some cases. The fix for this basically comes down to using`Dom.alignedLow` /`Dom.alignedHigh` in place of `Dom.low`/`Dom.high`.

This also required adding lower/upper bounds to the slices passed in `quickSort()`, due to the array slicing behavior differing from range-slicing behavior.

## Other
* Overloaded `insertionSort` to minimize performance impact of strided support - performance testing revealed that this made a difference.
    * Note: It's post-release TODO to merge these overloaded implementations without any performance hit.
* Minor cleanup
* Added new tests in Sort/Search module testing for misaligned strided array

**Sort/Search/Random correctness testing completed locally**
`[Summary: #Successes = 6522 | #Failures = 0 | #Futures = 0]`
