### PR TITLE
Tweak for LLVM

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1167,11 +1167,13 @@ static bool tryCResolve(ModuleSymbol*                     module,
                         const char*                       name,
                         llvm::SmallSet<ModuleSymbol*, 24> visited) {
 
-  if (! module) return false;
+  if (module == NULL) {
+    return false;
 
-  if (llvm_small_set_insert(visited, module)) {
+  } else if (llvm_small_set_insert(visited, module)) {
     // visited.insert(module)) {
     // we added it to the set, so continue.
+
   } else {
     // It was already in the set.
     return false;
@@ -1194,7 +1196,9 @@ static bool tryCResolve(ModuleSymbol*                     module,
 
         collectDefExprs(c_expr, v);
 
-        addToSymbolTable(v);
+        for_vector(DefExpr, def, v) {
+          addToSymbolTable(def);
+        }
 
         if (DefExpr* de = toDefExpr(c_expr)) {
           if (TypeSymbol* ts = toTypeSymbol(de->sym)) {


### PR DESCRIPTION
I realized that I had overlooked a trivial tweak in scopeResolve.cpp that was
within a HAVE_LLVM guard.  Fixed here.

Compiled on clang/darwin and gcc/linux64 with CHPL_LLVM=none and
on gcc/linux64 with CHPL_LLVM=llvm

Ran start_test on a portion of release with -compopts --llvm
