### PR TITLE
fasta: Changed from busy-wait to waitFor()

### DIFF
--- a/test/release/examples/benchmarks/shootout/fasta.chpl
+++ b/test/release/examples/benchmarks/shootout/fasta.chpl
@@ -121,7 +121,7 @@ proc randomMake(desc, nuclInfo, n) {
   // create tasks to pipeline the RNG, computation, and output
   coforall tid in 0..#numTasks {
     const chunkSize = lineLength*blockSize,
-          nextTask = (tid + 1) % numTasks;
+          nextTid = (tid + 1) % numTasks;
 
     var myBuff: [0..#(lineLength+1)*blockSize] int(8),
         myRands: [0..chunkSize] randType;
@@ -131,9 +131,9 @@ proc randomMake(desc, nuclInfo, n) {
       const bytes = min(chunkSize, n-i);
 
       // Get 'bytes' random numbers in a coordinated manner
-      wait(randGo);
+      randGo[tid].waitFor(i);
       getRands(bytes, myRands);
-      signal(randGo);
+      randGo[nextTid].write(i+chunkSize);
 
       // Compute 'bytes' nucleotides and store in 'myBuff'
       var col = 0,
@@ -162,18 +162,9 @@ proc randomMake(desc, nuclInfo, n) {
       }
 
       // Write the output in a coordinated manner
-      wait(outGo);
+      outGo[tid].waitFor(i);
       stdout.write(myBuff[0..#off]);
-      signal(outGo);
-
-      // Helper routines for taking turns with shared resources
-      inline proc wait(guard) {
-        while guard[tid].read() != i do ;
-      }
-
-      inline proc signal(guard) {
-        guard[nextTask].write(i+chunkSize);
-      }
+      outGo[nextTid].write(i+chunkSize);
     }
   }
 }

--- a/test/studies/shootout/fasta/bradc/fasta-blc-numa.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc-numa.chpl
@@ -158,7 +158,7 @@ proc randomMake(desc, nuclInfo, n) {
     if itid%div == 0 {
     const tid = itid / div;
     const chunkSize = lineLength*blockSize,
-          nextTask = (tid + 1) % numTasks;
+          nextTid = (tid + 1) % numTasks;
 
     var myBuff: [0..#(lineLength+1)*blockSize] int(8),
         myRands: [0..chunkSize] randType;
@@ -168,9 +168,9 @@ proc randomMake(desc, nuclInfo, n) {
       const bytes = min(chunkSize, n-i);
 
       // Get 'bytes' random numbers in a coordinated manner
-      wait(randGo);
+      randGo[tid].waitFor(i);
       getRands(bytes, myRands);
-      signal(randGo);
+      randGo[nextTid].write(i+chunkSize);
 
       // Compute 'bytes' nucleotides and store in 'myBuff'
       var col = 0,
@@ -199,18 +199,9 @@ proc randomMake(desc, nuclInfo, n) {
       }
 
       // Write the output in a coordinated manner
-      wait(outGo);
+      outGo[tid].waitFor(i);
       stdout.write(myBuff[0..#off]);
-      signal(outGo);
-
-      // Helper routines for taking turns with shared resources
-      inline proc wait(guard) {
-        while guard[tid].read() != i do ;
-      }
-
-      inline proc signal(guard) {
-        guard[nextTask].write(i+chunkSize);
-      }
+      outGo[nextTid].write(i+chunkSize);
     }
     }
   }

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -131,7 +131,7 @@ proc randomMake(desc, nuclInfo, n) {
   // create tasks to pipeline the RNG, computation, and output
   coforall tid in 0..#numTasks {
     const chunkSize = lineLength*blockSize,
-          nextTask = (tid + 1) % numTasks;
+          nextTid = (tid + 1) % numTasks;
 
     var myBuff: [0..#(lineLength+1)*blockSize] int(8),
         myRands: [0..chunkSize] randType;
@@ -141,9 +141,9 @@ proc randomMake(desc, nuclInfo, n) {
       const bytes = min(chunkSize, n-i);
 
       // Get 'bytes' random numbers in a coordinated manner
-      wait(randGo);
+      randGo[tid].waitFor(i);
       getRands(bytes, myRands);
-      signal(randGo);
+      randGo[nextTid].write(i+chunkSize);
 
       // Compute 'bytes' nucleotides and store in 'myBuff'
       var col = 0,
@@ -172,18 +172,9 @@ proc randomMake(desc, nuclInfo, n) {
       }
 
       // Write the output in a coordinated manner
-      wait(outGo);
+      outGo[tid].waitFor(i);
       stdout.write(myBuff[0..#off]);
-      signal(outGo);
-
-      // Helper routines for taking turns with shared resources
-      inline proc wait(guard) {
-        while guard[tid].read() != i do ;
-      }
-
-      inline proc signal(guard) {
-        guard[nextTask].write(i+chunkSize);
-      }
+      outGo[nextTid].write(i+chunkSize);
     }
   }
 }


### PR DESCRIPTION
In conversations with the Bens, particularly BHarsh, I took an IOU to
see how much switching from a busy-wait to a more principled waitFor()
hurts performance.  It's reasonably minimal, so I made the switch.  In
addition to using supplied features and avoiding the taboo of
busy-waiting, this also reduces the need for the helper functions which
I eliminated.

While here, I renamed nextTask to nextTid to improve the symmetry
between the waitFor() and the write().