### PR TITLE
move Error to SysError; whitespace

### DIFF
--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -117,7 +117,7 @@ HDFS Support Types and Functions
  */
 module HDFS {
 
-use IO, SysBasic, Error, UtilReplicatedVar;
+use IO, SysBasic, SysError, UtilReplicatedVar;
 
 pragma "no doc"
 extern type qio_locale_map_ptr_t;     // array of locale to byte range mappings

--- a/modules/standard/Buffers.chpl
+++ b/modules/standard/Buffers.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,7 +38,7 @@
  */
 module Buffers {
   use SysBasic;
-  use Error;
+  use SysError;
 
   pragma "no doc"
   extern type qbytes_ptr_t;
@@ -105,7 +105,7 @@ module Buffers {
   /* This type represents a contiguous sequence of bytes.
      This sequence of bytes is represented with a C pointer and length and is
      currently reference counted.  Note that this record contains private
-     fields in addition to the home field. 
+     fields in addition to the home field.
 
    */
   pragma "ignore noinit"
@@ -135,7 +135,7 @@ module Buffers {
   }*/
 
   /* Construct a bytes object by allocating zero-filled memory.
-   
+
      :arg len: the number of bytes to allocate
      :arg error: (optional) capture an error that was encountered instead of
                  halting on error
@@ -165,7 +165,7 @@ module Buffers {
   }
   pragma "no doc"
   private proc create_iobuf():bytes {
-    var err:syserr = ENOERR; 
+    var err:syserr = ENOERR;
     var ret = create_iobuf(err);
     if err then ioerror(err, "in create_iobuf");
     return ret;
@@ -183,7 +183,7 @@ module Buffers {
       var ret:bytes;
       ret.home = here;
       // The initial ref count is 1, so no need to call qbytes_retain here.
-      ret._bytes_internal = bulk_get_bytes(x.home.id, x._bytes_internal); 
+      ret._bytes_internal = bulk_get_bytes(x.home.id, x._bytes_internal);
       return ret;
     }
   }
@@ -207,8 +207,8 @@ module Buffers {
         qbytes_release(ret._bytes_internal);
       }
       ret.home = here;
-      ret._bytes_internal = bulk_get_bytes(x.home.id, x._bytes_internal); 
-      // On return from bulk_get_bytes, the ref count in ret._bytes_internal 
+      ret._bytes_internal = bulk_get_bytes(x.home.id, x._bytes_internal);
+      // On return from bulk_get_bytes, the ref count in ret._bytes_internal
       // should be 1.
       // Note that the error case is not handled (bulk_get_bytes must succeed).
     }
@@ -247,7 +247,7 @@ module Buffers {
   /* This type represents a particular location with a buffer.
      Use buffer methods like :proc:`buffer.start` and :proc:`buffer.advance` to
      create and manipulate :record:`buffer_iterator` s.  Note that this record
-     contains private fields in addition to the home field. 
+     contains private fields in addition to the home field.
 
    */
   pragma "ignore noinit"
@@ -257,7 +257,7 @@ module Buffers {
     pragma "no doc"
     var _bufit_internal:qbuffer_iter_t = qbuffer_iter_null();
   }
-  
+
   /* Create a :record:`buffer_iterator` that points nowhere */
   pragma "no doc"
   proc buffer_iterator.buffer_iterator() {
@@ -287,7 +287,7 @@ module Buffers {
 
   /* A buffer which can contain multiple memory regions
      (that is, multiple regions of :record:`bytes` objects).  Note that this
-     record contains private fields in addition to the home field. 
+     record contains private fields in addition to the home field.
 
    */
   pragma "ignore noinit"
@@ -381,7 +381,7 @@ module Buffers {
       var ret:buffer;
       var start_offset:int(64);
       var end_offset:int(64);
-     
+
       on x.home {
         start_offset = qbuffer_start_offset(x._buf_internal);
         end_offset = qbuffer_end_offset(x._buf_internal);
@@ -432,7 +432,7 @@ module Buffers {
 
       var start_offset:int(64);
       var end_offset:int(64);
-     
+
       on x.home {
         start_offset = qbuffer_start_offset(x._buf_internal);
         end_offset = qbuffer_end_offset(x._buf_internal);
@@ -632,7 +632,7 @@ module Buffers {
      so it reads a binary value in native endianness. For strings, this method
      reads a string encoded as the string length (as :type:`int`) followed by
      that number of bytes (as :type:`uint(8)`).
-     
+
      :arg it: a :record:`buffer_iterator` where reading will start
      :arg value: a basic type or :type:`string`
      :arg error: (optional) capture an error that was encountered instead of

--- a/modules/standard/Error.chpl
+++ b/modules/standard/Error.chpl
@@ -1,0 +1,5 @@
+use SysError;
+
+compilerWarning(
+  "Module 'Error' has been deprecated in favor of 'SysError' -- please update your 'use' clause"
+);

--- a/modules/standard/Error.chpl
+++ b/modules/standard/Error.chpl
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use SysError;
 
 compilerWarning(

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -85,7 +85,7 @@
  */
 module FileSystem {
 
-use Error, Path;
+use SysError, Path;
 
 /* S_IRUSR and the following constants are values of the form
    S_I[R | W | X][USR | GRP | OTH], S_IRWX[U | G | O], S_ISUID, S_ISGID, or
@@ -575,11 +575,11 @@ proc exists(name: string): bool {
    similar to simple invocations of the command-line `find` utility.
    May be invoked in serial or non-zippered parallel contexts.
 
-   :arg startdir: The root directory from which to start the search 
+   :arg startdir: The root directory from which to start the search
                   (defaults to ``"."``)
    :type startdir: `string`
 
-   :arg recursive: Indicates whether or not to descend recursively into 
+   :arg recursive: Indicates whether or not to descend recursively into
                    subdirectories (defaults to `false`)
    :type recursive: `bool`
 
@@ -589,7 +589,7 @@ proc exists(name: string): bool {
    :yield:  The paths to any files found, relative to `startdir`, as strings
 */
 
-iter findfiles(startdir: string = ".", recursive: bool = false, 
+iter findfiles(startdir: string = ".", recursive: bool = false,
                hidden: bool = false): string {
   if (recursive) then
     for subdir in walkdirs(startdir, hidden=hidden) do
@@ -601,8 +601,8 @@ iter findfiles(startdir: string = ".", recursive: bool = false,
 }
 
 pragma "no doc"
-iter findfiles(startdir: string = ".", recursive: bool = false, 
-               hidden: bool = false, param tag: iterKind): string 
+iter findfiles(startdir: string = ".", recursive: bool = false,
+               hidden: bool = false, param tag: iterKind): string
        where tag == iterKind.standalone {
   if (recursive) then
     forall subdir in walkdirs(startdir, hidden=hidden) do
@@ -735,7 +735,7 @@ private module chpl_glob_c_interface {
 
   extern const GLOB_NOMATCH: c_int;
 
-  extern proc chpl_glob(pattern:c_string, flags: c_int, 
+  extern proc chpl_glob(pattern:c_string, flags: c_int,
                         ref ret_glob:glob_t):c_int;
   extern proc chpl_glob_num(x:glob_t): size_t;
   extern proc chpl_glob_index(x:glob_t, idx:size_t): c_string;
@@ -820,7 +820,7 @@ iter glob(pattern: string = "*", param tag: iterKind)
 }
 
 pragma "no doc"
-iter glob(pattern: string = "*", followThis, param tag: iterKind): string 
+iter glob(pattern: string = "*", followThis, param tag: iterKind): string
        where tag == iterKind.follower {
   use chpl_glob_c_interface;
   var glb : glob_t;
@@ -978,28 +978,28 @@ proc isMount(name: string): bool {
 /* Lists the contents of a directory.  May be invoked in serial
    contexts only.
 
-   :arg path: The directory whose contents should be listed 
+   :arg path: The directory whose contents should be listed
               (defaults to ``"."``)
    :type path: `string`
 
-   :arg hidden: Indicates whether hidden files/directory should be listed 
+   :arg hidden: Indicates whether hidden files/directory should be listed
                 (defaults to `false`)
    :type hidden: `bool`
 
-   :arg dirs: Indicates whether directories should be listed 
+   :arg dirs: Indicates whether directories should be listed
               (defaults to `true`)
    :type dirs: `bool`
 
    :arg files: Indicates whether files should be listed (defaults to `true`)
    :type files: `bool`
 
-   :arg listlinks: Indicates whether symbolic links should be listed 
+   :arg listlinks: Indicates whether symbolic links should be listed
                    (defaults to `true`)
    :type listlinks: `bool`
 
    :yield: The names of the specified directory's contents, as strings
 */
-iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true, 
+iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
               files: bool = true, listlinks: bool = true): string {
   extern type DIRptr;
   extern type direntptr;
@@ -1397,9 +1397,9 @@ proc locale.umask(mask: int): int {
 
 
 /* Recursively walk a directory structure, yielding directory names.
-   May be invoked in serial or non-zippered parallel contexts.  
+   May be invoked in serial or non-zippered parallel contexts.
 
-   .. note:: 
+   .. note::
             The current parallel version is not very adaptive/dynamic
             in its application of parallelism to the list of
             subdirectories at any given level of the traversal, and
@@ -1426,7 +1426,7 @@ proc locale.umask(mask: int): int {
    :yield: The directory names encountered, relative to `path`, as strings
 */
 iter walkdirs(path: string = ".", topdown: bool = true, depth: int = max(int),
-              hidden: bool = false, followlinks: bool = false, 
+              hidden: bool = false, followlinks: bool = false,
               sort: bool = false): string {
 
   if (topdown) then
@@ -1441,7 +1441,7 @@ iter walkdirs(path: string = ".", topdown: bool = true, depth: int = max(int),
 
     for subdir in subdirs {
       const fullpath = path + "/" + subdir;
-      for subdir in walkdirs(fullpath, topdown, depth-1, hidden, 
+      for subdir in walkdirs(fullpath, topdown, depth-1, hidden,
                              followlinks, sort) do
         yield subdir;
     }
@@ -1456,9 +1456,9 @@ iter walkdirs(path: string = ".", topdown: bool = true, depth: int = max(int),
 // Here's a parallel version
 //
 pragma "no doc"
-iter walkdirs(path: string = ".", topdown: bool = true, depth: int =max(int), 
-              hidden: bool = false, followlinks: bool = false, 
-              sort: bool = false, param tag: iterKind): string 
+iter walkdirs(path: string = ".", topdown: bool = true, depth: int =max(int),
+              hidden: bool = false, followlinks: bool = false,
+              sort: bool = false, param tag: iterKind): string
        where tag == iterKind.standalone {
 
   if (sort) then

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -142,7 +142,7 @@ A code example::
 */
 module GMP {
   use SysBasic;
-  use Error;
+  use SysError;
   use BigInteger;
 
   /* The GMP ``mp_bitcnt_t`` type */

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -121,7 +121,7 @@ The default value of the :record:`iostyle` type is undefined.  However, the
 compiler-generated constructor is available.  It can be used to generate the
 default I/O style, with or without modifications. In addition, the function
 :proc:`defaultIOStyle` will return the default I/O style just as ``new
-iostyle()`` will. 
+iostyle()`` will.
 
 The I/O style for an I/O operation can be provided through an optional
 ``style=`` argument in a variety of places:
@@ -320,7 +320,7 @@ Error Handling
 
 Most I/O routines accept an optional `error=` argument. If that argument
 is used, instead of halting when an error is encountered, the function
-will return the error code. 
+will return the error code.
 
 These error codes are stored with the type :type:`SysBasic.syserr`. Success is
 represented by :proc:`SysBasic.ENOERR`. The error codes and their meaning
@@ -511,14 +511,14 @@ formatted complex number is padded to the requested size. For example:
 See :ref:`about-io-formatted-pound-details` for more details
 on this conversion type.
 
-``%n`` 
+``%n``
   a "number" - equivalent to one of %i, %u, %r, %m, or %z below,
   depending on the type
 
 ``%17n``
   a number padded out to 17 columns
 
-``%.4n`` 
+``%.4n``
   a number with 4 significant digits or a precision of 4
 
 Integral Conversions
@@ -600,7 +600,7 @@ Real Conversions
 
 ``%dr``
  a real number in decimal notation, e.g. ``12.34``
-``%6dr`` 
+``%6dr``
  a decimal number padded on the left to 6 columns (right-justified)
 ``%.4dr``
  a decimal number with 4 digits after the radix point
@@ -851,7 +851,7 @@ rules.
 ``%{}``
  curly braces can wrap a ``%`` or ``#`` conversion specifier. That way, even
  odd specifiers can be interpreted unambiguously. Some of the more complex
- features require the use of the ``%{}`` syntax, but it's always 
+ features require the use of the ``%{}`` syntax, but it's always
  acceptable to use curly braces to make the format string clearer.
  Curly braces are required for # conversion specifiers.
 
@@ -877,7 +877,7 @@ Going through each section for text conversions:
    decimal (e.g. ``0xFFF`` or ``0b101011``); and it will format a complex
    number with parens instead of as e.g. ``1.0+2.0i``
   ``+``
-   means to show a plus sign when printing positive numbers 
+   means to show a plus sign when printing positive numbers
   ``0``
    means to pad numeric conversions with 0 instead of space
   ``" "``
@@ -892,7 +892,7 @@ Going through each section for text conversions:
    present in the Chapel type. This flag currently only works in combination
    with the JSON format.  This flag allows a Chapel program to describe only the
    relevant fields in a record when the input might contain many more fields.
-  
+
 
 [optional field width]
    When printing numeric or string values, the field width specifies the number
@@ -901,10 +901,10 @@ Going through each section for text conversions:
    the converted value.
 
    For string conversions in readf (``%s`` ``%"`` ``%'`` ``%//``), the field
-   width specifies the maximum number of bytes to read. 
+   width specifies the maximum number of bytes to read.
 
    For numeric conversions in readf, the field width is ignored.
-   
+
 [optional . then precision]
    When printing floating point values, the precision is used to control
    the number of decimal digits to print.  For ``%r`` conversions, it
@@ -917,7 +917,7 @@ Going through each section for text conversions:
    precision indicates the maximum number of columns to print - and the result
    will be truncated if it does not fit. In readf for these textual string
    conversions, the precision indicates the maximum number of characters
-   (e.g. Unicode code points) to input. 
+   (e.g. Unicode code points) to input.
 
    The precision is silently ignored for integral conversions
    (``%i``, ``%u``, etc) and for ``%//`` conversions.
@@ -928,11 +928,11 @@ Going through each section for text conversions:
    ``x``
     means lower-case hexadecimal
    ``X``
-    means upper-case hexadecimal 
+    means upper-case hexadecimal
    ``o``
     means octal
    ``b``
-    means binary 
+    means binary
    ``j``
     means JSON-style strings, numbers, and structures
    ``h``
@@ -981,9 +981,9 @@ Going through each section for text conversions:
     means regular expression with flags *xyz*
    ``c``
     means a Unicode character - either the first character in a string
-    or an integral character code 
- 
-For binary conversions: 
+    or an integral character code
+
+For binary conversions:
 
 [optional endian flag]
    ``<``
@@ -1200,7 +1200,7 @@ module IO {
 */
 
 use SysBasic;
-use Error;
+use SysError;
 
 /*
 
@@ -1515,7 +1515,7 @@ extern const QIO_STRING_FORMAT_TOEOF:uint(8);
 
 /*
 
-The :record:`iostyle` type represents I/O styles 
+The :record:`iostyle` type represents I/O styles
 defining how Chapel's basic types should be read or written.
 
 See :ref:`about-io-style`.
@@ -1523,7 +1523,7 @@ See :ref:`about-io-style`.
 */
 extern record iostyle { // aka qio_style_t
   /* Perform binary I/O? 1 - yes, 0 - no.
-     This field is ignored for :type:`iokind` values other than ``dynamic``. 
+     This field is ignored for :type:`iokind` values other than ``dynamic``.
    */
   var binary:uint(8) = 0;
   // binary style choices
@@ -1532,7 +1532,7 @@ extern record iostyle { // aka qio_style_t
      It should be set to a value in :type:`iokind`.
    */
   var byteorder:uint(8) = iokind.native:uint(8);
-  
+
   /*
      What string format should we use when writing strings
      in binary mode? See :type:`iostringstyle` for more information
@@ -1891,7 +1891,7 @@ pragma "no doc"
 extern proc qio_format_error_bad_regexp():syserr;
 private extern proc qio_format_error_write_regexp():syserr;
 
-/* 
+/*
    :returns: the default I/O style. See :record:`iostyle`
              and :ref:`about-io-styles`
 
@@ -1903,7 +1903,7 @@ proc defaultIOStyle():iostyle {
 }
 
 /* Get an I/O style indicating binary I/O in native byte order.
-   
+
    :arg str_style: see :type:`iostringstyle` - which format to use when reading
                    or writing strings. Defaults to variable-byte length.
    :returns: the requested :record:`iostyle`
@@ -1917,7 +1917,7 @@ proc iostyle.native(str_style:int(64)=stringStyleWithVariableLength()):iostyle {
 }
 
 /* Get an I/O style indicating binary I/O in big-endian byte order.
-   
+
    :arg str_style: see :type:`iostringstyle` - which format to use when reading
                    or writing strings. Defaults to variable-byte length.
    :returns: the requested :record:`iostyle`
@@ -1931,7 +1931,7 @@ proc iostyle.big(str_style:int(64)=stringStyleWithVariableLength()):iostyle {
 }
 
 /* Get an I/O style indicating binary I/O in little-endian byte order.
-   
+
    :arg str_style: see :type:`iostringstyle` - which format to use when reading
                    or writing strings. Defaults to variable-byte length.
    :returns: the requested :record:`iostyle`
@@ -1966,7 +1966,7 @@ proc iostyle.text(/* args coming later */):iostyle  {
 pragma "no doc"
 extern type fdflag_t = c_int;
 
-/* 
+/*
 
 A value of the :type:`iohints` type defines a set of hints about the I/O that
 the file or channel will perform.  These hints may be used by the
@@ -2080,7 +2080,7 @@ proc ref file.~file() {
 /*
    We could support file locking and unlocking, but
    at the moment I don't see any use case in which
-   it would make sense. 
+   it would make sense.
 proc file.lock() {
   on this.home {
     seterr(nil, qio_file_lock(_file_internal));
@@ -2113,7 +2113,7 @@ proc file._style:iostyle {
 
    In order to free the resources allocated for a file, it
    must be closed using this method.
-  
+
    It is an error to perform any I/O operations on a file
    that has been closed.
    It is an error to close a file when it has channels that
@@ -2227,7 +2227,7 @@ proc file.tryGetPath() : string {
   else return ret;
 }
 
-/* 
+/*
 
 Get the path to an open file. Halt if there is an error getting the path.
 
@@ -2448,7 +2448,7 @@ The system file descriptor will be closed when the Chapel file is closed.
   descriptors that do not support the ``seek`` functionality. For example, file
   descriptors that represent pipes or open socket connections have this
   property. In that case, the resulting file value should only be used with one
-  :record:`channel` at a time.  
+  :record:`channel` at a time.
   The I/O system will ignore the channel offsets when reading or writing
   to files backed by non-seekable file descriptors.
 
@@ -2875,7 +2875,7 @@ proc channel._ch_ioerror(errstr:string, msg:string) {
 
 /*
    Acquire a channel's lock.
-   
+
    :arg error: optional argument to capture an error code. If this argument
                is not provided and an error is encountered, this function
                will halt with an error message.
@@ -2901,7 +2901,7 @@ inline proc channel.lock() {
 
 /*
    Release a channel's lock.
- */ 
+ */
 inline proc channel.unlock() {
   if locking {
     on this.home {
@@ -2931,11 +2931,11 @@ proc channel.offset():int(64) {
 
 /*
    Move a channel offset forward.
-   
+
    For a reading channel, this function will consume the next ``amount``
    bytes. If EOF is reached, the channel position may be left at the
    EOF.
-   
+
    For a writing channel, this function will write ``amount`` zeros - or some
    other data if it is stored in the channel's buffer, for example with
    :proc:`channel._mark` and :proc:`channel._revert`.
@@ -2944,7 +2944,7 @@ proc channel.offset():int(64) {
                is not provided and an error is encountered, this function
                will halt with an error message.
 
- */   
+ */
 proc channel.advance(amount:int(64), ref error:syserr) {
   on this.home {
     this.lock();
@@ -2964,7 +2964,7 @@ proc channel.advance(amount:int(64)) {
   }
 }
 
-// These begin with an _ to indicated that 
+// These begin with an _ to indicated that
 // you should have a lock before you use these... there is probably
 // a better name for them...
 
@@ -2985,13 +2985,13 @@ inline proc channel._offset():int(64) {
    *mark* a channel - that is, save the current offset of the channel on its
    *mark stack*. This function should only be called on a channel that is
    already locked with with :proc:`channel.lock`.
-   
+
    The *mark stack* stores several channel offsets. For any channel offset that
    is between the minimum and maximum value in the *mark stack*, I/O operations
    on the channel will keep that region of the file buffered in memory so that
    those operations can be un-done. As a result, it is possible to perform *I/O
    transactions* on a channel. The basic steps for an *I/O transaction* are:
-   
+
     * lock the channel with :proc:`channel.lock`
       (or work on an already-locked channel)
     * *mark* the current position with :proc:`channel._mark`
@@ -3003,7 +3003,7 @@ inline proc channel._offset():int(64) {
       calling :proc:`channel._revert`. Subsequent I/O operations will work
       as though nothing happened.
     * unlock the channel with :proc:`channel.unlock` if necessary
-   
+
   .. note::
 
     Note that it is possible to request an entire file be buffered in memory
@@ -3013,7 +3013,7 @@ inline proc channel._offset():int(64) {
 
   :returns: an error code, if an error was encountered.
 
- */ 
+ */
 // TODO - use the out error= style and otherwise halt on error, for consistency
 inline proc channel._mark():syserr {
   return qio_channel_mark(false, _channel_internal);
@@ -3089,7 +3089,7 @@ This function is equivalent to calling :proc:`open` and then
             to ``iokind.dynamic``, meaning that the associated
             :record:`iostyle` controls the formatting choices.
 :arg locking: compile-time argument to determine whether or not the
-              channel should use locking; sets the 
+              channel should use locking; sets the
               corresponding parameter of the :record:`channel` type.
               Defaults to true, but when safe, setting it to false
               can improve performance.
@@ -3097,7 +3097,7 @@ This function is equivalent to calling :proc:`open` and then
             channel should start reading. Defaults to 0.
 :arg end: zero-based byte offset indicating where in the file the
           channel should no longer be allowed to read. Defaults
-          to a ``max(int)`` - meaning no end point. 
+          to a ``max(int)`` - meaning no end point.
 :arg hints: optional argument to specify any hints to the I/O system about
             this file. See :type:`iohints`.
 :arg url: optional argument to specify a URL to open. See :mod:`Curl` and
@@ -3158,7 +3158,7 @@ This function is equivalent to calling :proc:`open` with ``iomode.cwr`` and then
            to ``iokind.dynamic``, meaning that the associated
            :record:`iostyle` controls the formatting choices.
 :arg locking: compile-time argument to determine whether or not the
-              channel should use locking; sets the 
+              channel should use locking; sets the
               corresponding parameter of the :record:`channel` type.
               Defaults to true, but when safe, setting it to false
               can improve performance.
@@ -3166,7 +3166,7 @@ This function is equivalent to calling :proc:`open` with ``iomode.cwr`` and then
             channel should start writing. Defaults to 0.
 :arg end: zero-based byte offset indicating where in the file the
           channel should no longer be allowed to write. Defaults
-          to a ``max(int)`` - meaning no end point. 
+          to a ``max(int)`` - meaning no end point.
 :arg hints: optional argument to specify any hints to the I/O system about
             this file. See :type:`iohints`.
 :arg url: optional argument to specify a URL to open. See :mod:`Curl` and
@@ -3229,7 +3229,7 @@ proc openwriter(path:string="", param kind=iokind.dynamic, param locking=true,
               to ``iokind.dynamic``, meaning that the associated
               :record:`iostyle` controls the formatting choices.
    :arg locking: compile-time argument to determine whether or not the
-                 channel should use locking; sets the 
+                 channel should use locking; sets the
                  corresponding parameter of the :record:`channel` type.
                  Defaults to true, but when safe, setting it to false
                  can improve performance.
@@ -3237,7 +3237,7 @@ proc openwriter(path:string="", param kind=iokind.dynamic, param locking=true,
                channel should start reading. Defaults to 0.
    :arg end: zero-based byte offset indicating where in the file the
              channel should no longer be allowed to read. Defaults
-             to a ``max(int)`` - meaning no end point. 
+             to a ``max(int)`` - meaning no end point.
    :arg hints: provide hints about the I/O that this channel will perform. See
                :type:`iohints`. The default value of :const:`IOHINT_NONE`
                will cause the channel to use the hints provided when opening
@@ -3245,7 +3245,7 @@ proc openwriter(path:string="", param kind=iokind.dynamic, param locking=true,
    :arg style: provide a :record:`iostyle` to use with this channel. The
                default value will be the :record:`iostyle` associated with
                this file.
-   
+
  */
 // It is the responsibility of the caller to release the returned channel
 // if the error code is nonzero.
@@ -3328,7 +3328,7 @@ proc file.lines(param locking:bool = true, start:int(64) = 0, end:int(64) = max(
               to ``iokind.dynamic``, meaning that the associated
               :record:`iostyle` controls the formatting choices.
    :arg locking: compile-time argument to determine whether or not the
-                 channel should use locking; sets the 
+                 channel should use locking; sets the
                  corresponding parameter of the :record:`channel` type.
                  Defaults to true, but when safe, setting it to false
                  can improve performance.
@@ -3336,7 +3336,7 @@ proc file.lines(param locking:bool = true, start:int(64) = 0, end:int(64) = max(
                channel should start writing. Defaults to 0.
    :arg end: zero-based byte offset indicating where in the file the
              channel should no longer be allowed to write. Defaults
-             to a ``max(int)`` - meaning no end point. 
+             to a ``max(int)`` - meaning no end point.
    :arg hints: provide hints about the I/O that this channel will perform. See
                :type:`iohints`. The default value of :const:`IOHINT_NONE`
                will cause the channel to use the hints provided when opening
@@ -3344,7 +3344,7 @@ proc file.lines(param locking:bool = true, start:int(64) = 0, end:int(64) = max(
    :arg style: provide a :record:`iostyle` to use with this channel. The
                default value will be the :record:`iostyle` associated with
                this file.
-   
+
  */
 // It is the responsibility of the caller to retain and release the returned
 // channel.
@@ -3362,7 +3362,7 @@ proc file.writer(out error:syserr, param kind=iokind.dynamic, param locking=true
 
 // documented in error= version
 pragma "no doc"
-proc file.writer(param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:c_int = 0, style:iostyle = this._style): channel(true,kind,locking) 
+proc file.writer(param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:c_int = 0, style:iostyle = this._style): channel(true,kind,locking)
 {
   var err:syserr = ENOERR;
   var ret = this.writer(err, kind, locking, start, end, hints, style);
@@ -3690,7 +3690,7 @@ private inline proc _write_one_internal(_channel_internal:qio_channel_ptr_t, par
 }
 
 private inline proc _read_one_internal(_channel_internal:qio_channel_ptr_t, param kind:iokind, ref x:?t):syserr {
-  
+
   // Create a new channel that borrows the pointer in the
   // existing channel so we can avoid locking (because we
   // already have the lock)
@@ -4108,7 +4108,7 @@ inline proc channel.read(ref args ...?k):bool {
   }
 }
 
-/* 
+/*
 
    Read values from a channel. The input will be consumed atomically - the
    channel lock will be held while reading all of the passed values.
@@ -4289,7 +4289,7 @@ proc channel.readstring(ref str_out:string, len:int(64) = -1, out error:syserr):
     var binary:uint(8) = qio_channel_binary(_channel_internal);
     var byteorder:uint(8) = qio_channel_byteorder(_channel_internal);
 
-    if binary { 
+    if binary {
       error = qio_channel_read_string(false, byteorder,
                                       iostringstyle.data_toeof,
                                       this._channel_internal, tx,
@@ -4440,7 +4440,7 @@ proc channel.readln(ref args ...?k,
   return this.read((...args), nl, error=error);
 }
 
-/* 
+/*
 
    Read values from a channel and then consume any bytes until
    newline is reached. The input will be consumed atomically - the
@@ -4477,7 +4477,7 @@ proc channel.readln(ref args ...?k,
 /*
    Read a value of passed type.
    Halts if an error is encountered.
-  
+
    .. note::
 
      It is difficult to handle errors or to handle reaching the end of
@@ -4506,7 +4506,7 @@ proc channel.read(type t) {
 /*
    Read a value of passed type followed by a newline.
    Halts if an error is encountered.
-   
+
    .. note::
 
      It is difficult to handle errors or to handle reaching the end of
@@ -4529,7 +4529,7 @@ proc channel.readln(type t) {
    Read values of passed types followed by a newline
    and return a tuple containing the read values.
    Halts if an error is encountered.
-   
+
    :arg t: more than one type to read
    :returns: a tuple of the read values
  */
@@ -4544,7 +4544,7 @@ proc channel.readln(type t ...?numTypes) where numTypes > 1 {
 /*
    Read values of passed types and return a tuple containing the read values.
    Halts if an error is encountered.
-   
+
    :arg t: more than one type to read
    :returns: a tuple of the read values
  */
@@ -4670,7 +4670,7 @@ proc channel.writeln(args ...?k,
 }
 
 
-/* 
+/*
 
    Write values to a channel followed by a newline.  The output will be
    produced atomically - the channel lock will be held while writing all of the
@@ -4896,11 +4896,11 @@ proc channel.itemWriter(type ItemType, param kind:iokind=iokind.dynamic) {
 // And now, the toplevel items.
 
 /* standard input, otherwise known as file descriptor 0 */
-const stdin:channel(false, iokind.dynamic, true) = openfd(0).reader(); 
+const stdin:channel(false, iokind.dynamic, true) = openfd(0).reader();
 /* standard output, otherwise known as file descriptor 1 */
-const stdout:channel(true, iokind.dynamic, true) = openfp(chpl_cstdout()).writer(); 
+const stdout:channel(true, iokind.dynamic, true) = openfp(chpl_cstdout()).writer();
 /* standard error, otherwise known as file descriptor 2 */
-const stderr:channel(true, iokind.dynamic, true) = openfp(chpl_cstderr()).writer(); 
+const stderr:channel(true, iokind.dynamic, true) = openfp(chpl_cstderr()).writer();
 
 /* Equivalent to stdout.write. See :proc:`channel.write` */
 proc write(args ...?n) {
@@ -4943,7 +4943,7 @@ proc read(type t ...?numTypes) {
 
 /* Delete a file. This function is likely to be replaced
    by :proc:`FileSystem.remove`.
- 
+
    :arg path: the path to the file to remove
    :arg error: optional argument to capture an error code. If this argument
                is not provided and an error is encountered, this function
@@ -5452,7 +5452,7 @@ proc channel._format_reader(
                conv.preArg2 != QIO_CONV_UNK ||
                conv.preArg3 != QIO_CONV_UNK
             {
-              // We need to consume args as part of matching this regexp. 
+              // We need to consume args as part of matching this regexp.
               gotConv = true;
               break;
             } else {
@@ -6512,7 +6512,7 @@ proc channel._extractMatch(m:reMatch, ref arg:reMatch, ref error:syserr) {
   // If the argument is a match record, just return it.
   arg = m;
 }
- 
+
 pragma "no doc"
 proc channel._extractMatch(m:reMatch, ref arg:string, ref error:syserr) {
   var cur:int(64);
@@ -6546,14 +6546,14 @@ proc channel._extractMatch(m:reMatch, ref arg:string, ref error:syserr) {
                                 _channel_internal, ts, gotlen, len: ssize_t);
     s = new string(ts, length=gotlen, needToCopy=false);
   }
- 
+
   if ! error {
     arg = s;
   } else {
     arg = "";
   }
 }
- 
+
 pragma "no doc"
 proc channel._extractMatch(m:reMatch, ref arg:?t, ref error:syserr) where t != reMatch && t != string {
   // If there was no match, return the default value of the type
@@ -6565,7 +6565,7 @@ proc channel._extractMatch(m:reMatch, ref arg:?t, ref error:syserr) where t != r
   // Read into a string the appropriate region of the file.
   var s:string;
   _extractMatch(m, s, error);
- 
+
   if ! error {
     arg = s:arg.type;
   } else {
@@ -6581,7 +6581,7 @@ proc channel._extractMatch(m:reMatch, ref arg:?t, ref error:syserr) where t != r
     the captures are being returned. Will change the channel
     position to just after the match. Will not do anything
     if error is set.
-   
+
     :arg m: a :record:`Regexp.reMatch` storing a location that matched
     :arg arg: an argument to retrieve the match into. If it is not a string,
               the string match will be cast to arg.type.
@@ -6689,7 +6689,7 @@ proc channel.search(re:regexp):reMatch
     :arg error: optional argument to capture an error code. If this argument
                 is not provided and an error is encountered, this function
                 will halt with an error message.
-    :returns: the region of the channel that matched 
+    :returns: the region of the channel that matched
  */
 
 proc channel.search(re:regexp, ref captures ...?k, ref error:syserr):reMatch
@@ -6799,7 +6799,7 @@ proc channel.match(re:regexp):reMatch
    If there was a match, leaves the channel position at
    the match. If there was no match, leaves the channel
    position where it was at the start of this call.
-   
+
    :arg re: a :record:`Regexp.regexp` record representing a compiled
              regular expression.
    :arg captures: an optional variable number of arguments in which to
@@ -6808,7 +6808,7 @@ proc channel.match(re:regexp):reMatch
    :arg error: optional argument to capture an error code. If this argument
                is not provided and an error is encountered, this function
                will halt with an error message.
-   :returns: the region of the channel that matched 
+   :returns: the region of the channel that matched
 
  */
 
@@ -7041,7 +7041,7 @@ proc file.localesForRegion(start:int(64), end:int(64)) {
 
   proc findloc(loc:string, locs:c_ptr(c_string), end:int) {
     for i in 0..end-1 {
-      if (loc == locs[i]) then 
+      if (loc == locs[i]) then
         return true;
     }
     return false;
@@ -7067,8 +7067,8 @@ proc file.localesForRegion(start:int(64), end:int(64)) {
     }
 
     // We found no "good" locales. So any locale is just as good as the next
-    if ret.numIndices == 0 then 
-      for loc in Locales do 
+    if ret.numIndices == 0 then
+      for loc in Locales do
         ret += loc;
   }
   return ret;

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,7 +35,7 @@
 */
 module Path {
 
-use Error;
+use SysError;
 
 /* Returns the basename of the file name provided.  For instance, in the
    name `/foo/bar/baz`, this function would return `baz`, while `/foo/bar/`

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,24 +18,24 @@
  */
 
 /*
-   
+
    Support for error handling.
 
    This module helps to handle errors. In particular, it enables routines
    to return a syserr - encoding an error state - and then contains routines
    that can be provided a syserr in order to print out a useful error message.
-   
+
    This module defines the type syserr, which can encode an error code or an
    error message. This type can be returned from routines generating an error.
-   
+
    The IO module uses these routines in a way that supports error inspection
    and also rapid prototyping. Most routines in the IO module have two forms.
    In one form, an error (of type syserr) is returned in an out error argument.
    In the second form, no error is returned, and instead the task will halt
    with a fatal error if an error is encountered.
-   
+
  */
-module Error {
+module SysError {
 
 use SysBasic;
 
@@ -128,7 +128,7 @@ proc ioerror(error:syserr, msg:string, path:string, offset:int(64))
 }
 
 /* Halt with a useful message. Instead of an error argument, this routine takes
-   in an error string to report. 
+   in an error string to report.
    The error message printed when halting will describe the error passed and
    msg will be appended to it, along with the path and file offset related to
    the error. For example, this routine might indicate a file format error at a
@@ -150,7 +150,7 @@ proc ioerror(errstr:string, msg:string, path:string, offset:int(64))
 
 /* Convert a syserr error code to a human-readable string describing that
    error.
-   
+
    :arg errstr: the error string
    :returns: a string describing the error
  */

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -35,7 +35,7 @@ Parsing module files:
   $CHPL_HOME/modules/packages/RangeChunk.chpl
   $CHPL_HOME/modules/packages/Search.chpl
   $CHPL_HOME/modules/standard/Sys.chpl
-  $CHPL_HOME/modules/standard/Error.chpl
+  $CHPL_HOME/modules/standard/SysError.chpl
   $CHPL_HOME/modules/standard/Regexp.chpl
 In bar
 In baz

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -32,7 +32,7 @@ Initializing Modules:
      List
     ChapelIO
      IO
-      Error
+      SysError
       Regexp
     LocaleTree
     DefaultAssociative


### PR DESCRIPTION
In anticipation of the coming `Error` class, the module `Error` had to be moved to `SysError`. This is in line with the current naming scheme of `SysBasic` and `Sys`.

- while there, fixed trailing whitespace
- passes linux64+flat testing