### PR TITLE
Change the type of the receiver in type methods from _any to the defining type

### DIFF
--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -212,6 +212,9 @@ static void add_parens_to_deinit_fns(FnSymbol* fn) {
 static void set_receiver_type_in_type_methods(FnSymbol* fn) {
   if (fn->hasFlag(FLAG_METHOD) && fn->thisTag == INTENT_TYPE) {
     if (TypeSymbol* ts = toTypeSymbol(fn->defPoint->parentSymbol)) {
+      // This only applies to primary methods.  Secondary methods will
+      // not get get changed here, but basically the same change happens
+      // to them in a later pass (normalize).
       if (fn->_this->type == dtAny) {
         fn->_this->type = ts->type;
       }

--- a/test/classes/diten/typeMethodOverload.bad
+++ b/test/classes/diten/typeMethodOverload.bad
@@ -1,3 +1,0 @@
-typeMethodOverload.chpl:13: error: ambiguous call 'type C1.typeMethod()'
-typeMethodOverload.chpl:2: note: candidates are: _any.typeMethod()
-typeMethodOverload.chpl:8: note:                 _any.typeMethod()

--- a/test/classes/diten/typeMethodOverload.future
+++ b/test/classes/diten/typeMethodOverload.future
@@ -1,5 +1,0 @@
-bug: using the same type method name in two classes gives ambiguous call error
-
-I would have expected the receiver type to disambiguate which method to call.
-One possible workaround is to add where clauses like the ones that are
-commented out in the test.

--- a/test/classes/diten/typeMethodWrongReceiverType.bad
+++ b/test/classes/diten/typeMethodWrongReceiverType.bad
@@ -1,1 +1,0 @@
-C.typeMethod()

--- a/test/classes/diten/typeMethodWrongReceiverType.future
+++ b/test/classes/diten/typeMethodWrongReceiverType.future
@@ -1,6 +1,0 @@
-bug: type method can be called on any type, not just the type it is defined for
-
-A type method is defined for a class "C", but then called on type "int".  This
-should be an unresolved call, but instead it compiles and calls C's type
-method.  A simple workaround is to add a where clause like the one that is
-commented out in the test.


### PR DESCRIPTION
Change the type of the receiver for type methods from _any to the type of the
class/record/union that defined the method.  This prevents calling type
methods on types other than the one that defined them and allows overloading
type methods.

Removed two .futures.