### PR TITLE
Top level Modules

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1871,10 +1871,27 @@ void EnumSymbol::accept(AstVisitor* visitor) {
   visitor->visitEnumSym(this);
 }
 
-/******************************** | *********************************
-*                                                                   *
-*                                                                   *
-********************************* | ********************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+static std::vector<ModuleSymbol*>    sTopLevelModules;
+
+void ModuleSymbol::addTopLevelModule(ModuleSymbol* module) {
+  sTopLevelModules.push_back(module);
+
+  theProgram->block->insertAtTail(new DefExpr(module));
+}
+
+
+void ModuleSymbol::getTopLevelModules(std::vector<ModuleSymbol*>& mods) {
+  for (size_t i = 0; i < sTopLevelModules.size(); i++) {
+    mods.push_back(sTopLevelModules[i]);
+  }
+}
+
 
 ModuleSymbol::ModuleSymbol(const char* iName,
                            ModTag      iModTag,

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1086,14 +1086,21 @@ std::string AggregateType::docsDirective() {
 ************************************** | *************************************/
 
 void initRootModule() {
-  rootModule           = new ModuleSymbol("_root", MOD_INTERNAL, new BlockStmt());
+  rootModule           = new ModuleSymbol("_root",
+                                          MOD_INTERNAL,
+                                          new BlockStmt());
+
   rootModule->filename = astr("<internal>");
 }
 
 void initStringLiteralModule() {
-  stringLiteralModule = new ModuleSymbol("ChapelStringLiterals", MOD_INTERNAL, new BlockStmt());
+  stringLiteralModule           = new ModuleSymbol("ChapelStringLiterals",
+                                                   MOD_INTERNAL,
+                                                   new BlockStmt());
+
   stringLiteralModule->filename = astr("<internal>");
-  theProgram->block->insertAtTail(new DefExpr(stringLiteralModule));
+
+  ModuleSymbol::addTopLevelModule(stringLiteralModule);
 }
 
 /************************************* | **************************************

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -562,14 +562,19 @@ class EnumSymbol : public Symbol {
   Immediate*      getImmediate();
 };
 
-/******************************** | *********************************
-*                                                                   *
-*                                                                   *
-********************************* | ********************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 struct ExternBlockInfo;
 
 class ModuleSymbol : public Symbol {
+public:
+  static void          addTopLevelModule (ModuleSymbol*               module);
+  static void          getTopLevelModules(std::vector<ModuleSymbol*>& mods);
+
 public:
                        ModuleSymbol(const char* iName,
                                     ModTag      iModTag,

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -806,7 +806,9 @@ static ModuleSymbol* parseFile(const char* path,
         if (DefExpr* defExpr = toDefExpr(stmt)) {
           if (ModuleSymbol* modSym = toModuleSymbol(defExpr->sym)) {
 
-            theProgram->block->insertAtTail(defExpr->remove());
+            defExpr->remove();
+
+            ModuleSymbol::addTopLevelModule(modSym);
 
             addModuleToDoneList(modSym);
 
@@ -825,7 +827,7 @@ static ModuleSymbol* parseFile(const char* path,
 
       retval = buildModule(modName, modTag, yyblock, yyfilename, false, NULL);
 
-      theProgram->block->insertAtTail(new DefExpr(retval));
+      ModuleSymbol::addTopLevelModule(retval);
 
       addModuleToDoneList(retval);
     }


### PR DESCRIPTION
Before this PR there was not a trivial way to traverse the "top level" modules of a
program; the best one could do would be to traverse theProgram.

This PR allocates a static member variable on ModuleSymbol that stores the
top level modules and updates the initialization steps and the parser to update
this set.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed a single-locale paratest
