### PR TITLE
Ensure a call-site is still alive before adding it to the callers for a function

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -171,7 +171,9 @@ void compute_call_sites() {
   forv_Vec(CallExpr, call, gCallExprs) {
     if (call->isEmpty() == true) {
 
-    } else if (FnSymbol* fn = call->isResolved()) {
+    } else if (isAlive(call) == false) {
+
+    } else if (FnSymbol* fn = call->resolvedFunction()) {
       fn->calledBy->add(call);
 
     } else if (call->isPrimitive(PRIM_FTABLE_CALL)) {


### PR DESCRIPTION
While examining the recursive inlining question, I attempted to invoke compute_call_sites()
twice in a single pass but got incorrect results for the second call.  It turned out that this
function was not ignoring call-sites that had been removed from the AST between the
two calls.

Trivial change to add an isAlive() check.  This change generated the expected behavior
for the case that drew my attention.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran paratest on linux64 with --verify.

