### PR TITLE
Only compute configured-clang-sysroot-arguments for HOST_COMPILER=clang

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -132,9 +132,17 @@ $(LLVM_CLANG_FILE):
 	  cd $(LLVM_BUILD_DIR) && cmake --build . --target install-clang ; \
 	fi
 
+# Create a file containing extra arguments for clang
+# This file is necessary on darwin where important headers are
+# not in /usr/include. This causes a problem when building another clang
+# because the new clang can't find the appropriate headers.
 $(LLVM_CLANG_CONFIG_FILE):
 	mkdir -p $(LLVM_INSTALL_DIR)
-	../../util/config/gather-clang-sysroot-arguments $(CLANG_CC) > $(LLVM_CLANG_CONFIG_FILE)
+	if [ "clang" = "$(CHPL_MAKE_HOST_COMPILER)" ]; then \
+	  ../../util/config/gather-clang-sysroot-arguments clang > $(LLVM_CLANG_CONFIG_FILE) ; \
+        else \
+          touch $(LLVM_CLANG_CONFIG_FILE) ; \
+        fi
 
 configure-llvm: $(LLVM_CONFIGURED_HEADER_FILE)
 


### PR DESCRIPTION
Otherwise we end up with paths to third-party/llvm/install
which causes problems with the module build.

Build/check testing with CHPL_LLVM=llvm, CHPL_LLVM=system on Ubuntu 16 and with CHPL_LLVM=llvm on darwin.

Trivial and not reviewed.