### PR TITLE
Add time-graph for synch_p2p and clean up PRK graphs

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -170,9 +170,11 @@ studies/isx/isx-per-task.graph
 release/examples/benchmarks/isx/isx-release.graph
 # suite: PRK benchmarks
 studies/prk/synch_p2p/prk-synch_p2p.graph
+studies/prk/synch_p2p/prk-synch_p2p-time.graph
 studies/prk/stencil/prk-stencil.graph
 studies/prk/stencil/prk-stencil-time.graph
 studies/prk/transpose/prk-transpose.graph
+studies/prk/transpose/prk-transpose-time.graph
 # suite: NAS Parallel benchmarks
 npb/cg/cg.graph
 npb/cg/cg-a.graph

--- a/test/studies/prk/stencil/prk-stencil-time.graph
+++ b/test/studies/prk/stencil/prk-stencil-time.graph
@@ -3,4 +3,3 @@ files: stencil-defaultdist.dat, stencil-blockdist.dat, stencil-stencildist.dat, 
 graphkeys: DefaultDist, BlockDist, StencilDist, Serial
 graphtitle: PRK stencil time
 ylabel: Time (seconds)
-graphname: prk-stencil-time

--- a/test/studies/prk/stencil/prk-stencil.graph
+++ b/test/studies/prk/stencil/prk-stencil.graph
@@ -3,4 +3,3 @@ files: stencil-defaultdist.dat, stencil-blockdist.dat, stencil-stencildist.dat, 
 graphkeys: DefaultDist, BlockDist, StencilDist, Serial
 graphtitle: PRK stencil
 ylabel: Rate (MFlops/s)
-graphname: prk-stencil

--- a/test/studies/prk/stencil/prk-stencil.ml-perf.graph
+++ b/test/studies/prk/stencil/prk-stencil.ml-perf.graph
@@ -3,4 +3,3 @@ files: stencil-blockdist.dat, stencil-stencildist.dat
 graphkeys: blockdist, stencildist
 graphtitle: PRK stencil
 ylabel: Rate (MFlops/s)
-graphname: prk-stencil

--- a/test/studies/prk/synch_p2p/prk-synch_p2p-time.graph
+++ b/test/studies/prk/synch_p2p/prk-synch_p2p-time.graph
@@ -3,4 +3,3 @@ files: p2p-serial-fast.dat
 graphkeys: serial-fast
 graphtitle: PRK synch_p2p time
 ylabel: Time (seconds)
-graphname: prk-synch_p2p-time

--- a/test/studies/prk/synch_p2p/prk-synch_p2p-time.graph
+++ b/test/studies/prk/synch_p2p/prk-synch_p2p-time.graph
@@ -1,0 +1,6 @@
+perfkeys: Avg time (s):
+files: p2p-serial-fast.dat
+graphkeys: serial-fast
+graphtitle: PRK synch_p2p time
+ylabel: Time (seconds)
+graphname: prk-synch_p2p-time

--- a/test/studies/prk/synch_p2p/prk-synch_p2p.graph
+++ b/test/studies/prk/synch_p2p/prk-synch_p2p.graph
@@ -1,8 +1,5 @@
 perfkeys: Rate (MFlops/s): 
 files: p2p-serial-fast.dat
 graphkeys: serial-fast
-graphtitle: synch_p2p
+graphtitle: PRK synch_p2p
 ylabel: Rate (MFlops/s)
-graphname: prk-synch_p2p
-
-

--- a/test/studies/prk/transpose/prk-transpose-time.graph
+++ b/test/studies/prk/transpose/prk-transpose-time.graph
@@ -1,0 +1,5 @@
+perfkeys: Avg time (s):, Avg time (s):
+files: ./transpose-serial.dat, ./transpose-defaultdist.dat
+graphkeys: Serial, DefaultDist
+graphtitle: PRK transpose time
+ylabel: Time (seconds)

--- a/test/studies/prk/transpose/prk-transpose.graph
+++ b/test/studies/prk/transpose/prk-transpose.graph
@@ -3,4 +3,3 @@ files: ./transpose-serial.dat, ./transpose-defaultdist.dat
 graphkeys: Serial, DefaultDist
 graphtitle: PRK transpose
 ylabel: Rate (MB/s)
-graphname: prk-stencil


### PR DESCRIPTION
- Add time-graph for synch_p2p and transpose
- Make graphtitles consistent
- Remove deprecated `graphname` field from PRK graph files
- Update `GRAPHFILES`

**Testing**
- [X] Double checking a `start_test --performance` works...
- [X] `check_annotations.py`
    - `No fatal annotation errors detected`