### PR TITLE
Revert "Alignment support for Search/Sort/Random.shuffle()"

### DIFF
--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -159,7 +159,7 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.lo
    :rtype: (`bool`, `Dom.idxType`)
 
  */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.alignedLow, in hi=Dom.alignedHigh) {
+proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high) {
   chpl_check_comparator(comparator, Data.eltType);
 
   const stride = if Dom.stridable then abs(Dom.stride) else 1;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -310,7 +310,7 @@ proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator): bool {
   chpl_check_comparator(comparator, eltType);
   const stride = if Dom.stridable then abs(Dom.stride) else 1;
 
-  for i in Dom.alignedLow..Dom.alignedHigh-stride by stride do
+  for i in Dom.low..Dom.high-stride by stride do
     if chpl_compare(Data[i+stride], Data[i], comparator) < 0 then
       return false;
   return true;
@@ -377,8 +377,8 @@ iter sorted(x, comparator:?rec=defaultComparator) {
  */
 proc bubbleSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
   chpl_check_comparator(comparator, eltType);
-  const low = Dom.alignedLow,
-        high = Dom.alignedHigh,
+  const low = Dom.low,
+        high = Dom.high,
         stride = abs(Dom.stride);
 
   var swapped = true;
@@ -414,8 +414,8 @@ proc bubbleSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
  */
 proc heapSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
   chpl_check_comparator(comparator, eltType);
-  const low = Dom.alignedLow,
-        high = Dom.alignedHigh,
+  const low = Dom.low,
+        high = Dom.high,
         size = Dom.size,
         stride = abs(Dom.stride);
 
@@ -479,8 +479,8 @@ proc heapSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
  */
 proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
   chpl_check_comparator(comparator, eltType);
-  const low = Dom.alignedLow,
-        high = Dom.alignedHigh,
+  const low = Dom.low,
+        high = Dom.high,
         stride = abs(Dom.stride);
 
   for i in low..high by stride {
@@ -491,32 +491,6 @@ proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
         Data[j+stride] = Data[j];
       } else {
         Data[j+stride] = ithVal;
-        inserted = true;
-        break;
-      }
-    }
-    if (!inserted) {
-      Data[low] = ithVal;
-    }
-  }
-}
-
-
-/* Non-stridable insertionSort */
-proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
-  where !Dom.stridable {
-  chpl_check_comparator(comparator, eltType);
-
-  const low = Dom.alignedLow;
-
-  for i in Dom {
-    const ithVal = Data[i];
-    var inserted = false;
-    for j in low..i-1 by -1 {
-      if chpl_compare(ithVal, Data[j], comparator) < 0 {
-        Data[j+1] = Data[j];
-      } else {
-        Data[j+1] = ithVal;
         inserted = true;
         break;
       }
@@ -554,64 +528,47 @@ proc mergeSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparat
 
 private proc _MergeSort(Data: [?Dom], minlen=16, comparator:?rec=defaultComparator)
   where Dom.rank == 1 {
-
-  const low = Dom.alignedLow,
-        high = Dom.alignedHigh;
-
-  if high-low < minlen {
+  const lo = Dom.dim(1).low;
+  const hi = Dom.dim(1).high;
+  if hi-lo < minlen {
     insertionSort(Data, comparator);
     return;
   }
-
-  const size = Dom.size,
-        stride = abs(Dom.stride),
-        mid = if high == low then high
-        else if size % 2 then low + ((size - 1)/2) * stride
-        else low + (size/2 - 1) * stride;
-
-  var A1 = Data[low..mid by stride];
-  var A2 = Data[mid+stride..high by stride];
+  const mid = (hi-lo)/2+lo;
+  var A1 = Data[lo..mid];
+  var A2 = Data[mid+1..hi];
   cobegin {
     { _MergeSort(A1, minlen, comparator); }
     { _MergeSort(A2, minlen, comparator); }
   }
 
   // TODO -- This iterator causes unnecessary overhead - we can do without it
-  for (a, _a) in zip(Data[low..high by stride], _MergeIterator(A1, A2, comparator=comparator)) do a = _a;
+  for (a, _a) in zip(Data[lo..hi], _MergeIterator(A1, A2, comparator=comparator)) do a = _a;
 }
 
 
-private iter _MergeIterator(A1: [?A1Dom] ?eltType, A2: [?A2Dom] eltType, comparator:?rec=defaultComparator) {
-  var a1 = A1Dom.alignedLow,
-      a2 = A2Dom.alignedLow;
-  const a1hi = A1Dom.alignedHigh,
-        a2hi = A2Dom.alignedHigh,
-        stride = abs(A1Dom.stride);
-
+private iter _MergeIterator(A1: [] ?eltType, A2: [] eltType, comparator:?rec=defaultComparator) {
+  var a1 = A1.domain.dim(1).low;
+  const a1hi = A1.domain.dim(1).high;
+  var a2 = A2.domain.dim(1).low;
+  const a2hi = A2.domain.dim(1).high;
   while ((a1 <= a1hi) && (a2 <= a2hi)) {
     while (chpl_compare(A1(a1), A2(a2), comparator) <= 0) {
       yield A1(a1);
-      a1 += stride;
+      a1 += 1;
       if a1 > a1hi then break;
     }
     if a1 > a1hi then break;
     while (chpl_compare(A2(a2), A1(a1), comparator) <= 0) {
       yield A2(a2);
-      a2 += stride;
+      a2 += 1;
       if a2 > a2hi then break;
     }
   }
-
-  if a1 == a1hi then
-    yield A1(a1);
-  else if a2 == a2hi then
-    yield A2(a2);
-  if a1 < a1hi then
-    for a in A1[a1..a1hi by stride] do
-      yield a;
-  else if a2 < a2hi then
-    for a in A2[a2..a2hi by stride] do
-      yield a;
+  if a1 == a1hi then yield A1(a1);
+  else if a2 == a2hi then yield A2(a2);
+  if a1 < a1hi then for a in A1[a1..a1hi] do yield a;
+  else if a2 < a2hi then for a in A2[a2..a2hi] do yield a;
 }
 
 
@@ -636,21 +593,20 @@ proc mergeSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
  */
 proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparator) {
   chpl_check_comparator(comparator, eltType);
-
-  const size = Dom.size;
-
-  // base case -- use insertion sort
-  if (size < minlen) {
-    insertionSort(Data, comparator=comparator);
-    return;
-  }
-
+  // grab obvious indices
   const stride = abs(Dom.stride),
-        lo = Dom.alignedLow,
-        hi = Dom.alignedHigh,
+        lo = Dom.low,
+        hi = Dom.high,
+        size = Dom.size,
         mid = if hi == lo then hi
               else if size % 2 then lo + ((size - 1)/2) * stride
               else lo + (size/2 - 1) * stride;
+
+  // base case -- use insertion sort
+  if (hi - lo < minlen) {
+    insertionSort(Data, comparator=comparator);
+    return;
+  }
 
   // find pivot using median-of-3 method
   if (chpl_compare(Data(mid), Data(lo), comparator) < 0) then
@@ -661,7 +617,8 @@ proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparat
     Data(hi) <=> Data(mid);
 
   const pivotVal = Data(mid);
-  (Data(mid), Data(hi-stride)) = (Data(hi-stride), pivotVal);
+  Data(mid) = Data(hi-stride);
+  Data(hi-stride) = pivotVal;
   // end median-of-3 partitioning
 
   var loptr = lo,
@@ -679,8 +636,8 @@ proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparat
 
   // TODO -- Get this cobegin working and tested
   //  cobegin {
-    quickSort(Data[lo..loptr-stride by stride], minlen, comparator);
-    quickSort(Data[loptr+stride..hi by stride], minlen, comparator);
+    quickSort(Data[..loptr-stride], minlen, comparator);  // could use unbounded ranges here
+    quickSort(Data[loptr+stride..], minlen, comparator);
   //  }
 }
 
@@ -692,15 +649,14 @@ proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparat
 
   // grab obvious indices
   const lo = Dom.low,
-        hi = Dom.high;
+        hi = Dom.high,
+        mid = lo + (hi-lo+1)/2;
 
   // base case -- use insertion sort
   if (hi - lo < minlen) {
     insertionSort(Data, comparator=comparator);
     return;
   }
-
-  const mid = lo + (hi-lo+1)/2;
 
   // find pivot using median-of-3 method
   if (chpl_compare(Data(mid), Data(lo), comparator) < 0) then
@@ -711,7 +667,8 @@ proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparat
     Data(hi) <=> Data(mid);
 
   const pivotVal = Data(mid);
-  (Data(mid), Data(hi-1)) = (Data(hi-1), pivotVal);
+  Data(mid) = Data(hi-1);
+  Data(hi-1) = pivotVal;
   // end median-of-3 partitioning
 
   var loptr = lo,
@@ -754,8 +711,8 @@ proc quickSort(Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparat
 
  */
 proc selectionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
-  const low = Dom.alignedLow,
-        high = Dom.alignedHigh,
+  const low = Dom.low,
+        high = Dom.high,
         stride = abs(Dom.stride);
 
   for i in low..high-stride by stride {

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -712,8 +712,8 @@ module Random {
         if D.rank != 1 then
           compilerError("Shuffle requires 1-D array");
 
-        const low = D.alignedLow,
-              high = D.alignedHigh,
+        const low = D.low,
+              high = D.high,
               stride = D.stride;
 
         if parSafe then

--- a/test/modules/packages/Search/correctness.chpl
+++ b/test/modules/packages/Search/correctness.chpl
@@ -9,8 +9,7 @@ proc main() {
   var result: (bool, int);
 
   const strideD = {10..40 by 10},
-        revStrideD = {10..40 by -10},
-        alignD = {1..8 by -2 align 8};
+        revStrideD = {10..40 by -10};
 
   // Sorted arrays
   const    A = [-4, -1, 2, 3],
@@ -19,8 +18,7 @@ proc main() {
      revAbsA = [ -4, 3, 2, -1],
         strA = ['Brad', 'anthony', 'ben', 'david'],
     strideA : [strideD] int = [-4, -1, 2, 3],
-    revStrideA : [revStrideD] int = [-4, -1, 2, 3],
-      alignA: [alignD] int = [-4, -1, 2, 3];
+    revStrideA : [revStrideD] int = [-4, -1, 2, 3];
 
   // Comparators
   const absKey = new AbsKeyCmp(),
@@ -55,12 +53,6 @@ proc main() {
 
   result = binarySearch(revStrideA, 2);
   checkSearch(result, (true, 30), revStrideA, 'binarySearch');
-
-  result = linearSearch(alignA, 2);
-  checkSearch(result, (true, 6), alignA, 'linearSearch');
-
-  result = binarySearch(alignA, 2);
-  checkSearch(result, (true, 6), alignA, 'binarySearch');
 
   result = linearSearch(strideA, 5);
   checkSearch(result, (false, strideD.high+strideD.stride), strideA, 'linearSearch');

--- a/test/modules/packages/Sort/correctness/correctness.chpl
+++ b/test/modules/packages/Sort/correctness/correctness.chpl
@@ -16,15 +16,12 @@ proc main() {
         tupleKey = new TupleCmp();
 
   // Arrays and Domains
-  const largeD = {1..101}, // quickSort requires domain.size > 16
+  const largeD = {1..20}, // quickSort requires domain.size > 16
         strideD = {2..8 by 2},
-      strideRevD = {2..8 by -2},
-        alignD = {1..8 by -2 align 8};
+      strideRevD = {2..8 by -2};
   var largeA: [largeD] int,
       strideA: [strideD] int = [-3, -1, 4, 5],
-      strideRevA: [strideRevD] int = [-3, -1, 4, 5],
-      alignA: [alignD] int = [-3, -1, 4, 5];
-
+      strideRevA: [strideRevD] int = [-3, -1, 4, 5];
     [i in largeD] largeA[i] = i;
 
   // Pre-sorted arrays paired with comparators to test
@@ -37,7 +34,6 @@ proc main() {
                 (largeA, defaultComparator),
                 (strideA, defaultComparator),
                 (strideRevA, defaultComparator),
-                (alignA, defaultComparator),
 
                 // Testing comparators
                 ([-1, 2, 3, -4], absKey),


### PR DESCRIPTION
Reverts chapel-lang/chapel#4669

#4669 adds usage of the `Dom.alignedLow` and `Dom.alignedHigh` members, which are not defined for several distributions such as Cyclic and Replicated. Oddly enough, this also broke correctness of a block-distributed sort, which might imply the `alignedHigh`/`Low` members of the block distribution are not completely correct, but it could also be something else. This will be revisited post-release.