### PR TITLE
Fixing a .bad that changed due to better domain query field errors

### DIFF
--- a/test/classes/generic/domainQueryField-feature.bad
+++ b/test/classes/generic/domainQueryField-feature.bad
@@ -1,8 +1,1 @@
-domainQueryField-feature.chpl:2: internal error: CAL0057 chpl Version 1.14.0.117304e
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+domainQueryField-feature.chpl:2: error: Domain query expressions may currently only be used in formal argument types


### PR DESCRIPTION
This was a completely naive oversight on my part.  When I added the
error message for this test, I should've realized that the .bad for
this .future would need to be updated...