### PR TITLE
Document dim and dims.

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1007,16 +1007,15 @@ module ChapelArray {
     }
 
     /*
-       Returns a tuple of ranges for a rectangular domain.
-       This tuple represents the bounds of the domain.
-       For sparse domains, returns the bounds of the parent domain.
-       */
+       Returns a tuple of ranges describing the bounds of a rectangular domain.
+       For a sparse domain, returns the bounds of the parent domain.
+     */
     proc dims() return _value.dsiDims();
 
     /*
        Returns a range representing the boundary of this
        domain in a particular dimension.
-       */
+     */
     proc dim(d : int) return _value.dsiDim(d);
 
     pragma "no doc"

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1006,10 +1006,17 @@ module ChapelArray {
         compilerError("a domain slice requires either a single domain argument or exactly one argument per domain dimension");
     }
 
-    pragma "no doc"
+    /*
+       Returns a tuple of ranges for a rectangular domain.
+       This tuple represents the bounds of the domain.
+       For sparse domains, returns the bounds of the parent domain.
+       */
     proc dims() return _value.dsiDims();
 
-    pragma "no doc"
+    /*
+       Returns a range representing the boundary of this
+       domain in a particular dimension.
+       */
     proc dim(d : int) return _value.dsiDim(d);
 
     pragma "no doc"


### PR DESCRIPTION
Adds basic documentation comments for proc dims() and proc dim(d:int).

We could also document proc dim(param d) and iter dimIter, but
Brad pointed out problems with that:
 * we probably can't actually do anything with the param version
   of proc dim.
 * dimIter isn't implemented very completely and might
   need a different interface to support arbitrary iteration
   orders over multidimensional sparse domains/arrays.

Discussed with/reviewed by @bradcray and @vasslitvinov.