### PR TITLE
Attempt to clarify need to send in GitHub ID with CLA

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,13 +2,14 @@ How to Contribute
 =================
 
 As an open-source project, Chapel welcomes source contributions from
-the community.  Contributors are asked to sign a contributor agreement
-in order to help us maintain Chapel's license terms.  The
-contributor's agreement can be found in
+the community.  Contributors are asked to sign a contributor license
+agreement (CLA) in order to help us maintain Chapel's license terms.
+Instructions for submitting the CLA can be found in
 [doc/rst/developer/contributorsAgreements/][0].
 
 The high-level steps for contributing code are:
 
+0. Send us your CLA and GitHub ID
 1. Fork repo on github
 2. Create new branch
 3. Submit pull request

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -57,9 +57,8 @@ similar, though the specific people involved are likely to change and grow).
   alert the chapel-developers_ mailing list of this as, presently, such code
   packages must be approved by Cray leadership before being committed.
 
-* Sign a Chapel contributor's agreement, located at the URL below, and send it
-  to your contact at Cray (ask for one at the chapel_admin _at_ cray.com list
-  if you don't).
+* Sign a Chapel contributor's agreement and mail it, with your GitHub
+  ID, using the instructions here:
 
   https://github.com/chapel-lang/chapel/tree/master/doc/rst/developer/contributorAgreements/
 

--- a/doc/rst/developer/contributorAgreements/README.md
+++ b/doc/rst/developer/contributorAgreements/README.md
@@ -20,3 +20,4 @@ There are two versions:
 
 Once completed, CLAs should be scanned as PDFs and mailed to:
 **chapel<!---deleteme-->_admin<!---deleteme-->@<!---deleteme-->cray.com**
+along with your GitHub ID.


### PR DESCRIPTION
This mod attempts to clarify the request to send in GitHub IDs with CLAs and to remove some duplicated text (for maintenance purposes) while here.
