### PR TITLE
Extract PartialCopyData from symbol.{h,cpp}

### DIFF
--- a/compiler/AST/Makefile.share
+++ b/compiler/AST/Makefile.share
@@ -28,6 +28,7 @@ AST_SRCS =                                          \
            iterator.cpp                             \
            foralls.cpp                              \
            flags.cpp                                \
+           PartialCopyData.cpp                      \
            primitive.cpp                            \
            stmt.cpp                                 \
            symbol.cpp                               \

--- a/compiler/AST/PartialCopyData.cpp
+++ b/compiler/AST/PartialCopyData.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PartialCopyData.h"
+
+#include "symbol.h"
+
+#include <map>
+
+static std::map<int, PartialCopyData> sFnMap;
+
+PartialCopyData::PartialCopyData() {
+  partialCopySource = NULL;
+  varargOldFormal   = NULL;
+}
+
+PartialCopyData::~PartialCopyData() {
+
+  partialCopyMap.clear();
+  varargNewFormals.clear();
+}
+
+// Return the entry for 'fn' in partialCopyFnMap or NULL if it does not exist.
+PartialCopyData* getPartialCopyData(FnSymbol* fn) {
+  std::map<int, PartialCopyData>::iterator it     = sFnMap.find(fn->id);
+  PartialCopyData*                         retval = NULL;
+
+  if (it != sFnMap.end()) {
+    retval = &(it->second);
+  }
+
+  return retval;
+}
+
+// Add 'fn' to partialCopyFnMap; remove the corresponding entry.
+PartialCopyData& addPartialCopyData(FnSymbol* fn) {
+  INT_ASSERT(sFnMap.count(fn->id) == 0);
+
+  return sFnMap[fn->id];
+}
+
+// Remove 'fn' from partialCopyFnMap.
+void clearPartialCopyData(FnSymbol* fn) {
+  size_t cnt = sFnMap.erase(fn->id);
+
+  INT_ASSERT(cnt == 1); // Convention: clear only what was added before.
+}
+
+void clearPartialCopyDataFnMap() {
+  sFnMap.clear();
+}
+
+// Since FnSymbols can get removed at pass boundaries, leaving them
+// in here may result in useless entries.
+// As of this writing, PartialCopyData is used only within resolution.
+void checkEmptyPartialCopyDataFnMap() {
+  if (sFnMap.size()) {
+    INT_FATAL("partialCopyFnMap is not empty");
+  }
+}

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -34,6 +34,7 @@
 #include "iterator.h"
 #include "misc.h"
 #include "optimizations.h"
+#include "PartialCopyData.h"
 #include "passes.h"
 #include "resolution.h"
 #include "stmt.h"
@@ -1107,43 +1108,6 @@ FnSymbol::copyInnerCore(SymbolMap* map) {
 }
 
 
