### PR TITLE
Adding API for Task ID comparison and conversion to string

### DIFF
--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -228,6 +228,21 @@ c_sublocid_t chpl_task_getRequestedSubloc(void);
 chpl_taskID_t chpl_task_getId(void);
 
 //
+// Checks whether two task IDs are the same
+//
+chpl_bool chpl_task_idEquals(chpl_taskID_t, chpl_taskID_t);
+
+//
+// Returns the string representation of task ID
+// The string returned is the same buffer passed as argument
+// In case of an error NULL is returned
+//
+char* chpl_task_idTostring(
+               char *,         //buffer on which ID is written
+               size_t,         //length of the buffer in bytes
+               chpl_taskID_t); //Task ID
+
+//
 // Yield.
 //
 void chpl_task_yield(void);

--- a/runtime/include/tasks/fifo/tasks-fifo.h
+++ b/runtime/include/tasks/fifo/tasks-fifo.h
@@ -51,7 +51,7 @@ void chpl_task_stdModulesInitialized(void);
 typedef uint64_t chpl_taskID_t;
 #define chpl_nullTaskID 0
 #ifndef CHPL_TASK_ID_STRING_MAX_LEN
-#define CHPL_TASK_ID_STRING_MAX_LEN 20
+#define CHPL_TASK_ID_STRING_MAX_LEN 21
 #endif
 
 //

--- a/runtime/include/tasks/fifo/tasks-fifo.h
+++ b/runtime/include/tasks/fifo/tasks-fifo.h
@@ -50,6 +50,9 @@ void chpl_task_stdModulesInitialized(void);
 //
 typedef uint64_t chpl_taskID_t;
 #define chpl_nullTaskID 0
+#ifndef CHPL_TASK_ID_STRING_MAX_LEN
+#define CHPL_TASK_ID_STRING_MAX_LEN 20
+#endif
 
 //
 // Task layer private area argument bundle header

--- a/runtime/include/tasks/massivethreads/tasks-massivethreads.h
+++ b/runtime/include/tasks/massivethreads/tasks-massivethreads.h
@@ -46,7 +46,7 @@ typedef struct {
 typedef intptr_t chpl_taskID_t;
 #define chpl_nullTaskID 0
 #ifndef CHPL_TASK_ID_STRING_MAX_LEN
-#define CHPL_TASK_ID_STRING_MAX_LEN 20
+#define CHPL_TASK_ID_STRING_MAX_LEN 21
 #endif
 
 //

--- a/runtime/include/tasks/massivethreads/tasks-massivethreads.h
+++ b/runtime/include/tasks/massivethreads/tasks-massivethreads.h
@@ -45,6 +45,9 @@ typedef struct {
 // between C code and Chapel code in the runtime.
 typedef intptr_t chpl_taskID_t;
 #define chpl_nullTaskID 0
+#ifndef CHPL_TASK_ID_STRING_MAX_LEN
+#define CHPL_TASK_ID_STRING_MAX_LEN 20
+#endif
 
 //
 // Task layer private area argument bundle header

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -52,7 +52,7 @@ void chpl_task_yield(void);
 typedef unsigned int chpl_taskID_t;
 #define chpl_nullTaskID QTHREAD_NULL_TASK_ID
 #ifndef CHPL_TASK_ID_STRING_MAX_LEN
-#define CHPL_TASK_ID_STRING_MAX_LEN 20
+#define CHPL_TASK_ID_STRING_MAX_LEN 21
 #endif
 
 //

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -51,6 +51,9 @@ void chpl_task_yield(void);
 //
 typedef unsigned int chpl_taskID_t;
 #define chpl_nullTaskID QTHREAD_NULL_TASK_ID
+#ifndef CHPL_TASK_ID_STRING_MAX_LEN
+#define CHPL_TASK_ID_STRING_MAX_LEN 20
+#endif
 
 //
 // Sync variables

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -818,6 +818,17 @@ chpl_taskID_t chpl_task_getId(void) {
   return get_current_ptask()->bundle.id;
 }
 
+chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {
+  return id1 == id2;
+}
+
+char* chpl_task_idTostring(char* buff, size_t size, chpl_taskID_t id) {
+  int ret = snprintf(buff, size, "%"PRIu64, id);
+  if(ret>0 && ret<size)
+    return buff;
+  else
+    return NULL;
+}
 
 void chpl_task_yield(void) {
   chpl_thread_yield();

--- a/runtime/src/tasks/massivethreads/tasks-massivethreads.c
+++ b/runtime/src/tasks/massivethreads/tasks-massivethreads.c
@@ -646,6 +646,18 @@ chpl_taskID_t chpl_task_getId(void) {
   return tid;
 }
 
+chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {
+  return id1 == id2;
+}
+
+char* chpl_task_idTostring(char* buff, size_t size, chpl_taskID_t id) {
+  int ret = snprintf(buff, size, "%"PRIiPTR, id);
+  if(ret>0 && ret<size)
+    return buff;
+  else
+    return NULL;
+}
+
 //
 // Yield.
 //

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1016,6 +1016,18 @@ chpl_taskID_t chpl_task_getId(void)
     return *id_ptr;
 }
 
+chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {
+  return id1 == id2;
+}
+
+char* chpl_task_idTostring(char* buff, size_t size, chpl_taskID_t id) {
+  int ret = snprintf(buff, size, "%u", id);
+  if(ret>0 && ret<size)
+    return buff;
+  else
+    return NULL;
+}
+
 void chpl_task_sleep(double secs)
 {
     if (qthread_shep() == NO_SHEPHERD) {


### PR DESCRIPTION
API is required for comparing task IDs that are not integers,
since other types such as struct wont work with binary operators.
Also adding a 'to string' API to help with printing of task IDs.
Adding CHPL_TASK_ID_STRING_MAX_LEN to define the
maximum length of string buffer to use.