### PR TITLE
Add symbolic link  examples -> test/release/examples

### DIFF
--- a/examples
+++ b/examples
@@ -1,0 +1,1 @@
+test/release/examples/

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -166,7 +166,7 @@ SystemOrDie("make man-chpldoc");
 SystemOrDie("make clobber");
 
 print "Creating the examples directory...\n";
-SystemOrDie("rm -f examples"); # remove examples symbolic link
+SystemOrDie("rm examples"); # remove examples symbolic link
 SystemOrDie("cp -r test/release/examples .");
 SystemOrDie("cd util && cp start_test ../examples/");
 SystemOrDie("./util/devel/test/extract_tests --no-futures -o ./examples/spec spec/*.tex");

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -166,6 +166,7 @@ SystemOrDie("make man-chpldoc");
 SystemOrDie("make clobber");
 
 print "Creating the examples directory...\n";
+SystemOrDie("rm -rf examples"); # remove examples symbolic link
 SystemOrDie("cp -r test/release/examples .");
 SystemOrDie("cd util && cp start_test ../examples/");
 SystemOrDie("./util/devel/test/extract_tests --no-futures -o ./examples/spec spec/*.tex");

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -166,7 +166,7 @@ SystemOrDie("make man-chpldoc");
 SystemOrDie("make clobber");
 
 print "Creating the examples directory...\n";
-SystemOrDie("rm -rf examples"); # remove examples symbolic link
+SystemOrDie("rm -f examples"); # remove examples symbolic link
 SystemOrDie("cp -r test/release/examples .");
 SystemOrDie("cd util && cp start_test ../examples/");
 SystemOrDie("./util/devel/test/extract_tests --no-futures -o ./examples/spec spec/*.tex");


### PR DESCRIPTION
With this link, documentation works as well for a release or for the master branch.

Tested with

    CHPL_GEN_RELEASE_NO_CLONE=1./util/buildRelease/testRelease -debug

which seemed to work except for "Unexpected version string".

Discussed with @awallace-cray and @bradcray.