-// FnSymbol id -> PartialCopyData
-// Todo: this really should be a hashtable, as it accumulates lots of entries.
-static std::map<int,PartialCopyData> partialCopyFnMap;
-
-// Return the entry for 'fn' in partialCopyFnMap or NULL if it does not exist.
-PartialCopyData* getPartialCopyInfo(FnSymbol* fn) {
-  std::map<int,PartialCopyData>::iterator it = partialCopyFnMap.find(fn->id);
-  if (it == partialCopyFnMap.end()) return NULL;
-  else                              return &(it->second);
-}
-
-// Add 'fn' to partialCopyFnMap; remove the corresponding entry.
-PartialCopyData& addPartialCopyInfo(FnSymbol* fn) {
-  // A duplicate addition does not make sense, although technically possible.
-  INT_ASSERT(!partialCopyFnMap.count(fn->id));
-  return partialCopyFnMap[fn->id];
-}
-
-// Remove 'fn' from partialCopyFnMap.
-void clearPartialCopyInfo(FnSymbol* fn) {
-  size_t cnt = partialCopyFnMap.erase(fn->id);
-  INT_ASSERT(cnt == 1); // Convention: clear only what was added before.
-}
-
-void clearPartialCopyFnMap() {
-  partialCopyFnMap.clear();
-}
-
-// Since FnSymbols can get removed at pass boundaries, leaving them
-// in here may result in useless entries.
-// As of this writing, PartialCopyData is used only within resolution.
-void checkEmptyPartialCopyFnMap() {
-  if (partialCopyFnMap.size())
-    INT_FATAL("partialCopyFnMap is not empty");
-}
-
-
 /** Copy just enough of the AST to get through filter candidate and
  *  disambiguate-by-match.
  *
@@ -1157,10 +1121,11 @@ void checkEmptyPartialCopyFnMap() {
  * \param map Map from symbols in the old function to symbols in the new one
  */
 FnSymbol* FnSymbol::partialCopy(SymbolMap* map) {
-  FnSymbol* newFn = this->copyInnerCore(map);
+  FnSymbol*        newFn = this->copyInnerCore(map);
 
   // Indicate that we need to instantiate its body later.
-  PartialCopyData& pci = addPartialCopyInfo(newFn);
+  PartialCopyData& pci   = addPartialCopyData(newFn);
+
   pci.partialCopySource  = this;
 
   if (this->_this == NULL) {
@@ -1173,25 +1138,31 @@ FnSymbol* FnSymbol::partialCopy(SymbolMap* map) {
 
   } else {
     /*
-     * Case 3: _this symbol is defined in the function's body.  A new symbol is
-     * created.  This symbol will have to be used to replace some of the symbols
-     * generated from copying the function's body during finalizeCopy.
+     * Case 3: _this symbol is defined in the function's body.
+     * A new symbol is created.  This symbol will have to be used
+     * to replace some of the symbols generated from copying the
+     * function's body during finalizeCopy.
      */
+
+    DefExpr* defPoint = this->_this->defPoint;
+
     newFn->_this           = this->_this->copy(map);
     newFn->_this->defPoint = new DefExpr(newFn->_this,
-                                         COPY_INT(this->_this->defPoint->init),
-                                         COPY_INT(this->_this->defPoint->exprType));
+                                         COPY_INT(defPoint->init),
+                                         COPY_INT(defPoint->exprType));
   }
 
   // Copy and insert the where clause if it is present.
   if (this->where != NULL) {
     newFn->where = COPY_INT(this->where);
+
     insert_help(newFn->where, NULL, newFn);
   }
 
   // Copy and insert the retExprType if it is present.
   if (this->retExprType != NULL) {
     newFn->retExprType = COPY_INT(this->retExprType);
+
     insert_help(newFn->retExprType, NULL, newFn);
   }
 
@@ -1218,17 +1189,20 @@ FnSymbol* FnSymbol::partialCopy(SymbolMap* map) {
 
   } else {
     // Case 4: Function returns a symbol defined in the body.
+    DefExpr* defPoint = this->getReturnSymbol()->defPoint;
+
     newFn->retSymbol = COPY_INT(this->getReturnSymbol());
 
     newFn->retSymbol->defPoint = new DefExpr(newFn->retSymbol,
-                                             COPY_INT(this->getReturnSymbol()->defPoint->init),
-                                             COPY_INT(this->getReturnSymbol()->defPoint->exprType));
+                                             COPY_INT(defPoint->init),
+                                             COPY_INT(defPoint->exprType));
 
     update_symbols(newFn->retSymbol, map);
   }
 
   // Add a map entry from this FnSymbol to the newly generated one.
   map->put(this, newFn);
+
   // Update symbols in the sub-AST as is appropriate.
   update_symbols(newFn, map);
 
