### PR TITLE
Turn off Qthreads sleep(3) interception, experimentally.

### DIFF
--- a/third-party/qthread/qthread-src/src/syscalls/sleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/sleep.c
@@ -20,6 +20,7 @@
 #include "qthread_innards.h" /* for qlib */
 #include "qt_qthread_mgmt.h"
 
+#if 0
 unsigned int sleep(unsigned int seconds)
 {
     if (qt_blockable()) {
@@ -50,5 +51,6 @@ unsigned int sleep(unsigned int seconds)
 #endif  /* if HAVE_SYSCALL */
     }
 }
+#endif
 
 /* vim:set expandtab: */


### PR DESCRIPTION
This is a very ad-hoc, interim solution to the problem of Qthreads
sleep(3) interception not sleeping at all in our build configuration on
Cray X* systems when called from other than a qthread.  The interception
causes problems when PMI _init code uses sleep() as a delay mechanism
while connecting processes of job together, but the sleep() doesn't
really sleep().  (Yes, it's true that this isn't bulletproof code on
PMI's part because sleep() actually isn't guaranteed to do anything,
including sleep, but in practice it's not unreasonable for programmers
to expect sleep() to create SOME kind of delay, and this one doesn't.)

The solution here is just to use #if 0 ... #endif to remove the
intercept function entirely.  Big hammer!

Throwing --disable-syscall-interception seemed like a better solution,
but it turned out to have no effect.  I'm going to ping the Qthreads
person to see if there's a more proper way to achieve what we want here.
But for now, I at least want to try this out to see if removing the
sleep interception really does solve our PMI problems.