### PR TITLE
Make ~ on bool an error

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -441,7 +441,7 @@ module ChapelBase {
   //
   // bitwise operations on primitive types
   //
-  inline proc ~(a: bool) return __primitive("u~", a);
+  inline proc ~(a: bool) { compilerError("~ is not suported on bool"); }
   inline proc ~(a: int(?w)) return __primitive("u~", a);
   inline proc ~(a: uint(?w)) return __primitive("u~", a);
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -441,9 +441,10 @@ module ChapelBase {
   //
   // bitwise operations on primitive types
   //
-  inline proc ~(a: bool) { compilerError("~ is not suported on bool"); }
   inline proc ~(a: int(?w)) return __primitive("u~", a);
   inline proc ~(a: uint(?w)) return __primitive("u~", a);
+  // note: where clause used here to enable a user-defined overload
+  inline proc ~(a: bool) where true { compilerError("~ is not suported on operands of boolean type"); }
 
   inline proc &(a: bool, b: bool) return __primitive("&", a, b);
   inline proc &(a: int(?w), b: int(w)) return __primitive("&", a, b);

--- a/test/types/scalar/bradc/bitNegateBool.good
+++ b/test/types/scalar/bradc/bitNegateBool.good
@@ -1,1 +1,1 @@
-bitNegateBool.chpl:4: error: ~ is not suported on bool
+bitNegateBool.chpl:4: error: ~ is not suported on operands of boolean type

--- a/test/types/scalar/bradc/bitNegateBool.good
+++ b/test/types/scalar/bradc/bitNegateBool.good
@@ -1,2 +1,1 @@
-~true = true
-~false = true
+bitNegateBool.chpl:4: error: ~ is not suported on bool

--- a/test/types/scalar/bradc/bitNegateBoolUserDefined.chpl
+++ b/test/types/scalar/bradc/bitNegateBoolUserDefined.chpl
@@ -1,5 +1,7 @@
 var t: bool = true;
 var f: bool = false;
 
+proc ~(a: bool) return !a;
+
 writeln("~true = ", ~t);
 writeln("~false = ", ~f);

--- a/test/types/scalar/bradc/bitNegateBoolUserDefined.good
+++ b/test/types/scalar/bradc/bitNegateBoolUserDefined.good
@@ -1,0 +1,2 @@
+~true = false
+~false = true

--- a/test/types/scalar/bradc/bools2.chpl
+++ b/test/types/scalar/bradc/bools2.chpl
@@ -8,7 +8,6 @@ proc testBoolCombo(x, y) {
   writeln("!x = ", !x);
   writeln("x && y = ", x && y);
   writeln("x || y = ", x || y);
-  writeln("~x = ", ~x);
   writeln("x ^ y = ", x ^ y);
   writeln("x | y = ", x | y);
   writeln("x & y = ", x & y);

--- a/test/types/scalar/bradc/bools2.good
+++ b/test/types/scalar/bradc/bools2.good
@@ -1,7 +1,6 @@
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -12,7 +11,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -23,7 +21,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -34,7 +31,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -45,7 +41,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -56,7 +51,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -67,7 +61,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -78,7 +71,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -89,7 +81,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -100,7 +91,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -111,7 +101,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -122,7 +111,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -133,7 +121,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -144,7 +131,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -155,7 +141,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -166,7 +151,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -177,7 +161,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -188,7 +171,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -199,7 +181,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -210,7 +191,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -221,7 +201,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -232,7 +211,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -243,7 +221,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -254,7 +231,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true
@@ -265,7 +241,6 @@ x is true
 !x = false
 x && y = true
 x || y = true
-~x = true
 x ^ y = false
 x | y = true
 x & y = true


### PR DESCRIPTION
See issue #5787, which discusses the problem with `~` on bools and the strategy for improvement.

If we want to continue to support `~` on bools, the implementation would need to change (possibly to calling `!`). The previous implementation had different behavior for --llvm and when compliing with GCC 7.

Note that this PR adds a `where true` clause to the error overload of `~`. At first I tried to mark it with `pragma "compiler generated"` to make it a last-resort candidate. However, if I do that, the other `~` overload will apply. (I.e. `~` on bool will coerce the argument to int, then run bit complement). Since the disambiguation rules prefer a match without a `where` clause to one with a `where` clause, I used `where true` to achieve the same effect (mostly). I've also added a test that checks that user-defined overload of `~` is possible.

Passed full local testing.

Reviewed by @bradcray - thanks!