### PR TITLE
Use Time.sleep so that these tests play nice with qthreads

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -844,3 +844,33 @@ timeVectorArray:
     - increased array-as-vec problem size (#3422)
   05/28/16:
     - upgrade jemalloc to 4.2.0 (#3919)
+
+dynamic:
+  02/28/17:
+    - Bring in upstream fixes for qthreads sleep interception bug (#5446)
+  03/04/17:
+    - Use Time.sleep so that these tests play nice with qthreads (#5483)
+
+distAdaptativeWSv1:
+  02/28/17:
+    - Bring in upstream fixes for qthreads sleep interception bug (#5446)
+  03/04/17:
+    - Use Time.sleep so that these tests play nice with qthreads (#5483)
+
+distAdaptativeWSv2:
+  02/28/17:
+    - Bring in upstream fixes for qthreads sleep interception bug (#5446)
+  03/04/17:
+    - Use Time.sleep so that these tests play nice with qthreads (#5483)
+
+guided:
+  02/28/17:
+    - Bring in upstream fixes for qthreads sleep interception bug (#5446)
+  03/04/17:
+    - Use Time.sleep so that these tests play nice with qthreads (#5483)
+
+distAdaptativeWS:
+  02/28/17:
+    - Bring in upstream fixes for qthreads sleep interception bug (#5446)
+  03/04/17:
+    - Use Time.sleep so that these tests play nice with qthreads (#5483)

--- a/test/functions/iterators/angeles/distAdaptativeWS.chpl
+++ b/test/functions/iterators/angeles/distAdaptativeWS.chpl
@@ -8,7 +8,6 @@
 
 // Contributed by Angeles Navarro 
 use DynamicIters;
-extern proc usleep(val:uint);
 config const nTasks:int=4; // number of cores; should be here.maxTaskPar?
 writeln("Working with ", nTasks, " Threads");
 
@@ -69,7 +68,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in adaptive(r,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  A[c]=A[c]+1;
 	}
 	t.stop();
@@ -104,7 +103,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in adaptive(r,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  B[c]=B[c]+1;
 	}
 	t.stop();
@@ -143,7 +142,7 @@ proc CheckCorrectness(grainsize:string)
       t.start();
       forall c in adaptive(r,nTasks) do {
 	for j in c..n do{
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  C[c,j]=C[c,j]+1;
 	}
       }
@@ -194,7 +193,7 @@ proc CheckCorrectness(grainsize:string)
   
       t.start();
       forall c in  adaptive(r,nTasks) do {
-	usleep(delayran(c));
+	sleep(delayran(c), TimeUnits.microseconds);
 	D[c]=D[c]+1;
       }
       t.stop();

--- a/test/functions/iterators/angeles/distAdaptativeWSv1.chpl
+++ b/test/functions/iterators/angeles/distAdaptativeWSv1.chpl
@@ -8,7 +8,6 @@
 
 // Contributed by Angeles Navarro 
 use DynamicIters;
-extern proc usleep(val:uint);
 config const nTasks:int=4; // number of cores; should be here.maxTaskPar?
 writeln("Working with ", nTasks, " Threads");
 
@@ -71,7 +70,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in adaptive(r,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  A[c]=A[c]+1;
 	}
 	t.stop();
@@ -106,7 +105,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in adaptive(r,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  B[c]=B[c]+1;
 	}
 	t.stop();
@@ -145,7 +144,7 @@ proc CheckCorrectness(grainsize:string)
       t.start();
       forall c in adaptive(r,nTasks) do {
 	for j in c..n do{
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  C[c,j]=C[c,j]+1;
 	}
       }
@@ -197,7 +196,7 @@ proc CheckCorrectness(grainsize:string)
   
       t.start();
       forall c in  adaptive(r,nTasks) do {
-	usleep(delayran(c));
+	sleep(delayran(c), TimeUnits.microseconds);
 	D[c]=D[c]+1;
       }
       t.stop();

--- a/test/functions/iterators/angeles/distAdaptativeWSv2.chpl
+++ b/test/functions/iterators/angeles/distAdaptativeWSv2.chpl
@@ -8,7 +8,6 @@
 
 // Contributed by Angeles Navarro 
 use DynamicIters;
-extern proc usleep(val:uint);
 config const nTasks:int=4; // number of cores; should be here.maxTaskPar?
 writeln("Working with ", nTasks, " Threads");
 
@@ -70,7 +69,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in adaptive(r,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  A[c]=A[c]+1;
 	}
 	t.stop();
@@ -105,7 +104,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in adaptive(r,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  B[c]=B[c]+1;
 	}
 	t.stop();
@@ -144,7 +143,7 @@ proc CheckCorrectness(grainsize:string)
       t.start();
       forall c in adaptive(r,nTasks) do {
 	for j in c..n do{
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  C[c,j]=C[c,j]+1;
 	}
       }
@@ -196,7 +195,7 @@ proc CheckCorrectness(grainsize:string)
   
       t.start();
       forall c in  adaptive(r,nTasks) do {
-	usleep(delayran(c));
+	sleep(delayran(c), TimeUnits.microseconds);
 	D[c]=D[c]+1;
       }
       t.stop();

--- a/test/functions/iterators/angeles/dynamic.chpl
+++ b/test/functions/iterators/angeles/dynamic.chpl
@@ -4,7 +4,6 @@
 
 // Contributed by Angeles Navarro 
 use DynamicIters;
-extern proc usleep(val:uint);
 config const nTasks:int=4; // number of cores; should be here.maxTaskPar?
 writeln("Working with ", nTasks, " Threads");
 
@@ -68,7 +67,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in dynamic(r,chunk,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  A[c]=A[c]+1;
 	}
 	t.stop();
@@ -103,7 +102,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in dynamic(r,chunk,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  B[c]=B[c]+1;
 	}
 	t.stop();
@@ -140,7 +139,7 @@ proc CheckCorrectness(grainsize:string)
       t.start();
       forall c in dynamic(r,chunk,nTasks) do {
 	for j in c..n do{
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  C[c,j]=C[c,j]+1;
 	}
       }
@@ -190,7 +189,7 @@ proc CheckCorrectness(grainsize:string)
   
       t.start();
       forall c in dynamic(r,chunk,nTasks) do {
-	usleep(delayran(c));
+	sleep(delayran(c), TimeUnits.microseconds);
 	D[c]=D[c]+1;
       }
       t.stop();

--- a/test/functions/iterators/angeles/guided.chpl
+++ b/test/functions/iterators/angeles/guided.chpl
@@ -6,7 +6,6 @@
 
 // Contributed by Angeles Navarro 
 use DynamicIters;
-extern proc usleep(val:uint);
 config const nTasks:int=4; // number of cores; should be here.maxTaskPar?
 writeln("Working with ", nTasks, " Threads");
 
@@ -67,7 +66,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in guided(r,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  A[c]=A[c]+1;
 	}
 	t.stop();
@@ -102,7 +101,7 @@ proc CheckCorrectness(grainsize:string)
 	writeln();
 	t.start();
 	forall c in guided(r,nTasks) do {
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  B[c]=B[c]+1;
 	}
 	t.stop();
@@ -141,7 +140,7 @@ proc CheckCorrectness(grainsize:string)
       t.start();
       forall c in guided(r,nTasks) do {
 	for j in c..n do{
-	  usleep(delay);
+	  sleep(delay, TimeUnits.microseconds);
 	  C[c,j]=C[c,j]+1;
 	}
       }
@@ -193,7 +192,7 @@ proc CheckCorrectness(grainsize:string)
   
       t.start();
       forall c in guided(r,nTasks) do {
-	usleep(delayran(c));
+	sleep(delayran(c), TimeUnits.microseconds);
 	D[c]=D[c]+1;
       }
       t.stop();


### PR DESCRIPTION
Prior to #5446 , qthreads was intercepting the ``usleep`` call. When that PR went in we observed a "regression" in nightly testing for these tests. Using ``Time.sleep`` is the proper way to sleep and play nice with the tasking layer.