### PR TITLE
Clean up malformed cross-references and URLs in docs

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -703,12 +703,12 @@ Successively higher levels of overflow checking are more likely both to
 catch overflow and to catch it earlier, but they also have more overhead
 and thus a greater impact on performance.
 
-Note: in some situations the check as to whether or not the task
-stacks are in hugepage memory gets the wrong answer, leading to
-internal errors when the tasking layer tries to use guard pages and
-cannot do so.  This issue and its workarounds are tracked here:
+.. note::
 
-  https://chapel.atlassian.net/browse/CHAPEL-117
+    In some situations the check as to whether or not the task
+    stacks are in hugepage memory gets the wrong answer, leading to
+    internal errors when the tasking layer tries to use guard pages and
+    cannot do so.
 
 
 Number of Threads per Locale

--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -83,7 +83,7 @@ What is GASNet?
 
 GASNet is a one-sided communication and active message library being
 developed by Lawrence Berkeley National Laboratory and UC Berkeley.  For
-details, refer to the `GASNet website <http://gasnet.cs.berkeley.edu>`_.
+details, refer to the `GASNet website <http://gasnet.lbl.gov/>`_.
 
 .. _set-comm-conduit:
 
@@ -126,7 +126,7 @@ psm
 shmem
     SHMEM for SGI Altix
 
-See the `GASNet website <http://gasnet.cs.berkeley.edu>`_ for more
+See the `GASNet website <http://gasnet.lbl.gov/>`_ for more
 information on each of these conduits.
 
 Current defaults are:

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -65,7 +65,7 @@ BLAS Implementations:
 
   * **MKL**
 
-    * Compile with :param:`-sisBLAS_MKL` if using MKL BLAS.
+    * Compile with :param:`isBLAS_MKL` if using MKL BLAS.
 
   * **OpenBLAS**
 

--- a/modules/packages/Futures.chpl
+++ b/modules/packages/Futures.chpl
@@ -48,7 +48,7 @@ A future that is initialized by a call to :proc:`async()` or
 :proc:`Future.andThen()` is created in a valid state.  Otherwise |---| for
 example, when a future is declared but not initialized |---| the future is in
 an invalid state and method calls other than :proc:`Future.isValid()` on an
-invalid future will :proc:`halt()`.  If such a future object is subsequently
+invalid future will :proc:`~ChapelIO.halt()`.  If such a future object is subsequently
 assigned to by a call to :proc:`async()` or :proc:`Future.andThen()`, then
 the future will become valid.
 
