### PR TITLE
alternative of 'lvalue' in error messages #5068

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5052,7 +5052,7 @@ void lvalueCheck(CallExpr* call)
                          " using the default assignment operator"
                          " because it has 'const' field(s)", recordName);
         else
-          USR_FATAL_CONT(actual, "illegal lvalue in assignment");
+          USR_FATAL_CONT(actual, "illegal assignment");
       }
       else
       {


### PR DESCRIPTION
If finding the alternative for original 'lvalue' statement was the only purpose of #5068 , I guess we need to come up with more relevant names.