### PR TITLE
Handle .bad mismatch for configHelp.chpl

### DIFF
--- a/test/execflags/bradc/configHelp.bad
+++ b/test/execflags/bradc/configHelp.bad
@@ -1,39 +1,4 @@
-
-FLAGS:
-======
   -h, --help            : print this message
-  -a, --about           : print compilation information
-  -nl <n>               : run program using n locales
-                          (equivalent to setting the numLocales config const)
-  -q, --quiet           : run program in quiet mode
-  -v, --verbose         : run program in verbose mode
-  -b, --blockreport     : report location of blocked threads on SIGINT
-  -t, --taskreport      : report list of pending and executing tasks on SIGINT
-  --gdb                 : run program in gdb
-  -E<envVar>=<val>      : set the value of an environment variable
-
-CONFIG VAR FLAGS:
-=================
-  -s, --<cfgVar>=<val>  : set the value of a config var
-  -f<filename>          : read in a file of config var assignments
-
 CONFIG VARS:
-============
-Built-in config vars:
-       printModuleInitOrder: bool
-      dataParTasksPerLocale: int(64)
-  dataParIgnoreRunningTasks: bool
-      dataParMinGranularity: int(64)
-                   memTrack: bool
-                   memStats: bool
-             memLeaksByType: bool
-                   memLeaks: bool
-                     memMax: uint(64)
-               memThreshold: uint(64)
-                     memLog: string
-                memLeaksLog: string
-             memLeaksByDesc: string
                  numLocales: int(64)
-
-configHelp config vars:
                        help: bool

--- a/test/execflags/bradc/configHelp.prediff
+++ b/test/execflags/bradc/configHelp.prediff
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Make the comparison against .bad insensitive
+# to most of the specifics of the help message.
+
+# ... except if the output already matches the .good.
+cmp -s $1.good $2 && exit
+
+set -x
+grep -E 'CONFIG VARS|numLocales:|help|custom' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
#5744 caused .bad mismatch on configHelp.chpl

Instead of adjusting .bad, I am adding a .prediff
that greps out most of the normal help message.

That way comparing against .bad will be insensitive to most of the
specifics of the help message that may again change in the future.
(Yes, I adjusted .bad for this prediff.)

I am preventing the .prediff from messing with the output
if it already matches .good, just because I can.