### PR TITLE
Propagate isGeneric

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -599,6 +599,10 @@ bool AggregateType::isGeneric() const {
   return mIsGeneric;
 }
 
+void AggregateType::markAsGeneric() {
+  mIsGeneric = true;
+}
+
 void AggregateType::addDeclarations(Expr* expr) {
   if (DefExpr* defExpr = toDefExpr(expr)) {
     addDeclaration(defExpr);

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -352,7 +352,10 @@ public:
   bool                  isClass()                                        const;
   bool                  isRecord()                                       const;
   bool                  isUnion()                                        const;
+
   bool                  isGeneric()                                      const;
+  void                  markAsGeneric();
+
 
 
   AggregateTag          aggregateTag;

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -681,6 +681,10 @@ static void addClassToHierarchy(AggregateType*            ct,
 
     ct->dispatchParents.add(pt);
 
+    if (ct->isGeneric() == false && pt->isGeneric() == true) {
+      ct->markAsGeneric();
+    }
+
     if (pt->dispatchChildren.add_exclusive(ct) == false) {
       INT_ASSERT(false);
     }


### PR DESCRIPTION
The motivation for this PR is to introduce a minor update to 

static void addClassToHierarchy(AggregateType* ct) ;

in scopeResolve.cpp to propagate the isGeneric property upwards along
a class hierarchy.  The first pass for this property considered only the
immediate fields of a class/record while it is being constructed.

While there

1. Performed some minor local non-functional cleanup

2. Converted a use of Vec<AggregateType*> to a use of std::set<AggregateType*>.

Compiled on clang/darwin and gcc/linux64.
Passed paratest

