### PR TITLE
"make check" saves stdout/stderr from chpl compilation in memory, not tmp file

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -152,15 +152,12 @@ TEST_JOB=${TEST_JOB_BASENAME}
 chpl_comm="$($CHPL_HOME/util/chplenv/chpl_comm.py)"
 chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"
 
-# Log file for compile output
-TEST_COMP_OUT=${TEST_JOB}.comp.out
-
 # Necessary to suppress warnings when WARNINGS=1 (e.g. nightly build settings)
 COMP_FLAGS="--cc-warnings"
 
 # Compile test job into temporary directory
 log_info "Compiling \$CHPL_HOME/${REL_TEST_DIR}/${TEST_JOB}.chpl"
-${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} > ${TMP_TEST_DIR}/${TEST_COMP_OUT} 2>&1
+TEST_COMP_OUT=$( ${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} 2>&1 )
 COMPILE_STATUS=$?
 
 # Check that compile was successful
@@ -169,13 +166,13 @@ log_debug "Compilation exit status was ${COMPILE_STATUS}"
 if [ ${COMPILE_STATUS} -ne 0 ]; then
     log_error "Test job failed to compile - Chapel is not installed correctly"
     log_error "Compilation output:"
-    cat ${TMP_TEST_DIR}/${TEST_COMP_OUT}
+    echo "${TEST_COMP_OUT}"
     log_debug "Exit \"make check\" script with status code 1"
     exit 1
-elif [ -s ${TMP_TEST_DIR}/${TEST_COMP_OUT} ]; then
+elif [ -n "${TEST_COMP_OUT}" ]; then
     log_error "Test job compiled with output - Chapel is not installed correctly"
     log_error "Compilation output:"
-    cat ${TMP_TEST_DIR}/${TEST_COMP_OUT}
+    echo "${TEST_COMP_OUT}"
     log_debug "Exit \"make check\" script with status code 1"
     exit 1
 else


### PR DESCRIPTION
    "make check" saves stdout/stderr from chpl compilation in memory, not tmp file
    
    A "disk full" on $HOME file system should not prevent us from seeing the "disk full" error messages.