### PR TITLE
Add AstCount, --print-module-resolution prints counts

### DIFF
--- a/compiler/AST/AstCount.cpp
+++ b/compiler/AST/AstCount.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "AstCount.h"
+
+
+AstCount::AstCount() {
+#define init_members(type) num##type = 0
+foreach_ast(init_members);
+#undef init_members
+
+  numForallIntents = 0;
+  numWhileDoStmt = 0;
+  numDoWhileStmt = 0;
+  numCForLoop = 0;
+  numForLoop = 0;
+  numParamForLoop = 0;
+}
+
+AstCount::~AstCount() {
+}
+
+int AstCount::total() {
+  int sum = 0;
+#define count_members(type) sum += num##type
+foreach_ast(count_members);
+#undef count_members
+
+  // and handle those not covered by the baseAST macro
+  sum += numForallIntents;
+  sum += numWhileDoStmt;
+  sum += numDoWhileStmt;
+  sum += numCForLoop;
+  sum += numForLoop;
+  sum += numParamForLoop;
+
+
+
+  return sum;
+}
+
+bool AstCount::enterAggrType(AggregateType* node) {
+  numAggregateType++;
+  return true;
+}
+
+void AstCount::exitAggrType(AggregateType* node) {
+}
+
+bool AstCount::enterEnumType(EnumType* node) {
+  numEnumType++;
+  return true;
+}
+
+void AstCount::exitEnumType(EnumType* node) {
+}
+
+void AstCount::visitPrimType(PrimitiveType* node) {
+  numPrimitiveType++;
+}
+
+bool AstCount::enterArgSym(ArgSymbol* node) {
+  numArgSymbol++;
+  return true;
+}
+
+void AstCount::exitArgSym(ArgSymbol* node) {
+}
+
+void AstCount::visitEnumSym(EnumSymbol* node) {
+  numEnumSymbol++;
+}
+
+bool AstCount::enterFnSym(FnSymbol* node) {
+  numFnSymbol++;
+  return true;
+}
+
+void AstCount::exitFnSym(FnSymbol* node) {
+}
+
+void AstCount::visitLabelSym(LabelSymbol* node) {
+  numLabelSymbol++;
+}
+
+bool AstCount::enterModSym(ModuleSymbol* node) {
+  numModuleSymbol++;
+  return true;
+}
+
+void AstCount::exitModSym(ModuleSymbol* node) {
+}
+
+bool AstCount::enterTypeSym(TypeSymbol* node) {
+  numTypeSymbol++;
+  return true;
+}
+
+void AstCount::exitTypeSym(TypeSymbol* node) {
+}
+
+void AstCount::visitVarSym(VarSymbol* node) {
+  numVarSymbol++;
+}
+
+bool AstCount::enterCallExpr(CallExpr* node) {
+  numCallExpr++;
+  return true;
+}
+
+void AstCount::exitCallExpr(CallExpr* node) {
+}
+
+bool AstCount::enterContextCallExpr(ContextCallExpr* node) {
+  numContextCallExpr++;
+  return true;
+}
+
+void AstCount::exitContextCallExpr(ContextCallExpr* node) {
+}
+
+bool AstCount::enterDefExpr(DefExpr* node) {
+  numDefExpr++;
+  return true;
+}
+
+void AstCount::exitDefExpr(DefExpr* node) {
+}
+
+bool AstCount::enterNamedExpr(NamedExpr* node) {
+  numNamedExpr++;
+  return true;
+}
+
+void AstCount::exitNamedExpr(NamedExpr* node) {
+}
+
+void AstCount::visitSymExpr(SymExpr* node) {
+  numSymExpr++;
+}
+
+void AstCount::visitUsymExpr(UnresolvedSymExpr* node) {
+  numUnresolvedSymExpr++;
+}
+
+void AstCount::visitUseStmt(UseStmt* node) {
+  numUseStmt++;
+}
+
+bool AstCount::enterBlockStmt(BlockStmt* node) {
+  numBlockStmt++;
+  return true;
+}
+
+void AstCount::exitBlockStmt(BlockStmt* node) {
+}
+
+void AstCount::visitForallIntents(ForallIntents* clause) {
+  numForallIntents++;
+}
+
+bool AstCount::enterWhileDoStmt(WhileDoStmt* node) {
+  numWhileDoStmt++;
+  return true;
+}
+
+void AstCount::exitWhileDoStmt(WhileDoStmt* node) {
+}
+
+bool AstCount::enterDoWhileStmt(DoWhileStmt* node) {
+  numDoWhileStmt++;
+  return true;
+}
+
+void AstCount::exitDoWhileStmt(DoWhileStmt* node) {
+}
+
+bool AstCount::enterCForLoop(CForLoop* node) {
+  numCForLoop++;
+  return true;
+}
+
+void AstCount::exitCForLoop(CForLoop* node) {
+}
+
+bool AstCount::enterForLoop(ForLoop* node) {
+  numForLoop++;
+  return true;
+}
+
+void AstCount::exitForLoop(ForLoop* node) {
+}
+
+bool AstCount::enterParamForLoop(ParamForLoop* node) {
+  numParamForLoop++;
+  return true;
+}
+
+void AstCount::exitParamForLoop(ParamForLoop* node) {
+}
+
+bool AstCount::enterCondStmt(CondStmt* node) {
+  numCondStmt++;
+  return true;
+}
+
+void AstCount::exitCondStmt(CondStmt* node) {
+}
+
+void AstCount::visitEblockStmt(ExternBlockStmt* node) {
+  numExternBlockStmt++;
+}
+
+bool AstCount::enterGotoStmt(GotoStmt* node) {
+  numGotoStmt++;
+  return true;
+}
+
+void AstCount::exitGotoStmt(GotoStmt* node) {
+}
+
+bool AstCount::enterForwardingStmt(ForwardingStmt* node) {
+  numForwardingStmt++;
+  return true;
+}
+
+void AstCount::exitForwardingStmt(ForwardingStmt* node) {
+}
+
+bool AstCount::enterTryStmt(TryStmt* node) {
+  numTryStmt++;
+  return true;
+}
+
+void AstCount::exitTryStmt(TryStmt* node) {
+}
+
+bool AstCount::enterCatchStmt(CatchStmt* node) {
+  numCatchStmt++;
+  return true;
+}
+
+void AstCount::exitCatchStmt(CatchStmt* node) {
+}
+
+

