### PR TITLE
Improve release fasta: use int probabilities/randoms

### DIFF
--- a/test/release/examples/benchmarks/shootout/fasta.chpl
+++ b/test/release/examples/benchmarks/shootout/fasta.chpl
@@ -9,6 +9,11 @@
 config const n = 1000,   // controls the length of the generated strings
              lineLength = 60;
 
+config param IM = 139968, // parameters for the RNG
+             IA = 3877,
+             IC = 29573,
+             seed = 42;
+
 //
 // Nucleotide definitions
 //
@@ -63,22 +68,9 @@ const HomoSapiens = [(a, 0.3029549426680),
 
 
 proc main() {
-  sumProbs(IUB);
-  sumProbs(HomoSapiens);
   repeatMake(">ONE Homo sapiens alu\n", ALU, n * 2);
   randomMake(">TWO IUB ambiguity codes\n", IUB, n * 3);
   randomMake(">THREE Homo sapiens frequency\n", HomoSapiens, n * 5);
-}
-
-//
-// Scan the alphabets' probabilities to compute cut-offs
-//
-proc sumProbs(alphabet: []) {
-  var p = 0.0;
-  for letter in alphabet {
-    p += letter(prob);
-    letter(prob) = p;
-  }
 }
 
 //
@@ -106,31 +98,35 @@ proc repeatMake(desc, alu, n) {
 //
 // Output a random sequence of length 'n' using distribution a
 //
-proc randomMake(desc, a, n) {
-  var line_buff: [0..lineLength] int(8);
-    
+proc randomMake(desc, nucleotides: [?D], n) {
   stdout.write(desc);
-  for i in 1..n by lineLength do
-    addLine(min(lineLength, n-i+1));
 
-  //
-  // Add a line of random sequence
-  //
-  proc addLine(bytes) {
+  var cumulProb: [D] int;
+  var p = 0.0;
+  for i in D {
+    p += nucleotides[i](prob);
+    cumulProb[i] = 1 + (p*IM):int;
+  }
+
+  var line_buff: [0..lineLength] int(8);
+
+  for i in 1..n by lineLength {
+    const bytes = min(lineLength, n-i+1);
+
     for (r, i) in zip(getRands(bytes), 0..) {
-      if r < a[1](prob) {
-        line_buff[i] = a[1](nucl);
+      if r < cumulProb[1] {
+        line_buff[i] = nucleotides[1](nucl);
       } else {
-        var lo = a.domain.low,
-            hi = a.domain.high;
+        var lo = D.low,
+            hi = D.high;
         while (hi > lo+1) {
           var ai = (hi + lo) / 2;
-          if (r < a[ai](prob)) then
+          if (r < cumulProb[ai]) then
             hi = ai;
           else
             lo = ai;
         }
-        line_buff[i] = a[hi](nucl);
+        line_buff[i] = nucleotides[hi](nucl);
       }
     }
     line_buff[bytes] = newline:int(8);
@@ -143,15 +139,11 @@ proc randomMake(desc, a, n) {
 //
 // Deterministic random number generator
 //
-var lastRand = 42;
+var lastRand = seed;
 
 iter getRands(n) {
-  param IA = 3877,
-        IC = 29573,
-        IM = 139968;
-
   for 0..#n {
     lastRand = (lastRand * IA + IC) % IM;
-    yield lastRand: real / IM;
+    yield lastRand;
   }
 }


### PR DESCRIPTION
As I improve my study version of fasta, my plan is to propagate
changes into the release version as they prove profitable.  Here,
I'm incorporating the change (used by the #1 entry) of having
the RNG generate ints rather than floats, and to pre-scan the
cumulated probabilities to convert them from floating point values
to int values in order to avoid floating point math in the inner
loop.

As part of this change, I did some refactorings, some necessary,
some for aesthetics:

* moved the sumProbs() function into the randomMake() routine since
  it's related to that routine.

* removed the nested addLine() procedure which seemed pretty
  pointless.

* moved the RNG parameters to config params, in part because one
  of them has to be used in multiple scopes now, in part because
  these characterize the benchmarks.

These changes correspond to the ones I made in my study version in PR
parallelism adds a lot of code overhead and didn't result in a clear
win as far as I could tell, so I'm going to save that one for last in
the release version after making other improvements that seem to help
my study version.