### PR TITLE
At Brad's request, expand this error message to suggest possible alternate paths

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1114,7 +1114,7 @@ static void call_constructor_for_class(CallExpr* call) {
         se->replace(new UnresolvedSymExpr("chpl__buildDistType"));
       } else {
         if (ct->initializerStyle == DEFINES_INITIALIZER && ct->isGeneric()) {
-          USR_FATAL_CONT(se, "Sorry, type constructors aren't generated properly for generic types that define initializers");
+          USR_FATAL_CONT(se, "Type constructors are not yet supported for generic types that define initializers.  As a workaround, try relying on type inference");
         }
 
         // Transform C ( ... ) into _type_construct_C ( ... ) .

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8542,7 +8542,7 @@ resolveExpr(Expr* expr) {
               (ct->isGeneric() ||
                (isAggregateType(ct->instantiatedFrom) &&
                 toAggregateType(ct->instantiatedFrom)->isGeneric()))) {
-            USR_FATAL(ct, "Sorry, type constructors aren't generated properly for generic types that define initializers");
+            USR_FATAL(ct, "Type constructors are not yet supported for generic types that define initializers.  As a workaround, try relying on type inference");
           }
 
           resolveFormals(ct->defaultTypeConstructor);


### PR DESCRIPTION
Since generics are usable, just not when you declare the explicit instantiation
instead of relying on type inference.