### PR TITLE
Init this init

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -239,7 +239,7 @@ public:
   bool            isPhase1()                                             const;
   bool            isPhase2()                                             const;
 
-  Expr*           completePhase1(Expr* insertBefore);
+  Expr*           completePhase1(CallExpr* insertBefore);
   void            initializeFieldsBefore(Expr* insertBefore);
 
   bool            isFieldReinitialized(DefExpr* field)                   const;
@@ -381,13 +381,15 @@ bool InitVisitor::inParallelStmt() const {
          mBlockType == cBlockCobegin  ;
 }
 
-Expr* InitVisitor::completePhase1(Expr* initStmt) {
+Expr* InitVisitor::completePhase1(CallExpr* initStmt) {
   Expr* retval = initStmt->next;
 
-  initializeFieldsBefore(initStmt);
+  if (isSuperInit(initStmt) == true) {
+    initializeFieldsBefore(initStmt);
 
-  if (isRecord() == true) {
-    initStmt->remove();
+    if (isRecord() == true) {
+      initStmt->remove();
+    }
   }
 
   mPhase = cPhase2;
@@ -644,7 +646,7 @@ static InitVisitor preNormalize(BlockStmt*  block,
           }
 
         } else {
-          stmt = state.completePhase1(stmt);
+          stmt = state.completePhase1(callExpr);
         }
 
       // Stmt is simple/compound assignment to a local field

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -33,7 +33,6 @@
 #include "type.h"
 #include "view.h"
 
-
 static
 void resolveInitializer(CallExpr* call);
 
@@ -56,6 +55,8 @@ filterInitCandidate(Vec<ResolutionCandidate*>& candidates,
 
 static FnSymbol*
 instantiateInitSig(FnSymbol* fn, SymbolMap& subs, CallExpr* call);
+
+static bool isRefWrapperForNonGenericRecord(AggregateType* at);
 
 // Rewrite of instantiateSignature, for initializers.  Removed some bits,
 // modified others.
@@ -556,7 +557,9 @@ void temporaryInitializerFixup(CallExpr* call) {
       INT_ASSERT(sym != NULL);
 
       if (AggregateType* ct = toAggregateType(sym->symbol()->type)) {
-        if (ct->initializerStyle == DEFINES_NONE_USE_DEFAULT) {
+
+        if (isRefWrapperForNonGenericRecord(ct) == false &&
+            ct->initializerStyle                == DEFINES_NONE_USE_DEFAULT) {
 
           // This code should be removed when the compiler generates
           // initializers as the default method of construction and
@@ -569,6 +572,52 @@ void temporaryInitializerFixup(CallExpr* call) {
     }
   }
 }
+
+
+//
+// Noakes 2017/03/26
+//   The function temporaryInitializerFixup is designed to update
+//   certain calls to init() while the initializer update matures.
+//
+//   Unfortunately this transformation is triggered incorrectly for uses of
+//           this.init(...);
+//
+//   inside initializers for non-generic records.
+//
+//   For those uses of init() the "this" argument has currently has type
+//   _ref(<Record>) rather than <Record>
+//
+//  This rather unfortunate function catches this case and enables the
+//  transformation to be skipped.
+//
+static bool isRefWrapperForNonGenericRecord(AggregateType* at) {
+  bool retval = false;
+
+  if (isClass(at)                           == true &&
+      strncmp(at->symbol->name, "_ref(", 5) == 0    &&
+      at->fields.length                     == 1) {
+    Symbol* sym = toDefExpr(at->fields.head)->sym;
+
+    if (strcmp(sym->name, "_val") == 0) {
+      retval = isNonGenericRecordWithInitializers(sym->type);
+    }
+  }
+
+  return retval;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 void removeAggTypeFieldInfo() {
   forv_Vec(AggregateType, at, gAggregateTypes) {

--- a/test/classes/initializers/siblingCall/record-0.chpl
+++ b/test/classes/initializers/siblingCall/record-0.chpl
@@ -1,0 +1,32 @@
+record MyRec {
+  var x : int;
+  var y : int = 1;
+  var z : int = 2;
+
+  proc init() {
+    writeln('init()     Phase 0');
+    writeln();
+
+    this.init(5);
+
+    writeln();
+    writeln('init()     Phase 2');
+  }
+
+  proc init(_z : int) {
+    writeln('init(_z)   Phase 1');
+
+    z = _z;
+
+    super.init();
+
+    writeln('init(_z)   Phase 2');
+  }
+}
+
+proc main() {
+  var r1 : MyRec;
+
+  writeln();
+  writeln('r1: ', r1);
+}

--- a/test/classes/initializers/siblingCall/record-0.good
+++ b/test/classes/initializers/siblingCall/record-0.good
@@ -1,0 +1,8 @@
+init()     Phase 0
+
+init(_z)   Phase 1
+init(_z)   Phase 2
+
+init()     Phase 2
+
+r1: (x = 0, y = 1, z = 5)


### PR DESCRIPTION
Before this PR calls to this.init(..) within an initializer for a non-generic record failed.  There were
two problems

A. The early-normalize step that is intended to remove uses of super.init() from initializers for
non-generic records was unintentionally also removing uses of this.init().  The first commit avoids
this.

B. There'a a complicated transition function "temporaryInitializerFixup" that modifies calls to
init() in certain circumstances.  This logic was triggering unintentionally for uses of this.init(..)
within record initializers.  The second commit add a modestly unruly filter function to prevent
this in this specialized case.

C. Add a test to verify that this.init(..) works for non-generic records.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Specialized testing with inspection of AST.
start_test for classes/initializers with futures on darwin
single-locale paratest with futures on linux64
