### PR TITLE
Update PRK PIC inputs

### DIFF
--- a/test/studies/prk/PIC/pic.chpl
+++ b/test/studies/prk/PIC/pic.chpl
@@ -24,11 +24,11 @@ config const L = 10, // grid size
              particleMode = "SINUSOIDAL"; //how to initialize the input
 
 // for geomteric initialization
-config const rho = 1.0;
+config const rho = 0.99;
 
 // for linear initialization
-config const alpha = 0.5;
-config const beta = 0.5;
+config const alpha = 1.0;
+config const beta = 3.0;
 
 // for patch initialization
 record bbox {
@@ -38,10 +38,10 @@ record bbox {
       top: int;
 }
 
-config const initPatchLeft = 1;
-config const initPatchRight = 2;
-config const initPatchTop= 1;
-config const initPatchBottom = 2;
+config const initPatchLeft = 1;     // Reference: 0
+config const initPatchRight = 2;    // Reference: 200
+config const initPatchTop= 1;       // Reference: 100
+config const initPatchBottom = 2;   // Reference: 200
 
 const patch = new bbox(initPatchLeft,
                        initPatchRight,
@@ -166,6 +166,7 @@ proc initializeGrid(L) {
 proc initializeGeometric() {
 
   const A = n * ((1.0-rho) / (1.0-(rho**L))) / L;
+
   LCG_init();
 
 
@@ -275,19 +276,20 @@ proc initializePatch() {
   }
 
   inline proc outsidePatch(x, y) {
-    return x<patch.left   || x>patch.right ||
-            y<patch.bottom || y>patch.top;
+    return x < patch.left || x > patch.right ||
+           y < patch.bottom || y > patch.top;
   }
 
   proc badPatch(patch, patch_contain) {
-    if patch.left>=patch.right || patch.bottom>=patch.top then
+    if patch.left >= patch.right || patch.bottom >= patch.top then
       return true;
-    if patch.left  <patch_contain.left   ||
-      patch.right>patch_contain.right then
-        return true;
-    if patch.bottom<patch_contain.bottom ||
-      patch.top > patch_contain.top then
-        return true;
+    if patch.left < patch_contain.left ||
+       patch.right > patch_contain.right then
+       return true;
+    if patch.bottom < patch_contain.bottom ||
+       patch.top > patch_contain.top then
+       return true;
+
     return false;
   }
 }
@@ -381,7 +383,7 @@ proc verifyParticle(p) {
 }
 
 inline proc placeParticles(ref pIdx, n, x, y) {
-  for p in 0..#(n:int) {
+  for 1..n {
     particles[pIdx].x = x + REL_X;
     particles[pIdx].y = y + REL_Y;
     particles[pIdx].k = k;


### PR DESCRIPTION
Update `GEOMETRIC` to use `rho=0.99` instead of `1.0`, which resulted in a `NaN` bug due to division by zero.  This matches the reference inputs.

Also updated `LINEAR` to use `alpha=1.0`, `beta=3.0` to match reference inputs.

I've added a comment denoting the `PATCH` reference inputs, but I believe they require a larger problem size, so I am leaving the correctness test size alone (we can use the reference values for performance tests).

Also, minimized a for-loop which wasn't using the iteration variable.