### PR TITLE
Init updates

### DIFF
--- a/compiler/main/log.cpp
+++ b/compiler/main/log.cpp
@@ -112,7 +112,7 @@ void log_writeLog(const char* passName, int passNum, char logTag) {
 
   if (log_flags.set_in(logTag) != 0) {
     if (fUseIPE == false)
-      AstDump::view(passName, passNum);
+      AstDumpToNode::view(passName, passNum);
     else
       AstDumpToNode::view(passName, passNum);
   }

--- a/compiler/main/log.cpp
+++ b/compiler/main/log.cpp
@@ -112,7 +112,7 @@ void log_writeLog(const char* passName, int passNum, char logTag) {
 
   if (log_flags.set_in(logTag) != 0) {
     if (fUseIPE == false)
-      AstDumpToNode::view(passName, passNum);
+      AstDump::view(passName, passNum);
     else
       AstDumpToNode::view(passName, passNum);
   }

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -924,8 +924,9 @@ static void fieldInitTypeInference(Expr*      stmt,
 
     if (isPrimitiveScalar(type) == true) {
       SymExpr* fieldAccess = createFieldAccess(stmt, fn, field);
+      SymExpr* rhs         = normalizeExpr(stmt, state, initExpr);
 
-      stmt->insertBefore(new CallExpr("=", fieldAccess, initExpr));
+      stmt->insertBefore(new CallExpr("=", fieldAccess, rhs));
 
     } else {
       Symbol* _this = fn->_this;
@@ -968,10 +969,11 @@ static void fieldInitTypeInference(Expr*      stmt,
       INT_ASSERT(false);
 
     } else {
-      Symbol* _this = fn->_this;
-      Symbol* name  = new_CStringSymbol(field->sym->name);
+      Symbol*  _this = fn->_this;
+      Symbol*  name  = new_CStringSymbol(field->sym->name);
+      SymExpr* rhs   = normalizeExpr(stmt, state, initExpr);
 
-      stmt->insertBefore(new CallExpr(PRIM_INIT_FIELD, _this, name, initExpr));
+      stmt->insertBefore(new CallExpr(PRIM_INIT_FIELD, _this, name, rhs));
     }
 
   } else {

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -390,15 +390,22 @@ bool IterState::startsInPhase1(BlockStmt* block) const {
 }
 
 DefExpr* IterState::firstField(FnSymbol* fn) const {
-  AggregateType* at   = toAggregateType(fn->_this->type);
-  Expr*          head = at->fields.head;
+  AggregateType* at     = toAggregateType(fn->_this->type);
+  DefExpr*       retval = toDefExpr(at->fields.head);
 
   // Skip the psuedo-field "super"
   if (::isClass(at) == true) {
-    head = head->next;
+    retval = toDefExpr(retval->next);
   }
 
-  return toDefExpr(head);
+  // Skip the psuedo-field "outer" (if present)
+  if (retval->exprType                   == NULL &&
+      retval->init                       == NULL &&
+      strcmp(retval->sym->name, "outer") ==    0) {
+    retval = toDefExpr(retval->next);
+  }
+
+  return retval;
 }
 
 Expr* IterState::fieldInitFromInitStmt(DefExpr* field, CallExpr* initStmt) {

--- a/test/classes/initializers/parentCall/inParallel.future
+++ b/test/classes/initializers/parentCall/inParallel.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/parentCall/inParallel.good
+++ b/test/classes/initializers/parentCall/inParallel.good
@@ -1,1 +1,2 @@
-inParallel.chpl:7: error: super.init() call in parallel statement
+inParallel.chpl:4: In initializer:
+inParallel.chpl:6: error: use of super.init() call in a parallel statement

--- a/test/classes/initializers/phase1/dependence.future
+++ b/test/classes/initializers/phase1/dependence.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/hasParallelBad.future
+++ b/test/classes/initializers/phase1/hasParallelBad.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/hasParallelBad.good
+++ b/test/classes/initializers/phase1/hasParallelBad.good
@@ -1,2 +1,2 @@
-hasParallelBad.chpl:7: error: field "a" initialized in parallel statement (fields must be initialized in order)
-hasParallelBad.chpl:8: error: field "b" initialized in parallel statement (fields must be initialized in order)
+hasParallelBad.chpl:5: In initializer:
+hasParallelBad.chpl:7: error: can't initialize field "a" inside a parallel statement during phase 1 of initialization

--- a/test/classes/initializers/siblingCall/loopSiblingCall.future
+++ b/test/classes/initializers/siblingCall/loopSiblingCall.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/siblingCall/loopSiblingCall.good
+++ b/test/classes/initializers/siblingCall/loopSiblingCall.good
@@ -1,1 +1,2 @@
-loopSiblingCall.chpl:13: error: use of this.init() call in loop body
+loopSiblingCall.chpl:4: In initializer:
+loopSiblingCall.chpl:13: error: use of this.init() in a conditional stmt in phase 1

--- a/test/classes/initializers/siblingCall/parallelSiblingCall.future
+++ b/test/classes/initializers/siblingCall/parallelSiblingCall.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/siblingCall/parallelSiblingCall.good
+++ b/test/classes/initializers/siblingCall/parallelSiblingCall.good
@@ -1,1 +1,2 @@
-parallelSiblingCall.chpl:5: error: this.init() call in parallel statement
+parallelSiblingCall.chpl:4: In initializer:
+parallelSiblingCall.chpl:5: error: use of this.init() call in a parallel statement


### PR DESCRIPTION
This "in-progress" PR rolls up three changes

1) Completes the updates so that current tests that initialize fields using default values
are normalized correctly

2) Generates appropriate error messages if there are attempts to initialize a field or invoke
super/this.init() within begin/cobegin statements

3) Skips the pseudo-field "outer" for nested class/records.

Updates the required set of .good files and retires some futures.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed start_test for tests/classes/initializers with -futures on darwin
Passed paratest for single-locale with -futures on linux64
