### PR TITLE
Add a .bad file to track the error message on type constructors with generics

### DIFF
--- a/test/classes/initializers/records/generics/init-type.bad
+++ b/test/classes/initializers/records/generics/init-type.bad
@@ -1,0 +1,1 @@
+init-type.chpl:16: error: Type constructors are not yet supported for generic types that define initializers.  As a workaround, try relying on type inference


### PR DESCRIPTION
Though this error message is not expected to live in the compiler very long (as
it is a placeholder for work that should be finished by the next release), it
is good to ensure that we still get this error in the cases we expect.  So add
this temporary .bad file, on the off chance that the generation of type
constructor calls changes between now and when I get back to fixing the issue.

Suggested by Brad