### PR TITLE
Update --[no-]vectorize docs now that it's not enabled by --fast

### DIFF
--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -146,8 +146,8 @@ OPTIONS
 
 **--fast**
 
-    Turns off all runtime checks using **--no-checks**, turns on **-O**,
-    **--specialize**, and **--vectorize**.
+    Turns off all runtime checks using **--no-checks**, turns on **-O** and
+    **--specialize**.
 
 **--[no-]fast-followers**
 
@@ -199,9 +199,9 @@ OPTIONS
 
 **--[no-]vectorize**
 
-    Enable [disable] generating vectorization hints for target compiler. If
-    enabled, hints will always be generated, but the effects will vary based
-    on the target compiler.
+    Enable [disable] generating vectorization hints for the target compiler.
+    If enabled, hints will always be generated, but the effects on performance
+    (and in some cases correctness) will vary based on the target compiler.
 
 **--[no-]optimize-on-clauses**
 

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -21,9 +21,9 @@
 // vectorizeOnly iterators found at the bottom of this file.
 /*
   Data parallel constructs (such as ``forall`` loops) are implicitly
-  vectorizable. If the ``--vectorize`` compiler flag is thrown (implied by
-  ``--fast``), the Chapel compiler will emit vectorization hints to the backend
-  compiler, though the effects will vary based on the target compiler.
+  vectorizable. If the ``--vectorize`` compiler flag is thrown the Chapel
+  compiler will emit vectorization hints to the backend compiler, though the
+  effects will vary based on the target compiler.
 
   In order to allow users to explicitly request vectorization, this prototype
   vectorizing iterator is being provided. Loops that invoke this iterator will


### PR DESCRIPTION
Update vectorization docs since --vectorize is no longer implied by --fast
(changed with #3920.)

Also try to add some wiggle room to the docs since we've seen correctness
issues with it (which is why we disabled it in the first place.)