### PR TITLE
Scope update

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1742,17 +1742,17 @@ static void insertFieldAccess(FnSymbol*          method,
   const char* name      = usymExpr->unresolved;
   Type*       type      = method->_this->type;
   int         nestDepth = computeNestedDepth(name, type);
-  Expr*       dot       = NULL;
+  Expr*       dot       = new SymExpr(method->_this);
 
   for (int i = 0; i <= nestDepth; i++) {
     if (i == 0) {
       if (i < nestDepth) {
-        dot = new CallExpr(".", method->_this, new_CStringSymbol("outer"));
+        dot = new CallExpr(".", dot, new_CStringSymbol("outer"));
       } else {
         if (isTypeSymbol(sym))
-          dot = new CallExpr(".", method->_this, sym);
+          dot = new CallExpr(".", dot, sym);
         else
-          dot = new CallExpr(".", method->_this, new_CStringSymbol(name));
+          dot = new CallExpr(".", dot, new_CStringSymbol(name));
       }
     } else {
       if (i < nestDepth) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1690,42 +1690,42 @@ static void updateMethod(UnresolvedSymExpr*            usymExpr,
 
   while (isModuleSymbol(parent) == false) {
     if (FnSymbol* method = toFnSymbol(parent)) {
-
       // stopgap bug fix: do not let methods shadow symbols
       // that are more specific than methods
-      if (sym && sym->defPoint->getFunction() == method) {
+      if (sym != NULL && sym->defPoint->getFunction() == method) {
         break;
-      }
 
-      if (method->_this && (!symExpr || symExpr->symbol() != method->_this)) {
-        Type*       type = method->_this->type;
-        TypeSymbol* cts  = NULL;
+      } else if (method->_this != NULL) {
+        if (symExpr == NULL || symExpr->symbol() != method->_this) {
+          Type*       type = method->_this->type;
+          TypeSymbol* cts  = NULL;
 
-        if (sym != NULL) {
-          cts = toTypeSymbol(sym->defPoint->parentSymbol);
-        }
-
-        if ((cts != NULL && isAggregateType(cts->type) == true) ||
-            isMethodName(name, type) == true) {
-          CallExpr* call = toCallExpr(expr->parentExpr);
-
-          if (call                              != NULL &&
-              call->baseExpr                    == expr &&
-              call->numActuals()                >= 2    &&
-              isSymExpr(call->get(1))           == true &&
-              toSymExpr(call->get(1))->symbol() == gMethodToken) {
-            UnresolvedSymExpr* use = new UnresolvedSymExpr(name);
-
-            expr->replace(use);
-
-            skipSet.insert(use);
-
-          } else {
-            insertFieldAccess(method, usymExpr, sym, expr);
+          if (sym != NULL) {
+            cts = toTypeSymbol(sym->defPoint->parentSymbol);
           }
-        }
 
-        break;
+          if ((cts != NULL && isAggregateType(cts->type) == true) ||
+              isMethodName(name, type) == true) {
+            CallExpr* call = toCallExpr(expr->parentExpr);
+
+            if (call                              != NULL &&
+                call->baseExpr                    == expr &&
+                call->numActuals()                >= 2    &&
+                isSymExpr(call->get(1))           == true &&
+                toSymExpr(call->get(1))->symbol() == gMethodToken) {
+              UnresolvedSymExpr* use = new UnresolvedSymExpr(name);
+
+              expr->replace(use);
+
+              skipSet.insert(use);
+
+            } else {
+              insertFieldAccess(method, usymExpr, sym, expr);
+            }
+          }
+
+          break;
+        }
       }
     }
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1608,14 +1608,12 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr*            usymExpr,
     } else if (fn->hasFlag(FLAG_METHOD) == true) {
       updateMethod(usymExpr, skipSet, NULL, NULL);
 
-    } else {
-      // handle function call without parentheses
-      if (fn->hasFlag(FLAG_NO_PARENS) == true) {
-        checkIdInsideWithClause(usymExpr, usymExpr);
-        usymExpr->replace(new CallExpr(fn));
-        return;
-      }
+    // handle function call without parentheses
+    } else if (fn->hasFlag(FLAG_NO_PARENS) == true) {
+      checkIdInsideWithClause(usymExpr, usymExpr);
+      usymExpr->replace(new CallExpr(fn));
 
+    } else {
       if (sym) {
         if (Expr* parent = usymExpr->parentExpr) {
           CallExpr* call = toCallExpr(parent);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1604,17 +1604,16 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr*            usymExpr,
 
       updateMethod(usymExpr, skipSet, sym, symExpr);
 
+    // sjd: stopgap to avoid shadowing variables or functions by methods
+    } else if (fn->hasFlag(FLAG_METHOD) == true) {
+      updateMethod(usymExpr, skipSet, NULL, NULL);
+
     } else {
       // handle function call without parentheses
-      if (fn->_this == NULL && fn->hasFlag(FLAG_NO_PARENS) == true) {
+      if (fn->hasFlag(FLAG_NO_PARENS) == true) {
         checkIdInsideWithClause(usymExpr, usymExpr);
         usymExpr->replace(new CallExpr(fn));
         return;
-      }
-
-      // sjd: stopgap to avoid shadowing variables or functions by methods
-      if (fn->hasFlag(FLAG_METHOD) == true) {
-        sym = NULL;
       }
 
       if (sym) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1614,37 +1614,35 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr*            usymExpr,
       usymExpr->replace(new CallExpr(fn));
 
     } else {
-      if (sym) {
-        if (Expr* parent = usymExpr->parentExpr) {
-          CallExpr* call = toCallExpr(parent);
+      if (Expr* parent = usymExpr->parentExpr) {
+        CallExpr* call = toCallExpr(parent);
 
-          if (call == NULL || call->baseExpr != usymExpr) {
-            //
-            // If we detect that this function reference is within a
-            // c_ptrTo() call then we only need a C pointer to the
-            // function, not a full Chapel first-class function (which
-            // can capture variables).
-            //
-            // TODO: Can we avoid strcmp or ensure it's "our" fn?
-            //
-            bool captureForC = (call && call->isNamed("c_ptrTo"));
+        if (call == NULL || call->baseExpr != usymExpr) {
+          //
+          // If we detect that this function reference is within a
+          // c_ptrTo() call then we only need a C pointer to the
+          // function, not a full Chapel first-class function (which
+          // can capture variables).
+          //
+          // TODO: Can we avoid strcmp or ensure it's "our" fn?
+          //
+          bool captureForC = (call && call->isNamed("c_ptrTo"));
 
-            //If the function is being used as a first-class value, handle
-            // this with a primitive and unwrap the primitive later in
-            // functionResolution
-            CallExpr* prim_capture_fn = new CallExpr(captureForC ?
-                                                     PRIM_CAPTURE_FN_FOR_C :
-                                                     PRIM_CAPTURE_FN_FOR_CHPL);
+          //If the function is being used as a first-class value, handle
+          // this with a primitive and unwrap the primitive later in
+          // functionResolution
+          CallExpr* prim_capture_fn = new CallExpr(captureForC ?
+                                                   PRIM_CAPTURE_FN_FOR_C :
+                                                   PRIM_CAPTURE_FN_FOR_CHPL);
 
-            usymExpr->replace(prim_capture_fn);
+          usymExpr->replace(prim_capture_fn);
 
-            prim_capture_fn->insertAtTail(usymExpr);
+          prim_capture_fn->insertAtTail(usymExpr);
 
-            // Don't do it again if for some reason we return
-            // to trying to resolve this symbol.
-            skipSet.insert(usymExpr);
-            return;
-          }
+          // Don't do it again if for some reason we return
+          // to trying to resolve this symbol.
+          skipSet.insert(usymExpr);
+          return;
         }
       }
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1734,6 +1734,7 @@ static void updateMethod(UnresolvedSymExpr*            usymExpr,
   }
 }
 
+// Apply implicit this pointers and outer this pointers
 static void insertFieldAccess(FnSymbol*          method,
                               UnresolvedSymExpr* usymExpr,
                               Symbol*            sym,
@@ -1744,24 +1745,18 @@ static void insertFieldAccess(FnSymbol*          method,
   Expr*       dot       = NULL;
 
   for (int i = 0; i <= nestDepth; i++) {
-    // Apply implicit this pointers and outer this pointers
     if (i == 0) {
       if (i < nestDepth) {
-        dot = new CallExpr(".",
-                           method->_this,
-                           new_CStringSymbol("outer"));
+        dot = new CallExpr(".", method->_this, new_CStringSymbol("outer"));
       } else {
         if (isTypeSymbol(sym))
           dot = new CallExpr(".", method->_this, sym);
         else
-          dot = new CallExpr(".",
-                             method->_this,
-                             new_CStringSymbol(name));
+          dot = new CallExpr(".", method->_this, new_CStringSymbol(name));
       }
     } else {
       if (i < nestDepth) {
-        dot = new CallExpr(".",
-                           dot, new_CStringSymbol("outer"));
+        dot = new CallExpr(".", dot, new_CStringSymbol("outer"));
       } else {
         if (isTypeSymbol(sym))
           dot = new CallExpr(".", dot, sym);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1687,10 +1687,12 @@ static void updateMethod(UnresolvedSymExpr*            usymExpr,
   const char* name   = usymExpr->unresolved;
   Expr*       expr   = (symExpr != NULL) ? (Expr*) symExpr : (Expr*) usymExpr;
   Symbol*     parent = expr->parentSymbol;
-  TypeSymbol* cts    = NULL;
+  bool        isAggr = false;
 
   if (sym != NULL) {
-    cts = toTypeSymbol(sym->defPoint->parentSymbol);
+    if (TypeSymbol* cts = toTypeSymbol(sym->defPoint->parentSymbol)) {
+      isAggr = isAggregateType(cts->type);
+    }
   }
 
   while (isModuleSymbol(parent) == false) {
@@ -1704,8 +1706,7 @@ static void updateMethod(UnresolvedSymExpr*            usymExpr,
         if (symExpr == NULL || symExpr->symbol() != method->_this) {
           Type* type = method->_this->type;
 
-          if ((cts != NULL && isAggregateType(cts->type) == true) ||
-              isMethodName(name, type) == true) {
+          if (isAggr == true || isMethodName(name, type) == true) {
             CallExpr* call = toCallExpr(expr->parentExpr);
 
             if (call                              != NULL &&

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1687,6 +1687,11 @@ static void updateMethod(UnresolvedSymExpr*            usymExpr,
   const char* name   = usymExpr->unresolved;
   Expr*       expr   = (symExpr != NULL) ? (Expr*) symExpr : (Expr*) usymExpr;
   Symbol*     parent = expr->parentSymbol;
+  TypeSymbol* cts    = NULL;
+
+  if (sym != NULL) {
+    cts = toTypeSymbol(sym->defPoint->parentSymbol);
+  }
 
   while (isModuleSymbol(parent) == false) {
     if (FnSymbol* method = toFnSymbol(parent)) {
@@ -1697,12 +1702,7 @@ static void updateMethod(UnresolvedSymExpr*            usymExpr,
 
       } else if (method->_this != NULL) {
         if (symExpr == NULL || symExpr->symbol() != method->_this) {
-          Type*       type = method->_this->type;
-          TypeSymbol* cts  = NULL;
-
-          if (sym != NULL) {
-            cts = toTypeSymbol(sym->defPoint->parentSymbol);
-          }
+          Type* type = method->_this->type;
 
           if ((cts != NULL && isAggregateType(cts->type) == true) ||
               isMethodName(name, type) == true) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1740,22 +1740,21 @@ static void insertFieldAccess(FnSymbol*          method,
                               Symbol*            sym,
                               Expr*              expr) {
   const char* name      = usymExpr->unresolved;
-  Type*       type      = method->_this->type;
-  int         nestDepth = computeNestedDepth(name, type);
+  int         nestDepth = computeNestedDepth(name, method->_this->type);
   Expr*       dot       = new SymExpr(method->_this);
 
-  for (int i = 0; i <= nestDepth; i++) {
-    if (i < nestDepth) {
+  checkIdInsideWithClause(expr, usymExpr);
+
+  if (nestDepth > 0) {
+    for (int i = 0; i < nestDepth; i++) {
       dot = new CallExpr(".", dot, new_CStringSymbol("outer"));
-    } else {
-      if (isTypeSymbol(sym))
-        dot = new CallExpr(".", dot, sym);
-      else
-        dot = new CallExpr(".", dot, new_CStringSymbol(name));
     }
   }
 
-  checkIdInsideWithClause(expr, usymExpr);
+  if (isTypeSymbol(sym) == true)
+    dot = new CallExpr(".", dot, sym);
+  else
+    dot = new CallExpr(".", dot, new_CStringSymbol(name));
 
   expr->replace(dot);
 }

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1745,24 +1745,13 @@ static void insertFieldAccess(FnSymbol*          method,
   Expr*       dot       = new SymExpr(method->_this);
 
   for (int i = 0; i <= nestDepth; i++) {
-    if (i == 0) {
-      if (i < nestDepth) {
-        dot = new CallExpr(".", dot, new_CStringSymbol("outer"));
-      } else {
-        if (isTypeSymbol(sym))
-          dot = new CallExpr(".", dot, sym);
-        else
-          dot = new CallExpr(".", dot, new_CStringSymbol(name));
-      }
+    if (i < nestDepth) {
+      dot = new CallExpr(".", dot, new_CStringSymbol("outer"));
     } else {
-      if (i < nestDepth) {
-        dot = new CallExpr(".", dot, new_CStringSymbol("outer"));
-      } else {
-        if (isTypeSymbol(sym))
-          dot = new CallExpr(".", dot, sym);
-        else
-          dot = new CallExpr(".", dot, new_CStringSymbol(name));
-      }
+      if (isTypeSymbol(sym))
+        dot = new CallExpr(".", dot, sym);
+      else
+        dot = new CallExpr(".", dot, new_CStringSymbol(name));
     }
   }
 


### PR DESCRIPTION
Work on initializers provoked me to look as some "normalization" code for methods that's
currently tucked in to one of the inner loops of scope resolution.   The surrounding code
seems to me to be unreasonably/unnecessarily convoluted.

This PR refactors that portion of scope-resolve a) on principle b) to support possible next
steps for initializers.


This PR does not / should not change the behavior of any Chapel program.  The PR consists
of a relatively large number of relatively small commits in order to simplify the task of confirming
that the business logic is unchanged.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux.

Also compiled with CHPL_LLVM=llvm as I made trivial changes to some code inside a LLVM
guard in scopeResolve.cpp

Standard single-locale paratest on linux64 with -futures and then with --llvm

