### PR TITLE
Rename and then refactor FnSymbol::tag_generic()

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1398,27 +1398,35 @@ hasGenericArgs(FnSymbol* fn) {
 }
 
 
-// Tag the given function as generic.
-// Returns true if there was a change, false otherwise.
-bool FnSymbol::tag_generic() {
-  if (hasFlag(FLAG_GENERIC))
-    return false;  // Already generic, no change.
+//
+// If the function is not currently marked as generic
+//    then if it is generic
+//      1) Update some flags
+//      2) Return true to indicate the status has been modified
+//
+bool FnSymbol::tagIfGeneric() {
+  bool retval = false;
 
-  if (int result = hasGenericArgs(this)) {
-    // This function has generic arguments, so mark it as generic.
-    addFlag(FLAG_GENERIC);
+  if (hasFlag(FLAG_GENERIC) == false) {
+    int result = hasGenericArgs(this);
 
-    // If the return type is not completely unknown (which is generic enough)
-    // and this function is a type constructor function,
-    // then mark its return type as generic.
-    if (retType != dtUnknown && hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
-      retType->symbol->addFlag(FLAG_GENERIC);
-      if (result == 2)
-        retType->hasGenericDefaults = true;
+    // If this function has at least 1 generic formal
+    if (result > 0) {
+      addFlag(FLAG_GENERIC);
+
+      if (retType != dtUnknown && hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
+        retType->symbol->addFlag(FLAG_GENERIC);
+
+        if (result == 2) {
+          retType->hasGenericDefaults = true;
+        }
+      }
+
+      retval = true;
     }
-    return true;
   }
-  return false;
+
+  return retval;
 }
 
 bool FnSymbol::isResolved() const {

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -820,37 +820,37 @@ void TypeSymbol::accept(AstVisitor* visitor) {
   }
 }
 
-/******************************** | *********************************
-*                                                                   *
-*                                                                   *
-********************************* | ********************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
-FnSymbol::FnSymbol(const char* initName) :
-  Symbol(E_FnSymbol, initName),
-  formals(),
-  retType(dtUnknown),
-  where(NULL),
-  retExprType(NULL),
-  body(new BlockStmt()),
-  thisTag(INTENT_BLANK),
-  retTag(RET_VALUE),
-  iteratorInfo(NULL),
-  _this(NULL),
-  _outer(NULL),
-  instantiatedFrom(NULL),
-  instantiationPoint(NULL),
-  basicBlocks(NULL),
-  calledBy(NULL),
-  userString(NULL),
-  valueFunction(NULL),
-  codegenUniqueNum(1),
-  doc(NULL),
-  retSymbol(NULL),
-  llvmDISubprogram(NULL),
-  _throwsError(false)
-{
+FnSymbol::FnSymbol(const char* initName) : Symbol(E_FnSymbol, initName) {
+  retType            = dtUnknown;
+  where              = NULL;
+  retExprType        = NULL;
+  body               = new BlockStmt();
+  thisTag            = INTENT_BLANK;
+  retTag             = RET_VALUE;
+  iteratorInfo       = NULL;
+  _this              = NULL;
+  _outer             = NULL;
+  instantiatedFrom   = NULL;
+  instantiationPoint = NULL;
+  basicBlocks        = NULL;
+  calledBy           = NULL;
+  userString         = NULL;
+  valueFunction      = NULL;
+  codegenUniqueNum   = 1;
+  doc                = NULL;
+  retSymbol          = NULL;
+  llvmDISubprogram   = NULL;
+  _throwsError       = false;
+
   substitutions.clear();
+
   gFnSymbols.add(this);
+
   formals.parent = this;
 }
 
@@ -858,16 +858,24 @@ FnSymbol::FnSymbol(const char* initName) :
 FnSymbol::~FnSymbol() {
   if (iteratorInfo) {
     // Also set iterator class and iterator record iteratorInfo = NULL.
-    if (iteratorInfo->iclass)
+    if (iteratorInfo->iclass) {
       iteratorInfo->iclass->iteratorInfo = NULL;
-    if (iteratorInfo->irecord)
+    }
+
+    if (iteratorInfo->irecord) {
       iteratorInfo->irecord->iteratorInfo = NULL;
+    }
+
     delete iteratorInfo;
   }
+
   BasicBlock::clear(this);
-  delete basicBlocks; basicBlocks = 0;
-  if (calledBy)
+
+  delete basicBlocks;
+
+  if (calledBy) {
     delete calledBy;
+  }
 }
 
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -373,121 +373,129 @@ class TypeSymbol : public Symbol {
   const char* doc;
 };
 
-/******************************** | *********************************
-*                                                                   *
-*                                                                   *
-********************************* | ********************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 class FnSymbol : public Symbol {
- public:
-  AList formals; // each formal is an ArgSymbol, but the
-                 // elements of this list are DefExprs
-  Type* retType; // The return type of the function.  This field is not
-                 // fully established until resolution, and could be NULL
-                 // before then.  Up to that point, return type information is
-                 // stored in the retExprType field.
-  BlockStmt* where;
-  BlockStmt* retExprType;
-  BlockStmt* body;
-  IntentTag thisTag;
-  RetTag retTag;
-  IteratorInfo* iteratorInfo; // Attached only to iterators, specifically to
-                              // original (user) iterators before lowering.
-  Symbol* _this;
-  Symbol* _outer;
-  FnSymbol *instantiatedFrom;
-  SymbolMap substitutions;
-  BlockStmt* instantiationPoint; // point of instantiation
-  std::vector<BasicBlock*>* basicBlocks;
-  Vec<CallExpr*>* calledBy;
-  const char* userString;
-  FnSymbol* valueFunction; // pointer to value function (created in
-                           // resolve and used in cullOverReferences)
-  int codegenUniqueNum;
-  const char *doc;
+public:
+  // each formal is an ArgSymbol, but the elements are DefExprs
+  AList                      formals;
+
+  // The return type of the function. This field is not fully established
+  // until function resolution, and could be NULL before then.  Up to that
+  // point, return type information is stored in the retExprType field.
+  Type*                      retType;
+
+  BlockStmt*                 where;
+  BlockStmt*                 retExprType;
+  BlockStmt*                 body;
+  IntentTag                  thisTag;
+  RetTag                     retTag;
+
+  // Attached original (user) iterators before lowering.
+  IteratorInfo*              iteratorInfo;
+
+  Symbol*                    _this;
+  Symbol*                    _outer;
+  FnSymbol*                  instantiatedFrom;
+  SymbolMap                  substitutions;
+  BlockStmt*                 instantiationPoint;
+  std::vector<BasicBlock*>*  basicBlocks;
+  Vec<CallExpr*>*            calledBy;
+  const char*                userString;
+
+  // pointer to value function (created in function resolution
+  // and used in cullOverReferences)
+  FnSymbol*                  valueFunction;
+
+  int                        codegenUniqueNum;
+  const char*                doc;
 
   // Used to store the return symbol during partial copying.
-  // Move to PartialCopyData?
-  Symbol* retSymbol;
+  Symbol*                    retSymbol;
 
   // Number of formals before tuple type constructor formals are added.
-  int numPreTupleFormals;
+  int                        numPreTupleFormals;
 
 #ifdef HAVE_LLVM
-  llvm::MDNode* llvmDISubprogram;
+  llvm::MDNode*              llvmDISubprogram;
 #else
-  void* llvmDISubprogram;
+  void*                      llvmDISubprogram;
 #endif
 
 
-                  FnSymbol(const char* initName);
-                 ~FnSymbol();
+                             FnSymbol(const char* initName);
+                            ~FnSymbol();
 
-  void            verify();
-  virtual void    accept(AstVisitor* visitor);
+  void                       verify();
+  virtual void               accept(AstVisitor* visitor);
 
   DECLARE_SYMBOL_COPY(FnSymbol);
 
-  FnSymbol*       copyInnerCore(SymbolMap* map);
-  FnSymbol*       getFnSymbol(void);
-  void            replaceChild(BaseAST* old_ast, BaseAST* new_ast);
+  FnSymbol*                  copyInnerCore(SymbolMap* map);
+  FnSymbol*                  getFnSymbol();
+  void                       replaceChild(BaseAST* oldAst, BaseAST* newAst);
 
-  FnSymbol*       partialCopy(SymbolMap* map);
-  void            finalizeCopy();
+  FnSymbol*                  partialCopy(SymbolMap* map);
+  void                       finalizeCopy();
 
   // Returns an LLVM type or a C-cast expression
-  GenRet          codegenFunctionType(bool forHeader);
-  GenRet          codegenCast(GenRet fnPtr);
+  GenRet                     codegenFunctionType(bool forHeader);
+  GenRet                     codegenCast(GenRet fnPtr);
 
-  GenRet          codegen();
-  void            codegenHeaderC();
-  void            codegenPrototype();
-  void            codegenDef();
+  GenRet                     codegen();
+  void                       codegenHeaderC();
+  void                       codegenPrototype();
+  void                       codegenDef();
 
-  void            printDef(FILE* outfile);
+  void                       printDef(FILE* outfile);
 
-  void            insertAtHead(Expr* ast);
-  void            insertAtHead(const char* format, ...);
+  void                       insertAtHead(Expr* ast);
+  void                       insertAtHead(const char* format, ...);
 
-  void            insertAtTail(Expr* ast);
-  void            insertAtTail(const char* format, ...);
+  void                       insertAtTail(Expr* ast);
+  void                       insertAtTail(const char* format, ...);
 
-  void            insertBeforeReturn(Expr* ast);
-  void            insertBeforeReturnAfterLabel(Expr* ast);
+  void                       insertBeforeReturn(Expr* ast);
+  void                       insertBeforeReturnAfterLabel(Expr* ast);
 
-  void            insertFormalAtHead(BaseAST* ast);
-  void            insertFormalAtTail(BaseAST* ast);
+  void                       insertFormalAtHead(BaseAST* ast);
+  void                       insertFormalAtTail(BaseAST* ast);
 
-  Symbol*         getReturnSymbol();
-  Symbol*         replaceReturnSymbol(Symbol* newRetSymbol, Type* newRetType);
+  Symbol*                    getReturnSymbol();
+  Symbol*                    replaceReturnSymbol(Symbol* newRetSymbol,
+                                                 Type*   newRetType);
 
-  int             numFormals()                                 const;
-  ArgSymbol*      getFormal(int i); // return ith formal
+  int                        numFormals()                                const;
+  ArgSymbol*                 getFormal(int i);
 
-  void            collapseBlocks();
+  void                       collapseBlocks();
 
-  bool            tagIfGeneric();
+  bool                       tagIfGeneric();
 
-  bool            isResolved()                                 const;
-  bool            isMethod()                                   const;
-  bool            isPrimaryMethod()                            const;
-  bool            isSecondaryMethod()                          const;
-  bool            isIterator()                                 const;
-  bool            returnsRefOrConstRef()                       const;
+  bool                       isResolved()                                const;
+  bool                       isMethod()                                  const;
+  bool                       isPrimaryMethod()                           const;
+  bool                       isSecondaryMethod()                         const;
+  bool                       isIterator()                                const;
+  bool                       returnsRefOrConstRef()                      const;
 
-  QualifiedType   getReturnQualType()                          const;
+  QualifiedType              getReturnQualType()                         const;
 
-  virtual void    printDocs(std::ostream *file, unsigned int tabs);
+  virtual void               printDocs(std::ostream* file,
+                                       unsigned int  tabs);
 
-  void            throwsErrorInit();
-  bool            throwsError()                                const;
+  void                       throwsErrorInit();
+  bool                       throwsError()                               const;
 
 private:
-  virtual std::string docsDirective();
+  virtual std::string        docsDirective();
 
-  int                 hasGenericFormals()                      const;
+  int                        hasGenericFormals()                         const;
 
-  bool                _throwsError;
+  bool                       _throwsError;
 };
 
 /******************************** | *********************************

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -466,7 +466,8 @@ class FnSymbol : public Symbol {
 
   void            collapseBlocks();
 
-  bool            tag_generic();
+  bool            tagIfGeneric();
+
   bool            isResolved()                                 const;
   bool            isMethod()                                   const;
   bool            isPrimaryMethod()                            const;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -484,6 +484,9 @@ class FnSymbol : public Symbol {
 
 private:
   virtual std::string docsDirective();
+
+  int                 hasGenericFormals()                      const;
+
   bool                _throwsError;
 };
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8852,8 +8852,9 @@ computeStandardModuleSet() {
 }
 
 
-void
-resolve() {
+void resolve() {
+  bool changed = true;
+
   parseExplainFlag(fExplainCall, &explainCallLine, &explainCallModule);
 
   computeStandardModuleSet(); // Lydia NOTE 09/12/16: is not linked to our
@@ -8863,11 +8864,15 @@ resolve() {
   // call _nilType nil so as to not confuse the user
   dtNil->symbol->name = gNil->name;
 
-  bool changed = true;
-  while (changed) {
+  // Iterate until all generic functions have been tagged with FLAG_GENERIC
+  while (changed == true) {
     changed = false;
+
     forv_Vec(FnSymbol, fn, gFnSymbols) {
-      changed = fn->tagIfGeneric() || changed;
+      // Returns true if status of fn is changed
+      if (fn->tagIfGeneric() == true) {
+        changed = true;
+      }
     }
   }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8867,7 +8867,7 @@ resolve() {
   while (changed) {
     changed = false;
     forv_Vec(FnSymbol, fn, gFnSymbols) {
-      changed = fn->tag_generic() || changed;
+      changed = fn->tagIfGeneric() || changed;
     }
   }
 

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -36,11 +36,11 @@
 #include <cstdlib>
 #include <inttypes.h>
 
-static int explainInstantiationLine = -2;
-static ModuleSymbol* explainInstantiationModule = NULL;
+static int             explainInstantiationLine   = -2;
+static ModuleSymbol*   explainInstantiationModule = NULL;
+static Vec<FnSymbol*>  whereStack;
 
-static Vec<FnSymbol*> whereStack;
-
+static bool evaluateWhereClause(FnSymbol* fn);
 
 static void
 explainInstantiation(FnSymbol* fn) {
@@ -140,25 +140,6 @@ getNewSubType(FnSymbol* fn, Symbol* key, TypeSymbol* actualTS) {
 }
 
 
-static bool
-evaluateWhereClause(FnSymbol* fn) {
-  if (fn->where) {
-    whereStack.add(fn);
-    resolveFormals(fn);
-    resolveBlockStmt(fn->where);
-    whereStack.pop();
-    SymExpr* se = toSymExpr(fn->where->body.last());
-    if (!se)
-      USR_FATAL(fn->where, "invalid where clause");
-    if (se->symbol() == gFalse)
-      return false;
-    if (se->symbol() != gTrue)
-      USR_FATAL(fn->where, "invalid where clause");
-  }
-  return true;
-}
-
-
 static void
 checkInfiniteWhereInstantiation(FnSymbol* fn) {
   if (fn->where) {
@@ -196,7 +177,7 @@ static void
 checkInstantiationLimit(FnSymbol* fn) {
   static Map<FnSymbol*,int> instantiationLimitMap;
 
-  // Don't count instantiations on internal modules 
+  // Don't count instantiations on internal modules
   // nor ones explicitly marked NO_INSTANTIATION_LIMIT.
   if (fn->getModule() &&
       fn->getModule()->modTag != MOD_INTERNAL &&
@@ -221,14 +202,14 @@ checkInstantiationLimit(FnSymbol* fn) {
 static void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
 {
   const size_t bufSize = 128;
-  char immediate[bufSize]; 
+  char immediate[bufSize];
   snprint_imm(immediate, bufSize, *var->immediate);
 
   // escape quote characters in name string
   char name[bufSize];
-  char * name_p = &name[0]; 
+  char * name_p = &name[0];
   char * immediate_p = &immediate[0];
-  for ( ; 
+  for ( ;
         name_p < &name[bufSize-1] && // don't overflow buffer
           '\0' != *immediate_p;      // stop at null in source
         name_p++, immediate_p++) {
@@ -239,9 +220,9 @@ static void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
   }
   *name_p = '\0';
   sym->name = astr(sym->name, name);
-            
+
   // add ellipsis if too long for buffer
-  if (name_p == &name[bufSize-1]) {       
+  if (name_p == &name[bufSize-1]) {
     sym->name = astr(sym->name, "...");
   }
 
@@ -253,8 +234,8 @@ static void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
 
   for ( ; immediate_p < &immediate_p[bufSize-1] &&  // don't overflow buffer
           cname_p < &cname[maxNameLength-1] &&      // stop at max length
-          '\0' != *immediate_p; 
-        immediate_p++ ) { 
+          '\0' != *immediate_p;
+        immediate_p++ ) {
     if (('A' <= *immediate_p && *immediate_p <= 'Z') ||
         ('a' <= *immediate_p && *immediate_p <= 'z') ||
         ('0' <= *immediate_p && *immediate_p <= '9') ||
@@ -270,7 +251,7 @@ static void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
   if (immediate_p == &immediate[bufSize-1] || // too long for buffer
       cname_p == &cname[maxNameLength-1]) {   // exceeds max length
     sym->cname = astr(sym->cname, "_etc");
-  }                   
+  }
 }
 
 static void
@@ -463,23 +444,29 @@ instantiateTypeForTypeConstructor(FnSymbol* fn, SymbolMap& subs, CallExpr* call,
  * \param subs Type substitutions to be made during instantiation
  * \param call Call that is being resolved
  */
-FnSymbol*
-instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
+FnSymbol* instantiateSignature(FnSymbol*  fn,
+                               SymbolMap& subs,
+                               CallExpr*  call) {
 
   //
   // Handle tuples explicitly
   // (_build_tuple, tuple type constructor, tuple default constructor)
   //
-  FnSymbol* tupleFn = createTupleSignature(fn, subs, call);
-  if (tupleFn) return tupleFn;
+  if (FnSymbol* tupleFn = createTupleSignature(fn, subs, call)) {
+    return tupleFn;
+  }
 
   form_Map(SymbolMapElem, e, subs) {
     if (TypeSymbol* ts = toTypeSymbol(e->value)) {
-      if (ts->type->symbol->hasFlag(FLAG_GENERIC))
+      if (ts->type->symbol->hasFlag(FLAG_GENERIC)) {
         INT_FATAL(fn, "illegal instantiation with a generic type");
+      }
+
       TypeSymbol* nts = getNewSubType(fn, e->key, ts);
-      if (ts != nts)
+
+      if (ts != nts) {
         e->value = nts;
+      }
     }
   }
 
@@ -487,8 +474,9 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   // determine root function in the case of partial instantiation
   //
   FnSymbol* root = fn;
-  while (root->instantiatedFrom &&
-         root->numFormals() == root->instantiatedFrom->numFormals()) {
+
+  while (root->instantiatedFrom != NULL &&
+         root->numFormals()     == root->instantiatedFrom->numFormals()) {
     root = root->instantiatedFrom;
   }
 
@@ -498,12 +486,13 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   // substitutions to refer to the root function's formal arguments
   //
   SymbolMap all_subs;
+
   if (fn->instantiatedFrom) {
     form_Map(SymbolMapElem, e, fn->substitutions) {
       all_subs.put(e->key, e->value);
     }
   }
-  
+
   form_Map(SymbolMapElem, e, subs) {
     copyGenericSub(all_subs, root, fn, e->key, e->value);
   }
@@ -514,9 +503,11 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   if (FnSymbol* cached = checkCache(genericsCache, root, &all_subs)) {
     if (cached != (FnSymbol*)gVoid) {
       checkInfiniteWhereInstantiation(cached);
+
       return cached;
-    } else
+    } else {
       return NULL;
+    }
   }
 
   SET_LINENO(fn);
@@ -525,6 +516,7 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   // copy generic class type if this function is a type constructor
   //
   Type* newType = NULL;
+
   if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
     newType = instantiateTypeForTypeConstructor(fn, subs, call, fn->retType);
   }
@@ -532,13 +524,13 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   //
   // instantiate function
   //
-  
+
   SymbolMap map;
-  
+
   if (newType) {
     map.put(fn->retType->symbol, newType->symbol);
   }
-  
+
   FnSymbol* newFn = fn->partialCopy(&map);
 
   addCache(genericsCache, root, newFn, &all_subs);
@@ -553,10 +545,11 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   }
 
   Expr* putBefore = fn->defPoint;
-  if( !putBefore->list ) {
+
+  if (putBefore->list == NULL) {
     putBefore = call->parentSymbol->defPoint;
   }
-  
+
   putBefore->insertBefore(new DefExpr(newFn));
 
   //
@@ -567,8 +560,11 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
       if (arg->intent == INTENT_PARAM) {
         Symbol* key = map.get(arg);
         Symbol* val = subs.v[i].value;
-        if (!key || !val || isTypeSymbol(val))
+
+        if (!key || !val || isTypeSymbol(val)) {
           INT_FATAL("error building parameter map in instantiation");
+        }
+
         paramMap.put(key, val);
       }
     }
@@ -583,8 +579,11 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
     if (paramMap.get(arg)) {
       Symbol* key = map.get(arg);
       Symbol* val = paramMap.get(arg);
-      if (!key || !val)
+
+      if (!key || !val) {
         INT_FATAL("error building parameter map in instantiation");
+      }
+
       paramMap.put(key, val);
     }
   }
@@ -595,24 +594,39 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   //
   for_formals(formal, fn) {
     ArgSymbol* newFormal = toArgSymbol(map.get(formal));
+
     if (Symbol* value = subs.get(formal)) {
       INT_ASSERT(formal->intent == INTENT_PARAM || isTypeSymbol(value));
+
       if (formal->intent == INTENT_PARAM) {
         newFormal->intent = INTENT_BLANK;
+
         newFormal->addFlag(FLAG_INSTANTIATED_PARAM);
-        if (newFormal->type->symbol->hasFlag(FLAG_GENERIC))
+
+        if (newFormal->type->symbol->hasFlag(FLAG_GENERIC)) {
           newFormal->type = paramMap.get(newFormal)->type;
+        }
+
       } else {
         newFormal->instantiatedFrom = formal->type;
-        newFormal->type = value->type;
+        newFormal->type             = value->type;
       }
+
       if (!newFormal->defaultExpr || formal->hasFlag(FLAG_TYPE_VARIABLE)) {
-        if (newFormal->defaultExpr)
+        Symbol* defaultSym = NULL;
+
+        if (newFormal->defaultExpr) {
           newFormal->defaultExpr->remove();
-        if (Symbol* sym = paramMap.get(newFormal))
-          newFormal->defaultExpr = new BlockStmt(new SymExpr(sym));
-        else
-          newFormal->defaultExpr = new BlockStmt(new SymExpr(gTypeDefaultToken));
+        }
+
+        if (Symbol* sym = paramMap.get(newFormal)) {
+          defaultSym = sym;
+        } else {
+          defaultSym = gTypeDefaultToken;
+        }
+
+        newFormal->defaultExpr = new BlockStmt(new SymExpr(defaultSym));
+
         insert_help(newFormal->defaultExpr, NULL, newFormal);
       }
     }
@@ -620,42 +634,89 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
 
   if (newType) {
     newType->defaultTypeConstructor = newFn;
-    newFn->retType = newType;
+    newFn->retType                  = newType;
   }
-  
+
   fixupTupleFunctions(fn, newFn, call);
 
-  if (newFn->numFormals() > 1 && newFn->getFormal(1)->type == dtMethodToken) {
+  if (newFn->numFormals()       >  1 &&
+      newFn->getFormal(1)->type == dtMethodToken) {
     newFn->getFormal(2)->type->methods.add(newFn);
   }
 
   newFn->tagIfGeneric();
 
-  if (!newFn->hasFlag(FLAG_GENERIC) && !evaluateWhereClause(newFn)) {
+  if (newFn->hasFlag(FLAG_GENERIC) == false &&
+      evaluateWhereClause(newFn)   == false) {
     //
     // where clause evaluates to false so cache gVoid as a function
     //
     replaceCache(genericsCache, root, (FnSymbol*)gVoid, &all_subs);
+
     return NULL;
   }
 
-  if (explainInstantiationLine == -2)
-    parseExplainFlag(fExplainInstantiation, &explainInstantiationLine, &explainInstantiationModule);
+  if (explainInstantiationLine == -2) {
+    parseExplainFlag(fExplainInstantiation,
+                     &explainInstantiationLine,
+                     &explainInstantiationModule);
+  }
 
   if (!newFn->hasFlag(FLAG_GENERIC) && explainInstantiationLine) {
     explainInstantiation(newFn);
   }
-  
+
   checkInstantiationLimit(fn);
-  
+
   return newFn;
 }
 
+static bool evaluateWhereClause(FnSymbol* fn) {
+  if (fn->where) {
+    whereStack.add(fn);
+
+    resolveFormals(fn);
+
+    resolveBlockStmt(fn->where);
+
+    whereStack.pop();
+
+    SymExpr* se = toSymExpr(fn->where->body.last());
+
+    if (se == NULL) {
+      USR_FATAL(fn->where, "invalid where clause");
+    }
+
+    if (se->symbol() == gFalse) {
+      return false;
+    }
+
+    if (se->symbol() != gTrue) {
+      USR_FATAL(fn->where, "invalid where clause");
+    }
+  }
+
+  return true;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /** Finish copying and instantiating the partially instantiated function.
- * 
+ *
  * TODO: See if more code from instantiateSignature can be moved into this
  *       function.
- * 
+ *
  * \param fn   Generic function to finish instantiating
  */
 void
@@ -667,7 +728,7 @@ instantiateBody(FnSymbol* fn) {
 
 /** Fully instantiate a generic function given a map of substitutions and a
  *  call site.
- * 
+ *
  * \param fn   Generic function to instantiate
  * \param subs Type substitutions to be made during instantiation
  * \param call Call that is being resolved
@@ -675,12 +736,12 @@ instantiateBody(FnSymbol* fn) {
 FnSymbol*
 instantiate(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   FnSymbol* newFn;
-  
+
   newFn = instantiateSignature(fn, subs, call);
-  
+
   if (newFn != NULL) {
     instantiateBody(newFn);
   }
-  
+
   return newFn;
 }

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -629,7 +629,7 @@ instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
     newFn->getFormal(2)->type->methods.add(newFn);
   }
 
-  newFn->tag_generic();
+  newFn->tagIfGeneric();
 
   if (!newFn->hasFlag(FLAG_GENERIC) && !evaluateWhereClause(newFn)) {
     //


### PR DESCRIPTION
While working on initializers I tripped over FnSymbol::tag_generic().

This is the only method on FnSymbol using the older underscore naming convention and it
was hard to guess from the name what it did.  A quick look at the code revealed a slightly
convoluted implementation of slightly odd behavior.

In practice this function might attach FLAG_GENERIC to a function and if it were to do so then
it would return true.  Otherwise it returns false.  It relies on a comparably slightly convoluted
static function.

Renamed the method to be FnSymbol:::tagIfGeneric() and converted the static function to be
a private method.  Simplified the control flow in these small methods.

However there is no change in functionality and the changes are trivial.  These are the first
two commits.

While there made some whitespace adjustments in the neighborhood i.e. reformatted a few
statements to fit in 80 columns, removed some trailing whitespace, inserted some braces for
clarity, and so on.  Most of this is in the second commit and then there is one last trivial change
in the fourth commit.



Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran paratest on
single-locale linux64 and gasnet linux64.   As I touched a header file I also verified it compiled
on LLVM.

