### PR TITLE
Add a test of a known chpldoc failure with multiline comments

### DIFF
--- a/test/chpldoc/basics/interruptingSingleComment.doc.bad
+++ b/test/chpldoc/basics/interruptingSingleComment.doc.bad
@@ -1,0 +1,9 @@
+interruptingSingleComment.doc
+
+Usage:
+   use interruptingSingleComment.doc;
+
+   proc foo()
+      This long comment shouldn't get attached to foo, because there is a single
+      line comment in the way 
+

--- a/test/chpldoc/basics/interruptingSingleComment.doc.catfiles
+++ b/test/chpldoc/basics/interruptingSingleComment.doc.catfiles
@@ -1,0 +1,1 @@
+docs/interruptingSingleComment.doc.txt

--- a/test/chpldoc/basics/interruptingSingleComment.doc.chpl
+++ b/test/chpldoc/basics/interruptingSingleComment.doc.chpl
@@ -1,0 +1,7 @@
+/* This long comment shouldn't get attached to foo, because there is a single
+   line comment in the way */
+
+// Blocking!
+proc foo() {
+
+}

--- a/test/chpldoc/basics/interruptingSingleComment.doc.future
+++ b/test/chpldoc/basics/interruptingSingleComment.doc.future
@@ -1,0 +1,6 @@
+bug: accidentally grabs multiline comment even with intervening single line comment
+
+chpldoc intentionally grabs multiline comments that precede a symbol, no matter
+the intervening space.  However, if there is an intervening single line or
+otherwise non-documentation comment, it probably shouldn't assume that the
+multiline comment is relevant.

--- a/test/chpldoc/basics/interruptingSingleComment.doc.good
+++ b/test/chpldoc/basics/interruptingSingleComment.doc.good
@@ -1,0 +1,6 @@
+interruptingSingleComment.doc
+
+Usage:
+   use interruptingSingleComment.doc;
+
+   proc foo()


### PR DESCRIPTION
chpldoc intentionally grabs multiline comments that precede a symbol, no matter
the intervening space present.  However, if there is an intervening single line
or otherwise non-documentation comment, it probably shouldn't assume that the
earlier multiline comment is relevant.

This was reported ages ago, I believe when we were documenting a library module.
Apparently I forgot to file a future when I created the original issue, so I am
fixing that oversight now.