### PR TITLE
Remove the chplvis primers from the generated html due to redundancy

### DIFF
--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -53,7 +53,7 @@ primers: clean-primers
 	@#Note - this assumes that we are not in a release tar ball
 	$(CHPL2RST) $(CHPL2RSTOPTS) ../../test/release/examples/primers/*.chpl
 	$(CHPL2RST) $(CHPL2RSTOPTS) ../../test/release/examples/primers/*doc.chpl --codeblock
-	$(CHPL2RST) $(CHPL2RSTOPTS) ../../test/release/examples/primers/chplvis/*.chpl
+	cp ../../test/release/examples/primers/chplvis/*.chpl source/primers/primers/
 
 
 checkdocs: FORCE

--- a/doc/sphinx/source/primers/index.rst
+++ b/doc/sphinx/source/primers/index.rst
@@ -87,10 +87,6 @@ Tools
    :maxdepth: 1
 
    chpldoc <primers/chpldoc.doc>
-   chplvis example 1 <primers/chplvis1>
-   chplvis example 2 <primers/chplvis2>
-   chplvis example 3 <primers/chplvis3>
-   chplvis example 4 <primers/chplvis4>
 
 Language Overview
 -----------------

--- a/doc/sphinx/source/tools/chplvis/chplvis.rst
+++ b/doc/sphinx/source/tools/chplvis/chplvis.rst
@@ -51,28 +51,19 @@ Example 1
 
 Consider the chapel program ``prog1.chpl``: (The example programs in this
 primer are found in the directory ``examples/primers/chplvis`` in your
-distribution tree.  The files have more comments than are shown here.)
+distribution tree.)
 
-.. code-block:: chapel
-
-     //  Example 1 using visual debug
-
-     use VisualDebug;
-
-     startVdebug("E1");
-
-     coforall loc in Locales do
-       on loc do writeln("Hello from locale " + here.id + ".");
-
-     stopVdebug();
+.. literalinclude:: ../../primers/primers/chplvis1.chpl
+   :language: chapel
+   :lines: 1-3, 6-28
 
 Compiling the program and running it with the options ``-nl 6`` will then
 produce a directory called ``E1`` containing 6 data files, one
 for each of the locales and named ``E1-n`` where ``n`` is
 replaced with the locale number, a number from 0 to 5.  Once this
 directory is created, one can run ``chplvis`` as ``chplvis E1`` or
-simply ``chplvis`` and then opening the file ``E1/E1-0``
-from the ``file/open`` menu.  The resulting display is:
+simply ``chplvis`` and then open the file ``E1/E1-0`` from the
+``file/open`` menu.  The resulting display is:
 
 .. image:: E1.png
 
@@ -182,7 +173,7 @@ programs run by starting low level tasks to do the required jobs. This
 display shows the order the tasks are executed and the color of each
 task shows the clock time for that task.  The black vertical vertical
 lines show the life time of the task.  There are two kinds of tasks
-shown: tasks started remotely via the "on" statements (on calls) to
+shown: tasks started remotely via the ``on`` statements (on calls) to
 this locale indicated by an *OC* and tasks started locally indicated
 by an *L*.  Also, some tasks communicate with other locales and others
 do not.   The tasks that communicate with other locales are marked with
@@ -337,52 +328,9 @@ their program in addition to seeing the total statistics.  ``prog2.chpl``
 gives an example of using the :mod:`VisualDebug` functions
 :proc:`~VisualDebug.tagVdebug` and :proc:`~VisualDebug.pauseVdebug`.
 
-.. code-block:: chapel
-
-    // Example 2 of use of VisualDebug module and chplvis tool.
-
-    use BlockDist;
-    use VisualDebug;
-
-    config var ncells = 10;
-
-    proc main() {
-
-       // Create a couple of domains and a block mapped data array.
-       const Domain = { 1 .. ncells };
-       const mapDomain = Domain dmapped Block(Domain);
-
-       var  data : [mapDomain] int = 1;
-
-       // Start VisualDebug here
-       startVdebug ("E2");
-
-       // First computation step ... a simple forall
-       forall i in Domain do data[i] += here.id + 1;
-
-       // Write the result, we want to see the results of the above
-       // so we tag before we continue.
-       tagVdebug("writeln 1");
-       writeln("data= ", data);
-
-       // Second computation step ... using the distributed domain
-       tagVdebug("step 2");
-       forall i in mapDomain do data[i] += here.id+1;
-
-       // Don't capture the writeln
-       pauseVdebug();
-       writeln("data2= ", data);
-
-       // Reduction step
-       tagVdebug("reduce");
-       var i = + reduce data;
-
-       // done with visual debug
-       stopVdebug();
-
-       writeln ("sum is " + i + ".");
-    }
-
+.. literalinclude:: ../../primers/primers/chplvis2.chpl
+   :language: chapel
+   :lines: 1-3, 6-
 
 Note that the ``startVdebug("E2")`` is placed after the declarations
 so that tasks and communication for the declarations are not included.
@@ -561,47 +509,8 @@ To help show another feature of the "`Concurrency View`_", prog4.chpl was
 written to create a *begin* task on all locales and have those tasks
 live across calls to the :mod:`VisualDebug` module.  The code is:
 
-.. code-block:: chapel
-
-   // Example 4, begin tasks as shown in chplvis
-   // This is a contrived example to have tasks live
-   // across a tagVdebug() call.
-
-   use VisualDebug;
-   use BlockDist;
-
-   const space =  { 0 .. #numLocales };
-   const Dspace = space dmapped Block (boundingBox=space);
-
-   startVdebug("E4");
-
-   var go$: [Dspace] single bool;
-   var done$: [Dspace] single bool;
-
-   // Start a begin task on all locales.  The task will start and then block.
-   coforall loc in Locales do
-     on loc do begin { // start a async task
-
-              go$[here.id]; // Block until ready!
-              writeln ("Finishing running the 'begin' statement on locale "
-                        + here.id + ".");
-              done$[here.id] = true;
-           }
-
-   tagVdebug("loc");
-
-   coforall loc in Locales do
-       on loc do writeln("Hello from " + here.id);
-
-   tagVdebug("finish");
-
-   // Let all tasks go
-   go$ = true;
-
-   // Wait until all tasks are finished
-   done$;
-
-   stopVdebug();
+.. literalinclude:: ../../primers/primers/chplvis4.chpl
+   :language: chapel
 
 First we will look at the results of running this code on a single
 locale.  Even though there is no communication, ``chplvis`` can help

--- a/test/release/examples/primers/chplvis/chplvis1.chpl
+++ b/test/release/examples/primers/chplvis/chplvis1.chpl
@@ -1,7 +1,7 @@
 // chplvis: Basic Usage
 
 //  Example 1 using visual debug
-//  Full primer is found in doc/chplvis/chplvis.rst.
+//  Full primer is found in doc/sphinx/source/tools/chplvis/chplvis.rst.
 //  Please read that documentation for a better understanding of chplvis.
 
 //  The standard module "VisualDebug" is needed to generate data
@@ -27,5 +27,5 @@ stopVdebug();
 //  Now that the program has completed and generated data files,
 //  run "chplvis E1" to look at the results.
 //
-//  The chplvis.rst documentation in doc/chplvis shows you what
-//  you should expect to see when running chplvis.
+//  The chplvis.rst documentation in doc/sphinx/source/tools/chplvis shows you
+//  what you should expect to see when running chplvis.

--- a/test/release/examples/primers/chplvis/chplvis2.chpl
+++ b/test/release/examples/primers/chplvis/chplvis2.chpl
@@ -1,8 +1,8 @@
 // chplvis: Tags
 
-// Example 2 of use of VisualDebug module and chplvis tool.
-// Read the file doc/chplvis/chplvis.rst for full documentation
-// on chplvis.
+// Example 2 of use of the VisualDebug module and chplvis tool.
+// Read the file doc/sphinx/source/tools/chplvis/chplvis.rst for full
+// documentation on chplvis.
 
 use BlockDist;
 use VisualDebug;


### PR DESCRIPTION
The chplvis tools description provides much of the same information as the
primers, including many of the code blocks.  It is also more extensive.  Make
it directly include the code it can include easily, and drop the primers from
their location within the primers hierarchy.

I updated the Makefile to copy the .chpl files to an expected location so that
it will be consistent, no matter the final layout of the test directory.  I
updated the primers index to no longer include the chplvis files.  I replaced
the code blocks for Examples 1, 2, and 4 with direct references to the copied
files (I did not do the same for Example 3 as it is more selective in the code
it demonstrates).  I updated the comment on Example 1's lead in to no longer
mention that the .chpl file has more comments (and had the include of that
file and the file for Example 2 ignore the comments referencing the tools
description's location).  I fixed a grammatical error, back tic'ed a reference
to "on statements", and updated the references in the primer .chpl files to
point to the current location of the chplvis.rst file.

Verified that the html output pleased me.