### PR TITLE
Fix indentation in concreteIntentForArg

### DIFF
--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -140,12 +140,13 @@ IntentTag concreteIntentForArg(ArgSymbol* arg) {
 void resolveArgIntent(ArgSymbol* arg) {
   if (!resolved) {
     if (arg->type == dtMethodToken ||
-      arg->type == dtTypeDefaultToken ||
-      arg->type == dtVoid ||
-      arg->type == dtUnknown ||
-      arg->hasFlag(FLAG_TYPE_VARIABLE) ||
-      arg->hasFlag(FLAG_PARAM))
+        arg->type == dtTypeDefaultToken ||
+        arg->type == dtVoid ||
+        arg->type == dtUnknown ||
+        arg->hasFlag(FLAG_TYPE_VARIABLE) ||
+        arg->hasFlag(FLAG_PARAM)) {
       return; // Leave these alone during resolution.
+    }
   }
 
   IntentTag intent = concreteIntentForArg(arg);


### PR DESCRIPTION
A bug in resolution led me to this code. The indentation was bad, so I fixed
it.  Passed full std/ testing