### PR TITLE
NUMA-localize comm=ugni desired shared heap.

### DIFF
--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -234,7 +234,7 @@ void chpl_mem_layerFree(void*, int32_t lineno, int32_t filename);
 // where chpl_mem_doLocalization is true, above.)
 //
 static inline
-chpl_bool chpl_mem_allocLocalizes(void) {
+bool chpl_mem_allocLocalizes(void) {
 #ifdef CHPL_MEM_IMPL_ALLOCLOCALIZES
     return CHPL_MEM_IMPL_ALLOCLOCALIZES;
 #else

--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -59,11 +59,16 @@ int chpl_posix_memalign_check_valid(size_t alignment);
 // and no additional error checking.
 #include "chpl-mem-impl.h"
 
+size_t chpl_mem_localizationThreshold;
+
 void chpl_mem_init(void);
 void chpl_mem_exit(void);
 
 int chpl_mem_inited(void);
 
+// predeclared here because we need it below; actual definition is
+// near the end
+static chpl_bool chpl_mem_allocLocalizes(void);
 
 static inline
 void* chpl_mem_allocMany(size_t number, size_t size,
@@ -133,9 +138,17 @@ void* chpl_mem_array_alloc(size_t nmemb, size_t eltSize,
                            int32_t lineno, int32_t filename) {
   void* p = chpl_mem_allocMany(nmemb, eltSize, CHPL_RT_MD_ARRAY_ELEMENTS,
                                lineno, filename);
-  if (localizeSubchunks || isActualSublocID(subloc)) {
-    chpl_topo_setMemLocality(p, nmemb * eltSize,
-                             true, localizeSubchunks, subloc);
+  if (isActualSublocID(subloc)) {
+    if (!chpl_mem_allocLocalizes()
+        && nmemb * eltSize >= chpl_mem_localizationThreshold) {
+      chpl_topo_setMemLocality(p, nmemb * eltSize, true, subloc);
+    }
+  }
+  else if (localizeSubchunks) {
+    if (!chpl_mem_allocLocalizes()
+        && nmemb * eltSize >= chpl_mem_localizationThreshold) {
+      chpl_topo_setMemSubchunkLocality(p, nmemb * eltSize, true, NULL);
+    }
   }
   return p;
 }
@@ -210,6 +223,24 @@ void chpl_mem_layerExit(void);
 void* chpl_mem_layerAlloc(size_t, int32_t lineno, int32_t filename);
 void* chpl_mem_layerRealloc(void*, size_t, int32_t lineno, int32_t filename);
 void chpl_mem_layerFree(void*, int32_t lineno, int32_t filename);
+
+//
+// Does the implementation provide allocated memory that is already
+// localized to the calling sublocale?  That is, when the locale model
+// has sublocales and an allocation is done while running on one, will
+// the allocated memory be localized to that sublocale?  (Note that the
+// answer doesn't have to be completely truthful; it really only matters
+// for allocations large enough that we'll try to force localization
+// where chpl_mem_doLocalization is true, above.)
+//
+static inline
+chpl_bool chpl_mem_allocLocalizes(void) {
+#ifdef CHPL_MEM_IMPL_ALLOCLOCALIZES
+    return CHPL_MEM_IMPL_ALLOCLOCALIZES;
+#else
+    return false;
+#endif
+}
 
 #else // LAUNCHER
 

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -39,6 +39,21 @@ void chpl_topo_init(void);
 void chpl_topo_exit(void);
 
 //
+// how many NUMA domains are there?
+//
+int chpl_topo_getNumNumaDomains(void);
+
+//
+// set the sublocale where the current thread is running
+//
+void chpl_topo_setThreadLocality(c_sublocid_t);
+
+//
+// get the sublocale where the current thread is running
+//
+c_sublocid_t chpl_topo_getThreadLocality(void);
+
+//
 // set the locality of a block of memory, to a specific NUMA domain
 //
 // args:
@@ -46,12 +61,22 @@ void chpl_topo_exit(void);
 //   size (bytes)
 //   onlyInside?  true: only localize pages strictly within the memory
 //                false: also localize partial pages at edges
-//   doSubchunks?  true: block-localize the subchunks
-//                 false: localize the entirety to the given sublocale
-//   desired sublocale (NUMA domain), if !doSubChunks
+//   desired sublocale (NUMA domain)
 //
-void chpl_topo_setMemLocality(void*, size_t, chpl_bool,
-                              chpl_bool, c_sublocid_t);
+void chpl_topo_setMemLocality(void*, size_t, chpl_bool, c_sublocid_t);
+
+//
+// set the locality of the sub-blocks of a block of memory, to each
+// of the NUMA domains in order
+//
+// args:
+//   base address
+//   size (bytes)
+//   onlyInside?  true: only localize pages strictly within the memory
+//                false: also localize partial pages at edges
+//   (optional) address of result vector of subchunk sizes
+//
+void chpl_topo_setMemSubchunkLocality(void*, size_t, chpl_bool, size_t*);
 
 //
 // get memory locality of (the page containing) an address

--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -21,8 +21,6 @@
 #ifndef _chpl_mem_impl_H_
 #define _chpl_mem_impl_H_
 
-#include "chpl-comm.h"
-
 // jemalloc.h references the token "malloc" (but not the actual function) and
 // our warning macros mess up jemalloc's use of it.
 #include "chpl-mem-no-warning-macros.h"
@@ -32,7 +30,7 @@
 #define MALLOCX_NO_FLAGS 0
 
 
-extern chpl_bool chpl_mem_impl_allocLocalizes;
+extern bool chpl_mem_impl_allocLocalizes;
 #define CHPL_MEM_IMPL_ALLOCLOCALIZES chpl_mem_impl_allocLocalizes
 
 

--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -21,6 +21,8 @@
 #ifndef _chpl_mem_impl_H_
 #define _chpl_mem_impl_H_
 
+#include "chpl-comm.h"
+
 // jemalloc.h references the token "malloc" (but not the actual function) and
 // our warning macros mess up jemalloc's use of it.
 #include "chpl-mem-no-warning-macros.h"
@@ -28,6 +30,11 @@
 #include "chpl-mem-warning-macros.h"
 
 #define MALLOCX_NO_FLAGS 0
+
+
+extern chpl_bool chpl_mem_impl_allocLocalizes;
+#define CHPL_MEM_IMPL_ALLOCLOCALIZES chpl_mem_impl_allocLocalizes
+
 
 static inline void* chpl_calloc(size_t n, size_t size) {
   return chpl_je_calloc(n,size);

--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -30,10 +30,6 @@
 #define MALLOCX_NO_FLAGS 0
 
 
-extern bool chpl_mem_impl_allocLocalizes;
-#define CHPL_MEM_IMPL_ALLOCLOCALIZES chpl_mem_impl_allocLocalizes
-
-
 static inline void* chpl_calloc(size_t n, size_t size) {
   return chpl_je_calloc(n,size);
 }
@@ -62,6 +58,12 @@ static inline size_t chpl_good_alloc_size(size_t minSize) {
   if (minSize == 0) { return 0; }
   return chpl_je_nallocx(minSize, MALLOCX_NO_FLAGS);
 }
+
+
+bool chpl_mem_impl_alloc_localizes(void);
+
+#define CHPL_MEM_IMPL_ALLOC_LOCALIZES() chpl_mem_impl_alloc_localizes()
+
 
 // TODO (EJR 03/11/16): Can/should we consider using the extended API? See JIRA
 // issue 190 (https://chapel.atlassian.net/browse/CHAPEL-190) for more info.

--- a/runtime/src/chpl-mem.c
+++ b/runtime/src/chpl-mem.c
@@ -29,9 +29,14 @@
 
 static int heapInitialized = 0;
 
+size_t chpl_mem_localizationThreshold;
+
+
 void chpl_mem_init(void) {
   chpl_mem_layerInit();
   heapInitialized = 1;
+  chpl_mem_localizationThreshold =
+      chpl_topo_getNumNumaDomains() * 2 * chpl_getHeapPageSize();
 }
 
 

--- a/runtime/src/chpl-mem.c
+++ b/runtime/src/chpl-mem.c
@@ -29,14 +29,10 @@
 
 static int heapInitialized = 0;
 
-size_t chpl_mem_localizationThreshold;
-
 
 void chpl_mem_init(void) {
   chpl_mem_layerInit();
   heapInitialized = 1;
-  chpl_mem_localizationThreshold =
-      chpl_topo_getNumNumaDomains() * 2 * chpl_getHeapPageSize();
 }
 
 

--- a/runtime/src/chpl-topo.c
+++ b/runtime/src/chpl-topo.c
@@ -386,6 +386,9 @@ c_sublocid_t chpl_topo_getMemLocality(void* p) {
   }
 
   node = hwloc_bitmap_first(nodeset);
+  if (!isActualSublocID(node)) {
+    node = c_sublocid_any;
+  }
 
   hwloc_bitmap_free(nodeset);
 

--- a/runtime/src/chpl-topo.c
+++ b/runtime/src/chpl-topo.c
@@ -30,6 +30,7 @@
 #include "error.h"
 
 #include <errno.h>
+#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,7 +49,7 @@
 // note: format arg 'f' must be a string constant
 #define _DBG_P(f, ...)                                                  \
         do {                                                            \
-          printf("%s:%d" f "\n", __FILE__, __LINE__, ## __VA_ARGS__);   \
+          printf("%s:%d: " f "\n", __FILE__, __LINE__, ## __VA_ARGS__); \
         } while (0)
 #else
 #define _DBG_P(f, ...)
@@ -67,8 +68,10 @@ static int numaLevel;
 static int numNumaDomains;
 
 
+static void alignAddrSize(void*, size_t, chpl_bool,
+                          size_t*, unsigned char**, size_t*);
 static void chpl_topo_setMemLocalityByPages(unsigned char*, size_t,
-                                            hwloc_nodeset_t);
+                                            hwloc_obj_t numaObj);
 static void report_error(const char*, int);
 
 
@@ -106,6 +109,7 @@ void chpl_topo_init(void) {
   topoSupport = hwloc_topology_get_support(topology);
 
   //
+  // TODO: update comment
   // For now, don't support setting memory locality when comm=ugni or
   // comm=gasnet, seg!=everything.  Those are the two configurations in
   // which we use hugepages and/or memory registered with the comm
@@ -114,9 +118,8 @@ void chpl_topo_init(void) {
   // the future.
   //
   do_set_area_membind = true;
-  if (strcmp(CHPL_COMM, "ugni") == 0
-      || (strcmp(CHPL_COMM, "gasnet") == 0
-          && strcmp(CHPL_GASNET_SEGMENT, "everything") != 0)) {
+  if ((strcmp(CHPL_COMM, "gasnet") == 0
+       && strcmp(CHPL_GASNET_SEGMENT, "everything") != 0)) {
       do_set_area_membind = false;
   }
 
@@ -163,26 +166,153 @@ void chpl_topo_exit(void) {
 }
 
 
-void chpl_topo_setMemLocality(void* p, size_t size, chpl_bool onlyInside,
-                              chpl_bool doSubchunks, c_sublocid_t subloc) {
-  unsigned char* pCh;
-  size_t pgSize;
-  size_t pgMask;
-  unsigned char* pPgLo;
-  size_t nPages;
-  hwloc_obj_t numaObj;
+int chpl_topo_getNumNumaDomains(void) {
+  return numNumaDomains;
+}
 
-  _DBG_P("chpl_topo_setMemLocality(%p, %#zx, onlyIn=%s, doSub=%s, %d)\n",
-         p, size,
-         (onlyInside ? "T" : "F"), (doSubchunks ? "T" : "F"), (int) subloc);
+
+void chpl_topo_setThreadLocality(c_sublocid_t subloc) {
+  hwloc_cpuset_t cpuset;
+  hwloc_obj_t numaObj;
+  int flags;
+
+  _DBG_P("chpl_topo_setThreadLocality(%d)\n", (int) subloc);
 
   if (!haveTopology) {
     return;
   }
 
-  pCh = (unsigned char*) p;
-  pgSize = chpl_getHeapPageSize();
-  pgMask = pgSize - 1;
+  if (!topoSupport->cpubind->set_thread_cpubind)
+    return;
+
+  if ((cpuset = hwloc_bitmap_alloc()) == NULL) {
+    report_error("hwloc_bitmap_alloc()", errno);
+  }
+
+  numaObj = hwloc_get_obj_by_depth(topology, numaLevel, subloc);
+  hwloc_cpuset_from_nodeset(topology, cpuset, numaObj->allowed_nodeset);
+
+  flags = HWLOC_CPUBIND_THREAD | HWLOC_CPUBIND_STRICT;
+  if (hwloc_set_cpubind(topology, cpuset, flags)) {
+    report_error("hwloc_set_cpubind()", errno);
+  }
+
+  hwloc_bitmap_free(cpuset);
+}
+
+
+c_sublocid_t chpl_topo_getThreadLocality(void) {
+  hwloc_cpuset_t cpuset;
+  hwloc_nodeset_t nodeset;
+  int flags;
+  int node;
+
+  if (!haveTopology) {
+    return c_sublocid_any;
+  }
+
+  if (!topoSupport->cpubind->get_thread_cpubind) {
+    return c_sublocid_any;
+  }
+
+  if ((cpuset = hwloc_bitmap_alloc()) == NULL
+      || (nodeset = hwloc_bitmap_alloc()) == NULL) {
+    report_error("hwloc_bitmap_alloc()", errno);
+  }
+
+  flags = HWLOC_CPUBIND_THREAD;
+  if (hwloc_get_thread_cpubind(topology, pthread_self(), cpuset, flags)) {
+    report_error("hwloc_get_cpubind()", errno);
+  }
+
+  hwloc_cpuset_to_nodeset(topology, cpuset, nodeset);
+
+  node = hwloc_bitmap_first(nodeset);
+
+  hwloc_bitmap_free(nodeset);
+  hwloc_bitmap_free(cpuset);
+
+  return node;
+}
+
+
+void chpl_topo_setMemLocality(void* p, size_t size, chpl_bool onlyInside,
+                              c_sublocid_t subloc) {
+  size_t pgSize;
+  unsigned char* pPgLo;
+  size_t nPages;
+  hwloc_obj_t numaObj;
+
+  _DBG_P("chpl_topo_setMemLocality(%p, %#zx, onlyIn=%s, doSub=%s, %d)\n",
+         p, size, (onlyInside ? "T" : "F"), (int) subloc);
+
+  if (!haveTopology) {
+    return;
+  }
+
+  alignAddrSize(p, size, onlyInside, &pgSize, &pPgLo, &nPages);
+
+  _DBG_P("    localize %p, %#zx bytes (%#zx pages)\n",
+         pPgLo, nPages * pgSize, nPages);
+
+  if (nPages == 0)
+    return;
+
+  numaObj = hwloc_get_obj_by_depth(topology, numaLevel, subloc);
+  chpl_topo_setMemLocalityByPages(pPgLo, nPages * pgSize, numaObj);
+}
+
+
+void chpl_topo_setMemSubchunkLocality(void* p, size_t size,
+                                      chpl_bool onlyInside,
+                                      size_t* subchunkSizes) {
+  size_t pgSize;
+  unsigned char* pPgLo;
+  size_t nPages;
+  hwloc_obj_t numaObj;
+  int i;
+  size_t pg;
+  size_t pgNext;
+
+  _DBG_P("chpl_topo_setMemSubchunkLocality(%p, %#zx, onlyIn=%s)\n",
+         p, size, (onlyInside ? "T" : "F"));
+
+  if (!haveTopology) {
+    return;
+  }
+
+  alignAddrSize(p, size, onlyInside, &pgSize, &pPgLo, &nPages);
+
+  _DBG_P("    localize %p, %#zx bytes (%#zx pages)\n",
+         pPgLo, nPages * pgSize, nPages);
+
+  if (nPages == 0)
+    return;
+
+  for (i = 0, pg = 0; i < numNumaDomains; i++, pg = pgNext) {
+    if (i == numNumaDomains - 1)
+      pgNext = nPages;
+    else
+      pgNext = 1 + (nPages * (i + 1) - 1) / numNumaDomains;
+    numaObj = hwloc_get_obj_by_depth(topology, numaLevel, i);
+    chpl_topo_setMemLocalityByPages(pPgLo + pg * pgSize,
+                                    (pgNext - pg) * pgSize, numaObj);
+    if (subchunkSizes != NULL) {
+      subchunkSizes[i] = (pgNext - pg) * pgSize;
+    }
+  }
+}
+
+
+static inline
+void alignAddrSize(void* p, size_t size, chpl_bool onlyInside,
+                   size_t* p_pgSize, unsigned char** p_pPgLo,
+                   size_t* p_nPages) {
+  unsigned char* pCh = (unsigned char*) p;
+  size_t pgSize = chpl_getHeapPageSize();
+  size_t pgMask = pgSize - 1;
+  unsigned char* pPgLo;
+  size_t nPages;
 
   if (onlyInside) {
     pPgLo = round_up_to_mask_ptr(pCh, pgMask);
@@ -195,32 +325,9 @@ void chpl_topo_setMemLocality(void* p, size_t size, chpl_bool onlyInside,
     nPages = round_up_to_mask(size + (pCh - pPgLo), pgMask) / pgSize;
   }
 
-  _DBG_P("    localize %p, %#zx bytes (%#zx pages)\n",
-         pPgLo, nPages * pgSize, nPages);
-
-  if (nPages == 0)
-    return;
-
-  if (doSubchunks) {
-    int i;
-    size_t pg;
-    size_t pgNext;
-
-    for (i = 0, pg = 0; i < numNumaDomains; i++, pg = pgNext) {
-      if (i == numNumaDomains - 1)
-        pgNext = nPages;
-      else
-        pgNext = 1 + (nPages * (i + 1) - 1) / numNumaDomains;
-      numaObj = hwloc_get_obj_by_depth(topology, numaLevel, i);
-      chpl_topo_setMemLocalityByPages(pPgLo + pg * pgSize,
-                                      (pgNext - pg) * pgSize,
-                                      numaObj->nodeset);
-    }
-  }
-  else if (subloc >= 0 && subloc < numNumaDomains) {
-    numaObj = hwloc_get_obj_by_depth(topology, numaLevel, subloc);
-    chpl_topo_setMemLocalityByPages(pPgLo, nPages * pgSize, numaObj->nodeset);
-  }
+  *p_pgSize = pgSize;
+  *p_pPgLo = pPgLo;
+  *p_nPages = nPages;
 }
 
 
@@ -229,8 +336,8 @@ void chpl_topo_setMemLocality(void* p, size_t size, chpl_bool onlyInside,
 //
 static
 void chpl_topo_setMemLocalityByPages(unsigned char* p, size_t size,
-                                     hwloc_nodeset_t nodeset) {
-  const int flags = HWLOC_MEMBIND_MIGRATE | HWLOC_MEMBIND_STRICT;
+                                     hwloc_obj_t numaObj) {
+  int flags;
 
   if (!haveTopology) {
     return;
@@ -241,25 +348,27 @@ void chpl_topo_setMemLocalityByPages(unsigned char* p, size_t size,
     return;
 
   _DBG_P("hwloc_set_area_membind_nodeset(%p, %#zx, %d)\n", p, size,
-         (int) hwloc_bitmap_first(nodeset));
+         (int) hwloc_bitmap_first(numaObj->allowed_nodeset));
+
+  flags = HWLOC_MEMBIND_MIGRATE | HWLOC_MEMBIND_STRICT;
   if (hwloc_set_area_membind_nodeset(topology, p, size,
-                                     nodeset, HWLOC_MEMBIND_BIND, flags)) {
+                                     numaObj->allowed_nodeset,
+                                     HWLOC_MEMBIND_BIND, flags)) {
     report_error("hwloc_set_area_membind_nodeset()", errno);
   }
 }
 
 
 c_sublocid_t chpl_topo_getMemLocality(void* p) {
-  const int flags = HWLOC_MEMBIND_STRICT;
+  int flags;
   hwloc_nodeset_t nodeset;
-  hwloc_membind_policy_t policy;
   int node;
 
   if (!haveTopology) {
     return c_sublocid_any;
   }
 
-  if (!topoSupport->membind->get_area_membind) {
+  if (!topoSupport->membind->get_area_memlocation) {
     return c_sublocid_any;
   }
 
@@ -271,9 +380,9 @@ c_sublocid_t chpl_topo_getMemLocality(void* p) {
     report_error("hwloc_bitmap_alloc()", errno);
   }
 
-  if (hwloc_get_area_membind_nodeset(topology, p, 1,
-                                     nodeset, &policy, flags)) {
-    report_error("hwloc_get_area_membind_nodeset()", errno);
+  flags = HWLOC_MEMBIND_BYNODESET;
+  if (hwloc_get_area_memlocation(topology, p, 1, nodeset, flags)) {
+    report_error("hwloc_get_area_memlocation()", errno);
   }
 
   node = hwloc_bitmap_first(nodeset);
@@ -300,8 +409,14 @@ void report_error(const char* what, int errnum) {
 
 void chpl_topo_init(void) { }
 void chpl_topo_exit(void) { }
+int chpl_topo_getNumNumaDomains(void) { return 1; }
+void chpl_topo_setThreadLocality(c_sublocid_t subloc) { }
+c_sublocid_t chpl_topo_getThreadLocality(void) { return c_sublocid_any; }
 void chpl_topo_setMemLocality(void* p, size_t size, chpl_bool onlyInside,
-                              chpl_bool doSubchunks, c_sublocid_t subloc) { }
+                              c_sublocid_t subloc) { }
+void chpl_topo_setMemSubchunkLocality(void* p, size_t size,
+                                      chpl_bool onlyInside,
+                                      size_t* subchunkSizes) { }
 c_sublocid_t chpl_topo_getMemLocality(void* p) { return c_sublocid_any; }
 
 #endif // if defined(CHPL_HAS_HWLOC)

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -74,7 +74,7 @@ static int get_num_heaps(void) {
   return num_heaps;
 }
 
-static inline int get_heap(void) {
+static inline int get_nearby_heap(void) {
   if (get_num_heaps() == 1) {
     return 0;
   } else {
@@ -173,7 +173,7 @@ static void* chunk_alloc(void *chunk, size_t size, size_t alignment, bool *zero,
   size_t cur_heap_size;
 
   // which heap?
-  hpi = get_heap();
+  hpi = get_nearby_heap();
 
   // this function can be called concurrently and it looks like jemalloc
   // doesn't call it inside a lock, so we need to protect it ourselves

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -50,7 +50,7 @@ typedef struct shared_heap {
 static shared_heap_t heaps[MAX_HEAPS];
 static int num_heaps;
 
-chpl_bool chpl_mem_impl_allocLocalizes = false;
+bool chpl_mem_impl_allocLocalizes = false;
 
 
 // compute aligned index into our shared heap, alignment must be a power of 2

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -326,36 +326,6 @@ static void initializeSharedHeap(void) {
   useUpMemNotInHeap();
 }
 
-static void showDesiredSharedHeapLocality(c_string);
-static void showDesiredSharedHeapLocality(c_string hdr) {
-  void* heap_base;
-  size_t heap_size;
-  char* hbc;
-  size_t i;
-  size_t ps = chpl_getHeapPageSize();
-  c_sublocid_t sublocLast;
-  size_t iLast = 0;
-
-  printf("--------------------\n");
-  printf("%s\n", hdr);
-
-  chpl_comm_desired_shared_heap(&heap_base, &heap_size);
-  hbc = (char*) heap_base;
-  sublocLast = chpl_topo_getMemLocality(hbc);
-  for (i = ps; i < heap_size; i += ps) {
-    c_sublocid_t subloc = chpl_topo_getMemLocality(hbc + i);
-    if (subloc != sublocLast) {
-      if (sublocLast != c_sublocid_none)
-        printf("%p-%p %d\n", hbc + iLast, hbc + i - 1, (int) sublocLast);
-      sublocLast = subloc;
-      iLast = i;
-    }
-  }
-  printf("%p-%p %d\n", hbc + iLast, hbc + i - 1, (int) sublocLast);
-
-  printf("--------------------\n");
-}
-
 
 void chpl_mem_layerInit(void) {
   void* heap_base;
@@ -430,16 +400,6 @@ void chpl_mem_layerInit(void) {
       }
 
       chpl_mem_impl_allocLocalizes = true;
-
-      if (chpl_nodeID == 0) {
-        printf("Multiple shared heaps:\n");
-        for (hpi = 0; hpi < num_heaps; hpi++) {
-          printf("%d: base %p, size %#zx\n",
-                 hpi, heaps[hpi].base, heaps[hpi].size);
-        }
-        printf("--------------------\n");
-        showDesiredSharedHeapLocality("Shared heap locality");
-      }
     }
 
     initializeSharedHeap();

--- a/test/runtime/gbt/topo/array-loc.chpl
+++ b/test/runtime/gbt/topo/array-loc.chpl
@@ -27,7 +27,6 @@ extern proc chpl_topo_getMemLocality(p: c_ptr): chpl_sublocID_t;
 
 
 {
-
   var locality: localityCheck_t;
   if A._value.oneDData {
     locality = checkMemLocalityParts(c_ptrTo(A), A.domain.numIndices,


### PR DESCRIPTION
With comm=ugni as it's normally used, we have a fixed-size heap that is
registered with the NIC.  If the heap were not registered with the NIC
then we could (and indeed, do) re-localize allocated memory however we'd
like.  But in order for memory gotten from the registered uGNI/Aries
heap to have a specific locality it must already have that locality when
it is allocated.  The locality cannot be changed post-allocation because
NIC registration fixes the memory page virtual-to-physical relationship
and thus the NUMA locality.  The new multi-ddata feature for arrays gets
us partway to a solution, because it allows the memory for an array to
consist of separately allocated subchunks, one for each NUMA domain
sublocale.  That's necessary but not sufficient.  This is the rest of
the solution: here we split the heap itself into per-sublocale
subchunks, bind those chunks to their NUMA domains, and arrange for
tasks to allocate from the NUMA domain they are running in at the time
they call the allocator.  The calls to allocate multi-ddata chunks are
already being made from the sublocales on which we want the memory to
reside -- that code was included in the original multi-ddata work.  With
this change, the allocated memory will actually have that locality.

Here, in the jemalloc memory layer, we block-localize the subchunks of
the comm layer desired shared heap across the NUMA sublocales and then
manage each subchunk as a separate sub-heap.  Jemalloc maintains a fixed
number of arenas (a small multiple of the number of processor cores).
Each pthread has a particular arena bound to it.  With a tasking layer
such as qthreads which has one worker pthread per core or hyperthread
(depending on circumstances) and thus fewer pthreads than arenas, each
pthread will essentially end up with a private arena.  When we extend an
arena we get the memory for that from the sub-heap the thread is running
on, so a thread's arena will consist entirely of memory localized to the
NUMA domain Qthreads has bound the thread to, and tasks running on that
worker will always allocate memory bound to that domain.

For free() we don't have to do anything special, since jemalloc
internally arranges to free memory back to the same arena from which it
was allocated.

Most of the work here is in mem-jemalloc and most of that is to support          
multiple heaps (at most 4, currently) instead of just 1.  Once we know           
we have a desired shared heap from the comm layer, if we have multiple           
NUMA domains (it's too early to ask the tasking layer about this so we           
ask the topology layer), we call the topology layer to block-localize            
that heap, and then manage the localized blocks as our arenas.  (For             
reasons that are not entirely clear at this point we still have to touch         
the pages of these blocks while running on the appropriate NUMA domains          
to get the actual memory localized, so that is also done at this time.           
We'll look further into why this is needed later.)                               
                                                                                 
In the topology layer, there are new functions to get and set execution
locality.  And, what used to be a single function to localize either the
whole of an area of memory of its subchunks has been turned into two
functions that do specifically those tasks, with common code factored
out into helpers.  There are also some changes for the sake of clarity,
such as moving flag settings closer to where they are used.

Finally, at the top surface of the memory layer interface in chpl-mem.h,
we now localize memory after allocation only if the allocator does not
return already-localized memory and the allocation is large enough that
it seems like localizing would help performance.  This threshold is
currently 2 pages times the number of sublocales.  For now, jemalloc is
the only memory layer that can allocate localized memory directly, and
then only when the comm layer provides the desired shared heap.
