### PR TITLE
Minor update for non-generic class/record initializers

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1906,6 +1906,19 @@ bool isNonGenericClass(Type* type) {
   return retval;
 }
 
+bool isNonGenericClassWithInitializers(Type* type) {
+  bool retval = false;
+
+  if (AggregateType* at = toAggregateType(type)) {
+    if (at->isGeneric()      == false &&
+        at->isClass()        == true  &&
+        at->initializerStyle == DEFINES_INITIALIZER) {
+      retval = true;
+    }
+  }
+
+  return retval;
+}
 bool isNonGenericRecordWithInitializers(Type* type) {
   bool retval = false;
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -576,6 +576,8 @@ bool isUserDefinedRecord(Type* type);
 
 bool isPrimitiveScalar(Type* type);
 bool isNonGenericClass(Type* type);
+
+bool isNonGenericClassWithInitializers (Type* type);
 bool isNonGenericRecordWithInitializers(Type* type);
 
 void registerTypeToStructurallyCodegen(TypeSymbol* type);

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1047,6 +1047,14 @@ static void build_record_copy_function(AggregateType* ct) {
     return;
   }
 
+  if (isNonGenericClassWithInitializers(ct)  == true) {
+    return;
+  }
+
+  if (isNonGenericRecordWithInitializers(ct) == true) {
+    return;
+  }
+
   // if there is a copy-initializer for this record type, use that.
   const char* copyCtorName         = astr("_construct_", ct->symbol->name);
   bool        foundUserDefinedCopy = false;
@@ -1234,9 +1242,15 @@ static void buildRecordQuery(AggregateType* ct,
                              PrimitiveTag   tag);
 
 static void buildDefaultOfFunction(AggregateType* ct) {
-  if (function_exists("_defaultOf", 1, ct)     == NULL  &&
-      ct->symbol->hasFlag(FLAG_ITERATOR_CLASS) == false &&
-      ct->defaultValue                         != gNil) {
+  if        (isNonGenericClassWithInitializers(ct)  == true) {
+
+
+  } else if (isNonGenericRecordWithInitializers(ct) == true) {
+
+
+  } else if (function_exists("_defaultOf", 1, ct)     == NULL  &&
+             ct->symbol->hasFlag(FLAG_ITERATOR_CLASS) == false &&
+             ct->defaultValue                         != gNil) {
 
     FnSymbol*  fn  = new FnSymbol("_defaultOf");
     ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", ct);

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1041,17 +1041,17 @@ static void build_union_assignment_function(AggregateType* ct) {
   normalize(fn);
 }
 
-
 static void build_record_copy_function(AggregateType* ct) {
   if (function_exists("chpl__initCopy", 1, ct) != NULL) {
     return;
   }
 
-  if (isNonGenericClassWithInitializers(ct)  == true) {
-    return;
-  }
+  if (isNonGenericClassWithInitializers(ct)  == true ||
+      isNonGenericRecordWithInitializers(ct) == true) {
+    if (function_exists("init", 3, dtMethodToken, ct, ct) != NULL) {
+      ct->symbol->addFlag(FLAG_NOT_POD);
+    }
 
-  if (isNonGenericRecordWithInitializers(ct) == true) {
     return;
   }
 

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -100,13 +100,9 @@ void handleInitializerRules(FnSymbol* fn, AggregateType* ct) {
 
     // Insert phase 2 analysis here
 
-    if (isClass(ct) == false) {
-      fn->insertAtTail(new CallExpr(PRIM_RETURN, new SymExpr(fn->_this)));
-    } else {
-      Symbol* voidType = dtVoid->symbol;
+    Symbol* voidType = dtVoid->symbol;
 
-      fn->retExprType = new BlockStmt(new SymExpr(voidType), BLOCK_SCOPELESS);
-    }
+    fn->retExprType = new BlockStmt(new SymExpr(voidType), BLOCK_SCOPELESS);
   }
 }
 


### PR DESCRIPTION
Record initializers finally have void return type; classes with initializers have been
like this for a little while.

This proved to be the right time to disable compiler generated versions of
_defaultOf() and chpl__initCopy() for non-generic record/class with initializers.
These were relying , indirectly, on the version of record init that returned a value.

This change is limited to these types.
