### PR TITLE
Tidy up mpicc tests

### DIFF
--- a/util/cron/common-mpicc.bash
+++ b/util/cron/common-mpicc.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Configure environment for MPI module testing on linux64
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+# Currently, only fifo supported for MPI module
+export CHPL_TASKS=fifo
+export CHPL_TARGET_COMPILER=mpi-gnu
+
+# Load MPI environment module and confirm it has loaded
+echo >&2 module load mpi
+module load mpi
+
+set -x
+: confirm mpi module is loaded
+module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?

--- a/util/cron/test-mpicc.bash
+++ b/util/cron/test-mpicc.bash
@@ -1,26 +1,14 @@
 #!/usr/bin/env bash
 #
-# Test CHPL_COMM=none && CHPL_TARGET_COMPILER=mpi-gnu for MPI module testing
-#
+# Test MPI Module for CHPL_COMM=none on linux64
+
 CWD=$(cd $(dirname $0) ; pwd)
-source $CWD/common.bash
+source $CWD/common-mpicc.bash
 
-echo >&2 module load mpi
-module load mpi
-
-set -x
-: confirm mpi module is loaded
-module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
-
-export MPICH_MAX_THREAD_SAFETY=multiple
-
-export CHPL_TARGET_COMPILER=mpi-gnu
-export CHPL_TASKS=fifo
-export CHPL_COMM=none
 export CHPL_LAUNCHER=mpirun
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl modules/packages/mpi"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="mpicc"
 
-$CWD/nightly -cron -no-buildcheck ${nightly_args}
+$CWD/nightly -cron -no-buildcheck

--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -6,7 +6,6 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-mpicc.bash
 source $CWD/common-gasnet.bash
 
-export CHPL_TARGET_COMPILER=mpi-gnu
 export CHPL_COMM_SUBSTRATE=mpi
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl modules/packages/mpi"

--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -1,21 +1,13 @@
 #!/usr/bin/env bash
 #
-# Test CHPL_COMM=gasnet && CHPL_TARGET_COMPILER=mpi-gnu for MPI module testing
-#
-
-export CHPL_TARGET_COMPILER=mpi-gnu
-export CHPL_TASKS=fifo
-export CHPL_COMM_SUBSTRATE=mpi
+# Test MPI Module for CHPL_COMM=gasnet on linux64
 
 CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-mpicc.bash
 source $CWD/common-gasnet.bash
 
-echo >&2 module load mpi
-module load mpi
-
-set -x
-: confirm mpi module is loaded
-module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
+export CHPL_TARGET_COMPILER=mpi-gnu
+export CHPL_COMM_SUBSTRATE=mpi
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl modules/packages/mpi"
 
@@ -23,4 +15,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="mpicc.gasnet"
 
 export GASNET_QUIET=Y
 
-$CWD/nightly -cron -no-buildcheck ${nightly_args}
+$CWD/nightly -cron -no-buildcheck


### PR DESCRIPTION
This PR cleans up the mpicc cron tests, following conventions applied in other cron tests.