### PR TITLE
Loop over Defs and Uses with SymbolSymExprs

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -359,6 +359,9 @@ bool isRelationalOperator(CallExpr* call) {
 // return & 1 is true if se is a def
 // return & 2 is true if se is a use
 //
+// Note that a DefExpr is where we hang the variable declaration, but after
+// normalize, a DefExpr itself does not set a variable, and so it does not count
+// as a Def.
 int isDefAndOrUse(SymExpr* se) {
   if (CallExpr* call = toCallExpr(se->parentExpr)) {
     if ((call->isPrimitive(PRIM_MOVE) || call->isPrimitive(PRIM_ASSIGN)) &&

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -1020,11 +1020,6 @@ static void insertLocalsForRefs(Vec<Symbol*>& syms,
                                 FnSymbol*     fn,
                                 Vec<Symbol*>& yldSymSet)
 {
-  Map<Symbol*, Vec<SymExpr*>*> defMap;
-  Map<Symbol*, Vec<SymExpr*>*> useMap;
-
-  buildDefUseMaps(fn, defMap, useMap);
-
   // Walk the variables in this (iterator) function
   // which are not the return symbol nor argument, and are ref symbols.
   forv_Vec(Symbol, sym, syms) {
@@ -1032,15 +1027,13 @@ static void insertLocalsForRefs(Vec<Symbol*>& syms,
       continue;
 
     if (sym->type->symbol->hasFlag(FLAG_REF)) {
-      Vec<SymExpr*>* defs = defMap.get(sym);
-
       CallExpr* move = NULL;
-      if (defs == NULL) {
+      if (!sym->isDefined()) {
         INT_FATAL(sym, "Expected sym to have at least one definition");
       }
 
       // Ignores reference actuals passed to reference formals
-      for_defs(def, defMap, sym) {
+      for_SymbolDefs(def, sym) {
         CallExpr* parent = toCallExpr(def->parentExpr);
         INT_ASSERT(parent);
         if (parent->isPrimitive(PRIM_MOVE)) {
@@ -1102,8 +1095,6 @@ static void insertLocalsForRefs(Vec<Symbol*>& syms,
       }
     }
   }
-
-  freeDefUseMaps(defMap, useMap);
 }
 
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -345,6 +345,53 @@ SymExpr* Symbol::lastSymExpr() const {
   return symExprsTail;
 }
 
+int Symbol::countDefs(int max) const {
+  int ret = 0;
+  for_SymbolDefs(def, this) {
+    ret += 1;
+    if (ret >= max) break;
+  }
+  return ret;
+}
+
+int Symbol::countUses(int max) const {
+  int ret = 0;
+  for_SymbolUses(use, this) {
+    ret += 1;
+    if (ret >= max) break;
+  }
+  return ret;
+}
+
+bool Symbol::isUsed() const {
+  return (this->countUses(1) >= 1);
+}
+
+bool Symbol::isDefined() const {
+  return (this->countDefs(1) >= 1);
+}
+
+SymExpr* Symbol::getSingleUse() const {
+  SymExpr* ret = NULL;
+  for_SymbolUses(use, this) {
+    if (ret != NULL) return NULL;
+    ret = use;
+  }
+  return ret;
+}
+
+SymExpr* Symbol::getSingleDef() const {
+  SymExpr* ret = NULL;
+  for_SymbolDefs(def, this) {
+    if (ret != NULL) return NULL;
+    ret = def;
+  }
+  return ret;
+}
+
+
+
+
 bool Symbol::isImmediate() const {
   return false;
 }

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -154,11 +154,23 @@ public:
   DefExpr*           defPoint; // Point of definition
 
   // Managing the list of SymExprs that refer to this Symbol
+  // use for_SymbolSymExprs, for_SymbolDefs, for_SymbolUses
+  // to traverse these.
   void               addSymExpr(SymExpr* se);
   void               removeSymExpr(SymExpr* se);
   SymExpr*           firstSymExpr()                            const;
   SymExpr*           lastSymExpr()                             const;
-
+  // Get the number of Defs or Uses up to the maximum number
+  int                countDefs(int max=INT_MAX)                const;
+  int                countUses(int max=INT_MAX)                const;
+  // Does the Symbol have any Uses? same as countUses() > 0
+  // but may be faster.
+  bool               isUsed()                                  const;
+  bool               isDefined()                               const;
+  // Return the single use of this Symbol, or NULL if there are 0 or >= 2
+  SymExpr*           getSingleUse()                            const;
+  // Return the single def of this Symbol, or NULL if there are 0 or >= 2
+  SymExpr*           getSingleDef()                            const;
 protected:
                      Symbol(AstTag      astTag,
                             const char* init_name,
@@ -183,6 +195,14 @@ private:
        se;                                                              \
        se = _se_next,                                                   \
          _se_next = se ? se->symbolSymExprsNext : NULL)
+
+#define for_SymbolDefs(def, symbol)                                      \
+  for_SymbolSymExprs(def, symbol)                                        \
+    if ((isDefAndOrUse(def) & 1))
+
+#define for_SymbolUses(use, symbol)                                      \
+  for_SymbolSymExprs(use, symbol)                                        \
+    if ((isDefAndOrUse(use) & 2))
 
 
 bool isString(Symbol* symbol);

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -41,8 +41,7 @@ inline bool unsafeExprInBetween(Expr* e1, Expr* e2, Expr* exprToMove,
 inline bool requiresCast(Type* t);
 inline bool isIntegerPromotionPrimitive(PrimitiveTag tag);
 bool isDenormalizable(Symbol* sym,
-    Map<Symbol*,Vec<SymExpr*>*>& defMap,
-    Map<Symbol*,Vec<SymExpr*>*>& useMap, SymExpr** useOut, Expr** defOut,
+    SymExpr** useOut, Expr** defOut,
     Type** castTo, SafeExprAnalysis& analysisData);
 void findCandidatesInFunc(FnSymbol *fn, UseDefCastMap& candidates,
     SafeExprAnalysis& analysisData);
@@ -170,11 +169,6 @@ void denormalizeOrDeferCandidates(UseDefCastMap& candidates,
 void findCandidatesInFuncOnlySym(FnSymbol* fn, Vec<Symbol*> symVec,
     UseDefCastMap& udcMap, SafeExprAnalysis& analysisData) {
 
-  Map<Symbol*,Vec<SymExpr*>*> defMap;
-  Map<Symbol*,Vec<SymExpr*>*> useMap;
-
-  buildDefUseMaps(fn, defMap, useMap);
-
   bool cachedGlobalManip = analysisData.isRegisteredGlobalManip(fn);
   bool cachedExternManip = analysisData.isRegisteredExternManip(fn);
 
@@ -205,8 +199,7 @@ void findCandidatesInFuncOnlySym(FnSymbol* fn, Vec<Symbol*> symVec,
 
     }
 
-    if(isDenormalizable(sym, defMap, useMap, &use, &def, &castTo,
-          analysisData)) {
+    if(isDenormalizable(sym, &use, &def, &castTo, analysisData)) {
 
       // Initially I used to defer denormalizing actuals and have
       // special treatment while denormalizing actuals of a function
@@ -243,20 +236,13 @@ void findCandidatesInFunc(FnSymbol *fn, UseDefCastMap& udcMap,
     SafeExprAnalysis& analysisData) {
 
   Vec<Symbol*> symSet;
-  Map<Symbol*,Vec<SymExpr*>*> defMap;
-  Map<Symbol*,Vec<SymExpr*>*> useMap;
 
   collectSymbolSet(fn, symSet);
-  buildDefUseMaps(symSet, defMap, useMap);
 
   findCandidatesInFuncOnlySym(fn, symSet, udcMap, analysisData);
-
-  freeDefUseMaps(defMap, useMap);
 }
 
 bool isDenormalizable(Symbol* sym,
-    Map<Symbol*,Vec<SymExpr*>*> & defMap,
-    Map<Symbol*,Vec<SymExpr*>*> & useMap,
     SymExpr** useOut, Expr** defOut, Type** castTo,
     SafeExprAnalysis& analysisData) {
 
@@ -267,11 +253,11 @@ bool isDenormalizable(Symbol* sym,
       Expr *def = NULL;
       Expr *defPar = NULL;
 
-      Vec<SymExpr*>* defs = defMap.get(sym);
-      Vec<SymExpr*>* uses = useMap.get(sym);
+      SymExpr* singleDef = sym->getSingleDef();
+      SymExpr* singleUse = sym->getSingleUse();
 
-      if(defs && defs->n == 1 && uses && uses->n == 1) { // check def-use counts
-        SymExpr* se = defs->first();
+      if(singleDef != NULL && singleUse != NULL) { // check def-use counts
+        SymExpr* se = singleDef;
         defPar = se->parentExpr;
 
         //defPar has to be a move without any coercion
@@ -321,7 +307,7 @@ bool isDenormalizable(Symbol* sym,
         if(def) {
           *defOut = def;
           // we have def now find where the value is used
-          SymExpr* se = uses->first();
+          SymExpr* se = singleUse;
           usePar = se->parentExpr;
           if(CallExpr* ce = toCallExpr(usePar)) {
             if( !(ce->isPrimitive(PRIM_ADDR_OF) ||

--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -95,11 +95,7 @@ void addAutoDestroyCalls() {
 
 static void cullForDefaultConstructor(FnSymbol* fn) {
   if (isVarSymbol(fn->getReturnSymbol()) == true) {
-    Map<Symbol*, Vec<SymExpr*>*> defMap;
-    Map<Symbol*, Vec<SymExpr*>*> useMap;
     std::vector<DefExpr*>        defs;
-
-    buildDefUseMaps(fn, defMap, useMap);
 
     collectDefExprs(fn, defs);
 
@@ -110,7 +106,7 @@ static void cullForDefaultConstructor(FnSymbol* fn) {
           // type, and remove the flag. (We don't actually check that var is
           // of record type, because chpl__autoDestroy() is a NO-OP when
           // applied to all other types.
-          for_uses(se, useMap, var) {
+          for_SymbolUses(se, var) {
             CallExpr* call = toCallExpr(se->parentExpr);
 
             if (call->isPrimitive(PRIM_SET_MEMBER) == true &&
@@ -121,8 +117,6 @@ static void cullForDefaultConstructor(FnSymbol* fn) {
         }
       }
     }
-
-    freeDefUseMaps(defMap, useMap);
   }
 }
 


### PR DESCRIPTION
Continuing PR #4992, this PR uses SymbolSymExprs in more places in the compiler.  In particular, it adds loop macros for_SymbolDefs and for_SymbolUses which can be used to replace for_defs and for_uses. Additionally, it provides some convenient methods on the Symbol class: countDefs, countUses, isUsed, isDefined, getSingleUse, getSingleDef.

Then, this PR updates 7 files to use the new functionality and removes 11 calls to buildDefUseMaps in the process. The new code has lower complexity and some basic experimentation shows about a 5% compile time improvement for hello4-datapar-dist.chpl on my system.

About 25 uses of  buildDefUseMaps remain. The main tricky thing to watch out for when replacing the old pattern with the new one is in loops that add AST while iterating over uses or defs. With for_defs/for_uses, the new AST will not be looped over, since the def/use lists and maps have already been computed. With for_SymbolDefs or for_SymbolUses, the new AST can be looped over.

I personally think that a compiler transformations of the style
 * figure out what to modify and add it to a work queue / list / vector
 * do the modification where appropriate

are generally easier to reason about. Such transformations can work with for_SymbolDefs/Uses or for_defs/uses without any issue.

Passed full local testing.
Passed hellos with --baseline --verify;  with --no-local; and with GASNet.

Reviewed by @benharsh - thanks!