### PR TITLE
Changes to chapcs-mloc slurm-gasnet-ibv "numa" correctness test.

### DIFF
--- a/util/cron/test-slurm-gasnet-ibv.numa.bash
+++ b/util/cron/test-slurm-gasnet-ibv.numa.bash
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 #
 # Multi-node, multi-locale testing on a linux64 cluster with slurm-gasnetrun_ibv launcher:
-# test numa locale model with comm=gasnet on multilocale and examples.
+# test numa locale model with comm=gasnet against "examples"
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-ibv.bash
-source $CWD/common-numa.bash
+
+export CHPL_LOCALE_MODEL=numa
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.numa"
 
-export GASNET_QUIET=Y
-
-$CWD/nightly -cron -multilocale ${nightly_args} < /dev/null
+$CWD/nightly -cron -examples ${nightly_args} < /dev/null


### PR DESCRIPTION
* Reduce the scope of the testing to just the "examples" subtree, so it could actually succeed
  as a nightly job. 

* Change the job configuration to avoid source'ing common-numa.bash.
  The existing common-numa.bash carries other config settings besides
  "CHPL_LOCALE_MODEL=numa", including Qthreads oversubscription- which we
  do not want in this test config.