### PR TITLE
Fix cross-references and readThis/writeThis docs

### DIFF
--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -163,15 +163,15 @@ Default ``readThis`` methods are created for all types for which a user-defined
 ``readThis`` method is not provided.  The default ``readThis`` methods are
 defined to read in the output of the default ``writeThis`` method.
 
-Additionally, the Chapel implementation includes ``writeThis`` or methods for
+Additionally, the Chapel implementation includes ``writeThis`` methods for
 built-in types as follows:
 
 * for an array: outputs the elements of the array in row-major order
   where rows are separated by line-feeds and blank lines are used to separate
   other dimensions.
-* for a `domain`: outputs the dimensions of the domain enclosed by
+* for a domain: outputs the dimensions of the domain enclosed by
   ``{`` and ``}``.
-* for a `range`: output the lower bound of the range, output ``..``,
+* for a range: output the lower bound of the range, output ``..``,
   then output the upper bound of the range.  If the stride of the range
   is not ``1``, output the word ``by`` and then the stride of the range.
   If the range has special alignment, output the word ``align`` and then the

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -57,6 +57,8 @@ a pair of variables ``x`` and ``y``.
   /* reading via multiple type arguments */
   (x, y) = read(int, real);
 
+.. _readThis-writeThis-readWriteThis:
+
 The readThis(), writeThis(), and readWriteThis() Methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -141,24 +143,15 @@ function resolution error if the class NoRead is read.
 
   delete nr;
 
-.. _default-write-and-read-methods:
+.. _default-readThis-writeThis:
 
-Default write and read Methods
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Default writeThis and readThis Methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default ``write`` methods are created for all types for which a user-defined
-``write`` method is not provided.  They have the following semantics:
+Default ``writeThis`` methods are created for all types for which a user-defined
+``writeThis`` or ``readWriteThis`` method is not provided.  They have the
+following semantics:
 
-* for an array argument: outputs the elements of the array in row-major order
-  where rows are separated by line-feeds and blank lines are used to separate
-  other dimensions.
-* for a `domain` argument: outputs the dimensions of the domain enclosed by
-  ``[`` and ``]``.
-* for a `range` argument: output the lower bound of the range, output ``..``,
-  then output the upper bound of the range.  If the stride of the range
-  is not ``1``, output the word ``by`` and then the stride of the range.
-* for a tuples, outputs the components of the tuple in order delimited by ``(``
-  and ``)``, and separated by commas.
 * for a class: outputs the values within the fields of the class prefixed by
   the name of the field and the character ``=``.  Each field is separated by a
   comma.  The output is delimited by ``{`` and ``}``.
@@ -166,9 +159,29 @@ Default ``write`` methods are created for all types for which a user-defined
   the name of the field and the character ``=``.  Each field is separated by a
   comma.  The output is delimited by ``(`` and ``)``.
 
-Default ``read`` methods are created for all types for which a user-defined
-``read`` method is not provided.  The default ``read`` methods are defined to
-read in the output of the default ``write`` method.
+Default ``readThis`` methods are created for all types for which a user-defined
+``readThis`` method is not provided.  The default ``readThis`` methods are
+defined to read in the output of the default ``writeThis`` method.
+
+Additionally, the Chapel implementation includes ``writeThis`` or methods for
+built-in types as follows:
+
+* for an array: outputs the elements of the array in row-major order
+  where rows are separated by line-feeds and blank lines are used to separate
+  other dimensions.
+* for a `domain`: outputs the dimensions of the domain enclosed by
+  ``{`` and ``}``.
+* for a `range`: output the lower bound of the range, output ``..``,
+  then output the upper bound of the range.  If the stride of the range
+  is not ``1``, output the word ``by`` and then the stride of the range.
+  If the range has special alignment, output the word ``align`` and then the
+  alignment.
+* for tuples, outputs the components of the tuple in order delimited by ``(``
+  and ``)``, and separated by commas.
+
+These types also include ``readThis`` methods to read the corresponding format.
+Note that when reading an array, the domain of the array must be set up
+appropriately before the elements can be read.
 
 .. note::
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -155,12 +155,9 @@ As an example for specifying an I/O style, the code below specifies the minimum 
 
 I/O facilities in Chapel also include several other ways to control I/O
 formatting. There is support for :ref:`formatted I/O <about-io-formatted-io>`
-with :proc:`channel.readf` and :proc:`channel.writef`.  It is possible to write
-data to strings (see "The write and writeln Methods on Strings" in the Chapel
-language specification) which can then be further modified or combined
-programmatically. Lastly, record or class implementations can provide custom
-functions implementing read or write operations for that type (see
-:ref:`readThis-writeThis-readWriteThis`).
+with :proc:`channel.readf` and :proc:`channel.writef`. Also note that record or
+class implementations can provide custom functions implementing read or write
+operations for that type (see :ref:`readThis-writeThis-readWriteThis`).
 
 .. _about-io-files:
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -159,9 +159,8 @@ with :proc:`channel.readf` and :proc:`channel.writef`.  It is possible to write
 data to strings (see "The write and writeln Methods on Strings" in the Chapel
 language specification) which can then be further modified or combined
 programmatically. Lastly, record or class implementations can provide custom
-functions implementing read or write operations for that type (see "The
-readThis, writeThis, and readWriteThis Methods" in the Chapel language
-specification).
+functions implementing read or write operations for that type (see
+:ref:`readThis-writeThis-readWriteThis`).
 
 .. _about-io-files:
 
@@ -4114,7 +4113,7 @@ inline proc channel.read(ref args ...?k):bool {
    :arg args: a list of arguments to read. Basic types are handled
               internally, but for other types this function will call
               value.readThis() with a ``Reader`` argument as described
-              in the specification.
+              in :ref:`readThis-writeThis-readWriteThis`.
    :arg style: optional argument to provide an :type:`iostyle` for this read.
                If this argument is not provided, use the current style
                associated with this channel.
@@ -4448,7 +4447,7 @@ proc channel.readln(ref args ...?k,
               with zero or more such arguments. Basic types are handled
               internally, but for other types this function will call
               value.readThis() with a ``Reader`` argument as described
-              in the specification.
+              in :ref:`readThis-writeThis-readWriteThis`.
    :arg style: optional argument to provide an :type:`iostyle` for this read.
                If this argument is not provided, use the current style
                associated with this channel.


### PR DESCRIPTION
I noticed that IO.chpl still referred to the language specification for readThis/writeThis, even though this material moved to the "IO Support" document (generated from ChapelIO.chpl).

This PR adds cross references to fix that.

While fixing the references, I noticed some out-of-date and incorrect text about default read/write methods (should be readThis / writeThis methods). Fixed those too.

Reviewed by @lydia-duncan - thanks!
