### PR TITLE
More test fixes

### DIFF
--- a/test/multilocale/deitz/needMultiLocales/raCommCheck.good
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheck.good
@@ -5,7 +5,7 @@ Number of updates = 4096
 
 Locale: (gets, puts, forks, fast forks, non-blocking forks)
 1: (get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 212, execute_on_fast = 0, execute_on_nb = 3)
-2: (get = 4, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 849, execute_on_fast = 1, execute_on_nb = 0)
-3: (get = 4, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 872, execute_on_fast = 1, execute_on_nb = 0)
-4: (get = 4, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 837, execute_on_fast = 1, execute_on_nb = 0)
+2: (get = 24, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 849, execute_on_fast = 1, execute_on_nb = 0)
+3: (get = 24, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 872, execute_on_fast = 1, execute_on_nb = 0)
+4: (get = 24, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 837, execute_on_fast = 1, execute_on_nb = 0)
 Validation: SUCCESS

--- a/test/multilocale/deitz/needMultiLocales/raCommCheck.lm-numa.good
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheck.lm-numa.good
@@ -5,7 +5,7 @@ Number of updates = 4096
 
 Locale: (gets, puts, forks, fast forks, non-blocking forks)
 1: (get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 212, execute_on_fast = 0, execute_on_nb = 3)
-2: (get = 1, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 849, execute_on_fast = 1, execute_on_nb = 0)
-3: (get = 1, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 872, execute_on_fast = 1, execute_on_nb = 0)
-4: (get = 1, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 837, execute_on_fast = 1, execute_on_nb = 0)
+2: (get = 8, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 849, execute_on_fast = 1, execute_on_nb = 0)
+3: (get = 8, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 872, execute_on_fast = 1, execute_on_nb = 0)
+4: (get = 8, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 837, execute_on_fast = 1, execute_on_nb = 0)
 Validation: SUCCESS

--- a/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.good
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.good
@@ -5,7 +5,7 @@ Number of updates = 4096
 
 Locale: (gets, puts, forks, fast forks, non-blocking forks)
 1: (get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 0, execute_on_nb = 3)
-2: (get = 4, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
-3: (get = 4, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
-4: (get = 4, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
+2: (get = 24, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
+3: (get = 24, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
+4: (get = 24, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
 Validation: SUCCESS

--- a/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.lm-numa.good
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.lm-numa.good
@@ -5,7 +5,7 @@ Number of updates = 4096
 
 Locale: (gets, puts, forks, fast forks, non-blocking forks)
 1: (get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 0, execute_on_nb = 3)
-2: (get = 1, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
-3: (get = 1, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
-4: (get = 1, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
+2: (get = 8, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
+3: (get = 8, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
+4: (get = 8, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 768, execute_on_fast = 1, execute_on_nb = 0)
 Validation: SUCCESS

--- a/test/types/string/sungeun/stringInBegin.skipif
+++ b/test/types/string/sungeun/stringInBegin.skipif
@@ -1,2 +1,3 @@
-# This test seems to pass with GASNet for some reason
+# This test seems to pass with GASNet/no-local for some reason
 CHPL_COMM!=none
+COMPOPTS <= --no-local


### PR DESCRIPTION
*  In PR #4792, I assumed that comm counts would be the same on different machines. That is not currently the case. So, this PR updates the .good files to match the output on the machines where nightly testing is run. I hope to address the source of these comm count increases directly.
* In PR #4790, I added a skipif for a .future because it passes under gasnet. It also passes under --no-local, so skip in that configuration as well.

Note that I expect these updated comm counts not to match for gasnet.darwin testing. However, we have other issues in that configuration - and meanwhile I hope to address the source of these new GETs in any case.