### PR TITLE
compiler pass: lower error handling 

### DIFF
--- a/compiler/include/checks.h
+++ b/compiler/include/checks.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2016 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,6 +41,7 @@ void check_replaceArrayAccessesWithRefTemps();
 void check_processIteratorYields();
 void check_flattenFunctions();
 void check_cullOverReferences();
+void check_lowerErrorHandling();
 void check_callDestructors();
 void check_lowerIterators();
 void check_parallel();

--- a/compiler/include/errorHandling.h
+++ b/compiler/include/errorHandling.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _ERROR_HANDLING_H_
+#define _ERROR_HANDLING_H_
+
+void lowerErrorHandling(void);
+
+#endif

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -54,6 +54,7 @@ void insertLineNumbers();
 void insertWideReferences();
 void localizeGlobals();
 void loopInvariantCodeMotion();
+void lowerErrorHandling();
 void lowerIterators();
 void makeBinary();
 void normalize();

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -26,6 +26,7 @@
 #include "primitive.h"
 #include "resolution.h"
 #include "docsDriver.h" // for fDocs
+#include "TryStmt.h"
 
 //
 // Static function declarations.
@@ -41,6 +42,7 @@ static void check_afterNormalization(); // Checks to be performed after
 static void check_afterResolution(); // Checks to be performed after every pass
                                      // following resolution.
 static void check_afterResolveIntents();
+static void check_afterLowerErrorHandling();
 static void check_afterCallDestructors(); // Checks to be performed after every
                                           // pass following callDestructors.
 static void check_afterLowerIterators();
@@ -198,6 +200,14 @@ void check_cullOverReferences()
   }
 }
 
+void check_lowerErrorHandling()
+{
+  check_afterEveryPass();
+  check_afterNormalization();
+  check_afterLowerErrorHandling();
+  // Suggestion: Ensure every constructor call has a matching destructor call.
+}
+
 void check_callDestructors()
 {
   check_afterEveryPass();
@@ -303,7 +313,7 @@ void check_deadCodeElimination()
   check_afterEveryPass();
   check_afterNormalization();
   check_afterCallDestructors();
-  check_afterLowerIterators(); 
+  check_afterLowerIterators();
   check_afterResolveIntents();
   // Suggestion: Ensure no dead code.
 }
@@ -422,7 +432,7 @@ void check_makeBinary()
 // Extra structural checks on the AST, applicable to all passes.
 void check_afterEveryPass()
 {
-  if (fVerify) 
+  if (fVerify)
   {
     verify();
     checkForDuplicateUses();
@@ -488,6 +498,28 @@ static void check_afterResolveIntents()
           INT_FATAL("Symbol should not have unknown qualifier: %s (%d)", sym->cname, sym->id);
         }
       }
+    }
+  }
+}
+
+
+static void check_afterLowerErrorHandling()
+{
+  if (fVerify)
+  {
+    // check no more TryStmt
+    forv_Vec(TryStmt, stmt, gTryStmts)
+    {
+      INT_FATAL(stmt, "TryStmt should no longer exist");
+    }
+
+    // TODO: check no more CatchStmt
+
+    // check no more PRIM_THROW
+    forv_Vec(CallExpr, call, gCallExprs)
+    {
+      if (call->isPrimitive(PRIM_THROW))
+        INT_FATAL(call, "PRIM_THROW should no longer exist");
     }
   }
 }
@@ -604,7 +636,7 @@ checkTaskRemovedPrims()
       }
 }
 
