### PR TITLE
Re-add a space to the expected output of the zipper.chpl spec test

### DIFF
--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -569,7 +569,7 @@ writeln();
 \end{chapelpost}
 is
 \begin{chapelprintoutput}{}
-1 4 2 5 3 6
+1 4 2 5 3 6 
 \end{chapelprintoutput}
 \end{chapelexample}
 


### PR DESCRIPTION
It was accidentally removed with #4703, leading the spec test to fail