### PR TITLE
Hide CHPL_JEMALLOC in printchplenv unless explicitly set

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -515,25 +515,27 @@ CHPL_HWLOC
        all versions. For best results, we recommend using the bundled hwloc
        if possible.
 
-.. _readme-chplenv.CHPL_JEMALLOC:
+..  (comment) CHPL_JEMALLOC is not a user-facing feature
 
-CHPL_JEMALLOC
-~~~~~~~~~~~~~
-   Optionally, the ``CHPL_JEMALLOC`` environment variable can select
-   between no jemalloc, or using the jemalloc distributed with Chapel in
-   third-party. This setting is intended to elaborate upon
-   ``CHPL_MEM=jemalloc``.
+   .. _readme-chplenv.CHPL_JEMALLOC:
 
-       ======== ==============================================================
-       Value    Description
-       ======== ==============================================================
-       none     do not build or use jemalloc
-       jemalloc use the jemalloc distribution bundled with Chapel in third-party
-       ======== ==============================================================
+   CHPL_JEMALLOC
+   ~~~~~~~~~~~~~
+      Optionally, the ``CHPL_JEMALLOC`` environment variable can select
+      between no jemalloc, or using the jemalloc distributed with Chapel in
+      third-party. This setting is intended to elaborate upon
+      ``CHPL_MEM=jemalloc``.
 
-   If unset, ``CHPL_JEMALLOC`` defaults to ``jemalloc`` if
-   :ref:`readme-chplenv.CHPL_MEM` is ``jemalloc``.  In all other cases it
-   defaults to ``none``.
+          ======== ==============================================================
+          Value    Description
+          ======== ==============================================================
+          none     do not build or use jemalloc
+          jemalloc use the jemalloc distribution bundled with Chapel in third-party
+          ======== ==============================================================
+
+      If unset, ``CHPL_JEMALLOC`` defaults to ``jemalloc`` if
+      :ref:`readme-chplenv.CHPL_MEM` is ``jemalloc``.  In all other cases it
+      defaults to ``none``.
 
    .. (comment) CHPL_JEMALLOC=system is also available but it is only
        intended to support packaging.

--- a/modules/internal/ChapelEnv.chpl
+++ b/modules/internal/ChapelEnv.chpl
@@ -95,6 +95,7 @@ module ChapelEnv {
   /* See :ref:`readme-chplenv.CHPL_HWLOC` for more information. */
   param CHPL_HWLOC:string           = __primitive("get compiler variable", "CHPL_HWLOC");
 
+  pragma "no doc"
   /* See :ref:`readme-chplenv.CHPL_JEMALLOC` for more information. */
   param CHPL_JEMALLOC:string           = __primitive("get compiler variable", "CHPL_JEMALLOC");
 

--- a/test/chplenv/chplconfig/correctness/correctness.chpl
+++ b/test/chplenv/chplconfig/correctness/correctness.chpl
@@ -17,7 +17,6 @@ writeln("CHPL_LAUNCHER: none *");
 writeln("CHPL_TIMERS: generic *");
 writeln("CHPL_UNWIND: none *");
 writeln("CHPL_MEM: jemalloc *");
-writeln("  CHPL_JEMALLOC: jemalloc");
 writeln("CHPL_MAKE: make *");
 writeln("CHPL_ATOMICS: intrinsics *");
 writeln("CHPL_GMP: none *");

--- a/test/chplenv/printchplenv/printchplenv.chpl
+++ b/test/chplenv/printchplenv/printchplenv.chpl
@@ -14,8 +14,6 @@ writeln('CHPL_LAUNCHER: ', CHPL_LAUNCHER);
 writeln('CHPL_TIMERS: ', CHPL_TIMERS);
 writeln('CHPL_UNWIND: ', CHPL_UNWIND);
 writeln('CHPL_MEM: ', CHPL_MEM);
-if CHPL_MEM == 'jemalloc' then
-  writeln('  CHPL_JEMALLOC: ', CHPL_JEMALLOC);
 writeln('CHPL_MAKE: ', CHPL_MAKE);
 writeln('CHPL_ATOMICS: ', CHPL_ATOMICS);
 if CHPL_COMM != 'none' then

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -99,8 +99,8 @@ def print_mode(mode='list', anonymize=False):
     else:
         print_var('CHPL_MEM', target_mem, mode, 'mem', ('runtime', 'launcher'))
 
-    if m == 'make' or (target_mem == 'jemalloc' and overrides.get('CHPL_JEMALLOC')) or m == 'shell':
-        jemalloc = chpl_jemalloc.get()
+    jemalloc = chpl_jemalloc.get()
+    if (target_mem == 'jemalloc' and not jemalloc == 'jemalloc') or m == 'make' or m == 'shell':
         print_var('  CHPL_JEMALLOC', jemalloc, mode, 'jemalloc', ('runtime',))
 
     if m == 'list' or m == 'make' or m == 'shell':

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -99,7 +99,7 @@ def print_mode(mode='list', anonymize=False):
     else:
         print_var('CHPL_MEM', target_mem, mode, 'mem', ('runtime', 'launcher'))
 
-    if m == 'make' or (target_mem == 'jemalloc') or m == 'shell':
+    if m == 'make' or (target_mem == 'jemalloc' and overrides.get('CHPL_JEMALLOC')) or m == 'shell':
         jemalloc = chpl_jemalloc.get()
         print_var('  CHPL_JEMALLOC', jemalloc, mode, 'jemalloc', ('runtime',))
 


### PR DESCRIPTION
`CHPL_JEMALLOC` is not intended for user exposure. This PR hides it from the `printchplenv` output unless it is set to anything except its default value of `jemalloc` when using `CHPL_MEM=jemalloc`.

This follows up on some of the changes made in #6133