### PR TITLE
Changing fasta timers from default to high-precision

### DIFF
--- a/test/studies/shootout/fasta/bradc/PERFTIMEEXEC
+++ b/test/studies/shootout/fasta/bradc/PERFTIMEEXEC
@@ -1,1 +1,1 @@
-defaultTimer
+highPrecisionTimer

--- a/test/studies/shootout/fasta/caseyb/PERFTIMEEXEC
+++ b/test/studies/shootout/fasta/caseyb/PERFTIMEEXEC
@@ -1,1 +1,1 @@
-defaultTimer
+highPrecisionTimer

--- a/test/studies/shootout/fasta/kbrady/PERFTIMEEXEC
+++ b/test/studies/shootout/fasta/kbrady/PERFTIMEEXEC
@@ -1,1 +1,1 @@
-defaultTimer
+highPrecisionTimer


### PR DESCRIPTION
On the shootout machine, I'm seeing dramatically different timings
for command-line time vs. the h.p. timer for the reference version
of fasta.  I haven't seen the same with the Chapel versions, but in any
case, it doesn't seem like a good idea to be using different timers on
different versions of the benchmark (and the high precision timer is
what we use in the release version and seems closer to what is used
in the actual competition).