### PR TITLE
Skip DateTime tests for --baseline and --no-inline

### DIFF
--- a/test/modules/standard/datetime/SKIPIF
+++ b/test/modules/standard/datetime/SKIPIF
@@ -1,0 +1,5 @@
+# --no-inline causes a problem described in the future
+# test/extern/diten/externLong.future
+# When that future is fixed, this SKIPIF can be removed.
+COMPOPTS <= --baseline
+COMPOPTS <= --no-inline


### PR DESCRIPTION
The tests in test/modules/standard/datetime/ can fail to compile if
--no-inline is used due to the problem described in issue #5563.  Skip them
for --baseline and --no-inline.  There is a .future to demonstrate the problem
at: test/extern/diten/externLong.future

If that problem is resolved these datetime tests should work for --baseline.