### PR TITLE
Add a workaround for an issue with RVF'ing a reduce intent shadow var

### DIFF
--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -167,9 +167,19 @@ IntentTag concreteIntentForArg(ArgSymbol* arg) {
   else if (arg->hasFlag(FLAG_ARG_THIS) && arg->intent == INTENT_CONST)
     return constIntentForThisArg(arg->type);
   else if (toFnSymbol(arg->defPoint->parentSymbol)->hasFlag(FLAG_EXTERN) &&
-           arg->intent == INTENT_BLANK) {
+           arg->intent == INTENT_BLANK)
     return INTENT_CONST_IN;
-  } else
+  else if (toFnSymbol(arg->defPoint->parentSymbol)->hasFlag(FLAG_ALLOW_REF) &&
+           arg->type->symbol->hasFlag(FLAG_REF))
+
+    // This is a workaround for an issue with RVF erroneously forwarding a
+    // reduce variable. The workaround adjusts the build_tuple_always_allow_ref
+    // call to take all _ref arguments by `ref` intent regardless of
+    // the type. It would be better to rely on task/forall intents
+    // to correctly mark const / not const / maybe const.
+    return INTENT_REF;
+
+  else
     return concreteIntent(arg->intent, arg->type);
 
 }

--- a/test/optimizations/bulkcomm/bharshbarg/remote.good.orig
+++ b/test/optimizations/bulkcomm/bharshbarg/remote.good.orig
@@ -11,6 +11,33 @@ Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
 Original domains   :(1..10, 1..10) <-- (1..10, 1..10)
 LBlk = (10, 1)
 RBlk = (10, 1)
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 0
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 0
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=2, elemSize=8
+	local get() from 0
 BulkTransferStride with values:
 	Locale        = 0
 	Stride levels = 1
@@ -29,6 +56,33 @@ Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
 Original domains   :(1..10, 1..10) <-- (1..10, 1..10)
 LBlk = (10, 1)
 RBlk = (10, 1)
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 0
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 0
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=2, elemSize=8
+	local get() from 0
 BulkTransferStride with values:
 	Locale        = 0
 	Stride levels = 1
@@ -51,6 +105,33 @@ Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
 Original domains   :(1..10, 1..10) <-- (1..10, 1..10)
 LBlk = (10, 1)
 RBlk = (10, 1)
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 1
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 1
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=2, elemSize=8
+	local get() from 1
 BulkTransferStride with values:
 	Locale        = 1
 	Stride levels = 1
@@ -69,6 +150,33 @@ Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
 Original domains   :(1..10, 1..10) <-- (1..10, 1..10)
 LBlk = (10, 1)
 RBlk = (10, 1)
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 1
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 1
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=2, elemSize=8
+	local get() from 1
 BulkTransferStride with values:
 	Locale        = 1
 	Stride levels = 1
@@ -92,6 +200,33 @@ Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
 Original domains   :(1..10, 1..10) <-- (1..10, 1..10)
 LBlk = (10, 1)
 RBlk = (10, 1)
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 0
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 0
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=2, elemSize=8
+	local get() from 0
 BulkTransferStride with values:
 	Locale        = 0
 	Stride levels = 1
@@ -111,6 +246,33 @@ Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
 Original domains   :(1..10, 1..10) <-- (1..10, 1..10)
 LBlk = (10, 1)
 RBlk = (10, 1)
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 1
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=1, elemSize=8
+	local get() from 1
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiCanBulkTransfer()
+isDataContiguous(): origin=0 off=(1) blk=(1)
+	YES!
+In DefaultRectangularArr.doiUseBulkTransfer()
+In DefaultRectangularArr.doiBulkTransfer(): Alo=(1), Blo=(1), len=2, elemSize=8
+	local get() from 1
 BulkTransferStride with values:
 	Locale        = 1
 	Stride levels = 1


### PR DESCRIPTION
After PR #5134, the _build_tuple_always_allow_ref function used in the
implementation of reduce intents no longer caused remote value forwarding
to decide references were mutable. The result was forwarding and
localizing a reference to a reduction shadow variable in this test

    parallel/forall/vass/binary-tree-spawn.no-recurse.chpl

This PR adds a simple workaround to resolveIntents to restore something
like the previous behavior. However, it would be better for forall/task
intents to clearly mark the arguments in a way that distinguishes these
cases for references:

 * not const
 * const
 * later analysis should decide if it's const

Passed full local testing.
Passed GASNet testing.
Trivial and not reviewed.