### PR TITLE
Update TRAP_INT serial kernel to match the performance of the reference

### DIFF
--- a/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
@@ -97,7 +97,7 @@ module RunBRawLoops {
             var val = 0.0;
             ltimer.start();
             for 0..#num_samples {
-              for i in 0..#len {
+              for i in 0..(len-1):int(32) {
                 var x = x0 + i*h;
                 sumx += trap_int_func(x, y, xp, yp);
               }


### PR DESCRIPTION
Updated TRAP_INT to use a 32-bit range and loop index instead of 64-bit.  This
makes it match the performance of the serial reference version on the system
I've been testing on.