### PR TITLE
Enable comparator passed to domain.sorted()

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2228,8 +2228,9 @@ module ChapelArray {
       } else if canResolveMethod(_value, "dsiSorted") {
         compilerError(_value.type:string + " does not support dsiSorted(comparator)");
       } else {
+        use Sort;
         var copy = this;
-        quickSort(copy, comparator=comparator);
+        sort(copy, comparator=comparator);
         for ind in copy do
           yield ind;
       }

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -430,14 +430,14 @@ module DefaultAssociative {
       }
     }
   
-    iter dsiSorted() {
+    iter dsiSorted(comparator:?t) {
       use Sort;
       var tableCopy: [0..#numEntries.read()] idxType;
   
       for (tmp, slot) in zip(tableCopy.domain, _fullSlots()) do
         tableCopy(tmp) = table[slot].idx;
   
-      sort(tableCopy);
+      sort(tableCopy, comparator=comparator);
   
       for ind in tableCopy do
         yield ind;

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -701,13 +701,13 @@ module DefaultAssociative {
     // Associative array interface
     //
   
-    iter dsiSorted() {
+    iter dsiSorted(comparator:?t) {
       use Sort;
       var tableCopy: [0..dom.dsiNumIndices-1] eltType;
       for (copy, slot) in zip(tableCopy.domain, dom._fullSlots()) do
         tableCopy(copy) = data(slot);
   
-      sort(tableCopy);
+      sort(tableCopy, comparator=comparator);
   
       for elem in tableCopy do
         yield elem;

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -430,7 +430,7 @@ module DefaultAssociative {
       }
     }
   
-    iter dsiSorted(comparator:?t) {
+    iter dsiSorted(comparator) {
       use Sort;
       var tableCopy: [0..#numEntries.read()] idxType;
   
@@ -701,7 +701,7 @@ module DefaultAssociative {
     // Associative array interface
     //
   
-    iter dsiSorted(comparator:?t) {
+    iter dsiSorted(comparator) {
       use Sort;
       var tableCopy: [0..dom.dsiNumIndices-1] eltType;
       for (copy, slot) in zip(tableCopy.domain, dom._fullSlots()) do

--- a/modules/internal/DefaultOpaque.chpl
+++ b/modules/internal/DefaultOpaque.chpl
@@ -186,8 +186,8 @@ module DefaultOpaque {
     }
   
   
-    iter dsiSorted() {
-      for e in anarray.dsiSorted() do
+    iter dsiSorted(comparator) {
+      for e in anarray.dsiSorted(comparator) do
         yield e;
     }
   }

--- a/test/associative/ferguson/assoc-sort-comparator.chpl
+++ b/test/associative/ferguson/assoc-sort-comparator.chpl
@@ -1,0 +1,31 @@
+use Sort;
+
+var D:domain(int);
+
+var A:[D] int;
+
+
+D += 1;
+D += 2;
+D += 3;
+D += 5;
+D += 7;
+
+
+A[1] = 10;
+A[2] = 8;
+A[3] = 7;
+A[5] = 5;
+A[7] = 3;
+
+writeln("reverse sorted D");
+for i in D.sorted(reverseComparator) {
+  writeln(i);
+}
+
+writeln("reverse sorted A");
+for x in A.sorted(reverseComparator) {
+  writeln(x);
+}
+
+

--- a/test/associative/ferguson/assoc-sort-comparator.good
+++ b/test/associative/ferguson/assoc-sort-comparator.good
@@ -1,0 +1,12 @@
+reverse sorted D
+7
+5
+3
+2
+1
+reverse sorted A
+10
+8
+7
+5
+3

--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -320,7 +320,7 @@ class UserMapAssocDom: BaseAssociativeDom {
     // TODO
   }
 
-  iter dsiSorted() {
+  iter dsiSorted(comparator) {
     use Sort;
     // This function creates a local copy of an entire distributed
     // data structure, which is probably a bad idea.
@@ -354,7 +354,7 @@ class UserMapAssocDom: BaseAssociativeDom {
       }
     }
 
-    quickSort(tableCopy);
+    sort(tableCopy, comparator);
 
     for ind in tableCopy do
       yield ind;

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -28,13 +28,13 @@ Parsing module files:
   $CHPL_HOME/modules/standard/gen/.../SysCTypes.chpl
   $CHPL_HOME/modules/standard/Sys.chpl
   $CHPL_HOME/modules/dists/DSIUtil.chpl
-  $CHPL_HOME/modules/standard/List.chpl
   $CHPL_HOME/modules/packages/Sort.chpl
+  $CHPL_HOME/modules/standard/Reflection.chpl
+  $CHPL_HOME/modules/standard/List.chpl
   $CHPL_HOME/modules/standard/SysBasic.chpl
   $CHPL_HOME/modules/standard/IO.chpl
   $CHPL_HOME/modules/packages/RangeChunk.chpl
   $CHPL_HOME/modules/packages/Search.chpl
-  $CHPL_HOME/modules/standard/Reflection.chpl
   $CHPL_HOME/modules/standard/Error.chpl
   $CHPL_HOME/modules/standard/Regexp.chpl
 In bar

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -19,13 +19,13 @@ Initializing Modules:
      DefaultRectangular
       DSIUtil
       ChapelArray
+       Sort
      ChapelNumLocales
      Sys
       SysBasic
     LocalesArray
     ChapelDistribution
      List
-     Sort
     ChapelIO
      IO
       Error


### PR DESCRIPTION
For associative arrays and domains.

Passed full local testing.
Reviewed by @ben-albrecht - thanks!
