### PR TITLE
Fix bugs when reading null bytes into strings

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -165,9 +165,10 @@ module String {
       the user to ensure that the underlying buffer is not freed if the
       `c_string` is not copied in.
      */
-    proc string(cs: c_string, owned: bool = true, needToCopy:  bool = true) {
+    proc string(cs: c_string, length: int = cs.length,
+                owned: bool = true, needToCopy:  bool = true) {
       this.owned = owned;
-      const cs_len = cs.length;
+      const cs_len = length;
       this.reinitString(cs:bufferType, cs_len, cs_len+1, needToCopy);
     }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3420,7 +3420,7 @@ private proc _read_text_internal(_channel_internal:qio_channel_ptr_t, out x:?t):
     var len:int(64);
     var tx: c_string_copy;
     var ret = qio_channel_scan_string(false, _channel_internal, tx, len, -1);
-    x = new string(tx, needToCopy=false);
+    x = new string(tx, length=len, needToCopy=false);
     return ret;
   } else if isEnumType(t) {
     var err:syserr = ENOERR;
@@ -3547,7 +3547,7 @@ private inline proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, p
     var ret = qio_channel_read_string(false, byteorder,
                                       qio_channel_str_style(_channel_internal),
                                       _channel_internal, tx, len, -1);
-    x = new string(tx, needToCopy=false);
+    x = new string(tx, length=len, needToCopy=false);
     return ret;
   } else if isEnumType(t) {
     var i:enum_mintype(t);
@@ -4304,7 +4304,7 @@ proc channel.readstring(ref str_out:string, len:int(64) = -1, out error:syserr):
 
     this.unlock();
 
-    str_out = new string(tx, needToCopy=false);
+    str_out = new string(tx, length=lenread, needToCopy=false);
   }
 
   return !error;
@@ -6540,7 +6540,7 @@ proc channel._extractMatch(m:reMatch, ref arg:string, ref error:syserr) {
     error =
         qio_channel_read_string(false, iokind.native, stringStyleExactLen(len),
                                 _channel_internal, ts, gotlen, len: ssize_t);
-    s = new string(ts, needToCopy=false);
+    s = new string(ts, length=gotlen, needToCopy=false);
   }
  
   if ! error {

--- a/test/io/ferguson/read-string-zero.chpl
+++ b/test/io/ferguson/read-string-zero.chpl
@@ -1,0 +1,39 @@
+
+var str = "hello\x00goodbye\n";
+
+var f = opentmp();
+
+{
+  var w = f.writer(kind=iokind.native);
+  w.write(str);
+  w.close();
+}
+
+{
+  // test 1: readstring
+  var r = f.reader(kind=iokind.native);
+
+  var s:string;
+  var got = r.readstring(s, str.length);
+
+  assert(got);
+  writeln("readstring read a string with length ", s.length);
+  assert(s.length == str.length);
+  assert(s == str);
+}
+
+{
+  // test 2: readf
+  var r = f.reader(kind=iokind.native);
+
+  var s:string;
+  var len = str.length;
+  var got = r.readf("%|*s", len, s);
+
+  assert(got);
+  writeln("readf read a string with length ", s.length);
+  assert(s.length == str.length);
+  assert(s == str);
+}
+
+f.close();

--- a/test/io/ferguson/read-string-zero.good
+++ b/test/io/ferguson/read-string-zero.good
@@ -1,0 +1,2 @@
+readstring read a string with length 14
+readf read a string with length 14


### PR DESCRIPTION
Chapel strings store a length (unlike C strings) and so can store
strings that contain zero bytes. However, we had some bugs preventing
this from working when reading a particular number of bytes from a file
into a string.

The bugs had to do with the construction of the string from the
c_string_copy that the I/O system created. In particular,
we were calling

    str_out = new string(tx, needToCopy=false);

which causes the string's length to be initialized by finding the
zero byte (which is normally what you want for C strings). But the
I/O system read a particular number of bytes and returned the size
of the buffer. So, instead we now call

    str_out = new string(tx, length=readlength, needToCopy=false);

and have added this length= argument to that string constructor.

Passed full local testing.
Reviewed by @lydia-duncan - thanks!