### PR TITLE
Param guard reads/writes of chpl_arrayInitMethod

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -605,10 +605,30 @@ module ChapelBase {
 
   enum ArrayInit {heuristicInit, noInit, serialInit, parallelInit};
   config param chpl_defaultArrayInitMethod = ArrayInit.heuristicInit;
-  var chpl_arrayInitMethod = chpl_defaultArrayInitMethod;
+
+  config param chpl_arrayInitMethodRuntimeSelectable = false;
+  private var chpl_arrayInitMethod = chpl_defaultArrayInitMethod;
+
+  inline proc chpl_setArrayInitMethod(initMethod: ArrayInit) {
+    if chpl_arrayInitMethodRuntimeSelectable == false {
+      compilerWarning("must set 'chpl_arrayInitMethodRuntimeSelectable' for ",
+                      "'chpl_setArrayInitMethod' to have any effect");
+    }
+    const oldInit = chpl_arrayInitMethod;
+    chpl_arrayInitMethod = initMethod;
+    return oldInit;
+  }
+
+  inline proc chpl_getArrayInitMethod() {
+    if chpl_arrayInitMethodRuntimeSelectable == false {
+      return chpl_defaultArrayInitMethod;
+    } else {
+      return chpl_arrayInitMethod;
+    }
+  }
 
   proc init_elts(x, s, type t) : void {
-    var initMethod = chpl_arrayInitMethod;
+    var initMethod = chpl_getArrayInitMethod();
 
     // for uints, check that s > 0, so the `s-1` below doesn't overflow
     if isUint(s) && s == 0 {

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -197,9 +197,9 @@ module ChapelRange {
   // for debugging
   pragma "no doc"
   proc range.displayRepresentation(msg: string = ""): void {
-    writeln(msg, "(", idxType:string, ",", boundedType, ",", stridable,
-            " : ", low, ",", high, ",", stride, ",",
-            if aligned then alignment:string else "?", ")");
+    chpl_debug_writeln(msg, "(", idxType:string, ",", boundedType, ",", stridable,
+                       " : ", low, ",", high, ",", stride, ",",
+                       if aligned then alignment:string else "?", ")");
   }
 
   //////////////////////////////////////////////////////////////////////////////////
@@ -1642,7 +1642,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
       __primitive("chpl_error", c"these -- Attempt to iterate over a range with ambiguous alignment.");
     }
     if debugChapelRange {
-      writeln("*** In range standalone iterator:");
+      chpl_debug_writeln("*** In range standalone iterator:");
     }
 
     const len = this.length;
@@ -1650,7 +1650,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
                       1 else _computeNumChunks(len);
 
     if debugChapelRange {
-      writeln("*** RI: length=", len, " numChunks=", numChunks);
+      chpl_debug_writeln("*** RI: length=", len, " numChunks=", numChunks);
     }
 
     if numChunks <= 1 {
@@ -1691,7 +1691,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
       __primitive("chpl_error", c"these -- Attempt to iterate over a range with ambiguous alignment.");
 
     if debugChapelRange then
-      writeln("*** In range leader:"); // ", this);
+      chpl_debug_writeln("*** In range leader:"); // ", this);
     const numSublocs = here.getChildCount();
 
     if localeModelHasSublocales && numSublocs != 0 {
@@ -1712,11 +1712,11 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
                                                   minIndicesPerTask,
                                                   len);
       if debugDataParNuma {
-        writeln("### numSublocs = ", numSublocs, "\n" +
-                "### numTasksPerSubloc = ", numSublocTasks, "\n" +
-                "### ignoreRunning = ", ignoreRunning, "\n" +
-                "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
-                "### numChunks = ", numChunks);
+        chpl_debug_writeln("### numSublocs = ", numSublocs, "\n" +
+                           "### numTasksPerSubloc = ", numSublocTasks, "\n" +
+                           "### ignoreRunning = ", ignoreRunning, "\n" +
+                           "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
+                           "### numChunks = ", numChunks);
       }
         
       if numChunks == 1 {
@@ -1726,8 +1726,8 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
           local on here.getChild(chunk) {
             if debugDataParNuma {
               if chunk!=chpl_getSubloc() then
-                writeln("*** ERROR: ON WRONG SUBLOC (should be "+chunk+
-                        ", on "+chpl_getSubloc()+") ***");
+                chpl_debug_writeln("*** ERROR: ON WRONG SUBLOC (should be "+
+                                   chunk+", on "+chpl_getSubloc()+") ***");
             }
             const (lo,hi) = _computeBlock(len, numChunks, chunk, len-1);
             const locRange = lo..hi;
@@ -1743,8 +1743,8 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
             coforall core in 0..#numTasks {
               const (low, high) = _computeBlock(locLen, numTasks, core, hi, lo, lo);
               if debugDataParNuma {
-                writeln("### chunk = ", chunk, "  core = ", core, "  " +
-                        "locRange = ", locRange, "  coreRange = ", low..high);
+                chpl_debug_writeln("### chunk = ", chunk, "  core = ", core, "  " +
+                                   "locRange = ", locRange, "  coreRange = ", low..high);
               }
               yield (low..high,);
             }
@@ -1759,8 +1759,8 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
   
       if debugChapelRange
       {
-        writeln("*** RI: length=", v, " numChunks=", numChunks);
-        writeln("*** RI: Using ", numChunks, " chunk(s)");
+        chpl_debug_writeln("*** RI: length=", v, " numChunks=", numChunks);
+        chpl_debug_writeln("*** RI: Using ", numChunks, " chunk(s)");
       }
   
       if numChunks == 1 then
@@ -1771,7 +1771,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
         {
           const (lo,hi) = _computeBlock(v, numChunks, chunk, v-1);
           if debugChapelRange then
-            writeln("*** RI: tuple = ", (lo..hi,));
+            chpl_debug_writeln("*** RI: tuple = ", (lo..hi,));
           yield (lo..hi,);
         }
       }
@@ -1793,12 +1793,12 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
       compilerError("iteration over a range with multi-dimensional iterator");
   
     if debugChapelRange then
-      writeln("In range follower code: Following ", followThis);
+      chpl_debug_writeln("In range follower code: Following ", followThis);
   
     var myFollowThis = followThis(1);
   
     if debugChapelRange then
-      writeln("Range = ", myFollowThis);
+      chpl_debug_writeln("Range = ", myFollowThis);
   
     if ! this.hasFirst() {
       if this.isEmpty() {
@@ -1839,7 +1839,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
         }
 
         if debugChapelRange then
-          writeln("Expanded range = ",r);
+          chpl_debug_writeln("Expanded range = ",r);
 
         for i in r do
           yield i;
@@ -1856,7 +1856,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
         }
 
         if debugChapelRange then
-          writeln("Expanded range = ",r);
+          chpl_debug_writeln("Expanded range = ",r);
 
         for i in r do
           yield i;
@@ -1875,7 +1875,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
       {
         const r = first .. by stride:strType;
         if debugChapelRange then
-          writeln("Expanded range = ",r);
+          chpl_debug_writeln("Expanded range = ",r);
       
         for i in r do
           yield i;
@@ -1884,7 +1884,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
       {
         const r = .. first by stride:strType;
         if debugChapelRange then
-          writeln("Expanded range = ",r);
+          chpl_debug_writeln("Expanded range = ",r);
       
         for i in r do
           yield i;


### PR DESCRIPTION
chpl_arrayInitMethod is a global variable. Reading it required a get, which had
the nasty side effect of increased comm counts and not being able to declare
arrays inside of a local-block.

This adds a param guard around it, which avoids the gets, but makes changing
the array init method at runtime more cumbersome.

Now instead of just doing

```chapel
chpl_arrayInitMethod = ArrayInit.parallelInit;
var A: [1..100] int;
```

you now have to compile with `-schpl_arrayInitMethodRuntimeSelectable` and do

```chapel
chpl_setArrayInitMethod(ArrayInit.parallelInit);
var A: [1..100] int;
```

which is annoying, but fine since this feature is just meant to help us explore
initialization strategies effect on first-touch.