### PR TITLE
Remove unused use of _value in test ra_prefetch.chpl

### DIFF
--- a/test/optimizations/cache-remote/ferguson/reduces_comm/ra_prefetch.chpl
+++ b/test/optimizations/cache-remote/ferguson/reduces_comm/ra_prefetch.chpl
@@ -44,8 +44,6 @@ proc test(n_prefetch:int): (int,real) {
       clock.clear();
       clock.start();
 
-      var data = A._value.theData;
-
       for j in 1..n {
         var i = f(j);
 


### PR DESCRIPTION
Test was no longer compiling after the multi-ddata merge,
but _value isn't actually used anyway, so I just removed it.

Verified that this test now passes on quickstart+GASNet configuration.