### PR TITLE
Make MPI SPMD hello.chpl consistent

### DIFF
--- a/test/modules/packages/mpi/spmd/hello-chapel/hello.chpl
+++ b/test/modules/packages/mpi/spmd/hello-chapel/hello.chpl
@@ -1,10 +1,16 @@
 use MPI;
+use IO;
+
+//extern proc fflush(stream);
 
 var rank = commRank(CHPL_COMM_WORLD),
     size = commSize(CHPL_COMM_WORLD);
 
 for irank in 0.. #size {
-  if irank == rank then
+  if irank == rank {
     writef("Hello, Chapel! This is MPI rank=%i of size=%i, on locale.id=%i\n",rank, size, here.id);
+    stdout.flush();
+    //fflush(chpl_cstdout());
+  }
   C_MPI.MPI_Barrier(CHPL_COMM_WORLD);
 }

--- a/test/modules/packages/mpi/spmd/hello-chapel/hello.chpl
+++ b/test/modules/packages/mpi/spmd/hello-chapel/hello.chpl
@@ -1,7 +1,6 @@
-use MPI;
 use IO;
-
-//extern proc fflush(stream);
+use MPI;
+use Time;
 
 var rank = commRank(CHPL_COMM_WORLD),
     size = commSize(CHPL_COMM_WORLD);
@@ -9,8 +8,10 @@ var rank = commRank(CHPL_COMM_WORLD),
 for irank in 0.. #size {
   if irank == rank {
     writef("Hello, Chapel! This is MPI rank=%i of size=%i, on locale.id=%i\n",rank, size, here.id);
+    // MPI can result in stdout being merged in unspecified ways even with a
+    // fflush, so we throw in a sleep for good measure
     stdout.flush();
-    //fflush(chpl_cstdout());
+    sleep(10);
   }
   C_MPI.MPI_Barrier(CHPL_COMM_WORLD);
 }


### PR DESCRIPTION
MPI can result in stdout being merged in unspecified ways even with a flush, so we throw in a sleep for good measure, to ensure output matches the `.good` file.