### PR TITLE
Address valgrind failures from PR #5949

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -629,8 +629,8 @@ genFinfo(std::vector<FnSymbol*> & fSymbols, bool isHeader) {
   // Free the buffer for C conversions.
   if (buf) free(buf);
 
-  // make sure the table always contains at least 1 element
-  if (finfo.empty()) {
+  // make sure the table always contains at trailing NULL element
+  {
     GenRet nullStruct;
     if (info->cfile) {
       nullStruct.c = "{(char *)0, 0, 0}";

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -666,8 +666,8 @@ genVirtualMethodTable(std::vector<TypeSymbol*>& types, bool isHeader) {
     if (AggregateType* ct = toAggregateType(ts->type))
       if (isObjectOrSubclass(ct))
         if (Vec<FnSymbol*>* vfns = virtualMethodTable.get(ct))
-	  if (vfns->n > maxVMT)
-	    maxVMT = vfns->n;
+          if (vfns->n > maxVMT)
+            maxVMT = vfns->n;
   }
   gMaxVMT = maxVMT;
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -802,8 +802,8 @@ static void genUnwindSymbolTable(){
       table.push_back(codegenStringForTable(fn->cname));
       table.push_back(codegenStringForTable(fn->name));
     }
-    table.push_back("");
-    table.push_back("");
+    table.push_back(codegenStringForTable(""));
+    table.push_back(codegenStringForTable(""));
 
     // Now emit the global array declaration
     codegenGlobalConstArray(name, eltType, &table, false);


### PR DESCRIPTION
PR #5949 attempted to clean up the loop computing the maximum number of virtual method table slots for any type.  That clean-up was causing valgrind errors because the Virtual Method Table can contain keys that are no longer in the AST (and in fact are pointers to freed memory). Therefore, switch to using a pattern of traversing types that are in the AST and then 'get'ing the appropriate VMT elements.

Changes to the generation of the "finfo" table used by chplviz also caused problems in some testing configuration. The problem was we were no longer emitting a NULL element, which the chplviz code looks for. Fix that and also a think-o to do with stack -trace-on-halt tables.

- [x] verified valgrind errors addressed for hellos
- [x] full local testing
- [x] resolves --fast failures
- [x] stack trace on halt still functions
- [x] verified that running chplvis still appears to work

Reviewed by @benharsh - thanks!