### PR TITLE
Continued updates for initializers

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -250,7 +250,6 @@ IterState::IterState(FnSymbol* fn) {
   mBlockType  = cBlockNormal;
 }
 
-// Only used to generate error messages
 IterState::IterState(CondStmt* cond, const IterState& curr) {
   mFn         = curr.mFn;
   mCurrField  = curr.mCurrField;
@@ -258,7 +257,6 @@ IterState::IterState(CondStmt* cond, const IterState& curr) {
   mBlockType  = cBlockCond;
 }
 
-// Only used to generate error messages
 IterState::IterState(LoopStmt* loop, const IterState& curr) {
   mFn         = curr.mFn;
   mCurrField  = curr.mCurrField;
@@ -869,8 +867,9 @@ static void fieldInitTypeInference(Expr*      stmt,
 
     if (isPrimitiveScalar(type) == true) {
       SymExpr* fieldAccess = createFieldAccess(stmt, fn, field);
+      SymExpr* rhs         = normalizeExpr(stmt, state, initExpr);
 
-      stmt->insertBefore(new CallExpr("=", fieldAccess, initExpr));
+      stmt->insertBefore(new CallExpr("=", fieldAccess, rhs));
 
     } else {
       Symbol* _this = fn->_this;
@@ -913,10 +912,11 @@ static void fieldInitTypeInference(Expr*      stmt,
       INT_ASSERT(false);
 
     } else {
-      Symbol* _this = fn->_this;
-      Symbol* name  = new_CStringSymbol(field->sym->name);
+      Symbol*  _this = fn->_this;
+      Symbol*  name  = new_CStringSymbol(field->sym->name);
+      SymExpr* rhs   = normalizeExpr(stmt, state, initExpr);
 
-      stmt->insertBefore(new CallExpr(PRIM_INIT_FIELD, _this, name, initExpr));
+      stmt->insertBefore(new CallExpr(PRIM_INIT_FIELD, _this, name, rhs));
     }
 
   } else {

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -199,9 +199,10 @@ static bool     isCompoundAssignment(CallExpr* callExpr);
 
 class IterState {
 public:
-                  IterState(FnSymbol* fn);
-                  IterState(CondStmt* cond, const IterState& curr);
-                  IterState(LoopStmt* loop, const IterState& curr);
+                  IterState(FnSymbol*  fn);
+                  IterState(BlockStmt* block, const IterState& curr);
+                  IterState(LoopStmt*  loop,  const IterState& curr);
+                  IterState(CondStmt*  cond,  const IterState& curr);
 
   AggregateType*  type()                                                 const;
   FnSymbol*       theFn()                                                const;
@@ -217,6 +218,7 @@ public:
   bool            isFieldReinitialized(DefExpr* field)                   const;
   bool            inLoopBody()                                           const;
   bool            inCondStmt()                                           const;
+  bool            inParallelStmt()                                       const;
 
   DefExpr*        currField()                                            const;
 
@@ -228,6 +230,8 @@ private:
     cBlockNormal,
     cBlockCond,
     cBlockLoop,
+    cBlockBegin,
+    cBlockCobegin
   };
 
                   IterState();
@@ -248,6 +252,27 @@ IterState::IterState(FnSymbol* fn) {
   mCurrField  = firstField(fn);
   mIsPhase1   = startsInPhase1(fn);
   mBlockType  = cBlockNormal;
+}
+
+IterState::IterState(BlockStmt* block, const IterState& curr) {
+  mFn         = curr.mFn;
+  mCurrField  = curr.mCurrField;
+  mIsPhase1   = curr.mIsPhase1;
+
+  if (CallExpr* blockInfo = block->blockInfoGet()) {
+    if (blockInfo->isPrimitive(PRIM_BLOCK_BEGIN)   == true) {
+      mBlockType = cBlockBegin;
+
+    } else if (blockInfo->isPrimitive(PRIM_BLOCK_COBEGIN) == true) {
+      mBlockType = cBlockCobegin;
+
+    } else {
+      INT_ASSERT(false);
+    }
+
+  } else {
+    mBlockType = curr.mBlockType;
+  }
 }
 
 IterState::IterState(CondStmt* cond, const IterState& curr) {
@@ -312,6 +337,11 @@ bool IterState::inLoopBody() const {
 
 bool IterState::inCondStmt() const {
   return mBlockType == cBlockCond;
+}
+
+bool IterState::inParallelStmt() const {
+  return mBlockType == cBlockBegin   ||
+         mBlockType == cBlockCobegin  ;
 }
 
 Expr* IterState::completePhase1(Expr* initStmt) {
@@ -388,15 +418,23 @@ bool IterState::startsInPhase1(BlockStmt* block) const {
 }
 
 DefExpr* IterState::firstField(FnSymbol* fn) const {
-  AggregateType* at   = toAggregateType(fn->_this->type);
-  Expr*          head = at->fields.head;
+  AggregateType* at     = toAggregateType(fn->_this->type);
+  DefExpr*       retval = toDefExpr(at->fields.head);
 
-  // Skip the psuedo-field "super"
+  // Skip the pseudo-field "super"
   if (::isClass(at) == true) {
-    head = head->next;
+    retval = toDefExpr(retval->next);
   }
 
-  return toDefExpr(head);
+  // Skip the pseudo-field "outer" (if present)
+  if (retval                             != NULL &&
+      retval->exprType                   == NULL &&
+      retval->init                       == NULL &&
+      strcmp(retval->sym->name, "outer") ==    0) {
+    retval = toDefExpr(retval->next);
+  }
+
+  return retval;
 }
 
 Expr* IterState::fieldInitFromInitStmt(DefExpr* field, CallExpr* initStmt) {
@@ -528,6 +566,19 @@ static IterState preNormalize(BlockStmt* block, IterState state, Expr* stmt) {
             INT_ASSERT(false);
           }
 
+        } else if (state.inParallelStmt() == true) {
+          if (isSuperInit(callExpr) == true) {
+            USR_FATAL(stmt,
+                      "use of super.init() call in a parallel statement");
+
+          } else if (isThisInit(callExpr) == true) {
+            USR_FATAL(stmt,
+                      "use of this.init() call in a parallel statement");
+
+          } else {
+            INT_ASSERT(false);
+          }
+
         } else {
           stmt = state.completePhase1(stmt);
         }
@@ -564,6 +615,12 @@ static IterState preNormalize(BlockStmt* block, IterState state, Expr* stmt) {
           USR_FATAL(stmt,
                     "can't initialize field \"%s\" inside a "
                     "conditional during phase 1 of initialization",
+                    field->sym->name);
+
+        } else if (state.inParallelStmt() == true) {
+          USR_FATAL(stmt,
+                    "can't initialize field \"%s\" inside a "
+                    "parallel statement during phase 1 of initialization",
                     field->sym->name);
 
         } else {
@@ -603,7 +660,7 @@ static IterState preNormalize(BlockStmt* block, IterState state, Expr* stmt) {
       stmt = stmt->next;
 
     } else if (BlockStmt* block = toBlockStmt(stmt)) {
-      state = preNormalize(block, state);
+      state = preNormalize(block, IterState(block, state));
       stmt  = stmt->next;
 
     } else {

--- a/test/classes/initializers/parentCall/inParallel.future
+++ b/test/classes/initializers/parentCall/inParallel.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/parentCall/inParallel.good
+++ b/test/classes/initializers/parentCall/inParallel.good
@@ -1,1 +1,2 @@
-inParallel.chpl:7: error: super.init() call in parallel statement
+inParallel.chpl:4: In initializer:
+inParallel.chpl:6: error: use of super.init() call in a parallel statement

--- a/test/classes/initializers/phase1/dependence.future
+++ b/test/classes/initializers/phase1/dependence.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/hasParallelBad.future
+++ b/test/classes/initializers/phase1/hasParallelBad.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/hasParallelBad.good
+++ b/test/classes/initializers/phase1/hasParallelBad.good
@@ -1,2 +1,2 @@
-hasParallelBad.chpl:7: error: field "a" initialized in parallel statement (fields must be initialized in order)
-hasParallelBad.chpl:8: error: field "b" initialized in parallel statement (fields must be initialized in order)
+hasParallelBad.chpl:5: In initializer:
+hasParallelBad.chpl:7: error: can't initialize field "a" inside a parallel statement during phase 1 of initialization

--- a/test/classes/initializers/siblingCall/loopSiblingCall.future
+++ b/test/classes/initializers/siblingCall/loopSiblingCall.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/siblingCall/loopSiblingCall.good
+++ b/test/classes/initializers/siblingCall/loopSiblingCall.good
@@ -1,1 +1,2 @@
-loopSiblingCall.chpl:13: error: use of this.init() call in loop body
+loopSiblingCall.chpl:4: In initializer:
+loopSiblingCall.chpl:13: error: use of this.init() in a conditional stmt in phase 1

--- a/test/classes/initializers/siblingCall/parallelSiblingCall.future
+++ b/test/classes/initializers/siblingCall/parallelSiblingCall.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/siblingCall/parallelSiblingCall.good
+++ b/test/classes/initializers/siblingCall/parallelSiblingCall.good
@@ -1,1 +1,2 @@
-parallelSiblingCall.chpl:5: error: this.init() call in parallel statement
+parallelSiblingCall.chpl:4: In initializer:
+parallelSiblingCall.chpl:5: error: use of this.init() call in a parallel statement


### PR DESCRIPTION
This trivial PR has 3 small updates for initializers

A. Expand the code for normalizing the RHS of field initializers to the remaining use cases.
Retire one future that was caused by a link error for a field declaration.

B. Skip over the pseudo-field "outer" for nested class/record

C. Monitor use of begin/cobegin statements, generate new errors messages, retire 4 futures.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Use-case based testing
start_test classes/initializers with futures
single-locale paratest with futures
