### PR TITLE
Replace domain iterations with range iterations for a performance boost

### DIFF
--- a/test/release/examples/benchmarks/shootout/fasta.chpl
+++ b/test/release/examples/benchmarks/shootout/fasta.chpl
@@ -98,12 +98,13 @@ proc repeatMake(desc, alu, n) {
 //
 // Output a random sequence of length 'n' using distribution a
 //
-proc randomMake(desc, nucleotides: [?D], n) {
+proc randomMake(desc, nucleotides, n) {
   stdout.writeln(desc);
 
-  var cumulProb: [D] int;
+  const numNucls = nucleotides.size;
+  var cumulProb: [1..numNucls] int;
   var p = 0.0;
-  for i in D {
+  for i in 1..numNucls {
     p += nucleotides[i](prob);
     cumulProb[i] = 1 + (p*IM):int;
   }
@@ -114,7 +115,7 @@ proc randomMake(desc, nucleotides: [?D], n) {
     const bytes = min(lineLength, n-i+1);
 
     for (r, i) in zip(getRands(bytes), 0..) {
-      for j in D {
+      for j in 1..numNucls {
         if r < cumulProb[j] {
           line_buff[i] = nucleotides[j](nucl);
           break;

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -100,15 +100,17 @@ proc repeatMake(desc, str, n) {
 //
 // Output a random sequence of length 'n' using distribution 'a'
 //
-proc randomMake(desc, nuclInfo: [?D], n) {
+proc randomMake(desc, nuclInfo, n) {
+  const numNucls = nuclInfo.size;
+
   stdout.write(desc);
 
-  var cumul_p: [D] int;
+  var cumul_p: [1..numNucls] int;
   //
   // Sum the probabilities of the nucleotide info
   //
   var p = 0.0;
-  for i in D {
+  for i in 1..numNucls {
     p += nuclInfo[i](prob);
     cumul_p[i] = 1 + (p*IM):int;
   }
@@ -152,7 +154,7 @@ proc randomMake(desc, nuclInfo: [?D], n) {
         // TODO: reference version doesn't use real, why do I?
         //
         const r = rands[i];
-        for i in D {
+        for i in 1..numNucls {
           if r < cumul_p[i] {
             line_buff[off] = nuclInfo[i](nucl);
             break;


### PR DESCRIPTION
On the flight home from SC16, I did some detailed timings of the release version of fasta, comparing to the C version with OpenMP disabled and found that, on some platforms at least, a significant chunk of overhead is coming from iterating over a formal array argument's queried 1D domain rather than over the range that it represents.  This rewrite makes that change to see the impact across our testing machines.
