### PR TITLE
Update the spec for trailing commas allowed

### DIFF
--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -117,11 +117,13 @@ array-literal:
 Rectangular array literals are specified by enclosing a comma separated list of 
 expressions representing values in square brackets. A 1-based domain will 
 automatically be generated for the given array literal.  The type of the array's 
-values will be the type of the first element listed.
+values will be the type of the first element listed. A trailing comma is
+allowed.
 
 \begin{syntax}
 rectangular-array-literal:
   [ expression-list ]
+  [ expression-list , ]
 \end{syntax}
 
 \begin{chapelexample}{adecl-literal.chpl}
@@ -183,11 +185,12 @@ the default value of the element type.
 Associative array values are specified by enclosing a comma separated list of
 index-to-value bindings within square brackets. It is expected that the indices 
 in the listing match in type and, likewise, the types of values in the listing 
-also match. 
+also match. A trailing commas is allowed.
 
 \begin{syntax}
 associative-array-literal:
   [ associative-expr-list ]
+  [ associative-expr-list , ]
 
 associative-expr-list:
   index-expr => value-expr

--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -185,7 +185,7 @@ the default value of the element type.
 Associative array values are specified by enclosing a comma separated list of
 index-to-value bindings within square brackets. It is expected that the indices 
 in the listing match in type and, likewise, the types of values in the listing 
-also match. A trailing commas is allowed.
+also match. A trailing comma is allowed.
 
 \begin{syntax}
 associative-array-literal:

--- a/spec/Expressions.tex
+++ b/spec/Expressions.tex
@@ -70,6 +70,7 @@ literal-expression:
 Literal values for primitive types are described in
 \rsec{Primitive_Type_Literals}.
 Literal range values are described in \rsec{Range_Literals}.
+Literal tuple values are described in \rsec{Tuple_Values}.
 Literal values for domains are described in \rsec{Rectangular_Domain_Values}
 and \rsec{Associative_Domain_Values}.
 Literal values for arrays are described in  \rsec{Rectangular_Array_Literals}

--- a/spec/Tuples.tex
+++ b/spec/Tuples.tex
@@ -98,13 +98,15 @@ A value of a tuple type attaches a value to each component type.
 Tuple values can be specified by a parenthesized, comma-separated list
 of expressions.  The number of expressions in the list defines the
 size of the tuple; the types of these expressions specify the
-component types of the tuple.
+component types of the tuple. A trailing comma is allowed for tuple
+expressions.
 
 The syntax of a tuple expression is given by:
 \begin{syntax}
 tuple-expression:
   ( tuple-component , )
   ( tuple-component , tuple-component-list )
+  ( tuple-component , tuple-component-list , )
 
 tuple-component:
   expression

--- a/spec/Tuples.tex
+++ b/spec/Tuples.tex
@@ -98,8 +98,7 @@ A value of a tuple type attaches a value to each component type.
 Tuple values can be specified by a parenthesized, comma-separated list
 of expressions.  The number of expressions in the list defines the
 size of the tuple; the types of these expressions specify the
-component types of the tuple. A trailing comma is allowed for tuple
-expressions.
+component types of the tuple. A trailing comma is allowed.
 
 The syntax of a tuple expression is given by:
 \begin{syntax}


### PR DESCRIPTION
Trailing commas were enabled for array and tuple literals in PR #4521 but
the spec wasn't updated. This commit updates the spec. While there,
added a cross-reference from the Literal Expressions section to the
Tuple Value section (which describes tuple literals).