### PR TITLE
Change fasta syncs to atomics

### DIFF
--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -8,10 +8,10 @@
      Kyle Brady, and Preston Sahabu.
 */
 
-config const n = 1000,                   // the length of the generated strings
-             lineLength = 60,            // the number of columns in the output
-             blockSize = 1024,           // the parallelization granularity
-             numTasks = here.maxTaskPar; // the degree of parallelization
+config const n = 1000,           // the length of the generated strings
+             lineLength = 60,    // the number of columns in the output
+             blockSize = 1024,   // the parallelization granularity
+             numTasks = 3;       // the pipeline has 3 stages, so use 3 tasks
 
 //
 // Nucleotide definitions

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -140,7 +140,7 @@ proc randomMake(desc, nuclInfo, n) {
     const chunkSize = lineLength*blockSize;
     const nextTask = (tid + 1) % numTasks;
 
-    var line_buff: [0..(lineLength+1)*blockSize+1] int(8);
+    var line_buff: [0..(lineLength+1)*blockSize-1] int(8);
     var rands: [0..chunkSize] int/*(32)*/;
 
     //


### PR DESCRIPTION
This PR changes my study version of fasta to use atomics rather than sync vars.  This results in a big speed improvement for the shootout box.

The characteristic of the benchmark is that it has a small number of tasks (3 at most), so having them actively spin wait on atomics is a reasonable thing to do for processors with 4+ cores whild also being lower overhead than using sync variables (or, at least, it's proving to be in my experiments).  The default number of tasks limits the number to 'here.maxTaskPar' in order to avoid the deadlocks that can occur from busy-waiting.  There's some chance that I didn't get the logic here correct (i.e., is there some way it could still starve the tasks?  It doesn't seem like it, but race conditions and tasking are tricky...), but I didn't want to move to backoff locks without being more certain it was necessary because of (1) the code size overhead and (2) not wanting to experiment with how many spins would be necessary to avoid backing off in a "real" run.  I did do some testing with --memleaks on to see if I'd get deadlocks and did not see any.  I also tested with one runtime thread to make sure that running on a single-core machine would work.

While here, I also tightened up the size required by the buffer slightly