### PR TITLE
Add 'stridable' query to the Replicated Array class

### DIFF
--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -543,6 +543,10 @@ proc ReplicatedArr.ReplicatedArr(type eltType, dom: ReplicatedDom) {
   // initializes the fields 'eltType', 'dom' by name
 }
 
+proc ReplicatedArr.stridable param {
+  return dom.stridable;
+}
+
 // The same across all domain maps
 proc ReplicatedArr.dsiGetBaseDom() return dom;
 


### PR DESCRIPTION
It seems that our Replicated array class hasn't supported 'stridable'
queries though ChapelArray.chpl assumes that all rectangular arrays will
and the Replicated domain and local array class support it.  Add it in the
trivial way by adding a method that defers to the domain's stridable
value.

This fixes the weekend's regressions due to my bug fix for reindexing
between stridable ranges/domains.
