### PR TITLE
Adding API for Task ID comparison and conversion to string

### DIFF
--- a/doc/platforms/cygwin.rst
+++ b/doc/platforms/cygwin.rst
@@ -28,7 +28,7 @@ hard-drive (``/cygdrive/c/``) to create ``/cygdrive/c/chapel`` tends to
 work well. Currently, our compiler-generated Makefiles break when the
 compiler or runtime use an absolute path that contains spaces. If any
 Cygwin experts have tips on addressing this issue in a portable way,
-please let us know at chapel_info@cray.com.
+please let us know at :disguise:`chapel_info@cray.com`.
 
 
 Required Packages

--- a/doc/technotes/extern.rst
+++ b/doc/technotes/extern.rst
@@ -966,4 +966,4 @@ Future Directions
 We intend to continue improving these capabilities to provide richer
 and richer support for external types and functions over time.  If you
 have specific requests for improvement, please let us know at:
-chapel_info@cray.com.
+:disguise:`chapel_info@cray.com`.

--- a/doc/technotes/firstClassFns.rst
+++ b/doc/technotes/firstClassFns.rst
@@ -172,4 +172,4 @@ Future Directions
 
 Over time, we will be improving the support for first-class functions
 and their syntax.  If you have specific feature requests or
-suggestions, please let us know at: chapel_info@cray.com.
+suggestions, please let us know at: :disguise:`chapel_info@cray.com`.

--- a/doc/usingchapel/building.rst
+++ b/doc/usingchapel/building.rst
@@ -161,5 +161,5 @@ new build environment by creating ``Makefile.<compiler>`` and/or
 ``Makefile.<platform>`` files and setting your environment variables to
 refer to those files.  If you do develop new build environment support
 that you would like to contribute back to the community, we encourage
-you to send your changes back to us at: chapel_info@cray.com
+you to send your changes back to us at: :disguise:`chapel_info@cray.com`
 

--- a/doc/usingchapel/chplenv.rst
+++ b/doc/usingchapel/chplenv.rst
@@ -89,7 +89,8 @@ CHPL_HOST_PLATFORM
    We are interested in making our code framework portable to other platforms --
    if you are using Chapel on a platform other than the ones listed above,
    please refer to :ref:`platform-specific-settings` for ways to set up a
-   Makefile for this platform and/or contact us at: chapel_info@cray.com
+   Makefile for this platform and/or contact us at:
+   :disguise:`chapel_info@cray.com`
 
 PATH
 ~~~~

--- a/doc/usingchapel/tasks.rst
+++ b/doc/usingchapel/tasks.rst
@@ -36,7 +36,7 @@ detail.  The rest of this document includes:
 * a brief description of future directions for the tasking layer
 
 If you have questions about tasks that are not covered in the following,
-please send them to chapel_info@cray.com.
+please send them to :disguise:`chapel_info@cray.com`.
 
 
 --------------------------
@@ -311,8 +311,8 @@ threads per locale is too large.  For example, when running multi-locale
 programs, the GASNet communication layer typically places an upper bound
 of 127 or 255 on the number of threads per locale (There are ways to
 work around this assumption on certain platforms -- please contact us at
-chapel_info@cray.com or peruse the GASNet documentation if you need to
-do so.)
+:disguise:`chapel_info@cray.com` or peruse the GASNet documentation if you need
+to do so.)
 
 CHPL_TASKS == fifo
 ------------------
@@ -478,5 +478,5 @@ balancing at the other end of the spectrum (for programmers who would
 prefer not to manage threads or whose programs cannot trivially be
 load balanced manually).  Our hope is to leverage existing open source
 threading and task management software and to collaborate with others
-in these areas, so please contact us at chapel_info@cray.com if you'd
+in these areas, so please contact us at :disguise:`chapel_info@cray.com` if you'd
 like to work with us in this area.

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -228,6 +228,20 @@ c_sublocid_t chpl_task_getRequestedSubloc(void);
 chpl_taskID_t chpl_task_getId(void);
 
 //
