### PR TITLE
Update futures to compensate for changes in type inference

### DIFF
--- a/test/modules/diten/mutualuse.bad
+++ b/test/modules/diten/mutualuse.bad
@@ -1,1 +1,2 @@
-mutualuse.chpl:12: error: use of 'a' before encountering its definition, type unknown
+{field = 1}
+nil

--- a/test/modules/diten/mutualuse.chpl
+++ b/test/modules/diten/mutualuse.chpl
@@ -1,5 +1,27 @@
+/*
+   This is an invalid Chapel program.
+
+   M3 contains main().
+
+   M3 uses M1 which uses M2.
+     This implies that the partial initialization order is M2, M1, M3.
+
+     This implies an attempt to initialize M2.n before M1.a has been
+     initialized.
+
+  Historically this program has failed to type-resolve "because"
+  function resolution determined the types of a and n in the same
+  order that the program would execute.
+
+  Changes to certain simple cases for resolution in Feb 2017 mean
+  that the types of M1.a and M2.n are known sooner and so the
+  program has started to compile.   For this case it happens to
+  produce stable output but this is not assured.
+*/
+
 module M1 {
   use M2;
+
   class C {
     var field: int;
   }
@@ -9,12 +31,14 @@ module M1 {
 
 module M2 {
   use M1;
+
   var n = a;
 }
 
 module M3 {
-  proc main {
+  proc main() {
     use M1, M2;
+
     writeln(a);
     writeln(n);
   }

--- a/test/modules/diten/mutualuse.future
+++ b/test/modules/diten/mutualuse.future
@@ -1,5 +1,3 @@
-bug: out-of-order resolution
+bug: Failure to generate a good error message for use before definition
 
-bug: modules that mutually use each other can have some types lost
-
-I think M2.n should be assigned the default value of the C class - nil.
+Please see the comment in mutualuse.chpl

--- a/test/modules/diten/mutualuse.good
+++ b/test/modules/diten/mutualuse.good
@@ -1,2 +1,1 @@
-{ field = 1 }
-nil
+This should be a useful error message about module init order.

--- a/test/modules/diten/mutualuse2.future
+++ b/test/modules/diten/mutualuse2.future
@@ -1,3 +1,3 @@
 bug: Failure to generate a good error message for use before definition
 
-Please see the comment in mutualuse2.good
+Please see the comment in mutualuse2.chpl

--- a/test/modules/diten/mutualuse3.bad
+++ b/test/modules/diten/mutualuse3.bad
@@ -1,1 +1,2 @@
-mutualuse3.chpl:9: error: use of 'a' before encountering its definition, type unknown
+1
+0

--- a/test/modules/diten/mutualuse3.chpl
+++ b/test/modules/diten/mutualuse3.chpl
@@ -1,3 +1,24 @@
+/*
+   This is an invalid Chapel program.
+
+   M3 contains main().
+
+   M3 uses M1 which uses M2.
+     This implies that the partial initialization order is M2, M1, M3.
+
+     This implies an attempt to initialize M2.n before M1.a has been
+     initialized.
+
+  Historically this program has failed to type-resolve "because"
+  function resolution determined the types of a and n in the same
+  order that the program would execute.
+
+  Changes to certain simple cases for resolution in Feb 2017 mean
+  that the types of M1.a and M2.n are known sooner and so the
+  program has started to compile.   For this case it happens to
+  produce stable output but this is not assured.
+*/
+
 module M1 {
   use M2;
 
@@ -6,12 +27,14 @@ module M1 {
 
 module M2 {
   use M1;
+
   var n = a;
 }
 
 module M3 {
-  proc main {
+  proc main() {
     use M1, M2;
+
     writeln(a);
     writeln(n);
   }

--- a/test/modules/diten/mutualuse3.future
+++ b/test/modules/diten/mutualuse3.future
@@ -1,6 +1,3 @@
-bug: out-of-order resolution
+bug: Failure to generate a good error message for use before definition
 
-bug: modules that mutually use each other can have some types lost
-
-This is like mutualuse.chpl, except in this case the type that is lost is
-a primitive type.
+Please see the comment in mutualuse3.chpl

--- a/test/modules/diten/mutualuse3.good
+++ b/test/modules/diten/mutualuse3.good
@@ -1,2 +1,1 @@
-1
-0
+This should be a useful error message about module init order.


### PR DESCRIPTION
I failed to notice that a recent PR had caused 2 versions of a legacy future had started to pass
when they should have kept failing.  Also fix a trivial typo in the .good file for the 3rd version
of this pattern of testing.
