### PR TITLE
Fix problem with addAllToVirtualMaps

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8875,10 +8875,8 @@ addAllToVirtualMaps(FnSymbol* fn, AggregateType* pct) {
          ct->defaultTypeConstructor->isResolved()))
       addToVirtualMaps(fn, ct);
 
-    // if sub-class is not a generic instantiation
-    if (!ct->instantiatedFrom)
-      // add to maps transitively
-      addAllToVirtualMaps(fn, ct);
+    // add overrides of method fn by children of ct to virtual maps
+    addAllToVirtualMaps(fn, ct);
   }
 }
 

--- a/test/classes/ferguson/generic-inherit-bug1.chpl
+++ b/test/classes/ferguson/generic-inherit-bug1.chpl
@@ -1,0 +1,92 @@
+module Structure {
+
+  class GrandParent {
+    var gp_field: int;
+    proc baz() {
+      writeln("in GrandParent() baz");
+    }
+  }
+
+  class Parent : GrandParent {
+    param rank:int;
+    type idxType;
+    param stridable: bool;
+
+    proc foo( arg: rank*range(idxType, BoundedRangeType.bounded,stridable) ) {
+      writeln("in Parent(", rank, ") foo ", arg);
+    }
+    proc bar() {
+      writeln("in Parent(", rank, ") bar ");
+    }
+
+  }
+
+  class SubParent : Parent {
+    type eltType;
+  }
+
+
+  class ListerGrandParent {
+    var lst: list(GrandParent);
+  }
+
+  class ListerParent : ListerGrandParent {
+    param rank:int;
+    type idxType;
+    param stridable: bool;
+
+    proc getListedType() type {
+      return Parent(rank=rank, idxType=idxType, stridable=stridable);
+    }
+  }
+
+  proc test(lhs:?t) where t:ListerParent {
+    type subType = lhs.getListedType();
+    for e in lhs.lst {
+      var eCast = e:subType;
+      if eCast == nil then
+        halt("X");
+
+      writeln("foo");
+      (e:subType).foo( (100..100,) );
+      writeln("bar");
+      eCast.bar();
+      writeln("baz");
+      e.baz();
+    }
+  }
+
+
+}
+
+module Impl {
+  use Structure;
+
+  class Child : SubParent {
+    var x:eltType;
+    
+    proc foo( arg: rank*range(idxType, BoundedRangeType.bounded,stridable) ) {
+      writeln("in Child(", rank, ") foo ", arg, " " , x);
+    }
+    proc bar() {
+      writeln("in Child(", rank, ") bar ", x);
+    }
+    proc baz() {
+      writeln("in Child(", rank, ") baz ", x);
+    }
+
+  }
+
+
+  proc main() {
+    var aa = new Child(rank=1, idxType=int, stridable=false, eltType=real);
+    writeln(aa);
+
+    var a = new Child(rank=1, idxType=int, stridable=false, eltType=int);
+    var d = new ListerParent(rank=1, idxType=int, stridable=false);
+    d.lst.append(a);
+
+    test(d);
+  }
+}
+

--- a/test/classes/ferguson/generic-inherit-bug1.good
+++ b/test/classes/ferguson/generic-inherit-bug1.good
@@ -1,0 +1,7 @@
+{gp_field = 0, x = 0.0}
+foo
+in Child(1) foo (100..100) 0
+bar
+in Child(1) bar 0
+baz
+in Child(1) baz 0


### PR DESCRIPTION
The new test, generic-inherit-bug1, shows a case where the virtual dispatch tables were not being correctly set up. I encountered this issue when working on improving domain assignment for irregular domains.

In particular, the problem came up for generic classes where there is a class with no declarations between the base class defining some methods and a child class overriding it.

e.g.
```
  class GrandParent {
    type t;
    proc foo() {
      writeln("GrandParent.foo()");
    }
  }

  class Parent : GrandParent {
  }

  class Child : Parent {
    proc foo() {
      writeln("Child.foo()");
    }
  }

  var x:Parent(int);
  x = new Child(int);
  x.foo();
```
should output Child.foo() but before this change outputs GrandParent.foo().

This commit solves the problem by removing a conditional in addAllToVirtualMaps. I cannot explain why that conditional should be there now. It was added in SVC commit 7117 (git id c8befa71e8).

Passed quickstart testing.
Passed full local testing with --futures.

Reviewed by @lydia-duncan - thanks!