### PR TITLE
Update logic for pruning unused module level variables

### DIFF
--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -41,7 +41,6 @@ Initializing Modules:
     ChapelUtil
     ChapelDynDispHack
     Assert
-    CommDiagnostics
     AlignedTSupport
     RangeChunk
    printModuleInitOrder

--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
@@ -1,1 +1,1 @@
-Removed 19 dead modules.
+Removed 20 dead modules.


### PR DESCRIPTION
Work on normalization lead to a regression for 1 test due to the ad-hoc nature of some code at
the end of function-resolution that prunes unused module level variables.  This code has always
missed some cases and, on my branch, misses an important case that then leads to an INT_ASSERT.

Ripped out the ad-hoc logic and replaced it with a simple liveness test that uses the new-ish
infrastructure that Michael/Ben introduced for symbols.

On a simple test, akin to hello world, this pruned 22 module variables that were not being
pruned.  One of these was the final module level variable in CommDiagnostics.  This implies
that this PR removes 1 additional module for tests that don't use comm diagnostics.  Updated
two tests accordingly.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed paratest on linux64 for single-locale and gasnet



