### PR TITLE
Don't mess up schedaffinity when touching desired heap for locality.

### DIFF
--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -79,6 +79,18 @@ void chpl_topo_setMemLocality(void*, size_t, chpl_bool, c_sublocid_t);
 void chpl_topo_setMemSubchunkLocality(void*, size_t, chpl_bool, size_t*);
 
 //
+// touch a block of memory, while running on a given NUMA domain
+//
+// args:
+//   base address
+//   size (bytes)
+//   onlyInside?  true: only localize pages strictly within the memory
+//                false: also localize partial pages at edges
+//   desired sublocale (NUMA domain)
+//
+void chpl_topo_touchMemFromSubloc(void*, size_t, chpl_bool, c_sublocid_t);
+
+//
 // get memory locality of (the page containing) an address
 //
 // args:

--- a/runtime/src/chpl-topo.c
+++ b/runtime/src/chpl-topo.c
@@ -227,7 +227,7 @@ c_sublocid_t chpl_topo_getThreadLocality(void) {
   }
 
   flags = HWLOC_CPUBIND_THREAD;
-  if (hwloc_get_thread_cpubind(topology, pthread_self(), cpuset, flags)) {
+  if (hwloc_get_cpubind(topology, cpuset, flags)) {
     report_error("hwloc_get_cpubind()", errno);
   }
 
@@ -340,7 +340,7 @@ void chpl_topo_touchMemFromSubloc(void* p, size_t size, chpl_bool onlyInside,
   }
 
   flags = HWLOC_CPUBIND_THREAD;
-  if (hwloc_get_thread_cpubind(topology, pthread_self(), cpuset, flags)) {
+  if (hwloc_get_cpubind(topology, cpuset, flags)) {
     report_error("hwloc_get_cpubind()", errno);
   }
 

--- a/runtime/src/chpl-topo.c
+++ b/runtime/src/chpl-topo.c
@@ -310,6 +310,58 @@ void chpl_topo_setMemSubchunkLocality(void* p, size_t size,
 }
 
 
+void chpl_topo_touchMemFromSubloc(void* p, size_t size, chpl_bool onlyInside,
+                                  c_sublocid_t subloc) {
+  size_t pgSize;
+  unsigned char* pPgLo;
+  size_t nPages;
+  hwloc_cpuset_t cpuset;
+  int flags;
+
+  _DBG_P("chpl_topo_touchMemFromSubloc(%p, %#zx, onlyIn=%s, %d)\n",
+         p, size, (onlyInside ? "T" : "F"), (int) subloc);
+
+  if (!haveTopology
+      || !topoSupport->cpubind->get_thread_cpubind
+      || !topoSupport->cpubind->set_thread_cpubind) {
+    return;
+  }
+
+  alignAddrSize(p, size, onlyInside, &pgSize, &pPgLo, &nPages);
+
+  _DBG_P("    localize %p, %#zx bytes (%#zx pages)\n",
+         pPgLo, nPages * pgSize, nPages);
+
+  if (nPages == 0)
+    return;
+
+  if ((cpuset = hwloc_bitmap_alloc()) == NULL) {
+    report_error("hwloc_bitmap_alloc()", errno);
+  }
+
+  flags = HWLOC_CPUBIND_THREAD;
+  if (hwloc_get_thread_cpubind(topology, pthread_self(), cpuset, flags)) {
+    report_error("hwloc_get_cpubind()", errno);
+  }
+
+  chpl_topo_setThreadLocality(subloc);
+
+  {
+    size_t pg;
+    for (pg = 0; pg < nPages; pg++) {
+      pPgLo[pg * pgSize] = 0;
+    }
+  }
+
+  flags = HWLOC_CPUBIND_THREAD | HWLOC_CPUBIND_STRICT;
+  if (hwloc_set_cpubind(topology, cpuset, flags)) {
+    report_error("hwloc_set_cpubind()", errno);
+  }
+
+  hwloc_bitmap_free(cpuset);
+}
+
+
 static inline
 void alignAddrSize(void* p, size_t size, chpl_bool onlyInside,
                    size_t* p_pgSize, unsigned char** p_pPgLo,
@@ -426,6 +478,8 @@ void chpl_topo_setMemLocality(void* p, size_t size, chpl_bool onlyInside,
 void chpl_topo_setMemSubchunkLocality(void* p, size_t size,
                                       chpl_bool onlyInside,
                                       size_t* subchunkSizes) { }
+void chpl_topo_touchMemFromSubloc(void* p, size_t size, chpl_bool onlyInside,
+                                  c_sublocid_t subloc) { }
 c_sublocid_t chpl_topo_getMemLocality(void* p) { return c_sublocid_any; }
 
 #endif // if defined(CHPL_HAS_HWLOC)

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -134,18 +134,9 @@ static void setupLocalizedHeaps(void* heap_base, size_t heap_size) {
     // having the effect we desire, for reasons that are mostly but
     // not completely understood.  So for now, to get the locality
     // we want, touch the pages into existence while executing on
-    // the desired NUMA domains here.
+    // the desired NUMA domains.
     //
-    {
-      c_sublocid_t sublocWas = chpl_topo_getThreadLocality();
-      size_t off;
-      const size_t pgSize = chpl_getHeapPageSize();
-      chpl_topo_setThreadLocality(hpi);
-      for (off = 0; off < heaps[hpi].size; off += pgSize) {
-        ((char*) (heaps[hpi].base))[off] = 0;
-      }
-      chpl_topo_setThreadLocality(sublocWas);
-    }
+    chpl_topo_touchMemFromSubloc(heaps[hpi].base, heaps[hpi].size, true, hpi);
   }
 }
 


### PR DESCRIPTION
The code for touching desired heap pages into existence on the "right"
NUMA domains was careful to first record the thread's (process's) NUMA
locality and then restore it afterward.  Unfortunately, the function
used to get that locality was one designed to return the specific NUMA
domain associated with the thread and, as such, if the thread had
affinity to multiple domains the function reduced this to just the first
before it returned the value.  When we later "restored" that locality,
any NUMA domains the thread had originally had affinity to, other than
the first one, were lost.  The effect was observed in some runs on Cray
XE systems, where the reduced affinity had the effect of changing the
number of physical cores the program thought were available to it.

To work around this, move the page-touching localization code out of the
mem=jemalloc code and into the topology code, in a new function called
chpl_topo_touchMemFromSubloc().  Here we can save the original affinity
and restore it afterward without losing information.