### PR TITLE
Change return type of PRIM_GETCID

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -460,7 +460,7 @@ initPrimitive() {
 
   prim_def(PRIM_SETCID, "setcid", returnInfoVoid, true, true);
   prim_def(PRIM_TESTCID, "testcid", returnInfoBool, false, true);
-  prim_def(PRIM_GETCID, "getcid", returnInfoBool, false, true);
+  prim_def(PRIM_GETCID, "getcid", returnInfoInt32, false, true);
   prim_def(PRIM_SET_UNION_ID, "set_union_id", returnInfoVoid, true, true);
   prim_def(PRIM_GET_UNION_ID, "get_union_id", returnInfoDefaultInt, false, true);
   prim_def(PRIM_GET_MEMBER, ".", returnInfoGetMemberRef);

--- a/test/users/engin/getcid-rettype.chpl
+++ b/test/users/engin/getcid-rettype.chpl
@@ -1,0 +1,4 @@
+class foo {}
+var obj = new foo();
+var cid = __primitive("getcid", obj);
+assert(cid.type==int(32));


### PR DESCRIPTION
This -trivial- PR changes return type of PRIM_GETCID to 32-bit integer.

Also adds a test that would fail without this change.

I have discussed this with @lydia-duncan 