### PR TITLE
Minor correction to checkChplInstall, PR #5516

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -213,7 +213,7 @@ TEST_EXEC_OUT=${TEST_JOB}.exec.out
     EXEC_OPTS="$(cat ${TEST_DIR}/${TEST_JOB}.execopts)"
 
     log_info "Running test job."
-    ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} | sort > ${TEST_EXEC_OUT}
+    ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} 2>&1 | sort > ${TEST_EXEC_OUT}
     log_info "Test job complete."
 
     # Check result


### PR DESCRIPTION
When it runs Chapel test "hello6", checkChplInstall should handle
errors the same way the Chapel test harness does.
    
Currently, checkChplInstall ignores anything hello6 emits to stderr.
    
This change adds the stderr (if any) from running hello6 to the
stdout stream, to be compared with the .good file- just like
sub_test does.
