### PR TITLE
Add NUMA-aware array CHIP.

### DIFF
--- a/doc/developer/chips/18.rst
+++ b/doc/developer/chips/18.rst
@@ -245,7 +245,7 @@ partitioning of the array's domain among 4 tasks.  We will have poor
 affinity no matter what we do, and thus poor performance.
 
 DSIUtil chunking need not partition on the leftmost dimension of a
-multi-dimension domain.  It actually selects the leftmost dimension
+multi-dimensional domain.  It actually selects the leftmost dimension
 whose size is at least as large as the number of NUMA domains.  Consider
 this array:
 
@@ -396,10 +396,10 @@ This is a start, but note that if either the for-stmt here cannot be
 converted to a forall-stmt or ``complicatedExpensiveComputation()``
 really is as expensive as its name implies then the ``nextLayer``
 references in the loop kernel may not actually be particularly
-NUMA-sensitive, in that getting them perfectly right makes the loop run
-any faster overall.  But for now this is is all we have seen that might
-be sensitive to the cost of array-by-array registration as described
-here.
+NUMA-sensitive, in that the performance will be driven by other things
+and whether the NUMA affinity is right or wrong will not make much
+difference.  But for now this is all we have seen that might be affected
+by the cost of array-by-array registration as described here.
 
 If no such applications exist the performance concerns would be reduced
 but not eliminated, because there would still be the need for dynamic
@@ -525,10 +525,11 @@ optimizations that could be made in the access code.  Nevertheless while
 the multi-ddata access code could be faster than it is now, it will not
 ever be as simple or fast as plain base-plus-offset addressing.  At
 least with all the addressing exposed, getting within something like 3x
-of single-ddata for single-dimension arrays is probably the best we can
-hope for.  For multi-dimension arrays we can probably get closer just
-because multi-dimension addressing is more complicated and multi-ddata
-only adds a fixed cost, but the effect will always be noticeable.
+of single-ddata for single-dimensional arrays is probably the best we
+can hope for.  For multi-dimensional arrays we can probably get closer
+just because multi-dimensional addressing is more complicated and
+multi-ddata only adds a fixed cost, but the effect will always be
+noticeable.
 
 This does not mean that multi-ddata necessarily has bad performance
 overall.  Single-ddata only performs much better when the multi-ddata

--- a/doc/developer/chips/18.rst
+++ b/doc/developer/chips/18.rst
@@ -692,6 +692,17 @@ badly with any envisioned multi-ddata.
 
 ----
 
