### PR TITLE
Correct label to "Time(us)" (per iteration)

### DIFF
--- a/test/users/franzf/v0/chpl/main.graph
+++ b/test/users/franzf/v0/chpl/main.graph
@@ -1,3 +1,3 @@
 perfkeys: fft_2:, fft_4:, fft_8:, fft_16:, fft_32:, fft_64:, fft_128:, fft_256:, fft_512:, fft_1024:, fft_2048:
-ylabel: Time (seconds)
+ylabel: Time (us)
 graphtitle: Spiral 5.0 Chapel FFT example


### PR DESCRIPTION
Small graph file correction pointed out in #5159