+// Checks whether two task IDs are the same
+//
+chpl_bool chpl_task_idEquals(chpl_taskID_t, chpl_taskID_t);
+
+//
+// Returns the string representation of task ID
+// The string returned is the same buffer passed as argument
+//
+char* chpl_task_idTostring(
+                           char *,         //buffer on which ID is written
+			   size_t,         //length of the buffer in bytes
+			   chpl_taskID_t); //Task ID
+
+//
 // Yield.
 //
 void chpl_task_yield(void);

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -238,8 +238,8 @@ chpl_bool chpl_task_idEquals(chpl_taskID_t, chpl_taskID_t);
 //
 char* chpl_task_idTostring(
                            char *,         //buffer on which ID is written
-			   size_t,         //length of the buffer in bytes
-			   chpl_taskID_t); //Task ID
+                           size_t,         //length of the buffer in bytes
+                           chpl_taskID_t); //Task ID
 
 //
 // Yield.

--- a/runtime/include/tasks/fifo/tasks-fifo.h
+++ b/runtime/include/tasks/fifo/tasks-fifo.h
@@ -50,6 +50,9 @@ void chpl_task_stdModulesInitialized(void);
 //
 typedef uint64_t chpl_taskID_t;
 #define chpl_nullTaskID 0
+#ifndef CHPL_TASK_ID_STRING_MAX_LEN
+#define CHPL_TASK_ID_STRING_MAX_LEN 20
+#endif
 
 //
 // Task layer private area argument bundle header

