### PR TITLE
Fix two --baseline regressions

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -825,20 +825,22 @@ buildGetValue(IteratorInfo* ii, BlockStmt* singleLoop) {
   INT_ASSERT(my_this == ii->getValue->_this);
   map.put(advance_this, my_this);
 
-  VarSymbol* tmp         = newTemp(ii->getValue->retType);
-  getValueBody->insertAtTail(new DefExpr(tmp));
 
   if (singleLoop && singleLoop->isForLoop())
   {
     INT_FATAL(singleLoop, "Unexpected singleLoop iterator type");
   }
-  else
+  else if (ii->getValue->retType != dtVoid)
   {
+    VarSymbol* tmp = newTemp(ii->getValue->retType);
+    getValueBody->insertAtTail(new DefExpr(tmp));
     getValueBody->insertAtTail(new CallExpr(PRIM_MOVE, tmp,
                                             new CallExpr(PRIM_GET_MEMBER_VALUE,
                                                          my_this, ii->iclass->getField("value"))));
+    getValueBody->insertAtTail(new CallExpr(PRIM_RETURN, tmp));
+  } else {
+    getValueBody->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));
   }
-  getValueBody->insertAtTail(new CallExpr(PRIM_RETURN, tmp));
 
   ii->getValue->body->replace(getValueBody);
 }


### PR DESCRIPTION
In the iterator `getValue()` function, if the return type is `void` then
return the global void value instead of trying to look up the field in the
iterator class.

This problem didn't show up in regular testing because
deadCodeElimination covered it up.

This fixes the `--baseline` regressions for:
```
functions/iterators/diten/yieldNothingIterator
functions/iterators/diten/yieldVoidIterators
```

Tested with:
```
paratest -compopts --baseline (one regression remains)
paratest -compopts --verify (clean)
```