### PR TITLE
Disambiguate definitions of class Scope

### DIFF
--- a/compiler/include/AutoDestroyScope.h
+++ b/compiler/include/AutoDestroyScope.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _AUTO_DESTROY_SCOPE_H_
+#define _AUTO_DESTROY_SCOPE_H_
+
+class BlockStmt;
+class Expr;
+class FnSymbol;
+class VarSymbol;
+
+#include <vector>
+
+// Track status of auto destroy variables within lexical scopes
+class AutoDestroyScope {
+public:
+                           AutoDestroyScope(const AutoDestroyScope* parent,
+                                            const BlockStmt*        block);
+
+  void                     variableAdd(VarSymbol* var);
+
+  bool                     handlingFormalTemps(const Expr* stmt) const;
+
+  void                     insertAutoDestroys(FnSymbol* fn,
+                                              Expr*     refStmt);
+
+private:
+  void                     variablesDestroy(Expr*      refStmt,
+                                            VarSymbol* excludeVar)     const;
+
+  const AutoDestroyScope*  mParent;
+  const BlockStmt*         mBlock;
+
+  bool                     mLocalsHandled;     // Manage function epilogue
+  std::vector<VarSymbol*>  mFormalTemps;       // Temps for out/inout formals
+  std::vector<VarSymbol*>  mLocals;
+};
+
+#endif
+

--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _RESOLVE_SCOPE_H_
+#define _RESOLVE_SCOPE_H_
+
+#include <map>
+
+class BaseAST;
+class BlockStmt;
+class DefExpr;
+class FnSymbol;
+class Symbol;
+class TypeSymbol;
+
+// A preliminary version of a class to support the scope resolve pass
+// This is currently a thin wrapping over a previous typedef + functions
+class ResolveScope {
+public:
+  static ResolveScope*            findOrCreateScopeFor(DefExpr* def);
+
+  static ResolveScope*            getScopeFor(BaseAST* ast);
+
+  static void                     destroyAstMap();
+
+public:
+                                  ResolveScope(BlockStmt*  blockStmt);
+                                  ResolveScope(FnSymbol*   fnSym);
+                                  ResolveScope(TypeSymbol* typeSym);
+
+  bool                            extend(Symbol*     sym);
+
+  Symbol*                         lookup(const char* name)               const;
+
+private:
+                                  ResolveScope();
+
+  bool                            isAggregateTypeAndConstructor(Symbol* sym0,
+                                                                Symbol* sym1);
+
+  bool                            isSymbolAndMethod(Symbol* sym0,
+                                                    Symbol* sym1);
+
+  BaseAST*                        mAstRef;
+  std::map<const char*, Symbol*>  mBindings;
+};
+
+#endif

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -264,4 +264,7 @@ AggregateType* computeTupleWithIntent(IntentTag intent, Type* t);
 
 bool evaluateWhereClause(FnSymbol* fn);
 
+
+bool isAutoDestroyedVariable(Symbol* sym);
+
 #endif

--- a/compiler/include/scopeResolve.h
+++ b/compiler/include/scopeResolve.h
@@ -24,8 +24,10 @@ class BaseAST;
 class FnSymbol;
 class Symbol;
 
-void    addToSymbolTable(FnSymbol* fn);
+void     addToSymbolTable(FnSymbol* fn);
 
-Symbol* lookup(BaseAST* scope, const char* name);
+Symbol*  lookup(BaseAST* scope, const char* name);
+
+BaseAST* getScope(BaseAST* ast);
 
 #endif

--- a/compiler/passes/Makefile.share
+++ b/compiler/passes/Makefile.share
@@ -39,6 +39,7 @@ PASSES_SRCS =                                              \
         normalize.cpp                                      \
         parallel.cpp                                       \
         resolveIntents.cpp                                 \
