### PR TITLE
Update to scopeResolve.cpp

### DIFF
--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -35,7 +35,7 @@ class TypeSymbol;
 // This is currently a thin wrapping over a previous typedef + functions
 class ResolveScope {
 public:
-  static void           initializeScopeForChplProgram();
+  static ResolveScope*  getRootModule();
 
   static ResolveScope*  findOrCreateScopeFor(DefExpr* def);
 
@@ -72,6 +72,8 @@ private:
   typedef std::map<const char*, Symbol*>  Bindings;
 
                         ResolveScope();
+
+  void                  addBuiltIns();
 
   bool                  isAggregateTypeAndConstructor(Symbol* sym0,
                                                       Symbol* sym1);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -495,6 +495,9 @@ static void scopeResolve(const AList& alist, ResolveScope* scope) {
                isUnresolvedSymExpr(stmt) == true ||
                isGotoStmt(stmt)          == true) {
 
+    // May occur in --llvm runs
+    } else if (isExternBlockStmt(stmt)   == true) {
+
     } else {
       INT_ASSERT(false);
     }


### PR DESCRIPTION
The portion of resolution that is defined in scopeResolve.cpp performs a handful of 
traversals of sublists of ASTs.  The focus of this pass is a pair of walks

1) A walk over the elements of gDefExprs that constructs a global map from every definition to a
<name, symbol> pair in an appropriate "Scope Object".

2) A subsequent walk over the elements of gUnresolvedSymExprs that consults the scope map
to transform the UnresolvedSymExpr to a SymExpr when appropriate.

but there are several other walks in this pass.


This PR continues the process to convert this in to a more principled top-down traversal of
the AST starting with chpl__Program.  This is a work in progress.

Compiled with/without CHPL_DEVELOPER.  Ran a portion of release/ for both options.
Passed three paratests; a conventional single-locale, a single locale with --llvm, and a single
locale with --no-local
