### PR TITLE
Avoid localizing the heap for CHPL_LOCALE_MODEL=knl

### DIFF
--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -471,6 +471,6 @@ chpl_bool chpl_mem_impl_alloc_localizes(void) {
   // some virtual-memory, and we can't just go touching all the pages.
   //
   return (get_num_heaps() > 1
-          && strcmp(CHPL_LOCALE_MODEL, "flat") != 0
+          && strcmp(CHPL_LOCALE_MODEL, "numa") == 0
           && strcmp(CHPL_COMM, "ugni") == 0);
 }


### PR DESCRIPTION
Only localize the heap for CHPL_LOCALE_MODEL=numa. #5689 added support to
NUMA-localize the heap under comm=ugni and loc-mod!=flat. Unfortunately this
doesn't seem to be working under knl right now, so disable it until Greg has a
chance to look into it.

Current failure is pretty generic:
  "internal error: hwloc_set_cpubind(): Invalid argument"