### PR TITLE
Remove future that array literals added warning

### DIFF
--- a/test/domains/johnk/associative/literalsWarn.chpl
+++ b/test/domains/johnk/associative/literalsWarn.chpl
@@ -1,3 +1,0 @@
-var D : domain(string) = {"foo", "bar", "foobar"};
-
-writeln(D);

--- a/test/domains/johnk/associative/literalsWarn.future
+++ b/test/domains/johnk/associative/literalsWarn.future
@@ -1,1 +1,0 @@
-bug: Associative domain assignments are serialized.

--- a/test/domains/johnk/associative/literalsWarn.good
+++ b/test/domains/johnk/associative/literalsWarn.good
@@ -1,1 +1,0 @@
-{foobar, foo, bar}


### PR DESCRIPTION
They no longer warn, but assignment is still serial.