### PR TITLE
Align atomics

### DIFF
--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -28,18 +28,33 @@
   #include <intrinsics.h>
 #endif
 
+//
+// SIZE_ALIGN_TYPE:  Declare a version of a type aligned to at least its size.
+//
+// C11 syntax does not support using this on typedefs.  However,
+// all the compilers we support with the intrinsics version of atomics
+// also support the gcc alignment attribute syntax used here.
+//
+// This is needed for 64-bit atomic types on 32-bit machines,
+// to guarantee that the atomic objects will never straddle a
+// cache line boundary, which has a huge performance penalty.
+//
+#define SIZE_ALIGN_TYPE(t) __attribute__ ((aligned (sizeof(t)))) t
+
 typedef int_least8_t atomic_int_least8_t;
 typedef int_least16_t atomic_int_least16_t;
 typedef int_least32_t atomic_int_least32_t;
-typedef int_least64_t atomic_int_least64_t;
+typedef SIZE_ALIGN_TYPE(int_least64_t) atomic_int_least64_t;
 typedef uint_least8_t atomic_uint_least8_t;
 typedef uint_least16_t atomic_uint_least16_t;
 typedef uint_least32_t atomic_uint_least32_t;
-typedef uint_least64_t atomic_uint_least64_t;
+typedef SIZE_ALIGN_TYPE(uint_least64_t) atomic_uint_least64_t;
 typedef uintptr_t atomic_uintptr_t;
 typedef chpl_bool atomic_bool;
-typedef uint64_t atomic__real64;
+typedef SIZE_ALIGN_TYPE(uint64_t) atomic__real64;
 typedef uint32_t atomic__real32;
+
+#undef SIZE_ALIGN_TYPE
 
 typedef enum {
  memory_order_relaxed,

--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -31,13 +31,13 @@
 //
 // SIZE_ALIGN_TYPE:  Declare a version of a type aligned to at least its size.
 //
-// C11 syntax does not support using this on typedefs.  However,
+// C11 syntax does not support doing this to typedefs.  However,
 // all the compilers we support with the intrinsics version of atomics
 // also support the gcc alignment attribute syntax used here.
 //
 // This is needed for 64-bit atomic types on 32-bit machines,
 // to guarantee that the atomic objects will never straddle a
-// cache line boundary, which has a huge performance penalty.
+// cache line boundary, which has a severe performance penalty.
 //
 #define SIZE_ALIGN_TYPE(t) __attribute__ ((aligned (sizeof(t)))) t
 


### PR DESCRIPTION
64-bit align 64-bit atomic objects on 32-bit systems.

On some 32-bit systems, the max forced alignment is 32 bits.  This means some 64-bit objects will be misaligned, and therefore some of those will straddle cache line boundaries.  This is not a problem unless those objects are atomic.  Then there is a serious performance penalty.

For the locks implementation of atomics, hardware atomic instructions are not used, so we do not need to worry about alignment.  For the cstdlib implementation of atomics, the compiler vendors are supposed to choose the alignment optimally for each atomic type, relieving us of the need to do so.  For the intrinsics implementation of atomics, we need to force 64-bit atomic objects to be 64-bit aligned, to guarantee that they will never straddle a cache line boundary on 32-bit systems.  This change does that.