### PR TITLE
Add a .future test that uses an array of c_string

### DIFF
--- a/test/arrays/diten/array_of_c_string.chpl
+++ b/test/arrays/diten/array_of_c_string.chpl
@@ -1,0 +1,12 @@
+require "array_of_c_string.h";//, "array_of_c_string.c";
+
+extern proc foo(argc: int, argv: c_void_ptr);
+
+proc main(args: [] string) {
+  var c_args: [0..#args.numElements] c_string;
+
+  for i in 0..#args.numElements do
+    c_args[i] = args[i].c_str();
+
+  foo(c_args.numElements, c_ptrTo(c_args));
+}

--- a/test/arrays/diten/array_of_c_string.future
+++ b/test/arrays/diten/array_of_c_string.future
@@ -1,0 +1,1 @@
+bug: array of c_string causes internal error for --no-local

--- a/test/arrays/diten/array_of_c_string.good
+++ b/test/arrays/diten/array_of_c_string.good
@@ -1,0 +1,1 @@
+called foo

--- a/test/arrays/diten/array_of_c_string.h
+++ b/test/arrays/diten/array_of_c_string.h
@@ -1,0 +1,6 @@
+#include <stdint.h>
+#include <stdio.h>
+
+static inline void foo(int64_t argc, const char* argv[]) {
+  printf("called foo\n");
+}

--- a/test/arrays/diten/array_of_c_string.skipif
+++ b/test/arrays/diten/array_of_c_string.skipif
@@ -1,0 +1,3 @@
+# This test is not interesting on a single locale,
+# as it triggered a compiler bug only with --no-local.
+CHPL_COMM==none


### PR DESCRIPTION
Declaring an array of c_string causes compiler segfaults for --no-local
compiles.  This test includes an extern call similar to the motivation for
wanting an array of c_string, but it can be reduced to just the single line
that declares c_args.