### PR TITLE
A second round of updates to the normalization of DefExpr for VarSymbol

### DIFF
--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -114,14 +114,16 @@ class UseStmt : public Stmt {
 ************************************* | ************************************/
 
 enum BlockTag {
-// Bits:
+  // Bits:
   BLOCK_NORMAL      = 0,
   BLOCK_SCOPELESS   = 1<<0, ///< does not introduce a new scope
   BLOCK_TYPE_ONLY   = 1<<1, ///< deleted after type resolution
   BLOCK_EXTERN      = 1<<2, ///< init block for an extern var
   BLOCK_C_FOR_LOOP  = 1<<3, ///< init/test/incr block for a CForLoop
-// Bit masks:
+
+  // Bit masks:
   BLOCK_TYPE        = BLOCK_SCOPELESS | BLOCK_TYPE_ONLY,
+  BLOCK_EXTERN_TYPE = BLOCK_EXTERN    | BLOCK_TYPE
 };
 
 class BlockStmt : public Stmt {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1339,71 +1339,53 @@ static void init_typed_var(VarSymbol* var,
     return;
   }
 
-  //
-  // initialize variable based on specified type and then assign it
-  // the initialization expression if it exists
-  //
-  bool isNoinit     = init && init->isNoInitExpr();
-  bool moduleNoinit = false;
+  if (init->isNoInitExpr() == true) {
+    bool moduleNoinit = false;
 
-  if (isNoinit && !fUseNoinit) {
-    // In the case where --no-use-noinit is thrown, we want to still use
-    // noinit in the module code (as the correct operation of complexes
-    // depends on it).
+    if (fUseNoinit == false) {
+      // In the case where --no-use-noinit is thrown, we want to still use
+      // noinit in the module code (as the correct operation of complexes
+      // depends on it).
 
-    // Lydia note: The requirement for complexes is expected to go away when
-    // we transition to constructors for all types instead of the _defaultOf
-    // function
-    Symbol* moduleSource = var;
+      // Lydia note: The requirement for complexes is expected to go away when
+      // we transition to constructors for all types instead of the _defaultOf
+      // function
+      Symbol* moduleSource = var;
 
-    while (!isModuleSymbol(moduleSource)  &&
-           moduleSource           != NULL &&
-           moduleSource->defPoint != NULL) {
-      // This will go up the definition tree until it reaches a module symbol
-      // Or until it encounters a null field.
-      moduleSource = moduleSource->defPoint->parentSymbol;
+      while (!isModuleSymbol(moduleSource)  &&
+             moduleSource           != NULL &&
+             moduleSource->defPoint != NULL) {
+        // This will go up the definition tree until it reaches a module symbol
+        // Or until it encounters a null field.
+        moduleSource = moduleSource->defPoint->parentSymbol;
+      }
+
+      ModuleSymbol* mod = toModuleSymbol(moduleSource);
+
+      if (mod != NULL && moduleSource->defPoint != NULL) {
+        // As these are the only other cases that would have caused the prior
+        // while loop to exit, the moduleSource must be a module
+        moduleNoinit = mod->modTag == MOD_INTERNAL ||
+          mod->modTag == MOD_STANDARD;
+
+        // Check if the parent module of this variable is a standard or
+        // internal module, and store the result of this check in moduleNoinit
+      }
     }
 
-    ModuleSymbol* mod = toModuleSymbol(moduleSource);
+    init->remove();
 
-    if (mod != NULL && moduleSource->defPoint != NULL) {
-      // As these are the only other cases that would have caused the prior
-      // while loop to exit, the moduleSource must be a module
-      moduleNoinit = mod->modTag == MOD_INTERNAL ||
-                     mod->modTag == MOD_STANDARD;
+    if (fUseNoinit == true || moduleNoinit == true) {
+      CallExpr* noinitCall = new CallExpr(PRIM_NO_INIT, type->remove());
 
-      // Check if the parent module of this variable is a standard or
-      // internal module, and store the result of this check in moduleNoinit
+      stmt->insertAfter(new CallExpr(PRIM_MOVE, var, noinitCall));
+
+    } else {
+      // Ignore no-init expression and fall back on default init
+      init_typed_var(var, type, stmt, constTemp);
     }
-  }
-
-  // Lydia note:  I'm adding fUseNoinit here because utilizing noinit with
-  // return temps is necessary, so the only instances that should be
-  // controlled by the flag are generated here
-  if (isNoinit && (fUseNoinit || moduleNoinit)) {
-    // Only perform this action if noinit has been specified and the flag
-    // --no-use-noinit has not been thrown (or if the noinit is found in
-    // module code)
-    var->defPoint->init->remove();
-
-    CallExpr* initCall = new CallExpr(PRIM_MOVE,
-                                      var,
-                                      new CallExpr(PRIM_NO_INIT,
-                                                   type->remove()));
-
-    // Since the variable won't have been defined just yet (stmt is
-    // its def expression after all), insert the move after the defPoint
-    stmt->insertAfter(initCall);
 
   } else {
-    if (!fUseNoinit && isNoinit) {
-      // The instance would be initialized to noinit, but we aren't allowing
-      // noinit, so remove the initialization expression, allowing  it to
-      // default initialize.
-      init->remove();
-      init = NULL;
-    }
-
     //
     // MDN 2016/02/02
     // The code for resolving the type of an extern variable

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1329,7 +1329,7 @@ static void init_typed_var(VarSymbol* var,
   //
   // use cast for parameters to avoid multiple parameter assignments
   //
-  if (init && var->hasFlag(FLAG_PARAM)) {
+  if (var->hasFlag(FLAG_PARAM)) {
     stmt->insertAfter(new CallExpr(PRIM_MOVE,
                                    var,
                                    new CallExpr("_cast",
@@ -1389,25 +1389,12 @@ static void init_typed_var(VarSymbol* var,
 
     typeDefn->insertAfter(initCall);
 
-    if (init) {
-      CallExpr* assign = new CallExpr("=",       typeTemp,  init->remove());
-      CallExpr* move   = new CallExpr(PRIM_MOVE, constTemp, typeTemp);
+    CallExpr* assign = new CallExpr("=",       typeTemp,  init->remove());
+    CallExpr* move   = new CallExpr(PRIM_MOVE, constTemp, typeTemp);
 
-      // This should be copy-initialization, not assignment.
-      initCall->insertAfter(assign);
-      assign->insertAfter(move);
-
-    } else if (constTemp->isType()) {
-      initCall->insertAfter(new CallExpr(PRIM_MOVE,
-                                         constTemp,
-                                         new CallExpr(PRIM_TYPEOF, typeTemp)));
-
-    } else {
-      initCall->insertAfter(new CallExpr(PRIM_MOVE, constTemp, typeTemp));
-
-      if (constTemp->hasFlag(FLAG_EXTERN))
-        (unsigned&) block->blockTag |= BLOCK_EXTERN | BLOCK_TYPE;
-    }
+    // This should be copy-initialization, not assignment.
+    initCall->insertAfter(assign);
+    assign->insertAfter(move);
 
     if (block != NULL) {
       stmt->insertAfter(block);
@@ -1445,145 +1432,56 @@ static void init_typed_var(VarSymbol* var,
                            Expr*      type,
                            Expr*      stmt,
                            VarSymbol* constTemp) {
-  Expr* init = NULL;
-
   //
-  // use cast for parameters to avoid multiple parameter assignments
+  // MDN 2016/02/02
+  // The code for resolving the type of an extern variable
   //
-  if (init && var->hasFlag(FLAG_PARAM)) {
-    stmt->insertAfter(new CallExpr(PRIM_MOVE,
-                                   var,
-                                   new CallExpr("_cast",
-                                                type->remove(),
-                                                init->remove())));
+  //   functionResolution.cpp : resolveExternVarSymbols()
+  //
+  // expects to find the init code inside a block stmt.
+  //
+  // However the remaining cases do not need it.
+  //
+  BlockStmt* block = NULL;
 
-    return;
+  if (var->hasFlag(FLAG_EXTERN) == true) {
+    block = new BlockStmt(NULL, BLOCK_SCOPELESS);
   }
 
-  //
-  // initialize variable based on specified type and then assign it
-  // the initialization expression if it exists
-  //
-  bool isNoinit     = init && init->isNoInitExpr();
-  bool moduleNoinit = false;
+  VarSymbol* typeTemp = newTemp("type_tmp");
+  DefExpr*   typeDefn = new DefExpr(typeTemp);
+  CallExpr*  initCall = NULL;
 
-  if (isNoinit && !fUseNoinit) {
-    // In the case where --no-use-noinit is thrown, we want to still use
-    // noinit in the module code (as the correct operation of complexes
-    // depends on it).
-
-    // Lydia note: The requirement for complexes is expected to go away when
-    // we transition to constructors for all types instead of the _defaultOf
-    // function
-    Symbol* moduleSource = var;
-
-    while (!isModuleSymbol(moduleSource)  &&
-           moduleSource           != NULL &&
-           moduleSource->defPoint != NULL) {
-      // This will go up the definition tree until it reaches a module symbol
-      // Or until it encounters a null field.
-      moduleSource = moduleSource->defPoint->parentSymbol;
-    }
-
-    ModuleSymbol* mod = toModuleSymbol(moduleSource);
-
-    if (mod != NULL && moduleSource->defPoint != NULL) {
-      // As these are the only other cases that would have caused the prior
-      // while loop to exit, the moduleSource must be a module
-      moduleNoinit = mod->modTag == MOD_INTERNAL ||
-                     mod->modTag == MOD_STANDARD;
-
-      // Check if the parent module of this variable is a standard or
-      // internal module, and store the result of this check in moduleNoinit
-    }
+  if (var->hasFlag(FLAG_PARAM)) {
+    typeTemp->addFlag(FLAG_PARAM);
   }
 
-  // Lydia note:  I'm adding fUseNoinit here because utilizing noinit with
-  // return temps is necessary, so the only instances that should be
-  // controlled by the flag are generated here
-  if (isNoinit && (fUseNoinit || moduleNoinit)) {
-    // Only perform this action if noinit has been specified and the flag
-    // --no-use-noinit has not been thrown (or if the noinit is found in
-    // module code)
-    var->defPoint->init->remove();
+  initCall = new CallExpr(PRIM_MOVE,
+                          typeTemp,
+                          new CallExpr(PRIM_INIT, type->remove()));
 
-    CallExpr* initCall = new CallExpr(PRIM_MOVE,
-                                      var,
-                                      new CallExpr(PRIM_NO_INIT,
-                                                   type->remove()));
+  if (block != NULL) {
+    block->insertAtTail(typeDefn);
+  } else {
+    stmt->insertAfter(typeDefn);
+  }
 
-    // Since the variable won't have been defined just yet (stmt is
-    // its def expression after all), insert the move after the defPoint
-    stmt->insertAfter(initCall);
+  typeDefn->insertAfter(initCall);
+
+  if (constTemp->isType()) {
+    initCall->insertAfter(new CallExpr(PRIM_MOVE,
+                                       constTemp,
+                                       new CallExpr(PRIM_TYPEOF, typeTemp)));
 
   } else {
-    if (!fUseNoinit && isNoinit) {
-      // The instance would be initialized to noinit, but we aren't allowing
-      // noinit, so remove the initialization expression, allowing  it to
-      // default initialize.
-      init->remove();
-      init = NULL;
-    }
+    initCall->insertAfter(new CallExpr(PRIM_MOVE, constTemp, typeTemp));
 
-    //
-    // MDN 2016/02/02
-    // The code for resolving the type of an extern variable
-    //
-    //   functionResolution.cpp : resolveExternVarSymbols()
-    //
-    // expects to find the init code inside a block stmt.
-    //
-    // However the remaining cases do not need it.
-    //
-    BlockStmt* block = NULL;
+    if (constTemp->hasFlag(FLAG_EXTERN))
+      (unsigned&) block->blockTag |= BLOCK_EXTERN | BLOCK_TYPE;
+  }
 
-    if (var->hasFlag(FLAG_EXTERN) == true) {
-      block = new BlockStmt(NULL, BLOCK_SCOPELESS);
-    }
-
-    VarSymbol* typeTemp = newTemp("type_tmp");
-    DefExpr*   typeDefn = new DefExpr(typeTemp);
-    CallExpr*  initCall = NULL;
-
-    if (var->hasFlag(FLAG_PARAM)) {
-      typeTemp->addFlag(FLAG_PARAM);
-    }
-
-    initCall = new CallExpr(PRIM_MOVE,
-                            typeTemp,
-                            new CallExpr(PRIM_INIT, type->remove()));
-
-    if (block != NULL) {
-      block->insertAtTail(typeDefn);
-    } else {
-      stmt->insertAfter(typeDefn);
-    }
-
-    typeDefn->insertAfter(initCall);
-
-    if (init) {
-      CallExpr* assign = new CallExpr("=",       typeTemp,  init->remove());
-      CallExpr* move   = new CallExpr(PRIM_MOVE, constTemp, typeTemp);
-
-      // This should be copy-initialization, not assignment.
-      initCall->insertAfter(assign);
-      assign->insertAfter(move);
-
-    } else if (constTemp->isType()) {
-      initCall->insertAfter(new CallExpr(PRIM_MOVE,
-                                         constTemp,
-                                         new CallExpr(PRIM_TYPEOF, typeTemp)));
-
-    } else {
-      initCall->insertAfter(new CallExpr(PRIM_MOVE, constTemp, typeTemp));
-
-      if (constTemp->hasFlag(FLAG_EXTERN))
-        (unsigned&) block->blockTag |= BLOCK_EXTERN | BLOCK_TYPE;
-    }
-
-    if (block != NULL) {
-      stmt->insertAfter(block);
-    }
+  if (block != NULL) {
+    stmt->insertAfter(block);
   }
 }
 


### PR DESCRIPTION
Continue to straighten out the code to normalize DefExpr for VarSymbol in preparation for
changes to support the initialization of non-generic records.  No changes in behavior.

The overall diff might be hard to follow and so it is broken down in to a series of simple
commits with simple transformations.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux.
Passed full paratests
