### PR TITLE
Extend c2chapel with our own fake defines/typedefs

### DIFF
--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -51,7 +51,7 @@ c2chapel:
 	wget $(RELEASE) -O $(TAR) && \
 	tar xzf $(TAR) -C $(FAKES) --strip 3 pycparser-release_v$(VERSION)/utils/fake_libc_include
 
-	./utils/fixFakes.sh $(FAKES) ./utils/custom.h
+	./utils/fixFakes.sh $(FAKES) $(PWD)/utils/custom.h
 
 	virtualenv $(VENV)
 	. $(VENV)/bin/activate && \

--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -35,9 +35,9 @@ TAR=release_v$(VERSION).tar.gz
 
 RELEASE=https://github.com/eliben/pycparser/archive/$(TAR)
 
-INSTALL=./install
+INSTALL=$(realpath .)/install
 VENV=$(INSTALL)/venv
-UTILS=$(INSTALL)/utils
+FAKES=$(INSTALL)/fakeHeaders
 
 .PHONY: clean clobber c2chapel install
 
@@ -45,11 +45,13 @@ all: c2chapel
 
 c2chapel:
 	mkdir -p $(VENV)
-	mkdir -p $(UTILS)
+	mkdir -p $(FAKES)
 	cd $(INSTALL) && \
 	echo "Fetching release $(VERSION) tarball..." && \
 	wget $(RELEASE) -O $(TAR) && \
-	tar xzf $(TAR) -C utils --strip 2 pycparser-release_v$(VERSION)/utils/
+	tar xzf $(TAR) -C $(FAKES) --strip 3 pycparser-release_v$(VERSION)/utils/fake_libc_include
+
+	./utils/fixFakes.sh $(FAKES) ./utils/custom.h
 
 	virtualenv $(VENV)
 	. $(VENV)/bin/activate && \

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -401,7 +401,7 @@ def getFakeHeaderPath():
     ret    = ""
     if os.path.isfile(script):
         parent = os.path.dirname(script)
-        fakes = parent + "/install/utils/fake_libc_include/"
+        fakes = parent + "/install/fakeHeaders/"
         if os.path.isdir(fakes):
             ret = fakes
 

--- a/tools/c2chapel/utils/custom.h
+++ b/tools/c2chapel/utils/custom.h
@@ -1,0 +1,9 @@
+#ifndef _C2CHAPEL_CUSTOM_H_
+#define _C2CHAPEL_CUSTOM_H_
+
+#define __attribute__(x)
+#define __extension__(x)
+
+/* Add your own definitions below! */
+
+#endif

--- a/tools/c2chapel/utils/fixFakes.sh
+++ b/tools/c2chapel/utils/fixFakes.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 fakesDir=$1
-header=$(realpath $2)
+header=$2
 
 linkName="_c2chapel_custom.h"
 linkPath=${fakesDir}/${linkName}

--- a/tools/c2chapel/utils/fixFakes.sh
+++ b/tools/c2chapel/utils/fixFakes.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+fakesDir=$1
+header=$(realpath $2)
+
+linkName="_c2chapel_custom.h"
+linkPath=${fakesDir}/${linkName}
+
+if [ -d ${fakesDir} -a -f ${header} ]; then
+  echo "Fixing fake headers..."
+
+  # Use system limits.h
+  rm ${fakesDir}/limits.h
+
+  # include our custom header in every default fake header
+  for f in `find ${fakesDir} -iname "*.h"` ; do
+    echo "#include \"${linkName}\"" >> $f
+  done
+
+  if [ -f ${linkPath} ]; then
+    rm ${linkPath}
+  fi
+  ln -s ${header} ${linkPath}
+
+else
+  echo "FAILURE: Invalid arguments: ${fakesDir} ${header}"
+  exit 1
+fi


### PR DESCRIPTION
Users can add to the new utils/custom.h file to resolve parsing issues. Also removes fake limits.h header so that we rely on the system header.