### PR TITLE
Overlay nightly graphs onto releaseOverRelease graphs

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -793,7 +793,8 @@ if ($runtests == 0) {
 
             #delete the previous spliced data (from yesterday) and make a fresh directory
             $tmpDatDir = "/tmp/releaseOverReleaseDats/";
-            `rm -rf $tmpDatDir && mkdir $tmpDatDir`;
+            $tmpNightlyDatDir = "$tmpDatDir/nightly";
+            `rm -rf $tmpDatDir && mkdir $tmpDatDir && mkdir $tmpNightlyDatDir`;
 
             # for each .dat file, splice the historical data with the nightly
             # data. Do not send a message on failiure because you could end up
@@ -812,13 +813,14 @@ if ($runtests == 0) {
                 $spliceCommand = "$splice -from_a $today -to_a $today $svnPerfDir/$datName $historicalFile> $tmpDatDir/$datName";
                 $spliceDatMessage = "Attempting to splice historical data $historicalFile with nightly data $svnPerfDir/$datName";
                 mysystem($spliceCommand, $spliceMessage, 0, 0, 1);
+                `cp $svnPerfDir/$datName $tmpNightlyDatDir/$datName`;
             }
 
             # create the performance graphs from the newly spliced .dat files
             $altTitle = "Chapel Release Over Release Performance Graphs";
-            $startdate = "04/10/12"; # earliest date that we generate historical data for
+            $startdate = "09/22/14"; # start at 1.10
             $genGraphs = "$utildir/test/genGraphs";
-            $genGraphsCommand = "$genGraphs -p $tmpDatDir -o $svnReleasePerfDir/html/ -t $chplhomedir/test/ -a \"$altTitle\" -n $perfConfigName  -g $chplhomedir/test/GRAPHFILES -s $startdate";
+            $genGraphsCommand = "$genGraphs -p $tmpDatDir -o $svnReleasePerfDir/html/ -t $chplhomedir/test/ -a \"$altTitle\" -n $perfConfigName  -g $chplhomedir/test/GRAPHFILES -s $startdate -m default:v,nightly";
             $genGraphsMessage = "Generating release over release performance graphs";
             mysystem($genGraphsCommand, $genGraphsMessage, 0, 1, 1);
 


### PR DESCRIPTION
When looking at the releaseOverRelease graphs we often open up the nightly
graphs at the same time so that we can see if regressions are within the
nightly noise or if it's something real to investigate. This allows us to view
releaseOverRelease and the nightly results on the same graph to simplify
releaseOverRelease performance triage.