### PR TITLE
Fix hugepages

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -311,7 +311,11 @@ void chpl_computeHeapPageSize(void) {
 #endif
 
   // note: sets heapPageSize
-  computeHeapPageSizeByGuessing(pageSize);
+  if (pageSize == chpl_getSysPageSize()) {
+    computeHeapPageSizeByGuessing(pageSize);
+  } else {
+    heapPageSize = pageSize;
+  }
 }
 
 

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -310,10 +310,15 @@ void chpl_computeHeapPageSize(void) {
   pageSize = chpl_getSysPageSize();
 #endif
 
-  // note: sets heapPageSize
   if (pageSize == chpl_getSysPageSize()) {
+    // if the page size is the system page size, check that
+    // the heap isn't on hugepages when nobody told us.
+    //
+    // note: sets heapPageSize
     computeHeapPageSizeByGuessing(pageSize);
   } else {
+    // if the page size was configured by the user to be huge,
+    // just trust it.
     heapPageSize = pageSize;
   }
 }


### PR DESCRIPTION
Fixes a problem with chpl_computeHeapPageSize that @benharsh noticed with CHPL_COMM=ugni that was introduced by PR #4931.

computeHeapPageSizeByGuessing seems to be causing some sort of problem. It was added for the case that CHPL_COMM=gasnet provides the heap on huge pages, but huge pages aren't configured. Now CHPL_COMM=ugni is running into problems when huge pages are requested. So, this PR simply changes to trusting the user if a huge page size is set (which we used to do).

- [ ] get Greg's feedback
- [ ] test with CHPL_COMM=ugni and no huge page module loaded
- [ ] test with CHPL_COMM=ugni and a huge page module loaded
- [ ] test with CHPL_COMM=gasnet and a huge page module loaded
- [ ] test with CHPL_COMM=gasnet and no huge page module loaded