### PR TITLE
Fixed minor bug in printResolutionErrorUnresolved

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3187,6 +3187,7 @@ printResolutionErrorUnresolved(
                      CallInfo* info) {
   if( ! info ) INT_FATAL("CallInfo is NULL");
   if( ! info->call ) INT_FATAL("call is NULL");
+  bool needToReport = false;
   CallExpr* call = userCall(info->call);
 
   if (!strcmp("_cast", info->name)) {
@@ -3201,6 +3202,8 @@ printResolutionErrorUnresolved(
     if (info->actuals.n > 0 &&
         isRecord(info->actuals.v[2]->type))
       USR_FATAL_CONT(call, "delete not allowed on records");
+    else
+      needToReport = true;
   } else if (!strcmp("these", info->name)) {
     if (info->actuals.n == 2 &&
         info->actuals.v[0]->type == dtMethodToken) {
@@ -3211,6 +3214,8 @@ printResolutionErrorUnresolved(
         USR_FATAL_CONT(call, "cannot iterate over values of type %s",
                        toString(info->actuals.v[1]->type));
       }
+    } else {
+      needToReport = true;
     }
   } else if (!strcmp("_type_construct__tuple", info->name)) {
     if (info->call->argList.length == 0)
@@ -3248,6 +3253,11 @@ printResolutionErrorUnresolved(
                      toString(info));
     }
   } else {
+    needToReport = true;
+  }
+  // It would be eaiser to just check exit_eventually to catch all needToReport cases.
+  // Alas exit_eventually is static to misc.cpp.
+  if (needToReport) {
     const char* entity = "call";
     if (!strncmp("_type_construct_", info->name, 16))
       entity = "type specifier";
@@ -3291,7 +3301,7 @@ printResolutionErrorUnresolved(
   }
   if( developer ) {
     // Should this be controlled another way?
-    USR_FATAL_CONT(call, "unresolved call had id %i", call->id);
+    USR_PRINT(call, "unresolved call had id %i", call->id);
   }
   USR_STOP();
 }

--- a/test/functions/vass/report-unresolved-case.chpl
+++ b/test/functions/vass/report-unresolved-case.chpl
@@ -1,0 +1,3 @@
+
+for idx in 5.these(iterKind.standalone) do
+  writeln(idx);

--- a/test/functions/vass/report-unresolved-case.good
+++ b/test/functions/vass/report-unresolved-case.good
@@ -1,0 +1,1 @@
+report-unresolved-case.chpl:2: error: unresolved call 'int(64).these(iterKind)'

--- a/test/functions/vass/report-unresolved-case.prediff
+++ b/test/functions/vass/report-unresolved-case.prediff
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+grep -v ': note: ' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
It used to be the case that printResolutionErrorUnresolved()
reached this code at the end of it:

  if( developer ) {
    // Should this be controlled another way?
    USR_FATAL_CONT(call, "unresolved call had id %i", call->id);
  }
  USR_STOP();

without actually issuing a USR_FATAL_CONT(), for example when
calling these() method with arguments.

If so, no "unresolved" error would be issued and
* with --devel, only ""unresolved call had id NNN" would be printed
* with --no-devel, printResolutionErrorUnresolved() would return
and resolveNormalCall() would hit INT_FATAL(call, "unable to resolve call").

This PR fixes that by tracking the cases not yet handled.
It would be eaiser to just check exit_eventually instead,
however unfortunately exit_eventually is static to misc.cpp.

While there, I replaced USR_FATAL_CONT(call, "unresolved call had id %i",...)
with USR_PRINT because this is an information statement
and having it cause an error is not/should not be necessary.

Testing passed:
linux64 full suite
gasnet - multilocale tests
