### PR TITLE
Fix BLAS.trsv test 

### DIFF
--- a/test/modules/packages/blas/blas_helpers.chpl
+++ b/test/modules/packages/blas/blas_helpers.chpl
@@ -158,9 +158,7 @@ proc bandArrayTriangular(A: [?Dom] ?eltType, k, uplo=Uplo.Upper, order=Order.Row
   where A.rank == 2 {
 
   // Must be square matrix
-
-  if !isSquare(A) then
-    halt('non-square array passed to bandArrayTriangular. Aborting');
+  assert(Dom.dim(1).size == Dom.dim(2).size);
 
   // Matrix order
   const n = Dom.dim(1).size;

--- a/test/modules/packages/blas/blas_helpers.chpl
+++ b/test/modules/packages/blas/blas_helpers.chpl
@@ -3,9 +3,9 @@
 use Random;
 use BLAS;
 
+// TODO -- compute these thresholds in a principled way
 config const errorThresholdDouble = 1.e-10;
-// note: sporadically failures occur with 1.e-5
-config const errorThresholdSingle = 1.e-4;
+config const errorThresholdSingle = 1.e-3;
 
 proc printErrors(name: string, passed, failed, tests) {
   writef("%5s : %i PASSED, %i FAILED\n".format(name, passed, failed));

--- a/test/modules/packages/blas/blas_helpers.chpl
+++ b/test/modules/packages/blas/blas_helpers.chpl
@@ -3,7 +3,6 @@
 use Random;
 use BLAS;
 
-// TODO -- compute these thresholds in a principled way
 config const errorThresholdDouble = 1.e-10;
 config const errorThresholdSingle = 1.e-5;
 
@@ -243,12 +242,12 @@ proc determinant(A: [?Adom] ?eltType, i=0): eltType {
     halt('non-square array passed to determinant. Aborting');
 
   const n = Adom.dim(1).size;
-
   if n == 1 then return A[0, 0];
 
   var d = 0: eltType;
   for j in 0..#n do
     d += (((-1)**(i+j))*(A[i,j])*determinant(minor(i, j, A))): eltType;
+
   return d;
 
 }
@@ -259,28 +258,23 @@ proc minor(i, j, A: [?Adom] ?eltType) {
   if (i >= n || j >= n) then
     halt('Out of bounds index passed to minor()');
 
-
   var a : [0..#n-1, 0..#n-1] eltType;
   var K = 0,
       L = 0;
 
   for k in 0..#n {
     for l in 0..#n  {
-
       // K
       if k == i || l == j then continue;
       if k < i then K = k;
       else K = k-1;
-
       // L
       if l < j then L = l;
       else L = l-1;
-
       // a[K, L]
       a[K,L] = A[k,l];
     }
   }
-
   return a;
 }
 
@@ -290,11 +284,13 @@ proc isSquare(A: [?Adom]) {
   return m == n;
 }
 
-/* Make A a random non-singular matrix, currently just uses I */
+/* Make A a random non-singular matrix, currently just uses I
+   TODO - generate a truly random non-singular matrix */
 proc makeRandomNonSingularRandom(ref A: [] ?t) {
-  // TODO -- Actually generate a random matrix...
+  // Use identity matrix
+  makeUnit(A);
 
-  // This takes too long..
+  // This takes too long...
   /*
     const errorThreshold = blasError(t);
     var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
@@ -304,11 +300,4 @@ proc makeRandomNonSingularRandom(ref A: [] ?t) {
       d = determinant(A);
     }
   */
-
-  // Hack -- just use an identity matrix (works for now)
-  for (i, j) in A.domain {
-    if i != j then A[i,j] = 0: t;
-    else A[i, j] = 1: t;
-  }
-
 }

--- a/test/modules/packages/blas/test_blas2.chpl
+++ b/test/modules/packages/blas/test_blas2.chpl
@@ -1552,7 +1552,7 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    rng.fillRandom(A);
+    makeRandomNonSingularRandom(A);
     rng.fillRandom(X);
 
     // Make A a triangular matrix
@@ -1581,7 +1581,7 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    rng.fillRandom(A);
+    makeRandomNonSingularRandom(A);
     rng.fillRandom(X);
 
     // Make A a triangular matrix
@@ -1610,7 +1610,7 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    rng.fillRandom(A);
+    makeRandomNonSingularRandom(A);
     rng.fillRandom(X);
 
     // Make A a triangular matrix
@@ -1639,7 +1639,7 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    rng.fillRandom(A);
+    makeRandomNonSingularRandom(A);
     rng.fillRandom(X);
 
     // Make A a triangular matrix
@@ -1672,7 +1672,7 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    rng.fillRandom(A);
+    makeRandomNonSingularRandom(A[.., 0..#m]);
     rng.fillRandom(X);
 
     // Make A a triangular matrix

--- a/test/modules/packages/blas/test_blas2.chpl
+++ b/test/modules/packages/blas/test_blas2.chpl
@@ -1552,7 +1552,7 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    makeRandomNonSingularRandom(A);
+    makeRandomInvertible(A);
     rng.fillRandom(X);
 
     // Make A a triangular matrix
@@ -1581,7 +1581,7 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    makeRandomNonSingularRandom(A);
+    makeRandomInvertible(A);
     rng.fillRandom(X);
 
     // Make A a triangular matrix
@@ -1610,7 +1610,7 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    makeRandomNonSingularRandom(A);
+    makeRandomInvertible(A);
     rng.fillRandom(X);
 
     // Make A a triangular matrix
@@ -1639,11 +1639,12 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    makeRandomNonSingularRandom(A);
+    makeRandomInvertible(A);
     rng.fillRandom(X);
 
     // Make A a triangular matrix
     zeroTri(A);
+
     // Make A unit triangular
     for (i, j) in A.domain do
       if i == j then A[i, j] = 1 :t;
@@ -1672,7 +1673,7 @@ proc test_trsv_helper(type t){
         R : [X.domain] t; // Result
 
 
-    makeRandomNonSingularRandom(A[.., 0..#m]);
+    makeRandomInvertible(A[.., 0..#m]);
     rng.fillRandom(X);
 
     // Make A a triangular matrix


### PR DESCRIPTION
The test for `BLAS.trsv`, which solves `A*x = b` for `x`, did not check non-singularity on the randomly generated input matrix, resulting in sporadic failures whenever near-singular matrices were generated. 

This PR resolves this issue by generating a random invertible matrix with the following formula:

```
(1/n**2)*A**2 + I
```
where `A` is a randomly generated matrix, `n` is dimension of `A`, and `I` is the identity matrix.

I've also returned the `errorThresholdSingle` to it's original value of `1.e-5`, since we originally bumped it to `1.e-4` to overcome this specific sporadic failure.

- [X] Tested on OS X + netlib
  - Ran `test_blas*` 1000 times, to confirm sporadic failure is eliminated.