### PR TITLE
Fix order-of-destruction issue in _delete_arr

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -796,15 +796,18 @@ module ChapelDistribution {
     // decide whether or not the array is an alias
     var isalias = (arr._arrAlias != nil);
 
+    // array implementation can destroy data or other members
+    arr.dsiDestroyArr(isalias);
+
     if !isalias {
       // unlink domain referred to by arr.eltType
       // not necessary for aliases/slices because the original
       // array will take care of it.
+      // This needs to be done after the array elements are destroyed
+      // (by dsiDestroyArray above) because the array elements might
+      // refer to this inner domain.
       chpl_decRefCountsForDomainsInArrayEltTypes(arr, arr.eltType);
     }
-
-    // array implementation can destroy data or other members
-    arr.dsiDestroyArr(isalias);
 
     if privatized {
       _freePrivatizedClass(arr.pid, arr);


### PR DESCRIPTION
Fixes failures after PR #4762 with

        distributions/robust/arithmetic/basics/
           test_distributed_array_of_distributed_array1.chpl

using the compilation option -sdistType=DistType.cyclic

The issue was that the array elements were being destroyed after the
inner domain was destroyed. A simple reordering resolves the issue.

Passed full local testing
Passed quickstart+GASNet testing