### PR TITLE
Work around broken osx+gnu jemalloc support in our makefiles

### DIFF
--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -42,6 +42,16 @@ CHPL_JEMALLOC_CFG_OPTIONS += --with-malloc-conf=purge:decay
 #  """
 CHPL_JEMALLOC_EXTRA_CFLAGS += $(CFLAGS)
 
+
+# Tell configure that __builtin_unreachable is broken on osx+gnu by giving it a
+# "cached" value to use. This is a workaround until the problem an be resolved
+# upstream. See https://github.com/jemalloc/jemalloc/pull/504 for more info.
+ifeq ($(CHPL_MAKE_PLATFORM),darwin)
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),gnu)
+CHPL_JEMALLOC_CFG_OPTIONS += je_cv_gcc_builtin_unreachable=no
+endif
+endif
+
 CHPL_JEMALLOC_CFG_OPTIONS += $(CHPL_JEMALLOC_MORE_CFG_OPTIONS)
 
 default: all

--- a/third-party/jemalloc/jemalloc-src/configure
+++ b/third-party/jemalloc/jemalloc-src/configure
@@ -7394,43 +7394,6 @@ fi
 
 
 
-SAVED_CFLAGS="${CFLAGS}"
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether compiler supports \"${EXTRA_CFLAGS}\"" >&5
-$as_echo_n "checking whether compiler supports \"${EXTRA_CFLAGS}\"... " >&6; }
-TCFLAGS="${CFLAGS}"
-if test "x${CFLAGS}" = "x" ; then
-  CFLAGS=""${EXTRA_CFLAGS}""
-else
-  CFLAGS="${CFLAGS} "${EXTRA_CFLAGS}""
-fi
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-int
-main ()
-{
-
-    return 0;
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  je_cv_cflags_appended="${EXTRA_CFLAGS}"
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  je_cv_cflags_appended=
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-              CFLAGS="${TCFLAGS}"
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether a program using __builtin_unreachable is compilable" >&5
 $as_echo_n "checking whether a program using __builtin_unreachable is compilable... " >&6; }
@@ -7474,7 +7437,6 @@ else
   $as_echo "#define JEMALLOC_INTERNAL_UNREACHABLE abort" >>confdefs.h
 
 fi
-CFLAGS="${SAVED_CFLAGS}"
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether a program using __builtin_ffsl is compilable" >&5

--- a/third-party/jemalloc/jemalloc-src/configure.ac
+++ b/third-party/jemalloc/jemalloc-src/configure.ac
@@ -1125,9 +1125,6 @@ AC_SUBST([enable_cache_oblivious])
 
 
 
-dnl optimization level can impact whether __builtin_unreachable works
-SAVED_CFLAGS="${CFLAGS}"
-JE_CFLAGS_APPEND(["${EXTRA_CFLAGS}"])
 JE_COMPILABLE([a program using __builtin_unreachable], [
 void foo (void) {
   __builtin_unreachable();
@@ -1142,7 +1139,6 @@ if test "x${je_cv_gcc_builtin_unreachable}" = "xyes" ; then
 else
   AC_DEFINE([JEMALLOC_INTERNAL_UNREACHABLE], [abort])
 fi
-CFLAGS="${SAVED_CFLAGS}"
 
 dnl ============================================================================
 dnl Check for  __builtin_ffsl(), then ffsl(3), and fail if neither are found.


### PR DESCRIPTION
This reverts #4878, which worked around osx+gnu support by modifying the
jemalloc source, and replaces it with a workaround in our jemalloc makefile.

We now tell jemalloc's configure step that __builtin_unreachable is broken on
osx+gnu instead of letting it try to figure out it for itself since the check
for it is currently broken.

See https://github.com/jemalloc/jemalloc/pull/504 for more info
