### PR TITLE
Skip mergeSort performance testing temporarily

### DIFF
--- a/test/modules/packages/sort/performance/performance.perfexecopts
+++ b/test/modules/packages/sort/performance/performance.perfexecopts
@@ -1,6 +1,5 @@
 --sorts='q' --M=24 --correctness=false            # quickSort
 --sorts='h' --M=24 --correctness=false            # heapSort
---sorts='m' --M=24 --correctness=false            # mergeSort
 --sorts='i' --M=12 --correctness=false            # insertionSort
 --sorts='s' --M=12 --correctness=false            # selectionSort
 --sorts='b' --M=12 --correctness=false            # bubbleSort

--- a/test/modules/packages/sort/performance/sorts-linearithmic.graph
+++ b/test/modules/packages/sort/performance/sorts-linearithmic.graph
@@ -1,6 +1,6 @@
-perfkeys: (seconds):, (seconds):, (seconds):
-files: quickSort.dat, heapSort.dat, mergeSort.dat
-graphkeys: quickSort, heapSort, mergeSort
+perfkeys: (seconds):, (seconds):
+files: quickSort.dat, heapSort.dat
+graphkeys: quickSort, heapSort
 graphtitle: Linearithmic sorts on 2^24 bytes of shuffled data
 ylabel: Time (seconds)
 


### PR DESCRIPTION
Temporary partial revert of #4707 due to an unexpected behavior of mergeSort perf testing on some systems.