### PR TITLE
Avoid a failure when normalizing "var x = asdf;" where asdf is undefined

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1842,10 +1842,15 @@ static void normVarTypeInference(DefExpr* defExpr) {
   Symbol* var      = defExpr->sym;
   Expr*   initExpr = defExpr->init->remove();
 
+  // Do not complain here.  Put this stub in to the AST and let
+  // checkUseBeforeDefs() generate a consistent error message.
+  if (isUnresolvedSymExpr(initExpr) == true) {
+    defExpr->insertAfter(new CallExpr(PRIM_INIT_VAR, var, initExpr));
+
   // e.g.
   //   var x = <immediate>;
   //   var y = <identifier>;
-  if (SymExpr* initSym = toSymExpr(initExpr)) {
+  } else if (SymExpr* initSym = toSymExpr(initExpr)) {
     Type* type = initSym->symbol()->type;
 
     if (isPrimitiveScalar(type) == true) {

--- a/test/trivial/undeclared/variable-0.chpl
+++ b/test/trivial/undeclared/variable-0.chpl
@@ -1,0 +1,1 @@
+var x : int = asdf;

--- a/test/trivial/undeclared/variable-0.good
+++ b/test/trivial/undeclared/variable-0.good
@@ -1,0 +1,1 @@
+variable-0.chpl:1: error: 'asdf' undeclared (first use this function)

--- a/test/trivial/undeclared/variable-1.chpl
+++ b/test/trivial/undeclared/variable-1.chpl
@@ -1,0 +1,1 @@
+var x = asdf;

--- a/test/trivial/undeclared/variable-1.good
+++ b/test/trivial/undeclared/variable-1.good
@@ -1,0 +1,1 @@
+variable-1.chpl:1: error: 'asdf' undeclared (first use this function)


### PR DESCRIPTION
Prior to this PR the variable declaration

var x = asdf;

generated an internal ASSERT error if asdf was undefined; this was occurring
in the sub-pass of normalization that modifies DefExprs.

var x : int = asdf

generated a friendly error message in a later sub-pass of normalize.


This PR adds an explicit check for UnresolvedSymExpr, inserts some well-formed
"stub" AST, and lets the later sub-pass generate the preferred error message.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed a single-locale paratest with --verify
