### PR TITLE
Allow 'local field' pragma on arrays

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -462,7 +462,7 @@ static void fixType(Symbol* sym, bool mustBeWide, bool wideVal) {
     if (TypeSymbol* ts = toTypeSymbol(sym->defPoint->parentSymbol)) {
       if (isFullyWide(ts)) return; // Don't widen a field in a wide type.
 
-      if (sym->hasFlag(FLAG_LOCAL_FIELD) && !isClass(sym->type)) {
+      if (sym->hasFlag(FLAG_LOCAL_FIELD) && !(isClass(sym->type) || sym->type->symbol->hasFlag(FLAG_ARRAY))) {
         USR_WARN("\"local field\" pragma applied to non-class field %s (%s) in type %s\n",
             sym->cname, sym->type->symbol->cname, ts->cname);
       }
@@ -1277,8 +1277,10 @@ static void propagateField(Symbol* sym) {
               case PRIM_GET_SVEC_MEMBER:
                 // Currently we have to keep a 'local field' wide for
                 // compatibility with some codegen stuff.
-                debug(sym, "field causes _val of %s (%d) to be wide\n", lhs->cname, lhs->id);
-                setValWide(use, lhs);
+                if (fIgnoreLocalClasses || !sym->hasFlag(FLAG_LOCAL_FIELD)) {
+                  debug(sym, "field causes _val of %s (%d) to be wide\n", lhs->cname, lhs->id);
+                  setValWide(use, lhs);
+                }
                 break;
 
               case PRIM_GET_MEMBER_VALUE:

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -1284,8 +1284,6 @@ static void propagateField(Symbol* sym) {
             switch (call->primitive->tag) {
               case PRIM_GET_MEMBER:
               case PRIM_GET_SVEC_MEMBER:
-                // Currently we have to keep a 'local field' wide for
-                // compatibility with some codegen stuff.
                 if (fIgnoreLocalClasses || !isLocalField) {
                   debug(sym, "field causes _val of %s (%d) to be wide\n", lhs->cname, lhs->id);
                   setValWide(use, lhs);

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -382,6 +382,7 @@ class BlockArr: BaseArr {
   var doRADOpt: bool = defaultDoRADOpt;
   var dom: BlockDom(rank, idxType, stridable, sparseLayoutType);
   var locArr: [dom.dist.targetLocDom] LocBlockArr(eltType, rank, idxType, stridable);
+  pragma "local field"
   var myLocArr: LocBlockArr(eltType, rank, idxType, stridable);
   const SENTINEL = max(rank*idxType);
 }
@@ -403,6 +404,7 @@ class LocBlockArr {
   param stridable: bool;
   const locDom: LocBlockDom(rank, idxType, stridable);
   var locRAD: LocRADCache(eltType, rank, idxType, stridable); // non-nil if doRADOpt=true
+  pragma "local field"
   var myElems: [locDom.myBlock] eltType;
   var locRADLock: atomicbool; // This will only be accessed locally
                               // force the use of processor atomics
@@ -1273,7 +1275,7 @@ proc BlockArr.setRADOpt(val=true) {
 //
 // TODO: Should this be inlined?
 //
-proc LocBlockArr.this(i) ref {
+inline proc LocBlockArr.this(i) ref {
   return myElems(i);
 }
 

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -324,6 +324,7 @@ class StencilArr: BaseArr {
   var doRADOpt: bool = defaultDoRADOpt;
   var dom: StencilDom(rank, idxType, stridable, ignoreFluff);
   var locArr: [dom.dist.targetLocDom] LocStencilArr(eltType, rank, idxType, stridable);
+  pragma "local field"
   var myLocArr: LocStencilArr(eltType, rank, idxType, stridable);
   const SENTINEL = max(rank*idxType);
 }
@@ -345,6 +346,7 @@ class LocStencilArr {
   param stridable: bool;
   const locDom: LocStencilDom(rank, idxType, stridable);
   var locRAD: LocRADCache(eltType, rank, idxType, stridable); // non-nil if doRADOpt=true
+  pragma "local field"
   var myElems: [locDom.myFluff] eltType;
   var locRADLock: atomicbool; // This will only be accessed locally
                               // force the use of processor atomics
@@ -1480,7 +1482,7 @@ proc StencilArr.setRADOpt(val=true) {
 //
 // the accessor for the local array -- assumes the index is local
 //
-proc LocStencilArr.this(i) ref {
+inline proc LocStencilArr.this(i) ref {
   return myElems(i);
 }
 


### PR DESCRIPTION
The optimized Stencil PRK currently relies on a local block to squash
wide-pointer overhead. At a high-level, this should be done instead by
applying the 'local field' pragma to certain fields in the various
StencilDist classes. For the pragma to have effect, a change is made
to insertWideReferences to allow 'local field' to work on
PRIM_GET_MEMBER. A change was also made to squash the warning for arrays.

Testing:
- [x] full local
- [x] full no-local
- [x] full gasnet