### PR TITLE
Change the barrier class into a record

### DIFF
--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -43,7 +43,6 @@
 
    Note: When a barrier instance goes out of scope it is automatically deleted.
    After it is deleted, any copies of the barrier that remain are invalid.
-   Using a copy of a barrier after it has been deleted is undefined.
 
    Future direction
    ----------------

--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -65,6 +65,8 @@ module Barrier {
   record Barrier {
     pragma "no doc"
     var bar: BarrierBaseType;
+    pragma "no doc"
+    var owned: bool = false;
 
     /* Construct a new barrier object.
 
@@ -95,11 +97,12 @@ module Barrier {
           halt("unknown barrier type");
         }
       }
+      owned = true;
     }
 
     pragma "no doc"
     proc ~Barrier() {
-      if bar != nil {
+      if owned && bar != nil {
         delete bar;
       }
     }
@@ -335,6 +338,25 @@ module Barrier {
     inline proc check(): bool {
       return done.readXX();
     }
+  }
+
+  pragma "no doc"
+  proc =(ref lhs: Barrier, rhs: Barrier) {
+    if lhs.owned {
+      delete lhs.bar;
+    }
+    lhs.bar = rhs.bar;
+    lhs.owned = false;
+  }
+
+  pragma "init copy fn"
+  pragma "no doc"
+  proc chpl__initCopy(b: Barrier) {
+    pragma "no auto destroy"
+    var ret: Barrier;
+    ret.bar = b.bar;
+    ret.owned = false;
+    return ret;
   }
 }
 

--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -41,19 +41,11 @@
        writeln("Task ", tid, " is past the barrier");
      }
 
-     delete b;
-
    Future direction
    ----------------
    In the future, we expect to add more language-level support for a
    "task-team" concept.  A task-team will more directly support collective
    operations such as barriers between the tasks within a team.
-
-   The Barrier type is currently implemented as a class, requiring it to be
-   explicitly deleted before it goes out of scope.  It is expected that this
-   type will be changed into a record allowing it to be automatically
-   reclaimed.  When this change happens, code that uses this Barrier will need
-   to have the explicit deletes removed, but should require no other changes.
 
    The current implementation is designed for correctness, but is not expected
    to perform well at scale.  We expect performance at scale to improve as
@@ -70,7 +62,7 @@ module Barrier {
   enum BarrierType {Atomic, Sync}
 
   /* A barrier that will cause `numTasks` to wait before proceeding. */
-  class Barrier {
+  record Barrier {
     pragma "no doc"
     var bar: BarrierBaseType;
 
@@ -129,9 +121,13 @@ module Barrier {
     }
 
     /* Wait until `n` tasks have called :proc:`notify`.  If `reusable` is true,
-       reset the barrier to be used again.  Note: if `reusable` is true
-       :proc:`wait` will block until `n` tasks have called it after calling
-       :proc:`notify`.
+       reset the barrier to be used again.
+
+       Note: if `reusable` is true the tasks will wait until all `n` tasks
+       have called both :proc:`notify` and :proc:`wait` at which point the
+       barrier will automatically be reset for the next use.  If `reusable`
+       is false, each task calling :proc:`wait` can return as soon as all
+       `n` tasks have called :proc:`notify`.
      */
     inline proc wait() {
       on this {
@@ -139,16 +135,19 @@ module Barrier {
       }
     }
 
-    /* return `true` if `n` tasks have called :proc:`notify`
+    /* Return `true` if `n` tasks have called :proc:`notify`
      */
     inline proc check(): bool {
       return bar.check();
     }
 
-    pragma "no doc"
-    inline proc reset(_n: int) {
+    /* Reset the barrier, setting it to work with `nTasks` tasks.  If some
+       (but not all) tasks had already called :proc:`barrier` or :proc:`try`
+       when :proc:`reset` is called, the behavior is undefined.
+     */
+    inline proc reset(nTasks: int) {
       on this {
-        bar.reset(_n);
+        bar.reset(nTasks);
       }
     }
   }
@@ -177,7 +176,7 @@ module Barrier {
     }
 
     pragma "no doc"
-    proc reset(_n: int) {
+    proc reset(nTasks: int) {
       halt("reset() not implemented");
     }
   }
@@ -208,9 +207,9 @@ module Barrier {
     }
 
     pragma "no doc"
-    inline proc reset(_n: int) {
+    inline proc reset(nTasks: int) {
       on this {
-        n = _n;
+        n = nTasks;
         count.write(n);
         done.write(false);
       }
@@ -268,7 +267,7 @@ module Barrier {
       }
     }
 
-    /* return `true` if `n` tasks have called :proc:`notify`
+    /* Return `true` if `n` tasks have called :proc:`notify`
      */
     inline proc check(): bool {
       return done.read();
@@ -291,7 +290,8 @@ module Barrier {
     proc sBarrier(n: int) {
       count = n;
     }
-    proc reset(_n: int) {
+
+    proc reset(nTasks: int) {
       halt("cannot reset sync based barrier");
     }
 
@@ -330,7 +330,7 @@ module Barrier {
       done;
     }
 
-    /* return `true` if `n` tasks have called :proc:`notify`
+    /* Return `true` if `n` tasks have called :proc:`notify`
      */
     inline proc check(): bool {
       return done.readXX();

--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -41,6 +41,10 @@
        writeln("Task ", tid, " is past the barrier");
      }
 
+   Note: When a barrier instance goes out of scope it is automatically deleted.
+   After it is deleted, any copies of the barrier that remain are invalid.
+   Using a copy of a barrier after it has been deleted is undefined.
+
    Future direction
    ----------------
    In the future, we expect to add more language-level support for a

--- a/test/parallel/taskPar/diten/barrierCheck.chpl
+++ b/test/parallel/taskPar/diten/barrierCheck.chpl
@@ -23,5 +23,3 @@ coforall i in 1..nTasks {
   }
   b.wait();
 }
-
-delete b;

--- a/test/parallel/taskPar/diten/copyBarrier.chpl
+++ b/test/parallel/taskPar/diten/copyBarrier.chpl
@@ -1,0 +1,39 @@
+use Barrier;
+
+config const nTasks = 4;
+
+proc copyInBar(in bar: Barrier) {
+  coforall tid in 1..nTasks {
+    bar.barrier();
+  }
+  writeln("first coforall done!");
+}
+
+var bar = new Barrier(nTasks);
+
+copyInBar(bar);
+
+coforall tid in 1..nTasks {
+  bar.barrier();
+}
+
+writeln("second coforall done!");
+
+proc varCopyBar(bar: Barrier) {
+  var x = bar;
+  coforall tid in 1..nTasks {
+    if tid % 2 == 0 then
+      bar.barrier();
+    else
+      x.barrier();
+  }
+  writeln("third coforall done!");
+}
+
+varCopyBar(bar);
+
+coforall tid in 1..nTasks {
+  bar.barrier();
+}
+
+writeln("fourth coforall done!");

--- a/test/parallel/taskPar/diten/copyBarrier.good
+++ b/test/parallel/taskPar/diten/copyBarrier.good
@@ -1,0 +1,4 @@
+first coforall done!
+second coforall done!
+third coforall done!
+fourth coforall done!

--- a/test/parallel/taskPar/sungeun/barrier/basic.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/basic.chpl
@@ -30,12 +30,9 @@ localTest(b, numTasks);
 
 b.reset(numRemoteTasks);
 remoteTest(b, numRemoteTasks);
-delete b;
 
 var sb1 = new Barrier(numTasks, BarrierType.Sync);
 localTest(sb1, numTasks);
-delete sb1;
 
 var sb2 = new Barrier(numRemoteTasks, BarrierType.Sync);
 remoteTest(sb2, numRemoteTasks);
-delete sb2;

--- a/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
@@ -51,14 +51,11 @@ remoteTestBasic(b, numRemoteTasks);
 b.reset(numRemoteTasks);
 writeln("atomic remote test split phase");
 remoteTestSplitPhase(b, numRemoteTasks);
-delete b;
 
 var sb1 = new Barrier(numRemoteTasks, BarrierType.Sync);
 writeln("sync remote test basic");
 remoteTestBasic(sb1, numRemoteTasks);
-delete sb1;
 
 var sb2 = new Barrier(numRemoteTasks, BarrierType.Sync);
 writeln("sync remote test split phase");
 remoteTestSplitPhase(sb2, numRemoteTasks);
-delete sb2;

--- a/test/parallel/taskPar/sungeun/barrier/reuse.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/reuse.chpl
@@ -46,4 +46,3 @@ localTest(b, numTasks);
 
 b.reset(numRemoteTasks);
 remoteTest(b, numRemoteTasks);
-delete b;

--- a/test/parallel/taskPar/sungeun/barrier/split-phase.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/split-phase.chpl
@@ -41,12 +41,9 @@ localTest(b, numTasks);
 
 b.reset(numRemoteTasks);
 remoteTest(b, numRemoteTasks);
-delete b;
 
 var sb1 = new Barrier(numTasks, BarrierType.Sync);
 localTest(sb1, numTasks);
-delete sb1;
 
 var sb2 = new Barrier(numRemoteTasks, BarrierType.Sync);
 remoteTest(sb2, numRemoteTasks);
-delete sb2;

--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -172,8 +172,6 @@ proc main() {
 
   if printTimings then
     printTimingData("locales");
-
-  delete barrier;
 }
 
 

--- a/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
@@ -63,11 +63,11 @@ module RunSPMDRawLoops {
                   if ( vnewc[i] >= eosvmax ) then p_new[i] = 0.0;
                   if ( p_new[i]  <  pmin ) then p_new[i] = pmin;
                 }
+                bar.barrier(); // wait for all tasks before updating isamp
                 if tid == 0 then isamp += 1;
                 bar.barrier(); // The final barrier is still required
               }
             }
-            delete bar;
             ltimer.stop();
             loopFinalize(iloop, stat, ilength);
           }
@@ -166,11 +166,11 @@ module RunSPMDRawLoops {
                     if abs(q_new[i]) < q_cut then q_new[i] = 0.0;
                   }
                 }
+                bar.barrier(); // wait for all tasks before updating isamp
                 if tid == 0 then isamp += 1;
                 bar.barrier(); // The final barrier is still required
               }
             }
-            delete bar;
             ltimer.stop();
             loopFinalize(iloop, stat, ilength);
           }
@@ -277,11 +277,11 @@ module RunSPMDRawLoops {
 
                   vol[i] *= vnormq ;
                 }
+                bar.barrier(); // wait for all tasks before updating isamp
                 if tid == 0 then isamp += 1;
                 bar.barrier();
               }
             }
