### PR TITLE
Update a future that incorrectly started passing

### DIFF
--- a/test/modules/diten/mutualuse2.bad
+++ b/test/modules/diten/mutualuse2.bad
@@ -1,1 +1,2 @@
-mutualuse2.chpl:11: error: use of 'a' before encountering its definition, type unknown
+{field = 1}
+nil

--- a/test/modules/diten/mutualuse2.chpl
+++ b/test/modules/diten/mutualuse2.chpl
@@ -1,19 +1,44 @@
+/*
+   This is an invalid Chapel program.
+
+   M3 contains main().
+
+   M3 uses M1 which uses M2.
+     This implies that the partial initialization order is M2, M1, M3.
+
+     This implies an attempt to initialize M2.n before M1.a has been
+     initialized.
+
+  Historically this program has failed to type-resolve "because"
+  function resolution determined the types of a and n in the same
+  order that the program would execute.
+
+  Changes to certain simple cases for resolution in Feb 2017 mean
+  that the types of M1.a and M2.n are known sooner and so the
+  program has started to compile.   For this case it happens to
+  produce stable output but this is not assured.
+*/
+
 module M1 {
   use M2, Time;
+
   class C {
     var field: int;
   }
+
   var a:C = new C(1);
 }
 
 module M2 {
   use M1;
+
   var n:C = a;
 }
 
 module M3 {
-  proc main {
+  proc main() {
     use M1, M2;
+
     writeln(a);
     writeln(n);
   }

--- a/test/modules/diten/mutualuse2.future
+++ b/test/modules/diten/mutualuse2.future
@@ -1,6 +1,3 @@
-bug: out-of-order resolution
+bug: Failure to generate a good error message for use before definition
 
-bug: modules that mutually use each other can have some types lost
-
-This is very similar to mutualuse.chpl, except in this test, the types for the
-variables M1.a and M2.n are given explicitly. This causes a different error.
+Please see the comment in mutualuse2.good

--- a/test/modules/diten/mutualuse2.good
+++ b/test/modules/diten/mutualuse2.good
@@ -1,2 +1,1 @@
-{ field = 1 }
-nil
+This should be a useful error message about module init order.


### PR DESCRIPTION
Recent changes to the order in which some types are resolved caused an existing future to,
incorrectly, start passing.  The original .good file was developed when the rules for default
initialization may have been different.

This PR updates the .good, .bad, and .future files to cause this test to start failing again
and adds some comments to the .chpl file.

Discussed with Brad
