### PR TITLE
Non-functional clean up of checkUseBeforeDefs in normalize

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -524,67 +524,64 @@ static void checkUseBeforeDefs() {
 
       std::vector<BaseAST*> asts;
 
-      // Walk the asts in this function.
       collect_asts_postorder(fn, asts);
 
       for_vector(BaseAST, ast, asts) {
-        if (Symbol* symbol = theDefinedSymbol(ast)) {
-          defined.insert(symbol);
+        if (Symbol* sym = theDefinedSymbol(ast)) {
+          defined.insert(sym);
 
-        } else {
-          // The AST in question is not one of our methods of declaration so now
-          // we check if it is a (resolved/unresolved) symbol and make sure
-          // that symbol is not defined/declared before use
-          if (SymExpr* sym = toSymExpr(ast)) {
-            if (isModuleSymbol(sym->symbol()) == true) {
-              if (isFnSymbol(fn->defPoint->parentSymbol) == false) {
-                if (isUseStmt(sym->parentExpr) == false) {
-                  SymExpr* prev = toSymExpr(sym->prev);
+        // The AST in question is not one of our methods of declaration so now
+        // we check if it is a (resolved/unresolved) symbol and make sure
+        // that symbol is not defined/declared before use
+        } else if (SymExpr* sym = toSymExpr(ast)) {
+          if (isModuleSymbol(sym->symbol()) == true) {
+            if (isFnSymbol(fn->defPoint->parentSymbol) == false) {
+              if (isUseStmt(sym->parentExpr) == false) {
+                SymExpr* prev = toSymExpr(sym->prev);
 
-                  if (prev == NULL || prev->symbol() != gModuleToken) {
-                    USR_FATAL_CONT(sym,
-                                   "illegal use of module '%s'",
-                                   sym->symbol()->name);
-                  }
-                }
-              }
-
-            } else if (isLcnSymbol(sym->symbol())) {
-              if (sym->symbol()->defPoint->parentExpr != rootModule->block &&
-                  (sym->symbol()->defPoint->parentSymbol == fn ||
-                   (sym->symbol()->defPoint->parentSymbol == mod && mod->initFn == fn))) {
-                if (defined.find(sym->symbol())   == defined.end()) {
-                  if (!sym->symbol()->hasEitherFlag(FLAG_ARG_THIS,FLAG_EXTERN) &&
-                      !sym->symbol()->hasFlag(FLAG_TEMP)) {
-                    // Only complain one time
-                    if (undefined.find(sym->symbol()) == undefined.end()) {
-                      USR_FATAL_CONT(sym,
-                                     "'%s' used before defined (first used here)",
-                                     sym->symbol()->name);
-
-                      undefined.insert(sym->symbol());
-                    }
-                  }
+                if (prev == NULL || prev->symbol() != gModuleToken) {
+                  USR_FATAL_CONT(sym,
+                                 "illegal use of module '%s'",
+                                 sym->symbol()->name);
                 }
               }
             }
 
-          } else if (UnresolvedSymExpr* sym = toUnresolvedSymExpr(ast)) {
-            CallExpr* call = toCallExpr(sym->parentExpr);
+          } else if (isLcnSymbol(sym->symbol())) {
+            if (sym->symbol()->defPoint->parentExpr != rootModule->block &&
+                (sym->symbol()->defPoint->parentSymbol == fn ||
+                 (sym->symbol()->defPoint->parentSymbol == mod && mod->initFn == fn))) {
+              if (defined.find(sym->symbol())   == defined.end()) {
+                if (!sym->symbol()->hasEitherFlag(FLAG_ARG_THIS,FLAG_EXTERN) &&
+                    !sym->symbol()->hasFlag(FLAG_TEMP)) {
+                  // Only complain one time
+                  if (undefined.find(sym->symbol()) == undefined.end()) {
+                    USR_FATAL_CONT(sym,
+                                   "'%s' used before defined (first used here)",
+                                   sym->symbol()->name);
 
-            if (!call ||
-                (call->baseExpr != sym &&
-                 !call->isPrimitive(PRIM_CAPTURE_FN_FOR_CHPL) &&
-                 !call->isPrimitive(PRIM_CAPTURE_FN_FOR_C))) {
-              if (isFnSymbol(fn->defPoint->parentSymbol) == false) {
-                // Only complain one time
-                if (undeclared.find(sym->unresolved) == undeclared.end()) {
-                  USR_FATAL_CONT(sym,
-                                 "'%s' undeclared (first use this function)",
-                                 sym->unresolved);
-
-                  undeclared.insert(sym->unresolved);
+                    undefined.insert(sym->symbol());
+                  }
                 }
+              }
+            }
+          }
+
+        } else if (UnresolvedSymExpr* sym = toUnresolvedSymExpr(ast)) {
+          CallExpr* call = toCallExpr(sym->parentExpr);
+
+          if (!call ||
+              (call->baseExpr != sym &&
+               !call->isPrimitive(PRIM_CAPTURE_FN_FOR_CHPL) &&
+               !call->isPrimitive(PRIM_CAPTURE_FN_FOR_C))) {
+            if (isFnSymbol(fn->defPoint->parentSymbol) == false) {
+              // Only complain one time
+              if (undeclared.find(sym->unresolved) == undeclared.end()) {
+                USR_FATAL_CONT(sym,
+                               "'%s' undeclared (first use this function)",
+                               sym->unresolved);
+
+                undeclared.insert(sym->unresolved);
               }
             }
           }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -592,15 +592,17 @@ static void checkUseBeforeDefs() {
               if (sym->symbol()->defPoint->parentExpr != rootModule->block &&
                   (sym->symbol()->defPoint->parentSymbol == fn ||
                    (sym->symbol()->defPoint->parentSymbol == mod && mod->initFn == fn))) {
-                if (defined.find(sym->symbol())   == defined.end() &&
-                    undefined.find(sym->symbol()) == undefined.end()) {
+                if (defined.find(sym->symbol())   == defined.end()) {
                   if (!sym->symbol()->hasEitherFlag(FLAG_ARG_THIS,FLAG_EXTERN) &&
                       !sym->symbol()->hasFlag(FLAG_TEMP)) {
-                    USR_FATAL_CONT(sym,
-                                   "'%s' used before defined (first used here)",
-                                   sym->symbol()->name);
+                    // Only complain one time
+                    if (undefined.find(sym->symbol()) == undefined.end()) {
+                      USR_FATAL_CONT(sym,
+                                     "'%s' used before defined (first used here)",
+                                     sym->symbol()->name);
 
-                    undefined.insert(sym->symbol());
+                      undefined.insert(sym->symbol());
+                    }
                   }
                 }
               }
@@ -622,8 +624,9 @@ static void checkUseBeforeDefs() {
                   !call->isPrimitive(PRIM_CAPTURE_FN_FOR_C))) &&
                 sym->unresolved) {
 
-              if (undeclared.find(sym->unresolved) == undeclared.end()) {
-                if (isFnSymbol(fn->defPoint->parentSymbol) == false) {
+              if (isFnSymbol(fn->defPoint->parentSymbol) == false) {
+                // Only complain one time
+                if (undeclared.find(sym->unresolved) == undeclared.end()) {
                   USR_FATAL_CONT(sym,
                                  "'%s' undeclared (first use this function)",
                                  sym->unresolved);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -518,7 +518,7 @@ static void checkUseBeforeDefs() {
       std::set<Symbol*>     defined;
 
       std::set<Symbol*>     undefined;
-      Vec<const char*>      undeclared;
+      std::set<const char*> undeclared;
 
       std::vector<BaseAST*> asts;
 
@@ -622,13 +622,13 @@ static void checkUseBeforeDefs() {
                   !call->isPrimitive(PRIM_CAPTURE_FN_FOR_C))) &&
                 sym->unresolved) {
 
-              if (!undeclared.set_in(sym->unresolved)) {
+              if (undeclared.find(sym->unresolved) == undeclared.end()) {
                 if (isFnSymbol(fn->defPoint->parentSymbol) == false) {
                   USR_FATAL_CONT(sym,
                                  "'%s' undeclared (first use this function)",
                                  sym->unresolved);
 
-                  undeclared.set_add(sym->unresolved);
+                  undeclared.insert(sym->unresolved);
                 }
               }
             }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -580,19 +580,10 @@ static void checkUseBeforeDefs() {
           } else if (UnresolvedSymExpr* sym = toUnresolvedSymExpr(ast)) {
             CallExpr* call = toCallExpr(sym->parentExpr);
 
-            if (call &&
-                (call->isPrimitive(PRIM_MOVE) ||
-                 call->isPrimitive(PRIM_ASSIGN)) &&
-                call->get(1) == sym) {
-              continue; // We already handled this case above.
-            }
-
-            if ((!call ||
-                 (call->baseExpr != sym &&
-                  !call->isPrimitive(PRIM_CAPTURE_FN_FOR_CHPL) &&
-                  !call->isPrimitive(PRIM_CAPTURE_FN_FOR_C))) &&
-                sym->unresolved) {
-
+            if (!call ||
+                (call->baseExpr != sym &&
+                 !call->isPrimitive(PRIM_CAPTURE_FN_FOR_CHPL) &&
+                 !call->isPrimitive(PRIM_CAPTURE_FN_FOR_C))) {
               if (isFnSymbol(fn->defPoint->parentSymbol) == false) {
                 // Only complain one time
                 if (undeclared.find(sym->unresolved) == undeclared.end()) {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -517,7 +517,7 @@ static void checkUseBeforeDefs() {
 
       std::set<Symbol*>     defined;
 
-      Vec<Symbol*>          undefined;
+      std::set<Symbol*>     undefined;
       Vec<const char*>      undeclared;
 
       std::vector<BaseAST*> asts;
@@ -592,15 +592,15 @@ static void checkUseBeforeDefs() {
               if (sym->symbol()->defPoint->parentExpr != rootModule->block &&
                   (sym->symbol()->defPoint->parentSymbol == fn ||
                    (sym->symbol()->defPoint->parentSymbol == mod && mod->initFn == fn))) {
-                if (defined.find(sym->symbol()) == defined.end() &&
-                    !undefined.set_in(sym->symbol())) {
+                if (defined.find(sym->symbol())   == defined.end() &&
+                    undefined.find(sym->symbol()) == undefined.end()) {
                   if (!sym->symbol()->hasEitherFlag(FLAG_ARG_THIS,FLAG_EXTERN) &&
                       !sym->symbol()->hasFlag(FLAG_TEMP)) {
                     USR_FATAL_CONT(sym,
                                    "'%s' used before defined (first used here)",
                                    sym->symbol()->name);
 
-                    undefined.set_add(sym->symbol());
+                    undefined.insert(sym->symbol());
                   }
                 }
               }


### PR DESCRIPTION
Some changes for normalizing variable declarations for non-generic records have tripped up
due to the logic in checkUseBeforeDefs() in normalize.cpp.

An existing comment on this function points out that this isn't really the right place/way to be
doing these sorts of tests but I think this logic is currently in this location, vs post-function
resolution, in order to generate error messages that are linked more clearly to the user's code.


Before this PR, this code was very hard to read/understand and there were one or two comments
noting possible improvements.

After this PR, this code is merely quite difficult to read/understand.  I can imagine taking another
pass when I run in to more trouble.


There are not intended to be any changes in behavior from this PR.  The total delta is a little
daunting but this PR consists of many tiny commits that I think make it reasonably easy to follow.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passes full paratest on linux64 single-locale.

