### PR TITLE
Split fasta and fasta-redux cases into two graphs

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -14,6 +14,7 @@ studies/shootout/binary-trees/binary-trees.graph
 studies/shootout/chameneos-redux/chameneos-redux.graph
 studies/shootout/fannkuch-redux/fannkuch-redux.graph
 studies/shootout/fasta/fasta.graph
+studies/shootout/fasta/fastaredux.graph
 studies/shootout/mandelbrot/mandelbrot.graph
 studies/shootout/meteor/kbrady/meteor.graph
 studies/shootout/nbody/nbody.graph
@@ -35,6 +36,7 @@ studies/shootout/spectral-norm/spectralnorm.graph
 studies/shootout/nbody/nbody.graph
 studies/shootout/thread-ring/thread-ring.graph
 studies/shootout/fasta/fasta.graph
+studies/shootout/fasta/fastaredux.graph
 studies/shootout/mandelbrot/mandelbrot.graph
 studies/shootout/pidigits/pidigits.graph
 studies/shootout/meteor/kbrady/meteor.graph
@@ -94,6 +96,7 @@ studies/shootout/binary-trees/binary-trees.graph
 studies/shootout/chameneos-redux/chameneos-redux.graph
 studies/shootout/fannkuch-redux/fannkuch-redux.graph
 studies/shootout/fasta/fasta.graph
+studies/shootout/fasta/fastaredux.graph
 studies/shootout/k-nucleotide/knucleotide.graph
 studies/shootout/mandelbrot/mandelbrot.graph
 studies/shootout/meteor/kbrady/meteor.graph

--- a/test/studies/shootout/fasta/fasta.graph
+++ b/test/studies/shootout/fasta/fasta.graph
@@ -1,6 +1,6 @@
-perfkeys: real, real, real, real, real, real, real, real
-files: fasta.25000000.dat, fasta-lines.dat, fasta-printf.dat, fasta-qio.dat, fasta-enum.dat, fasta-blc.dat, fasta-release.dat, fastaredux-release.dat
-graphkeys: fasta, fasta-lines, fasta-printf, fasta-qio, fasta-enum, fasta-blc, fasta-release, fastaredux-release
+perfkeys: real, real
+files: fasta-blc.dat, fasta-release.dat
+graphkeys: release, bradc study version
 graphtitle: Fasta Shootout Benchmark (n=25,000,000)
 ylabel: Time (seconds)
 graphname: fasta.25000000

--- a/test/studies/shootout/fasta/fasta.graph
+++ b/test/studies/shootout/fasta/fasta.graph
@@ -1,6 +1,6 @@
 perfkeys: real, real
 files: fasta-blc.dat, fasta-release.dat
-graphkeys: release, bradc study version
+graphkeys: bradc study version, release
 graphtitle: Fasta Shootout Benchmark (n=25,000,000)
 ylabel: Time (seconds)
 graphname: fasta.25000000

--- a/test/studies/shootout/fasta/fastaredux.graph
+++ b/test/studies/shootout/fasta/fastaredux.graph
@@ -1,0 +1,6 @@
+perfkeys: real, real, real, real, real, real
+files: fasta.25000000.dat, fasta-lines.dat, fasta-printf.dat, fasta-qio.dat, fasta-enum.dat, fastaredux-release.dat
+graphkeys: fasta, fasta-lines, fasta-printf, fasta-qio, fasta-enum, fastaredux-release
+graphtitle: Fasta-redux Shootout Benchmark (n=25,000,000)
+ylabel: Time (seconds)
+graphname: fastaredux.25000000


### PR DESCRIPTION
This splits fasta and fasta-redux into two separate graphs.  We had
not been distinguishing well between them before (maybe the CLBG
hadn't been either?), and had been betting recently that fasta-redux
would persist, but it hasn't.  The one version that straddles this
divide is fasta-blc.chpl which originally was a fastaredux code but
recently was converted into a fasta code (to be annotated in a future
commit)