### PR TITLE
Edits to CHIP 10 on deinit()

### DIFF
--- a/doc/developer/chips/10.rst
+++ b/doc/developer/chips/10.rst
@@ -533,7 +533,7 @@ Deinitialization
 
 Deinitialization is performed in these cases:
 
- * For a ``var`` or ``const`` variable - when it does out of scope.
+ * For a ``var`` or ``const`` variable - when it goes out of scope.
  * For a ``[const] in`` formal - before its parent function returns;
    after the return value has been computed.
    There may be exceptions when a record or an array is returned.
@@ -551,17 +551,16 @@ Deinitialization is performed in these cases:
 Deinitialization consists of the following actions,
 depending on the type of the variable being deinitialized:
 
- * Primitive, enumerated, range, class, synchronization types -
+ * Primitive, enumerated, range, class, synchronization type -
    nothing happens. Implementation-level actions,
    ex. deallocation of a string or a sync variable,
    can be performed without affecting the observable behavior directly.
+ * Tuple - its components are deinitialized.
  * A record variable; a class instance (upon ``delete``) - see below.
- * Unions - t.b.d.
- * Arrays, domains, distributions - defined by their domain map
-   in a way t.b.d.
- * Arrays, tuples - their elements/components are deinitialized.
- * For an array, its elements are deinitialized before
-   its domain map-defined actions are performed.
+ * Union - t.b.d.
+ * Array - its elements are deinitialized. Then, additional actions
+   are performed as defined by its domain map, if any.
+ * Domain, distribution - defined by their domain map in a way t.b.d.
  * Alias types - at present, the action is determined by the aliasee type.
 
 Note that we distinguish between:
@@ -573,9 +572,9 @@ Note that we distinguish between:
 The remainder of this section is concerned with deinitialization of
 record variables, or "records", and class instances, or "classes".
  
-To specify actions that occur upon deinitialization, specify a `proc
-deinit()` method. This method must have zero arguments and cannot be called
-directly. If a type does not specify a `proc deinit()` method, the compiler
+To specify actions that occur upon deinitialization, specify a ``proc
+deinit()`` method. This method must have zero arguments and cannot be called
+directly. If a type does not specify a ``proc deinit()`` method, the compiler
 will generate one.
 It will be equivalent to a user-written ``deinit`` with an empty body.
 
@@ -585,10 +584,10 @@ compiler-generated or user-defined, in the process of deinitialization:
  * parent ``deinit`` methods are called in the case of inherited classes, and
  * all fields of record type are deinitialized.
 
-The expected use-case for the `deinit` method is to call `delete` on
+The expected use-case for the ``deinit`` method is to call ``delete`` on
 fields of class type, when appropriate. It is the responsibility of the
-class designer to `delete` fields when appropriate. The compiler will not
-automatically add `delete` calls for fields of class type.
+class designer to ``delete`` fields when appropriate. The compiler will not
+automatically add ``delete`` calls for fields of class type.
 Conversely, the compiler adds ``deinit`` calls on fields of record type.
 These calls cannot be added by the user.
 
@@ -618,13 +617,16 @@ in reverse declaration order.
 Rationale
 *********
 
-The goal of the above specifications is support type safety, specifically
+Our goal is to support type safety, specifically
 to prevent accesses to fields after they have been deinitialized.
 This includes preventing access to an array after its domain
 has been deinitialized.
-
-The above specifications one way to achieve this goal.
+The above rules specify one way to achieve this goal.
 They are a work in progress.
+
+For example, disallowing the use of ``this`` as a whole within ``deinit``
+is intended merely as the minimum functionality currently required,
+so that we can refine it in the future without breaking code.
 
 
 Summary

--- a/doc/developer/chips/10.rst
+++ b/doc/developer/chips/10.rst
@@ -533,102 +533,99 @@ Deinitialization
 
 Deinitialization is performed in these cases:
 
