### PR TITLE
Pre-exec files should check CHPL_TEST_ROOT_DIR before CHPL_HOME

### DIFF
--- a/test/release/examples/benchmarks/shootout/knucleotide.preexec
+++ b/test/release/examples/benchmarks/shootout/knucleotide.preexec
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/release/examples/benchmarks/shootout/regexdna.preexec
+++ b/test/release/examples/benchmarks/shootout/regexdna.preexec
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/release/examples/benchmarks/shootout/revcomp.preexec
+++ b/test/release/examples/benchmarks/shootout/revcomp.preexec
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/k-nucleotide/bharshbarg/PREEXEC
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/PREEXEC
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/k-nucleotide/bradc/PREEXEC
+++ b/test/studies/shootout/k-nucleotide/bradc/PREEXEC
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/regex-dna/bharshbarg/PREEXEC
+++ b/test/studies/shootout/regex-dna/bharshbarg/PREEXEC
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/reverse-complement/bharshbarg/PREEXEC
+++ b/test/studies/shootout/reverse-complement/bharshbarg/PREEXEC
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/reverse-complement/bradc/PREEXEC
+++ b/test/studies/shootout/reverse-complement/bradc/PREEXEC
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/submitted/knucleotide.preexec
+++ b/test/studies/shootout/submitted/knucleotide.preexec
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/submitted/regexdna.preexec
+++ b/test/studies/shootout/submitted/regexdna.preexec
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big

--- a/test/studies/shootout/submitted/revcomp.preexec
+++ b/test/studies/shootout/submitted/revcomp.preexec
@@ -7,7 +7,7 @@ set -e
 # Only run this script when doing a perf run
 if [ -n "$CHPL_TEST_PERF" ] && [ ! -f $CHPL_TEST_TMP_DIR/fasta.big ]; then
   # '$3' is the compiler given to us by sub_test
-  $3 $CHPL_HOME/test/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
+  $3 ${CHPL_TEST_ROOT_DIR:-$CHPL_HOME/test}/studies/shootout/fasta/kbrady/fasta-printf.chpl --fast -o tmpFasta
   
   # needed by k-nucleotide and reverse-complement
   ./tmpFasta --n=25000000 -nl 1 > $CHPL_TEST_TMP_DIR/fasta.big


### PR DESCRIPTION
11 pre-exec files are changed to check env var CHPL_TEST_ROOT_DIR
before CHPL_HOME, when constructing an absolute path to a test
file.

This change is needed to permit Cray module tests to work without
copying the entire test tree into the installed Chapel module.