### PR TITLE
Better error messages for chplenv scripts

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_comm, chpl_compiler, chpl_platform, overrides
 from compiler_utils import CompVersion, get_compiler_version
-from utils import memoize
+from utils import error, memoize
 
 
 @memoize
@@ -53,7 +53,7 @@ def get(flag='target'):
             if not atomics_val:
                 atomics_val = 'locks'
     else:
-        raise ValueError("Invalid flag: '{0}'".format(flag))
+        error("Invalid flag: '{0}'".format(flag), ValueError)
     return atomics_val
 
 

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -10,7 +10,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_platform, overrides
-from utils import memoize
+from utils import error, memoize
 
 
 
@@ -21,7 +21,7 @@ def get(flag='host'):
     elif flag == 'target':
         compiler_val = overrides.get('CHPL_TARGET_COMPILER', '')
     else:
-        raise ValueError("Invalid flag: '{0}'".format(flag))
+        error("Invalid flag: '{0}'".format(flag), ValueError)
 
     if compiler_val:
         return compiler_val

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -7,7 +7,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_platform, overrides
-from utils import memoize
+from utils import error, memoize
 
 
 @memoize
@@ -25,7 +25,7 @@ def get(flag='host'):
             else:
                 mem_val = 'jemalloc'
     else:
-        raise ValueError("Invalid flag: '{0}'".format(flag))
+        error("Invalid flag: '{0}'".format(flag), ValueError)
     return mem_val
 
 

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -9,7 +9,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import overrides, utils
-from utils import memoize
+from utils import error, memoize
 
 @memoize
 def get(flag='host'):
@@ -20,7 +20,7 @@ def get(flag='host'):
         if not platform_val:
             platform_val = get('host')
     else:
-        raise ValueError("Invalid flag: '{0}'".format(flag))
+        raise error("Invalid flag: '{0}'".format(flag), ValueError)
 
     if not platform_val:
         # Check for cray platform. It is a cray platform if there is an CLEinfo

--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -22,8 +22,8 @@ def get():
             return 'system'
     if osx:
         if val == 'libunwind':
-            error("Using CHPL_UNWIND=libunwind is not supported"+
-                  " on Mac OS X. Use CHPL_UNWIND=system instead.", ValueError)
+            error("Using CHPL_UNWIND=libunwind is not supported on Mac OS X."
+                  "\nUse CHPL_UNWIND=system instead.", ValueError)
         elif val == 'system':
             return 'system'
     return 'none'

--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -6,7 +6,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_platform, overrides
-from utils import memoize
+from utils import error, memoize
 
 @memoize
 def get():
@@ -22,8 +22,8 @@ def get():
             return 'system'
     if osx:
         if val == 'libunwind':
-            raise ValueError("Using CHPL_UNWIND=libunwind is not supported"+
-                            " on Mac OS X. Use CHPL_UNWIND=system instead.")
+            error("Using CHPL_UNWIND=libunwind is not supported"+
+                  " on Mac OS X. Use CHPL_UNWIND=system instead.", ValueError)
         elif val == 'system':
             return 'system'
     return 'none'

--- a/util/chplenv/chpl_wide_pointers.py
+++ b/util/chplenv/chpl_wide_pointers.py
@@ -8,7 +8,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import overrides
-from utils import memoize
+from utils import error, memoize
 
 
 @memoize
@@ -35,7 +35,7 @@ def get(flag='wide'):
     elif flag == 'define':
         return define
     else:
-        raise ValueError("Invalid flag: '{0}'".format(flag))
+        error("Invalid flag: '{0}'".format(flag), ValueError)
 
 
 def _main():

--- a/util/chplenv/compiler_utils.py
+++ b/util/chplenv/compiler_utils.py
@@ -57,8 +57,8 @@ def CompVersion(version_string):
         build    = int(match.group(7) or 0)
         return CompVersionT(major=major, minor=minor, revision=revision, build=build)
     else:
-        error("Could not convert version"+
-              " '{0}' to a tuple".format(version_string), ValueError)
+        error("Could not convert version '{0}' to a tuple".format(
+            version_string), ValueError)
 
 
 @memoize

--- a/util/chplenv/compiler_utils.py
+++ b/util/chplenv/compiler_utils.py
@@ -30,6 +30,7 @@ def get_compiler_name(compiler):
 
 @memoize
 def get_compiler_version(compiler):
+    """TODO: Handle case where gcc does not exist"""
     version_string = '0'
     if 'gnu' in compiler:
         # Asssuming the 'compiler' version matches the gcc version

