### PR TITLE
Fix issue where copies of AggregateTypes lost their initializerStyle

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -541,6 +541,7 @@ void AggregateType::verify() {
 AggregateType*
 AggregateType::copyInner(SymbolMap* map) {
   AggregateType* copy_type = new AggregateType(aggregateTag);
+  copy_type->initializerStyle = initializerStyle;
   copy_type->outer = outer;
   for_alist(expr, fields)
     copy_type->fields.insertAtTail(COPY_INT(expr));


### PR DESCRIPTION
Really trivial fix, just update AggregateType::copyInner to copy that
information as well - this was causing problems for me in my generics branch.

TODO: 
- [x] full paratest (in progress)