### PR TITLE
Suppress unneeded informational message from CCE 8.6

### DIFF
--- a/make/compiler/Makefile.cray-prgenv-cray
+++ b/make/compiler/Makefile.cray-prgenv-cray
@@ -21,6 +21,10 @@ CRAYPE_GEN_CFLAGS = -hnomessage=7212
 # Suppress warnings about unsigned ints being compared to 0
 CRAYPE_GEN_CFLAGS += -hnomessage=186
 
+# Suppress warnings about needing the optimizer to handle
+# certain cases of __asm__
+CRAYPE_GEN_CFLAGS += -hnomessage=3140
+
 # Could set CRAYPE_COMP_CXXFLAGS, CRAYPE_GEN_CFLAGS
 
 FAST_FLOAT_GEN_CFLAGS = -hfp2


### PR DESCRIPTION
CCE 8.6 added an informational message indicating that a portion of the optimizer is needed for certain cases involving \_\_asm\_\_ statements.  They look like this.
```
CC-3140 craycc: WARNING File = h3_c/_main.c, Line = 1, Column = 1
  The IPA optimization level was changed to "1" due to the presence of OMP, ACC,
          or ASM intrinsics.

Cray C : Version 8.6.0.22245 (20170502155645_12e5f4d83d42257e3f4dc7c6c72e2a87bf93f32a)
```
This makes start_test think that the compilation has failed.  This PR suppresses the message.