### PR TITLE
Fix problems with extern blocks, extern types

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1078,14 +1078,20 @@ static void build_record_copy_function(AggregateType* ct) {
 
   fn->insertFormalAtTail(arg);
 
-  CallExpr* call = NULL;
+  Expr* toReturn = NULL;
 
   if (foundUserDefinedCopy) {
-    call = new CallExpr(PRIM_NEW, ct->symbol, new SymExpr(arg));
+    toReturn = new CallExpr(PRIM_NEW, ct->symbol, new SymExpr(arg));
     // If it has a user-defined copy initializer, it's not POD
     ct->symbol->addFlag(FLAG_NOT_POD);
+  } else if (ct->symbol->hasFlag(FLAG_EXTERN)) {
+    // Extern records/classes should only get trivial initCopy fns
+    // (at least if no other init method was defined).
+    toReturn = new SymExpr(arg);
   } else {
+    CallExpr* call = NULL;
     // generate the default copy initializer in chpl__initCopy for now
+    // which is currently implemented to call the compiler-generated initializer
 
     // MPF 2016-11-03: It would be better to move all of the logic below
     // into the construction of a compiler-generated initializer. However,
@@ -1150,9 +1156,10 @@ static void build_record_copy_function(AggregateType* ct) {
 
       call->insertAtTail(new NamedExpr("meme", new SymExpr(meme)));
     }
+    toReturn = call;
   }
 
-  fn->insertAtTail(new CallExpr(PRIM_RETURN, call));
+  fn->insertAtTail(new CallExpr(PRIM_RETURN, toReturn));
 
   DefExpr* def = new DefExpr(fn);
 

--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -218,16 +218,17 @@ static const char* convertTypedef(ModuleSymbol* module, clang::TypedefNameDecl *
 
   //If we've already converted this, return immediately to
   //  avoid multiple Chapel definitions.
-  if( alreadyConvertedExtern(module, typedef_name) ) return typedef_name;
+  if( alreadyConvertedExtern(module, typedef_name) )
+    return typedef_name;
 
   if( contents_type->isStructureType() ) {
     clang::RecordDecl *rd = contents_type->getAsStructureType()->getDecl();
-    const char* struct_name = rd->getNameAsString().c_str();
+    const char* struct_name = astr(rd->getNameAsString().c_str());
     // We already make 'struct some_structure { .. }' create a
     // Chapel type for 'some_structure'. So if this is a typedef
     // creating an alias for 'struct some_structure' == 'some_structure',
     // just return the result of adding the structure.
-    if( 0 == strcmp(typedef_name, struct_name) ) {
+    if( typedef_name == struct_name ) {
       convertToChplType(module, contents_type, results);
       do_typedef = false;
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -700,8 +700,7 @@ resolveAutoCopyEtc(Type* type) {
         !type->symbol->hasFlag(FLAG_TUPLE) &&
         !isRecordWrappedType(type) &&
         !isSyncType(type) &
-        !isSingleType(type) &&
-        !type->symbol->hasFlag(FLAG_EXTERN)) {
+        !isSingleType(type)) {
       // Just use 'chpl__initCopy' instead of 'chpl__autoCopy'
       // for user-defined records. This way, if the type does not
       // support copying, the autoCopyMap will store a function

--- a/modules/minimal/internal/ChapelUtil.chpl
+++ b/modules/minimal/internal/ChapelUtil.chpl
@@ -28,7 +28,7 @@ module ChapelUtil {
   }
 
   // required by resolveAutoCopies()
-  proc chpl__autoCopy(arg: chpl_main_argument) return arg;
+  proc chpl__initCopy(arg: chpl_main_argument) return arg;
   proc chpl__autoDestroy(arg: chpl_main_argument) {}
   
 


### PR DESCRIPTION
This is a bug-fix PR - fixes #5166.

* Fixes a bug with .c_str() in externCResolve.cpp 
* Fixes an issue where, in a PRIM_MOVE between type variables, a RHS that is a type alias to an extern type might not be resolved yet.
* Don't try to call `init` on extern types in the generated `initCopy`. Instead, generate a trivial `initCopy` for extern types.

This gets test/users/npadmana/gsl_demonstration/gsl_demo.chpl working for me on an Ubuntu 16 system.

Passed test/extern/ferguson/ test/extern/jjueckstock/ test/release/examples/primers/ test/users/npadmana/ with and without --llvm in a compiler built with CHPL_LLVM=llvm.
Passed full local testing with CHPL_LLVM=none.

Reviewed by @vasslitvinov - thanks!