### PR TITLE
Close the gap for scope resolve

### DIFF
--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -33,6 +33,8 @@ class TypeSymbol;
 // This is currently a thin wrapping over a previous typedef + functions
 class ResolveScope {
 public:
+  static void                     initializeScopeForChplProgram();
+
   static ResolveScope*            findOrCreateScopeFor(DefExpr* def);
 
   static ResolveScope*            getScopeFor(BaseAST* ast);

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -103,6 +103,135 @@ void ResolveScope::destroyAstMap() {
   sScopeMap.clear();
 }
 
+/************************************* | **************************************
+*                                                                             *
+* Historically, definitions have been mapped to scopes by                     *
+*   1) Walking gDefExprs                                                      *
+*   2) Determining the "scope" for a given DefExpr by walking upwards         *
+*      through the AST.                                                       *
+*   3) Validating that the definition is valid.                               *
+*   4) Extending the scope with the definition                                *
+*                                                                             *
+* As a special case the built-in symbols, which are defined in rootModule,    *
+* are mapped as if they were defined in chpl_Program.                         *
+*                                                                             *
+* 2017/05/23:                                                                 *
+*   Begin to modify this process so that scopes and definitions are managed   *
+* using a traditional top-down traversal of the AST starting at chpl_Program. *
+*                                                                             *
+* This process will overlook the compiler defined built-ins.  This function   *
+* is responsible for pre-allocating the scope for chpl_Program and then       *
+* inserting the built-ins.
+*                                                                             *
+************************************** | *************************************/
+
+void ResolveScope::initializeScopeForChplProgram() {
+  ResolveScope* program = new ResolveScope(theProgram->block);
+
+  program->extend(dtObject->symbol);
+  program->extend(dtVoid->symbol);
+  program->extend(dtStringC->symbol);
+
+  program->extend(gFalse);
+  program->extend(gTrue);
+
+  program->extend(gTryToken);
+
+  program->extend(dtNil->symbol);
+  program->extend(gNil);
+
+  program->extend(gNoInit);
+
+  program->extend(dtUnknown->symbol);
+  program->extend(dtValue->symbol);
+
+  program->extend(gUnknown);
+  program->extend(gVoid);
+
+  program->extend(dtBools[BOOL_SIZE_SYS]->symbol);
+  program->extend(dtBools[BOOL_SIZE_1]->symbol);
+  program->extend(dtBools[BOOL_SIZE_8]->symbol);
+  program->extend(dtBools[BOOL_SIZE_16]->symbol);
+  program->extend(dtBools[BOOL_SIZE_32]->symbol);
+  program->extend(dtBools[BOOL_SIZE_64]->symbol);
+
+  program->extend(dtInt[INT_SIZE_8]->symbol);
+  program->extend(dtInt[INT_SIZE_16]->symbol);
+  program->extend(dtInt[INT_SIZE_32]->symbol);
+  program->extend(dtInt[INT_SIZE_64]->symbol);
+
+  program->extend(dtUInt[INT_SIZE_8]->symbol);
+  program->extend(dtUInt[INT_SIZE_16]->symbol);
+  program->extend(dtUInt[INT_SIZE_32]->symbol);
+  program->extend(dtUInt[INT_SIZE_64]->symbol);
+
+  program->extend(dtReal[FLOAT_SIZE_32]->symbol);
+  program->extend(dtReal[FLOAT_SIZE_64]->symbol);
+
+  program->extend(dtImag[FLOAT_SIZE_32]->symbol);
+  program->extend(dtImag[FLOAT_SIZE_64]->symbol);
+
+  program->extend(dtComplex[COMPLEX_SIZE_64]->symbol);
+  program->extend(dtComplex[COMPLEX_SIZE_128]->symbol);
+
+  program->extend(dtStringCopy->symbol);
+  program->extend(gStringCopy);
+
+  program->extend(dtCVoidPtr->symbol);
+  program->extend(dtCFnPtr->symbol);
+  program->extend(gCVoidPtr);
+  program->extend(dtSymbol->symbol);
+
+  program->extend(dtFile->symbol);
+  program->extend(gFile);
+
+  program->extend(dtOpaque->symbol);
+  program->extend(gOpaque);
+
+  program->extend(dtTaskID->symbol);
+  program->extend(gTaskID);
+
+  program->extend(dtSyncVarAuxFields->symbol);
+  program->extend(gSyncVarAuxFields);
+
+  program->extend(dtSingleVarAuxFields->symbol);
+  program->extend(gSingleVarAuxFields);
+
+  program->extend(dtAny->symbol);
+  program->extend(dtIntegral->symbol);
+  program->extend(dtAnyComplex->symbol);
+  program->extend(dtNumeric->symbol);
+
+  program->extend(dtIteratorRecord->symbol);
+  program->extend(dtIteratorClass->symbol);
+
+  program->extend(dtMethodToken->symbol);
+  program->extend(gMethodToken);
+
+  program->extend(dtTypeDefaultToken->symbol);
+  program->extend(gTypeDefaultToken);
+
+  program->extend(dtModuleToken->symbol);
+  program->extend(gModuleToken);
+
+  program->extend(dtAnyEnumerated->symbol);
+
+  program->extend(gBoundsChecking);
+  program->extend(gCastChecking);
+  program->extend(gDivZeroChecking);
+  program->extend(gPrivatization);
+  program->extend(gLocal);
+  program->extend(gNodeID);
+
+  sScopeMap[theProgram->block] = program;
+}
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
 ResolveScope::ResolveScope(BlockStmt* blockStmt) {
   mAstRef = blockStmt;
 }

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -264,11 +264,30 @@ static void addRecordDefaultConstruction() {
 *                                                                             *
 ************************************** | *************************************/
 
-static void addToSymbolTable(DefExpr* def);
+static void addToSymbolTable(ModuleSymbol* topLevelModule);
+
+static void addToSymbolTable(DefExpr*      def);
 
 static void addToSymbolTable() {
-  forv_Vec(DefExpr, def, gDefExprs) {
-    addToSymbolTable(def);
+  ResolveScope::initializeScopeForChplProgram();
+
+  for_alist(stmt, theProgram->block->body) {
+    if (ModuleSymbol* mod = definesModuleSymbol(stmt)) {
+      addToSymbolTable(mod->defPoint);
+      addToSymbolTable(mod);
+    }
+  }
+}
+
+static void addToSymbolTable(ModuleSymbol* topLevelModule) {
+  std::vector<BaseAST*> asts;
+
+  collect_asts(topLevelModule, asts);
+
+  for_vector(BaseAST, item, asts) {
+    if (DefExpr* def = toDefExpr(item)) {
+      addToSymbolTable(def);
+    }
   }
 }
 


### PR DESCRIPTION
This PR integrates a small portion of some business logic that is more fully developed on
a development branch.  The intent is to merge the code from that branch to master in a
manageable fashion.


Several of the sub-passes within scope resolve make use of a large global map from
certain AST nodes to an appropriate "Scope Object".  Each scope object is a map from
an Identifier to an appropriate Symbol based on the lexical rules for Chapel.  These
scope objects correspond to function definitions, block statements, record/class definitions
and so on.

Before this PR, this map was constructed by walking the elements of gDefExprs in ast-id
order and then walking upwards until an AST node that defined a scope boundary was found.
The resulting node is mapped to a "Scope Object", the definition is validated, and then the
symbol is inserted.

This simple PR begins the effort to traverse/accumulate the lexical scopes in a more traditional
top-down manner from chpl__Program.  It takes a first step to this goal by walking
chpl__Program and visiting each top-level module in turn.  However, for this PR, the processing
of the DefExprs within a module resembles the previous business logic.

Additional attention must be applied to the compiler builtins.  These are defined in the rootModule
but are scoped as if they are defined in chpl__Program.  Before this PR this was handled symbol
by symbol while walking gDefExprs. This PR does not walk rootModule or gDefExprs and
so a special, and slightly fragile, initialization step is used.  The details of this operation will be
revisited in a subsequent PR.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux.
Passed a fraction of release/ with these modes.  Also verified with llvm on linux.

Passed full paratest with -futures and then with --no-local
