### PR TITLE
s/parenthesesless/parentheses-less/

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8687,7 +8687,7 @@ buildVirtualMaps() {
       continue;
 
     if (fn->hasFlag(FLAG_NO_PARENS))
-      // Parenthesesless functions are statically bound; that is, they are not
+      // Parentheses-less functions are statically bound; that is, they are not
       // dispatched through the virtual table.
       continue;
 

--- a/doc/developer/chips/10.rst
+++ b/doc/developer/chips/10.rst
@@ -282,7 +282,7 @@ extensions to the type that the type designer did not intend, the type designer
 may still maintain control over which fields may be manipulated in this way.
 This can be done either by setting fields as private (when private fields and
 methods are supported) so that the knowledge of these fields' existence is
-hidden, or by defining a parenthesesless method instead of a field by the same
+hidden, or by defining a parentheses-less method instead of a field by the same
 name so that the value may be relied upon in all circumstances.
 
 Referencing Other Initializers

--- a/doc/technotes/dsi.rst
+++ b/doc/technotes/dsi.rst
@@ -180,7 +180,7 @@ class ``GlobalDomain``
 
   The fields ``rank``, ``idxType``, ``stridable`` are the attributes
   of the corresponding Chapel domain. (They could be replaced with
-  parenthesesless functions of the same names and param/type intents.)
+  parentheses-less functions of the same names and param/type intents.)
 
   The field ``dist`` must contain a reference
   to the ``GlobalDistribution`` object

--- a/spec/proposals/constructors/2012/Constructors.tex
+++ b/spec/proposals/constructors/2012/Constructors.tex
@@ -67,13 +67,13 @@ of overloaded constructors.
 
 Constructor declarations do not have a parentheses-less form.
 \begin{rationale}
-Normal methods may have either a single parenthesesless version or overloaded
+Normal methods may have either a single parentheses-less version or overloaded
 versions taking various argument lists.  In typical usage, we expect overloaded
-constructors to be common.  Also, the parenthesesless form would have the same
+constructors to be common.  Also, the parentheses-less form would have the same
 behavior as the default constructor --- that is, it would perform default
 initialization for all fields.  But the compiler-generated constructor already
 does this (if called with an empty argument list).  Given that the
-parenthesesless form is redundant, and potentially takes flexibility away from
+parentheses-less form is redundant, and potentially takes flexibility away from
 the user, there is no advantage to supporting it.
 \end{rationale}
 


### PR DESCRIPTION
Most instances of the word were hyphenated already.  The limited
feedback I've gotten was that bringing the rest into line by adding
these lines is preferable to adding the hyphen-less version to the
upcoming chplspell dictionary.