### PR TITLE
Replace more Vecs with STL

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -249,6 +249,15 @@ void collectSymbolSet(BaseAST* ast, Vec<Symbol*>& symSet) {
   AST_CHILDREN_CALL(ast, collectSymbolSet, symSet);
 }
 
+void collectSymbolSet(BaseAST* ast, std::set<Symbol*>& symSet) {
+  if (DefExpr* def = toDefExpr(ast)) {
+    if (isLcnSymbol(def->sym)) {
+      symSet.insert(def->sym);
+    }
+  }
+  AST_CHILDREN_CALL(ast, collectSymbolSet, symSet);
+}
+
 
 // builds the vectors for every variable/argument in 'fn' and looks
 // for uses and defs only in 'fn'

--- a/compiler/backend/beautify.cpp
+++ b/compiler/backend/beautify.cpp
@@ -69,7 +69,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define TRUE 1
 #define max(x,y) ((x)>(y) ? x : y)
 
-static Vec<int> justification;
+static std::vector<int> justification;
 static int depth = 0;
 static int parens = 0;
 static int justify = 0;
@@ -136,7 +136,7 @@ static void update_state(char *line) {
       break;
     case '(':
       if (!inquote && !intick) {
-        justification.add(oldstuff);
+        justification.push_back(oldstuff);
         if (oldstuff == -1) {
           INT_FATAL("Unbalanced parentheses:\n\t%s",line);
         }
@@ -151,7 +151,8 @@ static void update_state(char *line) {
       break;
     case ')':
       if (!inquote && !intick) {
-        oldstuff = justification.pop();
+        oldstuff = justification.back();
+        justification.pop_back();
         stuff = 0;
         parens--;
       } else {
@@ -276,7 +277,7 @@ void beautify(fileinfo* origfile) {
   command = astr("mv ", tmpfile->pathname, " ", origfile->pathname);
   mysystem(command, "moving beautified file");
   
-  if (justification.n != 0) {
+  if (justification.size() != 0) {
     INT_FATAL( "Parentheses or curly braces are not balanced "
                "in codegen for %s.", origfile->pathname);
   }

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -76,6 +76,7 @@ void collectSymbolSetSymExprVec(BaseAST* ast,
 // collect set of symbols
 //
 void collectSymbolSet(BaseAST* ast, Vec<Symbol*>& symSet);
+void collectSymbolSet(BaseAST* ast, std::set<Symbol*>& symSet);
 
 
 //

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -79,10 +79,10 @@ static bool isDeadVariable(Symbol* var) {
 }
 
 void deadVariableElimination(FnSymbol* fn) {
-  Vec<Symbol*> symSet;
+  std::set<Symbol*> symSet;
   collectSymbolSet(fn, symSet);
 
-  forv_Vec(Symbol, sym, symSet)
+  for_set(Symbol, sym, symSet)
   {
     // We're interested only in VarSymbols.
     if (!isVarSymbol(sym))

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -406,10 +406,10 @@ inLocalBlock(CallExpr *call) {
 }
 
 static int
-markFastSafeFn(FnSymbol *fn, int recurse, Vec<FnSymbol*> *visited) {
+markFastSafeFn(FnSymbol *fn, int recurse, std::set<FnSymbol*>& visited) {
 
   // First, handle functions we've already visited.
-  if (visited->in(fn)) {
+  if (visited.count(fn) != 0) {
     if (fn->hasFlag(FLAG_FAST_ON))
       return FAST_AND_LOCAL;
     if (fn->hasFlag(FLAG_LOCAL_FN))
@@ -419,7 +419,7 @@ markFastSafeFn(FnSymbol *fn, int recurse, Vec<FnSymbol*> *visited) {
 
   // Now, add fn to the set of visited functions,
   // since we will categorize it now.
-  visited->add_exclusive(fn);
+  visited.insert(fn);
 
   // Next, classify extern functions
   if (fn->hasFlag(FLAG_EXTERN)) {
@@ -565,9 +565,9 @@ optimizeOnClauses(void) {
   compute_call_sites();
 
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-    Vec<FnSymbol*> visited;
+    std::set<FnSymbol*> visited;
 
-    int is = markFastSafeFn(fn, optimize_on_clause_limit, &visited);
+    int is = markFastSafeFn(fn, optimize_on_clause_limit, visited);
 
     bool fastFork = isFast(is);
     bool removeRmemFences = isLocal(is);

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -47,12 +47,12 @@ bool isDenormalizable(Symbol* sym,
     Type** castTo, SafeExprAnalysis& analysisData);
 void findCandidatesInFunc(FnSymbol *fn, UseDefCastMap& candidates,
     SafeExprAnalysis& analysisData);
-void findCandidatesInFuncOnlySym(FnSymbol* fn, Vec<Symbol*> symVec,
+void findCandidatesInFuncOnlySym(FnSymbol* fn, std::set<Symbol*> symVec,
     UseDefCastMap& udcMap, SafeExprAnalysis& analysisData);
 void denormalize(void);
 void denormalize(Expr* def, SymExpr* use, Type* castTo);
 void denormalizeOrDeferCandidates(UseDefCastMap& candidates,
-    Vec<Symbol*>& deferredSyms);
+    std::set<Symbol*>& deferredSyms);
 
 /*
  * This function tries to remove temporary variables in function `fn`
@@ -74,7 +74,7 @@ void denormalizeOrDeferCandidates(UseDefCastMap& candidates,
 void denormalize(void) {
 
   UseDefCastMap candidates;
-  Vec<Symbol*> deferredSyms;
+  std::set<Symbol*> deferredSyms;
   SafeExprAnalysis analysisData;
 
   if(fDenormalize) {
@@ -101,7 +101,7 @@ void denormalize(void) {
         denormalizeOrDeferCandidates(candidates, deferredSyms);
 
         isFirstRound = false;
-      } while(deferredSyms.count() > 0);
+      } while(deferredSyms.size() > 0);
     }
   }
 }
@@ -150,7 +150,7 @@ void denormalize(void) {
  *   denormalize(void)
  */
 void denormalizeOrDeferCandidates(UseDefCastMap& candidates,
-    Vec<Symbol*>& deferredSyms) {
+    std::set<Symbol*>& deferredSyms) {
 
   for(UseDefCastMap::iterator it = candidates.begin() ;
       it != candidates.end() ; ++it) {
@@ -161,20 +161,20 @@ void denormalizeOrDeferCandidates(UseDefCastMap& candidates,
     Type* castTo = defCastPair.second;
 
     if(def->parentExpr == NULL) {
-      deferredSyms.add(use->symbol());
+      deferredSyms.insert(use->symbol());
       continue;
     }
     denormalize(def, use, castTo);
   }
 }
 
-void findCandidatesInFuncOnlySym(FnSymbol* fn, Vec<Symbol*> symVec,
+void findCandidatesInFuncOnlySym(FnSymbol* fn, std::set<Symbol*> symVec,
     UseDefCastMap& udcMap, SafeExprAnalysis& analysisData) {
 
   bool cachedGlobalManip = analysisData.isRegisteredGlobalManip(fn);
   bool cachedExternManip = analysisData.isRegisteredExternManip(fn);
 
-  forv_Vec(Symbol, sym, symVec) {
+  for_set(Symbol, sym, symVec) {
 
     SymExpr *use = NULL;
     Expr *def = NULL;
@@ -237,7 +237,7 @@ void findCandidatesInFuncOnlySym(FnSymbol* fn, Vec<Symbol*> symVec,
 void findCandidatesInFunc(FnSymbol *fn, UseDefCastMap& udcMap,
     SafeExprAnalysis& analysisData) {
 
-  Vec<Symbol*> symSet;
+  std::set<Symbol*> symSet;
 
   collectSymbolSet(fn, symSet);
 

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -25,10 +25,13 @@
 
 #include "astutil.h"
 #include "expr.h"
+#include "stlUtil.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
 #include "virtualDispatch.h"
+
+#include <vector>
 
 //
 // insertLineNumbers() inserts line numbers and filenames into
@@ -79,7 +82,7 @@ static void moveLinenoInsideArgBundle();
 // filename arguments have been added so that calls to these functions
 // can be updated with new actual arguments.
 //
-static Vec<FnSymbol*> queue;
+static std::vector<FnSymbol*> queue;
 
 static Map<FnSymbol*,ArgSymbol*> linenoMap; // fn to line number argument
 static Map<FnSymbol*,ArgSymbol*> filenameMap; // fn to filename argument
@@ -104,7 +107,7 @@ static ArgSymbol* newFile(FnSymbol* fn) {
   ArgSymbol* file = new ArgSymbol(INTENT_IN, "_fn", dtInt[INT_SIZE_32]);
   fn->insertFormalAtTail(file);
   filenameMap.put(fn, file);
-  queue.add(fn);
+  queue.push_back(fn);
   if (Vec<FnSymbol*>* rootFns = virtualRootsMap.get(fn)) {
     forv_Vec(FnSymbol, rootFn, *rootFns)
       if (!filenameMap.get(rootFn))
@@ -295,7 +298,7 @@ void insertLineNumbers() {
 
   // loop over all functions in the queue and all calls to these
   // functions, and pass the calls an actual line number and filename
-  forv_Vec(FnSymbol, fn, queue) {
+  for_vector(FnSymbol, fn, queue) {
     forv_Vec(CallExpr, call, *fn->calledBy) {
       insertLineNumber(call);
     }


### PR DESCRIPTION
Replaces various Vecs with std::set/vector/queue in the latter half
of the compiler.

Occasionally we iterate over a Vec while appending new elements. I
have handled this by using an std::queue.

An STL variant of the collectSymbolSet utility function was added to
support this change.

Testing:
- [x] full local
- [x] full gasnet