### PR TITLE
Enable multiple bad param errors

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7309,8 +7309,11 @@ postFold(Expr* expr) {
               }
             }
           }
-          if (!set && lhs->symbol()->isParameter())
-            USR_FATAL(call, "Initializing parameter '%s' to value not known at compile time", lhs->symbol()->name);
+          if (!set && lhs->symbol()->isParameter() && 
+              lhs->getModule()->modTag == MOD_USER) {
+            USR_FATAL_CONT(call, "Initializing parameter '%s' to value not known at compile time", lhs->symbol()->name);
+            lhs->symbol()->removeFlag(FLAG_PARAM);
+          }
         }
         if (!set) {
           if (lhs->symbol()->hasFlag(FLAG_MAYBE_TYPE)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7309,8 +7309,7 @@ postFold(Expr* expr) {
               }
             }
           }
-          if (!set && lhs->symbol()->isParameter() && 
-              lhs->getModule()->modTag == MOD_USER) {
+          if (!set && lhs->symbol()->isParameter()) {
             USR_FATAL_CONT(call, "Initializing parameter '%s' to value not known at compile time", lhs->symbol()->name);
             lhs->symbol()->removeFlag(FLAG_PARAM);
           }

--- a/test/param/errors/multipleParamInitErrors.chpl
+++ b/test/param/errors/multipleParamInitErrors.chpl
@@ -1,0 +1,2 @@
+param n = read(int),
+      quarterN = n / 4;

--- a/test/param/errors/multipleParamInitErrors.good
+++ b/test/param/errors/multipleParamInitErrors.good
@@ -1,0 +1,2 @@
+multipleParamInitErrors.chpl:1: error: Initializing parameter 'n' to value not known at compile time
+multipleParamInitErrors.chpl:2: error: Initializing parameter 'quarterN' to value not known at compile time

--- a/test/users/weili/metaprog2.good
+++ b/test/users/weili/metaprog2.good
@@ -1,2 +1,3 @@
 metaprog2.chpl:2: In function 'calPI':
 metaprog2.chpl:7: error: Initializing parameter 'ret' to value not known at compile time
+metaprog2.chpl:9: error: param function does not resolve to a param symbol


### PR DESCRIPTION
This change falls in the category of "making the compiler better at
reporting multiple errors."  Previously, when we hit a case where a
'param' was initialized with a non-param expression, we generated
one error and exited.  Here, I switch a USR_FATAL() into a 
USR_FATAL_CONT() in combination with marking the earlier param
symbol as not being a param (since, in reality, it isn't) as a means to
generating multiple errors in such cases.  Failure to de-mark the
symbol it like this resulted in other errors that added confusion
because we'd end up calling 'param' versions of functions
with seeming-param that the compiler couldn't interpret.  While this
removal of the flag is a little destructive in nature (throwing away
information), since we're about to error-out anyway, it seems justifiable
for the sake of giving users more error messages (which is a
common complaint against the Chapel compiler).

TODO:
- [X] implement a nice 5-minute fix (TM)
- [x] testing