### PR TITLE
Stop using curly-brace wildcards to accommodate limited shells

### DIFF
--- a/third-party/amudprun/Makefile
+++ b/third-party/amudprun/Makefile
@@ -23,7 +23,9 @@ amudprun: configure-amudprun build-amudprun install-amudprun
 configure-amudprun: FORCE
 	mkdir -p $(AMUDPRUN_BUILD_DIR)
 	cp $(AMUDPRUN_SRC_DIR)/Makefile* $(AMUDPRUN_BUILD_DIR)
-	cp $(AMUDPRUN_SRC_DIR)/*.{c,cpp,h} $(AMUDPRUN_BUILD_DIR)
+	cp $(AMUDPRUN_SRC_DIR)/*.c $(AMUDPRUN_BUILD_DIR)
+	cp $(AMUDPRUN_SRC_DIR)/*.cpp $(AMUDPRUN_BUILD_DIR)
+	cp $(AMUDPRUN_SRC_DIR)/*.h $(AMUDPRUN_BUILD_DIR)
 	cp $(AMUDPRUN_SRC_DIR)/../portable_*.h $(AMUDPRUN_BUILD_DIR)
 
 build-amudprun: FORCE


### PR DESCRIPTION
Ubuntu uses a faster, leaner shell with limited capabilities inside make.  Curly-brace wildcards are not supported.  This change removes an instance of curly-brace wildcards from #5750 for portability.

Thanks to @cassella for reporting this.

[trivial, tested but not reviewed]