+.. code-block:: chapel
+
+   var A: [0..7] [0..#2**20] int;
+   forall i in A.domain do forall j in A(i).domain do f(A(i)(j));
+
+Arrays of arrays are a use case we have not put any thought into yet,
+but we will need to do so when thinking longer term about the full
+solution space.
+
+----
+
 *Add examples here.*
 
 

--- a/doc/developer/chips/18.rst
+++ b/doc/developer/chips/18.rst
@@ -4,11 +4,11 @@ NUMA-Aware Array Storage
 Status
   Draft
 
-Author
-  Greg Titus (lead)
-  Ben Harshbarger
-  Elliot Ronaghan
-  Michael Ferguson
+Authors
+  Greg Titus (lead),
+  Ben Harshbarger,
+  Elliot Ronaghan,
+  Michael Ferguson,
   Sung-Eun Choi
 
 Abstract
@@ -26,8 +26,8 @@ particular array elements need to run on CPUs close to the NUMA domain
 on which those array elements are stored.  With ``locModel=numa``, the
 ``DefaultRectangular`` domain has long had NUMA-aware parallel
 iteration, based on ``DSIUtil.chpl:_computeChunkStuff()`` and related
-functionality.  (From here on this will be referred to as *DSIUtil*
-chunking.)  DSIUtil chunking divides the domain as equally as possible
+functionality.  (From here on this will be referred to as *DSIUtil
+chunking*.)  DSIUtil chunking divides the domain as equally as possible
 into subdomains, one for each sublocale, and then creates a task on each
 sublocale to process each subdomain.  What was missing was the ability
 to localize array data in a matching NUMA-sensitive way.  Recent work
@@ -43,19 +43,28 @@ multi-chunk array addressing code is more complicated than that for
 single-chunk addressing because of the need to compute a chunk index
 from the array index.  Thus the dsiAccess() array access method runs
 about 8x slower for multi-ddata arrays than for single-ddata ones.  In
-some cases the extra computation can be in effect hoisted out of kernel
+some cases the extra computation in effect can be hoisted out of kernel
 loops, but not always.  At present any loop which does not use the
 ``DefaultRectangularArr`` serial, parallel standalone, or parallel
 follower iterators performs quite poorly, and really only the parallel
 iterators give good performance.  The serial one is distinctly slower
 than for single-ddata, just not as bad as some other cases.  As an
 example, the following loop written in a natural style performs quite
-badly.
+badly with the current multi-ddata implementation, compared to how it
+does with single-ddata.
 
 .. code-block:: chapel
 
   forall i in A.domain do
     A(i) = i;
+
+But the following fairly similar loop performs quite well, similarly to
+how it does with ``locModel=flat``.
+
+.. code-block:: chapel
+
+  forall (a,i) in zip(A,A.domain) do
+    a = i;
 
 This CHIP documents our mid-course exploration of solutions for this
 problem and some other related ones.
@@ -142,29 +151,31 @@ What Matters for NUMA
 
 * network cooperation
 
-  Some network interface chips (NICs), including Cray's Aries, require
-  that memory be "registered" with them in order to be referenced in
-  network operations.  At least for Aries and probably for some others,
-  this involves pinning virtual addresses to physical addresses to fix
-  their relationship.  Doing so necessarily also sets the pages' NUMA
-  locality, since NUMA locality is a physical characteristic.  If the
-  localization of a registered page is to be changed, then the page must
-  be un-registered first and re-registered afterward.  By itself this
-  may not be very costly, but broadcasting the new registration to the
-  other nodes which need it, and synchronizing that broadcast, may be.
+  Some networks and/or their software interfaces, including the
+  libfabric interface and the Cray Aries network when accessed via
+  certain interfaces, require that memory be "registered" with them in
+  order to be referenced in network operations.  For Aries and likely
+  some others, this involves pinning virtual addresses to physical
+  addresses to fix their relationship.  Doing so necessarily also sets
+  the pages' NUMA locality, since NUMA locality is a physical
+  characteristic.  If the localization of a registered page is to be
+  changed, then the page must be un-registered first and re-registered
+  afterward.  By itself this may not be very costly, but broadcasting
+  the new registration to the other nodes which need it, and
+  synchronizing that broadcast, may be.
 
   The Cray network can have some secondary effects on NUMA performance.
-  On Cray X\* systems the NIC is slightly closer to NUMA domain 0 than
-  to NUMA domain 1.  That is, it takes slightly less time for the NIC to
-  access memory on NUMA domain 0.  So to maximize remote reference
-  performance for a given array we should allocate as much of it as
-  possible on NUMA domain 0 and only use NUMA domain 1 as a fallback.
-  However, remote references take longer than local ones, so doing this
-  only reduces the total remote latency by a small amount.  That being
-  the case, if there is significant local reference traffic to an array
-  that is also sometimes referenced remotely it is better to balance its
-  storage across the NUMA domains in order to receive the up to 2x local
-  performance benefit of doing so.
+  On Cray XC series systems the NIC is slightly closer to NUMA domain 0
+  than to NUMA domain 1.  That is, it takes slightly less time for the
+  NIC to access memory on NUMA domain 0.  So to maximize remote
+  reference performance for a given array we should allocate as much of
+  it as possible on NUMA domain 0 and only use NUMA domain 1 as a
+  fallback.  However, remote references take longer than local ones, so
+  doing this only reduces the total remote latency by a small amount.
+  That being the case, if there is significant local reference traffic
+  to an array that is also sometimes referenced remotely it is better to
+  balance its storage across the NUMA domains in order to receive the up
+  to 2x local performance benefit of doing so.
 
 
 NUMA Array Storage Alternatives
@@ -191,9 +202,15 @@ Description
 ...........
 
 This is the simplest model: allocate one ddata for an array and then
-NUMA-localize that memory.  It is what Chapel with ``locModel=numa``
-used to do, and still does for arrays of fewer than 2\*\*20 elements,
-and effectively what C with first-touch does.
+NUMA-localize that memory.  This is effectively what C and other
+languages do on NUMA architectures, implicitly, using first-touch.  Even
+Chapel does this, again implicitly by means of first-touch, for
+``locModel=flat`` and for arrays small enough to be placed on a single
+ddata chunk with ``locModel=numa``.  The proposal here is to do it
+explicitly instead, in order to get the desired localization in cases
+where first-touch fails to do so.  This can happen due to things like
+pre-localization of the memory, or the first touch coming from a CPU on
+other than the desired NUMA domain.
 
 
 Analysis
@@ -292,7 +309,7 @@ But for now we are not pursuing it further.
 The allocate-then-localize model used for single-ddata does not
 cooperate well with network interfaces that require registered memory.
 Chapel registers the heap and other data with the NIC for ``comm=ugni``
-on Cray X\* systems and also for ``comm=gasnet, conduit=aries``.
+and also for ``comm=gasnet, conduit=aries`` on Cray XC systems.
 Registration pins virtual pages to physical pages in order to fix their
 relationship.  But changing NUMA locality necessarily means changing
 physical addresses (because NUMA is a physical characteristic), which
@@ -304,9 +321,11 @@ allocation.
 All of the single-ddata alternatives have a lower limit on the size of
 array they can be applied to without too much waste.  Since the minimum
 unit of NUMA localization is a page, if it is to be localized an array
-needs to occupy at least as many memory pages as there are NUMA domains
-to avoid wasting space.  This can be large if NIC memory registration
-requires the use of hugepages, as it does on Cray X\* systems.
+needs to occupy at least as many memory pages as there are NUMA domains,
+and preferably many more to avoid wasting space.  This can be a large
+amount of memory if hugepages are being used, as will be the case for
+the highest-performing Chapel multi-locale configurations on Cray XC
+systems.
 
 
 Single-ddata with Separate Arrays
@@ -373,11 +392,18 @@ many NUMA-sensitive arrays turned up one that looks like this:
        }
     }
 
-Note that if either the for-stmt cannot be converted to a forall-stmt or
-``complicatedExpensiveComputation()`` really is expensive then the
-``nextLayer`` references in the kernel may not really be NUMA-sensitive.
-But for now this is is all we have seen that might be sensitive to the
-cost of array-by-array registration as described here.
+This is a start, but note that if either the for-stmt here cannot be
+converted to a forall-stmt or ``complicatedExpensiveComputation()``
+really is as expensive as its name implies then the ``nextLayer``
+references in the loop kernel may not actually be particularly
+NUMA-sensitive, in that getting them perfectly right makes the loop run
+any faster overall.  But for now this is is all we have seen that might
+be sensitive to the cost of array-by-array registration as described
+here.
+
+If no such applications exist the performance concerns would be reduced
+but not eliminated, because there would still be the need for dynamic
+registration and broadcast as arrays were created.
 
 
 Single-ddata with Cyclic Localization
