### PR TITLE
Add some .futures about type methods

### DIFF
--- a/test/classes/diten/typeMethodOverload.bad
+++ b/test/classes/diten/typeMethodOverload.bad
@@ -1,0 +1,3 @@
+typeMethodOverload.chpl:13: error: ambiguous call 'type C1.typeMethod()'
+typeMethodOverload.chpl:2: note: candidates are: _any.typeMethod()
+typeMethodOverload.chpl:8: note:                 _any.typeMethod()

--- a/test/classes/diten/typeMethodOverload.chpl
+++ b/test/classes/diten/typeMethodOverload.chpl
@@ -1,0 +1,14 @@
+class C1 {
+  proc type typeMethod() /* where this == C1 */ {
+    writeln("C1.typeMethod()");
+  }
+}
+
+class C2 {
+  proc type typeMethod() /* where this == C2 */ {
+    writeln("C2.typeMethod()");
+  }
+}
+
+C1.typeMethod();
+C2.typeMethod();

--- a/test/classes/diten/typeMethodOverload.future
+++ b/test/classes/diten/typeMethodOverload.future
@@ -1,0 +1,5 @@
+bug: using the same type method name in two classes gives ambiguous call error
+
+I would have expected the receiver type to disambiguate which method to call.
+One possible workaround is to add where clauses like the ones that are
+commented out in the test.

--- a/test/classes/diten/typeMethodOverload.good
+++ b/test/classes/diten/typeMethodOverload.good
@@ -1,0 +1,2 @@
+C1.typeMethod()
+C2.typeMethod()

--- a/test/classes/diten/typeMethodWrongReceiverType.bad
+++ b/test/classes/diten/typeMethodWrongReceiverType.bad
@@ -1,0 +1,1 @@
+C.typeMethod()

--- a/test/classes/diten/typeMethodWrongReceiverType.chpl
+++ b/test/classes/diten/typeMethodWrongReceiverType.chpl
@@ -1,0 +1,7 @@
+class C {
+  proc type typeMethod() /* where this == C */ {
+    writeln("C.typeMethod()");
+  }
+}
+
+int.typeMethod();

--- a/test/classes/diten/typeMethodWrongReceiverType.future
+++ b/test/classes/diten/typeMethodWrongReceiverType.future
@@ -1,0 +1,6 @@
+bug: type method can be called on any type, not just the type it is defined for
+
+A type method is defined for a class "C", but then called on type "int".  This
+should be an unresolved call, but instead it compiles and calls C's type
+method.  A simple workaround is to add a where clause like the one that is
+commented out in the test.

--- a/test/classes/diten/typeMethodWrongReceiverType.good
+++ b/test/classes/diten/typeMethodWrongReceiverType.good
@@ -1,0 +1,2 @@
+typeMethodWrongReceiverType.chpl:7: error: unresolved call 'type int(64).typeMethod()'
+typeMethodWrongReceiverType.chpl:2: note: candidates are: C.type typeMethod()


### PR DESCRIPTION
Type methods currently accept any type as the receiver, so defining a type
method with the same name in two different classes is ambiguous instead of
using the type of the receiver to disambiguate.

Also, a type method defined in class "C" can be called on any type, for example
"int".

Both of these can be worked around with simple where clauses.