### PR TITLE
Remove coupling between misc.h and driver.h et al

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -19,6 +19,7 @@
 
 #include "AstToText.h"
 
+#include "driver.h"
 #include "expr.h"
 #include "stmt.h"
 #include "symbol.h"

--- a/compiler/AST/WhileDoStmt.cpp
+++ b/compiler/AST/WhileDoStmt.cpp
@@ -22,6 +22,7 @@
 #include "AstVisitor.h"
 #include "build.h"
 #include "CForLoop.h"
+#include "driver.h"
 
 /************************************ | *************************************
 *                                                                           *

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -26,6 +26,7 @@
 #include "astutil.h"
 #include "CForLoop.h"
 #include "CatchStmt.h"
+#include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"
 #include "log.h"

--- a/compiler/AST/bb.cpp
+++ b/compiler/AST/bb.cpp
@@ -23,6 +23,7 @@
 #include "bitVec.h"
 #include "CForLoop.h"
 #include "DoWhileStmt.h"
+#include "driver.h"
 #include "ForLoop.h"
 #include "stlUtil.h"
 #include "stmt.h"

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -23,6 +23,7 @@
 #include "stlUtil.h"
 #include "baseAST.h"
 #include "config.h"
+#include "driver.h"
 #include "expr.h"
 #include "files.h"
 #include "ForLoop.h"

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -23,6 +23,7 @@
 #include "bb.h"
 #include "bitVec.h"
 #include "CForLoop.h"
+#include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"
 #include "oldCollectors.h"

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -27,6 +27,7 @@
 #include "AstVisitor.h"
 #include "build.h"
 #include "docsDriver.h"
+#include "driver.h"
 #include "expr.h"
 #include "files.h"
 #include "intlimits.h"

--- a/compiler/codegen/LoopStmt.cpp
+++ b/compiler/codegen/LoopStmt.cpp
@@ -18,7 +18,9 @@
  */
 
 #include "LoopStmt.h"
+
 #include "codegen.h"
+#include "driver.h"
 
 // If vectorization is enabled and this loop is order independent, codegen
 // CHPL_PRAGMA_IVDEP. This method is a no-op if vectorization is off, or the

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -23,6 +23,7 @@
 #include "astutil.h"
 #include "AstVisitor.h"
 #include "codegen.h"
+#include "driver.h"
 #include "ForLoop.h"
 #include "genret.h"
 #include "insertLineNumbers.h"

--- a/compiler/codegen/stmt.cpp
+++ b/compiler/codegen/stmt.cpp
@@ -20,21 +20,19 @@
 #include "stmt.h"
 
 #include "astutil.h"
+#include "AstVisitor.h"
 #include "codegen.h"
+#include "driver.h"
 #include "expr.h"
 #include "files.h"
+#include "llvmDebug.h"
 #include "misc.h"
 #include "passes.h"
 #include "stlUtil.h"
 #include "stringutil.h"
 
-#include "codegen.h"
-#include "llvmDebug.h"
-
-#include "AstVisitor.h"
-
-#include <cstring>
 #include <algorithm>
