### PR TITLE
Spit-and-polish for Elliot's chameneos

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -25,16 +25,19 @@ const colors10 = [blue, red, yellow, red, yellow, blue, red, yellow, red, blue];
 proc main() {
   printColorEquations();
 
-  const group1 = new Population(popSize1);
-  const group2 = new Population(popSize2);
+  const group1 = [i in 1..popSize1] new Chameneos(i, ((i-1)%3):Color);
+  const group2 = [i in 1..popSize2] new Chameneos(i, colors10[i]);
 
   cobegin {
-    group1.holdMeetings(n);
-    group2.holdMeetings(n);
+    holdMeetings(group1, n);
+    holdMeetings(group2, n);
   }
 
-  group1.print();
-  group2.print();
+  print(group1);
+  print(group2);
+
+  for c in group1 do delete c;
+  for c in group2 do delete c;
 }
 
 
@@ -50,57 +53,35 @@ proc printColorEquations() {
 
 
 //
-// a chameneos population
+// Hold meetings among the population by creating a shared meeting
+// place, and then creating per-chameneos tasks to have meetings.
 //
-record Population {
-  const size = 0;   // the size of the population
+proc holdMeetings(chameneos, numMeetings) {
+  const place = new MeetingPlace(numMeetings);
 
-  //
-  // an array of chameneos objects representing the population
-  //
-  var chameneos = [i in 1..size]
-                    new Chameneos(i, if size == 10 then colors10[i]
-                                                   else ((i-1)%3): Color);
+  coforall c in chameneos do           // create a task per chameneos
+    c.haveMeetings(place, chameneos);
 
-  //
-  // Hold meetings among the population by creating a shared meeting
-  // place, and then creating per-chameneos tasks to have meetings.
-  //
-  proc holdMeetings(numMeetings) {
-    const place = new MeetingPlace(numMeetings);
+  delete place;
+}
 
-    coforall c in chameneos do           // create a task per chameneos
-      c.haveMeetings(place, chameneos);
-
-    delete place;
+//
+// Print the chameneos' initial colors, the number of meetings each
+// had, and the number of self-meetings each had (spelled out).
+// Then spell out the total number of meetings for the population
+//
+proc print(chameneos) {
+  for c in chameneos do
+    write(" ", c.initialColor);
+  writeln();
+  
+  for c in chameneos {
+    write(c.meetings);
+    spellInt(c.meetingsWithSelf);
   }
-
-  //
-  // Print the chameneos' initial colors, the number of meetings each
-  // had, and the number of self-meetings each had (spelled out).
-  // Then spell out the total number of meetings for the population
-  //
-  proc print() {
-    for c in chameneos do
-      write(" ", c.initialColor);
-    writeln();
-
-    for c in chameneos {
-      write(c.meetings);
-      spellInt(c.meetingsWithSelf);
-    }
     
-    spellInt(+ reduce chameneos.meetings);
-    writeln();
-  }
-
-  //
-  // Delete the chameneos objects.
-  //
-  proc deinit() {
-    for c in chameneos do
-      delete c;
-  }
+  spellInt(+ reduce chameneos.meetings);
+  writeln();
 }
 
 

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -56,11 +56,11 @@ proc printColorEquations() {
 // Hold meetings among the population by creating a shared meeting
 // place, and then creating per-chameneos tasks to have meetings.
 //
-proc holdMeetings(chameneos, numMeetings) {
+proc holdMeetings(population, numMeetings) {
   const place = new MeetingPlace(numMeetings);
 
-  coforall c in chameneos do           // create a task per chameneos
-    c.haveMeetings(place, chameneos);
+  coforall c in population do           // create a task per chameneos
+    c.haveMeetings(place, population);
 
   delete place;
 }
@@ -70,17 +70,17 @@ proc holdMeetings(chameneos, numMeetings) {
 // had, and the number of self-meetings each had (spelled out).
 // Then spell out the total number of meetings for the population
 //
-proc print(chameneos) {
-  for c in chameneos do
+proc print(population) {
+  for c in population do
     write(" ", c.initialColor);
   writeln();
   
-  for c in chameneos {
+  for c in population {
     write(c.meetings);
     spellInt(c.meetingsWithSelf);
   }
     
-  spellInt(+ reduce chameneos.meetings);
+  spellInt(+ reduce population.meetings);
   writeln();
 }
 

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -14,11 +14,14 @@ config const n = 600,              // number of meetings (must be >= 0)
 enum Color {blue=0, red, yellow};  // the chameneos colors
 use Color;                         // permit unqualified references to them
 
+//
 // special colors to use for a chameneos population of size 10
+//
 const colors10 = [blue, red, yellow, red, yellow, blue, red, yellow, red, blue];
 
-
+//
 // Print the color equations and simulate the two population sizes.
+//
 proc main() {
   printColorEquations();
 

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -74,12 +74,12 @@ proc print(population) {
   for c in population do
     write(" ", c.initialColor);
   writeln();
-  
+
   for c in population {
     write(c.meetings);
     spellInt(c.meetingsWithSelf);
   }
-    
+
   spellInt(+ reduce population.meetings);
   writeln();
 }
@@ -117,7 +117,7 @@ class Chameneos {
         // participant:
         // - If we're the first to arrive, leave the number of
         //   meetings unchanged and store our ID
-        // - Otherwise, we're the second to arrive, so decrement 
+        // - Otherwise, we're the second to arrive, so decrement
         //   the number of meetings and reset the ID to zero.
         //
         if place.attemptToStore(currentState,

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -7,17 +7,10 @@
 */
 
 config const n = 600,              // number of meetings (must be >= 0)
-             popSize1 = 3,         // size of population 1 (must be > 1)
-             popSize2 = 10,        // size of population 2 (must be > 1)
              spinLimit = 15;       // number of times to spin before yielding
 
 enum Color {blue=0, red, yellow};  // the chameneos colors
 use Color;                         // permit unqualified references to them
-
-//
-// special colors to use for a chameneos population of size 10
-//
-const colors10 = [blue, red, yellow, red, yellow, blue, red, yellow, red, blue];
 
 //
 // Print the color equations and simulate the two population sizes.
@@ -25,8 +18,9 @@ const colors10 = [blue, red, yellow, red, yellow, blue, red, yellow, red, blue];
 proc main() {
   printColorEquations();
 
-  const group1 = new Population(popSize1);
-  const group2 = new Population(popSize2);
+  const group1 = new Population([blue, red, yellow]);
+  const group2 = new Population([blue, red, yellow, red, yellow,
+                                 blue, red, yellow, red, blue]);
 
   cobegin {
     group1.holdMeetings(n);
@@ -53,14 +47,12 @@ proc printColorEquations() {
 // a chameneos population
 //
 record Population {
-  const size = 0;   // the size of the population
+  var colors;
 
   //
   // an array of chameneos objects representing the population
   //
-  var chameneos = [i in 1..size]
-                    new Chameneos(i, if size == 10 then colors10[i]
-                                                   else ((i-1)%3): Color);
+  var chameneos = [i in colors.domain] new Chameneos(i, colors[i]);
 
   //
   // Hold meetings among the population by creating a shared meeting
@@ -89,7 +81,7 @@ record Population {
       write(c.meetings);
       spellInt(c.meetingsWithSelf);
     }
-    
+
     spellInt(+ reduce chameneos.meetings);
     writeln();
   }
@@ -136,7 +128,7 @@ class Chameneos {
         // participant:
         // - If we're the first to arrive, leave the number of
         //   meetings unchanged and store our ID
-        // - Otherwise, we're the second to arrive, so decrement 
+        // - Otherwise, we're the second to arrive, so decrement
         //   the number of meetings and reset the ID to zero.
         //
         if place.attemptToStore(currentState,

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -47,7 +47,7 @@ proc printColorEquations() {
 // a chameneos population
 //
 record Population {
-  var colors;
+  var colors;  // the colors of the chameneos in the population
 
   //
   // an array of chameneos objects representing the population

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -1,17 +1,23 @@
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 
-   contributed by Hannah Hemmaplardh, Lydia Duncan, and Brad Chamberlain
+   contributed by Hannah Hemmaplardh, Lydia Duncan, Brad Chamberlain,
+     and Elliot Ronaghan
    derived in part from the GNU C version by Dmitry Vyukov
 */
 
 config const n = 600,              // number of meetings (must be >= 0)
              popSize1 = 3,         // size of population 1 (must be > 1)
-             popSize2 = 10;        // size of population 2 (must be > 1)
+             popSize2 = 10,        // size of population 2 (must be > 1)
+             spinLimit = 15;       // number of times to spin before yielding
 
 enum Color {blue=0, red, yellow};  // the chameneos colors
 use Color;                         // permit unqualified references to them
 
+//
+// special colors to use for a chameneos population of size 10
+//
+const colors10 = [blue, red, yellow, red, yellow, blue, red, yellow, red, blue];
 
 //
 // Print the color equations and simulate the two population sizes.
@@ -27,12 +33,8 @@ proc main() {
     group2.holdMeetings(n);
   }
 
-  group1.printColors();
-  group1.printNotes();
-
-  group2.printColors();
-  group2.printNotes();
-
+  group1.print();
+  group2.print();
 }
 
 
@@ -48,11 +50,6 @@ proc printColorEquations() {
 
 
 //
-// special colors to use for a chameneos population of size 10
-//
-const colors10 = [blue, red, yellow, red, yellow, blue, red, yellow, red, blue];
-
-//
 // a chameneos population
 //
 record Population {
@@ -64,15 +61,6 @@ record Population {
   var chameneos = [i in 1..size]
                     new Chameneos(i, if size == 10 then colors10[i]
                                                    else ((i-1)%3): Color);
-
-  //
-  // Print the initial colors of the population.
-  //
-  proc printColors() {
-    for c in chameneos do
-      write(" ", c.initialColor);
-    writeln();
-  }
 
   //
   // Hold meetings among the population by creating a shared meeting
@@ -88,12 +76,15 @@ record Population {
   }
 
   //
-  // Print notes about the meetings by having each chameneos print the
-  // number of meetings it had and spell out the number of
-  // self-meetings it had.  Then spell out the total number of
-  // meetings for the population.
+  // Print the chameneos' initial colors, the number of meetings each
+  // had, and the number of self-meetings each had (spelled out).
+  // Then spell out the total number of meetings for the population
   //
-  proc printNotes() {
+  proc print() {
+    for c in chameneos do
+      write(" ", c.initialColor);
+    writeln();
+
     for c in chameneos {
       write(c.meetings);
       spellInt(c.meetingsWithSelf);
@@ -169,13 +160,12 @@ class Chameneos {
   // to become 'true' and then resetting it to 'false'.
   //
   proc waitForMeetingToEnd() {
-    var spin_count = 15;
+    var spinCount = spinLimit;
     while meetingCompleted.read() == false {
-      if spin_count {
-        spin_count -= 1;
-      } else {
+      if spinCount then
+        spinCount -= 1;
+      else
         chpl_task_yield();
-      }
     }
     meetingCompleted.write(false);
   }


### PR DESCRIPTION
Here, I made proposed changes for a next version of chameneos-redux to my study version, in approximate order of importance:

I wouldn't expect this to result in any behavioral or performance changes relative to Elliot's version -- it's mostly just code cleanup and organization.

* added Elliot's name to the byline due to his work in tuning it
* made spin limit into a config
* combined two print routines into one now that they're called consecutively
* removed 'Population' record which I think is arguably less useful now that main() has to do more juggling of the populations manually.  Moved contents either inline or into standalone procs
* hoisted colors10 to the top as a result and/or because it seems more "global"
* changed from underscores to camelCase
* removed some curly brackets from a simple if-then-else

I also updated Elliot's version (with his permission) to include all of these changes other than the removal of Population so that we could weigh the stylistic impacts on main() vs. having the record.  As part of this, we ended up simplifying the interface to Population to take a color array, removed the population size configs (because they're not really all that flexible anyway), and introducing a 'colors' field to the constructor in order to be able to set up the population properly.  (We tried adding an initializer to avoid having to store the colors field, but this ran afoul of issue #5935)