### PR TITLE
Switch this NOTEST'd directory to use a .future instead

### DIFF
--- a/test/chpldoc/compflags/externs/NOTEST
+++ b/test/chpldoc/compflags/externs/NOTEST
@@ -1,2 +1,0 @@
-This flag is not yet enabled (it lies, sleeping and commented out, within our
-flag list).  When it is enabled, run this test.

--- a/test/chpldoc/compflags/externs/externTest.doc.bad
+++ b/test/chpldoc/compflags/externs/externTest.doc.bad
@@ -1,0 +1,2 @@
+Unrecognized flag: '--no-externs' (use '-h' for help)
+cat: docs/source/modules/externTest.doc.rst: No such file or directory

--- a/test/chpldoc/compflags/externs/externTest.doc.future
+++ b/test/chpldoc/compflags/externs/externTest.doc.future
@@ -1,0 +1,6 @@
+semantic: Allow users to control presence of externs in chpldoc output?
+
+This feature is practically implemented today (due to being very easy to
+support), but we weren't sure of the utility, so didn't allow it as a flag.
+
+If there is user interest, this would be easy to turn on.


### PR DESCRIPTION
I'm not sure why this was made a notest instead of a semantic future in the
first place.  Tempted to smack past me.

This future is directly related to #6026 

Verified clean match against .bad on fresh branch