### PR TITLE
Fix to this morning's 16-node XC perf annotation

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -223,7 +223,7 @@ all:
       config: chapcs
   03/03/17:
     - Array views (#5338)
-  03/05/17:
+  03/06/17:
     - Wide-pointer optimization for arrays (#5487)
 
 
@@ -426,10 +426,13 @@ hpl_performance:
     - text: Improvements to inferConstRefs (#4904)
       config: 16 node XC
 
-hpl.hpcc2012:
+hpl.hpcc2012.ml-perf:
   03/03/17:
-    - text: Rewrote test as part of array views (#5338)
-      config: 16 node XC
+    - text: Modified test as part of array views (#5338)
+
+hpl.hpcc2012.ml-time:
+  03/03/17:
+    - text: Modified test as part of array views (#5338)
 
 init:
   05/03/16:


### PR DESCRIPTION
I got the format wrong for this case.  Also had a typical off-by-one
error for the date of BHarsh's wide pointer optimization.