### PR TITLE
Remove -q from diff command in checkChplInstall

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -217,7 +217,7 @@ TEST_EXEC_OUT=${TEST_JOB}.exec.out
     log_info "Test job complete."
 
     # Check result
-    DIFF_OUTPUT=$(diff -q ${GOOD} ${TEST_EXEC_OUT})
+    DIFF_OUTPUT=$(diff ${GOOD} ${TEST_EXEC_OUT})
 
     # Return success code (0) if diff is good
     if [ -z "${DIFF_OUTPUT}" ]; then


### PR DESCRIPTION
I noticed that diff -q is not portable (at least on OmniOS it is an error). At the same time, on Linux and Mac OS X, whet 'make check' works correctly, diff does not seem to output anything anyway.

The -q was added along with the diff to this script in c2f09379750f3e068def8cb0346758c9f078c415.

Verified make check looks OK on Mac OS X and on Linux.