### PR TITLE
Introduce AggregateType::isGeneric() const

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -499,6 +499,8 @@ AggregateType::AggregateType(AggregateTag initTag)
   fields.parent      = this;
   inherits.parent    = this;
 
+  mIsGeneric         = false;
+
   // set defaultValue to nil to keep it from being constructed
   if (aggregateTag == AGGREGATE_CLASS) {
     defaultValue = gNil;
@@ -593,6 +595,10 @@ bool AggregateType::isUnion() const {
   return aggregateTag == AGGREGATE_UNION;
 }
 
+bool AggregateType::isGeneric() const {
+  return mIsGeneric;
+}
+
 void AggregateType::addDeclarations(Expr* expr) {
   if (DefExpr* defExpr = toDefExpr(expr)) {
     addDeclaration(defExpr);
@@ -616,6 +622,16 @@ void AggregateType::addDeclaration(DefExpr* defExpr) {
 
   if (VarSymbol* var = toVarSymbol(defExpr->sym)) {
     var->makeField();
+
+    if (var->hasFlag(FLAG_TYPE_VARIABLE) == true) {
+      mIsGeneric = true;
+
+    } else if (var->hasFlag(FLAG_PARAM) == true) {
+      mIsGeneric = true;
+
+    } else if (defExpr->exprType == NULL) {
+      mIsGeneric = true;
+    }
 
   } else if (FnSymbol* fn = toFnSymbol(defExpr->sym)) {
     methods.add(fn);

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -23,21 +23,19 @@
 
 #include "AstToText.h"
 #include "astutil.h"
+#include "AstVisitor.h"
 #include "build.h"
 #include "docsDriver.h"
 #include "expr.h"
 #include "files.h"
 #include "intlimits.h"
 #include "ipe.h"
+#include "iterator.h"
 #include "misc.h"
 #include "passes.h"
 #include "stringutil.h"
 #include "symbol.h"
 #include "vec.h"
-
-#include "iterator.h"
-
-#include "AstVisitor.h"
 
 static bool isDerivedType(Type* type, Flag flag);
 
@@ -483,6 +481,11 @@ std::string EnumType::docsDirective() {
   }
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 AggregateType::AggregateType(AggregateTag initTag) :
   Type(E_AggregateType, NULL),
@@ -554,6 +557,22 @@ AggregateType::copyInner(SymbolMap* map) {
   return copy_type;
 }
 
+
+int AggregateType::numFields() const {
+  return fields.length;
+}
+
+bool AggregateType::isClass() const {
+  return aggregateTag == AGGREGATE_CLASS;
+}
+
+bool AggregateType::isRecord() const {
+  return aggregateTag == AGGREGATE_RECORD;
+}
+
+bool AggregateType::isUnion() const {
+  return aggregateTag == AGGREGATE_UNION;
+}
 
 static void addDeclaration(AggregateType* ct, DefExpr* def, bool tail) {
   if (def->sym->hasFlag(FLAG_REF_VAR)) {
@@ -880,6 +899,12 @@ std::string AggregateType::docsDirective() {
 }
 
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
 void initRootModule() {
   rootModule           = new ModuleSymbol("_root", MOD_INTERNAL, new BlockStmt());
   rootModule->filename = astr("<internal>");
@@ -891,11 +916,11 @@ void initStringLiteralModule() {
   theProgram->block->insertAtTail(new DefExpr(stringLiteralModule));
 }
 
-/************************************ | *************************************
-*                                                                           *
-*                                                                           *
-*                                                                           *
-************************************* | ************************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 static PrimitiveType* createPrimitiveType(const char* name, const char* cname);
 static PrimitiveType* createInternalType (const char* name, const char* cname);
@@ -1149,11 +1174,11 @@ static VarSymbol* createSymbol(PrimitiveType* primType, const char* name) {
   return retval;
 }
 
-/************************************ | *************************************
-*                                                                           *
-*                                                                           *
-*                                                                           *
-************************************* | ************************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 DefExpr* defineObjectClass() {
   DefExpr* retval = 0;

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -287,6 +287,12 @@ private:
 };
 
 
+/************************************* | **************************************
+*                                                                             *
+* A base type for union, class, and record.                                   *
+*                                                                             *
+************************************** | *************************************/
+
 enum AggregateTag {
   AGGREGATE_CLASS,
   AGGREGATE_RECORD,
@@ -299,52 +305,82 @@ enum InitializerStyle {
   DEFINES_NONE_USE_DEFAULT
 };
 
+
 class AggregateType : public Type {
- public:
-  AggregateTag aggregateTag;
-  InitializerStyle initializerStyle;
-  AList fields;
-  AList inherits; // used from parsing, sets dispatchParents
-  Symbol* outer;  // pointer to an outer class if this is an inner class
-
-  IteratorInfo* iteratorInfo; // Attached only to iterator class/records
-
-  const char *doc;
-
+public:
   AggregateType(AggregateTag initTag);
   ~AggregateType();
-  void verify();
-  virtual void    accept(AstVisitor* visitor);
+
   DECLARE_COPY(AggregateType);
-  void replaceChild(BaseAST* old_ast, BaseAST* new_ast);
-  void addDeclarations(Expr* expr, bool tail = true);
 
-  GenRet codegenClassStructType();
-  void codegenDef();
-  void codegenPrototype();
-  const char* classStructName(bool standalone);
-  int codegenStructure(FILE* outfile, const char* baseoffset);
-  int codegenFieldStructure(FILE* outfile, bool nested, const char* baseoffset);
+  virtual void          replaceChild(BaseAST* oldAst, BaseAST* newAst);
 
-  int getMemberGEP(const char *name);
+  virtual void          verify();
+  virtual void          accept(AstVisitor* visitor);
+  virtual void          printDocs(std::ostream* file, unsigned int tabs);
 
-  int getFieldPosition(const char* name, bool fatal = true);
-  Symbol* getField(const char* name, bool fatal = true);
-  Symbol* getField(int i);
+  void                  addDeclarations(Expr* expr, bool tail = true);
+
+  void                  codegenDef();
+
+  void                  codegenPrototype();
+
+  GenRet                codegenClassStructType();
+
+  int                   codegenStructure(FILE*       outfile,
+                                         const char* baseoffset);
+
+  int                   codegenFieldStructure(FILE*       outfile,
+                                              bool        nested,
+                                              const char* baseOffset);
+
+  const char*           classStructName(bool standalone);
+
+  int                   getMemberGEP(const char* name);
+
+  int                   getFieldPosition(const char* name,
+                                         bool        fatal = true);
+
+  Symbol*               getField(const char* name, bool fatal = true);
+  Symbol*               getField(int i);
+
   // e is as used in PRIM_GET_MEMBER/PRIM_GET_SVEC_MEMBER
-  QualifiedType getFieldType(Expr* e);
-  int numFields() { return fields.length; }
-  bool isClass() { return aggregateTag == AGGREGATE_CLASS; }
-  bool isRecord() { return aggregateTag == AGGREGATE_RECORD; }
-  bool isUnion() { return aggregateTag == AGGREGATE_UNION; }
+  QualifiedType         getFieldType(Expr* e);
 
-  virtual void printDocs(std::ostream *file, unsigned int tabs);
+  int                   numFields()                                      const;
+
+  bool                  isClass()                                        const;
+  bool                  isRecord()                                       const;
+  bool                  isUnion()                                        const;
+
+
+  AggregateTag          aggregateTag;
+  InitializerStyle      initializerStyle;
+
+  AList                 fields;
+
+  // used from parsing, sets dispatchParents
+  AList                 inherits;
+
+  // pointer to an outer class if this is an inner class
+  Symbol*               outer;
+
+  // Attached only to iterator class/records
+  IteratorInfo*         iteratorInfo;
+
+  const char*           doc;
 
 private:
-  virtual std::string docsDirective();
-  std::string docsSuperClass();
+  virtual std::string   docsDirective();
+  std::string           docsSuperClass();
 };
 
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 class PrimitiveType : public Type {
  public:
@@ -362,6 +398,12 @@ private:
   virtual std::string docsDirective();
 };
 
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 #ifndef TYPE_EXTERN
 #define TYPE_EXTERN extern

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -319,7 +319,7 @@ public:
   virtual void          accept(AstVisitor* visitor);
   virtual void          printDocs(std::ostream* file, unsigned int tabs);
 
-  void                  addDeclarations(Expr* expr, bool tail = true);
+  void                  addDeclarations(Expr* expr);
 
   void                  codegenDef();
 
@@ -372,9 +372,10 @@ public:
 
 private:
   virtual std::string   docsDirective();
-  std::string           docsSuperClass();
-};
 
+  std::string           docsSuperClass();
+  void                  addDeclaration(DefExpr* defExpr);
+};
 
 /************************************* | **************************************
 *                                                                             *

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -352,6 +352,7 @@ public:
   bool                  isClass()                                        const;
   bool                  isRecord()                                       const;
   bool                  isUnion()                                        const;
+  bool                  isGeneric()                                      const;
 
 
   AggregateTag          aggregateTag;
@@ -375,6 +376,8 @@ private:
 
   std::string           docsSuperClass();
   void                  addDeclaration(DefExpr* defExpr);
+
+  bool                  mIsGeneric;
 };
 
 /************************************* | **************************************

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -60,7 +60,7 @@ static void normalize_nested_function_expressions(DefExpr* def) {
       if (TypeSymbol* ts = toTypeSymbol(def->parentSymbol)) {
         if (AggregateType* ct = toAggregateType(ts->type)) {
           def->replace(new UnresolvedSymExpr(def->sym->name));
-          ct->addDeclarations(def, true);
+          ct->addDeclarations(def);
           return;
         }
       }
@@ -77,7 +77,7 @@ static void normalize_nested_function_expressions(DefExpr* def) {
     if (TypeSymbol* ts = toTypeSymbol(parent->defPoint->parentSymbol)) {
       AggregateType* ct = toAggregateType(ts->type);
       INT_ASSERT(ct);
-      ct->addDeclarations(def->remove(), true);
+      ct->addDeclarations(def->remove());
     } else {
       parent->defPoint->insertBefore(def->remove());
     }


### PR DESCRIPTION
This PR was developed to add a trivial method on AggregateType that returns true if
the aggregate type is generic (has one or more type fields, param fields, or variable
fields without types).

My branch to support normalization of non-generic records with initializers generated
a resolution error for one test that has a more human readable error on master.
Resolution has rather odd code to generate that message that doesn't trigger on my
branch.


While there

1) Non-functional clean up of the declaration for AggregateType

2) Non-functional clean up within the implementation of AggregateType

3) Noticed that the method 

  void addDeclarations(Expr* expr, bool tail = true);

is only ever called with tail set to true and so lopped the parameter off.
Additionally I converted the helper function

static void addDeclaration(AggregateType* ct, DefExpr* def, bool tail);

to be a private method on the class.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/lnux64
Passes single-locale paratest.

