### PR TITLE
Fix handful of standalone iter NUMA regressions

### DIFF
--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -221,7 +221,7 @@ module ArrayViewRankChange {
       }
     }
 
-    iter these(param tag: iterKind) where tag == iterKind.standalone {
+    iter these(param tag: iterKind) where tag == iterKind.standalone && !localeModelHasSublocales {
       if chpl__isDROrDRView(downDom) {
         for i in upDom.these(tag) do
           yield i;


### PR DESCRIPTION
We do not currently have a standalone iterator for DefaultRectangularDom under NUMA, so avoid this case entirely for now.