### PR TITLE
Fix a typo that led to a race in the users guide

### DIFF
--- a/test/release/examples/users-guide/datapar/promotion.chpl
+++ b/test/release/examples/users-guide/datapar/promotion.chpl
@@ -12,7 +12,7 @@ writeln(A, "\n");
 
 
 forall a in A do
-  negate(A);
+  negate(a);
 
 writeln(A, "\n");
 


### PR DESCRIPTION
Duh... the explicit version of this forall should pass in the scalar,
not the whole array.  Passing in the whole array did a promotion
within the forall which led to a race condition.