### PR TITLE
Make paratest.server work within salloc on Cray systems

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -682,7 +682,8 @@ sub main {
             }
         }
     } else { # else, just current node
-        if( defined $ENV{'SLURM_JOB_NODELIST'} ) {
+        if( (defined $ENV{'SLURM_JOB_NODELIST'}) &&
+            ($platform !~ /^cray-x/) ) {
             my $SLURM_NODELIST = $ENV{'SLURM_JOB_NODELIST'};
             my $SLURM_NODES = `scontrol show hostnames $SLURM_NODELIST`;
             my @SLURM_NODES = split(' ', $SLURM_NODES);


### PR DESCRIPTION
The paratest.server script is designed to ssh into the worker nodes when inside an salloc.  This works for a cluster, but on a Cray X-series system, it tries to ssh into the compute nodes.  Turning off the slurm detection when on a Cray X-series machine allows it to work under salloc there.  This is a two-line change to do that.

@mppf and @ronawho are likely to be interested in looking at this.