### PR TITLE
Fix dynamic linking for gasnet-aries

### DIFF
--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -81,7 +81,7 @@ export PE_CHAPEL_PKGCONFIG_LIBS := cray-pmi:cray-ugni:$(PE_CHAPEL_PKGCONFIG_LIBS
 endif
 ifeq ($(CHPL_MAKE_COMM), gasnet)
 ifneq (,$(filter $(CHPL_MAKE_COMM_SUBSTRATE),gemini aries))
-export PE_CHAPEL_PKGCONFIG_LIBS := cray-pmi:cray-ugni:$(PE_CHAPEL_PKGCONFIG_LIBS)
+export PE_CHAPEL_PKGCONFIG_LIBS := cray-pmi:cray-udreg:cray-ugni:$(PE_CHAPEL_PKGCONFIG_LIBS)
 endif
 endif
 


### PR DESCRIPTION
Fix dynamic linking for gasnet-aries by linking in udreg. #3541 fixed dynamic
linking for cray PrgEnvs by telling the cc driver that comm gasnet-aries and
ugni require cray-pmi and cray-ugni. This commit is similar, but now we also
require cray-udreg for gasnet-aries. GASNet 1.26.2 added support for using
udreg, so we need to make sure we link it in.

From the 1.26.2 release notes:
     "Use Cray's UDREG library to ammortize cost of dynamic registration"

This has been a bug for almost a year (#3921), but since we don't have
--dynamic testing on crays, we missed this. We should really add some testing
for this configuration: https://github.com/chapel-lang/chapel/issues/5675

@dmk42 discovered this while trying to test the module with KNL while memkind
was loaded (memkind forces dynamic linking.) Note that this only seems to be an
issue under CLE6, when chapel was built on CLE5 (like with the module.) I can
reproduce this by building on CLE5 and compiling on CLE6.