### PR TITLE
Make libnuma available on Crays when needed

### DIFF
--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -54,6 +54,17 @@ GEN_DYNAMIC_FLAG = -dynamic
 LIB_STATIC_FLAG =
 LIB_DYNAMIC_FLAG = -shared
 
+# Determine whether we need libnuma.  No static version of it is available.
+# If memkind is loaded, we need libnuma, and linking defaults to dynamic.
+# Otherwise, if the locale model is not flat, we need libnuma, and
+# linking must be forced to dynamic.
+ifneq (,$(CRAY_MEMKIND))
+CHPL_HWLOC_MORE_CFG_OPTIONS += --enable-libnuma
+else ifneq ($(CHPL_MAKE_LOCALE_MODEL), flat)
+CHPL_HWLOC_MORE_CFG_OPTIONS += --enable-libnuma
+RUNTIME_LFLAGS += -dynamic
+endif
+
 # Don't throw e.g. -march with a PrgEnv compiler since the PrgEnv environment
 # will take care of that Since we want to be able to get other flags from e.g.
 # Makefile.intel, here we replace SPECIALIZE_CFLAGS with nothing.

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -72,7 +72,10 @@ hwloc-config: FORCE
 # Then configure
 #
 	mkdir -p $(HWLOC_BUILD_DIR)
-	cd $(HWLOC_BUILD_DIR) && $(HWLOC_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CFLAGS)' --prefix=$(HWLOC_INSTALL_DIR) $(CHPL_HWLOC_CFG_OPTIONS)
+	cd $(HWLOC_BUILD_DIR) && $(HWLOC_SUBDIR)/configure CC='$(CC)' \
+		CFLAGS='$(CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CFLAGS)' \
+		LDFLAGS='$(RUNTIME_LFLAGS)' --prefix=$(HWLOC_INSTALL_DIR) \
+		$(CHPL_HWLOC_CFG_OPTIONS)
 
 hwloc-build: FORCE
 	cd $(HWLOC_BUILD_DIR) && $(MAKE)

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -106,7 +106,7 @@ qthread-config: FORCE
 	mkdir -p $(QTHREAD_BUILD_DIR)
 	cd $(QTHREAD_BUILD_DIR) \
 	&& $(QTHREAD_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS)' \
-	       CXX='$(CXX)'  CXXFLAGS='$(CFLAGS)' \
+	       CXX='$(CXX)'  CXXFLAGS='$(CFLAGS)' LDFLAGS='$(RUNTIME_LFLAGS)' \
 	       --prefix=$(QTHREAD_INSTALL_DIR) $(CHPL_QTHREAD_CFG_OPTIONS)
 
 qthread-build: FORCE

--- a/util/start_test
+++ b/util/start_test
@@ -676,7 +676,11 @@ def set_up_environment():
         args.performance = True
         args.gen_graphs = True
         args.compopts += " --fast"
-        if not tgt_platform == "darwin":
+        # Force static linking unless the target requires dynamic.
+        if (tgt_platform != 'darwin' and
+            not (chpl_compiler.get('target').startswith("cray-prgenv") and
+                 (os.getenv("CRAY_MEMKIND", "") != "" or
+                  chpl_locale_model.get() != 'flat'))):
             args.compopts += " --static"
 
     if args.performance_configs:


### PR DESCRIPTION
The memkind library requires libnuma, and there is no static version of either one of them.

On Crays, when the cray-memkind module is loaded (which also sets the default link mode to dynamic), we get libnuma whether we want it or not, so hwloc should take advantage of it.  This change does so for that case.

On Crays, when a non-flat locale model is used, we need hwloc to have access to libnuma, otherwise we will be unable to specify from which numa node a memory allocation should occur.  This change enables libnuma for that case as well.

This was tested on Mac, Linux, and Crays, including KNL with and without memkind, and with and without a flat locale model.