### PR TITLE
Fix testTime test for PrgEnv-cray

### DIFF
--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -87,7 +87,7 @@ module DateTime {
     return (tv.tv_sec, tv.tv_usec);
   }
 
-  private proc tm_zoneType() type {
+  private proc tm_zoneType type {
     if CHPL_TARGET_PLATFORM == "darwin" then
       return c_ptr(c_char); // char *
     else
@@ -106,7 +106,7 @@ module DateTime {
     var tm_yday:   c_int;         // day of year [0,365]
     var tm_isdst:  c_int;         // daylight savings flag
     var tm_gmtoff: c_long;        // Seconds east of UTC
-    var tm_zone:   tm_zoneType(); // Timezone abbreviation
+    var tm_zone:   tm_zoneType; // Timezone abbreviation
   }
 
   private proc getLocalTime(t: 2*int) {
@@ -636,11 +636,11 @@ module DateTime {
 
     if tzinfo != nil {
       timeStruct.tm_gmtoff = abs(utcoffset()).seconds: c_long;
-      timeStruct.tm_zone = __primitive("cast", tm_zoneType(), tzname().c_str());
+      timeStruct.tm_zone = __primitive("cast", tm_zoneType, tzname().c_str());
       timeStruct.tm_isdst = dst().seconds: int(32);
     } else {
       timeStruct.tm_gmtoff = 0;
-      timeStruct.tm_zone = __primitive("cast", tm_zoneType(), "".c_str());
+      timeStruct.tm_zone = __primitive("cast", tm_zoneType, "".c_str());
       timeStruct.tm_isdst = -1;
     }
 

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -87,6 +87,13 @@ module DateTime {
     return (tv.tv_sec, tv.tv_usec);
   }
 
+  private proc tm_zoneType() type {
+    if CHPL_TARGET_PLATFORM == "darwin" then
+      return c_ptr(c_char); // char *
+    else
+      return c_string; // const char *
+  }
+
   pragma "no doc"
   extern "struct tm" record tm {
     var tm_sec:    c_int;         // seconds [0,61]
@@ -99,7 +106,7 @@ module DateTime {
     var tm_yday:   c_int;         // day of year [0,365]
     var tm_isdst:  c_int;         // daylight savings flag
     var tm_gmtoff: c_long;        // Seconds east of UTC
-    var tm_zone:   c_ptr(c_char); // Timezone abbreviation
+    var tm_zone:   tm_zoneType(); // Timezone abbreviation
   }
 
   private proc getLocalTime(t: 2*int) {
@@ -629,11 +636,11 @@ module DateTime {
 
     if tzinfo != nil {
       timeStruct.tm_gmtoff = abs(utcoffset()).seconds: c_long;
-      timeStruct.tm_zone = __primitive("cast", c_ptr(c_char), tzname().c_str());
+      timeStruct.tm_zone = __primitive("cast", tm_zoneType(), tzname().c_str());
       timeStruct.tm_isdst = dst().seconds: int(32);
     } else {
       timeStruct.tm_gmtoff = 0;
-      timeStruct.tm_zone = __primitive("cast", c_ptr(c_char), "".c_str());
+      timeStruct.tm_zone = __primitive("cast", tm_zoneType(), "".c_str());
       timeStruct.tm_isdst = -1;
     }
 


### PR DESCRIPTION
The type of the field `tm_zone` in `struct tm` is platform dependent. On
darwin it is `char *` and on other platforms it is `const char *`. Set the
type based on CHPL_TARGET_PLATFORM.

Prior to this, the type was set to `c_ptr(c_char)` to match the darwin type.
Now it is `c_ptr(c_char)` for darwin, and `c_string` elsewhere.

Tested on the modules/standard/datetime tests on:
* darwin + clang
* linux64 + gcc
* Cray XC + PrgEnv-cray
* Cray XC + PrgEnv-gnu
* Cray XC + PrgEnv-intel
* Cray XC + PrgEnv-pgi