### PR TITLE
Minor adjustments to entry to visibleCandidates.cpp

### DIFF
--- a/compiler/include/visibleCandidates.h
+++ b/compiler/include/visibleCandidates.h
@@ -36,8 +36,8 @@ void      findVisibleCandidates(CallInfo&                  info,
 
 void      resolveTypedefedArgTypes(FnSymbol* fn);
 
-FnSymbol* expandVarArgs(FnSymbol* origFn,
-                        int       numActuals);
+FnSymbol* expandIfVarArgs(FnSymbol* origFn,
+                          int       numActuals);
 
 void      substituteVarargTupleRefs(BlockStmt*               ast,
                                     int                      numArgs,

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -158,7 +158,7 @@ static void
 filterInitConcreteCandidate(Vec<ResolutionCandidate*>& candidates,
                             ResolutionCandidate* currCandidate,
                             CallInfo& info) {
-  currCandidate->fn = expandVarArgs(currCandidate->fn, info.actuals.n);
+  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info.actuals.n);
 
   if (!currCandidate->fn) return;
 
@@ -187,7 +187,7 @@ static void
 filterInitGenericCandidate(Vec<ResolutionCandidate*>& candidates,
                            ResolutionCandidate* currCandidate,
                            CallInfo& info) {
-  currCandidate->fn = expandVarArgs(currCandidate->fn, info.actuals.n);
+  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info.actuals.n);
 
   if (!currCandidate->fn) return;
 


### PR DESCRIPTION
This simple PR performs some minor cleanup or the "filterCandidates" portion of
visibleCandidates.cpp

1) Rename expandVarArgs() to be expandIfVarArgs() so that it is more obvious, at the call sites,
when a function is being transformed.

2) Most of the helper functions for findVisibleCandidates() use a different, and less conventional,
arglist than findVisibleCandidates() itself.  Convert the helpers to match the entry point.

3) I puzzelled over doGatherCandidates() for a little while.  The control flow was more convoluted
than necessary and I wasn't clear what the test based on methodTag was for.  I moved some
debug logic from the body of doGatherCandidates() to the body of the version of visibleCandidate()
(Note doGatherCandidates is the only caller for this variation).  This made it easy to re-write the
control flow and then I added a large comment to help explain the remaining business logic

4) Some other minor tweaks

Compiled with/without CHPL_DEVELOPER on clang/darwin with C++14 mode enabled, and
on gcc/linux64.

Passed a single-locale paratest
