### PR TITLE
Fix call to chpl_mem_free in launch-pbs-aprun.c

### DIFF
--- a/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
+++ b/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
@@ -344,7 +344,7 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
       break;
   }
 
-  chpl_mem_free(aprun_cmd);
+  chpl_mem_free(aprun_cmd, 0, 0);
 
   if (generate_qsub_script) {
     fprintf(qsubScript, "\n\n");


### PR DESCRIPTION
In #6197 I changed a call to free to chpl_mem_free, but I forgot to add dummy
lineno and filename args.