### PR TITLE
strengthen verification of Symbols

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -510,8 +510,13 @@ void SymExpr::verify() {
   if (var == NULL)
     INT_FATAL(this, "SymExpr::verify %12d: var is NULL", id);
 
-  if (var != NULL && var->defPoint != NULL && var->defPoint->parentSymbol == NULL)
-    INT_FATAL(this, "SymExpr::verify %12d:  var->defPoint is not in AST", id);
+  if (var->defPoint) {
+    if (var->defPoint->parentSymbol == NULL)
+      INT_FATAL(this, "SymExpr::verify %12d:  var->defPoint is not in AST", id);
+  } else {
+    if (var != rootModule)
+      INT_FATAL(this, "SymExpr::var is a symbol without a defPoint");
+  }
 
   /* Check that:
       - every live SymExpr is in a Symbol's list

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -144,10 +144,15 @@ static inline void verifyInTree(BaseAST* ast, const char* msg) {
 }
 
 void Symbol::verify() {
-  if (defPoint && !defPoint->parentSymbol && !toModuleSymbol(this))
-    INT_FATAL(this, "Symbol::defPoint is not in AST");
-  if (defPoint && this != defPoint->sym)
-    INT_FATAL(this, "Symbol::defPoint != Sym::defPoint->sym");
+  if (defPoint) {
+    if (!defPoint->parentSymbol && this != rootModule)
+      INT_FATAL(this, "Symbol::defPoint is not in AST");
+    if (this != defPoint->sym)
+      INT_FATAL(this, "Symbol::defPoint != Sym::defPoint->sym");
+  } else {
+    if (this != rootModule)
+      INT_FATAL(this, "Symbol without a defPoint");
+  }
   verifyInTree(type, "Symbol::type");
 
   if (symExprsHead) {

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -381,13 +381,11 @@ static inline bool isAliveQuick(Symbol* symbol) {
 }
 
 static inline bool isAlive(Symbol* symbol) {
-  if (symbol->hasFlag(FLAG_GLOBAL_TYPE_SYMBOL)) return true;
-  if (! symbol->defPoint) return false;
-  return isAliveQuick(symbol);
+  return symbol->defPoint && isAlive(symbol->defPoint);
 }
 
 static inline bool isAlive(Type* type) {
-  return isAliveQuick(type->symbol);
+  return isAlive(type->symbol->defPoint);
 }
 
 #define isRootModule(ast)  \


### PR DESCRIPTION
* Ensure that the only symbol that can have null defPoint is rootModule.

* Ensure that the symbol referenced by a live SymExpr is itself live aka "in AST".

While there, removed special treatment of symbols with FLAG_GLOBAL_TYPE_SYMBOL
w.r.t. isAlive() check.

Why is it OK to remove the FLAG_GLOBAL_TYPE_SYMBOL check?
Suppose that it matters, i.e. there is a symbol S for which
isAlive returned true before this change and now returns false.
In that case, S will not undergo verification, which is an omission.
However, S will now be cleaned up i.e. deleted at the end of
the pass. If S were actually needed, then its deletion will cause
memory corruption, very likely. That should be detected by valgrind
testing and/or cause downstream failures.

(This was motivated by the verification check not catching a bug
I'd introduced in my local tree, which resulted in accessing
clobbered memory.)

Testing:
+ linux64 --verify on full suite
+ gasnet --verify on hello4
+ gasnet --verify on multilocale tests, for an earlier version
