### PR TITLE
Add multilocale MPI nightly testing

### DIFF
--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -12,7 +12,8 @@ set -x
 : confirm mpi module is loaded
 module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
 
-export MPICH_MAX_THREAD_SAFETY=multiple
+# Suppress the suggestion of using 'ibv' GASNet conduit
+export GASNET_QUIET=1
 
 export CHPL_TARGET_COMPILER=mpi-gnu
 export CHPL_TASKS=fifo

--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Test CHPL_COMM=gasnet && CHPL_TARGET_COMPILER=mpi-gnu for MPI module testing
+#
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+
+echo >&2 module load mpi
+module load mpi
+
+set -x
+: confirm mpi module is loaded
+module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
+
+export MPICH_MAX_THREAD_SAFETY=multiple
+
+export CHPL_TARGET_COMPILER=mpi-gnu
+export CHPL_TASKS=fifo
+export CHPL_COMM=gasnet
+export CHPL_COMM_SUBSTRATE=mpi
+
+export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl modules/packages/mpi"
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="mpicc.gasnet"
+
+$CWD/nightly -cron -no-buildcheck ${nightly_args}


### PR DESCRIPTION
Currently we test SPMD MPI nightly, which was added in #5380.

This PR extends testing to multilocale MPI as well.

Note that environment variables for multilocale MPI are not set in the test script:

```bash
MPICH_MAX_THREAD_SAFETY=multiple
AMMPI_MPI_THREAD=multiple         # if CHPL_COMM_SUBSTRATE=mpi
```
.. because we rely on the execenvs of the test directory.

Also note that we test the directory `modules/packages/mpi` and rely on the skipifs to select the correct subset of mpi tests, in this case, `modules/packages/mpi/multilocale`.

Remaining setup / testing:

- [x] Setup JJB for this test (PR open)
- [x] Test this script
