### PR TITLE
Add missing argument to buildFunctionDecl

### DIFF
--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -323,8 +323,13 @@ void convertDeclToChpl(ModuleSymbol* module, const char* name, Vec<Expr*> & resu
     f->addFlag(FLAG_EXTERN);
     f->addFlag(FLAG_LOCAL_ARGS);
     Expr* chpl_type = convertToChplType(module, resultType.getTypePtr(), results);
-    BlockStmt* result = buildFunctionDecl(
-       f, RET_VALUE, chpl_type, NULL, NULL, NULL);
+    BlockStmt* result = buildFunctionDecl( f, // fn
+                                           RET_VALUE, // retTag
+                                           chpl_type, // ret type
+                                           false,  // throws
+                                           NULL, // where
+                                           NULL, // body
+                                           NULL); // docs
 
     //convert args
     for (clang::FunctionDecl::param_iterator it=fd->param_begin(); it < fd->param_end(); ++it) {


### PR DESCRIPTION
PR #5007 changed buildFunctionDecl but didn't adjust LLVM-specific code (supporting extern blocks) that works with it, causing LLVM builds to fail. This PR fixes that.

Passed test/extern/ferguson with CHPL_LLVM=llvm.
Passed hellos with --llvm.
Trivial and not reviewed.