### PR TITLE
Allow casts between c_void_ptr and object types

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -102,10 +102,11 @@ module CPtr {
   inline proc _cast(type t, x) where t:string && x.type:c_ptr {
     return __primitive("ref to string", x):string;
   }
-
+  pragma "no doc"
   inline proc _cast(type t, x) where t:object && x.type:c_void_ptr {
     return __primitive("cast", t, x);
   }
+  pragma "no doc"
   inline proc _cast(type t, x) where t:c_void_ptr && x.type:object {
     return __primitive("cast", t, x);
   }

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -76,6 +76,11 @@ module CPtr {
   inline proc _cast(type t, x) where t:c_ptr && x:_nilType {
     return __primitive("cast", t, x);
   }
+  pragma "no doc"
+  inline proc _cast(type t, x) where t:c_void_ptr && x:_nilType {
+    return c_nil;
+  }
+
 
   pragma "no doc"
   inline proc _cast(type t, x) where t:c_ptr && x.type:c_ptr {
@@ -96,6 +101,13 @@ module CPtr {
   pragma "no doc"
   inline proc _cast(type t, x) where t:string && x.type:c_ptr {
     return __primitive("ref to string", x):string;
+  }
+
+  inline proc _cast(type t, x) where t:object && x.type:c_void_ptr {
+    return __primitive("cast", t, x);
+  }
+  inline proc _cast(type t, x) where t:c_void_ptr && x.type:object {
+    return __primitive("cast", t, x);
   }
 
 

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -167,6 +167,12 @@ module CString {
   inline proc _cast(type t, x: c_string) where t == c_void_ptr {
     return __primitive("cast", t, x);
   }
+  //
+  // casts from c_void_ptr to c_string
+  //
+  inline proc _cast(type t, x: c_void_ptr) where t == c_string {
+    return __primitive("cast", t, x);
+  }
 
   //
   // casts from c_string to bool types

--- a/test/types/cptr/void_ptr_object.chpl
+++ b/test/types/cptr/void_ptr_object.chpl
@@ -1,0 +1,19 @@
+
+class C {
+  var x:int;
+}
+
+
+proc main() {
+
+  var c = new C(1);
+  // cast it to a c_void_ptr
+  var ptr1 = c:c_void_ptr;
+  // cast that back to an object
+  var c2 = ptr1:C;
+  // cast nil into a c_void_ptr
+  var mynil = nil:c_void_ptr;
+  assert(ptr1 != mynil);
+  assert(c == c2);
+}
+

--- a/test/types/cptr/void_ptr_object.chpl
+++ b/test/types/cptr/void_ptr_object.chpl
@@ -15,5 +15,13 @@ proc main() {
   var mynil = nil:c_void_ptr;
   assert(ptr1 != mynil);
   assert(c == c2);
+
+  var my_cstr:c_string = c"test";
+  // cast c_string into c_void_ptr
+  var my_cstr_v = my_cstr:c_void_ptr;
+  assert(my_cstr_v != mynil);
+  // cast c_void_ptr into c_string
+  var my_cstr2 = my_cstr_v:c_string;
+  assert(my_cstr == my_cstr2);
 }
 


### PR DESCRIPTION
This functionality is used in my operations-bundling branch and is generally useful for some low-level Chapel programming. Enables explicit casts:

 * from nil to c_void_ptr
 * from an object type to c_void_ptr
 * from c_void_ptr to an object type
 * from c_void_ptr to c_string

Passed full local testing.
Reviewed by @lydia-duncan - thanks!
