### PR TITLE
Cleanup MPI with module deinit

### DIFF
--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -213,13 +213,9 @@ module MPI {
   // Module level deinit
   proc deinit() {
     if _freeChplComm {
-      if numLocales > 1 {
-        coforall loc in Locales do on loc {
-            C_MPI.MPI_Comm_free(CHPL_COMM_WORLD_REPLICATED(1));
-          }
-      } else {
-        C_MPI.MPI_Comm_free(CHPL_COMM_WORLD_REPLICATED(1));
-      }
+      coforall loc in Locales do on loc {
+          C_MPI.MPI_Comm_free(CHPL_COMM_WORLD_REPLICATED(1));
+        }
     }
     if _doinit {
       coforall loc in Locales do

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -208,42 +208,37 @@ module MPI {
   }
 
   pragma "no doc"
-  record _initMPI {
-    var doinit : bool = false;
-    var freeChplComm : bool = false;
-
-    pragma "no doc"
-    proc deinit() {
-      if freeChplComm {
-        if numLocales > 1 {
-          coforall loc in Locales do on loc {
+  var _doinit : bool = false;
+  var _freeChplComm : bool = false;
+  // Module level deinit
+  proc deinit() {
+    if _freeChplComm {
+      if numLocales > 1 {
+        coforall loc in Locales do on loc {
             C_MPI.MPI_Comm_free(CHPL_COMM_WORLD_REPLICATED(1));
           }
-        } else {
-          C_MPI.MPI_Comm_free(CHPL_COMM_WORLD_REPLICATED(1));
+      } else {
+        C_MPI.MPI_Comm_free(CHPL_COMM_WORLD_REPLICATED(1));
+      }
+    }
+    if _doinit {
+      coforall loc in Locales do
+        on loc {
+          // TODO : Need a gasnet barrier here???
+          if debugMPI then writeln("Calling MPI_Finalize....");
+          C_MPI.MPI_Finalize();
         }
-      }
-      if doinit {
-        coforall loc in Locales do
-          on loc {
-            // TODO : Need a gasnet barrier here???
-            if debugMPI then writeln("Calling MPI_Finalize....");
-            C_MPI.MPI_Finalize();
-          }
-      }
     }
   }
 
-  pragma "no doc"
-  var _mpi : _initMPI;
-
+  // Initialization routine
   if autoInitMPI {
     if debugMPI then writeln("Attempting to auto-initialize MPI.....");
     var flag : c_int;
     C_MPI.MPI_Initialized(flag);
     if flag==0 {
       if debugMPI then writeln("Initializing MPI....");
-      _mpi.doinit = true;
+      _doinit = true;
       initialize();
     } else {
       var provided : c_int;
@@ -295,7 +290,7 @@ module MPI {
     }
 
     // Set flag to free
-    _mpi.freeChplComm = true;
+    _freeChplComm = true;
   }
 
   /*


### PR DESCRIPTION
The MPI module previously used a module-level record to
handle cleanup of the MPI module. With the introduction of
module level deinits, this is no longer necessary, and so we
remove the record, and use a module deinit.

Note that the issue of CHPL_COMM_WORLD being deallocated too 
early has now been resolved upstream (thanks!).

Tested on Linux --
 
 CHPL_COMM=none 
    (modules/packages/mpi/spmd/hello-chapel)
 CHPL_COMM=gasnet CHPL_COMM_SUBSTRATE=mpi 
   (modules/packages/mpi/multilocale/hello-chapel)

This partially addresses #5751 (point 3).
 