### PR TITLE
Update phase when necessary

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -157,14 +157,14 @@ static bool isReturnVoid(FnSymbol* fn);
 void preNormalizeInitMethod(FnSymbol* fn) {
   AggregateType* at = toAggregateType(fn->_this->type);
 
-  if (fn->hasFlag(FLAG_NO_PARENS) == true) {
+  if (fn->hasFlag(FLAG_NO_PARENS)   ==  true) {
     USR_FATAL(fn, "an initializer cannot be declared without parentheses");
 
-  } else if (isReturnVoid(fn) == false) {
+  } else if (isReturnVoid(fn)       == false) {
     USR_FATAL(fn, "an initializer cannot return a non-void result");
 
-  } else if (isNonGenericRecord(at) == true ||
-             isNonGenericClass(at)  == true) {
+  } else if (isNonGenericRecord(at) ==  true ||
+             isNonGenericClass(at)  ==  true) {
     preNormalizeNonGenericInit(fn);
 
   } else {
@@ -256,6 +256,26 @@ enum InitPhase {
   cPhase2
 };
 
+static const char* phaseToString(InitPhase phase) {
+  const char* retval = "?";
+
+  switch (phase) {
+    case cPhase0:
+      retval = "Phase0";
+      break;
+
+    case cPhase1:
+      retval = "Phase1";
+      break;
+
+    case cPhase2:
+      retval = "Phase2";
+      break;
+  }
+
+  return retval;
+}
+
 class InitVisitor {
 public:
                   InitVisitor(FnSymbol*  fn);
@@ -275,6 +295,8 @@ public:
   bool            isPhase0()                                             const;
   bool            isPhase1()                                             const;
   bool            isPhase2()                                             const;
+
+  void            checkPhase(BlockStmt* block);
 
   Expr*           completePhase1(CallExpr* insertBefore);
   void            initializeFieldsBefore(Expr* insertBefore);
@@ -466,7 +488,6 @@ bool InitVisitor::isFieldInitialized(const DefExpr* field) const {
     }
   }
 
-
   return retval;
 }
 
@@ -535,6 +556,16 @@ InitPhase InitVisitor::startPhase(BlockStmt* block) const {
   return retval;
 }
 
+void InitVisitor::checkPhase(BlockStmt* block) {
+  if (mPhase == cPhase0) {
+    InitPhase newPhase = startPhase(block);
+
+    if (newPhase == cPhase1) {
+      mPhase = newPhase;
+    }
+  }
+}
+
 DefExpr* InitVisitor::firstField(FnSymbol* fn) const {
   AggregateType* at     = toAggregateType(fn->_this->type);
   DefExpr*       retval = toDefExpr(at->fields.head);
@@ -587,22 +618,7 @@ void InitVisitor::describe(int offset) const {
 
   printf("%s#<InitVisitor\n", pad);
 
-  printf("%s  Phase: ",       pad);
-
-  switch (mPhase) {
-    case cPhase0:
-      printf("phase 0\n");
-      break;
-
-    case cPhase1:
-      printf("phase 1\n");
-      break;
-
-    case cPhase2:
-      printf("phase 2\n");
-      break;
-  }
-
+  printf("%s  Phase: %s\n", pad, phaseToString(mPhase));
 
   printf("%s  Block: ",       pad);
 
@@ -654,10 +670,14 @@ static void preNormalizeNonGenericInit(FnSymbol* fn) {
   AggregateType* at = toAggregateType(fn->_this->type);
   InitVisitor    state(fn);
 
-  // This implies the body contains at least one instance of super.init()
-  // and/or this.init() i.e. the body is not empty and we do not need to
-  // insert super.init()
-  if (state.isPhase0() == true || state.isPhase1() == true) {
+  // The body contains at least one instance of this.init()
+  // i.e. the body is not empty and we do not need to insert super.init()
+  if (state.isPhase0() == true) {
+    preNormalize(fn->body, state);
+
+  // The body contains at least one instance of super.init()
+  // i.e. the body is not empty and we do not need to insert super.init()
+  } else if (state.isPhase1() == true) {
     preNormalize(fn->body, state);
 
   // 1) Insert super.init()
@@ -715,6 +735,9 @@ static InitVisitor preNormalize(BlockStmt*  block,
 static InitVisitor preNormalize(BlockStmt*  block,
                                 InitVisitor state,
                                 Expr*       stmt) {
+  // This sub-block may have a different phase than the parent
+  state.checkPhase(block);
+
   while (stmt != NULL) {
     if (isDefExpr(stmt) == true) {
       stmt = stmt->next;

--- a/test/classes/initializers/cond-both-1-plus-field-init.bad
+++ b/test/classes/initializers/cond-both-1-plus-field-init.bad
@@ -1,2 +1,0 @@
-cond-both-1-plus-field-init.chpl:17: In initializer:
-cond-both-1-plus-field-init.chpl:21: error: field initialization not allowed before this.init()

--- a/test/classes/initializers/cond-both-1-plus-field-init.future
+++ b/test/classes/initializers/cond-both-1-plus-field-init.future
@@ -1,5 +1,0 @@
-bug: if() with this.init() in one arm and field init + super.init() in other...
-
-...fails to compile.
-
-This is recorded in issue #5960


### PR DESCRIPTION
This simple PR corrects an oversight managing the "phase" of an initializer along the arms
of a conditional statement.  Consider

proc init(a : bool) {
  // Should be "phase 0" to prevent field initialization

  if a then {
    // Should be revised to "phase 1"
    x = 11;
    super.init();

  } else {
    // Should remain "phase 0"
    this.init();
  }
}


Prior to this PR the "rule checker" fails to revise the phase from 0 -> 1 at the entry
of the consequent and so incorrectly reports an error when trying to initialize x.

After this PR, the phase is updated at the entry to the consequent as required.
This only occurs at the start of blocks when the phase is currently phase 0 to
determine if it should be upgraded to phase 1.


This PR also retires the future for this failure.




Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed single-locale paratest with -futures

