### PR TITLE
Extract findVisibleFunctions() et. al. from functionResolution.cpp

### DIFF
--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -183,7 +183,4 @@ bool isTypeExpr(Expr* expr);
 Symbol* getSvecSymbol(CallExpr* call);
 void collectUsedFnSymbols(BaseAST* ast, std::set<FnSymbol*>& fnSymbols);
 
-// move to resolve when scope resolution is put in resolution directory
-BlockStmt* getVisibilityBlock(Expr* expr);
-
 #endif

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -27,14 +27,16 @@
 
 class CallInfo;
 
-extern SymbolMap      paramMap;
+extern SymbolMap       paramMap;
 
-extern Vec<CallExpr*> callStack;
-extern Vec<CondStmt*> tryStack;
+extern Vec<CallExpr*>  callStack;
+extern Vec<CondStmt*>  tryStack;
 
-extern Vec<CallExpr*> inits;
+extern Vec<CallExpr*>  inits;
 
-extern char           arrayUnrefName[];
+extern Vec<BlockStmt*> standardModuleSet;
+
+extern char            arrayUnrefName[];
 
 bool hasAutoCopyForType(Type* type);
 FnSymbol* getAutoCopyForType(Type* type);
@@ -53,12 +55,6 @@ Expr*      resolvePrimInit(CallExpr* call);
 bool       isTupleContainingOnlyReferences(Type* t);
 
 void       ensureEnumTypeResolved(EnumType* etype);
-
-BlockStmt* getVisibleFunctions(BlockStmt*       block,
-                               const char*      name,
-                               Vec<FnSymbol*>&  visibleFns,
-                               Vec<BlockStmt*>& visited,
-                               CallExpr*        callOrigin);
 
 void       resolveFnForCall(FnSymbol* fn, CallExpr* call);
 
