### PR TITLE
Fix a bug with array-as-vec pop_front

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2352,7 +2352,7 @@ module ChapelArray {
           if newRange.low > r2.low {
             // not able to take enough spaces off the low end.  Take them
             // off the high end instead.
-            const spaceNeeded = r2.low - newRange.low;
+            const spaceNeeded = newRange.low - r2.low;
             newRange = r2.low..(newRange.high-spaceNeeded);
           }
           return newRange;


### PR DESCRIPTION
@ronawho discovered that array.pop_front() was increasing the size of the
array instead of decreasing it.

When trying to shrink an array-as-vec for the pop_front function, the order
of the operands of a subtraction were reversed, causing the array to grow
instead of shrinking.  Switch them so the array shrinks as was intended.

Passed full testing on standard linux64.  Also ran
arrays/diten/array-as-vec-start-idx.chpl 25,000 times on our 32 bit testing VM.