### PR TITLE
Fix a compilation error with Apple clang 8

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1525,7 +1525,7 @@ int FnSymbol::hasGenericFormals() const {
     if (isGeneric == true) {
       hasGenericFormal = true;
 
-      if (formal->defaultExpr == false) {
+      if (formal->defaultExpr == NULL) {
         hasGenericDefaults = false;
       }
     }


### PR DESCRIPTION
It's a trivial error that gave a compilation error on my system.

Passed full local testing.
Trivial and not reviewed.