### PR TITLE
Make PRIM_WIDE_GET_ADDR return c_void_ptr

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -3443,6 +3443,8 @@ GenRet codegenCastToVoidStar(GenRet value)
   return ret;
 }
 
+/* Commented out because it is not currently used.
+
 static
 GenRet codegenCastPtrToInt(Type* toType, GenRet value)
 {
@@ -3463,7 +3465,7 @@ GenRet codegenCastPtrToInt(Type* toType, GenRet value)
     return ret;
   }
 }
-
+*/
 
 // Generates code to perform an "assignment" operation, given
 //  a destination pointer and a value.
@@ -4551,8 +4553,9 @@ GenRet CallExpr::codegenPrimitive() {
       ret = codegenValue(get(1));
     }
 
-    // _wide_get_addr promises to return a uint.  Hence the cast.
-    ret            = codegenCastPtrToInt(dtUInt[INT_SIZE_64], ret);
+    // _wide_get_addr promises to return a c void ptr.  Hence the cast.
+    ret = codegenCast(dtCVoidPtr, ret);
+    ret.isUnsigned = true;
 
     break;
   }

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -85,10 +85,12 @@ returnInfoInt64(CallExpr* call) {
   return QualifiedType(dtInt[INT_SIZE_64], QUAL_VAL);
 }
 
+/*
 static QualifiedType
 returnInfoUInt64(CallExpr* call) {
   return QualifiedType(dtUInt[INT_SIZE_64], QUAL_VAL);
 }
+*/
 
 static QualifiedType
 returnInfoSizeType(CallExpr* call) {
@@ -614,7 +616,7 @@ initPrimitive() {
   // PRIM_WIDE_GET_NODE. It might make sense to keep both of these
   // functions for debugging.
   prim_def(PRIM_WIDE_GET_NODE, "_wide_get_node", returnInfoNodeID, false, true);
-  prim_def(PRIM_WIDE_GET_ADDR, "_wide_get_addr", returnInfoUInt64, false, true);
+  prim_def(PRIM_WIDE_GET_ADDR, "_wide_get_addr", returnInfoCVoidPtr, false, true);
   prim_def(PRIM_IS_WIDE_PTR, "is wide pointer", returnInfoBool);
 
   prim_def(PRIM_ON_LOCALE_NUM, "chpl_on_locale_num", returnInfoLocaleID);

--- a/test/multilocale/ferguson/get-addr-node.chpl
+++ b/test/multilocale/ferguson/get-addr-node.chpl
@@ -1,0 +1,35 @@
+class C {
+  var x:int;
+}
+
+
+proc main() {
+  var obj = new C(1);
+
+  {
+    var node = __primitive("_wide_get_node", obj);
+    var loc = __primitive("_wide_get_locale", obj);
+    var raddr = __primitive("_wide_get_addr", obj);
+    var node2 = chpl_nodeFromLocaleID(loc);
+
+    var c_void_nil:c_void_ptr = c_nil;
+    assert(node == 0);
+    assert(node2 == 0);
+    assert(raddr != c_void_nil);
+  }
+
+  if numLocales > 1 {
+    on Locales[1] {
+      var node = __primitive("_wide_get_node", obj);
+      var loc = __primitive("_wide_get_locale", obj);
+      var raddr = __primitive("_wide_get_addr", obj);
+      var node2 = chpl_nodeFromLocaleID(loc);
+
+      var c_void_nil:c_void_ptr = c_nil;
+      assert(node == 0);
+      assert(node2 == 0);
+      assert(raddr != c_void_nil);
+    }
+  }
+}
+


### PR DESCRIPTION
PRIM_WIDE_GET_ADDR previously returned a uint(64) but that is not totally portable.

Passed full local testing.
Passed quickstart+GASNet testing for hellos and primers.

Reviewed by @benharsh - thanks!