### PR TITLE
Add serialized versions of the task spawn microbenchmark

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -210,6 +210,7 @@ statements/lydia/moduleVersusFunctionDifAccess.graph
 statements/lydia/moduleVersusFunction.graph
 # suite: Task Spawning
 parallel/taskCompare/elliot/taskSpawn.graph
+parallel/taskCompare/elliot/serialTaskSpawn.graph
 # suite: Compiler performance
 performance/compiler/bradc/fft-timecomp.graph
 performance/compiler/bradc/compSampler-timecomp.graph

--- a/test/parallel/taskCompare/elliot/empty-chpl-taskspawn.chpl
+++ b/test/parallel/taskCompare/elliot/empty-chpl-taskspawn.chpl
@@ -4,7 +4,8 @@ config const numTrials = 100;
 config const printTimings = false;
 
 enum TaskingMode {
-  forBeginT, coforallT, forallT
+  forBeginT, coforallT, forallT,
+  serialForBeginT, serialCoforallT, serialForallT
 };
 use TaskingMode;
 
@@ -15,9 +16,12 @@ proc main() {
 
   t.start();
   select taskingMode {
-     when forBeginT do forBeginTaskSpawn(numTrials, here.maxTaskPar);
-     when coforallT do coforallTaskSpawn(numTrials, here.maxTaskPar);
-     when forallT   do forallTaskSpawn  (numTrials, here.maxTaskPar);
+     when forBeginT       do           forBeginTaskSpawn(numTrials, here.maxTaskPar);
+     when coforallT       do           coforallTaskSpawn(numTrials, here.maxTaskPar);
+     when forallT         do           forallTaskSpawn  (numTrials, here.maxTaskPar);
+     when serialForBeginT do serial do forBeginTaskSpawn(numTrials, here.maxTaskPar);
+     when serialCoforallT do serial do coforallTaskSpawn(numTrials, here.maxTaskPar);
+     when serialForallT   do serial do forallTaskSpawn  (numTrials, here.maxTaskPar);
   }
   t.stop();
 

--- a/test/parallel/taskCompare/elliot/empty-chpl-taskspawn.compopts
+++ b/test/parallel/taskCompare/elliot/empty-chpl-taskspawn.compopts
@@ -1,3 +1,6 @@
 -staskingMode=forBeginT
 -staskingMode=coforallT
 -staskingMode=forallT
+-staskingMode=serialForBeginT
+-staskingMode=serialCoforallT
+-staskingMode=serialForallT

--- a/test/parallel/taskCompare/elliot/empty-chpl-taskspawn.perfcompopts
+++ b/test/parallel/taskCompare/elliot/empty-chpl-taskspawn.perfcompopts
@@ -1,3 +1,6 @@
--staskingMode=forBeginT # empty-for+begin
--staskingMode=coforallT # empty-coforall
--staskingMode=forallT   # empty-forall
+-staskingMode=forBeginT       # empty-for+begin
+-staskingMode=coforallT       # empty-coforall
+-staskingMode=forallT         # empty-forall
+-staskingMode=serialForBeginT # empty-serial-for+begin
+-staskingMode=serialCoforallT # empty-serial-coforall
+-staskingMode=serialForallT   # empty-serial-forall

--- a/test/parallel/taskCompare/elliot/empty-omp-taskspawn.chpl
+++ b/test/parallel/taskCompare/elliot/empty-omp-taskspawn.chpl
@@ -3,16 +3,26 @@ use Time;
 config const numTrials = 100;
 config const printTimings = false;
 
-extern proc ompTaskSpawn(trials, numTasks);
+enum TaskingMode {
+    ompParallelForT, ompSerialParallelForT
+};
+use TaskingMode;
+
+config param taskingMode = ompParallelForT;
 
 proc main() {
   var t: Timer;
 
   t.start();
-  ompTaskSpawn(numTrials, here.maxTaskPar);
+  select taskingMode {
+     when ompParallelForT       do ompTaskSpawn(numTrials, here.maxTaskPar, false);
+     when ompSerialParallelForT do ompTaskSpawn(numTrials, here.maxTaskPar, true);
+  }
   t.stop();
 
   if printTimings {
     writeln("Elapsed time: ", t.elapsed());
   }
 }
+
+extern proc ompTaskSpawn(trials, numTasks, runSerial);

--- a/test/parallel/taskCompare/elliot/empty-omp-taskspawn.compopts
+++ b/test/parallel/taskCompare/elliot/empty-omp-taskspawn.compopts
@@ -1,1 +1,2 @@
-ompTaskSpawn.h
+ompTaskSpawn.h -staskingMode=ompParallelForT
+ompTaskSpawn.h -staskingMode=ompSerialParallelForT

--- a/test/parallel/taskCompare/elliot/empty-omp-taskspawn.perfcompopts
+++ b/test/parallel/taskCompare/elliot/empty-omp-taskspawn.perfcompopts
@@ -1,1 +1,2 @@
---ccflags -fopenmp --ldflags -fopenmp ompTaskSpawn.h # empty-omp-parallel-for
+--ccflags -fopenmp --ldflags -fopenmp ompTaskSpawn.h -staskingMode=ompParallelForT       # empty-omp-parallel-for
+--ccflags -fopenmp --ldflags -fopenmp ompTaskSpawn.h -staskingMode=ompSerialParallelForT # empty-omp-serial-parallel-for

--- a/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.chpl
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.chpl
@@ -4,7 +4,8 @@ config const numTrials = 100;
 config const printTimings = false;
 
 enum TaskingMode {
-  qtChplLikeT, qtChplOptT
+  qtChplLikeT, qtChplOptT,
+  qtSerialChplLikeT, qtSerialChplOptT
 };
 use TaskingMode;
 
@@ -15,8 +16,10 @@ proc main() {
 
   t.start();
   select taskingMode {
-     when qtChplLikeT do qtChplLikeTaskSpawn(numTrials, here.maxTaskPar);
-     when qtChplOptT  do qtChplOptTaskSpawn (numTrials, here.maxTaskPar);
+     when qtChplLikeT       do qtChplLikeTaskSpawn(numTrials, here.maxTaskPar, false);
+     when qtChplOptT        do qtChplOptTaskSpawn (numTrials, here.maxTaskPar, false);
+     when qtSerialChplLikeT do qtChplLikeTaskSpawn(numTrials, here.maxTaskPar, true);
+     when qtSerialChplOptT  do qtChplOptTaskSpawn (numTrials, here.maxTaskPar, true);
   }
   t.stop();
 
@@ -25,5 +28,5 @@ proc main() {
   }
 }
 
-extern proc qtChplLikeTaskSpawn(trials, numTasks);
-extern proc qtChplOptTaskSpawn(trials, numTasks);
+extern proc qtChplLikeTaskSpawn(trials, numTasks, runSerial);
+extern proc qtChplOptTaskSpawn(trials, numTasks, runSerial);

--- a/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.compopts
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.compopts
@@ -1,2 +1,4 @@
 qtTaskSpawn.h -staskingMode=qtChplLikeT
 qtTaskSpawn.h -staskingMode=qtChplOptT
+qtTaskSpawn.h -staskingMode=qtSerialChplLikeT
+qtTaskSpawn.h -staskingMode=qtSerialChplOptT

--- a/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.perfcompopts
+++ b/test/parallel/taskCompare/elliot/empty-qthreads-taskspawn.perfcompopts
@@ -1,2 +1,4 @@
-qtTaskSpawn.h -staskingMode=qtChplLikeT # empty-qthreads-chpl-like
-qtTaskSpawn.h -staskingMode=qtChplOptT  # empty-qthreads-chpl-opt
+qtTaskSpawn.h -staskingMode=qtChplLikeT       # empty-qthreads-chpl-like
+qtTaskSpawn.h -staskingMode=qtChplOptT        # empty-qthreads-chpl-opt
+qtTaskSpawn.h -staskingMode=qtSerialChplLikeT # empty-qthreads-serial-chpl-like
+qtTaskSpawn.h -staskingMode=qtSerialChplOptT  # empty-qthreads-serial-chpl-opt

--- a/test/parallel/taskCompare/elliot/ompTaskSpawn.h
+++ b/test/parallel/taskCompare/elliot/ompTaskSpawn.h
@@ -4,11 +4,15 @@
 #include <omp.h>
 #endif
 
-static void ompTaskSpawn(int64_t trials, int64_t numTasks) {
+static void ompTaskSpawn(int64_t trials, int64_t numTasks, int64_t runSerial) {
   int i, j;
 
   #ifdef _OPENMP
-  omp_set_num_threads(numTasks);
+  if (runSerial) {
+    omp_set_num_threads(1);
+  } else {
+    omp_set_num_threads(numTasks);
+  }
   #endif
 
   for (i=0; i<trials; i++) {

--- a/test/parallel/taskCompare/elliot/serialTaskSpawn.graph
+++ b/test/parallel/taskCompare/elliot/serialTaskSpawn.graph
@@ -1,0 +1,5 @@
+perfkeys: Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:, Elapsed time:
+graphkeys: serialized forall, serialized coforall, serialized for+begin, serialized omp parallel-for, serialized chpl-like qthreads, serialized chpl-opt qthreads
+files: empty-serial-forall.dat, empty-serial-coforall.dat, empty-serial-for+begin.dat, empty-omp-serial-parallel-for.dat, empty-qthreads-serial-chpl-like.dat, empty-qthreads-serial-chpl-opt.dat
+graphtitle: Empty Serialized Task Spawn Timings (500,000 x maxTaskPar)
+ylabel: Time (seconds)


### PR DESCRIPTION
Test perf of `serial do coforall 1..numTasks` and friends. This is intended to
help capture the amount of overhead outside of the tasking layer itself. i.e.
we will still manipulate our end counts and task counters and call into the
runtime, but then the "task" function will just be directly executed and no
tasks will be spawned.