### PR TITLE
New formatting for functions in generated C code

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1007,11 +1007,15 @@ GenRet FnSymbol::codegenFunctionType(bool forHeader) {
         if (formal->hasFlag(FLAG_NO_CODEGEN))
           continue; // do not print locale argument, end count, dummy class
         if (count > 0)
-          str += ", ";
+          str += ",\n";
         str += formal->codegenType().c;
         if( forHeader ) {
           str += " ";
           str += formal->cname;
+        }
+        if (fGenIDS) {
+          str += " ";
+          str += idCommentTemp(formal);
         }
         count++;
       }


### PR DESCRIPTION
Print AST ids for formals when --gen-ids is thrown, and print newlines after each formal for easier reading. This formatting will also appear in chpl__header.h.

Testing:
- [x] full local
- [x] full no-local