### PR TITLE
Miscellaneous QualifiedType improvements

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -625,8 +625,22 @@ void AstDump::writeSymbol(Symbol* sym, bool def) {
         case INTENT_OUT:       write("out arg");       break;
         case INTENT_CONST:     write("const arg");     break;
         case INTENT_CONST_IN:  write("const in arg");  break;
-        case INTENT_CONST_REF: write("const ref arg"); break;
-        case INTENT_REF:       write("ref arg");       break;
+        case INTENT_CONST_REF: {
+          if (arg->isWideRef()) {
+            write("const wide-ref arg");
+          } else {
+            write("const ref arg");
+          }
+          break;
+        }
+        case INTENT_REF: {
+          if (arg->isWideRef()) {
+            write("wide-ref arg");
+          } else {
+            write("ref arg");
+          }
+          break;
+        }
         case INTENT_PARAM:     write("param arg");     break;
         case INTENT_TYPE:      write("type arg");      break;
         case INTENT_BLANK:     write("arg");           break;

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -173,26 +173,13 @@ returnInfoCast(CallExpr* call) {
 static QualifiedType
 returnInfoVal(CallExpr* call) {
   AggregateType* ct = toAggregateType(call->get(1)->typeInfo());
-  if (ct) {
-    if (call->get(1)->isRef()) {
-      if(ct->symbol->hasFlag(FLAG_REF)) {
-        return QualifiedType(ct->getField(1)->type, QUAL_VAL);
-      } else {
-        return QualifiedType(ct, QUAL_VAL);
-      }
-    } else if (call->get(1)->isWideRef()) {
-      if(ct->symbol->hasFlag(FLAG_WIDE_REF)) {
-        return QualifiedType(ct->getField(2)->type, QUAL_VAL);
-      } else {
-        return QualifiedType(ct, QUAL_VAL);
-      }
-    } else if (ct->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-      // insertWideReferences will sometimes insert a PRIM_DEREF to a
-      // wide class. There should probably be a better way of expressing the
-      // desired pattern...
-      return QualifiedType(ct, QUAL_VAL);
-    }
+
+  if (call->get(1)->isRefOrWideRef()) {
+    return QualifiedType(call->get(1)->getValType(), QUAL_VAL);
+  } else if (ct && ct->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+    return QualifiedType(ct, QUAL_VAL);
   }
+
   INT_FATAL(call, "attempt to get value type of non-reference type");
   return QualifiedType(NULL);
 }

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -1257,8 +1257,7 @@ GenRet codegenValue(GenRet r)
   return ret;
 }
 
-// Create a temporary
-// value holding r and return a pointer to it.
+// Create a temporary value holding r and return a pointer to it.
 // If r is already a pointer, do nothing.
 // Does not handle homogeneous tuples.
 // Does not handle wide pointers.
@@ -3163,7 +3162,7 @@ GenRet CallExpr::codegen() {
       if (fn->hasFlag(FLAG_EXTERN)) {
         if (actual->isWideRef() == true ||
             arg.isLVPtr         == GEN_WIDE_PTR) {
-          arg = codegenRaddr(codegenValue(arg));
+          arg = codegenValue(arg);
 
         } else if (isRefExternStarTuple(formal, actual) == true) {
           // In C, a fixed-size-array lvalue is already a pointer,
@@ -3173,8 +3172,11 @@ GenRet CallExpr::codegen() {
             arg = codegenDeref(arg);
         }
       }
+
+      // TODO: What if the actual is a wide-ref and the formal is a narrow ref?
+      // Should that be handled back in IWR?
       if (arg.chplType->symbol->isRefOrWideRef() && !formal->isRefOrWideRef()) {
-        arg = codegenDeref(arg);
+        arg = codegenValue(codegenDeref(arg));
       }
 
       args[i] = arg;

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -165,6 +165,11 @@ public:
   {
   }
 
+  QualifiedType(Qualifier qual, Type* type)
+    : _type(type), _qual(qual)
+  {
+  }
+
   QualifiedType(Type* type, Qualifier qual)
     : _type(type), _qual(qual)
   {
@@ -192,6 +197,13 @@ public:
   bool isRefType() const;
   bool isWideRefType() const;
 
+  QualifiedType toRef() {
+    return QualifiedType(QUAL_REF, _type->getValType());
+  }
+
+  QualifiedType toVal() {
+    return QualifiedType(QUAL_VAL, _type->getValType());
+  }
 
   Type* type() const {
     return _type;

--- a/compiler/passes/addInitGuards.cpp
+++ b/compiler/passes/addInitGuards.cpp
@@ -216,9 +216,7 @@ static void addPrintModInitOrder(FnSymbol* fn)
 
   // += and -+ take ref args, so we must first get a reference to the
   // indent level variable
-  Type* refIndentLevelType = gModuleInitIndentLevel->typeInfo()->refType;
-  INT_ASSERT(refIndentLevelType);
-  VarSymbol* refIndentLevel = newTemp("refIndentLevel",refIndentLevelType);
+  VarSymbol* refIndentLevel = newTemp("refIndentLevel",gModuleInitIndentLevel->qualType().toRef());
   CallExpr *getAddr = new CallExpr(PRIM_MOVE,
                                    new SymExpr(refIndentLevel),
                                    new CallExpr(PRIM_ADDR_OF,

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -97,7 +97,11 @@ IntentTag blankIntentForType(Type* t) {
 
 IntentTag concreteIntent(IntentTag existingIntent, Type* t) {
   if (existingIntent == INTENT_BLANK) {
-    return blankIntentForType(t);
+    if (t->symbol->hasFlag(FLAG_REF)) {
+      return INTENT_REF;
+    } else {
+      return blankIntentForType(t);
+    }
   } else if (existingIntent == INTENT_CONST) {
     return constIntentForType(t);
   } else {
@@ -108,7 +112,7 @@ IntentTag concreteIntent(IntentTag existingIntent, Type* t) {
 static IntentTag blankIntentForThisArg(Type* t) {
   // todo: be honest when 't' is an array or domain
 
-  if (isRecord(t) || isUnion(t))
+  if (isRecord(t) || isUnion(t) || t->symbol->hasFlag(FLAG_REF))
     return INTENT_REF;
   else
     return INTENT_CONST_IN;

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -98,6 +98,12 @@ IntentTag blankIntentForType(Type* t) {
 IntentTag concreteIntent(IntentTag existingIntent, Type* t) {
   if (existingIntent == INTENT_BLANK) {
     if (t->symbol->hasFlag(FLAG_REF)) {
+      // A formal with a ref type should always have the ref-intent. No other
+      // intent makes sense. This is will hopefully be a short-lived fix
+      // while converting entirely over to QualifiedType.
+      //
+      // TODO: Are there cases where we should handle const-ref intent? Should
+      // a QualifiedType be used instead of a Type* ?
       return INTENT_REF;
     } else {
       return blankIntentForType(t);

--- a/compiler/passes/returnStarTuplesByRefArgs.cpp
+++ b/compiler/passes/returnStarTuplesByRefArgs.cpp
@@ -49,7 +49,7 @@ void returnStarTuplesByRefArgs() {
       //
       // Is it redundant to make this both have ref intent and ref type?
       //
-      ArgSymbol* arg = new ArgSymbol(INTENT_REF, "_ret", ret->type->refType);
+      ArgSymbol* arg = new ArgSymbol(INTENT_REF, "_ret", ret->getValType());
       fn->insertFormalAtTail(arg);
       fn->retType = dtVoid;
       fn->insertBeforeReturnAfterLabel(new CallExpr(PRIM_MOVE, arg, ret));

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -229,9 +229,8 @@ ArgSymbol* ReturnByRef::addFormal(FnSymbol* fn)
 
   Type*          type    = fn->retType;
   AggregateType* refType = type->refType;
-  IntentTag      intent  = blankIntentForType(refType);
   // Note: other code does strcmps against the name _retArg
-  ArgSymbol*     formal  = new ArgSymbol(intent, "_retArg", refType);
+  ArgSymbol*     formal  = new ArgSymbol(INTENT_REF, "_retArg", refType);
   formal->addFlag(FLAG_RETARG);
 
   fn->insertFormalAtTail(formal);
@@ -669,7 +668,7 @@ createClonedFnWithRetArg(FnSymbol* fn, FnSymbol* useFn)
   SET_LINENO(fn);
   FnSymbol* newFn = fn->copy();
   // Note: other code does strcmps against the name _retArg
-  ArgSymbol* arg = new ArgSymbol(blankIntentForType(useFn->retType->refType), "_retArg", useFn->retType->refType);
+  ArgSymbol* arg = new ArgSymbol(INTENT_REF, "_retArg", useFn->retType->refType);
   arg->addFlag(FLAG_RETARG);
   newFn->insertFormalAtTail(arg);
   newFn->addFlag(FLAG_FN_RETARG);


### PR DESCRIPTION
- Improve AstDump::writeSymbol to display wide-ref qualifier
- Simplify returnInfoVal
- Correct some usage of codegenValue
- Add constructor: QualifiedType(Qualifier, Type*)
- Add methods toRef and toVal on QualifiedTypes
- Fix def/use bug in parallel.cpp when trying to insert broadcasts
- The 'concreteIntent' function should return INTENT_REF if the given
  type has FLAG_REF
- Use INTENT_REF in ReturnByRef::addFormal when creating a _retArg
- insertLocalsForRefs should look for a single PRIM_MOVE

Testing:
- [x] full local, no-local
- [x] full gasnet
- [x] llvm/llvm-no-local on examples/