### PR TITLE
Wide-pointer optimization for arrays

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -62,6 +62,7 @@ extern bool fNoVectorize;
 extern bool fNoPrivatization;
 extern bool fNoOptimizeOnClauses;
 extern bool fNoRemoveEmptyRecords;
+extern bool fNoInferLocalFields;
 extern bool fRemoveUnreachableBlocks;
 extern bool fReplaceArrayAccessesWithRefTemps;
 extern int  optimize_on_clause_limit;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -554,7 +554,7 @@ static void setBaselineFlag(const ArgumentDescription* desc, const char* unused)
   fNoPrivatization = true;            // --no-privatization
   fNoOptimizeOnClauses = true;        // --no-optimize-on-clauses
   fIgnoreLocalClasses = true;         // --ignore-local-classes
-  fNoInferLocalFields = true;       // --local-field-inference
+  fNoInferLocalFields = true;         // --no-infer-local-fields
   //fReplaceArrayAccessesWithRefTemps = false; // don't tie this to --baseline yet
   fDenormalize = false;               // --no-denormalize
   fConditionalDynamicDispatchLimit = 0;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -114,6 +114,7 @@ bool fNoFormalDomainChecks = false;
 bool fNoLocalChecks = false;
 bool fNoNilChecks = false;
 bool fNoStackChecks = false;
+bool fNoInferLocalFields = false;
 bool fReplaceArrayAccessesWithRefTemps = false;
 bool fUserSetStackChecks = false;
 bool fNoCastChecks = false;
