### PR TITLE
Header file shuffle

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -19,7 +19,6 @@
 
 // foralls.h, foralls.cpp - support for forall loops
 
-#include "expr.h"
 #include "foralls.h"
 #include "astutil.h"
 #include "stlUtil.h"

--- a/compiler/include/foralls.h
+++ b/compiler/include/foralls.h
@@ -22,6 +22,8 @@
 
 //// foralls.h, foralls.cpp - support for forall loops ////
 
+#include "expr.h"
+
 //
 // TFITag: a task or forall intent
 //


### PR DESCRIPTION
Mike's rule is that each header file must #include its dependencies
so that it is possible for a .cpp file to #include only that header.

This change brings forall.h in compliance with that rule.

Trivial, not reviewed.