### PR TITLE
Make count() on arrays parallel by default (issue #5402)

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2809,9 +2809,7 @@ module ChapelArray {
 
     /* Return the number of times ``val`` occurs in the array. */
     proc count(val: this.eltType): int {
-      var total: int = 0;
-      for i in this do if i == val then total += 1;
-      return total;
+      return + reduce (this == val);
     }
 
    /* Returns a tuple of integers describing the size of each dimension.


### PR DESCRIPTION
Parallelizing count() method on array. I read the the following - https://github.com/chapel-lang/chapel/commit/690b5e01fea87d6894489796b6fc73a055f061e0. Would like to know if it's useful.
Also from Ben's comment I interpreted(not sure yet) that using **reduction** construct isn't harmful.