### PR TITLE
Remove workaround in atomic intrinsics for newer cray compilers

### DIFF
--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -21,12 +21,8 @@
 #define _chpl_atomics_h_
 
 #include "chpltypes.h"
+#include "chpl-comp-detect-macros.h"
 #include <assert.h>
-
-// required to use __builtin_ia32_mfence
-#ifdef _CRAYC
-  #include <intrinsics.h>
-#endif
 
 //
 // SIZE_ALIGN_TYPE:  Declare a version of a type aligned to at least its size.
@@ -68,10 +64,12 @@ static inline memory_order _defaultOfMemoryOrder(void) {
   return memory_order_seq_cst;
 }
 
-// Cray does not support __sync_synchronize so we use a cray specific memory
-// fence. Cray also does not support __sync_bool_compare_and_swap so we 
-// cheat our way around this using __sync_val_compare_and_swap
-#ifdef _CRAYC
+// cce < 8.4 is missing __sync_synchronize and __sync_bool_compare_and_swap.
+// Use __builtin_ia32_mfence and __sync_val_compare_and_swap instead.
+#if RT_COMP_CC == RT_COMP_CRAY && \
+    (RT_COMP_CRAY_VERSION_MAJOR < 8 || \
+    (RT_COMP_CRAY_VERSION_MAJOR == 8 && RT_COMP_CRAY_VERSION_MINOR < 4))
+  #include <intrinsics.h>
   #define full_memory_barrier __builtin_ia32_mfence
   
   # define my__sync_bool_compare_and_swap(obj, expected, desired) \


### PR DESCRIPTION
42f9be21d1 ported our intrinsics atomic implementation to the cray compiler.
cce < 8.4 didn't support __sync_synchronize or __sync_bool_compare_and_swap so
we used __builtin_ia32_mfence (cray specific) and __sync_val_compare_and_swap
instead. cce 8.4.0 added support for both of the missing __sync intrinsics, so
just use those if we have a new enough version of cce.