### PR TITLE
Add param and type versions of the Reflection.getField() functions

### DIFF
--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -47,6 +47,22 @@ proc numFields(type t) param : int
 proc getFieldName(type t, param i:int) param : string
   return __primitive("field num to name", t, i);
 
+pragma "no doc"
+proc getField(const ref x:?t, param i: int) param
+  where i > 0 && i <= numFields(t) &&
+        isParam(__primitive("field by num", x, i)) {
+
+  return __primitive("field by num", x, i);
+}
+
+pragma "no doc"
+proc getField(const ref x:?t, param i: int) type
+  where i > 0 && i <= numFields(t) &&
+        isType(__primitive("field by num", x, i)) {
+
+  return __primitive("field by num", x, i);
+}
+
 /* Get the ith field in a class or record.
    Causes a compilation error if `i` is not in 1..numFields(t).
 
@@ -57,6 +73,20 @@ proc getFieldName(type t, param i:int) param : string
 inline
 proc getField(const ref x:?t, param i:int) const ref
   return __primitive("field by num", x, i);
+
+pragma "no doc"
+proc getField(const ref x:?t, param s: string) param
+  where getFieldIndex(t, s) != 0 && isParam(getField(x, getFieldIndex(t, s))) {
+
+  return getField(x, getFieldIndex(t, s));
+}
+
+pragma "no doc"
+proc getField(const ref x:?t, param s: string) type
+  where getFieldIndex(t, s) != 0 && isType(getField(x, getFieldIndex(t, s))) {
+
+  return getField(x, getFieldIndex(t, s));
+}
 
 /* Get a field in a class or record by name.
    Will generate a compilation error if a field with that name

--- a/test/modules/standard/Reflection/reflectOnTypesParams.chpl
+++ b/test/modules/standard/Reflection/reflectOnTypesParams.chpl
@@ -1,0 +1,36 @@
+use Reflection;
+
+record R {
+  type t = real;
+  param p = 1;
+  var a: t;
+}
+
+var r = new R();
+
+for param i in 1..numFields(r.type) {
+  if isParam(getField(r, i)) {
+    param f = getField(r,i);
+    writeln("field ", i, " = ", f, " is a param");
+  } else if isType(getField(r, i)) {
+    type f = getField(r,i);
+    writeln("field ", i, " = ", f:string, " is a type");
+  } else {
+    var f = getField(r,i);
+    writeln("field ", i, " = ", f, " is not a param or type");
+  }
+}
+
+for param i in 1..numFields(r.type) {
+  param fName = getFieldName(R, i);
+  if isParam(getField(r, fName)) {
+    param f = getField(r, fName);
+    writeln("field ", fName, " = ", f, " is a param");
+  } else if isType(getField(r, fName)) {
+    type f = getField(r,i);
+    writeln("field ", fName, " = ", f:string, " is a type");
+  } else {
+    var f = getField(r,i);
+    writeln("field ", fName, " = ", f, " is not a param or type");
+  }
+}

--- a/test/modules/standard/Reflection/reflectOnTypesParams.good
+++ b/test/modules/standard/Reflection/reflectOnTypesParams.good
@@ -1,0 +1,6 @@
+field 1 = real(64) is a type
+field 2 = 1 is a param
+field 3 = 0.0 is not a param or type
+field t = real(64) is a type
+field p = 1 is a param
+field a = 0.0 is not a param or type

--- a/test/param/ferguson/field-value-not-in-range.good
+++ b/test/param/ferguson/field-value-not-in-range.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/Reflection.chpl:59: error: '2' is not a valid field number for R
+$CHPL_HOME/modules/standard/Reflection.chpl:: error: '2' is not a valid field number for R

--- a/test/param/ferguson/field-value-not-in-range.prediff
+++ b/test/param/ferguson/field-value-not-in-range.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+output=$2
+
+sed -e 's/:[0-9]*:/::/' $output > $output.tmp
+mv $output.tmp $output

--- a/test/param/ferguson/field-value-not-in-range2.good
+++ b/test/param/ferguson/field-value-not-in-range2.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/Reflection.chpl:86: error: '2' is not a valid field number for R
+$CHPL_HOME/modules/standard/Reflection.chpl:: error: '2' is not a valid field number for R

--- a/test/param/ferguson/field-value-not-in-range2.prediff
+++ b/test/param/ferguson/field-value-not-in-range2.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+output=$2
+sed -e 's/:[0-9]*:/::/' $output > $output.tmp
+mv $output.tmp $output


### PR DESCRIPTION
If the field to get is a param or a type, the getField() functions can
return a param or type.

Added a test to check that this is working.  Removed standard module
line numbers from .good files for two tests and added .prediff scripts to
strip them from the output.

Passed full local paratest with --verify.