### PR TITLE
Add missing chapel allocator for qthreads 1.12

### DIFF
--- a/third-party/qthread/qthread-src/src/Makefile.am
+++ b/third-party/qthread/qthread-src/src/Makefile.am
@@ -35,7 +35,7 @@ libqthread_la_SOURCES = \
 	touch.c \
 	teams.c
 
-EXTRA_DIST = 
+EXTRA_DIST = alloc/
 
 if COMPILE_LF_HASH
 libqthread_la_SOURCES += lf_hashmap.c

--- a/third-party/qthread/qthread-src/src/Makefile.in
+++ b/third-party/qthread/qthread-src/src/Makefile.in
@@ -597,7 +597,7 @@ libqthread_la_SOURCES = cacheline.c envariables.c feb.c hazardptrs.c \
 	syscalls/user_defined.c syscalls/usleep.c syscalls/wait4.c \
 	syscalls/write.c $(am__append_11) $(am__append_12) \
 	$(am__append_13)
-EXTRA_DIST = ds/dictionary/dictionary_shavit.c \
+EXTRA_DIST = alloc/ ds/dictionary/dictionary_shavit.c \
 	ds/dictionary/dictionary_trie.c \
 	ds/dictionary/dictionary_simple.c \
 	threadqueues/distrib_threadqueues.c \

--- a/third-party/qthread/qthread-src/src/alloc/chapel.c
+++ b/third-party/qthread/qthread-src/src/alloc/chapel.c
@@ -1,0 +1,49 @@
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <stdlib.h>
+#ifdef HAVE_GETPAGESIZE
+# include <unistd.h>
+#else
+static QINLINE int getpagesize()
+{
+  return 4096;
+}
+#endif
+
+#include "chpl-mem-impl.h"
+
+void *qt_malloc(size_t size){
+  return chpl_malloc(size);
+}
+
+void qt_free(void *ptr){
+  chpl_free(ptr);
+}
+
+void *qt_calloc(size_t nmemb, size_t size) {
+  return chpl_calloc(nmemb, size);
+}
+
+void *qt_realloc(void *ptr, size_t size) {
+  return chpl_realloc(ptr, size);
+}
+
+/* local constants */
+size_t _pagesize = 0;
+
+void qt_internal_alignment_init(void) {
+  _pagesize = getpagesize();
+}
+
+void *qt_internal_aligned_alloc(size_t        alloc_size,
+                                     uint_fast16_t alignment) {
+    return chpl_memalign(alignment, alloc_size);
+}
+
+void qt_internal_aligned_free(void         *ptr,
+                                   uint_fast16_t alignment) {
+    chpl_free(ptr);
+}


### PR DESCRIPTION
The original qthreads 1.12 release was missing the chapel allocator. Bring in
the updated 1.12 release.