### PR TITLE
Extend normalization to handle a field that is initialized with a new-expr

### DIFF
--- a/test/classes/initializers/record-normalize-init-expr-1.chpl
+++ b/test/classes/initializers/record-normalize-init-expr-1.chpl
@@ -1,0 +1,34 @@
+var a : int  = 50;
+var b : real = 60.0;
+
+record MyRec {
+  var x  : int    = 10;
+  var y  : real   = foo();
+  var s0 : SubRec = new SubRec(a, b);
+  var s1 : SubRec = new SubRec(x, y);
+
+  proc init() {
+    writeln('MyRec.init()');
+  }
+}
+
+proc foo() : int {
+  return 20;
+}
+
+record SubRec {
+  var a : int  = 1;
+  var b : real = 2.0;
+
+  proc init(_a : int, _b : real) {
+    writeln('SubRec.init(', _a, ', ', _b, ')');
+    a = _a;
+    b = _b;
+  }
+}
+
+proc main() {
+  var r : MyRec;
+
+  writeln('r: ', r);
+}

--- a/test/classes/initializers/record-normalize-init-expr-1.good
+++ b/test/classes/initializers/record-normalize-init-expr-1.good
@@ -1,0 +1,4 @@
+SubRec.init(50, 60.0)
+SubRec.init(10, 20.0)
+MyRec.init()
+r: (x = 10, y = 20.0, s0 = (a = 50, b = 60.0), s1 = (a = 10, b = 20.0))


### PR DESCRIPTION
Update the code that normalizes field-level initializers with record type and a new-expr
as the initializer to normalize the actuals for the generate init call.  Added a test to lock
this in

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
start_test classes/initializers on darwin
single-locale paratest on linux64


