### PR TITLE
Improve loop vectorization for llvm back-end

### DIFF
--- a/compiler/codegen/CForLoop.cpp
+++ b/compiler/codegen/CForLoop.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 
+#ifdef HAVE_LLVM
 namespace
 {
   void addLoopVectorizationHint(llvm::Instruction* instruction)
@@ -45,6 +46,7 @@ namespace
     instruction->setMetadata(llvm::StringRef("llvm.loop"), llvmLoopMetadata);
   }
 }
+#endif
 
 /************************************ | *************************************
 *                                                                           *

--- a/compiler/codegen/CForLoop.cpp
+++ b/compiler/codegen/CForLoop.cpp
@@ -33,12 +33,17 @@ namespace
   {
     GenInfo* info    = gGenInfo;
     auto &C = info->module->getContext();
-    llvm::ArrayRef<llvm::Metadata*> loopVectorizeEnable({llvm::MDString::get(C, "loop.vectorize.enable"),
+    llvm::ArrayRef<llvm::Metadata*> loopVectorizeEnable({llvm::MDString::get(C, "llvm.loop.vectorize.enable"),
                                       llvm::ValueAsMetadata::get(llvm::ConstantInt::getTrue(C))}) ;
-    llvm::MDTuple* loopVectorizeMetadata = llvm::MDNode::get(C, loopVectorizeEnable);
+    llvm::MDTuple* loopVectorizeEnableMetadata = llvm::MDNode::get(C, loopVectorizeEnable);
 
-    llvm::ArrayRef<llvm::Metadata*> MDs({loopVectorizeMetadata });
-    llvm::MDTuple* llvmLoopMetadata = llvm::MDNode::getDistinct(C, MDs);
+    //llvm::MDNode* nullNode = nullptr;
+    llvm::TempMDTuple dummy = llvm::MDNode::getTemporary(C, {});
+    llvm::ArrayRef<llvm::Metadata*> MDs({dummy.get(), loopVectorizeEnableMetadata});
+    llvm::MDNode* llvmLoopMetadata = llvm::MDNode::get(C, MDs);
+
+    dummy->replaceAllUsesWith(llvmLoopMetadata);
+    //llvm::MDNode::deleteTemporary(dummy.get());
 
     instruction->setMetadata(llvm::StringRef("llvm.loop"), llvmLoopMetadata);
   }

--- a/compiler/codegen/CForLoop.cpp
+++ b/compiler/codegen/CForLoop.cpp
@@ -31,20 +31,17 @@ namespace
 {
   void addLoopVectorizationHint(llvm::Instruction* instruction)
   {
-    GenInfo* info    = gGenInfo;
-    auto &C = info->module->getContext();
-    llvm::ArrayRef<llvm::Metadata*> loopVectorizeEnable({llvm::MDString::get(C, "llvm.loop.vectorize.enable"),
-                                      llvm::ValueAsMetadata::get(llvm::ConstantInt::getTrue(C))}) ;
-    llvm::MDTuple* loopVectorizeEnableMetadata = llvm::MDNode::get(C, loopVectorizeEnable);
+    GenInfo* info                  = gGenInfo;
+    auto &C                        = info->module->getContext();
+    llvm::ArrayRef<llvm::Metadata*> loopVectorizeEnable({llvm::MDString::get(C, "llvm.loop.vectorize.enable"), llvm::ValueAsMetadata::get(llvm::ConstantInt::getTrue(C))});
+    llvm::MDTuple*                  loopVectorizeEnableMetadata = llvm::MDNode::get(C, loopVectorizeEnable);
 
-    //llvm::MDNode* nullNode = nullptr;
-    llvm::TempMDTuple dummy = llvm::MDNode::getTemporary(C, {});
+    //Try to make cyclic reference to itself, since that's how llvm.loop parameters are supposed to be passed
+    llvm::TempMDTuple dummy        = llvm::MDNode::getTemporary(C, {});
     llvm::ArrayRef<llvm::Metadata*> MDs({dummy.get(), loopVectorizeEnableMetadata});
     llvm::MDNode* llvmLoopMetadata = llvm::MDNode::get(C, MDs);
 
     dummy->replaceAllUsesWith(llvmLoopMetadata);
-    //llvm::MDNode::deleteTemporary(dummy.get());
-
     instruction->setMetadata(llvm::StringRef("llvm.loop"), llvmLoopMetadata);
   }
 }
@@ -151,10 +148,8 @@ GenRet CForLoop::codegen()
                                                llvm::ConstantInt::get(condValue0->getType(), 0),
                                                FNAME("condition"));
 
-
     // Create the conditional branch
     info->builder->CreateCondBr(condValue0, blockStmtBody, blockStmtEnd);
-
 
     // Now add the body.
     func->getBasicBlockList().push_back(blockStmtBody);

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -1498,7 +1498,7 @@ GenRet codegenAdd(GenRet a, GenRet b)
       if(values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = info->builder->CreateFAdd(values.a, values.b);
       } else {
-        ret.val = info->builder->CreateAdd(values.a, values.b, "", false, true);
+        ret.val = info->builder->CreateAdd(values.a, values.b, "", false, a_signed or b_signed);
       }
       ret.isUnsigned = !values.isSigned;
     }
@@ -1542,7 +1542,7 @@ GenRet codegenSub(GenRet a, GenRet b)
       if(values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = info->builder->CreateFSub(values.a, values.b);
       } else {
-        ret.val = info->builder->CreateSub(values.a, values.b, "", false, true);
+        ret.val = info->builder->CreateSub(values.a, values.b);
       }
       ret.isUnsigned = !values.isSigned;
     }

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -1498,7 +1498,7 @@ GenRet codegenAdd(GenRet a, GenRet b)
       if(values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = info->builder->CreateFAdd(values.a, values.b);
       } else {
-        ret.val = info->builder->CreateAdd(values.a, values.b, "", false, a_signed or b_signed);
+        ret.val = info->builder->CreateAdd(values.a, values.b, "", false, values.isSigned);
       }
       ret.isUnsigned = !values.isSigned;
     }

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -1498,7 +1498,7 @@ GenRet codegenAdd(GenRet a, GenRet b)
       if(values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = info->builder->CreateFAdd(values.a, values.b);
       } else {
-        ret.val = info->builder->CreateAdd(values.a, values.b);
+        ret.val = info->builder->CreateAdd(values.a, values.b, "", false, true);
       }
       ret.isUnsigned = !values.isSigned;
     }
@@ -1542,7 +1542,7 @@ GenRet codegenSub(GenRet a, GenRet b)
       if(values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = info->builder->CreateFSub(values.a, values.b);
       } else {
-        ret.val = info->builder->CreateSub(values.a, values.b);
+        ret.val = info->builder->CreateSub(values.a, values.b, "", false, true);
       }
       ret.isUnsigned = !values.isSigned;
     }


### PR DESCRIPTION
This is "work in progress" PR, where I'd like to keep my work associated with adding loop vectorization hints for llvm backend.

Here are subtasks to be done:
- Add `llvm.loop.vectorize.enable` metadata for every loop, and make sure they are passed properly. **DONE**

I consider this subtask to be done because in case of tests where loop could be vectorized but wasn't following error was printed:

```warning: <unknown>:0:0: loop not vectorized: failed explicitly specified loop vectorization```

I have also compared generated llvm code with clang generated code, where I have explicitly passed loop vectorization hints for selected loop using `#pragma clang loop vectorize(enable)` and metadata was passed in exactly same what as stated in http://llvm.org/docs/LangRef.html#llvm-loop-vectorize-and-llvm-loop-interleave and in clang generated llvm code.

The main difficulty was lack of existing examples on the internet and quite messy documentation. 

- Make sure that no `loop not vectorized` llvm errors are printed if loop wasn't vectorized.
- Add `llvm.mem.parallel_loop_access` for memory access instructions every loop.

- Investigate if loop vectorization can be improved even more like: give more hints, improve loop generation algorithm to be more adjusted to llvm vectorization algorithm. Some starting points might be here:
http://llvm.org/docs/Vectorizers.html
http://llvm.org/docs/doxygen/html/LoopVectorize_8cpp_source.html (contains references to papers)
http://llvm.org/docs/LangRef.html#llvm-loop-vectorize-width-metadata

- Finish the job: add tests and refactor.
