### PR TITLE
Fix some memory leaks in ArrayViewRankChange

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1140,9 +1140,13 @@ module ChapelArray {
           upranges(d) = emptyrange;
       }
 
-      const rcdist = new ArrayViewRankChangeDist(downdist = dist,
+      const rcdist = new ArrayViewRankChangeDist(downDistPid=dist._pid,
+                                                 downDistInst=dist._instance,
                                                  collapsedDim=collapsedDim,
                                                  idx = idx);
+      // TODO: Should this be set?
+      //rcdist._free_when_no_doms = true;
+
       const rcdistRec = _newDistribution(rcdist);
       const rcdomclass = rcdistRec.newRectangularDom(rank = uprank,
                                                      idxType = upranges(1).idxType,


### PR DESCRIPTION
This commit addresses two problems:

1) old domains in 'dsiSetIndices' were not free'd before being
overwritten
Solution: call dsiDestroyDom() to free the old domains (if they are not
null, as they might be in a freshly-created rank-change domain).

2) too many deep-copies of the downdist _distribution
Solution: Store a pointer to the downward distribution's PID and class
to avoid excessive copying without freeing.

Testing:
- [x] full local
- [x] full gasnet
- [x] valgrind?