### PR TITLE
Emit correct exit code for `make docs` failures

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,8 +29,8 @@ help-source:
 
 
 docs: FORCE
-	@../util/run-in-venv.bash $(MAKE) html-release || (echo;echo "If a documentation hierarchy change was made on the master branch, \
-	try resolving with: \`git clean "'$$CHPL_HOME'"/doc/*\`";echo)
+	@../util/run-in-venv.bash $(MAKE) html-release || $(MAKE) error_docs
+	
 
 man-chapel: FORCE
 	../util/run-in-venv.bash $(MAKE) man
@@ -114,6 +114,13 @@ clean-symlinks: FORCE
 	@echo
 	@echo "Removing all symbolic links"
 	find $(SOURCEDIR) -type l -delete
+
+error_docs: FORCE
+	@echo;
+	@echo "If a documentation hierarchy change was made on the master branch,"
+	@echo "try resolving with: \`git clean "'$$CHPL_HOME'"/doc/*\`"
+	@echo;
+	@exit 1 # Note that 'make' will return exit code of 2, despite exit 1
 
 
 FORCE:


### PR DESCRIPTION
This PR puts the docs error message in a separate target, and explicitly exits with error code 1. Note that `make` will exit with error code 2 anyway (as noted in the comment).

This eliminates a few symptoms that propagated up to `gen_release` and `testRelease`, which were pointed out in #6239.