### PR TITLE
Fix libunwind config to work with optional LZMA dependency

### DIFF
--- a/util/chplenv/chpl_3p_libunwind_configs.py
+++ b/util/chplenv/chpl_3p_libunwind_configs.py
@@ -14,45 +14,27 @@ def get_uniq_cfg_path():
     return third_party_utils.default_uniq_cfg_path()
 
 @memoize
-def get_libunwind_config_file():
-    install_path = third_party_utils.get_cfg_install_path('libunwind')
-    config_file = os.path.join(install_path, 'lib', 'pkgconfig', 'libunwind.pc')
-    return config_file
-
-@memoize
-def get_libunwind_la():
-    install_path = third_party_utils.get_cfg_install_path('libunwind')
-    la = os.path.join(install_path, 'lib', 'libunwind.la')
-    return la
-
-
-@memoize
 def get_link_args(unwind):
     platform_val = chpl_platform.get('target')
     osx = platform_val.startswith('darwin')
 
+    # Mac OS X supports libunwind in the C library
+    # it's not actually a special library.
     if osx:
       return []
 
-    libs = ['-lunwind']
-    if unwind == 'libunwind':
+    libs = []
+    # Get the link arguments (e.g. -lunwind)
+    if unwind == 'system':
+      # Try using pkg-config to get the libraries to link
+      # libunwind with.
+      libs = third_party_utils.pkgconfig_get_link_args(
+                       'libunwind', system=True, static=True)
+    elif unwind == 'libunwind':
       # the pkg-config file for libunwind is nice, but as of 1.1
-      # it is wrong. So try to get the libraries out of libunwind.la
-      # if it exists.
-      unwind_config = get_libunwind_config_file()
-      if os.access(unwind_config, os.R_OK):
-        unwind_link = run_command(['pkg-config', '--libs',
-                                   unwind_config, '--libs'])
-        libs = unwind_link.split()
-
-      unwind_la = get_libunwind_la()
-      if os.access(unwind_la, os.R_OK):
-        value = ''
-        with open(unwind_la) as f:
-          for line in f:
-            if line.startswith('dependency_libs='):
-              value = line.split('=')[1]
-              value = value.split("'")[1]
-              libs += value.split();
+      # it doesn't include -lzma when it probably should.
+      # So try to get the libraries out of libunwind.la.
+      libs = third_party_utils.default_get_link_args(
+                       'libunwind', libs=['libunwind.la'])
 
     return libs

--- a/util/chplenv/chpl_3p_libunwind_configs.py
+++ b/util/chplenv/chpl_3p_libunwind_configs.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_platform
 import third_party_utils
-from utils import memoize
+from utils import memoize, run_command
 
 
 @memoize
@@ -14,9 +14,45 @@ def get_uniq_cfg_path():
     return third_party_utils.default_uniq_cfg_path()
 
 @memoize
+def get_libunwind_config_file():
+    install_path = third_party_utils.get_cfg_install_path('libunwind')
+    config_file = os.path.join(install_path, 'lib', 'pkgconfig', 'libunwind.pc')
+    return config_file
+
+@memoize
+def get_libunwind_la():
+    install_path = third_party_utils.get_cfg_install_path('libunwind')
+    la = os.path.join(install_path, 'lib', 'libunwind.la')
+    return la
+
+
+@memoize
 def get_link_args(unwind):
     platform_val = chpl_platform.get('target')
-    linux = platform_val.startswith('linux64')
-    if (unwind == 'libunwind' or unwind == 'system') and linux:
-        return ['-lunwind']
-    return []
+    osx = platform_val.startswith('darwin')
+
+    if osx:
+      return []
+
+    libs = ['-lunwind']
+    if unwind == 'libunwind':
+      # the pkg-config file for libunwind is nice, but as of 1.1
+      # it is wrong. So try to get the libraries out of libunwind.la
+      # if it exists.
+      unwind_config = get_libunwind_config_file()
+      if os.access(unwind_config, os.R_OK):
+        unwind_link = run_command(['pkg-config', '--libs',
+                                   unwind_config, '--libs'])
+        libs = unwind_link.split()
+
+      unwind_la = get_libunwind_la()
+      if os.access(unwind_la, os.R_OK):
+        value = ''
+        with open(unwind_la) as f:
+          for line in f:
+            if line.startswith('dependency_libs='):
+              value = line.split('=')[1]
+              value = value.split("'")[1]
+              libs += value.split();
+
+    return libs

--- a/util/chplenv/chpl_3p_libunwind_configs.py
+++ b/util/chplenv/chpl_3p_libunwind_configs.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_platform
 import third_party_utils
-from utils import memoize, run_command
+from utils import memoize
 
 
 @memoize

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-import subprocess
 
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -73,7 +73,7 @@ def pkgconfig_get_link_args(pkg, ucp='', system=True, static=True):
   if not havePcFile:
     if system:
       # check that pkg-config knows about the package in question
-      subprocess.check_call(['pkg-config', '--exists', pkg])
+      run_command(['pkg-config', '--exists', pkg])
     else:
       # look for a .pc file
       if ucp == '':


### PR DESCRIPTION
Note that libunwind's configure looks for liblzma and needs to be linked with -llzma if it is found.

Verified that stack tracing works:
 - on linux with system libunwind
 - on linux with third-party libunwind with or without liblzma installed
 - on Mac OS X

This PR uses pkg-config to get libunwind dependencies if CHPL_UNWIND=system and gets the dependencies from a libtool .la file if CHPL_UNWIND=libunwind.

This is a little bit hacky but it resolves the issue for me. It would be better if the pkgconfig/libunwind.pc installed under third-party included -llzma if it is a dependency. That might work in libunwind 1.2 (which is not yet released) but doesn't work in 1.1.

(In my testing, the system-installed libunwind.pc includes the lzma dependency when the installed libunwind is built with lzma support but not if it isn't).

Reviewed by @ronawho and @ben-albrecht.
