### PR TITLE
Fix diff-ignoring-module-line-numbers for pre-release versions

### DIFF
--- a/util/test/diff-ignoring-module-line-numbers
+++ b/util/test/diff-ignoring-module-line-numbers
@@ -15,7 +15,7 @@ tmptmp=`mktemp "tmp.XXXXXX"`
 
 command='
   \|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/
-  s/chpl Version [0-9a-f.-]*$/chpl Version mmmm/
+  s/chpl Version [0-9]*.*$/chpl Version mmmm/
   s/internal error: \([A-Z][A-Z][A-Z]\)[0-9][0-9][0-9][0-9] chpl Version mmmm/internal error: \1nnnn chpl Version mmmm/
 '
 


### PR DESCRIPTION
diff-ignoring-module-line-numbers needed to be updated now that
non-release version strings went from

```
 chpl Version 1.15.0.c3577ca
```
to

```
 chpl Version 1.16.0 pre-release (a8b04f4)
```
Instead of continuing to change diff-ignoring-module-line-numbers as the
version string format changes, I opted to simply consider the rest of the
line beyond "chpl Version " to be the version number.  It still does
check for a digit 0-9 as the first character of the version number.

Passed local -futures testing.