### PR TITLE
Make valgrind testing use quickstart config

### DIFF
--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 #
-# Test default configuration on full suite with valgrind on linux64.
+# Test quickstart configuration on full suite with valgrind on linux64.
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
-source $CWD/common-fifo.bash
+source $CWD/common-quickstart.bash
 source $CWD/common-valgrind.bash
-
-export CHPL_MEM=cstdlib
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrind"
 


### PR DESCRIPTION
Since we updated RE2, it no longer runs valgrind-clean. It used to have special handling to avoid valgrind errors when running under valgrind.  But RE2 dropped support for valgrind.

Here we solve that by skipping RE2 testing in nightly valgrind testing.  To simplify matters, we switch to having valgrind test the quickstart configuration. Before, we were setting CHPL_TASKS and CHPL_MEM to the quickstart values and so we were most of the way to a quickstart configuration.

Reviewed by @ronawho - thanks!