### PR TITLE
Use at least C++11 when recent enough compiler available

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -70,7 +70,7 @@ CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 #
 # Flags for compiler, runtime, and generated code
 #
-COMP_CXXFLAGS = $(CPPFLAGS) $(CXXFLAGS)
+COMP_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)
 COMP_CXXFLAGS_NONCHPL = -Wno-error
 RUNTIME_CFLAGS = $(C_STD) $(CPPFLAGS) $(CFLAGS)
 RUNTIME_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -136,6 +136,7 @@ CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && 
 # If a compiler uses C++11 or newer by default, CXX11_STD will be blank.
 CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 
+COMP_CXXFLAGS += $(CXX_STD)
 RUNTIME_CFLAGS += $(C_STD)
 RUNTIME_CXXFLAGS += $(CXX_STD)
 GEN_CFLAGS += $(C_STD)

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -61,7 +61,7 @@ CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 # Warnings squashed for generated code:
 #  592 : squelch use-before-def problems -- we'll rely on valgrind to catch them
 
-COMP_CXXFLAGS = $(CPPFLAGS) $(CXXFLAGS)
+COMP_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)
 COMP_CXXFLAGS_NONCHPL = -wr111,193,1418,1419,2215,2259,170
 
 RUNTIME_CFLAGS = $(C_STD) $(CPPFLAGS) $(CFLAGS) -wr181,188


### PR DESCRIPTION
This does for the Chapel compiler what was already being done for the runtime.  If we are using a C\/C\+\+ compiler recent enough to default to C11, then we ensure that we use at least C\+\+11 to match.  However, we do not demote to C\+\+11 if the compiler defaults to something later.

This allows us to use some extra error checking, because fewer implicit type conversions are allowed for C\+\+11 and beyond.  It does not prevent us from testing with older standards; that only requires using an older compiler.

This shifts the amount of time to catch errors around a bit.  Errors caught by C\+\+11 will now be caught immediately, because clang has these checks.  (G\+\+ 7 will also perform the checking.)  Errors caused by using C\+\+11 features in the compiler will now be caught during the next nightly test instead of immediately.

This change is applied everywhere that we have this variable language standard scheme for the runtime:  the clang, gnu, and intel compilers.

Performed build and paratest with CHPL_HOST_COMPILER set to clang, gnu, and intel.
Tested with gcc 4.9, 5.4, and 6.3, which fall into the three separate prongs of the Makefile logic.
Tested with the latest Apple clang (approx. clang 3.9/4.0) and clang 3.3, which exercise the only two cases that clang exhibits to date.
Tested with v17 of the intel compiler, which exercises the only case that intel exhibits to date.
Also tested with and without CHPL_LLVM=llvm.