### PR TITLE
Remove usesOuterVars from virtual method call resolution

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -335,10 +335,6 @@ static std::string buildParentName(AList &arg_list, bool isFormal, Type *retType
 static AggregateType* createOrFindFunTypeFromAnnotation(AList &arg_list, CallExpr *call);
 static Expr* createFunctionAsValue(CallExpr *call);
 static Type* resolveTypeAlias(SymExpr* se);
-static bool
-isOuterVar(Symbol* sym, FnSymbol* fn, Symbol* parent = NULL);
-static bool
-usesOuterVars(FnSymbol* fn, Vec<FnSymbol*> &seen);
 static Type* resolveTypeAlias(SymExpr* se);
 static Expr* preFold(Expr* expr);
 static void foldEnumOp(int op, EnumSymbol *e1, EnumSymbol *e2, Immediate *imm);
@@ -5875,68 +5871,6 @@ static Expr* createFunctionAsValue(CallExpr *call) {
   return call_wrapper;
 }
 
-//
-// returns true if the symbol is defined in an outer function to fn
-// third argument not used at call site
-//
-static bool
-isOuterVar(Symbol* sym, FnSymbol* fn, Symbol* parent /* = NULL*/) {
-  if (!parent)
-    parent = fn->defPoint->parentSymbol;
-  if (!isFnSymbol(parent))
-    return false;
-  else if (sym->defPoint->parentSymbol == parent)
-    return true;
-  else
-    return isOuterVar(sym, fn, parent->defPoint->parentSymbol);
-}
-
-
-//
-// finds outer vars directly used in a function
-//
-static bool
-usesOuterVars(FnSymbol* fn, Vec<FnSymbol*> &seen) {
-  std::vector<BaseAST*> asts;
-  collect_asts(fn, asts);
-  for_vector(BaseAST, ast, asts) {
-    if (toCallExpr(ast)) {
-      CallExpr *call = toCallExpr(ast);
-
-      //dive into calls
-      Vec<FnSymbol*> visibleFns;
-      Vec<BlockStmt*> visited;
-
-      getVisibleFunctions(getVisibilityBlock(call), call->parentSymbol->name, visibleFns, visited, call);
-
-      forv_Vec(FnSymbol, called_fn, visibleFns) {
-        bool seen_this_fn = false;
-        forv_Vec(FnSymbol, seen_fn, seen) {
-          if (called_fn == seen_fn) {
-            seen_this_fn = true;
-            break;
-          }
-        }
-        if (!seen_this_fn) {
-          seen.add(called_fn);
-          if (usesOuterVars(called_fn, seen)) {
-            return true;
-          }
-        }
-      }
-    }
-    if (SymExpr* symExpr = toSymExpr(ast)) {
-      Symbol* sym = symExpr->var;
-
-      if (isLcnSymbol(sym)) {
-        if (isOuterVar(sym, fn))
-          return true;
-      }
-    }
-  }
-  return false;
-}
-
 // This function returns true for user fields, including
 // const, param, and type fields.
 // It returns false for compiler-introduced fields like
@@ -9461,32 +9395,12 @@ static void insertDynamicDispatchCalls() {
 
     SET_LINENO(call);
 
-    //Check to see if any of the overridden methods reference outer variables.  If they do, then when we later change the
-    //signature in flattenFunctions, the vtable style will break (function signatures will no longer match).  To avoid this
-    //we switch to the if-block style in the case where outer variables are discovered.
-    //Note: This is conservative, as we haven't finished resolving functions and calls yet, we check all possibilities.
-
-    bool referencesOuterVars = false;
-
-    Vec<FnSymbol*> seen;
-    referencesOuterVars = usesOuterVars(key, seen);
-
-    if (!referencesOuterVars) {
-      for (int i = 0; i < fns->n; ++i) {
-        seen.clear();
-        if ( (referencesOuterVars = usesOuterVars(key, seen)) ) {
-          break;
-        }
-      }
-    }
-
     bool isSuperAccess = false;
     if (SymExpr* base = toSymExpr(call->get(2))) {
       isSuperAccess = base->var->hasFlag(FLAG_SUPER_TEMP);
     }
 
-    if ((fns->n + 1 > fConditionalDynamicDispatchLimit) &&
-        (!referencesOuterVars) && !isSuperAccess ) {
+    if ((fns->n + 1 > fConditionalDynamicDispatchLimit) && !isSuperAccess ) {
       //
       // change call of root method into virtual method call;
       // Insert function SymExpr and virtual method temp at head of argument

--- a/test/functions/jturner/lambda_capture_var.future
+++ b/test/functions/jturner/lambda_capture_var.future
@@ -1,0 +1,5 @@
+semantic: first-class functions capturing a variable
+
+MPF 2016-10-28: language design for first-class functions is still a TODO, even
+though there has been a prototype.  It is not clear to me that programs such as
+this one need be valid in the language design we choose.

--- a/test/trivial/jturner/lambda_parent_capture_issue.future
+++ b/test/trivial/jturner/lambda_parent_capture_issue.future
@@ -1,0 +1,3 @@
+semantic: overridden method refers to outer variables
+
+MPF 2016-10-28: I don't think that Chapel should support such programs.


### PR DESCRIPTION
I started looking at usesOuterVars because of an issue with several tests in darwin + GASNet testing. after PR  #4762. E.g.

```
release/examples/benchmarks/ssca2/SSCA2_main
```

fails when clang compiles the generated C code:

```
 tmp/ChapelArray.c:24886:544: fatal error: bracket nesting level exceeded
```

In ChapelArray.chpl, there is:

```
proc _freePrivatizedClass(pid:int, original:object):void {
  ...

  delete original

  ...
}
```

This is being code-generated into a function that is about 10,000 lines long and consists of a whole lot of nested conditionals (implementing 'delete original').

During resolution of dynamic-dispatch calls, insertDynamicDispatchCalls calls usesOuterVars which is meant to check if an overridden method refers to an outer variable. If it does refer to an outer variable, it emits a series of conditionals instead of a virtual method table call. There is a problem with usesOuterVars where it returns true in the case above (and when it presumably should not). So, the above case creates a lot of conditionals.

It looks like this behavior started in the commit adding record-based strings to Chapel: 21b548aeb3. Since usesOuterVars does not seem to have changed, it seems likely that the new strings revealed a latent bug in usesOuterVars.

usesOuterVars was originally added in f54ca676 as part of first-class function support. It enables two tests to pass:

```
functions/jturner/lambda_capture_var
trivial/jturner/lambda_parent_capture_issue
```

First-class-fn support needs to be revisited/rewritten and several language design questions need answering. One language design question is how first-class-functions interact with captured variables. The language does not necessarily need to support captured variables in first-class functions at all.

Since the language design for first-class-functions is not complete, this patch simply removes support for first-class-functions that capture variables and makes the two tests into futures. This issue needs to be revisited along with a clear language design.

Passed full local testing.
Reviewed by @benharsh - thanks!