### PR TITLE
Check if doc/Makefile exists before invoking clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ clean: FORCE
 	cd modules && $(MAKE) clean
 	cd runtime && $(MAKE) clean
 	cd third-party && $(MAKE) clean
-	cd doc && $(MAKE) clean
+	if [ -a doc/Makefile ]; then cd doc && $(MAKE) clean; fi
 	rm -f util/chplenv/*.pyc
 
 cleanall: FORCE
@@ -145,7 +145,7 @@ cleanall: FORCE
 	cd modules && $(MAKE) cleanall
 	cd runtime && $(MAKE) cleanall
 	cd third-party && $(MAKE) cleanall
-	cd doc && $(MAKE) cleanall
+	if [ -a doc/Makefile ]; then cd doc && $(MAKE) cleanall; fi
 	rm -f util/chplenv/*.pyc
 	rm -rf build
 
@@ -159,7 +159,7 @@ clobber: FORCE
 	cd runtime && $(MAKE) clobber
 	cd third-party && $(MAKE) clobber
 	cd tools/chplvis && $(MAKE) clobber
-	cd doc $(MAKE) clobber
+	if [ -a doc/Makefile ]; then cd doc && $(MAKE) clobber; fi
 	rm -rf bin
 	rm -rf lib
 	rm -rf build


### PR DESCRIPTION
`doc/Makefile` does not exist for the release tarball, thus we need to wrap the clean docs step with a check. This is a result from changes in #4710.

In the past, we have used `-` prefix to ignore the error if it occurred, but this still results in the potentially confusing output at the end of the build:

`make: [clean] Error 1 (ignored)`

Therefore, I think directly checking against `doc/Makefile` in an if statement makes the most sense here.