### PR TITLE
Clean up passes/cleanup.cpp

### DIFF
--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -349,21 +349,13 @@ static void changeCastInWhere(FnSymbol* fn) {
     for_vector(BaseAST, ast, asts) {
       if (CallExpr* call = toCallExpr(ast)) {
         if (call->isCast() == true) {
-          CallExpr* isSubtype = NULL;
-          Expr*     to        = call->castTo();
-          Expr*     from      = call->castFrom();
-
-          // now remove to and from so we can add them
-          // again as arguments. Don't interleave the
-          // remove with the calls to castTo and castFrom.
+          Expr* to   = call->castTo();
+          Expr* from = call->castFrom();
 
           to->remove();
-
           from->remove();
 
-          isSubtype = new CallExpr(PRIM_IS_SUBTYPE, to, from);
-
-          call->replace(isSubtype);
+          call->replace(new CallExpr(PRIM_IS_SUBTYPE, to, from));
         }
       }
     }

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -38,6 +38,8 @@ static void cleanup(ModuleSymbol* module);
 
 static void normalizeNestedFunctionExpressions(DefExpr* def);
 
+static void normalizeLoopIterExpressions(DefExpr* def);
+
 static void flattenScopelessBlock(BlockStmt* block);
 
 static void destructureTupleAssignment(CallExpr* call);
@@ -74,6 +76,7 @@ static void cleanup(ModuleSymbol* module) {
       SET_LINENO(ast);
 
       normalizeNestedFunctionExpressions(def);
+      normalizeLoopIterExpressions(def);
     }
   }
 
@@ -125,8 +128,17 @@ static void normalizeNestedFunctionExpressions(DefExpr* def) {
 
     def->replace(new UnresolvedSymExpr(def->sym->name));
     stmt->insertBefore(def);
+  }
+}
 
-  } else if (strncmp("_iterator_for_loopexpr", def->sym->name, 22) == 0) {
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+static void normalizeLoopIterExpressions(DefExpr* def) {
+  if (strncmp("_iterator_for_loopexpr", def->sym->name, 22) == 0) {
     FnSymbol* parent = toFnSymbol(def->parentSymbol);
 
     INT_ASSERT(strncmp("_parloopexpr", parent->name, 12) == 0 ||


### PR DESCRIPTION
The "cleanup" pass appears to have started life as a final sub-pass
of the parser but has grown to include some early normalization steps.
Additionally a few of the functions within cleanup were expanded to
include multiple separable operations.

This PR provides a second step in refactoring this sub-pass with a
view to enabling the normalization operations to be extracted and
relocated to a more logical position in the compiler in later work.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed a single-locale paratest.
During development several different configurations were used
