### PR TITLE
Introduce a user-facing error message when inlining finds a cycle

### DIFF
--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -234,8 +234,17 @@ of module level procedures to outside modules.  By default, procedures are
 publicly visible.  More details on visibility can be found in
 ~\rsec{Visibility_Of_Symbols}.
 
-The linkage specifier \chpl{inline} indicates that the function body must be inlined at
-every call site.
+The linkage specifier \chpl{inline} indicates that the function body must
+be inlined at every call site.
+
+\begin{rationale}
+A Chapel compiler is permitted to inline any function if it determines
+there is likely to be a performance benefit to do so.  Hence an error
+must be reported if the compiler is unable to inline a procedure with
+this specifier.  One example of a preventable inlining error is to
+define a sequence of inlined calls that includes a cycle back to an
+inlined procedure.
+\end{rationale}
 
 See the chapter on interoperability (\rsec{Interoperability})
 for details on exported and imported functions.


### PR DESCRIPTION
1) I noticed that if a user writes a program with inlined functions that include a cycle, the current
implementation would generate an unhelpful internal fatal error.  This PR revises inlineFunction()
to use USR_FATAL and provide a more useful message.

While there I refactored inlineFunction() into 4 separate functions that handle the separate components of behavior.  However the only change in functionality is for the error message.


2) While we were considering this issue, we discussed the pros/cons of the choice to 
require the compiler to inline when the inline specifier is applied.  I added a "rationale" section
to this part of the spec to help to capture the current perspective on this.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Full paratest with --verify on linux64 for both single-locale and gasnet.
