### PR TITLE
Revert "Remove the Cray copyright notices from ... *.chpl tests"

### DIFF
--- a/test/modules/standard/FileSystem/bharshbarg/filer.chpl
+++ b/test/modules/standard/FileSystem/bharshbarg/filer.chpl
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use Sort;
 
 //

--- a/test/modules/standard/LinearAlgebraJama/TestMatrix.chpl
+++ b/test/modules/standard/LinearAlgebraJama/TestMatrix.chpl
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2004-2016 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use LinearAlgebraJama;
 use Math;
 

--- a/test/users/aroonsharma/MyBlockCyclic.chpl
+++ b/test/users/aroonsharma/MyBlockCyclic.chpl
@@ -1,3 +1,5 @@
+// Copyright (c) 2004-2013, Cray Inc.  (See LICENSE file for more details)
+
 config const debugzipopt = false;
 config const testzipopt = false; //not supported yet
 config var totalcomm3 = false; //do count total communication volume


### PR DESCRIPTION
Revert the 2017 copyright change (ie, restore the copyright block) in
         test/modules/standard/FileSystem/bharshbarg/filer.chpl
         test/modules/standard/LinearAlgebraJama/TestMatrix.chpl
         test/users/aroonsharma/MyBlockCyclic.chpl

Fixes test error in filer.chpl, caused by removing the copyright block in PR #5109 
(line numbers in .good). 

Also see bradcray comment, PR #5109 