### PR TITLE
Fix a linux/darwin difference in DateTime module

### DIFF
--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -1085,7 +1085,10 @@ module DateTime {
                (if minutes < 10 then "0" + minutes: string else minutes: string);
     }
 
-    return strftime("%Y-%m-%d" + sep + "%H:%M:%S" + micro + offset);
+    // on our Linux64 systems, the "%Y" format doesn't zero-pad to 4
+    // characters on its own, so do it manually.
+    var year = zeroPad(4, strftime("%Y"):int);
+    return strftime(year + "-%m-%d" + sep + "%H:%M:%S" + micro + offset);
   }
 
   /* Create a `datetime` as described by the `date_string` and `format`
@@ -1115,7 +1118,7 @@ module DateTime {
 
     if tzinfo != nil {
       timeStruct.tm_isdst = tzinfo.dst(this).seconds: int(32);
-      timeStruct.tm_gmtoff = tzinfo.gmtoff(): c_long;
+      timeStruct.tm_gmtoff = tzinfo.utcoffset(this).seconds: c_long;
       timeStruct.tm_zone = nil;
     } else {
       timeStruct.tm_isdst = -1: int(32);

--- a/test/modules/standard/datetime/testDatetime.notest
+++ b/test/modules/standard/datetime/testDatetime.notest
@@ -1,2 +1,0 @@
-# This test doesn't work on linux yet, so spiking it for the night to
-# avoid needless mails

--- a/test/modules/standard/datetime/testDatetimeTZ.notest
+++ b/test/modules/standard/datetime/testDatetimeTZ.notest
@@ -1,2 +1,0 @@
-# This test doesn't work on linux yet, so spiking it for the night to
-# avoid needless mails


### PR DESCRIPTION
The "%Y" (year) format specifier for function strftime zero-pads to 4 digits
on darwin, but doesn't zero-pad on Linux. Explicitly zero-pad it to 4 digits
in the isoformat function.

Removed two .notest files that were added due to this difference.

Changed a call to the non-existent gmtoff() into a call to utcoffset().

Tested on the datetime unit tests on Linux64 and darwin.