### PR TITLE
Auto-detect GSL in gsl_demonstration SKIPIF

### DIFF
--- a/test/modules/packages/ZMQ/SKIPIF
+++ b/test/modules/packages/ZMQ/SKIPIF
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 
+# The ZMQ package requires the zmq library.
+# Additionally, this testing is disabled currently for multi-locale runs.
+#
+# Installation of the ZMQ library is detected with the find_library function,
+# which looks for the appropriate dynamic library (e.g. libzmq.so).
+# Note that if the dynamic library is found, this test assumes that the
+# header and static library are available.
+
 from __future__ import print_function
 from ctypes.util import find_library
 from os import environ

--- a/test/users/npadmana/gsl_demonstration/README
+++ b/test/users/npadmana/gsl_demonstration/README
@@ -1,6 +1,15 @@
 A simple demonstration of accessing the GSL routines using
 the extern block functionality of Chapel.
 
-Requires GSL_DIR to be set, such that $GSL_DIR/include and
+This test requires:
+  * CHPL_LLVM!=none (since the test uses extern blocks)
+and a GSL installation detected like so:
+  * GSL_DIR environment variable is set, OR
+  * GSL dynamic library is detected
+
+Note that if the dynamic library is found, this
+test assumes that the header and static library are available.
+
+GSL_DIR can be set, such that $GSL_DIR/include and
 $GSL_DIR/lib point to the location of the headers and libraries.
 

--- a/test/users/npadmana/gsl_demonstration/SKIPIF
+++ b/test/users/npadmana/gsl_demonstration/SKIPIF
@@ -1,8 +1,25 @@
 #!/usr/bin/env python
 
 #
-# skip this test when FFTW_DIR is not set
+# This test requires:
+#  * CHPL_LLVM!=none (since the test uses extern blocks)
+# and a GSL installation detected like so:
+#  * GSL_DIR environment variable is set, OR
+#  * GSL dynamic library is detected
 #
+# Note that if the dynamic library is found, this
+# test assumes that the header and static library are available.
 
-import os
-print('GSL_DIR' not in os.environ)
+from __future__ import print_function
+from ctypes.util import find_library
+from os import environ
+
+if environ['CHPL_LLVM'] == 'none':
+  print (True) # Skip if we don't have extern block support
+else:
+  # OK, we have extern block support.
+  if 'GSL_DIR' in environ:
+    print (False) # Don't skip if GSL_DIR is set
+  else:
+    # Don't skip if a GSL library is installed
+    print (find_library('gsl') is None)


### PR DESCRIPTION
For now, this just follows the pattern from the ZMQ SKIPIF which is to use Python's ctypes find_library. That finds the .so file which isn't quite what we need but is a good start.

For now, I think it's a reasonable target that all of our nightly testing systems either:
 - have ZMQ/GSL .so .a and .h files available, OR
 - do not have ZMQ/GSL .so installed

Doing a better job at this is something we absolutely ought to do but it's not clear to me how to do it easily and correctly. (One idea is to use pkg-config but I don't know to what extent we can rely on that being installed. We could also try to find .a files and .h in common places).

This should be merged after PR #5205.
That's a first step towards getting gsl_demonstration tested nightly. The next step is to enable some testing that includes test/users/npadmana/ and sets CHPL_LLVM=llvm (but doesn't necessarily use --llvm).

Tested on chapcs11. Ran CHPL_LLVM=llvm full testing there with this and #5202 using the C backend. Didn't see any new failures.

Reviewed by @awallace-cray - thanks!