### PR TITLE
Remove sleep() from tests with 'diten' in their paths/names

### DIFF
--- a/test/memory/diten/useArrInBegin.chpl
+++ b/test/memory/diten/useArrInBegin.chpl
@@ -1,8 +1,9 @@
+var s$: sync bool;
+
 proc f2(A: []) {
   var _value = A._value;
   begin {
-    use Time;
-    sleep(1);
+    s$; // wait until after f2 returns
     var value = A._value;
     A[1] = 1;
   }
@@ -12,6 +13,7 @@ proc f1() {
   var A: [1..5] int;
   var _value = A._value;
   f2(A);
+  s$ = true;
 }
 
 proc main {

--- a/test/memory/diten/useDomInBegin.chpl
+++ b/test/memory/diten/useDomInBegin.chpl
@@ -1,15 +1,18 @@
-proc f() {
-  use Time;
+config const n = 10;
+var s$: [1..n] sync bool;
+
+proc f(i) {
   var D = {1..10};
   begin {
-    sleep(1);
+    s$[i]; // wait until after f() returns
     var A: [D] real;
   }
 }
 
-config const n = 10;
 
 proc main {
-  for i in 1..n do
-    f();
+  for i in 1..n {
+    f(i);
+    s$[i] = true;
+  }
 }

--- a/test/modules/diten/mutualuse.chpl
+++ b/test/modules/diten/mutualuse.chpl
@@ -1,9 +1,9 @@
 module M1 {
-  use M2, Time;
+  use M2;
   class C {
     var field: int;
   }
-  sleep(3);
+
   var a = new C(1);
 }
 

--- a/test/modules/diten/mutualuse3.chpl
+++ b/test/modules/diten/mutualuse3.chpl
@@ -1,6 +1,6 @@
 module M1 {
-  use M2, Time;
-  sleep(3);
+  use M2;
+
   var a = 1;
 }
 

--- a/test/modules/diten/useInBegin.chpl
+++ b/test/modules/diten/useInBegin.chpl
@@ -9,11 +9,9 @@ module M1 {
 
 module M2 {
   proc main {
-    use Time;
     for i in 1..100 {
       begin {
-        sleep(1);
-        { use M1; }
+        use M1;
       }
     }
   }

--- a/test/multilocale/deitz/needMultiLocales/test_large_nb_fork_bug_diten.chpl
+++ b/test/multilocale/deitz/needMultiLocales/test_large_nb_fork_bug_diten.chpl
@@ -1,18 +1,4 @@
-use Time;
-
 proc main {
-  on Locales(1) {
-    cobegin {
-      coforall i in 1..100 {
-        sleep(3);
-      }
-      coforall i in 1..100 {
-        sleep(3);
-      }
-    }
-    sleep(3);
-  }
-
   writeln("here 1");
 
   var tup: 300*int;

--- a/test/multilocale/diten/needMultiLocales/DijkstraTermination.chpl
+++ b/test/multilocale/diten/needMultiLocales/DijkstraTermination.chpl
@@ -120,17 +120,17 @@ var a: sync int = 0;
 use Time;
 
 proc foo() {
-  sleep(5);
+  // doWork3();
   turnBlack;
   on Locales(0) {
     incEndCount;
     begin {
-      sleep(3);
+      // doWork4();
       a += 1;
       decEndCount;
     }
   }
-  sleep(4);
+  // doWork5();
   a += 1;
 }
 
@@ -144,14 +144,14 @@ proc main {
   begin {
     turnBlack;
     on Locales(1) {
-      sleep(3);
+      // doWork1();
       a += 1;
     }
     decEndCount;
   }
   incEndCount;
   begin {
-    sleep(4);
+    // doWork2();
     a += 1;
     decEndCount;
   }

--- a/test/multilocale/diten/needMultiLocales/coforallon_maxThreads.chpl
+++ b/test/multilocale/diten/needMultiLocales/coforallon_maxThreads.chpl
@@ -1,10 +1,7 @@
-use Time;
-
 proc main {
   var a: atomic int;
   coforall loc in Locales {
     on loc {
-      sleep(2);
       a.add(1);
     }
   }

--- a/test/multilocale/diten/needMultiLocales/nestedOn.chpl
+++ b/test/multilocale/diten/needMultiLocales/nestedOn.chpl
@@ -1,5 +1,3 @@
-use Time;
-config const sleepTime:uint = 1;
 config const printIterations = false;
 proc main() {
   var s: string = "a string";

--- a/test/multilocale/diten/needMultiLocales/remoteString.chpl
+++ b/test/multilocale/diten/needMultiLocales/remoteString.chpl
@@ -1,5 +1,3 @@
-use Time;
-config const sleepTime:uint = 1;
 config const printIterations = false;
 proc main() {
   var s: string = "a string";
@@ -11,7 +9,6 @@ proc main() {
       s = "another string";
     }
     on Locales(0) {
-      sleep(sleepTime);
       s = "done";
     }
   }

--- a/test/multilocale/diten/needMultiLocales/remoteString2.chpl
+++ b/test/multilocale/diten/needMultiLocales/remoteString2.chpl
@@ -1,5 +1,3 @@
-use Time;
-config const sleepTime:uint = 1;
 config const printIterations = false;
 proc main() {
   var s: string = "a string";

--- a/test/parallel/cobegin/diten/cobeginRace.chpl
+++ b/test/parallel/cobegin/diten/cobeginRace.chpl
@@ -2,16 +2,6 @@ proc foo() { }
 
 proc bar() { }
 
-var done: single bool;
-
-proc timeout(n: uint) {
-  use Time;
-  begin { sleep(n); writeln("Timeout"); exit(1); }
-  begin { done; exit(0); }
-}
-
-timeout(30); // exit after 30 seconds or when done is set.
-
 for i in 1..20000 {
   cobegin {
     cobegin { bar(); foo(); }
@@ -22,5 +12,3 @@ for i in 1..20000 {
   if i % 10000 == 0 then
     writeln("iteration ", i, " done.");
 }
-
-done = true;

--- a/test/parallel/single/diten/simpleSingleAccess.chpl
+++ b/test/parallel/single/diten/simpleSingleAccess.chpl
@@ -1,10 +1,8 @@
-use Time;
-
 var a: single bool;
 
 proc foo() {
   writeln("Going to sleep for a bit.");
-  sleep(2);
+  // no need to actually sleep() here
   writeln("That was a nice nap. I'll do my work now.");
   a = true;
 }

--- a/test/parallel/sync/diten/tupleOfSync.chpl
+++ b/test/parallel/sync/diten/tupleOfSync.chpl
@@ -1,13 +1,3 @@
-var finished: sync bool;
-begin {
-  // This aborts the test if it takes too long.
-  use Time;
-  sleep(5);
-  if (!finished.isFull) then
-    halt("Timed out");
-}
-
-
 type t = sync bool;
 writeln("about to create sync tuple");
 var a: (t, t, t);
@@ -17,4 +7,3 @@ a(1) = true;
 writeln("set sync tuple field");
 writeln("sync value is: ", a(1).readFE());
 writeln("read it");
-finished = true;


### PR DESCRIPTION
Most of these were using sleep() to cause delays that weren't really
necessary.  Just removed the delays from these.

A few used sleep() to force a non-blocking task to wait until its parent had
returned before running. Use sync vars instead in these.

A few used sleep() to implement a timeout before the testing system had
easily configurable timeouts. Since a) they don't get normally stuck anymore
and b) we have nice timeouts in the testing system, remove the timeout
mechanism from the tests.  If we decide the timeout is still needed, we can
add it using the test system instead.