### PR TITLE
Miscellaneous cleanup from qualified refs merge

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -152,7 +152,7 @@ static QualifiedType
 returnInfoCast(CallExpr* call) {
   Type* t1 = call->get(1)->typeInfo();
   Type* t2 = call->get(2)->typeInfo();
-  if (t2->symbol->hasFlag(FLAG_WIDE_CLASS) /*&& !call->get(2)->isRef()*/) {
+  if (t2->symbol->hasFlag(FLAG_WIDE_CLASS)) {
     if (wideClassMap.get(t1))
       t1 = wideClassMap.get(t1);
   }
@@ -521,8 +521,8 @@ initPrimitive() {
 
   prim_def(PRIM_ADDR_OF, "addr of", returnInfoRef);
   prim_def(PRIM_DEREF,   "deref",   returnInfoVal, false, true);
-  // sets a reference to another reference value
-  // it is the RHS of a PRIM_MOVE with the argument reference to point to
+  // If the argument is a reference, simply return it. Otherwise, return a
+  // ref to the arg. The result is always a reference.
   prim_def(PRIM_SET_REFERENCE, "set reference", returnInfoAsRef);
 
   // local block primitives

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -155,7 +155,7 @@ enum Qualifier {
 //   ref aRef = aVar;
 //
 //   SymExpr(aVar) and Symbol(aVar) have QualifiedType(int, QUAL_VAL)
-//   SymExpr(aRef) and Symbol(aVar) have QualifiedType(int, QUAL_REF)
+//   SymExpr(aRef) and Symbol(aRef) have QualifiedType(int, QUAL_REF)
 //
 class QualifiedType {
 public:

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -722,26 +722,12 @@ checkFormalActualTypesMatch()
                     formal->name);
         }
 
-        if (formal->type != actual->typeInfo()) {
-          TypeSymbol* actualTS = actual->typeInfo()->symbol;
-          TypeSymbol* formalTS = formal->type->symbol;
-          if ((formal->intent & INTENT_FLAG_REF) &&
-              actualTS->hasEitherFlag(FLAG_REF, FLAG_WIDE_REF) &&
-              formal->type == actualTS->type->getValType()) {
-            // OK to pass a ref to a ref-intent function
-          } else if((formal->isRefOrWideRef()) &&
-                    formalTS->type->getValType() == actualTS->type->getValType()) {
-            // OK to pass a value to a ref-intent function
-          } else if (!formal->isRefOrWideRef() && actual->isRefOrWideRef() &&
-                    formal->getValType() == actual->getValType()) {
-            // OK to pass ref to non-ref, codegen will insert dereference
-          } else {
-            INT_FATAL(call,
-                      "actual formal type mismatch for %s: %s != %s",
-                      fn->name,
-                      actual->typeInfo()->symbol->name,
-                      formal->type->symbol->name);
-          }
+        if (formal->getValType() != actual->getValType()) {
+          INT_FATAL(call,
+                    "actual formal type mismatch for %s: %s != %s",
+                    fn->name,
+                    actual->typeInfo()->symbol->name,
+                    formal->type->symbol->name);
         }
       }
     }

--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -49,9 +49,9 @@ inlineCall(FnSymbol* fn, CallExpr* call, Vec<FnSymbol*>& canRemoveRefTempSet) {
     SymExpr* se = toSymExpr(actual);
     INT_ASSERT(se);
     if((formal->intent & INTENT_REF)) {
-      // TODO: this code will not be necessary if
-      // arguments by ref always work with ref attached
-      // to the ArgSymbol instead of to the formal's type
+      // BHARSH TODO: Michael suggested this code will be unnecessary when
+      // QualifiedType is used everywhere and ref-ness is no longer stored in
+      // the 'type' field.
       if (canRemoveRefTempSet.set_in(fn)) {
         if (se->var->hasFlag(FLAG_REF_TEMP)) {
           if (CallExpr* move = findRefTempInit(se)) {

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -2650,21 +2650,16 @@ shouldChangeArgumentTypeToRef(ArgSymbol* arg) {
 }
 
 static void
-changeArgumentTypeToRef(ArgSymbol* arg) {
-
-  arg->qual = QUAL_REF;
-  arg->intent = INTENT_REF;
-}
-
-static void
 adjustArgSymbolTypesForIntent(void)
 {
   // Adjust ArgSymbols that have ref/const ref concrete
   // intent so that their type is ref. This allows the
   // rest of this code to work as expected.
   forv_Vec(ArgSymbol, arg, gArgSymbols) {
-    if (shouldChangeArgumentTypeToRef(arg))
-      changeArgumentTypeToRef(arg);
+    if (shouldChangeArgumentTypeToRef(arg)) {
+      arg->qual   = QUAL_REF;
+      arg->intent = INTENT_REF;
+    }
   }
 }
 

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -219,14 +219,22 @@ static bool needsAutoCopyAutoDestroyForArg(Expr* arg, FnSymbol* fn)
   // BHARSH TODO: Move this into RVF. If we do, then we need to handle the
   // following case:
   // ```
-  // var a : sync int;
+  // var a : sync int; // a GLOBAL variable
   // begin {
+  //   writeln("inner begin");
   //   on {
+  //     writeln("on-stmt");
   //     begin {
-  //     a += 1;
+  //       a += 1;
   //     }
   //   }
   // }
+  // ```
+  //
+  // This issue was exposed by the following test:
+  //   test/multilocale/diten/needMultiLocales/DijkstraTermination.chpl
+  //
+  // The 'writeln's exist to make sure nothing is considered a begin-on.
   //
   // If the sync is rvf'd onto the on-statement's stack, we should not take
   // a reference to it as it is about to go out of scope with the outer begin.


### PR DESCRIPTION
A number of comments have been either removed or improved.
The verify function `checkFormalActualTypesMatch` has been simplified to
reflect the new ways in which arguments can be passed regardless of
their ref-ness. I also manually inlined a trivial function in IWR.