### PR TITLE
Revised solution to PR 5153

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -636,8 +636,8 @@ void AggregateType::addDeclarations(Expr* expr, bool tail) {
     addDeclaration(this, def, tail);
 
   } else if (BlockStmt* block = toBlockStmt(expr)) {
-    for_alist(expr, block->body) {
-      addDeclarations(expr, tail);
+    for_alist(stmt, block->body) {
+      addDeclarations(stmt, tail);
     }
 
   } else {

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -578,7 +578,8 @@ addDeclaration(AggregateType* ct, DefExpr* def, bool tail) {
       ArgSymbol* arg = new ArgSymbol(fn->thisTag, "this", ct);
       fn->_this = arg;
       if (fn->thisTag == INTENT_TYPE) {
-        setupTypeIntentArg(arg);
+        arg->intent = INTENT_BLANK;
+        arg->addFlag(FLAG_TYPE_VARIABLE);
       }
       arg->addFlag(FLAG_ARG_THIS);
       fn->insertFormalAtHead(new DefExpr(fn->_this));


### PR DESCRIPTION
Parsing a primary type method corrupted the type of the "this" ArgSymbol.
This resulted in a resolution failure for certain simple programs.  The first
solution for this error added code to the end of parsing to undo the
corruption.

The first commit reverts the changes to cleanup and fixes the root cause.

The second commit does some "whitespace" cleanup to the neighboring
code in type.cpp


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Full paratest with --verify on linux64
