### PR TITLE
Restrict this future to valgrind tests; the program tries to walk uninitialized memory

### DIFF
--- a/test/types/tuple/claridge/tuple_of_domains.chpl
+++ b/test/types/tuple/claridge/tuple_of_domains.chpl
@@ -1,2 +1,17 @@
-var domain_tuple: 2*domain(1);
+/*
+  Noakes 2017/03/08
+
+  This program attempts to allocate a variable that is a tuple of
+  domains that relies on the compiler to instantiate a valid default
+  initializer.
+
+  A number of interactions within the compiler cause the elements of
+  the tuple to be un-initialized and so this program has undefined
+  behavior.
+
+  The skipif for this future restricts it to valgrind testing
+*/
+
+var domain_tuple: 2 * domain(1);
+
 writeln(domain_tuple);

--- a/test/types/tuple/claridge/tuple_of_domains.future
+++ b/test/types/tuple/claridge/tuple_of_domains.future
@@ -1,5 +1,7 @@
-bug: Declaring a tuple of domains produces run-time error, "attempt to 
-dereference nil".  However, assigning the value directly with implicit
-typing does work, i.e.
-    var tuple_of_domains = ([1..0],[1..0]);
-works as expected.
+bug: Tuples of domains cannot be default-initialized
+
+The compiler-generated _defaultOf() function for a tuple that includes
+1 or more domains is incorrect.  The elements with domain type will be
+uninitialized. This is the result of a confluence of multiple problems
+in normalize and resolution especially for PRIM_INIT in the face of the
+specialized internal support for domains.

--- a/test/types/tuple/claridge/tuple_of_domains.skipif
+++ b/test/types/tuple/claridge/tuple_of_domains.skipif
@@ -1,0 +1,1 @@
+CHPL_TEST_VGRND_EXE!=on


### PR DESCRIPTION
Summary:

Update a future so that it only runs under valgrind.


Details:

Until recently the future types/tuple/claridge/tuple_of_domains.chpl has been failing
reasonably quickly with a seg-fault.  For some reason a recent initializer PR has
caused it to timeout instead.

A little investigation revealed that this future is a proxy for the fact that the compiler
fails to construct an appropriate default initializer for a variable with type tuple that
includes at least one domain.  Any domain fields will be uninitialized and so the program
may fail but in an un-defined way.

I spent some time pursuing this, as is it at heart an initializer issue, but it turns out to be
the result of multiple problems within the compiler that will take considerable effort to
address.  So, based on input from Elliot, I adding some comments and then a .skipif that
ensures this future is only tested by valgrind.


Verified that this future only runs under valgrind.


