### PR TITLE
Trivial change to get --llvm working again

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2136,8 +2136,8 @@ GenInfo::GenInfo(
            targetLayout(), globalToWideInfo(),
            FPM_postgen(NULL)
 {
-  std::string rtetc(CHPL_RUNTIME_ETC);
-  std::string rtmain = rtetc + "/rtmain.c";
+  std::string home(CHPL_HOME);
+  std::string rtmain = home + "/runtime/etc/rtmain.c";
 
   setupClang(this, rtmain);
 


### PR DESCRIPTION
PR #6036 made a change co codegen.cpp that no longer makes sense (it was based upon an earlier version of that PR). This commit simply puts it back the way it was.

- [x] compiler now builds with CHPL_LLVM=llvm
- [x] hello.chpl with --llvm now works

Trivial, not reviewed.