### PR TITLE
introduce ForallStmt node

### DIFF
--- a/compiler/AST/AstLogger.cpp
+++ b/compiler/AST/AstLogger.cpp
@@ -130,6 +130,13 @@ void AstLogger::exitBlockStmt(BlockStmt* node) {
 void AstLogger::visitForallIntents(ForallIntents* clause) {
 }
 
+bool AstLogger::enterForallStmt(ForallStmt* node) {
+  return true;
+}
+
+void AstLogger::exitForallStmt(ForallStmt* node) {
+}
+
 bool AstLogger::enterWhileDoStmt(WhileDoStmt* node) {
   return true;
 }

--- a/compiler/AST/AstPrintDocs.cpp
+++ b/compiler/AST/AstPrintDocs.cpp
@@ -175,6 +175,12 @@ bool AstPrintDocs::enterBlockStmt(BlockStmt* node) {
   return node->parentExpr == NULL;
 }
 
+
+bool AstPrintDocs::enterForallStmt(ForallStmt* node) {
+  return false;
+}
+
+
 bool AstPrintDocs::enterWhileDoStmt(WhileDoStmt* node) {
   return false;
 }

--- a/compiler/AST/AstVisitorTraverse.cpp
+++ b/compiler/AST/AstVisitorTraverse.cpp
@@ -178,6 +178,16 @@ void AstVisitorTraverse::visitForallIntents(ForallIntents* clause)
 
 }
 
+bool AstVisitorTraverse::enterForallStmt(ForallStmt* node)
+{
+  return true;
+}
+
+void AstVisitorTraverse::exitForallStmt(ForallStmt* node)
+{
+
+}
+
 bool AstVisitorTraverse::enterWhileDoStmt(WhileDoStmt* node)
 {
   return true;

--- a/compiler/AST/CollapseBlocks.cpp
+++ b/compiler/AST/CollapseBlocks.cpp
@@ -140,6 +140,10 @@ void CollapseBlocks::visitForallIntents(ForallIntents* clause) {
   INT_ASSERT(false);
 }
 
+bool CollapseBlocks::enterForallStmt(ForallStmt* node) {
+  return enterBlockStmt(node->fVar);
+}
+
 
 // The c for loop primitive is of the form:
 //   __primitive("C for loop", {inits}, {test}, {incrs})
@@ -333,6 +337,11 @@ void CollapseBlocks::visitUseStmt(UseStmt* node)
 }
 
 void CollapseBlocks::exitBlockStmt(BlockStmt* node)
