### PR TITLE
Add future for undeclared identifier error message

### DIFF
--- a/test/trivial/bharshbarg/undeclared.bad
+++ b/test/trivial/bharshbarg/undeclared.bad
@@ -1,0 +1,8 @@
+undeclared.chpl:1: internal error: NOR1893 chpl Version 1.15.0.54108ba
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/trivial/bharshbarg/undeclared.chpl
+++ b/test/trivial/bharshbarg/undeclared.chpl
@@ -1,0 +1,2 @@
+var x = asdf;
+writeln(x);

--- a/test/trivial/bharshbarg/undeclared.future
+++ b/test/trivial/bharshbarg/undeclared.future
@@ -1,0 +1,3 @@
+bug: INT_ASSERT instead of nice message for undeclared identifier
+
+This worked in 1.14, but not in 1.15

--- a/test/trivial/bharshbarg/undeclared.good
+++ b/test/trivial/bharshbarg/undeclared.good
@@ -1,0 +1,1 @@
+undeclared.chpl:1: error: 'asdf' undeclared (first use this function)


### PR DESCRIPTION
This test should emit a nice error message for the user instead of an INT_ASSERT. This worked in 1.14, but not in 1.15.