### PR TITLE
Add doc for no_push to upstream remote

### DIFF
--- a/doc/rst/developer/bestPractices/GitCheatsheet.rst
+++ b/doc/rst/developer/bestPractices/GitCheatsheet.rst
@@ -58,7 +58,11 @@ your fork:
     git remote add upstream https://github.com/chapel-lang/chapel.git
     # Make sure it works, get up-to-date without modifying your files
     git fetch upstream
-
+    # Change remote for upstream push to "no_push" 
+    git remote set-url --push upstream no_push 
+    # Optionally add remotes for commonly viewed branches
+    git remote add <branch_owner_username> https://github.com/<branch_owner_username>/chapel.git
+    
 Create and switch to a feature branch
 -------------------------------------
 


### PR DESCRIPTION
Added documentation for changing the upstream remote of a local git repository to disable the push capability and also for adding remotes to other users for easier access