### PR TITLE
Enable user-defined deinit() methods

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2394,7 +2394,8 @@ buildFunctionSymbol(FnSymbol*   fn,
   fn->cname   = fn->name = astr(name);
   fn->thisTag = thisTag;
 
-  if (fn->name[0] == '~' && fn->name[1] != '\0')
+  if ((fn->name[0] == '~' && fn->name[1] != '\0') ||
+      (strcmp(fn->name, "deinit") == 0))
     fn->addFlag(FLAG_DESTRUCTOR);
 
   if (receiver)

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1492,12 +1492,12 @@ static void buildStringCastFunction(EnumType* et) {
 
 
 void buildDefaultDestructor(AggregateType* ct) {
-  if (function_exists("chpl__deinit", 2, dtMethodToken, ct))
+  if (function_exists("deinit", 2, dtMethodToken, ct))
     return;
 
   SET_LINENO(ct->symbol);
 
-  FnSymbol* fn = new FnSymbol("chpl__deinit");
+  FnSymbol* fn = new FnSymbol("deinit");
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_DESTRUCTOR);
   fn->addFlag(FLAG_INLINE);

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -135,6 +135,7 @@ static const char* deinitAstr;
 static VarSymbol*  deinitStrLiteral;
 
 static void setupForCheckExplicitDeinitCalls() {
+  SET_LINENO(rootModule); // for --minimal-modules
   dotAstr = astr(".");
   deinitAstr = astr("deinit");
   deinitStrLiteral = new_CStringSymbol("deinit");

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -200,7 +200,7 @@ static void change_cast_in_where(FnSymbol* fn) {
 static void add_parens_to_deinit_fns(FnSymbol* fn) {
   if (fn->hasFlag(FLAG_DESTRUCTOR))
     // Make paren-less decls act as paren-ful. Otherwise
-    // "arg.chpl__deinit()" in proc chpl__delete(arg)
+    // "arg.deinit()" in proc chpl__delete(arg)
     // would not resolve.
     fn->removeFlag(FLAG_NO_PARENS);
 }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -173,13 +173,14 @@ void normalize() {
         DefExpr*       thisDef = toDefExpr(fn->formals.get(2));
         AggregateType* ct      = toAggregateType(thisDef->sym->type);
 
-        INT_ASSERT(fn->name[0] == '~' && thisDef);
+        INT_ASSERT(thisDef);
 
-        // make sure the name of the destructor matches the name of the class
-        if (ct && strcmp(fn->name + 1, ct->symbol->name) != 0) {
-          USR_FATAL(fn, "destructor name must match class name");
+        // verify the name of the destructor
+        if (ct && (strcmp(fn->name + 1, ct->symbol->name) &&
+                   strcmp(fn->name, "deinit"))) {
+          USR_FATAL(fn, "destructor name must match class name or deinit()");
         } else {
-          fn->name = astr("chpl__deinit");
+          fn->name = astr("deinit");
         }
       }
     // make sure methods don't attempt to overload operators

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -176,9 +176,13 @@ void normalize() {
         INT_ASSERT(thisDef);
 
         // verify the name of the destructor
-        if (ct && (strcmp(fn->name + 1, ct->symbol->name) &&
-                   strcmp(fn->name, "deinit"))) {
-          USR_FATAL(fn, "destructor name must match class name or deinit()");
+        bool notTildaName = (fn->name[0] != '~') ||
+                             strcmp(fn->name + 1, ct->symbol->name);
+        bool notDeinit = strcmp(fn->name, "deinit");
+
+        if (ct && notDeinit && notTildaName) {
+          USR_FATAL(fn,
+            "destructor name must match class/record name or deinit()");
         } else {
           fn->name = astr("deinit");
         }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8430,7 +8430,7 @@ resolveFns(FnSymbol* fn) {
           !isTupleContainingOnlyReferences(ct)) {
         BlockStmt* block = new BlockStmt();
         VarSymbol* tmp   = newTemp(ct);
-        CallExpr*  call  = new CallExpr("chpl__deinit", gMethodToken, tmp);
+        CallExpr*  call  = new CallExpr("deinit", gMethodToken, tmp);
 
         // In case resolveCall drops other stuff into the tree ahead of the
         // call, we wrap everything in a block for safe removal.

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -271,7 +271,7 @@ FnSymbol* makeDestructTuple(TypeSymbol* newTypeSymbol,
 {
   Type *newType = newTypeSymbol->type;
 
-  FnSymbol *dtor = new FnSymbol("chpl__deinit");
+  FnSymbol *dtor = new FnSymbol("deinit");
 
   dtor->cname = astr("chpl__auto_destroy_", newType->symbol->cname);
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1162,7 +1162,7 @@ module ChapelBase {
     if (isRecord(arg)) then
       compilerError("delete not allowed on records");
 
-    arg.chpl__deinit();
+    arg.deinit();
     on arg do
       chpl_here_free(__primitive("_wide_get_addr", arg));
   }

--- a/test/classes/deinitializers/deinit.chpl
+++ b/test/classes/deinitializers/deinit.chpl
@@ -1,0 +1,8 @@
+class C {
+  proc deinit() {
+    writeln("In my deinitializer!");
+  }
+}
+
+var myC = new C();
+delete myC;

--- a/test/classes/deinitializers/deinit.good
+++ b/test/classes/deinitializers/deinit.good
@@ -1,0 +1,1 @@
+In my deinitializer!

--- a/test/classes/deinitializers/deinitAndDestruct.chpl
+++ b/test/classes/deinitializers/deinitAndDestruct.chpl
@@ -1,0 +1,12 @@
+class C {
+  proc ~C() {
+    writeln("In my destructor!");
+  }
+  
+  proc deinit() {
+    writeln("In my deinitializer!");
+  }
+}
+
+var myC = new C();
+delete myC;

--- a/test/classes/deinitializers/deinitAndDestruct.good
+++ b/test/classes/deinitializers/deinitAndDestruct.good
@@ -1,0 +1,3 @@
+deinitAndDestruct.chpl:11: error: ambiguous call 'C.deinit()'
+deinitAndDestruct.chpl:2: note: candidates are: C.~C()
+deinitAndDestruct.chpl:6: note:                 C.deinit()

--- a/test/classes/deinitializers/deinitExplicitCall.chpl
+++ b/test/classes/deinitializers/deinitExplicitCall.chpl
@@ -1,0 +1,10 @@
+
+class CC { proc deinit() { writeln("CC.deinit()"); } }
+record RR { proc deinit() { writeln("RR.deinit()"); } }
+
+var cc = new CC();
+cc.deinit();
+delete cc;
+
+var rr: RR;
+rr.deinit();

--- a/test/classes/deinitializers/deinitExplicitCall.chpl
+++ b/test/classes/deinitializers/deinitExplicitCall.chpl
@@ -8,3 +8,12 @@ delete cc;
 
 var rr: RR;
 rr.deinit();
+
+deinit();
+deinit(cc);
+
+proc RR.something() {
+  deinit();
+  deinit(cc);
+}
+rr.something();

--- a/test/classes/deinitializers/deinitExplicitCall.good
+++ b/test/classes/deinitializers/deinitExplicitCall.good
@@ -1,2 +1,7 @@
 deinitExplicitCall.chpl:6: error: direct calls to deinit() are not allowed
 deinitExplicitCall.chpl:10: error: direct calls to deinit() are not allowed
+deinitExplicitCall.chpl:12: error: direct calls to deinit() are not allowed
+deinitExplicitCall.chpl:13: error: direct calls to deinit() are not allowed
+deinitExplicitCall.chpl:15: In function 'something':
+deinitExplicitCall.chpl:16: error: direct calls to deinit() are not allowed
+deinitExplicitCall.chpl:17: error: direct calls to deinit() are not allowed

--- a/test/classes/deinitializers/deinitExplicitCall.good
+++ b/test/classes/deinitializers/deinitExplicitCall.good
@@ -1,0 +1,2 @@
+deinitExplicitCall.chpl:6: error: direct calls to deinit() are not allowed
+deinitExplicitCall.chpl:10: error: direct calls to deinit() are not allowed

--- a/test/classes/deinitializers/deinitWithArg.chpl
+++ b/test/classes/deinitializers/deinitWithArg.chpl
@@ -1,0 +1,8 @@
+class C {
+  proc deinit(x: int) {
+    writeln("In deinit, x is: ", x, "!");
+  }
+}
+
+var myC = new C();
+delete myC;

--- a/test/classes/deinitializers/deinitWithArg.good
+++ b/test/classes/deinitializers/deinitWithArg.good
@@ -1,0 +1,1 @@
+deinitWithArg.chpl:2: error: destructors must not have arguments

--- a/test/classes/deinitializers/fieldorder.chpl
+++ b/test/classes/deinitializers/fieldorder.chpl
@@ -1,0 +1,69 @@
+
+config var confighelp = true;
+
+record F1 { proc deinit() { writeln("F1.deinit()"); } }
+record F2 { proc deinit() { writeln("F2.deinit()"); } }
+record F3 { proc deinit() { writeln("F3.deinit()"); } }
+record F4 { proc deinit() { writeln("F4.deinit()"); } }
+{
+  writeln("checking helpers F1-F4");
+  var f1: F1;
+  var f2: F2;
+  var f3: F3;
+  var f4: F4;
+}
+
+record RR { var f1: F1; var f2: F2; }
+{
+  writeln("checking field order in RR");
+  var rr: RR;
+}
+
+class CC { var f1: F1; var f2: F2; }
+{
+  writeln("checking field order in CC");
+  var cc = new CC();
+  delete cc;
+}
+
+class DD: CC { var f3: F3; var f4: F4; }
+{
+  writeln("checking field order in DD, child of CC");
+  writeln(" dd1");
+  var dd1 = new DD();
+  delete dd1;
+  writeln(" dd2");
+  var dd2: CC = if confighelp then new DD() else new CC();
+  delete dd2;
+  anotherCheckDD(true);
+  anotherCheckDD(false);
+}
+proc anotherCheckDD(arg:bool) {
+  writeln(" dd3 - ", arg);
+  var dd3: CC = if arg then new DD() else new CC();
+  delete dd3;
+}
+
+class EE {
+  var f1: F1;
+  var f2: F2;
+  proc deinit() { writeln("EE.deinit()"); }
+}
+{
+  writeln("checking field and deinit order in EE");
+  var ee = new EE();
+  delete ee;
+}
+
+class FF: EE {
+  var f3: F3;
+  var f4: F4;
+  // As of Jan 2017, it is undefined whether EE.deinit() is invoked
+  // before or after or in the middle of f3.deinit() and f4.deinit().
+  proc deinit() { writeln("FF.deinit()"); }
+}
+{
+  writeln("checking field and deinit order in FF, child of EE");
+  var ff = new FF();
+  delete ff;
+}

--- a/test/classes/deinitializers/fieldorder.good
+++ b/test/classes/deinitializers/fieldorder.good
@@ -1,0 +1,41 @@
+checking helpers F1-F4
+F1.deinit()
+F2.deinit()
+F3.deinit()
+F4.deinit()
+checking field order in RR
+F2.deinit()
+F1.deinit()
+checking field order in CC
+F2.deinit()
+F1.deinit()
+checking field order in DD, child of CC
+ dd1
+F4.deinit()
+F3.deinit()
+F2.deinit()
+F1.deinit()
+ dd2
+F4.deinit()
+F3.deinit()
+F2.deinit()
+F1.deinit()
+ dd3 - true
+F4.deinit()
+F3.deinit()
+F2.deinit()
+F1.deinit()
+ dd3 - false
+F2.deinit()
+F1.deinit()
+checking field and deinit order in EE
+EE.deinit()
+F2.deinit()
+F1.deinit()
+checking field and deinit order in FF, child of EE
+FF.deinit()
+F4.deinit()
+F3.deinit()
+EE.deinit()
+F2.deinit()
+F1.deinit()

--- a/test/classes/diten/multipledestructor.chpl
+++ b/test/classes/diten/multipledestructor.chpl
@@ -1,7 +1,7 @@
 class C {
-  proc ~C() { writeln("In ~C #1"); }
+  proc deinit() { writeln("In deinit #1"); }
 }
-proc C.~C() { writeln("In ~C #2"); }
+proc C.deinit() { writeln("In deinit #2"); }
 
 proc main {
   var c = new C();

--- a/test/classes/diten/multipledestructor.good
+++ b/test/classes/diten/multipledestructor.good
@@ -1,3 +1,3 @@
-multipledestructor.chpl:7: error: ambiguous call 'C.chpl__deinit()'
-multipledestructor.chpl:2: note: candidates are: C.~C()
-multipledestructor.chpl:4: note:                 C.~C()
+multipledestructor.chpl:7: error: ambiguous call 'C.deinit()'
+multipledestructor.chpl:2: note: candidates are: C.deinit()
+multipledestructor.chpl:4: note:                 C.deinit()

--- a/test/classes/figueroa/BogusDestructors.chpl
+++ b/test/classes/figueroa/BogusDestructors.chpl
@@ -1,15 +1,10 @@
+// See also: test/classes/deinitializers/deinitAndDestruct
+
 class C {
   proc ~C () {writeln("inside ~C");}
 }
 
 proc C.~C () {writeln("inside C.~C");}
 
-record R {
-  proc ~R () {writeln("inside ~R");}
-}
-
 var c: C;
-var r: R;
-
-delete c;
-delete r;
+delete c; // not intended to be executed

--- a/test/classes/figueroa/BogusDestructors.future
+++ b/test/classes/figueroa/BogusDestructors.future
@@ -1,8 +1,0 @@
-error message: "chpl_destroy" should not appear in the error message
-
-error message: destructors may not be defined for a record
-
-error message: class instances that have not been created (using new)
-may not be destroyed
-
-error message: records may not be destroyed

--- a/test/classes/figueroa/BogusDestructors.good
+++ b/test/classes/figueroa/BogusDestructors.good
@@ -1,1 +1,3 @@
-Replace this file once these bugs are fixed!
+BogusDestructors.chpl:9: error: ambiguous call 'C.deinit()'
+BogusDestructors.chpl:4: note: candidates are: C.~C()
+BogusDestructors.chpl:7: note:                 C.~C()

--- a/test/classes/figueroa/BogusDestructors5.good
+++ b/test/classes/figueroa/BogusDestructors5.good
@@ -1,1 +1,1 @@
-BogusDestructors5.chpl:2: error: destructor name must match class name
+BogusDestructors5.chpl:2: error: destructor name must match class/record name or deinit()

--- a/test/classes/figueroa/BogusDestructors6.chpl
+++ b/test/classes/figueroa/BogusDestructors6.chpl
@@ -1,3 +1,0 @@
-class C {
-  proc ~D () {writeln("inside ~D");}
-}

--- a/test/classes/figueroa/BogusDestructors6.good
+++ b/test/classes/figueroa/BogusDestructors6.good
@@ -1,1 +1,0 @@
-BogusDestructors6.chpl:2: error: destructor name must match class name

--- a/test/classes/figueroa/BogusDestructors7.good
+++ b/test/classes/figueroa/BogusDestructors7.good
@@ -1,1 +1,1 @@
-BogusDestructors7.chpl:5: error: destructor name must match class name
+BogusDestructors7.chpl:5: error: destructor name must match class/record name or deinit()

--- a/test/classes/figueroa/DestructorSubclassing2.bad
+++ b/test/classes/figueroa/DestructorSubclassing2.bad
@@ -1,0 +1,2 @@
+DestructorSubclassing2.chpl:11: error: unresolved call 'C1.init(int(64), meme=C2)'
+DestructorSubclassing2.chpl:1: note: candidates are: C1.init(x: int(64))

--- a/test/classes/figueroa/DestructorSubclassing2.chpl
+++ b/test/classes/figueroa/DestructorSubclassing2.chpl
@@ -12,5 +12,5 @@ class C: C1, C2 {
   proc ~C () {writeln("Inside ~C");}
 }
 
-var c: new C();
+var c = new C();
 delete c;

--- a/test/classes/figueroa/DestructorSubclassing2.future
+++ b/test/classes/figueroa/DestructorSubclassing2.future
@@ -1,6 +1,6 @@
-bug: multiple inheritance
+feature request: multiple inheritance
 
-Was:
+Do we want to provide multiple inheritance?
 
-bug: destructors of classes that inherit from multiple classes not allowed
-specifically in the case where more than one class from which it inherits have data.
+Currently the test fails when invoking parent initializer
+from child initilizer.

--- a/test/classes/figueroa/DestructorSubclassing2.future
+++ b/test/classes/figueroa/DestructorSubclassing2.future
@@ -3,4 +3,4 @@ feature request: multiple inheritance
 Do we want to provide multiple inheritance?
 
 Currently the test fails when invoking parent initializer
-from child initilizer.
+from child initializer.

--- a/test/classes/figueroa/DestructorSubclassing3.bad
+++ b/test/classes/figueroa/DestructorSubclassing3.bad
@@ -1,0 +1,2 @@
+DestructorSubclassing3.chpl:19: error: unresolved call 'C.init(int(64), meme=D)'
+DestructorSubclassing3.chpl:10: note: candidates are: C.init(x: int(64))

--- a/test/classes/figueroa/DestructorSubclassing3.chpl
+++ b/test/classes/figueroa/DestructorSubclassing3.chpl
@@ -20,5 +20,5 @@ class E: C, D {
   proc ~E () {writeln("Inside ~E");}
 }
 
-var e: new E();
+var e = new E();
 delete e;

--- a/test/classes/figueroa/DestructorSubclassing3.future
+++ b/test/classes/figueroa/DestructorSubclassing3.future
@@ -1,6 +1,6 @@
-bug: multiple inheritance
+feature request: multiple inheritance
 
-Was:
+Do we want to provide multiple inheritance?
 
-bug: destructors of classes that inherit from multiple classes not allowed
-specifically in the case where more than one class from which it inherits have data.
+Currently the test fails when invoking parent initializer
+from child initilizer.

--- a/test/classes/figueroa/DestructorSubclassing3.future
+++ b/test/classes/figueroa/DestructorSubclassing3.future
@@ -3,4 +3,4 @@ feature request: multiple inheritance
 Do we want to provide multiple inheritance?
 
 Currently the test fails when invoking parent initializer
-from child initilizer.
+from child initializer.

--- a/test/classes/initializers/callUserDefaultInitializer.future
+++ b/test/classes/initializers/callUserDefaultInitializer.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/error-destructor-return-type.future
+++ b/test/classes/initializers/error-destructor-return-type.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/error-destructor-return-type.good
+++ b/test/classes/initializers/error-destructor-return-type.good
@@ -1,1 +1,1 @@
-error-destructor-return-type.chpl:2: error: destructors may not declare a return type
+error-destructor-return-type.chpl:4: error: destructors may not declare a return type


### PR DESCRIPTION
This is an elaboration on #5200 that adjusts the code and tests
in accordance with the current CHIP 10. In particular,

* Disallow deinit() with arguments.
* Disallow user calls to deinit().
* Rename, internally to the compiler ~classname methods to deinit().
* Added tests.
* While there, tidied up some tests in classes/figueroa

Next steps:

* Convert our Chapel code base to the new name.
* Live in the new world for a while to make sure everything works.
* Deprecate ~classname naming.

Tested: linux64 on full suite; gasnet on multilocale tests.
