### PR TITLE
Do not insert an autoCopy for chpl__iterLF

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -305,8 +305,9 @@ void ReturnByRef::updateAssignmentsFromRefArgToValue(FnSymbol* fn)
           if (isUserDefinedRecord(symLhs->type) == true &&
               symRhs->type                      == symLhs->type)
           {
-            if (symLhs->hasFlag(FLAG_ARG_THIS) == false &&
-                symLhs->hasFlag(FLAG_NO_COPY)  == false &&
+            if (symLhs->hasFlag(FLAG_ARG_THIS)   == false &&
+                symLhs->hasFlag(FLAG_NO_COPY)    == false &&
+                symLhs->hasFlag(FLAG_CHPL__ITER) == false &&
                 (symRhs->intent == INTENT_REF ||
                  symRhs->intent == INTENT_CONST_REF))
             {


### PR DESCRIPTION
ArrayViews exposed an issue in callDestructors where an autoCopy was
inserted for a chpl__iterLF variable with an ArrayView type. The
autoCopy results in a non-view type, leading to compilation issues
later on. Vass and I feel that this autoCopy should be unnecessary
given the usage of chpl__iterLF variables, so for now we will
test for FLAG_CHPL__ITER and avoid inserting an autoCopy.

Testing:
- [x] full local
- [x] full gasnet
- [x] numa release/examples