### PR TITLE
Skip native qthreads spawn test if we're not using qthreads

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.skipif
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-chpl-like.skipif
@@ -1,0 +1,1 @@
+CHPL_TASKS!=qthreads


### PR DESCRIPTION
Whoops, stupid of me to have missed this before