### PR TITLE
Add annotations for this week

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -499,6 +499,10 @@ jacobi:
     - Allow casts between c_void_ptr and object types (#4802)
   11/10/16:
     - Make each Symbol keep a list of SymExprs (#4827)
+  01/07/17:
+    - add param versions of min/max for ints (#5073)
+  01/13/17:
+    - refactoring of rectangular IO (#5157)
 
 knucleotide:
   10/16/15:
@@ -537,6 +541,10 @@ mandelbrot:
     - Start using C99 functions for operations such as abs() on complex numbers (#4098)
   07/08/16:
     - Added compiler option --no-ieee-float to mandelbrot-complex (#4134)
+  01/15/17:
+    - Implement a Swift-like version of mandelbrot (#5168)
+  01/19/17:
+    - Mandelbrot tweaks (#5188)
 
 mandelbrot-extras:
   01/03/14:
@@ -577,6 +585,12 @@ memleaks:
     - Sync as record (#4309)
   08/17/16:
     - Single as record (#4350)
+  01/05/17:
+    - Maybe "adding support for params without initializers"(#5075)?
+  01/07/17:
+    - new test verifying the user's guide type aliases section (#5075)
+  01/17/17:
+    - new test of Sparse domain block clear functionality (#5173)
 
 memleaksfull:
   07/08/14:
@@ -764,6 +778,10 @@ stream:
 taskSpawn:
   07/24/16:
     - Stopped performing remote value forwarding on task functions (#4240)
+
+temporary-copies:
+  01/14/17:
+    - Likely cache effects
 
 testSerialReductions:
   08/16/14:


### PR DESCRIPTION
Covers AST size changes, improvements to the mandelbrot benchmark, and the
addition of new tests which contain unsurprising memory leaks, as well as a
note on what is likely due to cache effects

Verified that -generate-graphs works as expected, and that an intentional error
in the ANNOTATIONS file led to an expected failure (to ensure I would detect if
something went wrong)