### PR TITLE
Test array API on views

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1013,7 +1013,8 @@ module ChapelArray {
     pragma "no doc"
     proc this(args ...rank) where _validRankChangeArgs(args, _value.idxType) {
       var ranges = _getRankChangeRanges(args);
-      param newRank = ranges.size, stridable = chpl__anyStridable(ranges);
+      param newRank = ranges.size,
+            stridable = chpl__anyStridable(ranges) || this.stridable;
       var newRanges: newRank*range(idxType=_value.idxType, stridable=stridable);
       var newDistVal = _value.dist.dsiCreateRankChangeDist(newRank, args);
       var sameDist = (newDistVal == _value.dist);
@@ -2047,7 +2048,8 @@ module ChapelArray {
       if boundsChecking then
         checkRankChange(args);
       var ranges = _getRankChangeRanges(args);
-      param rank = ranges.size, stridable = chpl__anyStridable(ranges);
+      param rank = ranges.size,
+            stridable = chpl__anyStridable(ranges) || this._value.stridable;
       pragma "no auto destroy" var d = _dom((...args));
       d._value._free_when_no_arrs = true;
       var a = _value.dsiRankChange(d._value, rank, stridable, args);
@@ -2336,7 +2338,7 @@ module ChapelArray {
     // documentation. Don't document it for now.
     pragma "no doc"
     proc head(): this._value.eltType {
-      return this[this.domain.low];
+      return this[this.domain.alignedLow];
     }
 
     /* Return the last value in the array */
@@ -2344,7 +2346,7 @@ module ChapelArray {
     // documentation. Don't document it for now.
     pragma "no doc"
     proc tail(): this._value.eltType {
-      return this[this.domain.high];
+      return this[this.domain.alignedHigh];
     }
 
     /* Return a range that is grown or shrunk from r to accommodate 'r2' */

--- a/test/arrays/userAPI/arrayAPItest.chpl
+++ b/test/arrays/userAPI/arrayAPItest.chpl
@@ -41,9 +41,9 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
   writeln();
 
   // Test read access via tuples and varargs
-  writeln("low element is: ", X[X.domain.low]);
+  writeln("low element is: ", X[X.domain.alignedLow]);
   if (X.rank > 1) then
-    writeln("high element is: ", X[(...X.domain.high)]);
+    writeln("high element is: ", X[(...X.domain.alignedHigh)]);
   writeln();
 
   // Test local write accesses via tuples and varargs
@@ -58,9 +58,9 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
   writeln();
 
   // Test read access via tuples and varargs
-  writeln("low element is: ", X.localAccess[X.domain.low]);
+  writeln("low element is: ", X.localAccess[X.domain.alignedLow]);
   if (X.rank > 1) then
-    writeln("high element is: ", X.localAccess[(...X.domain.high)]);
+    writeln("high element is: ", X.localAccess[(...X.domain.alignedHigh)]);
   writeln();
 
   // Test serial iteration
@@ -101,8 +101,8 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
   writeln("is empty: ", X.isEmpty());
   writeln("head: ", X.head());
   writeln("tail: ", X.tail());
-  writeln("find last: ", X.find(X[X.domain.high]));
-  writeln("count last: ", X.count(X[X.domain.high]));
+  writeln("find last: ", X.find(X[X.domain.alignedHigh]));
+  writeln("count last: ", X.count(X[X.domain.alignedHigh]));
   var Y = X;
   writeln("equals same: ", X.equals(Y));
   var Z = X + 0.1;
@@ -111,8 +111,8 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
 
   // Test views
   writeln("slice by ", sliceDom, ":\n", X[sliceDom]);
-  writeln("rank change 1: ", X[X.domain.low(1), ..]);
-  writeln("rank change 2: ", X[sliceDom.dim(1), X.domain.high(2)]);
+  writeln("rank change 1: ", X[X.domain.alignedLow(1), ..]);
+  writeln("rank change 2: ", X[sliceDom.dim(1), X.domain.alignedHigh(2)]);
   for (i,x) in zip(reindexDom, X.reindex(reindexDom)) do
     writeln("reindexed X[", i, "] = ", x);
   writeln();

--- a/test/arrays/userAPI/rankChangeOps3to2D.chpl
+++ b/test/arrays/userAPI/rankChangeOps3to2D.chpl
@@ -1,0 +1,7 @@
+use arrayAPItest;
+
+var A: [0..5, 1..6, 1..4] real;
+
+testArrayAPI2D("rank change slice (dims 1-2)", A[1..4, 1..4, 2], {2..3, 3..4}, {0..3, 1..8 by 2});
+testArrayAPI2D("rank change slice (dims 2-3)", A[5, 1..4, ..], {2..3, 3..4}, {0..3, 1..8 by 2});
+testArrayAPI2D("rank change slice (dims 1&3)", A[1..4, 3, ..], {2..3, 3..4}, {0..3, 1..8 by 2});

--- a/test/arrays/userAPI/rankChangeOps3to2D.good
+++ b/test/arrays/userAPI/rankChangeOps3to2D.good
@@ -1,0 +1,336 @@
+rank change slice (dims 1-2)
+----------------
+eltType is: real(64)
+idxType is: int(64)
+rank is: 2
+
+size is: 16
+numElements is: 16
+shape is: (4, 4)
+
+X is:
+1.0 2.0 3.0 4.0
+5.0 6.0 7.0 8.0
+9.0 10.0 11.0 12.0
+13.0 14.0 15.0 16.0
+
+X's representation:
+off=(1, 1)
+blk=(24, 4)
+str=(1, 1)
+origin=25
+factoredOffs=28
+noinit_data=true
+
+X is:
+1.1 2.1 3.1 4.1
+5.1 6.1 7.1 8.1
+9.1 10.1 11.1 12.1
+13.1 14.1 15.1 16.1
+
+X is:
+1.2 2.2 3.2 4.2
+5.2 6.2 7.2 8.2
+9.2 10.2 11.2 12.2
+13.2 14.2 15.2 16.2
+
+low element is: 1.2
+high element is: 16.2
+
+X is:
+1.3 2.3 3.3 4.3
+5.3 6.3 7.3 8.3
+9.3 10.3 11.3 12.3
+13.3 14.3 15.3 16.3
+
+X is:
+1.4 2.4 3.4 4.4
+5.4 6.4 7.4 8.4
+9.4 10.4 11.4 12.4
+13.4 14.4 15.4 16.4
+
+low element is: 1.4
+high element is: 16.4
+
+X is:
+1.5 2.5 3.5 4.5
+5.5 6.5 7.5 8.5
+9.5 10.5 11.5 12.5
+13.5 14.5 15.5 16.5
+
+X is:
+1.6 2.6 3.6 4.6
+5.6 6.6 7.6 8.6
+9.6 10.6 11.6 12.6
+13.6 14.6 15.6 16.6
+
+X is:
+1.7 2.7 3.7 4.7
+5.7 6.7 7.7 8.7
+9.7 10.7 11.7 12.7
+13.7 14.7 15.7 16.7
+
+X is:
+1.8 2.8 3.8 4.8
+5.8 6.8 7.8 8.8
+9.8 10.8 11.8 12.8
+13.8 14.8 15.8 16.8
+
+local subdomain: {1..4, 1..4}
+local subdomains:
+{1..4, 1..4}
+
+is empty: false
+head: 1.8
+tail: 16.8
+find last: (true, (4, 4))
+count last: 1
+equals same: true
+equals diff: false
+
+slice by {2..3, 3..4}:
+7.8 8.8
+11.8 12.8
+rank change 1: 1.8 2.8 3.8 4.8
+rank change 2: 8.8 12.8
+reindexed X[(0, 1)] = 1.8
+reindexed X[(0, 3)] = 2.8
+reindexed X[(0, 5)] = 3.8
+reindexed X[(0, 7)] = 4.8
+reindexed X[(1, 1)] = 5.8
+reindexed X[(1, 3)] = 6.8
+reindexed X[(1, 5)] = 7.8
+reindexed X[(1, 7)] = 8.8
+reindexed X[(2, 1)] = 9.8
+reindexed X[(2, 3)] = 10.8
+reindexed X[(2, 5)] = 11.8
+reindexed X[(2, 7)] = 12.8
+reindexed X[(3, 1)] = 13.8
+reindexed X[(3, 3)] = 14.8
+reindexed X[(3, 5)] = 15.8
+reindexed X[(3, 7)] = 16.8
+
+rank change slice (dims 2-3)
+----------------
+eltType is: real(64)
+idxType is: int(64)
+rank is: 2
+
+size is: 16
+numElements is: 16
+shape is: (4, 4)
+
+X is:
+1.0 2.0 3.0 4.0
+5.0 6.0 7.0 8.0
+9.0 10.0 11.0 12.0
+13.0 14.0 15.0 16.0
+
+X's representation:
+off=(1, 1)
+blk=(4, 1)
+str=(1, 1)
+origin=120
+factoredOffs=5
+noinit_data=true
+
+X is:
+1.1 2.1 3.1 4.1
+5.1 6.1 7.1 8.1
+9.1 10.1 11.1 12.1
+13.1 14.1 15.1 16.1
+
+X is:
+1.2 2.2 3.2 4.2
+5.2 6.2 7.2 8.2
+9.2 10.2 11.2 12.2
+13.2 14.2 15.2 16.2
+
+low element is: 1.2
+high element is: 16.2
+
+X is:
+1.3 2.3 3.3 4.3
+5.3 6.3 7.3 8.3
+9.3 10.3 11.3 12.3
+13.3 14.3 15.3 16.3
+
+X is:
+1.4 2.4 3.4 4.4
+5.4 6.4 7.4 8.4
+9.4 10.4 11.4 12.4
+13.4 14.4 15.4 16.4
+
+low element is: 1.4
+high element is: 16.4
+
+X is:
+1.5 2.5 3.5 4.5
+5.5 6.5 7.5 8.5
+9.5 10.5 11.5 12.5
+13.5 14.5 15.5 16.5
+
+X is:
+1.6 2.6 3.6 4.6
+5.6 6.6 7.6 8.6
+9.6 10.6 11.6 12.6
+13.6 14.6 15.6 16.6
+
+X is:
+1.7 2.7 3.7 4.7
+5.7 6.7 7.7 8.7
+9.7 10.7 11.7 12.7
+13.7 14.7 15.7 16.7
+
+X is:
+1.8 2.8 3.8 4.8
+5.8 6.8 7.8 8.8
+9.8 10.8 11.8 12.8
+13.8 14.8 15.8 16.8
+
+local subdomain: {1..4, 1..4}
+local subdomains:
+{1..4, 1..4}
+
+is empty: false
+head: 1.8
+tail: 16.8
+find last: (true, (4, 4))
+count last: 1
+equals same: true
+equals diff: false
+
+slice by {2..3, 3..4}:
+7.8 8.8
+11.8 12.8
+rank change 1: 1.8 2.8 3.8 4.8
+rank change 2: 8.8 12.8
+reindexed X[(0, 1)] = 1.8
+reindexed X[(0, 3)] = 2.8
+reindexed X[(0, 5)] = 3.8
+reindexed X[(0, 7)] = 4.8
+reindexed X[(1, 1)] = 5.8
+reindexed X[(1, 3)] = 6.8
+reindexed X[(1, 5)] = 7.8
+reindexed X[(1, 7)] = 8.8
+reindexed X[(2, 1)] = 9.8
+reindexed X[(2, 3)] = 10.8
+reindexed X[(2, 5)] = 11.8
+reindexed X[(2, 7)] = 12.8
+reindexed X[(3, 1)] = 13.8
+reindexed X[(3, 3)] = 14.8
+reindexed X[(3, 5)] = 15.8
+reindexed X[(3, 7)] = 16.8
+
+rank change slice (dims 1&3)
+----------------
+eltType is: real(64)
+idxType is: int(64)
+rank is: 2
+
+size is: 16
+numElements is: 16
+shape is: (4, 4)
+
+X is:
+1.0 2.0 3.0 4.0
+5.0 6.0 7.0 8.0
+9.0 10.0 11.0 12.0
+13.0 14.0 15.0 16.0
+
+X's representation:
+off=(1, 1)
+blk=(24, 1)
+str=(1, 1)
+origin=32
+factoredOffs=25
+noinit_data=true
+
+X is:
+1.1 2.1 3.1 4.1
+5.1 6.1 7.1 8.1
+9.1 10.1 11.1 12.1
+13.1 14.1 15.1 16.1
+
+X is:
+1.2 2.2 3.2 4.2
+5.2 6.2 7.2 8.2
+9.2 10.2 11.2 12.2
+13.2 14.2 15.2 16.2
+
+low element is: 1.2
+high element is: 16.2
+
+X is:
+1.3 2.3 3.3 4.3
+5.3 6.3 7.3 8.3
+9.3 10.3 11.3 12.3
+13.3 14.3 15.3 16.3
+
+X is:
+1.4 2.4 3.4 4.4
+5.4 6.4 7.4 8.4
+9.4 10.4 11.4 12.4
+13.4 14.4 15.4 16.4
+
+low element is: 1.4
+high element is: 16.4
+
+X is:
+1.5 2.5 3.5 4.5
+5.5 6.5 7.5 8.5
+9.5 10.5 11.5 12.5
+13.5 14.5 15.5 16.5
+
+X is:
+1.6 2.6 3.6 4.6
+5.6 6.6 7.6 8.6
+9.6 10.6 11.6 12.6
+13.6 14.6 15.6 16.6
+
+X is:
+1.7 2.7 3.7 4.7
+5.7 6.7 7.7 8.7
+9.7 10.7 11.7 12.7
+13.7 14.7 15.7 16.7
+
+X is:
+1.8 2.8 3.8 4.8
+5.8 6.8 7.8 8.8
+9.8 10.8 11.8 12.8
+13.8 14.8 15.8 16.8
+
+local subdomain: {1..4, 1..4}
+local subdomains:
+{1..4, 1..4}
+
+is empty: false
+head: 1.8
+tail: 16.8
+find last: (true, (4, 4))
+count last: 1
+equals same: true
+equals diff: false
+
+slice by {2..3, 3..4}:
+7.8 8.8
+11.8 12.8
+rank change 1: 1.8 2.8 3.8 4.8
+rank change 2: 8.8 12.8
+reindexed X[(0, 1)] = 1.8
+reindexed X[(0, 3)] = 2.8
+reindexed X[(0, 5)] = 3.8
+reindexed X[(0, 7)] = 4.8
+reindexed X[(1, 1)] = 5.8
+reindexed X[(1, 3)] = 6.8
+reindexed X[(1, 5)] = 7.8
+reindexed X[(1, 7)] = 8.8
+reindexed X[(2, 1)] = 9.8
+reindexed X[(2, 3)] = 10.8
+reindexed X[(2, 5)] = 11.8
+reindexed X[(2, 7)] = 12.8
+reindexed X[(3, 1)] = 13.8
+reindexed X[(3, 3)] = 14.8
+reindexed X[(3, 5)] = 15.8
+reindexed X[(3, 7)] = 16.8
+

--- a/test/arrays/userAPI/reindexOps2D.chpl
+++ b/test/arrays/userAPI/reindexOps2D.chpl
@@ -1,0 +1,5 @@
+use arrayAPItest;
+
+var A: [1..4, 1..4] real;
+
+testArrayAPI2D("array reindex", A.reindex({0..3, 2..9 by 2}), {1..2, 6..9 by 2}, {1..8 by 2, 2..5});

--- a/test/arrays/userAPI/reindexOps2D.good
+++ b/test/arrays/userAPI/reindexOps2D.good
@@ -1,0 +1,112 @@
+array reindex
+----------------
+eltType is: real(64)
+idxType is: int(64)
+rank is: 2
+
+size is: 16
+numElements is: 16
+shape is: (4, 4)
+
+X is:
+1.0 2.0 3.0 4.0
+5.0 6.0 7.0 8.0
+9.0 10.0 11.0 12.0
+13.0 14.0 15.0 16.0
+
+X's representation:
+off=(0, 2)
+blk=(4, 1)
+str=(1, 2)
+origin=0
+factoredOffs=2
+noinit_data=true
+
+X is:
+1.1 2.1 3.1 4.1
+5.1 6.1 7.1 8.1
+9.1 10.1 11.1 12.1
+13.1 14.1 15.1 16.1
+
+X is:
+1.2 2.2 3.2 4.2
+5.2 6.2 7.2 8.2
+9.2 10.2 11.2 12.2
+13.2 14.2 15.2 16.2
+
+low element is: 1.2
+high element is: 16.2
+
+X is:
+1.3 2.3 3.3 4.3
+5.3 6.3 7.3 8.3
+9.3 10.3 11.3 12.3
+13.3 14.3 15.3 16.3
+
+X is:
+1.4 2.4 3.4 4.4
+5.4 6.4 7.4 8.4
+9.4 10.4 11.4 12.4
+13.4 14.4 15.4 16.4
+
+low element is: 1.4
+high element is: 16.4
+
+X is:
+1.5 2.5 3.5 4.5
+5.5 6.5 7.5 8.5
+9.5 10.5 11.5 12.5
+13.5 14.5 15.5 16.5
+
+X is:
+1.6 2.6 3.6 4.6
+5.6 6.6 7.6 8.6
+9.6 10.6 11.6 12.6
+13.6 14.6 15.6 16.6
+
+X is:
+1.7 2.7 3.7 4.7
+5.7 6.7 7.7 8.7
+9.7 10.7 11.7 12.7
+13.7 14.7 15.7 16.7
+
+X is:
+1.8 2.8 3.8 4.8
+5.8 6.8 7.8 8.8
+9.8 10.8 11.8 12.8
+13.8 14.8 15.8 16.8
+
+local subdomain: {0..3, 2..9 by 2}
+local subdomains:
+{0..3, 2..9 by 2}
+
+is empty: false
+head: 1.8
+tail: 16.8
+find last: (true, (3, 8))
+count last: 1
+equals same: true
+equals diff: false
+
+slice by {1..2, 6..9 by 2}:
+7.8 8.8
+11.8 12.8
+rank change 1: 1.8 2.8 3.8 4.8
+rank change 2: 8.8 12.8
+reindexed X[(1, 2)] = 1.8
+reindexed X[(1, 3)] = 2.8
+reindexed X[(1, 4)] = 3.8
+reindexed X[(1, 5)] = 4.8
+reindexed X[(3, 2)] = 5.8
+reindexed X[(3, 3)] = 6.8
+reindexed X[(3, 4)] = 7.8
+reindexed X[(3, 5)] = 8.8
+reindexed X[(5, 2)] = 9.8
+reindexed X[(5, 3)] = 10.8
+reindexed X[(5, 4)] = 11.8
+reindexed X[(5, 5)] = 12.8
+reindexed X[(7, 2)] = 13.8
+reindexed X[(7, 3)] = 14.8
+reindexed X[(7, 4)] = 15.8
+reindexed X[(7, 5)] = 16.8
+

--- a/test/arrays/userAPI/sliceOps2D.chpl
+++ b/test/arrays/userAPI/sliceOps2D.chpl
@@ -1,0 +1,5 @@
+use arrayAPItest;
+
+var A: [0..5, 0..5] real;
+
+testArrayAPI2D("array slice", A[1..4, 1..4], {2..3, 3..4}, {0..3, 1..8 by 2});

--- a/test/arrays/userAPI/sliceOps2D.good
+++ b/test/arrays/userAPI/sliceOps2D.good
@@ -1,0 +1,112 @@
+array slice
+----------------
+eltType is: real(64)
+idxType is: int(64)
+rank is: 2
+
+size is: 16
+numElements is: 16
+shape is: (4, 4)
+
+X is:
+1.0 2.0 3.0 4.0
+5.0 6.0 7.0 8.0
+9.0 10.0 11.0 12.0
+13.0 14.0 15.0 16.0
+
+X's representation:
+off=(1, 1)
+blk=(6, 1)
+str=(1, 1)
+origin=7
+factoredOffs=7
+noinit_data=true
+
+X is:
+1.1 2.1 3.1 4.1
+5.1 6.1 7.1 8.1
+9.1 10.1 11.1 12.1
+13.1 14.1 15.1 16.1
+
+X is:
+1.2 2.2 3.2 4.2
+5.2 6.2 7.2 8.2
+9.2 10.2 11.2 12.2
+13.2 14.2 15.2 16.2
+
+low element is: 1.2
+high element is: 16.2
+
+X is:
+1.3 2.3 3.3 4.3
+5.3 6.3 7.3 8.3
+9.3 10.3 11.3 12.3
+13.3 14.3 15.3 16.3
+
+X is:
+1.4 2.4 3.4 4.4
+5.4 6.4 7.4 8.4
+9.4 10.4 11.4 12.4
+13.4 14.4 15.4 16.4
+
+low element is: 1.4
+high element is: 16.4
+
+X is:
+1.5 2.5 3.5 4.5
+5.5 6.5 7.5 8.5
+9.5 10.5 11.5 12.5
+13.5 14.5 15.5 16.5
+
+X is:
+1.6 2.6 3.6 4.6
+5.6 6.6 7.6 8.6
+9.6 10.6 11.6 12.6
+13.6 14.6 15.6 16.6
+
+X is:
+1.7 2.7 3.7 4.7
+5.7 6.7 7.7 8.7
+9.7 10.7 11.7 12.7
+13.7 14.7 15.7 16.7
+
+X is:
+1.8 2.8 3.8 4.8
+5.8 6.8 7.8 8.8
+9.8 10.8 11.8 12.8
+13.8 14.8 15.8 16.8
+
+local subdomain: {1..4, 1..4}
+local subdomains:
+{1..4, 1..4}
+
+is empty: false
+head: 1.8
+tail: 16.8
+find last: (true, (4, 4))
+count last: 1
+equals same: true
+equals diff: false
+
+slice by {2..3, 3..4}:
+7.8 8.8
+11.8 12.8
+rank change 1: 1.8 2.8 3.8 4.8
+rank change 2: 8.8 12.8
+reindexed X[(0, 1)] = 1.8
+reindexed X[(0, 3)] = 2.8
+reindexed X[(0, 5)] = 3.8
+reindexed X[(0, 7)] = 4.8
+reindexed X[(1, 1)] = 5.8
+reindexed X[(1, 3)] = 6.8
+reindexed X[(1, 5)] = 7.8
+reindexed X[(1, 7)] = 8.8
+reindexed X[(2, 1)] = 9.8
+reindexed X[(2, 3)] = 10.8
+reindexed X[(2, 5)] = 11.8
+reindexed X[(2, 7)] = 12.8
+reindexed X[(3, 1)] = 13.8
+reindexed X[(3, 3)] = 14.8
+reindexed X[(3, 5)] = 15.8
+reindexed X[(3, 7)] = 16.8
+

--- a/test/arrays/vectorOps/headTailStrided.chpl
+++ b/test/arrays/vectorOps/headTailStrided.chpl
@@ -1,0 +1,14 @@
+var D = {1..4} by 2;
+var D2 = {1..4} by -2;
+
+var A: [D] real;
+var A2: [D2] real;
+
+for i in D do
+  A[i] = i / 10.0;
+
+for i in D2 do
+  A2[i] = i / 10.0;
+
+writeln("head/tail of A: ", (A.head(), A.tail()));
+writeln("head/tail of A2: ", (A2.head(), A2.tail()));

--- a/test/arrays/vectorOps/headTailStrided.good
+++ b/test/arrays/vectorOps/headTailStrided.good
@@ -1,0 +1,2 @@
+head/tail of A: 0.10.3
+head/tail of A2: 0.20.4

--- a/test/arrays/vectorOps/headTailStrided.good
+++ b/test/arrays/vectorOps/headTailStrided.good
@@ -1,2 +1,2 @@
-head/tail of A: 0.10.3
-head/tail of A2: 0.20.4
+head/tail of A: (0.1, 0.3)
+head/tail of A2: (0.2, 0.4)


### PR DESCRIPTION
The primary goal of this PR is to file a series of three tests which apply the same array API test from yesterday on (a) a slice of an array, (b) rank change slices of an array, (c) a reindexed array to make sure it works as expected.  This will then be taken to the array view branch to add confidence that no key array APIs are missing.

While getting the test working, I found a few bugs in arrays (and in my API test) that had easy fixes:

* head/tail (and my test yesterday) queried the domain's low and high bound rather than using alignedLow and alignedHigh, which made them brittle to strided domains in which the domain's extreme values weren't in the index set.  E.g., for 'A: [1..10 by 2] real', they would try to access A[10] rather than A[9] to get the high value.

* the existing reindex functions were insufficiently general in the presence of strided domains in the source and target index sets.  This was a bug I'd already addressed in the array views branch, but which none of our existing tests seem to run afoul of.