### PR TITLE
Remove duplicate .graph files from the performance tracking suite

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -72,9 +72,6 @@ performance/bradc/parOpEquals.graph
 performance/sungeun/assign.1024.graph
 performance/sungeun/init.graph
 performance/thomasvandoren/matrix-multiply.graph
-arrays/ferguson/return-array-40000000.graph
-domains/ferguson/build-associative.graph
-types/atomic/ferguson/atomictest.graph
 parallel/taskCompare/elliot/taskSpawn.graph
 parallel/taskCompare/elliot/serialTaskSpawn.graph
 distributions/robust/associative/performance/array_iter.graph

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -1043,6 +1043,9 @@ def main():
                 # suites it belongs to, else add it add it to the graphList
                 graphnames = [x[0] for x in graphList]
                 if graphnames.count(l):
+                    if currSuite in graphList[graphnames.index(l)][1]:
+                        sys.stdout.write('[Warning: duplicate graph "{0}" '
+                            'found in suite "{1}"]\n'.format(l, currSuite))
                     graphList[graphnames.index(l)][1].append(currSuite)
                     # the suites at the top of our list our more often 'meta'
                     # suites that contains graphs from various suites. To keep


### PR DESCRIPTION
Duplicates result in the URL being fully expanded instead of just showing
suite=performancetracking.

This adds a check for duplicate .graph files in suites, and removes the
duplicates in the perf tracking suite.