### PR TITLE
Support bmp output in c-ray

### DIFF
--- a/test/exercises/c-ray/c-ray.chpl
+++ b/test/exercises/c-ray/c-ray.chpl
@@ -382,12 +382,79 @@ proc computePixel(y: int, x: int): pixelType {
 // write the image to the output file
 //
 proc writeImage(pixels) {
+
+  if image.toLower().endsWith("ppm") {
+    writeImagePPM(pixels);
+  } else if image.toLower().endsWith("bmp") {
+    writeImageBMP(pixels);
+  } else {
+    halt("Unsupported image format for output file ", image);
+  }
+}
+
+proc writeImagePPM(pixels) {
   outfile.writeln("P6");
   outfile.writeln(pixels.domain.dim(2).size, " ", pixels.domain.dim(1).size);
   outfile.writeln(255);
   for p in pixels do
     for param c in 1..numColors do
       outfile.writef("%|1i", ((p >> colorOffset(c)) & colorMask));
+}
+
+proc writeImageBMP(pixels) {
+  const rows = pixels.domain.dim(1).length,
+        cols = pixels.domain.dim(2).length;
+
+  const header_size = 14;
+  const dib_header_size = 40;  // always use old BITMAPINFOHEADER
+  const   bits_per_pixel = 24;
+
+  // row size in bytes. Pad each row out to 4 bytes.
+  const row_quads = (bits_per_pixel * cols + 31) / 32;
+  const row_size = 4 * row_quads;
+  const row_size_bits = 8 * row_size;
+
+  const pixels_size = row_size * rows;
+  const size = header_size + dib_header_size + pixels_size;
+
+  const offset_to_pixel_data = header_size + dib_header_size;
+
+  // Write the BMP image header
+  outfile.writef("BM%<4u %<2u %<2u %<4u",
+                 size,
+                 0 /* reserved1 */,
+                 0 /* reserved2 */,
+                 offset_to_pixel_data);
+
+  // Write the DIB header BITMAPINFOHEADER
+  outfile.writef("%<4u %<4i %<4i %<2u %<2u %<4u %<4u %<4u %<4u %<4u %<4u",
+                 dib_header_size, cols, -rows /*neg for swap*/,
+                 1 /* 1 color plane */, bits_per_pixel,
+                 0 /* no compression */,
+                 pixels_size,
+                 2835, 2835 /*pixels/meter print resolution=72dpi*/,
+                 0 /* colors in palette */,
+                 0 /* "important" colors */);
+
+  for i in pixels.domain.dim(1) {
+    var nbits = 0;
+    for j in pixels.domain.dim(2) {
+      var p = pixels[i,j];
+      var redv = (p >> colorOffset(red)) & colorMask;
+      var greenv = (p >> colorOffset(green)) & colorMask;
+      var bluev = (p >> colorOffset(blue)) & colorMask;
+
+      // write 24-bit color value
+      outfile.writebits(bluev, 8);
+      outfile.writebits(greenv, 8);
+      outfile.writebits(redv, 8);
+      nbits += 24;
+    }
+    // write the padding.
+    // The padding is only rounding up to 4 bytes so
+    // can be written in a single writebits call.
+    outfile.writebits(0:uint, (row_size_bits-nbits):int(8));
+  }
 }
 
 //


### PR DESCRIPTION
* it is not currently the default
* it can be selected by specifying an output image ending in .bmp

TODO: if this is good, modify the forStudents version