### PR TITLE
"no doc" the MPI module deinit()

### DIFF
--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -209,8 +209,12 @@ module MPI {
 
   pragma "no doc"
   var _doinit : bool = false;
+
+  pragma "no doc"
   var _freeChplComm : bool = false;
-  // Module level deinit
+
+  pragma "no doc"
+  /* Module level deinit */
   proc deinit() {
     if _freeChplComm {
       coforall loc in Locales do on loc {


### PR DESCRIPTION
`chpldoc` has not yet been updated to handle module-level `deinit` so I am going to no-doc the function. I don't think this function should really be considered part of the public interface anyway.

This error was introduced in #5769 

Also, no-doc'd 2 private module-level variables.