### PR TITLE
Correct sublocid value meaning "memory locality unknown".

### DIFF
--- a/test/runtime/gbt/topo/array-loc.chpl
+++ b/test/runtime/gbt/topo/array-loc.chpl
@@ -74,7 +74,7 @@ proc checkMemLocalityParts(p: c_ptr, size, type eltType) {
   const nSublocs = here.getChildCount();
   const nPagesPerSubloc = nPages:real / nSublocs:real;
 
-  if chpl_topo_getMemLocality(myP) == c_sublocid_none then
+  if chpl_topo_getMemLocality(myP) == c_sublocid_any then
     return localityUnknown;
 
   for subloc in 0..#nSublocs {
@@ -119,7 +119,7 @@ proc checkMemLocalityWhole(p: c_ptr, size, type eltType,
   const sublocFirst = chpl_topo_getMemLocality(myP);
   var locality: localityCheck_t;
 
-  if sublocFirst == c_sublocid_none then
+  if sublocFirst == c_sublocid_any then
     locality = localityUnknown;
   else if sublocFirst == subloc then
     locality =localityRight;


### PR DESCRIPTION
The test was expecting c_sublocid_none when the topology layer didn't
know the memory locality, but chpl_topo_getMemLocality() actually
returns c_sublocid_any in that situation.  Fix the test.