### PR TITLE
Use paratest to speed up whitebox testing

### DIFF
--- a/util/cron/common-localnode-paratest.bash
+++ b/util/cron/common-localnode-paratest.bash
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Helpers to create "localhost" paratest file to use with nightly -parnodefile
+
+# Generate a "localhost" paratest nodefile
+function gen_nodefile
+{
+    nodepara=${1}
+    nodefile=${2}
+
+    for _ in $(seq ${nodepara}); do
+        echo "localhost"
+    done > "${nodefile}"
+}
+
+
+#
+# Generate a "localhost" paratest nodefile. Defaults to `nodepara 2`, but can
+# be set with `${1}`. Limits testing to only run 1 executable at a time unless
+# the "no_limit_exec" variant is used. Returns the args for using the nodefile
+# with nightly script (`-parnodefile <abs_nodefile>`)
+#
+
+function get_nightly_no_limit_exec_paratest_args
+{
+    nodepara=${1:-2}
+    parnodefile="${CHPL_HOME}/test/Nodes/${nodepara}-localhost"
+    gen_nodefile ${nodepara} ${parnodefile}
+    echo "-parnodefile ${parnodefile}"
+}
+
+function get_nightly_paratest_args
+{
+    get_nightly_no_limit_exec_paratest_args ${@}
+    export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes
+}

--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 #
-# Test a particular compiler with a specific environment on a whitebox against
-# the examples.
+# Test a particular compiler with a specific environment on a whitebox
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/functions.bash
 source $CWD/common-whitebox.bash
+source $CWD/common-localnode-paratest.bash
 
 # Run the tests!
-nightly_args="-cron"
+nightly_args="-cron $(get_nightly_paratest_args)"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."


### PR DESCRIPTION
Whitebox testing currently takes ~15 hours to complete (down from ~20 hours
with the new hardware.) Let's see if we can get it under 12 by using paratest.

Since we already oversubscribe the hardware by running concurrent correctness
jobs, limit paratest to only run one executable per machine at the same time.
This should actually reduce the number of tests that run at the same time, but
it will increase the number of compiles that happen concurrently.