### PR TITLE
Fix nolocal regression for printFinalMemStat

### DIFF
--- a/test/memory/shannon/printFinalMemStat.good
+++ b/test/memory/shannon/printFinalMemStat.good
@@ -3,7 +3,7 @@
 Memory Statistics
 ==============================================================
 Current Allocated Memory               256
-Maximum Simultaneous Allocated Memory  256
-Total Allocated Memory                 256
-Total Freed Memory                     0
+Maximum Simultaneous Allocated Memory  2nn
+Total Allocated Memory                 2nn
+Total Freed Memory                     mm
 ==============================================================

--- a/test/memory/shannon/printFinalMemStat.lm-numa.good
+++ b/test/memory/shannon/printFinalMemStat.lm-numa.good
@@ -1,9 +1,0 @@
-
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               256
-Maximum Simultaneous Allocated Memory  256
-Total Allocated Memory                 256
-Total Freed Memory                     0
-==============================================================

--- a/test/memory/shannon/printFinalMemStat.no-local.good
+++ b/test/memory/shannon/printFinalMemStat.no-local.good
@@ -1,9 +1,0 @@
-
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               256
-Maximum Simultaneous Allocated Memory  265
-Total Allocated Memory                 289
-Total Freed Memory                     33
-==============================================================

--- a/test/memory/shannon/printFinalMemStat.prediff
+++ b/test/memory/shannon/printFinalMemStat.prediff
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sed1='s@\(Maximum Simultaneous Allocated Memory  \)2[5-9][0-9]@\12nn@'
+sed2='s@\(Total Allocated Memory                 \)2[5-9][0-9]@\12nn@'
+sed3='s@\(Total Freed Memory                     \)[0-9][0-9]*@\1mm@'
+
+sed "$sed1;$sed2;$sed3" $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Background:

The amount of temporarily-used memory changed due to #5744
causing regression in test memory/shannon/printFinalMemStat

The test itself intentionally leaks 256 bytes.  This is probably
desirable to make sure that the stats we get using the
printFinalMemStat flag are correct.  The downfall of the test is
the changing amount of extra allocations/leaks introduced by
various configurations. These changes have been unpleasantly
frequent and have been turned up only after nightly testing,
causing testing noise and maintenance burden of updating .good.

Solutions we considered:

(a) Add a prediff to convert numbers to nnn. Still, leave unfiltered
    the number for "Current Allocated Memory" to ensure it remains 256.

(b) Add a .skipif that avoids testing this in any scenario where the
    result doesn't match the .good file.

(c) Free the buffers to avoid leaking.  Better yet, just create an array
    or something instead of manually calling the runtime function
    `chpl_mem_allocMany` to allocate memory.

Chosen solution:

We chose (a) because it is more airtight. Versus (c) it ensures
correct leaking amount. Versus (b) it avoids the danger of overlooking
breakage of --memStats on skipped configurations.

This change lets us remove the additional .good files.

Suggested by @bradcray 
Discussed with @ronawho 
Brought to light by @dmk42 
