### PR TITLE
Fix typos

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -259,7 +259,7 @@ static void addToSymbolTable() {
     }
   }
 
-  // This would be the place to handle use statments but
+  // This would be the place to handle use statements but
   // skipping for now as chpl__Program does not have any.
 
   // Now recurse on every top-level module

--- a/doc/rst/developer/chips/20.rst
+++ b/doc/rst/developer/chips/20.rst
@@ -49,7 +49,7 @@ to provide a sorting function that can be called. For example:
     proc < (a:MyType, b:MyType) { ... }
     var A:[1..100] MyType;
     ...
-    sort(A); // programmer indends it to call < declared above
+    sort(A); // programmer intends it to call < declared above
   }
  
 However, the ``<`` function declared in Test is not visible to the definition
@@ -134,7 +134,7 @@ Why does public/private interact with point-of-instantiation?
     private proc < (a:MyType, b:MyType) { ... }
     var A:[1..100] MyType;
     ...
-    sort(A); // programmer indends it to call < declared above
+    sort(A); // programmer intends it to call < declared above
   }
 
 In this example, should the ``sort`` call be able to find the ``<`` routine?
@@ -292,7 +292,7 @@ context to provide functions for use during generic instantiation would
 either:
 
  1. Meet the strict requirements above (e.g. public, none defined at
-    point of definiton)
+    point of definition)
  2. Use ``implements`` clauses to explicitly provide the functions
     to the generic function - see CHIP 2.
  3. Require these dependencies as first-class function arguments.

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -444,7 +444,7 @@ module ChapelBase {
   inline proc ~(a: int(?w)) return __primitive("u~", a);
   inline proc ~(a: uint(?w)) return __primitive("u~", a);
   // note: where clause used here to enable a user-defined overload
-  inline proc ~(a: bool) where true { compilerError("~ is not suported on operands of boolean type"); }
+  inline proc ~(a: bool) where true { compilerError("~ is not supported on operands of boolean type"); }
 
   inline proc &(a: bool, b: bool) return __primitive("&", a, b);
   inline proc &(a: int(?w), b: int(w)) return __primitive("&", a, b);

--- a/test/types/scalar/bradc/bitNegateBool.good
+++ b/test/types/scalar/bradc/bitNegateBool.good
@@ -1,1 +1,1 @@
-bitNegateBool.chpl:4: error: ~ is not suported on operands of boolean type
+bitNegateBool.chpl:4: error: ~ is not supported on operands of boolean type


### PR DESCRIPTION
Fix typos in chip 20, scopeResolve.cpp, and one in an error message in
ChapelBase and the associated bitNegateBool.good.

bitNegateBool.chpl still passes.