### PR TITLE
move /data/sea/chapel/Nightly* to /data/cf/chapel/Nightly* (except NightlyHistory)

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -142,7 +142,7 @@ export CHPL_LAUNCHER=none
 export CHPL_COMM=none
 
 # Set some vars that nightly cares about.
-export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/data/sea/chapel/Nightly}
+export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/data/cf/chapel/Nightly}
 export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 
 # Ensure that one of the CPU modules is loaded.

--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -85,7 +85,7 @@ export CHPL_TARGET_ARCH=none
 
 explicit_prefix=${CHPL_NIGHTLY_LOG_PREFIX}
 default_prefix=${TMPDIR:-/tmp}/chapel_logs
-cascade_prefix=/data/sea/chapel
+cascade_prefix=/data/cf/chapel
 if [ -n "$explicit_prefix" ]; then
     logdir_prefix=$explicit_prefix
 elif [ -d $cascade_prefix ] ; then

--- a/util/cron/historify-logs
+++ b/util/cron/historify-logs
@@ -13,7 +13,9 @@ if [ -n "$*" ]; then
   exit 1
 fi
 
-loghome=/data/sea/chapel
+# 2017-05-24: /data/sea/chapel/NightlyHistory remains in Seattle,
+#   while other /data/sea/chapel/Nightly* have moved to /data/cf/chapel
+loghome=/data/cf/chapel
 loghistdir=/data/sea/chapel/NightlyHistory
 logsources="\
 Nightly \

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -290,9 +290,9 @@ if ($perfConfigName eq "") {
 
 if ($cronlogdir eq "") {
     if ($performance == 1) {
-        $cronlogdir = "/data/sea/chapel/NightlyPerformance/$perfConfigName";
+        $cronlogdir = "/data/cf/chapel/NightlyPerformance/$perfConfigName";
     } else {
-        $cronlogdir = "/data/sea/chapel/Nightly";
+        $cronlogdir = "/data/cf/chapel/Nightly";
     }
 }
 
@@ -329,7 +329,7 @@ if ($memleaks ne "") {
     if ($debug == 1 && $memleaksdir eq "") {
         $memleaksdir = $logdir;
     } elsif ($memleaksdir eq "") {
-        $memleaksdir = "/data/sea/chapel/NightlyMemLeaks";
+        $memleaksdir = "/data/cf/chapel/NightlyMemLeaks";
     }
 
     unless(-d $memleaksdir) {

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -106,7 +106,7 @@ if ($debug == 1) {
 #
 # directory locations
 #
-$logdir = "/data/sea/chapel/Nightly";
+$logdir = "/data/cf/chapel/Nightly";
 $statdir = "$logdir/Stats";
 if ($debug == 1) {
     $statfile = "$chplhomedir/tokctnightly.debug.dat";


### PR DESCRIPTION
This commit is basically a mass grep-and-replace for /data/sea/chapel,
omitting some hits that are nothing to do with the target subdirectories.