### PR TITLE
Move rtmain.c out of an include directory

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1867,7 +1867,7 @@ GenInfo::GenInfo(
            FPM_postgen(NULL)
 {
   std::string home(CHPL_HOME);
-  std::string rtmain = home + "/runtime/include/rtmain.c";
+  std::string rtmain = home + "/runtime/etc/rtmain.c";
 
   setupClang(this, rtmain);
 

--- a/runtime/etc/rtmain.c
+++ b/runtime/etc/rtmain.c
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 
+// This file is used in --llvm compiles to compile the header
+// declarations for the Chapel runtime into an LLVM module.
+
 #include "stdchpl.h"
 #include "chpl-gen-includes.h"
 


### PR DESCRIPTION
To enable Debian packaging.

Passed these test directories  with CHPL_LLVM and with and without --llvm:
  * test/release/examples/
  * test/extern/ferguson/
  * test/extern/jjueckstock/