### PR TITLE
Cleanup inner loop for inlining

### DIFF
--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -205,6 +205,7 @@ static void inlineCall(CallExpr* call) {
     } else if (fn->retType == dtVoid) {
       stmt->remove();
 
+    // Replace the call with the return value
     } else {
       CallExpr* returnStmt  = toCallExpr(copy);
       Expr*     returnValue = returnStmt->get(1);

--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -32,7 +32,7 @@
 static void updateRefCalls();
 static void inlineFunctionsImpl();
 static void inlineFunction(FnSymbol* fn, std::set<FnSymbol*>& inlinedSet);
-static void inlineCall(FnSymbol* fn, CallExpr* call);
+static void inlineCall(CallExpr* call);
 static void updateDerefCalls();
 static void inlineCleanup();
 
@@ -155,7 +155,7 @@ static void simplifyBody(FnSymbol* fn) {
 static void inlineAtCallSites(FnSymbol* fn) {
   forv_Vec(CallExpr, call, *fn->calledBy) {
     if (call->isResolved()) {
-      inlineCall(fn, call);
+      inlineCall(call);
 
       if (report_inlining) {
         printf("chapel compiler: reporting inlining, "
@@ -172,12 +172,11 @@ static void inlineAtCallSites(FnSymbol* fn) {
 *                                                                             *
 ************************************** | *************************************/
 
-static void inlineCall(FnSymbol* fn, CallExpr* call) {
-  INT_ASSERT(call->resolvedFunction() == fn);
-
+static void inlineCall(CallExpr* call) {
   SET_LINENO(call);
 
-  Expr* stmt = call->getStmtExpr();
+  Expr*     stmt = call->getStmtExpr();
+  FnSymbol* fn   = call->resolvedFunction();
 
   //
   // calculate a map from actual symbols to formal symbols


### PR DESCRIPTION
Simplified logic for inlineCall() but no change in behavior.


A) Split this function in to two pieces 1) to create the copy of the function to be inlined 2) to
replace a call-site with the body of the copy


B) Simplify the business logic for replacing the call with the copy.  In the original version
this step creates invalid AST.

1) The copy of the called function is bundled as a complete BlockStmt and this block
is copied as the call site.

2) Then the return value is extracted from within the block-stmt and replaces the call site.
However this return symbol is declared within the block-stmt.

This doesn't cause a long term failure because later business logic simply flattens the block
statement.  However it is just as easy to implement this step in a manner that doesn't
temporarily introduce invalid AST; arguably even easier.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64

Tested on release/examples on clang/darwin and full paratest on linux-64 with --verify
