### PR TITLE
Fix 64-bit ARM GASNet build

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -69,7 +69,7 @@ CHPL_GASNET_CFG_OPTIONS += --disable-portals
 endif
 else
 ifeq ($(CHPL_MAKE_TARGET_PLATFORM),aarch64)
-CHPL_GASNET_CFG_OPTIONS += --host=aarch64-unknown-linux-gnu --enable-pthreads
+CHPL_GASNET_CFG_OPTIONS += --enable-pthreads
 CHPL_GASNET_CFG_SCRIPT=cross-configure-aarch64-linux
 XTRA_CONFIG_COMMAND=cp --update $(GASNET_SUBDIR)/other/contrib/$(CHPL_GASNET_CFG_SCRIPT) $(GASNET_SUBDIR)
 XTRA_POST_INSTALL_COMMAND=rm -f $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT)

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -69,7 +69,7 @@ CHPL_GASNET_CFG_OPTIONS += --disable-portals
 endif
 else
 ifeq ($(CHPL_MAKE_TARGET_PLATFORM),aarch64)
-CHPL_GASNET_CFG_OPTIONS += --enable-pthreads
+CHPL_GASNET_CFG_OPTIONS += --host=aarch64-unknown-linux-gnu --enable-pthreads
 CHPL_GASNET_CFG_SCRIPT=cross-configure-aarch64-linux
 XTRA_CONFIG_COMMAND=cp --update $(GASNET_SUBDIR)/other/contrib/$(CHPL_GASNET_CFG_SCRIPT) $(GASNET_SUBDIR)
 XTRA_POST_INSTALL_COMMAND=rm -f $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT)

--- a/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
+++ b/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
@@ -39,7 +39,7 @@ EXTRA_CONFIGURE_ARGS="$EXTRA_CONFIGURE_ARGS --enable-backtrace-execinfo"
 
 # 2. Fill in the canonical target machine type. You can usually obtain this
 #   by running config-aux/config.guess on the target machine
-TARGET_ID='x86_64-cnl-linux-gnu'
+TARGET_ID='aarch64-unknown-linux-gnu'
 
 # 3. Review the automatically-detected settings below and make corrections as necessary.
 
@@ -92,10 +92,10 @@ if test ! -f "$SRCDIR/configure" ; then
   echo "ERROR: The $0 script should be placed in the same directory as the configure script before execution"
   exit 1
 fi
-# Detect the build host machine type
-HOST_ARG=`echo "$@" | grep -e --host`
-HOST_APPEND=
-if test "$HOST_ARG" = ""; then
+# Detect the build machine type
+BUILD_ARG=`echo "$@" | grep -e --build`
+BUILD_APPEND=
+if test "$BUILD_ARG" = ""; then
   oldCC_FOR_BUILD="$CC_FOR_BUILD"
   oldHOST_CC="$HOST_CC"
   oldCC="$CC"
@@ -106,14 +106,14 @@ if test "$HOST_ARG" = ""; then
     HOST_ID=`$SRCDIR/config-aux/config.guess`
   fi
   if test "$HOST_ID" = ""; then
-    echo 'ERROR: failed to auto-detect build host. Please run with --host=machineid to identify the host machine running this script'
+    echo 'ERROR: failed to auto-detect build machine. Please run with --build=machineid to identify the build machine running this script'
     exit 1
   else
-    HOST_APPEND="--host=$HOST_ID"
+    BUILD_APPEND="--build=$HOST_ID"
   fi
   CC_FOR_BUILD="$oldCC_FOR_BUILD"
   HOST_CC="$oldHOST_CC"
   CC="$oldCC"
 fi
 # Now that everything is setup, run the actual configure script
-$SRCDIR/configure --enable-cross-compile $HOST_APPEND --build=$TARGET_ID --target=$TARGET_ID --program-prefix='' $EXTRA_CONFIGURE_ARGS "$@"
+$SRCDIR/configure --enable-cross-compile $BUILD_APPEND --host=$TARGET_ID --target=$TARGET_ID --program-prefix='' $EXTRA_CONFIGURE_ARGS "$@"

--- a/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
+++ b/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
@@ -39,7 +39,7 @@ EXTRA_CONFIGURE_ARGS="$EXTRA_CONFIGURE_ARGS --enable-backtrace-execinfo"
 
 # 2. Fill in the canonical target machine type. You can usually obtain this
 #   by running config-aux/config.guess on the target machine
-TARGET_ID='aarch64-unknown-linux-gnu'
+TARGET_ID='aarch64-cnl-linux-gnu'
 
 # 3. Review the automatically-detected settings below and make corrections as necessary.
 
@@ -116,4 +116,4 @@ if test "$HOST_ARG" = ""; then
   CC="$oldCC"
 fi
 # Now that everything is setup, run the actual configure script
