### PR TITLE
Fix typos in ssca2

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
@@ -399,10 +399,10 @@ module SSCA2_RMAT_graph_generator
 	       "edge end vertices out of high end of range");
 
           if !(w > 0) then halt( 
-	       "edge weightd out of low end of range");
+	       "edge weight out of low end of range");
 
           if !(w <= MAX_EDGE_WEIGHT) then halt(  
-	       "edge weightd out of high end of range");
+	       "edge weight out of high end of range");
         }
         // exit the scope to enable memory deallocation, if any
       }

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_compilation_config_params.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_compilation_config_params.chpl
@@ -16,7 +16,7 @@ module SSCA2_compilation_config_params
 // |  documentation.  This mode is normally used with the preceding mode to   |
 // |  create deterministic output for compiler regression testing.            |
 // |                                                                          |
-// |  "DISTRIBUTION_TYPE" selects among different distribution possiblities.  |
+// |  "DISTRIBUTION_TYPE" selects among different distribution possibilities. |
 // |  At present, only "BLOCK" distributions is supported in the code.        |
 // |  The alternative to "BLOCK" is "none" (undistributed).                   |
 // +==========================================================================+

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
@@ -168,7 +168,7 @@ module SSCA2_kernels
   // For task-private temporary variables
   config const defaultNumTPVs = 16;
   config var numTPVs = min(defaultNumTPVs, numLocales);
-  // Would be nice to use PriavteDist, but aliasing is not supported (yet)
+  // Would be nice to use PrivateDist, but aliasing is not supported (yet)
   const PrivateSpace = LocaleSpace dmapped Block(boundingBox=LocaleSpace);
 
   // ==================================================================
@@ -466,7 +466,7 @@ module SSCA2_kernels
 
         TPVM.releaseTPV(tid);
 
-      }; // closure of outer embarassingly parallel forall
+      }; // closure of outer embarrassingly parallel forall
 
       if PRINT_TIMING_STATISTICS then {
 	stopwatch.stop ();

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/io_RMAT_graph.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/io_RMAT_graph.chpl
@@ -446,7 +446,7 @@ module io_RMAT_graph
 
   //
   // For debugging, we are making these errors non-fatal.
-  // Especially usefil with --checkOnlyOnRead.
+  // Especially useful with --checkOnlyOnRead.
   //
   proc myerror(args...) {
     stderr.writeln("ERROR: ", (...args));

--- a/test/studies/ssca2/atomic/SSCA2_kernels_atomic.chpl
+++ b/test/studies/ssca2/atomic/SSCA2_kernels_atomic.chpl
@@ -397,7 +397,7 @@ module SSCA2_kernels
 	};
 	delete Active_Level;
 
-      }; // closure of outer embarassingly parallel forall
+      }; // closure of outer embarrasingly parallel forall
   
       if PRINT_TIMING_STATISTICS then {
 	stopwatch.stop ();

--- a/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
@@ -237,10 +237,10 @@ module SSCA2_RMAT_graph_generator
 	       "edge end vertices out of high end of range");
 
       assert ( Edge_Weight > 0, 
-	       "edge weightd out of low end of range");
+	       "edge weight out of low end of range");
 
       assert ( Edge_Weight <= MAX_EDGE_WEIGHT,  
-	       "edge weightd out of high end of range");
+	       "edge weight out of high end of range");
 
       writeln (); writeln ("Vertex Set in G:", G.vertices);
 
@@ -389,7 +389,7 @@ module SSCA2_RMAT_graph_generator
 
   //
   // For debugging, we are making these errors non-fatal.
