### PR TITLE
Correct mistakes in "Remove the Cray copyright notices from ... *.chpl tests"

### DIFF
--- a/test/modules/standard/FileSystem/bharshbarg/filer.good
+++ b/test/modules/standard/FileSystem/bharshbarg/filer.good
@@ -1,2 +1,2 @@
-filer.chpl:163: warning: sorting has no effect for parallel invocations of walkdirs()
+filer.chpl:144: warning: sorting has no effect for parallel invocations of walkdirs()
 .

--- a/test/users/aroonsharma/MyBlockCyclic.chpl
+++ b/test/users/aroonsharma/MyBlockCyclic.chpl
@@ -1,3 +1,5 @@
+// Copyright (c) 2004-2013, Cray Inc.  (See LICENSE file for more details)
+
 config const debugzipopt = false;
 config const testzipopt = false; //not supported yet
 config var totalcomm3 = false; //do count total communication volume


### PR DESCRIPTION
Correct mistakes in "Remove the Cray copyright notices from ... *.chpl tests"

1. Revert the 2017 copyright change (ie, restore the copyright) in file
   test/users/aroonsharma/MyBlockCyclic.chpl

2. Change the test output file "filer.good" to fix test error in file
   test/modules/standard/FileSystem/bharshbarg/filer.chpl, caused by
   removing the copyright block.