### PR TITLE
Update normalization of primitive scalars without an explicit type

### DIFF
--- a/test/modules/deitz/test_module_mutual_use.bad
+++ b/test/modules/deitz/test_module_mutual_use.bad
@@ -1,1 +1,1 @@
-test_module_mutual_use.chpl:10: error: use of 'a' before encountering its definition, type unknown
+(1, 2, 2, 0)

--- a/test/modules/deitz/test_module_mutual_use.chpl
+++ b/test/modules/deitz/test_module_mutual_use.chpl
@@ -1,13 +1,34 @@
+/*
+   This is an invalid Chapel program.
+
+   M3 contains main().
+
+   M3 uses M1 which uses M2.
+     This implies that the partial initialization order is M2, M1, M3.
+
+     This implies an attempt to initialize M2.d before M1.a has been
+     initialized.
+
+  Historically this program has failed to type-resolve "because"
+  function resolution determined the types of a and d in the same
+  order that the program would execute.
+
+  Changes to certain simple cases for resolution in Feb 2017 mean
+  that the types of M1.a and M2.d are known sooner and so the
+  program has started to compile.   For this case it happens to
+  produce stable output but this is not assured.
+*/
+
 module M1 {
   use M2;
   var a = 1;
-  var b = c;
+  var b = c;   // OK
 }
 
 module M2 {
   use M1;
   var c = 2;
-  var d = a;
+  var d = a;   // Use before definition
 }
 
 module M3 {

--- a/test/modules/deitz/test_module_mutual_use.future
+++ b/test/modules/deitz/test_module_mutual_use.future
@@ -1,6 +1,3 @@
-bug: out-of-order resolution
+bug: Failure to generate a good error message for use before definition
 
-This test shows an inadequacy in function resolution in which multiple
-functions cannot be resolved at the same time.  This should be fixed
-with a queue of calls that need to be resolved and the ability to skip
-over some of the calls.
+Please see the comment in test_module_mutual_use.chpl

--- a/test/modules/deitz/test_module_mutual_use.good
+++ b/test/modules/deitz/test_module_mutual_use.good
@@ -1,1 +1,1 @@
-(1, 2, 2, 1)
+This should be a useful error message about module init order.

--- a/test/users/ferguson/record_from_string.bad
+++ b/test/users/ferguson/record_from_string.bad
@@ -1,1 +1,1 @@
-record_from_string.chpl:11: error: type mismatch in assignment from string to Point
+record_from_string.chpl:11: error: illegal cast to non-type


### PR DESCRIPTION
Begin to streamline the normalization of DefExpr for variables that are amenable to simple
local type inference.  This simple PR recognizes certain cases of primitive scalar types.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64

Paratested on

single-locale linux64 *with futures* (yup, I can still learn)
on single-locale linux64 --baseline
linux64 gasnet
