### PR TITLE
Remove unreferenced flag FLAG_SPECIFIED_RETURN_TYPE

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -256,7 +256,6 @@ symbolFlag( FLAG_SHOULD_NOT_PASS_BY_REF, npr, "should not pass by ref", "this sy
 symbolFlag( FLAG_SINGLE , ypr, "single" , ncm )
 // Based on how this is used, I suggest renaming it to return_value_has_initializer
 // or something similar <hilde>.
-symbolFlag( FLAG_SPECIFIED_RETURN_TYPE , npr, "specified return type" , ncm )
 symbolFlag( FLAG_STAR_TUPLE , ypr, "star tuple" , "mark tuple types as star tuple types" )
 symbolFlag( FLAG_STAR_TUPLE_ACCESSOR , ypr, "star tuple accessor" , "this function for star tuple types" )
 symbolFlag( FLAG_SUPER_CLASS , npr, "super class" , ncm )

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -759,8 +759,6 @@ static void normalize_returns(FnSymbol* fn) {
                              "an iterator's return type cannot be 'void'; "
                              "if specified, it must be the type of the "
                              "expressions the iterator yields");
-
-      fn->addFlag(FLAG_SPECIFIED_RETURN_TYPE);
     }
 
     fn->insertAtHead(new DefExpr(retval));


### PR DESCRIPTION
While looking at normalize I noticed that the flag FLAG_SPECIFIED_RETURN_TYPE is set on
certain functions but is never read.

This PR removes this flag completely.

Compiled on all the obvious variations (including LLVM) and ran portions of test/release on
linux and darwin.
