### PR TITLE
Update bugs.rst for GitHub Issues + new privatebugs.rst

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,8 +34,7 @@ needs_sphinx = '1.3'
 extensions = [
     'sphinx.ext.todo',
     'sphinxcontrib.chapeldomain',
-    'sphinxcontrib.email',
-    'util.disguise'
+    'util.disguise',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,8 @@ needs_sphinx = '1.3'
 extensions = [
     'sphinx.ext.todo',
     'sphinxcontrib.chapeldomain',
+    'sphinxcontrib.email',
+    'util.disguise'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/usingchapel/bugs.rst
+++ b/doc/usingchapel/bugs.rst
@@ -13,8 +13,7 @@ See the :ref:`private issues <readme-privatebugs>` page for more details.
 
 
 Public issues that predate our issue tracker can be found on the (retired)
-`chapel-bugs mailing list archives`_ and ``$CHPL_HOME/STATUS`` file for bug
-reports that predate the usage of GitHub Issues.
+`chapel-bugs mailing list archives`_ and ``$CHPL_HOME/STATUS`` file.
 
 Futures
 -------

--- a/doc/usingchapel/bugs.rst
+++ b/doc/usingchapel/bugs.rst
@@ -1,53 +1,32 @@
 .. _readme-bugs:
 
-=====================
-Reporting Chapel Bugs
-=====================
+=======================
+Reporting Chapel Issues
+=======================
 
-If you encounter a bug, internal error, or unclear error message when
-using Chapel, please do not hesitate to send a bug report to the
-Chapel team.  Do so by sending mail to one of the following mailing
-lists:
+`GitHub Issues`_ are used to track public bug reports and feature requests for
+Chapel.
 
-  * chapel-bugs@lists.sourceforge.net : for bugs that are suitable for `public archive <https://sourceforge.net/p/chapel/mailman/chapel-bugs/>`_
-  * chapel_bugs@cray.com              : for bugs that the Chapel team at Cray Inc. should keep private
-
-Please include the following information in your email:
-
-  1. the version number of your Chapel compiler (``chpl --version``)
-  2. the output of the ``$CHPL_HOME/util/printchplenv --anonymize`` script
-  3. the back-end C compiler you are using and its version (e.g., ``gcc --version``)
-  4. the output of ``module list`` (if using a Cray system)
-  5. one of the following:
-
-     a) preferably, a reduced program demonstrating the issue
-     b) alternatively, the original program demonstrating the issue
-     c) as a last resort, a description of how to recreate the issue
-
-  6. any helper modules or input files required to reproduce the issue
-  7. a description of the behavior you are seeing
-
-A list of known bugs and unimplemented features can be found in
-``$CHPL_HOME/STATUS``.  Even if you run into a known issue, we
-encourage you to send us a bug report, particularly if it is impeding
-your progress.  Depending on the issue, we may be able to suggest a
-workaround or to prioritize the development of a fix.
+Private issues should be reported to chapel_bugs@cray.com.
+See the :ref:`private issues <readme-privatebugs>` page for more details.
 
 
-Filing Futures
---------------
 
-If you are a Chapel contributor and familiar with the `Chapel Testing
-System`_, you can file bugs by submitting `Future tests`_.
+Public issues that predate our issue tracker can be found on the (retired)
+`chapel-bugs mailing list archives`_ and ``$CHPL_HOME/STATUS`` file for bug
+reports that predate the usage of GitHub Issues.
 
+Futures
+-------
+
+Futures are tests in the code repository used by the Chapel team to track bugs
+and feature requests.
+
+If you are a Chapel contributor and are familiar with the
+`Chapel Testing System`_, you are encouraged to submit
+`future tests`_ in conjunction with your issues.
+
+.. _GitHub Issues: https://github.com/chapel-lang/chapel/issues
 .. _Chapel testing system: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst
-.. _Future tests: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst#user-content-futures-a-mechanism-for-tracking-bugs-feature-requests-etc
-
-
-JIRA Issues
------------
-
-The Chapel team is working to bring our `JIRA issues site`_ up to
-date. Bugs can be viewed without creating an account.
-
-.. _JIRA issues site: https://chapel.atlassian.net/projects/CHAPEL/issues/
+.. _future tests: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst#user-content-futures-a-mechanism-for-tracking-bugs-feature-requests-etc
+.. _chapel-bugs mailing list archives: https://sourceforge.net/p/chapel/mailman/chapel-bugs/

--- a/doc/usingchapel/bugs.rst
+++ b/doc/usingchapel/bugs.rst
@@ -8,7 +8,7 @@ Public Issues
 -------------
 
 Chapel uses `GitHub Issues`_ to track public issues. If you have a bug report,
-feature request, or other Chapel issue to report, please use the "New Issue"
+feature request, or other issue to report, please use the "New Issue"
 button on that page to file it.
 
 Public issues that predate our issue tracker can be found in the
@@ -18,7 +18,14 @@ Public issues that predate our issue tracker can be found in the
 Private Issues
 --------------
 
