### PR TITLE
Rearrange and remove renameInstantiatedType

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -870,57 +870,27 @@ void TypeSymbol::accept(AstVisitor* visitor) {
 void TypeSymbol::renameInstantiatedMulti(SymbolMap& subs, FnSymbol* fn) {
   renameInstantiatedStart();
 
-  bool first = false;
+  bool notFirst = false;
   for_formals(formal, fn) {
     if (Symbol* value = subs.get(formal)) {
-      if (TypeSymbol* ts = toTypeSymbol(value)) {
-        if (!first && this->hasFlag(FLAG_TUPLE)) {
-          if (this->hasFlag(FLAG_STAR_TUPLE)) {
-            this->name = astr(istr(fn->numFormals()-1), "*", ts->name);
-            this->cname = astr(this->cname, "star_", ts->cname);
-            return;
-          } else {
-            this->name = astr("(");
+      if (!notFirst) {
+        if (TypeSymbol* ts = toTypeSymbol(value)) {
+          if (this->hasFlag(FLAG_TUPLE)) {
+            if (this->hasFlag(FLAG_STAR_TUPLE)) {
+              this->name = astr(istr(fn->numFormals()-1), "*", ts->name);
+              this->cname = astr(this->cname, "star_", ts->cname);
+              return;
+            } else {
+              this->name = astr("(");
+            }
           }
         }
-        if (!this->hasFlag(FLAG_STAR_TUPLE)) {
-          if (first) {
-            this->name = astr(this->name, ",");
-            this->cname = astr(this->cname, "_");
-          }
-          this->name = astr(this->name, ts->name);
-          this->cname = astr(this->cname, ts->cname);
-        }
-        first = true;
+        notFirst = true;
       } else {
-        if (first) {
-          this->name = astr(this->name, ",");
-          this->cname = astr(this->cname, "_");
-        }
-        VarSymbol* var = toVarSymbol(value);
-        if (var && var->immediate) {
-          Immediate* immediate = var->immediate;
-          if (var->type == dtString || var->type == dtStringC)
-            renameInstantiatedTypeString(this, var);
-          else if (immediate->const_kind == NUM_KIND_BOOL) {
-            // Handle boolean types specially.
-            const char* name4bool = immediate->bool_value() ? "true" : "false";
-            const char* cname4bool = immediate->bool_value() ? "T" : "F";
-            this->name = astr(this->name, name4bool);
-            this->cname = astr(this->cname, cname4bool);
-          } else {
-            const size_t bufSize = 128;
-            char imm[bufSize];
-            snprint_imm(imm, bufSize, *var->immediate);
-            this->name = astr(this->name, imm);
-            this->cname = astr(this->cname, imm);
-          }
-        } else {
-          this->name = astr(this->name, value->cname);
-          this->cname = astr(this->cname, value->cname);
-        }
-        first = true;
+        this->name = astr(this->name, ",");
+        this->cname = astr(this->cname, "_");
       }
+      renameInstantiatedIndividual(value);
     }
   }
 
@@ -943,7 +913,35 @@ void TypeSymbol::renameInstantiatedStart() {
 }
 
 void TypeSymbol::renameInstantiatedIndividual(Symbol* sym) {
-
+  if (TypeSymbol* ts = toTypeSymbol(sym)) {
+    if (!this->hasFlag(FLAG_STAR_TUPLE)) {
+      this->name = astr(this->name, ts->name);
+      this->cname = astr(this->cname, ts->cname);
+    }
+  } else {
+    VarSymbol* var = toVarSymbol(sym);
+    if (var && var->immediate) {
+      Immediate* immediate = var->immediate;
+      if (var->type == dtString || var->type == dtStringC)
+        renameInstantiatedTypeString(this, var);
+      else if (immediate->const_kind == NUM_KIND_BOOL) {
+        // Handle boolean types specially.
+        const char* name4bool = immediate->bool_value() ? "true" : "false";
+        const char* cname4bool = immediate->bool_value() ? "T" : "F";
+        this->name = astr(this->name, name4bool);
+        this->cname = astr(this->cname, cname4bool);
+      } else {
+        const size_t bufSize = 128;
+        char imm[bufSize];
+        snprint_imm(imm, bufSize, *var->immediate);
+        this->name = astr(this->name, imm);
+        this->cname = astr(this->cname, imm);
+      }
+    } else {
+      this->name = astr(this->name, sym->cname);
+      this->cname = astr(this->cname, sym->cname);
+    }
+  }
 }
 
 void TypeSymbol::renameInstantiatedEnd() {

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -867,6 +867,27 @@ void TypeSymbol::accept(AstVisitor* visitor) {
   }
 }
 
+void TypeSymbol::renameInstantiatedMulti(SymbolMap& subs, FnSymbol* fn) {
+  renameInstantiatedStart();
+}
+
+void TypeSymbol::renameInstantiatedStart() {
+  if (this->name[strlen(this->name)-1] == ')') {
+    // avoid "strange" instantiated type names based on partial instantiation
+    //  instead of C(int,real)(imag) this results in C(int,real,imag)
+    char* buf = (char*)malloc(strlen(this->name) + 1);
+    memcpy(buf, this->name, strlen(this->name));
+    buf[strlen(this->name)-1] = '\0';
+    this->name = astr(buf, ",");
+    free(buf);
+  } else {
+    this->name = astr(this->name, "(");
+  }
+  this->cname = astr(this->cname, "_");
+}
+
+
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -383,6 +383,9 @@ class TypeSymbol : public Symbol {
   virtual void    accept(AstVisitor* visitor);
   DECLARE_SYMBOL_COPY(TypeSymbol);
   void replaceChild(BaseAST* old_ast, BaseAST* new_ast);
+
+  void renameInstantiatedMulti(SymbolMap& subs, FnSymbol* fn);
+
   GenRet codegen();
   void codegenDef();
   void codegenPrototype();
@@ -391,6 +394,11 @@ class TypeSymbol : public Symbol {
   void codegenMetadata();
 
   const char* doc;
+
+ private:
+  void renameInstantiatedStart();
+  void renameInstantiatedIndividual(Symbol* sym);
+  void renameInstantiatedEnd();
 };
 
 /************************************* | **************************************

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -254,18 +254,7 @@ void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
 
 static void
 renameInstantiatedType(TypeSymbol* sym, SymbolMap& subs, FnSymbol* fn) {
-  if (sym->name[strlen(sym->name)-1] == ')') {
-    // avoid "strange" instantiated type names based on partial instantiation
-    //  instead of C(int,real)(imag) this results in C(int,real,imag)
-    char* buf = (char*)malloc(strlen(sym->name) + 1);
-    memcpy(buf, sym->name, strlen(sym->name));
-    buf[strlen(sym->name)-1] = '\0';
-    sym->name = astr(buf, ",");
-    free(buf);
-  } else {
-    sym->name = astr(sym->name, "(");
-  }
-  sym->cname = astr(sym->cname, "_");
+  sym->renameInstantiatedMulti(subs, fn);
   bool first = false;
   for_formals(formal, fn) {
     if (Symbol* value = subs.get(formal)) {

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -252,11 +252,6 @@ void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
   }
 }
 
-static void
-renameInstantiatedType(TypeSymbol* sym, SymbolMap& subs, FnSymbol* fn) {
-  sym->renameInstantiatedMulti(subs, fn);
-}
-
 /** Instantiate a type
  *
  * \param fn   Type constructor we are working on
@@ -327,7 +322,7 @@ instantiateTypeForTypeConstructor(FnSymbol* fn, SymbolMap& subs, CallExpr* call,
     }
   }
 
-  renameInstantiatedType(newType->symbol, subs, fn);
+  newType->symbol->renameInstantiatedMulti(subs, fn);
 
   fn->retType->symbol->defPoint->insertBefore(new DefExpr(newType->symbol));
 

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -255,60 +255,6 @@ void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
 static void
 renameInstantiatedType(TypeSymbol* sym, SymbolMap& subs, FnSymbol* fn) {
   sym->renameInstantiatedMulti(subs, fn);
-  bool first = false;
-  for_formals(formal, fn) {
-    if (Symbol* value = subs.get(formal)) {
-      if (TypeSymbol* ts = toTypeSymbol(value)) {
-        if (!first && sym->hasFlag(FLAG_TUPLE)) {
-          if (sym->hasFlag(FLAG_STAR_TUPLE)) {
-            sym->name = astr(istr(fn->numFormals()-1), "*", ts->name);
-            sym->cname = astr(sym->cname, "star_", ts->cname);
-            return;
-          } else {
-            sym->name = astr("(");
-          }
-        }
-        if (!sym->hasFlag(FLAG_STAR_TUPLE)) {
-          if (first) {
-            sym->name = astr(sym->name, ",");
-            sym->cname = astr(sym->cname, "_");
-          }
-          sym->name = astr(sym->name, ts->name);
-          sym->cname = astr(sym->cname, ts->cname);
-        }
-        first = true;
-      } else {
-        if (first) {
-          sym->name = astr(sym->name, ",");
-          sym->cname = astr(sym->cname, "_");
-        }
-        VarSymbol* var = toVarSymbol(value);
-        if (var && var->immediate) {
-          Immediate* immediate = var->immediate;
-          if (var->type == dtString || var->type == dtStringC)
-            renameInstantiatedTypeString(sym, var);
-          else if (immediate->const_kind == NUM_KIND_BOOL) {
-            // Handle boolean types specially.
-            const char* name4bool = immediate->bool_value() ? "true" : "false";
-            const char* cname4bool = immediate->bool_value() ? "T" : "F";
-            sym->name = astr(sym->name, name4bool);
-            sym->cname = astr(sym->cname, cname4bool);
-          } else {
-            const size_t bufSize = 128;
-            char imm[bufSize];
-            snprint_imm(imm, bufSize, *var->immediate);
-            sym->name = astr(sym->name, imm);
-            sym->cname = astr(sym->cname, imm);
-          }
-        } else {
-          sym->name = astr(sym->name, value->cname);
-          sym->cname = astr(sym->cname, value->cname);
-        }
-        first = true;
-      }
-    }
-  }
-  sym->name = astr(sym->name, ")");
 }
 
 /** Instantiate a type


### PR DESCRIPTION
Move contents of renameInstantiatedType into a series of methods on TypeSymbols.
I reuse and modify some of this code for my generic initializers branch.
Really, it makes the most sense for this operation to be a method on the
TypeSymbol rather than an outside function.  This will improve code
maintainability for my initializers implementation.

In this change, I make four new methods on TypeSymbols:
- renameInstantiatedMulti: the only public method, which takes in all the
   substitutions performed on the type and the FnSymbol that is causing this
   change, and iterates through all of them to update the name of the
   instantiation.  Not all of the operations in this function will be useful for my
   branch, as generic initializers are updated through out Phase 1 on a per
   field basis in my implementation.  Separating the code in this manner may
   allow me to change my mind on that at a later time.
- renameInstantiatedStart: handles the prefix work which will always occur,
   regardless of whether the TypeSymbol came from a fully generic type or a
   partial instantiation
- renameInstantiatedEnd: a short method which always terminates the
   instantiation (except in the case of star tuples)
- renameInstantiatedIndividual: the meat of the change.  Has some adjustments
   for immediates and tuples (which were there prior to my shuffling).

I replaced the call to renameInstantiatedType with a call to the public method
and removed the old function entirely.

Verified that the generated log output after resolution and the generated C
code for hello.chpl was unchanged (and an error was caught by checking in
this manner).

TODO:
- [x] full std paratest run