+{
+
+}
+
+void CollapseBlocks::exitForallStmt(ForallStmt* node)
 {
 
 }

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -76,8 +76,8 @@ void printStatistics(const char* pass) {
 
   foreach_ast(decl_counters);
 
-  int nStmt = nCondStmt + nBlockStmt + nGotoStmt + nUseStmt + nTryStmt;
-  int kStmt = kCondStmt + kBlockStmt + kGotoStmt + kUseStmt + kExternBlockStmt + kTryStmt;
+  int nStmt = nCondStmt + nBlockStmt + nGotoStmt + nUseStmt + nForallStmt + nTryStmt;
+  int kStmt = kCondStmt + kBlockStmt + kGotoStmt + kUseStmt + kForallStmt + kExternBlockStmt + kTryStmt;
   int nExpr = nUnresolvedSymExpr + nSymExpr + nDefExpr + nCallExpr +
     nContextCallExpr + nForallExpr + nNamedExpr;
   int kExpr = kUnresolvedSymExpr + kSymExpr + kDefExpr + kCallExpr +
@@ -451,6 +451,10 @@ const char* BaseAST::astTagAsString() const {
 
     case E_GotoStmt:
       retval = "GotoStmt";
+      break;
+
+    case E_ForallStmt:
+      retval = "ForallStmt";
       break;
 
     case E_ExternBlockStmt:

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -278,6 +278,16 @@ void Expr::verify() {
   }
 }
 
+void Expr::verify(AstTag expectedTag) {
+  if (astTag != expectedTag)
+    INT_FATAL(this, "verify(id=%d): Bad astTag", id);
+  Expr::verify();
+}
+
+void Expr::verifyParent(const Expr* child, const char* field) {
+  if (child && child->parentExpr != this)
+    INT_FATAL(this, "bad parent of %s", field);
+}
 
 bool Expr::inTree() {
   if (parentSymbol)

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -21,10 +21,16 @@
 
 #include "expr.h"
 #include "foralls.h"
+#include "stmt.h"
 #include "astutil.h"
 #include "stlUtil.h"
 #include "passes.h" // for normalized, resolved
 #include "AstVisitor.h"
+#include "ForLoop.h"
+#include "resolution.h"
+#include "iterator.h"
+
+enum ParIterResult { pSA = 1, pLeader, pFailed };
 
 const char* tfiTagDescrString(TFITag tfiTag) {
   switch (tfiTag) {
@@ -40,9 +46,10 @@ const char* tfiTagDescrString(TFITag tfiTag) {
   return "";
 }
 
-//
+
+/////////////////////////////////
 // ForallIntents
-//
+/////////////////////////////////
 
 // constructor
 ForallIntents::ForallIntents() :
@@ -129,8 +136,7 @@ void ForallIntents::removeFI(Expr* parentB) {
 #undef REMOVE    
 }
 
-void ForallIntents::verifyFI(BlockStmt* parentB) {
-  Expr* parentE = (Expr*)parentB;
+void ForallIntents::verifyFI(Expr* parentE) const {
   int nv = numVars();
   INT_ASSERT((int)(fiVars.size())   == nv);
   INT_ASSERT((int)(fIntents.size()) == nv);
@@ -230,3 +236,681 @@ bool astUnderFI(const Expr* ast, ForallIntents* fi) {
   // none found
   return false;
 }  
+
+
+/////////////////////////////////
+// ForallStmt
+/////////////////////////////////
+
+// convert _build_tuple args to AList
+// todo: have the parser build AList directly or at least keep it as PRIM_ZIP
+// i.e. skip zipToTuple()
+static void convertIterator(AList& list, Expr* iter, bool zippered) {
+  if (zippered) {
+    CallExpr* icall = toCallExpr(iter);
+    INT_ASSERT(icall && icall->isNamed("_build_tuple"));
+    for_actuals(actual, icall)
+      list.insertAtTail(actual->remove());
+  } else {
+    list.insertAtTail(iter);
+  }
+}
+
+ForallStmt::ForallStmt(BlockStmt* var, Expr* iter, bool zippered,
+                       ForallIntents* intents, BlockStmt* body) :
+  Stmt(E_ForallStmt),
+  fVar(var),
+  fZippered(zippered),
+  fWith(intents),
+  fBody(body)
+{
+  fIter.parent = this;
+
+  if (iter)
+    convertIterator(fIter, iter, zippered);
+
+  // caller must provide these
+  INT_ASSERT(fVar);
+  INT_ASSERT(fVar->blockTag == BLOCK_NORMAL);
+  INT_ASSERT(fWith);
+  INT_ASSERT(fBody);
+  INT_ASSERT(fBody->blockTag == BLOCK_NORMAL);
+
+  if (fVar->body.tail != fBody) {
+    INT_ASSERT(!fBody->parentExpr); // fBody better not be inTree()
+    fVar->insertAtTail(fBody);
+  }
+
+  gForallStmts.add(this);
+
+  // Should not create any new ones after they have been lowered.
+  INT_ASSERT(beforeLoweringForallStmts);
+}
+
+ForallStmt::~ForallStmt() {
+  delete fWith;
+}
+
+ForallStmt* ForallStmt::copyInner(SymbolMap* map) {
+  BlockStmt* newVars = toBlockStmt(COPY_INT(fVar));
+  BlockStmt* newBody = toBlockStmt(newVars->body.tail);
+  ForallStmt* _this  = new ForallStmt(newVars, NULL, 
+                        fZippered,
+                        COPY_INT(fWith),
+                        newBody);
+
+  for_alist(expr, fIter)
+    _this->fIter.insertAtTail(COPY_INT(expr));
+
+  return _this;
+}
+
+void ForallStmt::replaceChild(Expr* oldAst, Expr* newAst) {
+  if (oldAst == fBody || oldAst == fVar) {
+    if (!newAst)
+      (oldAst == fBody ? fBody : fVar) = NULL;
+    else if (BlockStmt* newBlock = toBlockStmt(newAst)) {
+      INT_ASSERT(!newBlock->isLoopStmt());
+      (oldAst == fBody ? fBody : fVar) = newBlock;
+    } else
+      // newAst does not fit - caller responsibility
+      INT_ASSERT(false);
+
+  } else if (fWith->replaceChildFI(oldAst, newAst))
+    ; //good
+
+  else
+    // did not find oldAst in our ForallStmt - caller responsibility
+    INT_ASSERT(false);
+}
+
+void ForallStmt::verify() {
+  Expr::verify(E_ForallStmt);
+
+  INT_ASSERT(fIter.length > 0);
+
+  if (fIter.parent != this)
+    INT_FATAL(this, "ForallStmt::verify. Bad fIter.parent");
+
+  for_alist(expr, fIter) {
+    if (expr->parentExpr != this)
+      INT_FATAL(this, "ForallStmt::verify. Bad fIter.expr->parentExpr");
+  }
+
+  INT_ASSERT(fWith);
+  fWith->verifyFI(this);
+
+  INT_ASSERT(fVar);
+  verifyParent(fVar, "ForallStmt::fVar");
+  verifyNotOnList(fVar);
+  // should be a normal block
+  INT_ASSERT(fVar->blockTag == BLOCK_NORMAL);
+  INT_ASSERT(!fVar->blockInfoGet());
+  INT_ASSERT(!fVar->isLoopStmt());
+  INT_ASSERT(!fVar->modUses);
+  INT_ASSERT(!fVar->userLabel);
+  INT_ASSERT(!fVar->byrefVars);
+  INT_ASSERT(!fVar->forallIntents);
+
+  // fBody must be the last thing in fVar
+  INT_ASSERT(fBody);
+  INT_ASSERT(fVar->body.tail == fBody);
+
+  // should be a normal block
+  INT_ASSERT(fBody->blockTag == BLOCK_NORMAL);
+  INT_ASSERT(!fBody->blockInfoGet());
+  INT_ASSERT(!fBody->isLoopStmt());
+  INT_ASSERT(!fBody->modUses);
+  INT_ASSERT(!fBody->userLabel);
+  INT_ASSERT(!fBody->byrefVars);
+  INT_ASSERT(!fBody->forallIntents);
+
+  // ForallStmt are gone during resolve().
+  INT_ASSERT(!resolved);
+}
+
+void ForallStmt::accept(AstVisitor* visitor) {
+  if (visitor->enterForallStmt(this)) {
+    for_alist(next_ast, fIter)
+      next_ast->accept(visitor);
+    // not doing: fIter->accept(visitor);
+    fWith->acceptFI(visitor); // aka visitor->visitForallIntents(fWith);
+    fVar->accept(visitor); // includes fBody
+    visitor->exitForallStmt(this);
+  }
+}
+
+Expr* ForallStmt::getFirstChild() {
+  // Should we cater to fWith? Should fVar come earlier?
+  return fIter.head;
+}
+
+Expr* ForallStmt::getFirstExpr() {
+  return fIter.head->getFirstExpr();
+}
+
+Expr* ForallStmt::getNextExpr(Expr* expr) {
+  if (expr == fIter.tail)
+    return fVar->getFirstExpr();
+  else
+    return this;
+}
+
+bool isForallStmtIterator(ForallStmt* fs, Expr* expr) {
+  return expr->list && expr->list == &(fs->fIter);
+}
+
+ForallStmt* enclosingForallStmt(Expr* expr) {
+  for (Expr* curr = expr->parentExpr; curr; curr = curr->parentExpr)
+    if (ForallStmt* fs = toForallStmt(curr))
+      return fs;
+  return NULL;
+}
+
+int reduceIntentIdx(ForallStmt* fs, Symbol* reVar) {
+  ForallIntents* fi = fs->fWith;
+  int nv = fi->numVars();
+  for (int i = 0; i < nv; i++)
+    if (fi->isReduce(i))
+      if (SymExpr* varSE = toSymExpr(fi->fiVars[i]))
+        if (varSE->symbol() == reVar)
+          return i;
+
+  // Did not see 'reVar' with a reduce intent.
+  return -1;
+}
+
+VarSymbol* forallIndexVar(ForallStmt* fs) {
+  DefExpr* def = toDefExpr(fs->fVar->body.head);
+  INT_ASSERT(def);
+  VarSymbol* iv = toVarSymbol(def->sym);
+  INT_ASSERT(iv);
+  return iv;
+}
+
+VarSymbol* forallIdxCopyVar(ForallStmt* fs, VarSymbol* idxVar) {
+  DefExpr* def = toDefExpr(idxVar->defPoint->next);
+  INT_ASSERT(def);
+  VarSymbol* iv = toVarSymbol(def->sym);
+  INT_ASSERT(iv);
+  return iv;
+}
+
+static VarSymbol* forallIdxCopyVar(ForallStmt* fs) {
+  return forallIdxCopyVar(fs, forallIndexVar(fs));
+}
+
+
+/////////////////////////////////
+//                             //
+//    lowering a ForallStmt    //
+//                             //
+/////////////////////////////////
+
+//
+// Given an iterator function, find the type that it yields.
+// It would be fn->retType, alas protoIteratorClass() messes with that.
+// This helper is ForallStmt-specific because of the error message it issues.
+//
+static QualifiedType fsIterYieldType(FnSymbol* iterFn, CallExpr* iterCall,
+                                     ParIterResult saOrLeader)
+{
+  if (iterFn->hasFlag(FLAG_ITERATOR_FN)) {
+    IteratorInfo* ii = iterFn->iteratorInfo;
+    INT_ASSERT(ii);
+    return ii->getValue->getReturnQualType();
+  } else {
+    // e.g. "proc these() return _value.these();"
+    AggregateType* retType = toAggregateType(iterFn->retType);
+    if (retType && retType->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
+      FnSymbol* iterator = retType->iteratorInfo->iterator;
+      INT_ASSERT(iterator->hasFlag(FLAG_ITERATOR_FN)); // no more recursion?
+      return fsIterYieldType(iterator, iterCall, saOrLeader);
+    } else {
+      USR_FATAL_CONT(iterCall, "The iterable-expression resolves to a non-iterator function '%s' when looking for %s iterator", iterFn->name, saOrLeader == pSA ? "standalone" : "leader");
+      USR_PRINT(iterFn, "The function '%s' is declared here", iterFn->name);
+      USR_STOP();
+      return (QualifiedType)0; // dummy
+    }
+  }
+}
+
+// Like in build.cpp, here for ForallStmt.
+static BlockStmt*
+buildFollowLoop(VarSymbol* iter,
+                VarSymbol* leadIdxCopy,
+                VarSymbol* followIter,
+                VarSymbol* followIdx,
+                BlockStmt* loopBody,
+                Expr*      ref,
+                bool       fast,
+                bool       zippered) {
+  BlockStmt* followBlock = new BlockStmt();
+  ForLoop*   followBody  = new ForLoop(followIdx, followIter, loopBody, zippered);
+
+  // not needed:
+  //destructureIndices(followBody, indices, new SymExpr(followIdx), false);
+
+  followBlock->insertAtTail(new DefExpr(followIter));
+
+  if (fast) {
+
+    if (zippered) {
+      followBlock->insertAtTail("'move'(%S, _getIteratorZip(_toFastFollowerZip(%S, %S)))", followIter, iter, leadIdxCopy);
+    } else {
+      followBlock->insertAtTail("'move'(%S, _getIterator(_toFastFollower(%S, %S)))",       followIter, iter, leadIdxCopy);
+    }
+  } else {
+
+    if (zippered) {
+      followBlock->insertAtTail("'move'(%S, _getIteratorZip(_toFollowerZip(%S, %S)))",     followIter, iter, leadIdxCopy);
+    } else {
+      followBlock->insertAtTail("'move'(%S, _getIterator(_toFollower(%S, %S)))",           followIter, iter, leadIdxCopy);
+    }
+  }
+
+  ref->insertAfter(followBlock); // otherwise it wouldn't normalize
+  normalize(followBlock);
+  followBlock->remove();
+
+  followBlock->insertAtTail(new DefExpr(followIdx));
+
+  followBlock->insertAtTail("{TYPE 'move'(%S, iteratorIndex(%S)) }", followIdx, followIter);
+
+  followBlock->insertAtTail(followBody);
+  followBlock->insertAtTail(new CallExpr("_freeIterator", followIter));
+
+  return followBlock;
+}
+
+static SymExpr* normalizeFSIterExpr(ForallStmt* pfs, Symbol*& ieTemp,
+                                    Expr* origExpr, QualifiedType origType)
+{
+  SymExpr* iterSE = toSymExpr(origExpr);
+
+  // Normalize if needed.
+  if (iterSE) {
+    // leave origExpr alone
+    iterSE = iterSE->copy();
+  } else {
+    ieTemp = newTemp("chpl_ieTemp");
+    ieTemp->type = origType.type();
+    ieTemp->qual = origType.getQual();
+    iterSE = new SymExpr(ieTemp);
+
+    pfs->insertBefore(new DefExpr(ieTemp));
+    //Done in buildForallParIterCall():
+    //  pfs->insertBefore("'move'(%S,%E)", ieTemp, origExpr);
+  }
+
+  if (origType.type()->getValType()->symbol->
+        hasEitherFlag(FLAG_DOMAIN, FLAG_ARRAY))
+  {
+    // Redirect to _value. It would be simpler instead to have something
+    // like this in modules:
+    //   proc _domain.these(param tag) return _value.these(tag);
+    //
+    // However, that would result in an "unresolved call" error
+    // for a domain map without the standalone iterator.
+
+    VarSymbol* valTemp = newTemp("chpl_valueTemp");
+    pfs->insertBefore(new DefExpr(valTemp));
+    CallExpr*  valCall = new CallExpr("_value", gMethodToken, iterSE);
+    CallExpr* moveCall = new CallExpr(PRIM_MOVE, valTemp, valCall);
+    pfs->insertBefore(moveCall);
+
+    if (FnSymbol* callee = tryResolveCall(valCall)) {
+      // todo: replace somehow with resolveFnForCall(callee, valCall);
+      callStack.add(valCall);
+      resolveFns(callee);
+      callStack.pop();
+    } else {
+      if (iterSE->symbol()->hasFlag(FLAG_TYPE_VARIABLE)) {
+        USR_FATAL(origExpr, "unable to iterate over type '%s'",
+                  toString(iterSE->symbol()->type));
+      } else {
+        USR_FATAL(origExpr, "cannot iterate over values of type %s",
+                  toString(iterSE->symbol()->type));
+      }
+    }
+    resolveCall(moveCall);
+
+    iterSE = new SymExpr(valTemp);
+  }
+
+  return iterSE;
+}
+
+// Replaces 'origExpr' in the tree with the result.
+// If 'ieTemp' is created, origExpr will be inTree().
+static CallExpr* buildForallParIterCall(ForallStmt* pfs, Expr* origExpr,
+                                        Symbol*& ieTemp)
+{
+  CallExpr* iterCall;
+  QualifiedType origType = origExpr->qualType();
+  
+  if (origType.type()->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
+    // Our iterable expression is an iterator call.
+    iterCall = toCallExpr(origExpr->copy());
+    // If it is not a call, how do we convert it to a parallel iterator?
+    // We do not want to resort to PRIM_TO_STANDALONE et al.
+    // We'd probably need to work with the call that's assigned into iterCall.
+    INT_ASSERT(iterCall);
+    FnSymbol* origTarget = iterCall->isResolved();
+    INT_ASSERT(origTarget);
+    iterCall->baseExpr = new UnresolvedSymExpr(origTarget->name);
+
+  } else {
+    // Not an iterator call, so add a call to these().
+    SymExpr* iterSE = normalizeFSIterExpr(pfs, ieTemp, origExpr, origType);
+    iterCall = new CallExpr("these", gMethodToken, iterSE);
+  }
+
+  origExpr->replace(iterCall);
+
+  // Couldn't do it in normalizeFSIterExpr() because origExpr was inTree().
+  if (ieTemp)
+    ieTemp->defPoint->insertAfter("'move'(%S,%E)", ieTemp, origExpr);
+
+  return iterCall;
+}
+
+static ParIterResult findStandaloneOrLeader(ForallStmt* pfs,
+                                            CallExpr* iterCall, bool inTry)
+{
+  bool gotParallel = false;
+  ParIterResult saOrLeader = pSA;
+
+  // We are starting with a serial-iterator call.
+  // Transform it to a standalone/leader call.
+  NamedExpr* tag = new NamedExpr("tag", new SymExpr(gStandaloneTag));
+  iterCall->insertAtTail(tag);
+
+  // try standalone
+  if (!pfs->fZippered)
+    gotParallel = tryResolveCall(iterCall);
+
+  // try leader
+  if (!gotParallel) {
+    saOrLeader = pLeader;
+    tag->actual->replace(new SymExpr(gLeaderTag));
+    gotParallel = tryResolveCall(iterCall);
+  }
+
+  if (!gotParallel) {
+    if (inTry)
+      return pFailed;
+    
+    // Cannot USR_FATAL_CONT in general: e.g. if these() is not found,
+    // we do not know the type of the index variable. Without which
+    // which cannot typecheck the loop body.
+    USR_FATAL(iterCall, "A standalone or leader iterator is not found for the iterable expression in this forall loop");
+  }
+
+  return saOrLeader;
+}
+
+static Expr* rebuildIterableCall(ForallStmt* pfs,
+                                 CallExpr* iterCall, Expr* origExprFlw)
+{
+  INT_ASSERT(iterCall == pfs->fIter.head); // still here?
+
+  if (!pfs->fZippered) {
+    INT_ASSERT(!iterCall->next);
+    // no tuple building here
+    return origExprFlw;
+  }
+
+  int origLength = pfs->fIter.length;
+  CallExpr* result = new CallExpr("_build_tuple", origExprFlw);
+  while (Expr* curr = iterCall->next)
+    result->insertAtTail(curr->remove());
+
+  // todo: remove the assert and origLength
+  INT_ASSERT(result->numActuals() == origLength);
+  return result;
+}
+
+static void resolveParallelIteratorAndIdxVar(ForallStmt* pfs,
+                                             CallExpr* iterCall,
+                                             ParIterResult saOrLeader)
+{
+  // The iterator probably has been extendLeader()-ed for forall intents.
+  FnSymbol* parIter = iterCall->isResolved();
+  resolveFns(parIter);
+
+  // Set QualifiedType of the index variable.
+  QualifiedType iType = fsIterYieldType(parIter, iterCall, saOrLeader);
+  VarSymbol* idxVar = forallIndexVar(pfs);
+  idxVar->type = iType.type();
+  idxVar->qual = iType.getQual();
+}
+
+static void buildLeaderLoopBody(ForallStmt* pfs, Expr* iterExpr) {
+  bool zippered = pfs->fZippered;
+
+  // Set up the follower call etc.
+
+  // Extract leadIdxCopy and its type.
+  VarSymbol* leadIdxCopy = forallIdxCopyVar(pfs);
+
+  BlockStmt* resultBlock     = new BlockStmt();
+  // cf in build.cpp: new ForLoop(leadIdx, leadIter, NULL, zippered)
+  BlockStmt* leadForLoop     = new BlockStmt();
+
+  VarSymbol* iterRec         = newTemp("chpl__iterLF"); // serial iter, LF case
+
+  VarSymbol* followIdx       = newTemp("chpl__followIdx");
+  VarSymbol* followIter      = newTemp("chpl__followIter");
+  BlockStmt* followBlock     = NULL;
+
+  iterRec->addFlag(FLAG_EXPR_TEMP);
+  iterRec->addFlag(FLAG_CHPL__ITER);
+
+  followIdx->addFlag(FLAG_INDEX_OF_INTEREST);
+
+  resultBlock->insertAtTail(new DefExpr(iterRec));
+  resultBlock->insertAtTail(new CallExpr(PRIM_MOVE, iterRec, iterExpr));
+  Expr* toNormalize = resultBlock->body.tail;
+
+  // loop body to refer to followIdx instead of leadIdxCopy
+  for_SymbolSymExprs(se, leadIdxCopy)
+    if (se->parentExpr->parentExpr != pfs->fVar) // heuristic
+      se->replace(new SymExpr(followIdx));
+
+  BlockStmt* loopBody = pfs->fBody;
+  loopBody->remove();
+
+  followBlock = buildFollowLoop(iterRec,
+                                leadIdxCopy,
+                                followIter,
+                                followIdx,
+                                loopBody,
+                                pfs,
+                                false,
+                                zippered);
+
+  if (fNoFastFollowers == false) {
+    // from former buildForallLoopStmt()
+    Symbol* T1 = newTemp();
+    Symbol* T2 = newTemp();
+
+    VarSymbol* fastFollowIdx   = newTemp("chpl__fastFollowIdx");
+    VarSymbol* fastFollowIter  = newTemp("chpl__fastFollowIter");
+    BlockStmt* fastFollowBlock = NULL;
+
+
+    T1->addFlag(FLAG_EXPR_TEMP);
+    T1->addFlag(FLAG_MAYBE_PARAM);
+
+    T2->addFlag(FLAG_EXPR_TEMP);
+    T2->addFlag(FLAG_MAYBE_PARAM);
+
+    leadForLoop->insertAtTail(new DefExpr(T1));
+    leadForLoop->insertAtTail(new DefExpr(T2));
+
+    if (zippered == false) {
+      leadForLoop->insertAtTail("'move'(%S, chpl__staticFastFollowCheck(%S))",    T1, iterRec);
+      leadForLoop->insertAtTail(new CondStmt(new SymExpr(T1),
+                                          new_Expr("'move'(%S, chpl__dynamicFastFollowCheck(%S))",    T2, iterRec),
+                                          new_Expr("'move'(%S, %S)", T2, gFalse)));
+    } else {
+      leadForLoop->insertAtTail("'move'(%S, chpl__staticFastFollowCheckZip(%S))", T1, iterRec);
+      leadForLoop->insertAtTail(new CondStmt(new SymExpr(T1),
+                                          new_Expr("'move'(%S, chpl__dynamicFastFollowCheckZip(%S))", T2, iterRec),
+                                          new_Expr("'move'(%S, %S)", T2, gFalse)));
+    }
+
+    SymbolMap map;
+    map.put(followIdx, fastFollowIdx);
+    BlockStmt* loopBodyForFast = loopBody->copy(&map);
+
+    fastFollowBlock = buildFollowLoop(iterRec,
+                                      leadIdxCopy,
+                                      fastFollowIter,
+                                      fastFollowIdx,
+                                      loopBodyForFast,
+                                      pfs,
+                                      true,
+                                      zippered);
+
+    leadForLoop->insertAtTail(new CondStmt(new SymExpr(T2), fastFollowBlock, followBlock));
+  } else {
+    leadForLoop->insertAtTail(followBlock);
+  }
+
+  // Must happen before any resolving ex. resolveBlockStmt below.
+  // Otherwise functions defined within the forall body are not visible.
+  // Ex. functions/vass/ref-intent-bug-2big.chpl
+  pfs->fVar->insertAtTail(leadForLoop);
+
+  pfs->insertBefore(resultBlock);
+  normalize(toNormalize); // requires inTree()
+  resolveBlockStmt(resultBlock);
+  resultBlock->flattenAndRemove();
+}
+
+Expr* resolveParallelIteratorAndForallIntents(Expr* origExpr, bool inTry) {
+  ForallStmt* pfs = toForallStmt(origExpr->parentExpr);
+  if (!pfs || !origExpr->list)
+    return origExpr;
+
+  // We only get here for origExpr==fIter.head .
+  // If at that time there are any other elements in fIter, we remove them.
+  INT_ASSERT(origExpr == pfs->fIter.head);
+
+  Symbol* ieTemp = NULL;  // may be set in next line
+  CallExpr* iterCall = buildForallParIterCall(pfs, origExpr, ieTemp);
+
+  // So we know where iterCall is.
+  INT_ASSERT(iterCall == pfs->fIter.head);
+  // Later, use ieTemp if defined, otherwise use origExpr.
+  INT_ASSERT(!ieTemp == !origExpr->inTree());
+
+  ParIterResult saOrLeader = findStandaloneOrLeader(pfs, iterCall, inTry);
+  if (saOrLeader == pFailed)
+    return NULL;
+
+  implementForallIntentsNew(pfs, iterCall);
+
+  resolveParallelIteratorAndIdxVar(pfs, iterCall, saOrLeader);
+
+  if (saOrLeader == pLeader) {
+    Expr* origExprFlw = ieTemp ? new SymExpr(ieTemp) : origExpr;
+    buildLeaderLoopBody(pfs,
+                        rebuildIterableCall(pfs, iterCall, origExprFlw));
+  }
+
+  INT_ASSERT(iterCall == pfs->fIter.head); // still here?
+  INT_ASSERT(iterCall == pfs->fIter.tail); // only one element in fIter
+
+  return iterCall;
+}
+
+
+//
+// (A) We are doing this so the generated code looks like it did before.
+//     Even though arguably this should not matter.
+//     Eventually - or soon - this should go away.
+// (B) It is a heuristic based on the shape of the AST.
+//     If it does not work, delete. (See also (A).)
+//
+static void move_freeIterator_call(BlockStmt* SABlock) {
+  CallExpr* freeIt = toCallExpr(SABlock->body.tail);
+  INT_ASSERT(freeIt && freeIt->isNamed("_freeIterator"));
+  Expr *freeHere = NULL, *curr = SABlock;
+  for (int i = 0; i < 15; i++) {
+    curr = curr->next;
+    if (!curr) break;
+    if (CallExpr* currCE = toCallExpr(curr))
+      if (currCE->isNamed("chpl_here_free"))
+        { freeHere = curr; break; }
+  }
+  // freeHere==NULL for when riSpec is a user-defined/managed object
+  if (freeHere)
+    freeHere->insertAfter(freeIt->remove());
+}  
+
+void lowerForallStmts() {
+  forv_Vec(ForallStmt, fs, gForallStmts) {
+    if (!fs->inTree() || !fs->getFunction()->isResolved())
+      continue;
+
+    // Forall intents aka fs->fWith should have already been handled.
+
+    CallExpr* parIterCall = toCallExpr(fs->fIter.head);
+    INT_ASSERT(parIterCall && !parIterCall->next); // expected
+    SET_LINENO(parIterCall);
+    BlockStmt* SABlock = new BlockStmt();
+    fs->replace(SABlock); // so we can resolve SABlock below
+    // Maybe move this ->replace() down to resolveBlockStmt(SABlock) ?
+    // If so, add ->remove() to fs->fIter and perhaps others.
+
+    // From the original buildForallLoopStmt().
+    VarSymbol* iterRec   = newTemp("chpl__iterSA"); // serial iter, SA case
+    VarSymbol* saIter    = newTemp("chpl__saIter");
+    VarSymbol* saIdx     = forallIndexVar(fs);
+
+    iterRec->addFlag(FLAG_CHPL__ITER);
+    iterRec->addFlag(FLAG_MAYBE_REF);
+    iterRec->addFlag(FLAG_EXPR_TEMP);
+
+    saIter->addFlag(FLAG_EXPR_TEMP);
+    saIdx->addFlag(FLAG_INDEX_OF_INTEREST);
+    saIdx->addFlag(FLAG_INDEX_VAR);
+
+    SABlock->insertAtTail(new DefExpr(iterRec));
+    SABlock->insertAtTail(new DefExpr(saIter));
+    DefExpr* saIdxDef = toDefExpr(fs->fVar->body.head);
+    INT_ASSERT(saIdxDef && saIdxDef->sym == saIdx);
+    SABlock->insertAtTail(saIdxDef->remove());
+
+    SABlock->insertAtTail(new CallExpr(PRIM_MOVE, iterRec, parIterCall));
+    SABlock->insertAtTail("'move'(%S, _getIterator(%S))", saIter, iterRec);
+    SABlock->insertAtTail("{TYPE 'move'(%S, iteratorIndex(%S)) }", saIdx, saIter);
+
+    currentAstLoc = fs->fBody->astloc; // can't do SET_LINENO
+    ForLoop* SABody = new ForLoop(saIdx, saIter, NULL, false);
+
+    // not needed:
+    //destructureIndices(SABody, indices, new SymExpr(saIdxCopy), false);
+
+    SABlock->insertAtTail(SABody);
+    SABlock->insertAtTail("_freeIterator(%S)", saIter);
+
+    resolveBlockStmt(SABlock);
+    move_freeIterator_call(SABlock);
+    SABlock->flattenAndRemove();
+
+    BlockStmt* fsLoopBody = toBlockStmt(fs->fVar->body.tail);
+    fsLoopBody->flattenAndRemove(); // into fVar
+
+    SABody->insertAtTail(fs->fVar); // fs->fVar is already resolved
+    fs->fVar->flattenAndRemove();   // into SABody
+  }
+}
+
+GenRet ForallStmt::codegen() {
+  INT_ASSERT(false); // should not be invoked
+  return (GenRet)0;
+}

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -472,6 +472,17 @@ BlockStmt::canFlattenChapelStmt(const BlockStmt* stmt) const {
   return retval;
 }
 
+//
+// "Remove the curly braces":
+// move all contents out of this BlockStmt and remove it.
+//
+void BlockStmt::flattenAndRemove() {
+  for_alist(stmt, this->body)
+    this->insertBefore(stmt->remove());
+  INT_ASSERT(this->body.length == 0);
+  this->remove();
+}
+
 Expr*
 BlockStmt::getFirstChild() {
   Expr* retval = NULL;

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -127,6 +127,12 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
   bool is_C_loop = false;
   const char* block_explain = NULL;
   if (Expr* expr = toExpr(ast)) {
+    if (ForallStmt* pfs = toForallStmt(parentAst))
+      if (ast == pfs->fVar) {
+        printf("\n%6c", ' ');
+        for (int i = 0; i < indent; i++) printf(" ");
+        printf("do\n");
+      }
     do_list_line = !parentAst || list_line(expr, parentAst);
     if (do_list_line) {
       printf("%-7d ", expr->id);
@@ -149,6 +155,8 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
       printf("%s{\n", block_explain);
     } else if (toCondStmt(ast)) {
       printf("if ");
+    } else if (ForallStmt* fs = toForallStmt(ast)) {
+      printf("forall in%s\n", fs->fZippered ? " zip" : "");
     } else if (CallExpr* e = toCallExpr(expr)) {
       if (e->isPrimitive(PRIM_BLOCK_C_FOR_LOOP))
           is_C_loop = true;
@@ -244,6 +252,15 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
     } else if (CondStmt* cond = toCondStmt(parentAst)) {
       if (cond->condExpr == expr)
         printf("\n");
+    } else if (ForallStmt* fs = toForallStmt(parentAst)) {
+      if (expr == fs->fIter.tail) {
+        printf("\n%6c", ' ');
+        for (int i = 0; i < indent; i++) printf(" ");
+        if (fs->fWith->numVars())
+          printf("with (...)\n");
+        else
+          printf("with()");
+      }
     } else if (!toCondStmt(expr) && do_list_line) {
       DefExpr* def = toDefExpr(expr);
       if (!(def && early_newline))

--- a/compiler/include/AstLogger.h
+++ b/compiler/include/AstLogger.h
@@ -91,6 +91,8 @@ public:
   virtual void   exitBlockStmt       (BlockStmt*         node);
 
   virtual void   visitForallIntents  (ForallIntents*   clause);
+  virtual bool   enterForallStmt     (ForallStmt*        node);
+  virtual void   exitForallStmt      (ForallStmt*        node);
 
   virtual bool   enterWhileDoStmt    (WhileDoStmt*       node);
   virtual void   exitWhileDoStmt     (WhileDoStmt*       node);

--- a/compiler/include/AstPrintDocs.h
+++ b/compiler/include/AstPrintDocs.h
@@ -43,6 +43,7 @@ public:
   virtual void   visitVarSym      (VarSymbol*         node);
 
   virtual bool   enterBlockStmt   (BlockStmt*         node);
+  virtual bool   enterForallStmt  (ForallStmt*        node);
   virtual bool   enterWhileDoStmt (WhileDoStmt*       node);
   virtual bool   enterDoWhileStmt (DoWhileStmt*       node);
   virtual bool   enterCForLoop    (CForLoop*          node);

--- a/compiler/include/AstVisitor.h
+++ b/compiler/include/AstVisitor.h
@@ -42,6 +42,7 @@ class UnresolvedSymExpr;
 class UseStmt;
 class BlockStmt;
 class ForallIntents;
+class ForallStmt;
 class WhileDoStmt;
 class DoWhileStmt;
 class CForLoop;
@@ -127,6 +128,8 @@ public:
   virtual void   exitBlockStmt       (BlockStmt*         node) = 0;
 
   virtual void   visitForallIntents  (ForallIntents*   clause) = 0;
+  virtual bool   enterForallStmt     (ForallStmt*        node) = 0;
+  virtual void   exitForallStmt      (ForallStmt*        node) = 0;
 
   virtual bool   enterWhileDoStmt    (WhileDoStmt*       node) = 0;
   virtual void   exitWhileDoStmt     (WhileDoStmt*       node) = 0;

--- a/compiler/include/AstVisitorTraverse.h
+++ b/compiler/include/AstVisitorTraverse.h
@@ -99,6 +99,8 @@ public:
   virtual void   exitBlockStmt       (BlockStmt*         node);
 
   virtual void   visitForallIntents  (ForallIntents*   clause);
+  virtual bool   enterForallStmt     (ForallStmt*        node);
+  virtual void   exitForallStmt      (ForallStmt*        node);
 
   virtual bool   enterWhileDoStmt    (WhileDoStmt*       node);
   virtual void   exitWhileDoStmt     (WhileDoStmt*       node);

--- a/compiler/include/CollapseBlocks.h
+++ b/compiler/include/CollapseBlocks.h
@@ -87,6 +87,8 @@ public:
   virtual void   exitBlockStmt       (BlockStmt*         node);
 
   virtual void   visitForallIntents  (ForallIntents*   clause);
+  virtual bool   enterForallStmt     (ForallStmt*        node);
+  virtual void   exitForallStmt      (ForallStmt*        node);
 
   virtual bool   enterWhileDoStmt    (WhileDoStmt*       node);
   virtual void   exitWhileDoStmt     (WhileDoStmt*       node);

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -70,6 +70,7 @@
   macro(BlockStmt) sep                             \
   macro(CondStmt) sep                              \
   macro(GotoStmt) sep                              \
+  macro(ForallStmt) sep                            \
   macro(TryStmt) sep                               \
   macro(ExternBlockStmt)
 
@@ -147,6 +148,7 @@ enum AstTag {
   E_BlockStmt,
   E_CondStmt,
   E_GotoStmt,
+  E_ForallStmt,
   E_ExternBlockStmt,
 
   E_ModuleSymbol,
@@ -337,6 +339,7 @@ def_is_ast(UseStmt)
 def_is_ast(BlockStmt)
 def_is_ast(CondStmt)
 def_is_ast(GotoStmt)
+def_is_ast(ForallStmt)
 def_is_ast(TryStmt)
 def_is_ast(ExternBlockStmt)
 def_is_ast(ModuleSymbol)
@@ -379,6 +382,7 @@ def_to_ast(UseStmt)
 def_to_ast(BlockStmt)
 def_to_ast(CondStmt)
 def_to_ast(GotoStmt)
+def_to_ast(ForallStmt)
 def_to_ast(TryStmt)
 def_to_ast(ExternBlockStmt)
 def_to_ast(Expr)
@@ -543,6 +547,15 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
   case E_TryStmt:                                                       \
     AST_CALL_CHILD(_a, TryStmt, body(), call, __VA_ARGS__);             \
     break;                                                              \
+  case E_ForallStmt:                                                           \
+    AST_CALL_LIST (_a,  ForallStmt, fIter,             call, __VA_ARGS__);     \
+    AST_CALL_STDVEC(((ForallStmt*)_a)->fWith->fiVars, Expr, call, __VA_ARGS__);\
+    AST_CALL_STDVEC(((ForallStmt*)_a)->fWith->riSpecs,Expr, call, __VA_ARGS__);\
+    AST_CALL_CHILD(_a,  ForallStmt, fWith->iterRec,    call, __VA_ARGS__);     \
+    AST_CALL_CHILD(_a,  ForallStmt, fWith->leadIdx,    call, __VA_ARGS__);     \
+    AST_CALL_CHILD(_a,  ForallStmt, fWith->leadIdxCopy,call, __VA_ARGS__);     \
+    AST_CALL_CHILD(_a,  ForallStmt, fVar,              call, __VA_ARGS__);     \
+    break;                                                                     \
   case E_ModuleSymbol:                                                  \
     AST_CALL_CHILD(_a, ModuleSymbol, block, call, __VA_ARGS__);         \
     break;                                                              \

--- a/compiler/include/build.h
+++ b/compiler/include/build.h
@@ -85,12 +85,17 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
 BlockStmt* buildGotoStmt(GotoTag tag, const char* name);
 BlockStmt* buildPrimitiveStmt(PrimitiveTag tag, Expr* e1 = NULL, Expr* e2 = NULL);
 CallExpr* zipToTuple(CallExpr* zipExpr);
-BlockStmt* buildForallLoopStmt(Expr* indices,
+BlockStmt* buildForallLoopStmtOld(Expr* indices,
                                Expr* iterator,
                                ForallIntents* forall_intents,
                                BlockStmt* body,
                                bool zippered = false,
                                VarSymbol* useThisGlobalOp = NULL);
+BlockStmt* buildForallLoopStmt(Expr* indices,
+                               Expr* iterator,
+                               ForallIntents* forall_intents,
+                               BlockStmt* body,
+                               bool zippered = false);
 CallExpr* buildForLoopExpr(Expr* indices,
                            Expr* iterator,
                            Expr* expr,

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -40,6 +40,8 @@ public:
   virtual bool    isStmt()                                           const;
   virtual QualifiedType qualType();
   virtual void    verify();
+          void    verify(AstTag expectedTag);
+          void    verifyParent(const Expr* child, const char* field);
 
   // New interface
   virtual Expr*   copy(SymbolMap* map = NULL, bool internal = false)   = 0;

--- a/compiler/include/foralls.h
+++ b/compiler/include/foralls.h
@@ -54,18 +54,19 @@ public:
   ForallIntents();    // constructor
   ~ForallIntents() {} // destructor: just deallocate the vectors
 
-  int   numVars() { return fiVars.size(); }
-  bool  isReduce(int idx) { return fIntents[idx] == TFI_REDUCE; }
+  int   numVars()         const { return fiVars.size(); }
+  bool  isReduce(int idx) const { return fIntents[idx] == TFI_REDUCE; }
 
   // Support standard AST operations on the enclosing BlockStmt.
   ForallIntents* copy(SymbolMap* map, bool internal);
   bool replaceChildFI(Expr* oldAst, Expr* newAst);
   void removeFI(Expr* parentB);
-  void verifyFI(BlockStmt* parentB);
+  void verifyFI(Expr* parentE) const;
   void acceptFI(AstVisitor* visitor);
 };
 
 bool astUnderFI(const Expr* ast, ForallIntents* fi);
+void lowerForallStmts();
 
 #define for_riSpecs_vector(VAL, FI) \
   for_vector_allowing_0s(Expr, VAL, (FI)->riSpecs)

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -59,9 +59,12 @@ FnSymbol* getTheIteratorFn(CallExpr* call);
 FnSymbol* getTheIteratorFn(Type* icType);
 
 // forall intents
+extern bool beforeLoweringForallStmts;
+Expr* resolveParallelIteratorAndForallIntents(Expr* origExpr, bool inTry);
 void implementForallIntents1(DefExpr* defChplIter);
 void implementForallIntents2(CallExpr* call, CallExpr* origToLeaderCall);
 void implementForallIntents2wrapper(CallExpr* call, CallExpr* origToLeaderCall);
+void implementForallIntentsNew(ForallStmt* fs, CallExpr* parCall);
 void stashPristineCopyOfLeaderIter(FnSymbol* origLeader, bool ignore_isResolved);
 
 // reduce intents

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -36,19 +36,6 @@
 
 
 //
-// Move the statements in a block out of the block
-//
-static void
-flatten_scopeless_block(BlockStmt* block) {
-  for_alist(stmt, block->body) {
-    stmt->remove();
-    block->insertBefore(stmt);
-  }
-  block->remove();
-}
-
-
-//
 // Moves expressions that are parsed as nested function definitions
 // into their own statement; during parsing, these are embedded in
 // call expressions
@@ -224,7 +211,7 @@ void cleanup() {
 
     if (BlockStmt* block = toBlockStmt(ast1)) {
       if (block->blockTag == BLOCK_SCOPELESS && block->list) {
-        flatten_scopeless_block(block);
+        block->flattenAndRemove();
       }
 
     } else if (CallExpr* call = toCallExpr(ast1)) {

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -992,7 +992,7 @@ buildPromotionWrapper(FnSymbol* fn,
 
   if ((!fn->hasFlag(FLAG_EXTERN) && fn->getReturnSymbol() == gVoid) ||
       (fn->hasFlag(FLAG_EXTERN) && fn->retType == dtVoid)) {
-      wrapper->insertAtTail(new BlockStmt(buildForallLoopStmt(indices, iterator, /*byref_vars=*/ NULL, new BlockStmt(actualCall), zippered)));
+      wrapper->insertAtTail(new BlockStmt(buildForallLoopStmtOld(indices, iterator, /*byref_vars=*/ NULL, new BlockStmt(actualCall), zippered)));
   } else {
     wrapper->addFlag(FLAG_ITERATOR_FN);
     wrapper->removeFlag(FLAG_INLINE);

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -229,7 +229,13 @@ class SparseBlockDom: BaseSparseDomImpl {
       yield i;
   }
 
-  iter these(param tag: iterKind) where tag == iterKind.standalone {
+  iter these(param tag: iterKind) where tag == iterKind.standalone &&
+    // Ensure it is legal to invoke the standalone iterator
+    // on locDom.mySparseBlock below.
+    __primitive("method call resolves",
+                locDoms[createTuple(rank,int,0)].mySparseBlock._value,
+                "these", tag)
+  {
     coforall locDom in locDoms {
       on locDom {
         for i in locDom.mySparseBlock._value.these(tag) {
@@ -367,7 +373,13 @@ class SparseBlockArr: BaseSparseArr {
     }
   }
 
-  iter these(param tag: iterKind) ref where tag == iterKind.standalone {
+  iter these(param tag: iterKind) ref where tag == iterKind.standalone &&
+    // Ensure it is legal to invoke the standalone iterator
+    // on locA.myElems below.
+    __primitive("method call resolves",
+                locArr[locArrDom.low].myElems._value,
+                "these", tag)
+   {
     coforall locA in locArr do on locArr {
       // forward to sparse standalone iterator
       for i in locA.myElems._value.these(tag) {

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -36,6 +36,33 @@
   make it available.
  */
 module ChapelIteratorSupport {
+
+// start vass
+
+  // cf these() for _array and _domain
+
+  pragma "no doc"
+  inline proc _domain.these(param tag)
+    where tag == iterKind.follower
+      return _value.these(tag);
+
+  pragma "no doc"
+  inline proc _domain.these(param tag, followThis)
+    where tag == iterKind.follower
+      return _value.these(tag, followThis);
+
+  pragma "no doc"
+  inline proc _array.these(param tag)
+    where tag == iterKind.follower
+      return _value.these(tag);
+
+  pragma "no doc"
+  inline proc _array.these(param tag, followThis)
+    where tag == iterKind.follower
+      return _value.these(tag, followThis);
+
+// end vass
+
   //
   // module support for iterators
   //

--- a/modules/minimal/internal/ChapelBase.chpl
+++ b/modules/minimal/internal/ChapelBase.chpl
@@ -36,4 +36,509 @@ module ChapelBase {
   pragma "unalias fn"
   inline proc chpl__unalias(ref x) { }
 
+/////////////////////////////////////////////////////////////////////////////
+// integers
+
+  proc _defaultOf(type it) where it == int return 0;
+  proc =(ref a, b) { __primitive("=", a, b); }
+
+/////////////////////////////////////////////////////////////////////////////
+// string support
+
+  record string {}
+  proc string.string(args...) { }
+
+  pragma "donor fn"
+  pragma "auto copy fn"
+  pragma "no doc"
+  proc chpl__autoCopy(s: string) return s;
+  pragma "auto destroy fn"
+  proc chpl__autoDestroy(s: string) { }
+
+  pragma "data class"
+  pragma "no object"
+  pragma "no default functions"
+  pragma "no wide class"
+  pragma "c_ptr class"
+  class c_ptr {
+    /* The type that this pointer points to */
+    type eltType;
+    /* Retrieve the i'th element (zero based) from a pointer to an array.
+      Does the equivalent of ptr[i] in C.
+    */
+    inline proc this(i: integral) ref {
+      return __primitive("array_get", this, i);
+    }
+    /* Get element pointed to directly by this pointer. If the pointer
+      refers to an array, this will return ptr[0].
+    */
+    inline proc deref() ref {
+      return __primitive("array_get", this, 0);
+    }
+  }
+
+  inline proc _cast(type t, arg) return __primitive("cast", t, arg);
+
+/////////////////////////////////////////////////////////////////////////////
+// iterator support
+
+  pragma "allocator"
+  pragma "locale model alloc"
+  extern proc chpl_here_alloc(size:int, md:int(16)): c_void_ptr;
+
+  pragma "locale model free"
+  extern proc chpl_here_free(ptr:c_void_ptr): void;
+
+  pragma "no doc"
+  pragma "allow ref" // needs to to return tuples with refs
+  proc iteratorIndex(ic: _iteratorClass) {
+    ic.advance();
+    return ic.getValue();
+  }
+
+  pragma "no doc"
+  pragma "expand tuples with values"  // needs to return tuples with refs
+  proc iteratorIndex(t: _tuple) {
+    pragma "expand tuples with values"
+    proc iteratorIndexHelp(t: _tuple, param dim: int) {
+      if dim == t.size then
+        return _build_tuple_always_allow_ref(iteratorIndex(t(dim)));
+      else
+        return _build_tuple_always_allow_ref(iteratorIndex(t(dim)),
+                                             (...iteratorIndexHelp(t, dim+1)));
+    }
+
+    return iteratorIndexHelp(t, 1);
+  }
+
+  pragma "donor fn"
+  pragma "auto copy fn"
+  inline proc chpl__autoCopy(ir: _iteratorRecord) {
+    // body modified during call destructors pass
+    return ir;
+  }
+  pragma "auto destroy fn"
+  inline proc chpl__autoDestroy(ir: _iteratorRecord) {
+    // body inserted during call destructors pass
+  }
+  pragma "unalias fn"
+  inline proc chpl__unalias(const ref x:_iteratorRecord) { }
+
+  inline proc _freeIterator(ic: _iteratorClass) {
+    chpl_here_free(__primitive("cast_to_void_star", ic));
+  }
+
+  inline proc _freeIterator(x: _tuple) {
+    _freeIterator(x(1));
+    _freeIterator(x(2));
+  }
+
+// for parallel iterators, forall loops
+
+  enum iterKind {leader, follower, standalone};
+  inline proc ==(param a, param b) param return __primitive("==", a, b);
+
+  // for yielding shadow variables
+  pragma "tuple" record _tuple {
+    param size : int;
+  }
+
+  // tuple value (refs)
+  pragma "build tuple"
+  inline proc _build_tuple(x...) {
+      return x;
+  }
+
+  // tuple value allowing refs (ref actuals)
+  pragma "allow ref" 
+  pragma "build tuple"
+  inline proc _build_tuple_always_allow_ref(x...)
+    return x;
+
+  // Catch-all initCopy implementation:
+  pragma "compiler generated"
+  pragma "init copy fn"
+  inline proc chpl__initCopy(x) return x;
+
+  pragma "compiler generated"
+  pragma "donor fn"
+  pragma "auto copy fn"
+  inline proc chpl__autoCopy(x) return chpl__initCopy(x);
+
+
+  pragma "compiler generated"
+  pragma "auto destroy fn"
+  inline proc chpl__autoDestroy(x: ?t) {
+    __primitive("call destructor", x);
+  }
+
+  inline proc _getIterator(x) {
+    return _getIterator(x.these());
+  }
+
+  inline proc _getIterator(ic: _iteratorClass)
+    return ic;
+
+  proc _getIterator(type t) {
+    return _getIterator(t.these());
+  }
+
+  inline proc _getIteratorZip(x) {
+    return _getIterator(x);
+  }
+
+  inline proc _getIteratorZip(type t) {
+    return _getIterator(t);
+  }
+
+  inline proc _getIteratorZip(x: _tuple) {
+    inline proc _getIteratorZipInternal(x: _tuple, param dim: int) {
+      if dim == x.size then
+        return (_getIterator(x(dim)),);
+      else
+        return (_getIterator(x(dim)), (..._getIteratorZipInternal(x, dim+1)));
+    }
+    if x.size == 1 then
+      return _getIterator(x(1));
+    else
+      return _getIteratorZipInternal(x, 1);
+  }
+
+
+/*
+  // vass: is this one needed?
+  pragma "auto destroy fn"
+  inline proc chpl__autoDestroy(ir: _iteratorRecord) {
+    // body inserted during call destructors pass
+  }
+*/
+
+  proc chpl__staticFastFollowCheck(x) param {
+/*
+    pragma "no copy" const lead = x;
+    if isDomain(lead) || isArray(lead) then
+      return chpl__staticFastFollowCheck(x, lead);
+    else
+      return false;
+*/
+    return true;
+  }
+
+  proc chpl__staticFastFollowCheckZip(x: _tuple) param {
+/*
+    pragma "no copy" const lead = x(1);
+    if isDomain(lead) || isArray(lead) then
+      return chpl__staticFastFollowCheckZip(x, lead);
+    else
+*/
+      return false;
+  }
+
+  proc chpl__dynamicFastFollowCheck(x) {
+    return true;
+  }
+
+/////////////////////////////////
+  pragma "no implicit copy"
+  inline proc _toFollower(iterator: _iteratorClass, leaderIndex)
+    return chpl__autoCopy(__primitive("to follower", iterator, leaderIndex));
+
+  inline proc _toFollower(ir: _iteratorRecord, leaderIndex) {
+    pragma "no copy" var ic = _getIterator(ir);
+    pragma "no copy" var follower = _toFollower(ic, leaderIndex);
+    _freeIterator(ic);
+    return follower;
+  }
+
+  inline proc _toFollower(x, leaderIndex) {
+    return _toFollower(x.these(), leaderIndex);
+  }
+
+  inline proc _toFollowerZip(x, leaderIndex) {
+    return _toFollower(x, leaderIndex);
+  }
+
+  inline proc _toFollowerZip(x: _tuple, leaderIndex) {
+    return _toFollowerZipInternal(x, leaderIndex, 1);
+  }
+
+  inline proc _toFollowerZipInternal(x: _tuple, leaderIndex, param dim: int) {
+    if dim == x.size then
+      return (_toFollower(x(dim), leaderIndex),);
+    else
+      return (_toFollower(x(dim), leaderIndex),
+              (..._toFollowerZipInternal(x, leaderIndex, dim+1)));
+  }
+
+  // for fast followers et al
+  inline proc _cond_test(x) return x != 0;
+  inline proc _cond_test(x:bool) return x;
+  inline proc _cond_test(param x:bool) param return x;
+  inline proc +(param x, param y) param return __primitive("+", x, y);
+
+/////////////////////////////////
+  pragma "no implicit copy"
+  inline proc _toFastFollower(iterator: _iteratorClass, leaderIndex, fast: bool) {
+    return chpl__autoCopy(__primitive("to follower", iterator, leaderIndex, true));
+  }
+
+  inline proc _toFastFollower(ir: _iteratorRecord, leaderIndex, fast: bool) {
+    pragma "no copy" var ic = _getIterator(ir);
+    pragma "no copy" var follower = _toFastFollower(ic, leaderIndex, fast=true);
+    _freeIterator(ic);
+    return follower;
+  }
+
+  inline proc _toFastFollower(x, leaderIndex) {
+    if chpl__staticFastFollowCheck(x) then
+      return _toFastFollower(_getIterator(x), leaderIndex, fast=true);
+    else
+      return _toFollower(_getIterator(x), leaderIndex);
+  }
+
+  inline proc _toFastFollowerZip(x, leaderIndex) {
+    return _toFastFollower(x, leaderIndex);
+  }
+
+  inline proc _toFastFollowerZip(x: _tuple, leaderIndex) {
+    return _toFastFollowerZip(x, leaderIndex, 1);
+  }
+
+  inline proc _toFastFollowerZip(x: _tuple, leaderIndex, param dim: int) {
+    if dim == x.size-1 then
+      return (_toFastFollowerZip(x(dim), leaderIndex),
+              _toFastFollowerZip(x(dim+1), leaderIndex));
+    else
+      return (_toFastFollowerZip(x(dim), leaderIndex),
+              (..._toFastFollowerZip(x, leaderIndex, dim+1)));
+  }
+
+/////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////
+// task constructs
+
+  //
+  // data structures for naive implementation of end used for
+  // sync statements and for joining coforall and cobegin tasks
+  //
+
+//  config param useAtomicTaskCnt = true; // was: CHPL_NETWORK_ATOMICS!="none";
+
+  pragma "end count"
+  pragma "no default functions"
+  class _EndCount {
+    type iType;
+    type taskType;
+    var i: iType,
+        taskCnt: taskType,
+        taskList: c_void_ptr = _defaultOf(c_void_ptr);
+  }
+
+  // This function is called once by the initiating task.  No on
+  // statement needed, because the task should be running on the same
+  // locale as the sync/coforall/cobegin was initiated on and thus the
+  // same locale on which the object is allocated.
+  //
+  // TODO: 'taskCnt' can sometimes be local even if 'i' has to be remote.
+  // It is currently believed that only a remote-begin will want a network
+  // atomic 'taskCnt'. There should be a separate argument to control the type
+  // of 'taskCnt'.
+  pragma "dont disable remote value forwarding"
+  inline proc _endCountAlloc(param forceLocalTypes : bool) {
+    return new _EndCount(int,int); // avoid atomics
+/*
+    type taskCntType = if !forceLocalTypes && useAtomicTaskCnt then atomic int
+                                           else int;
+    if forceLocalTypes {
+      return new _EndCount(chpl__processorAtomicType(int), taskCntType);
+    } else {
+      return new _EndCount(chpl__atomicType(int), taskCntType);
+    }
+*/
+  }
+
+  // Compiler looks for this variable to determine the return type of
+  // the "get end count" primitive.
+  type _remoteEndCountType = _endCountAlloc(false).type;
+
+  // This function is called once by the initiating task.  As above, no
+  // on statement needed.
+  pragma "dont disable remote value forwarding"
+  inline proc _endCountFree(e: _EndCount) {
+    delete e;
+  }
+
+  // This function is called by the initiating task once for each new
+  // task *before* any of the tasks are started.  As above, no on
+  // statement needed.
+  pragma "dont disable remote value forwarding"
+  pragma "no remote memory fence"
+  proc _upEndCount(e: _EndCount, param countRunningTasks=true) {
+/*
+    if isAtomic(e.taskCnt) {
+      e.i.add(1, memory_order_release);
+      e.taskCnt.add(1, memory_order_release);
+    } else {
+      // note that this on statement does not have the usual
+      // remote memory fence because of pragma "no remote memory fence"
+      // above. So we do an acquire fence before it.
+      chpl_rmem_consist_fence(memory_order_release);
+      on e {
+        e.i.add(1, memory_order_release);
+        e.taskCnt += 1;
+      }
+    }
+    if countRunningTasks {
+      here.runningTaskCntAdd(1);  // decrement is in _waitEndCount()
+    }
+*/
+  }
+
+  // This function is called once by each newly initiated task.  No on
+  // statement is needed because the call to sub() will do a remote
+  // fork (on) if needed.
+  pragma "dont disable remote value forwarding"
+  proc _downEndCount(e: _EndCount) {
+/*
+    e.i.sub(1, memory_order_release);
+*/
+  }
+
+  // This function is called once by the initiating task.  As above, no
+  // on statement needed.
+  pragma "dont disable remote value forwarding"
+  proc _waitEndCount(e: _EndCount, param countRunningTasks=true) {
+/*
+    // See if we can help with any of the started tasks
+    chpl_taskListExecute(e.taskList);
+
+    // Remove the task that will just be waiting/yielding in the following
+    // waitFor() from the running task count to let others do real work. It is
+    // re-added after the waitFor().
+    here.runningTaskCntSub(1);
+
+    // Wait for all tasks to finish
+    e.i.waitFor(0, memory_order_acquire);
+
+    if countRunningTasks {
+      const taskDec = if isAtomic(e.taskCnt) then e.taskCnt.read() else e.taskCnt;
+      // taskDec-1 to adjust for the task that was waiting for others to finish
+      here.runningTaskCntSub(taskDec-1);  // increment is in _upEndCount()
+    } else {
+      // re-add the task that was waiting for others to finish
+      here.runningTaskCntAdd(1);
+    }
+*/
+  }
+
+  proc _upEndCount(param countRunningTasks=true) {
+    var e = __primitive("get end count");
+    _upEndCount(e, countRunningTasks);
+  }
+
+  proc _downEndCount() {
+    var e = __primitive("get end count");
+    _downEndCount(e);
+  }
+
+  proc _waitEndCount(param countRunningTasks=true) {
+    var e = __primitive("get end count");
+    _waitEndCount(e, countRunningTasks);
+  }
+
+  ///////////
+
+  pragma "dont disable remote value forwarding"
+  inline proc _createFieldDefault(type t, init) {
+    pragma "no auto destroy" var x: t;
+    x = init;
+    return x;
+  }
+
+  iter chpl_direct_range_iter(low: int(?w), high: int(w), stride: int(w)) {
+    yield low;
+    yield high;
+/*
+    const r = low..high by stride;
+    for i in r do yield i;
+*/
+  }
+
+  proc _defaultOf(type it) where it == c_void_ptr return __primitive("cast", it, 0);
+
+/////////////////////////////////////////////////////////////////////////////
+// + reductions
+
+  proc chpl__reduceCombine(globalOp, localOp) {
+/*
+    on globalOp {
+      globalOp.lock();
+*/
+      globalOp.combine(localOp);
+/*
+      globalOp.unlock();
+    }
+*/
+  }
+
+  inline proc chpl__cleanupLocalOp(globalOp, localOp) {
+    // should this be part of chpl__reduceCombine ?
+    delete localOp;
+  }
+
+  pragma "ReduceScanOp"
+  class ReduceScanOp {
+    var l: int; // was: atomicbool; // only accessed locally
+
+    proc lock() {
+/*
+      var lockAttempts = 0,
+          maxLockAttempts = (2**10-1);
+      while l.testAndSet() {
+        lockAttempts += 1;
+        if (lockAttempts & maxLockAttempts) == 0 {
+          maxLockAttempts >>= 1;
+          chpl_task_yield();
+        }
+      }
+*/
+    }
+    proc unlock() {
+/*
+      l.clear();
+*/
+    }
+  }
+  
+  class SumReduceScanOp: ReduceScanOp {
+    type eltType;
+    var value: eltType; // was: chpl__sumType(eltType);
+
+    // Rely on the default value of the desired type.
+    // Todo: is this efficient when that is an array?
+    proc identity {
+      var x: eltType; // was: chpl__sumType(eltType);
+      return x;
+    }
+    proc accumulate(x) {
+      value += x;
+    }
+    proc accumulateOntoState(ref state, x) {
+      state += x;
+    }
+    proc combine(x) {
+      value += x.value;
+    }
+    proc generate() return value;
+    proc clone() return new SumReduceScanOp(eltType=eltType);
+  }
+
+  inline proc +=(ref lhs, rhs) {
+    __primitive("+=", lhs, rhs);
+  }
+
+
+/////////////////////////////////////////////////////////////////////////////
+
 }

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -777,15 +777,15 @@ iter glob(pattern: string = "*", param tag: iterKind): string
   use chpl_glob_c_interface;
   var glb : glob_t;
 
-  const err = chpl_glob(pattern:c_string, 0, glb);
+  const err = chpl_glob(pattern.localize().c_str(), 0, glb);
   // TODO: Handle error cases better
   if (err != 0 && err != GLOB_NOMATCH) then
     __primitive("chpl_error", c"unhandled error in glob()");
   const num = chpl_glob_num(glb).safeCast(int);
+  globfree(glb);
+
   forall i in 0..num-1 do
     yield chpl_glob_index(glb, i.safeCast(size_t)): string;
-
-  globfree(glb);
 }
 
 //
@@ -832,6 +832,7 @@ iter glob(pattern: string = "*", followThis, param tag: iterKind): string
   if (err != 0 && err != GLOB_NOMATCH) then
     __primitive("chpl_error", c"unhandled error in glob()");
   const num = chpl_glob_num(glb);
+  globfree(glb);
   if (r.high >= num.safeCast(int)) then
     halt("glob() is being zipped with something too big; it only has ", num, " matches");
   for i in r do
@@ -839,8 +840,6 @@ iter glob(pattern: string = "*", followThis, param tag: iterKind): string
     // safe cast is used here to turn an int into a size_t
     //
     yield chpl_glob_index(glb, i.safeCast(size_t)): string;
-
-  globfree(glb);
 }
 
 

--- a/test/functions/iterators/diten/iteratorNoYield.good
+++ b/test/functions/iterators/diten/iteratorNoYield.good
@@ -1,1 +1,2 @@
-iteratorNoYield.chpl:9: error: illegal use of function that does not return a value: 'itr'
+iteratorNoYield.chpl:9: error: The iterable-expression resolves to a non-iterator function 'itr' when looking for leader iterator
+iteratorNoYield.chpl:6: note: The function 'itr' is declared here

--- a/test/parallel/forall/vass/3types-2-arg-error.good
+++ b/test/parallel/forall/vass/3types-2-arg-error.good
@@ -1,1 +1,2 @@
+3types-2-arg-error.chpl:43: In function 'main':
 3types-2-arg-error.chpl:46: error: for a reduce intent, the 'reduce' keyword must be preceded by the reduction operator or the name of the reduction class with the single optional argument indicating the type of the reduction input


### PR DESCRIPTION
This PR introduces the ForallStmt node - a subclass of Stmt.
These nodes are created in the parser and are lowered away in resolve().
This message is geared towards design review and omits minor details.

RATIONALE
---------

We used to lower forall statements immediately in the parser.
I believe the motivation for doing it that way originally was
to minimize the set of AST constructs for the compiler to deal wtih.

Recently we have been doing more things with forall loops,
such as forall intents. Having forall loops lowered before anything else
forced us to do pattern matching against the AST to access the information
about the forall loops that we need. This was costly in development time
and resulted in fragile compiler code.

Representing a forall loop with a ForallStmt node is a more direct
representation of the program and lets us access more information
about the forall loop easily.

IMPLEMENTATION HIGHLIGHTS - WORKFLOW
------------------------------------

The handling of a forall loop still follows most of the ingredients
of the old buildForallLoopStmt. The modifications are:

* During parsing, very minimal lowering for iterators and
forall intents is made.

* Dispatching to standalone vs. leader/follower is now done
in the compiler during resolution, by resolving direct calls
to iteratorName(tag=standalone) or, if that does not resolve, to
iteratorName(tag=leader). See findStandaloneOrLeader().
(The remainder is done in lowerForallStmts(), see below.)

  Once done with that, I establish the type yielded by the iterator.

  This replaces using tryToken; _toStandalone/_toLeader functions in
internal modules; PRIM_TO_STANDALONE/PRIM_TO_LEADER in the compiler.

  This brought up bugs in some standalone iterators, which used to be
masked by tryToken. In those cases leader/follower were silently chosen
instead of the intended standalone iterators. See below for details.

* Given the traversal order of for_exprs_postorder() / resolveBlockStmt(),
the above resolution of the parallel iterator is done when traversing
the iterable-expression of the forall loop, or the first of them
for a zippered forall. For that, I augmented resolveExpr() with calls to
resolveParallelIteratorAndForallIntents().

* At start of resolveParallelIteratorAndForallIntents() the iterable
expression(s) are (almost) what the user actually wrote. Specifically,
if it is a call, then only the subexpressions are normalized; the call
itself is preserved as-is. For that I added a test to insert_call_temps.

This gives us the opportunity to see at resolution what the user wrote.
In particular, if it is a call to an iterator, we can modify it to a call
to the corresponding standalone or leader. Otherwise we normalize i.e.
insert a call temp for that expression at this time and invoke these() on it.

This replaces the _getIterator functions in internal modules.
(The functions are still there because they are used in other contexts.)
I also needed to have the compiler redirect to _value when
the iterable expression is an array/domain. Before we used to do so
using these methods in _array/_domain:

    inline proc these() {
      return _value.these();
    }

* I also needed to prevent normalization of the reduce-intent
specification for reduce intents, see restoreRiSpecCall().
This is to support reduce intents of the form ReduceOp(InputType)
for specifying the input type of the reduction explicitly, see #4574.

* The follower loops are unaffected by this PR, allowing it to
be smaller in size and scope. Thankfully the follower loops are
orthogonal and can be dealt with separately. The key complexity
factor is the static+dynamic selection between fast and regular
followers. For that, we still have _toFollwer/_toFastFollower
and PRIM_TO_FOLLOWER (which can also do "to fast follower",
depending on the context). Zippering needs to be dealt with, too.

* The remainder of lowering of ForallStmt is done in lowerForallStmts().
This is in resolve() after most code has been "resolved"
i.e. after resolveUses(mainModule) and resolveFns(chpl_gen_main).
This sets up most of the iterator handling that used to be done
in buildForallLoopStmt during parsing.

  I lower ForallStmt completely and remove them from AST so that
downstream passes are unaffected. It makes sense to lower them later
in the compiler when we switch to a more high-level representation of
iterators in general, through resolution.

* resolveParallelIteratorAndForallIntents() invokes
implementForallIntentsNew(), which is a combination of
implementForallIntents1() and implementForallIntents2()
with simplifications afforded by a more direct representation.

IMPLEMENTATION HIGHLIGHTS - DATA STRUCTURES
-------------------------------------------

The ForallStmt node has fields, most notably, for:
- index variable(s) (fVar),
- iterable expression(s) (fIter),
- loop body (fBody).

* A big design question is where to place the DefExpr(s) for
the loop index variable(s). It would be great to store
them in a dedicated list, analogously to FnSymbol::formals.
I did not take it on. Instead I went for a simpler solution.

  I place them in a BlockStmt referenced by fVar. In that same
BlockStmt after those DefExprs I also place the BlockStmt with the
body of the original forall loop, referenced by fBody. That way
scoping works out.

  Currently there is always just one index variable whose DefExpr goes
into fVar initially. Having an enclosing BlockStmt ends up being
convenient because I can place scaffolding related to forall intents
into that same BlockStmt between the index var's DefExpr and the fBody.

  If the user program has a tuple of index variables,
those are detupled within fBody from the master index var.

  Todo: given the current design, it does not make sense to have
a separate field for fBody. I will probably replace that field
with an accessor method that fetches the last stmt of fVar.
Probably rename fVar as well - what would be a good name for it?

* For now ForallStmt reuses the existing ForallIntents class
to represent forall intents. (It is not an AST node.)
This is to reduce the scope of this change. Ideally
we want to switch to a new AST node. I list this
under Future Work below.

MODULE CHANGES
--------------

Fixed a couple of standalone iterators. Those errors used to be
masked due to tryToken as discussed above.

I had to use __primitive("method call resolves") in one standalone
iterator that redirects to another one so it is available only when
the redirectee is available. Currently canResolve() does not work
there because it loses param-ness of the 'tag' argument.

P.S. The change to modules/minimal/internal/ChapelBase.chpl
is not needed and is here unintentionally, I will revert it.

FUTURE WORK
-----------

* Convert the remaining cases where forall loops are created
to ForallStmt or other dedicated representation, e.g.:

  - forall expressions
  - promoted expressions
  - reduce expressions

* In propagateExtraLeaderArgs(), use a dedicated data structure
to indicate intents on individual variables. This is different
than the following item because of its localized use and
the need to carry more information.

* Switch the representation of forall intents to a new AST node.
This will blend better with our current representation and
traversals.

* When the parallel iterator is specialized for particular use/
forall intents, it is extended to yield shadow variables. We
need to switch to yielding those variables that correspond to
in intents by ref. Currently they are yielded by value, making
them iteration-private rather than task-private how they are
supposed to be. My only concern for this change is whether
performance will be affected.

* Work out user-defined reduction interface, as it will affect
how reduce intents are lowered.

* Implement partial reductions.
