### PR TITLE
Skip --baseline for printFinalMemStat

### DIFF
--- a/test/memory/shannon/printFinalMemStat.skipif
+++ b/test/memory/shannon/printFinalMemStat.skipif
@@ -1,3 +1,10 @@
 # With --no-local, we end up putting things on the heap when evaluating sync
 #   but don't account for this in the .good
 CHPL_COMM == gasnet
+
+#
+# with --baseline, the loop that frees the array of locales at the end
+# of the program increases our amount of memory, but don't account for
+# this in the .good
+#
+COMPOPTS <= --baseline


### PR DESCRIPTION
In --baseline mode, the newly added loop that frees the Locales array
at the end of the run requires memory allocation that we optimize away
in non-baseline mode, causing the memory stats for this test to
balloon.  It seems difficult to believe that printFinalMemStat would
break in a --baseline specific way, so skipping this test in this
configuration does not seem regrettable to me...