### PR TITLE
Refactor resolveNew()

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5162,8 +5162,6 @@ static void resolveNew(CallExpr* call) {
             call->parentExpr->insertBefore(def);;
           }
 
-          resolveExpr(def);
-
           if (isClass(typeToNew) == true) {
             // Invoking a type  method
             call->insertAtHead(new SymExpr(typeToNew->symbol));

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5141,14 +5141,12 @@ static void resolveNew(CallExpr* call) {
         parent_insert_help(call, call->baseExpr);
 
         if (initCall) {
-          Type* typeToNew = typeExpr->symbol()->typeInfo();
-
-          if (typeToNew->symbol->hasFlag(FLAG_GENERIC)) {
+          if (at->symbol->hasFlag(FLAG_GENERIC)) {
             USR_FATAL(call,
                       "Sorry, new style initializers don't work with "
                       "generics yet.  Stay tuned!");
           } else {
-            VarSymbol* newTmp = newTemp("new_temp", typeToNew);
+            VarSymbol* newTmp = newTemp("new_temp", at);
             DefExpr*   def    = new DefExpr(newTmp);
 
             if (isBlockStmt(call->parentExpr) == true) {
@@ -5157,9 +5155,9 @@ static void resolveNew(CallExpr* call) {
               call->parentExpr->insertBefore(def);
             }
 
-            if (isClass(typeToNew) == true) {
+            if (isClass(at) == true) {
               // Invoking a type  method
-              call->insertAtHead(new SymExpr(typeToNew->symbol));
+              call->insertAtHead(new SymExpr(at->symbol));
 
             } else {
               // Invoking an instance method

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5095,60 +5095,47 @@ static void resolveMove(CallExpr* call) {
 
 /************************************* | **************************************
 *                                                                             *
-* Some new expressions are converted in normalize().  For example, a call to  *
-* a type function is resolved at this point.                                  *
-* The syntax supports calling the result of a type function as a constructor, *
+* Resolve a PRIM_NEW expression.                                              *
+* The 1st argument is a type or a partial call to get the type and the        *
+* remaining arguments are assumed to be arguments for the constructor or      *
+* initializer call                                                            *
+*                                                                             *
+* Some new expressions are converted in normalize().                          *
+*   For example, a call to  type function is resolved at this point.          *
+*                                                                             *
+* The syntax supports calling the result of a type function as a constructor  *
 * but this is not fully implemented.                                          *
 *                                                                             *
 ************************************** | *************************************/
 
+static SymExpr* primNewTypeExpr(CallExpr* call);
+
 static void resolveNew(CallExpr* call) {
-  // This is a 'new' primitive
-  // we expect the 1st argument to be a type
-  //   or a partial call to get the type
-  // and the remaining arguments to be arguments for the constructor call
-
-  SymExpr* toReplace = NULL;
-
   // Perform three transformations on this PRIM_NEW
   // 1 replace the type in the 1st argument with
   //   an UnresolvedSymExpr to ct->defaultInitializer->name
   // 2 move the 1st argument into the baseExpr
   // 3 make it a normal call rather than a PRIM_NEW
 
-  if (CallExpr* subCall = toCallExpr(call->get(1))) {
-    // Handle e.g. 'new' (call (partial) R2 _mt this) call_tmp
-    // which comes up with nested classes (e.g. R2 is a nested class type)
-    if (SymExpr* se = toSymExpr(subCall->baseExpr)) {
-      if (subCall->partialTag) {
-        toReplace = se;
-      }
-    }
-
-  } else if (SymExpr* se = toSymExpr(call->get(1))) {
-    // Handle e.g. 'new' C arg
-    toReplace = se;
-  }
-
-  if (toReplace) {
+  if (SymExpr* typeExpr = primNewTypeExpr(call)) {
     SET_LINENO(call);
 
     bool initCall = false;
 
     // 1: replace the type with the constructor call name
-    if (Type* ty = resolveTypeAlias(toReplace)) {
+    if (Type* ty = resolveTypeAlias(typeExpr)) {
       if (AggregateType* ct = toAggregateType(ty)) {
         if (ct->initializerStyle == DEFINES_INITIALIZER) {
           const char* name = (isClass(ct) == true) ? "_new" : "init";
 
-          toReplace->replace(new UnresolvedSymExpr(name));
+          typeExpr->replace(new UnresolvedSymExpr(name));
 
           initCall = true;
 
         } else {
           FnSymbol* ctInit = ct->defaultInitializer;
 
-          toReplace->replace(new UnresolvedSymExpr(ctInit->name));
+          typeExpr->replace(new UnresolvedSymExpr(ctInit->name));
         }
       }
     }
@@ -5167,7 +5154,7 @@ static void resolveNew(CallExpr* call) {
     if (initCall) {
       // 4: insert the allocation for the instance and pass that in as an
       // argument if we're making a call to an initializer
-      Type*      typeToNew = toReplace->symbol()->typeInfo();
+      Type*      typeToNew = typeExpr->symbol()->typeInfo();
       VarSymbol* newTmp    = newTemp("new_temp", typeToNew);
 
       VarSymbol* newMT     = newTemp("_mt",      dtMethodToken);
@@ -5235,6 +5222,32 @@ static void resolveNew(CallExpr* call) {
     USR_FATAL(call, "invalid use of 'new'");
   }
 }
+
+// Find the SymExpr that captures the type
+static SymExpr* primNewTypeExpr(CallExpr* call) {
+  Expr*    arg1   = call->get(1);
+  SymExpr* retval = NULL;
+
+  // The common case e.g new MyClass(1, 2, 3);
+  if (SymExpr* se = toSymExpr(arg1)) {
+    retval = se;
+
+  // 'new' (call (partial) R2 _mt this), call_tmp0, call_tmp1, ...
+  // due to nested classes (i.e. R2 is a nested class type)
+  } else if (CallExpr* subCall = toCallExpr(arg1)) {
+    if (SymExpr* se = toSymExpr(subCall->baseExpr)) {
+      retval = (subCall->partialTag) ? se : NULL;
+    }
+  }
+
+  return retval;
+}
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 static void
 resolveCoerce(CallExpr* call) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5118,7 +5118,7 @@ static void resolveNew(CallExpr* call) {
 
         bool initCall = false;
 
-        // 1: replace the type with the constructor call name
+        // Replace the type with the constructor call name
         if (at->initializerStyle == DEFINES_INITIALIZER) {
           if (isClass(at) == true) {
             typeExpr->replace(new UnresolvedSymExpr("_new"));
@@ -5134,18 +5134,13 @@ static void resolveNew(CallExpr* call) {
           typeExpr->replace(new UnresolvedSymExpr(ctInit->name));
         }
 
-        // 2: move the 1st argument into the baseExpr
-        // 3: make it a normal call and not a PRIM_NEW
-        Expr* arg = call->get(1)->remove();
-
+        // Convert the PRIM_NEW to a normal call
         call->primitive = NULL;
-        call->baseExpr  = arg;
+        call->baseExpr  = call->get(1)->remove();
 
         parent_insert_help(call, call->baseExpr);
 
         if (initCall) {
-          // 4: insert the allocation for the instance and pass that in
-          // as an argument if we're making a call to an initializer
           Type* typeToNew = typeExpr->symbol()->typeInfo();
 
           if (typeToNew->symbol->hasFlag(FLAG_GENERIC)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5146,30 +5146,31 @@ static void resolveNew(CallExpr* call) {
         if (initCall) {
           // 4: insert the allocation for the instance and pass that in
           // as an argument if we're making a call to an initializer
-          Type*      typeToNew = typeExpr->symbol()->typeInfo();
-          VarSymbol* newTmp    = newTemp("new_temp", typeToNew);
-          DefExpr*   def       = new DefExpr(newTmp);
+          Type* typeToNew = typeExpr->symbol()->typeInfo();
 
           if (typeToNew->symbol->hasFlag(FLAG_GENERIC)) {
             USR_FATAL(call,
                       "Sorry, new style initializers don't work with "
                       "generics yet.  Stay tuned!");
-          }
-
-          if (isBlockStmt(call->parentExpr) == true) {
-            call->insertBefore(def);
           } else {
-            call->parentExpr->insertBefore(def);;
-          }
+            VarSymbol* newTmp = newTemp("new_temp", typeToNew);
+            DefExpr*   def    = new DefExpr(newTmp);
 
-          if (isClass(typeToNew) == true) {
-            // Invoking a type  method
-            call->insertAtHead(new SymExpr(typeToNew->symbol));
+            if (isBlockStmt(call->parentExpr) == true) {
+              call->insertBefore(def);
+            } else {
+              call->parentExpr->insertBefore(def);
+            }
 
-          } else {
-            // Invoking an instance method
-            call->insertAtHead(new SymExpr(newTmp));
-            call->insertAtHead(new SymExpr(gMethodToken));
+            if (isClass(typeToNew) == true) {
+              // Invoking a type  method
+              call->insertAtHead(new SymExpr(typeToNew->symbol));
+
+            } else {
+              // Invoking an instance method
+              call->insertAtHead(new SymExpr(newTmp));
+              call->insertAtHead(new SymExpr(gMethodToken));
+            }
           }
         }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5174,19 +5174,6 @@ static void resolveNew(CallExpr* call) {
         }
       }
     }
-  }
-
-  // Do some error checking
-  if (FnSymbol* fn = call->isResolved()) {
-    if (fn->hasFlag(FLAG_CONSTRUCTOR)) {
-
-    } else if (fn->hasFlag(FLAG_METHOD) && strcmp(fn->name, "init") == 0) {
-
-    } else if (fn->hasFlag(FLAG_METHOD) && strcmp(fn->name, "_new") == 0) {
-
-    } else {
-      USR_FATAL(call, "invalid use of 'new' on %s", fn->name);
-    }
 
   } else {
     if (Expr* arg = call->get(1)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5118,11 +5118,7 @@ static void resolveNew(CallExpr* call) {
 
         // Begin to support new-style initializers
         if (at->initializerStyle == DEFINES_INITIALIZER) {
-          if (at->symbol->hasFlag(FLAG_GENERIC)) {
-            USR_FATAL(call,
-                      "Sorry, new style initializers don't work with "
-                      "generics yet.  Stay tuned!");
-          } else {
+          if (at->symbol->hasFlag(FLAG_GENERIC) == false) {
             VarSymbol* newTmp = newTemp("new_temp", at);
             DefExpr*   def    = new DefExpr(newTmp);
 
@@ -5155,6 +5151,11 @@ static void resolveNew(CallExpr* call) {
             }
 
             resolveExpr(call);
+
+          } else {
+            USR_FATAL(call,
+                      "Sorry, new style initializers don't work with "
+                      "generics yet.  Stay tuned!");
           }
 
         // Continue to support old-style constructors


### PR DESCRIPTION
I happened to notice that resolveNew() has grown a bit wholly over time and it's
now surprisingly hard to recognize that it's actually doing something quite easy.
Things have been getting even worse as Lydia and I have been adding more cases
for initializers.

This PR performs a number of simple transformations, all as separate commits, that
serve to completely rewrite resolveNew().  IMO the final version is much easier to follow
than before.  Additionally it is much more clear what path is followed by existing production
code and what paths are being followed for the new initializer work.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed single-locale paratest on linux64.
Also passes test/classes/initializers on darwin.
