### PR TITLE
Vagrant testing scripts & Vagrantfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ gen
 TAGS
 tags
 *.DS_Store
+*.vagrant
 
 
 # Top level ignores.
@@ -491,3 +492,5 @@ tags
 /util/tokencount/tokencount.output
 /util/tokencount/tokencount.tab.c
 /util/tokencount/tokencount.tab.h
+
+/util/devel/test/vagrant/log

--- a/util/devel/test/vagrant/README-distro-timelines.txt
+++ b/util/devel/test/vagrant/README-distro-timelines.txt
@@ -1,0 +1,45 @@
+x means reached end of life
+- means end of life soon
+
+CentOS:
+- 5 updates until March 2017
+  6 updates until Nov   2020
+  7 updates until Nov   2024
+
+Debian:
+x 6 (squeeze) LTS EOL Feb 2016
+  7 (wheezy)  LTS EOL May 2018
+  8 (jessie)  LTS EOL May 2020
+
+
+OpenSuse:
+x 13.1 EOL Feb 2016 / evergreen in Nov 2016
+x 13.2 EOL Jan 2017
+- 42.1 EOL May 2017
+  42.2 EOL ?July 2018
+
+Fedora:
+
+x 21 EOL Dec 2015
+x 22 EOL July 2016 (released May 2015)
+x 23 EOL Dec  2016 (released Nov 2015)
+- 24 est EOL July 2017 (released June 2016)
+  25 est EOL Dec  2017 (released Nov 2016)
+
+FreeBSD:
+
+x 10.2 EOL Dec 2016
+  10.3 EOL Apr 2018
+  11.0 EOL Sep 2021
+
+Ubuntu:
+
+- 12.04 "Precise Pangolin" LTS until Apr 2017
+  14.04 "Trusty Tahir"     LTS until Apr 2019
+x 14.10 "Utopic Unicorn"   is EOL as of July 2015
+x 15.04 "Vivid Vervet"     is EOL as of Feb 2016
+x 15.10 "Wily Werewolf"    is EOL as of July 2016
+  16.04 "Xenial Xerus"     LTS until Apr 2021
+- 16.10 "Yakkety Yak"      until July 2017
+  17.04 "Zesty Zapus"      until Jan 2018
+

