### PR TITLE
Generate file-unique ID for GETs and PUTs

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2722,6 +2722,26 @@ VarSymbol *new_ComplexSymbol(const char *n, long double r, long double i,
   return s;
 }
 
+VarSymbol* new_CommIDSymbol(int64_t b) {
+  IF1_int_type size = INT_SIZE_64;
+  Immediate imm;
+  imm.v_int64 = b;
+
+  imm.const_kind = NUM_KIND_COMMID;
+  imm.num_index = size;
+  VarSymbol *s = uniqueConstantsHash.get(&imm);
+  PrimitiveType* dtRetType = dtInt[size];
+  if (s) {
+    return s;
+  }
+  s = new VarSymbol(astr("_literal_", istr(literal_id++)), dtRetType);
+  rootModule->block->insertAtTail(new DefExpr(s));
+  s->immediate = new Immediate;
+  *s->immediate = imm;
+  uniqueConstantsHash.put(s->immediate, s);
+  return s;
+}
+
 static Type*
 immediate_type(Immediate *imm) {
   switch (imm->const_kind) {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -38,6 +38,8 @@
 #endif
 
 #include <inttypes.h>
+#include <limits.h>
+#include <stdlib.h>
 
 #include "llvmDebug.h"
 
@@ -55,6 +57,8 @@ static bool compareSymbol(void* v1, void* v2);
 GenInfo* gGenInfo   =  0;
 int      gMaxVMT    = -1;
 int      gStmtCount =  0;
+
+std::map<std::string, int> commIDMap;
 
 
 // ensure these two produce consistent output
@@ -1017,6 +1021,13 @@ static void codegen_header_compilation_config() {
     genGlobalString("chpl_compileCommand", compileCommand);
     genGlobalString("chpl_compileVersion", compileVersion);
     genGlobalString("chpl_compileDirectory", getCwd());
+    if (strcmp(saveCDir, "") != 0) {
+      char *actualPath = realpath(saveCDir, NULL);
+      genGlobalString("chpl_saveCDir", actualPath);
+    } else {
+      genGlobalString("chpl_saveCDir", "");
+    }
+
     genGlobalString("CHPL_HOME",           CHPL_HOME);
 
     genGlobalInt("CHPL_STACK_CHECKS", !fNoStackChecks, false);

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -38,8 +38,6 @@
 #endif
 
 #include <inttypes.h>
-#include <limits.h>
-#include <stdlib.h>
 
 #include "llvmDebug.h"
 

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -235,6 +235,10 @@ PromotedPair convertValuesToLarger(llvm::Value *value1, llvm::Value *value2, boo
 
 static const char* wide_fields[] = {"locale", "addr", "size", NULL};
 
+static GenRet genCommID(GenInfo* info) {
+  return baseASTCodegen(new_CommIDSymbol(commIDMap[info->filename]++));
+}
+
 // Generates code to load the wide version of an address and returns an
 // expression that evaluates to this address.
 //
@@ -2471,6 +2475,7 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   codegenCall(fnName, args);
 }
 
+/*
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7)
@@ -2485,8 +2490,8 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   args.push_back(a7);
   codegenCall(fnName, args);
 }
+*/
 
-/* Commented out to avoid an unused function, this probably should be varargs
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7, GenRet a8)
@@ -2503,6 +2508,7 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   codegenCall(fnName, args);
 }
 
+/*
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7, GenRet a8,
@@ -2539,6 +2545,7 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   codegenCall(fnName, args);
 }*/
 
+/*
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7, GenRet a8,
@@ -2556,6 +2563,28 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   args.push_back(a9);
   args.push_back(a10);
   args.push_back(a11);
+  codegenCall(fnName, args);
+}
+*/
+
+static
+void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
+                 GenRet a4, GenRet a5, GenRet a6, GenRet a7, GenRet a8,
+                 GenRet a9, GenRet a10, GenRet a11, GenRet a12)
+{
+  std::vector<GenRet> args;
+  args.push_back(a1);
+  args.push_back(a2);
+  args.push_back(a3);
+  args.push_back(a4);
+  args.push_back(a5);
+  args.push_back(a6);
+  args.push_back(a7);
+  args.push_back(a8);
+  args.push_back(a9);
+  args.push_back(a10);
+  args.push_back(a11);
+  args.push_back(a12);
   codegenCall(fnName, args);
 }
 
@@ -3059,7 +3088,8 @@ void codegenAssign(GenRet to_ptr, GenRet from)
                       codegenRaddr(from),
                       codegenSizeof(type),
                       genTypeStructureIndex(type->symbol),
-                      info->lineno, gFilenameLookupCache[info->filename] );
+                      genCommID(info),
+                      info->lineno, gFilenameLookupCache[info->filename]);
         }
       }
     } else { // PUT
@@ -3081,6 +3111,7 @@ void codegenAssign(GenRet to_ptr, GenRet from)
                       codegenRaddr(to_ptr),
                       codegenSizeof(type),
                       genTypeStructureIndex(type->symbol),
+                      genCommID(info),
                       info->lineno, gFilenameLookupCache[info->filename]);
         }
       }
@@ -4258,6 +4289,7 @@ GenRet CallExpr::codegenPrimitive() {
                   remoteAddr,
                   size,
                   genTypeStructureIndex(dt),
+                  genCommID(gGenInfo),
                   get(5),
                   get(6));
 
@@ -4445,6 +4477,7 @@ GenRet CallExpr::codegenPrimitive() {
                 stridelevels,
                 eltSize,
                 genTypeStructureIndex(dt),
+                genCommID(gGenInfo),
                 get(8),
                 get(9));
 

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -313,6 +313,14 @@ GenRet VarSymbol::codegenVarSymbol(bool lhsInSetReference) {
         } else {
           ret.c = "UINT64(" + uint64_to_string(uconst) + ")";
         }
+      } else if (immediate->const_kind == NUM_KIND_COMMID) {
+        int64_t iconst = immediate->commid_value();
+        if (iconst == (1ll<<63)) {
+          ret.c = "-COMMID(9223372036854775807) - COMMID(1)";
+        } else {
+          INT_ASSERT(immediate->num_index == INT_SIZE_64);
+          ret.c = "COMMID(" + int64_to_string(iconst) + ")";
+        }
       } else {
         ret.c = cname; // in C, all floating point literals are (double)
       }
@@ -1340,6 +1348,7 @@ void ModuleSymbol::codegenDef() {
 
   info->filename = fname();
   info->lineno   = linenum();
+  commIDMap[info->filename] = 0;
 
   info->cStatements.clear();
   info->cLocalDecls.clear();

--- a/compiler/ifa/num.h
+++ b/compiler/ifa/num.h
@@ -32,13 +32,17 @@
 #define IFA_EXTERN_INIT(x)
 #endif
 
+//
+// NOTE: NUM_KIND_LAST is used to mark the last entry in this enum. The
+// 'IF1_const_kind' enum below uses it to set values.
+//
 enum IF1_num_kind {
   NUM_KIND_NONE, NUM_KIND_BOOL, NUM_KIND_UINT, NUM_KIND_INT, NUM_KIND_REAL,
-  NUM_KIND_IMAG, NUM_KIND_COMPLEX
+  NUM_KIND_IMAG, NUM_KIND_COMPLEX, NUM_KIND_COMMID, NUM_KIND_LAST
 };
 
 enum IF1_const_kind {
-  CONST_KIND_STRING = NUM_KIND_COMPLEX + 1, CONST_KIND_SYMBOL
+  CONST_KIND_STRING = NUM_KIND_LAST + 1, CONST_KIND_SYMBOL
 };
 
 enum IF1_string_kind {
@@ -118,6 +122,7 @@ class Immediate { public:
   };
 
   int64_t  int_value( void);
+  int64_t  commid_value( void);
   uint64_t uint_value( void);
   uint64_t bool_value( void);
   // calls int_value, uint_value, or bool_value as appropriate.
@@ -176,6 +181,13 @@ Immediate::int_value( void) {
     INT_FATAL("unknown int size");
   }
   return val;
+}
+
+inline int64_t
+Immediate::commid_value( void) {
+  INT_ASSERT(const_kind == NUM_KIND_COMMID &&
+             num_index == INT_SIZE_64);
+  return v_int64;
 }
 
 

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -148,6 +148,10 @@ extern GenInfo* gGenInfo;
 extern int      gMaxVMT;
 extern int      gStmtCount;
 
+// Map from filename to an integer that will represent an unique ID for each
+// generated GET/PUT
+extern std::map<std::string, int> commIDMap;
+
 #ifdef HAVE_LLVM
 void setupClang(GenInfo* info, std::string rtmain);
 #endif

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -690,6 +690,8 @@ VarSymbol *new_ImagSymbol(const char *n,
 VarSymbol *new_ComplexSymbol(const char *n, long double r, long double i,
                              IF1_complex_type size=COMPLEX_SIZE_128);
 
+VarSymbol *new_CommIDSymbol(int64_t b);
+
 VarSymbol *new_ImmediateSymbol(Immediate *imm);
 
 void createInitStringLiterals();

--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -65,10 +65,10 @@ void chpl_cache_release(int ln, int32_t fn)
 // calling on a put or a get.
 void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
                          size_t size, int32_t typeIndex,
-                         int ln, int32_t fn);
+                         int32_t commID, int ln, int32_t fn);
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
                          size_t size, int32_t typeIndex,
