### PR TITLE
Add an optimized qthreads task spawn test

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.chpl
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.chpl
@@ -3,16 +3,27 @@ use Time;
 config const numTrials = 100;
 config const printTimings = false;
 
-extern proc qtChplLikeTaskSpawn(trials, numTasks);
+enum TaskingMode {
+  qtChplLikeT, qtChplOptT
+};
+use TaskingMode;
+
+config param taskingMode = qtChplLikeT;
 
 proc main() {
   var t: Timer;
 
   t.start();
-  qtChplLikeTaskSpawn(numTrials, here.maxTaskPar);
+  select taskingMode {
+     when qtChplLikeT do qtChplLikeTaskSpawn(numTrials, here.maxTaskPar);
+     when qtChplOptT  do qtChplOptTaskSpawn (numTrials, here.maxTaskPar);
+  }
   t.stop();
 
   if printTimings {
     writeln("Elapsed time: ", t.elapsed());
   }
 }
+
+extern proc qtChplLikeTaskSpawn(trials, numTasks);
+extern proc qtChplOptTaskSpawn(trials, numTasks);

--- a/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.compopts
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.compopts
@@ -1,1 +1,2 @@
-qtTaskSpawn.h
+qtTaskSpawn.h -staskingMode=qtChplLikeT
+qtTaskSpawn.h -staskingMode=qtChplOptT

--- a/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.perfcompopts
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.perfcompopts
@@ -1,1 +1,2 @@
-qtTaskSpawn.h # empty-qthreads-chpl-like 
+qtTaskSpawn.h -staskingMode=qtChplLikeT # empty-qthreads-chpl-like
+qtTaskSpawn.h -staskingMode=qtChplOptT  # empty-qthreads-chpl-opt

--- a/test/parallel/taskCompare/elliot/qtTaskSpawn.h
+++ b/test/parallel/taskCompare/elliot/qtTaskSpawn.h
@@ -32,7 +32,7 @@ static void qtChplLikeTaskSpawn(int64_t trials, int64_t numTasks) {
 // Spawn and wait for tasks in a manner than an optimized chapel might (regular
 // non-copy fork, avoid EndCount allocation, increment atomic once instead of
 // once per task.)
-static void qtOptimizedChplSpawn(int64_t trials, int64_t numTasks) {
+static void qtChplOptTaskSpawn(int64_t trials, int64_t numTasks) {
   int i, j;
 
   for (i=0; i<trials; i++) {
@@ -41,7 +41,7 @@ static void qtOptimizedChplSpawn(int64_t trials, int64_t numTasks) {
     initEndCount(endCount);
     upEndCount(endCount, numTasks);
     for (j=0; j<numTasks; j++) {
-      qthread_fork_copyargs(decTask, &(endCount), sizeof(EndCount), NULL);
+      qthread_fork(decTask, &(endCount), NULL);
     }
     waitEndCount(endCount);
   }

--- a/test/parallel/taskCompare/elliot/taskSpawn.graph
+++ b/test/parallel/taskCompare/elliot/taskSpawn.graph
@@ -1,5 +1,5 @@
-perfkeys: Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:
-graphkeys: forall, coforall, for+begin, omp parallel-for, chpl-like qthreads
-files: empty-forall.dat, empty-coforall.dat, empty-for+begin.dat, empty-omp-parallel-for.dat, empty-qthreads-chpl-like.dat
+perfkeys: Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:
+graphkeys: forall, coforall, for+begin, omp parallel-for, chpl-like qthreads, chpl-opt qthreads
+files: empty-forall.dat, empty-coforall.dat, empty-for+begin.dat, empty-omp-parallel-for.dat, empty-qthreads-chpl-like.dat, empty-qthreads-chpl-opt.dat
 graphtitle: Empty Task Spawn Timings (500,000 x maxTaskPar)
 ylabel: Time (seconds)


### PR DESCRIPTION
Add an optimized qthreads variant that only increments the endcount once
instead of once per task, uses qthread_fork instead of qthread_fork_copyargs,
and uses a stack allocated EndCount instead of a heap allocated one.