### PR TITLE
Fix compilation error under CHPL_LLVM=llvm after #5046

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -841,11 +841,8 @@ FnSymbol::FnSymbol(const char* initName) :
   codegenUniqueNum(1),
   doc(NULL),
   retSymbol(NULL),
+  llvmDISubprogram(NULL),
   _throwsError(false)
-#ifdef HAVE_LLVM
-  ,
-  llvmDISubprogram(NULL)
-#endif
 {
   substitutions.clear();
   gFnSymbols.add(this);


### PR DESCRIPTION
PR #5046 introduced a trivial-to-fix compilation error for llvm builds. This PR fixes it.

* verified that the compiler builds, hello runs correctly with:
  * CHPL_LLVM=none
  * CHPL_LLVM=llvm and no --llvm
  * CHPL_LLVM=llvm and --llvm