+        ResolveScope.cpp                                   \
         returnStarTuplesByRefArgs.cpp                      \
         scopeResolve.cpp
 

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/************************************* | **************************************
+*                                                                             *
+* A ResolveScope supports the first phase in mapping a name to a lexically    *
+* scoped symbol. A scope is a set of bindings where a binding is a mapping    *
+* from a name to a single symbol.  The name must be unique within a given     *
+* scope.                                                                      *
+*                                                                             *
+*                                                                             *
+* May 8, 2017:                                                                *
+*   Until recently this state was implemented using a std::map and a handful  *
+* of file static function.  This first implementation simply wraps that code. *
+*                                                                             *
+* This representation is able to detect disallowed reuse of a name within a   *
+* scope but does not fully support function overloading; a name can only be   *
+* mapped to a single AST node.                                                *
+*                                                                             *
+* Scopes are created for 4 kinds of AST nodes                                 *
+*    1) A  BlockStmt  with tag BLOCK_NORMAL                                   *
+*    2) An FnSymbol   defines a scope for its formals and query variables     *
+*    3) A  TypeSymbol for an enum type                                        *
+*    4) A  TypeSymbol for an aggregate type                                   *
+*                                                                             *
+************************************** | *************************************/
+
+#include "ResolveScope.h"
+
+#include "scopeResolve.h"
+#include "stmt.h"
+#include "symbol.h"
+#include "type.h"
+
+static std::map<BaseAST*, ResolveScope*> sScopeMap;
+
+ResolveScope* ResolveScope::findOrCreateScopeFor(DefExpr* def) {
+  BaseAST*      ast    = getScope(def);
+  ResolveScope* retval = NULL;
+
+  if (ast == rootModule->block) {
+    ast = theProgram->block;
+  }
+
+  retval = getScopeFor(ast);
+
+  if (retval == NULL) {
+    if (BlockStmt* blockStmt = toBlockStmt(ast)) {
+      retval = new ResolveScope(blockStmt);
+
+    } else if (FnSymbol*  fnSymbol = toFnSymbol(ast)) {
+      retval = new ResolveScope(fnSymbol);
+
+    } else if (TypeSymbol* typeSymbol = toTypeSymbol(ast)) {
+      retval = new ResolveScope(typeSymbol);
+
+    } else {
+      INT_ASSERT(false);
+    }
+
+    sScopeMap[ast] = retval;
+  }
+
+  return retval;
+}
+
+ResolveScope* ResolveScope::getScopeFor(BaseAST* ast) {
+  std::map<BaseAST*, ResolveScope*>::iterator it;
+  ResolveScope*                               retval = NULL;
+
+  it = sScopeMap.find(ast);
+
+  if (it != sScopeMap.end()) {
+    retval = it->second;
+  }
+
+  return retval;
+}
+
+void ResolveScope::destroyAstMap() {
+  std::map<BaseAST*, ResolveScope*>::iterator it;
+
+  for (it = sScopeMap.begin(); it != sScopeMap.end(); it++) {
+    delete it->second;
+  }
+
+  sScopeMap.clear();
+}
+
+ResolveScope::ResolveScope(BlockStmt* blockStmt) {
+  mAstRef = blockStmt;
+}
+
+ResolveScope::ResolveScope(FnSymbol*  fnSymbol)  {
+  mAstRef = fnSymbol;
+}
+
+ResolveScope::ResolveScope(TypeSymbol* typeSymbol) {
+  Type* type = typeSymbol->type;
+
+  INT_ASSERT(isEnumType(type) || isAggregateType(type));
+
+  mAstRef = typeSymbol;
+}
+
+bool ResolveScope::extend(Symbol* newSym) {
+  const char* name   = newSym->name;
+  bool        retval = false;
+
+  if (Symbol* oldSym = lookup(name)) {
+    FnSymbol* oldFn = toFnSymbol(oldSym);
+    FnSymbol* newFn = toFnSymbol(newSym);
+
+    // Do not complain if they are both functions
+    if (oldFn != NULL && newFn != NULL) {
+      retval = true;
+
+    // e.g. record String and proc String(...)
+    } else if (isAggregateTypeAndConstructor(oldSym, newSym) == true ||
+               isAggregateTypeAndConstructor(newSym, oldSym) == true) {
+      retval = true;
+
+    // Methods currently leak their scope and can conflict with variables
+    } else if (isSymbolAndMethod(oldSym, newSym)             == true ||
+               isSymbolAndMethod(newSym, oldSym)             == true) {
+      retval = true;
+
+    } else {
+      USR_FATAL(oldSym,
+                "'%s' has multiple definitions, redefined at:\n  %s",
+                name,
+                newSym->stringLoc());
+    }
+
+    // If oldSym is a constructor and newSym is a type, update with the type
+    if (newFn == NULL || newFn->_this == NULL) {
+      mBindings[name] = newSym;
+    }
+
+  } else {
+    mBindings[name] = newSym;
+    retval          = true;
+  }
+
+  return retval;
+}
+
+bool ResolveScope::isAggregateTypeAndConstructor(Symbol* sym0, Symbol* sym1) {
+  TypeSymbol* typeSym = toTypeSymbol(sym0);
+  FnSymbol*   funcSym = toFnSymbol(sym1);
+  bool        retval  = false;
+
+  if (typeSym != NULL && funcSym != NULL && funcSym->_this != NULL) {
+    AggregateType* type0 = toAggregateType(typeSym->type);
+    AggregateType* type1 = toAggregateType(funcSym->_this->type);
+
+    retval = (type0 == type1) ? true : false;
+  }
+
+  return retval;
+}
+
+bool ResolveScope::isSymbolAndMethod(Symbol* sym0, Symbol* sym1) {
+  FnSymbol* fun0   = toFnSymbol(sym0);
+  FnSymbol* fun1   = toFnSymbol(sym1);
+  bool      retval = false;
+
+  if (fun0 == NULL && fun1 != NULL && fun1->_this != NULL) {
+    retval = true;
+  }
+
+  return retval;
+}
+
+Symbol* ResolveScope::lookup(const char* name) const {
+  std::map<const char*, Symbol*>::const_iterator it     = mBindings.find(name);
+  Symbol*                                        retval = NULL;
+
+  if (it != mBindings.end()) {
+    retval = it->second;
+  }
+
+  return retval;
+}

