### PR TITLE
Replace a VarSymbol of type dtMethodToken with a reference to gMethodToken

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1247,14 +1247,12 @@ static void buildDefaultOfFunction(AggregateType* ct) {
       fn->insertAtTail(new CallExpr(PRIM_RETURN, arg));
 
     } else if (ct->initializerStyle == DEFINES_INITIALIZER) {
-      VarSymbol* _mt   = newTemp("_mt",   dtMethodToken);
       VarSymbol* _this = newTemp("_this", ct);
       CallExpr*  call  = new CallExpr("init");
 
-      fn->insertAtHead(new DefExpr(_mt));
       fn->insertAtHead(new DefExpr(_this));
 
-      call->insertAtTail(new SymExpr(_mt));
+      call->insertAtTail(new SymExpr(gMethodToken));
       call->insertAtTail(new SymExpr(_this));
 
       fn->insertAtTail(new CallExpr(PRIM_RETURN, call));


### PR DESCRIPTION
My recent update to _defaultOf() functions to handle the revision to init methods exposed an
issue with variables of type dtMethodToken.  This issue is masked when inlining is enabled but
led to three regressions for initializer tests on records with --baseline.

I haven't spent the time to fully understand the issue because

  1) There's a trivial adjustment that avoids the issue

  2) I anticipate that I'll be updating the location of the issue again in one of the next few
PRs.



Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.

Passed start_test on test/classes/initializer for darwin for --verify and --verify, --baseline
Passed paratest for linux64-single-locale for --verify and --verify, --baseline
