### PR TITLE
Updated directories in historify-logs

### DIFF
--- a/util/cron/historify-logs
+++ b/util/cron/historify-logs
@@ -17,13 +17,14 @@ loghome=/data/sea/chapel
 loghistdir=/data/sea/chapel/NightlyHistory
 logsources="\
 Nightly \
-NightlyDists \
 NightlyMemLeaks \
 NightlyPerformance/bradc-lnx \
 NightlyPerformance/chap01 \
 NightlyPerformance/chap04 \
 NightlyPerformance/chap08 \
 NightlyPerformance/chap12 \
+NightlyPerformance/chapcs \
+NightlyPerformance/shootout \
 "
 
 # logs for "Cray hardware" configurations


### PR DESCRIPTION
Added NightlyPerformance/{chapcs,shootout}.
Logs from many nightly performance runs are there.

Removed NightlyDists.
We deleted this directory recently.

I also considered having nightly performance runs
put logs under Nightly/ where the other logs are.
However Tony expressed a concern that there would be
too many files in that directory.

Discussed with Elliot and Tony.
