### PR TITLE
Alter API to flattenFunctions

### DIFF
--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -106,7 +106,7 @@ void pruneThisArg(Symbol* parent, SymbolMap& uses);
 void deadBlockElimination();
 
 // flattenFunctions.cpp
-void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions);
+void flattenNestedFunction(FnSymbol* nestedFunction);
 
 // callDestructors.cpp
 void insertReferenceTemps(CallExpr* call);

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1116,11 +1116,7 @@ expandRecursiveIteratorInline(ForLoop* forLoop)
   loopBodyFn->retType = dtVoid;
 
   // Move the loop body function out to the module level.
-  Vec<FnSymbol*> nestedFunctions;
-
-  nestedFunctions.add(loopBodyFn);
-
-  flattenNestedFunctions(nestedFunctions);
+  flattenNestedFunction(loopBodyFn);
 
   FnSymbol* iteratorFn = iteratorFnMap.get(iterator);
 
@@ -1330,8 +1326,7 @@ expandBodyForIteratorInline(ForLoop*       forLoop,
         // while preserving correct scoping of its SymExprs.
         INT_ASSERT(isGlobal(cfn));
 
-        FnSymbol*      fcopy = taskFnCopies.get(cfn);
-        Vec<FnSymbol*> nestedFnVec;
+        FnSymbol* fcopy = taskFnCopies.get(cfn);
 
         if (!fcopy) {
           // Clone the function. Just once per 'body' should suffice.
@@ -1369,9 +1364,7 @@ expandBodyForIteratorInline(ForLoop*       forLoop,
         // We do it because it may eliminate further cloning of 'fcopy'
         // e.g. when the enclosing fn or block are copied for any reason.
         // Ideally, replace with flattenOneFunction().
-        nestedFnVec.add(fcopy);
-
-        flattenNestedFunctions(nestedFnVec);
+        flattenNestedFunction(fcopy);
       }
     }
   }


### PR DESCRIPTION
Trivial update to lowerIterators.cpp to use the new function

void flattenNestedFunction(FnSymbol* fn);

in preference to 

void flattenNestedFunctions(Vec<FnSymbol*> nestedFunctions);

and then make the latter function be static to flattenFunctions.cpp




Compiled on clang/darwin and gcc/linux64 with and without CHPL_DEVELOPER set.  Also
confirm that compiling for LLVM is unaltered.

Tested on release/ for clang/darwin and the full standard paratest on gcc/linux64.
