### PR TITLE
Suppress known LLVM issues

### DIFF
--- a/test/compflags/library/withMain/lib2.suppressif
+++ b/test/compflags/library/withMain/lib2.suppressif
@@ -2,4 +2,4 @@
 # with --library when using the LLVM back end.  See github issue
 # #6336.  Suppress this for now.
 
-CHPL_COMPILER==llvm
+CHPL_LLVM==llvm

--- a/test/compflags/library/withMain/lib2.suppressif
+++ b/test/compflags/library/withMain/lib2.suppressif
@@ -1,0 +1,5 @@
+# This is a known issue where we are not yet able to handle compiling
+# with --library when using the LLVM back end.  See github issue
+# #6336.  Suppress this for now.
+
+CHPL_COMPILER==llvm

--- a/test/compflags/library/withMain/lib2.suppressif
+++ b/test/compflags/library/withMain/lib2.suppressif
@@ -1,3 +1,5 @@
+# Known LLVM issue with --library
+#
 # This is a known issue where we are not yet able to handle compiling
 # with --library when using the LLVM back end.  See github issue
 # #6336.  Suppress this for now.

--- a/test/compflags/lydia/library/errorMessage/hasMain.suppressif
+++ b/test/compflags/lydia/library/errorMessage/hasMain.suppressif
@@ -2,4 +2,4 @@
 # with --library when using the LLVM back end.  See github issue
 # #6336.  Suppress this for now.
 
-CHPL_COMPILER==llvm
+CHPL_LLVM==llvm

--- a/test/compflags/lydia/library/errorMessage/hasMain.suppressif
+++ b/test/compflags/lydia/library/errorMessage/hasMain.suppressif
@@ -1,0 +1,5 @@
+# This is a known issue where we are not yet able to handle compiling
+# with --library when using the LLVM back end.  See github issue
+# #6336.  Suppress this for now.
+
+CHPL_COMPILER==llvm

--- a/test/compflags/lydia/library/errorMessage/hasMain.suppressif
+++ b/test/compflags/lydia/library/errorMessage/hasMain.suppressif
@@ -1,3 +1,5 @@
+# Known LLVM issue with --library
+#
 # This is a known issue where we are not yet able to handle compiling
 # with --library when using the LLVM back end.  See github issue
 # #6336.  Suppress this for now.

--- a/test/functions/iterators/diten/yieldNothingIterator.suppressif
+++ b/test/functions/iterators/diten/yieldNothingIterator.suppressif
@@ -1,0 +1,5 @@
+# This is a known issue with the interface to the LLVM back end not
+# being able to handle iterators that yield nothing.  See github issue
+# #6338.  Suppress this for now.
+
+CHPL_LLVM==llvm

--- a/test/functions/iterators/diten/yieldNothingIterator.suppressif
+++ b/test/functions/iterators/diten/yieldNothingIterator.suppressif
@@ -1,3 +1,5 @@
+# Known LLVM issue with yield-nothing iterators
+#
 # This is a known issue with the interface to the LLVM back end not
 # being able to handle iterators that yield nothing.  See github issue
 # #6338.  Suppress this for now.

--- a/test/functions/vass/proc-iter/error-no-yield-in-iter-1.suppressif
+++ b/test/functions/vass/proc-iter/error-no-yield-in-iter-1.suppressif
@@ -1,0 +1,5 @@
+# This is a known issue with the interface to the LLVM back end not
+# being able to handle iterators that yield nothing.  See github issue
+# #6338.  Suppress this for now.
+
+CHPL_LLVM==llvm

--- a/test/functions/vass/proc-iter/error-no-yield-in-iter-1.suppressif
+++ b/test/functions/vass/proc-iter/error-no-yield-in-iter-1.suppressif
@@ -1,3 +1,5 @@
+# Known LLVM issue with yield-nothing iterators
+#
 # This is a known issue with the interface to the LLVM back end not
 # being able to handle iterators that yield nothing.  See github issue
 # #6338.  Suppress this for now.


### PR DESCRIPTION
This is a trivial change adding four .suppressif files for `CHPL_LLVM==llvm`.

This resulted from discussions with @mppf regarding the test failures documented in issues #6336 and #6338 .  Since it will be a while before these can be fixed, adding .suppressif files will allow a clean paratest with LLVM for now, so that people making changes that affect LLVM can know that these issues are not their fault.