### PR TITLE
Only test configHelp for CHPL_COMM=none

### DIFF
--- a/test/execflags/bradc/configHelp.skipif
+++ b/test/execflags/bradc/configHelp.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM!=none

--- a/test/execflags/bradc/moduleHelp.chpl
+++ b/test/execflags/bradc/moduleHelp.chpl
@@ -1,4 +1,4 @@
-module bradModule() {
+module bradModule {
   config const n: int = 10;
 
   writeln("n is: ", n);


### PR DESCRIPTION
The .bad for this new future failed last night because I failed
to anticipate that the --help output in the .bad file changes
for GASNet since 'numLocales' is set.  Since this is a test
that's independent of things like CHPL_COMM, I chose to address
this by skipif-ing it for CHPL_COMM!=none.

While testing this directory, I noticed that one of the other
futures had a syntax error that I believe was unintentional,
so I fixed it while there.