--- a/compiler/resolution/AutoDestroyScope.cpp
+++ b/compiler/resolution/AutoDestroyScope.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "AutoDestroyScope.h"
+
+#include "expr.h"
+#include "resolution.h"
+#include "stmt.h"
+#include "symbol.h"
+
+/************************************* | **************************************
+*                                                                             *
+* Track the state of lexical scopes during the execution of a function.       *
+*                                                                             *
+*   1) We only track variables that have an autoDestroy flag                  *
+*                                                                             *
+*   2) The compiler introduces "formal temps" to manage formals with out and  *
+*      in-out concrete intents.  If a function has multiple returns then any  *
+*      formal temps must be handled differently from other locals.            *
+*                                                                             *
+************************************** | *************************************/
+
+static VarSymbol* variableToExclude(FnSymbol*  fn, Expr* refStmt);
+
+static bool       isReturnStmt(const Expr* stmt);
+
+static BlockStmt* findBlockForTarget(GotoStmt* stmt);
+
+AutoDestroyScope::AutoDestroyScope(const AutoDestroyScope* parent,
+                                   const BlockStmt*        block) {
+  mParent        = parent;
+  mBlock         = block;
+
+  mLocalsHandled = false;
+}
+
+void AutoDestroyScope::variableAdd(VarSymbol* var) {
+  if (var->hasFlag(FLAG_FORMAL_TEMP) == false) {
+    mLocals.push_back(var);
+  } else {
+    mFormalTemps.push_back(var);
+  }
+}
+
+//
+// Functions have an informal epilogue defined by code that
+//
+//   1) appears after a common "return label" (if present)
+//   2) copies values to out/in-out formals
+//
+// We must      destroy the primaries before (1).
+// We choose to destroy the primaries before (2).
+//
+// This code detects the start of (2)
+//
+bool AutoDestroyScope::handlingFormalTemps(const Expr* stmt) const {
+  bool retval = false;
+
+  if (mLocalsHandled == false) {
+    if (const CallExpr* call = toConstCallExpr(stmt)) {
+      if (FnSymbol* fn = call->resolvedFunction()) {
+        if (fn->hasFlag(FLAG_ASSIGNOP) == true && call->numActuals() == 2) {
+          SymExpr* lhs = toSymExpr(call->get(1));
+          SymExpr* rhs = toSymExpr(call->get(2));
+
+          if (lhs                                      != NULL &&
+              rhs                                      != NULL &&
+              isArgSymbol(lhs->symbol())               == true &&
+              rhs->symbol()->hasFlag(FLAG_FORMAL_TEMP) == true) {
+            retval = true;
+          }
+        }
+      }
+    }
+  }
+
+  return retval;
+}
+
+// If the refStmt is a goto then we need to recurse
+// to the block that contains the target of the goto
+void AutoDestroyScope::insertAutoDestroys(FnSymbol* fn, Expr* refStmt) {
+  GotoStmt*               gotoStmt   = toGotoStmt(refStmt);
+  bool                    recurse    = (gotoStmt != NULL) ? true : false;
+  BlockStmt*              forTarget  = findBlockForTarget(gotoStmt);
+  VarSymbol*              excludeVar = variableToExclude(fn, refStmt);
+  const AutoDestroyScope* scope      = this;
+
+  while (scope != NULL && scope->mBlock != forTarget) {
+    scope->variablesDestroy(refStmt, excludeVar);
+
+    scope = (recurse == true) ? scope->mParent : NULL;
+  }
+
+  mLocalsHandled = true;
+}
+
+void AutoDestroyScope::variablesDestroy(Expr*      refStmt,
+                                        VarSymbol* excludeVar) const {
+  // Handle the primary locals
+  if (mLocalsHandled == false) {
+    bool   insertAfter = false;
+    size_t count       = mLocals.size();
+
+    // If this is a simple nested block, insert after the final stmt
+    // Do not get tricked by sequences of unreachable code
+    if (refStmt->next == NULL) {
+      if (mParent != NULL && isGotoStmt(refStmt) == false) {
+        insertAfter = true;
+      }
+    }
+
+    for (size_t i = 1; i <= count; i++) {
+      VarSymbol* var = mLocals[count - i];
+
+      if (var != excludeVar) {
+        if (FnSymbol* autoDestroyFn = autoDestroyMap.get(var->type)) {
+          SET_LINENO(var);
+
+          INT_ASSERT(autoDestroyFn->hasFlag(FLAG_AUTO_DESTROY_FN));
+
+          CallExpr* autoDestroy = new CallExpr(autoDestroyFn, var);
+
+          if (insertAfter == true) {
+            refStmt->insertAfter (autoDestroy);
+          } else {
+            refStmt->insertBefore(autoDestroy);
+          }
+        }
+      }
+    }
+  }
+
+  // Handle the formal temps
+  if (isReturnStmt(refStmt) == true) {
+    size_t count = mFormalTemps.size();
+
+    for (size_t i = 1; i <= count; i++) {
+      VarSymbol* var = mFormalTemps[count - i];
+
+      if (FnSymbol* autoDestroyFn = autoDestroyMap.get(var->type)) {
+        SET_LINENO(var);
+
+        refStmt->insertBefore(new CallExpr(autoDestroyFn, var));
+      }
+    }
+  }
+}
+
+// Walk backwards from the current statement to determine if a sequence of
+// moves have copied a variable that is marked for auto destruction in to
+// the dedicated return-temp within the current scope.
+//
+// Note that the value we are concerned about may be copied in to one or
+// more temporary variables between being copied to the return temp.
+static VarSymbol* variableToExclude(FnSymbol* fn, Expr* refStmt) {
+  VarSymbol* retVar = toVarSymbol(fn->getReturnSymbol());
+  VarSymbol* retval = NULL;
+
+  if (retVar != NULL) {
+    if (isUserDefinedRecord(retVar)    == true ||
+        fn->hasFlag(FLAG_INIT_COPY_FN) == true) {
+      VarSymbol* needle = retVar;
+      Expr*      expr   = refStmt;
+
+      // Walk backwards looking for the variable that is being returned
+      while (retval == NULL && expr != NULL && needle != NULL) {
+        if (CallExpr* move = toCallExpr(expr)) {
+          if (move->isPrimitive(PRIM_MOVE) == true) {
+            SymExpr*   lhs    = toSymExpr(move->get(1));
+            VarSymbol* lhsVar = toVarSymbol(lhs->symbol());
+
+            if (needle == lhsVar) {
+              if (SymExpr* rhs = toSymExpr(move->get(2))) {
+                VarSymbol* rhsVar = toVarSymbol(rhs->symbol());
+
+                if (isAutoDestroyedVariable(rhsVar) == true) {
+                  retval = rhsVar;
+                } else {
+                  needle = rhsVar;
+                }
+              } else {
+                needle = NULL;
+              }
+            }
+          }
+        }
+
+        expr = expr->prev;
+      }
+    }
+  }
+
+  return retval;
+}
+
+static bool isReturnStmt(const Expr* stmt) {
+  bool retval = false;
+
+  if (const CallExpr* expr = toConstCallExpr(stmt)) {
+    retval = expr->isPrimitive(PRIM_RETURN);
+  }
+
+  return retval;
+}
+
+// Find the block stmt that encloses the target of this gotoStmt
+static BlockStmt* findBlockForTarget(GotoStmt* stmt) {
+  BlockStmt* retval = NULL;
+
+  if (stmt != NULL && stmt->isGotoReturn() == false) {
+    SymExpr* labelSymExpr = toSymExpr(stmt->label);
+    Expr*    ptr          = labelSymExpr->symbol()->defPoint;
+
+    while (ptr != NULL && isBlockStmt(ptr) == false) {
+      ptr = ptr->parentExpr;
+    }
+
+    retval = toBlockStmt(ptr);
+
+    INT_ASSERT(retval);
+  }
+
+  return retval;
+}

