### PR TITLE
Improve wide-pointer analysis for const-ref args

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -1884,9 +1884,8 @@ static void insertWideTemp(Type* type, SymExpr* src) {
   if (type->isRefOrWideRef() &&
       !src->isRefOrWideRef()) {
     needsAddrOf = true;
-  }
-  else if (src->isRefOrWideRef() &&
-      !type->isRefOrWideRef()) {
+  } else if (src->isRefOrWideRef() &&
+             !type->isRefOrWideRef()) {
     needsDeref = true;
   } else if (type->isRef() && src->isRef() &&
              type->getValType()->symbol->hasFlag(FLAG_WIDE_CLASS) &&

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -976,7 +976,9 @@ static void propagateVar(Symbol* sym) {
   // Actuals and formals have to have the same wideness of their _val field.
   // A ref_T can't be passed into a ref_wide_T, or vice versa, even with temps.
   // At least, this isn't possible today as far as I know.
-  if (isArgSymbol(sym) && sym->isRefOrWideRef() && valIsWideClass(sym)) {
+  ArgSymbol* argSym = toArgSymbol(sym);
+  if (argSym && sym->isRefOrWideRef() && valIsWideClass(sym) &&
+      argSym->intent != INTENT_CONST_REF) {
     FnSymbol* fn = toFnSymbol(sym->defPoint->parentSymbol);
     DEBUG_PRINTF("\tFixing types for arg %s (%d) in %s\n", sym->cname, sym->id, fn->cname);
     forv_Vec(CallExpr, call, *fn->calledBy) {

--- a/test/optimizations/widepointers/constRef.chpl
+++ b/test/optimizations/widepointers/constRef.chpl
@@ -1,0 +1,22 @@
+
+class Foo {
+  var x : int;
+}
+
+proc helper(const ref c : Foo) {
+  writeln("Inside helper, c = ", c);
+  writeln("is 'c' wide? ", __primitive("is wide pointer", c));
+}
+
+proc main() {
+  var loc = new Foo(42);
+  var rem = new Foo(100);
+  helper(loc);
+
+  on Locales[numLocales-1] {
+    helper(rem);
+  }
+
+  // Without optimizations, this will return 'true'
+  writeln("is 'loc' wide? ", __primitive("is wide pointer", loc));
+}

--- a/test/optimizations/widepointers/constRef.good
+++ b/test/optimizations/widepointers/constRef.good
@@ -1,0 +1,5 @@
+Inside helper, c = {x = 42}
+is 'c' wide? true
+Inside helper, c = {x = 100}
+is 'c' wide? true
+is 'loc' wide? false


### PR DESCRIPTION
If an argument has the const-ref intent and points to a wide symbol, we
have historically widened the actual at each callsite. This doesn't
quite make sense because the const-ref intent says that the function
cannot modify the actual. In other words, a local thing passed to a
const-ref formal (of whatever wideness) should remain local.

A change was made to 'insertWideTemp' to handle a new AST pattern.

Testing:
- [x] full no-local
- [x] full gasnet