### PR TITLE
start_test should set its own test_dir from --test-root-dir cmdline arg

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -590,7 +590,7 @@ def check_environment_with_args():
 
     auto_gen_spec_tests = os.access(os.path.join(home, "spec"), os.F_OK)
 
-    if args.test_root_dir and re.match(r'/+[^/]', str(args.test_root_dir)):
+    if args.test_root_dir:
         test_dir = str(args.test_root_dir)
     else:
         test_dir = os.path.join(home, "test")

--- a/util/start_test
+++ b/util/start_test
@@ -39,6 +39,8 @@ def main():
     preprocess_options()
     args = parser.parse_args()
 
+    check_environment_with_args()
+
     invocation_dir = os.getcwd()
     
     run_tests(args.tests)
@@ -582,17 +584,24 @@ def check_environment():
             print("Error: Cannot find {0}.".format(util_dir))
             sys.exit(1)
 
+def check_environment_with_args():
     # find test dir and check for access
     global test_dir, auto_gen_spec_tests
-    test_dir = os.path.join(home, "test")
+
     auto_gen_spec_tests = os.access(os.path.join(home, "spec"), os.F_OK)
-    if (not os.access(test_dir, os.F_OK) or not os.access(test_dir, os.W_OK)
-        or not os.access(test_dir, os.X_OK)):
-        test_dir = os.path.join(home, "examples")
-        auto_gen_spec_tests = False
+
+    if args.test_root_dir and re.match(r'/+[^/]', str(args.test_root_dir)):
+        test_dir = str(args.test_root_dir)
+    else:
+        test_dir = os.path.join(home, "test")
         if (not os.access(test_dir, os.F_OK) or not os.access(test_dir, os.W_OK)
             or not os.access(test_dir, os.X_OK)):
-            test_dir = os.getcwd()
+            test_dir = os.path.join(home, "examples")
+            auto_gen_spec_tests = False
+            if (not os.access(test_dir, os.F_OK) or not os.access(test_dir, os.W_OK)
+                or not os.access(test_dir, os.X_OK)):
+                test_dir = os.getcwd()
+
     if (not os.access(test_dir, os.F_OK) or not os.access(test_dir, os.W_OK)
         or not os.access(test_dir, os.X_OK)):
         print("Cannot write to test directory {0}".format(test_dir))


### PR DESCRIPTION
Currently, start_test recognizes a cmdline argument --test-root-dir,
ie, path to the top of the test tree, usually chapel.git/test.
However, start_test does not actually use the argument value itself;
start_test only passes the value down to sub_test through env var
CHPL_TEST_ROOT_DIR. Cray module tests needed this feature to be able
to have CHPL_HOME point to the installed Chapel Module, but actually
run the tests out of a separate copy of chapel.git/test plus overlays
from chapel-code.

start_test itself sets up an internal variable test_dir, derived from
CHPL_HOME or cwd, and uses that for most work that start_test actually
does. For performance tests, this includes running genGraphs and some
related GRAPHFILEs sniffing. The only way this genGraphs stuff works
for perf tests run from an installed Cray module, is for the caller
of start_test to first copy the entire test tree from chapel.git/test
into CHPL_HOME (ie, the installed Cray module).

This change simply makes start_test use the given value of
--test-root-dir (if any) as its own internal test_dir location,
just so the above genGraphs-related stuff will work on the Cray,
without anyone needing to copy the test tree into CHPL_HOME.

If --test-root-dir is not given, start_test will derive test_dir
the same way as before.

This change is needed to implement the 'Stop re-installing the Cray
Module in every test job' PR, in chapel-code. However, it should
not do any harm if merged independently.