### PR TITLE
Improve inferConstRefs' canRHSBeConstRef helper function

### DIFF
--- a/compiler/optimizations/inferConstRefs.cpp
+++ b/compiler/optimizations/inferConstRefs.cpp
@@ -317,9 +317,7 @@ static bool canRHSBeConstRef(CallExpr* parent, SymExpr* use) {
       // Note that the get-*-value primitives may return a reference if the
       // field is a reference.
       if (LHS->isRef()) {
-        if (!inferConstRef(LHS->symbol())) {
-          return false;
-        }
+        return inferConstRef(LHS->symbol());
       }
     }
     default:


### PR DESCRIPTION
This helper function would look at a certain set of primitives on the
RHS of a move/assign and determine if the LHS was const-ref. If so, then
the RHS use could also be const-ref.

However, we were only returning in this case if we knew the LHS was not
const-ref, then dropping into the default case where we would check if
the RHS was used in a 'safe' primitive. Generally, though, the first set
of primitives are not considered 'safe', and we would return false even
though the LHS was indeed const-ref.

To fix this, always return the result of inferConstRef(LHS) for the
initial set of primitives.

Testing:
- [x] full local
- [x] full gasnet
- [x] dist-cyclic
- [x] dist-replicated for distributions/robust/arithmetic/performance/multilocale/assign