### PR TITLE
Extend ResolveScope to support only/except lists for UseStmt

### DIFF
--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -323,64 +323,60 @@ void UseStmt::validateList() {
 }
 
 void UseStmt::noRepeats() const {
-  for (std::vector<const char*>::const_iterator it = named.begin();
-       it != named.end();
-       ++it) {
-    std::vector<const char*>::const_iterator next = it;
+  std::vector<const char*>::const_iterator           it1;
+  std::map<const char*, const char*>::const_iterator it2;
+
+  for (it1 = named.begin(); it1 != named.end(); ++it1) {
+    std::vector<const char*>::const_iterator           next = it1;
+    std::map<const char*, const char*>::const_iterator rit;
 
     for (++next; next != named.end(); ++next) {
       // Check rest of named for the same name
-      if (strcmp(*it, *next) == 0) {
-        USR_WARN(this, "identifier '%s' is repeated", *it);
+      if (strcmp(*it1, *next) == 0) {
+        USR_WARN(this, "identifier '%s' is repeated", *it1);
       }
     }
 
-    for (std::map<const char*, const char*>::const_iterator
-           renamedIt = renamed.begin();
-         renamedIt != renamed.end();
-         ++renamedIt) {
-
-      if (strcmp(*it, renamedIt->second) == 0) {
+    for (rit = renamed.begin(); rit != renamed.end(); ++rit) {
+      if (strcmp(*it1, rit->second) == 0) {
         // This identifier is also used as the old name for a renaming.
         // Probably a mistake on the user's part, but not a catastrophic one
-        USR_WARN(this, "identifier '%s' is repeated", *it);
+        USR_WARN(this, "identifier '%s' is repeated", *it1);
       }
 
-      if (strcmp(*it, renamedIt->first) == 0) {
+      if (strcmp(*it1, rit->first) == 0) {
         // The user attempted to rename a symbol to a name that was already
         // in the 'only' list.  This causes a naming conflict.
-        USR_FATAL_CONT(this, "symbol '%s' multiply defined", *it);
+        USR_FATAL_CONT(this, "symbol '%s' multiply defined", *it1);
       }
     }
   }
 
-  for (std::map<const char*, const char*>::const_iterator it = renamed.begin();
-       it != renamed.end();
-       ++it) {
-    std::map<const char*, const char*>::const_iterator next = it;
+  for (it2 = renamed.begin(); it2 != renamed.end(); ++it2) {
+    std::map<const char*, const char*>::const_iterator next = it2;
 
     for (++next; next != renamed.end(); ++next) {
-      if (strcmp(it->second, next->second) == 0) {
+      if (strcmp(it2->second, next->second) == 0) {
         // Renamed this variable twice.  Probably a mistake on the user's part,
         // but not a catastrophic one
-        USR_WARN(this, "identifier '%s' is repeated", it->second);
+        USR_WARN(this, "identifier '%s' is repeated", it2->second);
       }
 
-      if (strcmp(it->second, next->first) == 0) {
+      if (strcmp(it2->second, next->first) == 0) {
         // This name is the old_name in one rename and the new_name in another
         // Did the user actually want to cut out the middle man?
-        USR_WARN(this, "identifier '%s' is repeated", it->second);
+        USR_WARN(this, "identifier '%s' is repeated", it2->second);
         USR_PRINT("Did you mean to rename '%s' to '%s'?",
                   next->second,
-                  it->first);
+                  it2->first);
       }
 
-      if (strcmp(it->first, next->second) == 0) {
+      if (strcmp(it2->first, next->second) == 0) {
         // This name is the old_name in one rename and the new_name in another
         // Did the user actually want to cut out the middle man?
-        USR_WARN(this, "identifier '%s' is repeated", it->first);
+        USR_WARN(this, "identifier '%s' is repeated", it2->first);
         USR_PRINT("Did you mean to rename '%s' to '%s'?",
-                  it->second,
+                  it2->second,
                   next->first);
       }
     }
@@ -419,11 +415,11 @@ void UseStmt::validateNamed() {
 }
 
 void UseStmt::validateRenamed() {
+  std::map<const char*, const char*>::iterator it;
+
   BaseAST* scopeToUse = getSearchScope();
 
-  for (std::map<const char*, const char*>::iterator it = renamed.begin();
-       it != renamed.end();
-       ++it) {
+  for (it = renamed.begin(); it != renamed.end(); ++it) {
     if (Symbol* sym = lookup(it->second, scopeToUse)) {
       if (sym->isVisible(this) == true) {
         createRelatedNames(sym);
@@ -750,7 +746,7 @@ UseStmt* UseStmt::applyOuterUse(const UseStmt* outer) {
             newRenamed[it->first] = it->second;
           } else {
 
-            std::map<const char*, const char*>::iterator innerIt = renamed.find(it->second);
+            std::map<const char*, const char*>::const_iterator innerIt = renamed.find(it->second);
 
             if (innerIt != renamed.end()) {
               // We found this symbol in the renamed list and the outer

--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -21,6 +21,7 @@
 #define _RESOLVE_SCOPE_H_
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -79,11 +80,19 @@ public:
 
   Symbol*               lookupNameLocally(const char* name)              const;
 
+  // Support for UseStmt with only/except
+  // Has the potential to return multiple fields
+  // Includes public and private fields
+  void                  getFields(const char*           fieldName,
+                                  std::vector<Symbol*>& symbols)         const;
+
   void                  describe()                                       const;
 
 private:
   typedef std::vector<const UseStmt*>    UseList;
   typedef std::vector<Symbol*>           SymList;
+
+  typedef std::set<const ResolveScope*>  ScopeSet;
 
   typedef std::map<const char*, Symbol*> Bindings;
   typedef std::map<Symbol*,     UseList> UseMap;
@@ -109,6 +118,13 @@ private:
   Symbol*               getField(const char* fieldName)                  const;
 
   Symbol*               getFieldLocally(const char* fieldName)           const;
+
+  void                  getFields(const char* fieldName,
+                                  ScopeSet&   visited,
+                                  SymList&    symbols)                   const;
+
+  bool                  getFieldsWithUses(const char* fieldName,
+                                          SymList&    symbols)           const;
 
   void                  buildBreadthFirstUseList(UseList& useList)       const;
 


### PR DESCRIPTION
Extend ResolveScope to be able to return lists of symbols as needed for
the validate component for only/except lists on UseStmt

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Executed a portion of release on each configuration.  Also compiled with CHPL_LLVM=llvm
on linux64 and ran a portion of release/

Passed single-locale paratest with futures
