### PR TITLE
Stop disabling affinity for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,7 @@ matrix:
 script:
   - ./util/buildRelease/smokeTest
 
-# Set QTHREAD_AFFINITY=no to avoid pinning to processors that we don't actually
-# have access to. This seems to be an artifact caused by the interaction
-# between docker and hwloc on Travis's docker images.
 env:
-  - NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no
+  - NIGHTLY_TEST_SETTINGS=true
 
 sudo: false


### PR DESCRIPTION
When we originally switched to travis's container-based infrastructure (#2195)
we had to disable qthreads affinity. We believe this was because hwloc tried to
pin to physical cpus that that container didn't actually have access to.

Things seem to have gotten better since then, so try re-enabling affinity.