### PR TITLE
Improve error message when CHPL_MEM=cstdlib is used with a registered heap

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -389,8 +389,8 @@ CHPL_MEM
      Certain ``CHPL_COMM`` settings (e.g. ugni and gasnet segment fast/large)
      register the heap to improve communication performance.  Registering the
      heap requires special allocator support that not all allocators provide.
-     Currently ``jemalloc`` is required for configurations that require a
-     registered heap.
+     Currently only ``jemalloc`` is capable of supporting configurations that
+     require a registered heap.
 
 
 .. _readme-chplenv.CHPL_LAUNCHER:

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -385,6 +385,13 @@ CHPL_MEM
    If unset, ``CHPL_MEM`` defaults to ``jemalloc`` for most configurations.
    If the target platform is ``cygwin*`` it defaults to ``cstdlib``
 
+   .. note::
+     Certain ``CHPL_COMM`` settings (e.g. ugni and gasnet segment fast/large)
+     register the heap to improve communication performance.  Registering the
+     heap requires special allocator support that not all allocators provide.
+     Currently ``jemalloc`` is required for configurations that require a
+     registered heap.
+
 
 .. _readme-chplenv.CHPL_LAUNCHER:
 

--- a/runtime/src/mem/cstdlib/mem-cstdlib.c
+++ b/runtime/src/mem/cstdlib/mem-cstdlib.c
@@ -35,8 +35,11 @@ void chpl_mem_layerInit(void) {
   size_t size;
 
   chpl_comm_desired_shared_heap(&start, &size);
-  if (start || size)
-    chpl_error("set CHPL_MEM to a more appropriate mem type", 0, 0);
+  if (start || size) {
+    chpl_error("Your CHPL_MEM setting doesn't support the registered heap "
+               "required by your CHPL_COMM setting. You'll need to change one "
+               "of these configurations.", 0, 0);
+  }
 }
 
 


### PR DESCRIPTION
Improve the error message when CHPL_MEM=cstdlib is used in a configuration that
requires a registered heap. Also add some docs to chplenv.rst:CHPL_MEM to
provide more info about the error message.

Closes https://github.com/chapel-lang/chapel/issues/5649