### PR TITLE
Allow paratest to work on whiteboxes and real Cray hardware

### DIFF
--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -286,12 +286,13 @@ def get(location, map_to_compiler=False, get_lcd=False):
     isprgenv = compiler_is_prgenv(compiler_val)
 
     if isprgenv:
-        if arch and (arch != 'none' or arch != 'unknown'):
+        cray_arch = os.environ.get('CRAY_CPU_TARGET', 'none')
+        if arch and (arch != 'none' and arch != 'unknown' and arch != cray_arch):
             stderr.write("Warning: Setting the processor type through "
                          "environment variables is not supported for "
                          "cray-prgenv-*. Please use the appropriate craype-* "
                          "module for your processor type.\n")
-        arch = os.environ.get('CRAY_CPU_TARGET', 'none')
+        arch = cray_arch
         if arch == 'none':
             stderr.write("Warning: No craype-* processor type module was "
                          "detected, please load the appropriate one if you want "

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -603,6 +603,12 @@ if ($examples == 1) {
 }
 if ($parnodefile eq "") {
     $testflags = "$testflags $testdirs";
+} else {
+    if ($testdirs ne "") {
+        mysystem("cd $testdir && find $testdirs -wholename \"*.svn\" -prune -o -type d > DIRFILE",
+                 "making directory file", 1, 1);
+        $testflags = "$testflags -dirfile DIRFILE";
+    }
 }
 
 if (!($dist eq "")) {

--- a/util/start_test
+++ b/util/start_test
@@ -1199,7 +1199,7 @@ def parser_setup():
             dest="compiler", help="set alternate compiler")
     # program launch utility
     parser.add_argument("-launchcmd", "--launchcmd", action="store",
-            dest="launch_cmd", default="",
+            dest="launch_cmd", default=os.getenv("CHPL_TEST_LAUNCHCMD", ""),
             help="set a program to launch generated executables")
     # compiler options
     parser.add_argument("-compopts", "--compopts", action="append",


### PR DESCRIPTION
Paratest forwards the chplenv, explicitly setting the values on the clients.
However, on Cray's and whiteboxes we didn't allow CHPL_TARGET_ARCH to be set
manually, it had to be set through the cpu targeting module. This updates
chpl_arch.py to allow CHPL_TARGET_ARCH to be manually set to the value of the
cpu targeting module.

We also have to use chpl_launchcmd.py on some Cray's, but previously we had no
way of setting it for paratest. Now it can be set through CHPL_TEST_LAUNCHCMD

Lastly, nightly didn't respect CHPL_NIGHTLY_TEST_DIRS for paratest, so update
it to create a DIRFILE, like we do for -examples.