### PR TITLE
File a future for type methods with default arguments

### DIFF
--- a/test/classes/diten/typeMethodDefaultArg.bad
+++ b/test/classes/diten/typeMethodDefaultArg.bad
@@ -1,0 +1,1 @@
+typeMethodDefaultArg.chpl:1: error: illegal assignment of type to value

--- a/test/classes/diten/typeMethodDefaultArg.chpl
+++ b/test/classes/diten/typeMethodDefaultArg.chpl
@@ -1,0 +1,7 @@
+record R {
+  proc type method(a: int = 1) {
+    writeln("Called method");
+  }
+}
+
+R.method();

--- a/test/classes/diten/typeMethodDefaultArg.future
+++ b/test/classes/diten/typeMethodDefaultArg.future
@@ -1,0 +1,7 @@
+bug: type method with default argument causes compiler error
+
+A type method with a default argument causes an "illegal assignment of type
+to value" error. The error is coming from a wrapper for the method, where it
+assigns "this" to a temp.  Since it is a type method, "this" is a type.
+
+Calling the method with an argument avoids the wrapper and succeeds.

--- a/test/classes/diten/typeMethodDefaultArg.good
+++ b/test/classes/diten/typeMethodDefaultArg.good
@@ -1,0 +1,1 @@
+Called method


### PR DESCRIPTION
A type method with a default argument causes a cryptic compiler error.  The
compiler generated wrapper function assigns "this" to a temp.  Since it is a
type method, "this" is a type, but apparently the temp is not. The error is
"illegal assignment of type to value".