### PR TITLE
Fix race condition in counting number of PUs and begin refactoring locale models

### DIFF
--- a/modules/internal/LocaleModelHelp.chpl
+++ b/modules/internal/LocaleModelHelp.chpl
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// LocaleModelHelp.chpl
+//
+// Provides for declarations common to locale models
+// but that do not have to be the same in order to meet the
+// interface.
+
+// They are in this file as a practical matter to avoid code
+// duplication. If necessary, a locale model using this file
+// should feel free to reimplement them in some other way.
+module LocaleModelHelp {
+
+  use ChapelLocale;
+  use DefaultRectangular;
+  use ChapelNumLocales;
+  use Sys;
+
+  config param debugLocaleModel = false;
+
+  record chpl_root_locale_accum {
+    var nPUsPhysAcc: atomic int;
+    var nPUsPhysAll: atomic int;
+    var nPUsLogAcc: atomic int;
+    var nPUsLogAll: atomic int;
+    var maxTaskPar: atomic int;
+
+    proc accum(loc:locale) {
+      nPUsPhysAcc.add(loc.nPUsPhysAcc);
+      nPUsPhysAll.add(loc.nPUsPhysAll);
+      nPUsLogAcc.add(loc.nPUsLogAcc);
+      nPUsLogAll.add(loc.nPUsLogAll);
+      maxTaskPar.add(loc.maxTaskPar);
+    }
+    proc setRootLocaleValues(dst:RootLocale) {
+      dst.nPUsPhysAcc = nPUsPhysAcc.read();
+      dst.nPUsPhysAll = nPUsPhysAll.read();
+      dst.nPUsLogAcc = nPUsLogAcc.read();
+      dst.nPUsLogAll = nPUsLogAll.read();
+      dst.maxTaskPar = maxTaskPar.read();
+    }
+  }
+
+  proc helpSetupRootLocaleFlat(dst:RootLocale) {
+    var root_accum:chpl_root_locale_accum;
+
+    forall locIdx in dst.chpl_initOnLocales() {
+      const node = new LocaleModel(dst);
+      dst.myLocales[locIdx] = node;
+      root_accum.accum(node);
+    }
+
+    root_accum.setRootLocaleValues(dst);
+    here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
+  }
+
+  proc helpSetupRootLocaleNUMA(dst:RootLocale) {
+    var root_accum:chpl_root_locale_accum;
+
+    forall locIdx in dst.chpl_initOnLocales() {
+      chpl_task_setSubloc(c_sublocid_any);
+      const node = new LocaleModel(dst);
+      dst.myLocales[locIdx] = node;
+      root_accum.accum(node);
+    }
+
+    root_accum.setRootLocaleValues(dst);
+    here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
+  }
+
+}

--- a/modules/internal/LocaleModelHelpFlat.chpl
+++ b/modules/internal/LocaleModelHelpFlat.chpl
@@ -21,6 +21,6 @@ module LocaleModelHelpFlat {
 
   param localeModelHasSublocales = false;
 
-  use LocaleModelHelp;
+  use LocaleModelHelpSetup;
 
 }

--- a/modules/internal/LocaleModelHelpFlat.chpl
+++ b/modules/internal/LocaleModelHelpFlat.chpl
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module LocaleModelHelpFlat {
+
+  param localeModelHasSublocales = false;
+
+  use LocaleModelHelp;
+
+}

--- a/modules/internal/LocaleModelHelpNUMA.chpl
+++ b/modules/internal/LocaleModelHelpNUMA.chpl
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module LocaleModelHelpNUMA {
+
+  param localeModelHasSublocales = true;
+
+  use LocaleModelHelp;
+
+}

--- a/modules/internal/LocaleModelHelpNUMA.chpl
+++ b/modules/internal/LocaleModelHelpNUMA.chpl
@@ -21,6 +21,6 @@ module LocaleModelHelpNUMA {
 
   param localeModelHasSublocales = true;
 
-  use LocaleModelHelp;
+  use LocaleModelHelpSetup;
 
 }

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -19,7 +19,7 @@
 
 // LocaleModelHelpSetup.chpl
 //
-// Provides for declarations common to locale models
+// Provides for declarations common to locale model setup
 // but that do not have to be the same in order to meet the
 // interface.
 

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-// LocaleModelHelp.chpl
+// LocaleModelHelpSetup.chpl
 //
 // Provides for declarations common to locale models
 // but that do not have to be the same in order to meet the
@@ -26,7 +26,7 @@
 // They are in this file as a practical matter to avoid code
 // duplication. If necessary, a locale model using this file
 // should feel free to reimplement them in some other way.
