### PR TITLE
Extend ResolveScope with trivial helper functions for UseStmt

### DIFF
--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -22,6 +22,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 class BaseAST;
 class BlockStmt;
@@ -31,6 +32,7 @@ class FnSymbol;
 class ModuleSymbol;
 class Symbol;
 class TypeSymbol;
+class UseStmt;
 
 // A preliminary version of a class to support the scope resolve pass
 // This is currently a thin wrapping over a previous typedef + functions
@@ -63,7 +65,13 @@ public:
 
   int                   numBindings()                                    const;
 
-  bool                  extend(Symbol*     sym);
+  BlockStmt*            asBlockStmt()                                    const;
+
+  ModuleSymbol*         enclosingModule()                                const;
+
+  bool                  extend(Symbol*        sym);
+
+  bool                  extend(const UseStmt* stmt);
 
   Symbol*               getUsedSymbol(Expr* expr)                        const;
 
@@ -73,6 +81,7 @@ public:
 
 private:
   typedef std::map<const char*, Symbol*>  Bindings;
+  typedef std::vector<const UseStmt*>     UseList;
 
                         ResolveScope();
 
@@ -87,6 +96,7 @@ private:
   BaseAST*              mAstRef;
   const ResolveScope*   mParent;
   Bindings              mBindings;
+  UseList               mUseList;
 };
 
 #endif

--- a/compiler/include/UseStmt.h
+++ b/compiler/include/UseStmt.h
@@ -72,15 +72,16 @@ public:
 private:
   bool            isEnum(const Symbol* sym)                              const;
 
-  void            updateEnclosingBlock(Symbol* sym);
+  void            updateEnclosingBlock(ResolveScope* scope,
+                                       Symbol*       sym);
 
   bool            isValid(Expr* expr)                                    const;
 
   void            validateList();
 
-  void            validateNamed  (BaseAST* scopeToUse);
+  void            validateNamed();
 
-  void            validateRenamed(BaseAST* scopeToUse);
+  void            validateRenamed();
 
   void            createRelatedNames(Symbol* maybeType);
 

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -334,6 +334,33 @@ int ResolveScope::numBindings() const {
   return retval;
 }
 
+BlockStmt* ResolveScope::asBlockStmt() const {
+  BlockStmt* retval = NULL;
+
+  if (ModuleSymbol* modSym = toModuleSymbol(mAstRef)) {
+    retval = modSym->block;
+
+  } else if (BlockStmt* block = toBlockStmt(mAstRef)) {
+    retval = block;
+
+  } else {
+    retval = NULL;
+  }
+
+  return retval;
+}
+
+ModuleSymbol* ResolveScope::enclosingModule() const {
+  const ResolveScope* ptr    = NULL;
+  ModuleSymbol*       retval = NULL;
+
+  for (ptr = this; ptr != NULL && retval == NULL; ptr = ptr->mParent) {
+    retval = toModuleSymbol(ptr->mAstRef);
+  }
+
+  return retval;
+}
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *
@@ -380,6 +407,12 @@ bool ResolveScope::extend(Symbol* newSym) {
   }
 
   return retval;
+}
+
+bool ResolveScope::extend(const UseStmt* stmt) {
+  mUseList.push_back(stmt);
+
+  return true;
 }
 
 bool ResolveScope::isAggregateTypeAndConstructor(Symbol* sym0, Symbol* sym1) {


### PR DESCRIPTION
Continue to merge development branch to master

This PR adds a few simple helper functions to ResolveScope to centralize
support for UseStmt and then updates UseStmt accordingly.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran a portion
of release/ on all of these configurations.  Also compiled/ran with CHPL_LLVM=llvm.

Passed a single-locale paratest with futures
