### PR TITLE
Update privatization tests to not leak

### DIFF
--- a/test/distributions/privatization/runtime/addAndGetAndClearPrivatizedInParallel.chpl
+++ b/test/distributions/privatization/runtime/addAndGetAndClearPrivatizedInParallel.chpl
@@ -23,6 +23,8 @@ for classNum in 3..classSizes.size-1 {
 
     {
       for i in classSizes[classNum-2]..classSizes[classNum-1]-1 {
+        var c = getPrivatized(i);
+        delete c;
         clearPrivatized(i);
       }
     }
@@ -36,6 +38,15 @@ for classNum in 3..classSizes.size-1 {
     }
 
   }
+}
+
+// Report no leaks
+var big:int;
+big = max reduce classSizes;
+for i in 0..big-1 {
+  var c = getPrivatized(i);
+  delete c;
+  clearPrivatized(i);
 }
 
 writeln("OK");

--- a/test/distributions/privatization/runtime/addAndGetPrivatizedInParallel.chpl
+++ b/test/distributions/privatization/runtime/addAndGetPrivatizedInParallel.chpl
@@ -29,3 +29,12 @@ for classNum in 2..classSizes.size-1 {
 
   }
 }
+
+// Report no leaks
+var big:int;
+big = max reduce classSizes;
+for i in 0..big-1 {
+  var c = getPrivatized(i);
+  delete c;
+  clearPrivatized(i);
+}

--- a/test/distributions/privatization/runtime/addPrivatizedInOrder.chpl
+++ b/test/distributions/privatization/runtime/addPrivatizedInOrder.chpl
@@ -12,6 +12,8 @@ for i in 0..#numIters by -1 {
 }
 
 for i in 0..#numIters {
+  var c = getPrivatized(i);
+  delete c;
   clearPrivatized(i);
 }
 

--- a/test/distributions/privatization/runtime/addPrivatizedInParallel.chpl
+++ b/test/distributions/privatization/runtime/addPrivatizedInParallel.chpl
@@ -10,3 +10,10 @@ forall i in 0..#numIters {
 for i in 0..#numIters by -1 {
   writeln(getPrivatized(i).i);
 }
+
+// no leaks
+for i in 0..#numIters by -1 {
+  var c = getPrivatized(i);
+  delete c;
+  clearPrivatized(i);
+}

--- a/test/distributions/privatization/runtime/addPrivatizedLargeJump.chpl
+++ b/test/distributions/privatization/runtime/addPrivatizedLargeJump.chpl
@@ -4,10 +4,17 @@ var addOrder = [0, 1000, 10000];
 
 for i in addOrder {
   var newValue = new C(i);
-  insertPrivatized(new C(i), i);
+  insertPrivatized(newValue, i);
 }
 
 for i in addOrder {
   writeln(getPrivatized(i).i);
+}
+
+// no leaks
+for i in addOrder {
+  var c = getPrivatized(i);
+  delete c;
+  clearPrivatized(i);
 }
 

--- a/test/distributions/privatization/runtime/addPrivatizedOutOfOrder.chpl
+++ b/test/distributions/privatization/runtime/addPrivatizedOutOfOrder.chpl
@@ -4,9 +4,16 @@ var addOrder = [5000, 7500, 2500, 10000, 0];
 
 for i in addOrder {
   var newValue = new C(i);
-  insertPrivatized(new C(i), i);
+  insertPrivatized(newValue, i);
 }
 
 for i in addOrder {
   writeln(getPrivatized(i).i);
+}
+
+// no leaks
+for i in addOrder {
+  var c = getPrivatized(i);
+  delete c;
+  clearPrivatized(i);
 }

--- a/test/distributions/privatization/runtime/addRemovePrivatizedOutOfOrder.chpl
+++ b/test/distributions/privatization/runtime/addRemovePrivatizedOutOfOrder.chpl
@@ -6,10 +6,19 @@ var removeOrder = [5000, -1, 2500, 10000, 0];
 for (i,j) in zip(addOrder, removeOrder) {
   var newValue = new C(i);
   insertPrivatized(new C(i), i);
-  if j >= 0 then
+  if j >= 0 {
+    var c = getPrivatized(j);
+    delete c;
     clearPrivatized(j);
+  }
 }
 
 for i in addOrder {
   writeln(getPrivatized(i));
+}
+
+for i in addOrder {
+  var c = getPrivatized(i);
+  delete c;
+  clearPrivatized(i);
 }

--- a/test/distributions/privatization/runtime/addRemovePrivatizedOutOfOrder.chpl
+++ b/test/distributions/privatization/runtime/addRemovePrivatizedOutOfOrder.chpl
@@ -5,7 +5,7 @@ var removeOrder = [5000, -1, 2500, 10000, 0];
 
 for (i,j) in zip(addOrder, removeOrder) {
   var newValue = new C(i);
-  insertPrivatized(new C(i), i);
+  insertPrivatized(newValue, i);
   if j >= 0 {
     var c = getPrivatized(j);
     delete c;


### PR DESCRIPTION
One of them was pretty high up on the list of tests leaking memory.
While there, I fixed the others so that they also do not leak.

Reviewed by @ronawho.