### PR TITLE
Inline DefaultRectangular 1D strided iter

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1944,9 +1944,9 @@ module DefaultRectangular {
               start  = viewDomDim.first,
               second = info.getDataIndex(start + stride);
 
-        var   first  = info.getDataIndex(start),
-              step   = (second-first):chpl__signedType(viewDom.idxType),
-              last   = first + (viewDomDim.length-1) * step:viewDom.idxType;
+        var   first  = info.getDataIndex(start);
+        const step   = (second-first):chpl__signedType(viewDom.idxType);
+        var   last   = first + (viewDomDim.length-1) * step:viewDom.idxType;
 
         if step < 0 then
           last <=> first;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1942,16 +1942,17 @@ module DefaultRectangular {
         const viewDomDim = viewDom.dsiDim(1),
               stride = viewDomDim.stride: viewDom.idxType,
               start  = viewDomDim.first,
-              first  = info.getDataIndex(start),
-              second = info.getDataIndex(start + stride),
+              second = info.getDataIndex(start + stride);
+
+        var   first  = info.getDataIndex(start),
               step   = (second-first):chpl__signedType(viewDom.idxType),
               last   = first + (viewDomDim.length-1) * step:viewDom.idxType;
-        if step > 0 then
-          for i in first..last by step do
-            yield info.data(i);
-        else
-          for i in last..first by step do
-            yield info.data(i);
+
+        if step < 0 then
+          last <=> first;
+
+        for i in first..last by step do
+          yield info.data(i);
       }
     } else if useCache {
       for i in viewDom {


### PR DESCRIPTION
As far as I can tell, DefaultRectangular 1D strided iterators have never inlined (either directly or when zippered). We recently noticed a regression in a performance test that tracks 1D strided iteration performance. I'm not entirely sure of the cause but I believe b8fe0872 , which switched a call from 'ranges' to 'dsiDim', is involved. My guess is that creating that range every iteration was slightly more costly.

The simplest solution seems to be to rewrite this code such that it will inline, primarily by only having a single yield (as opposed to two across runtime-conditional branches).

This change not only resolves the regression, but brings the 1D strided performance even with 1D dense performance.

Testing:
- [x] full local