### PR TITLE
Continue to straighten out expandVarArgs

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1326,10 +1326,7 @@ void FnSymbol::finalizeCopy() {
 
     // Replace vararg formal if appropriate.
     if (pci->varargOldFormal) {
-      substituteVarargTupleRefs(this->body,
-                                pci->varargNewFormals.size(),
-                                pci->varargOldFormal,
-                                pci->varargNewFormals);
+      substituteVarargTupleRefs(this, pci);
     }
 
     // Clean up book keeping information.

--- a/compiler/include/visibleCandidates.h
+++ b/compiler/include/visibleCandidates.h
@@ -25,9 +25,9 @@
 #include <vector>
 
 class ArgSymbol;
-class BlockStmt;
 class CallInfo;
 class FnSymbol;
+class PartialCopyData;
 class ResolutionCandidate;
 
 void      findVisibleCandidates(CallInfo&                  info,
@@ -39,10 +39,8 @@ void      resolveTypedefedArgTypes(FnSymbol* fn);
 FnSymbol* expandIfVarArgs(FnSymbol* fn,
                           CallInfo& info);
 
-void      substituteVarargTupleRefs(BlockStmt*               ast,
-                                    int                      numArgs,
-                                    ArgSymbol*               formal,
-                                    std::vector<ArgSymbol*>& varargFormals);
+void      substituteVarargTupleRefs(FnSymbol*              fn,
+                                    const PartialCopyData* pci);
 
 bool      checkResolveFormalsWhereClauses(ResolutionCandidate* currCandidate);
 


### PR DESCRIPTION
Begin to simplify expandVarArgsFormal(); extract the first variation
of expandVarArgsBody() and expandVarArgsWhere().

Compiled with clang/gcc.
Passed a paratest
