### PR TITLE
Fix issue with closing expanded graphs

### DIFF
--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -388,7 +388,9 @@ function setupCloseGraphToggle(g, graphInfo, closeGraphToggle) {
 
   closeGraphToggle.onclick = function() {
     var checkBox = getCheckboxForGraph(g);
-    checkBox.checked = false;
+    if (typeof checkBox !== "undefined") {
+      checkBox.checked = false;
+    }
     $(g.divs.div).hide();
     $(g.divs.ldiv).hide();
     $(g.divs.gspacer).hide();


### PR DESCRIPTION
Expanded graphs don't have a corresponding checkbox, so don't attempt to uncheck them when hiding the graph.