### PR TITLE
Filing a set of futures relating to module init order / main modules

### DIFF
--- a/test/modules/require/whichModsInit/bam.chpl
+++ b/test/modules/require/whichModsInit/bam.chpl
@@ -1,0 +1,3 @@
+use foo;
+
+writeln("In baz's init");

--- a/test/modules/require/whichModsInit/bam.good
+++ b/test/modules/require/whichModsInit/bam.good
@@ -1,0 +1,2 @@
+In foo's init
+In baz's init

--- a/test/modules/require/whichModsInit/bar.bad
+++ b/test/modules/require/whichModsInit/bar.bad
@@ -1,0 +1,2 @@
+In foo's init
+In foo's main()

--- a/test/modules/require/whichModsInit/bar.chpl
+++ b/test/modules/require/whichModsInit/bar.chpl
@@ -1,0 +1,5 @@
+require 'foo.chpl';
+
+use foo;
+
+writeln("In bar's init");

--- a/test/modules/require/whichModsInit/bar.future
+++ b/test/modules/require/whichModsInit/bar.future
@@ -1,0 +1,28 @@
+semantic: module initialization for implicit main module
+
+This case threw me for a loop for awhile until I realized what was
+happening.  bar.chpl and baz.chpl 'use' module 'foo' which is defined
+in 'foo.chpl'.  'foo.chpl' can be named on the command-line or
+'require'd, but the behavior is the same: since it is the only module
+to contain a procedure named 'main()', it is considered the main
+module and all dependent module 'use's start from it.  However, it
+does not 'use' 'bar' or 'baz', so the init() functions (read:
+top-level code) of these modules never execute in spite of the fact
+that they are named on the command-line.  This seems confusing.
+
+Meanwhile, if bam.chpl is compiled without naming foo.chpl on the
+command line or requiring it, the init functions of both modules
+execute, yet bam is treated as the main module and foo's main is not
+executed.  This seems inconsistent (though this last case is one that
+we've explicitly discussed supporting, where the main() procedure in
+the "library" module foo is considered a way of unit testing that
+library.  But really, perhaps we should add a well-defined procedure
+test() for such cases?
+
+I think that the execution of all three is arguably correct, but that
+the compiler should print warnings when things might be surprising --
+e.g., a module named on the command-line is seemingly ignored and
+maybe _possibly_ when a module with a main() procedure that's not
+listed on the command line doesn't serve as the main module.  I put a
+proposed warning into the .good files for the first two cases, though
+I'm open to other approaches as well.

--- a/test/modules/require/whichModsInit/bar.good
+++ b/test/modules/require/whichModsInit/bar.good
@@ -1,0 +1,4 @@
+warning: though named on the command-line, module 'bar' is not 'use'd by
+         main module 'foo' and will not affect execution.
+In foo's init
+In foo's main()

--- a/test/modules/require/whichModsInit/baz.bad
+++ b/test/modules/require/whichModsInit/baz.bad
@@ -1,0 +1,2 @@
+In foo's init
+In foo's main()

--- a/test/modules/require/whichModsInit/baz.chpl
+++ b/test/modules/require/whichModsInit/baz.chpl
@@ -1,0 +1,3 @@
+use foo;
+
+writeln("In baz's init");

--- a/test/modules/require/whichModsInit/baz.compopts
+++ b/test/modules/require/whichModsInit/baz.compopts
@@ -1,0 +1,1 @@
+foo.chpl

--- a/test/modules/require/whichModsInit/baz.future
+++ b/test/modules/require/whichModsInit/baz.future
@@ -1,0 +1,28 @@
+semantic: module initialization for implicit main module
+
+This case threw me for a loop for awhile until I realized what was
+happening.  bar.chpl and baz.chpl 'use' module 'foo' which is defined
+in 'foo.chpl'.  'foo.chpl' can be named on the command-line or
+'require'd, but the behavior is the same: since it is the only module
+to contain a procedure named 'main()', it is considered the main
+module and all dependent module 'use's start from it.  However, it
+does not 'use' 'bar' or 'baz', so the init() functions (read:
+top-level code) of these modules never execute in spite of the fact
+that they are named on the command-line.  This seems confusing.
+
+Meanwhile, if bam.chpl is compiled without naming foo.chpl on the
+command line or requiring it, the init functions of both modules
+execute, yet bam is treated as the main module and foo's main is not
+executed.  This seems inconsistent (though this last case is one that
+we've explicitly discussed supporting, where the main() procedure in
+the "library" module foo is considered a way of unit testing that
+library.  But really, perhaps we should add a well-defined procedure
+test() for such cases?
+
+I think that the execution of all three is arguably correct, but that
+the compiler should print warnings when things might be surprising --
+e.g., a module named on the command-line is seemingly ignored and
+maybe _possibly_ when a module with a main() procedure that's not
+listed on the command line doesn't serve as the main module.  I put a
+proposed warning into the .good files for the first two cases, though
+I'm open to other approaches as well.

--- a/test/modules/require/whichModsInit/baz.good
+++ b/test/modules/require/whichModsInit/baz.good
@@ -1,0 +1,4 @@
+warning: though named on the command-line, module 'baz' is not 'use'd by
+         main module 'foo' and will not affect execution.
+In foo's init
+In foo's main()

--- a/test/modules/require/whichModsInit/foo.chpl
+++ b/test/modules/require/whichModsInit/foo.chpl
@@ -1,0 +1,5 @@
+writeln("In foo's init");
+
+proc main() {
+  writeln("In foo's main()");
+}

--- a/test/modules/require/whichModsInit/foo.notest
+++ b/test/modules/require/whichModsInit/foo.notest
@@ -1,0 +1,1 @@
+# this is a helper module


### PR DESCRIPTION
These tests threw me for a loop for awhile this evening (along the line
of "Why is my code not running?!?!"

The challenges relate to which modules are candidates for the main
module and which modules' init functions (top-level code) are run.
What we have today is rationalizable, but here I propose that some
warnings might help avoid confusion in cases like this.

I think what we have today is:
* modules that are 'require'd or named on the command-line are candidates
   for main modules; if a module is not in this group, it is not
   a candidate for the main module and its main() will not be run.
* among the modules that are candidates for main modules, if only one has
   main(), it is the main module
* once the main module is determined, module initialization is determined
   by walking the tree of 'use's starting from the 'main' module
* if a module is named on the command-line but is not reached via this
   tree, its initialization (top-level code) will not be run.

As I say in the .future, I think this is rationalizable, but it can be confusing
in some cases.  To that end, I propose putting a warning when modules
fall into bullet 4's case to avoid surprises.
