### PR TITLE
Documentation for Chapel on AWS EC2

### DIFF
--- a/doc/platforms/aws.rst
+++ b/doc/platforms/aws.rst
@@ -1,0 +1,135 @@
+.. _readme-aws:
+
+===================================
+Using Chapel on Amazon Web Services
+===================================
+
+This page contains AWS virtual machine setup details specific to Chapel.
+For more general instructions, see the tutorial on `launching a linux virtual machine`_
+
+.. _launching a linux virtual machine: https://aws.amazon.com/getting-started/tutorials/launch-a-virtual-machine/
+
+Before getting started, you will need an account on AWS: https://aws.amazon.com/
+
+Launching an EC2 instance configured for Chapel
+-----------------------------------------------
+
+From the EC2 console, do the following:
+
+1. Begin launching an instance.
+2. Choose an Amazon Machine Image (AMI).
+   - AMI must use a base OS that supports the `Chapel prerequisites`_, i.e.
+   includes a unix-like environment.
+3. For multilocale support, create or select a security group configured to
+   permit incoming TCP/UDP traffic
+4. Review and launch the instance.
+5. Create or Select create a private key.
+6. `Access the launched the instance`_ via ssh with the selected private key.
+
+.. _Chapel prerequisites: TODO
+.. _Access the launched the instance: TODO
+
+[1] region-specific links via http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-bookmarks.html
+[2] https://us-west-2.console.aws.amazon.com/ec2/v2/home#LaunchInstanceWizard:
+
+On copying across regions:
+http://stackoverflow.com/questions/5402013/move-amazon-ec2-amis-between-regions-via-web-interface#14205963
+
+Building Chapel on an EC2 instance
+----------------------------------
+
+To build Chapel on an EC2 instance, you can either launch an instance with the
+provided AMI, or launch any other AMI and build Chapel yourself.
+
+Starting from an AWS-provided AMI
++++++++++++++++++++++++++++++++++
+
+- Mileage will vary, but in general, you need to:
+
+.. code-block: bash
+
+    sudo yum -y install git gcc gcc-c++ gmp-devel
+
+.. code-block: bash
+
+    sudo apt-get install gcc g++ libgmp3-dev python-dev python-setuptools make
+
+        - Using EC2 as a Chapel development environment
+            - Building Chapel
+                - Setup using provided AMI
+                    - details about the AMI
+                - Setup manually (minimal instructions)
+        - Using EC2 as a compute node
+            - Security Groups
+                - Ensure TCP ports are open!
+            - Running multilocale programs over EC2 instances
+            - Copy pem onto all machines, as well as config
+    - Create publicly available AMI
+
+
+Using the provided AMI
+++++++++++++++++++++++
+
+The provided AMI comes with the following:
+
+Chapel 1.14.0 compiler pre-built
+
+sudo apt-get install gcc g++ libgmp3-dev python-dev python-setuptools make libx11-dev`## Configurations:- CHPL_COMM     = {gasnet, none}- CHPL_GMP
+
+
+
+
+= system- CHPL_REGEXP   = re2- CHPL_UNWIND   = {none, libunwind}
+
+* CHPL_LLVM     = {none, llvm}Invoke `printchplenv` to see your curr
+
+
+ent configuration.## Testing- Test environment built, invoke with `
+
+
+
+start_test`## Tooling- chpldoc installed, available in `$PATH`- ch
+
+
+
+
+plvis installed- vim-plugin installed- emacs-mode enabled## Docs-
+
+
+
+
+
+restructured text documentation in `$CHPL_HOME/doc`- html documentati
+on in `$CHPL_HOME/doc/html`
+
+
+Running multilocale Chapel programs
+-----------------------------------
+
+On a single instance
+++++++++++++++++++++
+
+
+Over multiple instances
++++++++++++++++++++++++
+
+
+Frequently Asked Questions
+--------------------------
+
+**How do I resolve the following error when compiling a program?
+``virtual memory exhausted: Cannot allocate memory``**
+
+This is a common error on systems with limited memory resources, such as the
+free tier of EC2 instances. If you do not wish to launch an instance with more
+memory resources, you can create a swap file or swap partition:
+
+https://www.cyberciti.biz/faq/linux-add-a-swap-file-howto/
+
+
+**How can I run the testing suite over AWS instances?**
+
+This is a planned addition to the paratest (parallel test) functionality, but
+is not yet officially supported.
+
+

--- a/doc/platforms/aws.rst
+++ b/doc/platforms/aws.rst
@@ -33,7 +33,14 @@ From the EC2 console, do the following:
 
 5. Create or select a private key.
 
+   - If creating the key, you will need to download the ``.pem`` identity file.
+     This will be used in the next step to access the instance.
+
 6. `Access the launched instance`_ via ssh using the private key chosen before.
+
+   - Summarizing the AWS documentation linked above, you can ssh into the
+     instance using the ``.pem`` identity file downloaded in the previous step
+     with the following command: ``ssh -i /path/to/key.pem username@hostname``
 
 .. _Access the launched instance: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstances.html?icmpid=docs_ec2_console
 

--- a/doc/platforms/aws.rst
+++ b/doc/platforms/aws.rst
@@ -4,36 +4,39 @@
 Using Chapel on Amazon Web Services
 ===================================
 
-This page contains AWS virtual machine setup details specific to Chapel.
-For more general instructions, see the tutorial on `launching a linux virtual machine`_
+This page contains Amazon Web Services (AWS) Elastic Cloud Compute (EC2)
+virtual machine setup details specific to Chapel. For more general instance
+configuration information, refer to the AWS documentation on
+`launching a linux virtual machine`_.
 
 .. _launching a linux virtual machine: https://aws.amazon.com/getting-started/tutorials/launch-a-virtual-machine/
 
-Before getting started, you will need an account on AWS: https://aws.amazon.com/
+Before getting started, you will need an AWS account, which can be created
+here: https://aws.amazon.com/
 
 Launching an EC2 instance configured for Chapel
 -----------------------------------------------
 
 From the EC2 console, do the following:
 
-1. Begin launching an instance.
-2. Choose an Amazon Machine Image (AMI).
-   - AMI must use a base OS that supports the `Chapel prerequisites`_, i.e.
-   includes a unix-like environment.
+1. Begin launching an instance by clicking the **Launch Instance** button.
+
+2. Choose an Amazon Machine Image (AMI) in the **Choose AMI** step.
+
+   - AMI must use a base OS that supports the :ref:`readme-prereqs`, i.e.
+     includes a unix-like environment.
+
 3. For multilocale support, create or select a security group configured to
-   permit incoming TCP/UDP traffic
+   permit incoming TCP/UDP traffic in the **Configure Security Group** step.
+
 4. Review and launch the instance.
-5. Create or Select create a private key.
-6. `Access the launched the instance`_ via ssh with the selected private key.
 
-.. _Chapel prerequisites: TODO
-.. _Access the launched the instance: TODO
+5. Create or select a private key.
 
-[1] region-specific links via http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-bookmarks.html
-[2] https://us-west-2.console.aws.amazon.com/ec2/v2/home#LaunchInstanceWizard:
+6. `Access the launched instance`_ via ssh using the private key chosen before.
 
-On copying across regions:
-http://stackoverflow.com/questions/5402013/move-amazon-ec2-amis-between-regions-via-web-interface#14205963
+.. _Access the launched instance: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstances.html?icmpid=docs_ec2_console
+
 
 Building Chapel on an EC2 instance
 ----------------------------------
@@ -44,92 +47,249 @@ provided AMI, or launch any other AMI and build Chapel yourself.
 Starting from an AWS-provided AMI
 +++++++++++++++++++++++++++++++++
 
-- Mileage will vary, but in general, you need to:
+- Install the dependencies as shown on the :ref:`readme-prereqs-installation` page.
+- Download a Chapel release from the `Download`_ page.
+- Build the Chapel release as shown on the :ref:`readme-building` page.
 
-.. code-block: bash
+  - Build with ``CHPL_COMM=gasnet`` if you plan to run multilocale programs
 
-    sudo yum -y install git gcc gcc-c++ gmp-devel
+.. _Download: http://chapel.cray.com/download.html
 
-.. code-block: bash
+Using the Chapel-development AMI
+++++++++++++++++++++++++++++++++
 
-    sudo apt-get install gcc g++ libgmp3-dev python-dev python-setuptools make
+Start an EC2 instance from the provided Chapel-development 64-bit AMIs,
+organized by region:
 
-        - Using EC2 as a Chapel development environment
-            - Building Chapel
-                - Setup using provided AMI
-                    - details about the AMI
-                - Setup manually (minimal instructions)
-        - Using EC2 as a compute node
-            - Security Groups
-                - Ensure TCP ports are open!
-            - Running multilocale programs over EC2 instances
-            - Copy pem onto all machines, as well as config
-    - Create publicly available AMI
+.. - us-east-1: US East (N. Virginia)
+.. - us-east-2: US East (Ohio)
+.. - us-west-1: US West (N. California)
 
+- `us-west-2`_: US West (Oregon)
 
-Using the provided AMI
-++++++++++++++++++++++
+.. - ca-central-1 Canada (Central)
+.. - eu-west-1 EU (Ireland)
+.. - eu-central-1 EU (Frankfurt)
+.. - eu-west-2 EU (London)
+.. - ap-northeast-1 Asia Pacific (Tokyo)
+.. - ap-northeast-2 Asia Pacific (Seoul)
+.. - ap-southeast-1 Asia Pacific (Singapore)
+.. - ap-southeast-2 Asia Pacific (Sydney)
+.. - ap-south-1 Asia Pacific (Mumbai)
+.. - sa-east-1 South America (São Paulo)
 
-The provided AMI comes with the following:
+.. _us-west-2: https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=TODO
 
-Chapel 1.14.0 compiler pre-built
+The provided Chapel-development AMI comes with the following:
 
-sudo apt-get install gcc g++ libgmp3-dev python-dev python-setuptools make libx11-dev`## Configurations:- CHPL_COMM     = {gasnet, none}- CHPL_GMP
+- Prerequisites installed::
 
