### PR TITLE
Fix compilation segfault with --llvm

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -138,6 +138,12 @@ llvm::Value* codegenImmediateLLVM(Immediate* i)
           break;
       }
       break;
+    case NUM_KIND_COMMID:
+      ret = llvm::ConstantInt::get(
+          llvm::Type::getInt64Ty(info->module->getContext()),
+          i->commid_value(),
+          true);
+      break;
     case NUM_KIND_INT:
       switch(i->num_index) {
         case INT_SIZE_8:


### PR DESCRIPTION
Add NUM_KIND_COMMID case to codegenImmediateLLVM, otherwise the compiler segfaults.

Passed release/examples/primers