### PR TITLE
Bring in upstream fixes for qthreads sleep interception bug

### DIFF
--- a/third-party/qthread/qthread-src/src/syscalls/nanosleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/nanosleep.c
@@ -62,5 +62,3 @@ int nanosleep(const struct timespec *rqtp,
 #endif /* if HAVE_SYSCALL && HAVE_DECL_SYS_NANOSLEEP */
 
 /* vim:set expandtab: */
-
-/* vim:set expandtab: */

--- a/third-party/qthread/qthread-src/src/syscalls/nanosleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/nanosleep.c
@@ -44,7 +44,7 @@ int qt_nanosleep(const struct timespec *rqtp,
         if (rmtp) {
             *rmtp = *rqtp;
         }
-        return 0;
+        return -1;
     }
 }
 

--- a/third-party/qthread/qthread-src/src/syscalls/nanosleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/nanosleep.c
@@ -21,7 +21,7 @@
 #include "qthread_innards.h" /* for qlib */
 #include "qt_qthread_mgmt.h"
 
-int nanosleep(const struct timespec *rqtp,
+int qt_nanosleep(const struct timespec *rqtp,
               struct timespec       *rmtp)
 {
     if (qt_blockable()) {
@@ -41,16 +41,26 @@ int nanosleep(const struct timespec *rqtp,
         qtimer_destroy(t);
         return 0;
     } else {
-#if HAVE_SYSCALL && HAVE_DECL_SYS_NANOSLEEP
-        return syscall(SYS_nanosleep, rqtp, rmtp);
-
-#else
         if (rmtp) {
             *rmtp = *rqtp;
         }
         return 0;
-#endif
     }
 }
+
+#if HAVE_SYSCALL && HAVE_DECL_SYS_NANOSLEEP
+int nanosleep(const struct timespec *rqtp,
+              struct timespec       *rmtp)
+{
+    if (qt_blockable()) {
+      return qt_nanosleep(rqtp, rmtp);
+    } else {
+      return syscall(SYS_nanosleep, rqtp, rmtp);
+    }
+}
+
+#endif /* if HAVE_SYSCALL && HAVE_DECL_SYS_NANOSLEEP */
+
+/* vim:set expandtab: */
 
 /* vim:set expandtab: */

--- a/third-party/qthread/qthread-src/src/syscalls/nanosleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/nanosleep.c
@@ -22,7 +22,7 @@
 #include "qt_qthread_mgmt.h"
 
 int qt_nanosleep(const struct timespec *rqtp,
-              struct timespec       *rmtp)
+                 struct timespec       *rmtp)
 {
     if (qt_blockable()) {
         qtimer_t t       = qtimer_create();

--- a/third-party/qthread/qthread-src/src/syscalls/sleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/sleep.c
@@ -20,7 +20,6 @@
 #include "qthread_innards.h" /* for qlib */
 #include "qt_qthread_mgmt.h"
 
-#if 0
 unsigned int sleep(unsigned int seconds)
 {
     if (qt_blockable()) {
@@ -51,6 +50,5 @@ unsigned int sleep(unsigned int seconds)
 #endif  /* if HAVE_SYSCALL */
     }
 }
-#endif
 
 /* vim:set expandtab: */

--- a/third-party/qthread/qthread-src/src/syscalls/sleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/sleep.c
@@ -20,7 +20,7 @@
 #include "qthread_innards.h" /* for qlib */
 #include "qt_qthread_mgmt.h"
 
-unsigned int sleep(unsigned int seconds)
+unsigned int qt_sleep(unsigned int seconds)
 {
     if (qt_blockable()) {
         qtimer_t t = qtimer_create();
@@ -32,23 +32,19 @@ unsigned int sleep(unsigned int seconds)
         qtimer_destroy(t);
         return 0;
     } else {
-#if HAVE_SYSCALL
-# if HAVE_DECL_SYS_SLEEP
-        return syscall(SYS_sleep, seconds);
-
-# elif HAVE_DECL_SYS_USLEEP
-        return syscall(SYS_usleep, seconds * 1e6);
-
-# elif HAVE_DECL_SYS_NANOSLEEP
-        return syscall(SYS_nanosleep, seconds * 1e9);
-
-# else
         return 0;
-# endif
-#else   /* if HAVE_SYSCALL */
-        return 0;
-#endif  /* if HAVE_SYSCALL */
     }
 }
+
+#if HAVE_SYSCALL && HAVE_DECL_SYS_SLEEP
+unsigned int sleep(unsigned int seconds)
+{
+  if (qt_blockable()) {
+    return qt_sleep(seconds);
+  } else {
+    return syscall(SYS_sleep, seconds);
+  }
+}
+#endif /* if HAVE_SYSCALL && HAVE_DECL_SYS_SLEEP */
 
 /* vim:set expandtab: */

--- a/third-party/qthread/qthread-src/src/syscalls/sleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/sleep.c
@@ -45,6 +45,7 @@ unsigned int sleep(unsigned int seconds)
     return syscall(SYS_sleep, seconds);
   }
 }
+
 #endif /* if HAVE_SYSCALL && HAVE_DECL_SYS_SLEEP */
 
 /* vim:set expandtab: */

--- a/third-party/qthread/qthread-src/src/syscalls/sleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/sleep.c
@@ -32,7 +32,7 @@ unsigned int qt_sleep(unsigned int seconds)
         qtimer_destroy(t);
         return 0;
     } else {
-        return 0;
+        return seconds;
     }
 }
 

