### PR TITLE
Convert BlockStmt::modUses to BlockStmt::useList

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -181,7 +181,7 @@ void AstDumpToNode::enterNode(BaseAST* node) const
   {
     if (FnSymbol* fn = toFnSymbol(node))
     {
-      fprintf(mFP, "%s%-10s", delimitEnter, node->astTagAsString());
+      fprintf(mFP, "%s%-12s", delimitEnter, node->astTagAsString());
 
       writeNodeID(node, true, false);
 
@@ -193,13 +193,13 @@ void AstDumpToNode::enterNode(BaseAST* node) const
 
     else if (isUnresolvedSymExpr(node) == true)
     {
-      fprintf(mFP, "%s%-10s", delimitEnter, "UsymExpr");
+      fprintf(mFP, "%s%-12s", delimitEnter, "UsymExpr");
       writeNodeID(node, true, false);
     }
 
     else
     {
-      fprintf(mFP, "%s%-10s", delimitEnter, node->astTagAsString());
+      fprintf(mFP, "%s%-12s", delimitEnter, node->astTagAsString());
       writeNodeID(node, true, false);
     }
   }
@@ -329,7 +329,7 @@ bool AstDumpToNode::enterBlockStmt(BlockStmt* node)
     next_ast->accept(this);
   }
 
-  if (node->modUses)
+  if (node->useList)
   {
     fprintf(mFP, "\n");
 
@@ -338,7 +338,7 @@ bool AstDumpToNode::enterBlockStmt(BlockStmt* node)
     write(false, "ModUses:", false);
     mOffset = mOffset + 2;
     newline();
-    node->modUses->accept(this);
+    node->useList->accept(this);
     mOffset = mOffset - 2;
   }
 

--- a/compiler/AST/CForLoop.cpp
+++ b/compiler/AST/CForLoop.cpp
@@ -244,8 +244,8 @@ void CForLoop::verify()
   if (incrBlockGet()->blockTag  != BLOCK_C_FOR_LOOP)
     INT_FATAL(this, "CForLoop::verify. incrBlock is not BLOCK_C_FOR_LOOP");
 
-  if (modUses                   != 0)
-    INT_FATAL(this, "CForLoop::verify. modUses   is not NULL");
+  if (useList                   != 0)
+    INT_FATAL(this, "CForLoop::verify. useList   is not NULL");
 
   if (byrefVars                 != 0)
     INT_FATAL(this, "CForLoop::verify. byrefVars is not NULL");

--- a/compiler/AST/DoWhileStmt.cpp
+++ b/compiler/AST/DoWhileStmt.cpp
@@ -110,8 +110,8 @@ void DoWhileStmt::accept(AstVisitor* visitor)
     if (condExprGet() != 0)
       condExprGet()->accept(visitor);
 
-    if (modUses)
-      modUses->accept(visitor);
+    if (useList)
+      useList->accept(visitor);
 
     if (byrefVars)
       byrefVars->accept(visitor);

--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -415,8 +415,8 @@ void ForLoop::verify()
   if (mIterator == 0)
     INT_FATAL(this, "ForLoop::verify. iterator  is NULL");
 
-  if (modUses   != 0)
-    INT_FATAL(this, "ForLoop::verify. modUses   is not NULL");
+  if (useList   != 0)
+    INT_FATAL(this, "ForLoop::verify. useList   is not NULL");
 
   if (byrefVars != 0)
     INT_FATAL(this, "ForLoop::verify. byrefVars is not NULL");
@@ -447,8 +447,8 @@ void ForLoop::accept(AstVisitor* visitor)
     if (iteratorGet() != 0)
       iteratorGet()->accept(visitor);
 
-    if (modUses)
-      modUses->accept(visitor);
+    if (useList)
+      useList->accept(visitor);
 
     if (byrefVars)
       byrefVars->accept(visitor);

--- a/compiler/AST/ParamForLoop.cpp
+++ b/compiler/AST/ParamForLoop.cpp
@@ -274,8 +274,8 @@ void ParamForLoop::accept(AstVisitor* visitor)
     for_alist(next_ast, body)
       next_ast->accept(visitor);
 
-    if (modUses)
-      modUses->accept(visitor);
+    if (useList)
+      useList->accept(visitor);
 
     if (byrefVars)
       byrefVars->accept(visitor);
