### PR TITLE
Get comm=ugni working with pgi

### DIFF
--- a/runtime/etc/Makefile.comm-ugni
+++ b/runtime/etc/Makefile.comm-ugni
@@ -29,9 +29,4 @@ ifeq (,$(findstring HUGETLB,$(PE_PRODUCT_LIST)))
 GEN_LFLAGS += -lhugetlbfs
 endif
 
-#
-# CCE doesn't understand -pthread, and the cc wrapper already throws -lpthread
-#
-ifneq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)
-GEN_LFLAGS += -pthread
-endif
+GEN_LFLAGS += -lpthread

--- a/runtime/src/comm/ugni/Makefile.share
+++ b/runtime/src/comm/ugni/Makefile.share
@@ -45,3 +45,8 @@ comm_ugni_CFLAGS = $(CHPL_MAKE_BASE_CFLAGS)
 ifeq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)
 comm_ugni_CFLAGS += -hipa0
 endif
+
+# Enable -c11 to get __thread support for pgi
+ifneq (, $(findstring pgi,$(CHPL_MAKE_TARGET_COMPILER)))
+comm_ugni_CFLAGS += -c11
+endif

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -4713,8 +4713,7 @@ int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len)
                                              void* opnd1,               \
                                              void* opnd2,               \
                                              int32_t loc) {             \
-    fork_t rf_req = { .a.cmd = _c,                                      \
-                      .a.obj = obj };                                   \
+    fork_t rf_req = { .a={.cmd=_c, .obj=obj} };                         \
     if (opnd1 != NULL)                                                  \
       memcpy(&rf_req.a.opnd1, opnd1, sizeof(_t));                       \
     if (opnd2 != NULL)                                                  \

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6221,16 +6221,16 @@ void chpl_resetCommDiagnosticsHere()
 
 void chpl_getCommDiagnosticsHere(chpl_commDiagnostics *cd)
 {
-  cd->get = (uint64_t) comm_diagnostics.get;
-  cd->get_nb = (uint64_t) comm_diagnostics.get_nb;
-  cd->put = (uint64_t) comm_diagnostics.put;
-  cd->put_nb = (uint64_t) comm_diagnostics.put_nb;
-  cd->test_nb = (uint64_t) comm_diagnostics.test_nb;
-  cd->wait_nb = (uint64_t) comm_diagnostics.wait_nb;
-  cd->try_nb = (uint64_t) comm_diagnostics.try_nb;
-  cd->execute_on = (uint64_t) comm_diagnostics.execute_on;
-  cd->execute_on_fast = (uint64_t) comm_diagnostics.execute_on_fast;
-  cd->execute_on_nb = (uint64_t) comm_diagnostics.execute_on_nb;
+  cd->get             = atomic_load_uint_least64_t(&comm_diagnostics.get);
+  cd->get_nb          = atomic_load_uint_least64_t(&comm_diagnostics.get_nb);
+  cd->put             = atomic_load_uint_least64_t(&comm_diagnostics.put);
+  cd->put_nb          = atomic_load_uint_least64_t(&comm_diagnostics.put_nb);
+  cd->test_nb         = atomic_load_uint_least64_t(&comm_diagnostics.test_nb);
+  cd->wait_nb         = atomic_load_uint_least64_t(&comm_diagnostics.wait_nb);
+  cd->try_nb          = atomic_load_uint_least64_t(&comm_diagnostics.try_nb);
+  cd->execute_on      = atomic_load_uint_least64_t(&comm_diagnostics.execute_on);
+  cd->execute_on_fast = atomic_load_uint_least64_t(&comm_diagnostics.execute_on_fast);
+  cd->execute_on_nb   = atomic_load_uint_least64_t(&comm_diagnostics.execute_on_nb);
 }
 
 void chpl_comm_ugni_help_register_global_var(int i, wide_ptr_t wide)

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -16,7 +16,7 @@ def get(flag='target'):
     if flag == 'network':
         atomics_val = overrides.get('CHPL_NETWORK_ATOMICS')
         if not atomics_val:
-            if chpl_comm.get() == 'ugni':
+            if chpl_comm.get() == 'ugni' and get('target') != 'locks':
                 atomics_val = 'ugni'
             else:
                 atomics_val = 'none'


### PR DESCRIPTION
Get ugni working with pgi:
 - switch a struct initializer that pgi couldn't handle
 - use atomic_load instead of just casting an atomic for comm diags
 - throw -c11 to get __thread support
 - just use -lpthread instead of -pthread
 - default to CHPL_NETWORK_ATOMICS=none when CHPL_ATOMICS=locks

This was mostly so that I didn't have to special case the documentation for
pgi, but it resulted in some minor cleanup as well.

With this ugni works with all supported Cray backends, including llvm