### PR TITLE
Remove unnecessary argument from _bulkGrow

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -367,7 +367,11 @@ module ChapelDistribution {
       }
     }
 
-    inline proc _bulkGrow(size: int) {
+    // This method assumes nnz is updated according to the size
+    // requested. So, a bulk addition into a sparse domain should: (1)
+    // calculate new nnz and update it, (2) call this method, (3) add
+    // indices
+    inline proc _bulkGrow() {
       if (nnz > nnzDom.size) {
         const _newNNZDomSize = (exp2(log2(nnz)+1.0)):int;
 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -245,7 +245,7 @@ module DefaultSparse {
       nnz += actualAddCnt;
 
       //grow nnzDom if necessary
-      _bulkGrow(nnz);
+      _bulkGrow();
 
       //linearly fill the new colIdx from backwards
       var newIndIdx = indsDom.high; //index into new indices

--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -293,7 +293,7 @@ class CSRDom: BaseSparseDomImpl {
     nnz += actualAddCnt;
 
     //grow nnzDom if necessary
-    _bulkGrow(nnz);
+    _bulkGrow();
 
     //linearly fill the new colIdx from backwards
     var newIndIdx = indsDom.high; //index into new indices


### PR DESCRIPTION
This PR removes the unnecessary argument from `_bulkGrow` method in `BaseSparseDomImpl`.

Locally tested /test/users/engin/sparse_bulk* with std and std+GASNet configs.