### PR TITLE
Skip test chplvis3 when running multinode multilocale tests on chapcs cluster

### DIFF
--- a/test/release/examples/README.testing
+++ b/test/release/examples/README.testing
@@ -67,4 +67,4 @@ For more information
 --------------------
 
 See:
-https://github.com/chapel-lang/chapel/blob/release/1.14/doc/developer/bestPractices/TestSystem.txt
+https://github.com/chapel-lang/chapel/blob/release/1.14/doc/developer/bestPractices/TestSystem.rst

--- a/test/release/examples/primers/chplvis/chplvis3.skipif
+++ b/test/release/examples/primers/chplvis/chplvis3.skipif
@@ -1,0 +1,9 @@
+# Skip test chplvis3 when running multinode multilocale tests on chapcs cluster
+
+# When chplvis3 tries to run multinode multilocale on the chapcs cluster
+# during the nightly builds, Slurm will block almost everything else while
+# it waits for 8 nodes to become available.
+
+# (chplvis3 wants 8 nodes, but chapcs cluster only has 11 "compute" nodes)
+
+CHPL_NIGHTLY_TEST_CONFIG_NAME <= ^slurm-gasnet-ibv


### PR DESCRIPTION
When chplvis3 tries to run multinode multilocale on the chapcs cluster
during the nightly builds, Slurm will block almost everything else while
it waits for 8 nodes to become available.

(chplvis3 wants 8 nodes, but chapcs cluster only has 11 "compute" nodes)
