### PR TITLE
Add domain.contains as a synonym for domain.member

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1214,6 +1214,16 @@ module ChapelArray {
     proc member(i: _value.idxType ...rank) {
       return member(i);
     }
+    pragma "no doc"
+    proc contains(i: rank*_value.idxType) {
+      return member(i);
+    }
+    /* Same as domain.member().
+       Return true if ``i`` is a member of this domain. Otherwise
+       return false. */
+    proc contains(i: _value.idxType ...rank) {
+      return member(i);
+    }
 
     pragma "no doc"
     pragma "reference to const when const this"

--- a/test/domains/ferguson/contains.chpl
+++ b/test/domains/ferguson/contains.chpl
@@ -1,0 +1,7 @@
+var D:domain(int);
+
+D += 4;
+
+assert(D.contains(4));
+assert(!D.contains(3));
+


### PR DESCRIPTION
- [ ] testing
- [ ] add a compiler warning to deprecate domain.member
- [ ] no-doc domain.member
- [ ] add deprecation tests, indicate removal for 1.17
