### PR TITLE
Test a hybrid spin/condwait scheme for nemesis scheduler in perf playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,11 +9,15 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test perf of qthreads distrib scheduler compared to nemesis
-export CHPL_QTHREAD_SCHEDULER=distrib
+# Test performance hybrid spin/condwait scheme
+GITHUB_USER=ronawho
+GITHUB_BRANCH=qthreads-hybrid-spin-condwait
+SHORT_NAME=taskSpawn
+START_DATE=11/18/16
 
-SHORT_NAME=distrib
-START_DATE=10/27/16
+git branch -D $GITHUB_USER-$GITHUB_BRANCH
+git checkout -b $GITHUB_USER-$GITHUB_BRANCH
+git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"


### PR DESCRIPTION
--enable-condwait-queue controls whether idle workers spin wait or do a
condwait while waiting for new tasks. Pure spinwaiting kills single threaded
performance because idle threads pound the cpu nonstop, but pure condwait
increases task startup. Using spinwait seems to dramatically improve our empty
task startup test (from ~21s to ~6s) and it seems to have a big impact on
parallel LCALS kernels too , which indicates a lot of time is being spent in
task startup.

Here we try a simple hybrid approach where we spin QT_NUM_SPINS_BEFORE_CONDWAIT
(default 100,000) iterations before going to condwait. This is a simple
approach to start experimenting with. Longer term, we probably want some sort
of adaptive hybrid spin/condwait approach that changes the amount of spinning
based on the task spawning behavior. We can probably look at openmp
implementations for inspiration.