--- a/compiler/resolution/Makefile.share
+++ b/compiler/resolution/Makefile.share
@@ -17,6 +17,7 @@
 
 RESOLUTION_SRCS =                                              \
                   addAutoDestroyCalls.cpp                      \
+                  AutoDestroyScope.cpp                         \
                   caches.cpp                                   \
                   callDestructors.cpp                          \
                   callInfo.cpp                                 \

--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -19,7 +19,10 @@
 
 #include "addAutoDestroyCalls.h"
 
+
+
 #include "astutil.h"
+#include "AutoDestroyScope.h"
 #include "expr.h"
 #include "resolution.h"
 #include "stlUtil.h"
@@ -28,54 +31,11 @@
 
 #include <vector>
 
-/************************************* | **************************************
-*                                                                             *
-* Track the state of lexical scopes during the execution of a function.       *
-*                                                                             *
-*   1) We only track variables that have an autoDestroy flag                  *
-*                                                                             *
-*   2) The compiler introduces "formal temps" to manage formals with out and  *
-*      in-out concrete intents.  If a function has multiple returns then any  *
-*      formal temps must be handled differently from other locals.            *
-*                                                                             *
-************************************** | *************************************/
-
-class Scope
-{
-public:
-                           Scope(const Scope*     parent,
-                                 const BlockStmt* block);
-
-  void                     variableAdd(VarSymbol* var);
-
-  bool                     startingToHandleFormalTemps(const Expr* stmt) const;
-
-  void                     insertAutoDestroys(FnSymbol* fn,
-                                              Expr*     refStmt);
-
-private:
-  void                     variablesDestroy(Expr*      refStmt,
-                                            VarSymbol* excludeVar)       const;
-
-  const Scope*             mParent;
-  const BlockStmt*         mBlock;
-
-  bool                     mLocalsHandled;       // Manage function epilogue
-
-  std::vector<VarSymbol*>  mFormalTemps;         // Temps for out/inout formals
-  std::vector<VarSymbol*>  mLocals;
-};
-
-static void walkBlock(FnSymbol* fn, Scope* parent, BlockStmt* block);
-static bool isAutoDestroyedVariable(Symbol* sym);
-
-/************************************* | **************************************
-*                                                                             *
-* Entry point                                                                 *
-*                                                                             *
-************************************** | *************************************/
-
 static void cullForDefaultConstructor(FnSymbol* fn);
