### PR TITLE
Don't heap promote locals used in on statements under qthreads

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1037,14 +1037,14 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
 //  CHPL_COMM == "gasnet" && CHPL_GASNET_SEGMENT == "everything";
 // or
 //  CHPL_STACK_CHECKS == 0 && CHPL_TASKS == "fifo"
+// or
+//  CHPL_TASKS == "qthreads"
 //
 // true otherwise.
 //
-// The tasking layer matters because fifo allocates
-// from task stacks the communication registered heap
-// (unless stack checks is on, in which case it might not
-//  be possible because of huge pages).
-// In the future, we hope that all tasking layers do this.
+// The tasking layer matters because qthreads and fifo allocate task stacks
+// from the communication registered heap (fifo can only do so if stack checks
+// are turned off.)
 static bool
 needHeapVars() {
   if (fLocal) return false;
@@ -1055,6 +1055,9 @@ needHeapVars() {
     return false;
 
   if (fNoStackChecks && (0 == strcmp(CHPL_TASKS, "fifo")))
+    return false;
+
+  if (0 == strcmp(CHPL_TASKS, "qthreads"))
     return false;
 
   return true;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -5701,9 +5701,7 @@ void do_fork_post(int locale,
     // it's mapped, and give the target locale that instead of the one
     // on our stack.
     //
-    // This happens when comm=ugni is used with tasks=fifo.  Tasks use
-    // the pthread stack, which is allocated by the pthreads library
-    // directly from malloc(), and thus isn't mapped.
+    // This can happen if task stacks aren't in the registered heap.
     //
     mem_region_t* rf_done_mr;
 


### PR DESCRIPTION
As of https://github.com/chapel-lang/chapel/pull/5637, qthread task stacks are
part of the registered heap, so there is no need promote locals used in on
statements anymore.