-  // Especially usefil with --checkOnlyOnRead.
+  // Especially useful with --checkOnlyOnRead.
   //
   proc myerror(args...) {
     stderr.writeln("ERROR: ", (...args));

--- a/test/studies/ssca2/jglewis/ssca2_version2/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/jglewis/ssca2_version2/SSCA2_RMAT_graph_generator.chpl
@@ -236,10 +236,10 @@ module SSCA2_RMAT_graph_generator
 	       "edge end vertices out of high end of range");
 
       assert ( Edge_Weight > 0, 
-	       "edge weightd out of low end of range");
+	       "edge weight out of low end of range");
 
       assert ( Edge_Weight <= MAX_EDGE_WEIGHT,  
-	       "edge weightd out of high end of range");
+	       "edge weight out of high end of range");
 
       writeln (); writeln ("Vertex Set in G:", G.vertices);
 

--- a/test/studies/ssca2/jglewis/ssca2_version2/SSCA2_compilation_config_params.chpl
+++ b/test/studies/ssca2/jglewis/ssca2_version2/SSCA2_compilation_config_params.chpl
@@ -22,7 +22,7 @@ module SSCA2_compilation_config_params
 // |                                                                          |
 // |  create deterministic output for compiler regression testing.            |
 // |                                                                          |
-// |  "DISTRIBUTION_TYPE" selects among different distribution possiblities.  |
+// |  "DISTRIBUTION_TYPE" selects among different distribution possibilities. |
 // |  At present, only "BLOCK" distributions are supported in the compiler.   |
 // |  The only alternative to "BLOCK" is "none" (undistributed).              |
 // |  Only the vertex domain is distributed in this current code.             |

--- a/test/studies/ssca2/jglewis/ssca2_version2/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/jglewis/ssca2_version2/SSCA2_kernels.chpl
@@ -420,7 +420,7 @@ module SSCA2_kernels
 	};
 	delete Active_Level;
 
-      }; // closure of outer embarassingly parallel forall
+      }; // closure of outer embarrassingly parallel forall
   
       if PRINT_TIMING_STATISTICS then {
 	stopwatch.stop ();

--- a/test/studies/ssca2/jglewis/ssca2_version2/SSCA2_kernels_atomic.chpl
+++ b/test/studies/ssca2/jglewis/ssca2_version2/SSCA2_kernels_atomic.chpl
@@ -393,7 +393,7 @@ module SSCA2_kernels
 	};
 	delete Active_Level;
 
-      }; // closure of outer embarassingly parallel forall
+      }; // closure of outer embarrassingly parallel forall
   
       if PRINT_TIMING_STATISTICS then {
 	stopwatch.stop ();

--- a/test/studies/ssca2/kristyn/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/kristyn/SSCA2_RMAT_graph_generator.chpl
@@ -236,10 +236,10 @@ module SSCA2_RMAT_graph_generator
 	       "edge end vertices out of high end of range");
 
       assert ( Edge_Weight > 0, 
-	       "edge weightd out of low end of range");
+	       "edge weight out of low end of range");
 
       assert ( Edge_Weight <= MAX_EDGE_WEIGHT,  
-	       "edge weightd out of high end of range");
+	       "edge weight out of high end of range");
 
       writeln (); writeln ("Vertex Set in G:", G.vertices);
 

--- a/test/studies/ssca2/kristyn/SSCA2_RMAT_graph_generator_1Darray.chpl
+++ b/test/studies/ssca2/kristyn/SSCA2_RMAT_graph_generator_1Darray.chpl
@@ -295,10 +295,10 @@ proc Gen_RMAT_graph_1D_array ( a : real, b : real, c : real, d : real,
 	       "edge end vertices out of high end of range");
 
       assert ( Edge_Weight > 0, 
-	       "edge weightd out of low end of range");
+	       "edge weight out of low end of range");
 
       assert ( Edge_Weight <= MAX_EDGE_WEIGHT,  
-	       "edge weightd out of high end of range");
+	       "edge weight out of high end of range");
 
       writeln (); writeln ("Vertex Set in G:", G.vertices);
 

--- a/test/studies/ssca2/kristyn/SSCA2_compilation_config_params.chpl
+++ b/test/studies/ssca2/kristyn/SSCA2_compilation_config_params.chpl
@@ -22,7 +22,7 @@ module SSCA2_compilation_config_params
 // |                                                                          |
 // |  create deterministic output for compiler regression testing.            |
 // |                                                                          |
