### PR TITLE
Revert "Test compiler performance impact of disabling copy propagation"

### DIFF
--- a/util/cron/test-fast.bash
+++ b/util/cron/test-fast.bash
@@ -9,7 +9,5 @@ source $CWD/common-fast.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="fast"
 
-sed "s/void copyPropagation(void) {/void copyPropagation(void) {\n  return;/" $CHPL_HOME/compiler/optimizations/copyPropagation.cpp  > CP.tmp && mv CP.tmp $CHPL_HOME/compiler/optimizations/copyPropagation.cpp
-
 nightly_args="${nightly_args} -compperformance (--fast)"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -8,7 +8,5 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
 
-sed "s/void copyPropagation(void) {/void copyPropagation(void) {\n  return;/" $CHPL_HOME/compiler/optimizations/copyPropagation.cpp  > CP.tmp && mv CP.tmp $CHPL_HOME/compiler/optimizations/copyPropagation.cpp
-
 nightly_args="-compperformance (default)"
 $CWD/nightly -cron -futures ${nightly_args}


### PR DESCRIPTION
This reverts commit df2ef3687c25a7e9fca43792c3c4fc0fe9a5ce63.

I'm done testing the perf impact of disabling copy propagation