### PR TITLE
Add basic support for TryStmt

### DIFF
--- a/compiler/include/AstDumpToNode.h
+++ b/compiler/include/AstDumpToNode.h
@@ -83,7 +83,6 @@ public:
   virtual void     exitAggrType        (AggregateType*     node);
 
   virtual bool     enterEnumType       (EnumType*          node);
-  virtual void     exitEnumType        (EnumType*          node);
 
   virtual void     visitPrimType       (PrimitiveType*     node);
 
@@ -103,6 +102,7 @@ public:
   virtual void     visitVarSym         (VarSymbol*         node);
 
   virtual bool     enterCallExpr       (CallExpr*          node);
+
   virtual bool     enterContextCallExpr(ContextCallExpr*   node);
 
   virtual bool     enterDefExpr        (DefExpr*           node);
@@ -133,7 +133,10 @@ public:
   virtual void     visitEblockStmt     (ExternBlockStmt*   node);
 
   virtual bool     enterGotoStmt       (GotoStmt*          node);
-  virtual void     exitGotoStmt        (GotoStmt*          node);
+
+  virtual bool     enterTryStmt        (TryStmt*           node);
+
+  virtual bool     enterCatchStmt      (CatchStmt*         node);
 
 private:
                    AstDumpToNode();


### PR DESCRIPTION
Minor updates to AstDumpToNode.{h,cpp} to provide preliminary support for TryStmt/CatchStmt.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64

This code is only used in certain debugging contexts and so I merely verified that a 
small portion of test/release ran without failure.
