### PR TITLE
domain.shape && array.shape

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1078,6 +1078,37 @@ module ChapelArray {
       for i in _value.dimIter(d, ind) do yield i;
     }
 
+   /* Returns a tuple of integers describing the size of each dimension.
+      For a sparse domain, returns the shape of the parent domain.*/
+    proc shape where isRectangularDom(this) {
+      var shape: rank*(int);
+      for (i, r) in zip(1..shape.size, dims()) do
+        shape(i) = r.size;
+      return shape;
+    }
+
+    pragma "no doc"
+    proc shape where isSparseDom(this) {
+      var shape: this._value.parentDom.rank*(int);
+      for (i, r) in zip(1..shape.size, this._value.parentDom.dims()) do
+        shape(i) = r.size;
+      return shape;
+    }
+
+    pragma "no doc"
+    proc shape where isOpaqueDom(this) || isAssociativeDom(this) { 
+      // Opaque domains assumed 1D
+      var shape: (int,);
+      shape[1] = size;
+      return shape;
+    }
+
+    pragma "no doc"
+    /* Unsupported case */
+    proc shape {
+      compilerError("this domain type does not support .shape");
+    }
+
     pragma "no doc"
     proc buildArray(type eltType) {
       var x = _value.dsiBuildArray(eltType);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1096,7 +1096,7 @@ module ChapelArray {
     }
 
     pragma "no doc"
-    proc shape where isOpaqueDom(this) || isAssociativeDom(this) { 
+    proc shape where isAssociativeDom(this) || isOpaqueDom(this) {
       // Opaque domains assumed 1D
       var shape: (int,);
       shape[1] = size;
@@ -1106,7 +1106,7 @@ module ChapelArray {
     pragma "no doc"
     /* Unsupported case */
     proc shape {
-      compilerError("this domain type does not support .shape");
+      compilerError(".shape not supported on this domain");
     }
 
     pragma "no doc"
@@ -2409,7 +2409,7 @@ module ChapelArray {
           if this._value.dataAllocRange.length < this.domain.numIndices {
             /* if dataAllocRange has fewer indices than this.domain it must not
                be set correctly.  Set it to match this.domain to start.
-             */ 
+             */
             this._value.dataAllocRange = this.domain.low..this.domain.high;
           }
           const oldRng = this._value.dataAllocRange;
@@ -2684,6 +2684,13 @@ module ChapelArray {
       for i in this do if i == val then total += 1;
       return total;
     }
+
+   /* Returns a tuple of integers describing the size of each dimension.
+      For a sparse array, returns the shape of the parent domain.*/
+    proc shape {
+      return this.domain.shape;
+    }
+
   }  // record _array
 
   //

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1080,27 +1080,19 @@ module ChapelArray {
 
    /* Returns a tuple of integers describing the size of each dimension.
       For a sparse domain, returns the shape of the parent domain.*/
-    proc shape where isRectangularDom(this) {
-      var shape: rank*(int);
-      for (i, r) in zip(1..shape.size, dims()) do
-        shape(i) = r.size;
-      return shape;
+    proc shape where isRectangularDom(this) || isSparseDom(this) {
+      var s: rank*(int);
+      for (i, r) in zip(1..s.size, dims()) do
+        s(i) = r.size;
+      return s;
     }
 
     pragma "no doc"
-    proc shape where isSparseDom(this) {
-      var shape: this._value.parentDom.rank*(int);
-      for (i, r) in zip(1..shape.size, this._value.parentDom.dims()) do
-        shape(i) = r.size;
-      return shape;
-    }
-
-    pragma "no doc"
+    /* Associative and Opaque domains assumed to be 1-D. */
     proc shape where isAssociativeDom(this) || isOpaqueDom(this) {
-      // Opaque domains assumed 1D
-      var shape: (int,);
-      shape[1] = size;
-      return shape;
+      var s: (int,);
+      s[1] = size;
+      return s;
     }
 
     pragma "no doc"

--- a/test/domains/methods/shape.chpl
+++ b/test/domains/methods/shape.chpl
@@ -1,0 +1,37 @@
+/* Test domain.shape method */
+
+//
+// Regular Domains & Arrays
+//
+
+// RectangularDom
+var rectDom = {1..10, 1..10};
+writeln(rectDom.shape);
+
+//
+// Irregular Domains & Arrays
+//
+
+// SparseDom
+var sparseDom: sparse subdomain(rectDom);
+writeln(sparseDom.shape);
+
+// OpaqueDom
+var opaqueDom: domain(opaque);
+opaqueDom.create();
+opaqueDom.create();
+writeln(opaqueDom.shape);
+
+// AssociativeDom
+var associativeDom: domain(int);
+associativeDom += 1;
+associativeDom += 2;
+writeln(associativeDom.shape);
+
+// EnumDom
+enum compass {N, E, S, W};
+var enumDom: domain(compass);
+writeln(enumDom.shape);
+
+
+

--- a/test/domains/methods/shape.chpl
+++ b/test/domains/methods/shape.chpl
@@ -1,5 +1,7 @@
 /* Test domain.shape method */
 
+use BlockDist;
+
 //
 // Regular Domains & Arrays
 //
@@ -7,6 +9,18 @@
 // RectangularDom
 var rectDom = {1..10, 1..10};
 writeln(rectDom.shape);
+
+// RectangularArray
+var rectArray: [rectDom] int;
+writeln(rectArray.shape);
+
+//
+// Distributed Domains & Arrays
+//
+
+// Block-distributed
+var blockDom = rectDom dmapped Block(boundingBox=rectDom);
+writeln(blockDom.shape);
 
 //
 // Irregular Domains & Arrays
@@ -16,11 +30,18 @@ writeln(rectDom.shape);
 var sparseDom: sparse subdomain(rectDom);
 writeln(sparseDom.shape);
 
+// RectangularArray
+var sparseArray: [sparseDom] int;
+writeln(sparseArray.shape);
+
 // OpaqueDom
 var opaqueDom: domain(opaque);
 opaqueDom.create();
 opaqueDom.create();
 writeln(opaqueDom.shape);
+
+var opaqueArray: [opaqueDom] int;
+writeln(opaqueArray.shape);
 
 // AssociativeDom
 var associativeDom: domain(int);
@@ -28,10 +49,16 @@ associativeDom += 1;
 associativeDom += 2;
 writeln(associativeDom.shape);
 
-// EnumDom
+var associativeArray: [associativeDom] int;
+writeln(associativeArray.shape);
+
+// EnumDom (a flavor of AssociateDom)
 enum compass {N, E, S, W};
 var enumDom: domain(compass);
 writeln(enumDom.shape);
+
+var enumArray: [enumDom] int;
+writeln(enumArray.shape);
 
 
 

--- a/test/domains/methods/shape.chpl
+++ b/test/domains/methods/shape.chpl
@@ -1,4 +1,4 @@
-/* Test domain.shape method */
+/* Test domain.shape method (called from array.shape) */
 
 use BlockDist;
 
@@ -8,19 +8,11 @@ use BlockDist;
 
 // RectangularDom
 var rectDom = {1..10, 1..10};
-writeln(rectDom.shape);
+assertEqual(rectDom.shape, (10, 10), msg='rectDom:');
 
 // RectangularArray
 var rectArray: [rectDom] int;
-writeln(rectArray.shape);
-
-//
-// Distributed Domains & Arrays
-//
-
-// Block-distributed
-var blockDom = rectDom dmapped Block(boundingBox=rectDom);
-writeln(blockDom.shape);
+assertEqual(rectArray.shape, (10, 10), msg='rectArray:');
 
 //
 // Irregular Domains & Arrays
@@ -28,37 +20,51 @@ writeln(blockDom.shape);
 
 // SparseDom
 var sparseDom: sparse subdomain(rectDom);
-writeln(sparseDom.shape);
+assertEqual(sparseDom.shape, (10, 10), msg='sparseDom:');
 
 // RectangularArray
 var sparseArray: [sparseDom] int;
-writeln(sparseArray.shape);
+assertEqual(sparseArray.shape, (10, 10), msg='sparseArray:');
 
 // OpaqueDom
 var opaqueDom: domain(opaque);
-opaqueDom.create();
-opaqueDom.create();
-writeln(opaqueDom.shape);
+for 1..10 do opaqueDom.create();
+assertEqual(opaqueDom.shape, (10,), msg='opaqueDom:');
 
 var opaqueArray: [opaqueDom] int;
-writeln(opaqueArray.shape);
+assertEqual(opaqueArray.shape, (10,), msg='opaqueArray:');
 
 // AssociativeDom
 var associativeDom: domain(int);
-associativeDom += 1;
-associativeDom += 2;
-writeln(associativeDom.shape);
+for i in 1..10 do associativeDom += i;
+assertEqual(associativeDom.shape, (10,), msg='associateDom:');
 
 var associativeArray: [associativeDom] int;
-writeln(associativeArray.shape);
+assertEqual(associativeArray.shape, (10,), msg='associateArray:');
 
 // EnumDom (a flavor of AssociateDom)
-enum compass {N, E, S, W};
-var enumDom: domain(compass);
-writeln(enumDom.shape);
+enum digits {zero, one, two, three, four, five, six, seven, eight, nine};
+var enumDom: domain(digits);
+assertEqual(enumDom.shape, (10,), msg='enumDom:');
 
 var enumArray: [enumDom] int;
-writeln(enumArray.shape);
+assertEqual(enumArray.shape, (10,), msg='enumArray:');
+
+//
+// Distributed Domains & Arrays
+//
+
+// Block-distributed
+var blockDom = rectDom dmapped Block(boundingBox=rectDom);
+assertEqual(blockDom.shape, (10, 10), msg='blockDom');
+
+var blockArray: [blockDom] int;
+assertEqual(blockArray.shape, (10, 10), msg='blockArray:');
 
 
-
+proc assertEqual(a, b, msg) {
+  if a != b {
+    writeln(msg);
+    writeln('AssertionError: %t != %t'.format(a, b));
+  }
+}


### PR DESCRIPTION
This PR adds the `domain.shape` and `array.shape` methods that return that shape of an array or domain in the form of a tuple, originally proposed and discussed in #5178. See the issue for further details.