### PR TITLE
Minor tweaks to the API to scopeResolve

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -835,12 +835,7 @@ void AggregateType::buildTypeConstructor() {
     outer = tmpOuter;
   }
 
-  // Update the symbol table with added defs.
-  std::vector<DefExpr*> defs;
-
-  collectDefExprs(fn, defs);
-
-  addToSymbolTable(defs);
+  addToSymbolTable(fn);
 }
 
 
@@ -1172,11 +1167,7 @@ void AggregateType::buildConstructor() {
 
   fn->insertAtTail(new CallExpr(PRIM_RETURN, fn->_this));
 
-  std::vector<DefExpr*> defs;
-
-  collectDefExprs(fn, defs);
-
-  addToSymbolTable(defs);
+  addToSymbolTable(fn);
 }
 
 ArgSymbol* AggregateType::createGenericArg(VarSymbol* field) {
@@ -1385,32 +1376,6 @@ AggregateType* AggregateType::discoverParentAndCheck(Expr* storesName) {
   }
 
   return pt;
-}
-
-void AggregateType::addRecordDefaultConstruction() {
-  forv_Vec(DefExpr, def, gDefExprs) {
-    // We're only interested in declarations that do not have initializers.
-    if (def->init != NULL) {
-
-    } else if (VarSymbol* var = toVarSymbol(def->sym)) {
-      if (AggregateType* at = toAggregateType(var->type)) {
-        if (at->isRecord() == false) {
-
-        // No initializer for extern records.
-        } else if (at->symbol->hasFlag(FLAG_EXTERN) == true) {
-
-        } else {
-          SET_LINENO(def);
-
-          CallExpr* ctor_call = new CallExpr(new SymExpr(at->symbol));
-
-          def->init = new CallExpr(PRIM_NEW, ctor_call);
-
-          insert_help(def->init, def, def->parentSymbol);
-        }
-      }
-    }
-  }
 }
 
 void AggregateType::setCreationStyle(TypeSymbol* t, FnSymbol* fn) {

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -44,8 +44,6 @@ enum InitializerStyle {
 
 class AggregateType : public Type {
 public:
-  static void                 addRecordDefaultConstruction();
-
   static void                 setCreationStyle(TypeSymbol* t, FnSymbol* fn);
 
 public:

--- a/compiler/include/scopeResolve.h
+++ b/compiler/include/scopeResolve.h
@@ -20,13 +20,11 @@
 #ifndef _SCOPE_RESOLVE_H_
 #define _SCOPE_RESOLVE_H_
 
-#include <vector>
-
 class BaseAST;
-class DefExpr;
+class FnSymbol;
 class Symbol;
 
-void    addToSymbolTable(std::vector<DefExpr*>& defs);
+void    addToSymbolTable(FnSymbol* fn);
 
 Symbol* lookup(BaseAST* scope, const char* name);
 


### PR DESCRIPTION
I am working on a branch that starts to update scopeResolve.cpp.

This is a  trivial PR that integrates a few simple adjustments to the "external API" to
this "module" so that future merges will be localized to scopeResolve.cpp.

No updates in behavior.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed a single-locale paratest
