### PR TITLE
Fix perf graphs date parsing issue

### DIFF
--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -16,7 +16,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.min.js"></script>
 
     <!-- Overrides the default Date.parse -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/datejs/1.0/date.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.0.0/dygraph.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.0.0/dygraph.min.css" />

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -1556,7 +1556,7 @@ function parseDate(date) {
   if (numericX) {
     return date;
   } else {
-    return Date.parse(date);
+    return moment(date, "YYYY*MM*DD").toDate().getTime();
   }
 }
 


### PR DESCRIPTION
The datejs library seems to cause problems with dygraphs under certain conditions. Use moment.js instead.