### PR TITLE
Fixed a bug in recursive iterator inlining

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -260,6 +260,22 @@ static void computeRecursiveIteratorSet() {
 }
 
 
+static bool containsYield(Expr* arg) {
+  std::vector<CallExpr*> calls;
+  collectCallExprs(arg, calls);
+  for_vector(CallExpr, call, calls) {
+    if (call->isPrimitive()) {
+      if (call->isPrimitive(PRIM_YIELD))
+        return true;
+    } else if (FnSymbol* tfn = resolvedToTaskFun(call)) { // vass need this?
+      if (containsYield(tfn->body))
+        return true;
+    }
+  }
+  return false;
+}
+
+
 //
 // If a local block has no yields, returns, gotos or labels
 // then it can safely be left unfragmented.
@@ -1186,6 +1202,11 @@ expandIteratorInline(ForLoop* forLoop) {
     // vass: ditto for task functions called from recursive iterators
     } else if (taskFunInRecursiveIteratorSet.set_in(forLoop->parentSymbol)) {
       return false;
+    } else if (containsYield(forLoop)) {
+      // Inlining a recursive iterator into a loop with a 'yield' pushes
+      // that 'yield' into one of _rec_ functions, where it dangles. Ex.:
+      // test/modules/standard/FileSystem/filerator/bradc/findfiles-par.chpl
+      return false;
     } else {
       expandRecursiveIteratorInline(forLoop);
       INT_ASSERT(!forLoop->inTree());
@@ -1740,7 +1761,7 @@ expandForLoop(ForLoop* forLoop) {
 
 
 // Find all iterator constructs
-// Select those whose _getIterator() functions have the FLAG_ITERATOR_INLINE.
+// Select those whose _getIterator() functions have the FLAG_INLINE_ITERATOR.
 // Inline the selected iterators at their call sites.
 static void
 inlineIterators() {
@@ -2121,6 +2142,34 @@ static void cleanupTemporaryVectors() {
 }
 
 
+// 'depth' is a heuristic to avoid the risk of unbounded recursion.
+// Ex. what if 'parentSym' is a recursive function?
+static bool maybeCalled(Symbol* parentSym, int depth) {
+  if (!parentSym || !parentSym->inTree())
+    return false;
+
+  FnSymbol* fn = toFnSymbol(parentSym);
+  if (!fn)
+    return true; // conservative
+
+  if (ftableMap.count(fn))
+    return true;
+
+  if (!fn->calledBy || fn->calledBy->n == 0)
+    return false;
+
+  if (depth <= 0)
+    return true; // conservative
+
+  depth--;
+
+  forv_Vec(CallExpr, call, *fn->calledBy)
+    if (maybeCalled(call->parentSymbol, depth))
+      return true;
+
+  return false;
+}
+
 // WORKAROUND:
 // When the body of a for loop is moved into the loop body function, yield
 // primitives remain in it (if the for loop itself appears in an iterator
@@ -2145,6 +2194,10 @@ static void removeUncalledIterators()
     // We only care about yields.
     if (! call->isPrimitive(PRIM_YIELD))
       continue;
+
+    // This is a backup check to ensure PRIM_INT_ERROR is never executed.
+    if (maybeCalled(call->parentSymbol, 4))
+      INT_FATAL(call, "unexpected leftover PRIM_YIELD");
 
     // If this function contains a yield, it was never expanded, so the static
     // analysis used in lowerIterators says it was never invoked through a for

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -2196,7 +2196,7 @@ static void removeUncalledIterators()
       continue;
 
     // This is a backup check to ensure PRIM_INT_ERROR is never executed.
-    if (maybeCalled(call->parentSymbol, 4))
+    if (fVerify && maybeCalled(call->parentSymbol, 4))
       INT_FATAL(call, "unexpected leftover PRIM_YIELD");
 
     // If this function contains a yield, it was never expanded, so the static


### PR DESCRIPTION
## WHAT IS THE BUG?

Consider a recursive iterator:

    iter RECITER() {
      ....
      for RECITER() {    // "recursive loop"
	yield someExpr;
      }
      ....
    }

Recursive iterator inlining converts the above "recursive loop"
so that `RECITER` looks like this:

    iter RECITER() {
      ....
      _rec_iter_fn_RECITER(bodyFnIdx=....);
      ....
    }

    proc _rec_iter_fn_RECITER(bodyFnIdx) {
      .... do whatever RECITER does ....

      .... instead of a yield, to this: ....
      call chpl_ftable[bodyFnIdx];
    }

where the ftable call invokes a function that represents the body of
the "recursive loop". That body still contains a `yield` verbatim.

So - the bug is that dangling `yield` is never gets lowered.

In general, a `yield` is lowered either when inlining an iterator
or when decomposing the iterator into "zip" pieces/advance functions/etc.
The function that's invoked through `chpl_ftable` is so far removed
from the iterator (mentally and in compiler representation) that
it is not looked at during either lowering transformation.

Also note that the "recursive loop" actually looks like this
when inlining happens:

    iter RECITER2() {
      ....
      for RECITER1() {    // "recursive loop"
	yield someExpr;
      }
      ....
    }

where `RECITER2` is not a recursive iterator. So if `RECITER2`
is inlined first into some other loop, then the "recursive loop"
no longer contains a `yield`. When the recursive `RECITER1`
is inlined into the "recursive loop" later, there is no `yield`
to push into chpl_ftable-invocable function, so the bug does not happen.

## WHAT IS THE FIX?

Recursive iterator inlining is done twice during lowerIterators
(the following zooms in on recursive iterators):

done earlier, for iterators marked with FLAG_INLINE_ITERATOR:

    lowerIterators
      inlineIterators
	forv_Vec(BlockStmt, block, gBlockStmts)
	  expandIteratorInline
	    if some conditions:
              expandRecursiveIteratorInline

done later, for all iterators:

    lowerIterators
      forv_Vec(BlockStmt, block, gBlockStmts)
	expandForLoop
	  expandIteratorInline
	    if some conditions:
              expandRecursiveIteratorInline
          if still not inlined:
            the general case of iterator lowering

Recursive iterator inlining is actually performed in
`expandRecursiveIteratorInline`.

So - the fix is to skip `expandRecursiveIteratorInline`
when the loop body contains a `yield`.
It is done by adding `!containsYield()` as part of "some conditions"
above.

For each recursive iterator that is not inlined during "done later",
it gets handled by "the general case of iterator lowering".
Testing confirms that this works.

## WHILE THERE

I added a compile-time check for dangling yields.

Prior to this PR, the compiler converted such yields to
PRIM_INT_ERROR. When executed at run time, they generated
"compiler generated error".

This PR adds a compile-time check for dangling yields.
If it finds any, it calls INT_FATAL.
So the problem is exposed at compile time, rather than at run time.

The key part of this check is `maybeCalled()`, which checks reachability
of the function containing the yield. (Yes there are yields left over
in functions that are (a) still "in tree" yet (b) not called from any
live code.)

`maybeCalled` is heuristic in that (a) it goes up the call tree only
up to a `depth` limit that I put to guard against the risk of
infinite recursion and extra-wide call trees, and (b) is not precise.
Ex. it returns `true` when the function's parent symbol is not a function
or the depth limit is reached. It returns `false` when the function is invoked
only through VMT (virtualMethodTable). It works so far and we may want
to tune it in the future or eliminate altogether?

This PR leaves the PRIM_YIELD -> PRIM_INT_ERROR conversion unchanged.
Otherwise I'd have to yank such PRIM_YIELDs - or their enclosing functions -
from the tree altogether. Which would hide any remaining bugs,
and I do not have a strong enough assurance that there aren't any.

Minor: corrected FLAG_ITERATOR_INLINE in a comment.

## TESTS/HOW TO SEE IT

Prior to this change, this bug was exposed by invoking

    modules/standard/FileSystem.chpl : iter walkdirs()

in these tests:

    test/modules/standard/FileSystem/bharshbarg/filer.chpl
    test/modules/standard/FileSystem/filerator/bradc/findfiles-par.chpl
    test/modules/standard/FileSystem/filerator/bradc/walk-par.chpl

There WERE dangling PRIM_YIELD that got replaced with PRIM_INT_ERROR
however those are not executed at run time during these tests.

They can still be observed. For that:

* Remove the newly-added clause like
`if (containsYield(forLoop)) then return false;`
in expandIteratorInline().

* When compiling the above tests, the newly-added INT_FATAL
in `removeUncalledIterators()` will be triggered.