### PR TITLE
Retire 'noRefCount'

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -37,35 +37,6 @@ To characterize Chapel performance, generally speaking...
   assignments are used to move chunks of data between locales.
 
 
-Experimental flags for improving performance
---------------------------------------------
-Our current implementation supports the following config param-based
-flags, which are intended to provide a preview of performance
-improvements that we are working on delivering automatically in
-upcoming releases.  Both are available for use "at your own risk" in
-that they are not guaranteed to maintain program correctness (detailed
-after the flag's description).
-
-* chpl -snoRefCount ...
-
-  At present, Chapel reference counts arrays, domains, and domain maps
-  in a manner that is far too conservative.  This can add unnecessary
-  overhead, particularly when passing such variables between functions.  
-
-  This flag turns off such reference counting, but also results in
-  leaking all arrays, domains, and domain maps.  For programs that
-  only use global arrays, domains, and domain maps, this is unlikely
-  to be an issue, but for programs with local arrays, domains, and
-  domain maps, the resulting memory leaks may prevent the program from
-  running correctly.
-
-  We are currently evaluating changes to the implementation and
-  language definition that would reduce (or eliminate) the amount of
-  reference counting required by Chapel programs without introducing
-  these memory leaks.  Once these changes are complete, this flag will
-  be retired.
-
-
 Tracking Chapel Performance
 ---------------------------
 We are currently working to improve Chapel performance with each

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -29,11 +29,6 @@ module ChapelBase {
   // Is the cache for remote data enabled at compile time?
   config param CHPL_CACHE_REMOTE: bool = false;
 
-  // TODO -- remove this param, it is no longer used.
-  // That will require updating tests that throw it, especially
-  // performance tests.
-  config param noRefCount = false;
-
   config param warnMaximalRange = false;    // Warns if integer rollover will cause
                                             // the iterator to yield zero times.
   proc _throwOpError(param op: string) {

--- a/test/release/examples/benchmarks/miniMD/explicit/miniMD.perfcompopts
+++ b/test/release/examples/benchmarks/miniMD/explicit/miniMD.perfcompopts
@@ -1,1 +1,1 @@
--snoRefCount -M helpers --no-local # miniMD.explicit.perfkeys
+-M helpers --no-local # miniMD.explicit.perfkeys

--- a/test/release/examples/benchmarks/miniMD/miniMD.perfcompopts
+++ b/test/release/examples/benchmarks/miniMD/miniMD.perfcompopts
@@ -1,4 +1,4 @@
--snoRefCount -M helpers -sdisableAliasedBulkTransfer=false # miniMD.simple.perfkeys
--snoRefCount -M helpers -sdisableAliasedBulkTransfer=false --no-local  # miniMD.simple-nolocal.perfkeys
--snoRefCount -M helpers -sdisableAliasedBulkTransfer=false --no-local -suseBlockDist=true # miniMD.simple-block.perfkeys
--snoRefCount -M helpers -suseStencilDist=true -sdefaultDoRADOpt=false -sdisableAliasedBulkTransfer=false --no-local # miniMD.stencil.perfkeys
+-M helpers -sdisableAliasedBulkTransfer=false # miniMD.simple.perfkeys
+-M helpers -sdisableAliasedBulkTransfer=false --no-local  # miniMD.simple-nolocal.perfkeys
+-M helpers -sdisableAliasedBulkTransfer=false --no-local -suseBlockDist=true # miniMD.simple-block.perfkeys
+-M helpers -suseStencilDist=true -sdefaultDoRADOpt=false -sdisableAliasedBulkTransfer=false --no-local # miniMD.stencil.perfkeys

--- a/test/studies/hpcc/HPL/vass/bug.future
+++ b/test/studies/hpcc/HPL/vass/bug.future
@@ -4,8 +4,7 @@ To be investigated. This is what is known so far:
 
 This runs OK with
 * CHPL_COMM=none, or
-* --no-local, or
-* -s noRefCount=true.
+* --no-local.
 
 With CHPL_COMM=gasnet I get this output:
 

--- a/test/studies/lulesh/bradc/lulesh-dense.perfcompopts
+++ b/test/studies/lulesh/bradc/lulesh-dense.perfcompopts
@@ -1,1 +1,1 @@
--snoRefCount=true -suseBlockDist --no-local -M../../../release/examples/benchmarks/lulesh
+-suseBlockDist --no-local -M../../../release/examples/benchmarks/lulesh


### PR DESCRIPTION
I was running some testing and needed a 10-minute task, so took
this stab at retiring 'noRefCount'.  Removed the config itself,
references to it in the test system and documentation.