### PR TITLE
Fix RVF bug involving a dereference

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -486,6 +486,8 @@ static void updateTaskArg(Map<Symbol*, Vec<SymExpr*>*>& useMap,
     if (call && call->isPrimitive(PRIM_DEREF)) {
       call->replace(new SymExpr(arg));
 
+    } else if (call && isDerefMove(call)) {
+      use->replace(new SymExpr(arg));
     } else if (call && call->isPrimitive(PRIM_MOVE)) {
       use->replace(new CallExpr(PRIM_ADDR_OF, arg));
 


### PR DESCRIPTION
Previously RVF would transform AST like this (a deref-move):
  ``(move myVar myRefArg)``
into this:
  ``(move myVar (addrof myRefArg))``
Which is clearly wrong. RVF wasn't being made aware of the deref-move
pattern, so this commit adds a case to handle it.

This pattern could later trip up other passes that expect the AST
to adhere to certain rules/conventions.

Testing:
- [x] full local
- [x] full gasnet