### PR TITLE
isDefaultRectangular should return false for ArrayViews

### DIFF
--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -402,7 +402,7 @@ module ArrayViewRankChange {
     //
 
     proc shouldUseIndexCache() param {
-      return _ArrInstance.isDefaultRectangular();
+      return chpl__isDROrDRView(_ArrInstance);
     }
 
     proc buildIndexCache() {
@@ -448,8 +448,6 @@ module ArrayViewRankChange {
     inline proc dsiGetBaseDom() {
       return dom;
     }
-
-    proc isDefaultRectangular() param return arr.isDefaultRectangular();
 
     proc _getActualArray() {
       if chpl__isArrayView(arr) {

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -369,7 +369,7 @@ module ArrayViewReindex {
     //
 
     proc shouldUseIndexCache() param {
-      return _ArrInstance.isDefaultRectangular();
+      return chpl__isDROrDRView(_ArrInstance);
     }
 
     proc buildIndexCache() {
@@ -415,8 +415,6 @@ module ArrayViewReindex {
     inline proc dsiGetBaseDom() {
       return dom;
     }
-
-    proc isDefaultRectangular() param return arr.isDefaultRectangular();
 
     proc _getActualArray() {
       if chpl__isArrayView(arr) {

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -317,7 +317,7 @@ module ArrayViewSlice {
     //
 
     proc shouldUseIndexCache() param {
-      return (_ArrInstance.isDefaultRectangular() &&
+      return (chpl__isDROrDRView(_ArrInstance) &&
               _containsRCRE());
     }
 
@@ -360,8 +360,6 @@ module ArrayViewSlice {
     inline proc dsiGetBaseDom() {
       return dom;
     }
-
-    proc isDefaultRectangular() param return arr.isDefaultRectangular();
 
     proc _getActualArray() {
       if chpl__isArrayView(arr) {

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -223,13 +223,13 @@ module CPtr {
     :arg arr: the array for which we should retrieve a pointer
     :returns: a pointer to the array data
   */
-  inline proc c_ptrTo(arr: []) where isRectangularArr(arr) && !arr._value.isDefaultRectangular() {
+  inline proc c_ptrTo(arr: []) where isRectangularArr(arr) && !chpl__isDROrDRView(arr) {
     if !chpl__getActualArray(arr).oneDData then halt("error: c_ptrTo(multi_ddata array");
     return c_pointer_return(arr[arr.domain.low]);
   }
 
   pragma "no doc"
-  inline proc c_ptrTo(arr: []) where arr._value.isDefaultRectangular() {
+  inline proc c_ptrTo(arr: []) where chpl__isDROrDRView(arr) {
     const val = arr._value;
     if chpl__isArrayView(val) {
       // BHARSH TODO: there *has* to be a cleaner way to do this sort of thing...

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -656,6 +656,20 @@ module ChapelArray {
     var ret = if chpl__isArrayView(value) then value._getActualArray() else value;
     return ret;
   }
+
+  //
+  // Returns true if 'arr' is a DefaultRectangular array or is an ArrayView
+  // over a DefaultRetangular array.
+  //
+  // 'arr' can be a full-fledged array type or a class that inherits from
+  // BaseArr
+  //
+  proc chpl__isDROrDRView(arr) param {
+    const value = if isArray(arr) then arr._value else arr;
+    param isDR = value.isDefaultRectangular();
+    param isDRView = chpl__isArrayView(value) && chpl__getActualArray(value).isDefaultRectangular();
+    return isDR || isDRView;
+  }
   //
   // End of array-view utility functions
   //
@@ -3386,8 +3400,8 @@ module ChapelArray {
   }
 
   inline proc chpl__bulkTransferHelper(a, b) {
-    if a._value.isDefaultRectangular() {
-      if b._value.isDefaultRectangular() {
+    if chpl__isDROrDRView(a) {
+      if chpl__isDROrDRView(b) {
         // implemented in DefaultRectangular
         a._value.doiBulkTransferStride(b, chpl__getViewDom(a));
       }
@@ -3395,7 +3409,7 @@ module ChapelArray {
         // b's domain map must implement this
         b._value.doiBulkTransferToDR(a, chpl__getViewDom(b));
     } else {
-      if b._value.isDefaultRectangular() then
+      if chpl__isDROrDRView(b) then
         // a's domain map must implement this
         a._value.doiBulkTransferFromDR(b, chpl__getViewDom(a));
       else

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1870,7 +1870,7 @@ module DefaultRectangular {
   }
 
   iter chpl__serialViewIter(arr, viewDom) ref
-    where arr.isDefaultRectangular() && !defRectSimpleDData {
+    where chpl__isDROrDRView(arr) && !defRectSimpleDData {
     param useCache = chpl__isArrayView(arr) && arr.shouldUseIndexCache();
     var info = if useCache then arr.indexCache
                else if arr.isSliceArrayView() then arr.arr
@@ -1910,7 +1910,7 @@ module DefaultRectangular {
   }
 
   iter chpl__serialViewIter(arr, viewDom) ref
-    where arr.isDefaultRectangular() && defRectSimpleDData {
+    where chpl__isDROrDRView(arr) && defRectSimpleDData {
     param useCache = chpl__isArrayView(arr) && arr.shouldUseIndexCache();
     var info = if useCache then arr.indexCache
                else if arr.isSliceArrayView() then arr.arr


### PR DESCRIPTION
@bradcray suggested that isDefaultRectangular shouldn't be returning
true for ArrayViews. This commit makes that change and implements a
helper function, chpl__isDROrDRView, which is used in a handful of
places for specialization of functions.

Testing:
- [x] full local
- [x] full gasnet
- [x] full numa