### PR TITLE
Accept libhugetlbfs page size setting; compute heap page size as and when needed.

### DIFF
--- a/runtime/include/chplsys.h
+++ b/runtime/include/chplsys.h
@@ -26,7 +26,6 @@
 
 size_t chpl_getSysPageSize(void);
 size_t chpl_getHeapPageSize(void); // note: only works after mem layer inited
-void chpl_computeHeapPageSize(void);
 uint64_t chpl_bytesPerLocale(void);
 size_t chpl_bytesAvailOnThisLocale(void);
 int chpl_getNumPhysicalCpus(chpl_bool accessible_only);

--- a/runtime/src/chpl-mem.c
+++ b/runtime/src/chpl-mem.c
@@ -32,11 +32,6 @@ static int heapInitialized = 0;
 void chpl_mem_init(void) {
   chpl_mem_layerInit();
   heapInitialized = 1;
-
-  // compute desired shared heap page size
-  // after this point, chpl_getHeapPageSize() will return
-  // a shared heap page size instead of 0.
-  chpl_computeHeapPageSize();
 }
 
 

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -349,19 +349,12 @@ size_t chpl_getHeapPageSize(void) {
     if (pthread_once(&onceCtl, computeHeapPageSize) != 0) {
       chpl_internal_error("pthread_once() failed");
     }
-  }
-#elif defined __CYGWIN__
-  return chpl_getSysPageSize();
-#else
-  //
-  // Note: no single-threaded initialization for non-POSIX OS.
-  //
-  if (heapPageSize == 0) {
-    computeHeapPageSize();
-  }
-#endif
 
-  return heapPageSize;
+    return heapPageSize;
+  }
+#else
+  return chpl_getSysPageSize();
+#endif
 }
 
 

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -350,6 +350,8 @@ size_t chpl_getHeapPageSize(void) {
       chpl_internal_error("pthread_once() failed");
     }
   }
+#elif defined __CYGWIN__
+  return chpl_getSysPageSize();
 #else
   //
   // Note: no single-threaded initialization for non-POSIX OS.


### PR DESCRIPTION
There are two primary changes here.  The first is that when computing
the heap page size, if we find the HUGETLB_DEFAULT_PAGE_SIZE environment
variable set then we simply accept that as the page size, rather than
doing any more work to see if a larger size seems to work.  This saves a
bit of time on Cray X* systems but much more importantly, it avoids the
page touching needed in order to explore for larger page sizes.  That
page touching could cause undesirable NUMA localization of some of the
memory in comm layer desired shared heaps.

The second change is to compute the heap page size the first time it is
requested, rather than doing it in an explicit initialization step ahead
of time.  This relieves us needing to move the init call around to make
sure it stays ahead of the first call to get the heap size it computed
as the runtime evolves.  (This was going to be an issue with an upcoming
change to NUMA-localize comm layer desired shared heaps.)  As a side
effect of this change I reworked how we decide whether to bring in the
pthreads.h #include file.