### PR TITLE
Use nonblocking transactions for strided transfers.

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -435,7 +435,9 @@ mpool_idx_base_t mpool_idx_finc(mpool_idx_t* pvar) {
 
 #define CD_ACTIVE_TRANS_MAX 128     // Max transactions in flight, per cd
 
-typedef atomic_uint_least32_t cq_cnt_t;
+typedef uint32_t cq_cnt_t;
+typedef atomic_uint_least32_t cq_cnt_atomic_t;
+
 #define CQ_CNT_STORE(cd, val) \
         atomic_store_uint_least32_t(&(cd)->cq_cnt_curr, val)
 #define CQ_CNT_LOAD(cd)       \
@@ -451,8 +453,8 @@ typedef struct {
   gni_nic_handle_t   nih;
   gni_ep_handle_t*   remote_eps;
   gni_cq_handle_t    cqh;
-  uint32_t           cq_cnt_max;
-  cq_cnt_t           cq_cnt_curr;
+  cq_cnt_t           cq_cnt_max;
+  cq_cnt_atomic_t    cq_cnt_curr;
   mem_map_t          mem_map;
 #ifdef DEBUG_STATS
   uint64_t           acqs;
@@ -2187,7 +2189,7 @@ void polling_task(void* ignore)
 static
 void set_up_for_polling(void)
 {
-  uint32_t     cq_cnt;
+  cq_cnt_t     cq_cnt;
   gni_return_t gni_rc;
   uint32_t     flags;
   uint32_t     i;
@@ -4067,6 +4069,69 @@ void do_remote_get(void* tgt_addr, int32_t locale, void* src_addr, size_t size,
 //
 // Strided bulk put/get, adapted from comm-none.c
 //
+
+
+//
+// We use non-blocking transactions for the multiple GETs/PUTs of a
+// strided transfer.  We can only track so many of these in flight at
+// once, obviously.  In practice based on quick experimentation, the
+// XC network is only about 10 transactions "wide" at the rate we can
+// initiate them in serial code here.  For simplicity, set ourselves
+// a static limit a bit larger than that and support up to 20 GETs or
+// PUTs in flight at once, subject also to any per-CD limit.
+//
+// Prefer initiating transactions to retiring them, in order to get
+// them started earlier.  Once we have as many transactions in flight
+// as we can track and are thus forced to retire some in order to
+// initiate more, only retire ones that have already completed.  Don't
+// wait for any more to finish.  Then at the end, wait for everything
+// to complete.
+//
+static const size_t strd_maxHandles
+                    = (20 < CD_ACTIVE_TRANS_MAX) ? 20 : CD_ACTIVE_TRANS_MAX;
+
+static inline
+void strd_nb_helper(chpl_comm_nb_handle_t (*xferFn)(void*, int32_t, void*,
+                                                    size_t,
+                                                    int32_t, int32_t,
+                                                    int, int32_t),
+                    void* localAddr, int32_t remoteLocale, void* remoteAddr,
+                    size_t cnt,
+                    chpl_comm_nb_handle_t* handles, size_t* pCurrHandles,
+                    int32_t typeIndex, int32_t commID, int ln, int32_t fn)
+{
+  size_t currHandles = *pCurrHandles;
+
+  if (currHandles >= strd_maxHandles) {
+    // reached max in flight -- retire some to make room
+    while (!chpl_comm_try_nb_some(handles, currHandles)) {
+      local_yield();
+    }
+
+    // compress retired transactions out of the list
+    {
+      size_t iOut, iIn;
+
+      for (iOut = iIn = 0; iIn < currHandles; ) {
+        if (handles[iIn] == NULL)
+          iIn++;
+        else
+          handles[iOut++] = handles[iIn++];
+      }
+
+      currHandles = iOut;
+    }
+  }
+
+  handles[currHandles] = (*xferFn)(localAddr, remoteLocale, remoteAddr, cnt,
+                                   typeIndex, commID, ln, fn);
+  if (handles[currHandles] != NULL)
+    currHandles++;
+
+  *pCurrHandles = currHandles;
+}
+
+
 void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
                          int32_t dstlocale,
                          void* srcaddr_arg, size_t* srcstrides,
@@ -4084,6 +4149,9 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
   size_t dststr[strlvls];
   size_t srcstr[strlvls];
   size_t cnt[strlvls+1];
+
+  chpl_comm_nb_handle_t handles[strd_maxHandles];
+  size_t currHandles = 0;
 
   PERFSTATS_INC(put_strd_cnt);
 
@@ -4116,30 +4184,37 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
     chpl_comm_put(srcaddr_arg, dstlocale, dstaddr_arg, cnt[0],
                   typeIndex, commID, ln, fn);
     break;
+
   case 1:
     dstaddr=(int8_t*)dstaddr_arg;
     srcaddr=(int8_t*)srcaddr_arg;
     for(i=0; i<cnt[1]; i++) {
       PERFSTATS_ADD(put_strd_byte_cnt, cnt[0]);
-      chpl_comm_put(srcaddr, dstlocale, dstaddr, cnt[0],
-                    typeIndex, commID, ln, fn);
+      strd_nb_helper(chpl_comm_put_nb,
+                     srcaddr, dstlocale, dstaddr, cnt[0],
+                     handles, &currHandles,
+                     typeIndex, commID, ln, fn);
       srcaddr+=srcstr[0];
       dstaddr+=dststr[0];
     }
     break;
+
   case 2:
     for(i=0; i<cnt[2]; i++) {
       srcaddr = (int8_t*)srcaddr_arg + srcstr[1]*i;
       dstaddr = (int8_t*)dstaddr_arg + dststr[1]*i;
       for(j=0; j<cnt[1]; j++) {
         PERFSTATS_ADD(put_strd_byte_cnt, cnt[0]);
-        chpl_comm_put(srcaddr, dstlocale, dstaddr, cnt[0],
-                      typeIndex, commID, ln, fn);
+        strd_nb_helper(chpl_comm_put_nb,
+                       srcaddr, dstlocale, dstaddr, cnt[0],
+                       handles, &currHandles,
+                       typeIndex, commID, ln, fn);
         srcaddr+=srcstr[0];
         dstaddr+=dststr[0];
       }
     }
     break;
+
   case 3:
     for(i=0; i<cnt[3]; i++) {
       srcaddr1 = (int8_t*)srcaddr_arg + srcstr[2]*i;
@@ -4149,14 +4224,17 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
         dstaddr = dstaddr1 + dststr[1]*j;
         for(k=0; k<cnt[1]; k++) {
           PERFSTATS_ADD(put_strd_byte_cnt, cnt[0]);
-          chpl_comm_put(srcaddr, dstlocale, dstaddr, cnt[0],
-                        typeIndex, commID, ln, fn);
+          strd_nb_helper(chpl_comm_put_nb,
+                         srcaddr, dstlocale, dstaddr, cnt[0],
+                         handles, &currHandles,
+                         typeIndex, commID, ln, fn);
           srcaddr+=srcstr[0];
           dstaddr+=dststr[0];
         }
       }
     }
     break;
+
   default:
     dstaddr=(int8_t*)dstaddr_arg;
     srcaddr=(int8_t*)srcaddr_arg;
@@ -4187,8 +4265,11 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
             dstdisp[j]=dststr[t-1]*x;
           }
           PERFSTATS_ADD(put_strd_byte_cnt, cnt[0]);
-          chpl_comm_put(srcaddr+srcdisp[j], dstlocale, dstaddr+dstdisp[j],
-                        cnt[0], typeIndex, commID, ln, fn);
+          strd_nb_helper(chpl_comm_put_nb,
+                         srcaddr+srcdisp[j], dstlocale, dstaddr+dstdisp[j],
+                         cnt[0],
+                         handles, &currHandles,
+                         typeIndex, commID, ln, fn);
           break;
 
         } else { //ELSE 1
@@ -4200,7 +4281,12 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
     chpl_mem_free(dstdisp,0,0);
     break;
   }
+
+  if (currHandles > 0) {
+    (void) chpl_comm_wait_nb_some(handles, currHandles);
+  }
 }
