### PR TITLE
Try fixing whitebox testing (round 2)

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -148,8 +148,14 @@ export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 # Ensure that one of the CPU modules is loaded.
 my_arch=$($CHPL_HOME/util/chplenv/chpl_arch.py 2> /dev/null)
 if [ "${my_arch}" = "none" ] ; then
-    log_info "Loading craype-shanghai module to stifle chpl_arch.py warnings."
-    module load craype-shanghai
+    if [ "${HOSTNAME:0:6}" = "esxbld" ] ; then
+        module unload $(module list -t 2>&1| grep craype-| grep -v craype-network |grep -v craype-target)
+        log_info "Setting CRAY_CPU_TARGET to x86-64 to stifle chpl_arch.py warnings."
+        export CRAY_CPU_TARGET=x86-64
+    else
+        log_info "Loading craype-shanghai module to stifle chpl_arch.py warnings."
+        module load craype-shanghai
+    fi
 fi
 
 if [ "${COMP_TYPE}" != "HOST-TARGET-no-PrgEnv" ] ; then


### PR DESCRIPTION
Apparently there's no appropriate cpu targeting module on our new whiteboxes..
so we have to force it to use x86-64.

Any of the AMD targeting modules result in a segfault, and any of the intel
ones are too new resulting in Illegal CPU instructions :(