### PR TITLE
Rename name field from NumaDomain and add tests

### DIFF
--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -54,27 +54,27 @@ module LocaleModel {
   //
   class NumaDomain : AbstractLocaleModel {
     const sid: chpl_sublocID_t;
-    const name: string;
+    const ndName: string; // note: locale provides `proc name`
 
     proc chpl_id() return (parent:LocaleModel)._node_id; // top-level node id
     proc chpl_localeid() {
       return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
                                 sid);
     }
-    proc chpl_name() return name;
+    proc chpl_name() return ndName;
 
     proc NumaDomain() {
     }
 
     proc NumaDomain(_sid, _parent) {
       sid = _sid;
-      name = "ND"+sid;
+      ndName = "ND"+sid;
       parent = _parent;
     }
 
     proc writeThis(f) {
       parent.writeThis(f);
-      f <~> '.'+name;
+      f <~> '.'+ndName;
     }
 
     proc getChildCount(): int { return 0; }

--- a/test/classes/ferguson/const-override-bug.bad
+++ b/test/classes/ferguson/const-override-bug.bad
@@ -1,0 +1,2 @@
+const-override-bug.chpl:19: In initializer 'myNumaDomain':
+const-override-bug.chpl:20: error: illegal lvalue in assignment

--- a/test/classes/ferguson/const-override-bug.chpl
+++ b/test/classes/ferguson/const-override-bug.chpl
@@ -1,0 +1,27 @@
+class myLocale {
+  
+  proc name return chpl_name() : string;
+
+  proc chpl_name() : string {
+    _throwPVFCError();
+    return "";
+  }
+
+}
+
+class myAbstractLocaleModel : myLocale {
+}
+
+class myNumaDomain : myAbstractLocaleModel {
+  const name: string;
+  proc chpl_name() return name;
+
+  proc myNumaDomain() {
+    name = "test";
+  }
+}
+
+
+var c = new myNumaDomain();
+writeln(c.name);
+

--- a/test/classes/ferguson/const-override-bug.future
+++ b/test/classes/ferguson/const-override-bug.future
@@ -1,0 +1,15 @@
+error message: overriding parentheses-less value method with field
+
+The problem here is that during function resolution, the call to the
+field accessor function`name` in the constructor for myNumaDomain is
+resolving to the `proc name` from class myLocale.
+
+I think it's debateable whether or not we even want to support this
+pattern. If we don't want to support it, we'd need a better error message
+for this case.
+
+If this behavior is meant to be supported, we need to fix something in
+resolution so that the field name is preferred over the parent class
+parentheses-less method name in the constructor for myNumaDomain. I
+expect that to be the case with the new initializers.
+

--- a/test/classes/ferguson/const-override-bug.good
+++ b/test/classes/ferguson/const-override-bug.good
@@ -1,0 +1,1 @@
+const-override-bug.chpl:16: error: overriding method with field

--- a/test/functions/ferguson/ref-pair/across-scopes.bad
+++ b/test/functions/ferguson/ref-pair/across-scopes.bad
@@ -1,0 +1,14 @@
+Calling child name functions
+Child
+Child
+Child
+Parent
+Parent
+Parent
+Calling parent name functions
+Parent
+Parent
+Parent
+Parent
+Parent
+Parent

--- a/test/functions/ferguson/ref-pair/across-scopes.chpl
+++ b/test/functions/ferguson/ref-pair/across-scopes.chpl
@@ -1,0 +1,52 @@
+
+var parentName = "Parent";
+var childName = "Child";
+
+class Parent {
+  // ref + const ref
+  proc name const ref return parentName;
+  proc name2 ref return parentName;
+
+  // const ref + value
+  proc name3 const ref return parentName;
+  proc name4 return parentName;
+
+  // ref + value
+  proc name5 return parentName;
+  proc name6 ref return parentName;
+}
+
+
+class Child : Parent {
+  // ref + const ref
+  proc name ref return childName;
+  proc name2 const ref return childName;
+
+  // const ref + value
+  proc name3 return childName;
+  proc name4 const ref return childName;
+
+  // ref + value
+  proc name5 ref return parentName;
+  proc name6 return parentName;
+}
+
+
+writeln("Calling child name functions");
+var c = new Child();
+writeln(c.name);
+writeln(c.name2);
+writeln(c.name3);
+writeln(c.name4);
+writeln(c.name5);
+writeln(c.name6);
+
+writeln("Calling parent name functions");
+var d = c:Parent;
+writeln(d.name);
+writeln(d.name2);
+writeln(d.name3);
+writeln(d.name4);
+writeln(d.name5);
+writeln(d.name6);
+

--- a/test/functions/ferguson/ref-pair/across-scopes.future
+++ b/test/functions/ferguson/ref-pair/across-scopes.future
@@ -1,0 +1,18 @@
+semantic: should ref-pairs be allowed across scopes?
+
+After PR #5561, the behavior of this program changed, because const ref
+vs value return is now included in ref-pair calculations in
+resolveNormalCall. However, the issue started with the first versions of
+ref-pair support in the compiler.
+
+The question is - if normal resolution rules would select the ref/const
+ref/value version in preference to the other version, should that always
+be used? Should ref-pair behavior only be triggered if there would
+otherwise be an ambiguity? It's not currently the case as this test
+demonstrates.
+
+One reason the answer to this question isn't entirely obvious is that
+generic functions with a matching `where` clause are normally selected in
+favor of generic functions without a `where` clause. That pattern comes
+up in the array accessor methods, where the `ref` return version does not
+have a `where` clause but the value or const ref return versions do.

--- a/test/functions/ferguson/ref-pair/across-scopes.good
+++ b/test/functions/ferguson/ref-pair/across-scopes.good
@@ -1,0 +1,14 @@
+Calling child name functions
+Child
+Child
+Child
+Child
+Child
+Child
+Calling parent name functions
+Parent
+Parent
+Parent
+Parent
+Parent
+Parent


### PR DESCRIPTION
The name field is confusingly named because the parent class locale
already has a parentheses-less method named `proc name`.

The recent PR #5561 changed function resolution in a way that revealed
this issue.

I'm not sure the language should support for such overloading, but even
if it does, I don't think we should use it in NumaDomain because we'll
just confuse ourselves.

So, this PR simply renames the name field to ndName.

It adds two futures. One future tracks the exact issue we were running
into with NumaDomain and is related to const-checking in a constructor.
The second future asks about how ref-pairs should be resolved when one of
the elements of the ref-pair would normally have lower resolution
precedence (e.g. requires coercion, in a different scope, etc).

Trivial, not reviewed.