### PR TITLE
Update ZMQ/weather test for PR #5303 and revise prediff from #5321

### DIFF
--- a/test/modules/packages/ZMQ/CLEANFILES
+++ b/test/modules/packages/ZMQ/CLEANFILES
@@ -1,3 +1,2 @@
 version.good
 version-c
-*.orig.tmp

--- a/test/modules/packages/ZMQ/weather.chpl
+++ b/test/modules/packages/ZMQ/weather.chpl
@@ -61,7 +61,7 @@ proc Launcher(exec: string) {
 }
 
 proc Master(exec: string) {
-  var rand = new RandomStream(13); rand.getNext();
+  var rand = new RandomStream(real,13); rand.getNext();
   var ctxt: Context;
   var sock = ctxt.socket(ZMQ.PUB);
   sock.bind("tcp://*:5556");

--- a/test/modules/packages/ZMQ/weather.good
+++ b/test/modules/packages/ZMQ/weather.good
@@ -1,0 +1,4 @@
+Average temperature for zipcode '10001' was xx.x F
+Average temperature for zipcode '20001' was xx.x F
+Average temperature for zipcode '60290' was xx.x F
+Average temperature for zipcode '90001' was xx.x F

--- a/test/modules/packages/ZMQ/weather.prediff
+++ b/test/modules/packages/ZMQ/weather.prediff
@@ -1,4 +1,26 @@
 #!/usr/bin/env bash
 
-mv $2 $1.orig.tmp
-echo -n '' > $2
+# Fuzz the calculated "average temperature" values in the test output file.
+
+# The ZMQ weather example/test program uses a pub/sub communication model.
+# A ZMQ pub/sub connection is inherently unreliable (like UDP, unlike TCP).
+# If one or more messages get dropped, the values of "average temperature"
+# will come out different than usual, and Chapel's automated test harness
+# will raise an error.
+
+# This prediff fuzzes the calculated data just enough so the test will pass,
+# even if a few ZMQ messages get dropped as described above.
+
+outfile=$2
+sort $outfile | sed -e 's, [0-9.+-]* F$, xx.x F,' > $outfile.tmp
+mv $outfile.tmp $outfile
+
+# Note: the corresponding weather.good file has been fuzzed to agree with
+# the test output, after this prediff.
+# FYI, here is the original test output from a normal weather.chpl test run
+# with no dropped messages (February, 2017)
+#
+# Average temperature for zipcode '10001' was 41 F
+# Average temperature for zipcode '60290' was 100.8 F
+# Average temperature for zipcode '90001' was 11.6 F
+# Average temperature for zipcode '20001' was 16.2 F


### PR DESCRIPTION
Add the mandatory first arg in RandomStream ctor, PR #5303 

Revise ZMQ/weather prediff from PR #5321 to hide fewer test errors.
    
By coincidence, the day we merged PR #5321, an unrelated PR #5303
went in the same day; and it made a change which should have broke
the ZMQ/weather test.

Unfortunately, the new weather.prediff from PR #5321 hides this
new chpl Warning from the test harness, and ZMQ/weather test
passes when it should fail.
    
This change rewrites ZMQ/weather.prediff so it ONLY hides the
kind of test error that PR #5321 was meant for.