### PR TITLE
Change an internal error message to a user-facing error message

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -466,7 +466,7 @@ static void build_chpl_entry_points() {
 
   if (fLibraryCompile) {
     if (chpl_user_main)
-      INT_FATAL(chpl_user_main, "'main' found when compiling a library");
+      USR_FATAL(chpl_user_main, "'main' found when compiling a library");
   }
 
   if (!chpl_user_main) {

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -466,7 +466,7 @@ static void build_chpl_entry_points() {
 
   if (fLibraryCompile) {
     if (chpl_user_main)
-      USR_FATAL(chpl_user_main, "'main' found when compiling a library");
+      USR_FATAL(chpl_user_main, "'main()' not permitted when compiling in --library mode");
   }
 
   if (!chpl_user_main) {

--- a/test/compflags/lydia/library/errorMessage/SKIPIF
+++ b/test/compflags/lydia/library/errorMessage/SKIPIF
@@ -1,0 +1,2 @@
+# Does not currently work with multilocale
+CHPL_COMM != none

--- a/test/compflags/lydia/library/errorMessage/hasMain.chpl
+++ b/test/compflags/lydia/library/errorMessage/hasMain.chpl
@@ -1,0 +1,5 @@
+module Hello {
+  proc main() {
+
+  }
+}

--- a/test/compflags/lydia/library/errorMessage/hasMain.compopts
+++ b/test/compflags/lydia/library/errorMessage/hasMain.compopts
@@ -1,0 +1,1 @@
+--library

--- a/test/compflags/lydia/library/errorMessage/hasMain.good
+++ b/test/compflags/lydia/library/errorMessage/hasMain.good
@@ -1,1 +1,1 @@
-hasMain.chpl:2: error: 'main' found when compiling a library
+hasMain.chpl:2: error: 'main()' not permitted when compiling in --library mode

--- a/test/compflags/lydia/library/errorMessage/hasMain.good
+++ b/test/compflags/lydia/library/errorMessage/hasMain.good
@@ -1,0 +1,1 @@
+hasMain.chpl:2: error: 'main' found when compiling a library


### PR DESCRIPTION
When --library is thrown while compiling a program with a main(), we used to
generate an internal error message.  However, it is really just a user error to
define a main() function when compiling in --library mode, so make this internal
error a user-facing error.

This resolves #6106 

Adds a test to lock in the error message.

Passed full std/ testing