### PR TITLE
Workaround cygwin pthread_attr_init bug

### DIFF
--- a/runtime/src/threads/pthreads/threads-pthreads.c
+++ b/runtime/src/threads/pthreads/threads-pthreads.c
@@ -211,6 +211,7 @@ static int do_pthread_create(pthread_t* thread,
   if(!chpl_alloc_stack_in_heap)
     return pthread_create(thread, attr, start_routine, arg);
 
+  memset(&local_attr, 0, sizeof(local_attr)); // avoid cygwin bug: see #5146
   rc = pthread_attr_init(&local_attr);
   if( rc != 0 ) {
     memset(thread, 0, sizeof(pthread_t));


### PR DESCRIPTION
chameneosredux-ejr is sporadically failing on cygwin32 because of a failure to
create more threads, leading to deadlock. Thread creation failure is caused by
pthread_attr_init in do_pthread_create failing with EBUSY. I believe this is
caused by a cygwin bug: https://cygwin.com/ml/cygwin/2016-04/msg00473.html

The jist of the bug seems to be that pthread_attr_init uses a magic number to
determine if the attribute has already been initialized. It looks like we're
occasionally reusing an old stack frame where the old attribute still has the
initialized value, which is leading to the failure. The odd part is we're
careful to call pthread_attr_destroy, which should unset that magic number.
Just doing a memset before the pthread_attr_init seems to workaround the issue
(passes 10,000 trials) so I'm going with that.

Note that this appears to be fixed in newer versions of cygwin, but users could
easily be using older versions.