### PR TITLE
Remove 'where true' from ~ on bools

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -443,8 +443,7 @@ module ChapelBase {
   //
   inline proc ~(a: int(?w)) return __primitive("u~", a);
   inline proc ~(a: uint(?w)) return __primitive("u~", a);
-  // note: where clause used here to enable a user-defined overload
-  inline proc ~(a: bool) where true { compilerError("~ is not supported on operands of boolean type"); }
+  inline proc ~(a: bool) { compilerError("~ is not supported on operands of boolean type"); }
 
   inline proc &(a: bool, b: bool) return __primitive("&", a, b);
   inline proc &(a: int(?w), b: int(w)) return __primitive("&", a, b);

--- a/test/types/scalar/bradc/bitNegateBoolUserDefined2.chpl
+++ b/test/types/scalar/bradc/bitNegateBoolUserDefined2.chpl
@@ -1,0 +1,17 @@
+
+module A {
+  proc ~(a: bool) return !a;
+}
+
+module B {
+
+  use A;
+
+  proc main() {
+    var t: bool = true;
+    var f: bool = false;
+
+    writeln("~true = ", ~t);
+    writeln("~false = ", ~f);
+  }
+}

--- a/test/types/scalar/bradc/bitNegateBoolUserDefined2.future
+++ b/test/types/scalar/bradc/bitNegateBoolUserDefined2.future
@@ -1,0 +1,10 @@
+feature request: define ~ on bools in user module
+
+The version of ~ on bool in ChapelBase.chpl can't be marked "compiler
+generated" i.e. last resolt because then the int versions will be called
+(with a coercion).
+
+The fact that this program generates an ambiguity instead of prefering
+the more locally scoped one in A seems to be more about module
+scopes than about ~.
+

--- a/test/types/scalar/bradc/bitNegateBoolUserDefined2.good
+++ b/test/types/scalar/bradc/bitNegateBoolUserDefined2.good
@@ -1,0 +1,2 @@
+~true = false
+~false = true


### PR DESCRIPTION
In PR #6300, I added a `where` clause to proc ~ for boolean types in the spirit of making it overloadable by user code.  Unfortunately I had that backwards - a function is *more specific* if a where clause matches, not the other way around. Anyway, the test of user overload of proc ~ for bools still works because the proc ~ it finds is scoped closer than the standard modules.

Adds a .future because creating an ~ overload in a module is not currently working.

Passed full local testing.

Trivial and not reviewed.