### PR TITLE
Utilize disguise role to obfuscate email addresses in docs

### DIFF
--- a/doc/platforms/cygwin.rst
+++ b/doc/platforms/cygwin.rst
@@ -28,7 +28,7 @@ hard-drive (``/cygdrive/c/``) to create ``/cygdrive/c/chapel`` tends to
 work well. Currently, our compiler-generated Makefiles break when the
 compiler or runtime use an absolute path that contains spaces. If any
 Cygwin experts have tips on addressing this issue in a portable way,
-please let us know at chapel_info@cray.com.
+please let us know at :disguise:`chapel_info@cray.com`.
 
 
 Required Packages

--- a/doc/technotes/extern.rst
+++ b/doc/technotes/extern.rst
@@ -966,4 +966,4 @@ Future Directions
 We intend to continue improving these capabilities to provide richer
 and richer support for external types and functions over time.  If you
 have specific requests for improvement, please let us know at:
-chapel_info@cray.com.
+:disguise:`chapel_info@cray.com`.

--- a/doc/technotes/firstClassFns.rst
+++ b/doc/technotes/firstClassFns.rst
@@ -172,4 +172,4 @@ Future Directions
 
 Over time, we will be improving the support for first-class functions
 and their syntax.  If you have specific feature requests or
-suggestions, please let us know at: chapel_info@cray.com.
+suggestions, please let us know at: :disguise:`chapel_info@cray.com`.

--- a/doc/usingchapel/building.rst
+++ b/doc/usingchapel/building.rst
@@ -161,5 +161,5 @@ new build environment by creating ``Makefile.<compiler>`` and/or
 ``Makefile.<platform>`` files and setting your environment variables to
 refer to those files.  If you do develop new build environment support
 that you would like to contribute back to the community, we encourage
-you to send your changes back to us at: chapel_info@cray.com
+you to send your changes back to us at: :disguise:`chapel_info@cray.com`
 

--- a/doc/usingchapel/chplenv.rst
+++ b/doc/usingchapel/chplenv.rst
@@ -89,7 +89,8 @@ CHPL_HOST_PLATFORM
    We are interested in making our code framework portable to other platforms --
    if you are using Chapel on a platform other than the ones listed above,
    please refer to :ref:`platform-specific-settings` for ways to set up a
-   Makefile for this platform and/or contact us at: chapel_info@cray.com
+   Makefile for this platform and/or contact us at:
+   :disguise:`chapel_info@cray.com`
 
 PATH
 ~~~~

--- a/doc/usingchapel/tasks.rst
+++ b/doc/usingchapel/tasks.rst
@@ -36,7 +36,7 @@ detail.  The rest of this document includes:
 * a brief description of future directions for the tasking layer
 
 If you have questions about tasks that are not covered in the following,
-please send them to chapel_info@cray.com.
+please send them to :disguise:`chapel_info@cray.com`.
 
 
 --------------------------
@@ -311,8 +311,8 @@ threads per locale is too large.  For example, when running multi-locale
 programs, the GASNet communication layer typically places an upper bound
 of 127 or 255 on the number of threads per locale (There are ways to
 work around this assumption on certain platforms -- please contact us at
-chapel_info@cray.com or peruse the GASNet documentation if you need to
-do so.)
+:disguise:`chapel_info@cray.com` or peruse the GASNet documentation if you need
+to do so.)
 
 CHPL_TASKS == fifo
 ------------------
@@ -478,5 +478,5 @@ balancing at the other end of the spectrum (for programmers who would
 prefer not to manage threads or whose programs cannot trivially be
 load balanced manually).  Our hope is to leverage existing open source
 threading and task management software and to collaborate with others
-in these areas, so please contact us at chapel_info@cray.com if you'd
+in these areas, so please contact us at :disguise:`chapel_info@cray.com` if you'd
 like to work with us in this area.


### PR DESCRIPTION
The disguise role was added back in #4922 to disguise an email address. This PR uses the role to disguise other email addresses in the docs.