### PR TITLE
Skip this test in NUMA configs

### DIFF
--- a/test/functions/ferguson/ref-pair/const-error-iterated.skipif
+++ b/test/functions/ferguson/ref-pair/const-error-iterated.skipif
@@ -1,0 +1,2 @@
+# Skip for NUMA since the error message is slightly different
+CHPL_LOCALE_MODEL == numa


### PR DESCRIPTION
The test
   test/functions/ferguson/ref-pair/const-error-iterated.chpl

was failing in NUMA configurations.

Thanks to @benharsh for pointing out the issue.

Since the error message from the compiler differs trivially in NUMA configs, just skip it there so we don't have to maintain another version of the .good file.