### PR TITLE
Update out-of-date comment

### DIFF
--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -339,7 +339,7 @@ void modAndResolveInitCall (CallExpr* call, AggregateType* typeToNew) {
 
   resolveInitializer(call);
 
-  // Because initializers determine the type they return based on the
+  // Because initializers determine the type they utilize based on the
   // execution of Phase 1, if the type is generic we will need to update the
   // type of the actual we are sending in for the this arg
   if (typeToNew->symbol->hasFlag(FLAG_GENERIC) == true) {


### PR DESCRIPTION
Mike noticed belatedly that this comment was stale, referencing the return type
of an initializer when the return type is now void.  The spirit of the comment
was still important, though, so I removed the direct reference to the return
type.

Spot checked with hello.chpl and test/classes/initializers since this is just a comment
update, no review.