-            delete bar;
             ltimer.stop();
             loopFinalize(iloop, stat, ilength);
           }
@@ -351,11 +351,11 @@ module RunSPMDRawLoops {
 
                   div[i] = dfxdx + dfydy + affine;
                 }
+                bar.barrier(); // wait for all tasks before updating isamp
                 if tid == 0 then isamp += 1;
                 bar.barrier();
               }
             }
-            delete bar;
             ltimer.stop();
             loopFinalize(iloop, stat, ilength);
           }
@@ -430,11 +430,11 @@ module RunSPMDRawLoops {
                     }
                   }
                 }
+                bar.barrier(); // wait for all tasks before updating isamp
                 if tid == 0 then isamp += 1;
                 bar.barrier();
               }
             }
-            delete bar;
             ltimer.stop();
             loopFinalize(iloop, stat, ilength);
           }
@@ -464,12 +464,12 @@ module RunSPMDRawLoops {
                   }
                   output[i] = sum;
                 }
+                bar.barrier(); // wait for all tasks before updating val/isamp
                 if tid == 0 then val = isamp;
                 if tid == 0 then isamp += 1;
                 bar.barrier();
               }
             }
-            delete bar;
             ltimer.stop();
             loop_data.RealArray_scalars[0] = (val + 0.00123) / (val - 0.00123);
             loopFinalize(iloop, stat, ilength);
