### PR TITLE
Pre-release prep. for Chapel 1.15.0 : increment version numbers

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -1,5 +1,5 @@
 ============================================
-Chapel Public Release Goals (version 1.14.0)
+Chapel Public Release Goals (version 1.15.0)
 ============================================
 
 The goals of this release are as follows:

--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -21,7 +21,7 @@
 #define _version_num_H_
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION "14"
+#define MINOR_VERSION "15"
 #define UPDATE_VERSION "0"
 
 static const char* BUILD_VERSION =

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,15 +54,15 @@ master_doc = 'index'
 # built documents.
 #
 # The short X.Y version.
-# version = '1.14'
+# version = '1.15'
 
 # We use a custom version variable (shortversion) instead, because setting
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
-shortversion = 1.14
+shortversion = 1.15
 
 # The full version, including alpha/beta/rc tags.
-release = '1.14.0'
+release = '1.15.0'
 
 # General information about the project.
 project = u'Chapel Documentation {0}'.format(shortversion)

--- a/doc/usingchapel/QUICKSTART.rst
+++ b/doc/usingchapel/QUICKSTART.rst
@@ -16,7 +16,7 @@ enable more features, such as distributed memory execution.
 0) See `doc/prereqs.rst`_ for more information about system tools and
    packages you may need to have installed to build and run Chapel.
 
-1) If you don't already have Chapel 1.14, see
+1) If you don't already have Chapel 1.15, see
    http://chapel.cray.com/download.html .
 
 2) If you are using a source release, build Chapel in a *quickstart*
@@ -28,14 +28,14 @@ enable more features, such as distributed memory execution.
 
       .. code-block:: bash
 
-         tar xzf chapel-1.14.0.tar.gz
+         tar xzf chapel-1.15.0.tar.gz
 
    b. Make sure that your shell is in the directory containing
       QUICKSTART.rst, for example:
 
       .. code-block:: bash
 
-         cd chapel-1.14.0
+         cd chapel-1.15.0
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than bash,
@@ -178,7 +178,7 @@ What's next?
 .. _doc/prereqs.rst: prereqs.html
 .. _doc/multilocale.rst: multilocale.html
 .. _platforms: ../platforms/index.html
-.. _chapel.cray.com/docs: http://chapel.cray.com/docs/1.14/
+.. _chapel.cray.com/docs: http://chapel.cray.com/docs/1.15/
 .. _doc/chplenv.rst: chplenv.html
 .. _doc/building.rst: building.html
 .. _doc/compiling.rst: compiling.html

--- a/doc/usingchapel/chplenv.rst
+++ b/doc/usingchapel/chplenv.rst
@@ -33,7 +33,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.14.0
+        export CHPL_HOME=~/chapel-1.15.0
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.14.0
+:Version: 1.15.0
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.14.0
+:Version: 1.15.0
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- Version 1.14.0
+ Version 1.15.0

--- a/test/release/examples/README.testing
+++ b/test/release/examples/README.testing
@@ -67,4 +67,4 @@ For more information
 --------------------
 
 See:
-https://github.com/chapel-lang/chapel/blob/release/1.14/doc/developer/bestPractices/TestSystem.rst
+https://github.com/chapel-lang/chapel/blob/release/1.15/doc/developer/bestPractices/TestSystem.rst


### PR DESCRIPTION
THIS IS NOT CHAPEL RELEASE 1.15.0

This increments the embedded version numbers from 1.14.0 to 1.15.0,
in preparation for later release; currently scheduled for 6 April 2017.