### PR TITLE
Add const to QualifiedType::qualStr() method

### DIFF
--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -213,13 +213,15 @@ public:
     return _qual;
   }
 
-  const char* qualStr() {
+  const char* qualStr() const {
     Qualifier q = _qual;
+
     if (isRefType()) {
       q = QUAL_REF;
     } else if (isWideRefType()) {
       q = QUAL_WIDE_REF;
     }
+
     switch (q) {
       case QUAL_UNKNOWN:
         return "unknown";


### PR DESCRIPTION
This is a trivial change to include/type.h to add the const qualifier to the method
QualifiedType::qualStr().  This method now matches the comparable methods in
this class.


Compiled with/without CHPL_DEVELOPER on clang/darwin, gcc/linux64.  Also compiled
with CHPL_DEVELOPER and CHPL_LLVM=llvm.

This is a trivial header file change but I did run small portions of release/ on darwin and linux64
out of superstition.
