### PR TITLE
Stop limiting numtrials for multi-locale MiniMD, SSCA2, and hpl.hpcc

### DIFF
--- a/test/release/examples/benchmarks/miniMD/miniMD.ml-numtrials
+++ b/test/release/examples/benchmarks/miniMD/miniMD.ml-numtrials
@@ -1,2 +1,0 @@
-# miniMd takes a long time so avoid multiple trials until it finishes faster
-1

--- a/test/release/examples/benchmarks/ssca2/SSCA2_main.ml-timeout
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_main.ml-timeout
@@ -1,2 +1,0 @@
-# size 22 occasionally takes just over the 5 minute mark for ugni+muxed
-400

--- a/test/studies/hpcc/HPL/vass/hpl.hpcc2012.ml-timeout
+++ b/test/studies/hpcc/HPL/vass/hpl.hpcc2012.ml-timeout
@@ -1,2 +1,0 @@
-# This tests currently takes just over the 5 minute mark for gn-aries.
-400


### PR DESCRIPTION
Stop limiting the number of trials for MiniMD, SSCA2, and hpl.hccc multi-locale
performance runs:

 - MiniMD is way faster than it used to be, so stop limiting to 1 trials.
 - SSCA2 no longer takes over 5 minutes for ugni+muxed, remove timeout
 - hpl.hpcc2012 is fast for gn-aries since the jemalloc switch, remove timeout