### PR TITLE
Move the multi-ddata metadata fields, checking cache effects for 'flat'.

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -648,6 +648,9 @@ module DefaultRectangular {
     var origin: idxType;
     var factoredOffs: idxType;
 
+    var data: _ddata(eltType);
+    var shiftedData: _ddata(eltType);
+
     inline proc oneDData return defRectSimpleDData || mdNumChunks < 2;
 
     var mdParDim: int;
@@ -658,9 +661,6 @@ module DefaultRectangular {
     var mdRLen: idxType;
     var mdBlk: idxType;
     var mdAlias: bool;
-
-    var data: _ddata(eltType);
-    var shiftedData: _ddata(eltType);
 
     var mData : _ddata(_multiData(eltType=eltType,
                                   idxType=idxType));
@@ -761,6 +761,12 @@ module DefaultRectangular {
     var origin: idxType;
     var factoredOffs: idxType;
 
+    pragma "local field"
+    var data : _ddata(eltType);
+
+    pragma "local field"
+    var shiftedData : _ddata(eltType);
+
     inline proc oneDData return defRectSimpleDData || mdNumChunks < 2;
 
                                  // these are only used if !defRectSimpleDData
@@ -772,12 +778,6 @@ module DefaultRectangular {
     var mdRLen: idxType;         //       "     "  .length
     var mdBlk: idxType;          //       "     "  block factor when sliced
     var mdAlias: bool;           //   is this an alias of another array?
-
-    pragma "local field"
-    var data : _ddata(eltType);
-
-    pragma "local field"
-    var shiftedData : _ddata(eltType);
 
     pragma "local field"
       var mData : _ddata(_multiData(eltType=eltType,


### PR DESCRIPTION
I'm temporarily moving the new multi-ddata metadata fields in the
DefaultRectangularArr class so that they follow the pre-existing data
and shifted_data fields instead of being before them.  I'm doing this to
see if the small performance degradation we saw with locModel=flat for
some tests is due to the new fields interfering with cache line sharing
effects.  (Manual runs for several of the tests that seem to show solid
~5-8% degradation since the multi-ddata PR are not reproducing that
degradation, thus the experiment.)