### PR TITLE
Remove obsolete warning flags

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -115,8 +115,7 @@ endif
 # Flags for turning on warnings for C++/C code
 #
 WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing -Wmissing-declarations
-# decl-after-stmt for non c99 compilers. See commit message 21665
-WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wdeclaration-after-statement -Wmissing-format-attribute
+WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized
 

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -145,8 +145,7 @@ GEN_CFLAGS += $(C_STD)
 # Flags for turning on warnings for C++/C code
 #
 WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing
-# decl-after-stmt for non c99 compilers. See commit message 21665
-WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wdeclaration-after-statement -Wmissing-format-attribute
+WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized
 

--- a/make/compiler/Makefile.pathscale
+++ b/make/compiler/Makefile.pathscale
@@ -58,8 +58,7 @@ CXX11_STD := unknown
 # Flags for turning on warnings for C++/C code
 #
 WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings
-# decl-after-stmt for non c99 compilers. See commit message 21665
-WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wdeclaration-after-statement -Wmissing-format-attribute
+WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -Wno-unused
 


### PR DESCRIPTION
This change removes the obsolete warning flags `-Wnested-externs` and `-Wdeclaration-after-statement` from C compilation.  The effect of removing these two warnings is that now declarations can appear closer to where the identifier is used (if desired), which can make code easier to read.

This is the result of a discussion with @ronawho , @gbtitus , and @bradcray .  It reverts change https://github.com/chapel-lang/chapel/commit/c8da236e7114a59e20c17510667e151242ab6223 from 2006.

`-Wdeclaration-after-statement` was a way to ensure all declarations occurred at the top of their block, to stay compatible with C90 compilers.  We are now completely dependent on C99 and later, e.g. because of inline functions, so there is no need to restrict the code to the older standard.

There was an earlier desire to remove `-Wdeclaration-after-statement` but it was not removed at that time, because MSVC did not support C99 mixed declarations and code.  As of MSVC 2013, though, it does:

https://blogs.msdn.microsoft.com/vcblog/2013/06/28/c1114-stl-features-fixes-and-breaking-changes-in-vs-2013/

In addition, MSVC is not a complete C99 compiler and probably never will be, so it is not clear that we could ever use it (although it does adopt a random collection of C99 features).  The Intel compiler is available as a plugin to Visual Studio, and those who care about C use it that way.

Some old K&amp;R compilers used to give all `extern` declarations file scope, even if they were inside a function.  `-Wnested-externs` was a way to avoid tickling this minor difference among compilers.  Since before C99, though, vendors have bundled C and C\+\+ together in the same compiler, and `extern` declarations within a block are given block scope, because doing otherwise would cause a gratuitous difference between a compiler's C mode and its C\+\+ mode.  No known C99 or later compiler gives file scope to `extern` declarations within a block.

MSVC's `/Za` option, which they recommend for portable code, also gives block scope to `extern` declarations that occur within a block:

https://msdn.microsoft.com/en-us/library/btathf3f.aspx

This change only removes warnings (which were made errors with `-Werror`).  Therefore, it should have no impact to the build.  However, I built Chapel and tested the hellos with clang and gcc.  I did not test the Pathscale compiler.