-static void 
+static void
 checkLowerIteratorsRemovedPrims()
 {
   for_alive_in_Vec(CallExpr, call, gCallExprs)

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -56,6 +56,7 @@ struct PassInfo {
 #define LOG_processIteratorYields              'y'
 #define LOG_flattenFunctions                   'e'
 #define LOG_cullOverReferences                 'O'
+#define LOG_lowerErrorHandling                 NUL
 #define LOG_callDestructors                    'd'
 #define LOG_lowerIterators                     'L'
 #define LOG_parallel                           'P'
@@ -122,6 +123,7 @@ static PassInfo sPassList[] = {
   RUN(processIteratorYields),   // adjustments to iterators
   RUN(flattenFunctions),        // denest nested functions
   RUN(cullOverReferences),      // remove excess references
+  RUN(lowerErrorHandling),      // lower error handling constructs
   RUN(callDestructors),
   RUN(lowerIterators),          // lowers iterators into functions/classes
   RUN(parallel),                // parallel transforms

--- a/compiler/passes/Makefile.share
+++ b/compiler/passes/Makefile.share
@@ -28,6 +28,7 @@ PASSES_SRCS = \
         createTaskFunctions.cpp \
         denormalize.cpp \
         docs.cpp \
+        errorHandling.cpp \
         expandExternArrayCalls.cpp \
         externCResolve.cpp \
         filesToAST.cpp \

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -17,18 +17,21 @@
  * limitations under the License.
  */
 
+#include "stmt.h"
 #include "symbol.h"
 #include "view.h"
 #include <cstdio>
 
   // change 'throws' to 'out'
-    // add an Error formal to a function marked 'throws'
+    // add an error_out formal to a function marked 'throws'
     // for all calls to such functions
-      // pass a variable to receive the Error arg
-      // check the Error arg after the call
+      // create and pass a variable error to receive error_out
+      // check error after the call
+  // change 'throw' to set error_out
 
   // TODO: how do we find Error temps from a call to a throwing function?
 
+// TODO: dtObject should be dtError, but we don't have that right now
 void lowerErrorHandling(void) {
   printf("hello world\n");
 
@@ -37,9 +40,58 @@ void lowerErrorHandling(void) {
     if (fn->throwsError()) {
       SET_LINENO(fn);
 
-      // TODO: dtObject should be dtError, but we don't have that right now
-      ArgSymbol* outFormal = new ArgSymbol(INTENT_REF, "error", dtObject);
+      // add an Error formal to a function marked 'throws'
+      ArgSymbol* outFormal = new ArgSymbol(INTENT_REF, "error_out", dtObject);
       fn->insertFormalAtTail(outFormal);
+
+      for_SymbolSymExprs(se, fn) {
+        if (CallExpr* call = toCallExpr(se->parentExpr)) {
+          if (fn == call->resolvedFunction()) {
+            // create a variable to receive the Error arg
+            VarSymbol* tempError= newTemp("error", dtObject);
+
+            // have the call pass the variable
+            call->insertAtTail(tempError);
+
+
+            // check the Error arg after the call
+            // TODO: do we need this temp?
+            VarSymbol* tempErrorExists = newTemp("errorExists", dtBool);
+            DefExpr* defErrorExists = new DefExpr(tempErrorExists);
+
+            Expr* setErrorExists = new CallExpr(
+              PRIM_MOVE,
+              tempErrorExists,
+              new CallExpr(PRIM_NOTEQUAL, tempError, gNil));
+
+            // TODO: better error message
+            Expr* haltOnError = new CallExpr(PRIM_RT_ERROR,
+              new_CStringSymbol("uncaught error"));
+            Expr* checkError = new CondStmt(new SymExpr(tempErrorExists), haltOnError);
+
+            // (works for calls inside calls)
+            call->getStmtExpr()->insertBefore(new DefExpr(tempError));
+            call->getStmtExpr()->insertAfter(defErrorExists);
+            defErrorExists->getStmtExpr()->insertAfter(setErrorExists);
+            setErrorExists->getStmtExpr()->insertAfter(checkError);
+          }
+        }
+      }
+
+      // change 'throw' to set error_out
+      // TODO: need "error" for SET_LINENO
+      for_exprs_postorder(expr, fn->body) {
+        if (CallExpr* call = toCallExpr(expr)) {
+          if (call->isPrimitive(PRIM_THROW)) {
+            SET_LINENO(call);
+
+            Expr* error = call->get(1)->remove();
+            Expr* castError = new CallExpr(PRIM_CAST, dtObject->symbol, error);
+            Expr* setError = new CallExpr(PRIM_MOVE, outFormal, castError);
+            call->replace(setError);
+          }
+        }
+      }
     }
   }
 }

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include "errorHandling.h"
 #include "stmt.h"
 #include "symbol.h"
 #include "view.h"

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -17,8 +17,29 @@
  * limitations under the License.
  */
 
+#include "symbol.h"
+#include "view.h"
 #include <cstdio>
+
+  // change 'throws' to 'out'
+    // add an Error formal to a function marked 'throws'
+    // for all calls to such functions
+      // pass a variable to receive the Error arg
+      // check the Error arg after the call
+
+  // TODO: how do we find Error temps from a call to a throwing function?
 
 void lowerErrorHandling(void) {
   printf("hello world\n");
+
+  // give 'throws' an 'out'
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (fn->throwsError()) {
+      SET_LINENO(fn);
+
+      // TODO: dtObject should be dtError, but we don't have that right now
+      ArgSymbol* outFormal = new ArgSymbol(INTENT_REF, "error", dtObject);
+      fn->insertFormalAtTail(outFormal);
+    }
+  }
 }

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdio>
+
+void lowerErrorHandling(void) {
+  printf("hello world\n");
+}

--- a/test/errhandling/inprogress/try-bang-temp.chpl
+++ b/test/errhandling/inprogress/try-bang-temp.chpl
@@ -1,0 +1,11 @@
+class SomeError { }
+
+proc throwAnError() throws {
+  throw new SomeError();
+}
+
+writeln("should not continue");
+
+try! throwAnError();
+
+writeln("continued");

--- a/test/errhandling/inprogress/try-bang-temp.good
+++ b/test/errhandling/inprogress/try-bang-temp.good
@@ -1,0 +1,2 @@
+should not continue
+try-bang-temp.chpl:3: error: uncaught error


### PR DESCRIPTION
Note: These are the first steps toward a fully functioning pass that lowers error handling AST. Strict mode, `catch`, and the `Error` type are completely non-functional here.

- creates the pass `lowerErrorHandling`, just before `callDestructors`
- creates checks `check_lowerErrorHandling`, `check_afterLowerErrorHandling`
- draft implementation of `throws`, `try!`
- passes linux64+flat testing

@ronawho: This is the PR that adds a compiler pass.