### PR TITLE
Clean docs symlinks in release

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -160,6 +160,7 @@ SystemOrDie("make -j docs");
 
 # TODO - make this more elegant / maintainable
 print "Pruning the docs directory...\n";
+SystemOrDie("cd doc && make clean-symlinks");
 SystemOrDie("cd doc && rm -f Makefile*");
 SystemOrDie("cd doc && rm -f conf.py");
 SystemOrDie("cd doc && rm -f index.rst");


### PR DESCRIPTION
#5183 resulted in symlinks existing in the release tarball, which caused trouble for the RPM build on Crays. This PR removes the doc symlinks from the release.

- [x] Tested `gen_release` and confirmed symlinks were removed