### PR TITLE
Inline cleanup 2

### DIFF
--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -201,14 +201,15 @@ void inlineFunctions() {
 /************************************* | **************************************
 *                                                                             *
 * The following is transition logic while ref intents are being cleaned up.   *
+*                                                                             *
 * It was being applied in the inner loop of inlineFunctions but               *
-*   1) That made inline functions a little more convoluted                    *
-*   2) Could be applied more generally                                        *
+*   1) That made inlineFunctions() a little more convoluted                   *
+*   2) This transformation could/should be applied more generally             *
 *                                                                             *
 * There are now many functions that have at least one formal with a ref       *
-* intent and a non-ref type e.g. a Record rather than a Class _ref(Record).   *
-* However there are still call sites that continue to pass a temp with a      *
-* ref-type.                                                                   *
+* intent and, correctly, a non-ref type e.g. a Record rather than a           *
+* Class _ref(Record).  However there are still call sites that continue to    *
+* pass a temp that is Class _ref(t).                                          *
 *                                                                             *
 * The longer term path is to eliminate the creation of those ref types but in *
 * the short term this inserts another tmp var that has the correct type and   *

--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -47,29 +47,7 @@ static void inlineCall(FnSymbol* fn, CallExpr* call) {
   SymbolMap map;
 
   for_formals_actuals(formal, actual, call) {
-    SymExpr* se = toSymExpr(actual);
-
-    INT_ASSERT(se);
-
-    if ((formal->intent & INTENT_REF) != 0     &&
-        isReferenceType(formal->type) == false &&
-        formal->type->getRefType()    == actual->typeInfo()) {
-      Expr*      point = call->getStmtExpr();
-      VarSymbol* tmp   = newTemp(astr("i_", formal->name), formal->type);
-      DefExpr*   def   = new DefExpr(tmp);
-      CallExpr*  move  = new CallExpr(PRIM_MOVE,
-                                      tmp,
-                                      new CallExpr(PRIM_SET_REFERENCE,
-                                                   se->symbol()));
-      tmp->qual = QUAL_REF;
-
-      point->insertBefore(def);
-      point->insertBefore(move);
-
-      map.put(formal, tmp);
-    } else {
-      map.put(formal, se->symbol());
-    }
+    map.put(formal, toSymExpr(actual)->symbol());
   }
 
   //


### PR DESCRIPTION
The inner loop of inlineFunctions use to include several special cases.  I recently applied a PR
that reduced this to 2 cases; a complex test for formals with ref-intent and then the default case.

The complex case was looking for the condition

1) the formal has ref-intent
2) the formal has a "base type" that is e.g. Record<t> rather than Class _ref(Record<t>)
3) the actual has "base type" Class _ref(Record<t>)

If it find this case then it modifies the call site to insert a true ref-temp (qual ref) with the
appropriate base type and uses a new primop to initialize this temp. 

This is a transitional transformation that was introduced to support the overhaul of 
references.



This PR removes that business logic from the inner loop of inlining and applies it more
broadly to all call-sites.  This

1) Removes an "incidental" responsibility from inlining

2) Applies this helpful transformation more broadly.




Compiled with clang/darwin and gcc/linux64 on both mac and chap01.
Tested a substantial portion of release/ on darwin

Full paratest on linux64 with std --verify and gasnet --verify
