### PR TITLE
Remove an obsolete .bad file

### DIFF
--- a/test/types/records/ferguson/copy-init/new-init-generic.bad
+++ b/test/types/records/ferguson/copy-init/new-init-generic.bad
@@ -1,2 +1,0 @@
-new-init-generic.chpl:6: In initializer:
-new-init-generic.chpl:9: error: 'super' undeclared (first use this function)


### PR DESCRIPTION
The recent fix for super.init() in record initializers has complicated the failure mode for this
future.  As a quick fix, drop the .bad file.