-$SRCDIR/configure --enable-cross-compile $HOST_APPEND --build=$HOST_ID --target=$TARGET_ID --program-prefix='' $EXTRA_CONFIGURE_ARGS "$@"
+$SRCDIR/configure --enable-cross-compile $HOST_APPEND --build=$TARGET_ID --target=$TARGET_ID --program-prefix='' $EXTRA_CONFIGURE_ARGS "$@"

--- a/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
+++ b/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
@@ -92,10 +92,10 @@ if test ! -f "$SRCDIR/configure" ; then
   echo "ERROR: The $0 script should be placed in the same directory as the configure script before execution"
   exit 1
 fi
-# Detect the build machine type
-BUILD_ARG=`echo "$@" | grep -e --build`
-BUILD_APPEND=
-if test "$BUILD_ARG" = ""; then
+# Detect the build host machine type
+HOST_ARG=`echo "$@" | grep -e --host`
+HOST_APPEND=
+if test "$HOST_ARG" = ""; then
   oldCC_FOR_BUILD="$CC_FOR_BUILD"
   oldHOST_CC="$HOST_CC"
   oldCC="$CC"
@@ -106,14 +106,14 @@ if test "$BUILD_ARG" = ""; then
     HOST_ID=`$SRCDIR/config-aux/config.guess`
   fi
   if test "$HOST_ID" = ""; then
-    echo 'ERROR: failed to auto-detect build machine. Please run with --build=machineid to identify the build machine running this script'
+    echo 'ERROR: failed to auto-detect build host. Please run with --host=machineid to identify the host machine running this script'
     exit 1
   else
-    BUILD_APPEND="--build=$HOST_ID"
+    HOST_APPEND="--host=$HOST_ID"
   fi
   CC_FOR_BUILD="$oldCC_FOR_BUILD"
   HOST_CC="$oldHOST_CC"
   CC="$oldCC"
 fi
 # Now that everything is setup, run the actual configure script
-$SRCDIR/configure --enable-cross-compile $BUILD_APPEND --host=$TARGET_ID --target=$TARGET_ID --program-prefix='' $EXTRA_CONFIGURE_ARGS "$@"
+$SRCDIR/configure --enable-cross-compile $HOST_APPEND --build=$HOST_ID --target=$TARGET_ID --program-prefix='' $EXTRA_CONFIGURE_ARGS "$@"

--- a/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
+++ b/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
@@ -31,7 +31,7 @@ MPI_CC="$CC" ; export MPI_CC     # MPI-enabled C compiler
 #MPI_CFLAGS='' ; export MPI_CFLAGS  # flags for MPI_CC
 MPI_LIBS='' ; export MPI_LIBS      # libs for linking with MPI_CC
 MPIRUN_CMD="${APRUN:-aprun} -n %N %C" ; export MPIRUN_CMD  # launch command for MPI jobs
-EXTRA_CONFIGURE_ARGS="--disable-auto-conduit-detect --enable-smp --disable-aligned-segments --enable-pshm --disable-pshm-posix --enable-pshm-xpmem --enable-throttle-poll"
+EXTRA_CONFIGURE_ARGS="--disable-auto-conduit-detect --enable-smp --enable-udp --disable-aligned-segments --enable-pshm --disable-pshm-posix --enable-pshm-xpmem --enable-throttle-poll"
 # OS string for test harness purposes
 EXTRA_CONFIGURE_ARGS="$EXTRA_CONFIGURE_ARGS --with-feature-list=os_cnl"
 # minimal backtracing support

--- a/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
+++ b/third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
@@ -31,7 +31,7 @@ MPI_CC="$CC" ; export MPI_CC     # MPI-enabled C compiler
 #MPI_CFLAGS='' ; export MPI_CFLAGS  # flags for MPI_CC
 MPI_LIBS='' ; export MPI_LIBS      # libs for linking with MPI_CC
 MPIRUN_CMD="${APRUN:-aprun} -n %N %C" ; export MPIRUN_CMD  # launch command for MPI jobs
-EXTRA_CONFIGURE_ARGS="--disable-auto-conduit-detect --enable-mpi --enable-smp --disable-aligned-segments --enable-pshm --disable-pshm-posix --enable-pshm-xpmem --enable-throttle-poll"
+EXTRA_CONFIGURE_ARGS="--disable-auto-conduit-detect --enable-smp --disable-aligned-segments --enable-pshm --disable-pshm-posix --enable-pshm-xpmem --enable-throttle-poll"
 # OS string for test harness purposes
 EXTRA_CONFIGURE_ARGS="$EXTRA_CONFIGURE_ARGS --with-feature-list=os_cnl"
 # minimal backtracing support


### PR DESCRIPTION
This change causes gasnet-udp to build correctly for 64-bit ARM.

Only one file is changed, and that file only affects this one configuration, which never worked before.  Therefore, this PR is tested but not reviewed.