### PR TITLE
Delete the root locale upon program termination

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -661,4 +661,11 @@ module ChapelLocale {
   proc chpl_taskRunningCntDec() {
     here.runningTaskCntSub(1);
   }
+
+  //
+  // Free the original root locale when the program is being torn down
+  //
+  proc deinit() {
+    delete origRootLocale;
+  }
 }

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -218,6 +218,11 @@ module LocaleModel {
       // node.
       return myLocales[chpl_rt_nodeFromLocaleID(id)];
     }
+
+    proc deinit() {
+      for loc in myLocales do
+        delete loc;
+    }
   }
 
   //////////////////////////////////////////

--- a/test/modules/vass/deinit-order-modules.verbose.good
+++ b/test/modules/vass/deinit-order-modules.verbose.good
@@ -34,3 +34,4 @@ uv4ae.deinit UC
   DefaultRectangular
   ChapelArray
   Sort
+  ChapelLocale


### PR DESCRIPTION
It was pointed out last week that we don't ever clean up the locale
classes, which prevents locale model authors from making clean-up
steps during program teardown.  This seems like an oversight, and
one that looks easy to correct.

TODO:
- [x] valgrind testing
- [x] gasnet testing
- [x] regular testing
- [x] review each locale model to see whether any need deinit() routines on their classes
  - to be done after the fact for numa and knl by @gbtitus and @dmk42 