@@ -139,7 +139,7 @@ module Futures {
     /*
       Get the result of a future, blocking until it is available.
 
-      If the future is not valid, this call will :proc:`halt()`.
+      If the future is not valid, this call will :proc:`~ChapelIO.halt()`.
      */
     proc get(): retType {
       if !isValid() then halt("get() called on invalid future");
@@ -149,7 +149,7 @@ module Futures {
     /*
       Test whether the result of the future is available.
 
-      If the future is not valid, this call will :proc:`halt()`.
+      If the future is not valid, this call will :proc:`~ChapelIO.halt()`.
      */
     proc isReady(): bool {
       if !isValid() then halt("get() called on invalid future");
@@ -171,7 +171,7 @@ module Futures {
       `retType` (i.e., the return type of the parent future) and will be
       executed when the parent future's value is available.
 
-      If the parent future is not valid, this call will :proc:`halt()`.
+      If the parent future is not valid, this call will :proc:`~ChapelIO.halt()`.
 
       :arg taskFn: The function to invoke as a continuation.
       :returns: A future of the return type of `taskFn`

--- a/modules/packages/OwnedObject.chpl
+++ b/modules/packages/OwnedObject.chpl
@@ -20,7 +20,7 @@
 
 /*
 
-   :record:`Owned` (along with :record:`Shared`) manage the deallocation
+   :record:`Owned` (along with :record:`~SharedObject.Shared`) manage the deallocation
    of a class instance. :record:`Owned` is meant to be used when only
    one reference to an object needs to manage that object's storage.
 

--- a/modules/packages/SharedObject.chpl
+++ b/modules/packages/SharedObject.chpl
@@ -19,7 +19,7 @@
 
 /*
 
-   :record:`Shared` (along with :record:`Owned`) manage the deallocation
+   :record:`Shared` (along with :record:`~OwnedObject.Owned`) manage the deallocation
    of a class instance. :record:`Shared` is meant to be used when many
    different references will exist to the object and these references
    need to keep the object alive.
@@ -181,7 +181,7 @@ module SharedObject {
        last :record:`Shared` managing that object.
        Does not return a value.
 
-       Equivalent to :proc:`Shared.retain(nil)`.
+       Equivalent to ``Shared.retain(nil)``.
      */
     proc ref clear() {
       if isClass(p) { // otherwise, let error happen on init call

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -170,7 +170,7 @@ In Chapel, sending or receiving messages on a :record:`Socket` uses
 and the :chpl:mod:`Reflection` module to serialize primitive and user-defined
 data types whenever possible.  Currently, the ZMQ module serializes primitive
 numeric types, strings, and records composed of these types.  Strings are
-encoded as a length (as :type:`int`) followed by the character array
+encoded as a length (as `int`) followed by the character array
 (in bytes).
 
 Tasking-Layer Interaction
@@ -188,7 +188,7 @@ semantically-blocking call to :proc:`Socket.send()` allow other Chapel tasks
 to be scheduled on the OS thread as supported by the tasking layer.
 Internally, the ZMQ module uses non-blocking calls to :proc:`zmq_send()` and
 :proc:`zmq_recv()` to transfer data, and yields to the tasking layer via
-:proc:`chpl_task_yield()` when the call would otherwise block.
+`chpl_task_yield()` when the call would otherwise block.
 
 Limitations and Future Work
 +++++++++++++++++++++++++++
@@ -399,7 +399,7 @@ module ZMQ {
   /*
     Query the ZMQ library version.
 
-    :returns: An :type:`(int,int,int)` tuple of the major, minor, and patch
+    :returns: An `(int,int,int)` tuple of the major, minor, and patch
         version of the ZMQ library.
    */
   proc version: (int,int,int) {
@@ -754,12 +754,12 @@ module ZMQ {
     }
 
     /*
-      Receive an object of type :type:`T` from a socket.
+      Receive an object of type `T` from a socket.
 
-      :arg T: The type of the object to be received. If :type:`T` is not
+      :arg T: The type of the object to be received. If `T` is not
           serializable by the ZMQ module, a compile-time error will be raised.
 
-      :returns: An object of type :type:`T`
+      :returns: An object of type `T`
      */
     proc recv(type T): T where !isZMQSerializable(T) {
       compilerError("Type \"", T:string, "\" is not serializable by ZMQ");

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -182,12 +182,12 @@ and may be cooperatively scheduled, a :record:`Socket` object should not be
 accessed concurrently by multiple Chapel tasks.
 
 The ZMQ module is designed to "play nicely" with the Chapel tasking layer.
-While the C-level call :proc:`zmq_send()` may be a blocking call (depending on
+While the C-level call ``zmq_send()`` may be a blocking call (depending on
 the socket type and flag arguments), it is desirable that a
 semantically-blocking call to :proc:`Socket.send()` allow other Chapel tasks
 to be scheduled on the OS thread as supported by the tasking layer.
-Internally, the ZMQ module uses non-blocking calls to :proc:`zmq_send()` and
-:proc:`zmq_recv()` to transfer data, and yields to the tasking layer via
+Internally, the ZMQ module uses non-blocking calls to ``zmq_send()`` and
+``zmq_recv()`` to transfer data, and yields to the tasking layer via
 `chpl_task_yield()` when the call would otherwise block.
 
 Limitations and Future Work

--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -148,7 +148,7 @@ module Barrier {
     }
 
     /* Reset the barrier, setting it to work with `nTasks` tasks.  If some
-       (but not all) tasks had already called :proc:`barrier` or :proc:`try`
+       (but not all) tasks had already called :proc:`barrier` or :proc:`check`
        when :proc:`reset` is called, the behavior is undefined.
      */
     inline proc reset(nTasks: int) {

--- a/modules/standard/Buffers.chpl
+++ b/modules/standard/Buffers.chpl
@@ -226,9 +226,9 @@ module Buffers {
     .. note::
 
        The pointer returned by this method is only valid for the lifetime of
-       the :type:`bytes` object and will be invalid if this memory is freed.
+       the `bytes` object and will be invalid if this memory is freed.
 
-    :returns: a :type:`c_void_ptr` to the internal byte array
+    :returns: a `c_void_ptr` to the internal byte array
    */
   proc bytes.ptr(): c_void_ptr {
     return qbytes_data(this._bytes_internal);
@@ -626,15 +626,15 @@ module Buffers {
 
   /* methods to read/write basic types. */
 
-  /* Read a basic type (integral or floating point value) or :type:`string`
+  /* Read a basic type (integral or floating point value) or `string`
      from a buffer.
      For basic types, this method reads the value by copying from memory -
      so it reads a binary value in native endianness. For strings, this method
-     reads a string encoded as the string length (as :type:`int`) followed by
-     that number of bytes (as :type:`uint(8)`).
+     reads a string encoded as the string length (as `int`) followed by
+     that number of bytes (as `uint(8)`).
 
      :arg it: a :record:`buffer_iterator` where reading will start
-     :arg value: a basic type or :type:`string`
+     :arg value: a basic type or `string`
      :arg error: (optional) capture an error that was encountered instead of
                  halting on error
      :returns: a buffer iterator storing the position immediately after
@@ -693,15 +693,15 @@ module Buffers {
     return ret;
   }
 
-  /* Write a basic type (integral or floating point value) or :type:`string`
+  /* Write a basic type (integral or floating point value) or `string`
      to a buffer.
      For basic types, this method writes the value by copying to memory -
      so it writes a binary value in native endianness. For strings, this method
-     writes a string encoded as the string length (as :type:`int`) followed by
-     that number of bytes (as :type:`uint(8)`).
+     writes a string encoded as the string length (as `int`) followed by
+     that number of bytes (as `uint(8)`).
 
      :arg it: a :record:`buffer_iterator` where reading will start
-     :arg value: a basic type or :type:`string`
+     :arg value: a basic type or `string`
      :arg error: (optional) capture an error that was encountered instead of
                  halting on error
      :returns: a buffer iterator storing the position immediately after

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -333,7 +333,7 @@ are described in :mod:`SysBasic`. Some of these error codes that are commonly us
    (e.g. reading 1000 into a `uint(8)`).
 
 An error code can be converted to a string using the function
-:proc:`Error.errorToString`.
+:proc:`~SysError.errorToString`.
 
 .. _about-io-ensuring-successful-io:
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1978,7 +1978,7 @@ module Random {
 
      The pseudorandom number generator (PRNG) implemented by
      this module uses the algorithm from the NAS Parallel Benchmarks
-     (NPB, available at: http://www.nas.nasa.gov/publications/npb.html),
+     (NPB, available at: https://www.nas.nasa.gov/publications/npb.html
      which can be used to generate random values of type `real(64)`,
      `imag(64)`, and `complex(128)`.
 

--- a/test/release/examples/primers/randomNumbers.chpl
+++ b/test/release/examples/primers/randomNumbers.chpl
@@ -10,7 +10,7 @@ use Random;
 // This primer shows two ways to generate a sequence of random numbers:
 // The first is by creating an array of random numbers using the
 // :proc:`Random.fillRandom` function. The second way is to use
-// a :class:`RandomStream` instance.
+// a :class:`~PCGRandom.RandomStream` instance.
 //
 
 // Using fillRandom
@@ -45,7 +45,7 @@ writeln();
 
 //
 // The second way to generate a sequence of random numbers is by creating a
-// :class:`RandomStream` class instance.  The first argument is the type
+// :class:`~PCGRandom.RandomStream` class instance.  The first argument is the type
 // of the elements that the instance should generate. If a particular
 // seed is desired, it should be specified upon creation of this instance.
 //
@@ -54,7 +54,7 @@ var randStreamSeeded: RandomStream(real) = new RandomStream(real, seed);
 
 //
 // Then the instance can be used to obtain the numbers.  This can be done in a
-// large chunk by calling :proc:`RandomStream.fillRandom`:
+// large chunk by calling :proc:`~PCGRandom.RandomStream.fillRandom`:
 //
 var randsFromStream: [1..10] real;
 randStream.fillRandom(randsFromStream);
@@ -104,19 +104,20 @@ for i in randStreamSeeded.iterate({5..10}, real) {
 
 
 //
-// By default, access using the :class:`RandomStream` instance will be safe in
-// the presence of parallelism. This can be changed for the entire stream during
-// class creation.  As a result, two parallel accesses or updates to the
-// position from which reading is intended may conflict.
+// By default, access using the :class:`~PCGRandom.RandomStream` instance will
+// be safe in the presence of parallelism. This can be changed for the entire
+// stream during class creation.  As a result, two parallel accesses or updates
+// to the position from which reading is intended may conflict.
 //
 var parallelUnsafe       = new RandomStream(real, parSafe=false);
 var parallelSeededUnsafe = new RandomStream(real, seed, false);
 
-// Now :class:`RandomStream` functions, such as ``parallelUnsafe.getNext()``
-// and ``parallelSeededUnsafe.getNext()`` can be called.
+// Now :class:`~PCGRandom.RandomStream` functions, such as
+// ``parallelUnsafe.getNext()`` and ``parallelSeededUnsafe.getNext()`` can be
+// called.
 
 //
-// At present, RandomStream instances are classes and so they must be
+// At present, ``RandomStream`` instances are classes and so they must be
 // deleted.
 //
 delete parallelSeededUnsafe;

--- a/test/release/examples/primers/randomNumbers.chpl
+++ b/test/release/examples/primers/randomNumbers.chpl
@@ -45,9 +45,9 @@ writeln();
 
 //
 // The second way to generate a sequence of random numbers is by creating a
-// :class:`~PCGRandom.RandomStream` class instance.  The first argument is the type
-// of the elements that the instance should generate. If a particular
-// seed is desired, it should be specified upon creation of this instance.
+// :class:`~PCGRandom.RandomStream` class instance.  The first argument is the
+// type of the elements that the instance should generate. If a particular seed
+// is desired, it should be specified upon creation of this instance.
 //
 var randStream:       RandomStream(real) = new RandomStream(real);
 var randStreamSeeded: RandomStream(real) = new RandomStream(real, seed);


### PR DESCRIPTION
This PR fixes most of the broken links and cross-references from `cd doc && make checkdocs`.

**Fixes**

All of the fixed links were fairly harmless (showed up as italics instead of link, or redirected correctly), except for a link in `cray.rst`, which was pointing users to an internal JIRA issue (whoops!). This link has been removed entirely.

Some links referenced `extern proc`s which are not supported in Chapel-sphinx, so these references were changed to ``inline code`` (mostly in the ZMQ module).

**Remaining Broken Links**

The remaining broken links are either false-negatives or are caused by `chpl2rst.py` stripping `//` from URLs. This should be fixed in the future, but redirects correctly still.

**Remaining Broken Cross-References**
It is not clear what is causing remaining broken cross-references in `ChapelArray.chpl`. The warning shows up as:

```
chpl:chplref reference target not found: bool
```

This warning doesn't appear to be serious and can be investigated further in the future.

**Testing**

- [x] `make docs`
- [x] `cd doc && make checkdocs`
