### PR TITLE
Stop limiting the number of ugni communication domains under slurm

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -366,13 +366,6 @@ typedef struct mem_map_t_struct {
 static mem_map_t* mem_map_map;
 
 //
-// See chpl_comm_desired_shared_heap() and compute_comm_dom_cnt().
-// This is a conservative estimate of the total amount of memory we
-// can register with the NIC when running under slurm.
-//
-#define MAX_MEM_REG_UNDER_SLURM  (((size_t) 240) << 30)
-
-//
 // This is the memory region for the guaranteed NIC-registered memory
 // in which remote fork descriptors, their is-free flags, and the
 // temporary bounce buffers live.  It saves a little bit of time not
@@ -1804,24 +1797,6 @@ static void compute_comm_dom_cnt(void)
   comm_dom_cnt++;  // count the polling task's dedicated comm domain
 
   //
-  // Note, a wrinkle: under slurm we have limited resources, and we
-  // can't register more than MAX_MEM_REG_UNDER_SLURM bytes of memory,
-  // total.  But we still insist on having at least 2 comm domains; if
-  // this causes memory registration problems we'll just report those
-  // when they happen.  See chpl_comm_desired_shared_heap() for more
-  // info.
-  //
-  if (strstr(CHPL_LAUNCHER, "slurm") != NULL) {
-    assert(registered_heap_info_set);
-    if (registered_heap_size > 0
-        && comm_dom_cnt > MAX_MEM_REG_UNDER_SLURM / registered_heap_size) {
-      comm_dom_cnt = MAX_MEM_REG_UNDER_SLURM / registered_heap_size;
-      if (comm_dom_cnt < 2)
-        comm_dom_cnt = 2;
-    }
-  }
-
-  //
   // For now, limit us to 30 communication domains.  (The Gemini NIC
   // only supports up to 32 anyway.  Aries supports 128, but it isn't
   // clear that we can make use of more than about 30.)
@@ -2459,16 +2434,9 @@ static void make_shared_heap(void)
       //
       // The user didn't specify a size.  Start with 2/3 of the free
       // RAM quantity from sysinfo(2), but not more than can be
-      // mapped by the NIC.  Except: under slurm, which limits NIC
-      // resources in order to allow for node sharing, start with
-      // the lesser of 2/3 of the free RAM quantity and 16 gb.
-      //
-      // (The slurm limit is effectively on the total registered
-      // memory, and should be no less than MAX_MEM_REG_UNDER_SLURM.
-      // We will register our heap in each of several uGNI comm
-      // domains, so we default to a smaller heap to allow for
-      // enough comm domains to provide decent network concurrency.
-      // The comm domain computation is in compute_comm_dom_cnt().)
+      // mapped by the NIC.  Except: under slurm, which we limit to
+      // 16GB for historical reasons (slurm's node sharing used to
+      // place static limits on NIC resources)
       //
       struct sysinfo s;
 


### PR DESCRIPTION
When "native" slurm was first added, we couldn't get exclusive access to all
the network resources, so we had to limit how much memory we registered with
the NIC. This is no longer an issue, so we don't have to limit the number of
communication domains under slurm.

Note that we're still limiting the default heap size under slurm to 16GB
instead of 2/3 available memory. This could be changed too, but the smaller
size seems to be working for us, and it improves startup time. This is
something to revisit at another time.

Increasing the number of communication domains results in some pretty dramatic
performance improvements for some latency bound benchmarks. I'm seeing a 25%
speedup for SSCA, 50% speedup for Lulesh, and a 75% improvement for RA:

| Benchmark | Old Perf     | New Perf     |
| --------- | ------------ | ------------ |
| SSCA#2    | 111 sec      | 85 sec       |
| Lulesh    | 4.7 sec      | 3.3 sec      |
| RA-atomic | .075 GUPS    | .12 GUPS     |
| RA-rmo    | .040 GUPS    | .075 GUPS    |