### PR TITLE
Update nightly shootout jobs

### DIFF
--- a/util/cron/test-perf.chapel-shootout-release.bash
+++ b/util/cron/test-perf.chapel-shootout-release.bash
@@ -8,9 +8,9 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout-release"
 
-# check out 1.13.0, but then grab the current tests
+# check out 1.14.0, but then grab the current tests
 currentSha=`git rev-parse HEAD`
-git checkout 1.13.0
+git checkout 1.14.0
 git checkout $currentSha -- $CHPL_HOME/test/
 git checkout $currentSha -- $CHPL_HOME/util/cron/
 

--- a/util/cron/test-perf.chapel-shootout.bash
+++ b/util/cron/test-perf.chapel-shootout.bash
@@ -8,5 +8,5 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout"
 
-export CHPL_NIGHTLY_TEST_DIRS="release/examples/benchmarks/shootout studies/shootout"
+export CHPL_NIGHTLY_TEST_DIRS="release/examples/benchmarks/shootout studies/shootout performance/elliot"
 $CWD/nightly -cron -performance -numtrials 5 -startdate 11/17/14


### PR DESCRIPTION
Have the release job test 1.14 instead of 1.13 and have the regular job run the
no-op/startup time test since it impacts the shootouts (and in particular
represents a significant portion of meteor's execution time.)