### PR TITLE
Improved READMEs in CHPL_HOME/examples

### DIFF
--- a/test/release/examples/benchmarks/hpcc/README
+++ b/test/release/examples/benchmarks/hpcc/README
@@ -32,6 +32,13 @@ The main files for these benchmarks are as follows:
      ptrans.chpl            : the global PTRANS benchmark
      hpl.chpl               : the High Performance Linpack benchmark
 
+Other files with the same base filenames as the Chapel test programs but
+different filename extensions, are for use by the automated test system.
+For example, file ra.execopts supports automated testing of ra.chpl.
+Files with all-uppercase filenames like NUMLOCALES (but not "README")
+are similar, except they are applied to all chpl tests in the
+directory. $CHPL_HOME/examples/README.testing contains more information.
+
 A subdirectory contains variants -- particularly more elegant
 implementations that do not yet perform as well as the ones in this
 directory.

--- a/test/release/examples/benchmarks/isx/README
+++ b/test/release/examples/benchmarks/isx/README
@@ -25,16 +25,17 @@ This directory's contents are as follows:
 
   Makefile       : builds an optimized ISx
 
-  CLEANFILES     :\
-  COMPOPTS       : \
-  NUMLOCALES     :  \
-  isx.execopts   :   | Used by the Chapel testing system
-  isx.precomp    :  /
-  goods-1/       : /
-  goods-4/       :/
-
   README         : this file
 
+  Other files with the same base filename as the Chapel test program but
+  different filename extensions, are for use by the automated test system.
+  For example, file isx.execopts supports automated testing of isx.chpl.
+  Files with all-uppercase filenames like NUMLOCALES (but not "README") are
+  similar, except they are applied to all chpl tests in the directory.
+  $CHPL_HOME/examples/README.testing contains more information.
+
+  goods-1/       : used by the Chapel testing system
+  goods-4/
 
 -----------------
 Execution Options
@@ -84,11 +85,11 @@ Language TODOs
 --------------
 * The stats would be much more complete (while remaining elegant/
   efficient) if we had min/max task reduction intents...
-  
+
 * Should we be able to support scans on arrays of atomics without a
   .read()?
 
 * We really want an exclusive scan, but Chapel's is inclusive.  Wasn't
   the original plan to support both?  Does code exist for this that
   simply isn't accessible currently?
- 
+

--- a/test/release/examples/benchmarks/lcals/README
+++ b/test/release/examples/benchmarks/lcals/README
@@ -21,7 +21,7 @@ Files
 This directory's contents are as follows:
 
 ./
-  LCALSMain.chpl       : The main entry point in the Chapel source code
+  LCALSMain.chpl        : The main entry point in the Chapel source code
 
   RunARawLoops.chpl             :\
   RunBRawLoops.chpl             : \
@@ -30,35 +30,32 @@ This directory's contents are as follows:
   RunSPMDRawLoops.chpl          : /
   RunVectorizeOnlyRawLoops.chpl :/
 
-  LCALSConfiguration.chpl : Configuration constants to define what to run
-  LCALSLoops.chpl         : Routines to initialize kernel data
+  LCALSConfiguration.chpl   : Configuration constants to define what to run
+  LCALSLoops.chpl           : Routines to initialize kernel data
 
-  LCALSDataTypes.chpl : | Data types and enumerations
-  LCALSEnums.chpl     :/
+  LCALSDataTypes.chpl   :\ Data types and enumerations
+  LCALSEnums.chpl       :/
 
-  LCALSParams.chpl : | Global variables and constants
-  LCALSStatic.chpl :/
+  LCALSParams.chpl      :\ Global variables and constants
+  LCALSStatic.chpl      :/
 
-  LCALSChecksums.chpl : Checks the validity of computed checksums
+  LCALSChecksums.chpl   : Checks the validity of computed checksums
 
-  Timer.chpl      : A simple timer
+  Timer.chpl            : A simple timer
 
-  LongDouble.chpl : | An interface to the "long double" type in C
-  longdouble.h    :/
+  LongDouble.chpl       :\  An interface to the "long double" type in C
+  longdouble.h          :/
 
-  Makefile       : Build LCALS
+  Makefile              : Build LCALS
 
