### PR TITLE
Increase a couple of timeouts, temporarily.

### DIFF
--- a/test/studies/elegance/tuplesVSarrays.perftimeout
+++ b/test/studies/elegance/tuplesVSarrays.perftimeout
@@ -1,0 +1,2 @@
+# locModel=numa requires this timeout for the time being
+600

--- a/test/studies/prk/stencil/stencil-serial.perftimeout
+++ b/test/studies/prk/stencil/stencil-serial.perftimeout
@@ -1,0 +1,2 @@
+# locModel=numa requires this timeout for the time being
+1800


### PR DESCRIPTION
These two tests are timing out in perf.chapcs.numa testing since the
multi-ddata PR (#5047).  I believe these perftimeout settings will be
sufficient to let them complete, so that they don't show up as failing
tests until we can figure out why they've slowed down so much.