### PR TITLE
Update signature for instantiate()

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -75,7 +75,7 @@ void cleanupRedRefs(Expr*& redRef1, Expr*& redRef2);
 void setupRedRefs(FnSymbol* fn, bool nested, Expr*& redRef1, Expr*& redRef2);
 bool isReduceOp(Type* type);
 
-FnSymbol* instantiate(FnSymbol* fn, SymbolMap& subs, CallExpr* call);
+FnSymbol* instantiate(FnSymbol* fn, SymbolMap& subs);
 FnSymbol* instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call);
 void      instantiateBody(FnSymbol* fn);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9342,9 +9342,12 @@ addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
             subs.put(arg, pfn->getFormal(i)->type->symbol);
           }
         }
+
         FnSymbol* fn = cfn;
+
         if (subs.n) {
-          fn = instantiate(fn, subs, NULL);
+          fn = instantiate(fn, subs);
+
           if (fn) {
             if (type->defaultTypeConstructor->instantiationPoint)
               fn->instantiationPoint = type->defaultTypeConstructor->instantiationPoint;
@@ -9353,10 +9356,13 @@ addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
             INT_ASSERT(fn->instantiationPoint);
           }
         }
+
         if (fn) {
           resolveFormals(fn);
+
           if (signature_match(pfn, fn) && evaluateWhereClause(fn)) {
             resolveFns(fn);
+
             if (fn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
                 pfn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
               AggregateType* fnRetType = toAggregateType(fn->retType);

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -365,6 +365,36 @@ instantiateTypeForTypeConstructor(FnSymbol* fn, SymbolMap& subs, CallExpr* call,
   return newType;
 }
 
+/** Fully instantiate a generic function given a map of substitutions and a
+ *  call site.
+ *
+ * \param fn   Generic function to instantiate
+ * \param subs Type substitutions to be made during instantiation
+ * \param call Call that is being resolved
+ */
+FnSymbol* instantiate(FnSymbol* fn, SymbolMap& subs) {
+  FnSymbol* newFn = instantiateSignature(fn, subs, NULL);
+
+  if (newFn != NULL) {
+    instantiateBody(newFn);
+  }
+
+  return newFn;
+}
+
+/** Finish copying and instantiating the partially instantiated function.
+ *
+ * TODO: See if more code from instantiateSignature can be moved into this
+ *       function.
+ *
+ * \param fn   Generic function to finish instantiating
+ */
+void instantiateBody(FnSymbol* fn) {
+  if (getPartialCopyInfo(fn)) {
+    fn->finalizeCopy();
+  }
+}
+
 /** Instantiate enough of the function for it to make it through the candidate
  *  filtering and disambiguation process.
  *
@@ -375,101 +405,115 @@ instantiateTypeForTypeConstructor(FnSymbol* fn, SymbolMap& subs, CallExpr* call,
 FnSymbol* instantiateSignature(FnSymbol*  fn,
                                SymbolMap& subs,
                                CallExpr*  call) {
+  FnSymbol* retval = NULL;
 
   //
   // Handle tuples explicitly
   // (_build_tuple, tuple type constructor, tuple default constructor)
   //
   if (FnSymbol* tupleFn = createTupleSignature(fn, subs, call)) {
-    return tupleFn;
-  }
+    retval = tupleFn;
 
-  form_Map(SymbolMapElem, e, subs) {
-    if (TypeSymbol* ts = toTypeSymbol(e->value)) {
-      if (ts->type->symbol->hasFlag(FLAG_GENERIC)) {
-        INT_FATAL(fn, "illegal instantiation with a generic type");
-      }
+  } else {
+    form_Map(SymbolMapElem, e, subs) {
+      if (TypeSymbol* ts = toTypeSymbol(e->value)) {
+        if (ts->type->symbol->hasFlag(FLAG_GENERIC)) {
+          INT_FATAL(fn, "illegal instantiation with a generic type");
+        }
 
-      TypeSymbol* nts = getNewSubType(fn, e->key, ts);
+        TypeSymbol* nts = getNewSubType(fn, e->key, ts);
 
-      if (ts != nts) {
-        e->value = nts;
+        if (ts != nts) {
+          e->value = nts;
+        }
       }
     }
-  }
 
-  //
-  // determine root function in the case of partial instantiation
-  //
-  FnSymbol* root = determineRootFunc(fn);
+    //
+    // determine root function in the case of partial instantiation
+    //
+    FnSymbol* root = determineRootFunc(fn);
 
-  //
-  // determine all substitutions (past substitutions in a partial
-  // instantiation plus the current substitutions) and change the
-  // substitutions to refer to the root function's formal arguments
-  //
-  SymbolMap all_subs;
-  determineAllSubs(fn, root, subs, all_subs);
+    //
+    // determine all substitutions (past substitutions in a partial
+    // instantiation plus the current substitutions) and change the
+    // substitutions to refer to the root function's formal arguments
+    //
+    SymbolMap allSubs;
 
-  //
-  // use cached instantiation if possible
-  //
-  if (FnSymbol* cached = checkCache(genericsCache, root, &all_subs)) {
-    if (cached != (FnSymbol*)gVoid) {
-      checkInfiniteWhereInstantiation(cached);
+    determineAllSubs(fn, root, subs, allSubs);
 
-      return cached;
+    //
+    // use cached instantiation if possible
+    //
+    if (FnSymbol* cached = checkCache(genericsCache, root, &allSubs)) {
+      if (cached != (FnSymbol*) gVoid) {
+        checkInfiniteWhereInstantiation(cached);
+
+        retval = cached;
+      } else {
+        retval = NULL;
+      }
     } else {
-      return NULL;
+      SET_LINENO(fn);
+
+      //
+      // copy generic class type if this function is a type constructor
+      //
+      Type* newType = NULL;
+
+      if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
+        newType = instantiateTypeForTypeConstructor(fn,
+                                                    subs,
+                                                    call,
+                                                    fn->retType);
+      }
+
+      //
+      // instantiate function
+      //
+      SymbolMap map;
+
+      if (newType) {
+        map.put(fn->retType->symbol, newType->symbol);
+      }
+
+      FnSymbol* newFn = instantiateFunction(fn,
+                                            root,
+                                            allSubs,
+                                            call,
+                                            subs,
+                                            map);
+
+      if (newType) {
+        newType->defaultTypeConstructor = newFn;
+        newFn->retType                  = newType;
+      }
+
+      bool fixedTuple = fixupTupleFunctions(fn, newFn, call);
+
+      // Fix up chpl__initCopy for user-defined records
+      if (fixedTuple                           == false &&
+          fn->hasFlag(FLAG_INIT_COPY_FN)       ==  true &&
+          fn->hasFlag(FLAG_COMPILER_GENERATED) ==  true) {
+        // Generate the initCopy function based upon initializer
+        fixupDefaultInitCopy(fn, newFn, call);
+      }
+
+      if (newFn->numFormals()       >  1 &&
+          newFn->getFormal(1)->type == dtMethodToken) {
+        newFn->getFormal(2)->type->methods.add(newFn);
+      }
+
+      newFn->tagIfGeneric();
+
+      explainAndCheckInstantiation(newFn, fn);
+
+      retval = newFn;
     }
   }
 
-  SET_LINENO(fn);
-
-  //
-  // copy generic class type if this function is a type constructor
-  //
-  Type* newType = NULL;
-
-  if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
-    newType = instantiateTypeForTypeConstructor(fn, subs, call, fn->retType);
-  }
-
-  //
-  // instantiate function
-  //
-  SymbolMap map;
-
-  if (newType) {
-    map.put(fn->retType->symbol, newType->symbol);
-  }
-
-  FnSymbol* newFn = instantiateFunction(fn, root, all_subs, call, subs, map);
-
-  if (newType) {
-    newType->defaultTypeConstructor = newFn;
-    newFn->retType                  = newType;
-  }
-  
-  bool fixedTuple = fixupTupleFunctions(fn, newFn, call);
-  // Fix up chpl__initCopy for user-defined records
-  if (!fixedTuple &&
-      fn->hasFlag(FLAG_INIT_COPY_FN) &&
-      fn->hasFlag(FLAG_COMPILER_GENERATED) ) {
-    // Generate the initCopy function based upon initializer
-    fixupDefaultInitCopy(fn, newFn, call);
-  }
-
-  if (newFn->numFormals()       >  1 &&
-      newFn->getFormal(1)->type == dtMethodToken) {
-    newFn->getFormal(2)->type->methods.add(newFn);
-  }
-
-  newFn->tagIfGeneric();
-
-  explainAndCheckInstantiation(newFn, fn);
-
-  return newFn;
+  return retval;
 }
 
 //
@@ -482,6 +526,7 @@ FnSymbol* determineRootFunc(FnSymbol* fn) {
          root->numFormals()     == root->instantiatedFrom->numFormals()) {
     root = root->instantiatedFrom;
   }
+
   return root;
 }
 
@@ -490,32 +535,38 @@ FnSymbol* determineRootFunc(FnSymbol* fn) {
   // instantiation plus the current substitutions) and change the
   // substitutions to refer to the root function's formal arguments
   //
-void determineAllSubs(FnSymbol* fn, FnSymbol* root, SymbolMap& subs,
-                      SymbolMap& all_subs) {
+void determineAllSubs(FnSymbol*  fn,
+                      FnSymbol*  root,
+                      SymbolMap& subs,
+                      SymbolMap& allSubs) {
   if (fn->instantiatedFrom) {
     form_Map(SymbolMapElem, e, fn->substitutions) {
-      all_subs.put(e->key, e->value);
+      allSubs.put(e->key, e->value);
     }
   }
 
   form_Map(SymbolMapElem, e, subs) {
-    copyGenericSub(all_subs, root, fn, e->key, e->value);
+    copyGenericSub(allSubs, root, fn, e->key, e->value);
   }
 }
 
 //
 // instantiate function
 //
-FnSymbol* instantiateFunction(FnSymbol* fn, FnSymbol* root, SymbolMap& all_subs,
-                              CallExpr* call, SymbolMap& subs, SymbolMap& map) {
+FnSymbol* instantiateFunction(FnSymbol*  fn,
+                              FnSymbol*  root,
+                              SymbolMap& allSubs,
+                              CallExpr*  call,
+                              SymbolMap& subs,
+                              SymbolMap& map) {
   FnSymbol* newFn = fn->partialCopy(&map);
 
-  addCache(genericsCache, root, newFn, &all_subs);
+  addCache(genericsCache, root, newFn, &allSubs);
 
   newFn->removeFlag(FLAG_GENERIC);
   newFn->addFlag(FLAG_INVISIBLE_FN);
   newFn->instantiatedFrom = fn;
-  newFn->substitutions.map_union(all_subs);
+  newFn->substitutions.map_union(allSubs);
 
   if (call) {
     newFn->instantiationPoint = getVisibilityBlock(call);
@@ -651,51 +702,4 @@ bool evaluateWhereClause(FnSymbol* fn) {
   }
 
   return true;
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-/** Finish copying and instantiating the partially instantiated function.
- *
- * TODO: See if more code from instantiateSignature can be moved into this
- *       function.
- *
- * \param fn   Generic function to finish instantiating
- */
-void
-instantiateBody(FnSymbol* fn) {
-  if (getPartialCopyInfo(fn)) {
-    fn->finalizeCopy();
-  }
-}
-
-/** Fully instantiate a generic function given a map of substitutions and a
- *  call site.
- *
- * \param fn   Generic function to instantiate
- * \param subs Type substitutions to be made during instantiation
- * \param call Call that is being resolved
- */
-FnSymbol*
-instantiate(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
-  FnSymbol* newFn;
-
-  newFn = instantiateSignature(fn, subs, call);
-
-  if (newFn != NULL) {
-    instantiateBody(newFn);
-  }
-
-  return newFn;
 }


### PR DESCRIPTION
I was debugging some  code for generics and tripped over a NULL.

Before this PR there was a single call to 

   FnSymbol* instantiate(FnSymbol* fn, SymbolMap& subs, CallExpr* call);

with call set to NULL.  The call-site and definition are in separate files. This NULL was
then passed to another function where it was less obvious that call could be NULL.


This is a trivial update to convert the function to be

   FnSymbol* instantiate(FnSymbol* fn, SymbolMap& subs);

Longer term it might be good to think about the consequences of NULL being passed along.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed single-locale paratest on linux64


