### PR TITLE
Use hw.ncpu to compute # cpus on FreeBSD

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -58,7 +58,7 @@
 #include <sys/mman.h>
 #include <sys/utsname.h>
 
-#if defined(__APPLE__) || defined(__NetBSD__)
+#if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #endif
 
@@ -519,6 +519,15 @@ int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
   if (numCpus == 0)
     numCpus = chpl_getNumLogicalCpus(true);
   return numCpus;
+#elif defined  __FreeBSD__
+  //
+  // FreeBSD
+  //
+  static int numCpus = 0;
+  if (numCpus == 0)
+    numCpus = chpl_getNumLogicalCpus(true);
+  return numCpus;
+
 #elif defined(__linux__) || defined(__NetBSD__)
   //
   // Linux
@@ -599,6 +608,18 @@ int chpl_getNumLogicalCpus(chpl_bool accessible_only) {
   if (numCpus == 0)
     numCpus = sysconf(_SC_NPROCESSORS_ONLN);
   return numCpus;
+#elif defined __FreeBSD__
+  //
+  // FreeBSD
+  //
+  static int32_t numCpus = 0;
+  if (numCpus == 0) {
+    size_t len = sizeof(numCpus);
+    if (sysctlbyname("hw.ncpu", &numCpus, &len, NULL, 0))
+      chpl_internal_error("query of number of PUs failed");
+  }
+  return (int) numCpus;
+
 #elif defined(__linux__) || defined(__NetBSD__)
   //
   // Linux


### PR DESCRIPTION
Avoids a compilation warning with FreeBSD 11 in quickstart mode. The warning we would see is:

```
chplsys.c:568:2: warning: "Target architecture is not yet supported."
      [-W#warnings]
#warning "Target architecture is not yet supported."
 ^
chplsys.c:639:2: warning: "Target architecture is not yet supported."
      [-W#warnings]
#warning "Target architecture is not yet supported."
 ^
2 warnings generated.
```

* full local testing
* verified clean build on FreeBSD 11
* verified here.numPUs reports a reasonable value on FreeBSD 11

Reviewed by @gbtitus - thanks!