--- a/runtime/include/tasks/massivethreads/tasks-massivethreads.h
+++ b/runtime/include/tasks/massivethreads/tasks-massivethreads.h
@@ -45,6 +45,9 @@ typedef struct {
 // between C code and Chapel code in the runtime.
 typedef intptr_t chpl_taskID_t;
 #define chpl_nullTaskID 0
+#ifndef CHPL_TASK_ID_STRING_MAX_LEN
+#define CHPL_TASK_ID_STRING_MAX_LEN 20
+#endif
 
 //
 // Task layer private area argument bundle header

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -51,6 +51,9 @@ void chpl_task_yield(void);
 //
 typedef unsigned int chpl_taskID_t;
 #define chpl_nullTaskID QTHREAD_NULL_TASK_ID
+#ifndef CHPL_TASK_ID_STRING_MAX_LEN
+#define CHPL_TASK_ID_STRING_MAX_LEN 20
+#endif
 
 //
 // Sync variables

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -818,6 +818,14 @@ chpl_taskID_t chpl_task_getId(void) {
   return get_current_ptask()->bundle.id;
 }
 
+chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {
+  return id1 == id2;
+}
+
+char* chpl_task_idTostring(char* buff, size_t size, chpl_taskID_t id) {
+  snprintf(buff, size, "%"PRIu64, id);
+  return buff;
+}
 
 void chpl_task_yield(void) {
   chpl_thread_yield();

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -823,8 +823,11 @@ chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {
 }
 
 char* chpl_task_idTostring(char* buff, size_t size, chpl_taskID_t id) {
-  snprintf(buff, size, "%"PRIu64, id);
-  return buff;
+  int ret = snprintf(buff, size, "%"PRIu64, id);
+  if(ret>0 && ret<size)
+    return buff;
+  else
+    return NULL;
 }
 
 void chpl_task_yield(void) {

--- a/runtime/src/tasks/massivethreads/tasks-massivethreads.c
+++ b/runtime/src/tasks/massivethreads/tasks-massivethreads.c
@@ -651,8 +651,11 @@ chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {
 }
 
 char* chpl_task_idTostring(char* buff, size_t size, chpl_taskID_t id) {
-  snprintf(buff, size, "%"PRIiPTR, id);
-  return buff;
+  int ret = snprintf(buff, size, "%"PRIiPTR, id);
+  if(ret>0 && ret<size)
+    return buff;
+  else
+    return NULL;
 }
 
 //

--- a/runtime/src/tasks/massivethreads/tasks-massivethreads.c
+++ b/runtime/src/tasks/massivethreads/tasks-massivethreads.c
@@ -646,6 +646,15 @@ chpl_taskID_t chpl_task_getId(void) {
   return tid;
 }
 
+chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {
+  return id1 == id2;
+}
+
+char* chpl_task_idTostring(char* buff, size_t size, chpl_taskID_t id) {
+  snprintf(buff, size, "%"PRIiPTR, id);
+  return buff;
+}
+
 //
 // Yield.
 //

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1021,8 +1021,11 @@ chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {
 }
 
 char* chpl_task_idTostring(char* buff, size_t size, chpl_taskID_t id) {
-  snprintf(buff, size, "%u", id);
-  return buff;
+  int ret = snprintf(buff, size, "%u", id);
+  if(ret>0 && ret<size)
+    return buff;
+  else
+    return NULL;
 }
 
 void chpl_task_sleep(double secs)

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1016,6 +1016,15 @@ chpl_taskID_t chpl_task_getId(void)
     return *id_ptr;
 }
 
+chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {
+  return id1 == id2;
+}
+
+char* chpl_task_idTostring(char* buff, size_t size, chpl_taskID_t id) {
+  snprintf(buff, size, "%u", id);
+  return buff;
+}
+
 void chpl_task_sleep(double secs)
 {
     if (qthread_shep() == NO_SHEPHERD) {

--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -111,6 +111,12 @@ release/examples/benchmarks/ssca2/performance.graph
 # suite: DOE proxy apps
 studies/lulesh/bradc/lulesh-dense.graph
 release/examples/benchmarks/miniMD/miniMD.graph
+release/examples/benchmarks/lcals/LCALS-raw-short.graph
+release/examples/benchmarks/lcals/LCALS-raw-medium.graph
+release/examples/benchmarks/lcals/LCALS-raw-long.graph
+release/examples/benchmarks/lcals/LCALS-parallel-short.graph
+release/examples/benchmarks/lcals/LCALS-parallel-medium.graph
+release/examples/benchmarks/lcals/LCALS-parallel-long.graph
 # suite: Shootout benchmarks
 studies/shootout/binary-trees/binary-trees.graph
 studies/shootout/chameneos-redux/chameneos-redux.graph

--- a/tools/chplvis/DataModel.cxx
+++ b/tools/chplvis/DataModel.cxx
@@ -157,6 +157,7 @@ int DataModel::LoadData(const char * filename, bool fromArgv)
 
   // Set the main task ID
   mainTID = tid;
+  mainTask.taskRec = new E_task (0, 0, 0, tid, 0, 0, -1, -1);
 
   // Debug
   std::list<Event *>::iterator itr;
@@ -953,7 +954,7 @@ int DataModel::LoadFile (const char *fileToOpen, int index, double seq)
             while (linedata[len] == '\n' || linedata[len] == ' ')
               linedata[len] = 0;
             const char *tag = strDB.getString(&linedata[nextCh]);
-             if (tagNames.size() <= tagId) {
+            if (tagNames.size() <= (unsigned)tagId) {
               if (tagNames.size() == 0)
                 tagNames.resize(64);
               else

--- a/util/chplspell
+++ b/util/chplspell
@@ -43,12 +43,20 @@ if ! $RIVENV $SCSPELL --help > /dev/null 2> /dev/null; then
     exit 1
 fi
 
-# The "globstar" option below lets these **/ patterns recurse
-NORMALGLOBS=("**/*.chpl" "**/*.cpp" "**/*.c" "**/*.h" \
-	     "**/README*" "**/*.md" "**/*.rst" "**/*.1")
+# Normal files to look for when recursing through directories.
+NORMALGLOBS=("-name" "*.chpl"  "-o"
+             "-name" "*.cpp"   "-o"
+             "-name" "*.c"     "-o"
+             "-name" "*.h"     "-o"
+             "-name" "README*" "-o"
+             "-name" "*.md"    "-o"
+             "-name" "*.rst"   "-o"
+             "-name" "*.1" )
 # *.1 are man pages
 
-LATEXGLOBS=("**/*.tex")
+# Latex files to look for when recursing through directories.
+# These are tracked separately because scspell needs --no-c-escapes for them.
+LATEXGLOBS=("-name" "*.tex")
 
 DEFAULTDIRS=( \
 	     compiler doc man modules runtime spec \
@@ -173,27 +181,31 @@ done
 if [ $JUSTARGS == 0 ]; then
     # If nothing was specified on the command line, use our default lists.
     if [ ${#TARGETDIRS} == 0 -a ${#NORMALFILES} == 0 -a $# == 0 ]; then
-	TARGETDIRS=("${DEFAULTDIRS[@]}")
-	NORMALFILES=("${DEFAULTFILES[@]}")
 	cd $CHPL_HOME
+	# Now that we're in $CHPL_HOME, use [*] to expand the globs in
+	# $DEFAULTFILES.  This is ok since DEFAULTFILES doesn't
+	# contain any filesnames with spaces etc.  DEFAULTDIRS has no
+	# globs.
+	NORMALFILES=(${DEFAULTFILES[*]})
+	TARGETDIRS=("${DEFAULTDIRS[@]}")
     fi
 
-    for d in "${TARGETDIRS[@]}"; do
-	# globstar enables the patterns above (e.g. **/*.chpl) to recurse.
-	# nullglob causes a glob that matches nothing to return an empty
-	# string instead of the literal glob.
-	shopt -s globstar nullglob
+    if [ ${#TARGETDIRS} != 0 ]; then
 	NFILES=() LFILES=()
-	for g in "${NORMALGLOBS[@]}"; do
-	    NFILES+=("$d"/$g)
-	done
-	for g in "${LATEXGLOBS[@]}"; do
-	    LFILES+=("$d"/$g)
-	done
-	shopt -u globstar nullglob
+
+	# Get the results of the find into a shell array.  Use find
+	# -print0 to avoid problems with spaces and special
+	# characters.  The "IFS=" and -d $'\0' allow 'read' to consume
+	# -print0 output.
+	while IFS= read -r -d $'\0' F; do
+	    NFILES+=("$F")
+	done < <(find "${TARGETDIRS[@]}" \( "${NORMALGLOBS[@]}" \) -print0)
+
+	while IFS= read -r -d $'\0' F; do
+	    LFILES+=("$F")
+	done < <(find "${TARGETDIRS[@]}" \( "${LATEXGLOBS[@]}" \) -print0)
 
 	# Filter out files listed in $FILTEROUT
-
 	for file in "${NFILES[@]}"; do
 	    b=$(basename "$file")
 	    KEEP=1
@@ -221,7 +233,7 @@ if [ $JUSTARGS == 0 ]; then
 		LATEXFILES+=("$file")
 	    fi
 	done
-    done
+    fi
 fi
 
 if [ ${#NORMALFILES[@]} != 0 -a  \
@@ -232,28 +244,19 @@ if [ ${#NORMALFILES[@]} != 0 -a  \
     exit 1
 fi
 
-# Sort the lists so that files in the same directory are presented to
-# the user at the same time, even if there's a mix of file types.
-# The LaTeX files are still separate, since they require the --no-c-escapes
-# option.
-
-# Shell array sorting courtesy of
-# http://stackoverflow.com/questions/7442417/how-to-sort-an-array-in-bash
 nrval=0  # normal rval
 if [ $JUSTARGS == 0 -a ${#NORMALFILES[@]} != 0 ]; then
-    IFS=$'\n' FILELIST=($(sort <<<"${NORMALFILES[*]}" | uniq))
     $RIVENV $SCSPELL --use-builtin-base-dict --override-dictionary $CHPL_DICT \
 	     --relative-to $CHPL_HOME \
-	     "${ARGS[@]}" "${FILELIST[@]}" "$@"
+	     "${ARGS[@]}" "${NORMALFILES[@]}" "$@"
     nrval=$?
 fi
 
 lrval=0  # latex rval
 if [ $JUSTARGS == 0 -a ${#LATEXFILES[@]} != 0 ]; then
-    IFS=$'\n' FILELIST=($(sort <<<"${LATEXFILES[*]}" | uniq))
     $RIVENV $SCSPELL --use-builtin-base-dict --override-dictionary $CHPL_DICT \
 	     --relative-to $CHPL_HOME \
-	     "${ARGS[@]}" --no-c-escapes "${FILELIST[@]}" "$@"
+	     "${ARGS[@]}" --no-c-escapes "${LATEXFILES[@]}" "$@"
     lrval=$?
 fi
 

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,12 +9,11 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of doing parallel init for parallel lcals and serial init
-# for serial versions
+# Test performance of stack allocating EndCounts
 GITHUB_USER=ronawho
-GITHUB_BRANCH=correct-lcals-arr-init
-SHORT_NAME=lcals-init
-START_DATE=01/07/17
+GITHUB_BRANCH=stack-end-count
+SHORT_NAME=stackEndCount
+START_DATE=01/09/17
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -6,8 +6,6 @@ CWD=$(cd $(dirname $0) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 
 source $CWD/common-perf.bash
-source $CWD/common-numa.bash
-
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
@@ -22,6 +20,6 @@ git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH
 git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
-perf_args="-performance-description $SHORT_NAME -performance-configs numa:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
+perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"
 $CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
API is required for comparing task IDs that are not integers,
since other types such as struct won't work with binary operators.
Also adding a 'to string' API to help with the printing of task IDs.