### PR TITLE
 Fix casting bug exposed by denormalize

### DIFF
--- a/compiler/util/exprAnalysis.cpp
+++ b/compiler/util/exprAnalysis.cpp
@@ -117,7 +117,7 @@ bool SafeExprAnalysis::fnHasNoSideEffects(FnSymbol* fnSym) {
 
   // check if fn have any ref arguments
   for_formals(formal, fnSym) {
-    if(isReferenceType(formal->typeInfo())) {
+    if (formal->isRef()) {
       safeFnCache[fnSym] = false;
       return false;
     }


### PR DESCRIPTION
Denormalization was turning AST like this:
```
(move notRef Ref) // deref-move
...(cast (int64) notRef)...
```
Into this: ``(cast (int64) Ref)``

This kind of transformation lost the implicit dereference, and we ended up casting the _ref_int64_t into an int64_t. I don't know how this didn't cause a ton of correctness issues.

This PR updates the PRIM_CAST codegen to dereference the source if the destination type is not a reference and the source type is a reference.

I also updated a case where we checked for a _ref type to use "->isRef()" instead, but it has nothing to do with the casting bug.

Testing:
- [x] full local
- [x] full no-local