### PR TITLE
Increase nightly test coverage for LLVM

### DIFF
--- a/util/cron/test-llvm.bash
+++ b/util/cron/test-llvm.bash
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
 #
-# Test default configuration with CHPL_LLVM=llvm and pass --llvm flag to
-# compiler on linux64.
+# Full test suite with CHPL_LLVM=llvm and pass --llvm flag to
+# compiler on linux64. Now uses paratest.server.
+
+# Needs /data/cf/chapel/setup_python27.bash (common-llvm)
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-llvm.bash
+source $CWD/common-localnode-paratest.bash
+
+# common-llvm restricts us to extern/ferguson, but we want all the tests
+unset CHPL_NIGHTLY_TEST_DIRS
+
+# paratest with 8 nodes on localhost
+nightly_args="${nightly_args} $(set +x ; get_nightly_paratest_args 8)"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="llvm"
 
-$CWD/nightly -cron -examples ${nightly_args}
+log_info START nightly -cron ${nightly_args}
+$CWD/nightly -cron ${nightly_args}
+log_info nightly EXIT status $?


### PR DESCRIPTION
Changes the existing llvm test config to
(a) run the entire test suite, instead of just examples + extern/ferguson,
(b) use paratest w 8 localhost nodes.