### PR TITLE
Next step towards using SymbolSymExprs more

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -169,26 +169,34 @@ void compute_call_sites() {
       fn->calledBy = new Vec<CallExpr*>();
   }
 
-  forv_Vec(CallExpr, call, gCallExprs) {
-    if (call->isEmpty() == true) {
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    for_SymbolSymExprs(se, fn) {
+      if (CallExpr* call = toCallExpr(se->parentExpr)) {
+        if (call->isEmpty() == true) {
+          assert(0); // not possible
 
-    } else if (isAlive(call) == false) {
+        } else if (isAlive(call) == false) {
+          assert(0); // not possible
 
-    } else if (FnSymbol* fn = call->resolvedFunction()) {
-      fn->calledBy->add(call);
+        } else if (fn == call->resolvedFunction()) {
+          fn->calledBy->add(call);
 
-    } else if (call->isPrimitive(PRIM_FTABLE_CALL)) {
-      // sjd: do we have to do anything special here?
-      //      should this call be added to some function's calledBy list?
+        } else if (call->isPrimitive(PRIM_FTABLE_CALL)) {
+          // sjd: do we have to do anything special here?
+          //      should this call be added to some function's calledBy list?
 
-    } else if (call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
-      FnSymbol*       fn       = toFnSymbol(toSymExpr(call->get(1))->symbol());
-      Vec<FnSymbol*>* children = virtualChildrenMap.get(fn);
+        } else if (call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
+          FnSymbol*      vFn       = toFnSymbol(toSymExpr(call->get(1))->symbol());
+          if (vFn == fn) {
+            Vec<FnSymbol*>* children = virtualChildrenMap.get(fn);
 
-      fn->calledBy->add(call);
+            fn->calledBy->add(call);
 
-      forv_Vec(FnSymbol, child, *children)
-        child->calledBy->add(call);
+            forv_Vec(FnSymbol, child, *children)
+              child->calledBy->add(call);
+          }
+        }
+      }
     }
   }
 }

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -73,6 +73,12 @@ void collectSymbolSetSymExprVec(BaseAST* ast,
                                 Vec<SymExpr*>& symExprs);
 
 //
+// collect set of symbols
+//
+void collectSymbolSet(BaseAST* ast, Vec<Symbol*>& symSet);
+
+
+//
 // Checks if a callExpr is one of the op= primitives
 // Note, this does not check if a callExpr is an
 // op= function call (such as before inlining)
@@ -100,10 +106,8 @@ int isDefAndOrUse(SymExpr* se);
 // vectors are built differently depending on the other arguments
 //
 
-// builds the vectors for every variable/argument in 'symSet' and
-// looks for uses and defs only in 'symExprs'
+// builds the vectors for every variable/argument in 'symSet'
 void buildDefUseMaps(Vec<Symbol*>& symSet,
-                     Vec<SymExpr*>& symExprs,
                      Map<Symbol*,Vec<SymExpr*>*>& defMap,
                      Map<Symbol*,Vec<SymExpr*>*>& useMap);
 
@@ -124,13 +128,6 @@ void buildDefUseMaps(BlockStmt* block,
                      Map<Symbol*,Vec<SymExpr*>*>& defMap,
                      Map<Symbol*,Vec<SymExpr*>*>& useMap);
 
