### PR TITLE
Pre-release prep. for Chapel 1.15.0 : update dockerfiles

### DIFF
--- a/util/dockerfiles/1.15.0/Dockerfile
+++ b/util/dockerfiles/1.15.0/Dockerfile
@@ -14,9 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     make \
     mawk \
+    file \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CHPL_VERSION 1.14.0
+ENV CHPL_VERSION 1.15.0
 ENV CHPL_HOME    /opt/chapel/$CHPL_VERSION
 ENV CHPL_GMP     system
 

--- a/util/dockerfiles/1.15.0/Dockerfile
+++ b/util/dockerfiles/1.15.0/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:jessie
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    ca-certificates \
+    gcc \
+    g++ \
+    perl \
+    python \
+    python-dev \
+    python-setuptools \
+    libgmp10 \
+    libgmp-dev \
+    bash \
+    make \
+    mawk \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CHPL_VERSION 1.14.0
+ENV CHPL_HOME    /opt/chapel/$CHPL_VERSION
+ENV CHPL_GMP     system
+
+RUN mkdir -p /opt/chapel \
+    && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
+    && make -C $CHPL_HOME \
+    && make -C $CHPL_HOME chpldoc
+
+ENV PATH $PATH:$CHPL_HOME/bin/linux64:$CHPL_HOME/util

--- a/util/dockerfiles/1.15.0/gasnet/Dockerfile
+++ b/util/dockerfiles/1.15.0/gasnet/Dockerfile
@@ -1,0 +1,8 @@
+FROM chapel/chapel:latest
+
+ENV CHPL_COMM gasnet
+
+RUN make -C $CHPL_HOME \
+    && make -C $CHPL_HOME chpldoc
+
+ENV GASNET_SPAWNFN L

--- a/util/dockerfiles/README.md
+++ b/util/dockerfiles/README.md
@@ -11,6 +11,7 @@
 
 ## `chapel/chapel:<version>`
 Supported Chapel versions:
+* [`1.15.0`, `latest` (_1.15.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.15.0/Dockerfile/)
 * [`1.14.0`, `latest` (_1.14.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.14.0/Dockerfile/)
 * [`1.13.1` (_1.13.1/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.13.1/Dockerfile)
 
@@ -18,6 +19,7 @@ This is the core image for Chapel. It provides the complete Chapel compiler and 
 
 ## [`chapel/chapel-gasnet:<version>`](https://hub.docker.com/r/chapel/chapel-gasnet/)
 
+* [`1.15.0`, `latest` (_1.15.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.15.0/gasnet/Dockerfile/)
 * [`1.14.0`, `latest` (_1.14.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.14.0/gasnet/Dockerfile/)
 
 The Chapel core image (above), rebuilt with `CHPL_COMM=gasnet` and `GASNET_SPAWNFN=L`. Simulates a multilocale Chapel platform within the Docker container.
@@ -64,7 +66,7 @@ Hello, world!
 
 # Documentation
 
-Chapel's documentation is [available online](http://chapel.cray.com/docs/latest/). Documentation for a specific release is also available: [1.14](http://chapel.cray.com/docs/1.14/), [1.13](http://chapel.cray.com/docs/1.13/).
+Chapel's documentation is [available online](http://chapel.cray.com/docs/latest/). Documentation for a specific release is also available: [1.15](http://chapel.cray.com/docs/1.15/), [1.14](http://chapel.cray.com/docs/1.14/), [1.13](http://chapel.cray.com/docs/1.13/).
 
 # License
 


### PR DESCRIPTION
THIS IS NOT CHAPEL RELEASE 1.15.0

This gets the dockerfiles ready for later release, currently scheduled for 6 April 2017.