### PR TITLE
delete errors, nested try

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -102,6 +102,7 @@ FnSymbol *gBuildTupleType = NULL;
 FnSymbol *gBuildStarTupleType = NULL;
 FnSymbol *gBuildTupleTypeNoRef = NULL;
 FnSymbol *gBuildStarTupleTypeNoRef = NULL;
+FnSymbol* gChplDeleteError = NULL;
 
 
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -786,6 +786,7 @@ extern FnSymbol *gChplDoDirectExecuteOn;
 extern FnSymbol *gGenericTupleTypeCtor;
 extern FnSymbol *gGenericTupleInit;
 extern FnSymbol *gGenericTupleDestroy;
+extern FnSymbol *gChplDeleteError;
 
 // These global symbols point to generic functions that
 // will be instantiated.

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -147,7 +147,7 @@ private:
   LabelSymbol*        epilogue;
   bool                insideCatch;
 
-  AList     handler           (TryStmt*   tryStmt,  VarSymbol* errorVar,
+  AList     lowerCatches      (TryStmt*   tryStmt,  VarSymbol* errorVar,
                                TryInfo*   outerTry);
   AList     setOutGotoEpilogue(VarSymbol* error);
   AList     errorCond         (VarSymbol* errorVar, BlockStmt* thenBlock,
@@ -189,14 +189,14 @@ void ErrorHandlingVisitor::exitTryStmt(TryStmt* node) {
   tryBlock->insertAtHead(new DefExpr(info.errorVar));
 
   tryBlock->insertAtTail(new DefExpr(info.handlerLabel));
-  tryBlock->insertAtTail(handler(node, info.errorVar, outerTry));
+  tryBlock->insertAtTail(lowerCatches(node, info.errorVar, outerTry));
 
   tryBlock->remove();
   node    ->replace(tryBlock);
 }
 
-AList ErrorHandlingVisitor::handler(TryStmt* tryStmt, VarSymbol* errorVar,
-                                       TryInfo* outerTry) {
+AList ErrorHandlingVisitor::lowerCatches(TryStmt* tryStmt, VarSymbol* errorVar,
+                                         TryInfo* outerTry) {
   BlockStmt* handlers    = new BlockStmt();
 
   bool       hasCatchAll = false;

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -148,7 +148,7 @@ private:
   bool                insideCatch;
 
   AList     handler           (TryStmt*   tryStmt,  VarSymbol* errorVar,
-                               TryInfo* outerTry);
+                               TryInfo*   outerTry);
   AList     setOutGotoEpilogue(VarSymbol* error);
   AList     errorCond         (VarSymbol* errorVar, BlockStmt* thenBlock,
                                BlockStmt* elseBlock = NULL);

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -93,7 +93,7 @@ try {
   handleSomehow();
 }
 
-{FFFFF
+{
   var _e1: Error;
   {
     var _e2: Error;
@@ -220,8 +220,8 @@ AList ErrorHandlingVisitor::handler(TryStmt* tryStmt, VarSymbol* errorVar,
       hasCatchAll = true;
       currHandler->insertAtTail(catchBody);
     } else {
-      Symbol* errSym  = catchDef->sym;
-      Type*   errType = errSym->type;
+      VarSymbol* errSym  = toVarSymbol(catchDef->sym);
+      Type*      errType = errSym->type;
 
       catchDef->remove();
       currHandler->insertAtTail(catchDef);
@@ -230,7 +230,7 @@ AList ErrorHandlingVisitor::handler(TryStmt* tryStmt, VarSymbol* errorVar,
       if (errType == dtError) {
         hasCatchAll = true;
         currHandler->insertAtTail(new CallExpr(PRIM_MOVE, errSym, errorVar));
-        currHandler->insertAtTail(errorCond(toVarSymbol(errSym), catchBody));
+        currHandler->insertAtTail(errorCond(errSym, catchBody));
 
       // specified catch
       } else {
@@ -240,8 +240,7 @@ AList ErrorHandlingVisitor::handler(TryStmt* tryStmt, VarSymbol* errorVar,
         BlockStmt* nextHandler = new BlockStmt();
 
         currHandler->insertAtTail(new CallExpr(PRIM_MOVE, errSym, castError));
-        currHandler->insertAtTail(errorCond(toVarSymbol(errSym), catchBody,
-                                            nextHandler));
+        currHandler->insertAtTail(errorCond(errSym, catchBody, nextHandler));
 
         currHandler = nextHandler;
       }

--- a/compiler/passes/filesToAST.cpp
+++ b/compiler/passes/filesToAST.cpp
@@ -83,7 +83,8 @@ static WellKnownFn sWellKnownFns[] = {
   {"_build_tuple",            &gBuildTupleType, FLAG_BUILD_TUPLE_TYPE},
   {"_build_tuple_noref",      &gBuildTupleTypeNoRef, FLAG_BUILD_TUPLE_TYPE},
   {"*",                       &gBuildStarTupleType, FLAG_BUILD_TUPLE_TYPE},
-  {"_build_star_tuple_noref", &gBuildStarTupleTypeNoRef, FLAG_BUILD_TUPLE_TYPE}
+  {"_build_star_tuple_noref", &gBuildStarTupleTypeNoRef, FLAG_BUILD_TUPLE_TYPE},
+  {"chpl_delete_error",       &gChplDeleteError, FLAG_UNKNOWN}
 };
 
 void parse() {

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -26,12 +26,7 @@ module ChapelError {
     }
   }
 
-  /* This is a work-around to prevent the compiler from
-     removing or not properly resolving the Error type. */
-  proc ensureErrorTypeRemains() {
-    var x = new Error();
-    delete x;
+  export proc chpl_delete_error(err: Error) {
+    delete err;
   }
-  ensureErrorTypeRemains();
-
 }

--- a/test/errhandling/psahabu/try-nested-prop.chpl
+++ b/test/errhandling/psahabu/try-nested-prop.chpl
@@ -1,0 +1,25 @@
+use ThrowError;
+
+class SpecificError : Error { }
+
+proc nestedTries() throws {
+  try {
+    writeln("outer try");
+    try {
+      writeln("inner try");
+      throw new OtherError();
+    } catch err: SpecificError {
+      writeln("fail: error should not be caught here");
+    }
+    writeln("fail: inner try did not throw");
+  } catch err: SpecificError {
+    writeln("fail: error should not be caught here");
+  }
+}
+
+try {
+  writeln("calling nestedTries");
+  nestedTries();
+} catch {
+  writeln("successfully propagated");
+}

--- a/test/errhandling/psahabu/try-nested-prop.good
+++ b/test/errhandling/psahabu/try-nested-prop.good
@@ -1,0 +1,4 @@
+calling nestedTries
+outer try
+inner try
+successfully propagated


### PR DESCRIPTION
This PR inserts `chpl_delete_error` to automatically delete `Error`s as they are consumed. This strategy was chosen because `PRIM_DELETE` is lowered before the `lowerErrorHandling` pass, so it was more straightforward to create a routine to delete `Error`, include that routine in `sWellKnownFns`, then call it from the error handling lowering pass. `chpl_delete_error` also ensures that the `Error` module is properly resolved and not hoisted, allowing us to remove the `ensureErrorTypeRemains` dummy.

This PR also allows `try` statements to propagate to an enclosing `try` statement.

flat+linux64 testing is clean.

### Example: inserted deletes
```
// given code
proc propagate() throws {
  try {
    a(); // throws
    b(); // does not throw
    c(); // throws
  } catch e: SubError {
    f();
  } catch e: AnotherSubError {
    g();
  }
}

// after this pass
proc propagate(out error_out: Error) {
  var error: Error;
  a(error);
  if error then
    goto handler;
  b();
  c(error);
  if error then
    goto handler;

  label handler:
  if error {
    var e = error: SubError;
    if _cast {
      f();
      delete e;
    } else {
      var e = error: AnotherSubError;
      if e {
        g();
        delete e;
      } else {
        // set and return
        error_out = error;
        goto epilogue_label;
      }
    }
  }
}
```

### Example: nested try
```
try {
  try {
    throwingCall();
  } catch e: SpecificError {
    handleGracefully();
  }
  otherThrowingCall();
} catch {
  handleSomehow();
}

{
  var _e1: Error;
  {
    var _e2: Error;
    throwingCall(_e2);
    if _e2 then
      goto handler2;

    label handler2:
    if _e2 {
      var _cast = _e2: SpecificError;
      if _cast {
        handleGracefully();
        delete _cast;
      } else {
        _e1 = _e2;
        goto handler1;
      }
    }
  }
  otherThrowingCall(_e1);
  if _e1 then
    goto handler1;

  label handler1:
  if _e1 {
    handleSomehow();
    delete _e1;
  }
}
```

### In list form
- creates and uses `gChplDeleteError` for `chpl_delete_error`
- inserts moves between `error` variables of nested `try` statements
- refactoring to support these changes