### PR TITLE
Add new PRKs

### DIFF
--- a/test/studies/prk/DGEMM/dgemm.chpl
+++ b/test/studies/prk/DGEMM/dgemm.chpl
@@ -130,11 +130,10 @@ else {
 if validate {
   const checksum = + reduce C;
   if abs(checksum-refChecksum)/refChecksum > epsilon then
-    halt("VALIDATION FAILED!\n \
-        Reference checksum = ", refChecksum, " Checksum = ",
-        checksum);
+    halt("VALIDATION FAILED! Reference checksum = ", refChecksum,
+                           " Checksum = ", checksum);
   else
-    writeln("Validation successful.");
+    writeln("Validation successful");
 }
 
 if !correctness {

--- a/test/studies/prk/DGEMM/dgemm.chpl
+++ b/test/studies/prk/DGEMM/dgemm.chpl
@@ -1,0 +1,137 @@
+use Time;
+use BlockDist;
+use RangeChunk;
+
+param PRKVERSION = "2.17";
+
+config type dtype = real;
+
+config param useBlockDist = false;
+
+config const order = 10,
+             epsilon = 1e-8,
+             iterations = 100,
+             blockSize = 0,
+             debug = false,
+             validate = true;
+
+
+// TODO current logic assumes order is divisible by blockSize. add that
+// check
+
+const vecRange = 0..#order;
+
+const matrixSpace = {vecRange, vecRange};
+const matrixDom = matrixSpace dmapped if useBlockDist then
+                      new dmap(new Block(boundingBox=matrixSpace)) else
+                      defaultDist;
+
+var A: [matrixDom] dtype,
+    B: [matrixDom] dtype,
+    C: [matrixDom] dtype;
+
+forall (i,j) in matrixDom {
+  A[i,j] = j;
+  B[i,j] = j;
+  C[i,j] = 0;
+}
+
+const nTasksPerLocale = here.maxTaskPar;
+writeln("Chapel Dense matrix-matrix multiplication");
+writeln("Max parallelism      =   ", nTasksPerLocale);
+writeln("Matrix order         =   ", order);
+writeln("Blocking factor      =   ", if blockSize>0 then blockSize+""
+    else "N/A");
+writeln("Number of iterations =   ", iterations);
+writeln();
+
+const refChecksum = (iterations) *
+    (0.25*order*order*order*(order-1.0)*(order-1.0));
+
+var t = new Timer();
+
+if blockSize == 0 {
+  for niter in 0..#iterations {
+    if iterations==1 || niter==1 then t.start();
+
+    // loop order is the same as the OpenMP version
+    forall (j,k,i) in {vecRange, vecRange, vecRange} {
+      C[i,j] += A[i,k] * B[k,j];
+    }
+  }
+  t.stop();
+}
+else {
+  // task-local arrays are necessary for blocked implementation, so
+  // using explicit coforalls
+  coforall l in Locales with (ref t) {
+    on l {
+      const blockDom = {bVecRange, bVecRange};
+      const localDom = matrixDom.localSubdomain();
+
+      coforall tid in 0..#nTasksPerLocale with (ref t) {
+        const myChunk = chunk(localDom.dim(2), nTasksPerLocale, tid);
+
+        var AA: [blockDom] dtype,
+            BB: [blockDom] dtype,
+            CC: [blockDom] dtype;
+
+        for niter in 0..#iterations {
+          if tid==0 && (iterations==1 || niter==1) then t.start();
+
+          for (jj,kk) in {myChunk by blockSize, vecRange by blockSize} {
+            const jMax = min(jj+blockSize-1, myChunk.high);
+            const kMax = min(kk+blockSize-1, vecRange.high);
+            const jRange = 0..jMax-jj;
+            const kRange = 0..kMax-kk;
+
+            // instead of unbounded ranges I was using 0..#blockSize in
+            // perf tests, which was running fine with --fast, but
+            // causing unequal iter length errors without --fast(if the
+            // order is not divisible by
+            // blockSize*numLocales*nTasksPerLocale
+            for (jB, j) in zip(jj..jMax, 0..) do
+              for (kB, k) in zip(kk..kMax, 0..) do
+                BB[j,k] = B[kB,jB];
+
+            for ii in localDom.dim(1) by blockSize {
+              const iMax = min(ii+blockSize-1, localDom.dim(1).high);
+              const iRange = 0..iMax-ii;
+
+              for (iB, i) in zip(ii..iMax, 0..) do
+                for (kB, k) in zip(kk..kMax, 0..) do
+                  AA[i,k] = A[iB, kB];
+
+              local {
+                for cc in CC do
+                  cc = 0.0;
+
+                for (k,j,i) in {kRange, jRange, iRange} do
+                  CC[i,j] += AA[i,k] * BB[j,k];
+
+                for (iB, i) in zip(ii..iMax, 0..) do
+                  for (jB, j) in zip(jj..jMax, 0..) do
+                    C[iB,jB] += CC[i,j];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  t.stop();
+}
+
+if validate {
+  const checksum = + reduce C;
+  if abs(checksum-refChecksum)/refChecksum > epsilon then
+    halt("VALIDATION FAILED!\n \
+        Reference checksum = ", refChecksum, " Checksum = ",
+        checksum);
+  else
+    writeln("Validation succesful.");
+}
+
+const nflops = 2.0*(order**3);
+const avgTime = t.elapsed()/iterations;
+writeln("Rate(MFlop/s) = ", 1e-6*nflops/avgTime, " Time : ", avgTime);

--- a/test/studies/prk/DGEMM/dgemm.execopts
+++ b/test/studies/prk/DGEMM/dgemm.execopts
@@ -1,0 +1,2 @@
+--correctness --iterations=2 --order=64 --blockSize=8
+--correctness --iterations=2 --order=64

--- a/test/studies/prk/DGEMM/dgemm.good
+++ b/test/studies/prk/DGEMM/dgemm.good
@@ -1,1 +1,1 @@
-Validation successful.
+Validation successful

--- a/test/studies/prk/DGEMM/dgemm.good
+++ b/test/studies/prk/DGEMM/dgemm.good
@@ -1,0 +1,1 @@
+Validation successful.

--- a/test/studies/prk/Nstream/nstream.chpl
+++ b/test/studies/prk/Nstream/nstream.chpl
@@ -10,7 +10,8 @@ config param useBlockDist = false;
 
 config const iterations = 100,
              length = 100,
-             validate = false;
+             correctness = false, //being run in start_test
+             validate = true;
 
 config var SCALAR = 3.0;
 
@@ -33,14 +34,13 @@ var A: [vectorDom] real,
     B: [vectorDom] real,
     C: [vectorDom] real;
 
-//
-// Print information before main loop
-//
-writeln("Parallel Research Kernels version ", PRKVERSION);
-writeln("Serial stream triad: A = B + SCALAR*C");
-writeln("Max parallelism        = ", here.maxTaskPar);
-writeln("Vector length          = ", length);
-writeln("Number of iterations   = ", iterations);
+if !correctness {
+  writeln("Parallel Research Kernels version ", PRKVERSION);
+  writeln("Serial stream triad: A = B + SCALAR*C");
+  writeln("Max parallelism        = ", here.maxTaskPar);
+  writeln("Vector length          = ", length);
+  writeln("Number of iterations   = ", iterations);
+}
 
 // initialization
 A = 0.0;
@@ -84,6 +84,8 @@ if validate {
     halt("Validation failed");
 }
 
-const bytes = 4 * 8 * length;
-writeln("Rate (MB/s): ", 1.0E-06*bytes/avgTime,
-   " Avg time (s): ",avgTime);
+if !correctness {
+  const bytes = 4 * 8 * length;
+  writeln("Rate (MB/s): ", 1.0E-06*bytes/avgTime,
+         " Avg time (s): ",avgTime);
+}

--- a/test/studies/prk/Nstream/nstream.chpl
+++ b/test/studies/prk/Nstream/nstream.chpl
@@ -1,0 +1,89 @@
+//
+// Chapel's implementation of nstream
+//
+use Time;
+use BlockDist;
+
+param PRKVERSION = "2.17";
+
+config param useBlockDist = false;
+
+config const iterations = 100,
+             length = 100,
+             validate = false;
+
+config var SCALAR = 3.0;
+
+//
+// Process and test input configs
+//
+if iterations < 1 then
+  halt("ERROR: iterations must be >= 1: ", iterations);
+
+if length < 0 then
+  halt("ERROR: vector length must be >= 1: ", length);
+
+// Domains
+const space = {0.. # length};
+const vectorDom = space dmapped if useBlockDist then
+                            new dmap(new Block(boundingBox=space)) else
+                            defaultDist;
+
+var A: [vectorDom] real,
+    B: [vectorDom] real,
+    C: [vectorDom] real;
+
+//
+// Print information before main loop
+//
+writeln("Parallel Research Kernels version ", PRKVERSION);
+writeln("Serial stream triad: A = B + SCALAR*C");
+writeln("Max parallelism        = ", here.maxTaskPar);
+writeln("Vector length          = ", length);
+writeln("Number of iterations   = ", iterations);
+
+// initialization
+A = 0.0;
+B = 2.0;
+C = 2.0;
+
+var timer = new Timer();
+
+//
+// Main loop
+//
+for iteration in 0..iterations {
+  if iteration == 1 then
+    timer.start(); //Start timer after a warmup lap
+
+  A += B+SCALAR*C;
+}
+
+// Timings
+timer.stop();
+var avgTime = timer.elapsed() / iterations;
+timer.clear();
+
+//
+// Analyze and output results
+//
+if validate {
+  config const epsilon = 1.e-8;
+
+  var aj=0.0, bj=2.0, cj=2.0;
+  for 0..iterations do
+    aj += bj+SCALAR*cj;
+
+  aj = aj * length:real;
+
+  var asum = + reduce A;
+
+  if abs(aj-asum)/asum <= epsilon then
+    writeln("Validation successful");
+  else
+    halt("Validation failed");
+}
+
+const bytes = 4 * 8 * length;
+writeln("Rate (MB/s): ", 1.0E-06*bytes/avgTime,
+   " Avg time (s): ",avgTime);

--- a/test/studies/prk/Nstream/nstream.chpl
+++ b/test/studies/prk/Nstream/nstream.chpl
@@ -81,7 +81,8 @@ if validate {
   if abs(aj-asum)/asum <= epsilon then
     writeln("Validation successful");
   else
-    halt("Validation failed");
+    halt("VALIDATION FAILED! Reference checksum = ", aj,
+                           " Checksum = ", asum);
 }
 
 if !correctness {

--- a/test/studies/prk/Nstream/nstream.execopts
+++ b/test/studies/prk/Nstream/nstream.execopts
@@ -1,0 +1,1 @@
+--correctness --iterations=2 --length=100

--- a/test/studies/prk/Nstream/nstream.good
+++ b/test/studies/prk/Nstream/nstream.good
@@ -1,0 +1,1 @@
+Validation successful

--- a/test/studies/prk/PIC/pic.chpl
+++ b/test/studies/prk/PIC/pic.chpl
@@ -176,8 +176,6 @@ proc initializeGeometric() {
 
   var pIdx = 0;
   for (x,y) in {0..#L, 0..#L} {
-    // TODO without cast this creates a seg fault and overflow
-    // warning with no --fast. Investigate for possible bug. Engin
     const actual_particles = random_draw(getSeed(x));
     placeParticles(pIdx, actual_particles, x, y);
   }
@@ -205,8 +203,6 @@ proc initializeSinusoidal() {
   // pIdx = pi in OpenMP code
   var pIdx = 0;
   for (x,y) in {0..#L, 0..#L} {
-    // TODO without cast this creates a seg fault and overflow
-    // warning with no --fast. Investigate for possible bug. Engin
     const actual_particles = random_draw(getSeed(x));
     placeParticles(pIdx, actual_particles, x, y);
   }
@@ -234,8 +230,6 @@ proc initializeLinear() {
 
   var pIdx = 0;
   for (x,y) in {0..#L, 0..#L} {
-    // TODO without cast this creates a seg fault and overflow
-    // warning with no --fast. Investigate for possible bug. Engin
     const actual_particles = random_draw(getSeed(x));
     placeParticles(pIdx, actual_particles, x, y);
   }

--- a/test/studies/prk/PIC/pic.chpl
+++ b/test/studies/prk/PIC/pic.chpl
@@ -140,10 +140,10 @@ t.stop();
 
 for i in 0..#particles.size {
   if !verifyParticle(particles[i]) then
-    halt("Verification failed");
+    halt("VALIDATION FAILED!");
 }
 
-writeln("Verification successful");
+writeln("Validation successful");
 
 if !correctness {
   const avgTime = t.elapsed()/iterations;
@@ -378,7 +378,7 @@ proc verifyParticle(p) {
   const y_periodic = mod(y_final+(iterations+1):real *abs(p.m)*L, L);
 
   if ( abs(p.x - x_periodic) > epsilon || abs(p.y - y_periodic) > epsilon) {
-    writeln("Verification for particle failed");
+    writeln("Validation for particle failed");
     writeln(p.x, " ", x_periodic);
     writeln(p.y, " ", y_periodic);
     return false;

--- a/test/studies/prk/PIC/pic.chpl
+++ b/test/studies/prk/PIC/pic.chpl
@@ -110,7 +110,7 @@ for niter in 0..iterations {
 
   if niter == 1 then t.start();
 
-  forall i in 0..#n {
+  forall i in 0..#particles.size {
 
     const (fx, fy) = computeTotalForce(particles[i]);
     if debug then writeln("Force acting on particle " , i, " ", (fx,fy));
@@ -134,7 +134,7 @@ for niter in 0..iterations {
 t.stop();
 
 
-for i in 0..#n {
+for i in 0..#particles.size {
   if !verifyParticle(particles[i]) then
     halt("Verification failed");
 }

--- a/test/studies/prk/PIC/pic.chpl
+++ b/test/studies/prk/PIC/pic.chpl
@@ -1,0 +1,391 @@
+require "random_draw.h", "random_draw.c";
+use Time;
+
+// use random_draw library from PRK repo
+extern proc LCG_init();
+extern proc random_draw(x: c_double): uint(64);
+
+param PRKVERSION = "2.17";
+
+param REL_X = 0.5,
+      REL_Y = 0.5,
+      DT = 1.0,
+      Q = 1.0,
+      MASS_INV = 1.0,
+      epsilon = 0.000001;
+
+config const L = 10, // grid size
+             n = 10, // particles requested
+             k = 1,
+             m = 1,
+             iterations = 10,
+             debug = false,
+             particleMode = "SINUSOIDAL"; //how to initialize the input
+
+// for geomteric initialization
+config const rho = 1.0;
+
+// for linear initialization
+config const alpha = 0.5;
+config const beta = 0.5;
+
+// for patch initialization
+record bbox {
+  var left: int,
+      right: int,
+      bottom: int,
+      top: int;
+}
+
+config const initPatchLeft = 1;
+config const initPatchRight = 2;
+config const initPatchTop= 1;
+config const initPatchBottom = 2;
+
+const patch = new bbox(initPatchLeft,
+                           initPatchRight,
+                           initPatchTop,
+                           initPatchBottom);
+
+const gridPatch = new bbox(0, (L+1), 0, (L+1));
+
+record particle {
+  var x: real;
+  var y: real;
+  var v_x: real;
+  var v_y: real;
+  var q: real;
+
+  var x0: real;
+  var y0: real;
+
+  var k: int;
+  var m: int;
+}
+
+writeln("Parallel Research Kernels Version ", PRKVERSION);
+writeln("Chapel Particle-in-Cell execution on 2D grid");
+writeln("Max parallelism                = ", here.maxTaskPar);
+writeln("Grid Size                      = ", L);
+writeln("Number of particles requested  = ", n);
+writeln("Number of time steps           = ", iterations);
+writeln("Initialization mode            = ", particleMode);
+select particleMode {
+  when "GEOMETRIC" do
+    writeln("\tAttenuation factor           = ", rho);
+  when "LINEAR" {
+    writeln("\tNegative Slope               = ", alpha);
+    writeln("\tOffset                       = ", beta);
+  }
+  when "PATCH" {
+    writeln("\tBounding box                 = ", (patch.left,
+                                                  patch.right,
+                                                  patch.top,
+                                                  patch.bottom));
+  }
+}
+writeln("Particle charge semi-increment = ", k);
+writeln("Vertical velocity              = ", m);
+
+var Qgrid = initializeGrid(L);
+
+var particleDom = {1..0};
+var particles: [particleDom] particle;
+
+select particleMode {
+  when "GEOMETRIC" do initializeGeometric();
+  when "SINUSOIDAL" do initializeSinusoidal();
+  when "LINEAR" do initializeLinear();
+  when "PATCH" do initializePatch();
+  otherwise do halt("Unknown particle mode: ", particleMode);
+}
+
+finishDistribution();
+
+writeln("Number of particles placed : ", particles.size);
+
+var t = new Timer();
+
+for niter in 0..iterations {
+
+  if niter == 1 then t.start();
+
+  forall i in 0..#n {
+
+    const (fx, fy) = computeTotalForce(particles[i]);
+    if debug then writeln("Force acting on particle " , i, " ", (fx,fy));
+    const ax = fx * MASS_INV;
+    const ay = fy * MASS_INV;
+
+    if debug then write("Particle ", i, " moved from ",
+        (particles[i].x,particles[i].y));
+
+    particles[i].x = mod(particles[i].x + particles[i].v_x*DT +
+        0.5*ax*DT*DT + L, L);
+    particles[i].y = mod(particles[i].y + particles[i].v_y*DT +
+        0.5*ay*DT*DT + L, L);
+
+    if debug then writeln(" to ", (particles[i].x,particles[i].y));
+
+    particles[i].v_x += ax * DT;
+    particles[i].v_y += ay * DT;
+  }
+}
+t.stop();
+
+
+for i in 0..#n {
+  if !verifyParticle(particles[i]) then
+    halt("Verification failed");
+}
+
+writeln("Verification succesful");
+
+const avgTime = t.elapsed()/iterations;
+writeln("Rate (Mparticles_moved/s): ", 1.0e-6*(n/avgTime));
+
+proc initializeGrid(L) {
+  const gridDom = {0..#(L+1), 0..#(L+1)};
+  var grid: [gridDom] real;
+
+  for (x,y) in grid.domain {
+    grid[y,x] = if x%2==0 then Q else -Q;
+  }
+  return grid;
+}
+
+proc initializeGeometric() {
+
+  const A = n * ((1.0-rho) / (1.0-(rho**L))) / L:real;
+  LCG_init();
+
+
+  var nPlaced = 0;
+  for (x,y) in {0..#L, 0..#L} do
+    nPlaced += random_draw(getSeed(x)):int;
+
+  particleDom = {0..#nPlaced};
+
+  LCG_init();
+
+  var pIdx = 0;
+  for (x,y) in {0..#L, 0..#L} {
+    // TODO without cast this creates a seg fault and overflow
+    // warning with no --fast. Investigate for possible bug. Engin
+    const actual_particles = random_draw(getSeed(x)):int;
+    placeParticles(pIdx, actual_particles, x, y);
+  }
+
+  inline proc getSeed(x) {
+    return A * (rho**x);
+  }
+}
+
+proc initializeSinusoidal() {
+
+  const step = pi/L;
+
+  LCG_init();
+
+  var nPlaced = 0;
+
+  for (x,y) in {0..#L, 0..#L} do
+    nPlaced += random_draw(getSeed(x)):int;
+
+  particleDom = {0..#nPlaced};
+
+  LCG_init();
+
+  // pIdx = pi in OpenMP code
+  var pIdx = 0;
+  for (x,y) in {0..#L, 0..#L} {
+    // TODO without cast this creates a seg fault and overflow
+    // warning with no --fast. Investigate for possible bug. Engin
+    const actual_particles = random_draw(getSeed(x)):int;
+    placeParticles(pIdx, actual_particles, x, y);
+  }
+
+  inline proc getSeed(x) {
+    return 2.0*(cos(x*step)**2)*n/(L**2);
+  }
+}
+
+proc initializeLinear() {
+
+  const step = 1.0/L;
+  const total_weight = beta*L-alpha*0.5*step*L*(L-1);
+
+  var nPlaced = 0;
+
+  LCG_init();
+
+  for (x,y) in {0..#L, 0..#L} do
+    nPlaced += random_draw(getSeed(x)):int;
+
+  particleDom = {0..#nPlaced};
+
+  LCG_init();
+
+  var pIdx = 0;
+  for (x,y) in {0..#L, 0..#L} {
+    // TODO without cast this creates a seg fault and overflow
+    // warning with no --fast. Investigate for possible bug. Engin
+    const actual_particles = random_draw(getSeed(x)):int;
+    placeParticles(pIdx, actual_particles, x, y);
+  }
+
+  inline proc getSeed(x) {
+    return n * ((beta - alpha * step * x:real)/total_weight)/L;
+  }
+}
+
+proc initializePatch() {
+
+  if badPatch(patch, gridPatch) then
+    halt("Bad patch given");
+
+  const total_cells  = (patch.right - patch.left+1)*(patch.top -
+      patch.bottom+1);
+  const particles_per_cell = (n/total_cells):real;
+
+  var nPlaced = 0;
+  LCG_init();
+
+  for (x,y) in {0..#L, 0..#L} {
+    const actual_particles = random_draw(particles_per_cell):int;
+    if !outsidePatch(x, y) then
+      nPlaced += actual_particles;
+  }
+
+  particleDom = {0..#nPlaced};
+
+  LCG_init();
+
+  var pIdx = 0;
+  for (x,y) in {0..#L, 0..#L} {
+    // TODO without cast this creates a seg fault and overflow
+    // warning with no --fast. Investigate for possible bug. Engin
+    const actual_particles = random_draw(particles_per_cell):int;
+    if !outsidePatch(x, y) {
+      placeParticles(pIdx, actual_particles, x, y);
+    }
+  }
+
+  inline proc outsidePatch(x, y) {
+    return x<patch.left   || x>patch.right ||
+            y<patch.bottom || y>patch.top;
+  }
+
+  proc badPatch(patch, patch_contain) {
+    if patch.left>=patch.right || patch.bottom>=patch.top then
+      return true;
+    if patch.left  <patch_contain.left   ||
+      patch.right>patch_contain.right then
+        return true;
+    if patch.bottom<patch_contain.bottom ||
+      patch.top > patch_contain.top then
+        return true;
+    return false;
+  }
+}
+
+proc finishDistribution() {
+  for p in particles {
+    var x_coord = p.x;
+    var y_coord = p.y;
+    var rel_x = mod(x_coord, 1.0);
+    var rel_y = mod(y_coord, 1.0);
+
+    var x = x_coord:uint;
+    var r1_sq = rel_y * rel_y + rel_x * rel_x;
+    var r2_sq = rel_y * rel_y + (1.0-rel_x) * (1.0-rel_x);
+    var cos_theta = rel_x/sqrt(r1_sq);
+    var cos_phi = (1.0-rel_x)/sqrt(r2_sq);
+    var base_charge = 1.0 / ((DT*DT) * Q * (cos_theta/r1_sq +
+          cos_phi/r2_sq));
+
+    p.v_x = 0.0;
+    p.v_y = p.m/DT;
+
+    p.q = if (x%2 == 0) then (2*p.k+1) * base_charge
+      else -1.0 * (2*p.k+1) * base_charge ;
+    p.x0 = x_coord;
+    p.y0 = y_coord;
+  }
+}
+
+inline proc computeCoulomb(x_dist, y_dist, q1, q2) {
+
+  const r2 = x_dist**2 + y_dist**2;
+  const r = sqrt(r2);
+  const f_coulomb = q1*q2/r2;
+
+  const fx = f_coulomb * x_dist/r;
+  const fy = f_coulomb * y_dist/r;
+
+  return (fx, fy);
+}
+
+proc computeTotalForce(p) {
+
+  const x = floor(p.x):int;
+  const y = floor(p.y):int;
+
+  const rel_x = p.x-x;
+  const rel_y = p.y-y;
+
+  var tmp_fx = 0.0;
+  var tmp_fy = 0.0;
+
+  (tmp_fx, tmp_fy) = computeCoulomb(rel_x, rel_y, p.q, Qgrid[y,x]);
+  var tmp_res_x = tmp_fx;
+  var tmp_res_y = tmp_fy;
+
+  (tmp_fx, tmp_fy) = computeCoulomb(rel_x, 1.0-rel_y, p.q, Qgrid[y+1,x]);
+  tmp_res_x += tmp_fx;
+  tmp_res_y -= tmp_fy;
+
+  (tmp_fx, tmp_fy) = computeCoulomb(1.0-rel_x, rel_y, p.q, Qgrid[y,x+1]);
+  tmp_res_x -= tmp_fx;
+  tmp_res_y += tmp_fy;
+
+  (tmp_fx, tmp_fy) = computeCoulomb(1.0-rel_x, 1.0-rel_y, p.q, Qgrid[y+1,x+1]);
+  tmp_res_x -= tmp_fx;
+  tmp_res_y -= tmp_fy;
+
+  if debug then writeln("Total force on particle : ", (tmp_res_x,
+        tmp_res_y));
+
+  return (tmp_res_x, tmp_res_y);
+}
+
+proc verifyParticle(p) {
+
+  const y = p.y0:int;
+  const x = p.x0:int;
+
+  const disp = (iterations+1):real*(2*p.k+1);
+  const x_final = if (p.q * Qgrid[y,x])>0 then p.x0+disp else p.x0-disp;
+  const y_final = p.y0 + p.m * (iterations+1):real;
+
+  const x_periodic = mod(x_final+(iterations+1):real *(2*p.k+1)*L, L);
+  const y_periodic = mod(y_final+(iterations+1):real *abs(p.m)*L, L);
+
+  if ( abs(p.x - x_periodic) > epsilon || abs(p.y - y_periodic) > epsilon) {
+    writeln("Verification for particle failed");
+    writeln(p.x, " ", x_periodic);
+    writeln(p.y, " ", y_periodic);
+    return false;
+  }
+  return true;
+}
+
+inline proc placeParticles(ref pIdx, n, x, y) {
+  for p in 0..#n {
+    particles[pIdx].x = x + REL_X;
+    particles[pIdx].y = y + REL_Y;
+    particles[pIdx].k = k;
+    particles[pIdx].m = m;
+    pIdx += 1;
+  }
+}

--- a/test/studies/prk/PIC/pic.chpl
+++ b/test/studies/prk/PIC/pic.chpl
@@ -116,20 +116,23 @@ for niter in 0..iterations {
 
   forall i in 0..#particles.size {
 
-    const (fx, fy) = computeTotalForce(particles[i]);
-    if debug then writeln("Force acting on particle " , i, " ", (fx,fy));
-    const ax = fx * MASS_INV;
-    const ay = fy * MASS_INV;
+    var x0:real, y0:real; // for debug mode
 
-    if debug then write("Particle ", i, " moved from ",
-        (particles[i].x,particles[i].y));
+    const (fx, fy) = computeTotalForce(particles[i]);
+    const (ax, ay) = (fx * MASS_INV, fy * MASS_INV);
+
+    if debug then
+      (x0,y0) = (particles[i].x, particles[i].y);
 
     particles[i].x = mod(particles[i].x + particles[i].v_x*DT +
-        0.5*ax*DT*DT + L, L);
+                         0.5*ax*DT*DT + L, L);
     particles[i].y = mod(particles[i].y + particles[i].v_y*DT +
-        0.5*ay*DT*DT + L, L);
+                         0.5*ay*DT*DT + L, L);
 
-    if debug then writeln(" to ", (particles[i].x,particles[i].y));
+    if debug then
+      writeln("Force acting on particle " , i, " ", (fx,fy),
+              "\n\tParticle moved from ", (x0,y0), " to ",
+                                    (particles[i].x,particles[i].y));
 
     particles[i].v_x += ax * DT;
     particles[i].v_y += ay * DT;
@@ -337,24 +340,21 @@ proc computeTotalForce(p) {
   var tmp_fx = 0.0;
   var tmp_fy = 0.0;
 
-  (tmp_fx, tmp_fy) = computeCoulomb(rel_x, rel_y, p.q, Qgrid[y,x]);
+  (tmp_fx, tmp_fy) = computeCoulomb(    rel_x,    rel_y, p.q, Qgrid[y  ,x  ]);
   var tmp_res_x = tmp_fx;
   var tmp_res_y = tmp_fy;
 
-  (tmp_fx, tmp_fy) = computeCoulomb(rel_x, 1.0-rel_y, p.q, Qgrid[y+1,x]);
+  (tmp_fx, tmp_fy) = computeCoulomb(    rel_x,1.0-rel_y, p.q, Qgrid[y+1,x  ]);
   tmp_res_x += tmp_fx;
   tmp_res_y -= tmp_fy;
 
-  (tmp_fx, tmp_fy) = computeCoulomb(1.0-rel_x, rel_y, p.q, Qgrid[y,x+1]);
+  (tmp_fx, tmp_fy) = computeCoulomb(1.0-rel_x,    rel_y, p.q, Qgrid[y  ,x+1]);
   tmp_res_x -= tmp_fx;
   tmp_res_y += tmp_fy;
 
-  (tmp_fx, tmp_fy) = computeCoulomb(1.0-rel_x, 1.0-rel_y, p.q, Qgrid[y+1,x+1]);
+  (tmp_fx, tmp_fy) = computeCoulomb(1.0-rel_x,1.0-rel_y, p.q, Qgrid[y+1,x+1]);
   tmp_res_x -= tmp_fx;
   tmp_res_y -= tmp_fy;
-
-  if debug then writeln("Total force on particle : ", (tmp_res_x,
-        tmp_res_y));
 
   return (tmp_res_x, tmp_res_y);
 }

--- a/test/studies/prk/PIC/pic.chpl
+++ b/test/studies/prk/PIC/pic.chpl
@@ -162,13 +162,13 @@ proc initializeGrid(L) {
 
 proc initializeGeometric() {
 
-  const A = n * ((1.0-rho) / (1.0-(rho**L))) / L:real;
+  const A = n * ((1.0-rho) / (1.0-(rho**L))) / L;
   LCG_init();
 
 
-  var nPlaced = 0;
+  var nPlaced = 0:uint;
   for (x,y) in {0..#L, 0..#L} do
-    nPlaced += random_draw(getSeed(x)):int;
+    nPlaced += random_draw(getSeed(x));
 
   particleDom = {0..#nPlaced};
 
@@ -178,7 +178,7 @@ proc initializeGeometric() {
   for (x,y) in {0..#L, 0..#L} {
     // TODO without cast this creates a seg fault and overflow
     // warning with no --fast. Investigate for possible bug. Engin
-    const actual_particles = random_draw(getSeed(x)):int;
+    const actual_particles = random_draw(getSeed(x));
     placeParticles(pIdx, actual_particles, x, y);
   }
 
@@ -193,10 +193,10 @@ proc initializeSinusoidal() {
 
   LCG_init();
 
-  var nPlaced = 0;
+  var nPlaced = 0:uint;
 
   for (x,y) in {0..#L, 0..#L} do
-    nPlaced += random_draw(getSeed(x)):int;
+    nPlaced += random_draw(getSeed(x));
 
   particleDom = {0..#nPlaced};
 
@@ -207,7 +207,7 @@ proc initializeSinusoidal() {
   for (x,y) in {0..#L, 0..#L} {
     // TODO without cast this creates a seg fault and overflow
     // warning with no --fast. Investigate for possible bug. Engin
-    const actual_particles = random_draw(getSeed(x)):int;
+    const actual_particles = random_draw(getSeed(x));
     placeParticles(pIdx, actual_particles, x, y);
   }
 
@@ -221,12 +221,12 @@ proc initializeLinear() {
   const step = 1.0/L;
   const total_weight = beta*L-alpha*0.5*step*L*(L-1);
 
-  var nPlaced = 0;
+  var nPlaced = 0:uint; // random_draw is a uint proc
 
   LCG_init();
 
   for (x,y) in {0..#L, 0..#L} do
-    nPlaced += random_draw(getSeed(x)):int;
+    nPlaced += random_draw(getSeed(x));
 
   particleDom = {0..#nPlaced};
 
@@ -236,7 +236,7 @@ proc initializeLinear() {
   for (x,y) in {0..#L, 0..#L} {
     // TODO without cast this creates a seg fault and overflow
     // warning with no --fast. Investigate for possible bug. Engin
-    const actual_particles = random_draw(getSeed(x)):int;
+    const actual_particles = random_draw(getSeed(x));
     placeParticles(pIdx, actual_particles, x, y);
   }
 
@@ -254,11 +254,11 @@ proc initializePatch() {
       patch.bottom+1);
   const particles_per_cell = (n/total_cells):real;
 
-  var nPlaced = 0;
+  var nPlaced = 0:uint;
   LCG_init();
 
   for (x,y) in {0..#L, 0..#L} {
-    const actual_particles = random_draw(particles_per_cell):int;
+    const actual_particles = random_draw(particles_per_cell);
     if !outsidePatch(x, y) then
       nPlaced += actual_particles;
   }
@@ -271,7 +271,7 @@ proc initializePatch() {
   for (x,y) in {0..#L, 0..#L} {
     // TODO without cast this creates a seg fault and overflow
     // warning with no --fast. Investigate for possible bug. Engin
-    const actual_particles = random_draw(particles_per_cell):int;
+    const actual_particles = random_draw(particles_per_cell);
     if !outsidePatch(x, y) {
       placeParticles(pIdx, actual_particles, x, y);
     }
@@ -387,7 +387,7 @@ proc verifyParticle(p) {
 }
 
 inline proc placeParticles(ref pIdx, n, x, y) {
-  for p in 0..#n {
+  for p in 0..#(n:int) {
     particles[pIdx].x = x + REL_X;
     particles[pIdx].y = y + REL_Y;
     particles[pIdx].k = k;

--- a/test/studies/prk/PIC/pic.execopts
+++ b/test/studies/prk/PIC/pic.execopts
@@ -1,0 +1,4 @@
+--correctness --L=100 --n=1000 --particleMode=SINUSOIDAL
+--correctness --L=100 --n=1000 --particleMode=GEOMETRIC
+--correctness --L=100 --n=1000 --particleMode=LINEAR
+--correctness --L=100 --n=1000 --particleMode=PATCH

--- a/test/studies/prk/PIC/pic.good
+++ b/test/studies/prk/PIC/pic.good
@@ -1,0 +1,1 @@
+Verification successful

--- a/test/studies/prk/PIC/pic.good
+++ b/test/studies/prk/PIC/pic.good
@@ -1,1 +1,1 @@
-Verification successful
+Validation successful

--- a/test/studies/prk/PIC/random_draw.c
+++ b/test/studies/prk/PIC/random_draw.c
@@ -1,0 +1,193 @@
+/*
+Copyright (c) 2015, Intel Corporation
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions 
+are met:
+
+* Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above 
+      copyright notice, this list of conditions and the following 
+      disclaimer in the documentation and/or other materials provided 
+      with the distribution.
+* Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products 
+      derived from this software without specific prior written 
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**********************************************************************
+
+Name:      LCG
+
+Purpose:   Provide a mixed Linear Congruential Generator of pseudo-random
+           numbers with a period of 2^64, plus tools to jump ahead in a sequence
+           of such generated numbers. For details, see individual functions.
+
+Functions: LCG_next:      a new pseudo-randon number
+           LCG_get_chunk: return subset of an interval of natural numbers
+           LCG_init:      initialize the generator
+           LCG_jump:      jump ahead into a sequence of pseudo-random numbers
+           random_draw:
+
+Notes:     LCG_init must be called by each thread or rank before any jump 
+           into a sequence of pseudo-random numbers is made
+
+History:   Written by Rob Van der Wijngaart, December 2015
+
+**********************************************************************/
+
+/*#include <par-res-kern_general.h>*/
+#include <math.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <limits.h>
+
+#include "random_draw.h"
+
+#define NMAX 64
+
+static uint64_t  LCG_a = 6364136223846793005;
+static uint64_t  LCG_c = 1442695040888963407;
+static uint64_t  LCG_seed_init = 27182818285; //used to (re)set seed 
+static uint64_t  LCG_seed      = 27182818285;
+static uint64_t  LCG_A[NMAX];
+#ifdef __OPENMP
+#pragma omp threadprivate (LCG_a, LCG_c, LCG_seed, LCG_A)
+#endif
+  
+/* for a range of 0 to size-i, find chunk assigned to calling thread */
+void LCG_get_chunk(uint64_t *start, uint64_t *end, int tid, int nthreads, uint64_t size) {
+    uint64_t chunk, remainder;
+    chunk = size/nthreads;
+    remainder = size - chunk*nthreads;
+ 
+    if ((uint64_t)tid < remainder) {
+      *start = tid*(chunk+1);
+      *end   = *start + chunk;
+    }
+    else {
+      *start = remainder*(chunk+1) + (tid-remainder)*chunk;
+      *end   = *start + chunk -1;
+    }
+    return;
+}
+ 
+ 
+static uint64_t tail(uint64_t x) {
+  uint64_t x2 = x;
+  if (!x) return x;
+  uint64_t result = 1;
+  while (x>>=1) result <<=1;
+  return (x2 - result);
+}  
+ 
+/* Sum(i=1,2^k) a^i */
+static uint64_t SUMPOWER(int k) {
+  if (!k) return LCG_a;
+  return SUMPOWER(k-1)*(1+LCG_A[k-1]);
+}
+ 
+static int LOG(uint64_t n) {
+  int result = 0;
+  while (n>>=1) result++;
+  return(result);
+}
+ 
+/* Sum(i=1,n) a^i, with n arbitrary */
+static uint64_t SUMK(uint64_t n) {
+  if (n==0) return(0);
+  uint64_t HEAD = SUMPOWER(LOG(n));
+  uint64_t TAILn = tail(n);
+  if (TAILn==0) return(HEAD);
+  return(HEAD + (LCG_A[LOG(n)])*SUMK(TAILn));
+}
+ 
+uint64_t LCG_next(uint64_t bound) {
+  LCG_seed = LCG_a*LCG_seed + LCG_c;
+  return (LCG_seed%bound);
+}
+ 
+void LCG_init(void){
+ 
+  int i;
+ 
+  LCG_seed = LCG_seed_init;
+  LCG_A[0] = LCG_a;
+  for (i=1; i<NMAX; i++) {
+    LCG_A[i] = LCG_A[i-1]*LCG_A[i-1];
+  }
+  return;
+}
+ 
+  void LCG_jump(uint64_t m, uint64_t bound){
+ 
+  int i, index, LCG_power[NMAX];
+  uint64_t mm, s_part;
+
+  for (i=0; i<NMAX; i++) LCG_power[i] = 0; 
+  LCG_seed = LCG_seed_init;
+  
+  /* Catch two special cases */
+  switch (m) {
+  case 0: return;
+  case 1: LCG_next(bound); return;
+  }
+ 
+  mm = m;
+  index = 0;
+  while (mm) {
+    LCG_power[index++] = mm&1;
+    mm >>=1;
+  }
+ 
+  s_part = 1;
+  for (i=0; i<index; i++) if (LCG_power[i]) s_part *= LCG_A[i];
+  LCG_seed = s_part*LCG_seed + (SUMK(m-1)+1)*LCG_c;
+  return;
+}
+
+uint64_t random_draw(double mu)
+{
+  const double   two_pi      = 2.0*3.14159265358979323846;
+  const uint64_t rand_max    = ULLONG_MAX;
+  const double   rand_div    = 1.0/ULLONG_MAX;
+  const uint64_t denominator = UINT_MAX;
+
+  static double   z0, z1;
+  double          u0, u1, sigma;
+  static uint64_t numerator;
+  static uint64_t i0, i1;
+
+  if (mu>=1.0) {
+    sigma = mu*0.15;  
+    u0 = LCG_next(rand_max) * rand_div;
+    u1 = LCG_next(rand_max) * rand_div;
+
+    z0 = sqrt(-2.0 * log(u0)) * cos(two_pi * u1);
+    z1 = sqrt(-2.0 * log(u0)) * sin(two_pi * u1);
+    return (uint64_t) (z0 * sigma + mu+0.5);
+  }
+  else {
+    /* we need to pick two integers whose quotient approximates mu; set one to UINT_MAX */
+    numerator = (uint32_t) (mu*(double)denominator);
+    i0 = LCG_next(denominator); /* don't use this value, but must call LCG_next twice   */
+    i1 = LCG_next(denominator);
+    return ((uint64_t)(i1<=numerator));
+  }
+
+}

--- a/test/studies/prk/PIC/random_draw.c
+++ b/test/studies/prk/PIC/random_draw.c
@@ -90,8 +90,8 @@ void LCG_get_chunk(uint64_t *start, uint64_t *end, int tid, int nthreads, uint64
  
 static uint64_t tail(uint64_t x) {
   uint64_t x2 = x;
-  if (!x) return x;
   uint64_t result = 1;
+  if (!x) return x;
   while (x>>=1) result <<=1;
   return (x2 - result);
 }  
@@ -110,9 +110,11 @@ static int LOG(uint64_t n) {
  
 /* Sum(i=1,n) a^i, with n arbitrary */
 static uint64_t SUMK(uint64_t n) {
+  uint64_t HEAD;
+  uint64_t TAILn;
   if (n==0) return(0);
-  uint64_t HEAD = SUMPOWER(LOG(n));
-  uint64_t TAILn = tail(n);
+  HEAD = SUMPOWER(LOG(n));
+  TAILn = tail(n);
   if (TAILn==0) return(HEAD);
   return(HEAD + (LCG_A[LOG(n)])*SUMK(TAILn));
 }

--- a/test/studies/prk/PIC/random_draw.h
+++ b/test/studies/prk/PIC/random_draw.h
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2015, Intel Corporation
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions 
+are met:
+
+* Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above 
+      copyright notice, this list of conditions and the following 
+      disclaimer in the documentation and/or other materials provided 
+      with the distribution.
+* Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products 
+      derived from this software without specific prior written 
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef RANDOM_DRAW_H
+#define RANDOM_DRAW_H
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <math.h>
+ 
+extern void     LCG_init(void);
+extern uint64_t LCG_next(uint64_t);
+extern void     LCG_get_chunk(uint64_t *, uint64_t *, int, int, uint64_t);
+extern void     LCG_jump(uint64_t, uint64_t);
+extern uint64_t random_draw(double);
+
+#endif

--- a/test/studies/prk/Sparse/sparse.chpl
+++ b/test/studies/prk/Sparse/sparse.chpl
@@ -1,0 +1,132 @@
+use BlockDist;
+use Time;
+use LayoutCSR;
+
+param PRKVERSION = "2.17";
+
+config param rowDistributeMatrix = false;
+
+config const lsize = 5,
+             radius = 2,
+             iterations = 10,
+             correctness = false,
+             scramble = true;
+
+const lsize2 = 2*lsize;
+const size = 1<<lsize;
+const size2 = size*size;
+const stencilSize = 4*radius+1;
+const sparsity = stencilSize:real/size2;
+
+// create vector domain
+const vectorSpace = {0..#size2};
+var vectorDom = vectorSpace dmapped Block(vectorSpace);
+
+// create matrix domain
+var rowDistLocDom = {0..#numLocales, 0..0};
+var rowDistLocArr: [rowDistLocDom] locale;
+rowDistLocArr[0..#numLocales, 0] = Locales[0..#numLocales];
+
+const parentDom = {0..#size2, 0..#size2};
+var matrixDenseDom = parentDom dmapped Block(parentDom,
+                              targetLocales=if rowDistributeMatrix then
+                              rowDistLocArr else Locales,
+                              sparseLayoutType=CSR);
+
+var matrixDom: sparse subdomain(matrixDenseDom);
+
+// temporary index buffer for fast initialization
+const indBufDom = {0..#(size2*stencilSize)};
+var indBuf: [indBufDom] 2*int;
+
+//initialize sparse domain
+for row in 0..#size2 {
+  const i = row%size;
+  const j = row/size;
+
+  var bufIdx = row*stencilSize;
+
+  indBuf[bufIdx] = (row, reverse(LIN(i,j)));
+  for r in 1..radius {
+    indBuf[bufIdx+1] = (row, reverse(LIN((i+r)%size,j)));
+    indBuf[bufIdx+2] = (row, reverse(LIN((i-r+size)%size,j)));
+    indBuf[bufIdx+3] = (row, reverse(LIN(i, (j+r)%size)));
+    indBuf[bufIdx+4] = (row, reverse(LIN(i, (j-r+size)%size)));
+    bufIdx += 4;
+  }
+}
+matrixDom.bulkAdd(indBuf, preserveInds=false);
+
+//do a sanitiy check to make sure we have created correct numver of
+//indicese in the sparse domain
+if matrixDom.numIndices != size2*stencilSize then
+  halt("Incorrect number of indices created");
+
+var matrix: [matrixDom] real;
+[(i,j) in matrixDom] matrix[i,j] = 1.0/(j+1);
+
+var vector: [vectorDom] real;
+var result: [vectorDom] real;
+vector = 0;
+result = 0;
+
+if !correctness {
+  // Print information before main loop
+  writeln("Parallel Research Kernels Version ", PRKVERSION);
+  writeln("Sparse matrix-dense vector multiplication");
+  writeln("Max parallelism      = ", here.maxTaskPar);
+  writeln("Row distribution     = ", rowDistributeMatrix);
+  writeln("Matrix order         = ", size2);
+  writeln("Stencil diameter     = ", 2*radius+1);
+  writeln("Sparsity             = ", sparsity);
+  writeln("Number of iterations = ", iterations);
+  writeln("Indexes are ", if !scramble then "not " else "", "scrambled");
+}
+
+var t = new Timer();
+for niter in 0..iterations {
+
+  if niter == 1 then t.start();
+  [i in vectorDom] vector[i] += i+1;
+
+  forall i in matrix.domain.dim(1) do
+    for j in matrix.domain.dim(2) do
+    result[i] += matrix[i,j] * vector[j];
+}
+t.stop();
+
+// verify the result
+const epsilon = 1e-8;
+const referenceSum = 0.5 * matrixDom.numIndices * (iterations+1) *
+    (iterations+2);
+const vectorSum = + reduce result;
+if abs(vectorSum-referenceSum) > epsilon then
+  halt("Validation failed. Reference sum = ", referenceSum,
+      " Vector sum = ", vectorSum);
+
+writeln("Validation successful");
+
+if !correctness {
+  const nflop = 2.0*matrixDom.numIndices;
+  const avgTime = t.elapsed()/iterations;
+  writeln("Rate (MFlops/s): ", 1e-6*nflop/avgTime, " Avg time (s): ",
+      avgTime);
+}
+
+inline proc LIN(i, j) {
+  return (i+(j<<lsize));
+}
+
+proc reverse(xx) {
+  if !scramble then return xx;
+
+  var x = xx:uint;
+
+  x = ((x >> 1)  & 0x5555555555555555) | ((x << 1)  & 0xaaaaaaaaaaaaaaaa);
+  x = ((x >> 2)  & 0x3333333333333333) | ((x << 2)  & 0xcccccccccccccccc);
+  x = ((x >> 4)  & 0x0f0f0f0f0f0f0f0f) | ((x << 4)  & 0xf0f0f0f0f0f0f0f0);
+  x = ((x >> 8)  & 0x00ff00ff00ff00ff) | ((x << 8)  & 0xff00ff00ff00ff00);
+  x = ((x >> 16) & 0x0000ffff0000ffff) | ((x << 16) & 0xffff0000ffff0000);
+  x = ((x >> 32) & 0x00000000ffffffff) | ((x << 32) & 0xffffffff00000000);
+  return (x>>(64-lsize2)):int;
+}

--- a/test/studies/prk/Sparse/sparse.chpl
+++ b/test/studies/prk/Sparse/sparse.chpl
@@ -101,7 +101,7 @@ const referenceSum = 0.5 * matrixDom.numIndices * (iterations+1) *
     (iterations+2);
 const vectorSum = + reduce result;
 if abs(vectorSum-referenceSum) > epsilon then
-  halt("Validation failed. Reference sum = ", referenceSum,
+  halt("VALIDATION FAILED!. Reference sum = ", referenceSum,
       " Vector sum = ", vectorSum);
 
 writeln("Validation successful");

--- a/test/studies/prk/Sparse/sparse.execopts
+++ b/test/studies/prk/Sparse/sparse.execopts
@@ -1,0 +1,1 @@
+--correctness --iterations=2 --lsize=3

--- a/test/studies/prk/Sparse/sparse.good
+++ b/test/studies/prk/Sparse/sparse.good
@@ -1,0 +1,1 @@
+Validation successful


### PR DESCRIPTION
Adds four new PRKs(the Parellel Research Kernels): DGEMM, Nstream,
PIC and Sparse

Issue #6162 has overall notes for improving PRKs. Some applies to the
PRKs in this PR, as well. Also, #6152 and #6153 updated the existing
Transpose and Stencil implementations recently.

Open questions / random notes:
- All but PIC are naively distributed. (There is no optimization
  whatsover) Should we keep it that way? Or not create distributed
  versions without properly optimizing them? PIC is not distributed at
  all.
- PIC code style needs a revision. I translated it from OpenMP version,
  trying to do things the Chapel way as much as I can. But variable
  names are almost identical to OpenMP variables. I think that's not the
  convention that Chapel community is adopting, so those should be
  changed to camel case where appropriate. (Possibly in a cleanup PR)
- PIC uses random_draw.c from the PRK repo almost as-is. I needed to
  make small adjustments so that variables are always declared in the
  beginning of blocks. It would be cool to have it implemented in
  Chapel, as well.  But I'd say it is very low priority at this point.
- DGEMM: I used unbounded ranges in deeply nested loops. I wonder if it
  has any performance problems compared to bounded ranges?
- DGEMM: In the CHIUW paper this version performed ~60% of OpenMP. But
  using C arrays for tile arrays makes Chapel performance almost
  identical to OpenMP. I wonder if that implementation of DGEMM would be
  frowned upon.
- On a similar note, should we have different flavors of PRKs? Such as
  coforall based Nstream.

Testing:
This PR only adds new tests to studies/prk. Said folder is locally
tested with standard linux64 and standard GASNet configs

Todo:
- [x] Cosmetic changes/more Chapel-ification in PIC
- [x] Investigate a TODO comment regarding unexpected behavior in PIC
