### PR TITLE
5/11 perf meeting updates

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -44,6 +44,8 @@ all:
   03/28/14:
     - Add static flag for performance testing (22992)
   05/08/14:
+  05/11/17:
+    - 
     - switched to gcc-4.7
   07/19/14:
     - no testing occurred, machine update
@@ -662,6 +664,10 @@ meteor:
   08/10/16:
     - Updated meteor's lock to yield less frequently (#4300)
 
+mg-b:
+  05/11/17:
+    - Move chpl_getPrivatizedClass() into chpl-privatization.h (#6212)
+
 miniMD:
   12/21/13:
     - clean up of noRefCount related code in modules/internal (22473)
@@ -735,6 +741,12 @@ prk-stencil.ml-perf:
     - Problem size increased from --order=1000 to --order=32000 (#3813)
   08/12/16:
     - Improve and enable strided bulk transfer optimization as default (#4318)
+  05/11/17:
+    - Move chpl_getPrivatizedClass() into chpl-privatization.h (#6212)
+
+prk-stencil-time:
+  05/11/17:
+    - Move chpl_getPrivatizedClass() into chpl-privatization.h (#6212)
 
 prk-transpose: &transpose-base
   05/04/17:

--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -74,8 +74,6 @@ performance/bradc/parOpEquals.graph
 performance/sungeun/assign.1024.graph
 performance/sungeun/init.graph
 performance/thomasvandoren/matrix-multiply.graph
-parallel/taskCompare/elliot/taskSpawn.graph
-parallel/taskCompare/elliot/serialTaskSpawn.graph
 distributions/robust/associative/performance/array_iter.graph
 performance/elliot/no-op.graph
 performance/bharshbarg/forall-dom-range.graph

--- a/test/performance/sungeun/copy_to_local.graph
+++ b/test/performance/sungeun/copy_to_local.graph
@@ -1,4 +1,5 @@
 perfkeys: Copy to local (1 locales):, Copy to local (1 locales):, Copy to local (1 locales):, Copy to local (1 locales):
 graphkeys: n=8192, n=16384, n=32768, n=65536
 files: copy_to_local.8192.dat, copy_to_local.16384.dat, copy_to_local.32768.dat, copy_to_local.65536.dat
+ylabel: Time (seconds)
 graphtitle: Array copy from Global to Local (Cyclic)

--- a/test/performance/sungeun/init.graph
+++ b/test/performance/sungeun/init.graph
@@ -1,9 +1,11 @@
 perfkeys: init serial:, init forall-for:, init serial:, init nested forall:, init forall-for:
 graphkeys: serial 256x256, forall-for 256x256, serial 1024x1024, nested forall 1024x1024, forall-for 1024x1024
 files: init.256.dat, init.256.dat, init.1024.dat, init.1024.dat, init.1024.dat
+ylabel: Time (seconds)
 graphtitle: Array initialization (faster idioms)
 
 perfkeys: init nested forall:, init for-forall:, init for-forall:
 graphkeys: nested forall 256x256, for-forall 256x256, for-forall 1024x1024
 files: init.256.dat, init.256.dat, init.1024.dat
+ylabel: Time (seconds)
 graphtitle: Array initialization (slower idioms)


### PR DESCRIPTION
@chapel-lang/perf-team:
- Added annotations for #6212:
  - PRK stencil graphs
  - NPB
- added y-axis to array init tests
- removed empty task spawning from perf tracking
- PRK stencils were already part of 16-node-xc perf tracking

Having trouble running `check_annotations.py`, so I'm holding off until Monday.