-  *.notest               :\
-  LCALS-*.graph          : \
-  LCALSMain.perfcompopts :  \
-  LCALSMain.perfexecopts :   \ Used by the Chapel testing system
-  LCALSMain.perfkeys     :   /
-  LCALSMain.perftimeout  :  /
-  LCALSMain.skipif       : /
-  LCALSMain.timeout      :/
+  README                    : This file
+  README-LCALS_license.txt  : The LCALS reference license
 
-  README                   : This file
-  README-LCALS_license.txt : The LCALS reference license
+  Other files with the same base filenames as the Chapel test programs but
+  different filename extensions, are for use by the automated test system.
+  For example, LCALSMain.skipif supports automated testing of LCALSMain.chpl.
+  $CHPL_HOME/examples/README.testing contains more information.
+
 
 -----------------
 Execution Options

--- a/test/release/examples/benchmarks/lulesh/README
+++ b/test/release/examples/benchmarks/lulesh/README
@@ -40,18 +40,15 @@ This directory's contents are as follows:
   coords.out        : the coordinates computed by the program are written
                       to this file, suitable for plotting
 
-  PRECOMP           :\
-  lulesh.catfiles   : \
-  lulesh.cleanfiles :  \
-  lulesh.compopts   :   \
-  lulesh.execopts   :    \ used by the Chapel testing system
-  lulesh*.good      :    /
-  lulesh.graph      :   /
-  luleshInit.notest :  / 
-  lulesh*.perf*     : /
-  test3DLulesh.*    :/
-
   README            : this file
+
+  Other files with the same base filename as the Chapel test program but
+  different filename extensions, are for use by the automated test system.
+  For example, file lulesh.execopts supports automated testing of
+  lulesh.chpl. Files with all-uppercase filenames like PRECOMP
+  (but not "README") are similar, except they are applied to all chpl
+  tests in the directory. $CHPL_HOME/examples/README.testing contains
+  more information.
 
 
 -----------------------------------

--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -30,6 +30,8 @@ At present, this directory contains the following codes:
     fasta.chpl          : Generates DNA with different nucleotide distributions
                           and a random number generator
 
+Note that chameneosredux.chpl has non-deterministic output.
+
 Over time, we plan to create versions of all the benchmarks and to
 enter Chapel into the competition.  Draft versions of other benchmarks
 that have not yet been promoted to the release can be found in our git
@@ -40,8 +42,10 @@ be run in correctness or performance modes using the Chapel testing
 system.  (See doc/developer/bestPractices/TestSystem.rst in the Chapel
 git repository: http://github.com/chapel-lang/chapel)
 
-Note that chameneosredux.chpl has non-deterministic output.
-
+Other files with the same base filenames as the Chapel test programs but
+different filename extensions, are for use by the automated test system.
+For example, file fasta.execopts supports automated testing of fasta.chpl.
+$CHPL_HOME/examples/README.testing contains more information.
 
 Future work / TODO
 ==================

--- a/test/release/examples/benchmarks/ssca2/README
+++ b/test/release/examples/benchmarks/ssca2/README
@@ -12,7 +12,9 @@ FILES
 =====
 
 SSCA2_main.chpl      : The main module
+
 SSCA2_Modules/       : Directory of additional modules
+
   SSCA2_compilation_config_params.chpl      : Config params
   SSCA2_execution_config_consts.chpl        : Config consts
   SSCA2_driver.chpl                         : Calls to kernels 2-4
@@ -27,6 +29,11 @@ SSCA2_Modules/       : Directory of additional modules
   analyze_torus_graphs_stencil_rep_v1.chpl  : Torus graph infrastructures
   analyze_torus_graphs_stencil_rep_v2.chpl
   analyze_torus_graphs_stencil_rep_v3.chpl
+
+Other files with the same base filename as the Chapel test program but
+different filename extensions, are for use by the automated test system.
+For example, file SSCA2_main.execopts supports automated testing of
+SSCA2_main.chpl. $CHPL_HOME/examples/README.testing contains more information.
 
 
 BUILDING


### PR DESCRIPTION
Many files were added to the examples subtree to support Chapel's
automated test system. This change adds a paragraph to several
READMEs to mention these files and refer the reader to
CHPL_HOME/examples/README.testing for more info.
In some READMEs, this new paragraph replaces existing lists of
filenames (like *.compopts, *.execopts, etc); those lists were no
more informative than the new text, and were more trouble to
maintain as directory contents changed.