### PR TITLE
Update .good file to match recent deprecation of '=>' 

### DIFF
--- a/test/arrays/deitz/part7/test_illegal_named_alias_argument.good
+++ b/test/arrays/deitz/part7/test_illegal_named_alias_argument.good
@@ -1,1 +1,2 @@
+test_illegal_named_alias_argument.chpl:7: warning: support for '=>' in constructor argument lists is deprecated as of chpl version 1.15 and is unlikely to work as well as it used to.  If you rely on this feature, please let the Chapel team know.
 test_illegal_named_alias_argument.chpl:7: error: alias-named-argument passing can only be used in constructor calls


### PR DESCRIPTION
I happened to notice that arrays/deitz/part7/test_illegal_named_alias_argument.chpl
started failing due to Brad's recent update.  This updates the .good file to resolve this.
