### PR TITLE
Fix string.join segfault on arrays over empty domains

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -831,7 +831,9 @@ module String {
     }
 
     proc _join(const ref S) : string where isTuple(S) || isArray(S) {
-      if S.size == 1 {
+      if S.size == 0 {
+        return '';
+      } else if S.size == 1 {
         // TODO: ensures copy, clean up when no longer needed
         var ret = S[S.domain.low];
         return ret;

--- a/test/types/string/methods/join-empty-domain.chpl
+++ b/test/types/string/methods/join-empty-domain.chpl
@@ -1,0 +1,4 @@
+/* Test passing an array over an empty domain to join */
+var S: [1..0] string;
+var j = ' '.join(S);
+assert(j.isEmptyString());


### PR DESCRIPTION
The following program compiles and seg faults during execution:

```chapel
var S: [1..0] string;
var j = ' '.join(S);
writeln(j);
```

This PR adds a special-case to `string.join` to account for `S.size == 1`, which returns an empty string. It also adds a test to confirm this new behavior.