### PR TITLE
Fix sense of conditional in --help future

### DIFF
--- a/test/execflags/bradc/configHelp.chpl
+++ b/test/execflags/bradc/configHelp.chpl
@@ -1,6 +1,6 @@
 config const help = false;
 
-if false then printUsage();
+if help then printUsage();
 
 proc printUsage() {
   writeln("This is my custom usage message!");


### PR DESCRIPTION
[pointed out by @mppf]

I think what happened was that after writing it, I hardcoded it to
'true' to verify the .good file and then mistakenly changed it to
'false' rather than 'help' upon fixing it.