### PR TITLE
Fix type error in ChapelRange

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1104,7 +1104,8 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
   
     if this.stride != other.stride && this.stride != -other.stride {
   
-      (g, x) = chpl__extendedEuclid(st1, st2);
+      const (tg, tx) = chpl__extendedEuclid(st1, st2);
+      (g, x) = (tg.safeCast(strType), tx.safeCast(strType));
       lcm = st1 / g * st2;        // The LCM of the two strides.
     // The division must be done first to prevent overflow.
   

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -2170,7 +2170,9 @@ module DefaultRectangular {
             const blkLen = if arr.mdParDim == arr.rank
                            then 1
                            else arr.blk(arr.mdParDim) / arr.blk(arr.mdParDim+1);
-            const len = dom.dsiDim(arr.mdParDim)[arr.mData(chunk).pdr].length * blkLen;
+            const outer = dom.dsiDim(arr.mdParDim);
+            const inner = arr.mData(chunk).pdr;
+            const len = outer[inner].length * blkLen;
             const size = len:ssize_t*elemSize:ssize_t;
             if f.writing {
               f.writeBytes(_ddata_shift(arr.eltType, src, idx), size);


### PR DESCRIPTION
For some reason the binary IO optimization for DefaultRectangular exposed an issue with a type conflict due to ``chpl__extendedEuclid`` returning ``int(32)`` into an ``int(8)``. The strided type can be a variety of integer widths, so for now safeCast to ``strType`` to avoid the compile-time error.

Testing:
- [x] full numa
- [x] full local