### PR TITLE
Updates to the issue template to simplify specifying futures

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,15 +27,15 @@ What behavior did you expect to observe?
 ```
 
 **Compile command:**
-<!-- e.g. ``chpl foo.chpl`` -->
+<!-- e.g. `chpl foo.chpl` -->
 
 **Execution command:**
-<!-- e.g. ``./foo -nl 4``
+<!-- e.g. `./foo -nl 4`
 If an input file is required, include it as well. -->
 
 **Associated Future Test(s):**
 <!-- Are there any tests in Chapel's test system that demonstrate this issue?
-     e.g. ``test/path/to/foo.future`` #1234 -->
+     e.g. `test/path/to/foo.future` #1234 -->
 
 ### Configuration Information
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -33,7 +33,7 @@ If an input file is required, include it as well. -->
 
 **Associated Future Test(s):**
 <!-- Are there any tests in Chapel's test system that demonstrate this issue?
-     e.g. [``test/path/to/foo.chpl``](
+     e.g. [`test/path/to/foo.chpl`](
            https://github.com/chapel-lang/chapel/blob/master/test/path/to/foo.chpl
           ) #1234 -->
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,9 +21,7 @@ What behavior did you expect to observe?
 // Otherwise, you can attach it as a file or provide a URL to it.
 // To the extent possible, providing simplified programs demonstrating the
 // problem will be appreciated.
-// If you're able to commit a '.future' test to our test system that
-// illustrates the issue, feel free to replace this section with the
-// "Associated Future Test(s)" section below.
+// You can also replace this section with "Associated Future Test(s)" below.
 ```
 
 **Compile command:**
@@ -35,7 +33,9 @@ If an input file is required, include it as well. -->
 
 **Associated Future Test(s):**
 <!-- Are there any tests in Chapel's test system that demonstrate this issue?
-     e.g. `test/path/to/foo.future` #1234 -->
+     e.g. [``test/path/to/foo.chpl``](
+           https://github.com/chapel-lang/chapel/blob/master/test/path/to/foo.chpl
+          ) #1234 -->
 
 ### Configuration Information
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,17 +21,21 @@ What behavior did you expect to observe?
 // Otherwise, you can attach it as a file or provide a URL to it.
 // To the extent possible, providing simplified programs demonstrating the
 // problem will be appreciated.
+// If you're able to commit a '.future' test to our test system that
+// illustrates the issue, feel free to replace this section with the
+// "Associated Future Test(s)" section below.
 ```
 
 **Compile command:**
-<!-- e.g. `chpl foo.chpl -o foo` -->
+<!-- e.g. ``chpl foo.chpl`` -->
 
 **Execution command:**
-<!-- e.g. `./foo -nl 4`. If an input file is required, include it as well. -->
+<!-- e.g. ``./foo -nl 4``
+If an input file is required, include it as well. -->
 
 **Associated Future Test(s):**
 <!-- Are there any tests in Chapel's test system that demonstrate this issue?
-     e.g. test/path/to/foo.future #1234 -->
+     e.g. ``test/path/to/foo.future`` #1234 -->
 
 ### Configuration Information
 


### PR DESCRIPTION
1) Encouraged people to use the "future tests" section rather than the
   inline sample code if a future exists already.  For me, it's
   streamlined filing the issue not to have to include the future code
   explicitly in the issue given that I'm typically going to file a
   future for my issues.

2) Changed the template reference to the future to include a hyperlink

3) Removed '-o foo' from the sample command-line because it's almost
   never necessary and doesn't add value that I can see.