### PR TITLE
GitHub Issues Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Bug Report
+<!--
+    If you are not submitting a bug report, ignore this template and see
+      http://Chapel-Issues-Best-Practices.com  (TODO)
+  -->
+### Summary of Problem
+
+
+### Steps to Reproduce
+
+**What behavior do you observe when encountering this issue?**
+
+**Please provide one of the following:**
+
+- Reduced program demonstrating issue *(preferred)*:
+- Original program demonstrating issue:
+- Description of how to recreate the issue *(last resort)*:
+
+**Please provide any of the following that are necessary to reproduce the issue:**
+
+- How to compile:
+- How to run:
+- Input files:
+- Helper modules:
+
+
+### General Information
+
+- `chpl --version`:
+- `$CHPL_HOME/util/printchplenv --anonymize`:
+- Back-end compiler version, e.g. `gcc --version` or `clang --version`:
+- *For Cray systems only*, output of `module list` :

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Bug Report
 <!--
 If you are filing an issue that is not a bug report, please feel free to erase
-this template and describe the issue as clearly as possible
+this template and describe the issue as clearly as possible.
 -->
 
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,23 +8,26 @@
 
 ### Steps to Reproduce
 
-**What behavior do you observe when encountering this issue?**
+**Behavior:**
+<!-- What behavior did you observe when encountering this issue?  -->
 
-**Please provide one of the following:**
+**Source Code:**
+<!-- Please provide source code that will reproduce the problem as an
+       attachment, an inline code block, or via a URL.  To the extent possible,
+       providing reduced reproducers of the problem will be appreciated. -->
 
-- Reduced program demonstrating issue *(preferred)*:
-- Original program demonstrating issue:
-- Description of how to recreate the issue *(last resort)*:
+```chapel
+// You can insert your code inline if it's not too long
+// Otherwise, you can attach it as a ZIP file or provide a URL to it
+```
 
-**Please provide any of the following that are necessary to reproduce the issue:**
+**Compile command:**
+<!-- e.g., `chpl foo.chpl -o foo` -->
 
-- How to compile:
-- How to run:
-- Input files:
-- Helper modules:
+**Execution command:**
+<!-- e.g., `./foo 42`. If an input file is required, include it as well. -->
 
-
-### General Information
+### Configuration Information
 
 - `chpl --version`:
 - `$CHPL_HOME/util/printchplenv --anonymize`:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,8 @@
 ## Bug Report
-<!-- If you are not submitting a bug report, erase this template -->
+<!--
+If you are filing an issue that is not a bug report, please feel free to erase
+this template and describe the issue as clearly as possible
+-->
 
 
 ### Summary of Problem
@@ -12,15 +15,13 @@ What behavior did you expect to observe?
 ### Steps to Reproduce
 
 **Source Code:**
-<!--
-Please provide source code that will reproduce the problem as an
-attachment, an inline code block, or via a URL.  To the extent possible,
-providing reduced reproducers of the problem will be appreciated.
--->
 
 ```chapel
-// You can insert your code inline if it's not too long
-// Otherwise, you can attach it as a file or provide a URL to it
+// Please provide source code that will reproduce the problem.
+// You can insert your code inline if it's not too long.
+// Otherwise, you can attach it as a file or provide a URL to it.
+// To the extent possible, providing simplified programs demonstrating the
+// problem will be appreciated.
 ```
 
 **Compile command:**
@@ -34,6 +35,6 @@ providing reduced reproducers of the problem will be appreciated.
 
 - Output of `chpl --version`:
 - Output of `$CHPL_HOME/util/printchplenv --anonymize`:
-- Back-end compiler and version:
+- Back-end compiler and version, e.g. `gcc --version` or `clang --version`:
 - (For Cray systems only) Output of `module list`:
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,18 +1,15 @@
 ## Bug Report
-<!--
-If you are not submitting a bug report, ignore this template and see
-http://chapel.cray.com/docs/master/usingchapel/bugs.html
--->
+<!-- If you are not submitting a bug report, erase this template -->
+
+
 ### Summary of Problem
-
-
-### Steps to Reproduce
-
-**Behavior:**
 <!--
 What behavior did you observe when encountering this issue?
 What behavior did you expect to observe?
 -->
+
+
+### Steps to Reproduce
 
 **Source Code:**
 <!--
@@ -27,10 +24,11 @@ providing reduced reproducers of the problem will be appreciated.
 ```
 
 **Compile command:**
-<!-- e.g., `chpl foo.chpl -o foo` -->
+<!-- e.g. `chpl foo.chpl -o foo` -->
 
 **Execution command:**
-<!-- e.g., `./foo 42`. If an input file is required, include it as well. -->
+<!-- e.g. `./foo 42`. If an input file is required, include it as well. -->
+
 
 ### Configuration Information
 
@@ -38,3 +36,4 @@ providing reduced reproducers of the problem will be appreciated.
 - Output of `$CHPL_HOME/util/printchplenv --anonymize`:
 - Back-end compiler and version:
 - (For Cray systems only) Output of `module list`:
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,24 +1,29 @@
 ## Bug Report
 <!--
-    If you are not submitting a bug report, ignore this template and see
-      http://Chapel-Issues-Best-Practices.com  (TODO)
-  -->
+If you are not submitting a bug report, ignore this template and see
+http://chapel.cray.com/docs/master/usingchapel/bugs.html
+-->
 ### Summary of Problem
 
 
 ### Steps to Reproduce
 
 **Behavior:**
-<!-- What behavior did you observe when encountering this issue?  -->
+<!--
+What behavior did you observe when encountering this issue?
+What behavior did you expect to observe?
+-->
 
 **Source Code:**
-<!-- Please provide source code that will reproduce the problem as an
-       attachment, an inline code block, or via a URL.  To the extent possible,
-       providing reduced reproducers of the problem will be appreciated. -->
+<!--
+Please provide source code that will reproduce the problem as an
+attachment, an inline code block, or via a URL.  To the extent possible,
+providing reduced reproducers of the problem will be appreciated.
+-->
 
 ```chapel
 // You can insert your code inline if it's not too long
-// Otherwise, you can attach it as a ZIP file or provide a URL to it
+// Otherwise, you can attach it as a file or provide a URL to it
 ```
 
 **Compile command:**
@@ -29,7 +34,7 @@
 
 ### Configuration Information
 
-- `chpl --version`:
-- `$CHPL_HOME/util/printchplenv --anonymize`:
-- Back-end compiler version, e.g. `gcc --version` or `clang --version`:
-- *For Cray systems only*, output of `module list` :
+- Output of `chpl --version`:
+- Output of `$CHPL_HOME/util/printchplenv --anonymize`:
+- Back-end compiler and version:
+- (For Cray systems only) Output of `module list`:


### PR DESCRIPTION
With Chapel moving to GitHub Issues for issue-tracking, we're going to need an `ISSUE_TEMPLATE.md`. Here is my first stab at this.
