### PR TITLE
Split off the part of resolveNormalCall related to determining visible functions

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -91,22 +91,6 @@ FnSymbol* instantiateFunction(FnSymbol* fn, FnSymbol* root, SymbolMap& all_subs,
 void explainAndCheckInstantiation(FnSymbol* newFn, FnSymbol* fn);
 
 // visible functions
-class VisibleFunctionBlock {
- public:
-  Map<const char*,Vec<FnSymbol*>*> visibleFunctions;
-  VisibleFunctionBlock() { }
-};
-
-extern Map<BlockStmt*,VisibleFunctionBlock*> visibleFunctionMap;
-extern int nVisibleFunctions; // for incremental build
-void buildVisibleFunctionMap();
-BlockStmt*
-getVisibleFunctions(BlockStmt* block,
-                    const char* name,
-                    Vec<FnSymbol*>& visibleFns,
-                    Vec<BlockStmt*>& visited,
-                    CallExpr* callOrigin);
-
 void fillVisibleFuncVec(CallExpr* call, CallInfo &info,
                         Vec<FnSymbol*> &visibleFns);
 

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -107,7 +107,7 @@ getVisibleFunctions(BlockStmt* block,
                     Vec<BlockStmt*>& visited,
                     CallExpr* callOrigin);
 
-void fillVisibleFuncVec(CallExpr* call, CallInfo info,
+void fillVisibleFuncVec(CallExpr* call, CallInfo &info,
                         Vec<FnSymbol*> &visibleFns);
 
 // disambiguation

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -107,6 +107,9 @@ getVisibleFunctions(BlockStmt* block,
                     Vec<BlockStmt*>& visited,
                     CallExpr* callOrigin);
 
+void fillVisibleFuncVec(CallExpr* call, CallInfo info,
+                        Vec<FnSymbol*> &visibleFns);
+
 // disambiguation
 /** A wrapper for candidates for function call resolution.
  *

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3830,7 +3830,7 @@ static void handleTaskIntentArgs(CallExpr* call, FnSymbol* taskFn,
   taskFn->removeFlag(FLAG_GENERIC);
 }
 
-void fillVisibleFuncVec(CallExpr* call, CallInfo info,
+void fillVisibleFuncVec(CallExpr* call, CallInfo &info,
                         Vec<FnSymbol*> &visibleFns) {
   //
   // update visible function map as necessary


### PR DESCRIPTION
I basically just reused this code entirely in my initializers work, so turn it
into a helper function and make the functions it relied upon static and
local to functionResolution again.