### PR TITLE
Scope gap 12

### DIFF
--- a/compiler/AST/LoopStmt.cpp
+++ b/compiler/AST/LoopStmt.cpp
@@ -71,14 +71,44 @@ LoopStmt* LoopStmt::findEnclosingLoop(Expr* expr)
   LoopStmt* retval = NULL;
 
   if (LoopStmt* loop = toLoopStmt(expr))
+  {
     retval = loop;
+  }
 
   else if (expr->parentExpr)
+  {
     retval = findEnclosingLoop(expr->parentExpr);
+  }
 
   else
+  {
     retval = NULL;
+  }
 
   return retval;
 
+}
+
+LoopStmt* LoopStmt::findEnclosingLoop(Expr* expr, const char* name)
+{
+  LoopStmt* retval = LoopStmt::findEnclosingLoop(expr);
+
+  while (retval != NULL && retval->isNamed(name) == false)
+  {
+    retval = LoopStmt::findEnclosingLoop(retval->parentExpr);
+  }
+
+  return retval;
+}
+
+bool LoopStmt::isNamed(const char* name) const
+{
+  bool retval = false;
+
+  if (userLabel != NULL)
+  {
+    retval = (strcmp(userLabel, name) == 0) ? true : false;
+  }
+
+  return retval;
 }

--- a/compiler/include/LoopStmt.h
+++ b/compiler/include/LoopStmt.h
@@ -25,18 +25,21 @@
 class LoopStmt : public BlockStmt
 {
 public:
-  virtual bool           isLoopStmt()                                 const;
+  static LoopStmt*       findEnclosingLoop(Expr* expr);
 
-  LabelSymbol*           breakLabelGet()                              const;
+  static LoopStmt*       findEnclosingLoop(Expr* expr, const char* name);
+
+public:
+  virtual bool           isLoopStmt()                                    const;
+
+  LabelSymbol*           breakLabelGet()                                 const;
   void                   breakLabelSet(LabelSymbol* sym);
 
-  LabelSymbol*           continueLabelGet()                           const;
+  LabelSymbol*           continueLabelGet()                              const;
   void                   continueLabelSet(LabelSymbol* sym);
 
-  bool                   isOrderIndependent()                         const;
+  bool                   isOrderIndependent()                            const;
   void                   orderIndependentSet(bool b);
-
-  static LoopStmt*       findEnclosingLoop(Expr* expr);
 
 protected:
                          LoopStmt(BlockStmt* initBody);
@@ -50,6 +53,8 @@ protected:
 
 private:
                          LoopStmt();
+
+  bool                   isNamed(const char* name)                       const;
 };
 
 #endif

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -87,8 +87,6 @@ static void          scopeResolve(ModuleSymbol*       module,
 
 static void          processImportExprs();
 
-static void          addRecordDefaultConstruction();
-
 static void          resolveGotoLabels();
 
 static void          resolveUnresolvedSymExprs();
@@ -170,8 +168,6 @@ void scopeResolve() {
       }
     }
   }
-
-  addRecordDefaultConstruction();
 
   //
   // resolve type of this for methods
@@ -507,38 +503,6 @@ static void processImportExprs() {
           ResolveScope* scope    = ResolveScope::getScopeFor(astScope);
 
           useStmt->scopeResolve(scope);
-        }
-      }
-    }
-  }
-}
-
-/************************************* | **************************************
-*                                                                             *
-*                                                                             *
-*                                                                             *
-************************************** | *************************************/
-
-static void addRecordDefaultConstruction() {
-  forv_Vec(DefExpr, def, gDefExprs) {
-    // We're only interested in declarations that do not have initializers.
-    if (def->init != NULL) {
-
-    } else if (VarSymbol* var = toVarSymbol(def->sym)) {
-      if (AggregateType* at = toAggregateType(var->type)) {
-        if (at->isRecord() == false) {
-
-        // No initializer for extern records.
-        } else if (at->symbol->hasFlag(FLAG_EXTERN) == true) {
-
-        } else {
-          SET_LINENO(def);
-
-          CallExpr* ctor_call = new CallExpr(new SymExpr(at->symbol));
-
-          def->init = new CallExpr(PRIM_NEW, ctor_call);
-
-          insert_help(def->init, def, def->parentSymbol);
         }
       }
     }

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -519,49 +519,31 @@ static void resolveGotoLabels() {
   forv_Vec(GotoStmt, gs, gGotoStmts) {
     SET_LINENO(gs);
 
-    if (SymExpr* label = toSymExpr(gs->label)) {
-      if (label->symbol() == gNil) {
-        LoopStmt* loop = LoopStmt::findEnclosingLoop(gs);
+    LoopStmt* loop = NULL;
 
-        if (!loop)
-          USR_FATAL(gs, "break or continue is not in a loop");
+    if (isSymExpr(gs->label) == true) {
+      loop = LoopStmt::findEnclosingLoop(gs);
 
-        if (gs->gotoTag == GOTO_BREAK) {
-          Symbol* breakLabel = loop->breakLabelGet();
-
-          INT_ASSERT(breakLabel);
-          gs->label->replace(new SymExpr(breakLabel));
-
-        } else if (gs->gotoTag == GOTO_CONTINUE) {
-          Symbol* continueLabel = loop->continueLabelGet();
-          INT_ASSERT(continueLabel);
-
-          gs->label->replace(new SymExpr(continueLabel));
-
-        } else
-          INT_FATAL(gs, "unexpected goto type");
+      if (loop == NULL) {
+        USR_FATAL(gs, "break or continue is not in a loop");
       }
 
     } else if (UnresolvedSymExpr* label = toUnresolvedSymExpr(gs->label)) {
-      const char* name = label->unresolved;
-      LoopStmt*   loop = LoopStmt::findEnclosingLoop(gs);
+      loop = LoopStmt::findEnclosingLoop(gs, label->unresolved);
 
-      while (loop && (!loop->userLabel || strcmp(loop->userLabel, name))) {
-        loop = LoopStmt::findEnclosingLoop(loop->parentExpr);
-      }
-
-      if (!loop) {
+      if (loop == NULL) {
         USR_FATAL(gs, "bad label on break or continue");
       }
+    }
 
-      if (gs->gotoTag == GOTO_BREAK)
-        label->replace(new SymExpr(loop->breakLabelGet()));
+    if (gs->gotoTag == GOTO_BREAK) {
+      gs->label->replace(new SymExpr(loop->breakLabelGet()));
 
-      else if (gs->gotoTag == GOTO_CONTINUE)
-        label->replace(new SymExpr(loop->continueLabelGet()));
+    } else if (gs->gotoTag == GOTO_CONTINUE) {
+      gs->label->replace(new SymExpr(loop->continueLabelGet()));
 
-      else
-        INT_FATAL(gs, "unexpected goto type");
+    } else {
+      INT_FATAL(gs, "unexpected goto type");
     }
   }
 }


### PR DESCRIPTION
Merge two trivial changes from scopeResolve branch to master

1. Before this PR this pass invoked a routine named addRecordDefaultDestruction().
This updated var declarations to include "= new SomeRecord()" under certain
circumstances.  In practice this only triggered for string literals in ChapeStringLiterals
and served no purpose in the current compiler.

2. scopeResolve includes logic to patch structured goto statements.  Some of the logic
is in LoopStmt.cpp and some in scopeResolve.cpp. Migrate a minor subset of the logic
that was in scopeResolve.cpp to LoopStmt.cpp for consistency with the other logic that
was already there.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran a portion
of release/ on all configs.  Also compiled with CHPL_LLVM=llvm on linux64 and ran a portion
of release/

Passed single-locale paratest with futures
