### PR TITLE
Fix enum param compare

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7227,14 +7227,19 @@ static void foldEnumOp(int op, EnumSymbol *e1, EnumSymbol *e2, Immediate *imm) {
   type2 = toEnumType(e2->type);
   INT_ASSERT(type1 && type2);
 
-  // If our two enum types are different and we're doing == or !=, the
-  // answer should always be false, not based on the two enums'
-  // integer values.
+  // If our two enum types are different and we're doing == (or !=),
+  // the answer should always be false (or true), not based on the two
+  // enums' integer values.  If the two enum types are the same, we
+  // can use their integer values, as the code below does.
   if (type1 != type2 &&
       (op == P_prim_equal || op == P_prim_notequal)) {
     imm->const_kind = NUM_KIND_BOOL;
     imm->num_index = BOOL_SIZE_SYS;
-    imm->v_bool = false;
+    if (op == P_prim_equal) {
+      imm->v_bool = false;
+    } else {
+      imm->v_bool = true;
+    }
     return;
   }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7227,6 +7227,17 @@ static void foldEnumOp(int op, EnumSymbol *e1, EnumSymbol *e2, Immediate *imm) {
   type2 = toEnumType(e2->type);
   INT_ASSERT(type1 && type2);
 
+  // If our two enum types are different and we're doing == or !=, the
+  // answer should always be false, not based on the two enums'
+  // integer values.
+  if (type1 != type2 &&
+      (op == P_prim_equal || op == P_prim_notequal)) {
+    imm->const_kind = NUM_KIND_BOOL;
+    imm->num_index = BOOL_SIZE_SYS;
+    imm->v_bool = false;
+    return;
+  }
+
   // Loop over the enum values to find the int value of e1
   for_enums(constant, type1) {
     if (!get_int(constant->init, &count)) {

--- a/test/types/enum/compareDiffEnums.bad
+++ b/test/types/enum/compareDiffEnums.bad
@@ -1,0 +1,1 @@
+That's not right!

--- a/test/types/enum/compareDiffEnums.chpl
+++ b/test/types/enum/compareDiffEnums.chpl
@@ -1,0 +1,17 @@
+enum color {red, green, blue};
+enum day {sunday, monday, tuesday};
+
+config var c1 = color.green;
+config var c2 = day.monday;
+
+if (c1 == c2) {
+  writeln("That's not right!");
+}
+
+if (c1 != color.green) {
+  writeln("That's not right either!");
+}
+
+if (c1 != c2) {
+  writeln("It works!");
+}

--- a/test/types/enum/compareDiffEnums.future
+++ b/test/types/enum/compareDiffEnums.future
@@ -1,0 +1,5 @@
+semantic: Should comparing different enum types compare values or symbols?
+
+At present, comparing different enum types seems to compare the int
+values of the enums, such that == might return true between two
+distinct enums.  This seems... surprising.

--- a/test/types/enum/compareDiffEnums.good
+++ b/test/types/enum/compareDiffEnums.good
@@ -1,0 +1,1 @@
+It works!

--- a/test/types/enum/paramCompareDiffEnums.chpl
+++ b/test/types/enum/paramCompareDiffEnums.chpl
@@ -1,0 +1,14 @@
+enum color {red, green, blue};
+enum day {sunday, monday, tuesday};
+
+if (color.green == day.monday) {
+  compilerError("That's not right!");
+}
+
+param c = color.green;
+
+if (c != day.monday) {
+  compilerError("That's not right either!");
+}
+
+compilerError("It works!");

--- a/test/types/enum/paramCompareDiffEnums.chpl
+++ b/test/types/enum/paramCompareDiffEnums.chpl
@@ -5,10 +5,10 @@ if (color.green == day.monday) {
   compilerError("That's not right!");
 }
 
-param c = color.green;
-
-if (c != day.monday) {
+if (color.green != color.green) {
   compilerError("That's not right either!");
 }
 
-compilerError("It works!");
+if (color.green != day.monday) {
+  compilerError("It works!");
+}

--- a/test/types/enum/paramCompareDiffEnums.good
+++ b/test/types/enum/paramCompareDiffEnums.good
@@ -1,0 +1,1 @@
+paramCompareDiffEnums.chpl:14: error: It works!

--- a/test/types/enum/paramCompareDiffEnums.good
+++ b/test/types/enum/paramCompareDiffEnums.good
@@ -1,1 +1,1 @@
-paramCompareDiffEnums.chpl:14: error: It works!
+paramCompareDiffEnums.chpl:13: error: It works!


### PR DESCRIPTION
While looking at enum param comparisons with @ronawho this afternoon, we noticed that it seems to be comparing enums based on their integer values rather than their symbols.  This means, for example that "blue == monday" could be true where blue and monday are two completely different enum types.  Should it be?  This PR assumed the answer was "no" and tried to fix it....
