### PR TITLE
Convert certain uses of isResolved() to resolvedFunction() 

### DIFF
--- a/compiler/include/alist.h
+++ b/compiler/include/alist.h
@@ -116,36 +116,60 @@ class AList {
        actual = _alist_prev,                                            \
          _alist_prev = actual ? actual->prev : NULL)
 
-// Visits the formal and actual parameters of a normal call or a virtual method call.
-// Virtual method calls are represented by the PRIM_VIRTUAL_METHOD_CALL primitive.
-// In this case, the first actual argument contains the FnSymbol representing the
-// function being called, and the second argument contains the call id (cid).
-// These two initial arguments are elided when the actuals list is traversed.
-// There can be fewer formals than actuals if some of the formals are param
-// arguments.  But we'll get a null reference error if there are too few actuals.
-#define for_formals_actuals(formal, actual, call)                       \
-  FnSymbol* _alist_fn = (call)->isResolved();                           \
-  Expr * actual = (call)->argList.head;                                 \
-  if (_alist_fn) {                                                      \
-    if (_alist_fn->numFormals() != (call)->argList.length)              \
-      INT_FATAL(call, "number of actuals does not match number of formals in %s()", _alist_fn->name); \
-  } else if ((call)->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {           \
-    _alist_fn = toFnSymbol(toSymExpr(call->get(1))->symbol());          \
-    if (_alist_fn->numFormals() != (call)->argList.length - 2)          \
-      INT_FATAL(call, "number of actuals does not match number of formals in %s()", _alist_fn->name); \
-    actual = actual->next->next;                                        \
-  }                                                                     \
-  Expr* _alist_actual_next = (actual) ? actual->next : NULL;            \
-  for (ArgSymbol *formal = (_alist_fn->formals.head) ?                  \
-         toArgSymbol(toDefExpr(_alist_fn->formals.head)->sym) : NULL,   \
-         *_alist_formal_next = (formal && formal->defPoint->next) ?     \
-         toArgSymbol(toDefExpr((formal)->defPoint->next)->sym) : NULL;  \
-       (formal);                                                        \
-       formal = _alist_formal_next,                                     \
-         _alist_formal_next = (formal && formal->defPoint->next) ?      \
-         toArgSymbol(toDefExpr((formal)->defPoint->next)->sym) : NULL,  \
-         actual = _alist_actual_next,                                   \
-         _alist_actual_next = (actual) ? actual->next : NULL)
+
+
+
+//
+// Visits the formal and actual parameters of a normal call or a virtual
+// method call.  Virtual method calls are represented by the
+// PRIM_VIRTUAL_METHOD_CALL primitive.  In this case, the first actual
+// argument contains the FnSymbol representing the function being called,
+// and the second argument contains the call id (cid).  These two initial
+// arguments are elided when the actuals list is traversed. There can be
+// fewer formals than actuals if some of the formals are param arguments.
+// But we'll get a null reference error if there are too few actuals.
+//
+
+#define for_formals_actuals(formal, actual, call)                             \
+  FnSymbol* _alist_fn = (call)->resolvedFunction();                           \
+  Expr*     actual    = (call)->argList.head;                                 \
+                                                                              \
+  if (_alist_fn) {                                                            \
+    if (_alist_fn->numFormals() != (call)->argList.length) {                  \
+      INT_FATAL(call,                                                         \
+                "number of actuals does not match number of formals in %s()", \
+                _alist_fn->name);                                             \
+    }                                                                         \
+                                                                              \
+  } else if ((call)->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {                 \
+    _alist_fn = toFnSymbol(toSymExpr(call->get(1))->symbol());                \
+                                                                              \
+    if (_alist_fn->numFormals() != (call)->argList.length - 2) {              \
+      INT_FATAL(call,                                                         \
+                "number of actuals does not match number of formals in %s()", \
+                _alist_fn->name);                                             \
+    }                                                                         \
+                                                                              \
+    actual = actual->next->next;                                              \
+  }                                                                           \
+                                                                              \
+  Expr* _alist_actual_next = (actual) ? actual->next : NULL;                  \
+                                                                              \
+  for (ArgSymbol* formal = (_alist_fn->formals.head) ?                        \
+         toArgSymbol(toDefExpr(_alist_fn->formals.head)->sym) : NULL,         \
+                                                                              \
+       *_alist_formal_next = (formal && formal->defPoint->next) ?             \
+         toArgSymbol(toDefExpr((formal)->defPoint->next)->sym) : NULL;        \
+                                                                              \
+       (formal);                                                              \
+                                                                              \
+       formal             = _alist_formal_next,                               \
+       _alist_formal_next = (formal && formal->defPoint->next) ?              \
+          toArgSymbol(toDefExpr((formal)->defPoint->next)->sym) : NULL,       \
+       actual             = _alist_actual_next,                               \
+       _alist_actual_next = (actual) ? actual->next : NULL)
+
+
 
 #define for_fields(field, ct)                                           \
   for (Symbol *field = ((ct)->fields.head) ? toDefExpr((ct)->fields.head)->sym : NULL, \

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -419,7 +419,7 @@ static inline bool isTaskFun(FnSymbol* fn) {
 
 static inline FnSymbol* resolvedToTaskFun(CallExpr* call) {
   INT_ASSERT(call);
-  if (FnSymbol* cfn = call->isResolved()) {
+  if (FnSymbol* cfn = call->resolvedFunction()) {
     if (isTaskFun(cfn))
       return cfn;
   }

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -75,5 +75,8 @@ void stopCatchingSignals(void);
 void clean_exit(int status);
 
 void gdbShouldBreakHere(void); // must be exposed to avoid dead-code elim.
+
+void printCallStack();
+void printCallStackCalls();
 
 #endif

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -708,7 +708,7 @@ checkFormalActualBaseTypesMatch()
     if (! call->parentSymbol->hasFlag(FLAG_RESOLVED))
       continue;
 
-    if (FnSymbol* fn = call->isResolved())
+    if (FnSymbol* fn = call->resolvedFunction())
     {
       if (fn->hasFlag(FLAG_EXTERN))
         continue;
@@ -768,7 +768,7 @@ checkFormalActualTypesMatch()
 {
   for_alive_in_Vec(CallExpr, call, gCallExprs)
   {
-    if (FnSymbol* fn = call->isResolved())
+    if (FnSymbol* fn = call->resolvedFunction())
     {
       if (fn->hasFlag(FLAG_EXTERN))
         continue;

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -149,7 +149,7 @@ findNonTaskCaller(FnSymbol* fn) {
     FnSymbol* caller = NULL;
     forv_Vec(CallExpr, call, gCallExprs) {
       if (call->inTree()) {
-        if (FnSymbol* cfn = call->isResolved()) {
+        if (FnSymbol* cfn = call->resolvedFunction()) {
           if (cfn == fn) {
             caller = toFnSymbol(call->parentSymbol);
             break;
@@ -353,22 +353,24 @@ static void printCallStackOnError() {
 //
 // debugging convenience
 //
-void printCallStack();
 void printCallStack() {
   printCallStack(true, true, stdout);
 }
 
 // another one
-void printCallStackCalls();
 void printCallStackCalls() {
   printf("\n" "callStack %d elms\n\n", callStack.n);
+
   for (int i = 0; i < callStack.n; i++) {
     CallExpr* call = callStack.v[i];
-    FnSymbol* cfn = call->isResolved();
-    printf("%d  %d %s  <-  %d %s\n", i,
-           cfn ? cfn->id : 0, cfn ? cfn->name: "<no callee>",
+    FnSymbol* cfn  = call->resolvedFunction();
+
+    printf("%d  %d %s  <-  %d %s\n",
+           i,
+           cfn  ? cfn->id  : 0, cfn  ? cfn->name         : "<no callee>",
            call ? call->id : 0, call ? call->stringLoc() : "<no call>");
   }
+
   printf("\n");
 }
 


### PR DESCRIPTION
It is incongruous that the code base includes

   FnSymbol* CallExpr::isResolved() const;

rather than

   bool CallExpr::isResolved() const;


I introduced 

   FnSymbol* CallExpr::resolvedFunction() const;

to serve as a migration path and have been migrating to it incrementally.  This is
the first of a short sequence of trivial PRs to complete the migration.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Also compiled with c++14 enabled for clang/darwin.
Passed a single-locale paratest

