### PR TITLE
Tidy up mpicc tests

### DIFF
--- a/util/cron/common-mpicc.bash
+++ b/util/cron/common-mpicc.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Configure environment for MPI module testing on linux64
+
+
+echo >&2 module load mpi
+module load mpi
+
+set -x
+: confirm mpi module is loaded
+module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
+
+export CHPL_TARGET_COMPILER=mpi-gnu
+# MPI module only works with CHPL_TASKS=fifo currently
+export CHPL_TASKS=fifo
+

--- a/util/cron/test-mpicc.bash
+++ b/util/cron/test-mpicc.bash
@@ -1,26 +1,15 @@
 #!/usr/bin/env bash
 #
-# Test CHPL_COMM=none && CHPL_TARGET_COMPILER=mpi-gnu for MPI module testing
-#
+# Test CHPL_COMM=none for MPI module on linux64
+
 CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-mpicc.bash
 source $CWD/common.bash
 
-echo >&2 module load mpi
-module load mpi
-
-set -x
-: confirm mpi module is loaded
-module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
-
-export MPICH_MAX_THREAD_SAFETY=multiple
-
-export CHPL_TARGET_COMPILER=mpi-gnu
-export CHPL_TASKS=fifo
-export CHPL_COMM=none
 export CHPL_LAUNCHER=mpirun
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl modules/packages/mpi"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="mpicc"
 
-$CWD/nightly -cron -no-buildcheck ${nightly_args}
+$CWD/nightly -cron -no-buildcheck

--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -1,27 +1,17 @@
 #!/usr/bin/env bash
 #
-# Test CHPL_COMM=gasnet && CHPL_TARGET_COMPILER=mpi-gnu for MPI module testing
-#
+# Test CHPL_COMM=gasnet for MPI module on linux64
+
 CWD=$(cd $(dirname $0) ; pwd)
-source $CWD/common.bash
+source $CWD/common-mpicc.bash
+source $CWD/common-gasnet.bash
 
-echo >&2 module load mpi
-module load mpi
-
-set -x
-: confirm mpi module is loaded
-module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
-
-# Suppress the suggestion of using 'ibv' GASNet conduit
-export GASNET_QUIET=1
-
-export CHPL_TARGET_COMPILER=mpi-gnu
-export CHPL_TASKS=fifo
-export CHPL_COMM=gasnet
 export CHPL_COMM_SUBSTRATE=mpi
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl modules/packages/mpi"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="mpicc.gasnet"
 
-$CWD/nightly -cron -no-buildcheck ${nightly_args}
+export GASNET_QUIET=Y
+
+$CWD/nightly -cron -no-buildcheck


### PR DESCRIPTION
This PR cleans up the mpicc cron tests, following conventions applied in other cron tests.