### PR TITLE
Trivial rework of insertCallTemps for new-expressions for records with initializers

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1118,6 +1118,9 @@ void CallExpr::setUnresolvedFunction(const char* name) {
   } else if (UnresolvedSymExpr* use = toUnresolvedSymExpr(baseExpr)) {
     use->unresolved = astr(name);
 
+  } else if (SymExpr*           se  = toSymExpr(baseExpr)) {
+    se->replace(new UnresolvedSymExpr(name));
+
   } else {
     INT_ASSERT(false);
   }

--- a/test/classes/initializers/records/record-no-copy-init.chpl
+++ b/test/classes/initializers/records/record-no-copy-init.chpl
@@ -1,24 +1,34 @@
-record R {
-  var x:int;
+// This test verifies that the compiler does not attempt
+// to rely on a copy initializer for MyRec.
+//
+// There would be a compile time failure if the compiler attempted to
+// introduce a copy operation as MyRec does not define a copy initializer.
+
+
+record MyRec {
+  var x : int;
+
   proc init() {
-    writeln("in R's default-init");
+    writeln("default init");
   }
-  // no copy init
-}
-
-proc makeR() {
-  return new R();
 }
 
 
-proc foo() {
-  var x = new R(); // no copy
+proc main() {
+  var x = new MyRec();         // This is pure initialization
+
   writeln(x);
 
-  var y = makeR(); // no copy
+  var y = makeRecord();        // This is a "move" rather than a "copy"
+
   writeln(y);
 }
 
 
-foo();
+// A local record is "initialized" and then "moved" to the caller
+proc makeRecord() {
+  return new MyRec();
+}
+
+
 

--- a/test/classes/initializers/records/record-no-copy-init.future
+++ b/test/classes/initializers/records/record-no-copy-init.future
@@ -1,4 +1,0 @@
-feature request: Generate a helpful error message
-
-The program requires a copy-initializer but generates an ugly
-resolution error.

--- a/test/classes/initializers/records/record-no-copy-init.good
+++ b/test/classes/initializers/records/record-no-copy-init.good
@@ -1,4 +1,4 @@
-in R's default-init
+default init
 (x = 0)
-in R's default-init
+default init
 (x = 0)


### PR DESCRIPTION
This PR makes a minor change to the portion of insertCallTemps() in normalize.cpp that
handles transforming new-expressions for non-generic records with initializers.

This serves to retire a trivial future for copy initializers.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed single-locale paratest with -futures
