### PR TITLE
Fix future (Thanks Ben H!)

### DIFF
--- a/test/functions/ferguson/ref-pair/across-scopes.bad
+++ b/test/functions/ferguson/ref-pair/across-scopes.bad
@@ -3,8 +3,8 @@ Child
 Child
 Child
 Parent
-Parent
-Parent
+Child
+Child
 Calling parent name functions
 Parent
 Parent

--- a/test/functions/ferguson/ref-pair/across-scopes.chpl
+++ b/test/functions/ferguson/ref-pair/across-scopes.chpl
@@ -27,8 +27,8 @@ class Child : Parent {
   proc name4 const ref return childName;
 
   // ref + value
-  proc name5 ref return parentName;
-  proc name6 return parentName;
+  proc name5 ref return childName;
+  proc name6 return childName;
 }
 
 


### PR DESCRIPTION
Ben noticed a trivial problem in the test itself, so this fixes it.

Verified test/functions/ferguson/ref-pair/across-scopes.chpl has clean match against .bad file.