### PR TITLE
Continue to update initializer rules

### DIFF
--- a/test/classes/initializers/records/generics/omittedGenerics2.future
+++ b/test/classes/initializers/records/generics/omittedGenerics2.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.


### PR DESCRIPTION
The inheritance story for records remain ill-defined.  This has been taken to imply that it is
unclear what it means to invoke super.init() in a record initializer.  And yet record initializers
may want to use super.init() in order to correctly "initialize" certain fields in phase1 as opposed
to allowing the compiler to inject default initializers and then have the user's code perform assigns.

We'd like a record-author to be able to insert a use of super.init() but it cannot currently survive
past normalize.

This PR

1) Refactors the code used to determine when a stmt is a pre-normalize form of this.init() or
super.init() to make it more readable and to provide an additional entry point

2) Uses this refactoring to delete any user-defined calls to super.init() after phase1/phase2
analysis.

3) Retires a future.


The PR is reasonably straight-forward and has only limited impacts on the pre-normalize
updates to initialize methods.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed start_test classes/initializers -futures and single-locale paratest
