### PR TITLE
Add support for passing arbitrary env vars to paratest clients

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -495,10 +495,11 @@ sub find_files {
 
 
 sub print_help {
-    print "Usage: paratest.server [-compopts s] [-dirfile d] [-dirs d] [-execopts s] [-filedist] [-futures] [-logfile l] [-memleaks f] [-nodefile n] [-nodepara m] [-valgrind[exe]] [-help|-h] [-timeout t]\n";
+    print "Usage: paratest.server [-compopts s] [-dirfile d] [-dirs d] [-env s] [-execopts s] [-filedist] [-futures] [-logfile l] [-memleaks f] [-nodefile n] [-nodepara m] [-valgrind[exe]] [-help|-h] [-timeout t]\n";
     print "    -compopts s: s is a string that is passed with -compopts to start_test.\n";
     print "    -dirfile  d: d is a file listing directories to test. Default is the current diretory.\n";
     print "    -dirs     d: d is a space separated list of directories to recursively search for directories to test\n";
+    print "    -env s     : s is a string of space separated env vars forwarded to each client\n";
     print "    -execopts s: s is a string that is passed with -execopts to start_test.\n";
     print "    -filedist  : distribute work at the granularity of files (directory granurality is the default).\n";
     print "    -futures   : include .future tests (default is none).\n";
@@ -541,6 +542,14 @@ sub main {
                 $execopts = "$execopts $ARGV[0]";
             } else {
                 print "missing -execopts arg\n";
+                exit (8);
+            }
+        } elsif (/^-env/) {
+            shift @ARGV;
+            if ($#ARGV >= 0) {
+                $extra_env = "$extra_env $ARGV[0]";
+            } else {
+                print "missing -env arg\n";
                 exit (8);
             }
         } elsif (/^-filedist/) {
@@ -755,6 +764,7 @@ sub main {
         }
         $chplenv .= "$key=$value ";
     }
+    $chplenv="$chplenv$extra_env";
 
     nodes_free ();         # signal that all nodes free
     feed_nodes ($chplenv); # parallel testing


### PR DESCRIPTION
Add the ability to do something like:

    $CHPL_HOME/util/test/paratest.server -env QT_AFFINITY=no

so that you can send arbitrary env vars to paratest clients. We already forward
the chplenv automatically, but we don't have any way (automatic or manual) to
set third-party or other arbitrary env vars.

To speed up testing and limit timeouts I like to run paratest with:

    QT_AFFINITY=no
    CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes

I always set `CHPL_TEST_LIMIT_RUNNING_EXECUTABLES` in my bashrc, but I can't just
do that for `QT_AFFINITY` since that could affect performance runs, so I have to
remember to set it only for paratesting, and then remember to remove it when
I'm done. This gives me a way to only set these env vars for paratesting, and
it's a feature I've heard others want for similar reasons (setting gasnet
vars, etc.)