### PR TITLE
Ensure all fields are initialized in constructor

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -161,6 +161,7 @@ ErrorHandlingVisitor::ErrorHandlingVisitor(ArgSymbol*   _outError,
                                            LabelSymbol* _epilogue) {
   outError = _outError;
   epilogue = _epilogue;
+  insideCatch = false;
 }
 
 bool ErrorHandlingVisitor::enterTryStmt(TryStmt* node) {


### PR DESCRIPTION
Without this, I was seeing failures for try-nested.chpl on linux64 (not on Mac) including valgrind issues.