### PR TITLE
Test perf of limiting TLS usage in task spawning

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,11 +9,11 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of stack allocating EndCounts
+# Test performance of limiting tls usage in task spawn
 GITHUB_USER=ronawho
-GITHUB_BRANCH=stack-end-count
-SHORT_NAME=stackEndCount
-START_DATE=01/09/17
+GITHUB_BRANCH=avoid-tls-in-task-spawn
+SHORT_NAME=avoidTLS
+START_DATE=01/10/17
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
Test out potential perf benefits of limiting how often we do a TLS get to see
if it's worth pursuing right now. I know this has a non-trivial performance
impact for serialized task spawning, but I'm curious to see the impact on real
task spawning and LCALS.

One way of limiting TLS usage will be to add a runtime "vector spawn"