### PR TITLE
Update more tests to pass to RandomStream by name

### DIFF
--- a/test/arrays/diten/arrayPerformance.chpl
+++ b/test/arrays/diten/arrayPerformance.chpl
@@ -32,7 +32,7 @@ proc main {
 
 proc initialize(B) {
   use Random;
-  var rnd = new RandomStream(real, randSeed);
+  var rnd = new RandomStream(eltType=real, seed=randSeed);
   rnd.fillRandom(B);
   delete rnd;
 }

--- a/test/domains/ferguson/build-associative.chpl
+++ b/test/domains/ferguson/build-associative.chpl
@@ -6,7 +6,7 @@ config const table = false;
 use Time;
 use Random;
 
-var rng = makeRandomStream(int, 0, false, RNG.PCG);
+var rng = makeRandomStream(eltType=int, seed=0, parSafe=false, algorithm=RNG.PCG);
 
 //var t2 = new Timer();
 //var t3 = new Timer();

--- a/test/npb/cg/bradc/cg-makea.chpl
+++ b/test/npb/cg/bradc/cg-makea.chpl
@@ -11,7 +11,7 @@ module CGMakeA {
     var size = 1.0;
     const ratio = rcond ** (1.0 / n);
 
-    var randStr = new NPBRandomStream(real, 314159265);
+    var randStr = new NPBRandomStream(eltType=real, seed=314159265);
     randStr.getNext();   // drop a value on floor to match NPB version
 
     for iouter in 1..n {

--- a/test/performance/compiler/bradc/cg-makea.chpl
+++ b/test/performance/compiler/bradc/cg-makea.chpl
@@ -11,7 +11,7 @@ module CGMakeA {
     var size = 1.0;
     const ratio = rcond ** (1.0 / n);
 
-    var randStr = new NPBRandomStream(real, 314159265);
+    var randStr = new NPBRandomStream(eltType=real, seed=314159265);
     randStr.getNext();   // drop a value on floor to match NPB version
 
     for iouter in 1..n {

--- a/test/performance/thomasvandoren/TestHelpers.chpl
+++ b/test/performance/thomasvandoren/TestHelpers.chpl
@@ -15,7 +15,7 @@ config const printC = true,
 // matrices.
 config const scalingFactor = 1;
 
-var randStream = makeRandomStream(real, randSeed, algorithm=RNG.NPB),
+var randStream = makeRandomStream(eltType=real, seed=randSeed, algorithm=RNG.NPB),
   timer: Timer;
 
 const inner = 1..5 * scalingFactor,

--- a/test/release/examples/benchmarks/hpcc/stream-ep.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream-ep.chpl
@@ -153,7 +153,7 @@ proc printConfiguration() {
 // Initialize vectors B and C using a random stream of values
 //
 proc initVectors(B, C) {
-  var randlist = new RandomStream(real, seed);
+  var randlist = new RandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/release/examples/benchmarks/hpcc/stream.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream.chpl
@@ -105,7 +105,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
+++ b/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
@@ -103,7 +103,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(real, seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/users/npadmana/twopt/do_smu_aos.chpl
+++ b/test/users/npadmana/twopt/do_smu_aos.chpl
@@ -42,7 +42,7 @@ record WeightedParticle3D {
 
 proc generateRandom(pp : []WeightedParticle3D) {
   var x,y,z : real;
-  var rng = new RandomStream(real);
+  var rng = new RandomStream(eltType=real);
   for ip in pp {
     x = rng.getNext()*1000.0; y = rng.getNext()*1000.0; z=rng.getNext()*1000.0;
     ip.x = (x,y,z);

--- a/test/users/npadmana/twopt/do_smu_soa.chpl
+++ b/test/users/npadmana/twopt/do_smu_soa.chpl
@@ -55,7 +55,7 @@ class Particle3D {
     Darr = {ParticleAttrib, 0.. #npart};
     Dpart = {0.. #npart};
     if random {
-      var rng = new RandomStream(real);
+      var rng = new RandomStream(eltType=real);
       var x, y, z : real;
       for ii in Dpart {
         x = rng.getNext()*1000.0; y = rng.getNext()*1000.0; z = rng.getNext()*1000.0;


### PR DESCRIPTION
Continuing #5485  enable release-over-release testing.

Verified tests that were failing in last release-over-release run pass now in normal testing (except for  studies/hpcc/STREAMS/perfComp/ which passes with -performance and is skipped in normal testing).

Passed full local testing.