### PR TITLE
Fix --fast failure by always throwing --bounds-checks for this test

### DIFF
--- a/test/distributions/bradc/blkCyc/blkCycSliceOOB.compopts
+++ b/test/distributions/bradc/blkCyc/blkCycSliceOOB.compopts
@@ -1,0 +1,1 @@
+--bounds-checks


### PR DESCRIPTION
This test was written to do bounds checks, so here I'm throwing the
flag to make sure they're enabled even if testing in configurations
like --fast that would normally disable them.