### PR TITLE
Fix a bad standalone iter in a vectorization test

### DIFF
--- a/test/performance/vectorization/vectorPragmas/nonInlinableFollower.chpl
+++ b/test/performance/vectorization/vectorPragmas/nonInlinableFollower.chpl
@@ -7,14 +7,14 @@ module iters {
     }
   }
 
-  // for loop in standalone should NOT get vector pragma because loop can't be
-  // inlined (2 yields), and will result in a 'reentrant' advance function
+  // for loop in standalone should get vector pragma because standalone iters
+  // are force inlined
   iter myiter(nn: int, nt: int, param tag: iterKind) where tag == iterKind.standalone {
     coforall i in 0..#nt {
       for j in i*nn..#nn-1 {
         yield j;
       }
-      yield i*nn..#nn.last;
+      yield (i*nn..#nn).last;
     }
   }
 
@@ -24,8 +24,8 @@ module iters {
     }
   }
 
-  // for loop in follower should NOT get vector pragma because loop can't be
-  // inlined (2 yields), and will result in a 'reentrant' advance function
+  // for loop in follower should NOT get vector pragma because iter can't be
+  // inlined (2 yields), and will result in a `advance` function
   iter myiter(nn:int, nt: int, followThis, param tag: iterKind) where tag == iterKind.follower {
       for j in followThis # (followThis.size - 1) {
         yield j;

--- a/test/performance/vectorization/vectorPragmas/nonInlinableFollower.compgood
+++ b/test/performance/vectorization/vectorPragmas/nonInlinableFollower.compgood
@@ -1,0 +1,1 @@
+Adding CHPL_PRAGMA_IVDEP to CForLoop for InvokeStandalone:23


### PR DESCRIPTION
Fix some invalid/bad syntax in the standalone iter for nonInlinableFollower
test. On master, our use of the tryToken to pick between standalone and
leader/follower hid this, but Vass discovered the bug in his forall-stmt work.

Correct the standalone iter, and update the test output and some comments to
accurately reflect that the for-loop in the standalone iter *should* be marked
as order-independent.