### PR TITLE
Add .futures about records declared in unused functions

### DIFF
--- a/test/types/records/diten/unusedExternRecordInProc.chpl
+++ b/test/types/records/diten/unusedExternRecordInProc.chpl
@@ -1,0 +1,11 @@
+proc foo() {
+  extern "struct timeval" record timeval {
+    var tv_sec: int;
+    var tv_usec: int;
+  }
+
+  var tv: timeval;
+}
+
+writeln("Not calling foo.");
+// foo();

--- a/test/types/records/diten/unusedExternRecordInProc.future
+++ b/test/types/records/diten/unusedExternRecordInProc.future
@@ -1,0 +1,1 @@
+bug: extern record declared in unused procedure causes internal compiler error

--- a/test/types/records/diten/unusedExternRecordInProc.good
+++ b/test/types/records/diten/unusedExternRecordInProc.good
@@ -1,0 +1,1 @@
+Not calling foo.

--- a/test/types/records/diten/unusedRecordInProc.chpl
+++ b/test/types/records/diten/unusedRecordInProc.chpl
@@ -1,0 +1,11 @@
+proc foo() {
+  record R {
+    var a: int;
+    var b: int;
+  }
+
+  var r = new R();
+}
+
+writeln("Not calling foo.");
+// foo();

--- a/test/types/records/diten/unusedRecordInProc.future
+++ b/test/types/records/diten/unusedRecordInProc.future
@@ -1,0 +1,1 @@
+bug: record declared in unused procedure causes internal compiler error

--- a/test/types/records/diten/unusedRecordInProc.good
+++ b/test/types/records/diten/unusedRecordInProc.good
@@ -1,0 +1,1 @@
+Not calling foo.


### PR DESCRIPTION
One declares a normal record in an unused function, the other declares an
extern record in an unused function. They fail to compile with two different
internal errors.  Both tests compile and run if the function is called.