### PR TITLE
Simplify visibleFunctions

### DIFF
--- a/compiler/include/visibleFunctions.h
+++ b/compiler/include/visibleFunctions.h
@@ -28,15 +28,12 @@ class CallInfo;
 class Expr;
 class FnSymbol;
 
-void       findVisibleFunctions(CallExpr*       call,
-                                CallInfo&       info,
+void       findVisibleFunctions(CallInfo&       info,
                                 Vec<FnSymbol*>& visibleFns);
 
-BlockStmt* getVisibleFunctions(BlockStmt*       block,
-                               const char*      name,
-                               Vec<FnSymbol*>&  visibleFns,
-                               Vec<BlockStmt*>& visited,
-                               CallExpr*        callOrigin);
+void       getVisibleFunctions(const char*      name,
+                               CallExpr*        call,
+                               Vec<FnSymbol*>&  visibleFns);
 
 BlockStmt* getVisibilityBlock(Expr* expr);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3341,7 +3341,7 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
   Vec<ResolutionCandidate*> candidates;
 
   // First, try finding candidates without delegation
-  findVisibleFunctions(call, info, visibleFns);
+  findVisibleFunctions (info, visibleFns);
   findVisibleCandidates(info, visibleFns, candidates);
 
   bool retry_find = false;
@@ -3367,7 +3367,7 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
     candidates.clear();
 
     // try again to include forwarded functions
-    findVisibleFunctions(call, info, visibleFns);
+    findVisibleFunctions (info, visibleFns);
     findVisibleCandidates(info, visibleFns, candidates);
   }
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -397,7 +397,7 @@ void resolveInitCall(CallExpr* call) {
 
   Vec<FnSymbol*> visibleFns; // visible functions
 
-  findVisibleFunctions(call, info, visibleFns);
+  findVisibleFunctions(info, visibleFns);
 
 
   // Modified narrowing down the candidates to operate in an

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1031,13 +1031,8 @@ static Expr* createFunctionAsValue(CallExpr *call) {
   const char*        flname = use->unresolved;
 
   Vec<FnSymbol*>     visibleFns;
-  Vec<BlockStmt*>    visited;
 
-  getVisibleFunctions(getVisibilityBlock(call),
-                      flname,
-                      visibleFns,
-                      visited,
-                      call);
+  getVisibleFunctions(flname, call, visibleFns);
 
   if (visibleFns.n > 1) {
     USR_FATAL(call, "%s: can not capture overloaded functions as values",


### PR DESCRIPTION
This trivial PR makes two minor updates to visibleFunctions

1. Simplify the "public API" to this "module".

2. Convert an internal use of Vec to std::set and do some "whitespace" cleanup
in the affected function.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Also compiled with std=C++14 on clang.

Passed a single-locale paratest.
