### PR TITLE
Rename ReplicatedDist (the class) to Replicated

### DIFF
--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -135,7 +135,7 @@ and distributes using block-cyclic distribution in the second dimension.
     for loc in MyLocales do on loc {
 
       // The ReplicatedDim specifier always accesses the local replicand.
-      // (This differs from how the ReplicatedDist distribution works.)
+      // (This differs from how the Replicated distribution works.)
       //
       // Therefore, 'forall a in A' when executed on MyLocales[loc1,loc2]
       // visits only the replicands on MyLocales[loc1,0..N_2-1].

--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -33,11 +33,11 @@ type bcdPosInt = int;
 
 // chpldoc TODO
 // * Get the BlockCyclic distribution references to be presented
-//   as links. Currently they are not perhaps because chpldoc does not find
-//   that module while creating this documentation.
-//   Cf. it finds ReplicatedDist while processing ReplicatedDim.
-//   That is perhaps because the name of the class and the name of the file
-//   match in the ReplicatedDist case.
+//   as links. At some point in the past they were not perhaps because
+//   chpldoc did not find that module while creating this documentation.
+//   Cf. it found ReplicatedDist while processing ReplicatedDim.
+//   That may have been because the name of the class and the name of the file
+//   used to match in the ReplicatedDist case.
 //
 /*
 This Block-Cyclic dimension specifier is for use with the

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -34,7 +34,7 @@ This Replicated dimension specifier is for use with the
 The dimension of a domain or array for which this specifier is used
 has a *replicand* for each element of ``targetLocales``
 in the same dimension. This is similar to the Replicated distribution
-(:class:`ReplicatedDist`). The dimension specifies differs
+(:class:`Replicated`). The dimension specifies differs
 in that it always accesses the local replicand, whereas the Replicated
 distribution accesses all replicands in certain cases, as specified there.
 

--- a/modules/standard/UtilReplicatedVar.chpl
+++ b/modules/standard/UtilReplicatedVar.chpl
@@ -42,7 +42,7 @@ Limitations:
 
 .. code-block:: chapel
 
-   var replArray: [MyDomain dmapped ReplicatedDist()] real;
+   var replArray: [MyDomain dmapped Replicated()] real;
 
 .. _basic-usage:
 
@@ -83,13 +83,10 @@ modify the above variable declarations as follows:
 
 .. code-block:: chapel
 
-    var myRepVar: [rcDomainBase dmapped ReplicatedDist(myLocales,
+    var myRepVar: [rcDomainBase dmapped Replicated(myLocales,
                      "over which to replicate 'myRepVar'")] MyType;
     var collected: [myLocales.domain] MyType;
 
-``myLocales`` must be "consistent", as defined for ReplicatedDist.
-That is, for each ``ix`` in ``myLocales.domain``,
-``myLocales[ix]`` must equal ``Locales[ix]``.
 
 Tip: if the domain of the desired array of locales cannot be described
 as a rectangular domain (which could be strided, multi-dimensional,
@@ -108,11 +105,11 @@ private const rcDomainIx   = 1; // todo convert to param
    as shown :ref:`above <subset-of-locales>`. */
 const rcDomainBase = {rcDomainIx..rcDomainIx};
 private const rcLocales    = Locales;
-private const rcDomainMap  = new ReplicatedDist(rcLocales);
+private const rcDomainMap  = new Replicated(rcLocales);
 /* Use this domain to declare a user-level replicated variable,
    as shown :ref:`above <basic-usage>` . */
 const rcDomain     = rcDomainBase dmapped new dmap(rcDomainMap);
-private param _rcErr1 = " must be 'rcDomain' or 'rcDomainBase dmapped ReplicatedDist(an array of locales)'";
+private param _rcErr1 = " must be 'rcDomain' or 'rcDomainBase dmapped Replicated(an array of locales)'";
 
 private proc _rcTargetLocalesHelper(replicatedVar: [?D])
   where replicatedVar._value.type: ReplicatedArr
@@ -238,7 +235,7 @@ proc rcExampleOverLocales(initVal: ?MyType, newVal: MyType, newLocale: locale,
 
   // declare a replicated variable
   // DIFFERENT from rcExample(): the domain in myRepVar's type
-  var myRepVar: [rcDomainBase dmapped ReplicatedDist(localesToReplicateOver,
+  var myRepVar: [rcDomainBase dmapped Replicated(localesToReplicateOver,
    "over which to replicate 'myRepVar' in rcExampleOverLocales()")] MyType;
 
   // initialize all copies to 'initVal'

--- a/test/distributions/bradc/ReplWithMultiDim.chpl
+++ b/test/distributions/bradc/ReplWithMultiDim.chpl
@@ -2,5 +2,5 @@ use ReplicatedDist;
 
 const Space = {1..8, 1..8};
 const OneLocOnly: [0..0, 0..0] locale = Locales[0];
-const R2 = Space dmapped ReplicatedDist(targetLocales=OneLocOnly);
+const R2 = Space dmapped Replicated(targetLocales=OneLocOnly);
 writeln(R2);

--- a/test/distributions/bradc/distEquality.chpl
+++ b/test/distributions/bradc/distEquality.chpl
@@ -87,8 +87,8 @@ writeln();
 
 const OneLocOnly1D: [0..0] locale = Locales[0];
 
-const R1 = Space dmapped ReplicatedDist();
-const R2 = Space dmapped ReplicatedDist(targetLocales=OneLocOnly1D);
+const R1 = Space dmapped Replicated();
+const R2 = Space dmapped Replicated(targetLocales=OneLocOnly1D);
 
 writeln("Replicated comparisons:");
 
@@ -97,4 +97,4 @@ writeln(R1.dist == R2.dist);
 
 writeln(R2.dist == R2.dist);
 
-writeln(R2.dist == (Space dmapped ReplicatedDist(targetLocales=OneLocOnly1D)).dist);
+writeln(R2.dist == (Space dmapped Replicated(targetLocales=OneLocOnly1D)).dist);

--- a/test/distributions/bradc/passDistDomsToFns.chpl
+++ b/test/distributions/bradc/passDistDomsToFns.chpl
@@ -25,7 +25,7 @@ proc fooBC(X:[BlkCycSpace] int) {
   writeln("In fooBC!");
 }
 
-const ReplicatedSpace = Space dmapped ReplicatedDist();
+const ReplicatedSpace = Space dmapped Replicated();
 var RA: [ReplicatedSpace] int;
 fooR(RA);
 proc fooR(X:[ReplicatedSpace] int) {

--- a/test/distributions/dm/hplx.chpl
+++ b/test/distributions/dm/hplx.chpl
@@ -12,7 +12,7 @@ use ReplicatedDist;
 config const blk = 5, fac=10;
 const n = blk*fac;
 
-const Dist2D = new dmap(new ReplicatedDist());
+const Dist2D = new dmap(new Replicated());
 
 proc main() {
   const AbD: domain(2) dmapped Dist2D = {1..n, 1..n};

--- a/test/distributions/replicated/consistentLocales/testLocaleScramble.chpl
+++ b/test/distributions/replicated/consistentLocales/testLocaleScramble.chpl
@@ -10,7 +10,7 @@ for (loc, i) in zip(Locales, 0..#numLocales by -1) {
 
 writeln("Grid is: ", Grid);
 
-const D = {1..3} dmapped ReplicatedDist(Grid);
+const D = {1..3} dmapped Replicated(Grid);
 var A: [D] real;
 
 coforall loc in Locales do

--- a/test/distributions/replicated/consistentLocales/testLocaleScramble2.chpl
+++ b/test/distributions/replicated/consistentLocales/testLocaleScramble2.chpl
@@ -10,7 +10,7 @@ for (loc, i) in zip(Locales, 0..#numLocales by -1) {
 
 writeln("Grid is: ", Grid);
 
-const D = {1..3} dmapped ReplicatedDist(Grid);
+const D = {1..3} dmapped Replicated(Grid);
 var A: [D] real;
 
 coforall loc in Locales do

--- a/test/distributions/replicated/consistentLocales/testLocaleScramble2D.chpl
+++ b/test/distributions/replicated/consistentLocales/testLocaleScramble2D.chpl
@@ -10,7 +10,7 @@ var Grid = reshape(Locales, GridD);
 
 writeln("Grid is: ", Grid);
 
-const D = {1..3} dmapped ReplicatedDist(Grid);
+const D = {1..3} dmapped Replicated(Grid);
 var A: [D] real;
 
 coforall loc in Locales do

--- a/test/distributions/replicated/repl-int-error.chpl
+++ b/test/distributions/replicated/repl-int-error.chpl
@@ -2,7 +2,7 @@ use ReplicatedDist;
 
 config const n = 8;
 const Space = {1..n, 1..n};
-const ReplicatedSpace = Space dmapped ReplicatedDist();
+const ReplicatedSpace = Space dmapped Replicated();
 var RA: [ReplicatedSpace] int;
 
 coforall loc in Locales do

--- a/test/distributions/replicated/testReplWrites.chpl
+++ b/test/distributions/replicated/testReplWrites.chpl
@@ -1,6 +1,6 @@
 use ReplicatedDist;
 
-const D = {1..3, 1..3} dmapped ReplicatedDist();
+const D = {1..3, 1..3} dmapped Replicated();
 
 var A: [D] real;
 

--- a/test/distributions/robust/arithmetic/driver.chpl
+++ b/test/distributions/robust/arithmetic/driver.chpl
@@ -57,11 +57,11 @@ proc setupDistributions() {
   }
   if distType == DistType.replicated {
     return (
-            new dmap(new ReplicatedDist()),
-            new dmap(new ReplicatedDist()),
-            new dmap(new ReplicatedDist()),
-            new dmap(new ReplicatedDist()),
-            new dmap(new ReplicatedDist())
+            new dmap(new Replicated()),
+            new dmap(new Replicated()),
+            new dmap(new Replicated()),
+            new dmap(new Replicated()),
+            new dmap(new Replicated())
            );
   }
   halt("unexpected 'distType': ", distType);

--- a/test/distributions/robust/arithmetic/resizing/resizeFromOtherLocale.chpl
+++ b/test/distributions/robust/arithmetic/resizing/resizeFromOtherLocale.chpl
@@ -32,7 +32,7 @@ proc buildSpace(Dom) {
     return Dom dmapped Cyclic(startIdx=1);
   }
   else if distType == DistType.replicated {
-    return Dom dmapped ReplicatedDist();
+    return Dom dmapped Replicated();
   }
   else {
     compilerError("Compiling with unknown DistType.");

--- a/test/distributions/vass/testReplicatedDist1.chpl
+++ b/test/distributions/vass/testReplicatedDist1.chpl
@@ -15,7 +15,7 @@ config type elt = int;
 // ARepl - the replicated array to be tested
 
 const repllocales = Locales;  // in case this changes
-var ReplBlockDist = new dmap(new ReplicatedDist());
+var ReplBlockDist = new dmap(new Replicated());
 var DRepl: domain(2) dmapped ReplBlockDist = Dsub;
 var ARepl: [DRepl] elt;
 

--- a/test/distributions/vass/testReplicatedDistLocal1.chpl
+++ b/test/distributions/vass/testReplicatedDistLocal1.chpl
@@ -5,7 +5,7 @@ use ReplicatedDist;
 const ls = Locales;
 writeln("running on locales ", ls.domain);
 
-var d = {1..3,1..3} dmapped ReplicatedDist(ls);
+var d = {1..3,1..3} dmapped Replicated(ls);
 var a: [d] int;
 
 //

--- a/test/distributions/vass/testReplicatedVar1.chpl
+++ b/test/distributions/vass/testReplicatedVar1.chpl
@@ -34,7 +34,7 @@ if numLocales >= 4 {
   var myL = Locales(1..3 by 2);
 //  myL[1] = myL[2];  // this makes myL violate the "consistency" requirement
   writeln("\nadvanced case: ", myL);
-  var x: [rcDomainBase dmapped ReplicatedDist(myL)] real;
+  var x: [rcDomainBase dmapped Replicated(myL)] real;
   writeln("\ninitially");
   writeReplicands(x, myL);
   rcReplicate(x, 5);

--- a/test/io/vass/writeThis-on.future
+++ b/test/io/vass/writeThis-on.future
@@ -19,7 +19,7 @@ It would be easier to print the current-locale view directly.
 
 Note on the code: it took some work to set things up to illustrate the
 issue using a replicated array. Specifically, an array mapped using
-the multi-dimensional ReplicatedDist prints out all replicands,
+the multi-dimensional ReplicatedDist used to print out all replicands,
 regardless of which locale its writeThis() is invoked on.
 So that does not illustrate the issue. Therefore I had to use
 a replicated dimension with DimensionalDist2D.

--- a/test/memory/sungeun/refCount/domainMaps.chpl
+++ b/test/memory/sungeun/refCount/domainMaps.chpl
@@ -11,7 +11,7 @@ proc myDM(param dmType: DMType) {
     when DMType.block do return new dmap(new Block(rank=1, boundingBox={1..n}));
     when DMType.cyclic do return new dmap(new Cyclic(startIdx=1));
     when DMType.blockcyclic do return new dmap(new BlockCyclic(startIdx=(1,), blocksize=(3,)));
-    when DMType.replicated do return new dmap(new ReplicatedDist());
+    when DMType.replicated do return new dmap(new Replicated());
     otherwise halt("unexpected 'dmType': ", dmType);
     }
 }

--- a/test/parallel/forall/vass/ri-4-arrdom.chpl
+++ b/test/parallel/forall/vass/ri-4-arrdom.chpl
@@ -31,7 +31,7 @@ proc setupDistributions() {
     return new dmap(new BlockCyclic(startIdx=(0,0), blocksize=(3,3)));
 
   else if distType == DistType.replicated then
-    return new dmap(new ReplicatedDist());
+    return new dmap(new Replicated());
 
   else compilerError("unexpected 'distType': ", distType:c_string);
 }

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/io_RMAT_graph.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/io_RMAT_graph.chpl
@@ -201,7 +201,7 @@ module io_RMAT_graph
 
     } else {
       // !IOserial
-      const repfileMap = new ReplicatedDist(Locales);
+      const repfileMap = new Replicated(Locales);
       const repfileDom = repfileBase dmapped new dmap(repfileMap);
       var repfiles: [repfileDom] file;
 

--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -241,10 +241,10 @@ verifyID(BA);
 // Replicated
 // ----------
 //
-// The ``ReplicatedDist`` distribution is different from the previous
+// The ``Replicated`` distribution is different from the previous
 // cases: each of the original domain's indices is replicated onto
 // each locale, as are the corresponding array elements.  For example,
-// a domain ``{1..3}`` distributed using ``ReplicatedDist`` will store
+// a domain ``{1..3}`` distributed using ``Replicated`` will store
 // three indices per locale that the distribution is targeting (by
 // default, all locales).  Similarly, an array declared over that
 // domain will store three elements per locale.  Each locale's copy of
@@ -263,7 +263,7 @@ verifyID(BA);
 //
 // Here's a declaration of a replicated domain and array:
 //
-const ReplicatedSpace = Space dmapped ReplicatedDist();
+const ReplicatedSpace = Space dmapped Replicated();
 var RA: [ReplicatedSpace] int;
 
 // Queries about the size of a replicated domain or array will return
@@ -404,7 +404,7 @@ const DimReplicatedBlockcyclicSpace = Space
 var DRBA: [DimReplicatedBlockcyclicSpace] int;
 
 // The ``ReplicatedDim`` specifier always accesses the local replicand.
-// (This differs from how the ``ReplicatedDist`` distribution works.)
+// (This differs from how the ``Replicated`` distribution works.)
 //
 // This example visits each replicand. The behavior is the same
 // regardless of the second index into ``MyLocales`` below.

--- a/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
@@ -88,7 +88,7 @@ compilerAssert(CHPL_NETWORK_ATOMICS == "none",
 
   printBriefConfiguration();
 
-  const distReplicated = new ReplicatedDist();
+  const distReplicated = new Replicated();
 
   // Replicate 'targetLocales' to reduce comm.
   // 'targetLocales' itself could be replicated instead,

--- a/test/studies/hpcc/HPL/vass/hpl.performance.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.performance.chpl
@@ -101,7 +101,7 @@ var tInit, tPS1iter, tUBR1iter, tSC1call, tLF1iter, tBScall, tVer: VTimer;
           divceilpos(n, blkSize*tl1), "*", divceilpos(n+1, blkSize*tl2),
           "  locs ", tl1, "*", tl2, "  dPTPL ", dataParTasksPerLocale);
 
-  const distReplicated = new ReplicatedDist();
+  const distReplicated = new Replicated();
 
   // Replicate 'targetLocales' to reduce comm.
   // 'targetLocales' itself could be replicated instead,


### PR DESCRIPTION
This is nicer for the user's dmapped clauses and more symmetric
to what we do for Block, Cyclic, and other distributions.

TODO:
- [x] linux64 testing
- [x] gasnet testing
- [x] distribution robustness testing for replicated
- [ ] add deprecated version of ReplicatedDist