### PR TITLE
Adjust verify on AggregateTypes

### DIFF
--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -521,8 +521,8 @@ static void checkAggregateTypes()
 {
   for_alive_in_Vec(AggregateType, at, gAggregateTypes)
   {
-    if (! at->defaultInitializer)
-      INT_FATAL(at, "aggregate type has no initializer");
+    if (! at->defaultInitializer && at->initializerStyle != DEFINES_INITIALIZER)
+      INT_FATAL(at, "aggregate type did not define an initializer and has no default constructor");
     if (! at->defaultTypeConstructor)
       INT_FATAL(at, "aggregate type has no default type constructor");
   }


### PR DESCRIPTION
After my change yesterday (PR #4980), verification started failing for my
initializer tests.  This is because --verify expects all AggregateTypes to have
their defaultInitializer field defined, but we've changed the expectation for
initializers so that if any initializer is defined, the default constructor or
initializer will not be generated.  Update the check to recognize that exception
to its rule.

- [x] full paratest run w/ verify