### PR TITLE
Modify sys.path to support older Python versions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,8 +21,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
-sys.path.append(os.path.join(os.path.dirname(__file__), 'util'))
+sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 
@@ -35,7 +34,7 @@ needs_sphinx = '1.3'
 extensions = [
     'sphinx.ext.todo',
     'sphinxcontrib.chapeldomain',
-    'disguise',
+    'util.disguise',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,6 +22,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
+sys.path.append(os.path.join(os.path.dirname(__file__), 'util'))
 
 # -- General configuration ------------------------------------------------
 
@@ -34,7 +35,7 @@ needs_sphinx = '1.3'
 extensions = [
     'sphinx.ext.todo',
     'sphinxcontrib.chapeldomain',
-    'util.disguise',
+    'disguise',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Fixes the error for Python 2.6, `publish_module_docs.sh`:

```
Extension error:
Could not import extension util.disguise (exception: No module named util.disguise)
```