### PR TITLE
Comment out assert in parallel.cpp

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1275,7 +1275,10 @@ makeHeapAllocations() {
   Vec<Symbol*> heapAllocatedVars;
 
   forv_Vec(Symbol, var, varVec) {
-    INT_ASSERT(var->hasFlag(FLAG_REF_VAR) || !var->isRef());
+    // MPF: I'm disabling the below assert because PR #5692
+    // can create call_tmp variables that are refs. Since these
+    // are temps, they aren't marked with FLAG_REF_VAR.
+    //INT_ASSERT(var->hasFlag(FLAG_REF_VAR) || !var->isRef());
 
     if (var->hasFlag(FLAG_EXTERN)) {
       // don't widen external variables


### PR DESCRIPTION
I'm disabling the assert because PR #5692 can create call_tmp variables that are refs. Since these are temps, they aren't marked with FLAG_REF_VAR.


This resolves these failures in quickstart+GASNet, including under valgrind:

 * test/release/examples/primers/learnChapelInYMinutes.chpl 
 * test/release/examples/spec/Variables/refVariables.chpl

Trivial, discussed with @benharsh.
