### PR TITLE
Fix subclass check to be O(1)

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -509,6 +509,8 @@ AggregateType::AggregateType(AggregateTag initTag)
   genericField        = 0;
   mIsGeneric          = false;
 
+  classId = 0;
+
   // set defaultValue to nil to keep it from being constructed
   if (aggregateTag == AGGREGATE_CLASS) {
     defaultValue = gNil;

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -452,7 +452,9 @@ GenRet codegenTypeByName(const char* type_name)
   if (info->cfile) {
     ret.c = type_name;
   } else {
+#ifdef HAVE_LLVM
     ret.type = getTypeLLVM(type_name);
+#endif
   }
   return ret;
 }
@@ -467,16 +469,16 @@ GenRet codegenTypedNull(GenRet funcPtrType)
   GenInfo* info = gGenInfo;
 
   GenRet nullFn;
-#ifdef HAVE_LLVM
   if (info->cfile) {
     // C doesn't really care about the type of NULL, so use existing routine.
     nullFn.c = "(" + funcPtrType.c + ")(NULL)";
   } else {
+#ifdef HAVE_LLVM
     // With LLVM, generate a NULL of the right type.
     INT_ASSERT(funcPtrType.type);
     nullFn.val = llvm::Constant::getNullValue(funcPtrType.type);
-  }
 #endif
+  }
   return nullFn;
 }
 
@@ -500,7 +502,9 @@ GenRet codegenStringForTable(std::string s)
   if (info->cfile) {
     ret.c = "\"" + s + "\"";
   } else {
+#ifdef HAVE_LLVM
     ret.val = codegenStringForTableLLVM(s);
+#endif
   }
   return ret;
 }

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -405,27 +405,6 @@ codegenGlobalConstArray(const char* name, const char* eltType, std::vector<GenRe
 
   }
 }
-static void
-genIntegerArray(const char* name, std::vector<int> * vals, bool isHeader)
-{
-  const char* eltType = "chpl__class_id";
-
-  // Just pass NULL when generating header
-  if(isHeader) {
-    codegenGlobalConstArray(name, eltType, NULL, true);
-    return;
-  }
-
-  INT_ASSERT(vals != NULL);
-  std::vector<int> & array = *vals;
-
-  // Construct the GenRet array of integers
-  std::vector<GenRet> tmp;
-  for(size_t i = 0; i < vals->size(); i++) {
-    tmp.push_back( new_IntSymbol(array[i], INT_SIZE_32)->codegen() );
-  }
-  codegenGlobalConstArray(name, eltType, &tmp, false);
-}
 
 // This uses Schubert Numbering but we could use Cohen's Display,
 // which can be computed more incrementally.
