### PR TITLE
Quiet void_extern_proc_array under cce

### DIFF
--- a/test/users/ibertolacc/void_extern_proc_array.c
+++ b/test/users/ibertolacc/void_extern_proc_array.c
@@ -5,3 +5,4 @@ void voidArrayFunction( int* a, int elems ){
     a[i] = i;
   }
 }
+

--- a/test/users/ibertolacc/void_extern_proc_array.h
+++ b/test/users/ibertolacc/void_extern_proc_array.h
@@ -1,1 +1,2 @@
 void voidArrayFunction( int* a, int elems );
+


### PR DESCRIPTION
This recently retired future was failing under cce with a warning about not
ending with a newline. This just adds a newline to the .c/.h files.