### PR TITLE
Add test to demonstrate subtle behavior for shadowed methods

### DIFF
--- a/test/visibility/shadow-overload.chpl
+++ b/test/visibility/shadow-overload.chpl
@@ -1,0 +1,21 @@
+/* Test to ensure that functions shadowed by methods
+   *cannot* be called without the module-access-expression, even when the
+   function and method have different signatures */
+
+proc shadow(x) {
+  writeln('outer scope');
+}
+
+record R {
+
+  proc shadow() {
+    writeln('R scope');
+    // This should not work!
+    shadow(10);
+  }
+
+}
+
+
+var r = new R();
+r.shadow();

--- a/test/visibility/shadow-overload.good
+++ b/test/visibility/shadow-overload.good
@@ -1,0 +1,4 @@
+shadow-overload.chpl:11: In function 'shadow':
+shadow-overload.chpl:14: error: unresolved call 'R.shadow(10)'
+shadow-overload.chpl:5: note: candidates are: shadow(x)
+shadow-overload.chpl:11: note:                 R.shadow()

--- a/test/visibility/shadow.chpl
+++ b/test/visibility/shadow.chpl
@@ -1,3 +1,5 @@
+/* Test to ensure that functions shadowed by methods can be called with
+   module-access-expression */
 module A {
 
   proc shadow() {
@@ -11,11 +13,9 @@ module A {
 
       writeln('R scope');
 
-      // These work fine
       A.newline();
       newline();
 
-      // This does not
       A.shadow();
     }
   }


### PR DESCRIPTION
There was a discussion about what the behavior of the following program should be:

```chapel

proc shadow(x) {
  writeln('outer scope');
}

record R {

  proc shadow() {
    writeln('R scope');
    shadow(10);
  }

}


var r = new R();
r.shadow();
```

The conclusion was that the call to `shadow()` without a *module-access-expression* is invalid in Chapel. This follows what other languages that also support implicit *member-access-expression* do, including: C++, D, and Swift

This PR adds a test to ensure that we don't break this subtle behavior in the future.
