### PR TITLE
Add --no-ieee-float to LCALS perfcompopts

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
@@ -1,1 +1,1 @@
--sperfTesting=true
+-sperfTesting=true --no-ieee-float


### PR DESCRIPTION
We normally use --no-ieee-float when we report performance numbers in release
reports, so turn it on for nightly performance testing.

Note: we want to wait a day or two before merging this in order to keep the performance impact of this separated from another PR.

Suggested by @ronawho.