### PR TITLE
Verify less

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -512,19 +512,6 @@ void SymExpr::verify() {
 
   if (var != NULL && var->defPoint != NULL && var->defPoint->parentSymbol == NULL)
     INT_FATAL(this, "SymExpr::verify %12d:  var->defPoint is not in AST", id);
-
-  // Check that we can find this SymExpr in the Symbol's list
-  bool found = false;
-  for_SymbolSymExprs(se, var) {
-    if (se == this) {
-      found = true;
-      break;
-    }
-  }
-
-  if (!found)
-    INT_FATAL(this, "SymExpr::verify %12d:  SymExpr not in Symbol's list", id);
-
 }
 
 SymExpr* SymExpr::copyInner(SymbolMap* map) {

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -155,7 +155,7 @@ extern bool fLibraryCompile;
 extern bool fUseNoinit;
 extern bool no_codegen;
 extern bool developer;
-extern bool fVerify;
+extern int  fVerify;
 extern int  num_constants_per_variable;
 extern bool printCppLineno;
 

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -468,6 +468,7 @@ void check_afterEveryPass()
     checkForDuplicateUses();
     checkFlagRelationships();
     checkEmptyPartialCopyFnMap();
+    if (fVerify > 1) checkSymbolSymExprs();
   }
 }
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -86,7 +86,7 @@ static char log_flags[512] = "";
 bool fLibraryCompile = false;
 bool no_codegen = false;
 int debugParserLevel = 0;
-bool fVerify = false;
+int fVerify = 0;
 bool ignore_errors = false;
 bool ignore_errors_for_pass = false;
 bool ignore_warnings = false;
@@ -567,6 +567,10 @@ static void setHtmlUser(const ArgumentDescription* desc, const char* unused) {
   fdump_html_include_system_modules = false;
 }
 
+static void setVerify(const ArgumentDescription* desc, const char* unused) {
+  fVerify++;
+}
+
 static void setWarnTupleIteration(const ArgumentDescription* desc, const char* unused) {
   const char *val = fNoWarnTupleIteration ? "false" : "true";
   parseCmdLineConfig("CHPL_WARN_TUPLE_ITERATION", astr("\"", val, "\""));
@@ -768,7 +772,7 @@ static ArgumentDescription arg_desc[] = {
  {"log-ids", ' ', NULL, "[Don't] include BaseAST::ids in log files", "N", &fLogIds, "CHPL_LOG_IDS", NULL},
  {"log-module", ' ', "<module-name>", "Restrict IR dump to the named module", "S256", log_module, "CHPL_LOG_MODULE", NULL},
 // {"log-symbol", ' ', "<symbol-name>", "Restrict IR dump to the named symbol(s)", "S256", log_symbol, "CHPL_LOG_SYMBOL", NULL}, // This doesn't work yet.
- {"verify", ' ', NULL, "Run consistency checks during compilation", "N", &fVerify, "CHPL_VERIFY", NULL},
+ {"verify", ' ', NULL, "Run consistency checks during compilation", "N", &fVerify, "CHPL_VERIFY", setVerify},
  {"parse-only", ' ', NULL, "Stop compiling after 'parse' pass for syntax checking", "N", &fParseOnly, NULL, NULL},
  {"parser-debug", 'D', NULL, "Set parser debug level", "+", &debugParserLevel, "CHPL_PARSER_DEBUG", NULL},
  {"debug-short-loc", ' ', NULL, "Display long [short] location in certain debug outputs", "N", &debugShortLoc, "CHPL_DEBUG_SHORT_LOC", NULL},


### PR DESCRIPTION
* Move verification of Symbol's list of SymExpr to checks.cpp
* Enable --verify --verify to do extra verification after every pass

Now the slow verification only occurs after functionResolution with --verify,
but if --verify --verify is used, it occurs after every pass.