### PR TITLE
error syntax highlighting for vim, highlight

### DIFF
--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -177,10 +177,6 @@ or variable identifier (that's being defined)."
   "Keywords besides constants and operators that start primary expressions."
   chpl '("new" "delete")) ;; Not really a keyword, but practically works as one.
 
-(c-lang-defconst c-error-handling-kwds
-  "Keywords for error handling."
-  chpl '("catch" "throw" "throws" "try" "try!"))
-
 (c-lang-defconst c-other-kwds
   "Keywords not accounted for by any other `*-kwds' language constant."
   chpl '("align" "atomic" "begin" "by" "cobegin" "coforall" "dmapped" "for" "forall" "if" "in" "inout" "local" "noinit" "on" "out" "reduce" "ref" "scan" "serial" "single" "sparse" "sync" "where" "while" "with" "zip"))

--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -177,6 +177,7 @@ or variable identifier (that's being defined)."
   "Keywords besides constants and operators that start primary expressions."
   chpl '("new" "delete")) ;; Not really a keyword, but practically works as one.
 
+
 (c-lang-defconst c-other-kwds
   "Keywords not accounted for by any other `*-kwds' language constant."
   chpl '("align" "atomic" "begin" "by" "cobegin" "coforall" "dmapped" "for" "forall" "if" "in" "inout" "local" "noinit" "on" "out" "reduce" "ref" "scan" "serial" "single" "sparse" "sync" "where" "while" "with" "zip"))

--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -177,6 +177,9 @@ or variable identifier (that's being defined)."
   "Keywords besides constants and operators that start primary expressions."
   chpl '("new" "delete")) ;; Not really a keyword, but practically works as one.
 
+(c-lang-defconst c-error-handling-kwds
+  "Keywords for error handling."
+  chpl '("catch" "throw" "throws" "try" "try!"))
 
 (c-lang-defconst c-other-kwds
   "Keywords not accounted for by any other `*-kwds' language constant."

--- a/highlight/highlight/langDefs/chpl.lang
+++ b/highlight/highlight/langDefs/chpl.lang
@@ -12,15 +12,15 @@ Description="Chapel"
 Keywords={
   { Id=1,
    List={"as", "align", "atomic", "begin", "break", "by", "catch", "class",
-         "cobegin", "coforall", "config", "const", "continue", "proc", "iter",
-         "delete", "dmapped", "do", "domain", "else", "enum", "except",
-         "export", "extern", "false", "for", "forall", "if", "in", "index",
-         "inline", "inout", "label", "lambda", "let", "local", "module", "new",
+         "cobegin", "coforall", "config", "const", "continue", "delete",
+         "dmapped", "do", "domain", "else", "enum", "except", "export",
+         "extern", "false", "for", "forall", "if", "in", "index", "inline",
+         "inout", "iter", "label", "lambda", "let", "local", "module", "new",
          "nil", "noinit", "on", "only", "otherwise", "out", "param", "private",
-         "public", "record", "reduce", "ref", "require", "return", "scan",
-         "select", "serial", "single", "sparse", "subdomain", "sync", "then",
-         "throw", "throws", "true", "try", "try!", "type", "union", "use",
-         "var", "when", "where", "while", "with", "yield", "zip"
+         "proc", "public", "record", "reduce", "ref", "require", "return",
+         "scan", "select", "serial", "single", "sparse", "subdomain", "sync",
+         "then", "throw", "throws", "true", "try", "try!", "type", "union",
+         "use", "var", "when", "where", "while", "with", "yield", "zip"
         }
   },
   { Id=2,

--- a/highlight/highlight/langDefs/chpl.lang
+++ b/highlight/highlight/langDefs/chpl.lang
@@ -19,8 +19,8 @@ Keywords={
          "nil", "noinit", "on", "only", "otherwise", "out", "param", "private",
          "proc", "public", "record", "reduce", "ref", "require", "return",
          "scan", "select", "serial", "single", "sparse", "subdomain", "sync",
-         "then", "throw", "throws", "true", "try", "try!", "type", "union",
-         "use", "var", "when", "where", "while", "with", "yield", "zip"
+         "then", "throw", "throws", "true", "try", "type", "union", "use",
+         "var", "when", "where", "while", "with", "yield", "zip"
         }
   },
   { Id=2,

--- a/highlight/highlight/langDefs/chpl.lang
+++ b/highlight/highlight/langDefs/chpl.lang
@@ -11,16 +11,16 @@ Description="Chapel"
 
 Keywords={
   { Id=1,
-   List={"as", "align", "atomic", "begin", "break", "by", "class", "cobegin",
-         "coforall", "config", "const", "continue", "proc", "iter", "delete",
-         "dmapped", "do", "domain", "else", "enum", "except", "export",
-         "extern", "false", "for", "forall", "if", "in", "index", "inline",
-         "inout", "label", "lambda", "let", "local", "module", "new", "nil",
-         "noinit", "on", "only", "otherwise", "out", "param", "private",
+   List={"as", "align", "atomic", "begin", "break", "by", "catch", "class",
+         "cobegin", "coforall", "config", "const", "continue", "proc", "iter",
+         "delete", "dmapped", "do", "domain", "else", "enum", "except",
+         "export", "extern", "false", "for", "forall", "if", "in", "index",
+         "inline", "inout", "label", "lambda", "let", "local", "module", "new",
+         "nil", "noinit", "on", "only", "otherwise", "out", "param", "private",
          "public", "record", "reduce", "ref", "require", "return", "scan",
          "select", "serial", "single", "sparse", "subdomain", "sync", "then",
-         "true", "type", "union", "use", "var", "when", "where", "while",
-         "with", "yield", "zip"
+         "throw", "throws", "true", "try", "try!", "type", "union", "use",
+         "var", "when", "where", "while", "with", "yield", "zip"
         }
   },
   { Id=2,

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -258,6 +258,7 @@ syn keyword chplConditional	if then else
 syn keyword chplConstant	nil
 syn keyword chplRepeat		while for do coforall forall in serial
 syn keyword chplLabel	        when otherwise label
+syn keyword chplErrorHandling   throw throws try try! catch
 
 " Folding
 syn region scopeFold start="{" end="}" fold transparent
@@ -274,6 +275,7 @@ if version >= 508 || !exists("did_chpl_syntax_inits")
     command -nargs=+ HiLink hi def link <args>
   endif
   HiLink chplCast		chplStatement
+  HiLink chplErrorHandling	chplStatement
   HiLink chplOperator		Operator
   HiLink chplStatement		Statement
   HiLink chplIntent		StorageClass

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -258,7 +258,7 @@ syn keyword chplConditional	if then else
 syn keyword chplConstant	nil
 syn keyword chplRepeat		while for do coforall forall in serial
 syn keyword chplLabel	        when otherwise label
-syn keyword chplErrorHandling   throw throws try try! catch
+syn keyword chplErrorHandling   throw throws try catch
 
 " Folding
 syn region scopeFold start="{" end="}" fold transparent


### PR DESCRIPTION
@ben-albrecht is working with error handling and would like syntax highlighting in `vim` sooner. Hence, I'm merging what I have now for error handling syntax in `vim` and `highlight`.