### PR TITLE
Minor adjustment in PRK-DGEMM

### DIFF
--- a/test/studies/prk/DGEMM/dgemm.chpl
+++ b/test/studies/prk/DGEMM/dgemm.chpl
@@ -58,9 +58,10 @@ if blockSize == 0 {
   for niter in 0..#iterations {
     if iterations==1 || niter==1 then t.start();
 
-    // loop order is the same as the OpenMP version
-    forall (j,k,i) in {vecRange, vecRange, vecRange} {
-      C[i,j] += A[i,k] * B[k,j];
+    forall (i,j) in matrixSpace {
+      for k in vecRange {
+        C[i,j] += A[i,k] * B[k,j];
+      }
     }
   }
   t.stop();

--- a/test/studies/prk/DGEMM/dgemm.chpl
+++ b/test/studies/prk/DGEMM/dgemm.chpl
@@ -58,11 +58,10 @@ if blockSize == 0 {
   for niter in 0..#iterations {
     if iterations==1 || niter==1 then t.start();
 
-    forall (i,j) in matrixSpace {
-      for k in vecRange {
+    forall (i,j) in matrixSpace do
+      for k in vecRange do
         C[i,j] += A[i,k] * B[k,j];
-      }
-    }
+
   }
   t.stop();
 }


### PR DESCRIPTION
@cassella noticed that unblocked branch in DGEMM has forall that looks unsafe. This PR fixes the issue. Also:

- Diverges from OpenMP loop ordering in favor of the standard ijk order.
- Uses a predefined domain to avoid creating domains at every iteration. (Similar to the blocked branch)

Changed test passes with standard linux64 config.