### PR TITLE
Error handling CHIP

### DIFF
--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -175,20 +175,20 @@ Syntax
   proc canThrowErrors() throws { … }
   proc cannotThrowErrors() { … }
 
-* Statements that contain calls to functions that throw should be enclosed:
-
-  * ``try`` propagates the error.
-
-    * If an error is thrown, it will be passed to a matching ``catch`` block.
-
-    * If none exists, the error will be passed out of the procedure, hence the
-      procedure must ``throw``.
-
-    * If the procedure does not ``throw``, the compiler will raise an error.
-
-  * ``try!`` will ``halt()`` if an error occurs.
-  
 * Errors can be handled with ``catch`` statements.
+
+* Statements that contain calls to functions that throw should be enclosed
+  by ``try`` or ``try!``.
+  
+  * Both will attempt to handle errors with a matching ``catch`` block.
+
+  * If no matching ``catch`` block exists:
+   
+    * ``try`` propagates the error. This can either be to an enclosing ``try``
+      block, or out of the enclosing procedure, which must ``throw``.
+
+    * ``try!`` will ``halt()``, even if enclosed by another ``try``.
+  
 
 Here is an example.
 
@@ -196,7 +196,7 @@ Here is an example.
 
   try {
     canThrowErrors();      // handled by catch on error
-    try canThrowErrors();  // also handled by catch ("in scope")
+    try canThrowErrors();  // propagates to outer try, then catch
     try! canThrowErrors(); // halts on error
   } catch e {
     writeln("One of the first two calls failed!")
@@ -210,7 +210,7 @@ the compiler will run checks in one of two modes, based on a flag.
 
 1. **Default.** If a call to a throwing procedure is not enclosed by a ``try``
    or ``try!``, the program will compile with a warning and the call will
-   ``halt()`` on an error, as if the procedure were called with ``try!``.
+   ``halt()`` on an error.
 
 2. **Strict.** If a call to a throwing procedure is not enclosed by a ``try``
    or ``try!``, the compiler will raise an error.
@@ -265,13 +265,12 @@ For example, here is some Chapel code that throws and handles an error:
 
   class IllegalArgumentError: Error {} 
 
-  proc handle(arg) throws {
-    try {
+  proc handle(arg) {
+    try! {
       callee(arg);
     } catch e: IllegalArgumentError {
       writeln("illegal arg, exiting caller");
     }
-    // no catch-all block -> throws
   }
 
   proc passThru(arg) throws {
@@ -290,7 +289,7 @@ The compiler could translate this into the following Chapel code:
 
   class IllegalArgumentError: Error {} 
 
-  proc handle(arg, out _e_out: Error) {
+  proc handle(arg) {
     var e: Error; 
 
     callee(arg, e);
@@ -299,8 +298,7 @@ The compiler could translate this into the following Chapel code:
       delete e;
       writeln("illegal arg, exiting caller"); 
     } else if e {
-      _e_out = e;
-      return;
+      halt(e.message);
     }
   }
 
@@ -318,7 +316,7 @@ The compiler could translate this into the following Chapel code:
   }
 
 In default mode, calling throwing functions without an enclosing
-``try`` will produce a ``halt()``.
+``try`` or ``try!`` will ``halt()`` on error.
  
 .. code-block:: chapel
 

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -169,7 +169,7 @@ Syntax
   proc canThrowErrors() throws { … }
   proc cannotThrowErrors() { … }
 
-* Statements that contain calls to functions that throw should be marked:
+* Statements that contain calls to functions that throw should be enclosed:
 
   * ``try`` propagates the error.
 
@@ -202,12 +202,12 @@ Default vs strict mode
 To address the desire for both fast prototyping and enforced error handling,
 the compiler will run checks in one of two modes, based on a flag.
 
-1. **Default.** If a call to a throwing procedure is not marked with a ``try`` or
-   ``try!``, the program will compile with a warning and the call will ``halt()``
-   on an error, as if the procedure were called with ``try!``.
+1. **Default.** If a call to a throwing procedure is not enclosed by a ``try``
+   or ``try!``, the program will compile with a warning and the call will
+   ``halt()`` on an error, as if the procedure were called with ``try!``.
 
-2. **Strict.** If a call to a throwing procedure is not marked with a ``try`` or
-   ``try!``, the compiler will raise an error.
+2. **Strict.** If a call to a throwing procedure is not enclosed by a ``try``
+   or ``try!``, the compiler will raise an error.
 
 Error types
 +++++++++++
@@ -522,7 +522,7 @@ Example 5: Runtime operations
 +++++++++++++++++++++++++++++
 
 Many kinds of runtime operations in Chapel have the potential to fail (say if
-you are out of memory). This class of errors should be marked with ``try!``
+you are out of memory). This class of errors should be enclosed with ``try!``
 so that if one is encountered at runtime, your program will ``halt()`` before
 causing other catastrophic errors.
 

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -181,7 +181,7 @@ Syntax
 
     * If an error is thrown, it will be passed to a matching ``catch`` block.
 
-    * If none exists, the error will be passed out of the function, hence the
+    * If none exists, the error will be passed out of the procedure, hence the
       procedure must ``throw``.
 
     * If the procedure does not ``throw``, the compiler will raise an error.
@@ -195,9 +195,9 @@ Here is an example.
 ::
 
   try {
-    canThrowErrors();      // handled by catch on failure
+    canThrowErrors();      // handled by catch on error
     try canThrowErrors();  // also handled by catch ("in scope")
-    try! canThrowErrors(); // halts on failure
+    try! canThrowErrors(); // halts on error
   } catch e {
     writeln("One of the first two calls failed!")
   }
@@ -516,12 +516,21 @@ These errors will be provided at task join.
 The implementation requires that the ``cobegin`` statements be
 synchronized first.
 
-// TODO: finish
 .. code_block:: chapel
 
-  proc encounterError(out _e_out) { _e_out = new Error(); }
-  proc noError(out _e_out) { return; }
-  
+  proc encounterError(out _e_out: Error) { _e_out = new Error(); }
+  proc noError(out _e_out: Error) { return; }
+
+  var _e1, _e2, _e3: Error;
+  sync cobegin {
+    encounterError(_e1);
+    noError(_e2);
+    encounterError(_e3);
+  }
+  var errors: AsyncErrors = new AsyncErrors(_e1, _e2, _e3);
+  for e in errors {
+    writeln(e);
+  }
 
 Example 4: Iterators
 ++++++++++++++++++++
@@ -569,7 +578,7 @@ Which would be implemented like this:
 
 .. code-block:: chapel
 
-    iter glob(pattern: string = "*", out _e_out: Error) : string {
+    iter glob(out _e_out: Error, pattern: string = "*") : string {
       ...
       if (err != 0 && err != GLOB_NOMATCH) {
         _e_out = new Error("unhandled error in glob()");
@@ -579,7 +588,7 @@ Which would be implemented like this:
     } 
 
     var e: Error;
-    for x in glob(_e_out = e) do
+    for x in glob(e) do
       writeln(x);
     if e then
       writeln("Error in glob");
@@ -613,7 +622,8 @@ causing other catastrophic errors.
 
 For reference, here is an implementation:
 
-// TODO: finish
+// TODO: how to get an error from an on clause
+
 .. code-block:: chapel
 
     var e: Error;

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -175,8 +175,6 @@ Syntax
 
     * If an error is thrown, it will be passed to a matching ``catch`` block.
 
-    * If none exists, the error will be passed to an enclosing ``catch`` block.
-
     * If none exists, the error will be passed out of the function, hence the
       procedure must ``throw``.
 
@@ -192,6 +190,7 @@ Here is an example.
 
   try {
     canThrowErrors();      // handled by catch on failure
+    try canThrowErrors();  // also handled by catch ("in scope")
     try! canThrowErrors(); // halts on failure
   } catch e {
     writeln("The first call failed!")
@@ -213,19 +212,24 @@ the compiler will run checks in one of two modes, based on a flag.
 Error types
 +++++++++++
 
-* Errors are classes that extend a base class ``Error``.
-
-* Errors will not be typechecked, but an error hierarchy is permitted.
+* ``Error`` will be a class defined in the standard library.
+  
+* ``Error`` may be extended to create custom errors and a hierarchy.
 
 ::
 
   class MyBaseError: Error {}
   class MySubError: MyBaseError {}
 
-* Errors can be matched against in ``catch`` blocks. They will be checked in
-  order, so even if a better fitting type is present, it will not be chosen
-  if a matching general type precedes it. If a type is not specified,
-  any ``Error`` will match.
+* Error types will not be checked by the compiler.
+
+* At runtime ``catch`` blocks can match against errors.
+
+  * These matches will be evaluated in order, so even if a better fitting
+    type is present, it will not be chosen if a matching general type
+    precedes it.
+
+  * If a type is not specified, any ``Error`` will match.
 
 :: 
 
@@ -284,6 +288,7 @@ The compiler could translate this into the following Chapel code:
 .. code-block:: chapel
 
   class IllegalArgumentError: Error {} 
+  class IteratorError: Error {}
 
   proc caller(arg, out _e_out: Error): A {
     var _e: Error; 
@@ -325,7 +330,7 @@ The compiler could translate this into the following Chapel code:
 
   iter iterating(arg, out _e_out: Error): A {
     if arg < 1 {
-      _e_out = new IllegalArgumentError();
+      _e_out = new IteratorError();
       return;
     }
 
@@ -441,12 +446,15 @@ currently handle these with ``out`` arguments and halting.
     channel.write(1, 2, 4, 8, err);
   }
 
-// TODO: Think about it
 Example 3: Cobegins
-+++++++++++++++++++++++++++++
++++++++++++++++++++
 
-``cobegin``, and other task parallel constructs create tasks which could
-have errors. These errors will be provided at task join.
+``begin`` and ``cobegin`` are parallel constructs that create
+asynchronous tasks which could have errors. Given that our error
+handling is synchronous, the compiler will force these tasks to
+``sync`` before the program is allowed to continue.
+
+These errors will be provided at task join.
 
 .. code-block:: chapel
 
@@ -458,14 +466,14 @@ have errors. These errors will be provided at task join.
       noError();
       encounterError();
     }
-  } catch errors: CobeginErrors { // could use a better name
+  } catch errors: AsyncErrors {
     for e in errors {
       writeln(e); // would print out two lines
     }
   }
 
 Example 4: Iterators
-++++++++++++++++++++++++++++++
+++++++++++++++++++++
 This is the current ``glob`` iterator in the ``FileSystem`` module:
 
 .. code-block:: chapel
@@ -510,9 +518,8 @@ Raising an error will halt the execution of the iterator. Errors in follower
 iterations in ``coforall`` and ``forall`` loops may still allow some iteration
 to occur. All errors will be reported at task join, as in Example 3.
 
-
 Example 5: Runtime operations
-+++++++++++++++++++++++++++++++++++++++
++++++++++++++++++++++++++++++
 
 Many kinds of runtime operations in Chapel have the potential to fail (say if
 you are out of memory). This class of errors should be marked with ``try!``
@@ -548,12 +555,5 @@ Future Design Work
 * Task joins propagate errors to parent tasks:
 
   * Occurs at the end of sync/coforall/cobegin blocks
-
-
-Implementation Notes
---------------------
-
-Since this error handling strategy is based off returning either the value or
-an error, better support for union types in chapel may be necessary.
 
 .. _Swift: https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/ErrorHandling.html

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -36,7 +36,8 @@ propagates errors, and provides useful messages when errors are not handled.
 Model: Swift Error Handling
 ---------------------------
 
-This error handling proposal is inspired by the Swift_ error handling strategy.
+This error handling proposal was originally inspired by the Swift_ error
+handling strategy.
 
 Swift's strategy is appealing because it:
 
@@ -45,8 +46,8 @@ Swift's strategy is appealing because it:
   return mechanisms; and
 * fits well with existing task parallelism.
 
-Swift Syntax
-++++++++++++
+Syntax
+++++++
 
 * Functions that can throw an error are declared with ``throws``:
 
@@ -72,8 +73,8 @@ Swift Syntax
     writeln("The first call failed!")
   }
 
-Why Decorate Statements That Throw
-++++++++++++++++++++++++++++++++++
+Decorating statements that throw
+++++++++++++++++++++++++++++++++
 
 The Swift error handling approach includes the use of ``try`` to mark statements
 that can throw. This design addresses the most serious criticism of exceptions
@@ -82,25 +83,161 @@ reason about. By marking each statement that can throw, the control flow
 possibilities can again be reasoned about with local information only.
 
 
+Feedback Received (7/20)
+------------------------
+
+1. ``try`` is verbose within ``do`` blocks. While it clarifies control flow
+   within the block, it would be tiresome to repeat with throwing functions
+   that are closely related (ex. I/O). 
+
+2. ``try`` is also verbose from an iteration perspective. For example, 
+   ``writeln("hello world")`` would have to be prefaced with a ``try``
+   statement if it were strictly enforced.
+
+3. Repeated ``try`` statements may also desensitize users from
+   paying close attention to ``try`` and ``throws``.
+
+4. ``main()`` ought to have some sort of reasonable response to an error
+   being propagated up to it.
+
+Potential solutions
++++++++++++++++++++
+
+1. **Elide** ``try``.
+  
+* Within ``do`` blocks, ``try`` is only a visual aide to track control
+  flow. It is reasonable for developers to track that a procedure throws
+  without this assistance because it's already in a ``do`` block. However,
+  ``try!`` would be permitted inside ``do`` blocks for critical failures.
+
+* Outside of ``do`` blocks, ``try`` or ``try!`` can be elided on throwing
+  procedure calls depending on the calling procedure's signature. If the
+  calling procedure ``throws``, then ``try``, else ``try!``.
+
+* The downside of this is that it would be possible to pass errors of a
+  called procedure through the callee without any visual indication of
+  which call is throwing. This could lead to poorly handled error cases.
+    
+2. **Elide** ``try`` **with a compiler flag.**
+
+* Same as (1), but we would add an option to enforce marking statements
+  with ``try`` for a thoroughly checked version. This addresses the
+  potential downside of only eliding ``try`` without losing the ability
+  to draft code quickly.
+
+3. **Eliminate** ``do``.
+
+* ``do`` is already a keyword in Chapel, so it would take more effort to 
+  determine that the ``do`` is being used in association with a ``catch``.
+
+* In its place, ``try`` could be defined for single and compound statements.
+
+* The downside is that ``try`` could no longer be used in an expression
+  form, so assignments that might throw an error may look more awkward.
+
+::
+
+  var a = try canThrowErrors(); // expression
+  try var a = canThrowErrors(); // statement
+
+4. **Cleaning up after an error.**
+
+* It is often necessary to cleanup state if an error occurs. To capture this,
+  ``do``/``catch`` could be associated with a ``finally`` block that will
+  run when the ``do`` (or ``try``) block is exited.
+
+* Swift's version of this is ``defer``, which runs when the scope it is
+  defined in is exited. This is a more general form of ``finally`` which
+  may better fit Chapel's needs. 
+
+Enacted solution
+++++++++++++++++
+
+This CHIP will move forward with a combination of the first three solutions.
+
+
 Chapel Error Handling
 ---------------------
 
-Beyond the syntax and the additions below, Chapel's error handling strategy
-will be more or less identical to that of Swift. 
+Syntax
+++++++
 
-Expected Additions
-++++++++++++++++++
+* Functions that can throw an error are declared with ``throws``:
 
-* Throwing errors from iterators
-* Ability to catch errors generated in runtime layers:
+::
 
-  * Communication
-  * Memory allocation
-  * Task creation
+  proc canThrowErrors() throws { … }
+  proc cannotThrowErrors() { … }
 
-* Task joins propagate errors to parent tasks:
+* Statements that contain calls to functions that throw should be marked:
 
-  * Occurs at end the of sync/coforall/cobegin blocks
+  * ``try`` propagates the error.
+
+    * If an error is thrown, it will be passed to a matching ``catch`` block.
+
+    * If none exists, the error will be passed to an enclosing ``catch`` block.
+
+    * If none exists, the error will be passed out of the function, hence the
+      procedure must ``throw``.
+
+  * ``try!`` will ``halt()`` if an error occurs.
+
+  * Both may be used with single and compound statements.
+  
+* Errors can be handled with ``catch`` statements.
+
+Here is an example.
+
+::
+
+  try {
+    canThrowErrors();      // handled by catch on failure
+    try! canThrowErrors(); // halts on failure
+  } catch e {
+    writeln("The first call failed!")
+  }
+
+Default vs strict mode
+++++++++++++++++++++++
+
+To address the desire for both fast prototyping and enforced error handling,
+the compiler will run checks in one of two modes, based on a flag.
+
+1. **Default.** If a call to a throwing procedure is not marked with a ``try`` or
+   ``try!``, the program will compile and the call will ``halt()`` on an error,
+   as if the procedure were called with ``try!``.
+
+2. **Strict.** If a call to a throwing procedure is not marked with a ``try`` or
+   ``try!``, the compiler will raise an error.
+
+Error types
++++++++++++
+
+* Errors are classes that extend a base class ``Error``.
+
+* Errors will not be typechecked, but an error hierarchy is permitted.
+
+::
+
+  class MyBaseError: Error {}
+  class MySubError: MyBaseError {}
+
+* Errors can be matched against in ``catch`` blocks. They will be checked in
+  order, so even if a better fitting type is present, it will not be chosen
+  if a matching general type precedes it. If a type is not specified,
+  any ``Error`` will match.
+
+:: 
+
+  try {
+    ...
+  } catch e: MySubError {
+    ...
+  } catch e: MyBaseError {
+    ...
+  } catch e {
+    ...
+  }
 
 Implementation
 ++++++++++++++
@@ -115,7 +252,7 @@ For example, here is some Chapel code that handles an error:
 
   class IllegalArgumentError: Error {} 
 
-  proc caller(arg): A {
+  proc nohandle(arg): A {
     var value: A = callee(arg);
     return value;
   }
@@ -143,102 +280,36 @@ The compiler could translate this into the following Chapel code:
 
   class IllegalArgumentError: Error {} 
 
-  proc caller(arg): A {
+  proc nohandle(arg): A {
     var _e: Error;
     var value: A = callee(arg, _e);
     if _e then
       halt(e.message());
-    else
-      return value;
+    return value;
   }
 
   proc handler(arg, out _e: Error): A {
-    var _e2: Error;
-    var value: A = callee(arg, _e2);
-    if _e2: IllegalArgumentError then
-      delete _e2;
+    var _e_in: Error;
+    var value: A = callee(arg, _e_in);
+    if _e_in: IllegalArgumentError {
+      delete _e_in;
       return DEFAULT_A;
-    else if _e2 then
-      _e = _e2; 
-    else
-      return value;
+    } else if _e_in {
+      _e = _e_in; 
+      return;
+    }
+    return value;
   }
 
   proc callee(arg, out _e: Error): A {
     if arg then
       return new A;
-    else
+    else {
       _e = new IllegalArgumentError();
+      return;
+    }
   }
 
-Feedback Received (7/20)
-------------------------
-
-1. ``try`` is verbose within ``do`` blocks. While it clarifies control flow
-   within the block, it would be tiresome to repeat with throwing functions
-   that are closely related (ex. I/O).
-
-2. ``try`` is also verbose from an iteration perspective. For example, 
-   ``writeln("hello world")`` would have to be prefaced with a ``try``
-   statement if it were strictly enforced.
-
-3. main() ought to have some sort of reasonable response to an error being
-   propagated up to it.
-
-Potential Solutions
-+++++++++++++++++++
-
-1. Elide ``try``.
-  
-* Within ``do`` blocks, ``try`` is only a visual aide to track control
-  flow. It is reasonable for developers to track that a procedure throws
-  without this assistance because it's already in a ``do`` block. However,
-  ``try!`` would be permitted inside ``do`` blocks for critical failures.
-
-* Outside of ``do`` blocks, ``try`` or ``try!`` can be elided on throwing
-  procedure calls depending on the calling procedure's signature. If the
-  calling procedure ``throws``, then ``try``, else ``try!``.
-
-* The downside of this is that it would be possible to pass errors of a
-  called procedure through the callee without any visual indication of
-  which call is throwing. This could lead to poorly handled error cases.
-    
-2. Elide ``try`` with a compiler flag.
-
-* Same as (1), but we would add an option to enforce marking statements
-  with ``try`` for a thoroughly checked version. This addresses the
-  potential downside of only eliding ``try`` without losing the ability
-  to draft code quickly.
-
-3. Eliminate ``do``.
-
-* ``do`` is already a keyword in Chapel, so it would take more effort to 
-  determine that the ``do`` is being used in association with a ``catch``.
-
-* In its place, ``try`` could be defined for single and compound statements.
-  
-  * If an error is thrown, it will look for a matching ``catch`` block.
-  * If none exists, it will throw to a surrounding ``try`` block.
-  * If none exists, then the procedure invoking it must ``throw`` or the
-    program will not compile.
-
-* The downside is that ``try`` could no longer be used in an expression
-  form, so assignments that might throw an error may look more awkward.
-
-:: 
-
-  var a = try canThrowErrors(); // expression
-  try var a = canThrowErrors(); // statement
-
-4. Cleaning up after an error.
-
-* It is often necessary to cleanup state if an error occurs. To capture this,
-  ``do``/``catch`` could be associated with a ``finally`` block that will
-  run when the ``do`` (or ``try``) block is exited.
-
-* Swift's version of this is ``defer``, which runs when the scope it is
-  defined in is exited. This is a more general form of ``finally`` which
-  may better fit Chapel's needs. 
 
 Examples
 --------
@@ -418,6 +489,21 @@ program will halt.
         writeln("Hello!");
       }
     }
+
+
+Future Design Work
+------------------
+
+* Throwing errors from iterators
+* Ability to catch errors generated in runtime layers:
+
+  * communication
+  * memory allocation
+  * task creation
+
+* Task joins propagate errors to parent tasks:
+
+  * Occurs at the end of sync/coforall/cobegin blocks
 
 
 Implementation Notes

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -159,7 +159,9 @@ throw. This is being done for developer ergonomics and legibility.
 
 The design will also reflect the goals of the second solution, elide ``try``
 with a compiler flag, in the sense that there will be multiple levels of
-strictness in error handling.
+strictness when annotating error handling cases.
+
+Finaly, the fourth solution will be addressed in the Future Work section.
 
 
 Chapel Error Handling
@@ -487,7 +489,7 @@ be provided at task join.
   }
 
 The implementation requires that the ``cobegin`` statements be
-synchronized first.
+synchronized before the errors are handled.
 
 .. code_block:: chapel
 
@@ -570,13 +572,48 @@ Raising an error will halt the execution of the iterator. Errors in follower
 iterations in ``coforall`` and ``forall`` loops may still allow some iteration
 to occur. All errors will be reported at task join, as in Example 3.
 
-Example 5: Runtime operations
-+++++++++++++++++++++++++++++
 
-Many kinds of runtime operations in Chapel have the potential to fail (say if
-you are out of memory). This class of errors should be enclosed with ``try!``
-so that if one is encountered at runtime, your program will ``halt()`` before
-causing other catastrophic errors.
+Future Work
+-----------
+
+Error cleanup
++++++++++++++
+
+Chapel will adopt something similar to Swift's ``defer``. Code enclosed in a
+``defer`` block is run whenever the enclosing scope exits, whether it be by
+error or normal execution. 
+
+.. code-block:: chapel
+    
+    proc caller() throws {
+      try {
+        var a = allocateBigObject();
+        defer {
+          delete a;
+        }
+        canThrowErrors(a);
+      }
+    }
+
+If multiple ``defer`` blocks are contained within a single scope,they are
+executed in reverse order of declaration, like a stack. If a ``defer``
+block is not reached in the execution of a scope, it will not be run on
+the scope's exit.
+
+This has a few advantages when compared to ``finally`` in Java/C#:
+
+  * Cleanup code is local to initializing code
+  * ``defer`` can be used outside of error handling
+
+Runtime errors
+++++++++++++++
+
+Many kinds of runtime operations in Chapel have the potential to fail
+(usually from running out of memory):
+
+  * communication
+  * memory allocation
+  * task creation
 
 .. code-block:: chapel
 
@@ -593,28 +630,25 @@ causing other catastrophic errors.
       }
     }
 
