### PR TITLE
Next two fasta edits

### DIFF
--- a/test/release/examples/benchmarks/shootout/fasta.chpl
+++ b/test/release/examples/benchmarks/shootout/fasta.chpl
@@ -115,19 +115,11 @@ proc randomMake(desc, nucleotides: [?D], n) {
     const bytes = min(lineLength, n-i+1);
 
     for (r, i) in zip(getRands(bytes), 0..) {
-      if r < cumulProb[1] {
-        line_buff[i] = nucleotides[1](nucl);
-      } else {
-        var lo = D.low,
-            hi = D.high;
-        while (hi > lo+1) {
-          var ai = (hi + lo) / 2;
-          if (r < cumulProb[ai]) then
-            hi = ai;
-          else
-            lo = ai;
+      for j in D {
+        if r < cumulProb[j] {
+          line_buff[i] = nucleotides[j](nucl);
+          break;
         }
-        line_buff[i] = nucleotides[hi](nucl);
       }
     }
     line_buff[bytes] = newline:int(8);

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -57,13 +57,13 @@ param IM = 139968;
 //
 // Probability tables for sequences to be randomly generated
 //
-const IUB: [1..15] (int(8), real) = [(a, 0.27), (c, 0.12), (g, 0.12),
+const IUB = [(a, 0.27), (c, 0.12), (g, 0.12),
                                      (t, 0.27), (B, 0.02), (D, 0.02),
                                      (H, 0.02), (K, 0.02), (M, 0.02),
                                      (N, 0.02), (R, 0.02), (S, 0.02),
                                      (V, 0.02), (W, 0.02), (Y, 0.02)];
 
-const HomoSapiens: [1..4] (int(8), real) = [(a, 0.3029549426680),
+const HomoSapiens = [(a, 0.3029549426680),
                                             (c, 0.1979883004921),
                                             (g, 0.1975473066391),
                                             (t, 0.3015094502008)];


### PR DESCRIPTION
For release version: switched from binary search to linear search
For my version: removed forced casts of enum to int(8) to see if the benefit has gone away as it seems to have on the release branch (unless the change in how "\n"s are printed was the culprit).