### PR TITLE
fasta: Clean up some whitespace, formatting, and comments

### DIFF
--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -113,6 +113,14 @@ o We should introduce local "static" variables (using some other
 o It seems like a param uint(8) whose value is known to fit in an
   int(8) should be assignable without a cast, but currently it isn't.
 
+o Multiple config types can't currently be declared with a current
+  statement it seems.  If they were, I'd alias int(8) to 'char'
+  but don't care about it enough to have two config type statements
+  (which seems lame).
+
+o Seems like we should have an iterator that does the block-cyclic
+  round robin dealing out of chunks of a given size from a range...
+
 
 knucleotide
 -----------

--- a/test/release/examples/benchmarks/shootout/fasta.chpl
+++ b/test/release/examples/benchmarks/shootout/fasta.chpl
@@ -71,7 +71,6 @@ const HomoSapiens = [(a, 0.3029549426680),
                      (g, 0.1975473066391),
                      (t, 0.3015094502008)];
 
-
 proc main() {
   repeatMake(">ONE Homo sapiens alu", ALU, 2*n);
   randomMake(">TWO IUB ambiguity codes", IUB, 3*n);
@@ -107,11 +106,10 @@ proc repeatMake(desc, alu, n) {
 proc randomMake(desc, nuclInfo, n) {
   stdout.writeln(desc);
 
-  const numNucls = nuclInfo.size;
-  var cumulProb: [1..numNucls] randType;
-
   // compute the cumulative probabilities of the nucleotides
-  var p = 0.0;
+  const numNucls = nuclInfo.size;
+  var cumulProb: [1..numNucls] randType,
+      p = 0.0;
   for i in 1..numNucls {
     p += nuclInfo[i](prob);
     cumulProb[i] = 1 + (p*IM):randType;
@@ -120,6 +118,7 @@ proc randomMake(desc, nuclInfo, n) {
   // guard when tasks can access the random numbers or output stream
   var randGo, outGo: [0..#numTasks] atomic int;
 
+  // create tasks to pipeline the RNG, computation, and output
   coforall tid in 0..#numTasks {
     const chunkSize = lineLength*blockSize,
           nextTask = (tid + 1) % numTasks;
@@ -127,7 +126,8 @@ proc randomMake(desc, nuclInfo, n) {
     var myBuff: [0..#(lineLength+1)*blockSize] int(8),
         myRands: [0..chunkSize] randType;
 
-    for i in tid*chunkSize .. n-1 by numTasks*chunkSize {
+    // iterate over 0..n-1 in a round-robin fashion across tasks
+    for i in tid*chunkSize..n-1 by numTasks*chunkSize {
       const bytes = min(chunkSize, n-i);
 
       // Get 'bytes' random numbers in a coordinated manner
@@ -140,7 +140,6 @@ proc randomMake(desc, nuclInfo, n) {
           off = 0;
 
       for j in 0..#bytes {
-
         const r = myRands[j];
         var nid = 1;
         for k in 1..numNucls do

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -78,7 +78,6 @@ const HomoSapiens = [(a, 0.3029549426680),
                      (g, 0.1975473066391),
                      (t, 0.3015094502008)];
 
-
 proc main() {
   repeatMake(">ONE Homo sapiens alu\n", ALU, 2*n);
   randomMake(">TWO IUB ambiguity codes\n", IUB, 3*n);
@@ -114,11 +113,10 @@ proc repeatMake(desc, alu, n) {
 proc randomMake(desc, nuclInfo, n) {
   stdout.write(desc);
 
-  const numNucls = nuclInfo.size;
-  var cumulProb: [1..numNucls] randType;
-
   // compute the cumulative probabilities of the nucleotides
-  var p = 0.0;
+  const numNucls = nuclInfo.size;
+  var cumulProb: [1..numNucls] randType,
+      p = 0.0;
   for i in 1..numNucls {
     p += nuclInfo[i](prob);
     cumulProb[i] = 1 + (p*IM):randType;
@@ -130,6 +128,7 @@ proc randomMake(desc, nuclInfo, n) {
   randGo.write(0);
   outGo.write(0);
 
+  // create tasks to pipeline the RNG, computation, and output
   coforall tid in 0..#numTasks {
     const chunkSize = lineLength*blockSize,
           nextTask = (tid + 1) % numTasks;
@@ -137,7 +136,8 @@ proc randomMake(desc, nuclInfo, n) {
     var myBuff: [0..#(lineLength+1)*blockSize] int(8),
         myRands: [0..chunkSize] randType;
 
-    for i in tid*chunkSize .. n-1 by numTasks*chunkSize {
+    // iterate over 0..n-1 in a round-robin fashion across tasks
+    for i in tid*chunkSize..n-1 by numTasks*chunkSize {
       const bytes = min(chunkSize, n-i);
 
       // Get 'bytes' random numbers in a coordinated manner
@@ -150,7 +150,6 @@ proc randomMake(desc, nuclInfo, n) {
           off = 0;
 
       for j in 0..#bytes {
-
         const r = myRands[j];
         var nid = 1;
         for k in 1..numNucls do
@@ -191,6 +190,7 @@ proc randomMake(desc, nuclInfo, n) {
 
 //
 // Deterministic random number generator
+// (lastRand really wants to be a local static...)
 //
 var lastRand = seed;
 


### PR DESCRIPTION
I didn't realize until BenA was reviewing the code for clarity
today that these didn't get pushed to master before my fasta
merges earlier this week as intended.  Oops!

None of these changes should be functional in nature...