@@ -288,19 +288,19 @@ void ParamForLoop::verify()
 {
   BlockStmt::verify();
 
-  if (mResolveInfo              == 0)
+  if (mResolveInfo              == NULL)
     INT_FATAL(this, "ParamForLoop::verify. mResolveInfo is NULL");
 
-  if (BlockStmt::blockInfoGet() != 0)
+  if (BlockStmt::blockInfoGet() != NULL)
     INT_FATAL(this, "ParamForLoop::verify. blockInfo is not NULL");
 
-  if (modUses                   != 0)
-    INT_FATAL(this, "ParamForLoop::verify. modUses   is not NULL");
+  if (useList                   != NULL)
+    INT_FATAL(this, "ParamForLoop::verify. useList   is not NULL");
 
-  if (byrefVars                 != 0)
+  if (byrefVars                 != NULL)
     INT_FATAL(this, "ParamForLoop::verify. byrefVars is not NULL");
 
-  if (forallIntents             != 0)
+  if (forallIntents             != NULL)
     INT_FATAL(this, "ParamForLoop::verify. forallIntents is not NULL");
 }
 

--- a/compiler/AST/WhileDoStmt.cpp
+++ b/compiler/AST/WhileDoStmt.cpp
@@ -134,8 +134,8 @@ void WhileDoStmt::accept(AstVisitor* visitor)
     if (condExprGet() != 0)
       condExprGet()->accept(visitor);
 
-    if (modUses)
-      modUses->accept(visitor);
+    if (useList)
+      useList->accept(visitor);
 
     if (byrefVars)
       byrefVars->accept(visitor);

--- a/compiler/AST/WhileStmt.cpp
+++ b/compiler/AST/WhileStmt.cpp
@@ -75,8 +75,8 @@ void WhileStmt::verify()
   if (BlockStmt::blockInfoGet() != 0)
     INT_FATAL(this, "WhileStmt::verify. blockInfo is not NULL");
 
