### PR TITLE
Switch array view playground over to new reindex work

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -11,7 +11,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
 # Test performance of array-views branch
 GITHUB_USER=bradcray
-GITHUB_BRANCH=rankChangeDomDistView
+GITHUB_BRANCH=reindexDomDistView
 SHORT_NAME=arrView
 START_DATE=02/06/17
 


### PR DESCRIPTION
This switches the array view playground over to my new "preserve locality for domains/distributions of reindex views branch"
