### PR TITLE
Add '(pre-release)' label to --version output with SHA

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -26,6 +26,6 @@ void
 get_version(char *v) {
   v += sprintf(v, "%d.%s.%s", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (strcmp(BUILD_VERSION, "0") != 0 || developer)
-    sprintf(v, ".%s", BUILD_VERSION);
+    sprintf(v, ".%s (pre-release)", BUILD_VERSION);
 }
 

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -26,6 +26,6 @@ void
 get_version(char *v) {
   v += sprintf(v, "%d.%s.%s", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (strcmp(BUILD_VERSION, "0") != 0 || developer)
-    sprintf(v, ".%s (pre-release)", BUILD_VERSION);
+    sprintf(v, " pre-release (%s)", BUILD_VERSION);
 }
 

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,4 +5,4 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n "." && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \" ; }
+    { echo -n "." && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo " (pre-release)" ; }

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,4 +5,4 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n "." && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo " (pre-release)" ; }
+    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }


### PR DESCRIPTION
For some time now, we've been discussing bumping our compiler
version number just after a release rather than just before it.
In doing so, we wanted to clearly label the version as being
a pre-release version.  This mod notes that this condition is
met whenever we print the SHA of the GitHub repo and simply
extends the logic that prints the SHA with a print of "(pre-release)".
It also updates the script that creates the .good file for our
test of the version number similarly.