### PR TITLE
Make Math.conjg more robust

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -371,10 +371,10 @@ module Math {
 
      :rtype: A complex number of the same type as `z`.
   */
-  inline proc conjg(z: ?t) where isComplex(z) {
+  inline proc conjg(z: complex(?w)) {
     extern proc conjf(z: complex(64)): complex(64);
     extern proc conj(z: complex(128)): complex(128);
-    if numBits(t) == 64 then
+    if w == 64 then
       return conjf(z);
     else
       return conj(z);
@@ -384,7 +384,7 @@ module Math {
 
      :rtype: An imaginary number of the same type as `z`.
   */
-  inline proc conjg(z) where isImag(z) {
+  inline proc conjg(z: imag(?w)) {
     return -z;
   }
 
@@ -392,10 +392,17 @@ module Math {
 
      :rtype: A number that is not complex or imaginary of the same type as `z`.
   */
-  inline proc conjg(z) where isIntegral(z) || isReal(z) {
+  inline proc conjg(z: int(?w)) {
     return z;
   }
 
+  inline proc conjg(z: uint(?w)) {
+    return z;
+  }
+
+  inline proc conjg(z: real(?w)) {
+    return z;
+  }
 
   /* Returns the projection of `z` on a Riemann sphere. */
   inline proc cproj(z: complex(?w)): real(w/2) {

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -103,7 +103,7 @@ module Math {
     return result;
   }
 
-  // 
+  //
   //////////////////////////////////////////////////////////////////////////
 
 
@@ -367,17 +367,34 @@ module Math {
   }
 
 
-  /* Returns the complex conjugate of the argument `z`.
+  /* Returns the complex conjugate of the complex argument `z`.
 
      :rtype: A complex number of the same type as `z`.
   */
-  inline proc conjg(z: complex(?w)): complex(w) {
+  inline proc conjg(z: complex(?w)) where isComplexType(z.type): complex(w)
+  {
     extern proc conjf(z: complex(64)): complex(64);
     extern proc conj(z: complex(128)): complex(128);
     if w == 64 then
       return conjf(z);
     else
       return conj(z);
+  }
+
+  /* Returns the complex conjugate of the imaginary argument `z`.
+
+     :rtype: An imaginary number of the same type as `z`.
+  */
+  inline proc conjg(z: imag(?w)) {
+    return -z;
+  }
+
+  /* Returns value `z`.
+
+     :rtype: A number that is not complex or imaginary of the same type as `z`.
+  */
+  inline proc conjg(z: ?t) where isNumericType(t) {
+    return z;
   }
 
 
@@ -437,7 +454,7 @@ module Math {
 
 
   /* Returns :proc:`ceil`\(`m`/`n`),
-     i.e., the fraction `m`/`n` rounded up to the nearest integer. 
+     i.e., the fraction `m`/`n` rounded up to the nearest integer.
 
      If the arguments are of unsigned type, then
      fewer conditionals will be evaluated at run time.
@@ -451,7 +468,7 @@ module Math {
       else                     (m + n + 1) / n;
 
   /* Returns :proc:`ceil`\(`m`/`n`),
-     i.e., the fraction `m`/`n` rounded up to the nearest integer. 
+     i.e., the fraction `m`/`n` rounded up to the nearest integer.
 
      If the arguments are of unsigned type, then
      fewer conditionals will be evaluated at run time.
@@ -682,7 +699,7 @@ module Math {
   extern proc log10(x: real(64)): real(64);
 
   /* Returns the base 10 logarithm of the argument `x`.
-     
+
      It is an error if `x` is less than or equal to zero.
   */
   inline proc log10(x : real(32)): real(32) {
@@ -760,7 +777,7 @@ module Math {
   }
 
   /* Returns the base 2 logarithm of the argument `x`.
-     
+
      :rtype: `int(64)`
 
      It is an error if `x` is less than or equal to zero.
@@ -814,7 +831,7 @@ module Math {
   }
 
   /* Computes the mod operator on the two numbers, defined as
-     ``mod(x,y) = x - y * floor(x / y)``. 
+     ``mod(x,y) = x - y * floor(x / y)``.
 
      The return value has the same type as `x`.
   */
@@ -940,7 +957,7 @@ module Math {
   }
 
 
-  /* Returns the square root of the argument `x`.  
+  /* Returns the square root of the argument `x`.
 
      It is an error if the `x` is less than zero.
   */

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -371,11 +371,10 @@ module Math {
 
      :rtype: A complex number of the same type as `z`.
   */
-  inline proc conjg(z: complex(?w)) where isComplexType(z.type): complex(w)
-  {
+  inline proc conjg(z: ?t) where isComplex(z) {
     extern proc conjf(z: complex(64)): complex(64);
     extern proc conj(z: complex(128)): complex(128);
-    if w == 64 then
+    if numBits(t) == 64 then
       return conjf(z);
     else
       return conj(z);
@@ -385,7 +384,7 @@ module Math {
 
      :rtype: An imaginary number of the same type as `z`.
   */
-  inline proc conjg(z: imag(?w)): imag(w) {
+  inline proc conjg(z) where isImag(z) {
     return -z;
   }
 
@@ -393,7 +392,7 @@ module Math {
 
      :rtype: A number that is not complex or imaginary of the same type as `z`.
   */
-  inline proc conjg(z: ?t) where isNumericType(t) {
+  inline proc conjg(z) where isIntegral(z) || isReal(z) {
     return z;
   }
 

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -385,11 +385,11 @@ module Math {
 
      :rtype: An imaginary number of the same type as `z`.
   */
-  inline proc conjg(z: imag(?w)) {
+  inline proc conjg(z: imag(?w)): imag(w) {
     return -z;
   }
 
-  /* Returns value `z`.
+  /* Returns the argument `z`.
 
      :rtype: A number that is not complex or imaginary of the same type as `z`.
   */

--- a/test/modules/standard/math/conjg.chpl
+++ b/test/modules/standard/math/conjg.chpl
@@ -1,0 +1,26 @@
+use Math;
+
+// Type tests
+typetest(complex(64));
+typetest(complex(128));
+typetest(imag(32));
+typetest(imag(64));
+typetest(real(32));
+typetest(real(64));
+typetest(int(32));
+typetest(int(64));
+typetest(uint(8));
+typetest(uint(16));
+typetest(uint(32));
+typetest(uint(64));
+
+
+/* Check that input type always matches output type */
+proc typetest(type t) {
+  var input: t;
+  var output = conjg(input);
+  if input.type != output.type {
+    writeln('Failed on type ', input.type:string,
+            ', received: ', output.type:string);
+  }
+}


### PR DESCRIPTION
Due to coercion rules, `Math.conjg` (complex conjugate) accepts any numeric type and always returns a `complex(64)` or `complex(128)` type. This means programs that support many numeric types and use `conjg` must often cast the result of `conjg` back to the type of the input.

Consider a simple generic L-2 `norm()` implementation that doesn't rely on the `abs` function:

Today, this might look like:

```chapel
/* Take the L-2 vector norm of a vector with coordinates x and y. */
proc norm(x: ?t, y: ?t) where isNumeric(x) && isNumeric(y) {
    return sqrt((conjg(x): t)*x + (conjg(y): t)*y);
}
```

With this change, it could look like:
```chapel
/* Take the L-2 vector norm of a vector with coordinates x and y. */
proc norm(x, y) where isNumeric(x) && isNumeric(y) {
    return sqrt(conjg(x)*x + conjg(y)*y);
}
```

This PR ensures the `conjg` function always has the same return type as the argument type.



### Testing

- [x] linux64 testing *passed*
