### PR TITLE
Try out a hybrid spin/condwait approach for the nemesis scheduler

### DIFF
--- a/third-party/qthread/qthread-src/src/threadqueues/nemesis_threadqueues.c
+++ b/third-party/qthread/qthread-src/src/threadqueues/nemesis_threadqueues.c
@@ -18,6 +18,7 @@
 #include "qt_asserts.h"
 #include "qt_prefetch.h"
 #include "qt_threadqueues.h"
+#include "qt_envariables.h"
 #include "qt_qthread_struct.h"
 #include "qt_debug.h"
 #ifdef QTHREAD_USE_EUREKAS
@@ -30,6 +31,8 @@
  * http://www.mcs.anl.gov/~buntinas/papers/ccgrid06-nemesis.pdf
  * Note: it is NOT SAFE to use with multiple de-queuers, it is ONLY safe to use
  * with multiple enqueuers and a single de-queuer. */
+
+int num_spins_before_condwait;
 
 /* Data Structures */
 struct _qt_threadqueue_node {
@@ -84,6 +87,9 @@ static void qt_threadqueue_subsystem_shutdown(void)
 
 void INTERNAL qt_threadqueue_subsystem_init(void)
 {   /*{{{*/
+
+    num_spins_before_condwait = qt_internal_get_env_num("NUM_SPINS_BEFORE_CONDWAIT", 100000, 0);
+
     generic_threadqueue_pools.queues = qt_mpool_create(sizeof(qt_threadqueue_t));
     generic_threadqueue_pools.nodes  = qt_mpool_create_aligned(sizeof(qt_threadqueue_node_t), 8);
     qthread_internal_cleanup(qt_threadqueue_subsystem_shutdown);
@@ -352,6 +358,7 @@ qthread_t INTERNAL *qt_scheduler_get_thread(qt_threadqueue_t         *q,
                                             qt_threadqueue_private_t *QUNUSED(qc),
                                             uint_fast8_t              QUNUSED(active))
 {                                      /*{{{ */
+    int i;
 #ifdef QTHREAD_USE_EUREKAS
     qt_eureka_disable();
 #endif /* QTHREAD_USE_EUREKAS */
@@ -366,6 +373,10 @@ qthread_t INTERNAL *qt_scheduler_get_thread(qt_threadqueue_t         *q,
 #ifdef QTHREAD_USE_EUREKAS
         qt_eureka_check(0);
 #endif /* QTHREAD_USE_EUREKAS */
+        for (i= num_spins_before_condwait; q->q.shadow_head == NULL && q->q.head == NULL && i > 0; i--) {
+            SPINLOCK_BODY();
+        }
+
         while (q->q.shadow_head == NULL && q->q.head == NULL) {
 #ifndef QTHREAD_CONDWAIT_BLOCKING_QUEUE
             SPINLOCK_BODY();


### PR DESCRIPTION
--enable-condwait-queue controls whether idle workers spin wait or do a
condwait while waiting for new tasks. Pure spinwaiting kills single threaded
performance because idle threads pound the cpu nonstop, but pure condwait
increases task startup. Using spinwait seems to dramatically improve our empty
task startup test (from ~21s to ~6s) and it seems to have a big impact on
parallel LCALS kernels too , which indicates a lot of time is being spent in
task startup.

Here we try a simple hybrid approach where we spin QT_NUM_SPINS_BEFORE_CONDWAIT
(default 10,000) iterations before going to condwait. This is a simple approach
to start experimenting with. Longer term, we probably want some sort of
adaptive hybrid spin/condwait approach that changes the amount of spinning
based on the task spawn behavior. We can probably look at openmp
implementations for inspiration.