### PR TITLE
Drop "unused" virtual method getFnSymbol()

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -257,11 +257,6 @@ BlockStmt* Symbol::getDeclarationScope() const {
 }
 
 
-FnSymbol* Symbol::getFnSymbol() {
-  return NULL;
-}
-
-
 bool Symbol::hasFlag(Flag flag) const {
   CHECK_FLAG(flag);
   return flags[flag];
@@ -1040,11 +1035,6 @@ void FnSymbol::verify() {
   // Should those even persist between passes?
   verifyInTree(valueFunction, "FnSymbol::valueFunction");
   verifyInTree(retSymbol, "FnSymbol::retSymbol");
-}
-
-
-FnSymbol* FnSymbol::getFnSymbol(void) {
-  return this;
 }
 
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -116,8 +116,6 @@ public:
   virtual void       replaceChild(BaseAST* oldAst,
                                   BaseAST* newAst)               = 0;
 
-  virtual FnSymbol*  getFnSymbol();
-
   virtual bool       isConstant()                              const;
   virtual bool       isConstValWillNotChange()                 const;
   virtual bool       isImmediate()                             const;
@@ -463,7 +461,6 @@ public:
   DECLARE_SYMBOL_COPY(FnSymbol);
 
   FnSymbol*                  copyInnerCore(SymbolMap* map);
-  FnSymbol*                  getFnSymbol();
   void                       replaceChild(BaseAST* oldAst, BaseAST* newAst);
 
   FnSymbol*                  partialCopy(SymbolMap* map);

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -649,7 +649,8 @@ void createTaskFunctions(void) {
               // Do not add remote memory barriers.
               needsMemFence = false;
             } else {
-              FnSymbol* fnSymbol = parent->getFnSymbol();
+              FnSymbol* fnSymbol = toFnSymbol(parent);
+
               // For methods on atomic types, we do not add the memory
               // barriers, because these functions have an 'order'
               // argument, which needs to get passed to the memory barrier,


### PR DESCRIPTION
I happened to trip over the method

virtual FnSymbol* Symbol::getFnSymbol();

which is defined to return NULL on Symbol and to return this on FnSymbol.  It has just one
caller.  It is clear that this method implements the same functionality as

FnSymbol* toFnSymbol(BaseAST* ast);

which is the customary way to handle this.

Drop this needless method.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux.
Merely out of paranoia I also ran a single-locale paratest.
