### PR TITLE
Annotate re2 update

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -766,6 +766,12 @@ regexdna:
     - Fixed string memory leak resulting from redundant autoCopies (#3023)
   03/12/16:
     - implemented good_alloc_size for jemalloc(#3446)
+  04/20/17:
+    - Update RE2 (#6024)
+
+regexdna-redux:
+  04/20/17:
+    - Update RE2 (#6024)
 
 return-array-8: &return-array-base
   03/04/17:
@@ -863,6 +869,12 @@ taskSpawn:
 temporary-copies:
   01/14/17:
     - Likely cache effects
+  04/20/17:
+    - Update RE2 (#6024)
+
+search:
+  04/20/17:
+    - Update RE2 (#6024)
 
 testSerialReductions:
   08/16/14:


### PR DESCRIPTION
Added re2 annotation for strings tests.

Tested:

```bash
> ./check_annotations.py

No fatal annotation errors detected
```