### PR TITLE
Broaden special-casing of mandelbrot.chpl to handle mandelbrot*.chpl

### DIFF
--- a/util/test/prediff-for-aprun-with-moab
+++ b/util/test/prediff-for-aprun-with-moab
@@ -11,7 +11,6 @@
 # variants...
 #
 if [[ "${1}" != mandelbrot* ]] ; then
-    echo "match!"
     outfile=$2
     cat $outfile | grep -v -E '.*/cray-ccm-epilogue: line .*: echo: write error: Broken pipe' > $outfile.tmp
     mv $outfile.tmp $outfile

--- a/util/test/prediff-for-aprun-with-moab
+++ b/util/test/prediff-for-aprun-with-moab
@@ -2,7 +2,16 @@
 #
 # Remove occasional mysterious warning from moab flavor of pbs.
 
-if [ "${1}" != "mandelbrot" ] ; then
+#
+# This is a really silly test which seems to be designed to dodge
+# around the fact that mandelbrot's output is binary and therefore
+# cannot easily be grepped.  It'd be more robust to see whether
+# outfile is binary or not but I'm leaving that for future generations
+# for today and am just broadening it to cover all mandelbrot*
+# variants...
+#
+if [[ "${1}" != mandelbrot* ]] ; then
+    echo "match!"
     outfile=$2
     cat $outfile | grep -v -E '.*/cray-ccm-epilogue: line .*: echo: write error: Broken pipe' > $outfile.tmp
     mv $outfile.tmp $outfile


### PR DESCRIPTION
[source of problem found by @ronawho]

This is a silly test which seems to be designed to dodge around the
fact that mandelbrot's output is binary and therefore cannot easily be
grepped.  Previously, we checked for mandelbrot.chpl.  This change
makes us check for mandelbrot*.chpl.  A better test might be to see if
outfile is binary, but unfortunately I can't afford to take more test
failures this week so am leaving a comment instead.