### PR TITLE
Fix cygwin warnings

### DIFF
--- a/runtime/include/mem/cstdlib/chpl-mem-impl.h
+++ b/runtime/include/mem/cstdlib/chpl-mem-impl.h
@@ -23,13 +23,14 @@
 
 // Uses the built-in malloc, calloc, realloc and free.
 
+// disable mem warnings since cstdlib uses the system allocator
+#include "chpl-mem-no-warning-macros.h"
+
 #include <stdlib.h>
 #if defined(__APPLE__)
 #include <malloc/malloc.h>
 #endif
 
-// disable mem warnings since cstdlib uses the system allocator
-#include "chpl-mem-no-warning-macros.h"
 
 #include <stdlib.h>
 

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -34,6 +34,11 @@
 #include "chpltypes.h"
 #include "error.h"
 
+// disable mem warnings for this file
+// to enable warnings-free compilation
+// (malloc might be used in the system headers)
+#include "chpl-mem-no-warning-macros.h"
+
 // System headers
 
 // We need this first so we can then decide based on the existence and

--- a/runtime/src/qio/sys_xsi_strerror_r.c
+++ b/runtime/src/qio/sys_xsi_strerror_r.c
@@ -29,7 +29,7 @@
 #undef _POSIX_C_SOURCE
 #endif
 
-#define _POSIX_C_SOURCE 20112L
+#define _POSIX_C_SOURCE 200112L
 #define _XOPEN_SOURCE 600
 #undef _GNU_SOURCE
 

--- a/test/regexp/ferguson/ctests/sub_test
+++ b/test/regexp/ferguson/ctests/sub_test
@@ -58,7 +58,7 @@ else
   exit
 fi
 
-DEPS="$OPTS --std=c++11 -Wall -DCHPL_RT_UNIT_TEST $DEFS $RE2INCLS"
+DEPS="$OPTS --std=gnu++11 -Wall -DCHPL_RT_UNIT_TEST $DEFS $RE2INCLS"
 LDEPS="$RSRC/qio.c $RSRC/sys.c $RSRC/sys_xsi_strerror_r.c $RSRC/qbuffer.c $RSRC/qio_error.c $RSRC/deque.c $RSRC/regexp/re2/re2-interface.cc $RE2LIB -lpthread"
 
 T1="$CXX $DEPS -g regexp_test.cc -o regexp_test $LDEPS"


### PR DESCRIPTION
* Update runtime to build without warnings on current Cygwin
   This is with Cygwin 2017-04-01 release version 2.8.0 with GCC 5.4.0.
   - add #include "chpl-mem-no-warning-macros.h" to runtime/src/chplsys.c since some `static inline` functions in the system headers included there use `malloc` (on Cygwin, at least).
   - moved #include "chpl-mem-no-warning-macros.h" before including any system headers in runtime/include/mem/cstdlib/chpl-mem-impl.h, since sometimes the system headers use `malloc` in static inline functions.
   - fix a typo in  runtime/src/qio/sys_xsi_strerror_r.c: #define _POSIX_C_SOURCE 20112L (missing a 0)
* Compile C++ regexp tests with std=gnu++11 vs c++11. Using C++11 causes problems with GCC 5.4.0 on Cygwin where strdup is never defined by string.h. I think you are supposed to be able to write
  ``` c++
  #define __STDC_WANT_LIB_EXT2__ 1
  #include <string.h>
  ```
  but my attempts at doing so did not work for some reason.

- [x] compiler, runtime bulid with CHPL_DEVELOPER on Cygwin
- [x] test/regexp passes on Cygwin
- [x] test/rexgep passes on Linux
- [x] test/rexgep passes on Mac OS X
- [x] full local testing

Trivial and not reviewed.
