### PR TITLE
Don't be so fancy with the chpl_task_idToString() extern decl.

### DIFF
--- a/test/runtime/gbt/tasks/idToString.chpl
+++ b/test/runtime/gbt/tasks/idToString.chpl
@@ -1,6 +1,6 @@
 type buf_t = c_char;
 
-extern proc chpl_task_idToString(buf: c_ptr(buf_t),
+extern proc chpl_task_idToString(buf: c_void_ptr,
                                  size: size_t,
                                  id: chpl_taskID_t): c_string;
 extern proc chpl_task_getId(): chpl_taskID_t;


### PR DESCRIPTION
It turns out that trying to declare chpl_task_idToString() as extern
with an explicit (C) char* first argument ends up making it an int8_t*
instead, and then at least the Cray cc compiler barks at the mismatch
versus the real declaration.  To try to get around this, make the first
argument just a void* instead.