### PR TITLE
Remove use of '=>' operator from madness tests

### DIFF
--- a/test/studies/madness/aniruddha/madchap/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/MRA.chpl
@@ -195,8 +195,8 @@ class Function {
     proc refine(curNode: Node) {
         // project f(x) at next level
         var sc : [0..2*k-1] real;
-        var s0 : [0..k-1] => sc[0..k-1];
-        var s1 : [0..k-1] => sc[k..2*k-1];
+        ref s0 = sc[0..k-1];
+        ref s1 = sc[k..2*k-1];
 
         const child = curNode.get_children();
         s0 = project(child(1));

--- a/test/studies/madness/aniruddha/madchap/mytests/par-compress/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/mytests/par-compress/MRA.chpl
@@ -178,8 +178,8 @@ class Function {
     proc refine(curNode: Node) {
         // project f(x) at next level
         var sc : [0..2*k-1] real;
-        var s0 : [0..k-1] => sc[0..k-1];
-        var s1 : [0..k-1] => sc[k..2*k-1];
+        ref s0 = sc[0..k-1];
+        ref s1 = sc[k..2*k-1];
 
         const child = curNode.get_children();
         s0 = project(child(1));

--- a/test/studies/madness/aniruddha/madchap/mytests/par-reconstruct/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/mytests/par-reconstruct/MRA.chpl
@@ -178,8 +178,8 @@ class Function {
     proc refine(curNode: Node) {
         // project f(x) at next level
         var sc : [0..2*k-1] real;
-        var s0 : [0..k-1] => sc[0..k-1];
-        var s1 : [0..k-1] => sc[k..2*k-1];
+        ref s0 = sc[0..k-1];
+        ref s1 = sc[k..2*k-1];
 
         const child = curNode.get_children();
         s0 = project(child(1));

--- a/test/studies/madness/aniruddha/madchap/mytests/par-refine/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/mytests/par-refine/MRA.chpl
@@ -176,8 +176,8 @@ class Function {
     proc refine(curNode: Node) {
         // project f(x) at next level
         var sc : [0..2*k-1] real;
-        var s0 : [0..k-1] => sc[0..k-1];
-        var s1 : [0..k-1] => sc[k..2*k-1];
+        ref s0 = sc[0..k-1];
+        ref s1 = sc[k..2*k-1];
 
         const child = curNode.get_children();
         s0 = project(child(1));

--- a/test/studies/madness/aniruddha/madchap/recordBug/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/recordBug/MRA.chpl
@@ -175,8 +175,8 @@ class Function {
     proc refine(curNode: 2*int) {
         // project f(x) at next level
         var sc : [0..2*k-1] real;
-        var s0 : [0..k-1] => sc[0..k-1];
-        var s1 : [0..k-1] => sc[k..2*k-1];
+        ref s0 = sc[0..k-1];
+        ref s1 = sc[k..2*k-1];
 
         const child = sumC.get_children(curNode);
         s0 = project(child(1));

--- a/test/studies/madness/common/MRA.chpl
+++ b/test/studies/madness/common/MRA.chpl
@@ -172,8 +172,8 @@ class Function {
     proc refine(curNode: 2*int) {
         // project f(x) at next level
         var sc : [0..2*k-1] real;
-        var s0 : [0..k-1] => sc[0..k-1];
-        var s1 : [0..k-1] => sc[k..2*k-1];
+        ref s0 = sc[0..k-1];
+        ref s1 = sc[k..2*k-1];
 
         const child = sumC.get_children(curNode);
         s0 = project(child(1));


### PR DESCRIPTION
A bunch of madness code used reindexing, but needlessly so.  Rewrote
to avoid the reindexing and the '=>' operator (favoring 'ref' instead).