### PR TITLE
Test performance of having qthreads use Chapel's allocator

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -9,11 +9,11 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
-# Test performance of limiting tls usage in task spawn
+# Test performance of having qthreads use chapel's allocator
 GITHUB_USER=ronawho
-GITHUB_BRANCH=avoid-tls-in-task-spawn
-SHORT_NAME=avoidTLS
-START_DATE=01/10/17
+GITHUB_BRANCH=use-chpl-alloc-for-qt
+SHORT_NAME=qtChplAlloc
+START_DATE=01/20/17
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
Test performance of having qthreads use Chapel's allocator

In other words, test the performance of having qthreads use jemalloc as its
allocator. qthreads uses memory pools for a lot of "hot" data-structures so I
don't expect a huge win for single-locale but we'll see what the perf
playground results are like.

For multi-locale, using our allocator means that task-stacks will be in the
registered heap so we won't need to trampoline, which can have significant
performance implications. With this ugni-qthreads now seems to be on par or
beating all the benchmarks where it was previously losing to ugni-muxed!

  | Benchmark | Old Perf     | New Perf     | vs. ugni-muxed |
  | --------- | ------------ | ------------ | -------------- |
  | MiniMD    | 60 sec       | 35 sec       | 20% faster     |
  | HPCC HPL  | 260 GFlops   | 325 GFlops   | 10% faster     |
  | HPL rel   | .0014 GFlops | .0017 GFlops |  2% slower     |
  | fft       | .035 GFlops  | .090 GFlops  | 50% faster     |

fft is a little sporadic and varies between .03 and .1GFlops. Increasing
QT_SPINCOUNT to 3000000 seems to stabilize timings to .09 GFlops.