@@ -1246,8 +1220,8 @@ FnSymbol* FnSymbol::partialCopy(SymbolMap* map) {
  *
  * \param map Map from symbols in the old function to symbols in the new one
  */
-void FnSymbol::finalizeCopy(void) {
-  if (PartialCopyData* pci = getPartialCopyInfo(this)) {
+void FnSymbol::finalizeCopy() {
+  if (PartialCopyData* pci = getPartialCopyData(this)) {
     FnSymbol* const partialCopySource = pci->partialCopySource;
 
     // Make sure that the source has been finalized.
@@ -1352,23 +1326,28 @@ void FnSymbol::finalizeCopy(void) {
 
     // Replace vararg formal if appropriate.
     if (pci->varargOldFormal) {
-      substituteVarargTupleRefs(this->body, pci->varargNewFormals.size(),
-                                pci->varargOldFormal, pci->varargNewFormals);
+      substituteVarargTupleRefs(this->body,
+                                pci->varargNewFormals.size(),
+                                pci->varargOldFormal,
+                                pci->varargNewFormals);
     }
 
     // Clean up book keeping information.
-    clearPartialCopyInfo(this);
+    clearPartialCopyData(this);
   }
 }
 
 
-void FnSymbol::replaceChild(BaseAST* old_ast, BaseAST* new_ast) {
-  if (old_ast == body) {
-    body = toBlockStmt(new_ast);
-  } else if (old_ast == where) {
-    where = toBlockStmt(new_ast);
-  } else if (old_ast == retExprType) {
-    retExprType = toBlockStmt(new_ast);
+void FnSymbol::replaceChild(BaseAST* oldAst, BaseAST* newAst) {
+  if (oldAst == body) {
+    body = toBlockStmt(newAst);
+
+  } else if (oldAst == where) {
+    where = toBlockStmt(newAst);
+
+  } else if (oldAst == retExprType) {
+    retExprType = toBlockStmt(newAst);
+
   } else {
     INT_FATAL(this, "Unexpected case in FnSymbol::replaceChild");
   }

--- a/compiler/include/PartialCopyData.h
+++ b/compiler/include/PartialCopyData.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _PARTIAL_COPY_DATA_H_
+#define _PARTIAL_COPY_DATA_H_
+
+//
+// Used to pass information from FnSymbol::partialCopy() to
+// FnSymbol::finalizeCopy().
+//
+
+#include "baseAST.h"
+
+#include <vector>
+
+class ArgSymbol;
+class FnSymbol;
+
+class PartialCopyData {
+public:
+                          PartialCopyData();
+                         ~PartialCopyData();
+
+  SymbolMap               partialCopyMap;
+
+  FnSymbol*               partialCopySource;
+
+  ArgSymbol*              varargOldFormal;
+  std::vector<ArgSymbol*> varargNewFormals;
+
+};
+
+PartialCopyData* getPartialCopyData(FnSymbol* fn);
+PartialCopyData& addPartialCopyData(FnSymbol* fn);
+
+void             clearPartialCopyData(FnSymbol* fn);
+void             clearPartialCopyDataFnMap();
+void             checkEmptyPartialCopyDataFnMap();
+
+
+#endif

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -709,30 +709,6 @@ const char* intentDescrString(IntentTag intent);
 // pass-by-reference intents are used.
 bool argMustUseCPtr(Type* t);
 
-//
-// Used to pass information from partialCopy() to finalizeCopy().
-//
-class PartialCopyData {
- public:
-  // Used to keep track of symbol substitutions during partial copying.
-  SymbolMap partialCopyMap;
-  // Source of a partially copied function.
-  FnSymbol* partialCopySource;
-  // Vararg formal to be replaced with individual formals, or NULL.
-  ArgSymbol* varargOldFormal;
-  // Individual formals to replace varargOldFormal.
-  std::vector<ArgSymbol*> varargNewFormals;
-
-  PartialCopyData() : partialCopySource(NULL), varargOldFormal(NULL) { }
-  ~PartialCopyData() { partialCopyMap.clear(); varargNewFormals.clear(); }
-};
-
-PartialCopyData* getPartialCopyInfo(FnSymbol* fn);
-PartialCopyData& addPartialCopyInfo(FnSymbol* fn);
-void clearPartialCopyInfo(FnSymbol* fn);
-void clearPartialCopyFnMap();
-void checkEmptyPartialCopyFnMap();
-
 // Parser support.
 class ForallIntents;
 void addForallIntent(ForallIntents* fi, Expr* var, IntentTag intent, Expr* ri);

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -21,11 +21,12 @@
 
 #include "checks.h"
 
+#include "docsDriver.h"
 #include "expr.h"
+#include "PartialCopyData.h"
 #include "passes.h"
 #include "primitive.h"
 #include "resolution.h"
-#include "docsDriver.h" // for fDocs
 #include "TryStmt.h"
 
 //
@@ -436,7 +437,7 @@ void check_afterEveryPass()
     verify();
     checkForDuplicateUses();
     checkFlagRelationships();
-    checkEmptyPartialCopyFnMap();
+    checkEmptyPartialCopyDataFnMap();
   }
 }
 

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -23,6 +23,7 @@
 #include "caches.h"
 #include "chpl.h"
 #include "expr.h"
+#include "PartialCopyData.h"
 #include "resolveIntents.h"
 #include "stmt.h"
 #include "stringutil.h"
@@ -391,7 +392,7 @@ FnSymbol* instantiate(FnSymbol* fn, SymbolMap& subs) {
  * \param fn   Generic function to finish instantiating
  */
 void instantiateBody(FnSymbol* fn) {
-  if (getPartialCopyInfo(fn)) {
+  if (getPartialCopyData(fn)) {
     fn->finalizeCopy();
   }
 }

--- a/compiler/resolution/visibleCandidates.cpp
+++ b/compiler/resolution/visibleCandidates.cpp
@@ -22,6 +22,7 @@
 #include "astutil.h"
 #include "callInfo.h"
 #include "expr.h"
+#include "PartialCopyData.h"
 #include "resolution.h"
 #include "stlUtil.h"
 #include "stmt.h"
@@ -587,8 +588,9 @@ static void handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
       bool needTupleInBody = true; //avoid "may be used uninitialized" warning
 
       // Replace mappings to the old formal with mappings to the new variable.
-      if (PartialCopyData* pci = getPartialCopyInfo(workingFn)) {
+      if (PartialCopyData* pci = getPartialCopyData(workingFn)) {
         bool gotFormal = false; // for assertion only
+
         for (int index = pci->partialCopyMap.n; --index >= 0;) {
           SymbolMapElem& mapElem = pci->partialCopyMap.v[index];
 
@@ -710,7 +712,7 @@ static void handleSymExprInExpandVarArgs(FnSymbol*  workingFn,
           workingFn->insertAtHead(new DefExpr(var));
         }
 
-        if (PartialCopyData* pci = getPartialCopyInfo(workingFn)) {
+        if (PartialCopyData* pci = getPartialCopyData(workingFn)) {
           // If this is a partial copy,
           // store the mapping for substitution later.
           pci->partialCopyMap.put(formal, var);


### PR DESCRIPTION
This trivial PR pulls the class PartialCopyData, a curious data structure that plays an
important role in generic instantiation, out of symbol.{h, cpp} and in to their own files.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran a single-locale paratest out of superstition.
