### PR TITLE
Draft of language evolution for array scoping, return, blank intent changes

### DIFF
--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -53,10 +53,10 @@ Now the act of returning an array makes a copy:
 .. code-block:: chapel
 
   var A: [1..4] int;
-  proc f() {
+  proc returnsArray() {
     return A;
   }
-  ref B = f();
+  ref B = returnsArray();
   B = 1;
   writeln(a);
   // outputs 1 1 1 1 historically
@@ -71,7 +71,7 @@ return a local `int` variable by `ref`.
 
 .. code-block:: chapel
 
-  proc f() ref {
+  proc returnsArrayReference() ref {
     return A;
   }
 
@@ -140,23 +140,23 @@ argument `x` is `ref`:
 
 .. code-block:: chapel
 
-  proc f(x) {
+  proc setElementOne(x) {
     // x is modified, so as if formal was ref x
     x[1] = 1;
   }
   var A:[1..10] int;
-  f(A);
+  setElementOne(A);
 
 In contrast, in the following program, the default intent for the formal argument `y` is `const ref`:
 
 .. code-block:: chapel
 
-  proc g(y) {
+  proc getElementOne(y) {
     // y is not modified, so as if formal was const ref y
     var tmp = y[1];
   }
   const B:[1..10] int;
-  g(B);
+  getElementOne(B);
 
 
 record `this` default intent

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -11,6 +11,71 @@ predated the changes.
 version 1.15, April 2017
 ------------------------
 
+Version 1.15 includes several language changes to improve array semantics.
+
+array lexical scoping
+*********************
+
+Continuing on the changes for 1.12 described below in
+:ref:`readme-evolution.lexical-scoping`, using arrays beyond
+their scope is now a user error:
+
+.. code-block:: chapel
+
+  proc badBegin() {
+    var A: [1..10000] int;
+    begin {
+      A += 1;
+    }
+    // Error: A destroyed here at function end, but the begin could still be using it!
+  }
+
+
+Similarly, using a slice after an array has been destroyed is an error:
+
+.. code-block:: chapel
+
+  proc badBeginSlice() {
+    var A: [1..10000] int;
+    var slice => A[1..1000];
+    begin {
+      slice += 1;
+    }
+    // Error: A destroyed here at function end, but the begin tries to use it through the slice!
+  }
+
+
+arrays return by value by default
+*********************************
+
+Now the act of returning an array makes a copy:
+
+.. code-block:: chapel
+
+  var A: [1..4] int;
+  proc f() {
+    return A;
+  }
+  ref B = f();
+  B = 1;
+  writeln(a);
+  // outputs 1 1 1 1 historically
+  // outputs 0 0 0 0 after this work
+
+
+This behavior applies to array slices as well.
+
+The old behavior is available with the `ref` return intent. Note though that
+returning a `ref` to a local array is an error just like it is an error to
+return a local `int` variable by `ref`.
+
+.. code-block:: chapel
+
+  proc f() ref {
+    return A;
+  }
+
+
 array blank intent
 ******************
 
@@ -181,6 +246,8 @@ call that function from the getter or setter.
 
 version 1.12, October 2015
 --------------------------
+
+.. _readme-evolution.lexical-scoping:
 
 lexical scoping
 ***************

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -85,7 +85,7 @@ to modifying array formal arguments in their functions. Unfortunately, it
 interacted poorly with the `ref-pair` feature in the language.
 Additionally, the implementation had several bugs in this area.
 
-The following example shows how it might be suprising that the `ref-pair`
+The following example shows how it might be surprising that the `ref-pair`
 feature behaves very differently for arrays than for other types. As
 the example shows, this issue affects program behavior and not just
 const-checking error messages from the compiler.
@@ -130,7 +130,7 @@ const-checking error messages from the compiler.
 
 See GitHub issue #5217 for more examples and discussion.
 
-In order to make such programs less suprising, version 1.15 changes the default
+In order to make such programs less surprising, version 1.15 changes the default
 intent for arrays to `ref` if the formal argument is modified in the function
 and `const ref` if not. As a result, the above example behaves similarly for an
 associative array of integers and an associative array of dense arrays.

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -58,7 +58,7 @@ Now the act of returning an array makes a copy:
   }
   ref B = returnsArray();
   B = 1;
-  writeln(a);
+  writeln(A);
   // outputs 1 1 1 1 historically
   // outputs 0 0 0 0 after this work
 
@@ -82,11 +82,11 @@ array blank intent
 Before 1.15, the default intent for arrays was `ref`. The rationale for
 this feature was that it was a convenience for programmers who are used
 to modifying array formal arguments in their functions. Unfortunately, it
-interacted poorly with the `ref-pair` feature in the language.
+interacted poorly with return intent overloading.
 Additionally, the implementation had several bugs in this area.
 
-The following example shows how it might be surprising that the `ref-pair`
-feature behaves very differently for arrays than for other types. As
+The following example shows how it might be surprising that return intent
+overloading behaves very differently for arrays than for other types. As
 the example shows, this issue affects program behavior and not just
 const-checking error messages from the compiler.
 
@@ -141,7 +141,7 @@ argument `x` is `ref`:
 .. code-block:: chapel
 
   proc setElementOne(x) {
-    // x is modified, so as if formal was ref x
+    // x is modified, so x has ref intent
     x[1] = 1;
   }
   var A:[1..10] int;
@@ -152,7 +152,7 @@ In contrast, in the following program, the default intent for the formal argumen
 .. code-block:: chapel
 
   proc getElementOne(y) {
-    // y is not modified, so as if formal was const ref y
+    // y is not modified, so y has const ref intent
     var tmp = y[1];
   }
   const B:[1..10] int;
@@ -173,14 +173,12 @@ See GitHub issue #5266 for more details and discussion.
     var field: int;
 
     proc setFieldToOne() {
-      // since this is not modified, as if
-      // this intent was ref
+      // this is modified, so this-intent is ref
       this.field = 1;
     }
 
     proc printField() {
-      // since this is not modified, as if
-      // this intent was const ref
+      // this is not modified, so this-intent is const ref
       writeln(this.field);
     }
   }


### PR DESCRIPTION
Updates evolution.rst to discuss:
 * more strict array "lexical scoping"
 * arrays return by value by default
 * array blank intent is ref-if-modified
 * record this blank intent is ref-if-modified

Reviewed by @benharsh - thanks!