### PR TITLE
Document support for iterator type methods

### DIFF
--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -872,6 +872,35 @@ true
 \end{chapeloutput}
 \end{chapelexample}
 
+Type methods can also be iterators.
+
+\begin{chapelexample}{typeMethodIter.chpl}
+In the following code, the record \chpl{R} defines a type method
+iterator which can be invoked on the type itself:
+\begin{chapel}
+record R {
+  var x: int;
+  var y: string;
+
+  iter type myIter() {
+    yield 3;
+    yield 5;
+    yield 7;
+    yield 11;
+  }
+}
+
+for r in R.myIter() do
+  writeln(r);
+\end{chapel}
+\begin{chapeloutput}
+3
+5
+7
+11
+\end{chapeloutput}
+\end{chapelexample}
+
 When \sntx{this-intent} is \chpl{ref}, the receiver argument will be
 passed by reference, allowing modifications to \chpl{this}.  If
 no \sntx{this-intent} is specified, the receiver will be passed with
@@ -949,8 +978,8 @@ thisMethod.chpl:9: error: halt reached - ThreeArray index out of bounds: 4
 \index{these@\chpl{these}}
 \index{classes!these@\chpl{these}}
 
-An iterator method declared with the name \chpl{these} allows a class to be
-``iterated over'' similarly to how a domain or array is iterated over.
+An iterator method declared with the name \chpl{these} allows a class object to be
+``iterated over'' similarly to how a domain or array supports iteration.
 Using a class in the context of a loop where
 an \sntx{iteratable-expression} is expected has the semantics of calling
 a method on the class named \chpl{these}.
@@ -984,6 +1013,36 @@ delete ta;
 3
 \end{chapeloutput}
 
+\end{chapelexample}
+
+An iterator type method with the name \chpl{these} supports iteration
+over the class type itself.
+
+\begin{chapelexample}{typeMethodIterThese.chpl}
+In the following code, the record \chpl{R} defines a type method
+iterator named these, supporting direct iteration over the type:
+\begin{chapel}
+record R {
+  var x: int;
+  var y: string;
+
+  iter type these() {
+    yield 1;
+    yield 2;
+    yield 4;
+    yield 8;
+  }
+}
+
+for r in R do
+  writeln(r);
+\end{chapel}
+\begin{chapeloutput}
+1
+2
+4
+8
+\end{chapeloutput}
 \end{chapelexample}
 
 \section{Common Operations}

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -875,7 +875,7 @@ true
 Type methods can also be iterators.
 
 \begin{chapelexample}{typeMethodIter.chpl}
-In the following code, the class \chpl{R} defines a type method
+In the following code, the class \chpl{C} defines a type method
 iterator which can be invoked on the type itself:
 \begin{chapel}
 class C {
@@ -1019,7 +1019,7 @@ An iterator type method with the name \chpl{these} supports iteration
 over the class type itself.
 
 \begin{chapelexample}{typeMethodIterThese.chpl}
-In the following code, the class \chpl{R} defines a type method
+In the following code, the class \chpl{C} defines a type method
 iterator named \chpl{these}, supporting direct iteration over the type:
 \begin{chapel}
 class C {

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -878,7 +878,7 @@ Type methods can also be iterators.
 In the following code, the record \chpl{R} defines a type method
 iterator which can be invoked on the type itself:
 \begin{chapel}
-record R {
+class R {
   var x: int;
   var y: string;
 
@@ -1022,7 +1022,7 @@ over the class type itself.
 In the following code, the record \chpl{R} defines a type method
 iterator named these, supporting direct iteration over the type:
 \begin{chapel}
-record R {
+class R {
   var x: int;
   var y: string;
 

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -878,7 +878,7 @@ Type methods can also be iterators.
 In the following code, the class \chpl{R} defines a type method
 iterator which can be invoked on the type itself:
 \begin{chapel}
-class R {
+class C {
   var x: int;
   var y: string;
 
@@ -890,8 +890,8 @@ class R {
   }
 }
 
-for r in R.myIter() do
-  writeln(r);
+for i in C.myIter() do
+  writeln(i);
 \end{chapel}
 \begin{chapeloutput}
 3
@@ -1020,9 +1020,9 @@ over the class type itself.
 
 \begin{chapelexample}{typeMethodIterThese.chpl}
 In the following code, the class \chpl{R} defines a type method
-iterator named these, supporting direct iteration over the type:
+iterator named \chpl{these}, supporting direct iteration over the type:
 \begin{chapel}
-class R {
+class C {
   var x: int;
   var y: string;
 
@@ -1034,8 +1034,8 @@ class R {
   }
 }
 
-for r in R do
-  writeln(r);
+for i in C do
+  writeln(i);
 \end{chapel}
 \begin{chapeloutput}
 1

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -875,7 +875,7 @@ true
 Type methods can also be iterators.
 
 \begin{chapelexample}{typeMethodIter.chpl}
-In the following code, the record \chpl{R} defines a type method
+In the following code, the class \chpl{R} defines a type method
 iterator which can be invoked on the type itself:
 \begin{chapel}
 class R {
@@ -1019,7 +1019,7 @@ An iterator type method with the name \chpl{these} supports iteration
 over the class type itself.
 
 \begin{chapelexample}{typeMethodIterThese.chpl}
-In the following code, the record \chpl{R} defines a type method
+In the following code, the class \chpl{R} defines a type method
 iterator named these, supporting direct iteration over the type:
 \begin{chapel}
 class R {


### PR DESCRIPTION
This is a simple change to the language specification to clarify that type methods also support type iterators (where the default these() type iterator method is new as of this release).
