### PR TITLE
throws for instantiations of generic functions

### DIFF
--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -530,6 +530,9 @@ FnSymbol* instantiateSignature(FnSymbol*  fn,
     }
   }
 
+  if (retval != NULL && fn->throwsError())
+    retval->throwsErrorInit();
+
   return retval;
 }
 

--- a/test/errhandling/psahabu/generic-throws.chpl
+++ b/test/errhandling/psahabu/generic-throws.chpl
@@ -1,0 +1,10 @@
+proc test(x) throws {
+  throw new Error(x:string + " is a numeric type");
+}
+
+config const num = 42;
+try {
+  test(num);
+} catch e {
+  halt(e:string);
+}

--- a/test/errhandling/psahabu/generic-throws.good
+++ b/test/errhandling/psahabu/generic-throws.good
@@ -1,0 +1,1 @@
+generic-throws.chpl:9: error: halt reached - {msg = 42 is a numeric type}


### PR DESCRIPTION
One of our users discovered a bug where generic functions could be marked `throws`, but their instantiations would not inherit that `throws` declaration. This PR ensures that `_throwsError` is carried over from the generic to any of its instantiations.