### PR TITLE
Add new files initializerResolution.h and .cpp and support them

### DIFF
--- a/compiler/include/initializerResolution.h
+++ b/compiler/include/initializerResolution.h
@@ -17,13 +17,23 @@
  * limitations under the License.
  */
 
-#ifndef _INITIALIZER_RULES_H_
-#define _INITIALIZER_RULES_H_
+#ifndef _INITIALIZER_RESOLUTION_H_
+#define _INITIALIZER_RESOLUTION_H_
 
-class FnSymbol;
-class AggregateType;
+#include "callInfo.h"
 
-void handleInitializerRules(FnSymbol* fn, AggregateType* t);
-FnSymbol* buildClassAllocator(FnSymbol* initMethod, AggregateType* ct);
+// Defines the resolution strategy for initializers.  This is different than
+// how normal generic functions are handled and how generic constructors are
+// handled, as we want to have the this argument for the type in the initializer
+// argument list, and want to utilize Phase 1 of the initializer body to
+// determine the generic instantiation of it.
+class BlockStmt;
+class CallExpr;
+class DefExpr;
+class Expr;
+class Symbol;
+class SymExpr;
+
+void temporaryInitializerFixup(CallExpr* call);
 
 #endif

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -37,6 +37,12 @@ extern Map<FnSymbol*,FnSymbol*> iteratorLeaderMap;
 extern Map<FnSymbol*,FnSymbol*> iteratorFollowerMap;
 extern std::map<CallExpr*,CallExpr*> eflopiMap;
 
+FnSymbol* expandVarArgs(FnSymbol* origFn, int numActuals);
+
+// explain call stuff
+extern int explainCallLine;
+bool explainCallMatch(CallExpr* call);
+
 FnSymbol* requiresImplicitDestroy(CallExpr* call);
 bool isLeaderIterator(FnSymbol* fn);
 bool isStandaloneIterator(FnSymbol* fn);
@@ -73,6 +79,134 @@ FnSymbol* instantiate(FnSymbol* fn, SymbolMap& subs, CallExpr* call);
 FnSymbol* instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call);
 void      instantiateBody(FnSymbol* fn);
 
