### PR TITLE
Add --ieee-float to HPCC FFT test

### DIFF
--- a/test/release/examples/benchmarks/hpcc/fft.compopts
+++ b/test/release/examples/benchmarks/hpcc/fft.compopts
@@ -1,0 +1,1 @@
+--ieee-float

--- a/test/release/examples/benchmarks/hpcc/fft.perfcompopts
+++ b/test/release/examples/benchmarks/hpcc/fft.perfcompopts
@@ -1,0 +1,1 @@
+--fast --ieee-float


### PR DESCRIPTION
A reasonable alternative would be to change the tolerance in the
test. I tried quickly looking at the HPCC challenge reference version
but it wasn't immediately obvious how the error checking corresponded.
In particular , the reference version (1.5.0) uses

    if (maxErr / log(n) / deps < params->test.thrsh) failure = 0;

where params->test.thrsh is 16 by default, and deps may be the
machine precision. Our version does not seem to have this division
by log(n) and I do not know why.