### PR TITLE
Removed $dirs_to_ignore from paratest.server

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -31,8 +31,6 @@
 $debug = 0;                            # turn on debug output
 $verbose = 0;                          # more verbose output
 
-$dirs_to_ignore = "Bin|Logs|Samples|OUTPUT|RCS";
-
 $logdir = "Logs";                      # dir under test to store logs
 $synchdir = "$logdir/.synch";          # where to store temporary metadata
 $rem_exe = "ssh -x";                   # disable X
@@ -437,7 +435,6 @@ sub find_subdirs {
     }
     
     foreach $filen (@cdir) {
-	next if ($filen =~ /$dirs_to_ignore/);
 	if (-d "$targetdir/$filen") {                 # if dir
         # .skipif does double duty here.  
         # When attached to a directory name, skips it and all descendents if the condition is true.
@@ -469,7 +466,6 @@ sub find_files {
     closedir CURRDIR;
 
     foreach $filen (@cdir) {
-	next if ($filen =~ /$dirs_to_ignore/);
 	$filepath = "$targetdir/$filen";
 	unless (-e "$targetdir/NOTEST") {             # do not ignore this dir?
 	    if ($filepath =~ /\.chpl$/) {


### PR DESCRIPTION
We had this in paratest.server:

  $dirs_to_ignore = "Bin|Logs|Samples|OUTPUT|RCS";

which excluded from para-testing any directories whose names contained
one of these words. There was/is no counterpart to that in start_test.
As one outcome, nightlies tested $CHPL_HOME/test/Samples, whereas
paratest did not, with consequent divergence in total test counts.

This change removes $dirs_to_ignore and associated code.

Tested: linux64 -futures. The test counts and the set of lines matching -i "success" in the log file are the same (except for compiler timing-related output) as for the nightly linux64 test for the same tree.
