### PR TITLE
Add a test that throw destroys local records

### DIFF
--- a/test/errhandling/inprogress/throws-destroys.1.good
+++ b/test/errhandling/inprogress/throws-destroys.1.good
@@ -1,0 +1,3 @@
+in simpleThrow, r=(x = 1)
+destroying R(x=1)
+throws-destroys.chpl:9: error: uncaught error

--- a/test/errhandling/inprogress/throws-destroys.2.good
+++ b/test/errhandling/inprogress/throws-destroys.2.good
@@ -1,0 +1,3 @@
+in conditionalThrow, r=(x = 2)
+destroying R(x=2)
+throws-destroys.chpl:11: error: uncaught error

--- a/test/errhandling/inprogress/throws-destroys.3.good
+++ b/test/errhandling/inprogress/throws-destroys.3.good
@@ -1,0 +1,2 @@
+in conditionalThrow, r=(x = 2)
+destroying R(x=2)

--- a/test/errhandling/inprogress/throws-destroys.4.good
+++ b/test/errhandling/inprogress/throws-destroys.4.good
@@ -1,0 +1,3 @@
+in loopThrow, r=(x = 3)
+destroying R(x=3)
+throws-destroys.chpl:15: error: uncaught error

--- a/test/errhandling/inprogress/throws-destroys.5.good
+++ b/test/errhandling/inprogress/throws-destroys.5.good
@@ -1,0 +1,3 @@
+in loopThrow, r=(x = 3)
+destroying R(x=3)
+throws-destroys.chpl:17: error: uncaught error

--- a/test/errhandling/inprogress/throws-destroys.6.good
+++ b/test/errhandling/inprogress/throws-destroys.6.good
@@ -1,0 +1,3 @@
+in inThrow, r=(x = 4)
+destroying R(x=4)
+throws-destroys.chpl:19: error: uncaught error

--- a/test/errhandling/inprogress/throws-destroys.7.good
+++ b/test/errhandling/inprogress/throws-destroys.7.good
@@ -1,0 +1,3 @@
+in loopThrow, r=(x = 101)
+destroying R(x=101)
+throws-destroys.chpl:21: error: uncaught error

--- a/test/errhandling/inprogress/throws-destroys.8.good
+++ b/test/errhandling/inprogress/throws-destroys.8.good
@@ -1,0 +1,5 @@
+in loopThrow, r=(x = 101)
+destroying R(x=101)
+in loopThrow, r=(x = 102)
+destroying R(x=102)
+throws-destroys.chpl:23: error: uncaught error

--- a/test/errhandling/inprogress/throws-destroys.chpl
+++ b/test/errhandling/inprogress/throws-destroys.chpl
@@ -1,0 +1,67 @@
+// Some testing that return-via-throw destroys records appropriately
+config const test = 1;
+use SomeError;
+
+run();
+
+proc run() {
+  if test == 1 then
+    try! simpleThrow();
+  if test == 2 then
+    try! conditionalThrow(true);
+  if test == 3 then
+    try! conditionalThrow(false);
+  if test == 4 then
+    try! loopThrow(1);
+  if test == 5 then
+    try! loopThrow(2);
+  if test == 6 then
+    try! inThrow(new R(4));
+  if test == 7 then
+    try! loopThrow2(1);
+  if test == 8 then
+    try! loopThrow2(2);
+}
+
+record R {
+  var x:int;
+  proc ~R() {
+    writeln("destroying R(x=", x, ")");
+  }
+}
+
+proc simpleThrow() throws {
+  var r = new R(1);
+  writeln("in simpleThrow, r=", r);
+  throw new SomeError();
+}
+proc conditionalThrow(arg:bool) throws {
+  var r = new R(2);
+  writeln("in conditionalThrow, r=", r);
+  if arg then
+    throw new SomeError();
+}
+proc loopThrow(arg:int) throws {
+  var r = new R(3);
+  writeln("in loopThrow, r=", r);
+  for i in 1..10 {
+    if i == arg then
+      throw new SomeError();
+  }
+}
+
+proc inThrow(in r:R) throws {
+  writeln("in inThrow, r=", r);
+  throw new SomeError();
+}
+
+proc loopThrow2(arg:int) throws {
+  for i in 1..10 {
+    var r = new R(100+i);
+    writeln("in loopThrow, r=", r);
+    if i == arg then
+      throw new SomeError();
+  }
+}
+
+

--- a/test/errhandling/inprogress/throws-destroys.execopts
+++ b/test/errhandling/inprogress/throws-destroys.execopts
@@ -1,0 +1,8 @@
+--test=1 # throws-destroys.1.good
+--test=2 # throws-destroys.2.good
+--test=3 # throws-destroys.3.good
+--test=4 # throws-destroys.4.good
+--test=5 # throws-destroys.5.good
+--test=6 # throws-destroys.6.good
+--test=7 # throws-destroys.7.good
+--test=8 # throws-destroys.8.good


### PR DESCRIPTION
The intent here is to just make sure that a function that throws still cleans up local variables appropriately on the throwing path. That means, in particular, calling a record destructor, which is what this test exercises.

This is a simple test and it is implemented oddly because we don't have catch blocks yet...

Verified that test/errhandling still passes.

Test change only. Not reviewed.