### PR TITLE
Rearrange filterGenericCandidate so that I can reuse part of it

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -150,6 +150,7 @@ public:
 };
 
 bool checkResolveFormalsWhereClauses(ResolutionCandidate* currCandidate);
+bool checkGenericFormals(ResolutionCandidate* currCandidate);
 
 typedef enum {
   FIND_EITHER = 0,


### PR DESCRIPTION
Instead of copy+pasting all of filterGenericCandidate, my initializers work will
now utilize the helper method for checking the generic formals.  The parts that
needed to be modified will stay modified, but this should make the logic a bit
more maintainable.

Passed full std/ testing