### PR TITLE
Add annotation for "ListDest" array-vector perf regression

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -857,6 +857,8 @@ timeVectorArray:
     - increased array-as-vec problem size (#3422)
   05/28/16:
     - upgrade jemalloc to 4.2.0 (#3919)
+  01/31/17:
+    - upgrade jemalloc to 4.4.0 (#5278)
 
 dynamic:
   02/28/17:


### PR DESCRIPTION
Turns out the regression was caused by the jemalloc 4.4.0 upgrade (which also
hurt binary-trees a little.) #5278 has more details on the regression, and it's
not one I think we should worry about. Also note that overall this test has
benefited significantly from jemalloc, so I'm not worried about a minor
regression anyways.)