+
 
 void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
                          int32_t srclocale,
@@ -4218,6 +4304,9 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
   size_t dststr[strlvls];
   size_t srcstr[strlvls];
   size_t cnt[strlvls+1];
+
+  chpl_comm_nb_handle_t handles[strd_maxHandles];
+  size_t currHandles = 0;
 
   PERFSTATS_INC(get_strd_cnt);
 
@@ -4252,30 +4341,37 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
     chpl_comm_get(dstaddr, srclocale, srcaddr, cnt[0],
                   typeIndex, commID, ln, fn);
     break;
+
   case 1:
     dstaddr=(int8_t*)dstaddr_arg;
     srcaddr=(int8_t*)srcaddr_arg;
     for(i=0; i<cnt[1]; i++) {
       PERFSTATS_ADD(get_strd_byte_cnt, cnt[0]);
-      chpl_comm_get(dstaddr, srclocale, srcaddr, cnt[0],
-                    typeIndex, commID, ln, fn);
+      strd_nb_helper(chpl_comm_get_nb,
+                     dstaddr, srclocale, srcaddr, cnt[0],
+                     handles, &currHandles,
+                     typeIndex, commID, ln, fn);
       srcaddr+=srcstr[0];
       dstaddr+=dststr[0];
     }
     break;
+
   case 2:
     for(i=0; i<cnt[2]; i++) {
       srcaddr = (int8_t*)srcaddr_arg + srcstr[1]*i;
       dstaddr = (int8_t*)dstaddr_arg + dststr[1]*i;
       for(j=0; j<cnt[1]; j++) {
         PERFSTATS_ADD(get_strd_byte_cnt, cnt[0]);
-        chpl_comm_get(dstaddr, srclocale, srcaddr, cnt[0],
-                      typeIndex, commID, ln, fn);
+        strd_nb_helper(chpl_comm_get_nb,
+                       dstaddr, srclocale, srcaddr, cnt[0],
+                       handles, &currHandles,
+                       typeIndex, commID, ln, fn);
         srcaddr+=srcstr[0];
         dstaddr+=dststr[0];
       }
     }
     break;
