### PR TITLE
Fix multi-ddata for aligned arrays (cherry-pick #5903)

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -926,7 +926,7 @@ module DefaultRectangular {
         high = if rad.stridable then strideAlignDown(high, newDom.dsiDim(mdParDim)) else high;
 
         const rng = low..high;
-        rad.mData(i).pdr = if !rad.stridable then rng else rng by newDom.dsiDim(mdParDim).stride;
+        rad.mData(i).pdr = if !rad.stridable then rng else rng by newDom.dsiDim(mdParDim).stride align newDom.dsiDim(mdParDim).alignment;
       }
 
     }
@@ -980,7 +980,7 @@ module DefaultRectangular {
         high += radLo;
 
         const rng = low..high;
-        rad.mData(i).pdr = if !rad.stridable then rng else rng by radStr;
+        rad.mData(i).pdr = if !rad.stridable then rng else rng by radStr align newDom.dsiDim(mdParDim).alignment;
       }
     }
 
@@ -1052,7 +1052,7 @@ module DefaultRectangular {
         for i in 1..#mdNumChunks {
           const rng = max(this.mData(i).pdr.low, newDom.dsiDim(rad.mdParDim).low)
                       ..min(this.mData(i).pdr.high, newDom.dsiDim(rad.mdParDim).high);
-          rad.mData(i).pdr = if !rad.stridable then rng else rng by newDom.dsiDim(rad.mdParDim).stride;
+          rad.mData(i).pdr = if !rad.stridable then rng else rng by newDom.dsiDim(rad.mdParDim).stride align newDom.dsiDim(rad.mdParDim).alignment;
         }
       } else {
         // If the mdParDim'th dimension is removed, then we switch to
@@ -1069,7 +1069,7 @@ module DefaultRectangular {
         for i in 1..#mdNumChunks {
           const (lo, hi) = rad.mdChunk2Ind(i-1);
           const rng = max(lo, newDom.dsiDim(1).low) .. min(hi, newDom.dsiDim(1).high);
-          rad.mData(i).pdr = if !rad.stridable then rng else rng by newDom.dsiDim(1).stride;
+          rad.mData(i).pdr = if !rad.stridable then rng else rng by newDom.dsiDim(1).stride align newDom.dsiDim(1).alignment;
         }
       }
     }
@@ -1575,7 +1575,7 @@ module DefaultRectangular {
         if mdNumChunks == 1 {
           if stridable then
             mData(0).pdr = dom.dsiDim(mdParDim).low..dom.dsiDim(mdParDim).high
-                           by dom.dsiDim(mdParDim).stride;
+                           by dom.dsiDim(mdParDim).stride align dom.dsiDim(mdParDim).alignment;
           else
             mData(0).pdr = dom.dsiDim(mdParDim).low..dom.dsiDim(mdParDim).high;
           mData(0).data =
@@ -1589,7 +1589,7 @@ module DefaultRectangular {
             mData(i).dataOff  = dataOff;
             const (lo, hi) = mdChunk2Ind(i);
             if stridable then
-              mData(i).pdr = lo..hi by dom.dsiDim(mdParDim).stride;
+              mData(i).pdr = lo..hi by dom.dsiDim(mdParDim).stride align dom.dsiDim(mdParDim).alignment;
             else
               mData(i).pdr = lo..hi;
             const chunkSize = size / mdRLen * mData(i).pdr.length;


### PR DESCRIPTION
Previously multi-ddata's per-dimension-range (basically a range that represents
a sub-chunk) wasn't preserving the alignment of the original array. This caused
sporadic timeouts under numa for a program like:

   var SA: [1..3 by 2  align 2] string = ["align 2"];
   var SB: [1..3 by -2 align 2] string = ["reverse iter"];

We were only seeing this under numa and only for ~1/1000 runs, so I had been
worried that this was a startup race in our qthreads shim, or a bug in the
'distrib' schedulers mccoy threads. Luckily though, it was just a bogus free
manifesting itself strangely.

The problem was that we were ended up trying to call a destructor and free
memory that was never initialized. Under CHPL_MEM=jemalloc, this meant we were
sometimes trying to acquire a lock that was already held, leading to deadlock.

Under CHPL_MEM=cstdlib we got some hard failures, and by hacking fifo I was
able to run under valgrind and discover that we were trying to free
uninitialized memory.

The problem code comes from when we're trying to compute the size of each chunk
in order to free it. We do:

    chunkSize = numElts / mdRLen * mData(chunk).pdr.length;

and mData(chunk).pdr was just `1..3 by 2` instead of `1..3 by 2 align 2` so we
were computing the length as 2 instead of 1, which led to trying to call
chpl__autoDestroy on `dataChunk(0)[1]`, which in turn tried to destroy and free
memory that it shouldn't.

This just corrects the mulit-ddata code to maintain alignment.