### PR TITLE
Support CHPL_COMM=ugni, gasnet+aries and the MPI module

### DIFF
--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -124,10 +124,10 @@ follows:
 
 .. code-block:: sh
 
-  CHPL_TARGET_COMPILER=cray-prgenv-gnu
+  CHPL_TARGET_COMPILER=cray-prgenv-{gnu,intel}
   CHPL_TASKS=fifo
-  CHPL_COMM=gasnet
-  CHPL_COMM_SUBSTRATE=mpi           # or aries
+  CHPL_COMM={ugni, gasnet}
+  CHPL_COMM_SUBSTRATE={aries,mpi}   # if CHPL_COMM=gasnet 
   MPICH_MAX_THREAD_SAFETY=multiple
   AMMPI_MPI_THREAD=multiple         # if CHPL_COMM_SUBSTRATE=mpi
 

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -124,10 +124,10 @@ follows:
 
 .. code-block:: sh
 
-  CHPL_TARGET_COMPILER=cray-prgenv-{gnu,intel}
+  CHPL_TARGET_COMPILER=cray-prgenv-{gnu, intel}
   CHPL_TASKS=fifo
   CHPL_COMM={ugni, gasnet}
-  CHPL_COMM_SUBSTRATE={aries,mpi}   # if CHPL_COMM=gasnet 
+  CHPL_COMM_SUBSTRATE={aries, mpi}   # if CHPL_COMM=gasnet 
   MPICH_MAX_THREAD_SAFETY=multiple
   AMMPI_MPI_THREAD=multiple         # if CHPL_COMM_SUBSTRATE=mpi
 

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -131,6 +131,9 @@ follows:
   MPICH_MAX_THREAD_SAFETY=multiple
   AMMPI_MPI_THREAD=multiple         # if CHPL_COMM_SUBSTRATE=mpi
 
+Running under ``gasnet+aries`` might require setting ``MPICH_GNI_DYNAMIC_CONN=disabled``.
+This is discussed `here <http://chapel.cray.com/docs/latest/platforms/cray.html#known-constraints-and-bugs>`.
+
 These are the configurations in which this module is currently tested. Any
 launcher should work fine for this mode. Support is expected to expand in
 future versions.

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -149,9 +149,8 @@ Communicators
 The GASNet runtime, and therefore Chapel, makes no guarantees that the MPI
 ranks will match the GASNet locales. This module creates a new MPI communicator
 :proc:`CHPL_COMM_WORLD` that ensures that this mapping is true.
