### PR TITLE
Convert UseStmt::getUsedSymbol() to be ResolveScope::getUsedSymbol()

### DIFF
--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -26,6 +26,7 @@
 class BaseAST;
 class BlockStmt;
 class DefExpr;
+class Expr;
 class FnSymbol;
 class ModuleSymbol;
 class Symbol;
@@ -63,6 +64,8 @@ public:
   int                   numBindings()                                    const;
 
   bool                  extend(Symbol*     sym);
+
+  Symbol*               getUsedSymbol(Expr* expr)                        const;
 
   Symbol*               lookup(const char* name)                         const;
 

--- a/compiler/include/UseStmt.h
+++ b/compiler/include/UseStmt.h
@@ -82,8 +82,6 @@ private:
 
   void            validateRenamed(BaseAST* scopeToUse);
 
-  Symbol*         getUsedSymbol(Expr* expr);
-
   void            createRelatedNames(Symbol* maybeType);
 
   bool            matchedNameOrConstructor(const char* name)             const;


### PR DESCRIPTION
Continue to merge work from my scope-resolve branch to master.



Before this PR, the method UseStmt::getUsedSymbol(Expr* expr) provided a portion of the
logic necessary to map an Expr* (either an UnresolvedSymExpr* or a CallExpr* for a dotted-expr)
to a Symbol.

After this PR, this business logic is implemented as ResolveScope::getUsedSymbol(Expr* expr).
The goal is to start to centralize a couple of logic paths for mapping names to symbols.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran a small
portion of release/ on all configs

Passed a single-locale paratest with futures
