### PR TITLE
Init tweaks

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -702,7 +702,12 @@ static InitVisitor preNormalize(BlockStmt*  block,
 
       // Stmt is simple/compound assignment to a local field
       } else if (DefExpr* field = toLocalFieldInit(state.type(), callExpr)) {
-        if (state.isPhase2() == true) {
+
+        if (state.isPhase0() == true) {
+          USR_FATAL(stmt,
+                    "field initialization not allowed with sibling initializer call");
+
+        } else if (state.isPhase2() == true) {
           if (field->sym->hasFlag(FLAG_CONST) == true) {
             USR_FATAL(stmt,
                       "cannot update a const field, \"%s\", in phase 2",

--- a/test/classes/initializers/phase1/badDependence2.future
+++ b/test/classes/initializers/phase1/badDependence2.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/siblingCall/endsInitBad.future
+++ b/test/classes/initializers/siblingCall/endsInitBad.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/siblingCall/endsInitBad.good
+++ b/test/classes/initializers/siblingCall/endsInitBad.good
@@ -1,1 +1,2 @@
+endsInitBad.chpl:5: In initializer:
 endsInitBad.chpl:6: error: field initialization not allowed with sibling initializer call

--- a/test/classes/initializers/siblingCall/middleBad.future
+++ b/test/classes/initializers/siblingCall/middleBad.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/siblingCall/middleBad.good
+++ b/test/classes/initializers/siblingCall/middleBad.good
@@ -1,1 +1,2 @@
+middleBad.chpl:5: In initializer:
 middleBad.chpl:6: error: field initialization not allowed with sibling initializer call


### PR DESCRIPTION
Generate error messages for two modes

A. Detect that a field is used before it is initialized.  Retire 1 future.

B. Detect that a field is initialized before a call to this.init().  Retire 2 futures.

Compiled with/without CHP_DEVELOPER on clang/darwin and gcc/linux64
start_test classes/initializers with futures on darwin
single-locale paratest with futures on linux64
