### PR TITLE
Update .good for multi-ddata in no-local testing.

### DIFF
--- a/test/memory/sungeun/refCount/domainMaps.no-local.good
+++ b/test/memory/sungeun/refCount/domainMaps.no-local.good
@@ -65,10 +65,10 @@ total:
 Replicated Dist
 ===============
 Copy of domain map:
-	224 bytes leaked
+	296 bytes leaked
 	0 private objects leaked
 Return domain map:
-	224 bytes leaked
+	296 bytes leaked
 	0 private objects leaked
 Create domain:
 	0 bytes leaked
@@ -77,4 +77,4 @@ Create domain and array:
 	0 bytes leaked
 	0 private objects leaked
 total:
-	672 bytes leaked
+	888 bytes leaked


### PR DESCRIPTION
Missed another .good file when updating results for the multi-ddata work (#5047).