### PR TITLE
primitive codegen for TryStmt

### DIFF
--- a/compiler/AST/TryStmt.cpp
+++ b/compiler/AST/TryStmt.cpp
@@ -73,7 +73,3 @@ Expr* TryStmt::getFirstExpr() {
 Expr* TryStmt::getNextExpr(Expr* expr) {
   return this;
 }
-
-GenRet TryStmt::codegen() {
-  return GenRet(0);
-}

--- a/compiler/codegen/Makefile.share
+++ b/compiler/codegen/Makefile.share
@@ -28,6 +28,7 @@ CODEGEN_SRCS =                                          \
                alist.cpp                                \
                stmt.cpp                                 \
                symbol.cpp                               \
+               TryStmt.cpp                              \
                type.cpp
 
 

--- a/compiler/codegen/TryStmt.cpp
+++ b/compiler/codegen/TryStmt.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TryStmt.h"
+
+GenRet TryStmt::codegen() {
+  codegenStmt(this);
+
+  return body->codegen();
+}


### PR DESCRIPTION
@mppf:
- moved codegen from `AST/TryStmt.cpp` to `codegen/TryStmt.cpp`
- now invokes and returns the body's codegen
- passes linux64+flat testing