### PR TITLE
Add a test for barrier.try() method

### DIFF
--- a/test/parallel/taskPar/diten/barrierTry.chpl
+++ b/test/parallel/taskPar/diten/barrierTry.chpl
@@ -1,0 +1,27 @@
+use Barrier;
+
+config const nTasks = 4;
+config const printSpinCount = false;
+
+var b = new Barrier(nTasks);
+
+coforall i in 1..nTasks {
+  if i < nTasks {
+    b.notify();
+  } else {
+    var spinCount = 0;
+    writeln(b.try()); // false
+    b.notify();
+
+    /* wait until all tasks have notified */
+    while !b.try() {
+      spinCount += 1;
+    }
+    writeln(b.try()); // true
+    if printSpinCount then
+      writeln(spinCount);
+  }
+  b.wait();
+}
+
+delete b;

--- a/test/parallel/taskPar/diten/barrierTry.good
+++ b/test/parallel/taskPar/diten/barrierTry.good
@@ -1,0 +1,2 @@
+false
+true


### PR DESCRIPTION
The test checks that barrier.try() is false before all tasks have called
barrier.notify() and then waits for barrier.try() to become true before
completing.