### PR TITLE
Actually limit whitebox testing to only run 1 executable at a time

### DIFF
--- a/util/cron/common-localnode-paratest.bash
+++ b/util/cron/common-localnode-paratest.bash
@@ -16,21 +16,17 @@ function gen_nodefile
 
 #
 # Generate a "localhost" paratest nodefile. Defaults to `nodepara 2`, but can
-# be set with `${1}`. Limits testing to only run 1 executable at a time unless
-# the "no_limit_exec" variant is used. Returns the args for using the nodefile
-# with nightly script (`-parnodefile <abs_nodefile>`)
+# be set with `${1}`. Limits testing to only run 1 executable at a time, unset
+# CHPL_TEST_LIMIT_RUNNING_EXECUTABLES to prevent this. Returns the args for
+# using the nodefile with nightly script (`-parnodefile <abs_nodefile>`)
 #
 
-function get_nightly_no_limit_exec_paratest_args
+export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes
+
+function get_nightly_paratest_args
 {
     nodepara=${1:-2}
     parnodefile="${CHPL_HOME}/test/Nodes/${nodepara}-localhost"
     gen_nodefile ${nodepara} ${parnodefile}
     echo "-parnodefile ${parnodefile}"
-}
-
-function get_nightly_paratest_args
-{
-    get_nightly_no_limit_exec_paratest_args ${@}
-    export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes
 }


### PR DESCRIPTION
I was setting CHPL_TEST_LIMIT_RUNNING_EXECUTABLES inside a function that got
called inside of a subshell, so it wasn't actually getting set for nightly
testing.

We now set it at the top-level of common-localnode-paratest.bash so it gets set
when that script is sourced. Clients will now have to manually unset
CHPL_TEST_LIMIT_RUNNING_EXECUTABLES if they don't want to limit the number of
executables running concurrently.