### PR TITLE
Array with unsigned domain API test

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1189,7 +1189,7 @@ module ChapelArray {
       for i in _value.dimIter(d, ind) do yield i;
     }
 
-   /* Returns a tuple of integers describing the size of each dimension.
+   /* Returns a tuple of ``idxType`` describing the size of each dimension.
       For a sparse domain, returns the shape of the parent domain.*/
     proc shape where isRectangularDom(this) || isSparseDom(this) {
       var s: rank*(idxType);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1192,7 +1192,7 @@ module ChapelArray {
    /* Returns a tuple of integers describing the size of each dimension.
       For a sparse domain, returns the shape of the parent domain.*/
     proc shape where isRectangularDom(this) || isSparseDom(this) {
-      var s: rank*(int);
+      var s: rank*(idxType);
       for (i, r) in zip(1..s.size, dims()) do
         s(i) = r.size;
       return s;
@@ -1201,7 +1201,7 @@ module ChapelArray {
     pragma "no doc"
     /* Associative and Opaque domains assumed to be 1-D. */
     proc shape where isAssociativeDom(this) || isOpaqueDom(this) {
-      var s: (int,);
+      var s: (idxType,);
       s[1] = size;
       return s;
     }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1192,7 +1192,7 @@ module ChapelArray {
    /* Returns a tuple of ``idxType`` describing the size of each dimension.
       For a sparse domain, returns the shape of the parent domain.*/
     proc shape where isRectangularDom(this) || isSparseDom(this) {
-      var s: rank*(idxType);
+      var s: rank*(dim(1).idxType);
       for (i, r) in zip(1..s.size, dims()) do
         s(i) = r.size;
       return s;
@@ -1201,7 +1201,7 @@ module ChapelArray {
     pragma "no doc"
     /* Associative and Opaque domains assumed to be 1-D. */
     proc shape where isAssociativeDom(this) || isOpaqueDom(this) {
-      var s: (idxType,);
+      var s: (size.type,);
       s[1] = size;
       return s;
     }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -995,6 +995,7 @@ module DefaultRectangular {
   //
   proc _remoteAccessData.toRankChange(newDom, cd, idx) {
     compilerAssert(this.rank == idx.size && this.rank != newDom.rank);
+    type idxSignedType = chpl__signedType(idxType);
 
     // Unconditionally sets 'blkChanged'
     //
@@ -1014,7 +1015,8 @@ module DefaultRectangular {
     for param j in 1..idx.size {
       if !collapsedDims(j) {
         rad.off(curDim) = newDom.dsiDim(curDim).low;
-        rad.origin     += this.blk(j) * (rad.off(curDim) - this.off(j)) / this.str(j);
+        const off       = (rad.off(curDim) - this.off(j)):idxSignedType;
+        rad.origin     += ((this.blk(j):idxSignedType) * off / this.str(j)):idxType;
         rad.blk(curDim) = this.blk(j);
         rad.str(curDim) = this.str(j);
 
@@ -1025,7 +1027,8 @@ module DefaultRectangular {
 
         curDim += 1;
       } else {
-        rad.origin += this.blk(j) * (idx(j) - this.off(j)) / this.str(j);
+        const off   = (idx(j) - this.off(j)):idxSignedType;
+        rad.origin += (this.blk(j):idxSignedType *  off / this.str(j)):idxType;
 
         if !defRectSimpleDData && j == mdParDim {
           mdpdIsRange = false;

--- a/test/arrays/userAPI/unsignedOps.chpl
+++ b/test/arrays/userAPI/unsignedOps.chpl
@@ -1,0 +1,25 @@
+use arrayAPItest;
+
+{
+  var A: [1:uint..4:uint, 1:uint..4:uint] real;
+
+  testArrayAPI2D("Array with unsigned domain", A, {2:uint..3:uint, 3:uint..4:uint}, {0:uint..3:uint, 1:uint..8:uint by 2:uint});
+}
+
+{
+  var A: [0:uint..5:uint, 0:uint..5:uint] real;
+
+  testArrayAPI2D("Slice of array with unsigned domain", A[1:uint..4:uint, 1:uint..4:uint], {2:uint..3:uint, 3:uint..4:uint}, {0:uint..3:uint, 1:uint..8:uint by 2:uint});
+}
+
+{
+  var A: [1:uint..4:uint, 1:uint..4:uint] real;
+
+  testArrayAPI2D("Reindex of array with unsigned domain", A.reindex({0:uint..3:uint, 2:uint..9:uint by 2:uint}), {1:uint..2:uint, 6:uint..9:uint by 2:uint}, {1:uint..8:uint by 2:uint, 2:uint..5:uint});
+}
+
+{
+  var A: [0:uint..5:uint, 1:uint..6:uint, 1:uint..4:uint] real;
+
+  testArrayAPI2D("RankChange of array with unsigned domain", A[1:uint..4:uint, 1:uint..4:uint, 2:uint], {2:uint..3:uint, 3:uint..4:uint}, {0:uint..3:uint, 1:uint..8:uint by 2:uint});
+}

--- a/test/arrays/userAPI/unsignedOps.good
+++ b/test/arrays/userAPI/unsignedOps.good
@@ -1,0 +1,420 @@
+Array with unsigned domain
+----------------
+eltType is: real(64)
+idxType is: uint(64)
+rank is: 2
+
+size is: 16
+numElements is: 16
+shape is: (4, 4)
+
+X is:
+1.0 2.0 3.0 4.0
+5.0 6.0 7.0 8.0
+9.0 10.0 11.0 12.0
+13.0 14.0 15.0 16.0
+
+X is:
+1.1 2.1 3.1 4.1
+5.1 6.1 7.1 8.1
+9.1 10.1 11.1 12.1
+13.1 14.1 15.1 16.1
+
+X is:
+1.2 2.2 3.2 4.2
+5.2 6.2 7.2 8.2
+9.2 10.2 11.2 12.2
+13.2 14.2 15.2 16.2
+
+low element is: 1.2
+high element is: 16.2
+
+X is:
+1.3 2.3 3.3 4.3
+5.3 6.3 7.3 8.3
+9.3 10.3 11.3 12.3
+13.3 14.3 15.3 16.3
+
+X is:
+1.4 2.4 3.4 4.4
+5.4 6.4 7.4 8.4
+9.4 10.4 11.4 12.4
+13.4 14.4 15.4 16.4
+
+low element is: 1.4
+high element is: 16.4
+
+X is:
+1.5 2.5 3.5 4.5
+5.5 6.5 7.5 8.5
+9.5 10.5 11.5 12.5
+13.5 14.5 15.5 16.5
+
+X is:
+1.6 2.6 3.6 4.6
+5.6 6.6 7.6 8.6
+9.6 10.6 11.6 12.6
+13.6 14.6 15.6 16.6
+
+X is:
+1.7 2.7 3.7 4.7
+5.7 6.7 7.7 8.7
+9.7 10.7 11.7 12.7
+13.7 14.7 15.7 16.7
+
+X is:
+1.8 2.8 3.8 4.8
+5.8 6.8 7.8 8.8
+9.8 10.8 11.8 12.8
+13.8 14.8 15.8 16.8
+
+target locales: LOCALE0
+local subdomain: {1..4, 1..4}
+local subdomains:
+{1..4, 1..4}
+
+is empty: false
+head: 1.8
+tail: 16.8
+find last: (true, (4, 4))
+count last: 1
+equals same: true
+equals diff: false
+
+slice by {2..3, 3..4}:
+7.8 8.8
+11.8 12.8
+rank change 1: 1.8 2.8 3.8 4.8
+rank change 2: 8.8 12.8
+reindexed X[(0, 1)] = 1.8
+reindexed X[(0, 3)] = 2.8
+reindexed X[(0, 5)] = 3.8
+reindexed X[(0, 7)] = 4.8
+reindexed X[(1, 1)] = 5.8
+reindexed X[(1, 3)] = 6.8
+reindexed X[(1, 5)] = 7.8
+reindexed X[(1, 7)] = 8.8
+reindexed X[(2, 1)] = 9.8
+reindexed X[(2, 3)] = 10.8
+reindexed X[(2, 5)] = 11.8
+reindexed X[(2, 7)] = 12.8
+reindexed X[(3, 1)] = 13.8
+reindexed X[(3, 3)] = 14.8
+reindexed X[(3, 5)] = 15.8
+reindexed X[(3, 7)] = 16.8
+
+Slice of array with unsigned domain
+----------------
+eltType is: real(64)
+idxType is: uint(64)
+rank is: 2
+
+size is: 16
+numElements is: 16
+shape is: (4, 4)
+
+X is:
+1.0 2.0 3.0 4.0
+5.0 6.0 7.0 8.0
+9.0 10.0 11.0 12.0
+13.0 14.0 15.0 16.0
+
+X is:
+1.1 2.1 3.1 4.1
+5.1 6.1 7.1 8.1
+9.1 10.1 11.1 12.1
+13.1 14.1 15.1 16.1
+
+X is:
+1.2 2.2 3.2 4.2
+5.2 6.2 7.2 8.2
+9.2 10.2 11.2 12.2
+13.2 14.2 15.2 16.2
+
+low element is: 1.2
+high element is: 16.2
+
+X is:
+1.3 2.3 3.3 4.3
+5.3 6.3 7.3 8.3
+9.3 10.3 11.3 12.3
+13.3 14.3 15.3 16.3
+
+X is:
+1.4 2.4 3.4 4.4
+5.4 6.4 7.4 8.4
+9.4 10.4 11.4 12.4
+13.4 14.4 15.4 16.4
+
+low element is: 1.4
+high element is: 16.4
+
+X is:
+1.5 2.5 3.5 4.5
+5.5 6.5 7.5 8.5
+9.5 10.5 11.5 12.5
+13.5 14.5 15.5 16.5
+
+X is:
+1.6 2.6 3.6 4.6
+5.6 6.6 7.6 8.6
+9.6 10.6 11.6 12.6
+13.6 14.6 15.6 16.6
+
+X is:
+1.7 2.7 3.7 4.7
+5.7 6.7 7.7 8.7
+9.7 10.7 11.7 12.7
+13.7 14.7 15.7 16.7
+
+X is:
+1.8 2.8 3.8 4.8
+5.8 6.8 7.8 8.8
+9.8 10.8 11.8 12.8
+13.8 14.8 15.8 16.8
+
+target locales: LOCALE0
+local subdomain: {1..4, 1..4}
+local subdomains:
+{1..4, 1..4}
+
+is empty: false
+head: 1.8
+tail: 16.8
+find last: (true, (4, 4))
+count last: 1
+equals same: true
+equals diff: false
+
+slice by {2..3, 3..4}:
+7.8 8.8
+11.8 12.8
+rank change 1: 1.8 2.8 3.8 4.8
+rank change 2: 8.8 12.8
+reindexed X[(0, 1)] = 1.8
+reindexed X[(0, 3)] = 2.8
+reindexed X[(0, 5)] = 3.8
+reindexed X[(0, 7)] = 4.8
+reindexed X[(1, 1)] = 5.8
+reindexed X[(1, 3)] = 6.8
+reindexed X[(1, 5)] = 7.8
+reindexed X[(1, 7)] = 8.8
+reindexed X[(2, 1)] = 9.8
+reindexed X[(2, 3)] = 10.8
+reindexed X[(2, 5)] = 11.8
+reindexed X[(2, 7)] = 12.8
+reindexed X[(3, 1)] = 13.8
+reindexed X[(3, 3)] = 14.8
+reindexed X[(3, 5)] = 15.8
+reindexed X[(3, 7)] = 16.8
+
+Reindex of array with unsigned domain
+----------------
+eltType is: real(64)
+idxType is: uint(64)
+rank is: 2
+
+size is: 16
+numElements is: 16
+shape is: (4, 4)
+
+X is:
+1.0 2.0 3.0 4.0
+5.0 6.0 7.0 8.0
+9.0 10.0 11.0 12.0
+13.0 14.0 15.0 16.0
+
+X is:
+1.1 2.1 3.1 4.1
+5.1 6.1 7.1 8.1
+9.1 10.1 11.1 12.1
+13.1 14.1 15.1 16.1
+
+X is:
+1.2 2.2 3.2 4.2
+5.2 6.2 7.2 8.2
+9.2 10.2 11.2 12.2
+13.2 14.2 15.2 16.2
+
+low element is: 1.2
+high element is: 16.2
+
+X is:
+1.3 2.3 3.3 4.3
+5.3 6.3 7.3 8.3
+9.3 10.3 11.3 12.3
+13.3 14.3 15.3 16.3
+
+X is:
+1.4 2.4 3.4 4.4
+5.4 6.4 7.4 8.4
+9.4 10.4 11.4 12.4
+13.4 14.4 15.4 16.4
+
+low element is: 1.4
+high element is: 16.4
+
+X is:
+1.5 2.5 3.5 4.5
+5.5 6.5 7.5 8.5
+9.5 10.5 11.5 12.5
+13.5 14.5 15.5 16.5
+
+X is:
+1.6 2.6 3.6 4.6
+5.6 6.6 7.6 8.6
+9.6 10.6 11.6 12.6
+13.6 14.6 15.6 16.6
+
+X is:
+1.7 2.7 3.7 4.7
+5.7 6.7 7.7 8.7
+9.7 10.7 11.7 12.7
+13.7 14.7 15.7 16.7
+
+X is:
+1.8 2.8 3.8 4.8
+5.8 6.8 7.8 8.8
+9.8 10.8 11.8 12.8
+13.8 14.8 15.8 16.8
+
+target locales: LOCALE0
+local subdomain: {0..3, 2..9 by 2}
+local subdomains:
+{0..3, 2..9 by 2}
+
+is empty: false
+head: 1.8
+tail: 16.8
+find last: (true, (3, 8))
+count last: 1
+equals same: true
+equals diff: false
+
+slice by {1..2, 6..9 by 2}:
+7.8 8.8
+11.8 12.8
+rank change 1: 1.8 2.8 3.8 4.8
+rank change 2: 8.8 12.8
+reindexed X[(1, 2)] = 1.8
+reindexed X[(1, 3)] = 2.8
+reindexed X[(1, 4)] = 3.8
+reindexed X[(1, 5)] = 4.8
+reindexed X[(3, 2)] = 5.8
+reindexed X[(3, 3)] = 6.8
+reindexed X[(3, 4)] = 7.8
+reindexed X[(3, 5)] = 8.8
+reindexed X[(5, 2)] = 9.8
+reindexed X[(5, 3)] = 10.8
+reindexed X[(5, 4)] = 11.8
+reindexed X[(5, 5)] = 12.8
+reindexed X[(7, 2)] = 13.8
+reindexed X[(7, 3)] = 14.8
+reindexed X[(7, 4)] = 15.8
+reindexed X[(7, 5)] = 16.8
+
+RankChange of array with unsigned domain
+----------------
+eltType is: real(64)
+idxType is: uint(64)
+rank is: 2
+
+size is: 16
+numElements is: 16
+shape is: (4, 4)
+
+X is:
+1.0 2.0 3.0 4.0
+5.0 6.0 7.0 8.0
+9.0 10.0 11.0 12.0
+13.0 14.0 15.0 16.0
+
+X is:
+1.1 2.1 3.1 4.1
+5.1 6.1 7.1 8.1
+9.1 10.1 11.1 12.1
+13.1 14.1 15.1 16.1
+
+X is:
+1.2 2.2 3.2 4.2
+5.2 6.2 7.2 8.2
+9.2 10.2 11.2 12.2
+13.2 14.2 15.2 16.2
+
+low element is: 1.2
+high element is: 16.2
+
+X is:
+1.3 2.3 3.3 4.3
+5.3 6.3 7.3 8.3
+9.3 10.3 11.3 12.3
+13.3 14.3 15.3 16.3
+
+X is:
+1.4 2.4 3.4 4.4
+5.4 6.4 7.4 8.4
+9.4 10.4 11.4 12.4
+13.4 14.4 15.4 16.4
+
+low element is: 1.4
+high element is: 16.4
+
+X is:
+1.5 2.5 3.5 4.5
+5.5 6.5 7.5 8.5
+9.5 10.5 11.5 12.5
+13.5 14.5 15.5 16.5
+
+X is:
+1.6 2.6 3.6 4.6
+5.6 6.6 7.6 8.6
+9.6 10.6 11.6 12.6
+13.6 14.6 15.6 16.6
+
+X is:
+1.7 2.7 3.7 4.7
+5.7 6.7 7.7 8.7
+9.7 10.7 11.7 12.7
+13.7 14.7 15.7 16.7
+
+X is:
+1.8 2.8 3.8 4.8
+5.8 6.8 7.8 8.8
+9.8 10.8 11.8 12.8
+13.8 14.8 15.8 16.8
+
+target locales: LOCALE0
+local subdomain: {1..4, 1..4}
+local subdomains:
+{1..4, 1..4}
+
+is empty: false
+head: 1.8
+tail: 16.8
+find last: (true, (4, 4))
+count last: 1
+equals same: true
+equals diff: false
+
+slice by {2..3, 3..4}:
+7.8 8.8
+11.8 12.8
+rank change 1: 1.8 2.8 3.8 4.8
+rank change 2: 8.8 12.8
+reindexed X[(0, 1)] = 1.8
+reindexed X[(0, 3)] = 2.8
+reindexed X[(0, 5)] = 3.8
+reindexed X[(0, 7)] = 4.8
+reindexed X[(1, 1)] = 5.8
+reindexed X[(1, 3)] = 6.8
+reindexed X[(1, 5)] = 7.8
+reindexed X[(1, 7)] = 8.8
+reindexed X[(2, 1)] = 9.8
+reindexed X[(2, 3)] = 10.8
+reindexed X[(2, 5)] = 11.8
+reindexed X[(2, 7)] = 12.8
+reindexed X[(3, 1)] = 13.8
+reindexed X[(3, 3)] = 14.8
+reindexed X[(3, 5)] = 15.8
+reindexed X[(3, 7)] = 16.8
+


### PR DESCRIPTION
Adds tests for slices, rank-changes, and reindexes on an array
declared over a domain of unsigned ints.

This test exposed some minor bugs in our internal modules, which
are also fixed by this PR.

Testing:
- [x] full local
- [x] full gasnet
