### PR TITLE
Improve how 'CHPL_UNWIND' output is squashed in testing

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -560,6 +560,9 @@ def check_environment():
     if "CHPL_DEVELOPER" in os.environ: # unset CHPL_DEVELOPER
         del os.environ["CHPL_DEVELOPER"]
 
+    if "CHPL_UNWIND" in os.environ:    # squash CHPL_UNWIND output
+        os.environ["CHPL_RT_UNWIND"] = "0"
+
     # Check for $CHPL_HOME
     global home
     if "CHPL_HOME" in os.environ:
@@ -742,15 +745,6 @@ def set_up_general():
 
     logger.write("[Starting Chapel regression tests - {0}]"
             .format(time.strftime("%y%m%d.%H%M%S")))
-
-    # warn (and optionally exit) if CHPL_UNWIND is set
-    if "CHPL_UNWIND" in os.environ:    # unset CHPL_UNWIND
-        if os.environ["CHPL_UNWIND"] != "none":
-            logger.write("[Warning: CHPL_UNWIND is enabled, which may cause output differences]")
-            if "CHPL_TEST_HALT_IF_UNWIND_ENABLED" in os.environ:
-                logger.write("[Exiting due to CHPL_TEST_HALT_IF_UNWIND_ENABLED]")
-                sys.exit(1)
-
 
     # check to see if we are in subdir of CHPL_HOME
     if args.chpl_home_warn:

--- a/util/start_test
+++ b/util/start_test
@@ -560,9 +560,6 @@ def check_environment():
     if "CHPL_DEVELOPER" in os.environ: # unset CHPL_DEVELOPER
         del os.environ["CHPL_DEVELOPER"]
 
-    if "CHPL_UNWIND" in os.environ:    # unset CHPL_UNWIND
-        del os.environ["CHPL_UNWIND"]
-
     # Check for $CHPL_HOME
     global home
     if "CHPL_HOME" in os.environ:
@@ -745,6 +742,15 @@ def set_up_general():
 
     logger.write("[Starting Chapel regression tests - {0}]"
             .format(time.strftime("%y%m%d.%H%M%S")))
+
+    # warn (and optionally exit) if CHPL_UNWIND is set
+    if "CHPL_UNWIND" in os.environ:    # unset CHPL_UNWIND
+        if os.environ["CHPL_UNWIND"] != "none":
+            logger.write("[Warning: CHPL_UNWIND is enabled, which may cause output differences]")
+            if "CHPL_TEST_HALT_IF_UNWIND_ENABLED" in os.environ:
+                logger.write("[Exiting due to CHPL_TEST_HALT_IF_UNWIND_ENABLED]")
+                sys.exit(1)
+
 
     # check to see if we are in subdir of CHPL_HOME
     if args.chpl_home_warn:


### PR DESCRIPTION
An unanticipated impact of my change to unset CHPL_UNWIND in
start_test (#5184) is that if you've got CHPL_UNWIND set, build the
runtime, and then run start_test, you may not have the correct runtime
built and up-to-date since we specialize the runtime builds based on
the CHPL_UNWIND setting.  Thus, you could get an error saying that the
proper runtime configuration isn't built (even though you thought you
just built it), or you could inadvertantly test a stale runtime that
you had lying around.

This change backs out the unsetting of CHPL_UNWIND and switches
to the undocumented CHPL_RT_UNWIND variable that @ronawho 
noticed which serves as a means to squash CHPL_UNWIND output on
a run-by-run basis.
