### PR TITLE
Use --ieee-float with this test to avoid PGI errors

### DIFF
--- a/test/types/file/fileIO.compopts
+++ b/test/types/file/fileIO.compopts
@@ -1,0 +1,1 @@
+--ieee-float


### PR DESCRIPTION
Direct comparison of floating point numbers might not be reasonable in some optimization modes. Since this test is about I/O and not about floating point math, just include --ieee-float.

This is a follow-on to PR #4716.