### PR TITLE
Add PRIM_STACK_ALLOCATE_CLASS to exprAnalysis.cpp

### DIFF
--- a/compiler/util/exprAnalysis.cpp
+++ b/compiler/util/exprAnalysis.cpp
@@ -274,6 +274,7 @@ bool SafeExprAnalysis::isSafePrimitive(CallExpr* ce) {
     case PRIM_GET_PRIV_CLASS:
     case PRIM_GET_SVEC_MEMBER:
     case PRIM_GET_SVEC_MEMBER_VALUE:
+    case PRIM_STACK_ALLOCATE_CLASS:
       return true;
     case PRIM_UNKNOWN:
       if(strcmp(prim->name, "string_length") == 0 ||


### PR DESCRIPTION
Treating it as "safe" because it just allocates a local stack variable
and then does a cast. Since the allocation amounts to creating a
temporary variable, all of this could safely be eliminated or reordered.

Without this change, hello4 fails to compile with --denormalize after PR #4074.

Reviewed by @daviditen.