### PR TITLE
Rewrite linear search to avoid 'break'

### DIFF
--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -150,16 +150,14 @@ proc randomMake(desc, nuclInfo, n) {
       var col = 0;
       var off = 0;
       for i in 0..#bytes {
-        //
-        // TODO: reference version doesn't use real, why do I?
-        //
         const r = rands[i];
-        for i in 1..numNucls {
-          if r < cumul_p[i] {
-            line_buff[off] = nuclInfo[i](nucl);
-            break;
-          }
-        }
+        var ncnt = 1;
+        for j in 1..numNucls do
+          if r >= cumul_p[j] then
+            ncnt += 1;
+
+        line_buff[off] = nuclInfo[ncnt](nucl);
+
         off += 1;
         col += 1;
         if (col == lineLength) {


### PR DESCRIPTION
It looks like a major performance delta between our fasta and
the reference one in terms of times was that we were using a
'break' in our linear search and they were not.  This rewrites
the linear search into a style more like the reference, shaving
some time off in the process (at least on my Mac and the
shootout machine, from my informal timings).