### PR TITLE
Update TRAP_INT kernel to use int(32) ranges in all variants of LCALS

### DIFF
--- a/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
@@ -469,7 +469,7 @@ module RunParallelRawLoops {
             var val = 0.0;
             ltimer.start();
             for 0..#num_samples {
-              forall i in 0..#len with (+ reduce sumx) {
+              forall i in 0..(len-1):int(32) with (+ reduce sumx) {
                 var x = x0 + i*h;
                 sumx += trap_int_func(x, y, xp, yp);
               }

--- a/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
@@ -608,7 +608,7 @@ module RunSPMDRawLoops {
             ltimer.start();
             coforall tid in 0..#nTasks with (ref isamp, + reduce sumx, ref val) {
               while isamp < num_samples {
-                for i in chunk(0..#len, nTasks, tid) {
+                for i in chunk(0..(len-1):int(32), nTasks, tid) {
                   var x = x0 + i*h;
                   sumx += trap_int_func(x, y, xp, yp);
                 }

--- a/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
@@ -469,7 +469,7 @@ module RunVectorizeOnlyRawLoops {
             var val = 0.0;
             ltimer.start();
             for 0..#num_samples {
-              forall i in vectorizeOnly(0..#len) with (+ reduce sumx) {
+              forall i in vectorizeOnly(0..(len-1):int(32)) with (+ reduce sumx) {
                 var x = x0 + i*h;
                 sumx += trap_int_func(x, y, xp, yp);
               }


### PR DESCRIPTION
This is the exact same change as PR #4756, but now applied to the parallel,
vectorizeOnly, and SPMD variants in addition to the serial variant.