### PR TITLE
Update to the latest version of qthreads 1.12

### DIFF
--- a/third-party/qthread/qthread-src/Makefile.in
+++ b/third-party/qthread/qthread-src/Makefile.in
@@ -206,7 +206,8 @@ am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/config/compile \
 	$(top_srcdir)/config/install-sh $(top_srcdir)/config/ltmain.sh \
 	$(top_srcdir)/config/missing AUTHORS COPYING INSTALL NEWS TODO \
 	config/compile config/config.guess config/config.sub \
-	config/install-sh config/ltmain.sh config/missing
+	config/depcomp config/install-sh config/ltmain.sh \
+	config/missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)

--- a/third-party/qthread/qthread-src/src/Makefile.am
+++ b/third-party/qthread/qthread-src/src/Makefile.am
@@ -35,7 +35,7 @@ libqthread_la_SOURCES = \
 	touch.c \
 	teams.c
 
-EXTRA_DIST = alloc/
+EXTRA_DIST = 
 
 if COMPILE_LF_HASH
 libqthread_la_SOURCES += lf_hashmap.c
@@ -106,6 +106,8 @@ EXTRA_DIST += \
 			 barrier/array.c \
 			 barrier/log.c \
 			 barrier/sinc.c \
+			 alloc/base.c \
+			 alloc/chapel.c \
 			 affinity/common.c \
 			 affinity/hwloc.c \
 			 affinity/binders.c \

--- a/third-party/qthread/qthread-src/src/Makefile.in
+++ b/third-party/qthread/qthread-src/src/Makefile.in
@@ -597,7 +597,7 @@ libqthread_la_SOURCES = cacheline.c envariables.c feb.c hazardptrs.c \
 	syscalls/user_defined.c syscalls/usleep.c syscalls/wait4.c \
 	syscalls/write.c $(am__append_11) $(am__append_12) \
 	$(am__append_13)
-EXTRA_DIST = alloc/ ds/dictionary/dictionary_shavit.c \
+EXTRA_DIST = ds/dictionary/dictionary_shavit.c \
 	ds/dictionary/dictionary_trie.c \
 	ds/dictionary/dictionary_simple.c \
 	threadqueues/distrib_threadqueues.c \
@@ -608,11 +608,12 @@ EXTRA_DIST = alloc/ ds/dictionary/dictionary_shavit.c \
 	threadqueues/sherwood_threadqueues.c \
 	threadqueues/nottingham_threadqueues.c sincs/donecount.c \
 	sincs/donecount_cas.c sincs/original.c barrier/feb.c \
-	barrier/array.c barrier/log.c barrier/sinc.c affinity/common.c \
-	affinity/hwloc.c affinity/binders.c affinity/hwloc_v2.c \
-	affinity/sys.c affinity/libnuma.c affinity/libnumaV2.c \
-	affinity/mach.c affinity/tilera.c affinity/plpa.c \
-	affinity/lgrp.c affinity/shepcomp.h
+	barrier/array.c barrier/log.c barrier/sinc.c alloc/base.c \
+	alloc/chapel.c affinity/common.c affinity/hwloc.c \
+	affinity/binders.c affinity/hwloc_v2.c affinity/sys.c \
+	affinity/libnuma.c affinity/libnumaV2.c affinity/mach.c \
+	affinity/tilera.c affinity/plpa.c affinity/lgrp.c \
+	affinity/shepcomp.h
 
 # version-info fields are:
 # 1. the current interface revision number (i.e. whenever arguments of existing


### PR DESCRIPTION
There were a few issues with the initial qthreads 1.12 releases. I think those
have all been fixed now, so bring in the latest official 1.12 release.

This effectively brings in #5643, but in an official qthreads release.