### PR TITLE
Update mpicc.gasnet testing to use common-gasnet.bash

### DIFF
--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -21,4 +21,6 @@ export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl modules/packages/mpi
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="mpicc.gasnet"
 
+export GASNET_QUIET=Y
+
 $CWD/nightly -cron -no-buildcheck ${nightly_args}

--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -2,6 +2,11 @@
 #
 # Test CHPL_COMM=gasnet && CHPL_TARGET_COMPILER=mpi-gnu for MPI module testing
 #
+
+export CHPL_TARGET_COMPILER=mpi-gnu
+export CHPL_TASKS=fifo
+export CHPL_COMM_SUBSTRATE=mpi
+
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
 
@@ -11,11 +16,6 @@ module load mpi
 set -x
 : confirm mpi module is loaded
 module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
-
-export CHPL_TARGET_COMPILER=mpi-gnu
-export CHPL_TASKS=fifo
-export CHPL_COMM=gasnet
-export CHPL_COMM_SUBSTRATE=mpi
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl modules/packages/mpi"
 

--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -3,7 +3,7 @@
 # Test CHPL_COMM=gasnet && CHPL_TARGET_COMPILER=mpi-gnu for MPI module testing
 #
 CWD=$(cd $(dirname $0) ; pwd)
-source $CWD/common.bash
+source $CWD/common-gasnet.bash
 
 echo >&2 module load mpi
 module load mpi
@@ -11,9 +11,6 @@ module load mpi
 set -x
 : confirm mpi module is loaded
 module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
-
-# Suppress the suggestion of using 'ibv' GASNet conduit
-export GASNET_QUIET=1
 
 export CHPL_TARGET_COMPILER=mpi-gnu
 export CHPL_TASKS=fifo


### PR DESCRIPTION
Use `common-gasnet.bash` instead of `common.bash`.