### PR TITLE
Adjust STREAMS again for RandomStream interface change

### DIFF
--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
@@ -61,7 +61,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
@@ -61,7 +61,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
@@ -71,7 +71,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
@@ -66,7 +66,7 @@ proc initVectors(B, C) {
   // TODO: should write a fillRandom() implementation that does this
   coforall loc in B.dom.dist.targetLocs {
     on loc {
-      var randlist = new NPBRandomStream(real, seed);
+      var randlist = new NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
       randlist.skipToNth(B.locArr(loc).locDom.low);
       randlist.fillRandom(B.locArr(loc).myElems);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
@@ -77,7 +77,7 @@ proc initVectors(B, C) {
   // TODO: should write a fillRandom() implementation that does this
   coforall loc in B.dom.dist.targetLocDom {
     on B.dom.dist.targetLocs(loc) {
-      var randlist = new NPBRandomStream(real, seed);
+      var randlist = new NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
       randlist.skipToNth(B.locArr(loc).locDom.low);
       randlist.fillRandom(B.locArr(loc).myElems);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
@@ -85,7 +85,7 @@ proc initVectors(B, C) {
   // TODO: should write a fillRandom() implementation that does this
   coforall loc in B.dom.dist.targetLocDom {
     on B.dom.dist.targetLocs(loc) {
-      var randlist = new NPBRandomStream(real, seed);
+      var randlist = new NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
       randlist.skipToNth(B.locArr(loc).locDom.low);
       randlist.fillRandom(B.locArr(loc).myElems);

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
@@ -64,7 +64,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace, print) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
@@ -67,7 +67,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/bradc/stream-nopromote.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-nopromote.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-slice.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-slice.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
+++ b/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
@@ -67,7 +67,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/marybeth/stream.chpl
+++ b/test/studies/hpcc/STREAMS/marybeth/stream.chpl
@@ -71,7 +71,7 @@ proc main() {
 }
 
 proc initStreamVectors() {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(A);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/stream-hpcc06.chpl
+++ b/test/studies/hpcc/STREAMS/stream-hpcc06.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/stream-nopromote.chpl
+++ b/test/studies/hpcc/STREAMS/stream-nopromote.chpl
@@ -50,7 +50,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);


### PR DESCRIPTION
Adjusts .chpl files in test/studies/hpcc/STREAMS.

Use by-name argument passing to enable release-over-release testing.

Verified no compile failures when testing this directory with -performance under 1.14.
Verified directory passes local testing and local -performance testing.
Trivial, not reviewed.