### PR TITLE
Ignore nested functions when verifying initializers don't return values

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -187,7 +187,7 @@ static bool isReturnVoid(FnSymbol* fn) {
   } else {
     std::vector<CallExpr*> calls;
 
-    collectCallExprs(fn->body, calls);
+    collectMyCallExprs(fn->body, calls, fn);
 
     for (size_t i = 0; i < calls.size() && retval == true; i++) {
       if (calls[i]->isPrimitive(PRIM_RETURN) == true) {

--- a/test/classes/initializers/initViaConditional.bad
+++ b/test/classes/initializers/initViaConditional.bad
@@ -1,2 +1,0 @@
-initViaConditional.chpl:6: In initializer:
-initViaConditional.chpl:7: error: initializers cannot return a value

--- a/test/classes/initializers/initViaConditional.future
+++ b/test/classes/initializers/initViaConditional.future
@@ -1,4 +1,0 @@
-bug: can't use conditional expressions within an initializer
-
-My wild guess is that the check for returns within an initializer is
-looking into nested functions?


### PR DESCRIPTION
Resolves #5935 

Prior to this change, we weren't distinguishing between the initializer and any
functions that were defined within its bounds (whether compiler inserted or
otherwise).  Since under the covers we define conditional expressions as nested
functions, this meant that we were complaining about returning from those
functions when the initializer itself was not trying to return anything.

The fix for this was very simple: when gathering the call expressions to check
for return statements, only gather those whose parent symbol was the initializer
itself.  With this change, the future
test/classes/initializers/initViaConditional.chpl now passes.

Tested with futures over test/classes/initializers, passed full std/ paratest