### PR TITLE
Fix minor logic error in new business logic to track generic AggregateTypes

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -633,7 +633,8 @@ void AggregateType::addDeclaration(DefExpr* defExpr) {
     } else if (var->hasFlag(FLAG_PARAM) == true) {
       mIsGeneric = true;
 
-    } else if (defExpr->exprType == NULL) {
+    } else if (defExpr->exprType == NULL &&
+               defExpr->init     == NULL) {
       mIsGeneric = true;
     }
 


### PR DESCRIPTION
Lydia noted that the new code I introduced to track generic class/record had a trivial
and embarrassing error.  The code path in question is not currently being stressed on
master and so didn't surface as a failure in behavior.

Compiled on clang/darwin
Tested on darwin for release/examples.