-                         int ln, int32_t fn);
+                         int32_t commID, int ln, int32_t fn);
 void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
                               size_t size, int32_t typeIndex,
                               int ln, int32_t fn);
@@ -76,12 +76,12 @@ void  chpl_cache_comm_get_strd(
                    void *addr, void *dststr, c_nodeid_t node, void *raddr,
                    void *srcstr, void *count, int32_t strlevels,
                    size_t elemSize, int32_t typeIndex,
-                   int ln, int32_t fn);
+                   int32_t commID, int ln, int32_t fn);
 void  chpl_cache_comm_put_strd(
                       void *addr, void *dststr, c_nodeid_t node, void *raddr,
                       void *srcstr, void *count, int32_t strlevels,
                       size_t elemSize, int32_t typeIndex,
-                      int ln, int32_t fn);
+                      int32_t commID, int ln, int32_t fn);
 
 // For debugging.
 void chpl_cache_print(void);

--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -137,6 +137,7 @@ typedef struct {
       void *raddr;               // Destination address
       size_t size;               // Size of communication
       int32_t typeIndex;         // type of the communication
+      int32_t commID;            // unique identifier for this get/put
       int lineno;                // source line of communication
       int32_t filename;          // source file of communication
     } comm;
@@ -151,6 +152,7 @@ typedef struct {
       int32_t stridelevels;
       size_t elemSize;
       int32_t typeIndex;
+      int32_t commID;           // unique identifier for this get/put
       int lineno;               // source line of communication
       int32_t filename;         // source file of communication
     } comm_strd;

--- a/runtime/include/chpl-comm-compiler-llvm-support.h
+++ b/runtime/include/chpl-comm-compiler-llvm-support.h
@@ -40,7 +40,7 @@ void chpl_gen_comm_get_ctl(void *dst_addr, wide_ptr_t src, int64_t n, int64_t ct
 {
   c_nodeid_t src_node = chpl_wide_ptr_get_node(src);
   void* src_addr = chpl_wide_ptr_get_address(src);
-  chpl_gen_comm_get(dst_addr, src_node, src_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, -1, 0);
+  chpl_gen_comm_get(dst_addr, src_node, src_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, CHPL_UNKNOWN_COMM_ID, -1, 0);
 }
 
 static inline
@@ -48,7 +48,7 @@ void chpl_gen_comm_put_ctl(wide_ptr_t dst, void *src_addr, int64_t n, int64_t ct
 {
   c_nodeid_t dst_node = chpl_wide_ptr_get_node(dst);
   void* dst_addr = chpl_wide_ptr_get_address(dst);
-  chpl_gen_comm_put(src_addr, dst_node, dst_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, -1, 0);
+  chpl_gen_comm_put(src_addr, dst_node, dst_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, CHPL_UNKNOWN_COMM_ID, -1, 0);
 }
 
 // This function implements memcpy/memmove when both the source and destination

--- a/runtime/include/chpl-comm-compiler-llvm-support.h
+++ b/runtime/include/chpl-comm-compiler-llvm-support.h
@@ -40,7 +40,7 @@ void chpl_gen_comm_get_ctl(void *dst_addr, wide_ptr_t src, int64_t n, int64_t ct
 {
   c_nodeid_t src_node = chpl_wide_ptr_get_node(src);
   void* src_addr = chpl_wide_ptr_get_address(src);
-  chpl_gen_comm_get(dst_addr, src_node, src_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, CHPL_UNKNOWN_COMM_ID, -1, 0);
+  chpl_gen_comm_get(dst_addr, src_node, src_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, CHPL_COMM_UNKNOWN_ID, -1, 0);
 }
 
 static inline
@@ -48,7 +48,7 @@ void chpl_gen_comm_put_ctl(wide_ptr_t dst, void *src_addr, int64_t n, int64_t ct
 {
   c_nodeid_t dst_node = chpl_wide_ptr_get_node(dst);
   void* dst_addr = chpl_wide_ptr_get_address(dst);
-  chpl_gen_comm_put(src_addr, dst_node, dst_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, CHPL_UNKNOWN_COMM_ID, -1, 0);
+  chpl_gen_comm_put(src_addr, dst_node, dst_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, CHPL_COMM_UNKNOWN_ID, -1, 0);
 }
 
 // This function implements memcpy/memmove when both the source and destination

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -65,7 +65,7 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
 static inline
 void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
                             size_t size, int32_t typeIndex,
-                            int32_t commID, int ln, int32_t fn)
+                            int ln, int32_t fn)
 {
   const size_t MAX_BYTES_LOCAL_PREFETCH = 1024;
   size_t offset;

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -51,7 +51,7 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
     chpl_memcpy(addr, raddr, size);
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_get(addr, node, raddr, size, typeIndex, ln, fn);
+    chpl_cache_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_GET
@@ -98,7 +98,7 @@ void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
     chpl_memcpy(raddr, addr, size);
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_put(addr, node, raddr, size, typeIndex, ln, fn);
+    chpl_cache_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_PUT
@@ -118,7 +118,7 @@ void chpl_gen_comm_get_strd(void *addr, void *dststr, c_nodeid_t node, void *rad
   if( 0 ) {
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, ln, fn);
+    chpl_cache_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_GET_STRD
@@ -138,7 +138,7 @@ void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, void *rad
   if( 0 ) {
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, ln, fn);
+    chpl_cache_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_PUT_STRD

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -39,7 +39,7 @@
 // Note: Macros starting with CHPL_COMM involve some kind of communication
 //
 
-#define CHPL_UNKNOWN_COMM_ID -1
+#define CHPL_COMM_UNKNOWN_ID -1
 
 
 static inline

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -39,11 +39,13 @@
 // Note: Macros starting with CHPL_COMM involve some kind of communication
 //
 
+#define CHPL_UNKNOWN_COMM_ID -1
+
 
 static inline
 void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
                        size_t size, int32_t typeIndex,
-                       int ln, int32_t fn)
+                       int32_t commID, int ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
     chpl_memcpy(addr, raddr, size);
@@ -53,9 +55,9 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_GET
-    chpl_task_comm_get(addr, node, raddr, size, typeIndex, ln, fn);
+    chpl_task_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #else
-    chpl_comm_get(addr, node, raddr, size, typeIndex, ln, fn);
+    chpl_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
   }
 }
@@ -63,7 +65,7 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
 static inline
 void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
                             size_t size, int32_t typeIndex,
-                            int ln, int32_t fn)
+                            int32_t commID, int ln, int32_t fn)
 {
   const size_t MAX_BYTES_LOCAL_PREFETCH = 1024;
   size_t offset;
@@ -90,7 +92,7 @@ void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
 static inline
 void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
                        size_t size, int32_t typeIndex,
-                       int ln, int32_t fn)
+                       int32_t commID, int ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
     chpl_memcpy(raddr, addr, size);
@@ -100,9 +102,9 @@ void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_PUT
-    chpl_task_comm_put(addr, node, raddr, size, typeIndex, ln, fn);
+    chpl_task_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #else
-    chpl_comm_put(addr, node, raddr, size, typeIndex, ln, fn);
+    chpl_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
   }
 }
@@ -111,7 +113,7 @@ static inline
 void chpl_gen_comm_get_strd(void *addr, void *dststr, c_nodeid_t node, void *raddr,
                        void *srcstr, void *count, int32_t strlevels, 
                        size_t elemSize, int32_t typeIndex,
-                       int ln, int32_t fn)
+                       int32_t commID, int ln, int32_t fn)
 {
   if( 0 ) {
 #ifdef HAS_CHPL_CACHE_FNS
@@ -120,9 +122,9 @@ void chpl_gen_comm_get_strd(void *addr, void *dststr, c_nodeid_t node, void *rad
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_GET_STRD
-  chpl_task_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, ln, fn);
+  chpl_task_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
 #else
-  chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, ln, fn);
+  chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
 #endif
   }
 }
@@ -131,7 +133,7 @@ static inline
 void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, void *raddr,
                        void *srcstr, void *count, int32_t strlevels, 
                        size_t elemSize, int32_t typeIndex,
-                       int ln, int32_t fn)
+                       int32_t commID, int ln, int32_t fn)
 {
   if( 0 ) {
 #ifdef HAS_CHPL_CACHE_FNS
@@ -140,9 +142,9 @@ void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, void *rad
 #endif
   } else {
 #ifdef CHPL_TASK_COMM_PUT_STRD
-  chpl_task_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, ln, fn);
+  chpl_task_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
 #else
-  chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, ln, fn);
+  chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
 #endif
   }
 }

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -125,14 +125,14 @@ void chpl_comm_taskCallFTable(chpl_fn_int_t fid,      // ftable[] entry to call
 // before the request completes (after waiting on the returned handle)
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t typeIndex,
-                                       int ln, int32_t fn);
+                                       int32_t commID, int ln, int32_t fn);
 
 // Do a PUT in a nonblocking fashion, returning a handle which can be used to
 // wait for the PUT to complete. The source buffer must not be modified before
 // the request completes (after waiting on the returned handle)
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t typeIndex,
-                                       int ln, int32_t fn);
+                                       int32_t commID, int ln, int32_t fn);
 
 // Returns nonzero iff the handle has already been waited for and has
 // been cleared out in a call to chpl_comm_{wait,try}_some.
