### PR TITLE
Use -std=c++11 when building re2, re2-interface.cc

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -65,6 +65,7 @@ DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -
 DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/')
 C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
 CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
+CXX11_STD := -std=c++11
 
 #
 # Flags for compiler, runtime, and generated code

--- a/make/compiler/Makefile.cray-prgenv-cray
+++ b/make/compiler/Makefile.cray-prgenv-cray
@@ -25,6 +25,8 @@ CRAYPE_GEN_CFLAGS += -hnomessage=186
 FAST_FLOAT_GEN_CFLAGS = -hfp2
 IEEE_FLOAT_GEN_CFLAGS = -hfp0
 
+CXX11_STD := -h std=c++11
+
 # If this is not a --fast compilation or OPTIMIZE=1 is not set, disable
 # optimizations for cce. This is done by default for other compilers and it
 # tends to improve the compiler performance.

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -116,6 +116,7 @@ DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -
 DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/')
 C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
 CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
+CXX11_STD := -std=c++11
 
 RUNTIME_CFLAGS += $(C_STD)
 RUNTIME_CXXFLAGS += $(CXX_STD)

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -48,6 +48,7 @@ DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -
 DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/')
 C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
 CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
+CXX11_STD := -std=c++11
 
 #
 # Flags for compiler, runtime, and generated code

--- a/make/compiler/Makefile.pgi
+++ b/make/compiler/Makefile.pgi
@@ -63,6 +63,7 @@ WARN_CXXFLAGS =
 WARN_CFLAGS =
 WARN_GEN_CFLAGS = 
 
+CXX11_STD := -std=c++11
 
 #
 # compiler warnings settings

--- a/runtime/Makefile.help
+++ b/runtime/Makefile.help
@@ -27,7 +27,8 @@ RUNTIME_SUBDIR = .
 #
 include $(RUNTIME_ROOT)/make/Makefile.runtime.head
 
-
+# To run this, from runtime/
+# make printstuff.helpme
 printstuff:
 	@echo MAKE_LAUNCHER = $(MAKE_LAUNCHER)
 	@echo CHPL_MAKE_PLATFORM = $(CHPL_MAKE_PLATFORM)
@@ -41,6 +42,8 @@ printstuff:
 	@echo CHPL_MAKE_HOST_TARGET = $(CHPL_MAKE_HOST_TARGET)
 	@echo CHPL_MAKE_TARGET_ARCH = $(CHPL_MAKE_TARGET_ARCH)
 	@echo CHPL_ORIG_TARGET_COMPILER = $(CHPL_ORIG_TARGET_COMPILER)
+	@echo CXX_STD = $(CXX_STD)
+	@echo RUNTIME_CXXFLAGS += $(RUNTIME_CXXFLAGS)
 
 
 #

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -204,11 +204,13 @@ typedef struct _chpl_fn_info {
 
 // It is tempting to #undef true and false and then #define them just to be sure
 // they expand correctly, but future versions of the C standard may not allow this!
+#ifndef __cplusplus
 #ifndef false
 #define false 0
 #endif
 #ifndef  true
 #define  true 1
+#endif
 #endif
 
 typedef float               _real32;

--- a/runtime/src/qio/regexp/re2/Makefile.share
+++ b/runtime/src/qio/regexp/re2/Makefile.share
@@ -25,6 +25,9 @@ REGEXP_OBJS = \
 
 RUNTIME_INCLS += -I$(RE2_INCLUDE_DIR) -I$(RE2_INCLUDE_DIR2)
 
+# Note: passing -std=c++11 in addition to RUNTIME_CXXFLAGS below
+# Hopefully RUNTIME_CXXFLAGS includes a C++ standard version. If not,
+# the preceeding -std=c++11 will apply.
 $(RUNTIME_OBJ_DIR)/re2-interface.o: re2-interface.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)
-	$(CXX) -c $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<
+	$(CXX) -c -std=c++11 $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<

--- a/runtime/src/qio/regexp/re2/Makefile.share
+++ b/runtime/src/qio/regexp/re2/Makefile.share
@@ -25,9 +25,15 @@ REGEXP_OBJS = \
 
 RUNTIME_INCLS += -I$(RE2_INCLUDE_DIR) -I$(RE2_INCLUDE_DIR2)
 
-# Note: passing -std=c++11 in addition to RUNTIME_CXXFLAGS below
+# RE2 2017-04-01 uses C++11 features
+
+ifeq (,$(CXX11_STD))
+  $(error CXX11_STD is not set for this compiler - update make/compiler/...)
+endif
+
+# Note: passing CXX11_STD in addition to RUNTIME_CXXFLAGS below
 # Hopefully RUNTIME_CXXFLAGS includes a C++ standard version. If not,
-# the preceeding -std=c++11 will apply.
+# the preceeding CXX11_STD will apply.
 $(RUNTIME_OBJ_DIR)/re2-interface.o: re2-interface.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)
-	$(CXX) -c -std=c++11 $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<
+	$(CXX) -c $(CXX11_STD) $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<

