### PR TITLE
Tweak AstDumpToNode to report the type-qualifier for a Symbol

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -1609,7 +1609,9 @@ void AstDumpToNode::writeSymbol(Symbol* sym) const
       else
       {
         writeLongString("name: ", name);
-        len = writeType(sym->type);
+
+        len = 0   + writeQual(sym->qualType());
+        len = len + writeType(sym->type);
       }
 
       if (compact == false && var->depth() >= 0)
@@ -1812,6 +1814,15 @@ void AstDumpToNode::ast_symbol(Symbol* sym, bool def)
 #endif
 
   mNeedSpace = true;
+}
+
+int AstDumpToNode::writeQual(QualifiedType qual) const
+{
+  const char* name = qual.qualStr();
+
+  fprintf(mFP, "qual: %s", name);
+
+  return 6 + ((int) strlen(name));
 }
 
 int AstDumpToNode::writeType(Type* type, bool announce) const

--- a/compiler/include/AstDumpToNode.h
+++ b/compiler/include/AstDumpToNode.h
@@ -27,8 +27,10 @@
 class BaseAST;
 class Expr;
 class ModuleSymbol;
+class QualifiedType;
 class Symbol;
 class Type;
+
 
 class AstDumpToNode : public AstLogger
 {
@@ -142,9 +144,11 @@ private:
   void             ast_symbol(const char* tag, Symbol* sym, bool def);
   void             ast_symbol(Symbol* sym, bool def);
 
-  void             writeSymbol(Symbol* sym)                             const;
-  void             writeSymbolCompact(Symbol* sym)                      const;
-  int              writeType(Type* type, bool announce = true)          const;
+  void             writeSymbol(Symbol* sym)                              const;
+  void             writeSymbolCompact(Symbol* sym)                       const;
+
+  int              writeQual(QualifiedType type)                         const;
+  int              writeType(Type*         type, bool announce = true)   const;
 
   void             write(const char* text);
   void             write(bool spaceBefore, const char* text, bool spaceAfter);


### PR DESCRIPTION
Trivial tweaks so that AstDumpToNode reports the qualifier portion
of a type when printing the value of a symbol.

Compiled with/without CHPL_DEVELOPER on clang/darwin, gcc/linux64 and with
CHPL_DEVELOPER and CHPL_LLVM=llvm.

Also ran portions of release/  on darwin and linux64 out of superstition
