### PR TITLE
Fix a copy propagation bug related to array alloc

### DIFF
--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -416,6 +416,7 @@ static bool isUse(SymExpr* se)
       if (se == call->get(1))
         return false;
       return true;
+     case PRIM_ARRAY_ALLOC:
      case PRIM_ADDR_OF:
       return false; // See Note #2.
      case PRIM_PRIVATE_BROADCAST:


### PR DESCRIPTION
Prevent propagating through an array alloc primitive. This fixes a bug
@gbtitus ran into while trying to edit our ddata_allocate function.