### PR TITLE
Trivial updates to UseStmt.{h,cpp}

### DIFF
--- a/compiler/include/UseStmt.h
+++ b/compiler/include/UseStmt.h
@@ -22,6 +22,8 @@
 
 #include "stmt.h"
 
+class ResolveScope;
+
 class UseStmt : public Stmt {
 public:
                   UseStmt(BaseAST* source);
@@ -53,26 +55,29 @@ public:
 
   bool            isARename(const char* name)                            const;
 
-  const char*     getRename(const char* name);
+  const char*     getRename(const char* name)                            const;
 
-  bool            isValid()                                              const;
+  void            scopeResolve(ResolveScope* scope);
 
-  void            scopeResolve();
-
-  void            validateList();
-
-  UseStmt*        applyOuterUse(UseStmt* outer);
+  UseStmt*        applyOuterUse(const UseStmt* outer);
 
   bool            skipSymbolSearch(const char* name)                     const;
 
-  bool            providesNewSymbols(UseStmt* other)                     const;
+  bool            providesNewSymbols(const UseStmt* other)               const;
 
   BaseAST*        getSearchScope()                                       const;
 
   void            writeListPredicate(FILE* mFP)                          const;
 
 private:
+
   bool            isValid(Expr* expr)                                    const;
+
+  void            validateList();
+
+  void            validateNamed  (BaseAST* scopeToUse);
+
+  void            validateRenamed(BaseAST* scopeToUse);
 
   Symbol*         getUsedSymbol(Expr* expr);
 


### PR DESCRIPTION
I have made some progress on my scope-resolve branch and am starting an effort to reduce the
delta between my branch and master through a small sequence of simple PRs.


This PR commits a few trivial updates to UseStmt.{h,cpp}; add const to a few formals and methods,
introduce a couple of helper functions and then simplify an existing definition etc.  There is no change
in observable behavior.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran a portion of
release/ on all four configurations.  Also compiled with CHPL_LLVM=llvm on linux64 and ran a
portion of release/.

Passed a single-locale paratest with futures
