### PR TITLE
Add initial support for user-defined copy initialization

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1040,13 +1040,16 @@ static void build_record_copy_function(AggregateType* ct) {
   const char* copyCtorName = astr("_construct_", ct->symbol->name);
   const char* copyInitName = "init";
   bool foundUserDefinedCopy = false;
-  if (FnSymbol* ctor = function_exists(copyCtorName, 1, ct))
-    // note: default ctor has 1 arg, meme
-    if (!ctor->getFormal(1)->hasFlag(FLAG_IS_MEME))
-      foundUserDefinedCopy = true;
+  // as an optimization, the below conditionals use ct->initializerStyle
+  if (ct->initializerStyle == DEFINES_CONSTRUCTOR)
+    if (FnSymbol* ctor = function_exists(copyCtorName, 1, ct))
+      // note: default ctor has 1 arg, meme
+      if (!ctor->getFormal(1)->hasFlag(FLAG_IS_MEME))
+        foundUserDefinedCopy = true;
 
-  if (function_exists(copyInitName, 2, ct, ct /*meme*/ ))
-    foundUserDefinedCopy = true;
+  if (ct->initializerStyle == DEFINES_INITIALIZER)
+    if (function_exists(copyInitName, 2, ct, ct /*meme*/ ))
+      foundUserDefinedCopy = true;
 
   // if no copy-init function existed...
   FnSymbol* fn = new FnSymbol("chpl__initCopy");

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1036,51 +1036,82 @@ static void build_record_copy_function(AggregateType* ct) {
   if (function_exists("chpl__initCopy", 1, ct))
     return;
 
+  // if there is a copy-initializer for this record type, use that.
+  const char* copyCtorName = astr("_construct_", ct->symbol->name);
+  const char* copyInitName = "init";
+  bool foundUserDefinedCopy = false;
+  if (FnSymbol* ctor = function_exists(copyCtorName, 1, ct))
+    // note: default ctor has 1 arg, meme
+    if (!ctor->getFormal(1)->hasFlag(FLAG_IS_MEME))
+      foundUserDefinedCopy = true;
+
+  if (function_exists(copyInitName, 2, ct, ct /*meme*/ ))
+    foundUserDefinedCopy = true;
+
+  // if no copy-init function existed...
   FnSymbol* fn = new FnSymbol("chpl__initCopy");
   fn->addFlag(FLAG_INIT_COPY_FN);
   fn->addFlag(FLAG_COMPILER_GENERATED);
   ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "x", ct);
   arg->addFlag(FLAG_MARKED_GENERIC);
   fn->insertFormalAtTail(arg);
-  CallExpr* call = new CallExpr(ct->defaultInitializer);
-  for_fields(tmp, ct)
-  {
-    // Weed out implicit alias and promotion type fields.
-    if (tmp->hasFlag(FLAG_IMPLICIT_ALIAS_FIELD))
-      continue;
-    // TODO: This needs to be done uniformly, using an ignore_field flag or...
-    if (!strcmp("_promotionType", tmp->name))
-      continue;
 
-    CallExpr* init = new CallExpr(".", arg, new_CStringSymbol(tmp->name));
-    call->insertAtTail(new NamedExpr(tmp->name, init));
+  CallExpr* call = NULL;
 
-    // Special handling for nested record types:
-    // We need to convert the constructor call into a method call.
-    if (!strcmp(tmp->name, "outer"))
-      call->insertAtHead(gMethodToken);
-  }
-  if (ct->symbol->hasFlag(FLAG_EXTERN)) {
-    int actualsNeeded = ct->defaultInitializer->formals.length;
-    int actualsGiven = call->argList.length;
-    // This code assumes that in the case where an extern has not been fully
-    // specified in Chapel code, its default constructor will require one more
-    // actual than the fields specified: another object of that extern type
-    // whose contents can be used.
-    if (actualsNeeded == actualsGiven + 1) {
-      call->insertAtTail(arg);
-    } else if (actualsNeeded != actualsGiven) {
-      // The user didn't partially specify the type in Chapel code, but the
-      // number of actuals provided didn't match the expected number.  This is
-      // an internal error.
-      INT_FATAL(arg, "Extern type's constructor call didn't create expected # of actuals");
+  if (foundUserDefinedCopy) {
+    call = new CallExpr(PRIM_NEW, ct->symbol, new SymExpr(arg));
+    // If it has a user-defined copy initializer, it's not POD
+    ct->symbol->addFlag(FLAG_NOT_POD);
+  } else {
+    // generate the default copy initializer in chpl__initCopy for now
+
+    // MPF 2016-11-03: It would be better to move all of the logic below
+    // into the construction of a compiler-generated initializer. However,
+    // at the moment, compiler-generated initializers follow a very different
+    // code path from initializers.
+    // In addition, we could entirely remove chpl__initCopy and instead
+    // rely on the copy initializer.
+
+    call = new CallExpr(ct->defaultInitializer);
+    for_fields(tmp, ct)
+    {
+      // Weed out implicit alias and promotion type fields.
+      if (tmp->hasFlag(FLAG_IMPLICIT_ALIAS_FIELD))
+        continue;
+      // TODO: This needs to be done uniformly, using an ignore_field flag or...
+      if (!strcmp("_promotionType", tmp->name))
+        continue;
+
+      CallExpr* init = new CallExpr(".", arg, new_CStringSymbol(tmp->name));
+      call->insertAtTail(new NamedExpr(tmp->name, init));
+
+      // Special handling for nested record types:
+      // We need to convert the constructor call into a method call.
+      if (!strcmp(tmp->name, "outer"))
+        call->insertAtHead(gMethodToken);
     }
-  }
-  if (ct->initializerStyle == DEFINES_INITIALIZER) {
-    // We want the initializer to take in the memory it will initialize
-    VarSymbol* meme = newTemp("meme_tmp", ct);
-    fn->insertAtHead(new DefExpr(meme));
-    call->insertAtTail(new NamedExpr("meme", new SymExpr(meme)));
+    if (ct->symbol->hasFlag(FLAG_EXTERN)) {
+      int actualsNeeded = ct->defaultInitializer->formals.length;
+      int actualsGiven = call->argList.length;
+      // This code assumes that in the case where an extern has not been fully
+      // specified in Chapel code, its default constructor will require one more
+      // actual than the fields specified: another object of that extern type
+      // whose contents can be used.
+      if (actualsNeeded == actualsGiven + 1) {
+        call->insertAtTail(arg);
+      } else if (actualsNeeded != actualsGiven) {
+        // The user didn't partially specify the type in Chapel code, but the
+        // number of actuals provided didn't match the expected number.  This is
+        // an internal error.
+        INT_FATAL(arg, "Extern type's constructor call didn't create expected # of actuals");
+      }
+    }
+    if (ct->initializerStyle == DEFINES_INITIALIZER) {
+      // We want the initializer to take in the memory it will initialize
+      VarSymbol* meme = newTemp("meme_tmp", ct);
+      fn->insertAtHead(new DefExpr(meme));
+      call->insertAtTail(new NamedExpr("meme", new SymExpr(meme)));
+    }
   }
   fn->insertAtTail(new CallExpr(PRIM_RETURN, call));
   DefExpr* def = new DefExpr(fn);

--- a/test/types/records/ferguson/copy-init/new-init-concrete.chpl
+++ b/test/types/records/ferguson/copy-init/new-init-concrete.chpl
@@ -1,0 +1,30 @@
+record R {
+  var x:int;
+}
+
+
+proc R.init(x:int)
+{
+  this.x = x;
+}
+
+proc R.init(from:R)
+{
+  writeln("In R.init");
+  this.x = from.x;
+}
+
+proc run() {
+  writeln("Creating r");
+  var r = new R(1);
+  writeln("r ", r);
+  writeln("copy-initializing");
+  var copy1 = r;
+  writeln("copy1 ", copy1);
+  writeln("explicitly copy-initializing");
+  var copy2 = new R(r);
+  writeln("copy2 ", copy2);
+  writeln("r ", r);
+}
+
+run();

--- a/test/types/records/ferguson/copy-init/new-init-concrete.good
+++ b/test/types/records/ferguson/copy-init/new-init-concrete.good
@@ -1,0 +1,9 @@
+Creating r
+r (x = 1)
+copy-initializing
+In R.init
+copy1 (x = 1)
+explicitly copy-initializing
+In R.init
+copy2 (x = 1)
+r (x = 1)

--- a/test/types/records/ferguson/copy-init/new-init-generic.bad
+++ b/test/types/records/ferguson/copy-init/new-init-generic.bad
@@ -1,0 +1,1 @@
+new-init-generic.chpl:11: error: initializer for class 'R' requires a generic argument called 'x'

--- a/test/types/records/ferguson/copy-init/new-init-generic.chpl
+++ b/test/types/records/ferguson/copy-init/new-init-generic.chpl
@@ -1,0 +1,30 @@
+record R {
+  var x;
+}
+
+
+proc R.init(x)
+{
+  this.x = x;
+}
+
+proc R.init(from)
+{
+  writeln("In R.init");
+  this.x = from.x;
+}
+
+proc run() {
+  writeln("Creating r");
+  var r = new R(1);
+  writeln("r ", r);
+  writeln("copy-initializing");
+  var copy1 = r;
+  writeln("copy1 ", copy1);
+  writeln("explicitly copy-initializing");
+  var copy2 = new R(r);
+  writeln("copy2 ", copy2);
+  writeln("r ", r);
+}
+
+run();

--- a/test/types/records/ferguson/copy-init/new-init-generic.future
+++ b/test/types/records/ferguson/copy-init/new-init-generic.future
@@ -1,0 +1,1 @@
+feature request: copy initializer for generic record

--- a/test/types/records/ferguson/copy-init/new-init-generic.good
+++ b/test/types/records/ferguson/copy-init/new-init-generic.good
@@ -1,0 +1,9 @@
+Creating r
+r (x = 1)
+copy-initializing
+In R.init
+copy1 (x = 1)
+explicitly copy-initializing
+In R.init
+copy2 (x = 1)
+r (x = 1)

--- a/test/types/records/ferguson/copy-init/old-ctor-concrete.chpl
+++ b/test/types/records/ferguson/copy-init/old-ctor-concrete.chpl
@@ -1,0 +1,26 @@
+record R {
+  var x:int;
+}
+
+
+proc R.R(from:R)
+{
+  writeln("In R.ctor");
+  this.x = from.x;
+}
+
+
+proc run() {
+  writeln("Creating r");
+  var r = new R(1);
+  writeln("r ", r);
+  writeln("copy-initializing");
+  var copy1 = r;
+  writeln("copy1 ", copy1);
+  writeln("explicitly copy-initializing");
+  var copy2 = new R(r);
+  writeln("copy2 ", copy2);
+  writeln("r ", r);
+}
+
+run();

--- a/test/types/records/ferguson/copy-init/old-ctor-concrete.good
+++ b/test/types/records/ferguson/copy-init/old-ctor-concrete.good
@@ -1,0 +1,9 @@
+Creating r
+r (x = 1)
+copy-initializing
+In R.ctor
+copy1 (x = 1)
+explicitly copy-initializing
+In R.ctor
+copy2 (x = 1)
+r (x = 1)

--- a/test/types/records/ferguson/copy-init/old-ctor-generic.bad
+++ b/test/types/records/ferguson/copy-init/old-ctor-generic.bad
@@ -1,0 +1,1 @@
+old-ctor-generic.chpl:6: error: initializer for class 'R' requires a generic argument called 'x'

--- a/test/types/records/ferguson/copy-init/old-ctor-generic.chpl
+++ b/test/types/records/ferguson/copy-init/old-ctor-generic.chpl
@@ -1,0 +1,26 @@
+record R {
+  var x;
+}
+
+
+proc R.R(from:R)
+{
+  writeln("In R.ctor");
+  this.x = from.x;
+}
+
+
+proc run() {
+  writeln("Creating r");
+  var r = new R(1);
+  writeln("r ", r);
+  writeln("copy-initializing");
+  var copy1 = r;
+  writeln("copy1 ", copy1);
+  writeln("explicitly copy-initializing");
+  var copy2 = new R(r);
+  writeln("copy2 ", copy2);
+  writeln("r ", r);
+}
+
+run();

--- a/test/types/records/ferguson/copy-init/old-ctor-generic.future
+++ b/test/types/records/ferguson/copy-init/old-ctor-generic.future
@@ -1,0 +1,3 @@
+semantic: can't write copy ctor for generic record
+
+I expect that the new initializers story is the solution here.

--- a/test/types/records/ferguson/copy-init/old-ctor-generic.good
+++ b/test/types/records/ferguson/copy-init/old-ctor-generic.good
@@ -1,0 +1,9 @@
+Creating r
+r (x = 1)
+copy-initializing
+In R.ctor
+copy1 (x = 1)
+explicitly copy-initializing
+In R.ctor
+copy2 (x = 1)
+r (x = 1)


### PR DESCRIPTION
Allows type authors to write a copy-initializer (or old-style copy constructor) for their type and for that to be called in the generated initCopy routine.

Note:
* generic types do not work yet. New-style initializers don't support generics yet. Old-style constructors support generics but would need special adjustment to avoid the normal type-constructor issue (one argument per generic type in the constructor is used to do the type-construction).
* it might be nice to remove initCopy entirely but... one step at a time

Passed full local testing.
Reviewed by @lydia-duncan - thanks!