-// |  "DISTRIBUTION_TYPE" selects among different distribution possiblities.  |
+// |  "DISTRIBUTION_TYPE" selects among different distribution possibilities. |
 // |  At present, only "BLOCK" distributions are supported in the compiler.   |
 // |  The only alternative to "BLOCK" is "none" (undistributed).              |
 // |  Only the vertex domain is distributed in this current code.             |

--- a/test/studies/ssca2/kristyn/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/kristyn/SSCA2_kernels.chpl
@@ -407,7 +407,7 @@ module SSCA2_kernels
 	};
 	delete Active_Level;
 
-      }; // closure of outer embarassingly parallel forall
+      }; // closure of outer embarrassingly parallel forall
   
       if PRINT_TIMING_STATISTICS then {
 	stopwatch.stop ();

--- a/test/studies/ssca2/kristyn/SSCA2_kernels_K4opt.chpl
+++ b/test/studies/ssca2/kristyn/SSCA2_kernels_K4opt.chpl
@@ -445,7 +445,7 @@ module SSCA2_kernels_K4opt
 	};
 	delete Active_Level;
 
-      }; // closure of outer embarassingly parallel forall
+      }; // closure of outer embarrassingly parallel forall
   
 
       if PRINT_TIMING_STATISTICS then {

--- a/test/studies/ssca2/kristyn/SSCA2_kernels_atomic.chpl
+++ b/test/studies/ssca2/kristyn/SSCA2_kernels_atomic.chpl
@@ -397,7 +397,7 @@ module SSCA2_kernels
 	};
 	delete Active_Level;
 
-      }; // closure of outer embarassingly parallel forall
+      }; // closure of outer embarrassingly parallel forall
   
       if PRINT_TIMING_STATISTICS then {
 	stopwatch.stop ();

--- a/test/studies/ssca2/rachels/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/rachels/SSCA2_kernels.chpl
@@ -170,7 +170,7 @@ module SSCA2_kernels
   // For task-private temporary variables
   config const defaultNumTPVs = 16;
   config var numTPVs = min(defaultNumTPVs, numLocales);
-  // Would be nice to use PriavteDist, but aliasing is not supported (yet)
+  // Would be nice to use PrivateDist, but aliasing is not supported (yet)
   const PrivateSpace = LocaleSpace dmapped Block(boundingBox=LocaleSpace);
 
   // ==================================================================
@@ -486,7 +486,7 @@ module SSCA2_kernels
 
         TPVM.releaseTPV(tid);
 
-      }; // closure of outer embarassingly parallel forall
+      }; // closure of outer embarrassingly parallel forall
 
       if PRINT_TIMING_STATISTICS then {
 	stopwatch.stop ();

--- a/test/studies/ssca2/sungeun/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/sungeun/SSCA2_kernels.chpl
@@ -168,7 +168,7 @@ module SSCA2_kernels
   // For task-private temporary variables
   config const defaultNumTPVs = 16;
   config var numTPVs = min(defaultNumTPVs, numLocales);
-  // Would be nice to use PriavteDist, but aliasing is not supported (yet)
+  // Would be nice to use PrivateDist, but aliasing is not supported (yet)
   const PrivateSpace = {LocaleSpace} dmapped Block(boundingBox={LocaleSpace});
 
   // ==================================================================
@@ -466,7 +466,7 @@ module SSCA2_kernels
 
         TPVM.releaseTPV(tid);
 
-      }; // closure of outer embarassingly parallel forall
+      }; // closure of outer embarrassingly parallel forall
 
       if PRINT_TIMING_STATISTICS then {
 	stopwatch.stop ();


### PR DESCRIPTION
Fix typos in test/releas/examples/benchmarks/ssca2.  While I'm at it,
spot-fix those same typos where they appear in test/studies/ssca2,
without attempting a full spellchecking of those versions.