### PR TITLE
Further limit travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,8 @@
 language: c
 os:
   - linux
-  - osx
 compiler:
   - gcc
-  - clang
-
-matrix:
-  exclude:
-    - os: osx
-      compiler: gcc
-    - os: linux
-      compiler: clang
-
 
 script:
   - ./util/buildRelease/smokeTest


### PR DESCRIPTION
#4427 limited us to just linux+gcc and osx+clang testing in order to speed up
travis testing times. Unfortunately osx+clang testing is still taking ~30+
minutes during the work day because of travis's relatively limited osx
infrastructure, which leads to a large backlog of osx builds during the day.
This drops us to just linux+gcc testing for travis. Note that we still test
osx+clang (and other configs) internally post-commit.