### PR TITLE
spec: describe array passing, returning, ref-if-modified

### DIFF
--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -656,16 +656,10 @@ Section~\ref{Rectangular_Array_Slicing}.
 \index{arrays!actual arguments}
 \index{arguments!array}
 
-Arrays are passed to functions by reference.  Formal arguments that
-receive arrays are aliases of the actual arguments.
-
-% Do we really need to say this?  Should it be said here -- seems like
-% there is no normal rule and that the cases should be described in
-% the function intents section.
-%
-%  The ordinary rule
-%that disallows assignment to formal arguments of default intent does not
-%apply to arrays.
+By default, arrays are passed to function by \chpl{ref} or \chpl{const
+ref} depending on whether or not the formal argument is modified. The
+\chpl{in}, \chpl{inout}, and \chpl{out} intent can create copies of
+arrays.
 
 When a formal argument has array type, the element type of the array
 can be omitted and/or the domain of the array can be queried or
@@ -678,6 +672,13 @@ index set.  If the formal array's domain was declared using an
 explicit domain map, the actual array's domain must use an equivalent
 domain map.
 
+\section{Returning Arrays from Functions}
+\label{Returning_Arrays_from_Functions}
+\index{arrays!returning}
+\index{returning!array}
+
+Arrays return by value by default. The \chpl{ref} and \chpl{const ref}
+return intents can be used to return a reference to an array.
 
 \subsection{Array Promotion of Scalar Functions}
 \label{Array_Promotion_of_Scalar_Functions}

--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -593,7 +593,7 @@ type & default intent \\
 \chpl{sync}    & \chpl{ref}   \\
 \chpl{single}  & \chpl{ref}   \\
 \chpl{atomic}  & \chpl{ref}   \\
-\chpl{record}  & \chpl{const} \\
+\chpl{record}  & \chpl{const} (but see below) \\
 \chpl{class}   & \chpl{const} \\
 \chpl{union}   & \chpl{const} \\
 \chpl{dmap}    & \chpl{const} \\
@@ -603,12 +603,16 @@ array          & \chpl{ref} / \chpl{const ref} \\
 \end{tabular}
 \end{center}
 
-The blank intent for arrays is \chpl{ref} or \chpl{const ref} - meaning
+The default intent for arrays is \chpl{ref} or \chpl{const ref} - meaning
 that the array is not copied by default. The compiler will choose
 \chpl{ref} or \chpl{const ref} based upon whether or not the formal
 argument is modified inside of the function. The choice between
 \chpl{ref} and \chpl{const ref} is similar to and interacts with the
 ref-pair feature (see \rsec{Ref_Pair}).
+
+The default intent for the implicit \chpl{this} argument for records is
+\chpl{ref} or \chpl{const ref} depending on whether the formal argument
+is modified inside of the function.
 
 \begin{openissue}
 How tuples should be handled under default intents is an open issue;

--- a/spec/Functions.tex
+++ b/spec/Functions.tex
@@ -598,10 +598,17 @@ type & default intent \\
 \chpl{union}   & \chpl{const} \\
 \chpl{dmap}    & \chpl{const} \\
 \chpl{domain}  & \chpl{const} \\
-array          & \chpl{ref}   \\
+array          & \chpl{ref} / \chpl{const ref} \\
 \hline
 \end{tabular}
 \end{center}
+
+The blank intent for arrays is \chpl{ref} or \chpl{const ref} - meaning
+that the array is not copied by default. The compiler will choose
+\chpl{ref} or \chpl{const ref} based upon whether or not the formal
+argument is modified inside of the function. The choice between
+\chpl{ref} and \chpl{const ref} is similar to and interacts with the
+ref-pair feature (see \rsec{Ref_Pair}).
 
 \begin{openissue}
 How tuples should be handled under default intents is an open issue;


### PR DESCRIPTION
This is the spec change to go along with PR #5134. See also issues #5217 and #5219.
While here, also include record  _this arguments, to go along with PR #5618 and issue #5266.

See also #5767 which changes evolution.rst.

Reviewed by @benharsh - thanks!