### PR TITLE
Describe const intent for tuples in CHIP 6

### DIFF
--- a/doc/developer/chips/6.rst
+++ b/doc/developer/chips/6.rst
@@ -85,9 +85,12 @@ Tuple Argument Behavior
 
 A tuple argument to a function with blank intent will not make a copy of
 the tuple elements but can accept a tuple expression. A tuple argument
-with ref intent requires an `lvalue` argument - a variable or returned
+with `ref` intent requires an `lvalue` argument - a variable or returned
 tuple. In neither case does passing a tuple argument to a function create
 a copy of the tuple.
+
+A tuple argument declared with `const` intent will work similarly to one
+with a `blank` intent, but contain `const` elements.
 
 Tuple Expression Behavior
 -------------------------


### PR DESCRIPTION
CHIP 6 describes tuple behavior. I noticed it did not describe what happens with the `const` argument intent. This PR adds a few words to describe it.