### PR TITLE
Document KNL locale model

### DIFF
--- a/doc/rst/platforms/knl.rst
+++ b/doc/rst/platforms/knl.rst
@@ -8,9 +8,10 @@ The following information is assembled to help Chapel users get up and
 running on Intel Xeon Phi, Knights Landing (KNL).
 
 The initial implementation has only been tested on Cray machines where
-the KNL chip is the host processor. While we have not explicitly tested
-on other platforms, or with KNL as a Coprocessor, we don't know of any
-reason an advanced user couldn't run on such a platform.
+the KNL chip is used as a self-hosted processor. While we have not
+explicitly tested on other platforms, or with KNL as a Coprocessor, we
+don't know of any reason an advanced user couldn't run on such a
+platform.
 
 ---------------
 Getting started
@@ -28,17 +29,33 @@ You'll also want to ensure you have a new enough target compiler loaded
 that is KNL/AVX-512 ready. We recommend using at least gcc 5.3, cce 8.5,
 or intel 16.
 
-Currently we don't provide any mechanism to manage the MCDRAM (High
-Bandwidth Memory/HBM.) As a result, we recommend running with HBM in
-cache-only mode. We intend to add HBM support (through Locale Models)
-in future releases.
+We provide a KNL locale model for making use of the MCDRAM (High
+Bandwidth Memory/HBM).  Please see :ref:`readme-KNLlm` for details.
 
------------------
-Future Directions
------------------
+KNL provides many memory configurations and clustering modes.  If a
+program will manage HBM explicitly using the KNL locale model, the
+``flat`` memory configuration is a good place to start.  If not, the
+``cache`` configuration will use the HBM as a level 3 cache.  Two
+in-between configurations are available, ``equal`` for 50% cache/50%
+explicitly managed, and ``split`` for 25% cache/75% explicitly
+managed.  It is likely that the highest performing configuration is
+different for different programs, so it pays to experiment.
 
-As mentioned above, we plan to add support for targeting the HBM through
-our Locale Model interface.
+So far, the clustering modes that seem to have the most promise for
+Chapel programs are ``quad`` and ``snc4``.  The ``quad`` mode,
+contrary to its name, places all the KNL cores in one NUMA node.  The
+``snc4`` mode splits the cores equally into four NUMA nodes.  Again,
+experimentation will tell which works best for a given program, and
+other clustering modes may be worth trying as well.
 
-We also plan to explore which clustering mode(s) tend to work best for a
-typical Chapel program.
+The method of choosing the clustering mode and memory configuration is
+different for different machine installations.  Please see your system
+administrator for more information on this.  When using Slurm, a
+common method is to use the ``--constraint=`` flag to ``srun``.  For
+Chapel, this flag can be set using the ``CHPL_LAUNCHER_CONSTRAINT``
+environment variable.  For example, to use the ``snc4`` clustering
+mode and the ``flat`` memory model, the following would be used.
+
+.. code-block:: sh
+
+    export CHPL_LAUNCHER_CONSTRAINT=snc4,flat

--- a/doc/rst/technotes/localeModels.rst
+++ b/doc/rst/technotes/localeModels.rst
@@ -56,6 +56,8 @@ locales have homogeneous processor cores and all cores are equidistant from
 memory.
 
 
+.. _readme-NUMAlm:
+
 -----------------
 NUMA Locale Model
 -----------------
@@ -91,6 +93,98 @@ To use the NUMA locale model:
 .. code-block:: sh
 
     chpl -o jacobi $CHPL_HOME/examples/programs/jacobi.chpl
+
+
+.. _readme-KNLlm:
+
+----------------
+KNL Locale Model
+----------------
+
+The KNL locale model has the same properties as the NUMA locale model,
+plus it allows access to the Xeon Phi processor's on-package
+high-bandwidth memory.
+
+The KNL locale model requires the Intel Memkind library, which can be
+obtained in source form, and is also available in the binary
+repositories of some Linux distributions.
+
+For more information on the Memkind library, please see:
+
+    https://memkind.github.io
+
+On a Cray system, Memkind can be loaded with the following command.
+Note that this makes dynamic linking the default, because Memkind is
+dynamically linked.
+
+.. code-block:: sh
+
+    module load cray-memkind
+
+Once the Memkind library is available, Chapel can be built using the
+instructions under :ref:`readme-NUMAlm`, except that
+``CHPL_LOCALE_MODEL`` must be set to ``knl``.
+
+On a Cray system, the KNL locale model is included in the Chapel
+module, so the following commands are sufficient.
+
+.. code-block:: sh
+
+    module load cray-memkind
+    module load chapel
+    export CHPL_LOCALE_MODEL=knl
+
+Please see :ref:`readme-cray` for more detailed information.
+
+New locale model member functions are provided for controlling which
+kind of memory is used for new allocations.  To allocate in high
+bandwidth memory, use the ``.highBandwidthMemory()`` member function.
+For example:
+
+.. code-block:: sh
+
+    on here.highBandwidthMemory() {
+      x = new MyObject();
+    }
+
+It is also possible to say "Use the same locale as variable ``y``, but
+use high bandwidth memory" as follows.
+
+.. code-block:: sh
+
+    on y.locale.highBandwidthMemory() {
+      // . . .
+    }
+
+In case one is nested inside ``on`` statements and desires to get back
+to the default externally-attached memory, a ``.defaultMemory()``
+member function is available.
+
+.. code-block:: sh
+
+    on x {
+      // . . .
+      on here.defaultMemory() {
+        // . . .
+      }
+    }
+
+In addition, ``.lowLatencyMemory()`` and ``.largeMemory()`` functions
+are provided for explicitly referencing the externally-attached
+memory.  In the KNL locale model, ``.defaultMemory()``,
+``.lowLatencyMemory()``, and ``.largeMemory()`` are all the same.
+
+If the KNL processor is booted in the ``cache`` configuration, where
+high-bandwidth memory is not exposed to the user, then the program
+will still run and ``.highBandwidthMemory()`` will use the default
+externally-attached memory.
+
+The four memory selection functions have also been added to the flat
+and NUMA locale models, so it is possible to write programs that take
+advantage of the KNL processor when it is present, and yet still run
+on other processors.
+
+Please see :ref:`readme-knl` for additional information.
 
 
 --------------------------


### PR DESCRIPTION
This change adds documentation for the KNL locale model, and updates platform coverage for KNL on items that used to be future directions, but are now done.