### PR TITLE
Update attribution of these bigint versions of pidigits

### DIFF
--- a/test/release/examples/benchmarks/shootout/pidigits-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/pidigits-fast.chpl
@@ -1,8 +1,9 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org
 
-   contributed by Tom Hildebrandt, Brad Chamberlain, and Lydia Duncan
-   derived from the GNU C version by Mr Ledrug
+   contributed by Thomas Van Doren, Michael Noakes, and Brad Chamberlain
+   derived from the Chapel version by Tom Hildebrandt et al. and the
+     GNU C version by Mr Ledrug
 */
 
 use BigInteger;

--- a/test/release/examples/benchmarks/shootout/pidigits.chpl
+++ b/test/release/examples/benchmarks/shootout/pidigits.chpl
@@ -1,8 +1,9 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org
 
-   contributed by Tom Hildebrandt, Brad Chamberlain, and Lydia Duncan
-   derived from the GNU C version by Mr Ledrug
+   contributed by Thomas Van Doren, Michael Noakes, and Brad Chamberlain
+   derived from the Chapel version by Tom Hildebrandt et al. and the
+     GNU C version by Mr Ledrug
 */
 
 use BigInteger;
@@ -24,7 +25,7 @@ proc main() {
   //
   // Pad out any trailing digits for the final line
   //
-  const leftover = n%digitsPerLine;
+  const leftover = n % digitsPerLine;
   if (leftover) {
     for leftover..digitsPerLine do
       write(" ");


### PR DESCRIPTION
When pushing these to the release, I was focused on the code more
than the attribution of them.  Here I've updated the bigint versions
to be based on the GMP Chapel version and the LeDrug version and
given credit to Thomas (who did the original BigInt ports), Mike
(who updated Thomas's versions to bigints), and myself (who merged
them with the release GMP versions).  Sorry for not catching this
comment before the 1.14 release went out, guys.