### PR TITLE
chplspell: support new options for scspell 2.1

### DIFF
--- a/util/chplspell
+++ b/util/chplspell
@@ -138,10 +138,20 @@ while true; do
 
 	# Pass-through args with two parameters.  Pass via $ARGS to preserve
 	# ordering and not attempt directory expansion
-	--merge-file-ids|--rename-file)
+	--copy-file|--merge-file-ids|--rename-file)
 	    ARGS+=("$1" "$2" "$3")
 	    shift 3
 	    JUSTARGS=1
+	    ;;
+	--add-to-dict)
+	    # --add-to-dict takes 2 or 3 args
+	    ARGS+=("$1" "$2" "$3")
+	    shift 3
+	    JUSTARGS=1
+	    if [ -n "$1" ]; then
+		ARGS+=("$1")
+		shift
+	    fi
 	    ;;
 	--delete-files)
 	    DELETE_INVOKED=1


### PR DESCRIPTION
scpell 2.1 adds two new commandline options:

--copy-file and --add-to-dict.  Add these to the options chplspell
knows how not to interfere with.