### PR TITLE
Miscellaneous c2chapel improvements

### DIFF
--- a/tools/c2chapel/test/chapelKeywords.chpl
+++ b/tools/c2chapel/test/chapelKeywords.chpl
@@ -1,0 +1,18 @@
+// Generated with c2chapel version 0.1.0
+
+// Header given to c2chapel:
+require "chapelKeywords.h";
+
+// Note: Generated with fake std headers
+
+extern proc foo(out_arg : c_int, ref_arg : c_char) : c_int;
+
+// Unable to generate function 'coforall' because its name is a Chapel keyword
+
+// ==== c2chapel typedefs ====
+
+// Fields omitted because one or more of the identifiers is a Chapel keyword
+extern record bar {}
+
+// Unable to generate struct 'record' because its name is a Chapel keyword
+

--- a/tools/c2chapel/test/chapelKeywords.h
+++ b/tools/c2chapel/test/chapelKeywords.h
@@ -1,0 +1,14 @@
+
+int foo(int out, char ref);
+
+int coforall(int a, int b);
+
+typedef struct {
+  int a;
+  int b;
+  int c;
+} record;
+
+typedef struct {
+  int index;
+} bar;

--- a/tools/c2chapel/test/chapelVarargs.chpl
+++ b/tools/c2chapel/test/chapelVarargs.chpl
@@ -7,5 +7,11 @@ require "chapelVarargs.h";
 
 extern proc printf_wrapper(format : c_string, c__varargs ...) : void;
 
+// Overload for empty varargs
+extern proc printf_wrapper(format : c_string) : void;
+
 extern proc multiArgs(a : c_int, b : c_char, c__varargs ...) : c_int;
+
+// Overload for empty varargs
+extern proc multiArgs(a : c_int,b : c_char) : c_int;
 

--- a/tools/c2chapel/test/cstrvoid.chpl
+++ b/tools/c2chapel/test/cstrvoid.chpl
@@ -13,7 +13,7 @@ extern proc ret_cstr() : c_string;
 
 extern proc ret_void_ptr() : c_void_ptr;
 
-extern proc arg_ptr_to_cstr(ref out : c_string) : void;
+extern proc arg_ptr_to_cstr(ref out_arg : c_string) : void;
 
-extern proc arg_ptr_to_void_ptr(ref out : c_void_ptr) : void;
+extern proc arg_ptr_to_void_ptr(ref out_arg : c_void_ptr) : void;
 

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -30,6 +30,9 @@ extern type my_int = c_int;
 
 extern type my_string = c_string;
 
+// Typedef'd pointer to struct
+extern type recp;
+
 extern type renamedFancy = fancyStruct;
 
 extern type renamedStruct = simpleStruct;

--- a/tools/c2chapel/test/miscTypedef.h
+++ b/tools/c2chapel/test/miscTypedef.h
@@ -25,3 +25,8 @@ typedef fancyStruct renamedFancy;
 fancyStruct retStruct(my_int a, my_int b, renamedStruct r);
 
 void tdPointer(fancyStruct* a, renamedStruct** b);
+
+typedef struct {
+  int i;
+  char c;
+} *recp;


### PR DESCRIPTION
- Map 'unsigned' type to 'c_uint'
- Map 'FILE' type to '_file'
- Avoid generating structs, arguments, and functions with identifiers that
  are also Chapel keywords
- Fix bug related to returning a c_fn_ptr
- Generate an overload for empty varargs
- Better handling for typedef'd pointer to struct