--- a/util/chplenv/compiler_utils.py
+++ b/util/chplenv/compiler_utils.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-from utils import memoize, run_command
+from utils import error, memoize, run_command
 
 
 @memoize
@@ -30,7 +30,6 @@ def get_compiler_name(compiler):
 
 @memoize
 def get_compiler_version(compiler):
-    """TODO: Handle case where gcc does not exist"""
     version_string = '0'
     if 'gnu' in compiler:
         # Asssuming the 'compiler' version matches the gcc version
@@ -58,8 +57,8 @@ def CompVersion(version_string):
         build    = int(match.group(7) or 0)
         return CompVersionT(major=major, minor=minor, revision=revision, build=build)
     else:
-        raise ValueError("Could not convert version '{0}' to "
-                         "a tuple".format(version_string))
+        error("Could not convert version"+
+              " '{0}' to a tuple".format(version_string), ValueError)
 
 
 @memoize

--- a/util/chplenv/template
+++ b/util/chplenv/template
@@ -10,7 +10,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import overrides
-from utils import memoize
+from utils import error, memoize
 
 #TODO: @memoize causes the calls to this function to get cached
 @memoize
@@ -20,7 +20,7 @@ def get(flag='host'):
     elif flag == 'target':
         FOOBAR_val = overrides.get('CHPL_TARGET_FOOBAR', '')
     else:
-        raise ValueError("Invalid flag: '{0}'".format(flag))
+        error("Invalid flag: '{0}'".format(flag), ValueError)
 
     if not FOOBAR_val:
         #TODO: Set the default for FOOBAR_val

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_arch, chpl_compiler, chpl_locale_model, chpl_platform
 from chpl_home_utils import get_chpl_home, using_chapel_module
-from utils import memoize, run_command
+from utils import error, memoize, run_command
 
 
 #
@@ -83,7 +83,7 @@ def pkgconfig_get_link_args(pkg, ucp='', system=True, static=True):
                            'pkgconfig', pcfile)
 
       if not os.access(pcArg, os.R_OK):
-        raise ValueError("Could not find '{0}'".format(pcArg))
+        error("Could not find '{0}'".format(pcArg), ValueError)
 
   static_arg = [ ]
   if static:

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -3,12 +3,10 @@ import os
 import subprocess
 import sys
 
-CHPL_DEVELOPER = os.environ.get('CHPL_DEVELOPER')
-
 
 def error(msg, exception=Exception):
     """Exception raising wrapper that differentiates developer-mode output"""
-    if CHPL_DEVELOPER:
+    if os.environ.get('CHPL_DEVELOPER'):
         raise exception(msg)
     else:
         sys.stderr.write('\nError: ')

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -1,14 +1,13 @@
-""" Utility functions for chplenv modules """
+"""Utility functions for chplenv modules"""
 import os
 import subprocess
 import sys
 
-# Developer mode affects error output behavior
 CHPL_DEVELOPER = os.getenv('CHPL_DEVELOPER')
 
 
 def error(msg, exception=Exception):
-    """Error function for chplenv modules"""
+    """Exception raising wrapper that differentiates developer-mode output"""
     if CHPL_DEVELOPER:
         raise exception(msg)
     else:
@@ -32,11 +31,12 @@ def memoize(func):
 
 
 class CommandError(Exception):
+    """Custom exception for run_command errors"""
     pass
 
 
 def run_command(command, stdout=True, stderr=False, cmd_input=None):
-    """subprocess convenience wrapper.
+    """Command subprocess wrapper.
        This should be the only invocation of subprocess in all chplenv scripts.
        This could be replaced by subprocess.check_output, but that
        is only available after Python 2.7, and we still support 2.6 :("""

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 
-CHPL_DEVELOPER = os.getenv('CHPL_DEVELOPER')
+CHPL_DEVELOPER = os.environ.get('CHPL_DEVELOPER')
 
 
 def error(msg, exception=Exception):


### PR DESCRIPTION
This PR does 2 things:

0. Improved some documentation
1. Wraps `run_command` in a try-except statement
    - This was motivated by a user trying to install Chapel on windows, where no backend C compiler was found, resulting in a not-too-helpful `OSError` & traceback.
2. Provides an error-handling wrapper function that differentiates error output based on `CHPL_DEVELOPER` being set:
    - In user-mode (`CHPL_DEVELOPER` unset), the error is formatted as `Error: {error_msg}`
    - In developer-mode (`CHPL_DEVELOPER` set), an exception is raised as `raise Exception(error_msg)`
        - This results in a full traceback

With this addition, we may assert that users should never encounter raised exceptions, and if they do, it is an exception we are not catching properly.