### PR TITLE
Minor tweaks to name lookups

### DIFF
--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -77,7 +77,7 @@ public:
 
   Symbol*               lookup(Expr*       expr)                         const;
 
-  Symbol*               lookup(const char* name)                         const;
+  Symbol*               lookupNameLocally(const char* name)              const;
 
   void                  describe()                                       const;
 
@@ -105,6 +105,10 @@ private:
   bool                  isRepeat(Symbol* toAdd, const SymList& symbols)  const;
 
   Symbol*               getFieldFromPath(CallExpr* dottedExpr)           const;
+
+  Symbol*               getField(const char* fieldName)                  const;
+
+  Symbol*               getFieldLocally(const char* fieldName)           const;
 
   void                  buildBreadthFirstUseList(UseList& useList)       const;
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1002,7 +1002,7 @@ static void resolveModuleCall(CallExpr* call) {
         enclosingModule->moduleUseAdd(mod);
 
         if (ResolveScope* scope = ResolveScope::getScopeFor(mod->block)) {
-          sym = scope->lookup(mbrName);
+          sym = scope->lookupNameLocally(mbrName);
         }
 
         if (sym != NULL) {
@@ -1464,7 +1464,7 @@ static Symbol* inSymbolTable(const char* name, BaseAST* ast) {
   Symbol* retval = NULL;
 
   if (ResolveScope* scope = ResolveScope::getScopeFor(ast)) {
-    if (Symbol* sym = scope->lookup(name)) {
+    if (Symbol* sym = scope->lookupNameLocally(name)) {
       if (sym->hasFlag(FLAG_METHOD) == false) {
         retval = sym;
 


### PR DESCRIPTION
A few minor tweaks for ResolveScope to continue to advance the code
to fetch fields from objects; currently centered on Modules and UseStmts.

compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran a portion of release/ for all configurations.  Also add CHPL_LLVM=llvm for linux64.

Passed a full single-locale paratest
