### PR TITLE
Extend CallInfo to support generic initializers

### DIFF
--- a/compiler/resolution/callInfo.cpp
+++ b/compiler/resolution/callInfo.cpp
@@ -60,18 +60,24 @@ CallInfo::CallInfo(CallExpr* icall, bool checkonly, bool initOkay) :
     INT_ASSERT(se);
     Type* t = se->symbol()->type;
     if (t == dtUnknown && ! se->symbol()->hasFlag(FLAG_TYPE_VARIABLE) ) {
-      if (checkonly) badcall = true;
-      else USR_FATAL(call, "use of '%s' before encountering its definition, "
-                           "type unknown", se->symbol()->name);
+      if (checkonly) {
+        badcall = true;
+      } else {
+        USR_FATAL(call, "use of '%s' before encountering its definition, "
+                  "type unknown", se->symbol()->name);
+      }
     }
     if (t->symbol->hasFlag(FLAG_GENERIC)) {
       if (initOkay && isThis) {
         // initOkay is only used when resolving an initializer call, so we
         // allow the this argument to be generic, as we will perform the work
         // necessary to instantiate it.
-      } else if (checkonly) badcall = true;
-      else INT_FATAL(call, "the type of the actual argument '%s' is generic",
-                            se->symbol()->name);
+      } else if (checkonly) {
+        badcall = true;
+      } else {
+        INT_FATAL(call, "the type of the actual argument '%s' is generic",
+                  se->symbol()->name);
+      }
     }
     actuals.add(se->symbol());
   }

--- a/compiler/resolution/callInfo.h
+++ b/compiler/resolution/callInfo.h
@@ -35,7 +35,7 @@ class CallInfo {
   Vec<Symbol*>     actuals;     // actual symbols
   Vec<const char*> actualNames; // named arguments
   bool             badcall;     // the call is an error but checkonly set
-  CallInfo(CallExpr* icall, bool checkonly);
+  CallInfo(CallExpr* icall, bool checkonly, bool initOkay = false);
 };
 
 #endif


### PR DESCRIPTION
When an initializer is called, if the type being initialized is generic, then
the type of the actual will not be determined until we have resolved phase 1 of
the body of the best match.  Normally, CallInfo creation would reject such calls
immediately.  This change convinces CallInfo to let it pass for now.

Also cleans up a bit of the surrounding code.

Todo:

- [x] review results of my full standard testing run

This PR has been reviewed