### PR TITLE
Add a raw qthreads variant of the task spawning perf test

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.chpl
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.chpl
@@ -1,0 +1,18 @@
+use Time;
+
+config const numTrials = 100;
+config const printTimings = false;
+
+extern proc qtChplLikeTaskSpawn(trials, numTasks);
+
+proc main() {
+  var t: Timer;
+
+  t.start();
+  qtChplLikeTaskSpawn(numTrials, here.maxTaskPar);
+  t.stop();
+
+  if printTimings {
+    writeln("Elapsed time: ", t.elapsed());
+  }
+}

--- a/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.compopts
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.compopts
@@ -1,0 +1,1 @@
+qtTaskSpawn.h

--- a/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.perfcompopts
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.perfcompopts
@@ -1,0 +1,1 @@
+qtTaskSpawn.h

--- a/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.perfkeys
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.perfkeys
@@ -1,0 +1,1 @@
+Elapsed time:

--- a/test/parallel/taskCompare/elliot/qtTaskSpawn.h
+++ b/test/parallel/taskCompare/elliot/qtTaskSpawn.h
@@ -1,0 +1,45 @@
+#include <stdint.h>
+
+#include "qthread/qthread.h"
+#include <qthread/qloop.h>
+
+#include "chpl-atomics.h"
+
+// 
+// Spawn and wait for tasks similar to how Chapel does (fork per task, and
+// an atomic counter for task counting.)
+//
+static aligned_t decTask(void* arg) {
+  atomic_fetch_sub_int_least64_t((atomic_int_least64_t*)arg, 1);
+  return 0;
+}
+static void qtChplLikeTaskSpawn(int64_t trials, int64_t numTasks) {
+  int i, j;
+
+  atomic_int_least64_t runningTasks = 0;
+  int counter = 0;
+  for (i=0; i<trials; i++) {
+    for (j=0; j<numTasks; j++) {
+      atomic_fetch_add_int_least64_t(&runningTasks, 1);
+      qthread_fork(decTask, (void*)(&runningTasks), NULL);
+    }
+    while (atomic_load_int_least64_t(&runningTasks)) { qthread_yield(); }
+  }
+}
+
+//
+// Currently unused: 
+//
+// Spawn with qt_loop (or consider qt_loop_dc, qt_loop_sinc, qt_loop_sv, or
+// qt_loop_aligned variants, which change how task completion is tracked using
+// donecount, sinc_t, syncvar_t, and aligned_t respectively. These all seem to
+// be much slower than the atomic counter we use.)
+//
+static void emptyFunction(size_t start, size_t stop, void* arg) { }
+static void qtLoopTaskSpawn(int64_t trials, int64_t numTasks) {
+  int i;
+  for (i=0; i<trials; i++) {
+    qt_loop(0, numTasks, emptyFunction, NULL);
+  }
+}
+

--- a/test/parallel/taskCompare/elliot/taskSpawn.graph
+++ b/test/parallel/taskCompare/elliot/taskSpawn.graph
@@ -1,5 +1,5 @@
-perfkeys: Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:
-graphkeys: forall, coforall, for+begin, omp parallel-for
-files: empty-forall.dat, empty-coforall.dat, empty-for+begin.dat, empty-omp-parallel-for.dat
+perfkeys: Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:
+graphkeys: forall, coforall, for+begin, omp parallel-for, chpl-like qthreads
+files: empty-forall.dat, empty-coforall.dat, empty-for+begin.dat, empty-omp-parallel-for.dat, empty-qthreads-chpl-like.dat
 graphtitle: Empty Task Spawn Timings (500,000 x maxTaskPar)
 ylabel: Time (seconds)


### PR DESCRIPTION
This is a raw qthreads version that mimics how Chapel spawns and waits for
tasks (qt_fork per task + an atomic counter)

Happily this version is competitive with the OpenMP variant on chapcs00: 3.2s
vs 3.1s. This indicates that qthreads itself doesn't have much overhead
compared to OpenMP, so we should be able to get our task spawning times to
match OpenMP with some work on our end. Note that the 3.2s requires using
spinwaiting. With condwait, the timing is more like 16s.