### PR TITLE
Retire two I/O futures

### DIFF
--- a/STATUS.devel
+++ b/STATUS.devel
@@ -732,11 +732,6 @@ Standard Modules, Standard Distributions, and Standard Layouts
 
 Input and Output
 ----------------
-- Input of whole arrays is not implemented.
-  Workaround: use a loop, e.g., for e in A do read(e);
-  # types/file/fileIO.future
-- Reading of tuple types not supported.
-  # io/bradc/readTuple.future
 - Printing of replicated arrays may not work properly.
   # io/vass/writeThis-on.future
 - Using 'on' in a writeThis() method can lead to a deadlock.

--- a/test/io/bradc/readTuple.dat
+++ b/test/io/bradc/readTuple.dat
@@ -1,4 +1,4 @@
-1 2 3
-3.4 five true
-6 7 8
-9.0 ten false
+(1, 2, 3)
+(3.4, five , true)
+(6, 7, 8)
+(9.0, ten , false)

--- a/test/io/bradc/readTuple.future
+++ b/test/io/bradc/readTuple.future
@@ -1,9 +1,0 @@
-bug: reading tuple type
-
-Although the new QIO system supports the ability to read a given type
-(e.g., read(int)), it seems that it does not permit this type to be a
-tuple type (e.g., read((int, int))).  However, through the use of
-varargs type functions, it does support the following as a workaround:
-read(int, int).  That said, I think that for orthogonality, it should
-support reading a single tuple type as well, so this bug checks for
-that.

--- a/test/types/file/fileIO.chpl
+++ b/test/types/file/fileIO.chpl
@@ -1,9 +1,9 @@
 config var n = 10,
            filename = "arr.out";
 
-const ADom = [1..n, 1..n];
+const ADom = {1..n, 1..n};
 
-var A: [(i,j) in ADom] real = (i-1) + ((j-1)/10.0);
+var A: [ADom] real = [(i,j) in ADom] (i-1) + ((j-1)/10.0);
 
 writeArray(n, A, filename);
 var B = readArray(filename);
@@ -20,7 +20,7 @@ if (numErrors > 0) {
 
 
 proc writeArray(n, X, filename) {
-  var outfile = open(filename, iomode.w).writer();
+  var outfile = open(filename, iomode.cw).writer();
   outfile.writeln(n, " ", n);
   outfile.writeln(X);
   outfile.close();
@@ -33,7 +33,7 @@ proc readArray(filename) {
   var infile = open(filename, iomode.r).reader();
   infile.read(m, n);
 
-  const XDom = [1..m, 1..n];
+  const XDom = {1..m, 1..n};
   var X: [XDom] real;
 
   infile.read(X);

--- a/test/types/file/fileIO.future
+++ b/test/types/file/fileIO.future
@@ -1,3 +1,0 @@
-unimplemented feature: array reads
-
-reading arrays from files doesn't work


### PR DESCRIPTION
Both of these futures are wrong, in that reading tuples and arrays is in fact supported and functional. It's just that these futures were not testing for what works currently.

Discussed with @bradcray.
