### PR TITLE
Actually fix copy prop bug for array alloc primitive

### DIFF
--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -626,7 +626,7 @@ static void propagateCopies(std::vector<SymExpr*>& symExprs,
     // If we encounter an ADDR_OF with a symbol, do not allow further
     // replacements in case the reference is used to modify the symbol's data.
     if (CallExpr* parent = toCallExpr(se->parentExpr)) {
-      if (parent->isPrimitive(PRIM_ADDR_OF)) {
+      if (parent->isPrimitive(PRIM_ADDR_OF) || parent->isPrimitive(PRIM_ARRAY_ALLOC)) {
         AvailableMap::iterator ami = available.find(se->symbol());
         if (ami != available.end()) {
           available.erase(ami);


### PR DESCRIPTION
#5398 was buggy, hopefully this fixes it correctly this time.

Passes full std,  --no-denormalize, and --baseline testing and fixes 
the --performance regression for studies/parboil/SAD/sadSerial