### PR TITLE
Add future for missing implicit this for forwarded method

### DIFF
--- a/test/classes/ferguson/forwarding/call-forwarded-omit-this.bad
+++ b/test/classes/ferguson/forwarding/call-forwarded-omit-this.bad
@@ -1,0 +1,4 @@
+call-forwarded-omit-this.chpl:27: In function 'bad':
+call-forwarded-omit-this.chpl:28: error: unresolved call 'area()'
+call-forwarded-omit-this.chpl:5: note: candidates are: MyCircleImpl.area()
+call-forwarded-omit-this.chpl:25: note:                 MyCircle.area()

--- a/test/classes/ferguson/forwarding/call-forwarded-omit-this.chpl
+++ b/test/classes/ferguson/forwarding/call-forwarded-omit-this.chpl
@@ -1,0 +1,41 @@
+class MyCircleImpl {
+  var radius:real;
+
+
+  proc area() {
+    return pi*radius*radius;
+  }
+  proc circumference() {
+    return 2.0*pi*radius;
+  }
+}
+
+record MyCircle {
+  forwarding var impl: MyCircleImpl;
+  // above declaration requests forwarding
+
+  // compiler creates area() method
+  // to call impl.area()
+
+  // compiler creates circumference() method
+  // to call impl.circumference()
+
+ 
+  proc good() {
+    writeln("I'm a circle with area ", this.area());
+  }
+  proc bad() {
+    writeln("I'm a circle with area ", area());
+  }
+  proc ugly() {
+    good();
+  }
+
+
+}
+
+
+var r = new MyCircle(new MyCircleImpl(1.0));
+r.good();
+r.bad();
+r.ugly();

--- a/test/classes/ferguson/forwarding/call-forwarded-omit-this.future
+++ b/test/classes/ferguson/forwarding/call-forwarded-omit-this.future
@@ -1,0 +1,10 @@
+bug: forwarding does not work without 'this'
+
+In the current compiler, scopeResolve is responsible for adding the
+implicit 'this.' to a method call within a method. That's not happening
+if the method called is a forwarded method, because scope resolve runs
+before the set of forwarded methods is computed.
+
+I think that the solution here is to move the implicit  'this.' logic
+from scopeResolve into functionResolution. See also
+ test/functions/ferguson/spec-insn-method-no-this.future

--- a/test/classes/ferguson/forwarding/call-forwarded-omit-this.good
+++ b/test/classes/ferguson/forwarding/call-forwarded-omit-this.good
@@ -1,0 +1,3 @@
+I'm a circle with area 3.14159
+I'm a circle with area 3.14159
+I'm a circle with area 3.14159


### PR DESCRIPTION
Adds a future for a case of forwarding not working (Forwarding added in PR #5058).

This works when `area` is a forwarded method:

``` chapel
  proc good() {
    writeln("I'm a circle with area ", this.area());
  }
```

but this does not:
``` chapel
  proc bad() {
    writeln("I'm a circle with area ", area());
  }
```

In the current compiler, scopeResolve is responsible for adding the implicit 'this.' to a method call within a method. That's not happening if the method called is a forwarded method, because scope resolve runs before the set of forwarded methods is computed.

I think that the solution here is to move the implicit  'this.' logic from scopeResolve into functionResolution. See also test/functions/ferguson/spec-insn-method-no-this.future