- * Record variables are deinitialized when they go out of scope.
- * Class variables are deinitialized when `delete` is called on them.
+ * For a ``var`` or ``const`` variable - when it does out of scope.
+ * For a ``[const] in`` formal - before its parent function returns;
+   after the return value has been computed.
+   There may be exceptions when a record or an array is returned.
+ * For a ``[const] ref`` formal - never directly.
+   Deinitialization is performed on the corresponding actual
+   as required by these rules.
+ * For a component of an aggregate - when the enclosing aggregate
+   is deinitialized. This includes:
+    + fields of a record or class,
+    + elements of an array,
+    + components of a tuple.
+ * For a class instance - when ``delete`` is invoked on a variable
+   that references that class instance.
 
-To specify actions that occur upon deinitialization, user can specify a `proc
+Deinitialization consists of the following actions,
+depending on the type of the variable being deinitialized:
+
+ * Primitive, enumerated, range, class, synchronization types -
+   nothing happens. Implementation-level actions,
+   ex. deallocation of a string or a sync variable,
+   can be performed without affecting the observable behavior directly.
+ * A record variable; a class instance (upon ``delete``) - see below.
+ * Unions - t.b.d.
+ * Arrays, domains, distributions - defined by their domain map
+   in a way t.b.d.
+ * Arrays, tuples - their elements/components are deinitialized.
+ * For an array, its elements are deinitialized before
+   its domain map-defined actions are performed.
+ * Alias types - at present, the action is determined by the aliasee type.
+
+Note that we distinguish between:
+
+ * deinitialization of a class variable, which is a no-op, and
+ * deinitialization of a class instance, which happens upon ``delete``
+   on a class variable and is defined below.
+
+The remainder of this section is concerned with deinitialization of
+record variables, or "records", and class instances, or "classes".
+ 
+To specify actions that occur upon deinitialization, specify a `proc
 deinit()` method. This method must have zero arguments and cannot be called
 directly. If a type does not specify a `proc deinit()` method, the compiler
 will generate one.
-It will be equivalent to a user-written `deinit` with an empty body.
+It will be equivalent to a user-written ``deinit`` with an empty body.
 
-In addition to the actions specified by the `deinit` method, whether
+In addition to the actions specified by the ``deinit`` method, whether
 compiler-generated or user-defined, in the process of deinitialization:
 
- * parent `deinit` methods are called in the case of inherited classes, and
+ * parent ``deinit`` methods are called in the case of inherited classes, and
  * all fields of record type are deinitialized.
 
 The expected use-case for the `deinit` method is to call `delete` on
 fields of class type, when appropriate. It is the responsibility of the
 class designer to `delete` fields when appropriate. The compiler will not
 automatically add `delete` calls for fields of class type.
-Conversely, the compiler adds `deinit` calls on fields of record type.
+Conversely, the compiler adds ``deinit`` calls on fields of record type.
 These calls cannot be added by the user.
-
-Ensuring type safety
-********************
-
-We would like to ensure that a field cannot be accessed after it has been
-deinitialized. In the deinitialization process, the field `F` of a record
-or class `RC` could potentially be accessed in the following cases:
-
- (a) From `RC.deinit()` or functions it invokes.
-
- (b) From `deinit()` in a child of `RC` (if `RC` is a class),
-     via direct reference or a function call not involving
-     dynamic dispatch on `this`.
-
- (c) From `deinit` in a parent of `RC` by invoking a method on `this`
-     that dynamically dispatches to `RC` or RC's child.
-
- (d) In the case of dependencies between fields within `RC`, when
-     deinitializing a field that depends on `F`.
-     Recall that field initialization order prevents fields of
-     a child class to depend on fields of a parent class.
-
-As a simple example of field dependency in (d), in the following code
-the field `A` depends on the field `D`:
-
-.. code-block:: chapel
-
-    record R {
-      const n = 10;
-      const D = {1..n};
-      var A: [D] real;
-      ...
-    }
-
-Our current proposal handles these cases as follows:
-
- (a) `RC.deinit()` is executed before `F` is deinitialized.
-
- (b) `deinit()` in children of `RC`, if any, are invoked
-     before `RC.deinit()` and therefore before `F` is deinitialized.
-
- (c) Dynamic dispatch on `this` is disallowed in `deinit` methods.
-
- (d) Dependent fields within `RC` are deinitialized
-     in reverse declaration order.
-
-This approach is detailed below. It is a work in progress.
 
 Limitations
 ***********
 
-It is an error for a `deinit` method to make a virtual method call, including
-by passing `this` to another function or method that in turn makes a virtual
-method call.
+It is an error for a ``deinit`` method to invoke a method
+on ``this`` or to pass ``this`` as an argument to a function.
 
-However, when a class inherits from another class, its `deinit` method can
-refer to any field in that class or its parent classes.
+However, the ``deinit`` method can refer to any field in its class or
+record. The ``deinit`` in a class can also refer to any field in its
+parent class(es), if any.
 
 Order of deinitialization
 *************************
 
-Suppose a class `Child` inherits from another class `Parent`.  When a
-variable of type `Child` is deinitialized, the compiler will arrange to call the
-`deinit` methods - first for `Child`, then for Parent.
+Suppose a class ``Child`` inherits from another class ``Parent``.
+When an instance of ``Child`` is deinitialized, the ``deinit`` method
+for ``Child`` is invoked before the ``deinit`` method for ``Parent``.
 
 The fields of a given class or record will be deinitialized after the
-`deinit` method for that class or record has completed.
+``deinit`` method for that class or record has completed.
 
-Within a class or a record, record fields are deinitialized in reverse
-declaration order.
+Within a class or a record, fields are deinitialized
+in reverse declaration order.
 
-This proposal does not define the de-initialization order of fields within a
-class. However note that when one field uses another - such as when an array is
-declared over a domain in another field - the field declared later (the array)
-would need to be de-initialized first.
+Rationale
+*********
+
+The goal of the above specifications is support type safety, specifically
+to prevent accesses to fields after they have been deinitialized.
+This includes preventing access to an array after its domain
+has been deinitialized.
+
+The above specifications one way to achieve this goal.
+They are a work in progress.
+
 
 Summary
 +++++++

--- a/doc/developer/chips/10.rst
+++ b/doc/developer/chips/10.rst
@@ -537,16 +537,28 @@ Deinitialization is performed in these cases:
  * For a ``[const] in`` formal - before its parent function returns;
    after the return value has been computed.
    There may be exceptions when a record or an array is returned.
- * For a ``[const] ref`` formal - never directly.
-   Deinitialization is performed on the corresponding actual
-   as required by these rules.
+ * For a ``[const] ref`` formal or a ``[const] ref`` variable - never directly.
+   (The corresponding actual or aliasee is subject to these rules
+   independently.)
  * For a component of an aggregate - when the enclosing aggregate
    is deinitialized. This includes:
+
     + fields of a record or class,
     + elements of an array,
     + components of a tuple.
+
  * For a class instance - when ``delete`` is invoked on a variable
    that references that class instance.
+
+.. We may want to mention what happens for the other kinds of formals,
+   for 'param' constants and 'type' aliases. We do not feel like this
+   CHIP needs to go into that.
+
+.. For example, an 'inout' or 'out' formal is currently converted
+   to a 'ref' formal plus assignments to/from a local copy of the value.
+   There is deinitialization to be done to that local copy.
+
+.. For the spec, we should also specify an optional "move" optimization.
 
 Deinitialization consists of the following actions,
 depending on the type of the variable being deinitialized:
@@ -614,8 +626,8 @@ The fields of a given class or record will be deinitialized after the
 Within a class or a record, fields are deinitialized
 in reverse declaration order.
 
-Rationale
-*********
+Rationale for deinit Rules
+**************************
 
 Our goal is to support type safety, specifically
 to prevent accesses to fields after they have been deinitialized.

--- a/doc/developer/chips/10.rst
+++ b/doc/developer/chips/10.rst
@@ -531,24 +531,76 @@ For more details on when the copy initializer would be called, please refer to
 Deinitialization
 ++++++++++++++++
 
-Records and classes can specify actions to take when a variable of that type is
-deinitialized. Record variables are deinitialized when they go out of scope and
-class variables are deinitialized when `delete` is called on them.
+Deinitialization is performed in these cases:
 
-To specify additional actions that occur upon deinitialization, specify a `proc
+ * Record variables are deinitialized when they go out of scope.
+ * Class variables are deinitialized when `delete` is called on them.
+
+To specify actions that occur upon deinitialization, user can specify a `proc
 deinit()` method. This method must have zero arguments and cannot be called
 directly. If a type does not specify a `proc deinit()` method, the compiler
 will generate one.
