### PR TITLE
Restore previous level of memory leaks in studies/amr code

### DIFF
--- a/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
+++ b/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
@@ -104,6 +104,18 @@ class CandidateDomain {
   const min_width:  rank*int;
   var   signatures: rank*ArrayWrapper;
 
+  
+  class ArrayWrapper
+  {
+    var Domain: domain(1,stridable=true);
+    var array: [Domain] int;
+  }
+  
+  
+  //|\''''''''''''''''''''|\
+  //| >    constructor    | >
+  //|/....................|/
+
   //
   // TODO: At present, the compiler-generated constructor for classes
   // with array fields like this requires the actual that's passed to
@@ -126,30 +138,6 @@ class CandidateDomain {
     D = initD;
     flags = initFlags;
     min_width = initMin_width;
-    initialize();
-  }
-  
-  
-  class ArrayWrapper
-  {
-    var Domain: domain(1,stridable=true);
-    var array: [Domain] int;
-  }
-  
-  
-  
-  //|\''''''''''''''''''''|\
-  //| >    constructor    | >
-  //|/....................|/
-
-  //------------------------------------------------------------------
-  // Currently forced to use initialize rather than a constructor, as
-  // this class is generic.
-  //------------------------------------------------------------------
-  
-  proc initialize ()
-  {
-    
     //---- Calculate signatures ----
     for d in 1..rank do
       signatures(d) = new ArrayWrapper( {D.dim(d)} );


### PR DESCRIPTION
Restore previous level of memory leaks in studies/amr code

As part of the array views work in PR #5338, I introduced a user constructor into one of the amr study codes in order to work around issue #5289.  However, in doing so, I inadvertently introduced a new memory leak by calling initialize() explicitly within the constructor, thereby overwriting existing class fields without deleting them.  I thought that there was a reason that I needed to call initialize() explicitly rather than relying on the compiler-provided call, but can't recall what it is offhand.

Here, I remove the initialize() procedure altogether (a feature we want to move away from anyway) and fold its body into the user constructor.  This should restore the memory leaks to their pre-array-view levels for this test (and since it was the biggest delta in that PR, for testing overall by and large).

In a separate PR #5550 I close a number of user-level leaks in the AMR codes, but am going to merge that on another night to verify that this PR had the intended effect.