+// generics support
+TypeSymbol* getNewSubType(FnSymbol* fn, Symbol* key, TypeSymbol* actualTS);
+void
+copyGenericSub(SymbolMap& subs, FnSymbol* root, FnSymbol* fn, Symbol* key, Symbol* value);
+void checkInfiniteWhereInstantiation(FnSymbol* fn);
+extern int explainInstantiationLine;
+extern ModuleSymbol* explainInstantiationModule;
+void explainInstantiation(FnSymbol* fn);
+void checkInstantiationLimit(FnSymbol* fn);
+void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var);
+
+// visible functions
+class VisibleFunctionBlock {
+ public:
+  Map<const char*,Vec<FnSymbol*>*> visibleFunctions;
+  VisibleFunctionBlock() { }
+};
+
+extern Map<BlockStmt*,VisibleFunctionBlock*> visibleFunctionMap;
+extern int nVisibleFunctions; // for incremental build
+void buildVisibleFunctionMap();
+BlockStmt*
+getVisibleFunctions(BlockStmt* block,
+                    const char* name,
+                    Vec<FnSymbol*>& visibleFns,
+                    Vec<BlockStmt*>& visited,
+                    CallExpr* callOrigin);
+
+// disambiguation
+/** A wrapper for candidates for function call resolution.
+ *
+ * If a best candidate was found than the function member will point to it.
+ */
+class ResolutionCandidate {
+public:
+  /// A pointer to the best candidate function.
+  FnSymbol* fn;
+
+  /** The actual arguments for the candidate, aligned so that they have the same
+   *  index as their corresponding formal argument in the called function.
+   */
+  Vec<Symbol*> formalIdxToActual; // note: was alignedActuals
+
+  /** The formal arguments for the candidate, aligned so that they have the same
+   *  index as their corresponding actual argument in the call.
+   */
+  Vec<ArgSymbol*> actualIdxToFormal; // note: was alignedFormals
+
+  /// A symbol map for substitutions that were made during the copying process.
+  SymbolMap substitutions;
+
+  /** The main constructor.
+   *
+   * \param fn A function that is a candidate for the resolution process.
+   */
+  ResolutionCandidate(FnSymbol* function) : fn(function) {}
+
+  /** Compute the alignment of actual and formal arguments for the wrapped
+   *  function and the current call site.
+   *
+   * \param info The CallInfo object corresponding to the call site.
+   *
+   * \return If a valid alignment was found.
+   */
+  bool computeAlignment(CallInfo& info);
+
+  /// Compute substitutions for wrapped function that is generic.
+  void computeSubstitutions();
+};
+
+typedef enum {
+  FIND_EITHER = 0,
+  FIND_REF,
+  FIND_NOT_REF
+} disambiguate_kind_t;
+
+
+/** Contextual info used by the disambiguation process.
+ *
+ * This class wraps information that is used by multiple functions during the
+ * function disambiguation process.
+ */
+class DisambiguationContext {
+public:
+  /// The actual arguments from the call site.
+  Vec<Symbol*>* actuals;
+  /// The scope in which the call is made.
+  Expr* scope;
+  /// Whether or not to print out tracing information.
+  bool explain;
+  /// Indexes used when printing out tracing information.
+  int i, j;
+
+  /** A simple constructor that initializes all of the values except i and j.
+   *
+   * \param actuals The actual arguments from the call site.
+   * \param scope   A block representing the scope the call was made in.
+   * \param explain Whether or not a trace of this disambiguation process should
+   *                be printed for the developer.
+   */
+  DisambiguationContext(Vec<Symbol*>* actuals, Expr* scope, bool explain) :
+    actuals(actuals), scope(scope), explain(explain), i(-1), j(-1) {}
+
+  /** A helper function used to set the i and j members.
+   *
+   * \param i The index of the left-hand side of the comparison.
+   * \param j The index of the right-hand side of the comparison.
+   *
+   * \return A constant reference to this disambiguation context.
+   */
+  const DisambiguationContext& forPair(int newI, int newJ) {
+    this->i = newI;
+    this->j = newJ;
+
+    return *this;
+  }
+};
+
+
+ResolutionCandidate* disambiguateByMatch(Vec<ResolutionCandidate*>& candidates,
+                                         DisambiguationContext DC,
+                                         disambiguate_kind_t kind);
+bool isBetterMatch(ResolutionCandidate* candidate1,
+                   ResolutionCandidate* candidate2,
+                   const DisambiguationContext& DC,
+                   bool onlyConsiderPromotion);
+
+// Regular resolve functions
 void resolveFormals(FnSymbol* fn);
 void resolveBlockStmt(BlockStmt* blockStmt);
 void resolveCall(CallExpr* call);
@@ -80,6 +214,13 @@ void resolveCallAndCallee(CallExpr* call, bool allowUnresolved = false);
 void makeRefType(Type* type);
 FnSymbol* tryResolveCall(CallExpr* call);
 void resolveFns(FnSymbol* fn);
+void resolveDefaultGenericType(CallExpr* call);
+void resolveTypedefedArgTypes(FnSymbol* fn);
+
+// FnSymbol changes
+extern bool tryFailure;
+void insertFormalTemps(FnSymbol* fn);
+void insertCasts(BaseAST* ast, FnSymbol* fn, Vec<CallExpr*>& casts);
 
 FnSymbol* defaultWrap(FnSymbol* fn, Vec<ArgSymbol*>* actualFormals,  CallInfo* info);
 void reorderActuals(FnSymbol* fn, Vec<ArgSymbol*>* actualFormals,  CallInfo* info);
@@ -92,6 +233,13 @@ FnSymbol* getUnalias(Type* t);
 
 
 bool isPOD(Type* t);
+
+// resolution errors and warnings
+void printResolutionErrorAmbiguous(Vec<FnSymbol*>& candidates, CallInfo* info);
+void printResolutionErrorUnresolved(Vec<FnSymbol*>& visibleFns, CallInfo* info);
+void resolveNormalCallCompilerWarningStuff(FnSymbol* resolvedFn);
+void lvalueCheck(CallExpr* call);
+void checkForStoringIntoTuple(CallExpr* call, FnSymbol* resolvedFn);
 
 // tuples
 FnSymbol* createTupleSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call);

