### PR TITLE
Add a new future requesting that we avoid the term 'lvalue' in errors

### DIFF
--- a/test/variables/constants/assignConstError.bad
+++ b/test/variables/constants/assignConstError.bad
@@ -1,0 +1,1 @@
+assignConstError.chpl:2: error: illegal lvalue in assignment

--- a/test/variables/constants/assignConstError.chpl
+++ b/test/variables/constants/assignConstError.chpl
@@ -1,0 +1,2 @@
+const two = 2;
+two = 3;

--- a/test/variables/constants/assignConstError.future
+++ b/test/variables/constants/assignConstError.future
@@ -1,0 +1,11 @@
+error message: avoid term 'lvalue' in error messages
+
+The term 'lvalue', while reasonably widely known, is not as intuitive
+and approachable as I think we'd like our error messages to be.  To
+that end, this future asks for a kinder, gentler error message for
+cases like this.  The proposed message in the .good file is just a
+placeholder/proposal.  Others would be acceptable as well.
+
+Note that there are probably other contexts in which the compiler uses
+'lvalue' in its error messages as well... I didn't go looking for
+them.

--- a/test/variables/constants/assignConstError.good
+++ b/test/variables/constants/assignConstError.good
@@ -1,0 +1,1 @@
+assignConstError.chpl:2: error: can't re-assign a 'const' after its declaration


### PR DESCRIPTION
From the .future:

The term 'lvalue', while reasonably widely known, is not as intuitive
and approachable as I think we'd like our error messages to be.  To
that end, this future asks for a kinder, gentler error message for
cases like this.  The proposed message in the .good file is just a
placeholder/proposal.  Others would be acceptable as well.

Note that there are probably other contexts in which the compiler uses
'lvalue' in its error messages as well... I didn't go looking for
them.