### PR TITLE
New LICENSE.devel for dev tool licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -43,13 +43,6 @@ The Chapel implementation is composed of two categories of code:
                                                                    Python
                                                                    BSD
                                                                    GPL 3
-       scspell        Spell-checking utility (developer-only)      GPL 2
-       scspell SCOWL word lists
-                      Spell-checking dictionaries (developer-only) MIT-like
-                                                                   BSD
-                                                                   other (UKACD)
-                                                                   public domain
-
      gasnet           portable communication library               BSD-like
      gmp              optional multi-precision math library        L-GPL
      hwloc            portable NUMA compute node utilities         new BSD

--- a/LICENSE.devel
+++ b/LICENSE.devel
@@ -8,7 +8,6 @@ code that doesn't appear in the release.
 
    directory/package  use                                          license
    -----------------  -------------------------------------------  -------
-
    third-party/
        scspell        Spell-checking utility                       GPL 2
        scspell SCOWL word lists
@@ -16,5 +15,3 @@ code that doesn't appear in the release.
                                                                    BSD
                                                                    other (UKACD)
                                                                    public domain
-   -----------------  -------------------------------------------  -------
-

--- a/LICENSE.devel
+++ b/LICENSE.devel
@@ -1,0 +1,20 @@
+======================================
+Chapel Development License Information
+======================================
+
+As a developer, we assume you're familiar with LICENSE and LICENSE.chapel. This
+file is designed to make you aware of other third-party licenses related to
+code that doesn't appear in the release.
+
+   directory/package  use                                          license
+   -----------------  -------------------------------------------  -------
+
+   third-party/
+       scspell        Spell-checking utility                       GPL 2
+       scspell SCOWL word lists
+                      Spell-checking dictionaries                  MIT-like
+                                                                   BSD
+                                                                   other (UKACD)
+                                                                   public domain
+   -----------------  -------------------------------------------  -------
+


### PR DESCRIPTION
Delivering on suggestion from #6055 to remove scspell from LICENSE 

Double checked that `gen_release` does not require any changes -- top-level files require explicit inclusion for the release tarball.