### PR TITLE
Update certain uses of isResolved() in optimizations/*.cpp and passes/*.cpp

### DIFF
--- a/compiler/optimizations/replaceArrayAccessesWithRefTemps.cpp
+++ b/compiler/optimizations/replaceArrayAccessesWithRefTemps.cpp
@@ -113,15 +113,19 @@ static bool anyAssignmentsToArray(std::vector<ContextCallExpr*> allContextCalls,
 void replaceArrayAccessesWithRefTemps() {
   if (!fReplaceArrayAccessesWithRefTemps)
     return;
+
   forv_Vec(BlockStmt, block, gBlockStmts) {
     if (ForLoop* forLoop = toForLoop(block)) {
-      std::vector<ContextCallExpr*> allContextCalls;
-      SymExpr* loopIdx = forLoop->indexGet();
-      CallExpr* indexMove = NULL;
-      Symbol* indexVar = NULL;
+      std::vector<ContextCallExpr*>                     allContextCalls;
+      std::vector<BaseAST*>                             asts;
       std::map<Symbol*, std::vector<ContextCallExpr*> > arrayAccessMap;
-      std::vector<BaseAST*> asts;
+
+      SymExpr*  loopIdx   = forLoop->indexGet();
+      CallExpr* indexMove = NULL;
+      Symbol*   indexVar  = NULL;
+
       collect_asts(forLoop, asts);
+
       for_vector(BaseAST, ast, asts) {
         if (CallExpr* call = toCallExpr(ast)) {
           // find the move that stores the for loop's index variable into
@@ -142,6 +146,7 @@ void replaceArrayAccessesWithRefTemps() {
           }
         }
       }
+
       if (!indexMove) {
         // If we couldn't find an expected index move, skip the optimization
         if (DEBUG_RAAWRT) {
@@ -149,33 +154,44 @@ void replaceArrayAccessesWithRefTemps() {
                  "Not replacing accesses in loop\n",
                  forLoop->fname(), forLoop->linenum());
         }
+
         continue;
       }
+
       for_vector(BaseAST, astNode, asts) {
         if (ContextCallExpr* contextCall = toContextCallExpr(astNode)) {
           allContextCalls.push_back(contextCall);
+
           CallExpr* call = toCallExpr(contextCall);
+
           if (contextCall->parentSymbol != forLoop->parentSymbol ||
               call->numActuals() != 2) {
             // TODO: Multidimensional not handled yet.
             // TODO: Nested functions not handled yet.
             continue;
           }
-          if (FnSymbol* fn = call->isResolved()) {
+
+          if (FnSymbol* fn = call->resolvedFunction()) {
             if (fn->hasFlag(FLAG_REMOVABLE_ARRAY_ACCESS)) {
               assert(isSymExpr(call->get(1)));
+
               Symbol* arraySym = toSymExpr(call->get(1))->symbol();
+
               if (SymExpr* arrayIdx = toSymExpr(call->get(2))) {
-                if (arrayIdx->symbol()->defPoint->parentExpr == forLoop && /*indexVar == arrayIdx->var &&*/ arrayIdx->symbol()->hasFlag(FLAG_INDEX_VAR)) {
+                if (arrayIdx->symbol()->defPoint->parentExpr == forLoop &&
+                    /*indexVar == arrayIdx->var &&*/
+                    arrayIdx->symbol()->hasFlag(FLAG_INDEX_VAR)) {
                   // build map from array symbol to vector of context calls
                   // where the context calls are all of the form:
                   // ContextCallExpr(CallExpr('this', 'array', 'loopIdx'),
                   //                 CallExpr('this', 'array', 'loopIdx'))
                   arrayAccessMap[arraySym].push_back(contextCall);
+
                   if (DEBUG_RAAWRT) {
-                    CallExpr* call = toCallExpr(contextCall);
-                    SymExpr* array = toSymExpr(call->get(1));
-                    SymExpr* idx = toSymExpr(call->get(2));
+                    CallExpr* call  = toCallExpr(contextCall);
+                    SymExpr*  array = toSymExpr(call->get(1));
+                    SymExpr*  idx   = toSymExpr(call->get(2));
+
                     printf("%s:%d: found removable array access %s[%s] (%d)\n",
                            contextCall->fname(),
                            contextCall->linenum(),
@@ -189,53 +205,81 @@ void replaceArrayAccessesWithRefTemps() {
           }
         }
       }
+
       for (std::map<Symbol*, std::vector<ContextCallExpr*> >::iterator it = arrayAccessMap.begin(); it != arrayAccessMap.end(); ++it) {
-        int vecSize = it->second.size();
+        int              vecSize   = it->second.size();
         ContextCallExpr* firstCall = it->second.front();
+
         if (vecSize <= 2) {
           if (DEBUG_RAAWRT) {
-            CallExpr* call = toCallExpr(firstCall);
-            SymExpr* array = toSymExpr(call->get(1));
-            SymExpr* idx = toSymExpr(call->get(2));
+            CallExpr* call  = toCallExpr(firstCall);
+            SymExpr*  array = toSymExpr(call->get(1));
+            SymExpr*  idx   = toSymExpr(call->get(2));
+
             printf("%s:%d: not replacing array access %s[%s] (%d), "
                    "number of accesses %d is under threshold\n",
-                   firstCall->fname(), firstCall->linenum(), array->symbol()->name,
-                   idx->symbol()->name, firstCall->id, vecSize);
+                   firstCall->fname(),
+                   firstCall->linenum(),
+                   array->symbol()->name,
+                   idx->symbol()->name,
+                   firstCall->id, vecSize);
           }
+
         } else /*if (vecSize > 2) */ { // TODO: tune this threshold
           SET_LINENO(indexMove);
-          CallExpr* accessCall = toCallExpr(firstCall);
-          SymExpr* array = toSymExpr(accessCall->get(1));
+
+          CallExpr*  accessCall = toCallExpr(firstCall);
+          SymExpr*   array      = toSymExpr(accessCall->get(1));
+
           // assign an array indexing context call in the vector to a 'ref'
           // variable at the top of the loop
-          VarSymbol* ref = newTemp("arrayAccessTmp", firstCall->typeInfo());
+          VarSymbol* ref        = newTemp("arrayAccessTmp",
+                                          firstCall->typeInfo());
+
           if (anyAssignmentsToArray(allContextCalls, array)) {
             // If any assignment to the array happens in the loop, mark the
             // temp as a user-level reference var.  This will prevent it
             // from being changed to by-value during cullOverReferences.
             if (DEBUG_RAAWRT) {
-              printf("found an assignment to %s, forcing refs\n", array->symbol()->name);
+              printf("found an assignment to %s, forcing refs\n",
+                     array->symbol()->name);
             }
+
             ref->addFlag(FLAG_REF_VAR);
           }
 
-          indexMove->insertAfter(new CallExpr(PRIM_MOVE, ref, firstCall->copy()));
+          indexMove->insertAfter(new CallExpr(PRIM_MOVE,
+                                              ref,
+                                              firstCall->copy()));
+
           indexMove->insertAfter(new DefExpr(ref));
 
           // then replace all of the indexing context calls in the vector
           // with uses of that 'ref'
-          for (std::vector<ContextCallExpr*>::iterator calls = it->second.begin(); calls != it->second.end(); ++calls) {
+          for (std::vector<ContextCallExpr*>::iterator calls = it->second.begin();
+               calls != it->second.end();
+               ++calls) {
+
             ContextCallExpr* call = *calls;
+
             if (DEBUG_RAAWRT) {
-              CallExpr* accessCall = toCallExpr(call);
-              SymExpr* array = toSymExpr(accessCall->get(1));
-              SymExpr* idx = toSymExpr(accessCall->get(2));
-              const char* sayref = ref->hasFlag(FLAG_REF_VAR) ? " ref " : " ";
+              CallExpr*   accessCall = toCallExpr(call);
+              SymExpr*    array      = toSymExpr(accessCall->get(1));
+              SymExpr*    idx        = toSymExpr(accessCall->get(2));
+              const char* sayref     = NULL;
+
+              sayref = ref->hasFlag(FLAG_REF_VAR) ? " ref " : " ";
+
               printf("%s:%d: replacing array access %s[%s] (%d)"
                      " with%stemp\n",
-                     call->fname(), call->linenum(), array->symbol()->name,
-                     idx->symbol()->name, call->id, sayref);
+                     call->fname(),
+                     call->linenum(),
+                     array->symbol()->name,
+                     idx->symbol()->name,
+                     call->id,
+                     sayref);
             }
+
             call->replace(new SymExpr(ref));
           }
         }

--- a/compiler/optimizations/scalarReplace.cpp
+++ b/compiler/optimizations/scalarReplace.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,9 +23,10 @@
 // This pass implements scalar replacement of aggregates.
 //
 
+#include "optimizations.h"
+
 #include "astutil.h"
 #include "expr.h"
-#include "optimizations.h"
 #include "passes.h"
 #include "stmt.h"
 #include "stringutil.h"
@@ -209,7 +210,7 @@ scalarReplaceClass(AggregateType* ct, Symbol* sym) {
     return false;
   if (!
       (alloc->isResolved() &&
-       alloc->isResolved()->hasFlag(FLAG_ALLOCATOR)))
+       alloc->resolvedFunction()->hasFlag(FLAG_ALLOCATOR)))
     return false;
 
   //
@@ -235,10 +236,10 @@ scalarReplaceClass(AggregateType* ct, Symbol* sym) {
             // chpl_here_free() have as its first argument a void *
             call->isPrimitive(PRIM_CAST_TO_VOID_STAR) ||
             (call->isResolved() &&
-             (call->isResolved()->hasFlag(FLAG_ALLOCATOR) ||
+             (call->resolvedFunction()->hasFlag(FLAG_ALLOCATOR) ||
               // TODO: don't know this is necessary as the arg to free
               // is a void *
-              call->isResolved()->hasFlag(FLAG_LOCALE_MODEL_FREE)))))
+              call->resolvedFunction()->hasFlag(FLAG_LOCALE_MODEL_FREE)))))
         return false;
     }
   }
