### PR TITLE
Expand CHPL_TEST_NOMAIL handling to recognize well-known 'false' strings

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -170,7 +170,7 @@ if ($debug == 1) {
     $mailcommand = "| $mailer -s \"$mailsubject \" $successmail";
 }
     
-if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
     open(MAIL, $mailcommand);
 
     print MAIL "=== Results - testRelease =================================================\n";
@@ -225,7 +225,7 @@ sub mysystem {
             $mailcommand = "| $mailer -s \"$mailsubject \" $failuremail";
         }
 
-        if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+        if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or $ENV{"CHPL_TEST_NOMAIL"} eq "") {
             print "Trying to mail message... using $mailcommand\n";
             open(MAIL, $mailcommand);
             print MAIL "=== Summary - testRelease ===================================================\n";

--- a/util/cron/lookForTabs.cron
+++ b/util/cron/lookForTabs.cron
@@ -16,7 +16,7 @@ $matches = `wc -l $matchfile`;
 chomp($matches);
 if ($matches != 0) {
   print "matches!\n";
-  if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+  if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
       open(MAIL, "| mail -s 'Cron Nightly TAB check' chapel_dev\@cray.com");
       open(MESSAGE, "<$matchfile");
       while (<MESSAGE>) {
@@ -51,7 +51,7 @@ sub mysystem {
 	print "Error $_[1]: $status\n";
 
     if ($mailmsg != 0) {
-        if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+        if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
             open(MAIL, $mailcommand);
             print MAIL "=== Summary ===================================================\n";
             print MAIL "ERROR $_[1]: $status\n";

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -523,7 +523,7 @@ if ($buildruntime == 0) {
     $mailsubject = "$subjectid $config_name";
     $mailcommand = "| $mailer -s \"$mailsubject \" $nochangerecipient";
 
-    if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+    if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
         print "Mailing to minimal group\n";
         open(MAIL, $mailcommand);
 
@@ -713,7 +713,7 @@ if ($runtests == 0) {
     $mailsubject = "$subjectid $config_name";
     $mailcommand = "| $mailer -s \"$mailsubject \" $recipient";
 
-    if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+    if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
         open(MAIL, $mailcommand);
 
         print MAIL startMailHeader($revision, "<no logfile>", $starttime, $endtime, $crontab, "");

--- a/util/cron/nightly_email.pl
+++ b/util/cron/nightly_email.pl
@@ -110,7 +110,7 @@ if ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpas
 $mailsubject = "$subjectid $config_name";
 $mailcommand = "| $mailer -s \"$mailsubject \" $recipient";
 
-if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
     print "Trying... $mailcommand\n";
     open(MAIL, $mailcommand);
 

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -30,7 +30,7 @@ sub mysystem {
             $mailsubject = "$subjectid $config_name Failure";
             $mailcommand = "| $mailer -s \"$mailsubject \" $recipient";
 
-            if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+            if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
                 print "Trying to mail message... using $mailcommand\n";
                 open(MAIL, $mailcommand);
                 print MAIL startMailHeader($revision, $rawlog, $starttime, $endtime, $crontab, "");

--- a/util/cron/start_opt_test
+++ b/util/cron/start_opt_test
@@ -72,7 +72,7 @@ foreach $line (@lines) {
     }
 }
 
-if ($cron && !exists($ENV{"CHPL_TEST_NOMAIL"})) {
+if ($cron && (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?'))) {
     $nerror = $nerrort2/2;
     if ($nerror == 0) {
         open(FILE, "| mail -s \"Cron $nerror/$nerror (chap02:opts tests)\" $allmail $ENV{'USER'}\@cray.com");

--- a/util/pastPerformance/getoldperf
+++ b/util/pastPerformance/getoldperf
@@ -137,7 +137,7 @@ sub mysystem {
 	print "Error $_[1]: $status\n";
 
     if ($mailmsg != 0) {
-        if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+        if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
             open(MAIL, $mailcommand);
             print MAIL "=== Summary ===================================================\n";
             print MAIL "ERROR $_[1]: $status\n";

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -301,7 +301,7 @@ sub mysystem {
         $mailsubject = "$subjectid Failure";
         $mailcommand = "| $mailer -s \"$mailsubject \" $recipient";
 
-        if (!exists($ENV{"CHPL_TEST_NOMAIL"})) {
+        if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
             print "Trying to mail message... using $mailcommand\n";
             open(MAIL, $mailcommand);
             print MAIL "=== Summary ===================================================\n";


### PR DESCRIPTION
Currently, if environment variable CHPL_TEST_NOMAIL is defined with ANY
string value, even the zero-length string, it means "do not send the e-mails".

With this change, CHPL_TEST_NOMAIL can be set to a well-known 'false' string
values (F, False, N, No, 0, \<null string\>, or \<whitespace\>) (case-insensitive),
and the e-mails will still be sent; same as if CHPL_TEST_NOMAIL was
completely undefined. Any OTHER string value still means, "do not send".

This will make it more convenient to configure CHPL_TEST_NOMAIL as a Jenkins
build parameter.