### PR TITLE
Remove leak workaround in formalRequiresTemp

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5294,15 +5294,6 @@ formalRequiresTemp(ArgSymbol* formal) {
      //
      ((formal->intent == INTENT_IN || formal->intent == INTENT_CONST_IN) &&
       (backendRequiresCopyForIn(formal->type) || !fn->hasFlag(FLAG_INLINE)))
-     //
-     // The following case reduces memory leaks for zippered forall
-     // leader/follower pairs where the communicated intermediate
-     // result is a tuple of ranges, but I can't explain why it'd be
-     // needed.  Tom has said that iterators haven't really been
-     // bolted down in terms of memory leaks, so future work would be
-     // to remove this hack and close the leak properly.
-     //
-     || strcmp(formal->name, "followThis") == 0
      );
 }
 


### PR DESCRIPTION
This workaround interfered with other work I'm doing (to do with cleaning up const checking). Although I might use a different approach for the other work, I believe this workaround can be removed.

See commits 4e918181b9 and  2cd1856f5e4 for information about its origin.

I ran memory leaks testing with test/release/examples and observed no change in the number of tests with leaks (compared to nightly testing) and the same order of magnitude of leaked memory.

Passed full local testing.
Passed test/release/examples with --no-local.
Reviewed by @bradcray - thanks!
