### PR TITLE
ZMQ weather test fix

### DIFF
--- a/test/modules/packages/ZMQ/CLEANFILES
+++ b/test/modules/packages/ZMQ/CLEANFILES
@@ -1,2 +1,3 @@
 version.good
 version-c
+*.orig.tmp

--- a/test/modules/packages/ZMQ/weather.chpl
+++ b/test/modules/packages/ZMQ/weather.chpl
@@ -43,8 +43,6 @@ iter zipcodes(num: int) {
 }
 
 proc Launcher(exec: string) {
-  writeln("Launcher: ", exec);
-
   var master = spawn(["master", "--mode=Master",
                       "--memLeaks=" + memLeaks:string],
                      env=env, executable=exec);

--- a/test/modules/packages/ZMQ/weather.good
+++ b/test/modules/packages/ZMQ/weather.good
@@ -1,5 +1,0 @@
-Average temperature for zipcode '10001' was 41 F
-Average temperature for zipcode '60290' was 100.8 F
-Average temperature for zipcode '90001' was 11.6 F
-Average temperature for zipcode '20001' was 16.2 F
-Launcher: ./weather

--- a/test/modules/packages/ZMQ/weather.prediff
+++ b/test/modules/packages/ZMQ/weather.prediff
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+mv $2 $1.orig.tmp
+echo -n '' > $2


### PR DESCRIPTION
This PR fixes failures with a ZMQ module test.

The ZMQ weather example/test program uses a pub/sub communication model. A ZMQ pub/sub connection is inherently unreliable (like UDP, unlike TCP). This was resulting in some automated test failures when message(s) would get dropped. This test preserves the example, but doesn't check the output, which was pseudo-randomly generated and subject to packet losses as described here.

Poking @awallace-cray, who brought this to my attention. 