### PR TITLE
Add test/optimizations/bulkcomm/bharshbarg/remote.good to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -312,6 +312,8 @@ tags
 
 /test/npb/cg/bradc/latex
 
+/test/optimizations/bulkcomm/bharshbarg/remote.good
+
 /test/parallel/taskPar/taskIntents/src/*.d
 /test/parallel/taskPar/taskIntents/src/*.o
 

--- a/test/optimizations/bulkcomm/bharshbarg/CLEANFILES
+++ b/test/optimizations/bulkcomm/bharshbarg/CLEANFILES
@@ -1,0 +1,1 @@
+remote.good


### PR DESCRIPTION
@bradcray pointed out that this file is now generated and so should be cleaned/ignored.