### PR TITLE
Fix annotations by removing extra '-' from config line

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -394,7 +394,7 @@ hpl_performance:
     - Fixed string leak in DimensionalDist2D (#3013)
   11/30/16:
     - text: Improvements to inferConstRefs (#4904)
-    - config: 16 node XC
+      config: 16 node XC
 
 init:
   05/03/16:
@@ -712,7 +712,7 @@ STREAM_performance:
 steam-promoted.xc-perf:
   12/02/16:
     - text: RVF reference fields with record-wrapped type (#4925)
-    - config: 16 node XC
+      config: 16 node XC
 
 STREAM_study:
   10/21/16:


### PR DESCRIPTION
We should really add some sort of annotation validator to the smoke test: https://github.com/chapel-lang/chapel/issues/4998