### PR TITLE
Add annotation for hybrid spin/condwait (#4902)

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -201,6 +201,8 @@ all:
   11/08/16:
     - text: RVF arrays in records (#4821)
       config: 16 node XC
+  11/27/16:
+    - Use hybrid spin/condwait (#4902)
 
 
 AllCompTime:


### PR DESCRIPTION
Some awesome perf improvements for [single locale](http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/11/12&enddate=2016/11/28&graphs=ssca2kernels23scale8,ssca2kernel4scale8,ssca2graphconstructionscale8,lcalsrawlong,lcalsrawompshort,lcalsrawompmedium,lcalsrawomplong,ssca2scale8,luleshrelease,hpcchplperformancegflops,ssca2kernel4tepsscale8,luleshbradcstudyversion,minimdljsize10time,synchp2p,nasparallelbenchmarkscgtimingssizes,nasparallelbenchmarkscgtimingssizew,nasparallelbenchmarksfttimingssizes,nasparallelbenchmarksfttimingssizew,nasparallelbenchmarksfttimingssizea,npbmg,npbmg,npbmg,2darrayassignment256x256,dgemmperformance128x128,2darrayassignment1024x1024,2dnonlocalarrayassignment1024x1024,arrayinitialization,emptytaskspawntimings500000xmaxtaskpar,hpcchpltime,reductionstimesec,timetobuildtrees) and some modest improvements for [multi-locale](http://chapel.sourceforge.net/perf/16-node-xc/?startdate=2016/10/11&enddate=2016/11/26&graphs=hpccfftperfgflopsn220,hpcchplreleaseperfgflopsn255nb32,hpccraonperfgupsn233nu10m,doeluleshdensetimesecsedov15oct,doeminimdtimesecsize20,reductionstimesec)