### PR TITLE
Added a check that first-class functions aren't generic

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6154,6 +6154,10 @@ static Expr* createFunctionAsValue(CallExpr *call) {
     DefExpr* dExp = toDefExpr(formalExpr);
     ArgSymbol* fArg = toArgSymbol(dExp->sym);
 
+    if (fArg->type->symbol->hasFlag(FLAG_GENERIC)) {
+      USR_FATAL_CONT("Generic functions can't be captured as values");
+    }
+
     ArgSymbol* newFormal = new ArgSymbol(INTENT_BLANK, fArg->name, fArg->type);
     if (fArg->typeExpr)
       newFormal->typeExpr = fArg->typeExpr->copy();

--- a/test/functions/firstClassFns/captureGenericFn.chpl
+++ b/test/functions/firstClassFns/captureGenericFn.chpl
@@ -1,0 +1,23 @@
+proc f1(x) {
+  return x;
+}
+
+class R {
+  type t;
+}
+
+proc f2(x:R) {
+  return x;
+}
+
+proc f3(x:?t) {
+  return x;
+}
+
+var func1 = f1;
+var func2 = f2;
+var func3 = f3;
+
+writeln(func1(42));
+writeln(func2(42));
+writeln(func3(42));

--- a/test/functions/firstClassFns/captureGenericFn.good
+++ b/test/functions/firstClassFns/captureGenericFn.good
@@ -1,0 +1,7 @@
+captureGenericFn.chpl:17: error: Generic functions can't be captured as values
+Note: This source location is a guess.
+captureGenericFn.chpl:18: error: Generic functions can't be captured as values
+Note: This source location is a guess.
+captureGenericFn.chpl:19: error: Generic functions can't be captured as values
+Note: This source location is a guess.
+captureGenericFn.chpl:21: error: illegal access of first class function


### PR DESCRIPTION
We require first-class functions to be concrete.  This adds a quick
check that prints an error if they aren't.

I've also added an expanded version of the test that @npadmana 
included when filing issue #5545 that covers a few different
cases.