### PR TITLE
Make _this formals of record type be ref-if-modified

### DIFF
--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -144,8 +144,14 @@ static IntentTag constIntentForThisArg(Type* t) {
 static IntentTag blankIntentForThisArg(Type* t) {
   // todo: be honest when 't' is an array or domain
 
+  Type* valType = t->getValType();
+
+  // For user records or types with FLAG_DEFAULT_INTENT_IS_REF_MAYBE_CONST,
+  // the intent for this is INTENT_REF_MAYBE_CONST
+  //
   // This applies to both arguments of type _ref(t) and t
-  if (t->getValType()->symbol->hasFlag(FLAG_DEFAULT_INTENT_IS_REF_MAYBE_CONST))
+  if (isRecord(valType) ||
+      valType->symbol->hasFlag(FLAG_DEFAULT_INTENT_IS_REF_MAYBE_CONST))
     return INTENT_REF_MAYBE_CONST;
 
   if (isRecordWrappedType(t))  // domain / distribution

--- a/test/functions/ferguson/ref-pair/record-this-intent-const-error.chpl
+++ b/test/functions/ferguson/ref-pair/record-this-intent-const-error.chpl
@@ -1,0 +1,15 @@
+
+
+record R {
+  var field:int;
+
+  proc setsField() {
+    field = 1;
+  }
+}
+
+const globalR = new R();
+
+globalR.setsField();
+
+

--- a/test/functions/ferguson/ref-pair/record-this-intent-const-error.future
+++ b/test/functions/ferguson/ref-pair/record-this-intent-const-error.future
@@ -1,0 +1,1 @@
+error message: calling modifying method on const record

--- a/test/functions/ferguson/ref-pair/record-this-intent-const-error.good
+++ b/test/functions/ferguson/ref-pair/record-this-intent-const-error.good
@@ -1,0 +1,5 @@
+record-this-intent-const-error.chpl:13: error: const actual is passed to 'ref' formal 'this' of setsField()
+record-this-intent-const-error.chpl:3: note: to ref formal here
+record-this-intent-const-error.chpl:7: note: passed as ref here
+record-this-intent-const-error.chpl:4: note: to ref formal here
+record-this-intent-const-error.chpl:7: note: passed as ref here

--- a/test/functions/ferguson/ref-pair/record-this-intent.chpl
+++ b/test/functions/ferguson/ref-pair/record-this-intent.chpl
@@ -1,0 +1,32 @@
+
+
+record R {
+  var field:int;
+
+  proc setsField() {
+    field = 1;
+  }
+
+  proc readsField() {
+    writeln(field);
+  }
+
+}
+
+var globalR = new R();
+
+proc getter() ref {
+  writeln("REF");
+  return globalR;
+}
+
+proc getter() const ref {
+  writeln("CONST REF");
+  return globalR;
+}
+
+getter().setsField();
+
+getter().readsField();
+
+

--- a/test/functions/ferguson/ref-pair/record-this-intent.good
+++ b/test/functions/ferguson/ref-pair/record-this-intent.good
@@ -1,0 +1,3 @@
+REF
+CONST REF
+1


### PR DESCRIPTION
Closes #5266.

* Adjusts blankIntentForThisArg in resolveIntents to treat
  records similarly to arrays

* Adds two tests. One is a future because late const checking is
  currently disabled.

Passed full local testing.
Reviewed by @benharsh - thanks!