### PR TITLE
Switch the max number of tasks to use for fasta from 3 to 4

### DIFF
--- a/test/release/examples/benchmarks/shootout/fasta.chpl
+++ b/test/release/examples/benchmarks/shootout/fasta.chpl
@@ -10,7 +10,7 @@
 config const n = 1000,            // the length of the generated strings
              lineLength = 60,     // the number of columns in the output
              blockSize = 1024,    // the parallelization granularity
-             numTasks = min(3, here.maxTaskPar);  // how many tasks to use?
+             numTasks = min(4, here.maxTaskPar);  // how many tasks to use?
 
 config type randType = uint(32);  // type to use for random numbers
 

--- a/test/studies/shootout/fasta/bradc/fasta-blc-numa.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc-numa.chpl
@@ -29,7 +29,7 @@ config param numSockets = 2;
 config const maxTaskPar = here.maxTaskPar,
              idealTasks = numSockets*3,
              numTasks = if idealTasks > maxTaskPar
-                          then min(3, maxTaskPar)
+                          then min(4, maxTaskPar)
                           else idealTasks / numSockets,
              numNumaTasks = if numTasks*numSockets > maxTaskPar
                               then numTasks

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -10,13 +10,19 @@
 config const n = 1000,            // the length of the generated strings
              lineLength = 60,     // the number of columns in the output
              blockSize = 1024,    // the parallelization granularity
-             numTasks = min(3, here.maxTaskPar);  // how many tasks to use?
+             numTasks = min(4, here.maxTaskPar);  // how many tasks to use?
 //
 // the computational pipeline has 3 distinct stages, so ideally, we'd
-// like to use 3 tasks.  However, if the locale can't support that
-// much parallelism, we'll use a number of tasks equal to its maximum
-// degree of task parallelism to avoid starvation (because we rely on
-// busy-waits which could cause deadlocks otherwise).
+// like to use 3 tasks.  However, there is one stage which does not
+// require any coordination and it tends to be the slowest stage, so
+// we could have multiple tasks working on it simultaneously.  In
+// practice, though, that phase is not that much slower than the sum
+// of the other two, and using too many tasks can just add overhead
+// that isn't helpful.  So we go with 4 tasks to pick up some slack,
+// and because it seems to work best on all the machine we've tried in
+// practice.  If the locale can't support that much parallelism, we'll
+// use a number of tasks equal to its maximum degree of task
+// parallelism to avoid oversubscription.
 //
 
 config type randType = uint(32);  // type to use for random numbers


### PR DESCRIPTION
Previously, we've used no more than 3 tasks for fasta.  This has been
due to an argument I've been making that there are 3 stages to the
pipeline and that, therefore, much more than 3 tasks would just add
overhead without speeding things up.  It was also based on some
empirical studies I did awhile back to see whether there was another
sweet spot we shold be looking at.  At that time, it seemed there was
not, and so it confirmed my sense that 3 was the "right" number.

Since then, though (1) our execution times have come down a lot due to
various improvements (making the previous empirical studies outdated)
and (2) I've realized a flaw in my "just 3 tasks" argument, which is:
Of the three stages in the pipeline, only two of them are guarded by a
lock in order to avoid races.  The third, where computation is done,
can be done by multiple tasks simultaneously *and* happens to be the
stage that forms the bottleneck in the cases where I've timed each
stage.  That suggests that more than 3 tasks could be useful since
multiple of them could do the computation phase simultaneously.

But how many more than 3?  Again, based on my per-pipeline stage
timings, my sense was "not many" (the computation phase was not that
significant of a bottleneck compared to the other two), and today I've
been sweeping the number of tasks on various systems, all of which
suggest that 4 is either the optimal number of tasks for current
systems that we're testing on or close enough to it to not be worth
being smarter abeout.  Notably, here.maxTaskPar (another obvious balue
to pick) tends to be further off from the optimal time and on some
platforms (e.g., chapcs) introduces significant instability in the
timings from run to run.

For this reason and the sense that there's only a little bit of
slack in the pipeline, we'll set '4' as our ideal number of tasks.

If here.maxTaskPar is less than 4, we continue to use that value
instead.  This is no longer necessary since we moved away from
busy-waiting.  But it seems like it'll only be a waste and introduce
contention to use more tasks than that.