+
+static void walkBlock(FnSymbol*         fn,
+                      AutoDestroyScope* parent,
+                      BlockStmt*        block);
 
 void addAutoDestroyCalls() {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
@@ -165,11 +125,13 @@ static LabelSymbol* findReturnLabel(FnSymbol* fn);
 static bool         isReturnLabel(const Expr*        stmt,
                                   const LabelSymbol* returnLabel);
 
-static void walkBlock(FnSymbol* fn, Scope* parent, BlockStmt* block) {
-  Scope        scope(parent, block);
+static void walkBlock(FnSymbol*         fn,
+                      AutoDestroyScope* parent,
+                      BlockStmt*        block) {
+  AutoDestroyScope scope(parent, block);
 
-  LabelSymbol* retLabel   = (parent == NULL) ? findReturnLabel(fn) : NULL;
-  bool         isDeadCode = false;
+  LabelSymbol*     retLabel   = (parent == NULL) ? findReturnLabel(fn) : NULL;
+  bool             isDeadCode = false;
 
   for_alist(stmt, block->body) {
     //
@@ -190,7 +152,7 @@ static void walkBlock(FnSymbol* fn, Scope* parent, BlockStmt* block) {
         scope.variableAdd(var);
 
       // AutoDestroy primary locals at start of function epilogue (2)
-      } else if (scope.startingToHandleFormalTemps(stmt) == true) {
+      } else if (scope.handlingFormalTemps(stmt) == true) {
         scope.insertAutoDestroys(fn, stmt);
 
       // Recurse in to a BlockStmt (or sub-classes of BlockStmt e.g. a loop)
@@ -297,209 +259,11 @@ static bool isReturnLabel(const Expr* stmt, const LabelSymbol* returnLabel) {
 
 /************************************* | **************************************
 *                                                                             *
-*                                                                             *
-*                                                                             *
-************************************** | *************************************/
-
-static VarSymbol* variableToExclude(FnSymbol*  fn, Expr* refStmt);
-static bool       isReturnStmt(const Expr* stmt);
-static BlockStmt* findBlockForTarget(GotoStmt* stmt);
-
-Scope::Scope(const Scope* parent, const BlockStmt* block) {
-  mParent        = parent;
-  mBlock         = block;
-
-  mLocalsHandled = false;
-}
-
-void Scope::variableAdd(VarSymbol* var) {
-  if (var->hasFlag(FLAG_FORMAL_TEMP) == false)
-    mLocals.push_back(var);
-  else
-    mFormalTemps.push_back(var);
-}
-
-//
-// Functions have an informal epilogue defined by code that
-//
-//   1) appears after a common "return label" (if present)
-//   2) copies values to out/in-out formals
-//
-// We must      destroy the primaries before (1).
-// We choose to destroy the primaries before (2).
-//
-// This code detects the start of (2)
-//
-bool Scope::startingToHandleFormalTemps(const Expr* stmt) const {
-  bool retval = false;
-
-  if (mLocalsHandled == false) {
-    if (const CallExpr* call = toConstCallExpr(stmt)) {
-      if (FnSymbol* fn = call->resolvedFunction()) {
-        if (fn->hasFlag(FLAG_ASSIGNOP) == true && call->numActuals() == 2) {
-          SymExpr* lhs = toSymExpr(call->get(1));
-          SymExpr* rhs = toSymExpr(call->get(2));
-
-          if (lhs                                      != NULL &&
-              rhs                                      != NULL &&
-              isArgSymbol(lhs->symbol())               == true &&
-              rhs->symbol()->hasFlag(FLAG_FORMAL_TEMP) == true) {
-            retval = true;
-          }
-        }
-      }
-    }
-  }
-
-  return retval;
-}
-
-// If the refStmt is a goto then we need to recurse
-// to the block that contains the target of the goto
-void Scope::insertAutoDestroys(FnSymbol* fn, Expr* refStmt) {
-  GotoStmt*    gotoStmt   = toGotoStmt(refStmt);
-  bool         recurse    = (gotoStmt != NULL) ? true : false;
-  BlockStmt*   forTarget  = findBlockForTarget(gotoStmt);
-  VarSymbol*   excludeVar = variableToExclude(fn, refStmt);
-  const Scope* scope      = this;
-
-  while (scope != NULL && scope->mBlock != forTarget) {
-    scope->variablesDestroy(refStmt, excludeVar);
-
-    scope = (recurse == true) ? scope->mParent : NULL;
-  }
-
-  mLocalsHandled = true;
-}
-
-void Scope::variablesDestroy(Expr* refStmt, VarSymbol* excludeVar) const {
-  // Handle the primary locals
-  if (mLocalsHandled == false) {
-    bool   insertAfter = false;
-    size_t count       = mLocals.size();
-
-    // If this is a simple nested block, insert after the final stmt
-    // Do not get tricked by sequences of unreachable code
-    if (refStmt->next == NULL) {
-      if (mParent != NULL && isGotoStmt(refStmt) == false) {
-        insertAfter = true;
-      }
-    }
-
-    for (size_t i = 1; i <= count; i++) {
-      VarSymbol* var = mLocals[count - i];
-
-      if (var != excludeVar) {
-        if (FnSymbol* autoDestroyFn = autoDestroyMap.get(var->type)) {
-          SET_LINENO(var);
-
-          INT_ASSERT(autoDestroyFn->hasFlag(FLAG_AUTO_DESTROY_FN));
-
-          CallExpr* autoDestroy = new CallExpr(autoDestroyFn, var);
-
-          if (insertAfter == true)
-            refStmt->insertAfter (autoDestroy);
-          else
-            refStmt->insertBefore(autoDestroy);
-        }
-      }
-    }
-  }
-
-  // Handle the formal temps
-  if (isReturnStmt(refStmt) == true) {
-    size_t count = mFormalTemps.size();
-
-    for (size_t i = 1; i <= count; i++) {
-      VarSymbol* var = mFormalTemps[count - i];
-
-      if (FnSymbol* autoDestroyFn = autoDestroyMap.get(var->type)) {
-        SET_LINENO(var);
-
-        refStmt->insertBefore(new CallExpr(autoDestroyFn, var));
-      }
-    }
-  }
-}
-
-// Walk backwards from the current statement to determine if a sequence of
-// moves have copied a variable that is marked for auto destruction in to
-// the dedicated return-temp within the current scope.
-//
-// Note that the value we are concerned about may be copied in to one or
-// more temporary variables between being copied to the return temp.
-static VarSymbol* variableToExclude(FnSymbol*  fn, Expr* refStmt) {
-  VarSymbol* retVar = toVarSymbol(fn->getReturnSymbol());
-  VarSymbol* retval = NULL;
-
-  if (retVar != NULL) {
-    if (isUserDefinedRecord(retVar)    == true ||
-        fn->hasFlag(FLAG_INIT_COPY_FN) == true) {
-      VarSymbol* needle = retVar;
-      Expr*      expr   = refStmt;
-
-      // Walk backwards looking for the variable that is being returned
-      while (retval == NULL && expr != NULL && needle != NULL) {
-        if (CallExpr* move = toCallExpr(expr)) {
-          if (move->isPrimitive(PRIM_MOVE) == true) {
-            SymExpr*   lhs    = toSymExpr(move->get(1));
-            VarSymbol* lhsVar = toVarSymbol(lhs->symbol());
-
-            if (needle == lhsVar) {
-              SymExpr*   rhs    = toSymExpr(move->get(2));
-              VarSymbol* rhsVar = (rhs != NULL) ? toVarSymbol(rhs->symbol()) : NULL;
-
-              if (isAutoDestroyedVariable(rhsVar) == true)
-                retval = rhsVar;
-              else
-                needle = rhsVar;
-            }
-          }
-        }
-
-        expr = expr->prev;
-      }
-    }
-  }
-
-  return retval;
-}
-
-static bool isReturnStmt(const Expr* stmt) {
-  bool retval = false;
-
-  if (const CallExpr* expr = toConstCallExpr(stmt))
-    retval = expr->isPrimitive(PRIM_RETURN);
-
-  return retval;
-}
-
-// Find the block stmt that encloses the target of this gotoStmt
-static BlockStmt* findBlockForTarget(GotoStmt* stmt) {
-  BlockStmt* retval = NULL;
-
-  if (stmt != NULL && stmt->isGotoReturn() == false) {
-    SymExpr*   labelSymExpr = toSymExpr(stmt->label);
-    Expr*      ptr          = labelSymExpr->symbol()->defPoint;
-
-    while (ptr != NULL && isBlockStmt(ptr) == false)
-      ptr = ptr->parentExpr;
-
-    retval = toBlockStmt(ptr);
-
-    INT_ASSERT(retval);
-  }
-
-  return retval;
-}
-
-/************************************* | **************************************
-*                                                                             *
-* Common utilities                                                            *
+* A shared utilty function for resolution.                                    *
 *                                                                             *
 ************************************** | *************************************/
 
-static bool isAutoDestroyedVariable(Symbol* sym) {
+bool isAutoDestroyedVariable(Symbol* sym) {
   bool retval = false;
 
   if (VarSymbol* var = toVarSymbol(sym)) {


### PR DESCRIPTION
This is effectively a re-packaging of PR #6190.  That PR passed the conventional testing
that I do before and after a PR and also ran well on most nightly configurations but was
found to fail with a seg-fault in addAutoDestroyCalls.cpp if CHPL_DEVELOPER is set.

The issue turned out to be that addAutoDestroyCalls.cpp provided the complete definition
of a class named "Scope" and that PR #6190 introduced a new class with the same name
to scopeResolve.cpp.

The behavior when doing this is undefined.


This PR 

A. renames the Scope in scopeResolve.cpp to be ResolveScope and migrates the
declaration/implementation to be in ResolveScope.{h,cpp}

B. renames the Scope in addAutoDestroyCalls.cpp to be AutoDestroyScope and migrates
the declaration/implementation to be AutoDestroyScope.{h,cpp}


Strictly speaking the renaming would solve the immediate problem but the extra step
serves to reduce the likelihood of unintended re-definitions in the future.  I believe there
are now 5 classes that are defined within some non-descript C++ file.  They have
reasonably distinctive names but it would probably be wise to extract them when
modifying the neighboring code.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  As I touched
.h files I also compiled with CHPL_LLVM.

Ran a portion of release/ with CHPL_DEVELOPER set and, separately, with --llvm.
Passed a full single-locale paratest.



