### PR TITLE
Enable inlining the multi-ddata array follower iterator.

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1170,8 +1170,8 @@ module DefaultRectangular {
       } else {
         const mdPDLow = dom.dsiDim(mdParDim).low;
         const chunk = mdInd2Chunk(mdPDLow + followThis(mdParDim).low);
-        if debugDataParMultiDData {
-          // this code assumes followThis spans but a single chunk
+        if boundsChecking {
+          // the code here assumes followThis spans but a single chunk
           assert(mdPDLow + followThis(mdParDim).high <= mData(chunk).pdr.high);
         }
 


### PR DESCRIPTION
The follower iterator for the multi-ddata case could not be inlined
because it had two separate iteration loops with an execution-time test
to choose which one to use.  I believe that the test actually checked a
condition that is always true, so here I'm removing it in order to get
the iterator inlined.  I am leaving behind a debug-protected assert()
test to check the condition, however.

For a number of tests, such as stream-ep, this gets performance back to
the expected range after the original multi-ddata slowed them way down.
It does not fix the largest losses, though, such as for '1D Array
Parallel Iteration'.  That has a different cause and will be treated
separately.