### PR TITLE
remove unused fns from FnSymbol

### DIFF
--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -458,9 +458,6 @@ public:
   void                       insertAtTail(Expr* ast);
   void                       insertAtTail(const char* format, ...);
 
-  void                       insertBeforeReturn(Expr* ast);
-  void                       insertBeforeReturnAfterLabel(Expr* ast);
-
   void                       insertFormalAtHead(BaseAST* ast);
   void                       insertFormalAtTail(BaseAST* ast);
 


### PR DESCRIPTION
Addendum to #5160, thanks to @mppf for catching it.