### PR TITLE
Don't spinwait as much when qthreads is oversubscribed

### DIFF
--- a/third-party/qthread/qthread-src/src/threadqueues/nemesis_threadqueues.c
+++ b/third-party/qthread/qthread-src/src/threadqueues/nemesis_threadqueues.c
@@ -88,7 +88,11 @@ static void qt_threadqueue_subsystem_shutdown(void)
 void INTERNAL qt_threadqueue_subsystem_init(void)
 {   /*{{{*/
 
+#ifdef QTHREAD_OVERSUBSCRIPTION
+    num_spins_before_condwait = qt_internal_get_env_num("SPINCOUNT", 300, 0);
+#else
     num_spins_before_condwait = qt_internal_get_env_num("SPINCOUNT", 300000, 0);
+#endif
 
     generic_threadqueue_pools.queues = qt_mpool_create(sizeof(qt_threadqueue_t));
     generic_threadqueue_pools.nodes  = qt_mpool_create_aligned(sizeof(qt_threadqueue_node_t), 8);


### PR DESCRIPTION
spinwaiting can lead to timeouts when we're oversubscribed (gasnet testing), so
limit the number of spins we do when qthreads is configured for
oversubscription.