### PR TITLE
Retire passing future test

### DIFF
--- a/test/classes/initializers/generic_initializer.future
+++ b/test/classes/initializers/generic_initializer.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.


### PR DESCRIPTION
This test is now passing, thanks to PR #5549.  Retiring the future
just to reduce the amount of mail received tonight by a bit.