### PR TITLE
Add tests of exit() in inline and regular procedures

### DIFF
--- a/test/functions/lydia/inlineExitBad.bad
+++ b/test/functions/lydia/inlineExitBad.bad
@@ -1,0 +1,1 @@
+inlineExitBad.chpl:1: error: control reaches end of function that returns a value

--- a/test/functions/lydia/inlineExitBad.chpl
+++ b/test/functions/lydia/inlineExitBad.chpl
@@ -1,0 +1,16 @@
+inline proc exiter(x: int): int {
+  if (x > 10) {
+    exit(0);
+  } else {
+    return x;
+  }
+}
+
+proc callExiter(x: int) {
+  writeln(exiter(x));
+}
+
+writeln("starting program!");
+callExiter(5);
+callExiter(11);
+writeln("Should never reach here!");

--- a/test/functions/lydia/inlineExitBad.future
+++ b/test/functions/lydia/inlineExitBad.future
@@ -1,0 +1,6 @@
+semantic: should exit() satisfy analysis of function return?
+
+This program gives an error when a return statement is not present in the
+control flow after an exit() call, even though the program will terminate at
+that point.  Should exit() be an acceptable alternative to having a return
+statement in that path of control flow?

--- a/test/functions/lydia/inlineExitBad.good
+++ b/test/functions/lydia/inlineExitBad.good
@@ -1,0 +1,2 @@
+starting program!
+5

--- a/test/functions/lydia/inlineExitGood1.chpl
+++ b/test/functions/lydia/inlineExitGood1.chpl
@@ -1,0 +1,15 @@
+inline proc exiter(x: int): int {
+  if (x > 10) {
+    exit(0);
+  }
+  return x;
+}
+
+proc callExiter(x: int) {
+  writeln(exiter(x));
+}
+
+writeln("starting program!");
+callExiter(5);
+callExiter(11);
+writeln("Should never reach here!");

--- a/test/functions/lydia/inlineExitGood1.good
+++ b/test/functions/lydia/inlineExitGood1.good
@@ -1,0 +1,2 @@
+starting program!
+5

--- a/test/functions/lydia/inlineExitGood2.chpl
+++ b/test/functions/lydia/inlineExitGood2.chpl
@@ -1,0 +1,11 @@
+inline proc exiter() {
+  exit(0);
+}
+
+proc callExiter() {
+  exiter();
+}
+
+writeln("starting program!");
+callExiter();
+writeln("Should never reach here!");

--- a/test/functions/lydia/inlineExitGood2.good
+++ b/test/functions/lydia/inlineExitGood2.good
@@ -1,0 +1,1 @@
+starting program!

--- a/test/functions/lydia/regularExitBad.bad
+++ b/test/functions/lydia/regularExitBad.bad
@@ -1,0 +1,2 @@
+regularExitBad.chpl:1: In function 'exiter':
+regularExitBad.chpl:1: error: control reaches end of function that returns a value

--- a/test/functions/lydia/regularExitBad.chpl
+++ b/test/functions/lydia/regularExitBad.chpl
@@ -1,0 +1,16 @@
+proc exiter(x: int): int {
+  if (x > 10) {
+    exit(0);
+  } else {
+    return x;
+  }
+}
+
+proc callExiter(x: int) {
+  writeln(exiter(x));
+}
+
+writeln("starting program!");
+callExiter(5);
+callExiter(11);
+writeln("Should never reach here!");

--- a/test/functions/lydia/regularExitBad.future
+++ b/test/functions/lydia/regularExitBad.future
@@ -1,0 +1,6 @@
+semantic: should exit() satisfy analysis of function return?
+
+This program gives an error when a return statement is not present in the
+control flow after an exit() call, even though the program will terminate at
+that point.  Should exit() be an acceptable alternative to having a return
+statement in that path of control flow?

--- a/test/functions/lydia/regularExitBad.good
+++ b/test/functions/lydia/regularExitBad.good
@@ -1,0 +1,2 @@
+starting program!
+5


### PR DESCRIPTION
A user encountered an error message with exit() in a function that returns.
These tests document cases that don't generate that error message, and adds a
future for the ones that do, since perhaps our return analysis should allow
for exit() calls to not be followed by a return statement.

I'm tracking both the inline version and the normal proc version, since the user
first encountered this with an inlined procedure

These tests track issue #6374 