### PR TITLE
Test qthreads 1.12 in performance playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground-2.bash
+++ b/util/cron/test-perf.chapcs.playground-2.bash
@@ -9,11 +9,11 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground-2"
 
-# Test performance of qthreads 1.12 RC
+# Test performance of qthreads 1.12
 GITHUB_USER=ronawho
-GITHUB_BRANCH=use-chpl-alloc-for-qt-3
+GITHUB_BRANCH=upgrade-qthreads-1.12
 SHORT_NAME=qthreads-1.12
-START_DATE=03/04/17
+START_DATE=03/08/17
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
Note that I'm not using the new --with-alloc=chapel feature, so there shouldn't
be any performance differences since the only other real change in 1.12 is my
hybrid spin/condwait change that's already in our repo.

Assuming we don't see any performance changes with the plain 1.12 I'll start
testing the performance of --with-alloc=chapel (qthreads grabs memory from
chapel's allocator.)