--- a/compiler/resolution/Makefile.share
+++ b/compiler/resolution/Makefile.share
@@ -24,6 +24,7 @@ RESOLUTION_SRCS =                                    \
 	implementForallIntents.cpp                   \
 	generics.cpp                                 \
 	functionResolution.cpp                       \
+	initializerResolution.cpp                    \
 	lowerIterators.cpp                           \
 	tuples.cpp                                   \
 	wrappers.cpp

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -34,7 +34,7 @@
 #include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"
-#include "initializerRules.h"
+#include "initializerResolution.h"
 #include "iterator.h"
 #include "ParamForLoop.h"
 #include "passes.h"
@@ -66,88 +66,6 @@
 #else
 #define TRACE_DISAMBIGUATE_BY_MATCH(...)
 #endif
-
-/** Contextual info used by the disambiguation process.
- *
- * This class wraps information that is used by multiple functions during the
- * function disambiguation process.
- */
-class DisambiguationContext {
-public:
-  /// The actual arguments from the call site.
-  Vec<Symbol*>* actuals;
-  /// The scope in which the call is made.
-  Expr* scope;
-  /// Whether or not to print out tracing information.
-  bool explain;
-  /// Indexes used when printing out tracing information.
-  int i, j;
-
-  /** A simple constructor that initializes all of the values except i and j.
-   *
-   * \param actuals The actual arguments from the call site.
-   * \param scope   A block representing the scope the call was made in.
-   * \param explain Whether or not a trace of this disambiguation process should
-   *                be printed for the developer.
-   */
-  DisambiguationContext(Vec<Symbol*>* actuals, Expr* scope, bool explain) :
-    actuals(actuals), scope(scope), explain(explain), i(-1), j(-1) {}
-
-  /** A helper function used to set the i and j members.
-   *
-   * \param i The index of the left-hand side of the comparison.
-   * \param j The index of the right-hand side of the comparison.
-   *
-   * \return A constant reference to this disambiguation context.
-   */
-  const DisambiguationContext& forPair(int newI, int newJ) {
-    this->i = newI;
-    this->j = newJ;
-
-    return *this;
-  }
-};
-
-/** A wrapper for candidates for function call resolution.
- *
- * If a best candidate was found than the function member will point to it.
- */
-class ResolutionCandidate {
-public:
-  /// A pointer to the best candidate function.
-  FnSymbol* fn;
-
-  /** The actual arguments for the candidate, aligned so that they have the same
-   *  index as their corresponding formal argument in the called function.
-   */
-  Vec<Symbol*> formalIdxToActual; // note: was alignedActuals
-
-  /** The formal arguments for the candidate, aligned so that they have the same
-   *  index as their corresponding actual argument in the call.
-   */
-  Vec<ArgSymbol*> actualIdxToFormal; // note: was alignedFormals
-
-  /// A symbol map for substitutions that were made during the copying process.
-  SymbolMap substitutions;
-
-  /** The main constructor.
-   *
-   * \param fn A function that is a candidate for the resolution process.
-   */
-  ResolutionCandidate(FnSymbol* function) : fn(function) {}
-
-  /** Compute the alignment of actual and formal arguments for the wrapped
-   *  function and the current call site.
-   *
-   * \param info The CallInfo object corresponding to the call site.
-   *
-   * \return If a valid alignment was found.
-   */
-  bool computeAlignment(CallInfo& info);
-
-  /// Compute substitutions for wrapped function that is generic.
-  void computeSubstitutions();
-};
 
 /// State information used during the disambiguation process.
 class DisambiguationState {
@@ -198,10 +116,12 @@ bool resolved = false;
 bool inDynamicDispatchResolution = false;
 SymbolMap paramMap;
 
+int explainCallLine;
+bool tryFailure = false;
+
 //#
 //# Static Variables
 //#
-static int explainCallLine;
 static ModuleSymbol* explainCallModule;
 
 static Vec<CallExpr*> inits;
@@ -209,7 +129,6 @@ static Vec<FnSymbol*> resolvedFormals;
 Vec<CallExpr*> callStack;
 
 static Vec<CondStmt*> tryStack;
-static bool tryFailure = false;
 
 static Map<Type*,Type*> runtimeTypeMap; // map static types to runtime types
                                         // e.g. array and domain runtime types
@@ -271,8 +190,6 @@ static void
 computeGenericSubs(SymbolMap &subs,
                    FnSymbol* fn,
                    Vec<Symbol*>& formalIdxToActual);
-static FnSymbol*
-expandVarArgs(FnSymbol* origFn, int numActuals);
 
 static void
 filterCandidate(Vec<ResolutionCandidate*>& candidates,
@@ -290,29 +207,13 @@ isMoreVisibleInternal(BlockStmt* block, FnSymbol* fn1, FnSymbol* fn2,
                       Vec<BlockStmt*>& visited);
 static bool
 isMoreVisible(Expr* expr, FnSymbol* fn1, FnSymbol* fn2);
-static bool explainCallMatch(CallExpr* call);
 static CallExpr* userCall(CallExpr* call);
-static void
-printResolutionErrorAmbiguous(
-                     Vec<FnSymbol*>& candidateFns,
-                     CallInfo* info);
-static void
-printResolutionErrorUnresolved(
-                     Vec<FnSymbol*>& visibleFns,
-                     CallInfo* info);
 static void issueCompilerError(CallExpr* call);
 static void reissueCompilerWarning(const char* str, int offset);
 BlockStmt* getVisibilityBlock(Expr* expr);
-static void buildVisibleFunctionMap();
-static BlockStmt*
-getVisibleFunctions(BlockStmt* block,
-                    const char* name,
-                    Vec<FnSymbol*>& visibleFns,
-                    Vec<BlockStmt*>& visited,
-                    CallExpr* callOrigin);
 static Expr* resolve_type_expr(Expr* expr);
 static void makeNoop(CallExpr* call);
-static void resolveDefaultGenericType(CallExpr* call);
+void resolveDefaultGenericType(CallExpr* call);
 static Type* resolveDefaultGenericTypeSymExpr(SymExpr* se);
 
 static void
@@ -321,7 +222,6 @@ gatherCandidates(Vec<ResolutionCandidate*>& candidates,
                  CallInfo& info);
 
 static FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly=false);
-static void lvalueCheck(CallExpr* call);
 static void resolveTupleAndExpand(CallExpr* call);
 static void resolveTupleExpand(CallExpr* call);
 static void resolveSetMember(CallExpr* call);
@@ -329,7 +229,6 @@ static void resolveMove(CallExpr* call);
 static void resolveNew(CallExpr* call);
 static void resolveCoerce(CallExpr* call);
 static bool formalRequiresTemp(ArgSymbol* formal);
-static void insertFormalTemps(FnSymbol* fn);
 static void addLocalCopiesAndWritebacks(FnSymbol* fn, SymbolMap& formals2vars);
 
 static Expr* dropUnnecessaryCast(CallExpr* call);
@@ -338,7 +237,6 @@ static FnSymbol* createAndInsertFunParentMethod(CallExpr *call, AggregateType *p
 static std::string buildParentName(AList &arg_list, bool isFormal, Type *retType);
 static AggregateType* createOrFindFunTypeFromAnnotation(AList &arg_list, CallExpr *call);
 static Expr* createFunctionAsValue(CallExpr *call);
-static Type* resolveTypeAlias(SymExpr* se);
 static Type* resolveTypeAlias(SymExpr* se);
 static Expr* preFold(Expr* expr);
 static void foldEnumOp(int op, EnumSymbol *e1, EnumSymbol *e2, Immediate *imm);
@@ -354,8 +252,6 @@ computeReturnTypeParamVectors(BaseAST* ast,
                               Symbol* retSymbol,
                               Vec<Type*>& retTypes,
                               Vec<Symbol*>& retParams);
-static void
-insertCasts(BaseAST* ast, FnSymbol* fn, Vec<CallExpr*>& casts);
 static bool
 possible_signature_match(FnSymbol* fn, FnSymbol* gn);
 static bool signature_match(FnSymbol* fn, FnSymbol* gn);
@@ -367,7 +263,6 @@ static void addAllToVirtualMaps(FnSymbol* fn, AggregateType* ct);
 static void buildVirtualMaps();
 static void
 addVirtualMethodTableEntry(Type* type, FnSymbol* fn, bool exclusive = false);
-static void resolveTypedefedArgTypes(FnSymbol* fn);
 static void computeStandardModuleSet();
 static void unmarkDefaultedGenerics();
 static void resolveUses(ModuleSymbol* mod);
@@ -2394,7 +2289,7 @@ handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
 }
 
 
-static FnSymbol*
+FnSymbol*
 expandVarArgs(FnSymbol* origFn, int numActuals) {
 
   bool      genericArgSeen = false;
@@ -3099,7 +2994,7 @@ static void testArgMapping(FnSymbol* fn1, ArgSymbol* formal1,
  *
  * \return True if fn1 is a more specific function than f2, false otherwise.
  */
-static bool isBetterMatch(ResolutionCandidate* candidate1,
+bool isBetterMatch(ResolutionCandidate* candidate1,
                           ResolutionCandidate* candidate2,
                           const DisambiguationContext& DC,
                           bool onlyConsiderPromotion=false) {
@@ -3155,12 +3050,6 @@ static bool isBetterMatch(ResolutionCandidate* candidate1,
   return DS.fn1MoreSpecific && !DS.fn2MoreSpecific;
 }
 
-typedef enum {
-  FIND_EITHER = 0,
-  FIND_REF,
-  FIND_NOT_REF
-} disambiguate_kind_t;
-
 /** Find the best candidate from a list of candidates.
  *
  * This function finds the best Chapel function from a set of candidates, given
@@ -3173,7 +3062,7 @@ typedef enum {
  *
  * \return The result of the disambiguation process.
  */
-static ResolutionCandidate*
+ResolutionCandidate*
 disambiguateByMatch(Vec<ResolutionCandidate*>& candidates,
                     DisambiguationContext DC,
                     disambiguate_kind_t kind) {
@@ -3242,7 +3131,7 @@ disambiguateByMatch(Vec<ResolutionCandidate*>& candidates,
 }
 
 
-static bool
+bool
 explainCallMatch(CallExpr* call) {
   if (!call->isNamed(fExplainCall))
     return false;
@@ -3274,10 +3163,8 @@ userCall(CallExpr* call) {
 }
 
 
-static void
-printResolutionErrorAmbiguous(
-                     Vec<FnSymbol*>& candidates,
-                     CallInfo* info) {
+void
+printResolutionErrorAmbiguous(Vec<FnSymbol*>& candidates, CallInfo* info) {
   CallExpr* call = userCall(info->call);
   if (!strcmp("this", info->name)) {
     USR_FATAL(call, "ambiguous access of '%s' by '%s'",
@@ -3315,10 +3202,8 @@ printResolutionErrorAmbiguous(
   }
 }
 
-static void
-printResolutionErrorUnresolved(
-                     Vec<FnSymbol*>& visibleFns,
-                     CallInfo* info) {
+void
+printResolutionErrorUnresolved(Vec<FnSymbol*>& visibleFns, CallInfo* info) {
   if( ! info ) INT_FATAL("CallInfo is NULL");
   if( ! info->call ) INT_FATAL("call is NULL");
   bool needToReport = false;
@@ -3538,14 +3423,8 @@ static void reissueCompilerWarning(const char* str, int offset) {
   USR_WARN(from, "%s", str);
 }
 
-class VisibleFunctionBlock {
- public:
-  Map<const char*,Vec<FnSymbol*>*> visibleFunctions;
-  VisibleFunctionBlock() { }
-};
-
-static Map<BlockStmt*,VisibleFunctionBlock*> visibleFunctionMap;
-static int nVisibleFunctions = 0; // for incremental build
+Map<BlockStmt*,VisibleFunctionBlock*> visibleFunctionMap;
+int nVisibleFunctions = 0; // for incremental build
 static Map<BlockStmt*,BlockStmt*> visibilityBlockCache;
 static Vec<BlockStmt*> standardModuleSet;
 
@@ -3595,7 +3474,7 @@ getVisibilityBlock(Expr* expr) {
   }
 }
 
-static void buildVisibleFunctionMap() {
+void buildVisibleFunctionMap() {
   for (int i = nVisibleFunctions; i < gFnSymbols.n; i++) {
     FnSymbol* fn = gFnSymbols.v[i];
     if (!fn->hasFlag(FLAG_INVISIBLE_FN) && fn->defPoint->parentSymbol && !isArgSymbol(fn->defPoint->parentSymbol)) {
@@ -3648,7 +3527,7 @@ static void buildVisibleFunctionMap() {
 // getVisibleFunctions returns the block appropriate for visibilityBlockCache
 // or NULL if there is none, e.g. when the next block up is the rootModule.
 //
-static BlockStmt*
+BlockStmt*
 getVisibleFunctions(BlockStmt* block,
                     const char* name,
                     Vec<FnSymbol*>& visibleFns,
@@ -4169,7 +4048,7 @@ static void setFlagsAndCheckForConstAccess(Symbol* dest,
 
 // Report an error when storing a sync or single variable into a tuple.
 // This is because currently we deallocate memory excessively in this case.
-static void checkForStoringIntoTuple(CallExpr* call, FnSymbol* resolvedFn)
+void checkForStoringIntoTuple(CallExpr* call, FnSymbol* resolvedFn)
 {
   // Do not perform the checks if:
       // not building a tuple
@@ -4270,7 +4149,7 @@ resolveDefaultGenericTypeSymExpr(SymExpr* te) {
   return te->typeInfo();
 }
 
-static void
+void
 resolveDefaultGenericType(CallExpr* call) {
   SET_LINENO(call);
   for_actuals(actual, call) {
@@ -4629,23 +4508,26 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
     lvalueCheck(call);
     checkForStoringIntoTuple(call, resolvedFn);
 
-    if (const char* str = innerCompilerWarningMap.get(resolvedFn)) {
-      reissueCompilerWarning(str, 2);
-      if (callStack.n >= 2)
-        if (FnSymbol* fn = toFnSymbol(callStack.v[callStack.n-2]->isResolved()))
-          outerCompilerWarningMap.put(fn, str);
-    }
-
-    if (const char* str = outerCompilerWarningMap.get(resolvedFn)) {
-      reissueCompilerWarning(str, 1);
-    }
+    resolveNormalCallCompilerWarningStuff(resolvedFn);
   }
 
   return resolvedFn;
 }
 
+void resolveNormalCallCompilerWarningStuff(FnSymbol* resolvedFn) {
+  if (const char* str = innerCompilerWarningMap.get(resolvedFn)) {
+    reissueCompilerWarning(str, 2);
+    if (callStack.n >= 2)
+      if (FnSymbol* fn = toFnSymbol(callStack.v[callStack.n-2]->isResolved()))
+        outerCompilerWarningMap.put(fn, str);
+  }
 
-static void lvalueCheck(CallExpr* call)
+  if (const char* str = outerCompilerWarningMap.get(resolvedFn)) {
+    reissueCompilerWarning(str, 1);
+  }
+}
+
+void lvalueCheck(CallExpr* call)
 {
   // Check to ensure the actual supplied to an OUT, INOUT or REF argument
   // is an lvalue.
@@ -5382,7 +5264,7 @@ formalRequiresTemp(ArgSymbol* formal) {
      );
 }
 
-static void
+void
 insertFormalTemps(FnSymbol* fn) {
   SymbolMap formals2vars;
 
@@ -8090,7 +7972,7 @@ computeReturnTypeParamVectors(BaseAST* ast,
   AST_CHILDREN_CALL(ast, computeReturnTypeParamVectors, retSymbol, retTypes, retParams);
 }
 
-static void
+void
 insertCasts(BaseAST* ast, FnSymbol* fn, Vec<CallExpr*>& casts) {
   if (CallExpr* call = toCallExpr(ast)) {
     if (call->parentSymbol == fn) {
@@ -8996,7 +8878,7 @@ static void resolveExternVarSymbols()
 }
 
 
-static void resolveTypedefedArgTypes(FnSymbol* fn)
+void resolveTypedefedArgTypes(FnSymbol* fn)
 {
   for_formals(formal, fn)
   {

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -36,11 +36,11 @@
 #include <cstdlib>
 #include <inttypes.h>
 
-static int             explainInstantiationLine   = -2;
-static ModuleSymbol*   explainInstantiationModule = NULL;
+int                    explainInstantiationLine   = -2;
+ModuleSymbol*          explainInstantiationModule = NULL;
 static Vec<FnSymbol*>  whereStack;
 
-static void
+void
 explainInstantiation(FnSymbol* fn) {
   if (strcmp(fn->name, fExplainInstantiation) &&
       (strncmp(fn->name, "_construct_", 11) ||
@@ -97,7 +97,7 @@ explainInstantiation(FnSymbol* fn) {
 }
 
 
-static void
+void
 copyGenericSub(SymbolMap& subs, FnSymbol* root, FnSymbol* fn, Symbol* key, Symbol* value) {
   if (!strcmp("_type_construct__tuple", root->name) && key->name[0] == 'x') {
     subs.put(new_IntSymbol(atoi(key->name+1)), value);
@@ -114,7 +114,7 @@ copyGenericSub(SymbolMap& subs, FnSymbol* root, FnSymbol* fn, Symbol* key, Symbo
   }
 }
 
-static TypeSymbol*
+TypeSymbol*
 getNewSubType(FnSymbol* fn, Symbol* key, TypeSymbol* actualTS) {
   if (fn->hasEitherFlag(FLAG_TUPLE,FLAG_PARTIAL_TUPLE)) {
     return actualTS;
@@ -138,7 +138,7 @@ getNewSubType(FnSymbol* fn, Symbol* key, TypeSymbol* actualTS) {
 }
 
 
-static void
+void
 checkInfiniteWhereInstantiation(FnSymbol* fn) {
   if (fn->where) {
     forv_Vec(FnSymbol, where, whereStack) {
@@ -171,7 +171,7 @@ checkInfiniteWhereInstantiation(FnSymbol* fn) {
 // because folding is done via instantiation; therefore, be careful
 // developing in the base module
 //
-static void
+void
 checkInstantiationLimit(FnSymbol* fn) {
   static Map<FnSymbol*,int> instantiationLimitMap;
 
@@ -197,7 +197,7 @@ checkInstantiationLimit(FnSymbol* fn) {
 }
 
 
-static void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
+void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
 {
   const size_t bufSize = 128;
   char immediate[bufSize];

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "initializerResolution.h"
+
+#include "astutil.h"
+#include "caches.h"
+#include "callInfo.h"
+#include "expr.h"
+#include "initializerRules.h"
+#include "passes.h"
+#include "resolution.h"
+#include "stlUtil.h"
+#include "stmt.h"
+#include "stringutil.h"
+#include "symbol.h"
+#include "type.h"
+#include "view.h"
+
+void temporaryInitializerFixup(CallExpr* call) {
+  if (UnresolvedSymExpr* usym = toUnresolvedSymExpr(call->baseExpr)) {
+    // Support super.init() calls (for instance) when the super type does not
+    // define either an initializer or a constructor.  Also ignores errors from
+    // improperly inserted .init() calls (so be sure to check here if something
+    // is behaving oddly - Lydia, 08/19/16)
+    if (strcmp(usym->unresolved, "init") == 0 &&
+        call->numActuals()               >= 2) {
+      SymExpr* _mt = toSymExpr(call->get(1));
+      SymExpr* sym = toSymExpr(call->get(2));
+
+      INT_ASSERT(sym != NULL);
+
+      if (AggregateType* ct = toAggregateType(sym->symbol()->type)) {
+        if (ct->initializerStyle == DEFINES_NONE_USE_DEFAULT) {
+
+          // This code should be removed when the compiler generates
+          // initializers as the default method of construction and
+          // initialization for a type (Lydia note, 08/19/16)
+          usym->unresolved = astr("_construct_", ct->symbol->name);
+
+          _mt->remove();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This involved moving some contents from initializerRules into
initializerResolution.  It also moved a lot of class and function declarations
into resolution.h, as my support for resolving initializers relies on them.

I suspect this may impact compilation time in the resolve pass, as this removes
the static declaration from roughly 15-20 functions.  We shall see.