### PR TITLE
Use export keyword with chpl_nodeFromLocaleID etc

### DIFF
--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -72,14 +72,17 @@ module LocaleModel {
 
   // Compiler (and module code) interface for manipulating global locale IDs..
   pragma "insert line file info"
+  export
   proc chpl_buildLocaleID(node: chpl_nodeID_t, subloc: chpl_sublocID_t)
     return chpl_rt_buildLocaleID(node, subloc);
 
   pragma "insert line file info"
+  export
   proc chpl_nodeFromLocaleID(loc: chpl_localeID_t)
     return chpl_rt_nodeFromLocaleID(loc);
 
   pragma "insert line file info"
+  export
   proc chpl_sublocFromLocaleID(loc: chpl_localeID_t)
     return chpl_rt_sublocFromLocaleID(loc);
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -75,14 +75,17 @@ module LocaleModel {
 
   // Compiler (and module code) interface for manipulating global locale IDs..
   pragma "insert line file info"
+  export
   proc chpl_buildLocaleID(node: chpl_nodeID_t, subloc: chpl_sublocID_t)
     return chpl_rt_buildLocaleID(node, subloc);
 
   pragma "insert line file info"
+  export
   proc chpl_nodeFromLocaleID(loc: chpl_localeID_t)
     return chpl_rt_nodeFromLocaleID(loc);
 
   pragma "insert line file info"
+  export
   proc chpl_sublocFromLocaleID(loc: chpl_localeID_t)
     return chpl_rt_sublocFromLocaleID(loc);
 


### PR DESCRIPTION
The other routines in the LocaleModels.chpl file are marked with export
but these were not for some reason. I believe that was an oversight.

One of the effects of marking them with export is that the arguments are
not considered to be wide. (note that an alternative way to keep the
arguments from being widened is to use pragma "local args").

For some reason, PR #4794 caused testing failures in numa configuration.
These failures were C-level compilation failures because
chpl_nodeFromLocaleID was passed a local pointer actual when the type of
the formal was a wide pointer. I'm not sure why PR #4794 triggered these
errors, but the solution is pretty clear. The functions now 'export'd are
there to create or unpack locale IDs and are not meant to include
communication.

Passed full local testing.
Also passed hellos and primers in these configurations:
- GASNet quickstart testing on darwin
- GASNet+NUMA testing on linux
- NUMA testing on linux

Reviewed by @benharsh - thanks!