### PR TITLE
Update the .bad file after my generic instantiation change

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
@@ -1,8 +1,1 @@
-chameneosredux-blc-ideal.chpl:21: internal error: MIS0491 chpl Version 1.16.0 pre-release (5d73d1c)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+chameneosredux-blc-ideal.chpl:55: error: Generic records that define initializers are not yet supported, stay tuned!


### PR DESCRIPTION
Prior to my #6209 to support type constructors and declarations of generic
instantiations, this test was failing with an internal compiler segfault.  As
part of my change, I added an error message with generic records that define
initializers, because the error mode they would encounter was not specifically
related to them rather than something due to them and sometimes due to the
type constructor issue.  Update the .bad file to reflect this new error mode.

I'm going to check a fresh checkout before merging