### PR TITLE
Double oops -- back out accidentally commented-out code

### DIFF
--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -150,13 +150,11 @@ proc ReplicatedDist.ReplicatedDist(targetLocales: [] locale = Locales,
 // TODO: going over all the locales - is there a scalability issue?
 proc ReplicatedDist._localesCheckHelper(purposeMessage: string): void {
   // ideally would like to make this a "eureka"
-  /*
   forall (ix, loc) in zip(targetLocDom, targetLocales) do
     if loc.id != ix {
       halt("The array of locales ", purposeMessage, " must be \"consistent\".",
            " See ReplicatedDist documentation for details.");
     }
-  */
 }
 
 proc ReplicatedDist.dsiEqualDMaps(that: ReplicatedDist(?)) {


### PR DESCRIPTION
Paul pointed out that my "wording changes" this morning also commented
out some code that I didn't notice in the diff.  Doing so doesn't
cause problems (the reason I didn't catch it), but wasn't meant to go
in just yet (maybe tomorrow).