### PR TITLE
Test compiler performance impact of disabling copy propagation

### DIFF
--- a/util/cron/test-fast.bash
+++ b/util/cron/test-fast.bash
@@ -9,5 +9,7 @@ source $CWD/common-fast.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="fast"
 
+sed "s/void copyPropagation(void) {/void copyPropagation(void) {\n  return;/" $CHPL_HOME/compiler/optimizations/copyPropagation.cpp  > CP.tmp && mv CP.tmp $CHPL_HOME/compiler/optimizations/copyPropagation.cpp
+
 nightly_args="${nightly_args} -compperformance (--fast)"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -8,5 +8,7 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
 
+sed "s/void copyPropagation(void) {/void copyPropagation(void) {\n  return;/" $CHPL_HOME/compiler/optimizations/copyPropagation.cpp  > CP.tmp && mv CP.tmp $CHPL_HOME/compiler/optimizations/copyPropagation.cpp
+
 nightly_args="-compperformance (default)"
 $CWD/nightly -cron -futures ${nightly_args}


### PR DESCRIPTION
Hijack linux64 and --fast testing in order to see how much of an impact
disabling copy propagation has on compiler performance.