### PR TITLE
Update some failing futures due to my initializers changes from yesterday

### DIFF
--- a/test/classes/vass/nested-class-with-user-defined-constructor-1.bad
+++ b/test/classes/vass/nested-class-with-user-defined-constructor-1.bad
@@ -1,1 +1,1 @@
-nested-class-with-user-defined-constructor-1.chpl:4: error: initializer for class 'inner' requires a generic argument called 'outer'
+nested-class-with-user-defined-constructor-1.chpl:4: error: constructor for class 'inner' requires a generic argument called 'outer'

--- a/test/types/records/ferguson/copy-init/new-init-generic.bad
+++ b/test/types/records/ferguson/copy-init/new-init-generic.bad
@@ -1,1 +1,6 @@
-new-init-generic.chpl:11: error: initializer for class 'R' requires a generic argument called 'x'
+new-init-generic.chpl:6: In initializer:
+new-init-generic.chpl:6: error: can't omit initialization of field "x", no type or default value provided
+new-init-generic.chpl:12: In initializer:
+new-init-generic.chpl:12: error: can't omit initialization of field "x", no type or default value provided
+new-init-generic.chpl:6: In initializer:
+new-init-generic.chpl:9: error: 'super' undeclared (first use this function)

--- a/test/types/records/ferguson/copy-init/new-init-generic.chpl
+++ b/test/types/records/ferguson/copy-init/new-init-generic.chpl
@@ -6,12 +6,14 @@ record R {
 proc R.init(x)
 {
   this.x = x;
+  super.init();
 }
 
 proc R.init(from)
 {
   writeln("In R.init");
   this.x = from.x;
+  super.init();
 }
 
 proc run() {

--- a/test/types/records/ferguson/copy-init/old-ctor-generic.bad
+++ b/test/types/records/ferguson/copy-init/old-ctor-generic.bad
@@ -1,1 +1,1 @@
-old-ctor-generic.chpl:6: error: initializer for class 'R' requires a generic argument called 'x'
+old-ctor-generic.chpl:6: error: constructor for class 'R' requires a generic argument called 'x'


### PR DESCRIPTION
I altered the analysis of initializers to insert Phase 1 initialization in
initializers that were otherwise Phase 2 only bodies.  This caused
test/types/records/ferguson/copy-init/new-init-generic.chpl to fail to match its
.bad file, because the initialization of the generic var field was not
explicitly in Phase 1 and so was viewed as omitted during that Phase.  I updated
the test to adjust for this.  My handling of "super" for records in this case
is not correct, so this update also impacted the .bad file (which would have
needed to be changed anyways because we do not correctly grab the initialization
and type information for generic fields yet anyways).

I also altered the handling of initializers to no longer insert a call to the
default constructor, changing the error message for constructors that elided
necessary generic arguments to indicate that they only impacted constructors.
This caused test/classes/vass/nested-class-with-user-defined-constructor-1.chpl
and test/types/records/ferguson/copy-init/old-ctor-generic.chpl to no longer
match their .bad files.