### PR TITLE
Update link to "Copies" chip from "Initializers" chip.

### DIFF
--- a/doc/developer/chips/10.rst
+++ b/doc/developer/chips/10.rst
@@ -507,7 +507,7 @@ For more details on when the copy initializer would be called, please refer to
 `CHIP 13 - When Do Records and Array Copies Occur`_
 
 .. _CHIP 13 - When Do Records and Array Copies Occur:
-   https://github.com/chapel-lang/chapel/blob/master/doc/chips/13.rst
+   https://github.com/chapel-lang/chapel/blob/master/doc/developer/chips/13.rst
 
 Summary
 +++++++


### PR DESCRIPTION
This link got broken with the docs reorg.  Restore it.