### PR TITLE
Test perf of re-enabling rvf on task functions in playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,10 +9,10 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of using the non copyargs versions of qthread_fork
+# Test performance of re-enabling rvf on task functions
 GITHUB_USER=ronawho
-GITHUB_BRANCH=qthread-no-copyargs
-SHORT_NAME=noCopyargs
+GITHUB_BRANCH=rvf-task-functions
+SHORT_NAME=rvfTask
 START_DATE=12/13/16
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
This has a surprisingly positive impact on the task spawn micro-benchmark.
Mike/I decided to disable it for task functions before and we didn't see any
real regressions, but I want to see if things are different now, particularly
now that LCALS short is not throwing dataParMinGranularity