### PR TITLE
Fix gasnet 1.28.0 even more for aarch64

### DIFF
--- a/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
+++ b/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
@@ -12,14 +12,6 @@
 CC="${CC:-cc}"   # vanilla target C compiler
 CXX="${CXX:-CC}" # vanilla target C++ compiler
 
-# Default optimization on ICC is an irritation:
-# -wd10120 suppresses "command line warning #10120: overriding '-O0' with '-O3'"
-if test x"$PE_ENV" = xINTEL &&
-    ( $CC -dM -E /dev/null | grep __OPTIMIZE__ ) >& /dev/null; then
-  CC="$CC -O0 -wd10120"
-  CXX="$CXX -O0 -wd10120"
-fi
-
 export CC
 export CXX
 

--- a/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
+++ b/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
@@ -9,8 +9,8 @@
 # NOTE: this relies on module-established PATH setting to automatically 
 # select the GCC or PGI-based MPI compilers, based on which PrgEnv is currently loaded
 # The same PrgEnv *must* be loaded when building and using the GASNet install
-CC='cc'  # vanilla target C compiler
-CXX='CC' # vanilla target C++ compiler
+CC="${CC:-cc}"   # vanilla target C compiler
+CXX="${CXX:-CC}" # vanilla target C++ compiler
 
 # Default optimization on ICC is an irritation:
 # -wd10120 suppresses "command line warning #10120: overriding '-O0' with '-O3'"


### PR DESCRIPTION
Duplicate 2 commits that made local changes to our copy of GASNet, into the upgraded 1.28.0 GASNet.  I unaccountably missed these when doing the upgrade before, probably due to woking too quickly on it.