### PR TITLE
Add time variation to PRK stencil

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -74,7 +74,7 @@ studies/jacobi/jacobi.graph
 performance/elliot/no-op.graph
 performance/bharshbarg/forall-dom-range.graph
 performance/bharshbarg/arr-forall.graph
-studies/prk/stencil/prk-stencil.graph
+studies/prk/stencil/prk-stencil-time.graph
 # suite: HPC Challenge
 studies/hpcc/STREAM_study_fragmented.graph
 studies/hpcc/STREAM_study.graph

--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -142,6 +142,7 @@ release/examples/benchmarks/isx/isx-release.graph
 # suite: PRK benchmarks
 studies/prk/synch_p2p/prk-synch_p2p.graph
 studies/prk/stencil/prk-stencil.graph
+studies/prk/stencil/prk-stencil-time.graph
 studies/prk/transpose/prk-transpose.graph
 # suite: NAS Parallel benchmarks
 npb/cg/cg.graph

--- a/test/studies/prk/stencil/prk-stencil-time.graph
+++ b/test/studies/prk/stencil/prk-stencil-time.graph
@@ -1,0 +1,6 @@
+perfkeys: Avg time (s):, Avg time (s):, Avg time (s):, Avg time (s):
+files: stencil-defaultdist.dat, stencil-blockdist.dat, stencil-stencildist.dat, stencil-serial.dat
+graphkeys: DefaultDist, BlockDist, StencilDist, Serial
+graphtitle: PRK stencil time
+ylabel: Time (seconds)
+graphname: prk-stencil-time


### PR DESCRIPTION
and add it to the performance tracking suite.

Leaving the multi-locale testing as performance-only, since that seems to be the convention for multi-locale performance tests.

*Testing*

- [X] Confirm that `start_test --performance` & `start_test --gen-graphs` run successfully