### PR TITLE
Remove the rule to generate STATUS from STATUS.devel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ tags
 # Top level ignores.
 /BUILD_VERSION
 /Chapel.xcodeproj
-/STATUS
 /SVNLOG
 /.SVNLOG-revnum
 /bin

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -17,7 +17,7 @@
 
 PYTHON_VERSION_DIR = py$(shell $(CHPL_MAKE_HOME)/util/chplenv/chpl_python_version.py)
 
-develall: STATUS
+develall:
 	@$(MAKE) always-build-man
 	@$(MAKE) always-build-chplspell-venv
 
@@ -63,10 +63,6 @@ SPECTEST_DIR = ./test/release/examples/spec
 spectests: FORCE
 	rm -rf $(SPECTEST_DIR)
 	./util/devel/test/extract_tests -o $(SPECTEST_DIR) spec/*.tex
-
-STATUS: STATUS.devel
-	grep -v "^\ *#" STATUS.devel > STATUS
-
 
 FUTURES:
 	cd test && find . -wholename ".svn" -prune -o \( -name \*.future \) -exec head -n 1 {} + > FUTURES


### PR DESCRIPTION
Remove the STATUS file completely.  Remove the rule to generate it and remove
it from the .gitignore file.

Since we only intend to use the STATUS information internally, STATUS.devel is
more useful anyway.  It includes pointers to the tests in question.