-  if (modUses                   != 0)
-    INT_FATAL(this, "WhileStmt::verify. modUses   is not NULL");
+  if (useList                   != 0)
+    INT_FATAL(this, "WhileStmt::verify. useList   is not NULL");
 
   if (byrefVars                 != 0)
     INT_FATAL(this, "WhileStmt::verify. byrefVars is not NULL");

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2266,7 +2266,7 @@ void ModuleSymbol::addDefaultUses() {
   } else if (this == baseModule) {
     SET_LINENO(this);
 
-    block->moduleUseAdd(rootModule);
+    block->useListAdd(rootModule);
 
     UnresolvedSymExpr* modRef = new UnresolvedSymExpr("ChapelStringLiterals");
     block->insertAtHead(new UseStmt(modRef));
@@ -2306,7 +2306,7 @@ void ModuleSymbol::moduleUseRemove(ModuleSymbol* mod) {
   int index = modUseList.index(mod);
 
   if (index >= 0) {
-    bool inBlock = block->moduleUseRemove(mod);
+    bool inBlock = block->useListRemove(mod);
 
     modUseList.remove(index);
 
@@ -2316,8 +2316,9 @@ void ModuleSymbol::moduleUseRemove(ModuleSymbol* mod) {
       if (modUseList.index(modUsedByDeadMod) < 0) {
         SET_LINENO(this);
 
-        if (inBlock == true)
-          block->moduleUseAdd(modUsedByDeadMod);
+        if (inBlock == true) {
+          block->useListAdd(modUsedByDeadMod);
+        }
 
         modUseList.add(modUsedByDeadMod);
       }

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -527,7 +527,7 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
     } else  {                                                                  \
       AST_CALL_LIST (stmt, BlockStmt,    body,           call, __VA_ARGS__);   \
       AST_CALL_CHILD(stmt, BlockStmt,    blockInfoGet(), call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, BlockStmt,    modUses,        call, __VA_ARGS__);   \
+      AST_CALL_CHILD(stmt, BlockStmt,    useList,        call, __VA_ARGS__);   \
       AST_CALL_CHILD(stmt, BlockStmt,    byrefVars,      call, __VA_ARGS__);   \
       if (ForallIntents* bi = stmt->forallIntents) {                           \
         AST_CALL_STDVEC(bi->fiVars,  Expr, call, __VA_ARGS__);                 \

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -183,17 +183,17 @@ public:
 
   int                 length()                                     const;
 
-  void                moduleUseAdd(ModuleSymbol* mod);
-  void                moduleUseAdd(UseStmt* use);
-  bool                moduleUseRemove(ModuleSymbol* mod);
-  void                moduleUseClear();
+  void                useListAdd(ModuleSymbol* mod);
+  void                useListAdd(UseStmt*      use);
+  bool                useListRemove(ModuleSymbol* mod);
+  void                useListClear();
 
   virtual CallExpr*   blockInfoGet()                               const;
   virtual CallExpr*   blockInfoSet(CallExpr* expr);
 
   BlockTag            blockTag;
   AList               body;
-  CallExpr*           modUses;       // module uses
+  CallExpr*           useList;       // module/enum uses for this block
   const char*         userLabel;
   CallExpr*           byrefVars;     // task intents - task constructs only
   ForallIntents*      forallIntents; // only for forall-body blocks

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -786,7 +786,7 @@ insertUseForExplicitModuleCalls(void) {
       BlockStmt* block = new BlockStmt();
       stmt->insertBefore(block);
       block->insertAtHead(stmt->remove());
-      block->moduleUseAdd(mod);
+      block->useListAdd(mod);
     }
   }
 }

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -355,7 +355,7 @@ static void processImportExprs(UseStmt* useStmt) {
 
   useStmt->getStmtExpr()->remove();
 
-  useParent->moduleUseAdd(useStmt);
+  useParent->useListAdd(useStmt);
 
   useStmt->validateList();
 }
@@ -1283,13 +1283,13 @@ static bool lookupThisScopeAndUses(const char*           name,
   if (symbols.size() == 0) {
     // Nothing found so far, look into the uses.
     if (BlockStmt* block = toBlockStmt(scope)) {
-      if (block->modUses != NULL) {
+      if (block->useList != NULL) {
         Vec<UseStmt*>* moduleUses = NULL;
 
         if (moduleUsesCache.count(block) == 0) {
           moduleUses = new Vec<UseStmt*>();
 
-          for_actuals(expr, block->modUses) {
+          for_actuals(expr, block->useList) {
             UseStmt* use = toUseStmt(expr);
             INT_ASSERT(use);
 
@@ -1517,8 +1517,8 @@ static void buildBreadthFirstModuleList(
       SymExpr* se = toSymExpr(source->src);
       INT_ASSERT(se);
       if (ModuleSymbol* mod = toModuleSymbol(se->symbol())) {
-        if (mod->block->modUses) {
-          for_actuals(expr, mod->block->modUses) {
+        if (mod->block->useList != NULL) {
+          for_actuals(expr, mod->block->useList) {
             UseStmt* use = toUseStmt(expr);
             INT_ASSERT(use);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1857,8 +1857,8 @@ isMoreVisibleInternal(BlockStmt* block, FnSymbol* fn1, FnSymbol* fn2,
   //
   // ensure f2 is not more visible via module uses, and recurse
   //
-  if (block && block->modUses) {
-    for_actuals(expr, block->modUses) {
+  if (block && block->useList) {
+    for_actuals(expr, block->useList) {
       UseStmt* use = toUseStmt(expr);
       INT_ASSERT(use);
       SymExpr* se = toSymExpr(use->src);
@@ -5876,8 +5876,8 @@ computeStandardModuleSet() {
   stack.add(standardModule);
 
   while (ModuleSymbol* mod = stack.pop()) {
-    if (mod->block->modUses) {
-      for_actuals(expr, mod->block->modUses) {
+    if (mod->block->useList) {
+      for_actuals(expr, mod->block->useList) {
         UseStmt* use = toUseStmt(expr);
         INT_ASSERT(use);
         SymExpr* se = toSymExpr(use->src);
@@ -5991,7 +5991,7 @@ void resolve() {
   clearPartialCopyDataFnMap();
 
   forv_Vec(BlockStmt, stmt, gBlockStmts) {
-    stmt->moduleUseClear();
+    stmt->useListClear();
   }
 
   resolved = true;

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -440,8 +440,8 @@ static BlockStmt* getVisibleFunctions(const char*           name,
       }
     }
 
-    if (block->modUses != NULL) {
-      for_actuals(expr, block->modUses) {
+    if (block->useList != NULL) {
+      for_actuals(expr, block->useList) {
         UseStmt* use = toUseStmt(expr);
 
         INT_ASSERT(use);


### PR DESCRIPTION
Convert CallExpr* BlockStmt::modUses to be CallExpr* BlockStmt::useList and comparable
method names.

In the distant past the member variable BlockStmt::modUses was a list of use-statements
and use-statements were certain to be simple uses of modules.  Hence the name of the
member variable and associated methods().

Later use statements were extended to support enums and modules.  This PR updates the
name of the list and the associated methods.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Also compiled
with CHPL_LLVM=llvm on gcc/linux64.

Tested a fraction of release with CHPL_DEVELOPER set on both darwin and linux64.
Separately tested a fraction of release with CHPL_LLVM=llvm on linux64
Passed a full single-locale paratest
