### PR TITLE
Test perf of forcing LCALS RAW to use serial init and OMP to use parallel init

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -11,11 +11,12 @@ source $CWD/common-numa.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of multi-ddata 
-GITHUB_USER=gbtitus
-GITHUB_BRANCH=DefRectArr-multi-ddata
-SHORT_NAME=multi-ddata-numa
-START_DATE=12/20/16
+# Test performance of doing parallel init for parallel lcals and serial init
+# for serial versions
+GITHUB_USER=ronawho
+GITHUB_BRANCH=correct-lcals-arr-init
+SHORT_NAME=lcals-init
+START_DATE=01/07/17
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
In playground, test branch that attempts to force proper first-init for lcals kernels.