### PR TITLE
Change default of --log-ids from false to true

### DIFF
--- a/compiler/main/log.cpp
+++ b/compiler/main/log.cpp
@@ -34,7 +34,7 @@
 char             log_dir   [FILENAME_MAX + 1]           = "./log";
 char             log_module[FILENAME_MAX + 1]           =      "";
 
-bool             fLogIds                                =   false;
+bool             fLogIds                                =    true;
 
 int              fdump_html                             =       0;
 char             fdump_html_chpl_home[FILENAME_MAX + 1] =      "";


### PR DESCRIPTION
I've found that most of the time when I want to use --log, I invariably look at
the output and curse myself for not throwing --log-ids, and then have to rerun
my compilation command.  The default could be overridden with the environment
variable CHPL_LOG_IDS, but since debugging is easier with node ids in hand (such
as with the flags --break-on-id, --break-on-resolve-id, and
--break-on-delete-id), it seemed reasonable to change the default.

Discussed with the group via issue #5260 - most were either in favor of or
neutral to the change (and willing to set the environment variable, as it
affects their workflow less often).

I looked into whether it was reasonable to have the default for the flag switch
depending on if logging was going to occur, but it seemed like doing so would
override the user's wishes for certain flag orderings, so I abandoned that
approach.

Verified the correct output for not using the flag, setting it explicitly, and setting it
explicitly off.  Also passed a full std/ paratest.