@@ -312,7 +312,7 @@ void chpl_comm_exit(int all, int status);
 //
 void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
                     size_t size, int32_t typeIndex,
-                    int ln, int32_t fn);
+                    int32_t commID, int ln, int32_t fn);
 
 //
 // get 'size' bytes of remote data at 'raddr' on locale 'locale' to
@@ -323,7 +323,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 //
 void  chpl_comm_get(void *addr, c_nodeid_t node, void* raddr,
                     size_t size, int32_t typeIndex,
-                    int ln, int32_t fn);
+                    int32_t commID, int ln, int32_t fn);
 
 //
 // put the number of elements pointed out by count array, with strides pointed
@@ -340,7 +340,7 @@ void  chpl_comm_get(void *addr, c_nodeid_t node, void* raddr,
 void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode,
                      void* srcaddr, size_t* srcstrides, size_t* count,
                      int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
-                     int ln, int32_t fn);
+                     int32_t commID, int ln, int32_t fn);
 
 //
 // same as chpl_comm_puts(), but do get instead
@@ -348,7 +348,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode,
 void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode,
                      void* srcaddr, size_t* srcstrides, size_t* count,
                      int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
-                     int ln, int32_t fn);
+                     int32_t commID, int ln, int32_t fn);
 
 //
 // Get a local copy of a wide string.

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -40,6 +40,7 @@
 extern const char* chpl_compileCommand;
 extern const char* chpl_compileVersion;
 extern const char* chpl_compileDirectory;
+extern const char* chpl_saveCDir;
 
 extern const char* CHPL_HOME;
 extern const char* CHPL_HOST_PLATFORM;

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -186,6 +186,8 @@ typedef void* chpl_opaque;
 #define UINT32( i) ((uint32_t)(UINT32_C(i)))
 #define UINT64( i) ((uint64_t)(UINT64_C(i)))
 
+#define COMMID( i)  ((int64_t)(INT64_C(i)))
+
 
 typedef int8_t chpl_bool8;
 typedef int16_t chpl_bool16;

--- a/runtime/include/comm/ugni/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ugni/chpl-comm-task-decls.h
@@ -69,7 +69,7 @@ typedef void* chpl_comm_nb_handle_t;
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, int32_t locale, void* raddr,
                                        size_t size, int32_t typeIndex,
-                                       int ln, int32_t fn);
+                                       int32_t commID, int ln, int32_t fn);
 chpl_bool chpl_comm_test_get_nb(chpl_comm_nb_handle_t handle,
                                 int ln, int32_t fn);
 

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -1934,7 +1934,7 @@ void cache_put(struct rdcache_s* cache,
                 unsigned char* addr,
                 c_nodeid_t node, raddr_t raddr, size_t size,
                 cache_seqn_t last_acquire,
-                int ln, int32_t fn)
+                int32_t commID, int ln, int32_t fn)
 {
   struct cache_entry_s* entry;
   raddr_t ra_first_page;
@@ -2089,7 +2089,7 @@ void cache_get(struct rdcache_s* cache,
                 c_nodeid_t node, raddr_t raddr, size_t size,
                 cache_seqn_t last_acquire,
                 int sequential_readahead_length,
-                int ln, int32_t fn);
+                int32_t commID, int ln, int32_t fn);
 
 static
 void cache_get_trigger_readahead(struct rdcache_s* cache,
@@ -2100,7 +2100,7 @@ void cache_get_trigger_readahead(struct rdcache_s* cache,
                                  readahead_distance_t skip,
                                  readahead_distance_t len,
                                  cache_seqn_t last_acquire,
-                                 int ln, int32_t fn)
+                                 int32_t commID, int ln, int32_t fn)
 {
   int next_ra_length;
   int ok;
@@ -2182,7 +2182,7 @@ void cache_get_trigger_readahead(struct rdcache_s* cache,
                 prefetch_start, prefetch_end - prefetch_start,
                 last_acquire,
                 next_ra_length,
-                ln, fn);
+                commID, ln, fn);
     } else {
       // We could not prefetch, so record a cache miss so
       //  that sequential prefetch will continue when we access
@@ -2231,7 +2231,7 @@ void cache_get(struct rdcache_s* cache,
                 c_nodeid_t node, raddr_t raddr, size_t size,
                 cache_seqn_t last_acquire,
                 int sequential_readahead_length,
-                int ln, int32_t fn)
+                int32_t commID, int ln, int32_t fn)
 {
   struct cache_entry_s* entry;
   raddr_t ra_first_page;
@@ -2428,7 +2428,7 @@ void cache_get(struct rdcache_s* cache,
                                         readahead_skip,
                                         readahead_len,
                                         last_acquire,
-                                        ln, fn);
+                                        commID, ln, fn);
             entry = NULL; // note trigger readahead could evict entry...
           }
         }
@@ -2476,7 +2476,7 @@ void cache_get(struct rdcache_s* cache,
       chpl_comm_get_nb(page+(ra_line-ra_page), /*local addr*/
                        node, (void*) ra_line,
                        ra_line_end - ra_line /*size*/, -1/*typei*/,
-                       CHPL_COMM_UNKNOWN_ID, ln, fn);
+                       commID, ln, fn);
 #ifdef TIME
     clock_gettime(CLOCK_REALTIME, &start_get2);
 #endif
@@ -2789,7 +2789,7 @@ void chpl_cache_fence(int acquire, int release, int ln, int32_t fn)
 
 void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
                          size_t size, int32_t typeIndex,
-                         int ln, int32_t fn)
+                         int32_t commID, int ln, int32_t fn)
 {
   //printf("put len %d node %d raddr %p\n", (int) len * elemSize, node, raddr);
   struct rdcache_s* cache = tls_cache_remote_data();
@@ -2809,13 +2809,13 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
   //saturating_increment(&info->put_since_release);
   //task_local->last_op = seqn_max(cache, addr, node, raddr, size);
   cache_put(cache, addr, node, (raddr_t)raddr, size, task_local->last_acquire,
-            ln, fn);
+            commID, ln, fn);
   return;
 }
 
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
                          size_t size, int32_t typeIndex,
-                         int ln, int32_t fn)
+                         int32_t commID, int ln, int32_t fn)
 {
   //printf("get len %d node %d raddr %p\n", (int) len * elemSize, node, raddr);
   struct rdcache_s* cache = tls_cache_remote_data();
@@ -2834,7 +2834,7 @@ void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
 
   //saturating_increment(&info->get_since_acquire);
   cache_get(cache, addr, node, (raddr_t)raddr, size, task_local->last_acquire,
-            0, ln, fn);
+            0, commID, ln, fn);
 
   return;
 }
@@ -2852,12 +2852,13 @@ void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
   // Always use the cache for prefetches.
   //saturating_increment(&info->prefetch_since_acquire);
   cache_get(cache, NULL, node, (raddr_t)raddr, size, task_local->last_acquire,
-            0, ln, fn);
+            0, CHPL_COMM_UNKNOWN_ID, ln, fn);
 }
 void chpl_cache_comm_get_strd(void *addr, void *dststr, c_nodeid_t node,
                               void *raddr, void *srcstr, void *count,
                               int32_t strlevels, size_t elemSize,
-                              int32_t typeIndex, int ln, int32_t fn) {
+                              int32_t typeIndex, int32_t commID,
+                              int ln, int32_t fn) {
   TRACE_PRINT(("%d: in chpl_cache_comm_get_strd\n", chpl_nodeID));
   // do a full fence - so that:
   // 1) any pending writes are completed (in case they were to the
@@ -2870,16 +2871,17 @@ void chpl_cache_comm_get_strd(void *addr, void *dststr, c_nodeid_t node,
   // do the strided get.
 #ifdef CHPL_TASK_COMM_GET_STRD
   chpl_task_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                          elemSize, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
+                          elemSize, typeIndex, commID, ln, fn);
 #else
   chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                     elemSize, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
+                     elemSize, typeIndex, commID, ln, fn);
 #endif
 }
 void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
                               void *raddr, void *srcstr, void *count,
                               int32_t strlevels, size_t elemSize,
-                              int32_t typeIndex, int ln, int32_t fn) {
+                              int32_t typeIndex, int32_t commID,
+                              int ln, int32_t fn) {
   TRACE_PRINT(("%d: in chpl_cache_comm_put_strd\n", chpl_nodeID));
   // do a full fence - so that:
   // 1) any pending writes are completed (in case they were to the
@@ -2892,10 +2894,10 @@ void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
   // do the strided put.
 #ifdef CHPL_TASK_COMM_PUT_STRD
   chpl_task_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                          elemSize, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
+                          elemSize, typeIndex, commID, ln, fn);
 #else
   chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                     elemSize, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
