### PR TITLE
Add test showing winner of dynamic dispatch vs. forwarding

### DIFF
--- a/test/classes/forwarding/dynDispatchVsForward.chpl
+++ b/test/classes/forwarding/dynDispatchVsForward.chpl
@@ -1,0 +1,27 @@
+class C {
+  proc foo() {
+    writeln("In C's foo()");
+  }
+}
+
+class D: C {
+  proc foo() {
+    writeln("In D's foo()");
+  }
+
+  proc bar() {
+    writeln("In D's bar()");
+  }
+}
+
+class E: C {
+  forwarding var myD: D;
+}
+
+proc E.E() {
+  myD = new D();
+}
+
+var myE = new E();
+myE.bar();
+myE.foo();

--- a/test/classes/forwarding/dynDispatchVsForward.good
+++ b/test/classes/forwarding/dynDispatchVsForward.good
@@ -1,0 +1,2 @@
+In D's bar()
+In C's foo()


### PR DESCRIPTION
While trying to use forwarding to support 'Replicated' and
'ReplicatedDist' without code duplication yesterday, I was thwarted by
the fact that a method that can either be dynamically dispatched or
forwarded will choose the dynamic dispatch case.  Michael argues that
this is intentional because the role of forwarding is to serve as a
last resort.  I can buy this argument, so am filing this test to lock
the current behavior in.