### PR TITLE
Add future field to template file

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,3 @@
-## Bug Report
 <!--
 If you are filing an issue that is not a bug report, please feel free to erase
 this template and describe the issue as clearly as possible.
@@ -28,7 +27,7 @@ What behavior did you expect to observe?
 <!-- e.g. `chpl foo.chpl -o foo` -->
 
 **Execution command:**
-<!-- e.g. `./foo 42`. If an input file is required, include it as well. -->
+<!-- e.g. `./foo -nl 4`. If an input file is required, include it as well. -->
 
 **Associated Future Test(s):**
 <!-- Are there any tests in Chapel's test system that demonstrate this issue?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,6 +30,9 @@ What behavior did you expect to observe?
 **Execution command:**
 <!-- e.g. `./foo 42`. If an input file is required, include it as well. -->
 
+**Associated Future Test(s):**
+<!-- Are there any tests in Chapel's test system that demonstrate this issue?
+     e.g. test/path/to/foo.future #1234 -->
 
 ### Configuration Information
 


### PR DESCRIPTION
Add optional `Associated Future Test(s)` field to template to include path and PR # for a test demonstrating a bug.

Also in these changes:
- Remove `# Bug Report` header (can be confused for `## Summary of Problem` field)
- Make execution example more examplary, using numlocales arg: `./foo -nl 4`   