### PR TITLE
add TryStmt to gTryStmts

### DIFF
--- a/compiler/AST/TryStmt.cpp
+++ b/compiler/AST/TryStmt.cpp
@@ -31,6 +31,8 @@ BlockStmt* TryStmt::buildChplStmt(Expr* expr) {
 TryStmt::TryStmt(bool tryBang, BlockStmt* body) : Stmt(E_TryStmt) {
   _tryBang = tryBang;
   _body    = body;
+
+  gTryStmts.add(this);
 }
 
 TryStmt::~TryStmt() {


### PR DESCRIPTION
[trivial, self-reviewed]
- `TryStmt` constructor adds `this` to `gTryStmts`
- passes `--verify` testing locally
- thanks to @noakesmichael for pointing this out