### PR TITLE
Add cast functions to the compiler

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -862,11 +862,11 @@ void AstToText::appendExpr(CallExpr* expr, bool printingType)
         appendExpr(expr->get(1), printingType);
       }
 
-      else if (strcmp(fnName, "_cast")                        == 0)
+      else if (expr->isCast())
       {
-        appendExpr(expr->get(2), printingType);
+        appendExpr(expr->castFrom(), printingType);
         mText += ": ";
-        appendExpr(expr->get(1), printingType);
+        appendExpr(expr->castTo(), printingType);
       }
 
       else if (strcmp(fnName, "chpl__atomicType")             == 0)

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1200,6 +1200,28 @@ FnSymbol* CallExpr::findFnSymbol(void) {
   return fn;
 }
 
+bool CallExpr::isCast(void) {
+  return isNamed("_cast");
+}
+
+Expr* CallExpr::castFrom(void) {
+  INT_ASSERT(isCast());
+
+  return get(2);
+}
+
+Expr* CallExpr::castTo(void) {
+  INT_ASSERT(isCast());
+
+  return get(1);
+}
+
+CallExpr* createCast(BaseAST* src, BaseAST* toType)
+{
+  CallExpr* expr = new CallExpr("_cast", toType, src);
+  return expr;
+}
+
 
 QualifiedType CallExpr::qualType(void) {
   if (primitive)

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2464,7 +2464,7 @@ VarSymbol *new_StringSymbol(const char *str) {
   VarSymbol* castTemp = newTemp("call_tmp");
   CallExpr *castCall = new CallExpr(PRIM_MOVE,
       castTemp,
-      new CallExpr("_cast", cptrTemp, new_CStringSymbol(str)));
+      createCast(new_CStringSymbol(str), cptrTemp));
 
   int strLength = unescapeString(str, castCall).length();
 

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -251,6 +251,10 @@ public:
   // True if the callExpr has been emptied (aka dead)
   bool            isEmpty()                                              const;
 
+  bool            isCast();
+  Expr*           castFrom();
+  Expr*           castTo();
+
   bool            isPrimitive()                                          const;
   bool            isPrimitive(PrimitiveTag primitiveTag)                 const;
   bool            isPrimitive(const char*  primitiveName)                const;
@@ -453,6 +457,8 @@ CallExpr* callChplHereFree(BaseAST* p);
        e = (e != last) ? getNextExpr(e) : NULL)
 
 Expr* getNextExpr(Expr* expr);
+
+CallExpr* createCast(BaseAST* src, BaseAST* toType);
 
 Expr* new_Expr(const char* format, ...);
 Expr* new_Expr(const char* format, va_list vl);

--- a/compiler/parser/bison-chapel.cpp
+++ b/compiler/parser/bison-chapel.cpp
@@ -7806,7 +7806,7 @@ yyreduce:
 
 /* Line 1806 of yacc.c  */
 #line 1535 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("_cast", (yyvsp[(3) - (3)].pexpr), (yyvsp[(1) - (3)].pexpr)); }
+    { (yyval.pexpr) = createCast((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
     break;
 
   case 386:

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -1532,7 +1532,7 @@ expr:
 | TLP TDOTDOTDOT expr TRP
     { $$ = new CallExpr(PRIM_TUPLE_EXPAND, $3); }
 | expr TCOLON expr
-    { $$ = new CallExpr("_cast", $3, $1); }
+    { $$ = createCast($1, $3); }
 | expr TDOTDOT expr
     { $$ = new CallExpr("chpl_build_bounded_range", $1, $3); }
 | expr TDOTDOT

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -187,9 +187,17 @@ static void change_cast_in_where(FnSymbol* fn) {
     collect_asts(fn->where, asts);
     for_vector(BaseAST, ast, asts) {
       if (CallExpr* call = toCallExpr(ast)) {
-        if (call->isNamed("_cast")) {
-          call->primitive = primitives[PRIM_IS_SUBTYPE];
-          call->baseExpr->remove();
+        if (call->isCast()) {
+          CallExpr* isSubtype;
+          Expr* to = call->castTo();
+          Expr* from = call->castFrom();
+          // now remove to and from so we can add them
+          // again as arguments. Don't interleave the
+          // remove with the calls to castTo and castFrom.
+          to->remove();
+          from->remove();
+          isSubtype = new CallExpr(PRIM_IS_SUBTYPE, to, from);
+          call->replace(isSubtype);
         }
       }
     }

--- a/compiler/passes/expandExternArrayCalls.cpp
+++ b/compiler/passes/expandExternArrayCalls.cpp
@@ -116,9 +116,9 @@ void expandExternArrayCalls() {
           } else {
             // Generic array, replace with (c_ptr(eltType)):c_void_ptr
             externCall->argList.insertAtTail(
-                new CallExpr("_cast",
-                  new UnresolvedSymExpr("c_void_ptr"),
-                  new CallExpr("c_ptrTo", new SymExpr(formal))));
+                createCast(
+                  new CallExpr("c_ptrTo", new SymExpr(formal)),
+                  new UnresolvedSymExpr("c_void_ptr")));
           }
         } else {
           externCall->argList.insertAtTail(new SymExpr(formal));

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1340,7 +1340,7 @@ static void normalizeConfigVariableDefinition(DefExpr* defExpr) {
       init_typed_var(var, type, insert, varTmp);
 
     } else if (var->hasFlag(FLAG_PARAM) == true) {
-      CallExpr* cast = new CallExpr("_cast", type->remove(), init->remove());
+      CallExpr* cast = createCast(init->remove(), type->remove());
 
       insert->insertAfter(new CallExpr(PRIM_MOVE, var, cast));
 
@@ -1539,7 +1539,7 @@ static void normalizeVariableDefinition(DefExpr* defExpr) {
 
   } else if (type != NULL && init != NULL) {
     if (var->hasFlag(FLAG_PARAM) == true) {
-      CallExpr* cast = new CallExpr("_cast", type->remove(), init->remove());
+      CallExpr* cast = createCast(init->remove(), type->remove());
 
       defExpr->insertAfter(new CallExpr(PRIM_MOVE, var, cast));
 

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -594,7 +594,7 @@ instantiate_tuple_cast(FnSymbol* fn)
       element = new VarSymbol(astr("elt_", name), toField->type);
       block->insertAtTail(new DefExpr(element));
 
-      CallExpr* cast = new CallExpr("_cast", toField->type->symbol, readF);
+      CallExpr* cast = createCast(readF, toField->type->symbol);
       block->insertAtTail(new CallExpr(PRIM_MOVE, element, cast));
     } else if (isReferenceType(toField->type)) {
       // fromField: ref(t)  toField : ref(t)

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -698,7 +698,7 @@ static void addArgCoercion(FnSymbol*  fn,
 
   if (castCall == NULL) {
     // the common case
-    castCall = new CallExpr("_cast", fts, prevActual);
+    castCall = createCast(prevActual, fts);
 
     if (isString(fts))
       castTemp->addFlag(FLAG_INSERT_AUTO_DESTROY);


### PR DESCRIPTION
Adds createCast, isCast, castFrom, castTo functions to simplify working with "_cast" AST in the compiler.

This should not have any behavior impact and is merely a refactoring. It enables work towards user-defined coercions, in which we will probably change the name of "_cast" to something else.

Passed full local testing.

Reviewed by @vasslitvinov - thanks!