### PR TITLE
Error handling futures, CHIP 8 improvements

### DIFF
--- a/doc/developer/chips/8.rst
+++ b/doc/developer/chips/8.rst
@@ -211,9 +211,13 @@ the compiler will run checks in one of two modes, based on a flag.
 
 If a call to a throwing procedure is not enclosed by a ``try`` or ``try!``: 
 
-1. **Default.**: the program will compile with a warning. An error will
-   be propagated by the calling procedure if it ``throws``, and will
-   ``halt()`` if it does not throw.
+1. **Default.**: 
+
+   a. if the call is contained in a procedure labelled with ``throws``, any
+      error encountered will be propagated.
+
+   b. if the call is contained in a procedure not labelled with ``throws``,
+      the program will ``halt()`` if an error is encountered.
 
 2. **Strict.**: the compiler will raise an error.
 

--- a/doc/developer/chips/8.rst
+++ b/doc/developer/chips/8.rst
@@ -175,6 +175,7 @@ Syntax
 ::
 
   proc canThrowErrors() throws { … }
+  proc canAlsoThrowErrors(): A throws where ... { … }
   proc cannotThrowErrors() { … }
 
 * Errors can be handled with ``catch`` statements.
@@ -208,14 +209,15 @@ Default vs strict mode
 To address the desire for both fast prototyping and enforced error handling,
 the compiler will run checks in one of two modes, based on a flag.
 
-1. **Default.** If a call to a throwing procedure is not enclosed by a ``try``
-   or ``try!``, the program will compile with a warning and the call will
-   ``halt()`` on an error.
+If a call to a throwing procedure is not enclosed by a ``try`` or ``try!``: 
 
-2. **Strict.** If a call to a throwing procedure is not enclosed by a ``try``
-   or ``try!``, the compiler will raise an error.
+1. **Default.**: the program will compile with a warning. An error will
+   be propagated by the calling procedure if it ``throws``, and will
+   ``halt()`` if it does not throw.
 
-A more fine-grained approach should be included in the future, with the
+2. **Strict.**: the compiler will raise an error.
+
+A more fine-grained approach will be included in the future, with the
 default/strict policy set per-module or per-function.
 
 Errors

--- a/test/errhandling/catch-match.bad
+++ b/test/errhandling/catch-match.bad
@@ -1,0 +1,1 @@
+catch-match.chpl:6: syntax error: near 'new'

--- a/test/errhandling/catch-match.chpl
+++ b/test/errhandling/catch-match.chpl
@@ -1,0 +1,27 @@
+class OtherError: Error {
+
+}
+
+proc throwAnError() throws {
+  throw new Error();
+}
+
+proc throwOtherError throws {
+  throw new OtherError;
+}
+
+try {
+  throwAnError();
+} catch e: OtherError {
+  write("should not catch here");
+} catch {
+  write("caught Error");
+}
+
+try {
+  throwOtherError();
+} catch e: OtherError {
+  write("caught OtherError");
+} catch {
+  write("should not catch here");
+}

--- a/test/errhandling/catch-match.future
+++ b/test/errhandling/catch-match.future
@@ -1,0 +1,4 @@
+unimplemented: matching errors to catch blocks
+
+If an error is caught by a try block then it should
+direct control flow to a matching catch block.

--- a/test/errhandling/catch-match.good
+++ b/test/errhandling/catch-match.good
@@ -1,0 +1,2 @@
+caught Error
+caught OtherError

--- a/test/errhandling/try-bang.bad
+++ b/test/errhandling/try-bang.bad
@@ -1,0 +1,1 @@
+try-bang.chpl:2: syntax error: near 'new'

--- a/test/errhandling/try-bang.chpl
+++ b/test/errhandling/try-bang.chpl
@@ -1,0 +1,9 @@
+proc throwAnError() throws {
+  throw new Error();
+}
+
+write("should not continue");
+
+try! throwAnError();
+
+write("continued");

--- a/test/errhandling/try-bang.future
+++ b/test/errhandling/try-bang.future
@@ -1,0 +1,4 @@
+unimplemented: single statement try!
+
+If a statement that may throw an error is preceded by
+try!, an error will cause the program to halt(). 

--- a/test/errhandling/try-bang.good
+++ b/test/errhandling/try-bang.good
@@ -1,0 +1,1 @@
+should not continue

--- a/test/errhandling/try-catch.bad
+++ b/test/errhandling/try-catch.bad
@@ -1,0 +1,1 @@
+try-catch.chpl:2: syntax error: near 'new'

--- a/test/errhandling/try-catch.chpl
+++ b/test/errhandling/try-catch.chpl
@@ -1,0 +1,9 @@
+proc throwAnError() throws {
+  throw new Error();
+}
+
+try {
+  throwAnError();
+} catch {
+  write("caught an error");
+}

--- a/test/errhandling/try-catch.future
+++ b/test/errhandling/try-catch.future
@@ -1,0 +1,4 @@
+unimplemented: basic error handling
+
+A function that only throws an Error is called within the
+try block and should be handled by the catch block.

--- a/test/errhandling/try-catch.good
+++ b/test/errhandling/try-catch.good
@@ -1,0 +1,1 @@
+caught an error

--- a/test/errhandling/try-propagation.bad
+++ b/test/errhandling/try-propagation.bad
@@ -1,0 +1,1 @@
+try-propagation.chpl:2: syntax error: near 'new'

--- a/test/errhandling/try-propagation.chpl
+++ b/test/errhandling/try-propagation.chpl
@@ -1,0 +1,15 @@
+proc throwAnError() throws {
+  throw new Error();
+}
+
+proc throwAnErrorToo() throws {
+  try {
+    throwAnError();
+  }
+}
+
+try {
+  throwAnErrorToo();
+} catch {
+  write("caught an error");
+}

--- a/test/errhandling/try-propagation.future
+++ b/test/errhandling/try-propagation.future
@@ -1,0 +1,6 @@
+unimplemented: propagating an error with try 
+
+If a statement that may throw an error is enclosed by
+a try block, but a resulting error does not match an
+associated catch block, the error will be propagated
+out of the procedure if it throws. 

--- a/test/errhandling/try-propagation.good
+++ b/test/errhandling/try-propagation.good
@@ -1,0 +1,1 @@
+caught an error


### PR DESCRIPTION
- updated the CHIP to include auto-propagation in Default mode
- added four futures to `test/errhandling`:
  - basic `try-catch`
  - matching errors to a `catch`
  - propagating an error with `try`
  - single-statement `try!`