### PR TITLE
Update AstDumpToNode for ExternBlockStmt

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -1138,7 +1138,14 @@ bool AstDumpToNode::enterCondStmt(CondStmt* node)
 void AstDumpToNode::visitEblockStmt(ExternBlockStmt* node)
 {
   enterNode(node);
-  fprintf(mFP, "(%s", node->astTagAsString());
+
+  mOffset = mOffset + 2;
+  newline();
+
+  fputs(node->c_code, mFP);
+
+  mOffset = mOffset - 2;
+  newline();
   exitNode(node);
 }
 


### PR DESCRIPTION
Trivial update to AST/AstDumpToNode.cpp to improve handling of ExternBlockStmt.

This is only invoked in debugging situations.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran a small fraction of release/ on all 4 configs.
