### PR TITLE
Respect cpp lines flag

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -288,7 +288,7 @@ void closeCFile(fileinfo* fi, bool beautifyIt) {
   // beautify without also improving indentation and such which could
   // save some time.
   //
-  if (beautifyIt && (saveCDir[0] || (debugCCode && printCppLineno)))
+  if (beautifyIt && (saveCDir[0] || printCppLineno))
     beautify(fi);
 }
 

--- a/test/compflags/codegen/cppLines.chpl
+++ b/test/compflags/codegen/cppLines.chpl
@@ -1,0 +1,5 @@
+require 'printfileline.h';
+
+extern proc printFileLine();
+
+printFileLine();

--- a/test/compflags/codegen/cppLines.compopts
+++ b/test/compflags/codegen/cppLines.compopts
@@ -1,0 +1,7 @@
+--cpp-lines
+--devel --cpp-lines
+--cpp-lines --savec output
+--devel --cpp-lines --savec output
+-g
+# this isn't intended to work... developers debug c lines by default
+#-g --devel

--- a/test/compflags/codegen/cppLines.good
+++ b/test/compflags/codegen/cppLines.good
@@ -1,0 +1,1 @@
+cppLines.chpl:5

--- a/test/compflags/codegen/printfileline.h
+++ b/test/compflags/codegen/printfileline.h
@@ -1,0 +1,1 @@
+#define printFileLine() (printf("%s:%d\n", __FILE__, __LINE__))


### PR DESCRIPTION
It turns out that throwing --cpp-lines didn't always generate # line
directives in the generated code as it should.  I think that part of the
problem with this code is that we haven't had very good testing of
the flag in the past.  So here, the main thing I do is add such a test
while also striving to get the flag working right by adjusting the
conditional that calls beautify (which inserts the # line directives).

The new test tries to enforce that the compiler inserts #line directives
when --cpp-lines is thrown (whether by a user or developer, whether C
is being saved or not) and when -g is thrown by users (but not by
developers).  It seems that previous attempts to clamp down on when
we beautify resulted in not respecting the --cpp-lines flag, which I think
is a mistake.  It may have been postulated that the user wouldn't know
whether or not we added #line directives if they did not save the C
code, but this is not the case.

For example, if the back-end C compiler hits a compilation error when
compiling with --cpp-lines even if the C is not saved, it should
reveal the .chpl line number where the problem occurred rather than
the .c line number.  This can be helpful for quickly tracking down the
root cause of the problem without looking through all the C code.
Another use case is when the __FILE__ or __LINE__ directives are used
in the generated C code, as in this test.

One downside of this test is that it does not check that other cases
(e.g., not throwing --cpp-lines, compiling -g as a developer) do not
generate cpp-lines.  I checked these by hand before merging the
test, but it's more difficult to test for automatically since the C files can
be saved in various TMPDIR places and therefore have different __FILE__
names; and also because the __LINE__ printed would be unstable as the
generated code changes over time.

As noted in util/files.cpp, beautify and the insertion of #lines are
arguably interwoven more tightly than they should be.  E.g., if
--savec is not used, we could insert #lines without beautifying
(indenting/ pretty printing) the generated code.  I didn't undertake
any improvements here as part of this effort.