### PR TITLE
fix return array through arg cases

### DIFF
--- a/test/arrays/ferguson/return-array.chpl
+++ b/test/arrays/ferguson/return-array.chpl
@@ -24,20 +24,19 @@ proc returnArrayArg(X) {
   for (x,i) in zip(X, 1..size) {
     x = i;
   }
-  return X;
 }
 
 proc returnArrayArgTyped(X:[1..size] real) {
   for (x,i) in zip(X, 1..size) {
     x = i;
   }
-  return X;
 }
 
 var t1 = new Timer();
 var t2 = new Timer();
 var t3 = new Timer();
 var t4 = new Timer();
+var sum0 = 0.0;
 var sum1 = 0.0;
 var sum2 = 0.0;
 var sum3 = 0.0;
@@ -47,6 +46,15 @@ writeln("checking array return performance");
 writeln("array size: ", size);
 writeln("iterations: ", iters);
 writeln();
+
+// Warm-up loop
+// I noticed that the 1st thing measured is slower
+// than the others...
+for it in 1..iters {
+  var A = returnArray();
+  for a in A do sum0 += a;
+}
+
 
 t1.start();
 


### PR DESCRIPTION
proc returnArrayArg(X) and proc returnArrayArgTyped(X:[1..size] real) are
meant to "return" the array by filling in the values of the argument.
But, they previously included a return statement. That return statement
was not needed.

Before the arrays rework, these functions wouldn't have a version made to
copy the argument out to the return variable (because of details of how
the implementation worked). But that does happen after the arrays rework.

Certainly we could consider re-enabling an optimization to avoid copies
from returning when a function is called but the return value is not
used. However that's unlikely to be important in real benchmarks.

When investigating performance, I also noticed a slight relative
slow-down in performance for the 1st thing tested here. So, I
added a warm-up loop that is not timed to try to tamp that down.

Passed -performance test/arrays/ferguson/ in quickstart and standard local configurations. 
Passed test/arrays/ferguson in local testing.