### PR TITLE
Update assign-param-segfault future with new error message.

### DIFF
--- a/test/classes/constructors/assign-param-segfault.bad
+++ b/test/classes/constructors/assign-param-segfault.bad
@@ -1,8 +1,3 @@
 assign-param-segfault.chpl:6: In initializer 'Bar':
-assign-param-segfault.chpl:11: internal error: EXP0492 chpl Version 1.12.0.223383c
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+assign-param-segfault.chpl:10: error: illegal lvalue in assignment
+assign-param-segfault.chpl:10: error: parameter set multiple times

--- a/test/classes/constructors/assign-param-segfault.future
+++ b/test/classes/constructors/assign-param-segfault.future
@@ -1,4 +1,9 @@
-bug: assigning param member causes segfault
+bug: assigning param member triggers compiler error about multiple assignments to param
+
+This program used to segfault until a compiler error was added for multiple
+assignments to a param. If this behavior is still illegal within constructors,
+a more descriptive compiler error would be nice. Here's the original
+description of the segfault behavior, in case it's still useful:
 
 For some reason, assigning the param 'foo' member in its constructor
 causes a segfault rather than a useful error message.  Strangely,


### PR DESCRIPTION
PR #4876 changed the failure mode for this future, so the .bad file needed to be updated. I'm not sure if this is the intended error message, or if we expect this program to be valid, so I'll leave it as a bug for now.