### PR TITLE
Generate an error for domain queries in field

### DIFF
--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -55,7 +55,7 @@ checkParsed() {
   }
 
   forv_Vec(DefExpr, def, gDefExprs) {
-    if (toVarSymbol(def->sym))
+    if (toVarSymbol(def->sym)) {
       // The test for FLAG_TEMP allows compiler-generated (temporary) variables
       // to be declared without an explicit type or initializer expression.
       if ((!def->init || def->init->isNoInitExpr())
@@ -66,6 +66,25 @@ checkParsed() {
               USR_FATAL_CONT(def->sym,
                              "Variable '%s' is not initialized or has no type",
                              def->sym->name);
+    }
+
+    //
+    // This test checks to see if query domains (e.g., '[?D]') are
+    // used in places other than formal argument type specifiers.
+    //
+    if (!toFnSymbol(def->parentSymbol)) {
+      if (CallExpr* type = toCallExpr(def->exprType)) {
+        if (type->isNamed("chpl__buildArrayRuntimeType")) {
+          if (CallExpr* domainExpr = toCallExpr(type->get(1))) {
+            DefExpr* queryDomain = toDefExpr(domainExpr->get(1));
+            if (queryDomain) {
+              USR_FATAL_CONT(queryDomain,
+                             "Domain query expressions may currently only be used in formal argument types");
+            }
+          }
+        }
+      }
+    }
 
     checkPrivateDecls(def);
   }

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -72,7 +72,7 @@ checkParsed() {
     // This test checks to see if query domains (e.g., '[?D]') are
     // used in places other than formal argument type specifiers.
     //
-    if (!toFnSymbol(def->parentSymbol)) {
+    if (!isFnSymbol(def->parentSymbol)) {
       if (CallExpr* type = toCallExpr(def->exprType)) {
         if (type->isNamed("chpl__buildArrayRuntimeType")) {
           if (CallExpr* domainExpr = toCallExpr(type->get(1))) {

--- a/test/classes/generic/domainQueryField.bad
+++ b/test/classes/generic/domainQueryField.bad
@@ -1,8 +1,0 @@
-domainQueryField.chpl:2: internal error: CAL0057 chpl Version 1.14.0.117304e
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/classes/generic/domainQueryField.future
+++ b/test/classes/generic/domainQueryField.future
@@ -1,9 +1,0 @@
-bug: domain query fields cause internal errors
-
-When using the domain query syntax in an array field, the compiler
-currently generates an internal error.  I don't believe that we ever
-intended to support domain queries in the field context, so this
-future is intended to change the internal error into a user-facing
-error (where the message in the .good file is negotiable).  A sibling
-future (domainQueryField-feature.chpl) asks the question whether we
-ought to support the syntax in this context.

--- a/test/classes/generic/domainQueryField.good
+++ b/test/classes/generic/domainQueryField.good
@@ -1,1 +1,1 @@
-domainQueryField2:2: domain queries are not currently supported in class members
+domainQueryField.chpl:2: error: Domain query expressions may currently only be used in formal argument types


### PR DESCRIPTION
This PR fixes #5140 in which a user reported that the use of domain queries in array field types resulted in an internal error.  This is something we've never intended to support, but have not generated a good error message for either.  Issue #5141 asks whether it's something we might want to support down the line.

The approach taken here is to add a check to the checkParsed pass that looks for DefExprs whose types are arrays and whose queries themselves contain a DefExpr.  I borrowed this logic from normalize.cpp which processes such domain queries when they do occur in formal argument types.