### PR TITLE
C-ray: timeout-related improvements

### DIFF
--- a/test/exercises/c-ray/c-ray.execopts
+++ b/test/exercises/c-ray/c-ray.execopts
@@ -1,2 +1,5 @@
 --printTiming=false                   # c-ray.good
---printTiming=false --scene=sphfract  # c-ray.sphfract.good
+#
+# skipping this due to it taking too long under valgrind and baseline testing:
+#
+#--printTiming=false --scene=sphfract  # c-ray.sphfract.good


### PR DESCRIPTION
This commit:

a) transposes the pixel array,
b) parallelizes the render step,
c) stops testing the more complex scene

The hope is that these changes will accelerate valgrind and baseline
testing to address the timeout issues that have been occurring since
I checked in the test.  If not, I will reduce the test size.

The transpose of the pixel array reflects the fact that I have a
hard time remembering which order image dimensions are given in
and decided to transpose them for the Chapel array in order to
make the first and second dimension match the way we normally
draw Chapel arrays.  This also results in a more natural iteration
order when writing the image out to a file and therefore should
result in a better memory order in rendering (not that memory is
likely to be a bottleneck here).

The parallelization of the rendering step is trivial -- changed
a 'for' to a 'forall'.

Skipping the more complex scene seems too bad ("what if it
breaks?") yet seems better than another very long valgrind
test.  A future move might be to make a second test that
piggy-backs off the first to do the second scene and skip
that test for valgrind.

While here, I noticed some arguments that weren't used due to
arrays/domains carrying their bounds with them.
