### PR TITLE
Make install llvm

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -971,8 +971,12 @@ static void printStuff(const char* argv0) {
 
   if( fPrintChplSettings ) {
     char buf[FILENAME_MAX+1] = "";
+    printf("CHPL_HOME: %s\n", CHPL_HOME);
+    printf("CHPL_RUNTIME_LIB: %s\n", CHPL_RUNTIME_LIB);
+    printf("CHPL_RUNTIME_INCL: %s\n", CHPL_RUNTIME_INCL);
+    printf("CHPL_THIRD_PARTY: %s\n", CHPL_THIRD_PARTY);
+    printf("\n");
     snprintf(buf, FILENAME_MAX, "%s/util/printchplenv", CHPL_HOME);
-    printf("Running %s\n", buf);
     int status = mysystem(buf, "running printchplenv", false);
     clean_exit(status);
   }

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -198,6 +198,11 @@ myinstallfile util/printchplenv       "$DEST_CHPL_HOME"/util/
 # copy util/chplenv
 myinstalldir  util/chplenv            "$DEST_CHPL_HOME"/util/chplenv/
 
+# copy util/config/compileline
+# (needed for LLVM builds)
+myinstallfile util/config/compileline "$DEST_CHPL_HOME"/util/config/
+
+
 if [ ! -z "$DEST_DIR" ]
 then
   # copy util/setchplenv*, util/quickstart

--- a/util/config/compileline
+++ b/util/config/compileline
@@ -28,6 +28,15 @@ if( defined $ENV{"CHPL_HOME"} ) {
 }
 
 $ENV{"CHPL_MAKE_HOME"} = $chpl_home_dir;
+if( defined $ENV{"CHPL_RUNTIME_LIB"} ) {
+  $ENV{"CHPL_MAKE_RUNTIME_LIB"} = $ENV{"CHPL_RUNTIME_LIB"}
+}
+if( defined $ENV{"CHPL_RUNTIME_INCL"} ) {
+  $ENV{"CHPL_MAKE_RUNTIME_INCL"} = $ENV{"CHPL_RUNTIME_INCL"}
+}
+if( defined $ENV{"CHPL_THIRD_PARTY"} ) {
+  $ENV{"CHPL_MAKE_THIRD_PARTY"} = $ENV{"CHPL_THIRD_PARTY"}
+}
 
 $make = `$chpl_home_dir/util/chplenv/chpl_make.py`;
 chomp($make);

--- a/util/config/compileline
+++ b/util/config/compileline
@@ -37,6 +37,15 @@ $make = "$make --no-print-directory";
 
 sub mysystem {
   my $cmd = shift;
+
+  # Uncomment for debug output
+  #print "About to run $cmd\n";
+  #for my $k (keys %ENV) {
+  #  if ($k =~ /CHPL/) {
+  #    print "$k=$ENV{$k}\n";
+  #  }
+  #}
+
   # Run $cmd but filter out e.g. make[2]: lines
   # (about which directory we are in)
   open(CMD, "$cmd |") or die "Cannot run $cmd: $!";


### PR DESCRIPTION
* Improves debugging output from --print-chpl-settings
* Adds some commented out debugging code to uti/config/compileline to help next time
* Fixes make install + --llvm

The --llvm compiles use the compileline script, so install that.  (It also might be useful in some cases when bulding C code to be integrated with Chapel).

Then, modify compileline to set CHPL_MAKE_RUNTIME_LIB, CHPL_MAKE_RUNTIME_INCL, and CHPL_MAKE_THIRD_PARTY. It was already setting CHPL_MAKE_HOME but these others need to be set too in order for the installed Make to work correctly.

Reviewed by @ben-albrecht - thanks!
Passed full local testing.