### PR TITLE
Remove old native qthreads sync var prototype code

### DIFF
--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -64,51 +64,6 @@ typedef struct {
     syncvar_t signal_empty;
 } chpl_sync_aux_t;
 
-#define chpl_sync_reset(x) qthread_syncvar_empty(&(x)->sync_aux.signal_full)
-
-#define chpl_read_FE(x) ({                                                           \
-                             uint64_t y;                                             \
-                             qthread_syncvar_readFE(&y, &(x)->sync_aux.signal_full); \
-                             y; })
-
-#define chpl_read_FF(x) ({                                                           \
-                             uint64_t y;                                             \
-                             qthread_syncvar_readFF(&y, &(x)->sync_aux.signal_full); \
-                             y; })
-
-#define chpl_read_XX(x) ((x)->sync_aux.signal_full.u.s.data)
-
-#define chpl_write_EF(x, y) do {                                 \
-        uint64_t z = (uint64_t)(y);                              \
-        qthread_syncvar_writeEF(&(x)->sync_aux.signal_full, &z); \
-} while(0)
-
-#define chpl_write_FF(x, y) do {                                    \
-        uint64_t z, dummy;                                          \
-        z = (uint64_t)(y);                                          \
-        qthread_syncvar_readFE(&dummy, &(x)->sync_aux.signal_full); \
-        qthread_syncvar_writeF(&(x)->sync_aux.signal_full, &z);     \
-} while(0)
-
-#define chpl_write_XF(x, y) do {                                \
-        uint64_t z = (uint64_t)(y);                             \
-        qthread_syncvar_writeF(&(x)->sync_aux.signal_full, &z); \
-} while(0)
-
-#define chpl_single_reset(x) qthread_syncvar_empty(&(x)->single_aux.signal_full)
-
-#define chpl_single_read_FF(x) ({                                                             \
-                                    uint64_t y;                                               \
-                                    qthread_syncvar_readFF(&y, &(x)->single_aux.signal_full); \
-                                    y; })
-
-#define chpl_single_write_EF(x, y) do {                            \
-        uint64_t z = (uint64_t)(y);                                \
-        qthread_syncvar_writeEF(&(x)->single_aux.signal_full, &z); \
-} while(0)
-
-#define chpl_single_read_XX(x) ((x)->single_aux.signal_full.u.s.data)
-
 //
 // Task private data
 //


### PR DESCRIPTION
Remove some old (and so far as I can tell never used) code in our qthreads shim
that attempted to map simple sync/single types down to native qthread sync
vars.

It looks like this was originally added to qthreads in https://github.com/Qthreads/qthreads/commit/c97ab1f.

It made use of the old "fast" sync var machinery that MTA used (https://github.com/chapel-lang/chapel/commit/8503f6e) but so
far as I can tell it was never enabled.

https://github.com/chapel-lang/chapel/commit/d770743 removed all the old mta code and https://github.com/chapel-lang/chapel/pull/4489 added true support native 
qthread sync vars, so this code is no longer needed.