### PR TITLE
Update .bad for idealized chameneos

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
@@ -1,2 +1,8 @@
-chameneosredux-blc-ideal.chpl:55: In initializer:
-chameneosredux-blc-ideal.chpl:56: error: initializers cannot return a value
+chameneosredux-blc-ideal.chpl:21: internal error: MIS0491 chpl Version 1.16.0 pre-release (5d73d1c)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+


### PR DESCRIPTION
This test was failing due to issue #5935, which was fixed in PR #6053.
I expected it to have additional problems once we got past #5935, and
it seems it does.  I'm currently getting a seg-fault internal error with
the following stack trace:

````
isRecordWrappedType()
resolveFormals()
checkResolveFormalsWhereClauses()
filterInitConcreteCandidate()
````

So I updated the .bad to reflect this.