### PR TITLE
Replace download.html with install.html in source repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ The Chapel Language
 
 What is Chapel?
 ---------------
-Chapel is an emerging programming language designed for productive
+Chapel is a modern programming language designed for productive
 parallel computing at scale. Chapel's design and implementation have
 been undertaken with portability in mind, permitting Chapel to run on
 multicore desktops and laptops, commodity clusters, and the cloud, in
@@ -26,7 +26,7 @@ For more information about Chapel, please refer to the following resources:
 
 =====================  ========================================
 Project homepage:      http://chapel.cray.com
-Installing Chapel:     http://chapel.cray.com/install.html
+Installing Chapel:     http://chapel.cray.com/download.html
 Building from source:  `QUICKSTART.rst <QUICKSTART.rst>`_ (in this directory)
 Sample computations:   http://chapel.cray.com/hellos.html
 Learning Chapel:       http://chapel.cray.com/learning.html

--- a/doc/sphinx/source/users-guide/base/hello.rst
+++ b/doc/sphinx/source/users-guide/base/hello.rst
@@ -25,8 +25,8 @@ complete Chapel program.  If you type or paste it into a text editor
 and save it into a file, say ``hello.chpl``, you'll have written your
 first Chapel program.
 
-Given a working Chapel compiler (see `Installing Chapel
-<http://chapel.cray.com/install.html>`_ for details), you can compile
+Given a working Chapel compiler (see `Downloading Chapel
+<http://chapel.cray.com/download.html>`_ for details), you can compile
 the program using::
 
     chpl hello.chpl -o hello


### PR DESCRIPTION
We're retiring install.html as a main URL, focusing on download.html
instead.

While here, replaced 'emerging' with 'modern' in top-level README.