### PR TITLE
Rearrange later portion of resolveNormalCall

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -138,6 +138,8 @@ public:
 
 bool checkResolveFormalsWhereClauses(ResolutionCandidate* currCandidate);
 bool checkGenericFormals(ResolutionCandidate* currCandidate);
+void explainGatherCandidate(Vec<ResolutionCandidate*>& candidates,
+                            CallInfo& info, CallExpr* call);
 
 typedef enum {
   FIND_EITHER = 0,

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -140,6 +140,8 @@ bool checkResolveFormalsWhereClauses(ResolutionCandidate* currCandidate);
 bool checkGenericFormals(ResolutionCandidate* currCandidate);
 void explainGatherCandidate(Vec<ResolutionCandidate*>& candidates,
                             CallInfo& info, CallExpr* call);
+void wrapAndCleanUpActuals(ResolutionCandidate* best, CallInfo& info,
+                           bool buildFastFollowerChecks);
 
 typedef enum {
   FIND_EITHER = 0,

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4339,22 +4339,8 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
   Vec<ResolutionCandidate*> candidates;
   gatherCandidates(candidates, visibleFns, info);
 
-  if ((explainCallLine && explainCallMatch(info.call)) ||
-      call->id == explainCallID)
-  {
-    if (candidates.n == 0) {
-      USR_PRINT(info.call, "no candidates found");
+  explainGatherCandidate(candidates, info, call);
 
-    } else {
-      bool first = true;
-      forv_Vec(ResolutionCandidate*, candidate, candidates) {
-        USR_PRINT(candidate->fn, "%s %s",
-                  first ? "candidates are:" : "               ",
-                  toString(candidate->fn));
-        first = false;
-      }
-    }
-  }
 
   Expr* scope = (info.scope) ? info.scope : getVisibilityBlock(call);
   bool explain = fExplainVerbose &&
@@ -4539,6 +4525,26 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
   }
 
   return resolvedFn;
+}
+
+void explainGatherCandidate(Vec<ResolutionCandidate*>& candidates,
+                            CallInfo& info, CallExpr* call) {
+  if ((explainCallLine && explainCallMatch(info.call)) ||
+      call->id == explainCallID)
+  {
+    if (candidates.n == 0) {
+      USR_PRINT(info.call, "no candidates found");
+
+    } else {
+      bool first = true;
+      forv_Vec(ResolutionCandidate*, candidate, candidates) {
+        USR_PRINT(candidate->fn, "%s %s",
+                  first ? "candidates are:" : "               ",
+                  toString(candidate->fn));
+        first = false;
+      }
+    }
+  }
 }
 
 void resolveNormalCallCompilerWarningStuff(FnSymbol* resolvedFn) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4521,8 +4521,7 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
 void explainGatherCandidate(Vec<ResolutionCandidate*>& candidates,
                             CallInfo& info, CallExpr* call) {
   if ((explainCallLine && explainCallMatch(info.call)) ||
-      call->id == explainCallID)
-  {
+      call->id == explainCallID) {
     if (candidates.n == 0) {
       USR_PRINT(info.call, "no candidates found");
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4427,22 +4427,13 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
       }
     }
   } else {
-    INT_ASSERT(best->fn);
-    best->fn = defaultWrap(best->fn, &best->actualIdxToFormal, &info);
-    reorderActuals(best->fn, &best->actualIdxToFormal, &info);
-    coerceActuals(best->fn, &info);
-    best->fn = promotionWrap(best->fn, &info, /*buildFastFollowerChecks=*/true);
+    wrapAndCleanUpActuals(best, info, true);
     if (valueCall) {
       // If we're resolving a ref and non-ref pair,
       // also handle the value version. best is the ref version.
       CallInfo valueInfo(valueCall, checkonly);
 
-      INT_ASSERT(bestValue->fn);
-      bestValue->fn = defaultWrap(bestValue->fn, &bestValue->actualIdxToFormal,
-                                  &valueInfo);
-      reorderActuals(bestValue->fn, &bestValue->actualIdxToFormal, &valueInfo);
-      coerceActuals(bestValue->fn, &valueInfo);
-      bestValue->fn = promotionWrap(bestValue->fn, &valueInfo, /*buildFastFollowerChecks=*/false);
+      wrapAndCleanUpActuals(bestValue, valueInfo, false);
     }
   }
 
@@ -4545,6 +4536,15 @@ void explainGatherCandidate(Vec<ResolutionCandidate*>& candidates,
       }
     }
   }
+}
+
+void wrapAndCleanUpActuals(ResolutionCandidate* best, CallInfo& info,
+                           bool buildFastFollowerChecks) {
+  INT_ASSERT(best->fn);
+  best->fn = defaultWrap(best->fn, &best->actualIdxToFormal, &info);
+  reorderActuals(best->fn, &best->actualIdxToFormal, &info);
+  coerceActuals(best->fn, &info);
+  best->fn = promotionWrap(best->fn, &info, buildFastFollowerChecks);
 }
 
 void resolveNormalCallCompilerWarningStuff(FnSymbol* resolvedFn) {


### PR DESCRIPTION
Some of my work in the generic initializer version of this function can
be shared between the two versions, for code maintainability purposes.
I created two new helper functions with this intention - this portion of
the code was trickier to rearrange than my last few merges, so I
realized that much of what I had copied is actually not necessary, beyond
the updates to make these functions.

Passed full std/ testing