### PR TITLE
Expand paths to chpl_launchcmd

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -951,7 +951,7 @@ def set_up_executables():
     os.environ['EXECOPTS'] = args.execopts
 
     logger.write('[launchcmd: "{0}"]'.format(args.launch_cmd))
-    os.environ['LAUNCHCMD'] = args.launch_cmd
+    os.environ['LAUNCHCMD'] = os.path.expandvars(args.launch_cmd)
 
     comm = chpl_comm.get()
     launcher = chpl_launcher.get()


### PR DESCRIPTION
This lets us do: `CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py`
in a .bashrc or something, and have the value of CHPL_HOME be the one set at
start_test time instead of at login time.