--- a/util/devel/test/vagrant/README.txt
+++ b/util/devel/test/vagrant/README.txt
@@ -1,0 +1,55 @@
+Testing Chapel with Vagrant
+
+This directory is meant to help with testing Chapel with Vagrant. It
+contains scripts and Vagrantfiles.
+
+== Pre-requisites ==
+
+You'll need to install Vagrant and VirtualBox to use this directory.
+(You might be able to get another VM solution to work... but that's on you)
+
+== About <distribution>/Vagrantfile, boxes, and VMs ==
+
+The Vagrantfiles are each in a directory named in an obvious way from the
+available vagrant VM. For example, the Vagrant VM available as
+bento/centos-6.8-i386 is requested in the Vagrantfile in the directory
+bento-centos-6.8-i386.
+
+If you are unfamiliar with Vagrant, reading up on it a bit before trying
+to use this directory is probably a good idea. Each Vagrantfile is just
+some instructions for how to set up a VM. The VMs themselves are stored
+in two places:
+ * vagrant boxes (e.g. run `vagrant box list`)
+ * VirtualBox VMs (or whatever) - for me, these end up in:
+   ~/VirtualBox\ VMs
+
+Some of these Vagrantfiles assume you are using VirtualBox to run the
+VMs. While Vagrant supports other options, VirtualBox is the most
+supported / most recommended and the boxes (such as bento and ubuntu
+images that the Vagrantfiles specify to download) usually start with
+VirtualBox support.
+
+== About the scripts in this directory ==
+
+The scripts in this directory automate common tasks that amount to doing
+the same thing across all the VMs / distributions. I expect that simply
+
+./chapelquickcheck.sh
+
+and
+
+./chapeldefaultcheck.sh
+
+will be sufficient for basic testing, but the other scripts are there for
+debugging and doing other investigations. Each script summarizes its
+purpose in comments near the top, and most take no arguments.
+
+== About the scripts in provision-scripts ==
+
+The scripts in provision-scripts are ones that Vagrant will use when
+setting up these VMs, as directed in the Vagrantfiles. For example,
+there is a script to use apt-get to install Chapel dependencies.
+
+which Vagrant will use when setting up
+VMs, as directed in Vagrantfiles.
+

--- a/util/devel/test/vagrant/bento-centos-6.8-i386/Vagrantfile
+++ b/util/devel/test/vagrant/bento-centos-6.8-i386/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/centos-6.8-i386"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/yum-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-centos-6.8/Vagrantfile
+++ b/util/devel/test/vagrant/bento-centos-6.8/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/centos-6.8"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/yum-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-centos-7.3/Vagrantfile
+++ b/util/devel/test/vagrant/bento-centos-7.3/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/centos-7.3"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/yum-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-debian-7.11/Vagrantfile
+++ b/util/devel/test/vagrant/bento-debian-7.11/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/debian-7.11"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-debian-8.7/Vagrantfile
+++ b/util/devel/test/vagrant/bento-debian-8.7/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/debian-8.7"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-fedora-25/Vagrantfile
+++ b/util/devel/test/vagrant/bento-fedora-25/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/fedora-25"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/dnf-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-freebsd-10.3/Vagrantfile
+++ b/util/devel/test/vagrant/bento-freebsd-10.3/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/freebsd-10.3"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/freebsd-pkg-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/gmake-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-freebsd-11.0/Vagrantfile
+++ b/util/devel/test/vagrant/bento-freebsd-11.0/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/freebsd-11.0"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/freebsd-pkg-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/gmake-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-omnios-r151018/Vagrantfile
+++ b/util/devel/test/vagrant/bento-omnios-r151018/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/omnios-r151018"
+
+  # disable folder sync since it does not seem to work
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/omnios-pkg-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/gmake-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-opensuse-13.2/Vagrantfile
+++ b/util/devel/test/vagrant/bento-opensuse-13.2/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/opensuse-13.2"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/zypper-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/bento-opensuse-leap-42.1/Vagrantfile
+++ b/util/devel/test/vagrant/bento-opensuse-leap-42.1/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/opensuse-leap-42.1"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/zypper-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/boxupdate.sh
+++ b/util/devel/test/vagrant/boxupdate.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Downloads new vagrant boxes, but doesn't take any
+# action to get the VMs to use them.
+
+for name in *
+do
+  if [ -f $name/Vagrantfile ]
+  then
+    cd $name
+    echo "------------ $name ---- vagrant box update"
+    vagrant box update
+    cd ..
+  fi
+done
+

--- a/util/devel/test/vagrant/chapelbranch.sh
+++ b/util/devel/test/vagrant/chapelbranch.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# check out a particular branch in the VMs chapel directory
+#
+# Usage:
+#   ./chapelbranch.sh <github-user-name> <github-branch-name>
+#
+
+GITHUB_USER=$1
+GITHUB_BRANCH=$2
+
+if [ -z "$GITHUB_USER" -o -z "$GITHUB_BRANCH" ]
+then
+  echo Usage: $0 <github-user-name> <github-branch>
+fi
+
+echo "Checking out github branch $GITHUB_USER/$GITHUB_BRANCH"
+
+./tryit.sh "cd chapel && git remote add $GITHUB_USER https://github.com/$GITHUB_USER/chapel && git fetch $GITHUB_USER $GITHUB_BRANCH && git reset --hard $GITHUB_USER/$GITHUB_BRANCH"
+

--- a/util/devel/test/vagrant/chapeldefaultcheck.sh
+++ b/util/devel/test/vagrant/chapeldefaultcheck.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Check if default (util/setchplenv) Chapel build passes make check
+# Prints summary at the end
+
+./tryit.sh 'bash -c '\''cd chapel && source util/setchplenv.bash && export GMAKE=`which gmake` && export MAKE=${GMAKE:-make} && $MAKE && $MAKE check'\'

--- a/util/devel/test/vagrant/chapelquickcheck.sh
+++ b/util/devel/test/vagrant/chapelquickcheck.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Checks if a Quickstart build basses make check
+# Prints a summary at the end.
+
+./tryit.sh 'bash -c '\''cd chapel && source util/quickstart/setchplenv.bash && export GMAKE=`which gmake` && export MAKE=${GMAKE:-make} && $MAKE && $MAKE check'\'

--- a/util/devel/test/vagrant/chapelshowcommit.sh
+++ b/util/devel/test/vagrant/chapelshowcommit.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Show the current commit of each VM's chapel git repository
+
+./tryit.sh "cd chapel && GIT_PAGER=cat git log --oneline -n 1 && GIT_PAGER=cat git diff"
+

--- a/util/devel/test/vagrant/chapelupdate.sh
+++ b/util/devel/test/vagrant/chapelupdate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Update the Chapel git repository in each VM to master
+
+./tryit.sh "cd chapel && git fetch origin --depth=1 && git checkout origin/master && GIT_PAGER=cat git log --oneline -n 1 && GIT_PAGER=cat git diff"
+

--- a/util/devel/test/vagrant/clobber.sh
+++ b/util/devel/test/vagrant/clobber.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# make clobber in each VM's chapel directory
+
+./tryit.sh "cd chapel && make clobber"

--- a/util/devel/test/vagrant/destroy.sh
+++ b/util/devel/test/vagrant/destroy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Destroy (delete) each VM
+# Removes space occupied by each VM
+# Don't do this if you have work you want to save in the VMs!
+
+for name in *
+do
+  if [ -f $name/Vagrantfile ]
+  then
+    cd $name
+    echo "------------ $name ---- vagrant destroy"
+    vagrant destroy -f
+    cd ..
+  fi
+done
+

--- a/util/devel/test/vagrant/halt.sh
+++ b/util/devel/test/vagrant/halt.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Stop any running VMs
+
+for name in *
+do
+  if [ -f $name/Vagrantfile ]
+  then
+    cd $name
+    echo "------------ $name ---- vagrant halt"
+    vagrant halt
+    cd ..
+  fi
+done
+

--- a/util/devel/test/vagrant/interact.sh
+++ b/util/devel/test/vagrant/interact.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Log in to each VM in turn to run commands manually
+# Assumes VMs are up and leaves them running
+
+for name in *
+do
+  if [ -f $name/Vagrantfile ]
+  then
+    cd $name
+    echo "------------ $name ---- vagrant ssh"
+    #vagrant up
+    vagrant ssh
+    #vagrant halt
+    cd ..
+  fi
+done
+

--- a/util/devel/test/vagrant/provision-scripts/apt-get-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/apt-get-deps.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+apt-get update
+apt-get install -y git gcc g++ perl python tcsh bash gcc g++ perl python python-dev python-setuptools bash make mawk

--- a/util/devel/test/vagrant/provision-scripts/dnf-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/dnf-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+dnf -y install git gcc gcc-c++ perl python tcsh bash gcc gcc-c++ perl python python-devel python-setuptools bash make gawk

--- a/util/devel/test/vagrant/provision-scripts/freebsd-pkg-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/freebsd-pkg-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pkg install --yes gcc perl5 python py27-setuptools bash gmake gawk git

--- a/util/devel/test/vagrant/provision-scripts/git-clone-chapel.sh
+++ b/util/devel/test/vagrant/provision-scripts/git-clone-chapel.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -d chapel ]
+then
+  echo WARNING: chapel directory already exists, not cloning
+else
+  git clone --depth 1 https://github.com/chapel-lang/chapel
+fi

