### PR TITLE
Fix flaws in #5689 pointed out by smoke testing.

### DIFF
--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -238,7 +238,7 @@ void chpl_mem_layerFree(void*, int32_t lineno, int32_t filename);
 #endif
 
 static inline
-bool chpl_mem_alloc_localizes(void) {
+chpl_bool chpl_mem_alloc_localizes(void) {
   return CHPL_MEM_IMPL_ALLOC_LOCALIZES();
 }
 

--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -26,6 +26,7 @@
 #include "chpl-mem-no-warning-macros.h"
 #include "jemalloc.h"
 #include "chpl-mem-warning-macros.h"
+#include "chpltypes.h"
 
 #define MALLOCX_NO_FLAGS 0
 
@@ -60,7 +61,7 @@ static inline size_t chpl_good_alloc_size(size_t minSize) {
 }
 
 
-bool chpl_mem_impl_alloc_localizes(void);
+chpl_bool chpl_mem_impl_alloc_localizes(void);
 
 #define CHPL_MEM_IMPL_ALLOC_LOCALIZES() chpl_mem_impl_alloc_localizes()
 

--- a/runtime/src/chpl-topo.c
+++ b/runtime/src/chpl-topo.c
@@ -215,8 +215,11 @@ c_sublocid_t chpl_topo_getThreadLocality(void) {
     return c_sublocid_any;
   }
 
-  if ((cpuset = hwloc_bitmap_alloc()) == NULL
-      || (nodeset = hwloc_bitmap_alloc()) == NULL) {
+  if ((cpuset = hwloc_bitmap_alloc()) == NULL) {
+    report_error("hwloc_bitmap_alloc()", errno);
+  }
+
+  if ((nodeset = hwloc_bitmap_alloc()) == NULL) {
     report_error("hwloc_bitmap_alloc()", errno);
   }
 

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -461,7 +461,7 @@ void chpl_mem_layerExit(void) {
 }
 
 
-bool chpl_mem_impl_alloc_localizes(void) {
+chpl_bool chpl_mem_impl_alloc_localizes(void) {
   //
   // For now, we only NUMA-localize the comm layer desired shared heap
   // if we're using the ugni comm layer.  ugni is the simpler case


### PR DESCRIPTION
The bool type seems to be available where I used it only on some
platforms, not all.

On Mac, clang reports a spurious use without def because it can't tell
that report_error() will halt the program.