### PR TITLE
Fix the .good file for the chpldoc enum future

### DIFF
--- a/test/chpldoc/enum/docConstants.doc.good
+++ b/test/chpldoc/enum/docConstants.doc.good
@@ -1,8 +1,8 @@
 docConstants.doc
- 
+
 Usage:
    use docConstants.doc;
 
-  enum Color { Red, Yellow }
+   enum Color { Red, Yellow }
       enum documentation 
 


### PR DESCRIPTION
The .good file for this future was not correct for the number of spaces needed.
I discovered this when I opened the issue for the test on github, as part of
verifying I remembered what the test was expected to do.