### PR TITLE
Stop generating internal errors for generic instantiation variable declarations

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1109,12 +1109,17 @@ static void call_constructor_for_class(CallExpr* call) {
       primNewToFix = parentParent;
       INT_ASSERT(primNewToFix->get(1) == parent);
     } else if (ct) {
-      if (ct->symbol->hasFlag(FLAG_SYNTACTIC_DISTRIBUTION))
+      if (ct->symbol->hasFlag(FLAG_SYNTACTIC_DISTRIBUTION)) {
         // Call chpl__buildDistType for syntactic distributions.
         se->replace(new UnresolvedSymExpr("chpl__buildDistType"));
-      else
+      } else {
+        if (ct->initializerStyle == DEFINES_INITIALIZER && ct->isGeneric()) {
+          USR_FATAL_CONT(se, "Sorry, type constructors aren't generated properly for generic types that define initializers");
+        }
+
         // Transform C ( ... ) into _type_construct_C ( ... ) .
         se->replace(new UnresolvedSymExpr(ct->defaultTypeConstructor->name));
+      }
     }
 
     if (primNewToFix) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8538,6 +8538,13 @@ resolveExpr(Expr* expr) {
             !ct->symbol->hasFlag(FLAG_ITERATOR_CLASS) &&
             !ct->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
             ct->defaultTypeConstructor) {
+          if (ct->initializerStyle == DEFINES_INITIALIZER &&
+              (ct->isGeneric() ||
+               (isAggregateType(ct->instantiatedFrom) &&
+                toAggregateType(ct->instantiatedFrom)->isGeneric()))) {
+            USR_FATAL(ct, "Sorry, type constructors aren't generated properly for generic types that define initializers");
+          }
+
           resolveFormals(ct->defaultTypeConstructor);
           if (resolvedFormals.set_in(ct->defaultTypeConstructor)) {
             if (getPartialCopyInfo(ct->defaultTypeConstructor))


### PR DESCRIPTION
This was a portion of generics that the initializers team didn't actually
discuss fully.  Generate a warning for users while we figure out what to do
about it.

Does not impact constructors.  Only affects declarations of the form:
`var x: Foo(args);` when an initializer is defined.

I've checked that I get the right error message in the cases I expect.  I'm
saving the tests until we know what the expected behavior for them is.

Passed full std paratest run