### PR TITLE
Add deinit to KNL and numa locale models

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -665,6 +665,9 @@ module ChapelLocale {
   //
   // Free the original root locale when the program is being torn down
   //
+  // Be careful to free only origRootLocale, and never the copy in
+  // rootLocale, or the same locales will be torn down twice.
+  //
   pragma "no doc"
   proc deinit() {
     delete origRootLocale;

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -290,6 +290,11 @@ module LocaleModel {
       chpl_task_setSubloc(origSubloc);
     }
 
+    proc deinit() {
+      delete ddr;
+      delete hbm;
+    }
+
     proc writeThis(f) {
       parent.writeThis(f);
       f <~> '.'+ndName;
@@ -434,6 +439,13 @@ module LocaleModel {
       chpl_task_setSubloc(origSubloc);
     }
     //------------------------------------------------------------------------}
+
+    proc deinit() {
+      for loc in childLocales do
+        delete loc;
+      delete ddr;
+      delete hbm;
+    }
  }
 
   //
@@ -508,6 +520,11 @@ module LocaleModel {
         return ((myLocales[node:int]:LocaleModel).hbm):locale;
       else
         return (myLocales[node:int].getChild(subloc:int)):locale;
+    }
+
+    proc deinit() {
+      for loc in myLocales do
+        delete loc;
     }
   }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -195,6 +195,11 @@ module LocaleModel {
       helpSetupLocaleNUMA(this, local_name, numSublocales);
     }
     //------------------------------------------------------------------------}
+
+    proc deinit() {
+      for loc in childLocales do
+        delete loc;
+    }
  }
 
   //
@@ -266,6 +271,11 @@ module LocaleModel {
         return (myLocales[node:int]):locale;
       else
         return (myLocales[node:int].getChild(subloc:int)):locale;
+    }
+
+    proc deinit() {
+      for loc in myLocales do
+        delete loc;
     }
   }
 }


### PR DESCRIPTION
This change cleans up the numa and KNL locale models at program exit. The prior work by @bradcray for the flat locale model is in #6202 and #6238 .

First, correctness was verified by inserting printfs in the deinits and other strategic places to observe behavior on teardown.  This was done on Mac, Linux (with and without GASNet), and both KNL and non-KNL Cray for the numa locale model, and on both KNL and non-KNL Cray for the KNL locale model.  Testing for the KNL locale model had to be limited to places where the memkind library was available.

Then the printfs were removed and full paratesting was performed, on the same systems as above.