### PR TITLE
Make where clause for rank change operations more specific

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3175,8 +3175,15 @@ module ChapelArray {
       }
       return false;
     }
+    proc oneNonRange() param {
+      for param dim in 1.. args.size {
+        if !isRange(args(dim)) then
+          return true;
+      }
+      return false;
+    }
 
-    return allValid() && oneRange();
+    return allValid() && oneRange() && oneNonRange();
     //return help(1);
   }
 


### PR DESCRIPTION
I noticed that the rank change overload for `this` was participating in overload resolution for array slices. E.g. for a 1-D array, A[1..10]. I can't explain why it worked before (perhaps a
bug in overload resolution)?

This commit fixes that by checking that there is both a range argument and a non-range argument in _validRankChangeArgs.

Passed full local testing.
Reviewed by @daviditen - thanks!