### PR TITLE
Correct note about why we skip omp task spawn test under cce

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-omp-taskspawn.skipif
+++ b/test/parallel/taskCompare/elliot/empty-omp-taskspawn.skipif
@@ -1,4 +1,4 @@
-# cce optimizes away the loop entirely resulting in a no-op test
+# cce doesn't support running omp constructs from a pthread
 CHPL_TARGET_COMPILER==cray-prgenv-cray
 # older versions of clang don't support openmp
 CHPL_TARGET_COMPILER==clang


### PR DESCRIPTION
It turns out CCE doesn't optimize away the empty omp loop in the task spawn
test. It's just that with
https://github.com/chapel-lang/chapel/pull/1929#issuecomment-264376876 we
started always throwing -O0 to cce, which disables openmp support so the loop
was serial and thus super fast since there was no task startup time.

When we actually throw -O3 (and leave openmp enabled) it turns out that cce
doesn't currently support running openmp constructs from a pthread and all our
tasking layers end up calling chpl_main from a pthread.