### PR TITLE
ignore/clean test/modules/standard/Spawn/stdout-stderr_real

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,6 +299,7 @@ tags
 /test/modules/standard/FileSystem/lydia/sameFile/moveMe.txt
 /test/modules/standard/FileSystem/lydia/symlink/bar.txt
 /test/modules/standard/Path/lydia/realpath/blahblahblah.txt
+/test/modules/standard/Spawn/stdout-stderr_real
 /test/modules/standard/Time/stonea/getCurrentDayOfWeek.good
 /test/modules/standard/machine/numPUs.good
 /test/modules/standard/memory/countMemory/countMemory.*.good

--- a/test/modules/standard/Spawn/CLEANFILES
+++ b/test/modules/standard/Spawn/CLEANFILES
@@ -1,0 +1,1 @@
+stdout-stderr_real


### PR DESCRIPTION
This file appears in GASNet configurations but should be ignored/cleaned.