+
   case 3:
     for(i=0; i<cnt[3]; i++) {
       srcaddr1 = (int8_t*)srcaddr_arg + srcstr[2]*i;
@@ -4285,14 +4381,17 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
         dstaddr = dstaddr1 + dststr[1]*j;
         for(k=0; k<cnt[1]; k++) {
           PERFSTATS_ADD(get_strd_byte_cnt, cnt[0]);
-          chpl_comm_get(dstaddr, srclocale, srcaddr, cnt[0],
-                        typeIndex, commID, ln, fn);
+          strd_nb_helper(chpl_comm_get_nb,
+                         dstaddr, srclocale, srcaddr, cnt[0],
+                         handles, &currHandles,
+                         typeIndex, commID, ln, fn);
           srcaddr+=srcstr[0];
           dstaddr+=dststr[0];
         }
       }
     }
     break;
+
   default:
     dstaddr=(int8_t*)dstaddr_arg;
     srcaddr=(int8_t*)srcaddr_arg;
@@ -4323,8 +4422,11 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
             dstdisp[j]=dststr[t-1]*x;
           }
           PERFSTATS_ADD(get_strd_byte_cnt, cnt[0]);
-          chpl_comm_get(dstaddr+dstdisp[j], srclocale, srcaddr+srcdisp[j],
-                        cnt[0], typeIndex, commID, ln, fn);
+          strd_nb_helper(chpl_comm_get_nb,
+                         dstaddr+dstdisp[j], srclocale, srcaddr+srcdisp[j],
+                         cnt[0],
+                         handles, &currHandles,
+                         typeIndex, commID, ln, fn);
           break;
 
         } else {  //ELSE 1
@@ -4335,6 +4437,10 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
     chpl_mem_free(srcdisp,0,0);
     chpl_mem_free(dstdisp,0,0);
     break;
+  }
+
+  if (currHandles > 0) {
+    (void) chpl_comm_wait_nb_some(handles, currHandles);
   }
 }
 


### PR DESCRIPTION
In the general case the strided transfer routines may do many GETs or
PUTs one after another.  Improve performance on these by doing them with
nonblocking transactions and having many in flight at once.  (This idea
due to @benharsh - thanks!)