-module LocaleModelHelp {
+module LocaleModelHelpSetup {
 
   use ChapelLocale;
   use DefaultRectangular;

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -28,14 +28,7 @@
 //
 module LocaleModel {
 
-  param localeModelHasSublocales = false;
-
-  use ChapelLocale;
-  use DefaultRectangular;
-  use ChapelNumLocales;
-  use Sys;
-
-  config param debugLocaleModel = false;
+  use LocaleModelHelpFlat;
 
   // We would really like a class-static storage class.(C++ nomenclature)
   var doneCreatingLocales: bool = false;
@@ -225,17 +218,7 @@ module LocaleModel {
     // parallel) over the locales to set up the LocaleModel object.
     // In addition, the initial 'here' must be set.
     proc setup() {
-      forall locIdx in chpl_initOnLocales() {
-        const node = new LocaleModel(this);
-        myLocales[locIdx] = node;
-        nPUsPhysAcc += node.nPUsPhysAcc;
-        nPUsPhysAll += node.nPUsPhysAll;
-        nPUsLogAcc += node.nPUsLogAcc;
-        nPUsLogAll += node.nPUsLogAll;
-        maxTaskPar += node.maxTaskPar;
-      }
-
-      here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
+      helpSetupRootLocaleFlat(this);
     }
 
     // Has to be globally unique and not equal to a node ID.

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -28,16 +28,9 @@
 //
 module LocaleModel {
 
-  param localeModelHasSublocales = true;
-
-  use ChapelLocale;
-  use DefaultRectangular;
-  use ChapelNumLocales;
-  use Sys;
+  use LocaleModelHelpNUMA;
 
   extern proc chpl_task_getRequestedSubloc(): int(32);
-
-  config param debugLocaleModel = false;
 
   // We would really like a class-static storage class.(C++ nomenclature)
   var doneCreatingLocales: bool = false;
@@ -306,18 +299,7 @@ module LocaleModel {
     // parallel) over the locales to set up the LocaleModel object.
     // In addition, the initial 'here' must be set.
     proc setup() {
-      forall locIdx in chpl_initOnLocales() {
-        chpl_task_setSubloc(c_sublocid_any);
-        const node = new LocaleModel(this);
-        myLocales[locIdx] = node;
-        nPUsPhysAcc += node.nPUsPhysAcc;
-        nPUsPhysAll += node.nPUsPhysAll;
-        nPUsLogAcc += node.nPUsLogAcc;
-        nPUsLogAll += node.nPUsLogAll;
-        maxTaskPar += node.maxTaskPar;
-      }
-
-      here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
+      helpSetupRootLocaleNUMA(this);
     }
 
     // Has to be globally unique and not equal to a node ID.

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -26,7 +26,6 @@ Parsing module files:
   $CHPL_HOME/modules/standard/Math.chpl
   $CHPL_HOME/modules/standard/CommDiagnostics.chpl
   $CHPL_HOME/modules/standard/gen/.../SysCTypes.chpl
-  $CHPL_HOME/modules/standard/Sys.chpl
   $CHPL_HOME/modules/dists/DSIUtil.chpl
   $CHPL_HOME/modules/packages/Sort.chpl
   $CHPL_HOME/modules/standard/Reflection.chpl
@@ -35,6 +34,7 @@ Parsing module files:
   $CHPL_HOME/modules/standard/IO.chpl
   $CHPL_HOME/modules/packages/RangeChunk.chpl
   $CHPL_HOME/modules/packages/Search.chpl
+  $CHPL_HOME/modules/standard/Sys.chpl
   $CHPL_HOME/modules/standard/Error.chpl
   $CHPL_HOME/modules/standard/Regexp.chpl
 In bar

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -15,14 +15,15 @@ Initializing Modules:
     ChapelTuple
     ChapelRange
     LocaleModel
-     ChapelLocale
-     DefaultRectangular
-      DSIUtil
-      ChapelArray
-       Sort
-     ChapelNumLocales
-     Sys
-      SysBasic
+     LocaleModelHelp
+      ChapelLocale
+      DefaultRectangular
+       DSIUtil
+       ChapelArray
+        Sort
+      ChapelNumLocales
+      Sys
+       SysBasic
     LocalesArray
     ChapelDistribution
      List

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -15,7 +15,7 @@ Initializing Modules:
     ChapelTuple
     ChapelRange
     LocaleModel
-     LocaleModelHelp
+     LocaleModelHelpSetup
       ChapelLocale
       DefaultRectangular
        DSIUtil

--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
@@ -1,1 +1,1 @@
-Removed 19 dead modules.
+Removed 20 dead modules.


### PR DESCRIPTION
There was a race condition in initializing the root locale, caused by each node writing to the number of PUs simultaneously.  This change removes the race condition by accumulating the values into atomic variables.

To reduce the amount of duplicated code between different locale models, the new code is placed in a common helper file.  This is the beginning of a larger code restructuring to make it easier to implement new locale models such as the one for KNL.

A few expected test results had to be adjusted due to the new module being added.  The code has been tested with the flat locale model on Linux and Mac, and the flat and numa locale models on Crays, including KNL.