### PR TITLE
Add an option --[no-]print-callgraph to print the callgraph for programs

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -120,6 +120,7 @@ extern char fExplainInstantiation[256];
 /// resolution.
 extern bool fExplainVerbose;
 extern bool fParseOnly;
+extern bool fPrintCallGraph;
 extern bool fPrintCallStackOnError;
 extern bool fPrintIDonError;
 extern bool fPrintModuleResolution;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -162,6 +162,7 @@ bool fDenormalize = false;
 char fExplainInstantiation[256] = "";
 bool fExplainVerbose = false;
 bool fParseOnly = false;
+bool fPrintCallGraph = false;
 bool fPrintCallStackOnError = false;
 bool fPrintIDonError = false;
 bool fPrintModuleResolution = false;
@@ -714,6 +715,7 @@ static ArgumentDescription arg_desc[] = {
  {"explain-instantiation", ' ', "<function|type>[:<module>][:<line>]", "Explain instantiation of type", "S256", fExplainInstantiation, NULL, NULL},
  {"explain-verbose", ' ', NULL, "Enable [disable] tracing of disambiguation with 'explain' options", "N", &fExplainVerbose, "CHPL_EXPLAIN_VERBOSE", NULL},
  {"instantiate-max", ' ', "<max>", "Limit number of instantiations", "I", &instantiation_limit, "CHPL_INSTANTIATION_LIMIT", NULL},
+ {"print-callgraph", ' ', NULL, "Print a representation of the callgraph for the program", "N", &fPrintCallGraph, "CHPL_PRINT_CALLGRAPH", NULL},
  {"print-callstack-on-error", ' ', NULL, "print the Chapel call stack leading to each error or warning", "N", &fPrintCallStackOnError, "CHPL_PRINT_CALLSTACK_ON_ERROR", NULL},
  {"set", 's', "<name>[=<value>]", "Set config param value", "S", NULL, NULL, readConfig},
  {"task-tracking", ' ', NULL, "Enable [disable] runtime task tracking", "N", &fEnableTaskTracking, "CHPL_TASK_TRACKING", NULL},

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9761,10 +9761,12 @@ static void printCallGraph(FnSymbol* startPoint, int indent, std::set<FnSymbol*>
 static FnSymbol* findMainFn() {
   FnSymbol* genMain = NULL;
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (!strcmp("main", fn->name)) {
-      return fn;
-    } else if (!strcmp("chpl_gen_main", fn->name)) {
-      genMain = fn;
+    if (fn->isResolved()) {
+      if (!strcmp("main", fn->name)) {
+        return fn;
+      } else if (!strcmp("chpl_gen_main", fn->name)) {
+        genMain = fn;
+      }
     }
   }
   assert(genMain != NULL);

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -477,6 +477,15 @@ OPTIONS
     instantiated. This flag raises that maximum in the event that a legal
     instantiation is being pruned too aggressively.
 
+**--[no-]print-callgraph**
+
+    Print a textual call graph representing the program being compiled. The
+    output is in top-down and depth first order. Recursive calls are marked
+    and cause the traversal to stop along the path containing the recursion.
+    Only a single call to each function is displayed from within any given
+    parent function.
+
+
 **--[no-]print-callstack-on-error**
 
     Accompany certain error and warning messages with the Chapel call stack

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -112,6 +112,8 @@ Miscellaneous Options:
       --[no-]explain-verbose          Enable [disable] tracing of
                                       disambiguation with 'explain' options
       --instantiate-max <max>         Limit number of instantiations
+      --[no-]print-callgraph          Print a representation of the callgraph
+                                      for the program
       --[no-]print-callstack-on-error print the Chapel call stack leading to
                                       each error or warning
   -s, --set <name>[=<value>]          Set config param value

--- a/test/compflags/diten/printCallGraph.chpl
+++ b/test/compflags/diten/printCallGraph.chpl
@@ -1,0 +1,36 @@
+proc e(n) {
+  if n > 0 {
+    f(n-1);
+  } else if n < 0 {
+    g(n+1);
+  } else {
+    h(n);
+  }
+}
+
+proc f(n) {
+  if n > 0 {
+    e(n-1);
+  } else if n < 0 {
+    e(n+1);
+  } else {
+    h(n);
+  }
+}
+
+proc g(n) {
+  if n > 0 {
+    f(n-1);
+  } else if n < 0 {
+    f(n+1);
+  } else {
+    h(n);
+  }
+}
+
+proc h(n) {
+  writeln("H");
+}
+
+e(4);
+e(-4);

--- a/test/compflags/diten/printCallGraph.compopts
+++ b/test/compflags/diten/printCallGraph.compopts
@@ -1,0 +1,1 @@
+--print-callgraph

--- a/test/compflags/diten/printCallGraph.good
+++ b/test/compflags/diten/printCallGraph.good
@@ -1,0 +1,13 @@
+e
+  f
+    e (Recursive)
+    h
+  g
+    f
+      e (Recursive)
+      h
+    h
+  h
+main
+H
+H


### PR DESCRIPTION
--print-callgraph causes a textual callgraph to be printed just after
resolution.  Recursive calls are marked "(Recursive) fn_name" and stop
the traversal down a given path.  Repeated calls to the same function
from a given function only print once, including calls to different
instantiations of a generic function.

This printout needs to be done after resolution, but before the cleanup
that happens at the end of resolution. This is because it needs all calls
to be resolved, but needs to happen before generic functions are removed
as unused.  This way all instantiations of a function can be treated as
a single function - the generic.