### PR TITLE
Remove SKIPIF on manpage testing

### DIFF
--- a/test/man/SKIPIF
+++ b/test/man/SKIPIF
@@ -1,3 +1,0 @@
-CHPL_COMM!=none
-CHPL_HOST_PLATFORM!=linux64
-CHPL_TASKS!=qthreads


### PR DESCRIPTION
We've been testing the manpage on a very narrow platform list for some
time now, which causes problems for Mac developers, those who are set
up for valgrind or gasnet testing, etc.  As best I can tell, this
limit was put into place in the first place to avoid wasting testing
time (?) or redundant errors when someone fails to update it; but the
developer time is more precious, and we still get lots of redundant
errors when someone fails to update it (which they're more likely to
do if the SKIPIF meant that their test run didn't catch it).  So let's
just always run it by default.