### PR TITLE
 make eltType mandatory first arg in RandomStream ctors

### DIFF
--- a/modules/packages/LinearAlgebraJama.chpl
+++ b/modules/packages/LinearAlgebraJama.chpl
@@ -2245,7 +2245,7 @@ class Matrix {
 
    proc random (m, n:int) {
       var A = new Matrix(m,n);
-      var randlist = new RandomStream(seed);
+      var randlist = new RandomStream(real, seed);
       randlist.fillRandom(A.A);
       return A;
    }
@@ -2262,7 +2262,7 @@ class Matrix {
 
 proc random (m, n:int) {
    var A = new Matrix(m,n);
-   var randlist = new RandomStream(seed);
+   var randlist = new RandomStream(real, seed);
    randlist.fillRandom(A.A);
    return A;
 }

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -217,7 +217,7 @@ module Random {
                         param parSafe: bool = true,
                         type eltType = real(64),
                         param algorithm = defaultRNG) {
-    compilerWarning("makeRandomStream now requires eltType as first argument");
+    compilerWarning("makeRandomStream requires eltType as first argument");
     return makeRandomStream(eltType, seed, parSafe, algorithm);
   }
 

--- a/test/arrays/deitz/parallelism/stream/test_stream_is_parallel.chpl
+++ b/test/arrays/deitz/parallelism/stream/test_stream_is_parallel.chpl
@@ -33,7 +33,7 @@ proc main() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new RandomStream(seed);
+  var randlist = new RandomStream(real, seed);
   randlist.fillRandom(B);
   randlist.fillRandom(C);
   delete randlist;

--- a/test/arrays/deitz/parallelism/stream/test_stream_no_fast_follow.chpl
+++ b/test/arrays/deitz/parallelism/stream/test_stream_no_fast_follow.chpl
@@ -37,7 +37,7 @@ proc main() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new RandomStream(seed);
+  var randlist = new RandomStream(real, seed);
   randlist.fillRandom(B);
   randlist.fillRandom(C);
   delete randlist;

--- a/test/arrays/deitz/parallelism/stream/test_whole_array_stream_is_parallel.chpl
+++ b/test/arrays/deitz/parallelism/stream/test_whole_array_stream_is_parallel.chpl
@@ -33,7 +33,7 @@ proc main() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new RandomStream(seed);
+  var randlist = new RandomStream(real, seed);
   randlist.fillRandom(B);
   randlist.fillRandom(C);
   delete randlist;

--- a/test/arrays/deitz/parallelism/stream/test_whole_array_stream_no_fast_followers.chpl
+++ b/test/arrays/deitz/parallelism/stream/test_whole_array_stream_no_fast_followers.chpl
@@ -38,7 +38,7 @@ proc main() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new RandomStream(seed);
+  var randlist = new RandomStream(real, seed);
   randlist.fillRandom(B);
   randlist.fillRandom(C);
   delete randlist;

--- a/test/arrays/diten/arrayPerformance.chpl
+++ b/test/arrays/diten/arrayPerformance.chpl
@@ -32,7 +32,7 @@ proc main {
 
 proc initialize(B) {
   use Random;
-  var rnd = new RandomStream(randSeed);
+  var rnd = new RandomStream(real, randSeed);
   rnd.fillRandom(B);
   delete rnd;
 }

--- a/test/arrays/opaque/bradc/opaque-segfaults.chpl
+++ b/test/arrays/opaque/bradc/opaque-segfaults.chpl
@@ -46,7 +46,7 @@ proc createRandomGraph() {
 
   // set up random number stream
   use Random;
-  var myRandNums = new RandomStream(seed=314159265);
+  var myRandNums = new RandomStream(real, seed=314159265);
 
   // allocate vertices
   for i in 1..numVertices {

--- a/test/deprecated/randctor.chpl
+++ b/test/deprecated/randctor.chpl
@@ -1,0 +1,13 @@
+use Random;
+
+var x = new RandomStream(13);
+
+delete x;
+
+var y = new NPBRandomStream(13);
+
+delete y;
+
+var z = makeRandomStream(13);
+
+delete z;

--- a/test/deprecated/randctor.good
+++ b/test/deprecated/randctor.good
@@ -1,3 +1,3 @@
 randctor.chpl:3: warning: RandomStream constructor requires eltType as first argument
 randctor.chpl:7: warning: NPBRandomStream constructor requires eltType as first argument
-randctor.chpl:11: warning: makeRandomStream now requires eltType as first argument
+randctor.chpl:11: warning: makeRandomStream requires eltType as first argument

--- a/test/deprecated/randctor.good
+++ b/test/deprecated/randctor.good
@@ -1,0 +1,3 @@
+randctor.chpl:3: warning: RandomStream constructor requires eltType as first argument
+randctor.chpl:7: warning: NPBRandomStream constructor requires eltType as first argument
+randctor.chpl:11: warning: makeRandomStream now requires eltType as first argument

--- a/test/distributions/jglewis/cyclicOnEvenNumLocales.chpl
+++ b/test/distributions/jglewis/cyclicOnEvenNumLocales.chpl
@@ -14,7 +14,7 @@ module cholesky_test {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const MatIdx = { index_base .. #n, index_base .. #n };
 

--- a/test/distributions/robust/arithmetic/kernels/stream.chpl
+++ b/test/distributions/robust/arithmetic/kernels/stream.chpl
@@ -105,7 +105,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new RandomStream(seed);
+  var randlist = new RandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/distributions/robust/arithmetic/modules/test_module_Search.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Search.chpl
@@ -5,7 +5,7 @@ use Random;
 use Sort;
 use Search;
 
-var rng = new RandomStream(314159265);
+var rng = new RandomStream(real, 314159265);
 
 var found: bool;
 var foundIdx: int;

--- a/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
@@ -4,7 +4,7 @@ use driver_real_arrays;
 use Random;
 use Sort;
 
-var rng = new RandomStream(314159265);
+var rng = new RandomStream(real, 314159265);
 
 enum SortType { BUBBLE=0, INSERTION, MERGE, SELECTION, QUICK, HEAP };
 

--- a/test/domains/ferguson/build-associative.chpl
+++ b/test/domains/ferguson/build-associative.chpl
@@ -6,7 +6,7 @@ config const table = false;
 use Time;
 use Random;
 
-var rng = makeRandomStream(0, false, int, RNG.PCG);
+var rng = makeRandomStream(real, 0, false, int, RNG.PCG);
 
 //var t2 = new Timer();
 //var t3 = new Timer();

--- a/test/domains/ferguson/build-associative.chpl
+++ b/test/domains/ferguson/build-associative.chpl
@@ -6,7 +6,7 @@ config const table = false;
 use Time;
 use Random;
 
-var rng = makeRandomStream(real, 0, false, int, RNG.PCG);
+var rng = makeRandomStream(int, 0, false, RNG.PCG);
 
 //var t2 = new Timer();
 //var t3 = new Timer();

--- a/test/exercises/MonteCarloPi/dataParallel.chpl
+++ b/test/exercises/MonteCarloPi/dataParallel.chpl
@@ -7,7 +7,7 @@ writeln("Number of points      = ", n);
 writeln("Random number seed    = ", seed);
 writeln("dataParTasksPerLocale = ", dataParTasksPerLocale);
 
-var rs = new NPBRandomStream(seed, parSafe=false);
+var rs = new NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Create a domain over the number of random points to generate.

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/dataParallelMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/dataParallelMonteCarloPi.chpl
@@ -27,7 +27,7 @@ writeln("dataParTasksPerLocale = ", dataParTasksPerLocale);
 // accesses to this object, set parSafe to false to avoid locking
 // overhead.
 //
-var rs = new NPBRandomStream(seed, parSafe=false);
+var rs = new NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Create a domain over the number of random points to generate.

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/multiLocaleDataParallelMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/multiLocaleDataParallelMonteCarloPi.chpl
@@ -29,7 +29,7 @@ writeln("dataParTasksPerLocale = ", dataParTasksPerLocale);
 // accesses to this object, set parSafe to false to avoid locking
 // overhead.
 //
-var rs = new NPBRandomStream(seed, parSafe=false);
+var rs = new NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Create a domain over the number of random points to generate.

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/multiLocaleTaskParallelMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/multiLocaleTaskParallelMonteCarloPi.chpl
@@ -37,7 +37,7 @@ var counts: [LocaleSpace] [1..tasks] int;
 coforall loc in Locales do on loc {
   var myN = (loc.id+1)*n/numLocales - (loc.id)*n/numLocales;
   coforall task in 1..tasks {
-    var rs = new NPBRandomStream(seed + loc.id*tasks*2 + task*2, parSafe=false);
+    var rs = new NPBRandomStream(real, seed + loc.id*tasks*2 + task*2, parSafe=false);
     var count = 0;
     for i in (task-1)*myN/tasks+1..task*myN/tasks do
       count += rs.getNext()**2 + rs.getNext()**2 <= 1.0;

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/serialMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/serialMonteCarloPi.chpl
@@ -26,7 +26,7 @@ writeln("Random number seed  = ", seed);
 // accesses to this object, set parSafe to false to avoid locking
 // overhead.
 //
-var rs = new NPBRandomStream(seed, parSafe=false);
+var rs = new NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Run the Monte Carlo simulation.

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/taskParallelMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/taskParallelMonteCarloPi.chpl
@@ -34,7 +34,7 @@ writeln("Number of tasks     = ", tasks);
 //
 var counts: [1..tasks] int;
 coforall task in 1..tasks {
-  var rs = new NPBRandomStream(seed + task*2, parSafe=false);
+  var rs = new NPBRandomStream(real, seed + task*2, parSafe=false);
   var count = 0;
   for i in (task-1)*n/tasks+1..task*n/tasks do
     count += rs.getNext()**2 + rs.getNext()**2 <= 1.0;

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/variantMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/variantMonteCarloPi.chpl
@@ -31,7 +31,7 @@ writeln("Random number seed  = ", seed);
 // accesses to this object, set parSafe to false to avoid locking
 // overhead.
 //
-var rs = new NPBRandomStream(seed, parSafe=false);
+var rs = new NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Run the Monte Carlo simulation until the approximation of PI is

--- a/test/exercises/MonteCarloPi/multiLocaleDataParallel.chpl
+++ b/test/exercises/MonteCarloPi/multiLocaleDataParallel.chpl
@@ -8,7 +8,7 @@ writeln("Number of points      = ", n);
 writeln("Random number seed    = ", seed);
 writeln("dataParTasksPerLocale = ", dataParTasksPerLocale);
 
-var rs = new NPBRandomStream(seed, parSafe=false);
+var rs = new NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Distribute the domain representing the random points in a 

--- a/test/exercises/MonteCarloPi/multiLocaleTaskParallel.chpl
+++ b/test/exercises/MonteCarloPi/multiLocaleTaskParallel.chpl
@@ -50,7 +50,7 @@ coforall loc in Locales {
     // delete the RandomStream object.
     //
     coforall tid in 0..#tasksPerLocale {
-      var rs = new NPBRandomStream(seed, parSafe=false);
+      var rs = new NPBRandomStream(real, seed, parSafe=false);
       const locNPerTask = locN/tasksPerLocale,
             extras = locN%tasksPerLocale;
       rs.skipToNth(2*(locFirstPt + 

--- a/test/exercises/MonteCarloPi/serial.chpl
+++ b/test/exercises/MonteCarloPi/serial.chpl
@@ -29,7 +29,7 @@ writeln("Random number seed  = ", seed);
 // accesses to this object by distinct tasks, parSafe can be set to
 // false to avoid thread safety overheads.
 // 
-var rs = new NPBRandomStream(seed, parSafe=false);
+var rs = new NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Run the Monte Carlo simulation.  'count' is the number of random

--- a/test/exercises/MonteCarloPi/serialVariant.chpl
+++ b/test/exercises/MonteCarloPi/serialVariant.chpl
@@ -14,7 +14,7 @@ const pi = 3.14159265358979323846;
 writef("Epsilon             = %{#.#################}\n", epsilon);
 writeln("Random number seed  = ", seed);
 
-var rs = new NPBRandomStream(seed, parSafe=false);
+var rs = new NPBRandomStream(real, seed, parSafe=false);
 
 //
 // keep track of the number of points we generate before converging

--- a/test/exercises/MonteCarloPi/taskParallel.chpl
+++ b/test/exercises/MonteCarloPi/taskParallel.chpl
@@ -20,7 +20,7 @@ writeln("Number of tasks     = ", tasks);
 //
 var counts: [0..#tasks] int;
 coforall tid in 0..#tasks {
-  var rs = new NPBRandomStream(seed, parSafe=false);
+  var rs = new NPBRandomStream(real, seed, parSafe=false);
   const nPerTask = n/tasks,
         extras = n%tasks;
   rs.skipToNth(2*(tid*nPerTask + (if tid < extras then tid else extras)) + 1);

--- a/test/exercises/boundedBuffer/boundedBuffer.chpl
+++ b/test/exercises/boundedBuffer/boundedBuffer.chpl
@@ -189,7 +189,7 @@ class BoundedBuffer {
       head = 0,                            // the head's cursor position
       tail = 0;                            // the tail's cursor position
 
-  var rng = new RandomStream();
+  var rng = new RandomStream(real);
 
   //
   // Place an item at the head position of the buffer, assuming

--- a/test/exercises/boundedBuffer/solutions/boundedBuffer-atomic.chpl
+++ b/test/exercises/boundedBuffer/solutions/boundedBuffer-atomic.chpl
@@ -124,7 +124,7 @@ class BoundedBuffer {
       head: atomic int,                    // the head's cursor position
       tail: atomic int;                    // the tail's cursor position
 
-  var rng = new RandomStream();
+  var rng = new RandomStream(real);
 
 
   //

--- a/test/exercises/boundedBuffer/solutions/boundedBuffer-sync.chpl
+++ b/test/exercises/boundedBuffer/solutions/boundedBuffer-sync.chpl
@@ -124,7 +124,7 @@ class BoundedBuffer {
       head$: sync int = 0,                  // the head's cursor position
       tail$: sync int = 0;                  // the tail's cursor position
 
-  var rng = new RandomStream();
+  var rng = new RandomStream(real);
 
   //
   // Place an item at the head position of the buffer, assuming

--- a/test/functions/deitz/iterators/leader_follower/test_strided_leader1.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_strided_leader1.chpl
@@ -29,7 +29,7 @@ use Random;
 {
   var B: [1..n] real;
 
-  var rs = new NPBRandomStream(seed=315);
+  var rs = new NPBRandomStream(real, seed=315);
 
   forall (i, r) in zip({1..n}, rs.iterate({1..n})) do
     B(i) = r;

--- a/test/functions/deitz/iterators/leader_follower/test_strided_leader1.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_strided_leader1.chpl
@@ -40,7 +40,7 @@ use Random;
 {
   var B: [1..n] real;
 
-  var rs = new NPBRandomStream(seed=315);
+  var rs = new NPBRandomStream(real, seed=315);
 
   forall (f, r) in zip(foo(n), rs.iterate({1..n})) do
     B(f) = r;

--- a/test/functions/deitz/iterators/leader_follower/test_strided_leader2.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_strided_leader2.chpl
@@ -29,7 +29,7 @@ use Random;
 {
   var B: [1..n] real;
 
-  var rs = makeRandomStream(seed=315, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed=315, algorithm=RNG.NPB);
 
   forall (i, r) in zip({1..n}, rs.iterate({1..n})) do
     B(i) = r;
@@ -42,7 +42,7 @@ use Random;
 {
   var B: [1..n] real;
 
-  var rs = makeRandomStream(seed=315, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed=315, algorithm=RNG.NPB);
 
   forall (f, r) in zip(foo(n), rs.iterate({1..n})) do
     B(f) = r;

--- a/test/modules/standard/Random/bradc/test-Random-evenseed.chpl
+++ b/test/modules/standard/Random/bradc/test-Random-evenseed.chpl
@@ -17,7 +17,7 @@ var Vec1 : [Vector1] real;
 var Vec2 : [Vector1] real;
 var Vec3 : [Vector1] real;
 
-var rng = makeRandomStream(314159264, algorithm=rtype);
+var rng = makeRandomStream(real, 314159264, algorithm=rtype);
 
 rng.fillRandom(Vec1);
 

--- a/test/modules/standard/Random/bradc/testGetNth.chpl
+++ b/test/modules/standard/Random/bradc/testGetNth.chpl
@@ -5,9 +5,9 @@ config var n = 100;
 config param useNPB = true;
 config param rtype = if useNPB then RNG.NPB else RNG.PCG;
 
-var randStr1 = makeRandomStream(314159265, algorithm=rtype);
-var randStr2 = makeRandomStream(314159265, algorithm=rtype);
-var randStr3 = makeRandomStream(314159265, algorithm=rtype);
+var randStr1 = makeRandomStream(real, 314159265, algorithm=rtype);
+var randStr2 = makeRandomStream(real, 314159265, algorithm=rtype);
+var randStr3 = makeRandomStream(real, 314159265, algorithm=rtype);
 
 for i in 1..n {
   const r1 = randStr1.getNext();

--- a/test/modules/standard/Random/bradc/testGetNth2.chpl
+++ b/test/modules/standard/Random/bradc/testGetNth2.chpl
@@ -5,9 +5,9 @@ config var n = 100;
 config param useNPB = true;
 config param rtype = if useNPB then RNG.NPB else RNG.PCG;
 
-var randStr1 = makeRandomStream(314159265, algorithm=rtype);
-var randStr2 = makeRandomStream(314159265, algorithm=rtype);
-var randStr3 = makeRandomStream(314159265, algorithm=rtype);
+var randStr1 = makeRandomStream(real, 314159265, algorithm=rtype);
+var randStr2 = makeRandomStream(real, 314159265, algorithm=rtype);
+var randStr3 = makeRandomStream(real, 314159265, algorithm=rtype);
 
 var A, B: [1..n] real;
 

--- a/test/modules/standard/Random/bradc/writeRandomStream.chpl
+++ b/test/modules/standard/Random/bradc/writeRandomStream.chpl
@@ -5,7 +5,7 @@ module A2 {
   config param rtype  = if useNPB then RNG.NPB else RNG.PCG;
 
   proc main() {
-    var rnd  = makeRandomStream(seed=314159265, algorithm=rtype);
+    var rnd  = makeRandomStream(real, seed=314159265, algorithm=rtype);
 
     writeln(rnd);
 

--- a/test/modules/standard/Random/deitz/test1D2D.chpl
+++ b/test/modules/standard/Random/deitz/test1D2D.chpl
@@ -5,7 +5,7 @@ config const seed: int = 1;
 config const n: int = 8;
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   writeln(for i in 1..n do "%{#.#####}".format(rs.getNext()));
   writeln(rs.getNext());
@@ -14,7 +14,7 @@ config const n: int = 8;
 }
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   writeln(for i in 1..n do "%{#.#####}".format(rs.getNth(i)));
   writeln(rs.getNext());
@@ -23,7 +23,7 @@ config const n: int = 8;
 }
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   var A: [1..n] real;
   rs.fillRandom(A);
@@ -34,7 +34,7 @@ config const n: int = 8;
 }
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   var A: [1..n/2, 1..2] real;
   rs.fillRandom(A);
@@ -45,7 +45,7 @@ config const n: int = 8;
 }
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n})] real;
   rs.fillRandom(A);
@@ -57,7 +57,7 @@ config const n: int = 8;
 }
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n/2})] real;
   rs.fillRandom(A);
@@ -69,7 +69,7 @@ config const n: int = 8;
 }
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n})] real;
   forall (a,r) in zip(A,rs.iterate(A.domain)) do
@@ -82,7 +82,7 @@ config const n: int = 8;
 }
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n/2})] real;
   forall (a,r) in zip(A,rs.iterate(A.domain)) do
@@ -95,7 +95,7 @@ config const n: int = 8;
 }
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n})] real;
   forall (r,a) in zip(rs.iterate(A.domain), A) do
@@ -108,7 +108,7 @@ config const n: int = 8;
 }
 
 {
-  var rs = makeRandomStream(seed, algorithm=RNG.NPB);
+  var rs = makeRandomStream(real, seed, algorithm=RNG.NPB);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n/2})] real;
   forall (r,a) in zip(rs.iterate(A.domain), A) do