+                     elemSize, typeIndex, commID, ln, fn);
 #endif
 }
 

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -1737,7 +1737,7 @@ void flush_entry(struct rdcache_s* cache, struct cache_entry_s* entry, int op,
                              entry->base.node,
                              (void*)(entry->raddr+start),
                              got_len /*size*/, -1/*typei*/,
-                             CHPL_UNKNOWN_COMM_ID, -1, 0);
+                             CHPL_COMM_UNKNOWN_ID, -1, 0);
 
           // Save the handle in the list of pending requests.
           entry->max_put_sequence_number = pending_push(cache, handle);
@@ -2476,7 +2476,7 @@ void cache_get(struct rdcache_s* cache,
       chpl_comm_get_nb(page+(ra_line-ra_page), /*local addr*/
                        node, (void*) ra_line,
                        ra_line_end - ra_line /*size*/, -1/*typei*/,
-                       CHPL_UNKNOWN_COMM_ID, ln, fn);
+                       CHPL_COMM_UNKNOWN_ID, ln, fn);
 #ifdef TIME
     clock_gettime(CLOCK_REALTIME, &start_get2);
 #endif
@@ -2870,10 +2870,10 @@ void chpl_cache_comm_get_strd(void *addr, void *dststr, c_nodeid_t node,
   // do the strided get.
 #ifdef CHPL_TASK_COMM_GET_STRD
   chpl_task_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                          elemSize, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
+                          elemSize, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
 #else
   chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                     elemSize, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
+                     elemSize, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
 #endif
 }
 void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
@@ -2892,10 +2892,10 @@ void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
   // do the strided put.
 #ifdef CHPL_TASK_COMM_PUT_STRD
   chpl_task_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                          elemSize, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
+                          elemSize, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
 #else
   chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                     elemSize, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
+                     elemSize, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
 #endif
 }
 

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -280,6 +280,7 @@ use.
 #include "chpl-cache.h"
 #include "chpl-linefile-support.h"
 #include "sys.h" // sys_page_size()
+#include "chpl-comm-compiler-macros.h"
 #include "chpl-comm-no-warning-macros.h" // No warnings for chpl_comm_get etc.
 #include <string.h> // memcpy, memset, etc.
 #include <assert.h>
@@ -1736,7 +1737,7 @@ void flush_entry(struct rdcache_s* cache, struct cache_entry_s* entry, int op,
                              entry->base.node,
                              (void*)(entry->raddr+start),
                              got_len /*size*/, -1/*typei*/,
-                             -1, 0);
+                             CHPL_UNKNOWN_COMM_ID, -1, 0);
 
           // Save the handle in the list of pending requests.
           entry->max_put_sequence_number = pending_push(cache, handle);
@@ -2475,7 +2476,7 @@ void cache_get(struct rdcache_s* cache,
       chpl_comm_get_nb(page+(ra_line-ra_page), /*local addr*/
                        node, (void*) ra_line,
                        ra_line_end - ra_line /*size*/, -1/*typei*/,
-                       ln, fn);
+                       CHPL_UNKNOWN_COMM_ID, ln, fn);
 #ifdef TIME
     clock_gettime(CLOCK_REALTIME, &start_get2);
 #endif
@@ -2869,10 +2870,10 @@ void chpl_cache_comm_get_strd(void *addr, void *dststr, c_nodeid_t node,
   // do the strided get.
 #ifdef CHPL_TASK_COMM_GET_STRD
   chpl_task_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                          elemSize, typeIndex, ln, fn);
+                          elemSize, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
 #else
   chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                     elemSize, typeIndex, ln, fn);
+                     elemSize, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
 #endif
 }
 void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
@@ -2891,10 +2892,10 @@ void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
   // do the strided put.
 #ifdef CHPL_TASK_COMM_PUT_STRD
   chpl_task_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                          elemSize, typeIndex, ln, fn);
+                          elemSize, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
 #else
   chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                     elemSize, typeIndex, ln, fn);
+                     elemSize, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
 #endif
 }
 

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -58,7 +58,7 @@ void chpl_gen_comm_wide_string_get(void *addr, c_nodeid_t node, void *raddr,
   if (chpl_nodeID == node) {
     chpl_memcpy(addr, raddr, size);
   } else {
-    chpl_gen_comm_get(addr, node, raddr, size, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
+    chpl_gen_comm_get(addr, node, raddr, size, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
   }
 
   // And now we copy the bytes in the string itself.
@@ -115,7 +115,7 @@ chpl_comm_wide_get_string(chpl_string* local, struct chpl_chpl____wide_chpl_stri
     chpl_gen_comm_get((void *)&(*chpl_macro_tmp),
                       chpl_rt_nodeFromLocaleID(x->locale), (void *)(x->addr),
                       sizeof(char) * x->size, tid,
-                      CHPL_UNKNOWN_COMM_ID, lineno, filename);
+                      CHPL_COMM_UNKNOWN_ID, lineno, filename);
   *local = chpl_macro_tmp;
 }
 

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -58,7 +58,7 @@ void chpl_gen_comm_wide_string_get(void *addr, c_nodeid_t node, void *raddr,
   if (chpl_nodeID == node) {
     chpl_memcpy(addr, raddr, size);
   } else {
-    chpl_gen_comm_get(addr, node, raddr, size, typeIndex, ln, fn);
+    chpl_gen_comm_get(addr, node, raddr, size, typeIndex, CHPL_UNKNOWN_COMM_ID, ln, fn);
   }
 
   // And now we copy the bytes in the string itself.
@@ -115,7 +115,7 @@ chpl_comm_wide_get_string(chpl_string* local, struct chpl_chpl____wide_chpl_stri
     chpl_gen_comm_get((void *)&(*chpl_macro_tmp),
                       chpl_rt_nodeFromLocaleID(x->locale), (void *)(x->addr),
                       sizeof(char) * x->size, tid,
-                      lineno, filename);
+                      CHPL_UNKNOWN_COMM_ID, lineno, filename);
   *local = chpl_macro_tmp;
 }
 

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -66,6 +66,9 @@ int chpl_vdebug = 0;
 
 #define TID_STRING(buff, tid) (chpl_task_idToString(buff, CHPL_TASK_ID_STRING_MAX_LEN, tid))
 
+#define CHPL_VDEBUG_GETPUT_FORMAT_NAMES "tv srcNodeID dstNodeID commTaskID addr raddr elemSize typeIndex length commID lineNumber fileno"
+#define CHPL_VDEBUG_GETPUT_FORMAT_STRING(name) #name ": %lld.%06ld %d %d %s %#lx %#lx 1 %zd %d %d %d %d\n"
+
 int chpl_dprintf (int fd, const char * format, ...) {
   char buffer[2048]; 
   va_list ap;
@@ -154,7 +157,7 @@ void chpl_vdebug_start (const char *fileroot, double now) {
     ru.ru_stime.tv_usec = 0;
   }
   chpl_dprintf (chpl_vdebug_fd,
-                "ChplVdebug: ver 1.2 nodes %d nid %d tid %s seq %.3lf %lld.%06ld %ld.%06ld %ld.%06ld \n",
+                "ChplVdebug: ver 1.3 nodes %d nid %d tid %s seq %.3lf %lld.%06ld %ld.%06ld %ld.%06ld \n",
                 chpl_numNodes, chpl_nodeID, TID_STRING(buff, startTask), now,
                 (long long) tv.tv_sec, (long) tv.tv_usec,
                 (long) ru.ru_utime.tv_sec, (long) ru.ru_utime.tv_usec,
@@ -167,6 +170,7 @@ void chpl_vdebug_start (const char *fileroot, double now) {
 
     chpl_dprintf (chpl_vdebug_fd, "CHPL_HOME: %s\n", CHPL_HOME);
     chpl_dprintf (chpl_vdebug_fd, "DIR: %s\n", chpl_compileDirectory);
+    chpl_dprintf (chpl_vdebug_fd, "SAVEC: %s\n", chpl_saveCDir);
 
     chpl_dprintf (chpl_vdebug_fd, "Tablesize: %d\n", chpl_filenameTableSize);
     for (ix = 0; ix < chpl_filenameTableSize ; ix++) {
@@ -312,11 +316,11 @@ void cb_comm_put_nb (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd, 
-                  "nb_put: %lld.%06ld %d %d %s %#lx %#lx %d %d %d %d %d\n",
+                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(nb_put),
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, 1, cm->typeIndex, (int)cm->size,
-                  cm->lineno, cm->filename);
+                  (unsigned long) cm->raddr, cm->size, cm->typeIndex,
+                  cm->commID, cm->lineno, cm->filename);
   }
 }
 
@@ -333,11 +337,11 @@ void cb_comm_get_nb (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  "nb_get: %lld.%06ld %d %d %s %#lx %#lx %d %d %d %d %d\n",
+                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(nb_get),
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, 1, cm->typeIndex, (int)cm->size,
-                  cm->lineno, cm->filename);
+                  (unsigned long) cm->raddr, cm->size, cm->typeIndex,
+                  cm->commID, cm->lineno, cm->filename);
   }
 }
 
