### PR TITLE
Extract class ModuleSymbol from symbol.{h,cpp} in to ModuleSymbol.{h.cpp}

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -237,9 +237,10 @@ bool AstDumpToNode::enterModSym(ModuleSymbol* node)
   }
   else
   {
-    const char* tag = modTagDescrString(node->modTag);
+    const char* tag = ModuleSymbol::modTagToString(node->modTag);
 
     enterNode(node);
+
     fprintf(mFP, " %s", node->name);
 
     mOffset = mOffset + 2;
@@ -247,6 +248,7 @@ bool AstDumpToNode::enterModSym(ModuleSymbol* node)
     newline();
 
     fprintf(mFP, "ModTag: %s\n", tag);
+
     newline();
 
     retval  = true;

--- a/compiler/AST/Makefile.share
+++ b/compiler/AST/Makefile.share
@@ -29,6 +29,7 @@ AST_SRCS =                                          \
            iterator.cpp                             \
            foralls.cpp                              \
            flags.cpp                                \
+           ModuleSymbol.cpp                         \
            PartialCopyData.cpp                      \
            primitive.cpp                            \
            stmt.cpp                                 \

--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -1,0 +1,572 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "ModuleSymbol.h"
+
+#include "AstVisitor.h"
+#include "docsDriver.h"
+#include "stlUtil.h"
+#include "stmt.h"
+#include "stringutil.h"
+
+ModuleSymbol*                      rootModule            = NULL;
+ModuleSymbol*                      theProgram            = NULL;
+ModuleSymbol*                      baseModule            = NULL;
+ModuleSymbol*                      mainModule            = NULL;
+
+ModuleSymbol*                      stringLiteralModule   = NULL;
+ModuleSymbol*                      standardModule        = NULL;
+ModuleSymbol*                      printModuleInitModule = NULL;
+
+Vec<ModuleSymbol*>                 userModules; // Contains user + main modules
+Vec<ModuleSymbol*>                 allModules;  // Contains all modules
+
+static std::vector<ModuleSymbol*>  sTopLevelModules;
+
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+void ModuleSymbol::addTopLevelModule(ModuleSymbol* module) {
+  sTopLevelModules.push_back(module);
+
+  theProgram->block->insertAtTail(new DefExpr(module));
+}
+
+
+void ModuleSymbol::getTopLevelModules(std::vector<ModuleSymbol*>& mods) {
+  for (size_t i = 0; i < sTopLevelModules.size(); i++) {
+    mods.push_back(sTopLevelModules[i]);
+  }
+}
+
+const char* ModuleSymbol::modTagToString(ModTag modTag) {
+  const char* retval = NULL;
+
+  switch (modTag) {
+    case MOD_INTERNAL:
+      retval = "internal";
+      break;
+
+    case MOD_STANDARD:
+      retval = "standard";
+      break;
+
+    case MOD_USER:
+      retval = "user";
+      break;
+  }
+
+  return retval;
+}
+
+
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+ModuleSymbol::ModuleSymbol(const char* iName,
+                           ModTag      iModTag,
+                           BlockStmt*  iBlock)
+  : Symbol(E_ModuleSymbol, iName) {
+
+  modTag              = iModTag;
+  block               = iBlock;
+  initFn              = NULL;
+  deinitFn            = NULL;
+  filename            = NULL;
+  doc                 = NULL;
+  extern_info         = NULL;
+  llvmDINameSpace     = NULL;
+
+  block->parentSymbol = this;
+
+  registerModule(this);
+
+  gModuleSymbols.add(this);
+}
+
+
+ModuleSymbol::~ModuleSymbol() {
+
+}
+
+
+void ModuleSymbol::verify() {
+  Symbol::verify();
+
+  if (astTag != E_ModuleSymbol) {
+    INT_FATAL(this, "Bad ModuleSymbol::astTag");
+  }
+
+  if (block && block->parentSymbol != this) {
+    INT_FATAL(this, "Bad ModuleSymbol::block::parentSymbol");
+  }
+
+  verifyNotOnList(block);
+
+  if (initFn) {
+    verifyInTree(initFn, "ModuleSymbol::initFn");
+
+    INT_ASSERT(initFn->defPoint->parentSymbol == this);
+  }
+
+  if (deinitFn) {
+    verifyInTree(deinitFn, "ModuleSymbol::deinitFn");
+
+    INT_ASSERT(deinitFn->defPoint->parentSymbol == this);
+
+    // initFn must call chpl_addModule(deinitFn) if deinitFn is present.
+    INT_ASSERT(initFn);
+  }
+}
+
+
+ModuleSymbol* ModuleSymbol::copyInner(SymbolMap* map) {
+  INT_FATAL(this, "Illegal call to ModuleSymbol::copy");
+
+  return NULL;
+}
+
+// Collect the top-level classes for this Module.
+//
+// 2014/07/25 MDN.  This function is currently only called by
+// docs.  Historically all of the top-level classes were buried
+// inside the prototypical module initFn.
+//
+// Installing The initFn is being moved forward but there are
+// still short periods of time when the classes will still be
+// buried inside the module initFn.
+//
+// Hence this function is currently able to handle the before
+// and after case.  The before case can be pulled out once the
+// construction of the initFn is cleaned up.
+//
+
+Vec<AggregateType*> ModuleSymbol::getTopLevelClasses() {
+  Vec<AggregateType*> classes;
+
+  for_alist(expr, block->body) {
+    if (DefExpr* def = toDefExpr(expr)) {
+
+      if (TypeSymbol* type = toTypeSymbol(def->sym)) {
+        if (AggregateType* cl = toAggregateType(type->type)) {
+          classes.add(cl);
+        }
+
+      // Step in to the initFn
+      } else if (FnSymbol* fn = toFnSymbol(def->sym)) {
+        if (fn->hasFlag(FLAG_MODULE_INIT)) {
+          for_alist(expr2, fn->body->body) {
+            if (DefExpr* def2 = toDefExpr(expr2)) {
+              if (TypeSymbol* type = toTypeSymbol(def2->sym)) {
+                if (AggregateType* cl = toAggregateType(type->type)) {
+                  classes.add(cl);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return classes;
+}
+
+
+void ModuleSymbol::printDocs(std::ostream* file,
+                             unsigned int  tabs,
+                             std::string   parentName) {
+  if (this->noDocGen()) {
+    return;
+  }
+
+  // Print the module directive first, for .rst mode. This will associate the
+  // Module: <name> title with the module. If the .. module:: directive comes
+  // after the title, sphinx will complain about a duplicate id error.
+  if (!fDocsTextOnly) {
+    *file << ".. default-domain:: chpl" << std::endl << std::endl;
+    *file << ".. module:: " << this->docsName() << std::endl;
+
+    if (this->doc != NULL) {
+      this->printTabs(file, tabs + 1);
+
+      *file << ":synopsis: ";
+      *file << firstNonEmptyLine(this->doc);
+      *file << std::endl;
+    }
+
+    *file << std::endl;
+  }
+
+  this->printTabs(file, tabs);
+
+  const char* moduleTitle = astr(this->docsName().c_str());
+
+  *file << moduleTitle << std::endl;
+
+  if (fDocsTextOnly == false) {
+    int length = tabs * this->tabText.length() + strlen(moduleTitle);
+
+    for (int i = 0; i < length; i++) {
+      *file << "=";
+    }
+
+    *file << std::endl;
+  }
+
+  if (fDocsTextOnly == false) {
+    *file << "**Usage**" << std::endl << std::endl;
+    *file << ".. code-block:: chapel" << std::endl << std::endl;
+
+  } else {
+    *file << std::endl;
+    *file << "Usage:" << std::endl;
+  }
+
+  this->printTabs(file, tabs + 1);
+
+  *file << "use ";
+
+  if (parentName != "") {
+    *file << parentName << ".";
+  }
+
+  *file << name << ";" << std::endl << std::endl;
+
+  // If we had submodules, be sure to link to them
+  if (hasTopLevelModule() == true) {
+    this->printTableOfContents(file);
+  }
+
+  if (this->doc != NULL) {
+    // Only print tabs for text only mode. The .rst prefers not to have the
+    // tabs for module level comments and leading whitespace removed.
+    unsigned int t = tabs;
+
+    if (fDocsTextOnly == true) {
+      t += 1;
+    }
+
+    this->printDocsDescription(this->doc, file, t);
+
+    if (fDocsTextOnly == false) {
+      *file << std::endl;
+    }
+  }
+}
+
+
+/*
+ * Append 'prefix' to existing module name prefix.
+ */
+void ModuleSymbol::printTableOfContents(std::ostream* file) {
+  int tabs = 1;
+
+  if (fDocsTextOnly == false) {
+    *file << "**Submodules**" << std::endl << std::endl;
+
+    *file << ".. toctree::" << std::endl;
+    this->printTabs(file, tabs);
+
+    *file << ":maxdepth: 1" << std::endl;
+    this->printTabs(file, tabs);
+
+    *file << ":glob:" << std::endl << std::endl;
+    this->printTabs(file, tabs);
+    *file << name << "/*" << std::endl << std::endl;
+
+  } else {
+    *file << "Submodules for this module are located in the " << name;
+    *file << "/ directory" << std::endl << std::endl;
+  }
+}
+
+
+/*
+ * Returns name of module, including any prefixes that have been set.
+ */
+std::string ModuleSymbol::docsName() {
+  return this->name;
+}
+
+
+// This is intended to be called by getTopLevelConfigsVars and
+// getTopLevelVariables, since the code for them would otherwise be roughly
+// the same.
+
+// It is also private to ModuleSymbols
+//
+// See the comment on getTopLevelFunctions() for the rationale behind the AST
+// traversal
+void ModuleSymbol::getTopLevelConfigOrVariables(Vec<VarSymbol*>* contain,
+                                                Expr*            expr,
+                                                bool             config) {
+  if (DefExpr* def = toDefExpr(expr)) {
+
+    if (VarSymbol* var = toVarSymbol(def->sym)) {
+      if (var->hasFlag(FLAG_CONFIG) == config) {
+        // The config status of the variable matches what we are looking for
+        contain->add(var);
+      }
+
+    } else if (FnSymbol* fn = toFnSymbol(def->sym)) {
+      if (fn->hasFlag(FLAG_MODULE_INIT)) {
+        for_alist(expr2, fn->body->body) {
+          if (DefExpr* def2 = toDefExpr(expr2)) {
+            if (VarSymbol* var = toVarSymbol(def2->sym)) {
+              if (var->hasFlag(FLAG_CONFIG) == config) {
+                // The config status of the variable matches what we are
+                // looking for
+                contain->add(var);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Collect the top-level config variables for this Module.
+Vec<VarSymbol*> ModuleSymbol::getTopLevelConfigVars() {
+  Vec<VarSymbol*> configs;
+
+  for_alist(expr, block->body) {
+    getTopLevelConfigOrVariables(&configs, expr, true);
+  }
+
+  return configs;
+}
+
+// Collect the top-level variables that aren't configs for this Module.
+Vec<VarSymbol*> ModuleSymbol::getTopLevelVariables() {
+  Vec<VarSymbol*> variables;
+
+  for_alist(expr, block->body) {
+    getTopLevelConfigOrVariables(&variables, expr, false);
+  }
+
+  return variables;
+}
+
+// Collect the top-level functions for this Module.
+//
+// This one is similar to getTopLevelModules() and
+// getTopLevelClasses() except that it collects any
+// functions and then steps in to initFn if it finds it.
+//
+Vec<FnSymbol*> ModuleSymbol::getTopLevelFunctions(bool includeExterns) {
+  Vec<FnSymbol*> fns;
+
+  for_alist(expr, block->body) {
+    if (DefExpr* def = toDefExpr(expr)) {
+      if (FnSymbol* fn = toFnSymbol(def->sym)) {
+        // Ignore external and prototype functions.
+        if (includeExterns == false &&
+            fn->hasFlag(FLAG_EXTERN)) {
+          continue;
+        }
+
+        fns.add(fn);
+
+        // The following additional overhead and that present in getConfigVars
+        // and getClasses is a result of the docs pass occurring before
+        // the functions/configvars/classes are taken out of the module
+        // initializer function and put on the same level as that function.
+        // If and when that changes, the code encapsulated in this if
+        // statement may be removed.
+        if (fn->hasFlag(FLAG_MODULE_INIT)) {
+          for_alist(expr2, fn->body->body) {
+            if (DefExpr* def2 = toDefExpr(expr2)) {
+              if (FnSymbol* fn2 = toFnSymbol(def2->sym)) {
+                if (includeExterns == false &&
+                    fn2->hasFlag(FLAG_EXTERN)) {
+                  continue;
+                }
+
+                fns.add(fn2);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return fns;
+}
+
+Vec<ModuleSymbol*> ModuleSymbol::getTopLevelModules() {
+  Vec<ModuleSymbol*> mods;
+
+  for_alist(expr, block->body) {
+    if (DefExpr* def = toDefExpr(expr))
+      if (ModuleSymbol* mod = toModuleSymbol(def->sym)) {
+        if (strcmp(mod->defPoint->parentSymbol->name, name) == 0)
+          mods.add(mod);
+      }
+  }
+
+  return mods;
+}
+
+// Intended for documentation purposes only, please don't use otherwise.
+bool ModuleSymbol::hasTopLevelModule() {
+  for_alist(expr, block->body) {
+    if (DefExpr* def = toDefExpr(expr)) {
+      if (ModuleSymbol* mod = toModuleSymbol(def->sym)) {
+        if (mod->defPoint->parentExpr == block && !mod->noDocGen()) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+void ModuleSymbol::replaceChild(BaseAST* oldAst, BaseAST* newAst) {
+  if (oldAst == block) {
+    block = toBlockStmt(newAst);
+
+  } else {
+    INT_FATAL(this, "Unexpected case in ModuleSymbol::replaceChild");
+  }
+}
+
+void ModuleSymbol::accept(AstVisitor* visitor) {
+  if (visitor->enterModSym(this) == true) {
+    if (block != NULL) {
+      block->accept(visitor);
+    }
+
+    visitor->exitModSym(this);
+  }
+}
+
+void ModuleSymbol::addDefaultUses() {
+  if (modTag != MOD_INTERNAL) {
+    ModuleSymbol* parentModule = toModuleSymbol(this->defPoint->parentSymbol);
+
+    assert (parentModule != NULL);
+
+    //
+    // Don't insert 'use ChapelStandard' for nested user modules.
+    // They should get their ChapelStandard symbols from their parent.
+    //
+    if (parentModule->modTag != MOD_USER) {
+      SET_LINENO(this);
+
+      UnresolvedSymExpr* modRef = new UnresolvedSymExpr("ChapelStandard");
+
+      block->insertAtHead(new UseStmt(modRef));
+    }
+
+  // We don't currently have a good way to fetch the root module by name.
+  // Insert it directly rather than by name
+  } else if (this == baseModule) {
+    SET_LINENO(this);
+
+    block->useListAdd(rootModule);
+
+    UnresolvedSymExpr* modRef = new UnresolvedSymExpr("ChapelStringLiterals");
+
+    block->insertAtHead(new UseStmt(modRef));
+  }
+}
+
+//
+// NOAKES 2014/07/22
+//
+// There is currently a problem in functionResolve that this function
+// has a "temporary" work around for.
+
+// There is somewhere within that code that believes the order of items in
+// modUseList is an indicator of "dependence order" even though this list
+// does not and cannot maintain that information.
+//
+// Fortunately there are currently no tests that expose this fallacy so
+// long at ChapelStandard always appears first in the list
+void ModuleSymbol::moduleUseAdd(ModuleSymbol* mod) {
+  if (mod != this && modUseList.index(mod) < 0) {
+    if (mod == standardModule) {
+      modUseList.insert(0, mod);
+
+    } else {
+      modUseList.add(mod);
+    }
+  }
+}
+
+// If the specified module is currently used by the target
+// then remove the module from the use-state of this module
+// but introduce references to the children of the module
+// being dropped.
+//
+// At this time this is only used for deadCodeElimination and
+// it is not clear if there will be other uses.
+void ModuleSymbol::moduleUseRemove(ModuleSymbol* mod) {
+  int index = modUseList.index(mod);
+
+  if (index >= 0) {
+    bool inBlock = block->useListRemove(mod);
+
+    modUseList.remove(index);
+
+    // The dead module may have used other modules.  If so add them
+    // to the current module
+    forv_Vec(ModuleSymbol, modUsedByDeadMod, mod->modUseList) {
+      if (modUseList.index(modUsedByDeadMod) < 0) {
+        SET_LINENO(this);
+
+        if (inBlock == true) {
+          block->useListAdd(modUsedByDeadMod);
+        }
+
+        modUseList.add(modUsedByDeadMod);
+      }
+    }
+  }
+}
+
+void initRootModule() {
+  rootModule           = new ModuleSymbol("_root",
+                                          MOD_INTERNAL,
+                                          new BlockStmt());
+
+  rootModule->filename = astr("<internal>");
+}
+
+void initStringLiteralModule() {
+  stringLiteralModule           = new ModuleSymbol("ChapelStringLiterals",
+                                                   MOD_INTERNAL,
+                                                   new BlockStmt());
+
+  stringLiteralModule->filename = astr("<internal>");
+
+  ModuleSymbol::addTopLevelModule(stringLiteralModule);
+}

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -17,10 +17,6 @@
  * limitations under the License.
  */
 
-#include <ostream>
-#include <sstream>
-#include <string>
-
 #include "baseAST.h"
 
 #include "astutil.h"
@@ -30,6 +26,7 @@
 #include "expr.h"
 #include "ForLoop.h"
 #include "log.h"
+#include "ModuleSymbol.h"
 #include "ParamForLoop.h"
 #include "parser.h"
 #include "passes.h"
@@ -40,6 +37,10 @@
 #include "TryStmt.h"
 #include "type.h"
 #include "WhileStmt.h"
+
+#include <ostream>
+#include <sstream>
+#include <string>
 
 //
 // declare global vectors gSymExprs, gCallExprs, gFnSymbols, ...
@@ -545,9 +546,6 @@ void BaseAST::printDocsDescription(const char *doc, std::ostream *file, unsigned
 
 
 astlocT currentAstLoc(0,NULL);
-
-Vec<ModuleSymbol*> userModules; // Contains user + main modules
-Vec<ModuleSymbol*> allModules;  // Contains all modules
 
 void registerModule(ModuleSymbol* mod) {
   switch (mod->modTag) {

--- a/compiler/AST/flags.cpp
+++ b/compiler/AST/flags.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -73,31 +73,41 @@ void writeFlags(FILE* fp, Symbol* sym) {
 
 
 // these affect what viewFlags() prints
-bool viewFlagsShort = true;
-bool viewFlagsPragma = false;
-bool viewFlagsName  = false;
+bool viewFlagsShort   = true;
+bool viewFlagsPragma  = false;
+bool viewFlagsName    = false;
 bool viewFlagsComment = false;
-bool viewFlagsExtras = true;
+bool viewFlagsExtras  = true;
 
-void
-viewFlags(BaseAST* ast) {
-  if (!viewFlagsShort && !viewFlagsName && !viewFlagsComment)
+void viewFlags(BaseAST* ast) {
+  if (!viewFlagsShort && !viewFlagsName && !viewFlagsComment) {
     viewFlagsName = true;
+  }
+
   if (Symbol* sym = toSymbol(ast)) {
     for (int flagNum = FLAG_FIRST; flagNum <= FLAG_LAST; flagNum++) {
       if (sym->flags[flagNum]) {
-        if (viewFlagsName)
+        if (viewFlagsName) {
           printf("%s ", flagNames[flagNum]);
-        if (viewFlagsPragma)
+        }
+
+        if (viewFlagsPragma) {
           printf("%s", flagPragma[flagNum] ? "ypr " : "npr ");
-        if (viewFlagsShort)
+        }
+
+        if (viewFlagsShort) {
           printf("\"%s\" ", flagShortNames[flagNum]);
-        if (viewFlagsComment)
+        }
+
+        if (viewFlagsComment) {
           printf("// %s",
                  *flagComments[flagNum] ? flagComments[flagNum] : "ncm");
+        }
+
         printf("\n");
       }
     }
+
     if (viewFlagsExtras) {
       if (VarSymbol* vs = toVarSymbol(sym)) {
         if (vs->immediate) {
@@ -105,24 +115,33 @@ viewFlags(BaseAST* ast) {
           fprint_imm(stdout, *toVarSymbol(sym)->immediate, true);
           printf("\n");
         }
+
       } else if (ArgSymbol* as = toArgSymbol(sym)) {
         printf("%s arg\n", as->intentDescrString());
+
       } else if (toTypeSymbol(sym)) {
         printf("a TypeSymbol\n");
+
       } else if (FnSymbol* fs = toFnSymbol(sym)) {
         printf("fn %s(%d args) %s\n",
                fs->_this ? intentDescrString(fs->thisTag) : "",
-               fs->numFormals(), retTagDescrString(fs->retTag));
+               fs->numFormals(),
+               retTagDescrString(fs->retTag));
+
       } else if (toEnumSymbol(sym)) {
         printf("an EnumSymbol\n");
+
       } else if (ModuleSymbol* ms = toModuleSymbol(sym)) {
-        printf("module %s\n", modTagDescrString(ms->modTag));
+        printf("module %s\n", ModuleSymbol::modTagToString(ms->modTag));
+
       } else if (toLabelSymbol(sym)) {
         printf("a LabelSymbol\n");
+
       } else {
         printf("unknown symbol kind\n");
       }
     }
+
   } else {
     printf("[%d]: not a Symbol, has no flags\n", ast->id);
   }

--- a/compiler/include/ModuleSymbol.h
+++ b/compiler/include/ModuleSymbol.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _MODULE_SYMBOL_H_
+#define _MODULE_SYMBOL_H_
+
+#include "symbol.h"
+
+enum ModTag {
+  MOD_INTERNAL,  // an internal module that the user shouldn't know about
+  MOD_STANDARD,  // a standard module from the Chapel libraries
+  MOD_USER       // a module found along the user's search path
+};
+
+struct ExternBlockInfo;
+
+class ModuleSymbol : public Symbol {
+public:
+  static void          addTopLevelModule (ModuleSymbol*               module);
+  static void          getTopLevelModules(std::vector<ModuleSymbol*>& mods);
+
+  static const char*   modTagToString(ModTag modTag);
+
+
+public:
+                       ModuleSymbol(const char* iName,
+                                    ModTag      iModTag,
+                                    BlockStmt*  iBlock);
+
+                      ~ModuleSymbol();
+
+  // Interface to BaseAST
+  virtual void         verify();
+  virtual void         accept(AstVisitor* visitor);
+
+  DECLARE_SYMBOL_COPY(ModuleSymbol);
+
+  // Interface to Symbol
+  virtual void         replaceChild(BaseAST* oldAst, BaseAST* newAst);
+  virtual void         codegenDef();
+
+  // New interface
+  Vec<AggregateType*>  getTopLevelClasses();
+  Vec<VarSymbol*>      getTopLevelConfigVars();
+  Vec<VarSymbol*>      getTopLevelVariables();
+  Vec<FnSymbol*>       getTopLevelFunctions(bool includeExterns);
+  Vec<ModuleSymbol*>   getTopLevelModules();
+
+  void                 addDefaultUses();
+  void                 moduleUseAdd(ModuleSymbol* module);
+  void                 moduleUseRemove(ModuleSymbol* module);
+
+  void                 printDocs(std::ostream* file,
+                                 unsigned int  tabs,
+                                 std::string   parentName);
+
+  void                 printTableOfContents(std::ostream* file);
+
+  std::string          docsName();
+
+
+  ModTag               modTag;
+
+  BlockStmt*           block;
+  FnSymbol*            initFn;
+  FnSymbol*            deinitFn;
+
+  Vec<ModuleSymbol*>   modUseList;
+
+  const char*          filename;
+  const char*          doc;
+
+  // LLVM uses this for extern C blocks.
+#ifdef HAVE_LLVM
+  ExternBlockInfo*     extern_info;
+  llvm::MDNode*        llvmDINameSpace;
+#else
+  void*                extern_info;
+  void*                llvmDINameSpace;
+#endif
+
+private:
+  void                 getTopLevelConfigOrVariables(Vec<VarSymbol*>* contain,
+                                                    Expr*            expr,
+                                                    bool             config);
+  bool                 hasTopLevelModule();
+};
+
+extern ModuleSymbol*      rootModule;
+extern ModuleSymbol*      theProgram;
+extern ModuleSymbol*      baseModule;
+extern ModuleSymbol*      mainModule;
+
+extern ModuleSymbol*      stringLiteralModule;
+extern ModuleSymbol*      standardModule;
+extern ModuleSymbol*      printModuleInitModule;
+
+extern Vec<ModuleSymbol*> allModules;
+extern Vec<ModuleSymbol*> userModules;
+
+
+void        initRootModule();
+
+void        initStringLiteralModule();
+
+#endif

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -301,12 +301,6 @@ public:
 };
 
 //
-// vectors of modules
-//
-extern Vec<ModuleSymbol*> allModules;  // contains all modules
-extern Vec<ModuleSymbol*> userModules; // contains user modules
-
-//
 // class test inlines: determine the dynamic type of a BaseAST*
 //
 static inline bool isExpr(const BaseAST* a)

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -60,36 +60,29 @@ enum RetTag {
   RET_TYPE
 };
 
-const int INTENT_FLAG_IN    = 0x01;
-const int INTENT_FLAG_OUT   = 0x02;
-const int INTENT_FLAG_CONST = 0x04;
-const int INTENT_FLAG_REF   = 0x08;
-const int INTENT_FLAG_PARAM = 0x10;
-const int INTENT_FLAG_TYPE  = 0x20;
-const int INTENT_FLAG_BLANK = 0x40;
+const int INTENT_FLAG_IN          = 0x01;
+const int INTENT_FLAG_OUT         = 0x02;
+const int INTENT_FLAG_CONST       = 0x04;
+const int INTENT_FLAG_REF         = 0x08;
+const int INTENT_FLAG_PARAM       = 0x10;
+const int INTENT_FLAG_TYPE        = 0x20;
+const int INTENT_FLAG_BLANK       = 0x40;
 const int INTENT_FLAG_MAYBE_CONST = 0x80;
 
 // If this enum is modified, ArgSymbol::intentDescrString()
 // and intentDescrString(IntentTag) should also be updated to match
 enum IntentTag {
-  INTENT_IN        = INTENT_FLAG_IN,
-  INTENT_OUT       = INTENT_FLAG_OUT,
-  INTENT_INOUT     = INTENT_FLAG_IN    | INTENT_FLAG_OUT,
-  INTENT_CONST     = INTENT_FLAG_CONST,
-  INTENT_CONST_IN  = INTENT_FLAG_CONST | INTENT_FLAG_IN,
-  INTENT_REF       = INTENT_FLAG_REF,
-  INTENT_CONST_REF = INTENT_FLAG_CONST | INTENT_FLAG_REF,
+  INTENT_IN              = INTENT_FLAG_IN,
+  INTENT_OUT             = INTENT_FLAG_OUT,
+  INTENT_INOUT           = INTENT_FLAG_IN          | INTENT_FLAG_OUT,
+  INTENT_CONST           = INTENT_FLAG_CONST,
+  INTENT_CONST_IN        = INTENT_FLAG_CONST       | INTENT_FLAG_IN,
+  INTENT_REF             = INTENT_FLAG_REF,
+  INTENT_CONST_REF       = INTENT_FLAG_CONST       | INTENT_FLAG_REF,
   INTENT_REF_MAYBE_CONST = INTENT_FLAG_MAYBE_CONST | INTENT_FLAG_REF,
-  INTENT_PARAM     = INTENT_FLAG_PARAM,
-  INTENT_TYPE      = INTENT_FLAG_TYPE,
-  INTENT_BLANK     = INTENT_FLAG_BLANK
-};
-
-// keep in sync with modTagDescrString()
-enum ModTag {
-  MOD_INTERNAL,  // an internal module that the user shouldn't know about
-  MOD_STANDARD,  // a standard module from the Chapel libraries
-  MOD_USER,      // a module found along the user's search path
+  INTENT_PARAM           = INTENT_FLAG_PARAM,
+  INTENT_TYPE            = INTENT_FLAG_TYPE,
+  INTENT_BLANK           = INTENT_FLAG_BLANK
 };
 
 typedef std::bitset<NUM_FLAGS> FlagSet;
@@ -546,7 +539,7 @@ private:
 ************************************** | *************************************/
 
 class EnumSymbol : public Symbol {
- public:
+public:
                   EnumSymbol(const char* initName);
 
   virtual void    verify();
@@ -568,87 +561,16 @@ class EnumSymbol : public Symbol {
 *                                                                             *
 ************************************** | *************************************/
 
-struct ExternBlockInfo;
+#include "ModuleSymbol.h"
 
-class ModuleSymbol : public Symbol {
-public:
-  static void          addTopLevelModule (ModuleSymbol*               module);
-  static void          getTopLevelModules(std::vector<ModuleSymbol*>& mods);
-
-public:
-                       ModuleSymbol(const char* iName,
-                                    ModTag      iModTag,
-                                    BlockStmt*  iBlock);
-
-                      ~ModuleSymbol();
-
-  // Interface to BaseAST
-  virtual void         verify();
-  virtual void         accept(AstVisitor* visitor);
-
-  DECLARE_SYMBOL_COPY(ModuleSymbol);
-
-  // Interface to Symbol
-  virtual void replaceChild(BaseAST* old_ast, BaseAST* new_ast);
-  virtual void codegenDef();
-
-  // New interface
-  Vec<AggregateType*>  getTopLevelClasses();
-  Vec<VarSymbol*>      getTopLevelConfigVars();
-  Vec<VarSymbol*>      getTopLevelVariables();
-  Vec<FnSymbol*>       getTopLevelFunctions(bool includeExterns);
-  Vec<ModuleSymbol*>   getTopLevelModules();
-
-  void                 addDefaultUses();
-  void                 moduleUseAdd(ModuleSymbol* module);
-  void                 moduleUseRemove(ModuleSymbol* module);
-
-  ModTag               modTag;
-
-  BlockStmt*           block;
-  FnSymbol*            initFn;
-  FnSymbol*            deinitFn;
-
-  Vec<ModuleSymbol*>   modUseList;
-
-  const char*          filename;
-  const char*          doc;
-
-  // LLVM uses this for extern C blocks.
-#ifdef HAVE_LLVM
-  ExternBlockInfo*     extern_info;
-  llvm::MDNode*        llvmDINameSpace;
-#else
-  void*                extern_info;
-  void*                llvmDINameSpace;
-#endif
-
-  void                 printDocs(std::ostream* file,
-                                 unsigned int  tabs,
-                                 std::string   parentName);
-
-  void                 printTableOfContents(std::ostream* file);
-
-  std::string          docsName();
-
-private:
-  void                 getTopLevelConfigOrVariables(Vec<VarSymbol*>* contain,
-                                                    Expr*            expr,
-                                                    bool             config);
-  bool                 hasTopLevelModule();
-};
-
-void initRootModule();
-
-void initStringLiteralModule();
-
-/******************************** | *********************************
-*                                                                   *
-*                                                                   *
-********************************* | ********************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 class LabelSymbol : public Symbol {
- public:
+public:
   GotoStmt* iterResumeGoto;
   LabelSymbol(const char* init_name);
   void verify();
@@ -658,10 +580,11 @@ class LabelSymbol : public Symbol {
   void codegenDef();
 };
 
-/******************************** | *********************************
-*                                                                   *
-*                                                                   *
-********************************* | ********************************/
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 // Processes a char* to replace any escape sequences with the actual bytes
 std::string unescapeString(const char* const str, BaseAST* astForError);
@@ -721,9 +644,10 @@ VarSymbol* newTempConst(Type* type);
 VarSymbol* newTempConst(const char* name, QualifiedType qt);
 VarSymbol* newTempConst(QualifiedType qt);
 
+void       verifyInTree(BaseAST* ast, const char* msg);
+
 // for use in an English sentence
-const char* retTagDescrString(RetTag retTag);
-const char* modTagDescrString(ModTag modTag);
+const char* retTagDescrString(RetTag    retTag);
 const char* intentDescrString(IntentTag intent);
 
 // Return true if the arg must use a C pointer whether or not
@@ -737,18 +661,12 @@ void addTaskIntent(CallExpr* ti,        Expr* var, IntentTag intent, Expr* ri);
 
 extern bool localTempNames;
 
-extern HashMap<Immediate *, ImmHashFns, VarSymbol *> uniqueConstantsHash;
-extern HashMap<Immediate *, ImmHashFns, VarSymbol *> stringLiteralsHash;
+extern HashMap<Immediate*, ImmHashFns, VarSymbol*> uniqueConstantsHash;
+extern HashMap<Immediate*, ImmHashFns, VarSymbol*> stringLiteralsHash;
+
 extern StringChainHash uniqueStringHash;
 
-extern ModuleSymbol* rootModule;
-extern ModuleSymbol* theProgram;
-extern ModuleSymbol* mainModule;
-extern ModuleSymbol* baseModule;
-extern ModuleSymbol* stringLiteralModule;
-extern FnSymbol* initStringLiterals;
-extern ModuleSymbol* standardModule;
-extern ModuleSymbol* printModuleInitModule;
+extern FnSymbol *initStringLiterals;
 extern Symbol *gNil;
 extern Symbol *gUnknown;
 extern Symbol *gMethodToken;


### PR DESCRIPTION
Extract the class ModuleSymbol from symbol.{h,cpp} to ModuleSymbol.{h,cpp} respectively.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64. Ran start_test on a
portion of release/ with both modes on both machines.  Also compiled with CHPL_LLVM=llvm
and ran start_test on a portion of release/ with --llvm

Passed single-locale paratest with -futures
