### PR TITLE
Make array init method selectable

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -604,11 +604,11 @@ module ChapelBase {
   }
 
   enum ArrayInit {heuristicInit, noInit, serialInit, parallelInit};
-  config param defaultArrayInitMethod = ArrayInit.heuristicInit;
-  var arrayInitMethod = defaultArrayInitMethod;
+  config param chpl_defaultArrayInitMethod = ArrayInit.heuristicInit;
+  var chpl_arrayInitMethod = chpl_defaultArrayInitMethod;
 
   proc init_elts(x, s, type t) : void {
-    var initMethod = arrayInitMethod;
+    var initMethod = chpl_arrayInitMethod;
 
     // for uints, check that s > 0, so the `s-1` below doesn't overflow
     if isUint(s) && s == 0 {

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -603,9 +603,60 @@ module ChapelBase {
     __primitive("chpl_exit_any", status);
   }
 
-  config param parallelInitElts=true;
+  enum ArrayInit {defaultInit, noInit, serialInit, parallelInit};
+  config var arrayInitMethod = ArrayInit.defaultInit;
+
   proc init_elts(x, s, type t) : void {
-    //
+    var initMethod = arrayInitMethod;
+
+    // for uints, check that s > 0, so the `s-1` below doesn't overflow
+    if isUint(s) && s == 0 {
+      initMethod = ArrayInit.noInit;
+    } else if initMethod == ArrayInit.defaultInit {
+      // Heuristically determine if we should do parallel initialization. The
+      // current heuristic really just checks that we have a numeric array that's
+      // at least 2MB. This value was chosen experimentally: Any smaller and the
+      // cost of a forall (mostly the task creation) outweighs the benefit of
+      // using multiple tasks. This was tested on a 2 core laptop, 8 core
+      // workstation, and 24 core XC40.
+      //
+      // Ideally we want to be able to do parallel initialization for all types,
+      // but we're currently blocked by an issue with arrays of arrays and thus
+      // arrays of aggregate types where at one field is an array. The issue is
+      // basically that an array's domain stores a linked list of all its arrays
+      // and removal becomes expensive when addition and removal occur in
+      // different orders. We don't currently have a good way to check if an
+      // aggregate type contains arrays, so we limit parallel init to numeric
+      // types.
+      //
+      // Long term we probably want to store the domain's arrays as an
+      // associative domain or some data structure with < log(n) find/add/remove
+      // times. Currently we can't do that because the domain's arrays are part
+      // of the base domain, so we have a circular reference. As a stepping
+      // stone, we could do parallel init for plain old data (POD) types.
+      if !isNumericType(t) {
+        initMethod = ArrayInit.serialInit;
+      } else {
+        param elemsizeInBytes = numBytes(t);
+        const arrsizeInBytes = s.safeCast(int) * elemsizeInBytes;
+        param heuristicThresh = 2 * 1024 * 1024;
+        const heuristicWantsPar = arrsizeInBytes > heuristicThresh;
+
+        if heuristicWantsPar {
+          initMethod = ArrayInit.parallelInit;
+        } else {
+          initMethod = ArrayInit.serialInit;
+        }
+      }
+    }
+
+    // need a real `here` since it's used in the range parallel iters
+    if initMethod == ArrayInit.parallelInit {
+      if here == dummyLocale {
+        initMethod = ArrayInit.serialInit;
+      }
+    }
+
     // Q: why is the declaration of 'y' in the following loops?
     //
     // A: so that if the element type is something like an array,
@@ -613,64 +664,28 @@ module ChapelBase {
     // One effect of having it in the loop is that the reference
     // count for an array element's domain gets bumped once per
     // element.  Is this good, bad, necessary?  Unclear.
-    //
-
-    //
-    // Heuristically determine if we should do parallel initialization. The
-    // current heuristic really just checks that we have a numeric array that's
-    // at least 2MB. This value was chosen experimentally: Any smaller and the
-    // cost of a forall (mostly the task creation) outweighs the benefit of
-    // using multiple tasks. This was tested on a 2 core laptop, 8 core
-    // workstation, and 24 core XC40.
-    //
-    // Ideally we want to be able to do parallel initialization for all types,
-    // but we're currently blocked by an issue with arrays of arrays and thus
-    // arrays of aggregate types where at one field is an array. The issue is
-    // basically that an array's domain stores a linked list of all its arrays
-    // and removal becomes expensive when addition and removal occur in
-    // different orders. We don't currently have a good way to check if an
-    // aggregate type contains arrays, so we limit parallel init to numeric
-    // types.
-    //
-    // Long term we probably want to store the domain's arrays as an
-    // associative domain or some data structure with < log(n) find/add/remove
-    // times. Currently we can't do that because the domain's arrays are part
-    // of the base domain, so we have a circular reference. As a stepping
-    // stone, we could do parallel init for plain old data (POD) types.
-    //
-
-    // for uints we need to check that s > 0, so the `s-1` in the following
-    // loops doesn't overflow.
-    if isUint(s) && s == 0 {
-      return;
-    }
-
-    if parallelInitElts && isNumericType(t) {
-
-      param elemsizeInBytes = numBytes(t);
-      const arrsizeInBytes = s.safeCast(int) * elemsizeInBytes;
-      param heuristicThresh = 2 * 1024 * 1024;
-      const heuristicWantsPar = arrsizeInBytes > heuristicThresh;
-
-      if heuristicWantsPar && here != dummyLocale {
-        forall i in 0..s-1 {
-          pragma "no auto destroy" var y: t;
-          __primitive("array_set_first", x, i, y);
-        }
-
-      } else {
+    select initMethod {
+      when ArrayInit.noInit {
+        return;
+      }
+      when ArrayInit.serialInit {
         for i in 0..s-1 {
           pragma "no auto destroy" var y: t;
           __primitive("array_set_first", x, i, y);
         }
       }
-    } else {
-      for i in 0..s-1 {
-        pragma "no auto destroy" var y: t;
-        __primitive("array_set_first", x, i, y);
+      when ArrayInit.parallelInit {
+        forall i in 0..s-1 {
+          pragma "no auto destroy" var y: t;
+          __primitive("array_set_first", x, i, y);
+        }
+      }
+      otherwise {
+        halt("ArrayInit.defaultInit should have been made concrete");
       }
     }
   }
+
 
   // dynamic data block class
   // (note that c_ptr(type) is similar, but local only,

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -603,8 +603,9 @@ module ChapelBase {
     __primitive("chpl_exit_any", status);
   }
 
-  enum ArrayInit {defaultInit, noInit, serialInit, parallelInit};
-  config var arrayInitMethod = ArrayInit.defaultInit;
+  enum ArrayInit {heuristicInit, noInit, serialInit, parallelInit};
+  config param defaultArrayInitMethod = ArrayInit.heuristicInit;
+  var arrayInitMethod = defaultArrayInitMethod;
 
   proc init_elts(x, s, type t) : void {
     var initMethod = arrayInitMethod;
@@ -612,7 +613,7 @@ module ChapelBase {
     // for uints, check that s > 0, so the `s-1` below doesn't overflow
     if isUint(s) && s == 0 {
       initMethod = ArrayInit.noInit;
-    } else if initMethod == ArrayInit.defaultInit {
+    } else if initMethod == ArrayInit.heuristicInit {
       // Heuristically determine if we should do parallel initialization. The
       // current heuristic really just checks that we have a numeric array that's
       // at least 2MB. This value was chosen experimentally: Any smaller and the
@@ -681,7 +682,7 @@ module ChapelBase {
         }
       }
       otherwise {
-        halt("ArrayInit.defaultInit should have been made concrete");
+        halt("ArrayInit.heuristicInit should have been made concrete");
       }
     }
   }

--- a/test/studies/isx/isx-hand-optimized.compopts
+++ b/test/studies/isx/isx-hand-optimized.compopts
@@ -1,1 +1,1 @@
---no-warnings -sarrayInitMethod=ArrayInit.serialInit --no-bounds-checks
+--no-warnings -sdefaultArrayInitMethod=ArrayInit.serialInit --no-bounds-checks

--- a/test/studies/isx/isx-hand-optimized.compopts
+++ b/test/studies/isx/isx-hand-optimized.compopts
@@ -1,1 +1,1 @@
---no-warnings -sdefaultArrayInitMethod=ArrayInit.serialInit --no-bounds-checks
+--no-warnings -schpl_defaultArrayInitMethod=ArrayInit.serialInit --no-bounds-checks

--- a/test/studies/isx/isx-hand-optimized.compopts
+++ b/test/studies/isx/isx-hand-optimized.compopts
@@ -1,1 +1,1 @@
---no-warnings -sparallelInitElts=false --no-bounds-checks
+--no-warnings -sarrayInitMethod=ArrayInit.serialInit --no-bounds-checks

--- a/test/studies/isx/isx-hand-optimized.ml-compopts
+++ b/test/studies/isx/isx-hand-optimized.ml-compopts
@@ -1,1 +1,1 @@
---no-warnings -sparallelInitElts=false -sdisableBlockLazyRAD
+--no-warnings -schpl_defaultArrayInitMethod=ArrayInit.serialInit -sdisableBlockLazyRAD

--- a/test/studies/isx/isx-hand-optimized.perfcompopts
+++ b/test/studies/isx/isx-hand-optimized.perfcompopts
@@ -1,1 +1,1 @@
---no-warnings -sparallelInitElts=false -sdisableBlockLazyRAD
+--no-warnings -sarrayInitMethod=ArrayInit.serialInit -sdisableBlockLazyRAD

--- a/test/studies/isx/isx-hand-optimized.perfcompopts
+++ b/test/studies/isx/isx-hand-optimized.perfcompopts
@@ -1,1 +1,1 @@
---no-warnings -sdefaultArrayInitMethod=ArrayInit.serialInit -sdisableBlockLazyRAD
+--no-warnings -schpl_defaultArrayInitMethod=ArrayInit.serialInit -sdisableBlockLazyRAD

--- a/test/studies/isx/isx-hand-optimized.perfcompopts
+++ b/test/studies/isx/isx-hand-optimized.perfcompopts
@@ -1,1 +1,1 @@
---no-warnings -sarrayInitMethod=ArrayInit.serialInit -sdisableBlockLazyRAD
+--no-warnings -sdefaultArrayInitMethod=ArrayInit.serialInit -sdisableBlockLazyRAD


### PR DESCRIPTION
Allow us to specify noinit, serial init, parallel init, or heuristic init for
arrays. This is intended to help test out the performance implications of
serial vs parallel init for LCALS and other benchmarks where we want to make
sure we get first-touch right. Note that this is a hacky/not user-facing
solution meant to let us test things out until we have a real
initialization story.

We can now do something like:

```chapel
chpl_arrayInitMethod = ArrayInit.parallelInit;
var A: [1..100] int;
chpl_arrayInitMethod = ArrayInit.noInit;
var B: [1..10000000] int;
chpl_arrayInitMethod = ArrayInit. heuristicInit;
```

The default can also be set with ` -schpl_defaultArrayInitMethod=ArrayInit.serialInit`