### PR TITLE
Use a hybrid spin/yield loop for chameneos

### DIFF
--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -169,7 +169,14 @@ class Chameneos {
   // to become 'true' and then resetting it to 'false'.
   //
   proc waitForMeetingToEnd() {
-    meetingCompleted.waitFor(true);
+    var spin_count = 15;
+    while meetingCompleted.read() == false {
+      if spin_count {
+        spin_count -= 1;
+      } else {
+        chpl_task_yield();
+      }
+    }
     meetingCompleted.write(false);
   }
 


### PR DESCRIPTION
While one chameneos is waiting to meet with another it used to continuously
yield. The second chameneos often arrived fairly soon afterwards, which meant we
wasted a lot of time yielding. This updates the wait loop to spin for a few
iterations before yielding.

This has a pretty dramatic performance impact taking execution time from ~3.8
seconds to ~1.2 seconds on the shootout-like box. This puts us in ~4th place
after a .6s C version, 1.05s Go version, and 1.1s Lisp version.