### PR TITLE
Expand CHPL_TEST_NOMAIL to recognize well-known 'false' strings (cont'd)

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -225,7 +225,7 @@ sub mysystem {
             $mailcommand = "| $mailer -s \"$mailsubject \" $failuremail";
         }
 
-        if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or $ENV{"CHPL_TEST_NOMAIL"} eq "") {
+        if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
             print "Trying to mail message... using $mailcommand\n";
             open(MAIL, $mailcommand);
             print MAIL "=== Summary - testRelease ===================================================\n";


### PR DESCRIPTION
The previous commit overlooked one line that should have been changed
like all the others. This change corrects that omission.