@@ -353,11 +357,11 @@ void cb_comm_put (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  "put: %lld.%06ld %d %d %s %#lx %#lx %d %d %d %d %d\n",
+                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(put),
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, 1, cm->typeIndex, (int)cm->size,
-                  cm->lineno, cm->filename);
+                  (unsigned long) cm->raddr, cm->size, cm->typeIndex,
+                  cm->commID, cm->lineno, cm->filename);
   }
 }
 
@@ -374,11 +378,11 @@ void cb_comm_get (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  "get: %lld.%06ld %d %d %s %#lx %#lx %d %d %d %d %d\n",
+                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(get),
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, 1, cm->typeIndex, (int)cm->size,
-                  cm->lineno, cm->filename);
+                  (unsigned long) cm->raddr, cm->size, cm->typeIndex,
+                  cm->commID, cm->lineno, cm->filename);
   }
 }
 
@@ -393,11 +397,11 @@ void cb_comm_put_strd (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  "st_put: %lld.%06ld %d %ld %s %#lx %#lx 1 %zd %d %d %d\n",
+                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(st_put),
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID, 
-                  (long) info->remoteNodeID, TID_STRING(buff, commTask),
+                  info->remoteNodeID, TID_STRING(buff, commTask),
                   (unsigned long) cm->srcaddr, (unsigned long) cm->dstaddr, cm->elemSize,
-                  cm->typeIndex, cm->lineno, cm->filename);
+                  cm->typeIndex, cm->commID, cm->lineno, cm->filename);
     // printout srcstrides and dststrides and stridelevels and count?
   }
 
@@ -416,11 +420,11 @@ void cb_comm_get_strd (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  "st_get: %lld.%06ld %d %ld %s %#lx %#lx 1 %zd %d %d %d\n",
+                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(st_get),
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
-                  (long) info->remoteNodeID, TID_STRING(buff, commTask),
+                  info->remoteNodeID, TID_STRING(buff, commTask),
                   (unsigned long) cm->dstaddr, (unsigned long) cm->srcaddr, cm->elemSize,
-                  cm->typeIndex, cm->lineno, cm->filename);
+                  cm->typeIndex, cm->commID, cm->lineno, cm->filename);
     // print out the srcstrides and dststrides and stridelevels and count?
   }
 }

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -319,7 +319,7 @@ void cb_comm_put_nb (const chpl_comm_cb_info_t *info) {
                   CHPL_VDEBUG_GETPUT_FORMAT_STRING(nb_put),
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, 1, cm->typeIndex, cm->size,
+                  (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
                   cm->commID, cm->lineno, cm->filename);
   }
 }
@@ -340,7 +340,7 @@ void cb_comm_get_nb (const chpl_comm_cb_info_t *info) {
                   CHPL_VDEBUG_GETPUT_FORMAT_STRING(nb_get),
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, 1, cm->typeIndex, cm->size,
+                  (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
                   cm->commID, cm->lineno, cm->filename);
   }
 }
@@ -360,7 +360,7 @@ void cb_comm_put (const chpl_comm_cb_info_t *info) {
                   CHPL_VDEBUG_GETPUT_FORMAT_STRING(put),
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, 1, cm->typeIndex, cm->size,
+                  (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
                   cm->commID, cm->lineno, cm->filename);
   }
 }
@@ -381,7 +381,7 @@ void cb_comm_get (const chpl_comm_cb_info_t *info) {
                   CHPL_VDEBUG_GETPUT_FORMAT_STRING(get),
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, 1, cm->typeIndex, cm->size,
+                  (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
                   cm->commID, cm->lineno, cm->filename);
   }
 }
