### PR TITLE
Remove bashism from clean/cleanall/clobber targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ clean: FORCE
 	cd modules && $(MAKE) clean
 	cd runtime && $(MAKE) clean
 	cd third-party && $(MAKE) clean
-	if [ -a doc/Makefile ]; then cd doc && $(MAKE) clean; fi
+	if [ -e doc/Makefile ]; then cd doc && $(MAKE) clean; fi
 	rm -f util/chplenv/*.pyc
 
 cleanall: FORCE
@@ -149,7 +149,7 @@ cleanall: FORCE
 	cd modules && $(MAKE) cleanall
 	cd runtime && $(MAKE) cleanall
 	cd third-party && $(MAKE) cleanall
-	if [ -a doc/Makefile ]; then cd doc && $(MAKE) cleanall; fi
+	if [ -e doc/Makefile ]; then cd doc && $(MAKE) cleanall; fi
 	rm -f util/chplenv/*.pyc
 	rm -rf build
 
@@ -163,7 +163,7 @@ clobber: FORCE
 	cd runtime && $(MAKE) clobber
 	cd third-party && $(MAKE) clobber
 	cd tools/chplvis && $(MAKE) clobber
-	if [ -a doc/Makefile ]; then cd doc && $(MAKE) clobber; fi
+	if [ -e doc/Makefile ]; then cd doc && $(MAKE) clobber; fi
 	rm -rf bin
 	rm -rf lib
 	rm -rf build


### PR DESCRIPTION
I've been working on an Ubuntu 17.04 system and there, Makefile commands
run with /bin/sh. A result of that is that an if statement like

     if [ -a doc/Makefile ]

results in a syntax error, since -a is a bash-ism.

This commit simply changes it to use -e which as far as I can tell does
exactly the same thing (does the file exist?) and is compatible with
/bin/sh.

Passed full local testing.
Reviewed by @ben-albrecht.