### PR TITLE
Change int32_t to c_nodeid_t for the locale/node argument

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -291,7 +291,7 @@ void  chpl_comm_get(void *addr, c_nodeid_t node, void* raddr,
 //   Proposal for Extending the UPC Memory Copy Library Functions and Supporting 
 //   Extensions to GASNet, Version 2.0. Author: Dan Bonachea 
 //
-void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, int32_t dstlocale, 
+void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode,
                      void* srcaddr, size_t* srcstrides, size_t* count,
                      int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
                      int ln, int32_t fn);
@@ -299,7 +299,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, int32_t dstlocale,
 //
 // same as chpl_comm_puts(), but do get instead
 //
-void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, int32_t srclocale, 
+void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode,
                      void* srcaddr, size_t* srcstrides, size_t* count,
                      int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
                      int ln, int32_t fn);

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -146,23 +146,23 @@ void chpl_comm_pre_task_exit(int all) { }
 
 void chpl_comm_exit(int all, int status) { }
 
-void  chpl_comm_put(void* addr, int32_t locale, void* raddr,
+void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
                     size_t size, int32_t typeIndex,
                     int ln, int32_t fn) {
-  assert(locale==0);
+  assert(node==0);
 
   memmove(raddr, addr, size);
 }
 
-void  chpl_comm_get(void* addr, int32_t locale, void* raddr,
+void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
                     size_t size, int32_t typeIndex,
                     int ln, int32_t fn) {
-  assert(locale==0);
+  assert(node==0);
 
   memmove(addr, raddr, size);
 }
 
-void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
+void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t dstnode,
                          void* srcaddr_arg, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t typeIndex,
                          int ln, int32_t fn)
@@ -179,7 +179,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, int32_t dstlocal
   size_t srcstr[strlvls];
   size_t cnt[strlvls+1];
 
-  assert(dstlocale==0);
+  assert(dstnode==0);
 
   //Only count[0] and strides are measured in number of bytes.
   cnt[0] = count[0] * elemSize;
@@ -316,7 +316,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, int32_t dstlocal
   }
 }
 
-void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
+void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t srcnode,
                          void* srcaddr_arg, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t typeIndex,
                          int ln, int32_t fn)
@@ -332,7 +332,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, int32_t srclocal
   size_t srcstr[strlvls];
   size_t cnt[strlvls+1];
 
-  assert(srclocale==0);
+  assert(srcnode==0);
 
   //Only count[0] and strides are measured in number of bytes.
   cnt[0] = count[0] * elemSize;


### PR DESCRIPTION
We somehow missed this in the big Locale Model Change of '13.

Built runtime and tested examples directory with comm none.

@gbtitus 