### PR TITLE
Update the formals for init methods to be like other methods

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1247,12 +1247,15 @@ static void buildDefaultOfFunction(AggregateType* ct) {
       fn->insertAtTail(new CallExpr(PRIM_RETURN, arg));
 
     } else if (ct->initializerStyle == DEFINES_INITIALIZER) {
-      VarSymbol* meme = newTemp("meme_tmp", ct);
-      CallExpr*  call = new CallExpr("init");
+      VarSymbol* _mt   = newTemp("_mt",   dtMethodToken);
+      VarSymbol* _this = newTemp("_this", ct);
+      CallExpr*  call  = new CallExpr("init");
 
-      fn->insertAtHead(new DefExpr(meme));
+      fn->insertAtHead(new DefExpr(_mt));
+      fn->insertAtHead(new DefExpr(_this));
 
-      call->insertAtTail(new NamedExpr("meme", new SymExpr(meme)));
+      call->insertAtTail(new SymExpr(_mt));
+      call->insertAtTail(new SymExpr(_this));
 
       fn->insertAtTail(new CallExpr(PRIM_RETURN, call));
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -25,8 +25,8 @@
 #endif
 
 #include "resolution.h"
+
 #include "astutil.h"
-#include "stlUtil.h"
 #include "build.h"
 #include "caches.h"
 #include "callInfo.h"
@@ -40,19 +40,21 @@
 #include "passes.h"
 #include "resolveIntents.h"
 #include "scopeResolve.h"
+#include "stlUtil.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
 #include "TryStmt.h"
-#include "WhileStmt.h"
-#include "../ifa/prim_data.h"
 #include "view.h"
+#include "WhileStmt.h"
+
+#include "../ifa/prim_data.h"
 
 #include <inttypes.h>
 #include <map>
 #include <sstream>
-#include <vector>
 #include <string>
+#include <vector>
 
 // Allow disambiguation tracing to be controlled by the command-line option
 // --explain-verbose.
@@ -5142,13 +5144,16 @@ static void resolveMove(CallExpr* call) {
 }
 
 
-// Some new expressions are converted in normalize().  For example, a call to a
-// type function is resolved at this point.
-// The syntax supports calling the result of a type function as a constructor,
-// but this is not fully implemented.
-static void
-resolveNew(CallExpr* call)
-{
+/************************************* | **************************************
+*                                                                             *
+* Some new expressions are converted in normalize().  For example, a call to  *
+* a type function is resolved at this point.                                  *
+* The syntax supports calling the result of a type function as a constructor, *
+* but this is not fully implemented.                                          *
+*                                                                             *
+************************************** | *************************************/
+
+static void resolveNew(CallExpr* call) {
   // This is a 'new' primitive
   // we expect the 1st argument to be a type
   //   or a partial call to get the type
@@ -5165,9 +5170,11 @@ resolveNew(CallExpr* call)
   if (CallExpr* subCall = toCallExpr(call->get(1))) {
     // Handle e.g. 'new' (call (partial) R2 _mt this) call_tmp
     // which comes up with nested classes (e.g. R2 is a nested class type)
-    if (SymExpr* se = toSymExpr(subCall->baseExpr))
-      if (subCall->partialTag)
+    if (SymExpr* se = toSymExpr(subCall->baseExpr)) {
+      if (subCall->partialTag) {
         toReplace = se;
+      }
+    }
   } else if (SymExpr* se = toSymExpr(call->get(1))) {
     // Handle e.g. 'new' C arg
     toReplace = se;
@@ -5184,8 +5191,11 @@ resolveNew(CallExpr* call)
         if (ct->initializerStyle == DEFINES_INITIALIZER) {
           toReplace->replace(new UnresolvedSymExpr("init"));
           initCall = true;
+
         } else {
-          toReplace->replace(new UnresolvedSymExpr(ct->defaultInitializer->name));
+          FnSymbol* ctInit = ct->defaultInitializer;
+
+          toReplace->replace(new UnresolvedSymExpr(ctInit->name));
         }
       }
     }
@@ -5193,72 +5203,86 @@ resolveNew(CallExpr* call)
     // 2: move the 1st argument into the baseExpr
     // 3: make it a normal call and not a PRIM_NEW
     Expr* arg = call->get(1);
+
     arg->remove();
+
     call->primitive = NULL;
-    call->baseExpr = arg;
+    call->baseExpr  = arg;
+
     parent_insert_help(call, call->baseExpr);
 
     if (initCall) {
       // 4: insert the allocation for the instance and pass that in as an
       // argument if we're making a call to an initializer
-      Type* typeToNew = toReplace->symbol()->typeInfo();
-      VarSymbol* new_temp = newTemp("new_temp", typeToNew);
+      Type*      typeToNew = toReplace->symbol()->typeInfo();
+      VarSymbol* newTmp    = newTemp("new_temp", typeToNew);
+
       if (typeToNew->symbol->hasFlag(FLAG_GENERIC)) {
-        USR_FATAL(call, "Sorry, new style initializers don't work with generics yet.  Stay tuned!");
+        USR_FATAL(call,
+                  "Sorry, new style initializers don't work with "
+                  "generics yet.  Stay tuned!");
       }
-      DefExpr* def = new DefExpr(new_temp);
-      Expr* insertBeforeMe = ((!isBlockStmt(call->parentExpr)) ?
-                              call->parentExpr : call);
+
+      DefExpr* def            = new DefExpr(newTmp);
+      Expr*    insertBeforeMe = NULL;
+
+      if (isBlockStmt(call->parentExpr) == true) {
+        insertBeforeMe = call;
+
+      } else {
+        insertBeforeMe = call->parentExpr;
+      }
+
       insertBeforeMe->insertBefore(def);
+
       resolveExpr(def);
 
       if (!isRecord(typeToNew) && !isUnion(typeToNew)) {
-        BlockStmt* allocCallBlock = new BlockStmt();
+        BlockStmt* allocBlock = new BlockStmt();
+        CallExpr*  allocCall  = callChplHereAlloc(typeToNew);
 
-        CallExpr* innerCall = callChplHereAlloc(typeToNew);
-        CallExpr* allocCall = new CallExpr(PRIM_MOVE, new_temp,
-                                           innerCall);
-        insertBeforeMe->insertBefore(allocCallBlock);
-        allocCallBlock->insertAtTail(allocCall);
+        insertBeforeMe->insertBefore(allocBlock);
 
-        CallExpr* setIdCall = new CallExpr(PRIM_SETCID, new_temp);
-        allocCallBlock->insertAtTail(setIdCall);
-        normalize(allocCallBlock);
-        resolveBlockStmt(allocCallBlock);
+        allocBlock->insertAtTail(new CallExpr(PRIM_MOVE,   newTmp, allocCall));
+        allocBlock->insertAtTail(new CallExpr(PRIM_SETCID, newTmp));
+
+        normalize(allocBlock);
+
+        resolveBlockStmt(allocBlock);
       }
-      call->insertAtTail(new NamedExpr("meme", new SymExpr(new_temp)));
+
+      call->insertAtTail(new NamedExpr("meme", new SymExpr(newTmp)));
     }
 
-    // Now finish resolving it, since we are after all in
-    // resolveNew.
     resolveExpr(call);
   }
 
   // Do some error checking
-  if (FnSymbol* fn = call->isResolved())
-  {
+  if (FnSymbol* fn = call->isResolved()) {
     // If the function is a constructor, OK
-    if (fn->hasFlag(FLAG_CONSTRUCTOR))
+    if (fn->hasFlag(FLAG_CONSTRUCTOR)) {
       return;
-    else // otherwise, issue an error
+
+    } else {
       USR_FATAL(call, "invalid use of 'new' on %s", fn->name);
-  }
+    }
 
-  if (call->get(1)) {
-    Expr* arg = call->get(1);
-
-    if (UnresolvedSymExpr* urse = toUnresolvedSymExpr(arg)) {
-      USR_FATAL(call, "invalid use of 'new' on %s", urse->unresolved);
-      return;
-    } else if (CallExpr* subCall = toCallExpr(arg)) {
-      if (FnSymbol* fn = subCall->isResolved()) {
-        USR_FATAL(call, "invalid use of 'new' on %s", fn->name);
+  } else {
+    if (Expr* arg = call->get(1)) {
+      if (UnresolvedSymExpr* urse = toUnresolvedSymExpr(arg)) {
+        USR_FATAL(call, "invalid use of 'new' on %s", urse->unresolved);
         return;
+
+      } else if (CallExpr* subCall = toCallExpr(arg)) {
+        if (FnSymbol* fn = subCall->isResolved()) {
+          USR_FATAL(call, "invalid use of 'new' on %s", fn->name);
+          return;
+        }
       }
     }
-  }
 
-  USR_FATAL(call, "invalid use of 'new'");
+    USR_FATAL(call, "invalid use of 'new'");
+  }
 }
 
 static void
@@ -8364,8 +8388,11 @@ resolveFns(FnSymbol* fn) {
   // actually execute the body of the loop that invoked the iterator. Note that
   // for nested loops with a single yield, only the inner most loop is marked.
   //
-  if (isFollowerIterator(fn) || isStandaloneIterator(fn) || isVecIterator(fn)) {
+  if (isFollowerIterator(fn)   ||
+      isStandaloneIterator(fn) ||
+      isVecIterator(fn)) {
     std::vector<CallExpr*> callExprs;
+
     collectCallExprs(fn->body, callExprs);
 
     for_vector(CallExpr, call, callExprs) {
@@ -8412,9 +8439,13 @@ resolveFns(FnSymbol* fn) {
 
   if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
     AggregateType* ct = toAggregateType(fn->retType);
-    if (!ct)
+
+    if (!ct) {
       INT_FATAL(fn, "Constructor has no class type");
+    }
+
     setScalarPromotionType(ct);
+
     if (!developer) {
       fixTypeNames(ct);
     }
@@ -8427,7 +8458,9 @@ resolveFns(FnSymbol* fn) {
   //
   if (fn->retTag != RET_PARAM) {
     Vec<CallExpr*> casts;
+
     insertCasts(fn->body, fn, casts);
+
     forv_Vec(CallExpr, cast, casts) {
       resolveCallAndCallee(cast, true);
     }
@@ -8440,8 +8473,12 @@ resolveFns(FnSymbol* fn) {
   // Resolve base class type constructors as well.
   if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
     forv_Vec(Type, parent, fn->retType->dispatchParents) {
-      if (toAggregateType(parent) && parent != dtValue && parent != dtObject && parent->defaultTypeConstructor) {
+      if (isAggregateType(parent)        == true     &&
+          parent                         != dtValue  &&
+          parent                         != dtObject &&
+          parent->defaultTypeConstructor != NULL) {
         resolveFormals(parent->defaultTypeConstructor);
+
         if (resolvedFormals.set_in(parent->defaultTypeConstructor)) {
           resolveFns(parent->defaultTypeConstructor);
         }
@@ -8453,6 +8490,7 @@ resolveFns(FnSymbol* fn) {
         if (AggregateType* fct = toAggregateType(field->type)) {
           if (fct->defaultTypeConstructor) {
             resolveFormals(fct->defaultTypeConstructor);
+
             if (resolvedFormals.set_in(fct->defaultTypeConstructor)) {
               resolveFns(fct->defaultTypeConstructor);
             }
@@ -8461,7 +8499,8 @@ resolveFns(FnSymbol* fn) {
       }
     }
 
-    // This instantiates the default constructor for the corresponding type constructor.
+    // This instantiates the default constructor
+    // for  the corresponding type constructor.
     instantiate_default_constructor(fn);
 
     //
@@ -8471,20 +8510,24 @@ resolveFns(FnSymbol* fn) {
       if (!ct->destructor &&
           !ct->symbol->hasFlag(FLAG_REF) &&
           !isTupleContainingOnlyReferences(ct)) {
-        VarSymbol* tmp = newTemp(ct);
-        CallExpr* call = new CallExpr("chpl__deinit", gMethodToken, tmp);
+        BlockStmt* block = new BlockStmt();
+        VarSymbol* tmp   = newTemp(ct);
+        CallExpr*  call  = new CallExpr("chpl__deinit", gMethodToken, tmp);
 
         // In case resolveCall drops other stuff into the tree ahead of the
         // call, we wrap everything in a block for safe removal.
-        BlockStmt* block = new BlockStmt();
+
         block->insertAtHead(call);
 
         fn->insertAtHead(block);
         fn->insertAtHead(new DefExpr(tmp));
+
         resolveCallAndCallee(call);
+
         ct->destructor = call->isResolved();
 
         block->remove();
+
         tmp->defPoint->remove();
       }
     }
@@ -8504,22 +8547,22 @@ resolveFns(FnSymbol* fn) {
   //
   if (fn->hasFlag(FLAG_METHOD) && fn->_this != NULL) {
     Type* thisType = fn->_this->type->getValType();
+    bool  found    = false;
+
     INT_ASSERT(thisType);
     INT_ASSERT(thisType != dtUnknown);
-    // add it to thisType->methods if it's not already there
-    // TODO: consider making Type::methods into a set
-    bool found = false;
+
     forv_Vec(FnSymbol, method, thisType->methods) {
       if (method == fn) {
         found = true;
         break;
       }
     }
-    if (!found)
+
+    if (found == false) {
       thisType->methods.add(fn);
+    }
   }
-
-
 }
 
 

--- a/test/classes/initializers/constAndParamInHeader.future
+++ b/test/classes/initializers/constAndParamInHeader.future
@@ -1,0 +1,3 @@
+bug: Failing to report that a field has been used too early in an
+initializer; in fact as a default value for a formal for an init
+method

--- a/test/classes/initializers/error-initializer-return-type.future
+++ b/test/classes/initializers/error-initializer-return-type.future
@@ -1,0 +1,6 @@
+bug: Fails to report an error that an init method is returning a value
+
+Currently the implementation of init methods return a value and the error
+does not get generated.  Work is underway to make the implementation match
+the specification.  Unclear if the error message will be acceptable once
+that happens.


### PR DESCRIPTION
The first implementation of init methods largely followed the specialized code paths for constructors.
In particular the methodToken is removed and a "meme" argument is inserted.

This PR updates those instances of this issue that are currently being tested.  In future PRs
I will be looking through the code base for any other paths that still do this.

These changes resulted in two regressions under classes/initializers.  In order to make progress
these have been, temporarily, converted to futures.  One of these exposes an issue that was
already planned for a next pass.  The other issue needs a little more thought.

This PR has been organized as a handful of well defined commits that may simplify a review.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Paratested on linux64-single-locale and linux64-gasnet

