### PR TITLE
Fix date parsing in perf graphs

### DIFF
--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -14,6 +14,7 @@
         <![endif]-->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/datejs/1.0/date.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.0.0/dygraph.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.0.0/dygraph.min.css" />


### PR DESCRIPTION
Use datejs third-party library to parse dates instead of native Date.parse