### PR TITLE
Suppress I-fail-without-re2 test if using PGI

### DIFF
--- a/test/regexp/elliot/I-fail-without-re2.suppressif
+++ b/test/regexp/elliot/I-fail-without-re2.suppressif
@@ -1,0 +1,3 @@
+# re2 requires C++11 atomic support, which pgi doesn't have
+CHPL_TARGET_COMPILER==cray-prgenv-pgi
+CHPL_TARGET_COMPILER==pgi

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -142,7 +142,7 @@ export CHPL_LAUNCHER=none
 export CHPL_COMM=none
 
 # Set some vars that nightly cares about.
-export CHPL_NIGHTLY_LOGDIR=/data/sea/chapel/Nightly
+export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/data/sea/chapel/Nightly}
 export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 
 # Ensure that one of the CPU modules is loaded.


### PR DESCRIPTION
  ##  Suppress I-fail-without-re2 test if using PGI
    
    Current version of re2 requires C++11 atomic support, which PGI
    does not have. So, with PGI, re2 does not get built and the
    I-fail-without-re2 test fails.
    
    This change adds I-fail-without-re2.suppressif to quiet this error.
    
    PGI is only used in Cray Whitebox tests, so those are the only tests
    that should be affected by this change.

  ##  Parameterize CHPL_NIGHTLY_LOGDIR for whitebox jobs.
    
    Makes common-whitebox.bash honor the existing env variable, if any,
    instead of always forcing it to /data/sea/chapel/Nightly.
    
    This allows casual whitebox tests to be run using "nightly", without
    disturbing the nightly test logs or sending misleading email
    notifications.