### PR TITLE
Update time comparison operators to avoid floating point

### DIFF
--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -663,11 +663,16 @@ module DateTime {
         (t1.tzinfo == nil && t2.tzinfo != nil) {
       halt("both datetimes must both be either naive or aware");
     } else if t1.tzinfo == t2.tzinfo {
-      const sec1 = t1.hour*3600 + t1.minute*60 +
-                   t1.second + t1.microsecond/1000000.0;
-      const sec2 = t2.hour*3600 + t2.minute*60 +
-                   t2.second + t2.microsecond/1000000.0;
-      return sec1 < sec2;
+      const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
+      const usec1 = t1.microsecond;
+      const sec2 = t2.hour*3600 + t2.minute*60 + t2.second;
+      const usec2 = t2.microsecond;
+      if sec1 < sec2 then
+        return true;
+      else if sec1 == sec2 then
+        return usec1 < usec2;
+      else
+        return false;
     } else {
       // As far as I can tell, python's datetime.time() comparisons don't
       // pay attention to the timezones.
@@ -698,11 +703,16 @@ module DateTime {
         (t1.tzinfo == nil && t2.tzinfo != nil) {
       halt("both datetimes must both be either naive or aware");
     } else if t1.tzinfo == t2.tzinfo {
-      const sec1 = t1.hour*3600 + t1.minute*60 +
-                   t1.second + t1.microsecond/1000000.0;
-      const sec2 = t2.hour*3600 + t2.minute*60 +
-                   t2.second + t2.microsecond/1000000.0;
-      return sec1 <= sec2;
+      const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
+      const usec1 = t1.microsecond;
+      const sec2 = t2.hour*3600 + t2.minute*60 + t2.second;
+      const usec2 = t2.microsecond;
+      if sec1 < sec2 then
+        return true;
+      else if sec1 == sec2 then
+        return usec1 <= usec2;
+      else
+        return false;
     } else {
       const dt1 = datetime.combine(new date(1900, 1, 1), t1);
       const dt2 = datetime.combine(new date(1900, 1, 1), t2);
@@ -718,11 +728,16 @@ module DateTime {
         (t1.tzinfo == nil && t2.tzinfo != nil) {
       halt("both datetimes must both be either naive or aware");
     } else if t1.tzinfo == t2.tzinfo {
-      const sec1 = t1.hour*3600 + t1.minute*60 +
-                   t1.second + t1.microsecond/1000000.0;
-      const sec2 = t2.hour*3600 + t2.minute*60 +
-                   t2.second + t2.microsecond/1000000.0;
-      return sec1 > sec2;
+      const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
+      const usec1 = t1.microsecond;
+      const sec2 = t2.hour*3600 + t2.minute*60 + t2.second;
+      const usec2 = t2.microsecond;
+      if sec1 > sec2 then
+        return true;
+      else if sec1 == sec2 then
+        return usec1 > usec2;
+      else
+        return false;
     } else {
       const dt1 = datetime.combine(new date(1900, 1, 1), t1);
       const dt2 = datetime.combine(new date(1900, 1, 1), t2);
@@ -738,11 +753,16 @@ module DateTime {
         (t1.tzinfo == nil && t2.tzinfo != nil) {
       halt("both datetimes must both be either naive or aware");
     } else if t1.tzinfo == t2.tzinfo {
-      const sec1 = t1.hour*3600 + t1.minute*60 +
-                   t1.second + t1.microsecond/1000000.0;
-      const sec2 = t2.hour*3600 + t2.minute*60 +
-                   t2.second + t2.microsecond/1000000.0;
-      return sec1 >= sec2;
+      const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
+      const usec1 = t1.microsecond;
+      const sec2 = t2.hour*3600 + t2.minute*60 + t2.second;
+      const usec2 = t2.microsecond;
+      if sec1 > sec2 then
+        return true;
+      else if sec1 == sec2 then
+        return usec1 >= usec2;
+      else
+        return false;
     } else {
       const dt1 = datetime.combine(new date(1900, 1, 1), t1);
       const dt2 = datetime.combine(new date(1900, 1, 1), t2);
@@ -1212,7 +1232,7 @@ module DateTime {
           d2: date = dt2.replace(tzinfo=nil).getdate();
       var t1: time = dt1.replace(tzinfo=nil).gettime(),
           t2: time = dt2.replace(tzinfo=nil).gettime();
-     
+
       return d1.year == d2.year && d1.month == d2.month && d1.day == d2.day &&
                         t1.hour == t2.hour && t1.minute == t2.minute &&
                         t1.second == t2.second &&
@@ -1233,7 +1253,7 @@ module DateTime {
     if (dt1.tzinfo != nil && dt2.tzinfo == nil) ||
         (dt1.tzinfo == nil && dt2.tzinfo != nil) {
       halt("both datetimes must both be either naive or aware");
-    } else if dt1.tzinfo == nil || dt1.tzinfo == dt2.tzinfo {
+    } else if dt1.tzinfo == dt2.tzinfo {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
       if date1 < date2 then return true;

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -1205,7 +1205,7 @@ module DateTime {
        (dt1.tzinfo == nil && dt2.tzinfo != nil) {
       halt("both datetimes must both be either naive or aware");
     }
-    if dt1.tzinfo == nil || dt1.tzinfo == dt2.tzinfo {
+    if dt1.tzinfo == dt2.tzinfo {
       const newmicro = dt1.microsecond - dt2.microsecond,
             newsec = dt1.second - dt2.second,
             newmin = dt1.minute - dt2.minute,
@@ -1272,7 +1272,7 @@ module DateTime {
     if (dt1.tzinfo != nil && dt2.tzinfo == nil) ||
         (dt1.tzinfo == nil && dt2.tzinfo != nil) {
       halt("both datetimes must both be either naive or aware");
-    } else if dt1.tzinfo == nil || dt1.tzinfo == dt2.tzinfo {
+    } else if dt1.tzinfo == dt2.tzinfo {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
       if date1 < date2 then return true;
@@ -1291,7 +1291,7 @@ module DateTime {
     if (dt1.tzinfo != nil && dt2.tzinfo == nil) ||
         (dt1.tzinfo == nil && dt2.tzinfo != nil) {
       halt("both datetimes must both be either naive or aware");
-    } else if dt1.tzinfo == nil || dt1.tzinfo == dt2.tzinfo {
+    } else if dt1.tzinfo == dt2.tzinfo {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
       if date1 > date2 then return true;
@@ -1310,7 +1310,7 @@ module DateTime {
     if (dt1.tzinfo != nil && dt2.tzinfo == nil) ||
         (dt1.tzinfo == nil && dt2.tzinfo != nil) {
       halt("both datetimes must both be either naive or aware");
-    } else if dt1.tzinfo == nil || dt1.tzinfo == dt2.tzinfo {
+    } else if dt1.tzinfo == dt2.tzinfo {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
       if date1 > date2 then return true;


### PR DESCRIPTION
Using floating point in the time comparison operators led to some problems on
linux32, so switch to using integers only.  This should fix the testTime failure on linux32.

While there, noticed some unnecessary nil checks, so removed them.