### PR TITLE
Address a problem with copy initializers for non-generic records

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -182,6 +182,7 @@ void AstDumpToNode::enterNode(BaseAST* node) const
     if (FnSymbol* fn = toFnSymbol(node))
     {
       fprintf(mFP, "%s%-10s", delimitEnter, node->astTagAsString());
+
       writeNodeID(node, true, false);
 
       if (fn->hasFlag(FLAG_GENERIC) == true)
@@ -189,6 +190,13 @@ void AstDumpToNode::enterNode(BaseAST* node) const
         fprintf(mFP, " (Generic)");
       }
     }
+
+    else if (isUnresolvedSymExpr(node) == true)
+    {
+      fprintf(mFP, "%s%-10s", delimitEnter, "UsymExpr");
+      writeNodeID(node, true, false);
+    }
+
     else
     {
       fprintf(mFP, "%s%-10s", delimitEnter, node->astTagAsString());

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6112,22 +6112,16 @@ static void resolveAutoCopyEtc(Type* type);
 
 static void resolveAutoCopies() {
   forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-    if (!ts->defPoint->parentSymbol)
-      continue; // Type is not in tree
+    if (ts->defPoint->parentSymbol               != NULL   &&
+        ts->hasFlag(FLAG_GENERIC)                == false  &&
+        ts->hasFlag(FLAG_SYNTACTIC_DISTRIBUTION) == false) {
+      if (isRecord(ts->type) == true) {
+        resolveAutoCopyEtc(ts->type);
+        propagateNotPOD(ts->type);
 
-    if (ts->hasFlag(FLAG_GENERIC))
-      continue; // Consider only concrete types.
-
-    if (ts->hasFlag(FLAG_SYNTACTIC_DISTRIBUTION))
-      continue; // Skip the "dmapped" pseudo-type.
-
-    if (isRecord(ts->type)) {
-      resolveAutoCopyEtc(ts->type);
-    }
-
-    if (isAggregateType(ts->type) ) {
-      // Mark record/tuple/class types as POD or NOT_POD
-      propagateNotPOD(ts->type);
+      } else if (isAggregateType(ts->type) == true) {
+        propagateNotPOD(ts->type);
+      }
     }
   }
 }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6222,93 +6222,92 @@ static FnSymbol* autoMemoryFunction(Type* type, const char* fnName) {
 ************************************** | *************************************/
 
 bool propagateNotPOD(Type* t) {
-  // non-aggregate types (e.g. int, bool) are POD
-  // but we don't run this function on all of them,
-  // so we don't mark them with FLAG_POD.
-  if (!isAggregateType(t))
-    return false;
+  bool retval = false;
 
-  // Move past any types that we've already handled
-  if (t->symbol->hasFlag(FLAG_POD))
-    return false;
+  if (AggregateType* at = toAggregateType(t)) {
+    // Move past any types that we've already handled
+    if (t->symbol->hasFlag(FLAG_POD))
+      return false;
 
-  if (t->symbol->hasFlag(FLAG_NOT_POD))
-    return true;
+    if (t->symbol->hasFlag(FLAG_NOT_POD))
+      return true;
 
-  AggregateType* at     = (AggregateType*) t;
-  bool           notPOD = false;
+    bool           notPOD = false;
 
-  // Some special rules for special things.
-  if (isSyncType(t)   ||
-      isSingleType(t) ||
-      t->symbol->hasFlag(FLAG_ATOMIC_TYPE)) {
-    notPOD = true;
-  }
-
-  // Most class types are POD (user classes, _ddata, c_ptr)
-  // Also, there is no need to check the fields of a class type
-  // since a variable of that type is a pointer to the instance.
-  if ( isClass(t) ) {
-    // don't enumerate sub-fields or check for autoCopy etc
-
-  } else {
-    // If any field in a record/tuple is not POD, the
-    // aggregate is not POD.
-    for_fields(field, at) {
-      Type* ft = field->typeInfo();
-
-      notPOD |= propagateNotPOD(ft);
-    }
-
-    // Make sure we have resolved auto copy/auto destroy.
-    // Except not for runtime types, because that causes
-    // some sort of fatal resolution error. This is a workaround.
-    if (! t->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE)) {
-      resolveAutoCopyEtc(t);
-    }
-
-    // Also check for a non-compiler generated autocopy/autodestroy.
-    FnSymbol* autoCopyFn    = autoCopyMap[t];
-    FnSymbol* autoDestroyFn = autoDestroyMap.get(t);
-    FnSymbol* destructor    = t->destructor;
-
-    // Ignore invisible (compiler-defined) functions.
-    if (autoCopyFn && autoCopyFn->hasFlag(FLAG_COMPILER_GENERATED)) {
-      autoCopyFn = NULL;
-    }
-
-    if (autoDestroyFn && autoDestroyFn->hasFlag(FLAG_COMPILER_GENERATED)) {
-      autoDestroyFn = NULL;
-    }
-
-    if (destructor && destructor->hasFlag(FLAG_COMPILER_GENERATED)) {
-      destructor = NULL;
-    }
-
-    // if it has flag ignore no-init, it's not pod
-    // if it has a user-specified auto copy / auto destroy, it's not pod
-    // if it has a user-specified destructor, it's not pod
-    if (t->symbol->hasFlag(FLAG_IGNORE_NOINIT) ||
-        autoCopyFn                             ||
-        autoDestroyFn                          ||
-        destructor) {
+    // Some special rules for special things.
+    if (isSyncType(t)   ||
+        isSingleType(t) ||
+        t->symbol->hasFlag(FLAG_ATOMIC_TYPE)) {
       notPOD = true;
     }
 
-    // Since hasUserAssign tries to resolve =, we only
-    // check it if we think we have a POD type.
-    if (!notPOD && hasUserAssign(t)) {
-      notPOD = true;
+    // Most class types are POD (user classes, _ddata, c_ptr)
+    // Also, there is no need to check the fields of a class type
+    // since a variable of that type is a pointer to the instance.
+    if ( isClass(t) ) {
+      // don't enumerate sub-fields or check for autoCopy etc
+
+    } else {
+      // If any field in a record/tuple is not POD, the
+      // aggregate is not POD.
+      for_fields(field, at) {
+        Type* ft = field->typeInfo();
+
+        notPOD |= propagateNotPOD(ft);
+      }
+
+      // Make sure we have resolved auto copy/auto destroy.
+      // Except not for runtime types, because that causes
+      // some sort of fatal resolution error. This is a workaround.
+      if (! t->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE)) {
+        resolveAutoCopyEtc(t);
+      }
+
+      // Also check for a non-compiler generated autocopy/autodestroy.
+      FnSymbol* autoCopyFn    = autoCopyMap[t];
+      FnSymbol* autoDestroyFn = autoDestroyMap.get(t);
+      FnSymbol* destructor    = t->destructor;
+
+      // Ignore invisible (compiler-defined) functions.
+      if (autoCopyFn && autoCopyFn->hasFlag(FLAG_COMPILER_GENERATED)) {
+        autoCopyFn = NULL;
+      }
+
+      if (autoDestroyFn && autoDestroyFn->hasFlag(FLAG_COMPILER_GENERATED)) {
+        autoDestroyFn = NULL;
+      }
+
+      if (destructor && destructor->hasFlag(FLAG_COMPILER_GENERATED)) {
+        destructor = NULL;
+      }
+
+      // if it has flag ignore no-init, it's not pod
+      // if it has a user-specified auto copy / auto destroy, it's not pod
+      // if it has a user-specified destructor, it's not pod
+      if (t->symbol->hasFlag(FLAG_IGNORE_NOINIT) ||
+          autoCopyFn                             ||
+          autoDestroyFn                          ||
+          destructor) {
+        notPOD = true;
+      }
+
+      // Since hasUserAssign tries to resolve =, we only
+      // check it if we think we have a POD type.
+      if (!notPOD && hasUserAssign(t)) {
+        notPOD = true;
+      }
     }
+
+    if (notPOD) {
+      t->symbol->addFlag(FLAG_NOT_POD);
+    } else {
+      t->symbol->addFlag(FLAG_POD);
+    }
+
+    retval = notPOD;
   }
 
-  if (notPOD) {
-    t->symbol->addFlag(FLAG_NOT_POD);
-  } else {
-    t->symbol->addFlag(FLAG_POD);
-  }
-
-  return notPOD;
+  return retval;
 }
 
 /************************************* | **************************************

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6131,11 +6131,13 @@ static void resolveAutoCopies() {
 static void resolveAutoCopyEtc(Type* type) {
   SET_LINENO(type->symbol);
 
-  // resolve autoCopy
-  if (hasAutoCopyForType(type) == false) {
-    FnSymbol* fn = autoMemoryFunction(type, autoCopyFnForType(type));
+  if (isNonGenericRecordWithInitializers(type) == false) {
+    // resolve autoCopy
+    if (hasAutoCopyForType(type) == false) {
+      FnSymbol* fn = autoMemoryFunction(type, autoCopyFnForType(type));
 
-    autoCopyMap[type] = fn;
+      autoCopyMap[type] = fn;
+    }
   }
 
   // resolve autoDestroy

--- a/test/classes/initializers/initCallsDom.bad
+++ b/test/classes/initializers/initCallsDom.bad
@@ -1,3 +1,0 @@
-initCallsDom.chpl:7: In initializer:
-initCallsDom.chpl:8: error: unresolved call 'R._dom'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1991: note: candidates are: _array._domreturn

--- a/test/classes/initializers/not-a-copy-initializer.bad
+++ b/test/classes/initializers/not-a-copy-initializer.bad
@@ -1,3 +1,0 @@
-not-a-copy-initializer.chpl:16: In initializer:
-not-a-copy-initializer.chpl:17: error: unresolved call 'Foo.someMethod()'
-not-a-copy-initializer.chpl:7: note: candidates are: OtherRecord.someMethod()

--- a/test/classes/initializers/not-a-copy-initializer.future
+++ b/test/classes/initializers/not-a-copy-initializer.future
@@ -1,9 +1,0 @@
-bug: can't call method on generic record arg in record initializer
-
-This is a generalized version of initCallsDom.future.  The issue is that
-the compiler tries to use generic single argument record initializers in
-initCopy calls as copy initializers, but the initializers defined in these
-tests were not intended as copy initializers.  Work has been done to allow
-records that don't define copy initializers to not trigger this error message,
-but that examination depends on the argument list, not the resolution of the
-function itself.


### PR DESCRIPTION
There is a semantic problem if a non-generic record defines an initializer with a single
generic argument.  The user might implement the initializer with the expectation that
they have an understanding of the actual type of the argument based on their uses of
new().  These assumptions may be invalid if the compiler specializes the initializer "as if" it
is a copy initializer.

This is a longer term issue that needs attention.  In the near term it may block the development
of some simple tests.  This PR provides a partial work-around that reduces the impact of
this issue while we continue to develop initializers.

The tactical problem is that function resolution implements the function 

static void resolveAutoCopyEtc(Type* type);

which generates calls to autoCopy/autoDestroy and unalias for every aggregate type.
The code for autoCopy generates a specialization using the generic initializer even if
the application does not require a copy initializer.

The longer term story for initializers should eliminate the use of autoCopy/autoDestroy
for record/class.  This PR disables the autoCopy expansion for non-generic records with
initializers.


The PR consists of a sequence of trivial commits.  The preliminary commits simplify the
implementation of resolveAutoCopies() and propagateNotPOD() without altering behavior.
The sequence is intended to make it easy to verify that the transformations are valid.

The penultimate commit actually disables the insertion of autoCopy for non-generic records.

The final commit retires one passing future and removes the existing .bad file for a future that
has changed behavior.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Also enabled C++14
for local testing on clang.

Passed a single-locale paratest with -futures and then with --no-local
