### PR TITLE
Test performance of making the multi-ddata array fields void for flat

### DIFF
--- a/util/cron/test-perf.chapcs.playground-2.bash
+++ b/util/cron/test-perf.chapcs.playground-2.bash
@@ -9,11 +9,11 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground-2"
 
-# Test performance of qthreads 1.12 using chapel's allocator
+# Test performance of making DefaultRect multi-ddata fields void
 GITHUB_USER=ronawho
-GITHUB_BRANCH=qt-use-chpl-alloc
-SHORT_NAME=qt-chpl-alloc
-START_DATE=03/09/17
+GITHUB_BRANCH=ronawho-newVoidTypeFC
+SHORT_NAME=md-void-fields
+START_DATE=03/14/17
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
Check if making DefaultRectangular's multi-ddata specific fields `void`
resolves the flat performance regressions.

Uses David's newVoidTypeFC branch