@@ -495,11 +495,11 @@ module RunSPMDRawLoops {
                   out2[i] = res;
                   out1[i] = res;
                 }
+                bar.barrier(); // wait for all tasks before updating isamp
                 if tid == 0 then isamp += 1;
                 bar.barrier();
               }
             }
-            delete bar;
             ltimer.stop();
             loopFinalize(iloop, stat, ilength);
           }
@@ -523,11 +523,11 @@ module RunSPMDRawLoops {
                   out2[i] = in1[i] + in2[i];
                   out3[i] = in1[i] - in2[i];
                 }
+                bar.barrier(); // wait for all tasks before updating isamp
                 if tid == 0 then isamp += 1;
                 bar.barrier();
               }
             }
-            delete bar;
             ltimer.stop();
             loopFinalize(iloop, stat, ilength);
           }
@@ -557,11 +557,11 @@ module RunSPMDRawLoops {
                     x1[i] = 0.0;
                   }
                 }
+                bar.barrier(); // wait for all tasks before updating isamp
                 if tid == 0 then isamp += 1;
                 bar.barrier();
               }
             }
-            delete bar;
             ltimer.stop();
             loopFinalize(iloop, stat, ilength);
           }
@@ -593,12 +593,12 @@ module RunSPMDRawLoops {
                   sumx += trap_int_func(x, y, xp, yp);
                 }
                 sumx += initSumx;
