### PR TITLE
Include ref-vars in 'addAllLocalVariables', otherwise they may be NULL

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -1149,9 +1149,11 @@ addAllLocalVariables(Vec<Symbol*>& syms, Vec<BaseAST*>& asts) {
   forv_Vec(BaseAST, ast, asts) {
     if (DefExpr* def = toDefExpr(ast))
       if (VarSymbol* var = toVarSymbol(def->sym))
-        if (!var->type->symbol->hasFlag(FLAG_REF) || var->hasFlag(FLAG_INDEX_VAR) ||
-             var->hasFlag(FLAG_REF_VAR))
+        if (!var->type->symbol->hasFlag(FLAG_REF) ||
+             var->hasFlag(FLAG_INDEX_VAR) ||
+             var->hasFlag(FLAG_REF_VAR)) {
           syms.add(var);
+        }
   }
 }
 

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -1149,7 +1149,8 @@ addAllLocalVariables(Vec<Symbol*>& syms, Vec<BaseAST*>& asts) {
   forv_Vec(BaseAST, ast, asts) {
     if (DefExpr* def = toDefExpr(ast))
       if (VarSymbol* var = toVarSymbol(def->sym))
-        if (!var->type->symbol->hasFlag(FLAG_REF) || var->hasFlag(FLAG_INDEX_VAR))
+        if (!var->type->symbol->hasFlag(FLAG_REF) || var->hasFlag(FLAG_INDEX_VAR) ||
+             var->hasFlag(FLAG_REF_VAR))
           syms.add(var);
   }
 }


### PR DESCRIPTION
We recently began to see failures in the release version of SSCA2 under --baseline.
The generated code went a little something like this:
```chpl
proc advance(ic : iterClass) {
  if ic.more == 2 then
    goto someLabel;
  // ...
  ref neighbors = someArray;
  // ...
  someLabel:
  ... neighbors[i] ...
}
```

In the case that ``ic.more == 2``, we would skip past the initialization
of the ``neighbors`` ref-var and it would be NULL when used. Baseline
disables live analysis, which was adding all local variables except for
references to the iterator class. Adding a special case for ref-vars appears
to resolve the problem.

_This PR brought to you by @ronawho: the leading brand in figuring
out really weird iterator bugs._

Testing:
- [x] full local
- [x] full baseline