### PR TITLE
Minor changes to initializers

### DIFF
--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -109,7 +109,9 @@ void checkPrimitives()
 
       // These do not survive past resolution.
      case PRIM_INIT:
-     case PRIM_INITIALIZER_SET_FIELD:
+     case PRIM_INIT_FIELD:
+     case PRIM_INIT_VAR:
+
      case PRIM_TYPE_TO_STRING:
      case PRIM_TO_LEADER:
      case PRIM_TO_FOLLOWER:

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -454,12 +454,12 @@ initPrimitive() {
   // dst, src. PRIM_MOVE can set a reference.
   prim_def(PRIM_MOVE, "move", returnInfoVoid, false, true);
 
-  prim_def(PRIM_INIT,      "init",      returnInfoFirstDeref);
-  prim_def(PRIM_INIT_VAR,  "initVar",   returnInfoVoid);
-  prim_def(PRIM_NO_INIT,   "no init",   returnInfoFirstDeref);
-  prim_def(PRIM_TYPE_INIT, "type init", returnInfoFirstDeref);
+  prim_def(PRIM_INIT,       "init",       returnInfoFirstDeref);
+  prim_def(PRIM_INIT_FIELD, "init field", returnInfoVoid, false, true);
+  prim_def(PRIM_INIT_VAR,   "init var",   returnInfoVoid);
+  prim_def(PRIM_NO_INIT,    "no init",    returnInfoFirstDeref);
+  prim_def(PRIM_TYPE_INIT,  "type init",  returnInfoFirstDeref);
 
-  prim_def(PRIM_INITIALIZER_SET_FIELD, "initializer set field", returnInfoVoid, false, true);
   prim_def(PRIM_REF_TO_STRING, "ref to string", returnInfoStringC);
   prim_def(PRIM_RETURN, "return", returnInfoFirst, true);
   prim_def(PRIM_THROW, "throw", returnInfoFirst, true, true);

--- a/compiler/include/primitive.h
+++ b/compiler/include/primitive.h
@@ -36,12 +36,13 @@ enum PrimitiveTag {
   PRIM_MOVE,
 
   PRIM_INIT,
+  PRIM_INIT_FIELD,
   PRIM_INIT_VAR,
   PRIM_NO_INIT,
   PRIM_TYPE_INIT,       // Used in a context where only a type is needed.
                         // Establishes the type of the result without
                         // generating code.
-  PRIM_INITIALIZER_SET_FIELD,
+
   PRIM_REF_TO_STRING,
   PRIM_RETURN,
   PRIM_THROW,

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -590,10 +590,13 @@ checkResolveRemovedPrims(void) {
     if (call->primitive) {
       switch(call->primitive->tag) {
         case PRIM_BLOCK_PARAM_LOOP:
+
         case PRIM_INIT:
+        case PRIM_INIT_FIELD:
+        case PRIM_INIT_VAR:
         case PRIM_NO_INIT:
         case PRIM_TYPE_INIT:
-        case PRIM_INITIALIZER_SET_FIELD:
+
         case PRIM_LOGICAL_FOLDER:
         case PRIM_TYPEOF:
         case PRIM_TYPE_TO_STRING:

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -239,11 +239,13 @@ classifyPrimitive(CallExpr *call) {
 
   case PRIM_REDUCE_ASSIGN:
   case PRIM_NEW:
+
   case PRIM_INIT:
+  case PRIM_INIT_FIELD:
   case PRIM_INIT_VAR:
   case PRIM_NO_INIT:
   case PRIM_TYPE_INIT:
-  case PRIM_INITIALIZER_SET_FIELD:
+
   case PRIM_LOGICAL_FOLDER:
   case PRIM_TYPEOF:
   case PRIM_TYPE_TO_STRING:

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -142,12 +142,6 @@ void initMethodPreNormalize(FnSymbol* fn) {
     // Insert phase 2 analysis here
 
 
-    // Mark the initializer as void return
-    Symbol* voidType = dtVoid->symbol;
-
-    fn->retExprType = new BlockStmt(new SymExpr(voidType), BLOCK_SCOPELESS);
-
-
     // If this is a non-generic class then create a type method
     // to wrap this initializer
     if (isClass(at) == true && at->isGeneric() == false) {

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -383,8 +383,11 @@ Expr* modifyFieldAccess(Expr* fieldAccess, DefExpr* curField) {
 
 
   SET_LINENO(fieldAccess);
-  CallExpr* replacement = new CallExpr(PRIM_INITIALIZER_SET_FIELD, argThis,
+
+  CallExpr* replacement = new CallExpr(PRIM_INIT_FIELD,
+                                       argThis,
                                        new_CStringSymbol(curField->sym->name));
+
   for_actuals(actual, call) {
     if (actual == call->get(1)) {
       // The first arg is the this.field access, which we have already
@@ -481,9 +484,9 @@ static void insertOmittedField(Expr* next, DefExpr* field, AggregateType* t) {
                    nextField);
 
   } else {
-    Symbol*   _this      = toFnSymbol(next->parentSymbol)->_this;
+    Symbol*   _this   = toFnSymbol(next->parentSymbol)->_this;
 
-    CallExpr* newInit = new CallExpr(PRIM_INITIALIZER_SET_FIELD,
+    CallExpr* newInit = new CallExpr(PRIM_INIT_FIELD,
                                      new SymExpr(_this),
                                      new_CStringSymbol(nextField));
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5308,6 +5308,117 @@ static void handleSetMemberTypeMismatch(Type* t, Symbol* fs, CallExpr* call,
 
 /************************************* | **************************************
 *                                                                             *
+* Resolves calls inserted into initializers during Phase 1,                   *
+* to fully determine the instantiated type.                                   *
+*                                                                             *
+* This function is a combination of resolveMove and resolveSetMember          *
+*                                                                             *
+************************************** | *************************************/
+
+static void resolveInitField(CallExpr* call) {
+  if (call->id == breakOnResolveID) {
+    gdbShouldBreakHere();
+  }
+
+  INT_ASSERT(call->argList.length == 3);
+  // PRIM_INIT_FIELD contains three args:
+  // fn->_this, the name of the field, and the value/type it is to be given
+
+  SymExpr* rhs = toSymExpr(call->get(3)); // the value/type to give the field
+
+  // Get the field name.
+  SymExpr* sym = toSymExpr(call->get(2));
+  if (!sym)
+    INT_FATAL(call, "bad initializer set field primitive");
+  VarSymbol* var = toVarSymbol(sym->symbol());
+  if (!var || !var->immediate)
+    INT_FATAL(call, "bad initializer set field primitive");
+  const char* name = var->immediate->v_string;
+
+  // Get the type
+  AggregateType* ct = toAggregateType(call->get(1)->typeInfo()->getValType());
+  if (!ct)
+    INT_FATAL(call, "bad initializer set field primitive");
+
+  Symbol* fs = NULL;
+  int index = 1;
+  for_fields(field, ct) {
+    if (!strcmp(field->name, name)) {
+      fs = field; break;
+    }
+    index++;
+  }
+
+  if (!fs)
+    INT_FATAL(call, "bad initializer set field primitive");
+
+  Type* t = rhs->typeInfo();
+  // I think this never happens, so can be turned into an assert. <hilde>
+  if (t == dtUnknown)
+    INT_FATAL(call, "Unable to resolve field type");
+
+  if (t == dtNil && fs->type == dtUnknown)
+    USR_FATAL(call->parentSymbol, "unable to determine type of field from nil");
+  if (fs->type == dtUnknown) {
+    // Update the type of the field.  If necessary, update to a new
+    // instantiation of the overarching type (and replaces references to the
+    // fields from the old instantiation
+    if ((fs->hasFlag(FLAG_TYPE_VARIABLE) && isTypeExpr(rhs)) ||
+        fs->hasFlag(FLAG_PARAM) ||
+        (fs->defPoint->exprType == NULL && fs->defPoint->init == NULL)) {
+      AggregateType* instantiate = ct->getInstantiation(rhs, index);
+      if (instantiate != ct) {
+        // TODO: make this set of operations a helper function I can call
+        FnSymbol* parentFn = toFnSymbol(call->parentSymbol);
+        INT_ASSERT(parentFn);
+        INT_ASSERT(parentFn->_this);
+        parentFn->_this->type = instantiate;
+
+        SymbolMap fieldTranslate;
+        for (int i = 1; i <= instantiate->fields.length; i++) {
+          fieldTranslate.put(ct->getField(i), instantiate->getField(i));
+        }
+        update_symbols(parentFn, &fieldTranslate);
+
+        ct = instantiate;
+        fs = instantiate->getField(index);
+      }
+    } else {
+      // The field is not generic.
+      if (fs->defPoint->exprType == NULL) {
+        fs->type = t;
+      } else if (fs->defPoint->exprType) {
+        fs->type = fs->defPoint->exprType->typeInfo();
+      }
+    }
+  }
+
+  if (t != fs->type && t != dtNil && t != dtObject) {
+    Symbol*   actual = rhs->symbol();
+    FnSymbol* fn     = toFnSymbol(call->parentSymbol);
+
+    if (canCoerceTuples(t, actual, fs->type, fn)) {
+      // Add a PRIM_MOVE so that insertCasts will take care of it later.
+      VarSymbol* tmp = newTemp("coerce_elt", fs->type);
+
+      call->insertBefore(new DefExpr(tmp));
+      call->insertBefore(new CallExpr(PRIM_MOVE, tmp, rhs->remove()));
+
+      call->insertAtTail(tmp);
+
+    } else {
+      USR_FATAL(userCall(call),
+                "cannot assign expression of type %s to field of type %s",
+                toString(t),
+                toString(fs->type));
+    }
+  }
+
+  call->primitive = primitives[PRIM_SET_MEMBER];
+}
+
+/************************************* | **************************************
+*                                                                             *
 * This handles expressions of the form                                        *
 *      CallExpr(PRIM_INIT_VAR, dst, src)                                      *
 *                                                                             *
@@ -5597,93 +5708,6 @@ static void resolveMove(CallExpr* call) {
       }
     }
   }
-}
-
-// Resolves calls inserted into initializers during Phase 1, to fully determine
-// the instantiated type
-//
-// This function is a combination of resolveMove and resolveSetMember
-static void
-resolveInitField(CallExpr* call) {
-  if (call->id == breakOnResolveID )
-    gdbShouldBreakHere();
-
-  INT_ASSERT(call->argList.length == 3);
-  // PRIM_INIT_FIELD contains three args:
-  // fn->_this, the name of the field, and the value/type it is to be given
-
-  SymExpr* rhs = toSymExpr(call->get(3)); // the value/type to give the field
-
-  // Get the field name.
-  SymExpr* sym = toSymExpr(call->get(2));
-  if (!sym)
-    INT_FATAL(call, "bad initializer set field primitive");
-  VarSymbol* var = toVarSymbol(sym->symbol());
-  if (!var || !var->immediate)
-    INT_FATAL(call, "bad initializer set field primitive");
-  const char* name = var->immediate->v_string;
-
-  // Get the type
-  AggregateType* ct = toAggregateType(call->get(1)->typeInfo()->getValType());
-  if (!ct)
-    INT_FATAL(call, "bad initializer set field primitive");
-
-  Symbol* fs = NULL;
-  int index = 1;
-  for_fields(field, ct) {
-    if (!strcmp(field->name, name)) {
-      fs = field; break;
-    }
-    index++;
-  }
-
-  if (!fs)
-    INT_FATAL(call, "bad initializer set field primitive");
-
-  Type* t = rhs->typeInfo();
-  // I think this never happens, so can be turned into an assert. <hilde>
-  if (t == dtUnknown)
-    INT_FATAL(call, "Unable to resolve field type");
-
-  if (t == dtNil && fs->type == dtUnknown)
-    USR_FATAL(call->parentSymbol, "unable to determine type of field from nil");
-  if (fs->type == dtUnknown) {
-    // Update the type of the field.  If necessary, update to a new
-    // instantiation of the overarching type (and replaces references to the
-    // fields from the old instantiation
-    if ((fs->hasFlag(FLAG_TYPE_VARIABLE) && isTypeExpr(rhs)) ||
-        fs->hasFlag(FLAG_PARAM) ||
-        (fs->defPoint->exprType == NULL && fs->defPoint->init == NULL)) {
-      AggregateType* instantiate = ct->getInstantiation(rhs, index);
-      if (instantiate != ct) {
-        // TODO: make this set of operations a helper function I can call
-        FnSymbol* parentFn = toFnSymbol(call->parentSymbol);
-        INT_ASSERT(parentFn);
-        INT_ASSERT(parentFn->_this);
-        parentFn->_this->type = instantiate;
-
-        SymbolMap fieldTranslate;
-        for (int i = 1; i <= instantiate->fields.length; i++) {
-          fieldTranslate.put(ct->getField(i), instantiate->getField(i));
-        }
-        update_symbols(parentFn, &fieldTranslate);
-
-        ct = instantiate;
-        fs = instantiate->getField(index);
-      }
-    } else {
-      // The field is not generic.
-      if (fs->defPoint->exprType == NULL) {
-        fs->type = t;
-      } else if (fs->defPoint->exprType) {
-        fs->type = fs->defPoint->exprType->typeInfo();
-      }
-    }
-  }
-
-  handleSetMemberTypeMismatch(t, fs, call, rhs);
-
-  call->primitive = primitives[PRIM_SET_MEMBER];
 }
 
 /************************************* | **************************************

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -239,9 +239,9 @@ static void resolveTupleExpand(CallExpr* call);
 static void handleSetMemberTypeMismatch(Type* t, Symbol* fs, CallExpr* call,
                                         SymExpr* rhs);
 static void resolveSetMember(CallExpr* call);
+static void resolveInitField(CallExpr* call);
 static void resolveInitVar(CallExpr* call);
 static void resolveMove(CallExpr* call);
-static void resolveFieldInit(CallExpr* call);
 static void resolveNew(CallExpr* call);
 static void resolveCoerce(CallExpr* call);
 static bool formalRequiresTemp(ArgSymbol* formal);
@@ -4605,22 +4605,21 @@ void resolveCall(CallExpr* call) {
       resolveSetMember(call);
       break;
 
+    case PRIM_INIT:
+    case PRIM_NO_INIT:
+    case PRIM_TYPE_INIT:
+      resolveDefaultGenericType(call);
+      break;
+
+    case PRIM_INIT_FIELD:
+      resolveInitField(call);
+      break;
     case PRIM_INIT_VAR:
       resolveInitVar(call);
       break;
 
     case PRIM_MOVE:
       resolveMove(call);
-      break;
-
-    case PRIM_INITIALIZER_SET_FIELD:
-      resolveFieldInit(call);
-      break;
-
-    case PRIM_INIT:
-    case PRIM_NO_INIT:
-    case PRIM_TYPE_INIT:
-      resolveDefaultGenericType(call);
       break;
 
     case PRIM_COERCE:
@@ -5605,12 +5604,12 @@ static void resolveMove(CallExpr* call) {
 //
 // This function is a combination of resolveMove and resolveSetMember
 static void
-resolveFieldInit(CallExpr* call) {
+resolveInitField(CallExpr* call) {
   if (call->id == breakOnResolveID )
     gdbShouldBreakHere();
 
   INT_ASSERT(call->argList.length == 3);
-  // PRIM_INITIALIZER_SET_FIELD contains three args:
+  // PRIM_INIT_FIELD contains three args:
   // fn->_this, the name of the field, and the value/type it is to be given
 
   SymExpr* rhs = toSymExpr(call->get(3)); // the value/type to give the field


### PR DESCRIPTION
1) Rename PRIM_INITIALIZER_SET_FIELD to be PRIM_INIT_FIELD

The new name is shorter and is consistent with PRIM_INIT_VAR (which plays a broadly similar role
for variables).


2) An update to the pre-normalize phase for initializers.  Stop setting the returnExprType to be
"void" for initializers.  No change in behavior but the intermediate AST is trivially simpler.


3) Decouple the new function from resolveFieldInit() from the old function resolveSetMember().
The former needs additional edits to resolve initializer bugs.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed local start_test on darwin for test/classes/initializers -futures -compopts --verify
Passed single-locale paratest for -futures -compopts --verify
