### PR TITLE
Move some code in filterConcreteCandidate to a helper function

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -149,6 +149,8 @@ public:
   void computeSubstitutions();
 };
 
+bool checkResolveFormalsWhereClauses(ResolutionCandidate* currCandidate);
+
 typedef enum {
   FIND_EITHER = 0,
   FIND_REF,


### PR DESCRIPTION
This is so that I can reuse that code in my initializers work without having to
copy+paste it (thus making it more maintainable going forward)

Running full std/ testing