--- a/util/devel/test/vagrant/provision-scripts/gmake-chapel-quick.sh
+++ b/util/devel/test/vagrant/provision-scripts/gmake-chapel-quick.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cd chapel
+source util/quickstart/setchplenv.bash
+gmake
+gmake check

--- a/util/devel/test/vagrant/provision-scripts/make-chapel-quick.sh
+++ b/util/devel/test/vagrant/provision-scripts/make-chapel-quick.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cd chapel
+source util/quickstart/setchplenv.bash
+make
+make check

--- a/util/devel/test/vagrant/provision-scripts/omnios-pkg-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/omnios-pkg-deps.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# perl seems to be installed by the system & doesn't have an obvious
+# package name
+
+pkg install developer/gcc51 developer/object-file developer/linker system/header system/library/math/header-math runtime/python-27 library/python-27/setuptools shell/bash developer/build/gnu-make text/gawk shell/tcsh developer/versioning/git

--- a/util/devel/test/vagrant/provision-scripts/yum-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/yum-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+yum -y install git gcc gcc-c++ perl python tcsh bash gcc gcc-c++ perl python python-devel python-setuptools bash make gawk

--- a/util/devel/test/vagrant/provision-scripts/zypper-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/zypper-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+zypper install -y gcc gcc-c++ perl python python-devel python-setuptools bash make gawk tcsh git

