### PR TITLE
Perf annotations & label corrections

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -216,6 +216,8 @@ all:
       config: 16 node XC
   12/22/16:
     - multi-ddata (#5047)
+  01/11/17:
+    - Move the multi-ddata metadata fields, checking cache effects for 'flat'. (#5145)
 
 
 AllCompTime:
@@ -430,6 +432,9 @@ is:
 isx:
   02/26/16:
     - ISx ref to array (#3365)
+  01/10/17:
+    - text: Use comm primitive in ISx study version (#5131)
+      config: 16 node XC
 
 isx-bucket-spmd:
   02/26/16:
@@ -667,6 +672,10 @@ prk-stencil.xc-perf:
     - Problem size increased from --order=1000 to --order=32000 (#3813)
   08/12/16:
     - Improve and enable strided bulk transfer optimization as default (#4318)
+
+ptrans:
+  01/11/17:
+    - Replace temporary array in BlockCycDist with tuple (#5139)
 
 ra:
   05/13/16:

--- a/test/npb/cg/cg-a.graph
+++ b/test/npb/cg/cg-a.graph
@@ -2,3 +2,4 @@ perfkeys: Execution time =
 files: cg.A.dat
 graphkeys: runtime - A
 graphtitle: NAS Parallel Benchmarks: CG timings - size A
+ylabel: Time (seconds)

--- a/test/npb/cg/cg.graph
+++ b/test/npb/cg/cg.graph
@@ -2,11 +2,13 @@ perfkeys: Execution time =
 files: cg.S.dat
 graphkeys: runtime - S
 graphtitle: NAS Parallel Benchmarks: CG timings - size S
+ylabel: Time (seconds)
 
 perfkeys: Execution time =
 files: cg.W.dat
 graphkeys: runtime - W
 graphtitle: NAS Parallel Benchmarks: CG timings - size W
+ylabel: Time (seconds)
 
 #perfkeys: Execution time =
 #files: cg.B.dat

--- a/test/npb/ep/ep-b.graph
+++ b/test/npb/ep/ep-b.graph
@@ -2,3 +2,4 @@ perfkeys:  Time in seconds =, Time in seconds =
 files: ep.B.dat, ep.B.maxLogical.dat
 graphkeys: runtime - B, MAX_LOGICAL - B
 graphtitle: NAS Parallel Benchmarks: EP timings - size B
+ylabel: Time (seconds)

--- a/test/npb/ep/ep.graph
+++ b/test/npb/ep/ep.graph
@@ -2,16 +2,19 @@ perfkeys:  Time in seconds =, Time in seconds =
 files: ep.S.dat, ep.S.maxLogical.dat
 graphkeys: runtime - S, MAX_LOGICAL - S
 graphtitle: NAS Parallel Benchmarks: EP timings - size S
+ylabel: Time (seconds)
 
 perfkeys:  Time in seconds =, Time in seconds =
 files: ep.W.dat, ep.W.maxLogical.dat
 graphkeys: runtime - W, MAX_LOGICAL - W
 graphtitle: NAS Parallel Benchmarks: EP timings - size W
+ylabel: Time (seconds)
 
 perfkeys:  Time in seconds =, Time in seconds =
 files: ep.A.dat, ep.A.maxLogical.dat
 graphkeys: runtime - A, MAX_LOGICAL - A
 graphtitle: NAS Parallel Benchmarks: EP timings - size A
+ylabel: Time (seconds)
 
 #perfkeys:  Time in seconds =, Time in seconds =
 #files: ep.B.dat, ep.B.maxLogical.dat

--- a/test/npb/ft/ft-a.graph
+++ b/test/npb/ft/ft-a.graph
@@ -2,3 +2,4 @@ perfkeys:  Time in seconds =
 files: ft.A.dat
 graphkeys: runtime - A
 graphtitle: NAS Parallel Benchmarks: FT timings - size A
+ylabel: Time (seconds)

--- a/test/npb/ft/ft.graph
+++ b/test/npb/ft/ft.graph
@@ -2,11 +2,13 @@ perfkeys:  Time in seconds =
 files: ft.S.dat
 graphkeys: runtime - S
 graphtitle: NAS Parallel Benchmarks: FT timings - size S
+ylabel: Time (seconds)
 
 perfkeys:  Time in seconds =
 files: ft.W.dat
 graphkeys: runtime - W
 graphtitle: NAS Parallel Benchmarks: FT timings - size W
+ylabel: Time (seconds)
 
 #perfkeys:  Time in seconds =
 #files: ft.A.dat

--- a/test/users/franzf/v0/chpl/main.graph
+++ b/test/users/franzf/v0/chpl/main.graph
@@ -1,3 +1,3 @@
 perfkeys: fft_2:, fft_4:, fft_8:, fft_16:, fft_32:, fft_64:, fft_128:, fft_256:, fft_512:, fft_1024:, fft_2048:
-ylabel: Mflop/s
+ylabel: Time (seconds)
 graphtitle: Spiral 5.0 Chapel FFT example


### PR DESCRIPTION
## Annotations

* Replace temporary array in BlockCycDist with tuple (#5139)
* Move the multi-ddata metadata fields, checking cache effects for 'flat'. (#5145)
* Use comm primitive in ISx study version (#5131)

## Corrections

- Add ylabel `Time (seconds)` for NPBs
- Correct Spiral FFT ylabel to time instead of MFLOP/s