### PR TITLE
Mark the Chapel test "failed" if .skipif or .suppressif returns error

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -408,6 +408,15 @@ def printTestVariation(compoptsnum, compoptslist,
     sys.stdout.write(')')
     return
 
+# print '[Elapsed time to compile and execute all versions of ...'
+#   in the format expected by convert_start_test_log_to_junit_xml.py.
+
+def printEndOfTestMsg(test_name, elapsedTime):
+    sys.stdout.flush()
+    print('[Elapsed time to compile and execute all versions of "{0}" - '
+        '{1:.3f} seconds]'.format(test_name, elapsedTime))
+
+
 # return true if string is an integer
 def IsInteger(str):
     try:
@@ -1095,8 +1104,7 @@ for testname in testsrc:
                 sys.stdout.write(str(e)+'\n')
                 sys.stdout.write('[Error processing .skipif file for %s]\n'
                     % os.path.join(localdir, test_filename))
-                sys.stdout.write('[Elapsed time to compile and execute all versions of "%s" - 0.0 seconds]\n'
-                    % os.path.join(localdir, test_filename))
+                printEndOfTestMsg(os.path.join(localdir, test_filename), 0.0)
                 do_not_test=True
             if do_not_test:
                 break
@@ -1121,8 +1129,7 @@ for testname in testsrc:
                 sys.stdout.write(str(e)+'\n')
                 sys.stdout.write('[Error processing .suppressif file for %s]\n'
                     % os.path.join(localdir, test_filename))
-                sys.stdout.write('[Elapsed time to compile and execute all versions of "%s" - 0.0 seconds]\n'
-                    % os.path.join(localdir, test_filename))
+                printEndOfTestMsg(os.path.join(localdir, test_filename), 0.0)
                 do_not_test=True
                 break
 
@@ -2175,8 +2182,7 @@ for testname in testsrc:
 
     elapsedCurFileTestTime = time.time() - curFileTestStart
     test_name = os.path.join(localdir, test_filename)
-    print('[Elapsed time to compile and execute all versions of "{0}" - '
-        '{1:.3f} seconds]'.format(test_name, elapsedCurFileTestTime))
+    printEndOfTestMsg(test_name, elapsedCurFileTestTime)
 
 
 sys.exit(0)

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -507,14 +507,18 @@ def runSkipIf(skipifName):
     p = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
     status = p.returncode
+
     stderr = stderr.strip()
+    errmsg = ""
+    if stderr:
+        errmsg = stderr
     if status:
         if stderr:
-            sys.stdout.write(stderr+'\n')
-        Fatal('%s: exit status %d' % (skipifName, status))
-    elif stderr:
-        sys.stdout.write(stderr+'\n')
-        Fatal('%s: %s' % (skipifName, stderr.splitlines()[-1]))
+            errmsg += '\n'
+        errmsg += 'exit status %d' % (status)
+    if stderr or status:
+        raise RuntimeError(errmsg)
+
     return stdout
 
 # Start of sub_test proper
@@ -1078,24 +1082,29 @@ for testname in testsrc:
         elif (suffix=='.skipif' and (os.access(f, os.R_OK) and
                (os.getenv('CHPL_TEST_SINGLES')=='0'))):
             testskipiffile=True
-            skiptest=runSkipIf(f)
             try:
                 skipme=False
+                skiptest=runSkipIf(f)
                 if skiptest.strip() != "False":
                     skipme = skiptest.strip() == "True" or int(skiptest) == 1
                 if skipme:
-                    sys.stdout.write('[Skipping test based on .skipif environment settings: %s/%s]\n'%(localdir,test_filename))
+                    sys.stdout.write('[Skipping test based on .skipif environment settings: %s]\n'
+                        % os.path.join(localdir, test_filename))
                     do_not_test=True
-            except ValueError:
-                sys.stdout.write('[Error processing .skipif file %s/%s]\n'%(localdir,f))
+            except (ValueError, RuntimeError) as e:
+                sys.stdout.write(str(e)+'\n')
+                sys.stdout.write('[Error processing .skipif file for %s]\n'
+                    % os.path.join(localdir, test_filename))
+                sys.stdout.write('[Elapsed time to compile and execute all versions of "%s" - 0.0 seconds]\n'
+                    % os.path.join(localdir, test_filename))
                 do_not_test=True
             if do_not_test:
                 break
 
         elif (suffix=='.suppressif' and (os.access(f, os.R_OK))):
-            suppresstest=runSkipIf(f)
             try:
                 suppressme=False
+                suppresstest=runSkipIf(f)
                 if suppresstest.strip() != "False":
                     suppressme = suppresstest.strip() == "True" or int(suppresstest) == 1
                 if suppressme:
@@ -1108,8 +1117,14 @@ for testname in testsrc:
                                 suppressline = line.replace('#','').strip()
                                 break
                     futuretest='Suppress (' + suppressline + ') '
-            except ValueError:
-                sys.stdout.write('[Error processing .suppressif file %s/%s]\n'%(localdir,f))
+            except (ValueError, RuntimeError) as e:
+                sys.stdout.write(str(e)+'\n')
+                sys.stdout.write('[Error processing .suppressif file for %s]\n'
+                    % os.path.join(localdir, test_filename))
+                sys.stdout.write('[Elapsed time to compile and execute all versions of "%s" - 0.0 seconds]\n'
+                    % os.path.join(localdir, test_filename))
+                do_not_test=True
+                break
 
         elif (suffix==timeoutsuffix and os.access(f, os.R_OK)):
             timeout=ReadIntegerValue(f, localdir)

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -504,8 +504,18 @@ def get_exec_log_name(execname, comp_opts_count=None, exec_opts_count=None):
 # Use testEnv to process skipif files, it works for executable and
 # non-executable versions
 def runSkipIf(skipifName):
-    skiptest = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE).communicate()[0]
-    return skiptest
+    p = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (stdout, stderr) = p.communicate()
+    status = p.returncode
+    stderr = stderr.strip()
+    if status:
+        if stderr:
+            sys.stdout.write(stderr+'\n')
+        Fatal('%s: exit status %d' % (skipifName, status))
+    elif stderr:
+        sys.stdout.write(stderr+'\n')
+        Fatal('%s: %s' % (skipifName, stderr.splitlines()[-1]))
+    return stdout
 
 # Start of sub_test proper
 #

--- a/util/test/testEnv
+++ b/util/test/testEnv
@@ -28,7 +28,8 @@ if (-x "$envfile") {
   $envfile = abs_path($envfile);
   $execskiptest = `$envfile`;
   print "$execskiptest";
-  exit("$?");
+# exit with the return code that the envfile gave us
+  exit($?>>8);
 }
 
 #


### PR DESCRIPTION
As discussed with mppf. If the test harness runs a .skipif (or .suppressif) script and it emits anything to stderr, sub_test should flag the corresponding Chapel test as failed. 
This change does not apply to directory-wide SKIPIFs. 