### PR TITLE
Initializer "in progress" step 2

### DIFF
--- a/test/classes/initializers/init_before_userdef_initializer.future
+++ b/test/classes/initializers/init_before_userdef_initializer.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.


### PR DESCRIPTION
This is a second "in progress" merge of work being done to stabilize initializers for
non-generics with a focus on normalizing field initializers correctly.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Local testing of defined test cases and comparison of AST before/after.
start_test test/classes/initializers with futures on darwin
single-locale paratest with futures on linux64



More background:

Consider

record Foo {
  var x : int = 10;
  var y : int = x + 10;

  proc init() {
    x = 10;
    y = x + 10;

   super.init();        // Or without this
}

This initializer currently works on master based on interactions
between code in scope-resolve.cpp, initializer-rules.cpp, normalize.cpp
and function-resolution.cpp

This initializer does not work on master if the super.init() is removed.
The compiler attempts to use the field declarations to default initialize
the fields but the AST on the RHS of the declarations has a much different
structure.

The path then is to be able to walk the AST for the init-expr in either version
and emit the required final AST.  This ability will also enable better semantic
validation in the future.

This PR begins to handle the RHS of phase-1 statements in a somewhat
more principled way.  A subsequent PR will do the same for default field
initializers.

