### PR TITLE
Try fixing whitebox testing (round 3)

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -106,7 +106,7 @@ case $COMPILER in
         # swap out network modules to get "host-only" environment
         log_info "Swap network module for host-only environment."
         module unload $(module list -t 2>&1 | grep craype-network)
-        module load craype-target-local_host
+        module load craype-network-none
         ;;
     pgi)
         # EJR (04/07/16): Since the default pgi was upgraded from 15.10.0 to
@@ -148,14 +148,15 @@ export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 # Ensure that one of the CPU modules is loaded.
 my_arch=$($CHPL_HOME/util/chplenv/chpl_arch.py 2> /dev/null)
 if [ "${my_arch}" = "none" ] ; then
-    if [ "${HOSTNAME:0:6}" = "esxbld" ] ; then
-        module unload $(module list -t 2>&1| grep craype-| grep -v craype-network |grep -v craype-target)
-        log_info "Setting CRAY_CPU_TARGET to x86-64 to stifle chpl_arch.py warnings."
-        export CRAY_CPU_TARGET=x86-64
-    else
-        log_info "Loading craype-shanghai module to stifle chpl_arch.py warnings."
-        module load craype-shanghai
-    fi
+    log_info "Loading craype-shanghai module to stifle chpl_arch.py warnings."
+    module load craype-shanghai
+fi
+
+# no cpu targeting module supports the esxbld CPUs, so force x86-64
+if [ "${HOSTNAME:0:6}" = "esxbld" ] ; then
+    module unload $(module list -t 2>&1| grep craype-| grep -v craype-network |grep -v craype-target)
+    log_info "Setting CRAY_CPU_TARGET to x86-64 to stifle chpl_arch.py warnings."
+    export CRAY_CPU_TARGET=x86-64
 fi
 
 if [ "${COMP_TYPE}" != "HOST-TARGET-no-PrgEnv" ] ; then


### PR DESCRIPTION
craype-target-local_host is deprecated, use craype-network-none instead

A default CPU targeting module is loaded on esxbld*, but it doesn't work so
force x86-64 even if a targeting module was loaded