### PR TITLE
C ray bmp cleanup

### DIFF
--- a/test/exercises/c-ray/TODO
+++ b/test/exercises/c-ray/TODO
@@ -1,3 +1,8 @@
+priorities
+----------
+* move image code into a helper module
+* add case for dynamic iteration
+
 testing improvements
 --------------------
 * test stdout (or files if I do the below)

--- a/test/exercises/c-ray/TODO
+++ b/test/exercises/c-ray/TODO
@@ -1,0 +1,42 @@
+testing improvements
+--------------------
+* test stdout (or files if I do the below)
+* switch back to diffing against 'stdout' to avoid catfiles?
+* test .bmp
+* don't do full cross-product of compopts x execopts?  linearize each axis?
+* add more tests for other command-line arguments / halts / errors
+
+quality
+-------
+* git .ppm diffs matching the reference version
+* .bmp file appears darker than .ppm -- is this my programs, or a bug?
+
+benchmark improvements
+----------------------
+* should be able to use an enum for the RGB and XYZ params, but... it
+  didn't work?
+    e.g., enum colors { red=1, green, blue}
+          use colors;
+          param numColors = colors.size;
+
+* at one point I changed vec3 into an array [1..3] but it didn't seem
+  to work.  Did I mess up or is something broken?
+
+* string library experts: Is there a better way to ignore comments than
+  what I've done?
+
+* sf and aspect really want to be local statics in getSamplePos()
+
+* simplify repeated expressions in raySphere()?
+
+* simplify error margin check in raySphere?
+
+* use a reduction in shade()?
+
+
+Chapel implementation
+---------------------
+* make compilerError, halt, and such optionally squash where the message is
+  coming from.  End-users won't care in many cases.
+* add readlines() iterator to ChapelIO module.
+

--- a/test/exercises/c-ray/c-ray.chpl
+++ b/test/exercises/c-ray/c-ray.chpl
@@ -28,6 +28,7 @@
 // (Override defaults on compiler line using -s<cfg>=<val>)
 //
 config type pixelType = int;
+
 config param bitsPerColor = 8;
 
 //
@@ -98,13 +99,6 @@ param X = 1,          // names for accessing vec3 elements
       numdims = 3;
 
 //