-// builds the vectors for every variable/argument in 'symSet' and
-// looks for uses and defs in the entire program
-inline void buildDefUseMaps(Vec<Symbol*>& symSet,
-                     Map<Symbol*,Vec<SymExpr*>*>& defMap,
-                     Map<Symbol*,Vec<SymExpr*>*>& useMap) {
-  buildDefUseMaps(symSet, gSymExprs, defMap, useMap);
-}
 
 //
 // add a def to a defMap or a use to a useMap

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -1385,7 +1385,6 @@ size_t singleAssignmentRefPropagation(FnSymbol* fn) {
 
   Vec<Symbol*> refSet;
   Vec<Symbol*> refVec;
-  Vec<SymExpr*> symExprs;
   // Walk the asts in this function, and build lists of reference variables and sym exprs.
   for_vector(BaseAST, ast, asts) {
     if (VarSymbol* var = toVarSymbol(ast)) {
@@ -1393,8 +1392,6 @@ size_t singleAssignmentRefPropagation(FnSymbol* fn) {
         refVec.add(var);
         refSet.set_add(var);
       }
-    } else if (SymExpr* se = toSymExpr(ast)) {
-      symExprs.add(se);
     }
   }
 
@@ -1402,7 +1399,7 @@ size_t singleAssignmentRefPropagation(FnSymbol* fn) {
   // but restricted to only the ref variables therein.
   Map<Symbol*,Vec<SymExpr*>*> defMap;
   Map<Symbol*,Vec<SymExpr*>*> useMap;
-  buildDefUseMaps(refSet, symExprs, defMap, useMap);
+  buildDefUseMaps(refSet, defMap, useMap);
 
   s_ref_repl_count = 0;
   // Walk the list of reference vars

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -83,12 +83,11 @@ static bool isDeadVariable(Symbol* var,
 
 void deadVariableElimination(FnSymbol* fn) {
   Vec<Symbol*> symSet;
-  Vec<SymExpr*> symExprs;
-  collectSymbolSetSymExprVec(fn, symSet, symExprs);
+  collectSymbolSet(fn, symSet);
 
   Map<Symbol*,Vec<SymExpr*>*> defMap;
   Map<Symbol*,Vec<SymExpr*>*> useMap;
-  buildDefUseMaps(symSet, symExprs, defMap, useMap);
+  buildDefUseMaps(symSet, defMap, useMap);
 
   forv_Vec(Symbol, sym, symSet)
   {

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -239,12 +239,11 @@ void findCandidatesInFunc(FnSymbol *fn, UseDefCastMap& udcMap,
     SafeExprAnalysis& analysisData) {
 
   Vec<Symbol*> symSet;
-  Vec<SymExpr*> symExprs;
   Map<Symbol*,Vec<SymExpr*>*> defMap;
   Map<Symbol*,Vec<SymExpr*>*> useMap;
 
-  collectSymbolSetSymExprVec(fn, symSet, symExprs);
-  buildDefUseMaps(symSet, symExprs, defMap, useMap);
+  collectSymbolSet(fn, symSet);
+  buildDefUseMaps(symSet, defMap, useMap);
 
   findCandidatesInFuncOnlySym(fn, symSet, udcMap, analysisData);
 

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -897,7 +897,6 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
 
   Vec<Symbol*> symSet;
   std::vector<BaseAST*> asts;
-  Vec<SymExpr*> symExprs;
   collect_asts(rootModule, asts);
   for_vector(BaseAST, ast, asts) {
     if (DefExpr* def = toDefExpr(ast)) {
@@ -906,13 +905,11 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
           symSet.set_add(def->sym);
         }
       }
-    } else if (SymExpr* se = toSymExpr(ast)) {
-      symExprs.add(se);
     }
   }
   Map<Symbol*,Vec<SymExpr*>*> defMap;
   Map<Symbol*,Vec<SymExpr*>*> useMap;
-  buildDefUseMaps(symSet, symExprs, defMap, useMap);
+  buildDefUseMaps(symSet, defMap, useMap);
 
   forv_Vec(Symbol, var, heapAllocatedVars) {
     // find out if a variable that was put on the heap could be passed in as an


### PR DESCRIPTION
This PR adjusts bulidDefUseMaps and compute_call_sites to use SymbolSymExprs. It is an intermediate step. The next step is to entirely remove the vectors/sets associated with these functions and instead compute them on-the-fly. (Along with adding some helper functions to make that easy).


Passed full local testing.
Passed quickstart+verify testing.

Reviewed by @lydia-duncan - thanks!