### PR TITLE
added CHPL_HOME/build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tags
 # Compiler ignores.
 /compiler/BROWSE
 /compiler/chpl
+/compiler/codegen/reservedSymbolNames.h
 /compiler/ifa/prim_data.cpp
 /compiler/ifa/prim_data.h
 /compiler/ifa/make_prims/make_prims
@@ -36,7 +37,6 @@ tags
 /compiler/main/COPYRIGHT
 /compiler/main/LICENSE
 /compiler/parser/bison-chapel.output
-/compiler/passes/reservedSymbolNames.h
 
 # Doc ignores.
 /doc/**/*.aux

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tags
 /SVNLOG
 /.SVNLOG-revnum
 /bin
+/build
 /lib
 /tar
 


### PR DESCRIPTION
Adjusting .gitignore for #4826:
* ignore CHPL_HOME/build, which stores generated files
* moving reservedSymbolNames.h
