### PR TITLE
Fix issue with c2chapel custom.h

### DIFF
--- a/tools/c2chapel/utils/fixFakes.sh
+++ b/tools/c2chapel/utils/fixFakes.sh
@@ -10,11 +10,22 @@ if [ -d ${fakesDir} -a -f ${header} ]; then
   echo "Fixing fake headers..."
 
   # Use system limits.h
-  rm ${fakesDir}/limits.h
+  if [ -f ${fakesDir}/limits.h ]; then
+    rm ${fakesDir}/limits.h
+  fi
+
+  if [ -e ${linkPath} ]; then
+    rm ${linkPath}
+  fi
 
   # include our custom header in every default fake header
   for f in `find ${fakesDir} -iname "*.h"` ; do
-    echo "#include \"${linkName}\"" >> $f
+    pattern="#include \"${linkName}\""
+    if grep -q ${linkName} $f; then
+      echo "Skipping $f..."
+    else
+      echo $pattern >> $f
+    fi
   done
 
   if [ -f ${linkPath} ]; then


### PR DESCRIPTION
Update fixFakes.sh helper script to not make changes if it was ran before. Otherwise we might accidentally recursively include custom.h.