### PR TITLE
Copy initializer futures

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5065,7 +5065,8 @@ static bool hasCopyConstructor(AggregateType* ct) {
       ArgSymbol* _this  = fn->getFormal(2);
       ArgSymbol* _other = fn->getFormal(3);
 
-      if (_this->type == ct && _other->type == ct) {
+      if ((_this->type == ct || _this->type == ct->refType) &&
+          _other->type == ct) {
         retval = true;
         break;
       }

--- a/test/classes/initializers/records/checking-copies-bad.future
+++ b/test/classes/initializers/records/checking-copies-bad.future
@@ -1,4 +1,0 @@
-feature request: Generate a helpful error message
-
-The program requires a copy-initializer but generates an ugly
-resolution error.

--- a/test/classes/initializers/records/checking-copies-bad.good
+++ b/test/classes/initializers/records/checking-copies-bad.good
@@ -1,2 +1,2 @@
 checking-copies-bad.chpl:13: In function 'main':
-checking-copies-bad.chpl:15: error: copy-initialization invoked for a type that does not have a copy initializer
+checking-copies-bad.chpl:15: error: No copy constructor for initializer

--- a/test/classes/initializers/records/checking-moves.future
+++ b/test/classes/initializers/records/checking-moves.future
@@ -1,4 +1,0 @@
-feature request: Generate a helpful error message
-
-The program requires a copy-initializer but generates an ugly
-resolution error.

--- a/test/classes/initializers/records/checking-moves.good
+++ b/test/classes/initializers/records/checking-moves.good
@@ -1,1 +1,2 @@
-(x = 15, y = true)
+checking-moves.chpl:19: In function 'main':
+checking-moves.chpl:20: error: No copy constructor for initializer


### PR DESCRIPTION
This is a trivial PR to improve the user-facing message that is generated when a
variable declaration requires a copy-initializer but one has not been provided.
This tests for the presence of a copy-initializer during resolution rather than 
generting an ugly resolution failure.

Compiled on clang/gcc
Paratested
