### PR TITLE
Improve LICM effectiveness for iterator classes

### DIFF
--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -858,19 +858,22 @@ static void computeLoopInvariants(std::vector<SymExpr*>& loopInvariants, Loop*
     // Note that not all things that are passed by ref will have the ref intent
     // flag, and may just be ref variables. This is a known bug, see comments
     // in addVarsToFormals(): flattenFunctions.cpp.
-    if(ArgSymbol* argSymbol = toArgSymbol(symExpr->symbol())) {
-      if(argSymbol->intent == INTENT_REF ||
-         argSymbol->intent == INTENT_CONST_REF ||
-         isReferenceType(argSymbol->type)) {
-        mightHaveBeenDeffedElseWhere = true;
-      }
-    }
-    for_set(Symbol, aliasSym, aliases[symExpr->symbol()]) {
-      if(ArgSymbol* argSymbol = toArgSymbol(aliasSym)) {
+    if (isArgSymbol(symExpr->symbol()) &&
+        symExpr->getValType()->symbol->hasFlag(FLAG_ITERATOR_CLASS) == false) {
+      if(ArgSymbol* argSymbol = toArgSymbol(symExpr->symbol())) {
         if(argSymbol->intent == INTENT_REF ||
            argSymbol->intent == INTENT_CONST_REF ||
            isReferenceType(argSymbol->type)) {
           mightHaveBeenDeffedElseWhere = true;
+        }
+      }
+      for_set(Symbol, aliasSym, aliases[symExpr->symbol()]) {
+        if(ArgSymbol* argSymbol = toArgSymbol(aliasSym)) {
+          if(argSymbol->intent == INTENT_REF ||
+             argSymbol->intent == INTENT_CONST_REF ||
+             isReferenceType(argSymbol->type)) {
+            mightHaveBeenDeffedElseWhere = true;
+          }
         }
       }
     }
@@ -940,18 +943,18 @@ static void computeLoopInvariants(std::vector<SymExpr*>& loopInvariants, Loop*
   printf("\n");
   printf("HOISTABLE Invariants\n");
   for_set(SymExpr, loopInvariant, loopInvariantInstructions) {
-    printf("Symbol %s with id %d is a hoistable loop invariant\n", loopInvariant->var->name, loopInvariant->var->id);
+    printf("Symbol %s with id %d is a hoistable loop invariant\n", loopInvariant->symbol()->name, loopInvariant->symbol()->id);
   }
   
   printf("\n\n\n");
   printf("Invariant OPERANDS\n");
   for_set(SymExpr, symExpr2, loopInvariantOperands) {
-    printf("%s %d is invariant\n", symExpr2->var->name, symExpr2->id);
+    printf("%s %d is invariant\n", symExpr2->symbol()->name, symExpr2->id);
   }
   
   printf("\n\n\n");
   for_vector(SymExpr, symExpr3, loopSymExprs) {
-    printf("%s %dis used/ defed\n", symExpr3->var->name, symExpr3->var->id);
+    printf("%s %d is used/ defed\n", symExpr3->symbol()->name, symExpr3->symbol()->id);
   } 
 #endif  
  


### PR DESCRIPTION
LICM currently checks if any symbols used in the loop
are formals with a ref intent. If that's the case, then it will
not hoist them out of the loop. We observed a performance
regression in the views-forall mini-benchmark for rank-change
arrays, and tracked the cause down to a lack of hoisting due
to the way in which an iterator class was used.

@ronawho and I feel that we can safely side-step this formal
check in the case that the formal is an iterator class. We think
that this is a safe approach because in order to see changes
synchronization would be required to comply with our memory
model, and LICM does not attempt hoisting if such constructs
are present in the loop.

While other tests also generated less-than-ideal loops, the
rank-change loop involved more work (reading blk(rank)).

TODO: Long-term we'd like to revisit this ArgSymbol check
in its entirety, but we're close to the release and this seems
like a fairly targeted change.

Testing:
- [x] full local
- [x] full gasnet