### PR TITLE
Give resolveFns some helper functions

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -215,6 +215,7 @@ void resolveTypedefedArgTypes(FnSymbol* fn);
 extern bool tryFailure;
 void insertFormalTemps(FnSymbol* fn);
 void insertAndResolveCasts(FnSymbol* fn);
+void ensureInMethodList(FnSymbol* fn);
 
 FnSymbol* defaultWrap(FnSymbol* fn, Vec<ArgSymbol*>* actualFormals,  CallInfo* info);
 void reorderActuals(FnSymbol* fn, Vec<ArgSymbol*>* actualFormals,  CallInfo* info);

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -214,7 +214,7 @@ void resolveTypedefedArgTypes(FnSymbol* fn);
 // FnSymbol changes
 extern bool tryFailure;
 void insertFormalTemps(FnSymbol* fn);
-void insertCasts(BaseAST* ast, FnSymbol* fn, Vec<CallExpr*>& casts);
+void insertAndResolveCasts(FnSymbol* fn);
 
 FnSymbol* defaultWrap(FnSymbol* fn, Vec<ArgSymbol*>* actualFormals,  CallInfo* info);
 void reorderActuals(FnSymbol* fn, Vec<ArgSymbol*>* actualFormals,  CallInfo* info);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8298,6 +8298,27 @@ static void resolveReturnType(FnSymbol* fn)
 
 }
 
+void ensureInMethodList(FnSymbol* fn) {
+  if (fn->hasFlag(FLAG_METHOD) && fn->_this != NULL) {
+    Type* thisType = fn->_this->type->getValType();
+    bool  found    = false;
+
+    INT_ASSERT(thisType);
+    INT_ASSERT(thisType != dtUnknown);
+
+    forv_Vec(FnSymbol, method, thisType->methods) {
+      if (method == fn) {
+        found = true;
+        break;
+      }
+    }
+
+    if (found == false) {
+      thisType->methods.add(fn);
+    }
+  }
+}
+
 // Simple wrappers to check if a function is a specific type of iterator
 static bool isIteratorOfType(FnSymbol* fn, Symbol* iterTag) {
   if (fn->isIterator()) {
@@ -8504,24 +8525,7 @@ resolveFns(FnSymbol* fn) {
   //
   // make sure methods are in the methods list
   //
-  if (fn->hasFlag(FLAG_METHOD) && fn->_this != NULL) {
-    Type* thisType = fn->_this->type->getValType();
-    bool  found    = false;
-
-    INT_ASSERT(thisType);
-    INT_ASSERT(thisType != dtUnknown);
-
-    forv_Vec(FnSymbol, method, thisType->methods) {
-      if (method == fn) {
-        found = true;
-        break;
-      }
-    }
-
-    if (found == false) {
-      thisType->methods.add(fn);
-    }
-  }
+  ensureInMethodList(fn);
 }
 
 


### PR DESCRIPTION
More of my ongoing code rearrangement for maintainability.  In
resolveFns, I reuse the insertion of casts as necessary and
the code which verifies that functions marked with FLAG_METHOD
are in the methods list for the type on which they are defined.

With this change, my exporting of insertCasts wasn't necessary, so
I made that static and local to functionResolution again.