### PR TITLE
Update PRK Transpose

### DIFF
--- a/test/studies/prk/transpose/transpose.chpl
+++ b/test/studies/prk/transpose/transpose.chpl
@@ -1,5 +1,5 @@
 //
-// Chapel's serial implementation of transpose
+// Chapel's parallel implementation of transpose
 //
 use Time;
 use BlockDist;

--- a/test/studies/prk/transpose/transpose.chpl
+++ b/test/studies/prk/transpose/transpose.chpl
@@ -2,37 +2,51 @@
 // Chapel's serial implementation of transpose
 //
 use Time;
+use BlockDist;
 
-param PRKVERSION = "2.15";
+param PRKVERSION = "2.17";
 
-config const iterations : int = 100,
-             order : int = 100,
-             debug: bool = false,
-             validate: bool = false;
+config param useBlockDist = false;
 
-config var tileSize: int = 0;
+config const iterations = 100,
+             order = 100,
+             validate = false,
+             debug = false;
+
+config var tileSize = 0;
 
 //
 // Process and test input configs
 //
 if (iterations < 1) {
-  writeln("ERROR: iterations must be >= 1: ", iterations);
-  exit(1);
+  halt("ERROR: iterations must be >= 1: ", iterations);
 }
+
 if (order < 0) {
-  writeln("ERROR: Matrix Order must be greater than 0 : ", order);
-  exit(1);
+  halt("ERROR: Matrix Order must be greater than 0 : ", order);
+}
+
+if (tileSize > order) {
+  halt("ERROR: Tile size cannot be larger than order");
 }
 
 // Determine tiling
-var tiled = (tileSize < order && tileSize > 0);
+const tiled = tileSize > 0;
 
 // Safety check for creation of tiledDom
 if (!tiled) then tileSize = 1;
 
 // Domains
-const    Dom = {0.. # order, 0.. # order};
-var tiledDom = {0.. # order by tileSize, 0.. # order by tileSize};
+const localDom = {0..#order, 0..#order};
+var tiledLocalDom = {0..#order by tileSize, 0..#order by tileSize};
+
+
+const blockDist = new dmap(new Block(localDom));
+const Dist =  if useBlockDist then blockDist
+                              else defaultDist;
+
+const Dom = localDom dmapped Dist;
+const tiledDom = tiledLocalDom dmapped Dist;
 
 var timer: Timer,
     bytes = 2.0 * numBytes(real) * order * order,
@@ -53,8 +67,8 @@ if (!validate) {
 // Fill original column matrix
 [(i, j) in Dom] A[i,j] = order*j + i;
 
-// Set transpose matrix to known garbage value
-B = -1.0;
+// Initialize B for clarity
+B = 0.0;
 
 //
 // Main loop
@@ -67,17 +81,18 @@ for iteration in 0..iterations {
     forall (i,j) in tiledDom {
       for it in i .. # min(order - i, tileSize) {
         for jt in j .. # min(order - j, tileSize) {
-          B[jt,it] = A[it,jt];
+          B[jt,it] += A[it,jt];
+          A[it,jt] += 1.0;
         }
       }
     }
   }
   else {
     forall (i,j) in Dom {
-      B[j,i] = A[i,j];
+      B[j,i] += A[i,j];
+      A[i,j] += 1.0;
     }
   }
-
 } // end of main loop
 
 timer.stop();
@@ -92,11 +107,9 @@ var transposeTime = timer.elapsed(),
 
 // Error tolerance
 const epsilon = 1.e-8;
-
-var absErr = 0.0;
-for (i,j) in Dom {
-  absErr += abs(B[i,j] - (order*i + j));
-}
+const addit = ((iterations+1) * iterations)/2.0;
+var absErr = + reduce [(i,j) in Dom]
+    abs(B[i,j]-((order*i+j)*(iterations+1)+addit));
 
 if (debug) {
   writeln("transposeTime = ", transposeTime);


### PR DESCRIPTION
This PR updates the PRK Transpose study

  - Bumps up the version number
  - Changes error printouts from writeln/exit to halt
  - Drops types
  - Adds support for distributed data (without any optimization)
  - Adjusts input initialization and minor changes in the logic
    This minor changes is due to the changes in the main PRK repo. It
    increases the computation slightly, so we can expect some
    performance degradation.
  - Adjusts validation accordingly

Change is limited to the test file. And it has been tested on standard
linux64 with `CHPL_COMM=none` and `CHPL_COMM=gasnet`

General PRK notes
- I will be creating other PRs to contribute other PRKs I have
- After we are done adding new PRKs, I think another cleanup PR is
  necessary for the following reasons:
  - README.md must be updated or removed completely
  - Folder names should be adjusted(capitalization) to align with PRK
    names from the main repo. (Not a must but why not?)
  - Coding style adjustments/alignments. I am trying to keep the diff
    minimal for this PR.
  - IMHO the `validate` flag needs to be changed. (1) The name
    doesn't reflect its function precisely, (2) Its function seems to be
    suppressing output so that start_test can compare against the good
    file, which can (I think should) be handled with prediff.