### PR TITLE
Fix a bug in parallel iteration over aligned block-distrib. doms/arrs

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -849,9 +849,10 @@ iter BlockDom.these(param tag: iterKind, followThis) where tag == iterKind.follo
   type strType = chpl__signedType(idxType);
   for param i in 1..rank {
     var stride = whole.dim(i).stride: strType;
+    var alignment = whole.dim(i).alignment;
     // not checking here whether the new low and high fit into idxType
-    var low = (stride * followThis(i).low:strType):idxType;
-    var high = (stride * followThis(i).high:strType):idxType;
+    var low = (stride * followThis(i).low:strType):idxType + alignment;
+    var high = (stride * followThis(i).high:strType):idxType + alignment;
     t(i) = ((low..high by stride:strType) + whole.dim(i).low by followThis(i).stride:strType).safeCast(t(i).type);
   }
   for i in {(...t)} {
@@ -1125,9 +1126,10 @@ iter BlockArr.these(param tag: iterKind, followThis, param fast: bool = false) r
 
   for param i in 1..rank {
     var stride = dom.whole.dim(i).stride;
+    var alignment = whole.dim(i).alignment;
     // NOTE: Not bothering to check to see if these can fit into idxType
-    var low = followThis(i).low * abs(stride):idxType;
-    var high = followThis(i).high * abs(stride):idxType;
+    var low = followThis(i).low * abs(stride):idxType + alignment;
+    var high = followThis(i).high * abs(stride):idxType + alignment;
     myFollowThis(i) = ((low..high by stride) + dom.whole.dim(i).low by followThis(i).stride).safeCast(myFollowThis(i).type);
     lowIdx(i) = myFollowThis(i).low;
   }


### PR DESCRIPTION
This is motivated by issue #6383 filed by Nikhil and Paul.

TODO:
- [ ] verify assumption made that alignment is always in 0..#stride
- [ ] add tests to make sure I didn't introduce a bug like the one Nikhil caught below
- [ ] full block dist test run
- [ ] see if other dists have similar issues and test as appropriate
