### PR TITLE
Beef up arrays mem tests

### DIFF
--- a/test/memory/sungeun/refCount/arrays-rankchange.chpl
+++ b/test/memory/sungeun/refCount/arrays-rankchange.chpl
@@ -1,0 +1,78 @@
+config const dummy = false;
+config const printMemStats = false;
+
+proc pass_original(A: []) {
+  A;
+}
+
+proc return_original(A: []) {
+  return A;
+}
+
+proc create_rankchange(A: []) {
+  A[.., 3];
+  if dummy then writeln(A.domain);
+}
+
+proc return_rankchange(A: []) {
+  return A[.., 3];
+}
+
+use Memory;
+proc main() {
+  var A: [1..9, 1..9] int;
+
+  writeln("Calling pass_original() with rank-change:");
+  var m1 = memoryUsed();
+  serial {
+    pass_original(A[3, 1..9]);
+  }
+  var m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling return_original() with rank-change:");
+  m1 = memoryUsed();
+  serial {
+    return_original(A[3, 1..9]);
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling return_original() with rank-change and assignment:");
+  m1 = memoryUsed();
+  serial {
+    var A2 = return_original(A[3, 1..9]);
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling create_rankchange():");
+  m1 = memoryUsed();
+  serial {
+    create_rankchange(A);
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling return_rankchange():");
+  m1 = memoryUsed();
+  serial {
+    return_rankchange(A);
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling return_rankchange() with assignment:");
+  m1 = memoryUsed();
+  serial {
+    var A2 = return_rankchange(A);
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+}

--- a/test/memory/sungeun/refCount/arrays-rankchange.good
+++ b/test/memory/sungeun/refCount/arrays-rankchange.good
@@ -1,0 +1,12 @@
+Calling pass_original() with rank-change:
+	0 bytes leaked
+Calling return_original() with rank-change:
+	0 bytes leaked
+Calling return_original() with rank-change and assignment:
+	0 bytes leaked
+Calling create_rankchange():
+	0 bytes leaked
+Calling return_rankchange():
+	0 bytes leaked
+Calling return_rankchange() with assignment:
+	0 bytes leaked

--- a/test/memory/sungeun/refCount/arrays.chpl
+++ b/test/memory/sungeun/refCount/arrays.chpl
@@ -19,15 +19,25 @@ proc return_alias(A: []) {
 proc create_slice(A: []) {
   A[2..3];
 }
+
+proc pass_original(A: [] ) {
+  A;
+}
+
+proc return_original(A: []) {
+  return A;
+}
+
 proc return_slice(A: []) {
   return A[2..3];
 }
 
-proc create_reindex(A: [3..6]) {
+proc create_reindex(A: []) {
+  A.reindex({3..6});
   if dummy then writeln(A.domain);
 }
-proc return_reindex(A: [3..6]) {
-  return A;
+proc return_reindex(A: []) {
+  return A.reindex({3..6});
 }
 
 use Memory;
@@ -115,10 +125,64 @@ proc main() {
   writeln("\t", m2-m1, " bytes leaked");
   if printMemStats then printMemAllocs();
 
+  writeln("Calling pass_original() for slice:");
+  m1 = memoryUsed();
+  serial {
+    pass_original(A[2..3]);
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling return_original() for slice:");
+  m1 = memoryUsed();
+  serial {
+    return_original(A[2..3]);
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling return_original for slice with assignment:");
+  m1 = memoryUsed();
+  serial {
+    var A2 = return_original(A[2..3]);
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling pass_original() with reindex:");
+  m1 = memoryUsed();
+  serial {
+    pass_original(A.reindex({3..6}));
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling return_original() with reindex:");
+  m1 = memoryUsed();
+  serial {
+    return_original(A.reindex({3..6}));
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
+  writeln("Calling return_original() with reindex and assignment:");
+  m1 = memoryUsed();
+  serial {
+    var A2 = return_original(A.reindex({3..6}));
+  }
+  m2 = memoryUsed();
+  writeln("\t", m2-m1, " bytes leaked");
+  if printMemStats then printMemAllocs();
+
   writeln("Calling create_reindex():");
   m1 = memoryUsed();
   serial {
-    create_reindex(A.reindex({3..6}));
+    create_reindex(A);
   }
   m2 = memoryUsed();
   writeln("\t", m2-m1, " bytes leaked");
@@ -127,7 +191,7 @@ proc main() {
   writeln("Calling return_reindex():");
   m1 = memoryUsed();
   serial {
-    return_reindex(A.reindex({3..6}));
+    return_reindex(A);
   }
   m2 = memoryUsed();
   writeln("\t", m2-m1, " bytes leaked");
@@ -136,7 +200,7 @@ proc main() {
   writeln("Calling return_reindex() with assignment:");
   m1 = memoryUsed();
   serial {
-    var A2 = return_reindex(A.reindex({3..6}));
+    var A2 = return_reindex(A);
   }
   m2 = memoryUsed();
   writeln("\t", m2-m1, " bytes leaked");

--- a/test/memory/sungeun/refCount/arrays.good
+++ b/test/memory/sungeun/refCount/arrays.good
@@ -16,6 +16,18 @@ Calling return_slice():
 	0 bytes leaked
 Calling return_slice() with assignment:
 	0 bytes leaked
+Calling pass_original() for slice:
+	0 bytes leaked
+Calling return_original() for slice:
+	0 bytes leaked
+Calling return_original for slice with assignment:
+	0 bytes leaked
+Calling pass_original() with reindex:
+	0 bytes leaked
+Calling return_original() with reindex:
+	0 bytes leaked
+Calling return_original() with reindex and assignment:
+	0 bytes leaked
 Calling create_reindex():
 	0 bytes leaked
 Calling return_reindex():


### PR DESCRIPTION
On the array views branch, I noticed some cases that were leaking but which weren't
caught by current tests of memory leaks so far related to whether the array view was
computed within a function or passed into it.  Happily these cases work on master.
To that extent, I beefed up Sung's arrays memory test to cover additional patterns
and created a variation of it that does similar patterns for rank change.  These will
be good stress tests for memory management on the array views branch(es).
