### PR TITLE
Address a minor oversight for PR 6305

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -239,8 +239,6 @@ void scopeResolve() {
 *                                                                             *
 ************************************** | *************************************/
 
-static void addToSymbolTable(ModuleSymbol* topLevelModule);
-
 // 2017/05/23: Noakes
 //
 // This is a specialized walk for the simplified case of chpl__Program.
@@ -267,30 +265,7 @@ static void addToSymbolTable() {
   // Now recurse on every top-level module
   for_alist(stmt, theProgram->block->body) {
     if (ModuleSymbol* mod = definesModuleSymbol(stmt)) {
-      if (mod->modTag == MOD_USER) {
-        scopeResolve(mod, rootScope);
-      } else {
-        addToSymbolTable(mod);
-      }
-    }
-  }
-}
-
-// The legacy way to process the DefExprs, but on a module by module basis
-static void addToSymbolTable(ModuleSymbol* topLevelModule) {
-  std::vector<BaseAST*> asts;
-
-  collect_asts(topLevelModule, asts);
-
-  for_vector(BaseAST, item, asts) {
-    if (DefExpr* def = toDefExpr(item)) {
-      Symbol* newSym = def->sym;
-      if (newSym->hasFlag(FLAG_TEMP) == false &&
-          isLabelSymbol(newSym)      == false) {
-        ResolveScope* entry = ResolveScope::findOrCreateScopeFor(def);
-
-        entry->extend(newSym);
-      }
+      scopeResolve(mod, rootScope);
     }
   }
 }
@@ -435,6 +410,7 @@ static void scopeResolve(TypeSymbol*         typeSym,
 }
 
 static void scopeResolve(const AList& alist, ResolveScope* scope) {
+  // Add the local definitions to the scope
   for_alist(stmt, alist) {
     if (DefExpr* def = toDefExpr(stmt))   {
       Symbol* sym = def->sym;
@@ -446,6 +422,12 @@ static void scopeResolve(const AList& alist, ResolveScope* scope) {
     }
   }
 
+
+  // Should process use statements here
+
+
+
+  // Process the remaining statements
   for_alist(stmt, alist) {
     if (DefExpr* def = toDefExpr(stmt))   {
       Symbol* sym = def->sym;


### PR DESCRIPTION
This is a trivial extension for PR #6305.

While finalizing #6305, I had to fix a trivial issue for LLVM.  I unintentionally
left a bit of the debugging mode in place.  This PR backs that out properly.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran start_test on a small portion of release/ for these configurations.
Passed a full single-locale paratest
 