-
-
-
-= system- CHPL_REGEXP   = re2- CHPL_UNWIND   = {none, libunwind}
-
-* CHPL_LLVM     = {none, llvm}Invoke `printchplenv` to see your curr
-
-
-ent configuration.## Testing- Test environment built, invoke with `
-
-
-
-start_test`## Tooling- chpldoc installed, available in `$PATH`- ch
-
+    gcc
+    g++
+    make
+    libgmp3-dev
+    python-dev
+    python-setuptools
+    libx11-dev
 
 
+- Chapel 1.14.0 compiler pre-built with configurations::
 
-plvis installed- vim-plugin installed- emacs-mode enabled## Docs-
+    CHPL_COMM = {gasnet, none}
+    CHPL_GMP = system
+    CHPL_REGEXP = re2
+    CHPL_UNWIND = {none, libunwind}
 
+- Other pre-built tools:
 
+  - :ref:`readme-chpldoc`
 
+  - :ref:`chplvis`
 
+  - ``start_test`` (test environment)
 
-restructured text documentation in `$CHPL_HOME/doc`- html documentati
-on in `$CHPL_HOME/doc/html`
+  - text (rst) documentation built in ``$CHPL_HOME/doc``
+
+  - html documentation built in ``$CHPL_HOME/doc/html``
+
+  - text editor support for vim and emacs
+
 
 
 Running multilocale Chapel programs
 -----------------------------------
 
+For more in-depth information about GASNet or multilocale execution with Chapel,
+refer to the `GASNet documentation`_ and :ref:`readme-multilocale` page,
+respectively.
+
 On a single instance
 ++++++++++++++++++++
 
+**1. Compile the program**
+
+Compile the program with ``CHPL_COMM=gasnet``.
+
+**2. Set up GASNet environment variables**
+
+Set the following GASNet environment variable:
+
+.. code-block:: sh
+
+    # Job spawn mechanism, where 'L' means localhost spawn
+    GASNET_SPAWNFN='L'
+
+**3. Run the program**
+
+Run the program as you would any other multilocale program:
+
+.. code-block:: sh
+
+    ./hello -nl 2
 
 Over multiple instances
 +++++++++++++++++++++++
+
+To run a program across multiple EC2 instances, do the following:
+
+**1. Enable password-less ssh between machines**
+
+This can be done by using the existing identity file (the ``.pem``) , or by
+using another authentication method, such as RSA ssh keys.
+
+If using the identity file, copy the identity file onto each instance
+into the same path, such as ``~/.ssh/foo.pem``. By default, using this file
+requires passing the identity flag and the file path to `ssh`:
+
+.. code-block:: sh
+
+   ssh -i ~/.ssh/foo.pem ec2-11-222-33-444.us-west-2.compute.amazonaws.com
+
+This can be made the default behavior by adding this rule to a new or existing
+``~/.ssh/config``:
+
+.. code-block:: text
+
+   Hostname *compute.amazonaws.com
+   IdentityFile ~/.ssh/foo.pem
+
+Copy this config file into ``~/.ssh/config`` on every EC2 instance as well.
+You should now be able to ssh freely between the EC2 instances.
+
+.. tip::
+
+    The option ``StrictHostKeyChecking no`` can be appended to the new
+    ``.ssh/config`` rule to override the trusted host prompt when first
+    connecting to each machine.  This can be convenient when deploying a large
+    number of instances, but is only recommended if you understand the security
+    implications of the change.
+
+**2. Compile and distribute the binary**
+
+Compile the program with ``CHPL_COMM=gasnet`` set, and copy the compiled
+binary onto all of the EC2 instances, under the same path. For example:
+
+.. code-block:: sh
+
+    export CHPL_COMM=gasnet
+    cd ~/chapel-projects
+    chpl hello.chpl -o hello
+    scp hello ec2-11-222-33-444.us-west-2.compute.amazonaws.com:chapel-projects/hello
+    scp hello ec2-11-222-33-445.us-west-2.compute.amazonaws.com:chapel-projects/hello
+
+**3. Set up GASNet environment variables**
+
+There are several configuration options available for GASNet, which can be
+found in the `GASNet documentation`_.
+The essential configurations, with examples, are as follows:
+
+.. code-block:: sh
+
+    # Space-delimied list of server names
+    GASNET_SSH_SERVERS='ec2-11-222-33-444.us-west-2.compute.amazonaws.com ec2-11-222-33-445.us-west-2.compute.amazonaws.com'
+    # Job spawn mechanism, where 'S' means ssh/rsh-based spawn
+    GASNET_SPAWNFN='S'
+
+Some other common optional configurations are:
+
+.. code-block:: sh
+
+    # Defaults to current working directory
+    GASNET_REMOTE_PATH='~/chapel-projects/'
+    # Defaults to gethostname() of the launching node
+    GASNET_MASTERIP='ec2-11-222-33-444.us-west-2.compute.amazonaws.com'
+    # Defaults to empty, can be used instead of copying config files onto each machine
+    SSH_OPTIONS='-i ~/.ssh/foo.pem'
+
+.. _GASNet documentation: http://gasnet.lbl.gov/dist/udp-conduit/README
+
+**4. Run the program**
+
+Run the program as you would any other multilocale program:
+
+.. code-block:: sh
+
+    ./hello -nl 2
+
+.. note::
+    GASNet is not configured to oversubscribe locales by default. That is, the
+    number of locales (``-nl``) provided cannot exceed the number of servers in
+    ``GASNET_SSH_SERVERS``. If you wish to oversubscribe nodes, you can include
+    servers in ``GASNET_SSH_SERVERS`` multiple times, to reach the desired number
+    of locales.
 
 
 Frequently Asked Questions
 --------------------------
 
-**How do I resolve the following error when compiling a program?
-``virtual memory exhausted: Cannot allocate memory``**
+**How do I resolve the following error:**
+``virtual memory exhausted: Cannot allocate memory``
 
 This is a common error on systems with limited memory resources, such as the
 free tier of EC2 instances. If you do not wish to launch an instance with more
-memory resources, you can create a swap file or swap partition:
+memory resources, you can create a swap file or swap partition.
 
-https://www.cyberciti.biz/faq/linux-add-a-swap-file-howto/
+This can be done on Linux distributions with the following steps:
 
+.. code-block:: sh
 
-**How can I run the testing suite over AWS instances?**
+    # Log in as root
+    sudo -s
+
+    # Create a 512MB swap file (1024 * 512MB = 524288 block size)
+    dd if=/dev/zero of=/swapfile1 bs=1024 count=524288
+
+    # Secure swap file
+    chown root:root /swapfile1
+    chmod 0600 /swapfile1
+
+    # Set up linux swap file
+    mkswap /swapfile1
+
+    # Enable swap file
+    swapon /swapfile1
+
+Then edit ``/etc/fstab`` to include:
+
+.. code-block:: sh
+
+    /swapfile1 none swap sw 0 0
+
+Enable the new swapfile without rebooting:
+
+.. code-block:: sh
+
+   swapoff -a
+   swapon -a
+
+Confirm the swapfile is working:
+
+.. code-block:: sh
+
+   free -m
+
+**How can I run the testing suite in parallel over EC2 instances?**
 
 This is a planned addition to the paratest (parallel test) functionality, but
 is not yet officially supported.
-
 

--- a/doc/platforms/aws.rst
+++ b/doc/platforms/aws.rst
@@ -41,11 +41,7 @@ From the EC2 console, do the following:
 Building Chapel on an EC2 instance
 ----------------------------------
 
-To build Chapel on an EC2 instance, you can either launch an instance with the
-provided AMI, or launch any other AMI and build Chapel yourself.
-
-Starting from an AWS-provided AMI
-+++++++++++++++++++++++++++++++++
+Once connected to the instance via ssh, do the following:
 
 - Install the dependencies as shown on the :ref:`readme-prereqs-installation` page.
 - Download a Chapel release from the `Download`_ page.
@@ -54,66 +50,6 @@ Starting from an AWS-provided AMI
   - Build with ``CHPL_COMM=gasnet`` if you plan to run multilocale programs
 
 .. _Download: http://chapel.cray.com/download.html
-
-Using the Chapel-development AMI
-++++++++++++++++++++++++++++++++
-
-Start an EC2 instance from the provided Chapel-development 64-bit AMIs,
-organized by region:
-
-.. - us-east-1: US East (N. Virginia)
-.. - us-east-2: US East (Ohio)
-.. - us-west-1: US West (N. California)
-
-- `us-west-2`_: US West (Oregon)
-
-.. - ca-central-1 Canada (Central)
-.. - eu-west-1 EU (Ireland)
-.. - eu-central-1 EU (Frankfurt)
-.. - eu-west-2 EU (London)
-.. - ap-northeast-1 Asia Pacific (Tokyo)
-.. - ap-northeast-2 Asia Pacific (Seoul)
-.. - ap-southeast-1 Asia Pacific (Singapore)
-.. - ap-southeast-2 Asia Pacific (Sydney)
-.. - ap-south-1 Asia Pacific (Mumbai)
-.. - sa-east-1 South America (São Paulo)
-
-.. _us-west-2: https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=TODO
-
-The provided Chapel-development AMI comes with the following:
-
-- Prerequisites installed::
-
-    gcc
-    g++
-    make
-    libgmp3-dev
-    python-dev
-    python-setuptools
-    libx11-dev
-
-
-- Chapel 1.14.0 compiler pre-built with configurations::
-
-    CHPL_COMM = {gasnet, none}
-    CHPL_GMP = system
-    CHPL_REGEXP = re2
-    CHPL_UNWIND = {none, libunwind}
-
-- Other pre-built tools:
-
-  - :ref:`readme-chpldoc`
-
-  - :ref:`chplvis`
-
-  - ``start_test`` (test environment)
-
-  - text (rst) documentation built in ``$CHPL_HOME/doc``
-
-  - html documentation built in ``$CHPL_HOME/doc/html``
-
-  - text editor support for vim and emacs
-
 
 
 Running multilocale Chapel programs

--- a/doc/platforms/index.rst
+++ b/doc/platforms/index.rst
@@ -13,6 +13,8 @@ Major Platforms
    cray
    knl
    cygwin
+   aws
+
 
 Networks
 --------

--- a/doc/usingchapel/prereqs.rst
+++ b/doc/usingchapel/prereqs.rst
@@ -32,6 +32,8 @@ about your environment for using Chapel:
   * If you wish to use Chapel's test system, python-setuptools and
     python-devel (or equivalent packages for your platform) are required.
 
+.. _readme-prereqs-installation:
+
 Installation
 ------------
 


### PR DESCRIPTION
### Chapel on AWS EC2

Here is a step-by-step guide to launching Amazon Web Services (AWS) Elastic Compute Cloud (EC2) instances, configuring them for multilocale Chapel programs, and executing multilocale Chapel programs over them.

This also includes the option to use an pre-built Chapel-development Amazon Machine Image (AMI).

### In a future PR:

- Add link to actual AMI setup (when hosted)
- Copy AMI to other regions with links