-For reference, here is an implementation:
-
-// TODO: how to get an error from an on clause
+The implementation of runtime error handling will keep the C runtime
+independent of Chapel error handling. The runtime will be modified
+to return error codes instead of halting, and Chapel module code
+will translate these runtime error codes into Chapel ``throws``.
 
 .. code-block:: chapel
 
-    var e: Error;
-    on Locales[0]
+    proc chpl_here_alloc(size: int): c_void_ptr throws {
+      extern proc chpl_mem_alloc(size: int) : c_void_ptr; //  runtime function
+      const p = chpl_mem_alloc(size); //  always returns
+      if p == c_nil then              //  runtime says allocation failed
+        throw new OutOfMemoryError();
+      return p;
+    }
 
+Asynchronous error handling
++++++++++++++++++++++++++++
 
-Future Design Work
-------------------
-
-* Throwing errors from iterators
-* Ability to catch errors generated in runtime layers:
-
-  * communication
-  * memory allocation
-  * task creation
-
-* Task joins propagate errors to parent tasks:
-
-  * Occurs at the end of sync/coforall/cobegin blocks
+Asynchronous tasks should not have to be synchronized before their errors
+can be handled. No design has yet been proposed to handle this case.
 
 .. _Swift: https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/ErrorHandling.html

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -254,26 +254,24 @@ For example, here is some Chapel code that throws and handles an error:
 
   class IllegalArgumentError: Error {} 
 
