### PR TITLE
Update isUserDefinedRecord

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1708,7 +1708,7 @@ bool isString(Type* type) {
 }
 
 //
-// NOAKES 2016/02/29
+// Noakes 2016/02/29
 //
 // To support the merge of the string-as-rec branch we defined a
 // function, isString(), which is only true of the record that was
@@ -1726,8 +1726,13 @@ bool isString(Type* type) {
 // In the longer term we plan to further broaden the cases that the new
 // logic can handle and reduce the exceptions that are filtered out here.
 //
-// MPF 2016-09-15
+//
+//
+// MPF    2016/09/15
 // This function now includes tuples, distributions, domains, and arrays.
+//
+// Noakes 2017/03/02
+// This function now includes range and atomics
 //
 bool isUserDefinedRecord(Type* type) {
   bool retval = false;
@@ -1738,18 +1743,15 @@ bool isUserDefinedRecord(Type* type) {
 
     // Must be a record type
     if (aggr->aggregateTag != AGGREGATE_RECORD) {
-
-    // Not a range
-    } else if (sym->hasFlag(FLAG_RANGE)              == true) {
-
-    // Not an atomic type
-    } else if (sym->hasFlag(FLAG_ATOMIC_TYPE)        == true) {
+      retval = false;
 
     // Not a RUNTIME_type
     } else if (sym->hasFlag(FLAG_RUNTIME_TYPE_VALUE) == true) {
+      retval = false;
 
     // Not an iterator
     } else if (strncmp(name, "_ir_", 4)              ==    0) {
+      retval = false;
 
     } else {
       retval = true;


### PR DESCRIPTION
Summary: This PR reduces the number of special cases that distinguish isRecord() from the
transition function isUserDefinedRecord(). This causes ranges and the atomic types to be
handled more consistently with user-defined records.

This is a "trivial" change; just 2 lines of code are involved.  I paratested with single-locale
and no-local and I verified that memory leaks are unchanged.




Details: isUserDefinedRecord() was an extension of the predicate isString() which was created
during the steps to land the string-as-rec branch.  It is used to control the number of record-like
types that are handled by certain new logic paths.


A recent change to the normalization of certain DefExprs generated 88 failures for no-local
testing.   All of these errors were due to an assertion in parallel.cpp that is responsible for
replicating const module-level variables.  This code was unable to recognize that certain variables
were "defined" exactly once; in fact it couldn't find any definitions.  This is a consequence of
the challenge of computing def-use points for ref variables.  Normalization currently generates
"extra" temporary variables for const variables that masks this issue.

In the cases that are failing the ref-variables are injected by the code to convert functions that
return records to be functions that, conceptually, return records by out intent but in an unprincipled
way.

There are two implementations of this transformation; the original version and a version that I
created during string-as-rec.  They're both pretty awful but the new one is slightly more
manageable.  The failing cases that I was looking at were going through the old code and
prompted me to determine if more cases could be diverted to the new implementation.  Sure
enough ranges and the atomic-types are now ready for the preferred code paths.


As a further test for this PR I created a separate branch in which I applied the recent normalization
change on top of this PR and ran a full gasnet paratest.  This simple change reduced the number
of regressions from 88 to 24.





