### PR TITLE
Disable deadStringLiteralElimination if inlining or copy-propagation is disabled

### DIFF
--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -308,10 +308,12 @@ void deadCodeElimination(FnSymbol* fn) {
 *   3) Remove the code that initializes the literal.                          *
 *                                                                             *
 *      This is fragile as it currently depends on implementation details in   *
-*      other portions of the compiler.                                        *
+*      other portions of the compiler.  It is believed that this will be      *
+*      easier to manage when record initializers are in production.           *
 *                                                                             *
 * The hardest part is determining when this code needs to be revisited.       *
 * 2017/03/04: Perform an "ad hoc" sanity check for now.                       *
+* 2017/03/09: Disable this pass if flags might alter the pattern.             *
 *                                                                             *
 ************************************** | *************************************/
 
@@ -319,36 +321,44 @@ static bool isDeadStringLiteral(VarSymbol* string);
 static void removeDeadStringLiteral(DefExpr* defExpr);
 
 static void deadStringLiteralElimination() {
-  int numStmt        = 0;
-  int numDeadLiteral = 0;
+  // Noakes 2017/03/09
+  //   These two flags are known to alter the pattern we are looking for.
+  //   Rather than handle the variations we simply leak if these flags are
+  //   on.  We anticipate that this will be easier to handle when record
+  //   initializers are in production and have been applied to strings.
+  if (fNoCopyPropagation == false &&
+      fNoInline          == false) {
+    int numStmt        = 0;
+    int numDeadLiteral = 0;
 
-  for_alist(stmt, stringLiteralModule->block->body) {
-    numStmt = numStmt + 1;
+    for_alist(stmt, stringLiteralModule->block->body) {
+      numStmt = numStmt + 1;
 
-    if (DefExpr* defExpr = toDefExpr(stmt)) {
-      if (VarSymbol* symbol = toVarSymbol(defExpr->sym)) {
-        if (isDeadStringLiteral(symbol) == true) {
-          removeDeadStringLiteral(defExpr);
+      if (DefExpr* defExpr = toDefExpr(stmt)) {
+        if (VarSymbol* symbol = toVarSymbol(defExpr->sym)) {
+          if (isDeadStringLiteral(symbol) == true) {
+            removeDeadStringLiteral(defExpr);
 
-          numDeadLiteral = numDeadLiteral + 1;
+            numDeadLiteral = numDeadLiteral + 1;
+          }
         }
       }
     }
-  }
 
-  //
-  // Noakes 2017/03/04
-  //
-  // There is not currently a principled way to determine if other
-  // paseses have changed in a way that would confuse this pass.
-  //
-  // A quick review of a portion of test/release/examles shows that
-  // this pass removes 85 - 95% of the string literals.  Signal an
-  // error if this pass doesn't reclaim at least 10% of all string
-  // literals unless this is minimal modules
-  //
-  if (fMinimalModules == false) {
-    INT_ASSERT((1.0 * numDeadLiteral) / numStmt > 0.10);
+    //
+    // Noakes 2017/03/04
+    //
+    // There is not a principled way to determine if other passes
+    // have changed in a way that would confuse this pass.
+    //
+    // A quick review of a portion of test/release/examles shows that
+    // this pass removes 85 - 95% of the string literals.  Signal an
+    // error if this pass doesn't reclaim at least 10% of all string
+    // literals unless this is minimal modules
+    //
+    if (fMinimalModules == false) {
+      INT_ASSERT((1.0 * numDeadLiteral) / numStmt > 0.10);
+    }
   }
 }
 


### PR DESCRIPTION
Summary:

This is a trivial change to disable deadStringLiteralElimination in certain non-production situations.

Compiled with/without CHPL_DEVELOPER on clang and gcc.
Local testing and then ran start_test on a non-trivial portion of release/

Discussed with Elliot



Background:

A recent change to callDestructors() caused the original implementation of
deadStringLiteralElimination() to fail.  The current approach to dead string literal elimination
is fundamentally fragile; it is reasonably easy to identify the dead string literals but it is relatively
hard to determine the set of nodes that were inserted for a given literal.

While updating the implementation to compensate for the changes in callDestructors()
I added some checks to ensure that the cleanup code was removing the correct AST.
These additional checks clarified that toggling certain optimization flags will change
the AST that this pass is trying to clean up.

In particular Michael was debugging something by throwing --no-copy-propagation.
This changed the AST that is emitted for string literals and this was flagged, in a
brutal fashion, by my additional checks. (Sorry Michael).

Rather than trying to implement checks for the other patterns, Elliot and I agreed that
it is more pragmatic to simply disable dead string elimination when the impacting flags
are thrown.  We concluded that it was sufficient to catch --no-copy-propagation and
--no-inline.  We view these as "debugging" flags and conclude that it is acceptable to
forgo the cleanup in these modes.

We anticipate that this issue will be more straight forward to address when record
initializers are in production cand can be applied to Chapel strings.


