### PR TITLE
prunedocs: remove extra pdf copies in release

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -77,6 +77,14 @@ checkdocs: FORCE
 %.docs: FORCE
 	../util/run-in-venv.bash $(MAKE) $*.html
 
+prunedocs: FORCE
+	rm -f html/_downloads/quickReference.pdf
+	rm -f html/_downloads/chapelLanguageSpec.pdf
+	if [ -d "html" ]; then \
+	ln -s ../../$(SOURCEDIR)/language/quickReference.pdf html/_downloads/quickReference.pdf; \
+	ln -s ../../$(SOURCEDIR)/language/chapelLanguageSpec.pdf html/_downloads/chapelLanguageSpec.pdf; \
+	fi
+
 
 clean: clean-source
 

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -160,13 +160,14 @@ SystemOrDie("make -j docs");
 # TODO - make this more elegant / maintainable
 print "Pruning the docs directory...\n";
 SystemOrDie("cd doc && make clean-symlinks");
+SystemOrDie("cd doc && make prunedocs");
 SystemOrDie("cd doc && rm -f Makefile*");
 SystemOrDie("cd doc && rm -rf util");
 SystemOrDie("cd doc && rm -f rst/conf.py");
 SystemOrDie("cd doc && rm -f rst/index.rst");
 SystemOrDie("cd doc && rm -f rst/*/index.rst");
 SystemOrDie("cd doc && rm -rf rst/developer"); # remove when dev-docs enabled
-SystemOrDie("cd doc && rm -rf rst/meta"); # Remove all dot files/directories
+SystemOrDie("cd doc && rm -rf rst/meta");
 
 print "Building the man pages...\n";
 SystemOrDie("make man");


### PR DESCRIPTION
Introducing the new `cd doc && make prunedocs` target, which removes the `pdf` files in `html/` and replaces them with symlinks to the `rst/` copies.

This reduces the `doc/` size from `16M` -> `15M` for the 1.15.0 release.

This PR is part of the effort proposed in #5457 

- [x] tested locally
- [x] tested `gen_release`
- [x] Double check that we don't copy the release `doc/html/` directory in any builds
     - This would break...