### PR TITLE
Remove '=>'-in-constructor error test

### DIFF
--- a/test/arrays/deitz/part7/test_illegal_named_alias_argument.chpl
+++ b/test/arrays/deitz/part7/test_illegal_named_alias_argument.chpl
@@ -1,7 +1,0 @@
-proc foo(A: [1..3] int) {
-  writeln(A);
-}
-
-var B: [2..4] int;
-
-foo(A=>B);

--- a/test/arrays/deitz/part7/test_illegal_named_alias_argument.good
+++ b/test/arrays/deitz/part7/test_illegal_named_alias_argument.good
@@ -1,2 +1,0 @@
-test_illegal_named_alias_argument.chpl:7: warning: support for '=>' in constructor argument lists is deprecated as of chpl version 1.15 and is unlikely to work as well as it used to.  If you rely on this feature, please let the Chapel team know.
-test_illegal_named_alias_argument.chpl:7: error: alias-named-argument passing can only be used in constructor calls


### PR DESCRIPTION
This test escaped my deprecation of '=>' commits earlier because I was
mistakenly grepping for tests that used '=>' and 'new' on the same
line when double-checking that I'd caught everything after my full test
run, and was mis-accounting for the number of tests I needed to
update (I'd already accidentally blown away the logs and thought I had
both cases, so didn't want to re-run).  Here, I'm retiring the test because
we already have a placeholder for the new deprecation warning and this
test itself doesn't add additional value.  Thanks to @noakesmichael for
saving me the embarrassment of having this fail everywhere by updating its
.good earlier.