### PR TITLE
Improvements for scalarReplace, refPropagation, and copyPropagation

### DIFF
--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -602,6 +602,17 @@ static void propagateCopies(std::vector<SymExpr*>& symExprs,
       }
     }
 
+    // If we encounter an ADDR_OF with a symbol, do not allow further
+    // replacements in case the reference is used to modify the symbol's data.
+    if (CallExpr* parent = toCallExpr(se->parentExpr)) {
+      if (parent->isPrimitive(PRIM_ADDR_OF)) {
+        AvailableMap::iterator ami = available.find(se->var);
+        if (ami != available.end()) {
+          available.erase(ami);
+        }
+      }
+    }
+
     // Also if the SymExpr is used in an expression of the form (deref se),
     // and there exists a ref-def pair s.t. ref == (addr_of def) and
     // se->var == ref, replace the deref expression with def.

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -1188,7 +1188,7 @@ eliminateSingleAssignmentReference(Map<Symbol*,Vec<SymExpr*>*>& defMap,
                                    Symbol* var) {
   if (CallExpr* move = findRefDef(defMap, var)) {
     if (CallExpr* rhs = toCallExpr(move->get(2))) {
-      if (rhs->isPrimitive(PRIM_ADDR_OF)) {
+      if (rhs->isPrimitive(PRIM_ADDR_OF) || rhs->isPrimitive(PRIM_SET_REFERENCE)) {
         bool stillAlive = false;
         for_uses(se, useMap, var) {
           CallExpr* parent = toCallExpr(se->parentExpr);
@@ -1214,13 +1214,26 @@ eliminateSingleAssignmentReference(Map<Symbol*,Vec<SymExpr*>*>& defMap,
             ++s_ref_repl_count;
             addUse(useMap, se);
           }
-          else if (parent && isMoveOrAssign(parent)) {
+          else if (parent && (parent->isPrimitive(PRIM_MOVE) || parent->isPrimitive(PRIM_SET_REFERENCE))) {
             CallExpr* rhsCopy = rhs->copy();
+            if (parent->isPrimitive(PRIM_SET_REFERENCE)) {
+              // Essentially a pointer copy like a (move refA refB)
+              parent = toCallExpr(parent->parentExpr);
+              INT_ASSERT(parent && isMoveOrAssign(parent));
+            }
             parent->get(2)->replace(rhsCopy);
             ++s_ref_repl_count;
             SymExpr* se = toSymExpr(rhsCopy->get(1));
             INT_ASSERT(se);
             addUse(useMap, se);
+            // BHARSH TODO: Is it possible to handle the following case safely
+            // for PRIM_ASSIGN?
+            //
+            // ref i_foo : T;
+            // (move i_foo (set reference bar))
+            // (= call_tmp i_foo)
+            //
+            // Should that turn into (= call_tmp bar)?
           } else
             stillAlive = true;
         }

--- a/compiler/optimizations/scalarReplace.cpp
+++ b/compiler/optimizations/scalarReplace.cpp
@@ -566,6 +566,11 @@ scalarReplace() {
     //
     forv_Vec(VarSymbol, var, gVarSymbols) {
       if (AggregateType* ct = toAggregateType(var->type)) {
+        if (var->isRef() && !isReferenceType(var->type)) {
+          // Handle qualified refs without the _ref type
+          ct = var->type->refType;
+        }
+        INT_ASSERT(ct);
         if (Vec<Symbol*>* varVec = typeVarMap.get(ct)) {
           if (isFnSymbol(var->defPoint->parentSymbol)) {
             varSet.set_add(var);


### PR DESCRIPTION
After PR #4745 we observed worse performance for promoted-stream with --no-local. It turned out that scalarReplace wasn't as effective as before, and was problematic for the inner stream loop.

There are three parts to this change:
1. Fix scalarReplace to add qualified-refs to the correct vector
2. Improve eliminateSingleAssignmentReference to handle PRIM_SET_REFERENCE. Specifically, to handle the case where PRIM_SET_REFERENCE took another reference, which basically turns into a copy of the pointer.
3. Fix a bug in propagateCopies that would replace a variable after that variable was modified via reference.