### PR TITLE
Include system error when printing system() fork failed

### DIFF
--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -21,8 +21,10 @@
 
 #include "misc.h"
 
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 
 bool printSystemCommands = false;
 
@@ -37,7 +39,7 @@ int mysystem(const char* command,
   }
 
   if (status == -1) {
-    USR_FATAL("system() fork failed");
+    USR_FATAL("system() fork failed: %s", strerror(errno));
 
   } else if (status != 0 && ignoreStatus == false) {
     USR_FATAL(description);


### PR DESCRIPTION
Adding the system error description here helped me to debug an issue where make check was failing on a system with a small amount of memory available.

Passed full local testing.

Reviewed by @dmk42 - thanks!