### PR TITLE
Add general version of initCallsDom future

### DIFF
--- a/test/classes/initializers/initCallsDom.future
+++ b/test/classes/initializers/initCallsDom.future
@@ -3,3 +3,6 @@ bug: can't call '.domain' on array in record initializer
 For some reason, it seems I can't call .domain on an array argument in
 a record initializer.  If I change the initializer to a constructor it
 works.
+
+A more general version of this future can be found at
+not-a-copy-initializer.chpl

--- a/test/classes/initializers/not-a-copy-initializer.bad
+++ b/test/classes/initializers/not-a-copy-initializer.bad
@@ -1,0 +1,3 @@
+not-a-copy-initializer.chpl:16: In initializer:
+not-a-copy-initializer.chpl:17: error: unresolved call 'Foo.someMethod()'
+not-a-copy-initializer.chpl:7: note: candidates are: OtherRecord.someMethod()

--- a/test/classes/initializers/not-a-copy-initializer.chpl
+++ b/test/classes/initializers/not-a-copy-initializer.chpl
@@ -1,0 +1,25 @@
+// This test case is a more general version of initCallsDom.chpl, showing that
+// the issue is with calling methods not defined on the type (basically, with
+// assuming the generic argument will not be used as a copy initializer).
+record OtherRecord {
+  var someField = 10;
+
+  proc someMethod() {
+    writeln("In otherRecord's someMethod");
+  }
+}
+
+
+record Foo {
+  var a: bool;
+
+  proc init(genericArg) {
+    genericArg.someMethod();
+    a = true;
+    super.init();
+  }
+}
+
+var other = new OtherRecord();
+var foo = new Foo(other);
+writeln(foo);

--- a/test/classes/initializers/not-a-copy-initializer.future
+++ b/test/classes/initializers/not-a-copy-initializer.future
@@ -1,0 +1,9 @@
+bug: can't call method on generic record arg in record initializer
+
+This is a generalized version of initCallsDom.future.  The issue is that
+the compiler tries to use generic single argument record initializers in
+initCopy calls as copy initializers, but the initializers defined in these
+tests were not intended as copy initializers.  Work has been done to allow
+records that don't define copy initializers to not trigger this error message,
+but that examination depends on the argument list, not the resolution of the
+function itself.

--- a/test/classes/initializers/not-a-copy-initializer.good
+++ b/test/classes/initializers/not-a-copy-initializer.good
@@ -1,0 +1,2 @@
+In otherRecord's someMethod
+{a = true}


### PR DESCRIPTION
In looking at the bug behind initCallsDom, I had realized that the problem
wasn't specific to arrays at all - it was due to the compiler assuming the
generic argument for that initializer was allowed to be of the type on which
the initializer was defined, making it a candidate copy initializer.  Then,
when it tried some autoCopy/initCopy operations with that assumption, it ran
into issues because the method called on the argument was not defined for the
type it was trying to use.  However, copies aren't actually made of the type,
so trying to resolve the initCopy/autoCopy functions that make this bad call
is incorrect.  We've avoided this for other types that obviously didn't define
a copy initializer, but that avoidance was thwarted by having the argument
list appear like what we were expecting (by being generic).