### PR TITLE
First draft of deinit()

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2394,7 +2394,8 @@ buildFunctionSymbol(FnSymbol*   fn,
   fn->cname   = fn->name = astr(name);
   fn->thisTag = thisTag;
 
-  if (fn->name[0] == '~' && fn->name[1] != '\0')
+  if ((fn->name[0] == '~' && fn->name[1] != '\0') ||
+      (strcmp(fn->name, "deinit") == 0))
     fn->addFlag(FLAG_DESTRUCTOR);
 
   if (receiver)

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1439,12 +1439,12 @@ static void buildStringCastFunction(EnumType* et) {
 
 
 void buildDefaultDestructor(AggregateType* ct) {
-  if (function_exists("chpl__deinit", 2, dtMethodToken, ct))
+  if (function_exists("deinit", 2, dtMethodToken, ct))
     return;
 
   SET_LINENO(ct->symbol);
 
-  FnSymbol* fn = new FnSymbol("chpl__deinit");
+  FnSymbol* fn = new FnSymbol("deinit");
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_DESTRUCTOR);
   fn->addFlag(FLAG_INLINE);

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -200,7 +200,7 @@ static void change_cast_in_where(FnSymbol* fn) {
 static void add_parens_to_deinit_fns(FnSymbol* fn) {
   if (fn->hasFlag(FLAG_DESTRUCTOR))
     // Make paren-less decls act as paren-ful. Otherwise
-    // "arg.chpl__deinit()" in proc chpl__delete(arg)
+    // "arg.deinit()" in proc chpl__delete(arg)
     // would not resolve.
     fn->removeFlag(FLAG_NO_PARENS);
 }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -132,11 +132,12 @@ void normalize() {
         USR_FATAL(fn, "destructors must not have arguments");
       } else {
         DefExpr* thisDef = toDefExpr(fn->formals.get(2));
-        INT_ASSERT(fn->name[0] == '~' && thisDef);
+        INT_ASSERT(thisDef);
         AggregateType* ct = toAggregateType(thisDef->sym->type);
         // make sure the name of the destructor matches the name of the class
-        if (ct && strcmp(fn->name + 1, ct->symbol->name)) {
-          USR_FATAL(fn, "destructor name must match class name");
+        if (ct && (strcmp(fn->name + 1, ct->symbol->name) &&
+                   strcmp(fn->name, "deinit"))) {
+          USR_FATAL(fn, "destructor name must match class name or deinit()");
         } else {
           fn->name = astr("chpl__deinit");
         }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -128,7 +128,8 @@ void normalize() {
       if (fn->formals.length < 2
           || fn->getFormal(1)->typeInfo() != gMethodToken->typeInfo()) {
         USR_FATAL(fn, "destructors must be methods");
-      } else if (fn->formals.length > 2) {
+      } else if (fn->formals.length > 2 && fn->name[0] == '~') {
+        // TODO When we retire destructors, this test can go away
         USR_FATAL(fn, "destructors must not have arguments");
       } else {
         DefExpr* thisDef = toDefExpr(fn->formals.get(2));
@@ -139,7 +140,7 @@ void normalize() {
                    strcmp(fn->name, "deinit"))) {
           USR_FATAL(fn, "destructor name must match class name or deinit()");
         } else {
-          fn->name = astr("chpl__deinit");
+          fn->name = astr("deinit");
         }
       }
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8345,7 +8345,7 @@ resolveFns(FnSymbol* fn) {
           !ct->symbol->hasFlag(FLAG_REF) &&
           !isTupleContainingOnlyReferences(ct)) {
         VarSymbol* tmp = newTemp(ct);
-        CallExpr* call = new CallExpr("chpl__deinit", gMethodToken, tmp);
+        CallExpr* call = new CallExpr("deinit", gMethodToken, tmp);
 
         // In case resolveCall drops other stuff into the tree ahead of the
         // call, we wrap everything in a block for safe removal.

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -271,7 +271,7 @@ FnSymbol* makeDestructTuple(TypeSymbol* newTypeSymbol,
 {
   Type *newType = newTypeSymbol->type;
 
-  FnSymbol *dtor = new FnSymbol("chpl__deinit");
+  FnSymbol *dtor = new FnSymbol("deinit");
 
   dtor->cname = astr("chpl__auto_destroy_", newType->symbol->cname);
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1123,7 +1123,7 @@ module ChapelBase {
     if (isRecord(arg)) then
       compilerError("delete not allowed on records");
 
-    arg.chpl__deinit();
+    arg.deinit();
     on arg do
       chpl_here_free(__primitive("_wide_get_addr", arg));
   }

--- a/test/classes/deinitializers/callMyDeinit.chpl
+++ b/test/classes/deinitializers/callMyDeinit.chpl
@@ -1,0 +1,9 @@
+class C {
+  proc deinit() {
+    writeln("In my deinitializer!");
+  }
+}
+
+var myC = new C();
+myC.deinit();
+delete myC;

--- a/test/classes/deinitializers/callMyDeinit.good
+++ b/test/classes/deinitializers/callMyDeinit.good
@@ -1,0 +1,2 @@
+In my deinitializer!
+In my deinitializer!

--- a/test/classes/deinitializers/deinit.chpl
+++ b/test/classes/deinitializers/deinit.chpl
@@ -1,0 +1,8 @@
+class C {
+  proc deinit() {
+    writeln("In my deinitializer!");
+  }
+}
+
+var myC = new C();
+delete myC;

--- a/test/classes/deinitializers/deinit.good
+++ b/test/classes/deinitializers/deinit.good
@@ -1,0 +1,1 @@
+In my deinitializer!

--- a/test/classes/deinitializers/deinitAndDestruct.chpl
+++ b/test/classes/deinitializers/deinitAndDestruct.chpl
@@ -1,0 +1,12 @@
+class C {
+  proc ~C() {
+    writeln("In my destructor!");
+  }
+  
+  proc deinit() {
+    writeln("In my deinitializer!");
+  }
+}
+
+var myC = new C();
+delete myC;

--- a/test/classes/deinitializers/deinitAndDestruct.good
+++ b/test/classes/deinitializers/deinitAndDestruct.good
@@ -1,0 +1,3 @@
+deinitAndDestruct.chpl:11: error: ambiguous call 'C.chpl__deinit()'
+deinitAndDestruct.chpl:2: note: candidates are: C.~C()
+deinitAndDestruct.chpl:6: note:                 C.deinit()

--- a/test/classes/deinitializers/deinitAndDestruct.good
+++ b/test/classes/deinitializers/deinitAndDestruct.good
@@ -1,3 +1,3 @@
-deinitAndDestruct.chpl:11: error: ambiguous call 'C.chpl__deinit()'
+deinitAndDestruct.chpl:11: error: ambiguous call 'C.deinit()'
 deinitAndDestruct.chpl:2: note: candidates are: C.~C()
 deinitAndDestruct.chpl:6: note:                 C.deinit()

--- a/test/classes/deinitializers/deinitTakesArgs.chpl
+++ b/test/classes/deinitializers/deinitTakesArgs.chpl
@@ -1,0 +1,9 @@
+class C {
+  proc deinit(x=1) {
+    writeln("In my deinitializer, x is ", x, "!");
+  }
+}
+
+var myC = new C();
+myC.deinit(2);
+delete myC;

--- a/test/classes/deinitializers/deinitTakesArgs.good
+++ b/test/classes/deinitializers/deinitTakesArgs.good
@@ -1,0 +1,2 @@
+In my deinitializer, x is 2!
+In my deinitializer, x is 1!

--- a/test/classes/deinitializers/deinitTakesArgs2.chpl
+++ b/test/classes/deinitializers/deinitTakesArgs2.chpl
@@ -1,0 +1,14 @@
+class C {
+  proc deinit() {
+    writeln("In my deinitializer!");
+  }
+
+  proc deinit(x:int) {
+    writeln("In my deinitializer, x is ", x, "!");
+  }
+}
+
+var myC = new C();
+myC.deinit(2);
+myC.deinit();
+delete myC;

--- a/test/classes/deinitializers/deinitTakesArgs2.good
+++ b/test/classes/deinitializers/deinitTakesArgs2.good
@@ -1,0 +1,3 @@
+In my deinitializer, x is 2!
+In my deinitializer!
+In my deinitializer!

--- a/test/classes/deinitializers/noZeroArgDeinit.chpl
+++ b/test/classes/deinitializers/noZeroArgDeinit.chpl
@@ -1,0 +1,9 @@
+class C {
+  proc deinit(x: int) {
+    writeln("In deinit, x is: ", x, "!");
+  }
+}
+
+var myC = new C();
+myC.deinit(2);
+delete myC;

--- a/test/classes/deinitializers/noZeroArgDeinit.good
+++ b/test/classes/deinitializers/noZeroArgDeinit.good
@@ -1,0 +1,1 @@
+In deinit, x is: 2!

--- a/test/classes/diten/multipledestructor.chpl
+++ b/test/classes/diten/multipledestructor.chpl
@@ -1,7 +1,7 @@
 class C {
-  proc ~C() { writeln("In ~C #1"); }
+  proc deinit() { writeln("In deinit #1"); }
 }
-proc C.~C() { writeln("In ~C #2"); }
+proc C.deinit() { writeln("In deinit #2"); }
 
 proc main {
   var c = new C();

--- a/test/classes/diten/multipledestructor.good
+++ b/test/classes/diten/multipledestructor.good
@@ -1,3 +1,3 @@
-multipledestructor.chpl:7: error: ambiguous call 'C.chpl__deinit()'
-multipledestructor.chpl:2: note: candidates are: C.~C()
-multipledestructor.chpl:4: note:                 C.~C()
+multipledestructor.chpl:7: error: ambiguous call 'C.deinit()'
+multipledestructor.chpl:2: note: candidates are: C.deinit()
+multipledestructor.chpl:4: note:                 C.deinit()

--- a/test/classes/initializers/callUserDefaultInitializer.future
+++ b/test/classes/initializers/callUserDefaultInitializer.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/error-destructor-return-type.future
+++ b/test/classes/initializers/error-destructor-return-type.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/error-destructor-return-type.good
+++ b/test/classes/initializers/error-destructor-return-type.good
@@ -1,1 +1,1 @@
-error-destructor-return-type.chpl:2: error: destructors may not declare a return type
+error-destructor-return-type.chpl:4: error: destructors may not declare a return type


### PR DESCRIPTION
This patch is a first draft of adding deinit() to the compiler as the next-generation alternative to destructors.  In this patch, either destructors or deinit can be used.  The main difference between the two is that deinit() can be called by a user and can optionally take arguments (as long as there is still a zero-argument version available).  The rationale for these differences is that users sometimes wish to call destructors/deinitializers on their types in order to free up resources without freeing up the object (via delete or letting it go out of scope).  Of course, a well-written class/record would support multiple such calls without causing problems.

I undertook this mod after realizing that we'd failed to sign up anyone to own it in the 1.15 planning, and after being assured that it shouldn't be hard.  To the extent that my attempt is correct-ish, it wasn't -- a 30-minute fix (TM).  I essentially:

* had the parser flag functions named deinit() as it did functions starting with ~
* loosened some requirements on deinit() to permit what I believe the expected semantics should be
* renamed chpl__deinit() to deinit()

Here I file tests that
* define deinit() and have it be called by delete
* show what happens if you define both deinit() and a destructor (ambiguity)
* called deinit()
* called a version of deinit() that takes an optional argument
* show that deinit() can be overloaded, that the compiler will call the right one, and that the user can call either
* retired some futures that anticipated deinit()
* updated another test whose output would've had to change to not name chpl__deinit() to use deinit() instead

Note that so far I've done nothing to test deinit() on records which may present additional challenges (or perhaps simply extraneous calls to deinit()?)