### PR TITLE
Only include objects with CPUs in the NUMA node count.

### DIFF
--- a/runtime/src/chpl-topo.c
+++ b/runtime/src/chpl-topo.c
@@ -153,24 +153,9 @@ void chpl_topo_init(void) {
   // is memory-only, no CPUs.
   //
   {
-    hwloc_cpuset_t cpuset;
-    hwloc_obj_t obj;
-
-    if ((cpuset = hwloc_bitmap_alloc()) == NULL) {
-      report_error("hwloc_bitmap_alloc()", errno);
-    }
-
-    numNumaDomains = 0;
-    for (obj = hwloc_get_next_obj_by_depth(topology, numaLevel, NULL);
-         obj != NULL;
-         obj = hwloc_get_next_obj_by_depth(topology, numaLevel, obj)) {
-      hwloc_bitmap_and(cpuset, obj->online_cpuset, obj->allowed_cpuset);
-      if (!hwloc_bitmap_iszero(cpuset)) {
-        numNumaDomains++;
-      }
-    }
-
-    hwloc_bitmap_free(cpuset);
+    const hwloc_cpuset_t cpusetAll = hwloc_get_root_obj(topology)->cpuset;
+    numNumaDomains =
+      hwloc_get_nbobjs_inside_cpuset_by_depth(topology, cpusetAll, numaLevel);
   }
 }
 

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -471,6 +471,6 @@ chpl_bool chpl_mem_impl_alloc_localizes(void) {
   // some virtual-memory, and we can't just go touching all the pages.
   //
   return (get_num_heaps() > 1
-          && strcmp(CHPL_LOCALE_MODEL, "numa") == 0
+          && strcmp(CHPL_LOCALE_MODEL, "flat") != 0
           && strcmp(CHPL_COMM, "ugni") == 0);
 }


### PR DESCRIPTION
The topology layer's NUMA node count was simply the number of objects at
the topology's NUMA level.  This isn't right when some of the objects
there don't actually have CPUs, as for example the object for Intel Xeon
Phi (AKA KNL)  onboard memory (AKA HBM, MCDRAM, etc.).  From now on,
only include in the count objects that have CPUs associated with them.

Having done this, re-enable registered heap localization for KNL.

While here, I also fixed a broken debug output request in the topology
layer.