### PR TITLE
Continued small updates to visibleCandidates

### DIFF
--- a/compiler/include/visibleCandidates.h
+++ b/compiler/include/visibleCandidates.h
@@ -36,8 +36,8 @@ void      findVisibleCandidates(CallInfo&                  info,
 
 void      resolveTypedefedArgTypes(FnSymbol* fn);
 
-FnSymbol* expandIfVarArgs(FnSymbol* origFn,
-                          int       numActuals);
+FnSymbol* expandIfVarArgs(FnSymbol* fn,
+                          CallInfo& info);
 
 void      substituteVarargTupleRefs(BlockStmt*               ast,
                                     int                      numArgs,

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -158,7 +158,7 @@ static void
 filterInitConcreteCandidate(Vec<ResolutionCandidate*>& candidates,
                             ResolutionCandidate* currCandidate,
                             CallInfo& info) {
-  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info.actuals.n);
+  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info);
 
   if (!currCandidate->fn) return;
 
@@ -187,7 +187,7 @@ static void
 filterInitGenericCandidate(Vec<ResolutionCandidate*>& candidates,
                            ResolutionCandidate* currCandidate,
                            CallInfo& info) {
-  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info.actuals.n);
+  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info);
 
   if (!currCandidate->fn) return;
 

--- a/compiler/resolution/visibleCandidates.cpp
+++ b/compiler/resolution/visibleCandidates.cpp
@@ -186,7 +186,7 @@ static void filterCandidate(CallInfo&                  info,
 static void filterConcrete(CallInfo&                  info,
                            ResolutionCandidate*       currCandidate,
                            Vec<ResolutionCandidate*>& candidates) {
-  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info.actuals.n);
+  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info);
 
   if (currCandidate->fn != NULL) {
     resolveTypedefedArgTypes(currCandidate->fn);
@@ -290,7 +290,7 @@ static void resolveTypeConstructor(CallInfo& info, FnSymbol* fn) {
 static void filterGeneric(CallInfo&                  info,
                           ResolutionCandidate*       currCandidate,
                           Vec<ResolutionCandidate*>& candidates) {
-  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info.actuals.n);
+  currCandidate->fn = expandIfVarArgs(currCandidate->fn, info);
 
   if (currCandidate->fn                     != NULL &&
       currCandidate->computeAlignment(info) == true &&
@@ -328,7 +328,8 @@ static bool needVarArgTupleAsWhole(BlockStmt* ast,
                                    int        numArgs,
                                    ArgSymbol* formal);
 
-FnSymbol* expandIfVarArgs(FnSymbol* origFn, int numActuals) {
+FnSymbol* expandIfVarArgs(FnSymbol* origFn, CallInfo& info) {
+  int       numActuals     = info.actuals.n;
   bool      genericArgSeen = false;
   FnSymbol* workingFn      = origFn;
 


### PR DESCRIPTION
This simple PR begins to update the logic for expandVarArgs().

A. Rename the external uses of this function to be expandIfVarArgs() so that it is more
obvious, at the call sites, that this is a conditional update to the function that is being
processed.


B. expandIfVarArgs() maintains a cache that maps user-defined functions to the expanded
version of the function.  Before this PR *every* function in the code base was inserted in
to the cache.  After this PR only functions with varargs are inserted.  It is unlikely that this
will result in an observable performance difference, especially for the first implementation
of this change, but it makes the intent clearer and supports possible future enhancements.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed a single-locale paratest
