### PR TITLE
Add floating-point tolerance to short-sleeping test

### DIFF
--- a/test/modules/standard/Time/sleepTimeUnits.chpl
+++ b/test/modules/standard/Time/sleepTimeUnits.chpl
@@ -1,7 +1,14 @@
 use Time;
 
 config param printTime = false;
-config const tolerance = 2.0;
+
+// nanosecond
+config const tolerance = 1e-9;
+
+// Returns true if 'a' is less than 'b' by the above tolerance
+proc lt(a : real, b : real) {
+  return a < (b-tolerance);
+}
 
 var timer: Timer;
 
@@ -17,7 +24,7 @@ sleep(100, TimeUnits.microseconds);
 timer.stop();
 if printTime then
   stderr.writeln(timer.elapsed());
-if timer.elapsed() < 1e-6*100 then
+if lt(timer.elapsed(), 1e-6*100) then
   halt("Slept short on TimeUnits.microseconds", ": ", timer.elapsed());
 timer.clear();
 
@@ -26,7 +33,7 @@ sleep(100, TimeUnits.milliseconds);
 timer.stop();
 if printTime then
   stderr.writeln(timer.elapsed());
-if timer.elapsed() < 1e-3*100 then
+if lt(timer.elapsed(), 1e-3*100) then
   halt("Slept short on TimeUnits.milliseconds: ", timer.elapsed());
 timer.clear();
 
@@ -35,7 +42,7 @@ sleep(3);
 timer.stop();
 if printTime then
   stderr.writeln(timer.elapsed());
-if timer.elapsed() < 3 then
+if lt(timer.elapsed(), 3) then
   halt("Slept short on TimeUnits.seconds: ", timer.elapsed());
 timer.clear();
 


### PR DESCRIPTION
Use a tolerance to compare the sleep amount in case of floating point issues (seen on PGI).

The sleepTimeUnits test was sporadically failing in whitebox PGI testing due to short-sleeping by less than 1e-16, when checking the time for 100 milliseconds. I added some extra printing to the test when I was running trials yesterday to print the value of the timer when it failed:

```chpl
writef("Slept short: %.17r\n", timer.elapsed());
```

I figured that would be plenty of significant digits. When the test would fail, I saw numbers like ``0.099999999999999992``. The difference between that value and ``0.01`` is far less than the resolution of the system clock, which lead me to think it was a floating-point issue.

Before this change, the test could fail about 2% of the time. @ronawho suggested testing with --ieee-float, and we observed no failures for 2000 trials. With such a small value, and seemingly no failures with --ieee-float, it seems like this is simply a floating point precision issue.