### PR TITLE
Work around a bug involving tuple types in conditional expressions

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -50,7 +50,10 @@ module DefaultRectangular {
   // helper function to set the types of multi-ddata specific fields
   // to 'void' when they are not needed
   proc mdType(type baseType) type {
-    return if defRectSimpleDData then void else baseType;
+    if defRectSimpleDData then
+      return void;
+    else
+      return baseType;
   }
 
   class DefaultDist: BaseDist {


### PR DESCRIPTION
The void-multi-ddata fields change ran into a bug (see PR #5741) that caused
errors about using a value where a type was expected. Use a conditional
statement with two returns instead of a conditional expression to work
around that bug.

I tested that all of the failing tests now compile for CHPL_LOCALE_MODEL=numa
And did a plain linux64 paratest