### PR TITLE
Fine-tune Elliot's chameneos

### DIFF
--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -47,12 +47,14 @@ proc printColorEquations() {
 // a chameneos population
 //
 record Population {
-  var colors;  // the colors of the chameneos in the population
+  var chamSpace: domain(1);
+  var chameneos: [chamSpace] Chameneos;
 
-  //
-  // an array of chameneos objects representing the population
-  //
-  var chameneos = [i in colors.domain] new Chameneos(i, colors[i]);
+  proc Population(colors) {
+    chamSpace = colors.domain;
+    forall i in chamSpace do
+      chameneos[i] = new Chameneos(i, colors[i]);
+  }
 
   //
   // Hold meetings among the population by creating a shared meeting
@@ -89,7 +91,7 @@ record Population {
   //
   // Delete the chameneos objects.
   //
-  proc deinit {
+  proc ~Population {
     for c in chameneos do
       delete c;
   }

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -47,9 +47,15 @@ proc printColorEquations() {
 // a chameneos population
 //
 record Population {
+  //
+  // a domain and array representing the chameneos in this population
+  //
   const chamSpace: domain(1),
         chameneos: [chamSpace] Chameneos;
 
+  //
+  // construct the population in terms of an array of colors passed in
+  //
   proc Population(colors) {
     chamSpace = colors.domain;
     forall i in chamSpace do

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -47,8 +47,8 @@ proc printColorEquations() {
 // a chameneos population
 //
 record Population {
-  var chamSpace: domain(1);
-  var chameneos: [chamSpace] Chameneos;
+  const chamSpace: domain(1),
+        chameneos: [chamSpace] Chameneos;
 
   proc Population(colors) {
     chamSpace = colors.domain;


### PR DESCRIPTION
Something about last night's changes (the storage of 'color' as a field
of 'Population'?) made Elliot's chameneos perform much more poorly than
it had been.  Here, I remove the color field, replacing it with a
constructor (I tried to use an initializer but ran afoul of issue #5935).
The constructor-based approach seemed to require the declaration of a
domain field as well -- i.e., I couldn't find a way to simply make
'chameneos' generic and have the constructor resolve.  I also changed
the deinitializer to a destructor for symmtry.

This version seems to be going faster than it has before, and faster
than my variation as well.  Unfortunately, it relies on
constructors/destructors which will be going away soon, so will need
to be updated in the future.