### PR TITLE
Cleanup Vec<>

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -96,13 +96,6 @@ void collectSymExprs(BaseAST* ast, std::vector<SymExpr*>& symExprs) {
     symExprs.push_back(symExpr);
 }
 
-static void collectMySymExprsHelp(BaseAST* ast, Vec<SymExpr*>& symExprs) {
-  if (isSymbol(ast)) return; // do not descend into nested symbols
-  AST_CHILDREN_CALL(ast, collectMySymExprsHelp, symExprs);
-  if (SymExpr* se = toSymExpr(ast))
-    symExprs.add(se);
-}
-
 static void collectMySymExprsHelp(BaseAST*               ast,
                                   std::vector<SymExpr*>& symExprs) {
   if (isSymbol(ast)) return; // do not descend into nested symbols

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -42,14 +42,6 @@ static void pruneUnusedRefs(Vec<TypeSymbol*>& types);
 static void changeDeadTypesToVoid(Vec<TypeSymbol*>& types);
 
 
-void collectFnCalls(BaseAST* ast, Vec<CallExpr*>& calls) {
-  AST_CHILDREN_CALL(ast, collectFnCalls, calls);
-  if (CallExpr* call = toCallExpr(ast))
-    if (call->isResolved())
-      calls.add(call);
-}
-
-
 void collectFnCalls(BaseAST* ast, std::vector<CallExpr*>& calls) {
   AST_CHILDREN_CALL(ast, collectFnCalls, calls);
   if (CallExpr* call = toCallExpr(ast))
@@ -63,15 +55,6 @@ void collectExprs(BaseAST* ast, std::vector<Expr*>& exprs) {
     exprs.push_back(expr);
 }
 
-void collect_stmts(BaseAST* ast, Vec<Expr*>& stmts) {
-  if (Expr* expr = toExpr(ast)) {
-    stmts.add(expr);
-    if (isBlockStmt(expr) || isCondStmt(expr)) {
-      AST_CHILDREN_CALL(ast, collect_stmts, stmts);
-    }
-  }
-}
-
 void collect_stmts(BaseAST* ast, std::vector<Expr*>& stmts) {
   if (Expr* expr = toExpr(ast)) {
     stmts.push_back(expr);
@@ -81,36 +64,16 @@ void collect_stmts(BaseAST* ast, std::vector<Expr*>& stmts) {
   }
 }
 
-void collectDefExprs(BaseAST* ast, Vec<DefExpr*>& defExprs) {
-  AST_CHILDREN_CALL(ast, collectDefExprs, defExprs);
-  if (DefExpr* defExpr = toDefExpr(ast))
-    defExprs.add(defExpr);
-}
-
 void collectDefExprs(BaseAST* ast, std::vector<DefExpr*>& defExprs) {
   AST_CHILDREN_CALL(ast, collectDefExprs, defExprs);
   if (DefExpr* defExpr = toDefExpr(ast))
     defExprs.push_back(defExpr);
 }
 
-void collectCallExprs(BaseAST* ast, Vec<CallExpr*>& callExprs) {
-  AST_CHILDREN_CALL(ast, collectCallExprs, callExprs);
-  if (CallExpr* callExpr = toCallExpr(ast))
-    callExprs.add(callExpr);
-}
-
 void collectCallExprs(BaseAST* ast, std::vector<CallExpr*>& callExprs) {
   AST_CHILDREN_CALL(ast, collectCallExprs, callExprs);
   if (CallExpr* callExpr = toCallExpr(ast))
     callExprs.push_back(callExpr);
-}
-
-void collectMyCallExprs(BaseAST* ast, Vec<CallExpr*>& callExprs,
-                        FnSymbol* parent_fn) {
-  AST_CHILDREN_CALL(ast, collectMyCallExprs, callExprs, parent_fn);
-  if (CallExpr* callExpr = toCallExpr(ast))
-    if (callExpr->parentSymbol == parent_fn)
-      callExprs.add(callExpr);
 }
 
 void collectMyCallExprs(BaseAST* ast, std::vector<CallExpr*>& callExprs,
@@ -121,22 +84,10 @@ void collectMyCallExprs(BaseAST* ast, std::vector<CallExpr*>& callExprs,
       callExprs.push_back(callExpr);
 }
 
-void collectGotoStmts(BaseAST* ast, Vec<GotoStmt*>& gotoStmts) {
-  AST_CHILDREN_CALL(ast, collectGotoStmts, gotoStmts);
-  if (GotoStmt* gotoStmt = toGotoStmt(ast))
-    gotoStmts.add(gotoStmt);
-}
-
 void collectGotoStmts(BaseAST* ast, std::vector<GotoStmt*>& gotoStmts) {
   AST_CHILDREN_CALL(ast, collectGotoStmts, gotoStmts);
   if (GotoStmt* gotoStmt = toGotoStmt(ast))
     gotoStmts.push_back(gotoStmt);
-}
-
-void collectSymExprs(BaseAST* ast, Vec<SymExpr*>& symExprs) {
-  AST_CHILDREN_CALL(ast, collectSymExprs, symExprs);
-  if (SymExpr* symExpr = toSymExpr(ast))
-    symExprs.add(symExpr);
 }
 
 void collectSymExprs(BaseAST* ast, std::vector<SymExpr*>& symExprs) {
@@ -152,18 +103,12 @@ static void collectMySymExprsHelp(BaseAST* ast, Vec<SymExpr*>& symExprs) {
     symExprs.add(se);
 }
 
-static void collectMySymExprsHelp(BaseAST* ast, std::vector<SymExpr*>& symExprs) {
+static void collectMySymExprsHelp(BaseAST*               ast,
+                                  std::vector<SymExpr*>& symExprs) {
   if (isSymbol(ast)) return; // do not descend into nested symbols
   AST_CHILDREN_CALL(ast, collectMySymExprsHelp, symExprs);
   if (SymExpr* se = toSymExpr(ast))
     symExprs.push_back(se);
-}
-
-// Collect the SymExprs only *directly* under 'me'.
-// Do not include those in nested functions/other nested symbols.
-void collectMySymExprs(Symbol* me, Vec<SymExpr*>& symExprs) {
-  // skip the isSymbol(ast) check in collectMySymExprsHelp()
-  AST_CHILDREN_CALL(me, collectMySymExprsHelp, symExprs);
 }
 
 // The same for std::vector.
@@ -172,21 +117,10 @@ void collectMySymExprs(Symbol* me, std::vector<SymExpr*>& symExprs) {
   AST_CHILDREN_CALL(me, collectMySymExprsHelp, symExprs);
 }
 
-void collectSymbols(BaseAST* ast, Vec<Symbol*>& symbols) {
-  AST_CHILDREN_CALL(ast, collectSymbols, symbols);
-  if (Symbol* symbol = toSymbol(ast))
-    symbols.add(symbol);
-}
-
 void collectSymbols(BaseAST* ast, std::vector<Symbol*>& symbols) {
   AST_CHILDREN_CALL(ast, collectSymbols, symbols);
   if (Symbol* symbol = toSymbol(ast))
     symbols.push_back(symbol);
-}
-
-void collect_asts(BaseAST* ast, Vec<BaseAST*>& asts) {
-  asts.add(ast);
-  AST_CHILDREN_CALL(ast, collect_asts, asts);
 }
 
 void collect_asts(BaseAST* ast, std::vector<BaseAST*>& asts) {
@@ -204,19 +138,8 @@ void collect_asts_postorder(BaseAST* ast, std::vector<BaseAST*>& asts) {
   asts.push_back(ast);
 }
 
-static void collect_top_asts_internal(BaseAST* ast, Vec<BaseAST*>& asts) {
-  if (!isSymbol(ast) || isArgSymbol(ast)) {
-    AST_CHILDREN_CALL(ast, collect_top_asts_internal, asts);
-    asts.add(ast);
-  }
-}
-
-void collect_top_asts(BaseAST* ast, Vec<BaseAST*>& asts) {
-  AST_CHILDREN_CALL(ast, collect_top_asts_internal, asts);
-  asts.add(ast);
-}
-
-static void collect_top_asts_internal(BaseAST* ast, std::vector<BaseAST*>& asts) {
+static void collect_top_asts_internal(BaseAST*               ast,
+                                      std::vector<BaseAST*>& asts) {
   if (!isSymbol(ast) || isArgSymbol(ast)) {
     AST_CHILDREN_CALL(ast, collect_top_asts_internal, asts);
     asts.push_back(ast);
@@ -390,12 +313,16 @@ bool isMoveOrAssign(CallExpr* call) {
 // - the RHS is a reference
 //
 bool isDerefMove(CallExpr* call) {
-  return isMoveOrAssign(call) && isSymExpr(call->get(2)) && !call->get(1)->isRefOrWideRef() && call->get(2)->isRefOrWideRef();
+  return isMoveOrAssign(call)                    &&
+         isSymExpr(call->get(2))                 &&
+         call->get(1)->isRefOrWideRef() == false &&
+         call->get(2)->isRefOrWideRef() ==  true;
 }
 
 
 //
-// Check if a callExpr is a relational operator primitive (==, !=, <=, >=, <, >)
+// Check if a callExpr is a relational operator primitive
+// (==, !=, <=, >=, <, >)
 //
 bool isRelationalOperator(CallExpr* call) {
   if (call->isPrimitive(PRIM_EQUAL)          ||
@@ -440,7 +367,9 @@ int isDefAndOrUse(SymExpr* se) {
       ArgSymbol* arg = actual_to_formal(se);
       if (arg->intent == INTENT_REF ||
           arg->intent == INTENT_INOUT ||
-          (!strcmp(fn->name, "=") && fn->getFormal(1) == arg && isRecord(arg->type)) ||
+          (strcmp(fn->name, "=") == 0   &&
+           fn->getFormal(1)      == arg &&
+           isRecord(arg->type)) ||
           isRecordWrappedType(arg->type)) { // pass by reference
         return 3;
         // also use; do not "continue"
@@ -460,8 +389,10 @@ void buildDefUseMaps(Vec<Symbol*>& symSet,
   forv_Vec(SymExpr, se, symExprs) {
     if (se->parentSymbol && symSet.set_in(se->var)) {
       int result = isDefAndOrUse(se);
+
       if (result & 1)
         addDef(defMap, se);
+
       if (result & 2)
         addUse(useMap, se);
     }
@@ -679,8 +610,13 @@ bool isTypeExpr(Expr* expr)
   return false;
 }
 
-static void pruneVisit(TypeSymbol* ts, Vec<FnSymbol*>& fns, Vec<TypeSymbol*>& types);
-static void pruneVisitFn(FnSymbol* fn, Vec<FnSymbol*>& fns, Vec<TypeSymbol*>& types);
+static void pruneVisit(TypeSymbol*       ts,
+                       Vec<FnSymbol*>&   fns,
+                       Vec<TypeSymbol*>& types);
+
+static void pruneVisitFn(FnSymbol*         fn,
+                         Vec<FnSymbol*>&   fns,
+                         Vec<TypeSymbol*>& types);
 
 static void
 pruneVisit(Symbol* sym, Vec<FnSymbol*>& fns, Vec<TypeSymbol*>& types) {
@@ -746,7 +682,8 @@ visitVisibleFunctions(Vec<FnSymbol*>& fns, Vec<TypeSymbol*>& types)
   }
 
   // Functions appearing the function pointer table are visible.
-  // These are blocks that can be started through a forall, coforall or on statement.
+  // These are blocks that can be started through a forall, coforall,
+  // or on statement.
   forv_Vec(FnSymbol, fn, ftableVec)
     pruneVisit(fn, fns, types);
 
@@ -862,7 +799,11 @@ static void changeDeadTypesToVoid(Vec<TypeSymbol*>& types)
   // change symbols with dead types to void (important for baseline)
   //
   forv_Vec(DefExpr, def, gDefExprs) {
-    if (def->parentSymbol && def->sym->type && isAggregateType(def->sym->type) && !isTypeSymbol(def->sym) && !types.set_in(def->sym->type->symbol))
+    if (def->parentSymbol                != NULL  &&
+        def->sym->type                   != NULL  &&
+        isAggregateType(def->sym->type)  ==  true &&
+        isTypeSymbol(def->sym)           == false &&
+        !types.set_in(def->sym->type->symbol))
       def->sym->type = dtVoid;
   }
 }
@@ -937,7 +878,8 @@ Symbol* getSvecSymbol(CallExpr* call) {
 }
 
 
-static void addToUsedFnSymbols(std::set<FnSymbol*>& fnSymbols, FnSymbol* newFn) {
+static void addToUsedFnSymbols(std::set<FnSymbol*>& fnSymbols,
+                               FnSymbol*            newFn) {
   if(fnSymbols.count(newFn) == 0) {
     fnSymbols.insert(newFn);
     AST_CHILDREN_CALL(newFn->body, collectUsedFnSymbols, fnSymbols);

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -19,9 +19,6 @@
 
 #include "iterator.h"
 
-#include <map>
-#include <vector>
-
 #include "astutil.h"
 #include "bb.h"
 #include "bitVec.h"
@@ -35,6 +32,9 @@
 #include "stringutil.h"
 #include "view.h"
 #include "WhileStmt.h"
+
+#include <map>
+#include <vector>
 
 //
 // This file implements lowerIterator() called by the lowerIterators pass
@@ -928,25 +928,35 @@ static void collectLiveLocalVariables(Vec<Symbol*>& syms, FnSymbol* fn, BlockStm
   liveVariableAnalysis(fn, locals, localMap, useSet, defSet, OUT);
 
   int block = 0;
+
   for_vector(BasicBlock, bb, *fn->basicBlocks) {
     bool collect = false;
+
     for_vector(Expr, expr, bb->exprs) {
       CallExpr* call = toCallExpr(expr);
+
       if (call && call->isPrimitive(PRIM_YIELD))
         collect = true;
+
       if (singleLoop && expr == singleLoop->next)
         collect = true;
+
       if (singleLoop && expr == singleLoop->body.head)
         collect = true;
     }
+
     if (collect) {
       BitVec live(locals.n);
+
       for (int j = 0; j < locals.n; j++) {
         if (OUT[block]->get(j))
           live.set(j);
       }
+
       for (int k = bb->exprs.size() - 1; k >= 0; k--) {
-        CallExpr* call = toCallExpr(bb->exprs[k]);
+        CallExpr*             call = toCallExpr(bb->exprs[k]);
+        std::vector<SymExpr*> symExprs;
+
         if ((call && call->isPrimitive(PRIM_YIELD)) ||
             (singleLoop && bb->exprs[k] == singleLoop->next) ||
             (singleLoop && bb->exprs[k] == singleLoop->body.head)) {
@@ -956,16 +966,19 @@ static void collectLiveLocalVariables(Vec<Symbol*>& syms, FnSymbol* fn, BlockStm
             }
           }
         }
-        Vec<SymExpr*> symExprs;
+
         collectSymExprs(bb->exprs[k], symExprs);
-        forv_Vec(SymExpr, se, symExprs) {
+
+        for_vector(SymExpr, se, symExprs) {
           if (defSet.set_in(se))
             live.unset(localMap.get(se->var));
+
           if (useSet.set_in(se))
             live.set(localMap.get(se->var));
         }
       }
     }
+
     block++;
   }
 
@@ -976,12 +989,12 @@ static void collectLiveLocalVariables(Vec<Symbol*>& syms, FnSymbol* fn, BlockStm
   // converted to fields.  The test/incr fields are handled correctly
   // as a result of being inserted in to the body of the loop
   if (singleLoop != NULL && singleLoop->isCForLoop() == true) {
-    Vec<SymExpr*> symExprs;
-    CForLoop*     cforLoop = toCForLoop(singleLoop);
+    std::vector<SymExpr*> symExprs;
+    CForLoop*             cforLoop = toCForLoop(singleLoop);
 
     collectSymExprs(cforLoop->initBlockGet(), symExprs);
 
-    forv_Vec(SymExpr, se, symExprs) {
+    for_vector(SymExpr, se, symExprs) {
       if (useSet.set_in(se)) {
         syms.add_exclusive(se->var);
       }
@@ -990,7 +1003,8 @@ static void collectLiveLocalVariables(Vec<Symbol*>& syms, FnSymbol* fn, BlockStm
 }
 
 
-static bool containsRefVar(Vec<Symbol*>& syms, FnSymbol* fn,
+static bool containsRefVar(Vec<Symbol*>& syms,
+                           FnSymbol*     fn,
                            Vec<Symbol*>& yldSymSet)
 {
   forv_Vec(Symbol, sym, syms)
@@ -1168,13 +1182,13 @@ rebuildIterator(IteratorInfo* ii,
                 SymbolMap&    local2field,
                 Vec<Symbol*>& locals) {
   // Remove the original iterator function.
-  FnSymbol*      fn = ii->iterator;
-  Vec<CallExpr*> icalls;
+  FnSymbol*              fn = ii->iterator;
+  std::vector<CallExpr*> icalls;
 
   collectCallExprs(fn, icalls);
 
   // ... and the task functions that it calls.
-  forv_Vec(CallExpr, call, icalls) {
+  for_vector(CallExpr, call, icalls) {
     if (FnSymbol* taskFn = resolvedToTaskFun(call)) {
       // What to do if multiple calls? may or may not cause unwanted deletion.
       if (fVerify) // this assert is expensive to compute

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/compiler/include/oldCollectors.h
+++ b/compiler/include/oldCollectors.h
@@ -28,18 +28,6 @@
 #ifndef OLD_COLLECTORS_H
 #define OLD_COLLECTORS_H
 
-void collectFnCalls(BaseAST* ast, Vec<CallExpr*>& calls);
-void collect_asts(BaseAST* ast, Vec<BaseAST*>& asts);
 void collect_asts_postorder(BaseAST*, Vec<BaseAST*>& asts);
-void collect_top_asts(BaseAST* ast, Vec<BaseAST*>& asts);
-void collect_stmts(BaseAST* ast, Vec<Expr*>& stmts);
-void collectDefExprs(BaseAST* ast, Vec<DefExpr*>& defExprs);
-void collectCallExprs(BaseAST* ast, Vec<CallExpr*>& callExprs);
-void collectMyCallExprs(BaseAST* ast, Vec<CallExpr*>& callExprs, FnSymbol* fn);
-void collectGotoStmts(BaseAST* ast, Vec<GotoStmt*>& gotoStmts);
-void collectSymExprs(BaseAST* ast, Vec<SymExpr*>& symExprs);
-void collectMySymExprs(Symbol* me, Vec<SymExpr*>& symExprs);
-void collectSymbols(BaseAST* ast, Vec<Symbol*>& symbols);
-
 
 #endif

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1873,7 +1873,7 @@ static bool tryCResolve_set(ModuleSymbol* module, const char* name,
 
     if (c_exprs.count()) {
       forv_Vec(Expr*, c_expr, c_exprs) {
-        Vec<DefExpr*> v;
+        std::vector<DefExpr*> v;
 
         collectDefExprs(c_expr, v);
 

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -110,7 +110,9 @@ static void nonLeaderParCheck()
 static void nonLeaderParCheckInt(FnSymbol* fn, bool allowYields)
 {
   std::vector<CallExpr*> calls;
+
   collectCallExprs(fn, calls);
+
   for_vector(CallExpr, call, calls) {
     if ((call->isPrimitive(PRIM_BLOCK_BEGIN)) ||
         (call->isPrimitive(PRIM_BLOCK_COBEGIN)) ||
@@ -119,15 +121,20 @@ static void nonLeaderParCheckInt(FnSymbol* fn, bool allowYields)
       // If they are not, need issue the USR_FATAL_CONT like below.
       INT_ASSERT(false);
     }
+
     FnSymbol* taskFn = resolvedToTaskFun(call);
+
     bool isParallelConstruct = taskFn &&
-      (taskFn->hasFlag(FLAG_BEGIN) ||
-       taskFn->hasFlag(FLAG_COBEGIN_OR_COFORALL));
+                               (taskFn->hasFlag(FLAG_BEGIN) ||
+                                taskFn->hasFlag(FLAG_COBEGIN_OR_COFORALL));
+
     if (isParallelConstruct ||
         call->isNamed("_toLeader") ||
         call->isNamed("_toStandalone")) {
-      USR_FATAL_CONT(call, "invalid use of parallel construct in serial iterator");
+      USR_FATAL_CONT(call,
+                     "invalid use of parallel construct in serial iterator");
     }
+
     if ((call->isPrimitive(PRIM_BLOCK_ON)) ||
         (call->isPrimitive(PRIM_BLOCK_BEGIN_ON)) ||
         (call->isPrimitive(PRIM_BLOCK_COBEGIN_ON)) ||
@@ -983,17 +990,21 @@ static void convertYieldsAndReturns(std::vector<BaseAST*>& asts, Symbol* index,
 static bool fnContainsOn(FnSymbol* fn)
 {
   std::vector<CallExpr*> calls;
+
   collectCallExprs(fn, calls);
+
   for_vector(CallExpr, call, calls) {
     if (call->isPrimitive(PRIM_BLOCK_ON) ||
         call->isPrimitive(PRIM_BLOCK_BEGIN_ON) ||
         call->isPrimitive(PRIM_BLOCK_COBEGIN_ON) ||
         call->isPrimitive(PRIM_BLOCK_COFORALL_ON))
       return true;
+
     if (FnSymbol* taskFn = resolvedToTaskFun(call))
       if (fnContainsOn(taskFn))
         return true;
   }
+
   return false;
 }
 
@@ -1206,6 +1217,7 @@ expandIteratorInline(ForLoop* forLoop) {
     // replaced in the functions below though.
     if (isOrderIndependent) {
       std::vector<CallExpr*> callExprs;
+
       collectCallExprs(ibody, callExprs);
 
       for_vector(CallExpr, call, callExprs) {
@@ -1378,8 +1390,11 @@ countYieldsInFn(FnSymbol* fn)
 
 {
   unsigned count = 0;
+
   std::vector<CallExpr*> calls;
+
   collectCallExprs(fn, calls);
+
   for_vector(CallExpr, call, calls)
   {
     if (call->isPrimitive(PRIM_YIELD))
@@ -1428,10 +1443,10 @@ canInlineSingleYieldIterator(Symbol* gIterator) {
   getRecursiveIterators(iterators, gIterator);
 
   for (int i = 0; i < iterators.n; i++) {
-    FnSymbol*      iterator = getTheIteratorFn(iterators.v[i]);
-    BlockStmt*     block    = iterator->body;
-    Vec<CallExpr*> calls;
-    int            numYields = 0;
+    FnSymbol*              iterator = getTheIteratorFn(iterators.v[i]);
+    BlockStmt*             block    = iterator->body;
+    std::vector<CallExpr*> calls;
+    int                    numYields = 0;
 
     INT_ASSERT(block);
 
@@ -1440,7 +1455,8 @@ canInlineSingleYieldIterator(Symbol* gIterator) {
     // Replace this loop with an equivalent predicate that uses std::vector in
     // a valid fashion.
     collectCallExprs(block, calls);
-    forv_Vec(CallExpr, call, calls) {
+
+    for_vector(CallExpr, call, calls) {
       if (call && call->isPrimitive(PRIM_YIELD)) {
         numYields++;
 


### PR DESCRIPTION
Trivial replacement of a handful of uses of Vec<t> with std::vector<t>.  After these tweaks
include/oldCollectors.h has just one exported prototype;

void collect_asts_postorder(BaseAST*, Vec<BaseAST*>& asts);

but this one was too tough to untangle right now.  Of course there are still many internal
uses of Vec<> in various files.

Compiled on clang/darwin, gcc/linux64, and gcc/linux64 with --llvm enabled.  Tested on
full std paratest and llvm paratest.
