### PR TITLE
Add range and domain explicit conversions to the spec

### DIFF
--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -379,6 +379,21 @@ another record type \chpl{D} provided that \chpl{C} is derived
 from \chpl{D}.  There are no explicit record conversions that are not
 also implicit record conversions.
 
+\subsection{Explicit Range Conversions}
+\label{Explicit_Range_Conversions}
+\index{conversions!range}
+\index{conversions!explicit!range}
+
+An expression of stridable range type can be explicitly converted
+to an unstridable range type, changing the stride to 1 in the process.
+
+\subsection{Explicit Domain Conversions}
+\label{Explicit_Domain_Conversions}
+\index{conversions!domain}
+\index{conversions!explicit!domain}
+
+An expression of stridable domain type can be explicitly converted
+to an unstridable domain type, changing all strides to 1 in the process.
 
 \subsection{Explicit Type to String Conversions}
 \label{Explicit_Type_to_String_Conversions}

--- a/spec/Domains.tex
+++ b/spec/Domains.tex
@@ -715,6 +715,9 @@ indices (for irregular domains).  If the domain variable being
 assigned was used to declare arrays, these arrays are reallocated as
 discussed in~\rsec{Association_of_Arrays_to_Domains}.
 
+It is an error to assign a stridable domain to an unstridable domain
+without an explicit conversion.
+
 \begin{example}
 The following three assignments show ways of assigning indices to a
 sparse domain, \chpl{SpsD}.  The first assigns the domain two index

--- a/spec/Ranges.tex
+++ b/spec/Ranges.tex
@@ -475,8 +475,10 @@ Range assignment is legal when:
 \item An implicit conversion is allowed from \chpl{idxType} of the source range
        to \chpl{idxType} of the destination range type,
 \item the two range types have the same \chpl{boundedType}, and
-\item either the destination range is stridable or the source range's
-      stride is 1.
+\item either the destination range is stridable or the source range
+      is not stridable.
+\item Or an explicit conversion is used to make the source range match the
+      type of the destination range.
 \end{itemize}
 
 \subsection{Range Comparisons}

--- a/spec/Ranges.tex
+++ b/spec/Ranges.tex
@@ -477,8 +477,6 @@ Range assignment is legal when:
 \item the two range types have the same \chpl{boundedType}, and
 \item either the destination range is stridable or the source range
       is not stridable.
-\item Or an explicit conversion is used to make the source range match the
-      type of the destination range.
 \end{itemize}
 
 \subsection{Range Comparisons}


### PR DESCRIPTION
Added range and domain explicit conversions to the spec and updated the
range and domain assignment sections to mention that it is an error to assign
a stridable range/domain to an unstridable one without an explicit cast.