### PR TITLE
Fix the declaration test failures in numa

### DIFF
--- a/test/classes/initializers/records/declaration.good
+++ b/test/classes/initializers/records/declaration.good
@@ -1,17 +1,3 @@
 declaration.chpl:12: error: unresolved call 'Foo.init()'
 declaration.chpl:6: note: candidates are: Foo.init(xVal)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1485: note:                 init(_mt: _MT, this: _ic_chpl_direct_param_stride_range_iter)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1421: note:                 init(_mt: _MT, this: _ic_chpl_direct_range_iter)
-$CHPL_HOME/modules/internal/String.chpl:328: note:                 init(_mt: _MT, this: _ic_these__ref_string)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1551: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_bounded_T)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1578: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_bounded_F)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1523: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_boundedLow_F)
-$CHPL_HOME/modules/standard/List.chpl:88: note:                 init(_mt: _MT, this: _ic_these__ref_list_BaseArr)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1640: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_bounded_F)
-$CHPL_HOME/modules/internal/DefaultRectangular.chpl:181: note:                 init(_mt: _MT, this: _ic_these_DefaultRectangularDom_1_int64_t_F)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:407: note:                 init(_mt: _MT, this: _ic_chpl_initOnLocales_AbstractRootLocale)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1640: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_bounded_F)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1466: note:                 init(_mt: _MT, this: _ic_chpl_direct_pos_stride_range_iter)
-$CHPL_HOME/modules/internal/DefaultRectangular.chpl:1928: note:                 init(_mt: _MT, this: _ic_chpl__serialViewIter)
-$CHPL_HOME/modules/internal/DefaultRectangular.chpl:1289: note:                 init(_mt: _MT, this: _ic_these_DefaultRectangularArr_localesSignal_1_int64_t_F_int64_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:420: note:                 init(_mt: _MT, this: _ic_chpl_initOnLocales_AbstractRootLocale)
+deleted module lines

--- a/test/classes/initializers/records/declaration.prediff
+++ b/test/classes/initializers/records/declaration.prediff
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+output=$2
+cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
+echo "deleted module lines" >> $output.tmp
+mv $output.tmp $output

--- a/test/classes/initializers/records/declaration2.good
+++ b/test/classes/initializers/records/declaration2.good
@@ -1,17 +1,3 @@
 declaration2.chpl:12: error: unresolved call 'Foo.init()'
 declaration2.chpl:6: note: candidates are: Foo.init(xVal: int)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1485: note:                 init(_mt: _MT, this: _ic_chpl_direct_param_stride_range_iter)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1421: note:                 init(_mt: _MT, this: _ic_chpl_direct_range_iter)
-$CHPL_HOME/modules/internal/String.chpl:328: note:                 init(_mt: _MT, this: _ic_these__ref_string)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1551: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_bounded_T)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1578: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_bounded_F)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1523: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_boundedLow_F)
-$CHPL_HOME/modules/standard/List.chpl:88: note:                 init(_mt: _MT, this: _ic_these__ref_list_BaseArr)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1640: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_bounded_F)
-$CHPL_HOME/modules/internal/DefaultRectangular.chpl:181: note:                 init(_mt: _MT, this: _ic_these_DefaultRectangularDom_1_int64_t_F)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:407: note:                 init(_mt: _MT, this: _ic_chpl_initOnLocales_AbstractRootLocale)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1640: note:                 init(_mt: _MT, this: _ic_these__ref_range_int64_t_bounded_F)
-$CHPL_HOME/modules/internal/ChapelRange.chpl:1466: note:                 init(_mt: _MT, this: _ic_chpl_direct_pos_stride_range_iter)
-$CHPL_HOME/modules/internal/DefaultRectangular.chpl:1928: note:                 init(_mt: _MT, this: _ic_chpl__serialViewIter)
-$CHPL_HOME/modules/internal/DefaultRectangular.chpl:1289: note:                 init(_mt: _MT, this: _ic_these_DefaultRectangularArr_localesSignal_1_int64_t_F_int64_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:420: note:                 init(_mt: _MT, this: _ic_chpl_initOnLocales_AbstractRootLocale)
+deleted module lines

--- a/test/classes/initializers/records/declaration2.prediff
+++ b/test/classes/initializers/records/declaration2.prediff
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+output=$2
+cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
+echo "deleted module lines" >> $output.tmp
+mv $output.tmp $output


### PR DESCRIPTION
The output for potential matching functions was different for numa, but the
functions causing the problem weren't the important part of the output.  When
I take the chance to clean up our resolution failure output for methods, the
output for these tests will be consistent, but until then just sanitize it and
be done.

Verified that a clean checkout of these tests passes