### PR TITLE
Fix futures 5561

### DIFF
--- a/test/arrays/bradc/refArray2.bad
+++ b/test/arrays/bradc/refArray2.bad
@@ -1,1 +1,0 @@
-refArray2.chpl:5: error: Cannot set a non-const reference to a const variable.

--- a/test/arrays/bradc/refArray2.chpl
+++ b/test/arrays/bradc/refArray2.chpl
@@ -7,3 +7,5 @@ proc foo(A: []) {
   writeln(A);
   writeln(AA);
 }
+
+foo(A);

--- a/test/arrays/bradc/refArray2.future
+++ b/test/arrays/bradc/refArray2.future
@@ -1,3 +1,0 @@
-bug: Taking 'ref' to array formal not permitted
-
-Since arrays are passed by 'ref' by default, it seems like this should work?

--- a/test/distributions/deitz/test_distribution_syntax2.bad
+++ b/test/distributions/deitz/test_distribution_syntax2.bad
@@ -4,4 +4,4 @@ Block-Distributed Array
 (0, 5) (0, 6) (1, 7) (1, 8)
 (2, 9) (2, 10) (3, 11) (3, 12)
 (2, 13) (2, 14) (3, 15) (3, 16)
-$CHPL_HOME/modules/internal/ChapelArray.chpl:829: error: attempt to dereference nil
+$CHPL_HOME/modules/internal/ChapelArray.chpl:n: error: attempt to dereference nil

--- a/test/distributions/deitz/test_distribution_syntax2.prediff
+++ b/test/distributions/deitz/test_distribution_syntax2.prediff
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Ignore line numbers, reduce multiple 'printing _ddata class' to single.
+TESTNAME=$1
+OUTFILE=$2
+TMPFILE1=$OUTFILE.prediff.tmp.1
+sed 's/:[0-9]*:/:n:/g' < $OUTFILE > $TMPFILE1
+cat $TMPFILE1 > $OUTFILE
+rm $TMPFILE1

--- a/test/types/records/ferguson/choose-record/choose-record10.bad
+++ b/test/types/records/ferguson/choose-record/choose-record10.bad
@@ -1,7 +1,0 @@
-choose-record10.chpl:20: internal error: CHE0450 chpl Version 1.14.0.efccf5c
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/types/records/ferguson/choose-record/choose-record10.future
+++ b/test/types/records/ferguson/choose-record/choose-record10.future
@@ -1,1 +1,0 @@
-error message: capturing returned const record as ref

--- a/test/types/records/ferguson/choose-record/choose-record10.good
+++ b/test/types/records/ferguson/choose-record/choose-record10.good
@@ -1,1 +1,2 @@
-choose-record10.chpl:20: error: capturing constant value as ref
+choose-record10.chpl:20: error: Cannot set a non-const reference to a const variable.
+choose-record10.chpl:23: error: Cannot set a non-const reference to a const variable.

--- a/test/types/records/ferguson/copy-init/new-init-generic.bad
+++ b/test/types/records/ferguson/copy-init/new-init-generic.bad
@@ -1,6 +1,2 @@
 new-init-generic.chpl:6: In initializer:
-new-init-generic.chpl:6: error: can't omit initialization of field "x", no type or default value provided
-new-init-generic.chpl:12: In initializer:
-new-init-generic.chpl:12: error: can't omit initialization of field "x", no type or default value provided
-new-init-generic.chpl:6: In initializer:
 new-init-generic.chpl:9: error: 'super' undeclared (first use this function)

--- a/test/variables/sungeun/refvar-assign-with-cast.bad
+++ b/test/variables/sungeun/refvar-assign-with-cast.bad
@@ -1,7 +1,0 @@
-refvar-assign-with-cast.chpl:2: internal error: CHE0450 chpl Version 1.14.0.efccf5c
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/variables/sungeun/refvar-assign-with-cast.future
+++ b/test/variables/sungeun/refvar-assign-with-cast.future
@@ -1,1 +1,0 @@
-bug: Initializing a ref var with a casted variable results in an internal error during function resolution

--- a/test/variables/sungeun/refvar-assign-with-cast.good
+++ b/test/variables/sungeun/refvar-assign-with-cast.good
@@ -1,1 +1,1 @@
-FIX ME!
+refvar-assign-with-cast.chpl:2: error: Cannot set a non-const reference to a const variable.

--- a/test/variables/vass/ref-to-const-domain.bad
+++ b/test/variables/vass/ref-to-const-domain.bad
@@ -1,7 +1,0 @@
-ref-to-const-domain.chpl:5: internal error: CHE0450 chpl Version 1.14.0.efccf5c
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/variables/vass/ref-to-const-domain.future
+++ b/test/variables/vass/ref-to-const-domain.future
@@ -1,3 +1,0 @@
-bug: compiler crashes upon 'ref D = fun();' where fun returns a domain.
-
-There is an unhandled case in functionResolution.cpp.

--- a/test/variables/vass/ref-to-const-domain.good
+++ b/test/variables/vass/ref-to-const-domain.good
@@ -1,2 +1,2 @@
-ref-to-const-domain.chpl:5: error: Cannot set a non-const reference to a const value.
-ref-to-const-domain.chpl:10: error: Cannot set a non-const reference to a const value.
+ref-to-const-domain.chpl:5: error: Cannot set a non-const reference to a const variable.
+ref-to-const-domain.chpl:10: error: Cannot set a non-const reference to a const variable.


### PR DESCRIPTION
Fix a variety of .bad files and/or retire futures from .bad mismatches in last night's testing.

Most of these are due to PR #5561.

Verified that these tests pass/fail as expected with GASNet and quickstart testing.