-Note that this is only set in mixed Chapel-MPI mode. If numLocales is 1, then
-:proc:`CHPL_COMM_WORLD` is set to :const:`MPI_COMM_NULL`, and will cause an MPI
-error if used.
+Note that if numLocales is 1, :proc:`CHPL_COMM_WORLD` is identical to :const:`MPI_COMM_WORLD`,
+which is the desired behaviour for SPMD mode programs.
 
 .. note::
   #. Pointer arguments are written as ``ref`` arguments, so no casting to a ``c_ptr``

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -263,12 +263,15 @@ module MPI {
     // If we are running using the uGNI layer, then the following hack
     // appears to be necessary in order to run MPI, as well as Chapel
     // See : https://hpcrdm.lbl.gov/pipermail/upc-users/2014-May/002061.html
-    if CHPL_COMM=="ugni" {
+    if (CHPL_COMM=="ugni") || (CHPL_COMM=="gasnet" && CHPL_COMM_SUBSTRATE=="aries") {
       coforall loc in Locales do on loc {
           // This must be done on all locales!
           var pmiGniCookie = C_Env.getenv("PMI_GNI_COOKIE") : string;
           if !pmiGniCookie.isEmptyString() {
-            C_Env.setenv("PMI_GNI_COOKIE",("%i".format(pmiGniCookie:int+1)).c_str(),1);
+            // This may be a colon separated string.
+            var cookieJar = pmiGniCookie.split(":");
+            cookieJar[1] = ((cookieJar[1]):int + 1):string;
+            C_Env.setenv("PMI_GNI_COOKIE",("%s".format(":".join(cookieJar))).c_str(),1);
           }
         }
     }

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -262,14 +262,15 @@ module MPI {
     // If we are running using the uGNI layer, then the following hack
     // appears to be necessary in order to run MPI, as well as Chapel
     // See : https://hpcrdm.lbl.gov/pipermail/upc-users/2014-May/002061.html
-    if (CHPL_COMM=="ugni") || (CHPL_COMM=="gasnet" && CHPL_COMM_SUBSTRATE=="aries") {
+    if (CHPL_COMM=="ugni") {
       coforall loc in Locales do on loc {
           // This must be done on all locales!
           var pmiGniCookie = C_Env.getenv("PMI_GNI_COOKIE") : string;
           if !pmiGniCookie.isEmptyString() {
             // This may be a colon separated string.
             var cookieJar = pmiGniCookie.split(":");
-            cookieJar[1] = ((cookieJar[1]):int + 1):string;
+            const lastcookie = cookieJar.domain.last;
+            cookieJar[lastcookie] = ((cookieJar[lastcookie]):int + 1):string;
             C_Env.setenv("PMI_GNI_COOKIE",("%s".format(":".join(cookieJar))).c_str(),1);
           }
         }

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -174,12 +174,7 @@ module MPI {
   use SysCTypes;
   require "mpi.h";
 
-
   use UtilReplicatedVar;
-
-  // TODO : This shouldn't need to be set by the user
-  // How do we query CHPL_COMM?
-  config param isUGNI=false;
 
   /*
      Automatically initializes MPI (if not already initialized by the runtime), and
@@ -268,7 +263,7 @@ module MPI {
     // If we are running using the uGNI layer, then the following hack
     // appears to be necessary in order to run MPI, as well as Chapel
     // See : https://hpcrdm.lbl.gov/pipermail/upc-users/2014-May/002061.html
-    if isUGNI {
+    if CHPL_COMM=="ugni" {
       coforall loc in Locales do on loc {
           // This must be done on all locales!
           var pmiGniCookie = C_Env.getenv("PMI_GNI_COOKIE") : string;

--- a/test/modules/packages/mpi/multilocale/hello-chapel-nl-1/SKIPIF
+++ b/test/modules/packages/mpi/multilocale/hello-chapel-nl-1/SKIPIF
@@ -14,7 +14,8 @@ retval = ((compiler !="mpi-gnu")
 # Only support fifo 
 retval |= (os.environ['CHPL_TASKS']!="fifo")
 
-# Only support GASNET+MPI 
+# Check CHPL_COMM support
+# Currently supports GASNET+MPI, GASNET+Aries, uGNI
 comm=os.environ['CHPL_COMM']
 substrate=os.environ['CHPL_COMM_SUBSTRATE']
 

--- a/test/modules/packages/mpi/multilocale/hello-chapel-nl-1/SKIPIF
+++ b/test/modules/packages/mpi/multilocale/hello-chapel-nl-1/SKIPIF
@@ -5,6 +5,7 @@ import os
 retval = True
 
 # Only support the GNU compilers for now
+# except on Crays
 compiler=os.environ['CHPL_TARGET_COMPILER']
 retval = ((compiler !="mpi-gnu")
           & (compiler!="cray-prgenv-gnu")

--- a/test/modules/packages/mpi/multilocale/hello-chapel-nl-1/SKIPIF
+++ b/test/modules/packages/mpi/multilocale/hello-chapel-nl-1/SKIPIF
@@ -6,15 +6,22 @@ retval = True
 
 # Only support the GNU compilers for now
 compiler=os.environ['CHPL_TARGET_COMPILER']
-retval = (compiler !="mpi-gnu") & (compiler!="cray-prgenv-gnu")
+retval = ((compiler !="mpi-gnu")
+          & (compiler!="cray-prgenv-gnu")
+          & (compiler!='cray-prgenv-intel'))
 
 # Only support fifo 
 retval |= (os.environ['CHPL_TASKS']!="fifo")
 
 # Only support GASNET+MPI 
-retval |= (os.environ['CHPL_COMM']!="gasnet")
-retval |= (os.environ['CHPL_COMM_SUBSTRATE']!="mpi")
+comm=os.environ['CHPL_COMM']
+substrate=os.environ['CHPL_COMM_SUBSTRATE']
 
+gasnetmpi=(comm=="gasnet") & (substrate=="mpi")
+gasnetaries=(comm=="gasnet") & (substrate=="aries")
+ugni=(comm=="ugni")
+
+retval |= not (ugni | gasnetmpi | gasnetaries)
 
 print(retval)
 

--- a/test/modules/packages/mpi/multilocale/hello-chapel/SKIPIF
+++ b/test/modules/packages/mpi/multilocale/hello-chapel/SKIPIF
@@ -14,7 +14,8 @@ retval = ((compiler !="mpi-gnu")
 # Only support fifo 
 retval |= (os.environ['CHPL_TASKS']!="fifo")
 
-# Only support GASNET+MPI 
+# Check CHPL_COMM support
+# Currently supports GASNET+MPI, GASNET+Aries, uGNI
 comm=os.environ['CHPL_COMM']
 substrate=os.environ['CHPL_COMM_SUBSTRATE']
 

--- a/test/modules/packages/mpi/multilocale/hello-chapel/SKIPIF
+++ b/test/modules/packages/mpi/multilocale/hello-chapel/SKIPIF
@@ -5,6 +5,7 @@ import os
 retval = True
 
 # Only support the GNU compilers for now
+# except on Crays
 compiler=os.environ['CHPL_TARGET_COMPILER']
 retval = ((compiler !="mpi-gnu")
           & (compiler!="cray-prgenv-gnu")

--- a/test/modules/packages/mpi/multilocale/hello-chapel/SKIPIF
+++ b/test/modules/packages/mpi/multilocale/hello-chapel/SKIPIF
@@ -6,15 +6,22 @@ retval = True
 
 # Only support the GNU compilers for now
 compiler=os.environ['CHPL_TARGET_COMPILER']
-retval = (compiler !="mpi-gnu") & (compiler!="cray-prgenv-gnu")
+retval = ((compiler !="mpi-gnu")
+          & (compiler!="cray-prgenv-gnu")
+          & (compiler!='cray-prgenv-intel'))
 
 # Only support fifo 
 retval |= (os.environ['CHPL_TASKS']!="fifo")
 
 # Only support GASNET+MPI 
-retval |= (os.environ['CHPL_COMM']!="gasnet")
-retval |= (os.environ['CHPL_COMM_SUBSTRATE']!="mpi")
+comm=os.environ['CHPL_COMM']
+substrate=os.environ['CHPL_COMM_SUBSTRATE']
 
+gasnetmpi=(comm=="gasnet") & (substrate=="mpi")
+gasnetaries=(comm=="gasnet") & (substrate=="aries")
+ugni=(comm=="ugni")
+
+retval |= not (ugni | gasnetmpi | gasnetaries)
 
 print(retval)
 

--- a/test/modules/packages/mpi/spmd/hello-chapel/SKIPIF
+++ b/test/modules/packages/mpi/spmd/hello-chapel/SKIPIF
@@ -5,8 +5,11 @@ import os
 retval = True
 
 # Only support the GNU compilers for now
+# except on Crays.
 compiler=os.environ['CHPL_TARGET_COMPILER']
-retval = (compiler !="mpi-gnu") & (compiler!="cray-prgenv-gnu")
+retval = ((compiler !="mpi-gnu")
+          & (compiler!="cray-prgenv-gnu")
+          & (compiler!='cray-prgenv-intel'))
 
 # Only support fifo 
 retval |= (os.environ['CHPL_TASKS']!="fifo")


### PR DESCRIPTION
This PR fixes the MPI module to allow it to work with ``CHPL_COMM=ugni``.

The original module fails in the ``MPI_Init_thread`` with a ``GNI_CdmAttach (GNI_RC_INVALID_STATE)`` error.  

Following the discussion here -- 
  https://hpcrdm.lbl.gov/pipermail/upc-users/2014-May/002061.html
the MPI module now updates ``PMI_GNI_COOKIE``.
   * In the case where ``PMI_GNI_COOKIE`` is a single number, we just increment by 1. This appears to be the case when ``CHPL_COMM=ugni``.
   * When ``PMI_GNI_COOKIE`` is a colon separated number, we increment the last number by 1, but keep the full list. 

While in the guts here --
 * also fixed an outdated comment about ``CHPL_COMM_WORLD`` not supported for ``numLocales==1`` (including SPMD mode). This was fixed in #4184, and is tested by the current SPMD code.
 * Chased many red herrings on ``gasnet+aries``. Codes here may require setting ``MPICH_GNI_DYNAMIC_CONN=disabled``, although I struggle to reproducibly trigger a failure. As we test more, this may clarify itself. We currently document this....

With lots of contributions/reviews/help from @ben-albrecht, @gbtitus and @ronawho -- thanks!!

Still to do --
- [x] Can we determine what CHPL_COMM is at compile time in the code, to do away with the ``isUGNI``param?
- [x] Update documentation
- [x] Update text in this PR
- [x] Add ugni to our configs for MPI testing?