### PR TITLE
Check for small absolute difference instead of using --ieee-float

### DIFF
--- a/test/types/file/fileIO.chpl
+++ b/test/types/file/fileIO.chpl
@@ -1,5 +1,6 @@
 config var n = 10,
            filename = "arr.out";
+config const epsilon = 10e-13;
 
 const ADom = {1..n, 1..n};
 
@@ -8,7 +9,7 @@ var A: [ADom] real = [(i,j) in ADom] (i-1) + ((j-1)/10.0);
 writeArray(n, A, filename);
 var B = readArray(filename);
 
-const numErrors = + reduce [i in ADom] (A(i) != B(i));
+const numErrors = + reduce [i in ADom] (abs(A(i) - B(i)) > epsilon);
 
 writeln("B is:\n", B);
 

--- a/test/types/file/fileIO.compopts
+++ b/test/types/file/fileIO.compopts
@@ -1,1 +1,0 @@
---ieee-float


### PR DESCRIPTION
This revises PR #4813 to use a strategy already used in sibling tests in PR #1962.

Thanks to @ronawho for pointing out the better approach.
Verified that the test passes on darwin and with PGI (even with --fast).