### PR TITLE
Update for record initializers

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1081,7 +1081,7 @@ void CallExpr::replaceChild(Expr* oldAst, Expr* newAst) {
 
 
 void CallExpr::insertAtHead(BaseAST* ast) {
-  Expr *toInsert;
+  Expr* toInsert = NULL;
 
   if (Symbol* a = toSymbol(ast))
     toInsert = new SymExpr(a);
@@ -1095,7 +1095,7 @@ void CallExpr::insertAtHead(BaseAST* ast) {
 
 
 void CallExpr::insertAtTail(BaseAST* ast) {
-  Expr *toInsert;
+  Expr* toInsert = NULL;
 
   if (Symbol* a = toSymbol(ast))
     toInsert = new SymExpr(a);
@@ -1107,11 +1107,26 @@ void CallExpr::insertAtTail(BaseAST* ast) {
   parent_insert_help(this, toInsert);
 }
 
+void CallExpr::setUnresolvedFunction(const char* name) {
+  // Currently a PRIM_OP
+  if (primitive != NULL) {
+    primitive = NULL;
+    baseExpr  = new UnresolvedSymExpr(astr(name));
+
+    parent_insert_help(this, baseExpr);
+
+  } else if (UnresolvedSymExpr* use = toUnresolvedSymExpr(baseExpr)) {
+    use->unresolved = astr(name);
+
+  } else {
+    INT_ASSERT(false);
+  }
+}
+
 // MDN 2016/01/29: This will become a predicate
 FnSymbol* CallExpr::isResolved() const {
   return resolvedFunction();
 }
-
 
 FnSymbol* CallExpr::resolvedFunction() const {
   FnSymbol* retval = NULL;
@@ -1155,6 +1170,24 @@ FnSymbol* CallExpr::resolvedFunction() const {
   return retval;
 }
 
+void CallExpr::setResolvedFunction(FnSymbol* fn) {
+  // Currently a PRIM_OP
+  if (primitive != NULL) {
+    primitive = NULL;
+    baseExpr  = new SymExpr(fn);
+
+    parent_insert_help(this, baseExpr);
+
+  } else if (isUnresolvedSymExpr(baseExpr) == true) {
+    baseExpr->replace(new SymExpr(fn));
+
+  } else if (SymExpr* se = toSymExpr(baseExpr)) {
+    se->setSymbol(fn);
+
+  } else {
+    INT_ASSERT(false);
+  }
+}
 
 FnSymbol* CallExpr::theFnSymbol() const {
   FnSymbol* retval = NULL;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1853,3 +1853,69 @@ bool isPOD(Type* t)
   return false;
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+bool isPrimitiveScalar(Type* type) {
+  bool retval = false;
+
+  if (type == dtBools[BOOL_SIZE_8]         ||
+      type == dtBools[BOOL_SIZE_16]        ||
+      type == dtBools[BOOL_SIZE_32]        ||
+      type == dtBools[BOOL_SIZE_64]        ||
+
+      type == dtInt[INT_SIZE_8]            ||
+      type == dtInt[INT_SIZE_16]           ||
+      type == dtInt[INT_SIZE_32]           ||
+      type == dtInt[INT_SIZE_64]           ||
+
+      type == dtUInt[INT_SIZE_8]           ||
+      type == dtUInt[INT_SIZE_16]          ||
+      type == dtUInt[INT_SIZE_32]          ||
+      type == dtUInt[INT_SIZE_64]          ||
+
+      type == dtReal[FLOAT_SIZE_32]        ||
+      type == dtReal[FLOAT_SIZE_64]        ||
+
+      type == dtImag[FLOAT_SIZE_32]        ||
+      type == dtImag[FLOAT_SIZE_64]) {
+
+    retval = true;
+
+  } else {
+    retval = false;
+  }
+
+  return retval;
+}
+
+bool isNonGenericClass(Type* type) {
+  bool retval = false;
+
+  if (AggregateType* at = toAggregateType(type)) {
+    if (at->isGeneric()                  == false &&
+        at->isClass()                    ==  true &&
+        at->symbol->hasFlag(FLAG_EXTERN) == false) {
+      retval = true;
+    }
+  }
+
+  return retval;
+}
+
+bool isNonGenericRecordWithInitializers(Type* type) {
+  bool retval = false;
+
+  if (AggregateType* at = toAggregateType(type)) {
+    if (at->isGeneric()      == false &&
+        at->isRecord()       == true  &&
+        at->initializerStyle == DEFINES_INITIALIZER) {
+      retval = true;
+    }
+  }
+
+  return retval;
+}

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -259,8 +259,11 @@ public:
   bool            isPrimitive(PrimitiveTag primitiveTag)                 const;
   bool            isPrimitive(const char*  primitiveName)                const;
 
+  void            setUnresolvedFunction(const char* name);
+
   FnSymbol*       isResolved()                                           const;
   FnSymbol*       resolvedFunction()                                     const;
+  void            setResolvedFunction(FnSymbol* fn);
 
   FnSymbol*       theFnSymbol()                                          const;
 
@@ -269,7 +272,6 @@ public:
   int             numActuals()                                           const;
   Expr*           get(int index)                                         const;
   FnSymbol*       findFnSymbol();
-
 
 private:
   GenRet          codegenPrimitive();

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -574,6 +574,10 @@ bool isArrayClass(Type* type);
 bool isString(Type* type);
 bool isUserDefinedRecord(Type* type);
 
+bool isPrimitiveScalar(Type* type);
+bool isNonGenericClass(Type* type);
+bool isNonGenericRecordWithInitializers(Type* type);
+
 void registerTypeToStructurallyCodegen(TypeSymbol* type);
 GenRet genTypeStructureIndex(TypeSymbol* typesym);
 void codegenTypeStructures(FILE* hdrfile);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -103,10 +103,6 @@ static void init_noinit_var(VarSymbol* var,
 
 static bool moduleHonorsNoinit(Symbol* var, Expr* init);
 
-static bool isPrimitiveScalar(Type* type);
-static bool isNonGenericClass(Type* type);
-static bool isNonGenericRecordWithInitializers(Type* type);
-
 static void updateVariableAutoDestroy(DefExpr* defExpr);
 
 static void clone_for_parameterized_primitive_formals(FnSymbol* fn,
@@ -1889,73 +1885,6 @@ static void normVarNoinit(DefExpr* defExpr) {
     // Ignore no-init expression and fall back on default init
     normVarTypeWoutInit(defExpr);
   }
-}
-
-/************************************* | **************************************
-*                                                                             *
-*                                                                             *
-*                                                                             *
-************************************** | *************************************/
-
-static bool isPrimitiveScalar(Type* type) {
-  bool retval = false;
-
-  if (type == dtBools[BOOL_SIZE_8]         ||
-      type == dtBools[BOOL_SIZE_16]        ||
-      type == dtBools[BOOL_SIZE_32]        ||
-      type == dtBools[BOOL_SIZE_64]        ||
-
-      type == dtInt[INT_SIZE_8]            ||
-      type == dtInt[INT_SIZE_16]           ||
-      type == dtInt[INT_SIZE_32]           ||
-      type == dtInt[INT_SIZE_64]           ||
-
-      type == dtUInt[INT_SIZE_8]           ||
-      type == dtUInt[INT_SIZE_16]          ||
-      type == dtUInt[INT_SIZE_32]          ||
-      type == dtUInt[INT_SIZE_64]          ||
-
-      type == dtReal[FLOAT_SIZE_32]        ||
-      type == dtReal[FLOAT_SIZE_64]        ||
-
-      type == dtImag[FLOAT_SIZE_32]        ||
-      type == dtImag[FLOAT_SIZE_64]) {
-
-    retval = true;
-
-  } else {
-    retval = false;
-  }
-
-  return retval;
-}
-
-static bool isNonGenericClass(Type* type) {
-  bool retval = false;
-
-  if (AggregateType* at = toAggregateType(type)) {
-    if (at->isGeneric()                  == false &&
-        at->isClass()                    ==  true &&
-        at->symbol->hasFlag(FLAG_EXTERN) == false) {
-      retval = true;
-    }
-  }
-
-  return retval;
-}
-
-static bool isNonGenericRecordWithInitializers(Type* type) {
-  bool retval = false;
-
-  if (AggregateType* at = toAggregateType(type)) {
-    if (at->isGeneric()      == false &&
-        at->isRecord()       == true  &&
-        at->initializerStyle == DEFINES_INITIALIZER) {
-      retval = true;
-    }
-  }
-
-  return retval;
 }
 
 /************************************* | **************************************

--- a/test/classes/initializers/records/checking-copies-bad.future
+++ b/test/classes/initializers/records/checking-copies-bad.future
@@ -1,0 +1,4 @@
+feature request: Generate a helpful error message
+
+The program requires a copy-initializer but generates an ugly
+resolution error.

--- a/test/classes/initializers/records/checking-moves.future
+++ b/test/classes/initializers/records/checking-moves.future
@@ -1,0 +1,4 @@
+feature request: Generate a helpful error message
+
+The program requires a copy-initializer but generates an ugly
+resolution error.

--- a/test/classes/initializers/records/record-no-copy-init-error.future
+++ b/test/classes/initializers/records/record-no-copy-init-error.future
@@ -1,0 +1,4 @@
+feature request: Generate a helpful error message
+
+The program requires a copy-initializer but generates an ugly
+resolution error.

--- a/test/classes/initializers/records/record-no-copy-init.future
+++ b/test/classes/initializers/records/record-no-copy-init.future
@@ -1,0 +1,4 @@
+feature request: Generate a helpful error message
+
+The program requires a copy-initializer but generates an ugly
+resolution error.


### PR DESCRIPTION
This is an incremental update to support the declaration of record variables that rely
on copy initializers e.g. the declaration of y in the following program fragment.

var x = new MyRec(1, 2);
var y = x;

This simple PR exports a few utility functions that were static in normalize.cpp to be extern
in type.cpp and then extends the implementation of resolveInitVar.  4 initializer tests have
been futurized for a day or two.

Compiled with/without CHPL_DEVELOPER on clang and gcc. 
Paratested for single-locale and gasnet on linux64.
