### PR TITLE
Make the FFTW includes and libraries param strings

### DIFF
--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -88,13 +88,15 @@
 
 module FFTW {
 
-  // Define includes and libraries
-  config param FFTW_includes : string ="fftw3.h";
-  config param FFTW_libraries : string ="-lfftw3";
+  // The MKL implementation of FFTW requires an additional
+  // include file
+  config param isFFTW_MKL=false;
 
   use SysCTypes;
-  require FFTW_includes, FFTW_libraries;
-
+  require "fftw3.h"; // This is common
+  if (isFFTW_MKL) {
+    require "fftw3_mkl.h";
+  }
 
   /*
     Controls execution-time array size checks in the FFTW

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -36,16 +36,19 @@
 
   2. Add ``use FFTW;`` to your Chapel code.
 
-  3. Include the appropriate libraries in your compilation command. For
-     a standard FFTW installation, this may be as simple as including
-     ``-lfftw3`` when compiling. You may also need to use the ``-I`` and
-     ``-L`` flags to specify the locations of the header and library files.
+  3. Include the appropriate libraries in your compilation command.
 
-  .. note::
-   To use the MKL FFTW wrappers, compile with ``-sisFFTW_MKL`` to include
-   the ``fftw3_mkl.h`` header in addition to the usual ``fftw3.h`` header
-   file. You may also need to add ``-I${MKLROOT}/include/fftw`` to point the
-   compiler to the location of these header files.
+     a. For a standard FFTW installation, this may be as simple as including
+        ``-lfftw3`` when compiling. You may also need to use the ``-I`` and
+        ``-L`` flags to specify the locations of the header and library files
+        if these are in non-standard locations.
+
+     b. *Intel MKL* : To use the MKL FFTW wrappers, compile with ``-sisFFTW_MKL`` to include
+        the ``fftw3_mkl.h`` header in addition to the usual ``fftw3.h`` header
+        file. You may also need to add ``-I${MKLROOT}/include/fftw`` to point the
+        compiler to the location of these header files. Refer to the Intel MKL
+        documentation for the appropriate libraries to include.
+
 
   As in standard FFTW usage, the flow is to:
 

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -29,17 +29,23 @@
 
   To use this module:
 
-  1. Ensure that FFTW (version 3) is installed on your system and that
-     the header and library files (e.g., fftw3.h, libfftw3.*) are
-     either installed in a standard system location or that your C
-     compiler's environment variables are set up to find them
-     (alternatively, the Chapel compiler's ``-I`` and ``-L`` flags can
-     be used to specify these locations).
+  1. Ensure that FFTW (version 3) is installed on your system. The
+     current version of the Chapel module only supports double precision ``real(64)``
+     transforms. We do support using the FFTW compatible wrappers provided
+     by the Intel Math Kernel Library (MKL) (see below for usage).
 
   2. Add ``use FFTW;`` to your Chapel code.
 
-  3. Compile and run your Chapel program as usual.
+  3. Include the appropriate libraries in your compilation command. For
+     a standard FFTW installation, this may be as simple as including
+     ``-lfftw3`` when compiling. You may also need to use the ``-I`` and
+     ``-L`` flags to specify the locations of the header and library files.
 
+  .. note::
+   To use the MKL FFTW wrappers, compile with ``-sisFFTW_MKL`` to include
+   the ``fftw3_mkl.h`` header in addition to the usual ``fftw3.h`` header
+   file. You may also need to add ``-I${MKLROOT}/include/fftw`` to point the
+   compiler to the location of these header files.
 
   As in standard FFTW usage, the flow is to:
 
@@ -88,8 +94,10 @@
 
 module FFTW {
 
-  // The MKL implementation of FFTW requires an additional
-  // include file
+  /*
+    Set this to `true` if you are using the Intel MKL FFTW
+    wrappers
+  */
   config param isFFTW_MKL=false;
 
   use SysCTypes;

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -89,7 +89,7 @@
 module FFTW {
 
   // Define includes and libraries
-  config param FFTW_includes : string ="fftw/fftw3.h, fftw/fftw3_mkl.h";
+  config param FFTW_includes : string ="fftw3.h";
   config param FFTW_libraries : string ="-lfftw3";
 
   use SysCTypes;

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -88,8 +88,12 @@
 
 module FFTW {
 
+  // Define includes and libraries
+  config param FFTW_includes : string ="fftw/fftw3.h, fftw/fftw3_mkl.h";
+  config param FFTW_libraries : string ="-lfftw3";
+
   use SysCTypes;
-  require "fftw3.h", "-lfftw3";
+  require FFTW_includes, FFTW_libraries;
 
 
   /*

--- a/test/modules/standard/FFTW/COMPOPTS
+++ b/test/modules/standard/FFTW/COMPOPTS
@@ -1,1 +1,1 @@
--I$FFTW_DIR/include -L$FFTW_DIR/lib
+-I$FFTW_DIR/include -L$FFTW_DIR/lib -lfftw3

--- a/test/release/examples/primers/FFTWlib.compopts
+++ b/test/release/examples/primers/FFTWlib.compopts
@@ -1,1 +1,1 @@
--I$FFTW_DIR/include -L$FFTW_DIR/lib
+-I$FFTW_DIR/include -L$FFTW_DIR/lib -lfftw3

--- a/test/users/npadmana/fftw/testFFTW_MT.compopts
+++ b/test/users/npadmana/fftw/testFFTW_MT.compopts
@@ -1,1 +1,1 @@
--I$FFTW_DIR/include -L$FFTW_DIR/lib -M../../../release/examples/primers
+-I$FFTW_DIR/include -L$FFTW_DIR/lib -M../../../release/examples/primers -lfftw3


### PR DESCRIPTION
The PR has two changes to the FFTW module --

1. It removes the explicit require command for the FFTW libraries. This allows the user to link in different
versions of FFT libraries (which may, eg., be machine dependent), as long as they conform to the FFTW3 calling definitions. An example here is the Intel MKL, which provides FFTW3 compatible wrappers. 

A side benefit of this is that it will allow us to merge the FFTW and FFTW_MT modules. 

2. We've added in a switch for the Intel MKL wrappers, which includes the additional MKL header files. Compiling with `-sisFFTW_MKL` includes these headers.

------------------------------------------------------------------------------------------------------
(The original PR comment is below, for archival purposes)

The current FFTW module has hardcoded strings to specify its include and library dependencies. This makes using a different FFTW implementation (eg. the MKL version) harder, since the libraries are different and there are additional include files.

This pull request makes these param strings, defaulting to their original values. One can now change these at compile time. For the default values, this passes the tests test/release/examples/primers

Trying this on the MKL version, there were a few surprises here. I required the following compile command

```
 chpl -o FFTWlib FFTWlib.chpl  \
   -sFFTW_includes='"fftw3_mkl.h"' \
   -sFFTW_includes='"fftw3.h"' \
   -sFFTW_libraries='"-lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl"'  \
   -I$MKLROOT/include/fftw
```

1. Note that I needed to double-quote the filenames, otherwise I got an undefined symbol error.
2. I could not figure out how to put both includes in one string. Using 
   '"fftw3_mkl.h","fftw3.h"' resulted in a 
 Command-line arg (FFTW_includes): syntax error parsing '"fftw/fftw3.h","fftw/fftw3_mkl.h"'

  '"fftw3_mkl.h fftw3.h"' or '"fftw3_mkl.h, fftw3.h"' 
resulted in a file not found.  

Somewhat surprising to me was the fact that putting each in its own option worked; I'm guessing that the semantics for these parameters concatenates strings.

3. Interestingly, for the libraries, putting the full list in one string worked fine. 

In putting this together, I couldn't seem to find the syntax for require described anywhere... 

If we like this solution, we can update the multi-threaded version as well, as well as BLAS/LAPACK.

@bradcray, @ben-albrecht --- this might interest you.
