### PR TITLE
Faster SymExpr::verify

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -324,6 +324,10 @@ SymExpr* Symbol::firstSymExpr() const {
   return symExprsHead;
 }
 
+SymExpr* Symbol::lastSymExpr() const {
+  return symExprsTail;
+}
+
 bool Symbol::isImmediate() const {
   return false;
 }

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -150,11 +150,23 @@ void Symbol::verify() {
     INT_FATAL(this, "Symbol::defPoint != Sym::defPoint->sym");
   verifyInTree(type, "Symbol::type");
 
-  if (symExprsHead && symExprsHead->symbolSymExprsPrev != NULL)
-    INT_FATAL(this, "Symbol's SymExpr list is malformed (head)");
+  if (symExprsHead) {
+    if (symExprsHead->symbolSymExprsPrev != NULL)
+      INT_FATAL(this, "Symbol's SymExpr list is malformed (head)");
+    if (symExprsHead->symbol() != this)
+      INT_FATAL(this, "Symbol's SymExpr head has other symbol");
+    if (symExprsHead->inTree() == false)
+      INT_FATAL(this, "Symbol's SymExpr head not in tree");
+  }
 
-  if (symExprsTail && symExprsTail->symbolSymExprsNext != NULL)
-    INT_FATAL(this, "Symbol's SymExpr list is malformed (tail)");
+  if (symExprsTail) {
+    if (symExprsTail->symbolSymExprsNext != NULL)
+      INT_FATAL(this, "Symbol's SymExpr list is malformed (tail)");
+    if (symExprsTail->symbol() != this)
+      INT_FATAL(this, "Symbol's SymExpr tail has other symbol");
+    if (symExprsTail->inTree() == false)
+      INT_FATAL(this, "Symbol's SymExpr tail not in tree");
+  }
 }
 
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -157,6 +157,7 @@ public:
   void               addSymExpr(SymExpr* se);
   void               removeSymExpr(SymExpr* se);
   SymExpr*           firstSymExpr()                            const;
+  SymExpr*           lastSymExpr()                             const;
 
 protected:
                      Symbol(AstTag      astTag,


### PR DESCRIPTION
Verify Symbol's SymExpr list using local operations

 * each Symbol checks that its first and last list elements are in the tree and have the same Symbol
 * each SymExpr checks that its prev and next elements, if any, are in the tree and have the same Symbol. If there is no prev/next element, check that this SymExpr is the head/tail of the appropriate Symbol's list.

I've checked that these rules catch likely invalid possibilites, such as:
 - setting SymExpr::var without using setSymbol()
 - inappropriately calling Symbol::removeSymExpr()
 - inappropriately calling Symbol::removeSymExpr() and then
   Symbol::addSymExpr() with the wrong Symbol.

These rules produce better checking than we had before. Moreover, I think that one could prove that these rules ensure the following properties:

 - every live SymExpr is in the appropriate Symbol's list
 - no Symbol's list contains a SymExpr with the with a different symbol()

Passed full local --verify testing.
Reviewed by @benharsh - thanks!