### PR TITLE
Update CHIP status expectations in 1.rst, update statuses

### DIFF
--- a/doc/chips/1.rst
+++ b/doc/chips/1.rst
@@ -2,7 +2,7 @@ Chapel Improvement Proposals
 ============================
 
 Status
-  Draft
+  Active
 
 Author
   Michael Ferguson
@@ -90,13 +90,26 @@ Status can be:
 
  * Draft - CHIPs start here
  * Active - No longer a draft. Informational.
- * Accepted - The Chapel community likes the idea and work is planned on it
- * Deferred - Progress is not being made on an issue
+ * Partially Accepted - There is agreement on the general direction but
+   some details need attention.
+ * Accepted - The Chapel community likes the idea
  * Rejected - The proposal has been discussed and the Chapel project does
    not plan to incorporate the proposal.
  * Withdrawn - A champion can withdraw their proposal for any reason
- * Final - Work on the feature has completed and it is in the repository
+ * Partially Implemented - Accepted and additionally, some of the
+   described functionality is implemented in the repository
+ * Implemented - Work on the feature has completed and it is in the
+   repository
  * Superseded - The proposal has been replaced by another proposal
+
+The status marker can also include a description of what needs to happen
+next after a comma. This can be anything, but some common scenarios might
+be:
+
+ * Deferred (Progress is not being made on an issue)
+ * Needs Review
+ * Needs Implementation
+ * Needs Design Adjustment
 
 
 Abstract

--- a/doc/chips/10.rst
+++ b/doc/chips/10.rst
@@ -4,7 +4,7 @@ Initializers
 ============
 
 Status:
-  Draft
+  Partially Implemented
 
 Authors:
   Lydia Duncan, Michael Ferguson, Mike Noakes, Vassily Litvinov, Kyle Brady

--- a/doc/chips/12.rst
+++ b/doc/chips/12.rst
@@ -4,7 +4,7 @@ Basics of Initialization
 ========================
 
 Status:
-  Draft
+  Active
 
 Authors:
   Michael Ferguson

--- a/doc/chips/13.rst
+++ b/doc/chips/13.rst
@@ -4,7 +4,7 @@ When Do Record and Array Copies Occur
 =====================================
 
 Status:
-  Draft
+  Partially Implemented
 
 Authors:
   Michael Ferguson

--- a/doc/chips/14.rst
+++ b/doc/chips/14.rst
@@ -2,7 +2,7 @@ Chapel stack traces
 ===================
 
 Status
-  Draft
+  Implemented
 
 Author
   Andrea Francesco Iuorio

--- a/doc/chips/2.rst
+++ b/doc/chips/2.rst
@@ -2,7 +2,7 @@ Constrained Generics
 ====================
 
 Status
-  Draft
+  Partially Accepted, Deferred, Needs Design Adjustment
 
 Author
   Michael Ferguson, Jeremy Siek

--- a/doc/chips/3.rst
+++ b/doc/chips/3.rst
@@ -2,7 +2,7 @@ ZeroMQ Integration
 ==================
 
 Status
-  Draft
+  Partially Implemented
 
 Author
   Michael Ferguson

--- a/doc/chips/4.rst
+++ b/doc/chips/4.rst
@@ -2,7 +2,7 @@ Constructor Syntax and Semantics
 ================================
 
 Status
-  Superseded
+  Superseded, see CHIP 10
 
 Author
   Tom Hildebrandt

--- a/doc/chips/5.rst
+++ b/doc/chips/5.rst
@@ -2,7 +2,7 @@ Implement Object Copying Using a "Postblit" Method
 ##################################################
 
 Status
-  Draft
+  Superseded, see CHIP 10
 
 Author
   Tom Hildebrandt, Michael Ferguson

--- a/doc/chips/7.rst
+++ b/doc/chips/7.rst
@@ -2,7 +2,7 @@ Rules for inserting autoCopy
 ============================
 
 Status
-  Draft
+  Superseded, see CHIP 13
 
 Author
   Vassily Litvinov, Chapel Team

--- a/doc/chips/8.rst
+++ b/doc/chips/8.rst
@@ -2,7 +2,7 @@ Error Handling in Chapel
 ========================
 
 Status:
-  Draft
+  Partially Accepted, Needs Implementation
 
 Authors:
   Greg Titus, Kyle Brady, Michael Ferguson, Preston Sahabu

--- a/doc/chips/9.rst
+++ b/doc/chips/9.rst
@@ -2,7 +2,7 @@ Chapel Package Manager
 ======================
 
 Status
-  Draft
+  Partially Accepted, Needs Implementation
 
 Authors
   Kyle Brady,


### PR DESCRIPTION
I've found it hard to say when a CHIP is "Accepted" but often
can say more in the status field. This commit adjusts the expectations
for the status field described in 1.rst to be something I think is
more achievable to track and then updates the statuses for various
CHIPs to indicate what is going on with them.

Reviewed by @lydia-duncan - thanks!