### PR TITLE
Chpl program

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -800,15 +800,6 @@ void initChplProgram(DefExpr* objectDef) {
 
   theProgram->addFlag(FLAG_NO_CODEGEN);
 
-  UseStmt* base = new UseStmt(new UnresolvedSymExpr("ChapelBase"));
-  UseStmt* std  = new UseStmt(new UnresolvedSymExpr("ChapelStandard"));
-
-  theProgram->block->insertAtTail(base);
-
-  // it may be better to add the following use after parsing
-  // to simplify insertion of module guard sync var defs
-  theProgram->block->insertAtTail(std);
-
   theProgram->block->insertAtHead(objectDef);
 
   rootModule->block->insertAtTail(new DefExpr(theProgram));
@@ -818,11 +809,13 @@ void initChplProgram(DefExpr* objectDef) {
 // matching 'value'. For use in initCompilerGlobals.
 static void setupBoolGlobal(VarSymbol* globalVar, bool value) {
   rootModule->block->insertAtTail(new DefExpr(globalVar));
+
   if (value) {
-    globalVar->immediate = new Immediate;
+     globalVar->immediate = new Immediate;
     *globalVar->immediate = *gTrue->immediate;
+
   } else {
-    globalVar->immediate = new Immediate;
+     globalVar->immediate = new Immediate;
     *globalVar->immediate = *gFalse->immediate;
   }
 }

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -40,6 +40,7 @@
 //   classes... should I?
 //
 module ArrayViewRankChange {
+  use ChapelStandard;
 
   //
   // This class represents a distribution that knows how to create
@@ -51,7 +52,7 @@ module ArrayViewRankChange {
     // lower-dimensional views of
     var downDistPid:int;
     var downDistInst;
-    
+
     // These two fields represent whether or not each dimension was
     // collapsed as part of the rank-change; and if so, what the
     // index of that collapsed dimension was.  So for A[lo..hi, 3]

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -23,6 +23,7 @@
 // represent reindexings of another array via a domain.
 //
 module ArrayViewReindex {
+  use ChapelStandard;
 
   //
   // The class representing a slice of an array.  Like other array

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -23,6 +23,7 @@
 // represent slices of another array via a domain.
 //
 module ArrayViewSlice {
+  use ChapelStandard;
 
   //
   // The class representing a slice of an array.  Like other array

--- a/modules/internal/AtomicsCommon.chpl
+++ b/modules/internal/AtomicsCommon.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,8 @@
  */
 
 module AtomicsCommon {
+  use ChapelStandard;
+
   record atomic_refcnt {
     // The common case seems to be local access to this class, so we
     // will use explicit processor atomics, even when network
@@ -25,7 +27,7 @@ module AtomicsCommon {
     // network and processor atomic versions of atomic_refcnt if
     // necessary.
     var _cnt:atomic_int64;
-    // Reference counting implemented according to 
+    // Reference counting implemented according to
 // http://www.chaoticmind.net/~hcb/projects/boost.atomic/doc/atomic/usage_examples.html#boost_atomic.usage_examples.example_reference_counters
 // http://stackoverflow.com/questions/10268737/c11-atomics-and-intrusive-shared-pointer-reference-count
     inline proc inc(cnt=1) {

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -19,6 +19,8 @@
 
 /* A Chapel version of a C pointer. */
 module CPtr {
+  use ChapelStandard;
+
   /* A Chapel version of a C NULL pointer. */
   extern const c_nil:c_void_ptr;
 
@@ -42,7 +44,8 @@ module CPtr {
       if !x then do writeln("x is nil");
 
   */
-  //   Similar to _ddata from ChapelBase, but differs 
+
+  //   Similar to _ddata from ChapelBase, but differs
   //   from _ddata because it can never be wide.
   pragma "data class"
   pragma "no object"

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,6 +39,7 @@
 // rules, but still makes use of the distinction between unowned c_strings and
 // owned c_string_copies.
 module CString {
+  use ChapelStandard;
 
   // The following method is called by the compiler to determine the default
   // value of a given type.

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -21,6 +21,7 @@
 //
 
 module ChapelBase {
+  use ChapelStandard;
 
   // These two are called by compiler-generated code.
   extern proc chpl_config_has_value(name:c_string, module_name:c_string): bool;

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -26,6 +26,7 @@
  */
 
 module ChapelDebugPrint {
+  use ChapelStandard;
 
   proc chpl_debug_stringify(args...) : string {
     var str = "";

--- a/modules/internal/ChapelDynDispHack.chpl
+++ b/modules/internal/ChapelDynDispHack.chpl
@@ -18,6 +18,8 @@
  */
 
 module ChapelDynDispHack {
+  use ChapelStandard;
+
   //
   // This is an incredibly lame hack.  If the test:
   //

--- a/modules/internal/ChapelEnv.chpl
+++ b/modules/internal/ChapelEnv.chpl
@@ -30,6 +30,7 @@
 
  */
 module ChapelEnv {
+  use ChapelStandard;
 
   /* See :ref:`readme-chplenv.CHPL_HOME` for more information. */
   param CHPL_HOME:string            = __primitive("get compiler variable", "CHPL_HOME");

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -18,6 +18,8 @@
  */
 
 module ChapelError {
+  use ChapelStandard;
+
   class Error {
     var msg: string;
 

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -36,6 +36,8 @@
   make it available.
  */
 module ChapelIteratorSupport {
+  use ChapelStandard;
+
   //
   // module support for iterators
   //

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -39,6 +39,8 @@ proceed if it is a single variable.
 */
 
 module ChapelSyncvar {
+  use ChapelStandard;
+
   use AlignedTSupport;
   use MemConsistency;
   use SyncVarRuntimeSupport;
@@ -836,6 +838,7 @@ module ChapelSyncvar {
 
 
 private module SyncVarRuntimeSupport {
+  use ChapelStandard;
   use AlignedTSupport;
 
   //

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,11 +38,12 @@ The following method is also available:
 It returns the number of components of the tuple.
 */
 module ChapelTuple {
-  
+  use ChapelStandard;
+
   pragma "tuple" record _tuple {
     param size : int;
   }
-  
+
   //
   // syntactic support for tuples
   //
@@ -69,7 +70,7 @@ module ChapelTuple {
   }
 
   // tuple value allowing refs (ref actuals)
-  pragma "allow ref" 
+  pragma "allow ref"
   pragma "build tuple"
   inline proc _build_tuple_always_allow_ref(x...)
     return x;
@@ -107,41 +108,41 @@ module ChapelTuple {
   proc *(p: int, type t) type {
     compilerError("tuple size must be static");
   }
-  
+
   // make it a tuple if it is not already
   inline proc chpl__tuplify(x) {
     if isTuple(x) then return x; else return (x,);
   }
-  
+
   //
   // isTuple, isTupleType and isHomogeneousTuple param functions
   //
   pragma "no doc" // we are not advertising isXxxValue() functions at present
   proc isTupleValue(x: _tuple) param
     return true;
-  
+
   pragma "no doc"
   proc isTupleValue(x) param
     return false;
-  
+
   pragma "no doc"
   proc isHomogeneousTupleValue(x) param
     return __primitive("is star tuple type", x);
-  
+
   /*
     Returns `true` if its argument is a tuple type.
     The argument must be a type.
   */
   proc isTupleType(type t) param
     return __primitive("is tuple type", t);
-  
+
   /*
     Returns `true` if its argument is a homogeneous tuple type.
     The argument must be a type.
   */
   proc isHomogeneousTupleType(type t) param
     return __primitive("is star tuple type", t);
-  
+
   //
   // tuple assignment
   //
@@ -150,7 +151,7 @@ module ChapelTuple {
     for param i in 1..x.size do
       x(i) = y(i);
   }
-  
+
   //
   // homogeneous tuple accessor
   // the result is const when the tuple is
@@ -179,7 +180,7 @@ module ChapelTuple {
   //
   pragma "no doc"
   config param CHPL_WARN_TUPLE_ITERATION = "unset";
-  
+
   //
   // iterator support for tuples
   //
@@ -196,10 +197,10 @@ module ChapelTuple {
       yield(this(i));
     }
   }
-  
+
   pragma "no doc"
-  iter _tuple.these(param tag:iterKind) 
-      where tag == iterKind.leader 
+  iter _tuple.these(param tag:iterKind)
+      where tag == iterKind.leader
   {
 
     const numTasks = if dataParTasksPerLocale==0 then here.maxTaskPar
@@ -215,7 +216,7 @@ module ChapelTuple {
     if numChunks == 1 {
       yield myRange;
     } else {
-  
+
       coforall chunk in 0..#numChunks {
         // _computeBlock assumes 0-based ranges
         const (lo,hi) = _computeBlock(length, numChunks, chunk, length-1);
@@ -224,14 +225,14 @@ module ChapelTuple {
       }
     }
   }
-  
+
   pragma "no doc"
   iter _tuple.these(param tag:iterKind, followThis)
       where tag == iterKind.follower
   {
     for i in followThis do yield this(i);
   }
-  
+
   //
   // tuple methods
   //
@@ -285,7 +286,7 @@ module ChapelTuple {
     c.im = x(2):real(32);
     return c;
   }
-  
+
   inline proc _cast(type t, x: (?,?)) where t == complex(128) {
     var c: complex(128) = noinit;
     // There is no point allowing this to default initialize, we're just going
@@ -302,7 +303,7 @@ module ChapelTuple {
   inline proc _cast(type t, x: _tuple) where t:_tuple {
     // body filled in during resolution
   }
-  
+
   //
   // helper function to return a tuple of all of the components in a
   // tuple except the first
@@ -312,7 +313,7 @@ module ChapelTuple {
       return rest;
     return chpl__tupleRestHelper((...t));
   }
-  
+
   //
   // standard overloaded unary operators on tuples.
   //
@@ -329,21 +330,21 @@ module ChapelTuple {
       result(d) = -a(d);
     return result;
   }
-  
+
   inline proc ~(a: _tuple) {
     var result: a.type;
     for param d in 1..a.size do
       result(d) = ~a(d);
     return result;
   }
-  
+
   inline proc !(a: _tuple) {
     var result: a.type;
     for param d in 1..a.size do
       result(d) = !a(d);
     return result;
   }
-  
+
   /*
     Returns a tuple of type t with each component set to ``max``
     of the type in the corresponding component of the argument.
@@ -355,7 +356,7 @@ module ChapelTuple {
     }
     return result;
   }
-  
+
   /*
   Returns a tuple of type t with each component set to ``min``
   of the type in the corresponding component of the argument.
@@ -367,7 +368,7 @@ module ChapelTuple {
     }
     return result;
   }
-  
+
   proc chpl_TwoHomogTuples(t1, t2) param {
     return isHomogeneousTuple(t1) && isHomogeneousTuple(t2);
   }
@@ -410,7 +411,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc -(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to - have different sizes");
@@ -431,7 +432,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc *(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to * have different sizes");
@@ -440,7 +441,7 @@ module ChapelTuple {
     else
       return (a(1)*b(1), (...chpl__tupleRest(a)*chpl__tupleRest(b)));
   }
-  
+
   inline proc /(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to / have different sizes");
@@ -451,7 +452,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc /(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to / have different sizes");
@@ -460,7 +461,7 @@ module ChapelTuple {
     else
       return (a(1)/b(1), (...chpl__tupleRest(a)/chpl__tupleRest(b)));
   }
-  
+
   inline proc %(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to % have different sizes");
@@ -471,7 +472,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc %(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to % have different sizes");
@@ -480,7 +481,7 @@ module ChapelTuple {
     else
       return (a(1)%b(1), (...chpl__tupleRest(a)%chpl__tupleRest(b)));
   }
-  
+
   inline proc **(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to ** have different sizes");
@@ -491,7 +492,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc **(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to ** have different sizes");
@@ -500,7 +501,7 @@ module ChapelTuple {
     else
       return (a(1)**b(1), (...chpl__tupleRest(a)**chpl__tupleRest(b)));
   }
-  
+
   inline proc &(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to & have different sizes");
@@ -511,7 +512,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc &(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to & have different sizes");
@@ -520,7 +521,7 @@ module ChapelTuple {
     else
       return (a(1)&b(1), (...chpl__tupleRest(a)&chpl__tupleRest(b)));
   }
-  
+
   inline proc |(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to | have different sizes");
@@ -531,7 +532,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc |(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to | have different sizes");
@@ -540,7 +541,7 @@ module ChapelTuple {
     else
       return (a(1)|b(1), (...chpl__tupleRest(a)|chpl__tupleRest(b)));
   }
-  
+
   inline proc ^(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to ^ have different sizes");
@@ -551,7 +552,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc ^(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to ^ have different sizes");
@@ -560,7 +561,7 @@ module ChapelTuple {
     else
       return (a(1)^b(1), (...chpl__tupleRest(a)^chpl__tupleRest(b)));
   }
-  
+
   inline proc <<(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to << have different sizes");
@@ -571,7 +572,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc <<(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to << have different sizes");
@@ -580,7 +581,7 @@ module ChapelTuple {
     else
       return (a(1)<<b(1), (...chpl__tupleRest(a)<<chpl__tupleRest(b)));
   }
-  
+
   inline proc >>(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to >> have different sizes");
@@ -591,7 +592,7 @@ module ChapelTuple {
 
     return result;
   }
-  
+
   inline proc >>(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to >> have different sizes");
@@ -600,7 +601,7 @@ module ChapelTuple {
     else
       return (a(1)>>b(1), (...chpl__tupleRest(a)>>chpl__tupleRest(b)));
   }
-  
+
   //
   // standard overloaded relational operators on tuples
   //
@@ -614,7 +615,7 @@ module ChapelTuple {
         return false;
     return false;
   }
-  
+
   inline proc >=(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to >= have different sizes");
@@ -625,7 +626,7 @@ module ChapelTuple {
         return false;
     return true;
   }
-  
+
   inline proc <(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to < have different sizes");
@@ -636,7 +637,7 @@ module ChapelTuple {
         return false;
     return false;
   }
-  
+
   inline proc <=(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to <= have different sizes");
@@ -647,7 +648,7 @@ module ChapelTuple {
         return false;
     return true;
   }
-  
+
   inline proc ==(a: _tuple, b: _tuple) {
     if a.size != b.size then
       return false;
@@ -656,7 +657,7 @@ module ChapelTuple {
         return false;
     return true;
   }
-  
+
   inline proc !=(a: _tuple, b: _tuple) {
     if a.size != b.size then
       return true;
@@ -677,7 +678,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc +(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc +(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -692,7 +693,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc -(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc -(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -707,7 +708,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc *(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc *(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        x: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -722,7 +723,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc /(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc /(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -737,7 +738,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc %(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc %(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -752,7 +753,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc **(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc **(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -767,7 +768,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc &(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc &(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -782,7 +783,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc |(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc |(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -797,7 +798,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc ^(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc ^(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -812,7 +813,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc <<(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc <<(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do
@@ -827,7 +828,7 @@ module ChapelTuple {
     return result;
   }
 
-  inline proc >>(x: ?t, y: _tuple) where isHomogeneousTuple(y) && 
+  inline proc >>(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                        t: (y(1).type)  {
     var result: y.size * y(1).type;
     for param d in 1..y.size do

--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@
 // Internal data structures module
 //
 module ChapelUtil {
+  use ChapelStandard;
 
   //
   // safeAdd: If a and b are of type t, return true iff no
@@ -52,7 +53,7 @@ module ChapelUtil {
       }
     }
   }
-  
+
   //
   // safeSub: If a and b are of type t, return true iff no
   //  underflow/overflow would occur for a - b

--- a/modules/internal/DefaultOpaque.chpl
+++ b/modules/internal/DefaultOpaque.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@
 // DefaultOpaque.chpl
 //
 module DefaultOpaque {
+  use ChapelStandard;
 
   // record _OpaqueIndex is defined in ChapelArray
 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -20,6 +20,7 @@
 // DefaultSparse.chpl
 //
 module DefaultSparse {
+  use ChapelStandard;
   use RangeChunk only ;
 
   config param debugDefaultSparse = false;

--- a/modules/internal/LocaleModelHelpMem.chpl
+++ b/modules/internal/LocaleModelHelpMem.chpl
@@ -27,6 +27,7 @@
 // duplication. If necessary, a locale model using this file
 // should feel free to reimplement them in some other way.
 module LocaleModelHelpMem {
+  use ChapelStandard;
 
   //////////////////////////////////////////
   //

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -27,6 +27,7 @@
 // duplication. If necessary, a locale model using this file
 // should feel free to reimplement them in some other way.
 module LocaleModelHelpRuntime {
+  use ChapelStandard;
 
   // The chpl_localeID_t type is used internally.  It should not be exposed to
   // the user.  The runtime defines the actual type, as well as a functional

--- a/modules/internal/LocalesArray.chpl
+++ b/modules/internal/LocalesArray.chpl
@@ -38,6 +38,8 @@
 //
 
 module LocalesArray {
+  use ChapelStandard;
+
   // Initialize the rootLocale
   chpl_init_rootLocale();
 

--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -21,6 +21,8 @@
 //
 module MemTracking
 {
+  use ChapelStandard;
+
   config const
     memTrack: bool = false,
     memStats: bool = false,
@@ -40,7 +42,7 @@ module MemTracking
      because they are tracked allocations with no corresponding free.
 
      The dump is performed only if the --memLeaksByDesc option is present and has
-     a string argument.  
+     a string argument.
        --memLeaksByDesc="" causes all memory records to be printed.  Same as --memLeaks.
        --memLeaksByDesc="<alloc-type-string>" causes only those memory records
          matching the given <alloc-type-string> to be printed.

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@
 
 pragma "atomic module"
 module NetworkAtomics {
+  use ChapelStandard;
 
   // int(64)
   pragma "insert line file info"

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -32,6 +32,8 @@
  */
 
 private module BaseStringType {
+  use ChapelStandard;
+
   // TODO: figure out why I can't move this definition into `module String`
   type bufferType = c_ptr(uint(8));
 }

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,8 @@
  */
 
 module StringCasts {
+  use ChapelStandard;
+
   // TODO: I want to break all of these casts from string to T out into
   // T.parse(string), but we dont support methods on types yet. Ideally they
   // would use a tagged union return val as well.

--- a/modules/minimal/internal/ChapelLocale.chpl
+++ b/modules/minimal/internal/ChapelLocale.chpl
@@ -20,6 +20,8 @@
 // ChapelLocale.chpl
 //
 module ChapelLocale {
+  use ChapelBase;
+
   pragma "no doc"
   type chpl_sublocID_t = int(32);
 

--- a/test/modules/noakes/list.chpl
+++ b/test/modules/noakes/list.chpl
@@ -1,0 +1,20 @@
+// Until May 13, 2017 it was possible for top-level modules to intercept
+// lexical lookups within internal modules in certain situations.
+
+// This occurred because
+//   a) chpl__Program 'used' ChapelStandard
+//
+//   b) Some internal modules implicitly found needed names in other
+//      modules by reaching chpl__Program and then following the use.
+
+// For example there were lookup paths for the type 'list' that would
+// be blocked if a user innocently created a file named 'list.chpl'.
+
+// This test demonstrates that one version of this bug has been
+// resolved.
+//
+// As of May 13, 2017 there are still problems with the scoping of
+// certain primitive types and primitive variables.
+
+
+writeln("Module 'list' can be defined");

--- a/test/modules/noakes/list.good
+++ b/test/modules/noakes/list.good
@@ -1,0 +1,1 @@
+Module 'list' can be defined


### PR DESCRIPTION
Before this PR the compiler synthesized a module to represent "the program" with the
internal name "chpl__Program".  The compiler also inserted the statements

use ChapelBase;
use ChapelStandard;

in to this module.  This has been occurring since the early days of the compiler but it
means that the internal modules implicitly import ChapelStandard.  This can lead to
scoping errors in certain edge cases, and facilitates the introduction of undesirable
cyclic dependencies in to internal modules



This PR 

1. updates the compiler to stop inserting these use statements

2. As a simplifying stop-gap inserts use ChapelStandard; into roughly 1/2 of the
internal modules.  I suspect that some of these could be converted to more
thoughtful uses, but the cyclic dependencies makes this hard in the general case.

3. Adds one simple test to help lock in this behavior; this test failed without this update

4. Adds one instance of 'use ChapelBase;' within minimal-modules.

Compiled in the usual ways.
Passed single-locale with -futures and then with --no-local
