### PR TITLE
Noinline attribute when using llvm-print-ir

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -45,6 +45,7 @@
 #include "stringutil.h"
 #include "type.h"
 #include "resolution.h"
+#include "llvm/IR/Attributes.h"
 
 
 #include <algorithm>
@@ -1260,8 +1261,10 @@ void FnSymbol::codegenDef() {
     func = getFunctionLLVM(cname);
 
     if(llvmPrintIrStageNum != llvmStageNum::NOPRINT
-            && strcmp(llvmPrintIrName, name) == 0)
+            && strcmp(llvmPrintIrName, name) == 0) {
+        func->addFnAttr(llvm::Attribute::NoInline);
         llvmPrintIrCName = cname;
+    }
 
     llvm::BasicBlock *block =
       llvm::BasicBlock::Create(info->module->getContext(), "entry", func);

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -45,8 +45,6 @@
 #include "stringutil.h"
 #include "type.h"
 #include "resolution.h"
-#include "llvm/IR/Attributes.h"
-
 
 #include <algorithm>
 #include <cstdlib>
@@ -55,6 +53,10 @@
 
 #include <inttypes.h>
 #include <stdint.h>
+
+#ifdef HAVE_LLVM
+#include "llvm/IR/Attributes.h"
+#endif
 
 /******************************** | *********************************
 *                                                                   *

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -54,10 +54,6 @@
 #include <inttypes.h>
 #include <stdint.h>
 
-#ifdef HAVE_LLVM
-#include "llvm/IR/Attributes.h"
-#endif
-
 /******************************** | *********************************
 *                                                                   *
 *                                                                   *


### PR DESCRIPTION
In full optimization stage function sometimes was inlined and removed from llvm module, easiest way to fix this is to add 'noinline' attribute for it.

The preferred way however is to add noinline pragma before function we want to print so that this option doesn't interfere with other optimization options and it is explicitly stated in code.

Other solution would be add _llvm-print-inline_ option which would specify if we want to turn this off or on.

Anyway, now we can see that adding noinline attribute is very easy to do.