### PR TITLE
Replace symbolic link prediff with forwarding script

### DIFF
--- a/test/release/examples/primers/associative.prediff
+++ b/test/release/examples/primers/associative.prediff
@@ -1,1 +1,3 @@
-../../../../util/test/sort-words-within-literals
+#!/bin/sh
+
+$CHPL_HOME/util/test/sort-words-within-literals $*


### PR DESCRIPTION
The symbolic link poses problems when the test moves, which
happens as part of module/release creation.