### PR TITLE
Reorganize performance suites to avoid latest singleton

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -274,7 +274,7 @@ users/npadmana/twopt/twopt-buildtrees.graph
 users/npadmana/twopt/twopt-paircount.graph
 # suite: Elegance
 studies/elegance/elegance.graph
-# suite: Scalar Performance
+# suite: Serial Performance
 patterns/prime_generator/prime.graph
 statements/lydia/forCompare.graph
 statements/lydia/whileCompare.graph
@@ -305,6 +305,5 @@ statements/lydia/ifVersusSelect.alternates.graph
 statements/lydia/moduleVersusFunctionBaseline.graph
 statements/lydia/moduleVersusFunctionDifAccess.graph
 statements/lydia/moduleVersusFunction.graph
-
 # suite: Samples (bogus)
 Samples/Performance/foo.graph

--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -217,25 +217,11 @@ functions/iterators/angeles/distAdaptativeWSv1.graph
 functions/iterators/angeles/distAdaptativeWSv2.graph
 functions/iterators/angeles/guided.graph
 functions/iterators/angeles/distAdaptativeWS.graph
-# suite: Chapel versus C comparisons
-statements/lydia/forCompare.graph
-statements/lydia/whileCompare.graph
-io/vass/time-write.graph
-arrays/diten/time_iterate.graph
-arrays/lydia/time_access.graph
-statements/lydia/externMethodCallPerf.graph
-# suite: Statement comparisons
-statements/lydia/forVersusWhilePerf.graph
-statements/lydia/ifVersusSelect.graph
-statements/lydia/ifVersusSelect.random.graph
-statements/lydia/ifVersusSelect.alternates.graph
+# suite: Parallel Statement Comparisons
 parallel/taskCompare/lydia/forBeginCompare.graph
 parallel/taskCompare/lydia/coforallCompare.graph
 parallel/taskCompare/lydia/coforallBeginCompare.graph
 parallel/taskCompare/lydia/loopCompare.graph
-statements/lydia/moduleVersusFunctionBaseline.graph
-statements/lydia/moduleVersusFunctionDifAccess.graph
-statements/lydia/moduleVersusFunction.graph
 # suite: Task Spawning
 parallel/taskCompare/elliot/taskSpawn.graph
 parallel/taskCompare/elliot/serialTaskSpawn.graph
@@ -288,7 +274,37 @@ users/npadmana/twopt/twopt-buildtrees.graph
 users/npadmana/twopt/twopt-paircount.graph
 # suite: Elegance
 studies/elegance/elegance.graph
-# suite: Math operations
+# suite: Scalar Performance
 patterns/prime_generator/prime.graph
+statements/lydia/forCompare.graph
+statements/lydia/whileCompare.graph
+io/vass/time-write.graph
+arrays/diten/time_iterate.graph
+arrays/lydia/time_access.graph
+statements/lydia/externMethodCallPerf.graph
+statements/lydia/forVersusWhilePerf.graph
+statements/lydia/ifVersusSelect.graph
+statements/lydia/ifVersusSelect.random.graph
+statements/lydia/ifVersusSelect.alternates.graph
+statements/lydia/moduleVersusFunctionBaseline.graph
+statements/lydia/moduleVersusFunctionDifAccess.graph
+statements/lydia/moduleVersusFunction.graph
+# suite: - Chapel versus C Comparisons
+patterns/prime_generator/prime.graph
+statements/lydia/forCompare.graph
+statements/lydia/whileCompare.graph
+io/vass/time-write.graph
+arrays/diten/time_iterate.graph
+arrays/lydia/time_access.graph
+statements/lydia/externMethodCallPerf.graph
+# suite: - Statement Comparisons
+statements/lydia/forVersusWhilePerf.graph
+statements/lydia/ifVersusSelect.graph
+statements/lydia/ifVersusSelect.random.graph
+statements/lydia/ifVersusSelect.alternates.graph
+statements/lydia/moduleVersusFunctionBaseline.graph
+statements/lydia/moduleVersusFunctionDifAccess.graph
+statements/lydia/moduleVersusFunction.graph
+
 # suite: Samples (bogus)
 Samples/Performance/foo.graph


### PR DESCRIPTION
This
- removes the top-level suites "Chapel versus C comparisons", "Statement
  Comparisons" and "Math operations"
- creates a new top-level suite "Serial Performance" and two sub-suites,
  "Chapel versus C Comparisons" and "Statment Comparisons"
  - moves entirety of old top level suite "Chapel versus C comparisons" into
    suite of same name, and moves entirety of "Math operations" into the same
    suite
- moves some of "Statement Comparisons" into a new suite, "Parallel Statement
  Comparisons"
  - moves the rest of the old "Statement Comparisons" suite into the new
    sub-suite of the same name.

Verified output with --generate-graphs and that no .graph was missing after the
commit.