--- a/compiler/AST/AstCount.cpp
+++ b/compiler/AST/AstCount.cpp
@@ -227,20 +227,20 @@ void AstCount::visitEblockStmt(ExternBlockStmt* node) {
   numExternBlockStmt++;
 }
 
-bool AstCount::enterGotoStmt(GotoStmt* node) {
-  numGotoStmt++;
-  return true;
-}
-
-void AstCount::exitGotoStmt(GotoStmt* node) {
-}
-
 bool AstCount::enterForwardingStmt(ForwardingStmt* node) {
   numForwardingStmt++;
   return true;
 }
 
 void AstCount::exitForwardingStmt(ForwardingStmt* node) {
+}
+
+bool AstCount::enterGotoStmt(GotoStmt* node) {
+  numGotoStmt++;
+  return true;
+}
+
+void AstCount::exitGotoStmt(GotoStmt* node) {
 }
 
 bool AstCount::enterTryStmt(TryStmt* node) {

--- a/compiler/AST/AstCount.cpp
+++ b/compiler/AST/AstCount.cpp
@@ -21,10 +21,15 @@
 
 
 AstCount::AstCount() {
+
+// Initialize member variables for each AST node type
+// that is handled by the baseAST macro.
 #define init_members(type) num##type = 0
-foreach_ast(init_members);
+  foreach_ast(init_members);
 #undef init_members
 
+  // Initialize other member variables for AST types
+  // not handled by the baseAST macro.
   numForallIntents = 0;
   numWhileDoStmt = 0;
   numDoWhileStmt = 0;
@@ -38,19 +43,19 @@ AstCount::~AstCount() {
 
 int AstCount::total() {
   int sum = 0;
+
+  // Add those covered by the baseAST macro
 #define count_members(type) sum += num##type
 foreach_ast(count_members);
 #undef count_members
 
-  // and handle those not covered by the baseAST macro
+  // and then add those not covered by the baseAST macro
   sum += numForallIntents;
   sum += numWhileDoStmt;
   sum += numDoWhileStmt;
   sum += numCForLoop;
   sum += numForLoop;
   sum += numParamForLoop;
-
-
 
   return sum;
 }

--- a/compiler/AST/Makefile.share
+++ b/compiler/AST/Makefile.share
@@ -53,6 +53,8 @@ AST_SRCS =                                          \
            AstDumpToHtml.cpp                        \
            AstDumpToNode.cpp                        \
                                                     \
+           AstCount.cpp                             \
+                                                    \
            AstPrintDocs.cpp                         \
                                                     \
            AstToText.cpp                            \

--- a/compiler/include/AstCount.h
+++ b/compiler/include/AstCount.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _AST_COUNT_H_
+#define _AST_COUNT_H_
+
+#include "AstVisitor.h"
+#include "baseAST.h"
+
+class AstCount : public AstVisitor
+{
+public:
+
+  // Create member variables for each AST node type
+  // that is handled by the baseAST macro.
+#define decl_members(type) int num##type
+foreach_ast(decl_members);
+#undef decl_members
+
+  // Create member variables for AST types not handled
+  // by the baseAST macro.
+  int numForallIntents;
+  int numWhileDoStmt;
+  int numDoWhileStmt;
+  int numCForLoop;
+  int numForLoop;
+  int numParamForLoop;
+
+                 AstCount();
+  virtual       ~AstCount();
+
+  int            total();
+
+  //
+  // The sub-classes of Type
+  //
+  virtual bool   enterAggrType       (AggregateType*     node);
+  virtual void   exitAggrType        (AggregateType*     node);
+
+  virtual bool   enterEnumType       (EnumType*          node);
+  virtual void   exitEnumType        (EnumType*          node);
+
+  virtual void   visitPrimType       (PrimitiveType*     node);
+
+  //
+  // The sub-classes of Symbol
+  //
+  virtual bool   enterArgSym         (ArgSymbol*         node);
+  virtual void   exitArgSym          (ArgSymbol*         node);
+
+  virtual void   visitEnumSym        (EnumSymbol*        node);
+
+  virtual bool   enterFnSym          (FnSymbol*          node);
+  virtual void   exitFnSym           (FnSymbol*          node);
+
+  virtual void   visitLabelSym       (LabelSymbol*       node);
+
+  virtual bool   enterModSym         (ModuleSymbol*      node);
+  virtual void   exitModSym          (ModuleSymbol*      node);
+
+  virtual bool   enterTypeSym        (TypeSymbol*        node);
+  virtual void   exitTypeSym         (TypeSymbol*        node);
+
+  virtual void   visitVarSym         (VarSymbol*         node);
+
+  //
+  // The sub-classes of Expr
+  //
+  virtual bool   enterCallExpr       (CallExpr*          node);
+  virtual void   exitCallExpr        (CallExpr*          node);
+
+  virtual bool   enterContextCallExpr(ContextCallExpr*   node);
+  virtual void   exitContextCallExpr (ContextCallExpr*   node);
+
+  virtual bool   enterDefExpr        (DefExpr*           node);
+  virtual void   exitDefExpr         (DefExpr*           node);
+
+  virtual bool   enterNamedExpr      (NamedExpr*         node);
+  virtual void   exitNamedExpr       (NamedExpr*         node);
+
+  virtual void   visitSymExpr        (SymExpr*           node);
+
+  virtual void   visitUsymExpr       (UnresolvedSymExpr* node);
+
+  //
+  // The sub-classes of Stmt
+  //
+  virtual void   visitUseStmt        (UseStmt*           node);
+
+  virtual bool   enterBlockStmt      (BlockStmt*         node);
+  virtual void   exitBlockStmt       (BlockStmt*         node);
+
+  virtual void   visitForallIntents  (ForallIntents*   clause);
+
+  virtual bool   enterWhileDoStmt    (WhileDoStmt*       node);
+  virtual void   exitWhileDoStmt     (WhileDoStmt*       node);
+
+  virtual bool   enterDoWhileStmt    (DoWhileStmt*       node);
+  virtual void   exitDoWhileStmt     (DoWhileStmt*       node);
+
+  virtual bool   enterCForLoop       (CForLoop*          node);
+  virtual void   exitCForLoop        (CForLoop*          node);
+
+  virtual bool   enterForLoop        (ForLoop*           node);
+  virtual void   exitForLoop         (ForLoop*           node);
+
+  virtual bool   enterParamForLoop   (ParamForLoop*      node);
+  virtual void   exitParamForLoop    (ParamForLoop*      node);
+
+  virtual bool   enterCondStmt       (CondStmt*          node);
+  virtual void   exitCondStmt        (CondStmt*          node);
+
+  virtual bool   enterForwardingStmt (ForwardingStmt*    node);
+  virtual void   exitForwardingStmt  (ForwardingStmt*    node);
+
+  virtual void   visitEblockStmt     (ExternBlockStmt*   node);
+
+  virtual bool   enterGotoStmt       (GotoStmt*          node);
+  virtual void   exitGotoStmt        (GotoStmt*          node);
+
+  virtual bool   enterTryStmt        (TryStmt*           node);
+  virtual void   exitTryStmt         (TryStmt*           node);
+
+  virtual bool   enterCatchStmt      (CatchStmt*         node);
+  virtual void   exitCatchStmt       (CatchStmt*         node);
+
+};
+
+#endif

--- a/compiler/include/AstCount.h
+++ b/compiler/include/AstCount.h
@@ -126,10 +126,10 @@ foreach_ast(decl_members);
   virtual bool   enterCondStmt       (CondStmt*          node);
   virtual void   exitCondStmt        (CondStmt*          node);
 
+  virtual void   visitEblockStmt     (ExternBlockStmt*   node);
+
   virtual bool   enterForwardingStmt (ForwardingStmt*    node);
   virtual void   exitForwardingStmt  (ForwardingStmt*    node);
-
-  virtual void   visitEblockStmt     (ExternBlockStmt*   node);
 
   virtual bool   enterGotoStmt       (GotoStmt*          node);
   virtual void   exitGotoStmt        (GotoStmt*          node);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -26,6 +26,7 @@
 
 #include "resolution.h"
 
+#include "AstCount.h"
 #include "astutil.h"
 #include "build.h"
 #include "caches.h"
@@ -6037,8 +6038,10 @@ static void resolveUses(ModuleSymbol* mod)
     resolveUses(usedMod);
 
   // Finally, myself.
-  if (fPrintModuleResolution)
-    fprintf(stderr, "%2d Resolving module %s ...", module_resolution_depth, mod->name);
+  if (fPrintModuleResolution) {
+    fprintf(stderr, "%2d Resolving module %30s ...",
+            module_resolution_depth, mod->name);
+  }
 
   FnSymbol* fn = mod->initFn;
   resolveFormals(fn);
@@ -6049,8 +6052,11 @@ static void resolveUses(ModuleSymbol* mod)
     resolveFns(defn);
   }
 
-  if (fPrintModuleResolution)
-    putc('\n', stderr);
+  if (fPrintModuleResolution) {
+    AstCount visitor = AstCount();
+    mod->accept(&visitor);
+    fprintf(stderr, " %6d asts\n", visitor.total());
+  }
 
   --module_resolution_depth;
 }

--- a/test/compflags/ferguson/print-module-resolution.chpl
+++ b/test/compflags/ferguson/print-module-resolution.chpl
@@ -1,0 +1,1 @@
+writeln("Hello");

--- a/test/compflags/ferguson/print-module-resolution.compopts
+++ b/test/compflags/ferguson/print-module-resolution.compopts
@@ -1,0 +1,1 @@
+--print-module-resolution

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -1,0 +1,1 @@
+nnnn Resolving module print-module-resolution ... nnnn asts

--- a/test/compflags/ferguson/print-module-resolution.prediff
+++ b/test/compflags/ferguson/print-module-resolution.prediff
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+TEST=$1
+LOG=$2
+# PREDIFF: Script to execute before diff'ing output (arguments: <test
+#    executable>, <log>, <compiler executable>)
+
+MYLOG=""
+
+LAST=""
+
+MYLOG=`grep print-module-resolution $LOG | sed 's/[0-9][0-9]*/nnnn/g'`
+
+echo $MYLOG > $LOG


### PR DESCRIPTION
I thought it would be interesting to investigate how many AST nodes were involved in each module. We could use this information to trim down the amount of AST that the compiler automatically includes.

So this PR does three things:

1) It adds a new AST visitor, AstCount, that counts the various kinds of AST elements
2) It adjusts the handling of --print-module-resolution to count the number of AST elements within each module after that module is resolved and to print out the total. This is not necessarily the best place to gather this information but it was easy to add.
3) It adds a test of --print-module-resolution that is designed to not become a maintenance burden.

- [x] full local testing

Reviewed by @daviditen - thanks!