### PR TITLE
Retire a passing future for try-stmt

### DIFF
--- a/test/errhandling/psahabu/try-nested.bad
+++ b/test/errhandling/psahabu/try-nested.bad
@@ -1,1 +1,0 @@
-try-nested.chpl:3: error: nested try is not yet supported

--- a/test/errhandling/psahabu/try-nested.future
+++ b/test/errhandling/psahabu/try-nested.future
@@ -1,4 +1,0 @@
-unimplemented: nested try blocks
-
-An inner try block should be able to propagate its error to
-the catch statements of an outer try block, if necessary.


### PR DESCRIPTION
I happened to notice that test/errhandling/psahabu/try-nested.future had started passing.
Removed the associated .bad and .future to help the next nightly run more cleanly.
