### PR TITLE
LinearAlgebra bug fixes & corrections

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -303,6 +303,7 @@ inline proc transpose(D: domain(1)) {
   return D;
 }
 
+pragma "no doc"
 inline proc transpose(D: domain(2)) {
   return {D.dim(2), D.dim(1)};
 }
@@ -320,7 +321,7 @@ pragma "no doc"
 proc _array.T where this.domain.rank == 1 { return transpose(this); }
 
 
-/* Transpose vector or matrix.
+/* Transpose vector, matrix, or domain.
 
    .. note::
 

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -161,7 +161,7 @@ proc Vector(Dom: domain(1), type eltType=real) {
 
 /* Return a vector (1D array) with domain and values of ``A`` */
 proc Vector(A: [?Dom] ?Atype, type eltType=Atype ) {
-  var V: [Dom] eltType = A;
+  var V: [Dom] eltType = A: eltType;
   return V;
 }
 
@@ -216,8 +216,8 @@ proc Matrix(Dom: domain(2), type eltType=real) where Dom.rank == 2 {
 
 
 /* Return a matrix (2D array) with domain and values of ``A`` */
-proc Matrix(A: [?Dom] ?eltType) where Dom.rank == 2 {
-  var M: [Dom] eltType = A;
+proc Matrix(A: [?Dom] ?Atype, type eltType=Atype) where Dom.rank == 2 {
+  var M: [Dom] eltType = A: eltType;
   return M;
 }
 

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -7,6 +7,8 @@ use LinearAlgebra;
    Many of these tests are trivial and can be expanded upon in the future.
 */
 
+config const verbose=false;
+
 //
 // Initializers
 //
@@ -159,6 +161,32 @@ use LinearAlgebra;
 }
 
 /* dot - calls matMult && inner*/
+
+// Test shapes
+{
+var M34 = Matrix([1, 2, 3, 4],
+                 [5, 6, 7, 8],
+                 [9, 10,11,12],
+                 eltType=real);
+var v4 = Vector([1,2,3,4], eltType=real );
+
+var v3 = Vector([1,2,3], eltType=real);
+
+// Sanity check
+assertEqual(M34.shape, (3, 4), 'M34.shape');
+assertEqual(v4.shape, (4,), 'v4.shape');
+assertEqual(v3.shape, (3,), 'v3.shape');
+
+assertEqual(dot(v3, M34).shape, (4,), 'dot(v3, M34).shape');
+assertEqual(dot(M34.T, v3).shape, (4,), 'dot(M34.T, v3).shape');
+
+assertEqual(dot(M34, v4).shape, (3,),'dot(M34, v4).shape');
+assertEqual(dot(v4, M34.T), (3,), 'dot(v4, M34.T)');
+
+asserEqual(dot(M34, M34.T), (3,3), 'dot(M34, M34.T)');
+asserEqual(dot(M34.T, M34), (4,4), 'dot(M34.T, M34)');
+}
+
 {
 
   proc test_dot(type t) {
@@ -373,6 +401,7 @@ use LinearAlgebra;
 //
 
 proc assertEqual(X, Y, msg="") {
+  if verbose then writeln(msg);
   if X != Y {
     writeln("Test Failed: ", msg);
     writeln(X, ' != ', Y);
@@ -382,6 +411,7 @@ proc assertEqual(X, Y, msg="") {
 
 proc assertEqual(X: [], Y: [], msg="") where isArrayValue(X) && isArrayValue(Y)
 {
+  if verbose then writeln(msg);
   if X.shape != Y.shape {
     writeln("Test Failed: ", msg);
     writeln(X, '\n!=\n', Y);
@@ -395,6 +425,7 @@ proc assertEqual(X: [], Y: [], msg="") where isArrayValue(X) && isArrayValue(Y)
 
 
 proc assertEqual(X: _tuple, Y: _tuple, msg="") {
+  if verbose then writeln(msg);
   if X.size != Y.size {
     writeln("Test Failed: ", msg);
     writeln(X, '\n!=\n', Y);
@@ -411,6 +442,7 @@ proc assertEqual(X: _tuple, Y: _tuple, msg="") {
 }
 
 proc assertTrue(x: bool, msg="") {
+  if verbose then writeln(msg);
   if !x {
     writeln("Test Failed: ", msg);
     writeln("boolean is false");
@@ -418,6 +450,7 @@ proc assertTrue(x: bool, msg="") {
 }
 
 proc assertFalse(x: bool, msg="") {
+  if verbose then writeln(msg);
   if x {
     writeln("Test Failed: ", msg);
     writeln("boolean is true");

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -63,6 +63,12 @@ config const verbose=false;
     var M = Matrix(A);
     assertEqual(M.domain, MDom, "Matrix(A)");
   }
+  {
+    var A: [MDom] real;
+    var M = Matrix(A, eltType=int);
+    assertEqual(M.domain, MDom, "Matrix(A)");
+    assertTrue(isIntType(M.eltType), "Matrix(A, eltType=int)");
+  }
 
   /* Variadic arguments of vectors */
   {
@@ -162,30 +168,6 @@ config const verbose=false;
 
 /* dot - calls matMult && inner*/
 
-// Test shapes
-{
-var M34 = Matrix([1, 2, 3, 4],
-                 [5, 6, 7, 8],
-                 [9, 10,11,12],
-                 eltType=real);
-var v4 = Vector([1,2,3,4], eltType=real );
-
-var v3 = Vector([1,2,3], eltType=real);
-
-// Sanity check
-assertEqual(M34.shape, (3, 4), 'M34.shape');
-assertEqual(v4.shape, (4,), 'v4.shape');
-assertEqual(v3.shape, (3,), 'v3.shape');
-
-assertEqual(dot(v3, M34).shape, (4,), 'dot(v3, M34).shape');
-assertEqual(dot(M34.T, v3).shape, (4,), 'dot(M34.T, v3).shape');
-
-assertEqual(dot(M34, v4).shape, (3,),'dot(M34, v4).shape');
-assertEqual(dot(v4, M34.T), (3,), 'dot(v4, M34.T)');
-
-asserEqual(dot(M34, M34.T), (3,3), 'dot(M34, M34.T)');
-asserEqual(dot(M34.T, M34), (4,4), 'dot(M34.T, M34)');
-}
 
 {
 
@@ -215,6 +197,29 @@ asserEqual(dot(M34.T, M34), (4,4), 'dot(M34.T, M34)');
     var vv = dot(v, v);
     var R = + reduce(v[..]*v[..]);
     assertEqual(vI, v, "dot(v, I)");
+
+
+    var M34 = Matrix([1, 2, 3, 4],
+                     [5, 6, 7, 8],
+                     [9, 10,11,12],
+                     eltType=t);
+    var v4 = Vector([1,2,3,4], eltType=t);
+
+    var v3 = Vector([1,2,3], eltType=t);
+
+    // Sanity check
+    assertEqual(M34.shape, (3, 4), 'M34.shape');
+    assertEqual(v4.shape, (4,), 'v4.shape');
+    assertEqual(v3.shape, (3,), 'v3.shape');
+
+    assertEqual(dot(v3, M34).shape, (4,), 'dot(v3, M34).shape');
+    assertEqual(dot(M34.T, v3).shape, (4,), 'dot(M34.T, v3).shape');
+
+    assertEqual(dot(M34, v4).shape, (3,),'dot(M34, v4).shape');
+    assertEqual(dot(v4, M34.T).shape, (3,), 'dot(v4, M34.T)');
+
+    assertEqual(dot(M34, M34.T).shape, (3,3), 'dot(M34, M34.T)');
+    assertEqual(dot(M34.T, M34).shape, (4,4), 'dot(M34.T, M34)');
   }
 
   test_dot(real);


### PR DESCRIPTION
**Correctness**
- Get correct shape for `LinearAlgebra._matvecMult()`
- Add explicit casting for `Matrix(A: [])` and `Vector(A: [])` constructors

**Tests**
- Update `correctness.chpl` to test for shapes explicitly
    - test for all types
- Add test for `Matrix(A: [], eltType)` constructor

**Docs**
- no-doc `transpose()` for domains

**Testing**
- [X] OS X + netlib LAPACK
