### PR TITLE
Fix qthreads --with-alloc=chapel for CHPL_MEM=cstdlib

### DIFF
--- a/third-party/qthread/qthread-src/src/alloc/chapel.c
+++ b/third-party/qthread/qthread-src/src/alloc/chapel.c
@@ -13,6 +13,8 @@ static QINLINE int getpagesize()
 }
 #endif
 
+#include <qthread/qthread-int.h> /* for uint_fast16_t */
+
 #include "chpl-mem-impl.h"
 
 void *qt_malloc(size_t size){

--- a/third-party/qthread/qthread-src/src/qthread.c
+++ b/third-party/qthread/qthread-src/src/qthread.c
@@ -1881,7 +1881,7 @@ unsigned API_FUNC qthread_size_tasklocal(void)
     return f->rdata->tasklocal_size ? f->rdata->tasklocal_size : qlib->qthread_tasklocal_size;
 } /*}}}*/
 
-void* API_FUNC qthread_tos(void)
+API_FUNC void* qthread_tos(void)
 {
     const qthread_t *f = qthread_internal_self();
 
@@ -1889,7 +1889,7 @@ void* API_FUNC qthread_tos(void)
 }
 
 
-void* API_FUNC qthread_bos(void)
+API_FUNC void* qthread_bos(void)
 {
     const qthread_t *f = qthread_internal_self();
 


### PR DESCRIPTION
uint_fast16_t was undefined under cstdlib, so bring in qthread-int.h.

Also quiet a visibility attribute warning.

I've opened a PR with these changes upstream, so hopefully we can get these in
an official 1.12 release soon: https://github.com/Qthreads/qthreads/pull/51