### PR TITLE
Add LLVM support for use of GMP macros

### DIFF
--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -672,10 +672,12 @@ module GMP {
   extern proc mpz_cmp_d(const ref op1: mpz_t,
                         op2: c_double) : c_int;
 
-  extern proc mpz_cmp_si(const ref op1: mpz_t,
+  extern chpl_mpz_cmp_si
+         proc mpz_cmp_si(const ref op1: mpz_t,
                          op2: c_long) : c_int;
 
-  extern proc mpz_cmp_ui(const ref op1: mpz_t,
+  extern chpl_mpz_cmp_ui
+         proc mpz_cmp_ui(const ref op1: mpz_t,
                          op2: c_ulong) : c_int;
 
   extern proc mpz_cmpabs(const ref op1: mpz_t,
@@ -687,7 +689,8 @@ module GMP {
   extern proc mpz_cmpabs_ui(const ref op1: mpz_t,
                             op2: c_ulong) : c_int;
 
-  extern proc mpz_sgn(const ref op: mpz_t) : c_int;
+  extern chpl_mpz_sgn
+         proc mpz_sgn(const ref op: mpz_t) : c_int;
 
 
   //
@@ -782,9 +785,11 @@ module GMP {
 
   extern proc mpz_fits_sshort_p(const ref op: mpz_t) : c_int;
 
-  extern proc mpz_odd_p(const ref op: mpz_t) : c_int;
+  extern chpl_mpz_odd_p
+         proc mpz_odd_p(const ref op: mpz_t) : c_int;
 
-  extern proc mpz_even_p(const ref op: mpz_t) : c_int;
+  extern chpl_mpz_even_p
+         proc mpz_even_p(const ref op: mpz_t) : c_int;
 
   extern proc mpz_sizeinbase(const ref op: mpz_t,
                              base: c_int) : size_t;

--- a/runtime/include/chplgmp.h
+++ b/runtime/include/chplgmp.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,13 +31,24 @@ void chpl_gmp_init(void);
 
 void chpl_gmp_get_mpz(mpz_t ret, int64_t src_locale, __mpz_struct from);
 
-void chpl_gmp_get_randstate(gmp_randstate_t not_inited_state, int64_t src_locale, __gmp_randstate_struct from);
+void chpl_gmp_get_randstate(gmp_randstate_t        not_inited_state,
+                            int64_t                src_locale,
+                            __gmp_randstate_struct from);
 
 uint64_t chpl_gmp_mpz_nlimbs(__mpz_struct from);
 
 void chpl_gmp_mpz_print(mpz_t x);
 
 c_string_copy chpl_gmp_mpz_get_str(int base, mpz_t x);
+
+// These functions wrap the equivalent GMP macros to support LLVM backend
+int chpl_mpz_cmp_si(const mpz_t op1, long op2);
+int chpl_mpz_cmp_ui(const mpz_t op1, unsigned long op2);
+
+int chpl_mpz_sgn(const mpz_t op);
+
+int chpl_mpz_odd_p(const mpz_t op);
+int chpl_mpz_even_p(const mpz_t op);
 
 #endif
 

--- a/runtime/src/chplgmp.c
+++ b/runtime/src/chplgmp.c
@@ -104,4 +104,28 @@ c_string_copy chpl_gmp_mpz_get_str(int base, mpz_t x) {
   return str;
 }
 
+//
+// These functions wrap the equivalent GMP macros to support LLVM backend
+//
+int chpl_mpz_cmp_si(const mpz_t op1, long op2) {
+  return mpz_cmp_si(op1, op2);
+}
+
+int chpl_mpz_cmp_ui(const mpz_t op1, unsigned long op2) {
+  return mpz_cmp_ui(op1, op2);
+}
+
+int chpl_mpz_sgn(const mpz_t op) {
+  return mpz_sgn(op);
+}
+
+int chpl_mpz_odd_p(const mpz_t op) {
+  return mpz_odd_p(op);
+}
+
+int chpl_mpz_even_p(const mpz_t op) {
+  return mpz_even_p(op);
+}
+
+
 #endif


### PR DESCRIPTION
GMP defines 6 operations as macros rather than functions; we rely on 5 of these.
This works fine for our C backend but is a problem for LLVM.

This simple PR defines 5 C functions in runtime/src/chplgmp.c that merely invoke the macros.
We then revise the Chapel GMP declarations of the chapel view of these operations to use our
bridge functions.

Tested every GMP program on

clang/darwin with/without gasnet
gcc/linux64 with/without gasnet
llvm/linux64 without gasnet

