### PR TITLE
Three fixes to for_vector etc

### DIFF
--- a/compiler/include/stlUtil.h
+++ b/compiler/include/stlUtil.h
@@ -34,31 +34,50 @@
 // FnSymbol* fn; and returns one FnSymbol* from the global list of
 // function symbol(pointer)s on each iteration.
 //
+// Implementation Note:
 // To implement iteration compatibly (with, for example, forv_Vec), we
 // need both an index (iterator) and the value obtained by
 // dereferencing it.  Since it is not possible to declare variables
-// with different base types in a for loop, we declare the hidden
-// iterator internally, and push the declaration of the value outside
-// the loop.  That is, the client code has to provide the declaration
-// where formerly it did not.
+// with different base types in a for loop, we declare unique-ified
+// temporary variables to store a reference to the collection, the
+// begin iterator, and the end iterator. The loop still declares
+// the VAL argument since its name cannot be unique-ified. In this
+// way, the implementation takes care to evaluate VEC only once
+// and allows multiple loops using the same index variable.
 //
-// CAVEAT: Using the same name for the value in the macro may lead to
-// compilation errors if both macro invocations are enclosed in the
-// same scope.
+// NOTE: We should consider replacing these with something else.
+// In C++11 perhaps these macros could be written
+//  for(TYPE* VAL: VEC)
 //
-// NOTE: We should consider replacing these with BOOST_FOREACH once
-// more of the Boost libraries are accepted into the C++ standard.
-//
-#define for_vector(TYPE, VAL, VEC) TYPE* VAL;                 \
-  for (std::vector<TYPE*>::iterator _i_##VAL = (VEC).begin(); \
-       (VAL = (_i_##VAL != (VEC).end()) ? *_i_##VAL : (TYPE*)0) ; _i_##VAL++ )
 
-#define for_set(TYPE, VAL, VEC) TYPE* VAL;                 \
-  for (std::set<TYPE*>::iterator _i_##VAL = (VEC).begin(); \
-       (VAL = (_i_##VAL != (VEC).end()) ? *_i_##VAL : (TYPE*)0) ; _i_##VAL++ )
+#define STL_UTIL_TOK_PASTE_INTERNAL(a, b) a ## b
+#define STL_UTIL_TOK_PASTE(a, b) STL_UTIL_TOK_PASTE_INTERNAL(a,b)
+#define STL_UTIL_UNIQUE(NAME) STL_UTIL_TOK_PASTE(NAME, __LINE__)
 
-#define for_queue(TYPE, VAL, VEC) TYPE* VAL;                 \
-  for (std::queue<TYPE*>::iterator _i_##VAL = (VEC).begin(); \
-       (VAL = (_i_##VAL != (VEC).end()) ? *_i_##VAL : (TYPE*)0) ; _i_##VAL++ )
+#define for_vector(TYPE, VAL, VEC) \
+  const std::vector<TYPE*> & STL_UTIL_UNIQUE(for_vector_vec) = (VEC); \
+  std::vector<TYPE*>::const_iterator STL_UTIL_UNIQUE(for_vector_iter) = \
+      STL_UTIL_UNIQUE(for_vector_vec).begin(); \
+  std::vector<TYPE*>::const_iterator STL_UTIL_UNIQUE(for_vector_end) = \
+      STL_UTIL_UNIQUE(for_vector_vec).end(); \
+  for (TYPE * VAL = NULL ; \
+       (VAL = ( STL_UTIL_UNIQUE(for_vector_iter) != \
+                STL_UTIL_UNIQUE(for_vector_end) ) ? \
+              * STL_UTIL_UNIQUE(for_vector_iter) : \
+              (TYPE*)0) ; \
+       STL_UTIL_UNIQUE(for_vector_iter)++ )
+
+#define for_set(TYPE, VAL, VEC) \
+  const std::set<TYPE*> & STL_UTIL_UNIQUE(for_set_set) = (VEC); \
+  std::set<TYPE*>::const_iterator STL_UTIL_UNIQUE(for_set_iter) = \
+      STL_UTIL_UNIQUE(for_set_set).begin(); \
+  std::set<TYPE*>::const_iterator STL_UTIL_UNIQUE(for_set_end) = \
+      STL_UTIL_UNIQUE(for_set_set).end(); \
+  for (TYPE * VAL = NULL ; \
+       (VAL = ( STL_UTIL_UNIQUE(for_set_iter) != \
+                STL_UTIL_UNIQUE(for_set_end) ) ? \
+              * STL_UTIL_UNIQUE(for_set_iter) : \
+              (TYPE*)0) ; \
+       STL_UTIL_UNIQUE(for_set_iter)++ )
 
 #endif

--- a/compiler/include/stlUtil.h
+++ b/compiler/include/stlUtil.h
@@ -65,7 +65,7 @@
                 STL_UTIL_UNIQUE(for_vector_end) ) ? \
               * STL_UTIL_UNIQUE(for_vector_iter) : \
               (TYPE*)0) ; \
-       STL_UTIL_UNIQUE(for_vector_iter)++ )
+       ++STL_UTIL_UNIQUE(for_vector_iter) )
 
 #define for_set(TYPE, VAL, VEC) \
   const std::set<TYPE*> & STL_UTIL_UNIQUE(for_set_set) = (VEC); \
@@ -78,6 +78,6 @@
                 STL_UTIL_UNIQUE(for_set_end) ) ? \
               * STL_UTIL_UNIQUE(for_set_iter) : \
               (TYPE*)0) ; \
-       STL_UTIL_UNIQUE(for_set_iter)++ )
+       ++STL_UTIL_UNIQUE(for_set_iter) )
 
 #endif

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1480,9 +1480,9 @@ reprivatizeIterators() {
     }
   }
 
-  for_vector(Symbol, sym2, privatizedFields) {
-    if (sym2)
-      sym2->type = dtInt[INT_SIZE_DEFAULT];
+  for_vector(Symbol, sym, privatizedFields) {
+    if (sym)
+      sym->type = dtInt[INT_SIZE_DEFAULT];
   }
 }
 


### PR DESCRIPTION
I noticed three problems for_vector, for_set, and for_queue in stlUtil.h.

First, these macros declared what appears to be the loop variable outside
of the loop. That means that an example such as this:

      for_vector(Symbol, sym, symbolVector) {
        ...
      }
      for_vector(Symbol, sym, symbolVector) {
        ...
      }

does not compile, because now there are two 'sym' variables declared in
the same scope. (It could be fixed if the second loop changes the index
variable to sym2 for example).

Second, these macros evaluated the collection being iterated over more
than once. Coverity pointed this out (in an obtuse manner) for code in
loopInvariantCodeMotion, such as:

      for_set(Symbol, rhsAlias, aliases[rhs]) {
        ..
      }

Third, the macro for_queue is never used in the compiler. It is dead
code.

This PR addresses these 3 problems. It adjusts the macros for
for_vector and for_set to declare the iterator as a variable outside
of the loop but to do so with a unique-ified name (by appending the
line number to theh variable name). Additionally, it adjusts these
macros to only evaluate the collection being iterated over once. The
loop variable (e.g. sym or rhsAlias in the examples above) is declared
in the for loop since its name cannot be changed.

Lastly (and most trivially) this PR removes the for_queue macro
since:
 * any adjustment to it would not be tested, and
 * adding it back would be fairly trivial based upon for_vector/for_set

Passed full local testing.
Passed full --no-local testing.

Reviewed by @dmk42 - thanks!