### PR TITLE
Fix task par and multi yield leader failures

### DIFF
--- a/test/parallel/begin/vass/multi-yield-leader.chpl
+++ b/test/parallel/begin/vass/multi-yield-leader.chpl
@@ -9,7 +9,6 @@ Just two yields within the leader would be sufficient, but
 it seems an 'if' is also needed. A couple of extra yields are just frills.
 */
 
-extern proc chpl_task_sleep(t:uint) : void; // instead of 'use Time'
 config const x = 0;  // ensure it's not known to the compiler
 
 // viter (Vass's iter): a leader with multiple yields
@@ -32,18 +31,20 @@ iter viter(param tag: iterKind, followThis) where tag == iterKind.follower {
 // 'forall' and the array are within a function
 proc test() {
   var AA7: [0..2] real;
-  forall idx7 in viter() do begin {
-    AA7(idx7) = 77;
+  sync {
+    forall idx7 in viter() do begin {
+        AA7(idx7) = 77;
+      }
   }
-  chpl_task_sleep(1);
   writeln(AA7);
 }
 test();
 
 // now the same at the top level
 var AA9: [0..2] real;
-forall idx9 in viter() do begin {
-  AA9(idx9) = 99;
+sync {
+  forall idx9 in viter() do begin {
+      AA9(idx9) = 99;
+    }
 }
-chpl_task_sleep(1);
 writeln(AA9);

--- a/test/parallel/taskPar/figueroa/taskParallel.chpl
+++ b/test/parallel/taskPar/figueroa/taskParallel.chpl
@@ -116,12 +116,12 @@ proc player(num) {
     }
 
     // This while statement makes a choice for each round of the game.
-    while notTired.readFF() {
+    do {
       var rockPaperScissors = chooseBetweenRockPaperScissors();
-      if refereeReady(num) && notTired.readFF() then
+      if refereeReady(num) then
         writeln ("Player ", num, ": ", rockPaperScissors);
       choice(num) = rockPaperScissors;
-    }
+    } while notTired.readFF();
   }
 
   // In order to ensure that the referee doesn't hang waiting for a player to
@@ -166,7 +166,7 @@ proc referee () {
     }
 
     // This while statement declares the winner for each round of the game.
-    while notTired.readFF() {
+    do {
       var delay = RandomNumber() * 2 + 1.0;
       sleep (delay : uint);
 
@@ -186,7 +186,7 @@ proc referee () {
       var player1 = choice(1),
           player2 = choice(2);
       determineWinner (player1, player2);
-    }
+    } while notTired.readFF();
   }
 
   // In order to ensure that none of the players hang waiting for the referee


### PR DESCRIPTION
Fix failures in taskPar and multi-yield-leader tests

multi-yield-leader.chpl
-----------------------

Using sleep() does not guarantee the expected execution.
Indeed it failed on 9/25 in our whitebox nightly testing.
Replacing it with sync{}.

parallel/taskPar/figueroa/taskParallel.chpl
-------------------------------------------

Note this is not in release primers.

It was possible - however unlikely - that legal output of this test,
after being processed with .prediff, would fall short of .good.
There are two possible scenarios:

(1) In both invocations of player(), i.e. player(1) and player(2):

* The test notTired.readFF() in the while loop header succeeds
the first time around.

* The same test notTired.readFF() in the if statement fails,
because notTired has been set to false since it was tested
in the while loop.

When this happens, the output will miss the lines:

  Player {1,2}: {rock,paper,scissors}
  # or, after prediff-ing:
  Player X: rock, paper, or scissors

Note that the referee will still judge the game (call determineWinner())
because choice({1,2} gets set after each player() exists the while loop.
So the following line will still get printed:

  Referee: Player {1,2} wins!
  # or, after prediff-ing:
  Referee: Player X wins!

(2) By the time notTired.readFF() is checked in referee() in the while
loop the first time around, notTired has already been set to false.

In this case, both of the above line groups will be missing from the output.
This is what we probably observed in the whitebox nightly failure on 9/25

To ensure that both the players and the referee play at least one game,
and therefore to ensure matching of the prediff-ed output, I am convering
a while-do loop to do-while. I am also removing the duplicate check
for notTired.readFF() within the players' if statement.

The above scenarios can probably still happen, however that can be
only after each loop is executed once. Which should not affect the
output after prediff-ing, as it sorts out duplicate lines.
