### PR TITLE
Fix ISx failure for numa

### DIFF
--- a/test/studies/isx/isx-hand-optimized.skipif
+++ b/test/studies/isx/isx-hand-optimized.skipif
@@ -1,0 +1,1 @@
+CHPL_LOCALE_MODEL == numa


### PR DESCRIPTION
Skip numa for isx-hand-optimized while we're using communication primitives and using the internal ddata fields