### PR TITLE
Correct a record init bug

### DIFF
--- a/test/classes/initializers/records/checking-moves.good
+++ b/test/classes/initializers/records/checking-moves.good
@@ -1,2 +1,1 @@
-checking-moves.chpl:19: In function 'main':
-checking-moves.chpl:20: error: No copy constructor for initializer
+(x = 15, y = true)


### PR DESCRIPTION
Fix a simple bug that caused copy-initializers to be executed when they should not be.  If the
user defined a copy-initializer the program would execute but leak.  If the user did not define
a copy-initializer then the compiler would incorrectly claim that one was needed.

1. Tweak resolveInitVar() so that

var r1 = makeMyRec();
var r2 = r1;

implements a prim-move for r1 and then a copy-initializer for r2 even though the internal AST
seems "quite similar" inside resolveInitVar(CallExpr* primCall);



2. Update the .good file for the test that was supposed to have stopped me from being
such a lunk-head.


Thanks to Lydia for, very gently, pointing out that I was a lunk-head.


This is a trivial fix.  Compiled with/without CHPL_DEVELOPER on clang/gcc.  Studied the
AST and generated C-code for checking-moves.chpl.  Tested all of test/classes/initializers
on darwin and then ran a single-locale paratest.