-  proc caller(arg) throws : A {
+  proc caller(arg) throws {
     try {
-      var value: A = callee(arg);
+      callee(arg);
       for i in iterating(arg) do
         writeln(i);
     } catch e: IllegalArgumentError {
-      return DEFAULT_A;
-    } catch e {
-      throw e;
-    } 
+      writeln("illegal arg, exiting caller");
+    }
+    // must throw because there is no catch-all block
   }
 
   proc callee(arg) throws : A {
-    if arg then
-      return new A;
-    else
+    if !arg then
       throw new IllegalArgumentError();
+    return new A(arg);
   }
 
-  iter iterating(arg) throws : A {
+  iter iterating(arg) throws : int {
     if arg < 1 then
       throw new IllegalArgumentError();
 
@@ -286,19 +284,18 @@ The compiler could translate this into the following Chapel code:
 .. code-block:: chapel
 
   class IllegalArgumentError: Error {} 
-  class IteratorError: Error {}
 
-  proc caller(arg, out _e_out: Error): A {
+  proc caller(arg, out _e_out: Error) {
     var _e: Error; 
-    var value: A = callee(arg, _e);
+    
+    callee(arg, _e);
 
     if _e: IllegalArgumentError {
       delete _e;
-      return DEFAULT_A;
+      writeln("illegal arg, exiting caller"); 
     } else if _e {
       _e_out = _e;
-      const _failure: A;
-      return _failure;
+      return;
     }
     
     for i in iterating(arg, _e) do
@@ -306,29 +303,27 @@ The compiler could translate this into the following Chapel code:
 
     if _e: IllegalArgumentError {
       delete _e;
-      return DEFAULT_A;
+      writeln("illegal arg, exiting caller"); 
     } else if _e {
       _e_out = _e;
-      const _failure: A;
-      return _failure;
+      return;
     }
 
     return value;
   }
 
   proc callee(arg, out _e_out: Error): A {
-    if arg then
-      return new A();
-    else {
+    if !arg {
       _e_out = new IllegalArgumentError();
-      const _failure: A;
-      return _failure; 
+      const _fail: A;
+      return _fail;
     }
+    return new A(arg);
   }
 
   iter iterating(arg, out _e_out: Error): A {
     if arg < 1 {
-      _e_out = new IteratorError();
+      _e_out = new IllegalArgumentError();
       return;
     }
 

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -5,7 +5,7 @@ Status:
   Draft
 
 Authors:
-  Greg Titus, Kyle Brady, Michael Ferguson
+  Greg Titus, Kyle Brady, Michael Ferguson, Preston Sahabu
 
 Abstract
 --------
@@ -14,52 +14,54 @@ A proposal for how error handling should work in Chapel.
 
 
 Rationale
----------
++++++++++
 
-Chapel currently lacks a general strategy for errors. The standard library
-currently primarily uses two approaches: `halt()` and optional `out` arguments
-(`out error: syserr`, if argument provided, assumes user will handle it; else
-call `halt()` ). Each of these approaches has serious drawbacks.
+Chapel currently lacks a general strategy for errors. The current standard
+library primarily uses two approaches, and each has serious drawbacks:
 
-  * Halting the program is not appropriate in library code
-  * The output argument approach only returns error codes and doesn't permit
-    users to add new error codes or new types of errors.
+* ``halt()``
+    
+  * Halting the program is not appropriate in library code.
 
-A more general strategy is desired. A good strategy would support the ability
-to write bulletproof code, ideally in a way that supports propagation of
-errors, and also the ability to get useful messages when errors are not
-handled.
+* optional ``out`` arguments, ex. ``out error: syserr``
 
-Description
------------
+  * ``if`` argument provided, assumes user will handle it; ``else halt()``
+  * Only returns error codes.
+  * Doesn't permit users to add new error codes or new types of errors.
 
-This error handling proposal is inspired by the Swift error handling strategy.
-See
-
-https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/ErrorHandling.html
+A more general strategy is desired, one that supports robust code,
+propagates errors, and provides useful messages when errors are not handled.
 
 
-This strategy is appealing because it represents a middle ground arguably
-acceptable to devotees of both exceptions and error codes; it is easier to
-implement than stack-unwinding since it re-uses the existing return mechanisms;
-and it fits well with existing task parallelism.
+Model: Swift Error Handling
+---------------------------
 
-Summary of the Swift Error Handling Strategy
-++++++++++++++++++++++++++++++++++++++++++++
+This error handling proposal is inspired by the Swift_ error handling strategy.
 
-Functions that can raise an error are declared with throws:
+Swift's strategy is appealing because it:
+
+* represents a middle ground between exceptions and error codes;
+* is easier to implement than stack-unwinding since it re-uses the existing
+  return mechanisms; and
+* fits well with existing task parallelism.
+
+Swift Syntax
+++++++++++++
+
+* Functions that can throw an error are declared with ``throws``:
 
 ::
 
   func canThrowErrors() throws { … }
   func cannotThrowErrors() { … }
 
-Calls that throw must be decorated with `try` or `try!`
+* Calls that throw must be decorated with ``try`` or ``try!``.
 
-`try` propagates the error to an enclosing `do`/`catch` block or out of a
-throwing function `try!` halts if an error occurred
+  * ``try`` propagates the error to an enclosing ``do``/``catch`` block or out
+    of a throwing function.
+  * ``try!`` halts if an error occurred.
 
-Programs can respond to errors with `do`/`catch` statements:
+* Programs can catch errors with ``do``/``catch`` statements:
 
 ::
 
@@ -70,18 +72,24 @@ Programs can respond to errors with `do`/`catch` statements:
     writeln("The first call failed!")
   }
 
-
 Why Decorate Statements That Throw
 ++++++++++++++++++++++++++++++++++
 
-The Swift error handling approach includes the use of `try` to mark statements
+The Swift error handling approach includes the use of ``try`` to mark statements
 that can throw. This design addresses the most serious criticism of exceptions
 as a language feature - that they make the control flow possibilities hard to
 reason about. By marking each statement that can throw, the control flow
 possibilities can again be reasoned about with local information only.
 
-Expected Additions for Chapel
-+++++++++++++++++++++++++++++
+
+Chapel Error Handling
+---------------------
+
+Beyond the syntax and the additions below, Chapel's error handling strategy
+will be more or less identical to that of Swift. 
+
+Expected Additions
+++++++++++++++++++
 
 * Throwing errors from iterators
 * Ability to catch errors generated in runtime layers:
@@ -89,12 +97,148 @@ Expected Additions for Chapel
   * Communication
   * Memory allocation
   * Task creation
-  * Not mandatory to check for these
 
 * Task joins propagate errors to parent tasks:
 
   * Occurs at end the of sync/coforall/cobegin blocks
 
+Implementation
+++++++++++++++
+
+Given that the compiler will enforce the handling of errors, it is possible
+for them to be implemented with the ``out`` argument method described in
+the introduction.
+
+For example, here is some Chapel code that handles an error:
+
+.. code-block:: chapel
+
+  class IllegalArgumentError: Error {} 
+
+  proc caller(arg): A {
+    var value: A = callee(arg);
+    return value;
+  }
+
+  proc handler(arg): A throws {
+    do {
+      var value: A = try callee(arg);
+    } catch e: IllegalArgumentError {
+      return DEFAULT_A;
+    } catch e: Error {
+      throw e;
+    } 
+  }
+
+  proc callee(arg): A throws {
+    if arg then
+      return new A;
+    else
+      throw new IllegalArgumentError();
+  }
+
+The compiler could translate this into the following Chapel code:
+
+.. code-block:: chapel
+
+  class IllegalArgumentError: Error {} 
+
+  proc caller(arg): A {
+    var _e: Error;
+    var value: A = callee(arg, _e);
+    if _e then
+      halt(e.message());
+    else
+      return value;
+  }
+
+  proc handler(arg, out _e: Error): A {
+    var _e2: Error;
+    var value: A = callee(arg, _e2);
+    if _e2: IllegalArgumentError then
+      delete _e2;
+      return DEFAULT_A;
+    else if _e2 then
+      _e = _e2; 
+    else
+      return value;
+  }
+
+  proc callee(arg, out _e: Error): A {
+    if arg then
+      return new A;
+    else
+      _e = new IllegalArgumentError();
+  }
+
+Feedback Received (7/20)
+------------------------
+
+1. ``try`` is verbose within ``do`` blocks. While it clarifies control flow
+   within the block, it would be tiresome to repeat with throwing functions
+   that are closely related (ex. I/O).
+
+2. ``try`` is also verbose from an iteration perspective. For example, 
+   ``writeln("hello world")`` would have to be prefaced with a ``try``
+   statement if it were strictly enforced.
+
+3. main() ought to have some sort of reasonable response to an error being
+   propagated up to it.
+
+Potential Solutions
++++++++++++++++++++
+
+1. Elide ``try``.
+  
+* Within ``do`` blocks, ``try`` is only a visual aide to track control
+  flow. It is reasonable for developers to track that a procedure throws
+  without this assistance because it's already in a ``do`` block. However,
+  ``try!`` would be permitted inside ``do`` blocks for critical failures.
+
+* Outside of ``do`` blocks, ``try`` or ``try!`` can be elided on throwing
+  procedure calls depending on the calling procedure's signature. If the
+  calling procedure ``throws``, then ``try``, else ``try!``.
+
+* The downside of this is that it would be possible to pass errors of a
+  called procedure through the callee without any visual indication of
+  which call is throwing. This could lead to poorly handled error cases.
+    
+2. Elide ``try`` with a compiler flag.
+
+* Same as (1), but we would add an option to enforce marking statements
+  with ``try`` for a thoroughly checked version. This addresses the
+  potential downside of only eliding ``try`` without losing the ability
+  to draft code quickly.
+
+3. Eliminate ``do``.
+
+* ``do`` is already a keyword in Chapel, so it would take more effort to 
+  determine that the ``do`` is being used in association with a ``catch``.
+
+* In its place, ``try`` could be defined for single and compound statements.
+  
+  * If an error is thrown, it will look for a matching ``catch`` block.
+  * If none exists, it will throw to a surrounding ``try`` block.
+  * If none exists, then the procedure invoking it must ``throw`` or the
+    program will not compile.
+
+* The downside is that ``try`` could no longer be used in an expression
+  form, so assignments that might throw an error may look more awkward.
+
+:: 
+
+  var a = try canThrowErrors(); // expression
+  try var a = canThrowErrors(); // statement
+
+4. Cleaning up after an error.
+
+* It is often necessary to cleanup state if an error occurs. To capture this,
+  ``do``/``catch`` could be associated with a ``finally`` block that will
+  run when the ``do`` (or ``try``) block is exited.
+
+* Swift's version of this is ``defer``, which runs when the scope it is
+  defined in is exited. This is a more general form of ``finally`` which
+  may better fit Chapel's needs. 
 
 Examples
 --------
@@ -281,3 +425,5 @@ Implementation Notes
 
 Since this error handling strategy is based off returning either the value or
 an error, better support for union types in chapel may be necessary.
+
+.. _Swift: https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/ErrorHandling.html

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -90,7 +90,7 @@ Feedback Received (7/20)
    within the block, it would be tiresome to repeat with throwing functions
    that are closely related (ex. I/O). 
 
-2. ``try`` is also verbose from an iteration perspective. For example, 
+2. ``try`` is also verbose from an ergonomic perspective. For example, 
    ``writeln("hello world")`` would have to be prefaced with a ``try``
    statement if it were strictly enforced.
 
@@ -153,7 +153,13 @@ Potential solutions
 Enacted solution
 ++++++++++++++++
 
-This CHIP will move forward with a combination of the first three solutions.
+This CHIP will move forward with the third solution, eliminate ``do``, which
+moves it away from the Swift approach of marking every statement that can
+throw. This is being done for developer ergonomics and legibility.
+
+The design will also reflect the goals of the second solution, elide ``try``
+with a compiler flag, in the sense that there will be multiple levels of
+strictness in error handling.
 
 
 Chapel Error Handling
@@ -177,6 +183,8 @@ Syntax
 
     * If none exists, the error will be passed out of the function, hence the
       procedure must ``throw``.
+
+    * If the procedure does not ``throw``, the compiler will raise an error.
 
   * ``try!`` will ``halt()`` if an error occurs.
   
@@ -207,10 +215,13 @@ the compiler will run checks in one of two modes, based on a flag.
 2. **Strict.** If a call to a throwing procedure is not enclosed by a ``try``
    or ``try!``, the compiler will raise an error.
 
-Error types
-+++++++++++
+Errors
+++++++
 
-* ``Error`` will be a class defined in the standard library.
+The long term plan is to support enums, unions, and tagged unions as Error
+types, but the first implementation will be restricted to classes.
+
+* ``Error`` will be a class defined in the standard library. 
   
 * ``Error`` may be extended to create custom errors and a hierarchy.
 
@@ -308,8 +319,6 @@ The compiler could translate this into the following Chapel code:
       _e_out = _e;
       return;
     }
-
-    return value;
   }
 
   proc callee(arg, out _e_out: Error): A {
@@ -349,7 +358,6 @@ produce a ``halt()``.
       halt(e.message());
     return value;
   }
-
 
 Examples
 --------
@@ -391,11 +399,18 @@ This function can now be used as follows:
 
     var my_timer: Timer;
     try! my_timer.start();
-    try
+    try {
       my_timer.start();
-    catch e: Error
+    } catch e: Error {
       writeln(e.message);
+    }
     try! my_timer.start(); // halts the program!
+
+Here is the implementation of this error-handling:
+
+.. code-block:: chapel
+    var my_timer: Timer;
+
 
 Example 2: File I/O
 +++++++++++++++++++

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -265,15 +265,17 @@ For example, here is some Chapel code that throws and handles an error:
 
   class IllegalArgumentError: Error {} 
 
-  proc caller(arg) throws {
+  proc handle(arg) throws {
     try {
       callee(arg);
-      for i in iterating(arg) do
-        writeln(i);
     } catch e: IllegalArgumentError {
       writeln("illegal arg, exiting caller");
     }
-    // must throw because there is no catch-all block
+    // no catch-all block -> throws
+  }
+
+  proc passThru(arg) throws {
+    try callee(arg);
   }
 
   proc callee(arg) throws : A {
@@ -282,23 +284,15 @@ For example, here is some Chapel code that throws and handles an error:
     return new A(arg);
   }
 
-  iter iterating(arg) throws : int {
-    if arg < 1 then
-      throw new IllegalArgumentError();
-
-    for i in 1..arg do
-      yield i;
-  }
-
 The compiler could translate this into the following Chapel code:
 
 .. code-block:: chapel
 
   class IllegalArgumentError: Error {} 
 
-  proc caller(arg, out _e_out: Error) {
+  proc handle(arg, out _e_out: Error) {
     var e: Error; 
-    
+
     callee(arg, e);
 
     if e: IllegalArgumentError {
@@ -308,17 +302,10 @@ The compiler could translate this into the following Chapel code:
       _e_out = e;
       return;
     }
-    
-    for i in iterating(arg, e) do
-      writeln(i);
+  }
 
-    if e: IllegalArgumentError {
-      delete e;
-      writeln("illegal arg, exiting caller"); 
-    } else if e {
-      _e_out = e;
-      return;
-    }
+  proc passThru(arg, out _e_out: Error) {
+    callee(arg, _e_out);
   }
 
   proc callee(arg, out _e_out: Error): A {
@@ -330,24 +317,13 @@ The compiler could translate this into the following Chapel code:
     return new A(arg);
   }
 
-  iter iterating(arg, out _e_out: Error): A {
-    if arg < 1 {
-      _e_out = new IllegalArgumentError();
-      return;
-    }
-
-    for i in 1..arg do
-      yield i;
-  } 
-
-In default mode, calling functions without handling their errors will
-produce a ``halt()``.
-
+In default mode, calling throwing functions without an enclosing
+``try`` will produce a ``halt()``.
+ 
 .. code-block:: chapel
 
   proc nohandle(arg): A {
-    var value: A = callee(arg);
-    return value;
+    return callee(arg);
   }
 
   // translated

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -204,8 +204,8 @@ To address the desire for both fast prototyping and enforced error handling,
 the compiler will run checks in one of two modes, based on a flag.
 
 1. **Default.** If a call to a throwing procedure is not marked with a ``try`` or
-   ``try!``, the program will compile and the call will ``halt()`` on an error,
-   as if the procedure were called with ``try!``.
+   ``try!``, the program will compile with a warning and the call will ``halt()``
+   on an error, as if the procedure were called with ``try!``.
 
 2. **Strict.** If a call to a throwing procedure is not marked with a ``try`` or
    ``try!``, the compiler will raise an error.
@@ -246,32 +246,37 @@ Given that the compiler will enforce the handling of errors, it is possible
 for them to be implemented with the ``out`` argument method described in
 the introduction.
 
-For example, here is some Chapel code that handles an error:
+For example, here is some Chapel code that throws and handles an error:
 
 .. code-block:: chapel
 
   class IllegalArgumentError: Error {} 
 
-  proc nohandle(arg): A {
-    var value: A = callee(arg);
-    return value;
-  }
-
-  proc handler(arg): A throws {
-    do {
-      var value: A = try callee(arg);
+  proc caller(arg) throws : A {
+    try {
+      var value: A = callee(arg);
+      for i in iterating(arg) do
+        writeln(i);
     } catch e: IllegalArgumentError {
       return DEFAULT_A;
-    } catch e: Error {
+    } catch e {
       throw e;
     } 
   }
 
-  proc callee(arg): A throws {
+  proc callee(arg) throws : A {
     if arg then
       return new A;
     else
       throw new IllegalArgumentError();
+  }
+
+  iter iterating(arg) throws : A {
+    if arg < 1 then
+      throw new IllegalArgumentError();
+
+    for i in 1..arg do
+      yield i;
   }
 
 The compiler could translate this into the following Chapel code:
@@ -280,6 +285,65 @@ The compiler could translate this into the following Chapel code:
 
   class IllegalArgumentError: Error {} 
 
+  proc caller(arg, out _e_out: Error): A {
+    var _e: Error; 
+    var value: A = callee(arg, _e);
+
+    if _e: IllegalArgumentError {
+      delete _e;
+      return DEFAULT_A;
+    } else if _e {
+      _e_out = _e;
+      const _failure: A;
+      return _failure;
+    }
+    
+    for i in iterating(arg, _e) do
+      writeln(i);
+
+    if _e: IllegalArgumentError {
+      delete _e;
+      return DEFAULT_A;
+    } else if _e {
+      _e_out = _e;
+      const _failure: A;
+      return _failure;
+    }
+
+    return value;
+  }
+
+  proc callee(arg, out _e_out: Error): A {
+    if arg then
+      return new A();
+    else {
+      _e_out = new IllegalArgumentError();
+      const _failure: A;
+      return _failure; 
+    }
+  }
+
+  iter iterating(arg, out _e_out: Error): A {
+    if arg < 1 {
+      _e_out = new IllegalArgumentError();
+      return;
+    }
+
+    for i in 1..arg do
+      yield i;
+  } 
+
+In default mode, calling functions without handling their errors will
+produce a ``halt()``.
+
+.. code-block:: chapel
+
+  proc nohandle(arg): A {
+    var value: A = callee(arg);
+    return value;
+  }
+
+  // translated
   proc nohandle(arg): A {
     var _e: Error;
     var value: A = callee(arg, _e);
@@ -288,37 +352,15 @@ The compiler could translate this into the following Chapel code:
     return value;
   }
 
-  proc handler(arg, out _e: Error): A {
-    var _e_in: Error;
-    var value: A = callee(arg, _e_in);
-    if _e_in: IllegalArgumentError {
-      delete _e_in;
-      return DEFAULT_A;
-    } else if _e_in {
-      _e = _e_in; 
-      return;
-    }
-    return value;
-  }
-
-  proc callee(arg, out _e: Error): A {
-    if arg then
-      return new A;
-    else {
-      _e = new IllegalArgumentError();
-      return;
-    }
-  }
-
 
 Examples
 --------
 
-Example 1: Simple Errors
+Example 1: Simple errors
 ++++++++++++++++++++++++
 
-As an example, this is a function currently (Jan 2016) on our Timer record in
-the standard modules:
+As an example, this function is currently in our Timer record, which is
+part of the standard modules:
 
 .. code-block:: chapel
 
@@ -331,8 +373,8 @@ the standard modules:
       }
     }
 
-It calls `halt` when the timer is already running, which is not very friendly.
-With our proposal this would instead be:
+It calls ``halt()`` when the timer is already running, which is not very
+user friendly. With our proposal this would instead be:
 
 .. code-block:: chapel
 
@@ -351,18 +393,17 @@ This function can now be used as follows:
 
     var my_timer: Timer;
     try! my_timer.start();
-    do {
-      try my_timer.start();
-    } catch e: Error {
-      writeln(Error.message);
-    }
-    try! my_timer.start(); // Will halt the program!
+    try
+      my_timer.start();
+    catch e: Error
+      writeln(e.message);
+    try! my_timer.start(); // halts the program!
 
-Example 2: File IO
-++++++++++++++++++
+Example 2: File I/O
++++++++++++++++++++
 
-A common place for errors is interactions with the filesystem, we currently
-handle these with two strategies, out arguments and halting.
+A common place for errors is interactions with the filesystem, and we
+currently handle these with ``out`` arguments and halting.
 
 .. code-block:: chapel
 
@@ -379,50 +420,53 @@ handle these with two strategies, out arguments and halting.
       halt("Failed to open channel");
     }
   } else {
-   halt("Failed to open file");
+    halt("Failed to open file");
   }
 
 .. code-block:: chapel
 
-  do {
-    var file = try open("my_data.dat");
-    var channel = try file.writer(err);
-    try channel.write(1, 2, 4, 8, err);
-  } catch  e: IOError {
+  try {
+    var file = open("my_data.dat");
+    var channel = file.writer(err);
+    channel.write(1, 2, 4, 8, err);
+  } catch e: IOError {
     halt(e.message());
   }
 
   // Equivalent to:
 
-  var file = try! open("my_data.dat");
-  var channel = try! file.writer(err);
-  try! channel.write(1, 2, 4, 8, err);
+  try! {
+    var file = open("my_data.dat");
+    var channel = file.writer(err);
+    channel.write(1, 2, 4, 8, err);
+  }
 
-Example 3: Errors In cobegins
+// TODO: Think about it
+Example 3: Cobegins
 +++++++++++++++++++++++++++++
 
-`cobegin`, and other task parallel constructs create tasks which could have
-errors. These errors will be provided at task join.
+``cobegin``, and other task parallel constructs create tasks which could
+have errors. These errors will be provided at task join.
 
 .. code-block:: chapel
 
   proc encounterError() throws { throw new Error(); }
   proc noError() throws { return; }
-  do {
-    try cobegin {
-      try encounterError();
-      try noError();
-      try encounterError();
+  try {
+    cobegin {
+      encounterError();
+      noError();
+      encounterError();
     }
   } catch errors: CobeginErrors { // could use a better name
     for e in errors {
-      writeln(e); // Would print out two lines
+      writeln(e); // would print out two lines
     }
   }
 
-Example 4: Errors In Iterators
+Example 4: Iterators
 ++++++++++++++++++++++++++++++
-This is the current `glob` iterator in the `FileSystem` module:
+This is the current ``glob`` iterator in the ``FileSystem`` module:
 
 .. code-block:: chapel
 
@@ -444,7 +488,7 @@ The new version would look like:
 
 .. code-block:: chapel
 
-  iter glob(pattern: string = "*"): string {
+  iter glob(pattern: string = "*") throws : string {
     ...
     if (err != 0 && err != GLOB_NOMATCH) then
       throw new Error("unhandled error in glob()");
@@ -455,37 +499,37 @@ Which can then be used like this:
 
 .. code-block:: chapel
 
-    do {
-      try for x in glob() {
+    try {
+      for x in glob() do 
         writeln(x);
-      }
-    } catch e: Error {
+    } catch e {
       writeln("Error in glob");
     }
 
 Raising an error will halt the execution of the iterator. Errors in follower
-iterations in `coforall` and `forall` loops may still allow some iteration to
-occur. All errors will be reported at task join, as in example 3.
+iterations in ``coforall`` and ``forall`` loops may still allow some iteration
+to occur. All errors will be reported at task join, as in Example 3.
 
 
-Example 5: Errors In Runtime Operations
+Example 5: Runtime operations
 +++++++++++++++++++++++++++++++++++++++
 
 Many kinds of runtime operations in Chapel have the potential to fail (say if
-you are out of memory). This class of errors will not be mandatory to check
-for. But, if one is encountered at runtime and you do not check for it, your
-program will halt.
+you are out of memory). This class of errors should be marked with ``try!``
+so that if one is encountered at runtime, your program will ``halt()`` before
+causing other catastrophic errors.
 
 .. code-block:: chapel
 
-    do {
-      try on Locales[0] {
+    try {
+      on Locales[0] {
         writeln("Hello!");
       }
     } catch e: OutOfMemoryError {
       free_large_object();
-      // This on statement does not have a try, and will halt execution if it fails
-      on Locales[0] {
+
+      // attempt again, halt execution if it fails
+      try! on Locales[0] {
         writeln("Hello!");
       }
     }

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -187,12 +187,10 @@ Syntax
   * If no matching ``catch`` block exists:
    
     * ``try`` propagates the error. This can either be to an enclosing ``try``
-      block, or out of the enclosing procedure, which must ``throw``.
+      block or out of the enclosing procedure (which must ``throw``).
 
     * ``try!`` will ``halt()``, even if enclosed by another ``try``.
   
-
-Here is an example.
 
 ::
 
@@ -217,13 +215,17 @@ the compiler will run checks in one of two modes, based on a flag.
 2. **Strict.** If a call to a throwing procedure is not enclosed by a ``try``
    or ``try!``, the compiler will raise an error.
 
+A more fine-grained approach should be included in the future, with the
+default/strict policy set per-module or per-function.
+
 Errors
 ++++++
 
-The long term plan is to support enums, unions, and tagged unions as Error
-types, but the first implementation will be restricted to classes.
+The long term plan is to support classes, records, enums, unions, and
+tagged unions as Error types, but the first implementation will be
+restricted to classes.
 
-* ``Error`` will be a class defined in the standard library. 
+* Base class ``Error`` will be a defined in the standard library. 
   
 * ``Error`` may be extended to create custom errors and a hierarchy.
 
@@ -232,13 +234,12 @@ types, but the first implementation will be restricted to classes.
   class MyBaseError: Error {}
   class MySubError: MyBaseError {}
 
-* Error types will not be checked by the compiler.
+* At runtime, ``catch`` blocks attempt to handle errors from their.
+  matching ``try`` or ``try!`` blocks. 
 
-* At runtime ``catch`` blocks can match against errors.
-
-  * These matches will be evaluated in order, so even if a better fitting
-    type is present, it will not be chosen if a matching general type
-    precedes it.
+  * ``catch`` clauses will be evaluated in order, so even if a more
+    exact type is present for an ``Error``, it will not be selected
+    if a matching general type precedes it.
 
   * If a type is not specified, any ``Error`` will match.
 

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -297,26 +297,26 @@ The compiler could translate this into the following Chapel code:
   class IllegalArgumentError: Error {} 
 
   proc caller(arg, out _e_out: Error) {
-    var _e: Error; 
+    var e: Error; 
     
-    callee(arg, _e);
+    callee(arg, e);
 
-    if _e: IllegalArgumentError {
-      delete _e;
+    if e: IllegalArgumentError {
+      delete e;
       writeln("illegal arg, exiting caller"); 
-    } else if _e {
-      _e_out = _e;
+    } else if e {
+      _e_out = e;
       return;
     }
     
-    for i in iterating(arg, _e) do
+    for i in iterating(arg, e) do
       writeln(i);
 
-    if _e: IllegalArgumentError {
-      delete _e;
+    if e: IllegalArgumentError {
+      delete e;
       writeln("illegal arg, exiting caller"); 
-    } else if _e {
-      _e_out = _e;
+    } else if e {
+      _e_out = e;
       return;
     }
   }
@@ -355,7 +355,7 @@ produce a ``halt()``.
     var _e: Error;
     var value: A = callee(arg, _e);
     if _e then
-      halt(e.message());
+      halt(e.message);
     return value;
   }
 
@@ -406,10 +406,24 @@ This function can now be used as follows:
     }
     try! my_timer.start(); // halts the program!
 
-Here is the implementation of this error-handling:
+Here is the implementation of this example:
 
 .. code-block:: chapel
+
     var my_timer: Timer;
+    var _e: Error;         // compiler generated
+    my_timer.start(_e);
+    if _e then
+      halt(_e.message);
+
+    var e: Error;          // user defined
+    my_timer.start(e);
+    if e then
+      writeln(e.message); 
+
+    my_timer.start(_e);    // can reuse compiler-gen error
+    if _e then
+      halt(_e.message);
 
 
 Example 2: File I/O
@@ -440,19 +454,38 @@ currently handle these with ``out`` arguments and halting.
 
   try {
     var file = open("my_data.dat");
-    var channel = file.writer(err);
-    channel.write(1, 2, 4, 8, err);
+    var channel = file.writer();
+    channel.write(1, 2, 4, 8);
   } catch e: IOError {
-    halt(e.message());
+    halt(e.message);
   }
 
   // Equivalent to:
 
   try! {
     var file = open("my_data.dat");
-    var channel = file.writer(err);
-    channel.write(1, 2, 4, 8, err);
+    var channel = file.writer();
+    channel.write(1, 2, 4, 8);
   }
+
+An implementation of the ``try!`` portion of the example:
+
+.. code-block:: chapel
+
+  var _e: Error;
+
+  var file = open("my_data.dat", _e);
+  if _e then
+    halt(_e.message);
+
+  var channel = file.writer(_e);
+  if _e then
+    halt(_e.message);
+
+  channel.write(1, 2, 4, 8, _e);
+  if _e then
+    halt(_e.message);
+
 
 Example 3: Cobegins
 +++++++++++++++++++
@@ -479,6 +512,16 @@ These errors will be provided at task join.
       writeln(e); // would print out two lines
     }
   }
+
+The implementation requires that the ``cobegin`` statements be
+synchronized first.
+
+// TODO: finish
+.. code_block:: chapel
+
+  proc encounterError(out _e_out) { _e_out = new Error(); }
+  proc noError(out _e_out) { return; }
+  
 
 Example 4: Iterators
 ++++++++++++++++++++
@@ -522,6 +565,25 @@ Which can then be used like this:
       writeln("Error in glob");
     }
 
+Which would be implemented like this:
+
+.. code-block:: chapel
+
+    iter glob(pattern: string = "*", out _e_out: Error) : string {
+      ...
+      if (err != 0 && err != GLOB_NOMATCH) {
+        _e_out = new Error("unhandled error in glob()");
+        return;
+      }
+      ...
+    } 
+
+    var e: Error;
+    for x in glob(_e_out = e) do
+      writeln(x);
+    if e then
+      writeln("Error in glob");
+
 Raising an error will halt the execution of the iterator. Errors in follower
 iterations in ``coforall`` and ``forall`` loops may still allow some iteration
 to occur. All errors will be reported at task join, as in Example 3.
@@ -548,6 +610,14 @@ causing other catastrophic errors.
         writeln("Hello!");
       }
     }
+
+For reference, here is an implementation:
+
+// TODO: finish
+.. code-block:: chapel
+
+    var e: Error;
+    on Locales[0]
 
 
 Future Design Work

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -179,8 +179,6 @@ Syntax
       procedure must ``throw``.
 
   * ``try!`` will ``halt()`` if an error occurs.
-
-  * Both may be used with single and compound statements.
   
 * Errors can be handled with ``catch`` statements.
 
@@ -193,7 +191,7 @@ Here is an example.
     try canThrowErrors();  // also handled by catch ("in scope")
     try! canThrowErrors(); // halts on failure
   } catch e {
-    writeln("The first call failed!")
+    writeln("One of the first two calls failed!")
   }
 
 Default vs strict mode

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -491,11 +491,10 @@ Example 3: Cobegins
 +++++++++++++++++++
 
 ``begin`` and ``cobegin`` are parallel constructs that create
-asynchronous tasks which could have errors. Given that our error
-handling is synchronous, the compiler will force these tasks to
-``sync`` before the program is allowed to continue.
-
-These errors will be provided at task join.
+asynchronous tasks which could have errors. The parent task will
+wait for error-throwing child tasks to complete, as with a sync
+statement or at the end of coforall/cobegin. These errors will
+be provided at task join.
 
 .. code-block:: chapel
 


### PR DESCRIPTION
@mppf, @gbtitus:

Overhauling the error handling CHIP, first as a source of the slides, then to reflect the changes in the slides. Most significant changes:

- dropped ``do`` from the syntax
- made ``try`` and ``try!`` more flexible
- detailed the class-oriented implementation approach
- touched on future work (``defer``, runtime errors)