### PR TITLE
Tighten up check for errors on test of release

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -146,7 +146,7 @@ $teststatus = mysystem("cd $tmpdir/chapel-test && ./testReleaseHelp `$chplhome/u
 # send mail
 #
 if ($teststatus == 0 or $teststatus == 2) {
-    $failures = `grep Error $tmpdir/chapel-test/examples/Logs/testReleaseHelp.log | wc -l`; chomp($failures);
+    $failures = `grep \\\\[Error $tmpdir/chapel-test/examples/Logs/testReleaseHelp.log | wc -l`; chomp($failures);
     if ($failures == "0") {
         $shortstatus = "Passed";
         $successmail = "$allmail";


### PR DESCRIPTION
Prior to this commit, we were grepping for 'Error' when looking to see
if there were testing errors when running start_test on the release.
This tightens that check up to look for '[Error' because we got a
false negative this past weekend due to a new config param named
'testErrors' that I added (oops).  We could tighten this up further in
the future by having start_test return a well-defined error code when
it detects failures and rely on the exit code rather than doing a grep
ourselves.  I took the approach here because of its simplicity and
due to concern that the current status code of '2' from start_test may
be overloaded...