### PR TITLE
Remove unnecessary state

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -885,18 +885,13 @@ static void updateMethod(UnresolvedSymExpr*            usymExpr,
           Type* type = method->_this->type;
 
           if (isAggr == true || isMethodName(name, type) == true) {
-            CallExpr* call = toCallExpr(expr->parentExpr);
-
-            if (call                              != NULL &&
-                call->baseExpr                    == expr &&
-                call->numActuals()                >= 2    &&
-                isSymExpr(call->get(1))           == true &&
-                toSymExpr(call->get(1))->symbol() == gMethodToken) {
-              UnresolvedSymExpr* use = new UnresolvedSymExpr(name);
-
-              expr->replace(use);
-
-              skipSet.insert(use);
+            if (CallExpr* call = toCallExpr(expr->parentExpr)) {
+              if (call->baseExpr                    != expr  ||
+                  call->numActuals()                <  2     ||
+                  isSymExpr(call->get(1))           == false ||
+                  toSymExpr(call->get(1))->symbol() != gMethodToken) {
+                insertFieldAccess(method, usymExpr, sym, expr);
+              }
 
             } else {
               insertFieldAccess(method, usymExpr, sym, expr);


### PR DESCRIPTION
I am working on a branch that improves scopeResolve.cpp.   This trivial PR closes a gap between
master and that branch by merging two trivial changes.

Both of these changes focus on the core of this "pass"; replacing a subset of uses of
UnresolvedSymExpr with an appropriate SymExpr.


A. Eliminate a "skipset" of UnresolvedSymExpr.

Before this PR there was a place deep within the call path in which an existing UnresolvedSymExpr
was replaced with a new UnresolvedSymExpr with the same name.  This could lead to an infinite
loop if this new UnresolvedSymExpr were encountered again.

This concern was addressed by allocating a set at the top-level of the call path, passing this
set through the required sequence of calls, and then inserting the new UnresolvedSymExpr
in to the skip set.  Tests of the skip-set provided a short circuit for this.

I presume that there was a variation of the code in which this process "made sense"
but, if so, this is not true any longer.  Removed the replacement and removed the skipset.


B. Eliminate a premature performance optimization

The update to support the private keyword added a set that would store the ID for any
private symbols encountered during a single call to map a symbol-name to the appropriate
lexically-scoped symbol.  The intent was to avoid repeating a portion of the visibility analysis
in certain situations.  Maintaining this set adds some minor complexity to the implementation but
does not provide any benefit in the current code base, and may or may not provide a benefit
if the private keyword were used extensively.  Finally this implementation might or might not
be relevant in the revised implementation.



Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Passed
a standard single-locale paratest, and a single-locale paratest with --no-local. 

This pass includes some minor additional functionality for HAVE_LLVM.  Compiled with
CHPL_LLVM=llvm and performance a single-locale paratest with --llvm.
