### PR TITLE
Remove --fast skipif for 32-bit mandelbrot

### DIFF
--- a/test/studies/shootout/mandelbrot/bradc/mandelbrot-blc.skipif
+++ b/test/studies/shootout/mandelbrot/bradc/mandelbrot-blc.skipif
@@ -3,5 +3,4 @@
 # See JIRA 244 for more info: https://chapel.atlassian.net/browse/CHAPEL-244
 
 # the issue with --fast occurs on chapcs with CHPL_TARGET_ARCH=native
-COMPOPTS <= --fast
 CHPL_TARGET_PLATFORM == linux32


### PR DESCRIPTION
I was thinking of this skipif as skipping the test for --fast testing,
but of course it also skips it for performance testing, which is what
I want to be doing.  Since the --fast failure didn't seem to occur
for any of the nightly testing configurations that we run, it seems
OK to disable it.  (It would presumably fail if we did --fast
performance testing on chapcs or did stricter verification of the
performance-sized mandelbrot output... unless the glitch doesn't
occur at that size?)

We may want to do this for the bharshbarg variant as well (?)