### PR TITLE
Don't line buffer output in the paratest.chapcs python rewrite

### DIFF
--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -72,8 +72,8 @@ def run_live_command(command):
     except OSError:
         error("command not found: {0}".format(command[0]), OSError)
 
-    for stdout_line in iter(process.stdout.readline, str.encode("")):
-        yield stdout_line.decode()
+    for stdout_char in iter(lambda: process.stdout.read(1), str.encode("")):
+        yield stdout_char.decode()
     process.stdout.close()
     returncode = process.wait()
 

--- a/util/test/paratest.chapcs.py
+++ b/util/test/paratest.chapcs.py
@@ -123,6 +123,7 @@ def run_paratest(args):
     start_time = timeit.default_timer()
     for line in utils.run_live_command(paratest_cmd):
         sys.stdout.write(line)
+        sys.stdout.flush()
     elapsed = int(timeit.default_timer() - start_time)
     minutes, seconds = divmod(elapsed, 60)
     print('paratest took {0} minutes and {1} seconds'.format(minutes, seconds))


### PR DESCRIPTION
We were previously doing `process.stdout.readline`, but for paratest this meant
the trailing smiley faces would be buffered until all testing was finished,
which gave the impression that paratest stopped working. Just read a character
at a time instead of a line at a time. This probably has terrible performance
for processes that have a huge amount of output, but paratest doesn't actually
output that much, so it's probably not a big deal.