### PR TITLE
Clean up RE2 and C++11 issues

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -65,7 +65,7 @@ DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -
 DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/')
 C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
 CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
-CXX11_STD := -std=c++11
+CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 
 #
 # Flags for compiler, runtime, and generated code

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -116,7 +116,11 @@ DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -
 DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/')
 C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
 CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
-CXX11_STD := -std=c++11
+
+# CXX11_STD is the flag to select C++11, or "unknown" for compilers
+# we don't know how to do that with yet.
+# If a compiler uses C++11 or newer by default, CXX11_STD will be blank.
+CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 
 RUNTIME_CFLAGS += $(C_STD)
 RUNTIME_CXXFLAGS += $(CXX_STD)

--- a/make/compiler/Makefile.ibm
+++ b/make/compiler/Makefile.ibm
@@ -57,6 +57,8 @@ LIB_DYNAMIC_FLAG = -qmkshrobj -X64
 # TODO: Set the target architecture for optimization (e.g. -qtune)
 # TODO: Set flag for lax or IEEE floating point (e.g. -qfloat)
 
+CXX11_STD := unknown
+
 #
 # Flags for turning on warnings for C++/C code
 #

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -48,7 +48,7 @@ DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -
 DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/')
 C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
 CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
-CXX11_STD := -std=c++11
+CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 
 #
 # Flags for compiler, runtime, and generated code

--- a/make/compiler/Makefile.pathscale
+++ b/make/compiler/Makefile.pathscale
@@ -51,6 +51,7 @@ GEN_DYNAMIC_FLAG =
 FAST_FLOAT_GEN_CFLAGS = -ffast-math
 IEEE_FLOAT_GEN_CFLAGS = --fno-fast-math
 
+CXX11_STD := unknown
 
 #
 # Flags for turning on warnings for C++/C code

--- a/make/compiler/Makefile.pgi
+++ b/make/compiler/Makefile.pgi
@@ -56,6 +56,8 @@ LIB_DYNAMIC_FLAG = -shared
 
 # TODO: set target architecture for optimization
 
+CXX11_STD := -std=c++11
+
 #
 # Flags for turning on warnings for C++/C code
 #

--- a/runtime/src/qio/regexp/re2/Makefile.share
+++ b/runtime/src/qio/regexp/re2/Makefile.share
@@ -27,7 +27,7 @@ RUNTIME_INCLS += -I$(RE2_INCLUDE_DIR) -I$(RE2_INCLUDE_DIR2)
 
 # RE2 2017-04-01 uses C++11 features
 
-ifeq (,$(CXX11_STD))
+ifeq ($(CXX11_STD),unknown)
   $(error CXX11_STD is not set for this compiler - update make/compiler/...)
 endif
 

--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -35,9 +35,11 @@ ifeq ($(CXX11_STD),unknown)
   $(error CXX11_STD is not set for this compiler - update make/compiler/...)
 endif
 
-# Pass -std=c++11 first, override it with RUNTIME_CXXFLAGS if possible
-# That way, even if RUNTIME_CXXFLAGS is empty, we still pass -std=c++11
-CHPL_RE2_CXXFLAGS += $(CFLAGS) $(CXX11_STD) $(RUNTIME_CXXFLAGS)
+# CXX11_STD will be blank for compilers that default to C++11,
+# or it will use e.g. gnu++11 or c++11 if not.
+# Note that RE2 itself sometimes throws -std=c++11, but this is
+# not done for some compilers that Chapel supports.
+CHPL_RE2_CXXFLAGS += $(CFLAGS) $(CXXFLAGS) $(CXX11_STD)
 
 default: all
 

--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -31,7 +31,7 @@ CHPL_RE2_CFG_OPTIONS += $(CHPL_RE2_MORE_CFG_OPTIONS)
 
 # RE2 2017-04-01 uses C++11 features
 
-ifeq (,$(CXX11_STD))
+ifeq ($(CXX11_STD),unknown)
   $(error CXX11_STD is not set for this compiler - update make/compiler/...)
 endif
 

--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -39,7 +39,7 @@ endif
 # or it will use e.g. gnu++11 or c++11 if not.
 # Note that RE2 itself sometimes throws -std=c++11, but this is
 # not done for some compilers that Chapel supports.
-CHPL_RE2_CXXFLAGS += $(CFLAGS) $(CXXFLAGS) $(CXX11_STD)
+CHPL_RE2_CXXFLAGS += $(CXXFLAGS) $(CXX11_STD)
 
 default: all
 
@@ -60,8 +60,8 @@ $(RE2_BUILD_SUBDIR):
 $(RE2_H_FILE): $(RE2_BUILD_SUBDIR)
 	cd $(RE2_SUBDIR) && \
 	$(MAKE) clean && \
-	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' $(CHPL_RE2_CFG_OPTIONS) obj/libre2.a && \
-	$(MAKE) CXX='$(CXX)' NODEBUG= CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' $(CHPL_RE2_CFG_OPTIONS) prefix=$(RE2_INSTALL_DIR) install-static && \
+	$(MAKE) CXX='$(CXX)' NODEBUG= CPPFLAGS='$(CPPFLAGS)' CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' $(CHPL_RE2_CFG_OPTIONS) obj/libre2.a && \
+	$(MAKE) CXX='$(CXX)' NODEBUG= CPPFLAGS='$(CPPFLAGS)' CXXFLAGS='$(RE_DEBUG_CXX) $(CHPL_RE2_CXXFLAGS)' $(CHPL_RE2_CFG_OPTIONS) prefix=$(RE2_INSTALL_DIR) install-static && \
 	mkdir -p ../build/$(RE2_UNIQUE_SUBDIR) && \
 	rm -rf ../build/$(RE2_UNIQUE_SUBDIR) && \
 	mv obj ../build/$(RE2_UNIQUE_SUBDIR)


### PR DESCRIPTION
Continuing PR #6065.

This PR performs the following changes:
 1) Let CXX11_STD be blank for compilers that default to >= C++11
 2) Do not add our warnings flags to the RE2 build

@dmk42 pointed out that the earlier PR downgraded some compilers defaulting to C++14 (say) to C++11 when compiling RE2 and RE2 support. This PR changes the CXX11_STD variable to be blank for compilers that default to >= C++11 and sets it to "unknown" for compilers where we don't know how to set it (to trigger the "Go update make/compilers/ error").

Additionally, this PR removes RUNTIME_CXXFLAGS from the RE2 build. I added this during the RE2 upgrade in an effort to get the right C++11 to be passed, but this PR cleans that up. We don't want to pass RUNTIME_CXXFLAGS to the RE2 build because it enables a bunch of warnings (and warnings-as-errors) that we intend only to be used in our own code.

Tested as part of PR #6070.
Reviewed by @dmk42 - thanks!