### PR TITLE
Speed up reduction stress test by eliminating repetitive array building

### DIFF
--- a/test/reductions/vass/reductions-stress-mf.chpl
+++ b/test/reductions/vass/reductions-stress-mf.chpl
@@ -6,10 +6,11 @@ config const r = 1000;
 writeln("n=", n, "   r=", r);
 var errors = 0;
 
+var d:domain(int);
+for i in 1..n {  d += i; }
+
 for rIdx in 1..r {
 
-  var d:domain(int);
-  for i in 1..n {  d += i; }
   var expected = n*(n+1)/2;
   var sumd = + reduce d;
   if (sumd != expected) {


### PR DESCRIPTION
reductions-stress*.chpl claims to be a reduction stress test, but almost all of
its runtime was spent building up an associative domain. This just moves the
building of the associative domain from the inner trial loop to the top level.

This dramatically reduces the runtime on chapcs:

    reductions-stress-mf   : 12.1s => 1.0s
    reductions-stress-fast : 15.5s => 0.1s

And we could probably bump the fast trial size and make it even more of a
reductions stresser now, but I'm not doing that here.