### PR TITLE
Introduce a _new "type method" to wrap every class init method

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -36,9 +36,16 @@ enum InitBody {
   FOUND_BOTH
 };
 
+
+static void     buildClassAllocator(FnSymbol* fn, AggregateType* ct);
 static InitBody getInitCall(FnSymbol* fn);
 static void     phase1Analysis(BlockStmt* body, AggregateType* t);
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 void temporaryInitializerFixup(CallExpr* call) {
   if (UnresolvedSymExpr* usym = toUnresolvedSymExpr(call->baseExpr)) {
@@ -68,11 +75,21 @@ void temporaryInitializerFixup(CallExpr* call) {
   }
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
 void handleInitializerRules(FnSymbol* fn, AggregateType* ct) {
   if (fn->hasFlag(FLAG_NO_PARENS)) {
     USR_FATAL(fn, "an initializer cannot be declared without parentheses");
   } else {
     InitBody bodyStyle = getInitCall(fn);
+
+    if (isClass(ct) == true) {
+      buildClassAllocator(fn, ct);
+    }
 
     if (bodyStyle != DID_NOT_FIND_INIT) {
       phase1Analysis(fn->body, ct);
@@ -560,4 +577,77 @@ bool loopAnalysis(BlockStmt* loop, DefExpr* curField, bool* seenField,
   // encountered
 
   return false;
+}
+
+/************************************* | **************************************
+*                                                                             *
+* Consider                                                                    *
+*                                                                             *
+*   var x = new MyClass(10, 20, 30);                                          *
+*                                                                             *
+* and assume MyClass defines an initializer that accepts 3 integers.          *
+*                                                                             *
+* The goal is to allocate an instance of MyClass on the heap and then invoke  *
+* the appropriate init method on this instance.                               *
+*                                                                             *
+* This is implemented by defining an internal "type method" on MyClass that   *
+* performs the allocation and then invokes the init method on the resulting   *
+* instance.  Note that there is a distinct _new method for every init         *
+* method.                                                                     *
+*                                                                             *
+************************************** | *************************************/
+
+static void buildClassAllocator(FnSymbol* initMethod, AggregateType* ct) {
+  SET_LINENO(ct);
+
+  FnSymbol*  fn          = new FnSymbol("_new");
+  BlockStmt* body        = fn->body;
+  ArgSymbol* type        = new ArgSymbol(INTENT_BLANK, "t", ct);
+  VarSymbol* newInstance = newTemp("instance", ct);
+  CallExpr*  allocCall   = callChplHereAlloc(ct);
+  CallExpr*  initCall    = new CallExpr("init", gMethodToken, newInstance);
+
+  type->addFlag(FLAG_TYPE_VARIABLE);
+
+  fn->addFlag(FLAG_METHOD);
+  fn->addFlag(FLAG_COMPILER_GENERATED);
+
+  fn->retExprType = new BlockStmt(new SymExpr(ct->symbol), BLOCK_SCOPELESS);
+
+  // Add the formal that provides the type for the type method
+  fn->insertFormalAtTail(type);
+
+  //
+  // Walk the formals to the init method
+  // Ignore _mt and _this
+  //   1) add a corresponding formal to the new type method
+  //   2) add that formal to the call to "init"
+  //
+  int count = 1;
+
+  for_formals(formal, initMethod) {
+    // Ignore _mt and this
+    if (count >= 3) {
+      ArgSymbol* arg = formal->copy();
+
+      fn->insertFormalAtTail(arg);
+      initCall->insertAtTail(new SymExpr(arg));
+    }
+
+    count = count + 1;
+  }
+
+  // Construct the body
+  body->insertAtTail(new DefExpr(newInstance));
+
+  body->insertAtTail(new CallExpr(PRIM_MOVE,   newInstance, allocCall));
+  body->insertAtTail(new CallExpr(PRIM_SETCID, newInstance));
+
+  body->insertAtTail(initCall);
+
+  body->insertAtTail(new CallExpr(PRIM_RETURN, newInstance));
+
+
+  // Insert the definition in to the tree
+  ct->symbol->defPoint->insertBefore(new DefExpr(fn));
 }

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -89,6 +89,7 @@ void handleInitializerRules(FnSymbol* fn, AggregateType* ct) {
 
     if (isClass(ct) == true) {
       buildClassAllocator(fn, ct);
+      fn->addFlag(FLAG_INLINE);
     }
 
     if (bodyStyle != DID_NOT_FIND_INIT) {

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -136,7 +136,13 @@ void handleInitializerRules(FnSymbol* fn, AggregateType* ct) {
 
     // Insert phase 2 analysis here
 
-    fn->insertAtTail(new CallExpr(PRIM_RETURN, new SymExpr(fn->_this)));
+    if (isClass(ct) == false) {
+      fn->insertAtTail(new CallExpr(PRIM_RETURN, new SymExpr(fn->_this)));
+    } else {
+      Symbol* voidType = dtVoid->symbol;
+
+      fn->retExprType = new BlockStmt(new SymExpr(voidType), BLOCK_SCOPELESS);
+    }
   }
 }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1866,16 +1866,11 @@ static void updateInitMethod(FnSymbol* fn) {
   Symbol* _this = fn->getFormal(2);
 
   if (AggregateType* ct = toAggregateType(_this->type)) {
-    if (fn->hasFlag(FLAG_NO_PARENS)) {
-      USR_FATAL(fn, "an initializer cannot be declared without parentheses");
-    }
-
     handleInitializerRules(fn, ct);
-
-    fn->insertAtTail(new CallExpr(PRIM_RETURN, new SymExpr(fn->_this)));
 
   } else if (_this->type == dtUnknown) {
     INT_FATAL(fn, "'this' argument has unknown type");
+
   } else {
     INT_FATAL(fn, "initializer on non-class type");
   }

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -180,33 +180,55 @@ printErrorHeader(BaseAST* ast) {
   if (!err_print) {
     if (Expr* expr = toExpr(ast)) {
       Symbol* parent = expr->parentSymbol;
+
       if (isArgSymbol(parent))
         parent = parent->defPoint->parentSymbol;
+
       FnSymbol* fn = toFnSymbol(parent);
+
       fn = findNonTaskCaller(fn);
+
       if (fn && fn != err_fn) {
         err_fn = fn;
+
         while ((fn = toFnSymbol(err_fn->defPoint->parentSymbol))) {
-          if (fn == fn->getModule()->initFn)
+          if (fn == fn->getModule()->initFn) {
             break;
+          }
+
           err_fn = fn;
         }
+
         // If the function is compiler-generated, or inlined, or doesn't match
         // the error function and line number, nothing is printed.
-        if (err_fn->getModule()->initFn != err_fn &&
+        if (err_fn->getModule()->initFn != err_fn     &&
             !err_fn->hasFlag(FLAG_COMPILER_GENERATED) &&
-            !err_fn->hasFlag(FLAG_INLINE) &&
             err_fn->linenum()) {
-          fprintf(stderr, "%s:%d: In ",
-                  cleanFilename(err_fn), err_fn->linenum());
-          if (!strncmp(err_fn->name, "_construct_", 11)) {
-            fprintf(stderr, "initializer '%s':\n", err_fn->name+11);
-          } else if (!strcmp(err_fn->name, "init")) {
-            fprintf(stderr, "initializer:\n");
-          } else {
-            fprintf(stderr, "%s '%s':\n",
-                    (err_fn->isIterator() ? "iterator" : "function"),
-                    err_fn->name);
+          bool suppress = false;
+
+          // Initializer might be inlined
+          if (err_fn->hasFlag(FLAG_INLINE) == true) {
+            suppress = (strcmp(err_fn->name, "init") != 0) ? true : false;
+          }
+
+          if (suppress == false) {
+            fprintf(stderr,
+                    "%s:%d: In ",
+                    cleanFilename(err_fn),
+                    err_fn->linenum());
+
+            if (strncmp(err_fn->name, "_construct_", 11) == 0) {
+              fprintf(stderr, "initializer '%s':\n", err_fn->name+11);
+
+            } else if (strcmp(err_fn->name, "init") == 0) {
+              fprintf(stderr, "initializer:\n");
+
+            } else {
+              fprintf(stderr,
+                      "%s '%s':\n",
+                      (err_fn->isIterator() ? "iterator" : "function"),
+                      err_fn->name);
+            }
           }
         }
       }

--- a/test/classes/initializers/noReturnInInit.bad
+++ b/test/classes/initializers/noReturnInInit.bad
@@ -1,6 +1,2 @@
-stretch tree of depth 11	 check: -1
-2048	 trees of depth 4	 check: -2048
-512	 trees of depth 6	 check: -512
-128	 trees of depth 8	 check: -128
-32	 trees of depth 10	 check: -32
-long lived tree of depth 10	 check: -1
+noReturnInInit.chpl:82: In initializer:
+noReturnInInit.chpl:84: error: illegal cast from Tree to void


### PR DESCRIPTION
Currently

var x  = new MyClass(10, 20, 30);

is converted to inline code allocate an instance of MyClass followed by a call to the appropriate
init method.  This method receives the new instance and also returns it.



This PR

1) creates a new "type method" for every init method of a class.  The type method allocates an
instance and then invokes the init method on the fresh memory.

2) converts the init method to have a void return

3) Adds the inline flag to the init method so that it is used efficiently by the only method that
could invoke it.

4) Updates resolution for new expressions for classes that have init methods to use the
new type method.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64

Ran paratest on linux64-single-locale, linux64-gasnet.

Also ran with -futures for classes/initializers
