### PR TITLE
Add some helper functions to use with generic initializers and type constructors

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1943,6 +1943,32 @@ bool isNonGenericClassWithInitializers(Type* type) {
   return retval;
 }
 
+bool isGenericClass(Type* type) {
+  bool retval = false;
+
+  if (AggregateType* at = toAggregateType(type)) {
+    if (at->isClass()                    == true  &&
+        at->isGeneric()                  == true  &&
+        at->symbol->hasFlag(FLAG_EXTERN) == false) {
+      retval = true;
+    }
+  }
+
+  return retval;
+}
+
+bool isGenericClassWithInitializers(Type* type) {
+  bool retval = false;
+
+  if (isGenericClass(type) == true) {
+    if (AggregateType* at = toAggregateType(type)) {
+      retval = at->initializerStyle == DEFINES_INITIALIZER;
+    }
+  }
+
+  return retval;
+}
+
 bool isNonGenericRecord(Type* type) {
   bool retval = false;
 
@@ -1961,6 +1987,32 @@ bool isNonGenericRecordWithInitializers(Type* type) {
   bool retval = false;
 
   if (isNonGenericRecord(type) == true) {
+    if (AggregateType* at = toAggregateType(type)) {
+      retval = at->initializerStyle == DEFINES_INITIALIZER;
+    }
+  }
+
+  return retval;
+}
+
+bool isGenericRecord(Type* type) {
+  bool retval = false;
+
+  if (AggregateType* at = toAggregateType(type)) {
+    if (at->isRecord()                   == true  &&
+        at->isGeneric()                  == true  &&
+        at->symbol->hasFlag(FLAG_EXTERN) == false) {
+      retval = true;
+    }
+  }
+
+  return retval;
+}
+
+bool isGenericRecordWithInitializers(Type* type) {
+  bool retval = false;
+
+  if (isGenericRecord(type) == true) {
     if (AggregateType* at = toAggregateType(type)) {
       retval = at->initializerStyle == DEFINES_INITIALIZER;
     }

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -605,6 +605,12 @@ bool isNonGenericRecord(Type* type);
 bool isNonGenericClassWithInitializers (Type* type);
 bool isNonGenericRecordWithInitializers(Type* type);
 
+bool isGenericClass (Type* type);
+bool isGenericRecord(Type* type);
+
+bool isGenericClassWithInitializers (Type* type);
+bool isGenericRecordWithInitializers(Type* type);
+
 void registerTypeToStructurallyCodegen(TypeSymbol* type);
 GenRet genTypeStructureIndex(TypeSymbol* typesym);
 void codegenTypeStructures(FILE* hdrfile);


### PR DESCRIPTION
Basically, these are copies of the isNonGeneric* and
isNonGeneric*WithInitializers functions, but to check for if the type *is*
generic instead of if the type *is not*.

Passed a sanity paratest