### PR TITLE
Fix third-party gasnet package dependence flaw.

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -105,10 +105,10 @@ gasnet-config: FORCE
 	$(XTRA_CONFIG_COMMAND)
 	cd $(GASNET_BUILD_DIR) && $(CHPL_GASNET_ENV_VARS) $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT) --prefix=$(GASNET_INSTALL_DIR) $(CHPL_GASNET_CFG_OPTIONS) --disable-seq --enable-par --disable-parsync $(CHPL_GASNET_CFG_OPTIONS)
 
-gasnet-build: FORCE
+gasnet-build: gasnet-config
 	cd $(GASNET_BUILD_DIR) && $(MAKE) all
 
-gasnet-install: FORCE
+gasnet-install: gasnet-build
 	cd $(GASNET_BUILD_DIR) && $(MAKE) install
 	$(XTRA_POST_INSTALL_COMMAND)
 
@@ -121,8 +121,6 @@ gasnet-install: FORCE
 post-install: FORCE
 	$(foreach mkfile, $(MKFILES), sed -i -e "s;$(GASNET_INSTALL_DIR);"'$$(GASNET_INSTALL_DIR);g' $(mkfile) &&) true
 
-gasnet: gasnet-config gasnet-build gasnet-install
+gasnet: gasnet-install
 
 FORCE:
-
-.NOTPARALLEL:

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -105,8 +105,10 @@ gasnet-config: FORCE
 	$(XTRA_CONFIG_COMMAND)
 	cd $(GASNET_BUILD_DIR) && $(CHPL_GASNET_ENV_VARS) $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT) --prefix=$(GASNET_INSTALL_DIR) $(CHPL_GASNET_CFG_OPTIONS) --disable-seq --enable-par --disable-parsync $(CHPL_GASNET_CFG_OPTIONS)
 
+# Temporarily force serial sub-make here, to avoid a file manipulation
+# race that empties gasnet_config.h.
 gasnet-build: gasnet-config
-	cd $(GASNET_BUILD_DIR) && $(MAKE) all
+	cd $(GASNET_BUILD_DIR) && $(MAKE) -j1 all
 
 gasnet-install: gasnet-build
 	cd $(GASNET_BUILD_DIR) && $(MAKE) install
@@ -124,5 +126,3 @@ post-install: FORCE
 gasnet: gasnet-install
 
 FORCE:
-
-.NOTPARALLEL:

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -124,3 +124,5 @@ post-install: FORCE
 gasnet: gasnet-install
 
 FORCE:
+
+.NOTPARALLEL:

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -105,8 +105,11 @@ gasnet-config: FORCE
 	$(XTRA_CONFIG_COMMAND)
 	cd $(GASNET_BUILD_DIR) && $(CHPL_GASNET_ENV_VARS) $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT) --prefix=$(GASNET_INSTALL_DIR) $(CHPL_GASNET_CFG_OPTIONS) --disable-seq --enable-par --disable-parsync $(CHPL_GASNET_CFG_OPTIONS)
 
-# Temporarily force serial sub-make here, to avoid a file manipulation
-# race that empties gasnet_config.h.
+#
+# Force serial make using -j1, to avoid the problem documented by
+#     https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=3389
+# which can corrupt gasnet_config.h.
+#
 gasnet-build: gasnet-config
 	cd $(GASNET_BUILD_DIR) && $(MAKE) -j1 all
 
@@ -126,3 +129,5 @@ post-install: FORCE
 gasnet: gasnet-install
 
 FORCE:
+
+.NOTPARALLEL:


### PR DESCRIPTION
The 'build' target needs to depend on the 'config' target, and the
'install' target on 'build'.  Otherwise, we can get ahead of ourselves
in parallel makes.  However, with those dependences added we can
re-enable parallelism.