### PR TITLE
Fix regex-redux .dat filename for release

### DIFF
--- a/test/release/examples/benchmarks/shootout/regexdna-redux.perfkeys
+++ b/test/release/examples/benchmarks/shootout/regexdna-redux.perfkeys
@@ -1,4 +1,4 @@
-# file: regexdnaredux-submitted.dat
+# file: regexdnaredux-release.dat
 real
 verify:agggtaa\[cgt\]|\[acg\]ttaccct 2178
 verify:50833411


### PR DESCRIPTION
Once I got the submitted regex-redux working, I copied its files
over to the release, failing to update the .dat filename specified
in the .perfkeys file.

(I don't think I realized .dat filenames could be specified in both
.perfexecopts and in .perfkeys, and didn't think to look for it here
in any case since each version had a unique name...)