### PR TITLE
Fix testing problems with a new C atomics test

### DIFF
--- a/test/runtime/ferguson/testatomics.skipif
+++ b/test/runtime/ferguson/testatomics.skipif
@@ -1,0 +1,3 @@
+# Skipping if CHPL_ATOMICS == locks because it is too hard
+# to link with the appropriate parts of the Chapel runtime.
+CHPL_ATOMICS==locks

--- a/test/runtime/ferguson/testatomics.skipif
+++ b/test/runtime/ferguson/testatomics.skipif
@@ -1,3 +1,13 @@
 # Skipping if CHPL_ATOMICS == locks because it is too hard
 # to link with the appropriate parts of the Chapel runtime.
 CHPL_ATOMICS==locks
+# Skipping under valgrind because of an error like this:
+# Conditional jump or move depends on uninitialised value(s)
+#   at 0x400642: atomic_store_explicit_bool (chpl-atomics.h:310)
+#   by 0x40066E: atomic_store_bool (chpl-atomics.h:310)
+#   by 0x401728: main (testatomics.test.c:77)
+#
+# and looking at the implementation of atomic_store_explicit_bool, it
+# does in fact have a loop depending on an uninitialized value
+# (because it checks that a compare-and-swap worked)
+CHPL_TEST_VGRND_EXE==on

--- a/test/runtime/ferguson/testatomics.skipif
+++ b/test/runtime/ferguson/testatomics.skipif
@@ -1,13 +1,3 @@
 # Skipping if CHPL_ATOMICS == locks because it is too hard
 # to link with the appropriate parts of the Chapel runtime.
 CHPL_ATOMICS==locks
-# Skipping under valgrind because of an error like this:
-# Conditional jump or move depends on uninitialised value(s)
-#   at 0x400642: atomic_store_explicit_bool (chpl-atomics.h:310)
-#   by 0x40066E: atomic_store_bool (chpl-atomics.h:310)
-#   by 0x401728: main (testatomics.test.c:77)
-#
-# and looking at the implementation of atomic_store_explicit_bool, it
-# does in fact have a loop depending on an uninitialized value
-# (because it checks that a compare-and-swap worked)
-CHPL_TEST_VGRND_EXE==on

--- a/test/runtime/ferguson/testatomics.test.c
+++ b/test/runtime/ferguson/testatomics.test.c
@@ -74,6 +74,8 @@ int main(int argc, char** argv)
 {
   atomic_bool flag;
 
+  memset(&flag, 0, sizeof(flag));
+
   atomic_store_bool(&flag, false);
   assert( false == atomic_exchange_bool(&flag, true) );
   assert( true == atomic_exchange_bool(&flag, true) );

--- a/test/runtime/ferguson/testatomics.test.c
+++ b/test/runtime/ferguson/testatomics.test.c
@@ -74,8 +74,7 @@ int main(int argc, char** argv)
 {
   atomic_bool flag;
 
-  memset(&flag, 0, sizeof(flag));
-
+  atomic_init_bool(&flag, true);
   atomic_store_bool(&flag, false);
   assert( false == atomic_exchange_bool(&flag, true) );
   assert( true == atomic_exchange_bool(&flag, true) );


### PR DESCRIPTION
I tried for a few minutes to run the test and link with the Chapel runtime but I couldn't quickly figure out how to do so. Therefore, for now, this test assumes that the relevant functionality is in header files, and it skips CHPL_ATOMICS which is the case where we know it is not.

Additionally, initialize a local variable so that this test runs cleanly under valgrind. (The error valgrind was complaining about is harmless and has to do with a compare-and-swap loop using memory that hasn't been written to yet, which is not necessarily wrong).

Verified test is skipped under CHPL_ATOMICS=locks and that the test passes with intrinsics or cstdlib atomics on my system.

Reviewed by @ronawho - thanks!