### PR TITLE
Fix baseline issue with PRIM_GET_MEMBER

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -6158,6 +6158,10 @@ static bool codegenIsSpecialPrimitive(BaseAST* target, Expr* e, GenRet& ret) {
         ret = codegenAddrOf(codegenFieldPtr(call->get(1), se));
 
         retval = true;
+      } else if ((target->isRef() && call->get(2)->isRef()) ||
+                 (target->isWideRef() && call->get(2)->isWideRef())) {
+        ret = codegenFieldPtr(call->get(1), se);
+        retval = true;
 
       } else if (target && (target->getValType() != call->get(2)->typeInfo())) {
         // get a narrow reference to the actual 'addr' field


### PR DESCRIPTION
In codegen, a PRIM_GET_MEMBER of a ref field should do the same thing as a PRIM_GET_MEMBER_VALUE because we don't allow references to references. For now it's easier to handle the problem here than to replace the primitive. This problem was exposed by #4869.

testing:
- [x] full local
- [x] full no-local
- [x] full baseline
- [x] gasnet for distributions/, multilocale/, and release/examples/