### PR TITLE
Add an OpenMP variant of the task spawning perf tests

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-coforall.chpl
+++ b/test/parallel/taskCompare/elliot/empty-coforall.chpl
@@ -3,14 +3,16 @@ use Time;
 config const numTrials = 100;
 config const printTimings = false;
 
+proc coforallTaskSpawn(trials, numTasks) {
+  for 1..trials do
+    coforall 1..numTasks { }
+}
+
 proc main() {
   var t: Timer;
 
   t.start();
-  for 1..numTrials {
-    coforall 1..here.maxTaskPar {
-    }
-  }
+  coforallTaskSpawn(numTrials, here.maxTaskPar);
   t.stop();
 
   if printTimings {

--- a/test/parallel/taskCompare/elliot/empty-for+begin.chpl
+++ b/test/parallel/taskCompare/elliot/empty-for+begin.chpl
@@ -3,18 +3,16 @@ use Time;
 config const numTrials = 100;
 config const printTimings = false;
 
+proc forBeginTaskSpawn(trials, numTasks) {
+  for 1..numTrials do
+    sync { for 1..here.maxTaskPar do begin { } }
+}
+
 proc main() {
   var t: Timer;
 
   t.start();
-  for 1..numTrials {
-    sync {
-      for 1..here.maxTaskPar {
-        begin {
-        }
-      }
-    }
-  }
+  forBeginTaskSpawn(numTrials, here.maxTaskPar);
   t.stop();
 
   if printTimings {

--- a/test/parallel/taskCompare/elliot/empty-forall.chpl
+++ b/test/parallel/taskCompare/elliot/empty-forall.chpl
@@ -3,14 +3,16 @@ use Time;
 config const numTrials = 100;
 config const printTimings = false;
 
+proc forallTaskSpawn(trials, numTasks) {
+  for 1..trials do
+    forall 1..numTasks { }
+}
+
 proc main() {
   var t: Timer;
 
   t.start();
-  for 1..numTrials {
-    forall 1..here.maxTaskPar {
-    }
-  }
+  forallTaskSpawn(numTrials, here.maxTaskPar);
   t.stop();
 
   if printTimings {

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.chpl
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.chpl
@@ -3,16 +3,13 @@ use Time;
 config const numTrials = 100;
 config const printTimings = false;
 
-proc forBeginTaskSpawn(trials, numTasks) {
-  for 1..numTrials do
-    sync { for 1..numTasks do begin { } }
-}
+extern proc ompTaskSpawn(trials, numTasks);
 
 proc main() {
   var t: Timer;
 
   t.start();
-  forBeginTaskSpawn(numTrials, here.maxTaskPar);
+  ompTaskSpawn(numTrials, here.maxTaskPar);
   t.stop();
 
   if printTimings {

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.compopts
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.compopts
@@ -1,0 +1,1 @@
+ompTaskSpawn.h

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfcompopts
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfcompopts
@@ -1,0 +1,1 @@
+--ccflags -fopenmp --ldflags -fopenmp ompTaskSpawn.h

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfexecenv
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfexecenv
@@ -1,0 +1,2 @@
+# need to let openmp do its own pinning without interference from qthreads
+QT_AFFINITY=no

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfkeys
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.perfkeys
@@ -1,0 +1,1 @@
+Elapsed time:

--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.skipif
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.skipif
@@ -1,0 +1,2 @@
+# cce optimizes away the loop entirely resulting in a no-op test
+CHPL_TARGET_COMPILER=cray-prgenv-cray

--- a/test/parallel/taskCompare/elliot/ompTaskSpawn.h
+++ b/test/parallel/taskCompare/elliot/ompTaskSpawn.h
@@ -1,0 +1,12 @@
+#include <omp.h>
+#include <stdint.h>
+
+static void ompTaskSpawn(int64_t trials, int64_t numTasks) {
+  int i, j;
+  omp_set_num_threads(numTasks);
+
+  for (i=0; i<trials; i++) {
+    #pragma omp parallel for
+    for (j=0; j<numTasks; j++) { }
+  }
+}

--- a/test/parallel/taskCompare/elliot/taskSpawn.graph
+++ b/test/parallel/taskCompare/elliot/taskSpawn.graph
@@ -1,5 +1,5 @@
-perfkeys: Elapsed time:, Elapsed time:, Elapsed time:
-graphkeys: forall, coforall, for+begin
-files: empty-forall.dat, empty-coforall.dat, empty-for+begin.dat
+perfkeys: Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:
+graphkeys: forall, coforall, for+begin, omp parallel-for
+files: empty-forall.dat, empty-coforall.dat, empty-for+begin.dat, empty-omp-parallel-for.dat
 graphtitle: Empty Task Spawn Timings (500,000 x maxTaskPar)
 ylabel: Time (seconds)


### PR DESCRIPTION
Add an OpenMP comparison to the task spawning suite. This is the OpenMP
equivalent of our forall version. We call an extern proc instead of just using
a test.c because this allows the test to work with launchers, use the same
number of tasks, and use the same timers.

On chapcs, the OpenMP version is roughly 7 time faster (~3s vs. ~21s) right now
