### PR TITLE
Replace all runtime calls to the system allocator with wrapper functions

### DIFF
--- a/runtime/include/chpl-mem-sys.h
+++ b/runtime/include/chpl-mem-sys.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_mem_sys_H_
+#define _chpl_mem_sys_H_
+
+// disable mem warnings since we need to call the system allocator
+#include "chpl-mem-no-warning-macros.h"
+
+#include <stdlib.h>
+#ifdef __GLIBC__
+#include <malloc.h>  // get memalign
+#endif
+
+static inline void* sys_calloc(size_t n, size_t size) {
+  return calloc(n, size);
+}
+
+static inline void* sys_malloc(size_t size) {
+  return malloc(size);
+}
+
+static inline void* sys_memalign(size_t boundary, size_t size) {
+#ifdef __GLIBC__
+  return memalign(boundary, size);
+#else
+  void* ret = NULL;
+  int rc;
+  rc = posix_memalign(&ret, boundary, size);
+  if( rc == 0 ) return ret;
+  else return NULL;
+#endif
+}
+
+static inline void* sys_realloc(void* ptr, size_t size) {
+  return realloc(ptr, size);
+}
+
+static inline void sys_free(void* ptr) {
+  free(ptr);
+}
+
+// Now that we've defined our functions, turn the warnings back on.
+#include "chpl-mem-warning-macros.h"
+
+#endif

--- a/runtime/include/chpl-mem-warning-macros.h
+++ b/runtime/include/chpl-mem-warning-macros.h
@@ -22,17 +22,6 @@
 // mem-no-warning headers can be included an arbitrary number of times to
 // disable and then re-enable the macros
 
-
-// this function gets its own ifdef so that it's not redefined
-#ifndef _chpl_mem_warning_macros_really_h_
-#define _chpl_mem_warning_macros_really_h_
-// MPF - I needed to call the system free to pair with system valloc
-// (these are for I/O buffers that don't belong on the Chapel sharable
-// heap anyway because they could be mmap'd - and then are only
-// sharable when everything is sharable)
-static inline void sys_free(void *ptr) { free(ptr); }
-#endif
-
 #define malloc  dont_use_malloc_use_chpl_mem_allocMany_instead
 #define calloc  dont_use_calloc_use_chpl_mem_allocMany_instead
 #define free    dont_use_free_use_chpl_mem_free_instead

