### PR TITLE
Continued incremental improvements to non-generic initializers

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -538,7 +538,7 @@ static void preNormalizeNonGenericInit(FnSymbol* fn) {
   // This implies the body contains at least one instance of super.init()
   // and/or this.init() i.e. the body is not empty and we do not need to
   // insert super.init()
-  if (state.isPhase1() == true) {
+  if (state.isPhase0() == true || state.isPhase1() == true) {
     preNormalize(fn->body, state);
 
   // 1) Insert super.init()
@@ -704,8 +704,8 @@ static InitVisitor preNormalize(BlockStmt*  block,
       }
 
     } else if (CondStmt* cond = toCondStmt(stmt)) {
-      // Focus on phase 1
-      if (state.isPhase1() == true) {
+      // Focus on phase 0 or phase 1
+      if (state.isPhase0() == true || state.isPhase1() == true) {
         preNormalize(cond->thenStmt, InitVisitor(cond, state));
 
         if (cond->elseStmt != NULL) {
@@ -716,8 +716,8 @@ static InitVisitor preNormalize(BlockStmt*  block,
       stmt = stmt->next;
 
     } else if (LoopStmt* loop = toLoopStmt(stmt)) {
-      // Focus on phase 1
-      if (state.isPhase1() == true) {
+      // Focus on phase 0 or phase 1
+      if (state.isPhase0() == true || state.isPhase1() == true) {
         preNormalize((BlockStmt*) stmt, InitVisitor(loop, state));
       }
 
@@ -728,8 +728,8 @@ static InitVisitor preNormalize(BlockStmt*  block,
       stmt  = stmt->next;
 
     } else {
-      // Focus on phase 1
-      if (state.isPhase1() == true) {
+      // Focus on phase 0 or phase 1
+      if (state.isPhase0() == true || state.isPhase1() == true) {
         INT_ASSERT(false);
       }
 

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -420,7 +420,10 @@ InitVisitor::Phase InitVisitor::startPhase(BlockStmt* block) const {
       stmt = stmt->next;
 
     } else if (CallExpr* callExpr = toCallExpr(stmt)) {
-      if (isInitStmt(callExpr) == true) {
+      if        (isThisInit(callExpr)  == true) {
+        retval = cPhase0;
+
+      } else if (isSuperInit(callExpr) == true) {
         retval = cPhase1;
 
       } else {
@@ -432,7 +435,7 @@ InitVisitor::Phase InitVisitor::startPhase(BlockStmt* block) const {
         Phase thenPhase = startPhase(cond->thenStmt);
 
         if (thenPhase != cPhase2) {
-          retval = cPhase1;
+          retval = thenPhase;
         } else {
           stmt   = stmt->next;
         }
@@ -441,10 +444,10 @@ InitVisitor::Phase InitVisitor::startPhase(BlockStmt* block) const {
         Phase thenPhase = startPhase(cond->thenStmt);
         Phase elsePhase = startPhase(cond->elseStmt);
 
-        if        (thenPhase != cPhase2) {
-          retval = cPhase1;
+        if        (thenPhase == cPhase0 || elsePhase == cPhase0) {
+          retval = cPhase0;
 
-        } else if (elsePhase != cPhase2) {
+        } else if (thenPhase == cPhase1 || elsePhase == cPhase1) {
           retval = cPhase1;
 
         } else {
@@ -456,7 +459,7 @@ InitVisitor::Phase InitVisitor::startPhase(BlockStmt* block) const {
       Phase phase = startPhase(block);
 
       if (phase != cPhase2) {
-        retval = cPhase1;
+        retval = phase;
       } else {
         stmt   = stmt->next;
       }


### PR DESCRIPTION
This PR is an in-progress update to introduce the notion of "phase0" to improve handling of
this.init() vs super.init().  Phase 0 is to used to represent "convenience initializers" that dispatch
via this.init() rather than super.int().  There are more constraints on the former than the latter.


Compiled with/without CHPL_DEVELOPER
start_test initializers with futures
single-locale paratest with futures