+#include <cstring>
 #include <vector>
 
 void codegenStmt(Expr* stmt) {

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -23,36 +23,36 @@
 
 #include "symbol.h"
 
-#include "astutil.h"
-#include "stlUtil.h"
+#include "AstToText.h"
 #include "bb.h"
+#include "AstVisitor.h"
+#include "astutil.h"
 #include "build.h"
 #include "codegen.h"
+#include "CollapseBlocks.h"
 #include "docsDriver.h"
+#include "driver.h"
 #include "expr.h"
 #include "files.h"
 #include "intlimits.h"
 #include "iterator.h"
+#include "llvmDebug.h"
 #include "misc.h"
 #include "optimizations.h"
 #include "passes.h"
+#include "stlUtil.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "type.h"
 #include "resolution.h"
 
-// LLVM debugging support
-#include "llvmDebug.h"
-
-#include "AstToText.h"
-#include "AstVisitor.h"
-#include "CollapseBlocks.h"
 
 #include <algorithm>
 #include <cstdlib>
-#include <inttypes.h>
 #include <iostream>
 #include <sstream>
+
+#include <inttypes.h>
 #include <stdint.h>
 
 /******************************** | *********************************

--- a/compiler/codegen/type.cpp
+++ b/compiler/codegen/type.cpp
@@ -21,22 +21,23 @@
 
 #include "AstToText.h"
 #include "astutil.h"
+#include "AstVisitor.h"
 #include "build.h"
 #include "codegen.h"
 #include "docsDriver.h"
+#include "driver.h"
 #include "expr.h"
 #include "files.h"
 #include "intlimits.h"
 #include "ipe.h"
+#include "iterator.h"
 #include "misc.h"
 #include "passes.h"
 #include "stringutil.h"
 #include "symbol.h"
 #include "vec.h"
 
-#include "iterator.h"
 
-#include "AstVisitor.h"
 
 GenRet Type::codegen() {
   if (this == dtUnknown) {

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -17,12 +17,11 @@
  * limitations under the License.
  */
 
-#ifndef _misc_H_
-#define _misc_H_
-
-#include "driver.h"
+#ifndef _MISC_H_
+#define _MISC_H_
 
 #include <cstdio>
+#include <cstdlib>
 
 #define exit(x) dont_use_exit_use_clean_exit_instead
 
@@ -34,11 +33,15 @@
 
 #define INT_FATAL      gdbShouldBreakHere(), \
                        setupError(__FILE__, __LINE__, 1), handleError
+
 #define USR_FATAL      gdbShouldBreakHere(), \
                        setupError(__FILE__, __LINE__, 2), handleError
+
 #define USR_FATAL_CONT gdbShouldBreakHere(), \
                        setupError(__FILE__, __LINE__, 3), handleError
+
 #define USR_WARN       setupError(__FILE__, __LINE__, 4), handleError
+
 #define USR_PRINT      setupError(__FILE__, __LINE__, 5), handleError
 
 #define USR_STOP       exitIfFatalErrorsEncountered
@@ -54,29 +57,35 @@
 
 class BaseAST;
 
-bool forceWidePtrsForLocal();
-bool requireWideReferences();
-bool requireOutlinedOn();
+bool        forceWidePtrsForLocal();
+bool        requireWideReferences();
+bool        requireOutlinedOn();
 
-const char* cleanFilename(BaseAST*    ast);
-const char* cleanFilename(const char* name);
+const char* cleanFilename(const BaseAST* ast);
+const char* cleanFilename(const char*    name);
 
-void setupError(const char* filename, int lineno, int tag);
-void handleError(const char* fmt, ...);
-void handleError(BaseAST* ast, const char* fmt, ...);
-void handleError(FILE* file, BaseAST* ast, const char* fmt, ...);
-void exitIfFatalErrorsEncountered(void);
-void considerExitingEndOfPass(void);
-void printCallStack(bool force, bool shortModule, FILE* out);
+void        setupError(const char* filename, int lineno, int tag);
 
-void startCatchingSignals(void);
-void stopCatchingSignals(void);
+void        handleError(const char* fmt, ...);
+void        handleError(const BaseAST* ast, const char* fmt, ...);
+void        handleError(FILE* file, const BaseAST* ast, const char* fmt, ...);
 
-void clean_exit(int status);
+void        exitIfFatalErrorsEncountered();
 
-void gdbShouldBreakHere(void); // must be exposed to avoid dead-code elim.
+void        considerExitingEndOfPass();
 
-void printCallStack();
-void printCallStackCalls();
+void        printCallStack(bool force, bool shortModule, FILE* out);
+
+void        startCatchingSignals();
+void        stopCatchingSignals();
+
+void        clean_exit(int status);
+
+void        printCallStack();
+void        printCallStackCalls();
+
+
+// must be exported to avoid dead-code elimination by C++ compiler
+void        gdbShouldBreakHere();
 
 #endif

--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -52,11 +52,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define __STDC_FORMAT_MACROS
 #endif
 
+#include "driver.h"
 #include "files.h"
 #include "misc.h"
 #include "stringutil.h"
 
 #include <cstdio>
+
 #include <inttypes.h>
 
 static const char* get_envvar_setting(const ArgumentDescription& desc);

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -22,6 +22,7 @@
 #include "checks.h"
 
 #include "docsDriver.h"
+#include "driver.h"
 #include "expr.h"
 #include "PartialCopyData.h"
 #include "passes.h"

--- a/compiler/main/config.cpp
+++ b/compiler/main/config.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "chpl.h"
+#include "driver.h"
 #include "expr.h"
 #include "parser.h"
 #include "stmt.h"

--- a/compiler/main/log.cpp
+++ b/compiler/main/log.cpp
@@ -22,7 +22,7 @@
 #include "AstDump.h"
 #include "AstDumpToHtml.h"
 #include "AstDumpToNode.h"
-
+#include "driver.h"
 #include "files.h"
 #include "misc.h"
 #include "runpasses.h"

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -20,6 +20,7 @@
 #include "runpasses.h"
 
 #include "checks.h"
+#include "driver.h"
 #include "log.h"
 #include "parser.h"
 #include "passes.h"

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -24,12 +24,11 @@
 #include "astutil.h"
 #include "bb.h"
 #include "bitVec.h"
+#include "driver.h"
 #include "expr.h"
 #include "passes.h"
 #include "stlUtil.h"
 #include "stmt.h"
-
-// view.h is used when DEBUG_CP is enabled.
 #include "view.h"
 
 //#############################################################################

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -22,13 +22,13 @@
 
 #include "astutil.h"
 #include "bb.h"
+#include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"
 #include "passes.h"
 #include "stlUtil.h"
 #include "stmt.h"
 #include "WhileStmt.h"
-#include "ForLoop.h"
 
 #include <queue>
 #include <set>

--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -20,6 +20,7 @@
 #include "passes.h"
 
 #include "astutil.h"
+#include "driver.h"
 #include "expr.h"
 #include "optimizations.h"
 #include "stlUtil.h"

--- a/compiler/optimizations/localizeGlobals.cpp
+++ b/compiler/optimizations/localizeGlobals.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,9 @@
 #include "passes.h"
 
 #include "astutil.h"
-#include "stlUtil.h"
+#include "driver.h"
 #include "expr.h"
+#include "stlUtil.h"
 #include "stmt.h"
 #include "stringutil.h"
 

--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -24,6 +24,7 @@
 #include "bitVec.h"
 #include "CForLoop.h"
 #include "dominator.h"
+#include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"
 #include "ParamForLoop.h"

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -24,12 +24,16 @@
 //  the handler (rather than creating a new task).
 //
 
-#include <vector>
-#include "stlUtil.h"
-#include "astutil.h"
-#include "expr.h"
-#include "stmt.h"
 #include "passes.h"
+
+#include "astutil.h"
+#include "driver.h"
+#include "expr.h"
+#include "stlUtil.h"
+#include "stmt.h"
+
+#include <vector>
+
 
 // There are two questions:
 // 1- is the primitive/function eligible to run in a fast block?

--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -20,10 +20,11 @@
 #include "optimizations.h"
 
 #include "astutil.h"
-#include "stringutil.h"
-#include "stlUtil.h"
+#include "driver.h"
 #include "expr.h"
+#include "stlUtil.h"
 #include "stmt.h"
+#include "stringutil.h"
 
 //#define DEBUG_SYNC_ACCESS_FUNCTION_SET
 

--- a/compiler/optimizations/removeEmptyRecords.cpp
+++ b/compiler/optimizations/removeEmptyRecords.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +17,15 @@
  * limitations under the License.
  */
 
-#include "astutil.h"
-#include "expr.h"
 #include "passes.h"
+
+#include "astutil.h"
+#include "driver.h"
+#include "expr.h"
+#include "stlUtil.h"
 #include "stmt.h"
 #include "symbol.h"
 #include "type.h"
-#include "stlUtil.h"
 
 void
 removeEmptyRecords() {
@@ -40,10 +42,11 @@ removeEmptyRecords() {
   // therefore be removed)
   //
   bool change = true;
+
   while (change) {
     change = false;
     forv_Vec(AggregateType, ct, gAggregateTypes) {
-      if (isRecord(ct) && ct->symbol->defPoint->parentSymbol && 
+      if (isRecord(ct) && ct->symbol->defPoint->parentSymbol &&
           !ct->symbol->hasFlag(FLAG_EXTERN)) {
         bool empty = true;
         for_fields(field, ct) {

--- a/compiler/optimizations/removeUnnecessaryAutoCopyCalls.cpp
+++ b/compiler/optimizations/removeUnnecessaryAutoCopyCalls.cpp
@@ -21,6 +21,7 @@
 
 #include "astutil.h"
 #include "bb.h"
+#include "driver.h"
 #include "expr.h"
 #include "passes.h"
 #include "stlUtil.h"

--- a/compiler/optimizations/removeWrapRecords.cpp
+++ b/compiler/optimizations/removeWrapRecords.cpp
@@ -20,6 +20,7 @@
 #include "passes.h"
 
 #include "astutil.h"
+#include "driver.h"
 #include "expr.h"
 #include "optimizations.h"
 #include "resolveIntents.h"

--- a/compiler/optimizations/replaceArrayAccessesWithRefTemps.cpp
+++ b/compiler/optimizations/replaceArrayAccessesWithRefTemps.cpp
@@ -20,11 +20,12 @@
 #include "optimizations.h"
 
 #include "astutil.h"
+#include "driver.h"
 #include "expr.h"
+#include "ForLoop.h"
 #include "passes.h"
 #include "stlUtil.h"
 #include "stmt.h"
-#include "ForLoop.h"
 
 #define DEBUG_RAAWRT 0
 

--- a/compiler/optimizations/scalarReplace.cpp
+++ b/compiler/optimizations/scalarReplace.cpp
@@ -26,6 +26,7 @@
 #include "optimizations.h"
 
 #include "astutil.h"
+#include "driver.h"
 #include "expr.h"
 #include "passes.h"
 #include "stmt.h"

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "countTokens.h"
 #include "docsDriver.h"
+#include "driver.h"
 #include "expr.h"
 #include "files.h"
 #include "flex-chapel.h"

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -22,6 +22,7 @@
 #include "astutil.h"
 #include "build.h"
 #include "config.h"
+#include "driver.h"
 #include "expr.h"
 #include "stlUtil.h"
 #include "stmt.h"

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -17,20 +17,24 @@
  * limitations under the License.
  */
 
-#include "astutil.h"
 #include "passes.h"
+
+#include "astutil.h"
+#include "driver.h"
+#include "resolution.h"
 #include "stmt.h"
 #include "stlUtil.h"
-#include "resolution.h"
 
 // 'markPruned' replaced deletion from SymbolMap, which does not work well.
 Symbol* markPruned;
+
 // initial value for 'uses' SymbolMap
 Symbol* markUnspecified;
 
 // These mark the intents for variables in a task intent clause.
 static ArgSymbol *tiMarkBlank, *tiMarkIn, *tiMarkConstDflt, *tiMarkConstIn,
                  *tiMarkConstRef, *tiMarkRef;
+
 // Dummy function to host the above.
 static FnSymbol* tiMarkHost;
 

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -17,19 +17,22 @@
  * limitations under the License.
  */
 
+#include "passes.h"
+
+
 #include "astutil.h"
 #include "baseAST.h"
-#include "stlUtil.h"
+#include "CForLoop.h"
+#include "driver.h"
 #include "expr.h"
+#include "exprAnalysis.h"
+#include "LoopStmt.h"
+#include "optimizations.h"
+#include "stlUtil.h"
 #include "stmt.h"
 #include "symbol.h"
 #include "type.h"
-#include "LoopStmt.h"
-#include "CForLoop.h"
 #include "WhileStmt.h"
-#include "exprAnalysis.h"
-#include "optimizations.h"
-
 
 //helper datastructures/types
 typedef std::pair<Expr*, Type*> DefCastPair;

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -21,6 +21,7 @@
 
 #include "AstVisitorTraverse.h"
 #include "CatchStmt.h"
+#include "driver.h"
 #include "stmt.h"
 #include "symbol.h"
 #include "TryStmt.h"

--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -22,6 +22,7 @@
 #include "astutil.h"
 #include "build.h"
 #include "codegen.h"
+#include "driver.h"
 #include "expr.h"
 #include "stmt.h"
 #include "stringutil.h"

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -19,18 +19,17 @@
 
 #include "insertLineNumbers.h"
 
-#include <algorithm>
-
-#include "passes.h"
-
 #include "astutil.h"
+#include "driver.h"
 #include "expr.h"
+#include "passes.h"
 #include "stlUtil.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
 #include "virtualDispatch.h"
 
+#include <algorithm>
 #include <queue>
 
 //

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -180,18 +180,21 @@
 //   treatment in this pass.
 //
 
-#include "expr.h"
-#include "stmt.h"
-#include "astutil.h"
-#include "stlUtil.h"
-#include "stringutil.h"
 #include "passes.h"
+
+#include "astutil.h"
+#include "driver.h"
+#include "expr.h"
 #include "optimizations.h"
-#include <map>
-#include "view.h"
-#include <set>
-#include <queue>
+#include "stlUtil.h"
+#include "stmt.h"
+#include "stringutil.h"
 #include "timer.h"
+#include "view.h"
+
+#include <map>
+#include <queue>
+#include <set>
 
 //
 // For debugging, uncomment the following macros for insights:

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -26,6 +26,7 @@
 
 #include "astutil.h"
 #include "build.h"
+#include "driver.h"
 #include "expr.h"
 #include "initializerRules.h"
 #include "stlUtil.h"

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -22,6 +22,7 @@
 #include "astutil.h"
 #include "build.h"
 #include "clangUtil.h"
+#include "driver.h"
 #include "expr.h"
 #include "externCResolve.h"
 #include "initializerRules.h"

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -20,6 +20,7 @@
 #include "passes.h"
 
 #include "astutil.h"
+#include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"
 #include "iterator.h"

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -22,6 +22,7 @@
 #include "astutil.h"
 #include "caches.h"
 #include "chpl.h"
+#include "driver.h"
 #include "expr.h"
 #include "PartialCopyData.h"
 #include "resolveIntents.h"

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -20,6 +20,7 @@
 #include "resolution.h"
 
 #include "astutil.h"
+#include "driver.h"
 #include "ForLoop.h"
 #include "passes.h"
 #include "resolveIntents.h"

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -22,6 +22,7 @@
 #include "astutil.h"
 #include "caches.h"
 #include "callInfo.h"
+#include "driver.h"
 #include "expandVarArgs.h"
 #include "expr.h"
 #include "initializerRules.h"

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -21,6 +21,7 @@
 
 #include "astutil.h"
 #include "CForLoop.h"
+#include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"
 #include "iterator.h"

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -20,7 +20,7 @@
 #include "preFold.h"
 
 #include "astutil.h"
-#include "expr.h"
+#include "driver.h"
 #include "expr.h"
 #include "ParamForLoop.h"
 #include "passes.h"

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -26,6 +26,7 @@
 #include "astutil.h"
 #include "caches.h"
 #include "chpl.h"
+#include "driver.h"
 #include "expr.h"
 #include "passes.h"
 #include "resolveIntents.h"

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -46,6 +46,7 @@ static child type could end up calling something in the parent.
 #include "virtualDispatch.h"
 
 #include "baseAST.h"
+#include "driver.h"
 #include "expr.h"
 #include "iterator.h"
 #include "resolution.h"

--- a/compiler/resolution/visibleCandidates.cpp
+++ b/compiler/resolution/visibleCandidates.cpp
@@ -20,6 +20,7 @@
 #include "visibleCandidates.h"
 
 #include "callInfo.h"
+#include "driver.h"
 #include "expandVarArgs.h"
 #include "expr.h"
 #include "resolution.h"

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -20,6 +20,7 @@
 #include "visibleFunctions.h"
 
 #include "callInfo.h"
+#include "driver.h"
 #include "expr.h"
 #include "map.h"
 #include "resolution.h"

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -42,6 +42,7 @@
 #include "caches.h"
 #include "callInfo.h"
 #include "chpl.h"
+#include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"
 #include "passes.h"

--- a/compiler/util/stringutil.cpp
+++ b/compiler/util/stringutil.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,12 +23,15 @@
 
 #include "stringutil.h"
 
+#include "map.h"
 #include "misc.h"
 
 #include <algorithm>
+#include <climits>
 #include <functional>
-#include <inttypes.h>
 #include <sstream>
+
+#include <inttypes.h>
 
 static ChainHashMap<const char*, StringHashFns, const char*> chapelStringsTable;
 


### PR DESCRIPTION
This trivial PR implements two simple changes for misc.{h,cpp}

1) Update a few functions that used to accept a BaseAST* to accept a const BaseAST* instead.

2) Simplify the dependencies in misc.h.  In particular remove #include "driver.h" from misc.h
Then compensate by updating the includes on roughly 50 .cpp files.  Almost all of these were
to add driver.cpp but one or two required a little extra work.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Also compiled with
CHPL_LLVM=llvm on gcc/linux64.

Ran a modest fraction of release with CHPL_DEVELOPER set and also with --llvm.
Ran a full single-locale paratest
