### PR TITLE
TryStmt, without the parser hooks

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -522,6 +522,24 @@ bool AstDump::enterGotoStmt(GotoStmt* node) {
 }
 
 //
+// TryStmt
+//
+bool AstDump::enterTryStmt(TryStmt* node) {
+  newline();
+  write("Try");
+  newline();
+  write("{");
+  ++mIndent;
+  return true;
+}
+
+void AstDump::exitTryStmt(TryStmt* node) {
+  --mIndent;
+  newline();
+  write("}");
+}
+
+//
 // Helper functions
 //
 

--- a/compiler/AST/AstLogger.cpp
+++ b/compiler/AST/AstLogger.cpp
@@ -182,6 +182,13 @@ bool AstLogger::enterGotoStmt(GotoStmt* node) {
 void AstLogger::exitGotoStmt(GotoStmt* node) {
 }
 
+bool AstLogger::enterTryStmt(TryStmt* node) {
+  return true;
+}
+
+void AstLogger::exitTryStmt(TryStmt* node) {
+}
+
 bool AstLogger::outputVector(FILE* mFP, std::vector<const char *> vec) {
   bool first = true;
   for_vector(const char, str, vec) {

--- a/compiler/AST/AstVisitorTraverse.cpp
+++ b/compiler/AST/AstVisitorTraverse.cpp
@@ -252,3 +252,13 @@ void AstVisitorTraverse::exitGotoStmt(GotoStmt* node)
 {
 
 }
+
+bool AstVisitorTraverse::enterTryStmt(TryStmt* node)
+{
+  return true;
+}
+
+void AstVisitorTraverse::exitTryStmt(TryStmt* node)
+{
+
+}

--- a/compiler/AST/CollapseBlocks.cpp
+++ b/compiler/AST/CollapseBlocks.cpp
@@ -381,3 +381,13 @@ void CollapseBlocks::exitGotoStmt(GotoStmt* node)
 {
 
 }
+
+bool CollapseBlocks::enterTryStmt(TryStmt* node)
+{
+  return true;
+}
+
+void CollapseBlocks::exitTryStmt(TryStmt* node)
+{
+
+}

--- a/compiler/AST/Makefile.share
+++ b/compiler/AST/Makefile.share
@@ -30,6 +30,7 @@ AST_SRCS =                                          \
            primitive.cpp                            \
            stmt.cpp                                 \
            symbol.cpp                               \
+           TryStmt.cpp                              \
            type.cpp                                 \
            view.cpp                                 \
                                                     \

--- a/compiler/AST/TryStmt.cpp
+++ b/compiler/AST/TryStmt.cpp
@@ -22,14 +22,14 @@
  
 TryStmt::TryStmt(bool _tryBang, BlockStmt* _body) : Stmt(E_TryStmt) {
   tryBang = _tryBang;
-  body = _body; 
+  body    = _body; 
 }
 
 TryStmt::~TryStmt() {
 
 }
 
-BlockStmt* TryStmt::getBody() {
+BlockStmt* TryStmt::getBody() const {
   return body;
 }
 

--- a/compiler/AST/TryStmt.cpp
+++ b/compiler/AST/TryStmt.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TryStmt.h"
+ 
+TryStmt::TryStmt(bool _tryBang, BlockStmt* _body) : Stmt(E_TryStmt) {
+  tryBang = _tryBang;
+  body = _body; 
+}
+
+TryStmt::~TryStmt() {
+
+}
+
+BlockStmt* TryStmt::getBody() {
+  return body;
+}
+
+void TryStmt::accept(AstVisitor* visitor) {
+  
+}
+
+Expr* TryStmt::copy(SymbolMap* map, bool internal) {
+  return NULL;
+}
+
+Expr* TryStmt::copyInner(SymbolMap* map) {
+  return NULL;
+}
+
+void TryStmt::replaceChild(Expr* old_ast, Expr* new_ast) {
+
+}
+
+Expr* TryStmt::getFirstChild() {
+  return body;
+}
+
+Expr* TryStmt::getFirstExpr() {
+  return body->getFirstExpr();
+}
+
+Expr* TryStmt::getNextExpr(Expr* expr) {
+  return this; 
+}
+
+GenRet TryStmt::codegen() {
+  return GenRet(0);
+}

--- a/compiler/AST/TryStmt.cpp
+++ b/compiler/AST/TryStmt.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "TryStmt.h"
+#include "AstVisitor.h"
  
 TryStmt::TryStmt(bool _tryBang, BlockStmt* _body) : Stmt(E_TryStmt) {
   tryBang = _tryBang;
@@ -33,7 +34,12 @@ BlockStmt* TryStmt::getBody() {
 }
 
 void TryStmt::accept(AstVisitor* visitor) {
-  
+  if (visitor->enterTryStmt(this)) {
+    if (body) {
+      body->accept(visitor);
+    }
+    visitor->exitTryStmt(this);
+  } 
 }
 
 Expr* TryStmt::copy(SymbolMap* map, bool internal) {

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -456,6 +456,10 @@ const char* BaseAST::astTagAsString() const {
       retval = "ExternBlockStmt";
       break;
 
+    case E_TryStmt:
+      retval = "TryStmt";
+      break;
+
     case E_ModuleSymbol:
       retval = "ModuleSymbol";
       break;

--- a/compiler/include/AstDump.h
+++ b/compiler/include/AstDump.h
@@ -96,6 +96,9 @@ public:
 
   virtual bool     enterGotoStmt    (GotoStmt*          node);
 
+  virtual bool     enterTryStmt     (TryStmt*           node);
+  virtual void     exitTryStmt      (TryStmt*           node);
+
 private:
                    AstDump();
 

--- a/compiler/include/AstLogger.h
+++ b/compiler/include/AstLogger.h
@@ -115,6 +115,9 @@ public:
   virtual bool   enterGotoStmt       (GotoStmt*          node);
   virtual void   exitGotoStmt        (GotoStmt*          node);
 
+  virtual bool   enterTryStmt        (TryStmt*           node);
+  virtual void   exitTryStmt         (TryStmt*           node);
+
 protected:
   bool outputVector (FILE* fp, std::vector<const char*> vec);
 

--- a/compiler/include/AstVisitor.h
+++ b/compiler/include/AstVisitor.h
@@ -50,6 +50,7 @@ class ParamForLoop;
 class ExternBlockStmt;
 class CondStmt;
 class GotoStmt;
+class TryStmt;
 
 class AstVisitor
 {
@@ -149,6 +150,9 @@ public:
 
   virtual bool   enterGotoStmt       (GotoStmt*          node) = 0;
   virtual void   exitGotoStmt        (GotoStmt*          node) = 0;
+
+  virtual bool   enterTryStmt        (TryStmt*           node) = 0;
+  virtual void   exitTryStmt         (TryStmt*           node) = 0;
 };
 
 #endif

--- a/compiler/include/AstVisitorTraverse.h
+++ b/compiler/include/AstVisitorTraverse.h
@@ -122,6 +122,9 @@ public:
 
   virtual bool   enterGotoStmt       (GotoStmt*          node);
   virtual void   exitGotoStmt        (GotoStmt*          node);
+
+  virtual bool   enterTryStmt        (TryStmt*           node);
+  virtual void   exitTryStmt         (TryStmt*           node);
 };
 
 #endif

--- a/compiler/include/CollapseBlocks.h
+++ b/compiler/include/CollapseBlocks.h
@@ -110,6 +110,9 @@ public:
 
   virtual bool   enterGotoStmt       (GotoStmt*          node);
   virtual void   exitGotoStmt        (GotoStmt*          node);
+
+  virtual bool   enterTryStmt        (TryStmt*           node);
+  virtual void   exitTryStmt         (TryStmt*           node);
 };
 
 #endif

--- a/compiler/include/TryStmt.h
+++ b/compiler/include/TryStmt.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _TRY_STMT_H_
+#define _TRY_STMT_H_
+
+#include <vector>
+
+#include "stmt.h"
+
+class TryStmt : public Stmt 
+{
+
+public:
+  TryStmt(bool tryBang, BlockStmt* body);
+  ~TryStmt();
+  BlockStmt* getBody();
+
+  void accept(AstVisitor* visitor);
+  Expr* copy(SymbolMap* map = NULL, bool internal = false);
+  Expr* copyInner(SymbolMap* map);
+  void replaceChild(Expr* old_ast, Expr* new_ast);
+  Expr* getFirstChild();
+  Expr* getFirstExpr();
+  Expr* getNextExpr(Expr* expr);
+  GenRet codegen();
+
+private:
+  bool tryBang;
+  BlockStmt* body;
+  TryStmt();
+
+};
+
+#endif

--- a/compiler/include/TryStmt.h
+++ b/compiler/include/TryStmt.h
@@ -20,29 +20,27 @@
 #ifndef _TRY_STMT_H_
 #define _TRY_STMT_H_
 
-#include <vector>
-
 #include "stmt.h"
 
 class TryStmt : public Stmt 
 {
 
 public:
-  TryStmt(bool tryBang, BlockStmt* body);
-  ~TryStmt();
-  BlockStmt* getBody();
+                TryStmt(bool tryBang, BlockStmt* body);
+                ~TryStmt();
+  BlockStmt*    getBody() const;
 
-  void accept(AstVisitor* visitor);
-  Expr* copy(SymbolMap* map = NULL, bool internal = false);
-  Expr* copyInner(SymbolMap* map);
-  void replaceChild(Expr* old_ast, Expr* new_ast);
-  Expr* getFirstChild();
-  Expr* getFirstExpr();
-  Expr* getNextExpr(Expr* expr);
-  GenRet codegen();
+  void          accept(AstVisitor* visitor);
+  Expr*         copy(SymbolMap* map = NULL, bool internal = false);
+  Expr*         copyInner(SymbolMap* map);
+  void          replaceChild(Expr* old_ast, Expr* new_ast);
+  Expr*         getFirstChild();
+  Expr*         getFirstExpr();
+  Expr*         getNextExpr(Expr* expr);
+  GenRet        codegen();
 
 private:
-  bool tryBang;
+  bool       tryBang;
   BlockStmt* body;
   TryStmt();
 

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -142,6 +142,7 @@ enum AstTag {
   E_ForallExpr,
   E_NamedExpr,
   E_UseStmt,
+  E_TryStmt,
   E_BlockStmt,
   E_CondStmt,
   E_GotoStmt,


### PR DESCRIPTION
@noakesmichael:

first commit:
- add `E_TryStmt` to `enum AstTag`
- `class TryStmt` (`.h`, `.cpp`), which extends `Stmt`
- updated `Makefile.share`

second commit:
- `AstVisitor` and subclasses: `enterTryStmt()` and `exitTryStmt()`
- `TryStmt`: properly implement `accept()`