### PR TITLE
Init return void future

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1828,6 +1828,24 @@ bool FnSymbol::throwsError() const {
   return _throwsError;
 }
 
+bool FnSymbol::retExprDefinesNonVoid() const {
+  bool retval = true;
+
+  if (retExprType == NULL) {
+    retval = false;
+
+  } else if (retExprType->length() != 1) {
+    retval = true;
+
+  } else if (SymExpr* expr = toSymExpr(retExprType->body.get(1))) {
+    retval = expr->symbol()->type != dtVoid ? true : false;
+
+  } else {
+    retval = true;
+  }
+
+  return retval;
+}
 
 /******************************** | *********************************
 *                                                                   *

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -405,6 +405,7 @@ class TypeSymbol : public Symbol {
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *
+*                                                                             *
 ************************************** | *************************************/
 
 class FnSymbol : public Symbol {
@@ -491,7 +492,8 @@ public:
 
   void                       insertBeforeEpilogue(Expr* ast);
 
-  // insertIntoEpilogue adds an Expr before the final return, but after the epilogue label
+  // insertIntoEpilogue adds an Expr before the final return,
+  // but after the epilogue label
   void                       insertIntoEpilogue(Expr* ast);
 
   LabelSymbol*               getEpilogueLabel();
@@ -523,6 +525,8 @@ public:
   void                       throwsErrorInit();
   bool                       throwsError()                               const;
 
+  bool                       retExprDefinesNonVoid()                     const;
+
 private:
   virtual std::string        docsDirective();
 
@@ -531,10 +535,11 @@ private:
   bool                       _throwsError;
 };
 
-/******************************** | *********************************
-*                                                                   *
-*                                                                   *
-********************************* | ********************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 class EnumSymbol : public Symbol {
  public:

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -35,7 +35,7 @@ enum InitBody {
   FOUND_BOTH
 };
 
-
+static bool     isReturnVoid(FnSymbol* fn);
 static InitBody getInitCall(FnSymbol* fn);
 static void     phase1Analysis(BlockStmt* body, AggregateType* t);
 
@@ -48,6 +48,9 @@ static void     phase1Analysis(BlockStmt* body, AggregateType* t);
 void handleInitializerRules(FnSymbol* fn, AggregateType* ct) {
   if (fn->hasFlag(FLAG_NO_PARENS)) {
     USR_FATAL(fn, "an initializer cannot be declared without parentheses");
+
+  } else if (isReturnVoid(fn) == false) {
+
   } else {
     InitBody bodyStyle = getInitCall(fn);
 
@@ -601,6 +604,45 @@ bool loopAnalysis(BlockStmt* loop, DefExpr* curField, bool* seenField,
   // encountered
 
   return false;
+}
+
+/************************************* | **************************************
+*                                                                             *
+* Initializers cannot                                                         *
+*                                                                             *
+*   1) Declare a return type other than void                                  *
+*                                                                             *
+*   2) Contain a return expression with a value                               *
+*                                                                             *
+************************************** | *************************************/
+
+static bool isReturnVoid(FnSymbol* fn) {
+  bool retval = true;
+
+  if (fn->retExprDefinesNonVoid() == true) {
+    USR_FATAL(fn, "initializers cannot declare a return type");
+    retval = false;
+
+  } else {
+    std::vector<CallExpr*> calls;
+
+    collectCallExprs(fn->body, calls);
+
+    for (size_t i = 0; i < calls.size() && retval == true; i++) {
+      if (calls[i]->isPrimitive(PRIM_RETURN) == true) {
+        SymExpr* value = toSymExpr(calls[i]->get(1));
+
+        if (value == NULL || value->symbol()->type != dtVoid) {
+          USR_FATAL(calls[i], "initializers cannot return a value");
+          retval = false;
+        }
+      }
+    }
+  }
+
+  fn->retType = dtVoid;
+
+  return retval;
 }
 
 /************************************* | **************************************

--- a/test/classes/initializers/error-initializer-return-type.chpl
+++ b/test/classes/initializers/error-initializer-return-type.chpl
@@ -1,4 +1,9 @@
 // Modified from
 // test/classes/constructors/error-constructor-return-type.chpl
-class C{}
-proc C.init():C {}
+
+class C {
+}
+
+proc C.init() : C {
+
+}

--- a/test/classes/initializers/error-initializer-return-type.future
+++ b/test/classes/initializers/error-initializer-return-type.future
@@ -1,6 +1,0 @@
-bug: Fails to report an error that an init method is returning a value
-
-Currently the implementation of init methods return a value and the error
-does not get generated.  Work is underway to make the implementation match
-the specification.  Unclear if the error message will be acceptable once
-that happens.

--- a/test/classes/initializers/error-initializer-return-type.good
+++ b/test/classes/initializers/error-initializer-return-type.good
@@ -1,1 +1,1 @@
-error-initializer-return-type.chpl:4: error: initializers may not declare a return type
+error-initializer-return-type.chpl:7: error: initializers cannot declare a return type

--- a/test/classes/initializers/noReturnInInit.future
+++ b/test/classes/initializers/noReturnInInit.future
@@ -1,6 +1,0 @@
-bug: returns should not be allowed in inits (right?)
-
-This test shows that while you can return from within an init(), we
-probably shouldn't allow it.  The error messages in the .good are just
-a proposed placeholder.  I'm open to other wordings and only printing
-out the first such occurrence if the developer has other ideas.

--- a/test/classes/initializers/noReturnInInit.good
+++ b/test/classes/initializers/noReturnInInit.good
@@ -1,2 +1,2 @@
-noReturnInInit.chpl:84: error: 'return' not permitted from 'init' routines
-noReturnInInit.chpl:86: error: 'return' not permitted from 'init' routines
+noReturnInInit.chpl:82: In initializer:
+noReturnInInit.chpl:84: error: initializers cannot return a value


### PR DESCRIPTION
In a recent PR I completed the work so that record/class initializers implement void return.

This PR adds 2 minor changes so that a user-facing message is generated if a developer
writes an initializer that attempts to return a value and then retires two futures associated
with this feature.

Compiled with/without CHPL_DEVELOPER on clang and gcc.
Paratested for single-locale linux64 and -futures.
