### PR TITLE
Update the prototype for void parse();

### DIFF
--- a/compiler/include/parser.h
+++ b/compiler/include/parser.h
@@ -36,6 +36,8 @@ extern int         yystartlineno;
 extern const char* yyfilename;
 extern BlockStmt*  yyblock;
 
+void               parse();
+
 void               setupModulePaths();
 
 void               addFlagModulePath(const char* newpath);

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -60,7 +60,6 @@ void makeBinary();
 void normalize();
 void optimizeOnClauses();
 void parallel();
-void parse();
 void processIteratorYields();
 void prune();
 void prune2();

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -19,9 +19,10 @@
 
 #include "runpasses.h"
 
-#include "checks.h"        // For check function prototypes.
-#include "log.h"           // For LOG_<passname> #defines.
-#include "passes.h"        // For pass function prototypes.
+#include "checks.h"
+#include "log.h"
+#include "parser.h"
+#include "passes.h"
 #include "PhaseTracker.h"
 
 #include <cstdio>

--- a/compiler/parser/Makefile
+++ b/compiler/parser/Makefile
@@ -71,4 +71,4 @@ $(OBJ_SUBDIR)/flex-chapel.o: ../include/bison-chapel.h ../include/flex-chapel.h 
 	$(CXX) -c $(COMP_CXXFLAGS) $(COMP_CXXFLAGS_NONCHPL) -o $@ flex-chapel.cpp
 
 $(OBJ_SUBDIR)/parser.o:  ../include/bison-chapel.h ../include/flex-chapel.h parser.cpp $(OBJ_SUBDIR_MADE)
-	$(CXX) -c $(COMP_CXXFLAGS) $(COMP_CXXFLAGS_NONCHPL) -o $@ parser.cpp
+	$(CXX) -c $(COMP_CXXFLAGS) -o $@ parser.cpp


### PR DESCRIPTION
1) Move the prototype for parse() from include/passes.h to include/parser.h

2) Fix a long-standing minor bug in parser/Makefile that unintentionally added -wno-error to
parser.cpp.  This was only intended to be applied to the 2 parser generated .cpp files

Compiled on clang/darwin (which failed to report a problem) and gcc/lnux64 (which reported
a problem but didn't halt because of the -wno-error bug).

Ran on a subset of test/release on darwin and linux64