--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -249,14 +249,14 @@ size_t chpl_mem_localizationThreshold(void) {
 
 #else // LAUNCHER
 
-#include <stdlib.h>
+#include "chpl-mem-sys.h"
 #include "arg.h"
 
 #define chpl_mem_allocMany(number, size, description, lineno, filename)        \
-  malloc((number)*(size))
+  sys_malloc((number)*(size))
 
 #define chpl_mem_free(ptr, lineno, filename)        \
-  free(ptr)
+  sys_free(ptr)
 
 #endif // LAUNCHER
 

--- a/runtime/include/mem/cstdlib/chpl-mem-impl.h
+++ b/runtime/include/mem/cstdlib/chpl-mem-impl.h
@@ -21,66 +21,40 @@
 #ifndef _chpl_mem_impl_H_
 #define _chpl_mem_impl_H_
 
-// Uses the built-in malloc, calloc, realloc and free.
-
-// disable mem warnings since cstdlib uses the system allocator
-#include "chpl-mem-no-warning-macros.h"
-
-#include <stdlib.h>
-#if defined(__APPLE__)
-#include <malloc/malloc.h>
-#endif
-
-
-#include <stdlib.h>
-
-#ifdef __GLIBC__
-// get memalign
-#include <malloc.h>
-#endif
+// Uses the system allocator
+#include "chpl-mem-sys.h"
 
 static inline void* chpl_calloc(size_t n, size_t size) {
-  return calloc(n,size);
+  return sys_calloc(n,size);
 }
 
 static inline void* chpl_malloc(size_t size) {
-  return malloc(size);
+  return sys_malloc(size);
 }
 
 static inline void* chpl_memalign(size_t boundary, size_t size) {
-#ifdef __GLIBC__
-  return memalign(boundary, size);
-#else
-  void* ret = NULL;
-  int rc;
-  rc = posix_memalign(&ret, boundary, size);
-  if( rc == 0 ) return ret;
-  else return NULL;
-#endif
+  return sys_memalign(boundary, size);
 }
 
 static inline void* chpl_realloc(void* ptr, size_t size) {
-  return realloc(ptr,size);
+  return sys_realloc(ptr,size);
 }
 
 static inline void chpl_free(void* ptr) {
-  free(ptr);
+  sys_free(ptr);
 }
 
 // malloc_good_size is OSX specific unfortunately. On other platforms just
 // return minSize.
 static inline size_t chpl_good_alloc_size(size_t minSize) {
 #if defined(__APPLE__)
+  #include <malloc/malloc.h>
   return malloc_good_size(minSize);
 #else
   return minSize;
 #endif
 }
 
-// Now that we've defined our functions, turn the warnings back on.
-#include "chpl-mem-warning-macros.h"
-
 #define CHPL_USING_CSTDLIB_MALLOC 1
-
 
 #endif

--- a/runtime/include/qio/deque.h
+++ b/runtime/include/qio/deque.h
@@ -45,8 +45,9 @@
 #define deque_free(ptr) chpl_mem_free(ptr, 0, 0)
 #define deque_memcpy(dest, src, num) chpl_memcpy(dest, src, num)
 #else
-#define deque_calloc(nmemb, size) calloc(nmemb,size)
-#define deque_free(ptr) free(ptr)
+#include "chpl-mem-sys.h"
+#define deque_calloc(nmemb, size) sys_calloc(nmemb,size)
+#define deque_free(ptr) sys_free(ptr)
 #define deque_memcpy(dest, src, num) memcpy(dest, src, num)
 #endif
 

--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -474,6 +474,24 @@ qioerr qbuffer_memset(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end, 
 #define qio_free(ptr) chpl_mem_free(ptr, 0, 0)
 #define qio_memcpy(dest, src, num) chpl_memcpy(dest, src, num)
 
+typedef chpl_bool qio_bool;
+
+#else
+
+#include "chpl-mem-sys.h"
+
+#define qio_malloc(size) sys_malloc(size)
+#define qio_calloc(nmemb, size) sys_calloc(nmemb,size)
+#define qio_realloc(ptr, size) sys_realloc(ptr, size)
+#define qio_memalign(boundary, size) sys_memalign(boundary, size)
+#define qio_free(ptr) sys_free(ptr)
+#define qio_memcpy(dest, src, num) memcpy(dest, src, num)
+
+typedef bool qio_bool;
+
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -487,24 +505,6 @@ static inline char* qio_strdup(const char* ptr)
 
 #ifdef __cplusplus
 } // end extern "C"
-#endif
-
-typedef chpl_bool qio_bool;
-
-#else
-
-#include "chpl-mem-sys.h"
-
-#define qio_malloc(size) sys_malloc(size)
-#define qio_calloc(nmemb, size) sys_calloc(nmemb,size)
-#define qio_realloc(ptr, size) sys_realloc(ptr, size)
-#define qio_memalign(boundary, size) sys_memalign(boundary, size)
-#define qio_free(ptr) sys_free(ptr)
-#define qio_strdup(ptr) strdup(ptr)
-#define qio_memcpy(dest, src, num) memcpy(dest, src, num)
-
-typedef bool qio_bool;
-
 #endif
 
 // Declare MAX_ON_STACK bytes. We declare it with the original

--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -470,7 +470,7 @@ qioerr qbuffer_memset(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end, 
 #define qio_malloc(size) chpl_mem_alloc(size, CHPL_RT_MD_IO_BUFFER, 0, 0)
 #define qio_calloc(nmemb, size) chpl_mem_allocManyZero(nmemb, size, CHPL_RT_MD_IO_BUFFER, 0, 0)
 #define qio_realloc(ptr, size) chpl_mem_realloc(ptr, size, CHPL_RT_MD_IO_BUFFER, 0, 0)
-#define qio_valloc(size) chpl_valloc(size)
+#define qio_memalign(boundary, size)  chpl_memalign(boundary, size)
 #define qio_free(ptr) chpl_mem_free(ptr, 0, 0)
 #define qio_memcpy(dest, src, num) chpl_memcpy(dest, src, num)
 
@@ -494,12 +494,11 @@ typedef chpl_bool qio_bool;
 #else
 
 #include "chpl-mem-sys.h"
-#include "sys.h"
 
 #define qio_malloc(size) sys_malloc(size)
 #define qio_calloc(nmemb, size) sys_calloc(nmemb,size)
 #define qio_realloc(ptr, size) sys_realloc(ptr, size)
-#define qio_valloc(size) sys_memalign(sys_page_size(), size)
+#define qio_memalign(boundary, size) sys_memalign(boundary, size)
 #define qio_free(ptr) sys_free(ptr)
 #define qio_strdup(ptr) strdup(ptr)
 #define qio_memcpy(dest, src, num) memcpy(dest, src, num)

--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -493,11 +493,14 @@ typedef chpl_bool qio_bool;
 
 #else
 
-#define qio_malloc(size) malloc(size)
-#define qio_calloc(nmemb, size) calloc(nmemb,size)
-#define qio_realloc(ptr, size) realloc(ptr, size)
-#define qio_valloc(size) valloc(size)
-#define qio_free(ptr) free(ptr)
+#include "chpl-mem-sys.h"
+#include "sys.h"
+
+#define qio_malloc(size) sys_malloc(size)
+#define qio_calloc(nmemb, size) sys_calloc(nmemb,size)
+#define qio_realloc(ptr, size) sys_realloc(ptr, size)
+#define qio_valloc(size) sys_memalign(sys_page_size(), size)
+#define qio_free(ptr) sys_free(ptr)
 #define qio_strdup(ptr) strdup(ptr)
 #define qio_memcpy(dest, src, num) memcpy(dest, src, num)
 

--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -498,8 +498,9 @@ extern "C" {
 
 static inline char* qio_strdup(const char* ptr)
 {
-  char* ret = (char*) qio_malloc(strlen(ptr)+1);
-  if( ret ) strcpy(ret, ptr);
+  size_t len = strlen(ptr) + 1;
+  char* ret = (char*) qio_malloc(len);
+  if( ret ) qio_memcpy(ret, ptr, len);
   return ret;
 }
 

--- a/runtime/src/chpl-mem-replace-malloc.c
+++ b/runtime/src/chpl-mem-replace-malloc.c
@@ -231,7 +231,7 @@ int posix_memalign(void **memptr, size_t alignment, size_t size)
     *memptr = NULL;
     ret = chpl_posix_memalign_check_valid(alignment);
     if( ret ) return ret;
-    *memptr = memalign(alignment, size);
+    *memptr = __libc_memalign(alignment, size);
     if( ! *memptr ) return ENOMEM;
     if( DEBUG_REPLACE_MALLOC ) 
       printf("in early posix_memalign %p = system posix_memalign(%#x)\n",

--- a/runtime/src/chpl-string-support.c
+++ b/runtime/src/chpl-string-support.c
@@ -77,22 +77,6 @@ c_string_copy chpl_format(c_string format, ...) {
 }
 
 
-//
-// We need an allocator for the rest of the code, but for the user
-// program it needs to be a locale-aware one with tracking, while for
-// the launcher the regular system one will do.
-//
-static inline void*
-chpltypes_malloc(size_t size, chpl_mem_descInt_t description,
-                 int32_t lineno, int32_t filename) {
-#ifndef LAUNCHER
-  return chpl_mem_alloc(size, description, lineno, filename);
-#else
-  return malloc(size);
-#endif
-}
-
-
 c_string_copy
 string_copy(c_string x, int32_t lineno, int32_t filename)
 {
@@ -102,8 +86,8 @@ string_copy(c_string x, int32_t lineno, int32_t filename)
   if (x == NULL)
     return NULL;
 
-  z = (char*)chpltypes_malloc(strlen(x)+1, CHPL_RT_MD_STR_COPY_DATA,
-                              lineno, filename);
+  z = (char*)chpl_mem_allocMany(1, strlen(x)+1, CHPL_RT_MD_STR_COPY_DATA,
+                                lineno, filename);
   return strcpy(z, x);
 }
 
@@ -122,9 +106,9 @@ string_concat(c_string x, c_string y, int32_t lineno, int32_t filename) {
   xlen = strlen(x);
   ylen = strlen(y);
 
-  z = (char*)chpltypes_malloc(xlen + ylen + 1,
-                              CHPL_RT_MD_STR_CONCAT_DATA,
-                              lineno, filename);
+  z = (char*)chpl_mem_allocMany(1, xlen + ylen + 1,
+                                CHPL_RT_MD_STR_CONCAT_DATA,
+                                lineno, filename);
 
   // memcpy can be more efficient than the str??? functions because it does not
   // look for terminating NUL characters.  We are guaranteed that the source
@@ -159,8 +143,8 @@ string_select(c_string x, int low, int high, int stride, int32_t lineno, int32_t
   if (high < low) return NULL;
 
   size = high - low + 1;
-  result = chpltypes_malloc(size + 1, CHPL_RT_MD_STR_SELECT_DATA,
-                            lineno, filename);
+  result = chpl_mem_allocMany(1, size + 1, CHPL_RT_MD_STR_SELECT_DATA,
+                              lineno, filename);
   src = stride > 0 ? x + low - 1 : x + high - 1;
   dst = result;
   if (stride == 1) {
@@ -191,8 +175,8 @@ string_index(c_string x, int i, int32_t lineno, int32_t filename) {
   {
     return NULL;
   }
-  buffer = chpltypes_malloc(2, CHPL_RT_MD_STR_COPY_DATA,
-                            lineno, filename);
+  buffer = chpl_mem_allocMany(1, 2, CHPL_RT_MD_STR_COPY_DATA,
+                              lineno, filename);
   sprintf(buffer, "%c", x[i-1]);
   return buffer;
 }

--- a/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
+++ b/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
@@ -344,7 +344,7 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
       break;
   }
 
-  free(aprun_cmd);
+  chpl_mem_free(aprun_cmd);
 
   if (generate_qsub_script) {
     fprintf(qsubScript, "\n\n");

--- a/runtime/src/qio/auxFilesys/hdfs/qio_plugin_hdfs.c
+++ b/runtime/src/qio/auxFilesys/hdfs/qio_plugin_hdfs.c
@@ -498,8 +498,8 @@ char* get_locale_name(char *loc)
   int len = strcspn (loc, keys);
   ret = (char*) qio_malloc(len+1);
   if (ret) {
-    ret[len] = '\0';
     qio_memcpy(ret, loc, len);
+    ret[len] = '\0';
   }
   return ret;
 }

--- a/runtime/src/qio/auxFilesys/hdfs/qio_plugin_hdfs.c
+++ b/runtime/src/qio/auxFilesys/hdfs/qio_plugin_hdfs.c
@@ -493,10 +493,15 @@ const qio_file_functions_ptr_t hdfs_function_struct_ptr = &hdfs_function_struct;
 static
 char* get_locale_name(char *loc)
 {
+  char* ret = NULL;
   const char *keys = "."; // We lop off the .us.cray...
-  int i = strcspn (loc, keys);
-
-  return strndup(loc, i);
+  int len = strcspn (loc, keys);
+  ret = (char*) qio_malloc(len+1);
+  if (ret) {
+    ret[len] = '\0';
+    qio_memcpy(ret, loc, len);
+  }
+  return ret;
 }
 
 qioerr hdfs_locales_for_range(void* file, off_t start_byte, off_t end_byte, const char*** loc_names_out, int* num_locs_out, void* fs) 

--- a/runtime/src/qio/qbuffer.c
+++ b/runtime/src/qio/qbuffer.c
@@ -148,14 +148,8 @@ qioerr _qbytes_init_iobuf(qbytes_t* ret)
 {
   void* data = NULL;
   
-  // allocate 4K-aligned (or page size aligned)
-  // multiple of 4K
-  data = qio_valloc(qbytes_iobuf_size);
+  data = qio_memalign(sys_page_size(), qbytes_iobuf_size);
   if( !data ) return QIO_ENOMEM;
-  // We used to use posix_memalign, but that didn't work on an old Mac;
-  // also, this should be page-aligned (vs iobuf_size aligned).
-  //err_t err = posix_memalign(&data, qbytes_iobuf_size, qbytes_iobuf_size);
-  //if( err ) return err;
   memset(data, 0, qbytes_iobuf_size);
 
   // The ref count in ret is initially 1.

--- a/runtime/src/qio/qio_popen.c
+++ b/runtime/src/qio/qio_popen.c
@@ -23,6 +23,7 @@
 #include "chplrt.h"
 #endif
 
+#include "chpl-mem-sys.h" // need to call system allocator
 #include "qio.h"
 #include "sys.h"
 
@@ -35,9 +36,6 @@
 #include <spawn.h>
 
 #include <pthread.h>
-
-// We need to be able to call malloc, free, etc.
-#include "chpl-mem-no-warning-macros.h"
 
 // current environment variables
 extern char** environ;
@@ -57,7 +55,7 @@ extern char** environ;
 const char* qio_spawn_strdup(const char* str)
 {
   size_t len = strlen(str);
-  char* ret = malloc(len + 1);
+  char* ret = sys_malloc(len + 1);
   // note: also copies '\0' at end of string.
   memcpy(ret, str, len + 1);
   return ret;
@@ -65,18 +63,18 @@ const char* qio_spawn_strdup(const char* str)
 
 const char** qio_spawn_allocate_ptrvec(size_t count)
 {
-  char** ret = calloc(count, sizeof(char*));
+  char** ret = sys_calloc(count, sizeof(char*));
   return (const char**) ret;
 }
 
 void qio_spawn_free_ptrvec(const char** args)
 {
-  free((void*) args);
+  sys_free((void*) args);
 }
 
 void qio_spawn_free_str(const char* str)
 {
-  free((void*) str);
+  sys_free((void*) str);
 }
 
 

--- a/test/io/ferguson/ctests/qio_bits_test.test.c
+++ b/test/io/ferguson/ctests/qio_bits_test.test.c
@@ -204,8 +204,8 @@ void check_write_read_pat(int width, int num, int pat, qio_chtype_t type, qio_hi
          width, num, pat, type,
          fhints, (int) file_hints, chhints, (int) ch_hints,  (int) reopen);
 
-  free(fhints);
-  free(chhints);
+  qio_free(fhints);
+  qio_free(chhints);
 
   if( memory ) {
     err = qio_file_open_mem_ext(&f, NULL, QIO_FDFLAG_READABLE|QIO_FDFLAG_WRITEABLE|QIO_FDFLAG_SEEKABLE, file_hints, NULL);

--- a/test/io/ferguson/ctests/qio_formatted_test.test.c
+++ b/test/io/ferguson/ctests/qio_formatted_test.test.c
@@ -800,7 +800,7 @@ void string_escape_tests()
               assert( got_len == input_len );
               assert( memcmp(got, input, got_len) == 0 );
 
-              free((void*) got);
+              qio_free((void*) got);
             }
      
             qio_channel_release(reading);
@@ -838,7 +838,7 @@ void write_65k_test()
         err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style);
         assert(!err);
 
-	p = (char *)calloc(1, buflen);
+	p = (char *)qio_calloc(1, buflen);
 	if(!p){ assert(0); }
 	memset(p, 'A', buflen);
 
@@ -856,7 +856,7 @@ void write_65k_test()
 			if(memcmp(out, p, buflen)!=0){
 				assert(0);
 			}
-			free((void*) out); out=NULL;
+			qio_free((void*) out); out=NULL;
 		}
 		if(err>0){ break; }
 	}
@@ -868,7 +868,7 @@ void write_65k_test()
         qio_file_release(f);
         f = NULL;
 
-	free(p);
+	qio_free(p);
 }
 
 /**
@@ -912,7 +912,7 @@ void max_width_test()
                 assert(0);
         }
 
-        free((void*) out);
+        qio_free((void*) out);
 
         qio_file_release(f);
         f = NULL;
@@ -960,7 +960,7 @@ void min_width_test()
 		assert(0);
 	}
 
-        free((void*) out);
+        qio_free((void*) out);
 
         qio_file_release(f);
         f = NULL;
@@ -1062,12 +1062,12 @@ void basicstring_test()
 
 			if(memcmp(out, string->string, string->length) != 0){
 				printf("FAIL: style %d, string='%s'\n", x, string->string);
-				free((void*) out);
+				qio_free((void*) out);
 				assert(0);
 			}
 
 			//printf("PASS: style %d\n", x);
-			if(out){ free((void*) out); out=NULL; }
+			if(out){ qio_free((void*) out); out=NULL; }
 		}
 	}
 
@@ -1454,7 +1454,7 @@ void test_quoted_string_maxlength(void)
         assert(ti.ret_chars == truncate_len);
         assert(truncate_len == strlen(got));
         assert( 0 == memcmp(got, input, truncate_len) );
-        free((void*) got);
+        qio_free((void*) got);
       }
 
       // Now, check that qio_quote_string returns the correct string.
@@ -1465,7 +1465,7 @@ void test_quoted_string_maxlength(void)
       assert(ti.ret_bytes == expect_len);
       assert(ti.ret_bytes == strlen(got));
       assert( 0 == strcmp(got, expect) );
-      free((void*) got);
+      qio_free((void*) got);
 
       // Now, check that the quoting works correctly when writing.
 

--- a/test/io/ferguson/ctests/qio_test.test.c
+++ b/test/io/ferguson/ctests/qio_test.test.c
@@ -88,11 +88,11 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
          (int) unbounded_channels,
          (int) reopen );
   }
-  free(fhints);
-  free(chhints);
+  qio_free(fhints);
+  qio_free(chhints);
 
-  chunk = malloc(chunksz);
-  got_chunk = malloc(chunksz);
+  chunk = qio_malloc(chunksz);
+  got_chunk = qio_malloc(chunksz);
 
   assert(chunk);
   assert(got_chunk);
@@ -279,8 +279,8 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
     unlink(filename);
   }
 
-  free(chunk);
-  free(got_chunk);
+  qio_free(chunk);
+  qio_free(got_chunk);
 }
 
 void check_channels(void)

--- a/test/regexp/ferguson/ctests/regexp_channel_test.cc
+++ b/test/regexp/ferguson/ctests/regexp_channel_test.cc
@@ -219,8 +219,8 @@ void check_channel(qio_hint_t file_hints, qio_hint_t ch_hints, char unbounded_ch
          discard_check_mask,
          allow_buffer_search,
 	 idx );
-  free(fhints);
-  free(chhints);
+  qio_free(fhints);
+  qio_free(chhints);
 
   printf("[%d] '%s' vs '%s'\n", test->kind, test->data, test->pattern);
 


### PR DESCRIPTION
Add sys_{malloc, calloc, realloc, memalign, free} wrappers and use them instead
of directly calling the system allocator. This allows the lookForBadAlloc
script (added in #6163) to run cleanly.

Generally speaking, we want our runtime to call the chapel allocator, instead
of the system one. This can offer better performance, and more importantly for
cases where the heap is registered, we usually want allocations in the runtime
to be registered as well. It also allows us to track memory allocations via
'chplmemtrack'. There are a few special cases where we need to call the system
allocator (memory layer not initialized yet, want non-registered memory.) Those
few cases now call the sys_ wrappers instead of directly calling the system
allocator.

Historically, we've enforced our "don't use the system allocator" policy with
'chpl-mem-warning-macros.h/chpl-mem-no-warning-macros.h/', which does something
like "#define malloc dont_use_malloc_use_chpl_mem_allocMany_instead". This
approach has a couple unfortunate downsides:
 - It prevents the token "malloc" from being used, not just calls the function
   so we have to turn off the warnings in more places than ideal
 - It causes portability issues (especially on cygwin). We define malloc
   before including system headers in many files, and so if a system header
   uses the token malloc, we fail to build. e.g.
    - https://github.com/chapel-lang/chapel/commit/95272793b4
    - https://github.com/chapel-lang/chapel/commit/59e3f5e5bb

This patch allows the ./util/devel/lookForBadAlloc script to pass. My intention
is to use that script to check that we're not mistakenly calling the system
allocator and retire chpl-mem-warning-macros.h.

Beyond changing calls to the system allocators to use the sys_ wrappers, there
are some minor cleanups, behavior changes, and bugfixes exposed by this effort:
 - fix mismatched call to system strndup and qio_free (hdfs bug)
 - fix chpl-mem-replace-malloc.c memalign call to __libc_memalign (memtrack bug)
 - remove chpltypes_malloc wrapper, which duplicated chpl_mem_allocMany logic
 - qbytes_iobuf is now system page aligned instead of heap page aligned
   - wastes less space when hugepages are used
   - may want to use system allocator for qbytes_iobuf in the future