--- a/third-party/qthread/qthread-src/src/syscalls/usleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/usleep.c
@@ -49,5 +49,4 @@ int usleep(useconds_t useconds)
 
 #endif /* if HAVE_SYSCALL && HAVE_DECL_SYS_USLEEP */
 
-
 /* vim:set expandtab: */

--- a/third-party/qthread/qthread-src/src/syscalls/usleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/usleep.c
@@ -19,7 +19,7 @@
 #include "qthread_innards.h" /* for qlib */
 #include "qt_qthread_mgmt.h"
 
-int usleep(useconds_t useconds)
+int qt_usleep(useconds_t useconds)
 {
     if ((qlib != NULL) && (qthread_internal_self() != NULL)) {
         qtimer_t t       = qtimer_create();
@@ -32,20 +32,22 @@ int usleep(useconds_t useconds)
         qtimer_destroy(t);
         return 0;
     } else {
-#if HAVE_SYSCALL
-# if HAVE_DECL_SYS_USLEEP
-        return syscall(SYS_usleep, useconds);
-
-# elif HAVE_DECL_SYS_NANOSLEEP
-        return syscall(SYS_nanosleep, useconds * 1e3);
-
-# else
         return 0;
-# endif
-#else
-        return 0;
-#endif  /* if HAVE_SYSCALL */
     }
 }
+
+
+#if HAVE_SYSCALL && HAVE_DECL_SYS_USLEEP
+int usleep(useconds_t useconds)
+{
+  if ((qlib != NULL) && (qthread_internal_self() != NULL)) {
+    return qt_usleep(useconds);
+  } else {
+    return syscall(SYS_usleep, useconds);
+  }
+}
+
+#endif /* if HAVE_SYSCALL && HAVE_DECL_SYS_USLEEP */
+
 
 /* vim:set expandtab: */

--- a/third-party/qthread/qthread-src/src/syscalls/usleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/usleep.c
@@ -32,7 +32,7 @@ int qt_usleep(useconds_t useconds)
         qtimer_destroy(t);
         return 0;
     } else {
-        return 0;
+        return -1;
     }
 }
 

--- a/third-party/qthread/qthread-src/src/syscalls/usleep.c
+++ b/third-party/qthread/qthread-src/src/syscalls/usleep.c
@@ -21,7 +21,7 @@
 
 int qt_usleep(useconds_t useconds)
 {
-    if ((qlib != NULL) && (qthread_internal_self() != NULL)) {
+     if (qt_blockable()) {
         qtimer_t t       = qtimer_create();
         double   seconds = useconds * 1e-6;
         qtimer_start(t);
@@ -40,7 +40,7 @@ int qt_usleep(useconds_t useconds)
 #if HAVE_SYSCALL && HAVE_DECL_SYS_USLEEP
 int usleep(useconds_t useconds)
 {
-  if ((qlib != NULL) && (qthread_internal_self() != NULL)) {
+  if (qt_blockable()) {
     return qt_usleep(useconds);
   } else {
     return syscall(SYS_usleep, useconds);


### PR DESCRIPTION
Pull in several qthreads commits that "fix" sleep interception. With 9bdacce we
disabled qthreads sleep interception because it was broken when it was called
by non-qthreads. This bug effectively turned calls to sleep() into no-ops,
which caused issues during PMI initialization. As a temporary work-around we
just disabled sleep interception until we could get a real solution from the
qthreads team.

This reverts our workaround and pulls in upstream fixes that should be included
in the next qthreads release.

Here's the summary of the fix:

Previously qthreads would always intercept calls to sleep, but the code was
broken for non-qthreads. Now sleep is _not_ intercepted by default. It will
only be intercepted if --enable-syscall-interception was thrown at configure
time and if support for the SYS_sleep syscall is detected. We don't build with
--enable-syscall-interception, so this effectively disables sleep interception
for us (which is what our workaround did before.)

I think this is ok in the short term, but longer term I think we want sleep()
to be intercepted so that 3rd party libraries that call sleep will get
intercepted. When that day comes I think this implementation is insufficient
for us because very few systems (none that I've found) actually support
SYS_sleep. But for now this is good enough.


Grabbing some text from https://github.com/Qthreads/qthreads/issues/37:

"""
https://github.com/Qthreads/qthreads/compare/1441082...88291a9 makes it so that
sleep, usleep, and nanosleep are no longer intercepted by default. They will
only be intercepted if --enable-syscall-interception is thrown at configure
time and support for SYS_sleep, SYS_usleep, and SYS_nanosleep respectively is
found.

In my experience very few systems (none that I've seen so far) support
SYS_sleep or SYS_usleep, which means sleep/usleep probably won't be
intercepted. They _might_ end up being intercepted in a round-about way because
glibc `sleep()` just fowards to `__nanosleep`, so calling the system sleep will
end up forwarding to nanosleep for some systems, which qthreads should be able
to intercept. Maybe in the long term, it'd be better to just have sleep/usleep
use SYS_nanosleep directly?

Since we don't build with `--enable-syscall-interception` these commits
effectively turn off sleep interception for chapel for now. I think that's fine
for this release, although we (chapel team) probably want to revisit this
decision in the future if we and/or our users end up with 3rd party code that
wants to call sleep() and have the worker process other qthreads while the
sleep is happening.
"""
