### PR TITLE
Fix LLVM issue with argMustUseCPtr

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1194,6 +1194,8 @@ bool argMustUseCPtr(Type* type) {
   if (isUnion(type))
     return true;
   if (isRecord(type) &&
+      // TODO: why are ref types being created with AGGREGATE_RECORD?
+      !type->symbol->hasFlag(FLAG_REF) &&
       !type->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS))
     return true;
   return false;


### PR DESCRIPTION
argMustUseCPtr should not return true when given a ref type.