### PR TITLE
Add system config defines for amudprun when appropriate

### DIFF
--- a/third-party/amudprun/Makefile
+++ b/third-party/amudprun/Makefile
@@ -5,6 +5,11 @@ endif
 CHPL_MAKE_HOST_TARGET = --host
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
+platform_defines = -DAMUDP_ENV_PREFIX=GASNET -Dif_pf=if -Dif_pt=if
+ifneq (,$(shell grep getifaddrs /usr/include/ifaddrs.h 2>/dev/null))
+platform_defines += -DHAVE_GETIFADDRS -DHAVE_IFADDRS_H
+endif
+
 default: all
 
 all: amudprun
@@ -29,7 +34,7 @@ configure-amudprun: FORCE
 	cp $(AMUDPRUN_SRC_DIR)/../portable_*.h $(AMUDPRUN_BUILD_DIR)
 
 build-amudprun: FORCE
-	cd $(AMUDPRUN_BUILD_DIR) && $(MAKE) -f Makefile.standalone CC="$(CC)" CXX="$(CXX)" platform_defines="-DAMUDP_ENV_PREFIX=GASNET -Dif_pf=if -Dif_pt=if"
+	cd $(AMUDPRUN_BUILD_DIR) && $(MAKE) -f Makefile.standalone CC="$(CC)" CXX="$(CXX)" platform_defines="$(platform_defines)"
 
 install-amudprun: FORCE
 	mkdir -p $(AMUDPRUN_INSTALL_DIR)/bin

--- a/third-party/amudprun/Makefile
+++ b/third-party/amudprun/Makefile
@@ -6,6 +6,18 @@ CHPL_MAKE_HOST_TARGET = --host
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 platform_defines = -DAMUDP_ENV_PREFIX=GASNET -Dif_pf=if -Dif_pt=if
+#
+# The amudprun launcher is to be run on the host, rather than the
+# target.  The following test of the environment should really be done
+# by a configure script, but it cannot take advantage of the output of
+# the target's configure, and it cannot reuse that script because it
+# wants all of GASNet.  Here we just want to use amudprun's
+# Makefile.standalone.
+#
+# A better way to do this is for the GASNet distribution itself to
+# compile launchers for the host instead of the target, rather than
+# doing that here.
+#
 ifneq (,$(shell grep getifaddrs /usr/include/ifaddrs.h 2>/dev/null))
 platform_defines += -DHAVE_GETIFADDRS -DHAVE_IFADDRS_H
 endif


### PR DESCRIPTION
In #5750 I left out two defines that were important for the case of running with GASNET_WORKERIP set.  When amudprun is built for the target (the wrong machine), these defines are set by the configure script.  I could not take advantage of the target configuration for the host, so in this change, the Makefile does a simple test to determine whether to set them.