### PR TITLE
Improve no-venv support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,12 @@ third-party-try-gmp: FORCE
 	fi
 
 third-party-test-venv: FORCE
-	-@if [ -z "$$CHPL_TEST_VENV_DIR" ]; then \
+	-@if [ -z "$$CHPL_DONT_BUILD_TEST_VENV" ]; then \
 	cd third-party && $(MAKE) test-venv; \
 	fi
 
 third-party-chpldoc-venv: FORCE
-	-@if [ -z "$$CHPL_TEST_VENV_DIR" ]; then \
+	-@if [ -z "$$CHPL_DONT_BUILD_CHPLDOC_VENV" ]; then \
 	cd third-party && $(MAKE) chpldoc-venv; \
 	fi
 


### PR DESCRIPTION
In #5579 I made it so that setting CHPL_TEST_VENV_DIR=none would prevent the
chpldoc and test virtual-envs from being built. This was intended to avoid
building them in cases where the requirements are installed locally, but those
targets are a dependency (like for building the man pages.) However, it also
meant that an explicit `make test-venv` would be a no-op, which seems like a
mistake.

Change it so that CHPL_DONT_BUILD_TEST_VENV and CHPL_DONT_BUILD_CHPLDOC_VENV
will prevent the virtual envs from being built instead.