### PR TITLE
Scope gap 9

### DIFF
--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -185,7 +185,7 @@ void UseStmt::scopeResolve(ResolveScope* scope) {
     if (SymExpr* se = toSymExpr(src)) {
       INT_ASSERT(se->symbol() == rootModule);
 
-    } else if (Symbol* sym = scope->getUsedSymbol(src)) {
+    } else if (Symbol* sym = scope->lookup(src)) {
       SET_LINENO(this);
 
       if (ModuleSymbol* modSym = toModuleSymbol(sym)) {

--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -26,12 +26,14 @@
 
 class BaseAST;
 class BlockStmt;
+class CallExpr;
 class DefExpr;
 class Expr;
 class FnSymbol;
 class ModuleSymbol;
 class Symbol;
 class TypeSymbol;
+class UnresolvedSymExpr;
 class UseStmt;
 
 // A preliminary version of a class to support the scope resolve pass
@@ -73,15 +75,18 @@ public:
 
   bool                  extend(const UseStmt* stmt);
 
-  Symbol*               getUsedSymbol(Expr* expr)                        const;
+  Symbol*               lookup(Expr*       expr)                         const;
 
   Symbol*               lookup(const char* name)                         const;
 
   void                  describe()                                       const;
 
 private:
-  typedef std::map<const char*, Symbol*>  Bindings;
-  typedef std::vector<const UseStmt*>     UseList;
+  typedef std::vector<const UseStmt*>    UseList;
+  typedef std::vector<Symbol*>           SymList;
+
+  typedef std::map<const char*, Symbol*> Bindings;
+  typedef std::map<Symbol*,     UseList> UseMap;
 
                         ResolveScope();
 
@@ -92,6 +97,23 @@ private:
 
   bool                  isSymbolAndMethod(Symbol* sym0,
                                           Symbol* sym1);
+
+  Symbol*               lookup(UnresolvedSymExpr* usymExpr)              const;
+
+  Symbol*               lookupWithUses(UnresolvedSymExpr* usymExpr)      const;
+
+  bool                  isRepeat(Symbol* toAdd, const SymList& symbols)  const;
+
+  Symbol*               getFieldFromPath(CallExpr* dottedExpr)           const;
+
+  void                  buildBreadthFirstUseList(UseList& useList)       const;
+
+  void                  buildBreadthFirstUseList(UseList& modules,
+                                                 UseList& current,
+                                                 UseMap&  visited)       const;
+
+   bool                 skipUse(UseMap&        visited,
+                                const UseStmt* current)                  const;
 
   BaseAST*              mAstRef;
   const ResolveScope*   mParent;

--- a/test/modules/diten/usemodule/test_nested_use2.good
+++ b/test/modules/diten/usemodule/test_nested_use2.good
@@ -1,2 +1,2 @@
 test_nested_use2.chpl:11: In function 'main':
-test_nested_use2.chpl:12: error: Cannot find module 'notinnermost'
+test_nested_use2.chpl:12: error: Cannot find field 'notinnermost'

--- a/test/modules/diten/usemodule/test_nested_use3.good
+++ b/test/modules/diten/usemodule/test_nested_use3.good
@@ -1,2 +1,2 @@
 test_nested_use3.chpl:11: In function 'main':
-test_nested_use3.chpl:12: error: Cannot find module 'notmiddlemost'
+test_nested_use3.chpl:12: error: Cannot find field 'notmiddlemost'

--- a/test/modules/diten/usemodule/test_nested_use4.good
+++ b/test/modules/diten/usemodule/test_nested_use4.good
@@ -1,2 +1,2 @@
 test_nested_use4.chpl:11: In function 'main':
-test_nested_use4.chpl:12: error: Cannot find module or enum 'notoutermost'
+test_nested_use4.chpl:12: error: Cannot find object 'notoutermost'


### PR DESCRIPTION
PR #6362 migrated UseStmt:getUsedSymbol(Expr*) to ResolveScope:getUsedSymbol(Expr*).

In practice this method replicates some of the general logic for mapping names to
symbols that is currently implemented in scopeResolve.cpp and then layers in some
error messages that are specific to UseStmts.

This PR renames the method to be ResolveScope::lookup(Expr*) and takes the first steps
to enable this code to be used more generally.  This includes cloning/modifying some of
the code that is currently in scopeResolve.cpp.  Future PRs will migrate the dependencies
in scopeResolve.cpp to use the new paths once they are fully developed.

This PR modifies the .good files for three tests with invalid UseStmts to account for the
slightly more general form of messaging for lookup failures.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran a portion of
release/ for all configurations.  Also compiled with CHPL_LLVM=llvm on gcc/linux64 and ran a
portion of release/ on linux64.

Passed a single-locale paratest with futures.
