### PR TITLE
Skip new mandelbrot version for linux32

### DIFF
--- a/test/studies/shootout/mandelbrot/bradc/mandelbrot-blc.skipif
+++ b/test/studies/shootout/mandelbrot/bradc/mandelbrot-blc.skipif
@@ -2,4 +2,6 @@
 #
 # See JIRA 244 for more info: https://chapel.atlassian.net/browse/CHAPEL-244
 
+# the issue with --fast occurs on chapcs with CHPL_TARGET_ARCH=native
+COMPOPTS <= --fast
 CHPL_TARGET_PLATFORM == linux32

--- a/test/studies/shootout/mandelbrot/bradc/mandelbrot-blc.skipif
+++ b/test/studies/shootout/mandelbrot/bradc/mandelbrot-blc.skipif
@@ -1,0 +1,5 @@
+# Floating point precision variations in some configs cause binary mismatch
+#
+# See JIRA 244 for more info: https://chapel.atlassian.net/browse/CHAPEL-244
+
+CHPL_TARGET_PLATFORM == linux32


### PR DESCRIPTION
This change follows the lead of PR #4405 which disabled some versions
of mandelbrot for linux32 and --fast.

Over the weekend, testing of my new mandelbrot version failed on
linux32 due to the absence of a single bit on the uppermost border
of the mandelbrot set, which can be seen by zooming into the
expected solution on the CLBG site:

  http://benchmarksgame.alioth.debian.org/download/mandelbrot200.png

It's a little odd that this bit is "on" given how far it is outside
of the mandelbrot set, and on linux32, it's computed as being "off".
But only when --denormalize is on (as it is by default, currently).

As noted on the associated JIRA issue
(https://chapel.atlassian.net/browse/CHAPEL-244), some of the
reference versions of mandelbrot also seem to fail when compiled
with optimizations on (and looking at the website, some of the
leading versions fail or don't seem to be run in the 32-bit
configuration, also seeming to underscore this point).

We didn't seem to get failures for cygwin32, so I made my .skipif more
specialized for now (and Elliot confirms that he made the previous
skipif skip 32-bit just as a precaution).  If the behavior is unstable over
time, it can be expanded as necessary.