@@ -434,10 +413,12 @@ genIntegerArray(const char* name, std::vector<int> * vals, bool isHeader)
 // by Roland Ducournau
 static void
 genSubclassArray(bool isHeader) {
-  const char* n2_name = "chpl_subclass_max_id";
+  const char* eltType = "chpl__class_id";
+  const char* name = "chpl_subclass_max_id";
 
-  if (isHeader) {
-    genIntegerArray(n2_name, NULL, true);
+  if(isHeader) {
+    // Just pass NULL when generating header
+    codegenGlobalConstArray(name, eltType, NULL, true);
     return;
   }
 
@@ -450,8 +431,14 @@ genSubclassArray(bool isHeader) {
   if (n2.empty())
     n2.push_back(0);
 
-  // Now generate arrays
-  genIntegerArray(n2_name, &n2, false);
+  // Construct the GenRet array of integers
+  std::vector<GenRet> tmp;
+  for(size_t i = 0; i < n2.size(); i++) {
+    tmp.push_back( new_IntSymbol(n2[i], INT_SIZE_32)->codegen() );
+  }
+
+  // Now emit the global array declaration
+  codegenGlobalConstArray(name, eltType, &tmp, false);
 }
 
 static void

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,6 +46,9 @@
 #include <cstdio>
 #include <vector>
 
+// function prototypes
+static bool compareSymbol(void* v1, void* v2);
+
 // Global so that we don't have to pass around
 // to all of the codegen() routines
 GenInfo* gGenInfo   =  0;
@@ -76,7 +79,7 @@ subChar(Symbol* sym, const char* ch, const char* x) {
   char* tmp = (char*)malloc(ch-sym->cname+1);
   strncpy(tmp, sym->cname, ch-sym->cname);
   tmp[ch-sym->cname] = '\0';
-  sym->cname = astr(tmp, x, ch+1); 
+  sym->cname = astr(tmp, x, ch+1);
   free(tmp);
   return sym->cname;
 }
@@ -106,7 +109,7 @@ static void legalizeName(Symbol* sym) {
           // If we're in the == case, replace the first = with EQUALS
           ch = subChar(sym, ch, equalsStr);
         } else {
-          if ((ch-equalsLen >= sym->cname) && 
+          if ((ch-equalsLen >= sym->cname) &&
               strncmp(ch-equalsLen, equalsStr, equalsLen) == 0) {
             // Otherwise, if the thing preceding this '=' is the
             // string _EQUALS_, we must have been the second '=' and
@@ -153,7 +156,7 @@ genGlobalDefClassId(const char* cname, int id, bool isHeader) {
   const char* id_type_name = "chpl__class_id";
   std::string name("chpl__cid_");
   name += cname;
-  
+
   if( info->cfile ) {
     if(isHeader)
       fprintf(info->cfile, "extern const %s %s;\n",
@@ -232,21 +235,237 @@ static void
 genClassIDs(std::vector<TypeSymbol*> & typeSymbol, bool isHeader) {
   genComment("Class Type Identification Numbers");
 
-  int count=0;
   forv_Vec(TypeSymbol, ts, typeSymbol) {
     if (AggregateType* ct = toAggregateType(ts->type)) {
-      if (!isReferenceType(ct) && isClass(ct)) {
-        genGlobalDefClassId(ts->cname, count, isHeader);
-        count++;
+      if (!isReferenceType(ct) && isClass(ct) &&
+          !ct->symbol->hasFlag(FLAG_NO_OBJECT)) {
+        int id = ct->classId;
+        INT_ASSERT(id != 0);
+        genGlobalDefClassId(ts->cname, id, isHeader);
       }
     }
   }
+}
+
+struct compareSymbolFunctor {
+  // This is really operator less-than
+  bool operator() (Symbol* a, Symbol* b) {
+    return compareSymbol(a, b);
+  }
+};
+
+
+// Visit class types in depth-first preorder order.
+// Assigns class IDs to classes in that order.
+static void
+preorderVisitClassesComputeIds(TypeSymbol* ts, int* nextNumber)
+{
+  typedef std::set<TypeSymbol*, compareSymbolFunctor> children_set;
+
+  children_set children;
+
+  if (ts == NULL)
+    return;
+
+  AggregateType* at = toAggregateType(ts->type);
+  INT_ASSERT(at != NULL);
+
+  // visit node
+  int myN1 = *nextNumber;
+  *nextNumber = *nextNumber + 1;
+  at->classId = myN1;
+
+  // visit children in order
+  forv_Vec(Type, child, ts->type->dispatchChildren) {
+    if (child)
+      children.insert(child->symbol);
+  }
+  for (children_set::iterator it = children.begin();
+       it != children.end();
+       ++it ) {
+    TypeSymbol* child = *it;
+    preorderVisitClassesComputeIds(child, nextNumber);
+  }
+}
+
+static int gMaxClassId = 1;
+
+static
+void assignClassIds()
+{
+  int next = 1;
+  preorderVisitClassesComputeIds(dtObject->symbol, &next);
+  gMaxClassId = next - 1;
+}
+
+
+// Computes a maximum ID of subclasses and stores that in n2.
+// Returns the maximum ID of a subclass.
+// This helps with Schubert numbering
+static
+int computeMaxSubclass(TypeSymbol* ts, std::vector<int> & n2)
+{
+  if (ts == NULL)
+    return 0;
+
+  AggregateType* at = toAggregateType(ts->type);
+  INT_ASSERT(at != NULL);
+
+  int myId = at->classId;
+  int maxN1 = myId;
+  forv_Vec(Type, child, ts->type->dispatchChildren) {
+    if (child) {
+      int subMax = computeMaxSubclass(child->symbol, n2);
+      if (subMax > maxN1)
+        maxN1 = subMax;
+    }
+  }
+
+  if ((size_t) myId >= n2.size())
+    n2.resize(myId + 1);
+
+  // set n2 for node, which is max of this n1
+  // and child n1s.
+  n2[myId] = maxN1;
+
+  return maxN1;
+}
+
+
+static void
+codegenGlobalConstArray(const char* name, const char* eltType, std::vector<GenRet> * vals, bool isHeader)
+{
+  GenInfo* info = gGenInfo;
+
+  if(isHeader) {
+    if( info->cfile ) {
+      FILE* hdrfile = info->cfile;
+      fprintf(hdrfile, "extern const %s %s[];\n", eltType, name);
+    }
+    return;
+  }
+
+  // Now generate arrays
+  if( info->cfile ) {
+    FILE* f = info->cfile;
+    fprintf(f, "const %s %s[] = {\n", eltType, name);
+    bool first = true;
+    std::vector<GenRet> & array = *vals;
+    int n = array.size();
+    for(int i = 0; i < n; i++ ) {
+      if (!first)
+        fprintf(f, ",\n");
+      fprintf(f, "/* %d */ %s", i, array[i].c.c_str());
+      first = false;
+    }
+    fprintf(f, "\n};\n");
+  } else {
+    // TODO
+    INT_FATAL("not implemented yet");
+
+#ifdef HAVE_LLVM
+    /*
+    if (!isHeader)
+      return;
+
+    const char* vmtData = "chpl_vmtable_data";
+    std::vector<llvm::Constant *> table;
+    llvm::Type *funcPtrType = getTypeLLVM("chpl_fn_p");
+    llvm::Type *vmTableEntryType = funcPtrType;
+
+    forv_Vec(TypeSymbol, ts, types) {
+      if (AggregateType* ct = toAggregateType(ts->type)) {
+        if (!isReferenceType(ct) && isClass(ct)) {
+          int n = 0;
+          if (Vec<FnSymbol*>* vfns = virtualMethodTable.get(ct)) {
+            forv_Vec(FnSymbol, vfn, *vfns) {
+              llvm::Function *func = getFunctionLLVM(vfn->cname);
+              table.push_back(llvm::cast<llvm::Constant>(
+                    info->builder->CreatePointerCast(func, funcPtrType)));
+              n++;
+            }
+          }
+          for (int i = n; i < maxVMT; i++) {
+            table.push_back(llvm::Constant::getNullValue(funcPtrType));
+            n++;
+          }
+        }
+      }
+    }
+
+    llvm::ArrayType *vmTableType =
+      llvm::ArrayType::get(vmTableEntryType, table.size());
+
+    if(llvm::GlobalVariable *vmTable = info->module->getNamedGlobal(vmtData)) {
+      vmTable->eraseFromParent();
+    }
+
+    llvm::GlobalVariable *vmTable =llvm::cast<llvm::GlobalVariable>(
+        info->module->getOrInsertGlobal(vmtData, vmTableType));
+    vmTable->setInitializer(llvm::ConstantArray::get(vmTableType, table));
+    vmTable->setConstant(true);
+
+    llvm::Value* vmtElmPtr =
+      info->builder->CreateConstInBoundsGEP2_64(vmTable, 0, 0);
+
+    info->lvt->addGlobalValue(vmt, vmtElmPtr, GEN_VAL, true);
+     */
+#endif
+
+  }
+}
+static void
+genIntegerArray(const char* name, std::vector<int> * vals, bool isHeader)
+{
+  // Just pass NULL when generating header
+  if(isHeader) {
+    codegenGlobalConstArray(name, "int", NULL, true);
+    return;
+  }
+
+  INT_ASSERT(vals != NULL);
+  std::vector<int> & array = *vals;
+
+  // Construct the GenRet array of integers
+  std::vector<GenRet> tmp;
+  for(size_t i = 0; i < vals->size(); i++) {
+    tmp.push_back( new_IntSymbol(array[i])->codegen() );
+  }
+  codegenGlobalConstArray(name, "int", &tmp, false);
+}
+
+// This uses Schubert Numbering but we could use Cohen's Display,
+// which can be computed more incrementally.
+// See issue ##5887 and/or
+// "Implementing statically typed object-oriented programming languages",
+// by Roland Ducournau
+static void
+genSubclassArray(bool isHeader) {
+  const char* n2_name = "chpl_subclass_max_id";
+
+  if (isHeader) {
+    genIntegerArray(n2_name, NULL, true);
+    return;
+  }
+
+  // Otherwise, compute n2 array and then code-generate it
+  std::vector<int> n2;
+
+  computeMaxSubclass(dtObject->symbol, n2);
+
+  // make sure n2 always contains at least 1 element
+  if (n2.empty())
+    n2.push_back(0);
+
+  // Now generate arrays
+  genIntegerArray(n2_name, &n2, false);
 }
 
 static void
 genFtable(std::vector<FnSymbol*> & fSymbols, bool isHeader) {
   GenInfo* info = gGenInfo;
   const char* ftable_name = "chpl_ftable";
+  // TODO -- refactor this to use codegenGlobalConstArray.
   if( info->cfile ) {
     FILE* hdrfile = info->cfile;
     if(isHeader) {
@@ -376,100 +595,87 @@ static void
 genVirtualMethodTable(std::vector<TypeSymbol*>& types, bool isHeader) {
   GenInfo* info = gGenInfo;
   const char* vmt = "chpl_vmtable";
-  if(info->cfile && isHeader) {
-    fprintf(info->cfile, "extern chpl_fn_p %s[];\n", vmt);
+  const char* eltType = "chpl_fn_p";
+  if(isHeader) {
+    codegenGlobalConstArray(vmt, eltType, NULL, true);
     return;
   }
-  int maxVMT = 0;
-  for (int i = 0; i < virtualMethodTable.size(); i++)
-    if(virtualMethodTable.begin()[i].key && virtualMethodTable.begin()[i].value->n > maxVMT)
-      maxVMT = virtualMethodTable.begin()[i].value->n;
 
+  // compute max # methods per type
+  int maxVMT = 0;
+  typedef MapElem<Type*,Vec<FnSymbol*>*> VmtMapElem;
+
+  form_Map(VmtMapElem, el, virtualMethodTable) {
+    AggregateType* t = toAggregateType(el->key);
+    Vec<FnSymbol*>* val = el->value;
+    if (t && val) {
+      if (val->n > maxVMT)
+        maxVMT = val->n;
+    }
+  }
   gMaxVMT = maxVMT;
 
-  if( info->cfile ) {
-    FILE* hdrfile = info->cfile;
-    // MPF - in order to simplify code generation, making
-    // chpl_vmtable a 1D array.
-    fprintf(hdrfile, "chpl_fn_p %s[] = {\n", vmt);
-    bool comma = false;
-    forv_Vec(TypeSymbol, ts, types) {
-      if (AggregateType* ct = toAggregateType(ts->type)) {
-        if (!isReferenceType(ct) && isClass(ct)) {
-          if (comma)
-            fprintf(hdrfile, ",\n");
-          fprintf(hdrfile, " /* %s */\n", ct->symbol->cname);
-          int n = 0;
-          if (Vec<FnSymbol*>* vfns = virtualMethodTable.get(ct)) {
-            forv_Vec(FnSymbol, vfn, *vfns) {
-              if (n > 0)
-                fprintf(hdrfile, ",\n");
-              fprintf(hdrfile, "(chpl_fn_p)%s", vfn->cname);
-              n++;
-            }
-          }
-          for (int i = n; i < maxVMT; i++) {
-            if (n > 0)
-              fprintf(hdrfile, ",\n");
-            fprintf(hdrfile, "(chpl_fn_p)NULL");
-            n++;
-          }
-          if (maxVMT > 0)
-            comma = true;
-        }
-      }
-    }
-    if (types.size() == 0 || maxVMT == 0)
-      fprintf(hdrfile, "(chpl_fn_p)0");
-    fprintf(hdrfile, "\n};\n");
-  } else {
-#ifdef HAVE_LLVM
-    if (!isHeader)
-      return;
 
-    const char* vmtData = "chpl_vmtable_data";
-    std::vector<llvm::Constant *> table;
-    llvm::Type *funcPtrType = getTypeLLVM("chpl_fn_p");
-    llvm::Type *vmTableEntryType = funcPtrType;
-    
-    forv_Vec(TypeSymbol, ts, types) {
-      if (AggregateType* ct = toAggregateType(ts->type)) {
-        if (!isReferenceType(ct) && isClass(ct)) {
-          int n = 0;
-          if (Vec<FnSymbol*>* vfns = virtualMethodTable.get(ct)) {
-            forv_Vec(FnSymbol, vfn, *vfns) {
+#ifdef HAVE_LLVM
+  // LLVM preliminaries
+  llvm::Type *funcPtrType = getTypeLLVM("chpl_fn_p");
+  llvm::Type *vmTableEntryType = funcPtrType;
+#endif
+
+
+  std::vector<GenRet> vmt_elts;
+
+  // Make sure VMT has at least one element
+  vmt_elts.resize(1);
+
+  // compute 1D virtual method table
+  // (this is not fundamental, but is currently used to simplify codegen)
+  //    indexExpr = maxVMT * classId + fnId
+  forv_Vec(TypeSymbol, ts, types) {
+    if (AggregateType* ct = toAggregateType(ts->type)) {
+      if (!isReferenceType(ct) && isClass(ct)) {
+        if (Vec<FnSymbol*>* vfns = virtualMethodTable.get(ct)) {
+          int i = 0;
+          forv_Vec(FnSymbol, vfn, *vfns) {
+            int classId = ct->classId;
+            int fnId = i;
+            int index = gMaxVMT * classId + fnId;
+
+            INT_ASSERT(classId > 0);
+
+            GenRet fnAddress;
+
+            if( info->cfile ) {
+              fnAddress.c = "(chpl_fn_p)";
+              fnAddress.c += vfn->cname;
+            } else {
+#ifdef HAVE_LLVM
               llvm::Function *func = getFunctionLLVM(vfn->cname);
-              table.push_back(llvm::cast<llvm::Constant>(
-                    info->builder->CreatePointerCast(func, funcPtrType)));
-              n++;
+              fnAddress.val = info->builder->CreatePointerCast(func, funcPtrType);
+#endif
             }
-          }
-          for (int i = n; i < maxVMT; i++) {
-            table.push_back(llvm::Constant::getNullValue(funcPtrType));
-            n++; 
+
+            if (vmt_elts.size() <= (size_t) index)
+              vmt_elts.resize(index+1);
+
+            vmt_elts[index] = fnAddress;
+
+            i++;
           }
         }
       }
     }
-    
-    llvm::ArrayType *vmTableType =
-      llvm::ArrayType::get(vmTableEntryType, table.size());
-    
-    if(llvm::GlobalVariable *vmTable = info->module->getNamedGlobal(vmtData)) {
-      vmTable->eraseFromParent();
-    }
-    
-    llvm::GlobalVariable *vmTable =llvm::cast<llvm::GlobalVariable>(
-        info->module->getOrInsertGlobal(vmtData, vmTableType));
-    vmTable->setInitializer(llvm::ConstantArray::get(vmTableType, table));
-    vmTable->setConstant(true);
-    
-    llvm::Value* vmtElmPtr =
-      info->builder->CreateConstInBoundsGEP2_64(vmTable, 0, 0);
-     
-    info->lvt->addGlobalValue(vmt, vmtElmPtr, GEN_VAL, true);
-#endif
   }
+
+  // Fill any elements not filled above with codegenNullPointer
+  for (size_t i = 0; i < vmt_elts.size(); i++) {
+    if (vmt_elts[i].isEmpty()) {
+      vmt_elts[i] = codegenNullPointer();
+    }
+  }
+
+
+  codegenGlobalConstArray(vmt, eltType, &vmt_elts, false);
 }
 
 static void genFilenameTable() {
@@ -887,6 +1093,7 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
   FILE* hdrfile = info->cfile;
 
   genClassIDs(types, false);
+  genSubclassArray(false);
 
   genComment("Function Pointer Table");
   genFtable(ftableVec, false);
@@ -906,7 +1113,7 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
 #ifndef HAVE_LLVM
   zlineToFileIfNeeded(rootModule, info->cfile);
 #endif
-  
+
   genGlobalInt("chpl_numGlobalsOnHeap", numGlobalsOnHeap, false);
   int globals_registry_static_size = (numGlobalsOnHeap ? numGlobalsOnHeap : 1);
   if( hdrfile ) {
@@ -1161,7 +1368,9 @@ static void codegen_header(std::set<const char*> & cnames, std::vector<TypeSymbo
 #endif
   }
 
+  assignClassIds();
   genClassIDs(types, true);
+  genSubclassArray(true);
 
   genComment("Class Prototypes");
   forv_Vec(TypeSymbol, typeSymbol, types) {
@@ -1354,7 +1563,7 @@ static void codegen_header(std::set<const char*> & cnames, std::vector<TypeSymbo
       GVar->eraseFromParent();
     }
 
-    llvm::ArrayType *private_broadcastTableType = 
+    llvm::ArrayType *private_broadcastTableType =
       llvm::ArrayType::get(private_broadcastTableEntryType,
                           private_broadcastTable.size());
     llvm::GlobalVariable *private_broadcastTableGVar =
@@ -1432,8 +1641,8 @@ codegen_config() {
     closeCFile(&configFile);
     info->cfile = mainfile;
   }
- 
- 
+
+
   if( llvmCodegen ) {
 #ifdef HAVE_LLVM
     llvm::FunctionType *createConfigType;
@@ -1766,7 +1975,7 @@ void codegen(void) {
     }
 
     finishCodegenLLVM();
-#endif 
+#endif
   } else {
     if (fHeterogeneous) {
       codegenTypeStructureInclude(mainfile.fptr);
@@ -1871,7 +2080,7 @@ GenInfo::GenInfo(
 
   setupClang(this, rtmain);
 
-  // Create a new LLVM module, IRBuilder, and LayeredValueTable. 
+  // Create a new LLVM module, IRBuilder, and LayeredValueTable.
   if( ! parseOnly ) {
     module = new llvm::Module(moduleName, llvmContext);
     builder = new llvm::IRBuilder<>(module->getContext());

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2059,7 +2059,7 @@ GenInfo::GenInfo(
            Clang(NULL), clangTargetOptions(), clangLangOptions(),
            moduleName("root"), llvmContext(), Ctx(NULL),
            targetData(NULL), cgBuilder(NULL), cgAction(NULL),
-           tbaaRootNode(NULL), tbaaFtableNode(NULL), tbaaVmtableNode(NULL),
+           tbaaRootNode(NULL),
            targetLayout(), globalToWideInfo(),
            FPM_postgen(NULL)
 {

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -1971,9 +1971,12 @@ GenRet codegenGlobalArrayElement(const char* table_name, GenRet elt)
     elementPtr = info->builder->CreateInBoundsGEP(table.val, GEPLocs);
 
     llvm::Instruction* element = info->builder->CreateLoad(elementPtr);
-    // Tell TBAA global array loads don't alias anything else, are constant
-    fnPtrV->setMetadata(llvm::LLVMContext::MD_tbaa,
-                        gGenInfo->tbaaVmtableNode);
+
+    // I don't think it matters, but we could provide TBAA metadata
+    // here to indicate global constant variable loads are constant...
+    // I'd expect LLVM to figure that out because the table loaded is
+    // constant.
+
     ret.val = element;
 #endif
   }
@@ -4707,9 +4710,6 @@ GenRet CallExpr::codegenPrimitive() {
       fnPtrPtr   = gGenInfo->builder->CreateInBoundsGEP(ftable.val, GEPLocs);
       fnPtr      = gGenInfo->builder->CreateLoad(fnPtrPtr);
 
-      // Tell TBAA ftable ptrs don't alias other things, are constant
-      fnPtr->setMetadata(llvm::LLVMContext::MD_tbaa, gGenInfo->tbaaFtableNode);
-
       // Generate an LLVM function type based upon the arguments.
       std::vector<llvm::Type*> argumentTypes;
       llvm::Type*              returnType;
@@ -4798,9 +4798,6 @@ GenRet CallExpr::codegenPrimitive() {
       GEPLocs[1] = index.val;
       fnPtrPtr = gGenInfo->builder->CreateInBoundsGEP(table.val, GEPLocs);
       llvm::Instruction* fnPtrV = gGenInfo->builder->CreateLoad(fnPtrPtr);
-      // Tell TBAA vmtable loads don't alias anything else, are constant
-      fnPtrV->setMetadata(llvm::LLVMContext::MD_tbaa,
-                          gGenInfo->tbaaVmtableNode);
       fnPtr.val = fnPtrV;
 #endif
     }

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -107,8 +107,6 @@ struct GenInfo {
   CCodeGenAction *cgAction;
 
   llvm::MDNode* tbaaRootNode;
-  llvm::MDNode* tbaaFtableNode;
-  llvm::MDNode* tbaaVmtableNode;
 
   // We stash the layout that Clang would like to use here.
   // With fLLVMWideOpt, this will be the layout that we

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -477,5 +477,6 @@ GenRet createTempVarWith(GenRet v);
 
 GenRet codegenDeref(GenRet toDeref);
 GenRet codegenLocalDeref(GenRet toDeref);
+GenRet codegenNullPointer();
 
 #endif

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -131,6 +131,10 @@ public:
     *this = baseASTCodegenString(str);
   }
 
+  // Return true if this GenRet is empty
+  bool isEmpty() const {
+    return c.empty() && val == NULL && type == NULL;
+  }
 };
 
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -436,6 +436,10 @@ public:
 
   const char*                 doc;
 
+  // Used during code generation for subclass checking,
+  // isa checking. This is the value we store in chpl__cid_XYZ.
+  int                         classId;
+
 private:
   virtual std::string         docsDirective();
 

--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -196,28 +196,6 @@ void setupClangContext(GenInfo* info, ASTContext* Ctx)
       Ops[0] = llvm::MDString::get(cx, "Chapel types");
       info->tbaaRootNode = llvm::MDNode::get(cx, Ops);
     }
-    // Create type for ftable
-    {
-      LLVM_METADATA_OPERAND_TYPE* Ops[3];
-      Ops[0] = llvm::MDString::get(cx, "Chapel ftable");
-      Ops[1] = info->tbaaRootNode;
-      // and mark it as constant
-      Ops[2] = llvm_constant_as_metadata(
-          ConstantInt::get(llvm::Type::getInt64Ty(cx), 1));
-
-      info->tbaaFtableNode = llvm::MDNode::get(cx, Ops);
-    }
-    {
-      LLVM_METADATA_OPERAND_TYPE* Ops[3];
-      Ops[0] = llvm::MDString::get(cx, "Chapel vmtable");
-      Ops[1] = info->tbaaRootNode;
-      // and mark it as constant
-      Ops[2] = llvm_constant_as_metadata(
-          ConstantInt::get(llvm::Type::getInt64Ty(cx), 1));
-
-      info->tbaaVmtableNode = llvm::MDNode::get(cx, Ops);
-    }
-
   }
 
   info->targetLayout = info->Ctx->getTargetInfo().getTargetDescription();

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -70,13 +70,13 @@ extern const int CHPL_CACHE_REMOTE;
 
 // Sorted lookup table of filenames used with insertLineNumbers for error
 // messages and logging. Defined in chpl_compilation_config.c (needed by launchers)
-extern c_string chpl_filenameTable[];
+extern const c_string chpl_filenameTable[];
 extern const int32_t chpl_filenameTableSize;
 
 // Lookup tables used as a symbol table by the stack unwinder for translating
 // C symbols into Chapel symbols. Defined in chpl_compilation_config.c
-extern c_string chpl_funSymTable[];
-extern int chpl_filenumSymTable[];
+extern const c_string chpl_funSymTable[];
+extern const int chpl_filenumSymTable[];
 extern const int32_t chpl_sizeSymTable;
 
 extern char* chpl_executionCommand;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -82,8 +82,8 @@ extern const int32_t chpl_sizeSymTable;
 extern char* chpl_executionCommand;
 
 /* generated */
-extern chpl_fn_p chpl_ftable[];
-extern chpl_fn_info chpl_finfo[];
+extern const chpl_fn_p chpl_ftable[];
+extern const chpl_fn_info chpl_finfo[];
 
 extern void chpl__initStringLiterals(void);
 


### PR DESCRIPTION
Fixes #5887. The subclass check is used in dynamic casting.

Before this PR, dynamic casts are implemented with conditionals linear in the number of potential subclasses (see issue #5887). This PR solves that problem by using a strategy called Schubert Numbering.

What is Schubert numbering in the context of subclass checking? I've learned this term from "Implementing statically typed object-oriented programming languages", Roland Ducournau but I outline it below:

The strategy of Schubert numbering consists of two components:

1) compute class IDs in a preorder depth-first traversal.  That way, subclasses of any class form a contiguous region in the space of class IDs.

 2) create an array storing for each class the maximum class ID of it or a subclass. Since property 1 made the class IDs of all subclasses contiguous in any list, this maximum can be used to check if one class ID represents a subclass of another. It just amounts to two comparisons.

I chose to implement Schubert numbering for the dynamic subclass check because it is reasonably convenient to implement in the current compiler.  There are certainly other ways to implement a subclass check.

While there, I refactored the generation of some global tables in code generation. This refactor is intended to allow some of the tables we currently generate in C even for LLVM configurations to be generated in native LLVM. As part of that, the runtime is updated since these tables are now marked `const`.

Passed:
 * quickstart testing.
 * full local testing.
 * release/examples with GASNet
 * release/examples with --llvm
 * release/examples with GASNet and --llvm

Verified that the first sample code from #5887 generates only O(1) code in the dynamic cast.
It looks like this:
``` c
static Child_chpl doDynamicCast_chpl(void) {
    ...
    tmp_cid = ((object)(first_chpl))->chpl__cid;
    ret_chpl = ( (((chpl__cid_Child_chpl <= tmp_cid) && (tmp_cid <= chpl_subclass_max_id[chpl__cid_Child_chpl])))?(((Child_chpl)(first_chpl))):(((Child_chpl)(NULL))) );
    ...
}
```

Reviewed by @benharsh - thanks!