### PR TITLE
add job script test-linux64-gcc63.bash

### DIFF
--- a/util/cron/test-linux64-gcc63.bash
+++ b/util/cron/test-linux64-gcc63.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with compiler gcc-6.3
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+source /data/cf/chapel/setup_gcc63.bash     # host-specific setup for target compiler
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc63"
+
+$CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
Prerequisite for Jenkins job correctness-test-linux64-gcc63, for new
gcc version 6.3.0.