### PR TITLE
Reduce memory leaks in AMR tests

### DIFF
--- a/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.chpl
+++ b/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.chpl
@@ -195,7 +195,7 @@ proc main {
 
   //<=== Generate output <===
   
-  
+  delete bc;
+  delete hierarchy;
+  delete flagger;
 }
-
-

--- a/test/studies/amr/advection/grid/Grid_AdvectionCTU_driver.chpl
+++ b/test/studies/amr/advection/grid/Grid_AdvectionCTU_driver.chpl
@@ -71,8 +71,10 @@ proc main {
     sol.clawOutput(frame_number);
   }
   //<=== Generate output <===
-  
 
+  delete sol;
+  delete bc;
+  delete grid;
 } // end main
 
 

--- a/test/studies/amr/advection/level/Level_AdvectionCTU_driver.chpl
+++ b/test/studies/amr/advection/level/Level_AdvectionCTU_driver.chpl
@@ -79,6 +79,7 @@ proc main {
   }
   //<=== Generate output <===
   
-  
-
+  delete bc;
+  delete solution;
+  delete level;;
 } // end main

--- a/test/studies/amr/diffusion/grid/GridSolution_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/grid/GridSolution_DiffusionBE.chpl
@@ -156,6 +156,11 @@ proc GridSolution.step_DiffusionBE(
 
   old_time = current_time;
   current_time += dt;
+
+  delete residual_update;
+  delete search_dir;
+  delete residual;
+  delete rhs;
 }
 //<=== Grid.step_DiffusionBE method <===
 //<========================================

--- a/test/studies/amr/diffusion/grid/Grid_DiffusionBE_driver.chpl
+++ b/test/studies/amr/diffusion/grid/Grid_DiffusionBE_driver.chpl
@@ -66,5 +66,7 @@ proc main {
   }
   //<=== Generate output <===
   
-
+  delete bc;
+  delete solution;
+  delete grid;
 } // end main

--- a/test/studies/amr/diffusion/level/LevelSolution_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/level/LevelSolution_DiffusionBE.chpl
@@ -78,7 +78,7 @@ proc LevelSolution.step_DiffusionBE(
   old_time = current_time;
   current_time += dt;
   
-
+  delete rhs;
 }
 // /|""""""""""""""""""""""""""""""""""""""""""""""/|
 //< |    LevelSolution.step_DiffusionBE method    < |

--- a/test/studies/amr/diffusion/level/LevelVariable_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/level/LevelVariable_DiffusionBE.chpl
@@ -91,7 +91,10 @@ proc LevelVariable.storeCGSolution(
   // /::::::::::::::::::::/
   //<=== CG iteration <===
   // \::::::::::::::::::::\
-  
+
+  delete residual_update;
+  delete search_dir;
+  delete residual;
 }
 // /""""""""""""""""""""""""""""""""""/
 //<=== LevelVariable.storeCGSolution <==<

--- a/test/studies/amr/diffusion/level/Level_DiffusionBE_driver.chpl
+++ b/test/studies/amr/diffusion/level/Level_DiffusionBE_driver.chpl
@@ -82,10 +82,7 @@ proc main {
   }
   //<=== Generate output <===
   
-  
-
+  delete bc;
+  delete solution;
+  delete level;
 } // end main
-
-
-
-

--- a/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
+++ b/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
@@ -151,6 +151,23 @@ class AMRHierarchy {
   //< |    constructor    < |
   // \|....................\|
 
+  //|\''''''''''''''''''''|\
+  //| >     destructor    | >
+  //|/....................|/
+
+  proc deinit() {
+    for lvl in levels do if lvl then delete lvl;
+    for reg in invalid_regions do if reg then delete reg;
+    for cgr in cf_ghost_regions do if cgr then delete cgr;
+    for pb in physical_boundaries do if pb then delete pb;
+    for lvl in level_solutions do if lvl then delete lvl;
+    for cgs in cf_ghost_solutions do if cgs then delete cgs;
+  }
+
+  // /|''''''''''''''''''''/|
+  //< |     destructor    < |
+  // \|....................\|
+
 
 }
 // /|"""""""""""""""""""""""""""/|
@@ -433,7 +450,7 @@ proc AMRHierarchy.buildRefinedLevel ( i_refining: int )
     
   }
 
-    
+  delete coarse_exterior;
   delete cluster_domains;
 
   //<=== Ensure proper nesting <===
@@ -676,10 +693,9 @@ proc AMRHierarchy.AMRHierarchy (
   parameter_file.readln( target_efficiency );
   parameter_file.close();
 
-  
-
   //==== Create and return hierarchy ====
-  return new AMRHierarchy(x_low,
+  delete this;
+  this = new AMRHierarchy(x_low,
                           x_high,
 			  n_coarsest_cells,
 			  n_ghost_cells,
@@ -1032,5 +1048,6 @@ proc main {
 				     elevatedSquare);
   
   hierarchy.clawOutput(0);
-  
+
+  delete hierarchy;
 }

--- a/test/studies/amr/lib/misc/BasicDataStructures.chpl
+++ b/test/studies/amr/lib/misc/BasicDataStructures.chpl
@@ -30,7 +30,7 @@ proc main {
   q.enqueue("b");
   q.enqueue("c");
   while !q.isEmpty() do writeln(q.dequeue());
-  
+  delete q;
 }
 
 

--- a/test/studies/amr/lib/misc/MultiDomain_def.chpl
+++ b/test/studies/amr/lib/misc/MultiDomain_def.chpl
@@ -153,6 +153,8 @@ class MultiDomain
         if node.right then q.enqueue( node.right );
       }
     }
+
+    delete q;
   }
   
   
@@ -173,6 +175,8 @@ class MultiDomain
       if node.left  then q.enqueue( node.left );
       if node.right then q.enqueue( node.right );
     }
+
+    delete q;
   }
     
 


### PR DESCRIPTION
This cleans up a bunch of user memory to dramatically reduce the amount
of memory leaked by the studies/amr tests.  While the original author did
a (reasonably) good job of creating destructors for the classes that cleaned
up after themselves, he did not do a good job of deleting the classes used
by the programs that exercised the framework (and in at least one major
important case, missed the class itself).

The few remaining leaks that I'm aware of are some compiler-leaked memory
related to first-class functions and some MDNodes that I wasn't easily able
to track down in AMR_AdvectionCTU_driver.chpl.