-// TODO: Should be able to use an enum for both of the above:
-//   enum colors {red=0, green, blue};
-//   use colors;
-//   param numColors = colors.size;
-//
-
-//
 // Verify that config-specified pixelType is appropriate for storing colors
 //
 if (isIntegral(pixelType)) {
@@ -117,15 +111,11 @@ if (isIntegral(pixelType)) {
 }
 
 
-
 //
 // establish types
 //
 
 type vec3 = numdims*real;   // a 3-tuple for positions, vectors
-//
-// TODO: Making this an array [0..3] doesn't work -- why?
-//
 
 record ray {
   var orig,           // origin
@@ -172,9 +162,6 @@ param nran = 1024;
 var urand: [0..#nran] vec3,
     irand: [0..#nran] int;
 
-//
-// TODO: Remove for exercise -- meant for testing only
-//
 config param multilocale = (CHPL_COMM != "none"),
              blockdist = true;
 config const loopStyle = 0;
@@ -259,7 +246,6 @@ proc loadScene() {
 
   for (rawLine, lineno) in zip(infile.readlines(), 1..) {
     // drop any comments (text following '#')
-    // TODO: string library experts, is there a better way to do this?
     const linePlusComment = rawLine.split('#', maxsplit=1, ignoreEmpty=false),
           line = linePlusComment[1];
 
@@ -539,11 +525,11 @@ proc getSamplePos(xy, sample) {
   pt(Y) = -pt(Y);
 
   if sample {
-    const sf = 2.0 / xres; // TODO: This really wants to be a local static
+    const sf = 2.0 / xres;
     pt += jitter(xy, sample) * sf;
   }
 
-  const aspect = xres:real / yres;  // image aspect ratio; TODO: local static
+  const aspect = xres:real / yres;  // image aspect ratio
   pt(Y) /= aspect;
 
   return pt;
@@ -567,7 +553,6 @@ proc jitter((x, y), s) {
 proc raySphere(sph, ray) {
   var sp: spoint;
 
-  // TODO: simplify this
   const a = ray.dir(X)**2 + ray.dir(Y)**2 + ray.dir(Z)**2,
         b = 2.0 * ray.dir(X) * (ray.orig(X) - sph.pos(X)) +
             2.0 * ray.dir(Y) * (ray.orig(Y) - sph.pos(Y)) +
@@ -586,7 +571,6 @@ proc raySphere(sph, ray) {
   var t1 = (-b + sqrtD) / (2.0 * a),
       t2 = (-b - sqrtD) / (2.0 * a);
 
-  // TODO: simplify?
   if (t1 < errorMargin && t2 < errorMargin) || (t1 > 1.0 && t2 > 1.0) then
     return (false, sp);
 
@@ -613,7 +597,7 @@ proc raySphere(sph, ray) {
 // Also handles reflections by calling trace again, if necessary.
 //
 proc shade(obj, sp, depth) {
-  var col: vec3;  // TODO: reduction?
+  var col: vec3;
 
   // for all lights...
   for l in lights {
@@ -690,9 +674,6 @@ proc imageFormat(filename) {
   halt("Unsupported image format for output file '", image, "'");
 }
 
-//
-// TODO: We should really add this to the IO module
-//
 iter channel.readlines() {
   var line: string;
 

--- a/test/exercises/c-ray/c-ray.execopts
+++ b/test/exercises/c-ray/c-ray.execopts
@@ -1,13 +1,14 @@
 #
 # basic test
 #
---noTiming
---noTiming --loopStyle=1
---noTiming --loopStyle=2
---noTiming --loopStyle=3
---noTiming --samples=4 --seed=1 --size=400x300  # c-ray.4samples.good
+--noTiming --image=image.ppm
+--noTiming --image=image.ppm --loopStyle=1
+--noTiming --image=image.ppm --loopStyle=2
+--noTiming --image=image.ppm --loopStyle=3
+--noTiming --image=image.ppm --samples=4 --seed=1 --size=400x300  # c-ray.4samples.good
 
 #
 # skipping this due to it taking too long under valgrind and baseline testing:
 #
-#--noTiming --scene=sphfract  # c-ray.sphfract.good
+#--noTiming --image=image.ppm --scene=sphfract  # c-ray.sphfract.good
+

--- a/test/exercises/c-ray/c-ray.noreal.good
+++ b/test/exercises/c-ray/c-ray.noreal.good
@@ -1,1 +1,1 @@
-c-ray.chpl:116: error: pixelType must be an integral type
+c-ray.chpl:110: error: pixelType must be an integral type

--- a/test/exercises/c-ray/c-ray.toosmall.good
+++ b/test/exercises/c-ray/c-ray.toosmall.good
@@ -1,1 +1,1 @@
-c-ray.chpl:112: error: pixelType 'int(8)' isn't big enough to store 8 bits per color
+c-ray.chpl:106: error: pixelType 'int(8)' isn't big enough to store 8 bits per color

--- a/test/exercises/c-ray/c-ray.usage.good
+++ b/test/exercises/c-ray/c-ray.usage.good
@@ -6,6 +6,7 @@ Primary Options:
   --samples <rays>      antialias using 'rays' samples per pixel
   --scene <file>        read scene from 'file' (can be 'stdin')
   --image <file>        write image to 'file' (can be 'stdout')
+  --format [ppm|bmp]    override the default file format
   --usage               print this usage information
 
 Other options:


### PR DESCRIPTION
Cleanups to Michael's addition of .bmp support:

* moved parsing of extension earlier so that we wouldn't find out
  we had a typo only after rendering a huge scene

* restored ability to specify 'stdout' as output format

* added the ability to override the default format determined by
  the file extension to support both ppm and bmp to stdout

* added an enum to specify the formats because it cleaned up some
  of the code (and showed off enums)

* removed underscores from new bmp code for consistency (with this
  module)

* other minor code formatting changes / reuses of existing symbols
  within the bmp code (more may be possible)

Also...

* moved my TODO comments into the TODO file I'd been using locally (one of
  which was to add support for .bmp -- thanks @mppf!) and added it