### PR TITLE
Fix denormalize bug with PRIM_ARRAY_SHIFT_BASE_POINTER

### DIFF
--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -319,11 +319,16 @@ bool isDenormalizable(Symbol* sym,
                   // FnSymbol expects to return one symbol, so it's easier to
                   // just not denormalize the returned symbol.
                   //
-                  // shift-base-pointer: we do not want to denormalize this:
+                  // PRIM_ARRAY_SHIFT_BASE_POINTER sets its first argument, so
+                  // we should not denormalize if 'se' is the first actual in
+                  // case of AST like this:
                   //   var ret = (cast ddata(...) nil)
                   //   shift_base_pointer(ret, ...)
-                  // into this:
+                  // turning into this:
                   //   shift_base_pointer((cast ddata nil), ...)
+                  //
+                  // TODO: Have PRIM_ARRAY_SHIFT_BASE_POINTER return instead of
+                  // setting its first arg, then we can rely on PRIM_MOVE logic.
                   //
                   ce->isPrimitive(PRIM_ARRAY_GET) ||
                   ce->isPrimitive(PRIM_GET_MEMBER) ||

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -319,11 +319,18 @@ bool isDenormalizable(Symbol* sym,
                   // FnSymbol expects to return one symbol, so it's easier to
                   // just not denormalize the returned symbol.
                   //
+                  // shift-base-pointer: we do not want to denormalize this:
+                  //   var ret = (cast ddata(...) nil)
+                  //   shift_base_pointer(ret, ...)
+                  // into this:
+                  //   shift_base_pointer((cast ddata nil), ...)
+                  //
                   ce->isPrimitive(PRIM_ARRAY_GET) ||
                   ce->isPrimitive(PRIM_GET_MEMBER) ||
                   ce->isPrimitive(PRIM_DEREF) ||
                   ce->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
                   ce->isPrimitive(PRIM_RETURN) ||
+                  (ce->isPrimitive(PRIM_ARRAY_SHIFT_BASE_POINTER) && ce->get(1) == se) ||
                   (ce->isPrimitive(PRIM_MOVE) &&
                    ce->get(1)->typeInfo() !=
                    ce->get(2)->typeInfo()))) {


### PR DESCRIPTION
Denormalize was modifying a PRIM_ARRAY_SHIFT_BASE_POINTER call such that
the return expr (the first expr in the alist) was an rvalue. More
specifically, it would transform AST like this:

  var ret = (cast ddata nil)
  shift_base_pointer(ret, ...)

into this:

  shift_base_pointer((cast ddata nil), ...)

Long-term, a better solution will be to have PRIM_ARRAY_SHIFT_BASE_POINTER return something instead of setting its first argument. We could then rely on PRIM_MOVE's logic.

Testing:
- [x] full local