@@ -289,7 +290,7 @@ scalarReplaceClass(AggregateType* ct, Symbol* sym) {
                  // TODO: don't know if this is still needed.  The
                  // PRIM_CAST_TO_VOID_STAR case may take care of it.
                  (call->isResolved() &&
-                  call->isResolved()->hasFlag(FLAG_LOCALE_MODEL_FREE))) {
+                  call->resolvedFunction()->hasFlag(FLAG_LOCALE_MODEL_FREE))) {
         //
         // we can remove the setting of the cid because it is never
         // used and we are otherwise able to remove the class
@@ -303,7 +304,7 @@ scalarReplaceClass(AggregateType* ct, Symbol* sym) {
         CallExpr* parentNext = toCallExpr(parent->next);
         if (parentNext &&
             parentNext->isResolved() &&
-            parentNext->isResolved()->hasFlag(FLAG_LOCALE_MODEL_FREE))
+            parentNext->resolvedFunction()->hasFlag(FLAG_LOCALE_MODEL_FREE))
           parentNext->remove();
         parent->remove();
       } else if (call->isPrimitive(PRIM_SET_MEMBER)) {

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -127,67 +127,82 @@ static ArgSymbol* newFile(FnSymbol* fn) {
 //
 static void
 insertLineNumber(CallExpr* call) {
-  FnSymbol* fn = call->getFunction();
-  ModuleSymbol* mod = fn->getModule();
-  ArgSymbol* file = filenameMap.get(fn);
-  ArgSymbol* line = linenoMap.get(fn);
   SET_LINENO(call);
 
-  if (call->isPrimitive(PRIM_GET_USER_FILE) || 
+  FnSymbol*     fn   = call->getFunction();
+  ModuleSymbol* mod  = fn->getModule();
+  ArgSymbol*    file = filenameMap.get(fn);
+  ArgSymbol*    line = linenoMap.get(fn);
+
+
+  if (call->isPrimitive(PRIM_GET_USER_FILE) ||
       call->isPrimitive(PRIM_GET_USER_LINE)) {
-    
+
     // add both arguments or none
-    if (!file) { 
+    if (!file) {
       line = newLine(fn);
       file = newFile(fn);
     }
-    
-    // 
+
+    //
     if (call->isPrimitive(PRIM_GET_USER_FILE)) {
       call->replace(new SymExpr(file));
     } else if (call->isPrimitive(PRIM_GET_USER_LINE)) {
       call->replace(new SymExpr(line));
     }
-  } else if (fn->hasFlag(FLAG_EXTERN) ||
-             (fn->hasFlag(FLAG_EXPORT) && !fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO)) ||
-             !strcmp(fn->name, "chpl__heapAllocateGlobals") ||
-             !strcmp(fn->name, "chpl__initStringLiterals") ||
-             !strcmp(fn->name, "chpl__initModuleGuards") ||
-             !strcmp(fn->name, "chpl_gen_main") ||
-             ftableMap.count(fn) ||
-             (mod->modTag == MOD_USER && 
-              !fn->hasFlag(FLAG_COMPILER_GENERATED) && !fn->hasFlag(FLAG_INLINE)) ||
-             (developer && strcmp(fn->name, "halt"))) {
-    // hilde sez: This special casing is suspect.  Can't we key off a flag?
 
+  } else if (fn->hasFlag(FLAG_EXTERN)                           ||
+             (fn->hasFlag(FLAG_EXPORT) &&
+              !fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO))         ||
+             strcmp(fn->name, "chpl__heapAllocateGlobals") == 0 ||
+             strcmp(fn->name, "chpl__initStringLiterals")  == 0 ||
+             strcmp(fn->name, "chpl__initModuleGuards")    == 0 ||
+             strcmp(fn->name, "chpl_gen_main")             == 0 ||
+             ftableMap.count(fn)                                ||
+             (mod->modTag == MOD_USER               &&
+              !fn->hasFlag(FLAG_COMPILER_GENERATED) &&
+              !fn->hasFlag(FLAG_INLINE)) ||
+             (developer && strcmp(fn->name, "halt"))) {
     // call is in user code; insert AST line number and filename
     // or developer flag is on and the call is not the halt() call
     // or the call is via the ftable
     if (call->isResolved() &&
-        call->isResolved()->hasFlag(FLAG_COMMAND_LINE_SETTING)) {
+        call->resolvedFunction()->hasFlag(FLAG_COMMAND_LINE_SETTING)) {
       call->insertAtTail(new_IntSymbol(0));
-      FnSymbol* fn = call->isResolved();
+
+      FnSymbol* fn = call->resolvedFunction();
+
       INT_ASSERT(fn);
       INT_ASSERT(fn->substitutions.n);
+
       VarSymbol* var = toVarSymbol(fn->substitutions.v[0].value);
+
       INT_ASSERT(var);
       INT_ASSERT(var->immediate);
       INT_ASSERT(var->immediate->const_kind == CONST_KIND_STRING);
-      const char *cmdLineSetting =
-          astr("<command line setting of '", var->immediate->v_string, "'>");
-      int filenameIdx = getFilenameLookupPosition(cmdLineSetting);
+
+      const char* cmdLineSetting = astr("<command line setting of '",
+                                        var->immediate->v_string,
+                                        "'>");
+
+      int         filenameIdx    = getFilenameLookupPosition(cmdLineSetting);
+
       call->insertAtTail(new_IntSymbol(filenameIdx, INT_SIZE_32));
+
     } else {
       call->insertAtTail(new_IntSymbol(call->linenum()));
 
       int filenameIdx = getFilenameLookupPosition(call->fname());
+
       call->insertAtTail(new_IntSymbol(filenameIdx, INT_SIZE_32));
     }
+
   } else if (file) {
     // call is in non-user code, but the function already has line
     // number and filename arguments
     call->insertAtTail(line);
     call->insertAtTail(file);
+
   } else {
     // call is in non-user code, and the function requires new line
     // number and filename arguments
@@ -201,18 +216,21 @@ insertLineNumber(CallExpr* call) {
 
 
 static bool isClassMethodCall(CallExpr* call) {
-  FnSymbol* fn = call->isResolved();
+  FnSymbol* fn     = call->resolvedFunction();
+  bool      retval = false;
+
   if (fn && fn->isMethod() && fn->_this) {
     if (AggregateType* ct = toAggregateType(fn->_this->typeInfo())) {
-      if (fn->numFormals() > 0 &&
+      if (fn->numFormals()             >  0 &&
           fn->getFormal(1)->typeInfo() == fn->_this->typeInfo()) {
         if (isClass(ct) || ct->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-          return true;
+          retval = true;
         }
       }
     }
   }
-  return false;
+
+  return retval;
 }
 
 
@@ -237,7 +255,7 @@ static void insertNilChecks() {
       AggregateType* ct   = toAggregateType(arg0->typeInfo());
 
       if (ct && (isClass(ct) || ct->symbol->hasFlag(FLAG_WIDE_CLASS))) {
-        FnSymbol* fn = call->isResolved();
+        FnSymbol* fn = call->resolvedFunction();
 
         // Avoid inserting a nil-check if this is a call to a destructor
         if (fn == NULL || fn->hasFlag(FLAG_DESTRUCTOR) == false) {
@@ -259,16 +277,19 @@ void insertLineNumbers() {
   // directly by the runtime. The index for these matter, and are provided to
   // the runtime as defines in chpl-linefile-support.h
   std::vector<std::string> constantFilenames;
+
   // Put a null string into the iterator at the first position, some runtime
   // calls will pass in NULL for their filename, we can then use this null
   // string to deal with that case.
   constantFilenames.push_back("");
+
   // Add "<internal>" to the filename table if it didn't make it in there, some
   // runtime functions use this name directly, and it doesn't always end up in
   // the table otherwise
   constantFilenames.push_back("<internal>");
 
-  gFilenameLookup.insert(gFilenameLookup.begin(), constantFilenames.begin(),
+  gFilenameLookup.insert(gFilenameLookup.begin(),
+                         constantFilenames.begin(),
                          constantFilenames.end());
 
   if (!fNoNilChecks) {

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -340,7 +340,7 @@ static void
 bundleArgs(CallExpr* fcall, BundleArgsFnData &baData) {
   SET_LINENO(fcall);
   ModuleSymbol* mod = fcall->getModule();
-  FnSymbol* fn = fcall->isResolved();
+  FnSymbol* fn = fcall->resolvedFunction();
 
   const bool firstCall = baData.firstCall;
   if (firstCall)
@@ -602,7 +602,7 @@ static void moveDownEndCountToWrapper(FnSymbol* fn, FnSymbol* wrap_fn, Symbol* w
 static void create_block_fn_wrapper(FnSymbol* fn, CallExpr* fcall, BundleArgsFnData &baData)
 {
   ModuleSymbol* mod = fcall->getModule();
-  INT_ASSERT(fn == fcall->isResolved());
+  INT_ASSERT(fn == fcall->resolvedFunction());
 
   AggregateType* ctype = baData.ctype;
   FnSymbol *wrap_fn = new FnSymbol( astr("wrap", fn->name));
@@ -956,7 +956,7 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
                   varsToTrack.add(toAdd);
                 }
               }
-              else if (fnsContainingTaskll.in(call->isResolved())) {
+              else if (fnsContainingTaskll.in(call->resolvedFunction())) {
                 freeVar = false;
                 break;
               }


### PR DESCRIPTION
Continue to convert certain uses of CallExpr::isResolved() to CallExpr::resolvedFunction().

Update optimizations/*.cpp and passes/*.cpp

Compiled with multiple configurations.
Passed a single-locale paratest.  Threw --no-local for this run.