--- a/test/modules/standard/Random/ferguson/check-time-seed.chpl
+++ b/test/modules/standard/Random/ferguson/check-time-seed.chpl
@@ -1,0 +1,163 @@
+use Random;
+use Time;
+
+config const debug = false;
+
+
+proc getRealRandoms(method:int) {
+  var A:[1..100] real;
+
+  if method == 0 {
+    var R = new RandomStream(real);
+
+    if debug then
+      writeln("method 0, seed ", R.seed);
+
+    for a in A do
+      a = R.getNext();
+
+    delete R;
+  }
+
+  if method == 1 {
+    var R = makeRandomStream(eltType=real);
+
+    if debug then
+      writeln("method ", method, ", seed ", R.seed);
+
+    for a in A do
+      a = R.getNext();
+
+    delete R;
+  }
+
+
+  if method == 2 {
+    var R = makeRandomStream(eltType=real, algorithm=RNG.PCG);
+
+    if debug then
+      writeln("method ", method, ", seed ", R.seed);
+
+    for a in A do
+      a = R.getNext();
+
+    delete R;
+  }
+
+  if method == 3 {
+    var R = new NPBRandomStream(real);
+
+    if debug then
+      writeln("method ", method, ", seed ", R.seed);
+
+    for a in A do
+      a = R.getNext();
+
+    delete R;
+  }
+
+  if method == 4 {
+    var R = makeRandomStream(eltType=real, algorithm=RNG.NPB);
+
+    if debug then
+      writeln("method ", method, ", seed ", R.seed);
+
+    for a in A do
+      a = R.getNext();
+
+    delete R;
+  }
+
+  return A;
+}
+
+proc getUintRandoms(method:int) {
+  var A:[1..100] uint;
+
+  if method == 0 {
+    var R = new RandomStream(uint);
+
+    if debug then
+      writeln("method ", method, ", seed ", R.seed);
+
+    for a in A do
+      a = R.getNext();
+
+    delete R;
+  }
+
+  if method == 1 {
+    var R = makeRandomStream(eltType=uint);
+
+    if debug then
+      writeln("method ", method, ", seed ", R.seed);
+
+    for a in A do
+      a = R.getNext();
+
+    delete R;
+  }
+
+  if method == 2 {
+    var R = makeRandomStream(eltType=uint, algorithm=RNG.PCG);
+
+    if debug then
+      writeln("method ", method, ", seed ", R.seed);
+
+    for a in A do
+      a = R.getNext();
+
+    delete R;
+  }
+
+  return A;
+}
+
+
+proc waitForNextSeed() {
+  // Wait for the time-based seed generator to give us
+  // a different value. The loop guards against
+  // under-sleeping.
+  var curSeed = SeedGenerator.oddCurrentTime;
+  var newSeed = curSeed;
+  do {
+    sleep(2, TimeUnits.milliseconds);
+    newSeed = SeedGenerator.oddCurrentTime;
+  } while (newSeed == curSeed);
+}
+
+for i in 0..4 {
+  // Get one random array
+  var A = getRealRandoms(i);
+  // Wait
+  waitForNextSeed();
+  // Get another, now the time should be different ->
+  // the seed should be different
+  var B = getRealRandoms(i);
+  // Check that these are not the same
+  var equal = && reduce (A == B);
+  if equal {
+    writeln("Error with time-based seed with real i=  ", i);
+    writeln("A = ", A);
+    writeln("B = ", B);
+  }
+}
+
+for i in 0..2 {
+  // Get one random array
+  var A = getUintRandoms(i);
+  // Wait
+  waitForNextSeed();
+  // Get another, now the time should be different ->
+  // the seed should be different
+  var B = getUintRandoms(i);
+  // Check that these are not the same
+  var equal = && reduce (A == B);
+  if equal {
+    writeln("Error with time-based seed with uint i=", i);
+    writeln("A = ", A);
+    writeln("B = ", B);
+  }
+}
+
+

