### PR TITLE
Refactor rectangular I/O into a helper routine

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1889,6 +1889,14 @@ module DefaultRectangular {
   proc DefaultRectangularDom.dsiSerialRead(f) { this.dsiSerialReadWrite(f); }
 
   proc DefaultRectangularArr.dsiSerialReadWrite(f /*: Reader or Writer*/) {
+    chpl_serialReadWriteRectangular(f, this);
+  }
+
+  proc chpl_serialReadWriteRectangular(f, arr, dom=arr.dom) {
+    param rank = arr.rank;
+    type idxType = arr.idxType;
+    type idxSignedType = chpl__signedType(idxType);
+
     proc writeSpaces(dim:int) {
       for i in 1..dim {
         f <~> new ioLiteral(" ");
@@ -1920,7 +1928,7 @@ module DefaultRectangular {
           else if isspace then f <~> new ioLiteral(" ");
           else if isjson || ischpl then f <~> new ioLiteral(", ");
           idx(dim) = j;
-          f <~> dsiAccess(idx);
+          f <~> arr.dsiAccess(idx);
         }
       } else {
         for j in dom.ranges(dim) by makeStridePositive {
@@ -2020,15 +2028,15 @@ module DefaultRectangular {
           // like push_back
           const newDom = {offset..#sz};
 
-          dsiReallocate( newDom );
+          arr.dsiReallocate( newDom );
           // This is different from how push_back does it
           // because push_back might lead to a call to
           // _reprivatize but I don't see how to do that here.
           dom.dsiSetIndices( newDom.getIndices() );
-          dsiPostReallocate();
+          arr.dsiPostReallocate();
         }
 
-        f <~> dsiAccess(offset + i);
+        f <~> arr.dsiAccess(offset + i);
 
         i += 1;
       }
@@ -2042,9 +2050,9 @@ module DefaultRectangular {
       {
         // trim down to actual size read.
         const newDom = {offset..#i};
-        dsiReallocate( newDom );
+        arr.dsiReallocate( newDom );
         dom.dsiSetIndices( newDom.getIndices() );
-        dsiPostReallocate();
+        arr.dsiPostReallocate();
       }
 
     } else {


### PR DESCRIPTION
This has been a longstanding change that I've carried around in
the various array view branches and which has been one of the
hardest to maintain.  Here, I'm pulling it out into its own PR
to see if I can get it onto master sooner.

The idea here is that a lot of printing of rectangular arrays
is reasonably independent of whether it's a default rectangular
array, a slice, a reindexed array, etc.  So to avoid repeating
that logic for each domain map, create a helper routine that
takes in the input/output stream, the array, and the domain
representing what should be printed and then just do what we
normally do.