### PR TITLE
Make p2p-serial-fast more serial

### DIFF
--- a/test/studies/prk/synch_p2p/p2p-serial-fast.chpl
+++ b/test/studies/prk/synch_p2p/p2p-serial-fast.chpl
@@ -31,7 +31,7 @@ const mrange = 0 .. # m,
       outerDom = {mrange, nrange},
       innerDom = outerDom(1.., 1..);
 
-var vector : [outerDom] real = 0.0;
+var vector : [outerDom] real;
 
 //
 // Print information before main loop
@@ -44,8 +44,8 @@ if (!validate) {
 }
 
 // Set boundary values (top and left side of grid)
-[j in nrange] vector[0,j] = j;
-[i in mrange] vector[i,0] = i;
+for j in nrange do vector[0,j] = j;
+for i in mrange do vector[i,0] = i;
 
 //
 // Main loop


### PR DESCRIPTION
p2p-serial-fast claims to be serial, but it used forall expressions and
promoted array assignment.

This removes the promoted array assignment (and just uses the default values)
and converts the forall expressions in to for-loops.

Context for this change: p2p-serial-fast was one of the benchmarks hurt by
improving qthreads task creation time (by spin-waiting longer before doing a
condwait.) Having idle workers spinwait instead of going to sleep can hurt the
performance of short-lived serial applications like p2p-serial-fast. I was
experimenting with having workers only spinwait after at least one task has
been added to their queue. It turned out to not help p2p-serial because there
were parallel constructs coming from promotion and forall expressions.

With this change in place, only spin-waiting once a task has been spawned
restores the old p2p-serial performance. Note that for longer running
applications the default spincount doesn't really matter, it only impacts short
running applications.