### PR TITLE
Update printFinalMemStat.good file for --no-local

### DIFF
--- a/test/memory/shannon/printFinalMemStat.no-local.good
+++ b/test/memory/shannon/printFinalMemStat.no-local.good
@@ -4,6 +4,6 @@ Memory Statistics
 ==============================================================
 Current Allocated Memory               256
 Maximum Simultaneous Allocated Memory  265
-Total Allocated Memory                 274
-Total Freed Memory                     18
+Total Allocated Memory                 289
+Total Freed Memory                     33
 ==============================================================


### PR DESCRIPTION
PR #5561 caused this test output to change, but only in --no-local testing. This PR updates the .good file for that configuration.