### PR TITLE
Update AST/*.cpp and codegen/expr.cpp

### DIFF
--- a/compiler/AST/ParamForLoop.cpp
+++ b/compiler/AST/ParamForLoop.cpp
@@ -480,26 +480,29 @@ Type* ParamForLoop::indexType()
   SymExpr*  lse     = lowExprGet();
   SymExpr*  hse     = highExprGet();
   CallExpr* range    = new CallExpr("chpl_build_bounded_range",
-                                    lse->copy(), hse->copy());
+                                    lse->copy(),
+                                    hse->copy());
   Type*     idxType = 0;
 
   insertBefore(range);
 
   resolveCall(range);
 
-  if (FnSymbol* sym = range->isResolved())
+  if (FnSymbol* sym = range->resolvedFunction())
   {
     resolveFormals(sym);
 
     DefExpr* formal = toDefExpr(sym->formals.get(1));
 
-    if (toArgSymbol(formal->sym)->typeExpr)
+    if (toArgSymbol(formal->sym)->typeExpr != NULL) {
       idxType = toArgSymbol(formal->sym)->typeExpr->body.tail->typeInfo();
-    else
+    } else {
       idxType = formal->sym->type;
+    }
 
     range->remove();
   }
+
   else
   {
     INT_FATAL("unresolved range");

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -376,8 +376,8 @@ bool isRelationalOperator(CallExpr* call) {
 // return & 2 is true if se is a use
 //
 // Note that a DefExpr is where we hang the variable declaration, but after
-// normalize, a DefExpr itself does not set a variable, and so it does not count
-// as a Def.
+// normalize, a DefExpr itself does not set a variable, and so it does not
+// count as a Def.
 int isDefAndOrUse(SymExpr* se) {
   if (CallExpr* call = toCallExpr(se->parentExpr)) {
 
@@ -387,16 +387,19 @@ int isDefAndOrUse(SymExpr* se) {
 //    Expr* src = NULL;
 //    if (getSettingPrimitiveDstSrc(call, &dest, &src) && dest == se) {
 //      CallExpr* rhsCall = toCallExpr(src);
+
     if ((call->isPrimitive(PRIM_MOVE) || call->isPrimitive(PRIM_ASSIGN)) &&
         call->get(1) == se) {
-      CallExpr* rhsCall = toCallExpr(call->get(2));
+      CallExpr*     rhsCall = toCallExpr(call->get(2));
       QualifiedType lhsQual = se->symbol()->qualType();
+
       if ((lhsQual.isRef() || lhsQual.isWideRef()) &&
           !isReferenceType(lhsQual.type()) &&
           !(rhsCall && rhsCall->isPrimitive(PRIM_SET_REFERENCE))) {
         // Assigning to a reference variable counts as a 'use'
         // of the reference and a 'def' of its value
         return 3;
+
 //      } else if(call->isPrimitive(PRIM_SET_MEMBER) ||
 //                call->isPrimitive(PRIM_SET_SVEC_MEMBER)) {
 //        // since setting a field might not change the entire object,
@@ -405,10 +408,13 @@ int isDefAndOrUse(SymExpr* se) {
 //        return 3;
       }
       return 1;
+
     } else if (isOpEqualPrim(call) && call->get(1) == se) {
       return 3;
-    } else if (FnSymbol* fn = call->isResolved()) {
+
+    } else if (FnSymbol* fn = call->resolvedFunction()) {
       ArgSymbol* arg = actual_to_formal(se);
+
       if (arg->intent == INTENT_REF ||
           arg->intent == INTENT_INOUT ||
           (strcmp(fn->name, "=") == 0   &&
@@ -420,11 +426,13 @@ int isDefAndOrUse(SymExpr* se) {
           //isRecordWrappedType(arg->type)) { // pass by reference
         return 3;
         // also use; do not "continue"
+
       } else if (arg->intent == INTENT_OUT) {
         return 1;
       }
     }
   }
+
   return 2;
 }
 
@@ -668,9 +676,11 @@ bool isTypeExpr(Expr* expr)
       }
     }
 
-    if (FnSymbol* fn = call->isResolved())
-      if (fn->retTag == RET_TYPE)
+    if (FnSymbol* fn = call->resolvedFunction()) {
+      if (fn->retTag == RET_TYPE) {
         return true;
+      }
+    }
   }
 
   return false;
@@ -970,13 +980,15 @@ static void addToUsedFnSymbols(std::set<FnSymbol*>& fnSymbols,
 */
 void collectUsedFnSymbols(BaseAST* ast, std::set<FnSymbol*>& fnSymbols) {
   AST_CHILDREN_CALL(ast, collectUsedFnSymbols, fnSymbols);
-  //if there is a function call, get the FnSymbol associated with it
-  //and look through that FnSymbol for other function calls. Do not
-  //look through an already visited FnSymbol, or you'll have an infinite
-  //loop in the case of recursion.
+
+  // if there is a function call, get the FnSymbol associated with it
+  // and look through that FnSymbol for other function calls. Do not
+  // look through an already visited FnSymbol, or you'll have an infinite
+  // loop in the case of recursion.
   if (CallExpr* call = toCallExpr(ast)) {
-    if (FnSymbol* fn = call->isResolved()) {
+    if (FnSymbol* fn = call->resolvedFunction()) {
       addToUsedFnSymbols(fnSymbols, fn);
+
     } else if (call->isPrimitive(PRIM_FTABLE_CALL)) {
       //
       // TODO: We'd like a way to accurately find the set of functions that

--- a/compiler/AST/bb.cpp
+++ b/compiler/AST/bb.cpp
@@ -211,8 +211,9 @@ void BasicBlock::buildBasicBlocks(FnSymbol* fn, Expr* stmt, bool mark) {
       // Set up goto map, so this block's successor can be back-patched later.
       std::vector<BasicBlock*>* vbb = gotoMaps.get(label);
 
-      if (!vbb)
+      if (vbb == NULL) {
         vbb = new std::vector<BasicBlock*>();
+      }
 
       vbb->push_back(basicBlock);
 
@@ -235,19 +236,20 @@ void BasicBlock::buildBasicBlocks(FnSymbol* fn, Expr* stmt, bool mark) {
     for_vector(BaseAST, ast, asts) {
       if (CallExpr* call = toCallExpr(ast)) {
         // mark function calls as essential
-        if (call->isResolved() != NULL)
+        if (call->resolvedFunction() != NULL) {
           mark = true;
 
         // mark essential primitives as essential
-        else if (call->primitive && call->primitive->isEssential)
+        } else if (call->primitive && call->primitive->isEssential) {
           mark = true;
 
         // mark assignments to global variables as essential
-        else if (call->isPrimitive(PRIM_MOVE) ||
+        } else if (call->isPrimitive(PRIM_MOVE) ||
                  call->isPrimitive(PRIM_ASSIGN)) {
           if (SymExpr* se = toSymExpr(call->get(1))) {
-            if (se->symbol()->type->refType == NULL)
+            if (se->symbol()->type->refType == NULL) {
               mark = true;
+            }
           }
         }
       }

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1261,14 +1261,19 @@ CallExpr* createCast(BaseAST* src, BaseAST* toType)
 
 
 QualifiedType CallExpr::qualType(void) {
-  if (primitive)
-    return primitive->returnInfo(this);
+  QualifiedType retval(NULL);
 
-  else if (isResolved())
-    return QualifiedType(isResolved()->retType);
+  if (primitive) {
+    retval = primitive->returnInfo(this);
 
-  else
-    return QualifiedType(dtUnknown);
+  } else if (isResolved()) {
+    retval = QualifiedType(resolvedFunction()->retType);
+
+  } else {
+    retval = QualifiedType(dtUnknown);
+  }
+
+  return retval;
 }
 
 void CallExpr::prettyPrint(std::ostream *o) {
@@ -1508,27 +1513,33 @@ CallExpr* ContextCallExpr::getRValueCall() {
 void  ContextCallExpr::getCalls(CallExpr*& refCall,
                                 CallExpr*& valueCall,
                                 CallExpr*& constRefCall) {
-  refCall = NULL;
-  valueCall = NULL;
+  refCall      = NULL;
+  valueCall    = NULL;
   constRefCall = NULL;
 
   if (options.length == 2) {
     refCall = getRefCall();
+
     CallExpr* rvalueCall = getRValueCall();
-    FnSymbol* fn = rvalueCall->isResolved();
+    FnSymbol* fn         = rvalueCall->resolvedFunction();
+
     INT_ASSERT(fn);
-    if (fn->retTag == RET_CONST_REF)
+
+    if (fn->retTag == RET_CONST_REF) {
       constRefCall = rvalueCall;
-    else
+    } else {
       valueCall = rvalueCall;
+    }
+
   } else if (options.length == 3) {
     // Note: it would be nicer to check retTag to decide between
     // ref / value versions. However, doing so is challenging because
     // of the way that iterator functions no longer have the original
     // retTag.
     constRefCall = toCallExpr(options.get(1));
-    valueCall = toCallExpr(options.get(2));
-    refCall = toCallExpr(options.get(3));
+    valueCall    = toCallExpr(options.get(2));
+    refCall      = toCallExpr(options.get(3));
+
   } else {
     INT_FATAL("Bad ContextCallExpr options");
   }

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -1059,7 +1059,7 @@ static void insertLocalsForRefs(Vec<Symbol*>& syms,
       else if (CallExpr* call = toCallExpr(move->get(2)))
       {
         // The RHS is a function call.
-        if (FnSymbol* fn = call->isResolved()) {
+        if (FnSymbol* fn = call->resolvedFunction()) {
           for_actuals(actual, call) {
             SymExpr* se = toSymExpr(actual);
 
@@ -1165,12 +1165,14 @@ noOtherCalls(FnSymbol* callee, CallExpr* theCall) {
       // TODO: This forv + filter casts a wide net.
       // Try to make the filter reject as many cases as possible
       // by first matching on the callee and then testing if call == theCall.
-      if (FnSymbol* rc = call->isResolved()) {
-        if (rc == callee)
+      if (FnSymbol* rc = call->resolvedFunction()) {
+        if (rc == callee) {
           return false;
+        }
       }
     }
   }
+
   return true;
 }
 

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -579,8 +579,9 @@ static bool isFlowStmt(Expr* stmt) {
     // false-positive memory allocation errors because the waiting (parent
     // task) can then proceed to test that the subtask has not leaked before
     // the subtask release locally-(dynamically-)allocated memory.
-    else if (FnSymbol* fn = call->isResolved())
+    else if (FnSymbol* fn = call->resolvedFunction()) {
       retval = (strcmp(fn->name, "_downEndCount") == 0) ? true : false;
+    }
   }
 
   return retval;

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3211,7 +3211,7 @@ static GenRet codegen_prim_get_real(GenRet arg, Type* type, bool real) {
 GenRet CallExpr::codegen() {
   SET_LINENO(this);
 
-  FnSymbol* fn = isResolved();
+  FnSymbol* fn = resolvedFunction();
   GenRet    ret;
 
   // Note (for debugging), function name is in parentSymbol->cname.
@@ -5285,7 +5285,7 @@ static bool codegenIsSpecialPrimitive(BaseAST* target, Expr* e, GenRet& ret) {
 }
 
 void CallExpr::codegenInvokeOnFun() {
-  FnSymbol*           fn       = isResolved();
+  FnSymbol*           fn       = resolvedFunction();
   GenRet              localeId = get(1);
   const char*         fname    = NULL;
   GenRet              argBundle;
@@ -5322,7 +5322,7 @@ void CallExpr::codegenInvokeOnFun() {
 }
 
 void CallExpr::codegenInvokeTaskFun(const char* name) {
-  FnSymbol*           fn            = isResolved();
+  FnSymbol*           fn            = resolvedFunction();
   GenRet              taskList      = codegenValue(get(1));
   GenRet              taskListNode;
   GenRet              taskBundle;


### PR DESCRIPTION
Continue to convert certain uses of CallExpr::isResolved() to CallExpr::resolvedFunction()
in codegen/expr.cpp and AST/*.cpp

Compiled with various configurations
Passed single-locale paratest