-Chapel accepts private issue reports :ref:`by email <readme-privatebugs>`.
+Chapel accepts private issue reports :any:`by email <privatebugs>`.
 
 .. _GitHub Issues: https://github.com/chapel-lang/chapel/issues
 .. _chapel-bugs mailing list archives: https://sourceforge.net/p/chapel/mailman/chapel-bugs/
+
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   privatebugs

--- a/doc/usingchapel/bugs.rst
+++ b/doc/usingchapel/bugs.rst
@@ -4,28 +4,21 @@
 Reporting Chapel Issues
 =======================
 
-`GitHub Issues`_ are used to track public bug reports and feature requests for
-Chapel.
+Public Issues
+-------------
 
-Private issues should be reported to chapel_bugs@cray.com.
-See the :ref:`private issues <readme-privatebugs>` page for more details.
+Chapel uses `GitHub Issues`_ to track public issues. If you have a bug report,
+feature request, or other Chapel issue to report, please use the "New Issue"
+button on that page to file it.
 
+Public issues that predate our issue tracker can be found in the
+``$CHPL_HOME/STATUS`` file and the (retired)
+`chapel-bugs mailing list archives`_.
 
+Private Issues
+--------------
 
-Public issues that predate our issue tracker can be found on the (retired)
-`chapel-bugs mailing list archives`_ and ``$CHPL_HOME/STATUS`` file.
-
-Futures
--------
-
-Futures are tests in the code repository used by the Chapel team to track bugs
-and feature requests.
-
-If you are a Chapel contributor and are familiar with the
-`Chapel Testing System`_, you are encouraged to submit
-`future tests`_ in conjunction with your issues.
+Chapel accepts private issue reports :ref:`by email <readme-privatebugs>`.
 
 .. _GitHub Issues: https://github.com/chapel-lang/chapel/issues
-.. _Chapel testing system: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst
-.. _future tests: https://github.com/chapel-lang/chapel/blob/master/doc/developer/bestPractices/TestSystem.rst#user-content-futures-a-mechanism-for-tracking-bugs-feature-requests-etc
 .. _chapel-bugs mailing list archives: https://sourceforge.net/p/chapel/mailman/chapel-bugs/

--- a/doc/usingchapel/index.rst
+++ b/doc/usingchapel/index.rst
@@ -20,3 +20,4 @@ Contents:
    tasks
    debugging
    bugs
+   privatebugs

--- a/doc/usingchapel/index.rst
+++ b/doc/usingchapel/index.rst
@@ -20,4 +20,3 @@ Contents:
    tasks
    debugging
    bugs
-   privatebugs

--- a/doc/usingchapel/privatebugs.rst
+++ b/doc/usingchapel/privatebugs.rst
@@ -4,9 +4,11 @@
 Private Issues Guidelines
 =========================
 
+If for any reason you are uncomfortable reporting your bug in a public setting,
+you may submit a private bug report.
+
 Private issues can be sent to the Cray Chapel team at:
 :disguise:`chapel_bugs@cray.com`
-
 
 When submitting a private bug report, please include the following information:
 

--- a/doc/usingchapel/privatebugs.rst
+++ b/doc/usingchapel/privatebugs.rst
@@ -24,7 +24,7 @@ When submitting a private bug report, please include the following information:
           problem will be appreciated.
         - If you are unable to submit code, please describe how to recreate the
           issue.
-    - How did you compile your program? e.g. ``chpl foo.chpl -o foo``
+    - **How did you compile your program? e.g.** ``chpl foo.chpl -o foo``
     - How did you execute your program? e.g. ``./foo 42``
         - If any input files are required, please include them as well.
 

--- a/doc/usingchapel/privatebugs.rst
+++ b/doc/usingchapel/privatebugs.rst
@@ -1,0 +1,35 @@
+.. _readme-privatebugs:
+
+===============================
+Reporting Private Chapel Issues
+===============================
+
+Private bug reports can be mailed directly to the Chapel team at Cray Inc.
+through chapel_bugs@cray.com
+
+When submitting a private bug report, please include the following information::
+
+    Summary of Problem
+    ------------------
+
+    - What behavior did you observe when encountering this issue?
+    - What behavior did you expect to observe?
+
+    Steps to Reproduce
+    ------------------
+
+    - Please attach source code that will reproduce the problem.
+      - To the extent possible, providing simplified programs demonstrating the
+        problem will be appreciated.
+      - If you are unable to do this, please describe how to recreate the issue.
+    - How did you compile your program?
+    - How did you execute your program?
+      - If any input files are required, please include them as well.
+
+    Configuration Information
+    -------------------------
+
+    - Output of `chpl --version`:
+    - Output of `$CHPL_HOME/util/printchplenv --anonymize`:
+    - Back-end compiler and version, e.g. `gcc --version` or `clang --version`:
+    - (For Cray systems only) Output of `module list`:

--- a/doc/usingchapel/privatebugs.rst
+++ b/doc/usingchapel/privatebugs.rst
@@ -1,11 +1,11 @@
 .. _readme-privatebugs:
 
