### PR TITLE
Skip OpenMP task spawn test for clang

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-omp-parallel-for.skipif
+++ b/test/parallel/taskCompare/elliot/empty-omp-parallel-for.skipif
@@ -1,2 +1,4 @@
 # cce optimizes away the loop entirely resulting in a no-op test
 CHPL_TARGET_COMPILER==cray-prgenv-cray
+# older versions of clang don't support openmp
+CHPL_TARGET_COMPILER==clang


### PR DESCRIPTION
Earlier versions of clang don't have openmp support. clang 3.8 on chapcs
supports openmp, but fails to statically link in libomp so perf testing fails