### PR TITLE
Stop testing displayRepresentation by default

### DIFF
--- a/test/arrays/userAPI/arrayAPItest.chpl
+++ b/test/arrays/userAPI/arrayAPItest.chpl
@@ -1,4 +1,4 @@
-config param testError = 0;
+config param testError = 0, testDisplayRepresentation = false;
 
 proc readArray(X) {
   open("realValues.txt", iomode.r).reader().read(X);
@@ -24,9 +24,9 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
   // Test I/O
   readArray(X);
   writeln("X is:\n", X);
-  writeln();
-  writeln("X's representation:");
-  X.displayRepresentation();
+  if testDisplayRepresentation {
+    writeln("X's representation:"); X.displayRepresentation();
+  }
   writeln();
 
   // Test write accesses via tuples and varargs

--- a/test/arrays/userAPI/arrayOps2D.good
+++ b/test/arrays/userAPI/arrayOps2D.good
@@ -14,14 +14,6 @@ X is:
 9.0 10.0 11.0 12.0
 13.0 14.0 15.0 16.0
 
-X's representation:
-off=(1, 1)
-blk=(4, 1)
-str=(1, 1)
-origin=0
-factoredOffs=5
-noinit_data=false
-
 X is:
 1.1 2.1 3.1 4.1
 5.1 6.1 7.1 8.1

--- a/test/arrays/userAPI/rankChangeOps3to2D.good
+++ b/test/arrays/userAPI/rankChangeOps3to2D.good
@@ -14,14 +14,6 @@ X is:
 9.0 10.0 11.0 12.0
 13.0 14.0 15.0 16.0
 
-X's representation:
-off=(1, 1)
-blk=(24, 4)
-str=(1, 1)
-origin=25
-factoredOffs=28
-noinit_data=true
-
 X is:
 1.1 2.1 3.1 4.1
 5.1 6.1 7.1 8.1
@@ -126,14 +118,6 @@ X is:
 9.0 10.0 11.0 12.0
 13.0 14.0 15.0 16.0
 
-X's representation:
-off=(1, 1)
-blk=(4, 1)
-str=(1, 1)
-origin=120
-factoredOffs=5
-noinit_data=true
-
 X is:
 1.1 2.1 3.1 4.1
 5.1 6.1 7.1 8.1
@@ -237,14 +221,6 @@ X is:
 5.0 6.0 7.0 8.0
 9.0 10.0 11.0 12.0
 13.0 14.0 15.0 16.0
-
-X's representation:
-off=(1, 1)
-blk=(24, 1)
-str=(1, 1)
-origin=32
-factoredOffs=25
-noinit_data=true
 
 X is:
 1.1 2.1 3.1 4.1

--- a/test/arrays/userAPI/reindexOps2D.good
+++ b/test/arrays/userAPI/reindexOps2D.good
@@ -14,14 +14,6 @@ X is:
 9.0 10.0 11.0 12.0
 13.0 14.0 15.0 16.0
 
-X's representation:
-off=(0, 2)
-blk=(4, 1)
-str=(1, 2)
-origin=0
-factoredOffs=2
-noinit_data=true
-
 X is:
 1.1 2.1 3.1 4.1
 5.1 6.1 7.1 8.1

--- a/test/arrays/userAPI/sliceOps2D.good
+++ b/test/arrays/userAPI/sliceOps2D.good
@@ -14,14 +14,6 @@ X is:
 9.0 10.0 11.0 12.0
 13.0 14.0 15.0 16.0
 
-X's representation:
-off=(1, 1)
-blk=(6, 1)
-str=(1, 1)
-origin=7
-factoredOffs=7
-noinit_data=true
-
 X is:
 1.1 2.1 3.1 4.1
 5.1 6.1 7.1 8.1


### PR DESCRIPTION
In my original take on this array API test, I tested
displayRepresentation for arrays even though the test was ostensibly
meant to test the user API and I consider displayRepresentation to be
a developer-oriented flag.

This resulted in regressions for this new test in numa testing whose
representation is different (duh).  It also required the tests to be
updated in the array view branch where they're different.  For those
reasons, I disabled that part of the test by default, though one can
throw a config param to re-enable it (though I haven't done that in
any of these tests for similar maintenance issues).

This should clear up last night's numa regressions.