### PR TITLE
Test impact of further limiting qthread pool size in a perf playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground-2.bash
+++ b/util/cron/test-perf.chapcs.playground-2.bash
@@ -9,11 +9,11 @@ source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground-2"
 
-# Test performance of making DefaultRect multi-ddata fields void
+# Test performance of limiting qthread memory pools 
 GITHUB_USER=ronawho
-GITHUB_BRANCH=ronawho-newVoidTypeFC
-SHORT_NAME=md-void-fields
-START_DATE=03/14/17
+GITHUB_BRANCH=limit-qt-pool-size
+SHORT_NAME=limit-qt-pool-size
+START_DATE=03/18/17
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
Turns out qtheads uses a memory pool per worker (or possibly shepherd, I'm not
100% sure yet) and not a single global pool for stacks. Our old limit for the
pool threshold was `2*hwpar*call_stack_size` because I thought we wanted to have
space for at least 2 stacks for each worker.

However, since it's a per-worker pool, this meant we were trying to allocate
space for 68 513MB pools on KNL. That's ~34 GB of ram, which far exceeds our
default 16GB heap under slurm.

This just tests a pool limit of `4*call_stack_size` to see the perf impact.