### PR TITLE
Don't ever report a number of CPUs less than 1 (one).

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -486,8 +486,10 @@ static void getCpuInfo(int* p_numPhysCpus, int* p_numLogCpus) {
     cpuCores = 1;
   if (siblings == 0)
     siblings = 1;
-  *p_numPhysCpus = procs / (siblings / cpuCores);
-  *p_numLogCpus = procs;
+  if ((*p_numPhysCpus = procs / (siblings / cpuCores)) <= 0)
+    *p_numPhysCpus = 1;
+  if ((*p_numLogCpus = procs) <= 0)
+    *p_numLogCpus = 1;
 }
 #endif
 
@@ -554,6 +556,9 @@ int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
         numLogCpusAcc = 1;
       numCpus = (numPhysCpus * numLogCpusAcc) / numLogCpus;
 #endif
+
+      if (numCpus <= 0)
+        numCpus = 1;
     }
     return numCpus;
   }
@@ -625,6 +630,9 @@ int chpl_getNumLogicalCpus(chpl_bool accessible_only) {
         numLogCpusAcc = 1;
       numCpus = (numLogCpusAcc < numLogCpus) ? numLogCpusAcc : numLogCpus;
 #endif
+
+      if (numCpus <= 0)
+        numCpus = 1;
     }
     return numCpus;
   }


### PR DESCRIPTION
A user issue (https://github.com/chapel-lang/chapel/issues/5536) reports
test failures that ultimately are caused by chpl_getNumPhysicalCpus()
returning 0 (zero).  This change ensures that both of the functions that
return CPU counts always return 1 (one) or higher.

In the next release much of this code should be reworked in favor of
getting the value from the topology layer, but that's too big a change
for code freeze week.