### PR TITLE
Init tweaks

### DIFF
--- a/test/classes/initializers/bothInitCalls.future
+++ b/test/classes/initializers/bothInitCalls.future
@@ -1,0 +1,1 @@
+unimplemented feature: Fail to accept init in param conditional

--- a/test/classes/initializers/noReturnInInit.chpl
+++ b/test/classes/initializers/noReturnInInit.chpl
@@ -36,12 +36,14 @@ proc main() {
   //
   forall depth in dynamic(depths, chunkSize=1) {
     const iterations = 2**(maxDepth - depth + minDepth);
-    var sum = 0;
-			
+    var   sum        = 0;
+
     for i in 1..iterations {
-      const posT = new Tree( i, depth), 
+      const posT = new Tree( i, depth),
             negT = new Tree(-i, depth);
+
       sum += posT.sum() + negT.sum();
+
       delete posT;
       delete negT;
     }
@@ -74,11 +76,13 @@ class Tree {
   // Two initializers (constructors) for a Tree object
   //
   proc init(item, left: Tree=nil, right: Tree=nil) {
-    this.item = item;
-    this.left = left;
+    this.item  = item;
+    this.left  = left;
     this.right = right;
+
+    super.init();
   }
-  
+
   proc init(item, depth) {
     if depth <= 0 then
       return new Tree(item);

--- a/test/classes/initializers/noReturnInInit.good
+++ b/test/classes/initializers/noReturnInInit.good
@@ -1,2 +1,2 @@
-noReturnInInit.chpl:82: In initializer:
-noReturnInInit.chpl:84: error: initializers cannot return a value
+noReturnInInit.chpl:86: In initializer:
+noReturnInInit.chpl:88: error: initializers cannot return a value

--- a/test/classes/initializers/parentCall/ifExplicitImplicit.future
+++ b/test/classes/initializers/parentCall/ifExplicitImplicit.future
@@ -1,0 +1,1 @@
+unimplemented feature: Fail to accept init in param conditional

--- a/test/classes/initializers/parentCall/inIf.future
+++ b/test/classes/initializers/parentCall/inIf.future
@@ -1,0 +1,1 @@
+unimplemented feature: Fail to accept init in param conditional

--- a/test/classes/initializers/parentCall/inLoop.future
+++ b/test/classes/initializers/parentCall/inLoop.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/parentCall/inLoop.good
+++ b/test/classes/initializers/parentCall/inLoop.good
@@ -1,1 +1,2 @@
-inLoop.chpl:13: error: use of super.init() call in loop body
+inLoop.chpl:4: In initializer:
+inLoop.chpl:13: error: use of super.init() in a conditional stmt in phase 1

--- a/test/classes/initializers/phase1/hasIf.future
+++ b/test/classes/initializers/phase1/hasIf.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/hasIf.good
+++ b/test/classes/initializers/phase1/hasIf.good
@@ -1,1 +1,2 @@
-{f1 = true, f2 = 10}
+hasIf.chpl:5: In initializer:
+hasIf.chpl:9: error: can't initialize field "f2" inside a conditional during phase 1 of initialization

--- a/test/classes/initializers/phase1/hasLoopBad.future
+++ b/test/classes/initializers/phase1/hasLoopBad.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/hasLoopBad.good
+++ b/test/classes/initializers/phase1/hasLoopBad.good
@@ -1,3 +1,2 @@
 hasLoopBad.chpl:4: In initializer:
-hasLoopBad.chpl:7: error: can't initialize field "highestNum" inside a loop during phase 1 of initialization
-hasLoopBad.chpl:10: error: can't initialize field "highestNum" inside a loop during phase 1 of initialization
+hasLoopBad.chpl:7: error: can't initialize field "highestNum" inside a conditional during phase 1 of initialization

--- a/test/classes/initializers/records/record-no-copy-init-error.future
+++ b/test/classes/initializers/records/record-no-copy-init-error.future
@@ -1,4 +1,0 @@
-feature request: Generate a helpful error message
-
-The program requires a copy-initializer but generates an ugly
-resolution error.

--- a/test/classes/initializers/records/record-no-copy-init-error.good
+++ b/test/classes/initializers/records/record-no-copy-init-error.good
@@ -1,4 +1,2 @@
 record-no-copy-init-error.chpl:18: In function 'foo':
-record-no-copy-init-error.chpl:28: error: copy-initialization invoked for a type that does not have a copy initializer
-record-no-copy-init-error.chpl:13: In function 'returnRef':
-record-no-copy-init-error.chpl:15: error: copy-initialization invoked for a type that does not have a copy initializer
+record-no-copy-init-error.chpl:28: error: No copy constructor for initializer

--- a/test/classes/initializers/recursiveCall.good
+++ b/test/classes/initializers/recursiveCall.good
@@ -1,6 +1,2 @@
-stretch tree of depth 11	 check: -1
-2048	 trees of depth 4	 check: -2048
-512	 trees of depth 6	 check: -512
-128	 trees of depth 8	 check: -128
-32	 trees of depth 10	 check: -32
-long lived tree of depth 10	 check: -1
+recursiveCall.chpl:84: In initializer:
+recursiveCall.chpl:86: error: use of this.init() in a conditional stmt in phase 1

--- a/test/classes/initializers/recursiveCall2.good
+++ b/test/classes/initializers/recursiveCall2.good
@@ -1,6 +1,2 @@
-stretch tree of depth 11	 check: -1
-2048	 trees of depth 4	 check: -2048
-512	 trees of depth 6	 check: -512
-128	 trees of depth 8	 check: -128
-32	 trees of depth 10	 check: -32
-long lived tree of depth 10	 check: -1
+recursiveCall2.chpl:86: In initializer:
+recursiveCall2.chpl:88: error: use of this.init() in a conditional stmt in phase 1

--- a/test/classes/initializers/siblingCall/inIf.future
+++ b/test/classes/initializers/siblingCall/inIf.future
@@ -1,0 +1,1 @@
+unimplemented feature: Fail to accept init in param conditional

--- a/test/classes/initializers/user_def_unique_initializer_const_multipleassign.future
+++ b/test/classes/initializers/user_def_unique_initializer_const_multipleassign.future
@@ -1,3 +1,0 @@
-semantic: multiple assignments to const fields in initializers
-
-error message: assigning a const field multiple times in the initializer does not result in an error message

--- a/test/classes/initializers/user_def_unique_initializer_const_multipleassign.good
+++ b/test/classes/initializers/user_def_unique_initializer_const_multipleassign.good
@@ -1,1 +1,2 @@
-Error message
+user_def_unique_initializer_const_multipleassign.chpl:6: In initializer:
+user_def_unique_initializer_const_multipleassign.chpl:11: error: cannot update a const field, "x", in phase 2

--- a/test/classes/initializers/user_def_unique_initializer_const_multipleassign2.chpl
+++ b/test/classes/initializers/user_def_unique_initializer_const_multipleassign2.chpl
@@ -4,8 +4,9 @@ class C {
   const x: int;
 
   proc init(y, z) {
-    x = y+z;
-    x -= 1;
+    x = y + z;
+    x = 1;
+
     super.init();
   }
 }

--- a/test/classes/initializers/user_def_unique_initializer_const_multipleassign2.future
+++ b/test/classes/initializers/user_def_unique_initializer_const_multipleassign2.future
@@ -1,3 +1,0 @@
-semantic: multiple assignments to const fields in initializers
-
-error message: assigning a const field multiple times in the initializer does not result in an error message

--- a/test/classes/initializers/user_def_unique_initializer_const_multipleassign2.good
+++ b/test/classes/initializers/user_def_unique_initializer_const_multipleassign2.good
@@ -1,1 +1,2 @@
-Error message
+user_def_unique_initializer_const_multipleassign2.chpl:6: In initializer:
+user_def_unique_initializer_const_multipleassign2.chpl:8: error: multiple initializations of field "x"

--- a/test/release/examples/benchmarks/shootout/binarytrees.chpl
+++ b/test/release/examples/benchmarks/shootout/binarytrees.chpl
@@ -67,16 +67,17 @@ proc main() {
 // A simple balanced tree node class
 //
 class Tree {
-  const item: int;
-  const left, right: Tree;
+  var item: int;
+  var left, right: Tree;
 
   //
   // A Tree-building initializer
   //
   proc init(item, depth) {
     this.item = item;
+
     if depth > 0 {
-      left = new Tree(2*item-1, depth-1);
+      left  = new Tree(2*item-1, depth-1);
       right = new Tree(2*item, depth-1);
     }
   }


### PR DESCRIPTION
This PR addresses three minor issues for initializers

A) Prior to this PR the compiler failed to find some instances of super.init() inside conditionals due
to an issue with findInitStyle().  This PR extends the implementation of startsInPhase1() to handle
this situation correctly.  Retired a future, updated 2 .good files, and converted 4 tests with
conditionals on params to futures.

B) Prior to this PR the compiler failed to generate an error message if a user updated a const field
in phase 2.  Updated some .good files, retired some futures.

Also updated the non-submitted version of shootout/binarytrees.chpl so that the fields of class Tree
are var rather than const so that the initializer can be phase 2 (Per Brad).

C) Prior to this PR the compiler failed to generate an error if the user applied a compound
"assignment" operator to a field in phase 1.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
start_test with futures for classes/initializers on darwin
single-locale paratest with futures on linux64




