### PR TITLE
Fix typos

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -594,7 +594,7 @@ genFinfo(std::vector<FnSymbol*> & fSymbols, bool isHeader) {
       if (len > buf_len)
         buf_len = len;
     }
-    // and then add 100 for two integers and punctiation
+    // and then add 100 for two integers and punctuation
     buf_len += 100;
     buf = (char*) malloc(buf_len);
   }

--- a/compiler/include/visibleCandidates.h
+++ b/compiler/include/visibleCandidates.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef _VISIBILE_CANDIDATES_H_
-#define _VISIBILE_CANDIDATES_H_
+#ifndef _VISIBLE_CANDIDATES_H_
+#define _VISIBLE_CANDIDATES_H_
 
 #include "vec.h"
 

--- a/compiler/include/visibleFunctions.h
+++ b/compiler/include/visibleFunctions.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef _VISIBILE_FUNCTIONS_H_
-#define _VISIBILE_FUNCTIONS_H_
+#ifndef _VISIBLE_FUNCTIONS_H_
+#define _VISIBLE_FUNCTIONS_H_
 
 #include "vec.h"
 

--- a/compiler/resolution/visibleCandidates.cpp
+++ b/compiler/resolution/visibleCandidates.cpp
@@ -319,7 +319,7 @@ static void filterGeneric(CallInfo&                  info,
 
 /************************************* | **************************************
 *                                                                             *
-* Maintain a cache from a vargArgs function to the function with the required *
+* Maintain a cache from a varArgs function to the function with the required  *
 * number of formals.                                                          *
 *                                                                             *
 ************************************** | *************************************/

--- a/test/release/examples/benchmarks/shootout/README
+++ b/test/release/examples/benchmarks/shootout/README
@@ -13,7 +13,7 @@ At present, this directory contains the following codes:
 
     binarytrees.chpl    : Allocates and deallocates many, many binary trees
     chameneosredux.chpl : Simulates meetings between color-changing Chameneos
-    chameneosredux-fast.chpl : A tuned version of chaneneosredux.chpl
+    chameneosredux-fast.chpl : A tuned version of chameneosredux.chpl
     fannkuchredux.chpl  : Performs many operations on small arrays
     knucleotide.chpl    : Count the frequencies of specific nucleotide sequences
     mandelbrot.chpl     : Plots the mandelbrot set [-1.5-i,0.5+i] on a bitmap


### PR DESCRIPTION
Fix typos in visibleFunctions, visibleCandidates, codegen.cpp, and the shootout README.