### PR TITLE
Optimize serial iteration for ArrayViews

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1122,7 +1122,7 @@ proc BlockArr.nonLocalAccess(i: rank*idxType) ref {
       pragma "no copy" pragma "no auto destroy" var myLocRAD = myLocArr.locRAD;
       pragma "no copy" pragma "no auto destroy" var radata = myLocRAD.RAD;
       if radata(rlocIdx).shiftedDataChunk(0) != nil {
-        var dataIdx = radata(rlocIdx).getRADDataIndex(myLocArr.stridable, i);
+        var dataIdx = radata(rlocIdx).getDataIndex(i);
         return radata(rlocIdx).getDataElem(dataIdx);
       }
     }

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1164,7 +1164,7 @@ proc StencilArr.nonLocalAccess(i: rank*idxType) ref {
       pragma "no copy" pragma "no auto destroy" var myLocRAD = myLocArr.locRAD;
       pragma "no copy" pragma "no auto destroy" var radata = myLocRAD.RAD;
       if radata(rlocIdx).shiftedDataChunk(0) != nil {
-        var dataIdx = radata(rlocIdx).getRADDataIndex(myLocArr.stridable, i);
+        var dataIdx = radata(rlocIdx).getDataIndex(i);
         return radata(rlocIdx).getDataElem(dataIdx);
       }
     }

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -142,8 +142,7 @@ module ArrayViewRankChange {
     //
 
     iter these() ref {
-      const info = if shouldUseIndexCache() then this else arr;
-      for elem in chpl__serialViewIter(info, privDom) do
+      for elem in chpl__serialViewIter(this, privDom) do
         yield elem;
     }
 

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -142,14 +142,9 @@ module ArrayViewRankChange {
     //
 
     iter these() ref {
-      for i in privDom {
-        if shouldUseIndexCache() {
-          const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
-          yield indexCache.getDataElem(dataIdx);
-        } else {
-          yield arr.dsiAccess(chpl_rankChangeConvertIdx(i));
-        }
-      }
+      const info = if shouldUseIndexCache() then this else arr;
+      for elem in chpl__serialViewIter(info, privDom) do
+        yield elem;
     }
 
     // TODO: We seem to run into compile-time bugs when using multiple yields.
@@ -158,7 +153,7 @@ module ArrayViewRankChange {
       where tag == iterKind.standalone && !localeModelHasSublocales {
       for i in privDom.these(tag) {
         yield if shouldUseIndexCache()
-                then indexCache.getDataElem(indexCache.getRADDataIndex(dom.stridable, i))
+                then indexCache.getDataElem(indexCache.getDataIndex(i))
                 else arr.dsiAccess(chpl_rankChangeConvertIdx(i));
       }
     }
@@ -173,7 +168,7 @@ module ArrayViewRankChange {
       where tag == iterKind.follower {
       for i in privDom.these(tag, followThis) {
         if shouldUseIndexCache() {
-          const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+          const dataIdx = indexCache.getDataIndex(i);
           yield indexCache.getDataElem(dataIdx);
         } else {
           yield arr.dsiAccess(chpl_rankChangeConvertIdx(i));
@@ -229,7 +224,7 @@ module ArrayViewRankChange {
     inline proc dsiAccess(i) ref {
       checkBounds(i);
       if shouldUseIndexCache() {
-        const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+        const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
       } else {
         return arr.dsiAccess(chpl_rankChangeConvertIdx(i));
@@ -240,7 +235,7 @@ module ArrayViewRankChange {
       where shouldReturnRvalueByValue(eltType) {
       checkBounds(i);
       if shouldUseIndexCache() {
-        const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+        const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
       } else {
         return arr.dsiAccess(chpl_rankChangeConvertIdx(i));
@@ -251,7 +246,7 @@ module ArrayViewRankChange {
       where shouldReturnRvalueByConstRef(eltType) {
       checkBounds(i);
       if shouldUseIndexCache() {
-        const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+        const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
       } else {
         return arr.dsiAccess(chpl_rankChangeConvertIdx(i));

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -123,21 +123,16 @@ module ArrayViewReindex {
     //
 
     iter these() ref {
-      for i in privDom {
-        if shouldUseIndexCache() {
-          const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
-          yield indexCache.getDataElem(dataIdx);
-        } else {
-          yield arr.dsiAccess(chpl_reindexConvertIdx(i));
-        }
-      }
+      const info = if shouldUseIndexCache() then this else arr;
+      for elem in chpl__serialViewIter(info, privDom) do
+        yield elem;
     }
 
     iter these(param tag: iterKind) ref
       where tag == iterKind.standalone && !localeModelHasSublocales {
       for i in privDom.these(tag) {
         if shouldUseIndexCache() {
-          const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+          const dataIdx = indexCache.getDataIndex(i);
           yield indexCache.getDataElem(dataIdx);
         } else {
           yield arr.dsiAccess(chpl_reindexConvertIdx(i));
@@ -155,7 +150,7 @@ module ArrayViewReindex {
       where tag == iterKind.follower {
       for i in privDom.these(tag, followThis) {
         if shouldUseIndexCache() {
-          const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+          const dataIdx = indexCache.getDataIndex(i);
           yield indexCache.getDataElem(dataIdx);
         } else {
           yield arr.dsiAccess(chpl_reindexConvertIdx(i));
@@ -208,7 +203,7 @@ module ArrayViewReindex {
     inline proc dsiAccess(i) ref {
       checkBounds(i);
       if shouldUseIndexCache() {
-        const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+        const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
       } else {
         return arr.dsiAccess(chpl_reindexConvertIdx(i));
@@ -219,7 +214,7 @@ module ArrayViewReindex {
       where shouldReturnRvalueByValue(eltType) {
       checkBounds(i);
       if shouldUseIndexCache() {
-        const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+        const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
       } else {
         return arr.dsiAccess(chpl_reindexConvertIdx(i));
@@ -230,7 +225,7 @@ module ArrayViewReindex {
       where shouldReturnRvalueByConstRef(eltType) {
       checkBounds(i);
       if shouldUseIndexCache() {
-        const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+        const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
       } else {
         return arr.dsiAccess(chpl_reindexConvertIdx(i));

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -123,8 +123,7 @@ module ArrayViewReindex {
     //
 
     iter these() ref {
-      const info = if shouldUseIndexCache() then this else arr;
-      for elem in chpl__serialViewIter(info, privDom) do
+      for elem in chpl__serialViewIter(this, privDom) do
         yield elem;
     }
 

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -84,8 +84,9 @@ module ArrayViewSlice {
     //
 
     iter these() ref {
-      for i in privDom do
-        yield arr.dsiAccess(i);
+      const info = if shouldUseIndexCache() then this else arr;
+      for elem in chpl__serialViewIter(info, privDom) do
+        yield elem;
     }
 
     iter these(param tag: iterKind) ref
@@ -151,7 +152,7 @@ module ArrayViewSlice {
     inline proc dsiAccess(i) ref {
       checkBounds(i);
       if shouldUseIndexCache() {
-        const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+        const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
       } else {
         return arr.dsiAccess(i);
@@ -162,7 +163,7 @@ module ArrayViewSlice {
       where shouldReturnRvalueByValue(eltType) {
       checkBounds(i);
       if shouldUseIndexCache() {
-        const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+        const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
       } else {
         return arr.dsiAccess(i);
@@ -173,7 +174,7 @@ module ArrayViewSlice {
       where shouldReturnRvalueByConstRef(eltType) {
       checkBounds(i);
       if shouldUseIndexCache() {
-        const dataIdx = indexCache.getRADDataIndex(dom.stridable, i);
+        const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
       } else {
         return arr.dsiAccess(i);

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -84,8 +84,7 @@ module ArrayViewSlice {
     //
 
     iter these() ref {
-      const info = if shouldUseIndexCache() then this else arr;
-      for elem in chpl__serialViewIter(info, privDom) do
+      for elem in chpl__serialViewIter(this, privDom) do
         yield elem;
     }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1883,14 +1883,17 @@ module DefaultRectangular {
       const lo     = viewDom.dsiDim(info.mdParDim).low;
       const hi     = viewDom.dsiDim(info.mdParDim).high;
 
+      param chunkOffset = if useCache then 1 else 0;
       var (chunk, idx) = info.getDataIndex(viewDom.dsiLow);
       var dd           = info.theDataChunk(chunk);
+      chunk += chunkOffset;
       var lastChunkInd = info.mData(chunk).pdr.high;
 
       for ind in chpl_direct_pos_stride_range_iter(lo, hi, 1:viewDom.idxType) {
         if ind > lastChunkInd { // traverse to next chunk
           (chunk, idx) = info.getDataIndex(ind);
           dd           = info.theDataChunk(chunk);
+          chunk += chunkOffset;
           lastChunkInd = info.mData(chunk).pdr.high;
         }
         yield dd(idx);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1872,9 +1872,11 @@ module DefaultRectangular {
   iter chpl__serialViewIter(arr, viewDom) ref
     where arr.isDefaultRectangular() && !defRectSimpleDData {
     param useCache = chpl__isArrayView(arr) && arr.shouldUseIndexCache();
-    var info = if useCache then arr.indexCache else arr;
+    var info = if useCache then arr.indexCache
+               else if arr.isSliceArrayView() then arr.arr
+               else arr;
 
-    if arr.rank == 1 && !viewDom.stridable && useCache {
+    if arr.rank == 1 && !viewDom.stridable {
       const first  = info.getDataIndex(viewDom.dsiLow, getChunked=false);
       const second = info.getDataIndex(viewDom.dsiLow+1, getChunked=false);
       const step   = (second-first);
@@ -1907,8 +1909,10 @@ module DefaultRectangular {
   iter chpl__serialViewIter(arr, viewDom) ref
     where arr.isDefaultRectangular() && defRectSimpleDData {
     param useCache = chpl__isArrayView(arr) && arr.shouldUseIndexCache();
-    var info = if useCache then arr.indexCache else arr;
-    if arr.rank == 1 && useCache {
+    var info = if useCache then arr.indexCache
+               else if arr.isSliceArrayView() then arr.arr
+               else arr;
+    if arr.rank == 1 {
       // This is specialized to avoid overheads of calling dsiAccess()
       if !viewDom.stridable {
         // Ideally we would like to be able to do something like

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -700,6 +700,14 @@ module DefaultRectangular {
       }
     }
 
+    inline proc theDataChunk(i) ref {
+      if stridable {
+        return dataChunk(i);
+      } else {
+        return shiftedDataChunk(i);
+      }
+    }
+
     inline proc getDataElem(i) ref {
       if stridable {
         return dataElem(i);
@@ -747,15 +755,17 @@ module DefaultRectangular {
     }
   }
 
-  inline proc _remoteAccessData.getRADDataIndex(param stridable, ind : idxType) {
-    return this.getRADDataIndex(stridable, chpl__tuplify(ind));
+  inline proc _remoteAccessData.getDataIndex(ind : idxType,
+                                             param getChunked=!defRectSimpleDData) {
+    return this.getDataIndex(chpl__tuplify(ind), getChunked);
   }
 
   //
   // Copied from DefaultRectangularArr.getDataIndex
   //
-  inline proc _remoteAccessData.getRADDataIndex(param stridable, ind: rank*idxType) {
-      param chunkify = !defRectSimpleDData;
+  inline proc _remoteAccessData.getDataIndex(ind: rank*idxType,
+                                             param getChunked=!defRectSimpleDData) {
+      param chunkify = !defRectSimpleDData && getChunked;
 
       if stridable {
         inline proc chunked_dataIndex(sum, str) {
@@ -1267,44 +1277,7 @@ module DefaultRectangular {
       if debugDefaultDist {
         chpl_debug_writeln("*** In defRectArr simple-dd serial iterator");
       }
-      if rank == 1 {
-        // This is specialized to avoid overheads of calling dsiAccess()
-        if !dom.stridable {
-          // Ideally we would like to be able to do something like
-          // "for i in first..last by step". However, right now that would
-          // result in a strided iterator which isn't as optimized. It would
-          // also add a range constructor, which in tight loops is pretty
-          // expensive. Instead we use a direct range iterator that is
-          // optimized for positively strided ranges. It should be just as fast
-          // as directly using a "c for loop", but it contains code check for
-          // overflow and invalid strides as well as the ability to use a less
-          // optimized iteration method if users are concerned about range
-          // overflow.
-          const first = getDataIndex(dom.dsiLow);
-          const second = getDataIndex(dom.dsiLow+1);
-          const step = (second-first);
-          const last = first + (dom.dsiNumIndices-1) * step;
-          for i in chpl_direct_pos_stride_range_iter(first, last, step) {
-            yield theData(i);
-          }
-        } else {
-          const stride = dom.ranges(1).stride: idxType,
-                start  = dom.ranges(1).first,
-                first  = getDataIndex(start),
-                second = getDataIndex(start + stride),
-                step   = (second-first):idxSignedType,
-                last   = first + (dom.ranges(1).length-1) * step:idxType;
-          if step > 0 then
-            for i in first..last by step do
-              yield data(i);
-          else
-            for i in last..first by step do
-              yield data(i);
-        }
-      } else {
-        for i in dom do
-          yield dsiAccess(i);
-      }
+      for elem in chpl__serialViewIter(this, dom) do yield elem;
     }
 
     iter these(param tag: iterKind,
@@ -1363,34 +1336,7 @@ module DefaultRectangular {
       if debugDefaultDist {
         chpl_debug_writeln("*** In defRectArr multi-dd serial iterator");
       }
-      if rank == 1 {
-        if !dom.stridable {
-          const first = getDataIndex(dom.dsiLow, getChunked=false);
-          const second = getDataIndex(dom.dsiLow+1, getChunked=false);
-          const step = (second-first);
-          const lo = dom.dsiDim(mdParDim).low;
-          const hi = dom.dsiDim(mdParDim).high;
-          var (chunk, idx) = getDataIndex(dom.dsiLow);
-          var dd = theDataChunk(chunk);
-          var lastChunkInd = mData(chunk).pdr.high;
-          for ind in chpl_direct_pos_stride_range_iter(lo, hi, 1:idxType) {
-            if ind > lastChunkInd { // traverse to next chunk
-              (chunk, idx) = getDataIndex(ind);
-              dd = theDataChunk(chunk);
-              lastChunkInd = mData(chunk).pdr.high;
-            }
-            yield dd(idx);
-            idx += step;
-          }
-        } else {
-          for i in dom do
-            yield dsiAccess(i);
-        }
-      } // if rank == 1 ...
-      else {
-        for i in dom do
-          yield dsiAccess(i);
-      }
+      for elem in chpl__serialViewIter(this, dom) do yield elem;
     }
 
     iter these(param tag: iterKind,
@@ -1920,6 +1866,102 @@ module DefaultRectangular {
 
     iter dsiLocalSubdomains() {
       yield _newDomain(dom);
+    }
+  }
+
+  iter chpl__serialViewIter(arr, viewDom) ref
+    where arr.isDefaultRectangular() && !defRectSimpleDData {
+    param useCache = chpl__isArrayView(arr) && arr.shouldUseIndexCache();
+    var info = if useCache then arr.indexCache else arr;
+
+    if arr.rank == 1 && !viewDom.stridable {
+      const first  = info.getDataIndex(viewDom.dsiLow, getChunked=false);
+      const second = info.getDataIndex(viewDom.dsiLow+1, getChunked=false);
+      const step   = (second-first);
+      const lo     = viewDom.dsiDim(info.mdParDim).low;
+      const hi     = viewDom.dsiDim(info.mdParDim).high;
+
+      var (chunk, idx) = info.getDataIndex(viewDom.dsiLow);
+      var dd           = info.theDataChunk(chunk);
+      var lastChunkInd = info.mData(chunk).pdr.high;
+
+      for ind in chpl_direct_pos_stride_range_iter(lo, hi, 1:viewDom.idxType) {
+        if ind > lastChunkInd { // traverse to next chunk
+          (chunk, idx) = info.getDataIndex(ind);
+          dd           = info.theDataChunk(chunk);
+          lastChunkInd = info.mData(chunk).pdr.high;
+        }
+        yield dd(idx);
+        idx += step;
+      }
+    } else if useCache {
+      for i in viewDom {
+        const dataIdx = info.getDataIndex(i);
+        yield info.getDataElem(dataIdx);
+      }
+    } else {
+      for elem in chpl__serialViewIterHelper(arr, viewDom) do yield elem;
+    }
+  }
+
+  iter chpl__serialViewIter(arr, viewDom) ref
+    where arr.isDefaultRectangular() && defRectSimpleDData {
+    param useCache = chpl__isArrayView(arr) && arr.shouldUseIndexCache();
+    var info = if useCache then arr.indexCache else arr;
+    if arr.rank == 1 {
+      // This is specialized to avoid overheads of calling dsiAccess()
+      if !viewDom.stridable {
+        // Ideally we would like to be able to do something like
+        // "for i in first..last by step". However, right now that would
+        // result in a strided iterator which isn't as optimized. It would
+        // also add a range constructor, which in tight loops is pretty
+        // expensive. Instead we use a direct range iterator that is
+        // optimized for positively strided ranges. It should be just as fast
+        // as directly using a "c for loop", but it contains code check for
+        // overflow and invalid strides as well as the ability to use a less
+        // optimized iteration method if users are concerned about range
+        // overflow.
+        const first  = info.getDataIndex(viewDom.dsiLow);
+        const second = info.getDataIndex(viewDom.dsiLow+1);
+        const step   = (second-first);
+        const last   = first + (viewDom.dsiNumIndices-1) * step;
+        for i in chpl_direct_pos_stride_range_iter(first, last, step) {
+          yield info.theDataChunk(0)(i);
+        }
+      } else {
+        const stride = viewDom.ranges(1).stride: viewDom.idxType,
+              start  = viewDom.ranges(1).first,
+              first  = info.getDataIndex(start),
+              second = info.getDataIndex(start + stride),
+              step   = (second-first):chpl__signedType(viewDom.idxType),
+              last   = first + (viewDom.ranges(1).length-1) * step:viewDom.idxType;
+        if step > 0 then
+          for i in first..last by step do
+            yield info.data(i);
+        else
+          for i in last..first by step do
+            yield info.data(i);
+      }
+    } else if useCache {
+      for i in viewDom {
+        const dataIdx = info.getDataIndex(i);
+        yield info.getDataElem(dataIdx);
+      }
+    } else {
+      for elem in chpl__serialViewIterHelper(arr, viewDom) do yield elem;
+    }
+  }
+
+  iter chpl__serialViewIter(arr, viewDom) ref {
+    for elem in chpl__serialViewIterHelper(arr, viewDom) do yield elem;
+  }
+
+  iter chpl__serialViewIterHelper(arr, viewDom) ref {
+    for i in viewDom {
+      const dataIdx = if arr.isReindexArrayView() then arr.chpl_reindexConvertIdx(i)
+                      else if arr.isRankChangeArrayView() then arr.chpl_rankChangeConvertIdx(i)
+                      else i;
+      yield arr.dsiAccess(dataIdx);
     }
   }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1874,7 +1874,7 @@ module DefaultRectangular {
     param useCache = chpl__isArrayView(arr) && arr.shouldUseIndexCache();
     var info = if useCache then arr.indexCache else arr;
 
-    if arr.rank == 1 && !viewDom.stridable {
+    if arr.rank == 1 && !viewDom.stridable && useCache {
       const first  = info.getDataIndex(viewDom.dsiLow, getChunked=false);
       const second = info.getDataIndex(viewDom.dsiLow+1, getChunked=false);
       const step   = (second-first);
@@ -1908,7 +1908,7 @@ module DefaultRectangular {
     where arr.isDefaultRectangular() && defRectSimpleDData {
     param useCache = chpl__isArrayView(arr) && arr.shouldUseIndexCache();
     var info = if useCache then arr.indexCache else arr;
-    if arr.rank == 1 {
+    if arr.rank == 1 && useCache {
       // This is specialized to avoid overheads of calling dsiAccess()
       if !viewDom.stridable {
         // Ideally we would like to be able to do something like
@@ -1961,7 +1961,8 @@ module DefaultRectangular {
       const dataIdx = if arr.isReindexArrayView() then arr.chpl_reindexConvertIdx(i)
                       else if arr.isRankChangeArrayView() then arr.chpl_rankChangeConvertIdx(i)
                       else i;
-      yield arr.dsiAccess(dataIdx);
+      const info = if chpl__isArrayView(arr) then arr.arr else arr;
+      yield info.dsiAccess(dataIdx);
     }
   }
 

--- a/test/performance/ferguson/remote-array-read.good
+++ b/test/performance/ferguson/remote-array-read.good
@@ -1,4 +1,4 @@
 100000
 1
 1
-(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 100010, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)
+(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 100008, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-array-write.good
+++ b/test/performance/ferguson/remote-array-write.good
@@ -1,3 +1,3 @@
 1
 1
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 10, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 8, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-class-read.good
+++ b/test/performance/ferguson/remote-class-read.good
@@ -1,4 +1,4 @@
 15000450000
 {x = 1, y = 2, z = 3}
 {x = 100000, y = 100001, z = 100002}
-(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 600010, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)
+(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 600008, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-class-write.good
+++ b/test/performance/ferguson/remote-class-write.good
@@ -1,3 +1,3 @@
 {x = 1, y = 1, z = 1}
 {x = 1, y = 1, z = 1}
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 300010, get_nb = 0, put = 300000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 300008, get_nb = 0, put = 300000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-record-read-1.good
+++ b/test/performance/ferguson/remote-record-read-1.good
@@ -1,4 +1,4 @@
 15000450000
 (x = 1, y = 2, z = 3)
 (x = 100000, y = 100001, z = 100002)
-(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 100010, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)
+(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 100008, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-record-read.good
+++ b/test/performance/ferguson/remote-record-read.good
@@ -1,4 +1,4 @@
 15000450000
 (x = 1, y = 2, z = 3)
 (x = 100000, y = 100001, z = 100002)
-(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 300010, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)
+(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 300008, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-record-write-1.good
+++ b/test/performance/ferguson/remote-record-write-1.good
@@ -1,3 +1,3 @@
 (x = 1, y = 1, z = 1)
 (x = 1, y = 1, z = 1)
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 10, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 8, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-record-write.good
+++ b/test/performance/ferguson/remote-record-write.good
@@ -1,3 +1,3 @@
 (x = 1, y = 1, z = 1)
 (x = 1, y = 1, z = 1)
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 10, get_nb = 0, put = 300000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 8, get_nb = 0, put = 300000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-tuple-read-1.good
+++ b/test/performance/ferguson/remote-tuple-read-1.good
@@ -1,4 +1,4 @@
 50006000000
 (2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
 (100001, 100002, 100003, 100004, 100005, 100006, 100007, 100008, 100009, 100010)
-(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 100010, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)
+(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 100008, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-tuple-read-small-1.good
+++ b/test/performance/ferguson/remote-tuple-read-small-1.good
@@ -1,4 +1,4 @@
 15000750000
 (2, 3, 4)
 (100001, 100002, 100003)
-(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 100010, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)
+(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 100008, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-tuple-read-small.good
+++ b/test/performance/ferguson/remote-tuple-read-small.good
@@ -1,4 +1,4 @@
 15000750000
 (2, 3, 4)
 (100001, 100002, 100003)
-(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 300010, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)
+(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 300008, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-tuple-read.good
+++ b/test/performance/ferguson/remote-tuple-read.good
@@ -1,4 +1,4 @@
 50006000000
 (2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
 (100001, 100002, 100003, 100004, 100005, 100006, 100007, 100008, 100009, 100010)
-(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 1000010, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)
+(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 1000008, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-tuple-write-1.good
+++ b/test/performance/ferguson/remote-tuple-write-1.good
@@ -1,3 +1,3 @@
 (1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
 (1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 10, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 8, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-tuple-write-small-1.good
+++ b/test/performance/ferguson/remote-tuple-write-small-1.good
@@ -1,3 +1,3 @@
 (1, 1, 1)
 (1, 1, 1)
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 10, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 8, get_nb = 0, put = 100000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-tuple-write-small.good
+++ b/test/performance/ferguson/remote-tuple-write-small.good
@@ -1,3 +1,3 @@
 (1, 1, 1)
 (1, 1, 1)
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 10, get_nb = 0, put = 300000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 8, get_nb = 0, put = 300000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-tuple-write.good
+++ b/test/performance/ferguson/remote-tuple-write.good
@@ -1,3 +1,3 @@
 (1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
 (1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
-(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 10, get_nb = 0, put = 1000000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)
+(get = 0, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 8, get_nb = 0, put = 1000000, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 0, execute_on_fast = 0, execute_on_nb = 0)

--- a/test/performance/ferguson/remote-two-array-read.good
+++ b/test/performance/ferguson/remote-two-array-read.good
@@ -1,4 +1,4 @@
 0
 1 -1
 1 -1
-(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 200020, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)
+(get = 3, get_nb = 0, put = 2, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0) (get = 200016, get_nb = 0, put = 0, put_nb = 0, test_nb = 0, wait_nb = 0, try_nb = 0, execute_on = 1, execute_on_fast = 0, execute_on_nb = 0)


### PR DESCRIPTION
When ArrayViews were merged we were no longer able to take
advantage of an optimization for serial iteration over a multi-ddata
array. This resulted in poor performance for STREAM.

This PR implements a serial iterator, named ``chpl__serialViewIter``, that
domain map authors can overload to optimize serial iteration over
ArrayViews for their fancy array.

The DefaultRectangular overload is very similar to the old serial iterator
implemented on DefaultRectangularArr. A main difference is that it will
utilize the indexCache from an ArrayView. This is possible due to the
similarities between _remoteAccessData and DefaultRectangularArr's
fields and methods.

Testing:
- [x] full numa
- [x] full local
- [x] full gasnet-flat
- [x] full gasnet-numa