### PR TITLE
Move chpl_getPrivatizedClass() into chpl-privatization.h

### DIFF
--- a/runtime/include/chpl-privatization.h
+++ b/runtime/include/chpl-privatization.h
@@ -29,8 +29,8 @@ void chpl_newPrivatizedClass(void*, int64_t);
 
 // Implementation is here for performance: getPrivatizedClass can be called
 // frequently, so putting it in a header allows the backend to fully optimize.
+extern void** chpl_privateObjects;
 static inline void* chpl_getPrivatizedClass(int64_t i) {
-  extern void** chpl_privateObjects;
   return chpl_privateObjects[i];
 }
 

--- a/runtime/include/chpl-privatization.h
+++ b/runtime/include/chpl-privatization.h
@@ -23,8 +23,6 @@
 #include <stdint.h>
 #include "chpltypes.h"
 
-extern void** chpl_privateObjects;
-
 void chpl_privatization_init(void);
 
 void chpl_newPrivatizedClass(void*, int64_t);
@@ -32,6 +30,7 @@ void chpl_newPrivatizedClass(void*, int64_t);
 // Implementation is here for performance: getPrivatizedClass can be called
 // frequently, so putting it in a header allows the backend to fully optimize.
 static inline void* chpl_getPrivatizedClass(int64_t i) {
+  extern void** chpl_privateObjects;
   return chpl_privateObjects[i];
 }
 

--- a/runtime/include/chpl-privatization.h
+++ b/runtime/include/chpl-privatization.h
@@ -23,10 +23,18 @@
 #include <stdint.h>
 #include "chpltypes.h"
 
+extern void** chpl_privateObjects;
+
 void chpl_privatization_init(void);
 
 void chpl_newPrivatizedClass(void*, int64_t);
-void* chpl_getPrivatizedClass(int64_t);
+
+// Implementation is here for performance: getPrivatizedClass can be called
+// frequently, so putting it in a header allows the backend to fully optimize.
+static inline void* chpl_getPrivatizedClass(int64_t i) {
+  return chpl_privateObjects[i];
+}
+
 void chpl_clearPrivatizedClass(int64_t);
 
 int64_t chpl_numPrivatizedClasses(void);

--- a/runtime/src/chpl-privatization.c
+++ b/runtime/src/chpl-privatization.c
@@ -25,7 +25,7 @@
 static int64_t chpl_capPrivateObjects = 0;
 static chpl_sync_aux_t privatizationSync;
 
-static void** chpl_privateObjects = NULL;
+void** chpl_privateObjects = NULL;
 
 void chpl_privatization_init(void) {
     chpl_sync_initAux(&privatizationSync);
@@ -70,12 +70,6 @@ void chpl_newPrivatizedClass(void* v, int64_t pid) {
   chpl_sync_unlock(&privatizationSync);
 }
 
-
-void* chpl_getPrivatizedClass(int64_t i) {
-  return chpl_privateObjects[i];
-}
-
-
 void chpl_clearPrivatizedClass(int64_t i) {
   chpl_sync_lock(&privatizationSync);
   chpl_privateObjects[i] = NULL;
@@ -93,4 +87,3 @@ int64_t chpl_numPrivatizedClasses(void) {
   chpl_sync_unlock(&privatizationSync);
   return ret;
 }
-


### PR DESCRIPTION
This is a second attempt at #6198, but only moves chpl_getPrivatizedClass()
instead of the entire privatization implementation. chpl_getPrivatizedClass()
is just a getter for chpl_privateObjects, so we also need to extern to
chpl_privateObjects.

chpl_getPrivatizedClass() can be called frequently, so we want to allow the
backend compiler to fully optimize/inline calls to it. This has a pretty big
performance impact for the stencil PRK, improving performance by about 15% for
16-node-xc. There's also some minor improvements for fft, and lulesh.

This is motivated by #6184, though it's not quite enough to close that issue
yet.