### PR TITLE
Add union operator `|` back into array-docs

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -81,15 +81,14 @@
    ================================================
 
    Associative domains and arrays support a number of operators for
-   set manipulations.  The supported set operators are:
+   set manipulations.  The supported set operators are demonstrated below:
 
-     =====  ====================
-     \+     Union
-     \|     Union
-     &      Intersection
-     \-      Difference
-     ^      Symmetric Difference
-     =====  ====================
+     =======  ====================
+     \+ , \|  Union
+     &        Intersection
+     \-       Difference
+     ^        Symmetric Difference
+     =======  ====================
 
    Consider the following code where ``A`` and ``B`` are associative arrays:
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -85,6 +85,7 @@
 
      =====  ====================
      \+     Union
+     \|     Union
      &      Intersection
      \-      Difference
      ^      Symmetric Difference

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -81,7 +81,7 @@
    ================================================
 
    Associative domains and arrays support a number of operators for
-   set manipulations.  The supported set operators are demonstrated below:
+   set manipulations.  The supported set operators are:
 
      =======  ====================
      \+ , \|  Union


### PR DESCRIPTION
@daviditen pointed out to me that the typo of `+|` in #6299 was intended to be `+ |` as in "both operators `+` and `|` represent the union operation. This puts `|` back in with a comma separation.