### PR TITLE
Remove the old flag FLAG_OMIT_FROM_CONSTRUCTOR

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -188,7 +188,6 @@ symbolFlag( FLAG_NO_REMOTE_MEMORY_FENCE , ypr, "no remote memory fence" , ncm)
 symbolFlag( FLAG_NOT_POD , ypr, "not plain old data" , "bit copy overridden")
 
 symbolFlag( FLAG_OBJECT_CLASS , npr, "object class" , ncm )
-symbolFlag( FLAG_OMIT_FROM_CONSTRUCTOR , ypr, "omit from constructor" , ncm )
 
 // FLAG_ON and FLAG_ON_BLOCK mark task functions and their wrappers,
 // respectively, that perform remote operations, i.e. corresponding to

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -939,8 +939,7 @@ static void build_type_constructor(AggregateType* ct) {
       Expr* exprType = field->defPoint->exprType;
       Expr* init = field->defPoint->init;
 
-      if (!strcmp(field->name, "_promotionType") ||
-          field->hasFlag(FLAG_OMIT_FROM_CONSTRUCTOR)) {
+      if (!strcmp(field->name, "_promotionType")) {
 
         fn->insertAtTail(
           new BlockStmt(
@@ -1085,7 +1084,6 @@ static void build_constructor(AggregateType* ct) {
       // "outer" is used internally to supply a pointer to
       // the outer parent of a nested class.
       if (!field->hasFlag(FLAG_SUPER_CLASS) &&
-          !field->hasFlag(FLAG_OMIT_FROM_CONSTRUCTOR) &&
           strcmp(field->name, "_promotionType") &&
           strcmp(field->name, "outer")) {
         // Create an argument to the default constructor

--- a/spec/proposals/constructors/Examples.tex
+++ b/spec/proposals/constructors/Examples.tex
@@ -527,13 +527,11 @@ look like:
 The current implementation uses the special pragma ``ignore noinit'', which is no longer
 needed because the noinit flag is simply ignored.
 
-When constructors are implemented to the point of supporting \sntx{initializer-clause}s,
-the pragma ``omit from constructor'' will also be unnecessary because the all-fields
-constructor would not always be called from an explicit constructor as it is today.
-Instead, field-initialization would be covered by the semantics of the
-\sntx{initializer-clause}.  The all-fields constructor would be called only if invoked
-explicitly from user code (impossible if any user-defined constructor is present), or to
-implement the semantics of \chpl{_defaultOf()}.
+When constructors are implemented to the point of supporting
+\sntx{initializer-clause}s, field-initialization would be covered by its
+semantics.  The all-fields constructor would be called only if invoked
+explicitly from user code (impossible if any user-defined constructor is
+present), or to implement the semantics of \chpl{_defaultOf()}.
 
 The implementation for single variable would, of course, parallel the implementation for
 sync vars.  When the \chpl{_defaultOf()} and the constructor calls are inlined, the above as would


### PR DESCRIPTION
I ran across this flag when trying to understand type constructors.  It appears
to be checked against but not attached to anything in either the compiler or
the modules.  It also appears to have been around for a really long time.  I
suspect that the last set of it was removed some time after 2010 (the latest
time the flags were reshuffled), but I don't know when that was removed.  In
any case, we don't use it now, so we might as well remove it.

In addition, at Elliot's suggestion, I removed a reference to the flag from the
old constructor proposal.

- [x] complete full paratest, for a sanity check.  I couldn't find a use of it with
grepcomp, grepmod or greptests, so this should just pass