### PR TITLE
Annotate last night's max tasks change for fasta

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -360,7 +360,9 @@ fasta:
   12/10/16:
     - Switch from 'sync' to 'atomic'-based coordination (#5004)
   12/15/16:
-    - Parallelize release version and refactor for CLBG submissions (#5024)
+    - Parallelize release version, make more use of randType and refactor for CLBG submissions (#5024)
+  12/19/16:
+    - Switch max number of tasks from 3 to 4 (#5078)
 
 fastaredux:
   01/14/14:

--- a/test/studies/shootout/fasta/bradc/fasta-blc-numa.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc-numa.chpl
@@ -26,10 +26,19 @@ config param numSockets = 2;
 // use a number of tasks equal to its maximum degree of task
 // parallelism to avoid oversubscription.
 //
+// 'maxComputeTasks' represents this number of tasks that will be working
+// 'idealTasks' scales it by the number of sockets so that we can create
+//   dummy tasks on sockets other than the first
+// 'numTasks' is the actual number of worker tasks that we'll use,
+//   designed to avoid oversubscribing the node
+// 'numNumaTasks' is the actual number of tasks we'll create, including
+//   the dummies
+//
 config const maxTaskPar = here.maxTaskPar,
-             idealTasks = numSockets*3,
+             maxComputeTasks = 4,
+             idealTasks = numSockets*maxComputeTasks,
              numTasks = if idealTasks > maxTaskPar
-                          then min(4, maxTaskPar)
+                          then min(maxComputeTasks, maxTaskPar)
                           else idealTasks / numSockets,
              numNumaTasks = if numTasks*numSockets > maxTaskPar
                               then numTasks


### PR DESCRIPTION
Also fix a case where I forgot to change a 3 to a 4 in the numa
study version as pointed out by @cassella.  Named it symbolically
to avoid such issues in the future.

THinking about the numa version in the waitFor() world, I'm also
realizing that we could now simplify a bunch of the complicated
logic I introduced to avoid starving tasks when we were using
busy waits.  Good post-vacation activity.