### PR TITLE
Add BOOL_SIZE_SYS to the list of types that are "primitive scalar" types

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1885,6 +1885,7 @@ bool isPrimitiveScalar(Type* type) {
       type == dtBools[BOOL_SIZE_16]        ||
       type == dtBools[BOOL_SIZE_32]        ||
       type == dtBools[BOOL_SIZE_64]        ||
+      type == dtBools[BOOL_SIZE_SYS]       ||
 
       type == dtInt[INT_SIZE_8]            ||
       type == dtInt[INT_SIZE_16]           ||


### PR DESCRIPTION
Prior to the is PR the utility predicate

bool isPrimitiveScalar(Type* type); 

failed to consider dtBool[BOOL_SIZE_SYS] to be a primitive scalar.

A trivial change to add this type to the list of other BOOL_SIZE_*.

Performed some local testing and then a single-locale paratest for the sake of cargo science.
