### PR TITLE
Add performance runs over more sizes for the NAS Parallel Benchmark MG

### DIFF
--- a/test/users/npadmana/npb-mg/mg.graph
+++ b/test/users/npadmana/npb-mg/mg.graph
@@ -1,4 +1,18 @@
 perfkeys: Elapsed time (seconds):
+files: npb-mg-s.dat
+graphkeys: Class S
+graphtitle: NPB MG
+ylabel: Time (seconds)
+graphname: npb-mg-size-s
+
+perfkeys: Elapsed time (seconds):
+files: npb-mg-a.dat
+graphkeys: Class A
+graphtitle: NPB MG
+ylabel: Time (seconds)
+graphname: npb-mg-size-a
+
+perfkeys: Elapsed time (seconds):
 files: npb-mg-b.dat
 graphkeys: Class B
 graphtitle: NPB MG

--- a/test/users/npadmana/npb-mg/mg.perfexecopts
+++ b/test/users/npadmana/npb-mg/mg.perfexecopts
@@ -1,1 +1,3 @@
+--NPBClass=NPB.S # npb-mg-s
+--NPBClass=NPB.A # npb-mg-a
 --NPBClass=NPB.B # npb-mg-b


### PR DESCRIPTION
Prior to this change, we were only performing performance runs over size B of
the NAS Parallel Benchmark MG implementation.  Since the smaller sizes are not
very expensive and we run them for the other NAS Parallel Benchmarks, add
performance runs for size S and A as well.

I chose not to add runs for size C yet, as it runs out of memory on one of our
oldest performance testing boxes, and takes more than an hour to complete on
another of our oldest performance testing boxes.  It completes fairly quickly on
chap04, though, so we might want to consider running it everywhere except those
older boxes.

Note that other NPB implementations include a size W in between size S and A.
This implementation does not currently support size W, or sizes D and E.  I took
a brief look at adding size W, but concluded it was more than a
Five-Minute-Fix (tm), so tabled that action for now.

ok'ed by @benharsh via chat, tested locally, otherwise trivial