### PR TITLE
More parallelism for BlockCyclic iteration

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -506,7 +506,8 @@ iter BlockCyclicDom.these(param tag: iterKind) where tag == iterKind.leader {
         const dim    = whole.dim(j);
         const dimLow = dim.low;
 
-        var temp = max(lo, dimLow)..
+        var temp : range(idxType, stridable=stridable);
+        temp = max(lo, dimLow)..
                    min(lo + dist.blocksize(j)-1, dim.high);
         temp     = dim[temp];
         temp     = temp.chpl__unTranslate(dimLow);

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -90,9 +90,6 @@ It has not been tuned for performance.
 
 The only ``idxType`` currently supported is `int` or `int(64)`.
 
-A `forall` loop over a Cyclic-distributed domain or array
-currently executes at most a single task on each locale.
-
 
 **Example**
 
@@ -177,8 +174,8 @@ They must match the rank and index type of the domains
 
 A `forall` loop over a Cyclic-distributed domain or array
 executes each iteration on the locale where that iteration's index
-is mapped to. Currently all iterations on a given locale
-execute within a single task.
+is mapped to.
+
 */
 class BlockCyclic : BaseDist {
   param rank: int;

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -37,7 +37,7 @@ use DSIUtil;
 //
 // Limitations
 //
-// 1. Changes to Block.tasksPerLocale are not made in privatized
+// 1. Changes to Block.dataParTasksPerLocale are not made in privatized
 //    copies of this distribution.
 //
 
@@ -142,9 +142,9 @@ The ``BlockCyclic`` class constructor is defined as follows:
       startIdx,
       blocksize,
       targetLocales: [] locale = Locales, 
-      tasksPerLocale = 0,
-      param rank: int  = // inferred from startIdx argument,
-      type idxType     = // inferred from startIdx argument )
+      dataParTasksPerLocale    = // value of dataParTasksPerLocale config const
+      param rank: int          = // inferred from startIdx argument,
+      type idxType             = // inferred from startIdx argument )
 
 The argument ``startIdx`` is a tuple of integers defining an index
 that will be distributed to the first locale in ``targetLocales``.
@@ -164,8 +164,8 @@ reshape the array of target locales so that it matches the rank of the
 distribution and each dimension contains an approximately equal number
 of indices.
 
-The argument ``tasksPerLocale`` is currently unused.
-If specified explicitly, it must be either ``0`` or ``1``.
+The argument ``dataParTasksPerLocale`` determines the maximum number
+of tasks on each Locale for data parallelism.
 
 The ``rank`` and ``idxType`` arguments are inferred from the
 ``startIdx`` argument unless explicitly set.
@@ -190,14 +190,14 @@ class BlockCyclic : BaseDist {
   const targetLocales: [targetLocDom] locale;
   const locDist: [targetLocDom] LocBlockCyclic(rank, idxType);
 
-  var tasksPerLocale: int; // tasks per locale for forall iteration
+  var dataParTasksPerLocale: int; // tasks per locale for forall iteration
 
   proc BlockCyclic(startIdx,  // ?nd*?idxType
                    blocksize,     // nd*int
                    targetLocales: [] locale = Locales, 
-                   tasksPerLocale = 0,
-                   param rank: int = _determineRankFromArg(startIdx),
-                   type idxType = _determineIdxTypeFromArg(startIdx))
+                   dataParTasksPerLocale    = getDataParTasksPerLocale(),
+                   param rank: int          = _determineRankFromArg(startIdx),
+                   type idxType             = _determineIdxTypeFromArg(startIdx))
   {
     // argument sanity checks, with friendly error messages
     if isTuple(startIdx) != isTuple(blocksize) then compilerError("when invoking BlockCyclic constructor, startIdx and blocksize must be either both tuples or both integers");
@@ -246,10 +246,10 @@ class BlockCyclic : BaseDist {
       on this.targetLocales(locid) do
         locDist(locid) = new LocBlockCyclic(rank, idxType, locid, this);
 
-    if tasksPerLocale == 0 then
-      this.tasksPerLocale = 1;   // TODO: here.maxTaskPar;
+    if dataParTasksPerLocale == 0 then
+      this.dataParTasksPerLocale = here.maxTaskPar;
     else
-      this.tasksPerLocale = tasksPerLocale;
+      this.dataParTasksPerLocale = dataParTasksPerLocale;
 
     if debugBlockCyclicDist then
       for loc in locDist do writeln(loc);
@@ -262,11 +262,11 @@ class BlockCyclic : BaseDist {
     targetLocDom = other.targetLocDom;
     targetLocales = other.targetLocales;
     locDist = other.locDist;
-    tasksPerLocale = other.tasksPerLocale;
+    dataParTasksPerLocale = other.dataParTasksPerLocale;
   }
 
   proc dsiClone() {
-    return new BlockCyclic(lowIdx, blocksize, targetLocales, tasksPerLocale);
+    return new BlockCyclic(lowIdx, blocksize, targetLocales, dataParTasksPerLocale);
   }
 
   proc dsiDestroyDist() {
@@ -497,42 +497,26 @@ iter BlockCyclicDom.these() {
 }
 
 iter BlockCyclicDom.these(param tag: iterKind) where tag == iterKind.leader {
-  const precomputedNumTasks = dist.tasksPerLocale;
-  const precomputedWholeLow = whole.low;
-  if (precomputedNumTasks != 1) then
-    halt("Can't use more than one task per locale with Block-Cyclic currently");
+  const maxTasks      = dist.dataParTasksPerLocale;
+  const ignoreRunning = getDataParIgnoreRunningTasks();
+  const minSize       = getDataParMinGranularity();
   coforall locDom in locDoms do on locDom {
-      var tmpblock:rank*range(idxType, stridable=stridable);
-    for i in locDom.myStarts {
-      //      writeln("[", here.id, "] starting at ", i);
-      for param j in 1..rank {
-        // TODO: support a tuple-oriented iteration of vectors to avoid this?
-        var lo: idxType;
-        if rank == 1 then
-          lo = i;
-        else
-          lo = i(j);
-        tmpblock(j) = max(lo, whole.dim(j).low)..
-                  min(lo + dist.blocksize(j)-1, whole.dim(j).high);
-        //        writeln("[", here.id, "] tmpblock(j) = ", tmpblock(j));
-        tmpblock(j) = whole.dim(j)[tmpblock(j)];
-        //        writeln("[", here.id, "] tmpblock(j) = ", tmpblock(j));
-        if rank == 1 then
-          lo = whole.low;
-        else
-          lo = whole.low(j);
-        //        writeln("lo = ", lo);
-        tmpblock(j) = tmpblock(j).chpl__unTranslate(lo);
-        //        writeln("[", here.id, "] tmpblock(j) = ", tmpblock(j));
-      }
-
+    forall i in locDom.myStarts._value.these(maxTasks,
+                                             ignoreRunning, minSize) {
       var retblock: rank*range(idxType);
-      for param i in 1..rank {
-        retblock(i) = (tmpblock(i).low / whole.dim(i).stride:idxType)..
-                        #tmpblock(i).length;
-          //        retblock(i) = (tmpblock(i) - whole.dim(i).low);
+      for param j in 1..rank {
+        const lo     = if rank == 1 then i else i(j);
+        const dim    = whole.dim(j);
+        const dimLow = dim.low;
+
+        var temp = max(lo, dimLow)..
+                   min(lo + dist.blocksize(j)-1, dim.high);
+        temp     = dim[temp];
+        temp     = temp.chpl__unTranslate(dimLow);
+
+        retblock(j) = (temp.low / dim.stride:idxType)..
+                      #temp.length;
       }
-      //      writeln(here.id, ": Domain leader yielding", retblock);
       yield retblock;
     }
   }
@@ -551,15 +535,17 @@ iter BlockCyclicDom.these(param tag: iterKind) where tag == iterKind.leader {
 // stencil communication will be done on a per-locale basis.
 //
 iter BlockCyclicDom.these(param tag: iterKind, followThis) where tag == iterKind.follower {
-  //  writeln(here.id, ": Domain follower following ", follower);
   var t: rank*range(idxType, stridable=stridable);
+
   for param i in 1..rank {
-    var stride = whole.dim(i).stride: idxType;
-    var low = stride * followThis(i).low;
-    var high = stride * followThis(i).high;
-    t(i) = ((low..high by stride:int) + whole.dim(i).low).safeCast(t(i).type);
+    const curFollow = followThis(i);
+    const dim       = whole.dim(i);
+    const stride    = dim.stride: idxType;
+    const low       = stride * curFollow.low;
+    const high      = stride * curFollow.high;
+    t(i) = ((low..high by stride:int) + dim.low).safeCast(t(i).type);
   }
-  //  writeln(here.id, ": Changed it into: ", t);
+
   for i in {(...t)} {
     yield i;
   }
@@ -870,38 +856,32 @@ iter BlockCyclicArr.these(param tag: iterKind) where tag == iterKind.leader {
 
 iter BlockCyclicArr.these(param tag: iterKind, followThis) ref where tag == iterKind.follower {
   var myFollowThis: rank*range(idxType=idxType, stridable=stridable);
-  var lowIdx: rank*idxType;
 
   for param i in 1..rank {
-    var stride = dom.whole.dim(i).stride;
-    var low = followThis(i).low * stride;
-    var high = followThis(i).high * stride;
-    myFollowThis(i) = ((low..high by stride) + dom.whole.dim(i).low).safeCast(myFollowThis(i).type);
-    lowIdx(i) = myFollowThis(i).low;
+    const curFollow = followThis(i);
+    const dim       = dom.whole.dim(i);
+    const stride    = dim.stride;
+    const low       = curFollow.low * stride;
+    const high      = curFollow.high * stride;
+    myFollowThis(i) = ((low..high by stride) + dim.low).safeCast(curFollow.type);
   }
+
   const myFollowThisDom = {(...myFollowThis)};
 
+  // TODO: Can we use the fast-follower optimization here at all? See BlockDist
+  // for a working examples.
   //
   // TODO: The following is a buggy hack that will only work when we're
   // distributing across the entire Locales array.  I still think the
   // locArr/locDoms arrays should be associative over locale values.
   //
-  const myLocArr = locArr(dom.dist.idxToLocaleInd(lowIdx));
+  // const myLocArr = locArr(dom.dist.idxToLocaleInd(lowIdx));
 
   //
   // we don't own all the elements we're following
   //
-  proc accessHelper(i) ref {
-//      if myLocArr.locale == here {
-//  local {
-//          if myLocArr.locDom.myStarts.member(i) then
-//            return myLocArr.this(i);
-//        }
-//      }
-    return dsiAccess(i);
-  }
   for i in myFollowThisDom {
-    yield accessHelper(i);
+    yield dsiAccess(i);
   }
 }
 


### PR DESCRIPTION
Prior to this change, BlockCyclic would only create one task per locale
when iterating over the domain (or array) in parallel. Iterating in
parallel over ``myStarts`` yields positive results for ptrans on
16-node-xc, and seems like a good starting point.

In support of this change, the ``tasksPerLocale`` argument to the
Blockcyclic constructor has been renamed to ``dataParTasksPerLocale`` to
match other distributions.

The parallel iterator bodies for BlockCyclicDom and BlockCyclicArr were
also cleaned up by:
- removing old commented-out debugging writelns
- caching common expressions to reduce verbosity

Testing:
- [x] full local
- [x] full gasnet