### PR TITLE
Separate the CG and MG largest sizes run into their own .graph files

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -146,11 +146,13 @@ studies/prk/stencil/prk-stencil-time.graph
 studies/prk/transpose/prk-transpose.graph
 # suite: NAS Parallel benchmarks
 npb/cg/cg.graph
+npb/cg/cg-a.graph
 npb/ep/ep.graph
 npb/ep/ep-b.graph
 npb/ft/ft.graph
 npb/ft/ft-a.graph
 users/npadmana/npb-mg/mg.graph
+users/npadmana/npb-mg/mg-b.graph
 # suite: Array/Domain performance
 arrays/diten/arrayPerformance-2d.graph
 arrays/diten/arrayPerformance-1d.graph

--- a/test/npb/cg/cg-a.graph
+++ b/test/npb/cg/cg-a.graph
@@ -1,0 +1,4 @@
+perfkeys: Execution time =
+files: cg.A.dat
+graphkeys: runtime - A
+graphtitle: NAS Parallel Benchmarks: CG timings - size A

--- a/test/npb/cg/cg.graph
+++ b/test/npb/cg/cg.graph
@@ -8,11 +8,6 @@ files: cg.W.dat
 graphkeys: runtime - W
 graphtitle: NAS Parallel Benchmarks: CG timings - size W
 
-perfkeys: Execution time =
-files: cg.A.dat
-graphkeys: runtime - A
-graphtitle: NAS Parallel Benchmarks: CG timings - size A
-
 #perfkeys: Execution time =
 #files: cg.B.dat
 #graphkeys: runtime - B

--- a/test/users/npadmana/npb-mg/mg-b.graph
+++ b/test/users/npadmana/npb-mg/mg-b.graph
@@ -1,0 +1,5 @@
+perfkeys: Elapsed time (seconds):
+files: npb-mg-b.dat
+graphkeys: Class B
+graphtitle: NPB MG Size B
+ylabel: Time (seconds)

--- a/test/users/npadmana/npb-mg/mg.graph
+++ b/test/users/npadmana/npb-mg/mg.graph
@@ -9,9 +9,3 @@ files: npb-mg-a.dat
 graphkeys: Class A
 graphtitle: NPB MG Size A
 ylabel: Time (seconds)
-
-perfkeys: Elapsed time (seconds):
-files: npb-mg-b.dat
-graphkeys: Class B
-graphtitle: NPB MG Size B
-ylabel: Time (seconds)


### PR DESCRIPTION
This will enable us to selectively include only the largest size in our
performance tracking suite, since we don't need the repetition of seeing all
the sizes when we spot check.

Verified that --generate-graphs still works with these changes