### PR TITLE
Deprecate ldA argument in BLAS module

### DIFF
--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -28,6 +28,9 @@ reference version of BLAS, this documentation refers to the
 `MKL BLAS <https://software.intel.com/en-us/node/520725>`_ documentation, due
 to quality and interface similarities.
 
+This module is intended to work with non-distributed dense rectangular arrays.
+
+
 Compiling with BLAS
 -------------------
 
@@ -105,6 +108,10 @@ dimensions of the matrices from the arrays that are passed in, even when one is
 passing in a sub-array such that the array elements are not contiguously stored
 in memory.
 
+.. warning::
+
+  The ``CHPL_LOCALE_MODEL=numa`` configuration is not supported by this module.
+
 .. MKL Documentation References
 
 .. _GEMM:   https://software.intel.com/en-us/node/ae8380b9-cac8-4c57-9af3-2eaac6acfc1b
@@ -163,6 +170,7 @@ in memory.
   - Clearer compiler errors instead of using where-clauses
   - Modular implementations using config param-wrapped require statements
   - More consistent documentation
+  - Support banded/packed matrix routines
 
 */
 module BLAS {

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -163,10 +163,9 @@ The native BLAS interface can still be accessed by calling routines from the
 .. _CABS1:  https://software.intel.com/en-us/node/64961e94-92d0-4671-90e6-86995e259a85
 
 .. BLAS Module TODO:
-  - [ ] Cleaner error checking instead of where-clauses
-  - [ ] Support for other BLAS distributions using config params, e.g. MKL
-  - [ ] Update getLeadingDim to take arrays instead of domains
-      - [ ] Support array views
+  - Clearer compiler errors instead of using where-clauses
+  - Modular implementations using config param-wrapped require statements
+  - More consistent documentation
 
 */
 module BLAS {
@@ -2328,18 +2327,6 @@ module BLAS {
   //
   // Helper functions
   //
-
-  pragma "no doc"
-  private inline proc assertIsVector(D: domain, func: string) param {
-    if D.rank != 1 then
-      compilerError("Expected 1-D array in %s, but received %i-D array".format(func, D.rank));
-  }
-
-  pragma "no doc"
-  private inline proc assertIsMatrix(D: domain, param func: string) param {
-    if D.rank != 2 then
-      compilerError("Expected 2-D array in %s, but received %i-D array".format(func, D.rank));
-  }
 
   pragma "no doc"
   private inline proc getLeadingDim(A: [?Adom], order : Order) : c_int {

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -84,8 +84,8 @@ Cray Systems:
   compiler, which implicitly links against the libsci library. Therefore, no
   additional steps are required of the user.
 
-Chapel's BLAS API
------------------
+Chapel BLAS API
+---------------
 
 This module provides higher-level wrappers around the BLAS functions. These
 provide reasonable default values for many less commonly used arguments and
@@ -100,13 +100,10 @@ wrapper for the ``[sdcz]gemm`` routines.
 The native BLAS interface can still be accessed by calling routines from the
 ``C_BLAS`` submodule.
 
-.. note::
- Chapel determines the dimensions of the matrices from the arrays that are
- passed in. However, if one is passing in a sub-array such that the array
- elements are not contiguously stored in memory, then the user needs to
- pass in the leading dimension (```lda``` etc) to the array, just as they
- would in C. These default to 0, in which case Chapel determines the appropriate
- values based on the array passed in.
+The ``ldA`` argument is omitted from the Chapel BLAS API. Chapel determines the
+dimensions of the matrices from the arrays that are passed in, even when one is
+passing in a sub-array such that the array elements are not contiguously stored
+in memory.
 
 .. MKL Documentation References
 
@@ -1622,7 +1619,7 @@ module BLAS {
             order : Order = Order.Row,
             uplo : Uplo = Uplo.Upper,
             diag : Diag = Diag.NonUnit,
-            ldA: int = 0, incx : c_int = 1)
+            incx : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
   {
 

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -26,7 +26,7 @@ low-level matrix, vector, and scalar operations. While `netlib
 <http://www.netlib.org/blas/#_documentation>`_ provides the official
 reference version of BLAS, this documentation refers to the
 `MKL BLAS <https://software.intel.com/en-us/node/520725>`_ documentation, due
-to quality and interface similarities.
+to interface similarities.
 
 This module is intended to work with non-distributed dense rectangular arrays.
 
@@ -65,11 +65,7 @@ BLAS Implementations:
 
   * **MKL**
 
-    * The BLAS module assumes that the C_BLAS functions are defined in the
-      header named ``cblas.h``.
-      MKL defines these in ``mkl_cblas.h``. This can be worked around by
-      creating a symbolic link to the correct header file name:
-      ``ln -s mkl_cblas.h cblas.h``
+    * Compile with :param:`-sisBLAS_MKL` if using MKL BLAS.
 
   * **OpenBLAS**
 
@@ -110,7 +106,8 @@ in memory.
 
 .. warning::
 
-  The ``CHPL_LOCALE_MODEL=numa`` configuration is not supported by this module.
+  The ``CHPL_LOCALE_MODEL=numa`` configuration is currently not supported by
+  this module.
 
 .. MKL Documentation References
 
@@ -168,17 +165,29 @@ in memory.
 
 .. BLAS Module TODO:
   - Clearer compiler errors instead of using where-clauses
-  - Modular implementations using config param-wrapped require statements
+  - Support more implementations using config param-wrapped require statements
+    - related: general RequireMKL module
   - More consistent documentation
   - Support banded/packed matrix routines
 
 */
 module BLAS {
 
+  /*
+    Tells the BLAS module to look for ``mkl_cblas.h`` instead of ``cblas.h``.
+    Set this to `true` if you are using the Intel MKL BLAS implementation.
+  */
+  config param isBLAS_MKL=false;
+
   use C_BLAS;
 
   use SysCTypes;
-  require "cblas.h";
+
+  if (isBLAS_MKL) {
+    require "mkl_cblas.h";
+  } else {
+    require "cblas.h";
+  }
 
 
   /* Define row or column order */

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -162,6 +162,12 @@ The native BLAS interface can still be accessed by calling routines from the
 .. _AMIN:   https://software.intel.com/en-us/node/50dceaa5-3463-402f-8065-a48bc68e0888
 .. _CABS1:  https://software.intel.com/en-us/node/64961e94-92d0-4671-90e6-86995e259a85
 
+.. BLAS Module TODO:
+  - [ ] Cleaner error checking instead of where-clauses
+  - [ ] Support for other BLAS distributions using config params, e.g. MKL
+  - [ ] Update getLeadingDim to take arrays instead of domains
+      - [ ] Support array views
+
 */
 module BLAS {
 
@@ -197,8 +203,7 @@ module BLAS {
   proc gemm(A : [?Adom], B : [?Bdom], C : [?Cdom],
     alpha, beta,
     opA : Op = Op.N, opB : Op = Op.N,
-    order : Order = Order.Row,
-    ldA : int = 0, ldB : int = 0, ldC : int = 0)
+    order : Order = Order.Row)
     where (Adom.rank == 2) && (Bdom.rank==2) && (Cdom.rank==2)
   {
     // Types
@@ -212,9 +217,9 @@ module BLAS {
                   else k = Adom.dim(2).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA),
-        _ldB = getLeadingDim(Bdom, order, ldB),
-        _ldC = getLeadingDim(Cdom, order, ldC);
+    var _ldA = getLeadingDim(A, order),
+        _ldB = getLeadingDim(B, order),
+        _ldC = getLeadingDim(C, order);
 
     select eltType {
       when real(32) {
@@ -262,8 +267,7 @@ module BLAS {
   proc symm(A : [?Adom], B : [?Bdom], C : [?Cdom],
     alpha, beta,
     uplo : Uplo = Uplo.Upper,  side : Side = Side.Left,
-    order : Order = Order.Row,
-    ldA : int = 0, ldB : int = 0, ldC : int = 0)
+    order : Order = Order.Row)
     where (Adom.rank == 2) && (Bdom.rank==2) && (Cdom.rank==2)
   {
     // Types
@@ -274,9 +278,9 @@ module BLAS {
         n = Cdom.dim(2).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA),
-        _ldB = getLeadingDim(Bdom, order, ldB),
-        _ldC = getLeadingDim(Cdom, order, ldC);
+    var _ldA = getLeadingDim(A, order),
+        _ldB = getLeadingDim(B, order),
+        _ldC = getLeadingDim(C, order);
 
     select eltType {
       when real(32) {
@@ -324,8 +328,7 @@ module BLAS {
   proc hemm(A : [?Adom], B : [?Bdom], C : [?Cdom],
     alpha, beta,
     uplo : Uplo = Uplo.Upper,  side : Side = Side.Left,
-    order : Order = Order.Row,
-    ldA : int = 0, ldB : int = 0, ldC : int = 0)
+    order : Order = Order.Row)
     where (Adom.rank == 2) && (Bdom.rank==2) && (Cdom.rank==2)
   {
     // Types
@@ -336,9 +339,9 @@ module BLAS {
         n = Cdom.dim(2).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA),
-        _ldB = getLeadingDim(Bdom, order, ldB),
-        _ldC = getLeadingDim(Cdom, order, ldC);
+    var _ldA = getLeadingDim(A, order),
+        _ldB = getLeadingDim(B, order),
+        _ldC = getLeadingDim(C, order);
 
     select eltType {
       when complex(64) {
@@ -377,8 +380,7 @@ module BLAS {
   proc syrk(A : [?Adom],  C : [?Cdom],
     alpha, beta,
     uplo : Uplo = Uplo.Upper,  trans : Op = Op.N,
-    order : Order = Order.Row,
-    ldA : int = 0,  ldC : int = 0)
+    order : Order = Order.Row)
     where (Adom.rank == 2) && (Cdom.rank==2)
   {
     // Types
@@ -391,8 +393,8 @@ module BLAS {
                      else k = Adom.dim(1).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA),
-        _ldC = getLeadingDim(Cdom, order, ldC);
+    var _ldA = getLeadingDim(A, order),
+        _ldC = getLeadingDim(C, order);
 
     select eltType {
       when real(32) {
@@ -441,8 +443,7 @@ module BLAS {
   proc herk(A : [?Adom],  C : [?Cdom],
     alpha, beta,
     uplo : Uplo = Uplo.Upper,  trans : Op = Op.N,
-    order : Order = Order.Row,
-    ldA : int = 0,  ldC : int = 0)
+    order : Order = Order.Row)
     where (Adom.rank == 2) && (Cdom.rank==2)
   {
     // Types
@@ -455,8 +456,8 @@ module BLAS {
                      else k = Adom.dim(1).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA),
-        _ldC = getLeadingDim(Cdom, order, ldC);
+    var _ldA = getLeadingDim(A, order),
+        _ldC = getLeadingDim(C, order);
 
     select eltType {
       when complex(64) {
@@ -496,8 +497,7 @@ module BLAS {
   proc syr2k(A : [?Adom],  B : [?Bdom], C : [?Cdom],
     alpha, beta,
     uplo : Uplo = Uplo.Upper,  trans : Op = Op.N,
-    order : Order = Order.Row,
-    ldA : int = 0,  ldB : int = 0, ldC : int = 0)
+    order : Order = Order.Row)
     where (Adom.rank == 2) && (Bdom.rank==2) && (Cdom.rank==2)
   {
     // Types
@@ -510,9 +510,9 @@ module BLAS {
                      else k = Adom.dim(1).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA),
-        _ldB = getLeadingDim(Bdom, order, ldB),
-        _ldC = getLeadingDim(Cdom, order, ldC);
+    var _ldA = getLeadingDim(A, order),
+        _ldB = getLeadingDim(B, order),
+        _ldC = getLeadingDim(C, order);
 
     select eltType {
       when real(32) {
@@ -561,8 +561,7 @@ module BLAS {
   proc her2k(A : [?Adom],  B : [?Bdom], C : [?Cdom],
     alpha, beta,
     uplo : Uplo = Uplo.Upper,  trans : Op = Op.N,
-    order : Order = Order.Row,
-    ldA : int = 0,  ldB : int = 0, ldC : int = 0)
+    order : Order = Order.Row)
     where (Adom.rank == 2) && (Bdom.rank==2) && (Cdom.rank==2)
   {
     // Types
@@ -575,9 +574,9 @@ module BLAS {
                      else k = Adom.dim(1).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA),
-        _ldB = getLeadingDim(Bdom, order, ldB),
-        _ldC = getLeadingDim(Cdom, order, ldC);
+    var _ldA = getLeadingDim(A, order),
+        _ldB = getLeadingDim(B, order),
+        _ldC = getLeadingDim(C, order);
 
     select eltType {
       when complex(64) {
@@ -610,27 +609,25 @@ module BLAS {
 
     where ``A`` is a triangular matrix.
   */
-  proc trmm(A : [?Adom],  B : [?Bdom],
+  proc trmm(A : [?Adom] ?eltType,  B : [?Bdom] eltType,
     alpha,
     uplo : Uplo = Uplo.Upper,  trans : Op = Op.N,
     side : Side = Side.Left, diag : Diag = Diag.NonUnit,
-    order : Order = Order.Row,
-    ldA : int = 0,  ldB : int = 0)
+    order : Order = Order.Row)
     where (Adom.rank == 2) && (Bdom.rank==2)
   {
-    // Types
-    type eltType = A.eltType;
+
 
     // Determine sizes
     var m = Bdom.dim(1).size : c_int,
         n = Bdom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to XXXX".format(m, n));
+      halt("Non-square array of dimensions %ix%i passed to trmm".format(m, n));
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA),
-        _ldB = getLeadingDim(Bdom, order, ldB);
+    var _ldA = getLeadingDim(A, order),
+        _ldB = getLeadingDim(B, order);
 
     select eltType {
       when real(32) {
@@ -673,8 +670,7 @@ module BLAS {
     alpha,
     uplo : Uplo = Uplo.Upper,  trans : Op = Op.N,
     side : Side = Side.Left, diag : Diag = Diag.NonUnit,
-    order : Order = Order.Row,
-    ldA : int = 0,  ldB : int = 0)
+    order : Order = Order.Row)
     where (Adom.rank == 2) && (Bdom.rank==2)
   {
     // Types
@@ -688,8 +684,8 @@ module BLAS {
       halt("Non-square array of dimensions %ix%i passed to TRSM".format(m, n));
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA),
-        _ldB = getLeadingDim(Bdom, order, ldB);
+    var _ldA = getLeadingDim(A, order),
+        _ldB = getLeadingDim(B, order);
 
     select eltType {
       when real(32) {
@@ -736,8 +732,7 @@ module BLAS {
             ref alpha: eltType, ref beta: eltType,
             kl : int = 0, ku : int = 0,
             trans : Op =  Op.N,
-            order : Order = Order.Row,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            order : Order = Order.Row, incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (Xdom.rank==1) && (Ydom.rank == 1)
   {
     // Determine sizes
@@ -745,7 +740,7 @@ module BLAS {
         n = Xdom.dim(1).size : c_int;
 
     // TODO -- 'order' may need to be swapped for banded matrices
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     var _kl = kl : c_int,
         _ku = ku : c_int;
@@ -784,7 +779,7 @@ module BLAS {
             alpha, beta,
             opA : Op = Op.N,
             order : Order = Order.Row,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (xdom.rank == 1) && (ydom.rank == 1)
   {
     // Determine sizes
@@ -792,7 +787,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when real(32) {
@@ -828,8 +823,7 @@ module BLAS {
 
   */
   proc ger(A: [?Adom] ?eltType, X: [?Xdom] eltType, Y: [?Ydom] eltType, alpha,
-           order : Order = Order.Row,
-           ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+           order : Order = Order.Row, incx : c_int = 1, incy : c_int = 1)
            where (Adom.rank == 2) && (Xdom.rank == 1) && (Ydom.rank == 1)
   {
 
@@ -838,7 +832,7 @@ module BLAS {
         n = Ydom.dim(1).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when real(32) {
@@ -862,15 +856,14 @@ module BLAS {
   */
   proc gerc(A: [?Adom] ?eltType, X: [?Xdom] eltType, Y: [?Ydom] eltType,
             ref alpha: eltType,
-            order : Order = Order.Row,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            order : Order = Order.Row, incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (Xdom.rank == 1) && (Ydom.rank == 1)
   {
     var m = Xdom.dim(1).size : c_int,
         n = Ydom.dim(1).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when complex(64) {
@@ -894,15 +887,14 @@ module BLAS {
   */
   proc geru(A: [?Adom] ?eltType, X: [?Xdom] eltType, Y: [?Ydom] eltType,
             ref alpha: eltType,
-            order : Order = Order.Row,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            order : Order = Order.Row, incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (Xdom.rank == 1) && (Ydom.rank == 1)
   {
     var m = Xdom.dim(1).size : c_int,
         n = Ydom.dim(1).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when complex(64) {
@@ -931,15 +923,14 @@ module BLAS {
             ref alpha: eltType, ref beta: eltType,
             k: int = 0,
             order : Order = Order.Row,
-            uplo : Uplo = Uplo.Upper,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            uplo : Uplo = Uplo.Upper, incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
   {
     var m = Adom.dim(1).size : c_int,
         n = Adom.dim(2).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     var _k = k : c_int;
 
@@ -965,8 +956,7 @@ module BLAS {
   proc hemv(A: [?Adom] ?eltType, X: [?vDom] eltType, Y: [vDom] eltType,
             ref alpha: eltType, ref beta: eltType,
             order : Order = Order.Row,
-            uplo : Uplo = Uplo.Upper,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            uplo : Uplo = Uplo.Upper, incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
     {
     var m = Adom.dim(1).size : c_int,
@@ -976,7 +966,7 @@ module BLAS {
       halt("Non-square array of dimensions %ix%i passed to hemv".format(m, n));
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when complex(64) {
@@ -999,8 +989,7 @@ module BLAS {
   */
   proc her(A: [?Adom] ?eltType, X: [?vDom] eltType, alpha,
             order : Order = Order.Row,
-            uplo : Uplo = Uplo.Upper,
-            ldA : int = 0, incx : c_int = 1)
+            uplo : Uplo = Uplo.Upper, incx : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
   {
     var m = Adom.dim(1).size : c_int,
@@ -1012,7 +1001,7 @@ module BLAS {
     // TODO -- Assert alpha is real
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when complex(64) {
@@ -1035,8 +1024,7 @@ module BLAS {
   proc her2(A: [?Adom] ?eltType, X: [?vDom] eltType, Y: [vDom] eltType,
             ref alpha: eltType,
             order : Order = Order.Row,
-            uplo : Uplo = Uplo.Upper,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            uplo : Uplo = Uplo.Upper, incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
     {
     var m = Adom.dim(1).size : c_int,
@@ -1047,7 +1035,7 @@ module BLAS {
 
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when complex(64) {
@@ -1177,14 +1165,14 @@ module BLAS {
             order : Order = Order.Row,
             uplo : Uplo = Uplo.Upper,
             k : int = 0,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
   {
     var m = Adom.dim(1).size : c_int,
         n = Adom.dim(2).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     var _k = k: c_int;
 
@@ -1306,7 +1294,7 @@ module BLAS {
             alpha, beta,
             order : Order = Order.Row,
             uplo : Uplo = Uplo.Upper,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
   {
     var m = Adom.dim(1).size : c_int,
@@ -1315,7 +1303,7 @@ module BLAS {
     if m != n then
       halt("Non-square array of dimensions %ix%i passed to symv".format(m, n));
 
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when real(32) {
@@ -1340,7 +1328,7 @@ module BLAS {
            alpha,
            order : Order = Order.Row,
            uplo : Uplo = Uplo.Upper,
-           ldA : int = 0, incx : c_int = 1)
+           incx : c_int = 1)
            where (Adom.rank == 2) && (vDom.rank == 1)
   {
 
@@ -1350,7 +1338,7 @@ module BLAS {
     if m != n then
       halt("Non-square array of dimensions %ix%i passed to syr".format(m, n));
 
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when real(32) {
@@ -1375,7 +1363,7 @@ module BLAS {
             alpha,
             order : Order = Order.Row,
             uplo : Uplo = Uplo.Upper,
-            ldA : int = 0, incx : c_int = 1, incy : c_int = 1)
+            incx : c_int = 1, incy : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
   {
 
@@ -1385,7 +1373,7 @@ module BLAS {
     if m != n then
       halt("Non-square array of dimensions %ix%i passed to syr2".format(m, n));
 
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when real(32) {
@@ -1417,7 +1405,7 @@ module BLAS {
             order : Order = Order.Row,
             uplo : Uplo = Uplo.Upper,
             diag : Diag = Diag.NonUnit,
-            ldA : int = 0, incx : c_int = 1)
+            incx : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
   {
     // Determine sizes
@@ -1425,7 +1413,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when real(32) {
@@ -1462,7 +1450,7 @@ module BLAS {
             order : Order = Order.Row,
             uplo : Uplo = Uplo.Upper,
             diag : Diag = Diag.NonUnit,
-            ldA : int = 0, incx : c_int = 1)
+            incx : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
   {
 
@@ -1475,7 +1463,7 @@ module BLAS {
                     else k = Adom.dim(1).size : c_int;
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when real(32) {
@@ -1591,7 +1579,7 @@ module BLAS {
             order : Order = Order.Row,
             uplo : Uplo = Uplo.Upper,
             diag : Diag = Diag.NonUnit,
-            ldA : int = 0, incx : c_int = 1)
+            incx : c_int = 1)
             where (Adom.rank == 2) && (vDom.rank == 1)
   {
 
@@ -1603,7 +1591,7 @@ module BLAS {
       halt("Non-square array of dimensions %ix%i passed to trmv".format(m, n));
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when real(32) {
@@ -1647,7 +1635,7 @@ module BLAS {
       halt("Non-square array of dimensions %ix%i passed to trsv".format(m, n));
 
     // Set strides if necessary
-    var _ldA = getLeadingDim(Adom, order, ldA);
+    var _ldA = getLeadingDim(A, order);
 
     select eltType {
       when real(32) {
@@ -2342,15 +2330,36 @@ module BLAS {
   //
 
   pragma "no doc"
-  private inline proc getLeadingDim(Adom : domain(2), order : Order, ldA : int) : c_int {
-    var _ldA = ldA : c_int;
-    if ldA==0 {
-      if order==Order.Row
-                  then _ldA = Adom.dim(2).size : c_int;
-                  else _ldA = Adom.dim(1).size : c_int;
-    }
-    return _ldA;
+  private inline proc assertIsVector(D: domain, func: string) param {
+    if D.rank != 1 then
+      compilerError("Expected 1-D array in %s, but received %i-D array".format(func, D.rank));
   }
+
+  pragma "no doc"
+  private inline proc assertIsMatrix(D: domain, param func: string) param {
+    if D.rank != 2 then
+      compilerError("Expected 2-D array in %s, but received %i-D array".format(func, D.rank));
+  }
+
+  pragma "no doc"
+  private inline proc getLeadingDim(A: [?Adom], order : Order) : c_int {
+    if order==Order.Row then
+      return Adom.dim(2).size : c_int;
+    else
+      return Adom.dim(1).size : c_int;
+  }
+
+  pragma "no doc"
+  private inline proc getLeadingDim(Arr: [], order : Order) : c_int
+  where chpl__isArrayView(Arr)
+  {
+    const dims = chpl__getActualArray(Arr).dom.dsiDims();
+    if order==Order.Row then
+      return dims(2).size : c_int;
+    else
+      return dims(1).size : c_int;
+  }
+
 
   /*
 

--- a/test/modules/packages/blas/blas_helpers.chpl
+++ b/test/modules/packages/blas/blas_helpers.chpl
@@ -4,6 +4,7 @@ use Random;
 use BLAS;
 
 config const errorThresholdDouble = 1.e-10;
+// note: sporadically failures occur with 1.e-5
 config const errorThresholdSingle = 1.e-4;
 
 proc printErrors(name: string, passed, failed, tests) {
@@ -70,10 +71,11 @@ proc makeBand(A:[?Adom] ?t, kl, ku)
   }
 }
 
-// Make band-diagonal triangular matrix
+/* TODO -- Make band-diagonal triangular matrix */
 proc makeBandTriangular(A:[?Adom], k,  uplo:Uplo=Uplo.Upper)
-  where Adom.rank == 2 {
-
+  where Adom.rank == 2
+{
+  compilerError('Not yet implemented');
 }
 
 
@@ -111,15 +113,6 @@ proc makeUnit(A : [?Adom], val:real = 1.0) {
     if (i!=j) then A[i,j] = zero;
               else A[i,i] = diag;
   }
-}
-
-// No-ops when conjugating real numbers...
-inline proc conjg(x : real(32)) {
-  return x;
-}
-
-inline proc conjg(x : real(64)) {
-  return x;
 }
 
 
@@ -216,9 +209,9 @@ proc bandArrayDense(a: [?Dom] ?eltType, l, u, m, n) where a.rank == 2 {
   return A;
 }
 
-/* Create packed array from dense array, assume 0-based domain*/
+/* TODO -- Create packed array from dense array, assume 0-based domain*/
 proc packedArray(A: [?Dom] ?elType) where A.rank == 2 {
-  // TODO
+  compilerError('Not yet implemented');
 }
 
 

--- a/test/modules/packages/blas/test_blas2.chpl
+++ b/test/modules/packages/blas/test_blas2.chpl
@@ -2,9 +2,15 @@ use Random;
 use BLAS;
 use blas_helpers;
 
+/* BLAS 2 Testing TODO:
+    - [ ] Banded matrices (commented out)
+      - [ ] blas_helpers functions (commented out in blas_helpers.chpl)
+    - [ ] Packed matrices (commented out)
+      - [ ] blas_helpers functions (commented out in blas_helpers.chpl)
+ */
+
 
 proc main() {
-    // TODO -- band Matrices & packed Matrices
     //test_gbmv(); // bandMatrix
     test_gemv();
     test_ger();
@@ -191,6 +197,7 @@ proc test_trsv() {
 // Helpers
 //
 
+// TODO -- work in progress
 proc test_gbmv_helper(type t){
   var passed = 0,
       failed = 0,
@@ -200,7 +207,6 @@ proc test_gbmv_helper(type t){
 
   // Simple test
   {
-    // TODO -- work in progress
     const m = 6,
           n = 6;
     // Square
@@ -326,9 +332,8 @@ proc test_gemv_helper(type t){
     const beta = rng.getNext();
 
     // Compute Result vector
-    for i in R.domain {
+    for i in R.domain do
       R[i] = beta*Y[i] + alpha*(+ reduce (conjg(A[..,i])*X[..]));
-    }
 
     gemv(A, X, Y, alpha, beta, opA=Op.H);
 
@@ -344,7 +349,7 @@ proc test_gemv_helper(type t){
           ld = 20 : c_int;
 
     // non-square matrix
-    var A : [{0.. #m, 0.. #ld}]t,
+    var A : [{0.. #ld, 0.. #ld}]t,
         X : [{0.. #n}]t,
         Y : [{0.. #m}]t,
         R : [{0.. #m}]t; // Result
@@ -359,9 +364,9 @@ proc test_gemv_helper(type t){
     const beta = rng.getNext();
 
     // Compute Result vector
-    for i in R.domain do R[i] = beta*Y[i] + alpha*(+ reduce (A[i,0.. #n]*X[..]));
+    for i in R.domain do R[i] = beta*Y[i] + alpha*(+ reduce (A[i+2 ,0.. #n]*X[..]));
 
-    gemv(A[.., 0.. #n] , X, Y, alpha, beta, ldA=ld);
+    gemv(A[2..#m, 0.. #n] , X, Y, alpha, beta);
 
     var err = max reduce abs(Y-R);
 
@@ -432,7 +437,7 @@ proc test_ger_helper(type t){
 
     for (i,j) in R.domain do R[i, j] = alpha*X[i]*Y[j] + A[i, j];
 
-    ger(A[.., 0.. #n], X, Y, alpha, ldA=ld);
+    ger(A[.., 0.. #n], X, Y, alpha);
 
     var err = max reduce abs(A[.., 0..#n]-R);
 
@@ -504,7 +509,7 @@ proc test_gerc_helper(type t){
     // Precompute result
     for (i,j) in R.domain do R[i, j] = alpha*X[i]*conjg(Y[j]) + A[i, j];
 
-    gerc(A[.., 0.. #n], X, Y, alpha, ldA=ld);
+    gerc(A[.., 0.. #n], X, Y, alpha);
 
     var err = max reduce abs(A[.., 0.. #n] - R);
 
@@ -573,7 +578,7 @@ proc test_geru_helper(type t){
     // Precompute result
     for (i,j) in R.domain do R[i, j] = alpha*X[i]*Y[j] + A[i, j];
 
-    geru(A[.., 0.. #n], X, Y, alpha, ldA=ld);
+    geru(A[.., 0.. #n], X, Y, alpha);
 
     var err = max reduce abs(A[.., 0.. #n] - R);
 
@@ -584,6 +589,7 @@ proc test_geru_helper(type t){
 }
 
 
+// TODO
 proc test_hbmv_helper(type t){
   var passed = 0,
       failed = 0,
@@ -592,7 +598,6 @@ proc test_hbmv_helper(type t){
   var name = "%shbmv".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
   }
   printErrors(name, passed, failed, tests);
 }
@@ -696,7 +701,7 @@ proc test_hemv_helper(type t){
 
     for i in R.domain do R[i] = + reduce(alpha*A[i,0..#m]*X[..]) + beta*Y[i];
 
-    hemv(A[.., 0..#m], X, Y, alpha, beta, ldA=ld);
+    hemv(A[.., 0..#m], X, Y, alpha, beta);
 
     var err = max reduce abs(Y-R);
 
@@ -799,7 +804,7 @@ proc test_her_helper(type t){
     zeroTri(A[.., 0..#m]);
     zeroTri(R);
 
-    her(A[.., 0..#m], X, alpha, ldA=ld);
+    her(A[.., 0..#m], X, alpha);
 
     var err = max reduce abs(A[.., 0..#m]-R);
 
@@ -905,7 +910,7 @@ proc test_her2_helper(type t){
     zeroTri(A[.., 0..#m]);
     zeroTri(R);
 
-    her2(A[.., 0..#m], X, Y, alpha, ldA=ld);
+    her2(A[.., 0..#m], X, Y, alpha);
 
     var err = max reduce abs(A[.., 0..#m]-R);
 
@@ -915,6 +920,7 @@ proc test_her2_helper(type t){
 }
 
 
+// TODO
 proc test_hpmv_helper(type t){
   var passed = 0,
       failed = 0,
@@ -923,12 +929,12 @@ proc test_hpmv_helper(type t){
   var name = "%shpmv".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
   }
   printErrors(name, passed, failed, tests);
 }
 
 
+// TODO
 proc test_hpr_helper(type t){
   var passed = 0,
       failed = 0,
@@ -937,12 +943,12 @@ proc test_hpr_helper(type t){
   var name = "%shpr".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
   }
   printErrors(name, passed, failed, tests);
 }
 
 
+// TODO
 proc test_hpr2_helper(type t){
   var passed = 0,
       failed = 0,
@@ -951,12 +957,12 @@ proc test_hpr2_helper(type t){
   var name = "%shpr2".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
   }
   printErrors(name, passed, failed, tests);
 }
 
 
+// TODO
 proc test_sbmv_helper(type t){
   var passed = 0,
       failed = 0,
@@ -965,12 +971,12 @@ proc test_sbmv_helper(type t){
   var name = "%ssbmv".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
   }
   printErrors(name, passed, failed, tests);
 }
 
 
+// TODO
 proc test_spmv_helper(type t){
   var passed = 0,
       failed = 0,
@@ -979,12 +985,12 @@ proc test_spmv_helper(type t){
   var name = "%sspmv".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
   }
   printErrors(name, passed, failed, tests);
 }
 
 
+// TODO
 proc test_spr_helper(type t){
   var passed = 0,
       failed = 0,
@@ -993,12 +999,12 @@ proc test_spr_helper(type t){
   var name = "%sspr".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
   }
   printErrors(name, passed, failed, tests);
 }
 
 
+// TODO
 proc test_spr2_helper(type t){
   var passed = 0,
       failed = 0,
@@ -1007,7 +1013,6 @@ proc test_spr2_helper(type t){
   var name = "%sspr2".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
   }
   printErrors(name, passed, failed, tests);
 }
@@ -1114,7 +1119,7 @@ proc test_symv_helper(type t){
     // A result is only stored in upper triangular array
     zeroTri(A[.., 0..#m]);
 
-    symv(A[.., 0..#m], X, Y, alpha, beta, ldA=ld);
+    symv(A[.., 0..#m], X, Y, alpha, beta);
 
     var err = max reduce abs(Y-R);
 
@@ -1214,7 +1219,7 @@ proc test_syr_helper(type t){
     zeroTri(R);
     zeroTri(A[.., 0..#m]);
 
-    syr(A[.., 0..#m], X, alpha, ldA=ld);
+    syr(A[.., 0..#m], X, alpha);
 
     var err = max reduce abs(A[.., 0..#m]-R);
 
@@ -1323,7 +1328,7 @@ proc test_syr2_helper(type t){
     zeroTri(R);
     zeroTri(A[.., 0..#m]);
 
-    syr2(A[.., 0..#m], X, Y, alpha, ldA=ld);
+    syr2(A[.., 0..#m], X, Y, alpha);
 
     var err = max reduce abs(A[.., 0..#m]-R);
 
@@ -1333,6 +1338,7 @@ proc test_syr2_helper(type t){
 }
 
 
+// TODO
 proc test_tbmv_helper(type t){
   var passed = 0,
       failed = 0,
@@ -1341,7 +1347,6 @@ proc test_tbmv_helper(type t){
   var name = "%stbmv".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
     const m = 5 : c_int;
 
     var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
@@ -1376,6 +1381,7 @@ proc test_tbmv_helper(type t){
 }
 
 
+// TODO
 proc test_tbsv_helper(type t){
   var passed = 0,
       failed = 0,
@@ -1384,7 +1390,6 @@ proc test_tbsv_helper(type t){
   var name = "%stbsv".format(blasPrefix(t));
   // Simple test
   {
-    // TODO
   }
   printErrors(name, passed, failed, tests);
 }
@@ -1519,7 +1524,7 @@ proc test_trmv_helper(type t){
 
     for i in R.domain do R[i] = + reduce (A[i, 0..#m]*X[..]);
 
-    trmv(A[.., 0..#m], X, ldA=ld);
+    trmv(A[.., 0..#m], X);
 
     var err = max reduce abs(X-R);
 
@@ -1676,7 +1681,7 @@ proc test_trsv_helper(type t){
     // Store X
     const Xsave = X;
 
-    trsv(A[.., 0..#m], X, ldA=ld);
+    trsv(A[.., 0..#m], X);
 
     for i in R.domain do R[i] = + reduce(A[i, 0..#m]*X[..]);
 

--- a/test/modules/packages/blas/test_blas3.chpl
+++ b/test/modules/packages/blas/test_blas3.chpl
@@ -173,7 +173,7 @@ proc test_gemm_helper(type t) {
     const alpha = rng.getNext(),
           beta = rng.getNext();
 
-    gemm(A[..,0.. #k],B[..,0.. #n],C[..,0.. #n],alpha,beta, ldA=ld, ldB=ld,ldC=ld);
+    gemm(A[..,0.. #k], B[..,0.. #n], C[..,0.. #n], alpha,beta);
     forall (i,j) in {0.. #m, 0.. #n} do
       D[i,j] = beta*D[i,j]+alpha*(+ reduce (A[i,0.. #k]*B[..,j]));
     var err = max reduce abs(C-D);


### PR DESCRIPTION
With the addition of array views, we can now compute the `ldA` values automatically in all cases, rendering the argument obsolete. 

In this PR:
- modify and overload `getLeadingDim()` to handle array views
- remove `ld*` as an argument in the BLAS routines and tests
- document this change in the Chapel BLAS documentation.

**Deprecation warning** -- I have opted to *not* provide a deprecation warning for the following reasons:
- BLAS was added in 1.14.0 as a WIP package module (BLAS 3 only)
- The `ldA` argument was already optional and would only be necessary if users were passing an array slice to a BLAS 3 routine.

I am open to including a deprecation warning if my reviewer feels strongly about it.


Some less noteworthy changes in this PR:
- Add `config param isBLAS_MKL`, so that users don't have to symlink their MKL BLAS header when using BLAS MKL (yuck!)
- Slightly modified the `gemv` array slice test to check that passing an array sliced on both dimensions works (made possible by #5662 -- thanks @benharsh !)
- Remove `conjg` BLAS helper routine, since `Math.conjg` has been updated to always return the same type it receives.
- Add next steps in a module-level TODO comment (requested in #5392 as a follow-up)

- [X] OS X + netlib
- [x] Cray XC + CrayBLAS