@@ -113,10 +109,6 @@ void determineAllSubs(FnSymbol* fn, FnSymbol* root, SymbolMap& subs,
 FnSymbol* instantiateFunction(FnSymbol* fn, FnSymbol* root, SymbolMap& all_subs,
                               CallExpr* call, SymbolMap& subs, SymbolMap& map);
 void explainAndCheckInstantiation(FnSymbol* newFn, FnSymbol* fn);
-
-// visible functions
-void fillVisibleFuncVec(CallExpr* call, CallInfo &info,
-                        Vec<FnSymbol*> &visibleFns);
 
 // disambiguation
 /** A wrapper for candidates for function call resolution.

--- a/compiler/include/visibleFunctions.h
+++ b/compiler/include/visibleFunctions.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _VISIBILE_FUNCTIONS_H_
+#define _VISIBILE_FUNCTIONS_H_
+
+#include "vec.h"
+
+class BlockStmt;
+class CallExpr;
+class CallInfo;
+class Expr;
+class FnSymbol;
+
+void       findVisibleFunctions(CallExpr*       call,
+                                CallInfo&       info,
+                                Vec<FnSymbol*>& visibleFns);
+
+BlockStmt* getVisibleFunctions(BlockStmt*       block,
+                               const char*      name,
+                               Vec<FnSymbol*>&  visibleFns,
+                               Vec<BlockStmt*>& visited,
+                               CallExpr*        callOrigin);
+
+BlockStmt* getVisibilityBlock(Expr* expr);
+
+void       visibleFunctionsClear();
+
+#endif

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -35,6 +35,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "visibleFunctions.h"
 
 #include <algorithm>
 #include <map>

--- a/compiler/resolution/Makefile.share
+++ b/compiler/resolution/Makefile.share
@@ -30,6 +30,7 @@ RESOLUTION_SRCS =                                              \
                   preFold.cpp                                  \
                   tuples.cpp                                   \
                   typeSpecifier.cpp                            \
+                  visibleFunctions.cpp                         \
                   wrappers.cpp
 
 SVN_SRCS        = $(RESOLUTION_SRCS)

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -50,6 +50,7 @@
 #include "TryStmt.h"
 #include "typeSpecifier.h"
 #include "view.h"
+#include "visibleFunctions.h"
 #include "WhileStmt.h"
 
 #include "../ifa/prim_data.h"
@@ -116,18 +117,20 @@ public:
 //#
 //# Global Variables
 //#
-bool           resolved                    = false;
-bool           inDynamicDispatchResolution = false;
-SymbolMap      paramMap;
+bool            resolved                    = false;
+bool            inDynamicDispatchResolution = false;
+SymbolMap       paramMap;
 
-int            explainCallLine             = 0;
-bool           tryFailure                  = false;
+int             explainCallLine             = 0;
+bool            tryFailure                  = false;
 
-char           arrayUnrefName[]            = "array_unref_ret_tmp";
+char            arrayUnrefName[]            = "array_unref_ret_tmp";
 
-Vec<CallExpr*> callStack;
-Vec<CallExpr*> inits;
-Vec<CondStmt*> tryStack;
+Vec<CallExpr*>  callStack;
+Vec<CallExpr*>  inits;
+Vec<CondStmt*>  tryStack;
+
+Vec<BlockStmt*> standardModuleSet;
 
 
 //#
@@ -213,7 +216,6 @@ isMoreVisible(Expr* expr, FnSymbol* fn1, FnSymbol* fn2);
 static CallExpr* userCall(CallExpr* call);
 static void issueCompilerError(CallExpr* call);
 static void reissueCompilerWarning(const char* str, int offset);
-static void buildVisibleFunctionMap();
 static Expr* resolve_type_expr(Expr* expr);
 static Type* resolveDefaultGenericTypeSymExpr(SymExpr* se);
 
@@ -3416,454 +3418,6 @@ static void reissueCompilerWarning(const char* str, int offset) {
   USR_WARN(from, "%s", str);
 }
 
-class VisibleFunctionBlock {
- public:
-  Map<const char*,Vec<FnSymbol*>*> visibleFunctions;
-  VisibleFunctionBlock() { }
-};
-
-static Map<BlockStmt*,VisibleFunctionBlock*> visibleFunctionMap;
-static int nVisibleFunctions = 0; // for incremental build
-static Map<BlockStmt*,BlockStmt*> visibilityBlockCache;
-static Vec<BlockStmt*> standardModuleSet;
-
-//
-// return true if expr is a CondStmt with chpl__tryToken as its condition
-//
-static bool isTryTokenCond(Expr* expr) {
-  CondStmt* cond = toCondStmt(expr);
-  if (!cond) return false;
-  SymExpr* sym = toSymExpr(cond->condExpr);
-  if (!sym) return false;
-  return sym->symbol() == gTryToken;
-}
-
-
-//
-// return the innermost block for searching for visible functions
-//
-BlockStmt*
-getVisibilityBlock(Expr* expr) {
-  if (BlockStmt* block = toBlockStmt(expr->parentExpr)) {
-    if (block->blockTag == BLOCK_SCOPELESS)
-      return getVisibilityBlock(block);
-    else if (block->parentExpr && isTryTokenCond(block->parentExpr)) {
-      // Make the visibility block of the then and else blocks of a
-      // conditional using chpl__tryToken be the block containing the
-      // conditional statement.  Without this, there were some cases where
-      // a function gets instantiated into one side of the conditional but
-      // used in both sides, then the side with the instantiation gets
-      // folded out leaving expressions with no visibility block.
-      // test/functions/iterators/angeles/dynamic.chpl is an example that
-      // currently fails without this.
-      return getVisibilityBlock(block->parentExpr);
-    } else
-      return block;
-  } else if (expr->parentExpr) {
-    return getVisibilityBlock(expr->parentExpr);
-  } else if (Symbol* s = expr->parentSymbol) {
-      FnSymbol* fn = toFnSymbol(s);
-      if (fn && fn->instantiationPoint)
-        return fn->instantiationPoint;
-      else
-        return getVisibilityBlock(s->defPoint);
-  } else {
-    INT_FATAL(expr, "Expression has no visibility block.");
-    return NULL;
-  }
-}
-
-static void buildVisibleFunctionMap() {
-  for (int i = nVisibleFunctions; i < gFnSymbols.n; i++) {
-    FnSymbol* fn = gFnSymbols.v[i];
-    if (!fn->hasFlag(FLAG_INVISIBLE_FN) && fn->defPoint->parentSymbol && !isArgSymbol(fn->defPoint->parentSymbol)) {
-      BlockStmt* block = NULL;
-      if (fn->hasFlag(FLAG_AUTO_II)) {
-        block = theProgram->block;
-      } else {
-        block = getVisibilityBlock(fn->defPoint);
-        //
-        // add all functions in standard modules to theProgram
-        //
-        // Lydia NOTE 09/12/16: The computation of the standardModuleSet is not
-        // tied to what is actually placed within theProgram->block.  As such
-        // there could be bugs where that implementation differs.  We have
-        // already encountered some with qualified access to default-included
-        // modules like List and Sort.  This implementation needs to be linked
-        // to the computation of the standardModuleSet.
-        //
-        if (standardModuleSet.set_in(block))
-          block = theProgram->block;
-      }
-      VisibleFunctionBlock* vfb = visibleFunctionMap.get(block);
-      if (!vfb) {
-        vfb = new VisibleFunctionBlock();
-        visibleFunctionMap.put(block, vfb);
-      }
-      Vec<FnSymbol*>* fns = vfb->visibleFunctions.get(fn->name);
-      if (!fns) {
-        fns = new Vec<FnSymbol*>();
-        vfb->visibleFunctions.put(fn->name, fns);
-      }
-      fns->add(fn);
-    }
-  }
-  nVisibleFunctions = gFnSymbols.n;
-}
-
-//
-// Collects functions called 'name' visible in 'block' and up the visibility
-// chain, which is defined by getVisibilityBlock().
-// The functions defined/visible in a block are given by 'visibleFunctionMap'.
-//
-// 'visibilityBlockCache' maps a block to the nearest block up the visibility
-// chain that contains any functions, according to visibleFunctionMap.
-// In other words, it skips those blocks that do not define any visible
-// functions (of any name).
-// Todo: some blocks only define if-functions (i.e. _if_fnNNN); such blocks
-// probably should not be present in visibleFunctionMap.
-//
-// getVisibleFunctions returns the block appropriate for visibilityBlockCache
-// or NULL if there is none, e.g. when the next block up is the rootModule.
-//
-BlockStmt* getVisibleFunctions(BlockStmt*       block,
-                               const char*      name,
-                               Vec<FnSymbol*>&  visibleFns,
-                               Vec<BlockStmt*>& visited,
-                               CallExpr*        callOrigin) {
-  //
-  // all functions in standard modules are stored in a single block
-  //
-  // Lydia NOTE 09/12/16: The computation of the standardModuleSet is not
-  // tied to what is actually placed within theProgram->block.  As such
-  // there could be bugs where that implementation differs.  We have
-  // already encountered some with qualified access to default-included
-  // modules like List and Sort.  This implementation needs to be linked
-  // to the computation of the standardModuleSet.
-  //
-  if (standardModuleSet.set_in(block))
-    block = theProgram->block;
-
-  //
-  // avoid infinite recursion due to modules with mutual uses
-  //
-  if (visited.set_in(block))
-    return NULL;
-
-  if (isModuleSymbol(block->parentSymbol))
-    visited.set_add(block);
-
-  bool canSkipThisBlock = true;
-
-  VisibleFunctionBlock* vfb = visibleFunctionMap.get(block);
-  if (vfb) {
-    canSkipThisBlock = false; // cannot skip if this block defines functions
-    Vec<FnSymbol*>* fns = vfb->visibleFunctions.get(name);
-    if (fns) {
-      forv_Vec(FnSymbol, fn, *fns) {
-        if (fn->isVisible(callOrigin)) {
-          // isVisible checks if the function is private to its defining
-          // module (and in that case, if we are under its defining module)
-          // This ensures that private functions will not be used outside
-          // of their proper scope.
-          visibleFns.add(fn);
-        }
-      }
-    }
-  }
-
-  if (block->modUses) {
-    for_actuals(expr, block->modUses) {
-      UseStmt* use = toUseStmt(expr);
-      INT_ASSERT(use);
-      if (use->skipSymbolSearch(name)) {
-        continue;
-      }
-      SymExpr* se = toSymExpr(use->src);
-      INT_ASSERT(se);
-      if (ModuleSymbol* mod = toModuleSymbol(se->symbol())) {
-        // The use statement could be of an enum instead of a module, but only
-        // modules can define functions.
-        canSkipThisBlock = false; // cannot skip if this block uses modules
-        if (mod->isVisible(callOrigin)) {
-          if (use->isARename(name)) {
-            getVisibleFunctions(mod->block, use->getRename(name), visibleFns, visited, callOrigin);
-          } else {
-            getVisibleFunctions(mod->block, name, visibleFns, visited, callOrigin);
-          }
-        }
-      }
-    }
-  }
-
-  //
-  // visibilityBlockCache contains blocks that can be skipped
-  //
-  if (BlockStmt* next = visibilityBlockCache.get(block)) {
-    getVisibleFunctions(next, name, visibleFns, visited, callOrigin);
-    return (canSkipThisBlock) ? next : block;
-  }
-
-  if (block != rootModule->block) {
-    BlockStmt* next = getVisibilityBlock(block);
-    BlockStmt* cache = getVisibleFunctions(next, name, visibleFns, visited, callOrigin);
-    if (cache)
-      visibilityBlockCache.put(block, cache);
-    return (canSkipThisBlock) ? cache : block;
-  }
-
-  return NULL;
-}
-
-// Ensure 'parent' is the block before which we want to do the capturing.
-static void verifyTaskFnCall(BlockStmt* parent, CallExpr* call) {
-  if (call->isNamed("coforall_fn") || call->isNamed("on_fn")) {
-    INT_ASSERT(parent->isForLoop());
-  } else if (call->isNamed("cobegin_fn")) {
-    DefExpr* first = toDefExpr(parent->getFirstExpr());
-    // just documenting the current state
-    INT_ASSERT(first && !strcmp(first->sym->name, "_cobeginCount"));
-  } else {
-    INT_ASSERT(call->isNamed("begin_fn"));
-  }
-}
-
-//
-// Allow invoking isConstValWillNotChange() even on formals
-// with blank and 'const' intents.
-//
-static bool isConstValWillNotChange(Symbol* sym) {
-  if (ArgSymbol* arg = toArgSymbol(sym)) {
-    IntentTag cInt = concreteIntent(arg->intent, arg->type->getValType());
-    return cInt == INTENT_CONST_IN;
-  }
-  return sym->isConstValWillNotChange();
-}
-
-//
-// Returns the expression that we want to capture before.
-//
-// Why not just 'parent'? In users/shetag/fock/fock-dyn-prog-cntr.chpl,
-// we cannot do parent->insertBefore() because parent->list is null.
-// That's because we have: if ... then cobegin ..., so 'parent' is
-// immediately under CondStmt. This motivated me for cobegins to capture
-// inside of the 'parent' block, at the beginning of it.
-//
-static Expr* parentToMarker(BlockStmt* parent, CallExpr* call) {
-  if (call->isNamed("cobegin_fn")) {
-    // I want to be cute and keep _cobeginCount def and move
-    // as the first two statements in the block.
-    DefExpr* def = toDefExpr(parent->body.head);
-    INT_ASSERT(def);
-    // Just so we know what we are doing.
-    INT_ASSERT(!strcmp((def->sym->name), "_cobeginCount"));
-    CallExpr* move = toCallExpr(def->next);
-    INT_ASSERT(move);
-    SymExpr* arg1 = toSymExpr(move->get(1));
-    INT_ASSERT(arg1->symbol() == def->sym);
-    // And this is where we want to insert:
-    return move->next;
-  }
-  // Otherwise insert before 'parent'
-  return parent;
-}
-
-// map: (block id) -> (map: sym -> sym)
-typedef std::map<int, SymbolMap*> CapturedValueMap;
-static CapturedValueMap capturedValues;
-static void freeCache(CapturedValueMap& c) {
-  for (std::map<int, SymbolMap*>::iterator it = c.begin(); it != c.end(); ++it)
-    delete it->second;
-}
-
-//
-// Generate code to store away the value of 'varActual' before
-// the cobegin or the coforall loop starts. Use this value
-// instead of 'varActual' as the actual to the task function,
-// meaning (later in compilation) in the argument bundle.
-//
-// This is to ensure that all task functions use the same value
-// for their respective formal when that has an 'in'-like intent,
-// even if 'varActual' is modified between creations of
-// the multiple task functions.
-//
-static void captureTaskIntentValues(int argNum, ArgSymbol* formal,
-                                    Expr* actual, Symbol* varActual,
-                                    CallInfo& info, CallExpr* call,
-                                    FnSymbol* taskFn)
-{
-  BlockStmt* parent = toBlockStmt(call->parentExpr);
-  INT_ASSERT(parent);
-  if (taskFn->hasFlag(FLAG_ON) && !parent->isForLoop()) {
-    // coforall ... { on ... { .... }} ==> there is an intermediate BlockStmt
-    parent = toBlockStmt(parent->parentExpr);
-    INT_ASSERT(parent);
-  }
-  if (fVerify && (argNum == 0 || (argNum == 1 && taskFn->hasFlag(FLAG_ON))))
-    verifyTaskFnCall(parent, call); //assertions only
-  Expr* marker = parentToMarker(parent, call);
-  if (varActual->hasFlag(FLAG_NO_CAPTURE_FOR_TASKING)) {
-      // No need to worry about this.
-      return;
-  }
-  if (varActual->defPoint->parentExpr == parent) {
-    // Index variable of the coforall loop? Do not capture it!
-    INT_ASSERT(varActual->hasFlag(FLAG_COFORALL_INDEX_VAR));
-    return;
-  }
-  SymbolMap*& symap = capturedValues[parent->id];
-  Symbol* captemp = NULL;
-  if (symap)
-    captemp = symap->get(varActual);
-  else
-    symap = new SymbolMap();
-  if (!captemp) {
-    captemp = newTemp(astr(formal->name, "_captemp"), formal->type);
-    marker->insertBefore(new DefExpr(captemp));
-    // todo: once AMM is in effect, drop chpl__autoCopy - do straight move
-    if (hasAutoCopyForType(formal->type)) {
-      FnSymbol* autoCopy = getAutoCopy(formal->type);
-      marker->insertBefore("'move'(%S,%S(%S))", captemp, autoCopy, varActual);
-    } else if (isReferenceType(varActual->type) &&
-             !isReferenceType(captemp->type))
-      marker->insertBefore("'move'(%S,'deref'(%S))", captemp, varActual);
-    else
-      marker->insertBefore("'move'(%S,%S)", captemp, varActual);
-    symap->put(varActual, captemp);
-  }
-  actual->replace(new SymExpr(captemp));
-  Symbol*& iact = info.actuals.v[argNum];
-  INT_ASSERT(iact == varActual);
-  iact = captemp;
-}
-
-//
-// Copy the type of the actual into the type of the corresponding formal
-// of a task function. (I think resolution wouldn't make this happen
-// automatically and correctly in all cases.)
-// Also do captureTaskIntentValues() when needed.
-//
-static void handleTaskIntentArgs(CallExpr* call, FnSymbol* taskFn,
-                                 CallInfo& info)
-{
-  INT_ASSERT(taskFn);
-  if (!needsCapture(taskFn)) {
-    // A task function should have args only if it needsCapture.
-    if (taskFn->hasFlag(FLAG_ON)) {
-      // Documenting the current state: fn_on gets a chpl_localeID_t arg.
-      INT_ASSERT(call->numActuals() == 1);
-    } else {
-      INT_ASSERT(!isTaskFun(taskFn) || call->numActuals() == 0);
-    }
-    return;
-  }
-
-  int argNum = -1;
-  for_formals_actuals(formal, actual, call) {
-    argNum++;
-    SymExpr* symexpActual = toSymExpr(actual);
-    if (!symexpActual) {
-      // We add NamedExpr args in propagateExtraLeaderArgs().
-      NamedExpr* namedexpActual = toNamedExpr(actual);
-      INT_ASSERT(namedexpActual);
-      symexpActual = toSymExpr(namedexpActual->actual);
-    }
-    INT_ASSERT(symexpActual); // because of how we invoke a task function
-    Symbol* varActual = symexpActual->symbol();
-
-    // If 'call' is in a generic function, it is supposed to have been
-    // instantiated by now. Otherwise our task function has to remain generic.
-    INT_ASSERT(!varActual->type->symbol->hasFlag(FLAG_GENERIC));
-
-    // Need to copy varActual->type even for type variables.
-    // BTW some formals' types may have been set in createTaskFunctions().
-    formal->type = varActual->type;
-
-    // If the actual is a ref, still need to capture it => remove ref.
-    if (isReferenceType(varActual->type)) {
-      Type* deref = varActual->type->getValType();
-      // todo: replace needsCapture() with always resolveArgIntent(formal)
-      // then checking (formal->intent & INTENT_FLAG_IN)
-      if (needsCapture(deref)) {
-        formal->type = deref;
-        // If the formal has a ref intent, DO need a ref type => restore it.
-        resolveArgIntent(formal);
-        if (formal->intent & INTENT_FLAG_REF) {
-          formal->type = varActual->type;
-        }
-        if (varActual->isConstant()) {
-          int newIntent = formal->intent | INTENT_FLAG_CONST;
-          // and clear INTENT_FLAG_MAYBE_CONST flag
-          newIntent &= ~ INTENT_FLAG_MAYBE_CONST;
-          formal->intent = (IntentTag)(newIntent);
-        }
-      }
-    }
-
-    if (varActual->hasFlag(FLAG_TYPE_VARIABLE))
-      formal->addFlag(FLAG_TYPE_VARIABLE);
-
-    // This does not capture records/strings that are passed
-    // by blank or const intent. As of this writing (6'2015)
-    // records and strings are (incorrectly) captured at the point
-    // when the task function/arg bundle is created.
-    if (taskFn->hasFlag(FLAG_COBEGIN_OR_COFORALL) &&
-        !isConstValWillNotChange(varActual) &&
-        (concreteIntent(formal->intent, formal->type->getValType())
-         & INTENT_FLAG_IN))
-      // skip dummy_locale_arg: chpl_localeID_t
-      if (argNum != 0 || !taskFn->hasFlag(FLAG_ON))
-        captureTaskIntentValues(argNum, formal, actual, varActual, info, call,
-                                taskFn);
-  }
-
-  // Even if some formals are (now) types, if 'taskFn' remained generic,
-  // gatherCandidates() would not instantiate it, for some reason.
-  taskFn->removeFlag(FLAG_GENERIC);
-}
-
-void fillVisibleFuncVec(CallExpr* call, CallInfo &info,
-                        Vec<FnSymbol*> &visibleFns) {
-  //
-  // update visible function map as necessary
-  //
-  if (gFnSymbols.n != nVisibleFunctions) {
-    buildVisibleFunctionMap();
-  }
-
-  if (!call->isResolved()) {
-    if (!info.scope) {
-      Vec<BlockStmt*> visited;
-      getVisibleFunctions(getVisibilityBlock(call), info.name, visibleFns, visited, call);
-    } else {
-      if (VisibleFunctionBlock* vfb = visibleFunctionMap.get(info.scope)) {
-        if (Vec<FnSymbol*>* fns = vfb->visibleFunctions.get(info.name)) {
-          visibleFns.append(*fns);
-        }
-      }
-    }
-  } else {
-    visibleFns.add(call->isResolved());
-    handleTaskIntentArgs(call, call->isResolved(), info);
-  }
-
-  if ((explainCallLine && explainCallMatch(call)) ||
-      call->id == explainCallID)
-  {
-    USR_PRINT(call, "call: %s", toString(&info));
-    if (visibleFns.n == 0)
-      USR_PRINT(call, "no visible functions found");
-    bool first = true;
-    forv_Vec(FnSymbol, visibleFn, visibleFns) {
-      USR_PRINT(visibleFn, "%s %s",
-                first ? "visible functions are:" : "                      ",
-                toString(visibleFn));
-      first = false;
-    }
-  }
-}
-
-
 // Resolves a param or type expression
 static Expr*
 resolve_type_expr(Expr* expr) {
@@ -4547,15 +4101,9 @@ FnSymbol* tryResolveCall(CallExpr* call) {
 }
 
 
-static void findVisibleCandidates(CallInfo& info,
-                                  Vec<FnSymbol*>& visibleFns,
+static void findVisibleCandidates(CallInfo&                  info,
+                                  Vec<FnSymbol*>&            visibleFns,
                                   Vec<ResolutionCandidate*>& candidates) {
-
-
-  CallExpr* call = info.call;
-
-  fillVisibleFuncVec(call, info, visibleFns);
-
   gatherCandidates(candidates, visibleFns, info);
 }
 
@@ -4585,6 +4133,7 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
   Vec<ResolutionCandidate*> candidates;
 
   // First, try finding candidates without delegation
+  findVisibleFunctions(call, info, visibleFns);
   findVisibleCandidates(info, visibleFns, candidates);
 
   bool retry_find = false;
@@ -4610,6 +4159,7 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
     candidates.clear();
 
     // try again to include forwarded functions
+    findVisibleFunctions(call, info, visibleFns);
     findVisibleCandidates(info, visibleFns, candidates);
   }
 
@@ -7645,20 +7195,9 @@ void resolve() {
   freeCache(genericsCache);
   freeCache(coercionsCache);
   freeCache(promotionsCache);
-  freeCache(capturedValues);
 
-  Vec<VisibleFunctionBlock*> vfbs;
-  visibleFunctionMap.get_values(vfbs);
-  forv_Vec(VisibleFunctionBlock, vfb, vfbs) {
-    Vec<Vec<FnSymbol*>*> vfns;
-    vfb->visibleFunctions.get_values(vfns);
-    forv_Vec(Vec<FnSymbol*>, vfn, vfns) {
-      delete vfn;
-    }
-    delete vfb;
-  }
-  visibleFunctionMap.clear();
-  visibilityBlockCache.clear();
+  visibleFunctionsClear();
+
   clearPartialCopyFnMap();
 
   forv_Vec(BlockStmt, stmt, gBlockStmts) {

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -17,24 +17,25 @@
  * limitations under the License.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include "resolution.h"
 
 #include "astutil.h"
 #include "caches.h"
 #include "chpl.h"
 #include "expr.h"
+#include "resolveIntents.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "visibleFunctions.h"
 
-#include "resolveIntents.h"
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
 
 #include <cstdlib>
-#include <inttypes.h>
 
 static int             explainInstantiationLine   = -2;
 static ModuleSymbol*   explainInstantiationModule = NULL;

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -18,13 +18,14 @@
  */
 
 #include "resolution.h"
+
 #include "astutil.h"
 #include "ForLoop.h"
 #include "passes.h"
+#include "resolveIntents.h"
 #include "stlUtil.h"
 #include "stringutil.h"
-#include "resolveIntents.h"
-
+#include "visibleFunctions.h"
 
 //
 //-----------------------------------------------------------------------------

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -32,6 +32,7 @@
 #include "symbol.h"
 #include "type.h"
 #include "view.h"
+#include "visibleFunctions.h"
 
 static
 void resolveInitializer(CallExpr* call);
@@ -395,7 +396,7 @@ void resolveInitCall(CallExpr* call) {
 
   Vec<FnSymbol*> visibleFns; // visible functions
 
-  fillVisibleFuncVec(call, info, visibleFns);
+  findVisibleFunctions(call, info, visibleFns);
 
 
   // Modified narrowing down the candidates to operate in an

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -31,6 +31,7 @@
 #include "stringutil.h"
 #include "symbol.h"
 #include "typeSpecifier.h"
+#include "visibleFunctions.h"
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -32,6 +32,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "visibleFunctions.h"
 
 #include <cstdlib>
 #include <inttypes.h>

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -1,0 +1,567 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "visibleFunctions.h"
+
+#include "callInfo.h"
+#include "expr.h"
+#include "map.h"
+#include "resolution.h"
+#include "resolveIntents.h"
+#include "stmt.h"
+#include "stringutil.h"
+#include "symbol.h"
+
+#include <map>
+
+class VisibleFunctionBlock {
+public:
+                                        VisibleFunctionBlock();
+
+  Map<const char*, Vec<FnSymbol*>*>     visibleFunctions;
+};
+
+// map: (block id) -> (map: sym -> sym)
+typedef std::map<int, SymbolMap*> CapturedValueMap;
+
+static CapturedValueMap                       capturedValues;
+
+static Map<BlockStmt*, VisibleFunctionBlock*> visibleFunctionMap;
+static Map<BlockStmt*, BlockStmt*>            visibilityBlockCache;
+
+static int                                    nVisibleFunctions       = 0;
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+static void  buildVisibleFunctionMap();
+
+static void  handleTaskIntentArgs(CallExpr* call,
+                                  FnSymbol* taskFn,
+                                  CallInfo& info);
+
+static bool  isConstValWillNotChange(Symbol* sym);
+
+static void  captureTaskIntentValues(int        argNum,
+                                     ArgSymbol* formal,
+                                     Expr*      actual,
+                                     Symbol*    varActual,
+                                     CallInfo&  info,
+                                     CallExpr*  call,
+                                     FnSymbol*  taskFn);
+
+static void  verifyTaskFnCall(BlockStmt* parent, CallExpr* call);
+
+static Expr* parentToMarker(BlockStmt* parent, CallExpr* call);
+
+void findVisibleFunctions(CallExpr*       call,
+                          CallInfo&       info,
+                          Vec<FnSymbol*>& visibleFns) {
+  //
+  // update visible function map as necessary
+  //
+  if (gFnSymbols.n != nVisibleFunctions) {
+    buildVisibleFunctionMap();
+  }
+
+  if (!call->isResolved()) {
+    if (!info.scope) {
+      Vec<BlockStmt*> visited;
+
+      getVisibleFunctions(getVisibilityBlock(call), info.name, visibleFns, visited, call);
+    } else {
+      if (VisibleFunctionBlock* vfb = visibleFunctionMap.get(info.scope)) {
+        if (Vec<FnSymbol*>* fns = vfb->visibleFunctions.get(info.name)) {
+          visibleFns.append(*fns);
+        }
+      }
+    }
+  } else {
+    visibleFns.add(call->isResolved());
+    handleTaskIntentArgs(call, call->isResolved(), info);
+  }
+
+  if ((explainCallLine && explainCallMatch(call)) ||
+      call->id == explainCallID)
+  {
+    USR_PRINT(call, "call: %s", toString(&info));
+
+    if (visibleFns.n == 0)
+      USR_PRINT(call, "no visible functions found");
+
+    bool first = true;
+
+    forv_Vec(FnSymbol, visibleFn, visibleFns) {
+      USR_PRINT(visibleFn, "%s %s",
+                first ? "visible functions are:" : "                      ",
+                toString(visibleFn));
+      first = false;
+    }
+  }
+}
+
+
+
+static void buildVisibleFunctionMap() {
+  for (int i = nVisibleFunctions; i < gFnSymbols.n; i++) {
+    FnSymbol* fn = gFnSymbols.v[i];
+    if (!fn->hasFlag(FLAG_INVISIBLE_FN) && fn->defPoint->parentSymbol && !isArgSymbol(fn->defPoint->parentSymbol)) {
+      BlockStmt* block = NULL;
+      if (fn->hasFlag(FLAG_AUTO_II)) {
+        block = theProgram->block;
+      } else {
+        block = getVisibilityBlock(fn->defPoint);
+        //
+        // add all functions in standard modules to theProgram
+        //
+        // Lydia NOTE 09/12/16: The computation of the standardModuleSet is not
+        // tied to what is actually placed within theProgram->block.  As such
+        // there could be bugs where that implementation differs.  We have
+        // already encountered some with qualified access to default-included
+        // modules like List and Sort.  This implementation needs to be linked
+        // to the computation of the standardModuleSet.
+        //
+        if (standardModuleSet.set_in(block))
+          block = theProgram->block;
+      }
+      VisibleFunctionBlock* vfb = visibleFunctionMap.get(block);
+      if (!vfb) {
+        vfb = new VisibleFunctionBlock();
+        visibleFunctionMap.put(block, vfb);
+      }
+      Vec<FnSymbol*>* fns = vfb->visibleFunctions.get(fn->name);
+      if (!fns) {
+        fns = new Vec<FnSymbol*>();
+        vfb->visibleFunctions.put(fn->name, fns);
+      }
+      fns->add(fn);
+    }
+  }
+  nVisibleFunctions = gFnSymbols.n;
+}
+
+//
+// Copy the type of the actual into the type of the corresponding formal
+// of a task function. (I think resolution wouldn't make this happen
+// automatically and correctly in all cases.)
+// Also do captureTaskIntentValues() when needed.
+//
+static void handleTaskIntentArgs(CallExpr* call, FnSymbol* taskFn,
+                                 CallInfo& info)
+{
+  INT_ASSERT(taskFn);
+  if (!needsCapture(taskFn)) {
+    // A task function should have args only if it needsCapture.
+    if (taskFn->hasFlag(FLAG_ON)) {
+      // Documenting the current state: fn_on gets a chpl_localeID_t arg.
+      INT_ASSERT(call->numActuals() == 1);
+    } else {
+      INT_ASSERT(!isTaskFun(taskFn) || call->numActuals() == 0);
+    }
+    return;
+  }
+
+  int argNum = -1;
+  for_formals_actuals(formal, actual, call) {
+    argNum++;
+    SymExpr* symexpActual = toSymExpr(actual);
+    if (!symexpActual) {
+      // We add NamedExpr args in propagateExtraLeaderArgs().
+      NamedExpr* namedexpActual = toNamedExpr(actual);
+      INT_ASSERT(namedexpActual);
+      symexpActual = toSymExpr(namedexpActual->actual);
+    }
+    INT_ASSERT(symexpActual); // because of how we invoke a task function
+    Symbol* varActual = symexpActual->symbol();
+
+    // If 'call' is in a generic function, it is supposed to have been
+    // instantiated by now. Otherwise our task function has to remain generic.
+    INT_ASSERT(!varActual->type->symbol->hasFlag(FLAG_GENERIC));
+
+    // Need to copy varActual->type even for type variables.
+    // BTW some formals' types may have been set in createTaskFunctions().
+    formal->type = varActual->type;
+
+    // If the actual is a ref, still need to capture it => remove ref.
+    if (isReferenceType(varActual->type)) {
+      Type* deref = varActual->type->getValType();
+      // todo: replace needsCapture() with always resolveArgIntent(formal)
+      // then checking (formal->intent & INTENT_FLAG_IN)
+      if (needsCapture(deref)) {
+        formal->type = deref;
+        // If the formal has a ref intent, DO need a ref type => restore it.
+        resolveArgIntent(formal);
+        if (formal->intent & INTENT_FLAG_REF) {
+          formal->type = varActual->type;
+        }
+        if (varActual->isConstant()) {
+          int newIntent = formal->intent | INTENT_FLAG_CONST;
+          // and clear INTENT_FLAG_MAYBE_CONST flag
+          newIntent &= ~ INTENT_FLAG_MAYBE_CONST;
+          formal->intent = (IntentTag)(newIntent);
+        }
+      }
+    }
+
+    if (varActual->hasFlag(FLAG_TYPE_VARIABLE))
+      formal->addFlag(FLAG_TYPE_VARIABLE);
+
+    // This does not capture records/strings that are passed
+    // by blank or const intent. As of this writing (6'2015)
+    // records and strings are (incorrectly) captured at the point
+    // when the task function/arg bundle is created.
+    if (taskFn->hasFlag(FLAG_COBEGIN_OR_COFORALL) &&
+        !isConstValWillNotChange(varActual) &&
+        (concreteIntent(formal->intent, formal->type->getValType())
+         & INTENT_FLAG_IN))
+      // skip dummy_locale_arg: chpl_localeID_t
+      if (argNum != 0 || !taskFn->hasFlag(FLAG_ON))
+        captureTaskIntentValues(argNum, formal, actual, varActual, info, call,
+                                taskFn);
+  }
+
+  // Even if some formals are (now) types, if 'taskFn' remained generic,
+  // gatherCandidates() would not instantiate it, for some reason.
+  taskFn->removeFlag(FLAG_GENERIC);
+}
+
+//
+// Allow invoking isConstValWillNotChange() even on formals
+// with blank and 'const' intents.
+//
+static bool isConstValWillNotChange(Symbol* sym) {
+  if (ArgSymbol* arg = toArgSymbol(sym)) {
+    IntentTag cInt = concreteIntent(arg->intent, arg->type->getValType());
+    return cInt == INTENT_CONST_IN;
+  }
+  return sym->isConstValWillNotChange();
+}
+
+//
+// Generate code to store away the value of 'varActual' before
+// the cobegin or the coforall loop starts. Use this value
+// instead of 'varActual' as the actual to the task function,
+// meaning (later in compilation) in the argument bundle.
+//
+// This is to ensure that all task functions use the same value
+// for their respective formal when that has an 'in'-like intent,
+// even if 'varActual' is modified between creations of
+// the multiple task functions.
+//
+static void captureTaskIntentValues(int        argNum,
+                                    ArgSymbol* formal,
+                                    Expr*      actual,
+                                    Symbol*    varActual,
+                                    CallInfo&  info,
+                                    CallExpr*  call,
+                                    FnSymbol*  taskFn) {
+  BlockStmt* parent = toBlockStmt(call->parentExpr);
+  INT_ASSERT(parent);
+  if (taskFn->hasFlag(FLAG_ON) && !parent->isForLoop()) {
+    // coforall ... { on ... { .... }} ==> there is an intermediate BlockStmt
+    parent = toBlockStmt(parent->parentExpr);
+    INT_ASSERT(parent);
+  }
+  if (fVerify && (argNum == 0 || (argNum == 1 && taskFn->hasFlag(FLAG_ON))))
+    verifyTaskFnCall(parent, call); //assertions only
+  Expr* marker = parentToMarker(parent, call);
+  if (varActual->hasFlag(FLAG_NO_CAPTURE_FOR_TASKING)) {
+      // No need to worry about this.
+      return;
+  }
+  if (varActual->defPoint->parentExpr == parent) {
+    // Index variable of the coforall loop? Do not capture it!
+    INT_ASSERT(varActual->hasFlag(FLAG_COFORALL_INDEX_VAR));
+    return;
+  }
+  SymbolMap*& symap = capturedValues[parent->id];
+  Symbol* captemp = NULL;
+  if (symap)
+    captemp = symap->get(varActual);
+  else
+    symap = new SymbolMap();
+  if (!captemp) {
+    captemp = newTemp(astr(formal->name, "_captemp"), formal->type);
+    marker->insertBefore(new DefExpr(captemp));
+    // todo: once AMM is in effect, drop chpl__autoCopy - do straight move
+    if (hasAutoCopyForType(formal->type)) {
+      FnSymbol* autoCopy = getAutoCopy(formal->type);
+      marker->insertBefore("'move'(%S,%S(%S))", captemp, autoCopy, varActual);
+    } else if (isReferenceType(varActual->type) &&
+             !isReferenceType(captemp->type))
+      marker->insertBefore("'move'(%S,'deref'(%S))", captemp, varActual);
+    else
+      marker->insertBefore("'move'(%S,%S)", captemp, varActual);
+    symap->put(varActual, captemp);
+  }
+  actual->replace(new SymExpr(captemp));
+  Symbol*& iact = info.actuals.v[argNum];
+  INT_ASSERT(iact == varActual);
+  iact = captemp;
+}
+
+
+// Ensure 'parent' is the block before which we want to do the capturing.
+static void verifyTaskFnCall(BlockStmt* parent, CallExpr* call) {
+  if (call->isNamed("coforall_fn") || call->isNamed("on_fn")) {
+    INT_ASSERT(parent->isForLoop());
+  } else if (call->isNamed("cobegin_fn")) {
+    DefExpr* first = toDefExpr(parent->getFirstExpr());
+    // just documenting the current state
+    INT_ASSERT(first && !strcmp(first->sym->name, "_cobeginCount"));
+  } else {
+    INT_ASSERT(call->isNamed("begin_fn"));
+  }
+}
+
+//
+// Returns the expression that we want to capture before.
+//
+// Why not just 'parent'? In users/shetag/fock/fock-dyn-prog-cntr.chpl,
+// we cannot do parent->insertBefore() because parent->list is null.
+// That's because we have: if ... then cobegin ..., so 'parent' is
+// immediately under CondStmt. This motivated me for cobegins to capture
+// inside of the 'parent' block, at the beginning of it.
+//
+static Expr* parentToMarker(BlockStmt* parent, CallExpr* call) {
+  if (call->isNamed("cobegin_fn")) {
+    // I want to be cute and keep _cobeginCount def and move
+    // as the first two statements in the block.
+    DefExpr* def = toDefExpr(parent->body.head);
+    INT_ASSERT(def);
+    // Just so we know what we are doing.
+    INT_ASSERT(!strcmp((def->sym->name), "_cobeginCount"));
+    CallExpr* move = toCallExpr(def->next);
+    INT_ASSERT(move);
+    SymExpr* arg1 = toSymExpr(move->get(1));
+    INT_ASSERT(arg1->symbol() == def->sym);
+    // And this is where we want to insert:
+    return move->next;
+  }
+  // Otherwise insert before 'parent'
+  return parent;
+}
+
+/************************************* | **************************************
+*                                                                             *
+* Collects functions called 'name' visible in 'block' and up the visibility   *
+* chain, which is defined by getVisibilityBlock().                            *
+* The functions defined/visible in a block are given by 'visibleFunctionMap'. *
+*                                                                             *
+* 'visibilityBlockCache' maps a block to the nearest block up the visibility  *
+* chain that contains any functions, according to visibleFunctionMap.         *
+* In other words, it skips those blocks that do not define any visible        *
+* functions (of any name).                                                    *
+* Todo: some blocks only define if-functions (i.e. _if_fnNNN); such blocks    *
+* probably should not be present in visibleFunctionMap.                       *
+*                                                                             *
+* getVisibleFunctions returns the block appropriate for visibilityBlockCache  *
+* or NULL if there is none, e.g. when the next block up is the rootModule.    *
+*                                                                             *
+************************************** | *************************************/
+
+BlockStmt* getVisibleFunctions(BlockStmt*       block,
+                               const char*      name,
+                               Vec<FnSymbol*>&  visibleFns,
+                               Vec<BlockStmt*>& visited,
+                               CallExpr*        callOrigin) {
+  //
+  // all functions in standard modules are stored in a single block
+  //
+  // Lydia NOTE 09/12/16: The computation of the standardModuleSet is not
+  // tied to what is actually placed within theProgram->block.  As such
+  // there could be bugs where that implementation differs.  We have
+  // already encountered some with qualified access to default-included
+  // modules like List and Sort.  This implementation needs to be linked
+  // to the computation of the standardModuleSet.
+  //
+  if (standardModuleSet.set_in(block))
+    block = theProgram->block;
+
+  //
+  // avoid infinite recursion due to modules with mutual uses
+  //
+  if (visited.set_in(block))
+    return NULL;
+
+  if (isModuleSymbol(block->parentSymbol))
+    visited.set_add(block);
+
+  bool canSkipThisBlock = true;
+
+  VisibleFunctionBlock* vfb = visibleFunctionMap.get(block);
+  if (vfb) {
+    canSkipThisBlock = false; // cannot skip if this block defines functions
+    Vec<FnSymbol*>* fns = vfb->visibleFunctions.get(name);
+    if (fns) {
+      forv_Vec(FnSymbol, fn, *fns) {
+        if (fn->isVisible(callOrigin)) {
+          // isVisible checks if the function is private to its defining
+          // module (and in that case, if we are under its defining module)
+          // This ensures that private functions will not be used outside
+          // of their proper scope.
+          visibleFns.add(fn);
+        }
+      }
+    }
+  }
+
+  if (block->modUses) {
+    for_actuals(expr, block->modUses) {
+      UseStmt* use = toUseStmt(expr);
+      INT_ASSERT(use);
+      if (use->skipSymbolSearch(name)) {
+        continue;
+      }
+      SymExpr* se = toSymExpr(use->src);
+      INT_ASSERT(se);
+      if (ModuleSymbol* mod = toModuleSymbol(se->symbol())) {
+        // The use statement could be of an enum instead of a module, but only
+        // modules can define functions.
+        canSkipThisBlock = false; // cannot skip if this block uses modules
+        if (mod->isVisible(callOrigin)) {
+          if (use->isARename(name)) {
+            getVisibleFunctions(mod->block, use->getRename(name), visibleFns, visited, callOrigin);
+          } else {
+            getVisibleFunctions(mod->block, name, visibleFns, visited, callOrigin);
+          }
+        }
+      }
+    }
+  }
+
+  //
+  // visibilityBlockCache contains blocks that can be skipped
+  //
+  if (BlockStmt* next = visibilityBlockCache.get(block)) {
+    getVisibleFunctions(next, name, visibleFns, visited, callOrigin);
+    return (canSkipThisBlock) ? next : block;
+  }
+
+  if (block != rootModule->block) {
+    BlockStmt* next = getVisibilityBlock(block);
+    BlockStmt* cache = getVisibleFunctions(next, name, visibleFns, visited, callOrigin);
+    if (cache)
+      visibilityBlockCache.put(block, cache);
+    return (canSkipThisBlock) ? cache : block;
+  }
+
+  return NULL;
+}
+
+/************************************* | **************************************
+*                                                                             *
+* return the innermost block for searching for visible functions              *
+*                                                                             *
+************************************** | *************************************/
+
+static bool isTryTokenCond(Expr* expr);
+
+BlockStmt* getVisibilityBlock(Expr* expr) {
+  if (BlockStmt* block = toBlockStmt(expr->parentExpr)) {
+    if (block->blockTag == BLOCK_SCOPELESS)
+      return getVisibilityBlock(block);
+    else if (block->parentExpr && isTryTokenCond(block->parentExpr)) {
+      // Make the visibility block of the then and else blocks of a
+      // conditional using chpl__tryToken be the block containing the
+      // conditional statement.  Without this, there were some cases where
+      // a function gets instantiated into one side of the conditional but
+      // used in both sides, then the side with the instantiation gets
+      // folded out leaving expressions with no visibility block.
+      // test/functions/iterators/angeles/dynamic.chpl is an example that
+      // currently fails without this.
+      return getVisibilityBlock(block->parentExpr);
+    } else
+      return block;
+  } else if (expr->parentExpr) {
+    return getVisibilityBlock(expr->parentExpr);
+  } else if (Symbol* s = expr->parentSymbol) {
+      FnSymbol* fn = toFnSymbol(s);
+      if (fn && fn->instantiationPoint)
+        return fn->instantiationPoint;
+      else
+        return getVisibilityBlock(s->defPoint);
+  } else {
+    INT_FATAL(expr, "Expression has no visibility block.");
+    return NULL;
+  }
+}
+
+//
+// return true if expr is a CondStmt with chpl__tryToken as its condition
+//
+static bool isTryTokenCond(Expr* expr) {
+  CondStmt* cond = toCondStmt(expr);
+
+  if (!cond) return false;
+
+  SymExpr* sym = toSymExpr(cond->condExpr);
+
+  if (!sym) return false;
+
+  return sym->symbol() == gTryToken;
+}
+
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+void visibleFunctionsClear() {
+  Vec<VisibleFunctionBlock*> vfbs;
+
+  visibleFunctionMap.get_values(vfbs);
+
+  forv_Vec(VisibleFunctionBlock, vfb, vfbs) {
+    Vec<Vec<FnSymbol*>*> vfns;
+
+    vfb->visibleFunctions.get_values(vfns);
+
+    forv_Vec(Vec<FnSymbol*>, vfn, vfns) {
+      delete vfn;
+    }
+
+    delete vfb;
+  }
+
+  visibleFunctionMap.clear();
+
+  visibilityBlockCache.clear();
+
+  for (std::map<int, SymbolMap*>::iterator it = capturedValues.begin();
+       it != capturedValues.end();
+       ++it) {
+    delete it->second;
+  }
+}
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+VisibleFunctionBlock::VisibleFunctionBlock() {
+
+}

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -50,6 +50,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "visibleFunctions.h"
 
 //########################################################################
 //# Static Function Forward Declarations


### PR DESCRIPTION
Extract findVisibleFunctions(), nee fillVisibleFuncVec(), and its associated helpers from
functionResolution.cpp.

This touched more files than the previous two extractions; the implementation has several
extern functions that have moved between header files and so there are more updates for
include directives.

compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
passed single-locale paratest
