### PR TITLE
performance-test-perf-bradc-lnx should run 3 trials instead of 5

### DIFF
--- a/util/cron/test-perf.bradc-lnx.bash
+++ b/util/cron/test-perf.bradc-lnx.bash
@@ -7,4 +7,4 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.bradc-lnx"
 
-$CWD/nightly -cron -performance -numtrials 5 -startdate 02/19/10
+$CWD/nightly -cron -performance -numtrials 3 -startdate 02/19/10


### PR DESCRIPTION
As we continue adding more perf tests to this job, it's running
later and later into the morning. This should help it finish
earlier.