@@ -494,15 +520,18 @@ This could be sped up significantly by doing an integer multiply by the
 reciprocal instead, or even a right-shift for power-of-two divisors.
 The ddatas and other per-chunk information are themselves currently
 stored as a ddata of records, which could be a tuple of records at a
-fair saving at array creation time.  And the are some other small
+fair saving at array creation time.  And there are some other small
 optimizations that could be made in the access code.  Nevertheless while
 the multi-ddata access code could be faster than it is now, it will not
-ever be as simple or fast as plain base-plus-offset addressing.  AT
+ever be as simple or fast as plain base-plus-offset addressing.  At
 least with all the addressing exposed, getting within something like 3x
-of single-ddata is probably the best we can hope for.
+of single-ddata for single-dimension arrays is probably the best we can
+hope for.  For multi-dimension arrays we can probably get closer just
+because multi-dimension addressing is more complicated and multi-ddata
+only adds a fixed cost, but the effect will always be noticeable.
 
 This does not mean that multi-ddata necessarily has bad performance
-overall.  Single-ddata only performs much better in when the multi-ddata
+overall.  Single-ddata only performs much better when the multi-ddata
 access cost is exposed.  The worst situation from a usability standpoint
 is probably parallel iteration over an array's domain, not zippered with
 iteration over the array itself.  Here the full cost of the array access
@@ -583,8 +612,8 @@ small enough for a single locale, because of the added involvement of
 the ``Block`` domain map where it is not currently used.
 
 
-Some Interesting Cases
-``````````````````````
+Some Interesting Use Cases
+``````````````````````````
 
 *This whole section is work in progress.*
 

