### PR TITLE
Fix graph title for new MG graphs

### DIFF
--- a/test/users/npadmana/npb-mg/mg.graph
+++ b/test/users/npadmana/npb-mg/mg.graph
@@ -1,20 +1,17 @@
 perfkeys: Elapsed time (seconds):
 files: npb-mg-s.dat
 graphkeys: Class S
-graphtitle: NPB MG
+graphtitle: NPB MG Size S
 ylabel: Time (seconds)
-graphname: npb-mg-size-s
 
 perfkeys: Elapsed time (seconds):
 files: npb-mg-a.dat
 graphkeys: Class A
-graphtitle: NPB MG
+graphtitle: NPB MG Size A
 ylabel: Time (seconds)
-graphname: npb-mg-size-a
 
 perfkeys: Elapsed time (seconds):
 files: npb-mg-b.dat
 graphkeys: Class B
-graphtitle: NPB MG
+graphtitle: NPB MG Size B
 ylabel: Time (seconds)
-graphname: npb-mg


### PR DESCRIPTION
They were otherwise indistinguishable.  Thanks @ronawho!

Verified that this change resulted in a different url per graph when selected.