### PR TITLE
Add param versions of min max for ints

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -578,6 +578,16 @@ module ChapelBase {
   inline proc min(x, y, z...?k) return min(min(x, y), (...z));
   inline proc max(x, y, z...?k) return max(max(x, y), (...z));
 
+  inline proc min(param x: int(?w), param y: int(w)) param
+    return if x < y then x else y;
+  inline proc max(param x: int(?w), param y: int(w)) param
+    return if x > y then x else y;
+
+  inline proc min(param x: uint(?w), param y: uint(w)) param
+    return if x < y then x else y;
+  inline proc max(param x: uint(?w), param y: uint(w)) param
+    return if x > y then x else y;
+
   inline proc min(x, y) where isAtomic(x) || isAtomic(y) {
     compilerError("min() and max() are not supported for atomic arguments - apply read() to those arguments first");
   }

--- a/test/param/functions/paramMinMax.chpl
+++ b/test/param/functions/paramMinMax.chpl
@@ -1,0 +1,9 @@
+config type t = int;
+
+param one = 1: t;
+param two = 2: t;
+
+param small = min(one,two);
+param big = max(one,two);
+
+compilerError("small = " + small:string + ", big = " + big: string);

--- a/test/param/functions/paramMinMax.compopts
+++ b/test/param/functions/paramMinMax.compopts
@@ -1,0 +1,10 @@
+-st=int(8)
+-st=int(16)
+-st=int(32)
+-st=int(64)
+-st=int
+-st=uint(8)
+-st=uint(16)
+-st=uint(32)
+-st=uint(64)
+-st=uint

--- a/test/param/functions/paramMinMax.good
+++ b/test/param/functions/paramMinMax.good
@@ -1,0 +1,1 @@
+paramMinMax.chpl:9: error: small = 1, big = 2


### PR DESCRIPTION
It seemed like an oversight and a non-orthogonality with other ChapelBase
operators that we don't support min() and max() on param ints.  This adds
them along with a test that exercises them.

We might want to think about supporting param min max for other types as well,
but I was nervous about doing it for floating point variables given that we typically
haven't supported operators on floating point params and supporting it on bools
and enums seemed a little "out there" without further conversation or thought.

TODO:
- [X] complete 5-minute fix (TM)
- [x] run full testing