### PR TITLE
Add note about GCC 5 in re2 README, prereqs.rst

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -29,6 +29,10 @@ about your environment for using Chapel:
     relatively recent versions of gcc/g++, clang, and compilers from
     Cray, Intel, and PGI.
 
+    * Note that you will need a C++11 compiler to build LLVM or regular
+      expression support (i.e.  CHPL_LLVM=llvm or CHPL_REGEXP=re2). If
+      GCC is used, we recommend GCC version 5 or newer for this purpose.
+
   * If you wish to use Chapel's test system, python-setuptools and
     python-devel (or equivalent packages for your platform) are required.
 

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -42,9 +42,9 @@ in the Chapel distribution.
 
 .. note::
 
-  if re2 support is not enabled (which is the default), all features
-  described below will compile successfully, but will result in an internal
-  error at *run time*, saying "No Regexp Support".
+  if re2 support is not enabled (which is the case in quickstart
+  configurations), the functionality described below will result in
+  either a compile-time or a run-time error.
 
 
 Using Regular Expression Support

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -42,9 +42,9 @@ in the Chapel distribution.
 
 .. note::
 
-  if re2 support is not enabled (which is the case in quickstart
-  configurations), the functionality described below will result in
-  either a compile-time or a run-time error.
+  if re2 support is not enabled (which is the case in quickstart configurations
+  as in :ref:`chapelhome-quickstart`), the functionality described below will
+  result in either a compile-time or a run-time error.
 
 
 Using Regular Expression Support

--- a/third-party/re2/README
+++ b/third-party/re2/README
@@ -10,6 +10,10 @@ for convenience and was obtained from:
 Any Chapel issues that seem to be related to re2 should be directed
 to the Chapel team at http://chapel.cray.com/bugs.html.
 
+Note that since RE2 uses C++11 atomics, it may not build or function with
+certain older compilers. In particular, if you are using GCC, we
+recommend at least GCC version 5. While this version of RE2 will build
+with GCC 4.7, the C++11 atomics were not sufficiently tested until GCC 5.
 
 Chapel modifications to re2
 ===========================


### PR DESCRIPTION
* Updates prereqs.rst to note GCC 5 for C++11 dependency in third-party
* Clarifies some error wording in Regexp.chpl
* Updates third-party/re2/README to note C++11 dependency and suggest GCC 5 and say why.

Reviewed by @dmk42 and @ben-albrecht - thanks!