### PR TITLE
Switch array view perf playground over to my new branch

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -11,7 +11,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
 # Test performance of array-views branch
 GITHUB_USER=bradcray
-GITHUB_BRANCH=arrayViewAllThree
+GITHUB_BRANCH=rankChangeDomDistView
 SHORT_NAME=arrView
 START_DATE=02/06/17
 


### PR DESCRIPTION
This will see whether the new locality-preserving rank change domains
will hurt performance for local testing (they're definitely higher
overhead to set up).