### PR TITLE
Use CHPL_TEST_NUM_LOCALES_AVAILABLE to limit demand for compute nodes…

### DIFF
--- a/test/release/examples/primers/chplvis/chplvis3.skipif
+++ b/test/release/examples/primers/chplvis/chplvis3.skipif
@@ -1,9 +1,0 @@
-# Skip test chplvis3 when running multinode multilocale tests on chapcs cluster
-
-# When chplvis3 tries to run multinode multilocale on the chapcs cluster
-# during the nightly builds, Slurm will block almost everything else while
-# it waits for 8 nodes to become available.
-
-# (chplvis3 wants 8 nodes, but chapcs cluster only has 11 "compute" nodes)
-
-CHPL_NIGHTLY_TEST_CONFIG_NAME <= ^slurm-gasnet-ibv

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1197,7 +1197,7 @@ for testname in testsrc:
     else:
         if maxLocalesAvailable is not None:
             if numlocales > maxLocalesAvailable:
-                sys.stdout.write('[Warning: skipping {0} because it requires '
+                sys.stdout.write('[Skipping test {0} because it requires '
                                  '{1} locales but only {2} are available]\n'
                                  .format(os.path.join(localdir, test_filename),
                                          numlocales, maxLocalesAvailable))


### PR DESCRIPTION
… on chapcs cluster

For scheduling reasons, we now use global env variable CHPL_TEST_NUM_LOCALES_AVAILABLE
to limit the max number of compute nodes that multi-node multi-locale tests can
request, on the chapcs cluster.

This change:
- Removes the word "Warning" from the log message issued when a test is skipped
  for that reason. The word "Warning" causes the test harness to mark the test as
  an "error"; instead, we just want to silently skip the test.
- Deletes a skipif file that was inserted a few months ago, which is no longer needed
  now that we are using CHPL_TEST_NUM_LOCALES_AVAILABLE.