### PR TITLE
Move new primality graph to its own suite

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -288,6 +288,7 @@ users/npadmana/twopt/twopt-buildtrees.graph
 users/npadmana/twopt/twopt-paircount.graph
 # suite: Elegance
 studies/elegance/elegance.graph
+# suite: Math operations
+patterns/prime_generator/prime.graph
 # suite: Samples (bogus)
 Samples/Performance/foo.graph
-patterns/prime_generator/prime.graph


### PR DESCRIPTION
It didn't make sense to force the contributor of the primality test to
worry so much about which suite the graph should go in, so I
resorted it myself after the merge.

Tested correctness and performance graph generation