--- a/doc/developer/chips/18.rst
+++ b/doc/developer/chips/18.rst
@@ -1,0 +1,825 @@
+NUMA-Aware Array Storage
+========================
+
+Status
+  Draft
+
+Author
+  Greg Titus (lead)
+  Ben Harshbarger
+  Elliot Ronaghan
+  Michael Ferguson
+  Sung-Eun Choi
+
+Abstract
+--------
+
+Place array elements in NUMA-localized memory so that Chapel programs
+can take advantage of NUMA performance in the architecture.
+
+Rationale
+---------
+
+For architectures with NUMA characteristics, best performance depends on
+affinity between execution and data storage.  The tasks that operate on
+particular array elements need to run on CPUs close to the NUMA domain
+on which those array elements are stored.  With ``locModel=numa``, the
+``DefaultRectangular`` domain has long had NUMA-aware parallel
+iteration, based on ``DSIUtil.chpl:_computeChunkStuff()`` and related
+functionality.  (From here on this will be referred to as *DSIUtil*
+chunking.)  DSIUtil chunking divides the domain as equally as possible
+into subdomains, one for each sublocale, and then creates a task on each
+sublocale to process each subdomain.  What was missing was the ability
+to localize array data in a matching NUMA-sensitive way.  Recent work
+added so-called *multi-ddata* storage for ``DefaultRectangularArr``
+arrays.  When the locale model supports sublocales, as ``numa`` does,
+this replaces the single *ddata* which provides the array storage with
+multiple ddatas, one per sublocale, and places array elements in these
+ddatas using the same DSIUtil chunking the DefaultRectangular domain
+parallel iterator uses to assign subdomains to sublocales.
+
+The resulting code performs well in some cases but badly in others.  The
+multi-chunk array addressing code is more complicated than that for
+single-chunk addressing because of the need to compute a chunk index
+from the array index.  Thus the dsiAccess() array access method runs
+about 8x slower for multi-ddata arrays than for single-ddata ones.  In
+some cases the extra computation can be in effect hoisted out of kernel
+loops, but not always.  At present any loop which does not use the
+``DefaultRectangularArr`` serial, parallel standalone, or parallel
+follower iterators performs quite poorly, and really only the parallel
+iterators give good performance.  The serial one is distinctly slower
+than for single-ddata, just not as bad as some other cases.  As an
+example, the following loop written in a natural style performs quite
+badly.
+
+.. code-block:: chapel
+
+  forall i in A.domain do
+    A(i) = i;
+
+This CHIP documents our mid-course exploration of solutions for this
+problem and some other related ones.
+
+Note that throughout the rest of the document and especially with regard
+to setting memory locality we are discussing possible future work rather
+than existing implementations.  At present the only "NUMA localization"
+done in Chapel is a side effect of first-touch memory semantics.
+
+
+Description
+-----------
+
+Here we discuss four alternatives for achieving NUMA-oriented
+performance, and the strengths and weaknesses of each.  First we define
+five things that matter for NUMA performance and applicability in
+Chapel, then go on to cover the alternatives themselves.
+
+
+What Matters for NUMA
+`````````````````````
+
+* affinity between execution and storage
+
+  The whole point of Chapel's ``locModel=numa`` effort is to produce
+  good affinity between execution and storage.  Tasks which process
+  array elements should run on the NUMA domains where those array
+  elements are stored.  The performance benefit of getting NUMA affinity
+  exactly right is not large, perhaps 2x at best, so minimizing
+  mismatches in execution/storage affinity is important.  Affinity
+  doesn't have to be perfect: if 1 reference out of 1,000,000 goes to
+  the "wrong" NUMA domain overall performance will not suffer.  But if 1
+  reference out of 10 does so it certainly will.
+
+  At least at large scale, when NUMA localization chunks occupy a large
+  number of pages, incorrect affinity at the edges of the chunks can be
+  made up for by good affinity in the middles of the chunks.  In other
+  words, as long as the NUMA localization chunks of an array are large
+  with respect to the page size incorrect affinity at the edges of those
+  chunks should only have secondary effects on performance.
+
+  The current serial ``DefaultRectangular`` domain and array iterators
+  do not localize execution and may not do so for some time if ever,
+  given the existing limitations on iterator inlining in the compiler
+  plus the fact that changing execution placement is expensive.  So for
+  NUMA performance, parallel iteration is key.
+
+* array element access speed
+
+  The ideal emitted code for an array reference is a memory reference
+  through a (possibly scaled) offset from a base pointer.  Anything more
+  complex than this will perform worse than C or single-ddata Chapel
+  unless it can somehow achieve better affinity to offset that.
+
+* balanced parallelism
+
+  Good load balancing maximizes overall performance in any parallel
+  language construct.  If the parallel construct cannot finish until the
+  task with the most work completes and the work is unbalanced, overall
+  progress is slowed.  The DSIUtil-based domain chunking currently in
+  the ``DefaultRectangular`` domain parallel iterators balances work
+  ideally: the largest and smallest chunks differ by no more than 1 in
+  size.  It seems unlikely that techniques which create significantly
+  unbalanced chunks can achieve NUMA-oriented speedups elsewhere that
+  would offset that imbalance and produce an overall win.
+
+* leveraging existing locality
+
+  Having execution and/or storage locality right in the first place is
+  valuable.  Starting a task takes about the same amount of time no
+  matter where it is placed, but it may take just as long to change
+  where an already existing one is running.  Touching a memory page into
+  existence, which requires storing zeroes into it, costs the same on
+  any NUMA domain but moving a page from one NUMA domain to another
+  takes even longer because the contents are copied even if they are
+  dead (the kernel cannot know).
+
+  As a corollary to the above, where tasks or memory already have NUMA
+  locality and that can be taken advantage of without additional effort
+  it is profitable to do so.  When there is a predefined heap for a
+  Chapel comm layer, for example, if we can arrange NUMA localization in
+  that heap and then use NUMA-aware allocation on it we need not do any
+  additional localization at all.
+
+* network cooperation
+
+  Some network interface chips (NICs), including Cray's Aries, require
+  that memory be "registered" with them in order to be referenced in
+  network operations.  At least for Aries and probably for some others,
+  this involves pinning virtual addresses to physical addresses to fix
+  their relationship.  Doing so necessarily also sets the pages' NUMA
+  locality, since NUMA locality is a physical characteristic.  If the
+  localization of a registered page is to be changed, then the page must
+  be un-registered first and re-registered afterward.  By itself this
+  may not be very costly, but broadcasting the new registration to the
+  other nodes which need it, and synchronizing that broadcast, may be.
+
+  The Cray network can have some secondary effects on NUMA performance.
+  On Cray X\* systems the NIC is slightly closer to NUMA domain 0 than
+  to NUMA domain 1.  That is, it takes slightly less time for the NIC to
+  access memory on NUMA domain 0.  So to maximize remote reference
+  performance for a given array we should allocate as much of it as
+  possible on NUMA domain 0 and only use NUMA domain 1 as a fallback.
+  However, remote references take longer than local ones, so doing this
+  only reduces the total remote latency by a small amount.  That being
+  the case, if there is significant local reference traffic to an array
+  that is also sometimes referenced remotely it is better to balance its
+  storage across the NUMA domains in order to receive the up to 2x local
+  performance benefit of doing so.
+
+
+NUMA Array Storage Alternatives
+```````````````````````````````
+
+
+Single-ddata
+''''''''''''
+
+**Synopsis**: one ddata, allocate then localize
+
+**Performance snapshot**
+
+    ==========================  ====
+    execution/storage affinity  fair
+    access speed                best
+    balance                     fair
+    leverage locality           poor
+    network cooperation         poor
+    ==========================  ====
+
+
+Description
+...........
+
+This is the simplest model: allocate one ddata for an array and then
+NUMA-localize that memory.  It is what Chapel with ``locModel=numa``
+used to do, and still does for arrays of fewer than 2\*\*20 elements,
+and effectively what C with first-touch does.
+
+
+Analysis
+........
+
+The access code for this model is minimal.
+
+Single-ddata cannot achieve perfect affinity in the general case in
+Chapel because the domain iterator's DSIUtil chunking for the parallel
+tasks and the system's page-based storage locality cannot always match.
+Fortunately, it can get affinity exactly right for the quite common case
+in which there are only 2 NUMA domains.  But when there are more than 2
+NUMA domains, the system's page-based storage localization may not be
+able to match the DSIUtil chunking exactly.
+
+With 2 NUMA domains we can always get the execution and storage locality
+to match up just by "sliding" the base of the array storage to make the
+DSIUtil subdomains and the system's page-based storage partitioning line
+up.  This works in all cases because there are only two subdomains and
+two chunks and thus only one boundary of each kind.
+
+However, when there are more than two chunks we may not be able to
+achieve perfect affinity.  Consider this array:
+
+.. code-block:: chapel
+
+   var A: [0..#5*(2**10)] int(32);
+
+This occupies 5 4-KiB pages.  On a system with 4 NUMA domains, no NUMA
+localization of the array's 5 pages can match up with a balanced
+partitioning of the array's domain among 4 tasks.  We will have poor
+affinity no matter what we do, and thus poor performance.
+
+DSIUtil chunking need not partition on the leftmost dimension of a
+multi-dimension domain.  It actually selects the leftmost dimension
+whose size is at least as large as the number of NUMA domains.  Consider
+this array:
+
+.. code-block:: chapel
+
+   var B: [0..1, 0..#2**20] int(32);
+
+DSIUtil chunking across 4 NUMA domains will partition this on the 2nd
+dimension, like this:
+
+    ====  =============================
+    Task  Assigned Subdomain
+    ====  =============================
+    0     ``(0..1, 0*(2**18)..#2**18)``
+    1     ``(0..1, 1*(2**18)..#2**18)``
+    2     ``(0..1, 2*(2**18)..#2**18)``
+    3     ``(0..1, 3*(2**18)..#2**18)``
+    ====  =============================
+
+Because the chunking is on the 2nd dimension instead of the 1st, the
+corresponding NUMA localization pattern across all the array element
+indices would the following cyclic one:
+
+    =============================  ===========
+    Array Element Indices          NUMA domain
+    =============================  ===========
+    ``(0..0, 0*(2**18)..#2**18)``  0
+    ``(0..0, 1*(2**18)..#2**18)``  1
+    ``(0..0, 2*(2**18)..#2**18)``  2
+    ``(0..0, 3*(2**18)..#2**18)``  3
+    ``(1..1, 0*(2**18)..#2**18)``  0
+    ``(1..1, 1*(2**18)..#2**18)``  1
+    ``(1..1, 2*(2**18)..#2**18)``  2
+    ``(1..1, 3*(2**18)..#2**18)``  3
+    =============================  ===========
+
+A cyclic pattern is certainly achievable in the sense that the system
+can do it (or approximate it), but it is subject to the same mismatch
+issues as in the previous example: to the extent the subdomain chunking
+is different than the page-based storage localization chunking, there
+will be affinity mismatches.  In the case here that would occur if the
+page size did not evenly divide the size in bytes of ``2**18`` array
+elements.
+
+An alternative technique would instead partition across both dimensions
+at once and also localize the array storage in the same way, like this:
+
+    ====  =============================  ===========
+    Task  Array Element Indices          NUMA domain
+    ====  =============================  ===========
+    0     ``(0..0, 0*(2**19)..#2**19)``  0
+    1     ``(0..0, 1*(2**19)..#2**19)``  1
+    2     ``(1..1, 2*(2**19)..#2**19)``  2
+    3     ``(1..1, 3*(2**19)..#2**19)``  3
+    ====  =============================  ===========
+
+This is a possibility we could explore in the future if it turns out
+there are situations where it works better than the current chunking.
+But for now we are not pursuing it further.
+
+The allocate-then-localize model used for single-ddata does not
+cooperate well with network interfaces that require registered memory.
+Chapel registers the heap and other data with the NIC for ``comm=ugni``
+on Cray X\* systems and also for ``comm=gasnet, conduit=aries``.
+Registration pins virtual pages to physical pages in order to fix their
+relationship.  But changing NUMA locality necessarily means changing
+physical addresses (because NUMA is a physical characteristic), which
+requires changing the registration, which in turn means synchronizing
+with all the remote nodes which know about the registration.  In
+particular, the need for synchronization could increase the cost of
+allocation.
+
+All of the single-ddata alternatives have a lower limit on the size of
+array they can be applied to without too much waste.  Since the minimum
+unit of NUMA localization is a page, if it is to be localized an array
+needs to occupy at least as many memory pages as there are NUMA domains
+to avoid wasting space.  This can be large if NIC memory registration
+requires the use of hugepages, as it does on Cray X\* systems.
+
+
+Single-ddata with Separate Arrays
+'''''''''''''''''''''''''''''''''
+
+**Synopsis**: as above, but allocate and localize big arrays separately
+
+**Performance snapshot**
+
+    ==========================  ====
+    execution/storage affinity  fair
+    access speed                best
+    balance                     fair
+    leverage locality           fair
+    network cooperation         fair
+    ==========================  ====
+
+
+Description
+...........
+
+The most serious failing of the ordinary single-ddata model is its poor
+cooperation with NIC-registered memory, whether or not that memory has
+NUMA locality.  This can be improved by adopting an idea described
+during the discussions leading up to this document.  That is to allocate
+NUMA-localized arrays individually from memory outside any existing NIC
+registration, and do the localization, registration, and registration
+broadcast to remote nodes after allocating.  This would avoid the
+re-registration problem created if we allocated from NIC-registered
+memory and then wanted to change its locality.
+
+
+Analysis
+........
+
+We would not necessarily need to invalidate such array registrations
+when the arrays were freed, because references to freed arrays are
+nonconforming in Chapel.  We would nevertheless need to invalidate such
+a registration if, after one array had been allocated and freed, a later
+allocation happened to overlap the same storage.  We would have to
+ensure that any other node referencing the new array had received the
+new registration before doing so.  This is no problem technically: the
+allocating node can broadcast the new registration info and wait for
+acknowledgment from all remotes before continuing.  But it does mean a
+one-to-all round-trip communication at allocation and registration time,
+or even effectively all-to-all communication if all nodes are behaving
+in synchrony.  The impact on overall application performance would
+depend on how often such updates were needed.
+
+A brief search for applications or mini-apps which allocate and free
+many NUMA-sensitive arrays turned up one that looks like this:
+
+.. code-block:: chapel
+
+    for layer in 1..numLayers {
+       var curLayer: [0..#nextLayer.size] node;
+       curLayer = nextLayer;
+       resize(nextLayer, n);
+
+       // I *think* this could be converted to a forall with some effort
+       for v in curLayer {
+           var idx: int = complicatedExpensiveComputation(v);
+           nextLayer[idx] = someValue;
+       }
+    }
+
+Note that if either the for-stmt cannot be converted to a forall-stmt or
+``complicatedExpensiveComputation()`` really is expensive then the
+``nextLayer`` references in the kernel may not really be NUMA-sensitive.
+But for now this is is all we have seen that might be sensitive to the
+cost of array-by-array registration as described here.
+
+
+Single-ddata with Cyclic Localization
+'''''''''''''''''''''''''''''''''''''
+
+**Synopsis**: one ddata, block-cyclic memory localization
+
+**Performance snapshot**
+
+    ==========================  ==========
+    execution/storage affinity  fair?
+    access speed                best/good?
+    balance                     fair?
+    leverage locality           fair?
+    network cooperation         fair?
+    ==========================  ==========
+
+
+Description
+...........
+
+Like single-ddata with separate arrays, this is aimed at solving the
+re-registration problem for NIC-registered memory while retaining the
+benefits of single-ddata for local references.  As currently envisioned,
+it involves registering a large heap with the NIC, as is currently done
+with ``comm=ugni`` and ``comm=gasnet, conduit=aries``.  Balanced blocks
+of that heap would be localized to the NUMA domains, as is expected for
+multi-ddata with a NIC-registered heap.  With 2 NUMA domains, the
+localized halves of the NIC-registered heap might be called *nic0* and
+*nic1*.  Then, the physical hugepages of *nic0* and *nic1* would be
+re-mapped into another region called, say, *cyclicnuma*, such that
+*cyclicnuma* was contiguous in virtual addresses but composed of pages
+or blocks of pages with alternating NUMA locality (thus "cyclic NUMA").
+Arrays would be allocated out of *cyclicnuma* and the program code would
+use those addresses to access them.  But at a low level, probably in the
+comm layer(s), references to *cyclicnuma* region addresses in NIC
+transactions would be page-translated to the corresponding *nic0*/*nic1*
+addresses on the owning nodes, so that the NICs would see virtual
+addresses in the ranges that had been registered with them.
+
+This idea was only recently proposed and is still in flux.
+
+
+Analysis
+........
+
+The goal here is to allow allocating single array ddatas with desired
+locality while also avoiding the need for re-registration.  But there
+are a number of outstanding issues that prevent good analysis.  For
+example, each different desired NUMA localization chunk size would seem
+to need its own *cyclicnuma* region.  How would allocation figure out
+what memory was allocated or free when doing new allocations?  Would the
+double-mapping (or more) create any memory coherency issues?
+
+Local access with this technique should be as simple and thus as fast as
+with single-ddata.  Remote access, or actually any access by the NIC
+itself such as the local store of the result of a remote GET, would
+require the additional page translation operation in the comm layer and
+thus be slightly slower.
+
+It would appear that this design has at least some of the same issues
+with mismatches between DSIUtil subdomain partitioning and page-based
+array storage chunking as is the case for regular single-ddata.
+
+For now this awaits more design work.
+
+
+Multi-ddata
+'''''''''''
+
+**Synopsis**: multiple ddatas, individually localized
+
+**Performance snapshot**
+
+    ==========================  ========
+    execution/storage affinity  best
+    access speed                bad/fair
+    balance                     best
+    leverage locality           good
+    network cooperation         good
+    ==========================  ========
+
+
+Description
+...........
+
+Multi-ddata differs from the other techniques in that it allocates
+multiple ddatas, one localized to each NUMA domain, and stores array
+elements on those ddata chunks in the same DSIUtil-based way that the
+``DefaultRectangular`` domain's iterators create partitioning
+subdomains.
+
+
+Analysis
+........
+
+On the positive side, multi-ddata can always get data localization and
+execution/storage affinity right at a reasonable cost, and load-balance
+well.  Assuming we can get NUMA awareness in NIC-registered heaps and
+NUMA-aware allocation, both of which build in a straightforward way on
+NUMA page-placement syscalls which are also needed for localizing
+single-ddata arrays, localization and affinity follow quite simply.
+
+If it needs to get more than one ddata chunk, multi-ddata takes longer
+to allocate space for an array than single-ddata does.  But on the other
+hand it can take advantage of memory that is already localized and also
+memory that is already NIC-registered, when those are available.
+
+What multi-ddata lacks most is access performance.  Array element
+accesses are slow due to extra computations and extra loads of the
+metadata fields used in those computations.  For one thing, computing a
+chunk index from an array index requires doing a divide, effectively.
+This could be sped up significantly by doing an integer multiply by the
+reciprocal instead, or even a right-shift for power-of-two divisors.
+The ddatas and other per-chunk information are themselves currently
+stored as a ddata of records, which could be a tuple of records at a
+fair saving at array creation time.  And the are some other small
+optimizations that could be made in the access code.  Nevertheless while
+the multi-ddata access code could be faster than it is now, it will not
+ever be as simple or fast as plain base-plus-offset addressing.  AT
+least with all the addressing exposed, getting within something like 3x
+of single-ddata is probably the best we can hope for.
+
+This does not mean that multi-ddata necessarily has bad performance
+overall.  Single-ddata only performs much better in when the multi-ddata
+access cost is exposed.  The worst situation from a usability standpoint
+is probably parallel iteration over an array's domain, not zippered with
+iteration over the array itself.  Here the full cost of the array access
+is in the kernel loop and the performance is quite bad.  But where the
+multi-ddata access computation is not exposed, for example in parallel
+iteration over the array, multi-ddata performs well.
+
+The multi-ddata technique does not necessarily have the array size lower
+limit issue that applies to all the single-ddata alternatives.  At least
+if the allocation comes from an already-localized memory pool, as could
+be the case with a NUMA-aware allocator, there is no effective lower
+limit on the array size.
+
+
+Other Techniques
+''''''''''''''''
+
+Here we briefly discuss a couple of other techniques for handling NUMA
+architectures in Chapel.  These came up in conversations but for various
+reasons weren't considered at length.
+
+
+Locale per NUMA Domain
+......................
+
+Instead of running one Chapel program instance per system node, on NUMA
+architectures we could run one program instance per NUMA domain.  This
+would let us continue with the simplicity of using single-ddata with
+first-touch localization for ``DefaultRectangularArr`` arrays.  The
+downside is that we would need to go to a multi-locale domain mapping
+such as ``Block`` for arrays too large to fit on a NUMA domain, whereas
+today we do not need to do so until they are too large to fit on a
+compute node.  Thus more array elements would be remote.  The impact
+this would have on performance could be reduced by using any of several
+techniques for bypassing the network for inter-process memory references
+within a compute node.
+
+This alternative seems like it would reduce overall performance because
+it would give:
+
+* the same performance for arrays small enough to fit in a NUMA domain
+
+* decidedly less performance for arrays too large for a single NUMA
+  domain but small enough for a single locale, because of the need to
+  use the ``Block`` domain where we currently do not (assuming any of
+  the array localization techniques described above work out)
+
+* slightly less performance for arrays too large to fit in a single
+  locale, because of the involvement of the ``Block`` domain map for
+  references to other NUMA domains on the same locale
+
+
+Distribution over Sublocales
+............................
+
+The ``Block`` distribution currently places data across the predefined
+``Locales`` array, thus across the top-level network-connected compute
+nodes.  But it could be modified to place data across an array of the
+NUMA sublocales instead.  Each DefaultRectangularArr sub-array of the
+distribution would reside within a single NUMA domain, so we could use
+single-ddata with first-touch localization.  In the domain map code,
+references to sub-arrays on network-remote locales could be done as we
+currently do (using network transactions) and references to sub-arrays
+in other NUMA sublocales of the network-local locale could be done using
+regular memory references.
+
+One objection to this was that although theoretically it should be
+straightforward to modify ``Block`` to distribute over any array of
+locales rather than over the predefined ``Locales`` array, in practice
+there are likely implicit interactions with, and/or subtle dependencies
+on, the current Chapel execution model that runs a program instance per
+compute node.  If so, implementing this idea might be harder than
+expected.
+
+As with "Locale per NUMA Domain" above, this seems likely to produce
+lower performance with arrays too large for a single NUMA domain but
+small enough for a single locale, because of the added involvement of
+the ``Block`` domain map where it is not currently used.
+
+
+Some Interesting Cases
+``````````````````````
+
+*This whole section is work in progress.*
+
+----
+
+.. code-block:: chapel
+
+   var A: [0..#2**30] int(8);
+
+The easiest case: large scale and we can achieve perfect affinity with
+any technique, with any expected number of NUMA domains.
+
+----
+
+.. code-block:: chapel
+
+   var A: [0..#2**30-2**20] int(8);
+
+Still good scale, but the DSIUtil subdomain chunking cannot match the
+page-based NUMA storage localization no matter how many NUMA domains we
+have.
+
+----
+
+.. code-block:: chapel
+
+   var A: [0..#2**11] int(8);
+
+The array is small compared to even the 4-KiB pages used for for memory
+localization in single-locale.
+
+----
+
+.. code-block:: chapel
+
+   var A: [0..1, 0..#2**30] int(8);
+
+Good scale and we can achieve perfect affinity, but creates a challenge
+for single-ddata because to match how the DSIUtil subdomain chunking
+will partition on the 2nd dimension we will need to localize the storage
+using a cyclic pattern.
+
+----
+
+.. code-block:: chapel
+
+   var A: [0..1, 0..#2**30-2**20] int(8);
+
+Like the above, but we can no longer achieve perfect affinity for
+single-ddata because a cyclic storage localization pattern cannot match
+how the DSIUtil subdomain chunking will partition on the 2nd dimension.
+
+----
+
+.. code-block:: chapel
+
+   var A: [0..#2**30] int(8);
+
+   forall a in A do f(a);
+
+Perfect affinity and array-based iteration: this will perform well with
+any solution.
+
+----
+
+.. code-block:: chapel
+
+   var A: [0..#2**30] int(8);
+
+   forall i in A.domain do f(A(i));
+
+Perfect affinity but domain-based iteration: this will perform well with
+single-ddata, but quite badly with the current multi-ddata and fairly
+badly with any envisioned multi-ddata.
+
+----
+
+*Add examples here.*
+
+
+Summary
+```````
+
+Here is a combined chart of the performance snapshots for single-ddata,
+single-ddata with separate arrays, and multi-ddata.  The cyclic NUMA
+idea isn't included here because estimating a performance snapshot for
+it is not yet possible.
+
+    ===================  ========  ================  ===========
+    characteristic       1-ddata   1-ddata + arrays  multi-ddata
+    ===================  ========  ================  ===========
+    affinity             fair      fair              best
+    access speed         best      best              bad/fair
+    balance              fair      fair              best
+    use locality         poor      fair              good
+    network cooperation  poor      fair              good
+    ===================  ========  ================  ===========
+
+Looking at things the other way, here are the areas in which each
+alternative seems most and least promising.
+
+    **Single-ddata**
+
+        *good:*
+
+        * low-cost array access in all cases
+
+        *bad:*
+
+        * cannot achieve perfect affinity in all cases (though does so
+          in common ones)
+
+        * cannot leverage NUMA-aware allocation because allocates, then
+          localizes sub-chunks
+
+        * localizing NIC-registered memory means re-registering it
+
+        *can do well on:*
+            large arrays (many pages), any loop iteration style, without
+            NIC registration
+
+        *will do poorly on:*
+            small arrays (few pages) or with other than a blocked
+            affinity pattern, or with NIC registration
+
+    **Single-ddata with Separate Arrays**
+
+        *good:*
+
+        * low-cost array access in all cases
+
+        * avoids plain single-ddata's problem with NIC re-registration
+
+        *bad:*
+
+        * cannot achieve perfect affinity in all cases (though does so
+          in common ones)
+
+        * cannot leverage NUMA-aware allocation because allocates, then
+          localizes sub-chunks
+
+        * dynamic NIC registration has direct and indirect costs, not
+          well understood yet
+
+        *can do well on:*
+            large arrays (many pages), any loop iteration style
+
+        *will do poorly on:*
+            small arrays (few pages) or with other than a blocked
+            affinity pattern
+
+    **Multi-ddata**
+
+        *good:*
+
+        * low-cost array access for parallel iteration (possibly
+          zippered) over an array itself
+
+        * leverages NUMA-aware allocation
+
+        * can cooperate with NIC registrations
+
+        * can achieve perfect affinity in all cases, even for small
+          arrays
+
+        *bad:*
+
+        * high-cost array access for many common iteration styles
+
+        *can do well on:*
+            iteration over arrays gotten from a NUMA-aware allocator,
+            with or without NIC interactions
+
+        *will do poorly on:*
+            many common iteration styles, irrespective of everything
+            else (scale, NIC involvement, etc.)
+
+In a nutshell, the single-ddata techniques have performance challenges
+mostly having to do with achieving good affinity and in situations where
+memory is already localized, and multi-data has performance challenges
+when iterating other than directly over them.  Neither seems like a full
+solution in the sense of providing adequate performance in all common
+circumstances, or even all desired ones.
+
+It seems premature at this point to pick a single winning solution and
+go forward only with that.  None of the existing implementations have
+actually been connected up to a NUMA-aware allocator so we can measure
+their performance.  And, there are known improvements we could make to
+multi-ddata to reduce its ``dsiAccess`` cost.  All of this should be
+done before hard performance comparisons are made.  Fortunately, tuning
+the implementations and doing NUMA-aware allocation, at least to the
+extent needed here, is not a very large amount of work.
+
+We therefore recommend short-term (1.15) and longer-term (1.16)
+solutions.  In the short term, we should support both "plain"
+single-ddata and multi-ddata for ``locModel=numa``, and implement NUMA
+localization as described above for both.  (Except: we should not
+implement the cyclic NUMA localization pattern needed for single-ddata
+when the DSIUtil subdomain partitioning is not on the leftmost
+dimension.)  We should default to single-ddata for ``locModel=flat`` and
+multi-ddata for ``locModel=numa``.  To allow changing the default easily
+for ``locModel=numa`` we should add a config param that forces the use
+of single-ddata even in that case.  (There is no need to be able to
+force the opposite configuration of multi-ddata with ``locModel=flat``.)
+We should make the known improvements to reduce addressing overheads in
+multi-ddata.
+
+Most of this work will consist of creating support for NUMA-localizing
+memory and applying that support to single-ddata memory.  Tuning the
+multi-ddata access code is a small effort in comparison.  And since
+multi-ddata already makes separate allocation calls for each chunk,
+getting NUMA localization correct in that case just requires changing
+the allocation calls to use a NUMA-aware allocation interface.  It is
+expected that this NUMA-aware allocation interface will be relatively
+production-ready (subject to time constraints), but the array-oriented
+localization may be less so.
+
+As stated, all of this will be completed in the 1.15 release.
+
+*[Author's note: I selected this short-term work as I did partly because
+I think it's the right way to proceed, but also because I know I can get
+it done for 1.15.]*
+
+The longer term work can start as early as now but certainly not later
+than right after the 1.15 release.  In that effort we should add support
+for single ddata with separate arrays and perhaps cyclic NUMA also, as
+the latter's design is refined and it seems worthwhile.  We can
+experiment with the various techniques, refine implementations, and
+decide what we want to keep going forward.  If we end up wanting to
+retain multi-ddata as well as single-ddata we can implement them as real
+domain maps and improve and perhaps further parameterize how we select
+between them, especially with respect to when each is the default.  If
+we decide to drop multi-ddata later as opposed to now we will have only
+wasted the tuning done for 1.15.  This work should be completed in 1.16.
+
+*[Author's note: If anybody has spare cycles to get this additional work
+done in 1.15 that would be great, too, but I don't think it's
+necessary.]*

--- a/doc/developer/chips/README.md
+++ b/doc/developer/chips/README.md
@@ -19,4 +19,4 @@ See the first CHIP for an overview.
 * [15 Chapel Incremental Compilation](15.rst)
 * [16 Optimizing Record and Array Copies in Chapel](16.rst)
 * [17 GPU Programming Features](17.rst)
-
+* [18 NUMA-Aware Array Storage](18.rst)


### PR DESCRIPTION
This is a draft CHIP On NUMA-aware array storage, access, and iteration.
It represents the work of a briefly-existing mini-team formed to do a
sanity check on our path forward for arrays with locModel=numa.