### PR TITLE
Fix messed up line numbers

### DIFF
--- a/test/exercises/c-ray/c-ray.noreal.good
+++ b/test/exercises/c-ray/c-ray.noreal.good
@@ -1,1 +1,1 @@
-c-ray.chpl:112: error: pixelType must be an integral type
+c-ray.chpl:113: error: pixelType must be an integral type

--- a/test/exercises/c-ray/c-ray.toosmall.good
+++ b/test/exercises/c-ray/c-ray.toosmall.good
@@ -1,1 +1,1 @@
-c-ray.chpl:108: error: pixelType 'int(8)' isn't big enough to store 8 bits per color
+c-ray.chpl:109: error: pixelType 'int(8)' isn't big enough to store 8 bits per color


### PR DESCRIPTION
The line numbers for these compiler errors got incremented when I
reformatted comments, and I mis-tested only c-ray.chpl before
committing last night.  Sorry everyone.

[This failure is a good motivator (beyond the improved user
experience) for the ability to have compilerError()s, halt()s, and
such that don't report any source information; but I didn't do it on
purpose simply to make that point....]