### PR TITLE
Introduce PRIM_INIT_VAR

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -449,13 +449,15 @@ void
 initPrimitive() {
   primitives[PRIM_UNKNOWN] = NULL;
 
-
   prim_def(PRIM_ACTUALS_LIST, "actuals list", returnInfoVoid);
   prim_def(PRIM_NOOP, "noop", returnInfoVoid);
   prim_def(PRIM_MOVE, "move", returnInfoVoid, false, true);
-  prim_def(PRIM_INIT, "init", returnInfoFirstDeref);
-  prim_def(PRIM_NO_INIT, "no init", returnInfoFirstDeref);
+
+  prim_def(PRIM_INIT,      "init",      returnInfoFirstDeref);
+  prim_def(PRIM_INIT_VAR,  "initVar",   returnInfoVoid);
+  prim_def(PRIM_NO_INIT,   "no init",   returnInfoFirstDeref);
   prim_def(PRIM_TYPE_INIT, "type init", returnInfoFirstDeref);
+
   prim_def(PRIM_INITIALIZER_SET_FIELD, "initializer set field", returnInfoVoid, false, true);
   prim_def(PRIM_REF_TO_STRING, "ref to string", returnInfoStringC);
   prim_def(PRIM_RETURN, "return", returnInfoFirst, true);

--- a/compiler/include/primitive.h
+++ b/compiler/include/primitive.h
@@ -33,7 +33,9 @@ enum PrimitiveTag {
   PRIM_ACTUALS_LIST,
   PRIM_NOOP,
   PRIM_MOVE,
+
   PRIM_INIT,
+  PRIM_INIT_VAR,
   PRIM_NO_INIT,
   PRIM_TYPE_INIT,       // Used in a context where only a type is needed.
                         // Establishes the type of the result without

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -240,6 +240,7 @@ classifyPrimitive(CallExpr *call) {
   case PRIM_REDUCE_ASSIGN:
   case PRIM_NEW:
   case PRIM_INIT:
+  case PRIM_INIT_VAR:
   case PRIM_NO_INIT:
   case PRIM_TYPE_INIT:
   case PRIM_INITIALIZER_SET_FIELD:

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -596,18 +596,16 @@ static void checkUseBeforeDefs() {
 static Symbol* theDefinedSymbol(BaseAST* ast) {
   Symbol* retval = NULL;
 
-  // 1) A symbol is "defined" if it is the LHS of a move or assign
-  if (CallExpr* call = toCallExpr(ast)) {
-    if (call->isPrimitive(PRIM_MOVE) || call->isPrimitive(PRIM_ASSIGN)) {
-      if (SymExpr* se = toSymExpr(call->get(1))) {
-        retval = se->symbol();
-      }
-    }
-
-  // 2) Another way to find the symbol that will be found by 1)
-  } else if (SymExpr* se = toSymExpr(ast)) {
+  // A symbol is "defined" if it is the LHS of a move, an assign,
+  // or a variable initialization.
+  //
+  // The caller performs a post-order traversal and so we find the
+  // symExpr before we see the callExpr
+  if (SymExpr* se = toSymExpr(ast)) {
     if (CallExpr* call = toCallExpr(se->parentExpr)) {
-      if (call->isPrimitive(PRIM_MOVE) || call->isPrimitive(PRIM_ASSIGN)) {
+      if (call->isPrimitive(PRIM_MOVE)     == true  ||
+          call->isPrimitive(PRIM_ASSIGN)   == true  ||
+          call->isPrimitive(PRIM_INIT_VAR) == true)  {
         if (call->get(1) == se) {
           retval = se->symbol();
         }
@@ -1154,8 +1152,15 @@ static void insert_call_temps(CallExpr* call)
 
   VarSymbol* tmp = newTemp("call_tmp");
 
-  if (!parentCall || !parentCall->isNamed("chpl__initCopy"))
+
+  // Add FLAG_EXPR_TEMP unless this tmp is being used
+  // as a sub-expression for a variable initialization.
+  // This flag triggers autoCopy/autoDestroy behavior.
+  if (parentCall == NULL ||
+      (parentCall->isNamed("chpl__initCopy")  == false &&
+       parentCall->isPrimitive(PRIM_INIT_VAR) == false)) {
     tmp->addFlag(FLAG_EXPR_TEMP);
+  }
 
   if (call->isPrimitive(PRIM_NEW))
     tmp->addFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW);
@@ -1624,17 +1629,11 @@ static void normVarTypeInference(DefExpr* defExpr) {
     Type* type = initSym->symbol()->type;
 
     if (isPrimitiveScalar(type) == true) {
-      defExpr->insertAfter(new CallExpr(PRIM_MOVE, var, initExpr));
+      defExpr->insertAfter(new CallExpr(PRIM_MOVE,     var, initExpr));
 
       var->type = type;
-
-    } else if (var->hasFlag(FLAG_NO_COPY) == true)  {
-      defExpr->insertAfter(new CallExpr(PRIM_MOVE, var, initExpr));
-
     } else {
-      CallExpr* rhs = new CallExpr("chpl__initCopy", initExpr);
-
-      defExpr->insertAfter(new CallExpr(PRIM_MOVE, var, rhs));
+      defExpr->insertAfter(new CallExpr(PRIM_INIT_VAR, var, initExpr));
     }
 
   // e.g.
@@ -1667,14 +1666,7 @@ static void normVarTypeInference(DefExpr* defExpr) {
       }
 
     } else {
-      if (var->hasFlag(FLAG_NO_COPY) == true) {
-        defExpr->insertAfter(new CallExpr(PRIM_MOVE, var, initExpr));
-
-      } else {
-        CallExpr* rhs = new CallExpr("chpl__initCopy", initExpr);
-
-        defExpr->insertAfter(new CallExpr(PRIM_MOVE, var, rhs));
-      }
+      defExpr->insertAfter(new CallExpr(PRIM_INIT_VAR, var, initExpr));
     }
 
   } else {


### PR DESCRIPTION
Summary:

This PR moves a small amount of resolution business logic from normalize.cpp
to functionResolution.cpp as a step towards improving the final version of
non-generic record initialization.

This first PR alters the AST emitted by normalize() for common uses of DefExpr
but has no impact on the AST emitted by resolve().  Hence there should be no
impact on application behavior.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Paratested with single-locale and gasnet on linux64.





Additional discussion.

Consider

  var x = buildMyRecord();

Before this PR, normalization converted this to (approximately)

  var tmp = buildMyRecord();
  CallExpr(PRIM_MOVE, x, CallExpr("initCopy", tmp));

This poses a challenge to initializing records in the desired manner.
This PR introduces a new primitive PRIM_INIT_VAR to avoid injecting the
initCopy prematurely.  Normalization becomes

  var tmp = buildMyRecord();
  CallExpr(PRIM_INIT_VAR, x, tmp);

and delays handling tmp until the type can be inspected i.e. in that
portion of resolution that is currently implemented in functionResolution.cpp.

However this first PR does not actually leverage the type information to emit
better AST.  This simply relocates existing business logic.
