### PR TITLE
Prefix jemalloc symbols with chpl_je_

### DIFF
--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -30,32 +30,32 @@
 #define MALLOCX_NO_FLAGS 0
 
 static inline void* chpl_calloc(size_t n, size_t size) {
-  return je_calloc(n,size);
+  return chpl_je_calloc(n,size);
 }
 
 static inline void* chpl_malloc(size_t size) {
-  return je_malloc(size);
+  return chpl_je_malloc(size);
 }
 
 static inline void* chpl_memalign(size_t boundary, size_t size) {
   void* ret = NULL;
   int rc;
-  rc = je_posix_memalign(&ret, boundary, size);
+  rc = chpl_je_posix_memalign(&ret, boundary, size);
   if( rc == 0 ) return ret;
   else return NULL;
 }
 
 static inline void* chpl_realloc(void* ptr, size_t size) {
-  return je_realloc(ptr, size);
+  return chpl_je_realloc(ptr, size);
 }
 
 static inline void chpl_free(void* ptr) {
-  je_free(ptr);
+  chpl_je_free(ptr);
 }
 
 static inline size_t chpl_good_alloc_size(size_t minSize) {
   if (minSize == 0) { return 0; }
-  return je_nallocx(minSize, MALLOCX_NO_FLAGS);
+  return chpl_je_nallocx(minSize, MALLOCX_NO_FLAGS);
 }
 
 // TODO (EJR 03/11/16): Can/should we consider using the extended API? See JIRA

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -134,7 +134,7 @@ static type get_ ## type ##_mallctl_value(const char* mallctl_string) { \
   type value; \
   size_t sz; \
   sz = sizeof(value); \
-  if (je_mallctl(mallctl_string, &value, &sz, NULL, 0) != 0) { \
+  if (chpl_je_mallctl(mallctl_string, &value, &sz, NULL, 0) != 0) { \
     char error_msg[256]; \
     snprintf(error_msg, sizeof(error_msg), "could not get mallctl value for %s", mallctl_string); \
     chpl_internal_error(error_msg); \
@@ -164,14 +164,14 @@ static void initialize_arenas(void) {
   //   calling this interface."
   narenas = get_num_arenas();
   for (arena=1; arena<narenas; arena++) {
-    if (je_mallctl("thread.arena", NULL, NULL, &arena, sizeof(arena)) != 0) {
+    if (chpl_je_mallctl("thread.arena", NULL, NULL, &arena, sizeof(arena)) != 0) {
       chpl_internal_error("could not change current thread's arena");
     }
   }
 
   // then set the current thread back to using arena 0
   arena = 0;
-  if (je_mallctl("thread.arena", NULL, NULL, &arena, sizeof(arena)) != 0) {
+  if (chpl_je_mallctl("thread.arena", NULL, NULL, &arena, sizeof(arena)) != 0) {
       chpl_internal_error("could not change current thread's arena back to 0");
   }
 }
@@ -198,7 +198,7 @@ static void replaceChunkHooks(void) {
   for (arena=0; arena<narenas; arena++) {
     char path[128];
     snprintf(path, sizeof(path), "arena.%u.chunk_hooks", arena);
-    if (je_mallctl(path, NULL, NULL, &new_hooks, sizeof(chunk_hooks_t)) != 0) {
+    if (chpl_je_mallctl(path, NULL, NULL, &new_hooks, sizeof(chunk_hooks_t)) != 0) {
       chpl_internal_error("could not update the chunk hooks");
     }
   }
@@ -275,11 +275,11 @@ static void useUpMemNotInHeap(void) {
     size_t alloc_size;
     alloc_size = classes[class];
     do {
-      if ((p = je_malloc(alloc_size)) == NULL) {
+      if ((p = chpl_je_malloc(alloc_size)) == NULL) {
         chpl_internal_error("could not use up memory outside of shared heap");
       }
     } while (addressNotInHeap(p));
-    je_free(p);
+    chpl_je_free(p);
   }
 }
 
@@ -319,10 +319,10 @@ void chpl_mem_layerInit(void) {
     initializeSharedHeap();
   } else {
     void* p;
-    if ((p = je_malloc(1)) == NULL) {
-      chpl_internal_error("cannot init heap: je_malloc() failed");
+    if ((p = chpl_je_malloc(1)) == NULL) {
+      chpl_internal_error("cannot init heap: chpl_je_malloc() failed");
     }
-    je_free(p);
+    chpl_je_free(p);
   }
 }
 

--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -15,7 +15,8 @@ CHPL_JEMALLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-g
 endif
 
 CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \
-			     --with-jemalloc-prefix=chpl_je_
+			     --with-jemalloc-prefix=chpl_je_ \
+			     --with-private-namespace=chpl_
 
 # Unless the user explicitly asks for stats gathering, disable it since
 # there is some runtime overhead of this capability

--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -15,7 +15,7 @@ CHPL_JEMALLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-g
 endif
 
 CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \
-			     --with-jemalloc-prefix=je_
+			     --with-jemalloc-prefix=chpl_je_
 
 # Unless the user explicitly asks for stats gathering, disable it since
 # there is some runtime overhead of this capability


### PR DESCRIPTION
To avoid a conflict with the memkind library, which uses its own copy of jemalloc, this change prefixes our jemalloc symbols with chpl_je_ .

The jemalloc documentation recommends using --with-private-namespace to avoid naming collisions when jemalloc is built statically (which we do).

Note that the private namespace gets je_ prepended to it automatically, so although the Makefile appears to be asking for just chpl_ for internal names, it ends up chpl_je_ .

This is a prerequisite for #5555 .