### PR TITLE
Add sub_test filtering for Jira 274

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -2066,6 +2066,12 @@ for testname in testsrc:
                                     DiffBinaryFiles(execgoodfile, execlog)
                                     break
 
+                            err_strings = ['Master got an xSocket: error in sendAll']
+                            for s in err_strings:
+                                if re.search(s, output, re.IGNORECASE) != None:
+                                    extra_msg = '(possible JIRA 274) '
+                                    break
+
                             sys.stdout.write('%s[Error %s'%(futuretest, extra_msg))
 
                         sys.stdout.write('matching program output for %s/%s'%


### PR DESCRIPTION
Jira 274 (Master got an xSocket) is a sporadic failure we see under gasnet-fast
for arrays/johnk/associative/tooFewKeys and a few other tests.

This adds sub_test filtering so it's easier to pick out when this error errors.
It doesn't happen too often in nightly testing, but I'm doing a bunch of trials
for the "qthreads use chapel allocator" work, and it comes up often enough to
warrant filtering.