### PR TITLE
Disable CHPL_UNWIND during start_test runs

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -560,6 +560,9 @@ def check_environment():
     if "CHPL_DEVELOPER" in os.environ: # unset CHPL_DEVELOPER
         del os.environ["CHPL_DEVELOPER"]
 
+    if "CHPL_UNWIND" in os.environ:    # unset CHPL_UNWIND
+        del os.environ["CHPL_UNWIND"]
+
     # Check for $CHPL_HOME
     global home
     if "CHPL_HOME" in os.environ:


### PR DESCRIPTION
This commit disables CHPL_UNWIND during start_test runs, since the
output can be dramatically different (e.g., if an expected error
message is called, which calls halt, a stack trace is printed).

It's an open question as to how we'd do testing in a "CHPL_UNWIND on
by default" world, but in the meantime, I'm trying to work with
CHPL_UNWIND on by default to see how well it works.  In the meantime,
this mod seems like the nice thing to do for developers who use it.

In the conversation on the PR, Michael points out that there is a prediff
script that can be manually invoked to filter out CHPL_UNWIND output
and that there are tests that will be skipped if CHPL_UNWIND is unset
(which now it always will be).  But, we're currently never running with
CHPL_UNWIND set in our nightly testing, so these tests aren't being run
anyway and Michael reports that their .good files are stale anyway.
Meanwhile, Michael has opened issue #5017 to further discuss how
CHPL_UNWIND testing should ultimately work.