### PR TITLE
Refactor Perf Graphs HTML

### DIFF
--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -22,8 +22,6 @@
 
   </head>
   <body onload="perfGraphInit()">
-    <center><h2 id="titleElem"></h2></center>
-    <center><h4 id="dateElem"></h4></center>
     <script>
       <!-- hide
            function jumpto(x){
@@ -34,32 +32,40 @@
            }
            // end hide -->
     </script>
-    <table>
-      <tr>
-        <td id="graphSelectionPane" class="graphSelectionPane">
-            <p id='toggleConf'><em>Toggle configurations</em></p>
-            <p><em>Select a test suite</em></p>
-            <div id="suiteMenu"></div>
-            <p><strong>OR</strong></p>
-            <p><em>Select and display specific tests</em></p>
-            <input type="button" onclick="displaySelectedGraphs()"
-            value="Display">
-             <input type="button" onclick="clearDates()"
-            value="Clear Dates">
-            <br>
-            <input type="button" onclick="selectAllGraphs()"
-            value="Select All">
-            <input type="button" onclick="unselectAllGraphs()"
-            value="Unselect All">
-            <p>Filter: <input type="text" name="filterBox"></p>
-            <div id="graphlist" class="graphList"></div>
-          <td valign="top">
-            <div id="graphdisplay" class=graphdisplay></div>
-          </td>
-          <td id="legenddisplay" valign="top">
-        </td>
-      </tr>
-    </table>
+    <div id="graphSelectionPane">
+      <a id="homeLink"
+         class="grayButton simpleLink"
+         href="http://chapel.sourceforge.net/perf/">Home</a>
+
+      <p id='toggleConf'><em>Toggle configurations</em></p>
+      <p><em>Select a test suite</em></p>
+      <div id="suiteMenu"></div>
+
+      <p><em>Select and display specific tests</em></p>
+
+      <div id="buttonMenu">
+        <button class="grayButton" onclick="displaySelectedGraphs()">Display</button>
+        <button class="grayButton" onclick="clearDates()">Clear Dates</button>
+
+        <button class="grayButton" onclick="selectAllGraphs()">Select All</button>
+        <button class="grayButton" onclick="unselectAllGraphs()">Unselect All</button>
+      </div>
+
+      <p>Filter: <input type="text" name="filterBox"></p>
+
+      <div id="graphlist">
+        <!-- populated with checkboxes by javascript -->
+      </div>
+    </div> <!-- End of graph selection pane -->
+
+    <div id="titleDiv">
+      <center><h2 id="titleElem"></h2></center>
+      <center><h4 id="dateElem"></h4></center>
+    </div>
+
+    <div id="graphdisplay">
+      <!-- populated with graphs by javascript -->
+    </div>
 
     <script src="perfgraph.js"></script>
   </body>

--- a/util/test/perf/perfgraph.css
+++ b/util/test/perf/perfgraph.css
@@ -1,24 +1,67 @@
 body {
     font-family: "Arial";
 }
-.graphdisplay {
+
+#graphdisplay {
     margin-left: 375px;
 }
+
+#graphSelectionPane {
+    padding-left: 20px;
+    padding-right: 20px;
+    position:fixed;
+    vertical-align: top;
+    border-right: 1px solid black;
+    height: 100%;
+}
+
+#graphlist {
+    margin-top: 10px;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#titleDiv {
+  margin-bottom: 30px;
+}
+
+#homeLink {
+  margin-left: 10px;
+  margin-top: 10px;
+  font-size: 20px;
+}
+
+#buttonMenu {
+  width: 75%;
+}
+#buttonMenu .grayButton {
+  min-width: 80px;
+}
+
 .graph {
     vertical-align: top;
     white-space: nowrap;
     font-size: 11px;
 }
+div.graphContainer {
+  /* width of graph + legend */
+  width: 1100px;
+  display: inline-block;
+}
 div.perfGraph {
     vertical-align: top;
     width: 700px;
     height: 300px;
+    float: left;
 }
 div.gspacer {
+    display: inline-block;
     width: 700px;
     height: 30px;
+    margin-bottom: 20px;
 }
 div.perfLegend {
+    float:left;
     vertical-align: top;
     width: 400px;
     height: 300px;
@@ -27,29 +70,46 @@ div.perfLegend {
 span.highlight {
     border: 1px solid grey;
 }
-div.lspacer {
-    width: 400px;
-    height: 30px;
-}
-.graphSelectionPane {
-    padding-left: 20px;
-    padding-right: 20px;
-    position:fixed;
-    vertical-align: top;
-    border-right: 1px solid black;
-}
-.graphList {
-    margin-top: 10px;
-    overflow-y: auto;
-    overflow-x: hidden;
-}
+
 .toggle {
     height: 20px;
     border: 1px solid grey;
     padding: 0px 5px;
     margin: 5px 10px 0px 0px;
 }
+.toggle:focus {
+  outline: 0;
+}
+
 .blackAnnotation {
   color: black !important;
   border-color: black !important;
+}
+
+.grayButton {
+  background-color: #d8d8d8;
+  border: 1px solid black;
+  font-size: 13px;
+  text-align: center;
+  padding: 3px 3px;
+  margin: 2px;
+}
+
+.grayButton:hover {
+  background-color: #b7b8bc;
+}
+.grayButton:active {
+  transform: scale(.9);
+}
+.grayButton:focus {
+  outline: 0;
+}
+
+.simpleLink {
+  color: black;
+  text-decoration: none;
+}
+.simpleLink:visited {
+  color: black;
+  text-decoration: none;
 }


### PR DESCRIPTION
This commit is primarily a refactoring and cleanup of the HTML and CSS
we use for our performance graphs. The main refactoring changes are:
- Get rid of tables in index.html
- use CSS IDs over classes when possible
- Eliminate 'legenddisplay' and use a container div for graphs

Some new additions are:
- 'Home' button in upper left corner
- New style for existing buttons in graph selection pane
- alt-text for graph pane checkboxes

As a result, the HTML and Javascript are simpler and easier to modify.