### PR TITLE
Skip tests -nl>4 when running multinode multilocale on chapcs cluster

### DIFF
--- a/test/release/examples/primers/chplvis/chplvis1.skipif
+++ b/test/release/examples/primers/chplvis/chplvis1.skipif
@@ -1,0 +1,6 @@
+# Skip test "chplvis1" when running multinode multilocale on chapcs cluster
+
+# The test wants 5 compute nodes, but Chapel's nightly build schedule as of 02/2017
+# only leaves 4 nodes available on the chapcs cluster
+
+CHPL_NIGHTLY_TEST_CONFIG_NAME <= ^slurm-gasnet-ibv

--- a/test/release/examples/primers/chplvis/chplvis2.skipif
+++ b/test/release/examples/primers/chplvis/chplvis2.skipif
@@ -1,0 +1,6 @@
+# Skip test "chplvis2" when running multinode multilocale on chapcs cluster
+
+# The test wants 5 compute nodes, but Chapel's nightly build schedule as of 02/2017
+# only leaves 4 nodes available on the chapcs cluster
+
+CHPL_NIGHTLY_TEST_CONFIG_NAME <= ^slurm-gasnet-ibv

--- a/test/release/examples/primers/chplvis/chplvis3.skipif
+++ b/test/release/examples/primers/chplvis/chplvis3.skipif
@@ -1,9 +1,6 @@
-# Skip test chplvis3 when running multinode multilocale tests on chapcs cluster
+# Skip test "chplvis3" when running multinode multilocale on chapcs cluster
 
-# When chplvis3 tries to run multinode multilocale on the chapcs cluster
-# during the nightly builds, Slurm will block almost everything else while
-# it waits for 8 nodes to become available.
-
-# (chplvis3 wants 8 nodes, but chapcs cluster only has 11 "compute" nodes)
+# The test wants 8 compute nodes, but Chapel's nightly build schedule as of 02/2017
+# only leaves 4 nodes available on the chapcs cluster
 
 CHPL_NIGHTLY_TEST_CONFIG_NAME <= ^slurm-gasnet-ibv

--- a/test/release/examples/primers/distributions.skipif
+++ b/test/release/examples/primers/distributions.skipif
@@ -1,0 +1,6 @@
+# Skip test "distributions" when running multinode multilocale on chapcs cluster
+
+# The test wants 6 compute nodes, but Chapel's nightly build schedule as of 02/2017
+# only leaves 4 nodes available on the chapcs cluster
+
+CHPL_NIGHTLY_TEST_CONFIG_NAME <= ^slurm-gasnet-ibv


### PR DESCRIPTION
A few tests in release/examples want > 4 compute nodes (in multilocale mode), 
but Chapel's nightly build schedule as of 02/2017 only leaves 4 nodes available 
on the chapcs cluster. 
This change skips those tests just for the one multinode multilocale test config
which runs on chapcs cluster.
