### PR TITLE
Update deprecated/bigint.good so that it is insensitive to line #'s in GMP.chpl

### DIFF
--- a/test/deprecated/PREDIFF
+++ b/test/deprecated/PREDIFF
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Ignores line numbers printed upon compilerError in Sort.chpl
+# Note: This is a work around for a bug. The line numbers should not be printed
+#
+
+tmpfile=$2
+
+tmptmp=`mktemp "tmp.XXXXXX"`
+
+regex='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+sed -e "$regex" $tmpfile > $tmptmp
+
+mv $tmptmp $tmpfile

--- a/test/deprecated/bigint.good
+++ b/test/deprecated/bigint.good
@@ -2,8 +2,8 @@ bigint.chpl:10: In function 'main':
 bigint.chpl:11: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
 bigint.chpl:12: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
 bigint.chpl:13: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
-$CHPL_HOME/modules/standard/GMP.chpl:1244: In function 'maybeCopy':
-$CHPL_HOME/modules/standard/GMP.chpl:1249: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
+$CHPL_HOME/modules/standard/GMP.chpl:nnnn: In function 'maybeCopy':
+$CHPL_HOME/modules/standard/GMP.chpl:nnnn: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
 bigint.chpl:10: In function 'main':
 bigint.chpl:18: warning: The class GMP.BigInt has been deprecated.  Please use the record BigInteger.bigint instead
 1138933401033937535238526500721813276068


### PR DESCRIPTION
The test deprecated/bigint.chpl confirms that the constructor for the old BigInt class
generates a warning.  However this makes it sensitive to edits to GMP.chpl.  Adopted
BenA's recent PREDIFF as a work-around for this.

Tested on clang/darwin and gnu/linux64
