### PR TITLE
Remove unnecessary 'no copy return' pragma

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -500,9 +500,6 @@ module ChapelArray {
   }
 
 
-  // BHARSH TODO: Is this 'no copy return' really necessary? Could we instead
-  // recognize that this is a 'convertValueToRuntimeType' function?
-  pragma "no copy return"
   proc chpl__convertValueToRuntimeType(arr: []) type
     return chpl__buildArrayRuntimeType(arr.domain, arr.eltType);
 


### PR DESCRIPTION
It turns out that this 'no copy return' pragma is unnecessary in this case.