### PR TITLE
Replace 4 FnSymbol fields + 1 FLAG with hashtable

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -208,7 +208,6 @@ symbolFlag( FLAG_PARAM , npr, "param" , "parameter (compile-time constant)" )
 
 symbolFlag( FLAG_PARENT_FIELD , npr, "parent field" , "field from parent type" )
 
-symbolFlag( FLAG_PARTIAL_COPY, npr, "partial copy", ncm )
 symbolFlag( FLAG_PARTIAL_TUPLE, npr, "partial tuple", ncm)
 
 // Is this type a Plain-Old Data (POD) type - ie no autocopy/destructor/=

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -384,20 +384,11 @@ class FnSymbol : public Symbol {
   int codegenUniqueNum;
   const char *doc;
 
-  // The following fields are used only when hasFlag(FLAG_PARTIAL_COPY)
-  // to pass information from partialCopy() to finalizeCopy().
-  /// Used to keep track of symbol substitutions during partial copying.
-  SymbolMap partialCopyMap;
-  /// Source of a partially copied function.
-  FnSymbol* partialCopySource;
-  /// Vararg formal to be replaced with individual formals, or NULL.
-  ArgSymbol* varargOldFormal;
-  /// Individual formals to replace varargOldFormal.
-  std::vector<ArgSymbol*> varargNewFormals;
-
-  /// Used to store the return symbol during partial copying.
+  // Used to store the return symbol during partial copying.
+  // Move to PartialCopyData?
   Symbol* retSymbol;
-  /// Number of formals before tuple type constructor formals are added.
+
+  // Number of formals before tuple type constructor formals are added.
   int numPreTupleFormals;
 
 #ifdef HAVE_LLVM
@@ -634,6 +625,30 @@ const char* intentDescrString(IntentTag intent);
 // Return true if the arg must use a C pointer whether or not
 // pass-by-reference intents are used.
 bool argMustUseCPtr(Type* t);
+
+//
+// Used to pass information from partialCopy() to finalizeCopy().
+//
+class PartialCopyData {
+ public:
+  // Used to keep track of symbol substitutions during partial copying.
+  SymbolMap partialCopyMap;
+  // Source of a partially copied function.
+  FnSymbol* partialCopySource;
+  // Vararg formal to be replaced with individual formals, or NULL.
+  ArgSymbol* varargOldFormal;
+  // Individual formals to replace varargOldFormal.
+  std::vector<ArgSymbol*> varargNewFormals;
+
+  PartialCopyData() : partialCopySource(NULL), varargOldFormal(NULL) { }
+  ~PartialCopyData() { partialCopyMap.clear(); varargNewFormals.clear(); }
+};
+
+PartialCopyData* getPartialCopyInfo(FnSymbol* fn);
+PartialCopyData& addPartialCopyInfo(FnSymbol* fn);
+void clearPartialCopyInfo(FnSymbol* fn);
+void clearPartialCopyFnMap();
+void checkEmptyPartialCopyFnMap();
 
 void substituteVarargTupleRefs(BlockStmt* ast, int numArgs, ArgSymbol* formal,
                                std::vector<ArgSymbol*>& varargFormals);

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -396,6 +396,7 @@ void check_afterEveryPass()
     verify();
     checkForDuplicateUses();
     checkFlagRelationships();
+    checkEmptyPartialCopyFnMap();
   }
 }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1882,15 +1882,15 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
       bool needTupleInBody = true; //avoid "may be used uninitialized" warning
 
       // Replace mappings to the old formal with mappings to the new variable.