+                bar.barrier(); // wait for all tasks before updating val/isamp
                 if tid == 0 then val = sumx * h;
                 if tid == 0 then isamp += 1;
                 bar.barrier();
               }
             }
-            delete bar;
             ltimer.stop();
             loop_data.RealArray_scalars[0] = (val + 0.00123) / (val - 0.00123);
             loopFinalize(iloop, stat, ilength);
@@ -663,11 +663,11 @@ module RunSPMDRawLoops {
                   /* #pragma omp atomic */
                   atomicH[j2,i2].add(1.0);
                 }
+                bar.barrier(); // wait for all tasks before updating isamp
                 if tid == 0 then isamp += 1;
                 bar.barrier();
               }
             }
-            delete bar;
 
             // copy the computed values out of the atomic array and
             // back into the 'h' array

--- a/test/studies/cholesky/jglewis/version2/elemental/block_distribution/elemental_cholesky_symmetric_index_ranges_block.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/block_distribution/elemental_cholesky_symmetric_index_ranges_block.chpl
@@ -267,7 +267,6 @@ module elemental_cholesky_symmetric_index_ranges_block {
 	  }
       }
     }
-    delete bar;
 
     // return success 
 

--- a/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges.chpl
@@ -264,7 +264,6 @@ module elemental_cholesky_symmetric_index_ranges {
 	  }
       }
     }
-    delete bar;
 
     // return success 
 

--- a/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges_alt.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges_alt.chpl
@@ -253,7 +253,6 @@ module elemental_cholesky_symmetric_index_ranges_alt {
 	  }
       }
     }
-    delete bar;
     // return success 
 
     return true;

--- a/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/elemental_cholesky_fully_blocked.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/elemental_cholesky_fully_blocked.chpl
@@ -264,7 +264,6 @@ module elemental_cholesky_fully_blocked {
 	  }
       }
     }
-    delete bar;
 
     // return success 
 

--- a/test/studies/cholesky/jglewis/version2/elemental/strided/elemental_cholesky_symmetric_strided.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/strided/elemental_cholesky_symmetric_strided.chpl
@@ -274,7 +274,6 @@ module elemental_cholesky_symmetric_strided {
 	  }
       }
     }
-    delete bar;
 
     // return success 
 

--- a/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/elemental_cholesky_unsymmetric_index_ranges.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/elemental_cholesky_unsymmetric_index_ranges.chpl
@@ -259,7 +259,6 @@ module elemental_cholesky_unsymmetric_index_ranges {
 	  }
       }
     }
-    delete bar;
 
     // return success 
 

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -168,8 +168,6 @@ proc main() {
 
   if printTimings then
     printTimingData("buckets");
-
-  delete barrier;
 }
 
 

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -168,8 +168,6 @@ proc main() {
 
   if printTimings then
     printTimingData("buckets");
-
-  delete barrier;
 }
 
 

--- a/test/studies/isx/isx-per-task.chpl
+++ b/test/studies/isx/isx-per-task.chpl
@@ -172,8 +172,6 @@ proc main() {
 
   if printTimings then
     printTimingData("locales");
-
-  delete barrier;
 }
 
 


### PR DESCRIPTION
Changed the barrier class into a record so that it doesn't require explicit
deletes.

Updated chpldoc comments for a few of the methods.

Documented the 'reset' method in order to expose it.

Updated tests to remove deletes of barriers.

Added another barrier to each SPMD LCALS kernel. While removing barrier
deletes, I realized that a barrier was required both before and after
updating the loop index variable, but previously only put one after the
update.