### PR TITLE
Fix typos

### DIFF
--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -259,7 +259,7 @@ static bool isReturnLabel(const Expr* stmt, const LabelSymbol* returnLabel) {
 
 /************************************* | **************************************
 *                                                                             *
-* A shared utilty function for resolution.                                    *
+* A shared utility function for resolution.                                   *
 *                                                                             *
 ************************************** | *************************************/
 

--- a/compiler/resolution/expandVarArgs.cpp
+++ b/compiler/resolution/expandVarArgs.cpp
@@ -76,7 +76,7 @@ static void      cacheExtend(FnSymbol* fn, FnSymbol* expansion);
 *                                                                             *
 *    1) Construct the required tuple within the body of the procedure         *
 *                                                                             *
-*    2) Convert the references to the typle to references to the formals      *
+*    2) Convert the references to the tuple to references to the formals      *
 *                                                                             *
 * The current implementation selects between these strategies based on the    *
 * way in which the varArg is used.                                            *

--- a/doc/rst/developer/chips/19.rst
+++ b/doc/rst/developer/chips/19.rst
@@ -19,7 +19,7 @@ discussed.
 Rationale
 ---------
 
-It is desireable to be able to create and load Chapel code at run-time.
+It is desirable to be able to create and load Chapel code at run-time.
 However,  s of Chapel 1.15, there are several issues preventing this from
 working in a straightforward manner.
 
@@ -194,7 +194,7 @@ Chapel code:
 
      b. The generated code could include calls that perform resolution
 
-   While b. is philisophically interesting, it amounts to embedding much
+   While b. is philosophically interesting, it amounts to embedding much
    of the interpreter in the generated code. It is not clear what
    advantage that would offer but it would restrict the flexibility of
    the interpreter/dynamic compiler.
@@ -231,7 +231,7 @@ Handling Ftable, Class IDs and Virtual Method Table
 There are two basic approaches to these tables
 
 1. Each of these tables could be constructed in a pointer-driven manner
-   that enables the class heirarchy information to be built at run-time.
+   that enables the class hierarchy information to be built at run-time.
    Adding a new class or function does not require changes to tables that
    store the other functions. This is the approach in C++.
 
@@ -257,10 +257,10 @@ There are two basic approaches to these tables
    code can continue to use the same indexes/IDs/offsets that it did
    before.
 
-   For the class IDs that support sub-class checks, the Shubert
+   For the class IDs that support sub-class checks, the Schubert
    numbering strategy can still be used if a new table is created to
    go from class ID (that are numbered based on load order) to a
-   depth-first traversal of the class heirarchy.
+   depth-first traversal of the class hierarchy.
 
 Appendix: Test Programs
 -----------------------

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -438,7 +438,7 @@ OPTIONS
 
     There are 3 optimization stages: none, basic, full:
 
-    1. 'none' is stage before any optimization has occured
+    1. 'none' is stage before any optimization has occurred
     2. 'basic' is stage where basic optimizations occurs.
     3. 'full' is stage where all kinds of optimization occurs, these consist
         of very big optimizations executed by chapel compiler on LLVM IR.


### PR DESCRIPTION
Fix typos, in compiler/resolution, man/chpl.rst, and chip 19.

chip 19 note: Google and compiler/codegen suggest it's "Schubert Numbering", not
"Shubert Numbering".
