### PR TITLE
Trivial cleanup for flattenClasses

### DIFF
--- a/compiler/passes/flattenClasses.cpp
+++ b/compiler/passes/flattenClasses.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,32 +17,21 @@
  * limitations under the License.
  */
 
-#include "alist.h"
-#include "astutil.h"
-#include "baseAST.h"
-#include "expr.h"
 #include "passes.h"
+
+#include "expr.h"
 #include "stmt.h"
 
-
-void flattenClasses(void) {
-  //
-  // collect nested classes
-  //
-  Vec<AggregateType*> nestedClasses;
+void flattenClasses() {
   forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-    if (AggregateType* ct = toAggregateType(ts->type))
-      if (toAggregateType(ct->symbol->defPoint->parentSymbol->type))
-        nestedClasses.add(ct);
-  }
+    if (AggregateType* ct = toAggregateType(ts->type)) {
+      if (toAggregateType(ct->symbol->defPoint->parentSymbol->type)) {
+        ModuleSymbol* mod = ct->getModule();
+        DefExpr*      def = ct->symbol->defPoint;
 
-  //
-  // move nested classes to module level
-  //
-  forv_Vec(AggregateType, ct, nestedClasses) {
-    ModuleSymbol* mod = ct->getModule();
-    DefExpr *def = ct->symbol->defPoint;
-    def->remove();
-    mod->block->insertAtTail(def);
+        def->remove();
+        mod->block->insertAtTail(def);
+      }
+    }
   }
 }


### PR DESCRIPTION
I happened to glance at flattenClasses.cpp and noted a trivial use of Vec;
   1) Collect a subset of TypeSymbols in to a Vec
   2) Process the Vec

I thought I would spend 60 seconds converting the Vec to a std::vector but 30 seconds
in to the effort I realized that the real "problem" is that there's no need to run two loops
at all.

Reduced to a single loop

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Full paratest with --verify on linux64-single-locale and linux64-gasnet