--- a/runtime/src/qio/regexp/re2/re2-interface.cc
+++ b/runtime/src/qio/regexp/re2/re2-interface.cc
@@ -5,7 +5,6 @@
 #endif
 
 #include <limits>
-#include <algorithm>
 #include <pthread.h>
 
   #include <stdlib.h>
@@ -19,7 +18,6 @@
   #undef printf
 
 #include "re2/re2.h"
-//#include "re2/regexp.h"
 
 using namespace re2;
 

--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -29,8 +29,10 @@ endif
 
 CHPL_RE2_CFG_OPTIONS += $(CHPL_RE2_MORE_CFG_OPTIONS)
 
-
-CHPL_RE2_CXXFLAGS += $(CFLAGS) $(CXXFLAGS)
+# RE2 2017-04-01 uses C++11 features
+# Pass -std=c++11 first, override it with RUNTIME_CXXFLAGS if possible
+# That way, if RUNTIME_CXXFLAGS is empty, we still pass -std=c++11
+CHPL_RE2_CXXFLAGS += $(CFLAGS) -std=c++11 $(RUNTIME_CXXFLAGS)
 
 default: all
 

--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -30,9 +30,14 @@ endif
 CHPL_RE2_CFG_OPTIONS += $(CHPL_RE2_MORE_CFG_OPTIONS)
 
 # RE2 2017-04-01 uses C++11 features
+
+ifeq (,$(CXX11_STD))
+  $(error CXX11_STD is not set for this compiler - update make/compiler/...)
+endif
+
 # Pass -std=c++11 first, override it with RUNTIME_CXXFLAGS if possible
-# That way, if RUNTIME_CXXFLAGS is empty, we still pass -std=c++11
-CHPL_RE2_CXXFLAGS += $(CFLAGS) -std=c++11 $(RUNTIME_CXXFLAGS)
+# That way, even if RUNTIME_CXXFLAGS is empty, we still pass -std=c++11
+CHPL_RE2_CXXFLAGS += $(CFLAGS) $(CXX11_STD) $(RUNTIME_CXXFLAGS)
 
 default: all
 

--- a/third-party/re2/re2-src/re2/nfa.cc
+++ b/third-party/re2/re2-src/re2/nfa.cc
@@ -700,8 +700,8 @@ bool NFA<StrPiece>::Search(const StrPiece& text, const StrPiece& const_context,
     for (int i = 0; i < nsubmatch; i++)
       submatch[i].set_ptr_end(match_[2 * i], match_[2 * i + 1]);
     if (ExtraDebug)
-      fprintf(stderr, "match (%td,%td)\n",
-              match_[0] - btext_, match_[1] - btext_);
+      fprintf(stderr, "match (%td,%ld)\n",
+              (long)(match_[0] - btext_), (long)(match_[1] - btext_));
     return true;
   }
   return false;

--- a/third-party/re2/re2-src/re2/nfa.cc
+++ b/third-party/re2/re2-src/re2/nfa.cc
@@ -700,8 +700,8 @@ bool NFA<StrPiece>::Search(const StrPiece& text, const StrPiece& const_context,
     for (int i = 0; i < nsubmatch; i++)
       submatch[i].set_ptr_end(match_[2 * i], match_[2 * i + 1]);
     if (ExtraDebug)
-      fprintf(stderr, "match (%td,%ld)\n",
-              (long)(match_[0] - btext_), (long)(match_[1] - btext_));
+      fprintf(stderr, "match (%jd,%jd)\n",
+              static_cast<intmax_t>(match_[0] - btext_), static_cast<intmax_t>(match_[1] - btext_));
     return true;
   }
   return false;


### PR DESCRIPTION
Addresses testing failures from PR #6024. The testing failures are because the 2017-04-01  version of RE2 uses some C++11 features and the previous version we were using did not.

This PR resolves these testing failures by:
 * introducing a Makefile variable, CXX11_STD, set in make/compiler/... to for example `-std=c++11`.
 * using CXX11_STD when compiling RE2 itself and when compiling re2-interface.cc
 * addressing other C++ warnings / errors from some tested configurations
    - defining true and false in chpltypes.h
    - removing #include <algorithm> from re2-interface.cc works around a problem with also including <intrinsics.h>
    - within RE2, fix a format string type mismatch

Verified quickstart+re2 build and test/regexp passes with:
- [x] Apple clang 8 on Mac OS X
- [x] Intel compiler version 15
- [x] Intel compiler version 16
- [x] Cray compiler version 8.4
- [x] Cray compiler version 8.5
- [x] GCC 4.7.3
- [x] GCC 4.8 on Ubuntu Trusty 32-bit
- [x] GCC 4.8 on CentOS 7
- [x] GCC 4.9

Configurations that worked before PR #6024 but still don't work after these fixes:
- PGI compiler version 16, 17: RE2 does not build
- GCC 4.6 on Ubuntu Precise 32-bit: -std=c++11 unrecognized command line option. Note that this distribution is End of Life this month (Apr 2017).
- GCC 4.4 on CentOS 6.8: unrecognized command line option "-std=c++11". Note that this distribution has End of Life in 2020.

Reviewed by @dmk42 - thanks!