### PR TITLE
Fix --verify error for RuntimeTypes' DefExpr

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10570,7 +10570,7 @@ static void removeInitFields()
   {
     if (! def->inTree()) continue;
     if (! def->init) continue;
-    if (! def->sym->hasFlag(FLAG_TYPE_VARIABLE)) continue;
+    if (! (def->sym->hasFlag(FLAG_TYPE_VARIABLE) || def->sym->type->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE))) continue;
     def->init->remove();
     def->init = NULL;
   }


### PR DESCRIPTION
The init Expr for a RuntimeType's DefExpr was being left in the tree when it should have been removed.
Addresses an issue that appeared in testing after PR #4762 which caused the following test to fail, among others:
   types/typedefs/bradc/arrayTypedef