### PR TITLE
Create wrappers for generic record initializers

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3289,11 +3289,6 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly) {
         // If the first actual is an instance of dtMethodToken and the call is
         // to "init" of a generic record that defined initializers
         resolveInitializer(call);
-        NamedExpr* named = toNamedExpr(call->get(2));
-        INT_ASSERT(named);
-        SymExpr* namedSe = toSymExpr(named->actual);
-        INT_ASSERT(namedSe);
-        namedSe->symbol()->type = call->resolvedFunction()->_this->type;
         return call->resolvedFunction();
       }
     }

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -57,6 +57,11 @@ filterInitCandidate(Vec<ResolutionCandidate*>& candidates,
 static FnSymbol*
 instantiateInitSig(FnSymbol* fn, SymbolMap& subs, CallExpr* call);
 
+static void makeRecordInitWrappers(CallExpr* call);
+static void makeActualsVector(const CallExpr* call,
+                              const CallInfo& info,
+                              Vec<ArgSymbol*>& actualIdxToFormal);
+
 static bool isRefWrapperForNonGenericRecord(AggregateType* at);
 
 // Rewrite of instantiateSignature, for initializers.  Removed some bits,
@@ -378,6 +383,8 @@ void resolveInitializer(CallExpr* call) {
     SymExpr* namedSe = toSymExpr(named->actual);
     INT_ASSERT(namedSe);
     namedSe->symbol()->type = call->resolvedFunction()->_this->type;
+
+    makeRecordInitWrappers(call);
   }
 
   callStack.pop();
@@ -546,6 +553,118 @@ void resolveMatch(FnSymbol* fn) {
   // make sure methods are in the methods list
   //
   ensureInMethodList(fn);
+}
+
+// This creates wrapper functions for calls to record initializers with default
+// values, out of order named arguments, etc.  That effort was skipped during
+// the call match stage because the "this" argument to the initializer was
+// still generic until the body had been resolved.  After we have determined
+// the concrete type for the "this" argument, then we are capable of creating
+// valid wrappers.
+//
+// Note that this action is not necessary for class initializers, because such
+// calls are wrapped by the "_new" function, and appropriate wrappers will
+// be created for it, so we don't need to wrap the initializer itself.
+static void makeRecordInitWrappers(CallExpr* call) {
+  CallInfo info(call, false, false);
+
+  Vec<ArgSymbol*> actualIdxToFormal;
+  makeActualsVector(call, info, actualIdxToFormal);
+
+
+  FnSymbol* wrap = call->resolvedFunction();
+
+  // Taken from wrapAndCleanUpActuals (modified to not need a
+  // ResolutionCandidate by recreating the necessary pieces)
+  wrap = defaultWrap(wrap, &actualIdxToFormal, &info);
+  reorderActuals(wrap, &actualIdxToFormal, &info);
+  coerceActuals(wrap, &info);
+  wrap = promotionWrap(wrap, &info, true);
+
+  call->baseExpr->replace(new SymExpr(wrap));
+
+  resolveFns(wrap);
+}
+
+// Modified version of computeActualFormalAlignment to only populate the
+// actualIdxToFormal Vec.  Substitutes the formalIdxToActual Vec with one
+// that stores booleans, because I do still need that information in order to
+// correctly populate the actuals
+//
+// This work was already performed when we found the right resolution candidate
+// so the "failure" modes should never get triggered.  The information we need
+// was cleaned up, though, so we are just going to recreate the parts we need.
+static void makeActualsVector(const CallExpr* call,
+                              const CallInfo& info,
+                              Vec<ArgSymbol*>& actualIdxToFormal) {
+  Vec<bool> formalIdxToActual;
+  FnSymbol* fn = call->resolvedFunction();
+
+  formalIdxToActual.fill(fn->numFormals());
+
+  actualIdxToFormal.fill(info.actuals.n);
+
+  for (int i = 0; i < actualIdxToFormal.n; i++) {
+    if (info.actualNames.v[i]) {
+      bool match = false;
+      int j = 0;
+      for_formals(formal, fn) {
+        if (!strcmp(info.actualNames.v[i], formal->name)) {
+          match = true;
+          actualIdxToFormal.v[i] = formal;
+          formalIdxToActual.v[j] = true;
+          break;
+        }
+        j++;
+      }
+      // Fail if no matching formal is found.
+      if (!match) {
+        INT_FATAL(call, "Compilation should have already ensured this action ",
+                  " would be valid");
+      }
+    }
+  }
+
+  // Fill in unmatched formals in sequence with the remaining actuals.
+  // Record successful substitutions.
+  int j = 0;
+  ArgSymbol* formal = (fn->numFormals()) ? fn->getFormal(1) : NULL;
+  for (int i = 0; i < actualIdxToFormal.n; i++) {
+    if (!info.actualNames.v[i]) {
+      bool match = false;
+      while (formal) {
+        if (formal->variableExpr)
+          return;
+        if (!formalIdxToActual.v[j]) {
+          match = true;
+          actualIdxToFormal.v[i] = formal;
+          formalIdxToActual.v[j] = true;
+          formal = next_formal(formal);
+          j++;
+          break;
+        }
+        formal = next_formal(formal);
+        j++;
+      }
+      // Fail if there are too many unnamed actuals.
+      if (!match && !(fn->hasFlag(FLAG_GENERIC) && fn->hasFlag(FLAG_TUPLE))) {
+        INT_FATAL(call, "Compilation should have verified this action was ",
+                  "valid");
+      }
+    }
+  }
+
+  // Make sure that any remaining formals are matched by name
+  // or have a default value.
+  while (formal) {
+    if (!formalIdxToActual.v[j] && !formal->defaultExpr) {
+      // Fail if not.
+      INT_FATAL(call, "Compilation should have verified this action was ",
+                "valid");
+    }
+    formal = next_formal(formal);
+    j++;
+  }
 }
 
 void temporaryInitializerFixup(CallExpr* call) {

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -372,6 +372,14 @@ void resolveInitializer(CallExpr* call) {
 
   resolveMatch(call->resolvedFunction());
 
+  if (isGenericRecord(call->get(2)->typeInfo())) {
+    NamedExpr* named = toNamedExpr(call->get(2));
+    INT_ASSERT(named);
+    SymExpr* namedSe = toSymExpr(named->actual);
+    INT_ASSERT(namedSe);
+    namedSe->symbol()->type = call->resolvedFunction()->_this->type;
+  }
+
   callStack.pop();
 }
 

--- a/test/classes/initializers/records/generics/assignment/paramArgDefaultValue.future
+++ b/test/classes/initializers/records/generics/assignment/paramArgDefaultValue.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/records/generics/assignment/typeArgDefaultValue.future
+++ b/test/classes/initializers/records/generics/assignment/typeArgDefaultValue.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/records/generics/assignment/varArgDefaultValue.future
+++ b/test/classes/initializers/records/generics/assignment/varArgDefaultValue.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.


### PR DESCRIPTION
We had skipped performing this action during normal candidate elimination due to
the type of the "this" actual still being generic until the body had been
resolved.  With classes, this was fine because the initializer call would be
wrapped by the "_new" function and that function would get the appropriate
wrappers created for it (and doing so in both places would be unnecessary and
problematic).  Records don't define a "_new" function, though, so needed to
have their wrappers created after the concrete type had been determined, in
order to handle arguments with default values, etc.

This change adds that support by taking the relevant portions of
computeActualFormalAlignment and wrapAndCleanUpActuals and adjusting them to
suit this specific use case.  It also moves the update of the "this" actual's type
earlier, so that this information was present for the creation of the wrapper (meant
to do that in my last PR, but forgot before merging, whoops!)

Removed the .future files on the three tests that now pass because of this
change.

Passed a futures run in test/classes/initializers, passed full std testing.