--- a/util/devel/test/vagrant/rebuild.sh
+++ b/util/devel/test/vagrant/rebuild.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Rebuild all of the VMs. This will delete all data on the VMs.
+# Don't do that if you have data you want to keep in any VM!
+
+# Get new versions of Vagrant boxes
+./boxupdate.sh
+# Destroy existing VMs
+./destroy.sh
+# Remove old (now unused) vagrant boxes
+vagrant box prune

--- a/util/devel/test/vagrant/tryit.sh
+++ b/util/devel/test/vagrant/tryit.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Runs a command (or series of commands) on all the VMs.
+# Launches each VM, runs the command, and then shuts it down.
+# Prints a summary of the output at the end.
+# Saves all the command output in the file called log.
+
+LOG=log
+
+declare -a NAME
+declare -a RESULT
+
+echo > log
+echo "Running command on images:" | tee -a log
+echo "$*" | tee -a log
+
+i=0
+
+# compute longest length for padding
+maxlen=0
+for name in *
+do
+  if [ -f $name/Vagrantfile ]
+  then
+    if (( ${#name} > $maxlen ))
+    then
+      maxlen=${#name}
+    fi
+  fi
+done
+
+for name in *
+do
+  if [ -f $name/Vagrantfile ]
+  then
+    cd $name
+    display=`printf "%${maxlen}s" $name`
+    NAME[$i]=$display
+    echo
+    echo "     ---- $display ---- " | tee -a ../log
+    vagrant up 2>&1 | tee -a ../log
+    vagrant ssh --command "$*" -- -q 2>&1 | tee -a ../log
+    if (( $? == 0 ))
+    then
+      echo
+      lastline=`tail -n 1 ../log`
+      RESULT[$i]="  OK: $lastline"
+      #echo "     SUCCESS:" $name
+    else
+      lastline=`tail -n 1 ../log`
+      RESULT[$i]="FAIL: $lastline"
+      echo "     FAIL:" $name
+      echo "     Leaving virtual machine up"
+      cd ..
+      echo "     You might want to run:"
+      echo
+      echo "     cd" $name
+      echo "     vagrant ssh"
+      echo "     " $*
+      echo
+      echo
+      exit 1
+    fi
+    vagrant halt 2>&1 | tee -a ../log
+    cd ..
+
+    ((i++))
+  fi
+done
+
+echo "     -------- SUMMARY --------"
+
+i=0
+for name in *
+do
+  if [ -f $name/Vagrantfile ]
+  then
+    echo "${NAME[$i]}:${RESULT[$i]}"
+
+    ((i++))
+  fi
+done

--- a/util/devel/test/vagrant/ubuntu-precise32/Vagrantfile
+++ b/util/devel/test/vagrant/ubuntu-precise32/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/precise32"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/ubuntu-trusty32/Vagrantfile
+++ b/util/devel/test/vagrant/ubuntu-trusty32/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty32"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/ubuntu-trusty64/Vagrantfile
+++ b/util/devel/test/vagrant/ubuntu-trusty64/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 1024
+    #vb.cpus = 2
+  end
+
+end

--- a/util/devel/test/vagrant/ubuntu-xenial32/Vagrantfile
+++ b/util/devel/test/vagrant/ubuntu-xenial32/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial32"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/ubuntu-xenial64/Vagrantfile
+++ b/util/devel/test/vagrant/ubuntu-xenial64/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/ubuntu-zesty32/Vagrantfile
+++ b/util/devel/test/vagrant/ubuntu-zesty32/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/zesty32"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/ubuntu-zesty64/Vagrantfile
+++ b/util/devel/test/vagrant/ubuntu-zesty64/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/zesty64"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/up.sh
+++ b/util/devel/test/vagrant/up.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Bring each VM up and leave it running.
+
+for name in *
+do
+  if [ -f $name/Vagrantfile ]
+  then
+    cd $name
+    echo "------------ $name ---- vagrant up"
+    vagrant up
+    cd ..
+  fi
+done
+

--- a/util/devel/test/vagrant/updown.sh
+++ b/util/devel/test/vagrant/updown.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Bring each VM up and then shut it down.
+# Useful for making sure they are basically working.
+
+for name in *
+do
+  if [ -f $name/Vagrantfile ]
+  then
+    cd $name
+    echo "------------ $name ---- vagrant up"
+    vagrant up
+    vagrant halt
+    cd ..
+  fi
+done
+

--- a/util/devel/test/vagrant/x_eol/bento-centos-5.11-i386/Vagrantfile
+++ b/util/devel/test/vagrant/x_eol/bento-centos-5.11-i386/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/centos-5.11-i386"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/yum-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/x_eol/bento-centos-5.11/Vagrantfile
+++ b/util/devel/test/vagrant/x_eol/bento-centos-5.11/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/centos-5.11"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/yum-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/x_future/bento-debian-8.7-i386/Vagrantfile
+++ b/util/devel/test/vagrant/x_future/bento-debian-8.7-i386/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/debian-8.7-i386"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/apt-get-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/x_future/bento-opensuse-leap-42.2/Vagrantfile
+++ b/util/devel/test/vagrant/x_future/bento-opensuse-leap-42.2/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/opensuse-leap-42.2"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/zypper-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+end

--- a/util/devel/test/vagrant/x_problems/bento-fedora-24/Vagrantfile-notworking
+++ b/util/devel/test/vagrant/x_problems/bento-fedora-24/Vagrantfile-notworking
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/fedora-24"
+
+  config.vm.provision "shell",
+    path: "../provision-scripts/dnf-deps.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../provision-scripts/make-chapel-quick.sh"
+
+  # I'm having trouble with this VM for some reason...
+  #config.vm.provider "virtualbox" do |vb|
+  #  vb.memory = 1024
+  #  #vb.cpus = 2
+  #end
+
+end


### PR DESCRIPTION
This PR adds util/devel/test/vagrant.

I've been using this setup to do portability testing for recent releases across a variety of free *nix distributions.

I recently got it automated enough that I'm willing to share it.  I hope it is useful to others.

I've written a README.txt outlining what this directory consists of and how to use it. You might find reading it useful if you are looking at this PR. See
 util/devel/test/vagrant/README.txt
added in this PR.

Reviewed by @awallace-cray - thanks!
