### PR TITLE
Skip man page testing for perf configurations

### DIFF
--- a/test/man/SKIPIF
+++ b/test/man/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_TEST_PERF == on


### PR DESCRIPTION
Yesterday, I widened the skipif for man page testing to support
testing in general configurations.  This broke for Cray performance
configurations, highlighting that we really don't want/need to run man
page testing on a performance testing run (I often think that this may
be true for any test directories that contain a manual sub_test).

It seems likely that the man page testing would also fail on a Cray
correctness testing run, but that because we don't test the full
suite on Crays, we don't see the failure.  I'd guess that the failure
is likely due either to a portability issue in the script or, more likely,
due to an assumption about the relationship between the test and the
Git repo which isn't portable to the Cray module-based testing
configuration.