### PR TITLE
Test jemalloc 4.4.0 in perf playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,11 +9,11 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of stack allocating arg bundles
-GITHUB_USER=mppf
-GITHUB_BRANCH=no-heap-alloc-bundles
-SHORT_NAME=stackArgs
-START_DATE=11/28/16
+# Test performance of jemalloc 4.4.0
+GITHUB_USER=ronawho
+GITHUB_BRANCH=upgrade-jemalloc-4.4.0
+SHORT_NAME=jemalloc-4.4.0
+START_DATE=12/05/16
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
I saw some regressions with binary-trees on chapcs, so I want to do a full test
run to see if there's a real regression that needs to be investigated or if
binary-trees is just a one-off.