### PR TITLE
Remove DR array standalone iterator for !defRectSimpleDData

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -183,7 +183,7 @@ module DefaultRectangular {
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity,
                offset=createTuple(rank, idxType, 0:idxType))
-      where tag == iterKind.standalone && !localeModelHasSublocales {
+      where tag == iterKind.standalone && defRectSimpleDData {
       if chpl__testParFlag then
         chpl__testPar("default rectangular domain standalone invoked on ", ranges);
       if debugDefaultDist then
@@ -1390,20 +1390,6 @@ module DefaultRectangular {
       else {
         for i in dom do
           yield dsiAccess(i);
-      }
-    }
-
-    iter these(param tag: iterKind,
-               tasksPerLocale = dataParTasksPerLocale,
-               ignoreRunning = dataParIgnoreRunningTasks,
-               minIndicesPerTask = dataParMinGranularity)
-      ref where tag == iterKind.standalone && !defRectSimpleDData {
-      if debugDefaultDist {
-        chpl_debug_writeln("*** In defRectArr multi-dd standalone iterator");
-      }
-      for i in dom.these(tag, tasksPerLocale,
-                         ignoreRunning, minIndicesPerTask) {
-        yield dsiAccess(i);
       }
     }
 


### PR DESCRIPTION
Before this change we had DefaultRectangularArr standalone iterator
applicable when !defRectSimpleDData, which redirected to the
DefaultRectangularDom standalone iterator. However the latter
has a where clause restricting it to defRectSimpleDData==true.
So the former failed to compile and the leader/follower iterator
was silently chosen instead.

This PR removes the array standalone for !defRectSimpleDData.
Once we write the domain standalone for !defRectSimpleDData,
we can put the array standalone back in, or perhaps just remove
the defRectSimpleDData==true restriction on the existing one.

The goal of treating the !defRectSimpleDData case separately is to
avoid the multi-ddata overhead from being seen in the single-ddata
case (flat locale model).

While there, I changed the where clause on the domain standalone
iterator from !localeModelHasSublocales to defRectSimpleDData.
These are identical, however the former is consistent with
the other uses throughout the file.

This change does not affect any behavior at the moment and
I am not adding any tests for it. It will affect behavior and be tested
by the upcoming ForallStmt PR.

