### PR TITLE
Match fasta's leading comment to the submitted version

### DIFF
--- a/test/studies/shootout/submitted/fasta.chpl
+++ b/test/studies/shootout/submitted/fasta.chpl
@@ -2,9 +2,8 @@
    http://benchmarksgame.alioth.debian.org/
 
    contributed by Preston Sahabu
-   derived from the Chapel fastaredux version by Casey Battaglino,
-               Kyle Brady, Preston Sahabu, and Brad Chamberlain
-   derived from the GNU C version by Paul Hsieh
+   derived from the Chapel fastaredux version by Casey Battaglino et al.
+            and the GNU C version by Paul Hsieh
 */
 
 config const n = 1000,   // controls the length of the generated strings


### PR DESCRIPTION
Somehow, the comment of our local cache of the submitted version
has differed from the one that's on the website (and that we submitted).
Bringing ours up-to-date to support diffs.