### PR TITLE
Increase QT_SPINCOUNT when running on a Cray

### DIFF
--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -685,6 +685,13 @@ static void setupWorkStealing(void) {
     chpl_qt_setenv("STEAL_RATIO", "0", 0);
 }
 
+static void setupSpinWaiting(void) {
+  const char *crayPlatform = "cray-x";
+  if (strncmp(crayPlatform, CHPL_TARGET_PLATFORM, strlen(crayPlatform)) == 0) {
+    chpl_qt_setenv("SPINCOUNT", "3000000", 0);
+  }
+}
+
 void chpl_task_init(void)
 {
     int32_t   commMaxThreads;
@@ -703,6 +710,7 @@ void chpl_task_init(void)
     setupCallStacks(hwpar);
     setupTasklocalStorage();
     setupWorkStealing();
+    setupSpinWaiting();
 
     if (verbosity >= 2) { chpl_qt_setenv("INFO", "1", 0); }
 


### PR DESCRIPTION
If you're using a Cray it's likely that your application is going to be pretty
parallel. This increases the amount of spinning we do on crays before putting a
worker to sleep.

With this ugni-qthreads should now beat ugni-muxed for all remaining benchmarks:
 - fft gets ~.090 GFlops (50% faster than ugni-muxed)
 - hpl-release gets .0028 GFlops (15% faster than ugni-muxed)
