### PR TITLE
Fix a type error exposed by std-c++14 mode

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1770,7 +1770,7 @@ static int computeNestedDepth(const char* name, Type* type) {
     // this symbol is first defined in
     AggregateType* ct = toAggregateType(type);
 
-    while (ct != NULL && ct->getField(name, false) == false) {
+    while (ct != NULL && ct->getField(name, false) == NULL) {
       retval = retval + 1;
       ct     = toAggregateType(ct->symbol->defPoint->parentSymbol->type);
     }


### PR DESCRIPTION
Russel Winder reported that GCC 7.0 has stricter type-checks than our current compiler
configurations and that this exposed a problem in a recent update to scopeResolve.cpp.

I developed a local update to Makefile.clang that enabled C14 mode and

a. verified the error that Russel reported
b. did not report any other errors.

This PR pushes the trivial fix but does not update Makefile.clang

Compiled with/without CHPL_DEVELOPER on clang/darwin
Ran start_test release/
