### PR TITLE
Add --multilocale-only and --max-locales options to start_test

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -691,7 +691,7 @@ def set_up_environment():
         os.environ["CHPL_LAUNCHER_TIMEOUT"] = str(args.launcher_timeout)
 
     # num trials
-    os.environ["CHPL_TEST_NUM_TRIALS"] = str(args.num_trials)
+    os.environ["CHPL_TEST_NUM_TRIALS"] = args.num_trials
 
     # test root dir
     if args.test_root_dir:
@@ -983,20 +983,20 @@ def set_up_executables():
 
     # comm
     if comm != "none" and args.num_locales == "0":
-        args.num_locales = 1
+        args.num_locales = "1"
 
     if args.num_locales == "0":
         logger.write('[numlocales: "(default)"]')
     else:
         logger.write('[numlocales: "{0}"]'.format(args.num_locales))
 
-    os.environ["NUMLOCALES"] = str(args.num_locales)
+    os.environ["NUMLOCALES"] = args.num_locales
 
     if args.max_locales == "0":
         logger.write('[max_locales: "(default)"]')
     else:
         logger.write('[max_locales: "{0}"]'.format(args.max_locales))
-        os.environ["CHPL_TEST_MAX_LOCALES"] = str(args.max_locales)
+        os.environ["CHPL_TEST_MAX_LOCALES"] = args.max_locales
 
     # only run multilocale tests
     if args.multilocale_only:

--- a/util/start_test
+++ b/util/start_test
@@ -992,6 +992,19 @@ def set_up_executables():
 
     os.environ["NUMLOCALES"] = str(args.num_locales)
 
+    if args.max_locales == "0":
+        logger.write('[max_locales: "(default)"]')
+    else:
+        logger.write('[max_locales: "{0}"]'.format(args.max_locales))
+        os.environ["CHPL_TEST_MAX_LOCALES"] = str(args.max_locales)
+
+    # only run multilocale tests
+    if args.multilocale_only:
+        if comm != "none":
+            os.environ["CHPL_TEST_MULTILOCALE_ONLY"] = "true"
+        else:
+            logger.write("[Warning: Ignoring --multilocale-only for CHPL_COMM=none]")
+
     # pre-exec
     if args.preexec:
         if os.path.isfile(args.preexec) and os.access(args.preexec, os.X_OK):
@@ -1292,6 +1305,14 @@ def parser_setup():
     parser.add_argument("-numlocales", "--numlocales", action="store",
             dest="num_locales", default="0",
             help="set the number of locales to run on")
+    # run tests that specify numlocales > 1
+    parser.add_argument("-max-locales", "--max-locales",
+            action="store", dest="max_locales", default="0",
+            help="Maximum number of locales to use")
+    # run tests that specify numlocales > 1
+    parser.add_argument("-multilocale-only", "--multilocale-only",
+            action="store_true", dest="multilocale_only",
+            help="Only run multilocale test (ignored for comm none)")
     # stdin redirect
     parser.add_argument("-nostdinredirect", "--nostdinredirect",
             action="store_true", dest="no_stdin_redirect",

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -48,6 +48,9 @@
 # CHPL_SYSTEM_PREDIFF: If set, run that script on each test output
 # CHPL_COMM: Chapel communication layer
 # CHPL_COMPONLY: Only build the test (same as -noexec flag)
+# CHPL_TEST_NUM_LOCALES_AVAILABLE: same as CHPL_TEST_MAX_LOCALES (for backwards compatibility)
+# CHPL_TEST_MAX_LOCALES: Maximum number of locales to use (overrides above)
+# CHPL_TEST_MULTILOCALE_ONLY: Only run tests that use numlocales > 1
 # CHPL_NO_STDIN_REDIRECT: do not redirect stdin when running tests
 #                         also, skip tests with .stdin files
 # CHPL_LAUNCHER_TIMEOUT: if defined, pass an option/options to the executable
@@ -736,7 +739,9 @@ else:
     globalNumlocales=int(os.getenv('NUMLOCALES', '0'))
 # sys.stdout.write('globalNumlocales=%s\n'%(globalNumlocales))
 
-maxLocalesAvailable = os.getenv('CHPL_TEST_NUM_LOCALES_AVAILABLE')
+maxLocalesAvailable = os.getenv('CHPL_TEST_MAX_LOCALES')
+if maxLocalesAvailable == None:
+    maxLocalesAvailable = os.getenv('CHPL_TEST_NUM_LOCALES_AVAILABLE')
 if maxLocalesAvailable is not None:
     maxLocalesAvailable = int(maxLocalesAvailable)
 
@@ -1197,6 +1202,11 @@ for testname in testsrc:
                                  .format(os.path.join(localdir, test_filename),
                                          numlocales, maxLocalesAvailable))
                 continue
+        if os.getenv('CHPL_TEST_MULTILOCALE_ONLY') and (numlocales <= 1):
+            sys.stdout.write('[Warning: skipping {0} because it does not '
+                             'use more than one locale]\n'
+                             .format(os.path.join(localdir, test_filename)))
+            continue
         numlocexecopts = ' -nl '+str(numlocales)
 
     # if any performance test has a timeout longer than the default we only


### PR DESCRIPTION
The --multi-locale flag to start_test causes sub_test to run only
tests that specify running on more than 1 locale.  That is, skip any
tests that would be run with -nl 1.  It has no effect when used with
CHPL_COMM=none (a warning is logged).
    
The --max-locales flag limits the number of locales to use.  This
functionality is already implemented in sub_test by the environment
variable CHPL_TEST_NUM_LOCALES_AVAILABLE, and this commit adds a
start_test flag for it.  The environment variable is still supported,
but will be overridden by --max-locales.

Tested in the examples directory with comm none and gasnet.

@bradcray @ben-albrecht 
