### PR TITLE
For locModel=numa, always use libnuma.

### DIFF
--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -54,19 +54,15 @@ GEN_DYNAMIC_FLAG = -dynamic
 LIB_STATIC_FLAG =
 LIB_DYNAMIC_FLAG = -shared
 
-# Determine whether we need libnuma.  No static version of it is available.
-# If memkind is loaded, we need libnuma, and linking defaults to dynamic.
-# Otherwise, if the locale model is not flat, we need libnuma, and
-# linking must be forced to dynamic.
-ifneq (,$(CRAY_MEMKIND))
-CHPL_HWLOC_MORE_CFG_OPTIONS += --enable-libnuma
-else ifneq ($(CHPL_MAKE_LOCALE_MODEL), flat)
-CHPL_HWLOC_MORE_CFG_OPTIONS += --enable-libnuma
+# With locale models other than 'flat' we will need libnuma.  That is
+# so far available only in .so form, but the PrgEnv compilers default
+# to forcing static linking.  So, override them in this case.
+ifneq ($(CHPL_MAKE_LOCALE_MODEL), flat)
 RUNTIME_LFLAGS += -dynamic
 endif
 
 # Don't throw e.g. -march with a PrgEnv compiler since the PrgEnv environment
-# will take care of that Since we want to be able to get other flags from e.g.
+# will take care of that. Since we want to be able to get other flags from e.g.
 # Makefile.intel, here we replace SPECIALIZE_CFLAGS with nothing.
 SPECIALIZE_CFLAGS =
 

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -27,9 +27,14 @@ CHPL_HWLOC_CFG_OPTIONS += --enable-static \
                           --disable-cairo \
                           --disable-libxml2 \
                           --disable-libudev \
-                          --disable-libnuma \
                           --disable-opencl \
                           --disable-pci
+
+ifeq ($(CHPL_MAKE_LOCALE_MODEL),flat)
+CHPL_HWLOC_CFG_OPTIONS += --disable-libnuma
+else
+CHPL_HWLOC_CFG_OPTIONS += --enable-libnuma
+endif
 
 CHPL_HWLOC_CFG_OPTIONS += $(CHPL_HWLOC_MORE_CFG_OPTIONS)
 

--- a/util/chplenv/chpl_3p_hwloc_configs.py
+++ b/util/chplenv/chpl_3p_hwloc_configs.py
@@ -4,13 +4,14 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import third_party_utils
+import chpl_locale_model, third_party_utils
 from utils import memoize
 
 
 @memoize
 def get_uniq_cfg_path():
-    return third_party_utils.default_uniq_cfg_path()
+    return '{0}-{1}'.format(third_party_utils.default_uniq_cfg_path(),
+                            chpl_locale_model.get())
 
 @memoize
 def get_link_args():

--- a/util/start_test
+++ b/util/start_test
@@ -679,11 +679,16 @@ def set_up_environment():
         args.performance = True
         args.gen_graphs = True
         args.compopts += " --fast"
-        # Force static linking unless the target requires dynamic.
-        if (tgt_platform != 'darwin' and
-            not (chpl_compiler.get('target').startswith("cray-prgenv") and
-                 (os.getenv("CRAY_MEMKIND", "") != "" or
-                  chpl_locale_model.get() != 'flat'))):
+        # Force static linking except where that won't work:
+        # - MacOS (darwin) targets
+        # - large Cray systems (proxied by cray-prgenv compilers here)
+        #   when the memkind package is being used (KNL, e.g.)
+        # - any locale model other than 'flat' (because we'll need
+        #   libnuma which is only available as a .so)
+        if (not (tgt_platform == 'darwin' or
+                 (chpl_compiler.get('target').startswith("cray-prgenv") and
+                  os.getenv("CRAY_MEMKIND", "") != "") or
+                 chpl_locale_model.get() != 'flat')):
             args.compopts += " --static"
 
     if args.performance_configs:


### PR DESCRIPTION
The primary change here is to change third-party/hwloc/Makefile to
disable libnuma in hwloc configuration for the flat locale model, and
enable it for all others.  This allows hwloc to be used to set and query
NUMA memory locality, among other things.  Since we now configure hwloc
differently for different locale models, we also make a change here to
include the locale model in the hwloc unique config path.

This in turn allows simplifying make/compiler/Makefile.cray-prgenv,
which essentially made the identical decision for hwloc configurations
but only with Cray PrgEnv target compilers.

Finally, there's a similar adjustment to util/start_test, where it
decides whether having been given -performance should cause it to throw
--static to the compiler.  It used to do that for non-flat locale models
only if a Cray PrgEnv target compiler was being used.  Now the target
compiler doesn't matter.