### PR TITLE
Forgot to add a SKIPIF for --fast / --no-checks testing

### DIFF
--- a/test/compflags/checks/SKIPIF
+++ b/test/compflags/checks/SKIPIF
@@ -1,0 +1,6 @@
+#
+# tests in this directory check execution-time checks, so we should
+# skip them if the --fast or --no-checks flags are set.
+#
+COMPOPTS <= --fast
+COMPOPTS <= --no-checks


### PR DESCRIPTION
You'd think that, having made this mistake once this week, I wouldn't have
made it again...