### PR TITLE
Fix a race condition in associative array set ops

### DIFF
--- a/test/associative/bharshbarg/arrays/arraySetOps.chpl
+++ b/test/associative/bharshbarg/arrays/arraySetOps.chpl
@@ -1,4 +1,8 @@
-config const n = 20;
+config const n = 100;
+
+// Increase the number of trials to try and catch any sporadic data races
+// with the forall loops in the internal module.
+config const numTrials = 1000;
 
 var ad, bd, cd : domain(int);
 var a : [ad] int;
@@ -15,29 +19,77 @@ c = 3;
 
 // contains all in 1..n
 var q = a + b;
-for i in 1..n {
-  assert(q.domain.member(i));
-  if i % 2 == 0 then assert(q[i] == 2);
-  else assert(q[i] == 1);
+for 1..numTrials {
+  var q = a + b;
+
+  var aad = a.domain;
+  var aa : [aad] int = a;
+  aa |= b;
+
+  for i in 1..n {
+    assert(q.domain.member(i));
+    assert(aa.domain.member(i));
+    if i % 2 == 0 {
+      assert(q[i] == 2);
+      assert(aa[i] == 2);
+    }
+    else {
+      assert(q[i] == 1);
+      assert(aa[i] == 1);
+    }
+  }
 }
 
 // a and b are disjoint, so r == a
-var r = a - b;
-for i in r.domain {
-  assert(ad.member(i));
-  assert(r[i] == a[i]);
+for 1..numTrials {
+  var r = a - b;
+
+  var aad = a.domain;
+  var aa : [aad] int = a;
+  aa -= b;
+
+  for i in r.domain {
+    assert(ad.member(i));
+    assert(r[i] == a[i]);
+    assert(aa[i] == a[i]);
+  }
+  assert(aa.domain == r.domain);
 }
 
-var s = a ^ b;
-for i in s.domain {
-  assert(q.domain.member(i));
-  assert(s[i] == q[i]);
+for 1..numTrials {
+  var s = a ^ b;
+
+  var aad = a.domain;
+  var aa : [aad] int = a;
+  aa ^= b;
+
+  for i in s.domain {
+    assert(q.domain.member(i));
+    assert(s[i] == q[i]);
+    assert(aa[i] == q[i]);
+  }
+  assert(aa.domain == s.domain);
 }
 
 // all indices should be less than n/2
-var t = a & c;
-for i in t.domain do assert(i <= n/2);
+for 1..numTrials {
+  var t = a & c;
 
-var u = b ^ c;
-for i in u.domain do
-  if i < n/2 then assert(i % 2 == 1);
+  var aad = a.domain;
+  var aa : [aad] int = a;
+  aa &= c;
+
+  for i in t.domain do assert(i <= n/2);
+  assert(aa.domain == t.domain);
+}
+
+for 1..numTrials {
+  var u = b ^ c;
+
+  var bbd = b.domain;
+  var bb : [bbd] int = b;
+  bb ^= c;
+  for i in u.domain do
+    if i < n/2 then assert(i % 2 == 1);
+  assert(bb.domain == u.domain);
+}


### PR DESCRIPTION
Consider the following snippet:

```chpl
var dom : domain(int, parSafe=true);
var A : [dom] int;
forall i in 1..100 {
  dom.add(i);
  A[i] = i; // WRONG!
}
```

Adding indices in parallel is fine (provided parSafe is set to true).
Where this program goes wrong is when it attemps to write to an element
while other indices/elements are being added.

``A[i]`` returns a reference to an integer stored in the associative's
array internal array buffer. If an index is added in parallel and the
array is resized, then that reference will now be pointing to invalid
memory. This isn't an issue if the elements are heap allocated.

It's conceivable then that the code could be interleaved like so:
```
   TASK 1           Task 2
-------------    -------------
ref ai = A[i];
                 dom.add(i); // causing a resize
*(ai) = i;
```

This commit updates the internal set operators on associative arrays to
add all the indices before writing to any elements.

Note that this will likely cause a performance regression for associative array set operations. In the future, we may want some kind of internal ``addAndSet(index=i, value=i)`` helper function to keep the lock while setting the value.