@@ -392,12 +392,13 @@ void cb_comm_get (const chpl_comm_cb_info_t *info) {
 void cb_comm_put_strd (const chpl_comm_cb_info_t *info) {
     if (chpl_vdebug) {
     struct timeval tv;
+    size_t length;
     const struct chpl_comm_info_comm_strd *cm = &info->iu.comm_strd;
     chpl_taskID_t commTask = chpl_task_getId();
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
 
-    size_t length = 1;
+    length = 1;
     for (int32_t i = 0; i < cm->stridelevels; i++) {
       length *= cm->count[i];
     }
@@ -421,12 +422,13 @@ void cb_comm_put_strd (const chpl_comm_cb_info_t *info) {
 void cb_comm_get_strd (const chpl_comm_cb_info_t *info) {
   if (chpl_vdebug) {
     struct timeval tv;
+    size_t length;
     const struct chpl_comm_info_comm_strd *cm = &info->iu.comm_strd;
     chpl_taskID_t commTask = chpl_task_getId();
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
 
-    size_t length = 1;
+    length = 1;
     for (int32_t i = 0; i < cm->stridelevels; i++) {
       length *= cm->count[i];
     }

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -66,8 +66,8 @@ int chpl_vdebug = 0;
 
 #define TID_STRING(buff, tid) (chpl_task_idToString(buff, CHPL_TASK_ID_STRING_MAX_LEN, tid))
 
-#define CHPL_VDEBUG_GETPUT_FORMAT_NAMES "tv srcNodeID dstNodeID commTaskID addr raddr elemSize typeIndex length commID lineNumber fileno"
-#define CHPL_VDEBUG_GETPUT_FORMAT_STRING(name) #name ": %lld.%06ld %d %d %s %#lx %#lx %zd %d %zd %d %d %d\n"
+#define VDEBUG_GETPUT_FORMAT_NAMES "kind tv srcNodeID dstNodeID commTaskID addr raddr elemSize typeIndex length commID lineNumber fileno"
+#define VDEBUG_GETPUT_FORMAT_STRING "%s: %lld.%06ld %d %d %s %#lx %#lx %zd %d %zd %d %d %d\n"
 
 int chpl_dprintf (int fd, const char * format, ...) {
   char buffer[2048]; 
@@ -316,7 +316,7 @@ void cb_comm_put_nb (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd, 
-                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(nb_put),
+                  VDEBUG_GETPUT_FORMAT_STRING, "nb_put",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
                   (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
@@ -337,7 +337,7 @@ void cb_comm_get_nb (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(nb_get),
+                  VDEBUG_GETPUT_FORMAT_STRING, "nb_get",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
                   (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
@@ -357,7 +357,7 @@ void cb_comm_put (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(put),
+                  VDEBUG_GETPUT_FORMAT_STRING, "put",
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
                   (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
@@ -378,7 +378,7 @@ void cb_comm_get (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(get),
+                  VDEBUG_GETPUT_FORMAT_STRING, "get",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
                   (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
@@ -404,7 +404,7 @@ void cb_comm_put_strd (const chpl_comm_cb_info_t *info) {
     }
 
     chpl_dprintf (chpl_vdebug_fd,
-                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(st_put),
+                  VDEBUG_GETPUT_FORMAT_STRING, "st_put",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID, 
                   info->remoteNodeID, TID_STRING(buff, commTask),
                   (unsigned long) cm->srcaddr, (unsigned long) cm->dstaddr, cm->elemSize,
@@ -434,7 +434,7 @@ void cb_comm_get_strd (const chpl_comm_cb_info_t *info) {
     }
 
     chpl_dprintf (chpl_vdebug_fd,
-                  CHPL_VDEBUG_GETPUT_FORMAT_STRING(st_get),
+                  VDEBUG_GETPUT_FORMAT_STRING, "st_get",
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask),
                   (unsigned long) cm->dstaddr, (unsigned long) cm->srcaddr, cm->elemSize,

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -321,10 +321,10 @@ void chpl_printMemAllocStats(int32_t lineno, int32_t filename) {
     fprintf(memLogFile, "==============================================================\n");
     for (i = 0; i < chpl_numNodes; i++) {
       static size_t m1, m2, m3, m4;
-      chpl_gen_comm_get(&m1, i, &totalMem,       sizeof(size_t), -1 /* broke for hetero */, CHPL_UNKNOWN_COMM_ID, lineno, filename);
-      chpl_gen_comm_get(&m2, i, &maxMem,         sizeof(size_t), -1 /* broke for hetero */, CHPL_UNKNOWN_COMM_ID, lineno, filename);
-      chpl_gen_comm_get(&m3, i, &totalAllocated, sizeof(size_t), -1 /* broke for hetero */, CHPL_UNKNOWN_COMM_ID, lineno, filename);
-      chpl_gen_comm_get(&m4, i, &totalFreed,     sizeof(size_t), -1 /* broke for hetero */, CHPL_UNKNOWN_COMM_ID, lineno, filename);
+      chpl_gen_comm_get(&m1, i, &totalMem,       sizeof(size_t), -1 /* broke for hetero */, CHPL_COMM_UNKNOWN_ID, lineno, filename);
+      chpl_gen_comm_get(&m2, i, &maxMem,         sizeof(size_t), -1 /* broke for hetero */, CHPL_COMM_UNKNOWN_ID, lineno, filename);
+      chpl_gen_comm_get(&m3, i, &totalAllocated, sizeof(size_t), -1 /* broke for hetero */, CHPL_COMM_UNKNOWN_ID, lineno, filename);
+      chpl_gen_comm_get(&m4, i, &totalFreed,     sizeof(size_t), -1 /* broke for hetero */, CHPL_COMM_UNKNOWN_ID, lineno, filename);
       fprintf(memLogFile, "%-9d  %-9zu  %-9zu  %-9zu  %-9zu\n", i, m1, m2, m3, m4);
     }
     fprintf(memLogFile, "==============================================================\n");

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -321,10 +321,10 @@ void chpl_printMemAllocStats(int32_t lineno, int32_t filename) {
     fprintf(memLogFile, "==============================================================\n");
     for (i = 0; i < chpl_numNodes; i++) {
       static size_t m1, m2, m3, m4;
-      chpl_gen_comm_get(&m1, i, &totalMem, sizeof(size_t), -1 /* broke for hetero */, lineno, filename);
-      chpl_gen_comm_get(&m2, i, &maxMem, sizeof(size_t), -1 /* broke for hetero */, lineno, filename);
-      chpl_gen_comm_get(&m3, i, &totalAllocated,  sizeof(size_t), -1 /* broke for hetero */, lineno, filename);
-      chpl_gen_comm_get(&m4, i, &totalFreed, sizeof(size_t), -1 /*broke for hetero */, lineno, filename);
+      chpl_gen_comm_get(&m1, i, &totalMem,       sizeof(size_t), -1 /* broke for hetero */, CHPL_UNKNOWN_COMM_ID, lineno, filename);
+      chpl_gen_comm_get(&m2, i, &maxMem,         sizeof(size_t), -1 /* broke for hetero */, CHPL_UNKNOWN_COMM_ID, lineno, filename);
+      chpl_gen_comm_get(&m3, i, &totalAllocated, sizeof(size_t), -1 /* broke for hetero */, CHPL_UNKNOWN_COMM_ID, lineno, filename);
+      chpl_gen_comm_get(&m4, i, &totalFreed,     sizeof(size_t), -1 /* broke for hetero */, CHPL_UNKNOWN_COMM_ID, lineno, filename);
       fprintf(memLogFile, "%-9d  %-9zu  %-9zu  %-9zu  %-9zu\n", i, m1, m2, m3, m4);
     }
     fprintf(memLogFile, "==============================================================\n");

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -370,7 +370,7 @@ static void fork_large_wrapper(large_fork_task_t* f) {
   // GET the bundle data
   // TODO: This could get only the payload
   chpl_comm_get(arg, caller, arg_on_caller, bundle_size_on_caller,
-                -1 /*typeIndex: unused*/, 0, CHPL_FILE_IDX_FORK_LARGE);
+                -1 /*typeIndex: unused*/, CHPL_UNKNOWN_COMM_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
 
   // Call the on body function
   chpl_ftable_call(fid, arg);
@@ -453,7 +453,7 @@ static void fork_nb_large_wrapper(large_fork_task_t* f) {
 
   // GET the bundle data
   chpl_comm_get(arg, caller, arg_on_caller, bundle_size_on_caller,
-                -1 /*typeIndex: unused*/, 0, CHPL_FILE_IDX_FORK_LARGE);
+                -1 /*typeIndex: unused*/, CHPL_UNKNOWN_COMM_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
 
   // Signal that the allocated region can be freed
   GASNET_Safe(gasnet_AMRequestShort2(caller, FREE,
@@ -599,7 +599,7 @@ static gasnet_handlerentry_t ftable[] = {
 //
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t typeIndex,
-                                       int ln, int32_t fn)
+                                       int32_t commID, int ln, int32_t fn)
 {
   gasnet_handle_t ret;
   int remote_in_segment;
@@ -608,7 +608,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put_nb)) {
     chpl_comm_cb_info_t cb_data = 
       {chpl_comm_cb_event_kind_put_nb, chpl_nodeID, node,
-       .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+       .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
     
@@ -619,7 +619,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
 #endif
 
   if(!remote_in_segment) {
-    chpl_comm_put(addr, node, raddr, size, typeIndex, ln, fn);
+    chpl_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
     ret = NULL;
     return (chpl_comm_nb_handle_t) ret;
   }
@@ -637,7 +637,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t typeIndex,
-                                       int ln, int32_t fn)
+                                       int32_t commID, int ln, int32_t fn)
 {
   gasnet_handle_t ret;
   int remote_in_segment;
@@ -646,7 +646,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get_nb)) {
     chpl_comm_cb_info_t cb_data = 
       {chpl_comm_cb_event_kind_get_nb, chpl_nodeID, node,
-       .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+       .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -657,7 +657,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
 #endif
 
   if(!remote_in_segment) {
-    chpl_comm_get(addr, node, raddr, size, typeIndex, ln, fn);
+    chpl_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
     ret = NULL;
     return (chpl_comm_nb_handle_t) ret;
   }
@@ -919,7 +919,7 @@ void chpl_comm_broadcast_global_vars(int numGlobals) {
     for (i = 0; i < numGlobals; i++) {
       chpl_comm_get(chpl_globals_registry[i], 0,
                     &((wide_ptr_t*)seginfo_table[0].addr)[i],
-                    sizeof(wide_ptr_t), -1 /*typeIndex: unused*/, 0, 0);
+                    sizeof(wide_ptr_t), -1 /*typeIndex: unused*/, CHPL_UNKNOWN_COMM_ID, 0, 0);
     }
   }
 }
@@ -1083,7 +1083,7 @@ void chpl_comm_exit(int all, int status) {
 
 void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
                     size_t size, int32_t typeIndex,
-                    int ln, int32_t fn) {
+                    int32_t commID, int ln, int32_t fn) {
   int remote_in_segment;
 
   if (chpl_nodeID == node) {
@@ -1093,7 +1093,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
     if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put)) {
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put, chpl_nodeID, node,
-         .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1165,7 +1165,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 ////GASNET - look at GASNET tools at top of README.tools has atomic counters
 void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
                     size_t size, int32_t typeIndex,
-                    int ln, int32_t fn) {
+                    int32_t commID, int ln, int32_t fn) {
   int remote_in_segment;
 
   if (chpl_nodeID == node) {
@@ -1175,7 +1175,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
     if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_get, chpl_nodeID, node,
-         .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1295,7 +1295,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
 void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_id, 
                          void* srcaddr, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
-                         int ln, int32_t fn) {
+                         int32_t commID, int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
   const gasnet_node_t srcnode = (gasnet_node_t)srcnode_id;
@@ -1340,7 +1340,7 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
     chpl_comm_cb_info_t cb_data =
       {chpl_comm_cb_event_kind_get_strd, chpl_nodeID, srcnode_id,
        .iu.comm_strd={srcaddr, srcstrides, dstaddr, dststrides, count,
-                      stridelevels, elemSize, typeIndex, ln, fn}};
+                      stridelevels, elemSize, typeIndex, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
   
@@ -1362,7 +1362,7 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
 void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_id, 
                          void* srcaddr, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
-                         int ln, int32_t fn) {
+                         int32_t commID, int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
   const gasnet_node_t dstnode = (gasnet_node_t)dstnode_id;
@@ -1405,7 +1405,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put_strd, chpl_nodeID, dstnode_id,
          .iu.comm_strd={srcaddr, srcstrides, dstaddr, dststrides, count,
-                        stridelevels, elemSize, typeIndex, ln, fn}};
+                        stridelevels, elemSize, typeIndex, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -370,7 +370,7 @@ static void fork_large_wrapper(large_fork_task_t* f) {
   // GET the bundle data
   // TODO: This could get only the payload
   chpl_comm_get(arg, caller, arg_on_caller, bundle_size_on_caller,
-                -1 /*typeIndex: unused*/, CHPL_UNKNOWN_COMM_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
+                -1 /*typeIndex: unused*/, CHPL_COMM_UNKNOWN_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
 
   // Call the on body function
   chpl_ftable_call(fid, arg);
@@ -453,7 +453,7 @@ static void fork_nb_large_wrapper(large_fork_task_t* f) {
 
   // GET the bundle data
   chpl_comm_get(arg, caller, arg_on_caller, bundle_size_on_caller,
-                -1 /*typeIndex: unused*/, CHPL_UNKNOWN_COMM_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
+                -1 /*typeIndex: unused*/, CHPL_COMM_UNKNOWN_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
 
   // Signal that the allocated region can be freed
   GASNET_Safe(gasnet_AMRequestShort2(caller, FREE,
@@ -919,7 +919,7 @@ void chpl_comm_broadcast_global_vars(int numGlobals) {
     for (i = 0; i < numGlobals; i++) {
       chpl_comm_get(chpl_globals_registry[i], 0,
                     &((wide_ptr_t*)seginfo_table[0].addr)[i],
-                    sizeof(wide_ptr_t), -1 /*typeIndex: unused*/, CHPL_UNKNOWN_COMM_ID, 0, 0);
+                    sizeof(wide_ptr_t), -1 /*typeIndex: unused*/, CHPL_COMM_UNKNOWN_ID, 0, 0);
     }
   }
 }

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -57,7 +57,7 @@ static int mysystem(const char* command, const char* description,
 // Chapel interface
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t typeIndex,
-                                       int ln, int32_t fn)
+                                       int32_t commID, int ln, int32_t fn)
 {
   assert(node == 0);
   chpl_memcpy(raddr, addr, size);
@@ -66,7 +66,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t typeIndex,
-                                       int ln, int32_t fn)
+                                       int32_t commID, int ln, int32_t fn)
 {
   assert(node == 0);
   chpl_memcpy(addr, raddr, size);
@@ -148,7 +148,7 @@ void chpl_comm_exit(int all, int status) { }
 
 void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
                     size_t size, int32_t typeIndex,
-                    int ln, int32_t fn) {
+                    int32_t commID, int ln, int32_t fn) {
   assert(node==0);
 
   memmove(raddr, addr, size);
@@ -156,7 +156,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 
 void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
                     size_t size, int32_t typeIndex,
-                    int ln, int32_t fn) {
+                    int32_t commID, int ln, int32_t fn) {
   assert(node==0);
 
   memmove(addr, raddr, size);
@@ -165,7 +165,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
 void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t dstnode,
                          void* srcaddr_arg, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t typeIndex,
-                         int ln, int32_t fn)
+                         int32_t commID, int ln, int32_t fn)
 {
   const size_t strlvls = (size_t)stridelevels;
   size_t i,j,k,l,m,t,total,off,x,carry;
@@ -319,7 +319,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t dstno
 void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t srcnode,
                          void* srcaddr_arg, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t typeIndex,
-                         int ln, int32_t fn)
+                         int32_t commID, int ln, int32_t fn)
 {
   const size_t strlvls = (size_t)stridelevels;
   size_t i,j,k,l,m,t,total,off,x,carry;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3740,7 +3740,7 @@ void consume_all_outstanding_cq_events(int cdi)
 
 void chpl_comm_put(void* addr, int32_t locale, void* raddr,
                    size_t size, int32_t typeIndex,
-                   int ln, int32_t fn)
+                   int32_t commID, int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_put(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -3759,7 +3759,7 @@ void chpl_comm_put(void* addr, int32_t locale, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put)) {
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put, chpl_nodeID, locale,
-         .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -3880,7 +3880,7 @@ void do_remote_put(void* src_addr, int32_t locale, void* tgt_addr, size_t size,
 
 void chpl_comm_get(void* addr, int32_t locale, void* raddr,
                    size_t size, int32_t typeIndex,
-                   int ln, int32_t fn)
+                   int32_t commID, int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_get(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -3899,7 +3899,7 @@ void chpl_comm_get(void* addr, int32_t locale, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_get, chpl_nodeID, locale,
-         .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -4071,7 +4071,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
                          int32_t dstlocale,
                          void* srcaddr_arg, size_t* srcstrides,
                          size_t* count, int32_t stridelevels, size_t elemSize,
-                         int32_t typeIndex, int ln, int32_t fn)
+                         int32_t typeIndex, int32_t commID, int ln, int32_t fn)
 {
   const size_t strlvls=(size_t)stridelevels;
   size_t i,j,k,t,total,off,x,carry;
@@ -4092,7 +4092,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put_strd, chpl_nodeID, dstlocale,
          .iu.comm_strd={srcaddr_arg, srcstrides, dstaddr_arg, dststrides, count,
-                        stridelevels, elemSize, typeIndex, ln, fn}};
+                        stridelevels, elemSize, typeIndex, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -4114,7 +4114,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
   case 0:
     PERFSTATS_ADD(put_strd_byte_cnt, cnt[0]);
     chpl_comm_put(srcaddr_arg, dstlocale, dstaddr_arg, cnt[0],
-                  typeIndex, ln, fn);
+                  typeIndex, commID, ln, fn);
     break;
   case 1:
     dstaddr=(int8_t*)dstaddr_arg;
@@ -4122,7 +4122,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
     for(i=0; i<cnt[1]; i++) {
       PERFSTATS_ADD(put_strd_byte_cnt, cnt[0]);
       chpl_comm_put(srcaddr, dstlocale, dstaddr, cnt[0],
-                    typeIndex, ln, fn);
+                    typeIndex, commID, ln, fn);
       srcaddr+=srcstr[0];
       dstaddr+=dststr[0];
     }
@@ -4134,7 +4134,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
       for(j=0; j<cnt[1]; j++) {
         PERFSTATS_ADD(put_strd_byte_cnt, cnt[0]);
         chpl_comm_put(srcaddr, dstlocale, dstaddr, cnt[0],
-                      typeIndex, ln, fn);
+                      typeIndex, commID, ln, fn);
         srcaddr+=srcstr[0];
         dstaddr+=dststr[0];
       }
@@ -4150,7 +4150,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
         for(k=0; k<cnt[1]; k++) {
           PERFSTATS_ADD(put_strd_byte_cnt, cnt[0]);
           chpl_comm_put(srcaddr, dstlocale, dstaddr, cnt[0],
-                        typeIndex, ln, fn);
+                        typeIndex, commID, ln, fn);
           srcaddr+=srcstr[0];
           dstaddr+=dststr[0];
         }
@@ -4188,7 +4188,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
           }
           PERFSTATS_ADD(put_strd_byte_cnt, cnt[0]);
           chpl_comm_put(srcaddr+srcdisp[j], dstlocale, dstaddr+dstdisp[j],
-                        cnt[0], typeIndex, ln, fn);
+                        cnt[0], typeIndex, commID, ln, fn);
           break;
 
         } else { //ELSE 1
@@ -4206,7 +4206,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
                          int32_t srclocale,
                          void* srcaddr_arg, size_t* srcstrides,
                          size_t* count, int32_t stridelevels, size_t elemSize,
-                         int32_t typeIndex, int ln, int32_t fn)
+                         int32_t typeIndex, int32_t commID, int ln, int32_t fn)
 {
   const size_t strlvls=(size_t)stridelevels;
   size_t i,j,k,t,total,off,x,carry;
@@ -4226,7 +4226,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
     chpl_comm_cb_info_t cb_data =
       {chpl_comm_cb_event_kind_get_strd, chpl_nodeID, srclocale,
        .iu.comm_strd={srcaddr_arg, srcstrides, dstaddr_arg, dststrides, count,
-                      stridelevels, elemSize, typeIndex, ln, fn}};
+                      stridelevels, elemSize, typeIndex, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -4250,7 +4250,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
     srcaddr=(int8_t*)srcaddr_arg;
     PERFSTATS_ADD(get_strd_byte_cnt, cnt[0]);
     chpl_comm_get(dstaddr, srclocale, srcaddr, cnt[0],
-                  typeIndex, ln, fn);
+                  typeIndex, commID, ln, fn);
     break;
   case 1:
     dstaddr=(int8_t*)dstaddr_arg;
@@ -4258,7 +4258,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
     for(i=0; i<cnt[1]; i++) {
       PERFSTATS_ADD(get_strd_byte_cnt, cnt[0]);
       chpl_comm_get(dstaddr, srclocale, srcaddr, cnt[0],
-                    typeIndex, ln, fn);
+                    typeIndex, commID, ln, fn);
       srcaddr+=srcstr[0];
       dstaddr+=dststr[0];
     }
@@ -4270,7 +4270,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
       for(j=0; j<cnt[1]; j++) {
         PERFSTATS_ADD(get_strd_byte_cnt, cnt[0]);
         chpl_comm_get(dstaddr, srclocale, srcaddr, cnt[0],
-                      typeIndex, ln, fn);
+                      typeIndex, commID, ln, fn);
         srcaddr+=srcstr[0];
         dstaddr+=dststr[0];
       }
@@ -4286,7 +4286,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
         for(k=0; k<cnt[1]; k++) {
           PERFSTATS_ADD(get_strd_byte_cnt, cnt[0]);
           chpl_comm_get(dstaddr, srclocale, srcaddr, cnt[0],
-                        typeIndex, ln, fn);
+                        typeIndex, commID, ln, fn);
           srcaddr+=srcstr[0];
           dstaddr+=dststr[0];
         }
@@ -4324,7 +4324,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
           }
           PERFSTATS_ADD(get_strd_byte_cnt, cnt[0]);
           chpl_comm_get(dstaddr+dstdisp[j], srclocale, srcaddr+srcdisp[j],
-                        cnt[0], typeIndex, ln, fn);
+                        cnt[0], typeIndex, commID, ln, fn);
           break;
 
         } else {  //ELSE 1
@@ -4344,7 +4344,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
 //
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, int32_t locale, void* raddr,
                                        size_t size, int32_t typeIndex,
-                                       int ln, int32_t fn)
+                                       int32_t commID, int ln, int32_t fn)
 {
   mem_region_t*          local_mr;
   mem_region_t*          remote_mr;
@@ -4372,7 +4372,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, int32_t locale, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get_nb)) {
     chpl_comm_cb_info_t cb_data = 
       {chpl_comm_cb_event_kind_get_nb, chpl_nodeID, locale,
-       .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+       .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -4445,7 +4445,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, int32_t locale, void* raddr,
 
 chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, int32_t locale, void* raddr,
                                        size_t size, int32_t typeIndex,
-                                       int ln, int32_t fn)
+                                       int32_t commID, int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_put_nb(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -4455,7 +4455,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, int32_t locale, void* raddr,
   // it do a real nonblocking implementation, but right now we don't
   // have time.
   //
-  chpl_comm_put(addr, locale, raddr, size, typeIndex, ln, fn);
+  chpl_comm_put(addr, locale, raddr, size, typeIndex, commID, ln, fn);
   return NULL;
 
 #if 0
@@ -4467,7 +4467,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, int32_t locale, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put_nb)) {
     chpl_comm_cb_info_t cb_data = 
       {chpl_comm_cb_event_kind_put_nb, chpl_nodeID, locale,
-       .iu.comm={addr, raddr, size, typeIndex, ln, fn}};
+       .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 #endif
@@ -6229,7 +6229,7 @@ void chpl_comm_statsReport(chpl_bool32 sum_over_locales)
     sum = chpl_comm_pstats;
     for (int li = 0; li < chpl_numNodes; li++) {
       if (li != chpl_nodeID) {
-        chpl_comm_get(&ps, li, &chpl_comm_pstats, sizeof(ps), -1, 0, -1);
+        chpl_comm_get(&ps, li, &chpl_comm_pstats, sizeof(ps), -1, CHPL_UNKNOWN_COMM_ID, 0, -1);
 #define _PSV_SUM(psv) sum.psv += ps.psv;
         PERFSTATS_DO_ALL(_PSV_SUM);
 #undef _PSV_SUM

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6229,7 +6229,7 @@ void chpl_comm_statsReport(chpl_bool32 sum_over_locales)
     sum = chpl_comm_pstats;
     for (int li = 0; li < chpl_numNodes; li++) {
       if (li != chpl_nodeID) {
-        chpl_comm_get(&ps, li, &chpl_comm_pstats, sizeof(ps), -1, CHPL_UNKNOWN_COMM_ID, 0, -1);
+        chpl_comm_get(&ps, li, &chpl_comm_pstats, sizeof(ps), -1, CHPL_COMM_UNKNOWN_ID, 0, -1);
 #define _PSV_SUM(psv) sum.psv += ps.psv;
         PERFSTATS_DO_ALL(_PSV_SUM);
 #undef _PSV_SUM

--- a/runtime/src/qio/bulkget.c
+++ b/runtime/src/qio/bulkget.c
@@ -39,7 +39,7 @@ qbytes_t* bulk_get_bytes(int64_t src_locale, qbytes_t* src_addr)
 
   // First, get the length and local pointer to the bytes.
   chpl_gen_comm_get(&tmp, src_locale, src_addr, sizeof(qbytes_t),
-                    CHPL_TYPE_int64_t, CHPL_UNKNOWN_COMM_ID,
+                    CHPL_TYPE_int64_t, CHPL_COMM_UNKNOWN_ID,
                     -1, CHPL_FILE_IDX_INTERNAL);
   src_len = tmp.len;
   src_data = tmp.data;
@@ -55,7 +55,7 @@ qbytes_t* bulk_get_bytes(int64_t src_locale, qbytes_t* src_addr)
   if( src_data ) {
     chpl_gen_comm_get(ret->data, src_locale, src_data,
                       sizeof(uint8_t) * src_len, CHPL_TYPE_uint8_t,
-                      CHPL_UNKNOWN_COMM_ID, -1, CHPL_FILE_IDX_INTERNAL);
+                      CHPL_COMM_UNKNOWN_ID, -1, CHPL_FILE_IDX_INTERNAL);
   }
 
   // Great! All done.
@@ -92,7 +92,7 @@ qioerr bulk_put_buffer(int64_t dst_locale, void* dst_addr, int64_t dst_len,
                        dst_locale,
                        PTR_ADDBYTES(dst_addr, j),
                        sizeof(uint8_t)*iov[i].iov_len, CHPL_TYPE_uint8_t,
-                       CHPL_UNKNOWN_COMM_ID, -1, CHPL_FILE_IDX_INTERNAL);
+                       CHPL_COMM_UNKNOWN_ID, -1, CHPL_FILE_IDX_INTERNAL);
 
     j += iov[i].iov_len;
   }

--- a/runtime/src/qio/bulkget.c
+++ b/runtime/src/qio/bulkget.c
@@ -39,7 +39,8 @@ qbytes_t* bulk_get_bytes(int64_t src_locale, qbytes_t* src_addr)
 
   // First, get the length and local pointer to the bytes.
   chpl_gen_comm_get(&tmp, src_locale, src_addr, sizeof(qbytes_t),
-                    CHPL_TYPE_int64_t, -1, CHPL_FILE_IDX_INTERNAL);
+                    CHPL_TYPE_int64_t, CHPL_UNKNOWN_COMM_ID,
+                    -1, CHPL_FILE_IDX_INTERNAL);
   src_len = tmp.len;
   src_data = tmp.data;
 
@@ -53,8 +54,8 @@ qbytes_t* bulk_get_bytes(int64_t src_locale, qbytes_t* src_addr)
   // Next, get the data itself.
   if( src_data ) {
     chpl_gen_comm_get(ret->data, src_locale, src_data,
-                      sizeof(uint8_t) * src_len, CHPL_TYPE_uint8_t, -1,
-                      CHPL_FILE_IDX_INTERNAL);
+                      sizeof(uint8_t) * src_len, CHPL_TYPE_uint8_t,
+                      CHPL_UNKNOWN_COMM_ID, -1, CHPL_FILE_IDX_INTERNAL);
   }
 
   // Great! All done.
@@ -91,7 +92,7 @@ qioerr bulk_put_buffer(int64_t dst_locale, void* dst_addr, int64_t dst_len,
                        dst_locale,
                        PTR_ADDBYTES(dst_addr, j),
                        sizeof(uint8_t)*iov[i].iov_len, CHPL_TYPE_uint8_t,
-                       -1, CHPL_FILE_IDX_INTERNAL );
+                       CHPL_UNKNOWN_COMM_ID, -1, CHPL_FILE_IDX_INTERNAL);
 
     j += iov[i].iov_len;
   }

--- a/tools/chplvis/DataModel.h
+++ b/tools/chplvis/DataModel.h
@@ -135,6 +135,7 @@ class DataModel {
   // File name help
   const char *chpl_home;
   const char *dir;
+  const char *savec;
 
   filename *fileTbl;
   int fileTblSize;
@@ -264,6 +265,8 @@ class DataModel {
 
   // void DIR(const char *d) { dir = d; }
   const char * DIR() { return dir; }
+
+  const char * SAVEC() { return savec; }
 
   // Function name access
 

--- a/tools/chplvis/TextDataFormat.txt
+++ b/tools/chplvis/TextDataFormat.txt
@@ -15,16 +15,17 @@ First line of every file is:
 
   In the following record definitions the following will stand
   for a number in the line:
-     nid - local node id (locale)
-     rid - remote node id
-     tid - task id
-     tv  - time of day value  (sec.usec format)
-     tu  - user time          (sec.usec format)
-     ts  - system time        (sec.usec format)
-     tnum - tag number
-     lnum - line number
+     nid    - local node id (locale)
+     rid    - remote node id
+     tid    - task id
+     tv     - time of day value  (sec.usec format)
+     tu     - user time          (sec.usec format)
+     ts     - system time        (sec.usec format)
+     tnum   - tag number
+     commiD - unique ID per generated get/put, for mapping to generated code
+     lnum   - line number
      fileno - index in the file name table
-     fid - function id number
+     fid    - function id number
 
 Lines in the file:
 
@@ -74,12 +75,12 @@ Lines in the file:
   Etask: tv nid tid
     Task has ended execution
 
-  nb_put: tv nid rid tid addr raddr elemsize typeIndex length lnum fileno
-  nb_get: tv nid rid tid addr raddr elemsize typeIndex length lnum fileno
-  put: tv nid rid tid addr raddr elemsize typeIndex length lnum fileno
-  get: tv nid rid tid addr raddr elemsize typeIndex length lnum fileno
-  st_put:  tv nid rid tid addr raddr elemsize typeIndex length lnum fileno
-  st_get:  tv nid rid tid addr raddr elemsize typeIndex length lnum fileno
+  nb_put: tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
+  nb_get: tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
+  put   : tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
+  get   : tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
+  st_put: tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
+  st_get: tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
     communication.  Puts: data flow nid->rid, gets: data flow rid -> nid
     nb is non-blocking, st is strided.
 


### PR DESCRIPTION
While the line number and filename of a Chapel program is useful output from VisualDebug, it doesn't really help developers map gets/puts to the generated sources. Many gets/puts may share line/file info if they are within an iterator, for example.

This PR adds a new argument to the get/put runtime calls, called ``commID``, which is a unique integer ID for each get/put. This ID is unique within a file. In the generated C, this integer is wrapped in the new COMMID macro for readability.

I incremented the output version from 1.2 to 1.3, and updated ``chplvis`` to handle the new format. Otherwise there is no change to chplvis. The ``commID`` is not displayed anywhere in the GUI.

In the chpl-visual-debug.c file, I add code to compute the length of the get/put.

Otherwise, there are some minor style/formatting cleanups.

Testing:
- [x] test/chplvis and chplvis primers
  - [x] mac
  - [x] linux
  - [x] ugni
- [x] cache-remote
- [x] local paratest
- [x] gasnet paratest