-      if (workingFn->hasFlag(FLAG_PARTIAL_COPY)) {
+      if (PartialCopyData* pci = getPartialCopyInfo(workingFn)) {
         bool gotFormal = false; // for assertion only
-        for (int index = workingFn->partialCopyMap.n; --index >= 0;) {
-          SymbolMapElem& mapElem = workingFn->partialCopyMap.v[index];
+        for (int index = pci->partialCopyMap.n; --index >= 0;) {
+          SymbolMapElem& mapElem = pci->partialCopyMap.v[index];
 
           if (mapElem.value == formal) {
             gotFormal = true;
             needTupleInBody =
-              needVarArgTupleAsWhole(workingFn->partialCopySource->body, n,
+              needVarArgTupleAsWhole(pci->partialCopySource->body, n,
                                      toArgSymbol(mapElem.key));
 
             if (needTupleInBody) {
@@ -1898,8 +1898,8 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
             } else {
               // We will rely on mapElem.value==formal to replace it away
               // in finalizeCopy().  This assumes a single set of varargs.
-              workingFn->varargOldFormal = formal;
-              workingFn->varargNewFormals = varargFormals;
+              pci->varargOldFormal = formal;
+              pci->varargNewFormals = varargFormals;
             }
 
             break;
@@ -2004,9 +2004,9 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
           workingFn->insertAtHead(new DefExpr(var));
         }
 
-        if (workingFn->hasFlag(FLAG_PARTIAL_COPY)) {
+        if (PartialCopyData* pci = getPartialCopyInfo(workingFn)) {
           // If this is a partial copy, store the mapping for substitution later.
-          workingFn->partialCopyMap.put(formal, var);
+          pci->partialCopyMap.put(formal, var);
         } else {
           // Otherwise, do the substitution now.
           subSymbol(workingFn->body, formal, var);
@@ -7476,7 +7476,7 @@ resolveExpr(Expr* expr) {
             !ct->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
           resolveFormals(ct->defaultTypeConstructor);
           if (resolvedFormals.set_in(ct->defaultTypeConstructor)) {
-            if (ct->defaultTypeConstructor->hasFlag(FLAG_PARTIAL_COPY))
+            if (getPartialCopyInfo(ct->defaultTypeConstructor))
               instantiateBody(ct->defaultTypeConstructor);
             resolveFns(ct->defaultTypeConstructor);
           }
@@ -8445,6 +8445,7 @@ resolve() {
   }
   visibleFunctionMap.clear();
   visibilityBlockCache.clear();
+  clearPartialCopyFnMap();
 
   forv_Vec(BlockStmt, stmt, gBlockStmts) {
     stmt->moduleUseClear();

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -843,7 +843,7 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
  */
 void
 instantiateBody(FnSymbol* fn) {
-  if (fn->hasFlag(FLAG_PARTIAL_COPY)) {
+  if (getPartialCopyInfo(fn)) {
     fn->finalizeCopy();
 
     if (fn->hasFlag(FLAG_PARTIAL_TUPLE)) {


### PR DESCRIPTION
... or, more precisely, with a std::map.

The need to do this was suggested by Mike in while reviewing #3838.

FLAG_PARTIAL_COPY and these fields of FnSymbol:

 partialCopyMap
 partialCopySource
 varargOldFormal
 varargNewFormals

were used internally during resolution. Our guideline for this case
is to use a hashtable instead of a field. This is what this change does.

DETAILS

* The existence of the entry partialCopyFnMap[fn] is equivalent to
the former fn->hasFlag(FLAG_PARTIAL_COPY).

* I made values in partialCopyFnMap be the actual data, rather than
a pointer to a struct/class allocated separately, to avoid indirection
and alloc/free. So there is an entry IFF there is data.
I was able to make that work nicely using helper functions.

I use a single hashtable for all four fields rather than a separate
hashtable for each field. This should reduce overhead e.g. hashing.

* I made partialCopyFnMap's keys to be node IDs. Since some FnSymbols
present in the map will be deleted from the tree and deallocated,
using FnSymbol* for their keys could result in bogus entries.

* Currently I am cleaning up partialCopyFnMap at the end of resolution
and verifying that it is empty at the end of each pass. My use of
node IDs for keys allows us to relax the "clear at the end of each pass"
rule in the future, should that be needed.

OPEN QUESTIONS

* How to switch partialCopyFnMap to be a hashtable?

When compiling hello4, it grows to 6100 entries, so using a binary tree
that std::map is is unfortunate. Ideally, make it std::unordered_map,
however that's not supported well by gcc 4.7. One way to address that is
a suggestion from David K:

#if __cplusplus < 201103
typedef std::map<a,b> partialCopyType
#else
typedef std::unordered_map<a,b> partialCopyType;
#endif

Or, resort to using our own HashMap from map.h.

* Should I put empty initializers for partialCopyMap and varargNewFormals
in the constructor for PartialCopyData?

* See if FnSymbol::retSymbol can be moved to PartialCopyData as well.
While there is a comment on the field saying "during partial copying,"
it appeared non-obvious that this is actually the case.

Passes full linux64 testing and multilocale tests under gasnet.
