### PR TITLE
Roll up of a few pending trivial changes for initializers

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -1825,7 +1825,7 @@ int AstDumpToNode::writeQual(QualifiedType qual) const
 {
   const char* name = qual.qualStr();
 
-  fprintf(mFP, "qual: %s", name);
+  fprintf(mFP, "qual: %-16s", name);
 
   return 6 + ((int) strlen(name));
 }

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1915,8 +1915,8 @@ bool isNonGenericClass(Type* type) {
   bool retval = false;
 
   if (AggregateType* at = toAggregateType(type)) {
-    if (at->isGeneric()                  == false &&
-        at->isClass()                    ==  true &&
+    if (at->isClass()                    ==  true &&
+        at->isGeneric()                  == false &&
         at->symbol->hasFlag(FLAG_EXTERN) == false) {
       retval = true;
     }
@@ -1928,24 +1928,35 @@ bool isNonGenericClass(Type* type) {
 bool isNonGenericClassWithInitializers(Type* type) {
   bool retval = false;
 
+  if (isNonGenericClass(type) == true) {
+    if (AggregateType* at = toAggregateType(type)) {
+      retval = at->initializerStyle == DEFINES_INITIALIZER;
+    }
+  }
+
+  return retval;
+}
+
+bool isNonGenericRecord(Type* type) {
+  bool retval = false;
+
   if (AggregateType* at = toAggregateType(type)) {
-    if (at->isGeneric()      == false &&
-        at->isClass()        == true  &&
-        at->initializerStyle == DEFINES_INITIALIZER) {
+    if (at->isRecord()                   == true  &&
+        at->isGeneric()                  == false &&
+        at->symbol->hasFlag(FLAG_EXTERN) == false) {
       retval = true;
     }
   }
 
   return retval;
 }
+
 bool isNonGenericRecordWithInitializers(Type* type) {
   bool retval = false;
 
-  if (AggregateType* at = toAggregateType(type)) {
-    if (at->isGeneric()      == false &&
-        at->isRecord()       == true  &&
-        at->initializerStyle == DEFINES_INITIALIZER) {
-      retval = true;
+  if (isNonGenericRecord(type) == true) {
+    if (AggregateType* at = toAggregateType(type)) {
+      retval = at->initializerStyle == DEFINES_INITIALIZER;
     }
   }
 

--- a/compiler/include/initializerRules.h
+++ b/compiler/include/initializerRules.h
@@ -23,7 +23,8 @@
 class AggregateType;
 class FnSymbol;
 
-void      initMethodPreNormalize(FnSymbol* fn);
+void      preNormalizeFields(AggregateType* at);
+void      preNormalizeInitMethod(FnSymbol* fn);
 FnSymbol* buildClassAllocator(FnSymbol* initMethod);
 
 #endif

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -443,11 +443,14 @@ private:
   void                        addDeclaration(DefExpr* defExpr);
 
   std::vector<AggregateType*> instantiations;
+
   // genericField stores the index of the first generic field in the
-  // AggregateType which does not have a substitution, but only if the
-  // AggregateType defines an initializer.  If the type has no generic
-  // fields without substitutions, or if setNextGenericField has not been called
-  // on the base AggregateType, this will be set to 0.
+  // AggregateType which does not have a substitution,
+  // but only if the AggregateType defines an initializer.
+  //
+  // If the type has no generic fields without substitutions,
+  // or if setNextGenericField has not been called on the base AggregateType,
+  // this will be set to 0.
   int                         genericField;
 
   bool                        mIsGeneric;
@@ -591,7 +594,9 @@ bool isString(Type* type);
 bool isUserDefinedRecord(Type* type);
 
 bool isPrimitiveScalar(Type* type);
-bool isNonGenericClass(Type* type);
+
+bool isNonGenericClass (Type* type);
+bool isNonGenericRecord(Type* type);
 
 bool isNonGenericClassWithInitializers (Type* type);
 bool isNonGenericRecordWithInitializers(Type* type);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4614,6 +4614,7 @@ void resolveCall(CallExpr* call) {
     case PRIM_INIT_FIELD:
       resolveInitField(call);
       break;
+
     case PRIM_INIT_VAR:
       resolveInitVar(call);
       break;


### PR DESCRIPTION
This is a simple PR that collects a few trivial changes that I have accumulated on a branch.

A. Tweak the alignment when AstDumpToNode displays the qual sub-field of a qualified type


B. Add a helper function isNonGenericRecord() to type.{h,cpp}.  That is consistent with 
isNonGenericClass().


C. There is currently a "pre-normalize" sub-pass that operates on initializers early in normalize.
Add a sub-pass "pre-normalizes" the fields of these class/records in a few simple situations.


D. Add a missing new-line to function-resolution.cpp


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed local testing of classes/initializers -futures on darwin
Passed local testing of classes/initializers -futures on linux64
Passed single-locale paratest on chapcs


