### PR TITLE
Update lm-numa.good for the recent change in unused variable elimination

### DIFF
--- a/test/modules/sungeun/init/printModuleInitOrder.lm-numa.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.lm-numa.good
@@ -41,7 +41,6 @@ Initializing Modules:
     ChapelUtil
     ChapelDynDispHack
     Assert
-    CommDiagnostics
     AlignedTSupport
     RangeChunk
    printModuleInitOrder


### PR DESCRIPTION
Yesterday I developed a PR that removes a few unused variables that had been ignored
until now and thereby drops the module CommDiagnostics for common tests.  I failed to
observe that numa testing has a customized .good file for printModuleInitOrder.

This PR makes the corresponding change that was made in the base .good file
