### PR TITLE
Support params without initializers

### DIFF
--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -161,12 +161,6 @@ static void checkPrivateDecls(DefExpr* def) {
 
 static void
 checkParsedVar(VarSymbol* var) {
-  if (var->isParameter() && !var->immediate)
-    if (!var->defPoint->init &&
-        (toFnSymbol(var->defPoint->parentSymbol) ||
-         toModuleSymbol(var->defPoint->parentSymbol)))
-      USR_FATAL_CONT(var, "Top-level params must be initialized.");
-
   if (var->defPoint->init && var->defPoint->init->isNoInitExpr()) {
     if (var->hasFlag(FLAG_CONST))
       USR_FATAL_CONT(var, "const variables specified with noinit must be explicitly initialized.");

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1378,6 +1378,8 @@ static void init_typed_var(VarSymbol* var,
       block = new BlockStmt(NULL, BLOCK_SCOPELESS);
 
     VarSymbol* typeTemp = newTemp("type_tmp");
+    if (var->hasFlag(FLAG_PARAM))
+      typeTemp->addFlag(FLAG_PARAM);
     DefExpr*   typeDefn = new DefExpr(typeTemp);
     CallExpr*  initCall = NULL;
 

--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -372,10 +372,10 @@ Parameter expressions are restricted to the following constructs:
 \index{constants}
 \index{const@\chpl{const}}
 
-Runtime constants, or simply ``constants'',
-do not have the restrictions that are associated with
-parameters.  Constants can be of any type.  They require an initialization
-expression and contain the value of that expression throughout their lifetime.
+Runtime constants, or simply ``constants'', do not have the
+restrictions that are associated with parameters.  Constants can be of
+any type.  Whether initialized explicitly or via its type's default
+value, a constant stores the same value throughout its lifetime.
 
 A variable of a class type that is a constant is a constant reference.
 That is, the variable always

--- a/test/trivial/roxana/test_param_decl3.chpl
+++ b/test/trivial/roxana/test_param_decl3.chpl
@@ -1,1 +1,2 @@
 param x : int;
+writeln(x);

--- a/test/trivial/roxana/test_param_decl3.good
+++ b/test/trivial/roxana/test_param_decl3.good
@@ -1,1 +1,1 @@
-test_param_decl3.chpl:1: error: Top-level params must be initialized.
+0


### PR DESCRIPTION
While it's not very interesting or useful, it seems that we should
permit 'param' declarations without initialization expressions for
orthogonality (where the 'param's value would be its default value).
It turns out that it was a five-minute fix to enable this and that
only one test seemed to rely on the old "error message" behavior,
so I made the fix and propose we accept it.  While normal params
without initializers are not that interesting (because they can only
hold their type's default values), in the 'config param' case, it's
slightly more useful/interesting (though arguably, supplying an
initializer might still be considered better form).

I checked the spec to see if it needed updating if we accept this
change, but didn't see that params said anything about requiring
initializers. However, consts did say they required initializers even
though the compiler permits them to be elided (as I believe it should),
so I updated that wording since it is thematically related to this PR.

TODO
- [X] implement a nice 5-minute fix (TM)
- [x] run testing
- [x] make sure spec still builds
- [x] read spec pdf to make sure it rendered OK