### PR TITLE
Improve support for paratesting without building our venvs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,14 @@ third-party-try-gmp: FORCE
 	fi
 
 third-party-test-venv: FORCE
-	cd third-party && $(MAKE) test-venv
+	-@if [ -z "$$CHPL_TEST_VENV_DIR" ]; then \
+	cd third-party && $(MAKE) test-venv; \
+	fi
 
 third-party-chpldoc-venv: FORCE
-	cd third-party && $(MAKE) chpldoc-venv
+	-@if [ -z "$$CHPL_TEST_VENV_DIR" ]; then \
+	cd third-party && $(MAKE) chpldoc-venv; \
+	fi
 
 test-venv: third-party-test-venv
 

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -309,7 +309,7 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir) {
     CHPL_HOME, "/third-party/chpl-venv/install/", CHPL_HOST_PLATFORM,
     "/py", getChplPythonVersion().c_str(), "/chpl-virtualenv");
   const char * venvBinDir = astr(venvDir, "/bin");
-  const char * sphinxBuild = astr(venvBinDir, "/sphinx-build");
+  const char * sphinxBuild = astr("sphinx-build");
 
   const char * envVars = astr("export PATH=", venvBinDir, ":$PATH && "
                               "export VIRTUAL_ENV=", venvDir, " && "

--- a/man/Makefile
+++ b/man/Makefile
@@ -11,7 +11,7 @@ TARGETS = $(MANPAGE) $(PROGRAM).pdf $(CHPLDOC).pdf
 
 PYTHON_VERSION_DIR = py$(shell $(CHPL_MAKE_HOME)/util/chplenv/chpl_python_version.py)
 
-RST2MAN = $(CHPL_MAKE_HOME)/third-party/chpl-venv/install/*/$(PYTHON_VERSION_DIR)/chpl-virtualenv/bin/rst2man.py
+RST2MAN = $(shell which rst2man.py || echo $(CHPL_MAKE_HOME)/third-party/chpl-venv/install/*/$(PYTHON_VERSION_DIR)/chpl-virtualenv/bin/rst2man.py)
 
 STARS = \*\*\*\*\*
 


### PR DESCRIPTION

I install all the python dependencies required for test-venv and chpldoc-venv
locally and set CHPL_TEST_VENV_DIR=none. Since I'm often making third-party
changes I usually clobber of git clean, and installing the venv requirements
locally halves the build time.

test-venv and chpldoc-venv are dependencies for things like man-chpldoc, which
is required for clean paratesting. This just makes it possible to build
everything if CHPL_TEST_VENV_DIR is set. This way test/man/ won't fail.

This also allows our docs to use a locally installed sphinx-build instead of
always using the one in chpl-venv.