### PR TITLE
Fix off-by-one error in binary trees

### DIFF
--- a/test/release/examples/benchmarks/shootout/binarytrees.chpl
+++ b/test/release/examples/benchmarks/shootout/binarytrees.chpl
@@ -75,7 +75,7 @@ class Tree {
   //
   proc init(item, depth) {
     this.item = item;
-    if depth > 1 {
+    if depth > 0 {
       left = new Tree(2*item-1, depth-1);
       right = new Tree(2*item, depth-1);
     }

--- a/test/studies/shootout/binary-trees/binarytrees-blc.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-blc.chpl
@@ -76,7 +76,7 @@ class Tree {
   proc init(item, depth) {
     this.item = item;
     super.init();
-    if depth > 1 {
+    if depth > 0 {
       left = new Tree(2*item-1, depth-1);
       right = new Tree(2*item, depth-1);
     }


### PR DESCRIPTION
Frustratingly, the checksum used by the binary trees benchmark is not good enough to notice when you've failed to add an entire level of nodes to the tree, and sadly, the reason these versions have been twice as fast as the others is because they were in fact failing to add that entire level of nodes to the tree.  :'(
