### PR TITLE
Fix MPI module dereference nil bug

### DIFF
--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -215,12 +215,10 @@ module MPI {
     pragma "no doc"
     proc deinit() {
       if freeChplComm {
-        if numLocales > 1 {
-          coforall loc in Locales do on loc {
-            C_MPI.MPI_Comm_free(CHPL_COMM_WORLD_REPLICATED(1));
-          }
-        } else {
-          C_MPI.MPI_Comm_free(CHPL_COMM_WORLD_REPLICATED(1));
+        coforall loc in Locales do on loc {
+          // TODO : Don't leak this. This results in dereference nil error for
+          //        some cases, e.g. linux64 multilocale mode with gasnet+mpi
+          //C_MPI.MPI_Comm_free(CHPL_COMM_WORLD_REPLICATED(1));
         }
       }
       if doinit {


### PR DESCRIPTION
When running a Chapel program with the MPI module in multilocale mode with the gasnet+mpi configuration (more details below), it appears that `CHPL_COMM_WORLD_REPLICATED(1)` becomes freed before reaching the `_initMPI.deinit()` call. As a result, we get the following error `numLocales`-times at the end of the program execution:

```
$CHPL_HOME/modules/packages/MPI.chpl:220: error: attempt to dereference nil
```

Until we can correctly identify the condition in which `CHPL_COMM_WORLD_REPLICATED(1)` needs to be freed or not, this PR introduces a simple fix that omits the `MPI_Comm_Free` call altogether.

The result is a leak size on the order of `numLocales` at the end of MPI multilocale programs for some configurations. Obviously, a leak-free solution would be preferable in the long-term, but this patch reduces the run-time error to a negligible leak for now.

Configuration that encountered the issue:

```bash
CHPL_TARGET_PLATFORM: linux64
CHPL_TARGET_COMPILER: mpi-gnu *
CHPL_TARGET_ARCH: unknown
CHPL_LOCALE_MODEL: flat
CHPL_COMM: gasnet *
  CHPL_COMM_SUBSTRATE: mpi *
  CHPL_GASNET_SEGMENT: everything
CHPL_TASKS: fifo *
CHPL_LAUNCHER: gasnetrun_mpi
CHPL_MEM: jemalloc

# Using MPICH 12.1.0
MPICH_MAX_THREAD_SAFETY=multiple
AMMPI_MPI_THREAD=multiple
```

Also, the `coforall` over locales will effectively do the same thing as the
else-block for `numLocales == 1`, so this if/else block was dropped.