+It will be equivalent to a user-written `deinit` with an empty body.
 
-No matter whether the `deinit` method is compiler generated or user-defined,
-the compiler will ensure that in the process of deinitialization, all fields of
-record type are deinitialized. Additionally, the compiler will ensure that
-parent `deinit` methods are called in the case of inherited classes.
+In addition to the actions specified by the `deinit` method, whether
+compiler-generated or user-defined, in the process of deinitialization:
+
+ * parent `deinit` methods are called in the case of inherited classes, and
+ * all fields of record type are deinitialized.
 
 The expected use-case for the `deinit` method is to call `delete` on
 fields of class type, when appropriate. It is the responsibility of the
 class designer to `delete` fields when appropriate. The compiler will not
 automatically add `delete` calls for fields of class type.
+Conversely, the compiler adds `deinit` calls on fields of record type.
+These calls cannot be added by the user.
+
+Ensuring type safety
+********************
+
+We would like to ensure that a field cannot be accessed after it has been
+deinitialized. In the deinitialization process, the field `F` of a record
+or class `RC` could potentially be accessed in the following cases:
+
+ (a) From `RC.deinit()` or functions it invokes.
+
+ (b) From `deinit()` in a child of `RC` (if `RC` is a class),
+     via direct reference or a function call not involving
+     dynamic dispatch on `this`.
+
+ (c) From `deinit` in a parent of `RC` by invoking a method on `this`
+     that dynamically dispatches to `RC` or RC's child.
+
+ (d) In the case of dependencies between fields within `RC`, when
+     deinitializing a field that depends on `F`.
+     Recall that field initialization order prevents fields of
+     a child class to depend on fields of a parent class.
+
+As a simple example of field dependency in (d), in the following code
+the field `A` depends on the field `D`:
+
+.. code-block:: chapel
+
+    record R {
+      const n = 10;
+      const D = {1..n};
+      var A: [D] real;
+      ...
+    }
+
+Our current proposal handles these cases as follows:
+
+ (a) `RC.deinit()` is executed before `F` is deinitialized.
+
+ (b) `deinit()` in children of `RC`, if any, are invoked
+     before `RC.deinit()` and therefore before `F` is deinitialized.
+
+ (c) Dynamic dispatch on `this` is disallowed in `deinit` methods.
+
+ (d) Dependent fields within `RC` are deinitialized
+     in reverse declaration order.
+
+This approach is detailed below. It is a work in progress.
 
 Limitations
 ***********
