### PR TITLE
Move c_void_ptr comparisons from CPtr to ChapelBase

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -138,10 +138,6 @@ module CPtr {
     return __primitive("ptr_eq", a, b);
   }
   pragma "no doc"
-  inline proc ==(a: c_void_ptr, b: c_void_ptr) {
-    return __primitive("ptr_eq", a, b);
-  }
-  pragma "no doc"
   inline proc ==(a: c_ptr, b: _nilType) {
     return __primitive("ptr_eq", a, c_nil);
   }
@@ -168,10 +164,6 @@ module CPtr {
   }
   pragma "no doc"
   inline proc !=(a: c_void_ptr, b: c_ptr) {
-    return __primitive("ptr_neq", a, b);
-  }
-  pragma "no doc"
-  inline proc !=(a: c_void_ptr, b: c_void_ptr) {
     return __primitive("ptr_neq", a, b);
   }
   pragma "no doc"

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1095,8 +1095,14 @@ module ChapelBase {
     __primitive("call destructor", x);
   }
 
-  // = for c_void_ptr
+  // c_void_ptr operations
   inline proc =(ref a: c_void_ptr, b: c_void_ptr) { __primitive("=", a, b); }
+  inline proc ==(a: c_void_ptr, b: c_void_ptr) {
+    return __primitive("ptr_eq", a, b);
+  }
+  inline proc !=(a: c_void_ptr, b: c_void_ptr) {
+    return __primitive("ptr_neq", a, b);
+  }
 
   // Type functions for representing function types
   inline proc func() type { return __primitive("create fn type", void); }

--- a/test/types/cptr/ptr_eq.chpl
+++ b/test/types/cptr/ptr_eq.chpl
@@ -1,6 +1,13 @@
-proc test(x) {
+proc test_nil(x) {
   writeln(x == nil);
   writeln(nil == x);
 }
-var y: c_void_ptr = c_nil;
-test(y);
+proc test_eq(x, y) {
+  writeln(x == y);
+}
+
+var a: c_void_ptr = c_nil;
+var b: c_void_ptr = a;
+
+test_nil(a);
+test_eq(a, b);

--- a/test/types/cptr/ptr_eq.good
+++ b/test/types/cptr/ptr_eq.good
@@ -1,2 +1,3 @@
 true
 true
+true

--- a/test/types/cptr/ptr_neq.chpl
+++ b/test/types/cptr/ptr_neq.chpl
@@ -1,6 +1,14 @@
-proc test(x) {
+proc test_nil(x) {
   writeln(x != nil);
   writeln(nil != x);
 }
-var y: c_void_ptr = c_nil;
-test(y);
+proc test_neq(x, y) {
+  writeln(x != y);
+}
+
+var a: c_void_ptr = c_nil;
+var tmp: c_void_ptr = c_ptrTo(a):c_void_ptr;
+var b: c_void_ptr;
+b = tmp;
+test_nil(a);
+test_neq(a, b);

--- a/test/types/cptr/ptr_neq.good
+++ b/test/types/cptr/ptr_neq.good
@@ -1,2 +1,3 @@
 false
 false
+true


### PR DESCRIPTION
Since c_void_ptr is a primitive type, it makes sense that operations on it should be in ChapelBase. CPtr.chpl is really for the c_ptr type.

The == and != operations join the = operation for c_void_ptr in ChapelBase.

Also improved the testing for these functions to check both comparisons with nil and also comparisons with other c_void_ptrs.

Passed full local testing.