### PR TITLE
suppressif for error handling tests

### DIFF
--- a/test/errhandling/inprogress/empty-throws.suppressif
+++ b/test/errhandling/inprogress/empty-throws.suppressif
@@ -1,1 +1,7 @@
+# pgi
+#
+# When PGI is the host compiler, the lowering of TryStmt fails for no clear
+# reason. noakes and psahabu are strongly suspicious of the PGI compiler
+# itself, so suppressing the output makes sense for now.
+
 CHPL_HOST_COMPILER<=pgi

--- a/test/errhandling/inprogress/empty-throws.suppressif
+++ b/test/errhandling/inprogress/empty-throws.suppressif
@@ -4,4 +4,4 @@
 # reason. noakes and psahabu are strongly suspicious of the PGI compiler
 # itself, so suppressing the output makes sense for now.
 
-CHPL_HOST_COMPILER<=pgi
+CHPL_HOST_COMPILER==pgi

--- a/test/errhandling/inprogress/empty-throws.suppressif
+++ b/test/errhandling/inprogress/empty-throws.suppressif
@@ -1,0 +1,1 @@
+CHPL_HOST_COMPILER<=pgi

--- a/test/errhandling/inprogress/no-prop.suppressif
+++ b/test/errhandling/inprogress/no-prop.suppressif
@@ -1,1 +1,7 @@
+# pgi
+#
+# When PGI is the host compiler, the lowering of TryStmt fails for no clear
+# reason. noakes and psahabu are strongly suspicious of the PGI compiler
+# itself, so suppressing the output makes sense for now.
+
 CHPL_HOST_COMPILER<=pgi

--- a/test/errhandling/inprogress/no-prop.suppressif
+++ b/test/errhandling/inprogress/no-prop.suppressif
@@ -4,4 +4,4 @@
 # reason. noakes and psahabu are strongly suspicious of the PGI compiler
 # itself, so suppressing the output makes sense for now.
 
-CHPL_HOST_COMPILER<=pgi
+CHPL_HOST_COMPILER==pgi

--- a/test/errhandling/inprogress/no-prop.suppressif
+++ b/test/errhandling/inprogress/no-prop.suppressif
@@ -1,0 +1,1 @@
+CHPL_HOST_COMPILER<=pgi

--- a/test/errhandling/inprogress/propagate.suppressif
+++ b/test/errhandling/inprogress/propagate.suppressif
@@ -1,1 +1,7 @@
+# pgi
+#
+# When PGI is the host compiler, the lowering of TryStmt fails for no clear
+# reason. noakes and psahabu are strongly suspicious of the PGI compiler
+# itself, so suppressing the output makes sense for now.
+
 CHPL_HOST_COMPILER<=pgi

--- a/test/errhandling/inprogress/propagate.suppressif
+++ b/test/errhandling/inprogress/propagate.suppressif
@@ -4,4 +4,4 @@
 # reason. noakes and psahabu are strongly suspicious of the PGI compiler
 # itself, so suppressing the output makes sense for now.
 
-CHPL_HOST_COMPILER<=pgi
+CHPL_HOST_COMPILER==pgi

--- a/test/errhandling/inprogress/propagate.suppressif
+++ b/test/errhandling/inprogress/propagate.suppressif
@@ -1,0 +1,1 @@
+CHPL_HOST_COMPILER<=pgi

--- a/test/errhandling/inprogress/throws-destroys.good
+++ b/test/errhandling/inprogress/throws-destroys.good
@@ -1,0 +1,2 @@
+This file will only be compared against when the compilation of throws-destroys
+itself fails. The failure will be suppressed when PGI is the host compiler. 

--- a/test/errhandling/inprogress/throws-destroys.suppressif
+++ b/test/errhandling/inprogress/throws-destroys.suppressif
@@ -1,0 +1,1 @@
+CHPL_HOST_COMPILER<=pgi

--- a/test/errhandling/inprogress/throws-destroys.suppressif
+++ b/test/errhandling/inprogress/throws-destroys.suppressif
@@ -1,1 +1,7 @@
-CHPL_HOST_COMPILER<=pgi
+# pgi
+#
+# When PGI is the host compiler, the lowering of TryStmt fails for no clear
+# reason. noakes and psahabu are strongly suspicious of the PGI compiler
+# itself, so suppressing the output makes sense for now.
+
+CHPL_HOST_COMPILER==pgi

--- a/test/errhandling/inprogress/top-try-bang.suppressif
+++ b/test/errhandling/inprogress/top-try-bang.suppressif
@@ -1,1 +1,7 @@
+# pgi
+#
+# When PGI is the host compiler, the lowering of TryStmt fails for no clear
+# reason. noakes and psahabu are strongly suspicious of the PGI compiler
+# itself, so suppressing the output makes sense for now.
+
 CHPL_HOST_COMPILER<=pgi

--- a/test/errhandling/inprogress/top-try-bang.suppressif
+++ b/test/errhandling/inprogress/top-try-bang.suppressif
@@ -4,4 +4,4 @@
 # reason. noakes and psahabu are strongly suspicious of the PGI compiler
 # itself, so suppressing the output makes sense for now.
 
-CHPL_HOST_COMPILER<=pgi
+CHPL_HOST_COMPILER==pgi

--- a/test/errhandling/inprogress/top-try-bang.suppressif
+++ b/test/errhandling/inprogress/top-try-bang.suppressif
@@ -1,0 +1,1 @@
+CHPL_HOST_COMPILER<=pgi


### PR DESCRIPTION
When `CHPL_HOST_COMPILER=pgi`, there is an unexplained error in the lowering of `TryStmt`. @noakesmichael and I have a strong suspicion of the PGI compiler itself, so these tests will be suppressed for now.