### PR TITLE
FnSymbol::throwsError() should be const

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1554,7 +1554,7 @@ void FnSymbol::throwsErrorInit() {
   _throwsError = true;
 }
 
-bool FnSymbol::throwsError() {
+bool FnSymbol::throwsError() const {
   return _throwsError;
 }
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -478,7 +478,7 @@ class FnSymbol : public Symbol {
   virtual void    printDocs(std::ostream *file, unsigned int tabs);
 
   void            throwsErrorInit();
-  bool            throwsError();
+  bool            throwsError()                                const;
 
 private:
   virtual std::string docsDirective();


### PR DESCRIPTION
[trivial change, meant to include with #5007]