@@ -560,17 +612,15 @@ method call.
 However, when a class inherits from another class, its `deinit` method can
 refer to any field in that class or its parent classes.
 
-The exact details of this limitation are a work in progress.
-
 Order of deinitialization
 *************************
 
-Suppose a class ("Child") inherits from another class ("Parent").  When a
-variable of type Child is deinitialized, the compiler will arrange to call the
-`deinit` method for both Child and Parent. It will call the `deinit` method for
-Child first. Since fields can be used in the `deinit` methods, the fields of a
-given class will only be deinitialized after the `deinit` method for that class
-is run.
+Suppose a class `Child` inherits from another class `Parent`.  When a
+variable of type `Child` is deinitialized, the compiler will arrange to call the
+`deinit` methods - first for `Child`, then for Parent.
+
+The fields of a given class or record will be deinitialized after the
+`deinit` method for that class or record has completed.
 
 Within a class or a record, record fields are deinitialized in reverse
 declaration order.

--- a/doc/developer/chips/10.rst
+++ b/doc/developer/chips/10.rst
@@ -531,59 +531,6 @@ For more details on when the copy initializer would be called, please refer to
 Deinitialization
 ++++++++++++++++
 
-Deinitialization is performed in these cases:
-
- * For a ``var`` or ``const`` variable - when it goes out of scope.
- * For a ``[const] in`` formal - before its parent function returns;
-   after the return value has been computed.
-   There may be exceptions when a record or an array is returned.
- * For a ``[const] ref`` formal or a ``[const] ref`` variable - never directly.
-   (The corresponding actual or aliasee is subject to these rules
-   independently.)
- * For a component of an aggregate - when the enclosing aggregate
-   is deinitialized. This includes:
-
-    + fields of a record or class,
-    + elements of an array,
-    + components of a tuple.
-
- * For a class instance - when ``delete`` is invoked on a variable
-   that references that class instance.
-
-.. We may want to mention what happens for the other kinds of formals,
-   for 'param' constants and 'type' aliases. We do not feel like this
-   CHIP needs to go into that.
-
-.. For example, an 'inout' or 'out' formal is currently converted
-   to a 'ref' formal plus assignments to/from a local copy of the value.
-   There is deinitialization to be done to that local copy.
-
-.. For the spec, we should also specify an optional "move" optimization.
-
-Deinitialization consists of the following actions,
-depending on the type of the variable being deinitialized:
-
- * Primitive, enumerated, range, class, synchronization type -
-   nothing happens. Implementation-level actions,
-   ex. deallocation of a string or a sync variable,
-   can be performed without affecting the observable behavior directly.
- * Tuple - its components are deinitialized.
- * A record variable; a class instance (upon ``delete``) - see below.
- * Union - t.b.d.
- * Array - its elements are deinitialized. Then, additional actions
-   are performed as defined by its domain map, if any.
- * Domain, distribution - defined by their domain map in a way t.b.d.
- * Alias types - at present, the action is determined by the aliasee type.
-
-Note that we distinguish between:
-
- * deinitialization of a class variable, which is a no-op, and
- * deinitialization of a class instance, which happens upon ``delete``
-   on a class variable and is defined below.
-
-The remainder of this section is concerned with deinitialization of
-record variables, or "records", and class instances, or "classes".
- 
 To specify actions that occur upon deinitialization, specify a ``proc
 deinit()`` method. This method must have zero arguments and cannot be called
 directly. If a type does not specify a ``proc deinit()`` method, the compiler


### PR DESCRIPTION
Clarified that a compiler-generated deinit() is equivalent
to an empty user-defined deinit().

Added the rationale for current rules.

Minor style changes.

More changes needed
-------------------

While reading the CHIP, I realized that

* We need to define deinitialization at least for arrays.

* Deinitialization makes sense also for domains,
given that the domain map author may want to perform some actions
(like freeing resources) when the domain is deleted.

* To dot all the Is, we should at some point look through
all Chapel types and see which ones need to have deinitialization
defined or be not a NOP.

  As an intermediate step we could say things like "defining the actions
that happen when a domain is deinitialized is future work."

* The current CHIP imposes deinitialization order on record fields
and hints on that requirement for array/domain fields. Meanwhile
Brad in his email on 1/26 suggested, and we all agreed to,
reverse-declaration order of deinitialization for **all** fields.
Should we change the CHIP accordingly?

* [ ] change single backticks to double backticks
