### PR TITLE
Continue to straighten out var-args

### DIFF
--- a/compiler/resolution/visibleCandidates.cpp
+++ b/compiler/resolution/visibleCandidates.cpp
@@ -751,15 +751,16 @@ static bool handleCopyData(PartialCopyData* pci,
                            VarSymbol*       var,
                            ArgSymbol*       formal,
                            const Formals&   varargs) {
-  int  n         = static_cast<int>(varargs.size());
-  int  index     = pci->partialCopyMap.n - 1;
+  int  maxIndex  = pci->partialCopyMap.n - 1;
   bool gotFormal = false;
   bool retval    = false;
 
-  while (index >= 0 && gotFormal == false) {
+  for (int index = maxIndex; index >= 0 && gotFormal == false; index--) {
     SymbolMapElem& mapElem = pci->partialCopyMap.v[index];
 
     if (mapElem.value == formal) {
+      int n = static_cast<int>(varargs.size());
+
       retval = needVarArgTupleAsWhole(pci->partialCopySource->body,
                                       n,
                                       toArgSymbol(mapElem.key));
@@ -774,8 +775,6 @@ static bool handleCopyData(PartialCopyData* pci,
       }
 
       gotFormal = true;
-    } else {
-      index     = index - 1;
     }
   }
 
@@ -806,7 +805,7 @@ static CallExpr* buildTupleCall(ArgSymbol* formal, const Formals& formals) {
     retval = new CallExpr("_construct__tuple");
   }
 
-  retval ->insertAtTail(new_IntSymbol(n));
+  retval->insertAtTail(new_IntSymbol(n));
 
   for (int i = 0; i < n; i++) {
     retval->insertAtTail(formals[i]);

--- a/test/types/type_variables/deitz/test_query_field11.good
+++ b/test/types/type_variables/deitz/test_query_field11.good
@@ -1,3 +1,3 @@
 test_query_field11.chpl:13: error: ambiguous call 'foo(range(int(64),boundedLow,false), range(int(64),boundedLow,true))'
-test_query_field11.chpl:1: note: candidates are: foo(_e0_x: range, _e1_x: range)
-test_query_field11.chpl:9: note:                 foo(_e0_x: range, _e1_x: range)
+test_query_field11.chpl:1: note: candidates are: foo(_e1_x: range, _e2_x: range)
+test_query_field11.chpl:9: note:                 foo(_e1_x: range, _e2_x: range)


### PR DESCRIPTION
Another sequence of mostly trivial commits in the effort to make it clearer
how var-arg functions are resolved.  This effort reminded me that I introduced
a "band-aid" during the string-as-rec update to work-around problems with
blank intents and ref types.  I need to come back to this.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Also did a spot check with c++14 enabled.

Passed a single-locale paratest
