### PR TITLE
Complete conversion of CallExpr::isResolved()

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1126,9 +1126,8 @@ void CallExpr::setUnresolvedFunction(const char* name) {
   }
 }
 
-// MDN 2016/01/29: This will become a predicate
-FnSymbol* CallExpr::isResolved() const {
-  return resolvedFunction();
+bool CallExpr::isResolved() const {
+  return (resolvedFunction() != NULL) ? true : false;
 }
 
 FnSymbol* CallExpr::resolvedFunction() const {

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -261,7 +261,7 @@ public:
 
   void            setUnresolvedFunction(const char* name);
 
-  FnSymbol*       isResolved()                                           const;
+  bool            isResolved()                                           const;
   FnSymbol*       resolvedFunction()                                     const;
   void            setResolvedFunction(FnSymbol* fn);
 

--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -335,18 +335,18 @@ bool Scope::startingToHandleFormalTemps(const Expr* stmt) const {
 
   if (mLocalsHandled == false) {
     if (const CallExpr* call = toConstCallExpr(stmt)) {
-      FnSymbol* fn  =  NULL;
-      SymExpr*  lhs =  NULL;
-      SymExpr*  rhs =  NULL;
+      if (FnSymbol* fn = call->resolvedFunction()) {
+        if (fn->hasFlag(FLAG_ASSIGNOP) == true && call->numActuals() == 2) {
+          SymExpr* lhs = toSymExpr(call->get(1));
+          SymExpr* rhs = toSymExpr(call->get(2));
 
-      if ((fn  = call->isResolved())               != NULL &&
-          fn->hasFlag(FLAG_ASSIGNOP)               == true &&
-          call->numActuals()                       ==    2 &&
-          (lhs = toSymExpr(call->get(1)))          != NULL &&
-          (rhs = toSymExpr(call->get(2)))          != NULL &&
-          isArgSymbol(lhs->symbol())               == true &&
-          rhs->symbol()->hasFlag(FLAG_FORMAL_TEMP) == true) {
-        retval = true;
+          if (lhs                                      != NULL &&
+              rhs                                      != NULL &&
+              isArgSymbol(lhs->symbol())               == true &&
+              rhs->symbol()->hasFlag(FLAG_FORMAL_TEMP) == true) {
+            retval = true;
+          }
+        }
       }
     }
   }

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -161,7 +161,7 @@ void ReturnByRef::returnByRefCollectCalls(RefMap& calls)
 FnSymbol* ReturnByRef::theTransformableFunction(CallExpr* call)
 {
   // The common case of a user-level call to a resolved function
-  FnSymbol* theCall = call->isResolved();
+  FnSymbol* theCall = call->resolvedFunction();
 
   // Also handle the PRIMOP for a virtual method call
   if (theCall == NULL)
@@ -249,18 +249,23 @@ void ReturnByRef::insertAssignmentToFormal(FnSymbol* fn, ArgSymbol* formal)
   CallExpr* returnCall  = toCallExpr(returnPrim);
   Expr*     returnValue = returnCall->get(1)->remove();
   CallExpr* moveExpr    = new CallExpr(PRIM_ASSIGN, formal, returnValue);
+  Expr*     expr        = returnPrim;
 
-
-  Expr* expr = returnPrim;
   // Walk backwards while the previous element is an autoDestroy call
   while (expr->prev != NULL) {
     bool stop = true;
-    if (CallExpr* call = toCallExpr(expr->prev))
-      if (FnSymbol* calledFn = call->isResolved())
-        if (calledFn->hasFlag(FLAG_AUTO_DESTROY_FN))
-          stop = false;
 
-    if (stop) break;
+    if (CallExpr* call = toCallExpr(expr->prev)) {
+      if (FnSymbol* calledFn = call->resolvedFunction()) {
+        if (calledFn->hasFlag(FLAG_AUTO_DESTROY_FN)) {
+          stop = false;
+        }
+      }
+    }
+
+    if (stop == true) {
+      break;
+    }
 
     expr = expr->prev;
   }
@@ -380,9 +385,10 @@ void ReturnByRef::updateAssignmentsFromRefTypeToValue(FnSymbol* fn)
             // A chpl__unref call may be inserted to implement copy-out
             // semantics for the returning of arrays.
             bool isCopied = false;
+
             for_SymbolUses(use, varLhs) {
               if (CallExpr* call = toCallExpr(use->parentExpr)) {
-                if (FnSymbol* parentFn = call->isResolved()) {
+                if (FnSymbol* parentFn = call->resolvedFunction()) {
                   if (parentFn->hasFlag(FLAG_INIT_COPY_FN) ||
                       parentFn->hasFlag(FLAG_UNREF_FN)) {
                     isCopied = true;
@@ -506,11 +512,13 @@ void ReturnByRef::transform()
     }
     else
     {
-      FnSymbol * calledFn = call->isResolved();
-      if (!calledFn->hasFlag(FLAG_NEW_ALIAS_FN))
+      FnSymbol* calledFn = call->resolvedFunction();
+
+      if (!calledFn->hasFlag(FLAG_NEW_ALIAS_FN)) {
         // fixupNewAlias removes some - but not all - calls
         // to the newAlias function from the tree.
         INT_ASSERT(false);
+      }
     }
   }
 
@@ -568,7 +576,7 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
   Expr*     lhs       = moveExpr->get(1);
 
   CallExpr* callExpr  = toCallExpr(moveExpr->get(2));
-  FnSymbol* fn        = callExpr->isResolved();
+  FnSymbol* fn        = callExpr->resolvedFunction();
 
   Expr*     nextExpr  = moveExpr->next;
   CallExpr* copyExpr  = NULL;
@@ -599,7 +607,7 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
       {
         if (CallExpr* rhsCall = toCallExpr(callNext->get(2)))
         {
-          FnSymbol* rhsFn = rhsCall->isResolved();
+          FnSymbol* rhsFn = rhsCall->resolvedFunction();
 
           if (rhsFn                              != NULL &&
               (rhsFn->hasFlag(FLAG_AUTO_COPY_FN) == true ||
@@ -644,7 +652,7 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
 
   // Possibly reduce a copy operation to a simple move
   if (copyExpr) {
-    FnSymbol* rhsFn = copyExpr->isResolved();
+    FnSymbol* rhsFn = copyExpr->resolvedFunction();
 
     // If replacing an init copy, we got to a user variable.
     // Use an unalias call if possible
@@ -691,10 +699,12 @@ static Map<FnSymbol*,Vec<FnSymbol*>*> retToArgCache;
 // replacing it with (newSym), and the function that was called in the first
 // use of oldSym in the callee, to replace oldSym with newSym without breaking
 // the AST.
-inline static void
-replacementHelper(CallExpr* focalPt, VarSymbol* oldSym, Symbol* newSym,
-                  FnSymbol* useFn) {
-  focalPt->insertAfter(new CallExpr(PRIM_ASSIGN, newSym,
+inline static void replacementHelper(CallExpr*  focalPt,
+                                     VarSymbol* oldSym,
+                                     Symbol*    newSym,
+                                     FnSymbol* useFn) {
+  focalPt->insertAfter(new CallExpr(PRIM_ASSIGN,
+                                    newSym,
                                     new CallExpr(useFn, oldSym)));
 }
 
@@ -713,20 +723,32 @@ static FnSymbol*
 createClonedFnWithRetArg(FnSymbol* fn, FnSymbol* useFn)
 {
   SET_LINENO(fn);
-  FnSymbol* newFn = fn->copy();
+
+  FnSymbol*  newFn = fn->copy();
   // Note: other code does strcmps against the name _retArg
-  ArgSymbol* arg = new ArgSymbol(INTENT_REF, "_retArg", useFn->retType->refType);
+  ArgSymbol* arg   = new ArgSymbol(INTENT_REF,
+                                   "_retArg",
+                                   useFn->retType->refType);
+
   arg->addFlag(FLAG_RETARG);
+
   newFn->insertFormalAtTail(arg);
   newFn->addFlag(FLAG_FN_RETARG);
+
   VarSymbol* ret = toVarSymbol(newFn->getReturnSymbol());
+
   INT_ASSERT(ret);
+
   Expr* returnPrim = newFn->body->body.tail;
+
   returnPrim->replace(new CallExpr(PRIM_RETURN, gVoid));
+
   newFn->retType = dtVoid;
+
   fn->defPoint->insertBefore(new DefExpr(newFn));
 
   std::vector<SymExpr*> symExprs;
+
   collectSymExprs(newFn, symExprs);
 
   // In the body of the function, replace references to the original
@@ -737,53 +759,68 @@ createClonedFnWithRetArg(FnSymbol* fn, FnSymbol* useFn)
   for_vector(SymExpr, se, symExprs) {
     if (se->symbol() == ret) {
       CallExpr* move = toCallExpr(se->parentExpr);
+
       if (move && move->isPrimitive(PRIM_MOVE) && move->get(1) == se) {
         SET_LINENO(move);
         replacementHelper(move, ret, arg, useFn);
       } else {
         // Any other call or primitive.
-        FnSymbol* calledFn = move->isResolved();
-        CallExpr* parent = toCallExpr(move->parentExpr);
-        if (calledFn && !strcmp(calledFn->name, "=") &&
+        FnSymbol* calledFn = move->resolvedFunction();
+        CallExpr* parent   = toCallExpr(move->parentExpr);
+
+        if (calledFn                    != NULL &&
+            strcmp(calledFn->name, "=") ==    0 &&
             // Filter out case handled above.
             (!parent || !parent->isPrimitive(PRIM_MOVE))) {
           replacementHelper(move, ret, arg, useFn);
+
         } else {
-          Symbol* tmp = newTemp("ret_to_arg_tmp_", useFn->retType);
+          Symbol*   tmp   = newTemp("ret_to_arg_tmp_", useFn->retType);
+          CallExpr* deref = new CallExpr(PRIM_DEREF, arg);
+          CallExpr* move  = new CallExpr(PRIM_MOVE, tmp, deref);
+
           se->getStmtExpr()->insertBefore(new DefExpr(tmp));
-          se->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_DEREF, arg)));
+          se->getStmtExpr()->insertBefore(move);
+
           se->setSymbol(tmp);
         }
       }
     }
   }
+
   return newFn;
 }
 
 
-static void replaceRemainingUses(Vec<SymExpr*>& use, SymExpr* firstUse,
-                                 Symbol* actual)
-{
+static void replaceRemainingUses(Vec<SymExpr*>& use,
+                                 SymExpr*       firstUse,
+                                 Symbol*        actual) {
   // for each remaining use "se"
-  //   replace se with deref of the actual return value argument, unless parent is
-  //   accessing its address
+  //   replace se with deref of the actual return value argument,
+  //   unless parent is accessing its address
   forv_Vec(SymExpr, se, use) {
     // Because we've already handled the first use
     if (se != firstUse) {
       CallExpr* parent = toCallExpr(se->parentExpr);
+
       if (parent) {
         SET_LINENO(parent);
+
         if (parent->isPrimitive(PRIM_ADDR_OF)) {
           parent->replace(new SymExpr(actual));
         } else {
-          FnSymbol* parentFn = parent->isResolved();
+          FnSymbol* parentFn = parent->resolvedFunction();
+
           if (!(parentFn->hasFlag(FLAG_AUTO_COPY_FN) ||
                 parentFn->hasFlag(FLAG_INIT_COPY_FN))) {
             // Leave the auto copies/inits in, we'll need them for
             // moving information back to us.
 
             // Copy the information we currently have into the temp
-            se->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, se->symbol(), new CallExpr(PRIM_DEREF, actual)));
+            CallExpr* deref = new CallExpr(PRIM_DEREF, actual);
+            CallExpr* move  = new CallExpr(PRIM_MOVE, se->symbol(), deref);
+
+            se->getStmtExpr()->insertBefore(move);
           }
         }
       }
@@ -806,18 +843,20 @@ static void replaceRemainingUses(Vec<SymExpr*>& use, SymExpr* firstUse,
 // where a call to useFn replaces the return that used to be at the end of
 // newFn.  The use function is expected to be assignment, initCopy or
 // autoCopy.  All other cases are ignored.
-static void replaceUsesOfFnResultInCaller(CallExpr* move, CallExpr* call,
-                                          Vec<SymExpr*>& use, FnSymbol* fn)
-{
+static void replaceUsesOfFnResultInCaller(CallExpr*      move,
+                                          CallExpr*      call,
+                                          Vec<SymExpr*>& use,
+                                          FnSymbol*      fn) {
   SymExpr* firstUse = use.v[0];
+
   // If this isn't a call expression, we've got problems.
   if (CallExpr* useCall = toCallExpr(firstUse->parentExpr)) {
-    if (FnSymbol* useFn = useCall->isResolved()) {
-      if ((!strcmp(useFn->name, "=") && firstUse == useCall->get(2)) ||
-          useFn->hasFlag(FLAG_AUTO_COPY_FN) ||
+    if (FnSymbol* useFn = useCall->resolvedFunction()) {
+      if ((strcmp(useFn->name, "=") == 0 && firstUse == useCall->get(2)) ||
+          useFn->hasFlag(FLAG_AUTO_COPY_FN)                              ||
           useFn->hasFlag(FLAG_INIT_COPY_FN)) {
-        Symbol* actual;
-        FnSymbol* newFn = NULL;
+        Symbol*   actual = NULL;
+        FnSymbol* newFn  = NULL;
 
         //
         // check cache for new function
@@ -837,55 +876,64 @@ static void replaceUsesOfFnResultInCaller(CallExpr* move, CallExpr* call,
           // add new function to cache
           //
           Vec<FnSymbol*>* vfn = retToArgCache.get(fn);
-          if (!vfn)
+
+          if (!vfn) {
             vfn = new Vec<FnSymbol*>();
+          }
+
           vfn->add(useFn);
           vfn->add(newFn);
+
           retToArgCache.put(fn, vfn);
         }
 
         SET_LINENO(call);
         call->baseExpr->replace(new SymExpr(newFn));
 
-        CallExpr* useMove = toCallExpr(useCall->parentExpr);
-        if (useMove)
-        {
+        if (CallExpr* useMove = toCallExpr(useCall->parentExpr)) {
           INT_ASSERT(isMoveOrAssign(useMove));
 
           Symbol* useLhs = toSymExpr(useMove->get(1))->symbol();
-          if (!useLhs->isRef())
-          {
+
+          if (useLhs->isRef() == false) {
+            Expr*     lhs    = useMove->get(1)->remove();
+            CallExpr* addrOf = new CallExpr(PRIM_ADDR_OF, lhs);
+
             useLhs = newTemp("ret_to_arg_ref_tmp_", useFn->retType->refType);
+
             move->insertBefore(new DefExpr(useLhs));
-            move->insertBefore(new CallExpr(PRIM_MOVE, useLhs, new CallExpr(PRIM_ADDR_OF, useMove->get(1)->remove())));
+            move->insertBefore(new CallExpr(PRIM_MOVE, useLhs, addrOf));
           }
 
           move->replace(call->remove());
+
           useMove->remove();
+
           call->insertAtTail(useLhs);
 
           actual = useLhs;
-        }
-        else
-        {
+
+        } else {
           // We assume the useFn is an assignment.
-          if (strcmp(useFn->name, "="))
-          {
+          if (strcmp(useFn->name, "=") != 0) {
             INT_FATAL(useFn, "should be an assignment function");
             return;
+          } else {
+
+            // We expect that the used symbol is the second actual passed to
+            // the "=".  That is, it is an assignment from the result of the
+            // call to fn to useLhs.
+            INT_ASSERT(firstUse == useCall->get(2));
+
+            Symbol* useLhs = toSymExpr(useCall->get(1))->symbol();
+
+            move->replace(call->remove());
+            call->insertAtTail(useLhs);
+
+            actual = useLhs;
           }
-
-          // We expect that the used symbol is the second actual passed to
-          // the "=".  That is, it is an assignment from the result of the
-          // call to fn to useLhs.
-          INT_ASSERT(firstUse == useCall->get(2));
-
-          Symbol* useLhs = toSymExpr(useCall->get(1))->symbol();
-          move->replace(call->remove());
-          call->insertAtTail(useLhs);
-
-          actual = useLhs;
         }
+
         if (actual) {
           replaceRemainingUses(use, firstUse, actual);
         }
@@ -896,21 +944,26 @@ static void replaceUsesOfFnResultInCaller(CallExpr* move, CallExpr* call,
 
 
 static void
-changeRetToArgAndClone(CallExpr* move, Symbol* lhs,
-                       CallExpr* call, FnSymbol* fn) {
+changeRetToArgAndClone(CallExpr* move,
+                       Symbol*   lhs,
+                       CallExpr* call,
+                       FnSymbol* fn) {
   // Here are some relations between the arguments that can be relied upon.
-  INT_ASSERT(call->parentExpr == move);
-  INT_ASSERT(call->isResolved() == fn);
+  INT_ASSERT(call->parentExpr         == move);
+  INT_ASSERT(call->resolvedFunction() == fn);
 
   // In the suffix of the containing function, look for uses of the lhs of the
   // move containing the call to fn.
   Vec<SymExpr*> use;
+
   if (SymExpr* singleUse = lhs->getSingleUse()) {
     use.add(singleUse);
   } else {
     for (Expr* stmt = move->next; stmt; stmt = stmt->next) {
       std::vector<SymExpr*> symExprs;
+
       collectSymExprs(stmt, symExprs);
+
       for_vector(SymExpr, se, symExprs) {
         if (se->symbol() == lhs) {
           use.add(se);
@@ -1301,7 +1354,7 @@ void fixupNewAlias(void) {
   size_t lookForAliasFieldLen = strlen(lookForAliasField);
 
   forv_Vec(CallExpr, call, gCallExprs) {
-    FnSymbol* calledFn = call->isResolved();
+    FnSymbol* calledFn = call->resolvedFunction();
     if (calledFn && calledFn->hasFlag(FLAG_NEW_ALIAS_FN)) {
         newAliasCalls.push_back(call);
     }
@@ -1329,7 +1382,7 @@ void fixupNewAlias(void) {
   }
 
   for_vector(CallExpr, ctorCall, hasAliasArgInCtor) {
-    FnSymbol* fn = ctorCall->isResolved();
+    FnSymbol* fn = ctorCall->resolvedFunction();
 
     for_formals_actuals(formal, actual, ctorCall) {
 

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -281,23 +281,29 @@ instantiateTypeForTypeConstructor(FnSymbol* fn, SymbolMap& subs, CallExpr* call,
         // Set the type of super to be the instantiated
         // parent with substitutions.
 
-        CallExpr* parentTyCall = new CallExpr(astr("_type_construct_", parentTy->symbol->name));
+        CallExpr* parentTyCall = new CallExpr(astr("_type_construct_",
+                                                   parentTy->symbol->name));
+
         // Pass the special formals to the superclass type constructor.
         for_formals(arg, fn) {
           if (arg->hasFlag(FLAG_PARENT_FIELD)) {
             Symbol* value = subs.get(arg);
+
             if (!value) {
               value = arg;
               // Or error?
             }
+
             parentTyCall->insertAtTail(value);
           }
         }
+
         call->insertBefore(parentTyCall);
         resolveCallAndCallee(parentTyCall);
 
         oldParentTy = parentTy;
-        newParentTy = parentTyCall->isResolved()->retType;
+        newParentTy = parentTyCall->resolvedFunction()->retType;
+
         parentTyCall->remove();
 
         // Now adjust the super field's type.
@@ -308,6 +314,7 @@ instantiateTypeForTypeConstructor(FnSymbol* fn, SymbolMap& subs, CallExpr* call,
         for_alist(tmp, newCt->fields) {
           DefExpr* def = toDefExpr(tmp);
           INT_ASSERT(def);
+
           if (VarSymbol* field = toVarSymbol(def->sym)) {
             if (field->hasFlag(FLAG_SUPER_CLASS)) {
               superDef = def;

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1352,24 +1352,26 @@ static void propagateExtraLeaderArgs(CallExpr* call, VarSymbol* retSym,
                                      int numExtraArgs, Symbol* extraActuals[],
                                      bool reduceArgs[], bool nested)
 {
-  FnSymbol* fn = call->isResolved();
+  FnSymbol* fn = call->resolvedFunction();
+
   INT_ASSERT(fn); // callee's responsibility
+
   if (fn->hasFlag(FLAG_WRAPPER)) {
     // We are not handling void-returning wrappers at the moment.
     INT_ASSERT(!(fn->getReturnSymbol() == gVoid || fn->retType == dtVoid));
   }
 
-  Expr *redRef1 = NULL, *redRef2 = NULL;
+  Expr*   redRef1 = NULL, *redRef2 = NULL;
   Symbol* extraFormals[numExtraArgs];
   Symbol* shadowVars[numExtraArgs];
 
   for (int ix = 0; ix < numExtraArgs; ix++) {
-    Symbol*     eActual = extraActuals[ix];
-    bool        isReduce = nested ? reduceArgs[ix] :
-        // todo: eliminate potential false positives
-        // i.e. when there is a proper outer variable of a ReduceScanOp type
-        isReduceOp(eActual->type);
-    if (!nested) reduceArgs[ix] = isReduce;
+    Symbol* eActual  = extraActuals[ix];
+    bool    isReduce = nested ? reduceArgs[ix] : isReduceOp(eActual->type);
+
+    if (!nested) {
+      reduceArgs[ix] = isReduce;
+    }
 
     // Use named args to disambiguate from the already-existing iterator args,
     // just in case. This necessitates toNamedExpr() in handleCaptureArgs().
@@ -1381,8 +1383,11 @@ static void propagateExtraLeaderArgs(CallExpr* call, VarSymbol* retSym,
             : astrArg(ix, "tet");
 
     ArgSymbol*  eFormal = new ArgSymbol(INTENT_BLANK, eName, eActual->type);
+
     extraFormals[ix] = eFormal;
+
     call->insertAtTail(new NamedExpr(eName, new SymExpr(eActual)));
+
     fn->insertFormalAtTail(eFormal);
 
     // In leader outside any taskFn just use reduceParent.
@@ -1559,19 +1564,21 @@ static void extendLeader(CallExpr* call, CallExpr* origToLeaderCall,
 }
 
 void implementForallIntents2(CallExpr* call, CallExpr* origToLeaderCall) {
-  FnSymbol* origLeader = call->isResolved();
+  FnSymbol* origLeader = call->resolvedFunction();
   INT_ASSERT(origLeader);  // caller responsibility
 
   if (origToLeaderCall->numActuals() <= 1) {
     // No variables to propagate => no extendLeader.
     // Ensure we have a pristine copy for the other case.
-    if (!pristineLeaderIterators.get(origLeader))
+    if (!pristineLeaderIterators.get(origLeader)) {
       stashPristineCopyOfLeaderIter(origLeader, /*ignore_isResolved:*/ false);
+    }
   } else {
-    if (!strncmp(origLeader->name, "_iterator_for_loopexpr", 22))
+    if (strncmp(origLeader->name, "_iterator_for_loopexpr", 22) == 0) {
       propagateExtraArgsForLoopIter(call, origToLeaderCall, origLeader);
-    else
+    } else {
       extendLeader(call, origToLeaderCall, origLeader);
+    }
   }
 }
 
@@ -1618,10 +1625,12 @@ static void unresolveWrapper(FnSymbol* wrapper) {
 // Handle the wrapper if applicable.
 void implementForallIntents2wrapper(CallExpr* call, CallExpr* eflopiHelper)
 {
-  FnSymbol* dest = call->isResolved();
+  FnSymbol* dest = call->resolvedFunction();
+
   if (!dest->hasFlag(FLAG_WRAPPER)) {
     // the simple case
     ifi2checkAssumptions(dest);
+
     implementForallIntents2(call, eflopiHelper);
 
   } else {
@@ -1645,8 +1654,10 @@ void implementForallIntents2wrapper(CallExpr* call, CallExpr* eflopiHelper)
     int savedNumArgsW = wCall->numActuals();
     int numExtraArgs  = eflopiHelper->numActuals()-1;
 
-    ifi2checkAssumptions(wCall->isResolved());
+    ifi2checkAssumptions(wCall->resolvedFunction());
+
     implementForallIntents2(wCall, eflopiHelper);
+
     INT_ASSERT(wCall->numActuals() == savedNumArgsW + numExtraArgs);
 
     // propagate the additions to the original call
@@ -1682,7 +1693,8 @@ void implementForallIntents2wrapper(CallExpr* call, CallExpr* eflopiHelper)
     // So 'wDest' needs to be resolved again. To make that happen,
     // we un-resolve its relevant pieces.
     //
-    if (wDest->isResolved())
+    if (wDest->isResolved()) {
       unresolveWrapper(wDest);
+    }
   }
 }

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -347,7 +347,7 @@ void modAndResolveInitCall (CallExpr* call, AggregateType* typeToNew) {
   // execution of Phase 1, if the type is generic we will need to update the
   // type of the actual we are sending in for the this arg
   if (typeToNew->symbol->hasFlag(FLAG_GENERIC) == true) {
-    new_temp->type = call->isResolved()->_this->type;
+    new_temp->type = call->resolvedFunction()->_this->type;
 
     if (isClass(typeToNew) == true) {
       // use the allocator instead of directly calling the init method
@@ -357,7 +357,7 @@ void modAndResolveInitCall (CallExpr* call, AggregateType* typeToNew) {
       call->get(2)->remove();
       // Need to resolve the allocator
       resolveCall(call);
-      resolveFns(call->isResolved());
+      resolveFns(call->resolvedFunction());
 
       def->remove();
     }
@@ -373,7 +373,7 @@ void resolveInitializer(CallExpr* call) {
 
   INT_ASSERT(call->isResolved());
 
-  resolveMatch(call->isResolved());
+  resolveMatch(call->resolvedFunction());
 
   callStack.pop();
 }

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -95,7 +95,7 @@ Expr* postFold(Expr* expr) {
   SET_LINENO(expr);
 
   if (CallExpr* call = toCallExpr(expr)) {
-    if (FnSymbol* fn = call->isResolved()) {
+    if (FnSymbol* fn = call->resolvedFunction()) {
       if (fn->retTag == RET_PARAM || fn->hasFlag(FLAG_MAYBE_PARAM)) {
         VarSymbol* ret = toVarSymbol(fn->getReturnSymbol());
         if (ret && ret->immediate) {
@@ -216,7 +216,7 @@ Expr* postFold(Expr* expr) {
               if (rhs->symbol()->hasFlag(FLAG_TYPE_VARIABLE))
                 lhs->symbol()->addFlag(FLAG_TYPE_VARIABLE);
             } else if (CallExpr* rhs = toCallExpr(call->get(2))) {
-              if (FnSymbol* fn = rhs->isResolved()) {
+              if (FnSymbol* fn = rhs->resolvedFunction()) {
                 if (fn->retTag == RET_TYPE)
                   lhs->symbol()->addFlag(FLAG_TYPE_VARIABLE);
               } else if (rhs->isPrimitive(PRIM_DEREF)) {
@@ -229,7 +229,7 @@ Expr* postFold(Expr* expr) {
             if (rhs->isPrimitive(PRIM_TYPEOF)) {
               lhs->symbol()->addFlag(FLAG_TYPE_VARIABLE);
             }
-            if (FnSymbol* fn = rhs->isResolved()) {
+            if (FnSymbol* fn = rhs->resolvedFunction()) {
               if (!strcmp(fn->name, "=") && fn->retType == dtVoid) {
                 call->replace(rhs->remove());
                 result = rhs;

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -629,10 +629,12 @@ void insertDynamicDispatchCalls() {
     if (!call->parentSymbol) continue;
     if (!call->getStmtExpr()) continue;
 
-    FnSymbol* key = call->isResolved();
+    FnSymbol* key = call->resolvedFunction();
+
     if (!key) continue;
 
     Vec<FnSymbol*>* fns = virtualChildrenMap.get(key);
+
     if (!fns) continue;
 
     SET_LINENO(call);

--- a/compiler/resolution/visibleCandidates.cpp
+++ b/compiler/resolution/visibleCandidates.cpp
@@ -246,7 +246,7 @@ static void resolveTypeConstructor(CallInfo& info, FnSymbol* fn) {
 
     resolveFns(typeConstructorCall->resolvedFunction());
 
-    fn->_this->type = typeConstructorCall->isResolved()->retType;
+    fn->_this->type = typeConstructorCall->resolvedFunction()->retType;
 
     typeConstructorCall->remove();
   }

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -96,13 +96,12 @@ void findVisibleFunctions(CallInfo&       info,
       }
     }
   } else {
-    visibleFns.add(call->isResolved());
-    handleTaskIntentArgs(call, call->isResolved(), info);
+    visibleFns.add(call->resolvedFunction());
+    handleTaskIntentArgs(call, call->resolvedFunction(), info);
   }
 
   if ((explainCallLine && explainCallMatch(call)) ||
-      call->id == explainCallID)
-  {
+      call->id == explainCallID) {
     USR_PRINT(call, "call: %s", toString(&info));
 
     if (visibleFns.n == 0)

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -700,7 +700,7 @@ static void addArgCoercion(FnSymbol*  fn,
   call->getStmtExpr()->insertBefore(castMove);
 
   resolveCallAndCallee(castCall, true);
-  if (FnSymbol* castTarget = castCall->isResolved()) {
+  if (FnSymbol* castTarget = castCall->resolvedFunction()) {
 
     // Perhaps equivalently, we could check "if (tryToken)",
     // except tryToken is not visible in this file.
@@ -901,7 +901,7 @@ static void fixUnresolvedSymExprsForPromotionWrapper(FnSymbol* wrapper, FnSymbol
   std::vector<CallExpr*> calls;
   collectCallExprs(wrapper, calls);
   for_vector(CallExpr, call, calls) {
-    if (call->isResolved() == fn) {
+    if (call->resolvedFunction() == fn) {
       for_actuals(actual, call) {
         if (UnresolvedSymExpr* unsym = toUnresolvedSymExpr(actual)) {
           // Get the StmtExpr in case 'call' returns something


### PR DESCRIPTION
The final PR to convert

  FnSymbol* CallExpr::isResolved() const;

to become

   bool CallExpr::isResolved() const;


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Also compiled
with clang and C++14.

Ran multiple paratest configurations to help confirm that the only trivial changes have occurred
and that there is no change in behavior.
