### PR TITLE
Whitespace changes to initializer rules

### DIFF
--- a/compiler/include/initializerRules.h
+++ b/compiler/include/initializerRules.h
@@ -20,10 +20,10 @@
 #ifndef _INITIALIZER_RULES_H_
 #define _INITIALIZER_RULES_H_
 
-class FnSymbol;
 class AggregateType;
+class FnSymbol;
 
-void handleInitializerRules(FnSymbol* fn, AggregateType* t);
-FnSymbol* buildClassAllocator(FnSymbol* initMethod, AggregateType* ct);
+void      initMethodPreNormalize(FnSymbol* fn);
+FnSymbol* buildClassAllocator(FnSymbol* initMethod);
 
 #endif

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2491,12 +2491,10 @@ static void updateConstructor(FnSymbol* fn) {
 }
 
 static void updateInitMethod(FnSymbol* fn) {
-  Symbol* _this = fn->getFormal(2);
+  if (isAggregateType(fn->_this->type) == true) {
+    initMethodPreNormalize(fn);
 
-  if (AggregateType* ct = toAggregateType(_this->type)) {
-    handleInitializerRules(fn, ct);
-
-  } else if (_this->type == dtUnknown) {
+  } else if (fn->_this->type == dtUnknown) {
     INT_FATAL(fn, "'this' argument has unknown type");
 
   } else {

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -513,12 +513,10 @@ void resolveMatch(FnSymbol* fn) {
 
   resolveBlockStmt(fn->body);
 
-  if (wasGeneric) {
-    if (isClass(fn->_this->type) == true) {
-      FnSymbol* classAlloc = buildClassAllocator(fn,
-                                                 toAggregateType(fn->_this->type));
-      normalize(classAlloc);
-    }
+  if (wasGeneric == true && isClass(fn->_this->type) == true) {
+    FnSymbol* classAlloc = buildClassAllocator(fn);
+
+    normalize(classAlloc);
   }
 
   if (tryFailure) {


### PR DESCRIPTION
This is a simple merge of a few "whitespace" changes I have collected as I begin to work on the
issues with initializing class/record fields within initializer methods.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed start_test on classes/initializers -futures and a single-locale paratest
