### PR TITLE
Let hwloc auto-detect libnuma for non-flat locModels; don't force it.

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -30,10 +30,10 @@ CHPL_HWLOC_CFG_OPTIONS += --enable-static \
                           --disable-opencl \
                           --disable-pci
 
+# Libnuma requires dynamic linking, so for the flat locale model where
+# we have no need for NUMA info, disable it so we can link statically.
 ifeq ($(CHPL_MAKE_LOCALE_MODEL),flat)
 CHPL_HWLOC_CFG_OPTIONS += --disable-libnuma
-else
-CHPL_HWLOC_CFG_OPTIONS += --enable-libnuma
 endif
 
 CHPL_HWLOC_CFG_OPTIONS += $(CHPL_HWLOC_MORE_CFG_OPTIONS)


### PR DESCRIPTION
This fixes a flaw in #5418 (yesterday).  There I arranged to throw
--enable-libnuma to the hwloc configure step for locale models other
than 'flat'.  But when libnuma is not present on the system, doing so
will cause the configure step to produce an error.  On systems without
libnuma, we want to be able to use such locale models even though they
might be hobbled by the lack of NUMA info.  So instead of insisting that
hwloc use libnuma in this case, just let it auto-detect libnuma, and
we'll get by as best we can if it's not there.