### PR TITLE
Include sub_test's stderr in start_test's log file

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -443,7 +443,8 @@ def run(test=False):
     # output to the command line, instead of logging all output in one huge
     # block.
     logger.write("[Starting {0} {1}]".format(sub_test, date_str))
-    p = subprocess.Popen([sub_test, compiler], stdout=subprocess.PIPE)
+    p = subprocess.Popen([sub_test, compiler],
+                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     printout(p.stdout)
     p.wait()
     return p.returncode


### PR DESCRIPTION
Redirection of sub_test's stderr into the log file
was lost in #2185:

```
-   $sub_test "$compiler" |& $tee -a $logfile
+   p = subprocess.Popen([sub_test, compiler], stdout=subprocess.PIPE)
```

This trivial change restores this redirection.