### PR TITLE
Change a record destructor into a deinit

### DIFF
--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -533,7 +533,7 @@ module DateTime {
   }
 
   pragma "no doc"
-  proc time.~time() {
+  proc time.deinit() {
     // delete tzinfo if needed
   }
 


### PR DESCRIPTION
At @lydia-duncan's request, changed an old style destructor into a new
style deinit() in the DateTime module.