### PR TITLE
Update line number for .bad file

### DIFF
--- a/test/users/ferguson/bug-zhao.bad
+++ b/test/users/ferguson/bug-zhao.bad
@@ -1,4 +1,4 @@
-bug-zhao.chpl:7: internal error: EXP5737 chpl Version 1.12.0.bebb76c
+bug-zhao.chpl:7: internal error: EXP3147 chpl Version 1.12.0.bebb76c
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 


### PR DESCRIPTION
I noticed that the future test/users/ferguson/bug-zhao had started failing due to a mismatched
.bad file.  The error had not changed but the line number had.

This PR updates the line number in the .bad file so that the future is failing in the expected way.

I have done local testing on darwin.



Point of Confusion

However I am a little confused about this.  The .future describes the correct problem but
the line number in the .bad is completely out of date.  The line number is consistent with
the error that would have been produced for expr.cpp before it was split into AST/expr.cpp
and codegen/expr.cpp.  It couldn't possibly be correct now.

I looked at some recent nightly logs and they show that the program has been producing the
"correct" line number.  So I can't see why start_test has only just started reporting the mismatch
for the .bad file.

I tried checking out a few old commits and it seemed to me that the failures on the old branches
are consistent with what I see on master.

