### PR TITLE
Added a check to Expr::verify

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -269,6 +269,17 @@ void Expr::verify() {
 
   if (list && parentExpr && list->parent != parentExpr)
     INT_FATAL(this, "Bad Expr::list::parent");
+
+  if (list && !parentExpr) {
+    if (Symbol* lps = toSymbol(list->parent))
+      if (lps != parentSymbol)
+        INT_FATAL(this, "Bad symbol Expr::list::parent");
+    if (Type* lpt = toType(list->parent))
+      if (lpt->symbol != parentSymbol)
+        INT_FATAL(this, "Bad type Expr::list::parent");
+    if (isExpr(list->parent))
+      INT_FATAL(this, "Expr::list::parent is an Expr unexpectedly");
+  }
 }
 
 


### PR DESCRIPTION
When an Expr node is a part of a list, Expr::verify checks that:
  this->parentExpr == this->list->parent
This check only fires when this->parentExpr is non-NULL.

I am adding a check that when this->parentExpr==NULL, then:
* either this->list->parent is a symbol that is this->parentSymbol
* or this->list->parent is a type that is this->parentSymbol->type
* in any case this->list->parent is not an Expr.

Passes full linux64 suite and multilocale tests under gasnet,
both with --verify.
