### PR TITLE
Clean up runtime include paths

### DIFF
--- a/runtime/make/Makefile.runtime.head
+++ b/runtime/make/Makefile.runtime.head
@@ -42,8 +42,6 @@ include $(RUNTIME_ROOT)/../make/Makefile.base
 
 LAUNCHER_CFLAGS = $(RUNTIME_CFLAGS) -DLAUNCHER
 LAUNCHER_INCLS = \
-        -I$(RUNTIME_ROOT)/include/comp-$(CHPL_MAKE_HOST_COMPILER) \
-        -I$(RUNTIME_ROOT)/include/$(subst -sim,,$(CHPL_MAKE_HOST_PLATFORM)) \
         -I$(RUNTIME_ROOT)/include/comm/$(CHPL_MAKE_COMM) \
         -I$(RUNTIME_ROOT)/include/comm \
         -I$(RUNTIME_ROOT)/include

--- a/runtime/make/Makefile.runtime.include
+++ b/runtime/make/Makefile.runtime.include
@@ -65,14 +65,12 @@ RUNTIME_INCLS += \
         -I$(RUNTIME_INCLUDE_ROOT)/comm \
         -I$(RUNTIME_INCLUDE_ROOT)/tasks/$(CHPL_MAKE_TASKS) \
         -I$(RUNTIME_INCLUDE_ROOT)/threads/$(CHPL_MAKE_THREADS) \
-        -I$(RUNTIME_INCLUDE_ROOT)/comp-$(CHPL_MAKE_COMPILER) \
-        -I$(RUNTIME_INCLUDE_ROOT)/$(subst -sim,,$(CHPL_MAKE_TARGET_PLATFORM)) \
         -I$(RUNTIME_INCLUDE_ROOT) \
         -I$(RUNTIME_INCLUDE_ROOT)/qio \
         -I$(RUNTIME_INCLUDE_ROOT)/atomics/$(CHPL_MAKE_ATOMICS) \
         -I$(RUNTIME_INCLUDE_ROOT)/mem/$(CHPL_MAKE_MEM) \
         -I$(THIRD_PARTY_DIR)/utf8-decoder \
-        -I$(CHPL_MAKE_HOME)/runtime/src/$(RUNTIME_OBJDIR) \
+        -I$(RUNTIME_BUILD)/include \
 
 RUNTIME_CYGWIN=0
 ifeq ($(CHPL_MAKE_TARGET_PLATFORM),cygwin32)


### PR DESCRIPTION
- Fix runtime include path for chpl-env-gen.h
- Removed bogus paths

@mppf 

Tested hello*.chpl with CHPL_COMM=none and gasnet.