### PR TITLE
Nightly build fails if Chapel test elapsed time is negative

### DIFF
--- a/util/test/convert_start_test_log_to_junit_xml.py
+++ b/util/test/convert_start_test_log_to_junit_xml.py
@@ -303,16 +303,17 @@ def _get_test_time(test_case_lines):
             raise ValueError(msg)
     time_line = test_case_lines[time_line_idx]
 
-    pattern = re.compile(' - (?P<time>\d+\.\d+) seconds\]$')
+    pattern = re.compile(' - (?P<time>-?\d+\.\d+) seconds\]$')
     match = pattern.search(time_line)
-    if match is None:
+    if match:
+        time = match.group('time')
+    else:
+        time = '0.0'
         msg = 'Could not find time in: {0}'.format(time_line)
         logging.warn(msg)
         if DEBUG:
             raise ValueError(msg)
-
-    time = match.group('time')
-    return float(time)
+    return max(float(time),0.0)
 
 
 def _get_test_error(test_case_lines):


### PR DESCRIPTION
Once a month or so, a nightly Jenkins correctness test build fails
completely, because the script that reads the build log and writes
the JUnit result XML file dies. For some reason, a negative value
of "elapsed time" gets emitted into the log by something upstream
(probably sub_test or start_test, not sure), and that makes this
script throw an exception. The entire test build, including all
the test results, is lost.

There is reason to believe these negative elapsed times are due to
some kind of system clock skew on the Jenkins build slave, which is
always a VM when this happens.

Whatever is going on, there's no reason we have to lose the entire
build.

This change fixes util/test/convert_start_test_log_to_junit_xml.py
to be able to handle negative values of "elapsed time" without
throwing an exception.