--- a/test/modules/standard/Random/marybeth/test-Random.chpl
+++ b/test/modules/standard/Random/marybeth/test-Random.chpl
@@ -5,7 +5,7 @@ use Random;
 var Vector1 = {1..20};
 var Vec1 : [Vector1] real;
 
-var rng = makeRandomStream(314159265, algorithm=RNG.NPB);
+var rng = makeRandomStream(real, 314159265, algorithm=RNG.NPB);
 
 rng.fillRandom(Vec1);
 writeln(Vec1);

--- a/test/multilocale/deitz/needMultiLocales/streamCommCheck.chpl
+++ b/test/multilocale/deitz/needMultiLocales/streamCommCheck.chpl
@@ -13,7 +13,7 @@ proc main() {
   const ProblemSpace: domain(1, int(64)) dmapped Dist = {1..m};
   var A, B, C: [ProblemSpace] elemType;
 
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
   randlist.fillRandom(B);
   randlist.fillRandom(C);
   startCommDiagnostics();

--- a/test/npb/cg/bradc/cg-makea.chpl
+++ b/test/npb/cg/bradc/cg-makea.chpl
@@ -11,7 +11,7 @@ module CGMakeA {
     var size = 1.0;
     const ratio = rcond ** (1.0 / n);
 
-    var randStr = new NPBRandomStream(314159265);
+    var randStr = new NPBRandomStream(real, 314159265);
     randStr.getNext();   // drop a value on floor to match NPB version
 
     for iouter in 1..n {

--- a/test/npb/cg/bradc/cg.chpl
+++ b/test/npb/cg/bradc/cg.chpl
@@ -101,7 +101,7 @@ proc makea() {
   var size = 1.0;
   const ratio = rcond ** (1.0 / n);
 
-  var randStr = new NPBRandomStream(314159265);
+  var randStr = new NPBRandomStream(real, 314159265);
 
   for iouter in 1..n {
     var nzv = nonzer;

--- a/test/npb/ep/mcahir/ep.chpl
+++ b/test/npb/ep/mcahir/ep.chpl
@@ -85,7 +85,7 @@ proc gaussPairsBatch(k: int(64), numPairs: int) {
 	
 	var startTime, randTime, gaussTime: real;
 
-	var rs = new NPBRandomStream(seed=seed, parSafe=false);
+	var rs = new NPBRandomStream(real, seed=seed, parSafe=false);
 	//Find starting seed for this batch
 	rs.skipToNth(k * 2*nk + 1);
 

--- a/test/npb/is/diten/is.chpl
+++ b/test/npb/is/diten/is.chpl
@@ -48,7 +48,7 @@ var passedVerifications = 0;
 
 proc main() {
   var time = new Timer();
-  var randomStream = new NPBRandomStream(seed);
+  var randomStream = new NPBRandomStream(real, seed);
   var tempreals: [1..4] real;
   var max = maxKey / 4;
 

--- a/test/npb/is/diten/is_mt.chpl
+++ b/test/npb/is/diten/is_mt.chpl
@@ -45,7 +45,7 @@ var passedVerifications = 0;
 
 proc main() {
   var time = new Timer();
-  var randomStream = new NPBRandomStream(seed);
+  var randomStream = new NPBRandomStream(real, seed);
   var tempreals: [1..4] real;
   var max = maxKey / 4;
 

--- a/test/npb/is/diten/is_no_buckets.chpl
+++ b/test/npb/is/diten/is_no_buckets.chpl
@@ -43,7 +43,7 @@ var passedVerifications = 0;
 
 proc main() {
   var time = new Timer();
-  var randomStream = new NPBRandomStream(seed);
+  var randomStream = new NPBRandomStream(real, seed);
   var tempreals: [1..4] real;
   var max = Bmax / 4;
 

--- a/test/npb/is/mcahir/intsort.mtml.chpl
+++ b/test/npb/is/mcahir/intsort.mtml.chpl
@@ -484,7 +484,7 @@ proc gen_keys () {
       var first: int = mype*(nkeys/numLocales);
       var last : int = first+(nkeys/numLocales) - 1;
  
-      var rs = new NPBRandomStream(seed);
+      var rs = new NPBRandomStream(real, seed);
       rs.skipToNth(first*4+1);
       for i in first..last {
         rs.fillRandom(tmpreals);

--- a/test/parallel/forall/vass/alist-error.chpl
+++ b/test/parallel/forall/vass/alist-error.chpl
@@ -4,7 +4,7 @@ use Random;
 class A {
   var X: domain(int);
   proc A(N: int) {
-    var R = new RandomStream(13);
+    var R = new RandomStream(real, 13);
     this.X = [x in 1..N] x;
     var Y = [x in this.X] R.getNext();
     delete R;

--- a/test/performance/compiler/bradc/cg-makea.chpl
+++ b/test/performance/compiler/bradc/cg-makea.chpl
@@ -11,7 +11,7 @@ module CGMakeA {
     var size = 1.0;
     const ratio = rcond ** (1.0 / n);
 
-    var randStr = new NPBRandomStream(314159265);
+    var randStr = new NPBRandomStream(real, 314159265);
     randStr.getNext();   // drop a value on floor to match NPB version
 
     for iouter in 1..n {

--- a/test/performance/thomasvandoren/TestHelpers.chpl
+++ b/test/performance/thomasvandoren/TestHelpers.chpl
@@ -15,7 +15,7 @@ config const printC = true,
 // matrices.
 config const scalingFactor = 1;
 
-var randStream = makeRandomStream(randSeed, algorithm=RNG.NPB),
+var randStream = makeRandomStream(real, randSeed, algorithm=RNG.NPB),
   timer: Timer;
 
 const inner = 1..5 * scalingFactor,

--- a/test/reductions/thomasvandoren/test/Common.chpl
+++ b/test/reductions/thomasvandoren/test/Common.chpl
@@ -8,7 +8,7 @@ config const randSeed = SeedGenerator.oddCurrentTime;
 
 var emptyArray: [1..0] int(8),
   realArray: [1..1000] real,
-  randStream = new NPBRandomStream(randSeed);
+  randStream = new NPBRandomStream(real, randSeed);
 
 randStream.fillRandom(realArray);
 var intArray = [i in 1..1000] (realArray[i] * 1000): int;

--- a/test/release/examples/benchmarks/hpcc/stream-ep.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream-ep.chpl
@@ -153,7 +153,7 @@ proc printConfiguration() {
 // Initialize vectors B and C using a random stream of values
 //
 proc initVectors(B, C) {
-  var randlist = new RandomStream(seed);
+  var randlist = new RandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/release/examples/benchmarks/hpcc/stream.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream.chpl
@@ -105,7 +105,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
+++ b/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
@@ -103,7 +103,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
@@ -274,9 +274,9 @@ module SSCA2_RMAT_graph_generator
       // Random Numbers return in the range [0.0, 1.0)
 
       var Rand_Gen = if REPRODUCIBLE_PROBLEMS then 
-	               new NPBRandomStream (seed = 0556707007)
+	               new NPBRandomStream (real, seed = 0556707007)
 		     else
-		       new NPBRandomStream ();
+		       new NPBRandomStream (real);
 
       var   Noisy_a     : [edge_domain] real,
             Noisy_b     : [edge_domain] real,

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_driver.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_driver.chpl
@@ -111,9 +111,9 @@ module SSCA2_driver
             var linear_index         : index (vertex_indices);
 
             var Rand_Gen = if REPRODUCIBLE_PROBLEMS then 
-                             new NPBRandomStream (seed = 3217900597)
+                             new NPBRandomStream (real, seed = 3217900597)
                            else
-                             new NPBRandomStream ();
+                             new NPBRandomStream (real);
 
             var V_s      = 0;
 

--- a/test/release/examples/primers/opaque.chpl
+++ b/test/release/examples/primers/opaque.chpl
@@ -244,7 +244,7 @@ proc createRandomGraph() {
   // Uses the NPB random number generator for historical reasons.
   //
   use Random;
-  var myRandNums = makeRandomStream(seed=314159265,algorithm=RNG.NPB);
+  var myRandNums = makeRandomStream(real, seed=314159265,algorithm=RNG.NPB);
 
   //
   // allocate all the vertices and assign them labels and random weights

--- a/test/release/examples/primers/randomNumbers.chpl
+++ b/test/release/examples/primers/randomNumbers.chpl
@@ -110,8 +110,8 @@ for i in randStreamSeeded.iterate({5..10}, real) {
 // class creation.  As a result, two parallel accesses or updates to the
 // position from which reading is intended may conflict.
 //
-var parallelUnsafe       = new RandomStream(parSafe=false);
-var parallelSeededUnsafe = new RandomStream(seed, false);
+var parallelUnsafe       = new RandomStream(real, parSafe=false);
+var parallelSeededUnsafe = new RandomStream(real, seed, false);
 
 // Now :class:`RandomStream` functions, such as ``parallelUnsafe.getNext()``
 // and ``parallelSeededUnsafe.getNext()`` can be called.

--- a/test/release/examples/primers/randomNumbers.chpl
+++ b/test/release/examples/primers/randomNumbers.chpl
@@ -45,11 +45,13 @@ writeln();
 
 //
 // The second way to generate a sequence of random numbers is by creating a
-// :class:`RandomStream` class instance.  If one is desired, the seed must be
-// specified upon creation of this instance.
+// :class:`RandomStream` class instance.  The first argument is the type
+// of the elements that the instance should generate. If a particular
+// seed is desired, it should be specifid specified upon creation of this
+// instance.
 //
-var randStream:       RandomStream(real) = new RandomStream();
-var randStreamSeeded: RandomStream(real) = new RandomStream(seed);
+var randStream:       RandomStream(real) = new RandomStream(real);
+var randStreamSeeded: RandomStream(real) = new RandomStream(real, seed);
 
 //
 // Then the instance can be used to obtain the numbers.  This can be done in a

--- a/test/release/examples/programs/linkedList.chpl
+++ b/test/release/examples/programs/linkedList.chpl
@@ -152,8 +152,8 @@ proc main() {
 
   var lst = new List(int);
   var rnd = if useClockSeed 
-              then new NPBRandomStream()
-              else new NPBRandomStream(seed = randomSeed);
+              then new NPBRandomStream(real)
+              else new NPBRandomStream(real, seed = randomSeed);
   const maxValue = 100;
 
   //

--- a/test/studies/IMSuite/vertexColor/vertexColoring-serial.chpl
+++ b/test/studies/IMSuite/vertexColor/vertexColoring-serial.chpl
@@ -210,7 +210,7 @@ module vertexColoring {
    proc six2three() {
        for k in 1..3 {
             var x = 6-k;
-            var randStream = new RandomStream(3);
+            var randStream = new RandomStream(real, 3);
             var ncolor : int = randStream.getNext(): int;
             ncolor = ncolor%3;
             shiftDown();

--- a/test/studies/cholesky/jglewis/test_cholesky.chpl
+++ b/test/studies/cholesky/jglewis/test_cholesky.chpl
@@ -89,7 +89,7 @@ module cholesky_test {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const mat_dom : domain (2) = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/cholesky/jglewis/test_dataflow_cholesky.chpl
+++ b/test/studies/cholesky/jglewis/test_dataflow_cholesky.chpl
@@ -84,7 +84,7 @@ module test_dataflow_cholesky {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const mat_dom : domain (2) = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/cholesky/jglewis/version2/dataflow/test_dataflow_cholesky.chpl
+++ b/test/studies/cholesky/jglewis/version2/dataflow/test_dataflow_cholesky.chpl
@@ -84,7 +84,7 @@ module test_dataflow_cholesky {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const mat_dom : domain (2) = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/cholesky/jglewis/version2/elemental/block_distribution/test_elemental_cholesky_block.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/block_distribution/test_elemental_cholesky_block.chpl
@@ -26,7 +26,7 @@ module cholesky_test_elemental_symmetric_ranges {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const MatIdx = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/test_fully_blocked_elemental_cholesky.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/test_fully_blocked_elemental_cholesky.chpl
@@ -17,7 +17,7 @@ module test_fully_blocked_elemental_cholesky {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const MatIdx = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/cholesky/jglewis/version2/elemental/strided/test_elemental_cholesky_explicitly_symmetric_strided.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/strided/test_elemental_cholesky_explicitly_symmetric_strided.chpl
@@ -25,7 +25,7 @@ module test_elemental_explicitly_strided_cholesky {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const unstrided_MatIdx = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/cholesky/jglewis/version2/elemental/test_elemental_cholesky.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/test_elemental_cholesky.chpl
@@ -18,7 +18,7 @@ module cholesky_test_elemental_symmetric_ranges {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const MatIdx = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/test_elemental_cholesky_unsymmetric_ranges.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/test_elemental_cholesky_unsymmetric_ranges.chpl
@@ -22,7 +22,7 @@ module cholesky_test_unsymmetric_ranges {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const MatIdx = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/cholesky/jglewis/version2/performance/test_cholesky_performance.chpl
+++ b/test/studies/cholesky/jglewis/version2/performance/test_cholesky_performance.chpl
@@ -38,7 +38,7 @@ module performance_cholesky_test {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const mat_dom : domain (2) = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/cholesky/jglewis/version2/standard_cholesky/test_standard_cholesky.chpl
+++ b/test/studies/cholesky/jglewis/version2/standard_cholesky/test_standard_cholesky.chpl
@@ -91,7 +91,7 @@ module standard_cholesky_test {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const mat_dom : domain (2) = { index_base .. #n, index_base .. #n };
 

--- a/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_dyn.chpl
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_dyn.chpl
@@ -111,7 +111,7 @@ proc main(){
   var space: [0..1, totalSpaceRange ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall i in computationSpaceRange do{
     space[0, i] = 0;
@@ -161,7 +161,7 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
   for x in computationSpaceRange do
     spaceEndState[ x ] = space[ T & 1, x ];
 
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for i in computationSpaceRange do
     space[0, i] = generator.getNext();

--- a/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_static.chpl
@@ -111,7 +111,7 @@ proc main(){
   var timer: Timer;
 
   // initialize space with values
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall i in computationSpaceRange do{
     space[0, i] = 0;
@@ -161,7 +161,7 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
   for x in computationSpaceRange do
     spaceEndState[ x ] = space[ T & 1, x ];
 
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for i in computationSpaceRange do
     space[0, i] = generator.getNext();

--- a/test/studies/colostate/Jacobi1D-NaiveParallel-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi1D-NaiveParallel-Chapel_static.chpl
@@ -46,7 +46,7 @@ proc main(){
   var space: [0..1, totalSpaceRange ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall i in computationSpaceRange do{
      space[0, i] = 0;
@@ -102,7 +102,7 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
   for x in computationSpaceRange do
      spaceEndState[ x ] = space[ T & 1, x ];
 
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for i in computationSpaceRange do
      space[0, i] = generator.getNext();

--- a/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_dyn.chpl
+++ b/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_dyn.chpl
@@ -173,7 +173,7 @@ proc main(){
   var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall (x,y) in computationDomain do{
      space[0, x, y] = 0;
@@ -227,7 +227,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
 
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
      space[0, x, y] = generator.getNext();

--- a/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_static.chpl
@@ -173,7 +173,7 @@ proc main(){
   var timer: Timer;
 
   // initialize space with values
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall (x,y) in computationDomain do{
      space[0, x, y] = 0;
@@ -228,7 +228,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
 
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
      space[0, x, y] = generator.getNext();

--- a/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_dyn.chpl
+++ b/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_dyn.chpl
@@ -46,7 +46,7 @@ proc main(){
   var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall (x,y) in computationDomain do{
      space[0, x, y] = 0;
@@ -105,7 +105,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
 
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
      space[0, x, y] = generator.getNext();

--- a/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_static.chpl
@@ -46,7 +46,7 @@ proc main(){
   var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall (x,y) in computationDomain do{
      space[0, x, y] = 0;
@@ -106,7 +106,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
 
-  var generator = new RandomStream( globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
      space[0, x, y] = generator.getNext();

--- a/test/studies/graph500/v2/main.chpl
+++ b/test/studies/graph500/v2/main.chpl
@@ -105,7 +105,7 @@ module Graph500_main
 
     // Generate a list of valid starting roots
     // Valid starting roots have at least one edge to another node
-    var Rand_Gen = new RandomStream (seed = 9);
+    var Rand_Gen = new RandomStream (real, seed = 9);
     var Unif_Random: [1..NUM_CANDIDATES] real;
     Rand_Gen.fillRandom ( Unif_Random );
     var runID: int = 1;

--- a/test/studies/graph500/v2/scalableDataGenerator.chpl
+++ b/test/studies/graph500/v2/scalableDataGenerator.chpl
@@ -73,9 +73,9 @@ module Scalable_Graph_Generator
 
     // Random Numbers return in the range [0.0, 1.0)
     var Rand_Gen = if REPRODUCIBLE_PROBLEMS then
-                      new RandomStream (seed = 0556707007)
+                      new RandomStream (real, seed = 0556707007)
                    else
-                      new RandomStream ();
+                      new RandomStream (real);
 
     const vertex_range = 1..n_vertices;
 

--- a/test/studies/hpcc/HPL/marybeth/Init.chpl
+++ b/test/studies/hpcc/HPL/marybeth/Init.chpl
@@ -183,7 +183,7 @@ proc init(A:[?D]) {
   var n = D.dim(1).length;
   var Asquare => A(..,1..n);
   var b => A(..,n+1);
-  var rstream = new RandomStream(seed=1234567891);
+  var rstream = new RandomStream(real, seed=1234567891);
 
   rstream.fillRandom(Asquare);
   rstream.fillRandom(b);

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample2.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample2.chpl
@@ -349,7 +349,7 @@ proc test_permuteMatrix(rprt = true) : bool {
 }
 
 proc test_panelSolve(rprt = true) : bool {
-    var rand = new RandomStream();
+    var rand = new RandomStream(real);
 
     var piv : [1..8] int = [i in 1..8] i;
     var A : [1..8, 1..9] real =
@@ -391,7 +391,7 @@ proc test_panelSolve(rprt = true) : bool {
 }
 
 proc test_updateBlockRow(rprt = true) : bool {
-    var rand = new RandomStream();
+    var rand = new RandomStream(real);
 
     // construct a matrix A = [X | Y], where X is an already LU-factorized
     // submatrix and Y is the block row we wish to update and test
@@ -471,7 +471,7 @@ proc test_LUFactorizeNorms(
 
 proc test_LUFactorize(rprt = true, seed = -1) : bool {
     // construct a matrix of random size with random values 
-    var rand = new RandomStream(seed);
+    var rand = new RandomStream(real, seed);
 
     var randomN : int = (rand.getNext() * 10):int + 1;
     var A : [1..randomN, 1..randomN+1] real;

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample2.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample2.chpl
@@ -313,7 +313,7 @@ proc test_permuteMatrix(rprt = true) : bool {
     // little too meta here?)
 
     param n = 10;
-    var rand = new RandomStream();
+    var rand = new RandomStream(real);
 
     // this n by n array is filled so each element is assigned to its
     // row number. This test will permute these elements, keeping a pivot

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample3.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample3.chpl
@@ -329,7 +329,7 @@ proc test_LUFactorizeNorms(
 
 proc test_LUFactorize(rprt = true) : bool {
     // construct a 100x100 matrix filled with random values
-    var rand = new RandomStream(seed);
+    var rand = new RandomStream(real, seed);
     var A : [1..n, 1..n+1] real;
     for idx in A.domain do A[idx] = rand.getNext();
     delete rand;

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample4.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample4.chpl
@@ -316,7 +316,7 @@ proc test_LUFactorizeNorms(
 
 proc test_LUFactorize(rprt = true) : bool {
     // construct a 100x100 matrix filled with random values
-    var rand = new RandomStream(seed);
+    var rand = new RandomStream(real, seed);
     var A : [1..n, 1..n+1] real;
     for idx in A.domain do A[idx] = rand.getNext();
     delete rand;

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
@@ -61,7 +61,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
@@ -61,7 +61,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
@@ -71,7 +71,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
@@ -66,7 +66,7 @@ proc initVectors(B, C) {
   // TODO: should write a fillRandom() implementation that does this
   coforall loc in B.dom.dist.targetLocs {
     on loc {
-      var randlist = new NPBRandomStream(seed);
+      var randlist = new NPBRandomStream(real, seed);
       // TODO: Need to clean this up to use more normal method names
       randlist.skipToNth(B.locArr(loc).locDom.low);
       randlist.fillRandom(B.locArr(loc).myElems);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
@@ -77,7 +77,7 @@ proc initVectors(B, C) {
   // TODO: should write a fillRandom() implementation that does this
   coforall loc in B.dom.dist.targetLocDom {
     on B.dom.dist.targetLocs(loc) {
-      var randlist = new NPBRandomStream(seed);
+      var randlist = new NPBRandomStream(real, seed);
       // TODO: Need to clean this up to use more normal method names
       randlist.skipToNth(B.locArr(loc).locDom.low);
       randlist.fillRandom(B.locArr(loc).myElems);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
@@ -85,7 +85,7 @@ proc initVectors(B, C) {
   // TODO: should write a fillRandom() implementation that does this
   coforall loc in B.dom.dist.targetLocDom {
     on B.dom.dist.targetLocs(loc) {
-      var randlist = new NPBRandomStream(seed);
+      var randlist = new NPBRandomStream(real, seed);
       // TODO: Need to clean this up to use more normal method names
       randlist.skipToNth(B.locArr(loc).locDom.low);
       randlist.fillRandom(B.locArr(loc).myElems);

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
@@ -64,7 +64,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace, print) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
@@ -67,7 +67,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/bradc/stream-nopromote.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-nopromote.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-slice.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-slice.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
+++ b/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
@@ -67,7 +67,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/marybeth/stream.chpl
+++ b/test/studies/hpcc/STREAMS/marybeth/stream.chpl
@@ -71,7 +71,7 @@ proc main() {
 }
 
 proc initStreamVectors() {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(A);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/marybeth/stream.chpl
+++ b/test/studies/hpcc/STREAMS/marybeth/stream.chpl
@@ -91,7 +91,7 @@ proc computeStreamResults() {
 
 
 proc checkSTREAMresults() {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   var Aref, Bref, Cref, error : [VecDomain] elemType;
 

--- a/test/studies/hpcc/STREAMS/stream-hpcc06.chpl
+++ b/test/studies/hpcc/STREAMS/stream-hpcc06.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/stream-nopromote.chpl
+++ b/test/studies/hpcc/STREAMS/stream-nopromote.chpl
@@ -50,7 +50,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(seed);
+  var randlist = new NPBRandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/common/bradc/unit/parRandom2-fill.chpl
+++ b/test/studies/hpcc/common/bradc/unit/parRandom2-fill.chpl
@@ -10,8 +10,8 @@ const ProblemSpace: domain(1, int(64)) dmapped(ProblemDist) = {1..n};
 var A: [ProblemSpace] real;
 var B: [ProblemSpace] real;
 
-var randStr1 = new NPBRandomStream(314159265);
-var randStr2 = new NPBRandomStream(314159265);
+var randStr1 = new NPBRandomStream(real, 314159265);
+var randStr2 = new NPBRandomStream(real, 314159265);
 
 randStr1.fillRandom(A);
 

--- a/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
@@ -113,9 +113,9 @@ module SSCA2_RMAT_graph_generator
       // Random Numbers return in the range [0.0, 1.0)
 
       var Rand_Gen = if REPRODUCIBLE_PROBLEMS then 
-	               new NPBRandomStream (seed = 0556707007)
+	               new NPBRandomStream (real, seed = 0556707007)
 		     else
-		       new NPBRandomStream ();
+		       new NPBRandomStream (real);
 
       var   Noisy_a     : [edge_range] real, 
 	    Noisy_b     : [edge_range] real, 

--- a/test/studies/sudoku/dinan/sudoku-smart.chpl
+++ b/test/studies/sudoku/dinan/sudoku-smart.chpl
@@ -8,7 +8,7 @@ config const MAX_ITER  = 500000;
 var givenBoard: [1..9, 1..9] int;  // The given board
 var initBoard:  [1..9, 1..9] int;  // The initialized board
 
-var myRand = new RandomStream();
+var myRand = new RandomStream(real);
 
 
 // Return a random number on the range [1, n]

--- a/test/studies/sudoku/dinan/sudoku.chpl
+++ b/test/studies/sudoku/dinan/sudoku.chpl
@@ -8,7 +8,7 @@ config const MAX_ITER  = 1000000;
 var givenBoard: [1..9, 1..9] int;  // The given board
 var initBoard:  [1..9, 1..9] int;  // The initialized board
 
-var myRand = new NPBRandomStream(seed=314159265);
+var myRand = new NPBRandomStream(real, seed=314159265);
 
 
 // Return a random number on the range [1, n]

--- a/test/trivial/diten/pi_monte_carlo.chpl
+++ b/test/trivial/diten/pi_monte_carlo.chpl
@@ -7,7 +7,7 @@ config const verbose: bool = false;
 
 var count:int;
 var pi, startTime, totalTime: real;
-var rs = new NPBRandomStream(seed);
+var rs = new NPBRandomStream(real, seed);
 
 startTime = getCurrentTime(TimeUnits.microseconds);
 

--- a/test/users/jglewis/cholesky_version_1/test_cholesky.chpl
+++ b/test/users/jglewis/cholesky_version_1/test_cholesky.chpl
@@ -89,7 +89,7 @@ module cholesky_test {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const mat_dom : domain (2) = { index_base .. #n, index_base .. #n };
 

--- a/test/users/npadmana/twopt/do_smu_aos.chpl
+++ b/test/users/npadmana/twopt/do_smu_aos.chpl
@@ -42,7 +42,7 @@ record WeightedParticle3D {
 
 proc generateRandom(pp : []WeightedParticle3D) {
   var x,y,z : real;
-  var rng = new RandomStream();
+  var rng = new RandomStream(real);
   for ip in pp {
     x = rng.getNext()*1000.0; y = rng.getNext()*1000.0; z=rng.getNext()*1000.0;
     ip.x = (x,y,z);

--- a/test/users/npadmana/twopt/do_smu_soa.chpl
+++ b/test/users/npadmana/twopt/do_smu_soa.chpl
@@ -55,7 +55,7 @@ class Particle3D {
     Darr = {ParticleAttrib, 0.. #npart};
     Dpart = {0.. #npart};
     if random {
-      var rng = new RandomStream();
+      var rng = new RandomStream(real);
       var x, y, z : real;
       for ii in Dpart {
         x = rng.getNext()*1000.0; y = rng.getNext()*1000.0; z = rng.getNext()*1000.0;
@@ -96,7 +96,7 @@ class Particle3D {
     }
 
     // Set the random number generator
-    var rng = new RandomStream(41);
+    var rng = new RandomStream(real, 41);
     var jj : int;
     for ii in 0..(npart-2) {
       jj = (rng.getNext()*(npart-ii)):int + ii;

--- a/test/users/vass/internal-error-message.chpl
+++ b/test/users/vass/internal-error-message.chpl
@@ -328,7 +328,7 @@ module cholesky_scalar_algorithms {
 
   proc main {
 
-    var Rand = new RandomStream ( seed = 314159) ;
+    var Rand = new RandomStream ( real, seed = 314159) ;
 
     const MatIdx = { index_base .. #n, index_base .. #n };
 


### PR DESCRIPTION
Fixed issue #5281 by adjusting RandomStream constructor arguments. Before this PR, they are
``` chapel
      proc RandomStream(seed: int(64) = SeedGenerator.currentTime,
                        param parSafe: bool = true,
                        type eltType = real(64) )
```
and this PR changes them to
``` chapel
      proc RandomStream(type eltType,
                        seed: int(64) = SeedGenerator.currentTime,
                        param parSafe: bool = true)
```



since:

1) the type is more important, important enough to
    be the first argument and important enough to be required
2) the default of `real` only really made sense when NPB
    was the only RNG and it couldn't do integers.

(See the issue for details for why this change resolves the issue).

This PR additionally uses a function of last resort (with the "compiler generated" pragma) to create a deprecation error in cases that would require code changes.

Passed full local testing.
Passed quickstart+GASNet testing.

Reviewed by @ben-albrecht - thanks!