### PR TITLE
File future in support of issue #6337 showing internal error

### DIFF
--- a/test/functions/iterators/errors/badArgs.bad
+++ b/test/functions/iterators/errors/badArgs.bad
@@ -1,0 +1,7 @@
+$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:176: internal error: FUN3616 chpl Version 1.16.0 pre-release (b99bdb1)
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/iterators/errors/badArgs.chpl
+++ b/test/functions/iterators/errors/badArgs.chpl
@@ -1,0 +1,12 @@
+iter myiter(r: range) {
+  for r in r do
+    yield r;
+}
+
+iter myiter(param tag: iterKind, r: range) {
+  for r in r do
+    yield r;
+}
+
+forall i in myiter(iterKind.standalone, 1..10) do
+  writeln(i);

--- a/test/functions/iterators/errors/badArgs.future
+++ b/test/functions/iterators/errors/badArgs.future
@@ -1,0 +1,10 @@
+bug: internal error due to bad call to standalone iterator
+
+This is a test motivated by issue #6337 in which we generate an
+internal error because, in resolving a standalone iterator, there's a
+mismatch between the formals and actuals.  It seems as though this
+internal error could be changed to a user error as a starting point,
+but I couldn't quickly figure out where that was happening.  Better
+would be to give the user a more specific error message pointing out
+that they don't need to / can't supply the iterKind argument -- that
+the compiler will fill that in.

--- a/test/functions/iterators/errors/badArgs.good
+++ b/test/functions/iterators/errors/badArgs.good
@@ -1,0 +1,1 @@
+badArgs.chpl:11: error: number of actuals does not match number of formals in myiter()


### PR DESCRIPTION
We generate an internal error for a bad invocation of a parallel iterator.  We shouldn't.