### PR TITLE
Linear Algebra module

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -103,6 +103,7 @@ PACKAGES_TO_DOCUMENT = \
 	packages/HDFS.chpl \
 	packages/HDFSiterator.chpl \
 	packages/LAPACK.chpl \
+	packages/LinearAlgebra.chpl \
 	packages/MPI.chpl \
 	packages/Norm.chpl \
 	packages/RangeChunk.chpl \

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -189,6 +189,10 @@ module BLAS {
     require "cblas.h";
   }
 
+  /* Return `true` if type is supported by BLAS */
+  proc isBLASType(type t) param: bool{
+    return isRealType(t) || isComplexType(t);
+  }
 
   /* Define row or column order */
   enum Order {Row=101: c_int, Col};
@@ -2343,7 +2347,7 @@ module BLAS {
   //
 
   pragma "no doc"
-  private inline proc getLeadingDim(A: [?Adom], order : Order) : c_int {
+  inline proc getLeadingDim(A: [?Adom], order : Order) : c_int {
     if order==Order.Row then
       return Adom.dim(2).size : c_int;
     else
@@ -2351,7 +2355,7 @@ module BLAS {
   }
 
   pragma "no doc"
-  private inline proc getLeadingDim(Arr: [], order : Order) : c_int
+  inline proc getLeadingDim(Arr: [], order : Order) : c_int
   where chpl__isArrayView(Arr)
   {
     const dims = chpl__getActualArray(Arr).dom.dsiDims();

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -22,7 +22,8 @@
 A high-level interface to linear algebra operations and procedures.
 
 .. note::
-  This is
+  This is an early prototype package module. As a result, interfaces may change
+  over the next release.
 
 Compiling with Linear Algebra
 -----------------------------
@@ -32,8 +33,6 @@ many routines. In order to compile a Chapel program with this module, be sure
 to have BLAS and LAPACK implementations available on your system. See the BLAS
 and LAPACK documentation for further details.
 
-.. comment:
-  - native implementations some day
 
 Linear Algebra API
 ------------------
@@ -81,37 +80,62 @@ An outer product can be computed with the :proc:`outer` function.
 
 **Promotion flattening**
 
-``TODO``
+Promotion flattening is an unintended consequence of Chapel's
+:ref:`promotion feature <ug-promotion>`, when a multi-dimensional array assignment
+gets type-inferred as a 1-dimensional array of the same size, effectively
+flattening the array dimensionality. This can result in unexpected behavior in
+programs such as this:
 
-Discuss promotion flattening, and how to get around it, providing examples
-and helper functions like :proc:`matPlus`.
+.. code-block:: chapel
 
-.. note::
-    Promotion flattening is not an intended feature, and should be resolved in
-    future releases of Chapel.
+  var A = Matrix(4, 4),
+      B = Matrix(4, 4);
+  // A + B is a promoted operation, and C becomes a 1D array
+  var C = A + B;
+  // This code would then result in an error due to rank mismatch:
+  C += A;
 
-.. Examples:
+To get avoid this, you can avoid relying on inferred-types for new arrays:
 
-.. Features:
+.. code-block:: chapel
 
-.. Future directions:
+  var A = Matrix(4, 4),
+      B = Matrix(4, 4);
+  // C's type is not inferred and promotion flattening is not a problem
+  var C: [A.domain] A.eltType = A + B;
+  // Works as expected
+  C += A;
+
+Alternatively, you can use the LinearAlgebra helper routines, which create
+and return a new array:
+
+.. code-block:: chapel
+
+  var A = Matrix(4, 4),
+      B = Matrix(4, 4);
+  // matPlus will create a new array with an explicit type
+  var C = matPlus(A, B);
+  // Works as expected
+  C += A;
+
+Promotion flattening is not expected to be an issue in future releases.
+
+
+.. LinearAlgebra Module Future TODOs:
+  - Support non-matching domains and eltTypes in matOperations
+    - check that eltTypes are coercible
+    - check domain shapes are equal
+  - Add LinearAlgebra primer
+  - Add feature table, comparing to numpy and matlab
+  - performance testing
   - Domain maps
     - Distributed array support
-      - PBLAS
     - Sparse support
-      - suiteSparse
     - GPU support
-      - CuBLAS
   - Support fully native implementations
     - Only use the BLAS/LAPACK version when the libraries are installed
   - Provide MKL BLAS/LAPACK with Chapel installation
     - install with something like: CHPL_EXTRAS=MKL
-
-.. LinearAlgebra Module TODOs
-  - Support non-matching domains and eltTypes in matOperations
-    - check that eltTypes are coercible
-    - check domain shapes are equal
-  - performance testing
 
 */
 

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -531,22 +531,6 @@ proc matPow(a, B: [?Bdom] ?eltType) where isNumeric(a) {
 }
 
 
-// TODO -- matrix-exponential
-/* Return element-wise exponential: ``e**A[i,j]`` */
-proc matExp(A: [?Dom] ?eltType) {
-  var B: [Dom] eltType = e**A;
-  return B;
-}
-
-
-pragma "no doc"
-/* Integer overload */
-proc matExp(A: [?Dom] ?eltType) where isIntegralType(eltType) {
-  var B: [Dom] real = e**A;
-  return B;
-}
-
-
 /* Return cross-product of 3-element vectors ``A`` and ``B`` with domain of
   ``A`` */
 proc cross(A: [?Adom] ?eltType, B: [?Bdom] eltType) {

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1,0 +1,690 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* TODO
+    - implementations
+    - testing
+    - documentation
+      - document types
+    - performance testing
+*/
+
+/* Linear Algebra Module
+
+A high-level interface to linear algebra operations and procedures.
+
+.. note::
+  This is
+
+Compiling with Linear Algebra
+-----------------------------
+
+The linear algebra module uses both `BLAS` and `LAPACK` for
+many routines. In order to compile a Chapel program with this module, be sure
+to have BLAS and LAPACK implementations available on your system. See the BLAS
+and LAPACK documentation for further details.
+
+.. comment:
+  - native implementations some day
+
+Linear Algebra API
+------------------
+
+**Matrix and Vector representation**
+
+Matrices and vectors are represented as Chapel arrays, which means the
+convenience constructors provided in this module are not necessary to use this
+module's functions. This also means that matrices (2D arrays) and vectors (1D
+arrays) will work with any other Chapel library works with arrays.
+
+.. note::
+
+  This documentation uses the terms `matrix` to refer to `2D arrays`, and
+  `vector` to refer to `1D arrays`.
+
+**Indexing**
+
+All functions that return new arrays will return arrays over 0-based indices,
+unless otherwise specified.
+
+**Matrix multiplication**
+
+``dot()`` is the general matrix multiplication function provided in this module.
+This function supports any combination of scalars, vectors (1D arrays), and
+matrices (2D arrays). See the :proc:`dot` documentation for more information.
+
+If you find this convenient notation confusing, you can opt to calling the
+underlying functions: :proc:`matMult` and `inner`.
+
+The :proc:`dot` function, along with others may be given a matrix-specific
+operator in future releases.
+
+.. comment:
+  It is also less verbose than matrixMultiply, matMult, or mMult.
+
+**Row vs Column vectors**
+
+Row and column vectors are both represented as 1D arrays and are
+indistinguishable in Chapel. In the :proc:`dot` function, matrix-vector
+multiplication assumes a column vector, vector-matrix multiplcation assumes a
+row vector, vector-vector multiplication is always treated as an inner-product,
+as the function name implies.
+An outer product can be computed with the :proc:`outer` function.
+
+**Promotion flattening**
+
+``TODO``
+
+Discuss promotion flattening, and how to get around it, providing examples
+and helper functions like :proc:`matPlus`.
+
+.. note::
+    Promotion flattening is not an intended feature, and should be resolved in
+    future releases of Chapel.
+
+.. Examples:
+
+.. Features:
+
+.. Future directions:
+  - Domain maps
+    - Distributed array support
+      - PBLAS
+    - Sparse support
+      - suiteSparse
+    - GPU support
+      - CuBLAS
+  - Support fully native implementations
+    - Only use the BLAS/LAPACK version when the libraries are installed
+  - Provide MKL BLAS/LAPACK with Chapel installation
+    - install with something like: CHPL_EXTRAS=MKL
+
+.. Reviewer Notes:
+ - naming scheme OK?
+ - Should we support the promotion-helpers?
+    - matPlus, matMinus
+ - Should we provide matMult, or just dot?
+  - dot as a method?
+
+.. LinearAlgebra Module TODOs
+  - Support non-matching domains and eltTypes in matOperations
+    - check that eltTypes are coercible
+    - check domain shapes are equal
+*/
+
+module LinearAlgebra {
+
+ use Norm; // TODO -- merge Norm into LinearAlgebra
+ use BLAS;
+// use LAPACK; // TODO -- Use LAPACK routines
+
+
+//
+// Matrix and Vector Initializers
+//
+
+/* Return a vector (1D array) over domain ``{0..#length}``*/
+proc Vector(length, type eltType=real) {
+  var V: [0..#length] eltType;
+  return V;
+}
+
+
+/* Return a vector (1D array) over domain ``Dom`` */
+proc Vector(Dom: domain(1), type eltType=real) {
+  var V: [Dom] eltType;
+  return V;
+}
+
+
+/* Return a vector (1D array) with domain and values of ``A`` */
+proc Vector(A: [?Dom] ?Atype, type eltType=Atype ) {
+  var V: [Dom] eltType = A;
+  return V;
+}
+
+
+pragma "no doc"
+proc Vector(x: ?t, Scalars...?n)  where isNumericType(t) {
+  type eltType = Scalars(1).type;
+  return Vector((...Scalars), eltType=eltType);
+}
+
+
+/* Return a vector (1D array), given 2 or more numeric values
+
+   If `type` is omitted, it will be inferred from the first argument
+*/
+proc Vector(x: ?t, Scalars...?n, type eltType) where isNumericType(t) {
+
+  if !isNumeric(Scalars(1)) then
+      compilerError("Vector() expected numeric arguments");
+
+  var V: [0..n] eltType;
+
+  V[0] = x: eltType;
+
+  for i in 1..n do V[i] = Scalars[i]: eltType;
+
+  return V;
+}
+
+
+/* Return a matrix (2D array) over domain ``{0..#rows, 0..#cols}``*/
+proc Matrix(rows, cols, type eltType=real) where isIntegral(rows) && isIntegral(cols) {
+  var M: [0..#rows, 0..#cols] eltType;
+  return M;
+}
+
+
+/* Return a matrix (2D array) over domain ``Dom`` */
+proc Matrix(Dom, type eltType=real) where Dom.rank == 2 {
+  var M: [Dom] eltType;
+  return M;
+}
+
+
+/* Return a matrix (2D array) with domain and values of ``A`` */
+proc Matrix(A: [?Dom] ?eltType) where Dom.rank == 2 {
+  var M: [Dom] eltType = A;
+  return M;
+}
+
+
+pragma "no doc"
+proc Matrix(Arrays...?n) {
+  type eltType = Arrays(1).eltType;
+  return Matrix((...Arrays), eltType=eltType);
+}
+
+
+/*
+    Return a matrix (2D array), given 2 or more vectors. Vectors are
+    concatenated such that the ``ith`` vector corresponds to the matrix slice:
+    ``A[i, ..]``
+
+    If `type` is omitted, it will be inferred from the first argument
+*/
+proc Matrix(Arrays...?n, type eltType) {
+  // TODO -- assert all array domains are same length
+  //         Can this be done via type query?
+
+  if Arrays(1).domain.rank != 1 then compilerError("Matrix() expected 1D arrays");
+
+  const dim2 = 0..#Arrays(1).domain.dim(1).length,
+        dim1 = 0..#n;
+
+  var M: [{dim1, dim2}] eltType;
+
+  for i in dim1 do
+    M[i, ..] = Arrays(i+1)[..]: eltType;
+
+  return M;
+}
+
+
+/* Return an identity matrix over domain ``{0..#m, 0..#n}`` */
+proc eye(m, n, type eltType=real) {
+  var A: [{0..#m, 0..#n}] eltType;
+  const diagonal = min(m, n);
+  for i in 0..#diagonal do A[i, i] = 1: eltType;
+  return A;
+}
+
+
+/* Return an identity matrix over domain ``Dom`` */
+proc eye(Dom: domain(2), type eltType=real) {
+  var A: [Dom] eltType;
+  const diagonal = min(Dom.shape(1), Dom.shape(2));
+  return eye(Dom.shape(1), Dom.shape(2), eltType=eltType);
+}
+
+
+//
+// Matrix Operations
+//
+
+pragma "no doc"
+/* Transpose vector (no-op) */
+inline proc transpose(A: [?Dom]) where Dom.rank == 1 {
+  return A;
+}
+
+
+pragma "no doc"
+/* Syntactic sugar for transpose(Vector) */
+proc _array.T where this.domain.rank == 1 { return transpose(this); }
+
+
+/* Transpose vector or matrix.
+
+   .. note::
+
+      Since row vectors and columns vectors are indistinguishable, passing
+      a vector to this function will return that vector unchanged
+
+*/
+proc transpose(A: [?Dom] ?eltType) where Dom.rank == 2 {
+  if isIntegralType(eltType) then return _transpose(A);
+  else {
+    var B: [Dom] eltType = eye(Dom, eltType=eltType);
+    var C: [{Dom.dim(2), Dom.dim(1)}] eltType;
+    // TODO -- more efficient algorithm (BLAS not necessary)
+    gemm(A, B, C, 1:eltType, 0:eltType, opA=Op.T);
+    return C;
+  }
+}
+
+
+/* Transpose vector or matrix */
+proc _array.T where this.domain.rank == 2 { return transpose(this); }
+
+
+/* Transpose matrix with native implementation */
+pragma "no doc"
+private proc _transpose(A: [?Dom] ?eltType) {
+  var C: [{Dom.dim(2), Dom.dim(1)}] eltType;
+
+  // naive algorithm
+  forall (i, j) in Dom do
+    C[j, i] = A[i, j];
+
+  return C;
+}
+
+
+/* Add matrices, maintaining dimensions */
+proc matPlus(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
+  if Adom.size != Bdom.size then halt('Unmatched array size');
+  var C: [Adom] eltType = A + B;
+  return C;
+}
+
+
+/* Subtract matrices, maintaining dimensions */
+proc matMinus(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
+  if Adom.size != Bdom.size then halt('Unmatched array size');
+  var C: [Adom] eltType = A - B;
+  return C;
+}
+
+/*
+    Generic matrix multiplication, ``A`` and ``B`` can be a matrix, vector, or
+    scalar
+*/
+proc dot(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
+  // vector-vector
+  if Adom.rank == 1 && Bdom.rank == 1 then
+    return inner(A, B);
+  // matrix-(vector|matrix)
+  else
+    return matMult(A, B);
+}
+
+
+pragma "no doc"
+/* Element-wise scalar multiplication */
+proc dot(A: [?Adom] ?eltType, b) where isNumeric(b) {
+  var C: [Adom] eltType = A*b;
+}
+
+
+pragma "no doc"
+/* Element-wise scalar multiplication */
+proc dot(a, B: []) where isNumeric(a) {
+  return dot(B, a);
+}
+
+
+pragma "no doc"
+/* Explicit matrix-(matrix|vector) multiplication */
+proc matMult(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
+  // matrix-vector
+  if Adom.rank == 2 && Bdom.rank == 1 then
+    // TODO -- assert shapes are correct
+    return _matvecMult(A, B);
+  // vector-matrix
+  else if Adom.rank == 1 && Bdom.rank == 2 then
+    // TODO -- assert shapes are correct
+    return _matvecMult(B, A);
+  // matrix-matrix
+  else if Adom.rank == 2 && Bdom.rank == 2 then
+    // TODO -- assert shapes are correct
+    return _matmatMult(A, B);
+  else
+    compilerError("Rank sizes are not 1 or 2");
+}
+
+
+pragma "no doc"
+/* matrix-vector multiplication */
+proc _matvecMult(A: [?Adom] ?eltType, X: [?Xdom] eltType)
+  where isBLASType(eltType)
+{
+  if Adom.rank != 2 || Xdom.rank != 1 then
+    compilerError("Rank sizes are not 2 and 1");
+
+  var Y: [Xdom] eltType;
+  gemv(A, X, Y, 1:eltType, 0:eltType);
+  return Y;
+}
+
+
+pragma "no doc"
+/* matrix-matrix multiplication */
+proc _matmatMult(A: [?Adom] ?eltType, B: [?Bdom] eltType)
+  where isBLASType(eltType)
+{
+  if Adom.rank != 2 || Bdom.rank != 2 then
+    compilerError("Rank sizes are not 2");
+
+  var C: [Adom.dim(1), Bdom.dim(2)] eltType;
+  gemm(A, B, C, 1:eltType, 0:eltType);
+  return C;
+}
+
+
+/* Inner product of 2 vectors */
+proc inner(A: [?Adom], B: [?Bdom]) {
+  if Adom.rank != 1 || Bdom.rank != 1 then
+    compilerError("Rank sizes are not 1");
+
+  return + reduce(A[..], B[..]);
+}
+
+
+/* Outer product of 2 vectors */
+proc outer(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
+  if Adom.rank != 1 || Bdom.rank != 1 then
+    compilerError("Rank sizes are not 1");
+
+  var C: eltType [Adom.dim(1), Bdom.dim(2)];
+  forall (i,j) in C.domain do
+    C[i, j] = A[i]*B[j];
+}
+
+
+pragma "no doc"
+/* Generic matrix-vector multiplication */
+proc _matvecMult(A: [?Adom] ?eltType, X: [?Xdom] eltType)
+  where !isBLASType(eltType)
+{
+  if Adom.rank != 2 || Xdom.rank != 1 then
+    compilerError("Rank sizes are not 2 and 1");
+
+  var C: [Xdom] eltType;
+
+  // naive algorithm
+  forall i in Xdom do
+    C[i] = + reduce (A[i,..]*X[..]);
+
+  return C;
+}
+
+pragma "no doc"
+/* Generic matrix-matrix multiplication */
+proc _matmatMult(A: [?Adom] ?eltType, B: [?Bdom] eltType)
+  where !isBLASType(eltType)
+{
+  if Adom.rank != 2 || Bdom.rank != 2 then
+    compilerError("Rank sizes are not 2 and 1");
+
+  var C: [Adom.dim(1), Bdom.dim(2)] eltType;
+
+  // naive algorithm
+  forall (i,j) in C.domain do
+    C[i,j] = + reduce (A[i,..]*B[..,j]);
+
+  return C;
+}
+
+
+/* Return the matrix ``A`` to the ``bth`` power, where ``b`` is a positive
+   integral type. */
+proc matPow(A: [], b) where isNumeric(b) {
+  if !isIntegral(b) then
+    // TODO -- support all reals with Sylvester's formula
+    compilerError("matPow only support powers of integers");
+  if !isSquare(A) then
+    halt("Array not square");
+
+  return _expBySquaring(A, b);
+}
+
+
+pragma "no doc"
+/* Exponentiate by squaring recursively */
+private proc _expBySquaring(x: ?t, n): t {
+    // TODO -- _expBySquaring(pinv(x), -n);
+    if n < 0  then halt("Negative powers not yet supported");
+    else if n == 0  then return eye(x.domain);
+    else if n == 1  then return x;
+    else if n%2 == 0  then return _expBySquaring(dot(x, x), n / 2);
+    else return dot(x, _expBySquaring(dot(x, x), (n - 1) / 2));
+}
+
+
+/* Return element-wise power: ``a**B`` */
+proc matPow(a, B: [?Bdom] ?eltType) where isNumeric(a) {
+  var C: [Bdom] eltType = a**B;
+  return C;
+}
+
+
+/* Return element-wise exponential: ``e**A[i,j]`` */
+proc matExp(A: [?Dom] ?eltType) {
+  var B: [Dom] eltType = e**A;
+  return B;
+}
+
+
+pragma "no doc"
+/* Integer overload */
+proc matExp(A: [?Dom] ?eltType) where isIntegralType(eltType) {
+  var B: [Dom] real = e**A;
+  return B;
+}
+
+
+/* Return cross-product of vectors ``A`` and ``B`` with domains of size ``3`` */
+proc cross(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
+  if Adom.rank != 1 || Bdom.rank != 1 then
+    compilerError("Rank sizes are not 1");
+  if Adom.size != 3 || Bdom.size != 3 then
+    halt("cross() expects arrays of 3 elements");
+
+  var cross = Vector(Adom.size, eltType);
+
+  cross[0] = A[1]*B[2] - A[2]*B[1];
+  cross[1] = A[2]*B[0] - A[0]*B[2];
+  cross[2] = A[0]*B[1] - A[1]*B[0];
+
+  return cross;
+}
+
+
+//
+// Matrix Structure
+//
+
+/* Return lower triangular part of matrix, below the diagonal + ``k`` */
+proc tril(A: [?D] ?eltType, k=0) {
+  if D.rank != 2 then
+    compilerError("Rank size is not 2");
+  var L = Matrix(A);
+  forall (i, j) in D do
+    if (i < j-k) then L[i, j] = 0: eltType;
+  return L;
+}
+
+
+/* Return upper triangular part of matrix, above the diagonal + ``k`` */
+proc triu(A: [?D] ?eltType, k=0) {
+  if D.rank != 2 then
+    compilerError("Rank size is not 2");
+  var U = Matrix(A);
+  forall (i, j) in D do
+    if (i > j-k) then U[i, j] = 0: eltType;
+  return U;
+}
+
+
+/* Return `true` if matrix is diagonal */
+proc isDiag(A: [?D] ?eltType) {
+  if D.rank != 2 then
+    compilerError("Rank size is not 2");
+
+  const zero = 0: eltType;
+  for (i, j) in D do
+    if i != j && D[i, j] != zero return false
+  return true;
+}
+
+
+/* Return `true` if matrix is Hermitian */
+proc isHermitian(A: [?D]) {
+  if D.rank != 2 then
+    compilerError("Rank size is not 2");
+  for (i, j) in D {
+    if i > j {
+      if D[i, j] != conjg(D[j, i]) then return false;
+    }
+  }
+  return true;
+}
+
+
+/* Return `true` if matrix is symmetric */
+proc isSymmetric(A: [?D]) {
+  if D.rank != 2 then
+    compilerError("Rank size is not 2");
+  for (i, j) in D {
+    if i > j {
+      if D[i, j] != D[j, i] then return false;
+    }
+  }
+  return true;
+}
+
+
+/* Return `true` if matrix is lower triangular below the diagonal + ``k`` */
+proc isTril(A: [?D], k=0) {
+  if D.rank != 2 then
+    compilerError("Rank size is not 2");
+  const zero = 0: eltType;
+  for (i, j) in D do
+    if (i < j-k) && (A[i, j] != zero) then
+      return false;
+  return true;
+}
+
+
+/* Return `true` if matrix is upper triangular */
+proc isTriu(A: [?D] ?eltType, k=0) {
+  if D.rank != 2 then
+    compilerError("Rank size is not 2");
+  const zero = 0: eltType;
+  for (i, j) in D do
+    if (i > j-k) && (A[i, j] != zero) then
+      return false;
+  return true;
+}
+
+
+/* Return `true` if matrix is square */
+proc isSquare(A: [?D]) {
+  if D.rank != 2 then
+    compilerError("Rank size is not 2");
+  const (M, N) = A.shape;
+  return M == N;
+}
+
+
+/* Return the determinant of square matrix ``A`` */
+proc det(A: [?D] ?eltType) {
+  // Naive algorithm -
+  //    Better solution uses LU decomp: det M = det LU = det L * det U
+  if D.rank != 2 then
+    compilerError("Rank size not 2");
+
+  // Handle odd domains inefficiently:
+  if D.stridable {
+    var Atmp = Matrix(A);
+    return det(Atmp);
+  }
+  if D.first != 0 || D.last != D.shape(1) {
+    var Atmp = Matrix(A);
+    return det(Atmp);
+  }
+  // Assume 0-based non-strided domain below this point
+
+  if !isSquare(A) then
+    halt('non-square array passed to determinant. Aborting');
+
+  const n = D.shape(1);
+  if n == 1 then return A[0];
+
+  var d = 0: eltType;
+  forall j in 0..#n with (+ reduce d) do
+    d += (((-1)**(j))*(A[0,j])*det(_minor(A, j))): eltType;
+
+  return d;
+}
+
+
+pragma "no doc"
+/* Helper function for determinant */
+private proc _minor(A: [?Adom] ?eltType, j) {
+  const n = Adom.dim(1).size;
+  var a : [0..#n-1, 0..#n-1] eltType;
+  var K = 0,
+      L = 0,
+      i = 0;
+
+  for k in 0..#n {
+    for l in 0..#n  {
+      // K
+      if k == i || l == j then continue;
+      if k < i then K = k;
+      else K = k-1;
+      // L
+      if l < j then L = l;
+      else L = l-1;
+      // a[K, L]
+      a[K,L] = A[k,l];
+    }
+  }
+  return a;
+}
+
+
+/* Return the trace of ``A`` */
+proc trace(A: [?D] ?eltType) {
+  if D.rank == 1 then return + reduce A[..];
+  else if D.rank == 2 {
+    var trace = 0: eltType;
+    forall (i, j) in zip(D.dim(1), D.dim(2)) with (+ reduce trace) do
+      trace += A[i, j];
+    return trace;
+  } else {
+    compilerError("Rank size not 1 or 2");
+  }
+}
+
+} // module LinearAlgebra

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -621,7 +621,7 @@ proc isSymmetric(A: [?D]) : bool {
     compilerError("Rank size is not 2");
   for (i, j) in D {
     if i > j {
-      if D[i, j] != D[j, i] then return false;
+      if A[i, j] != A[j, i] then return false;
     }
   }
   return true;
@@ -661,38 +661,6 @@ proc isSquare(A: [?D]) {
 }
 
 
-/* Return the determinant of square matrix ``A`` */
-proc det(A: [?D] ?eltType) {
-  // Naive algorithm -
-  //    Better solution uses LU decomp: det M = det LU = det L * det U
-  if D.rank != 2 then
-    compilerError("Rank size not 2");
-
-  // Handle odd domains inefficiently:
-  if D.stridable {
-    var Atmp = Matrix(A);
-    return det(Atmp);
-  }
-  if D.first != 0 || D.last != D.shape(1) {
-    var Atmp = Matrix(A);
-    return det(Atmp);
-  }
-  // Assume 0-based non-strided domain below this point
-
-  if !isSquare(A) then
-    halt('non-square array passed to determinant. Aborting');
-
-  const n = D.shape(1);
-  if n == 1 then return A[0];
-
-  var d = 0: eltType;
-  forall j in 0..#n with (+ reduce d) do
-    d += (((-1)**(j))*(A[0,j])*det(_minor(A, j))): eltType;
-
-  return d;
-}
-
-
 pragma "no doc"
 /* Helper function for determinant */
 private proc _minor(A: [?Adom] ?eltType, j) {
@@ -719,7 +687,7 @@ private proc _minor(A: [?Adom] ?eltType, j) {
 }
 
 
-/* Return the trace of matrix square matrix ``A`` */
+/* Return the trace of square matrix ``A`` */
 proc trace(A: [?D] ?eltType) {
   if D.rank != 2 then compilerError("Rank size not 2");
   else

--- a/test/modules/packages/linearalgebra/correctness/Makefile
+++ b/test/modules/packages/linearalgebra/correctness/Makefile
@@ -1,0 +1,8 @@
+LAPACKFLAGS = $(CFLAGS) $(LDFLAGS) -llapacke -llapack -lblas -lcblas -lgfortran
+CHPLFLAGS += --ccflags -Wno-enum-conversion
+
+all: correctness
+
+correctness: correctness.chpl
+	chpl correctness.chpl ${LAPACKFLAGS} ${CHPLFLAGS} -o correctness
+

--- a/test/modules/packages/linearalgebra/correctness/SKIPIF
+++ b/test/modules/packages/linearalgebra/correctness/SKIPIF
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+"""
+LinearAlgebra requires BLAS module (and will eventually require LAPACK)
+
+Testing BLAS module requires cray-libsci for compiling. The following flags are
+implicitly passed via the back-end 'cc' wrapper:
+
+    -I $CRAY_LIBSCI_PREFIX_DIR/include
+    -L $CRAY_LIBSCI_PREFIX_DIR/lib
+    -l sci_gnu
+
+Since this is a long-running test and Cray machines guarantee BLAS availability,
+we only test on XC, cray-prgenv-gnu target platform, non-whitebox,
+and non-llvm configurations.
+"""
+
+from os import getenv, path
+
+isXC = getenv('CHPL_TARGET_PLATFORM') == 'cray-xc'
+isGNU = 'gnu' in str(getenv('CHPL_TARGET_COMPILER'))
+isWB = not path.exists('/etc/opt/cray/release') or not path.exists('/etc/opt/cray/release/CLEinfo')
+isLLVM = '--llvm' in str(getenv('COMPOPTS'))
+
+if isXC and isGNU and not isWB and not isLLVM:
+  print(False) # Don't skip
+else:
+  print(True) # Do skip

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -1,8 +1,11 @@
 use LinearAlgebra;
 
-/* LinearAlgebra correctness tests */
+/* LinearAlgebra correctness tests
 
-/* Nothing prints if tests are successful */
+   Any output denotes failure
+
+   Many of these tests are trivial and can be expanded upon in the future.
+*/
 
 //
 // Initializers
@@ -104,6 +107,18 @@ use LinearAlgebra;
     assertEqual(v.T, vT, "v.T");
   }
 
+  /* transpose - Nx1 , 1xN vectors */
+  {
+    var v31 = Matrix(3, 1);
+    var v13 = Matrix(1, 3);
+
+    v31 = 1;
+    v13 = 1;
+
+    assertEqual(v13, v31.T, "Matrix(3, 1).T");
+    assertEqual(v31, v13.T, "Matrix(1, 3).T");
+  }
+
   /* transpose - square matrix */
   {
 
@@ -173,9 +188,52 @@ use LinearAlgebra;
   test_dot(int(64));
 }
 
+/* dot scalars */
+
+{
+  var I = eye(3, 3);
+  var I2: [I.domain] real = 2*I;
+
+  assertEqual(I2, dot(2, I), "dot(2, I)");
+  assertEqual(I2, dot(I, 2), "dot(I, 2)");
+
+  var v = Vector(3);
+  var v2 = 2*v;
+
+  assertEqual(v2, dot(2, v), "dot(2, v)");
+  assertEqual(v2, dot(v, 2), "dot(v, 2)");
+}
+
+
+/* dot - Nx1 , 1xN vectors */
+{
+  var v31 = Matrix(3, 1);
+  var v13 = Matrix(1, 3);
+  var M = Matrix(3, 3);
+  var S = Matrix(1, 1);
+
+  v31 = 1;
+  v13 = 1;
+  M = 1;
+
+  S[0, 0] =  inner(v13[0, ..], v31[.., 0]);
+
+  // outer-product
+  assertEqual(dot(v31, v13), M, "dot(Matrix(3, 1), Matrix(1, 3))");
+  // inner-product
+  assertEqual(dot(v13, v31), S, "dot(Matrix(1, 3), Matrix(3, 1))");
+}
+
 /* outer */
 {
-  // TODO
+  var v = Vector(3);
+  var M = Matrix(3, 3);
+
+  v = 1;
+  M = 1;
+
+  // outer-product
+  assertEqual(outer(v, v), M, "outer(Vector(3), Vector(3))");
 }
 
 /* matPow scalar-matrix */
@@ -206,8 +264,6 @@ use LinearAlgebra;
   assertEqual(A3, B3, "matPow(A, 3)");
 }
 
-/* matSqrt */
-
 /* matExp */
 {
   var A = Matrix([1,2,3,4],[4,3,2,1], eltType=real);
@@ -220,7 +276,15 @@ use LinearAlgebra;
 
 /* cross */
 {
-  // TODO
+  var v1 = Vector(1,2,3);
+  var v2 = Vector(4,5,6);
+  var C = Vector(-3, 6, -3);
+  var C12 = cross(v1, v2);
+  var C21 = cross(v2, v1);
+
+  assertEqual(C, C12, "cross(v1, v2)");
+  C = -C;
+  assertEqual(C, C21, "cross(v2, v1)");
 }
 
 /* trace */
@@ -264,6 +328,29 @@ use LinearAlgebra;
   }
 }
 
+/* isDiag */
+{
+  var I = eye(3,3);
+  assertTrue(isDiag(I), "isDiag(I)");
+
+  var M = I;
+  M[0,2] = 1;
+  assertFalse(isDiag(I), "isDiag(M)");
+}
+
+// TODO
+/* isHermitian */
+
+/* isSymmetric */
+
+/* isTril */
+
+/* isTriu */
+
+/* isSquare */
+
+/* det */
+
 //
 // Helpers
 //
@@ -275,7 +362,9 @@ proc assertEqual(X, Y, msg="") {
   }
 }
 
-proc assertEqual(X: [], Y: [], msg="") {
+
+proc assertEqual(X: [], Y: [], msg="") where isArrayValue(X) && isArrayValue(Y)
+{
   if X.shape != Y.shape {
     writeln("Test Failed: ", msg);
     writeln(X, '\n!=\n', Y);
@@ -287,3 +376,33 @@ proc assertEqual(X: [], Y: [], msg="") {
   }
 }
 
+
+proc assertEqual(X: _tuple, Y: _tuple, msg="") {
+  if X.size != Y.size {
+    writeln("Test Failed: ", msg);
+    writeln(X, '\n!=\n', Y);
+    return;
+  } else {
+    for (x, y) in zip(X, Y) {
+      if x != y {
+        writeln("Test Failed: ", msg);
+        writeln(X, '\n!=\n', Y);
+        return;
+      }
+    }
+  }
+}
+
+proc assertTrue(x: bool, msg="") {
+  if !x {
+    writeln("Test Failed: ", msg);
+    writeln("boolean is false");
+  }
+}
+
+proc assertFalse(x: bool, msg="") {
+  if x {
+    writeln("Test Failed: ", msg);
+    writeln("boolean is true");
+  }
+}

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -241,19 +241,9 @@ use LinearAlgebra;
   v = 1;
   M = 1;
 
-  // outer-product
   assertEqual(outer(v, v), M, "outer(Vector(3), Vector(3))");
 }
 
-/* matPow scalar-matrix */
-{
-  var A = Matrix([1,2,3,4],[4,3,2,1], eltType=real);
-
-  var B = matPow(2, A);
-  var R: [A.domain] real = 2**A;
-
-  assertEqual(B, R, "matPow(2, A)");
-}
 
 /* matPow matrix-scalar */
 {

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -335,7 +335,7 @@ use LinearAlgebra;
 
   var M = I;
   M[0,2] = 1;
-  assertFalse(isDiag(I), "isDiag(M)");
+  assertFalse(isDiag(M), "isDiag(M)");
 }
 
 // TODO

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -27,12 +27,21 @@ use LinearAlgebra;
     assertEqual(v.domain, Dom, "Vector(Dom)");
   }
 
+
   /* Array */
   {
     var A: [Dom] real;
     var v = Vector(A);
     assertEqual(v.domain, Dom, "Vector(A)");
   }
+
+
+  /* Rows */
+  {
+    var M = Matrix(3);
+    assertEqual(M.domain, MDom, "Matrix(3)");
+  }
+
 
   /* Dimensions */
   {
@@ -296,11 +305,6 @@ use LinearAlgebra;
   var Mtrace = 15.0;
   var t = trace(M);
   assertEqual(Mtrace, t);
-
-  var v = Vector([1,2,3], eltType=real);
-  var vtrace = 6.0;
-  t = trace(v);
-  assertEqual(vtrace, t);
 }
 
 /* tril & triu */

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -273,15 +273,6 @@ use LinearAlgebra;
   assertEqual(A3, B3, "matPow(A, 3)");
 }
 
-/* matExp */
-{
-  var A = Matrix([1,2,3,4],[4,3,2,1], eltType=real);
-
-  var B = matExp(A);
-  var R: [A.domain] real = e**A;
-
-  assertEqual(B, R, "matExp(2, A)");
-}
 
 /* cross */
 {

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -1,0 +1,289 @@
+use LinearAlgebra;
+
+/* LinearAlgebra correctness tests */
+
+/* Nothing prints if tests are successful */
+
+//
+// Initializers
+//
+
+{
+  const Dom = {0..#10};
+  const MDom = {0..#3, 0..#3};
+
+  /* Dimensions */
+  {
+    var v = Vector(10);
+    assertEqual(v.domain, Dom, "Vector(10)");
+  }
+
+  /* Domain */
+  {
+    var v = Vector(Dom);
+    assertEqual(v.domain, Dom, "Vector(Dom)");
+  }
+
+  /* Array */
+  {
+    var A: [Dom] real;
+    var v = Vector(A);
+    assertEqual(v.domain, Dom, "Vector(A)");
+  }
+
+  /* Dimensions */
+  {
+    var M = Matrix(3, 3);
+    assertEqual(M.domain, MDom, "Matrix(3, 3)");
+  }
+
+  /* Domain */
+  {
+    var M = Matrix(MDom);
+    assertEqual(M.domain, MDom, "Matrix(MDom)");
+  }
+
+  /* Array */
+  {
+    var A: [MDom] real;
+    var M = Matrix(A);
+    assertEqual(M.domain, MDom, "Matrix(A)");
+  }
+
+  /* Variadic arguments of vectors */
+  {
+    var M = Matrix([1,2,3],
+                   [4,5,6],
+                   [7,8,9]);
+    assertEqual(M.domain, MDom, "Matrix([1,2,3], [4,5,6], [7,8,9]).domain");
+    assertEqual(M[1,1], 5, "Matrix([1,2,3], [4,5,6], [7,8,9])[1,1]");
+  }
+
+  /* Identity - Dimensions */
+  {
+    proc checkIdentity(m, n, type t = real) {
+      var Identity: [0..#m, 0..#n] t;
+      const count = min(m, n);
+      for i in 0..#count {
+        Identity[i, i] = 1: t;
+      }
+
+      var I = eye(m, n, eltType=t);
+      assertEqual(I, Identity,
+          "checkIdentity(%i, %i, %s)".format(m, n, t:string));
+    }
+
+    checkIdentity(3, 3);
+    checkIdentity(3, 4);
+    checkIdentity(4, 3);
+    checkIdentity(3, 3, complex);
+  }
+
+  {
+    var Identity: [MDom] real;
+    for i in MDom.dim(1) do Identity[i, i] = 1.0;
+
+    var I = eye(MDom);
+    assertEqual(I, Identity, "eye(D)");
+  }
+}
+
+//
+// Matrix operations
+//
+
+
+{
+  /* transpose - vector */
+  {
+    var v = Vector([1,2,3]);
+    var vT = transpose(v);
+
+    assertEqual(v, vT, "transpose(v)");
+    assertEqual(v.shape, vT.shape, "transpose(v).shape");
+    assertEqual(v.T, vT, "v.T");
+  }
+
+  /* transpose - square matrix */
+  {
+
+    var A =  Matrix([1.0,2.0,3.0],
+                    [4.0,5.0,6.0],
+                    [7.0,8.0,9.0]);
+    var AT = Matrix([1.0,4.0,7.0],
+                    [2.0,5.0,8.0],
+                    [3.0,6.0,9.0]);
+
+    assertEqual(transpose(A).shape, AT.shape, "transpose(A).shape");
+    assertEqual(transpose(A), AT, "transpose(A)");
+    assertEqual(A.T, AT, "A.T");
+  }
+
+  /* transpose - non-square matrix */
+  {
+    var A =  Matrix([1,2,3],
+                    [4,5,6]);
+
+    var AT = Matrix([1,4],
+                    [2,5],
+                    [3,6]);
+
+    assertEqual(transpose(A).shape, AT.shape, "transpose(A).shape");
+    assertEqual(transpose(A), AT, "transpose(A)");
+    assertEqual(A.T, AT, "A.T");
+  }
+}
+
+/* dot - calls matMult && inner*/
+{
+
+  proc test_dot(type t) {
+    var M = Matrix([1,2,3],
+                   [4,5,6],
+                   [7,8,9],
+                   eltType=t);
+    var I = eye(M.domain, eltType=t);
+
+    var v = Vector(1,2,3, eltType=t);
+
+    // matrix-matrix
+    var MI = dot(M, I);
+    assertEqual(MI, M, "dot(M, I)");
+
+    // vector-matrix && matrix-vector
+    var Iv = dot(I, v);
+
+    assertEqual(Iv, v, "dot(I, v)");
+
+    var vI = dot(I, v);
+
+    assertEqual(vI, v, "dot(v, I)");
+
+    // vector-vector (inner-product)
+    var vv = dot(v, v);
+    var R = + reduce(v[..]*v[..]);
+    assertEqual(vI, v, "dot(v, I)");
+  }
+
+  test_dot(real);
+  test_dot(real(32));
+  test_dot(complex);
+  test_dot(complex(128));
+  test_dot(int(32));
+  test_dot(int(64));
+}
+
+/* outer */
+{
+  // TODO
+}
+
+/* matPow scalar-matrix */
+{
+  var A = Matrix([1,2,3,4],[4,3,2,1], eltType=real);
+
+  var B = matPow(2, A);
+  var R: [A.domain] real = 2**A;
+
+  assertEqual(B, R, "matPow(2, A)");
+}
+
+/* matPow matrix-scalar */
+{
+  const v1 = [1,2,3];
+  var A = Matrix(v1,v1,v1, eltType=real);
+
+  const v2 = [6, 12, 18];
+  const A2 = Matrix(v2,v2,v2, eltType=real);
+
+  const v3 = [36, 72, 108];
+  const A3 = Matrix(v3,v3,v3, eltType=real);
+
+  var B2 = matPow(A, 2);
+  var B3 = matPow(A, 3);
+
+  assertEqual(A2, B2, "matPow(A, 2)");
+  assertEqual(A3, B3, "matPow(A, 3)");
+}
+
+/* matSqrt */
+
+/* matExp */
+{
+  var A = Matrix([1,2,3,4],[4,3,2,1], eltType=real);
+
+  var B = matExp(A);
+  var R: [A.domain] real = e**A;
+
+  assertEqual(B, R, "matExp(2, A)");
+}
+
+/* cross */
+{
+  // TODO
+}
+
+/* trace */
+{
+  var M = Matrix([1,2,3],
+                 [4,5,6],
+                 [7,8,9],
+                 eltType=real);
+  var Mtrace = 15.0;
+  var t = trace(M);
+  assertEqual(Mtrace, t);
+
+  var v = Vector([1,2,3], eltType=real);
+  var vtrace = 6.0;
+  t = trace(v);
+  assertEqual(vtrace, t);
+}
+
+/* tril & triu */
+{
+  var M = eye(5,5);
+  M = 1;
+
+  {
+    var L = tril(M, -1);
+    var U = triu(M);
+    var LU = matPlus(L, U);
+    assertEqual(M, LU, "tril(M, -1) + triu(M)");
+  }
+  {
+    var L = tril(M);
+    var U = triu(M, 1);
+    var LU = matPlus(L, U);
+    assertEqual(M, LU, "tril(M) + triu(M, 1)");
+  }
+  {
+    var L = tril(M, 1);
+    var U = triu(M, 2);
+    var LU = matPlus(L, U);
+    assertEqual(M, LU, "tril(M, 1) + triu(M, 2)");
+  }
+}
+
+//
+// Helpers
+//
+
+proc assertEqual(X, Y, msg="") {
+  if X != Y {
+    writeln("Test Failed: ", msg);
+    writeln(X, ' != ', Y);
+  }
+}
+
+proc assertEqual(X: [], Y: [], msg="") {
+  if X.shape != Y.shape {
+    writeln("Test Failed: ", msg);
+    writeln(X, '\n!=\n', Y);
+    return;
+  } else if !X.equals(Y) {
+    writeln("Test Failed: ", msg);
+    writeln(X, '\n!=\n', Y);
+    return;
+  }
+}
+

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -308,18 +308,30 @@ use LinearAlgebra;
     var U = triu(M);
     var LU = matPlus(L, U);
     assertEqual(M, LU, "tril(M, -1) + triu(M)");
+    assertTrue(isTril(L, -1), "isTril(L, -1)");
+    assertTrue(isTriu(U), "isTriu(U)");
+    assertFalse(isTril(U, -1), "isTril(U, -1)");
+    assertFalse(isTriu(L), "isTriu(L)");
   }
   {
     var L = tril(M);
     var U = triu(M, 1);
     var LU = matPlus(L, U);
     assertEqual(M, LU, "tril(M) + triu(M, 1)");
+    assertTrue(isTril(L), "isTril(L)");
+    assertTrue(isTriu(U, 1), "isTriu(U, 1)");
+    assertFalse(isTril(U), "isTril(U)");
+    assertFalse(isTriu(L, 1), "isTriu(L, 1)");
   }
   {
     var L = tril(M, 1);
     var U = triu(M, 2);
     var LU = matPlus(L, U);
     assertEqual(M, LU, "tril(M, 1) + triu(M, 2)");
+    assertTrue(isTril(L, 1), "isTril(L, 1)");
+    assertTrue(isTriu(U, 2), "isTriu(U, 2)");
+    assertFalse(isTril(U, 1), "isTril(U, 1)");
+    assertFalse(isTriu(L, 2), "isTriu(L, 2)");
   }
 }
 
@@ -333,18 +345,38 @@ use LinearAlgebra;
   assertFalse(isDiag(M), "isDiag(M)");
 }
 
-// TODO
 /* isHermitian */
+{
+  var H = Matrix([2.0+0.0i, 2.0+1.0i, 4.0+0.0i],
+                 [2.0-1.0i, 3.0+0.0i, 0.0+1.0i],
+                 [4.0+0.0i, 0.0-1.0i, 1.0+0.0i],
+                 eltType=complex);
+  assertTrue(isHermitian(H), "isHermitian(H)");
+  H[0,1] += -2i;
+  assertFalse(isHermitian(H), "isHermitian(H')");
+}
 
 /* isSymmetric */
+{
+  var S = Matrix([2.0+0.0i, 2.0+1.0i, 4.0+0.0i],
+                 [2.0+1.0i, 3.0+0.0i, 0.0+1.0i],
+                 [4.0+0.0i, 0.0+1.0i, 1.0+0.0i],
+                 eltType=complex);
+  assertTrue(isSymmetric(S), "isSymmetric(S)");
+  S[0, 1] += 2;
+  assertFalse(isSymmetric(S), "isSymmetric(S')");
+}
 
-/* isTril */
-
-/* isTriu */
 
 /* isSquare */
+{
+  var Square = Matrix(3, 3);
+  var Rect = Matrix(4, 3);
 
-/* det */
+  assertTrue(isSquare(Square), "isSquare(Square)");
+  assertFalse(isSquare(Rect), "isSquare(Rect)");
+}
+
 
 //
 // Helpers


### PR DESCRIPTION
# Linear Algebra module

The small feature set in this package mainly consists of:
- matrix/vector convenience initializers
    - e.g. `var A = Matrix(4, 4);` , `var v = Vector(3);`
- matrix structure functions
    -  e.g.`var d = triu(A)`
- BLAS-supported matrix|vector operations
    - e.g. `var AB = dot(A, B);`

The feature coverage is fairly minimal, as I have dropped LAPACK support for this release cycle, which is required for a large number of routines. As a result, this is still considered a prototype package module.

Some points of discussion with reviewer(s):

- Indexing
   - module creates new arrays with 0-based indexing unless a user specifies otherwise (with a domain of their own)
- Naming schemes
    - e.g. casing on array initializer wrappers: `Matrix()` and `Vector()`.
- Are the matrix operations that purely exist to create temp arrays and override promotion flattening valuable enough to include?
   - `matPlus`, `matMinus`, ...
   - See the documentation on promotion flattening if this doesn't make sense...
- Implementations
   - Are we OK with naive implementation for some routines, or would we prefer to not support them yet at all?
- Array methods
    - Are we OK with a package module adding base array methods as syntactic sugar?
        - This PR only introduced `_array.T`, but we could support many others down the road.
        - See the [numpy array documentation](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html) to get an idea of what kind of array methods we could utilize.

 
**Remaining TODOs**
- [x] Finish shape-assertions in multiplication operations
- [x] Finish Matrix structure tests
- [x] Testing
    - [x] OS X + netlib
    - [x] Cray + CrayBLAS
