### PR TITLE
Uggh!!  Add missed -M argument for c-ray performance testing...

### DIFF
--- a/test/exercises/c-ray/c-ray.perfcompopts
+++ b/test/exercises/c-ray/c-ray.perfcompopts
@@ -1,0 +1,1 @@
+-M forStudents


### PR DESCRIPTION
Stupid oversight, I'm sorry everyone:  When I added a helper module for image files, I only added it to one of the two directories that I've been working in which required -M options for other test cases.  While I'd added this to all of the correctness testing options, I'd forgotten to add it to performance testing, hence the failures on the performance runs.  Sigh.