### PR TITLE
Add ability to specify n_cpus to use for chpl_launchcmd.py

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -146,6 +146,9 @@ class AbstractJob(object):
         :returns: Number of cpus to reserve, or -1 if there was no cnselect output
         """
         try:
+            n_cpus = os.environ.get('CHPL_LAUNCHCMD_NUM_CPUS')
+            if n_cpus is not None:
+                return n_cpus
             logging.debug('Checking for number of cpus to reserve.')
             cnselect_proc = subprocess.Popen(
                 ['cnselect', '-Lnumcores'],


### PR DESCRIPTION
Instead of always going with the lowest value reported by cnselect, add the
ability to set the number of cpus via an env var.