@@ -506,6 +507,7 @@ static void setFastFlag(const ArgumentDescription* desc, const char* unused) {
   fNoTupleCopyOpt = false;
   fNoPrivatization = false;
   fNoChecks = true;
+  fNoInferLocalFields = false;
   fIgnoreLocalClasses = false;
   fNoOptimizeOnClauses = false;
   //fReplaceArrayAccessesWithRefTemps = true; // don't tie this to --fast yet
@@ -552,6 +554,7 @@ static void setBaselineFlag(const ArgumentDescription* desc, const char* unused)
   fNoPrivatization = true;            // --no-privatization
   fNoOptimizeOnClauses = true;        // --no-optimize-on-clauses
   fIgnoreLocalClasses = true;         // --ignore-local-classes
+  fNoInferLocalFields = true;       // --local-field-inference
   //fReplaceArrayAccessesWithRefTemps = false; // don't tie this to --baseline yet
   fDenormalize = false;               // --no-denormalize
   fConditionalDynamicDispatchLimit = 0;
@@ -666,6 +669,7 @@ static ArgumentDescription arg_desc[] = {
  {"tuple-copy-opt", ' ', NULL, "Enable [disable] tuple (memcpy) optimization", "n", &fNoTupleCopyOpt, "CHPL_DISABLE_TUPLE_COPY_OPT", NULL},
  {"tuple-copy-limit", ' ', "<limit>", "Limit on the size of tuples considered for optimization", "I", &tuple_copy_limit, "CHPL_TUPLE_COPY_LIMIT", NULL},
  {"use-noinit", ' ', NULL, "Enable [disable] ability to skip default initialization through the keyword noinit", "N", &fUseNoinit, NULL, NULL},
+ {"infer-local-fields", ' ', NULL, "Enable [disable] analysis to infer local fields in classes and records (experimental)", "n", &fNoInferLocalFields, "CHPL_DISABLE_INFER_LOCAL_FIELDS", NULL},
  {"vectorize", ' ', NULL, "Enable [disable] generation of vectorization hints", "n", &fNoVectorize, "CHPL_DISABLE_VECTORIZATION", NULL},
 
  {"", ' ', NULL, "Run-time Semantic Check Options", NULL, NULL, NULL, NULL},

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -306,7 +306,7 @@ static bool isRefType(BaseAST* bs)
 }
 
 static bool isArrayRec(BaseAST* bs) {
-  return isRecord(bs->typeInfo()) && bs->typeInfo()->symbol->hasFlag(FLAG_ARRAY);
+  return isRecord(bs->typeInfo()) && bs->typeInfo()->symbol->hasFlag(FLAG_ARRAY) && !fNoInferLocalFields;
 }
 
 static bool isObj(BaseAST* bs) {
@@ -568,7 +568,7 @@ static void printCauses(Symbol* sym) {
 static void setWide(BaseAST* cause, Symbol* sym) {
   if (!typeCanBeWide(sym)) return;
   if (isArgSymbol(sym) && sym->defPoint->parentSymbol->hasFlag(FLAG_LOCAL_ARGS)) return;
-  if (isVarSymbol(sym) && sym->defPoint->parentSymbol->hasFlag(FLAG_ARRAY)) {
+  if (isVarSymbol(sym) && sym->defPoint->parentSymbol->hasFlag(FLAG_ARRAY) && !fNoInferLocalFields) {
     // Do not widen the '_instance' field of an _array record
     return;
   }
@@ -893,7 +893,7 @@ static void addKnownWides() {
         if (typeCanBeWide(var)) {
           setWide(fn, var);
         }
-        if (isRecord(var->type) && isArrayRec(var)) {
+        if (isRecord(var->type) && !isArrayRec(var)) {
           widenSubAggregateTypes(fn, var->type);
         }
       }
@@ -2480,7 +2480,9 @@ insertWideReferences(void) {
     }
   }
 
-  fixArrayTypes();
+  if (fNoInferLocalFields == false) {
+    fixArrayTypes();
+  }
 
   // IWR
   insertStringLiteralTemps();

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -257,6 +257,11 @@ OPTIONS
     Enable [disable] ability to skip default initialization through the
     keyword noinit
 
+**--[no-]infer-local-fields**
+
+    Enable [disable] analysis to infer local fields in classes and records
+    (experimental)
+
 *Run-time Semantic Check Options* 
 
 **--no-checks**

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -54,6 +54,9 @@ Optimization Control Options:
       --[no-]use-noinit               Enable [disable] ability to skip default
                                       initialization through the keyword
                                       noinit
+      --[no-]infer-local-fields       Enable [disable] analysis to infer local
+                                      fields in classes and records
+                                      (experimental)
       --[no-]vectorize                Enable [disable] generation of
                                       vectorization hints
 

--- a/test/optimizations/widepointers/return.bad
+++ b/test/optimizations/widepointers/return.bad
@@ -1,0 +1,14 @@
+Starting reflect()...
+{x = 11}
+{x = 11}
+Local var was returned as wide pointer: true
+{x = 42}
+{x = 42}
+Remote var was returned as wide pointer: true
+Starting assignReflect()...
+{x = 11}
+{x = 1337}
+Local var was returned as wide pointer: true
+{x = 42}
+{x = 1337}
+Remote var was returned as wide pointer: true

--- a/test/optimizations/widepointers/return.future
+++ b/test/optimizations/widepointers/return.future
@@ -1,0 +1,5 @@
+Performance: Wide-pointer analysis should be able to infer wideness of returned classes
+
+This test was working prior to 1.15, but was futurized because:
+1) The analysis was the source of sporadic compile-time bugs
+2) I planned to rewrite IWR entirely

--- a/test/optimizations/widepointers/slicing.chpl
+++ b/test/optimizations/widepointers/slicing.chpl
@@ -7,7 +7,7 @@ proc main() {
   // type to be a wide pointer.
   for a in A[1..n/2] do a = 2;
 
-  writeln("A is wide pointer? ", __primitive("is wide pointer", A));
+  writeln("A is wide pointer? ", __primitive("is wide pointer", A._value));
 
   writeln("SUCCESS");
 }


### PR DESCRIPTION
IWR will now pretend that an _array record is actually the _instance
class inside of that record. This allows for the _instance field to be
inferred to be local (when being accessed), which improves performance
for array indexing. I expect this optimization to have a positive impact
on ISx performance.

With the ArrayViews work in, the wide-return optimization is no longer
very useful. I have removed it because:
- it is complex and ugly
- it has been the source of sporadic compiler bugs
- it will hopefully be re-implemented in a more general way in the future

This optimization can be toggled with a new compiler flag named
``--[no-]infer-local-fields``. I expect to keep this flag long-term, but
have marked it as 'experimental' in the meantime.

Testing:
- [x] local
- [x] no-local
- [x] no-local --no-infer-local-fields
- [x] gasnet