-===============================
-Reporting Private Chapel Issues
-===============================
+=========================
+Private Issues Guidelines
+=========================
 
-Private bug reports can be mailed directly to the Chapel team at Cray Inc.
-through: :disguise:`chapel_bugs@cray.com`
+Private issues can be sent to the Cray Chapel team at:
+:disguise:`chapel_bugs@cray.com`
 
 
 When submitting a private bug report, please include the following information:

--- a/doc/usingchapel/privatebugs.rst
+++ b/doc/usingchapel/privatebugs.rst
@@ -5,31 +5,32 @@ Reporting Private Chapel Issues
 ===============================
 
 Private bug reports can be mailed directly to the Chapel team at Cray Inc.
-through chapel_bugs@cray.com
+through :disguise:`chapel_bugs@cray.com`.
 
-When submitting a private bug report, please include the following information::
 
-    Summary of Problem
-    ------------------
+When submitting a private bug report, please include the following information:
+
+.. note::
+
+    **Summary of Problem**
 
     - What behavior did you observe when encountering this issue?
     - What behavior did you expect to observe?
 
-    Steps to Reproduce
-    ------------------
+    **Steps to Reproduce**
 
     - Please attach source code that will reproduce the problem.
-      - To the extent possible, providing simplified programs demonstrating the
-        problem will be appreciated.
-      - If you are unable to do this, please describe how to recreate the issue.
-    - How did you compile your program?
-    - How did you execute your program?
-      - If any input files are required, please include them as well.
+        - To the extent possible, providing simplified programs demonstrating the
+          problem will be appreciated.
+        - If you are unable to submit code, please describe how to recreate the
+          issue.
+    - How did you compile your program? e.g. ``chpl foo.chpl -o foo``
+    - How did you execute your program? e.g. ``./foo 42``
+        - If any input files are required, please include them as well.
 
-    Configuration Information
-    -------------------------
+    **Configuration Information**
 
-    - Output of `chpl --version`:
-    - Output of `$CHPL_HOME/util/printchplenv --anonymize`:
-    - Back-end compiler and version, e.g. `gcc --version` or `clang --version`:
-    - (For Cray systems only) Output of `module list`:
+    - Output of ``chpl --version``:
+    - Output of ``$CHPL_HOME/util/printchplenv --anonymize``:
+    - Back-end compiler and version, e.g. ``gcc --version`` or ``clang --version``:
+    - (For Cray systems only) Output of ``module list``:

--- a/doc/usingchapel/privatebugs.rst
+++ b/doc/usingchapel/privatebugs.rst
@@ -5,7 +5,7 @@ Reporting Private Chapel Issues
 ===============================
 
 Private bug reports can be mailed directly to the Chapel team at Cray Inc.
-through :disguise:`chapel_bugs@cray.com`.
+through: :disguise:`chapel_bugs@cray.com`
 
 
 When submitting a private bug report, please include the following information:

--- a/doc/util/__init__.py
+++ b/doc/util/__init__.py
@@ -1,0 +1,2 @@
+"""This __init__.py allows the usage of python files in this directory as
+Sphinx extensions"""

--- a/doc/util/disguise.py
+++ b/doc/util/disguise.py
@@ -4,9 +4,11 @@ def disguise_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     """
     Role to obfuscate e-mail addresses using DISGUISE comments.
     """
-    text = text.decode('utf-8').encode('utf-8')
 
     obfuscated = '<!-- DISGUISE -->'.join(list(text))
+
+    obfuscated = '<b>' + obfuscated
+    obfuscated = obfuscated + '</b>'
 
     node = nodes.raw('', obfuscated, format='html')
     return [node], []

--- a/doc/util/disguise.py
+++ b/doc/util/disguise.py
@@ -1,0 +1,15 @@
+from docutils import nodes
+
+def disguise_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+    """
+    Role to obfuscate e-mail addresses using DISGUISE comments.
+    """
+    text = text.decode('utf-8').encode('utf-8')
+
+    obfuscated = '<!-- DISGUISE -->'.join(list(text))
+
+    node = nodes.raw('', obfuscated, format='html')
+    return [node], []
+
+def setup(app):
+    app.add_role('disguise', disguise_role)


### PR DESCRIPTION
- Point users to GitHub Issues from our bug reporting page, now named *Reporting Chapel Issues*
    - Note: link to issues redirects to pull requests until we enable issues
- Remove mentions of JIRA
- Reduce the content in `bugs.rst`, since instructions are in `ISSUE_TEMPLATE.md` and `privatebugs.rst`
- Create a `privatebugs.rst` for instructions on submitting private issues
    - I chose to put the requested information into a code block so that users reporting private bugs could easily copy/paste the requested information into an email body, preserving spacing/formatting. If there is opposition, we can put this back into rendered markup.
    - Open question: Should we adopt and document a security policy similar to [Go's security policy](https://golang.org/security) ?
- New custom sphinx extension that adds a `:disguise:` role for disguising email addresses with HTML comments

I think we can open up GitHub Issues in conjunction with merging this PR