### PR TITLE
Assigning to a param twice should emit a compiler error

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7307,6 +7307,15 @@ postFold(Expr* expr) {
           expr->replace(result);
         }
       }
+      if (call->isNamed("=")) {
+        if (SymExpr* lhs = toSymExpr(call->get(1))) {
+          if (lhs->symbol()->hasFlag(FLAG_MAYBE_PARAM) || lhs->symbol()->isParameter()) {
+            if (paramMap.get(lhs->symbol())) {
+              USR_FATAL(call, "parameter set multiple times");
+            }
+          }
+        }
+      }
     } else if (call->isPrimitive(PRIM_QUERY_TYPE_FIELD) ||
                call->isPrimitive(PRIM_QUERY_PARAM_FIELD)) {
       SymExpr* classWrap = toSymExpr(call->get(1));
@@ -7598,17 +7607,31 @@ postFold(Expr* expr) {
       CallExpr* call = toCallExpr(sym->parentExpr);
       if (call && call->get(1) == sym) {
         // This is a place where param substitution has already determined the
-        // value of a move or assignment, so we can just ignore the update.
-        if (call->isPrimitive(PRIM_MOVE)) {
-          makeNoop(call);
-          return result;
-        }
-
+        // value of a move or assignment. If it's a RVV, then we should ignore
+        // the update because the RVV may have multiple valid defs in the AST
+        // that we currently cannot squash if there are multiple return
+        // statements. For example, consider the following param function:
+        //
+        // proc foo(type t) param {
+        //   if firstCheck(t) then return true;
+        //   if otherCheck(t) then return false;
+        //   return true;
+        // }
+        //
+        // The final "return true" can manifest as a PRIM_MOVE into the RVV
+        // variable. I think we're currently unable to move the def because
+        // of GOTOs.
+        //
+        // If it's not a RVV, then we might be assigning to a user-defined
+        // param multiple times. In that case, we'll just return the result
+        // and let resolution catch the problem later.
+        //
         // The substitution usually happens before resolution, so for
         // assignment, we key off of the name :-(
-        if (call->isNamed("="))
-        {
-          makeNoop(call);
+        if (call->isPrimitive(PRIM_MOVE) || call->isNamed("=")) {
+          if (sym->symbol()->hasFlag(FLAG_RVV)) {
+            makeNoop(call);
+          }
           return result;
         }
       }

--- a/test/param/bharshbarg/setMultiple.chpl
+++ b/test/param/bharshbarg/setMultiple.chpl
@@ -1,0 +1,3 @@
+param foobar = true;
+foobar = false;
+writeln(foobar);

--- a/test/param/bharshbarg/setMultiple.good
+++ b/test/param/bharshbarg/setMultiple.good
@@ -1,0 +1,2 @@
+setMultiple.chpl:2: error: illegal lvalue in assignment
+setMultiple.chpl:2: error: parameter set multiple times


### PR DESCRIPTION
Somehow we don't have any tests that attempt to assign to a param twice. What the compiler did in that case was turn the second assignment into a PRIM_NOOP, which had the surprising side effect of causing the for_exprs_postorder macro to skip resolving the rest of the BlockStmt.

The postFold branch that created the no-op would return the SymExpr for the param. That SymExpr had just been removed from the tree to make room for the no-op, and the macro relied on the SymExpr to find the next expression to resolve. This caused the macro loop to stop, leaving the result of the BlockStmt unresolved. This left unresolved exprs in the AST, which eventually caused an internal error.

Long-term, a better route for RVVs might be to squash sections of code that will definitely be skipped over by a GOTO.

Testing:
- [x] full local
- [x] full no-local